### PR TITLE
chore(ci): qualify PR 1844 cumulative integration on B5

### DIFF
--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -12,6 +12,24 @@ import (
 	"testing"
 )
 
+func recommendAliasForTest(t *testing.T, alias string) []providerRecommendationEntry {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
+		"recommend", alias,
+		"--limit", "1",
+		"--json",
+	})
+	if err != nil {
+		t.Fatalf("providers recommend %s error=%v stderr=%q", alias, err, stderr.String())
+	}
+	var entries []providerRecommendationEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	return entries
+}
+
 func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	entries := providerMatrix()
 	var aws *providerMatrixEntry
@@ -712,19 +730,7 @@ func TestProvidersRecommendArtifactDownloadPrefersArtifactProviders(t *testing.T
 }
 
 func TestProvidersRecommendArtifactDownloadAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "run-artifacts",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend run-artifacts error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "run-artifacts")
 	if len(entries) != 1 || !providerRecommendationHasFeature(entries[0].Features, FeatureRunArtifacts) {
 		t.Fatalf("run-artifacts alias entries=%#v", entries)
 	}
@@ -766,19 +772,7 @@ func TestProvidersRecommendCodeInterpreterPrefersSandboxExecution(t *testing.T) 
 }
 
 func TestProvidersRecommendPythonSandboxAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "python-sandbox",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend python-sandbox error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "python-sandbox")
 	if len(entries) != 1 {
 		t.Fatalf("python-sandbox alias entries=%#v", entries)
 	}
@@ -822,19 +816,7 @@ func TestProvidersRecommendCostControlPrefersReusableOrGovernedCapacity(t *testi
 }
 
 func TestProvidersRecommendCostControlAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "budget",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend budget error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "budget")
 	if len(entries) != 1 || !strings.HasPrefix(entries[0].Category, "local-") {
 		t.Fatalf("budget alias entries=%#v", entries)
 	}
@@ -870,19 +852,7 @@ func TestProvidersRecommendDisposableExecutionRequiresCleanupSandboxes(t *testin
 }
 
 func TestProvidersRecommendEphemeralSandboxAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "ephemeral-sandbox",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend ephemeral-sandbox error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "ephemeral-sandbox")
 	if len(entries) != 1 {
 		t.Fatalf("ephemeral-sandbox alias entries=%#v", entries)
 	}
@@ -934,19 +904,7 @@ func TestProvidersRecommendOfflineValidationPrefersCredentiallessProviders(t *te
 }
 
 func TestProvidersRecommendNoCredentialsAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "no-credentials",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend no-credentials error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "no-credentials")
 	if len(entries) != 1 || !strings.HasPrefix(entries[0].Category, "local-") {
 		t.Fatalf("no-credentials alias entries=%#v", entries)
 	}
@@ -1051,19 +1009,7 @@ func TestProvidersRecommendWarmStartPrefersReusableState(t *testing.T) {
 }
 
 func TestProvidersRecommendWarmPoolAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "warm-pool",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend warm-pool error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "warm-pool")
 	if len(entries) != 1 {
 		t.Fatalf("warm-pool alias entries=%#v", entries)
 	}
@@ -1106,19 +1052,7 @@ func TestProvidersRecommendWebAppSmokeUsesReachableAppSurfaces(t *testing.T) {
 }
 
 func TestProvidersRecommendBrowserSmokeAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "browser-smoke",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend browser-smoke error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "browser-smoke")
 	if len(entries) != 1 {
 		t.Fatalf("browser-smoke alias entries=%#v", entries)
 	}
@@ -1132,19 +1066,7 @@ func TestProvidersRecommendBrowserSmokeAlias(t *testing.T) {
 }
 
 func TestProvidersRecommendFailedRunAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "failed-run",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend failed-run error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "failed-run")
 	if len(entries) != 1 || entries[0].Provider != "blacksmith-testbox" {
 		t.Fatalf("failed-run alias entries=%#v", entries)
 	}
@@ -1186,19 +1108,7 @@ func TestProvidersRecommendInteractiveDebugSurfaces(t *testing.T) {
 }
 
 func TestProvidersRecommendLiveDebugAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "live-debug",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend live-debug error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "live-debug")
 	if len(entries) != 1 {
 		t.Fatalf("live-debug alias entries=%#v", entries)
 	}
@@ -1238,19 +1148,7 @@ func TestProvidersRecommendFanoutTestingRequiresForkableWorkspaces(t *testing.T)
 }
 
 func TestProvidersRecommendBestOfNAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "best-of-n",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend best-of-n error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "best-of-n")
 	if len(entries) != 1 || !providerRecommendationHasFeature(entries[0].Features, FeatureFork) {
 		t.Fatalf("best-of-n alias entries=%#v", entries)
 	}
@@ -1312,19 +1210,7 @@ func TestProvidersRecommendResourceObservability(t *testing.T) {
 }
 
 func TestProvidersRecommendTelemetryAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "telemetry",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend telemetry error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "telemetry")
 	if len(entries) != 1 {
 		t.Fatalf("telemetry alias entries=%#v", entries)
 	}
@@ -1371,19 +1257,7 @@ func TestProvidersRecommendRunSessionPrefersInspectableRuns(t *testing.T) {
 }
 
 func TestProvidersRecommendRunSessionAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "inspectable-run",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend inspectable-run error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "inspectable-run")
 	if len(entries) != 1 || !providerRecommendationHasFeature(entries[0].Features, FeatureRunSession) {
 		t.Fatalf("inspectable-run alias entries=%#v", entries)
 	}
