### PR TITLE
fix(aws): require complete recovery inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Read all AWS recovery inventory pages and retain cleanup debt when pagination is incomplete; describe interrupted provisioning without assuming a deployment caused it. [PR 1832](https://github.com/openclaw/crabbox/pull/1832). Thanks @steipete.
 - Preserve literal profile arguments through CodeSandbox, OpenComputer, and Docker Sandbox execution, sharing command-intent parsing without changing provider shells or environment transports. [PR 1830](https://github.com/openclaw/crabbox/pull/1830). Thanks @steipete.
 
 - Reject changed Azure VM identities during acquisition readiness and use identity-checked VM/companion cleanup for failed acquisitions instead of blind name-based rollback. [PR 1827](https://github.com/openclaw/crabbox/pull/1827). Thanks @steipete.

--- a/docs/features/lifecycle-cleanup.md
+++ b/docs/features/lifecycle-cleanup.md
@@ -89,6 +89,20 @@ cancel an already-dispatched provider request. Failed and released records can
 still carry unresolved cleanup responsibility. Their local state alone is not
 proof that the provider resource was deleted.
 
+Interrupted provisioning recovery describes an observed interruption, without
+attributing it to a deployment. It can reconcile settled calls in the same
+coordinator generation as well as attempts observed after reconstruction; the
+existing generation and settlement eligibility checks still apply.
+
+AWS recovery inventory is evidence only for the queried Region and existing
+tag/state filters. Both the coordinator's instance inventory and private
+workspace lookup read every `DescribeInstances` page, retaining duplicate
+matches for ambiguity checks. A repeated pagination token, more than 100 pages,
+or a later-page failure makes the inventory incomplete and rejects the entire
+lookup. Incomplete inventory retains cleanup debt and cannot confirm absence,
+even after the existing 30-minute absence confirmation window. A complete empty
+inventory remains subject to that window and the existing ownership checks.
+
 For an exact Azure lease whose provisioning stops before VM creation, ordinary
 owned-resource release can clean the observed creation prefix: an unattached
 canonical public IP alone, or the exact canonical public IP and NIC together.

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -44,6 +44,7 @@ import type {
 
 const awsUbuntuOwner = "099720109477";
 const ec2Version = "2016-11-15";
+const awsDescribeInstancesMaxPages = 100;
 const stsVersion = "2011-06-15";
 const awsSpotQuotaCode = "L-34B43A08";
 const awsOnDemandQuotaCode = "L-1216C47A";
@@ -942,7 +943,7 @@ export class EC2SpotClient {
   }
 
   async listCrabboxServers(): Promise<ProviderMachine[]> {
-    const root = await this.ec2("DescribeInstances", {
+    return this.describeAllInstances({
       "Filter.1.Name": "tag:crabbox",
       "Filter.1.Value.1": "true",
       "Filter.2.Name": "instance-state-name",
@@ -951,15 +952,10 @@ export class EC2SpotClient {
       "Filter.2.Value.3": "stopping",
       "Filter.2.Value.4": "stopped",
     });
-    return reservations(root).flatMap((reservation) =>
-      items(record(record(reservation)["instancesSet"])["item"]).map((instance) =>
-        this.withRegion(instanceToMachine(instance)),
-      ),
-    );
   }
 
   async findWorkspaceServerByLease(leaseID: string): Promise<ProviderMachine | undefined> {
-    const root = await this.ec2("DescribeInstances", {
+    const matches = await this.describeAllInstances({
       "Filter.1.Name": "tag:crabbox",
       "Filter.1.Value.1": "true",
       "Filter.2.Name": "tag:created_by",
@@ -976,15 +972,45 @@ export class EC2SpotClient {
       "Filter.6.Value.3": "stopping",
       "Filter.6.Value.4": "stopped",
     });
-    const matches = reservations(root).flatMap((reservation) =>
-      items(record(record(reservation)["instancesSet"])["item"]).map((instance) =>
-        this.withRegion(instanceToMachine(instance)),
-      ),
-    );
     if (matches.length > 1) {
       throw new Error(`AWS private workspace recovery is ambiguous for lease ${leaseID}`);
     }
     return matches[0];
+  }
+
+  private async describeAllInstances(params: Record<string, string>): Promise<ProviderMachine[]> {
+    const machines: ProviderMachine[] = [];
+    const seenTokens = new Set<string>();
+    let nextToken = "";
+    const incomplete = `aws DescribeInstances inventory incomplete in ${this.region}`;
+    for (let page = 0; page < awsDescribeInstancesMaxPages; page++) {
+      let root: Record<string, unknown>;
+      try {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- EC2 pagination depends on the previous token.
+        root = await this.ec2("DescribeInstances", {
+          ...params,
+          ...(nextToken ? { NextToken: nextToken } : {}),
+        });
+      } catch (error) {
+        if (page === 0) throw error;
+        // oxlint-disable-next-line eslint/preserve-caught-error -- Upstream causes can expose opaque tokens or credentials.
+        throw new Error(`${incomplete}: page ${page + 1} request failed`);
+      }
+      machines.push(
+        ...reservations(root).flatMap((reservation) =>
+          items(record(reservation["instancesSet"])["item"]).map((instance) =>
+            this.withRegion(instanceToMachine(instance)),
+          ),
+        ),
+      );
+      nextToken = asString(root["nextToken"]);
+      if (!nextToken) return machines;
+      if (seenTokens.has(nextToken)) {
+        throw new Error(`${incomplete}: repeated pagination token`);
+      }
+      seenTokens.add(nextToken);
+    }
+    throw new Error(`${incomplete}: pagination exceeded ${awsDescribeInstancesMaxPages} pages`);
   }
 
   async refreshSSHIngress(config: LeaseConfig, options: AWSIngressOptions = {}): Promise<void> {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -16363,7 +16363,7 @@ export class FleetCoordinator {
       }
       const failedAtDate = new Date();
       const failedAt = failedAtDate.toISOString();
-      const interruption = "coordinator deployment interrupted provider provisioning";
+      const interruption = "provider provisioning was interrupted";
       current.updatedAt = failedAt;
       if (server) {
         current.state = lease.state === "released" ? "released" : "failed";

--- a/worker/test/aws-inventory.test.ts
+++ b/worker/test/aws-inventory.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { EC2SpotClient } from "../src/aws";
+
+const leaseID = "cbx_abcdef123456";
+const region = "eu-west-1";
+const inventoryFilters = {
+  "Filter.1.Name": "tag:crabbox",
+  "Filter.1.Value.1": "true",
+  "Filter.2.Name": "instance-state-name",
+  "Filter.2.Value.1": "pending",
+  "Filter.2.Value.2": "running",
+  "Filter.2.Value.3": "stopping",
+  "Filter.2.Value.4": "stopped",
+};
+const workspaceFilters = {
+  "Filter.1.Name": "tag:crabbox",
+  "Filter.1.Value.1": "true",
+  "Filter.2.Name": "tag:created_by",
+  "Filter.2.Value.1": "crabbox",
+  "Filter.3.Name": "tag:crabbox_workspace",
+  "Filter.3.Value.1": "true",
+  "Filter.4.Name": "tag:access_mode",
+  "Filter.4.Value.1": "ssm",
+  "Filter.5.Name": "tag:lease",
+  "Filter.5.Value.1": leaseID,
+  "Filter.6.Name": "instance-state-name",
+  "Filter.6.Value.1": "pending",
+  "Filter.6.Value.2": "running",
+  "Filter.6.Value.3": "stopping",
+  "Filter.6.Value.4": "stopped",
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe.each([
+  { lookup: "inventory", filters: inventoryFilters },
+  { lookup: "workspace", filters: workspaceFilters },
+])("AWS $lookup pagination", ({ lookup, filters }) => {
+  function read(client: EC2SpotClient) {
+    return lookup === "inventory"
+      ? client.listCrabboxServers()
+      : client.findWorkspaceServerByLease(leaseID);
+  }
+
+  function createClient() {
+    return new EC2SpotClient(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
+      region,
+    );
+  }
+
+  function expected(ids: string[]) {
+    const machines = ids.map((cloudID) =>
+      expect.objectContaining({ cloudID, region, labels: { lease: leaseID } }),
+    );
+    return lookup === "inventory" ? machines : machines[0];
+  }
+
+  it.each([{ ids: [] }, { ids: ["i-only"] }])(
+    "handles a complete one-page response $ids",
+    async ({ ids }) => {
+      const fetchMock = vi.fn<typeof fetch>(async () => instancePage(ids));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(read(createClient())).resolves.toEqual(expected(ids));
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("includes a later-page resource and preserves all filters, region and NextToken", async () => {
+    const calls: Record<string, string>[] = [];
+    const token = "opaque+/=next-page";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        expect(new URL(request.url).hostname).toBe(`ec2.${region}.amazonaws.com`);
+        expect(request.method).toBe("POST");
+        calls.push(Object.fromEntries(new URLSearchParams(await request.text())));
+        return calls.length === 1 ? instancePage([], token) : instancePage(["i-later"]);
+      }),
+    );
+
+    await expect(read(createClient())).resolves.toEqual(expected(["i-later"]));
+    const params = { Action: "DescribeInstances", Version: "2016-11-15", ...filters };
+    expect(calls).toEqual([params, { ...params, NextToken: token }]);
+  });
+
+  it.each(["i-second", "i-first"])(
+    "retains later-page match %s for ambiguity checks",
+    async (secondID) => {
+      const fetchMock = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(instancePage(["i-first"], "next-page"))
+        .mockResolvedValueOnce(instancePage([secondID]));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await read(createClient()).catch((error: unknown) => error);
+      expect(result).toEqual(
+        lookup === "workspace"
+          ? new Error(`AWS private workspace recovery is ambiguous for lease ${leaseID}`)
+          : expected(["i-first", secondID]),
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each([
+    { name: "repeated token", tokens: ["opaque-a", "opaque-a"] },
+    { name: "token cycle", tokens: ["opaque-a", "opaque-b", "opaque-a"] },
+  ])("rejects the entire inventory on a $name", async ({ tokens }) => {
+    let page = 0;
+    const fetchMock = vi.fn<typeof fetch>(async () => instancePage(["i-first"], tokens[page++]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(read(createClient())).rejects.toThrow(
+      `aws DescribeInstances inventory incomplete in ${region}: repeated pagination token`,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(tokens.length);
+  });
+
+  it.each([false, true])("bounds inventory at 100 pages (more pages: %s)", async (morePages) => {
+    let page = 0;
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      page++;
+      return instancePage(
+        page === 100 ? ["i-last"] : [],
+        page < 100 || morePages ? `opaque-page-${page}` : undefined,
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await read(createClient()).catch((error: unknown) => error);
+    expect(result).toEqual(
+      morePages
+        ? new Error(
+            `aws DescribeInstances inventory incomplete in ${region}: pagination exceeded 100 pages`,
+          )
+        : expected(["i-last"]),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(100);
+  });
+
+  it.each(["http", "transport"])(
+    "rejects the whole result on a later-page %s failure without leaking upstream details",
+    async (failure) => {
+      const fetchMock = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(instancePage(["i-first"], "opaque-token"));
+      const detail = "opaque-token synthetic-credential";
+      if (failure === "http") {
+        fetchMock.mockResolvedValueOnce(
+          new Response(
+            `<Response><Errors><Error><Code>InvalidNextToken</Code><Message>${detail}</Message></Error></Errors></Response>`,
+            { status: 400 },
+          ),
+        );
+      } else {
+        fetchMock.mockRejectedValueOnce(new Error(detail));
+      }
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(read(createClient())).rejects.toEqual(
+        new Error(`aws DescribeInstances inventory incomplete in ${region}: page 2 request failed`),
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    },
+  );
+});
+
+function instancePage(ids: string[], nextToken?: string): Response {
+  const reservations = ids.map(
+    (id) => `<item><instancesSet><item>
+      <instanceId>${id}</instanceId>
+      <instanceState><name>running</name></instanceState>
+      <tagSet><item><key>lease</key><value>${leaseID}</value></item></tagSet>
+    </item></instancesSet></item>`,
+  );
+  return new Response(
+    `<DescribeInstancesResponse><reservationSet>${reservations.join("")}</reservationSet>
+      ${nextToken ? `<nextToken>${nextToken}</nextToken>` : ""}
+    </DescribeInstancesResponse>`,
+    { headers: { "content-type": "text/xml" } },
+  );
+}

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -12959,8 +12959,7 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value<LeaseRecord>("lease:cbx_000000000091")).toMatchObject({
       state: "failed",
       cloudID: "",
-      failureError:
-        "coordinator deployment interrupted provider provisioning; no provider resource found",
+      failureError: "provider provisioning was interrupted; no provider resource found",
       provisioningResourceMayExist: false,
       provisioningFailureRetryable: false,
     });
@@ -13618,8 +13617,7 @@ describe("fleet lease identity and idle", () => {
       state: "provisioning",
       provisioningResourceMayExist: true,
       provisioningFailureRetryable: true,
-      cleanupError:
-        "coordinator deployment interrupted provider provisioning; provider resource not yet visible",
+      cleanupError: "provider provisioning was interrupted; provider resource not yet visible",
     });
     expect(Date.parse(uncertain?.provisioningRecoveryMissingSince ?? "")).toBeGreaterThanOrEqual(
       now,
@@ -13753,7 +13751,7 @@ describe("fleet lease identity and idle", () => {
       state: "failed",
       cloudID: "crabbox-interrupted",
       failureError:
-        "coordinator deployment interrupted provider provisioning; recovered provider resource for cleanup",
+        "provider provisioning was interrupted; recovered provider resource for cleanup",
       provisioningResourceMayExist: false,
       provisioningFailureRetryable: false,
     });
@@ -13909,6 +13907,96 @@ describe("fleet lease identity and idle", () => {
     expect(Date.parse(lease?.cleanupRetryAt ?? "")).toBeGreaterThan(now);
     expect(storage.alarm()).toBe(Date.parse(lease?.cleanupRetryAt ?? ""));
   });
+
+  it.each([false, true])(
+    "retains cleanup debt after incomplete AWS inventory (absence window elapsed: %s)",
+    async (absenceWindowElapsed) => {
+      const storage = new MemoryStorage();
+      const now = Date.now();
+      const missingSince = absenceWindowElapsed
+        ? new Date(now - 31 * 60_000).toISOString()
+        : undefined;
+      const leaseID = "cbx_000000000094";
+      const calls: Array<{ action: string | null; token: string | null; host: string }> = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const inventoryRequest = input instanceof Request ? input : new Request(input, init);
+          const params = new URLSearchParams(await inventoryRequest.text());
+          calls.push({
+            action: params.get("Action"),
+            token: params.get("NextToken"),
+            host: new URL(inventoryRequest.url).hostname,
+          });
+          return calls.length === 1
+            ? ec2XMLResponse(
+                "<DescribeInstancesResponse><reservationSet/><nextToken>next-page</nextToken></DescribeInstancesResponse>",
+              )
+            : ec2XMLResponse(
+                "<Response><Errors><Error><Code>InvalidNextToken</Code><Message>unavailable page</Message></Error></Errors></Response>",
+                400,
+              );
+        }),
+      );
+      const fleet = testFleet(
+        storage,
+        {},
+        {
+          AWS_ACCESS_KEY_ID: "test",
+          AWS_SECRET_ACCESS_KEY: "secret",
+          CRABBOX_AWS_ORPHAN_SWEEP_ENABLED: "0",
+          CF_VERSION_METADATA: {
+            id: "new-version",
+            timestamp: new Date(now - 10 * 60_000).toISOString(),
+          },
+        },
+      );
+      storage.seed(
+        `lease:${leaseID}`,
+        testLease({
+          id: leaseID,
+          slug: "inventory",
+          provider: "aws",
+          region: "eu-west-1",
+          owner: "alice@example.com",
+          org: "example-org",
+          cloudID: "",
+          serverID: 0,
+          serverName: "",
+          host: "",
+          state: "provisioning",
+          provisioningResourceMayExist: true,
+          provisioningRequestStartedAt: new Date(now - 60_000).toISOString(),
+          provisioningCoordinatorVersion: "old-version",
+          provisioningRecoveryObservedAt: new Date(now - 10 * 60_000).toISOString(),
+          provisioningRecoveryMissingSince: missingSince,
+          expiresAt: new Date(now + 60 * 60_000).toISOString(),
+        }),
+      );
+
+      await fleet.alarm();
+
+      expect(calls).toEqual([
+        { action: "DescribeInstances", token: null, host: "ec2.eu-west-1.amazonaws.com" },
+        { action: "DescribeInstances", token: "next-page", host: "ec2.eu-west-1.amazonaws.com" },
+      ]);
+      const lease = storage.value<LeaseRecord>(`lease:${leaseID}`);
+      expect(lease).toMatchObject({
+        state: "provisioning",
+        cloudID: "",
+        provisioningResourceMayExist: true,
+        provisioningCoordinatorVersion: "old-version",
+        cleanupAttempts: 1,
+        cleanupError:
+          "interrupted provisioning recovery failed: aws DescribeInstances inventory incomplete in eu-west-1: page 2 request failed",
+      });
+      expect(lease?.provisioningRecoveryMissingSince).toBe(missingSince);
+      expect(lease?.failureError).toBeUndefined();
+      expect(lease?.endedAt).toBeUndefined();
+      expect(Date.parse(lease?.cleanupRetryAt ?? "")).toBeGreaterThan(now);
+      expect(storage.alarm()).toBe(Date.parse(lease?.cleanupRetryAt ?? ""));
+    },
+  );
 
   it("does not let registration overwrite another owner or managed lease", async () => {
     const storage = new MemoryStorage();


### PR DESCRIPTION
## Summary

AWS recovery inventory previously read only the first `DescribeInstances` page. A matching resource—or an additional ambiguous match—on a later page could be missed, weakening the coordinator's absence evidence.

Both coordinator inventory and private-workspace lookup now use one provider-owned paginator. It preserves the existing filters, region and duplicate matches; a token cycle, the 100-page budget, or a later-page failure rejects the entire result instead of returning partial inventory. The recovery message now describes interrupted provisioning without assuming a deployment caused it. Ownership checks and generation/settlement eligibility are unchanged.

The original single-page implementation is present in https://github.com/openclaw/crabbox/commit/52d30da07cc0d6291eec4433ba050589747c1887, verified against its raw parent. This is a focused recovery correction, not a provisioning-controller rewrite.

## Verification

- Added 24 regression cases for both lookup paths, complete/empty inventories, filter and token preservation, later-page resources and duplicate matches, cycles, the page budget, later-page HTTP/transport failures, and coordinator cleanup-debt retention after the absence window.
- Synthetic red/green proof: the baseline misses a page-two lease after one request; the patch finds it after two. All fetches were intercepted; no provider calls.
- Full Worker suite: 2,587 passed, 3 skipped.
- Worker format, lint, TypeScript and Node-runtime typechecks passed.
- Worker dry-run, Node-runtime and Cloudflare Dynamic Workers builds passed.
- Documentation link check passed.
- Independent Codex review: no actionable P0–P2 findings.

## Boundaries

No new dependencies, configuration changes, credentials, cloud resources or live cleanup were needed. The paginator bounds pages, not the duration of an individual provider request. Complete inventory is still region- and filter-scoped; `serverId=0` or coordinator cleanup completion is not account-wide absence proof.

This does not claim to explain or fix the initiating HTTP 500/1101 from the separate provisioning investigation, and it does not modify the Windows bootstrap-port fix in https://github.com/openclaw/crabbox/pull/1801. Native Windows/WSL2 live proof remains unexecuted. Ordinary repository auto-deployment follows merge; no manual deployment or release is included.