### PR TITLE
fix: unify checked SmolVM byte uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Report SmolVM decoder, file-write and extraction failures instead of false upload success, isolate temporary upload files, and preserve existing files when decoding fails. Thanks @steipete.
 - Stop direct AWS, Azure, GCP, and Hetzner bootstrap retries from allocating another machine when rollback reports a cleanup failure, preserving both the original failure and cleanup diagnostics. [PR 1819](https://github.com/openclaw/crabbox/pull/1819). Thanks @steipete.
 - Cloudflare: retain recovery claims when teardown fails, preserve command/cancellation outcomes, and fence reuse and cleanup against replaced local claims. [PR 1817](https://github.com/openclaw/crabbox/pull/1817). Thanks @steipete.
 - Preserve existing Cloudflare container workspaces when sync upload or extraction fails, clean partial archives, and enforce full-checkout size limits before fresh allocation. [PR 1814](https://github.com/openclaw/crabbox/pull/1814). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Report SmolVM decoder, file-write and extraction failures instead of false upload success, isolate temporary upload files, and preserve existing files when decoding fails. Thanks @steipete.
+- Report SmolVM decoder, file-write and extraction failures instead of false upload success, isolate temporary upload files, and preserve existing files when decoding fails. [PR 1826](https://github.com/openclaw/crabbox/pull/1826). Thanks @steipete.
 - Stop direct AWS, Azure, GCP, and Hetzner bootstrap retries from allocating another machine when rollback reports a cleanup failure, preserving both the original failure and cleanup diagnostics. [PR 1819](https://github.com/openclaw/crabbox/pull/1819). Thanks @steipete.
 - Cloudflare: retain recovery claims when teardown fails, preserve command/cancellation outcomes, and fence reuse and cleanup against replaced local claims. [PR 1817](https://github.com/openclaw/crabbox/pull/1817). Thanks @steipete.
 - Preserve existing Cloudflare container workspaces when sync upload or extraction fails, clean partial archives, and enforce full-checkout size limits before fresh allocation. [PR 1814](https://github.com/openclaw/crabbox/pull/1814). Thanks @steipete.

--- a/docs/providers/smolvm.md
+++ b/docs/providers/smolvm.md
@@ -97,7 +97,7 @@ Defaults: image `alpine` (lightweight; provides the standard shell tools needed 
 
 1. `warmup` / `run` without `--id` creates a microVM sandbox from the configured `--smolvm-image`.
 2. Before startup, Crabbox durably binds a local claim to the returned machine ID, name, creation timestamp, full API endpoint, normal `cbx_...` lease ID, and friendly slug.
-3. By default `run` archive-syncs the working tree using a direct API call to `/exec` (the tarball is base64-encoded and sent in a shell heredoc; the guest decodes + extracts with `base64 -d | tar`).
+3. By default `run` archive-syncs the working tree using a direct API call to `/exec` (the tarball is base64-encoded and sent in a shell heredoc; the guest completes checked base64 decoding before extracting with `tar`).
 4. The user command executes inside the microVM. Because the smolfleet API does not stream live output, command output appears after the command completes.
 5. One-shot sandboxes are deleted after a `run` that did not pass `--keep`. `--keep` and `--keep-on-failure` retain the sandbox until `crabbox stop`.
 6. `run --lease-output <path>` writes the SmolVM lease ID, slug, reuse/retention state, and exact cleanup command for orchestration handoff.
@@ -125,6 +125,8 @@ The [hosted API](https://smolmachines.com/docs/cloud/api-reference) uses 404 bot
 - Defaults to the lightweight `alpine` image (provides `sh` + `base64` + `tar` for direct API-driven archive sync; user commands can `apk add` additional packages as needed).
 - Network is open by default.
 - Archive sync and small file writes use direct calls to the smolfleet `/exec` API (heredoc payload).
+- Archive and small-file uploads share a checked byte-transfer path: an invocation-private directory holds a fully decoded file before extraction or publication. Decoder, write, extraction and temporary-cleanup failures return nonzero status; an earlier failure remains primary. Small files are published from a private same-filesystem staging file, so failed decoding does not truncate an existing destination. Archive extraction retains the incoming file-mode mask.
+- Remote traps clean temporary upload files on ordinary completion and handled signals. They do not guarantee cleanup after SIGKILL or an ambiguous HTTP failure while the remote command may still run. This does not make workspace replacement transactional or change the lifetime of the final environment profile.
 - No direct `crabbox ssh` / `crabbox vnc` (delegated execution model).
 - Supports `warmup`, `run`, `status`, `stop`, `list`, and `doctor`.
 

--- a/internal/providers/smolvm/backend_test.go
+++ b/internal/providers/smolvm/backend_test.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -108,13 +109,13 @@ func TestClientUsesSmolvmRESTShape(t *testing.T) {
 				t.Fatal(err)
 			}
 			// Direct heredoc-based archive inject.
-			if strings.Contains(body.Command, "crabbox-sync.tgz") || strings.Contains(body.Command, "smolvm-direct-archive-extract") {
+			if strings.Contains(body.Command, "tar -xzf") {
 				injectSeen = true
 				_ = json.NewEncoder(w).Encode(map[string]any{"exitCode": 0, "stdout": "smolvm-direct-archive-extract: ok\n"})
 				return
 			}
 			// Direct write (env profile etc) also uses base64 heredoc /exec.
-			if strings.Contains(body.Command, "smolvm-direct-write") || strings.Contains(body.Command, "CRABBOX_WRITE_B64_EOF") {
+			if strings.Contains(body.Command, "mv -f") {
 				_ = json.NewEncoder(w).Encode(map[string]any{"exitCode": 0, "stdout": "smolvm-direct-write: ok\n"})
 				return
 			}
@@ -899,5 +900,170 @@ func testMachineResponse(id, name, state string) map[string]any {
 		"resources": map[string]any{"cpus": 2, "memoryMb": 4096},
 		"network":   map[string]any{"mode": "blocked"},
 		"ephemeral": false, "createdAt": "2026-06-12T20:00:00Z", "updatedAt": "2026-06-12T20:00:00Z",
+	}
+}
+
+// Exercise the actual HTTP client and generated shell; only the hosted exec
+// service is replaced with a local, credential-free subprocess fixture.
+func TestClientNativeUploadFailureAndPublication(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("native upload fixture requires POSIX shell tools")
+	}
+	for _, tool := range []string{"sh", "base64", "tar", "mktemp"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s unavailable", tool)
+		}
+	}
+	decoder, _ := exec.LookPath("base64")
+	if runtime.GOOS == "darwin" {
+		var err error
+		decoder, err = exec.LookPath("gbase64")
+		if err != nil {
+			t.Skip("GNU base64 required to reproduce the Linux decoder contract")
+		}
+	}
+	for _, tc := range []struct {
+		name, operation, failure string
+		wantError                bool
+	}{
+		{"write", "write", "", false},
+		{"write-partial-decoder", "write", "decode", true},
+		{"write-directory", "write", "directory", true},
+		{"write-cleanup-failure", "write", "cleanup", true},
+		{"write-decode-and-cleanup-failure", "write", "decode-cleanup", true},
+		{"archive", "archive", "", false},
+		{"archive-corrupt", "archive", "corrupt", true},
+		{"archive-decoder-late-failure", "archive", "decode-after-output", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			workspace := filepath.Join(root, "work space'quoted")
+			if err := os.Mkdir(workspace, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			destination := filepath.Join(workspace, "env.sh")
+			if tc.failure == "directory" {
+				if err := os.Mkdir(destination, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.WriteFile(destination, []byte("old"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			const content = "literal quote'\n$(must-not-execute)\x00bytes"
+			scriptPrefix := "base64() { " + shellQuote(decoder) + " \"$@\"; };\n"
+			if tc.failure == "decode" || tc.failure == "decode-cleanup" {
+				scriptPrefix = "base64() { printf partial; return 23; };\n"
+			} else if tc.failure == "decode-after-output" {
+				scriptPrefix = "base64() { " + shellQuote(decoder) + " \"$@\"; return 23; };\n"
+			}
+			if strings.Contains(tc.failure, "cleanup") {
+				scriptPrefix += "rm() { return 17; };\n"
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.URL.Path != "/v1/machines/fixture/exec" {
+					http.Error(w, "unexpected request", 400)
+					return
+				}
+				var request struct {
+					Command string `json:"command"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+					http.Error(w, err.Error(), 400)
+					return
+				}
+				// Isolate the old fixed staging name when demonstrating the regression.
+				script := strings.ReplaceAll(request.Command, "/tmp/crabbox-sync.tgz", shellQuote(filepath.Join(root, "baseline-sync.tgz")))
+				script = strings.ReplaceAll(script, "/tmp/crabbox-write-", filepath.Join(root, "baseline-write-"))
+				cmd := exec.Command("sh", "-c", "umask 022\n"+scriptPrefix+script)
+				cmd.Env = []string{"PATH=" + os.Getenv("PATH"), "HOME=" + root, "TMPDIR=" + root}
+				out, err := cmd.CombinedOutput()
+				code := 0
+				if err != nil {
+					var ee *exec.ExitError
+					if !errors.As(err, &ee) {
+						http.Error(w, err.Error(), 500)
+						return
+					}
+					code = ee.ExitCode()
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"exitCode": code, "stdout": string(out)})
+			}))
+			defer server.Close()
+			c := &client{base: server.URL, http: server.Client()}
+			var uploadErr error
+			if tc.operation == "write" {
+				uploadErr = c.WriteFile(t.Context(), "fixture", destination, content)
+			} else {
+				repo := t.TempDir()
+				if err := os.WriteFile(filepath.Join(repo, "uploaded"), []byte(content), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				archive, err := core.CreateSyncArchive(t.Context(), Repo{Root: repo}, SyncManifest{Files: []string{"uploaded"}}, "crabbox-smolvm-native-*.tgz")
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer os.Remove(archive.Name())
+				if err := archive.Close(); err != nil {
+					t.Fatal(err)
+				}
+				if tc.failure == "corrupt" {
+					if err := os.WriteFile(archive.Name(), []byte("not an archive"), 0o600); err != nil {
+						t.Fatal(err)
+					}
+				}
+				uploadErr = c.InjectArchive(t.Context(), "fixture", archive.Name(), workspace)
+			}
+			if (uploadErr != nil) != tc.wantError {
+				t.Fatalf("upload error=%v, wantError=%v", uploadErr, tc.wantError)
+			}
+			if strings.HasPrefix(tc.failure, "decode") {
+				var exitErr ExitError
+				if !errors.As(uploadErr, &exitErr) || exitErr.Code != 23 {
+					t.Fatalf("decoder status lost: %v", uploadErr)
+				}
+			}
+			if strings.Contains(tc.failure, "cleanup") && !strings.Contains(uploadErr.Error(), "upload staging cleanup failed") {
+				t.Fatalf("cleanup diagnostic lost: %v", uploadErr)
+			}
+			if tc.operation == "write" && tc.failure != "directory" {
+				got, err := os.ReadFile(destination)
+				want := content
+				if tc.wantError && tc.failure != "cleanup" {
+					want = "old"
+				}
+				if err != nil || string(got) != want {
+					t.Fatalf("destination=%q err=%v, want %q", got, err, want)
+				}
+				info, err := os.Stat(destination)
+				if err != nil || info.Mode().Perm() != 0o600 {
+					t.Fatalf("private file mode: info=%v err=%v", info, err)
+				}
+			} else if tc.operation == "archive" {
+				got, err := os.ReadFile(filepath.Join(workspace, "uploaded"))
+				if tc.wantError {
+					if !os.IsNotExist(err) {
+						t.Fatalf("failed upload consumed archive: data=%q err=%v", got, err)
+					}
+				} else if err != nil || string(got) != content {
+					t.Fatalf("archive payload=%q err=%v", got, err)
+				}
+				if !tc.wantError {
+					info, err := os.Stat(filepath.Join(workspace, "uploaded"))
+					if err != nil || info.Mode().Perm() != 0o755 {
+						t.Fatalf("archive mode changed: info=%v err=%v", info, err)
+					}
+				}
+			}
+			for _, dir := range []string{root, workspace} {
+				matches, err := filepath.Glob(filepath.Join(dir, ".crabbox-upload.*"))
+				wantResidue := 0
+				if dir == workspace && strings.Contains(tc.failure, "cleanup") {
+					wantResidue = 1
+				}
+				if err != nil || len(matches) != wantResidue {
+					t.Fatalf("staging residue=%v err=%v", matches, err)
+				}
+			}
+		})
 	}
 }

--- a/internal/providers/smolvm/client.go
+++ b/internal/providers/smolvm/client.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -326,66 +326,46 @@ func (c *client) InjectArchive(ctx context.Context, machineID, localPath, target
 	if err != nil {
 		return err
 	}
-	b64 := base64.StdEncoding.EncodeToString(data)
-
-	// Direct API call: embed the base64 of the tgz in a heredoc inside the exec
-	// command string sent to /exec. The guest only needs sh + base64 + tar (no
-	// Python, no "installing" anything). This is a pure direct call to the
-	// smolfleet exec API with the payload in the request body.
-	// We use a distinctive delimiter that cannot appear in base64 output.
-	const eof = "CRABBOX_SYNC_B64_EOF_9f8e7d6c5b4a"
 	absTarget := targetDir
 	if !strings.HasPrefix(absTarget, "/") {
 		absTarget = "/workspace"
 	}
-	script := fmt.Sprintf(`cat > /tmp/crabbox-sync.tgz << '%s'
-%s
-%s
-base64 -d /tmp/crabbox-sync.tgz | tar -xzf - -C %s && rm -f /tmp/crabbox-sync.tgz
-echo "smolvm-direct-archive-extract: ok"
-`, eof, b64, eof, shellQuote(absTarget))
-
-	res, err := c.Exec(ctx, machineID, script, "")
-	if err != nil {
-		return fmt.Errorf("smolvm direct archive exec: %w", err)
-	}
-	if res.ExitCode != 0 {
-		msg := strings.TrimSpace(res.Error)
-		if msg == "" {
-			msg = strings.TrimSpace(res.Output)
-		}
-		return exit(res.ExitCode, "smolvm direct archive extract: %s", msg)
-	}
-	return nil
+	return c.withDecodedFile(ctx, machineID, data, "", `"${TMPDIR:-/tmp}"`,
+		"tar -xzf \"$upload_dir/payload\" -C "+shellQuote(absTarget), "archive extract")
 }
 
 func (c *client) WriteFile(ctx context.Context, machineID, remotePath, content string) error {
-	// Direct API: write small text (e.g. env profile) via heredoc in a single
-	// /exec call. Pure shell, no Python or extra interpreters required.
 	absPath := remotePath
 	if !strings.HasPrefix(absPath, "/") {
 		absPath = "/workspace/" + strings.TrimLeft(absPath, "/")
 	}
-	b64 := base64.StdEncoding.EncodeToString([]byte(content))
-	const eof = "CRABBOX_WRITE_B64_EOF_4e2d8a7c9b1f"
-	tmpPath := "/tmp/crabbox-write-" + base64.RawURLEncoding.EncodeToString([]byte(filepath.Base(absPath))) + ".b64"
-	script := fmt.Sprintf(`mkdir -p %s && cat > %s << '%s'
-%s
-%s
-base64 -d %s > %s && rm -f %s
-echo "smolvm-direct-write: ok"
-`, shellQuote(filepath.Dir(absPath)), shellQuote(tmpPath), eof, b64, eof, shellQuote(tmpPath), shellQuote(absPath), shellQuote(tmpPath))
+	parent := shellQuote(path.Dir(absPath))
+	// Stage beside the destination so publication stays on one filesystem.
+	prepare := "mkdir -p " + parent + "\n[ ! -d " + shellQuote(absPath) + " ] || { echo 'file destination is a directory' >&2; exit 1; }\n"
+	return c.withDecodedFile(ctx, machineID, []byte(content), prepare, parent,
+		"mv -f \"$upload_dir/payload\" "+shellQuote(absPath), "write")
+}
 
+// withDecodedFile owns only this exec's private staging directory. Its trap
+// cannot guarantee cleanup after SIGKILL or ambiguous remote HTTP completion.
+func (c *client) withDecodedFile(ctx context.Context, machineID string, data []byte, prepare, stagingParent, consume, operation string) error {
+	// Check decoding separately from consumption: POSIX pipelines only expose
+	// the last command's status, even when the decoder emitted partial data.
+	const eof = "CRABBOX_UPLOAD_B64_EOF"
+	script := "set -eu\nupload_umask=$(umask)\numask 077\n" + prepare +
+		"upload_dir=$(mktemp -d " + stagingParent + "/.crabbox-upload.XXXXXXXXXX)\n" +
+		`trap 'upload_status=$?; trap - 0; rm -rf -- "$upload_dir" || { echo "upload staging cleanup failed" >&2; [ "$upload_status" -ne 0 ] || upload_status=1; }; exit "$upload_status"' 0` + "\n" +
+		"trap 'exit 129' HUP\ntrap 'exit 130' INT\ntrap 'exit 143' TERM\n" +
+		"base64 -d > \"$upload_dir/payload\" << '" + eof + "'\n" +
+		base64.StdEncoding.EncodeToString(data) + "\n" + eof + "\n" +
+		"umask \"$upload_umask\"\n" +
+		consume + "\n"
 	res, err := c.Exec(ctx, machineID, script, "")
 	if err != nil {
-		return fmt.Errorf("smolvm direct write exec: %w", err)
+		return fmt.Errorf("smolvm direct %s exec: %w", operation, err)
 	}
 	if res.ExitCode != 0 {
-		msg := strings.TrimSpace(res.Error)
-		if msg == "" {
-			msg = strings.TrimSpace(res.Output)
-		}
-		return exit(res.ExitCode, "smolvm direct write: %s", msg)
+		return commandExitError("smolvm direct "+operation, res)
 	}
 	return nil
 }

--- a/internal/providers/smolvm/sync.go
+++ b/internal/providers/smolvm/sync.go
@@ -1,14 +1,14 @@
 package smolvm
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func (b *backend) syncWorkspace(ctx context.Context, client api, machineID string, req RunRequest, workdir, folder string) ([]timingPhase, time.Duration, error) {
@@ -34,7 +34,7 @@ func (b *backend) syncWorkspace(ctx context.Context, client api, machineID strin
 	}
 	prepareDuration := b.now().Sub(prepareStarted)
 	archiveStarted := b.now()
-	archive, err := createSyncArchive(ctx, req.Repo, manifest, b.rt.Stderr)
+	archive, err := core.CreateSyncArchive(ctx, req.Repo, manifest, "crabbox-smolvm-sync-*.tgz")
 	if err != nil {
 		return nil, 0, err
 	}
@@ -93,31 +93,4 @@ func (b *backend) execShell(ctx context.Context, client api, machineID, command 
 		return commandExitError("smolvm exec "+command, result)
 	}
 	return nil
-}
-
-func createSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, stderr io.Writer) (*os.File, error) {
-	var input bytes.Buffer
-	input.Write(manifest.NUL())
-	archive, err := os.CreateTemp("", "crabbox-smolvm-sync-*.tgz")
-	if err != nil {
-		return nil, fmt.Errorf("create sync archive temp file: %w", err)
-	}
-	keep := false
-	defer func() {
-		if !keep {
-			name := archive.Name()
-			_ = archive.Close()
-			_ = os.Remove(name)
-		}
-	}()
-	cmd := exec.CommandContext(ctx, "tar", "--no-xattrs", "-czf", "-", "-C", repo.Root, "--null", "-T", "-")
-	cmd.Stdin = &input
-	cmd.Env = append(os.Environ(), "COPYFILE_DISABLE=1")
-	cmd.Stdout = archive
-	cmd.Stderr = stderr
-	if err := cmd.Run(); err != nil {
-		return nil, exit(6, "create sync archive: %v", err)
-	}
-	keep = true
-	return archive, nil
 }


### PR DESCRIPTION
## Summary

Replace SmolVM's two shell upload implementations with one checked byte-transfer owner. Both archive injection and small-file writes previously ended in an unconditional success echo, hiding failed decoding, redirection and extraction. Archive injection also checked only the final stage of a decoder-to-tar pipeline; both paths used predictable shared staging names.

The shared private helper exclusively creates a temporary directory, decodes into a private file, checks decoding before consuming the payload, and cleans only its own directory. Cleanup preserves an earlier failure and reports a cleanup-only failure. WriteFile publishes the complete private payload from the destination filesystem, so failed decoding does not truncate existing content. Archive extraction restores the caller's umask; private staging does not strip executable/read permissions from repository files. SmolVM's local external-tar archive producer is also replaced by the existing shared Go archive producer.

## Before/after verification

Credential-free native fixtures exercise the actual SmolVM HTTP client against a loopback exec service that runs the generated POSIX shell, GNU base64, tar and filesystem operations. Healthy write and archive controls pass on the baseline. Four baseline cases falsely return success: partial decoder output, a directory destination, corrupt tar data, and a decoder that emits valid archive data then exits 23. The candidate rejects all four and does not consume a failed decode.

The expanded eight-case suite also checks that cleanup failure remains visible, exit 23 survives simultaneous cleanup failure, successful publication can remain present after a cleanup error, private file modes remain 0600, archive executable mode remains 0755, and staging is absent except where cleanup was deliberately failed. Tests isolate baseline fixed staging names and remove all fixture directories. This is actual client/native-shell fixture proof, not a hosted SmolVM lifecycle or mounted-workspace proof.

The complete SmolVM race suite, vet, CLI build and documentation build pass. Managed review is scoped-clean; independent semantic review caught the umask interaction, which was fixed and regression-tested, and has no outstanding findings. Documentation and a maintainer Unreleased entry are included.

## Deliberate boundaries

This patch does not rename or make replacement of the /workspace mount root transactional. Existing sync preparation ordering and final environment-profile lifetime remain separate work. The remote trap cannot promise cleanup after SIGKILL or an ambiguous HTTP response while execution may continue. There is no retry of ambiguous extraction and no broad cleanup request. Provider identity/lifecycle protocols and credentials are unchanged; no new package dependency is added.
