### PR TITLE
refactor(railway): remove unreachable redeploy tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ hardware for macOS VM workflows.
 | [Microsoft Execution Containers](docs/providers/mxc.md) — `mxc` (`execution-container`)                        | Windows      | Policy-driven local Windows process containment.                                |
 | [OpenComputer](docs/providers/opencomputer.md) — `opencomputer` (`oc`, `open-computer`)                        | Linux        | OpenComputer Linux VMs through the OpenComputer REST API.                       |
 | [OpenSandbox](docs/providers/opensandbox.md) — `opensandbox`                                                   | Linux        | OpenSandbox delegated containers through the OpenSandbox Go SDK.                |
-| [Railway](docs/providers/railway.md) — `railway` (`rail`, `railwayapp`)                                        | Linux        | Redeploy and stream an existing Railway service.                                |
+| [Railway](docs/providers/railway.md) — `railway` (`rail`, `railwayapp`)                                        | Linux        | Inspect and stop an existing Railway service.                                   |
 | [Anthropic Sandbox Runtime](docs/providers/anthropic-sandbox-runtime.md) — `anthropic-sandbox-runtime` (`srt`) | macOS, Linux | Local one-shot sandboxing through Anthropic's `srt` CLI.                        |
 | [SmolVM](docs/providers/smolvm.md) — `smolvm` (`smol`, `smolmachines`, `smolfleet`)                            | Linux        | Smol Machines microVM sandboxes via the smolfleet API.                          |
 | [Tensorlake](docs/providers/tensorlake.md) — `tensorlake` (`tl`, `tensorlake-sbx`)                             | Linux        | Tensorlake Firecracker sandbox via the Tensorlake CLI.                          |

--- a/internal/providers/railway/backend.go
+++ b/internal/providers/railway/backend.go
@@ -5,54 +5,16 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io"
-	"math/rand"
 	"strings"
 	"sync"
-	"time"
 )
 
-// Polling configuration for Railway redeploy tracking. Railway has no
-// synchronous exec endpoint; redeploy tracking polls the new deployment's status
-// until it reaches a terminal state. The interval grows exponentially with
-// jitter so a long deployment doesn't hammer the API while a short one still
-// feels snappy.
 const (
-	railwayPollInitialInterval   = 5 * time.Second
-	railwayPollMaxInterval       = 30 * time.Second
-	railwayPollOverallTimeout    = 30 * time.Minute
-	railwayDeployResolveTimeout  = 2 * time.Minute
-	railwayPollJitterFraction    = 0.2
-	railwayPollLogLimit          = 500
 	railwayClaimServiceLabel     = "railwayServiceId"
 	railwayClaimProjectLabel     = "railwayProjectId"
 	railwayClaimEnvironmentLabel = "railwayEnvironmentId"
 	railwayClaimDeploymentLabel  = "railwayDeploymentId"
 )
-
-// railwayPollRand seeds a private rand.Source on first use so jitter doesn't
-// rely on the global generator (which other tests may reseed) while staying
-// dependency-free.
-var (
-	railwayPollRandOnce sync.Once
-	railwayPollRand     *rand.Rand
-	railwayPollRandMu   sync.Mutex
-)
-
-func railwayJitter(d time.Duration) time.Duration {
-	railwayPollRandOnce.Do(func() {
-		railwayPollRand = rand.New(rand.NewSource(time.Now().UnixNano()))
-	})
-	railwayPollRandMu.Lock()
-	defer railwayPollRandMu.Unlock()
-	// Centered jitter in [-fraction, +fraction] * d.
-	delta := (railwayPollRand.Float64()*2 - 1) * railwayPollJitterFraction
-	jittered := time.Duration(float64(d) * (1 + delta))
-	if jittered <= 0 {
-		return d
-	}
-	return jittered
-}
 
 func NewRailwayBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	cfg.Provider = providerName
@@ -64,14 +26,6 @@ type railwayBackend struct {
 	cfg    Config
 	rt     Runtime
 	client railwayAPI
-
-	// pollOverride lets tests shrink the polling interval without changing the
-	// production defaults. When zero, railwayPollInitialInterval is used.
-	pollInitialOverride time.Duration
-	// pollOverallOverride lets tests shorten the overall poll timeout.
-	pollOverallOverride time.Duration
-	// deployResolveOverride lets tests shorten empty-trigger deployment resolution.
-	deployResolveOverride time.Duration
 }
 
 func (b *railwayBackend) Spec() ProviderSpec { return b.spec }
