### PR TITLE
fix: share literal command intent across argv providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Preserve literal profile arguments through CodeSandbox, OpenComputer, and Docker Sandbox execution, sharing command-intent parsing without changing provider shells or environment transports. Thanks @steipete.
+
 - Report SmolVM decoder, file-write and extraction failures instead of false upload success, isolate temporary upload files, and preserve existing files when decoding fails. [PR 1826](https://github.com/openclaw/crabbox/pull/1826). Thanks @steipete.
 - Stop direct AWS, Azure, GCP, and Hetzner bootstrap retries from allocating another machine when rollback reports a cleanup failure, preserving both the original failure and cleanup diagnostics. [PR 1819](https://github.com/openclaw/crabbox/pull/1819). Thanks @steipete.
 - Reject inconsistent Hetzner creation/readiness identities before SSH, and keep failed-acquisition cleanup bound to the original server and key; share exact ID/name validation with RunPod. [PR 1821](https://github.com/openclaw/crabbox/pull/1821). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Preserve literal profile arguments through CodeSandbox, OpenComputer, and Docker Sandbox execution, sharing command-intent parsing without changing provider shells or environment transports. Thanks @steipete.
+- Preserve literal profile arguments through CodeSandbox, OpenComputer, and Docker Sandbox execution, sharing command-intent parsing without changing provider shells or environment transports. [PR 1830](https://github.com/openclaw/crabbox/pull/1830). Thanks @steipete.
 
 - Reject changed Azure VM identities during acquisition readiness and use identity-checked VM/companion cleanup for failed acquisitions instead of blind name-based rollback. [PR 1827](https://github.com/openclaw/crabbox/pull/1827). Thanks @steipete.
 - Report SmolVM decoder, file-write and extraction failures instead of false upload success, isolate temporary upload files, and preserve existing files when decoding fails. [PR 1826](https://github.com/openclaw/crabbox/pull/1826). Thanks @steipete.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -34,7 +34,8 @@ The trailing command after `--` is sent to the box verbatim as argv. Use
 `--shell` to run it through the remote shell instead, for multi-statement
 snippets, pipes, or shell expansion.
 
-On Cloudflare Sandbox, Superserve, Crownest, Vercel Sandbox, and Nomad,
+On Cloudflare Sandbox, Superserve, Crownest, Vercel Sandbox, Nomad, CodeSandbox,
+OpenComputer, and Docker Sandbox,
 quoted or interpolated profile arguments retain their literal meaning through
 the delegated command transport. A value such as `&&` does not become a shell
 operator, and an executable named `FOO=x` is invoked rather than treated as an

--- a/internal/providers/codesandbox/backend.go
+++ b/internal/providers/codesandbox/backend.go
@@ -179,10 +179,11 @@ func (b *codeSandboxBackend) Run(ctx context.Context, req RunRequest) (result Ru
 		return result, nil
 	}
 
-	command, err := buildCommand(req.Command, req.ShellMode)
+	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
 	if err != nil {
 		return finishResult(RunResult{}), err
 	}
+	command := intent.Argv("bash", "-lc")
 	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
 		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}

--- a/internal/providers/codesandbox/backend_test.go
+++ b/internal/providers/codesandbox/backend_test.go
@@ -690,3 +690,56 @@ func initGitRepo(t *testing.T, dir string) {
 		}
 	}
 }
+
+func TestRunCommandIntentReachesNativeRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		command []string
+		literal map[int]bool
+		shell   bool
+		want    []string
+	}{
+		{"ordinary", []string{"printf", "%s", "hello"}, nil, false, []string{"printf", "%s", "hello"}},
+		{"literal separator", []string{"printf", "%s", ";", "touch", "sentinel"}, map[int]bool{2: true}, false, []string{"printf", "%s", ";", "touch", "sentinel"}},
+		{"literal assignment executable", []string{"FOO=x", "argument"}, map[int]bool{0: true}, false, []string{"FOO=x", "argument"}},
+		{"literal singleton", []string{"literal command $(echo x)"}, map[int]bool{0: true}, false, []string{"literal command $(echo x)"}},
+		{"invalid assignment executable", []string{"bad-name=x", "argument"}, nil, false, []string{"bad-name=x", "argument"}},
+		{"mixed operators", []string{"printf", "%s", ";", "&&", "printf", "%s", "done"}, map[int]bool{2: true}, false, []string{"bash", "-lc", "'printf' '%s' ';' && 'printf' '%s' 'done'"}},
+		{"inferred source", []string{"printf one && printf two"}, nil, false, []string{"bash", "-lc", "printf one && printf two"}},
+		{"explicit source", []string{"printf one; exit 7"}, nil, true, []string{"bash", "-lc", "printf one; exit 7"}},
+		{"leading assignment", []string{"GREETING=hello world", "printf", "%s", "$GREETING"}, nil, false, []string{"bash", "-lc", "GREETING='hello world' 'printf' '%s' '$GREETING'"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			fake := newFakeCodeSandboxAPI()
+			backend, _, _ := newFakeBackend(t, fake)
+			_, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "my-app", Root: t.TempDir()}, NoSync: true, Command: tc.command, ShellMode: tc.shell, CommandLiteralArgs: tc.literal})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(fake.commands) != 2 {
+				t.Fatalf("commands=%#v", fake.commands)
+			}
+			got := fake.commands[1].Command
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("native command=%#v want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunRejectsEmptyCommandBeforeCreate(t *testing.T) {
+	for _, shellMode := range []bool{false, true} {
+		for _, command := range [][]string{nil, {""}, {"  "}} {
+			fake := newFakeCodeSandboxAPI()
+			backend, _, _ := newFakeBackend(t, fake)
+			_, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "my-app", Root: t.TempDir()}, NoSync: true, ShellMode: shellMode, Command: command})
+			if err == nil || !strings.Contains(err.Error(), "missing command") {
+				t.Fatalf("command=%#v shell=%v err=%v", command, shellMode, err)
+			}
+			if len(fake.created) != 0 {
+				t.Fatalf("created before validation: %#v", fake.created)
+			}
+		}
+	}
+}

