### PR TITLE
chore(release): authorize v0.49.1 source

### DIFF
--- a/release/records/v0.49.1.json
+++ b/release/records/v0.49.1.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.49.1",
+  "tagObject": "a321016446f4a38241d2727124bd959e93b0938c",
+  "sourceCommit": "775ebb1160d61921486dea54bb58d3e298a87dac",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
Authorize the signed v0.49.1 source for release production and publication. Tag object `a321016446f4a38241d2727124bd959e93b0938c` binds source commit `775ebb1160d61921486dea54bb58d3e298a87dac`; GitHub verifies its signature.

The source landed in https://github.com/openclaw/crabbox/pull/1838 and its tree exactly matches the reviewed candidate. Full CI passed at https://github.com/openclaw/crabbox/actions/runs/33925603116 and the protected Release Check passed at https://github.com/openclaw/crabbox/actions/runs/33925603123.

The source guard validates the new ready record against the exact tag, source, signature, and main ancestry. Independent Codex review found no actionable P0 issue. The original v0.49.0 record remains bound to its restored Go-published source.
