### PR TITLE
fix(images): qualify receipt-based rollback

### DIFF
--- a/docs/behavior/aws-image-qualification.md
+++ b/docs/behavior/aws-image-qualification.md
@@ -34,11 +34,11 @@ tokens from bounded responses before returning them to the executor.
 The relay rejects an absent or expired run timestamp and rechecks expiry
 immediately before candidate dispatch.
 
-The publisher proof records a seeded base revision, failed candidate revision,
-and fresh rollback revision. It requires the rollback receipt to restore the
-base image under a new revision, retire the failed candidate revision, and
-reject a stale compare-and-swap request with the fresh rollback revision as the
-current default. Full candidate API readbacks before and after that stale
+The publisher proof records a seeded base revision and failed candidate revision.
+It requires the rollback receipt to restore the exact seeded default aliases and
+revision, retire the failed candidate revision, and reject a stale
+compare-and-swap request naming that failed revision. Full candidate API
+readbacks before and after that stale
 request must match, including catalog, default, and Fast Snapshot Restore state.
 A retired AMI may remain visible as a matching provider-only record, but it
 must have no revision, promotion timestamp, or catalog-only marker.

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -731,12 +731,11 @@ signer dispatch. The candidate publisher then boots source, candidate-image,
 and promoted-image leases sequentially. A trusted `CRABBOX_BIN` adapter
 delegates every command to the exact candidate CLI and captures the structured
 promotion and rollback receipts. Candidate API readbacks must prove the exact
-seeded base image was restored under a fresh rollback revision, distinct from
-both the seeded and failed promotion revisions, and the failed image revision
-lost its catalog role. A `200` readback for that AMI is accepted only as a
-matching provider-only record with no revision, promotion timestamp, or
-catalog-only marker; `404` is also valid. A stale request naming the seeded
-revision must then return 409 with the fresh rollback revision as current,
+seeded base image and revision were restored and the failed image revision lost
+its catalog role. A `200` readback for that AMI is accepted only as a matching
+provider-only record with no revision, promotion timestamp, or catalog-only
+marker; `404` is also valid. A stale request naming the failed revision must
+then return 409 with the seeded revision as current,
 while complete candidate API readbacks remain unchanged, including catalog,
 default, and FSR state. Candidate logs are supplemental only. The adapter
 returns exit 86 only after the promoted smoke succeeds. A credentialless child

