### PR TITLE
refactor: remove unused private provider types

### DIFF
--- a/internal/cli/proxmox.go
+++ b/internal/cli/proxmox.go
@@ -1364,19 +1364,6 @@ func (c *ProxmoxClient) waitTask(ctx context.Context, upid string) error {
 	}
 }
 
-type proxmoxAgentExecStart struct {
-	PID int `json:"pid"`
-}
-
-type proxmoxAgentExecStatus struct {
-	Exited   proxmoxBool `json:"exited"`
-	ExitCode int         `json:"exitcode"`
-	OutData  string      `json:"out-data"`
-	ErrData  string      `json:"err-data"`
-}
-
-type proxmoxBool bool
-
 type proxmoxAgentInterface struct {
 	Name        string `json:"name"`
 	IPAddresses []struct {

--- a/internal/providers/azuredynamicsessions/client.go
+++ b/internal/providers/azuredynamicsessions/client.go
@@ -71,16 +71,6 @@ type azureDynamicSessionsSession struct {
 	} `json:"properties"`
 }
 
-type azureDynamicSessionsErrorResponse struct {
-	Error *azureDynamicSessionsError `json:"error,omitempty"`
-}
-
-type azureDynamicSessionsError struct {
-	Code    string `json:"code,omitempty"`
-	Message string `json:"message,omitempty"`
-	Target  string `json:"target,omitempty"`
-}
-
 type azureDynamicSessionsAPIError struct {
 	StatusCode int
 	Status     string

--- a/internal/providers/cloudflaresandbox/client.go
+++ b/internal/providers/cloudflaresandbox/client.go
@@ -82,10 +82,6 @@ type execResult struct {
 	ExitCode int    `json:"exitCode"`
 }
 
-type writeFileResponse struct {
-	OK bool `json:"ok,omitempty"`
-}
-
 type persistRequest struct {
 	Path string `json:"path,omitempty"`
 }

--- a/internal/providers/cua/core.go
+++ b/internal/providers/cua/core.go
@@ -29,8 +29,6 @@ type Server = core.Server
 type Repo = core.Repo
 type LeaseClaim = core.LeaseClaim
 type ExitError = core.ExitError
-type timingReport = core.TimingReport
-type timingPhase = core.TimingPhase
 
 const (
 	providerName             = "cua"

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -43,10 +43,6 @@ type hypervVM struct {
 	State int    `json:"State"`
 }
 
-type hypervNetAdapter struct {
-	IPAddresses []string `json:"IPAddresses"`
-}
-
 func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	applyDefaults(&cfg)
 	return &backend{

--- a/internal/providers/xcpng/types.go
+++ b/internal/providers/xcpng/types.go
@@ -14,12 +14,6 @@ type xapiVM struct {
 	Labels     map[string]string
 }
 
-type xapiObject struct {
-	Ref       string
-	UUID      string
-	NameLabel string
-}
-
 type xcpNgISOMediaRef struct {
 	VDIRef    string
 	UUID      string


### PR DESCRIPTION
## What Problem This Solves

Removes private provider declarations that have no callers and add noise to static-analysis results.

## Why This Change Was Made

The declarations were confirmed unused across their package boundaries and the supported root build matrix. This is a mechanical cleanup only; sibling declarations, provider contracts, imports, tests, and deferred constants are unchanged.

## User Impact

No user-visible behavior changes. Maintainers get a smaller private API surface and cleaner unused-code reports.

## Evidence

- `gofmt` completed on all six changed Go files.
- `git diff --check`
- GitHub CI will provide the product build and test validation.