@@ -1465,15 +1339,7 @@ func TestProvidersRecommendIsolatedExecutionIncludesLocalSandboxes(t *testing.T)
 }
 
 func TestProvidersRecommendIsolatedExecutionAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"recommend", "secure-sandbox", "--limit", "1", "--json"})
-	if err != nil {
-		t.Fatalf("providers recommend secure-sandbox error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "secure-sandbox")
 	if len(entries) != 1 || entries[0].Kind != ProviderKindDelegatedRun {
 		t.Fatalf("secure-sandbox alias entries=%#v", entries)
 	}
@@ -1505,19 +1371,7 @@ func TestProvidersRecommendNetworkIsolationPrefersSandboxBoundaries(t *testing.T
 }
 
 func TestProvidersRecommendNetworkIsolationAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "egress-control",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend egress-control error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "egress-control")
 	if len(entries) != 1 || entries[0].Category != "delegated-sandbox" {
 		t.Fatalf("egress-control alias entries=%#v", entries)
 	}
@@ -1545,15 +1399,7 @@ func TestProvidersRecommendTeamCloudPrefersBrokerableProviders(t *testing.T) {
 }
 
 func TestProvidersRecommendTeamCloudAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{"recommend", "brokered-cloud", "--limit", "1", "--json"})
-	if err != nil {
-		t.Fatalf("providers recommend brokered-cloud error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "brokered-cloud")
 	if len(entries) != 1 || entries[0].Category != "brokerable-cloud" {
 		t.Fatalf("brokered-cloud alias entries=%#v", entries)
 	}
@@ -1603,19 +1449,7 @@ func TestProvidersRecommendForkableWorkspaceAlias(t *testing.T) {
 }
 
 func TestProvidersRecommendWorkspaceReuseAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "workspace-reuse",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend workspace-reuse error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "workspace-reuse")
 	if len(entries) != 1 {
 		t.Fatalf("entry count=%d entries=%#v", len(entries), entries)
 	}
@@ -1640,19 +1474,7 @@ func TestProvidersRecommendMCPSandbox(t *testing.T) {
 }
 
 func TestProvidersRecommendMCPSandboxAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "mcp",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend mcp error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "mcp")
 	if len(entries) != 1 || !providerRecommendationHasFeature(entries[0].Features, FeatureMCP) {
 		t.Fatalf("mcp alias entries=%#v", entries)
 	}
@@ -1685,19 +1507,7 @@ func TestSealosDevboxIsRemoteDevProvider(t *testing.T) {
 }
 
 func TestProvidersRecommendRemoteDevAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "codespaces",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend codespaces error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "codespaces")
 	if len(entries) != 1 || !isRemoteDevProvider(entries[0].Provider) {
 		t.Fatalf("codespaces alias entries=%#v", entries)
 	}
@@ -1726,19 +1536,7 @@ func TestProvidersRecommendPreviewURLPrefersURLBridgeProviders(t *testing.T) {
 }
 
 func TestProvidersRecommendPreviewURLAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "app-preview",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend app-preview error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "app-preview")
 	if len(entries) != 1 || !providerRecommendationHasFeature(entries[0].Features, FeatureURLBridge) {
 		t.Fatalf("app-preview alias entries=%#v", entries)
 	}
@@ -1764,19 +1562,7 @@ func TestProvidersRecommendPauseResumePrefersResumableProviders(t *testing.T) {
 }
 
 func TestProvidersRecommendPauseResumeAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "resumable-workspace",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend resumable-workspace error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "resumable-workspace")
 	if len(entries) != 1 || !providerRecommendationHasFeature(entries[0].Features, FeaturePauseResume) {
 		t.Fatalf("resumable-workspace alias entries=%#v", entries)
 	}
@@ -1818,19 +1604,7 @@ func TestProvidersRecommendLiveSmokePrefersProvableLifecycle(t *testing.T) {
 }
 
 func TestProvidersRecommendLiveSmokeAlias(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	err := (App{Stdout: &stdout, Stderr: &stderr}).providers(context.Background(), []string{
-		"recommend", "provider-smoke",
-		"--limit", "1",
-		"--json",
-	})
-	if err != nil {
-		t.Fatalf("providers recommend provider-smoke error=%v stderr=%q", err, stderr.String())
-	}
-	var entries []providerRecommendationEntry
-	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
-		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
-	}
+	entries := recommendAliasForTest(t, "provider-smoke")
 	if len(entries) != 1 || entries[0].Score <= 0 {
 		t.Fatalf("provider-smoke alias entries=%#v", entries)
 	}