--- a/internal/providers/codesandbox/claims.go
+++ b/internal/providers/codesandbox/claims.go
@@ -229,26 +229,6 @@ func isTerminalState(state string) bool {
 	}
 }
 
-func buildCommand(command []string, shellMode bool) ([]string, error) {
-	if len(command) == 0 {
-		return nil, errors.New("missing command")
-	}
-	if shellMode {
-		return []string{"bash", "-lc", strings.Join(command, " ")}, nil
-	}
-	if shouldUseShell(command) || leadingEnvAssignment(command) {
-		if len(command) == 1 {
-			return []string{"bash", "-lc", command[0]}, nil
-		}
-		return []string{"bash", "-lc", shellScriptFromArgv(command)}, nil
-	}
-	return command, nil
-}
-
-func leadingEnvAssignment(command []string) bool {
-	return len(command) > 1 && strings.Contains(command[0], "=") && !strings.HasPrefix(command[0], "-")
-}
-
 func randomSuffix() string {
 	return shared.RandomSuffix()
 }

--- a/internal/providers/codesandbox/core.go
+++ b/internal/providers/codesandbox/core.go
@@ -117,14 +117,6 @@ func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []s
 	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
 }
 
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
 func shellQuote(s string) string {
 	return core.ShellQuote(s)
 }

--- a/internal/providers/dockersandbox/backend.go
+++ b/internal/providers/dockersandbox/backend.go
@@ -115,10 +115,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			}
 		}()
 	}
-	command, err := buildCommand(req.Command, req.ShellMode)
+	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
 	if err != nil {
 		return RunResult{}, err
 	}
+	command := intent.Argv("sh", "-lc")
 	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
 		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
@@ -545,22 +546,6 @@ func validateCreateRepo(cfg Config, repo Repo) error {
 		}
 	}
 	return nil
-}
-
-func buildCommand(command []string, shellMode bool) ([]string, error) {
-	if len(command) == 0 {
-		return nil, errors.New("missing command")
-	}
-	if shellMode {
-		return []string{"sh", "-lc", strings.Join(command, " ")}, nil
-	}
-	if len(command) == 1 && shouldUseShell(command) {
-		return []string{"sh", "-lc", command[0]}, nil
-	}
-	if shouldUseShell(command) || leadingEnvAssignment(command) {
-		return []string{"sh", "-lc", shellScriptFromArgv(command)}, nil
-	}
-	return command, nil
 }
 
 func dockerSandboxAgent(cfg Config) string {

--- a/internal/providers/dockersandbox/backend_test.go
+++ b/internal/providers/dockersandbox/backend_test.go
@@ -1155,39 +1155,6 @@ func TestDockerSandboxSmallHelpers(t *testing.T) {
 	}
 }
 
