### PR TITLE
fix: stop fresh acquisition retries after rollback failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Stop direct AWS, Azure, GCP, and Hetzner bootstrap retries from allocating another machine when rollback reports a cleanup failure, preserving both the original failure and cleanup diagnostics.
+
 - Preserve existing Cloudflare container workspaces when sync upload or extraction fails, clean partial archives, and enforce full-checkout size limits before fresh allocation. [PR 1814](https://github.com/openclaw/crabbox/pull/1814). Thanks @steipete.
 - Protect Nomad runs from overwriting replacement claims or recreating retired leases, and expose standard run-session handles with cleanup-aware final outcomes that preserve the original command exit. [PR 1810](https://github.com/openclaw/crabbox/pull/1810). Thanks @steipete.
 - Preserve individual AWS, Azure, and GCP candidate failures in successful leases' provisioning history across market and regional fallback, including previously omitted GCP on-demand failures. [PR 1811](https://github.com/openclaw/crabbox/pull/1811). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Stop direct AWS, Azure, GCP, and Hetzner bootstrap retries from allocating another machine when rollback reports a cleanup failure, preserving both the original failure and cleanup diagnostics.
+- Stop direct AWS, Azure, GCP, and Hetzner bootstrap retries from allocating another machine when rollback reports a cleanup failure, preserving both the original failure and cleanup diagnostics. [PR 1819](https://github.com/openclaw/crabbox/pull/1819). Thanks @steipete.
 - Cloudflare: retain recovery claims when teardown fails, preserve command/cancellation outcomes, and fence reuse and cleanup against replaced local claims. [PR 1817](https://github.com/openclaw/crabbox/pull/1817). Thanks @steipete.
 - Preserve existing Cloudflare container workspaces when sync upload or extraction fails, clean partial archives, and enforce full-checkout size limits before fresh allocation. [PR 1814](https://github.com/openclaw/crabbox/pull/1814). Thanks @steipete.
 - Protect Nomad runs from overwriting replacement claims or recreating retired leases, and expose standard run-session handles with cleanup-aware final outcomes that preserve the original command exit. [PR 1810](https://github.com/openclaw/crabbox/pull/1810). Thanks @steipete.

--- a/docs/features/lifecycle-cleanup.md
+++ b/docs/features/lifecycle-cleanup.md
@@ -365,6 +365,17 @@ Without a coordinator, the CLI talks to the provider API directly and owns
 cleanup itself. Releasing a direct lease (`crabbox stop` / `crabbox release`)
 deletes the backing machine immediately.
 
+Ordinary direct AWS, Azure, GCP, and Hetzner acquisition can retry a bootstrap
+timeout with a fresh lease. If rollback reports a cleanup failure, acquisition
+stops instead: the original failure and cleanup diagnostics remain available,
+and no second allocation is attempted. This consumes each adapter's existing
+cleanup result; it does not give all providers the same deletion-confirmation
+guarantee. AWS termination acceptance and Hetzner DELETE success still differ
+from GCP operation completion and Azure's dependent-resource absence checks.
+GCP also stops retrying if its selected-scope cleanup client cannot be rebuilt,
+even if the existing best-effort fallback client returns success. That fallback
+does not establish that the selected project and zone were cleaned.
+
 `crabbox cleanup` (alias `crabbox machine cleanup`) sweeps expired
 direct-provider machines and stale local state. It refuses to run when a
 coordinator is configured, because sweeping provider resources can race live

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -69,7 +69,7 @@ func (b *awsLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (Leas
 	})
 }
 
-func (b *awsLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (LeaseTarget, error) {
+func (b *awsLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (result LeaseTarget, retErr error) {
 	if b.Cfg.Tailscale.Enabled && b.Cfg.Tailscale.AuthKey == "" {
 		return LeaseTarget{}, exit(2, "direct --tailscale requires %s to contain a Tailscale auth key; brokered mode uses coordinator OAuth secrets", b.Cfg.Tailscale.AuthKeyEnv)
 	}
@@ -111,7 +111,7 @@ func (b *awsLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedS
 		}
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), awsAcquireRollbackTimeout)
 		defer cancel()
-		cleanupAWSCreatedResources(cleanupCtx, b.RT.Stderr, cfg, rollbackCloudID, rollbackKeyID)
+		retErr = shared.JoinAcquireCleanupError(retErr, cleanupAWSCreatedResources(cleanupCtx, b.RT.Stderr, cfg, rollbackCloudID, rollbackKeyID))
 	}()
 	client, err = newAWSClient(ctx, cfg)
 	if err != nil {
@@ -1093,22 +1093,26 @@ func (e *awsProviderKeyCleanupError) Error() string {
 
 func (e *awsProviderKeyCleanupError) Unwrap() error { return e.err }
 
-func cleanupAWSCreatedResources(ctx context.Context, stderr io.Writer, cfg Config, cloudID, keyPairID string) {
+func cleanupAWSCreatedResources(ctx context.Context, stderr io.Writer, cfg Config, cloudID, keyPairID string) error {
 	client, err := newAWSClient(ctx, cfg)
 	if err != nil {
 		fmt.Fprintf(stderr, "warning: create aws cleanup client for %s region=%s: %v\n", cloudID, cfg.AWSRegion, err)
-		return
+		return fmt.Errorf("create aws cleanup client for %s region=%s: %w", cloudID, cfg.AWSRegion, err)
 	}
+	var cleanupErr error
 	if strings.TrimSpace(cloudID) != "" {
 		if err := client.DeleteServer(ctx, cloudID); err != nil {
 			fmt.Fprintf(stderr, "warning: cleanup aws instance %s after acquire failure: %v\n", cloudID, err)
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("cleanup aws instance %s after acquire failure: %w", cloudID, err))
 		}
 	}
 	if strings.TrimSpace(keyPairID) != "" {
 		if err := client.DeleteCleanupSSHKeyID(ctx, keyPairID); err != nil {
 			fmt.Fprintf(stderr, "warning: cleanup aws key pair %s after acquire failure: %v\n", keyPairID, err)
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("cleanup aws key pair %s after acquire failure: %w", keyPairID, err))
 		}
 	}
+	return cleanupErr
 }
 
 func awsRegionConfigs(cfg Config) []Config {

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -2091,6 +2092,71 @@ func TestAWSAcquireUsesTailscaleHostnameOnlyForStrictMode(t *testing.T) {
 			}
 			if bootstrapHost != test.want {
 				t.Fatalf("bootstrap host=%q, want %q", bootstrapHost, test.want)
+			}
+		})
+	}
+}
+
+func TestAWSAcquireStopsFreshRetryAfterRollbackFailure(t *testing.T) {
+	for _, failure := range []string{"none", "instance", "key", "client"} {
+		t.Run(failure, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			primary := core.Exit(5, "timed out waiting for SSH: fixture")
+			debt := errors.New("cleanup unavailable")
+			fake := &fakeAWSClient{}
+			if failure == "instance" {
+				fake.deleteServerErr = debt
+			}
+			if failure == "key" {
+				fake.deleteKeyErr = debt
+			}
+			oldClient, oldBootstrap := newAWSClient, bootstrapAWSWindowsDesktop
+			bootstrapReached := false
+			newAWSClient = func(ctx context.Context, _ Config) (awsClient, error) {
+				if failure == "client" && bootstrapReached {
+					if _, bounded := ctx.Deadline(); bounded {
+						return nil, debt
+					}
+				}
+				return fake, nil
+			}
+			bootstrapAWSWindowsDesktop = func(context.Context, Config, *SSHTarget, string, io.Writer) error {
+				bootstrapReached = true
+				return primary
+			}
+			t.Cleanup(func() { newAWSClient = oldClient; bootstrapAWSWindowsDesktop = oldBootstrap })
+			var stderr bytes.Buffer
+			cfg := Config{Provider: "aws", AWSRegion: "us-east-1", AWSSSHCIDRs: []string{"198.51.100.7/32"}}
+			b := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+			_, err := b.Acquire(context.Background(), AcquireRequest{})
+			want := 1
+			if failure == "none" {
+				want = 2
+			}
+			if fake.createCalls != want || !errors.Is(err, primary) {
+				t.Fatalf("creates=%d error=%v", fake.createCalls, err)
+			}
+			wantCleanup := want
+			if failure == "client" {
+				wantCleanup = 0
+			}
+			if len(fake.deletedInstances) != wantCleanup || len(fake.deletedKeys) != wantCleanup {
+				t.Fatalf("cleanup changed: instances=%v keys=%v", fake.deletedInstances, fake.deletedKeys)
+			}
+			for _, id := range fake.deletedInstances {
+				if id != fake.created.CloudID {
+					t.Fatalf("wrong instance cleanup: %v", fake.deletedInstances)
+				}
+			}
+			for _, id := range fake.deletedKeys {
+				if id != fake.created.Labels["aws_key_pair_id"] {
+					t.Fatalf("wrong key cleanup: %v", fake.deletedKeys)
+				}
+			}
+			if failure != "none" && (!errors.Is(err, debt) || strings.Contains(stderr.String(), "retrying with fresh lease")) {
+				t.Fatalf("cleanup debt lost: error=%v stderr=%s", err, stderr.String())
 			}
 		})
 	}

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -57,7 +57,7 @@ func (b *azureLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (Le
 	})
 }
 
-func (b *azureLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (LeaseTarget, error) {
+func (b *azureLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (result LeaseTarget, retErr error) {
 	cfg := b.Cfg
 	if cfg.Tailscale.Enabled && cfg.Tailscale.AuthKey == "" {
 		return LeaseTarget{}, exit(2, "direct --tailscale requires %s to contain a Tailscale auth key; brokered mode uses coordinator OAuth secrets", cfg.Tailscale.AuthKeyEnv)
@@ -102,6 +102,7 @@ func (b *azureLeaseBackend) acquireOnce(ctx context.Context, keep bool, requeste
 		defer cancel()
 		if err := client.DeleteServer(cleanupCtx, rollbackCloudID); err != nil {
 			fmt.Fprintf(b.RT.Stderr, "warning: cleanup azure server %s after acquire failure: %v\n", rollbackCloudID, err)
+			retErr = shared.JoinAcquireCleanupError(retErr, fmt.Errorf("cleanup azure server %s after acquire failure: %w", rollbackCloudID, err))
 		}
 	}()
 	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s server=%s type=%s\n", leaseID, server.DisplayID(), cfg.ServerType)

--- a/internal/providers/azure/backend_test.go
+++ b/internal/providers/azure/backend_test.go
@@ -1,8 +1,10 @@
 package azure
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"maps"
 	"os"
@@ -23,6 +25,8 @@ type fakeAzureClient struct {
 	prepareOwned      []Server
 	prepareFunc       func(Server) Server
 	prepareErr        error
+	deleteErr         error
+	createLeaseIDs    []string
 	deleteOwnedFunc   func(Server) error
 	deleteCleanupFunc func(Server) error
 	tagged            []string
@@ -55,7 +59,8 @@ func (c *fakeAzureClient) ListCrabboxServers(context.Context) ([]Server, error) 
 	return c.servers, nil
 }
 
-func (c *fakeAzureClient) CreateServerWithFallback(context.Context, Config, string, string, string, bool, func(string, ...any)) (Server, Config, error) {
+func (c *fakeAzureClient) CreateServerWithFallback(_ context.Context, _ Config, _ string, leaseID string, _ string, _ bool, _ func(string, ...any)) (Server, Config, error) {
+	c.createLeaseIDs = append(c.createLeaseIDs, leaseID)
 	if c.createErr != nil {
 		return Server{}, Config{}, c.createErr
 	}
@@ -95,7 +100,7 @@ func (c *fakeAzureClient) GetServer(_ context.Context, id string) (Server, error
 
 func (c *fakeAzureClient) DeleteServer(_ context.Context, name string) error {
 	c.deleted = append(c.deleted, name)
-	return nil
+	return c.deleteErr
 }
 
 func (c *fakeAzureClient) PrepareOwnedServer(_ context.Context, server Server) (Server, error) {
@@ -824,4 +829,39 @@ func storeAzureTestClaim(t *testing.T, server Server) core.LeaseClaim {
 		t.Fatalf("claim exists=%v err=%v", exists, err)
 	}
 	return claim
+}
+
+func TestAzureAcquireStopsFreshRetryAfterRollbackFailure(t *testing.T) {
+	for _, failed := range []bool{false, true} {
+		t.Run(fmt.Sprint(failed), func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			primary := core.Exit(5, "timed out waiting for SSH: fixture")
+			fake := &fakeAzureClient{createCfg: azureAcquireTestConfig()}
+			if failed {
+				fake.deleteErr = errors.New("delete unavailable")
+			}
+			oldClient, oldBootstrap := newAzureClient, bootstrapManagedWindowsDesktop
+			newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+			bootstrapManagedWindowsDesktop = func(context.Context, Config, *SSHTarget, string, io.Writer) error { return primary }
+			t.Cleanup(func() { newAzureClient = oldClient; bootstrapManagedWindowsDesktop = oldBootstrap })
+			var stderr bytes.Buffer
+			b := NewAzureLeaseBackend(ProviderSpec{}, fake.createCfg, Runtime{Stderr: &stderr}).(*azureLeaseBackend)
+			_, err := b.Acquire(context.Background(), AcquireRequest{})
+			want := 2
+			if failed {
+				want = 1
+			}
+			if len(fake.createLeaseIDs) != want || len(fake.deleted) != want || !errors.Is(err, primary) {
+				t.Fatalf("creates=%v deletes=%v error=%v", fake.createLeaseIDs, fake.deleted, err)
+			}
+			if !failed && fake.createLeaseIDs[0] == fake.createLeaseIDs[1] {
+				t.Fatal("retry reused lease identity")
+			}
+			if failed && (!errors.Is(err, fake.deleteErr) || strings.Contains(stderr.String(), "retrying with fresh lease")) {
+				t.Fatalf("cleanup debt lost: error=%v stderr=%s", err, stderr.String())
+			}
+		})
+	}
 }

--- a/internal/providers/gcp/backend.go
+++ b/internal/providers/gcp/backend.go
@@ -3,7 +3,6 @@ package gcp
 import (
 	"context"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 
@@ -49,7 +48,7 @@ func (b *gcpLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (Leas
 	})
 }
 
-func (b *gcpLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (LeaseTarget, error) {
+func (b *gcpLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (result LeaseTarget, retErr error) {
 	if b.Cfg.Tailscale.Enabled && b.Cfg.Tailscale.AuthKey == "" {
 		return LeaseTarget{}, exit(2, "direct --tailscale requires %s to contain a Tailscale auth key; brokered mode uses coordinator OAuth secrets", b.Cfg.Tailscale.AuthKeyEnv)
 	}
@@ -93,10 +92,12 @@ func (b *gcpLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedS
 		cleanupClient, cleanupClientErr := newGCPClient(cleanupCtx, cfg)
 		if cleanupClientErr != nil {
 			fmt.Fprintf(b.RT.Stderr, "warning: create gcp cleanup client for %s: %v\n", rollbackCloudID, cleanupClientErr)
+			retErr = shared.JoinAcquireCleanupError(retErr, fmt.Errorf("create gcp cleanup client for %s project=%s zone=%s: %w", rollbackCloudID, cfg.GCPProject, cfg.GCPZone, cleanupClientErr))
 			cleanupClient = rollbackClient
 		}
 		if err := cleanupClient.DeleteServer(cleanupCtx, rollbackCloudID); err != nil {
 			fmt.Fprintf(b.RT.Stderr, "warning: cleanup gcp server %s after acquire failure: %v\n", rollbackCloudID, err)
+			retErr = shared.JoinAcquireCleanupError(retErr, fmt.Errorf("cleanup gcp server %s after acquire failure: %w", rollbackCloudID, err))
 		}
 	}()
 	client, err = newGCPClient(ctx, cfg)
@@ -470,9 +471,9 @@ func providerKeyForLease(leaseID string) string { return core.ProviderKeyForLeas
 func sshTargetFromConfig(cfg Config, host string) SSHTarget {
 	return core.SSHTargetFromConfig(cfg, host)
 }
-func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
-	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
-}
+
+var waitForSSHReady = core.WaitForSSHReady
+
 func bootstrapWaitTimeout(cfg Config) time.Duration { return core.BootstrapWaitTimeout(cfg) }
 func blank(value, fallback string) string           { return core.Blank(value, fallback) }
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {

--- a/internal/providers/gcp/backend_doctor_test.go
+++ b/internal/providers/gcp/backend_doctor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"maps"
 	"net/http"
@@ -16,17 +17,19 @@ import (
 )
 
 type fakeGCPDoctorClient struct {
-	listCalls int
-	deleted   []string
-	mutated   bool
-	servers   []Server
-	complete  []Server
-	get       map[string]Server
-	getErr    error
-	created   Server
-	createCfg Config
-	createErr error
-	waitErr   error
+	listCalls   int
+	deleted     []string
+	mutated     bool
+	servers     []Server
+	complete    []Server
+	get         map[string]Server
+	getErr      error
+	created     Server
+	createCfg   Config
+	createErr   error
+	waitErr     error
+	deleteErr   error
+	createCalls int
 }
 
 func (c *fakeGCPDoctorClient) ListCrabboxServers(context.Context) ([]Server, error) {
@@ -43,6 +46,7 @@ func (c *fakeGCPDoctorClient) ListCrabboxServersComplete(context.Context) ([]Ser
 }
 
 func (c *fakeGCPDoctorClient) CreateServerWithFallback(context.Context, Config, string, string, string, bool, func(string, ...any)) (Server, Config, error) {
+	c.createCalls++
 	c.mutated = true
 	if c.createErr != nil {
 		return Server{}, Config{}, c.createErr
@@ -75,7 +79,7 @@ func (c *fakeGCPDoctorClient) GetServer(_ context.Context, name string) (Server,
 func (c *fakeGCPDoctorClient) DeleteServer(_ context.Context, name string) error {
 	c.deleted = append(c.deleted, name)
 	c.mutated = true
-	return nil
+	return c.deleteErr
 }
 
 func (c *fakeGCPDoctorClient) SetLabels(context.Context, string, map[string]string) error {
@@ -630,5 +634,71 @@ func TestGCPDoctorListsInventoryOnly(t *testing.T) {
 	}
 	if fake.mutated {
 		t.Fatal("doctor called a mutating GCP method")
+	}
+}
+
+func TestGCPAcquireStopsFreshRetryAfterRollbackFailure(t *testing.T) {
+	for _, failed := range []bool{false, true} {
+		t.Run(fmt.Sprint(failed), func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			bootstrapErr := core.Exit(5, "timed out waiting for SSH: fixture readiness failure")
+			oldWait := waitForSSHReady
+			waitForSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error { return bootstrapErr }
+			t.Cleanup(func() { waitForSSHReady = oldWait })
+			fake := &fakeGCPDoctorClient{created: Server{CloudID: "crabbox-created", Labels: map[string]string{}}, createCfg: Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}}
+			if failed {
+				fake.deleteErr = errors.New("delete unavailable")
+			}
+			old := newGCPClient
+			newGCPClient = func(context.Context, Config) (gcpClient, error) { return fake, nil }
+			t.Cleanup(func() { newGCPClient = old })
+			var stderr bytes.Buffer
+			backend := NewGCPLeaseBackend(core.ProviderSpec{}, fake.createCfg, Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
+			_, err := backend.Acquire(context.Background(), AcquireRequest{})
+			want := 2
+			if failed {
+				want = 1
+			}
+			if fake.createCalls != want || len(fake.deleted) != want {
+				t.Fatalf("creates=%d deletes=%d want=%d error=%v", fake.createCalls, len(fake.deleted), want, err)
+			}
+			if !core.IsBootstrapWaitError(err) {
+				t.Fatalf("lost original bootstrap cause: %v", err)
+			}
+			if failed && (!errors.Is(err, fake.deleteErr) || strings.Contains(stderr.String(), "retrying with fresh lease")) {
+				t.Fatalf("lost cleanup debt or retried: error=%v stderr=%s", err, stderr.String())
+			}
+		})
+	}
+}
+
+func TestGCPAcquireRetainsCleanupClientFailureDespiteFallbackSuccess(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	primary := core.Exit(5, "timed out waiting for SSH: fixture")
+	debt := errors.New("selected-zone cleanup client unavailable")
+	fake := &fakeGCPDoctorClient{createCfg: Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-c"}}
+	oldClient, oldWait := newGCPClient, waitForSSHReady
+	bootstrapReached := false
+	newGCPClient = func(ctx context.Context, cfg Config) (gcpClient, error) {
+		if bootstrapReached {
+			if _, bounded := ctx.Deadline(); bounded {
+				return nil, debt
+			}
+		}
+		return fake, nil
+	}
+	waitForSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+		bootstrapReached = true
+		return primary
+	}
+	t.Cleanup(func() { newGCPClient = oldClient; waitForSSHReady = oldWait })
+	b := NewGCPLeaseBackend(ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
+	_, err := b.Acquire(context.Background(), AcquireRequest{})
+	if fake.createCalls != 1 || len(fake.deleted) != 1 || !errors.Is(err, primary) || !errors.Is(err, debt) {
+		t.Fatalf("creates=%d deletes=%v error=%v", fake.createCalls, fake.deleted, err)
 	}
 }

--- a/internal/providers/hetzner/backend.go
+++ b/internal/providers/hetzner/backend.go
@@ -96,7 +96,7 @@ func (b *hetznerLeaseBackend) acquireOnce(ctx context.Context, keep bool, reques
 			return
 		}
 		if cleanupErr := rollbackHetznerAcquire(client, rollbackServer, rollbackServerCreated, rollbackKey, rollbackKeyCreated); cleanupErr != nil {
-			err = errors.Join(err, fmt.Errorf("hetzner cleanup failed: %w", cleanupErr))
+			err = shared.JoinAcquireCleanupError(err, fmt.Errorf("hetzner cleanup failed: %w", cleanupErr))
 		}
 	}()
 	if cfg.ProviderKey != "" {

--- a/internal/providers/hetzner/backend_test.go
+++ b/internal/providers/hetzner/backend_test.go
@@ -1,8 +1,10 @@
 package hetzner
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"path/filepath"
 	"strconv"
@@ -18,6 +20,7 @@ type fakeHetznerClient struct {
 	list    []Server
 
 	createServer Server
+	createCalls  int
 	createErr    error
 	deleteErr    error
 	keyDeleteErr error
@@ -36,6 +39,7 @@ func (f *fakeHetznerClient) EnsureSSHKey(_ context.Context, name, _ string) (cor
 }
 
 func (f *fakeHetznerClient) CreateServerWithFallback(context.Context, Config, string, string, string, bool, func(string, ...any)) (Server, Config, error) {
+	f.createCalls++
 	return f.createServer, Config{}, f.createErr
 }
 
@@ -528,4 +532,56 @@ func installHetznerClaimState(t *testing.T) {
 	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
 	t.Setenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", "")
 	t.Setenv("CRABBOX_PROVIDER", "")
+}
+
+func TestHetznerAcquireStopsFreshRetryAfterRollbackFailure(t *testing.T) {
+	for _, failure := range []string{"none", "server", "key"} {
+		t.Run(failure, func(t *testing.T) {
+			debt := errors.New("cleanup unavailable")
+			fake := &fakeHetznerClient{servers: map[int64]Server{}, keyCreated: true}
+			if failure == "server" {
+				fake.deleteErr = debt
+			}
+			if failure == "key" {
+				fake.keyDeleteErr = debt
+			}
+			installHetznerTestHooks(t, fake)
+			sequence := 0
+			newLeaseID = func() string {
+				sequence++
+				id := fmt.Sprintf("cbx_%012x", sequence)
+				server := crabboxHetznerServer(int64(42+sequence), id)
+				fake.createServer = server
+				fake.servers[server.ID] = server
+				return id
+			}
+			primary := core.Exit(5, "timed out waiting for SSH: fixture")
+			waitForSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error { return primary }
+			var stderr bytes.Buffer
+			b := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: &stderr}).(*hetznerLeaseBackend)
+			_, err := b.Acquire(context.Background(), AcquireRequest{})
+			want := 1
+			if failure == "none" {
+				want = 2
+			}
+			if fake.createCalls != want || len(fake.deletedKeys) != want || !errors.Is(err, primary) {
+				t.Fatalf("creates=%d keys=%v error=%v", fake.createCalls, fake.deletedKeys, err)
+			}
+			wantDeletes := want
+			if failure == "key" {
+				wantDeletes = 0
+			}
+			if len(fake.deletedServers) != wantDeletes {
+				t.Fatalf("server deletion order changed: %v", fake.deletedServers)
+			}
+			for i, id := range fake.deletedServers {
+				if id != int64(43+i) {
+					t.Fatalf("wrong cleanup identity: %v", fake.deletedServers)
+				}
+			}
+			if failure != "none" && (!errors.Is(err, debt) || strings.Contains(stderr.String(), "retrying with fresh lease")) {
+				t.Fatalf("cleanup debt lost: error=%v stderr=%s", err, stderr.String())
+			}
+		})
+	}
 }

--- a/internal/providers/shared/direct.go
+++ b/internal/providers/shared/direct.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -114,6 +115,21 @@ func (b *DirectSSHBackend) Touch(ctx context.Context, server core.Server, state 
 	return core.TouchDirectLeaseBestEffort(ctx, b.Cfg, server, state, b.RT.Stderr)
 }
 
+// JoinAcquireCleanupError marks reported rollback failure as a fresh-allocation
+// retry veto while preserving both causes. A nil cleanup error says only that
+// the provider's existing cleanup contract succeeded, not universal absence.
+func JoinAcquireCleanupError(acquireErr, cleanupErr error) error {
+	if cleanupErr == nil {
+		return acquireErr
+	}
+	return &acquireCleanupError{cause: errors.Join(acquireErr, cleanupErr)}
+}
+
+type acquireCleanupError struct{ cause error }
+
+func (e *acquireCleanupError) Error() string { return e.cause.Error() }
+func (e *acquireCleanupError) Unwrap() error { return e.cause }
+
 func AcquireAttemptsRetry(rt core.Runtime, keep bool, acquire func() (core.LeaseTarget, error)) (core.LeaseTarget, error) {
 	var lastErr error
 	attempts := core.AcquireAttempts(keep)
@@ -123,6 +139,11 @@ func AcquireAttemptsRetry(rt core.Runtime, keep bool, acquire func() (core.Lease
 			return lease, nil
 		}
 		lastErr = err
+		var cleanupErr *acquireCleanupError
+		if errors.As(err, &cleanupErr) {
+			fmt.Fprintf(rt.Stderr, "warning: acquisition cleanup failed; refusing a fresh lease retry: %v\n", err)
+			return core.LeaseTarget{}, err
+		}
 		if attempt == attempts || !core.IsBootstrapWaitError(err) {
 			return core.LeaseTarget{}, err
 		}

--- a/internal/providers/shared/direct_test.go
+++ b/internal/providers/shared/direct_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -398,4 +399,39 @@ func testCleanupServerWithLabels(name string, labels map[string]string) core.Ser
 
 func bootstrapWaitErr() error {
 	return core.Exit(5, "timed out waiting for SSH: test")
+}
+
+func TestAcquireCleanupFailureVetoesRetryThroughWrapping(t *testing.T) {
+	for _, keep := range []bool{false, true} {
+		for _, wrapped := range []bool{false, true} {
+			t.Run(fmt.Sprintf("keep=%t/wrapped=%t", keep, wrapped), func(t *testing.T) {
+				primary := bootstrapWaitErr()
+				cleanup := core.Exit(9, "cleanup denied")
+				var stderr bytes.Buffer
+				attempts := 0
+				_, err := AcquireAttemptsRetry(core.Runtime{Stderr: &stderr}, keep, func() (core.LeaseTarget, error) {
+					attempts++
+					debt := JoinAcquireCleanupError(primary, cleanup)
+					if wrapped {
+						debt = errors.Join(errors.New("attempt context"), fmt.Errorf("wrapped: %w", debt))
+					}
+					return core.LeaseTarget{}, debt
+				})
+				var ee core.ExitError
+				if attempts != 1 || !errors.Is(err, primary) || !errors.Is(err, cleanup) || !core.AsExitError(err, &ee) || ee.Code != 5 {
+					t.Fatalf("attempts=%d error=%v primary=%+v", attempts, err, ee)
+				}
+				if strings.Contains(stderr.String(), "retrying with fresh lease") {
+					t.Fatalf("unexpected retry: %s", stderr.String())
+				}
+				if !strings.Contains(stderr.String(), "cleanup denied") {
+					t.Fatalf("cleanup diagnosis missing from CLI diagnostics: %s", stderr.String())
+				}
+			})
+		}
+	}
+	primary := bootstrapWaitErr()
+	if got := JoinAcquireCleanupError(primary, nil); got != primary {
+		t.Fatalf("successful cleanup changed primary: %v", got)
+	}
 }


### PR DESCRIPTION
## Summary

Make reported acquisition cleanup failure a shared, cause-preserving veto on allocating a fresh lease. Ordinary direct AWS, Azure, GCP and Hetzner acquisition already share a two-attempt bootstrap retry loop, but their rollback outcomes were inconsistent: warning-only errors in three adapters, an ordinary joined error in Hetzner. Both representations allowed another allocation after cleanup failed.

`JoinAcquireCleanupError` retains both causes and marks the failed rollback. The shared retry owner checks that marker before classifying bootstrap retry and emits the combined recovery diagnosis. Bootstrap exit5 remains the primary exit; cleanup failures remain inspectable through errors.Is. Successful cleanup still permits the existing retry budget.

Adapters keep their resource identities, deadlines and deletion order. AWS still attempts instance then exact key-ID cleanup, including its existing key attempt after an instance error. Hetzner still deletes an owned-created key first and makes no server DELETE after key failure. Fixed-ID AWS acquisition and brokered cleanup are untouched. GCP also retains cleanup-client reconstruction failure even when its existing fallback client returns nil; that fallback is not proof of selected-scope cleanup.

## Verification

The baseline GCP regression made two creates/two cleanup attempts despite a failed delete. The fixed public Acquire paths now stop after one allocation when rollback fails; successful-cleanup controls keep two attempts. Tests cover AWS client/instance/key failures, Azure/GCP delete failures, GCP cleanup-client fallback, Hetzner key-first ordering, and shared wrapped/joined markers with both keep values. The GCP SSH forwarding wrapper is now injectable, matching the other adapters, so final tests inject the classified failure at the actual bootstrap phase rather than the IP phase.

All five affected package race suites pass; combined-main races also include Cloudflare's newly landed shared-lifecycle consumer. Vet, build, docs generation and whole-repository dead-code checks pass. Managed precommit/main-integration reviews and independent semantic review have no accepted actionable finding.

These are high-confidence adapter/loop regression tests with injected provider failures, not a claim of a live cloud cleanup failure or uniformly confirmed deletion. No cloud resource was deliberately leaked for proof. The exact control flow and provider-call ordering are exercised through the actual public Acquire entry points. The focused trace is below.

```sh
go test -v -race -count=1 -timeout=3m ./internal/providers/shared ./internal/providers/aws ./internal/providers/azure ./internal/providers/gcp ./internal/providers/hetzner -run 'Test(AcquireCleanupFailureVetoesRetryThroughWrapping|.*AcquireStopsFreshRetryAfterRollbackFailure|GCPAcquireRetainsCleanupClientFailureDespiteFallbackSuccess)$'
```

```text
=== RUN   TestAcquireCleanupFailureVetoesRetryThroughWrapping
=== RUN   TestAcquireCleanupFailureVetoesRetryThroughWrapping/keep=false/wrapped=false
=== RUN   TestAcquireCleanupFailureVetoesRetryThroughWrapping/keep=false/wrapped=true
=== RUN   TestAcquireCleanupFailureVetoesRetryThroughWrapping/keep=true/wrapped=false
=== RUN   TestAcquireCleanupFailureVetoesRetryThroughWrapping/keep=true/wrapped=true
--- PASS: TestAcquireCleanupFailureVetoesRetryThroughWrapping (0.00s)
    --- PASS: TestAcquireCleanupFailureVetoesRetryThroughWrapping/keep=false/wrapped=false (0.00s)
    --- PASS: TestAcquireCleanupFailureVetoesRetryThroughWrapping/keep=false/wrapped=true (0.00s)
    --- PASS: TestAcquireCleanupFailureVetoesRetryThroughWrapping/keep=true/wrapped=false (0.00s)
    --- PASS: TestAcquireCleanupFailureVetoesRetryThroughWrapping/keep=true/wrapped=true (0.00s)
PASS
ok  	github.com/openclaw/crabbox/internal/providers/shared	1.523s
=== RUN   TestAWSAcquireStopsFreshRetryAfterRollbackFailure
=== RUN   TestAWSAcquireStopsFreshRetryAfterRollbackFailure/none
=== RUN   TestAWSAcquireStopsFreshRetryAfterRollbackFailure/instance
=== RUN   TestAWSAcquireStopsFreshRetryAfterRollbackFailure/key
=== RUN   TestAWSAcquireStopsFreshRetryAfterRollbackFailure/client
--- PASS: TestAWSAcquireStopsFreshRetryAfterRollbackFailure (0.06s)
    --- PASS: TestAWSAcquireStopsFreshRetryAfterRollbackFailure/none (0.02s)
    --- PASS: TestAWSAcquireStopsFreshRetryAfterRollbackFailure/instance (0.01s)
    --- PASS: TestAWSAcquireStopsFreshRetryAfterRollbackFailure/key (0.01s)
    --- PASS: TestAWSAcquireStopsFreshRetryAfterRollbackFailure/client (0.01s)
PASS
ok  	github.com/openclaw/crabbox/internal/providers/aws	2.933s
=== RUN   TestAzureAcquireStopsFreshRetryAfterRollbackFailure
=== RUN   TestAzureAcquireStopsFreshRetryAfterRollbackFailure/false
=== RUN   TestAzureAcquireStopsFreshRetryAfterRollbackFailure/true
--- PASS: TestAzureAcquireStopsFreshRetryAfterRollbackFailure (0.13s)
    --- PASS: TestAzureAcquireStopsFreshRetryAfterRollbackFailure/false (0.08s)
    --- PASS: TestAzureAcquireStopsFreshRetryAfterRollbackFailure/true (0.05s)
PASS
ok  	github.com/openclaw/crabbox/internal/providers/azure	1.730s
=== RUN   TestGCPAcquireStopsFreshRetryAfterRollbackFailure
=== RUN   TestGCPAcquireStopsFreshRetryAfterRollbackFailure/false
=== RUN   TestGCPAcquireStopsFreshRetryAfterRollbackFailure/true
--- PASS: TestGCPAcquireStopsFreshRetryAfterRollbackFailure (0.04s)
    --- PASS: TestGCPAcquireStopsFreshRetryAfterRollbackFailure/false (0.02s)
    --- PASS: TestGCPAcquireStopsFreshRetryAfterRollbackFailure/true (0.01s)
=== RUN   TestGCPAcquireRetainsCleanupClientFailureDespiteFallbackSuccess
--- PASS: TestGCPAcquireRetainsCleanupClientFailureDespiteFallbackSuccess (0.01s)
PASS
ok  	github.com/openclaw/crabbox/internal/providers/gcp	2.097s
=== RUN   TestHetznerAcquireStopsFreshRetryAfterRollbackFailure
=== RUN   TestHetznerAcquireStopsFreshRetryAfterRollbackFailure/none
=== RUN   TestHetznerAcquireStopsFreshRetryAfterRollbackFailure/server
=== RUN   TestHetznerAcquireStopsFreshRetryAfterRollbackFailure/key
--- PASS: TestHetznerAcquireStopsFreshRetryAfterRollbackFailure (0.56s)
    --- PASS: TestHetznerAcquireStopsFreshRetryAfterRollbackFailure/none (0.41s)
    --- PASS: TestHetznerAcquireStopsFreshRetryAfterRollbackFailure/server (0.07s)
    --- PASS: TestHetznerAcquireStopsFreshRetryAfterRollbackFailure/key (0.07s)
PASS
ok  	github.com/openclaw/crabbox/internal/providers/hetzner	4.051s
```

## Boundaries

No new configuration, credentials, dependencies, retry budget or API protocol is introduced. A nil cleanup error still means each existing provider contract: AWS termination-request acceptance, Hetzner DELETE success, GCP delete-operation completion, or Azure's dependency deletion/absence checks. This patch does not unify those protocols or claim generation-fenced deletion. GCP's preexisting fallback-client scope ambiguity and create-to-readiness identity binding are separate follow-ups. Docs and the maintainer Unreleased entry record the changed retry behavior.
