### PR TITLE
fix: share existing-shell command intent rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Preserve literal SmolVM and Upstash Box profile arguments, accept inferred single-string shell commands, and share source rendering without adding another shell. Thanks @steipete.
+- Preserve literal SmolVM and Upstash Box profile arguments, accept inferred single-string shell commands, and share source rendering without adding another shell. [PR 1833](https://github.com/openclaw/crabbox/pull/1833). Thanks @steipete.
 - Preserve literal profile arguments through CodeSandbox, OpenComputer, and Docker Sandbox execution, sharing command-intent parsing without changing provider shells or environment transports. [PR 1830](https://github.com/openclaw/crabbox/pull/1830). Thanks @steipete.
 
 - Reject changed Azure VM identities during acquisition readiness and use identity-checked VM/companion cleanup for failed acquisitions instead of blind name-based rollback. [PR 1827](https://github.com/openclaw/crabbox/pull/1827). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Preserve literal SmolVM and Upstash Box profile arguments, accept inferred single-string shell commands, and share source rendering without adding another shell. Thanks @steipete.
+
 - Reject changed Azure VM identities during acquisition readiness and use identity-checked VM/companion cleanup for failed acquisitions instead of blind name-based rollback. [PR 1827](https://github.com/openclaw/crabbox/pull/1827). Thanks @steipete.
 - Report SmolVM decoder, file-write and extraction failures instead of false upload success, isolate temporary upload files, and preserve existing files when decoding fails. [PR 1826](https://github.com/openclaw/crabbox/pull/1826). Thanks @steipete.
 - Clean failed SmolVM environment-profile uploads with bounded original-claim checks, isolate each run's profile, and reuse shared shell-profile handling without requiring Bash. [PR 1829](https://github.com/openclaw/crabbox/pull/1829). Thanks @steipete.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -34,7 +34,7 @@ The trailing command after `--` is sent to the box verbatim as argv. Use
 `--shell` to run it through the remote shell instead, for multi-statement
 snippets, pipes, or shell expansion.
 
-On Cloudflare Sandbox, Superserve, Crownest, Vercel Sandbox, and Nomad,
+On Cloudflare Sandbox, Superserve, Crownest, Vercel Sandbox, Nomad, SmolVM, and Upstash Box,
 quoted or interpolated profile arguments retain their literal meaning through
 the delegated command transport. A value such as `&&` does not become a shell
 operator, and an executable named `FOO=x` is invoked rather than treated as an

--- a/docs/providers/smolvm.md
+++ b/docs/providers/smolvm.md
@@ -170,6 +170,16 @@ during the first exec.
 - Forwarded environment values use an independently named profile in the validated workdir. The shared profile owner retains cleanup responsibility after a failed upload; cleanup runs before one-shot teardown with a fresh bounded context, checking the original local claim and native machine identity. Changed ownership retains the remote file and warns rather than authorizing stale cleanup. The source check uses the existing POSIX shell and does not require Bash or change user-command errexit behavior.
 - The direct archive sync sends the (base64) tar inside the `/exec` command body. Very large repos may hit request size limits (the usual preflight checks still apply).
 
+## Command interpretation
+
+Quoted and interpolated profile arguments remain literal through the source-only
+command transport. Unmarked single-string commands follow the shared shell-source
+inference, while explicit `--shell` remains source in the provider's existing
+shell. Literal argv retains terminal `exec`; Crabbox does not introduce another
+shell or a Bash dependency for this interpretation. Environment-profile and
+working-directory handling remain provider-specific.
+
+
 ## Related docs
 
 - [Provider backends](../provider-backends.md)

--- a/docs/providers/upstash-box.md
+++ b/docs/providers/upstash-box.md
@@ -164,6 +164,16 @@ pass `--keep=false` to `warmup`, Crabbox prints a warning and still keeps it.
   `--keep` independently controls whether a one-shot `run` deletes the Box
   afterward.
 
+## Command interpretation
+
+Quoted and interpolated profile arguments remain literal through the source-only
+command transport. Unmarked single-string commands follow the shared shell-source
+inference, while explicit `--shell` remains source in the provider's existing
+shell. Literal argv retains terminal `exec`; Crabbox does not introduce another
+shell or a Bash dependency for this interpretation. Environment-profile and
+working-directory handling remain provider-specific.
+
+
 ## Related docs
 
 - [Crabbox setup guide](https://upstash.com/docs/box/guides/crabbox-setup) — Upstash's walkthrough for running Crabbox on Upstash Box.

--- a/internal/cli/command_intent.go
+++ b/internal/cli/command_intent.go
@@ -42,3 +42,12 @@ func (c CommandIntent) Argv(shellPrefix ...string) []string {
 func (c CommandIntent) ShellCommand(shellPrefix ...string) string {
 	return strings.Join(shellWords(c.Argv(shellPrefix...)), " ")
 }
+
+// ShellSource renders a terminal workload for the caller's existing POSIX shell.
+// Shell intent remains source in that shell; literal argv replaces it with exec.
+func (c CommandIntent) ShellSource() string {
+	if c.shell {
+		return c.source
+	}
+	return "exec " + strings.Join(shellWords(c.args), " ")
+}

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -1127,15 +1127,17 @@ func TestCommandIntentNativeTransport(t *testing.T) {
 		{"literal mixed with intentional operator", []string{"printf", "%s", ";", "&&", "printf", "%s", "done"}, false, ";done", 0, map[int]bool{2: true}},
 	}
 	for _, tt := range tests {
-		for _, serialized := range []bool{false, true} {
-			t.Run(fmt.Sprintf("%s/serialized=%t", tt.name, serialized), func(t *testing.T) {
+		for _, transport := range []string{"argv", "command", "source"} {
+			t.Run(fmt.Sprintf("%s/transport=%s", tt.name, transport), func(t *testing.T) {
 				intent, err := ParseCommandIntent(tt.command, tt.shell, tt.literal)
 				if err != nil {
 					t.Fatal(err)
 				}
 				argv := intent.Argv(bash, "-lc")
-				if serialized {
+				if transport == "command" {
 					argv = []string{"/bin/sh", "-c", intent.ShellCommand(bash, "-lc")}
+				} else if transport == "source" {
+					argv = []string{"/bin/sh", "-c", intent.ShellSource()}
 				}
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
@@ -6434,5 +6436,54 @@ $t=$raw.WriteAsync($b,0,$b.Length);if(!$t.Wait(5000)){exit 74};$null=$t.GetAwait
 				t.Fatalf("post-preamble bytes=%x err=%v", got, err)
 			}
 		})
+	}
+}
+
+func TestCommandIntentShellSourceKeepsExistingShell(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell context")
+	}
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh unavailable")
+	}
+	root := t.TempDir()
+	source, err := ParseCommandIntent([]string{`printf '%s:' "$hidden"; say "$1"; exit 7`}, true, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prelude := `hidden=local; say() { printf '%s' "$1"; }; set -- argument; trap 'printf :trap' EXIT; `
+	cmd := exec.Command(sh, "-c", prelude+source.ShellSource())
+	cmd.Env = []string{"HOME=" + root, "PATH=/usr/bin:/bin", "ENV=" + os.DevNull}
+	out, runErr := cmd.CombinedOutput()
+	var ee *exec.ExitError
+	if !errors.As(runErr, &ee) || ee.ExitCode() != 7 || string(out) != "local:argument:trap" {
+		t.Fatalf("existing shell output=%q err=%v", out, runErr)
+	}
+	program := filepath.Join(root, "argv-program")
+	if err := os.WriteFile(program, []byte("#!/bin/sh\nprintf argv\nexit 42\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	argv, err := ParseCommandIntent([]string{program}, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd = exec.Command(sh, "-c", `trap 'printf old-shell-trap' EXIT; `+argv.ShellSource()+`; printf old-shell-suffix`)
+	cmd.Env = []string{"HOME=" + root, "PATH=/usr/bin:/bin", "ENV=" + os.DevNull}
+	out, runErr = cmd.CombinedOutput()
+	if !errors.As(runErr, &ee) || ee.ExitCode() != 42 || string(out) != "argv" {
+		t.Fatalf("terminal exec output=%q err=%v", out, runErr)
+	}
+	for _, tc := range []struct {
+		shell bool
+		want  string
+	}{{true, ""}, {false, "exec ''"}} {
+		intent, err := ParseCommandIntent([]string{""}, tc.shell, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := intent.ShellSource(); got != tc.want {
+			t.Fatalf("empty source shell=%t got=%q want=%q", tc.shell, got, tc.want)
+		}
 	}
 }

--- a/internal/providers/smolvm/backend.go
+++ b/internal/providers/smolvm/backend.go
@@ -152,10 +152,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		return result, nil
 	}
 
-	command, err := buildCommand(req.Command, req.ShellMode)
+	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
 	if err != nil {
 		return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: b.now().Sub(started), SyncDelegated: true, Session: session}, err
 	}
+	command := intent.ShellSource()
 	if req.EnvSummary {
 		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
@@ -595,21 +596,6 @@ func cleanWorkdir(workdir string) (string, error) {
 		return "", exit(2, "smolvm workdir %q is too broad; choose a dedicated subdirectory", clean)
 	}
 	return clean, nil
-}
-
-func buildCommand(command []string, shellMode bool) (string, error) {
-	if len(command) == 0 {
-		return "", errors.New("missing command")
-	}
-	var script string
-	if shellMode {
-		script = strings.Join(command, " ")
-	} else if shouldUseShell(command) || leadingEnvAssignment(command) {
-		script = shellScriptFromArgv(command)
-	} else {
-		script = "exec " + strings.Join(shellWords(command), " ")
-	}
-	return script, nil
 }
 
 const workspaceRoot = "/workspace"

--- a/internal/providers/smolvm/backend_test.go
+++ b/internal/providers/smolvm/backend_test.go
@@ -468,13 +468,7 @@ func TestCleanWorkdirAndCommand(t *testing.T) {
 			t.Fatalf("cleanWorkdir(%q) succeeded unexpectedly", value)
 		}
 	}
-	command, err := buildCommand([]string{"go", "test", "./..."}, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if command != "exec 'go' 'test' './...'" {
-		t.Fatalf("command=%q", command)
-	}
+
 }
 
 func TestWarmupRejectsActionsRunner(t *testing.T) {
@@ -1176,6 +1170,66 @@ func TestEnvironmentProfileCleanupRejectsChangedOwnership(t *testing.T) {
 			}
 			if !strings.Contains(stderr.String(), "env profile cleanup failed") {
 				t.Fatalf("missing cleanup warning: %s", stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunSourceIntentSurvivesNativeShell(t *testing.T) {
+	if os.PathSeparator != '/' {
+		t.Skip("POSIX source transport")
+	}
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh unavailable")
+	}
+	for _, tc := range []struct {
+		name    string
+		command []string
+		literal map[int]bool
+		want    string
+		code    int
+	}{
+		{"literal separator", []string{"printf", "<%s>", ";", "touch", "sentinel"}, map[int]bool{2: true}, "<;><touch><sentinel>", 0},
+		{"literal executable", []string{"FOO=x", "argument"}, map[int]bool{0: true}, "literal:argument", 42},
+		{"mixed intent", []string{"printf", "%s", ";", "&&", "printf", "%s", "done"}, map[int]bool{2: true}, ";done", 0},
+		{"inferred singleton", []string{"printf 'source value'"}, nil, "source value", 0},
+		{"ordinary argv", []string{"printf", "%s", "value"}, nil, "value", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			root := t.TempDir()
+			program := filepath.Join(root, "FOO=x")
+			if err := os.WriteFile(program, []byte("#!/bin/sh\nprintf 'literal:%s' \"$*\"\nexit 42\n"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			fake := &fakeAPI{}
+			withFakeAPI(t, fake)
+			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+			_, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: root, Name: "fixture"}, NoSync: true, Keep: true, Command: tc.command, CommandLiteralArgs: tc.literal})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(fake.streamCommands) != 1 {
+				t.Fatalf("stream commands=%v", fake.streamCommands)
+			}
+			cmd := exec.Command(sh, "-c", fake.streamCommands[0])
+			cmd.Dir = root
+			cmd.Env = []string{"HOME=" + root, "PATH=" + root + ":/usr/bin:/bin", "ENV=" + os.DevNull}
+			out, runErr := cmd.CombinedOutput()
+			code := 0
+			if runErr != nil {
+				var ee *exec.ExitError
+				if !errors.As(runErr, &ee) {
+					t.Fatal(runErr)
+				}
+				code = ee.ExitCode()
+			}
+			if string(out) != tc.want || code != tc.code {
+				t.Fatalf("source=%q output=%q code=%d want=%q/%d", fake.streamCommands[0], out, code, tc.want, tc.code)
+			}
+			if _, err := os.Stat(filepath.Join(root, "sentinel")); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("literal created sentinel: %v", err)
 			}
 		})
 	}

--- a/internal/providers/smolvm/core.go
+++ b/internal/providers/smolvm/core.go
@@ -90,22 +90,6 @@ func shellQuote(s string) string {
 	return core.ShellQuote(s)
 }
 
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
-func shellWords(words []string) []string {
-	return core.ShellWords(words)
-}
-
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func leadingEnvAssignment(command []string) bool {
-	return core.LeadingEnvAssignment(command)
-}
-
 func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
 	return core.SyncExcludes(root, cfg)
 }

--- a/internal/providers/upstashbox/backend.go
+++ b/internal/providers/upstashbox/backend.go
@@ -2,7 +2,6 @@ package upstashbox
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"path"
@@ -179,10 +178,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		return result, nil
 	}
 
-	command, err := buildCommand(req.Command, req.ShellMode)
+	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
 	if err != nil {
 		return RunResult{}, err
 	}
+	command := intent.ShellSource()
 	if req.EnvSummary {
 		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
@@ -611,21 +611,6 @@ func cleanWorkdir(workdir string) (string, error) {
 		return "", exit(2, "upstash-box workdir %q is too broad; choose a dedicated subdirectory", clean)
 	}
 	return clean, nil
-}
-
-func buildCommand(command []string, shellMode bool) (string, error) {
-	if len(command) == 0 {
-		return "", errors.New("missing command")
-	}
-	var script string
-	if shellMode {
-		script = strings.Join(command, " ")
-	} else if shouldUseShell(command) || leadingEnvAssignment(command) {
-		script = shellScriptFromArgv(command)
-	} else {
-		script = "exec " + strings.Join(shellWords(command), " ")
-	}
-	return script, nil
 }
 
 const workspaceRoot = "/workspace/home"

--- a/internal/providers/upstashbox/backend_test.go
+++ b/internal/providers/upstashbox/backend_test.go
@@ -563,13 +563,7 @@ func TestCleanWorkdirAndCommand(t *testing.T) {
 			t.Fatalf("cleanWorkdir(%q) succeeded", value)
 		}
 	}
-	command, err := buildCommand([]string{"go", "test", "./..."}, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if command != "exec 'go' 'test' './...'" {
-		t.Fatalf("command=%q", command)
-	}
+
 	env := shellEnvProfile(map[string]string{"B": "two", "A": "one two", "BAD; id >&2 #": "boom"})
 	if env != "set -a\nA='one two'\nB='two'\nset +a\n" {
 		t.Fatalf("env profile=%q", env)
@@ -1187,5 +1181,65 @@ func runGit(t *testing.T, dir string, args ...string) {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+}
+
+func TestRunSourceIntentSurvivesNativeShell(t *testing.T) {
+	if os.PathSeparator != '/' {
+		t.Skip("POSIX source transport")
+	}
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh unavailable")
+	}
+	for _, tc := range []struct {
+		name    string
+		command []string
+		literal map[int]bool
+		want    string
+		code    int
+	}{
+		{"literal separator", []string{"printf", "<%s>", ";", "touch", "sentinel"}, map[int]bool{2: true}, "<;><touch><sentinel>", 0},
+		{"literal executable", []string{"FOO=x", "argument"}, map[int]bool{0: true}, "literal:argument", 42},
+		{"mixed intent", []string{"printf", "%s", ";", "&&", "printf", "%s", "done"}, map[int]bool{2: true}, ";done", 0},
+		{"inferred singleton", []string{"printf 'source value'"}, nil, "source value", 0},
+		{"ordinary argv", []string{"printf", "%s", "value"}, nil, "value", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			root := t.TempDir()
+			program := filepath.Join(root, "FOO=x")
+			if err := os.WriteFile(program, []byte("#!/bin/sh\nprintf 'literal:%s' \"$*\"\nexit 42\n"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			fake := &fakeAPI{}
+			withFakeAPI(t, fake)
+			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+			_, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: root, Name: "fixture"}, NoSync: true, Keep: true, Command: tc.command, CommandLiteralArgs: tc.literal})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(fake.streamCommands) != 1 {
+				t.Fatalf("stream commands=%v", fake.streamCommands)
+			}
+			cmd := exec.Command(sh, "-c", fake.streamCommands[0])
+			cmd.Dir = root
+			cmd.Env = []string{"HOME=" + root, "PATH=" + root + ":/usr/bin:/bin", "ENV=" + os.DevNull}
+			out, runErr := cmd.CombinedOutput()
+			code := 0
+			if runErr != nil {
+				var ee *exec.ExitError
+				if !errors.As(runErr, &ee) {
+					t.Fatal(runErr)
+				}
+				code = ee.ExitCode()
+			}
+			if string(out) != tc.want || code != tc.code {
+				t.Fatalf("source=%q output=%q code=%d want=%q/%d", fake.streamCommands[0], out, code, tc.want, tc.code)
+			}
+			if _, err := os.Stat(filepath.Join(root, "sentinel")); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("literal created sentinel: %v", err)
+			}
+		})
 	}
 }

--- a/internal/providers/upstashbox/core.go
+++ b/internal/providers/upstashbox/core.go
@@ -103,22 +103,6 @@ func upstashBoxCleanupCommand(leaseID string) string {
 	return "crabbox stop --provider " + providerName + " " + shellQuote(leaseID)
 }
 
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
-func shellWords(words []string) []string {
-	return core.ShellWords(words)
-}
-
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func leadingEnvAssignment(command []string) bool {
-	return core.LeadingEnvAssignment(command)
-}
-
 func inventoryDoctorResult(provider string, leases int) DoctorResult {
 	return core.InventoryDoctorResult(provider, leases)
 }


### PR DESCRIPTION
## Summary

SmolVM and Upstash Box now use the existing CommandIntent owner instead of two identical metadata-blind source builders. The new ShellSource method renders a terminal workload for the provider's existing POSIX shell: classified source stays source, while literal argv retains terminal exec and individual word quoting. It does not introduce another interpreter, choose Bash, add grouping, or change the existing Argv/ShellCommand methods.

Both adapters now carry profile literal positions through the final source string. Literal separators and assignment-shaped executable names remain data; mixed real/literal operators work. Unmarked single-string commands also follow core's existing shell-source inference instead of the old builders quoting the entire snippet as an executable name. That is an intentional behavior correction, documented alongside literal profile preservation. Old builders and obsolete wrappers are deleted.

## Proof

Eight native provider regressions fail on the baseline across the two adapters: literal separator, assignment-shaped executable with an argument, mixed operators, and inferred singleton source. They pass on the candidate. The existing core native matrix now covers the source transport as well as argv and nested-command serialization. Additional native tests prove source sees its caller's unexported variable, function, positional parameter and EXIT trap, while terminal argv exec replaces the old shell without running its trap or suffix.

An unchanged fixture drives both built CLIs through public profiles and the unmodified production HTTP clients. The candidate passes all 16 cases; the baseline passes eight. Received SmolVM CommandSpec remains a string; Upstash still sends sh -c. The local service executes the actual source with only the remote filesystem namespace mapped into a temporary directory. Literal arguments, executable exit 42, explicit shell/environment exit 7, existing-shell context, profile removal and ordinary one-shot cleanup are checked. No real credentials or hosted resources are used.

Empty composed source remains provider-specific: after successful profile sourcing, SmolVM's existing guarded-newline prefix accepts an empty body; Upstash's existing trailing && composition returns its existing syntax error. Both observations match the baseline. No normalization or fallback was added.

Full SmolVM/Upstash race suites, focused core command-intent/native tests, vet, CLI build and docs build pass. Managed reviews are scoped-clean and independent semantic review found no actionable defect. Current main is integrated; changelog and affected command/provider docs are included.

## Boundaries

No dependency, credential or configuration change. Profile custody, cwd, API folder conversion, timeout, output and cleanup ownership stay provider-specific. These are production-client/native-shell loopback fixtures, not hosted SmolVM/Upstash proof; fixture-defined shell state demonstrates the renderer contract without claiming a particular production image defines that state. Modal and the remaining source adapters are not changed in this PR.

Complete public-CLI fixture and baseline/candidate observations: https://github.com/openclaw/crabbox/pull/1833#issuecomment-5544212725.