--- a/internal/providers/applevm/cleanup_toctou_test.go
+++ b/internal/providers/applevm/cleanup_toctou_test.go
@@ -36,7 +36,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -122,36 +121,9 @@ func TestCleanupOrphanSweepGuardDeclinesReclaimedCandidate(t *testing.T) {
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	var out bytes.Buffer
 
-	oldGOOS, oldGOARCH := hostGOOS, hostGOARCH
-	oldMacOSVersion := hostMacOSVersion
-	hostGOOS, hostGOARCH = "darwin", "arm64"
-	hostMacOSVersion = func() (string, error) { return "26.5", nil }
-	t.Cleanup(func() {
-		hostGOOS, hostGOARCH = oldGOOS, oldGOARCH
-		hostMacOSVersion = oldMacOSVersion
-	})
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".state"))
-	root := t.TempDir()
-
-	cfg := core.BaseConfig()
-	cfg.Provider = providerName
-	cfg.AppleVM = core.AppleVMConfig{
-		HelperPath:  "/tmp/helper-source",
-		Image:       "https://cloud-images.ubuntu.com/releases/noble/release-20260518/ubuntu-24.04-server-cloudimg-arm64.img",
-		ImageSHA256: "6a61b967ba4a27dd1966f835a67643073ed55c2860ce3dc1cb0517282e6b8bec",
-		User:        "runner",
-		WorkRoot:    "/workspace/crabbox",
-		CPUs:        4,
-		MemoryMiB:   8192,
-		DiskGiB:     40,
-	}
-	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: &out, Exec: runner}).(*backend)
-	b.prepareHelper = func(context.Context, core.Config) (string, error) { return "helper", nil }
-	b.stateRoot = func() (string, error) { return root, nil }
-	b.waitForSSH = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	b := testBackend(t, runner)
+	b.rt.Stdout, b.rt.Stderr = &out, &out
+	root, _ := b.stateRoot()
 
 	leaseID := "cbx_orphan67890"
 	slug := "orphan-slug"
@@ -213,36 +185,9 @@ func TestCleanupRetainsKeyPreparedByConcurrentAcquire(t *testing.T) {
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	var out bytes.Buffer
 
-	oldGOOS, oldGOARCH := hostGOOS, hostGOARCH
-	oldMacOSVersion := hostMacOSVersion
-	hostGOOS, hostGOARCH = "darwin", "arm64"
-	hostMacOSVersion = func() (string, error) { return "26.5", nil }
-	t.Cleanup(func() {
-		hostGOOS, hostGOARCH = oldGOOS, oldGOARCH
-		hostMacOSVersion = oldMacOSVersion
-	})
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".state"))
-	root := t.TempDir()
-
-	cfg := core.BaseConfig()
-	cfg.Provider = providerName
-	cfg.AppleVM = core.AppleVMConfig{
-		HelperPath:  "/tmp/helper-source",
-		Image:       "https://cloud-images.ubuntu.com/releases/noble/release-20260518/ubuntu-24.04-server-cloudimg-arm64.img",
-		ImageSHA256: "6a61b967ba4a27dd1966f835a67643073ed55c2860ce3dc1cb0517282e6b8bec",
-		User:        "runner",
-		WorkRoot:    "/workspace/crabbox",
-		CPUs:        4,
-		MemoryMiB:   8192,
-		DiskGiB:     40,
-	}
-	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: &out, Exec: runner}).(*backend)
-	b.prepareHelper = func(context.Context, core.Config) (string, error) { return "helper", nil }
-	b.stateRoot = func() (string, error) { return root, nil }
-	b.waitForSSH = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	b := testBackend(t, runner)
+	b.rt.Stdout, b.rt.Stderr = &out, &out
+	root, _ := b.stateRoot()
 
 	leaseID := "cbx_keyretained67890"
 	slug := "key-retained-slug"
@@ -283,36 +228,9 @@ func TestCleanupDryRunDoesNotPlanReclaimedCandidateRemoval(t *testing.T) {
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	var out bytes.Buffer
 
-	oldGOOS, oldGOARCH := hostGOOS, hostGOARCH
-	oldMacOSVersion := hostMacOSVersion
-	hostGOOS, hostGOARCH = "darwin", "arm64"
-	hostMacOSVersion = func() (string, error) { return "26.5", nil }
-	t.Cleanup(func() {
-		hostGOOS, hostGOARCH = oldGOOS, oldGOARCH
-		hostMacOSVersion = oldMacOSVersion
-	})
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".state"))
-	root := t.TempDir()
-
-	cfg := core.BaseConfig()
-	cfg.Provider = providerName
-	cfg.AppleVM = core.AppleVMConfig{
-		HelperPath:  "/tmp/helper-source",
-		Image:       "https://cloud-images.ubuntu.com/releases/noble/release-20260518/ubuntu-24.04-server-cloudimg-arm64.img",
-		ImageSHA256: "6a61b967ba4a27dd1966f835a67643073ed55c2860ce3dc1cb0517282e6b8bec",
-		User:        "runner",
-		WorkRoot:    "/workspace/crabbox",
-		CPUs:        4,
-		MemoryMiB:   8192,
-		DiskGiB:     40,
-	}
-	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: &out, Exec: runner}).(*backend)
-	b.prepareHelper = func(context.Context, core.Config) (string, error) { return "helper", nil }
-	b.stateRoot = func() (string, error) { return root, nil }
-	b.waitForSSH = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	b := testBackend(t, runner)
+	b.rt.Stdout, b.rt.Stderr = &out, &out
+	root, _ := b.stateRoot()
 
 	leaseID := "cbx_dryrun67890"
 	slug := "dryrun-orphan-slug"
