### PR TITLE
fix: preserve literal intent through delegated command transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,13 @@
 
 ## Unreleased
 
-- Preserve literal profile arguments and assignment-shaped executable names across Cloudflare Sandbox, Superserve, Crownest, Vercel Sandbox, and Nomad command transports without reinterpreting them as shell syntax.
-
 - Preserve existing Cloudflare container workspaces when sync upload or extraction fails, clean partial archives, and enforce full-checkout size limits before fresh allocation. [PR 1814](https://github.com/openclaw/crabbox/pull/1814). Thanks @steipete.
 - Protect Nomad runs from overwriting replacement claims or recreating retired leases, and expose standard run-session handles with cleanup-aware final outcomes that preserve the original command exit. [PR 1810](https://github.com/openclaw/crabbox/pull/1810). Thanks @steipete.
 - Preserve individual AWS, Azure, and GCP candidate failures in successful leases' provisioning history across market and regional fallback, including previously omitted GCP on-demand failures. [PR 1811](https://github.com/openclaw/crabbox/pull/1811). Thanks @steipete.
 - Allow fresh brokered AWS Windows and WSL2 leases to bootstrap through advertised SSH port 22 while preserving an explicitly selected final workload port. [PR 1801](https://github.com/openclaw/crabbox/pull/1801). Thanks @steipete.
 - Reuse one Azure or GCP token refresh across concurrent requests, reducing duplicate authentication traffic while preserving credential isolation, refresh margins, and retry behavior. [PR 1802](https://github.com/openclaw/crabbox/pull/1802). Thanks @steipete.
 - Fix GCP metadata authentication in workerd by using supported redirect handling while continuing to reject redirected token responses without following them. [PR 1815](https://github.com/openclaw/crabbox/pull/1815). Thanks @steipete.
+- Preserve literal profile arguments and assignment-shaped executable names across Cloudflare Sandbox, Superserve, Crownest, Vercel Sandbox, and Nomad command transports without reinterpreting them as shell syntax. [PR 1818](https://github.com/openclaw/crabbox/pull/1818). Thanks @steipete.
 - Skip unnecessary APT translation, AppStream, and command-not-found downloads during minimal Linux bootstrap while preserving required package indexes, signature checks, and later operator defaults. [PR 1794](https://github.com/openclaw/crabbox/pull/1794). Thanks @steipete.
 - Report the correct install, build, or test failure stage from supported phase markers, preserving original exit codes and keeping later artifact-collection failures separate. [PR 1795](https://github.com/openclaw/crabbox/pull/1795). Thanks @steipete.
 - Restore current Tenki CLI inventory and legacy-claim recovery, and retain ownership claims until the exact session acknowledges termination; obsolete workspace/project settings now give migration guidance before creating a lease. [PR 1741](https://github.com/openclaw/crabbox/pull/1741). Thanks @eddiewang.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Preserve literal profile arguments and assignment-shaped executable names across Cloudflare Sandbox, Superserve, Crownest, Vercel Sandbox, and Nomad command transports without reinterpreting them as shell syntax.
+
 - Preserve existing Cloudflare container workspaces when sync upload or extraction fails, clean partial archives, and enforce full-checkout size limits before fresh allocation. [PR 1814](https://github.com/openclaw/crabbox/pull/1814). Thanks @steipete.
 - Protect Nomad runs from overwriting replacement claims or recreating retired leases, and expose standard run-session handles with cleanup-aware final outcomes that preserve the original command exit. [PR 1810](https://github.com/openclaw/crabbox/pull/1810). Thanks @steipete.
 - Preserve individual AWS, Azure, and GCP candidate failures in successful leases' provisioning history across market and regional fallback, including previously omitted GCP on-demand failures. [PR 1811](https://github.com/openclaw/crabbox/pull/1811). Thanks @steipete.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -34,6 +34,12 @@ The trailing command after `--` is sent to the box verbatim as argv. Use
 `--shell` to run it through the remote shell instead, for multi-statement
 snippets, pipes, or shell expansion.
 
+On Cloudflare Sandbox, Superserve, Crownest, Vercel Sandbox, and Nomad,
+quoted or interpolated profile arguments retain their literal meaning through
+the delegated command transport. A value such as `&&` does not become a shell
+operator, and an executable named `FOO=x` is invoked rather than treated as an
+environment assignment. Explicit `--shell` still selects shell source.
+
 On POSIX SSH targets, `--shell` runs in a Bash login shell. Its startup and
 logout files are part of that shell's behavior: for example, `set -e` plus a
 failing `~/.bash_logout` command can change an explicit `exit 7` to exit 1.

--- a/internal/cli/command_intent.go
+++ b/internal/cli/command_intent.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"slices"
+	"strings"
 )
 
 // CommandIntent separates command meaning from an adapter's execution transport.
@@ -34,4 +35,10 @@ func (c CommandIntent) Argv(shellPrefix ...string) []string {
 		return append(slices.Clone(shellPrefix), c.source)
 	}
 	return slices.Clone(c.args)
+}
+
+// ShellCommand quotes execution argv for a POSIX source-only transport. Once
+// classified, arguments must not be reinterpreted as operators or assignments.
+func (c CommandIntent) ShellCommand(shellPrefix ...string) string {
+	return strings.Join(shellWords(c.Argv(shellPrefix...)), " ")
 }

--- a/internal/cli/prewarm.go
+++ b/internal/cli/prewarm.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"maps"
 	"strings"
 	"time"
 )
@@ -458,6 +459,7 @@ func admitPrewarmProbe(args []string) error {
 		return err
 	}
 	req := runRequestFromFlags(cfg, flags, expansion.Command)
+	req.CommandLiteralArgs = maps.Clone(expansion.LiteralArgs)
 	req.ReuseLease = true
 	req.ShellMode = expansion.Shell
 	req.Preflight = expansion.Preflight

--- a/internal/cli/prewarm_admission_test.go
+++ b/internal/cli/prewarm_admission_test.go
@@ -266,3 +266,31 @@ func TestRunProviderAdmissionBeforeConfigure(t *testing.T) {
 		})
 	}
 }
+
+func TestRunProfileLiteralIntentSurvivesDelegatedHandoff(t *testing.T) {
+	for _, mixed := range []bool{false, true} {
+		t.Run(fmt.Sprintf("mixed=%t", mixed), func(t *testing.T) {
+			p := setupProbeAdmission(t, nil)
+			preset := "printf {{scenario}}"
+			want := []string{"printf", "&&"}
+			if mixed {
+				preset += " && printf done"
+				want = append(want, "&&", "printf", "done")
+			}
+			writeFile(t, os.Getenv("CRABBOX_CONFIG"), "provider: probe-admission-test\nprofiles:\n  qa:\n    presets:\n      check:\n        command: "+preset+"\n")
+			var stdout, stderr bytes.Buffer
+			err := (App{Stdout: &stdout, Stderr: &stderr}).Run(t.Context(), []string{"run", "--profile", "qa", "--preset", "check", "--scenario", "&&", "--id", "cbx_0123456789ab", "--no-sync", "--no-hydrate"})
+			if err != nil {
+				t.Fatalf("run: %v\n%s", err, stderr.String())
+			}
+			if len(p.admissions) != 1 || p.ran != 1 {
+				t.Fatalf("admissions=%d executions=%d", len(p.admissions), p.ran)
+			}
+			for _, req := range []RunRequest{p.admissions[0], p.execution.req} {
+				if req.ShellMode || !reflect.DeepEqual(req.Command, want) || !reflect.DeepEqual(req.CommandLiteralArgs, map[int]bool{1: true}) {
+					t.Fatalf("lost literal intent: command=%q literal=%v shell=%t", req.Command, req.CommandLiteralArgs, req.ShellMode)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -1187,6 +1187,7 @@ type RunRequest struct {
 	FreshPR               FreshPRSpec
 	ApplyLocalPatch       bool
 	Command               []string
+	CommandLiteralArgs    map[int]bool // Profile argument positions that must not introduce shell syntax.
 	Label                 string
 	RequestedSlug         string
 	TimingJSON            bool

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"strings"
 	"sync/atomic"
@@ -789,6 +790,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	scriptRequested := *scriptPath != "" || *scriptStdin
 	var script *RunScriptSpec
 	runReq := runRequestFromFlags(cfg, runFlags, command)
+	runReq.CommandLiteralArgs = maps.Clone(expansion.LiteralArgs)
 	runReq.Repo = repo
 	runReq.RunID = executionRunID
 	runReq.Env = envSelection.Effective
@@ -3550,7 +3552,7 @@ func shouldUseShellWithLiteralArgs(command []string, literalArgs map[int]bool) b
 		}
 		return strings.ContainsAny(command[0], " \t\r\n&|;<>*$`()")
 	}
-	if leadingEnvAssignment(command) {
+	if !literalArgs[0] && leadingEnvAssignment(command) {
 		return true
 	}
 	for idx, word := range command {

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -1063,6 +1063,7 @@ func TestCommandIntentArgv(t *testing.T) {
 		{"operators", []string{"echo", "a b", "&&", "echo", "done"}, false, nil, []string{"bash", "-lc", "'echo' 'a b' && 'echo' 'done'"}},
 		{"assignment", []string{"FOO=a b", "printenv", "FOO"}, false, nil, []string{"bash", "-lc", "FOO='a b' 'printenv' 'FOO'"}},
 		{"invalid assignment is executable", []string{"bad-name=x", "arg"}, false, nil, []string{"bad-name=x", "arg"}},
+		{"literal assignment executable", []string{"FOO=x", "argument"}, false, map[int]bool{0: true}, []string{"FOO=x", "argument"}},
 		{"literal operator", []string{"echo", "&&"}, false, map[int]bool{1: true}, []string{"echo", "&&"}},
 		{"literal single source", []string{"echo ok && false"}, false, map[int]bool{0: true}, []string{"echo ok && false"}},
 	}
@@ -1099,36 +1100,47 @@ func TestCommandIntentNativeTransport(t *testing.T) {
 		t.Skip("bash unavailable")
 	}
 	home := t.TempDir()
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "FOO=x"), []byte("#!/bin/sh\nprintf literal-executable\nexit 42\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	marker := filepath.Join(home, "must-not-exist")
 	tests := []struct {
 		name    string
 		command []string
 		shell   bool
 		want    string
 		code    int
+		literal map[int]bool
 	}{
-		{"literal arguments", []string{"printf", "<%s>", "a b", "", "$HOME", "$(printf bad)", "`bad`", "*.go", "a'b"}, false, "<a b><><$HOME><$(printf bad)><`bad`><*.go><a'b>", 0},
-		{"inferred source", []string{"printf '%s' 'raw source'"}, false, "raw source", 0},
-		{"operators", []string{"printf", "%s", "first", "&&", "printf", "%s", "second"}, false, "firstsecond", 0},
-		{"environment", []string{"CBX_NATIVE_VALUE=a b", "printenv", "CBX_NATIVE_VALUE"}, false, "a b\n", 0},
-		{"explicit source", []string{"printf '%s' 'explicit source'"}, true, "explicit source", 0},
-		{"empty source", []string{""}, true, "", 0},
-		{"nonzero exit", []string{"exit 42"}, true, "", 42},
+		{"literal arguments", []string{"printf", "<%s>", "a b", "", "$HOME", "$(printf bad)", "`bad`", "*.go", "a'b"}, false, "<a b><><$HOME><$(printf bad)><`bad`><*.go><a'b>", 0, nil},
+		{"inferred source", []string{"printf '%s' 'raw source'"}, false, "raw source", 0, nil},
+		{"operators", []string{"printf", "%s", "first", "&&", "printf", "%s", "second"}, false, "firstsecond", 0, nil},
+		{"environment", []string{"CBX_NATIVE_VALUE=a b", "printenv", "CBX_NATIVE_VALUE"}, false, "a b\n", 0, nil},
+		{"explicit source", []string{"printf '%s' 'explicit source'"}, true, "explicit source", 0, nil},
+		{"empty source", []string{""}, true, "", 0, nil},
+		{"nonzero exit", []string{"exit 42"}, true, "", 42, nil},
+		{"literal assignment executable", []string{"FOO=x"}, false, "literal-executable", 42, nil},
+		{"literal assignment with argument", []string{"FOO=x", "argument"}, false, "literal-executable", 42, map[int]bool{0: true}},
+		{"literal separator", []string{"printf", "%s", ";", "touch", marker}, false, ";touch" + marker, 0, map[int]bool{2: true}},
+		{"literal mixed with intentional operator", []string{"printf", "%s", ";", "&&", "printf", "%s", "done"}, false, ";done", 0, map[int]bool{2: true}},
 	}
 	for _, tt := range tests {
 		for _, serialized := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s/serialized=%t", tt.name, serialized), func(t *testing.T) {
-				intent, err := ParseCommandIntent(tt.command, tt.shell, nil)
+				intent, err := ParseCommandIntent(tt.command, tt.shell, tt.literal)
 				if err != nil {
 					t.Fatal(err)
 				}
 				argv := intent.Argv(bash, "-lc")
 				if serialized {
-					argv = []string{"/bin/sh", "-c", shellScriptFromArgv(argv)}
+					argv = []string{"/bin/sh", "-c", intent.ShellCommand(bash, "-lc")}
 				}
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
 				cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
-				cmd.Env = []string{"HOME=" + home, "PATH=" + filepath.Dir(bash) + ":/usr/bin:/bin", "BASH_ENV=" + os.DevNull, "ENV=" + os.DevNull}
+				cmd.Env = []string{"HOME=" + home, "PATH=" + bin + ":" + filepath.Dir(bash) + ":/usr/bin:/bin", "BASH_ENV=" + os.DevNull, "ENV=" + os.DevNull}
 				out, err := cmd.CombinedOutput()
 				code := 0
 				if err != nil {
@@ -1143,6 +1155,9 @@ func TestCommandIntentNativeTransport(t *testing.T) {
 				}
 			})
 		}
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("literal separator created marker: %v", err)
 	}
 }
 

--- a/internal/providers/cloudflaresandbox/backend.go
+++ b/internal/providers/cloudflaresandbox/backend.go
@@ -179,12 +179,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			return b.ensureWorkspace(ctx, api, sandboxID, workdir)
 		},
 		Command: func(context.Context) (shared.DelegatedSandboxCommand, error) {
-			intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, nil)
+			intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
 			if err != nil {
 				return shared.DelegatedSandboxCommand{}, err
 			}
-			command := intent.Argv("bash", "-lc")
-			commandText := commandScript(command)
+			commandText := intent.ShellCommand("bash", "-lc")
 			commandEnv, strippedAuthEnv := cloudflareSandboxCommandEnv(req.Env)
 			if len(strippedAuthEnv) > 0 {
 				fmt.Fprintf(b.rt.Stderr, "warning: provider=%s did not forward provider authentication variables: %s\n", providerName, strings.Join(strippedAuthEnv, ","))
@@ -842,10 +841,6 @@ func newSandboxName(repo Repo) string {
 		return base + "-" + hex.EncodeToString(token[:])
 	}
 	return fmt.Sprintf("%s-%x", base, time.Now().UnixNano()&0xffffffff)
-}
-
-func commandScript(command []string) string {
-	return shellScriptFromArgv(command)
 }
 
 type cloudflareSandboxNotFoundError struct {

--- a/internal/providers/cloudflaresandbox/backend_test.go
+++ b/internal/providers/cloudflaresandbox/backend_test.go
@@ -313,8 +313,9 @@ func TestRunOneShotSyncsExecutesAndDeletes(t *testing.T) {
 	fake.stdout = "ok\n"
 	backend := testBackend(fake, &stdout, &stderr)
 	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: repo},
-		Command: []string{"echo", "ok"},
+		Repo:               Repo{Name: "my-app", Root: repo},
+		Command:            []string{"echo", "ok", "&&"},
+		CommandLiteralArgs: map[int]bool{2: true},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -342,6 +343,9 @@ func TestRunOneShotSyncsExecutesAndDeletes(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "ok\n") {
 		t.Fatalf("stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if result.CommandText != "'echo' 'ok' '&&'" {
+		t.Fatalf("literal intent lost in final payload: %q", result.CommandText)
 	}
 }
 

--- a/internal/providers/cloudflaresandbox/core.go
+++ b/internal/providers/cloudflaresandbox/core.go
@@ -98,10 +98,6 @@ func cloudflareSandboxCleanupCommand(leaseID string) string {
 	return "crabbox stop --provider " + providerName + " --id " + shellQuote(leaseID)
 }
 
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
 	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
 }

--- a/internal/providers/crownest/backend.go
+++ b/internal/providers/crownest/backend.go
@@ -159,12 +159,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 			}
 		}()
 	}
-	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, nil)
+	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
 	if err != nil {
 		return RunResult{}, err
 	}
-	command := intent.Argv("bash", "-lc")
-	commandText := shellScriptFromArgv(command)
+	commandText := intent.ShellCommand("bash", "-lc")
 	commandEnv, stripped := commandEnv(req.Env)
 	if len(stripped) > 0 {
 		fmt.Fprintf(b.rt.Stderr, "warning: provider=crownest did not forward provider authentication variables: %s\n", strings.Join(stripped, ","))

--- a/internal/providers/crownest/backend_test.go
+++ b/internal/providers/crownest/backend_test.go
@@ -32,8 +32,9 @@ func TestRunUploadsArchiveStreamsLogsAndCleansUp(t *testing.T) {
 	}
 
 	result, err := b.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: repoRoot, Name: "demo"},
-		Command: []string{"pnpm", "test"},
+		Repo:               Repo{Root: repoRoot, Name: "demo"},
+		Command:            []string{"pnpm", "test", "&&"},
+		CommandLiteralArgs: map[int]bool{2: true},
 	})
 	if err != nil {
 		t.Fatalf("Run err=%v", err)
@@ -66,6 +67,9 @@ func TestRunUploadsArchiveStreamsLogsAndCleansUp(t *testing.T) {
 	}
 	if claim, err := readLeaseClaim(result.LeaseID); err != nil || claim.LeaseID != "" {
 		t.Fatalf("claim=%#v err=%v, want one-shot local claim removed without sandbox delete", claim, err)
+	}
+	if result.CommandText != "'pnpm' 'test' '&&'" {
+		t.Fatalf("literal intent lost in final payload: %q", result.CommandText)
 	}
 }
 

--- a/internal/providers/crownest/core.go
+++ b/internal/providers/crownest/core.go
@@ -84,10 +84,6 @@ func removeLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
 	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
 }
 
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
 func shellQuote(value string) string {
 	return core.ShellQuote(value)
 }

--- a/internal/providers/nomad/core.go
+++ b/internal/providers/nomad/core.go
@@ -80,10 +80,6 @@ func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []s
 	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
 }
 
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
 func shellQuote(value string) string {
 	return core.ShellQuote(value)
 }

