### PR TITLE
fix(upstash-box): share isolated environment profile custody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Clean partial Upstash Box environment uploads after failure or cancellation, isolate each profile, and refuse stale file cleanup while preserving discovery-only reuse and original command outcomes. Thanks @steipete.
 - Preserve literal profile arguments through CodeSandbox, OpenComputer, and Docker Sandbox execution, sharing command-intent parsing without changing provider shells or environment transports. [PR 1830](https://github.com/openclaw/crabbox/pull/1830). Thanks @steipete.
 
 - Reject changed Azure VM identities during acquisition readiness and use identity-checked VM/companion cleanup for failed acquisitions instead of blind name-based rollback. [PR 1827](https://github.com/openclaw/crabbox/pull/1827). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Clean partial Upstash Box environment uploads after failure or cancellation, isolate each profile, and refuse stale file cleanup while preserving discovery-only reuse and original command outcomes. Thanks @steipete.
+- Clean partial Upstash Box environment uploads after failure or cancellation, isolate each profile, and refuse stale file cleanup while preserving discovery-only reuse and original command outcomes. [PR 1834](https://github.com/openclaw/crabbox/pull/1834). Thanks @steipete.
 - Read all AWS recovery inventory pages and retain cleanup debt when pagination is incomplete; describe interrupted provisioning without assuming a deployment caused it. [PR 1832](https://github.com/openclaw/crabbox/pull/1832). Thanks @steipete.
 - Preserve literal profile arguments through CodeSandbox, OpenComputer, and Docker Sandbox execution, sharing command-intent parsing without changing provider shells or environment transports. [PR 1830](https://github.com/openclaw/crabbox/pull/1830). Thanks @steipete.
 

--- a/docs/providers/upstash-box.md
+++ b/docs/providers/upstash-box.md
@@ -157,9 +157,20 @@ pass `--keep=false` to `warmup`, Crabbox prints a warning and still keeps it.
   `--env-helper`, `--capture-stdout` / `--capture-stderr`, `--capture-on-fail`,
   `--download`, `--artifact-glob`, `--require-artifact`, `--emit-proof`, and
   `--stop-after`.
-- Forwarded environment values are written to a temporary shell profile in the
-  Box workspace, sourced (`set -a`) for the command, and removed best-effort
-  afterward. They are never placed on the local process argv.
+- Forwarded environment values use a private local profile and a unique remote
+  profile under `/workspace/home`, uploaded through the normal multipart file
+  transport. The command sources it (`set -a`) in its existing shell; failed
+  sourcing stops the whole script, and an explicitly empty script is valid.
+  Values are never placed on the local process argv. Removal is attempted after
+  command completion or a failed/canceled upload, with a separate 15-second
+  budget. A cleanup-only failure is reported as exit code 5; cleanup diagnostics
+  do not replace an existing command exit or upload/cancellation error.
+- Profile upload/removal requires an unchanged Box ID, name, positive creation
+  timestamp, and the originally observed local claim (or continued absence of
+  one). Discovery-only runs remain supported without creating a claim. This
+  file-only receipt cannot authorize Box deletion. Changed/uncertain identity
+  refuses file mutation; it does not promise an atomic remote check-and-remove,
+  cancellation of a delayed server upload, or whole-run concurrency isolation.
 - `upstashBox.keepAlive` maps to the Box create `keep_alive` option. Crabbox
   `--keep` independently controls whether a one-shot `run` deletes the Box
   afterward.

--- a/internal/providers/upstashbox/backend.go
+++ b/internal/providers/upstashbox/backend.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"path"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -186,20 +185,27 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	if req.EnvSummary {
 		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
-	envPath := ""
+	var cleanupEnv func() error
 	if len(req.Env) > 0 {
-		envPath = workspacePath(".crabbox-env-" + leaseID + ".sh")
-		if err := client.WriteFile(ctx, boxID, envPath, shellEnvProfile(req.Env)); err != nil {
+		var envPath string
+		envPath, cleanupEnv, err = uploadEnvProfile(ctx, client, leaseID, boxID, slug, req.Env)
+		if cleanupEnv != nil {
+			defer func() { _ = cleanupEnv() }()
+		}
+		if err != nil {
+			if cleanupEnv != nil {
+				err = errors.Join(err, cleanupEnv())
+			}
 			return RunResult{}, err
 		}
-		command = ". " + shellQuote(envPath) + " && " + command
+		command = shared.ShellScriptWithEnvProfile(command, envPath)
 	}
 	commandStarted := b.now()
 	exitCode, commandErr := client.ExecStream(ctx, boxID, command, folder, b.rt.Stdout)
 	commandDuration := b.now().Sub(commandStarted)
 	envCleanupErr := error(nil)
-	if envPath != "" {
-		envCleanupErr = b.cleanupEnvFile(client, boxID, envPath)
+	if cleanupEnv != nil {
+		envCleanupErr = cleanupEnv()
 	}
 	finalExitCode := exitCode
 	if commandErr != nil {
@@ -265,26 +271,6 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		return result, ExitError{Code: 5, Message: envCleanupErr.Error()}
 	}
 	return result, nil
-}
-
-func (b *backend) cleanupEnvFile(client api, boxID, envPath string) error {
-	if err := cleanupRemoteFile(client, boxID, envPath); err != nil {
-		return fmt.Errorf("upstash-box env cleanup failed for %s: %w", boxID, err)
-	}
-	return nil
-}
-
-func cleanupRemoteFile(client api, boxID, remotePath string) error {
-	cleanupCtx, cancel := upstashBoxCleanupContext()
-	defer cancel()
-	result, err := client.Exec(cleanupCtx, boxID, "rm -f "+shellQuote(remotePath), "")
-	if err != nil {
-		return err
-	}
-	if result.ExitCode != 0 {
-		return commandExitError("upstash-box exec rm -f "+remotePath, result)
-	}
-	return nil
 }
 
 func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
@@ -644,38 +630,4 @@ func workspaceFolder(workdir string) (string, error) {
 
 func workspacePath(name string) string {
 	return path.Join(workspaceRoot, name)
-}
-
-func shellEnvProfile(env map[string]string) string {
-	var b strings.Builder
-	keys := make([]string, 0, len(env))
-	for key := range env {
-		if !validEnvName(key) {
-			continue
-		}
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	b.WriteString("set -a\n")
-	for _, key := range keys {
-		b.WriteString(key)
-		b.WriteString("=")
-		b.WriteString(shellQuote(env[key]))
-		b.WriteByte('\n')
-	}
-	b.WriteString("set +a\n")
-	return b.String()
-}
-
-func validEnvName(name string) bool {
-	if name == "" {
-		return false
-	}
-	for i, r := range name {
-		if r == '_' || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (i > 0 && r >= '0' && r <= '9') {
-			continue
-		}
-		return false
-	}
-	return true
 }

--- a/internal/providers/upstashbox/backend_test.go
+++ b/internal/providers/upstashbox/backend_test.go
@@ -16,6 +16,7 @@ import (
 	"reflect"
 	"runtime/pprof"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -153,7 +154,6 @@ func TestStopFinalizesRetainedClaimAfterUpstashBoxWasAlreadyDeleted(t *testing.T
 func TestClientUsesUpstashBoxRESTShape(t *testing.T) {
 	var createBody map[string]any
 	var deleteBody map[string]any
-	var writeBody map[string]any
 	uploadSeen := false
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("X-Box-Api-Key"); got != "box_key" {
@@ -203,11 +203,6 @@ func TestClientUsesUpstashBoxRESTShape(t *testing.T) {
 			}
 			uploadSeen = true
 			w.WriteHeader(http.StatusNoContent)
-		case "/v2/box/box_1/files/write":
-			if err := json.NewDecoder(r.Body).Decode(&writeBody); err != nil {
-				t.Fatal(err)
-			}
-			w.WriteHeader(http.StatusNoContent)
 		default:
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
@@ -242,12 +237,6 @@ func TestClientUsesUpstashBoxRESTShape(t *testing.T) {
 	}
 	if !uploadSeen {
 		t.Fatal("upload not seen")
-	}
-	if err := client.WriteFile(context.Background(), "box_1", "/tmp/env.sh", "export A=1\n"); err != nil {
-		t.Fatal(err)
-	}
-	if writeBody["path"] != "/tmp/env.sh" || writeBody["content"] != "export A=1\n" {
-		t.Fatalf("write body=%v", writeBody)
 	}
 	if err := client.DeleteBoxes(context.Background(), []string{"box_1"}); err != nil {
 		t.Fatal(err)
@@ -569,10 +558,6 @@ func TestCleanWorkdirAndCommand(t *testing.T) {
 	}
 	if command != "exec 'go' 'test' './...'" {
 		t.Fatalf("command=%q", command)
-	}
-	env := shellEnvProfile(map[string]string{"B": "two", "A": "one two", "BAD; id >&2 #": "boom"})
-	if env != "set -a\nA='one two'\nB='two'\nset +a\n" {
-		t.Fatalf("env profile=%q", env)
 	}
 }
 
@@ -1059,6 +1044,13 @@ func withUpstashBoxCleanupTimeout(t *testing.T, timeout time.Duration) {
 }
 
 type fakeAPI struct {
+	uploadHook func(context.Context, string, string) error
+	execHook   func(context.Context, string) (execResult, error)
+	streamHook func()
+	getHook    func() (boxData, error)
+	streamCode int
+	streamErr  error
+
 	verbs           []string
 	createReq       createRequest
 	box             boxData
@@ -1077,24 +1069,27 @@ type fakeAPI struct {
 func (f *fakeAPI) CreateBox(_ context.Context, createRequest createRequest) (boxData, error) {
 	f.verbs = append(f.verbs, "create")
 	f.createReq = createRequest
-	f.box = boxData{ID: "box_1", Name: createRequest.Name, Runtime: createRequest.Runtime, Size: createRequest.Size, Status: "running", KeepAlive: createRequest.KeepAlive}
+	f.box = boxData{ID: "box_1", CreatedAt: 1700000000, Name: createRequest.Name, Runtime: createRequest.Runtime, Size: createRequest.Size, Status: "running", KeepAlive: createRequest.KeepAlive}
 	return f.box, nil
 }
 
 func (f *fakeAPI) GetBox(context.Context, string) (boxData, error) {
 	f.getBoxCalls++
+	if f.getHook != nil {
+		return f.getHook()
+	}
 	if f.notFoundOnGet == f.getBoxCalls {
 		return boxData{}, errors.New("box not found")
 	}
 	if f.box.ID == "" {
-		f.box = boxData{ID: "box_1", Name: "crabbox-blue-123456789abc", Status: "running"}
+		f.box = boxData{ID: "box_1", CreatedAt: 1700000000, Name: "crabbox-blue-123456789abc", Status: "running"}
 	}
 	return f.box, nil
 }
 
 func (f *fakeAPI) ListBoxes(context.Context) ([]boxData, error) {
 	if f.box.ID == "" {
-		f.box = boxData{ID: "box_1", Name: "crabbox-blue-123456789abc", Status: "running"}
+		f.box = boxData{ID: "box_1", CreatedAt: 1700000000, Name: "crabbox-blue-123456789abc", Status: "running"}
 	}
 	return []boxData{f.box}, nil
 }
@@ -1113,6 +1108,9 @@ func (f *fakeAPI) Exec(ctx context.Context, _ string, command, folder string) (e
 	f.verbs = append(f.verbs, "exec")
 	f.execCommands = append(f.execCommands, command)
 	f.execFolders = append(f.execFolders, folder)
+	if f.execHook != nil {
+		return f.execHook(ctx, command)
+	}
 	if f.blockEnvCleanup && strings.Contains(command, ".crabbox-env-") {
 		<-ctx.Done()
 		return execResult{}, ctx.Err()
@@ -1129,17 +1127,18 @@ func (f *fakeAPI) ExecStream(_ context.Context, _ string, command, folder string
 	f.verbs = append(f.verbs, "stream")
 	f.streamCommands = append(f.streamCommands, command)
 	f.streamFolders = append(f.streamFolders, folder)
+	if f.streamHook != nil {
+		f.streamHook()
+	}
 	_, _ = io.WriteString(stdout, "ok\n")
-	return 0, nil
+	return f.streamCode, f.streamErr
 }
 
-func (f *fakeAPI) UploadFile(context.Context, string, string, string) error {
+func (f *fakeAPI) UploadFile(ctx context.Context, _ string, localPath, remotePath string) error {
 	f.verbs = append(f.verbs, "upload")
-	return nil
-}
-
-func (f *fakeAPI) WriteFile(context.Context, string, string, string) error {
-	f.verbs = append(f.verbs, "write")
+	if f.uploadHook != nil {
+		return f.uploadHook(ctx, localPath, remotePath)
+	}
 	return nil
 }
 
@@ -1187,5 +1186,543 @@ func runGit(t *testing.T, dir string, args ...string) {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+}
+
+func TestRunPartialEnvUploadRetainsCleanup(t *testing.T) {
+	for _, canceled := range []bool{false, true} {
+		t.Run(fmt.Sprint(canceled), func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			root := t.TempDir()
+			remote := filepath.Join(root, "partial-profile")
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			primary := errors.New("synthetic upload failure")
+			var localFile, remotePath string
+			cleanups := 0
+			write := func(_ context.Context, path, content string) error {
+				remotePath = path
+				if err := os.WriteFile(remote, []byte(content), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if canceled {
+					cancel()
+					return context.Canceled
+				}
+				return primary
+			}
+			fake := &fakeAPI{}
+			fake.uploadHook = func(ctx context.Context, local, path string) error {
+				localFile = local
+				data, err := os.ReadFile(local)
+				if err != nil {
+					return err
+				}
+				return write(ctx, path, string(data))
+			}
+			fake.execHook = func(cleanupCtx context.Context, command string) (execResult, error) {
+				if !strings.HasPrefix(command, "rm -f ") {
+					return execResult{}, nil
+				}
+				cleanups++
+				if cleanupCtx.Err() != nil {
+					t.Fatalf("cleanup canceled: %v", cleanupCtx.Err())
+				}
+				if _, ok := cleanupCtx.Deadline(); !ok {
+					t.Fatal("unbounded cleanup")
+				}
+				if command != "rm -f "+shellQuote(remotePath) {
+					t.Fatalf("wrong removal: %s", command)
+				}
+				return execResult{}, os.Remove(remote)
+			}
+			withFakeAPI(t, fake)
+			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+			_, err := b.Run(ctx, RunRequest{Repo: Repo{Root: root, Name: "fixture"}, NoSync: true, Keep: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
+			want := primary
+			if canceled {
+				want = context.Canceled
+			}
+			if !errors.Is(err, want) {
+				t.Fatalf("primary lost: %v", err)
+			}
+			if cleanups != 1 || len(fake.streamCommands) != 0 || len(fake.deletedIDs) != 0 {
+				t.Fatalf("cleanups=%d workload=%v deletes=%v", cleanups, fake.streamCommands, fake.deletedIDs)
+			}
+			if _, err := os.Stat(remote); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("remote profile remains: %v", err)
+			}
+			if localFile != "" {
+				if _, err := os.Stat(localFile); !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("local profile remains: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestRunEnvDiscoveryDoesNotRequireOrCreateClaim(t *testing.T) {
+	for _, id := range []string{"box_1", "blue", "cbx_123456789abc"} {
+		t.Run(id, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			fake := &fakeAPI{}
+			withFakeAPI(t, fake)
+			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+			result, err := b.Run(t.Context(), RunRequest{ID: id, Repo: Repo{Root: t.TempDir()}, NoSync: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
+			if err != nil || result.ExitCode != 0 || len(fake.streamCommands) != 1 || len(fake.deletedIDs) != 0 {
+				t.Fatalf("result=%#v err=%v verbs=%v", result, err, fake.verbs)
+			}
+			if !reflect.DeepEqual(fake.verbs, []string{"exec", "upload", "stream", "exec"}) {
+				t.Fatalf("file lifecycle=%v", fake.verbs)
+			}
+			if _, exists, err := core.ReadLeaseClaimWithPresence("cbx_123456789abc"); err != nil || exists {
+				t.Fatalf("discovery published claim: exists=%v err=%v", exists, err)
+			}
+		})
+	}
+}
+
+func TestEnvProfileRefusesChangedReceipt(t *testing.T) {
+	for _, change := range []string{"box ID", "box name", "box creation", "lookup failure", "claim appeared", "claim changed", "claim removed", "unchanged legacy claim"} {
+		t.Run(change, func(t *testing.T) {
+			state := t.TempDir()
+			t.Setenv("XDG_STATE_HOME", state)
+			const leaseID = "cbx_123456789abc"
+			claimPath := filepath.Join(state, "crabbox", "claims", leaseID+".json")
+			writeClaim := func(slug string) {
+				t.Helper()
+				if err := os.MkdirAll(filepath.Dir(claimPath), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				data, err := json.Marshal(core.LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(claimPath, data, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if change == "claim changed" || change == "claim removed" || change == "unchanged legacy claim" {
+				writeClaim("blue")
+			}
+			fake := &fakeAPI{}
+			var local string
+			fake.uploadHook = func(_ context.Context, localPath, _ string) error { local = localPath; return nil }
+			_, cleanup, err := uploadEnvProfile(t.Context(), fake, leaseID, "box_1", "blue", map[string]string{"FIXTURE": "synthetic"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			switch change {
+			case "box ID":
+				fake.box.ID = "box_replacement"
+			case "box name":
+				fake.box.Name = "crabbox-other-123456789abc"
+			case "box creation":
+				fake.box.CreatedAt++
+			case "lookup failure":
+				fake.notFoundOnGet = fake.getBoxCalls + 1
+			case "claim appeared", "claim changed":
+				writeClaim("replacement")
+			case "claim removed":
+				if err := os.Remove(claimPath); err != nil {
+					t.Fatal(err)
+				}
+			}
+			before, beforeExists, err := core.ReadLeaseClaimWithPresence(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = cleanup()
+			if change == "unchanged legacy claim" {
+				if err != nil || len(fake.execCommands) != 1 {
+					t.Fatalf("legacy cleanup=%v commands=%v", err, fake.execCommands)
+				}
+			} else if err == nil || len(fake.execCommands) != 0 {
+				t.Fatalf("stale cleanup=%v commands=%v", err, fake.execCommands)
+			}
+			if _, err := os.Stat(local); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("local file remains: %v", err)
+			}
+			after, afterExists, err := core.ReadLeaseClaimWithPresence(leaseID)
+			if err != nil || afterExists != beforeExists || !reflect.DeepEqual(after, before) {
+				t.Fatalf("cleanup mutated claim: %v", err)
+			}
+			if len(fake.deletedIDs) != 0 {
+				t.Fatalf("file receipt deleted Box: %v", fake.deletedIDs)
+			}
+		})
+	}
+}
+
+func TestEnvProfileDeniedUploadHasNoRemoteCustody(t *testing.T) {
+	for _, phase := range []string{"missing creation", "changed before upload", "canceled before upload"} {
+		t.Run(phase, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			tmp := t.TempDir()
+			for _, name := range []string{"TMPDIR", "TMP", "TEMP"} {
+				t.Setenv(name, tmp)
+			}
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			fake := &fakeAPI{}
+			box := boxData{ID: "box_1", Name: "crabbox-blue-123456789abc", CreatedAt: 1700000000}
+			fake.getHook = func() (boxData, error) {
+				if phase == "missing creation" {
+					box.CreatedAt = 0
+				}
+				if fake.getBoxCalls == 2 && phase == "changed before upload" {
+					box.CreatedAt++
+				}
+				if fake.getBoxCalls == 1 && phase == "canceled before upload" {
+					cancel()
+				}
+				return box, nil
+			}
+			_, cleanup, err := uploadEnvProfile(ctx, fake, "cbx_123456789abc", "box_1", "blue", map[string]string{"FIXTURE": "synthetic"})
+			if err == nil {
+				t.Fatal("denied upload succeeded")
+			}
+			if cleanup != nil {
+				if err := cleanup(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if len(fake.verbs) != 0 {
+				t.Fatalf("remote custody after denial: %v", fake.verbs)
+			}
+			entries, err := os.ReadDir(tmp)
+			if err != nil || len(entries) != 0 {
+				t.Fatalf("local residue=%v err=%v", entries, err)
+			}
+		})
+	}
+}
+
+func TestRunEnvCleanupPreservesPrimaryOutcome(t *testing.T) {
+	for _, outcome := range []string{"command exit", "transport error", "upload cancellation"} {
+		t.Run(outcome, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			fake := &fakeAPI{}
+			fake.execHook = func(_ context.Context, command string) (execResult, error) {
+				if strings.HasPrefix(command, "rm -f ") {
+					return execResult{ExitCode: 9, Error: "synthetic cleanup failure"}, nil
+				}
+				return execResult{}, nil
+			}
+			wantCode := 42
+			switch outcome {
+			case "command exit":
+				fake.streamCode = 42
+			case "transport error":
+				fake.streamErr = errors.New("synthetic transport failure")
+				wantCode = 1
+			case "upload cancellation":
+				fake.uploadHook = func(context.Context, string, string) error { return context.Canceled }
+			}
+			withFakeAPI(t, fake)
+			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+			result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, Keep: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
+			if err == nil || !strings.Contains(err.Error(), "synthetic cleanup failure") {
+				t.Fatalf("missing cleanup diagnosis: %v", err)
+			}
+			if outcome == "upload cancellation" {
+				if !errors.Is(err, context.Canceled) || len(fake.streamCommands) != 0 {
+					t.Fatalf("primary cancellation lost: %v", err)
+				}
+			} else {
+				var exitErr ExitError
+				if !errors.As(err, &exitErr) || exitErr.Code != wantCode || result.ExitCode != wantCode {
+					t.Fatalf("primary outcome lost: result=%#v err=%v", result, err)
+				}
+			}
+		})
+	}
+}
+
+func TestEnvFileReceiptHoldsAbsentClaimFenceDuringMutation(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const leaseID = "cbx_123456789abc"
+	receipt, err := captureEnvFileReceipt(t.Context(), &fakeAPI{}, leaseID, "box_1", "blue")
+	if err != nil {
+		t.Fatal(err)
+	}
+	entered, release := make(chan struct{}), make(chan struct{})
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	defer unblock()
+	done := make(chan error, 1)
+	go func() {
+		done <- receipt.withUnchanged(ctx, func() error {
+			close(entered)
+			select {
+			case <-release:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		})
+	}()
+	select {
+	case <-entered:
+	case err := <-done:
+		t.Fatalf("file operation did not enter: %v", err)
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	writerCtx, cancel := context.WithTimeout(t.Context(), 30*time.Millisecond)
+	defer cancel()
+	err = core.WithDurableLeaseClaimLockContext(writerCtx, leaseID, func(_ *core.LeaseClaim, _ bool, _ func() error) error {
+		return errors.New("claim writer entered during file mutation")
+	})
+	unblock()
+	if operationErr := <-done; operationErr != nil {
+		t.Fatal(operationErr)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("absent-claim fence released early: %v", err)
+	}
+}
+
+func TestEnvProfilesOnSameBoxHaveIndependentCustody(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	root := t.TempDir()
+	fake := &fakeAPI{}
+	fake.uploadHook = func(_ context.Context, localPath, remotePath string) error {
+		data, err := os.ReadFile(localPath)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(filepath.Join(root, filepath.Base(remotePath)), data, 0o600)
+	}
+	var paths []string
+	var cleanups []func() error
+	for range 2 {
+		path, cleanup, err := uploadEnvProfile(t.Context(), fake, "cbx_123456789abc", "box_1", "blue", map[string]string{"FIXTURE": "synthetic"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		paths = append(paths, path)
+		cleanups = append(cleanups, cleanup)
+	}
+	if paths[0] == paths[1] {
+		t.Fatal("profiles share a remote filename")
+	}
+	fake.execHook = func(_ context.Context, command string) (execResult, error) {
+		for _, path := range paths {
+			if command == "rm -f "+shellQuote(path) {
+				return execResult{}, os.Remove(filepath.Join(root, filepath.Base(path)))
+			}
+		}
+		return execResult{}, errors.New("unexpected cleanup target")
+	}
+	if err := cleanups[0](); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(root, filepath.Base(paths[1]))); err != nil {
+		t.Fatalf("first cleanup affected second profile: %v", err)
+	}
+	if err := cleanups[0](); err != nil {
+		t.Fatalf("Close not idempotent: %v", err)
+	}
+	if err := cleanups[1](); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil || len(entries) != 0 || len(fake.execCommands) != 2 {
+		t.Fatalf("custody residue=%v commands=%v err=%v", entries, fake.execCommands, err)
+	}
+}
+
+func TestRunEnvProfileThroughNativeHTTPTransport(t *testing.T) {
+	if os.PathSeparator != '/' {
+		t.Skip("native POSIX transport")
+	}
+	for _, scenario := range []string{"healthy", "lost upload acknowledgement", "canceled upload", "changed generation", "source failure", "empty source"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			local := t.TempDir()
+			t.Setenv("TMPDIR", local)
+			remote := t.TempDir()
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			var mu sync.Mutex
+			box := boxData{ID: "box_fixture", Name: "crabbox-blue-123456789abc", CreatedAt: 1700000000, Status: "running"}
+			var profilePath string
+			uploads, removals, workloads, deletes := 0, 0, 0, 0
+			mapPath := func(value string) string { return strings.ReplaceAll(value, workspaceRoot, remote) }
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				defer mu.Unlock()
+				if r.Header.Get("X-Box-Api-Key") != "synthetic-fixture" {
+					t.Error("missing synthetic authentication")
+					http.Error(w, "auth", 401)
+					return
+				}
+				switch r.URL.Path {
+				case "/v2/box/box_fixture":
+					_ = json.NewEncoder(w).Encode(box)
+				case "/v2/box":
+					deletes++
+					http.Error(w, "unexpected box mutation", 400)
+				case "/v2/box/box_fixture/files/upload", "/v2/box/box_fixture/files/write":
+					var content string
+					if strings.HasSuffix(r.URL.Path, "/upload") {
+						reader, err := r.MultipartReader()
+						if err != nil {
+							t.Error(err)
+							http.Error(w, "multipart", 400)
+							return
+						}
+						fields := readMultipart(t, reader)
+						profilePath, content = fields["paths"], fields["files"]
+					} else {
+						// The baseline uses JSON; keep the server fixture identical for red/green proof.
+						var body struct{ Path, Content string }
+						if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+							t.Error(err)
+							return
+						}
+						profilePath, content = body.Path, body.Content
+					}
+					if !strings.HasPrefix(profilePath, workspaceRoot+"/.crabbox-env-") {
+						t.Error("profile outside workspace")
+						http.Error(w, "path", 400)
+						return
+					}
+					if scenario == "source failure" {
+						content = "return 9\n"
+					}
+					if err := os.WriteFile(mapPath(profilePath), []byte(content), 0o600); err != nil {
+						t.Error(err)
+						return
+					}
+					uploads++
+					switch scenario {
+					case "lost upload acknowledgement":
+						http.Error(w, "synthetic upload acknowledgement failure", 500)
+						return
+					case "canceled upload":
+						cancel()
+						return
+					case "changed generation":
+						box.CreatedAt++
+					}
+					w.WriteHeader(http.StatusNoContent)
+				case "/v2/box/box_fixture/exec", "/v2/box/box_fixture/exec-stream":
+					var body struct {
+						Command []string
+						Folder  string
+					}
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Error(err)
+						return
+					}
+					if len(body.Command) != 3 || body.Command[0] != "sh" || body.Command[1] != "-c" {
+						t.Error("unexpected native shell envelope")
+						http.Error(w, "command", 400)
+						return
+					}
+					stream := strings.HasSuffix(r.URL.Path, "exec-stream")
+					if stream {
+						workloads++
+					}
+					if strings.HasPrefix(body.Command[2], "rm -f ") {
+						if body.Command[2] != "rm -f "+shellQuote(profilePath) {
+							t.Error("removal targeted different file")
+							http.Error(w, "target", 400)
+							return
+						}
+						removals++
+					}
+					cmd := exec.CommandContext(r.Context(), body.Command[0], body.Command[1], mapPath(body.Command[2]))
+					cmd.Dir = filepath.Join(remote, body.Folder)
+					cmd.Env = []string{"PATH=/usr/bin:/bin", "HOME=" + remote, "ENV=" + os.DevNull}
+					output, runErr := cmd.CombinedOutput()
+					code := 0
+					if runErr != nil {
+						var exitErr *exec.ExitError
+						if !errors.As(runErr, &exitErr) {
+							t.Error(runErr)
+							http.Error(w, "native exec", 500)
+							return
+						}
+						code = exitErr.ExitCode()
+					}
+					if stream {
+						_, _ = w.Write(output)
+						_, _ = fmt.Fprintf(w, "\nevent: exit\ndata: {\"exit_code\":%d}\n\n", code)
+					} else {
+						_ = json.NewEncoder(w).Encode(execResult{ExitCode: code, Output: string(output)})
+					}
+				default:
+					t.Errorf("unexpected fixture route: %s", r.URL.Path)
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+			cfg := testConfig()
+			cfg.UpstashBox.BaseURL, cfg.UpstashBox.APIKey = server.URL, "synthetic-fixture"
+			var stdout bytes.Buffer
+			b := NewBackend(Provider{}.Spec(), cfg, Runtime{HTTP: server.Client(), Stdout: &stdout, Stderr: io.Discard}).(*backend)
+			command := `printf '%s\n' "$FIXTURE"`
+			if scenario == "source failure" {
+				command = "printf first; printf escaped"
+			}
+			if scenario == "empty source" {
+				command = ""
+			}
+			result, err := b.Run(ctx, RunRequest{ID: "box_fixture", Repo: Repo{Root: t.TempDir()}, NoSync: true, Command: []string{command}, ShellMode: true, Env: map[string]string{"FIXTURE": "quote ' newline\n$literal"}})
+			mu.Lock()
+			defer mu.Unlock()
+			wantWorkloads, wantRemovals := 1, 1
+			switch scenario {
+			case "lost upload acknowledgement":
+				wantWorkloads = 0
+				if err == nil || !strings.Contains(err.Error(), "synthetic upload acknowledgement failure") {
+					t.Fatalf("lost primary upload error: %v", err)
+				}
+			case "canceled upload":
+				wantWorkloads = 0
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("lost cancellation: %v", err)
+				}
+			case "changed generation":
+				wantRemovals = 0
+				if err == nil || result.ExitCode != 5 {
+					t.Fatalf("stale cleanup not refused: result=%#v err=%v", result, err)
+				}
+			case "source failure":
+				if err == nil || result.ExitCode != 9 || strings.Contains(stdout.String(), "escaped") {
+					t.Fatalf("source failure escaped: code=%d err=%v out=%q", result.ExitCode, err, stdout.String())
+				}
+			default:
+				if err != nil || result.ExitCode != 0 {
+					t.Fatalf("result=%#v err=%v", result, err)
+				}
+				if scenario == "healthy" && !strings.Contains(stdout.String(), "quote ' newline\n$literal") {
+					t.Fatalf("profile value changed: %q", stdout.String())
+				}
+			}
+			if uploads != 1 || removals != wantRemovals || workloads != wantWorkloads || deletes != 0 {
+				t.Fatalf("uploads=%d removals=%d workloads=%d deletes=%d", uploads, removals, workloads, deletes)
+			}
+			_, statErr := os.Stat(mapPath(profilePath))
+			if wantRemovals == 1 && !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("remote residue: %v", statErr)
+			}
+			if wantRemovals == 0 && statErr != nil {
+				t.Fatalf("refused cleanup changed remote file: %v", statErr)
+			}
+			if _, exists, err := core.ReadLeaseClaimWithPresence("cbx_123456789abc"); err != nil || exists {
+				t.Fatalf("discovery claim changed: exists=%v err=%v", exists, err)
+			}
+			entries, err := os.ReadDir(local)
+			if err != nil || len(entries) != 0 {
+				t.Fatalf("local residue=%v err=%v", entries, err)
+			}
+			t.Logf("uploads=%d removals=%d workloads=%d deletes=%d exit=%d", uploads, removals, workloads, deletes, result.ExitCode)
+		})
 	}
 }

--- a/internal/providers/upstashbox/client.go
+++ b/internal/providers/upstashbox/client.go
@@ -28,7 +28,6 @@ type api interface {
 	Exec(context.Context, string, string, string) (execResult, error)
 	ExecStream(context.Context, string, string, string, io.Writer) (int, error)
 	UploadFile(context.Context, string, string, string) error
-	WriteFile(context.Context, string, string, string) error
 }
 
 type client struct {
@@ -280,11 +279,6 @@ func (c *client) UploadFile(ctx context.Context, boxID, localPath, remotePath st
 		return finishProducer(c.apiError(resp))
 	}
 	return finishProducer(nil)
-}
-
-func (c *client) WriteFile(ctx context.Context, boxID, remotePath, content string) error {
-	body := map[string]any{"path": remotePath, "content": content}
-	return c.doJSON(ctx, http.MethodPost, "/v2/box/"+url.PathEscape(boxID)+"/files/write", nil, body, nil)
 }
 
 func (c *client) doJSON(ctx context.Context, method, path string, query url.Values, body any, out any) error {

--- a/internal/providers/upstashbox/env.go
+++ b/internal/providers/upstashbox/env.go
@@ -1,0 +1,95 @@
+package upstashbox
+
+import (
+	"context"
+	"fmt"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+// An envFileReceipt authorizes only this operation's profile, never Box deletion
+// or claim publication. Discovery-only runs do not require a local claim.
+type envFileReceipt struct {
+	client      api
+	box         boxData
+	leaseID     string
+	claim       core.LeaseClaim
+	claimExists bool
+}
+
+func captureEnvFileReceipt(ctx context.Context, client api, leaseID, boxID, slug string) (envFileReceipt, error) {
+	receipt := envFileReceipt{client: client, leaseID: leaseID}
+	err := core.WithDurableLeaseClaimLockContext(ctx, leaseID, func(claim *core.LeaseClaim, exists bool, _ func() error) error {
+		box, err := client.GetBox(ctx, boxID)
+		if err != nil {
+			return err
+		}
+		if box.ID != boxID || !isCrabboxBox(box) || boxLeaseID(box) != leaseID || boxSlug(leaseID, box) != slug || box.CreatedAt <= 0 {
+			return fmt.Errorf("upstash-box environment profile requires complete matching Box identity for %s", boxID)
+		}
+		receipt.box, receipt.claim, receipt.claimExists = box, *claim, exists
+		return nil
+	})
+	return receipt, err
+}
+
+func (r envFileReceipt) withUnchanged(ctx context.Context, action func() error) error {
+	guarded := func() error {
+		box, err := r.client.GetBox(ctx, r.box.ID)
+		if err != nil {
+			return err
+		}
+		if box.ID != r.box.ID || box.Name != r.box.Name || box.CreatedAt != r.box.CreatedAt {
+			return fmt.Errorf("upstash-box environment profile Box identity changed for %s", r.box.ID)
+		}
+		return action()
+	}
+	if r.claimExists {
+		return core.WithLeaseClaimUnchangedShared(ctx, r.leaseID, r.claim, guarded)
+	}
+	return core.WithDurableLeaseClaimLockContext(ctx, r.leaseID, func(_ *core.LeaseClaim, exists bool, _ func() error) error {
+		if exists {
+			return fmt.Errorf("lease %s claim changed; retry", r.leaseID)
+		}
+		return guarded()
+	})
+}
+
+func uploadEnvProfile(ctx context.Context, client api, leaseID, boxID, slug string, env map[string]string) (string, func() error, error) {
+	receipt, err := captureEnvFileReceipt(ctx, client, leaseID, boxID, slug)
+	if err != nil {
+		return "", nil, err
+	}
+	profile, err := shared.PrepareShellEnvProfile(env, workspaceRoot, ".crabbox-env-")
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup := func() error {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), upstashBoxCleanupTimeout)
+		defer cancel()
+		err := profile.Close(cleanupCtx, func(removeCtx context.Context, remotePath string) error {
+			return receipt.withUnchanged(removeCtx, func() error {
+				result, err := client.Exec(removeCtx, boxID, "rm -f "+shellQuote(remotePath), "")
+				if err != nil {
+					return err
+				}
+				if result.ExitCode != 0 {
+					return commandExitError("upstash-box exec rm -f "+remotePath, result)
+				}
+				return nil
+			})
+		})
+		if err != nil {
+			return fmt.Errorf("upstash-box env cleanup failed for %s: %w", boxID, err)
+		}
+		return nil
+	}
+	// Admission encloses Upload so a refused write never acquires remote custody.
+	err = receipt.withUnchanged(ctx, func() error {
+		return profile.Upload(ctx, func(uploadCtx context.Context, localPath, remotePath string) error {
+			return client.UploadFile(uploadCtx, boxID, localPath, remotePath)
+		})
+	})
+	return profile.RemotePath(), cleanup, err
+}


### PR DESCRIPTION
## Summary

Adopt the shared environment-profile owner for Upstash Box. One private local file and one unique remote path now have an explicit upload-attempt lifetime, so an upload error or cancellation cannot skip cleanup. The shared source wrapper rejects the entire workload after failed profile sourcing and permits an explicitly empty source body. Delete Upstash's duplicate renderer, environment-name validator, deterministic filename, and env-only JSON WriteFile transport; use the existing synchronous multipart uploader.

Keep Upstash's authority and outcome rules in the adapter. A file-only receipt captures the original API client, Box ID/name/positive creation timestamp, and the observed local claim or its absence. Each upload/removal runs under that unchanged claim-state fence and a fresh native identity check. Discovery-only raw-ID, slug, and lease-ID reuse still works without publishing a claim; this receipt cannot authorize Box deletion. Cleanup has the existing separate 15-second budget and runs before final timing/outcome selection. Cleanup-only failure remains exit 5; a primary command exit, transport error, or upload cancellation retains its outcome.

## Verification

The production newAPI factory, HTTP client, multipart uploader, exec-stream parser, and native sh process run against a loopback fixture included in the existing provider test file. The identical fixture passes one of six cases on the unchanged baseline and all six after this fix:

| Case | Baseline | Candidate |
|---|---|---|
| Healthy quoted/multiline environment | Pass | Pass |
| Server writes file then returns upload failure | Remote residue | One removal; original error |
| Cancellation after server writes file | Remote residue | One bounded removal; cancellation preserved |
| Box generation changes after upload | Stale removal | Refuses removal; exit 5 |
| Profile returns failure before a multi-command script | Later command runs | Whole script stopped; exit 9 |
| Explicitly empty source with environment | Syntax error | Valid no-op; cleanup succeeds |

Additional regressions cover raw-ID/slug/lease discovery, full legacy claim snapshots, changed/removed/appearing claims, changed native identity, denied-before-upload custody, an absent-claim fence held during mutation, two independent profiles on the same Box, idempotent close, bounded cleanup, and primary error/exit precedence. Two original partial-upload regressions also fail on the baseline and pass after the fix.

Full race suites pass for Upstash Box, shared helpers, SmolVM, Modal, and Tensorlake. Scoped vet, CLI build, and docs build pass. Managed review is scoped-clean; independent semantic review found two test robustness issues, both corrected and read back, with no remaining actionable finding. The native fixtures are local production-client proof, not hosted Upstash proof; no cloud resource or real credential was used.

## Boundaries

No new dependency or configuration option. Positive creation identity is required before environment upload; an incomplete or changed identity fails closed. Native GET and file mutation are not an atomic generation-CAS, cancellation cannot guarantee that a delayed server write stops, and this does not claim whole-run concurrency isolation or remote file mode guarantees. Existing Box retention/deletion policy remains separate. Maintainer changelog and provider documentation are included.
