### PR TITLE
fix: share literal-safe workspace command wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Preserve literal Agent Sandbox profile arguments through pod stdin execution and share checked workspace/environment command wrapping with Nomad. Thanks @steipete.
+
 - Reject changed Azure VM identities during acquisition readiness and use identity-checked VM/companion cleanup for failed acquisitions instead of blind name-based rollback. [PR 1827](https://github.com/openclaw/crabbox/pull/1827). Thanks @steipete.
 - Report SmolVM decoder, file-write and extraction failures instead of false upload success, isolate temporary upload files, and preserve existing files when decoding fails. [PR 1826](https://github.com/openclaw/crabbox/pull/1826). Thanks @steipete.
 - Stop direct AWS, Azure, GCP, and Hetzner bootstrap retries from allocating another machine when rollback reports a cleanup failure, preserving both the original failure and cleanup diagnostics. [PR 1819](https://github.com/openclaw/crabbox/pull/1819). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Preserve literal Agent Sandbox profile arguments through pod stdin execution and share checked workspace/environment command wrapping with Nomad. Thanks @steipete.
+- Preserve literal Agent Sandbox profile arguments through pod stdin execution and share checked workspace/environment command wrapping with Nomad. [PR 1831](https://github.com/openclaw/crabbox/pull/1831). Thanks @steipete.
 
 - Reject changed Azure VM identities during acquisition readiness and use identity-checked VM/companion cleanup for failed acquisitions instead of blind name-based rollback. [PR 1827](https://github.com/openclaw/crabbox/pull/1827). Thanks @steipete.
 - Report SmolVM decoder, file-write and extraction failures instead of false upload success, isolate temporary upload files, and preserve existing files when decoding fails. [PR 1826](https://github.com/openclaw/crabbox/pull/1826). Thanks @steipete.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -34,7 +34,7 @@ The trailing command after `--` is sent to the box verbatim as argv. Use
 `--shell` to run it through the remote shell instead, for multi-statement
 snippets, pipes, or shell expansion.
 
-On Cloudflare Sandbox, Superserve, Crownest, Vercel Sandbox, and Nomad,
+On Cloudflare Sandbox, Superserve, Crownest, Vercel Sandbox, Nomad, and Agent Sandbox,
 quoted or interpolated profile arguments retain their literal meaning through
 the delegated command transport. A value such as `&&` does not become a shell
 operator, and an executable named `FOO=x` is invoked rather than treated as an

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -415,11 +415,19 @@ core instead.
 for delegated POSIX command adapters. It reuses core shell inference and literal
 argument handling, snapshots the input, and rejects a missing command. The
 result's `Argv` method applies an adapter-supplied shell prefix only when needed;
-an explicitly empty shell source remains valid. Cloudflare Sandbox, Superserve,
-Crownest, Vercel Sandbox, and Nomad use this boundary. They retain their existing
-transport serialization, shell choice, working directory, environment, and
-execution lifecycle. These adapters currently pass no literal-argument map;
-the extraction does not change profile-literal propagation through transports.
+an explicitly empty shell source remains valid. Adopters include Cloudflare
+Sandbox, Superserve, Crownest, Vercel Sandbox, Nomad, CodeSandbox, OpenComputer,
+Docker Sandbox, and Agent Sandbox. Pass all three request fields (`Command`,
+`ShellMode`, and `CommandLiteralArgs`) so profile arguments remain literal through
+the transport. Adapters retain their shell choice and execution lifecycle;
+serialize the classified intent without running shell inference again.
+
+Agent Sandbox and Nomad use `shared.ShellWorkspaceCommand` for their common
+POSIX-stdin wrapper: create and enter the workdir, export validated environment
+names in deterministic order, then execute the classified command. Pod and
+allocation readiness, stdin transport, timeout, and exit mapping remain local
+to each adapter. This wrapper is not the SSH command runner, whose environment
+and workspace setup contracts differ.
 
 Claim-only recovery adapters may use `shared.ResolveProviderClaimStrict` to
 resolve an exact provider/scope-bound claim before a slug while preventing a

--- a/docs/providers/agent-sandbox.md
+++ b/docs/providers/agent-sandbox.md
@@ -53,6 +53,9 @@ hydration, Tailscale, or the normal SSH/rsync data plane.
 - A sandbox image that provides `/bin/sh`, `bash`, `tar`, `cp`, and a writable
   workdir. Crabbox uses `/bin/sh` for transport scripts and `bash -lc` for
   user shell-mode and auto-shell commands.
+  Quoted and interpolated profile arguments remain literal through the stdin
+  transport; workspace setup and environment export share the same command wrapper
+  as Nomad without sharing Kubernetes lifecycle or execution machinery.
 
 ## Supported Agent Sandbox Version
 

--- a/internal/providers/agentsandbox/core.go
+++ b/internal/providers/agentsandbox/core.go
@@ -174,14 +174,6 @@ func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []s
 	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
 }
 
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
 func shellQuote(s string) string {
 	return core.ShellQuote(s)
 }

--- a/internal/providers/agentsandbox/exec.go
+++ b/internal/providers/agentsandbox/exec.go
@@ -7,6 +7,9 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func (b *backend) execContext(ctx context.Context) (context.Context, context.CancelFunc) {
@@ -44,14 +47,14 @@ func (b *backend) execShell(ctx context.Context, client kubernetesClient, ready 
 }
 
 func (b *backend) runCommand(ctx context.Context, client kubernetesClient, ready sandboxReadiness, req RunRequest, workdir string) (int, error) {
-	command, err := buildCommand(req.Command, req.ShellMode)
+	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
 	if err != nil {
 		return 0, err
 	}
 	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
 		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
-	script := remoteCommandScript(workdir, req.Env, command)
+	script := shared.ShellWorkspaceCommand(workdir, req.Env, intent, "bash", "-lc")
 	execCtx, cancel := b.execContext(ctx)
 	defer cancel()
 	err = b.execPod(execCtx, client, ready, podExecRequest{
@@ -89,62 +92,4 @@ func remoteExitStatus(err error) (int, bool) {
 		return code, true
 	}
 	return 0, false
-}
-
-func buildCommand(command []string, shellMode bool) ([]string, error) {
-	if len(command) == 0 {
-		return nil, errors.New("missing command")
-	}
-	if shellMode {
-		return []string{"bash", "-lc", strings.Join(command, " ")}, nil
-	}
-	if shouldUseShell(command) || leadingEnvAssignment(command) {
-		if len(command) == 1 {
-			return []string{"bash", "-lc", command[0]}, nil
-		}
-		return []string{"bash", "-lc", shellScriptFromArgv(command)}, nil
-	}
-	return command, nil
-}
-
-func leadingEnvAssignment(command []string) bool {
-	return len(command) > 1 && strings.Contains(command[0], "=") && !strings.HasPrefix(command[0], "-")
-}
-
-func remoteCommandScript(workdir string, env map[string]string, command []string) string {
-	var b strings.Builder
-	b.WriteString("mkdir -p ")
-	b.WriteString(shellQuote(workdir))
-	b.WriteString(" && cd ")
-	b.WriteString(shellQuote(workdir))
-	for key, value := range env {
-		if !validShellEnvName(key) {
-			continue
-		}
-		b.WriteString(" && export ")
-		b.WriteString(key)
-		b.WriteString("=")
-		b.WriteString(shellQuote(value))
-	}
-	b.WriteString(" && exec ")
-	b.WriteString(shellScriptFromArgv(command))
-	return b.String()
-}
-
-func validShellEnvName(name string) bool {
-	if name == "" {
-		return false
-	}
-	for i, r := range name {
-		if i == 0 {
-			if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || r == '_') {
-				return false
-			}
-			continue
-		}
-		if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_') {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/providers/agentsandbox/exec_test.go
+++ b/internal/providers/agentsandbox/exec_test.go
@@ -2,7 +2,12 @@ package agentsandbox
 
 import (
 	"context"
-	"reflect"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,25 +38,63 @@ func TestExecContextHonorsZeroAsNoDeadline(t *testing.T) {
 	}
 }
 
-func TestBuildCommandUsesBashCompatibleShell(t *testing.T) {
-	tests := []struct {
-		name      string
-		command   []string
-		shellMode bool
-		want      []string
-	}{
-		{name: "shell mode", command: []string{"echo ok"}, shellMode: true, want: []string{"bash", "-lc", "echo ok"}},
-		{name: "single string shell syntax", command: []string{"echo ok && pwd"}, want: []string{"bash", "-lc", "echo ok && pwd"}},
-		{name: "leading env assignment", command: []string{"FOO=bar", "printenv", "FOO"}, want: []string{"bash", "-lc", "FOO='bar' 'printenv' 'FOO'"}},
+func TestRunLiteralArgumentsSurviveNativeStdinTransport(t *testing.T) {
+	if os.PathSeparator != '/' {
+		t.Skip("POSIX stdin transport")
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildCommand(tt.command, tt.shellMode)
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh unavailable")
+	}
+	for _, literalExecutable := range []bool{false, true} {
+		t.Run(fmt.Sprint(literalExecutable), func(t *testing.T) {
+			cfg := testAgentSandboxConfig(t)
+			fake := readyFakeClient(cfg)
+			b := testBackend(cfg, fake, nil, nil)
+			ready, err := sandboxReadinessOnce(t.Context(), fake, cfg.AgentSandbox.Namespace, "claim-a", fakeClaimIdentity(cfg))
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("buildCommand()=%#v want %#v", got, tt.want)
+			workdir := t.TempDir()
+			marker := filepath.Join(workdir, "must-not-exist")
+			command := []string{"printf", "%s", ";", "touch", marker}
+			literal := map[int]bool{2: true}
+			want := ";touch" + marker
+			wantCode := 0
+			if literalExecutable {
+				program := filepath.Join(workdir, "FOO=x")
+				if err := os.WriteFile(program, []byte("#!/bin/sh\nprintf 'literal:%s' \"$*\"\nexit 42\n"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				command = []string{"FOO=x", "argument"}
+				literal = map[int]bool{0: true}
+				want = "literal:argument"
+				wantCode = 42
+			}
+			_, err = b.runCommand(t.Context(), fake, ready, RunRequest{Command: command, CommandLiteralArgs: literal}, workdir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(fake.execInput) != 1 {
+				t.Fatalf("exec inputs=%d", len(fake.execInput))
+			}
+			cmd := exec.Command(sh, "-s")
+			cmd.Stdin = strings.NewReader(string(fake.execInput[0]))
+			cmd.Env = []string{"HOME=" + workdir, "PATH=" + workdir + ":/usr/bin:/bin", "ENV=" + os.DevNull}
+			out, runErr := cmd.CombinedOutput()
+			code := 0
+			if runErr != nil {
+				var exitErr *exec.ExitError
+				if !errors.As(runErr, &exitErr) {
+					t.Fatal(runErr)
+				}
+				code = exitErr.ExitCode()
+			}
+			if string(out) != want || code != wantCode {
+				t.Fatalf("script=%q output=%q code=%d want=%q/%d", fake.execInput[0], out, code, want, wantCode)
+			}
+			if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("literal created marker: %v", err)
 			}
 		})
 	}

--- a/internal/providers/nomad/exec.go
+++ b/internal/providers/nomad/exec.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type nomadExecRequest struct {
@@ -56,7 +57,7 @@ func (b *backend) runCommand(ctx context.Context, client Client, ready allocatio
 	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
 		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
-	script := remoteCommandScript(workdir, req.Env, intent)
+	script := shared.ShellWorkspaceCommand(workdir, req.Env, intent, "bash", "-lc")
 	execCtx, cancel := b.execContext(ctx)
 	defer cancel()
 	exitCode, err := b.allocationExec(execCtx, client, ready, []string{"sh", "-s"}, strings.NewReader(script), b.rt.Stdout, b.rt.Stderr)
@@ -98,42 +99,4 @@ func normalizeExitCode(code int) int {
 		return 1
 	}
 	return code
-}
-
-func remoteCommandScript(workdir string, env map[string]string, command core.CommandIntent) string {
-	var b strings.Builder
-	b.WriteString("mkdir -p ")
-	b.WriteString(shellQuote(workdir))
-	b.WriteString(" && cd ")
-	b.WriteString(shellQuote(workdir))
-	for key, value := range env {
-		if !validShellEnvName(key) {
-			continue
-		}
-		b.WriteString(" && export ")
-		b.WriteString(key)
-		b.WriteString("=")
-		b.WriteString(shellQuote(value))
-	}
-	b.WriteString(" && exec ")
-	b.WriteString(command.ShellCommand("bash", "-lc"))
-	return b.String()
-}
-
-func validShellEnvName(name string) bool {
-	if name == "" {
-		return false
-	}
-	for i, r := range name {
-		if i == 0 {
-			if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || r == '_') {
-				return false
-			}
-			continue
-		}
-		if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_') {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/providers/shared/shell_env_profile.go
+++ b/internal/providers/shared/shell_env_profile.go
@@ -72,7 +72,7 @@ func (p *PreparedShellEnvProfile) Close(ctx context.Context, remove func(context
 	return p.closeErr
 }
 
-func renderShellEnvProfile(env map[string]string) string {
+func sortedShellEnvNames(env map[string]string) []string {
 	keys := make([]string, 0, len(env))
 	for key := range env {
 		valid := key != ""
@@ -87,6 +87,11 @@ func renderShellEnvProfile(env map[string]string) string {
 		}
 	}
 	sort.Strings(keys)
+	return keys
+}
+
+func renderShellEnvProfile(env map[string]string) string {
+	keys := sortedShellEnvNames(env)
 	var out strings.Builder
 	out.WriteString("set -a\n")
 	for _, key := range keys {

--- a/internal/providers/shared/shell_workspace_command.go
+++ b/internal/providers/shared/shell_workspace_command.go
@@ -1,0 +1,25 @@
+package shared
+
+import (
+	core "github.com/openclaw/crabbox/internal/cli"
+	"strings"
+)
+
+// ShellWorkspaceCommand sets up a POSIX workspace and environment, then executes
+// already-classified command intent. The adapter chooses the workload shell.
+func ShellWorkspaceCommand(workdir string, env map[string]string, command core.CommandIntent, shellPrefix ...string) string {
+	var out strings.Builder
+	out.WriteString("mkdir -p ")
+	out.WriteString(core.ShellQuote(workdir))
+	out.WriteString(" && cd ")
+	out.WriteString(core.ShellQuote(workdir))
+	for _, key := range sortedShellEnvNames(env) {
+		out.WriteString(" && export ")
+		out.WriteString(key)
+		out.WriteByte('=')
+		out.WriteString(core.ShellQuote(env[key]))
+	}
+	out.WriteString(" && exec ")
+	out.WriteString(command.ShellCommand(shellPrefix...))
+	return out.String()
+}

--- a/internal/providers/shared/shell_workspace_command_test.go
+++ b/internal/providers/shared/shell_workspace_command_test.go
@@ -1,0 +1,92 @@
+package shared
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestShellWorkspaceCommandNative(t *testing.T) {
+	if os.PathSeparator != '/' {
+		t.Skip("POSIX workspace command")
+	}
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh unavailable")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash unavailable")
+	}
+	for _, tc := range []struct {
+		name    string
+		command []string
+		literal map[int]bool
+		shell   bool
+		want    string
+		code    int
+	}{
+		{"argv", []string{"printf", "%s", "literal value"}, nil, false, "literal value", 0},
+		{"explicit", []string{"printf '%s' \"$VALUE\"; exit 7"}, nil, true, "quotes ' and $()\nline", 7},
+		{"inferred", []string{"printf '%s' inferred && printf '%s' source"}, nil, false, "inferredsource", 0},
+		{"mixed", []string{"printf", "%s", ";", "&&", "printf", "%s", "done"}, map[int]bool{2: true}, false, ";done", 0},
+		{"assignment", []string{"GREETING=hello world", "printenv", "GREETING"}, nil, false, "hello world\n", 0},
+		{"empty shell", []string{""}, nil, true, "", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			workdir := filepath.Join(root, "work ' directory")
+			intent, err := core.ParseCommandIntent(tc.command, tc.shell, tc.literal)
+			if err != nil {
+				t.Fatal(err)
+			}
+			script := ShellWorkspaceCommand(workdir, map[string]string{"VALUE": "quotes ' and $()\nline", "BAD-NAME": "must-not-enter-script", "": "must-not-enter-script"}, intent, "bash", "-lc")
+			if strings.Contains(script, "must-not-enter-script") {
+				t.Fatalf("invalid environment name retained: %s", script)
+			}
+			cmd := exec.Command(sh, "-s")
+			cmd.Stdin = strings.NewReader(script)
+			cmd.Env = []string{"HOME=" + root, "PATH=/usr/bin:/bin", "ENV=" + os.DevNull}
+			out, runErr := cmd.CombinedOutput()
+			code := 0
+			if runErr != nil {
+				var exitErr *exec.ExitError
+				if !errors.As(runErr, &exitErr) {
+					t.Fatal(runErr)
+				}
+				code = exitErr.ExitCode()
+			}
+			if string(out) != tc.want || code != tc.code {
+				t.Fatalf("out=%q code=%d want=%q/%d script=%q", out, code, tc.want, tc.code, script)
+			}
+			if stat, err := os.Stat(workdir); err != nil || !stat.IsDir() {
+				t.Fatalf("workspace not created: %v", err)
+			}
+		})
+	}
+	t.Run("setup failure blocks workload", func(t *testing.T) {
+		root := t.TempDir()
+		workdir := filepath.Join(root, "file")
+		if err := os.WriteFile(workdir, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		marker := filepath.Join(root, "marker")
+		intent, err := core.ParseCommandIntent([]string{"touch", marker}, false, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cmd := exec.Command(sh, "-s")
+		cmd.Stdin = strings.NewReader(ShellWorkspaceCommand(workdir, nil, intent, "bash", "-lc"))
+		cmd.Env = []string{"HOME=" + root, "PATH=/usr/bin:/bin", "ENV=" + os.DevNull}
+		if out, err := cmd.CombinedOutput(); err == nil {
+			t.Fatalf("setup succeeded: %s", out)
+		}
+		if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("workload ran after failed setup: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Give Agent Sandbox and Nomad one shared POSIX workspace-command wrapper: checked directory creation and change, validated environment exports, and terminal execution of already-classified command intent. Each adapter still chooses bash -lc for actual shell intent and owns its native transport, readiness checks, timeouts, and exit mapping.

Agent Sandbox previously ignored profile literal metadata and then serialized argv through a second shell heuristic. A quoted separator could become a command separator, and a literal assignment-shaped executable followed by an argument became an environment assignment. It now parses once and carries CommandIntent through the final pod stdin script. Nomad already used that interpretation; it adopts the identical shared wrapper without changing its allocation transport.

Delete both local workspace renderers and environment-name validators, plus Agent Sandbox's obsolete builder and heuristic wrappers. The shared environment-profile renderer and workspace wrapper use one sorted, valid-name selector. The core SSH command builder is deliberately not reused: its directory, environment and login-shell contracts differ.

## Proof

Two captured-pod-stdin regressions fail on the old Agent Sandbox path: a literal separator does not reach printf as data, and FOO=x with an argument exits 127 instead of executing the intended program with exit 42. Both pass after the fix by executing the actual generated stdin with a native POSIX shell. Nomad's existing native literal-stdin regression continues to pass.

Seven shared native cases cover ordinary argv, explicit shell and nonzero exit, inferred source, mixed literal/real operators, leading assignments, empty shell source, and setup failure preventing workload execution. Workdir quoting includes spaces and an apostrophe; environment values include literal shell-like text and newlines; invalid names never enter the script.

Full race suites pass for Agent Sandbox, Nomad, shared helpers, Modal and Tensorlake. Vet, CLI build and docs build pass. Managed review is scoped-clean and independent semantic review found no actionable issue. These are captured native stdin/subprocess fixtures, not Kubernetes or Nomad cloud-live proof. No cluster or allocation is created.

## Boundaries

No dependency, credential, or configuration change. The wrapper is not a new backend or lifecycle abstraction. Provider-specific ownership, readiness revalidation, execution addressing and cleanup remain with the adapters. User-visible documentation and the maintainer Unreleased entry are included.

## Production-client follow-up

The real Kubernetes subprocess client and production command runner also pass four native transport cases, while the identical baseline fails three. Full synthetic fixture and observations: https://github.com/openclaw/crabbox/pull/1831#issuecomment-5544712332. This strengthens the native stdin/output/status boundary proof; it is not a hosted-cluster claim. The architecture-guide review finding is corrected, and current main's independently landed AWS inventory fix is preserved in the integration.
