### PR TITLE
fix: retain cancellation causes for interrupted local bridges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Local provider bridges: preserve cancellation and deadline causes when a POSIX child is interrupted, without masking completed command exits or output-limit errors. Thanks @steipete.
+
 ## 0.49.1 - 2026-09-04
 
 Users upgrading from v0.48.1 also receive the [v0.49.0 changes](https://github.com/openclaw/crabbox/blob/v0.49.0/CHANGELOG.md#0490---2026-09-03), previously available through the Go module release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Report Azure Dynamic Sessions cleanup failures as failed runs, preserve primary Superserve/Azure errors through cleanup and timing output, and keep Superserve rollback bound to the originally created sandbox. [PR 1836](https://github.com/openclaw/crabbox/pull/1836). Thanks @steipete.
-- Local provider bridges: preserve cancellation and deadline causes when a POSIX child is interrupted, without masking completed command exits or output-limit errors. Thanks @steipete.
+- Local provider bridges: preserve cancellation and deadline causes when a POSIX child is interrupted, without masking completed command exits or output-limit errors. [PR 1862](https://github.com/openclaw/crabbox/pull/1862). Thanks @steipete.
 
 ## 0.49.1 - 2026-09-04
 

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -482,6 +482,13 @@ envelopes, versions, identity checks, redaction, and provider error semantics in
 the adapter. Do not use it for noisy CLI output, streaming or NDJSON protocols,
 or commands with ambiguous side effects.
 
+The local command runner preserves caller cancellation/deadline causes when
+its context watcher interrupts a child that then exits by signal. It retains
+the underlying process error and does not relabel observed nonnegative exits,
+post-exit capture cleanup, or output-limit failures as cancellation. This is a
+POSIX signal-termination guarantee; Windows forced-termination codes remain
+unchanged. It does not prove that canceling a bridge stops its remote workload.
+
 Vanilla provider HTTP redirect policy also belongs in
 `internal/providers/shared`. `shared.SecureHTTPClient` clones an injected
 client, rejects destinations outside a trusted `shared.SameOrigin`, preserves

--- a/internal/cli/command_capture_unix_test.go
+++ b/internal/cli/command_capture_unix_test.go
@@ -23,22 +23,26 @@ import (
 func TestExecCommandRunnerFileCapture(t *testing.T) {
 	t.Setenv(controllerProcessTreeOwnedEnv, "")
 	for _, tc := range []struct {
-		mode      string
-		code      int
-		stdout    string
-		stderr    string
-		cancel    bool
-		waitDelay bool
-		overflow  bool
+		mode       string
+		code       int
+		stdout     string
+		stderr     string
+		cancel     bool
+		deadline   bool
+		lateCancel bool
+		waitDelay  bool
+		overflow   bool
 	}{
 		{mode: "normal", stdout: "out", stderr: "err"},
 		{mode: "nonzero", code: 7, stdout: "out", stderr: "err"},
 		{mode: "early-close", cancel: true},
 		{mode: "cancel", cancel: true},
+		{mode: "deadline", cancel: true, deadline: true},
 		{mode: "stdout-overflow", code: 5, stdout: strings.Repeat("x", 1024), overflow: true},
 		{mode: "stderr-overflow", code: 5, stderr: strings.Repeat("x", 1024), overflow: true},
 		{mode: "overflow-exit", code: 5, stdout: strings.Repeat("x", 1024), overflow: true},
 		{mode: "inherited-writer", waitDelay: true},
+		{mode: "completed-exit", code: 23, lateCancel: true, waitDelay: true},
 	} {
 		t.Run(tc.mode, func(t *testing.T) {
 			dir := t.TempDir()
@@ -64,21 +68,32 @@ func TestExecCommandRunnerFileCapture(t *testing.T) {
 				})
 				done <- outcome{result, err}
 			}()
-			if tc.cancel {
+			if tc.cancel || tc.lateCancel {
 				awaitCaptureMarker(t, filepath.Join(dir, "ready"))
-				cancel()
+				if !tc.deadline {
+					cancel()
+				}
 			}
 			got := <-done
 			joined = true
-			if !tc.cancel && ctx.Err() != nil {
+			if !tc.cancel && !tc.lateCancel && ctx.Err() != nil {
 				t.Fatal("command needed the test deadline to stop")
 			}
 			if tc.cancel {
 				if got.err == nil || got.result.ExitCode == 0 {
 					t.Fatalf("canceled child succeeded: %+v", got.result)
 				}
+				if !errors.Is(got.err, ctx.Err()) {
+					t.Errorf("terminated child lost caller context: %v, want %v", got.err, ctx.Err())
+				}
 			} else if tc.waitDelay {
-				if !errors.Is(got.err, exec.ErrWaitDelay) || got.result.ExitCode == 0 {
+				if tc.lateCancel {
+					// The process exited, but Wait may still be joining its watcher;
+					// cancellation can settle the retained writer or leave WaitDelay.
+					if errors.Is(got.err, context.Canceled) || got.result.ExitCode != tc.code {
+						t.Fatalf("late cancellation replaced observed exit: result=%+v err=%v", got.result, got.err)
+					}
+				} else if !errors.Is(got.err, exec.ErrWaitDelay) || got.result.ExitCode == 0 {
 					t.Fatalf("retained writer result=%+v err=%v", got.result, got.err)
 				}
 			} else if got.result.ExitCode != tc.code || (got.err != nil) != (tc.code != 0) {
@@ -86,6 +101,9 @@ func TestExecCommandRunnerFileCapture(t *testing.T) {
 			}
 			if tc.overflow && !strings.Contains(got.err.Error(), "exceeded 1024-byte limit") {
 				t.Fatalf("overflow error=%v", got.err)
+			}
+			if tc.overflow && (errors.Is(got.err, context.Canceled) || errors.Is(got.err, context.DeadlineExceeded)) {
+				t.Fatalf("internal output-limit cancellation became caller cancellation: %v", got.err)
 			}
 			if got.result.Stdout != tc.stdout || got.result.Stderr != tc.stderr {
 				t.Fatalf("capture stdout bytes=%d stderr bytes=%d", len(got.result.Stdout), len(got.result.Stderr))
@@ -225,13 +243,28 @@ func TestExecCommandRunnerFileCaptureHelper(t *testing.T) {
 		}
 	}
 	switch mode {
+	case "completed-exit":
+		child := exec.Command(os.Args[0], append(captureHelperArgs("orphan-leaf", dir), strconv.Itoa(os.Getpid()))...)
+		child.Stdout, child.Stderr = os.Stdout, os.Stderr
+		if err := child.Start(); err != nil {
+			os.Exit(97)
+		}
+		os.Exit(23)
+	case "orphan-leaf":
+		parent, _ := strconv.Atoi(os.Args[index+3])
+		_ = os.WriteFile(filepath.Join(dir, "leaf-pgid"), []byte(strconv.Itoa(syscall.Getpgrp())), 0o600)
+		for os.Getppid() == parent {
+			time.Sleep(time.Millisecond)
+		}
+		_ = os.WriteFile(filepath.Join(dir, "ready"), []byte("parent exited"), 0o600)
+		time.Sleep(time.Hour)
 	case "normal", "nonzero":
 		_, _ = io.WriteString(os.Stdout, "out")
 		_, _ = io.WriteString(os.Stderr, "err")
 		if mode == "nonzero" {
 			os.Exit(7)
 		}
-	case "early-close", "cancel":
+	case "early-close", "cancel", "deadline":
 		if mode == "early-close" {
 			_ = os.Stdout.Close()
 			_ = os.Stderr.Close()

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -855,6 +855,16 @@ func (execCommandRunner) Run(ctx context.Context, req LocalCommandRequest) (Loca
 	if req.MaxCapturedOutputBytes > 0 && !req.DisableOutputCapture {
 		configureBoundedCommandCancellation(cmd)
 	}
+	stopCommand := cmd.Cancel
+	var interrupted error
+	cmd.Cancel = func() error {
+		cause := ctx.Err()
+		err := stopCommand()
+		if !errors.Is(err, os.ErrProcessDone) {
+			interrupted = cause
+		}
+		return err
+	}
 	env := req.Env
 	if env == nil {
 		env = os.Environ()
@@ -883,9 +893,15 @@ func (execCommandRunner) Run(ctx context.Context, req LocalCommandRequest) (Loca
 		var finishCapture func() commandFileCaptureOutcome
 		if files != nil {
 			files.closeWriters()
-			finishCapture = files.watch(cancel, cmd.Cancel, cmd.WaitDelay)
+			finishCapture = files.watch(cancel, stopCommand, cmd.WaitDelay)
 		}
 		err = cmd.Wait()
+		// Wait joins its context watcher. Keep observed exits primary; only a
+		// signaled child gains the caller cause from that watcher's stop attempt.
+		var processErr *exec.ExitError
+		if interrupted != nil && errors.As(err, &processErr) && processErr.ExitCode() < 0 {
+			err = errors.Join(err, interrupted)
+		}
 		if finishCapture != nil {
 			observed := finishCapture()
 			err = errors.Join(err, observed.err)
@@ -893,18 +909,18 @@ func (execCommandRunner) Run(ctx context.Context, req LocalCommandRequest) (Loca
 				return LocalCommandResult{ExitCode: exitCode(err)}, err
 			}
 			if readErr := files.read(&stdout, &stderr); readErr != nil {
-				_ = cmd.Cancel()
+				_ = stopCommand()
 				err = errors.Join(err, readErr)
 				return LocalCommandResult{ExitCode: exitCode(err)}, err
 			}
 			stdout.overflow = stdout.overflow || observed.overflow
 			if stdout.overflow || stderr.overflow || err != nil {
-				_ = cmd.Cancel()
+				_ = stopCommand()
 			}
 		}
 	}
 	if errors.Is(err, exec.ErrWaitDelay) && req.MaxCapturedOutputBytes > 0 && !req.DisableOutputCapture {
-		_ = cmd.Cancel()
+		_ = stopCommand()
 	}
 	result := LocalCommandResult{ExitCode: exitCode(err), Stdout: stdout.String(), Stderr: stderr.String()}
 	if stdout.overflow || stderr.overflow {

--- a/internal/cli/provider_backend_cancel_unix_test.go
+++ b/internal/cli/provider_backend_cancel_unix_test.go
@@ -5,11 +5,43 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
 )
+
+func TestExecCommandRunnerPreservesKilledContext(t *testing.T) {
+	for _, limit := range []int{0, 1024} {
+		t.Run(fmt.Sprintf("capture-limit=%d", limit), func(t *testing.T) {
+			dir := t.TempDir()
+			ready := filepath.Join(dir, "ready")
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			done := make(chan error, 1)
+			go func() {
+				_, err := (execCommandRunner{}).Run(ctx, LocalCommandRequest{
+					Name: "sh", Args: []string{"-c", `printf ready > "$1"; exec sleep 30`, "sh", ready},
+					MaxCapturedOutputBytes: limit,
+				})
+				done <- err
+			}()
+			awaitCaptureMarker(t, ready)
+			cancel()
+			select {
+			case err := <-done:
+				var processErr *exec.ExitError
+				if !errors.Is(err, context.Canceled) || !errors.As(err, &processErr) || processErr.ExitCode() != -1 {
+					t.Fatalf("expected both cancellation and signaled process cause, got %v", err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("interrupted command did not return")
+			}
+		})
+	}
+}
 
 func TestExecCommandRunnerAllowsGracefulCancellation(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

Preserve the caller's cancellation/deadline cause when the local command runner actually interrupts a child that then exits by signal. The error previously reached provider bridges only as `signal: killed`, so a real canceled CodeSandbox CLI run was classified as a provider failure. Fix the shared executor, not each bridge or lifecycle adapter.

Capture provenance only in os/exec's context-watcher cancellation callback. Wait synchronizes that callback; join its caller cause only for a negative/signaled process exit. File-capture watchers and post-Wait cleanup retain the raw stop callback, so later cleanup cannot fabricate cancellation provenance. Preserve observed nonnegative process exits, startup errors, output-limit exit5, cleanup ownership and capture limits.

## Verification

Five native subprocess regression cases fail before the fix: ordinary/bounded pipe cancellation and file-capture cancellation/early-close/deadline. They pass after the fix; the focused suite passes10 repetitions. Existing capture/streaming/graceful cancellation/retained-writer/controller-group tests pass. A late-cancel fixture verifies observed exit23 remains primary whether the retained output writer settles or times out. Independent review caught an initially overstrict scheduler assumption in that fixture; it was corrected and repeated.

Shared/procjson, CodeSandbox, SmolVM and Upstash race suites, scoped vet and docs build pass. The broader local CLI race suite hit its15-minute package timeout; the header reports a newly started retained-lease renewal test (0s), with no preceding failed assertion. This is not counted as a pass; focused diagnosis and current-head hosted CI are pending before landing. Managed Codex and independent semantic review have no actionable findings.

Actual Linux arm64 CLI + production Node bridge + real Bash, composed with the CodeSandbox lifecycle changes in https://github.com/openclaw/crabbox/pull/1843: real SIGTERM scenarios pass2/2 after this fix versus0/2 without it. Both default cleanup and keep-on-failure now report canceled; exact fixture resource/claim/env cleanup and container removal are verified. The SDK boundary is synthetic, container network is disabled, and this is not hosted CodeSandbox or vendor-SDK certification.

## Scope and risk

POSIX signal-termination fix only: Windows forced termination reports a nonnegative process code and remains unchanged. A local bridge stopping does not prove its remote workload stopped. No new dependencies, credentials, configuration, provider flags, permissions or deletion authority. Error chains now retain both the original process error and context cause. Frozen v0.49.1/v0.49.0 notes are unchanged; maintainer Unreleased entry added.
