### PR TITLE
refactor(smoke): share provider validation helpers

### DIFF
--- a/scripts/lib/live-smoke-common.sh
+++ b/scripts/lib/live-smoke-common.sh
@@ -1,0 +1,106 @@
+classify_validation_failure() {
+  local command="$1"
+  local status="$2"
+  local output="$3"
+  printf 'classification=validation_failed command=%q exit=%s\n' "$command" "$status" >&2
+  printf '%s\n' "$output" >&2
+}
+
+run_capture() {
+  local command="$1"
+  shift
+  local output
+  set +e
+  output="$("$@" 2>&1)"
+  local status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_blocker "$command" "$status" "$output"
+    exit "$status"
+  fi
+  printf '%s\n' "$output"
+}
+
+validate_list_json_contains_slug() {
+  local command="$1"
+  local output="$2"
+  local validation_output=""
+  local status=0
+  set +e
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
+import json
+import os
+import sys
+
+slug = os.environ["CRABBOX_SMOKE_SLUG"]
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+def has_slug(value):
+    if isinstance(value, dict):
+        labels = value.get("labels")
+        if isinstance(labels, dict) and labels.get("slug") == slug:
+            return True
+        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
+            return True
+        return any(has_slug(child) for child in value.values())
+    if isinstance(value, list):
+        return any(has_slug(child) for child in value)
+    return False
+
+if not has_slug(payload):
+    print(f"list JSON did not include slug {slug}", file=sys.stderr)
+    sys.exit(1)
+' <<<"$output" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_validation_failure "$command" "$status" "$validation_output"
+    exit "$status"
+  fi
+}
+
+validate_list_json_empty() {
+  local command="$1"
+  local output="$2"
+  local provider="$3"
+  local validation_output=""
+  local status=0
+  set +e
+  validation_output="$(python3 -c '
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+if payload != []:
+    print(f"{sys.argv[1]} Crabbox inventory is not empty", file=sys.stderr)
+    sys.exit(1)
+' "$provider" <<<"$output" 2>&1)"
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ]; then
+    classify_validation_failure "$command" "$status" "$validation_output"
+    exit "$status"
+  fi
+}
+
+local_testbox_key_snapshot() {
+  local roots=(
+    "${XDG_CONFIG_HOME:-$HOME/.config}/crabbox/testboxes"
+    "$HOME/Library/Application Support/crabbox/testboxes"
+  )
+  local root
+  for root in "${roots[@]}"; do
+    if [ -d "$root" ]; then
+      find "$root" -type f -print
+    fi
+  done | sort -u
+}

