### PR TITLE
fix: share safe archive sync for Upstash and Tensorlake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Preserve Upstash Box workspaces when archive upload or extraction fails, clean partial Upstash Box/Tensorlake uploads, and check complete archive limits before creating either sandbox. Thanks @steipete.
 - Cloudflare: retain recovery claims when teardown fails, preserve command/cancellation outcomes, and fence reuse and cleanup against replaced local claims. [PR 1817](https://github.com/openclaw/crabbox/pull/1817). Thanks @steipete.
+- Preserve Upstash Box workspaces when archive upload or extraction fails, clean partial Upstash Box/Tensorlake uploads, and check complete archive limits before creating either sandbox. [PR 1820](https://github.com/openclaw/crabbox/pull/1820). Thanks @steipete.
 - Preserve existing Cloudflare container workspaces when sync upload or extraction fails, clean partial archives, and enforce full-checkout size limits before fresh allocation. [PR 1814](https://github.com/openclaw/crabbox/pull/1814). Thanks @steipete.
 - Protect Nomad runs from overwriting replacement claims or recreating retired leases, and expose standard run-session handles with cleanup-aware final outcomes that preserve the original command exit. [PR 1810](https://github.com/openclaw/crabbox/pull/1810). Thanks @steipete.
 - Preserve individual AWS, Azure, and GCP candidate failures in successful leases' provisioning history across market and regional fallback, including previously omitted GCP on-demand failures. [PR 1811](https://github.com/openclaw/crabbox/pull/1811). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve Upstash Box workspaces when archive upload or extraction fails, clean partial Upstash Box/Tensorlake uploads, and check complete archive limits before creating either sandbox. Thanks @steipete.
 - Cloudflare: retain recovery claims when teardown fails, preserve command/cancellation outcomes, and fence reuse and cleanup against replaced local claims. [PR 1817](https://github.com/openclaw/crabbox/pull/1817). Thanks @steipete.
 - Preserve existing Cloudflare container workspaces when sync upload or extraction fails, clean partial archives, and enforce full-checkout size limits before fresh allocation. [PR 1814](https://github.com/openclaw/crabbox/pull/1814). Thanks @steipete.
 - Protect Nomad runs from overwriting replacement claims or recreating retired leases, and expose standard run-session handles with cleanup-aware final outcomes that preserve the original command exit. [PR 1810](https://github.com/openclaw/crabbox/pull/1810). Thanks @steipete.

--- a/docs/providers/tensorlake.md
+++ b/docs/providers/tensorlake.md
@@ -142,9 +142,13 @@ local `tensorlake` process argv.
    organization/project, requested namespace, and reported sandbox namespace.
 3. By default `run` archive-syncs the working tree: a `git ls-files`-driven
    manifest is packed into a gzipped tar locally, uploaded with
-   `tensorlake sbx cp` to `/tmp/crabbox-sync-*.tgz`, and extracted into the
-   configured workdir. Pass `--no-sync` to skip the archive step (the workdir is
-   still created).
+   `tensorlake sbx cp` to `/tmp/crabbox-tensorlake-sync-*.tgz`, and extracted into
+   the configured workdir. The complete archive is checked and built before
+   fresh allocation. Delete-sync stages extraction before replacing the existing
+   workspace; non-delete sync merges into it. A bounded cleanup attempt removes
+   partial uploads and staging directories even when transfer fails or is
+   canceled, warning on cleanup failure without replacing the original outcome.
+   Pass `--no-sync` to skip the archive step (the workdir is still created).
 4. The command runs via `tensorlake sbx exec -w <workdir> <id> -- <cmd>`,
    streaming stdout and stderr back through Crabbox.
 5. On release the original claim and provider scope are rechecked while claim

--- a/docs/providers/upstash-box.md
+++ b/docs/providers/upstash-box.md
@@ -108,7 +108,12 @@ Accepted values, validated before the API is called:
 2. By default `run` archive-syncs the working tree: Git manifest → local
    `tar -czf` → upload into the Box workspace as
    `.crabbox-upstash-box-sync-*.tgz` → in-Box `tar -xzf` into the workdir
-   (the temp archive is removed afterward).
+   (the temp archive is removed afterward). The full archive is checked and built
+   before fresh allocation. With delete-sync enabled, extraction completes in a
+   sibling staging directory before replacing the existing workdir; failed upload
+   or extraction leaves the previous workspace intact. Temporary archive/staging
+   cleanup is attempted even after a partial upload or cancellation. Cleanup
+   failures warn without replacing the original sync outcome.
 3. The user command runs through the Box exec-stream endpoint wrapped in
    `sh -c`, with the workspace folder set as the working directory, streaming
    output back through Crabbox.

--- a/internal/cli/delegated_archive_sync.go
+++ b/internal/cli/delegated_archive_sync.go
@@ -236,11 +236,14 @@ func RunDelegatedArchiveSync(ctx context.Context, req DelegatedArchiveSyncReques
 	cleanupRemote := func() {
 		cleanupCtx, cleanupCancel := cleanupContext(ctx)
 		defer cleanupCancel()
-		command := "rm -f " + ShellQuote(remoteArchive) + " 2>/dev/null || true"
+		command := "rm -f " + ShellQuote(remoteArchive) + " && crabbox_cleanup_status=0 || crabbox_cleanup_status=$?"
 		if stagingDir != "" {
-			command += "; rm -rf " + ShellQuote(stagingDir) + " 2>/dev/null || true"
+			command += "; rm -rf " + ShellQuote(stagingDir) + " || crabbox_cleanup_status=$?"
 		}
-		_ = req.Exec(cleanupCtx, command)
+		command += "; exit \"$crabbox_cleanup_status\""
+		if err := req.Exec(cleanupCtx, command); err != nil {
+			fmt.Fprintf(stderr, "warning: %s sync cleanup failed: %v\n", provider, err)
+		}
 	}
 	cleanupPending := true
 	defer func() {

--- a/internal/cli/delegated_archive_sync_test.go
+++ b/internal/cli/delegated_archive_sync_test.go
@@ -404,11 +404,14 @@ func TestRunDelegatedArchiveSyncCleanupOutlivesCanceledParent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	var cleanupContextActive bool
 	var calls int
+	var stderr bytes.Buffer
 
 	_, _, err := RunDelegatedArchiveSync(ctx, DelegatedArchiveSyncRequest{
-		Config:  baseConfig(),
-		Repo:    Repo{Root: root},
-		Workdir: "/workspace",
+		Config:   baseConfig(),
+		Repo:     Repo{Root: root},
+		Workdir:  "/workspace",
+		Provider: "test-provider",
+		Stderr:   &stderr,
 		CleanupContext: func(parent context.Context) (context.Context, context.CancelFunc) {
 			cleanupContextActive = parent.Err() == context.Canceled
 			return context.WithTimeout(context.WithoutCancel(parent), time.Second)
@@ -423,6 +426,9 @@ func TestRunDelegatedArchiveSyncCleanupOutlivesCanceledParent(t *testing.T) {
 			if strings.HasPrefix(command, "rm -f ") && callCtx.Err() != nil {
 				t.Fatalf("cleanup context canceled: %v", callCtx.Err())
 			}
+			if strings.HasPrefix(command, "rm -f ") {
+				return exec.CommandContext(callCtx, "sh", "-ec", "rm() { return 7; }; "+command).Run()
+			}
 			return nil
 		},
 	})
@@ -431,6 +437,9 @@ func TestRunDelegatedArchiveSyncCleanupOutlivesCanceledParent(t *testing.T) {
 	}
 	if !cleanupContextActive || calls < 3 {
 		t.Fatalf("cleanup active=%t calls=%d", cleanupContextActive, calls)
+	}
+	if !strings.Contains(stderr.String(), "warning: test-provider sync cleanup failed: exit status 7") {
+		t.Fatalf("missing cleanup warning: %s", stderr.String())
 	}
 }
 

--- a/internal/providers/tensorlake/backend.go
+++ b/internal/providers/tensorlake/backend.go
@@ -64,6 +64,14 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (result Run
 		return RunResult{}, err
 	}
 	started := b.now()
+	var prepared *core.PreparedArchive
+	if !req.NoSync {
+		prepared, err = b.prepareArchive(ctx, req)
+		if err != nil {
+			return RunResult{}, err
+		}
+		defer prepared.Close()
+	}
 	cli, err := newTensorlakeCLI(b.cfg, b.rt)
 	if err != nil {
 		return RunResult{}, err
@@ -150,7 +158,7 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (result Run
 	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
 	if !req.NoSync {
 		var err error
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, cli, sandboxID, req, workdir)
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, cli, sandboxID, req, workdir, prepared)
 		if err != nil {
 			return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, err
 		}

--- a/internal/providers/tensorlake/backend_test.go
+++ b/internal/providers/tensorlake/backend_test.go
@@ -643,54 +643,124 @@ func TestTensorlakeDeleteSyncDoesNotRemoveWorkspaceBeforeUpload(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "upload failed") {
 		t.Fatalf("err=%v, want upload failure", err)
 	}
-	prepare := findCallN(runner, "sbx exec", 0)
-	if prepare == nil {
-		t.Fatal("missing prepare command")
+	cleanup := findCallN(runner, "sbx exec", 0)
+	if cleanup == nil {
+		t.Fatal("missing failed-upload cleanup")
 	}
-	prepareText := strings.Join(prepare.Args, " ")
-	if strings.Contains(prepareText, "rm -rf") {
-		t.Fatalf("prepare deleted workspace before upload: %v", prepare.Args)
+	cleanupText := strings.Join(cleanup.Args, " ")
+	if !strings.Contains(cleanupText, "rm -f '/tmp/crabbox-tensorlake-sync-") || strings.Contains(cleanupText, "rm -rf '/workspace/crabbox'") {
+		t.Fatalf("cleanup=%s", cleanupText)
 	}
-	if !strings.Contains(prepareText, "mkdir -p") {
-		t.Fatalf("prepare should still create workspace: %v", prepare.Args)
-	}
-	if verbs := callMutationVerbs(runner); !reflect.DeepEqual(verbs, []string{"sbx create", "sbx exec", "sbx cp", "sbx terminate"}) {
+	if verbs := callMutationVerbs(runner); !reflect.DeepEqual(verbs, []string{"sbx create", "sbx cp", "sbx exec", "sbx terminate"}) {
 		t.Fatalf("verbs=%v", verbs)
 	}
 }
 
-func TestTensorlakeDeleteSyncExtractStagesBeforeReplacingWorkspace(t *testing.T) {
-	cmd := tensorlakeExtractArchiveCommand("/workspace/crabbox", "/tmp/archive.tgz", true)
-	tarAt := strings.Index(cmd, "tar -xzf '/tmp/archive.tgz'")
-	replaceAt := strings.Index(cmd, "mv '/workspace/crabbox' '/workspace/.crabbox-backup-")
-	if tarAt < 0 || replaceAt < 0 {
-		t.Fatalf("command missing staged extract or replacement: %s", cmd)
-	}
-	if replaceAt < tarAt {
-		t.Fatalf("workspace is replaced before archive extraction: %s", cmd)
-	}
-	if strings.Contains(cmd[:tarAt], "rm -rf '/workspace/crabbox'") {
-		t.Fatalf("workspace deleted before archive extraction: %s", cmd)
-	}
-	if !strings.Contains(cmd, "rm -f '/tmp/archive.tgz'") {
-		t.Fatalf("command should clean remote archive: %s", cmd)
-	}
-}
-
-func TestTensorlakeExtractArchiveCommandPreservesExtractStatus(t *testing.T) {
-	cmd := tensorlakeExtractArchiveCommand("/workspace/crabbox", "/tmp/archive.tgz", false)
-	for _, want := range []string{
-		"tar -xzf '/tmp/archive.tgz' -C '/workspace/crabbox'",
-		"; crabbox_status=$?;",
-		"; rm -f '/tmp/archive.tgz';",
-		"; exit \"$crabbox_status\"",
+func TestTensorlakeSyncNativeArchiveTransaction(t *testing.T) {
+	for _, scenario := range []struct {
+		name, failure string
+		delete        bool
+	}{
+		{"partial upload", "upload", true}, {"corrupt archive", "extract", true},
+		{"replace", "", true}, {"merge", "", false},
 	} {
-		if !strings.Contains(cmd, want) {
-			t.Fatalf("command missing %q: %s", want, cmd)
-		}
-	}
-	if strings.Contains(cmd, "rm -f '/tmp/archive.tgz' exit") {
-		t.Fatalf("cleanup and exit are not separated: %s", cmd)
+		t.Run(scenario.name, func(t *testing.T) {
+			root := t.TempDir()
+			workdir := filepath.Join(root, "work")
+			if err := os.Mkdir(workdir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			old := filepath.Join(workdir, "old.txt")
+			if err := os.WriteFile(old, []byte("preserve-me"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			runner := newRunner(nil, nil)
+			remoteArchive := ""
+			t.Cleanup(func() {
+				if remoteArchive != "" {
+					_ = os.Remove(remoteArchive)
+				}
+			})
+			runner.hook = func(req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+				if scriptKey(req.Args) == "sbx cp" {
+					src, dst := req.Args[len(req.Args)-2], req.Args[len(req.Args)-1]
+					_, remoteArchive, _ = strings.Cut(dst, ":")
+					data, err := os.ReadFile(src)
+					if err != nil {
+						return core.LocalCommandResult{}, err, true
+					}
+					if scenario.failure == "extract" {
+						data = []byte("corrupt archive")
+					}
+					if err := os.WriteFile(remoteArchive, data, 0o600); err != nil {
+						return core.LocalCommandResult{}, err, true
+					}
+					if scenario.failure == "upload" {
+						return core.LocalCommandResult{ExitCode: 7}, errors.New("synthetic partial upload failure"), true
+					}
+					return core.LocalCommandResult{}, nil, true
+				}
+				if scriptKey(req.Args) == "sbx exec" {
+					cmd := osexec.Command("sh", "-c", req.Args[len(req.Args)-1])
+					cmd.Stdout, cmd.Stderr = req.Stdout, req.Stderr
+					err := cmd.Run()
+					code := 0
+					if err != nil {
+						var exited *osexec.ExitError
+						if !errors.As(err, &exited) {
+							return core.LocalCommandResult{}, err, true
+						}
+						code = exited.ExitCode()
+					}
+					return core.LocalCommandResult{ExitCode: code}, err, true
+				}
+				return core.LocalCommandResult{}, nil, false
+			}
+			cfg := newTestConfig()
+			cfg.Sync.Delete = scenario.delete
+			backend := NewTensorlakeBackend(Provider{}.Spec(), cfg, newTestRuntime(runner)).(*tensorlakeBackend)
+			cli, err := newTensorlakeCLI(cfg, backend.rt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			repo := newGitRepo(t)
+			if err := os.WriteFile(filepath.Join(repo, "incoming.txt"), []byte("new"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, _, err = backend.syncWorkspace(context.Background(), cli, "sandbox_fixture", RunRequest{Repo: Repo{Root: repo}}, workdir)
+			if scenario.failure != "" && err == nil {
+				t.Fatal("expected transfer failure")
+			}
+			if scenario.failure == "" && err != nil {
+				t.Fatal(err)
+			}
+			if scenario.failure != "" || !scenario.delete {
+				data, err := os.ReadFile(old)
+				if err != nil || string(data) != "preserve-me" {
+					t.Fatalf("previous workspace lost: %q %v", data, err)
+				}
+			} else if _, err := os.Stat(old); !os.IsNotExist(err) {
+				t.Fatalf("old file remains: %v", err)
+			}
+			if scenario.failure == "" {
+				data, err := os.ReadFile(filepath.Join(workdir, "incoming.txt"))
+				if err != nil || string(data) != "new" {
+					t.Fatalf("incoming=%q err=%v", data, err)
+				}
+			}
+			if _, err := os.Stat(remoteArchive); !os.IsNotExist(err) {
+				t.Fatalf("remote archive remains: %v", err)
+			}
+			entries, err := os.ReadDir(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, e := range entries {
+				if e.Name() != "work" {
+					t.Errorf("staging/backup residue %s", e.Name())
+				}
+			}
+		})
 	}
 }
 
@@ -837,8 +907,8 @@ func TestRunPerformsArchiveSyncByDefault(t *testing.T) {
 		t.Fatalf("Run err=%v", err)
 	}
 	verbs := callMutationVerbs(runner)
-	// Expected order: create → mkdir-prepare exec → cp upload → tar-extract exec → user exec → terminate
-	want := []string{"sbx create", "sbx exec", "sbx cp", "sbx exec", "sbx exec", "sbx terminate"}
+	// Archive upload precedes preparation; its cleanup is separate from user execution.
+	want := []string{"sbx create", "sbx cp", "sbx exec", "sbx exec", "sbx exec", "sbx exec", "sbx terminate"}
 	if !reflect.DeepEqual(verbs, want) {
 		t.Fatalf("verbs=%v want %v", verbs, want)
 	}
@@ -846,8 +916,26 @@ func TestRunPerformsArchiveSyncByDefault(t *testing.T) {
 	if cp == nil {
 		t.Fatalf("missing sbx cp call")
 	}
-	if !containsArgPrefix(cp.Args, "syncidaaaaaaaaaaaaaa0:/tmp/crabbox-sync-") {
+	if !containsArgPrefix(cp.Args, "syncidaaaaaaaaaaaaaa0:/tmp/crabbox-tensorlake-sync-") {
 		t.Fatalf("cp args=%v missing remote dest", cp.Args)
+	}
+}
+
+func TestTensorlakeRunChecksArchiveBeforeAllocation(t *testing.T) {
+	runner := newRunner(nil, nil)
+	cfg := newTestConfig()
+	cfg.Sync.FailFiles = 1
+	backend := NewTensorlakeBackend(Provider{}.Spec(), cfg, newTestRuntime(runner)).(*tensorlakeBackend)
+	repo := newGitRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "incoming.txt"), []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Root: repo}, Command: []string{"true"}})
+	if err == nil || !strings.Contains(err.Error(), "sync candidate too large") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("provider called before archive admission: %v", runner.calls)
 	}
 }
 

--- a/internal/providers/tensorlake/core.go
+++ b/internal/providers/tensorlake/core.go
@@ -1,10 +1,8 @@
 package tensorlake
 
 import (
-	"context"
 	"flag"
 	"io"
-	"os"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -109,24 +107,6 @@ func shellQuote(s string) string {
 
 func tensorlakeCleanupCommand(leaseID string) string {
 	return "crabbox stop --provider " + providerName + " --id " + shellQuote(leaseID)
-}
-
-func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
-	return core.SyncExcludes(root, cfg)
-}
-
-func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (core.SyncManifest, error) {
-	return core.BuildSyncManifestFiltered(root, excludes, includes)
-}
-
-func checkSyncPreflight(manifest core.SyncManifest, cfg Config, force bool, stderr io.Writer) error {
-	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
-}
-
-type SyncManifest = core.SyncManifest
-
-func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
-	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
 }
 
 func cliDoctorResult(provider string, leases int, runtime string) DoctorResult {

--- a/internal/providers/tensorlake/sync.go
+++ b/internal/providers/tensorlake/sync.go
@@ -3,10 +3,9 @@ package tensorlake
 import (
 	"context"
 	"io"
-	"os"
-	"path"
-	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 // rejectIncompatibleSyncOptions refuses Crabbox sync flags whose semantics
@@ -24,117 +23,36 @@ func rejectIncompatibleSyncOptions(req RunRequest) error {
 	return nil
 }
 
-// syncWorkspace builds a gzipped tar archive of the repo, uploads it via
-// `tensorlake sbx cp`, and extracts it into the configured workdir. Returns
-// per-phase timings so warmup/run summaries can break the sync down the same
-// way islo and daytona do.
-func (b *tensorlakeBackend) syncWorkspace(ctx context.Context, cli *tensorlakeCLI, sandboxID string, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
-	start := b.now()
+func (b *tensorlakeBackend) prepareArchive(ctx context.Context, req RunRequest) (*core.PreparedArchive, error) {
+	return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+		TempPattern: "crabbox-tensorlake-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+	})
+}
 
-	excludes, err := syncExcludes(req.Repo.Root, b.cfg)
-	if err != nil {
-		return nil, 0, err
+func (b *tensorlakeBackend) syncWorkspace(ctx context.Context, cli *tensorlakeCLI, sandboxID string, req RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+	var archive *core.PreparedArchive
+	if len(prepared) > 0 {
+		archive = prepared[0]
 	}
-
-	manifestStart := b.now()
-	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
-	if err != nil {
-		return nil, 0, exit(6, "build sync file list: %v", err)
+	if archive == nil {
+		var err error
+		archive, err = b.prepareArchive(ctx, req)
+		if err != nil {
+			return nil, 0, err
+		}
 	}
-	manifestDuration := b.now().Sub(manifestStart)
-
-	preflightStart := b.now()
-	if err := checkSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
-		return nil, 0, err
-	}
-	preflightDuration := b.now().Sub(preflightStart)
-
-	prepareStart := b.now()
-	if err := b.prepareWorkspace(ctx, cli, sandboxID, workdir); err != nil {
-		return nil, 0, err
-	}
-	prepareDuration := b.now().Sub(prepareStart)
-
-	archiveStart := b.now()
-	archive, err := createTensorlakeSyncArchive(ctx, req.Repo, manifest, b.rt.Stderr)
-	if err != nil {
-		return nil, 0, err
-	}
-	defer func() {
-		_ = archive.Close()
-		_ = os.Remove(archive.Name())
-	}()
-	archiveDuration := b.now().Sub(archiveStart)
-
-	uploadStart := b.now()
-	remoteArchive := path.Join("/tmp", "crabbox-sync-"+randomSuffix()+".tgz")
-	if err := cli.uploadFile(ctx, sandboxID, archive.Name(), remoteArchive); err != nil {
-		return nil, 0, err
-	}
-	uploadDuration := b.now().Sub(uploadStart)
-
-	extractStart := b.now()
-	if err := b.extractRemoteArchive(ctx, cli, sandboxID, remoteArchive, workdir); err != nil {
-		// Best-effort cleanup of the remote archive even when extract fails.
-		_ = cli.execShell(context.Background(), sandboxID, "rm -f "+shellQuote(remoteArchive))
-		return nil, 0, err
-	}
-	extractDuration := b.now().Sub(extractStart)
-
-	total := b.now().Sub(start)
-	return []timingPhase{
-		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
-		{Name: "preflight", Ms: preflightDuration.Milliseconds()},
-		{Name: "prepare", Ms: prepareDuration.Milliseconds()},
-		{Name: "archive", Ms: archiveDuration.Milliseconds()},
-		{Name: "upload", Ms: uploadDuration.Milliseconds()},
-		{Name: "extract", Ms: extractDuration.Milliseconds()},
-		{Name: "tensorlake_sync", Ms: total.Milliseconds()},
-	}, total, nil
+	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
+		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+		Workdir: workdir, RemoteArchivePrefix: "crabbox-tensorlake-sync-",
+		Provider: providerName, PhaseName: "tensorlake_sync", Stderr: b.rt.Stderr, Now: b.now,
+		Upload: func(uploadCtx context.Context, remoteArchive string, _ io.Reader) error {
+			return cli.uploadFile(uploadCtx, sandboxID, archive.File.Name(), remoteArchive)
+		},
+		Exec: func(execCtx context.Context, command string) error { return cli.execShell(execCtx, sandboxID, command) },
+	}, archive)
 }
 
 func (b *tensorlakeBackend) prepareWorkspace(ctx context.Context, cli *tensorlakeCLI, sandboxID, workdir string) error {
 	return cli.execShell(ctx, sandboxID, "mkdir -p "+shellQuote(workdir))
-}
-
-func (b *tensorlakeBackend) extractRemoteArchive(ctx context.Context, cli *tensorlakeCLI, sandboxID, remoteArchive, workdir string) error {
-	return cli.execShell(ctx, sandboxID, tensorlakeExtractArchiveCommand(workdir, remoteArchive, b.cfg.Sync.Delete))
-}
-
-func tensorlakeExtractArchiveCommand(workdir, remoteArchive string, deleteExisting bool) string {
-	if !deleteExisting {
-		return strings.Join([]string{
-			"mkdir -p " + shellQuote(workdir) + " && tar -xzf " + shellQuote(remoteArchive) + " -C " + shellQuote(workdir),
-			"crabbox_status=$?",
-			"rm -f " + shellQuote(remoteArchive),
-			"exit \"$crabbox_status\"",
-		}, "; ")
-	}
-	parent := path.Dir(workdir)
-	tmp := path.Join(parent, ".crabbox-sync-"+randomSuffix())
-	backup := path.Join(parent, ".crabbox-backup-"+randomSuffix())
-	steps := []string{
-		"(",
-		"rm -rf " + shellQuote(tmp) + " " + shellQuote(backup) + " &&",
-		"mkdir -p " + shellQuote(tmp) + " &&",
-		"tar -xzf " + shellQuote(remoteArchive) + " -C " + shellQuote(tmp) + " &&",
-		"if [ -e " + shellQuote(workdir) + " ]; then mv " + shellQuote(workdir) + " " + shellQuote(backup) + "; fi &&",
-		"if mv " + shellQuote(tmp) + " " + shellQuote(workdir) + "; then",
-		"rm -rf " + shellQuote(backup) + ";",
-		"else",
-		"crabbox_swap_status=$?;",
-		"if [ -e " + shellQuote(backup) + " ]; then mv " + shellQuote(backup) + " " + shellQuote(workdir) + " || true; fi;",
-		"exit \"$crabbox_swap_status\";",
-		"fi",
-		");",
-		"crabbox_status=$?;",
-		"rm -rf " + shellQuote(tmp) + ";",
-		"rm -f " + shellQuote(remoteArchive) + ";",
-		"exit \"$crabbox_status\"",
-	}
-	return strings.Join(steps, " ")
-}
-
-func createTensorlakeSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, _ io.Writer) (*os.File, error) {
-	return createPortableSyncArchive(ctx, repo, manifest, "crabbox-tensorlake-sync-*.tgz")
 }

--- a/internal/providers/upstashbox/backend.go
+++ b/internal/providers/upstashbox/backend.go
@@ -69,6 +69,14 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		return RunResult{}, err
 	}
 	started := b.now()
+	var prepared *core.PreparedArchive
+	if !req.NoSync {
+		prepared, err = b.prepareArchive(ctx, req)
+		if err != nil {
+			return RunResult{}, err
+		}
+		defer prepared.Close()
+	}
 	client, err := newAPI(b.cfg, b.rt)
 	if err != nil {
 		return RunResult{}, err
@@ -142,12 +150,12 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	syncDuration := time.Duration(0)
 	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
 	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, boxID, req, workdir, folder)
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, boxID, req, workdir, folder, prepared)
 		if err != nil {
 			return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, err
 		}
 		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
-	} else if err := b.prepareWorkspace(ctx, client, boxID, folder, false); err != nil {
+	} else if err := b.prepareWorkspace(ctx, client, boxID, folder); err != nil {
 		return RunResult{}, err
 	}
 	if req.SyncOnly {

--- a/internal/providers/upstashbox/backend_test.go
+++ b/internal/providers/upstashbox/backend_test.go
@@ -802,12 +802,113 @@ func TestSyncWorkspaceCleansRemoteArchiveWhenExtractFails(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected extract failure")
 	}
-	if !reflect.DeepEqual(fake.verbs, []string{"exec", "upload", "exec", "exec"}) {
+	if !reflect.DeepEqual(fake.verbs, []string{"upload", "exec", "exec", "exec"}) {
 		t.Fatalf("verbs=%v", fake.verbs)
 	}
 	if !strings.Contains(fake.execCommands[2], "rm -f '.crabbox-upstash-box-sync-") {
 		t.Fatalf("cleanup command=%q", fake.execCommands[2])
 	}
+}
+
+func TestSyncWorkspaceNativePreservesExistingFilesOnTransferFailure(t *testing.T) {
+	for _, failure := range []string{"upload", "extract", ""} {
+		t.Run(blank(failure, "success"), func(t *testing.T) {
+			root := t.TempDir()
+			work := filepath.Join(root, "crabbox")
+			if err := os.Mkdir(work, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			old := filepath.Join(work, "old.txt")
+			if err := os.WriteFile(old, []byte("preserve-me"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			client := &filesystemSyncAPI{root: root, failure: failure}
+			cfg := testConfig()
+			cfg.Sync.Delete = true
+			backend := NewBackend(Provider{}.Spec(), cfg, testRuntime()).(*backend)
+			_, _, err := backend.syncWorkspace(context.Background(), client, "box_1", RunRequest{Repo: Repo{Name: "repo", Root: newGitRepo(t)}}, "/workspace/home/crabbox", "crabbox")
+			if failure != "" {
+				if err == nil {
+					t.Fatal("expected transfer failure")
+				}
+				got, readErr := os.ReadFile(old)
+				if readErr != nil || string(got) != "preserve-me" {
+					t.Fatalf("previous workspace lost: content=%q err=%v syncErr=%v", got, readErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := os.Stat(old); !os.IsNotExist(err) {
+					t.Fatalf("old file remains: %v", err)
+				}
+				if got, err := os.ReadFile(filepath.Join(work, "hello.txt")); err != nil || string(got) != "hello" {
+					t.Fatalf("new content=%q err=%v", got, err)
+				}
+			}
+			entries, err := os.ReadDir(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, entry := range entries {
+				if entry.Name() != "crabbox" {
+					t.Errorf("sync residue: %s", entry.Name())
+				}
+			}
+		})
+	}
+}
+
+func TestRunChecksArchiveBeforeAllocation(t *testing.T) {
+	fake := &fakeAPI{}
+	withFakeAPI(t, fake)
+	cfg := testConfig()
+	cfg.Sync.FailFiles = 1
+	backend := NewBackend(Provider{}.Spec(), cfg, testRuntime()).(*backend)
+	_, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Root: newGitRepo(t)}, Command: []string{"true"}})
+	if err == nil || !strings.Contains(err.Error(), "sync candidate too large") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(fake.verbs) != 0 {
+		t.Fatalf("provider called before archive admission: %v", fake.verbs)
+	}
+}
+
+type filesystemSyncAPI struct {
+	fakeAPI
+	root, failure string
+}
+
+func (f *filesystemSyncAPI) UploadFile(_ context.Context, _, localPath, remotePath string) error {
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		return err
+	}
+	if f.failure == "extract" {
+		data = []byte("corrupt archive")
+	}
+	if err := os.WriteFile(filepath.Join(f.root, filepath.Base(remotePath)), data, 0o600); err != nil {
+		return err
+	}
+	if f.failure == "upload" {
+		return errors.New("synthetic upload failed after writing remote bytes")
+	}
+	return nil
+}
+
+func (f *filesystemSyncAPI) Exec(ctx context.Context, _ string, command, _ string) (execResult, error) {
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	cmd.Dir = f.root
+	output, err := cmd.CombinedOutput()
+	code := 0
+	if err != nil {
+		var exited *exec.ExitError
+		if !errors.As(err, &exited) {
+			return execResult{}, err
+		}
+		code = exited.ExitCode()
+	}
+	return execResult{ExitCode: code, Output: string(output)}, nil
 }
 
 func TestSyncWorkspaceWarnsWhenRemoteArchiveCleanupExitsNonzero(t *testing.T) {
@@ -820,7 +921,7 @@ func TestSyncWorkspaceWarnsWhenRemoteArchiveCleanupExitsNonzero(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected extract failure")
 	}
-	if !strings.Contains(stderr.String(), "warning: upstash-box sync cleanup failed for box_1") || !strings.Contains(stderr.String(), "cleanup denied") {
+	if !strings.Contains(stderr.String(), "warning: upstash-box sync cleanup failed:") || !strings.Contains(stderr.String(), "cleanup denied") {
 		t.Fatalf("stderr=%q, want cleanup warning", stderr.String())
 	}
 }

--- a/internal/providers/upstashbox/core.go
+++ b/internal/providers/upstashbox/core.go
@@ -1,10 +1,8 @@
 package upstashbox
 
 import (
-	"context"
 	"flag"
 	"io"
-	"os"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -28,7 +26,6 @@ type StatusView = core.StatusView
 type StopRequest = core.StopRequest
 type Server = core.Server
 type Repo = core.Repo
-type SyncManifest = core.SyncManifest
 type ExitError = core.ExitError
 type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
@@ -120,22 +117,6 @@ func shouldUseShell(command []string) bool {
 
 func leadingEnvAssignment(command []string) bool {
 	return core.LeadingEnvAssignment(command)
-}
-
-func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
-	return core.SyncExcludes(root, cfg)
-}
-
-func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (SyncManifest, error) {
-	return core.BuildSyncManifestFiltered(root, excludes, includes)
-}
-
-func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
-	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
-}
-
-func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
-	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
 }
 
 func inventoryDoctorResult(provider string, leases int) DoctorResult {

--- a/internal/providers/upstashbox/sync.go
+++ b/internal/providers/upstashbox/sync.go
@@ -4,82 +4,62 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
-	"path"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *backend) syncWorkspace(ctx context.Context, client api, boxID string, req RunRequest, workdir, folder string) ([]timingPhase, time.Duration, error) {
-	start := b.now()
-	excludes, err := syncExcludes(req.Repo.Root, b.cfg)
-	if err != nil {
-		return nil, 0, err
-	}
-	manifestStarted := b.now()
-	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
-	if err != nil {
-		return nil, 0, exit(6, "build sync file list: %v", err)
-	}
-	manifestDuration := b.now().Sub(manifestStarted)
-	preflightStarted := b.now()
-	if err := checkSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
-		return nil, 0, err
-	}
-	preflightDuration := b.now().Sub(preflightStarted)
-	prepareStarted := b.now()
-	if err := b.prepareWorkspace(ctx, client, boxID, folder, b.cfg.Sync.Delete); err != nil {
-		return nil, 0, err
-	}
-	prepareDuration := b.now().Sub(prepareStarted)
-	archiveStarted := b.now()
-	archive, err := createSyncArchive(ctx, req.Repo, manifest, b.rt.Stderr)
-	if err != nil {
-		return nil, 0, err
-	}
-	defer func() {
-		_ = archive.Close()
-		_ = os.Remove(archive.Name())
-	}()
-	archiveDuration := b.now().Sub(archiveStarted)
-	uploadStarted := b.now()
-	remoteArchive := workspacePath(".crabbox-upstash-box-sync-" + randomSuffix() + ".tgz")
-	if err := client.UploadFile(ctx, boxID, archive.Name(), remoteArchive); err != nil {
-		return nil, 0, fmt.Errorf("upstash-box upload archive: %w", err)
-	}
-	remoteArchiveName := path.Base(remoteArchive)
-	extract := strings.Join([]string{
-		"tar -xzf " + shellQuote(remoteArchiveName) + " -C " + shellQuote(folder),
-		"rm -f " + shellQuote(remoteArchiveName),
-	}, " && ")
-	if err := b.execShell(ctx, client, boxID, extract, io.Discard); err != nil {
-		if cleanupErr := cleanupRemoteFile(client, boxID, remoteArchiveName); cleanupErr != nil {
-			fmt.Fprintf(b.rt.Stderr, "warning: upstash-box sync cleanup failed for %s: %v\n", boxID, cleanupErr)
-		}
-		return nil, 0, err
-	}
-	uploadDuration := b.now().Sub(uploadStarted)
-	total := b.now().Sub(start)
-	return []timingPhase{
-		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
-		{Name: "preflight", Ms: preflightDuration.Milliseconds()},
-		{Name: "prepare", Ms: prepareDuration.Milliseconds()},
-		{Name: "archive", Ms: archiveDuration.Milliseconds()},
-		{Name: "upload", Ms: uploadDuration.Milliseconds()},
-		{Name: "upstash_box_sync", Ms: total.Milliseconds()},
-	}, total, nil
+func (b *backend) prepareArchive(ctx context.Context, req RunRequest) (*core.PreparedArchive, error) {
+	return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+		TempPattern: "crabbox-upstash-box-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+	})
 }
 
-func (b *backend) prepareWorkspace(ctx context.Context, client api, boxID, folder string, delete bool) error {
+func (b *backend) syncWorkspace(ctx context.Context, client api, boxID string, req RunRequest, workdir, folder string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+	expectedFolder, err := workspaceFolder(workdir)
+	if err != nil {
+		return nil, 0, err
+	}
+	if folder != expectedFolder || strings.Contains(folder, "..") {
+		return nil, 0, exit(2, "upstash-box sync folder does not match workdir")
+	}
+	var archive *core.PreparedArchive
+	if len(prepared) > 0 {
+		archive = prepared[0]
+	}
+	if archive == nil {
+		archive, err = b.prepareArchive(ctx, req)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+	// Box file APIs use absolute workspace paths; exec runs relative to its
+	// workspace root. Keep that translation here, not in the shared lifecycle.
+	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
+		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+		Workdir: folder, RemoteArchiveDir: ".", RemoteArchivePrefix: ".crabbox-upstash-box-sync-",
+		Provider: providerName, PhaseName: "upstash_box_sync", Stderr: b.rt.Stderr, Now: b.now,
+		CleanupContext: func(context.Context) (context.Context, context.CancelFunc) { return upstashBoxCleanupContext() },
+		Upload: func(uploadCtx context.Context, remoteArchive string, _ io.Reader) error {
+			if err := client.UploadFile(uploadCtx, boxID, archive.File.Name(), workspacePath(remoteArchive)); err != nil {
+				return fmt.Errorf("upstash-box upload archive: %w", err)
+			}
+			return nil
+		},
+		Exec: func(execCtx context.Context, command string) error {
+			return b.execShell(execCtx, client, boxID, command, io.Discard)
+		},
+	}, archive)
+}
+
+func (b *backend) prepareWorkspace(ctx context.Context, client api, boxID, folder string) error {
 	folder = strings.Trim(strings.TrimSpace(folder), "/")
 	if folder == "" || strings.Contains(folder, "..") {
 		return exit(2, "upstash-box workspace folder %q is invalid", folder)
 	}
-	command := "mkdir -p " + shellQuote(folder)
-	if delete {
-		command = "rm -rf " + shellQuote(folder) + " && " + command
-	}
-	return b.execShell(ctx, client, boxID, command, io.Discard)
+	return b.execShell(ctx, client, boxID, "mkdir -p "+shellQuote(folder), io.Discard)
 }
 
 func (b *backend) execShell(ctx context.Context, client api, boxID, command string, stdout io.Writer) error {
@@ -94,12 +74,4 @@ func (b *backend) execShell(ctx context.Context, client api, boxID, command stri
 		return commandExitError("upstash-box exec "+command, result)
 	}
 	return nil
-}
-
-func createSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, _ io.Writer) (*os.File, error) {
-	return createPortableSyncArchive(ctx, repo, manifest, "crabbox-upstash-box-sync-*.tgz")
-}
-
-func randomSuffix() string {
-	return strings.ReplaceAll(time.Now().UTC().Format("20060102150405.000000000"), ".", "")
 }


### PR DESCRIPTION
## Summary

Give Upstash Box and Tensorlake the existing shared archive transaction owner: build and check the full snapshot before allocating a fresh sandbox, upload it before touching the workdir, stage delete-sync extraction before replacement, and arm bounded cleanup before the upload can leave partial bytes.

Upstash previously removed the old workdir before local archiving/upload. A failed upload or corrupt tar could therefore erase a reused workspace. Tensorlake already staged replacement, but its independently implemented upload path lost cleanup custody on a partial upload. Both now use PrepareDelegatedArchive and RunDelegatedArchiveSync; the old archive/planning/extraction wrappers are removed.

Native boundaries stay in the adapters. Upstash uploads to absolute paths below /workspace/home while its exec commands use root-relative workspace paths. Tensorlake retains its sbx cp upload and bash exec transport. No provider authentication, endpoint scope, claim authorization, or lifecycle teardown contract changes. SmolVM is intentionally excluded because its supported storage-backed /workspace root needs a separate publication/staging contract.

Shared archive cleanup still preserves the original sync outcome, but reports execution failures as warnings. Its shell retains removal failures and attempts both archive and staging cleanup even under errexit. Successful non-delete sync still merges files; replacement uses the existing shared staged-swap/rollback behavior.

## Verification

Before/after execution used the actual provider sync functions, real local sh/tar/filesystem operations, and synthetic upload/CLI seams. This is native local execution proof, not Upstash or Tensorlake cloud-live proof.

- Baseline Upstash: partial upload and corrupt archive both removed the existing old.txt. Candidate: old.txt retains its original contents; task archive/staging files are absent. Successful replacement removes old files and installs incoming files.
- Baseline Tensorlake: a partially written upload remained after the error. Candidate: the partial upload is removed; corruption preserves the old workspace; successful replace and merge modes preserve their respective semantics.
- Both public Run admission tests now reject an oversized full archive before any provider call. The existing shared full-snapshot guard and ForceSyncLarge behavior are reused.
- Existing cleanup/cancellation regression executes the generated cleanup under real sh -ec with a failing rm, verifies its warning, and retains the original cancellation error.
- Race suites passed for Upstash, Tensorlake, Cloudflare, Nomad, OpenSandbox and shared, plus focused core archive preparation/sync tests. Vet, CLI build, docs build and full deadcode check passed.
- Managed pre-commit review and independent semantic review completed without outstanding actionable findings. One semantic review finding exposed shell cleanup-error suppression; that was corrected and covered before committing.

Changelog and both provider docs are updated. No new dependencies, configuration fields, real cloud allocations, or secret changes.