--- a/internal/providers/nomad/exec.go
+++ b/internal/providers/nomad/exec.go
@@ -49,15 +49,14 @@ func (b *backend) execShell(ctx context.Context, client Client, ready allocation
 }
 
 func (b *backend) runCommand(ctx context.Context, client Client, ready allocationReadiness, req RunRequest, workdir string) (int, error) {
-	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, nil)
+	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
 	if err != nil {
 		return 0, err
 	}
-	command := intent.Argv("bash", "-lc")
 	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
 		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
-	script := remoteCommandScript(workdir, req.Env, command)
+	script := remoteCommandScript(workdir, req.Env, intent)
 	execCtx, cancel := b.execContext(ctx)
 	defer cancel()
 	exitCode, err := b.allocationExec(execCtx, client, ready, []string{"sh", "-s"}, strings.NewReader(script), b.rt.Stdout, b.rt.Stderr)
@@ -101,7 +100,7 @@ func normalizeExitCode(code int) int {
 	return code
 }
 
-func remoteCommandScript(workdir string, env map[string]string, command []string) string {
+func remoteCommandScript(workdir string, env map[string]string, command core.CommandIntent) string {
 	var b strings.Builder
 	b.WriteString("mkdir -p ")
 	b.WriteString(shellQuote(workdir))
@@ -117,7 +116,7 @@ func remoteCommandScript(workdir string, env map[string]string, command []string
 		b.WriteString(shellQuote(value))
 	}
 	b.WriteString(" && exec ")
-	b.WriteString(shellScriptFromArgv(command))
+	b.WriteString(command.ShellCommand("bash", "-lc"))
 	return b.String()
 }
 

--- a/internal/providers/nomad/lifecycle_test.go
+++ b/internal/providers/nomad/lifecycle_test.go
@@ -666,11 +666,12 @@ func TestRunNoSyncPropagatesRemoteExitAndCleansNewJob(t *testing.T) {
 	}
 	b, stdout, stderr := testBackend(t, fake)
 	result, err := b.Run(context.Background(), RunRequest{
-		ID:      " \t ",
-		Repo:    newNomadRunRepo(t),
-		NoSync:  true,
-		Env:     map[string]string{"TOKEN": "secret", "BAD-NAME": "skip"},
-		Command: []string{"go", "test", "./..."},
+		ID:                 " \t ",
+		Repo:               newNomadRunRepo(t),
+		NoSync:             true,
+		Env:                map[string]string{"TOKEN": "secret", "BAD-NAME": "skip"},
+		Command:            []string{"go", "test", "./...", "&&"},
+		CommandLiteralArgs: map[int]bool{3: true},
 	})
 	var exitErr ExitError
 	if !core.AsExitError(err, &exitErr) || exitErr.Code != 23 {
@@ -689,6 +690,9 @@ func TestRunNoSyncPropagatesRemoteExitAndCleansNewJob(t *testing.T) {
 	if len(fake.execs) < 2 || !strings.Contains(fake.execs[1].Stdin, "export TOKEN='secret'") ||
 		strings.Contains(fake.execs[1].Stdin, "BAD-NAME") {
 		t.Fatalf("execs=%#v", fake.execs)
+	}
+	if !strings.HasSuffix(fake.execs[1].Stdin, " && exec 'go' 'test' './...' '&&'") {
+		t.Fatalf("literal intent lost in final stdin: %q", fake.execs[1].Stdin)
 	}
 }
 
@@ -1100,4 +1104,35 @@ func mapValues(values map[string]string) []string {
 		out = append(out, value)
 	}
 	return out
+}
+
+func TestRunLiteralArgumentsSurviveNativeStdinTransport(t *testing.T) {
+	if os.PathSeparator != '/' {
+		t.Skip("POSIX stdin transport")
+	}
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh unavailable")
+	}
+	fake := newLifecycleFakeClient()
+	b, _, _ := testBackend(t, fake)
+	workdir := t.TempDir()
+	marker := filepath.Join(workdir, "must-not-exist")
+	_, err = b.runCommand(context.Background(), fake, allocationReadiness{JobID: "job", AllocationID: "alloc", Task: "task"}, RunRequest{Command: []string{"printf", "%s", ";", "touch", marker}, CommandLiteralArgs: map[int]bool{2: true}}, workdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.execs) != 1 {
+		t.Fatalf("execs=%+v", fake.execs)
+	}
+	cmd := exec.Command(sh, "-s")
+	cmd.Stdin = strings.NewReader(fake.execs[0].Stdin)
+	cmd.Env = []string{"HOME=" + workdir, "PATH=/usr/bin:/bin", "ENV=" + os.DevNull}
+	out, err := cmd.CombinedOutput()
+	if err != nil || string(out) != ";touch"+marker {
+		t.Fatalf("stdin=%q output=%q err=%v", fake.execs[0].Stdin, out, err)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("literal semicolon created marker: %v", err)
+	}
 }

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -293,12 +293,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		return result, nil
 	}
 
