### PR TITLE
refactor(providers): remove unused private state

### DIFF
--- a/internal/providers/applemachine/backend.go
+++ b/internal/providers/applemachine/backend.go
@@ -344,16 +344,15 @@ func (b *backend) createLease(ctx context.Context, repo Repo, reclaim bool, requ
 
 func (b *backend) waitMachineReady(ctx context.Context, claim core.LeaseClaim) error {
 	type observation struct {
-		result LocalCommandResult
-		err    error
+		err error
 	}
 	_, err := shared.Poll(ctx, 0, 500*time.Millisecond, shared.SleepContext,
 		func(ctx context.Context) (observation, error) {
 			if _, err := b.verifyMachineIdentity(ctx, claim); err != nil {
 				return observation{}, err
 			}
-			result, err := b.control(ctx, []string{"machine", "run", "--name", claim.CloudID, ":"})
-			return observation{result: result, err: err}, nil
+			_, err := b.control(ctx, []string{"machine", "run", "--name", claim.CloudID, ":"})
+			return observation{err: err}, nil
 		},
 		func(_ context.Context, current observation, identityErr error) (bool, error) {
 			if identityErr != nil {

--- a/internal/providers/scaleway/config.go
+++ b/internal/providers/scaleway/config.go
@@ -10,7 +10,6 @@ const (
 	defaultRegion = "fr-par"
 	defaultZone   = "fr-par-1"
 	defaultImage  = "ubuntu_noble"
-	defaultType   = "DEV1-S"
 )
 
 func regionForConfig(cfg core.Config) string {

--- a/internal/providers/sealosdevbox/kubectl.go
+++ b/internal/providers/sealosdevbox/kubectl.go
@@ -17,7 +17,6 @@ import (
 const (
 	devboxGroupVersion = "devbox.sealos.io/v1alpha2"
 	devboxResource     = "devboxes.devbox.sealos.io"
-	devboxCRD          = "devboxes.devbox.sealos.io"
 )
 
 func (b *backend) kubectl(ctx context.Context, stdout io.Writer, namespace bool, args ...string) (string, error) {

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -17,7 +17,6 @@ import (
 
 const (
 	superserveCleanupTimeout = 15 * time.Second
-	statusViewReady          = "running"
 	NetworkPublic            = "public"
 
 	metadataProviderKey = "crabbox.provider"

--- a/internal/providers/tensorlake/core.go
+++ b/internal/providers/tensorlake/core.go
@@ -32,18 +32,13 @@ type timingPhase = core.TimingPhase
 type LocalCommandRequest = core.LocalCommandRequest
 
 const (
-	providerName    = "tensorlake"
-	leasePrefix     = "tlsbx_"
-	namePrefix      = "crabbox-"
-	defaultAPIURL   = "https://api.tensorlake.ai"
-	defaultCLIPath  = "tensorlake"
-	defaultCPUs     = 1
-	defaultMemoryMB = 1024
-	defaultDiskMB   = 10240
-	defaultWorkdir  = "/workspace"
-	targetLinux     = core.TargetLinux
-	NetworkPublic   = core.NetworkPublic
-	statusViewReady = "running"
+	providerName   = "tensorlake"
+	leasePrefix    = "tlsbx_"
+	namePrefix     = "crabbox-"
+	defaultAPIURL  = "https://api.tensorlake.ai"
+	defaultCLIPath = "tensorlake"
+	targetLinux    = core.TargetLinux
+	NetworkPublic  = core.NetworkPublic
 
 	maxSandboxNameLen    = 63
 	sandboxNameSuffixLen = 6

--- a/internal/providers/vast/core.go
+++ b/internal/providers/vast/core.go
@@ -26,7 +26,6 @@ type SSHTarget = core.SSHTarget
 
 const (
 	providerName = "vast"
-	targetLinux  = core.TargetLinux
 )
 
 func exit(code int, format string, args ...any) core.ExitError {

--- a/internal/providers/xcpng/iso_e2e.go
+++ b/internal/providers/xcpng/iso_e2e.go
@@ -53,9 +53,7 @@ type isoE2ERuntime struct {
 	installerDrive    xcpNgConfigDrive
 	answerDrive       xcpNgConfigDrive
 	installDisk       xcpNgConfigDrive
-	remasteredISO     string
 	generatedSeed     string
-	generatedAnswer   string
 	linuxSeedPayload  xcpNgCloudInitPayload
 	keyPath           string
 	ownsKey           bool
@@ -536,7 +534,6 @@ func (r *isoE2ERuntime) prepareInstallerMedia(ctx context.Context, opts ISOE2EOp
 			summary.Reason = fmt.Sprintf("linux_autoinstall_boot_arg_unavailable: %v", err)
 			return err
 		}
-		r.remasteredISO = remasteredISO
 		r.keepLocal[remasteredISO] = struct{}{}
 		summary.Evidence["installer_iso_remastered"] = remasteredISO
 		opts.ISO = remasteredISO
@@ -636,7 +633,6 @@ func (r *isoE2ERuntime) prepareWindowsAnswerMedia(ctx context.Context, opts ISOE
 		return err
 	}
 	r.windowsUser = payload.Username
-	r.generatedAnswer = answerISO
 	r.cleanupLocal = append(r.cleanupLocal, answerISO)
 	answerDir := filepath.Dir(answerISO)
 	if strings.HasPrefix(filepath.Base(answerDir), "windows-answer-media-") {


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible
`Closes https://github.com/openclaw/crabbox/issues/<issue-number>` or
`Related: https://github.com/openclaw/crabbox/issues/<issue-number>` line below
this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Removes private provider state and constants that are no longer read. Keeping
these declarations implies lifecycle behavior that does not exist and makes
provider maintenance harder to audit.

## Why This Change Was Made

The change deletes only unused declarations and their write-only assignments.
It preserves local media paths, cleanup and retention bookkeeping, Apple
machine identity checks, polling cadence, and readiness error handling.

## User Impact

No user-visible behavior changes. Provider implementations are smaller and
their retained state more accurately reflects runtime behavior.

## Evidence

- `gofmt -d` is clean for all seven touched Go files.
- `git diff --check` passes.
- The reviewed source diff has SHA-256
  `9b9e32b30cf811dbb4ce8d5307edba77fed059f944d1e3c2dfc5cae88574569e`.
- No local tests or builds were run; draft PR CI provides validation against
  the current workflow set.