-func TestBuildCommandShellModePreservesShellScript(t *testing.T) {
-	got, err := buildCommand([]string{"echo one && echo two"}, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := []string{"sh", "-lc", "echo one && echo two"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("command=%#v want %#v", got, want)
-	}
-}
-
-func TestBuildCommandSingleShellStringStaysRaw(t *testing.T) {
-	got, err := buildCommand([]string{"echo one && echo two"}, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := []string{"sh", "-lc", "echo one && echo two"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("command=%#v want %#v", got, want)
-	}
-}
-
-func TestBuildCommandLeadingEnvAssignmentQuotesArgv(t *testing.T) {
-	got, err := buildCommand([]string{"GREETING=hello world", "printf", "%s\n", "$GREETING"}, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := []string{"sh", "-lc", "GREETING='hello world' 'printf' '%s\n' '$GREETING'"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("command=%#v want %#v", got, want)
-	}
-}
-
 func TestSBXErrorFormattingEdges(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	stderr.WriteString("plain failure")
@@ -1661,5 +1628,44 @@ func TestRunKeepOnFailureMarksSessionKept(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "keep-on-failure: kept lease=") {
 		t.Fatalf("stderr missing keep-on-failure hint: %s", stderr.String())
+	}
+}
+
+func TestRunCommandIntentReachesNativeRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		command []string
+		literal map[int]bool
+		shell   bool
+		want    []string
+	}{
+		{"empty explicit source", []string{""}, nil, true, []string{"sh", "-lc", ""}},
+		{"ordinary", []string{"printf", "%s", "hello"}, nil, false, []string{"printf", "%s", "hello"}},
+		{"literal separator", []string{"printf", "%s", ";", "touch", "sentinel"}, map[int]bool{2: true}, false, []string{"printf", "%s", ";", "touch", "sentinel"}},
+		{"literal assignment executable", []string{"FOO=x", "argument"}, map[int]bool{0: true}, false, []string{"FOO=x", "argument"}},
+		{"literal singleton", []string{"literal command $(echo x)"}, map[int]bool{0: true}, false, []string{"literal command $(echo x)"}},
+		{"invalid assignment executable", []string{"bad-name=x", "argument"}, nil, false, []string{"bad-name=x", "argument"}},
+		{"mixed operators", []string{"printf", "%s", ";", "&&", "printf", "%s", "done"}, map[int]bool{2: true}, false, []string{"sh", "-lc", "'printf' '%s' ';' && 'printf' '%s' 'done'"}},
+		{"inferred source", []string{"printf one && printf two"}, nil, false, []string{"sh", "-lc", "printf one && printf two"}},
+		{"explicit source", []string{"printf one; exit 7"}, nil, true, []string{"sh", "-lc", "printf one; exit 7"}},
+		{"leading assignment", []string{"GREETING=hello world", "printf", "%s", "$GREETING"}, nil, false, []string{"sh", "-lc", "GREETING='hello world' 'printf' '%s' '$GREETING'"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			runner := newRunner(nil, nil)
+			backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
+			_, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "my-app", Root: t.TempDir()}, Command: tc.command, ShellMode: tc.shell, CommandLiteralArgs: tc.literal})
+			if err != nil {
+				t.Fatal(err)
+			}
+			call := findCall(runner, "exec")
+			if call == nil || len(call.Args) < 5 || call.Args[1] != "--workdir" {
+				t.Fatalf("exec=%#v", call)
+			}
+			got := call.Args[4:]
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("native command=%#v want %#v", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/providers/dockersandbox/core.go
+++ b/internal/providers/dockersandbox/core.go
@@ -97,18 +97,6 @@ func listLeaseClaims() ([]core.LeaseClaim, error) {
 	return core.ListLeaseClaims()
 }
 
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func leadingEnvAssignment(command []string) bool {
-	return core.LeadingEnvAssignment(command)
-}
-
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
 func blank(value, fallback string) string {
 	return core.Blank(value, fallback)
 }

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -177,10 +177,11 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 		return result, nil
 	}
 
-	command, err := buildCommand(req.Command, req.ShellMode)
+	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
 	if err != nil {
 		return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: b.now().Sub(started), SyncDelegated: true, Session: session}, err
 	}
+	command := intent.Argv("bash", "-lc")
 	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
 		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
@@ -608,26 +609,6 @@ func isTerminalState(state string) bool {
 
 func randomSuffix() string {
 	return shared.RandomSuffix()
-}
-
-func buildCommand(command []string, shellMode bool) ([]string, error) {
-	if len(command) == 0 {
-		return nil, errors.New("missing command")
-	}
-	if shellMode {
-		return []string{"bash", "-lc", strings.Join(command, " ")}, nil
-	}
-	if shouldUseShell(command) || leadingEnvAssignment(command) {
-		if len(command) == 1 {
-			return []string{"bash", "-lc", command[0]}, nil
-		}
-		return []string{"bash", "-lc", shellScriptFromArgv(command)}, nil
-	}
-	return command, nil
-}
-
-func leadingEnvAssignment(command []string) bool {
-	return len(command) > 1 && strings.Contains(command[0], "=") && !strings.HasPrefix(command[0], "-")
 }
 
 // openComputerWorkdir returns the configured absolute workspace path inside the

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -74,55 +74,6 @@ func TestProviderDoesNotReportServerTypeMetadata(t *testing.T) {
 	}
 }
 
-func TestBuildCommandAutoWrapsShellMetacharacters(t *testing.T) {
-	got, err := buildCommand([]string{"pnpm install && pnpm test"}, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 3 || got[0] != "bash" || got[1] != "-lc" {
-		t.Fatalf("command=%#v want bash -lc wrapping", got)
-	}
-	if got[2] != "pnpm install && pnpm test" {
-		t.Fatalf("script=%q want unquoted shell expression", got[2])
-	}
-}
-
-func TestBuildCommandAutoWrapsLeadingEnvAssignment(t *testing.T) {
-	got, err := buildCommand([]string{"FOO=bar", "pnpm", "test"}, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 3 || got[0] != "bash" {
-		t.Fatalf("command=%#v want bash wrapping for FOO=bar", got)
-	}
-}
-
-func TestBuildCommandShellMode(t *testing.T) {
-	got, err := buildCommand([]string{"pnpm install && pnpm test"}, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(got, []string{"bash", "-lc", "pnpm install && pnpm test"}) {
-		t.Fatalf("command=%#v", got)
-	}
-}
-
-func TestBuildCommandPassThrough(t *testing.T) {
-	got, err := buildCommand([]string{"pnpm", "test"}, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(got, []string{"pnpm", "test"}) {
-		t.Fatalf("command=%#v", got)
-	}
-}
-
-func TestBuildCommandRejectsEmpty(t *testing.T) {
-	if _, err := buildCommand(nil, false); err == nil {
-		t.Fatalf("expected error for empty command")
-	}
-}
-
 func TestOpenComputerWorkdirRejectsRelative(t *testing.T) {
 	cfg := newTestConfig("")
 	cfg.OpenComputer.Workdir = "relative/path"
@@ -1525,4 +1476,57 @@ func newGitRepo(t *testing.T) string {
 		}
 	}
 	return root
+}
+
+func TestRunCommandIntentReachesNativeRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		command []string
+		literal map[int]bool
+		shell   bool
+		want    []string
+	}{
+		{"empty explicit source", []string{""}, nil, true, []string{"bash", "-lc", ""}},
+		{"ordinary", []string{"printf", "%s", "hello"}, nil, false, []string{"printf", "%s", "hello"}},
+		{"literal separator", []string{"printf", "%s", ";", "touch", "sentinel"}, map[int]bool{2: true}, false, []string{"printf", "%s", ";", "touch", "sentinel"}},
+		{"literal assignment executable", []string{"FOO=x", "argument"}, map[int]bool{0: true}, false, []string{"FOO=x", "argument"}},
+		{"literal singleton", []string{"literal command $(echo x)"}, map[int]bool{0: true}, false, []string{"literal command $(echo x)"}},
+		{"invalid assignment executable", []string{"bad-name=x", "argument"}, nil, false, []string{"bad-name=x", "argument"}},
+		{"mixed operators", []string{"printf", "%s", ";", "&&", "printf", "%s", "done"}, map[int]bool{2: true}, false, []string{"bash", "-lc", "'printf' '%s' ';' && 'printf' '%s' 'done'"}},
+		{"inferred source", []string{"printf one && printf two"}, nil, false, []string{"bash", "-lc", "printf one && printf two"}},
+		{"explicit source", []string{"printf one; exit 7"}, nil, true, []string{"bash", "-lc", "printf one; exit 7"}},
+		{"leading assignment", []string{"GREETING=hello world", "printf", "%s", "$GREETING"}, nil, false, []string{"bash", "-lc", "GREETING='hello world' 'printf' '%s' '$GREETING'"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := newFakeAPI(t)
+			backend := newAPIBackend(t, fake)
+			_, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "my-app", Root: t.TempDir()}, NoSync: true, Command: tc.command, ShellMode: tc.shell, CommandLiteralArgs: tc.literal})
+			if err != nil {
+				t.Fatal(err)
+			}
+			calls := fake.allExecs()
+			if len(calls) != 2 {
+				t.Fatalf("execs=%#v", calls)
+			}
+			got := append([]string{calls[1].req.Cmd}, calls[1].req.Args...)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("native command=%#v want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunMissingCommandRetainsCleanup(t *testing.T) {
+	fake := newFakeAPI(t)
+	backend := newAPIBackend(t, fake)
+	_, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "my-app", Root: t.TempDir()}, NoSync: true})
+	if err == nil || err.Error() != "missing command" {
+		t.Fatalf("err=%v", err)
+	}
+	if got := fake.callsExact(http.MethodDelete, "/api/sandboxes/"+fake.sandboxID); got != 1 {
+		t.Fatalf("delete calls=%d", got)
+	}
+	if calls := fake.allExecs(); len(calls) != 1 {
+		t.Fatalf("expected only workspace setup, got %#v", calls)
+	}
 }

