### PR TITLE
fix(aws): make interrupted warmups stoppable and use the Ubuntu primary archive

### DIFF
--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -74,6 +74,14 @@ the attempt during the original invocation. A changed create intent returns
 acquisition is marked complete, a missing bound instance is also a terminal
 conflict rather than permission to call `RunInstances` again.
 
+Once Crabbox observes an instance matching the durable launch attempt, it
+saves the instance identity and cleanup labels before waiting for its public
+IP or SSH readiness. The claim remains prepared until readiness succeeds, so
+an interrupted warmup can be stopped with
+`crabbox stop --provider aws --id cbx_...` without authorizing normal use of the
+unfinished lease. Replay remains bound to that exact instance; readiness cannot
+replace it with another instance carrying copied tags.
+
 Successful stop and exact resource/key cleanup retain a terminal receipt in
 the existing claim fields: the original account, region, canonical lease ID,
 slug, instance ID, repository path, and versioned intent plus its original
@@ -159,6 +167,16 @@ Set `architecture: arm64` or pass `--arch arm64` for Linux Graviton leases.
 Crabbox switches class fallback to C7g/M7g/R7g families and resolves Canonical
 Ubuntu ARM64 AMIs unless `aws.ami` is pinned. ARM64 is not supported for managed
 Windows or WSL2 targets.
+
+For fresh, automatically selected Canonical Ubuntu 26.04 amd64 images, direct
+CLI and public broker provisioning use cloud-init's APT policy to select
+`https://archive.ubuntu.com/ubuntu/` as the primary archive. Security updates
+retain the separate `http://security.ubuntu.com/ubuntu/` archive. This avoids
+relying on the regional EC2 HTTP archive for the normal bootstrap. Suite,
+component, signing-key, and source-preservation policies remain image-owned.
+Explicit AMIs (including `CRABBOX_AWS_AMI`), promoted images, checkpoint forks,
+ARM64, and Ubuntu 24.04 retain their existing source policy. The private AWS
+workspace service keeps its separate SSM bootstrap and HTTPS-only source policy.
 
 ### Environment variables (direct mode)
 

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -82,6 +82,15 @@ an interrupted warmup can be stopped with
 unfinished lease. Replay remains bound to that exact instance; readiness cannot
 replace it with another instance carrying copied tags.
 
+EC2 can temporarily report a newly allocated instance as missing. The existing
+readiness wait allows that propagation delay within its ten-minute limit and
+honors cancellation. Cleanup keeps a prepared claim and its keys when instance
+visibility or termination is uncertain. Retry while the exact instance is
+visible; an observed terminal instance permits key recovery. If termination
+was accepted but key cleanup failed and the instance is no longer visible,
+the prepared claim and keys remain for operator recovery. The existing
+already-gone recovery paths for acquired and ordinary leases are unchanged.
+
 Successful stop and exact resource/key cleanup retain a terminal receipt in
 the existing claim fields: the original account, region, canonical lease ID,
 slug, instance ID, repository path, and versioned intent plus its original

