### PR TITLE
fix: bind Azure acquisition to owned VM generations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reject changed Azure VM identities during acquisition readiness and use identity-checked VM/companion cleanup for failed acquisitions instead of blind name-based rollback. Thanks @steipete.
 - Stop direct AWS, Azure, GCP, and Hetzner bootstrap retries from allocating another machine when rollback reports a cleanup failure, preserving both the original failure and cleanup diagnostics. [PR 1819](https://github.com/openclaw/crabbox/pull/1819). Thanks @steipete.
 - Cloudflare: retain recovery claims when teardown fails, preserve command/cancellation outcomes, and fence reuse and cleanup against replaced local claims. [PR 1817](https://github.com/openclaw/crabbox/pull/1817). Thanks @steipete.
 - Preserve Upstash Box workspaces when archive upload or extraction fails, clean partial Upstash Box/Tensorlake uploads, and check complete archive limits before creating either sandbox. [PR 1820](https://github.com/openclaw/crabbox/pull/1820). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Reject changed Azure VM identities during acquisition readiness and use identity-checked VM/companion cleanup for failed acquisitions instead of blind name-based rollback. Thanks @steipete.
+- Reject changed Azure VM identities during acquisition readiness and use identity-checked VM/companion cleanup for failed acquisitions instead of blind name-based rollback. [PR 1827](https://github.com/openclaw/crabbox/pull/1827). Thanks @steipete.
 - Stop direct AWS, Azure, GCP, and Hetzner bootstrap retries from allocating another machine when rollback reports a cleanup failure, preserving both the original failure and cleanup diagnostics. [PR 1819](https://github.com/openclaw/crabbox/pull/1819). Thanks @steipete.
 - Cloudflare: retain recovery claims when teardown fails, preserve command/cancellation outcomes, and fence reuse and cleanup against replaced local claims. [PR 1817](https://github.com/openclaw/crabbox/pull/1817). Thanks @steipete.
 - Preserve Upstash Box workspaces when archive upload or extraction fails, clean partial Upstash Box/Tensorlake uploads, and check complete archive limits before creating either sandbox. [PR 1820](https://github.com/openclaw/crabbox/pull/1820). Thanks @steipete.

--- a/docs/features/lifecycle-cleanup.md
+++ b/docs/features/lifecycle-cleanup.md
@@ -444,3 +444,25 @@ attempt cannot overwrite or delete a newer claim.
 - [inspect command](../commands/inspect.md)
 - [Identifiers](identifiers.md)
 - [Security](../security.md)
+
+### Direct Azure acquisition identity
+
+After successful VM creation, direct Azure acquisition binds the returned native
+VM ID to the requested VM name and ownership tags. A final readiness observation
+must retain that binding before bootstrap, ready tagging, or claim publication.
+An incomplete creation result or changed readiness identity reports unresolved
+cleanup and withholds VM deletion; a later matching read does not erase the
+contradiction.
+
+Ordinary failures after a valid creation use the same prepared owned-cleanup
+operations as release: re-read the original VM, capture companion identities,
+revalidate them, delete the VM first, then its surviving companions. Refusal or
+cleanup failure preserves the original acquisition error and prevents a fresh
+bootstrap retry. This in-process rollback has no persisted recovery claim and
+does not provide crash-resumable companion cleanup.
+
+These are observed-identity checks, not an atomic generation-conditional Azure
+DELETE. Inner create-failure rollback and Windows setup performed during create,
+intermediate hidden readiness polls, and replacement races after the final
+validation remain separate boundaries. This does not change GCP cleanup or
+make name-addressed resources equivalent to immutable-ID deletion targets.

--- a/internal/cli/azure.go
+++ b/internal/cli/azure.go
@@ -1869,10 +1869,11 @@ func (c *AzureClient) DeleteServer(ctx context.Context, name string) error {
 }
 
 // PrepareOwnedServer captures immutable companion identities before the VM can
-// be deleted. The caller persists the returned labels in the exact lease claim.
+// be deleted. Callers requiring crash-resumable cleanup persist the returned
+// labels in the exact lease claim; acquisition rollback holds them in process.
 func (c *AzureClient) PrepareOwnedServer(ctx context.Context, expected Server) (Server, error) {
 	return c.prepareAzureDeleteServer(ctx, expected, func(expected, live Server) error {
-		return validateAzureOwnedVM(expected, live)
+		return ValidateAzureOwnedVM(expected, live)
 	})
 }
 
@@ -1931,7 +1932,7 @@ func (c *AzureClient) DeleteOwnedServer(ctx context.Context, expected Server) er
 	if err != nil {
 		return err
 	}
-	return c.deleteAzureValidatedResourcesWithRetry(ctx, expected, resources, validateAzureOwnedVM)
+	return c.deleteAzureValidatedResourcesWithRetry(ctx, expected, resources, ValidateAzureOwnedVM)
 }
 
 type azureCleanupSkipError struct{ err error }
@@ -2165,7 +2166,7 @@ func requireMatchingAzureDeleteResources(expected, live azureVMDeleteResources) 
 }
 
 func validateAzureCleanupVM(expected, live Server, now time.Time) error {
-	if err := validateAzureOwnedVM(expected, live); err != nil {
+	if err := ValidateAzureOwnedVM(expected, live); err != nil {
 		return err
 	}
 	if shouldDelete, reason := shouldCleanupServer(live, now); !shouldDelete {
@@ -2174,7 +2175,9 @@ func validateAzureCleanupVM(expected, live Server, now time.Time) error {
 	return nil
 }
 
-func validateAzureOwnedVM(expected, live Server) error {
+// ValidateAzureOwnedVM compares an observation with a frozen VM generation and
+// ownership binding. It does not authorize name-addressed mutations by itself.
+func ValidateAzureOwnedVM(expected, live Server) error {
 	expectedID := strings.TrimSpace(expected.CloudID)
 	if expectedID == "" || strings.TrimSpace(live.CloudID) != expectedID {
 		return fmt.Errorf("live Azure cloud id %q does not match cleanup candidate %q", live.CloudID, expected.CloudID)

--- a/internal/cli/azure_test.go
+++ b/internal/cli/azure_test.go
@@ -143,18 +143,18 @@ func TestValidateAzureOwnedVMDoesNotRequireExpiry(t *testing.T) {
 			"provider_key": providerKeyForLease("cbx_123456abcdef"),
 		},
 	}
-	if err := validateAzureOwnedVM(expected, expected); err != nil {
+	if err := ValidateAzureOwnedVM(expected, expected); err != nil {
 		t.Fatalf("valid release VM rejected: %v", err)
 	}
 	replacement := expected
 	replacement.ImmutableID = "vmid-replacement"
-	if err := validateAzureOwnedVM(expected, replacement); err == nil || !strings.Contains(err.Error(), "identity") {
+	if err := ValidateAzureOwnedVM(expected, replacement); err == nil || !strings.Contains(err.Error(), "identity") {
 		t.Fatalf("replacement VM error=%v", err)
 	}
 	changedKey := expected
 	changedKey.Labels = maps.Clone(expected.Labels)
 	changedKey.Labels["provider_key"] = "replacement"
-	if err := validateAzureOwnedVM(expected, changedKey); err == nil || !strings.Contains(err.Error(), "provider key") {
+	if err := ValidateAzureOwnedVM(expected, changedKey); err == nil || !strings.Contains(err.Error(), "provider key") {
 		t.Fatalf("changed provider key error=%v", err)
 	}
 }

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -84,6 +84,7 @@ func (b *azureLeaseBackend) acquireOnce(ctx context.Context, keep bool, requeste
 	}
 	cfg.SSHKey = keyPath
 	cfg.ProviderKey = providerKeyForLease(leaseID)
+	expected := Server{CloudID: core.LeaseProviderName(leaseID, slug), Labels: core.DirectLeaseLabels(cfg, leaseID, slug, "azure", "on-demand", keep, time.Now())}
 	fmt.Fprintf(b.RT.Stderr, "provisioning provider=azure lease=%s slug=%s class=%s preferred_type=%s location=%s rg=%s keep=%v\n",
 		leaseID, slug, cfg.Class, cfg.ServerType, cfg.AzureLocation, cfg.AzureResourceGroup, keep)
 	server, cfg, err := client.CreateServerWithFallback(ctx, cfg, publicKey, leaseID, slug, keep, func(format string, args ...any) {
@@ -92,23 +93,40 @@ func (b *azureLeaseBackend) acquireOnce(ctx context.Context, keep bool, requeste
 	if err != nil {
 		return LeaseTarget{}, err
 	}
+	expected.ImmutableID = server.ImmutableID
+	if err := validateAzureAcquiredVM(expected, server); err != nil {
+		return LeaseTarget{}, shared.JoinAcquireCleanupError(fmt.Errorf("azure creation rejected: %w", err), errors.New("Azure cleanup withheld: created VM binding is incomplete or inconsistent"))
+	}
+	created := server
+	created.Labels = maps.Clone(server.Labels)
 	rollback := true
-	rollbackCloudID := server.CloudID
 	defer func() {
-		if !rollback || strings.TrimSpace(rollbackCloudID) == "" {
+		if !rollback {
 			return
 		}
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), azureAcquireRollbackTimeout)
 		defer cancel()
-		if err := client.DeleteServer(cleanupCtx, rollbackCloudID); err != nil {
-			fmt.Fprintf(b.RT.Stderr, "warning: cleanup azure server %s after acquire failure: %v\n", rollbackCloudID, err)
-			retErr = shared.JoinAcquireCleanupError(retErr, fmt.Errorf("cleanup azure server %s after acquire failure: %w", rollbackCloudID, err))
+		prepared, err := client.PrepareOwnedServer(cleanupCtx, created)
+		if err == nil {
+			err = validateAzureAcquiredVM(created, prepared)
+		}
+		if err == nil {
+			err = client.DeleteOwnedServer(cleanupCtx, prepared)
+		}
+		if err != nil {
+			fmt.Fprintf(b.RT.Stderr, "warning: cleanup azure server %s after acquire failure: %v\n", created.CloudID, err)
+			retErr = shared.JoinAcquireCleanupError(retErr, fmt.Errorf("cleanup azure server %s after acquire failure: %w", created.CloudID, err))
 		}
 	}()
 	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s server=%s type=%s\n", leaseID, server.DisplayID(), cfg.ServerType)
 	server, err = client.WaitForServerIP(ctx, server.CloudID)
 	if err != nil {
 		return LeaseTarget{}, err
+	}
+	if err := validateAzureAcquiredVM(created, server); err != nil {
+		// A later matching read must not erase an observed replacement.
+		rollback = false
+		return LeaseTarget{}, shared.JoinAcquireCleanupError(fmt.Errorf("azure readiness rejected: %w", err), errors.New("Azure cleanup withheld after readiness identity loss"))
 	}
 	target := sshTargetFromConfig(cfg, azureServerHost(server, cfg.AzureNetwork))
 	if err := bootstrapManagedWindowsDesktop(ctx, cfg, &target, publicKey, b.RT.Stderr); err != nil {
@@ -291,7 +309,7 @@ func (b *azureLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 			}
 			return fmt.Errorf("re-read Azure cleanup candidate %s: %w", server.DisplayID(), err)
 		}
-		if err := validateAzureCleanupLiveServer(server, live); err != nil {
+		if err := core.ValidateAzureOwnedVM(server, live); err != nil {
 			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%v\n", server.DisplayID(), server.Name, err)
 			continue
 		}
@@ -491,22 +509,11 @@ func validateExactAzureClaim(claim core.LeaseClaim, server Server, expectedLease
 	return nil
 }
 
-func validateAzureCleanupLiveServer(expected, live Server) error {
-	cloudID := strings.TrimSpace(expected.CloudID)
-	if cloudID == "" || strings.TrimSpace(live.CloudID) != cloudID {
-		return fmt.Errorf("live cloud id %q does not match cleanup candidate %q", live.CloudID, expected.CloudID)
+func validateAzureAcquiredVM(expected, live Server) error {
+	if live.Name != expected.CloudID {
+		return fmt.Errorf("Azure VM name %q does not match allocation %q", live.Name, expected.CloudID)
 	}
-	if strings.TrimSpace(expected.ImmutableID) == "" || strings.TrimSpace(live.ImmutableID) != strings.TrimSpace(expected.ImmutableID) {
-		return fmt.Errorf("live VM identity %q does not match cleanup candidate identity %q", live.ImmutableID, expected.ImmutableID)
-	}
-	if !isCrabboxAzureLease(live) {
-		return fmt.Errorf("live VM no longer has canonical Crabbox ownership tags")
-	}
-	expectedLeaseID := strings.TrimSpace(expected.Labels["lease"])
-	if liveLeaseID := strings.TrimSpace(live.Labels["lease"]); liveLeaseID != expectedLeaseID {
-		return fmt.Errorf("live VM lease %q does not match cleanup candidate lease %q", liveLeaseID, expectedLeaseID)
-	}
-	return nil
+	return core.ValidateAzureOwnedVM(expected, live)
 }
 
 func isAzureCleanupNotFound(err error) bool {

--- a/internal/providers/azure/backend_test.go
+++ b/internal/providers/azure/backend_test.go
@@ -19,6 +19,7 @@ import (
 type fakeAzureClient struct {
 	claimScope        string
 	deleted           []string
+	plainDeletes      []string
 	cleanupExpected   []Server
 	ownedExpected     []Server
 	prepareCleanup    []Server
@@ -35,6 +36,9 @@ type fakeAzureClient struct {
 	created           Server
 	createCfg         Config
 	createErr         error
+	createFunc        func(Server) Server
+	waitFunc          func(Server) (Server, error)
+	waitCalls         int
 	waitErr           error
 	getErr            error
 	get               map[string]Server
@@ -59,18 +63,28 @@ func (c *fakeAzureClient) ListCrabboxServers(context.Context) ([]Server, error) 
 	return c.servers, nil
 }
 
-func (c *fakeAzureClient) CreateServerWithFallback(_ context.Context, _ Config, _ string, leaseID string, _ string, _ bool, _ func(string, ...any)) (Server, Config, error) {
+func (c *fakeAzureClient) CreateServerWithFallback(_ context.Context, cfg Config, _ string, leaseID, slug string, keep bool, _ func(string, ...any)) (Server, Config, error) {
 	c.createLeaseIDs = append(c.createLeaseIDs, leaseID)
 	if c.createErr != nil {
 		return Server{}, Config{}, c.createErr
 	}
-	if c.created.CloudID == "" {
-		c.created = Server{CloudID: "crabbox-created", Name: "crabbox-created", Labels: map[string]string{}}
+	c.created.CloudID = core.LeaseProviderName(leaseID, slug)
+	c.created.Name = c.created.CloudID
+	if c.created.ImmutableID == "" {
+		c.created.ImmutableID = "native-vm-" + leaseID
 	}
-	return c.created, c.createCfg, nil
+	c.created.Labels = core.DirectLeaseLabels(cfg, leaseID, slug, "azure", "on-demand", keep, time.Unix(1, 0))
+	if c.createFunc != nil {
+		c.created = c.createFunc(c.created)
+	}
+	return c.created, cfg, nil
 }
 
 func (c *fakeAzureClient) WaitForServerIP(context.Context, string) (Server, error) {
+	c.waitCalls++
+	if c.waitFunc != nil {
+		return c.waitFunc(c.created)
+	}
 	if c.waitErr != nil {
 		return Server{}, c.waitErr
 	}
@@ -99,6 +113,7 @@ func (c *fakeAzureClient) GetServer(_ context.Context, id string) (Server, error
 }
 
 func (c *fakeAzureClient) DeleteServer(_ context.Context, name string) error {
+	c.plainDeletes = append(c.plainDeletes, name)
 	c.deleted = append(c.deleted, name)
 	return c.deleteErr
 }
@@ -175,7 +190,7 @@ func TestAzureAcquireCleansUpCreatedServerOnIPFailure(t *testing.T) {
 	if !errors.Is(err, ipErr) {
 		t.Fatalf("err=%v, want IP failure", err)
 	}
-	if len(fake.deleted) != 1 || fake.deleted[0] != "crabbox-created" {
+	if len(fake.deleted) != 1 || fake.deleted[0] != fake.created.CloudID {
 		t.Fatalf("deleted=%v, want created server cleanup", fake.deleted)
 	}
 }
@@ -262,13 +277,13 @@ func TestAzureAcquireDoesNotRollbackReadyServer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if lease.Server.CloudID != "crabbox-ready" {
-		t.Fatalf("server=%s, want crabbox-ready", lease.Server.CloudID)
+	if lease.Server.CloudID != fake.created.CloudID {
+		t.Fatalf("server=%s, want created VM", lease.Server.CloudID)
 	}
 	if len(fake.deleted) != 0 {
 		t.Fatalf("deleted=%v, want no rollback on success", fake.deleted)
 	}
-	if len(fake.tagged) != 1 || fake.tagged[0] != "crabbox-ready" {
+	if len(fake.tagged) != 1 || fake.tagged[0] != fake.created.CloudID {
 		t.Fatalf("tagged=%v, want ready tag update", fake.tagged)
 	}
 	claim, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
@@ -310,7 +325,7 @@ func TestAzureAcquireRollsBackWhenExactClaimCannotPersist(t *testing.T) {
 	if _, err := backend.acquireOnce(context.Background(), false, ""); err == nil {
 		t.Fatal("expected exact-claim persistence failure")
 	}
-	if len(fake.deleted) != 1 || fake.deleted[0] != created.CloudID {
+	if len(fake.deleted) != 1 || fake.deleted[0] != fake.created.CloudID {
 		t.Fatalf("deleted=%v, want funded VM rollback after claim failure", fake.deleted)
 	}
 }
@@ -699,8 +714,8 @@ func TestAzureCleanupRejectsChangedLiveSlug(t *testing.T) {
 	if len(fake.cleanupExpected) != 0 || len(fake.deleted) != 0 {
 		t.Fatalf("cleanup crossed changed slug: expected=%v deleted=%v", fake.cleanupExpected, fake.deleted)
 	}
-	if !strings.Contains(stderr.String(), "exact local claim missing or stale") {
-		t.Fatalf("stderr=%q, want exact-claim diagnostic", stderr.String())
+	if !strings.Contains(stderr.String(), "Azure VM slug") {
+		t.Fatalf("stderr=%q, want changed-slug diagnostic", stderr.String())
 	}
 }
 
@@ -839,8 +854,9 @@ func TestAzureAcquireStopsFreshRetryAfterRollbackFailure(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			primary := core.Exit(5, "timed out waiting for SSH: fixture")
 			fake := &fakeAzureClient{createCfg: azureAcquireTestConfig()}
+			cleanupErr := errors.New("delete unavailable")
 			if failed {
-				fake.deleteErr = errors.New("delete unavailable")
+				fake.deleteOwnedFunc = func(Server) error { return cleanupErr }
 			}
 			oldClient, oldBootstrap := newAzureClient, bootstrapManagedWindowsDesktop
 			newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
@@ -853,14 +869,111 @@ func TestAzureAcquireStopsFreshRetryAfterRollbackFailure(t *testing.T) {
 			if failed {
 				want = 1
 			}
-			if len(fake.createLeaseIDs) != want || len(fake.deleted) != want || !errors.Is(err, primary) {
+			if len(fake.createLeaseIDs) != want || len(fake.ownedExpected) != want || len(fake.plainDeletes) != 0 || !errors.Is(err, primary) {
 				t.Fatalf("creates=%v deletes=%v error=%v", fake.createLeaseIDs, fake.deleted, err)
 			}
 			if !failed && fake.createLeaseIDs[0] == fake.createLeaseIDs[1] {
 				t.Fatal("retry reused lease identity")
 			}
-			if failed && (!errors.Is(err, fake.deleteErr) || strings.Contains(stderr.String(), "retrying with fresh lease")) {
+			if failed && (!errors.Is(err, cleanupErr) || strings.Contains(stderr.String(), "retrying with fresh lease")) {
 				t.Fatalf("cleanup debt lost: error=%v stderr=%s", err, stderr.String())
+			}
+		})
+	}
+}
+
+func TestAzureAcquireRejectsChangedReadinessGenerationWithoutMutation(t *testing.T) {
+	mutations := []struct {
+		name   string
+		change func(*Server)
+	}{
+		{"generation", func(s *Server) { s.ImmutableID = "replacement-vm" }},
+		{"missing-generation", func(s *Server) { s.ImmutableID = "" }},
+		{"cloud-name", func(s *Server) { s.CloudID = "replacement-name" }},
+		{"name", func(s *Server) { s.Name = "replacement-name" }},
+		{"owner", func(s *Server) { s.Labels["created_by"] = "other" }},
+		{"provider", func(s *Server) { s.Labels["provider"] = "gcp" }},
+		{"lease", func(s *Server) { s.Labels["lease"] = "cbx_111111111111" }},
+		{"slug", func(s *Server) { s.Labels["slug"] = "replacement" }},
+		{"key", func(s *Server) { s.Labels["provider_key"] = "replacement" }},
+	}
+	for _, creation := range []bool{false, true} {
+		for _, tc := range mutations {
+			// A nonempty generation at creation is the initial anchor.
+			if creation && tc.name == "generation" {
+				continue
+			}
+			t.Run(fmt.Sprintf("creation=%v/%s", creation, tc.name), func(t *testing.T) {
+				t.Setenv("HOME", t.TempDir())
+				t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+				t.Setenv("XDG_STATE_HOME", t.TempDir())
+				fake := &fakeAzureClient{}
+				if creation {
+					fake.createFunc = func(s Server) Server { tc.change(&s); return s }
+				} else {
+					// Deliberately mutate the aliased labels returned by creation.
+					fake.waitFunc = func(s Server) (Server, error) { tc.change(&s); return s, nil }
+				}
+				oldClient, oldBootstrap := newAzureClient, bootstrapManagedWindowsDesktop
+				newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+				bootstrapCalls := 0
+				bootstrapManagedWindowsDesktop = func(context.Context, Config, *SSHTarget, string, io.Writer) error { bootstrapCalls++; return nil }
+				t.Cleanup(func() { newAzureClient = oldClient; bootstrapManagedWindowsDesktop = oldBootstrap })
+				b := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+				_, err := b.Acquire(t.Context(), AcquireRequest{})
+				if err == nil || bootstrapCalls != 0 || len(fake.tagged) != 0 || len(fake.deleted) != 0 || len(fake.prepareOwned) != 0 || len(fake.createLeaseIDs) != 1 {
+					t.Fatalf("err=%v bootstrap=%d tags=%v deletes=%v prepared=%d creates=%v", err, bootstrapCalls, fake.tagged, fake.deleted, len(fake.prepareOwned), fake.createLeaseIDs)
+				}
+				if creation && fake.waitCalls != 0 {
+					t.Fatal("invalid creation reached waiter")
+				}
+				if _, exists, e := core.ReadLeaseClaimWithPresence(fake.createLeaseIDs[0]); e != nil || exists {
+					t.Fatalf("unexpected claim: exists=%v err=%v", exists, e)
+				}
+			})
+		}
+	}
+}
+
+func TestAzureAcquireRollbackKeepsOriginalBindingAndRefusesUnpreparedDelete(t *testing.T) {
+	for _, failure := range []string{"", "prepare", "changed-preparation"} {
+		t.Run(failure, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			primary := errors.New("readiness unavailable")
+			fake := &fakeAzureClient{waitErr: primary}
+			fake.prepareFunc = func(s Server) Server {
+				s.Labels = maps.Clone(s.Labels)
+				s.Labels["fixture_cleanup_binding"] = "captured"
+				return s
+			}
+			if failure == "prepare" {
+				fake.prepareErr = errors.New("cannot verify resources")
+			}
+			if failure == "changed-preparation" {
+				fake.prepareFunc = func(s Server) Server { s.ImmutableID = "replacement"; return s }
+			}
+			oldClient := newAzureClient
+			newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+			t.Cleanup(func() { newAzureClient = oldClient })
+			b := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+			_, err := b.Acquire(t.Context(), AcquireRequest{})
+			if !errors.Is(err, primary) || len(fake.prepareOwned) != 1 || len(fake.plainDeletes) != 0 {
+				t.Fatalf("err=%v prepare=%v plain=%v", err, fake.prepareOwned, fake.plainDeletes)
+			}
+			if fake.prepareOwned[0].ImmutableID != fake.created.ImmutableID {
+				t.Fatal("original binding lost")
+			}
+			wantDelete := 0
+			if failure == "" {
+				wantDelete = 1
+			}
+			if len(fake.ownedExpected) != wantDelete {
+				t.Fatalf("deletion calls=%d", len(fake.ownedExpected))
+			}
+			if wantDelete == 1 && fake.ownedExpected[0].Labels["fixture_cleanup_binding"] != "captured" {
+				t.Fatal("prepared companion evidence lost")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Unify Azure VM ownership validation and use it at the direct acquisition transition. The native Azure cleanup code already had a strict generation/lease/slug/provider-key validator; the provider adapter duplicated a weaker version and acquisition did not check the readiness result at all. The existing strict validator is now shared by those Azure paths; it is explicitly an observation check, not a general deletion capability.

Acquisition validates successful creation against the intended name and ownership, freezes the returned VM generation and copied labels, and checks final readiness before bootstrap, ready tagging or claim publication. Incomplete creation or contradictory readiness retains cleanup debt and performs no deletion. A later read cannot silently erase a detected replacement.

For ordinary failure after valid creation, outer rollback now calls the existing PrepareOwnedServer and DeleteOwnedServer operations with the original anchor. These capture and revalidate native companion identities, delete the VM first, then surviving companions, and check absence. There is no blind name-delete fallback. Preparation or deletion failure retains the original failure and prevents fresh bootstrap allocation.

## Verification

The baseline regression accepted a same-name replacement generation, called bootstrap, tagged it ready and returned success. The candidate rejects it before those operations. Seventeen invalid creation/readiness cases cover missing generation, changed name, owner/provider/lease/slug/key, and aliased mutable labels. Existing successful acquisition, claim-failure rollback and fresh-retry tests now use realistic request-derived creation identities. Additional tests prove original-anchor preparation, prepared companion evidence, refusal on incomplete/changed preparation, and preservation of bootstrap/cleanup errors.

Five credential-free native fixtures run public Acquire with controlled create/readiness responses but actual Azure SDK HTTP preparation/deletion over a loopback TLS service. The normal control deletes the VM before its NIC, public IP and disk and confirms absence. Replacement before preparation, replacement at the final VM revalidation, and changed NIC generation each produce zero DELETE requests. A readiness mismatch produces no cleanup HTTP requests at all. A test-only Go overlay supplies the synthetic credential/SDK constructor; no constructor seam, credential or fixture API ships in production.

The full Azure provider race suite and targeted core Azure/archive race tests pass. Vet, CLI build, docs build, managed review and independent semantic review passed. The native proof is real SDK/client execution against synthetic local responses, not cloud-live allocation or deletion. Documentation and the maintainer changelog are included; no new dependency or configuration.

## Limits

Azure delete remains name-addressed: this prevents mutations after observed identity loss but does not eliminate the final GET-to-DELETE race. Outer rollback keeps companion bindings in process, without crash-resumable claim persistence. Inner create-failure rollback, Windows setup performed inside create, hidden intermediate IP polls and later tag-update races are not covered. GCP is intentionally separate because its generation representation and native deletion contract differ. Existing exact-claim, scope, revision and expiry gates remain in place.

## Main integration

The first exact-head CI run passed all five workflows. Subsequent main changes required a changelog-only conflict resolution; both release notes were retained. The integrated candidate reruns the five-provider race cohort and all five SDK fixture scenarios successfully, with clean managed review. Fresh CI is required for the new integrated head. Public replay source and observed results: https://github.com/openclaw/crabbox/pull/1827#issuecomment-5543012297.