@@ -379,36 +297,9 @@ func TestCleanupDryRunReportsGenuineOrphanRemoval(t *testing.T) {
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	var out bytes.Buffer
 
-	oldGOOS, oldGOARCH := hostGOOS, hostGOARCH
-	oldMacOSVersion := hostMacOSVersion
-	hostGOOS, hostGOARCH = "darwin", "arm64"
-	hostMacOSVersion = func() (string, error) { return "26.5", nil }
-	t.Cleanup(func() {
-		hostGOOS, hostGOARCH = oldGOOS, oldGOARCH
-		hostMacOSVersion = oldMacOSVersion
-	})
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".state"))
-	root := t.TempDir()
-
-	cfg := core.BaseConfig()
-	cfg.Provider = providerName
-	cfg.AppleVM = core.AppleVMConfig{
-		HelperPath:  "/tmp/helper-source",
-		Image:       "https://cloud-images.ubuntu.com/releases/noble/release-20260518/ubuntu-24.04-server-cloudimg-arm64.img",
-		ImageSHA256: "6a61b967ba4a27dd1966f835a67643073ed55c2860ce3dc1cb0517282e6b8bec",
-		User:        "runner",
-		WorkRoot:    "/workspace/crabbox",
-		CPUs:        4,
-		MemoryMiB:   8192,
-		DiskGiB:     40,
-	}
-	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: &out, Exec: runner}).(*backend)
-	b.prepareHelper = func(context.Context, core.Config) (string, error) { return "helper", nil }
-	b.stateRoot = func() (string, error) { return root, nil }
-	b.waitForSSH = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	b := testBackend(t, runner)
+	b.rt.Stdout, b.rt.Stderr = &out, &out
+	root, _ := b.stateRoot()
 
 	leaseID := "cbx_dryrun_genuine"
 	slug := "dryrun-genuine-slug"
@@ -443,36 +334,9 @@ func TestCleanupSweepSkipsForeignProviderClaim(t *testing.T) {
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	var out bytes.Buffer
 
-	oldGOOS, oldGOARCH := hostGOOS, hostGOARCH
-	oldMacOSVersion := hostMacOSVersion
-	hostGOOS, hostGOARCH = "darwin", "arm64"
-	hostMacOSVersion = func() (string, error) { return "26.5", nil }
-	t.Cleanup(func() {
-		hostGOOS, hostGOARCH = oldGOOS, oldGOARCH
-		hostMacOSVersion = oldMacOSVersion
-	})
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".state"))
-	root := t.TempDir()
-
-	cfg := core.BaseConfig()
-	cfg.Provider = providerName
-	cfg.AppleVM = core.AppleVMConfig{
-		HelperPath:  "/tmp/helper-source",
-		Image:       "https://cloud-images.ubuntu.com/releases/noble/release-20260518/ubuntu-24.04-server-cloudimg-arm64.img",
-		ImageSHA256: "6a61b967ba4a27dd1966f835a67643073ed55c2860ce3dc1cb0517282e6b8bec",
-		User:        "runner",
-		WorkRoot:    "/workspace/crabbox",
-		CPUs:        4,
-		MemoryMiB:   8192,
-		DiskGiB:     40,
-	}
-	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &out, Stderr: &out, Exec: runner}).(*backend)
-	b.prepareHelper = func(context.Context, core.Config) (string, error) { return "helper", nil }
-	b.stateRoot = func() (string, error) { return root, nil }
-	b.waitForSSH = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	b := testBackend(t, runner)
+	b.rt.Stdout, b.rt.Stderr = &out, &out
+	root, _ := b.stateRoot()
 
 	const foreignProvider = "aws"
 	leaseID := "cbx_foreign_provider"

--- a/internal/providers/azuredynamicsessions/client.go
+++ b/internal/providers/azuredynamicsessions/client.go
@@ -502,24 +502,7 @@ func (c *azureDynamicSessionsClient) nextURL(next string) (string, error) {
 }
 
 func sameOriginURL(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveURLPort(a) == effectiveURLPort(b)
-}
-
-func effectiveURLPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	return shared.SameOrigin(a, b)
 }
 
 func (c *azureDynamicSessionsClient) url(path string, query url.Values) string {

--- a/internal/providers/blaxel/client.go
+++ b/internal/providers/blaxel/client.go
@@ -282,24 +282,7 @@ func secureHTTPClient(source *http.Client) *http.Client {
 }
 
 func sameOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectivePort(a) == effectivePort(b)
-}
-
-func effectivePort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	return shared.SameOrigin(a, b)
 }
 
 func (c *restClient) BaseURL() string { return c.base }

--- a/internal/providers/crownest/client.go
+++ b/internal/providers/crownest/client.go
@@ -122,24 +122,7 @@ func crownestRedirectError(destination *url.URL) error {
 }
 
 func sameOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectivePort(a) == effectivePort(b)
-}
-
-func effectivePort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	return shared.SameOrigin(a, b)
 }
 
 func (c *httpClient) BaseURL() string { return c.baseURL }