--- a/scripts/live-digitalocean-smoke.sh
+++ b/scripts/live-digitalocean-smoke.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+source "$(dirname "${BASH_SOURCE[0]}")/lib/live-smoke-common.sh"
+
 provider_enabled() {
   local list="${CRABBOX_LIVE_PROVIDERS:-digitalocean}"
   local item
@@ -26,99 +28,6 @@ classify_blocker() {
   fi
   printf 'classification=%s command=%q exit=%s\n' "$classification" "$command" "$status" >&2
   printf '%s\n' "$output" >&2
-}
-
-classify_validation_failure() {
-  local command="$1"
-  local status="$2"
-  local output="$3"
-  printf 'classification=validation_failed command=%q exit=%s\n' "$command" "$status" >&2
-  printf '%s\n' "$output" >&2
-}
-
-run_capture() {
-  local command="$1"
-  shift
-  local output
-  set +e
-  output="$("$@" 2>&1)"
-  local status=$?
-  set -e
-  if [ "$status" -ne 0 ]; then
-    classify_blocker "$command" "$status" "$output"
-    exit "$status"
-  fi
-  printf '%s\n' "$output"
-}
-
-validate_list_json_contains_slug() {
-  local command="$1"
-  local output="$2"
-  local validation_output=""
-  local status=0
-  set +e
-  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
-import json
-import os
-import sys
-
-slug = os.environ["CRABBOX_SMOKE_SLUG"]
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-def has_slug(value):
-    if isinstance(value, dict):
-        labels = value.get("labels")
-        if isinstance(labels, dict) and labels.get("slug") == slug:
-            return True
-        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
-            return True
-        return any(has_slug(child) for child in value.values())
-    if isinstance(value, list):
-        return any(has_slug(child) for child in value)
-    return False
-
-if not has_slug(payload):
-    print(f"list JSON did not include slug {slug}", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
-  status=$?
-  set -e
-  if [ "$status" -ne 0 ]; then
-    classify_validation_failure "$command" "$status" "$validation_output"
-    exit "$status"
-  fi
-}
-
-validate_list_json_empty() {
-  local command="$1"
-  local output="$2"
-  local validation_output=""
-  local status=0
-  set +e
-  validation_output="$(python3 -c '
-import json
-import sys
-
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-if payload != []:
-    print("DigitalOcean Crabbox inventory is not empty", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
-  status=$?
-  set -e
-  if [ "$status" -ne 0 ]; then
-    classify_validation_failure "$command" "$status" "$validation_output"
-    exit "$status"
-	fi
 }
 
 raw_digitalocean_has_slug() {
@@ -194,19 +103,6 @@ except Exception:
 
 print(json.dumps(sorted(keys, key=lambda key: (key["name"], str(key["id"]))), separators=(",", ":")))
 '
-}
-
-local_testbox_key_snapshot() {
-  local roots=(
-    "${XDG_CONFIG_HOME:-$HOME/.config}/crabbox/testboxes"
-    "$HOME/Library/Application Support/crabbox/testboxes"
-  )
-  local root
-  for root in "${roots[@]}"; do
-    if [ -d "$root" ]; then
-      find "$root" -type f -print
-    fi
-  done | sort -u
 }
 
 cleanup_armed=0
@@ -313,7 +209,7 @@ export DIGITALOCEAN_TOKEN
 doctor_output="$(run_capture "$crabbox_bin doctor --provider digitalocean" "$crabbox_bin" doctor --provider digitalocean)"
 printf '%s\n' "$doctor_output"
 initial_list_output="$(run_capture "$crabbox_bin list --provider digitalocean --json" "$crabbox_bin" list --provider digitalocean --json)"
-validate_list_json_empty "$crabbox_bin list --provider digitalocean --json" "$initial_list_output"
+validate_list_json_empty "$crabbox_bin list --provider digitalocean --json" "$initial_list_output" "DigitalOcean"
 initial_managed_key_snapshot="$(run_capture "digitalocean managed SSH key snapshot" raw_digitalocean_managed_key_snapshot)"
 initial_local_key_snapshot="$(local_testbox_key_snapshot)"
 cleanup_armed=1
@@ -327,7 +223,7 @@ run_capture "$crabbox_bin stop --provider digitalocean $slug" "$crabbox_bin" sto
 cleanup_armed=0
 cleanup_output="$(run_capture "$crabbox_bin cleanup --provider digitalocean --dry-run" "$crabbox_bin" cleanup --provider digitalocean --dry-run)"
 post_list_output="$(run_capture "$crabbox_bin list --provider digitalocean --json" "$crabbox_bin" list --provider digitalocean --json)"
-validate_list_json_empty "$crabbox_bin list --provider digitalocean --json" "$post_list_output"
+validate_list_json_empty "$crabbox_bin list --provider digitalocean --json" "$post_list_output" "DigitalOcean"
 printf '%s\n' "$cleanup_output"
 printf '%s\n' "$post_list_output"
 printf 'classification=live_digitalocean_smoke_passed slug=%s cleanup=complete\n' "$slug"

--- a/scripts/live-digitalocean-smoke.test.js
+++ b/scripts/live-digitalocean-smoke.test.js
@@ -50,7 +50,9 @@ exec ${JSON.stringify(python)} "$@"
 }
 
 const prepareSmokeRepo = (dir) =>
-  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-digitalocean-smoke.sh"));
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-digitalocean-smoke.sh"), [
+    "lib/live-smoke-common.sh",
+  ]);
 
 test("live digitalocean smoke skips unless opted in", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-do-skip-"));

--- a/scripts/live-linode-smoke.sh
+++ b/scripts/live-linode-smoke.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+source "$(dirname "${BASH_SOURCE[0]}")/lib/live-smoke-common.sh"
+
 provider_enabled() {
   local list="${CRABBOX_LIVE_PROVIDERS:-linode}"
   local item
@@ -26,99 +28,6 @@ classify_blocker() {
   fi
   printf 'classification=%s command=%q exit=%s\n' "$classification" "$command" "$status" >&2
   printf '%s\n' "$output" >&2
-}
-
-classify_validation_failure() {
-  local command="$1"
-  local status="$2"
-  local output="$3"
-  printf 'classification=validation_failed command=%q exit=%s\n' "$command" "$status" >&2
-  printf '%s\n' "$output" >&2
-}
-
-run_capture() {
-  local command="$1"
-  shift
-  local output
-  set +e
-  output="$("$@" 2>&1)"
-  local status=$?
-  set -e
-  if [ "$status" -ne 0 ]; then
-    classify_blocker "$command" "$status" "$output"
-    exit "$status"
-  fi
-  printf '%s\n' "$output"
-}
-
-validate_list_json_contains_slug() {
-  local command="$1"
-  local output="$2"
-  local validation_output=""
-  local status=0
-  set +e
-  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
-import json
-import os
-import sys
-
-slug = os.environ["CRABBOX_SMOKE_SLUG"]
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-def has_slug(value):
-    if isinstance(value, dict):
-        labels = value.get("labels")
-        if isinstance(labels, dict) and labels.get("slug") == slug:
-            return True
-        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
-            return True
-        return any(has_slug(child) for child in value.values())
-    if isinstance(value, list):
-        return any(has_slug(child) for child in value)
-    return False
-
-if not has_slug(payload):
-    print(f"list JSON did not include slug {slug}", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
-  status=$?
-  set -e
-  if [ "$status" -ne 0 ]; then
-    classify_validation_failure "$command" "$status" "$validation_output"
-    exit "$status"
-  fi
-}
-
-validate_list_json_empty() {
-  local command="$1"
-  local output="$2"
-  local validation_output=""
-  local status=0
-  set +e
-  validation_output="$(python3 -c '
-import json
-import sys
-
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-if payload != []:
-    print("Linode Crabbox inventory is not empty", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
-  status=$?
-  set -e
-  if [ "$status" -ne 0 ]; then
-    classify_validation_failure "$command" "$status" "$validation_output"
-    exit "$status"
-  fi
 }
 
 raw_linode_has_slug() {
@@ -158,19 +67,6 @@ except Exception:
 
 sys.exit(1)
 '
-}
-
-local_testbox_key_snapshot() {
-  local roots=(
-    "${XDG_CONFIG_HOME:-$HOME/.config}/crabbox/testboxes"
-    "$HOME/Library/Application Support/crabbox/testboxes"
-  )
-  local root
-  for root in "${roots[@]}"; do
-    if [ -d "$root" ]; then
-      find "$root" -type f -print
-    fi
-  done | sort -u
 }
 
 cleanup_armed=0
@@ -275,7 +171,7 @@ export LINODE_TOKEN
 doctor_output="$(run_capture "$crabbox_bin doctor --provider linode" "$crabbox_bin" doctor --provider linode)"
 printf '%s\n' "$doctor_output"
 initial_list_output="$(run_capture "$crabbox_bin list --provider linode --json" "$crabbox_bin" list --provider linode --json)"
-validate_list_json_empty "$crabbox_bin list --provider linode --json" "$initial_list_output"
+validate_list_json_empty "$crabbox_bin list --provider linode --json" "$initial_list_output" "Linode"
 initial_local_key_snapshot="$(local_testbox_key_snapshot)"
 cleanup_armed=1
 run_capture "$crabbox_bin warmup --provider linode --slug $slug --keep --type g6-standard-1 --ttl 20m --idle-timeout 5m" "$crabbox_bin" warmup --provider linode --slug "$slug" --keep --type g6-standard-1 --ttl 20m --idle-timeout 5m >/dev/null
@@ -288,7 +184,7 @@ run_capture "$crabbox_bin stop --provider linode $slug" "$crabbox_bin" stop --pr
 cleanup_armed=0
 cleanup_output="$(run_capture "$crabbox_bin cleanup --provider linode --dry-run" "$crabbox_bin" cleanup --provider linode --dry-run)"
 post_list_output="$(run_capture "$crabbox_bin list --provider linode --json" "$crabbox_bin" list --provider linode --json)"
-validate_list_json_empty "$crabbox_bin list --provider linode --json" "$post_list_output"
+validate_list_json_empty "$crabbox_bin list --provider linode --json" "$post_list_output" "Linode"
 printf '%s\n' "$cleanup_output"
 printf '%s\n' "$post_list_output"
 printf 'classification=live_linode_smoke_passed slug=%s cleanup=complete\n' "$slug"

--- a/scripts/live-linode-smoke.test.js
+++ b/scripts/live-linode-smoke.test.js
@@ -23,7 +23,9 @@ exec ${JSON.stringify(python)} "$@"
 }
 
 const prepareSmokeRepo = (dir) =>
-  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-linode-smoke.sh"));
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-linode-smoke.sh"), [
+    "lib/live-smoke-common.sh",
+  ]);
 
 test("live linode smoke skips unless opted in", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-linode-skip-"));

--- a/scripts/live-ovh-smoke.sh
+++ b/scripts/live-ovh-smoke.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+source "$(dirname "${BASH_SOURCE[0]}")/lib/live-smoke-common.sh"
+
 provider_enabled() {
   local list="${CRABBOX_LIVE_PROVIDERS:-ovh}"
   local item
@@ -26,99 +28,6 @@ classify_blocker() {
   fi
   printf 'classification=%s command=%q exit=%s\n' "$classification" "$command" "$status" >&2
   printf '%s\n' "$output" >&2
-}
-
-classify_validation_failure() {
-  local command="$1"
-  local status="$2"
-  local output="$3"
-  printf 'classification=validation_failed command=%q exit=%s\n' "$command" "$status" >&2
-  printf '%s\n' "$output" >&2
-}
-
-run_capture() {
-  local command="$1"
-  shift
-  local output
-  set +e
-  output="$("$@" 2>&1)"
-  local status=$?
-  set -e
-  if [ "$status" -ne 0 ]; then
-    classify_blocker "$command" "$status" "$output"
-    exit "$status"
-  fi
-  printf '%s\n' "$output"
-}
-
-validate_list_json_contains_slug() {
-  local command="$1"
-  local output="$2"
-  local validation_output=""
-  local status=0
-  set +e
-  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
-import json
-import os
-import sys
-
-slug = os.environ["CRABBOX_SMOKE_SLUG"]
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-def has_slug(value):
-    if isinstance(value, dict):
-        labels = value.get("labels")
-        if isinstance(labels, dict) and labels.get("slug") == slug:
-            return True
-        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
-            return True
-        return any(has_slug(child) for child in value.values())
-    if isinstance(value, list):
-        return any(has_slug(child) for child in value)
-    return False
-
-if not has_slug(payload):
-    print(f"list JSON did not include slug {slug}", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
-  status=$?
-  set -e
-  if [ "$status" -ne 0 ]; then
-    classify_validation_failure "$command" "$status" "$validation_output"
-    exit "$status"
-  fi
-}
-
-validate_list_json_empty() {
-  local command="$1"
-  local output="$2"
-  local validation_output=""
-  local status=0
-  set +e
-  validation_output="$(python3 -c '
-import json
-import sys
-
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-if payload != []:
-    print("OVH Crabbox inventory is not empty", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
-  status=$?
-  set -e
-  if [ "$status" -ne 0 ]; then
-    classify_validation_failure "$command" "$status" "$validation_output"
-    exit "$status"
-  fi
 }
 
 doctor_inventory_empty() {
@@ -236,7 +145,7 @@ doctor_output="$(run_capture "$crabbox_bin doctor --provider ovh" "$crabbox_bin"
 validate_doctor_inventory_empty "$crabbox_bin doctor --provider ovh" "$doctor_output"
 printf '%s\n' "$doctor_output"
 initial_list_output="$(run_capture "$crabbox_bin list --provider ovh --json" "$crabbox_bin" list --provider ovh --json)"
-validate_list_json_empty "$crabbox_bin list --provider ovh --json" "$initial_list_output"
+validate_list_json_empty "$crabbox_bin list --provider ovh --json" "$initial_list_output" "OVH"
 cleanup_armed=1
 run_capture "$crabbox_bin warmup --provider ovh --slug $slug --keep --type $ovh_flavor --ttl 20m --idle-timeout 5m" "$crabbox_bin" warmup --provider ovh --slug "$slug" --keep --type "$ovh_flavor" --ttl 20m --idle-timeout 5m >/dev/null
 run_capture "$crabbox_bin status --provider ovh --id $slug --wait --wait-timeout 300s" "$crabbox_bin" status --provider ovh --id "$slug" --wait --wait-timeout 300s >/dev/null
@@ -259,7 +168,7 @@ done
 validate_doctor_inventory_empty "$crabbox_bin doctor --provider ovh" "$post_doctor_output"
 cleanup_output="$(run_capture "$crabbox_bin cleanup --provider ovh --dry-run" "$crabbox_bin" cleanup --provider ovh --dry-run)"
 post_list_output="$(run_capture "$crabbox_bin list --provider ovh --json" "$crabbox_bin" list --provider ovh --json)"
-validate_list_json_empty "$crabbox_bin list --provider ovh --json" "$post_list_output"
+validate_list_json_empty "$crabbox_bin list --provider ovh --json" "$post_list_output" "OVH"
 printf '%s\n' "$cleanup_output"
 printf '%s\n' "$post_doctor_output"
 printf '%s\n' "$post_list_output"

--- a/scripts/live-ovh-smoke.test.js
+++ b/scripts/live-ovh-smoke.test.js
@@ -9,7 +9,9 @@ import { copySmokeRepo, writeExecutable, writeGoStub } from "./test-support/smok
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
 const prepareSmokeRepo = (dir) =>
-  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-ovh-smoke.sh"));
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-ovh-smoke.sh"), [
+    "lib/live-smoke-common.sh",
+  ]);
 
 test("live ovh smoke skips unless opted in", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-ovh-skip-"));

--- a/scripts/live-scaleway-smoke.sh
+++ b/scripts/live-scaleway-smoke.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+source "$(dirname "${BASH_SOURCE[0]}")/lib/live-smoke-common.sh"
+
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 repo="${CRABBOX_LIVE_REPO:-$root}"
 cb="${CRABBOX_BIN:-$root/bin/crabbox}"
@@ -71,89 +73,6 @@ run_capture() {
     exit "$status"
   fi
   redact_output "$output"
-}
-
-validate_list_json_contains_slug() {
-  local command="$1"
-  local output="$2"
-  local validation_output=""
-  local status=0
-  set +e
-  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
-import json
-import os
-import sys
-
-slug = os.environ["CRABBOX_SMOKE_SLUG"]
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-def has_slug(value):
-    if isinstance(value, dict):
-        labels = value.get("labels")
-        if isinstance(labels, dict) and labels.get("slug") == slug:
-            return True
-        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
-            return True
-        return any(has_slug(child) for child in value.values())
-    if isinstance(value, list):
-        return any(has_slug(child) for child in value)
-    return False
-
-if not has_slug(payload):
-    print(f"list JSON did not include slug {slug}", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
-  status=$?
-  set -e
-  if [ "$status" -ne 0 ]; then
-    classify_validation_failure "$command" "$status" "$validation_output"
-    exit "$status"
-  fi
-}
-
-validate_list_json_empty() {
-  local command="$1"
-  local output="$2"
-  local validation_output=""
-  local status=0
-  set +e
-  validation_output="$(python3 -c '
-import json
-import sys
-
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-if payload != []:
-    print("Scaleway Crabbox inventory is not empty", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
-  status=$?
-  set -e
-  if [ "$status" -ne 0 ]; then
-    classify_validation_failure "$command" "$status" "$validation_output"
-    exit "$status"
-  fi
-}
-
-local_testbox_key_snapshot() {
-  local roots=(
-    "${XDG_CONFIG_HOME:-$HOME/.config}/crabbox/testboxes"
-    "$HOME/Library/Application Support/crabbox/testboxes"
-  )
-  local root
-  for root in "${roots[@]}"; do
-    if [ -d "$root" ]; then
-      find "$root" -type f -print
-    fi
-  done | sort -u
 }
 
 cleanup_armed=0
@@ -280,7 +199,7 @@ export SCW_SECRET_KEY
 doctor_output="$(run_capture "bin/crabbox doctor --provider scaleway" run_crabbox doctor --provider scaleway)"
 printf '%s\n' "$doctor_output"
 initial_list_output="$(run_capture "bin/crabbox list --provider scaleway --json" run_crabbox list --provider scaleway --json)"
-validate_list_json_empty "bin/crabbox list --provider scaleway --json" "$initial_list_output"
+validate_list_json_empty "bin/crabbox list --provider scaleway --json" "$initial_list_output" "Scaleway"
 initial_local_key_snapshot="$(local_testbox_key_snapshot)"
 cleanup_armed=1
 run_capture "bin/crabbox warmup --provider scaleway --slug $slug --keep --type $scaleway_type --ttl 20m --idle-timeout 5m" run_crabbox warmup --provider scaleway --slug "$slug" --keep --type "$scaleway_type" --ttl 20m --idle-timeout 5m >/dev/null
@@ -292,7 +211,7 @@ validate_list_json_contains_slug "bin/crabbox list --provider scaleway --json" "
 run_capture "bin/crabbox stop --provider scaleway $slug" run_crabbox stop --provider scaleway "$slug" >/dev/null
 cleanup_output="$(run_capture "bin/crabbox cleanup --provider scaleway --dry-run" run_crabbox cleanup --provider scaleway --dry-run)"
 post_list_output="$(run_capture "bin/crabbox list --provider scaleway --json" run_crabbox list --provider scaleway --json)"
-validate_list_json_empty "bin/crabbox list --provider scaleway --json" "$post_list_output"
+validate_list_json_empty "bin/crabbox list --provider scaleway --json" "$post_list_output" "Scaleway"
 cleanup_armed=0
 printf '%s\n' "$cleanup_output"
 printf '%s\n' "$post_list_output"

--- a/scripts/live-scaleway-smoke.test.js
+++ b/scripts/live-scaleway-smoke.test.js
@@ -9,7 +9,9 @@ import { copySmokeRepo, writeExecutable, writeGoStub } from "./test-support/smok
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
 const prepareSmokeRepo = (dir) =>
-  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-scaleway-smoke.sh"));
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-scaleway-smoke.sh"), [
+    "lib/live-smoke-common.sh",
+  ]);
 
 const validEnv = {
   CRABBOX_LIVE: "1",
@@ -101,6 +103,8 @@ fi
 case "$1" in
   doctor)
     printf 'auth=ready control_plane=ready inventory=ready api=list mutation=false leases=0 region=fr-par zone=fr-par-1 type=DEV1-S\\n'
+    printf 'access=%s\\n' "\${SCW_ACCESS_KEY}"
+    printf 'secret=%s\\n' "\${SCW_SECRET_KEY}" >&2
     ;;
   warmup)
     printf '%s\\n' "$5" >"${slugFile}"
@@ -146,6 +150,7 @@ esac
   assert.equal(result.status, 0, result.stdout + result.stderr);
   assert.match(result.stdout, /classification=live_scaleway_smoke_passed/);
   assert.doesNotMatch(result.stdout + result.stderr, /test-scaleway-access|test-scaleway-secret/);
+  assert.match(result.stdout, /access=\[redacted\]\nsecret=\[redacted\]/);
 
   const seen = fs.readFileSync(calls, "utf8").trim().split("\n");
   assert.equal(seen[0], "doctor --provider scaleway");
@@ -377,6 +382,41 @@ esac
     "doctor --provider scaleway",
     "list --provider scaleway --json",
   ]);
+});
+
+test("live scaleway smoke redacts secret-bearing validation diagnostics", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-scaleway-redact-validation-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const binDir = path.join(dir, "bin");
+  const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+  fs.mkdirSync(binDir);
+  writeExecutable(
+    path.join(binDir, "python3"),
+    '#!/usr/bin/env bash\nprintf "invalid JSON: access=%s secret=%s\\n" "$SCW_ACCESS_KEY" "$SCW_SECRET_KEY" >&2\nexit 1\n',
+  );
+  writeGoStub(
+    binDir,
+    `#!/usr/bin/env bash
+case "$1" in
+  doctor) printf 'ready\\n' ;;
+  list) printf '[]\\n' ;;
+  *) exit 99 ;;
+esac
+`,
+  );
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: tempRoot,
+    env: {
+      ...process.env,
+      ...validEnv,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stderr, /classification=validation_failed/);
+  assert.match(result.stderr, /invalid JSON: access=\[redacted\] secret=\[redacted\]/);
+  assert.doesNotMatch(result.stdout + result.stderr, /test-scaleway-access|test-scaleway-secret/);
 });
 
 test("live scaleway smoke classifies quota output and redacts leaked keys", () => {

--- a/scripts/live-smoke-common.test.js
+++ b/scripts/live-smoke-common.test.js
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { copySmokeRepo, writeExecutable } from "./test-support/smoke-fixtures.mjs";
+
+const common = path.join(import.meta.dirname, "lib", "live-smoke-common.sh");
+
+function runCommon(body, args = [], options = {}) {
+  return spawnSync("bash", ["-c", 'source "$1"\nshift\n' + body, "smoke", common, ...args], {
+    encoding: "utf8",
+    ...options,
+  });
+}
+
+test("sourcing common smoke helpers only defines functions", () => {
+  for (const options of ["set +e", "set -euo pipefail"]) {
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        `${options}
+trap ':' USR1
+export SMOKE_SENTINEL='unchanged value'
+before="$(pwd; set +o; trap -p; export -p)"
+source "$1"
+after="$(pwd; set +o; trap -p; export -p)"
+[[ "$before" == "$after" ]]
+`,
+        "smoke",
+        common,
+      ],
+      { encoding: "utf8" },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, "");
+    assert.equal(result.stderr, "");
+  }
+});
+
+test("slug validation accepts exact supported fields anywhere in dictionaries and lists", () => {
+  const slug = "smoke-123";
+  const records = [
+    { labels: { slug } },
+    ...["slug", "name", "id", "leaseId"].map((key) => ({ [key]: slug })),
+  ];
+  for (const record of records) {
+    for (const payload of [record, [record], { arbitrary: [null, { child: record }] }]) {
+      const result = runCommon('slug="$1"\nvalidate_list_json_contains_slug "list --json" "$2"', [
+        slug,
+        JSON.stringify(payload),
+      ]);
+      assert.equal(result.status, 0, JSON.stringify(payload) + result.stderr);
+      assert.equal(result.stdout + result.stderr, "");
+    }
+  }
+});
+
+test("slug validation rejects unrelated values, aliases, scalar values, and partial matches", () => {
+  const slug = "smoke-123";
+  const payloads = [
+    [],
+    {},
+    null,
+    false,
+    123,
+    slug,
+    [slug],
+    { other: slug },
+    { lease_id: slug },
+    { labels: { other: slug } },
+    { slug: slug.toUpperCase() },
+    { name: `prefix-${slug}` },
+    { id: `${slug}-suffix` },
+    { slug: 123 },
+  ];
+  for (const payload of payloads) {
+    const result = runCommon(
+      'slug="$1"\nvalidate_list_json_contains_slug "list --json" "$2"\nprintf unreachable',
+      [slug, JSON.stringify(payload)],
+    );
+    assert.equal(result.status, 1, JSON.stringify(payload) + result.stderr);
+    assert.equal(result.stdout, "");
+    assert.equal(
+      result.stderr,
+      "classification=validation_failed command=list\\ --json exit=1\n" +
+        `list JSON did not include slug ${slug}\n`,
+    );
+  }
+  const numeric = runCommon("slug=123\nvalidate_list_json_contains_slug list '{\"id\":123}'");
+  assert.equal(numeric.status, 1, numeric.stderr);
+});
+
+test("empty inventory validation accepts only an empty JSON list and preserves display labels", () => {
+  for (const payload of ["[]", " \n [ ] \t"]) {
+    const result = runCommon('validate_list_json_empty list "$1" Example', [payload]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout + result.stderr, "");
+  }
+  for (const label of ["DigitalOcean", "Linode", "OVH", "Scaleway", "Tencent Cloud", "Vultr"]) {
+    for (const payload of ["{}", "null", "false", "0", '""', "[{}]", "[[]]"]) {
+      const result = runCommon(
+        'validate_list_json_empty "list --json" "$1" "$2"\nprintf unreachable',
+        [payload, label],
+      );
+      assert.equal(result.status, 1, result.stderr);
+      assert.equal(result.stdout, "");
+      assert.equal(
+        result.stderr,
+        "classification=validation_failed command=list\\ --json exit=1\n" +
+          `${label} Crabbox inventory is not empty\n`,
+      );
+    }
+  }
+});
+
+test("both JSON validators classify malformed input without losing parser diagnostics", () => {
+  for (const validator of ["validate_list_json_contains_slug", "validate_list_json_empty"]) {
+    const result = runCommon(`slug=smoke\n${validator} list '{"broken":' Example`);
+    assert.equal(result.status, 1, result.stderr);
+    assert.equal(result.stdout, "");
+    assert.match(
+      result.stderr,
+      /^classification=validation_failed command=list exit=1\ninvalid JSON: /,
+    );
+  }
+});
+
+test("capture preserves argument boundaries, merges streams, and normalizes trailing newlines", () => {
+  const result = runCommon(`
+run_capture ignored bash -c 'printf "<%s><%s>" "$1" "$2"; printf stderr >&2; printf "\\n\\n"' command 'a b' '*'
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "<a b><*>stderr\n");
+  assert.equal(result.stderr, "");
+});
+
+test("failed capture calls the provider classifier and exits with the original status", () => {
+  const result = runCommon(`
+classify_blocker() {
+  printf 'provider-blocker command=%q exit=%s\\n' "$1" "$2" >&2
+  printf '%s\\n' "$3" >&2
+}
+trap 'printf "exit=%s\\n" "$?" >&2' EXIT
+set +e
+run_capture 'doctor --name a b' bash -c 'printf out; printf "err\\n\\n" >&2; exit 37'
+printf unreachable
+`);
+  assert.equal(result.status, 37, result.stderr);
+  assert.equal(result.stdout, "");
+  assert.equal(
+    result.stderr,
+    "provider-blocker command=doctor\\ --name\\ a\\ b exit=37\nouterr\nexit=37\n",
+  );
+});
+
+test("capture and successful validators leave errexit enabled", () => {
+  for (const command of [
+    "run_capture command true",
+    'slug=smoke\nvalidate_list_json_contains_slug list \'{"slug":"smoke"}\'',
+    "validate_list_json_empty list '[]' Example",
+  ]) {
+    const result = runCommon(`set +e\n${command}\nfalse\nprintf unreachable`);
+    assert.equal(result.status, 1, result.stderr);
+    assert.doesNotMatch(result.stdout, /unreachable/);
+  }
+});
+
+test("local key snapshots retain both roots, regular files only, and sorted unique paths", (t) => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-smoke-keys-"));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const macRoot = path.join(home, "Library", "Application Support", "crabbox", "testboxes");
+  const xdg = path.join(home, "config");
+  const xdgRoot = path.join(xdg, "crabbox", "testboxes");
+  const files = [path.join(macRoot, "b"), path.join(xdgRoot, "nested", "a")];
+  for (const file of files) {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, "fixture");
+  }
+  fs.symlinkSync(files[0], path.join(xdgRoot, "linked-key"));
+  const env = { ...process.env, HOME: home, XDG_CONFIG_HOME: xdg, LC_ALL: "C" };
+  const result = runCommon("local_testbox_key_snapshot", [], { env });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, files.sort().join("\n") + "\n");
+
+  env.XDG_CONFIG_HOME = path.join(home, "Library", "Application Support");
+  const duplicate = runCommon("local_testbox_key_snapshot", [], { env });
+  assert.equal(duplicate.stdout, path.join(macRoot, "b") + "\n");
+  fs.renameSync(xdg, path.join(home, ".config"));
+  delete env.XDG_CONFIG_HOME;
+  const fallback = runCommon("local_testbox_key_snapshot", [], { env });
+  assert.equal(fallback.status, 0, fallback.stderr);
+  assert.equal(
+    fallback.stdout,
+    files
+      .map((file) => file.replace("/config/", "/.config/"))
+      .sort()
+      .join("\n") + "\n",
+  );
+});
+
+test("smoke fixtures copy only explicit dependencies and work outside a root with spaces", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox smoke fixture-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const source = path.join(dir, "source");
+  fs.mkdirSync(path.join(source, "lib"), { recursive: true });
+  const script = path.join(source, "smoke.sh");
+  writeExecutable(
+    script,
+    '#!/usr/bin/env bash\nsource "$(dirname "${BASH_SOURCE[0]}")/lib/live-smoke-common.sh"\nvalidate_list_json_empty list "[]" Example\n',
+  );
+  fs.copyFileSync(common, path.join(source, "lib", "live-smoke-common.sh"));
+  fs.writeFileSync(path.join(source, "unrelated"), "not a dependency");
+  const plain = copySmokeRepo(path.join(dir, "plain"), script);
+  assert.deepEqual(fs.readdirSync(path.join(plain.tempRoot, "scripts")), ["smoke.sh"]);
+  assert.equal(fs.statSync(plain.smokeScript).mode & 0o777, 0o755);
+
+  const copied = copySmokeRepo(path.join(dir, "copied"), script, ["lib/live-smoke-common.sh"]);
+  assert.equal(
+    fs
+      .lstatSync(path.join(copied.tempRoot, "scripts", "lib", "live-smoke-common.sh"))
+      .isSymbolicLink(),
+    false,
+  );
+  fs.rmSync(source, { recursive: true });
+  const result = spawnSync("bash", [copied.smokeScript], { cwd: dir, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout + result.stderr, "");
+  assert.throws(
+    () => copySmokeRepo(path.join(dir, "missing"), copied.smokeScript, ["missing.sh"]),
+    { code: "ENOENT" },
+  );
+});

--- a/scripts/live-tencentcloud-smoke.sh
+++ b/scripts/live-tencentcloud-smoke.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+source "$(dirname "${BASH_SOURCE[0]}")/lib/live-smoke-common.sh"
+
 provider_enabled() {
   local list="${CRABBOX_LIVE_PROVIDERS:-tencentcloud}"
   local item
@@ -26,99 +28,6 @@ classify_blocker() {
   fi
   printf 'classification=%s command=%q exit=%s\n' "$classification" "$command" "$status" >&2
   printf '%s\n' "$output" >&2
-}
-
-classify_validation_failure() {
-  local command="$1"
-  local status="$2"
-  local output="$3"
-  printf 'classification=validation_failed command=%q exit=%s\n' "$command" "$status" >&2
-  printf '%s\n' "$output" >&2
-}
-
-run_capture() {
-  local command="$1"
-  shift
-  local output
-  set +e
-  output="$("$@" 2>&1)"
-  local status=$?
-  set -e
-  if [ "$status" -ne 0 ]; then
-    classify_blocker "$command" "$status" "$output"
-    exit "$status"
-  fi
-  printf '%s\n' "$output"
-}
-
-validate_list_json_contains_slug() {
-  local command="$1"
-  local output="$2"
-  local validation_output=""
-  local status=0
-  set +e
-  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
-import json
-import os
-import sys
-
-slug = os.environ["CRABBOX_SMOKE_SLUG"]
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-def has_slug(value):
-    if isinstance(value, dict):
-        labels = value.get("labels")
-        if isinstance(labels, dict) and labels.get("slug") == slug:
-            return True
-        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
-            return True
-        return any(has_slug(child) for child in value.values())
-    if isinstance(value, list):
-        return any(has_slug(child) for child in value)
-    return False
-
-if not has_slug(payload):
-    print(f"list JSON did not include slug {slug}", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
-  status=$?
-  set -e
-  if [ "$status" -ne 0 ]; then
-    classify_validation_failure "$command" "$status" "$validation_output"
-    exit "$status"
-  fi
-}
-
-validate_list_json_empty() {
-	local command="$1"
-	local output="$2"
-	local validation_output=""
-  local status=0
-  set +e
-  validation_output="$(python3 -c '
-import json
-import sys
-
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-if payload != []:
-    print("Tencent Cloud Crabbox inventory is not empty", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
-  status=$?
-  set -e
-  if [ "$status" -ne 0 ]; then
-    classify_validation_failure "$command" "$status" "$validation_output"
-    exit "$status"
-	fi
 }
 
 list_json_empty() {
@@ -221,7 +130,7 @@ doctor_output="$(run_capture "$crabbox_bin doctor --provider tencentcloud" "$cra
 printf '%s\n' "$doctor_output"
 
 list_output="$(run_capture "$crabbox_bin list --provider tencentcloud --json" "$crabbox_bin" list --provider tencentcloud --json)"
-validate_list_json_empty "$crabbox_bin list --provider tencentcloud --json" "$list_output"
+validate_list_json_empty "$crabbox_bin list --provider tencentcloud --json" "$list_output" "Tencent Cloud"
 
 cleanup_armed=1
 warmup_output="$(run_capture "$crabbox_bin warmup --provider tencentcloud --slug $slug --keep --tencentcloud-image $image --tencentcloud-type $type_arg --ttl 20m --idle-timeout 5m" "$crabbox_bin" warmup --provider tencentcloud --slug "$slug" --keep --tencentcloud-image "$image" --tencentcloud-type "$type_arg" --ttl 20m --idle-timeout 5m)"
@@ -248,6 +157,6 @@ cleanup_output="$(run_capture "$crabbox_bin cleanup --provider tencentcloud --dr
 printf '%s\n' "$cleanup_output"
 
 list_output="$(run_capture "$crabbox_bin list --provider tencentcloud --json" "$crabbox_bin" list --provider tencentcloud --json)"
-validate_list_json_empty "$crabbox_bin list --provider tencentcloud --json" "$list_output"
+validate_list_json_empty "$crabbox_bin list --provider tencentcloud --json" "$list_output" "Tencent Cloud"
 
 printf 'classification=live_tencentcloud_smoke_passed slug=%s image=%s type=%s\n' "$slug" "$image" "$type_arg"

--- a/scripts/live-tencentcloud-smoke.test.js
+++ b/scripts/live-tencentcloud-smoke.test.js
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { copySmokeRepo, writeExecutable } from "./test-support/smoke-fixtures.mjs";
+
+function runSmoke(t, overrides = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox tencent smoke-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const { smokeScript } = copySmokeRepo(
+    dir,
+    path.join(import.meta.dirname, "live-tencentcloud-smoke.sh"),
+    ["lib/live-smoke-common.sh"],
+  );
+  const bin = path.join(dir, "bin");
+  fs.mkdirSync(bin);
+  const crabbox = path.join(bin, "crabbox");
+  const calls = path.join(dir, "calls.log");
+  writeExecutable(
+    path.join(bin, "sleep"),
+    '#!/usr/bin/env bash\nprintf "%s\\n" "$*" >>"$SMOKE_DIR/sleeps"\n',
+  );
+  writeExecutable(
+    crabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"$SMOKE_DIR/calls.log"
+if [[ "$1" == warmup ]]; then
+  printf '%s' "$5" >"$SMOKE_DIR/slug"
+fi
+if [[ "$1" == "\${TEST_FAIL_COMMAND:-}" ]]; then
+  printf '%s\\n' "\${TEST_FAILURE_OUTPUT:-command failed}" >&2
+  exit 37
+fi
+case "$1" in
+  config) printf '{"tencentcloud":{"image":"image-fixture"}}\\n' ;;
+  doctor|status) printf 'ready\\n' ;;
+  warmup) printf 'created\\n' ;;
+  run) printf '%s\\n' "\${TEST_RUN_OUTPUT:-ok}" ;;
+  list)
+    if [[ ! -f "$SMOKE_DIR/slug" ]]; then
+      printf '%s\\n' "\${TEST_INITIAL_LIST:-[]}"
+    elif [[ ! -f "$SMOKE_DIR/stopped" ]]; then
+      printf '{"nested":[{"labels":{"slug":"%s"}}]}\\n' "$(cat "$SMOKE_DIR/slug")"
+    elif [[ "\${TEST_SETTLE_ONCE:-}" == 1 && ! -f "$SMOKE_DIR/settled" ]]; then
+      touch "$SMOKE_DIR/settled"
+      printf '[{"name":"still-visible"}]\\n'
+    else
+      printf '[]\\n'
+    fi
+    ;;
+  stop) touch "$SMOKE_DIR/stopped"; printf 'stopped\\n' ;;
+  cleanup) printf 'dry-run\\n' ;;
+  *) exit 99 ;;
+esac
+`,
+  );
+  const result = spawnSync("bash", [smokeScript], {
+    cwd: dir,
+    env: {
+      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+      HOME: dir,
+      CRABBOX_BIN: crabbox,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_PROVIDERS: "tencentcloud",
+      CRABBOX_LIVE_TENCENTCLOUD_IMAGE: "image-fixture",
+      TENCENTCLOUD_SECRET_ID: "test-id",
+      TENCENTCLOUD_SECRET_KEY: "test-key",
+      SMOKE_DIR: dir,
+      ...overrides,
+    },
+    encoding: "utf8",
+  });
+  return {
+    ...result,
+    calls: fs.existsSync(calls) ? fs.readFileSync(calls, "utf8").trim().split("\n") : [],
+    slug: fs.existsSync(path.join(dir, "slug"))
+      ? fs.readFileSync(path.join(dir, "slug"), "utf8")
+      : "",
+    sleeps: fs.existsSync(path.join(dir, "sleeps"))
+      ? fs.readFileSync(path.join(dir, "sleeps"), "utf8")
+      : "",
+  };
+}
+
+test("Tencent smoke gates opt-in, provider selection, and credentials before invoking the CLI", (t) => {
+  for (const [env, reason] of [
+    [{ CRABBOX_LIVE: "" }, "CRABBOX_LIVE_not_enabled"],
+    [{ CRABBOX_LIVE_PROVIDERS: "aws" }, "tencentcloud_not_selected"],
+    [{ TENCENTCLOUD_SECRET_ID: "" }, "TENCENTCLOUD_SECRET_ID_or_SECRET_KEY_missing"],
+    [{ TENCENTCLOUD_SECRET_KEY: "" }, "TENCENTCLOUD_SECRET_ID_or_SECRET_KEY_missing"],
+  ]) {
+    const result = runSmoke(t, env);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, new RegExp(`reason=${reason}`));
+    assert.deepEqual(result.calls, []);
+  }
+});
+
+test("Tencent smoke preserves guarded lifecycle order and waits for empty inventory", (t) => {
+  const result = runSmoke(t, { TEST_SETTLE_ONCE: "1" });
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_tencentcloud_smoke_passed/);
+  assert.match(result.slug, /^tencentcloud-smoke-\d{14}-\d+$/);
+  assert.deepEqual(result.calls, [
+    "doctor --provider tencentcloud",
+    "list --provider tencentcloud --json",
+    `warmup --provider tencentcloud --slug ${result.slug} --keep --tencentcloud-image image-fixture --tencentcloud-type SA5.MEDIUM2 --ttl 20m --idle-timeout 5m`,
+    `status --provider tencentcloud --id ${result.slug} --wait --wait-timeout 300s`,
+    `run --provider tencentcloud --id ${result.slug} --no-sync -- echo ok`,
+    "list --provider tencentcloud --json",
+    `stop --provider tencentcloud ${result.slug}`,
+    "list --provider tencentcloud --json",
+    "list --provider tencentcloud --json",
+    "cleanup --provider tencentcloud --dry-run",
+    "list --provider tencentcloud --json",
+  ]);
+  assert.equal(result.sleeps, "10\n");
+});
+
+test("Tencent smoke retains provider aliases and config image lookup", (t) => {
+  for (const provider of ["tencent", "tencent-cvm", "cvm"]) {
+    const result = runSmoke(t, {
+      CRABBOX_LIVE_PROVIDERS: `aws, ${provider}`,
+      CRABBOX_LIVE_TENCENTCLOUD_IMAGE: "",
+    });
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    assert.equal(result.calls[0], "config show --provider tencentcloud --json");
+    assert.match(result.stdout, /image=image-fixture/);
+  }
+});
+
+test("Tencent smoke rejects malformed or non-empty initial inventory before mutation", (t) => {
+  for (const payload of ['{"broken":', "{}", '[{"name":"existing"}]']) {
+    const result = runSmoke(t, { TEST_INITIAL_LIST: payload });
+    assert.equal(result.status, 1, result.stderr);
+    assert.match(result.stderr, /classification=validation_failed/);
+    assert.match(result.stderr, /invalid JSON:|Tencent Cloud Crabbox inventory is not empty/);
+    assert.deepEqual(result.calls, [
+      "doctor --provider tencentcloud",
+      "list --provider tencentcloud --json",
+    ]);
+  }
+});
+
+test("Tencent smoke preserves failed command status and performs only targeted cleanup", (t) => {
+  for (const [command, output, classification] of [
+    ["warmup", "quota exhausted", "quota_blocked"],
+    ["status", "connection failed", "environment_blocked"],
+    ["run", "command failed", "environment_blocked"],
+  ]) {
+    const result = runSmoke(t, { TEST_FAIL_COMMAND: command, TEST_FAILURE_OUTPUT: output });
+    assert.equal(result.status, 37, result.stderr);
+    assert.match(result.stderr, new RegExp(`classification=${classification} .*exit=37`));
+    assert.match(result.stderr, new RegExp(output));
+    assert.equal(result.calls.at(-1), `stop --provider tencentcloud ${result.slug}`);
+    assert.equal(result.calls.filter((call) => call.startsWith("stop ")).length, 1);
+    assert.ok(!result.calls.some((call) => call.startsWith("cleanup ")));
+  }
+});
+
+test("Tencent smoke classifies invalid run output and cleans up the current slug", (t) => {
+  const result = runSmoke(t, { TEST_RUN_OUTPUT: "unexpected result" });
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stderr, /classification=validation_failed/);
+  assert.match(result.stderr, /unexpected result/);
+  assert.equal(result.calls.at(-1), `stop --provider tencentcloud ${result.slug}`);
+  assert.ok(!result.calls.some((call) => call.startsWith("cleanup ")));
+});