-	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, nil)
+	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
 	if err != nil {
 		return RunResult{}, err
 	}
-	command := intent.Argv("bash", "-lc")
-	commandText := commandScript(command)
+	commandText := intent.ShellCommand("bash", "-lc")
 	commandEnv, strippedAuthEnv := superserveCommandEnv(req.Env)
 	if len(strippedAuthEnv) > 0 {
 		fmt.Fprintf(b.rt.Stderr, "warning: provider=superserve did not forward provider authentication variables: %s\n", strings.Join(strippedAuthEnv, ","))
@@ -948,10 +947,6 @@ func superserveCommandEnv(env map[string]string) (map[string]string, []string) {
 	}
 	slices.Sort(stripped)
 	return out, stripped
-}
-
-func commandScript(command []string) string {
-	return shellScriptFromArgv(command)
 }
 
 func (b *backend) now() time.Time {

--- a/internal/providers/superserve/backend_test.go
+++ b/internal/providers/superserve/backend_test.go
@@ -396,9 +396,10 @@ func TestRunNoSyncExecForwardsEnvInRequestBodyAndMirrorsOutput(t *testing.T) {
 	backend.rt.Stderr = &stderr
 
 	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: t.TempDir()},
-		NoSync:  true,
-		Command: []string{"go", "test", "./..."},
+		Repo:               Repo{Name: "my-app", Root: t.TempDir()},
+		NoSync:             true,
+		Command:            []string{"go", "test", "./...", "&&"},
+		CommandLiteralArgs: map[int]bool{3: true},
 		Env: map[string]string{
 			"CRABBOX_SUPERSERVE_API_KEY": "crabbox_ss_test_not_real",
 			"SUPERSERVE_API_KEY":         "ss_test_not_real",
@@ -435,7 +436,7 @@ func TestRunNoSyncExecForwardsEnvInRequestBodyAndMirrorsOutput(t *testing.T) {
 		t.Fatalf("execs=%#v", fake.execs)
 	}
 	commandReq := fake.execs[1]
-	if commandReq.Command != "'go' 'test' './...'" || commandReq.WorkingDir != defaultWorkdir || commandReq.TimeoutSecs != backend.cfg.Superserve.ExecTimeoutSecs {
+	if commandReq.Command != "'go' 'test' './...' '&&'" || commandReq.WorkingDir != defaultWorkdir || commandReq.TimeoutSecs != backend.cfg.Superserve.ExecTimeoutSecs {
 		t.Fatalf("command req=%#v", commandReq)
 	}
 	if commandReq.Env["PROJECT_TOKEN"] != "project_test_not_real" || commandReq.Env["CI"] != "1" {
@@ -935,4 +936,34 @@ func cloneMap(in map[string]string) map[string]string {
 func cloneSandbox(in superserveSandbox) superserveSandbox {
 	in.Metadata = cloneMap(in.Metadata)
 	return in
+}
+
+func TestRunLiteralExecutableSurvivesFinalShellTransport(t *testing.T) {
+	if os.PathSeparator != '/' {
+		t.Skip("POSIX shell transport")
+	}
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh unavailable")
+	}
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "FOO=x"), []byte("#!/bin/sh\nprintf literal-executable\nexit 42\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	fake := newFakeSuperserveClient()
+	backend := newSuperserveTestBackend(t, fake)
+	result, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, NoSync: true, Command: []string{"FOO=x"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.execs) < 2 || fake.execs[len(fake.execs)-1].Command != result.CommandText {
+		t.Fatalf("missing final request: %+v", fake.execs)
+	}
+	cmd := exec.Command(sh, "-c", fake.execs[len(fake.execs)-1].Command)
+	cmd.Env = []string{"PATH=" + bin + ":/usr/bin:/bin", "HOME=" + t.TempDir(), "ENV=" + os.DevNull}
+	out, err := cmd.CombinedOutput()
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) || ee.ExitCode() != 42 || string(out) != "literal-executable" {
+		t.Fatalf("payload=%q output=%q error=%v, want executable/42", result.CommandText, out, err)
+	}
 }

--- a/internal/providers/superserve/core.go
+++ b/internal/providers/superserve/core.go
@@ -106,10 +106,6 @@ func superserveCleanupCommand(leaseID string) string {
 	return "crabbox stop --provider " + providerName + " --id " + shellQuote(leaseID)
 }
 
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
 func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
 	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }

--- a/internal/providers/vercelsandbox/backend.go
+++ b/internal/providers/vercelsandbox/backend.go
@@ -230,12 +230,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		return result, activityErr
 	}
 
-	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, nil)
+	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
 	if err != nil {
 		return finishResult(RunResult{}), err
 	}
