### PR TITLE
refactor(smoke): share provider JSON matchers

### DIFF
--- a/scripts/lib/live-smoke-json-match.py
+++ b/scripts/lib/live-smoke-json-match.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+
+PROFILES = {"standard", "runpod", "lambda", "nebius", "vast"}
+OPERATIONS = {"contains", "absent", "probe", "empty"}
+DIRECT_KEYS = ("slug", "name", "id", "leaseId")
+def has_slug(value, slug, profile):
+    if isinstance(value, dict):
+        labels = value.get("labels")
+        if profile in ("lambda", "vast"):
+            labels = labels or value.get("tags")
+        aliases = ("slug", "crabbox_slug") if profile == "nebius" else ("slug", "crabbox.slug") if profile in ("lambda", "vast") else ("slug",)
+        if isinstance(labels, dict) and any(labels.get(alias) == slug for alias in aliases):
+            return True
+        if profile != "runpod" and any(value.get(key) == slug for key in DIRECT_KEYS):
+            return True
+        if profile == "vast" and f"|{slug}|" in str(value.get("label", "")):
+            return True
+        return any(has_slug(child, slug, profile) for child in value.values())
+    if isinstance(value, list):
+        return any(has_slug(child, slug, profile) for child in value)
+    return False
+def main():
+    if len(sys.argv) != 3 or sys.argv[1] not in PROFILES or sys.argv[2] not in OPERATIONS:
+        print("usage: live-smoke-json-match.py PROFILE OPERATION", file=sys.stderr)
+        return 2
+    profile, operation = sys.argv[1:3]
+    try:
+        payload = json.load(sys.stdin)
+    except Exception as exc:
+        print(f"invalid JSON: {exc}", file=sys.stderr)
+        return 2 if operation == "probe" else 1
+    matched = payload == [] if operation == "empty" else has_slug(payload, os.environ["CRABBOX_SMOKE_SLUG"], profile)
+    if operation == "probe":
+        return 0 if matched else 1
+    if matched == (operation == "absent"):
+        print(os.environ["CRABBOX_SMOKE_FAILURE"], file=sys.stderr)
+        return 1
+    return 0
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/live-docker-sandbox-smoke.sh
+++ b/scripts/live-docker-sandbox-smoke.sh
@@ -62,34 +62,7 @@ validate_list_json_contains_slug() {
   local status=0
   set +e
   if command -v python3 >/dev/null 2>&1; then
-    validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
-import json
-import os
-import sys
-
-slug = os.environ["CRABBOX_SMOKE_SLUG"]
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-def has_slug(value):
-    if isinstance(value, dict):
-        labels = value.get("labels")
-        if isinstance(labels, dict) and labels.get("slug") == slug:
-            return True
-        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
-            return True
-        return any(has_slug(child) for child in value.values())
-    if isinstance(value, list):
-        return any(has_slug(child) for child in value)
-    return False
-
-if not has_slug(payload):
-    print(f"list JSON did not include slug {slug}", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
+    validation_output="$(CRABBOX_SMOKE_SLUG="$slug" CRABBOX_SMOKE_FAILURE="list JSON did not include slug $slug" python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/live-smoke-json-match.py" standard contains <<<"$output" 2>&1)"
     status=$?
   elif command -v node >/dev/null 2>&1; then
     validation_output="$(CRABBOX_SMOKE_SLUG="$slug" node -e '

--- a/scripts/live-docker-sandbox-smoke.test.js
+++ b/scripts/live-docker-sandbox-smoke.test.js
@@ -9,7 +9,9 @@ import { copySmokeRepo, writeExecutable, writeGoStub } from "./test-support/smok
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
 const prepareSmokeRepo = (dir) =>
-  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-docker-sandbox-smoke.sh"));
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-docker-sandbox-smoke.sh"), [
+    "lib/live-smoke-json-match.py",
+  ]);
 
 test("live docker sandbox smoke honors configured alternate sbx path", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-sbx-smoke-"));
@@ -198,6 +200,104 @@ exit 99`,
     assert.match(fs.readFileSync(stopped, "utf8"), /^docker-sandbox-smoke-\d{14}-\d+\n$/);
   });
 }
+
+test("live docker sandbox smoke preserves JSON parser selection and failure boundaries", async (t) => {
+  const realTools = Object.fromEntries(
+    ["python3", "node", "jq"].map((name) => {
+      const result = spawnSync("sh", ["-c", `command -v ${name}`], { encoding: "utf8" });
+      assert.equal(result.status, 0, `${name} is required for parser selection coverage`);
+      return [name, result.stdout.trim()];
+    }),
+  );
+
+  for (const testCase of [
+    { name: "python", hidden: [], expectedStatus: 0, selected: "python3" },
+    { name: "node", hidden: ["python3"], expectedStatus: 0, selected: "node" },
+    { name: "jq", hidden: ["python3", "node"], expectedStatus: 0, selected: "jq" },
+    { name: "none", hidden: ["python3", "node", "jq"], expectedStatus: 1, selected: "" },
+    {
+      name: "node failure does not fall through to jq",
+      hidden: ["python3"],
+      expectedStatus: 7,
+      selected: "node",
+      failing: "node",
+    },
+  ]) {
+    await t.test(testCase.name, () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-docker-parser-"));
+      const binDir = path.join(dir, "bin");
+      const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
+      const selectedFile = path.join(dir, "selected.log");
+      const slugFile = path.join(dir, "slug.txt");
+      const bashEnv = path.join(dir, "bash-env");
+      fs.mkdirSync(binDir, { recursive: true });
+
+      fs.writeFileSync(
+        bashEnv,
+        `command() {
+  if [[ "\${1:-}" == "-v" ]]; then
+    case "\${2:-}" in
+${testCase.hidden.map((name) => `      ${name}) return 1 ;;`).join("\n")}
+    esac
+  fi
+  builtin command "$@"
+}
+`,
+        "utf8",
+      );
+
+      for (const name of ["python3", "node", "jq"]) {
+        writeExecutable(
+          path.join(binDir, name),
+          `#!/usr/bin/env bash
+printf '%s\\n' ${JSON.stringify(name)} >>${JSON.stringify(selectedFile)}
+${testCase.failing === name ? "exit 7" : `exec ${JSON.stringify(realTools[name])} "$@"`}
+`,
+        );
+      }
+
+      writeGoStub(
+        binDir,
+        `#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  doctor) printf 'ok      sbx_version provider=docker-sandbox version=sbx-client-fake\\n' ;;
+  warmup)
+    while [[ "$#" -gt 0 ]]; do
+      if [[ "$1" == "--slug" ]]; then printf '%s' "$2" >${JSON.stringify(slugFile)}; break; fi
+      shift
+    done
+    ;;
+  run|stop) exit 0 ;;
+  list) printf '[{"labels":{"slug":"%s"}}]\\n' "$(cat ${JSON.stringify(slugFile)})" ;;
+  *) exit 99 ;;
+esac`,
+      );
+
+      const result = spawnSync("bash", [smokeScript], {
+        cwd: tempRoot,
+        env: {
+          ...process.env,
+          BASH_ENV: bashEnv,
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        },
+        encoding: "utf8",
+      });
+
+      assert.equal(result.status, testCase.expectedStatus, result.stdout + result.stderr);
+      const selected = fs.existsSync(selectedFile)
+        ? fs.readFileSync(selectedFile, "utf8").trim().split("\n")
+        : [];
+      assert.deepEqual(selected, testCase.selected ? [testCase.selected] : []);
+      if (testCase.name === "none") {
+        assert.match(result.stderr, /no JSON parser available/);
+      }
+      if (testCase.failing) {
+        assert.doesNotMatch(selected.join("\n"), /^jq$/m);
+      }
+    });
+  }
+});
 
 test("live docker sandbox smoke classifies provider preflight failures", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-docker-sandbox-"));

--- a/scripts/live-github-codespaces-smoke.sh
+++ b/scripts/live-github-codespaces-smoke.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+json_matcher="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/live-smoke-json-match.py"
+
 provider_enabled() {
   local list="${CRABBOX_LIVE_PROVIDERS:-github-codespaces}"
   local item
@@ -100,34 +102,7 @@ validate_list_json_contains_slug() {
   local validation_output=""
   local status=0
   set +e
-  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" "$python_bin" -c '
-import json
-import os
-import sys
-
-slug = os.environ["CRABBOX_SMOKE_SLUG"]
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-def has_slug(value):
-    if isinstance(value, dict):
-        labels = value.get("labels")
-        if isinstance(labels, dict) and labels.get("slug") == slug:
-            return True
-        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
-            return True
-        return any(has_slug(child) for child in value.values())
-    if isinstance(value, list):
-        return any(has_slug(child) for child in value)
-    return False
-
-if not has_slug(payload):
-    print(f"list JSON did not include slug {slug}", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" CRABBOX_SMOKE_FAILURE="list JSON did not include slug $slug" "$python_bin" "$json_matcher" standard contains <<<"$output" 2>&1)"
   status=$?
   set -e
   if [[ "$status" -ne 0 ]]; then
@@ -142,34 +117,7 @@ validate_list_json_missing_slug() {
   local validation_output=""
   local status=0
   set +e
-  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" "$python_bin" -c '
-import json
-import os
-import sys
-
-slug = os.environ["CRABBOX_SMOKE_SLUG"]
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-def has_slug(value):
-    if isinstance(value, dict):
-        labels = value.get("labels")
-        if isinstance(labels, dict) and labels.get("slug") == slug:
-            return True
-        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
-            return True
-        return any(has_slug(child) for child in value.values())
-    if isinstance(value, list):
-        return any(has_slug(child) for child in value)
-    return False
-
-if has_slug(payload):
-    print(f"list JSON still included slug {slug}", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" CRABBOX_SMOKE_FAILURE="list JSON still included slug $slug" "$python_bin" "$json_matcher" standard absent <<<"$output" 2>&1)"
   status=$?
   set -e
   if [[ "$status" -ne 0 ]]; then
@@ -227,32 +175,7 @@ for item in json.load(sys.stdin):
 }
 
 local_inventory_has_slug() {
-  CRABBOX_SMOKE_SLUG="$slug" "$python_bin" -c '
-import json
-import os
-import sys
-
-slug = os.environ["CRABBOX_SMOKE_SLUG"]
-
-def has_slug(value):
-    if isinstance(value, dict):
-        labels = value.get("labels")
-        if isinstance(labels, dict) and labels.get("slug") == slug:
-            return True
-        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
-            return True
-        return any(has_slug(child) for child in value.values())
-    if isinstance(value, list):
-        return any(has_slug(child) for child in value)
-    return False
-
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(2)
-sys.exit(0 if has_slug(payload) else 1)
-'
+  CRABBOX_SMOKE_SLUG="$slug" "$python_bin" "$json_matcher" standard probe
 }
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/live-github-codespaces-smoke.test.js
+++ b/scripts/live-github-codespaces-smoke.test.js
@@ -16,9 +16,15 @@ function prepareSmokeRepo(dir) {
   const tempRoot = path.join(dir, "repo");
   const tempScripts = path.join(tempRoot, "scripts");
   const fixtureDir = path.join(tempScripts, "fixtures", "github-codespaces");
+  const libDir = path.join(tempScripts, "lib");
   const smokeScript = path.join(tempScripts, "live-github-codespaces-smoke.sh");
   fs.mkdirSync(fixtureDir, { recursive: true });
+  fs.mkdirSync(libDir, { recursive: true });
   fs.copyFileSync(path.join(repoRoot, "scripts", "live-github-codespaces-smoke.sh"), smokeScript);
+  fs.copyFileSync(
+    path.join(repoRoot, "scripts", "lib", "live-smoke-json-match.py"),
+    path.join(libDir, "live-smoke-json-match.py"),
+  );
   fs.copyFileSync(
     path.join(repoRoot, "scripts", "fixtures", "github-codespaces", "devcontainer.json"),
     path.join(fixtureDir, "devcontainer.json"),

--- a/scripts/live-lambda-smoke.sh
+++ b/scripts/live-lambda-smoke.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+json_matcher="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/live-smoke-json-match.py"
+
 provider_enabled() {
   local list="${CRABBOX_LIVE_PROVIDERS:-lambda}"
   local item
@@ -103,34 +105,7 @@ validate_list_json_contains_slug() {
   local validation_output=""
   local status=0
   set +e
-  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
-import json
-import os
-import sys
-
-slug = os.environ["CRABBOX_SMOKE_SLUG"]
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-def has_slug(value):
-    if isinstance(value, dict):
-        labels = value.get("labels") or value.get("tags")
-        if isinstance(labels, dict) and (labels.get("slug") == slug or labels.get("crabbox.slug") == slug):
-            return True
-        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
-            return True
-        return any(has_slug(child) for child in value.values())
-    if isinstance(value, list):
-        return any(has_slug(child) for child in value)
-    return False
-
-if not has_slug(payload):
-    print(f"list JSON did not include slug {slug}", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" CRABBOX_SMOKE_FAILURE="list JSON did not include slug $slug" python3 "$json_matcher" lambda contains <<<"$output" 2>&1)"
   status=$?
   set -e
   if [ "$status" -ne 0 ]; then
@@ -145,20 +120,7 @@ validate_list_json_empty() {
   local validation_output=""
   local status=0
   set +e
-  validation_output="$(python3 -c '
-import json
-import sys
-
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-if payload != []:
-    print("Lambda Crabbox inventory is not empty", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" CRABBOX_SMOKE_FAILURE="Lambda Crabbox inventory is not empty" python3 "$json_matcher" standard empty <<<"$output" 2>&1)"
   status=$?
   set -e
   if [ "$status" -ne 0 ]; then

--- a/scripts/live-lambda-smoke.test.js
+++ b/scripts/live-lambda-smoke.test.js
@@ -27,7 +27,9 @@ exec ${JSON.stringify(python)} "$@"
 }
 
 const prepareSmokeRepo = (dir) =>
-  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-lambda-smoke.sh"));
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-lambda-smoke.sh"), [
+    "lib/live-smoke-json-match.py",
+  ]);
 
 test("live lambda smoke skips unless opted in", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-lambda-skip-"));

--- a/scripts/live-nebius-smoke.sh
+++ b/scripts/live-nebius-smoke.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+json_matcher="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/live-smoke-json-match.py"
+
 provider_enabled() {
   local list="${CRABBOX_LIVE_PROVIDERS:-}"
   local item
@@ -57,34 +59,7 @@ validate_list_json_contains_slug() {
   local validation_output=""
   local status=0
   set +e
-  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
-import json
-import os
-import sys
-
-slug = os.environ["CRABBOX_SMOKE_SLUG"]
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-def has_slug(value):
-    if isinstance(value, dict):
-        labels = value.get("labels")
-        if isinstance(labels, dict) and (labels.get("slug") == slug or labels.get("crabbox_slug") == slug):
-            return True
-        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
-            return True
-        return any(has_slug(child) for child in value.values())
-    if isinstance(value, list):
-        return any(has_slug(child) for child in value)
-    return False
-
-if not has_slug(payload):
-    print(f"list JSON did not include slug {slug}", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" CRABBOX_SMOKE_FAILURE="list JSON did not include slug $slug" python3 "$json_matcher" nebius contains <<<"$output" 2>&1)"
   status=$?
   set -e
   if [[ "$status" -ne 0 ]]; then
@@ -99,34 +74,7 @@ validate_list_json_absent_slug() {
   local validation_output=""
   local status=0
   set +e
-  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
-import json
-import os
-import sys
-
-slug = os.environ["CRABBOX_SMOKE_SLUG"]
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-def has_slug(value):
-    if isinstance(value, dict):
-        labels = value.get("labels")
-        if isinstance(labels, dict) and (labels.get("slug") == slug or labels.get("crabbox_slug") == slug):
-            return True
-        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
-            return True
-        return any(has_slug(child) for child in value.values())
-    if isinstance(value, list):
-        return any(has_slug(child) for child in value)
-    return False
-
-if has_slug(payload):
-    print(f"list JSON still includes slug {slug}", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" CRABBOX_SMOKE_FAILURE="list JSON still includes slug $slug" python3 "$json_matcher" nebius absent <<<"$output" 2>&1)"
   status=$?
   set -e
   if [[ "$status" -ne 0 ]]; then

--- a/scripts/live-nebius-smoke.test.js
+++ b/scripts/live-nebius-smoke.test.js
@@ -9,7 +9,9 @@ import { copySmokeRepo, shellArgHelper, writeExecutable } from "./test-support/s
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
 const prepareSmokeRepo = (dir) =>
-  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-nebius-smoke.sh"));
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-nebius-smoke.sh"), [
+    "lib/live-smoke-json-match.py",
+  ]);
 
 function writeGoStub(binDir, scriptBody) {
   writeExecutable(

--- a/scripts/live-nvidia-brev-smoke.sh
+++ b/scripts/live-nvidia-brev-smoke.sh
@@ -54,34 +54,7 @@ validate_list_json_contains_slug() {
   local validation_output=""
   local status=0
   set +e
-  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
-import json
-import os
-import sys
-
-slug = os.environ["CRABBOX_SMOKE_SLUG"]
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-def has_slug(value):
-    if isinstance(value, dict):
-        labels = value.get("labels")
-        if isinstance(labels, dict) and labels.get("slug") == slug:
-            return True
-        if value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
-            return True
-        return any(has_slug(child) for child in value.values())
-    if isinstance(value, list):
-        return any(has_slug(child) for child in value)
-    return False
-
-if not has_slug(payload):
-    print(f"list JSON did not include slug {slug}", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" CRABBOX_SMOKE_FAILURE="list JSON did not include slug $slug" python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/live-smoke-json-match.py" standard contains <<<"$output" 2>&1)"
   status=$?
   set -e
   if [[ "$status" -ne 0 ]]; then

--- a/scripts/live-nvidia-brev-smoke.test.js
+++ b/scripts/live-nvidia-brev-smoke.test.js
@@ -9,7 +9,9 @@ import { copySmokeRepo, shellArgHelper, writeExecutable } from "./test-support/s
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
 const prepareSmokeRepo = (dir) =>
-  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-nvidia-brev-smoke.sh"));
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-nvidia-brev-smoke.sh"), [
+    "lib/live-smoke-json-match.py",
+  ]);
 
 function writeGoStub(binDir, scriptBody) {
   writeExecutable(

--- a/scripts/live-runpod-smoke.sh
+++ b/scripts/live-runpod-smoke.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+json_matcher="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/live-smoke-json-match.py"
+
 provider_enabled() {
   local list="${CRABBOX_LIVE_PROVIDERS:-runpod}"
   local item
@@ -57,32 +59,7 @@ validate_list_json_contains_slug() {
   local validation_output=""
   local status=0
   set +e
-  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
-import json
-import os
-import sys
-
-slug = os.environ["CRABBOX_SMOKE_SLUG"]
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-def has_slug(value):
-    if isinstance(value, dict):
-        labels = value.get("labels")
-        if isinstance(labels, dict) and labels.get("slug") == slug:
-            return True
-        return any(has_slug(child) for child in value.values())
-    if isinstance(value, list):
-        return any(has_slug(child) for child in value)
-    return False
-
-if not has_slug(payload):
-    print(f"list JSON did not include slug {slug}", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" CRABBOX_SMOKE_FAILURE="list JSON did not include slug $slug" python3 "$json_matcher" runpod contains <<<"$output" 2>&1)"
   status=$?
   set -e
   if [ "$status" -ne 0 ]; then
@@ -97,20 +74,7 @@ validate_list_json_empty() {
   local validation_output=""
   local status=0
   set +e
-  validation_output="$(python3 -c '
-import json
-import sys
-
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-if payload != []:
-    print("RunPod Crabbox inventory is not empty", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" CRABBOX_SMOKE_FAILURE="RunPod Crabbox inventory is not empty" python3 "$json_matcher" standard empty <<<"$output" 2>&1)"
   status=$?
   set -e
   if [ "$status" -ne 0 ]; then

--- a/scripts/live-runpod-smoke.test.js
+++ b/scripts/live-runpod-smoke.test.js
@@ -9,7 +9,9 @@ import { copySmokeRepo, writeExecutable, writeGoStub } from "./test-support/smok
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
 const prepareSmokeRepo = (dir) =>
-  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-runpod-smoke.sh"));
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-runpod-smoke.sh"), [
+    "lib/live-smoke-json-match.py",
+  ]);
 
 test("live RunPod smoke embedded cleanup Python compiles", () => {
   const script = fs.readFileSync(path.join(repoRoot, "scripts", "live-runpod-smoke.sh"), "utf8");

--- a/scripts/live-smoke-json-match.test.js
+++ b/scripts/live-smoke-json-match.test.js
@@ -1,0 +1,290 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+
+const slug = "public-smoke-slug";
+const redactionProbe = "public-test-token";
+const matcher = path.join(import.meta.dirname, "lib", "live-smoke-json-match.py");
+
+const adapters = [
+  {
+    name: "lambda",
+    profile: "lambda",
+    operations: ["contains", "empty"],
+    interpreter: "python3",
+  },
+  {
+    name: "nebius",
+    profile: "nebius",
+    operations: ["contains", "absent"],
+    interpreter: "python3",
+  },
+  { name: "nvidia-brev", profile: "standard", operations: ["contains"], interpreter: "python3" },
+  {
+    name: "github-codespaces",
+    profile: "standard",
+    operations: ["contains", "absent", "probe"],
+    interpreter: "configured-python",
+  },
+  {
+    name: "runpod",
+    profile: "runpod",
+    operations: ["contains", "empty"],
+    interpreter: "python3",
+  },
+  { name: "vast", profile: "vast", operations: ["contains", "empty"], interpreter: "python3" },
+  { name: "docker-sandbox", profile: "standard", operations: ["contains"], interpreter: "python3" },
+];
+
+const cases = [
+  { name: "empty-list", raw: "[]" },
+  { name: "direct-slug", raw: JSON.stringify([{ slug }]) },
+  { name: "direct-name", raw: JSON.stringify([{ name: slug }]) },
+  { name: "direct-id", raw: JSON.stringify([{ id: slug }]) },
+  { name: "direct-lease-id", raw: JSON.stringify([{ leaseId: slug }]) },
+  { name: "labels-slug", raw: JSON.stringify([{ labels: { slug } }]) },
+  { name: "tags-slug", raw: JSON.stringify([{ tags: { slug } }]) },
+  { name: "labels-dotted-alias", raw: JSON.stringify([{ labels: { "crabbox.slug": slug } }]) },
+  {
+    name: "empty-labels-fall-through-to-tags",
+    raw: JSON.stringify([{ labels: {}, tags: { "crabbox.slug": slug } }]),
+  },
+  { name: "labels-underscore-alias", raw: JSON.stringify([{ labels: { crabbox_slug: slug } }]) },
+  { name: "vast-delimited-label", raw: JSON.stringify([{ label: `prefix|${slug}|suffix` }]) },
+  { name: "nested-labels-slug", raw: JSON.stringify({ outer: [{ inner: { labels: { slug } } }] }) },
+  { name: "partial-and-unrelated-values", raw: JSON.stringify([{ slug: `${slug}-other`, note: slug }]) },
+  {
+    name: "truthy-labels-mask-dotted-tag-alias",
+    raw: JSON.stringify([{ labels: { other: true }, tags: { "crabbox.slug": slug } }]),
+  },
+  { name: "vast-list-label-stringification", raw: JSON.stringify([{ label: [`|${slug}|`] }]) },
+  { name: "malformed-json", raw: "{" },
+];
+
+const baselineProgram = String.raw`
+import json
+import sys
+
+adapter, operation, slug = sys.argv[1:4]
+profile = {
+    "lambda": "lambda",
+    "nebius": "nebius",
+    "nvidia-brev": "standard",
+    "github-codespaces": "standard",
+    "runpod": "runpod",
+    "vast": "vast",
+    "docker-sandbox": "standard",
+}[adapter]
+
+def has_slug(value):
+    if isinstance(value, dict):
+        if profile in ("lambda", "vast"):
+            labels = value.get("labels") or value.get("tags")
+        else:
+            labels = value.get("labels")
+        if isinstance(labels, dict):
+            if labels.get("slug") == slug:
+                return True
+            if profile in ("lambda", "vast") and labels.get("crabbox.slug") == slug:
+                return True
+            if profile == "nebius" and labels.get("crabbox_slug") == slug:
+                return True
+        if profile != "runpod":
+            if any(value.get(key) == slug for key in ("slug", "name", "id", "leaseId")):
+                return True
+        if profile == "vast" and f"|{slug}|" in str(value.get("label", "")):
+            return True
+        return any(has_slug(child) for child in value.values())
+    if isinstance(value, list):
+        return any(has_slug(child) for child in value)
+    return False
+
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    print(f"invalid JSON: {exc}", file=sys.stderr)
+    sys.exit(2 if operation == "probe" else 1)
+
+matched = has_slug(payload)
+if operation == "probe":
+    sys.exit(0 if matched else 1)
+if operation == "empty":
+    if payload != []:
+        provider = {"lambda": "Lambda", "runpod": "RunPod", "vast": "Vast"}[adapter]
+        print(f"{provider} Crabbox inventory is not empty", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)
+if operation == "contains" and not matched:
+    print(f"list JSON did not include slug {slug}", file=sys.stderr)
+    sys.exit(1)
+if operation == "absent" and matched:
+    verb = "included" if adapter == "github-codespaces" else "includes"
+    print(f"list JSON still {verb} slug {slug}", file=sys.stderr)
+    sys.exit(1)
+`;
+
+function runBaseline(adapter, operation, raw) {
+  const result = spawnSync("python3", ["-c", baselineProgram, adapter.name, operation, slug], {
+    input: `${raw}\n`,
+    encoding: "utf8",
+    env: {
+      PATH: "/bin:/usr/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/usr/local/bin",
+    },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    interpreter: adapter.interpreter,
+    redacted: !result.stdout.includes(redactionProbe) && !result.stderr.includes(redactionProbe),
+  };
+}
+
+function failureMessage(adapter, operation) {
+  if (operation === "contains") {
+    return `list JSON did not include slug ${slug}`;
+  }
+  if (operation === "absent") {
+    const verb = adapter.name === "github-codespaces" ? "included" : "includes";
+    return `list JSON still ${verb} slug ${slug}`;
+  }
+  if (operation === "empty") {
+    const provider = { lambda: "Lambda", runpod: "RunPod", vast: "Vast" }[adapter.name];
+    return `${provider} Crabbox inventory is not empty`;
+  }
+  return "";
+}
+
+function runMatcher(profile, operation, raw, failure = "") {
+  return spawnSync("python3", [matcher, profile, operation], {
+    input: `${raw}\n`,
+    encoding: "utf8",
+    env: {
+      CRABBOX_SMOKE_FAILURE: failure,
+      CRABBOX_SMOKE_SLUG: slug,
+      PATH: "/bin:/usr/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/usr/local/bin",
+    },
+  });
+}
+
+function runCandidate(adapter, operation, raw) {
+  const matcherResult = runMatcher(
+    adapter.profile,
+    operation,
+    raw,
+    failureMessage(adapter, operation),
+  );
+  return {
+    status: matcherResult.status,
+    stdout: matcherResult.stdout,
+    stderr: matcherResult.stderr,
+    interpreter: adapter.interpreter,
+    redacted:
+      !matcherResult.stdout.includes(redactionProbe) &&
+      !matcherResult.stderr.includes(redactionProbe),
+  };
+}
+
+function wrapNested(value, depth) {
+  let nested = value;
+  for (let index = 0; index < depth; index += 1) {
+    nested = index % 2 === 0 ? { [`level${index}`]: [nested] } : [{ [`level${index}`]: nested }];
+  }
+  return nested;
+}
+
+let historicalRecords;
+
+function materializeHistoricalRecords() {
+  historicalRecords ??= adapters.flatMap((adapter) =>
+    cases.map((fixture) => ({
+      adapter: adapter.name,
+      profile: adapter.profile,
+      case: fixture.name,
+      raw: fixture.raw,
+      results: Object.fromEntries(
+        adapter.operations.map((operation) => [
+          operation,
+          runBaseline(adapter, operation, fixture.raw),
+        ]),
+      ),
+    })),
+  );
+  return historicalRecords;
+}
+
+test("historical provider matchers materialize 112 fixed differential cases", () => {
+  const records = materializeHistoricalRecords();
+
+  assert.equal(records.length, 112);
+  assert.equal(new Set(records.map(({ adapter, case: name }) => `${adapter}:${name}`)).size, 112);
+  for (const record of records) {
+    for (const result of Object.values(record.results)) {
+      assert.equal(typeof result.status, "number");
+      assert.equal(typeof result.stdout, "string");
+      assert.equal(typeof result.stderr, "string");
+      assert.ok(result.interpreter);
+      assert.equal(result.redacted, true);
+    }
+  }
+
+  const malformed = records.filter(({ case: name }) => name === "malformed-json");
+  assert.equal(malformed.length, 7);
+  assert.equal(malformed.find(({ adapter }) => adapter === "github-codespaces").results.probe.status, 2);
+  assert.match(malformed[0].results.contains.stderr, /^invalid JSON: /);
+});
+
+test("shared matcher reproduces all 112 historical adapter cases", () => {
+  for (const record of materializeHistoricalRecords()) {
+    const adapter = adapters.find(({ name }) => name === record.adapter);
+    for (const operation of adapter.operations) {
+      assert.deepEqual(
+        runCandidate(adapter, operation, record.raw),
+        record.results[operation],
+        `${record.adapter}:${record.case}:${operation}`,
+      );
+    }
+  }
+});
+
+test("historical provider matchers traverse the generated nested JSON corpus", () => {
+  const nestedCases = adapters.flatMap((adapter) =>
+    Array.from({ length: 8 }, (_, index) => ({
+      adapter,
+      depth: index + 1,
+      raw: JSON.stringify(wrapNested({ labels: { slug } }, index + 1)),
+    })),
+  );
+
+  assert.equal(nestedCases.length, 56);
+  for (const fixture of nestedCases) {
+    const result = runBaseline(fixture.adapter, "contains", fixture.raw);
+    assert.equal(result.status, 0, `${fixture.adapter.name} depth=${fixture.depth}: ${result.stderr}`);
+    assert.equal(result.stdout, "");
+    assert.equal(result.stderr, "");
+  }
+});
+
+test("shared matcher traverses the generated nested JSON corpus", () => {
+  for (const adapter of adapters) {
+    for (let depth = 1; depth <= 8; depth += 1) {
+      const raw = JSON.stringify(wrapNested({ labels: { slug } }, depth));
+      const expected = runBaseline(adapter, "contains", raw);
+      const actual = runCandidate(adapter, "contains", raw);
+      assert.deepEqual(actual, expected, `${adapter.name} depth=${depth}`);
+    }
+  }
+});
+
+test("shared matcher accepts only the five closed profiles", () => {
+  for (const profile of ["standard", "runpod", "lambda", "nebius", "vast"]) {
+    const result = runMatcher(profile, "probe", JSON.stringify({ labels: { slug } }));
+    assert.equal(result.status, 0, `${profile}: ${result.stderr}`);
+  }
+
+  const invalid = runMatcher("custom", "probe", "[]");
+  assert.equal(invalid.status, 2);
+  assert.equal(invalid.stdout, "");
+  assert.equal(invalid.stderr, "usage: live-smoke-json-match.py PROFILE OPERATION\n");
+});

--- a/scripts/live-vast-smoke.sh
+++ b/scripts/live-vast-smoke.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+json_matcher="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/live-smoke-json-match.py"
+
 provider_enabled() {
   local list="${CRABBOX_LIVE_PROVIDERS:-}"
   local item
@@ -124,35 +126,7 @@ validate_list_json_contains_slug() {
   local validation_output=""
   local status=0
   set +e
-  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" python3 -c '
-import json
-import os
-import sys
-
-slug = os.environ["CRABBOX_SMOKE_SLUG"]
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-def has_slug(value):
-    if isinstance(value, dict):
-        labels = value.get("labels") or value.get("tags")
-        if isinstance(labels, dict) and (labels.get("slug") == slug or labels.get("crabbox.slug") == slug):
-            return True
-        label = str(value.get("label", ""))
-        if f"|{slug}|" in label or value.get("slug") == slug or value.get("name") == slug or value.get("id") == slug or value.get("leaseId") == slug:
-            return True
-        return any(has_slug(child) for child in value.values())
-    if isinstance(value, list):
-        return any(has_slug(child) for child in value)
-    return False
-
-if not has_slug(payload):
-    print(f"list JSON did not include slug {slug}", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" CRABBOX_SMOKE_FAILURE="list JSON did not include slug $slug" python3 "$json_matcher" vast contains <<<"$output" 2>&1)"
   status=$?
   set -e
   if [[ "$status" -ne 0 ]]; then
@@ -167,20 +141,7 @@ validate_list_json_empty() {
   local validation_output=""
   local status=0
   set +e
-  validation_output="$(python3 -c '
-import json
-import sys
-
-try:
-    payload = json.load(sys.stdin)
-except Exception as exc:
-    print(f"invalid JSON: {exc}", file=sys.stderr)
-    sys.exit(1)
-
-if payload != []:
-    print("Vast Crabbox inventory is not empty", file=sys.stderr)
-    sys.exit(1)
-' <<<"$output" 2>&1)"
+  validation_output="$(CRABBOX_SMOKE_SLUG="$slug" CRABBOX_SMOKE_FAILURE="Vast Crabbox inventory is not empty" python3 "$json_matcher" standard empty <<<"$output" 2>&1)"
   status=$?
   set -e
   if [[ "$status" -ne 0 ]]; then

--- a/scripts/live-vast-smoke.test.js
+++ b/scripts/live-vast-smoke.test.js
@@ -14,7 +14,9 @@ import {
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
 const prepareSmokeRepo = (dir) =>
-  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-vast-smoke.sh"));
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-vast-smoke.sh"), [
+    "lib/live-smoke-json-match.py",
+  ]);
 
 function vastLiveEnv(overrides = {}) {
   return {


### PR DESCRIPTION
## What Problem This Solves

Seven live provider smoke scripts carried near-identical embedded Python JSON matching. The duplicated implementations made provider-specific aliases, diagnostics, and parser behavior easier to drift apart.

## Why This Change Was Made

This introduces one repository-local Python matcher with five closed behavior profiles while preserving each provider's existing shell-owned capture, redaction, classification, cleanup, interpreter, and literal diagnostic contracts. Codespaces keeps its three-state local probe and remote substring matcher, while Docker keeps its Python-to-Node-to-jq selection order without falling through after a selected parser fails.

## User Impact

No user-visible behavior changes. Maintainers get one tested implementation for the repeated JSON traversal logic while provider-specific behavior remains explicit.

## Evidence

- `node --test scripts/live-smoke-json-match.test.js`: 5 passed, covering 112 fixed historical differential cases and 56 generated nested JSON cases.
- Seven provider regression suites: 69 passed, 0 failed, 0 skipped.
- Previously landed shared-shell-helper regression suites: 130 passed, 0 failed, 0 skipped.
- Independent review: clear, including 12 focused behavior probes.
- Seven `/bin/bash -n` checks, Python compile validation, `git diff --check`, and scoped privacy scan passed.
- Production scripts and matcher: 66 additions, 319 deletions, net -253 lines.
- Full change including durable regression coverage: 478 additions, 325 deletions, net +153 lines.
- No configuration, credential, secret, or changelog changes.
