### PR TITLE
fix(cli): give runtimeForApp a timed HTTP client

### DIFF
--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -1677,8 +1677,14 @@ func routeConfiguredProvider(cfg *Config) error {
 	return nil
 }
 
+const defaultRuntimeHTTPTimeout = 60 * time.Second
+
+func defaultRuntimeHTTP() *http.Client {
+	return &http.Client{Timeout: defaultRuntimeHTTPTimeout}
+}
+
 func runtimeForApp(a App) Runtime {
-	return Runtime{Stdout: a.Stdout, Stderr: a.Stderr, Clock: realClock{}, Exec: execCommandRunner{}}
+	return Runtime{Stdout: a.Stdout, Stderr: a.Stderr, Clock: realClock{}, HTTP: defaultRuntimeHTTP(), Exec: execCommandRunner{}}
 }
 
 const (

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -25,7 +25,7 @@ func RuntimeForProviderOperation(stderr io.Writer) Runtime {
 	if stderr == nil {
 		stderr = io.Discard
 	}
-	return Runtime{Stdout: io.Discard, Stderr: stderr, Clock: realClock{}, Exec: execCommandRunner{}}
+	return Runtime{Stdout: io.Discard, Stderr: stderr, Clock: realClock{}, HTTP: defaultRuntimeHTTP(), Exec: execCommandRunner{}}
 }
 
 // ProviderSelectionIsAuthoritativeRoute reports whether cfg names an exact

--- a/internal/cli/runtime_http_test.go
+++ b/internal/cli/runtime_http_test.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"io"
+	"testing"
+	"time"
+)
+
+func TestRuntimeForAppSetsTimedHTTPClient(t *testing.T) {
+	rt := runtimeForApp(App{})
+	if rt.HTTP == nil {
+		t.Fatal("runtimeForApp HTTP is nil")
+	}
+	if got, want := rt.HTTP.Timeout, 60*time.Second; got != want {
+		t.Fatalf("runtimeForApp HTTP Timeout = %v, want %v", got, want)
+	}
+}
+
+func TestRuntimeForProviderOperationSetsTimedHTTPClient(t *testing.T) {
+	rt := RuntimeForProviderOperation(io.Discard)
+	if rt.HTTP == nil {
+		t.Fatal("RuntimeForProviderOperation HTTP is nil")
+	}
+	if got, want := rt.HTTP.Timeout, 60*time.Second; got != want {
+		t.Fatalf("RuntimeForProviderOperation HTTP Timeout = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `crabbox run`, `connect`, `status`, and other product commands against HTTP providers could hang forever when the provider control plane stopped responding. Those commands load backends through `runtimeForApp`, which left `Runtime.HTTP` unset. Providers such as opencomputer, crownest, superserve, opensandbox, unikraftcloud, and cloudrunsandbox then fell back to `http.DefaultClient`, which has no timeout.

The same hole exists on `RuntimeForProviderOperation`, used for provider lifecycle work that is not already bound to a configured backend.

## Why This Change Was Made

Give both constructors a shared 60-second `http.Client`, matching the finite-control clients already used in Azure and Hetzner helpers. A single `defaultRuntimeHTTP()` helper keeps the two paths from drifting.

This does not clone `http.DefaultTransport`. https://github.com/openclaw/crabbox/pull/1750 already bounded Daytona control-plane calls inside the Daytona adapter. This change covers the remaining unset `Runtime.HTTP` constructors on the product CLI path.

## User Impact

Stalled provider control-plane requests on the main CLI path now fail after 60 seconds instead of hanging until the process is killed. Operators get an error they can retry or diagnose. No config or flag changes.

## Evidence

Live `go` program calling the exported provider-operation runtime after the patch, plus the built `crabbox` binary from this tree:

```console
$ go run .
HTTP timeout: 1m0s
HTTP is DefaultClient: false
DefaultClient timeout: 0s
```

```console
$ crabbox --help
Crabbox leases remote test boxes, syncs your dirty checkout, runs commands, and cleans up.

Usage:
  crabbox <command> [flags]
  crabbox run [flags] -- <command...>
```

The same helper is used by unexported `runtimeForApp`, which is what `run`, `connect`, and `status` pass into `loadBackend`. Before the patch, `HTTP` was nil on both constructors, so those providers used `http.DefaultClient` (`Timeout` 0s, no deadline).

## Real behavior proof

- **Behavior or issue addressed:** Product CLI runtimes omitted HTTP, so provider control calls could hang forever on a stalled host via `http.DefaultClient`.
- **Real environment tested:** Windows 11, Go 1.27.0 windows/amd64, worktree at `fix/runtime-timed-http-client` based on origin/main [`6172f518`](https://github.com/openclaw/crabbox/commit/6172f518).
- **Exact steps or command run after this patch:** Built `crabbox` from this tree with `go build`, then ran a small `go` program in the same module that calls `cli.RuntimeForProviderOperation` and prints the client timeout next to `http.DefaultClient`.
- **Evidence after fix:** terminal output from the patched tree:

  ```console
  $ go run .
  HTTP timeout: 1m0s
  HTTP is DefaultClient: false
  DefaultClient timeout: 0s
  ```

- **Observed result after fix:** The exported provider-operation runtime now carries a 60-second HTTP client that is not `http.DefaultClient`. DefaultClient remains unbounded (0s), which is the hang that providers used when HTTP was nil.
- **What was not tested:** Live opencomputer, crownest, or superserve control-plane outage. Multi-minute Daytona archive uploads and E2B envd streams against a real host.

## Related

- https://github.com/openclaw/crabbox/pull/1229
- https://github.com/openclaw/crabbox/pull/1370
- https://github.com/openclaw/crabbox/pull/1371
- https://github.com/openclaw/crabbox/pull/1750
- Introduced on `runtimeForApp` in [`494f3a4d`](https://github.com/openclaw/crabbox/commit/494f3a4d) (2026-05-06)
- `RuntimeForProviderOperation` added in https://github.com/openclaw/crabbox/pull/1405
