### PR TITLE
fix: preserve Cloudflare workspaces with shared archive sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Preserve existing Cloudflare container workspaces when sync upload or extraction fails, clean partial archives, and enforce full-checkout size limits before fresh allocation. Thanks @steipete.
+- Preserve existing Cloudflare container workspaces when sync upload or extraction fails, clean partial archives, and enforce full-checkout size limits before fresh allocation. [PR 1814](https://github.com/openclaw/crabbox/pull/1814). Thanks @steipete.
 - Protect Nomad runs from overwriting replacement claims or recreating retired leases, and expose standard run-session handles with cleanup-aware final outcomes that preserve the original command exit. [PR 1810](https://github.com/openclaw/crabbox/pull/1810). Thanks @steipete.
 - Allow fresh brokered AWS Windows and WSL2 leases to bootstrap through advertised SSH port 22 while preserving an explicitly selected final workload port. [PR 1801](https://github.com/openclaw/crabbox/pull/1801). Thanks @steipete.
 - Reuse one Azure or GCP token refresh across concurrent requests, reducing duplicate authentication traffic while preserving credential isolation, refresh margins, and retry behavior. [PR 1802](https://github.com/openclaw/crabbox/pull/1802). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve existing Cloudflare container workspaces when sync upload or extraction fails, clean partial archives, and enforce full-checkout size limits before fresh allocation. Thanks @steipete.
 - Protect Nomad runs from overwriting replacement claims or recreating retired leases, and expose standard run-session handles with cleanup-aware final outcomes that preserve the original command exit. [PR 1810](https://github.com/openclaw/crabbox/pull/1810). Thanks @steipete.
 - Allow fresh brokered AWS Windows and WSL2 leases to bootstrap through advertised SSH port 22 while preserving an explicitly selected final workload port. [PR 1801](https://github.com/openclaw/crabbox/pull/1801). Thanks @steipete.
 - Reuse one Azure or GCP token refresh across concurrent requests, reducing duplicate authentication traffic while preserving credential isolation, refresh margins, and retry behavior. [PR 1802](https://github.com/openclaw/crabbox/pull/1802). Thanks @steipete.

--- a/docs/providers/cloudflare.md
+++ b/docs/providers/cloudflare.md
@@ -222,12 +222,17 @@ crabbox run \
 
 ## Behavior
 
-- `run` creates or reuses a container Durable Object, prepares `workdir`,
-  uploads a gzipped archive of the local checkout (unless `--no-sync`), extracts
-  it, then relays stdout, stderr, and exit status.
+- `run` creates or reuses a container Durable Object, uploads a gzipped archive
+  of the local checkout (unless `--no-sync`), extracts it, then relays stdout,
+  stderr, and exit status. Fresh runs prepare and size-check the full archive
+  before creating a container; a small dirty delta does not bypass full-archive limits.
+- With `sync.delete: true`, extraction uses a sibling staging directory and
+  replaces `workdir` only after extraction succeeds. Failed admission, upload,
+  or extraction preserves the old checkout, and exact temporary paths receive
+  best-effort cleanup. With deletion disabled, extraction merges into `workdir`.
 - Before upload, the provider checks remote disk headroom for both the archive
   and the extracted checkout, and fails early with a sizing hint if the selected
-  type is too small.
+  type is too small. This check does not remove the old checkout to free space.
 - `warmup` starts a container and leaves it alive until `crabbox stop` or the
   configured TTL/idle deadline expires.
 - Reuse, `status`, and `stop` resolve local Crabbox claims before calling the

--- a/internal/providers/cloudflare/backend.go
+++ b/internal/providers/cloudflare/backend.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func NewCloudflareBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
@@ -98,6 +100,14 @@ func (b *cloudflareBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 	}
 	leaseID, sandboxID, slug := "", "", ""
 	acquired := false
+	var prepared *core.PreparedArchive
+	if req.ID == "" && !req.NoSync {
+		prepared, err = b.prepareArchive(ctx, req)
+		if err != nil {
+			return RunResult{}, err
+		}
+		defer prepared.Close()
+	}
 	if req.ID == "" {
 		var sandbox cloudflareContainer
 		leaseID, sandbox, slug, err = b.createSandbox(ctx, client, req.Repo, req.Reclaim, req.RequestedSlug)
@@ -142,12 +152,12 @@ func (b *cloudflareBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 	syncDuration := time.Duration(0)
 	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
 	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, sandboxID, req, workdir)
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, sandboxID, req, workdir, prepared)
 		if err != nil {
 			return RunResult{Total: b.now().Sub(started), SyncDelegated: true, Session: session}, err
 		}
 		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
-	} else if err := b.prepareWorkspace(ctx, client, sandboxID, workdir, false); err != nil {
+	} else if err := b.prepareWorkspace(ctx, client, sandboxID, workdir); err != nil {
 		return RunResult{Session: session}, err
 	}
 	if req.SyncOnly {

--- a/internal/providers/cloudflare/backend_test.go
+++ b/internal/providers/cloudflare/backend_test.go
@@ -11,6 +11,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -658,44 +660,192 @@ func TestCloudflareStatusUsesClaimedInstanceType(t *testing.T) {
 	}
 }
 
-func TestCloudflarePrepareWorkspacePreservesWhenRequested(t *testing.T) {
-	for _, tc := range []struct {
-		name           string
-		deleteContents bool
-		wantDelete     bool
-	}{
-		{name: "preserve", deleteContents: false, wantDelete: false},
-		{name: "delete", deleteContents: true, wantDelete: true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			var got execStreamRequest
+func TestCloudflareArchiveGuardrailUsesFullSnapshotBeforeRemoteWork(t *testing.T) {
+	for _, reuse := range []bool{false, true} {
+		t.Run(fmt.Sprintf("reuse=%t", reuse), func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			root := t.TempDir()
+			git := func(args ...string) {
+				t.Helper()
+				cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+				if output, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("fixture git: %v: %s", err, output)
+				}
+			}
+			git("init", "--quiet")
+			if err := os.WriteFile(filepath.Join(root, "large.txt"), bytes.Repeat([]byte("x"), 2048), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(root, "small.txt"), []byte("before"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			git("add", ".")
+			git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.com", "-c", "commit.gpgsign=false", "commit", "--quiet", "-m", "fixture")
+			if err := os.WriteFile(filepath.Join(root, "small.txt"), []byte("after"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			calls := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { calls++; http.Error(w, "unexpected remote work", 503) }))
+			defer server.Close()
+			cfg := Config{Provider: providerName, TTL: time.Hour}
+			cfg.Cloudflare.APIURL = server.URL
+			cfg.Cloudflare.Token = "synthetic-token"
+			cfg.Sync.FailBytes = 256
+			req := RunRequest{Repo: Repo{Root: root, Name: "fixture"}, SyncOnly: true}
+			if reuse {
+				req.ID = "cbx_sync"
+				if err := claimLeaseForRepoProvider(req.ID, "sync", providerName, root, time.Hour, false); err != nil {
+					t.Fatal(err)
+				}
+			}
+			backend := cloudflareBackend{cfg: cfg, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+			_, err := backend.Run(context.Background(), req)
+			if err == nil || !strings.Contains(err.Error(), "sync candidate too large") || calls != 0 {
+				t.Fatalf("error=%v remote calls=%d", err, calls)
+			}
+		})
+	}
+}
+
+func TestCloudflareSyncPreservesWorkspaceUntilReplacement(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture executes POSIX workspace commands on the host")
+	}
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash is required for the workspace replacement fixture")
+	}
+	for _, mode := range []string{"upload rejected", "corrupt archive", "replace", "merge"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			repoRoot := t.TempDir()
+			if output, err := exec.Command("git", "init", "--quiet", repoRoot).CombinedOutput(); err != nil {
+				t.Fatalf("init fixture repo: %v: %s", err, output)
+			}
+			if err := os.WriteFile(filepath.Join(repoRoot, "new.txt"), []byte("replacement"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			workdir := filepath.Join(t.TempDir(), "workspace")
+			if err := os.MkdirAll(workdir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			old := filepath.Join(workdir, "old.txt")
+			if err := os.WriteFile(old, []byte("original"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := claimLeaseForRepoProvider("cbx_sync", "sync", providerName, repoRoot, time.Hour, false); err != nil {
+				t.Fatal(err)
+			}
+			var remoteArchive string
+			uploads, deletes := 0, 0
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/v1/sandboxes/cbx_test/exec-stream" {
+				switch {
+				case strings.HasSuffix(r.URL.Path, "/files"):
+					uploads++
+					remoteArchive = r.URL.Query().Get("path")
+					if !strings.HasPrefix(remoteArchive, "/tmp/crabbox-cloudflare-sync-") {
+						t.Errorf("unexpected archive %q", remoteArchive)
+						http.Error(w, "bad path", 500)
+						return
+					}
+					data, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Error(err)
+						http.Error(w, "read", 500)
+						return
+					}
+					if r.ContentLength != int64(len(data)) {
+						t.Errorf("Content-Length=%d, bytes=%d", r.ContentLength, len(data))
+					}
+					if mode == "upload rejected" || mode == "corrupt archive" {
+						data = []byte("partial invalid archive")
+					}
+					if err := os.WriteFile(remoteArchive, data, 0o600); err != nil {
+						t.Error(err)
+						http.Error(w, "write", 500)
+						return
+					}
+					if mode == "upload rejected" {
+						http.Error(w, "synthetic upload rejection", 500)
+						return
+					}
+					w.WriteHeader(http.StatusOK)
+				case strings.HasSuffix(r.URL.Path, "/exec-stream"):
+					var command execStreamRequest
+					if err := json.NewDecoder(r.Body).Decode(&command); err != nil {
+						t.Error(err)
+						http.Error(w, "decode", 500)
+						return
+					}
+					var output []byte
+					code := 0
+					if strings.Contains(command.Command, "df -B1") {
+						output = []byte("8589934592 /tmp\n8589934592 workspace\n")
+					} else {
+						if !strings.Contains(command.Command, filepath.Dir(workdir)) && (remoteArchive == "" || !strings.Contains(command.Command, remoteArchive)) {
+							t.Errorf("unexpected command %q", command.Command)
+							http.Error(w, "unexpected", 500)
+							return
+						}
+						var err error
+						output, err = exec.Command(bash, "-c", command.Command).CombinedOutput()
+						if err != nil {
+							code = 1
+						}
+					}
+					w.Header().Set("Content-Type", "application/x-ndjson")
+					_ = json.NewEncoder(w).Encode(map[string]any{"type": "stdout", "data": string(output)})
+					_ = json.NewEncoder(w).Encode(map[string]any{"type": "complete", "exitCode": code})
+				case r.Method == http.MethodDelete:
+					deletes++
+					w.WriteHeader(http.StatusOK)
+				default:
 					http.NotFound(w, r)
-					return
 				}
-				if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
-					t.Fatalf("decode exec request: %v", err)
-				}
-				w.Header().Set("Content-Type", "application/x-ndjson")
-				_, _ = io.WriteString(w, `{"type":"complete","exitCode":0}`+"\n")
 			}))
 			defer server.Close()
-
-			cfg := Config{}
+			defer func() {
+				if remoteArchive != "" {
+					_ = os.Remove(remoteArchive)
+				}
+			}()
+			cfg := Config{Provider: providerName, TTL: time.Hour}
 			cfg.Cloudflare.APIURL = server.URL
-			cfg.Cloudflare.Token = "token"
-			backend := cloudflareBackend{cfg: cfg, rt: Runtime{HTTP: server.Client(), Stderr: io.Discard}}
-			client, err := newCloudflareClient(cfg, backend.rt)
-			if err != nil {
-				t.Fatal(err)
+			cfg.Cloudflare.Token = "synthetic-token"
+			cfg.Cloudflare.Workdir = workdir
+			cfg.Sync.Delete = mode != "merge"
+			backend := cloudflareBackend{cfg: cfg, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+			result, err := backend.Run(context.Background(), RunRequest{ID: "cbx_sync", Repo: Repo{Root: repoRoot, Name: "fixture"}, SyncOnly: true})
+			failed := mode == "upload rejected" || mode == "corrupt archive"
+			if (err != nil) != failed {
+				t.Fatalf("Run error=%v, failed=%t", err, failed)
 			}
-			if err := backend.prepareWorkspace(context.Background(), client, "cbx_test", "/workspace/repo", tc.deleteContents); err != nil {
-				t.Fatal(err)
+			if uploads != 1 || deletes != 0 {
+				t.Fatalf("uploads=%d deletes=%d", uploads, deletes)
 			}
-			hasDelete := strings.Contains(got.Command, "rm -rf")
-			if hasDelete != tc.wantDelete {
-				t.Fatalf("prepare command = %q, rm -rf presence = %t, want %t", got.Command, hasDelete, tc.wantDelete)
+			if result.Session == nil || !result.Session.Reused || !result.Session.Kept {
+				t.Fatalf("session=%+v", result.Session)
+			}
+			oldData, oldErr := os.ReadFile(old)
+			if failed || mode == "merge" {
+				if oldErr != nil || string(oldData) != "original" {
+					t.Fatalf("old workspace lost: data=%q error=%v", oldData, oldErr)
+				}
+			} else if !os.IsNotExist(oldErr) {
+				t.Fatalf("old file retained on replacement: %v", oldErr)
+			}
+			if !failed {
+				data, err := os.ReadFile(filepath.Join(workdir, "new.txt"))
+				if err != nil || string(data) != "replacement" {
+					t.Fatalf("new file=%q error=%v", data, err)
+				}
+			}
+			if _, err := os.Stat(remoteArchive); !os.IsNotExist(err) {
+				t.Fatalf("temporary archive remains: %v", err)
+			}
+			staging, err := filepath.Glob(filepath.Join(filepath.Dir(workdir), ".workspace.crabbox-sync-*"))
+			if err != nil || len(staging) != 0 {
+				t.Fatalf("staging remains=%v error=%v", staging, err)
 			}
 		})
 	}
@@ -1364,26 +1514,6 @@ func TestCloudflareRemoteDiskCheckRejectsZeroOrUnknownAvailable(t *testing.T) {
 				t.Fatalf("error = %v, want %q", err, tc.want)
 			}
 		})
-	}
-}
-
-func TestCloudflareExtractArchiveCommandRemovesArchiveAfterFailure(t *testing.T) {
-	bash, err := exec.LookPath("bash")
-	if err != nil {
-		t.Skip("bash is required for extract cleanup command test")
-	}
-	dir := t.TempDir()
-	archive := dir + "/bad archive.tgz"
-	if err := os.WriteFile(archive, []byte("not a tar archive"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	cmd := exec.Command(bash, "-lc", cloudflareExtractArchiveCommand(archive, dir))
-	err = cmd.Run()
-	if err == nil {
-		t.Fatal("expected invalid archive extraction to fail")
-	}
-	if _, statErr := os.Stat(archive); !os.IsNotExist(statErr) {
-		t.Fatalf("archive still exists after failed extract: %v", statErr)
 	}
 }
 

--- a/internal/providers/cloudflare/client.go
+++ b/internal/providers/cloudflare/client.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -332,8 +331,4 @@ func redactCloudflareRunnerSecrets(value string, secrets ...string) string {
 		}
 	}
 	return cloudflareBearerPattern.ReplaceAllString(redacted, "Bearer [redacted]")
-}
-
-func remoteArchivePath() string {
-	return path.Join("/tmp", "crabbox-cloudflare-sync-"+time.Now().UTC().Format("20060102150405.000000000")+".tgz")
 }

--- a/internal/providers/cloudflare/core.go
+++ b/internal/providers/cloudflare/core.go
@@ -1,10 +1,8 @@
 package cloudflare
 
 import (
-	"context"
 	"flag"
 	"io"
-	"os"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -30,7 +28,6 @@ type CleanupRequest = core.CleanupRequest
 type Server = core.Server
 type LeaseClaim = core.LeaseClaim
 type Repo = core.Repo
-type SyncManifest = core.SyncManifest
 type ExitError = core.ExitError
 type FeatureSet = core.FeatureSet
 type Feature = core.Feature
@@ -134,20 +131,4 @@ func shouldUseShell(command []string) bool {
 
 func leadingEnvAssignment(command []string) bool {
 	return core.LeadingEnvAssignment(command)
-}
-
-func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
-	return core.SyncExcludes(root, cfg)
-}
-
-func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (SyncManifest, error) {
-	return core.BuildSyncManifestFiltered(root, excludes, includes)
-}
-
-func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
-	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
-}
-
-func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
-	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
 }

--- a/internal/providers/cloudflare/sync.go
+++ b/internal/providers/cloudflare/sync.go
@@ -5,76 +5,62 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *cloudflareBackend) syncWorkspace(ctx context.Context, client *cloudflareClient, sandboxID string, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
-	start := b.now()
-	syncCtx := ctx
-	cancel := func() {}
-	if b.cfg.Sync.Timeout > 0 {
-		syncCtx, cancel = context.WithTimeout(ctx, b.cfg.Sync.Timeout)
+func (b *cloudflareBackend) prepareArchive(ctx context.Context, req RunRequest) (*core.PreparedArchive, error) {
+	return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+		TempPattern: "crabbox-cloudflare-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+	})
+}
+
+func (b *cloudflareBackend) syncWorkspace(ctx context.Context, client *cloudflareClient, sandboxID string, req RunRequest, workdir string, prepared *core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+	if prepared == nil {
+		var err error
+		prepared, err = b.prepareArchive(ctx, req)
+		if err != nil {
+			return nil, 0, err
+		}
 	}
-	defer cancel()
-	excludes, err := syncExcludes(req.Repo.Root, b.cfg)
-	if err != nil {
-		return nil, 0, err
+	var diskDuration time.Duration
+	phases, total, err := core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
+		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge, Workdir: workdir,
+		Provider: providerName, PhaseName: "cloudflare_sync", RemoteArchivePrefix: "crabbox-cloudflare-sync-",
+		Stderr: b.rt.Stderr, Now: b.now,
+		CleanupContext: func(context.Context) (context.Context, context.CancelFunc) { return cloudflareCleanupContext() },
+		Upload: func(uploadCtx context.Context, remoteArchive string, _ io.Reader) error {
+			start := b.now()
+			if err := b.prepareWorkspace(uploadCtx, client, sandboxID, workdir); err != nil {
+				return err
+			}
+			if err := b.checkRemoteDiskForSync(uploadCtx, client, sandboxID, workdir, prepared.Manifest.Bytes, prepared.Size); err != nil {
+				return err
+			}
+			diskDuration = b.now().Sub(start)
+			// Reopen the same owned snapshot to preserve this transport's exact Content-Length.
+			if err := client.uploadFile(uploadCtx, sandboxID, prepared.File.Name(), remoteArchive); err != nil {
+				return fmt.Errorf("upload archive: %w", err)
+			}
+			return nil
+		},
+		Exec: func(execCtx context.Context, command string) error {
+			return b.execShell(execCtx, client, sandboxID, command, io.Discard)
+		},
+	}, prepared)
+	for i := range phases {
+		if phases[i].Name == "upload" {
+			phases[i].Ms -= diskDuration.Milliseconds()
+			phases = slices.Insert(phases, i, timingPhase{Name: "disk", Ms: diskDuration.Milliseconds()})
+			break
+		}
 	}
-	manifestStarted := b.now()
-	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
-	if err != nil {
-		return nil, 0, exit(6, "build sync file list: %v", err)
-	}
-	manifestDuration := b.now().Sub(manifestStarted)
-	preflightStarted := b.now()
-	if err := checkSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
-		return nil, 0, err
-	}
-	preflightDuration := b.now().Sub(preflightStarted)
-	prepareStarted := b.now()
-	if err := b.prepareWorkspace(syncCtx, client, sandboxID, workdir, b.cfg.Sync.Delete); err != nil {
-		return nil, 0, err
-	}
-	prepareDuration := b.now().Sub(prepareStarted)
-	archiveStarted := b.now()
-	archive, err := createCloudflareSyncArchive(syncCtx, req.Repo, manifest, b.rt.Stderr)
-	if err != nil {
-		return nil, 0, err
-	}
-	defer os.Remove(archive.Name())
-	defer archive.Close()
-	archiveInfo, err := archive.Stat()
-	if err != nil {
-		return nil, 0, fmt.Errorf("stat sync archive: %w", err)
-	}
-	archiveDuration := b.now().Sub(archiveStarted)
-	diskStarted := b.now()
-	if err := b.checkRemoteDiskForSync(syncCtx, client, sandboxID, workdir, manifest.Bytes, archiveInfo.Size()); err != nil {
-		return nil, 0, err
-	}
-	diskDuration := b.now().Sub(diskStarted)
-	uploadStarted := b.now()
-	remoteArchive := remoteArchivePath()
-	if err := client.uploadFile(syncCtx, sandboxID, archive.Name(), remoteArchive); err != nil {
-		return nil, 0, fmt.Errorf("upload archive: %w", err)
-	}
-	if err := b.execShell(syncCtx, client, sandboxID, cloudflareExtractArchiveCommand(remoteArchive, workdir), io.Discard); err != nil {
-		return nil, 0, err
-	}
-	uploadDuration := b.now().Sub(uploadStarted)
-	total := b.now().Sub(start)
-	return []timingPhase{
-		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
-		{Name: "preflight", Ms: preflightDuration.Milliseconds()},
-		{Name: "prepare", Ms: prepareDuration.Milliseconds()},
-		{Name: "archive", Ms: archiveDuration.Milliseconds()},
-		{Name: "disk", Ms: diskDuration.Milliseconds()},
-		{Name: "upload", Ms: uploadDuration.Milliseconds()},
-		{Name: "cloudflare_sync", Ms: total.Milliseconds()},
-	}, total, nil
+	return phases, total, err
 }
 
 func (b *cloudflareBackend) checkRemoteDiskForSync(ctx context.Context, client *cloudflareClient, sandboxID, workdir string, manifestBytes, archiveBytes int64) error {
@@ -142,12 +128,8 @@ func byteCount(bytes int64) string {
 	return fmt.Sprintf("%.1f PiB", value/unit)
 }
 
-func (b *cloudflareBackend) prepareWorkspace(ctx context.Context, client *cloudflareClient, sandboxID, workdir string, deleteContents bool) error {
-	command := "mkdir -p " + shellQuote(workdir)
-	if deleteContents {
-		command = "rm -rf " + shellQuote(workdir) + " && " + command
-	}
-	return b.execShell(ctx, client, sandboxID, command, io.Discard)
+func (b *cloudflareBackend) prepareWorkspace(ctx context.Context, client *cloudflareClient, sandboxID, workdir string) error {
+	return b.execShell(ctx, client, sandboxID, "mkdir -p "+shellQuote(workdir), io.Discard)
 }
 
 func (b *cloudflareBackend) execShell(ctx context.Context, client *cloudflareClient, sandboxID, command string, stdout io.Writer) error {
@@ -163,19 +145,4 @@ func (b *cloudflareBackend) execShell(ctx context.Context, client *cloudflareCli
 		return exit(code, "%s exec %q exited %d", providerName, command, code)
 	}
 	return nil
-}
-
-func cloudflareExtractArchiveCommand(remoteArchive, workdir string) string {
-	return strings.Join([]string{
-		"tar -xzf " + shellQuote(remoteArchive) + " -C " + shellQuote(workdir),
-		"status=$?",
-		"rm -f " + shellQuote(remoteArchive),
-		"cleanup=$?",
-		`if [ "$status" -ne 0 ]; then exit "$status"; fi`,
-		`exit "$cleanup"`,
-	}, "; ")
-}
-
-func createCloudflareSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, _ io.Writer) (*os.File, error) {
-	return createPortableSyncArchive(ctx, repo, manifest, "crabbox-cloudflare-sync-*.tgz")
 }


### PR DESCRIPTION
## Summary

The legacy Cloudflare Containers adapter deleted the live checkout before preparing and uploading its replacement. An upload refusal or invalid archive therefore erased an otherwise reusable workspace. It also checked dirty-delta limits before uploading a full checkout, and could leave partially uploaded archives behind.

Use the existing shared archive owner for preparation, upload, staged extraction, replacement, and exact temporary-path cleanup. Fresh sync prepares and checks its full snapshot before allocating a container. Cloudflare still owns disk admission, HTTP upload with exact Content-Length, and runner execution; no new shared abstraction or upload protocol is introduced. Deletion-disabled sync retains its merge behavior.

This is the `cloudflare`/`cf` provider, not Cloudflare Sandbox or Dynamic Workers. Full Run finalization, keep-on-failure during preparation, and claim-revision fencing are separate follow-up work; this change does not claim to fix them.

## Verification

Four unchanged-baseline regressions fail for the expected reasons: fresh/reused full-archive limits permit remote work, and rejected/corrupt uploads destroy existing files. Candidate tests execute real Bash/tar/filesystem operations through the transport fixture and verify preservation, replacement, merge semantics, Content-Length, and exact archive/staging cleanup.

Cloudflare/shared Go race tests, focused core archive races, vet, CLI build, docs build, and dead-code scan passed. The POSIX filesystem fixture now gates Windows/Bash availability after independent review caught that portability gap; Windows test compilation also passed. Managed Codex review is clean at the configured P0 threshold, and independent review found no production issue.

### Live local Worker/container proof

The built CLI ran through repository-pinned Wrangler 4.127.0, the actual Worker/Durable Object code, and the checked-in Go runner in a real local Linux/amd64 Docker container (on an arm64 Mac). A loopback fault proxy truncated actual uploads to the runner; one returned a synthetic 500 after the partial write, another allowed extraction to discover the corrupt archive. This was real local container execution with synthetic fault injection, not a production Cloudflare deployment.

```text
initial archive sync and file verification: passed
partial upload: exit 1; old file retained; new file absent; archive removed
corrupt extraction: exit 2; old file retained; archive/staging removed
successful replacement: new file present; old file removed
deletion-disabled merge: unrelated existing file retained
command exit 42: preserved
fresh sync and automatic cleanup: passed
explicit stop: passed
```

All 16 CLI steps completed with expected results. Both exact sandbox IDs reported `stopped`, their local claims were absent, and no container remained for the unique proof image. Wrangler and the fault proxy stopped, all three loopback listeners were absent, and task-only runtime/config state was removed. The image cache was retained.

CLI SHA256: `ac06ed6b9344403686613f810c84d0a11aff47a37b74b311109dd56f39fdf9f9`.
Runner image: `sha256:458f6dc81d22ee6c350dcb30fd305cde0e499b61bda3a30a07fbdaca89746001`.

Initial harness setup corrections concerned CLI config routing, proxy response encoding, required runner bindings, and discovering the installed Docker Buildx plugin inside an isolated configuration. None required a production code workaround, real credential, provider deployment, or changing the user's Docker configuration. Remote temporary cleanup remains best-effort and preserves the primary failure; this is not a durable cleanup journal.