--- a/scripts/image-qualification-control.mjs
+++ b/scripts/image-qualification-control.mjs
@@ -137,19 +137,20 @@ export function verifyCatalogRollbackEvidence({
     promoted.revision === prior.revision ||
     promotedPrevious.state !== "present" ||
     promotedPrevious.imageId !== prior.id ||
-    promotedPrevious.revision !== prior.revision
+    promotedPrevious.revision !== prior.revision ||
+    !Array.isArray(promotedPrevious.aliases) ||
+    promotedPrevious.aliases.length === 0
   ) {
-    throw new Error("promotion receipt did not advance from the seeded default revision");
+    throw new Error("promotion receipt did not capture and advance from the seeded default");
   }
   if (
     rollbackPrevious.state !== "present" ||
     rollbackPrevious.imageId !== promoted.id ||
     rollbackPrevious.revision !== promoted.revision ||
     rollbackImage.id !== prior.id ||
-    rollbackImage.revision === prior.revision ||
-    rollbackImage.revision === promoted.revision
+    rollbackImage.revision !== prior.revision
   ) {
-    throw new Error("rollback receipt did not restore the base image under a fresh revision");
+    throw new Error("rollback receipt did not restore the exact seeded default revision");
   }
   if (restored.id !== rollbackImage.id || restored.revision !== rollbackImage.revision) {
     throw new Error("rollback receipt and restored candidate API readback do not match");
@@ -172,8 +173,8 @@ export function verifyCatalogRollbackEvidence({
     Number(staleStatus) !== 409 ||
     stale.error !== "image_promotion_precondition_failed" ||
     staleExpected.state !== "present" ||
-    staleExpected.imageId !== prior.id ||
-    staleExpected.revision !== prior.revision ||
+    staleExpected.imageId !== promoted.id ||
+    staleExpected.revision !== promoted.revision ||
     staleCurrent.state !== "present" ||
     staleCurrent.imageId !== rollbackImage.id ||
     staleCurrent.revision !== rollbackImage.revision
@@ -196,7 +197,7 @@ export function verifyCatalogRollbackEvidence({
     restoredRevisionDigest: digest(rollbackImage.revision),
     seededDefaultReadback: true,
     priorDefaultImageRestored: true,
-    rollbackRevisionAdvanced: true,
+    priorDefaultRevisionRestored: true,
     failedCatalogRevisionRetired: true,
     staleCASRejected: true,
     staleReadbackUnchanged: true,
@@ -524,8 +525,9 @@ export function verifyPublisherContract(source) {
     /CRABBOX_BIN="\$\{CRABBOX_BIN:-/,
     /trap cleanup EXIT/,
     /rollback_promoted_image\(\)/,
-    /--expected-current-image "\$current_id".*--expected-current-revision "\$current_revision".*--retire-expected-catalog "\$rollback_image"/,
+    /--restore-receipt "\$receipt" "\$current_id"/,
     /promote_args=\(image promote .*--expected-current-image capture\)/,
+    /\.previous\.aliases \| length > 0/,
     /restored previous default image=%s/,
   ];
   if (requiredPatterns.some((pattern) => !pattern.test(source))) {
@@ -1632,7 +1634,7 @@ export function verifyQualificationEvidence(attestation, proof) {
     proof?.fsr?.rejected !== true ||
     proof?.catalog?.seededDefaultReadback !== true ||
     proof?.catalog?.priorDefaultImageRestored !== true ||
-    proof?.catalog?.rollbackRevisionAdvanced !== true ||
+    proof?.catalog?.priorDefaultRevisionRestored !== true ||
     proof?.catalog?.failedCatalogRevisionRetired !== true ||
     proof?.catalog?.staleCASRejected !== true ||
     proof?.catalog?.staleReadbackUnchanged !== true ||

--- a/scripts/image-qualification-crabbox-adapter.sh
+++ b/scripts/image-qualification-crabbox-adapter.sh
@@ -22,7 +22,7 @@ if [[ "$command_name" == image && "${2:-}" == promote ]]; then
   for argument in "$@"; do
     if [[ "$argument" == capture ]]; then
       receipt="$QUALIFICATION_ADAPTER_STATE/promotion-receipt.json"
-    elif [[ "$argument" == --retire-expected-catalog ]]; then
+    elif [[ "$argument" == --retire-expected-catalog || "$argument" == --restore-receipt ]]; then
       receipt="$QUALIFICATION_ADAPTER_STATE/rollback-receipt.json"
     fi
   done

--- a/scripts/image-qualification-execute.sh
+++ b/scripts/image-qualification-execute.sh
@@ -139,16 +139,20 @@ failed_status=$(curl --silent --show-error --max-time 30 \
   -H "@$relay_headers" -o "$raw/failed-readback.json" -w '%{http_code}' \
   "$QUALIFICATION_RELAY_URL/v1/images/$failed_image?provider=aws&target=linux&region=$QUALIFICATION_AWS_REGION")
 [[ "$failed_status" == 200 || "$failed_status" == 404 ]]
-node - "$raw/seed.json" "$raw/stale-cas-request.json" <<'NODE'
+node - "$QUALIFICATION_ADAPTER_STATE/promotion-receipt.json" "$raw/stale-cas-request.json" <<'NODE'
 const fs = require("node:fs");
-const seed = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
-if (!/^ami-[0-9a-f]+$/.test(seed?.id ?? "") || typeof seed?.revision !== "string") {
-  throw new Error("seed receipt does not contain an exact image revision");
+const promotion = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+if (!/^ami-[0-9a-f]+$/.test(promotion?.image?.id ?? "") || typeof promotion?.image?.revision !== "string") {
+  throw new Error("promotion receipt does not contain an exact failed image revision");
 }
 fs.writeFileSync(
   process.argv[3],
   `${JSON.stringify({
-    expectedCurrent: { state: "present", imageId: seed.id, revision: seed.revision },
+    expectedCurrent: {
+      state: "present",
+      imageId: promotion.image.id,
+      revision: promotion.image.revision,
+    },
   })}\n`,
   { mode: 0o600 },
 );

--- a/scripts/image-qualification-workflow.test.js
+++ b/scripts/image-qualification-workflow.test.js
@@ -278,7 +278,7 @@ cleanup() {
 }
 trap cleanup EXIT
 rollback_promoted_image() {
-  args+=(--expected-current-image "$current_id" --expected-current-revision "$current_revision" --retire-expected-catalog "$rollback_image")
+  args+=(--restore-receipt "$receipt" "$current_id")
   printf 'promoted-image smoke failed; restored previous default image=%s\\n' "$rollback_image"
 }
 run_cmd "$CRABBOX_BIN" stop --provider aws --target "$target" "$candidate_lease"
@@ -286,6 +286,7 @@ candidate_lease=""
 promote_args=(image promote --target "$target" --json --expected-current-image capture)
 rollback_pending=1
 run_json_tee "$promotion_log" "$CRABBOX_BIN" "\${promote_args[@]}"
+jq -e '.previous.aliases | length > 0' "$promotion_log"
 promoted_lease="$(warmup promoted)"
 smoke "$promoted_lease"
 rollback_pending=0
@@ -478,7 +479,7 @@ test("attestation gate requires FSR denial and exact sequential launch order", a
     catalog: {
       seededDefaultReadback: true,
       priorDefaultImageRestored: true,
-      rollbackRevisionAdvanced: true,
+      priorDefaultRevisionRestored: true,
       failedCatalogRevisionRetired: true,
       staleCASRejected: true,
       staleReadbackUnchanged: true,
@@ -570,24 +571,24 @@ test("attestation gate requires FSR denial and exact sequential launch order", a
   );
 });
 
-test("catalog proof requires a fresh rollback revision and rejects stale CAS mutation", async () => {
+test("catalog proof requires exact default restoration and rejects stale CAS mutation", async () => {
   const module = await import(
     `${pathToFileURL(path.join(root, "scripts/image-qualification-control.mjs"))}?catalog=${Date.now()}`
   );
   const prior = { id: "ami-11111111", revision: "revision-prior", promotedAt: "before" };
   const failed = { id: "ami-22222222", revision: "revision-failed", promotedAt: "during" };
-  const restored = {
-    ...prior,
-    revision: "revision-rollback",
-    promotedAt: "after",
-    fastSnapshotRestores: [],
-  };
+  const restored = { ...prior, fastSnapshotRestores: [] };
   const input = {
     seed: prior,
     seededReadback: { image: prior },
     promotion: {
       image: failed,
-      previous: { state: "present", imageId: prior.id, revision: prior.revision },
+      previous: {
+        state: "present",
+        imageId: prior.id,
+        revision: prior.revision,
+        aliases: [{ alias: "regional", state: "present", image: prior }],
+      },
     },
     rollback: {
       image: restored,
@@ -598,7 +599,7 @@ test("catalog proof requires a fresh rollback revision and rejects stale CAS mut
     failedStatus: 200,
     staleResponse: {
       error: "image_promotion_precondition_failed",
-      expected: { state: "present", imageId: prior.id, revision: prior.revision },
+      expected: { state: "present", imageId: failed.id, revision: failed.revision },
       current: { state: "present", imageId: restored.id, revision: restored.revision },
     },
     staleStatus: 409,
@@ -610,19 +611,22 @@ test("catalog proof requires a fresh rollback revision and rejects stale CAS mut
   };
   const evidence = module.verifyCatalogRollbackEvidence(input);
   assert.equal(evidence.priorDefaultImageRestored, true);
-  assert.equal(evidence.rollbackRevisionAdvanced, true);
+  assert.equal(evidence.priorDefaultRevisionRestored, true);
   assert.equal(evidence.failedCatalogRevisionRetired, true);
   assert.equal(evidence.staleCASRejected, true);
   assert.equal(evidence.staleReadbackUnchanged, true);
   assert.match(evidence.restoredRevisionDigest, /^[0-9a-f]{64}$/);
-  assert.equal("priorDefaultRevisionRestored" in evidence, false);
+  assert.equal("rollbackRevisionAdvanced" in evidence, false);
   assert.throws(
     () =>
       module.verifyCatalogRollbackEvidence({
         ...input,
-        rollback: { ...input.rollback, image: prior },
+        rollback: {
+          ...input.rollback,
+          image: { ...prior, revision: "revision-mismatch" },
+        },
       }),
-    /fresh revision/,
+    /exact seeded default revision/,
   );
   assert.throws(
     () =>
@@ -641,7 +645,7 @@ test("catalog proof requires a fresh rollback revision and rejects stale CAS mut
           previous: { state: "present", imageId: failed.id, revision: prior.revision },
         },
       }),
-    /fresh revision/,
+    /exact seeded default revision/,
   );
   assert.throws(
     () =>
@@ -1081,7 +1085,7 @@ fi
     assert.equal(
       spawnSync(
         path.join(root, "scripts/image-qualification-crabbox-adapter.sh"),
-        ["image", "promote", "--retire-expected-catalog", "ami-11111111"],
+        ["image", "promote", "--restore-receipt", path.join(temp, "promotion.json"), "ami-11111111"],
         { env },
       ).status,
       0,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the protected image qualification workflow on `main` cannot correctly evaluate the receipt-aware rollback candidate in https://github.com/openclaw/crabbox/pull/1756. The existing protected tooling expects rollback to create a new revision and builds its stale-CAS probe from the restored seed instead of the failed promoted revision.

## Why This Change Was Made

The protected admission and evidence path now requires the publisher's promotion receipt to capture aliases, verifies rollback restored the exact seeded default revision, records `--restore-receipt` output, and probes stale CAS against the failed promoted revision.

This is the protected-tooling prerequisite for qualifying https://github.com/openclaw/crabbox/pull/1756, plus the two operator passages required to keep the qualification contract accurate. It does not include that PR's rollback runtime, workflow, authority, policy, Wrangler, command documentation, broader runtime runbook changes, or changelog changes, and it does not close or merge that draft PR.

Production LOC: +22/-16 (net +6) | Tests: +21/-17 (net +4) | Docs: +10/-11 (net -1)

## User Impact

No direct runtime behavior changes. Maintainers can run the protected qualification workflow against the receipt-aware rollback candidate after that candidate is rebased onto this prerequisite.

## Evidence

- `node --test scripts/image-qualification-workflow.test.js` (17 passed)
- `node --check scripts/image-qualification-control.mjs`
- `node --check scripts/image-qualification-workflow.test.js`
- `bash -n scripts/image-qualification-crabbox-adapter.sh scripts/image-qualification-execute.sh`
- `shellcheck scripts/image-qualification-crabbox-adapter.sh scripts/image-qualification-execute.sh`
- `node scripts/generate-linux-readiness.mjs --check`
- `node scripts/generate-bootstrap.mjs --check`
- `scripts/check-docs.sh` (246 markdown files checked; 14 docs tests passed)
- `git diff --check`
- Exact file-content match to https://github.com/openclaw/crabbox/commit/c18fc707235487326f25471a2720da9f2012ad85 for the four prerequisite files

No cloud qualification run was performed for this prerequisite.
