### PR TITLE
fix: preserve literal intent through profile command transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve literal Tensorlake and OpenSandbox profile arguments through final execution, including environment-wrapped commands, and fix Tensorlake's inferred single-string shell execution. Thanks @steipete.
 - Read all AWS recovery inventory pages and retain cleanup debt when pagination is incomplete; describe interrupted provisioning without assuming a deployment caused it. [PR 1832](https://github.com/openclaw/crabbox/pull/1832). Thanks @steipete.
 - Preserve literal profile arguments through CodeSandbox, OpenComputer, and Docker Sandbox execution, sharing command-intent parsing without changing provider shells or environment transports. [PR 1830](https://github.com/openclaw/crabbox/pull/1830). Thanks @steipete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Preserve literal Tensorlake and OpenSandbox profile arguments through final execution, including environment-wrapped commands, and fix Tensorlake's inferred single-string shell execution. Thanks @steipete.
+- Preserve literal Tensorlake and OpenSandbox profile arguments through final execution, including environment-wrapped commands, and fix Tensorlake's inferred single-string shell execution. [PR 1835](https://github.com/openclaw/crabbox/pull/1835). Thanks @steipete.
 - Preserve literal SmolVM and Upstash Box profile arguments, accept inferred single-string shell commands, and share source rendering without adding another shell. [PR 1833](https://github.com/openclaw/crabbox/pull/1833). Thanks @steipete.
 - Read all AWS recovery inventory pages and retain cleanup debt when pagination is incomplete; describe interrupted provisioning without assuming a deployment caused it. [PR 1832](https://github.com/openclaw/crabbox/pull/1832). Thanks @steipete.
 - Preserve literal profile arguments through CodeSandbox, OpenComputer, and Docker Sandbox execution, sharing command-intent parsing without changing provider shells or environment transports. [PR 1830](https://github.com/openclaw/crabbox/pull/1830). Thanks @steipete.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -35,7 +35,7 @@ The trailing command after `--` is sent to the box verbatim as argv. Use
 snippets, pipes, or shell expansion.
 
 On Cloudflare Sandbox, Superserve, Crownest, Vercel Sandbox, Nomad, CodeSandbox,
-OpenComputer, and Docker Sandbox,
+OpenComputer, Docker Sandbox, Tensorlake, and OpenSandbox,
 quoted or interpolated profile arguments retain their literal meaning through
 the delegated command transport. A value such as `&&` does not become a shell
 operator, and an executable named `FOO=x` is invoked rather than treated as an

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -415,11 +415,19 @@ core instead.
 for delegated POSIX command adapters. It reuses core shell inference and literal
 argument handling, snapshots the input, and rejects a missing command. The
 result's `Argv` method applies an adapter-supplied shell prefix only when needed;
-an explicitly empty shell source remains valid. Cloudflare Sandbox, Superserve,
-Crownest, Vercel Sandbox, and Nomad use this boundary. They retain their existing
-transport serialization, shell choice, working directory, environment, and
-execution lifecycle. These adapters currently pass no literal-argument map;
-the extraction does not change profile-literal propagation through transports.
+`ShellCommand` renders that execution argv for a string transport. An explicitly
+empty shell source remains valid. Pass all three request fields (`Command`,
+`ShellMode`, and `CommandLiteralArgs`) so profile arguments remain literal.
+Adapters retain their shell choice, working directory, environment transport,
+and execution lifecycle. Serialize the classified intent without running shell
+inference again.
+
+`shared.WrapCommandWithShellEnvProfile` accepts execution argv, not unclassified
+user input. Its fallback quotes every word literally before terminal execution;
+it must not infer operators or assignments again. An exact three-word
+`bash -lc <body>` invocation reuses its body inside the existing profile wrapper,
+preserving the single login-shell boundary used by Modal and Tensorlake. Profile
+sourcing is failure-gated without adding global errexit to user source.
 
 Claim-only recovery adapters may use `shared.ResolveProviderClaimStrict` to
 resolve an exact provider/scope-bound claim before a slug while preventing a

--- a/docs/providers/opensandbox.md
+++ b/docs/providers/opensandbox.md
@@ -147,7 +147,11 @@ crabbox run --provider opensandbox --allow-env API_TOKEN -- printenv API_TOKEN
    `--sync-only` syncs and stops without running a command.
 4. The command runs through OpenSandbox execd with `cwd` set to the workdir and
    `envs` carrying forwarded environment values. The remote exit code is
-   mirrored by Crabbox.
+   mirrored by Crabbox. Command intent is classified once: literal profile
+   arguments stay data through the final execd source string, including shell
+   operators and assignment-shaped executable names. Explicit or inferred shell
+   source retains the existing Bash login wrapper; cwd and envs remain native
+   request fields.
 5. A newly created sandbox is deleted after the run unless `--keep` was set;
    reused sandboxes are retained.
    `--keep-on-failure` retains a newly created sandbox after a sync, workspace

--- a/docs/providers/tensorlake.md
+++ b/docs/providers/tensorlake.md
@@ -208,9 +208,11 @@ orchestrators that need to inspect or clean up retained sandboxes later.
   `--no-sync` with an explicit `--id` if the sandbox is already primed.
 - Large-sync guardrails still apply; pass `--force-sync-large` when a large
   archive sync is intentional.
-- `--shell` wraps the command as `bash -lc '<joined args>'`. Plain commands that
-  contain shell metacharacters (`&&`, `|`, `>`, etc.) or a leading `KEY=VALUE`
-  assignment are auto-wrapped the same way.
+- `--shell` wraps the command as `bash -lc '<joined args>'`. Inferred shell
+  source and unquoted operators or leading assignments use the same shell.
+  Literal profile arguments stay data, including assignment-shaped executable
+  names. Adding an environment profile does not reinterpret those arguments
+  as shell syntax; a single inferred source string remains executable source.
 - Forwarded environment values live in a temporary in-sandbox profile for the
   duration of the command, with an unpredictable per-operation name. The private
   local source is removed after upload returns, including partial-upload failure.

--- a/internal/providers/opensandbox/backend.go
+++ b/internal/providers/opensandbox/backend.go
@@ -232,7 +232,7 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 			return b.ensureWorkspace(ctx, api, sandboxID, workdir)
 		},
 		Command: func(context.Context) (shared.DelegatedSandboxCommand, error) {
-			command, err := buildCommand(req.Command, req.ShellMode)
+			intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
 			if err != nil {
 				return shared.DelegatedSandboxCommand{}, err
 			}
@@ -242,7 +242,7 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 			if remaining := deadline.Sub(b.now()); remaining < b.commandLifetime() {
 				return shared.DelegatedSandboxCommand{}, exit(5, "opensandbox sandbox %s has %s remaining before its absolute TTL, less than the %s command budget; create a new sandbox", sandboxID, remaining.Round(time.Second), b.commandLifetime())
 			}
-			text := commandScript(command)
+			text := intent.ShellCommand("bash", "-lc")
 			return shared.DelegatedSandboxCommand{
 				Text: text,
 				Run: func(ctx context.Context) (int, error) {
@@ -956,30 +956,6 @@ func (b *openSandboxBackend) ensureReusableSandbox(ctx context.Context, api open
 	default:
 		return exit(4, "opensandbox sandbox %q is %s and cannot be reused until it is running", sandboxID, sb.State)
 	}
-}
-
-func buildCommand(command []string, shellMode bool) ([]string, error) {
-	if len(command) == 0 {
-		return nil, errors.New("missing command")
-	}
-	if shellMode {
-		return []string{"bash", "-lc", strings.Join(command, " ")}, nil
-	}
-	if shouldUseShell(command) || leadingEnvAssignment(command) {
-		if len(command) == 1 {
-			return []string{"bash", "-lc", command[0]}, nil
-		}
-		return []string{"bash", "-lc", shellScriptFromArgv(command)}, nil
-	}
-	return command, nil
-}
-
-func leadingEnvAssignment(command []string) bool {
-	return len(command) > 1 && strings.Contains(command[0], "=") && !strings.HasPrefix(command[0], "-")
-}
-
-func commandScript(command []string) string {
-	return shellScriptFromArgv(command)
 }
 
 func openSandboxWorkdir(cfg Config) (string, error) {

--- a/internal/providers/opensandbox/backend_test.go
+++ b/internal/providers/opensandbox/backend_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"reflect"
@@ -686,9 +687,84 @@ func TestRunPreservesBashLoginShellForExplicitInvocation(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := fake.runs[len(fake.runs)-1].Command
-	want := shellScriptFromArgv([]string{"bash", "-lc", "echo hello"})
+	want := "'bash' '-lc' 'echo hello'"
 	if got != want {
 		t.Fatalf("command=%q want %q", got, want)
+	}
+}
+
+func TestRunCommandIntentSurvivesNativeExecdSource(t *testing.T) {
+	if os.PathSeparator != '/' {
+		t.Skip("native POSIX execd fixture")
+	}
+	for _, scenario := range []string{"literal pipe", "literal assignment", "singleton executable", "mixed operators", "inferred source", "explicit empty"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			root := t.TempDir()
+			marker := filepath.Join(root, "must-not-exist")
+			if err := os.WriteFile(filepath.Join(root, "FOO=x"), []byte("#!/bin/sh\nprintf 'literal:%s' \"$*\"\nexit 42\n"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			request := RunRequest{Repo: Repo{Name: "fixture", Root: t.TempDir()}, NoSync: true, Keep: true, Command: []string{"printf", "%s", "|", "touch", marker}, CommandLiteralArgs: map[int]bool{2: true}, Env: map[string]string{"FIXTURE": "synthetic"}}
+			want, wantCode := "|touch"+marker, 0
+			switch scenario {
+			case "literal assignment":
+				request.Command = []string{"FOO=x", "argument"}
+				request.CommandLiteralArgs = map[int]bool{0: true}
+				want = "literal:argument"
+				wantCode = 42
+			case "singleton executable":
+				request.Command = []string{"FOO=x"}
+				request.CommandLiteralArgs = nil
+				want = "literal:"
+				wantCode = 42
+			case "mixed operators":
+				request.Command = []string{"printf", "%s", ";", "&&", "printf", "%s", "tail"}
+				want = ";tail"
+			case "inferred source":
+				request.Command = []string{"printf '%s' source"}
+				request.CommandLiteralArgs = nil
+				want = "source"
+			case "explicit empty":
+				request.Command = []string{""}
+				request.CommandLiteralArgs = nil
+				request.ShellMode = true
+				want = ""
+			}
+			fake := newFakeClient()
+			b := newTestBackend(fake)
+			b.cfg.OpenSandbox.Workdir = root
+			var output string
+			workloads := 0
+			fake.afterRun = func(req runCommandRequest) {
+				if req.Workdir == "" {
+					return
+				}
+				workloads++
+				if req.Workdir != root || !reflect.DeepEqual(req.Env, request.Env) || req.TimeoutSecs != b.execTimeoutSecs() {
+					t.Fatalf("native fields changed: %#v", req)
+				}
+				cmd := exec.Command("sh", "-c", req.Command)
+				cmd.Dir = req.Workdir
+				cmd.Env = []string{"PATH=" + root + ":/usr/bin:/bin", "HOME=" + root, "ENV=" + os.DevNull, "FIXTURE=" + req.Env["FIXTURE"]}
+				out, err := cmd.CombinedOutput()
+				output = string(out)
+				if err != nil {
+					var exitErr *exec.ExitError
+					if !errors.As(err, &exitErr) {
+						t.Fatal(err)
+					}
+					fake.runExit = exitErr.ExitCode()
+				}
+			}
+			result, err := b.Run(t.Context(), request)
+			if workloads != 1 || output != want || result.ExitCode != wantCode || (err != nil) != (wantCode != 0) {
+				t.Fatalf("workloads=%d output=%q code=%d err=%v want=%q/%d", workloads, output, result.ExitCode, err, want, wantCode)
+			}
+			if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("literal sentinel created: %v", err)
+			}
+		})
 	}
 }
 
@@ -705,8 +781,8 @@ func TestRunPreservesBashLoginShellForAutoWrappedMetachars(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := fake.runs[len(fake.runs)-1].Command
-	inner := shellScriptFromArgv([]string{"pnpm", "install", "&&", "pnpm", "test"})
-	want := shellScriptFromArgv([]string{"bash", "-lc", inner})
+	inner := core.ShellScriptFromArgv([]string{"pnpm", "install", "&&", "pnpm", "test"})
+	want := strings.Join(core.ShellWords([]string{"bash", "-lc", inner}), " ")
 	if got != want {
 		t.Fatalf("command=%q want %q", got, want)
 	}

--- a/internal/providers/opensandbox/core.go
+++ b/internal/providers/opensandbox/core.go
@@ -118,14 +118,6 @@ func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []s
 	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
 }
 
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
 func shellQuote(s string) string {
 	return core.ShellQuote(s)
 }

--- a/internal/providers/shared/shell_env_profile.go
+++ b/internal/providers/shared/shell_env_profile.go
@@ -99,13 +99,14 @@ func renderShellEnvProfile(env map[string]string) string {
 	return out.String()
 }
 
-// WrapCommandWithShellEnvProfile gates only profile sourcing, not user commands.
+// WrapCommandWithShellEnvProfile composes execution argv without reinterpreting
+// literal arguments. It gates only profile sourcing, not user commands.
 func WrapCommandWithShellEnvProfile(command []string, envPath string) []string {
 	var script string
 	if len(command) == 3 && command[0] == "bash" && command[1] == "-lc" {
 		script = command[2]
 	} else {
-		script = "exec " + core.ShellScriptFromArgv(command)
+		script = "exec " + strings.Join(core.ShellWords(command), " ")
 	}
 	return []string{"bash", "-lc", ShellScriptWithEnvProfile(script, envPath)}
 }

--- a/internal/providers/shared/shell_env_profile_test.go
+++ b/internal/providers/shared/shell_env_profile_test.go
@@ -190,3 +190,29 @@ func TestPreparedShellEnvProfileRejectsRelativeRemoteDirectory(t *testing.T) {
 		}
 	}
 }
+
+func TestShellEnvProfilePreservesExecutionArgv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("native Bash profile transport")
+	}
+	for _, operator := range []string{"|", ";", "&&"} {
+		t.Run(operator, func(t *testing.T) {
+			root := t.TempDir()
+			profile := filepath.Join(root, "env.sh")
+			if err := os.WriteFile(profile, []byte("FIXTURE=synthetic\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			marker := filepath.Join(root, "must-not-exist")
+			argv := WrapCommandWithShellEnvProfile([]string{"printf", "%s", operator, "touch", marker}, profile)
+			cmd := exec.Command(argv[0], argv[1:]...)
+			cmd.Env = []string{"PATH=/usr/bin:/bin", "HOME=" + root, "ENV=" + os.DevNull}
+			output, err := cmd.CombinedOutput()
+			if err != nil || string(output) != operator+"touch"+marker {
+				t.Fatalf("argv=%q output=%q err=%v", argv, output, err)
+			}
+			if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("execution argv became shell operator: %v", err)
+			}
+		})
+	}
+}

--- a/internal/providers/tensorlake/backend.go
+++ b/internal/providers/tensorlake/backend.go
@@ -167,10 +167,11 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (result Run
 		return RunResult{}, err
 	}
 
-	command, err := buildCommand(req.Command, req.ShellMode)
+	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
 	if err != nil {
 		return RunResult{}, err
 	}
+	command := intent.Argv("bash", "-lc")
 	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
 		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
@@ -503,23 +504,6 @@ func isReadyState(state string) bool {
 
 func randomSuffix() string {
 	return shared.RandomSuffix()
-}
-
-func buildCommand(command []string, shellMode bool) ([]string, error) {
-	if len(command) == 0 {
-		return nil, errors.New("missing command")
-	}
-	if shellMode {
-		return []string{"bash", "-lc", strings.Join(command, " ")}, nil
-	}
-	if shouldUseShell(command) || leadingEnvAssignment(command) {
-		return []string{"bash", "-lc", shellScriptFromArgv(command)}, nil
-	}
-	return command, nil
-}
-
-func leadingEnvAssignment(command []string) bool {
-	return len(command) > 1 && strings.Contains(command[0], "=") && !strings.HasPrefix(command[0], "-")
 }
 
 // tensorlakeWorkdir returns the configured absolute workspace path inside the

--- a/internal/providers/tensorlake/backend_test.go
+++ b/internal/providers/tensorlake/backend_test.go
@@ -61,29 +61,6 @@ func TestProviderForResolvesNameAndAliases(t *testing.T) {
 	}
 }
 
-func TestBuildCommandAutoWrapsShellMetacharacters(t *testing.T) {
-	got, err := buildCommand([]string{"pnpm install && pnpm test"}, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 3 || got[0] != "bash" || got[1] != "-lc" {
-		t.Fatalf("command=%#v want bash -lc wrapping", got)
-	}
-	if !strings.Contains(got[2], "pnpm install") || !strings.Contains(got[2], "pnpm test") {
-		t.Fatalf("command=%#v missing user input", got)
-	}
-}
-
-func TestBuildCommandAutoWrapsLeadingEnvAssignment(t *testing.T) {
-	got, err := buildCommand([]string{"FOO=bar", "pnpm", "test"}, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 3 || got[0] != "bash" {
-		t.Fatalf("command=%#v want bash wrapping for FOO=bar", got)
-	}
-}
-
 func TestTensorlakeWorkdirRejectsRelative(t *testing.T) {
 	cfg := newTestConfig()
 	cfg.Tensorlake.Workdir = "relative/path"
@@ -125,34 +102,6 @@ func TestTensorlakeWorkdirDefault(t *testing.T) {
 	}
 	if got != "/workspace/crabbox" {
 		t.Fatalf("default=%q want /workspace/crabbox", got)
-	}
-}
-
-func TestBuildCommandShellMode(t *testing.T) {
-	got, err := buildCommand([]string{"pnpm install && pnpm test"}, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := []string{"bash", "-lc", "pnpm install && pnpm test"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("command=%#v want %#v", got, want)
-	}
-}
-
-func TestBuildCommandPassThrough(t *testing.T) {
-	got, err := buildCommand([]string{"pnpm", "test"}, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := []string{"pnpm", "test"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("command=%#v want %#v", got, want)
-	}
-}
-
-func TestBuildCommandRejectsEmpty(t *testing.T) {
-	if _, err := buildCommand(nil, false); err == nil {
-		t.Fatalf("expected error for empty command")
 	}
 }
 
@@ -580,6 +529,130 @@ func TestRunForwardsEnvViaUploadedProfile(t *testing.T) {
 	}
 	if !containsArg(userExec.Args, "bash") || !containsArg(userExec.Args, "-lc") || !containsArgSubstring(userExec.Args, "/tmp/crabbox-env-") {
 		t.Fatalf("exec args=%v missing env profile wrapper", userExec.Args)
+	}
+}
+
+func TestRunCommandIntentSurvivesNativeCLIArgv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("native POSIX CLI transport")
+	}
+	for _, withEnv := range []bool{false, true} {
+		for _, scenario := range []string{"literal pipe", "literal assignment", "mixed operators", "inferred source", "plain argv", "explicit exit", "explicit empty"} {
+			t.Run(fmt.Sprintf("env=%v/%s", withEnv, scenario), func(t *testing.T) {
+				b, _, runner, claim := ownedTensorlakeFixture(t)
+				root := t.TempDir()
+				b.cfg.Tensorlake.Workdir = root
+				t.Setenv("PATH", root+":/usr/bin:/bin")
+				if err := os.WriteFile(filepath.Join(root, "FOO=x"), []byte("#!/bin/sh\nprintf 'literal:%s' \"$*\"\nexit 42\n"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				marker := filepath.Join(root, "must-not-exist")
+				request := RunRequest{ID: claim.LeaseID, Repo: Repo{Root: claim.RepoRoot}, NoSync: true, Command: []string{"printf", "%s", "|", "touch", marker}, CommandLiteralArgs: map[int]bool{2: true}}
+				if withEnv {
+					request.Env = map[string]string{"FIXTURE": "quoted ' synthetic\n$literal", "PATH": root + ":/usr/bin:/bin"}
+				}
+				want, wantCode := "|touch"+marker, 0
+				switch scenario {
+				case "literal assignment":
+					request.Command = []string{"FOO=x", "argument"}
+					request.CommandLiteralArgs = map[int]bool{0: true}
+					want = "literal:argument"
+					wantCode = 42
+				case "mixed operators":
+					request.Command = []string{"printf", "%s", ";", "&&", "printf", "%s", "tail"}
+					want = ";tail"
+				case "inferred source":
+					request.Command = []string{"printf '%s' source"}
+					request.CommandLiteralArgs = nil
+					want = "source"
+				case "plain argv":
+					request.Command = []string{"printf", "%s", "plain"}
+					request.CommandLiteralArgs = nil
+					want = "plain"
+				case "explicit exit":
+					request.Command = []string{"printf explicit; exit 7"}
+					request.CommandLiteralArgs = nil
+					request.ShellMode = true
+					want, wantCode = "explicit", 7
+				case "explicit empty":
+					request.Command = []string{""}
+					request.CommandLiteralArgs = nil
+					request.ShellMode = true
+					want = ""
+				}
+				var stdout bytes.Buffer
+				b.rt.Stdout = &stdout
+				var localPath, remotePath string
+				t.Cleanup(func() {
+					if remotePath != "" {
+						_ = os.Remove(remotePath)
+					}
+				})
+				runner.contextHook = func(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+					switch scriptKey(req.Args) {
+					case "sbx cp":
+						localPath = req.Args[len(req.Args)-2]
+						_, remotePath, _ = strings.Cut(req.Args[len(req.Args)-1], ":")
+						data, err := os.ReadFile(localPath)
+						if err != nil {
+							return core.LocalCommandResult{}, err, true
+						}
+						file, err := os.OpenFile(remotePath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+						if err != nil {
+							return core.LocalCommandResult{}, err, true
+						}
+						_, writeErr := file.Write(data)
+						return core.LocalCommandResult{}, errors.Join(writeErr, file.Close()), true
+					case "sbx exec":
+						idIndex := -1
+						for i, arg := range req.Args {
+							if arg == claim.CloudID {
+								idIndex = i
+								break
+							}
+						}
+						if idIndex < 0 || idIndex+1 >= len(req.Args) {
+							t.Fatalf("missing native target: %v", req.Args)
+						}
+						argv := req.Args[idIndex+1:]
+						cmd := osexec.CommandContext(ctx, argv[0], argv[1:]...)
+						cmd.Dir = root
+						cmd.Env = []string{"PATH=" + root + ":/usr/bin:/bin", "HOME=" + root, "ENV=" + os.DevNull}
+						out, err := cmd.CombinedOutput()
+						if req.Stdout != nil {
+							_, _ = req.Stdout.Write(out)
+						}
+						code := 0
+						if err != nil {
+							var exitErr *osexec.ExitError
+							if !errors.As(err, &exitErr) {
+								t.Fatal(err)
+							}
+							code = exitErr.ExitCode()
+						}
+						return core.LocalCommandResult{ExitCode: code}, err, true
+					}
+					return core.LocalCommandResult{}, nil, false
+				}
+				result, err := b.Run(t.Context(), request)
+				if result.ExitCode != wantCode || stdout.String() != want || (err != nil) != (wantCode != 0) {
+					t.Fatalf("output=%q exit=%d err=%v want=%q/%d", stdout.String(), result.ExitCode, err, want, wantCode)
+				}
+				if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("literal sentinel created: %v", err)
+				}
+				if withEnv {
+					for _, file := range []string{localPath, remotePath} {
+						if file == "" {
+							t.Fatal("profile upload missing")
+						}
+						if _, err := os.Stat(file); !errors.Is(err, os.ErrNotExist) {
+							t.Fatalf("profile residue: %v", err)
+						}
+					}
+				}
+			})
+		}
 	}
 }
 

--- a/internal/providers/tensorlake/core.go
+++ b/internal/providers/tensorlake/core.go
@@ -93,14 +93,6 @@ func blank(value, fallback string) string {
 	return core.Blank(value, fallback)
 }
 
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
 func shellQuote(s string) string {
 	return core.ShellQuote(s)
 }


### PR DESCRIPTION
## Summary

Give Tensorlake and OpenSandbox the existing core command-intent boundary, including profile literal metadata. Tensorlake retains native execution argv; OpenSandbox retains its string command plus native cwd, envs, and timeout fields. Delete both provider-specific command builders, loose assignment heuristics, and the final OpenSandbox re-serializer.

The shared environment-profile wrapper also needed correction: its fallback was interpreting execution argv a second time. Merely migrating Tensorlake to the shared parser still turned a literal pipe into a pipeline when an environment profile was present. The fallback now quotes every execution word literally. Its exact bash/-lc/body path stays unchanged, preserving Modal and Tensorlake's existing single login-shell/profile behavior. OpenSandbox uses ShellCommand, not the terminal-exec ShellSource renderer, so its plain-command transport does not gain exec semantics.

## Proof

Fifteen baseline regressions reproduce the defects: three shared execution-argv cases, four OpenSandbox cases, and eight Tensorlake cases with/without environment profiles. A deliberate parse-only intermediate still fails the Tensorlake env-plus-literal-pipe case; the complete change passes it.

Native tests cover actual final execution source/argv, literal operators, assignment-shaped executables, mixed literal and real operators, inferred singleton source, ordinary argv, explicitly empty source, and nonzero exits. Tensorlake fixtures upload real synthetic profile bytes and run the emitted command; cleanup must remove both local and remote files. OpenSandbox executes the final request and verifies cwd/envs/timeout fields remain unchanged. Existing Modal profile tests remain a compatibility gate. Weak provider builder-string tests are replaced rather than retained as compatibility shims.

The built CLI and unmodified Tensorlake provider/production process runner also pass all eight public-profile native-contract cases against three on the unchanged baseline. The local native Tensorlake executable supplies synthetic identity/lifecycle responses, performs real file copies, and executes the received argv; it does not stand in for hosted Tensorlake or its external CLI implementation. Every case creates then removes its synthetic resource and profile. Full synthetic fixture and observations: https://github.com/openclaw/crabbox/pull/1835#issuecomment-5545172749.

Full race suites pass for shared helpers, Tensorlake, OpenSandbox and Modal. Fourteen Tensorlake native cases pass after adding explicit-source/empty-source/plain-argv controls. Scoped vet, CLI build and docs build pass; managed and independent semantic reviews are clean. All proof is native/local, not hosted-provider proof.

## Boundaries

No dependency, credential, configuration, or provider lifecycle change. Existing shells, profile custody/authorization, exit handling, and native cwd/env transports stay with their current owners. The intentional behavior corrections include Tensorlake single-string inferred source and literal assignment-shaped executables. Maintainer changelog and command/provider/architecture documentation are included.