--- a/scripts/live-vultr-smoke.sh
+++ b/scripts/live-vultr-smoke.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+source "$(dirname "${BASH_SOURCE[0]}")/lib/live-smoke-common.sh"
+
 provider_enabled() {
   local list="${CRABBOX_LIVE_PROVIDERS:-vultr}"
   local item
@@ -26,99 +28,6 @@ classify_blocker() {
   fi
   printf 'classification=%s command=%q exit=%s\n' "$classification" "$command" "$status" >&2
   printf '%s\n' "$output" >&2
-}
-
-classify_validation_failure() {
-  local command="$1"
-  local status="$2"
-  local output="$3"
-  printf 'classification=validation_failed command=%q exit=%s\n' "$command" "$status" >&2
-  printf '%s\n' "$output" >&2
-}
-
-run_capture() {
-  local command="$1"
-  shift
-  local output
-  set +e
-  output="$("$@" 2>&1)"
-  local status=$?
-  set -e
-  if [ "$status" -ne 0 ]; then
-    classify_blocker "$command" "$status" "$output"
-    exit "$status"
-  fi
-  printf '%s\n' "$output"
-}
-
-validate_list_json_contains_slug() {
-  local command="$1"
-  local output="$2"
-  local validation_output=""
-  local status=0
-  set +e
-  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
-import json
-import os
-import sys
-
-slug = os.environ["CRABBOX_SMOKE_SLUG"]
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-def has_slug(value):
-    if isinstance(value, dict):
-        labels = value.get("labels")
-        if isinstance(labels, dict) and labels.get("slug") == slug:
-            return True
-        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
-            return True
-        return any(has_slug(child) for child in value.values())
-    if isinstance(value, list):
-        return any(has_slug(child) for child in value)
-    return False
-
-if not has_slug(payload):
-    print(f"list JSON did not include slug {slug}", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
-  status=$?
-  set -e
-  if [ "$status" -ne 0 ]; then
-    classify_validation_failure "$command" "$status" "$validation_output"
-    exit "$status"
-  fi
-}
-
-validate_list_json_empty() {
-  local command="$1"
-  local output="$2"
-  local validation_output=""
-  local status=0
-  set +e
-  validation_output="$(python3 -c '
-import json
-import sys
-
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-if payload != []:
-    print("Vultr Crabbox inventory is not empty", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
-  status=$?
-  set -e
-  if [ "$status" -ne 0 ]; then
-    classify_validation_failure "$command" "$status" "$validation_output"
-    exit "$status"
-  fi
 }
 
 raw_vultr_has_slug() {
@@ -156,19 +65,6 @@ except Exception:
 
 sys.exit(1)
 '
-}
-
-local_testbox_key_snapshot() {
-  local roots=(
-    "${XDG_CONFIG_HOME:-$HOME/.config}/crabbox/testboxes"
-    "$HOME/Library/Application Support/crabbox/testboxes"
-  )
-  local root
-  for root in "${roots[@]}"; do
-    if [ -d "$root" ]; then
-      find "$root" -type f -print
-    fi
-  done | sort -u
 }
 
 cleanup_armed=0
@@ -268,7 +164,7 @@ export VULTR_API_KEY
 doctor_output="$(run_capture "bin/crabbox doctor --provider vultr" bin/crabbox doctor --provider vultr)"
 printf '%s\n' "$doctor_output"
 initial_list_output="$(run_capture "bin/crabbox list --provider vultr --json" bin/crabbox list --provider vultr --json)"
-validate_list_json_empty "bin/crabbox list --provider vultr --json" "$initial_list_output"
+validate_list_json_empty "bin/crabbox list --provider vultr --json" "$initial_list_output" "Vultr"
 initial_local_key_snapshot="$(local_testbox_key_snapshot)"
 cleanup_armed=1
 run_capture "bin/crabbox warmup --provider vultr --slug $slug --keep --type vc2-1c-1gb --ttl 20m --idle-timeout 5m" bin/crabbox warmup --provider vultr --slug "$slug" --keep --type vc2-1c-1gb --ttl 20m --idle-timeout 5m >/dev/null
@@ -281,7 +177,7 @@ run_capture "bin/crabbox stop --provider vultr $slug" bin/crabbox stop --provide
 cleanup_armed=0
 cleanup_output="$(run_capture "bin/crabbox cleanup --provider vultr --dry-run" bin/crabbox cleanup --provider vultr --dry-run)"
 post_list_output="$(run_capture "bin/crabbox list --provider vultr --json" bin/crabbox list --provider vultr --json)"
-validate_list_json_empty "bin/crabbox list --provider vultr --json" "$post_list_output"
+validate_list_json_empty "bin/crabbox list --provider vultr --json" "$post_list_output" "Vultr"
 printf '%s\n' "$cleanup_output"
 printf '%s\n' "$post_list_output"
 printf 'classification=live_vultr_smoke_passed slug=%s cleanup=complete\n' "$slug"

--- a/scripts/live-vultr-smoke.test.js
+++ b/scripts/live-vultr-smoke.test.js
@@ -23,7 +23,9 @@ exec ${JSON.stringify(python)} "$@"
 }
 
 const prepareSmokeRepo = (dir) =>
-  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-vultr-smoke.sh"));
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-vultr-smoke.sh"), [
+    "lib/live-smoke-common.sh",
+  ]);
 
 test("live vultr smoke embedded raw inventory Python compiles", () => {
   const script = fs.readFileSync(path.join(repoRoot, "scripts", "live-vultr-smoke.sh"), "utf8");

--- a/scripts/test-support/smoke-fixtures.mjs
+++ b/scripts/test-support/smoke-fixtures.mjs
@@ -6,13 +6,18 @@ export function writeExecutable(file, body) {
   fs.chmodSync(file, 0o755);
 }
 
-export function copySmokeRepo(dir, sourceScript) {
+export function copySmokeRepo(dir, sourceScript, dependencies = []) {
   const tempRoot = path.join(dir, "repo");
   const tempScripts = path.join(tempRoot, "scripts");
   const smokeScript = path.join(tempScripts, path.basename(sourceScript));
   fs.mkdirSync(tempScripts, { recursive: true });
   fs.copyFileSync(sourceScript, smokeScript);
   fs.chmodSync(smokeScript, 0o755);
+  for (const dependency of dependencies) {
+    const destination = path.join(tempScripts, dependency);
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.copyFileSync(path.join(path.dirname(sourceScript), dependency), destination);
+  }
   return { tempRoot, smokeScript };
 }
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Six provider smoke scripts duplicate the same inventory validation and command
capture logic, making behavioral consistency harder to maintain.

## Why This Change Was Made

Extract definition-only shared helpers and copy that dependency explicitly into
hermetic smoke fixtures. Keep provider selection, lifecycle ordering, raw API
checks, cleanup, key custody, Tencent inventory polling, and Scaleway redaction
in their existing owners.

## User Impact

No user-visible behavior, configuration, or credential changes. This mechanical
refactor removes 469 production lines; regression tests and fixture support add
459 lines, for a net reduction of 10 lines overall. No changelog entry is needed.

## Evidence

- Independently reviewed the exact 15-file diff before committing.
- Signed head: `25a35b3de87613e2de1e1a7415ced92b7d9bf861`.
- All 130 scoped Node tests passed with zero failures, cancellations, or skips:
  the six provider suites, common-helper suite, and shared dispatch suite.
- `bash -n` passed for all six provider scripts and the common helper.
- Formatting checks passed for both new Node suites and the fixture helper.
- `git diff --check` and the added-line privacy scan passed.
- The eight-file Node smoke suite ran with an empty test HOME, synthetic
  credentials, stub CLIs, and the system Bash first on PATH. An earlier run
  stalled in Homebrew Bash heredoc children and was cancelled before retrying.
- No real Go builds, dependency installs, or live provider calls were performed.

```sh
node --test scripts/live-{digitalocean,linode,ovh,scaleway,vultr,tencentcloud}-smoke.test.js \
  scripts/live-smoke-common.test.js scripts/live-smoke.test.js
```