--- a/internal/providers/nomad/client.go
+++ b/internal/providers/nomad/client.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hashicorp/go-cleanhttp"
 	nomadapi "github.com/hashicorp/nomad/api"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type Client interface {
@@ -112,24 +113,7 @@ func secureNomadHTTPClient(source *http.Client, trusted *url.URL) *http.Client {
 }
 
 func sameNomadOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveNomadPort(a) == effectiveNomadPort(b)
-}
-
-func effectiveNomadPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	return shared.SameOrigin(a, b)
 }
 
 func sanitizeNomadClientError(err error) error {

--- a/internal/providers/opensandbox/client.go
+++ b/internal/providers/opensandbox/client.go
@@ -237,24 +237,7 @@ func secureOpenSandboxHTTPClient(source *http.Client) *http.Client {
 }
 
 func sameOpenSandboxOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveOpenSandboxPort(a) == effectiveOpenSandboxPort(b)
-}
-
-func effectiveOpenSandboxPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	return shared.SameOrigin(a, b)
 }
 
 func (c *sdkOpenSandboxClient) BaseURL() string { return c.base }

--- a/internal/providers/ovh/client.go
+++ b/internal/providers/ovh/client.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const defaultEndpoint = "https://api.us.ovhcloud.com/1.0"
@@ -268,24 +269,7 @@ func secureOVHHTTPClient(source *http.Client, trusted *url.URL) *http.Client {
 }
 
 func sameOVHOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveOVHPort(a) == effectiveOVHPort(b)
-}
-
-func effectiveOVHPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	return shared.SameOrigin(a, b)
 }
 
 func sanitizeOVHClientError(err error) error {

--- a/internal/providers/scaleway/client.go
+++ b/internal/providers/scaleway/client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const defaultScalewayAPIURL = "https://api.scaleway.com"
@@ -279,24 +280,7 @@ func isScalewayRedirect(status int) bool {
 }
 
 func sameScalewayOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveScalewayPort(a) == effectiveScalewayPort(b)
-}
-
-func effectiveScalewayPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	return shared.SameOrigin(a, b)
 }
 
 func scalewayProfileFromSDKConfig() (*scw.Profile, error) {

--- a/internal/providers/semaphore/api.go
+++ b/internal/providers/semaphore/api.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type apiClient struct {
@@ -357,24 +358,7 @@ func (c *apiClient) apiURL(path string) (string, error) {
 }
 
 func sameOriginURL(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveURLPort(a) == effectiveURLPort(b)
-}
-
-func effectiveURLPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	return shared.SameOrigin(a, b)
 }
 
 func (c *apiClient) getWithHeaders(ctx context.Context, path string) ([]byte, http.Header, error) {

--- a/internal/providers/shared/httpredirect_test.go
+++ b/internal/providers/shared/httpredirect_test.go
@@ -31,8 +31,32 @@ func TestSameOrigin(t *testing.T) {
 			}
 		})
 	}
-	if SameOrigin(nil, base) || SameOrigin(base, nil) {
+	if SameOrigin(nil, base) || SameOrigin(base, nil) || SameOrigin(nil, nil) {
 		t.Fatal("SameOrigin accepted a nil URL")
+	}
+}
+
+func TestSameOriginEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{name: "http default port", a: "http://example.com", b: "HTTP://EXAMPLE.COM:80", want: true},
+		{name: "empty URLs", want: true},
+		{name: "unknown scheme", a: "custom://example.com", b: "CUSTOM://EXAMPLE.COM", want: true},
+		{name: "unknown scheme explicit port", a: "custom://example.com", b: "custom://example.com:443"},
+		{name: "zero padded port", a: "https://example.com:0443", b: "https://example.com:443"},
+		{name: "IPv6 textual difference", a: "https://[2001:db8::1]", b: "https://[2001:0db8::1]"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			a, b := mustParseURL(t, test.a), mustParseURL(t, test.b)
+			if got := SameOrigin(a, b); got != test.want {
+				t.Fatalf("SameOrigin(%q, %q) = %v, want %v", a, b, got, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/providers/unikraftcloud/client.go
+++ b/internal/providers/unikraftcloud/client.go
@@ -253,24 +253,7 @@ func isUnikraftCloudMutation(method string) bool {
 }
 
 func sameUnikraftCloudOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveUnikraftCloudPort(a) == effectiveUnikraftCloudPort(b)
-}
-
-func effectiveUnikraftCloudPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+	return shared.SameOrigin(a, b)
 }
 
 type unikraftCloudRedirectError struct {

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -104,6 +104,41 @@ function ownedAzureTags(overrides: Record<string, string> = {}): Record<string, 
   };
 }
 
