### PR TITLE
refactor(worker): reuse provider test fixtures

### DIFF
--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -104,6 +104,41 @@ function ownedAzureTags(overrides: Record<string, string> = {}): Record<string, 
   };
 }
 
+function ownedAzureVMProperties() {
+  return {
+    vmId: "vm-immutable-id",
+    networkProfile: {
+      networkInterfaces: [
+        {
+          id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
+        },
+      ],
+    },
+    storageProfile: {
+      osDisk: {
+        managedDisk: {
+          id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
+        },
+      },
+    },
+  };
+}
+
+function ownedAzureNICProperties() {
+  return {
+    resourceGuid: "nic-immutable-id",
+    ipConfigurations: [
+      {
+        properties: {
+          publicIPAddress: {
+            id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
+          },
+        },
+      },
+    ],
+  };
+}
+
 function memoryAzureDeleteClaimStorage(): {
   records: Map<string, unknown>;
   putKeys: string[];
@@ -947,23 +982,7 @@ describe("azure provider", () => {
           name: "crabbox-blue-lobster",
           location: "eastus",
           tags: ownedAzureTags(),
-          properties: {
-            vmId: "vm-immutable-id",
-            networkProfile: {
-              networkInterfaces: [
-                {
-                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
-                },
-              ],
-            },
-            storageProfile: {
-              osDisk: {
-                managedDisk: {
-                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
-                },
-              },
-            },
-          },
+          properties: ownedAzureVMProperties(),
         });
       }
       if (url.pathname.endsWith("/networkInterfaces/crabbox-blue-lobster-nic")) {
@@ -2476,23 +2495,7 @@ describe("azure provider", () => {
         const isPIP = url.pathname.includes("/publicIPAddresses/");
         const isDisk = url.pathname.includes("/disks/");
         const properties = isVM
-          ? {
-              vmId: "vm-immutable-id",
-              networkProfile: {
-                networkInterfaces: [
-                  {
-                    id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
-                  },
-                ],
-              },
-              storageProfile: {
-                osDisk: {
-                  managedDisk: {
-                    id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
-                  },
-                },
-              },
-            }
+          ? ownedAzureVMProperties()
           : isNIC
             ? {
                 resourceGuid: "nic-immutable-id",
@@ -3001,36 +3004,9 @@ describe("azure provider", () => {
         ? "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-blue-lobster"
         : undefined;
       const properties = url.pathname.includes("/virtualMachines/")
-        ? {
-            vmId: "vm-immutable-id",
-            networkProfile: {
-              networkInterfaces: [
-                {
-                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
-                },
-              ],
-            },
-            storageProfile: {
-              osDisk: {
-                managedDisk: {
-                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
-                },
-              },
-            },
-          }
+        ? ownedAzureVMProperties()
         : url.pathname.includes("/networkInterfaces/")
-          ? {
-              resourceGuid: "nic-immutable-id",
-              ipConfigurations: [
-                {
-                  properties: {
-                    publicIPAddress: {
-                      id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
-                    },
-                  },
-                },
-              ],
-            }
+          ? ownedAzureNICProperties()
           : url.pathname.includes("/publicIPAddresses/")
             ? { resourceGuid: "pip-immutable-id" }
             : url.pathname.includes("/disks/")
@@ -3155,36 +3131,9 @@ describe("azure provider", () => {
           : ownedAzureTags();
       const isDisk = url.pathname.includes("/disks/");
       const properties = url.pathname.includes("/virtualMachines/")
-        ? {
-            vmId: "vm-immutable-id",
-            networkProfile: {
-              networkInterfaces: [
-                {
-                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
-                },
-              ],
-            },
-            storageProfile: {
-              osDisk: {
-                managedDisk: {
-                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
-                },
-              },
-            },
-          }
+        ? ownedAzureVMProperties()
         : url.pathname.includes("/networkInterfaces/")
-          ? {
-              resourceGuid: "nic-immutable-id",
-              ipConfigurations: [
-                {
-                  properties: {
-                    publicIPAddress: {
-                      id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
-                    },
-                  },
-                },
-              ],
-            }
+          ? ownedAzureNICProperties()
           : url.pathname.includes("/publicIPAddresses/")
             ? { resourceGuid: "pip-immutable-id" }
             : isDisk
@@ -3228,36 +3177,9 @@ describe("azure provider", () => {
       const name = url.pathname.slice(url.pathname.lastIndexOf("/") + 1);
       const isDisk = url.pathname.includes("/disks/");
       const properties = url.pathname.includes("/virtualMachines/")
-        ? {
-            vmId: "vm-immutable-id",
-            networkProfile: {
-              networkInterfaces: [
-                {
-                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
-                },
-              ],
-            },
-            storageProfile: {
-              osDisk: {
-                managedDisk: {
-                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
-                },
-              },
-            },
-          }
+        ? ownedAzureVMProperties()
         : url.pathname.includes("/networkInterfaces/")
-          ? {
-              resourceGuid: "nic-immutable-id",
-              ipConfigurations: [
-                {
-                  properties: {
-                    publicIPAddress: {
-                      id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
-                    },
-                  },
-                },
-              ],
-            }
+          ? ownedAzureNICProperties()
           : url.pathname.includes("/publicIPAddresses/")
             ? { resourceGuid: "pip-immutable-id" }
             : isDisk

--- a/worker/test/postgres-storage.test.ts
+++ b/worker/test/postgres-storage.test.ts
@@ -264,38 +264,17 @@ describe("PostgresCoordinatorStorage", () => {
     const id = "chk_postgres_fanout";
     const now = new Date().toISOString();
     const org = orgKeyForLabel("example-org");
-    await storage.put(checkpointKey(id), {
-      version: 1,
-      id,
-      owner: "alice@example.com",
-      org,
-      leaseID: "cbx_000000000001",
-      provider: "aws",
-      scope: { region: "eu-west-1", accountID: "123456789012" },
-      name: "parallel-checkpoint",
-      strategy: "disk-snapshot",
-      noReboot: true,
-      image: {
-        id: "snap-owned",
-        resourceID: "snap-owned",
-        kind: "aws-ebs-snapshot",
-        immutableID: "snap-owned",
-        snapshotIDs: ["snap-owned"],
-        state: "available",
-      },
-      state: "ready",
-      retention: { mode: "manual" },
-      generation: 1,
-      revision: 1,
-      createdAt: now,
-      updatedAt: now,
-      lastUsedAt: now,
-      attempts: 0,
-      pinCount: 0,
-      activeUseCount: 0,
-      eventSequence: 0,
-      target: "linux",
-    } satisfies CoordinatorCheckpointRecord);
+    await storage.put(
+      checkpointKey(id),
+      postgresCheckpointFixture({
+        id,
+        owner: "alice@example.com",
+        org,
+        name: "parallel-checkpoint",
+        imageID: "snap-owned",
+        now,
+      }),
+    );
     const claims = await Promise.all(
       Array.from({ length: 12 }, async () =>
         acquireCheckpointUse(storage, id, { owner: "alice@example.com", org }),
@@ -317,38 +296,17 @@ describe("PostgresCoordinatorStorage", () => {
       const id = "chk_postgres_finish_retry";
       const now = new Date().toISOString();
       const org = orgKeyForLabel("example-org");
-      await storage.put(checkpointKey(id), {
-        version: 1,
-        id,
-        owner: "alice@example.com",
-        org,
-        leaseID: "cbx_000000000001",
-        provider: "aws",
-        scope: { region: "eu-west-1", accountID: "123456789012" },
-        name: "parallel-checkpoint",
-        strategy: "disk-snapshot",
-        noReboot: true,
-        image: {
-          id: "snap-owned",
-          resourceID: "snap-owned",
-          kind: "aws-ebs-snapshot",
-          immutableID: "snap-owned",
-          snapshotIDs: ["snap-owned"],
-          state: "available",
-        },
-        state: "ready",
-        retention: { mode: "manual" },
-        generation: 1,
-        revision: 1,
-        createdAt: now,
-        updatedAt: now,
-        lastUsedAt: now,
-        attempts: 0,
-        pinCount: 0,
-        activeUseCount: 0,
-        eventSequence: 0,
-        target: "linux",
-      } satisfies CoordinatorCheckpointRecord);
+      await storage.put(
+        checkpointKey(id),
+        postgresCheckpointFixture({
+          id,
+          owner: "alice@example.com",
+          org,
+          name: "parallel-checkpoint",
+          imageID: "snap-owned",
+          now,
+        }),
+      );
 
       const principal = { owner: "alice@example.com", org };
       const claim = await acquireCheckpointUse(storage, id, principal);
@@ -547,38 +505,17 @@ describe("PostgresCoordinatorStorage", () => {
     const now = new Date().toISOString();
     await Promise.all(
       checkpointIDs.map(async (id) => {
-        await storage.put(checkpointKey(id), {
-          version: 1,
-          id,
-          owner: principal.owner,
-          org: principal.org,
-          leaseID: "cbx_000000000001",
-          provider: "aws",
-          scope: { region: "eu-west-1", accountID: "123456789012" },
-          name: id,
-          strategy: "disk-snapshot",
-          noReboot: true,
-          image: {
+        await storage.put(
+          checkpointKey(id),
+          postgresCheckpointFixture({
             id,
-            resourceID: id,
-            kind: "aws-ebs-snapshot",
-            immutableID: id,
-            snapshotIDs: [id],
-            state: "available",
-          },
-          state: "ready",
-          retention: { mode: "manual" },
-          generation: 1,
-          revision: 1,
-          createdAt: now,
-          updatedAt: now,
-          lastUsedAt: now,
-          attempts: 0,
-          pinCount: 0,
-          activeUseCount: 0,
-          eventSequence: 0,
-          target: "linux",
-        } satisfies CoordinatorCheckpointRecord);
+            owner: principal.owner,
+            org: principal.org,
+            name: id,
+            imageID: id,
+            now,
+          }),
+        );
       }),
     );
     const claims = await Promise.all(
@@ -869,38 +806,17 @@ describe("PostgresCoordinatorStorage", () => {
     const now = new Date().toISOString();
     await Promise.all(
       checkpointIDs.map(async (id) => {
-        await storage.put(checkpointKey(id), {
-          version: 1,
-          id,
-          owner: principal.owner,
-          org: principal.org,
-          leaseID: "cbx_000000000001",
-          provider: "aws",
-          scope: { region: "eu-west-1", accountID: "123456789012" },
-          name: id,
-          strategy: "disk-snapshot",
-          noReboot: true,
-          image: {
+        await storage.put(
+          checkpointKey(id),
+          postgresCheckpointFixture({
             id,
-            resourceID: id,
-            kind: "aws-ebs-snapshot",
-            immutableID: id,
-            snapshotIDs: [id],
-            state: "available",
-          },
-          state: "ready",
-          retention: { mode: "manual" },
-          generation: 1,
-          revision: 1,
-          createdAt: now,
-          updatedAt: now,
-          lastUsedAt: now,
-          attempts: 0,
-          pinCount: 0,
-          activeUseCount: 0,
-          eventSequence: 0,
-          target: "linux",
-        } satisfies CoordinatorCheckpointRecord);
+            owner: principal.owner,
+            org: principal.org,
+            name: id,
+            imageID: id,
+            now,
+          }),
+        );
       }),
     );
     const claims = await Promise.all(
@@ -971,38 +887,17 @@ describe("PostgresCoordinatorStorage", () => {
     const id = "chk_postgres_claim_cap";
     const now = new Date().toISOString();
     const org = orgKeyForLabel("example-org");
-    await storage.put(checkpointKey(id), {
-      version: 1,
-      id,
-      owner: "alice@example.com",
-      org,
-      leaseID: "cbx_000000000001",
-      provider: "aws",
-      scope: { region: "eu-west-1", accountID: "123456789012" },
-      name: "parallel-checkpoint",
-      strategy: "disk-snapshot",
-      noReboot: true,
-      image: {
-        id: "snap-owned",
-        resourceID: "snap-owned",
-        kind: "aws-ebs-snapshot",
-        immutableID: "snap-owned",
-        snapshotIDs: ["snap-owned"],
-        state: "available",
-      },
-      state: "ready",
-      retention: { mode: "manual" },
-      generation: 1,
-      revision: 1,
-      createdAt: now,
-      updatedAt: now,
-      lastUsedAt: now,
-      attempts: 0,
-      pinCount: 0,
-      activeUseCount: 0,
-      eventSequence: 0,
-      target: "linux",
-    } satisfies CoordinatorCheckpointRecord);
+    await storage.put(
+      checkpointKey(id),
+      postgresCheckpointFixture({
+        id,
+        owner: "alice@example.com",
+        org,
+        name: "parallel-checkpoint",
+        imageID: "snap-owned",
+        now,
+      }),
+    );
     const limits = checkpointLimits({ CRABBOX_MAX_CHECKPOINT_USE_CLAIMS: "5" });
 
     const results = await Promise.allSettled(
@@ -1162,6 +1057,55 @@ describe("PostgresCoordinatorStorage", () => {
     },
   );
 });
+
+function postgresCheckpointFixture({
+  id,
+  owner,
+  org,
+  name,
+  imageID,
+  now,
+}: {
+  id: string;
+  owner: string;
+  org: string;
+  name: string;
+  imageID: string;
+  now: string;
+}) {
+  return {
+    version: 1,
+    id,
+    owner,
+    org,
+    leaseID: "cbx_000000000001",
+    provider: "aws",
+    scope: { region: "eu-west-1", accountID: "123456789012" },
+    name,
+    strategy: "disk-snapshot",
+    noReboot: true,
+    image: {
+      id: imageID,
+      resourceID: imageID,
+      kind: "aws-ebs-snapshot",
+      immutableID: imageID,
+      snapshotIDs: [imageID],
+      state: "available",
+    },
+    state: "ready",
+    retention: { mode: "manual" },
+    generation: 1,
+    revision: 1,
+    createdAt: now,
+    updatedAt: now,
+    lastUsedAt: now,
+    attempts: 0,
+    pinCount: 0,
+    activeUseCount: 0,
+    eventSequence: 0,
+    target: "linux",
+  } satisfies CoordinatorCheckpointRecord;
+}
 
 async function postgresReadyPoolFixture() {
   const pool = statefulFakePool();


### PR DESCRIPTION
## What Problem This Solves

Worker provider tests repeat PostgreSQL checkpoint and Azure companion-resource property objects, making the behavioral assertions harder to scan and fixture updates unnecessarily repetitive.

## Why This Change Was Made

Use test-only fixture builders for five PostgreSQL checkpoint acquisitions, five Azure VM calls, and three Azure NIC calls. Each call still receives a fresh object, while call order, identities, property order, assertions, and source-contract coverage remain unchanged.

Only `worker/test/postgres-storage.test.ts` and `worker/test/azure.test.ts` change. No production code, provider calls, configuration, security, or lifecycle contracts change.

## User Impact

No user-visible change. Maintainers get the same Worker test scenarios with 134 fewer lines of duplicated fixture setup. No configuration or secret changes.

## Evidence

- `git diff --check 0f11089ee08fde86fb8e2088a326ac7e856497b3..93dfa8a5bf22242a0328ab4b2ef66a8e8faed22f`
- Diff SHA-256: `3c10ae16cab00759cab4ffa9570498acd01873d5ab738a78414a73a0ac06ce28`
- Independent inverse-AST review reconstructed all five PostgreSQL, five Azure VM, and three Azure NIC calls and matched every assertion, identity, and property order.
- Source audit retained 24 PostgreSQL tests with 117 expectations and 95 Azure tests with 368 expectations.
- Both scoped commits have verified signatures; formatting, diff checks, and privacy review passed.
- Local Vitest and lint were not run because this recovery worktree has no `worker/node_modules`. Hosted Worker CI is required before merge.