-	command := intent.Argv("bash", "-lc")
-	commandText := commandScript(command)
+	commandText := intent.ShellCommand("bash", "-lc")
 	commandEnv, strippedAuthEnv := vercelSandboxCommandEnv(req.Env)
 	if len(strippedAuthEnv) > 0 {
 		fmt.Fprintf(b.rt.Stderr, "warning: provider=%s did not forward provider authentication variables: %s\n", providerName, strings.Join(strippedAuthEnv, ","))
@@ -1011,10 +1010,6 @@ func vercelSandboxCommandEnv(env map[string]string) (map[string]string, []string
 	}
 	slices.Sort(stripped)
 	return out, stripped
-}
-
-func commandScript(command []string) string {
-	return shellScriptFromArgv(command)
 }
 
 type vercelSandboxNotFoundError struct {

--- a/internal/providers/vercelsandbox/backend_test.go
+++ b/internal/providers/vercelsandbox/backend_test.go
@@ -190,8 +190,9 @@ func TestRunOneShotSyncsExecutesAndDeletes(t *testing.T) {
 	fake.stdout = "ok\n"
 	backend := testBackend(fake, &stdout, &stderr)
 	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: repo},
-		Command: []string{"echo", "ok"},
+		Repo:               Repo{Name: "my-app", Root: repo},
+		Command:            []string{"echo", "ok", "&&"},
+		CommandLiteralArgs: map[int]bool{2: true},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -216,6 +217,9 @@ func TestRunOneShotSyncsExecutesAndDeletes(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "ok\n") {
 		t.Fatalf("stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if result.CommandText != "'echo' 'ok' '&&'" {
+		t.Fatalf("literal intent lost in final payload: %q", result.CommandText)
 	}
 }
 

--- a/internal/providers/vercelsandbox/core.go
+++ b/internal/providers/vercelsandbox/core.go
@@ -108,10 +108,6 @@ func shellQuote(value string) string {
 	return core.ShellQuote(value)
 }
 
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
 func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
 	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }


