### PR TITLE
refactor: unify delegated archive preparation ownership

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -641,6 +641,15 @@ serialization, `core.RunDelegatedArchiveSync` for staged archive replacement,
 and scoped claim helpers for guarded local state. None of these grants native
 resource ownership or proves that canceling transport stopped a remote command.
 
+Archive preparation has one implementation with two caller lifetimes.
+`core.PrepareDelegatedArchive` returns an owned, seekable snapshot and cancels
+its preparation context before provisioning. A later sync charges the saved
+archive duration against a fresh transfer budget, excluding the provisioning
+gap. A sync that prepares its own archive keeps the same deadline continuously
+through archive construction and transfer; manifest planning and guardrails
+remain outside that budget. Both paths close and remove the owned archive on
+success or failure, and remote cleanup keeps its independent bounded context.
+
 ## Provider registration
 
 A provider implements `cli.Provider`:

--- a/internal/cli/delegated_archive_sync.go
+++ b/internal/cli/delegated_archive_sync.go
@@ -49,6 +49,18 @@ func (archive *PreparedArchive) Close() error {
 // Close removes it. Workspace changes after preparation are intentionally not
 // reflected in the uploaded pre-acquisition snapshot.
 func PrepareDelegatedArchive(ctx context.Context, req DelegatedArchivePreparationRequest) (*PreparedArchive, error) {
+	archive, _, cancel, err := prepareDelegatedArchive(ctx, req)
+	cancel()
+	return archive, err
+}
+
+func prepareDelegatedArchive(ctx context.Context, req DelegatedArchivePreparationRequest) (_ *PreparedArchive, archiveCtx context.Context, cancel context.CancelFunc, err error) {
+	archiveCtx, cancel = ctx, func() {}
+	defer func() {
+		if err != nil {
+			cancel()
+		}
+	}()
 	now := req.Now
 	if now == nil {
 		now = time.Now
@@ -60,12 +72,12 @@ func PrepareDelegatedArchive(ctx context.Context, req DelegatedArchivePreparatio
 
 	excludes, err := syncExcludes(req.Repo.Root, req.Config)
 	if err != nil {
-		return nil, err
+		return nil, archiveCtx, cancel, err
 	}
 	manifestStart := now()
 	manifest, err := syncManifestFilteredRules(req.Repo.Root, excludes, req.Config.Sync.Includes)
 	if err != nil {
-		return nil, exit(6, "build sync file list: %v", err)
+		return nil, archiveCtx, cancel, exit(6, "build sync file list: %v", err)
 	}
 	manifestDuration := now().Sub(manifestStart)
 
@@ -74,21 +86,18 @@ func PrepareDelegatedArchive(ctx context.Context, req DelegatedArchivePreparatio
 	archiveManifest.Changed = nil
 	archiveManifest.ChangedBytes = 0
 	if err := checkSyncPreflight(archiveManifest, req.Config, req.ForceSyncLarge, stderr); err != nil {
-		return nil, err
+		return nil, archiveCtx, cancel, err
 	}
 	preflightDuration := now().Sub(preflightStart)
 
-	archiveCtx := ctx
-	cancel := func() {}
 	if req.Config.Sync.Timeout > 0 {
 		archiveCtx, cancel = context.WithTimeout(ctx, req.Config.Sync.Timeout)
 	}
-	defer cancel()
 
 	archiveStart := now()
 	file, err := CreateSyncArchive(archiveCtx, req.Repo, manifest, blank(req.TempPattern, "crabbox-delegated-sync-*.tgz"))
 	if err != nil {
-		return nil, err
+		return nil, archiveCtx, cancel, err
 	}
 	archiveDuration := now().Sub(archiveStart)
 	info, err := file.Stat()
@@ -96,7 +105,7 @@ func PrepareDelegatedArchive(ctx context.Context, req DelegatedArchivePreparatio
 		name := file.Name()
 		_ = file.Close()
 		_ = os.Remove(name)
-		return nil, fmt.Errorf("stat sync archive: %w", err)
+		return nil, archiveCtx, cancel, fmt.Errorf("stat sync archive: %w", err)
 	}
 	return &PreparedArchive{
 		File:              file,
@@ -105,7 +114,7 @@ func PrepareDelegatedArchive(ctx context.Context, req DelegatedArchivePreparatio
 		ManifestDuration:  manifestDuration,
 		PreflightDuration: preflightDuration,
 		ArchiveDuration:   archiveDuration,
-	}, nil
+	}, archiveCtx, cancel, nil
 }
 
 type DelegatedArchiveSyncRequest struct {
@@ -135,6 +144,7 @@ func RunDelegatedArchiveSync(ctx context.Context, req DelegatedArchiveSyncReques
 			defer preparedArchive.Close()
 		}
 	}
+	preparedExternally := preparedArchive != nil
 	if req.Upload == nil || req.Exec == nil {
 		return nil, 0, fmt.Errorf("delegated archive sync requires upload and exec callbacks")
 	}
@@ -155,7 +165,6 @@ func RunDelegatedArchiveSync(ctx context.Context, req DelegatedArchiveSyncReques
 			return context.WithTimeout(context.WithoutCancel(parent), 30*time.Second)
 		}
 	}
-	tempPattern := blank(req.TempPattern, "crabbox-delegated-sync-*.tgz")
 	remoteDir := blank(req.RemoteArchiveDir, "/tmp")
 	remotePrefix := blank(req.RemoteArchivePrefix, "crabbox-sync-")
 	phaseName := blank(req.PhaseName, "delegated_archive_sync")
@@ -166,57 +175,29 @@ func RunDelegatedArchiveSync(ctx context.Context, req DelegatedArchiveSyncReques
 	}
 
 	start := now()
-	var manifestDuration, preflightDuration, archiveDuration time.Duration
-	var archive *os.File
 	syncCtx := ctx
 	if preparedArchive == nil {
-		excludes, err := syncExcludes(req.Repo.Root, req.Config)
+		// Keep the live archive deadline through transfer; reporting durations
+		// must not restart the continuous budget of local preparation.
+		var cancel context.CancelFunc
+		var err error
+		preparedArchive, syncCtx, cancel, err = prepareDelegatedArchive(ctx, DelegatedArchivePreparationRequest{
+			Config: req.Config, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+			TempPattern: req.TempPattern, Stderr: stderr, Now: now,
+		})
+		defer cancel()
 		if err != nil {
 			return nil, 0, err
 		}
-		manifestStart := now()
-		manifest, err := syncManifestFilteredRules(req.Repo.Root, excludes, req.Config.Sync.Includes)
-		if err != nil {
-			return nil, 0, exit(6, "build sync file list: %v", err)
-		}
-		manifestDuration = now().Sub(manifestStart)
-
-		preflightStart := now()
-		archiveManifest := manifest
-		archiveManifest.Changed = nil
-		archiveManifest.ChangedBytes = 0
-		if err := checkSyncPreflight(archiveManifest, req.Config, req.ForceSyncLarge, stderr); err != nil {
-			return nil, 0, err
-		}
-		preflightDuration = now().Sub(preflightStart)
-
-		// Match SSH sync semantics: local manifest planning is outside the
-		// transfer timeout. The timeout bounds archiving and synchronization.
-		if req.Config.Sync.Timeout > 0 {
-			archiveCtx, cancel := context.WithTimeout(ctx, req.Config.Sync.Timeout)
-			defer cancel()
-			syncCtx = archiveCtx
-		}
-
-		archiveStart := now()
-		archive, err = CreateSyncArchive(syncCtx, req.Repo, manifest, tempPattern)
-		if err != nil {
-			return nil, 0, err
-		}
-		defer func() {
-			_ = archive.Close()
-			_ = os.Remove(archive.Name())
-		}()
-		archiveDuration = now().Sub(archiveStart)
-	} else {
-		archive = preparedArchive.File
-		manifestDuration = preparedArchive.ManifestDuration
-		preflightDuration = preparedArchive.PreflightDuration
-		archiveDuration = preparedArchive.ArchiveDuration
+		defer preparedArchive.Close()
 	}
+	archive := preparedArchive.File
+	manifestDuration := preparedArchive.ManifestDuration
+	preflightDuration := preparedArchive.PreflightDuration
+	archiveDuration := preparedArchive.ArchiveDuration
 
 	// A prepared archive has already consumed part of the original sync budget.
-	if preparedArchive != nil && req.Config.Sync.Timeout > 0 {
+	if preparedExternally && req.Config.Sync.Timeout > 0 {
 		remaining := req.Config.Sync.Timeout - archiveDuration
 		if remaining < 0 {
 			remaining = 0
@@ -300,7 +281,7 @@ func RunDelegatedArchiveSync(ctx context.Context, req DelegatedArchiveSyncReques
 	cleanupDuration := now().Sub(cleanupStart)
 
 	total := now().Sub(start)
-	if preparedArchive != nil {
+	if preparedExternally {
 		total += manifestDuration + preflightDuration + archiveDuration
 	}
 	phases := []TimingPhase{

--- a/internal/cli/delegated_archive_sync_test.go
+++ b/internal/cli/delegated_archive_sync_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -142,14 +143,149 @@ func TestRunDelegatedArchiveSyncConsumesPreparedSnapshotAndPreservesTiming(t *te
 			t.Fatalf("missing %s phase: %#v", name, phases)
 		}
 	}
-	if total < 21*time.Millisecond {
-		t.Fatalf("total=%s, want prepared archive phases included", total)
+	if total != 98*time.Millisecond {
+		t.Fatalf("total=%s, want 77ms transfer plus 21ms saved preparation", total)
 	}
 	if _, err := os.Stat(archivePath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("prepared archive remains at %q: %v", archivePath, err)
 	}
 	if err := prepared.Close(); err != nil {
 		t.Fatalf("idempotent second close: %v", err)
+	}
+}
+
+func TestRunDelegatedArchiveSyncLocalPreparationCountsTimingOnce(t *testing.T) {
+	root := newDelegatedArchiveSyncRepo(t)
+	var stderr bytes.Buffer
+	calls := 0
+	phases, total, err := RunDelegatedArchiveSync(context.Background(), DelegatedArchiveSyncRequest{
+		Config: baseConfig(), Repo: Repo{Root: root}, Workdir: "/workspace", Stderr: &stderr,
+		Now: func() time.Time {
+			calls++
+			return time.Unix(0, int64(calls)*int64(7*time.Millisecond))
+		},
+		Upload: func(context.Context, string, io.Reader) error { return nil },
+		Exec:   func(context.Context, string) error { return nil },
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 119*time.Millisecond || phases[len(phases)-1].Ms != 119 {
+		t.Fatalf("phases=%v total=%s, want local elapsed 119ms without adding saved preparation", phases, total)
+	}
+	for _, phase := range phases[:3] {
+		if phase.Ms != 7 {
+			t.Fatalf("preparation phase=%v, want 7ms", phase)
+		}
+	}
+	if got := strings.Count(stderr.String(), "sync candidate:"); got != 1 {
+		t.Fatalf("preflight count=%d stderr=%q", got, stderr.String())
+	}
+}
+
+func TestRunDelegatedArchiveSyncPreservesContinuousLocalDeadline(t *testing.T) {
+	root := newDelegatedArchiveSyncRepo(t)
+	synctest.Test(t, func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Sync.Timeout = 5 * time.Second
+		calls := 0
+		var archiveStart time.Time
+		var transferCtx context.Context
+		_, _, err := RunDelegatedArchiveSync(context.Background(), DelegatedArchiveSyncRequest{
+			Config: cfg, Repo: Repo{Root: root}, Workdir: "/workspace",
+			Now: func() time.Time {
+				calls++
+				switch calls {
+				case 3:
+					time.Sleep(20 * time.Second) // Planning is outside the transfer budget.
+				case 6:
+					archiveStart = time.Now()
+					time.Sleep(2 * time.Second)
+				}
+				return time.Unix(0, 0) // Reporting time must not restart the real deadline.
+			},
+			Upload: func(ctx context.Context, _ string, body io.Reader) error {
+				transferCtx = ctx
+				deadline, ok := ctx.Deadline()
+				if !ok || !deadline.Equal(archiveStart.Add(5*time.Second)) || time.Until(deadline) != 3*time.Second {
+					t.Fatalf("deadline=%v archive start=%v remaining=%s", deadline, archiveStart, time.Until(deadline))
+				}
+				if _, ok := body.(*os.File); !ok {
+					t.Fatalf("upload body=%T, want seekable archive file", body)
+				}
+				time.Sleep(3 * time.Second)
+				synctest.Wait()
+				return ctx.Err()
+			},
+			Exec: func(ctx context.Context, command string) error {
+				if ctx.Err() != nil || !strings.HasPrefix(command, "rm -f ") {
+					t.Fatalf("cleanup context=%v command=%q", ctx.Err(), command)
+				}
+				return nil
+			},
+		})
+		if !errors.Is(err, context.DeadlineExceeded) || transferCtx == nil {
+			t.Fatalf("sync err=%v transfer=%v", err, transferCtx)
+		}
+	})
+}
+
+func TestRunDelegatedArchiveSyncPreparedDeadlineBudget(t *testing.T) {
+	root := newDelegatedArchiveSyncRepo(t)
+	for _, test := range []struct {
+		name       string
+		timeout    time.Duration
+		archiving  time.Duration
+		parent     time.Duration
+		remaining  time.Duration
+		noDeadline bool
+	}{
+		{name: "allocation gap excluded", timeout: 5 * time.Second, archiving: 2 * time.Second, remaining: 3 * time.Second},
+		{name: "parent wins", timeout: 5 * time.Second, parent: time.Second, remaining: time.Second},
+		{name: "disabled retains parent", parent: time.Second, remaining: time.Second},
+		{name: "disabled without parent", noDeadline: true},
+		{name: "exhausted", timeout: 5 * time.Second, archiving: 5 * time.Second},
+		{name: "overdrawn", timeout: 5 * time.Second, archiving: 6 * time.Second},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			prepared, err := PrepareDelegatedArchive(context.Background(), DelegatedArchivePreparationRequest{Config: baseConfig(), Repo: Repo{Root: root}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer prepared.Close()
+			prepared.ArchiveDuration = test.archiving
+			synctest.Test(t, func(t *testing.T) {
+				time.Sleep(time.Hour)
+				ctx := context.Background()
+				if test.parent > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, test.parent)
+					defer cancel()
+				}
+				cfg := baseConfig()
+				cfg.Sync.Timeout = test.timeout
+				var uploaded bool
+				_, _, err := RunDelegatedArchiveSync(ctx, DelegatedArchiveSyncRequest{
+					Config: cfg, Workdir: "/workspace",
+					Upload: func(ctx context.Context, _ string, _ io.Reader) error {
+						uploaded = true
+						deadline, ok := ctx.Deadline()
+						if ok == test.noDeadline || (ok && time.Until(deadline) != test.remaining) {
+							t.Fatalf("deadline=%v present=%v remaining=%s, want %s", deadline, ok, time.Until(deadline), test.remaining)
+						}
+						if ok {
+							time.Sleep(test.remaining)
+							synctest.Wait()
+						}
+						return ctx.Err()
+					},
+					Exec: func(ctx context.Context, _ string) error { return ctx.Err() },
+				}, prepared)
+				if !uploaded || (test.noDeadline && err != nil) || (!test.noDeadline && !errors.Is(err, context.DeadlineExceeded)) {
+					t.Fatalf("uploaded=%v err=%v", uploaded, err)
+				}
+			})
+		})
 	}
 }
 
@@ -208,6 +344,71 @@ func TestRunDelegatedArchiveSyncClosesPreparedArchiveOnEveryFailurePath(t *testi
 			}
 			if err := prepared.Close(); err != nil {
 				t.Fatalf("idempotent second close: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunDelegatedArchiveSyncClosesLocalArchiveOnFailure(t *testing.T) {
+	root := newDelegatedArchiveSyncRepo(t)
+	for _, stage := range []string{"upload", "extract", "replace"} {
+		t.Run(stage, func(t *testing.T) {
+			failure := errors.New(stage + " failed")
+			var archive *os.File
+			cleanups := 0
+			_, _, err := RunDelegatedArchiveSync(context.Background(), DelegatedArchiveSyncRequest{
+				Config: baseConfig(), Repo: Repo{Root: root}, Workdir: "/workspace",
+				Upload: func(_ context.Context, _ string, body io.Reader) error {
+					var ok bool
+					archive, ok = body.(*os.File)
+					if !ok {
+						t.Fatalf("upload body=%T", body)
+					}
+					if stage == "upload" {
+						return failure
+					}
+					return nil
+				},
+				Exec: func(_ context.Context, command string) error {
+					if strings.HasPrefix(command, "rm -f ") {
+						cleanups++
+					}
+					if stage == "extract" && strings.HasPrefix(command, "tar -xzf ") {
+						return failure
+					}
+					return nil
+				},
+				Replace: func(context.Context, string, string) error { return failure },
+			})
+			if !errors.Is(err, failure) || archive == nil || cleanups != 1 {
+				t.Fatalf("err=%v archive=%v cleanups=%d", err, archive, cleanups)
+			}
+			if _, err := archive.Stat(); !errors.Is(err, os.ErrClosed) {
+				t.Fatalf("archive not closed: %v", err)
+			}
+			if _, err := os.Stat(archive.Name()); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("archive not removed: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunDelegatedArchiveSyncInvalidLocalRequestDoesNotPrepare(t *testing.T) {
+	for _, stage := range []string{"callbacks", "workdir"} {
+		t.Run(stage, func(t *testing.T) {
+			req := DelegatedArchiveSyncRequest{
+				Workdir: "/workspace",
+				Now:     func() time.Time { t.Fatal("invalid request started preparation"); return time.Time{} },
+				Upload:  func(context.Context, string, io.Reader) error { t.Fatal("unexpected upload"); return nil },
+				Exec:    func(context.Context, string) error { t.Fatal("unexpected remote command"); return nil },
+			}
+			if stage == "callbacks" {
+				req.Upload = nil
+			} else {
+				req.Workdir = ""
+			}
+			if _, _, err := RunDelegatedArchiveSync(context.Background(), req); err == nil {
+				t.Fatal("invalid request succeeded")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Use one private implementation for delegated archive manifest selection, full-candidate guardrails, archive creation/stat, and file ownership. The existing public preparation entry point remains the boundary for a pre-provisioning snapshot; ordinary sync consumes the same implementation while retaining its live archive context through transfer. No new exported API, provider flag, dependency, or archive state field is introduced.

The important distinction is lifetime, not provider identity. Locally prepared sync retains one continuous deadline after planning; a supplied snapshot gets the existing remaining transfer budget, excluding provisioning time. Preparation is counted once in either mode. Upload continues to receive the concrete seekable file, and independent remote cleanup and callback error precedence are unchanged. The common path now stats locally prepared archives too, matching the existing snapshot validation.

## Verification

- Focused core preparation/sync/archive tests with `-race`: pass, including exact phase/total accounting, real archive custody, invalid requests, snapshot immutability, and virtual-time continuous/external/parent/disabled/exhausted deadline cases.
- Full E2B, OpenComputer, Modal, and shared provider race suites: pass before integration. Integrated current main then reran core archive tests and the existing provider archive/timeout/staging cases: pass.
- `go vet` on core and the three representative provider consumers; docs-site build; diff checks: pass.
- Independent semantic review found no actionable P1/P2 issues. Managed source and integration reviews are scoped-clean at their requested P0 threshold.

The tests use actual local Git manifests and archive files; existing provider tests include local HTTP timeout paths. This refactor does not claim a new hosted-provider smoke or vendor certification. No user-facing behavior change is intended, so provider-backend architecture docs are updated but no release-note bullet is added for internal deduplication alone. No credentials, config migration, or release mutation is involved.

## Integrated runtime evidence at f4e73126

The shared preparation refactor was exercised through OpenComputer's real production HTTP client and backend Run entry point by the existing `TestSyncHonorsConfiguredTimeout`. The fixture accepts the upload, blocks it, observes the canceled HTTP request context after the configured 500 ms budget, and then verifies the backend issued remote archive cleanup. No provider client callback is substituted in that test; its loopback HTTP server is synthetic, so this is not a hosted vendor certification.

Reproduction from this PR:

```sh
GOMAXPROCS=4 go test -p 1 -race -timeout=15m ./internal/providers/opencomputer ./internal/providers/e2b ./internal/providers/modal -run '^(TestSyncHonorsConfiguredTimeout|TestE2BSyncWorkspaceHonorsConfiguredTimeout|TestSyncWorkspaceUsesSharedTimeoutAndStaging)$' -v -count=1
```

The E2B and Modal cases are adapter callback fixtures, not additional real HTTP claims. They independently cover configured timeout propagation, prepared remaining budget, and staged cleanup. Core tests separately prove exact phase/total accounting, continuous local deadlines versus paused external snapshots, parent/disabled/exhausted budgets, snapshot bytes, and closed/removed archives after failure. No timeout was raised.

Captured after-fix output:

```text
=== RUN   TestSyncHonorsConfiguredTimeout
--- PASS: TestSyncHonorsConfiguredTimeout (0.71s)
PASS
ok  	github.com/openclaw/crabbox/internal/providers/opencomputer	2.374s
=== RUN   TestE2BSyncWorkspaceHonorsConfiguredTimeout
--- PASS: TestE2BSyncWorkspaceHonorsConfiguredTimeout (0.61s)
PASS
ok  	github.com/openclaw/crabbox/internal/providers/e2b	2.173s
=== RUN   TestSyncWorkspaceUsesSharedTimeoutAndStaging
--- PASS: TestSyncWorkspaceUsesSharedTimeoutAndStaging (0.11s)
PASS
ok  	github.com/openclaw/crabbox/internal/providers/modal	1.676s
```
