### PR TITLE
refactor(test): share provider client constructors

### DIFF
--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -25,6 +25,15 @@ import (
 	"time"
 )
 
+func mustNewCoordinatorClient(t *testing.T, cfg Config) *CoordinatorClient {
+	t.Helper()
+	coord, _, err := newCoordinatorClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return coord
+}
+
 type coordinatorAcquireValidationBackend struct {
 	testSSHBackend
 	err   error
@@ -99,10 +108,7 @@ func TestCoordinatorListUsesUserLeasesWithoutAdminProbe(t *testing.T) {
 		CoordToken:      "user-token",
 		CoordAdminToken: "stale-admin-token",
 	}
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &stderr}}
 
 	servers, err := backend.List(context.Background(), ListRequest{})
@@ -149,10 +155,7 @@ func TestCoordinatorListAllFallsBackToUserLeasesWhenAdminTokenUnauthorized(t *te
 		CoordToken:      "user-token",
 		CoordAdminToken: "stale-admin-token",
 	}
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &stderr}}
 
 	servers, err := backend.List(context.Background(), ListRequest{All: true})
@@ -191,10 +194,7 @@ func TestCoordinatorListJSONUsesUserLeasesWhenAdminTokenMissing(t *testing.T) {
 	defer server.Close()
 
 	cfg := Config{Provider: "daytona", TargetOS: targetLinux, Coordinator: server.URL, CoordToken: "user-token"}
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	var stderr bytes.Buffer
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &stderr}}
 
@@ -248,10 +248,7 @@ func TestCoordinatorStatusRedactsDaytonaSSHAccessToken(t *testing.T) {
 		Coordinator: server.URL,
 		CoordToken:  "user-token",
 	}
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord}
 
 	status, err := backend.Status(context.Background(), StatusRequest{ID: "cbx_123"})
@@ -303,10 +300,7 @@ func TestCoordinatorStatusKeepsFourSecondWindowsSSHProbe(t *testing.T) {
 	cfg.Network = NetworkPublic
 	cfg.Coordinator = server.URL
 	cfg.CoordToken = "user-token"
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord}
 	start := time.Now()
 	status, err := backend.Status(context.Background(), StatusRequest{ID: "cbx_windows_status"})
