### PR TITLE
refactor: share CodeSandbox run finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- CodeSandbox: share run finalization so failed cleanup returns an accurate recovery session, cancellation honors `--keep-on-failure`, and timing errors preserve the command outcome. Thanks @steipete.
+- CodeSandbox: share run finalization so failed cleanup returns an accurate recovery session, cancellation honors `--keep-on-failure`, and timing errors preserve the command outcome. [PR 1843](https://github.com/openclaw/crabbox/pull/1843). Thanks @steipete.
 
 ## 0.49.1 - 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- CodeSandbox: share run finalization so failed cleanup returns an accurate recovery session, cancellation honors `--keep-on-failure`, and timing errors preserve the command outcome. Thanks @steipete.
+
 - Keep canonical lease IDs separate from slug aliases in shared claim lookup and provider routing, preventing missing IDs from selecting, running on, or stopping a different sandbox while preserving provider recovery behavior. [PR 1839](https://github.com/openclaw/crabbox/pull/1839). Thanks @steipete.
 
 ## 0.49.0 - 2026-09-04

--- a/docs/providers/codesandbox.md
+++ b/docs/providers/codesandbox.md
@@ -126,6 +126,14 @@ Crabbox rejects broad paths such as `/` and `/project`.
    `pause` hibernates the sandbox and keeps the local claim so `resume`, `run`,
    `status`, and `stop` can target it later.
 
+Run outcomes and timing are finalized after automatic cleanup. A failed deletion
+returns a failure and a retained recovery session instead of success with a
+stopped session. An existing command failure keeps its exit code when cleanup or
+timing output also fails. `--keep-on-failure` includes canceled and timed-out
+commands; their original causes remain available for outcome classification.
+Reused sandboxes are never automatically deleted. Ownership checks and the SDK's
+command, environment-file, and deletion transports remain provider-specific.
+
 ## Ports And Preview URLs
 
 CodeSandbox exposes HTTP ports through provider-owned `csb.app` hosts.

--- a/internal/providers/codesandbox/backend.go
+++ b/internal/providers/codesandbox/backend.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type codeSandboxBackend struct {
@@ -53,7 +54,7 @@ func (b *codeSandboxBackend) Warmup(ctx context.Context, req WarmupRequest) erro
 	return nil
 }
 
-func (b *codeSandboxBackend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {
+func (b *codeSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if err := delegatedSyncOptionsError(b.spec, req); err != nil {
 		return RunResult{}, err
 	}
@@ -64,179 +65,87 @@ func (b *codeSandboxBackend) Run(ctx context.Context, req RunRequest) (result Ru
 	if !req.SyncOnly && (len(req.Command) == 0 || (len(req.Command) == 1 && strings.TrimSpace(req.Command[0]) == "")) {
 		return RunResult{}, exit(2, "missing command")
 	}
-	started := b.now()
-	api, err := newCodeSandboxClient(b.cfg, b.rt)
-	if err != nil {
-		return RunResult{}, err
+	var api codeSandboxAPI
+	var leaseID, sandboxID, slug string
+	boundSandbox := func() shared.DelegatedSandbox {
+		fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s\n", providerName, leaseID, sandboxID, workdir)
+		return shared.DelegatedSandbox{LeaseID: leaseID, Slug: slug, CleanupCommand: codeSandboxCleanupCommand(leaseID)}
 	}
-	var prepared *core.PreparedArchive
-	if req.ID == "" && !req.NoSync {
-		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
-			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-			TempPattern: "crabbox-codesandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
-		})
-		if err != nil {
-			return RunResult{}, err
-		}
-		defer prepared.Close()
-	}
-	leaseID, sandboxID, slug := "", "", ""
-	acquired := false
-	if req.ID == "" {
-		leaseID, sandboxID, slug, err = b.createSandbox(ctx, api, req.Repo, req.Reclaim, req.RequestedSlug)
-		if err != nil {
-			return RunResult{}, err
-		}
-		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, sandboxID)
-		acquired = true
-	} else {
-		var claim LeaseClaim
-		leaseID, sandboxID, slug, claim, err = resolveLeaseID(req.ID)
-		if err != nil {
-			return RunResult{}, err
-		}
-		sb, err := api.GetSandbox(ctx, sandboxID)
-		if err != nil {
-			return RunResult{}, err
-		}
-		if err := validateCodeSandboxSandboxOwnership(claim, sb); err != nil {
-			return RunResult{}, err
-		}
-		if req.Repo.Root != "" {
-			if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, claim.ProviderScope, b.cfg.Pond, req.Repo.Root,
-				timeoutOrDefault(b.cfg.IdleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), req.Reclaim); err != nil {
-				return RunResult{}, err
+	return shared.RunDelegatedSandbox(ctx, req, shared.DelegatedSandboxLifecycle{
+		Provider: providerName, Runtime: b.rt, Workdir: workdir,
+		IdleTimeout: b.cfg.IdleTimeout, TTL: b.cfg.TTL, CleanupTimeout: codeSandboxCleanupTimeout,
+		Preflight: func(context.Context) error {
+			var err error
+			api, err = newCodeSandboxClient(b.cfg, b.rt)
+			return err
+		},
+		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) {
+			return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+				Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+				TempPattern: "crabbox-codesandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+			})
+		},
+		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
+			var err error
+			leaseID, sandboxID, slug, err = b.createSandbox(ctx, api, req.Repo, req.Reclaim, req.RequestedSlug)
+			if err != nil {
+				return shared.DelegatedSandbox{}, err
 			}
-		}
-	}
-	shouldStop := acquired && !req.Keep
-	cleanedUp := false
-	session := &RunSessionHandle{
-		Provider:       providerName,
-		LeaseID:        leaseID,
-		Slug:           slug,
-		Reused:         !acquired,
-		Kept:           !shouldStop,
-		CleanupCommand: codeSandboxCleanupCommand(leaseID),
-	}
-	finishResult := func(result RunResult) RunResult {
-		result.Session = session
-		result.Session.Kept = !cleanedUp && !shouldStop
-		return result
-	}
-	if shouldStop {
-		defer func() {
-			if !shouldStop {
-				result = finishResult(result)
-				return
+			fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, sandboxID)
+			return boundSandbox(), nil
+		},
+		Resolve: func(ctx context.Context) (shared.DelegatedSandbox, error) {
+			var claim LeaseClaim
+			var err error
+			leaseID, sandboxID, slug, claim, err = resolveLeaseID(req.ID)
+			if err != nil {
+				return shared.DelegatedSandbox{}, err
 			}
-			cleanupCtx, cancel := b.cleanupContext(ctx)
-			defer cancel()
-			if err := api.DeleteSandbox(cleanupCtx, sandboxID); err != nil {
-				fmt.Fprintf(b.rt.Stderr, "warning: codesandbox stop failed for %s: %v\n", sandboxID, err)
-				result = finishResult(result)
-				return
+			sb, err := api.GetSandbox(ctx, sandboxID)
+			if err != nil {
+				return shared.DelegatedSandbox{}, err
+			}
+			if err := validateCodeSandboxSandboxOwnership(claim, sb); err != nil {
+				return shared.DelegatedSandbox{}, err
+			}
+			if req.Repo.Root != "" {
+				if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, claim.ProviderScope, b.cfg.Pond, req.Repo.Root,
+					timeoutOrDefault(b.cfg.IdleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), req.Reclaim); err != nil {
+					return shared.DelegatedSandbox{}, err
+				}
+			}
+			return boundSandbox(), nil
+		},
+		Sync: func(ctx context.Context, prepared *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
+			return b.syncWorkspace(ctx, api, sandboxID, req, workdir, prepared)
+		},
+		NoSync: func(ctx context.Context) error {
+			return b.ensureWorkspace(ctx, api, sandboxID, workdir)
+		},
+		Command: func(context.Context) (shared.DelegatedSandboxCommand, error) {
+			intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
+			if err != nil {
+				return shared.DelegatedSandboxCommand{}, err
+			}
+			command := intent.Argv("bash", "-lc")
+			if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
+				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+			}
+			return shared.DelegatedSandboxCommand{
+				Text: strings.Join(command, " "),
+				Run: func(ctx context.Context) (int, error) {
+					return b.execCommand(ctx, api, sandboxID, workdir, command, req.Env)
+				},
+			}, nil
+		},
+		Cleanup: func(ctx context.Context) error {
+			if err := api.DeleteSandbox(ctx, sandboxID); err != nil {
+				return err
 			}
 			removeLeaseClaim(leaseID)
-			cleanedUp = true
-			result = finishResult(result)
-		}()
-	}
-	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s\n", providerName, leaseID, sandboxID, workdir)
-
-	syncDuration := time.Duration(0)
-	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
-	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, sandboxID, req, workdir, prepared)
-		if err != nil {
-			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-			return finishResult(RunResult{Total: b.now().Sub(started), SyncDelegated: true, Provider: providerName, LeaseID: leaseID, Slug: slug}), err
-		}
-		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
-	} else if err := b.ensureWorkspace(ctx, api, sandboxID, workdir); err != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return finishResult(RunResult{}), err
-	}
-
-	if req.SyncOnly {
-		result := finishResult(RunResult{Total: b.now().Sub(started), SyncDelegated: true, Provider: providerName, LeaseID: leaseID, Slug: slug})
-		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
-		if req.TimingJSON {
-			return result, writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
-				Provider:      providerName,
-				LeaseID:       leaseID,
-				Slug:          slug,
-				SyncDelegated: true,
-				SyncMs:        syncDuration.Milliseconds(),
-				SyncPhases:    syncPhases,
-				SyncSkipped:   req.NoSync,
-				TotalMs:       result.Total.Milliseconds(),
-				ExitCode:      0,
-				Label:         strings.TrimSpace(req.Label),
-				Workdir:       workdir,
-			}, result, nil))
-		}
-		return result, nil
-	}
-
-	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
-	if err != nil {
-		return finishResult(RunResult{}), err
-	}
-	command := intent.Argv("bash", "-lc")
-	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
-		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
-	}
-	commandStart := b.now()
-	exitCode, runErr := b.execCommand(ctx, api, sandboxID, workdir, command, req.Env)
-	commandDuration := b.now().Sub(commandStart)
-	result = finishResult(RunResult{
-		ExitCode:      exitCode,
-		Command:       commandDuration,
-		Total:         b.now().Sub(started),
-		SyncDelegated: true,
-		Provider:      providerName,
-		LeaseID:       leaseID,
-		Slug:          slug,
-		CommandText:   strings.Join(command, " "),
+			return nil
+		},
 	})
