### PR TITLE
refactor(providers): reuse same-origin comparison

### DIFF
--- a/internal/providers/azuredynamicsessions/client.go
+++ b/internal/providers/azuredynamicsessions/client.go
@@ -502,24 +502,7 @@ func (c *azureDynamicSessionsClient) nextURL(next string) (string, error) {
 }
 
 func sameOriginURL(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveURLPort(a) == effectiveURLPort(b)
-}
-
-func effectiveURLPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	return shared.SameOrigin(a, b)
 }
 
 func (c *azureDynamicSessionsClient) url(path string, query url.Values) string {

--- a/internal/providers/blaxel/client.go
+++ b/internal/providers/blaxel/client.go
@@ -282,24 +282,7 @@ func secureHTTPClient(source *http.Client) *http.Client {
 }
 
 func sameOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectivePort(a) == effectivePort(b)
-}
-
-func effectivePort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	return shared.SameOrigin(a, b)
 }
 
 func (c *restClient) BaseURL() string { return c.base }

--- a/internal/providers/crownest/client.go
+++ b/internal/providers/crownest/client.go
@@ -122,24 +122,7 @@ func crownestRedirectError(destination *url.URL) error {
 }
 
 func sameOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectivePort(a) == effectivePort(b)
-}
-
-func effectivePort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	return shared.SameOrigin(a, b)
 }
 
 func (c *httpClient) BaseURL() string { return c.baseURL }

--- a/internal/providers/nomad/client.go
+++ b/internal/providers/nomad/client.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hashicorp/go-cleanhttp"
 	nomadapi "github.com/hashicorp/nomad/api"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type Client interface {
@@ -112,24 +113,7 @@ func secureNomadHTTPClient(source *http.Client, trusted *url.URL) *http.Client {
 }
 
 func sameNomadOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveNomadPort(a) == effectiveNomadPort(b)
-}
-
-func effectiveNomadPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	return shared.SameOrigin(a, b)
 }
 
 func sanitizeNomadClientError(err error) error {

--- a/internal/providers/opensandbox/client.go
+++ b/internal/providers/opensandbox/client.go
@@ -237,24 +237,7 @@ func secureOpenSandboxHTTPClient(source *http.Client) *http.Client {
 }
 
 func sameOpenSandboxOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveOpenSandboxPort(a) == effectiveOpenSandboxPort(b)
-}
-
-func effectiveOpenSandboxPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	return shared.SameOrigin(a, b)
 }
 
 func (c *sdkOpenSandboxClient) BaseURL() string { return c.base }

--- a/internal/providers/ovh/client.go
+++ b/internal/providers/ovh/client.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const defaultEndpoint = "https://api.us.ovhcloud.com/1.0"
@@ -268,24 +269,7 @@ func secureOVHHTTPClient(source *http.Client, trusted *url.URL) *http.Client {
 }
 
 func sameOVHOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveOVHPort(a) == effectiveOVHPort(b)
-}
-
-func effectiveOVHPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	return shared.SameOrigin(a, b)
 }
 
 func sanitizeOVHClientError(err error) error {

--- a/internal/providers/scaleway/client.go
+++ b/internal/providers/scaleway/client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const defaultScalewayAPIURL = "https://api.scaleway.com"
@@ -279,24 +280,7 @@ func isScalewayRedirect(status int) bool {
 }
 
 func sameScalewayOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveScalewayPort(a) == effectiveScalewayPort(b)
-}
-
-func effectiveScalewayPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	return shared.SameOrigin(a, b)
 }
 
 func scalewayProfileFromSDKConfig() (*scw.Profile, error) {

--- a/internal/providers/semaphore/api.go
+++ b/internal/providers/semaphore/api.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type apiClient struct {
@@ -357,24 +358,7 @@ func (c *apiClient) apiURL(path string) (string, error) {
 }
 
 func sameOriginURL(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveURLPort(a) == effectiveURLPort(b)
-}
-
-func effectiveURLPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	return shared.SameOrigin(a, b)
 }
 
 func (c *apiClient) getWithHeaders(ctx context.Context, path string) ([]byte, http.Header, error) {

--- a/internal/providers/shared/httpredirect_test.go
+++ b/internal/providers/shared/httpredirect_test.go
@@ -31,8 +31,32 @@ func TestSameOrigin(t *testing.T) {
 			}
 		})
 	}
-	if SameOrigin(nil, base) || SameOrigin(base, nil) {
+	if SameOrigin(nil, base) || SameOrigin(base, nil) || SameOrigin(nil, nil) {
 		t.Fatal("SameOrigin accepted a nil URL")
+	}
+}
+
+func TestSameOriginEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{name: "http default port", a: "http://example.com", b: "HTTP://EXAMPLE.COM:80", want: true},
+		{name: "empty URLs", want: true},
+		{name: "unknown scheme", a: "custom://example.com", b: "CUSTOM://EXAMPLE.COM", want: true},
+		{name: "unknown scheme explicit port", a: "custom://example.com", b: "custom://example.com:443"},
+		{name: "zero padded port", a: "https://example.com:0443", b: "https://example.com:443"},
+		{name: "IPv6 textual difference", a: "https://[2001:db8::1]", b: "https://[2001:0db8::1]"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			a, b := mustParseURL(t, test.a), mustParseURL(t, test.b)
+			if got := SameOrigin(a, b); got != test.want {
+				t.Fatalf("SameOrigin(%q, %q) = %v, want %v", a, b, got, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/providers/unikraftcloud/client.go
+++ b/internal/providers/unikraftcloud/client.go
@@ -253,24 +253,7 @@ func isUnikraftCloudMutation(method string) bool {
 }
 
 func sameUnikraftCloudOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveUnikraftCloudPort(a) == effectiveUnikraftCloudPort(b)
-}
-
-func effectiveUnikraftCloudPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	return shared.SameOrigin(a, b)
 }
 
 type unikraftCloudRedirectError struct {


### PR DESCRIPTION
## What Problem This Solves

Nine provider adapters duplicate the same URL-origin comparison and default-port rules. Keeping those copies synchronized adds unnecessary maintenance and review work around redirect handling.

## Why This Change Was Made

Keep each provider's existing predicate name and signature, but delegate its identical comparison to the existing `shared.SameOrigin` implementation. Remove only the nine now-unused port helpers and add the four required imports.

Provider redirect policies, callers, sentinels, headers, validation order, and path guards remain unchanged. The shared production implementation is untouched; LambdaMicroVM and Sprites retain their distinct behavior.

## User Impact

No intended user-visible behavior, security-boundary, configuration, or secret-handling change. Production code decreases by 149 lines; added edge-case coverage leaves a net reduction of 125 lines.

## Evidence

- Reviewed head: `73e81e0e21361bb6d7ff11f670ffe2b5b85b92d3`.
- Independent diff review passed. Inverse expansion reconstructs all nine base production files byte-for-byte, including their original helper bodies and imports.
- Shared implementation blob remains `1380dcc7ff7f2761ec295ddbe269f2707f794c94`.
- Existing test assertions are retained. Added cases cover HTTP default ports, nil/nil, empty URLs, unknown schemes, zero-padded ports, and textually different IPv6 hosts.
- Touched-file `gofmt`, `git diff --check`, and privacy checks passed.
- Local Go compilation, race tests, vet, and deadcode were not run under the local resource constraint. Normal exact-head hosted CI is required before landing; current-main integration proof remains a separate merge gate.
