### PR TITLE
refactor(providers): share FAT16 image encoding

### DIFF
--- a/internal/providers/firecracker/cloudinit.go
+++ b/internal/providers/firecracker/cloudinit.go
@@ -1,12 +1,12 @@
 package firecracker
 
 import (
-	"encoding/binary"
 	"fmt"
 	"os"
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type cloudInitPayload struct {
@@ -14,10 +14,7 @@ type cloudInitPayload struct {
 	MetaData string
 }
 
-type fatFile struct {
-	Name string
-	Data []byte
-}
+type fatFile = shared.FATFile
 
 func buildCloudInitPayload(cfg Config, leaseID, slug, publicKey string) (cloudInitPayload, error) {
 	publicKey = strings.TrimSpace(publicKey)
@@ -44,149 +41,5 @@ func writeCloudInitDrive(path string, payload cloudInitPayload) error {
 }
 
 func buildFAT16Image(label string, files []fatFile) ([]byte, error) {
-	const (
-		bytesPerSector    = 512
-		sectorsPerCluster = 4
-		reservedSectors   = 1
-		fatCount          = 2
-		rootEntries       = 512
-		totalSectors      = 20480
-		sectorsPerFAT     = 40
-	)
-	rootDirSectors := rootEntries * 32 / bytesPerSector
-	firstDataSector := reservedSectors + fatCount*sectorsPerFAT + rootDirSectors
-	clusterSize := sectorsPerCluster * bytesPerSector
-	dataClusters := (totalSectors - firstDataSector) / sectorsPerCluster
-	fatEntries := sectorsPerFAT * bytesPerSector / 2
-	image := make([]byte, totalSectors*bytesPerSector)
-	boot := image[:bytesPerSector]
-	boot[0] = 0xeb
-	boot[1] = 0x3c
-	boot[2] = 0x90
-	copy(boot[3:11], []byte("CRABBOX "))
-	binary.LittleEndian.PutUint16(boot[11:13], bytesPerSector)
-	boot[13] = sectorsPerCluster
-	binary.LittleEndian.PutUint16(boot[14:16], reservedSectors)
-	boot[16] = fatCount
-	binary.LittleEndian.PutUint16(boot[17:19], rootEntries)
-	binary.LittleEndian.PutUint16(boot[19:21], totalSectors)
-	boot[21] = 0xf8
-	binary.LittleEndian.PutUint16(boot[22:24], sectorsPerFAT)
-	binary.LittleEndian.PutUint16(boot[24:26], 63)
-	binary.LittleEndian.PutUint16(boot[26:28], 255)
-	boot[36] = 0x80
-	boot[38] = 0x29
-	binary.LittleEndian.PutUint32(boot[39:43], 0x43525842)
-	copyPadded(boot[43:54], strings.ToUpper(label), ' ')
-	copy(boot[54:62], []byte("FAT16   "))
-	boot[510] = 0x55
-	boot[511] = 0xaa
-
-	fatStart := reservedSectors * bytesPerSector
-	rootStart := (reservedSectors + fatCount*sectorsPerFAT) * bytesPerSector
-	dataStart := firstDataSector * bytesPerSector
-	fat := image[fatStart : fatStart+sectorsPerFAT*bytesPerSector]
-	binary.LittleEndian.PutUint16(fat[0:2], 0xfff8)
-	binary.LittleEndian.PutUint16(fat[2:4], 0xffff)
-	nextCluster := 2
-	rootOffset := 0
-	root := image[rootStart : rootStart+rootDirSectors*bytesPerSector]
-	labelEntry := root[rootOffset : rootOffset+32]
-	copyPadded(labelEntry[0:11], strings.ToUpper(label), ' ')
-	labelEntry[11] = 0x08
-	rootOffset += 32
-	for i, file := range files {
-		if strings.TrimSpace(file.Name) == "" {
-			return nil, exit(2, "firecracker cloud-init file name is required")
-		}
-		cluster := nextCluster
-		clusterCount := (len(file.Data) + clusterSize - 1) / clusterSize
-		if clusterCount == 0 {
-			clusterCount = 1
-		}
-		if cluster-2+clusterCount > dataClusters || cluster+clusterCount > fatEntries {
-			return nil, exit(2, "firecracker cloud-init payload is too large")
-		}
-		short := fmt.Sprintf("FC%06dTXT", i+1)
-		checksum := fatShortChecksum([]byte(short))
-		lfnEntries := fatLongNameEntries(file.Name, checksum)
-		if rootOffset+(len(lfnEntries)+1)*32 > len(root) {
-			return nil, exit(2, "firecracker cloud-init directory is too large")
-		}
-		for c := 0; c < clusterCount; c++ {
-			entry := (cluster + c) * 2
-			next := uint16(0xffff)
-			if c+1 < clusterCount {
-				next = uint16(cluster + c + 1)
-			}
-			binary.LittleEndian.PutUint16(fat[entry:entry+2], next)
-		}
-		dataOffset := dataStart + (cluster-2)*clusterSize
-		copy(image[dataOffset:dataOffset+len(file.Data)], file.Data)
-		for _, entry := range lfnEntries {
-			copy(root[rootOffset:rootOffset+32], entry[:])
-			rootOffset += 32
-		}
-		entry := root[rootOffset : rootOffset+32]
-		copy(entry[0:11], []byte(short))
-		entry[11] = 0x20
-		binary.LittleEndian.PutUint16(entry[26:28], uint16(cluster))
-		binary.LittleEndian.PutUint32(entry[28:32], uint32(len(file.Data)))
-		rootOffset += 32
-		nextCluster += clusterCount
-	}
-	copy(image[fatStart+sectorsPerFAT*bytesPerSector:fatStart+2*sectorsPerFAT*bytesPerSector], fat)
-	return image, nil
-}
-
-func copyPadded(dst []byte, value string, pad byte) {
-	for i := range dst {
-		dst[i] = pad
-	}
-	copy(dst, []byte(value))
-}
-
-func fatShortChecksum(short []byte) byte {
-	var sum byte
-	for _, b := range short {
-		sum = ((sum & 1) << 7) + (sum >> 1) + b
-	}
-	return sum
-}
-
-func fatLongNameEntries(name string, checksum byte) [][32]byte {
-	runes := []rune(name)
-	chunks := (len(runes) + 12) / 13
-	entries := make([][32]byte, 0, chunks)
-	for i := chunks - 1; i >= 0; i-- {
-		var entry [32]byte
-		sequence := byte(i + 1)
-		if i == chunks-1 {
-			sequence |= 0x40
-		}
-		entry[0] = sequence
-		entry[11] = 0x0f
-		entry[13] = checksum
-		start := i * 13
-		end := start + 13
-		if end > len(runes) {
-			end = len(runes)
-		}
-		writeLongNameRunes(entry[:], runes[start:end])
-		entries = append(entries, entry)
-	}
-	return entries
-}
-
-func writeLongNameRunes(entry []byte, runes []rune) {
-	positions := []int{1, 3, 5, 7, 9, 14, 16, 18, 20, 22, 24, 28, 30}
-	for i, pos := range positions {
-		value := uint16(0xffff)
-		if i < len(runes) {
-			value = uint16(runes[i])
-		} else if i == len(runes) {
-			value = 0x0000
-		}
-		binary.LittleEndian.PutUint16(entry[pos:pos+2], value)
-	}
+	return shared.BuildFAT16Image(label, files, "FC%06dTXT", "firecracker cloud-init")
 }

--- a/internal/providers/firecracker/cloudinit_test.go
+++ b/internal/providers/firecracker/cloudinit_test.go
@@ -1,0 +1,20 @@
+package firecracker
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+)
+
+func TestBuildFAT16ImagePreservesFirecrackerEncoding(t *testing.T) {
+	image, err := buildFAT16Image("cidata", []fatFile{
+		{Name: "user-data", Data: []byte("#cloud-config\nusers:\n- name: alice\n")},
+		{Name: "meta-data", Data: []byte("instance-id: crabbox-test\nlocal-hostname: my-app\n")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := fmt.Sprintf("%x", sha256.Sum256(image)), "8cf6c03a8acdb3642216daadda7a475df2f93d14a90173cdb97a263b121af03d"; got != want {
+		t.Fatalf("sha256=%s, want %s", got, want)
+	}
+}

--- a/internal/providers/shared/fat16.go
+++ b/internal/providers/shared/fat16.go
@@ -1,0 +1,162 @@
+package shared
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type FATFile struct {
+	Name string
+	Data []byte
+}
+
+func BuildFAT16Image(label string, files []FATFile, shortNameFormat, errorPrefix string) ([]byte, error) {
+	const (
+		bytesPerSector    = 512
+		sectorsPerCluster = 4
+		reservedSectors   = 1
+		fatCount          = 2
+		rootEntries       = 512
+		totalSectors      = 20480
+		sectorsPerFAT     = 40
+	)
+	rootDirSectors := rootEntries * 32 / bytesPerSector
+	firstDataSector := reservedSectors + fatCount*sectorsPerFAT + rootDirSectors
+	clusterSize := sectorsPerCluster * bytesPerSector
+	dataClusters := (totalSectors - firstDataSector) / sectorsPerCluster
+	fatEntries := sectorsPerFAT * bytesPerSector / 2
+	image := make([]byte, totalSectors*bytesPerSector)
+	boot := image[:bytesPerSector]
+	boot[0] = 0xeb
+	boot[1] = 0x3c
+	boot[2] = 0x90
+	copy(boot[3:11], []byte("CRABBOX "))
+	binary.LittleEndian.PutUint16(boot[11:13], bytesPerSector)
+	boot[13] = sectorsPerCluster
+	binary.LittleEndian.PutUint16(boot[14:16], reservedSectors)
+	boot[16] = fatCount
+	binary.LittleEndian.PutUint16(boot[17:19], rootEntries)
+	binary.LittleEndian.PutUint16(boot[19:21], totalSectors)
+	boot[21] = 0xf8
+	binary.LittleEndian.PutUint16(boot[22:24], sectorsPerFAT)
+	binary.LittleEndian.PutUint16(boot[24:26], 63)
+	binary.LittleEndian.PutUint16(boot[26:28], 255)
+	boot[36] = 0x80
+	boot[38] = 0x29
+	binary.LittleEndian.PutUint32(boot[39:43], 0x43525842)
+	copyPadded(boot[43:54], strings.ToUpper(label), ' ')
+	copy(boot[54:62], []byte("FAT16   "))
+	boot[510] = 0x55
+	boot[511] = 0xaa
+
+	fatStart := reservedSectors * bytesPerSector
+	rootStart := (reservedSectors + fatCount*sectorsPerFAT) * bytesPerSector
+	dataStart := firstDataSector * bytesPerSector
+	fat := image[fatStart : fatStart+sectorsPerFAT*bytesPerSector]
+	binary.LittleEndian.PutUint16(fat[0:2], 0xfff8)
+	binary.LittleEndian.PutUint16(fat[2:4], 0xffff)
+	nextCluster := 2
+	rootOffset := 0
+	root := image[rootStart : rootStart+rootDirSectors*bytesPerSector]
+	labelEntry := root[rootOffset : rootOffset+32]
+	copyPadded(labelEntry[0:11], strings.ToUpper(label), ' ')
+	labelEntry[11] = 0x08
+	rootOffset += 32
+	for i, file := range files {
+		if strings.TrimSpace(file.Name) == "" {
+			return nil, core.Exit(2, "%s file name is required", errorPrefix)
+		}
+		cluster := nextCluster
+		clusterCount := (len(file.Data) + clusterSize - 1) / clusterSize
+		if clusterCount == 0 {
+			clusterCount = 1
+		}
+		if cluster-2+clusterCount > dataClusters || cluster+clusterCount > fatEntries {
+			return nil, core.Exit(2, "%s payload is too large", errorPrefix)
+		}
+		short := fmt.Sprintf(shortNameFormat, i+1)
+		checksum := fatShortChecksum([]byte(short))
+		lfnEntries := fatLongNameEntries(file.Name, checksum)
+		if rootOffset+(len(lfnEntries)+1)*32 > len(root) {
+			return nil, core.Exit(2, "%s directory is too large", errorPrefix)
+		}
+		for c := 0; c < clusterCount; c++ {
+			entry := (cluster + c) * 2
+			next := uint16(0xffff)
+			if c+1 < clusterCount {
+				next = uint16(cluster + c + 1)
+			}
+			binary.LittleEndian.PutUint16(fat[entry:entry+2], next)
+		}
+		dataOffset := dataStart + (cluster-2)*clusterSize
+		copy(image[dataOffset:dataOffset+len(file.Data)], file.Data)
+		for _, entry := range lfnEntries {
+			copy(root[rootOffset:rootOffset+32], entry[:])
+			rootOffset += 32
+		}
+		entry := root[rootOffset : rootOffset+32]
+		copy(entry[0:11], []byte(short))
+		entry[11] = 0x20
+		binary.LittleEndian.PutUint16(entry[26:28], uint16(cluster))
+		binary.LittleEndian.PutUint32(entry[28:32], uint32(len(file.Data)))
+		rootOffset += 32
+		nextCluster += clusterCount
+	}
+	copy(image[fatStart+sectorsPerFAT*bytesPerSector:fatStart+2*sectorsPerFAT*bytesPerSector], fat)
+	return image, nil
+}
+
+func copyPadded(dst []byte, value string, pad byte) {
+	for i := range dst {
+		dst[i] = pad
+	}
+	copy(dst, []byte(value))
+}
+
+func fatShortChecksum(short []byte) byte {
+	var sum byte
+	for _, b := range short {
+		sum = ((sum & 1) << 7) + (sum >> 1) + b
+	}
+	return sum
+}
+
+func fatLongNameEntries(name string, checksum byte) [][32]byte {
+	runes := []rune(name)
+	chunks := (len(runes) + 12) / 13
+	entries := make([][32]byte, 0, chunks)
+	for i := chunks - 1; i >= 0; i-- {
+		var entry [32]byte
+		sequence := byte(i + 1)
+		if i == chunks-1 {
+			sequence |= 0x40
+		}
+		entry[0] = sequence
+		entry[11] = 0x0f
+		entry[13] = checksum
+		start := i * 13
+		end := start + 13
+		if end > len(runes) {
+			end = len(runes)
+		}
+		writeLongNameRunes(entry[:], runes[start:end])
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func writeLongNameRunes(entry []byte, runes []rune) {
+	positions := []int{1, 3, 5, 7, 9, 14, 16, 18, 20, 22, 24, 28, 30}
+	for i, pos := range positions {
+		value := uint16(0xffff)
+		if i < len(runes) {
+			value = uint16(runes[i])
+		} else if i == len(runes) {
+			value = 0x0000
+		}
+		binary.LittleEndian.PutUint16(entry[pos:pos+2], value)
+	}
+}

--- a/internal/providers/shared/fat16_test.go
+++ b/internal/providers/shared/fat16_test.go
@@ -1,0 +1,77 @@
+package shared
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestBuildFAT16ImageGolden(t *testing.T) {
+	files255 := make([]FATFile, 255)
+	for i := range files255 {
+		files255[i] = FATFile{Name: fmt.Sprintf("f%03d", i)}
+	}
+	cases := []struct {
+		name, label string
+		files       []FATFile
+		hashes      [2]string
+	}{
+		{"ordered-files", "cidata", []FATFile{{Name: "user-data", Data: []byte("#cloud-config\nusers:\n- name: alice\n")}, {Name: "meta-data", Data: []byte("instance-id: crabbox-test\nlocal-hostname: my-app\n")}}, [2]string{"8cf6c03a8acdb3642216daadda7a475df2f93d14a90173cdb97a263b121af03d", "a752d9264be7b8d65d7aa76c88b29390db32c01aeb32583018ec5046df8ea2b6"}},
+		{"empty-allocation", "cidata", []FATFile{{Name: "empty"}}, [2]string{"f900e21494f8059f3d529bd9488be5f26efffc8bba739a4d2cdf8633fd1722fa", "c58cb3d26116f066a07255508232d7fdbfbfbfe48dd082227d0bfbcb7cf28672"}},
+		{"multi-cluster", "cidata", []FATFile{{Name: "payload.bin", Data: bytes.Repeat([]byte("0123456789abcdef"), 321)}}, [2]string{"3965f5a85647fb1900551fed056e49d4a29aad5db4af54967006e66e1a2a80a7", "fd061834ae60dbd1d91eb2be53ed19f51d35866bc4d22c74d7d9a4e593c167e9"}},
+		{"label-pad", "id", []FATFile{{Name: "file", Data: []byte("x")}}, [2]string{"07274e4d21666867280db930c9a18536f7ec6a9081a25442c96f31fb3d390001", "9a541636761b52594893419fab8e06ccf03bfdad2385a07764aefaa61abd7b7d"}},
+		{"label-truncate", "abcdefghijklmnop", []FATFile{{Name: "file", Data: []byte("x")}}, [2]string{"491f6aec8706725bdba81c2e7cf30e6f2123ad988b1469bf4de92f2c05b233a4", "c41a9dcda7e219bcf48d7f5a289e159bad7505dfea1cea54ad9140382ba0860a"}},
+		{"lfn-13-runes", "cidata", []FATFile{{Name: "abcdefghijklm", Data: []byte("x")}}, [2]string{"68246b5f6dcf2f4fafef9eb5895b3b9819831094d0f3d01505c9a0437db55fc4", "ffa3cc58a18d26f5850137eb3010f634541dfcf4e8aa53c6853936e3ad95b57a"}},
+		{"lfn-14-runes", "cidata", []FATFile{{Name: "abcdefghijklmn", Data: []byte("x")}}, [2]string{"704d0dfab25c0c1957008c46e720299c40807fc4b336150adfdc9106a0f83eef", "49c0df807932004e021ad11e58fd16be5b5f648bbac9299caa05f0bac0b647d0"}},
+		{"lfn-non-bmp", "cidata", []FATFile{{Name: "prefix-🚀-suffix", Data: []byte("x")}}, [2]string{"fe323f8b6492a81375c2129d21df8e7e9c73098e6e6cd355bf305751ae629df9", "b6ef0942918d043c63f14861ce25fca5123f4404b9dbd1769e1c0c718f8df384"}},
+		{"directory-255-files", "cidata", files255, [2]string{"e24197abfd70a44bf9b2dcc3b69d87a988441929ca6fef023875ba725294f37f", "8b20aa081aa8a3f9bdf7d2feeef31ce621532f197d8f02c9bfe97cd7af37aeb8"}},
+	}
+	variants := []struct{ name, short, prefix string }{
+		{"firecracker", "FC%06dTXT", "firecracker cloud-init"},
+		{"xcpng", "CRAB%04dTXT", "config-drive"},
+	}
+	for i, variant := range variants {
+		for _, test := range cases {
+			t.Run(variant.name+"/"+test.name, func(t *testing.T) {
+				image, err := BuildFAT16Image(test.label, test.files, variant.short, variant.prefix)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got := fmt.Sprintf("%x", sha256.Sum256(image)); got != test.hashes[i] {
+					t.Fatalf("sha256=%s, want %s", got, test.hashes[i])
+				}
+			})
+		}
+	}
+}
+
+func TestBuildFAT16ImageErrors(t *testing.T) {
+	const maxDataBytes = ((20480 - (1 + 2*40 + 512*32/512)) / 4) * 4 * 512
+	oversized := bytes.Repeat([]byte{'x'}, maxDataBytes+1)
+	files256 := make([]FATFile, 256)
+	for i := range files256 {
+		files256[i] = FATFile{Name: fmt.Sprintf("f%03d", i)}
+	}
+	cases := []struct {
+		name, suffix string
+		files        []FATFile
+	}{
+		{"blank-name-order", "file name is required", []FATFile{{Name: " ", Data: oversized}}},
+		{"capacity-plus-one", "payload is too large", []FATFile{{Name: "payload.bin", Data: oversized}}},
+		{"directory-256-files", "directory is too large", files256},
+	}
+	for _, variant := range []struct{ name, short, prefix string }{{"firecracker", "FC%06dTXT", "firecracker cloud-init"}, {"xcpng", "CRAB%04dTXT", "config-drive"}} {
+		for _, test := range cases {
+			t.Run(variant.name+"/"+test.name, func(t *testing.T) {
+				image, err := BuildFAT16Image("cidata", test.files, variant.short, variant.prefix)
+				var exitErr core.ExitError
+				if image != nil || !core.AsExitError(err, &exitErr) || exitErr.Code != 2 || exitErr.Message != variant.prefix+" "+test.suffix {
+					t.Fatalf("imageNil=%v err=%#v", image == nil, err)
+				}
+			})
+		}
+	}
+}

--- a/internal/providers/shared/fat16_test.go
+++ b/internal/providers/shared/fat16_test.go
@@ -26,7 +26,7 @@ func TestBuildFAT16ImageGolden(t *testing.T) {
 		{"label-truncate", "abcdefghijklmnop", []FATFile{{Name: "file", Data: []byte("x")}}, [2]string{"491f6aec8706725bdba81c2e7cf30e6f2123ad988b1469bf4de92f2c05b233a4", "c41a9dcda7e219bcf48d7f5a289e159bad7505dfea1cea54ad9140382ba0860a"}},
 		{"lfn-13-runes", "cidata", []FATFile{{Name: "abcdefghijklm", Data: []byte("x")}}, [2]string{"68246b5f6dcf2f4fafef9eb5895b3b9819831094d0f3d01505c9a0437db55fc4", "ffa3cc58a18d26f5850137eb3010f634541dfcf4e8aa53c6853936e3ad95b57a"}},
 		{"lfn-14-runes", "cidata", []FATFile{{Name: "abcdefghijklmn", Data: []byte("x")}}, [2]string{"704d0dfab25c0c1957008c46e720299c40807fc4b336150adfdc9106a0f83eef", "49c0df807932004e021ad11e58fd16be5b5f648bbac9299caa05f0bac0b647d0"}},
-		{"lfn-non-bmp", "cidata", []FATFile{{Name: "prefix-🚀-suffix", Data: []byte("x")}}, [2]string{"fe323f8b6492a81375c2129d21df8e7e9c73098e6e6cd355bf305751ae629df9", "b6ef0942918d043c63f14861ce25fca5123f4404b9dbd1769e1c0c718f8df384"}},
+		{"lfn-non-bmp", "cidata", []FATFile{{Name: "prefix-\U0001F680-suffix", Data: []byte("x")}}, [2]string{"fe323f8b6492a81375c2129d21df8e7e9c73098e6e6cd355bf305751ae629df9", "b6ef0942918d043c63f14861ce25fca5123f4404b9dbd1769e1c0c718f8df384"}},
 		{"directory-255-files", "cidata", files255, [2]string{"e24197abfd70a44bf9b2dcc3b69d87a988441929ca6fef023875ba725294f37f", "8b20aa081aa8a3f9bdf7d2feeef31ce621532f197d8f02c9bfe97cd7af37aeb8"}},
 	}
 	variants := []struct{ name, short, prefix string }{

--- a/internal/providers/xcpng/cloudinit.go
+++ b/internal/providers/xcpng/cloudinit.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/base64"
-	"encoding/binary"
 	"encoding/xml"
 	"fmt"
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type xcpNgCloudInitPayload struct {
@@ -451,155 +451,8 @@ func buildConfigDriveImage(payload xcpNgCloudInitPayload) ([]byte, error) {
 	return buildFAT16Image("cidata", files)
 }
 
-type fatFile struct {
-	Name string
-	Data []byte
-}
+type fatFile = shared.FATFile
 
 func buildFAT16Image(label string, files []fatFile) ([]byte, error) {
-	const (
-		bytesPerSector    = 512
-		sectorsPerCluster = 4
-		reservedSectors   = 1
-		fatCount          = 2
-		rootEntries       = 512
-		totalSectors      = 20480
-		sectorsPerFAT     = 40
-	)
-	rootDirSectors := rootEntries * 32 / bytesPerSector
-	firstDataSector := reservedSectors + fatCount*sectorsPerFAT + rootDirSectors
-	clusterSize := sectorsPerCluster * bytesPerSector
-	dataClusters := (totalSectors - firstDataSector) / sectorsPerCluster
-	fatEntries := sectorsPerFAT * bytesPerSector / 2
-	image := make([]byte, totalSectors*bytesPerSector)
-	boot := image[:bytesPerSector]
-	boot[0] = 0xeb
-	boot[1] = 0x3c
-	boot[2] = 0x90
-	copy(boot[3:11], []byte("CRABBOX "))
-	binary.LittleEndian.PutUint16(boot[11:13], bytesPerSector)
-	boot[13] = sectorsPerCluster
-	binary.LittleEndian.PutUint16(boot[14:16], reservedSectors)
-	boot[16] = fatCount
-	binary.LittleEndian.PutUint16(boot[17:19], rootEntries)
-	binary.LittleEndian.PutUint16(boot[19:21], totalSectors)
-	boot[21] = 0xf8
-	binary.LittleEndian.PutUint16(boot[22:24], sectorsPerFAT)
-	binary.LittleEndian.PutUint16(boot[24:26], 63)
-	binary.LittleEndian.PutUint16(boot[26:28], 255)
-	boot[36] = 0x80
-	boot[38] = 0x29
-	binary.LittleEndian.PutUint32(boot[39:43], 0x43525842)
-	copyPadded(boot[43:54], strings.ToUpper(label), ' ')
-	copy(boot[54:62], []byte("FAT16   "))
-	boot[510] = 0x55
-	boot[511] = 0xaa
-
-	fatStart := reservedSectors * bytesPerSector
-	rootStart := (reservedSectors + fatCount*sectorsPerFAT) * bytesPerSector
-	dataStart := firstDataSector * bytesPerSector
-	fat := image[fatStart : fatStart+sectorsPerFAT*bytesPerSector]
-	binary.LittleEndian.PutUint16(fat[0:2], 0xfff8)
-	binary.LittleEndian.PutUint16(fat[2:4], 0xffff)
-	nextCluster := 2
-	rootOffset := 0
-	root := image[rootStart : rootStart+rootDirSectors*bytesPerSector]
-	labelEntry := root[rootOffset : rootOffset+32]
-	copyPadded(labelEntry[0:11], strings.ToUpper(label), ' ')
-	labelEntry[11] = 0x08
-	rootOffset += 32
-	for i, file := range files {
-		if strings.TrimSpace(file.Name) == "" {
-			return nil, exit(2, "config-drive file name is required")
-		}
-		cluster := nextCluster
-		clusterCount := (len(file.Data) + clusterSize - 1) / clusterSize
-		if clusterCount == 0 {
-			clusterCount = 1
-		}
-		if cluster-2+clusterCount > dataClusters || cluster+clusterCount > fatEntries {
-			return nil, exit(2, "config-drive payload is too large")
-		}
-		short := fmt.Sprintf("CRAB%04dTXT", i+1)
-		checksum := fatShortChecksum([]byte(short))
-		lfnEntries := fatLongNameEntries(file.Name, checksum)
-		if rootOffset+(len(lfnEntries)+1)*32 > len(root) {
-			return nil, exit(2, "config-drive directory is too large")
-		}
-		for c := 0; c < clusterCount; c++ {
-			entry := (cluster + c) * 2
-			next := uint16(0xffff)
-			if c+1 < clusterCount {
-				next = uint16(cluster + c + 1)
-			}
-			binary.LittleEndian.PutUint16(fat[entry:entry+2], next)
-		}
-		dataOffset := dataStart + (cluster-2)*clusterSize
-		copy(image[dataOffset:dataOffset+len(file.Data)], file.Data)
-		for _, entry := range lfnEntries {
-			copy(root[rootOffset:rootOffset+32], entry[:])
-			rootOffset += 32
-		}
-		entry := root[rootOffset : rootOffset+32]
-		copy(entry[0:11], []byte(short))
-		entry[11] = 0x20
-		binary.LittleEndian.PutUint16(entry[26:28], uint16(cluster))
-		binary.LittleEndian.PutUint32(entry[28:32], uint32(len(file.Data)))
-		rootOffset += 32
-		nextCluster += clusterCount
-	}
-	copy(image[fatStart+sectorsPerFAT*bytesPerSector:fatStart+2*sectorsPerFAT*bytesPerSector], fat)
-	return image, nil
-}
-
-func copyPadded(dst []byte, value string, pad byte) {
-	for i := range dst {
-		dst[i] = pad
-	}
-	copy(dst, []byte(value))
-}
-
-func fatShortChecksum(short []byte) byte {
-	var sum byte
-	for _, b := range short {
-		sum = ((sum & 1) << 7) + (sum >> 1) + b
-	}
-	return sum
-}
-
-func fatLongNameEntries(name string, checksum byte) [][32]byte {
-	runes := []rune(name)
-	chunks := (len(runes) + 12) / 13
-	entries := make([][32]byte, 0, chunks)
-	for i := chunks - 1; i >= 0; i-- {
-		var entry [32]byte
-		sequence := byte(i + 1)
-		if i == chunks-1 {
-			sequence |= 0x40
-		}
-		entry[0] = sequence
-		entry[11] = 0x0f
-		entry[13] = checksum
-		start := i * 13
-		end := start + 13
-		if end > len(runes) {
-			end = len(runes)
-		}
-		writeLongNameRunes(entry[:], runes[start:end])
-		entries = append(entries, entry)
-	}
-	return entries
-}
-
-func writeLongNameRunes(entry []byte, runes []rune) {
-	positions := []int{1, 3, 5, 7, 9, 14, 16, 18, 20, 22, 24, 28, 30}
-	for i, pos := range positions {
-		value := uint16(0xffff)
-		if i < len(runes) {
-			value = uint16(runes[i])
-		} else if i == len(runes) {
-			value = 0x0000
-		}
-		binary.LittleEndian.PutUint16(entry[pos:pos+2], value)
-	}
+	return shared.BuildFAT16Image(label, files, "CRAB%04dTXT", "config-drive")
 }

--- a/internal/providers/xcpng/cloudinit_test.go
+++ b/internal/providers/xcpng/cloudinit_test.go
@@ -1,6 +1,8 @@
 package xcpng
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -173,6 +175,19 @@ func TestBuildConfigDriveImageRejectsOversizedPayload(t *testing.T) {
 	}
 	if _, err := buildConfigDriveImage(payload); err == nil || !strings.Contains(err.Error(), "config-drive payload is too large") {
 		t.Fatalf("err=%v, want oversized payload validation", err)
+	}
+}
+
+func TestBuildFAT16ImagePreservesXCPngEncoding(t *testing.T) {
+	image, err := buildFAT16Image("cidata", []fatFile{
+		{Name: "user-data", Data: []byte("#cloud-config\nusers:\n- name: alice\n")},
+		{Name: "meta-data", Data: []byte("instance-id: crabbox-test\nlocal-hostname: my-app\n")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := fmt.Sprintf("%x", sha256.Sum256(image)), "a752d9264be7b8d65d7aa76c88b29390db32c01aeb32583018ec5046df8ea2b6"; got != want {
+		t.Fatalf("sha256=%s, want %s", got, want)
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

Resolves duplicated FAT16 image encoding in the Firecracker and XCP-ng cloud-init paths.

## Why This Change Was Made

Moves the byte-identical encoder into `internal/providers/shared` while retaining thin provider wrappers for the existing short-name formats and diagnostics. Geometry, FAT allocation, directory ordering, label handling, legacy non-BMP truncation, file permissions, and lifecycle behavior remain unchanged.

## User Impact

No user-visible behavior change. Providers continue producing byte-identical cloud-init images and exact existing validation errors.

## Evidence

- Captured 24 original outcomes before extraction: 18 whole-image SHA-256 goldens and 6 exact error, exit-code, and nil-image cases.
- Replayed all 24 cases against the extracted shared encoder in an isolated standard-library-only harness.
- Covered ordered files, empty allocation, multi-cluster payloads, label padding and truncation, 13/14-rune LFN boundaries, legacy non-BMP handling, capacity overflow, and 255/256-file directory limits.
- Verified formatting and `git diff --check`.
- Production code: net 132 lines removed. Full change including regression coverage: net 20 lines removed.

Required hosted validation:

- [ ] `go test -race ./internal/providers/shared ./internal/providers/firecracker ./internal/providers/xcpng`
- [ ] `go vet ./...`
- [ ] `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- [ ] Normal pull-request CI