@@ -631,10 +625,7 @@ func TestCoordinatorAcquireSendsTailscaleHostnameTemplate(t *testing.T) {
 	cfg.CoordToken = "user-token"
 	cfg.Tailscale.Enabled = true
 	cfg.Tailscale.HostnameTemplate = "lease-{slug}"
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
 
 	if _, err := backend.acquireOnce(context.Background(), false, "smoke"); err == nil || !strings.Contains(err.Error(), "stop after request capture") {
@@ -708,10 +699,7 @@ func TestCoordinatorAcquirePreservesAWSSSHCIDROwnership(t *testing.T) {
 			cfg.Coordinator = server.URL
 			cfg.CoordToken = "user-token"
 			cfg.AWSSSHCIDRs = test.cidrs
-			coord, _, err := newCoordinatorClient(cfg)
-			if err != nil {
-				t.Fatal(err)
-			}
+			coord := mustNewCoordinatorClient(t, cfg)
 			backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: io.Discard}}
 			if _, err := backend.acquireOnce(context.Background(), false, "cidr-source"); err == nil || !strings.Contains(err.Error(), "stop after request capture") {
 				t.Fatalf("err=%v, want captured request error", err)
@@ -759,10 +747,7 @@ func TestCoordinatorFixedAcquireUsesRequestedIDAndJoinsProvisioning(t *testing.T
 	cfg.TargetOS = targetLinux
 	cfg.Coordinator = server.URL
 	cfg.CoordToken = "user-token"
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
 	lease, err := backend.createCoordinatorLeaseWithProgressMode(
 		context.Background(), cfg, "ssh-ed25519 test", true,
@@ -829,10 +814,7 @@ func TestCoordinatorAcquireRetainsCurrentProvisioningTiming(t *testing.T) {
 	cfg.TargetOS = targetLinux
 	cfg.Coordinator = server.URL
 	cfg.CoordToken = "user-token"
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: io.Discard}}
 	acquired, err := backend.Acquire(context.Background(), AcquireRequest{
 		Keep: true, RequestedLeaseID: lease.ID, RequestedSlug: lease.Slug,
@@ -881,10 +863,7 @@ func TestCoordinatorAcquirePollsCanonicalIDFromProvisioningReplay(t *testing.T) 
 	cfg.TargetOS = targetLinux
 	cfg.Coordinator = server.URL
 	cfg.CoordToken = "user-token"
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
 	lease, err := backend.createCoordinatorLeaseWithProgressMode(
 		context.Background(), cfg, "ssh-ed25519 test", true, requestedID, "retained-canonical", false,
@@ -944,10 +923,7 @@ func TestCoordinatorFixedAcquireInvokesOnAcquiredOnceAndPropagatesError(t *testi
 	cfg.TargetOS = targetLinux
 	cfg.Coordinator = server.URL
 	cfg.CoordToken = "user-token"
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
 	want := errors.New("acknowledgment rejected")
 	callbacks := 0
@@ -997,14 +973,11 @@ func TestCoordinatorFixedAcquireDoesNotReleaseCommittedLeaseAfterClientBootstrap
 	cfg.TargetOS = targetLinux
 	cfg.Coordinator = server.URL
 	cfg.CoordToken = "user-token"
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
-	_, err = backend.Acquire(ctx, AcquireRequest{
+	_, err := backend.Acquire(ctx, AcquireRequest{
 		Keep: true, RequestedLeaseID: "cbx_abcdef123457", RequestedSlug: "fixed-bootstrap",
 	})
 	if err == nil {
@@ -1390,16 +1363,13 @@ func TestCoordinatorCreateLeaseTimesOutWithDiagnostics(t *testing.T) {
 	cfg.ServerType = "Standard_D32ads_v6"
 	cfg.Coordinator = server.URL
 	cfg.CoordToken = "user-token"
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	var stderr bytes.Buffer
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &stderr}}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	_, err = backend.createCoordinatorLeaseWithProgress(ctx, cfg, "ssh-rsa test", false, "cbx_timeout", "crimson-lobster")
+	_, err := backend.createCoordinatorLeaseWithProgress(ctx, cfg, "ssh-rsa test", false, "cbx_timeout", "crimson-lobster")
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}
@@ -1497,10 +1467,7 @@ func TestCoordinatorCreateLeaseCancellationUsesExactDurableAttemptToken(t *testi
 	cfg.TargetOS = targetLinux
 	cfg.Coordinator = server.URL
 	cfg.CoordToken = "user-token"
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	var stderr bytes.Buffer
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &stderr}}
 
@@ -1594,10 +1561,7 @@ func TestCanceledCoordinatorCreateRetriesTransientCancelFailure(t *testing.T) {
 	cfg.TargetOS = targetLinux
 	cfg.Coordinator = server.URL
 	cfg.CoordToken = "user-token"
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	backend := &coordinatorLeaseBackend{coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
 	recoverCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -1739,10 +1703,7 @@ func TestCoordinatorFixedCreateCancellationDoesNotReleaseDurableLease(t *testing
 	cfg.TargetOS = targetLinux
 	cfg.Coordinator = server.URL
 	cfg.CoordToken = "user-token"
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
 	ctx, cancel := context.WithCancel(context.Background())
 	resultCh := make(chan coordinatorCreateLeaseResult, 1)
@@ -1839,10 +1800,7 @@ func TestCanceledCoordinatorCreateAcceptsDurableTombstoneWithoutLease(t *testing
 	cfg.TargetOS = targetLinux
 	cfg.Coordinator = server.URL
 	cfg.CoordToken = "user-token"
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	backend := &coordinatorLeaseBackend{
 		cfg:   cfg,
 		coord: coord,
@@ -1902,13 +1860,10 @@ func TestCanceledCoordinatorCreateValidatesAttestation(t *testing.T) {
 			cfg.TargetOS = targetLinux
 			cfg.Coordinator = server.URL
 			cfg.CoordToken = "user-token"
-			coord, _, err := newCoordinatorClient(cfg)
-			if err != nil {
-				t.Fatal(err)
-			}
+			coord := mustNewCoordinatorClient(t, cfg)
 			backend := &coordinatorLeaseBackend{coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
 
-			err = backend.cancelCoordinatorLeaseCreate(
+			err := backend.cancelCoordinatorLeaseCreate(
 				context.Background(),
 				"cbx_cancel_expected",
 				"expected-crab",
@@ -2009,10 +1964,7 @@ func TestCoordinatorCreateLeaseRecoversWithSameTokenBoundPost(t *testing.T) {
 	cfg.WindowsMode = windowsModeNormal
 	cfg.Coordinator = server.URL
 	cfg.CoordToken = "user-token"
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	var stderr bytes.Buffer
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &stderr}}
 
@@ -2064,10 +2016,7 @@ func TestCoordinatorCreateLeaseDefinitiveErrorDoesNotReconcile(t *testing.T) {
 	cfg.TargetOS = targetLinux
 	cfg.Coordinator = server.URL
 	cfg.CoordToken = "user-token"
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	backend := &coordinatorLeaseBackend{
 		cfg:   cfg,
 		coord: coord,
@@ -2132,12 +2081,9 @@ func TestCoordinatorFixedCreateAmbiguousErrorRepeatsPutAndDoesNotAdoptConflictin
 	cfg.TargetOS = targetLinux
 	cfg.Coordinator = server.URL
 	cfg.CoordToken = "user-token"
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
-	_, err = backend.createCoordinatorLeaseWithProgressMode(
+	_, err := backend.createCoordinatorLeaseWithProgressMode(
 		context.Background(), cfg, "ssh-ed25519 test", true,
 		"cbx_abcdef123462", "fixed-conflict", true,
 	)
@@ -2529,10 +2475,7 @@ func TestCoordinatorResolveFallsBackToAdminToken(t *testing.T) {
 		CoordToken:      "user-token",
 		CoordAdminToken: "admin-token",
 	}
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
 
 	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: "cbx_admin"})
@@ -3023,10 +2966,7 @@ func newCoordinatorIdentityTestBackend(t *testing.T, serverURL, adminToken strin
 	cfg.Coordinator = serverURL
 	cfg.CoordToken = "user-token"
 	cfg.CoordAdminToken = adminToken
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	return &coordinatorLeaseBackend{
 		spec:  ProviderSpec{Name: "aws"},
 		cfg:   cfg,
@@ -3104,13 +3044,10 @@ func TestCoordinatorReleaseFallsBackToAdminToken(t *testing.T) {
 		CoordToken:      "user-token",
 		CoordAdminToken: "admin-token",
 	}
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
 
-	err = backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
+	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
 		LeaseID: "cbx_admin", Server: Server{Provider: "aws"},
 	}})
 	if err != nil {
@@ -3168,13 +3105,10 @@ func TestCoordinatorAcquireRollbackQueuesReleaseOnceWithoutObservation(t *testin
 	cfg.AWSSSHCIDRs = []string{"127.0.0.1/32"}
 	cfg.Coordinator = server.URL
 	cfg.CoordToken = "user-token"
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	var stderr bytes.Buffer
 	backend := &coordinatorLeaseBackend{spec: ProviderSpec{Name: "aws"}, cfg: cfg, coord: coord, rt: Runtime{Stderr: &stderr}}
-	_, err = backend.acquireOnceWithLeaseID(context.Background(), false, "", "rollback-test")
+	_, err := backend.acquireOnceWithLeaseID(context.Background(), false, "", "rollback-test")
 	if err == nil || !strings.Contains(err.Error(), "did not provision desktop=true") {
 		t.Fatalf("acquire error=%v, want capability mismatch", err)
 	}
@@ -3260,14 +3194,11 @@ func TestCoordinatorAcquireCancelsStaleInstanceLease(t *testing.T) {
 	cfg.TargetOS = targetLinux
 	cfg.Coordinator = server.URL
 	cfg.CoordToken = "user-token"
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	var stderr bytes.Buffer
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &stderr}}
 
-	_, err = backend.acquireOnce(context.Background(), false, "")
+	_, err := backend.acquireOnce(context.Background(), false, "")
 	if err == nil || !strings.Contains(err.Error(), "InvalidInstanceID.NotFound") {
 		t.Fatalf("err=%v", err)
 	}
@@ -3321,14 +3252,11 @@ func TestCoordinatorAcquireRetriesStaleInstanceAfterTokenCancellation(t *testing
 	cfg.TargetOS = targetLinux
 	cfg.Coordinator = server.URL
 	cfg.CoordToken = "user-token"
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	var stderr bytes.Buffer
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &stderr}}
 
-	_, err = backend.Acquire(context.Background(), AcquireRequest{})
+	_, err := backend.Acquire(context.Background(), AcquireRequest{})
 	if err == nil || !strings.Contains(err.Error(), "capacity exhausted after retry") {
 		t.Fatalf("err=%v", err)
 	}
@@ -3373,14 +3301,11 @@ func TestCoordinatorAcquireWrapsWorkerCleanupSignalWithoutRelease(t *testing.T) 
 	cfg.Coordinator = server.URL
 	cfg.CoordToken = "user-token"
 	cfg.AWSSSHCIDRs = []string{"0.0.0.0/0"}
-	coord, _, err := newCoordinatorClient(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	coord := mustNewCoordinatorClient(t, cfg)
 	var stderr bytes.Buffer
 	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &stderr}}
 
-	_, err = backend.acquireOnce(context.Background(), false, "")
+	_, err := backend.acquireOnce(context.Background(), false, "")
 	if err == nil || !strings.Contains(err.Error(), "InvalidInstanceID.NotFound") {
 		t.Fatalf("err=%v", err)
 	}

--- a/internal/providers/digitalocean/client_test.go
+++ b/internal/providers/digitalocean/client_test.go
@@ -15,6 +15,17 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
+func newDigitalOceanTestClient(t *testing.T, server *httptest.Server, token string) *digitalOceanClient {
+	t.Helper()
+	t.Setenv("DIGITALOCEAN_TOKEN", token)
+	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.baseURL = server.URL
+	return client
+}
+
 func TestDigitalOceanClientCreateDropletRequestShape(t *testing.T) {
 	var requests []struct {
 		Method string
@@ -85,12 +96,7 @@ func TestDigitalOceanClientCreateDropletRequestShape(t *testing.T) {
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "secret-token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "secret-token")
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
@@ -131,12 +137,7 @@ func TestDigitalOceanClientAccountIDPrefersTeamContext(t *testing.T) {
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 	accountID, err := client.AccountID(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -197,18 +198,13 @@ func TestDigitalOceanClientCreateDropletRollsBackKeyOnSemanticTagCollision(t *te
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
 	cfg.ServerType = "s-1vcpu-1gb"
 
-	_, err = client.CreateDroplet(context.Background(), cfg, "ssh-ed25519 test", "cbx_abcdef123456", "blue", false, time.Now())
+	_, err := client.CreateDroplet(context.Background(), cfg, "ssh-ed25519 test", "cbx_abcdef123456", "blue", false, time.Now())
 	if err == nil || !strings.Contains(err.Error(), `conflicts with existing account tag "Crabbox:Slug:Blue"`) {
 		t.Fatalf("CreateDroplet err=%v", err)
 	}
@@ -256,12 +252,7 @@ func TestDigitalOceanClientCreateDropletRetriesWithCanonicalTags(t *testing.T) {
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
@@ -308,13 +299,8 @@ func TestDigitalOceanClientReplaceDropletTagsDetachesObsoleteCrabboxTags(t *test
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
-	err = client.ReplaceDropletTags(
+	client := newDigitalOceanTestClient(t, server, "token")
+	err := client.ReplaceDropletTags(
 		context.Background(),
 		42,
 		[]string{tagCrabbox, "crabbox:lease:cbx_abcdef123456", "crabbox:state:running", "crabbox:last_touched_at:100", "other"},
@@ -369,12 +355,7 @@ func TestDigitalOceanClientReplaceDropletTagsUsesCanonicalTagName(t *testing.T) 
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 	if err := client.ReplaceDropletTags(
 		context.Background(),
 		42,
@@ -408,12 +389,7 @@ func TestDigitalOceanClientEnsureTagRejectsUnconfirmedConflict(t *testing.T) {
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 	if _, err := client.EnsureTag(context.Background(), "crabbox:state:ready", map[string]string{}); err == nil {
 		t.Fatal("EnsureTag unexpectedly suppressed unconfirmed 422")
 	}
@@ -430,12 +406,7 @@ func TestDigitalOceanClientEnsureTagRejectsSemanticCanonicalCollision(t *testing
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 	if _, err := client.EnsureTag(context.Background(), "crabbox:slug:blue", map[string]string{}); err == nil {
 		t.Fatal("EnsureTag accepted semantic canonical collision")
 	}
@@ -458,12 +429,7 @@ func TestDigitalOceanClientReplaceDropletTagsSkipsUnchangedSet(t *testing.T) {
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 	tags := []string{tagCrabbox, "crabbox:lease:cbx_111111111111", "crabbox:state:ready"}
 	if err := client.ReplaceDropletTags(context.Background(), 42, tags, append([]string(nil), tags...)); err != nil {
 		t.Fatal(err)
@@ -500,17 +466,12 @@ func TestDigitalOceanClientCreateDropletRollsBackNewSSHKeyOnCreateFailure(t *tes
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
 	cfg.ServerType = "s-1vcpu-1gb"
-	_, err = client.CreateDroplet(context.Background(), cfg, "ssh-ed25519 test", "cbx_abcdef123456", "blue", false, time.Now())
+	_, err := client.CreateDroplet(context.Background(), cfg, "ssh-ed25519 test", "cbx_abcdef123456", "blue", false, time.Now())
 	if err == nil {
 		t.Fatal("CreateDroplet succeeded")
 	}
@@ -543,12 +504,7 @@ func TestDigitalOceanClientCreateDropletPreservesKeyOnAmbiguousFailure(t *testin
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 	client.reconcileTimeout = 20 * time.Millisecond
 	client.reconcileInterval = time.Millisecond
 	cfg := core.BaseConfig()
@@ -556,7 +512,7 @@ func TestDigitalOceanClientCreateDropletPreservesKeyOnAmbiguousFailure(t *testin
 	cfg.TargetOS = core.TargetLinux
 	cfg.ServerType = "s-1vcpu-1gb"
 
-	_, err = client.CreateDroplet(context.Background(), cfg, "ssh-ed25519 test", "cbx_abcdef123456", "blue", false, time.Now())
+	_, err := client.CreateDroplet(context.Background(), cfg, "ssh-ed25519 test", "cbx_abcdef123456", "blue", false, time.Now())
 	var ambiguous *ambiguousDropletCreateError
 	if !errors.As(err, &ambiguous) {
 		t.Fatalf("CreateDroplet err=%v, want ambiguousDropletCreateError", err)
@@ -595,18 +551,13 @@ func TestDigitalOceanClientCreateDropletStopsReconciliationOnLeaseTagCollision(t
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
 	cfg.ServerType = "s-1vcpu-1gb"
 
-	_, err = client.CreateDroplet(context.Background(), cfg, "ssh-ed25519 test", "cbx_abcdef123456", "blue", false, time.Now())
+	_, err := client.CreateDroplet(context.Background(), cfg, "ssh-ed25519 test", "cbx_abcdef123456", "blue", false, time.Now())
 	var ambiguous *ambiguousDropletCreateError
 	if !errors.As(err, &ambiguous) || !strings.Contains(err.Error(), "conflicts with existing account tag") {
 		t.Fatalf("CreateDroplet err=%v", err)
@@ -637,14 +588,9 @@ func TestDigitalOceanClientRollbackCreatedSSHKeyUsesFreshContext(t *testing.T) {
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 
-	err = client.rollbackCreatedSSHKey(sshKey{ID: 123, Name: "crabbox-cbx-abcdef123456"}, context.Canceled)
+	err := client.rollbackCreatedSSHKey(sshKey{ID: 123, Name: "crabbox-cbx-abcdef123456"}, context.Canceled)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("rollback err=%v", err)
 	}
@@ -666,14 +612,9 @@ func TestDigitalOceanClientRollbackCreatedSSHKeyReportsRetryableOwnership(t *tes
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 	cause := errors.New("droplet create failed")
-	err = client.rollbackCreatedSSHKey(sshKey{ID: 123, Name: "crabbox-cbx-abcdef123456"}, cause)
+	err := client.rollbackCreatedSSHKey(sshKey{ID: 123, Name: "crabbox-cbx-abcdef123456"}, cause)
 	var cleanup *sshKeyCleanupError
 	if !errors.As(err, &cleanup) || !errors.Is(err, cause) || cleanup.keyID != 123 {
 		t.Fatalf("rollback err=%v, want sshKeyCleanupError wrapping cause", err)
@@ -734,12 +675,7 @@ func TestDigitalOceanClientCreateDropletReconcilesLostResponse(t *testing.T) {
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 
 	item, err := client.CreateDroplet(context.Background(), cfg, "ssh-ed25519 test", leaseID, slug, false, time.Now())
 	if err != nil {
@@ -802,12 +738,7 @@ func TestDigitalOceanClientCreateDropletReconcilesEmptySuccessBody(t *testing.T)
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 
 	item, err := client.CreateDroplet(context.Background(), cfg, "ssh-ed25519 test", leaseID, slug, false, time.Now())
 	if err != nil {
@@ -846,12 +777,7 @@ func TestDigitalOceanClientCreateDropletPreservesKeyWhenEmptySuccessCannotReconc
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 	client.reconcileTimeout = 20 * time.Millisecond
 	client.reconcileInterval = time.Millisecond
 	cfg := core.BaseConfig()
@@ -859,7 +785,7 @@ func TestDigitalOceanClientCreateDropletPreservesKeyWhenEmptySuccessCannotReconc
 	cfg.TargetOS = core.TargetLinux
 	cfg.ServerType = "s-1vcpu-1gb"
 
-	_, err = client.CreateDroplet(context.Background(), cfg, "ssh-ed25519 test", "cbx_abcdef123456", "empty-response", false, time.Now())
+	_, err := client.CreateDroplet(context.Background(), cfg, "ssh-ed25519 test", "cbx_abcdef123456", "empty-response", false, time.Now())
 	var ambiguous *ambiguousDropletCreateError
 	if !errors.As(err, &ambiguous) {
 		t.Fatalf("CreateDroplet err=%v, want ambiguousDropletCreateError", err)
@@ -1353,12 +1279,7 @@ func TestDigitalOceanClientEnsureSSHKeyReconcilesEmptySuccessBody(t *testing.T) 
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 	key, created, err := client.EnsureSSHKey(context.Background(), "crabbox-cbx-abcdef123456", "ssh-ed25519 test")
 	if err != nil {
 		t.Fatal(err)
@@ -1380,13 +1301,8 @@ func TestDigitalOceanClientEnsureSSHKeyRejectsMismatchedPublicKey(t *testing.T) 
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
-	_, _, err = client.EnsureSSHKey(context.Background(), "crabbox-cbx-abcdef123456", "ssh-ed25519 expected")
+	client := newDigitalOceanTestClient(t, server, "token")
+	_, _, err := client.EnsureSSHKey(context.Background(), "crabbox-cbx-abcdef123456", "ssh-ed25519 expected")
 	if err == nil || !strings.Contains(err.Error(), "exists with different public key") {
 		t.Fatalf("EnsureSSHKey err=%v", err)
 	}
@@ -1408,12 +1324,7 @@ func TestDigitalOceanClientEnsureSSHKeySelectsMatchingDuplicateName(t *testing.T
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 
 	key, created, err := client.EnsureSSHKey(context.Background(), "crabbox-cbx-abcdef123456", "ssh-ed25519 expected")
 	if err != nil {
@@ -1436,14 +1347,9 @@ func TestDigitalOceanClientFindSSHKeyRejectsDuplicatePublicKeyMatches(t *testing
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 
-	_, _, err = client.FindSSHKey(context.Background(), "crabbox-cbx-abcdef123456", "ssh-ed25519 expected")
+	_, _, err := client.FindSSHKey(context.Background(), "crabbox-cbx-abcdef123456", "ssh-ed25519 expected")
 	if err == nil || !strings.Contains(err.Error(), "multiple entries matching") {
 		t.Fatalf("FindSSHKey err=%v", err)
 	}
@@ -1504,15 +1410,10 @@ func TestDigitalOceanClientEnsureSSHKeyPreservesAmbiguousCreate(t *testing.T) {
 	}))
 	defer server.Close()
 
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 	client.reconcileTimeout = 20 * time.Millisecond
 	client.reconcileInterval = time.Millisecond
-	_, _, err = client.EnsureSSHKey(context.Background(), "crabbox-cbx-abcdef123456", "ssh-ed25519 test")
+	_, _, err := client.EnsureSSHKey(context.Background(), "crabbox-cbx-abcdef123456", "ssh-ed25519 test")
 	var ambiguous *ambiguousSSHKeyCreateError
 	if !errors.As(err, &ambiguous) {
 		t.Fatalf("EnsureSSHKey err=%v, want ambiguousSSHKeyCreateError", err)
@@ -1549,12 +1450,7 @@ func TestListCrabboxDropletsFiltersAndPaginates(t *testing.T) {
 		_, _ = w.Write([]byte(`{"droplets":[{"id":3,"name":"owned2","tags":["crabbox","crabbox:provider:digitalocean","crabbox:lease:cbx_222222222222","crabbox:slug:two","crabbox:target:linux"]}],"links":{"pages":{}}}`))
 	}))
 	defer server.Close()
-	t.Setenv("DIGITALOCEAN_TOKEN", "token")
-	client, err := newDigitalOceanClient(core.Runtime{HTTP: server.Client()})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.baseURL = server.URL
+	client := newDigitalOceanTestClient(t, server, "token")
 	droplets, err := client.ListCrabboxDroplets(context.Background())
 	if err != nil {
 		t.Fatal(err)

--- a/internal/providers/opensandbox/backend_test.go
+++ b/internal/providers/opensandbox/backend_test.go
@@ -31,6 +31,17 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
+func newOpenSandboxTestClient(t *testing.T, server *httptest.Server) openSandboxClient {
+	t.Helper()
+	cfg := testConfig()
+	cfg.OpenSandbox.APIURL = server.URL
+	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
 func TestProviderSpec(t *testing.T) {
 	p := Provider{}
 	if p.Name() != "opensandbox" {
@@ -1589,13 +1600,8 @@ func TestSDKClientCreateUsesHeadersAndRequestBody(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := testConfig()
-	cfg.OpenSandbox.APIURL = server.URL
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = client.CreateSandbox(context.Background(), createSandboxOptions{
+	client := newOpenSandboxTestClient(t, server)
+	_, err := client.CreateSandbox(context.Background(), createSandboxOptions{
 		Image:        "ubuntu:test",
 		CPU:          "500m",
 		Memory:       "512Mi",
@@ -1627,17 +1633,12 @@ func TestSDKClientLifecycleRequestsAreBounded(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := testConfig()
-	cfg.OpenSandbox.APIURL = server.URL
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := newOpenSandboxTestClient(t, server)
 	sdkClient := client.(*sdkOpenSandboxClient)
 	sdkClient.requestTimeoutOverride = 20 * time.Millisecond
 
 	start := time.Now()
-	err = client.Probe(context.Background())
+	err := client.Probe(context.Background())
 	if err == nil {
 		t.Fatal("expected stalled lifecycle request to time out")
 	}
@@ -1658,15 +1659,10 @@ func TestSDKClientMarksCreateRequestTimeoutAsAmbiguous(t *testing.T) {
 	defer server.Close()
 	defer close(release)
 
-	cfg := testConfig()
-	cfg.OpenSandbox.APIURL = server.URL
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := newOpenSandboxTestClient(t, server)
 	client.(*sdkOpenSandboxClient).requestTimeoutOverride = 20 * time.Millisecond
 
-	_, err = client.CreateSandbox(context.Background(), createSandboxOptions{
+	_, err := client.CreateSandbox(context.Background(), createSandboxOptions{
 		Image: "ubuntu:test", Metadata: map[string]string{openSandboxClaimKey: "scope"},
 	})
 	var ambiguous *ambiguousOpenSandboxCreateError
@@ -1693,13 +1689,8 @@ func TestSDKClientMarksSuccessfulCreateDecodeFailuresAsAmbiguous(t *testing.T) {
 			}))
 			defer server.Close()
 
-			cfg := testConfig()
-			cfg.OpenSandbox.APIURL = server.URL
-			client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-			if err != nil {
-				t.Fatal(err)
-			}
-			_, err = client.CreateSandbox(context.Background(), createSandboxOptions{
+			client := newOpenSandboxTestClient(t, server)
+			_, err := client.CreateSandbox(context.Background(), createSandboxOptions{
 				Image: "ubuntu:test", Metadata: map[string]string{openSandboxClaimKey: "scope"},
 			})
 			var ambiguous *ambiguousOpenSandboxCreateError
@@ -1733,13 +1724,8 @@ func TestSDKClientMarksSuccessfulCreateWithoutIDAsAmbiguous(t *testing.T) {
 			}))
 			defer server.Close()
 
-			cfg := testConfig()
-			cfg.OpenSandbox.APIURL = server.URL
-			client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-			if err != nil {
-				t.Fatal(err)
-			}
-			_, err = client.CreateSandbox(context.Background(), createSandboxOptions{
+			client := newOpenSandboxTestClient(t, server)
+			_, err := client.CreateSandbox(context.Background(), createSandboxOptions{
 				Image: "ubuntu:test", Metadata: map[string]string{openSandboxClaimKey: "scope"},
 			})
 			var ambiguous *ambiguousOpenSandboxCreateError
@@ -1758,15 +1744,10 @@ func TestSDKClientDoesNotDispatchPreCanceledCreate(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := testConfig()
-	cfg.OpenSandbox.APIURL = server.URL
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := newOpenSandboxTestClient(t, server)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err = client.CreateSandbox(ctx, createSandboxOptions{
+	_, err := client.CreateSandbox(ctx, createSandboxOptions{
 		Image: "ubuntu:test", Metadata: map[string]string{openSandboxClaimKey: "scope"},
 	})
 	if !errors.Is(err, context.Canceled) {
@@ -1814,12 +1795,7 @@ func TestSDKClientCreateWaitsForRunningAndExecdPing(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := testConfig()
-	cfg.OpenSandbox.APIURL = server.URL
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := newOpenSandboxTestClient(t, server)
 	info, err := client.CreateSandbox(context.Background(), createSandboxOptions{
 		Image:    "ubuntu:test",
 		CPU:      "500m",
@@ -1876,14 +1852,9 @@ func TestSDKClientRunningWaitHonorsDiscoveredExpiration(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := testConfig()
-	cfg.OpenSandbox.APIURL = server.URL
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := newOpenSandboxTestClient(t, server)
 	start := time.Now()
-	_, err = client.CreateSandbox(context.Background(), createSandboxOptions{
+	_, err := client.CreateSandbox(context.Background(), createSandboxOptions{
 		Image: "ubuntu:test", Metadata: map[string]string{openSandboxClaimKey: "scope"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "expired before reaching Running") {
@@ -1926,14 +1897,9 @@ func TestSDKClientRefreshesMissingCreateExpirationBeforeReadiness(t *testing.T) 
 	}))
 	defer server.Close()
 
-	cfg := testConfig()
-	cfg.OpenSandbox.APIURL = server.URL
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := newOpenSandboxTestClient(t, server)
 	start := time.Now()
-	_, err = client.CreateSandbox(context.Background(), createSandboxOptions{
+	_, err := client.CreateSandbox(context.Background(), createSandboxOptions{
 		Image: "ubuntu:test", Metadata: map[string]string{openSandboxClaimKey: "scope"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "did not become ready") {
@@ -1973,14 +1939,9 @@ func TestSDKClientUsesRefreshedExpirationForSecondRunningWait(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := testConfig()
-	cfg.OpenSandbox.APIURL = server.URL
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := newOpenSandboxTestClient(t, server)
 	start := time.Now()
-	_, err = client.CreateSandbox(context.Background(), createSandboxOptions{
+	_, err := client.CreateSandbox(context.Background(), createSandboxOptions{
 		Image: "ubuntu:test", Metadata: map[string]string{openSandboxClaimKey: "scope"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "wait for running after expiration refresh") {
@@ -2017,15 +1978,10 @@ func TestSDKClientCreateDeletesSandboxWhenReadinessFails(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := testConfig()
-	cfg.OpenSandbox.APIURL = server.URL
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := newOpenSandboxTestClient(t, server)
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
-	_, err = client.CreateSandbox(ctx, createSandboxOptions{
+	_, err := client.CreateSandbox(ctx, createSandboxOptions{
 		Image:    "ubuntu:test",
 		CPU:      "500m",
 		Memory:   "512Mi",
@@ -2061,14 +2017,9 @@ func TestSDKClientCreateSurfacesPermanentReadinessFailureImmediately(t *testing.
 	}))
 	defer server.Close()
 
-	cfg := testConfig()
-	cfg.OpenSandbox.APIURL = server.URL
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := newOpenSandboxTestClient(t, server)
 	start := time.Now()
-	_, err = client.CreateSandbox(context.Background(), createSandboxOptions{
+	_, err := client.CreateSandbox(context.Background(), createSandboxOptions{
 		Image: "ubuntu:test", Metadata: map[string]string{openSandboxClaimKey: "scope"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "must use HTTPS unless it is loopback") {
@@ -2170,13 +2121,8 @@ func TestSDKClientRejectsPlaintextPublicExecdEndpoint(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := testConfig()
-	cfg.OpenSandbox.APIURL = server.URL
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = client.RunCommand(context.Background(), "sb-public", runCommandRequest{Command: "true"})
+	client := newOpenSandboxTestClient(t, server)
+	_, err := client.RunCommand(context.Background(), "sb-public", runCommandRequest{Command: "true"})
 	if err == nil || !strings.Contains(err.Error(), `endpoint host "198.51.100.10:44772" must use HTTPS unless it is loopback`) {
 		t.Fatalf("err=%v, want public plaintext endpoint rejection", err)
 	}
@@ -2207,12 +2153,7 @@ func TestSDKClientPreservesExecdEndpointQueryAcrossPaths(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := testConfig()
-	cfg.OpenSandbox.APIURL = server.URL
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := newOpenSandboxTestClient(t, server)
 	if err := client.PingSandbox(context.Background(), "sb-signed"); err != nil {
 		t.Fatal(err)
 	}
@@ -2249,12 +2190,7 @@ func TestSDKClientRunCommandSendsTimeoutMillis(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := testConfig()
-	cfg.OpenSandbox.APIURL = server.URL
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := newOpenSandboxTestClient(t, server)
 	exitCode, err := client.RunCommand(context.Background(), "sb-timeout", runCommandRequest{
 		Command:     "true",
 		TimeoutSecs: 3600,
@@ -2288,12 +2224,7 @@ func TestSDKClientRunCommandRejectsPrematureEOF(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := testConfig()
-	cfg.OpenSandbox.APIURL = server.URL
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := newOpenSandboxTestClient(t, server)
 	exitCode, err := client.RunCommand(context.Background(), "sb-truncated", runCommandRequest{Command: "true"})
 	if err == nil || !strings.Contains(err.Error(), "stream ended before terminal event") {
 		t.Fatalf("err=%v, want premature EOF failure", err)
@@ -2319,16 +2250,11 @@ func TestSDKClientRunCommandBoundsEndpointDiscovery(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := testConfig()
-	cfg.OpenSandbox.APIURL = server.URL
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := newOpenSandboxTestClient(t, server)
 	client.(*sdkOpenSandboxClient).execTimeoutOverride = 20 * time.Millisecond
 
 	start := time.Now()
-	_, err = client.RunCommand(context.Background(), "sb-discovery-stalled", runCommandRequest{
+	_, err := client.RunCommand(context.Background(), "sb-discovery-stalled", runCommandRequest{
 		Command:     "true",
 		TimeoutSecs: 3600,
 	})
@@ -2521,12 +2447,7 @@ func TestSDKClientRunCommandAddsConfiguredSchemeToBareEndpoint(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := testConfig()
-	cfg.OpenSandbox.APIURL = server.URL
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := newOpenSandboxTestClient(t, server)
 	exitCode, err := client.RunCommand(context.Background(), "sb-bare", runCommandRequest{Command: "true"})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## What Problem This Solves

Reduces repeated provider client setup in tests, making the scenario-specific behavior easier to review and keeping shared constructor setup consistent.

## Why This Change Was Made

Introduces one private test helper in each affected package and replaces only the matching constructor blocks. Existing configuration, handlers, cleanup, assertions, timeouts, and negative cases remain unchanged.

## User Impact

No user-visible or runtime behavior changes. This is test-only maintenance.

## Evidence

- Independent actual-diff review: clear.
- Semantic inverse expansion restored all three original files byte-for-byte.
- Helper call counts: DigitalOcean 23, OpenSandbox 18, coordinator 28.
- Required error declaration repairs: 33.
- `gofmt -d` clean.
- `git diff --check` clean.
- No local product tests or builds were run for this mechanical cleanup; hosted CI is the validation surface.