+function ownedAzureVMProperties() {
+  return {
+    vmId: "vm-immutable-id",
+    networkProfile: {
+      networkInterfaces: [
+        {
+          id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
+        },
+      ],
+    },
+    storageProfile: {
+      osDisk: {
+        managedDisk: {
+          id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
+        },
+      },
+    },
+  };
+}
+
+function ownedAzureNICProperties() {
+  return {
+    resourceGuid: "nic-immutable-id",
+    ipConfigurations: [
+      {
+        properties: {
+          publicIPAddress: {
+            id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
+          },
+        },
+      },
+    ],
+  };
+}
+
 function memoryAzureDeleteClaimStorage(): {
   records: Map<string, unknown>;
   putKeys: string[];
@@ -947,23 +982,7 @@ describe("azure provider", () => {
           name: "crabbox-blue-lobster",
           location: "eastus",
           tags: ownedAzureTags(),
-          properties: {
-            vmId: "vm-immutable-id",
-            networkProfile: {
-              networkInterfaces: [
-                {
-                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
-                },
-              ],
-            },
-            storageProfile: {
-              osDisk: {
-                managedDisk: {
-                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
-                },
-              },
-            },
-          },
+          properties: ownedAzureVMProperties(),
         });
       }
       if (url.pathname.endsWith("/networkInterfaces/crabbox-blue-lobster-nic")) {
@@ -2476,23 +2495,7 @@ describe("azure provider", () => {
         const isPIP = url.pathname.includes("/publicIPAddresses/");
         const isDisk = url.pathname.includes("/disks/");
         const properties = isVM
-          ? {
-              vmId: "vm-immutable-id",
-              networkProfile: {
-                networkInterfaces: [
-                  {
-                    id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
-                  },
-                ],
-              },
-              storageProfile: {
-                osDisk: {
-                  managedDisk: {
-                    id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
-                  },
-                },
-              },
-            }
+          ? ownedAzureVMProperties()
           : isNIC
             ? {
                 resourceGuid: "nic-immutable-id",
@@ -3001,36 +3004,9 @@ describe("azure provider", () => {
         ? "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/virtualMachines/crabbox-blue-lobster"
         : undefined;
       const properties = url.pathname.includes("/virtualMachines/")
-        ? {
-            vmId: "vm-immutable-id",
-            networkProfile: {
-              networkInterfaces: [
-                {
-                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
-                },
-              ],
-            },
-            storageProfile: {
-              osDisk: {
-                managedDisk: {
-                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
-                },
-              },
-            },
-          }
+        ? ownedAzureVMProperties()
         : url.pathname.includes("/networkInterfaces/")
-          ? {
-              resourceGuid: "nic-immutable-id",
-              ipConfigurations: [
-                {
-                  properties: {
-                    publicIPAddress: {
-                      id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
-                    },
-                  },
-                },
-              ],
-            }
+          ? ownedAzureNICProperties()
           : url.pathname.includes("/publicIPAddresses/")
             ? { resourceGuid: "pip-immutable-id" }
             : url.pathname.includes("/disks/")
@@ -3155,36 +3131,9 @@ describe("azure provider", () => {
           : ownedAzureTags();
       const isDisk = url.pathname.includes("/disks/");
       const properties = url.pathname.includes("/virtualMachines/")
-        ? {
-            vmId: "vm-immutable-id",
-            networkProfile: {
-              networkInterfaces: [
-                {
-                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
-                },
-              ],
-            },
-            storageProfile: {
-              osDisk: {
-                managedDisk: {
-                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
-                },
-              },
-            },
-          }
+        ? ownedAzureVMProperties()
         : url.pathname.includes("/networkInterfaces/")
-          ? {
-              resourceGuid: "nic-immutable-id",
-              ipConfigurations: [
-                {
-                  properties: {
-                    publicIPAddress: {
-                      id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
-                    },
-                  },
-                },
-              ],
-            }
+          ? ownedAzureNICProperties()
           : url.pathname.includes("/publicIPAddresses/")
             ? { resourceGuid: "pip-immutable-id" }
             : isDisk
@@ -3228,36 +3177,9 @@ describe("azure provider", () => {
       const name = url.pathname.slice(url.pathname.lastIndexOf("/") + 1);
       const isDisk = url.pathname.includes("/disks/");
       const properties = url.pathname.includes("/virtualMachines/")
-        ? {
-            vmId: "vm-immutable-id",
-            networkProfile: {
-              networkInterfaces: [
-                {
-                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic",
-                },
-              ],
-            },
-            storageProfile: {
-              osDisk: {
-                managedDisk: {
-                  id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Compute/disks/crabbox-blue-lobster-osdisk",
-                },
-              },
-            },
-          }
+        ? ownedAzureVMProperties()
         : url.pathname.includes("/networkInterfaces/")
-          ? {
-              resourceGuid: "nic-immutable-id",
-              ipConfigurations: [
-                {
-                  properties: {
-                    publicIPAddress: {
-                      id: "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip",
-                    },
-                  },
-                },
-              ],
-            }
+          ? ownedAzureNICProperties()
           : url.pathname.includes("/publicIPAddresses/")
             ? { resourceGuid: "pip-immutable-id" }
             : isDisk

--- a/worker/test/postgres-storage.test.ts
+++ b/worker/test/postgres-storage.test.ts
@@ -264,38 +264,17 @@ describe("PostgresCoordinatorStorage", () => {
     const id = "chk_postgres_fanout";
     const now = new Date().toISOString();
     const org = orgKeyForLabel("example-org");
-    await storage.put(checkpointKey(id), {
-      version: 1,
-      id,
-      owner: "alice@example.com",
-      org,
-      leaseID: "cbx_000000000001",
-      provider: "aws",
-      scope: { region: "eu-west-1", accountID: "123456789012" },
-      name: "parallel-checkpoint",
-      strategy: "disk-snapshot",
-      noReboot: true,
-      image: {
-        id: "snap-owned",
-        resourceID: "snap-owned",
-        kind: "aws-ebs-snapshot",
-        immutableID: "snap-owned",
-        snapshotIDs: ["snap-owned"],
-        state: "available",
-      },
-      state: "ready",
-      retention: { mode: "manual" },
-      generation: 1,
-      revision: 1,
-      createdAt: now,
-      updatedAt: now,
-      lastUsedAt: now,
-      attempts: 0,
-      pinCount: 0,
-      activeUseCount: 0,
-      eventSequence: 0,
-      target: "linux",
-    } satisfies CoordinatorCheckpointRecord);
+    await storage.put(
+      checkpointKey(id),
+      postgresCheckpointFixture({
+        id,
+        owner: "alice@example.com",
+        org,
+        name: "parallel-checkpoint",
+        imageID: "snap-owned",
+        now,
+      }),
+    );
     const claims = await Promise.all(
       Array.from({ length: 12 }, async () =>
         acquireCheckpointUse(storage, id, { owner: "alice@example.com", org }),
@@ -317,38 +296,17 @@ describe("PostgresCoordinatorStorage", () => {
       const id = "chk_postgres_finish_retry";
       const now = new Date().toISOString();
       const org = orgKeyForLabel("example-org");
-      await storage.put(checkpointKey(id), {
-        version: 1,
-        id,
-        owner: "alice@example.com",
-        org,
-        leaseID: "cbx_000000000001",
-        provider: "aws",
-        scope: { region: "eu-west-1", accountID: "123456789012" },
-        name: "parallel-checkpoint",
-        strategy: "disk-snapshot",
-        noReboot: true,
-        image: {
-          id: "snap-owned",
-          resourceID: "snap-owned",
-          kind: "aws-ebs-snapshot",
-          immutableID: "snap-owned",
-          snapshotIDs: ["snap-owned"],
-          state: "available",
-        },
-        state: "ready",
-        retention: { mode: "manual" },
-        generation: 1,
-        revision: 1,
-        createdAt: now,
-        updatedAt: now,
-        lastUsedAt: now,
-        attempts: 0,
-        pinCount: 0,
-        activeUseCount: 0,
-        eventSequence: 0,
-        target: "linux",
-      } satisfies CoordinatorCheckpointRecord);
+      await storage.put(
+        checkpointKey(id),
+        postgresCheckpointFixture({
+          id,
+          owner: "alice@example.com",
+          org,
+          name: "parallel-checkpoint",
+          imageID: "snap-owned",
+          now,
+        }),
+      );
 
       const principal = { owner: "alice@example.com", org };
       const claim = await acquireCheckpointUse(storage, id, principal);
@@ -547,38 +505,17 @@ describe("PostgresCoordinatorStorage", () => {
     const now = new Date().toISOString();
     await Promise.all(
       checkpointIDs.map(async (id) => {
-        await storage.put(checkpointKey(id), {
-          version: 1,
-          id,
-          owner: principal.owner,
-          org: principal.org,
-          leaseID: "cbx_000000000001",
-          provider: "aws",
-          scope: { region: "eu-west-1", accountID: "123456789012" },
-          name: id,
-          strategy: "disk-snapshot",
-          noReboot: true,
-          image: {
+        await storage.put(
+          checkpointKey(id),
+          postgresCheckpointFixture({
             id,
-            resourceID: id,
-            kind: "aws-ebs-snapshot",
-            immutableID: id,
-            snapshotIDs: [id],
-            state: "available",
-          },
-          state: "ready",
-          retention: { mode: "manual" },
-          generation: 1,
-          revision: 1,
-          createdAt: now,
-          updatedAt: now,
-          lastUsedAt: now,
-          attempts: 0,
-          pinCount: 0,
-          activeUseCount: 0,
-          eventSequence: 0,
-          target: "linux",
-        } satisfies CoordinatorCheckpointRecord);
+            owner: principal.owner,
+            org: principal.org,
+            name: id,
+            imageID: id,
+            now,
+          }),
+        );
       }),
     );
     const claims = await Promise.all(
@@ -869,38 +806,17 @@ describe("PostgresCoordinatorStorage", () => {
     const now = new Date().toISOString();
     await Promise.all(
       checkpointIDs.map(async (id) => {
-        await storage.put(checkpointKey(id), {
-          version: 1,
-          id,
-          owner: principal.owner,
-          org: principal.org,
-          leaseID: "cbx_000000000001",
-          provider: "aws",
-          scope: { region: "eu-west-1", accountID: "123456789012" },
-          name: id,
-          strategy: "disk-snapshot",
-          noReboot: true,
-          image: {
+        await storage.put(
+          checkpointKey(id),
+          postgresCheckpointFixture({
             id,
-            resourceID: id,
-            kind: "aws-ebs-snapshot",
-            immutableID: id,
-            snapshotIDs: [id],
-            state: "available",
-          },
-          state: "ready",
-          retention: { mode: "manual" },
-          generation: 1,
-          revision: 1,
-          createdAt: now,
-          updatedAt: now,
-          lastUsedAt: now,
-          attempts: 0,
-          pinCount: 0,
-          activeUseCount: 0,
-          eventSequence: 0,
-          target: "linux",
-        } satisfies CoordinatorCheckpointRecord);
+            owner: principal.owner,
+            org: principal.org,
+            name: id,
+            imageID: id,
+            now,
+          }),
+        );
       }),
     );
     const claims = await Promise.all(
@@ -971,38 +887,17 @@ describe("PostgresCoordinatorStorage", () => {
     const id = "chk_postgres_claim_cap";
     const now = new Date().toISOString();
     const org = orgKeyForLabel("example-org");
-    await storage.put(checkpointKey(id), {
-      version: 1,
-      id,
-      owner: "alice@example.com",
-      org,
-      leaseID: "cbx_000000000001",
-      provider: "aws",
-      scope: { region: "eu-west-1", accountID: "123456789012" },
-      name: "parallel-checkpoint",
-      strategy: "disk-snapshot",
-      noReboot: true,
-      image: {
-        id: "snap-owned",
-        resourceID: "snap-owned",
-        kind: "aws-ebs-snapshot",
-        immutableID: "snap-owned",
-        snapshotIDs: ["snap-owned"],
-        state: "available",
-      },
-      state: "ready",
-      retention: { mode: "manual" },
-      generation: 1,
-      revision: 1,
-      createdAt: now,
-      updatedAt: now,
-      lastUsedAt: now,
-      attempts: 0,
-      pinCount: 0,
-      activeUseCount: 0,
-      eventSequence: 0,
-      target: "linux",
-    } satisfies CoordinatorCheckpointRecord);
+    await storage.put(
+      checkpointKey(id),
+      postgresCheckpointFixture({
+        id,
+        owner: "alice@example.com",
+        org,
+        name: "parallel-checkpoint",
+        imageID: "snap-owned",
+        now,
+      }),
+    );
     const limits = checkpointLimits({ CRABBOX_MAX_CHECKPOINT_USE_CLAIMS: "5" });
 
     const results = await Promise.allSettled(
@@ -1162,6 +1057,55 @@ describe("PostgresCoordinatorStorage", () => {
     },
   );
 });
+
+function postgresCheckpointFixture({
+  id,
+  owner,
+  org,
+  name,
+  imageID,
+  now,
+}: {
+  id: string;
+  owner: string;
+  org: string;
+  name: string;
+  imageID: string;
+  now: string;
+}) {
+  return {
+    version: 1,
+    id,
+    owner,
+    org,
+    leaseID: "cbx_000000000001",
+    provider: "aws",
+    scope: { region: "eu-west-1", accountID: "123456789012" },
+    name,
+    strategy: "disk-snapshot",
+    noReboot: true,
+    image: {
+      id: imageID,
+      resourceID: imageID,
+      kind: "aws-ebs-snapshot",
+      immutableID: imageID,
+      snapshotIDs: [imageID],
+      state: "available",
+    },
+    state: "ready",
+    retention: { mode: "manual" },
+    generation: 1,
+    revision: 1,
+    createdAt: now,
+    updatedAt: now,
+    lastUsedAt: now,
+    attempts: 0,
+    pinCount: 0,
+    activeUseCount: 0,
+    eventSequence: 0,
+    target: "linux",
+  } satisfies CoordinatorCheckpointRecord;
+}
 
 async function postgresReadyPoolFixture() {
   const pool = statefulFakePool();


### PR DESCRIPTION
## Qualification only

This draft pull request validates the cumulative integration prefix for source https://github.com/openclaw/crabbox/pull/1844 against frozen main commit `a6021b3633b828569d1bce9e75a07368f6a48295`.

**Never merge this pull request.** It is qualification evidence only.

- Source pull request: https://github.com/openclaw/crabbox/pull/1844
- B5 integration commit: `d4142b8a753026723f72609e5444d0fd9178a30d`
- Expected tree: `27bf71219af0f174e6282c90c1ac5117ed82906a`
- Integration parents: `81434e76bda9cde6658bcef9900003f5011fa9d6`, `a90a6fba3bb7cfd97a8bed43b4453f09f44aafd5`
- Fresh B5 synthetic merge: `28d5983adbee50c526a864494fff3d716f2b53ec`
- Synthetic parents: `a6021b3633b828569d1bce9e75a07368f6a48295`, `d4142b8a753026723f72609e5444d0fd9178a30d`
- Synthetic tree: `27bf71219af0f174e6282c90c1ac5117ed82906a`
- Reviewed B5 object manifest SHA-256: `1fc4252d33fdf1abe9b6acf2e324f9091170b3e1a076cadb8bd3a40261545683`

## Strict incremental route

Qualification is prefix-scoped. This source pull request may proceed only after the complete normal check set for this exact B5 synthetic merge and tree passes, and after a separate landing authorization confirms the expected current-main predecessor and resulting tree.

There is no all-nine completion barrier. That sequencing change does not weaken any per-prefix CI, Connector, Release Check, CodeQL, policy, checkout-identity, or landing guard.

Current status: checks are pending or running. This body does not claim that CI passed.

## Historical B4 evidence

- Historical B4 proof head: `81434e76bda9cde6658bcef9900003f5011fa9d6`
- Historical B4 synthetic merge: `94ca07b496251eb8b6d5d368f901df605f3c6b56`
- Historical B4 synthetic tree: `7cf73dfa146e5dc788dce5b5d0b966e35fadcf50`
- Reviewed B4 object manifest SHA-256: `6fe8b0dcb9470a566aa76125c6f0139085b0578678025d0e2dbb82b3f00f43e2`
- B4 initial publication receipt SHA-256: `21ee32113f8352d17754beff1cbd0beafdbd49867a8068b6dbfca45a255f0e56`
- B4 terminal unsealed receipt SHA-256: `e62073f7be2e0bd329e2f331ab8ecf00a9f4233bbd98983303592d602da7f649`

Historical B4, B3, and B2 objects, runs, and receipts remain preserved. They are not represented as a B5 pass and are not substitutes for fresh B5 checks.

No manual workflow dispatch, source-branch mutation, main mutation, proof closure, ready-for-review transition, or merge is authorized.
