### PR TITLE
perf: avoid recursive scans for literal run artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Unreleased
 
-- Collect literal run-artifact paths without scanning unrelated workspace files, preserving existing matching, required-file, and symlink guards.
-
+- Collect literal run-artifact paths without scanning unrelated workspace files, preserving existing matching, required-file, and symlink guards. [PR 1878](https://github.com/openclaw/crabbox/pull/1878). Thanks @steipete.
 - OpenComputer: share run finalization so cleanup failures are reported, timing errors preserve the original exit, and command preparation honors `--keep-on-failure`; preserve cancellation and timeout causes and distinguish transport errors from command exits. [PR 1845](https://github.com/openclaw/crabbox/pull/1845). Thanks @steipete.
 - Preserve literal E2B and CubeSandbox profile arguments through their shared envd command transport, and accept inferred single-string shell programs and explicit empty shell source. [PR 1837](https://github.com/openclaw/crabbox/pull/1837). Thanks @steipete.
 - Blaxel: stop the original process after interrupted polling requests and preserve cancellation and timeout causes without exposing redacted credentials. [PR 1846](https://github.com/openclaw/crabbox/pull/1846). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Collect literal run-artifact paths without scanning unrelated workspace files, preserving existing matching, required-file, and symlink guards. [PR 1878](https://github.com/openclaw/crabbox/pull/1878). Thanks @steipete.
+- Limit literal run-artifact discovery to the parent directory, preserving existing matching, required-file, and symlink guards. [PR 1878](https://github.com/openclaw/crabbox/pull/1878). Thanks @steipete.
 - OpenComputer: share run finalization so cleanup failures are reported, timing errors preserve the original exit, and command preparation honors `--keep-on-failure`; preserve cancellation and timeout causes and distinguish transport errors from command exits. [PR 1845](https://github.com/openclaw/crabbox/pull/1845). Thanks @steipete.
 - Preserve literal E2B and CubeSandbox profile arguments through their shared envd command transport, and accept inferred single-string shell programs and explicit empty shell source. [PR 1837](https://github.com/openclaw/crabbox/pull/1837). Thanks @steipete.
 - Blaxel: stop the original process after interrupted polling requests and preserve cancellation and timeout causes without exposing redacted credentials. [PR 1846](https://github.com/openclaw/crabbox/pull/1846). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Collect literal run-artifact paths without scanning unrelated workspace files, preserving existing matching, required-file, and symlink guards.
+
 - OpenComputer: share run finalization so cleanup failures are reported, timing errors preserve the original exit, and command preparation honors `--keep-on-failure`; preserve cancellation and timeout causes and distinguish transport errors from command exits. [PR 1845](https://github.com/openclaw/crabbox/pull/1845). Thanks @steipete.
 - Preserve literal E2B and CubeSandbox profile arguments through their shared envd command transport, and accept inferred single-string shell programs and explicit empty shell source. [PR 1837](https://github.com/openclaw/crabbox/pull/1837). Thanks @steipete.
 - Blaxel: stop the original process after interrupted polling requests and preserve cancellation and timeout causes without exposing redacted credentials. [PR 1846](https://github.com/openclaw/crabbox/pull/1846). Thanks @steipete.

--- a/docs/features/artifacts.md
+++ b/docs/features/artifacts.md
@@ -25,6 +25,9 @@ delegated providers still need an advertised bounded-artifact capability. On
 macOS, the remote needs stock `/bin/bash`, `find` with `-print0`, `tar`,
 `base64`, and `/bin/rm`.
 
+An exact ASCII file path checks one candidate instead of walking its directory tree,
+so unrelated workspace files do not consume the artifact-discovery budget.
+
 Repeat `--require-artifact <glob>` when the run should fail unless a proof file,
 manifest, or report exists after the command exits successfully. Required
 artifacts use the same safe relative glob syntax and target limits as

--- a/docs/features/artifacts.md
+++ b/docs/features/artifacts.md
@@ -25,8 +25,8 @@ delegated providers still need an advertised bounded-artifact capability. On
 macOS, the remote needs stock `/bin/bash`, `find` with `-print0`, `tar`,
 `base64`, and `/bin/rm`.
 
-An exact ASCII file path checks one candidate instead of walking its directory tree,
-so unrelated workspace files do not consume the artifact-discovery budget.
+Literal artifact paths limit discovery to their parent directory, so unrelated
+subdirectories do not consume the artifact-discovery budget.
 
 Repeat `--require-artifact <glob>` when the run should fail unless a proof file,
 manifest, or report exists after the command exits successfully. Required

--- a/internal/cli/run_artifact_literal_test.go
+++ b/internal/cli/run_artifact_literal_test.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestRunArtifactLiteralMatching(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{
+		"proof.json", " proof.json ", "leading.json", "trailing.json ", "Case.json",
+		"nested/proof.json", "nested/proof.json ", " nested/proof.json",
+		"nested/.git/private", "nested/.crabbox/private",
+		"\u00c2\u00a0proof.json",
+	} {
+		file := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(file, []byte(name), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for name, target := range map[string]string{
+		"leaf-link": "proof.json", "dangling": "missing", "parent-link": "nested",
+	} {
+		if err := os.Symlink(target, filepath.Join(dir, name)); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+	}
+	for i, tt := range []struct {
+		glob string
+		want []string
+	}{
+		{"proof.json", []string{"proof.json"}},
+		{"./proof.json", []string{"proof.json"}},
+		{"case.json", nil},
+		{"Case.json", []string{"Case.json"}},
+		{" proof.json ", []string{" proof.json "}},
+		// Trimmed Unicode whitespace retains the legacy byte-quoted regexp behavior.
+		{"\u00a0proof.json", []string{"\u00c2\u00a0proof.json"}},
+		{" leading.json", nil},
+		{"trailing.json ", []string{"trailing.json "}},
+		{"nested/proof.json", []string{"nested/proof.json"}},
+		{"./nested/proof.json", []string{"nested/proof.json"}},
+		{"nested/proof.json ", []string{"nested/proof.json "}},
+		{" nested/proof.json", nil},
+		{"nested//proof.json", nil},
+		{"nested/./proof.json", nil},
+		{"leaf-link", []string{"leaf-link"}},
+		{"dangling", nil},
+		{"parent-link/proof.json", nil},
+		{"nested/.git/private", nil},
+		{"nested/.crabbox/private", nil},
+		{"nested", nil},
+		{"missing.json", nil},
+	} {
+		t.Run(fmt.Sprintf("%q", tt.glob), func(t *testing.T) {
+			globs := []string{tt.glob, tt.glob}
+			out, err := exec.CommandContext(t.Context(), "bash", "-c", runArtifactRequireScript(dir, globs)).CombinedOutput()
+			if len(tt.want) > 0 {
+				if err != nil {
+					t.Fatalf("required literal: %v\n%s", err, out)
+				}
+			} else {
+				var exitErr *exec.ExitError
+				if !errors.As(err, &exitErr) || exitErr.ExitCode() != 8 {
+					t.Fatalf("error=%v, want missing-required exit 8; output=%s", err, out)
+				}
+			}
+			archive := fmt.Sprintf(".crabbox/literal-%d.tgz", i)
+			out, err = exec.CommandContext(t.Context(), "bash", "-c", runArtifactCollectScript(dir, archive, globs)).CombinedOutput()
+			if err != nil {
+				t.Fatalf("collect literal: %v\n%s", err, out)
+			}
+			if names := tarGzNames(t, filepath.Join(dir, archive)); !slices.Equal(names, tt.want) {
+				t.Fatalf("archive names=%q, want %q", names, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/run_artifact_literal_test.go
+++ b/internal/cli/run_artifact_literal_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package cli
 
 import (
@@ -6,9 +8,20 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
+	"strings"
 	"testing"
 )
+
+func runLiteralArtifactTestBash(t *testing.T, script string) ([]byte, error) {
+	t.Helper()
+	bash := "bash"
+	if runtime.GOOS == "darwin" {
+		bash = "/bin/bash"
+	}
+	return exec.CommandContext(t.Context(), bash, "-c", script).CombinedOutput()
+}
 
 func TestRunArtifactLiteralMatching(t *testing.T) {
 	dir := t.TempDir()
@@ -34,35 +47,38 @@ func TestRunArtifactLiteralMatching(t *testing.T) {
 		}
 	}
 	for i, tt := range []struct {
-		glob string
-		want []string
+		glob       string
+		want       []string
+		shellSetup string
 	}{
-		{"proof.json", []string{"proof.json"}},
-		{"./proof.json", []string{"proof.json"}},
-		{"case.json", nil},
-		{"Case.json", []string{"Case.json"}},
-		{" proof.json ", []string{" proof.json "}},
+		{"proof.json", []string{"proof.json"}, ""},
+		{"./proof.json", []string{"proof.json"}, ""},
+		{"case.json", nil, ""},
+		{"Case.json", []string{"Case.json"}, ""},
+		{" proof.json ", []string{" proof.json "}, ""},
 		// Trimmed Unicode whitespace retains the legacy byte-quoted regexp behavior.
-		{"\u00a0proof.json", []string{"\u00c2\u00a0proof.json"}},
-		{" leading.json", nil},
-		{"trailing.json ", []string{"trailing.json "}},
-		{"nested/proof.json", []string{"nested/proof.json"}},
-		{"./nested/proof.json", []string{"nested/proof.json"}},
-		{"nested/proof.json ", []string{"nested/proof.json "}},
-		{" nested/proof.json", nil},
-		{"nested//proof.json", nil},
-		{"nested/./proof.json", nil},
-		{"leaf-link", []string{"leaf-link"}},
-		{"dangling", nil},
-		{"parent-link/proof.json", nil},
-		{"nested/.git/private", nil},
-		{"nested/.crabbox/private", nil},
-		{"nested", nil},
-		{"missing.json", nil},
+		{"\u00a0proof.json", []string{"\u00c2\u00a0proof.json"}, ""},
+		{" leading.json", nil, ""},
+		{"trailing.json ", []string{"trailing.json "}, ""},
+		{"nested/proof.json", []string{"nested/proof.json"}, ""},
+		{"./nested/proof.json", []string{"nested/proof.json"}, ""},
+		{"nested/proof.json ", []string{"nested/proof.json "}, ""},
+		{" nested/proof.json", nil, ""},
+		{"nested//proof.json", nil, ""},
+		{"nested/./proof.json", nil, ""},
+		{"leaf-link", []string{"leaf-link"}, ""},
+		{"dangling", nil, ""},
+		{"parent-link/proof.json", nil, ""},
+		{"nested/.git/private", nil, ""},
+		{"nested/.crabbox/private", nil, ""},
+		{"nested", nil, ""},
+		{"missing.json", nil, ""},
+		{"proof.json", []string{"proof.json"}, "GLOBIGNORE='*.json'\n"},
+		{"case.json", []string{"Case.json"}, "shopt -s nocasematch\n"},
 	} {
-		t.Run(fmt.Sprintf("%q", tt.glob), func(t *testing.T) {
+		t.Run(strings.TrimSpace(fmt.Sprintf("%q %s", tt.glob, tt.shellSetup)), func(t *testing.T) {
 			globs := []string{tt.glob, tt.glob}
-			out, err := exec.CommandContext(t.Context(), "bash", "-c", runArtifactRequireScript(dir, globs)).CombinedOutput()
+			out, err := runLiteralArtifactTestBash(t, tt.shellSetup+runArtifactRequireScript(dir, globs))
 			if len(tt.want) > 0 {
 				if err != nil {
 					t.Fatalf("required literal: %v\n%s", err, out)
@@ -74,7 +90,7 @@ func TestRunArtifactLiteralMatching(t *testing.T) {
 				}
 			}
 			archive := fmt.Sprintf(".crabbox/literal-%d.tgz", i)
-			out, err = exec.CommandContext(t.Context(), "bash", "-c", runArtifactCollectScript(dir, archive, globs)).CombinedOutput()
+			out, err = runLiteralArtifactTestBash(t, tt.shellSetup+runArtifactCollectScript(dir, archive, globs))
 			if err != nil {
 				t.Fatalf("collect literal: %v\n%s", err, out)
 			}
@@ -82,5 +98,18 @@ func TestRunArtifactLiteralMatching(t *testing.T) {
 				t.Fatalf("archive names=%q, want %q", names, tt.want)
 			}
 		})
+	}
+}
+
+func TestRunArtifactLiteralRequireKeepsFilenameNormalization(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "proof.json\n"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Existing command substitution strips trailing newlines before matching.
+	// Discovery must not replace that normalization with a filename prefilter.
+	out, err := runLiteralArtifactTestBash(t, runArtifactRequireScript(dir, []string{"proof.json"}))
+	if err != nil || !strings.Contains(string(out), "required artifact proof.json matched=1") {
+		t.Fatalf("require normalized filename: %v\n%s", err, out)
 	}
 }

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 )
 
 const (
@@ -192,7 +193,20 @@ func writeArtifactGlobMatcher(b *strings.Builder) {
 }
 
 func writeArtifactGlobEnumeration(b *strings.Builder, glob, addFunction string) {
-	b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; artifact_root=" + shellQuote(artifactGlobSearchRoot(glob)) + "; if artifact_safe_search_root \"$artifact_root\"; then while IFS= read -r -d '' f; do rel=$(artifact_rel_path \"$f\") || continue; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then " + addFunction + " \"$f\"; fi; done < <(find \"$artifact_root\" \\( -name .git -o -name .crabbox \\) -prune -o \\( -type f -o -type l \\) -print0); fi\n")
+	root := artifactGlobSearchRoot(glob)
+	enumerate := `find "$artifact_root" \( -name .git -o -name .crabbox \) -prune -o \( -type f -o -type l \) -print0`
+	// The legacy regexp quotes bytes individually; keep non-ASCII spellings on that path.
+	asciiOnly := strings.IndexFunc(glob, func(r rune) bool { return r > unicode.MaxASCII }) < 0
+	if asciiOnly && !strings.ContainsAny(glob, "*?") {
+		// Expand one literal leaf to retain its directory-entry case on macOS.
+		// Keep outer whitespace: validation trims it, but the regex matches it literally.
+		leaf := glob[strings.LastIndex(glob, "/")+1:]
+		if leaf != "" {
+			last := len(leaf) - 1
+			enumerate = "printf '%s\\0' " + shellQuote(root+"/"+leaf[:last]) + "[" + shellQuote(leaf[last:]) + "]"
+		}
+	}
+	b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; artifact_root=" + shellQuote(root) + "; if artifact_safe_search_root \"$artifact_root\"; then while IFS= read -r -d '' f; do rel=$(artifact_rel_path \"$f\") || continue; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then " + addFunction + " \"$f\"; fi; done < <(" + enumerate + "); fi\n")
 }
 
 func runArtifactRequireScript(workdir string, globs []string) string {

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-	"unicode"
 )
 
 const (
@@ -193,20 +192,13 @@ func writeArtifactGlobMatcher(b *strings.Builder) {
 }
 
 func writeArtifactGlobEnumeration(b *strings.Builder, glob, addFunction string) {
-	root := artifactGlobSearchRoot(glob)
-	enumerate := `find "$artifact_root" \( -name .git -o -name .crabbox \) -prune -o \( -type f -o -type l \) -print0`
-	// The legacy regexp quotes bytes individually; keep non-ASCII spellings on that path.
-	asciiOnly := strings.IndexFunc(glob, func(r rune) bool { return r > unicode.MaxASCII }) < 0
-	if asciiOnly && !strings.ContainsAny(glob, "*?") {
-		// Expand one literal leaf to retain its directory-entry case on macOS.
-		// Keep outer whitespace: validation trims it, but the regex matches it literally.
-		leaf := glob[strings.LastIndex(glob, "/")+1:]
-		if leaf != "" {
-			last := len(leaf) - 1
-			enumerate = "printf '%s\\0' " + shellQuote(root+"/"+leaf[:last]) + "[" + shellQuote(leaf[last:]) + "]"
-		}
+	depth := ""
+	// Literal globs need only their guarded parent. Keep case folding and
+	// filename normalization in the existing matcher rather than a name prefilter.
+	if !strings.ContainsAny(glob, "*?") {
+		depth = " -mindepth 1 -maxdepth 1"
 	}
-	b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; artifact_root=" + shellQuote(root) + "; if artifact_safe_search_root \"$artifact_root\"; then while IFS= read -r -d '' f; do rel=$(artifact_rel_path \"$f\") || continue; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then " + addFunction + " \"$f\"; fi; done < <(" + enumerate + "); fi\n")
+	b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; artifact_root=" + shellQuote(artifactGlobSearchRoot(glob)) + "; if artifact_safe_search_root \"$artifact_root\"; then while IFS= read -r -d '' f; do rel=$(artifact_rel_path \"$f\") || continue; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then " + addFunction + " \"$f\"; fi; done < <(find \"$artifact_root\"" + depth + " \\( -name .git -o -name .crabbox \\) -prune -o \\( -type f -o -type l \\) -print0); fi\n")
 }
 
 func runArtifactRequireScript(workdir string, globs []string) string {


### PR DESCRIPTION
An exact artifact filename currently walks its whole directory tree before applying the filename matcher. Combining `--artifact-glob` with the same `--require-artifact` repeats that walk three times, so unrelated subdirectories can exhaust the collection budget after a successful command.

Limit literal patterns to one level below their existing guarded search root. The shared Bash matcher still owns case folding, filename normalization, protected paths, symlinks, and deduplication. Wildcard discovery is unchanged. The production delta is six lines; there are no new dependencies, configuration, protocol, timeout, or size-cap changes. Large flat parent directories retain their existing per-entry processing cost.

Validation:

- Actual [Blacksmith Testbox A/B](https://github.com/openclaw/crabbox/actions/runs/33962055085), using Go 1.26.5 builds of the final source and a verified baseline overlay changing only the enumerator. With 50,000 unrelated files and a 306,913-byte artifact, the baseline workload succeeded but collection failed at 33.674 seconds in adapter timing; the candidate succeeded at 3.952 seconds. Whole-CLI wall times were 38.99 and 8.80 seconds. The returned archive contained exactly the expected file with identical SHA-256. The owned Testbox was stopped.
- `go test -race -timeout=15m ./internal/cli ./internal/providers/blacksmith -run Artifact -count=1 -v`: 163 tests passed on Linux; two existing case-insensitive-filesystem publication tests skipped there. Both native comparison binaries built successfully.
- The full 23-case literal table, separate require-only newline-normalization test, and existing wildcard/symlink/empty-archive scenarios passed on stock macOS Bash 3.2. The new shell-setting and normalization cases fail against the discarded filename-lookup implementation and pass against both the original and final owners.
- Matching parity passed in 72 macOS locale cases and 54 GNU/Linux locale cases, including `nocasematch`, plus explicit `GLOBIGNORE` checks. A filename prefilter was rejected because it changes existing normalization and Unicode case-folding results; the final code adds only a traversal-depth limit.
- The unchanged original generated collector reached its 30-second budget with 10,000 unrelated nested files on macOS. The final script completed the same fixture in 0.146 seconds with identical payload bytes.
- Independent corrective and consolidated P2 reviews are clean. [Full repository CI](https://github.com/openclaw/crabbox/actions/runs/33962754988) and the required Release Check passed on the exact corrected head `f241a8db603ec767f10da730ba01952c095cb10b`.

Local full-package compilation was cancelled before tests to preserve disk space; the actual package tests and builds above ran on Testbox. Post-run portal reporting also showed a separate deadline in the baseline; this change does not address that additional reporting latency.