--- a/internal/providers/opencomputer/core.go
+++ b/internal/providers/opencomputer/core.go
@@ -104,14 +104,6 @@ func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []s
 	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
 }
 
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
 func shellQuote(s string) string {
 	return core.ShellQuote(s)
 }


### PR DESCRIPTION
## Summary

CodeSandbox, OpenComputer and Docker Sandbox now use the existing shared CommandIntent parser, including the literal argument positions already supplied by public profile expansion. Their independent builders ignored that metadata: quoted separators became operators, assignment-shaped executable names became environment assignments, and mixed literal/operator input could become invalid shell syntax.

Delete the three metadata-blind builders and their unused heuristic/serialization wrappers. CodeSandbox and OpenComputer still choose bash -lc for actual shell intent; Docker Sandbox still chooses sh -lc. CodeSandbox's final SDK command-string quoting, OpenComputer's cmd/args JSON, and Docker's native sbx argv all retain the classified intent. Workdir, environment, lifecycle, timeout and error ownership are unchanged. Invalid assignment-looking executable names now follow core's valid-identifier rule instead of the former loose equals-sign heuristic.

## Proof

The final-request regression matrix reproduces 14 failures on the old adapters and passes on the candidate. It covers literal separators, assignment-shaped executables, literal singleton commands, mixed syntax, ordinary argv, explicit/inferred shell, and leading assignments. Provider-specific empty/missing-command behavior is preserved and covered.

An unchanged external fixture drives both built binaries through public profiles and the actual provider boundaries. The old binary fails 12 of 24 cases; the candidate passes all 24. OpenComputer's loopback HTTP service and a configured synthetic sbx executable run the actual received argv locally: literal text stays data, sentinel files stay absent, a literal executable returns 42, explicit shell/env returns 7, and workdirs with spaces survive. CodeSandbox uses the real Node bridge with a local file-module SDK and verifies the exact final SDK command string, including mixed source and profile forwarding; it does not execute that string in a cloud sandbox. All fixture processes and temporary state are cleaned up. No live-provider claim is made.

All three complete provider race suites pass, along with focused core command-intent/profile tests, vet, CLI build and docs build. A later local run encountered missing entries in the shared Go build cache; the same suites and added compatibility tests passed with a task-owned cache. Managed reviews are scoped-clean; independent semantic review found no actionable issue. Current main is integrated.

## Boundaries

No new abstraction, dependency, credential, or configuration. No change to raw-command inference in other providers. The existing run documentation names these three new adopters; the maintainer Unreleased entry records the user-visible fix. CodeSandbox still rejects an explicitly empty command before acquisition, while OpenComputer and Docker retain their existing empty-shell behavior.
