### PR TITLE
refactor(worker): remove unused response and key helpers

### DIFF
--- a/worker/src/http.ts
+++ b/worker/src/http.ts
@@ -4,13 +4,6 @@ export function json(data: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(redactStackTraceFields(data)), { ...init, headers });
 }
 
-export function text(message: string, status = 200): Response {
-  return new Response(message, {
-    status,
-    headers: { "content-type": "text/plain; charset=utf-8" },
-  });
-}
-
 export async function readJson<T>(request: Request): Promise<T> {
   const value = (await request.json()) as unknown;
   return value as T;

--- a/worker/src/pairing.ts
+++ b/worker/src/pairing.ts
@@ -140,10 +140,6 @@ export function pairingGrantKey(grantHash: string): string {
   return `pairing-grant:${grantHash}`;
 }
 
-export function pairingGrantPrefixKey(): string {
-  return "pairing-grant:";
-}
-
 export function pairingGrantOwnerIndexKey(owner: string, org: string, grantHash: string): string {
   return `${pairingGrantOwnerIndexPrefix(owner, org)}${grantHash}`;
 }
@@ -172,10 +168,6 @@ export async function parsedDeviceToken(
 
 export function deviceTokenKey(id: string): string {
   return `device-token:${id}`;
-}
-
-export function deviceTokenPrefixKey(): string {
-  return "device-token:";
 }
 
 export function deviceOwnerIndexKey(owner: string, org: string, deviceID: string): string {


### PR DESCRIPTION
## What Problem This Solves

Removes three unreferenced Worker helper exports that no longer have callers or form part of a public package contract.

## Why This Change Was Made

The Worker package is private, its entrypoints do not expose these module helpers, and a full Worker TypeScript/JavaScript reference audit found no named, namespace, default, dynamic, re-export, config, or string-based uses. The live pairing and device-token key formats and their active builders remain unchanged.

## User Impact

No user-visible behavior changes. This reduces unused Worker surface area while preserving existing HTTP responses, storage keys, pairing grants, and device tokens.

## Evidence

- `git diff --check`
- Audited all 117 Worker TypeScript/JavaScript roots
- Zero remaining references to `pairingGrantPrefixKey` or `deviceTokenPrefixKey`
- Zero imports or exports of the removed `text` response helper
- Independent review of the exact 15-line deletion found no actionable issue
- CI pending: Worker formatting, lint, typecheck, tests, and Wrangler builds