### PR DESCRIPTION
## Summary

Classify command intent once, then quote its execution argv without interpreting it again. Apply this to the five adapters already using the shared command-intent owner: Cloudflare Sandbox, Superserve, Crownest, Vercel Sandbox and Nomad.

Profile expansion already knows which arguments are literal, but the delegated RunRequest handoff dropped that metadata. The adapters then called an operator-aware renderer on already-classified execution argv. As a concrete result, an executable named `FOO=x` could become an assignment that silently succeeded instead of invoking the executable and returning its exit status.

- Preserve an owned copy of profile literal positions in the ordinary run and prewarm request projections.
- Respect a marked literal first argument during assignment inference.
- Add CommandIntent.ShellCommand for literal POSIX transport quoting and remove the five adapters' old rendering wrappers.
- Preserve existing explicit-shell behavior, shell prefixes, native argv/stdin/API transports, environment filtering, cwd, lifecycle and cleanup ownership.

Docs and a maintainer Unreleased entry describe the user-visible fixes. No dependencies, configuration or secrets are changed. This does not standardize the ambiguous single-string behavior of every other provider.

## Proof

Two focused regressions failed before the patch: the final Superserve payload was `FOO='x'` and exited 0 without running the fixture executable, and a marked literal first word incorrectly introduced a Bash layer. Both now pass.

The actual App.Run profile test verifies exact argv and literal positions at both provider admission and delegated execution, including literal `&&` adjacent to a genuine operator. Existing lifecycle tests exercise final command payloads in all five adapters.

Native interpreter proof executes 22 direct/string-transport cases with real Bash/sh, covering quoted arguments, command substitutions as data, glob text, intentional operators and assignments, explicit/empty shell source, exit 42, assignment-shaped executable names and literal separators. The separator marker remains absent. Two additional tests execute the actual captured Superserve API payload and Nomad stdin script through real local shells. All pass with no skips. These are synthetic local interpreter/transport checks, not hosted cloud-account lifecycle claims.

All five adapter race suites and focused core/profile/prewarm race tests pass. Vet, CLI build, docs generation and whole-repository dead-code checks pass. Managed review is clean at the configured blocking threshold; independent semantic review found no actionable production issue. The first expanded native test needed its fixture binary directory in the test process PATH as well as the child environment; that harness setup was corrected before the final native run.