-	if req.NoSync {
-		fmt.Fprintf(b.rt.Stderr, "codesandbox run summary sync_skipped=true command=%s total=%s exit=%d\n",
-			result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
-	} else {
-		fmt.Fprintf(b.rt.Stderr, "codesandbox run summary sync=%s command=%s total=%s exit=%d\n",
-			syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
-	}
-	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
-			Provider:      providerName,
-			LeaseID:       leaseID,
-			Slug:          slug,
-			SyncDelegated: true,
-			SyncMs:        syncDuration.Milliseconds(),
-			SyncPhases:    syncPhases,
-			SyncSkipped:   req.NoSync,
-			CommandMs:     result.Command.Milliseconds(),
-			TotalMs:       result.Total.Milliseconds(),
-			ExitCode:      exitCode,
-			Label:         strings.TrimSpace(req.Label),
-			Workdir:       workdir,
-		}, result, runErr)); err != nil {
-			return result, err
-		}
-	}
-	if runErr != nil {
-		if errors.Is(runErr, context.Canceled) || errors.Is(runErr, context.DeadlineExceeded) {
-			return result, runErr
-		}
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return result, ExitError{Code: 1, Message: fmt.Sprintf("codesandbox run failed: %v", runErr)}
-	}
-	if exitCode != 0 {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return result, ExitError{Code: exitCode, Message: fmt.Sprintf("codesandbox run exited %d", exitCode)}
-	}
-	return result, nil
 }
 
 func (b *codeSandboxBackend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {

--- a/internal/providers/codesandbox/backend_test.go
+++ b/internal/providers/codesandbox/backend_test.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestWarmupCreatesSandboxClaim(t *testing.T) {
@@ -438,6 +440,97 @@ func TestRunByIDReturnsReusedSessionHandle(t *testing.T) {
 	}
 }
 
+func TestRunLifecycleFinalization(t *testing.T) {
+	for _, tc := range []struct {
+		name                                               string
+		code                                               int
+		commandErr                                         error
+		cleanupFails, writerFails, keepOnFailure, syncOnly bool
+		wantCode                                           int
+		wantKind                                           core.RunErrorKind
+		wantDeletes                                        int
+	}{
+		{name: "cleanup after success", cleanupFails: true, wantCode: 1, wantKind: core.RunErrorProvider, wantDeletes: 1},
+		{name: "cleanup and writer after exit", code: 23, cleanupFails: true, writerFails: true, wantCode: 23, wantKind: core.RunErrorCommandExit, wantDeletes: 1},
+		{name: "writer after retained exit", code: 23, writerFails: true, keepOnFailure: true, wantCode: 23, wantKind: core.RunErrorCommandExit},
+		{name: "keep canceled command", commandErr: context.Canceled, keepOnFailure: true, wantCode: 1, wantKind: core.RunErrorCanceled},
+		{name: "keep timed out command", commandErr: context.DeadlineExceeded, keepOnFailure: true, wantCode: 1, wantKind: core.RunErrorTimeout},
+		{name: "sync only cleanup", syncOnly: true, cleanupFails: true, wantCode: 1, wantKind: core.RunErrorProvider, wantDeletes: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			fake := newFakeCodeSandboxAPI()
+			backend, _, _ := newFakeBackend(t, fake)
+			clock := &fixedClock{t: time.Unix(0, 0)}
+			backend.rt.Clock = clock
+			observer := &lifecycleTimingObserver{fail: tc.writerFails}
+			backend.rt.Stderr = observer
+			if tc.cleanupFails {
+				fake.deleteErr = errors.New("fixture delete failed")
+			}
+			fake.onDelete = func(ctx context.Context) {
+				if ctx.Err() != nil {
+					t.Errorf("cleanup context canceled: %v", ctx.Err())
+				}
+				if deadline, ok := ctx.Deadline(); !ok || time.Until(deadline) > codeSandboxCleanupTimeout {
+					t.Error("cleanup deadline missing or extended")
+				}
+				if observer.count != 0 {
+					t.Error("timing was emitted before cleanup")
+				}
+				clock.t = clock.t.Add(5 * time.Second)
+			}
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			fake.commandHook = func(context.Context, CommandRequest) (CommandResult, error) {
+				if len(fake.commands) == 1 {
+					return CommandResult{}, nil
+				}
+				if tc.commandErr == context.Canceled {
+					cancel()
+				}
+				return CommandResult{ExitCode: tc.code}, tc.commandErr
+			}
+			result, err := backend.Run(ctx, RunRequest{Repo: Repo{Root: t.TempDir()}, NoSync: true, SyncOnly: tc.syncOnly, Command: []string{"true"}, KeepOnFailure: tc.keepOnFailure, TimingJSON: true})
+			var exitErr ExitError
+			if !errors.As(err, &exitErr) || exitErr.Code != tc.wantCode || result.ExitCode != tc.wantCode || result.ErrorKind != tc.wantKind {
+				t.Errorf("result=%#v error=%v, want %d/%s", result, err, tc.wantCode, tc.wantKind)
+			}
+			if tc.commandErr != nil && !errors.Is(err, tc.commandErr) {
+				t.Errorf("lost command cause: %v", err)
+			}
+			if result.Session == nil || !result.Session.Kept || len(fake.deleted) != tc.wantDeletes {
+				t.Fatalf("session=%#v deleted=%v", result.Session, fake.deleted)
+			}
+			if observer.count != 1 || result.Total != time.Duration(tc.wantDeletes)*5*time.Second || result.Command != 0 {
+				t.Errorf("timing count=%d total=%s command=%s", observer.count, result.Total, result.Command)
+			}
+			if !tc.writerFails && (observer.report.ExitCode != result.ExitCode || observer.report.RunStatus != result.Status || observer.report.ErrorKind != result.ErrorKind || observer.report.TotalMs != result.Total.Milliseconds()) {
+				t.Errorf("report=%#v result=%#v", observer.report, result)
+			}
+			if _, ok, err := resolveCodeSandboxLeaseClaim(result.LeaseID); err != nil || !ok {
+				t.Fatalf("retained claim missing: %t %v", ok, err)
+			}
+		})
+	}
+}
+
+type lifecycleTimingObserver struct {
+	bytes.Buffer
+	report core.TimingReport
+	count  int
+	fail   bool
+}
+
+func (w *lifecycleTimingObserver) WriteTimingReport(report core.TimingReport) error {
+	w.count++
+	w.report = report
+	if w.fail {
+		return io.ErrClosedPipe
+	}
+	return nil
+}
+
 func TestRunCancellationPropagates(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeCodeSandboxAPI()
@@ -554,6 +647,9 @@ type fakeCodeSandboxAPI struct {
 	waitedPorts    []int
 	commandResults []CommandResult
 	blockRun       bool
+	deleteErr      error
+	onDelete       func(context.Context)
+	commandHook    func(context.Context, CommandRequest) (CommandResult, error)
 }
 
 type fixedClock struct {
@@ -598,9 +694,12 @@ func (f *fakeCodeSandboxAPI) GetSandbox(context.Context, string) (SandboxSummary
 	return f.sandbox, nil
 }
 
-func (f *fakeCodeSandboxAPI) DeleteSandbox(_ context.Context, id string) error {
+func (f *fakeCodeSandboxAPI) DeleteSandbox(ctx context.Context, id string) error {
 	f.deleted = append(f.deleted, id)
-	return nil
+	if f.onDelete != nil {
+		f.onDelete(ctx)
+	}
+	return f.deleteErr
 }
 
 func (f *fakeCodeSandboxAPI) HibernateSandbox(_ context.Context, id string) error {
@@ -617,6 +716,9 @@ func (f *fakeCodeSandboxAPI) ResumeSandbox(_ context.Context, id string) (Sandbo
 
 func (f *fakeCodeSandboxAPI) RunCommand(ctx context.Context, _ string, req CommandRequest) (CommandResult, error) {
 	f.commands = append(f.commands, req)
+	if f.commandHook != nil {
+		return f.commandHook(ctx, req)
+	}
 	if f.blockRun {
 		<-ctx.Done()
 		return CommandResult{}, ctx.Err()

--- a/internal/providers/codesandbox/core.go
+++ b/internal/providers/codesandbox/core.go
@@ -21,7 +21,6 @@ type DoctorCheck = core.DoctorCheck
 type WarmupRequest = core.WarmupRequest
 type RunRequest = core.RunRequest
 type RunResult = core.RunResult
-type RunSessionHandle = core.RunSessionHandle
 type ListRequest = core.ListRequest
 type LeaseView = core.LeaseView
 type CleanupRequest = core.CleanupRequest
@@ -71,14 +70,6 @@ func delegatedSyncOptionsError(spec ProviderSpec, req RunRequest) error {
 
 func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
-}
-
-func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
-	return core.TimingReportWithRunResult(report, result, err)
-}
-
-func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
-	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }
 
 func newLeaseSlug(leaseID string) string {


### PR DESCRIPTION
## Summary

Move CodeSandbox runs onto the existing provider-neutral sandbox lifecycle. Failed automatic deletion now returns a failed outcome with a kept recovery session instead of success with `kept=false`. Command failures keep their selected exit code through cleanup or timing-write failures, and `--keep-on-failure` applies to cancellation and deadlines. Timing is emitted once after cleanup and includes its duration.

Remove the old finalizer and unused bridge wrappers (100 net production lines). Keep early validation, ownership verification before reclaim, partial-create rollback, native sandbox IDs, archive/mount handling, SDK command/environment transport, and standalone operations in the CodeSandbox adapter. Reused sandboxes remain retained. This does not introduce a claim-revision fence or change the vendor SDK.

## Verification

- Six regression cases fail on the baseline and pass after migration, including a controlled clock proving cleanup precedes the final timing record.
- Full CodeSandbox/shared Go race suites, scoped vet, docs build, and Linux arm64 CLI build pass.
- Built CLI + unmodified Node bridge + synthetic file SDK boundary + real Linux Bash: baseline 3/6, candidate 6/6. Cases cover success, failed deletion, nonzero exit with failed deletion, explicit keep, reuse, and real `/dev/full` timing failure with keep-on-failure. Final fixture resources, claims, and staged environment files are removed.
- Native proof uses Node v24.20.0 on Linux arm64, pinned image `node@sha256:be23f54a88d34e8824c741b19b91064094f92c1c97b194144bfc8b50d67258e2`, network disabled, read-only root, dropped capabilities and task-only temporary files. It does not use the vendor SDK implementation or a hosted CodeSandbox account; no cloud deletion is claimed.
- Managed Codex review and independent semantic review have no actionable findings. Refreshed against the finalized v0.49.1 source, preserving that release section and the original v0.49.0 notes.

## Configuration and risk

No new dependencies, credentials, configuration, command syntax, or provider permissions. This deliberately changes warning-only cleanup success into failure and preserves primary failures; callers consuming run status/retention should now receive the truthful result. Warmup/stop/pause/resume and their authorization boundaries are unchanged.

Complete native reproduction, observed baseline/candidate results and maintainer compatibility disposition: https://github.com/openclaw/crabbox/pull/1843#issuecomment-5547553934. Cancellation/deadline cause and retention currently have deterministic provider/shared regression coverage; the six-case native fixture does not independently exercise those two cases.
