### PR TITLE
ci: allow cold container bootstrap and stream smoke progress

### DIFF
--- a/.github/workflows/connector-e2e-smokes.yml
+++ b/.github/workflows/connector-e2e-smokes.yml
@@ -54,10 +54,11 @@ jobs:
             # Cold bootstrap allows 20m; leave room for build, use and cleanup.
             timeout-minutes: 30
             smoke: |
+              set -o pipefail
               CRABBOX_LIVE=1 \
               CRABBOX_LIVE_PROVIDERS=local-container \
               CRABBOX_BIN="$PWD/bin/crabbox" \
-                scripts/live-smoke.sh
+                scripts/live-smoke.sh 2>&1 | tee "$RUNNER_TEMP/local-container-smoke.log"
 
           # Read-only doctor readiness contract. Hosted runners do not ship
           # Firecracker or CNI plugins, so the script's own
@@ -147,3 +148,24 @@ jobs:
 
       - name: Run connector lifecycle smoke
         run: ${{ matrix.smoke }}
+
+      - name: Diagnose local-container bootstrap
+        if: failure() && matrix.name == 'local-container'
+        timeout-minutes: 1
+        shell: bash
+        run: |
+          log="$RUNNER_TEMP/local-container-smoke.log"
+          test -f "$log" || exit 0
+          lease="$(sed -nE 's/^provisioning provider=local-container lease=(cbx_[0-9a-f]{12}) .*/\1/p' "$log")"
+          if [[ ! "$lease" =~ ^cbx_[0-9a-f]{12}$ ]]; then
+            echo "No unique smoke lease; skipping container diagnostics"
+            exit 0
+          fi
+          containers="$(docker ps -aq --no-trunc --filter label=crabbox=true --filter label=provider=local-container --filter "label=lease=$lease")"
+          if [[ ! "$containers" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "No unique exact smoke container; skipping container diagnostics"
+            exit 0
+          fi
+          # Never dump Config.Env or argv: bootstrap needs only state and logs.
+          docker inspect --format '{{json .State}}' "$containers"
+          timeout 15s docker logs --tail 100 "$containers"

--- a/.github/workflows/connector-e2e-smokes.yml
+++ b/.github/workflows/connector-e2e-smokes.yml
@@ -37,7 +37,7 @@ jobs:
   hermetic:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 15
+    timeout-minutes: ${{ matrix.timeout-minutes || 15 }}
 
     strategy:
       fail-fast: false
@@ -51,6 +51,8 @@ jobs:
           - name: local-container
             runner: ubuntu-latest
             build-cli: true
+            # Cold bootstrap allows 20m; leave room for build, use and cleanup.
+            timeout-minutes: 30
             smoke: |
               CRABBOX_LIVE=1 \
               CRABBOX_LIVE_PROVIDERS=local-container \

--- a/scripts/connector-e2e-smokes-workflow.test.js
+++ b/scripts/connector-e2e-smokes-workflow.test.js
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
@@ -40,9 +42,7 @@ test("matrix rows do not fail fast and are time-bounded", () => {
 });
 
 test("SSH localhost asserts amd64 only on its hosted x64 lifecycle row", () => {
-  const rows = [
-    ...workflow.matchAll(/^ {10}- name: ssh-localhost\n((?: {12}[^\n]*\n)*)/gm),
-  ];
+  const rows = [...workflow.matchAll(/^ {10}- name: ssh-localhost\n((?: {12}[^\n]*\n)*)/gm)];
   assert.equal(rows.length, 1, "keep one existing SSH localhost row");
   const row = rows[0][1];
   assert.match(row, /^ {12}runner: ubuntu-latest$/m);
@@ -64,4 +64,81 @@ test("SSH localhost asserts amd64 only on its hosted x64 lifecycle row", () => {
 test("pull request runs cancel superseded attempts", () => {
   assert.match(workflow, /concurrency:\s*\n\s+group:/);
   assert.match(workflow, /cancel-in-progress:.*pull_request/);
+});
+
+test("failed bootstrap diagnostics read only the unique smoke container", (t) => {
+  const marker = "      - name: Diagnose local-container bootstrap\n";
+  const step = workflow.slice(workflow.indexOf(marker) + marker.length);
+  const script = step
+    .slice(step.indexOf("        run: |\n") + "        run: |\n".length)
+    .split("\n")
+    .map((line) => line.replace(/^ {10}/, ""))
+    .join("\n");
+  assert.match(step, /if: failure\(\) && matrix\.name == 'local-container'/);
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-bootstrap-diagnostics-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const docker = path.join(dir, "docker");
+  fs.writeFileSync(
+    docker,
+    `#!/usr/bin/env bash
+set -eu
+printf '%s\\n' "$*" >> "$DIAGNOSTIC_CALLS"
+case "$1" in
+  ps) printf '%s\\n' "$DIAGNOSTIC_IDS" ;;
+  inspect) printf '{"Running":false,"ExitCode":100}\\n' ;;
+  logs) printf 'synthetic apt failure\\n' ;;
+  *) exit 99 ;;
+esac
+`,
+    { mode: 0o755 },
+  );
+  fs.writeFileSync(path.join(dir, "timeout"), '#!/usr/bin/env bash\nshift\nexec "$@"\n', {
+    mode: 0o755,
+  });
+  const log = path.join(dir, "local-container-smoke.log");
+  const calls = path.join(dir, "calls.log");
+  const lease = "cbx_123456789abc";
+  const container = "a".repeat(64);
+  const launch = `provisioning provider=local-container lease=${lease} slug=synthetic\n`;
+  for (const scenario of [
+    { name: "exact", log: launch, ids: container, inspect: true },
+    { name: "missing log", log: null, ids: container, inventory: false },
+    { name: "no lease", log: "build failed\n", ids: container, inventory: false },
+    { name: "multiple leases", log: launch + launch, ids: container, inventory: false },
+    { name: "no container", log: launch, ids: "" },
+    { name: "ambiguous containers", log: launch, ids: container + "\n" + "b".repeat(64) },
+  ]) {
+    fs.writeFileSync(calls, "");
+    if (scenario.log === null) fs.rmSync(log, { force: true });
+    else fs.writeFileSync(log, scenario.log);
+    const result = spawnSync("bash", ["-euo", "pipefail", "-c", script], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${dir}:${process.env.PATH}`,
+        RUNNER_TEMP: dir,
+        DIAGNOSTIC_CALLS: calls,
+        DIAGNOSTIC_IDS: scenario.ids,
+      },
+    });
+    assert.equal(result.status, 0, `${scenario.name}: ${result.stdout}${result.stderr}`);
+    const observed = fs.readFileSync(calls, "utf8");
+    if (scenario.inventory === false) assert.equal(observed, "", scenario.name);
+    else
+      assert.match(
+        observed,
+        new RegExp(
+          `^ps -aq --no-trunc --filter label=crabbox=true --filter label=provider=local-container --filter label=lease=${lease}\\n`,
+        ),
+      );
+    if (scenario.inspect) {
+      assert.match(
+        observed,
+        new RegExp(`inspect --format \\{\\{json \\.State\\}\\} ${container}\\n`),
+      );
+      assert.match(observed, new RegExp(`logs --tail 100 ${container}\\n`));
+      assert.match(result.stdout, /synthetic apt failure/);
+    } else assert.doesNotMatch(observed, /^(inspect|logs) /m, scenario.name);
+    assert.doesNotMatch(observed, /Config|(^|\n)(rm|exec|stop|kill) /);
+  }
 });

--- a/scripts/connector-e2e-smokes-workflow.test.js
+++ b/scripts/connector-e2e-smokes-workflow.test.js
@@ -30,7 +30,13 @@ test("connector lifecycle gate stays hermetic: no secret references anywhere", (
 
 test("matrix rows do not fail fast and are time-bounded", () => {
   assert.match(workflow, /fail-fast:\s*false/);
-  assert.match(workflow, /timeout-minutes:\s*15/);
+  assert.match(workflow, /timeout-minutes: \$\{\{ matrix\.timeout-minutes \|\| 15 \}\}/);
+  const localContainer = workflow.match(
+    /- name: local-container\n([\s\S]*?)(?=\n {10}- name:)/,
+  )?.[1];
+  assert.ok(localContainer, "local-container row exists");
+  assert.match(localContainer, /timeout-minutes: 30/);
+  assert.equal((workflow.match(/^ {12}timeout-minutes:/gm) ?? []).length, 1);
 });
 
 test("SSH localhost asserts amd64 only on its hosted x64 lifecycle row", () => {

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -264,8 +264,8 @@ provider_smoke() (
   trap cleanup EXIT
 
   local out
-  capture_run out run_in_repo "$cb" warmup --provider "$provider" "$@"
-  printf '%s\n' "$out"
+  log_step "$provider warmup"
+  capture_run_live out run_in_repo "$cb" warmup --provider "$provider" "$@"
   lease="$(printf '%s\n' "$out" | extract_lease)"
   slug="$(printf '%s\n' "$out" | extract_slug)"
   test -n "$lease"
@@ -290,8 +290,8 @@ provider_smoke() (
 
   local runout
   # shellcheck disable=SC2016 # expanded by the remote shell.
-  capture_run runout run_in_repo "$cb" run --provider "$provider" --id "$slug" --shell -- "$live_command"
-  printf '%s\n' "$runout"
+  log_step "$provider run slug=$slug"
+  capture_run_live runout run_in_repo "$cb" run --provider "$provider" --id "$slug" --shell -- "$live_command"
   local runid
   runid="$(printf '%s\n' "$runout" | rg -o 'run_[a-f0-9]{12}' | tail -1 || true)"
   if needs_coordinator_preamble; then

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import test from "node:test";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
@@ -2200,11 +2200,12 @@ esac
   }
 });
 
-test("local-container live smoke uses the generic SSH lease lifecycle", () => {
+test("local-container live smoke uses the generic SSH lease lifecycle", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-local-container-"));
   const bin = path.join(dir, "bin");
   const fakeCrabbox = path.join(bin, "crabbox");
   const crabboxLog = path.join(dir, "crabbox.log");
+  const progressAck = path.join(dir, "progress-ack");
   fs.mkdirSync(bin);
   writeExecutable(
     fakeCrabbox,
@@ -2222,6 +2223,11 @@ printf '%s\\n' "$*" >>"\${CRABBOX_FAKE_LOG:?}"
 case "$1" in
   warmup)
     printf 'provisioning provider=local-container lease=cbx_123456789abc slug=local-container-smoke-test\\n'
+    for i in {1..200}; do
+      [[ -f "\${CRABBOX_PROGRESS_ACK:?}" ]] && break
+      sleep 0.05
+    done
+    [[ -f "\${CRABBOX_PROGRESS_ACK:?}" ]] || exit 92
     printf 'provisioned lease=cbx_123456789abc slug=local-container-smoke-test state=ready\\n'
     ;;
   status)
@@ -2256,24 +2262,41 @@ esac
 `,
   );
 
-  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
-    cwd: repoRoot,
-    env: {
-      ...process.env,
-      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
-      CRABBOX_BIN: fakeCrabbox,
-      CRABBOX_CONFIG: path.join(dir, "missing-crabbox.yaml"),
-      CRABBOX_FAKE_LOG: crabboxLog,
-      CRABBOX_LIVE: "1",
-      CRABBOX_LIVE_COORDINATOR: "0",
-      CRABBOX_LIVE_PROVIDERS: "local-container",
-      CRABBOX_LIVE_REPO: repoRoot,
-    },
-    encoding: "utf8",
+  const result = await new Promise((resolve, reject) => {
+    const child = spawn("bash", ["scripts/live-smoke.sh"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+        CRABBOX_BIN: fakeCrabbox,
+        CRABBOX_CONFIG: path.join(dir, "missing-crabbox.yaml"),
+        CRABBOX_FAKE_LOG: crabboxLog,
+        CRABBOX_PROGRESS_ACK: progressAck,
+        CRABBOX_LIVE: "1",
+        CRABBOX_LIVE_COORDINATOR: "0",
+        CRABBOX_LIVE_PROVIDERS: "local-container",
+        CRABBOX_LIVE_REPO: repoRoot,
+      },
+      timeout: 15000,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+      if (stdout.includes("provisioning provider=local-container") && !fs.existsSync(progressAck)) {
+        fs.writeFileSync(progressAck, "progress observed before warmup completed");
+      }
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (status) => resolve({ status, stdout, stderr }));
   });
 
   assert.equal(result.status, 0, result.stdout + result.stderr);
   assert.match(result.stdout, /crabbox-live-ok/);
+  assert.equal((result.stdout.match(/provisioning provider=local-container/g) ?? []).length, 1);
   const calls = fs.readFileSync(crabboxLog, "utf8");
   assert.match(calls, /^warmup --provider local-container --ttl 15m --idle-timeout 5m$/m);
   for (const command of ["status", "inspect", "ssh", "cache", "run", "stop"]) {
@@ -2282,15 +2305,20 @@ esac
   assert.doesNotMatch(calls, /^history(?: |$)/m);
 });
 
-test("generic coordinatorless live smoke cleans up after lifecycle failure", () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-cleanup-failure-"));
-  const fakeCrabbox = path.join(dir, "crabbox");
-  const crabboxLog = path.join(dir, "crabbox.log");
-  writeExecutable(
-    fakeCrabbox,
-    `#!/usr/bin/env bash
+for (const failStep of ["warmup", "inspect", "run"]) {
+  test(`generic coordinatorless smoke preserves ${failStep} failure and cleanup`, () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-cleanup-failure-"));
+    const fakeCrabbox = path.join(dir, "crabbox");
+    const crabboxLog = path.join(dir, "crabbox.log");
+    writeExecutable(
+      fakeCrabbox,
+      `#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\\n' "$*" >>"\${CRABBOX_FAKE_LOG:?}"
+if [[ "$1" == "\${CRABBOX_FAIL_STEP:?}" ]]; then
+  printf 'forced %s failure\\n' "$1" >&2
+  exit 42
+fi
 case "$1" in
   warmup)
     printf 'provisioned lease=cbx_123456789abc slug=cleanup-failure state=ready\\n'
@@ -2299,8 +2327,16 @@ case "$1" in
     printf 'lease=cbx_123456789abc slug=cleanup-failure state=ready\\n'
     ;;
   inspect)
-    printf 'forced inspect failure\\n' >&2
-    exit 42
+    printf '{}\\n'
+    ;;
+  ssh)
+    exit 0
+    ;;
+  cache)
+    printf '[]\\n'
+    ;;
+  run)
+    exit 98
     ;;
   stop)
     printf 'stopped %s\\n' "\${*: -1}"
@@ -2311,28 +2347,35 @@ case "$1" in
     ;;
 esac
 `,
-  );
+    );
 
-  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
-    cwd: repoRoot,
-    env: {
-      ...process.env,
-      CRABBOX_BIN: fakeCrabbox,
-      CRABBOX_CONFIG: path.join(dir, "missing-crabbox.yaml"),
-      CRABBOX_FAKE_LOG: crabboxLog,
-      CRABBOX_LIVE: "1",
-      CRABBOX_LIVE_COORDINATOR: "0",
-      CRABBOX_LIVE_PROVIDERS: "local-container",
-      CRABBOX_LIVE_REPO: repoRoot,
-    },
-    encoding: "utf8",
+    const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        CRABBOX_BIN: fakeCrabbox,
+        CRABBOX_CONFIG: path.join(dir, "missing-crabbox.yaml"),
+        CRABBOX_FAKE_LOG: crabboxLog,
+        CRABBOX_FAIL_STEP: failStep,
+        CRABBOX_LIVE: "1",
+        CRABBOX_LIVE_COORDINATOR: "0",
+        CRABBOX_LIVE_PROVIDERS: "local-container",
+        CRABBOX_LIVE_REPO: repoRoot,
+      },
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 42, result.stdout + result.stderr);
+    const calls = fs.readFileSync(crabboxLog, "utf8");
+    assert.match(result.stdout + result.stderr, new RegExp(`forced ${failStep} failure`));
+    if (failStep === "warmup") {
+      assert.doesNotMatch(calls, /^(?:status|inspect|run|stop) /m);
+    } else {
+      assert.match(calls, /^inspect --provider local-container /m);
+      assert.match(calls, /^stop --provider local-container cleanup-failure$/m);
+    }
   });
-
-  assert.equal(result.status, 42, result.stdout + result.stderr);
-  const calls = fs.readFileSync(crabboxLog, "utf8");
-  assert.match(calls, /^inspect --provider local-container /m);
-  assert.match(calls, /^stop --provider local-container cleanup-failure$/m);
-});
+}
 
 test("docker-sandbox live smoke dispatches to the provider-specific smoke", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-docker-sandbox-dispatch-"));


### PR DESCRIPTION
## Summary

Give only the local-container connector smoke a 30-minute job ceiling, retaining 15 minutes for other matrix rows. Reuse the existing live-capture helper for generic warmup and command execution so progress streams while lease, slug and run-ID extraction still works. Child failures preserve their original exit code. No readiness limit, lease policy, lifecycle assertion or cleanup authority is weakened.

If the credential-free hosted container bootstrap fails, capture bounded state and log diagnostics from only the uniquely identified smoke container. Selection requires one exact lease and one full Docker container ID with the expected labels. Missing or ambiguous identity skips diagnosis; no environment, argv, exec or deletion is added. Whole-job cancellation cannot run this diagnostic, and containers already removed by normal cleanup safely skip it.

## Why

The previous 15-minute job ceiling included 2–3 minutes of build time, while ordinary cold SSH bootstrap alone allows 20 minutes. One observed bootstrap completed after 12m14s but the job expired before use and cleanup. The ceiling needs bounded room for the lifecycle the application already permits.

Intermittent bootstrap failures are separate: initial head `59261e8844f31a7001080180ea00e209c17f3d9a` exhausted the existing 20-minute readiness allowance, but an exact-source retry passed. This PR does not claim a root-cause fix for those failures.

## Verification

- Existing real shell/pipe handshake fails against buffered baseline and passes with streamed provisioning output. Failure fixtures preserve exit 42 and clean only known leases.
- Existing workflow tests execute the actual inline diagnostic against missing, ambiguous and exact container identities. All six focused tests pass, including the new behavior test. The preceding full related script run passed 91 tests; a new broad local recheck encountered an unrelated existing XCP-ng fixture hang, which is being investigated separately.
- Actual Docker failure fixture: owned container exited 42, the diagnostic captured its State and bounded logs, then the fixture container was removed.
- Native local Docker lifecycle completed warmup, status, inspect, SSH, cache, sync, command and stop. This local macOS/ARM64 control is not substituted for hosted Linux proof.
- Hosted Linux Docker run https://github.com/openclaw/crabbox/actions/runs/33938746283 attempt 2 passed against exact head `59261e8844f31a7001080180ea00e209c17f3d9a`: build 1m59s, full native smoke 53s, total 3m16s. The diagnostic-only follow-up head is undergoing its own checks.
- Managed Codex review passed with no actionable findings at its configured P0 threshold; independent semantic review found no actionable issue. Diff and syntax checks passed.

This is CI/test-harness maintenance: no new dependency, credentials, provider flags or release mutation.
