### PR TITLE
refactor: remove production-only test helpers

### DIFF
--- a/internal/cli/artifacts_publish.go
+++ b/internal/cli/artifacts_publish.go
@@ -596,19 +596,6 @@ func defaultArtifactPublishPrefix(opts artifactPublishOptions, now time.Time) st
 	return strings.Join([]string{scope, bundle, stamp}, "/")
 }
 
-func uploadArtifactGrant(ctx context.Context, path string, grant CoordinatorArtifactUploadGrant) error {
-	file, err := os.Open(path)
-	if err != nil {
-		return exit(2, "open artifact %s: %v", grant.Name, err)
-	}
-	defer file.Close()
-	info, err := file.Stat()
-	if err != nil {
-		return exit(2, "stat artifact %s: %v", grant.Name, err)
-	}
-	return uploadArtifactGrantReader(ctx, file, info.Size(), grant)
-}
-
 func uploadArtifactGrantSnapshot(ctx context.Context, file artifactFile, grant CoordinatorArtifactUploadGrant) error {
 	if err := requireArtifactSnapshot(file); err != nil {
 		return err

--- a/internal/cli/artifacts_test.go
+++ b/internal/cli/artifacts_test.go
@@ -19,6 +19,19 @@ import (
 	"time"
 )
 
+func uploadArtifactGrant(ctx context.Context, path string, grant CoordinatorArtifactUploadGrant) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return exit(2, "open artifact %s: %v", grant.Name, err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return exit(2, "stat artifact %s: %v", grant.Name, err)
+	}
+	return uploadArtifactGrantReader(ctx, file, info.Size(), grant)
+}
+
 func TestParseArtifactPublishOptionsNormalizesStorage(t *testing.T) {
 	opts, err := parseArtifactPublishOptions([]string{
 		"--dir", "bundle",

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -1829,23 +1829,6 @@ func validateLeaseClaimFileIdentity(leaseID string, claim leaseClaim, exists boo
 	return nil
 }
 
-func leaseClaimExists(leaseID string) (bool, error) {
-	path, err := leaseClaimPath(leaseID)
-	if err != nil {
-		var invalid invalidLeaseClaimIDError
-		if errors.As(err, &invalid) {
-			return false, nil
-		}
-		return false, err
-	}
-	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	} else if err != nil {
-		return false, exit(2, "inspect claim %s: %v", path, err)
-	}
-	return true, nil
-}
-
 func readLeaseClaimPathWithPresence(path string) (leaseClaim, bool, error) {
 	// Share deletion on Windows; open nonblocking on Unix so a FIFO cannot hang.
 	file, err := openArtifactReadOnly(path)

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -1802,15 +1802,6 @@ func TestConditionalClaimHelpersAndExactResolution(t *testing.T) {
 			t.Fatalf("leaseClaimMatchesIdentifier(%q)=%v want %v", identifier, got, want)
 		}
 	}
-	if exists, err := leaseClaimExists(leaseID); err != nil || !exists {
-		t.Fatalf("existing claim exists=%v err=%v", exists, err)
-	}
-	if exists, err := leaseClaimExists("cbx_missingclaim123"); err != nil || exists {
-		t.Fatalf("missing claim exists=%v err=%v", exists, err)
-	}
-	if exists, err := leaseClaimExists("../invalid"); err != nil || exists {
-		t.Fatalf("invalid claim exists=%v err=%v", exists, err)
-	}
 }
 
 func TestResolveLeaseClaimForProviderCloudIDRejectsDuplicates(t *testing.T) {

--- a/internal/cli/pond_mesh.go
+++ b/internal/cli/pond_mesh.go
@@ -1236,20 +1236,3 @@ func runPondMeshForwards(ctx context.Context, opts pondConnectOptions, members [
 	wg.Wait()
 	return errors.Join(firstErr, closeErr)
 }
-
-// pondMeshDoctorCounts inspects a slice of servers (already filtered by
-// pond) and returns the per-plane summary doctor surfaces. The function is
-// intentionally pure: no network, no SSH, no provider calls. doctor invokes
-// it from doctorPondMeshSummary so the test suite exercises every branch
-// without spawning subprocesses.
-func pondMeshDoctorCounts(servers []Server) (memberCount, exposedCount, totalPorts int) {
-	for _, server := range servers {
-		memberCount++
-		ports := parseExposedPortsLabel(server.Labels[pondExposedPortsLabelKey])
-		if len(ports) > 0 {
-			exposedCount++
-			totalPorts += len(ports)
-		}
-	}
-	return memberCount, exposedCount, totalPorts
-}

--- a/internal/cli/pond_mesh_test.go
+++ b/internal/cli/pond_mesh_test.go
@@ -268,25 +268,6 @@ func TestParseExposedPortsLabelTolerantOfGarbage(t *testing.T) {
 	}
 }
 
-func TestPondMeshDoctorCounts(t *testing.T) {
-	servers := []Server{
-		{Name: "web", Labels: map[string]string{pondLabelKey: "alpha", pondExposedPortsLabelKey: "8080-9090"}},
-		{Name: "client", Labels: map[string]string{pondLabelKey: "alpha"}},
-		{Name: "worker", Labels: map[string]string{pondLabelKey: "alpha", pondExposedPortsLabelKey: "3000"}},
-	}
-	members, exposed, ports := pondMeshDoctorCounts(servers)
-	if members != 3 || exposed != 2 || ports != 3 {
-		t.Fatalf("counts=(%d,%d,%d) want (3,2,3)", members, exposed, ports)
-	}
-}
-
-func TestPondMeshDoctorCountsEmpty(t *testing.T) {
-	members, exposed, ports := pondMeshDoctorCounts(nil)
-	if members != 0 || exposed != 0 || ports != 0 {
-		t.Fatalf("counts=(%d,%d,%d) want (0,0,0)", members, exposed, ports)
-	}
-}
-
 func TestPreparePondMeshSummaryRendersHostsAndEnv(t *testing.T) {
 	tmp := t.TempDir()
 	members := []pondMember{

--- a/internal/providers/agentsandbox/kubernetes.go
+++ b/internal/providers/agentsandbox/kubernetes.go
@@ -788,22 +788,6 @@ func resolveSandboxPod(
 	return podState{}, fmt.Errorf("%w: Sandbox %s has no pod annotation or selector", errNotReady, sandbox.Metadata.Name)
 }
 
-func waitForSandboxReadiness(ctx context.Context, client kubernetesClient, namespace, claimName string, identity claimIdentity, poll time.Duration) (sandboxReadiness, error) {
-	resource, err := waitForSandboxResourceReadiness(ctx, client, namespace, claimName, identity, poll)
-	if err != nil {
-		return sandboxReadiness{}, err
-	}
-	pod, err := waitForSandboxPodReadiness(ctx, client, namespace, resource.ClaimName, resource.Sandbox, identity, poll)
-	if err != nil {
-		return sandboxReadiness{}, err
-	}
-	container, err := resolvePodContainer(pod, identity.Container)
-	if err != nil {
-		return sandboxReadiness{}, err
-	}
-	return newSandboxReadiness(resource, pod, identity, container), nil
-}
-
 func waitForSandboxReadinessWithTimeouts(ctx context.Context, client kubernetesClient, namespace, claimName string, identity claimIdentity, sandboxTimeout, podTimeout, poll time.Duration) (sandboxReadiness, error) {
 	sandboxCtx := ctx
 	sandboxCancel := func() {}

--- a/internal/providers/agentsandbox/kubernetes_test.go
+++ b/internal/providers/agentsandbox/kubernetes_test.go
@@ -516,7 +516,7 @@ func TestWaitForSandboxReadinessRetriesTransientKubernetesErrors(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	ready, err := waitForSandboxReadiness(ctx, fake, "sandboxes", "claim-a", fakeClaimIdentity(cfg), time.Millisecond)
+	ready, err := waitForSandboxReadinessWithTimeouts(ctx, fake, "sandboxes", "claim-a", fakeClaimIdentity(cfg), 0, 0, time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -591,7 +591,7 @@ func TestWaitForSandboxReadinessRejectsTerminalStates(t *testing.T) {
 			tt.mutate(fake)
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
-			_, err := waitForSandboxReadiness(ctx, fake, "sandboxes", "claim-a", fakeClaimIdentity(cfg), time.Millisecond)
+			_, err := waitForSandboxReadinessWithTimeouts(ctx, fake, "sandboxes", "claim-a", fakeClaimIdentity(cfg), 0, 0, time.Millisecond)
 			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
 				t.Fatalf("err=%v want substring %q", err, tt.wantError)
 			}
@@ -683,7 +683,7 @@ func TestSandboxReadinessRejectsDownstreamIdentityMismatch(t *testing.T) {
 			tt.mutate(fake)
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
-			_, err := waitForSandboxReadiness(ctx, fake, "sandboxes", "claim-a", fakeClaimIdentity(cfg), time.Millisecond)
+			_, err := waitForSandboxReadinessWithTimeouts(ctx, fake, "sandboxes", "claim-a", fakeClaimIdentity(cfg), 0, 0, time.Millisecond)
 			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
 				t.Fatalf("err=%v want substring %q", err, tt.wantError)
 			}
@@ -909,7 +909,7 @@ func TestWaitForSandboxReadinessTimesOut(t *testing.T) {
 	delete(fake.objects, sandboxClaimResource+"/sandboxes/claim-a")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
-	_, err := waitForSandboxReadiness(ctx, fake, "sandboxes", "claim-a", fakeClaimIdentity(cfg), time.Millisecond)
+	_, err := waitForSandboxReadinessWithTimeouts(ctx, fake, "sandboxes", "claim-a", fakeClaimIdentity(cfg), 0, 0, time.Millisecond)
 	if err == nil || !strings.Contains(err.Error(), "claim-a") {
 		t.Fatalf("err=%v", err)
 	}

--- a/internal/providers/cua/claims.go
+++ b/internal/providers/cua/claims.go
@@ -3,7 +3,6 @@ package cua
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -48,25 +47,6 @@ func cuaAPIKey() string {
 		return key
 	}
 	return os.Getenv("CUA_API_KEY")
-}
-
-func claimLabels(cfg Config, sandboxName, createdAt string, missing bool) map[string]string {
-	workdir, _ := cuaWorkdir(cfg)
-	labels := map[string]string{
-		labelSandboxName: sandboxName,
-		labelImage:       strings.TrimSpace(blank(cfg.Cua.Image, defaultImage)),
-		labelKind:        strings.ToLower(strings.TrimSpace(blank(cfg.Cua.Kind, defaultKind))),
-		labelRegion:      strings.TrimSpace(cfg.Cua.Region),
-		labelWorkdir:     workdir,
-		labelCreatedAt:   strings.TrimSpace(createdAt),
-	}
-	if cfg.TTL > 0 {
-		labels[labelTTLSeconds] = fmt.Sprintf("%d", int64(cfg.TTL/time.Second))
-	}
-	if missing {
-		labels[labelMissing] = "true"
-	}
-	return labels
 }
 
 func claimSandboxName(claim LeaseClaim) string {

--- a/internal/providers/cua/claims_test.go
+++ b/internal/providers/cua/claims_test.go
@@ -2,13 +2,34 @@ package cua
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
+
+func claimLabels(cfg Config, sandboxName, createdAt string, missing bool) map[string]string {
+	workdir, _ := cuaWorkdir(cfg)
+	labels := map[string]string{
+		labelSandboxName: sandboxName,
+		labelImage:       strings.TrimSpace(blank(cfg.Cua.Image, defaultImage)),
+		labelKind:        strings.ToLower(strings.TrimSpace(blank(cfg.Cua.Kind, defaultKind))),
+		labelRegion:      strings.TrimSpace(cfg.Cua.Region),
+		labelWorkdir:     workdir,
+		labelCreatedAt:   strings.TrimSpace(createdAt),
+	}
+	if cfg.TTL > 0 {
+		labels[labelTTLSeconds] = fmt.Sprintf("%d", int64(cfg.TTL/time.Second))
+	}
+	if missing {
+		labels[labelMissing] = "true"
+	}
+	return labels
+}
 
 func TestCUALeaseIDUsesProviderPrefix(t *testing.T) {
 	leaseID := newCUALeaseID()

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -1491,21 +1490,6 @@ func parseFirstIPv4(raw string) string {
 func isUsableIPv4(s string) bool {
 	addr, err := netip.ParseAddr(strings.TrimSpace(s))
 	return err == nil && addr.Is4() && addr.IsGlobalUnicast()
-}
-
-func isIPv4(s string) bool {
-	s = strings.TrimSpace(s)
-	parts := strings.Split(s, ".")
-	if len(parts) != 4 {
-		return false
-	}
-	for _, p := range parts {
-		n, err := strconv.Atoi(p)
-		if err != nil || n < 0 || n > 255 {
-			return false
-		}
-	}
-	return true
 }
 
 func escapePSString(s string) string {

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -351,19 +351,6 @@ func TestParseFirstIPv4(t *testing.T) {
 	}
 }
 
-func TestIsIPv4(t *testing.T) {
-	for _, good := range []string{"192.168.1.1", "10.0.0.1", "172.20.0.5", "0.0.0.0", "255.255.255.255"} {
-		if !isIPv4(good) {
-			t.Fatalf("isIPv4(%q) should be true", good)
-		}
-	}
-	for _, bad := range []string{"fe80::1", "abc", "192.168.1", "192.168.1.1.1", "300.0.0.1"} {
-		if isIPv4(bad) {
-			t.Fatalf("isIPv4(%q) should be false", bad)
-		}
-	}
-}
-
 func TestHypervState(t *testing.T) {
 	tests := map[int]string{
 		2:  "running",

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"slices"
 	"strings"
@@ -1026,20 +1025,4 @@ func errorsJoin(errs ...error) error {
 		out = fmt.Errorf("%v; %w", out, err)
 	}
 	return out
-}
-
-func dataPlaneHostForSandbox(sandboxID, sandboxHost string) string {
-	sandboxID = strings.TrimSpace(sandboxID)
-	sandboxHost = strings.TrimSpace(sandboxHost)
-	if sandboxID == "" || sandboxHost == "" {
-		return ""
-	}
-	if strings.Contains(sandboxHost, "://") {
-		return ""
-	}
-	if _, _, err := net.SplitHostPort(sandboxHost); err == nil {
-		host, _, _ := net.SplitHostPort(sandboxHost)
-		sandboxHost = host
-	}
-	return "boxd-" + sandboxID + "." + sandboxHost
 }

--- a/internal/providers/superserve/client_test.go
+++ b/internal/providers/superserve/client_test.go
@@ -678,16 +678,6 @@ func mustJSONLine(t *testing.T, v any) string {
 	return string(data)
 }
 
-func TestDataPlaneHostForSandbox(t *testing.T) {
-	got := dataPlaneHostForSandbox("sb_123", "sandbox.example.test")
-	if got != "boxd-sb_123.sandbox.example.test" {
-		t.Fatalf("host=%q", got)
-	}
-	if dataPlaneHostForSandbox("", "sandbox.example.test") != "" {
-		t.Fatal("empty sandbox id should not derive host")
-	}
-}
-
 func writeTestJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(v)


### PR DESCRIPTION
## What Problem This Solves

Crabbox production packages carried seven private helpers with no production callers. Five existed only to support isolated tests, while two convenience helpers were shared exclusively by test files. This enlarged the production surface and obscured which behavior is actually shipped.

## Why This Change Was Made

Remove the five dead helper/test pairs, move the CUA claim-label and artifact upload-path helpers unchanged into `_test.go` files, and route four AgentSandbox tests through the existing timeout-aware readiness helper with zero stage timeouts. Provider APIs, interfaces, registration, production call paths, and behavior remain unchanged.

Open PR https://github.com/openclaw/crabbox/pull/1836 also changes the Superserve backend file, but its current head retains the exact helper and test removed here; it is an overlap, not a duplicate.

## User Impact

There is no user-visible behavior change. Developers get a smaller production-only surface while retaining the same active parser, claim ownership, readiness, mesh, and artifact security coverage.

## Evidence

- Independent diff review cleared exact head `717cb09f12fe3e73689a6dbf79051c7032f512d0` and diff SHA-256 `237fa9221c19469e68b2b690bdda76bd671ccb9085cda9a2c465e099c2ca3bf0`.
- A six-target production/test reachability audit found all seven qualified symbols unreachable from production roots and reachable when tests were included on `darwin/amd64`, `darwin/arm64`, `linux/amd64`, `linux/arm64`, `windows/amd64`, and `windows/arm64`.
- Both production-to-test moves are byte-identical.
- `gofmt` and `git diff --check` pass.
- Local Go tests and builds were intentionally not run. Exact-head CI must provide race, vet, CLI, and provider validation. Separate six-target post-change compilation proof is also required before landing.