--- a/internal/cli/aws.go
+++ b/internal/cli/aws.go
@@ -859,20 +859,22 @@ func mapMarket(spot bool) string {
 }
 
 func (c *AWSClient) waitForServerIP(ctx context.Context, id string) (Server, error) {
-	deadline := time.Now().Add(10 * time.Minute)
+	ctx, cancel := context.WithTimeoutCause(ctx, 10*time.Minute, exit(5, "timed out waiting for AWS instance public IP"))
+	defer cancel()
 	for {
 		server, err := c.GetServer(ctx, id)
-		if err != nil {
+		if ctx.Err() != nil {
+			return Server{}, context.Cause(ctx)
+		}
+		// RunInstances can return an ID before DescribeInstances can see it.
+		if err != nil && awsAPIErrorCode(err) != "InvalidInstanceID.NotFound" {
 			return Server{}, err
 		}
-		if server.PublicNet.IPv4.IP != "" {
+		if err == nil && server.PublicNet.IPv4.IP != "" {
 			return server, nil
 		}
-		if time.Now().After(deadline) {
-			return Server{}, exit(5, "timed out waiting for AWS instance public IP")
-		}
 		if err := sleepContext(ctx, 5*time.Second); err != nil {
-			return Server{}, err
+			return Server{}, context.Cause(ctx)
 		}
 	}
 }

--- a/internal/cli/aws_test.go
+++ b/internal/cli/aws_test.go
@@ -989,6 +989,113 @@ func TestRetryableAWSSnapshotDeleteError(t *testing.T) {
 	}
 }
 
+func TestAWSWaitForServerIPWaitsForCreatedInstanceVisibility(t *testing.T) {
+	const instanceID = "i-1234567890abcdef0"
+	describes := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Error(err)
+			return
+		}
+		if r.Form.Get("Action") != "DescribeInstances" || r.Form.Get("InstanceId.1") != instanceID {
+			t.Errorf("unexpected lookup: %v", r.Form)
+			writeEC2Error(w, "Unexpected", "wrong instance lookup", http.StatusBadRequest)
+			return
+		}
+		describes++
+		if describes == 1 {
+			writeEC2Error(w, "InvalidInstanceID.NotFound", "newly created instance has not propagated", http.StatusBadRequest)
+			return
+		}
+		writeEC2XML(w, `<DescribeInstancesResponse><reservationSet><item><instancesSet><item><instanceId>`+instanceID+`</instanceId><instanceType>t3.micro</instanceType><ipAddress>203.0.113.44</ipAddress><instanceState><name>running</name></instanceState></item></instancesSet></item></reservationSet></DescribeInstancesResponse>`)
+	}))
+	t.Cleanup(server.Close)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	observed, err := testAWSClient(server.URL).WaitForServerIP(ctx, instanceID)
+	if err != nil {
+		t.Fatalf("newly created instance readiness stopped before visibility: %v", err)
+	}
+	if observed.CloudID != instanceID || observed.PublicNet.IPv4.IP != "203.0.113.44" || describes != 2 {
+		t.Fatalf("readiness=%+v describes=%d, want exact instance after propagation", observed, describes)
+	}
+}
+
+func TestAWSWaitForServerIPRejectsNonVisibilityErrors(t *testing.T) {
+	for _, code := range []string{"UnauthorizedOperation", "InvalidInstanceID.Malformed", ""} {
+		t.Run(code, func(t *testing.T) {
+			calls := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				if code == "" {
+					writeEC2XML(w, `<DescribeInstancesResponse><reservationSet/></DescribeInstancesResponse>`)
+				} else {
+					writeEC2Error(w, code, "InvalidInstanceID.NotFound text is not the API code", http.StatusBadRequest)
+				}
+			}))
+			t.Cleanup(server.Close)
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			defer cancel()
+			_, err := testAWSClient(server.URL).WaitForServerIP(ctx, "i-1234567890abcdef0")
+			if err == nil || calls != 1 || code != "" && awsAPIErrorCode(err) != code || code == "" && !strings.Contains(err.Error(), "aws instance not found") {
+				t.Fatalf("lookup err=%v calls=%d, want original error without retry", err, calls)
+			}
+		})
+	}
+}
+
+func TestAWSWaitForServerIPHonorsCallerCancellation(t *testing.T) {
+	for _, boundary := range []string{"cancel", "deadline", "in-flight deadline"} {
+		t.Run(boundary, func(t *testing.T) {
+			seen := make(chan struct{}, 1)
+			release := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				seen <- struct{}{}
+				if boundary == "in-flight deadline" {
+					select {
+					case <-r.Context().Done():
+					case <-release:
+						writeEC2Error(w, "UnauthorizedOperation", "test request released", http.StatusBadRequest)
+					}
+					return
+				}
+				writeEC2Error(w, "InvalidInstanceID.NotFound", "not visible yet", http.StatusBadRequest)
+			}))
+			t.Cleanup(server.Close)
+			t.Cleanup(func() { close(release) })
+			ctx, cancel := context.WithCancel(t.Context())
+			wantErr := context.Canceled
+			if boundary != "cancel" {
+				cancel()
+				ctx, cancel = context.WithTimeout(t.Context(), 200*time.Millisecond)
+				wantErr = context.DeadlineExceeded
+			}
+			defer cancel()
+			result := make(chan error, 1)
+			go func() {
+				_, err := testAWSClient(server.URL).WaitForServerIP(ctx, "i-1234567890abcdef0")
+				result <- err
+			}()
+			select {
+			case <-seen:
+			case <-time.After(2 * time.Second):
+				t.Fatal("readiness never issued its lookup")
+			}
+			if boundary == "cancel" {
+				cancel()
+			}
+			select {
+			case err := <-result:
+				if !errors.Is(err, wantErr) {
+					t.Fatalf("readiness error=%v, want %v", err, wantErr)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("cancelled readiness waited for its next five-second poll")
+			}
+		})
+	}
+}
+
 func TestCreateImageCheckpointRecordsCallerAccount(t *testing.T) {
 	var sawCreate bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cli/azure.go
+++ b/internal/cli/azure.go
@@ -1359,7 +1359,7 @@ func (c *AzureClient) azureOSProfile(cfg Config, publicKey, name, leaseID string
 }
 
 func azureLinuxCloudInit(cfg Config, publicKey string) string {
-	return cloudInitWithAdditionalBootstrap(cfg, publicKey, azureLinuxTruffleHogBootstrap())
+	return cloudInitWithExtras(cfg, publicKey, "", azureLinuxTruffleHogBootstrap())
 }
 
 func azureLinuxTruffleHogBootstrap() string {

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -14,15 +14,29 @@ func awsUserData(cfg Config, publicKey string) string {
 	case targetMacOS:
 		return macOSUserData(cfg, publicKey)
 	default:
-		return cloudInit(cfg, publicKey)
+		aptConfig := ""
+		if cfg.TargetOS == targetLinux && cfg.OSImage == "ubuntu:26.04" &&
+			cfg.AWSAMI == "" && cfg.AWSSnapshot == "" && effectiveArchitectureForConfig(cfg) == ArchitectureAMD64 {
+			// Only stock Canonical images use this policy; custom images own their sources.
+			// cloud-init copies primary into security unless security is explicit.
+			aptConfig = `apt:
+  primary:
+    - arches: [amd64]
+      uri: https://archive.ubuntu.com/ubuntu/
+  security:
+    - arches: [amd64]
+      uri: http://security.ubuntu.com/ubuntu/
+`
+		}
+		return cloudInitWithExtras(cfg, publicKey, aptConfig, "")
 	}
 }
 
 func cloudInit(cfg Config, publicKey string) string {
-	return cloudInitWithAdditionalBootstrap(cfg, publicKey, "")
+	return cloudInitWithExtras(cfg, publicKey, "", "")
 }
 
-func cloudInitWithAdditionalBootstrap(cfg Config, publicKey, additionalBootstrap string) string {
+func cloudInitWithExtras(cfg Config, publicKey, additionalConfig, additionalBootstrap string) string {
 	portLines := ""
 	for _, port := range sshPortCandidates(cfg.SSHPort, cfg.SSHFallbackPorts) {
 		portLines += fmt.Sprintf("      Port %s\n", port)
@@ -44,7 +58,7 @@ func cloudInitWithAdditionalBootstrap(cfg Config, publicKey, additionalBootstrap
 	return fmt.Sprintf(`#cloud-config
 package_update: false
 package_upgrade: false
-users:
+%[11]susers:
   - name: %[1]s
     groups: sudo
     shell: /bin/bash
@@ -96,7 +110,7 @@ runcmd:
     touch /var/lib/crabbox/bootstrapped
     crabbox-ready
     BOOT
-`, yamlSSHUser, yamlPublicKey, shellWorkRoot, portLines, readyChecks, writeFiles, shellSSHUser, bootstrap, readinessBootstrap, indentCloudInitRuncmd(sharedLinuxSSHRestart()))
+`, yamlSSHUser, yamlPublicKey, shellWorkRoot, portLines, readyChecks, writeFiles, shellSSHUser, bootstrap, readinessBootstrap, indentCloudInitRuncmd(sharedLinuxSSHRestart()), additionalConfig)
 }
 
 func CloudInitUserData(cfg Config, publicKey string) string {

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -6,10 +6,13 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestWriteWindowsBootstrapSSHWarningIncludesDetail(t *testing.T) {
@@ -606,6 +609,71 @@ func TestAWSUserDataDefaultsToCloudInit(t *testing.T) {
 	got := awsUserData(baseConfig(), "ssh-ed25519 test")
 	if !strings.Contains(got, "#cloud-config") || !strings.Contains(got, "ssh-ed25519 test") {
 		t.Fatalf("awsUserData(default) did not return Linux cloud-init")
+	}
+}
+
+func TestAWSUserDataUbuntuAPTPolicy(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		modify func(*Config)
+		want   bool
+	}{
+		{name: "default Canonical amd64", want: true},
+		{name: "explicit amd64", modify: func(cfg *Config) { cfg.architectureExplicit = true }, want: true},
+		{name: "custom or captured AMI", modify: func(cfg *Config) { cfg.AWSAMI = "ami-custom" }},
+		{name: "snapshot fork", modify: func(cfg *Config) { cfg.AWSSnapshot = "snap-captured" }},
+		{name: "Ubuntu 24.04", modify: func(cfg *Config) { cfg.OSImage = "ubuntu:24.04" }},
+		{name: "explicit ARM", modify: func(cfg *Config) {
+			cfg.Architecture, cfg.architectureExplicit = ArchitectureARM64, true
+		}},
+		{name: "inferred Graviton", modify: func(cfg *Config) { cfg.ServerType = "m7g.large" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := baseConfig()
+			cfg.Provider = "aws"
+			cfg.ServerType = "m7a.large"
+			if tc.modify != nil {
+				tc.modify(&cfg)
+			}
+			got := awsUserData(cfg, "ssh-ed25519 test")
+			var document map[string]any
+			if err := yaml.Unmarshal([]byte(got), &document); err != nil {
+				t.Fatalf("invalid cloud-config: %v", err)
+			}
+			if !tc.want {
+				if _, ok := document["apt"]; ok {
+					t.Fatal("custom image or unqualified target must retain its APT policy")
+				}
+				if got != cloudInit(cfg, "ssh-ed25519 test") {
+					t.Fatal("excluded image must retain the ordinary cloud-init bytes")
+				}
+				return
+			}
+			want := map[string]any{
+				"primary":  []any{map[string]any{"arches": []any{"amd64"}, "uri": "https://archive.ubuntu.com/ubuntu/"}},
+				"security": []any{map[string]any{"arches": []any{"amd64"}, "uri": "http://security.ubuntu.com/ubuntu/"}},
+			}
+			if !reflect.DeepEqual(document["apt"], want) {
+				t.Fatalf("APT policy = %#v, want primary HTTPS with the separate security archive", document["apt"])
+			}
+		})
+	}
+	for _, provider := range []string{"gcp", "hetzner", "azure"} {
+		t.Run(provider, func(t *testing.T) {
+			cfg := baseConfig()
+			cfg.Provider = provider
+			got := cloudInit(cfg, "ssh-ed25519 test")
+			if provider == "azure" {
+				got = azureLinuxCloudInit(cfg, "ssh-ed25519 test")
+			}
+			var document map[string]any
+			if err := yaml.Unmarshal([]byte(got), &document); err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := document["apt"]; ok {
+				t.Fatal("AWS archive policy must not change another provider")
+			}
+		})
 	}
 }
 

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -744,7 +744,7 @@ func (b *awsLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error
 					}
 					return fmt.Errorf("re-read AWS cleanup key for missing instance %s: %w", server.DisplayID(), keyErr)
 				}
-				if err := deleteMissingClaimedAWSResourcesWithClient(ctx, client, claim, cleanupKeyID); err != nil {
+				if err := finalizeAWSKeyRecovery(ctx, client, claim, cleanupKeyID, nil); err != nil {
 					return err
 				}
 				fmt.Fprintf(b.RT.Stderr, "delete missing server recovery id=%s name=%s\n", server.DisplayID(), server.Name)
@@ -1025,10 +1025,12 @@ func (b *awsLeaseBackend) cleanupOrphanedAWSClaims(ctx context.Context, dryRun b
 			fmt.Fprintf(b.RT.Stderr, "skip orphaned AWS claim lease=%s reason=current AWS account differs from exact local claim\n", claim.LeaseID)
 			continue
 		}
+		var terminal *Server
 		if live, err := client.GetServer(ctx, claim.CloudID); err == nil {
 			if !isAWSTerminalServer(live) {
 				continue
 			}
+			terminal = &live
 		} else if !isAWSResolveNotFound(err) {
 			return fmt.Errorf("re-read orphaned AWS claim %s: %w", claim.LeaseID, err)
 		}
@@ -1044,7 +1046,7 @@ func (b *awsLeaseBackend) cleanupOrphanedAWSClaims(ctx context.Context, dryRun b
 			fmt.Fprintf(b.RT.Stderr, "delete orphaned AWS key recovery lease=%s key=%s\n", claim.LeaseID, core.ServerProviderKey(server))
 			continue
 		}
-		if err := deleteMissingClaimedAWSResourcesWithClient(ctx, client, claim, cleanupKeyID); err != nil {
+		if err := finalizeAWSKeyRecovery(ctx, client, claim, cleanupKeyID, terminal); err != nil {
 			return err
 		}
 		fmt.Fprintf(b.RT.Stderr, "delete orphaned AWS key recovery lease=%s key=%s\n", claim.LeaseID, core.ServerProviderKey(server))
@@ -1052,7 +1054,19 @@ func (b *awsLeaseBackend) cleanupOrphanedAWSClaims(ctx context.Context, dryRun b
 	return nil
 }
 
-func deleteMissingClaimedAWSResourcesWithClient(ctx context.Context, client awsClient, claim core.LeaseClaim, cleanupKeyID string) error {
+func finalizeAWSKeyRecovery(ctx context.Context, client awsClient, claim core.LeaseClaim, cleanupKeyID string, terminal *Server) error {
+	if terminal != nil {
+		if !isAWSTerminalServer(*terminal) {
+			return exit(4, "AWS lease %s has no observed terminal instance", claim.LeaseID)
+		}
+		if err := validateExactAWSClaim(*terminal, claim.LeaseID, claim); err != nil {
+			return err
+		}
+	} else if fixedAWSLeaseKind.IsFixedClaim(claim) && claim.FixedCreateIntent.State == fixedAWSIntentPrepared {
+		// A new allocation can be temporarily invisible. Keep its cleanup authority
+		// until full release succeeds or the exact instance is observed terminal.
+		return exit(4, "AWS lease %s instance visibility is unresolved; retaining its claim and key; retry when the exact instance is visible, or arrange operator recovery if it remains absent", claim.LeaseID)
+	}
 	if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
 		return err
 	}
@@ -1069,7 +1083,7 @@ func isAWSClaimProvider(provider string) bool {
 }
 
 func deleteAWSCleanupServerWithClient(ctx context.Context, client awsClient, server Server, cleanupKeyID string) error {
-	if err := client.DeleteServer(ctx, server.CloudID); err != nil && !isAWSResolveNotFound(err) {
+	if err := client.DeleteServer(ctx, server.CloudID); err != nil {
 		return err
 	}
 	if cleanupKeyID != "" {
@@ -1119,6 +1133,7 @@ func cleanupAWSCreatedResources(ctx context.Context, stderr io.Writer, cfg Confi
 	if strings.TrimSpace(cloudID) != "" {
 		if err := client.DeleteServer(ctx, cloudID); err != nil {
 			fmt.Fprintf(stderr, "warning: cleanup aws instance %s after acquire failure: %v\n", cloudID, err)
+			return
 		}
 	}
 	if strings.TrimSpace(keyPairID) != "" {

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -246,15 +247,6 @@ func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) 
 						return exit(4, "lease_id_conflict: fixed lease %s resource %s does not match acquired CloudID %s", leaseID, blank(server.CloudID, "<empty>"), blank(claim.CloudID, "<empty>"))
 					}
 				}
-				if err := validateFixedAWSServer(server, leaseID, intent.Slug, fingerprint, accountID); err != nil {
-					return err
-				}
-				if pinned == nil {
-					return exit(4, "lease_id_conflict: fixed AWS resource for lease %s has no durable launch attempt", leaseID)
-				}
-				if err := validateFixedAWSAttemptServer(server, leaseID, *pinned); err != nil {
-					return err
-				}
 				resolvedCfg = awsConfigForServer(cfg, server)
 			} else {
 				if intent.State == fixedAWSIntentAcquired || claim.CloudID != "" {
@@ -307,8 +299,32 @@ func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) 
 					}
 					return err
 				}
+				// Inventory already carries the queried region; replay must not replace it from labels.
+				server = annotateAWSServerRegion(server, resolvedCfg.AWSRegion)
 			}
 
+			if err := validateFixedAWSServer(server, leaseID, intent.Slug, fingerprint, accountID); err != nil {
+				return err
+			}
+			pinned, err = fixedAWSAttemptFromIntent(intent)
+			if err != nil || pinned == nil {
+				return exit(4, "lease_id_conflict: fixed AWS lease %s has no valid durable launch attempt after provisioning", leaseID)
+			}
+			if err := validateFixedAWSAttemptServer(server, leaseID, *pinned); err != nil {
+				return err
+			}
+			if claim.CloudID == "" {
+				// Bind once before readiness can fail; replays retain the original cleanup
+				// identity. Prepared claims permit cleanup but cannot authorize normal use.
+				claim.CloudID = server.CloudID
+				claim.CloudImmutableID = server.ImmutableID
+				claim.Labels = maps.Clone(server.Labels)
+				if err := persist(); err != nil {
+					return err
+				}
+			} else if err := validateExactAWSClaim(server, leaseID, *claim); err != nil {
+				return err
+			}
 			serverClient, err := newAWSClient(ctx, resolvedCfg)
 			if err != nil {
 				return err
@@ -318,12 +334,11 @@ func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) 
 				return err
 			}
 			server = annotateAWSServerRegion(server, resolvedCfg.AWSRegion)
-			if err := validateFixedAWSServer(server, leaseID, intent.Slug, fingerprint, accountID); err != nil {
+			if err := validateExactAWSClaim(server, leaseID, *claim); err != nil {
 				return err
 			}
-			pinned, err = fixedAWSAttemptFromIntent(intent)
-			if err != nil || pinned == nil {
-				return exit(4, "lease_id_conflict: fixed AWS lease %s has no valid durable launch attempt after provisioning", leaseID)
+			if err := validateFixedAWSServer(server, leaseID, intent.Slug, fingerprint, accountID); err != nil {
+				return err
 			}
 			if err := validateFixedAWSAttemptServer(server, leaseID, *pinned); err != nil {
 				return err
@@ -364,7 +379,7 @@ func fixedAWSLeaseMatches(servers []LeaseView, leaseID string) []Server {
 }
 
 func validateFixedAWSServer(server Server, leaseID, slug, fingerprint, accountID string) error {
-	if !isCrabboxAWSLease(server) || server.Labels["lease"] != leaseID ||
+	if server.CloudID == "" || !isCrabboxAWSLease(server) || server.Labels["lease"] != leaseID ||
 		core.NormalizeLeaseSlug(server.Labels["slug"]) != slug ||
 		server.Labels["fixed_intent_sha256"] != fingerprint ||
 		server.Labels["aws_account_id"] != accountID {
@@ -379,6 +394,8 @@ func validateFixedAWSAttemptServer(server Server, leaseID string, attempt core.A
 	}
 	if strings.TrimSpace(server.ServerType.Name) != strings.TrimSpace(attempt.ServerType) ||
 		awsServerRegion(server) != strings.TrimSpace(attempt.Region) ||
+		strings.TrimSpace(server.Labels["provider_key"]) != core.ProviderKeyForLease(leaseID) ||
+		strings.TrimSpace(server.Labels["aws_key_pair_id"]) != strings.TrimSpace(attempt.KeyPairID) ||
 		strings.TrimSpace(server.HostID) != strings.TrimSpace(attempt.HostID) {
 		return exit(4, "lease_id_conflict: AWS resource for lease %s provider identity does not match its durable launch attempt", leaseID)
 	}

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/smithy-go"
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/testutil"
 )
@@ -1228,6 +1229,115 @@ func installFixedAWSTestClient(t *testing.T, fake *fakeAWSClient) func() {
 	}
 }
 
+func TestAWSFixedCleanupRetainsPreparedClaimWhileInstanceVisibilityIsUncertain(t *testing.T) {
+	for _, boundary := range []string{"describe", "terminate", "observed terminal", "wrong terminal identity"} {
+		t.Run(boundary, func(t *testing.T) {
+			testutil.IsolateUserDirs(t)
+			fake := &fakeAWSClient{waitErr: context.Canceled}
+			t.Cleanup(installFixedAWSTestClient(t, fake))
+			req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef12348a", RequestedSlug: "pending-visibility"}
+			backend := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+			if _, err := backend.Acquire(t.Context(), req); !errors.Is(err, context.Canceled) {
+				t.Fatalf("initial readiness cancellation: %v", err)
+			}
+			before, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+			if err != nil || before.CloudID == "" || before.FixedCreateIntent.State != fixedAWSIntentPrepared {
+				t.Fatalf("missing prepared allocation: %+v err=%v", before, err)
+			}
+			missing := &smithy.GenericAPIError{Code: "InvalidInstanceID.NotFound", Message: "allocated instance has not propagated"}
+			switch boundary {
+			case "describe":
+				fake.getErr = missing
+				err = backend.cleanupOrphanedAWSClaims(t.Context(), false)
+			case "terminate":
+				fake.deleteServerErr = missing
+				err = deleteClaimedAWSServerWithClient(t.Context(), fake, fake.created, before, before.Labels["aws_key_pair_id"])
+			default:
+				terminal := fake.created
+				terminal.Status = "terminated"
+				if boundary == "wrong terminal identity" {
+					terminal.CloudID = "i-other"
+				}
+				fake.get = map[string]Server{before.CloudID: terminal}
+				err = backend.cleanupOrphanedAWSClaims(t.Context(), false)
+			}
+			after, readErr := core.ReadLeaseClaim(req.RequestedLeaseID)
+			if boundary == "observed terminal" {
+				if err != nil || readErr != nil || after.FixedCreateIntent.State != fixedAWSIntentReleased || len(fake.deletedKeys) != 1 {
+					t.Fatalf("observed terminal instance was not recovered: claim=%+v keys=%v err=%v readErr=%v", after, fake.deletedKeys, err, readErr)
+				}
+				assertAWSReceiptIdentity(t, after, before)
+				return
+			}
+			if readErr != nil || !reflect.DeepEqual(before, after) || len(fake.deletedKeys) != 0 {
+				t.Fatalf("uncertain %s discarded allocation custody: before=%+v after=%+v keys=%v err=%v readErr=%v", boundary, before, after, fake.deletedKeys, err, readErr)
+			}
+			if boundary == "terminate" && !errors.Is(err, missing) {
+				t.Fatalf("uncertain termination error=%v, want provider error", err)
+			}
+		})
+	}
+}
+
+func TestAWSPreparedLeaseRetainsCustodyAfterPartialReleaseAndLostVisibility(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	fake := &fakeAWSClient{waitErr: context.Canceled}
+	t.Cleanup(installFixedAWSTestClient(t, fake))
+	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef12348b", RequestedSlug: "partial-release"}
+	backend := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	if _, err := backend.Acquire(t.Context(), req); !errors.Is(err, context.Canceled) {
+		t.Fatalf("initial readiness cancellation: %v", err)
+	}
+	before, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+	if err != nil || before.FixedCreateIntent == nil || before.FixedCreateIntent.State != fixedAWSIntentPrepared {
+		t.Fatalf("missing prepared allocation: %+v err=%v", before, err)
+	}
+	lease, err := backend.Resolve(t.Context(), ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyErr := errors.New("key cleanup denied")
+	fake.deleteKeyErr = keyErr
+	outcome, err := backend.ReleaseLeaseWithOutcome(t.Context(), ReleaseLeaseRequest{Lease: lease})
+	if !outcome.Terminal || !errors.Is(err, keyErr) {
+		t.Fatalf("partial release outcome=%+v err=%v", outcome, err)
+	}
+	fake.servers = nil
+	fake.getErr = &smithy.GenericAPIError{Code: "InvalidInstanceID.NotFound", Message: "instance no longer visible"}
+	fake.deleteKeyErr = nil
+	if err := backend.cleanupOrphanedAWSClaims(t.Context(), false); err == nil || !strings.Contains(err.Error(), "retaining its claim and key") {
+		t.Fatalf("missing instance must leave explicit recovery obligation: %v", err)
+	}
+	after, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+	if err != nil || !reflect.DeepEqual(before, after) || len(fake.deletedInstances) != 1 || len(fake.deletedKeys) != 1 {
+		t.Fatalf("partial release lost custody: claim=%+v instances=%v keys=%v err=%v", after, fake.deletedInstances, fake.deletedKeys, err)
+	}
+	keyPath, err := core.TestboxKeyPath(req.RequestedLeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("local key no longer available for recovery: %v", err)
+	}
+}
+
+func TestAWSAcquireRollbackRetainsKeyWhenTerminationIsUncertain(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	fake := &fakeAWSClient{
+		waitErr:         context.Canceled,
+		deleteServerErr: &smithy.GenericAPIError{Code: "InvalidInstanceID.NotFound", Message: "allocated instance has not propagated"},
+	}
+	t.Cleanup(installFixedAWSTestClient(t, fake))
+	var stderr strings.Builder
+	backend := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	if _, err := backend.acquireOnce(t.Context(), false, "uncertain-rollback"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("acquisition error=%v, want cancellation", err)
+	}
+	if len(fake.deletedInstances) != 1 || len(fake.deletedKeys) != 0 || !strings.Contains(stderr.String(), "warning: cleanup aws instance") {
+		t.Fatalf("uncertain rollback instances=%v keys=%v stderr=%q", fake.deletedInstances, fake.deletedKeys, stderr.String())
+	}
+}
+
 func TestAWSAcquireBindsImmutableProviderKeyID(t *testing.T) {
 	testutil.IsolateUserDirs(t)
 	fake := &fakeAWSClient{}
@@ -2068,7 +2178,7 @@ func TestAWSCleanupCopiedLeaseTagDoesNotSuppressOrphanRecovery(t *testing.T) {
 	assertAWSClaimMissing(t, claimed.Labels["lease"])
 }
 
-func TestAWSCleanupTreatsInstanceMissingAtDeleteBoundaryAsRemoved(t *testing.T) {
+func TestAWSCleanupRetainsKeyAfterUncertainTerminationThenRecoversMissingInstance(t *testing.T) {
 	isolateAWSClaimState(t)
 	server := awsTestServer("i-raced", "cbx_333333333333", "raced", "us-east-1")
 	server.Labels["provider_key"] = "crabbox-cbx-333333333333"
@@ -2085,8 +2195,18 @@ func TestAWSCleanupTreatsInstanceMissingAtDeleteBoundaryAsRemoved(t *testing.T) 
 	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
 	claimAWSCleanupServer(t, cfg, server)
 	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
-		t.Fatal(err)
+	if err := backend.Cleanup(context.Background(), CleanupRequest{}); !errors.Is(err, fake.deleteServerErr) {
+		t.Fatalf("uncertain termination error=%v, want %v", err, fake.deleteServerErr)
+	}
+	if len(fake.deletedKeys) != 0 {
+		t.Fatalf("uncertain termination deleted keys=%v", fake.deletedKeys)
+	}
+	assertAWSClaimCloudID(t, server.Labels["lease"], server.CloudID)
+	fake.servers = nil
+	fake.get = nil
+	fake.getErr = core.Exit(4, "aws instance not found: %s", server.CloudID)
+	if err := backend.Cleanup(t.Context(), CleanupRequest{}); err != nil {
+		t.Fatalf("later missing-instance recovery: %v", err)
 	}
 	if len(fake.deletedKeys) != 1 || fake.deletedKeys[0] != "key-id-for-"+server.Labels["provider_key"] {
 		t.Fatalf("deleted keys=%v, want raced instance key cleanup", fake.deletedKeys)

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"maps"
 	"os"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -216,6 +217,102 @@ func TestAWSAcquireCleansUpCreatedServerAndKeyOnIPFailure(t *testing.T) {
 	}
 }
 
+func TestAWSFixedAcquireAllowsReleaseAfterReadinessFailure(t *testing.T) {
+	for _, phase := range []string{"public IP", "SSH bootstrap"} {
+		t.Run(phase, func(t *testing.T) {
+			testutil.IsolateUserDirs(t)
+			fake := &fakeAWSClient{}
+			t.Cleanup(installFixedAWSTestClient(t, fake))
+			readinessErr := errors.New("readiness interrupted")
+			bootstrapCalls, acquiredCalls := 0, 0
+			bootstrapAWSWindowsDesktop = func(context.Context, Config, *SSHTarget, string, io.Writer) error {
+				bootstrapCalls++
+				return readinessErr
+			}
+			if phase == "public IP" {
+				fake.waitErr = readinessErr
+			}
+			cfg := fixedAWSTestConfig()
+			req := AcquireRequest{
+				Repo: core.Repo{Root: t.TempDir()}, Keep: true,
+				RequestedLeaseID: "cbx_abcdef123485", RequestedSlug: "interrupted-readiness",
+				OnAcquired: func(LeaseTarget) error { acquiredCalls++; return nil },
+			}
+			backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+			if _, err := backend.Acquire(t.Context(), req); !errors.Is(err, readinessErr) {
+				t.Fatalf("acquire error=%v, want interrupted readiness", err)
+			}
+			pending, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			restarted := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+			lease, err := restarted.Resolve(t.Context(), ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := restarted.AuthorizeStatusTouchClaim(t.Context(), lease, pending); err == nil || !strings.Contains(err.Error(), "no acquired fixed intent") {
+				t.Fatalf("pending claim authorized normal use: %v", err)
+			}
+			if err := restarted.ReleaseLease(t.Context(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+				t.Fatalf("release after %s failure: %v", phase, err)
+			}
+			if pending.CloudID != fake.created.CloudID || pending.FixedCreateIntent.State != fixedAWSIntentPrepared ||
+				pending.Labels["aws_account_id"] != "123456789012" || pending.Labels["aws_region"] != cfg.AWSRegion ||
+				pending.Labels["aws_key_pair_id"] != fake.created.Labels["aws_key_pair_id"] || pending.SSHHost != "" || pending.SSHPort != 0 {
+				t.Fatalf("pending claim lost resource identity or published readiness: %+v", pending)
+			}
+			terminal, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertAWSReceiptIdentity(t, terminal, pending)
+			if err := validateAWSTerminalReceipt(terminal, req.RequestedLeaseID); err != nil {
+				t.Fatal(err)
+			}
+			wantBootstrap := 0
+			if phase == "SSH bootstrap" {
+				wantBootstrap = 1
+			}
+			if fake.createCalls != 1 || bootstrapCalls != wantBootstrap || acquiredCalls != 0 || len(fake.tagged) != 0 ||
+				len(fake.deletedInstances) != 1 || fake.deletedInstances[0] != pending.CloudID || len(fake.deletedKeys) != 1 {
+				t.Fatalf("unexpected recovery effects: creates=%d bootstrap=%d acquired=%d tags=%v instances=%v keys=%v",
+					fake.createCalls, bootstrapCalls, acquiredCalls, fake.tagged, fake.deletedInstances, fake.deletedKeys)
+			}
+		})
+	}
+}
+
+func TestAWSFixedAcquireRejectsChangedCloudIDAfterIPWait(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	fake := &fakeAWSClient{}
+	fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg Config, leaseID, slug string) (Server, Config, error) {
+		fake.createCalls++
+		attempt := fixedAWSTestAttempt(cfg)
+		if err := control.BeforeAttempt(attempt); err != nil {
+			return Server{}, cfg, err
+		}
+		created := fixedAWSTestServer(control, cfg, leaseID, slug, attempt)
+		fake.servers = []Server{created}
+		fake.created = created
+		fake.created.CloudID = "i-copied-tags-after-wait"
+		return created, cfg, nil
+	}
+	t.Cleanup(installFixedAWSTestClient(t, fake))
+	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123486", RequestedSlug: "bound-before-wait"}
+	_, err := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(t.Context(), req)
+	if err == nil {
+		t.Fatal("accepted a different instance with copied tags after IP wait")
+	}
+	claim, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+	if err != nil || claim.CloudID != fake.servers[0].CloudID || claim.FixedCreateIntent.State != fixedAWSIntentPrepared {
+		t.Fatalf("post-wait replacement changed the bound claim: %+v err=%v", claim, err)
+	}
+	if len(fake.tagged) != 0 || fake.createCalls != 1 {
+		t.Fatalf("post-wait replacement became ready: tags=%v creates=%d", fake.tagged, fake.createCalls)
+	}
+}
+
 func TestAWSFixedAcquireReplaysSameLeaseAndRejectsIntentDrift(t *testing.T) {
 	testutil.IsolateUserDirs(t)
 	fake := &fakeAWSClient{}
@@ -287,29 +384,46 @@ func TestAWSFixedAcquireReplaysSameLeaseAndRejectsIntentDrift(t *testing.T) {
 	}
 }
 
-func TestAWSFixedAcquireRejectsDifferentAcquiredCloudIDWithCopiedTags(t *testing.T) {
-	testutil.IsolateUserDirs(t)
-	fake := &fakeAWSClient{}
-	restore := installFixedAWSTestClient(t, fake)
-	defer restore()
-	cfg := fixedAWSTestConfig()
-	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123481", RequestedSlug: "cloud-id-bound"}
-	lease, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	impostor := lease.Server
-	impostor.CloudID = "i-copied-fixed-tags"
-	impostor.Labels = maps.Clone(lease.Server.Labels)
-	fake.servers = []Server{impostor}
-	creates := fake.createCalls
-
-	_, err = NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req)
-	if err == nil || !strings.Contains(err.Error(), "lease_id_conflict") || !strings.Contains(err.Error(), "acquired CloudID") {
-		t.Fatalf("different acquired CloudID replay err=%v", err)
-	}
-	if fake.createCalls != creates {
-		t.Fatalf("different acquired CloudID replay called create: before=%d after=%d", creates, fake.createCalls)
+func TestAWSFixedAcquireRejectsBoundIdentityDrift(t *testing.T) {
+	for _, state := range []string{fixedAWSIntentPrepared, fixedAWSIntentAcquired} {
+		for _, field := range []string{"instance ID", "provider key"} {
+			t.Run(state+"/"+field, func(t *testing.T) {
+				testutil.IsolateUserDirs(t)
+				fake := &fakeAWSClient{}
+				t.Cleanup(installFixedAWSTestClient(t, fake))
+				cfg := fixedAWSTestConfig()
+				req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123481", RequestedSlug: "identity-bound"}
+				if state == fixedAWSIntentPrepared {
+					fake.waitErr = errors.New("readiness interrupted")
+				}
+				_, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(t.Context(), req)
+				if !errors.Is(err, fake.waitErr) {
+					t.Fatalf("initial acquisition: %v", err)
+				}
+				before, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				impostor := fake.created
+				impostor.Labels = maps.Clone(impostor.Labels)
+				if field == "instance ID" {
+					impostor.CloudID = "i-copied-fixed-tags"
+				} else {
+					impostor.Labels["provider_key"] = core.ProviderKeyForLease("cbx_abcdef987654")
+				}
+				fake.servers, fake.created, fake.waitErr = []Server{impostor}, impostor, nil
+				if _, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(t.Context(), req); err == nil {
+					t.Fatal("accepted changed bound identity")
+				}
+				after, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+				if err != nil || !reflect.DeepEqual(before, after) {
+					t.Fatalf("rejected replay changed durable ownership: before=%+v after=%+v err=%v", before, after, err)
+				}
+				if fake.createCalls != 1 {
+					t.Fatalf("replay creates=%d, want one original allocation", fake.createCalls)
+				}
+			})
+		}
 	}
 }
 
@@ -728,6 +842,9 @@ func TestAWSFixedAcquireRecoversCommitThenTimeoutAfterFreshBackend(t *testing.T)
 	if claim.FixedCreateIntent == nil || len(claim.FixedCreateIntent.Attempt) == 0 {
 		t.Fatalf("fixed create attempt was not persisted before the provider error: %#v", claim.FixedCreateIntent)
 	}
+	if claim.CloudID != "" {
+		t.Fatal("ambiguous provider response published an unobserved instance identity")
+	}
 	attempt, err := fixedAWSAttemptFromIntent(claim.FixedCreateIntent)
 	if err != nil || attempt == nil {
 		t.Fatalf("read persisted fixed attempt: attempt=%#v err=%v", attempt, err)
@@ -737,6 +854,15 @@ func TestAWSFixedAcquireRecoversCommitThenTimeoutAfterFreshBackend(t *testing.T)
 	}
 	fake.controlCreate = nil
 	second := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	fake.waitErr = errors.New("public IP readiness interrupted after adoption")
+	if _, err := second.Acquire(t.Context(), req); !errors.Is(err, fake.waitErr) {
+		t.Fatalf("adopted instance readiness: %v", err)
+	}
+	claim, err = core.ReadLeaseClaim(req.RequestedLeaseID)
+	if err != nil || claim.CloudID != fake.created.CloudID || claim.FixedCreateIntent.State != fixedAWSIntentPrepared {
+		t.Fatalf("adopted instance was not bound before readiness: %+v err=%v", claim, err)
+	}
+	fake.waitErr = nil
 	lease, err := second.Acquire(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
@@ -854,43 +980,69 @@ func TestAWSFixedAcquireRejectsMismatchedOrMissingAttemptAttestation(t *testing.
 				if fake.createCalls != creates {
 					t.Fatalf("%s %s attestation replay called create: before=%d after=%d", tag, mutation, creates, fake.createCalls)
 				}
+				claim, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+				if err != nil || claim.CloudID != "" || len(claim.Labels) != 0 {
+					t.Fatalf("unattested resource was bound to the pending claim: %+v err=%v", claim, err)
+				}
 			})
 		}
 	}
 }
 
-func TestAWSFixedAcquireRejectsCopiedAttemptTagsWhenProviderTypeDiffers(t *testing.T) {
-	testutil.IsolateUserDirs(t)
-	fake := &fakeAWSClient{}
-	fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg Config, leaseID, slug string) (Server, Config, error) {
-		fake.createCalls++
-		attempt := fixedAWSTestAttempt(cfg)
-		if err := control.BeforeAttempt(attempt); err != nil {
-			return Server{}, cfg, err
-		}
-		fake.created = fixedAWSTestServer(control, cfg, leaseID, slug, attempt)
-		return Server{}, cfg, errors.New("transport closed after ambiguous fixed create")
-	}
-	restore := installFixedAWSTestClient(t, fake)
-	defer restore()
-	cfg := fixedAWSTestConfig()
-	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123484", RequestedSlug: "provider-attested"}
-	if _, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err == nil {
-		t.Fatal("expected ambiguous create error")
-	}
-	candidate := fake.created
-	candidate.Labels = maps.Clone(fake.created.Labels)
-	candidate.ServerType.Name = "m7i.xlarge"
-	fake.servers = []Server{candidate}
-	fake.controlCreate = nil
-	creates := fake.createCalls
-
-	_, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req)
-	if err == nil || !strings.Contains(err.Error(), "lease_id_conflict") || !strings.Contains(err.Error(), "provider identity") {
-		t.Fatalf("copied attempt tags with wrong provider type err=%v", err)
-	}
-	if fake.createCalls != creates {
-		t.Fatalf("copied attempt tags replay called create: before=%d after=%d", creates, fake.createCalls)
+func TestAWSFixedAcquireRejectsCopiedAttemptTagsWhenProviderIdentityDiffers(t *testing.T) {
+	for _, field := range []string{"instance type", "observed region", "provider key", "key pair ID"} {
+		t.Run(field, func(t *testing.T) {
+			testutil.IsolateUserDirs(t)
+			fake := &fakeAWSClient{}
+			fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg Config, leaseID, slug string) (Server, Config, error) {
+				fake.createCalls++
+				attempt := fixedAWSTestAttempt(cfg)
+				if err := control.BeforeAttempt(attempt); err != nil {
+					return Server{}, cfg, err
+				}
+				fake.created = fixedAWSTestServer(control, cfg, leaseID, slug, attempt)
+				return Server{}, cfg, errors.New("transport closed after ambiguous fixed create")
+			}
+			t.Cleanup(installFixedAWSTestClient(t, fake))
+			cfg := fixedAWSTestConfig()
+			cfg.Capacity.Regions = []string{"eu-west-1"}
+			req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123484", RequestedSlug: "provider-attested"}
+			if _, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(t.Context(), req); err == nil {
+				t.Fatal("expected ambiguous create error")
+			}
+			candidate := fake.created
+			candidate.Labels = maps.Clone(candidate.Labels)
+			otherRegion := &fakeAWSClient{}
+			switch field {
+			case "instance type":
+				candidate.ServerType.Name = "m7i.xlarge"
+			case "provider key":
+				candidate.Labels["provider_key"] = core.ProviderKeyForLease("cbx_abcdef987654")
+			case "key pair ID":
+				candidate.Labels["aws_key_pair_id"] = "key-id-other"
+			}
+			if field == "observed region" {
+				otherRegion.servers = []Server{candidate}
+			} else {
+				fake.servers = []Server{candidate}
+			}
+			fake.created = candidate
+			newAWSClient = func(_ context.Context, regionCfg Config) (awsClient, error) {
+				if regionCfg.AWSRegion == "eu-west-1" {
+					return otherRegion, nil
+				}
+				return fake, nil
+			}
+			fake.controlCreate = nil
+			_, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(t.Context(), req)
+			if err == nil || !strings.Contains(err.Error(), "lease_id_conflict") || !strings.Contains(err.Error(), "provider") {
+				t.Fatalf("copied attempt tags with wrong %s: %v", field, err)
+			}
+			claim, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+			if err != nil || claim.CloudID != "" || len(claim.Labels) != 0 || fake.createCalls != 1 {
+				t.Fatalf("unattested resource was bound or recreated: claim=%+v creates=%d err=%v", claim, fake.createCalls, err)
+			}
+		})
 	}
 }
 

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -2036,17 +2036,18 @@ export class EC2SpotClient {
   ): Promise<ProviderMachine> {
     const now = new Date();
     const name = leaseProviderName(leaseID, slug);
-    const labels = leaseProviderLabels(
-      { ...config, selectedImage: awsLeaseImageIdentity(config, imageID, this.region) },
-      leaseID,
-      slug,
-      owner,
-      "aws",
-      now,
-      {
-        market: config.capacityMarket,
-      },
-    );
+    // The resolver also accepts an environment AMI; preserve that provenance in tags and bootstrap.
+    const launchConfig: LeaseConfig = {
+      ...config,
+      selectedImage: awsLeaseImageIdentity(
+        { ...config, awsAMI: config.awsAMI || this.env.CRABBOX_AWS_AMI || "" },
+        imageID,
+        this.region,
+      ),
+    };
+    const labels = leaseProviderLabels(launchConfig, leaseID, slug, owner, "aws", now, {
+      market: config.capacityMarket,
+    });
     const rootGB = config.awsRootGB || positiveInt(this.env.CRABBOX_AWS_ROOT_GB) || 400;
     const instanceProfile = config.awsProfile || this.env.CRABBOX_AWS_INSTANCE_PROFILE || "";
     const subnetID = config.awsSubnetID || this.env.CRABBOX_AWS_SUBNET_ID || "";
@@ -2063,7 +2064,7 @@ export class EC2SpotClient {
     let lastMacHostID = "";
     const run = async (macHostID: string): Promise<ProviderMachine> => {
       const params = await awsRunInstancesParams({
-        config,
+        config: launchConfig,
         leaseID,
         imageID,
         securityGroupID,

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -29,7 +29,24 @@ export function awsUserData(config: LeaseConfig): string {
   if (config.target === "macos") {
     return macOSUserData(config);
   }
-  return cloudInit(config);
+  // Custom images retain their sources. Keep security separate; cloud-init otherwise uses primary.
+  const aptConfig =
+    config.provider === "aws" &&
+    config.target === "linux" &&
+    !config.awsPrivate &&
+    config.os === "ubuntu:26.04" &&
+    config.architecture === "amd64" &&
+    config.selectedImage?.source === "stock"
+      ? `apt:
+  primary:
+    - arches: [amd64]
+      uri: https://archive.ubuntu.com/ubuntu/
+  security:
+    - arches: [amd64]
+      uri: http://security.ubuntu.com/ubuntu/
+`
+      : "";
+  return cloudInit(config, "", aptConfig);
 }
 
 export async function awsRunInstancesUserData(config: LeaseConfig): Promise<string> {
@@ -53,7 +70,11 @@ function base64Encode(bytes: Uint8Array): string {
   return btoa(chunks.join(""));
 }
 
-export function cloudInit(config: LeaseConfig, additionalBootstrap = ""): string {
+export function cloudInit(
+  config: LeaseConfig,
+  additionalBootstrap = "",
+  additionalCloudConfig = "",
+): string {
   if (config.awsPrivate) {
     return privateAWSCloudInit(config);
   }
@@ -69,7 +90,7 @@ export function cloudInit(config: LeaseConfig, additionalBootstrap = ""): string
   return `#cloud-config
 package_update: false
 package_upgrade: false
-users:
+${additionalCloudConfig}users:
   - name: ${config.sshUser}
     groups: sudo
     shell: /bin/bash

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -30,6 +30,7 @@ import {
   awsMacOSInstanceTypeCandidates,
   awsPromotedAMIConfigKey,
   leaseConfig,
+  type LeaseConfig,
 } from "../src/config";
 
 afterEach(() => {
@@ -1661,31 +1662,74 @@ describe("aws provider", () => {
     expect(isRetryableAWSProvisioningError(imageMiss)).toBe(true);
   });
 
-  it("sends compressed Linux cloud-init user data to RunInstances", async () => {
-    let userData = "";
-    let runImage = "";
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-        const request = input instanceof Request ? input : new Request(input, init);
-        if (new URL(request.url).hostname.startsWith("servicequotas.")) {
-          return new Response(JSON.stringify({ Quota: { Value: 999 } }), {
-            headers: { "content-type": "application/json" },
-          });
-        }
-        const params = new URLSearchParams(await request.clone().text());
-        const action = params.get("Action") ?? "";
-        const securityGroupResponse = ec2ConfiguredSecurityGroupResponse(action, params);
-        if (securityGroupResponse) {
-          return securityGroupResponse;
-        }
-        if (action === "DescribeKeyPairs") {
-          return ec2XMLResponse(
-            `<DescribeKeyPairsResponse><keySet><item><keyName>crabbox-cbx</keyName><publicKey>ssh-rsa ${"a".repeat(724)}</publicKey></item></keySet></DescribeKeyPairsResponse>`,
-          );
-        }
-        if (action === "DescribeImages") {
-          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+  it.each<[string, Partial<LeaseConfig>, string, string, string, boolean]>([
+    ["stock", {}, "", "ami-linux", "stock", true],
+    ["forced stock", { awsUseStockImage: true }, "ami-env", "ami-linux", "stock", true],
+    ["environment AMI", {}, "ami-env", "ami-env", "explicit", false],
+    ["request AMI", { awsAMI: "ami-request" }, "", "ami-request", "explicit", false],
+    [
+      "request before environment AMI",
+      { awsAMI: "ami-request" },
+      "ami-env",
+      "ami-request",
+      "explicit",
+      false,
+    ],
+    ["explicit stock AMI", { awsAMI: "ami-linux" }, "", "ami-linux", "explicit", false],
+    [
+      "promoted AMI",
+      {
+        awsAMI: "ami-promoted",
+        selectedImage: {
+          id: "ami-promoted",
+          source: "promoted",
+          provider: "aws",
+          kind: "aws-ami",
+          region: "us-east-1",
+        },
+      },
+      "",
+      "ami-promoted",
+      "promoted",
+      false,
+    ],
+    [
+      "ARM stock",
+      { architecture: "arm64", serverType: "c7g.8xlarge" },
+      "",
+      "ami-linux",
+      "stock",
+      false,
+    ],
+    ["Ubuntu 24.04 stock", { os: "ubuntu:24.04" }, "", "ami-linux", "stock", false],
+  ])(
+    "sends image-owned Linux cloud-init for %s",
+    async (_name, overrides, envAMI, imageID, source, aptOverride) => {
+      let userData = "";
+      let runImage = "";
+      let runLabels: Record<string, string> = {};
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          if (new URL(request.url).hostname.startsWith("servicequotas.")) {
+            return new Response(JSON.stringify({ Quota: { Value: 999 } }), {
+              headers: { "content-type": "application/json" },
+            });
+          }
+          const params = new URLSearchParams(await request.clone().text());
+          const action = params.get("Action") ?? "";
+          const securityGroupResponse = ec2ConfiguredSecurityGroupResponse(action, params);
+          if (securityGroupResponse) {
+            return securityGroupResponse;
+          }
+          if (action === "DescribeKeyPairs") {
+            return ec2XMLResponse(
+              `<DescribeKeyPairsResponse><keySet><item><keyName>crabbox-cbx</keyName><publicKey>ssh-rsa ${"a".repeat(724)}</publicKey></item></keySet></DescribeKeyPairsResponse>`,
+            );
+          }
+          if (action === "DescribeImages") {
+            return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
 <DescribeImagesResponse>
   <imagesSet>
     <item>
@@ -1696,11 +1740,16 @@ describe("aws provider", () => {
     </item>
   </imagesSet>
 </DescribeImagesResponse>`);
-        }
-        if (action === "RunInstances") {
-          userData = params.get("UserData") ?? "";
-          runImage = params.get("ImageId") ?? "";
-          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+          }
+          if (action === "RunInstances") {
+            userData = params.get("UserData") ?? "";
+            runImage = params.get("ImageId") ?? "";
+            runLabels = Object.fromEntries(
+              [...params.entries()]
+                .filter(([key]) => /^TagSpecification\.1\.Tag\.\d+\.Key$/.test(key))
+                .map(([key, value]) => [value, params.get(key.replace(/\.Key$/, ".Value")) ?? ""]),
+            );
+            return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
 <RunInstancesResponse>
   <instancesSet>
     <item>
@@ -1711,49 +1760,66 @@ describe("aws provider", () => {
     </item>
   </instancesSet>
 </RunInstancesResponse>`);
-        }
-        return ec2XMLResponse(
-          `<Response><Errors><Error><Code>Unexpected</Code><Message>${action}</Message></Error></Errors></Response>`,
-          500,
-        );
-      }),
-    );
-
-    const client = new EC2SpotClient(
-      {
-        AWS_ACCESS_KEY_ID: "test",
-        AWS_SECRET_ACCESS_KEY: "secret",
-        CRABBOX_AWS_SECURITY_GROUP_ID: "sg-123",
-        CRABBOX_AWS_SSH_CIDRS: "203.0.113.7/32",
-        CRABBOX_AWS_AMI: "ami-custom",
-      } as never,
-      "us-east-1",
-    );
-    await client.createServerWithFallback(
-      {
-        ...leaseConfig({
-          provider: "aws",
-          target: "linux",
-          class: "standard",
-          desktop: true,
-          browser: true,
-          sshPublicKey: `ssh-rsa ${"a".repeat(724)}`,
+          }
+          return ec2XMLResponse(
+            `<Response><Errors><Error><Code>Unexpected</Code><Message>${action}</Message></Error></Errors></Response>`,
+            500,
+          );
         }),
-        awsUseStockImage: true,
-      },
-      "cbx_abcdef123456",
-      "violet-prawn",
-      "alice@example.com",
-    );
+      );
 
-    expect(runImage).toBe("ami-linux");
-    expect(atob(userData).length).toBeLessThan(16 * 1024);
-    expect(await gunzipBase64(userData)).toContain("crabbox-configure-desktop-theme");
-  });
+      const client = new EC2SpotClient(
+        {
+          AWS_ACCESS_KEY_ID: "test",
+          AWS_SECRET_ACCESS_KEY: "secret",
+          CRABBOX_AWS_SECURITY_GROUP_ID: "sg-123",
+          CRABBOX_AWS_SSH_CIDRS: "203.0.113.7/32",
+          CRABBOX_AWS_AMI: envAMI,
+        } as never,
+        "us-east-1",
+      );
+      await client.createServerWithFallback(
+        {
+          ...leaseConfig({
+            provider: "aws",
+            target: "linux",
+            class: "standard",
+            desktop: true,
+            browser: true,
+            sshPublicKey: `ssh-rsa ${"a".repeat(724)}`,
+          }),
+          ...overrides,
+        },
+        "cbx_abcdef123456",
+        "violet-prawn",
+        "alice@example.com",
+      );
+
+      expect(runImage).toBe(imageID);
+      expect(runLabels["image_id"]).toBe(imageID);
+      expect(runLabels["image_source"]).toBe(source);
+      expect(atob(userData).length).toBeLessThan(16 * 1024);
+      const decoded = await gunzipBase64(userData);
+      expect(decoded).toContain("crabbox-configure-desktop-theme");
+      expect(decoded.includes("\napt:\n")).toBe(aptOverride);
+      expect(
+        decoded.includes(
+          "primary:\n    - arches: [amd64]\n      uri: https://archive.ubuntu.com/ubuntu/",
+        ),
+      ).toBe(aptOverride);
+      expect(
+        decoded.includes(
+          "security:\n    - arches: [amd64]\n      uri: http://security.ubuntu.com/ubuntu/",
+        ),
+      ).toBe(aptOverride);
+      expect(decoded).not.toContain("preserve_sources_list:");
+    },
+  );
 
   it("uses the capability-selected AMI for a Linux region", async () => {
     let imageQueries = 0;
     let runImage = "";
+    let userData = "";
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1778,6 +1844,7 @@ describe("aws provider", () => {
         }
         if (action === "RunInstances") {
           runImage = params.get("ImageId") ?? "";
+          userData = params.get("UserData") ?? "";
           return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
 <RunInstancesResponse><instancesSet><item>
   <instanceId>i-linux</instanceId><instanceType>t3.small</instanceType>
@@ -1818,6 +1885,7 @@ describe("aws provider", () => {
 
     expect(runImage).toBe("ami-capable");
     expect(imageQueries).toBe(0);
+    expect(await gunzipBase64(userData)).not.toContain("\napt:\n");
   });
 
   it("resolves macOS AMIs per fallback instance type", async () => {
@@ -2680,18 +2748,9 @@ describe("aws provider", () => {
       ensureSecurityGroup: () => Promise<string>;
       quotaPreflightAttempt: () => Promise<undefined>;
       ec2: (action: string, params?: Record<string, string>) => Promise<unknown>;
-      createServer: (...args: unknown[]) => Promise<{
-        provider: "aws";
-        id: number;
-        cloudID: string;
-        name: string;
-        status: string;
-        serverType: string;
-        host: string;
-        labels: Record<string, string>;
-      }>;
     };
     const calls: string[] = [];
+    let userData = "";
     client.ensureSSHKey = async () => {
       calls.push("ensure-key");
     };
@@ -2710,20 +2769,19 @@ describe("aws provider", () => {
     client.quotaPreflightAttempt = async () => undefined;
     client.ec2 = async (action, params) => {
       calls.push(`${action}:${params?.ImageId ?? ""}`);
+      if (action === "RunInstances") {
+        userData = params?.UserData ?? "";
+        return {
+          instancesSet: {
+            item: {
+              instanceId: "i-123",
+              instanceType: "t3.small",
+              instanceState: { name: "running" },
+            },
+          },
+        };
+      }
       return {};
-    };
-    client.createServer = async (...args: unknown[]) => {
-      calls.push(`launch:${String(args[4])}`);
-      return {
-        provider: "aws",
-        id: 1,
-        cloudID: "i-123",
-        name: "crabbox-blue-lobster",
-        status: "running",
-        serverType: "t3.small",
-        host: "192.0.2.10",
-        labels: {},
-      };
     };
 
     await client.createServerWithFallback(
@@ -2745,9 +2803,10 @@ describe("aws provider", () => {
       "register-snapshot",
       "wait:ami-transient",
       "security-group",
-      "launch:ami-transient",
+      "RunInstances:ami-transient",
       "DeregisterImage:ami-transient",
     ]);
+    expect(await gunzipBase64(userData)).not.toContain("\napt:\n");
   });
 
   it("deregisters transient AMIs when snapshot image waiting fails", async () => {

--- a/worker/test/bootstrap-private.test.ts
+++ b/worker/test/bootstrap-private.test.ts
@@ -14,6 +14,7 @@ describe("private AWS cloud-init", () => {
     expect(got).not.toContain("ssh_host_");
     expect(got).not.toContain("/etc/ssh");
     expect(got).not.toContain("openssh-server");
+    expect(got).not.toContain("\napt:\n");
     expect(got).not.toContain("NOPASSWD");
     expect(got).not.toMatch(/systemctl (?:enable|restart|start).*\bssh\b/);
     expect(got).toContain("systemctl disable --now ssh.service ssh.socket");
@@ -42,11 +43,12 @@ describe("private AWS cloud-init", () => {
     expect(got).not.toContain("ssh_authorized_keys");
     expect(got).not.toContain("ssh-ed25519 must-not-appear");
     expect(got).not.toContain("openssh-server");
+    expect(got).not.toContain("\napt:\n");
   });
 });
 
 function privateLeaseConfig(): LeaseConfig {
-  return leaseConfig({
+  const config = leaseConfig({
     provider: "aws",
     target: "linux",
     class: "standard",
@@ -67,6 +69,10 @@ function privateLeaseConfig(): LeaseConfig {
     sshUser: "crabbox",
     sshPublicKey: "ssh-ed25519 must-not-appear",
   });
+  return {
+    ...config,
+    selectedImage: { id: "ami-stock", source: "stock", provider: "aws", kind: "aws-ami" },
+  };
 }
 
 async function gunzipBase64(value: string): Promise<string> {

--- a/worker/test/bootstrap.test.ts
+++ b/worker/test/bootstrap.test.ts
@@ -197,6 +197,24 @@ async function gunzipBase64(value: string): Promise<string> {
 }
 
 describe("cloud-init bootstrap", () => {
+  it.each(["aws", "azure", "gcp", "hetzner"] as const)(
+    "keeps AWS archive policy out of shared %s cloud-init",
+    (provider) => {
+      const input: LeaseConfig = {
+        ...leaseConfig({ provider, sshPublicKey: "ssh-ed25519 fixture" }),
+        selectedImage: { id: "ami-stock", source: "stock", provider: "aws", kind: "aws-ami" },
+      };
+      const output = cloudInit(input, "echo additional-bootstrap");
+      expect(output).not.toContain("\napt:\n");
+      expect(output).toContain("echo additional-bootstrap");
+    },
+  );
+
+  it("does not assume an unclassified AWS image is stock", () => {
+    const input = leaseConfig({ provider: "aws", sshPublicKey: "ssh-ed25519 fixture" });
+    expect(awsUserData(input)).toBe(cloudInit(input));
+  });
+
   it("installs a coordinator-generated SSH host identity", () => {
     const got = cloudInit({
       ...config,


### PR DESCRIPTION
## What Problem This Solves

An interrupted fixed-ID AWS warmup could leave an allocated instance that ordinary stop could not clean up. Fresh EC2 instances can also be temporarily missing from DescribeInstances while their allocation propagates. Stock Ubuntu 26.04 amd64 provisioning depended on the regional EC2 HTTP package archive.

## Why This Change Was Made

The AWS acquisition owner now records the verified instance and cleanup identity before IP/SSH readiness, while keeping the lease prepared. Replay revalidates that exact identity before publishing readiness. The readiness waiter retries only typed InvalidInstanceID.NotFound for its newly allocated instance, within the existing ten-minute budget and five-second interval; cancellation, earlier deadlines, and other errors retain their behavior.

Cleanup keeps the prepared claim and key while instance visibility or termination is uncertain. Key-only recovery for a prepared claim requires an observed exact terminal instance. The main-branch rollback-error propagation and retry veto are preserved: uncertain termination cannot delete the key or trigger an unrelated replacement allocation.

Direct CLI and public Worker provisioning select Canonical's HTTPS primary archive through cloud-init for automatically selected stock Ubuntu 26.04 amd64 images. Security updates retain their separate archive. Explicit/environment-selected AMIs, promoted images, checkpoint forks, ARM64, other OS versions, and private workspaces retain their existing policy. No configuration option, claim field, lifecycle state, or storage format is added.

## Evidence on the Current Head

Reviewed and built commit: `14dad483f3e13d4f087ac4f9d7ae014893294c15`, tree `fea45553c0866a486290482ac4650096299d872a`. Native control-binary SHA-256: `02e41f59395e1a557a2e894ceb7892fd6a65d1d9345dc72a8b90fdd7e23cf80c`.

**Native cancellation, stale-identity rejection, stop, and replay:** a real fixed-ID acquisition was cancelled after its prepared identity had been persisted. Changing only its instance slug tag caused a fresh ordinary stop to exit 2 with the stale exact-claim rejection. Claim bytes and local SSH-key metadata stayed unchanged. Before restoring the tag, fresh AWS observations showed the same instance running, its exact provider key present, and its original root volume still attached. Ordinary stop then succeeded. A separately bounded cleanup continuation verified terminal replay, an unchanged released receipt, and absence of the instance, key, volume, temporary security group, and local SSH artifacts.

The original negative proof is retained as failed/expired: its request factory mistakenly treated the stale-stop label as the later stop label and blocked a dedicated follow-up check; authentication then expired during cleanup verification. The independent post-rejection observations above came from the restore owner's reads **before** tag restoration. After native sign-in renewal, cleanup and replay passed. The old outcome and deadline were not rewritten. No absence of AWS deletion API calls is claimed. Source ordering is explicit: [exact-claim validation](https://github.com/openclaw/crabbox/blob/14dad483f3e13d4f087ac4f9d7ae014893294c15/internal/providers/aws/backend.go#L635) precedes [destructive cleanup](https://github.com/openclaw/crabbox/blob/14dad483f3e13d4f087ac4f9d7ae014893294c15/internal/providers/aws/backend.go#L647); the slug mismatch rejects at [the claim validator](https://github.com/openclaw/crabbox/blob/14dad483f3e13d4f087ac4f9d7ae014893294c15/internal/providers/aws/backend.go#L930).

**Complete native AWS project reuse passed:** automatic stock Ubuntu 26.04 amd64 selection, on-demand m7a.large with a 40 GiB root disk, a real Crabbox checkout/build, native snapshot capture, an enrolled unconsumed reserve, a distinct session claiming that reserve after the source instance was reclaimed, successful command execution, and automatic replacement refill. Setup and build counts remained **1**, with the identical **157,802,551-byte** binary SHA-256 `0a5dd3db315477623ec7b7aa0b1b14c514c39120b5f3026f5c9f6362cf8df0dd` in both sessions. The observed stock archive projection matched the intended policy.

| Single-run measurement | Observed |
| --- | ---: |
| Cold dispatch to active, including initial preparation | 1,157.40 s |
| Warm dispatch to active | **3.94 s** |
| Warm dispatch through first command and reconciliation | **15.93 s** |

The integration used an isolated OpenClaw candidate and a synthetic model. A separately pinned QA fixture fixes the previous run's premature success response while exec was still running. These are observed activation and command/reconciliation timings, not model-response latency percentiles or a production rollout. The previous R8 EC2 visibility failure and R9 fixture failure remain failed historical runs.

**Full cleanup passed within the original bounds:** all three instances, provider keys and root volumes, the AMI and backing snapshot, six local SSH/control namespaces, and the temporary security group were removed. All command owners joined; **325 recorded process identities** were absent; no unknown provider outcomes or outstanding resources remained. The unchanged bounds were 30 minutes main, 10 minutes cleanup, 41 minutes outer; three leases, two forks, one capture, at most two live machines.

Redacted proof index (resource identifiers, account details, network addresses, endpoints, and credentials omitted):

```json
{
  "controlCommit": "14dad483f3e13d4f087ac4f9d7ae014893294c15",
  "staleStop": {"exitCode": 2, "claimUnchanged": true, "postRejectionInstanceRunning": true, "postRejectionKeyPresent": true, "postRejectionRootVolumeAttached": true},
  "negativeOriginalPacket": "failed/expired; retained",
  "negativeRecoveryCleanupSha256": "5aa1598051d5350920aaa60228253f2e8ac987da944416c745a11a39d37ff554",
  "realProjectRun": "passed",
  "realProjectOuterReceiptSha256": "d81e77f744f86dc12df8ece9920164cd18c5819d6e5d7eac6e7cb5604e7c350d",
  "realProjectRootCleanupSha256": "e7c438171b411190e19d0a9146541c1fbe25036573aa3a613dc46bda5b0d73ae",
  "buildCount": 1,
  "replacementRefill": "passed",
  "outstandingResources": []
}
```

Local RED/GREEN tests cover IP/SSH interruption, replay identity drift, typed versus text errors, cancellation and in-flight deadlines, prepared cleanup custody, terminal identity, and acquired/ordinary recovery. AWS/shared and sibling provider tests pass. Worker bootstrap/provisioning tests and static checks pass. Managed Codex and independent reviews through P2 are clear. [Current-head CI passed all 11 jobs](https://github.com/openclaw/crabbox/actions/runs/33889506955); all six automatic workflows passed.

The earlier native Node coordinator stock-image proof remains scoped to its earlier Worker subtree: it provisioned through Node server → FleetCoordinator → AWSProvider → EC2SpotClient, verified signed builder packages and archive policy, and cleaned every resource. It is not presented as final-head Worker equivalence; the final-head direct AWS integration above supplies the current stock-image proof.

Production delta: **+119/-50, net +69**; tests: **+685/-151, net +534**; docs: **net +27**. Added runtime logic preserves allocation ownership through propagation and carries the observed terminal identity into the existing cleanup finalizer; no parallel lifecycle is added.

## Known Limitation

If termination is accepted, key deletion fails, and a prepared instance later becomes permanently invisible, the existing claim has no durable intermediate termination witness. This change retains the claim/key and reports the operator-recovery obligation. An exact observed terminal instance still permits recovery. A separate persistence design would require acceptance before implementation; this PR does not add one.

The OpenClaw schema-16 PR remains separately held and is not merged or deployed by this change.
