### PR TITLE
fix: unify Cloudflare run and claim finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Cloudflare: retain recovery claims when teardown fails, preserve command/cancellation outcomes, and fence reuse and cleanup against replaced local claims.
+
 - Preserve existing Cloudflare container workspaces when sync upload or extraction fails, clean partial archives, and enforce full-checkout size limits before fresh allocation. [PR 1814](https://github.com/openclaw/crabbox/pull/1814). Thanks @steipete.
 - Protect Nomad runs from overwriting replacement claims or recreating retired leases, and expose standard run-session handles with cleanup-aware final outcomes that preserve the original command exit. [PR 1810](https://github.com/openclaw/crabbox/pull/1810). Thanks @steipete.
 - Allow fresh brokered AWS Windows and WSL2 leases to bootstrap through advertised SSH port 22 while preserving an explicitly selected final workload port. [PR 1801](https://github.com/openclaw/crabbox/pull/1801). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Preserve existing Cloudflare container workspaces when sync upload or extraction fails, clean partial archives, and enforce full-checkout size limits before fresh allocation. Thanks @steipete.
+- Preserve existing Cloudflare container workspaces when sync upload or extraction fails, clean partial archives, and enforce full-checkout size limits before fresh allocation. [PR 1814](https://github.com/openclaw/crabbox/pull/1814). Thanks @steipete.
 - Protect Nomad runs from overwriting replacement claims or recreating retired leases, and expose standard run-session handles with cleanup-aware final outcomes that preserve the original command exit. [PR 1810](https://github.com/openclaw/crabbox/pull/1810). Thanks @steipete.
 - Allow fresh brokered AWS Windows and WSL2 leases to bootstrap through advertised SSH port 22 while preserving an explicitly selected final workload port. [PR 1801](https://github.com/openclaw/crabbox/pull/1801). Thanks @steipete.
 - Reuse one Azure or GCP token refresh across concurrent requests, reducing duplicate authentication traffic while preserving credential isolation, refresh margins, and retry behavior. [PR 1802](https://github.com/openclaw/crabbox/pull/1802). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Cloudflare: retain recovery claims when teardown fails, preserve command/cancellation outcomes, and fence reuse and cleanup against replaced local claims.
+- Cloudflare: retain recovery claims when teardown fails, preserve command/cancellation outcomes, and fence reuse and cleanup against replaced local claims. [PR 1817](https://github.com/openclaw/crabbox/pull/1817). Thanks @steipete.
 - Preserve existing Cloudflare container workspaces when sync upload or extraction fails, clean partial archives, and enforce full-checkout size limits before fresh allocation. [PR 1814](https://github.com/openclaw/crabbox/pull/1814). Thanks @steipete.
 - Protect Nomad runs from overwriting replacement claims or recreating retired leases, and expose standard run-session handles with cleanup-aware final outcomes that preserve the original command exit. [PR 1810](https://github.com/openclaw/crabbox/pull/1810). Thanks @steipete.
 - Preserve individual AWS, Azure, and GCP candidate failures in successful leases' provisioning history across market and regional fallback, including previously omitted GCP on-demand failures. [PR 1811](https://github.com/openclaw/crabbox/pull/1811). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve existing Cloudflare container workspaces when sync upload or extraction fails, clean partial archives, and enforce full-checkout size limits before fresh allocation. Thanks @steipete.
 - Protect Nomad runs from overwriting replacement claims or recreating retired leases, and expose standard run-session handles with cleanup-aware final outcomes that preserve the original command exit. [PR 1810](https://github.com/openclaw/crabbox/pull/1810). Thanks @steipete.
 - Allow fresh brokered AWS Windows and WSL2 leases to bootstrap through advertised SSH port 22 while preserving an explicitly selected final workload port. [PR 1801](https://github.com/openclaw/crabbox/pull/1801). Thanks @steipete.
 - Reuse one Azure or GCP token refresh across concurrent requests, reducing duplicate authentication traffic while preserving credential isolation, refresh margins, and retry behavior. [PR 1802](https://github.com/openclaw/crabbox/pull/1802). Thanks @steipete.

--- a/docs/providers/cloudflare.md
+++ b/docs/providers/cloudflare.md
@@ -222,12 +222,17 @@ crabbox run \
 
 ## Behavior
 
-- `run` creates or reuses a container Durable Object, prepares `workdir`,
-  uploads a gzipped archive of the local checkout (unless `--no-sync`), extracts
-  it, then relays stdout, stderr, and exit status.
+- `run` creates or reuses a container Durable Object, uploads a gzipped archive
+  of the local checkout (unless `--no-sync`), extracts it, then relays stdout,
+  stderr, and exit status. Fresh runs prepare and size-check the full archive
+  before creating a container; a small dirty delta does not bypass full-archive limits.
+- With `sync.delete: true`, extraction uses a sibling staging directory and
+  replaces `workdir` only after extraction succeeds. Failed admission, upload,
+  or extraction preserves the old checkout, and exact temporary paths receive
+  best-effort cleanup. With deletion disabled, extraction merges into `workdir`.
 - Before upload, the provider checks remote disk headroom for both the archive
   and the extracted checkout, and fails early with a sizing hint if the selected
-  type is too small.
+  type is too small. This check does not remove the old checkout to free space.
 - `warmup` starts a container and leaves it alive until `crabbox stop` or the
   configured TTL/idle deadline expires.
 - Reuse, `status`, and `stop` resolve local Crabbox claims before calling the

--- a/docs/providers/cloudflare.md
+++ b/docs/providers/cloudflare.md
@@ -21,7 +21,7 @@ ports; they run module source through the Cloudflare Workers runtime.
 
 - **Targets:** Linux only.
 - **Supported commands:** `run`, `warmup`, `status`, `stop`, `list`, `doctor`,
-  and local-claim `cleanup`.
+  and claim-scoped `cleanup`.
 - **Run sessions:** `run --keep --lease-output <path>` writes a reusable lease
   handle with an exact cleanup command.
 - **Sync:** archive upload/extract (gzipped tar), not rsync.
@@ -237,6 +237,14 @@ crabbox run \
   configured TTL/idle deadline expires.
 - Reuse, `status`, and `stop` resolve local Crabbox claims before calling the
   runner and reject raw sandbox IDs without a matching claim.
+- Reuse and cleanup keep the captured local claim revision: another caller
+  replacing or removing that claim prevents stale admission or teardown. This
+  fences local claim writers, not remote operators recreating the same Durable
+  Object identity; the runner has no conditional generation-delete API.
+- Automatic cleanup finishes before the final result and timing record. A
+  cleanup failure fails an otherwise successful run and retains its recovery
+  claim; an existing command failure or cancellation stays the primary outcome.
+  `--keep-on-failure` also retains fresh sessions after preparation or sync fails.
 - `list` reports local Cloudflare claims. Add `--refresh` to check runner state
   for those claims. The runner intentionally does not expose a global container
   enumeration API.
@@ -250,8 +258,13 @@ crabbox run \
 - The runner stores lease metadata in Durable Object storage and schedules
   cleanup at the earlier of `--ttl` or `--idle-timeout`. Uploads and command
   execution extend the idle deadline.
-- `crabbox cleanup --provider cloudflare` only checks local claims. It removes
-  claims whose runner state is expired, stopped, or missing.
+- `status` reports expired or stopped metadata without retiring the local claim:
+  the runner may have stored that state before native destruction failed.
+  `crabbox cleanup --provider cloudflare` checks local claims and confirms or
+  retries native deletion for terminal containers before removing their claims.
+  An HTTP 404 can retire the exact unchanged claim; other errors preserve it.
+  `--dry-run` sends no DELETE requests and does not remove local claims; the
+  runner's expiry policy still applies during status reads.
 
 Cloudflare Containers can also reach Worker bindings through outbound handlers.
 Crabbox does not wire those by default, but custom runner images can add them:
@@ -260,7 +273,7 @@ Crabbox does not wire those by default, but custom runner images can add them:
 ## Limitations
 
 - Only Linux delegated `run`, `warmup`, `status`, `stop`, `list`, `doctor`, and
-  local-claim cleanup are supported.
+  claim-scoped cleanup are supported.
 - SSH, VNC, browser desktop, code-server, Actions hydration, `--download`, and
   `--fresh-pr` are not supported.
 - `--checksum` is not supported, because sync uses archive upload/extract rather

--- a/internal/providers/cloudflare/backend.go
+++ b/internal/providers/cloudflare/backend.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func NewCloudflareBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
@@ -98,6 +100,14 @@ func (b *cloudflareBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 	}
 	leaseID, sandboxID, slug := "", "", ""
 	acquired := false
+	var prepared *core.PreparedArchive
+	if req.ID == "" && !req.NoSync {
+		prepared, err = b.prepareArchive(ctx, req)
+		if err != nil {
+			return RunResult{}, err
+		}
+		defer prepared.Close()
+	}
 	if req.ID == "" {
 		var sandbox cloudflareContainer
 		leaseID, sandbox, slug, err = b.createSandbox(ctx, client, req.Repo, req.Reclaim, req.RequestedSlug)
@@ -142,12 +152,12 @@ func (b *cloudflareBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 	syncDuration := time.Duration(0)
 	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
 	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, sandboxID, req, workdir)
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, sandboxID, req, workdir, prepared)
 		if err != nil {
 			return RunResult{Total: b.now().Sub(started), SyncDelegated: true, Session: session}, err
 		}
 		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
-	} else if err := b.prepareWorkspace(ctx, client, sandboxID, workdir, false); err != nil {
+	} else if err := b.prepareWorkspace(ctx, client, sandboxID, workdir); err != nil {
 		return RunResult{Session: session}, err
 	}
 	if req.SyncOnly {

--- a/internal/providers/cloudflare/backend.go
+++ b/internal/providers/cloudflare/backend.go
@@ -2,16 +2,15 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
+	"net/http"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func NewCloudflareBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
@@ -63,11 +62,11 @@ func (b *cloudflareBackend) Warmup(ctx context.Context, req WarmupRequest) error
 	if err != nil {
 		return err
 	}
-	leaseID, sandbox, slug, err := b.createSandbox(ctx, client, req.Repo, req.Reclaim, req.RequestedSlug)
+	claim, sandbox, err := b.createSandbox(ctx, client, req.Repo, req.RequestedSlug)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, sandbox.ID)
+	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s sandbox=%s\n", claim.LeaseID, claim.Slug, providerName, sandbox.ID)
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: %s warmup keeps the container until explicit stop\n", providerName)
 	}
@@ -76,8 +75,8 @@ func (b *cloudflareBackend) Warmup(ctx context.Context, req WarmupRequest) error
 	if req.TimingJSON {
 		return writeTimingJSON(b.rt.Stderr, timingReport{
 			Provider: providerName,
-			LeaseID:  leaseID,
-			Slug:     slug,
+			LeaseID:  claim.LeaseID,
+			Slug:     claim.Slug,
 			TotalMs:  total.Milliseconds(),
 			ExitCode: 0,
 		})
@@ -86,161 +85,67 @@ func (b *cloudflareBackend) Warmup(ctx context.Context, req WarmupRequest) error
 }
 
 func (b *cloudflareBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
-	if err := rejectCloudflareSyncOptions(req); err != nil {
-		return RunResult{}, err
-	}
 	workdir, err := cloudflareWorkdir(b.cfg)
 	if err != nil {
 		return RunResult{}, err
 	}
-	started := b.now()
-	client, err := newCloudflareClient(b.cfg, b.rt)
-	if err != nil {
-		return RunResult{}, err
+	var client *cloudflareClient
+	var claim LeaseClaim
+	var command string
+	bound := func() shared.DelegatedSandbox {
+		return shared.DelegatedSandbox{LeaseID: claim.LeaseID, Slug: blank(claim.Slug, newLeaseSlug(claim.LeaseID)), CleanupCommand: cloudflareCleanupCommand(claim.LeaseID)}
 	}
-	leaseID, sandboxID, slug := "", "", ""
-	acquired := false
-	var prepared *core.PreparedArchive
-	if req.ID == "" && !req.NoSync {
-		prepared, err = b.prepareArchive(ctx, req)
-		if err != nil {
-			return RunResult{}, err
-		}
-		defer prepared.Close()
-	}
-	if req.ID == "" {
-		var sandbox cloudflareContainer
-		leaseID, sandbox, slug, err = b.createSandbox(ctx, client, req.Repo, req.Reclaim, req.RequestedSlug)
-		if err != nil {
-			return RunResult{}, err
-		}
-		sandboxID = sandbox.ID
-		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, sandboxID)
-		acquired = true
-	} else {
-		var instanceType string
-		leaseID, sandboxID, slug, instanceType, err = b.resolveSandboxID(req.ID, req.Repo.Root, req.Reclaim)
-		if err != nil {
-			return RunResult{}, err
-		}
-		client.useInstanceType(instanceType)
-	}
-	shouldStop := acquired && !req.Keep
-	if shouldStop {
-		defer func() {
-			if !shouldStop {
-				return
+	return shared.RunDelegatedSandbox(ctx, req, shared.DelegatedSandboxLifecycle{
+		Provider: providerName, Runtime: b.rt, Workdir: workdir,
+		IdleTimeout: b.cfg.IdleTimeout, TTL: b.cfg.TTL, CleanupTimeout: cloudflareCleanupTimeout,
+		Preflight: func(context.Context) error {
+			if err := rejectCloudflareSyncOptions(req); err != nil {
+				return err
 			}
-			cleanupCtx, cancel := cloudflareCleanupContext()
-			defer cancel()
-			if err := client.destroySandbox(cleanupCtx, sandboxID); err != nil {
-				fmt.Fprintf(b.rt.Stderr, "warning: %s destroy failed for %s: %v\n", providerName, sandboxID, err)
-				return
+			if !req.SyncOnly {
+				command, err = buildCloudflareCommand(req.Command, req.ShellMode)
+				if err != nil {
+					return err
+				}
 			}
-			removeLeaseClaim(leaseID)
-		}()
-	}
-	session := &RunSessionHandle{
-		Provider:       providerName,
-		LeaseID:        leaseID,
-		Slug:           slug,
-		Reused:         !acquired,
-		Kept:           !shouldStop,
-		CleanupCommand: cloudflareCleanupCommand(leaseID),
-	}
-
-	syncDuration := time.Duration(0)
-	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
-	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, sandboxID, req, workdir, prepared)
-		if err != nil {
-			return RunResult{Total: b.now().Sub(started), SyncDelegated: true, Session: session}, err
-		}
-		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
-	} else if err := b.prepareWorkspace(ctx, client, sandboxID, workdir); err != nil {
-		return RunResult{Session: session}, err
-	}
-	if req.SyncOnly {
-		result := RunResult{Total: b.now().Sub(started), SyncDelegated: true, Session: session}
-		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
-		if req.TimingJSON {
-			err := writeTimingJSON(b.rt.Stderr, timingReport{
-				Provider:      providerName,
-				LeaseID:       leaseID,
-				Slug:          slug,
-				SyncDelegated: true,
-				SyncMs:        syncDuration.Milliseconds(),
-				SyncPhases:    syncPhases,
-				SyncSkipped:   req.NoSync,
-				TotalMs:       result.Total.Milliseconds(),
-				ExitCode:      0,
-				Label:         strings.TrimSpace(req.Label),
-			})
-			return result, err
-		}
-		return result, nil
-	}
-
-	command, err := buildCloudflareCommand(req.Command, req.ShellMode)
-	if err != nil {
-		return RunResult{Session: session}, err
-	}
-	if req.EnvSummary {
-		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
-	}
-	commandStarted := b.now()
-	exitCode, commandErr := client.execStream(ctx, sandboxID, execStreamRequest{
-		Command:   command,
-		Cwd:       workdir,
-		Env:       req.Env,
-		TimeoutMS: durationMillisecondsCeil(b.cfg.TTL),
-	}, b.rt.Stdout, b.rt.Stderr)
-	if commandErr != nil && exitCode == 0 {
-		exitCode = 1
-	}
-	commandDuration := b.now().Sub(commandStarted)
-	result := RunResult{
-		ExitCode:      exitCode,
-		Command:       commandDuration,
-		Total:         b.now().Sub(started),
-		SyncDelegated: true,
-		Session:       session,
-	}
-	result = finalizeRunResult(result, commandErr)
-	if req.NoSync {
-		fmt.Fprintf(b.rt.Stderr, "%s run summary sync_skipped=true command=%s total=%s exit=%d\n", providerName, result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
-	} else {
-		fmt.Fprintf(b.rt.Stderr, "%s run summary sync=%s command=%s total=%s exit=%d\n", providerName, syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
-	}
-	if req.TimingJSON {
-		report := timingReportWithRunResult(timingReport{
-			Provider:      providerName,
-			LeaseID:       leaseID,
-			Slug:          slug,
-			SyncDelegated: true,
-			SyncMs:        syncDuration.Milliseconds(),
-			SyncPhases:    syncPhases,
-			SyncSkipped:   req.NoSync,
-			CommandMs:     commandDuration.Milliseconds(),
-			TotalMs:       result.Total.Milliseconds(),
-			ExitCode:      result.ExitCode,
-			Label:         strings.TrimSpace(req.Label),
-		}, result, commandErr)
-		if err := writeTimingJSON(b.rt.Stderr, report); err != nil {
-			return result, err
-		}
-	}
-	if commandErr != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		session.Kept = !shouldStop
-		return result, ExitError{Code: 1, Message: fmt.Sprintf("%s run failed: %v", providerName, commandErr)}
-	}
-	if result.ExitCode != 0 {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		session.Kept = !shouldStop
-		return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s run exited %d", providerName, result.ExitCode)}
-	}
-	return result, nil
+			client, err = newCloudflareClient(b.cfg, b.rt)
+			return err
+		},
+		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) { return b.prepareArchive(ctx, req) },
+		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
+			claim, _, err = b.createSandbox(ctx, client, req.Repo, req.RequestedSlug)
+			if err != nil {
+				return shared.DelegatedSandbox{}, err
+			}
+			fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s\n", claim.LeaseID, claim.Slug, providerName, claim.LeaseID)
+			return bound(), nil
+		},
+		Resolve: func(ctx context.Context) (shared.DelegatedSandbox, error) {
+			claim, err = resolveCloudflareClaim(req.ID)
+			if err != nil {
+				return shared.DelegatedSandbox{}, err
+			}
+			claim, err = admitRunClaim(ctx, claim, req.Repo.Root, req.Reclaim)
+			if err != nil {
+				return shared.DelegatedSandbox{}, err
+			}
+			client.useInstanceType(cloudflareClaimInstanceType(claim))
+			return bound(), nil
+		},
+		Sync: func(ctx context.Context, prepared *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
+			return b.syncWorkspace(ctx, client, claim.LeaseID, req, workdir, prepared)
+		},
+		NoSync: func(ctx context.Context) error { return b.prepareWorkspace(ctx, client, claim.LeaseID, workdir) },
+		Command: func(context.Context) (shared.DelegatedSandboxCommand, error) {
+			if req.EnvSummary {
+				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+			}
+			return shared.DelegatedSandboxCommand{Text: command, Run: func(ctx context.Context) (int, error) {
+				return client.execStream(ctx, claim.LeaseID, execStreamRequest{Command: command, Cwd: workdir, Env: req.Env, TimeoutMS: durationMillisecondsCeil(b.cfg.TTL)}, b.rt.Stdout, b.rt.Stderr)
+			}}, nil
+		},
+		Cleanup: func(ctx context.Context) error { _, err := destroyClaimedSandbox(ctx, client, claim); return err },
+	})
 }
 
 func (b *cloudflareBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
@@ -261,7 +166,7 @@ func (b *cloudflareBackend) List(ctx context.Context, req ListRequest) ([]LeaseV
 	return servers, nil
 }
 
-func (b *cloudflareBackend) listRefreshed(ctx context.Context, claims []localClaim) ([]LeaseView, error) {
+func (b *cloudflareBackend) listRefreshed(ctx context.Context, claims []LeaseClaim) ([]LeaseView, error) {
 	client, err := newCloudflareClient(b.cfg, b.rt)
 	if err != nil {
 		return nil, err
@@ -270,10 +175,10 @@ func (b *cloudflareBackend) listRefreshed(ctx context.Context, claims []localCla
 	defaultInstanceType := client.instanceType
 	for _, claim := range claims {
 		client.instanceType = defaultInstanceType
-		client.useInstanceType(claim.instanceType())
+		client.useInstanceType(cloudflareClaimInstanceType(claim))
 		sandbox, err := client.getSandbox(ctx, claim.LeaseID)
 		if err != nil {
-			if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
+			if cloudflareNotFoundError(err) {
 				servers = append(servers, claimToServer(claim, "missing"))
 				continue
 			}
@@ -291,30 +196,29 @@ func (b *cloudflareBackend) Status(ctx context.Context, req StatusRequest) (Stat
 	if err != nil {
 		return StatusView{}, err
 	}
-	leaseID, sandboxID, slug, instanceType, err := b.resolveSandboxID(req.ID, "", false)
+	claim, err := resolveCloudflareClaim(req.ID)
 	if err != nil {
 		return StatusView{}, err
 	}
-	client.useInstanceType(instanceType)
+	client.useInstanceType(cloudflareClaimInstanceType(claim))
 	deadline := b.now().Add(req.WaitTimeout)
 	if req.WaitTimeout <= 0 {
 		deadline = b.now().Add(5 * time.Minute)
 	}
 	for {
-		sandbox, err := client.getSandbox(ctx, sandboxID)
+		sandbox, err := client.getSandbox(ctx, claim.LeaseID)
 		if err != nil {
 			return StatusView{}, err
 		}
-		view := sandboxStatusView(leaseID, slug, sandbox)
+		view := sandboxStatusView(claim.LeaseID, claim.Slug, sandbox)
 		if cloudflareTerminalState(view.State) {
-			removeLeaseClaim(leaseID)
 			return view, nil
 		}
 		if !req.Wait || view.Ready {
 			return view, nil
 		}
 		if b.now().After(deadline) {
-			return StatusView{}, exit(5, "timed out waiting for %s container %s to become ready", providerName, sandboxID)
+			return StatusView{}, exit(5, "timed out waiting for %s container %s to become ready", providerName, claim.LeaseID)
 		}
 		select {
 		case <-ctx.Done():
@@ -329,22 +233,36 @@ func (b *cloudflareBackend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
-	leaseID, sandboxID, _, instanceType, err := b.resolveSandboxID(req.ID, "", false)
+	claim, err := resolveCloudflareClaim(req.ID)
 	if err != nil {
 		return err
 	}
-	client.useInstanceType(instanceType)
-	if err := client.destroySandbox(ctx, sandboxID); err != nil {
+	missing, err := destroyClaimedSandbox(ctx, client, claim)
+	if err != nil {
+		return err
+	}
+	if missing {
+		fmt.Fprintf(b.rt.Stdout, "removed stale %s claim %s reason=not-found\n", providerName, claim.LeaseID)
+	} else {
+		fmt.Fprintf(b.rt.Stdout, "stopped %s provider=%s sandbox=%s\n", claim.LeaseID, providerName, claim.LeaseID)
+	}
+	return nil
+}
+
+// Keep the captured local authority fenced through the native effect. The
+// runner's instance type is a routing preference, not a remote generation CAS.
+func destroyClaimedSandbox(ctx context.Context, client *cloudflareClient, claim LeaseClaim) (bool, error) {
+	client.useInstanceType(cloudflareClaimInstanceType(claim))
+	missing := false
+	err := core.CleanupLeaseClaimIfUnchangedAfterContext(ctx, claim.LeaseID, claim, true, func() error {
+		err := client.destroySandbox(ctx, claim.LeaseID)
 		if cloudflareNotFoundError(err) {
-			removeLeaseClaim(leaseID)
-			fmt.Fprintf(b.rt.Stdout, "removed stale %s claim %s reason=not-found\n", providerName, leaseID)
+			missing = true
 			return nil
 		}
 		return err
-	}
-	removeLeaseClaim(leaseID)
-	fmt.Fprintf(b.rt.Stdout, "stopped %s provider=%s sandbox=%s\n", leaseID, providerName, sandboxID)
-	return nil
+	})
+	return missing, err
 }
 
 func (b *cloudflareBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
@@ -360,7 +278,7 @@ func (b *cloudflareBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 	defaultInstanceType := client.instanceType
 	for _, claim := range claims {
 		client.instanceType = defaultInstanceType
-		client.useInstanceType(claim.instanceType())
+		client.useInstanceType(cloudflareClaimInstanceType(claim))
 		sandbox, err := client.getSandbox(ctx, claim.LeaseID)
 		if err != nil {
 			if cloudflareNotFoundError(err) {
@@ -368,7 +286,9 @@ func (b *cloudflareBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 					fmt.Fprintf(b.rt.Stdout, "would remove stale %s claim %s slug=%s reason=not-found\n", providerName, claim.LeaseID, blank(claim.Slug, "-"))
 					continue
 				}
-				removeLeaseClaim(claim.LeaseID)
+				if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+					return err
+				}
 				removed++
 				fmt.Fprintf(b.rt.Stdout, "removed stale %s claim %s slug=%s reason=not-found\n", providerName, claim.LeaseID, blank(claim.Slug, "-"))
 				continue
@@ -380,10 +300,12 @@ func (b *cloudflareBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 			continue
 		}
 		if req.DryRun {
-			fmt.Fprintf(b.rt.Stdout, "would remove stale %s claim %s slug=%s state=%s\n", providerName, claim.LeaseID, blank(claim.Slug, "-"), sandbox.State)
+			fmt.Fprintf(b.rt.Stdout, "would confirm cleanup of %s claim %s slug=%s state=%s\n", providerName, claim.LeaseID, blank(claim.Slug, "-"), sandbox.State)
 			continue
 		}
-		removeLeaseClaim(claim.LeaseID)
+		if _, err := destroyClaimedSandbox(ctx, client, claim); err != nil {
+			return err
+		}
 		removed++
 		fmt.Fprintf(b.rt.Stdout, "removed stale %s claim %s slug=%s state=%s\n", providerName, claim.LeaseID, blank(claim.Slug, "-"), sandbox.State)
 	}
@@ -394,79 +316,76 @@ func (b *cloudflareBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 }
 
 func cloudflareNotFoundError(err error) bool {
-	if err == nil {
-		return false
-	}
-	text := strings.ToLower(err.Error())
-	return strings.Contains(text, "404") || strings.Contains(text, "not found")
+	var responseErr *cloudflareResponseError
+	return errors.As(err, &responseErr) && responseErr.statusCode == http.StatusNotFound
 }
 
 func cloudflareCleanupCommand(leaseID string) string {
 	return fmt.Sprintf("crabbox stop --provider %s --id %s", providerName, shellQuote(leaseID))
 }
 
-func (b *cloudflareBackend) createSandbox(ctx context.Context, client *cloudflareClient, repo Repo, reclaim bool, requestedSlug string) (string, cloudflareContainer, string, error) {
+func (b *cloudflareBackend) createSandbox(ctx context.Context, client *cloudflareClient, repo Repo, requestedSlug string) (LeaseClaim, cloudflareContainer, error) {
+	if strings.TrimSpace(repo.Root) == "" {
+		return LeaseClaim{}, cloudflareContainer{}, exit(2, "cloudflare creation requires a repository root for the recovery claim")
+	}
 	leaseID := newLeaseID()
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
-		return "", cloudflareContainer{}, "", err
+		return LeaseClaim{}, cloudflareContainer{}, err
 	}
 	workdir, err := cloudflareWorkdir(b.cfg)
 	if err != nil {
-		return "", cloudflareContainer{}, "", err
+		return LeaseClaim{}, cloudflareContainer{}, err
 	}
-	labels := map[string]string{
-		"crabbox":       "true",
-		"provider":      providerName,
-		"lease":         leaseID,
-		"slug":          slug,
-		"repo":          repo.Name,
-		"instance_type": client.instanceType,
-	}
+	labels := map[string]string{"crabbox": "true", "provider": providerName, "lease": leaseID, "slug": slug, "repo": repo.Name, "instance_type": client.instanceType}
 	sandbox, err := client.createSandbox(ctx, createSandboxRequest{
-		ID:                 leaseID,
-		LeaseID:            leaseID,
-		Slug:               slug,
-		Repo:               repo.Name,
-		Workdir:            workdir,
-		InstanceType:       client.instanceType,
-		TTLSeconds:         durationSecondsCeil(b.cfg.TTL),
-		IdleTimeoutSeconds: durationSecondsCeil(b.cfg.IdleTimeout),
-		Labels:             labels,
+		ID: leaseID, LeaseID: leaseID, Slug: slug, Repo: repo.Name, Workdir: workdir,
+		InstanceType: client.instanceType, TTLSeconds: durationSecondsCeil(b.cfg.TTL), IdleTimeoutSeconds: durationSecondsCeil(b.cfg.IdleTimeout), Labels: labels,
 	})
 	if err != nil {
-		return "", cloudflareContainer{}, "", err
+		return LeaseClaim{}, cloudflareContainer{}, err
 	}
-	if err := claimLeaseForRepoProviderPondLabels(leaseID, slug, providerName, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim, labels); err != nil {
+	if sandbox.ID != leaseID {
+		return LeaseClaim{}, cloudflareContainer{}, fmt.Errorf("cloudflare creation returned unexpected sandbox %q for requested %q; inspect the runner before recovery", sandbox.ID, leaseID)
+	}
+	claim, err := core.ClaimLeaseForRepoProviderScopePondWithLabels(leaseID, slug, providerName, "", b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, labels)
+	if err != nil {
 		cleanupCtx, cancel := cloudflareCleanupContext()
-		cleanupErr := client.destroySandbox(cleanupCtx, sandbox.ID)
-		cancel()
+		defer cancel()
+		cleanupErr := core.CleanupLeaseClaimIfUnchangedAfterContext(cleanupCtx, leaseID, LeaseClaim{}, false, func() error { return client.destroySandbox(cleanupCtx, leaseID) })
 		if cleanupErr != nil {
-			return "", cloudflareContainer{}, "", fmt.Errorf("%w; cleanup failed for %s sandbox %s: %v", err, providerName, sandbox.ID, cleanupErr)
+			err = errors.Join(err, fmt.Errorf("cleanup failed for cloudflare sandbox %s; inspect its claim and runner before recovery: %w", leaseID, cleanupErr))
 		}
-		return "", cloudflareContainer{}, "", err
+		return LeaseClaim{}, cloudflareContainer{}, err
 	}
-	return leaseID, sandbox, slug, nil
+	return claim, sandbox, nil
 }
 
-func (b *cloudflareBackend) resolveSandboxID(identifier, repoRoot string, reclaim bool) (string, string, string, string, error) {
+func resolveCloudflareClaim(identifier string) (LeaseClaim, error) {
 	claim, ok, err := resolveLeaseClaimForProvider(identifier, providerName)
 	if err != nil {
-		return "", "", "", "", err
+		return LeaseClaim{}, err
 	}
 	if ok {
-		if repoRoot != "" {
-			if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, providerName, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim); err != nil {
-				return "", "", "", "", err
-			}
-		}
-		return claim.LeaseID, claim.LeaseID, blank(claim.Slug, newLeaseSlug(claim.LeaseID)), cloudflareClaimInstanceType(claim), nil
+		return claim, nil
 	}
 	value := strings.TrimSpace(identifier)
 	if value == "" {
-		return "", "", "", "", exit(2, "%s id is required", providerName)
+		return LeaseClaim{}, exit(2, "%s id is required", providerName)
 	}
-	return "", "", "", "", exit(2, "refusing to use %s sandbox %q without a local Crabbox claim", providerName, value)
+	return LeaseClaim{}, exit(2, "refusing to use %s sandbox %q without a local Crabbox claim", providerName, value)
+}
+
+func admitRunClaim(ctx context.Context, captured LeaseClaim, repoRoot string, reclaim bool) (LeaseClaim, error) {
+	if err := ctx.Err(); err != nil {
+		return LeaseClaim{}, err
+	}
+	if repoRoot == "" {
+		err := core.WithLeaseClaimUnchangedShared(ctx, captured.LeaseID, captured, func() error { return nil })
+		return captured, err
+	}
+	// Repository admission retains the existing non-cancelable local lock wait.
+	return core.ClaimLeaseForRepoProviderScopePondIfUnchanged(captured.LeaseID, captured.Slug, providerName, captured.ProviderScope, captured.Pond, repoRoot, time.Duration(captured.IdleTimeoutSeconds)*time.Second, reclaim, captured, true)
 }
 
 func buildCloudflareCommand(command []string, shellMode bool) (string, error) {
@@ -542,7 +461,7 @@ func sandboxToServer(leaseID, slug string, sandbox cloudflareContainer) Server {
 	return server
 }
 
-func claimToServer(claim localClaim, state string) Server {
+func claimToServer(claim LeaseClaim, state string) Server {
 	labels := map[string]string{
 		"provider": providerName,
 		"lease":    claim.LeaseID,
@@ -596,64 +515,20 @@ func (b *cloudflareBackend) now() time.Time {
 	return time.Now()
 }
 
-type localClaim struct {
-	LeaseID      string            `json:"leaseID"`
-	Slug         string            `json:"slug,omitempty"`
-	Provider     string            `json:"provider,omitempty"`
-	InstanceType string            `json:"instanceType,omitempty"`
-	Labels       map[string]string `json:"labels,omitempty"`
-}
-
-func (c localClaim) instanceType() string {
-	if c.InstanceType != "" {
-		return c.InstanceType
-	}
-	return c.Labels["instance_type"]
-}
-
 func cloudflareClaimInstanceType(claim LeaseClaim) string {
 	return claim.Labels["instance_type"]
 }
 
-func localCloudflareClaims() ([]localClaim, error) {
-	dir, err := localClaimsDir()
+func localCloudflareClaims() ([]LeaseClaim, error) {
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return nil, err
 	}
-	entries, err := os.ReadDir(dir)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, exit(2, "read claims directory: %v", err)
-	}
-	var claims []localClaim
-	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
-		if err != nil {
-			return nil, exit(2, "read claim %s: %v", entry.Name(), err)
-		}
-		var claim localClaim
-		if err := json.Unmarshal(data, &claim); err != nil {
-			return nil, exit(2, "parse claim %s: %v", entry.Name(), err)
-		}
+	var filtered []LeaseClaim
+	for _, claim := range claims {
 		if claim.Provider == providerName {
-			claims = append(claims, claim)
+			filtered = append(filtered, claim)
 		}
 	}
-	return claims, nil
-}
-
-func localClaimsDir() (string, error) {
-	if dir := os.Getenv("XDG_STATE_HOME"); dir != "" {
-		return filepath.Join(dir, "crabbox", "claims"), nil
-	}
-	dir, err := os.UserConfigDir()
-	if err != nil {
-		return "", exit(2, "user state directory is unavailable")
-	}
-	return filepath.Join(dir, "crabbox", "state", "claims"), nil
+	return filtered, nil
 }

--- a/internal/providers/cloudflare/backend_test.go
+++ b/internal/providers/cloudflare/backend_test.go
@@ -11,6 +11,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -658,44 +660,192 @@ func TestCloudflareStatusUsesClaimedInstanceType(t *testing.T) {
 	}
 }
 
-func TestCloudflarePrepareWorkspacePreservesWhenRequested(t *testing.T) {
-	for _, tc := range []struct {
-		name           string
-		deleteContents bool
-		wantDelete     bool
-	}{
-		{name: "preserve", deleteContents: false, wantDelete: false},
-		{name: "delete", deleteContents: true, wantDelete: true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			var got execStreamRequest
+func TestCloudflareArchiveGuardrailUsesFullSnapshotBeforeRemoteWork(t *testing.T) {
+	for _, reuse := range []bool{false, true} {
+		t.Run(fmt.Sprintf("reuse=%t", reuse), func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			root := t.TempDir()
+			git := func(args ...string) {
+				t.Helper()
+				cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+				if output, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("fixture git: %v: %s", err, output)
+				}
+			}
+			git("init", "--quiet")
+			if err := os.WriteFile(filepath.Join(root, "large.txt"), bytes.Repeat([]byte("x"), 2048), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(root, "small.txt"), []byte("before"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			git("add", ".")
+			git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.com", "-c", "commit.gpgsign=false", "commit", "--quiet", "-m", "fixture")
+			if err := os.WriteFile(filepath.Join(root, "small.txt"), []byte("after"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			calls := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { calls++; http.Error(w, "unexpected remote work", 503) }))
+			defer server.Close()
+			cfg := Config{Provider: providerName, TTL: time.Hour}
+			cfg.Cloudflare.APIURL = server.URL
+			cfg.Cloudflare.Token = "synthetic-token"
+			cfg.Sync.FailBytes = 256
+			req := RunRequest{Repo: Repo{Root: root, Name: "fixture"}, SyncOnly: true}
+			if reuse {
+				req.ID = "cbx_sync"
+				if err := claimLeaseForRepoProvider(req.ID, "sync", providerName, root, time.Hour, false); err != nil {
+					t.Fatal(err)
+				}
+			}
+			backend := cloudflareBackend{cfg: cfg, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+			_, err := backend.Run(context.Background(), req)
+			if err == nil || !strings.Contains(err.Error(), "sync candidate too large") || calls != 0 {
+				t.Fatalf("error=%v remote calls=%d", err, calls)
+			}
+		})
+	}
+}
+
+func TestCloudflareSyncPreservesWorkspaceUntilReplacement(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture executes POSIX workspace commands on the host")
+	}
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash is required for the workspace replacement fixture")
+	}
+	for _, mode := range []string{"upload rejected", "corrupt archive", "replace", "merge"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			repoRoot := t.TempDir()
+			if output, err := exec.Command("git", "init", "--quiet", repoRoot).CombinedOutput(); err != nil {
+				t.Fatalf("init fixture repo: %v: %s", err, output)
+			}
+			if err := os.WriteFile(filepath.Join(repoRoot, "new.txt"), []byte("replacement"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			workdir := filepath.Join(t.TempDir(), "workspace")
+			if err := os.MkdirAll(workdir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			old := filepath.Join(workdir, "old.txt")
+			if err := os.WriteFile(old, []byte("original"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := claimLeaseForRepoProvider("cbx_sync", "sync", providerName, repoRoot, time.Hour, false); err != nil {
+				t.Fatal(err)
+			}
+			var remoteArchive string
+			uploads, deletes := 0, 0
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/v1/sandboxes/cbx_test/exec-stream" {
+				switch {
+				case strings.HasSuffix(r.URL.Path, "/files"):
+					uploads++
+					remoteArchive = r.URL.Query().Get("path")
+					if !strings.HasPrefix(remoteArchive, "/tmp/crabbox-cloudflare-sync-") {
+						t.Errorf("unexpected archive %q", remoteArchive)
+						http.Error(w, "bad path", 500)
+						return
+					}
+					data, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Error(err)
+						http.Error(w, "read", 500)
+						return
+					}
+					if r.ContentLength != int64(len(data)) {
+						t.Errorf("Content-Length=%d, bytes=%d", r.ContentLength, len(data))
+					}
+					if mode == "upload rejected" || mode == "corrupt archive" {
+						data = []byte("partial invalid archive")
+					}
+					if err := os.WriteFile(remoteArchive, data, 0o600); err != nil {
+						t.Error(err)
+						http.Error(w, "write", 500)
+						return
+					}
+					if mode == "upload rejected" {
+						http.Error(w, "synthetic upload rejection", 500)
+						return
+					}
+					w.WriteHeader(http.StatusOK)
+				case strings.HasSuffix(r.URL.Path, "/exec-stream"):
+					var command execStreamRequest
+					if err := json.NewDecoder(r.Body).Decode(&command); err != nil {
+						t.Error(err)
+						http.Error(w, "decode", 500)
+						return
+					}
+					var output []byte
+					code := 0
+					if strings.Contains(command.Command, "df -B1") {
+						output = []byte("8589934592 /tmp\n8589934592 workspace\n")
+					} else {
+						if !strings.Contains(command.Command, filepath.Dir(workdir)) && (remoteArchive == "" || !strings.Contains(command.Command, remoteArchive)) {
+							t.Errorf("unexpected command %q", command.Command)
+							http.Error(w, "unexpected", 500)
+							return
+						}
+						var err error
+						output, err = exec.Command(bash, "-c", command.Command).CombinedOutput()
+						if err != nil {
+							code = 1
+						}
+					}
+					w.Header().Set("Content-Type", "application/x-ndjson")
+					_ = json.NewEncoder(w).Encode(map[string]any{"type": "stdout", "data": string(output)})
+					_ = json.NewEncoder(w).Encode(map[string]any{"type": "complete", "exitCode": code})
+				case r.Method == http.MethodDelete:
+					deletes++
+					w.WriteHeader(http.StatusOK)
+				default:
 					http.NotFound(w, r)
-					return
 				}
-				if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
-					t.Fatalf("decode exec request: %v", err)
-				}
-				w.Header().Set("Content-Type", "application/x-ndjson")
-				_, _ = io.WriteString(w, `{"type":"complete","exitCode":0}`+"\n")
 			}))
 			defer server.Close()
-
-			cfg := Config{}
+			defer func() {
+				if remoteArchive != "" {
+					_ = os.Remove(remoteArchive)
+				}
+			}()
+			cfg := Config{Provider: providerName, TTL: time.Hour}
 			cfg.Cloudflare.APIURL = server.URL
-			cfg.Cloudflare.Token = "token"
-			backend := cloudflareBackend{cfg: cfg, rt: Runtime{HTTP: server.Client(), Stderr: io.Discard}}
-			client, err := newCloudflareClient(cfg, backend.rt)
-			if err != nil {
-				t.Fatal(err)
+			cfg.Cloudflare.Token = "synthetic-token"
+			cfg.Cloudflare.Workdir = workdir
+			cfg.Sync.Delete = mode != "merge"
+			backend := cloudflareBackend{cfg: cfg, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+			result, err := backend.Run(context.Background(), RunRequest{ID: "cbx_sync", Repo: Repo{Root: repoRoot, Name: "fixture"}, SyncOnly: true})
+			failed := mode == "upload rejected" || mode == "corrupt archive"
+			if (err != nil) != failed {
+				t.Fatalf("Run error=%v, failed=%t", err, failed)
 			}
-			if err := backend.prepareWorkspace(context.Background(), client, "cbx_test", "/workspace/repo", tc.deleteContents); err != nil {
-				t.Fatal(err)
+			if uploads != 1 || deletes != 0 {
+				t.Fatalf("uploads=%d deletes=%d", uploads, deletes)
 			}
-			hasDelete := strings.Contains(got.Command, "rm -rf")
-			if hasDelete != tc.wantDelete {
-				t.Fatalf("prepare command = %q, rm -rf presence = %t, want %t", got.Command, hasDelete, tc.wantDelete)
+			if result.Session == nil || !result.Session.Reused || !result.Session.Kept {
+				t.Fatalf("session=%+v", result.Session)
+			}
+			oldData, oldErr := os.ReadFile(old)
+			if failed || mode == "merge" {
+				if oldErr != nil || string(oldData) != "original" {
+					t.Fatalf("old workspace lost: data=%q error=%v", oldData, oldErr)
+				}
+			} else if !os.IsNotExist(oldErr) {
+				t.Fatalf("old file retained on replacement: %v", oldErr)
+			}
+			if !failed {
+				data, err := os.ReadFile(filepath.Join(workdir, "new.txt"))
+				if err != nil || string(data) != "replacement" {
+					t.Fatalf("new file=%q error=%v", data, err)
+				}
+			}
+			if _, err := os.Stat(remoteArchive); !os.IsNotExist(err) {
+				t.Fatalf("temporary archive remains: %v", err)
+			}
+			staging, err := filepath.Glob(filepath.Join(filepath.Dir(workdir), ".workspace.crabbox-sync-*"))
+			if err != nil || len(staging) != 0 {
+				t.Fatalf("staging remains=%v error=%v", staging, err)
 			}
 		})
 	}
@@ -1364,26 +1514,6 @@ func TestCloudflareRemoteDiskCheckRejectsZeroOrUnknownAvailable(t *testing.T) {
 				t.Fatalf("error = %v, want %q", err, tc.want)
 			}
 		})
-	}
-}
-
-func TestCloudflareExtractArchiveCommandRemovesArchiveAfterFailure(t *testing.T) {
-	bash, err := exec.LookPath("bash")
-	if err != nil {
-		t.Skip("bash is required for extract cleanup command test")
-	}
-	dir := t.TempDir()
-	archive := dir + "/bad archive.tgz"
-	if err := os.WriteFile(archive, []byte("not a tar archive"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	cmd := exec.Command(bash, "-lc", cloudflareExtractArchiveCommand(archive, dir))
-	err = cmd.Run()
-	if err == nil {
-		t.Fatal("expected invalid archive extraction to fail")
-	}
-	if _, statErr := os.Stat(archive); !os.IsNotExist(statErr) {
-		t.Fatalf("archive still exists after failed extract: %v", statErr)
 	}
 }
 

--- a/internal/providers/cloudflare/backend_test.go
+++ b/internal/providers/cloudflare/backend_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -16,6 +17,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestCloudflareProviderSpec(t *testing.T) {
@@ -577,7 +580,8 @@ func TestCloudflareCreateSandboxSendsInstanceType(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	leaseID, _, slug, err := backend.createSandbox(context.Background(), client, Repo{Name: "my-app", Root: t.TempDir()}, false, "")
+	created, _, err := backend.createSandbox(context.Background(), client, Repo{Name: "my-app", Root: t.TempDir()}, "")
+	leaseID, slug := created.LeaseID, created.Slug
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -633,7 +637,7 @@ func TestCloudflareListRefreshChecksClaimState(t *testing.T) {
 
 func TestCloudflareStatusUsesClaimedInstanceType(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	if err := claimLeaseForRepoProviderPondLabels("cbx_lite", "blue-lobster", providerName, "", t.TempDir(), time.Hour, false, map[string]string{"instance_type": "lite"}); err != nil {
+	if _, err := core.ClaimLeaseForRepoProviderScopePondWithLabels("cbx_lite", "blue-lobster", providerName, "", "", t.TempDir(), time.Hour, map[string]string{"instance_type": "lite"}); err != nil {
 		t.Fatal(err)
 	}
 	var gotInstanceType string
@@ -1048,8 +1052,8 @@ func TestCloudflareRunReportsCommandErrorAsFailure(t *testing.T) {
 	if !strings.Contains(stderr.String(), `"exitCode":1`) {
 		t.Fatalf("stderr = %q, want timing exitCode=1", stderr.String())
 	}
-	if !strings.Contains(stderr.String(), `"runStatus":"failed"`) || !strings.Contains(stderr.String(), `"errorKind":"command-exit"`) {
-		t.Fatalf("stderr = %q, want failed command-exit timing", stderr.String())
+	if !strings.Contains(stderr.String(), `"runStatus":"failed"`) || !strings.Contains(stderr.String(), `"errorKind":"provider-error"`) {
+		t.Fatalf("stderr = %q, want failed provider timing", stderr.String())
 	}
 }
 
@@ -1092,13 +1096,13 @@ func TestCloudflareRunCleanupDestroyUsesBoundedContext(t *testing.T) {
 		Command: []string{"true"},
 		NoSync:  true,
 	})
-	if err != nil {
-		t.Fatal(err)
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("cleanup error=%v", err)
 	}
-	if result.ExitCode != 0 {
+	if result.ExitCode != 1 || result.Session == nil || !result.Session.Kept {
 		t.Fatalf("result=%#v", result)
 	}
-	if result.Status != "succeeded" || result.ErrorKind != "" {
+	if result.Status != "failed" || result.ErrorKind != core.RunErrorProvider {
 		t.Fatalf("status/error=%q/%q", result.Status, result.ErrorKind)
 	}
 	if execCalls != 2 {
@@ -1112,8 +1116,8 @@ func TestCloudflareRunCleanupDestroyUsesBoundedContext(t *testing.T) {
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Fatalf("Run took %s, want bounded cleanup", elapsed)
 	}
-	if !strings.Contains(stderr.String(), "warning: cloudflare destroy failed for "+createdID+":") || !strings.Contains(stderr.String(), "context deadline exceeded") {
-		t.Fatalf("stderr=%q, want destroy timeout warning", stderr.String())
+	if _, ok, err := resolveLeaseClaimForProvider(createdID, providerName); err != nil || !ok {
+		t.Fatalf("missing recovery claim: %v", err)
 	}
 }
 
@@ -1332,28 +1336,27 @@ func withCloudflareCleanupTimeout(t *testing.T, timeout time.Duration) {
 
 func TestCloudflareResolveClaimRequiresReclaimForOtherRepo(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	repoA := t.TempDir()
-	repoB := t.TempDir()
-	if err := claimLeaseForRepoProvider("cbx_claimed", "blue-lobster", providerName, repoA, time.Hour, false); err != nil {
-		t.Fatal(err)
-	}
-	backend := cloudflareBackend{}
-	if _, _, _, _, err := backend.resolveSandboxID("blue-lobster", repoB, false); err == nil || !strings.Contains(err.Error(), "use --reclaim") {
-		t.Fatalf("resolve without reclaim err=%v, want reclaim guard", err)
-	}
-	leaseID, sandboxID, slug, _, err := backend.resolveSandboxID("blue-lobster", repoB, true)
+	repoA, repoB := t.TempDir(), t.TempDir()
+	captured, err := core.ClaimLeaseForRepoProviderScopePondWithLabels("cbx_claimed", "blue-lobster", providerName, "runner-scope", "original-pond", repoA, time.Hour, map[string]string{"instance_type": "basic"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if leaseID != "cbx_claimed" || sandboxID != "cbx_claimed" || slug != "blue-lobster" {
-		t.Fatalf("resolved lease=%q sandbox=%q slug=%q", leaseID, sandboxID, slug)
+	claim, err := resolveCloudflareClaim("blue-lobster")
+	if err != nil {
+		t.Fatal(err)
 	}
-	claim, ok, err := resolveLeaseClaimForProvider("blue-lobster", providerName)
-	if err != nil || !ok {
-		t.Fatalf("resolve claim after reclaim ok=%t err=%v", ok, err)
+	if _, err := admitRunClaim(context.Background(), claim, repoB, false); err == nil || !strings.Contains(err.Error(), "use --reclaim") {
+		t.Fatalf("admission error=%v", err)
 	}
-	if claim.RepoRoot != repoB {
-		t.Fatalf("claim repo = %q, want %q", claim.RepoRoot, repoB)
+	updated, err := admitRunClaim(context.Background(), claim, repoB, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.RepoRoot != repoB || updated.ProviderScope != captured.ProviderScope || updated.Pond != captured.Pond || updated.IdleTimeoutSeconds != captured.IdleTimeoutSeconds || updated.Labels["instance_type"] != "basic" {
+		t.Fatalf("admission lost claim identity: %+v", updated)
+	}
+	if err := core.VerifyLeaseClaimUnchanged(updated.LeaseID, updated); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -1408,7 +1411,7 @@ func TestCloudflareUnclaimedIDNeverReachesRunner(t *testing.T) {
 	}
 }
 
-func TestCloudflareStatusPrunesExpiredClaim(t *testing.T) {
+func TestCloudflareStatusRetainsExpiredClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/sandboxes/cbx_expired" {
@@ -1439,7 +1442,7 @@ func TestCloudflareStatusPrunesExpiredClaim(t *testing.T) {
 	if view.State != "expired" {
 		t.Fatalf("state = %q, want expired", view.State)
 	}
-	if _, ok, err := resolveLeaseClaimForProvider("blue-lobster", providerName); err != nil || ok {
+	if _, ok, err := resolveLeaseClaimForProvider("blue-lobster", providerName); err != nil || !ok {
 		t.Fatalf("claim resolved after expired status ok=%t err=%v", ok, err)
 	}
 }
@@ -1560,5 +1563,434 @@ func TestCloudflareCleanupPrunesTerminalClaims(t *testing.T) {
 	}
 	if !bytes.Contains(stdout.Bytes(), []byte("removed=1 checked=2")) {
 		t.Fatalf("cleanup output = %q, want removed summary", stdout.String())
+	}
+}
+
+func TestCloudflareRunFinalizesAfterFailedCleanup(t *testing.T) {
+	for _, commandExit := range []int{0, 42} {
+		t.Run(fmt.Sprint(commandExit), func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			var leaseID string
+			execCalls, deletes := 0, 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/sandboxes":
+					var req createSandboxRequest
+					_ = json.NewDecoder(r.Body).Decode(&req)
+					leaseID = req.ID
+					_, _ = fmt.Fprintf(w, `{"id":%q,"state":"running"}`, req.ID)
+				case r.Method == http.MethodDelete:
+					deletes++
+					http.Error(w, "destroy unavailable", http.StatusServiceUnavailable)
+				default:
+					execCalls++
+					w.Header().Set("Content-Type", "application/x-ndjson")
+					code := 0
+					if execCalls > 1 {
+						code = commandExit
+					}
+					_, _ = fmt.Fprintf(w, "{\"type\":\"complete\",\"exitCode\":%d}\n", code)
+				}
+			}))
+			defer server.Close()
+			var stderr bytes.Buffer
+			backend := cloudflareBackend{cfg: Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: &stderr}}
+			result, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, NoSync: true, Command: []string{"true"}, TimingJSON: true})
+			wantExit, wantKind := commandExit, "command-exit"
+			if wantExit == 0 {
+				wantExit, wantKind = 1, string(core.RunErrorProvider)
+			}
+			var ee ExitError
+			if !errors.As(err, &ee) || ee.Code != wantExit || result.ExitCode != wantExit || result.Status != "failed" || string(result.ErrorKind) != wantKind {
+				t.Fatalf("result=%+v error=%v, want failed/%s/%d", result, err, wantKind, wantExit)
+			}
+			if deletes != 1 || result.Session == nil || !result.Session.Kept {
+				t.Fatalf("deletes=%d session=%+v", deletes, result.Session)
+			}
+			if _, ok, err := resolveLeaseClaimForProvider(leaseID, providerName); err != nil || !ok {
+				t.Fatalf("recovery claim missing: %v", err)
+			}
+			if strings.Count(stderr.String(), `"runStatus"`) != 1 || !strings.Contains(stderr.String(), fmt.Sprintf(`"exitCode":%d`, wantExit)) {
+				t.Fatalf("timing was not finalized after cleanup: %s", stderr.String())
+			}
+		})
+	}
+}
+
+func TestCloudflareFreshPublicationDoesNotReclaimCompetingClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := t.TempDir()
+	var competing LeaseClaim
+	deletes := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deletes++
+			return
+		}
+		var req createSandboxRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		var err error
+		competing, err = core.ClaimLeaseForRepoProviderScopePondWithLabels(req.ID, req.Slug, providerName, "", "other-pond", repo, time.Minute, map[string]string{"owner": "successor"})
+		if err != nil {
+			t.Error(err)
+		}
+		_, _ = fmt.Fprintf(w, `{"id":%q,"state":"running"}`, req.ID)
+	}))
+	defer server.Close()
+	backend := cloudflareBackend{cfg: Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+	err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "repo", Root: repo}, Reclaim: true, Keep: true})
+	if err == nil || deletes != 0 {
+		t.Fatalf("warmup error=%v deletes=%d, want rejected without destructive rollback", err, deletes)
+	}
+	if err := core.VerifyLeaseClaimUnchanged(competing.LeaseID, competing); err != nil {
+		t.Fatalf("competing claim changed: %v", err)
+	}
+}
+
+func TestCloudflareCleanupRequiresConfirmedAbsence(t *testing.T) {
+	for _, probe := range []string{"terminal", "misleading-error", "dry-run"} {
+		t.Run(probe, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			claim, err := core.ClaimLeaseForRepoProviderScopePondWithLabels("cbx_recovery", "recovery", providerName, "", "", t.TempDir(), time.Hour, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			deletes := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodDelete {
+					deletes++
+					http.Error(w, "destroy unavailable", http.StatusServiceUnavailable)
+					return
+				}
+				if probe == "misleading-error" {
+					http.Error(w, "upstream 404 not found", http.StatusInternalServerError)
+					return
+				}
+				_, _ = io.WriteString(w, `{"id":"cbx_recovery","state":"stopped"}`)
+			}))
+			defer server.Close()
+			backend := cloudflareBackend{cfg: Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+			_ = backend.Cleanup(context.Background(), CleanupRequest{DryRun: probe == "dry-run"})
+			if err := core.VerifyLeaseClaimUnchanged(claim.LeaseID, claim); err != nil {
+				t.Fatalf("lost recovery claim: %v", err)
+			}
+			wantDeletes := 0
+			if probe == "terminal" {
+				wantDeletes = 1
+			}
+			if deletes != wantDeletes {
+				t.Fatalf("deletes=%d want=%d", deletes, wantDeletes)
+			}
+		})
+	}
+}
+
+func TestCloudflareAdmissionRejectsStaleClaim(t *testing.T) {
+	for _, change := range []string{"remove", "replace", "same-value-new-revision"} {
+		for _, reclaim := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/reclaim=%t", change, reclaim), func(t *testing.T) {
+				t.Setenv("XDG_STATE_HOME", t.TempDir())
+				repo := t.TempDir()
+				captured, err := core.ClaimLeaseForRepoProviderScopePondWithLabels("cbx_stale", "stale", providerName, "", "", repo, time.Hour, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				successor := captured
+				if change == "remove" {
+					err = core.RemoveLeaseClaimIfUnchanged(captured.LeaseID, captured)
+				} else {
+					if change == "replace" {
+						successor.Pond = "successor"
+					}
+					successor, err = core.ReplaceLeaseClaimIfUnchangedDurableReturning(captured.LeaseID, captured, successor)
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, root := range []string{"", repo} {
+					if _, err := admitRunClaim(context.Background(), captured, root, reclaim); err == nil {
+						t.Fatal("stale admission succeeded")
+					}
+				}
+				if change == "remove" {
+					if _, ok, err := resolveLeaseClaimForProvider(captured.LeaseID, providerName); err != nil || ok {
+						t.Fatalf("retired claim resurrected: %v", err)
+					}
+				} else if err := core.VerifyLeaseClaimUnchanged(successor.LeaseID, successor); err != nil {
+					t.Fatal(err)
+				}
+			})
+		}
+	}
+}
+
+func TestCloudflareRunDoesNotDeleteSuccessorClaim(t *testing.T) {
+	for _, commandExit := range []int{0, 42} {
+		t.Run(fmt.Sprint(commandExit), func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			var leaseID string
+			var successor LeaseClaim
+			execCalls, deletes := 0, 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/sandboxes":
+					var req createSandboxRequest
+					_ = json.NewDecoder(r.Body).Decode(&req)
+					leaseID = req.ID
+					_, _ = fmt.Fprintf(w, `{"id":%q,"state":"running"}`, req.ID)
+				case r.Method == http.MethodDelete:
+					deletes++
+				default:
+					execCalls++
+					code := 0
+					if execCalls > 1 {
+						code = commandExit
+						claim, err := resolveCloudflareClaim(leaseID)
+						if err != nil {
+							t.Error(err)
+							http.Error(w, "fixture", 500)
+							return
+						}
+						next := claim
+						next.Pond = "successor"
+						successor, err = core.ReplaceLeaseClaimIfUnchangedDurableReturning(leaseID, claim, next)
+						if err != nil {
+							t.Error(err)
+						}
+					}
+					w.Header().Set("Content-Type", "application/x-ndjson")
+					_, _ = fmt.Fprintf(w, "{\"type\":\"complete\",\"exitCode\":%d}\n", code)
+				}
+			}))
+			defer server.Close()
+			backend := cloudflareBackend{cfg: Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+			result, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, NoSync: true, Command: []string{"true"}})
+			wantExit := commandExit
+			if wantExit == 0 {
+				wantExit = 1
+			}
+			if err == nil || result.ExitCode != wantExit || result.Session == nil || !result.Session.Kept || deletes != 0 {
+				t.Fatalf("result=%+v err=%v deletes=%d", result, err, deletes)
+			}
+			if err := core.VerifyLeaseClaimUnchanged(leaseID, successor); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestCloudflareCleanupDoesNotPruneSuccessor(t *testing.T) {
+	for _, missing := range []bool{false, true} {
+		t.Run(fmt.Sprint(missing), func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			claim, err := core.ClaimLeaseForRepoProviderScopePondWithLabels("cbx_successor", "successor", providerName, "", "", t.TempDir(), time.Hour, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var successor LeaseClaim
+			deletes := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodDelete {
+					deletes++
+					return
+				}
+				next := claim
+				next.Pond = "successor"
+				var err error
+				successor, err = core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, claim, next)
+				if err != nil {
+					t.Error(err)
+				}
+				if missing {
+					http.NotFound(w, r)
+					return
+				}
+				_, _ = io.WriteString(w, `{"id":"cbx_successor","state":"stopped"}`)
+			}))
+			defer server.Close()
+			backend := cloudflareBackend{cfg: Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+			if err := backend.Cleanup(context.Background(), CleanupRequest{}); err == nil {
+				t.Fatal("stale cleanup succeeded")
+			}
+			if deletes != 0 {
+				t.Fatalf("successor received %d deletes", deletes)
+			}
+			if err := core.VerifyLeaseClaimUnchanged(claim.LeaseID, successor); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestCloudflareFreshRunRequiresRecoveryOwnerAndCommand(t *testing.T) {
+	for _, req := range []RunRequest{{NoSync: true, Command: []string{"true"}}, {NoSync: true, Repo: Repo{Root: t.TempDir()}}, {ID: " ", NoSync: true, Repo: Repo{Root: t.TempDir()}, Command: []string{"true"}}} {
+		t.Run(fmt.Sprintf("root=%t", req.Repo.Root != ""), func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { requests++; http.Error(w, "unexpected", 500) }))
+			defer server.Close()
+			backend := cloudflareBackend{cfg: Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+			if _, err := backend.Run(context.Background(), req); err == nil {
+				t.Fatal("invalid run succeeded")
+			}
+			if requests != 0 {
+				t.Fatalf("invalid run made %d requests", requests)
+			}
+		})
+	}
+}
+
+func TestCloudflareDestroyClaimFenceSpansNativeDelete(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	claim, err := core.ClaimLeaseForRepoProviderScopePondWithLabels("cbx_fenced", "fenced", providerName, "", "", t.TempDir(), time.Hour, map[string]string{"instance_type": "lite"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entered, release := make(chan struct{}), make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Query().Get("instanceType") != "lite" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL)
+		}
+		close(entered)
+		<-release
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	client, err := newCloudflareClient(Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { _, err := destroyClaimedSandbox(context.Background(), client, claim); done <- err }()
+	<-entered
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	called := false
+	err = core.WithDurableLeaseClaimLockContext(ctx, claim.LeaseID, func(*LeaseClaim, bool, func() error) error { called = true; return nil })
+	close(release)
+	if !errors.Is(err, context.DeadlineExceeded) || called {
+		t.Fatalf("claim writer entered DELETE fence: called=%t err=%v", called, err)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := resolveLeaseClaimForProvider(claim.LeaseID, providerName); err != nil || ok {
+		t.Fatalf("cleanup did not remove exact claim: %v", err)
+	}
+}
+
+func TestCloudflareCanceledDestroyFenceMakesNoRequest(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	claim, err := core.ClaimLeaseForRepoProviderScopePondWithLabels("cbx_locked", "locked", providerName, "", "", t.TempDir(), time.Hour, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { requests++ }))
+	defer server.Close()
+	client, err := newCloudflareClient(Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entered, release := make(chan struct{}), make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- core.WithDurableLeaseClaimLockContext(context.Background(), claim.LeaseID, func(*LeaseClaim, bool, func() error) error { close(entered); <-release; return nil })
+	}()
+	<-entered
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err = destroyClaimedSandbox(ctx, client, claim)
+	close(release)
+	if lockErr := <-done; lockErr != nil {
+		t.Fatal(lockErr)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) || requests != 0 {
+		t.Fatalf("cleanup error=%v requests=%d", err, requests)
+	}
+	if err := core.VerifyLeaseClaimUnchanged(claim.LeaseID, claim); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCloudflareRunKeepOnPreparationFailure(t *testing.T) {
+	for _, noSync := range []bool{false, true} {
+		t.Run(fmt.Sprint(noSync), func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			repo := t.TempDir()
+			if err := os.WriteFile(filepath.Join(repo, "file.txt"), []byte("fixture"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			cmd := exec.Command("git", "init", "--quiet", repo)
+			if output, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git init: %s %v", output, err)
+			}
+			var leaseID string
+			deletes := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodDelete {
+					deletes++
+					return
+				}
+				if r.URL.Path == "/v1/sandboxes" {
+					var req createSandboxRequest
+					_ = json.NewDecoder(r.Body).Decode(&req)
+					leaseID = req.ID
+					_, _ = fmt.Fprintf(w, `{"id":%q,"state":"running"}`, req.ID)
+					return
+				}
+				http.Error(w, "preparation unavailable", http.StatusServiceUnavailable)
+			}))
+			defer server.Close()
+			backend := cloudflareBackend{cfg: Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+			result, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "repo", Root: repo}, NoSync: noSync, KeepOnFailure: true, Command: []string{"true"}})
+			if err == nil || result.Session == nil || !result.Session.Kept || deletes != 0 {
+				t.Fatalf("result=%+v error=%v deletes=%d", result, err, deletes)
+			}
+			if _, ok, err := resolveLeaseClaimForProvider(leaseID, providerName); err != nil || !ok {
+				t.Fatalf("recovery claim missing: %v", err)
+			}
+		})
+	}
+}
+
+func TestCloudflareRunCancellationSurvivesFailedCleanup(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var leaseID string
+	execCalls, deletes := 0, 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/sandboxes":
+			var req createSandboxRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			leaseID = req.ID
+			_, _ = fmt.Fprintf(w, `{"id":%q,"state":"running"}`, req.ID)
+		case r.Method == http.MethodDelete:
+			deletes++
+			http.Error(w, "cleanup unavailable", http.StatusServiceUnavailable)
+		default:
+			execCalls++
+			if execCalls > 1 {
+				cancel()
+				return
+			}
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			_, _ = io.WriteString(w, "{\"type\":\"complete\",\"exitCode\":0}\n")
+		}
+	}))
+	defer server.Close()
+	var stderr bytes.Buffer
+	backend := cloudflareBackend{cfg: Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: &stderr}}
+	result, err := backend.Run(ctx, RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, NoSync: true, Command: []string{"true"}, TimingJSON: true})
+	if !errors.Is(err, context.Canceled) || result.Status != core.RunStatusCanceled || result.Session == nil || !result.Session.Kept || deletes != 1 {
+		t.Fatalf("result=%+v error=%v deletes=%d", result, err, deletes)
+	}
+	if !strings.Contains(stderr.String(), `"runStatus":"canceled"`) || strings.Count(stderr.String(), `"runStatus"`) != 1 {
+		t.Fatalf("timing=%s", stderr.String())
+	}
+	if _, ok, err := resolveLeaseClaimForProvider(leaseID, providerName); err != nil || !ok {
+		t.Fatalf("recovery claim missing: %v", err)
 	}
 }

--- a/internal/providers/cloudflare/client.go
+++ b/internal/providers/cloudflare/client.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -332,8 +331,4 @@ func redactCloudflareRunnerSecrets(value string, secrets ...string) string {
 		}
 	}
 	return cloudflareBearerPattern.ReplaceAllString(redacted, "Bearer [redacted]")
-}
-
-func remoteArchivePath() string {
-	return path.Join("/tmp", "crabbox-cloudflare-sync-"+time.Now().UTC().Format("20060102150405.000000000")+".tgz")
 }

--- a/internal/providers/cloudflare/client.go
+++ b/internal/providers/cloudflare/client.go
@@ -307,19 +307,26 @@ func (c *cloudflareClient) doJSON(ctx context.Context, method, endpoint string, 
 	return json.NewDecoder(resp.Body).Decode(output)
 }
 
+type cloudflareResponseError struct {
+	statusCode int
+	message    string
+}
+
+func (e *cloudflareResponseError) Error() string { return e.message }
+
 func (c *cloudflareClient) responseError(resp *http.Response) error {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	var payload struct {
 		Error string `json:"error"`
 	}
-	if err := json.Unmarshal(body, &payload); err == nil && strings.TrimSpace(payload.Error) != "" {
-		return fmt.Errorf("%s API %s: %s", providerName, resp.Status, redactCloudflareRunnerSecrets(payload.Error, c.token))
-	}
 	text := strings.TrimSpace(string(body))
+	if err := json.Unmarshal(body, &payload); err == nil && strings.TrimSpace(payload.Error) != "" {
+		text = payload.Error
+	}
 	if text == "" {
 		text = resp.Status
 	}
-	return fmt.Errorf("%s API %s: %s", providerName, resp.Status, redactCloudflareRunnerSecrets(text, c.token))
+	return &cloudflareResponseError{statusCode: resp.StatusCode, message: fmt.Sprintf("%s API %s: %s", providerName, resp.Status, redactCloudflareRunnerSecrets(text, c.token))}
 }
 
 func redactCloudflareRunnerSecrets(value string, secrets ...string) string {

--- a/internal/providers/cloudflare/core.go
+++ b/internal/providers/cloudflare/core.go
@@ -1,10 +1,8 @@
 package cloudflare
 
 import (
-	"context"
 	"flag"
 	"io"
-	"os"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -30,7 +28,6 @@ type CleanupRequest = core.CleanupRequest
 type Server = core.Server
 type LeaseClaim = core.LeaseClaim
 type Repo = core.Repo
-type SyncManifest = core.SyncManifest
 type ExitError = core.ExitError
 type FeatureSet = core.FeatureSet
 type Feature = core.Feature
@@ -134,20 +131,4 @@ func shouldUseShell(command []string) bool {
 
 func leadingEnvAssignment(command []string) bool {
 	return core.LeadingEnvAssignment(command)
-}
-
-func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
-	return core.SyncExcludes(root, cfg)
-}
-
-func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (SyncManifest, error) {
-	return core.BuildSyncManifestFiltered(root, excludes, includes)
-}
-
-func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
-	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
-}
-
-func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
-	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
 }

--- a/internal/providers/cloudflare/core.go
+++ b/internal/providers/cloudflare/core.go
@@ -69,32 +69,12 @@ func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTim
 	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
 }
 
-func claimLeaseForRepoProviderPondLabels(leaseID, slug, provider, pond, repoRoot string, idleTimeout time.Duration, reclaim bool, labels map[string]string) error {
-	return core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, provider, "", pond, repoRoot, idleTimeout, reclaim, Server{Labels: labels}, core.SSHTarget{})
-}
-
 func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaimForProvider(identifier, provider)
 }
 
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
 func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
-}
-
-func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
-	return core.TimingReportWithRunResult(report, result, err)
-}
-
-func finalizeRunResult(result RunResult, err error) RunResult {
-	return core.FinalizeRunResult(result, err)
-}
-
-func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
-	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }
 
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {

--- a/internal/providers/cloudflare/sync.go
+++ b/internal/providers/cloudflare/sync.go
@@ -5,76 +5,62 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *cloudflareBackend) syncWorkspace(ctx context.Context, client *cloudflareClient, sandboxID string, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
-	start := b.now()
-	syncCtx := ctx
-	cancel := func() {}
-	if b.cfg.Sync.Timeout > 0 {
-		syncCtx, cancel = context.WithTimeout(ctx, b.cfg.Sync.Timeout)
+func (b *cloudflareBackend) prepareArchive(ctx context.Context, req RunRequest) (*core.PreparedArchive, error) {
+	return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+		TempPattern: "crabbox-cloudflare-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+	})
+}
+
+func (b *cloudflareBackend) syncWorkspace(ctx context.Context, client *cloudflareClient, sandboxID string, req RunRequest, workdir string, prepared *core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+	if prepared == nil {
+		var err error
+		prepared, err = b.prepareArchive(ctx, req)
+		if err != nil {
+			return nil, 0, err
+		}
 	}
-	defer cancel()
-	excludes, err := syncExcludes(req.Repo.Root, b.cfg)
-	if err != nil {
-		return nil, 0, err
+	var diskDuration time.Duration
+	phases, total, err := core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
+		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge, Workdir: workdir,
+		Provider: providerName, PhaseName: "cloudflare_sync", RemoteArchivePrefix: "crabbox-cloudflare-sync-",
+		Stderr: b.rt.Stderr, Now: b.now,
+		CleanupContext: func(context.Context) (context.Context, context.CancelFunc) { return cloudflareCleanupContext() },
+		Upload: func(uploadCtx context.Context, remoteArchive string, _ io.Reader) error {
+			start := b.now()
+			if err := b.prepareWorkspace(uploadCtx, client, sandboxID, workdir); err != nil {
+				return err
+			}
+			if err := b.checkRemoteDiskForSync(uploadCtx, client, sandboxID, workdir, prepared.Manifest.Bytes, prepared.Size); err != nil {
+				return err
+			}
+			diskDuration = b.now().Sub(start)
+			// Reopen the same owned snapshot to preserve this transport's exact Content-Length.
+			if err := client.uploadFile(uploadCtx, sandboxID, prepared.File.Name(), remoteArchive); err != nil {
+				return fmt.Errorf("upload archive: %w", err)
+			}
+			return nil
+		},
+		Exec: func(execCtx context.Context, command string) error {
+			return b.execShell(execCtx, client, sandboxID, command, io.Discard)
+		},
+	}, prepared)
+	for i := range phases {
+		if phases[i].Name == "upload" {
+			phases[i].Ms -= diskDuration.Milliseconds()
+			phases = slices.Insert(phases, i, timingPhase{Name: "disk", Ms: diskDuration.Milliseconds()})
+			break
+		}
 	}
-	manifestStarted := b.now()
-	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
-	if err != nil {
-		return nil, 0, exit(6, "build sync file list: %v", err)
-	}
-	manifestDuration := b.now().Sub(manifestStarted)
-	preflightStarted := b.now()
-	if err := checkSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
-		return nil, 0, err
-	}
-	preflightDuration := b.now().Sub(preflightStarted)
-	prepareStarted := b.now()
-	if err := b.prepareWorkspace(syncCtx, client, sandboxID, workdir, b.cfg.Sync.Delete); err != nil {
-		return nil, 0, err
-	}
-	prepareDuration := b.now().Sub(prepareStarted)
-	archiveStarted := b.now()
-	archive, err := createCloudflareSyncArchive(syncCtx, req.Repo, manifest, b.rt.Stderr)
-	if err != nil {
-		return nil, 0, err
-	}
-	defer os.Remove(archive.Name())
-	defer archive.Close()
-	archiveInfo, err := archive.Stat()
-	if err != nil {
-		return nil, 0, fmt.Errorf("stat sync archive: %w", err)
-	}
-	archiveDuration := b.now().Sub(archiveStarted)
-	diskStarted := b.now()
-	if err := b.checkRemoteDiskForSync(syncCtx, client, sandboxID, workdir, manifest.Bytes, archiveInfo.Size()); err != nil {
-		return nil, 0, err
-	}
-	diskDuration := b.now().Sub(diskStarted)
-	uploadStarted := b.now()
-	remoteArchive := remoteArchivePath()
-	if err := client.uploadFile(syncCtx, sandboxID, archive.Name(), remoteArchive); err != nil {
-		return nil, 0, fmt.Errorf("upload archive: %w", err)
-	}
-	if err := b.execShell(syncCtx, client, sandboxID, cloudflareExtractArchiveCommand(remoteArchive, workdir), io.Discard); err != nil {
-		return nil, 0, err
-	}
-	uploadDuration := b.now().Sub(uploadStarted)
-	total := b.now().Sub(start)
-	return []timingPhase{
-		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
-		{Name: "preflight", Ms: preflightDuration.Milliseconds()},
-		{Name: "prepare", Ms: prepareDuration.Milliseconds()},
-		{Name: "archive", Ms: archiveDuration.Milliseconds()},
-		{Name: "disk", Ms: diskDuration.Milliseconds()},
-		{Name: "upload", Ms: uploadDuration.Milliseconds()},
-		{Name: "cloudflare_sync", Ms: total.Milliseconds()},
-	}, total, nil
+	return phases, total, err
 }
 
 func (b *cloudflareBackend) checkRemoteDiskForSync(ctx context.Context, client *cloudflareClient, sandboxID, workdir string, manifestBytes, archiveBytes int64) error {
@@ -142,12 +128,8 @@ func byteCount(bytes int64) string {
 	return fmt.Sprintf("%.1f PiB", value/unit)
 }
 
-func (b *cloudflareBackend) prepareWorkspace(ctx context.Context, client *cloudflareClient, sandboxID, workdir string, deleteContents bool) error {
-	command := "mkdir -p " + shellQuote(workdir)
-	if deleteContents {
-		command = "rm -rf " + shellQuote(workdir) + " && " + command
-	}
-	return b.execShell(ctx, client, sandboxID, command, io.Discard)
+func (b *cloudflareBackend) prepareWorkspace(ctx context.Context, client *cloudflareClient, sandboxID, workdir string) error {
+	return b.execShell(ctx, client, sandboxID, "mkdir -p "+shellQuote(workdir), io.Discard)
 }
 
 func (b *cloudflareBackend) execShell(ctx context.Context, client *cloudflareClient, sandboxID, command string, stdout io.Writer) error {
@@ -163,19 +145,4 @@ func (b *cloudflareBackend) execShell(ctx context.Context, client *cloudflareCli
 		return exit(code, "%s exec %q exited %d", providerName, command, code)
 	}
 	return nil
-}
-
-func cloudflareExtractArchiveCommand(remoteArchive, workdir string) string {
-	return strings.Join([]string{
-		"tar -xzf " + shellQuote(remoteArchive) + " -C " + shellQuote(workdir),
-		"status=$?",
-		"rm -f " + shellQuote(remoteArchive),
-		"cleanup=$?",
-		`if [ "$status" -ne 0 ]; then exit "$status"; fi`,
-		`exit "$cleanup"`,
-	}, "; ")
-}
-
-func createCloudflareSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, _ io.Writer) (*os.File, error) {
-	return createPortableSyncArchive(ctx, repo, manifest, "crabbox-cloudflare-sync-*.tgz")
 }


### PR DESCRIPTION
## Summary

Move Cloudflare's persistent-container run sequence onto the existing shared sandbox lifecycle. Keep Cloudflare's archive transport, shell rendering, environment forwarding, instance-type routing and Worker-owned idle policy in the adapter.

This removes duplicated result/timing/keep/cleanup bookkeeping and fixes observable ownership failures:

- Cleanup finishes before the final result. Cleanup alone fails with exit 1; command exit 42 and cancellation remain primary when cleanup also fails. Failed teardown keeps the recovery session and claim.
- `--keep-on-failure` also covers fresh preparation and sync failures.
- Fresh publication is absent-fenced; `--reclaim` cannot overwrite a competing claim for a newly generated ID. Reuse carries a captured claim revision and cannot resurrect a removed claim or overwrite a successor.
- Stop and automatic cleanup hold the captured local claim fence through DELETE and claim retirement. Batch cleanup uses full core claim snapshots instead of its own reduced JSON decoder.
- Typed HTTP status replaces substring-based absence inference. Terminal runner metadata alone no longer discards recovery claims: status retains them; explicit cleanup confirms/retries deletion first.

Docs and the maintainer Unreleased entry describe the changed behavior. No configuration, credential, dependency or Worker-deployment changes are required.

## Verification

Regression cases fail on unchanged baseline for cleanup false success, incorrect retained-session state, fresh-publication collision, terminal-metadata claim loss and misleading `404` error text. Additional tests cover replacement/removal/same-value revisions, reclaimed repository ownership, stale cleanup after a native probe, the lock spanning DELETE, canceled lock admission, bounded teardown, cancellation, preparation failure, and invalid whitespace IDs.

Cloudflare/shared race suites, vet, build, docs generation and Windows test cross-compilation pass. Managed precommit and main-integration reviews are clean at the configured blocking threshold. Independent semantic review caught a whitespace-ID dispatch regression and an overbroad dry-run description; both were corrected before publication. A cancellation fixture initially waited on an unread HTTP request during server shutdown; the fixture was corrected and the final race suite passes.

Native proof uses the actual pinned local Wrangler/Worker/Durable Object and Linux/amd64 Go container runner on OrbStack, with synthetic inputs only. Fourteen steps cover readiness, whitespace-ID rejection without allocation, successful-command plus rejected DELETE, command42 plus rejected DELETE, actual reuse/recovery after both, preparation failure with keep-on-failure, automatic cleanup success, and retained command failure. A local fault proxy rejects the selected HTTP operation without sending that operation upstream; all recovery executions and successful teardown requests reach the real runner. All five candidate containers and their local claims were independently confirmed absent; the local runtime was stopped and task state removed. Candidate SHA-256: `48292065be81182daf6a004c85fef9140420c5fca1fab7c51e458406fa439199`. A preliminary doctor run correctly rejected the fixture config's 0644 permissions; it was corrected to 0600 before any allocation.

## Boundaries

This is native local-runtime proof, not a production Cloudflare deployment. The fence protects local claim writers, not a remote operator recreating the same Durable Object identity: the runner has no generation-conditional delete API, and instance type remains a routing preference. Repository admission retains its existing non-cancelable local lock wait; cleanup lock admission is context-bounded. Dry-run sends no DELETE and does not remove local claims, but the runner's existing expiry policy can still act during GET. Command literal-intent standardization is a separate follow-up.