@@ -98,201 +52,6 @@ func (b *railwayBackend) Run(ctx context.Context, req RunRequest) (RunResult, er
 		return RunResult{}, exit(2, "missing command")
 	}
 	return RunResult{}, exit(2, "provider=%s cannot execute arbitrary run commands; Railway only runs the service's configured start command", providerName)
-}
-
-func (b *railwayBackend) redeployService(ctx context.Context, serviceID string) (RunResult, error) {
-	projectID, environmentID, err := b.requireProjectEnv()
-	if err != nil {
-		return RunResult{}, err
-	}
-	client, err := b.api()
-	if err != nil {
-		return RunResult{}, err
-	}
-	started := b.now()
-	fmt.Fprintf(b.rt.Stderr, "redeploying %s service=%s (Railway runs the service's configured start command)\n", providerName, serviceID)
-
-	previousDeployment, previousErr := client.LatestDeployment(ctx, projectID, environmentID, serviceID)
-	deploymentID, err := client.TriggerDeploy(ctx, projectID, environmentID, serviceID)
-	if err != nil {
-		return RunResult{}, ExitError{Code: 1, Message: fmt.Sprintf("%s trigger deploy failed: %v", providerName, err)}
-	}
-	deploymentID = strings.TrimSpace(deploymentID)
-	if deploymentID == "" {
-		if previousErr != nil {
-			return RunResult{ExitCode: 1}, ExitError{Code: 1, Message: fmt.Sprintf("%s read latest deployment before trigger failed: %v", providerName, previousErr)}
-		}
-		deploymentID, err = b.resolveTriggeredDeployment(ctx, client, projectID, environmentID, serviceID, previousDeployment.ID)
-		if err != nil {
-			return RunResult{ExitCode: 1}, ExitError{Code: 1, Message: fmt.Sprintf("%s resolve triggered deployment failed: %v", providerName, err)}
-		}
-	}
-
-	logs := &railwayLogStreamer{out: b.rt.Stdout}
-	finalStatus, pollErr := b.pollDeployment(ctx, client, deploymentID, logs)
-	if pollErr != nil {
-		commandDuration := b.now().Sub(started)
-		return RunResult{ExitCode: 1, Command: commandDuration, Total: commandDuration}, ExitError{Code: 1, Message: fmt.Sprintf("%s deployment %s polling failed: %v", providerName, deploymentID, pollErr)}
-	}
-
-	commandDuration := b.now().Sub(started)
-	result := RunResult{
-		ExitCode: finalStatus.ExitCode(),
-		Command:  commandDuration,
-		Total:    commandDuration,
-	}
-	fmt.Fprintf(b.rt.Stderr, "%s redeploy summary elapsed=%s exit=%d status=%s\n", providerName, result.Total.Round(time.Millisecond), result.ExitCode, finalStatus)
-	if result.ExitCode != 0 {
-		return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s deployment status=%s", providerName, finalStatus)}
-	}
-	return result, nil
-}
-
-func (b *railwayBackend) resolveTriggeredDeployment(ctx context.Context, client railwayAPI, projectID, environmentID, serviceID, previousID string) (string, error) {
-	overall := railwayDeployResolveTimeout
-	if b.deployResolveOverride > 0 {
-		overall = b.deployResolveOverride
-	}
-	deadlineCtx, cancel := context.WithTimeout(ctx, overall)
-	defer cancel()
-
-	interval := railwayPollInitialInterval
-	if b.pollInitialOverride > 0 {
-		interval = b.pollInitialOverride
-	}
-	for {
-		deployment, err := client.LatestDeployment(deadlineCtx, projectID, environmentID, serviceID)
-		if err != nil {
-			if deadlineCtx.Err() != nil {
-				return "", fmt.Errorf("deployment resolution cancelled: %w", deadlineCtx.Err())
-			}
-			return "", err
-		}
-		deploymentID := strings.TrimSpace(deployment.ID)
-		if deploymentID != "" && deploymentID != strings.TrimSpace(previousID) {
-			return deploymentID, nil
-		}
-		sleepFor := railwayJitter(interval)
-		select {
-		case <-deadlineCtx.Done():
-			return "", fmt.Errorf("deployment resolution cancelled: %w", deadlineCtx.Err())
-		case <-time.After(sleepFor):
-		}
-		if interval < railwayPollMaxInterval {
-			interval *= 2
-			if interval > railwayPollMaxInterval {
-				interval = railwayPollMaxInterval
-			}
-		}
-	}
-}
-
-// pollDeployment polls a specific deployment until it reaches a terminal state
-// or the overall timeout / parent context expires. Returns the final observed
-// status on success.
-func (b *railwayBackend) pollDeployment(ctx context.Context, client railwayAPI, deploymentID string, logs *railwayLogStreamer) (railwayDeploymentStatus, error) {
-	overall := railwayPollOverallTimeout
-	if b.pollOverallOverride > 0 {
-		overall = b.pollOverallOverride
-	}
-	deadlineCtx, cancel := context.WithTimeout(ctx, overall)
-	defer cancel()
-
-	initial := railwayPollInitialInterval
-	if b.pollInitialOverride > 0 {
-		initial = b.pollInitialOverride
-	}
-	interval := initial
-
-	for {
-		dep, err := client.Deployment(deadlineCtx, deploymentID)
-		if err != nil {
-			// Bubble up context errors as-is so the caller can tell timeout from
-			// transport failures.
-			if deadlineCtx.Err() != nil {
-				return "", fmt.Errorf("polling cancelled: %w", deadlineCtx.Err())
-			}
-			return "", err
-		}
-		if dep.Status.IsTerminal() {
-			if logs != nil {
-				if err := logs.Flush(deadlineCtx, client, deploymentID); err != nil {
-					return "", err
-				}
-			}
-			return dep.Status, nil
-		}
-		if logs != nil {
-			if err := logs.Flush(deadlineCtx, client, deploymentID); err != nil {
-				return "", err
-			}
-		}
-		// Backoff with ±jitter, capped at railwayPollMaxInterval.
-		sleepFor := railwayJitter(interval)
-		select {
-		case <-deadlineCtx.Done():
-			return "", fmt.Errorf("polling cancelled: %w", deadlineCtx.Err())
-		case <-time.After(sleepFor):
-		}
-		if interval < railwayPollMaxInterval {
-			interval *= 2
-			if interval > railwayPollMaxInterval {
-				interval = railwayPollMaxInterval
-			}
-		}
-	}
-}
-
-type railwayLogStreamer struct {
-	out            io.Writer
-	buildSeen      []string
-	deploymentSeen []string
-}
-
-func (s *railwayLogStreamer) Flush(ctx context.Context, client railwayAPI, deploymentID string) error {
-	buildLogs, err := client.BuildLogs(ctx, deploymentID, railwayPollLogLimit)
-	if err != nil {
-		return fmt.Errorf("fetch build logs: %w", err)
-	}
-	s.buildSeen = printNewRailwayLogs(s.out, buildLogs, s.buildSeen)
-
-	deploymentLogs, err := client.DeploymentLogs(ctx, deploymentID, railwayPollLogLimit)
-	if err != nil {
-		return fmt.Errorf("fetch deployment logs: %w", err)
-	}
-	s.deploymentSeen = printNewRailwayLogs(s.out, deploymentLogs, s.deploymentSeen)
-	return nil
-}
-
-func printNewRailwayLogs(out io.Writer, lines []string, seen []string) []string {
-	start := overlappingRailwayLogLines(seen, lines)
-	for _, line := range lines[start:] {
-		fmt.Fprintln(out, line)
-	}
-	next := make([]string, len(lines))
-	copy(next, lines)
-	return next
-}
-
-func overlappingRailwayLogLines(previous, current []string) int {
-	n := len(previous)
-	if len(current) < n {
-		n = len(current)
-	}
-	for overlap := n; overlap > 0; overlap-- {
-		match := true
-		previousStart := len(previous) - overlap
-		for i := 0; i < overlap; i++ {
-			if previous[previousStart+i] != current[i] {
-				match = false
-				break
-			}
-		}
-		if match {
-			return overlap
-		}
-	}
-	return 0
 }
 
 func (b *railwayBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
@@ -584,11 +343,4 @@ func rejectRailwayRunOptions(req RunRequest) error {
 		return exit(2, "provider=%s cannot forward per-run environment variables", providerName)
 	}
 	return nil
-}
-
-func (b *railwayBackend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -10,10 +10,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
@@ -529,27 +529,33 @@ func TestRailwayRunRejectsArbitraryCommandBeforeDeploy(t *testing.T) {
 	cfg.Railway.ProjectID = "proj-1"
 	cfg.Railway.EnvironmentID = "env-1"
 	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
-	_, err := backend.Run(context.Background(), RunRequest{NoSync: true, ID: "svc-1", Command: []string{"false"}})
-	if err == nil || !strings.Contains(err.Error(), "cannot execute arbitrary run commands") {
+	result, err := backend.Run(context.Background(), RunRequest{NoSync: true, ID: "svc-1", Command: []string{"false"}})
+	var exitErr ExitError
+	wantMessage := "provider=railway cannot execute arbitrary run commands; Railway only runs the service's configured start command"
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 || exitErr.Message != wantMessage {
 		t.Fatalf("err = %v, want unsupported command rejection", err)
 	}
-	if api.triggerServiceID != "" || api.latestCalls != 0 || api.pollCalls != 0 {
-		t.Fatalf("Run touched Railway API: trigger=%q latest=%d poll=%d", api.triggerServiceID, api.latestCalls, api.pollCalls)
+	if !reflect.DeepEqual(result, RunResult{}) {
+		t.Fatalf("result = %#v, want zero result", result)
+	}
+	if len(api.calls) != 0 {
+		t.Fatalf("Run touched Railway API: %v", api.calls)
 	}
 }
 
-func TestRailwayRedeployRequiresProjectAndEnvironment(t *testing.T) {
-	backend := &railwayBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-	_, err := backend.redeployService(context.Background(), "svc-1")
-	if err == nil || !strings.Contains(err.Error(), "--railway-project") {
-		t.Fatalf("err = %v, want --railway-project rejection", err)
+func TestRailwayRunRequiresCommand(t *testing.T) {
+	api := &fakeRailwayAPI{}
+	backend := newRailwayBackendForTest(api)
+	result, err := backend.Run(context.Background(), RunRequest{NoSync: true, ID: "svc-1"})
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 || exitErr.Message != "missing command" {
+		t.Fatalf("err = %v, want missing command rejection", err)
 	}
-	cfg := Config{}
-	cfg.Railway.ProjectID = "proj-1"
-	backend2 := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-	_, err = backend2.redeployService(context.Background(), "svc-1")
-	if err == nil || !strings.Contains(err.Error(), "--railway-environment") {
-		t.Fatalf("err = %v, want --railway-environment rejection", err)
+	if !reflect.DeepEqual(result, RunResult{}) {
+		t.Fatalf("result = %#v, want zero result", result)
+	}
+	if len(api.calls) != 0 {
+		t.Fatalf("Run touched Railway API: %v", api.calls)
 	}
 }
 
@@ -606,32 +612,16 @@ func TestRailwayClientRejectsFalseStopDeploymentResponse(t *testing.T) {
 }
 
 type fakeRailwayAPI struct {
-	mu                   sync.Mutex
-	triggerProjectID     string
-	triggerEnvironmentID string
-	triggerServiceID     string
-	deployID             string
-	buildLogs            []string
-	buildLogsForID       string
-	logs                 []string
-	logsForID            string
-	deployment           railwayDeployment
-	latestDeployments    []railwayDeployment
-	latestCalls          int
-	// pollStatuses, when non-empty, is the sequence of statuses returned by
-	// Deployment() one call at a time. The last entry is replayed forever so
-	// callers can model "many non-terminal polls then a terminal one".
-	pollStatuses    []railwayDeploymentStatus
+	mu              sync.Mutex
+	calls           []string
+	deployment      railwayDeployment
+	latestCalls     int
 	pollCalls       int
-	deploymentErr   error
-	deploymentBlock chan struct{}
 	services        []railwayService
 	service         railwayService
 	getServiceCalls int
 	stopID          string
 	stopErr         error
-	triggerErr      error
-	logsErr         error
 	listErr         error
 	latestErr       error
 }
@@ -639,75 +629,47 @@ type fakeRailwayAPI struct {
 func (f *fakeRailwayAPI) TriggerDeploy(_ context.Context, projectID, environmentID, serviceID string) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.triggerProjectID = projectID
-	f.triggerEnvironmentID = environmentID
-	f.triggerServiceID = serviceID
-	return f.deployID, f.triggerErr
+	f.calls = append(f.calls, "TriggerDeploy")
+	return "", nil
 }
 
 func (f *fakeRailwayAPI) BuildLogs(_ context.Context, deploymentID string, _ int) ([]string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.buildLogsForID = deploymentID
-	return f.buildLogs, nil
+	f.calls = append(f.calls, "BuildLogs")
+	return nil, nil
 }
 
 func (f *fakeRailwayAPI) DeploymentLogs(_ context.Context, deploymentID string, _ int) ([]string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.logsForID = deploymentID
-	return f.logs, f.logsErr
+	f.calls = append(f.calls, "DeploymentLogs")
+	return nil, nil
 }
 
 func (f *fakeRailwayAPI) LatestDeployment(_ context.Context, _, _, _ string) (railwayDeployment, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.calls = append(f.calls, "LatestDeployment")
 	f.latestCalls++
 	if f.latestErr != nil {
 		return railwayDeployment{}, f.latestErr
-	}
-	if len(f.latestDeployments) > 0 {
-		idx := f.latestCalls - 1
-		if idx >= len(f.latestDeployments) {
-			idx = len(f.latestDeployments) - 1
-		}
-		return f.latestDeployments[idx], nil
 	}
 	return f.deployment, nil
 }
 
 func (f *fakeRailwayAPI) Deployment(ctx context.Context, deploymentID string) (railwayDeployment, error) {
-	// Optional gate that lets a test hold the call open so the polling loop can
-	// observe context-deadline cancellation.
-	f.mu.Lock()
-	block := f.deploymentBlock
-	f.mu.Unlock()
-	if block != nil {
-		select {
-		case <-block:
-		case <-ctx.Done():
-			return railwayDeployment{}, ctx.Err()
-		}
-	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.calls = append(f.calls, "Deployment")
 	f.pollCalls++
-	if f.deploymentErr != nil {
-		return railwayDeployment{}, f.deploymentErr
-	}
-	if len(f.pollStatuses) == 0 {
-		return railwayDeployment{ID: deploymentID, Status: f.deployment.Status}, nil
-	}
-	idx := f.pollCalls - 1
-	if idx >= len(f.pollStatuses) {
-		idx = len(f.pollStatuses) - 1
-	}
-	return railwayDeployment{ID: deploymentID, Status: f.pollStatuses[idx]}, nil
+	return railwayDeployment{ID: deploymentID, Status: f.deployment.Status}, nil
 }
 
 func (f *fakeRailwayAPI) StopDeployment(_ context.Context, id string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.calls = append(f.calls, "StopDeployment")
 	f.stopID = id
 	return f.stopErr
 }
@@ -715,12 +677,14 @@ func (f *fakeRailwayAPI) StopDeployment(_ context.Context, id string) error {
 func (f *fakeRailwayAPI) ListServices(_ context.Context) ([]railwayService, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.calls = append(f.calls, "ListServices")
 	return f.services, f.listErr
 }
 
 func (f *fakeRailwayAPI) GetService(_ context.Context, _ string) (railwayService, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.calls = append(f.calls, "GetService")
 	f.getServiceCalls++
 	return f.service, nil
 }
@@ -733,231 +697,10 @@ func newRailwayBackendForTest(api *fakeRailwayAPI) *railwayBackend {
 	cfg.Railway.EnvironmentID = "env-1"
 	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard}
 	return &railwayBackend{
-		spec:                  Provider{}.Spec(),
-		cfg:                   cfg,
-		rt:                    rt,
-		client:                api,
-		pollInitialOverride:   time.Millisecond,
-		pollOverallOverride:   5 * time.Second,
-		deployResolveOverride: 5 * time.Second,
-	}
-}
-
-func TestRailwayRedeployHappyPath(t *testing.T) {
-	api := &fakeRailwayAPI{
-		deployID: "dep-1",
-		// Trigger returns dep-1; the poll loop sees one non-terminal status before
-		// terminating on SUCCESS; logs are then fetched against that exact id.
-		pollStatuses: []railwayDeploymentStatus{railwayStatusDeploying, railwayStatusSuccess},
-		buildLogs:    []string{"building image"},
-		logs:         []string{"+ pnpm test", "PASS suite (1.2s)"},
-	}
-	backend := newRailwayBackendForTest(api)
-	result, err := backend.redeployService(context.Background(), "svc-1")
-	if err != nil {
-		t.Fatalf("Run error: %v", err)
-	}
-	if result.ExitCode != 0 {
-		t.Fatalf("exit code = %d, want 0", result.ExitCode)
-	}
-	if api.triggerServiceID != "svc-1" || api.triggerProjectID != "proj-1" || api.triggerEnvironmentID != "env-1" {
-		t.Fatalf("trigger called with svc=%q proj=%q env=%q", api.triggerServiceID, api.triggerProjectID, api.triggerEnvironmentID)
-	}
-	if api.logsForID != "dep-1" {
-		t.Fatalf("logs fetched for id=%q, want dep-1 (new deployment, not stale)", api.logsForID)
-	}
-	if api.buildLogsForID != "dep-1" {
-		t.Fatalf("build logs fetched for id=%q, want dep-1 (new deployment, not stale)", api.buildLogsForID)
-	}
-	if api.pollCalls < 2 {
-		t.Fatalf("poll calls = %d, want at least 2 (DEPLOYING then SUCCESS)", api.pollCalls)
-	}
-}
-
-func TestRailwayRedeployFailedDeploymentMapsToExit1(t *testing.T) {
-	api := &fakeRailwayAPI{
-		deployID:     "dep-1",
-		pollStatuses: []railwayDeploymentStatus{railwayStatusFailed},
-	}
-	backend := newRailwayBackendForTest(api)
-	result, err := backend.redeployService(context.Background(), "svc-1")
-	if err == nil {
-		t.Fatal("Run accepted FAILED deployment status")
-	}
-	if result.ExitCode != 1 {
-		t.Fatalf("exit code = %d, want 1", result.ExitCode)
-	}
-}
-
-func TestRailwayRedeployPollsDeployingThenSuccess(t *testing.T) {
-	api := &fakeRailwayAPI{
-		deployID:     "dep-new",
-		pollStatuses: []railwayDeploymentStatus{railwayStatusQueued, railwayStatusBuilding, railwayStatusDeploying, railwayStatusSuccess},
-		logs:         []string{"ok"},
-	}
-	backend := newRailwayBackendForTest(api)
-	result, err := backend.redeployService(context.Background(), "svc-1")
-	if err != nil {
-		t.Fatalf("Run err: %v", err)
-	}
-	if result.ExitCode != 0 {
-		t.Fatalf("exit code = %d, want 0", result.ExitCode)
-	}
-	if api.pollCalls != 4 {
-		t.Fatalf("poll calls = %d, want 4 (queued, building, deploying, success)", api.pollCalls)
-	}
-}
-
-func TestRailwayRedeployResolvesDeploymentWhenTriggerReturnsNoID(t *testing.T) {
-	api := &fakeRailwayAPI{
-		deployID: "",
-		latestDeployments: []railwayDeployment{
-			{ID: "dep-old", Status: railwayStatusSuccess},
-			{ID: "dep-old", Status: railwayStatusSuccess},
-			{ID: "dep-new", Status: railwayStatusQueued},
-		},
-		pollStatuses: []railwayDeploymentStatus{railwayStatusSuccess},
-		logs:         []string{"ok"},
-	}
-	backend := newRailwayBackendForTest(api)
-	result, err := backend.redeployService(context.Background(), "svc-1")
-	if err != nil {
-		t.Fatalf("Run err: %v", err)
-	}
-	if result.ExitCode != 0 {
-		t.Fatalf("exit code = %d, want 0", result.ExitCode)
-	}
-	if api.logsForID != "dep-new" {
-		t.Fatalf("logs fetched for id=%q, want dep-new", api.logsForID)
-	}
-	if api.latestCalls < 3 {
-		t.Fatalf("latest calls = %d, want fallback polling", api.latestCalls)
-	}
-}
-
-func TestRailwayRedeployRequiresPreviousDeploymentReadWhenTriggerReturnsNoID(t *testing.T) {
-	api := &fakeRailwayAPI{
-		deployID:  "",
-		latestErr: fmt.Errorf("latest unavailable"),
-	}
-	backend := newRailwayBackendForTest(api)
-	result, err := backend.redeployService(context.Background(), "svc-1")
-	if err == nil {
-		t.Fatal("Run accepted boolean trigger fallback without a trusted previous deployment")
-	}
-	if result.ExitCode == 0 {
-		t.Fatalf("exit code = %d, want non-zero on failed previous deployment read", result.ExitCode)
-	}
-	if !strings.Contains(err.Error(), "read latest deployment before trigger failed") {
-		t.Fatalf("err = %v, want previous deployment read message", err)
-	}
-	if api.triggerServiceID != "svc-1" {
-		t.Fatalf("trigger service = %q, want svc-1", api.triggerServiceID)
-	}
-}
-
-func TestRailwayRedeployIgnoresPreviousDeploymentReadErrorWhenTriggerReturnsID(t *testing.T) {
-	api := &fakeRailwayAPI{
-		deployID:     "dep-1",
-		latestErr:    fmt.Errorf("latest unavailable"),
-		pollStatuses: []railwayDeploymentStatus{railwayStatusSuccess},
-	}
-	backend := newRailwayBackendForTest(api)
-	result, err := backend.redeployService(context.Background(), "svc-1")
-	if err != nil {
-		t.Fatalf("Run err: %v", err)
-	}
-	if result.ExitCode != 0 {
-		t.Fatalf("exit code = %d, want 0", result.ExitCode)
-	}
-}
-
-func TestRailwayRedeployTreatsSleepingAsSuccessfulTerminalStatus(t *testing.T) {
-	api := &fakeRailwayAPI{
-		deployID:     "dep-1",
-		pollStatuses: []railwayDeploymentStatus{railwayStatusSleeping},
-		logs:         []string{"service is sleeping"},
-	}
-	backend := newRailwayBackendForTest(api)
-	result, err := backend.redeployService(context.Background(), "svc-1")
-	if err != nil {
-		t.Fatalf("Run err: %v", err)
-	}
-	if result.ExitCode != 0 {
-		t.Fatalf("exit code = %d, want 0", result.ExitCode)
-	}
-	if api.pollCalls != 1 {
-		t.Fatalf("poll calls = %d, want 1 for terminal SLEEPING", api.pollCalls)
-	}
-}
-
-func TestRailwayRedeployStreamsBuildAndDeploymentLogsWithoutDuplicates(t *testing.T) {
-	var stdout strings.Builder
-	api := &fakeRailwayAPI{
-		deployID:     "dep-1",
-		pollStatuses: []railwayDeploymentStatus{railwayStatusDeploying, railwayStatusSuccess},
-		buildLogs:    []string{"build line"},
-		logs:         []string{"deploy line"},
-	}
-	backend := newRailwayBackendForTest(api)
-	backend.rt.Stdout = &stdout
-	if _, err := backend.redeployService(context.Background(), "svc-1"); err != nil {
-		t.Fatalf("Run err: %v", err)
-	}
-	out := stdout.String()
-	if strings.Count(out, "build line") != 1 {
-		t.Fatalf("stdout = %q, want build line once", out)
-	}
-	if strings.Count(out, "deploy line") != 1 {
-		t.Fatalf("stdout = %q, want deploy line once", out)
-	}
-}
-
-func TestRailwayLogStreamerPrintsRollingWindowsOnce(t *testing.T) {
-	var stdout strings.Builder
-	var seen []string
-	seen = printNewRailwayLogs(&stdout, []string{"build 1", "build 2", "build 3"}, seen)
-	seen = printNewRailwayLogs(&stdout, []string{"build 1", "build 2", "build 3"}, seen)
-	seen = printNewRailwayLogs(&stdout, []string{"build 2", "build 3", "build 4"}, seen)
-	seen = printNewRailwayLogs(&stdout, []string{"build 3", "build 4", "build 5"}, seen)
-	if got := stdout.String(); got != "build 1\nbuild 2\nbuild 3\nbuild 4\nbuild 5\n" {
-		t.Fatalf("stdout = %q", got)
-	}
-}
-
-func TestRailwayRedeployReturnsErrorWhenTriggerYieldsEmptyID(t *testing.T) {
-	api := &fakeRailwayAPI{deployID: ""}
-	backend := newRailwayBackendForTest(api)
-	backend.deployResolveOverride = 25 * time.Millisecond
-	result, err := backend.redeployService(context.Background(), "svc-1")
-	if err == nil {
-		t.Fatal("Run accepted empty deployment id from TriggerDeploy")
-	}
-	if result.ExitCode == 0 {
-		t.Fatalf("exit code = %d, want non-zero on empty deployment id", result.ExitCode)
-	}
-	if !strings.Contains(err.Error(), "resolve triggered deployment") {
-		t.Fatalf("err = %v, want deployment resolution message", err)
-	}
-}
-
-func TestRailwayRedeployPollingHonorsContextDeadline(t *testing.T) {
-	block := make(chan struct{})
-	api := &fakeRailwayAPI{
-		deployID:        "dep-1",
-		pollStatuses:    []railwayDeploymentStatus{railwayStatusBuilding},
-		deploymentBlock: block,
-	}
-	backend := newRailwayBackendForTest(api)
-	backend.pollInitialOverride = time.Millisecond
-	backend.pollOverallOverride = 25 * time.Millisecond
-	defer close(block) // unblock at the end of the test so the goroutine exits cleanly
-	_, err := backend.redeployService(context.Background(), "svc-1")
-	if err == nil {
-		t.Fatal("Run accepted hung deployment status")
-	}
-	if !strings.Contains(err.Error(), "polling") && !strings.Contains(err.Error(), "deadline") {
-		t.Fatalf("err = %v, want polling/deadline message", err)
+		spec:   Provider{}.Spec(),
+		cfg:    cfg,
+		rt:     rt,
+		client: api,
 	}
 }
 
@@ -1013,31 +756,6 @@ func TestRailwayDeploymentStatusNormalizesOnUnmarshal(t *testing.T) {
 	}
 	if !dep.Status.IsTerminal() {
 		t.Fatal("normalized SUCCESS must be terminal")
-	}
-}
-
-// failingDeploymentClient lets the polling-error test thread a fake error
-// through Deployment() without bypassing the fakeRailwayAPI mutex.
-type failingDeploymentClient struct {
-	*fakeRailwayAPI
-	err error
-}
-
-func (f *failingDeploymentClient) Deployment(_ context.Context, _ string) (railwayDeployment, error) {
-	return railwayDeployment{}, f.err
-}
-
-func TestRailwayRedeploySurfacesPollingTransportError(t *testing.T) {
-	api := &fakeRailwayAPI{deployID: "dep-1"}
-	wrapped := &failingDeploymentClient{fakeRailwayAPI: api, err: fmt.Errorf("network broken")}
-	backend := newRailwayBackendForTest(api)
-	backend.client = wrapped
-	_, err := backend.redeployService(context.Background(), "svc-1")
-	if err == nil {
-		t.Fatal("Run accepted polling transport failure")
-	}
-	if !strings.Contains(err.Error(), "network broken") {
-		t.Fatalf("err = %v, want surfaced transport error", err)
 	}
 }
 

--- a/internal/providers/railway/client.go
+++ b/internal/providers/railway/client.go
@@ -15,13 +15,13 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-// railwayAPI is the minimal Railway GraphQL surface the provider needs.
+// railwayAPI is the Railway GraphQL client surface.
 //
 // Railway has no synchronous exec endpoint, so the provider models a "sandbox"
-// as a Railway service inside a project. Run redeploys the latest deployment
-// via deploymentRedeploy and surfaces deployment logs; List enumerates
-// services across visible projects; Status fetches the latest deployment for a
-// service; Stop calls deploymentStop on that latest deployment.
+// as a Railway service inside a project. Run rejects arbitrary commands before
+// calling the API; List enumerates services across visible projects; Status
+// fetches the latest deployment for a service; Stop calls deploymentStop only
+// for the exact claimed deployment.
 type railwayAPI interface {
 	TriggerDeploy(ctx context.Context, projectID, environmentID, serviceID string) (string, error)
 	BuildLogs(ctx context.Context, deploymentID string, limit int) ([]string, error)


### PR DESCRIPTION
## What Problem This Solves

The Railway provider carried redeploy polling, log streaming, and status handling that production code could not reach because `Run` rejects arbitrary commands before entering that path. The dead implementation and its test-only callers increased maintenance surface and obscured the provider's actual execution contract.

## Why This Change Was Made

Remove the unreachable private redeploy implementation and tests while preserving all live provider behavior, public API methods, bridge methods, claims, and registration. Align the README and client comment with the existing `Run` rejection contract.

## User Impact

No user-visible behavior changes. Railway `Run` continues to reject arbitrary commands with exit code 2, while live `Run`, `Status`, and `Stop` controls retain their existing behavior.

## Evidence

- Independent review found the eight removed private functions unreachable from production and reachable only from the deleted tests.
- The six-target reachability audit at https://github.com/openclaw/crabbox/actions/runs/33887555449/attempts/1 reported all eight candidates dead in production for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, `linux/arm64`, `windows/amd64`, and `windows/arm64`; it also reported `Run`, `Status`, and `Stop` live. This audit establishes reachability on the pre-change source, not post-change binary compilation.
- Independent review confirmed 39 retained Railway tests and byte-identical retained production functions.
- `git diff --check 0f11089ee08fde86fb8e2088a326ac7e856497b3..ec2df98c6a0a7b71ee77de51eb27bfeb6475f788`
- PR CI will run Go formatting, vet, deadcode, race tests, and the native CLI build. A separate report-only exact-head six-target CLI build is proposed as the remaining pre-merge gate because current PR CI does not cover that matrix.
