### PR TITLE
refactor: share Upstash Box lifecycle and preserve run failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Upstash Box: share run finalization so early failures honor `--keep-on-failure`, failed deletion reports a kept recovery session, and cleanup/timing errors preserve the primary exit; keep delegated command receipts when secondary cleanup fails. Thanks @steipete.
 - CubeSandbox: share sandbox run finalization so failed cleanup retains an accurate recovery session, setup failures honor `--keep-on-failure`, and timing errors no longer mask command exits; preserve observed abnormal exit codes. [PR 1850](https://github.com/openclaw/crabbox/pull/1850). Thanks @steipete.
 - Limit literal run-artifact discovery to the parent directory, preserving existing matching, required-file, and symlink guards. [PR 1878](https://github.com/openclaw/crabbox/pull/1878). Thanks @steipete.
 - OpenComputer: share run finalization so cleanup failures are reported, timing errors preserve the original exit, and command preparation honors `--keep-on-failure`; preserve cancellation and timeout causes and distinguish transport errors from command exits. [PR 1845](https://github.com/openclaw/crabbox/pull/1845). Thanks @steipete.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -567,6 +567,9 @@ including non-zero exits. SSH terminal receipts use schema v2 and bind the final
 run outcome, raw command digest, timing, retained-log digest, and full observed
 stream digest. Delegated providers retain schema v1 when they report a
 definitive command exit. Check local receipts with [`crabbox verify`](verify.md).
+Secondary cleanup errors do not suppress a receipt for an already-observed
+delegated command exit; provider/transport failures without a definitive exit
+do not produce that receipt.
 
 Brokered runs submit a schema v2 terminal receipt with the finish request even
 when `--attest` is omitted. The CLI verifies that the coordinator returns the

--- a/docs/providers/upstash-box.md
+++ b/docs/providers/upstash-box.md
@@ -118,7 +118,22 @@ Accepted values, validated before the API is called:
    `sh -c`, with the workspace folder set as the working directory, streaming
    output back through Crabbox.
 4. One-shot Boxes are deleted after a `run` that did not pass `--keep`. `--keep`
-   and `--keep-on-failure` retain the Box until `crabbox stop`.
+   retains the Box until `crabbox stop`; `--keep-on-failure` also retains it after
+   workspace setup, sync, command preparation, execution, or mandatory profile
+   cleanup fails. Reused Boxes are never automatically deleted.
+
+Run sequencing and finalization use the shared delegated-sandbox lifecycle.
+The adapter still owns Box identity and deletion authority, file-profile custody,
+workspace paths, uploads, and native command transport. Local configuration/auth
+validation precedes archive preparation; fresh archives are prepared before
+allocation, while reused archives are prepared after the Box is resolved.
+
+A failed Box deletion returns exit code 1 and a kept recovery session instead
+of a successful run. An earlier command or provider failure retains its exit code
+and status; later profile cleanup, Box deletion, and timing-write failures add
+diagnostics without replacing it. Failure retention is decided before timing
+output, so a failed timing writer cannot delete a Box already retained for a
+failed command. Profile-cleanup-only failures retain their documented code 5.
 
 Note: `warmup` always keeps the Box until an explicit `crabbox stop`. If you
 pass `--keep=false` to `warmup`, Crabbox prints a warning and still keeps it.

--- a/internal/cli/attest_test.go
+++ b/internal/cli/attest_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -525,6 +526,86 @@ func TestDelegatedRunReceiptOmitsMissingLeaseID(t *testing.T) {
 	}
 	if !strings.HasPrefix(out, "PASS ") {
 		t.Fatalf("unexpected verify output: %q", out)
+	}
+}
+
+type attestOutcomeProvider struct {
+	testStopReclaimProvider
+	result RunResult
+	err    error
+}
+
+func (p attestOutcomeProvider) Name() string { return "attest-outcome-test" }
+func (p attestOutcomeProvider) Spec() ProviderSpec {
+	spec := p.testStopReclaimProvider.Spec()
+	spec.Name = p.Name()
+	return spec
+}
+func (p attestOutcomeProvider) Configure(Config, Runtime) (Backend, error) {
+	return attestOutcomeBackend{testDelegatedBackend{spec: p.Spec()}, p.result, p.err}, nil
+}
+
+type attestOutcomeBackend struct {
+	testDelegatedBackend
+	result RunResult
+	err    error
+}
+
+func (b attestOutcomeBackend) Run(context.Context, RunRequest) (RunResult, error) {
+	return b.result, b.err
+}
+
+func TestDelegatedAttestUsesNormalizedPrimaryOutcome(t *testing.T) {
+	for _, scenario := range []string{"legacy command exit", "command plus cleanup cancellation", "command plus cleanup timeout", "provider timeout", "cleanup only"} {
+		t.Run(scenario, func(t *testing.T) {
+			clearConfigEnv(t)
+			isolatedConfigPath(t)
+			setAttestTestHome(t)
+			t.Chdir(t.TempDir())
+			result := RunResult{Provider: "attest-outcome-test", ExitCode: 42, CommandText: "exit 42"}
+			var runErr error = ExitError{Code: 42, Message: "command exited 42"}
+			wantReceipt := true
+			switch scenario {
+			case "command plus cleanup cancellation", "command plus cleanup timeout":
+				result.Status, result.ErrorKind = RunStatusFailed, RunErrorCommandExit
+				cleanupErr := context.Canceled
+				if scenario == "command plus cleanup timeout" {
+					cleanupErr = context.DeadlineExceeded
+				}
+				runErr = errors.Join(runErr, cleanupErr)
+			case "provider timeout":
+				runErr, wantReceipt = context.DeadlineExceeded, false
+			case "cleanup only":
+				result.Status, result.ErrorKind = RunStatusFailed, RunErrorProvider
+				runErr, wantReceipt = errors.New("cleanup failed"), false
+			}
+			p := attestOutcomeProvider{result: result, err: runErr}
+			RegisterProvider(p)
+			t.Cleanup(func() { delete(providerRegistry, p.Name()) })
+			receiptPath := filepath.Join(t.TempDir(), "receipt.json")
+			app := App{Stdout: io.Discard, Stderr: io.Discard}
+			err := app.Run(t.Context(), []string{"run", "--provider", p.Name(), "--no-sync", "--attest", receiptPath, "--", "true"})
+			if !errors.Is(err, runErr) {
+				t.Fatalf("primary error changed: %v", err)
+			}
+			data, err := os.ReadFile(receiptPath)
+			if !wantReceipt {
+				if !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("unexpected provider-failure receipt: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("completed command receipt missing: %v", err)
+			}
+			receipt, err := decodeRunReceipt(data)
+			if err != nil || receipt["exit_code"] != json.Number("42") {
+				t.Fatalf("receipt=%#v err=%v", receipt, err)
+			}
+			if _, err := runVerify(t, receiptPath); err != nil {
+				t.Fatalf("verify receipt: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1029,7 +1029,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			result.Artifacts = append(result.Artifacts, proof)
 			fmt.Fprintf(a.Stderr, "artifact kind=proof path=%s bytes=%d template=%s\n", proof.Path, proof.Bytes, blank(proof.Template, "default"))
 		}
-		if strings.TrimSpace(*attestOut) != "" && (runErr == nil || RunErrorKindForResult(result, runErr) == RunErrorCommandExit) {
+		if strings.TrimSpace(*attestOut) != "" && (runErr == nil || FinalizeRunResult(result, runErr).ErrorKind == RunErrorCommandExit) {
 			receipt, err := writeDelegatedRunReceipt(strings.TrimSpace(*attestOut), strings.TrimSpace(*attestKeyOverride), cfg, result, runReq)
 			if err != nil {
 				return err

--- a/internal/providers/modal/backend.go
+++ b/internal/providers/modal/backend.go
@@ -140,6 +140,7 @@ func (b *modalBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 			}
 			var cleanup func(context.Context)
+			var closeCommand func(context.Context) error
 			if len(req.Env) > 0 {
 				var envPath string
 				err = fenced(func() error {
@@ -147,12 +148,18 @@ func (b *modalBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 					envPath, cleanup, err = b.uploadEnvProfile(ctx, client, claim, req.Env)
 					return err
 				})
+				if cleanup != nil {
+					closeCommand = func(ctx context.Context) error {
+						cleanup(ctx)
+						return nil
+					}
+				}
 				if err != nil {
-					return shared.DelegatedSandboxCommand{Close: cleanup}, err
+					return shared.DelegatedSandboxCommand{Close: closeCommand}, err
 				}
 				command = shared.WrapCommandWithShellEnvProfile(command, envPath)
 			}
-			return shared.DelegatedSandboxCommand{Close: cleanup, Run: func(ctx context.Context) (int, error) {
+			return shared.DelegatedSandboxCommand{Close: closeCommand, Run: func(ctx context.Context) (int, error) {
 				var code int
 				err := fenced(func() error {
 					var err error

--- a/internal/providers/shared/delegated.go
+++ b/internal/providers/shared/delegated.go
@@ -25,11 +25,12 @@ type DelegatedSandbox struct {
 // DelegatedSandboxCommand keeps command preparation (including credential
 // staging) outside the execution timer. Close receives a bounded, uncanceled
 // context before sandbox cleanup, including for retained/reused sandboxes.
-// Best-effort transport cleanup and its diagnostics remain adapter-owned.
+// Adapters may return a mandatory cleanup failure, or warn and return nil for
+// best-effort cleanup. An explicit ExitError preserves its cleanup-only code.
 type DelegatedSandboxCommand struct {
 	Text  string
 	Run   func(context.Context) (int, error)
-	Close func(context.Context)
+	Close func(context.Context) error
 }
 
 type observedProcessEndError struct{ message string }
@@ -73,7 +74,7 @@ type DelegatedSandboxLifecycle struct {
 
 // RunDelegatedSandbox owns the single sandbox run sequence and finalization.
 // The first failure determines the exit code/status; later cleanup failures are
-// joined as diagnostics. Cleanup alone fails with code 1. A failed deletion
+// joined as diagnostics. Sandbox cleanup alone fails with code 1. A failed deletion
 // leaves the session kept (and its claim intact in the adapter) for recovery.
 func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle DelegatedSandboxLifecycle) (result core.RunResult, retErr error) {
 	now := time.Now
@@ -113,11 +114,6 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 		if prepared != nil {
 			defer prepared.Close()
 		}
-		if command.Close != nil {
-			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
-			command.Close(cleanupCtx)
-			cancel()
-		}
 		// Classify before secondary cleanup errors can obscure command/cancel
 		// outcomes. Setup exit codes are CLI failures, not user command exits.
 		if retErr != nil && result.Status == "" {
@@ -132,17 +128,28 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 			// themselves contain an ExitError with a different code.
 			retErr = ExitErrorWithCause(result.ExitCode, retErr.Error(), retErr)
 		}
-		appendFailure := func(err error) {
+		appendFailure := func(err error, firstCode int) {
 			if err == nil {
 				return
 			}
 			if retErr == nil {
-				result.ExitCode = 1
+				result.ExitCode = firstCode
 				result.Status, result.ErrorKind = core.RunStatusFailed, core.RunErrorProvider
-				retErr = ExitErrorWithCause(1, err.Error(), err)
+				retErr = ExitErrorWithCause(firstCode, err.Error(), err)
 			} else {
 				retErr = errors.Join(retErr, err)
 			}
+		}
+		if command.Close != nil {
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
+			closeErr := command.Close(cleanupCtx)
+			cancel()
+			code := 1
+			var ee core.ExitError
+			if errors.As(closeErr, &ee) && ee.Code != 0 {
+				code = ee.Code
+			}
+			appendFailure(closeErr, code)
 		}
 		if result.Session != nil {
 			shouldStop := acquired && !req.Keep
@@ -153,12 +160,12 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
 			if shouldStop {
 				if err := lifecycle.Cleanup(cleanupCtx); err != nil {
-					appendFailure(fmt.Errorf("%s cleanup failed: %w", lifecycle.Provider, err))
+					appendFailure(fmt.Errorf("%s cleanup failed: %w", lifecycle.Provider, err), 1)
 				} else {
 					result.Session.Kept = false
 				}
 			} else if reuseAdmitted && lifecycle.Retained != nil {
-				appendFailure(lifecycle.Retained(cleanupCtx))
+				appendFailure(lifecycle.Retained(cleanupCtx), 1)
 			}
 			cancel()
 		}
@@ -180,7 +187,7 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 			}, result, retErr))
 			// A failed writer cannot emit an agreed record. Still report the I/O
 			// failure without replacing an existing command/cleanup failure.
-			appendFailure(err)
+			appendFailure(err, 1)
 		}
 	}()
 

--- a/internal/providers/shared/delegated_test.go
+++ b/internal/providers/shared/delegated_test.go
@@ -44,6 +44,7 @@ func TestDelegatedSandboxLifecycle(t *testing.T) {
 		reuse, keep, keepOnFailure, noSync, syncOnly bool
 		commandCode                                  int
 		cleanupErr                                   error
+		closeErr                                     error
 		wantCode                                     int
 		wantStatus                                   core.RunStatus
 		wantKind                                     core.RunErrorKind
@@ -86,6 +87,17 @@ func TestDelegatedSandboxLifecycle(t *testing.T) {
 		{name: "keep canceled", phase: "exec", err: context.Canceled, keepOnFailure: true, wantCode: 1, wantStatus: core.RunStatusCanceled, wantKind: core.RunErrorCanceled, wantSession: true, wantKept: true},
 		{name: "timeout", phase: "exec", err: context.DeadlineExceeded, wantCode: 1, wantStatus: core.RunStatusTimedOut, wantKind: core.RunErrorTimeout, wantSession: true, wantCleanup: true},
 		{name: "cleanup", cleanupErr: cleanupFailure, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true, wantCleanup: true},
+		{name: "typed sandbox cleanup", cleanupErr: core.ExitError{Code: 5, Message: "delete failed"}, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true, wantCleanup: true},
+		{name: "command cleanup", closeErr: cleanupFailure, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantCleanup: true},
+		{name: "typed command cleanup", closeErr: core.ExitError{Code: 5, Message: "profile cleanup failed"}, wantCode: 5, wantKind: core.RunErrorProvider, wantSession: true, wantCleanup: true},
+		{name: "kept command cleanup", closeErr: core.ExitError{Code: 5, Message: "profile cleanup failed"}, keepOnFailure: true, wantCode: 5, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true},
+		{name: "reused command cleanup", closeErr: cleanupFailure, reuse: true, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true},
+		{name: "command cleanup deadline", closeErr: context.DeadlineExceeded, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantCleanup: true},
+		{name: "command and profile cleanup", commandCode: 7, closeErr: core.ExitError{Code: 5, Message: "profile cleanup failed"}, wantCode: 7, wantKind: core.RunErrorCommandExit, wantSession: true, wantCleanup: true},
+		{name: "command preparation and cleanup", phase: "command", err: failure, closeErr: cleanupFailure, keepOnFailure: true, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true},
+		{name: "transport and profile cancellation", phase: "exec", err: failure, closeErr: context.Canceled, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantCleanup: true},
+		{name: "transport and deletion timeout", phase: "exec", err: failure, cleanupErr: context.DeadlineExceeded, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true, wantCleanup: true},
+		{name: "cancel and profile cleanup", phase: "exec", err: context.Canceled, closeErr: context.DeadlineExceeded, wantCode: 1, wantStatus: core.RunStatusCanceled, wantKind: core.RunErrorCanceled, wantSession: true, wantCleanup: true},
 		{name: "sync only cleanup", syncOnly: true, cleanupErr: cleanupFailure, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true, wantCleanup: true},
 		{name: "command and cleanup", commandCode: 7, cleanupErr: cleanupFailure, wantCode: 7, wantKind: core.RunErrorCommandExit, wantSession: true, wantKept: true, wantCleanup: true},
 		{name: "setup and typed cleanup", phase: "setup", err: failure, cleanupErr: core.ExitError{Code: 4, Message: "claim changed"}, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true, wantCleanup: true},
@@ -163,7 +175,7 @@ func TestDelegatedSandboxLifecycle(t *testing.T) {
 							cancel()
 						}
 						return tc.commandCode, step("exec")
-					}, Close: func(ctx context.Context) { detached(ctx); _ = step("close-command") }}, step("command")
+					}, Close: func(ctx context.Context) error { detached(ctx); return errors.Join(step("close-command"), tc.closeErr) }}, step("command")
 				},
 				Retained: func(ctx context.Context) error {
 					detached(ctx)
@@ -197,6 +209,9 @@ func TestDelegatedSandboxLifecycle(t *testing.T) {
 			}
 			if tc.err != nil && !errors.Is(err, tc.err) {
 				t.Fatalf("lost primary cause: %v", err)
+			}
+			if tc.closeErr != nil && !errors.Is(err, tc.closeErr) {
+				t.Fatalf("lost command cleanup cause: %v", err)
 			}
 			if tc.cleanupErr != nil && !errors.Is(err, tc.cleanupErr) {
 				t.Fatalf("lost cleanup cause: %v", err)
@@ -293,7 +308,7 @@ func TestDelegatedSandboxSequence(t *testing.T) {
 		},
 		Command: func(context.Context) (DelegatedSandboxCommand, error) {
 			add("command")
-			return DelegatedSandboxCommand{Run: func(context.Context) (int, error) { add("exec"); return 0, nil }, Close: func(context.Context) { add("close-command") }}, nil
+			return DelegatedSandboxCommand{Run: func(context.Context) (int, error) { add("exec"); return 0, nil }, Close: func(context.Context) error { add("close-command"); return nil }}, nil
 		},
 		Cleanup: func(context.Context) error { add("cleanup"); return nil },
 	}

--- a/internal/providers/upstashbox/backend.go
+++ b/internal/providers/upstashbox/backend.go
@@ -2,7 +2,6 @@ package upstashbox
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"path"
@@ -58,224 +57,90 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	return nil
 }
 
-func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {
-	workdir, err := cleanWorkdir(workdir(b.cfg))
-	if err != nil {
-		return RunResult{}, err
+func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	workdir, validationErr := cleanWorkdir(workdir(b.cfg))
+	folder := ""
+	if validationErr == nil {
+		folder, validationErr = workspaceFolder(workdir)
 	}
-	folder, err := workspaceFolder(workdir)
-	if err != nil {
-		return RunResult{}, err
+	var client api
+	var leaseID, boxID, slug string
+	session := func() shared.DelegatedSandbox {
+		return shared.DelegatedSandbox{LeaseID: leaseID, Slug: slug, CleanupCommand: upstashBoxCleanupCommand(leaseID)}
 	}
-	started := b.now()
-	var prepared *core.PreparedArchive
-	if !req.NoSync {
-		prepared, err = b.prepareArchive(ctx, req)
-		if err != nil {
-			return RunResult{}, err
-		}
-		defer prepared.Close()
-	}
-	client, err := newAPI(b.cfg, b.rt)
-	if err != nil {
-		return RunResult{}, err
-	}
-	leaseID, boxID, slug := "", "", ""
-	acquired := false
-	if req.ID == "" {
-		var box boxData
-		leaseID, box, slug, err = b.createBox(ctx, client, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
-		if err != nil {
-			return RunResult{}, err
-		}
-		boxID = box.ID
-		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s box=%s name=%s\n", leaseID, slug, providerName, box.ID, box.Name)
-		acquired = true
-	} else {
-		leaseID, boxID, slug, err = b.resolveBoxID(ctx, client, req.ID, req.Repo.Root, req.Reclaim)
-		if err != nil {
-			return RunResult{}, err
-		}
-	}
-	shouldStop := acquired && !req.Keep
-	cleanedUp := false
-	session := &RunSessionHandle{
-		Provider:       providerName,
-		LeaseID:        leaseID,
-		Slug:           slug,
-		Reused:         !acquired,
-		Kept:           !shouldStop,
-		CleanupCommand: upstashBoxCleanupCommand(leaseID),
-	}
-	finishResult := func(result RunResult) RunResult {
-		if result.Provider == "" {
-			result.Provider = providerName
-		}
-		if result.LeaseID == "" {
-			result.LeaseID = leaseID
-		}
-		if result.Slug == "" {
-			result.Slug = slug
-		}
-		result.Session = session
-		result.Session.Kept = !cleanedUp && !shouldStop
-		return result
-	}
-	defer func() {
-		result = finishResult(result)
-	}()
-	cleanupBox := func() error {
-		if !shouldStop {
-			return nil
-		}
-		cleanupCtx, cancel := upstashBoxCleanupContext()
-		defer cancel()
-		if err := b.deleteClaimedBox(cleanupCtx, client, leaseID, boxID, slug); err != nil {
-			shouldStop = false
+	return shared.RunDelegatedSandbox(ctx, req, shared.DelegatedSandboxLifecycle{
+		Provider: providerName, Runtime: b.rt, Workdir: workdir,
+		IdleTimeout: b.cfg.IdleTimeout, TTL: b.cfg.TTL, CleanupTimeout: upstashBoxCleanupTimeout,
+		Preflight: func(context.Context) error {
+			if validationErr != nil {
+				return validationErr
+			}
+			var err error
+			client, err = newAPI(b.cfg, b.rt)
 			return err
-		}
-		cleanedUp = true
-		shouldStop = false
-		return nil
-	}
-	if shouldStop {
-		defer func() {
-			if err := cleanupBox(); err != nil {
-				fmt.Fprintf(b.rt.Stderr, "warning: upstash-box delete failed for %s: %v\n", boxID, err)
+		},
+		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) {
+			return b.prepareArchive(ctx, req)
+		},
+		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
+			var box boxData
+			var err error
+			leaseID, box, slug, err = b.createBox(ctx, client, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
+			if err != nil {
+				return shared.DelegatedSandbox{}, err
 			}
-		}()
-	}
-
-	syncDuration := time.Duration(0)
-	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
-	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, boxID, req, workdir, folder, prepared)
-		if err != nil {
-			return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, err
-		}
-		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
-	} else if err := b.prepareWorkspace(ctx, client, boxID, folder); err != nil {
-		return RunResult{}, err
-	}
-	if req.SyncOnly {
-		result := RunResult{Total: b.now().Sub(started), SyncDelegated: true}
-		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
-		if req.TimingJSON {
-			err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
-				Provider:      providerName,
-				LeaseID:       leaseID,
-				Slug:          slug,
-				SyncDelegated: true,
-				SyncMs:        syncDuration.Milliseconds(),
-				SyncPhases:    syncPhases,
-				SyncSkipped:   req.NoSync,
-				TotalMs:       result.Total.Milliseconds(),
-				ExitCode:      0,
-				Label:         strings.TrimSpace(req.Label),
-			}, result, nil))
-			return result, err
-		}
-		return result, nil
-	}
-
-	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
-	if err != nil {
-		return RunResult{}, err
-	}
-	command := intent.ShellSource()
-	if req.EnvSummary {
-		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
-	}
-	var cleanupEnv func() error
-	if len(req.Env) > 0 {
-		var envPath string
-		envPath, cleanupEnv, err = uploadEnvProfile(ctx, client, leaseID, boxID, slug, req.Env)
-		if cleanupEnv != nil {
-			defer func() { _ = cleanupEnv() }()
-		}
-		if err != nil {
-			if cleanupEnv != nil {
-				err = errors.Join(err, cleanupEnv())
+			boxID = box.ID
+			fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s box=%s name=%s\n", leaseID, slug, providerName, box.ID, box.Name)
+			return session(), nil
+		},
+		Resolve: func(ctx context.Context) (shared.DelegatedSandbox, error) {
+			var err error
+			leaseID, boxID, slug, err = b.resolveBoxID(ctx, client, req.ID, req.Repo.Root, req.Reclaim)
+			if err != nil {
+				return shared.DelegatedSandbox{}, err
 			}
-			return RunResult{}, err
-		}
-		command = shared.ShellScriptWithEnvProfile(command, envPath)
-	}
-	commandStarted := b.now()
-	exitCode := 0
-	commandErr := ctx.Err()
-	if commandErr == nil {
-		exitCode, commandErr = client.ExecStream(ctx, boxID, command, folder, b.rt.Stdout)
-	}
-	commandDuration := b.now().Sub(commandStarted)
-	envCleanupErr := error(nil)
-	if cleanupEnv != nil {
-		envCleanupErr = cleanupEnv()
-	}
-	finalExitCode := exitCode
-	if commandErr != nil {
-		finalExitCode = 1
-	} else if exitCode == 0 && envCleanupErr != nil {
-		finalExitCode = 5
-	}
-	result = RunResult{
-		ExitCode:      finalExitCode,
-		Command:       commandDuration,
-		Total:         b.now().Sub(started),
-		SyncDelegated: true,
-		Provider:      providerName,
-		LeaseID:       leaseID,
-		Slug:          slug,
-		CommandText:   strings.Join(req.Command, " "),
-	}
-	if req.NoSync {
-		fmt.Fprintf(b.rt.Stderr, "upstash-box run summary sync_skipped=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), finalExitCode)
-	} else {
-		fmt.Fprintf(b.rt.Stderr, "upstash-box run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), finalExitCode)
-	}
-	if req.TimingJSON {
-		timingErr := commandErr
-		if timingErr == nil {
-			timingErr = envCleanupErr
-		}
-		report := timingReportWithRunResult(timingReport{
-			Provider:      providerName,
-			LeaseID:       leaseID,
-			Slug:          slug,
-			SyncDelegated: true,
-			SyncMs:        syncDuration.Milliseconds(),
-			SyncPhases:    syncPhases,
-			SyncSkipped:   req.NoSync,
-			CommandMs:     commandDuration.Milliseconds(),
-			TotalMs:       result.Total.Milliseconds(),
-			ExitCode:      finalExitCode,
-			Label:         strings.TrimSpace(req.Label),
-		}, result, timingErr)
-		if commandErr == nil && envCleanupErr != nil {
-			report = timingReportWithProviderError(report)
-		}
-		if err := writeTimingJSON(b.rt.Stderr, report); err != nil {
-			return result, err
-		}
-	}
-	if commandErr != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		if envCleanupErr != nil {
-			return result, shared.ExitErrorWithCause(1, fmt.Sprintf("upstash-box run failed: %v; %v", commandErr, envCleanupErr), commandErr)
-		}
-		return result, shared.ExitErrorWithCause(1, fmt.Sprintf("upstash-box run failed: %v", commandErr), commandErr)
-	}
-	if exitCode != 0 {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		if envCleanupErr != nil {
-			return result, ExitError{Code: exitCode, Message: fmt.Sprintf("upstash-box run exited %d; %v", exitCode, envCleanupErr)}
-		}
-		return result, ExitError{Code: exitCode, Message: fmt.Sprintf("upstash-box run exited %d", exitCode)}
-	}
-	if envCleanupErr != nil {
-		return result, ExitError{Code: 5, Message: envCleanupErr.Error()}
-	}
-	return result, nil
+			return session(), nil
+		},
+		Sync: func(ctx context.Context, archive *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
+			return b.syncWorkspace(ctx, client, boxID, req, workdir, folder, archive)
+		},
+		NoSync: func(ctx context.Context) error {
+			return b.prepareWorkspace(ctx, client, boxID, folder)
+		},
+		Command: func(ctx context.Context) (shared.DelegatedSandboxCommand, error) {
+			intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
+			if err != nil {
+				return shared.DelegatedSandboxCommand{}, err
+			}
+			command := intent.ShellSource()
+			if req.EnvSummary {
+				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+			}
+			var closeCommand func(context.Context) error
+			if len(req.Env) > 0 {
+				envPath, cleanup, err := uploadEnvProfile(ctx, client, leaseID, boxID, slug, req.Env)
+				if cleanup != nil {
+					closeCommand = func(ctx context.Context) error {
+						if err := cleanup(ctx); err != nil {
+							return shared.ExitErrorWithCause(5, err.Error(), err)
+						}
+						return nil
+					}
+				}
+				if err != nil {
+					return shared.DelegatedSandboxCommand{Close: closeCommand}, err
+				}
+				command = shared.ShellScriptWithEnvProfile(command, envPath)
+			}
+			return shared.DelegatedSandboxCommand{Text: strings.Join(req.Command, " "), Close: closeCommand,
+				Run: func(ctx context.Context) (int, error) {
+					return client.ExecStream(ctx, boxID, command, folder, b.rt.Stdout)
+				}}, nil
+		},
+		Cleanup: func(ctx context.Context) error {
+			return b.deleteClaimedBox(ctx, client, leaseID, boxID, slug)
+		},
+	})
 }
 
 func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {

--- a/internal/providers/upstashbox/backend_test.go
+++ b/internal/providers/upstashbox/backend_test.go
@@ -683,11 +683,8 @@ func TestRunCleanupDeleteUsesBoundedContext(t *testing.T) {
 		Command: []string{"echo", "hello"},
 		NoSync:  true,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.ExitCode != 0 {
-		t.Fatalf("result=%#v", result)
+	if !errors.Is(err, context.DeadlineExceeded) || result.ExitCode != 1 || result.Status != core.RunStatusFailed || result.ErrorKind != core.RunErrorProvider {
+		t.Fatalf("result=%#v err=%v, want failed deletion reported", result, err)
 	}
 	if result.Session == nil || !result.Session.Kept {
 		t.Fatalf("session=%#v, want retained session after cleanup failure", result.Session)
@@ -695,8 +692,70 @@ func TestRunCleanupDeleteUsesBoundedContext(t *testing.T) {
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Fatalf("Run took %s, want bounded cleanup", elapsed)
 	}
-	if !strings.Contains(stderr.String(), "warning: upstash-box delete failed for box_1: context deadline exceeded") {
-		t.Fatalf("stderr=%q, want bounded cleanup warning", stderr.String())
+	if claim, exists, err := core.ReadLeaseClaimWithPresence(result.LeaseID); err != nil || !exists || claim.LeaseID != result.LeaseID {
+		t.Fatalf("failed deletion lost claim: exists=%v err=%v", exists, err)
+	}
+}
+
+func TestRunKeepsFailuresBeforeCommand(t *testing.T) {
+	for _, phase := range []string{"workspace", "archive upload", "command preparation", "environment upload"} {
+		t.Run(phase, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			fake := &fakeAPI{}
+			withFakeAPI(t, fake)
+			req := RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: true, TimingJSON: true, Command: []string{"true"}}
+			switch phase {
+			case "workspace":
+				fake.execHook = func(context.Context, string) (execResult, error) {
+					return execResult{}, errors.New("workspace unavailable")
+				}
+			case "archive upload":
+				req.NoSync = false
+				req.Repo.Root = newGitRepo(t)
+				fake.uploadHook = func(context.Context, string, string) error { return errors.New("archive upload unavailable") }
+			case "command preparation":
+				req.Command = nil
+			case "environment upload":
+				req.Env = map[string]string{"FIXTURE": "synthetic"}
+				fake.uploadHook = func(context.Context, string, string) error { return errors.New("environment upload unavailable") }
+			}
+			var stderr bytes.Buffer
+			b := NewBackend(Provider{}.Spec(), testConfig(), Runtime{Stdout: io.Discard, Stderr: &stderr}).(*backend)
+			result, err := b.Run(t.Context(), req)
+			if err == nil || result.Session == nil || !result.Session.Kept || result.Session.Reused || len(fake.deletedIDs) != 0 || len(fake.streamCommands) != 0 {
+				t.Fatalf("early failure lost retention: result=%#v err=%v calls=%v", result, err, fake.verbs)
+			}
+			if _, exists, err := core.ReadLeaseClaimWithPresence(result.LeaseID); err != nil || !exists {
+				t.Fatalf("retained claim missing: exists=%v err=%v", exists, err)
+			}
+			lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
+			var report core.TimingReport
+			if err := json.Unmarshal([]byte(lines[len(lines)-1]), &report); err != nil || report.RunStatus != core.RunStatusFailed || report.ErrorKind != core.RunErrorProvider || report.ExitCode != result.ExitCode {
+				t.Fatalf("early failure timing=%#v err=%v", report, err)
+			}
+		})
+	}
+}
+
+type failingTimingWriter struct{ cause error }
+
+func (w failingTimingWriter) Write(data []byte) (int, error) {
+	if bytes.HasPrefix(data, []byte("{")) {
+		return 0, w.cause
+	}
+	return len(data), nil
+}
+
+func TestRunTimingFailurePreservesCommandAndRetention(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeAPI{streamCode: 42}
+	withFakeAPI(t, fake)
+	cause := errors.New("synthetic timing write failure")
+	b := NewBackend(Provider{}.Spec(), testConfig(), Runtime{Stdout: io.Discard, Stderr: failingTimingWriter{cause}}).(*backend)
+	result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: true, TimingJSON: true, Command: []string{"false"}})
+	var exitErr ExitError
+	if !errors.Is(err, cause) || !errors.As(err, &exitErr) || exitErr.Code != 42 || result.ExitCode != 42 || result.Status != core.RunStatusFailed || result.ErrorKind != core.RunErrorCommandExit || result.Session == nil || !result.Session.Kept || len(fake.deletedIDs) != 0 {
+		t.Fatalf("timing masked command/retention: result=%#v err=%v deletes=%v", result, err, fake.deletedIDs)
 	}
 }
 
@@ -1325,7 +1384,9 @@ func TestEnvProfileRefusesChangedReceipt(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = cleanup()
+			cleanupCtx, cancel := upstashBoxCleanupContext()
+			defer cancel()
+			err = cleanup(cleanupCtx)
 			if change == "unchanged legacy claim" {
 				if err != nil || len(fake.execCommands) != 1 {
 					t.Fatalf("legacy cleanup=%v commands=%v", err, fake.execCommands)
@@ -1376,7 +1437,9 @@ func TestEnvProfileDeniedUploadHasNoRemoteCustody(t *testing.T) {
 				t.Fatal("denied upload succeeded")
 			}
 			if cleanup != nil {
-				if err := cleanup(); err != nil {
+				cleanupCtx, cancel := upstashBoxCleanupContext()
+				defer cancel()
+				if err := cleanup(cleanupCtx); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -1410,7 +1473,7 @@ func TestRunPreservesStreamErrorCause(t *testing.T) {
 				if !errors.Is(err, cause) || !errors.As(err, &exitErr) || exitErr.Code != 1 || len(fake.streamCommands) != 1 || t.Context().Err() != nil {
 					t.Fatalf("stream cause lost: err=%v stream calls=%d parent=%v", err, len(fake.streamCommands), t.Context().Err())
 				}
-				if got, want := core.RunStatusForResult(result, err), core.RunStatusForResult(result, cause); got != want {
+				if got, want := core.FinalizeRunResult(result, err).Status, core.RunStatusForResult(result, cause); got != want {
 					t.Fatalf("primary status=%s, want %s", got, want)
 				}
 			})
@@ -1540,7 +1603,7 @@ func TestEnvProfilesOnSameBoxHaveIndependentCustody(t *testing.T) {
 		return os.WriteFile(filepath.Join(root, filepath.Base(remotePath)), data, 0o600)
 	}
 	var paths []string
-	var cleanups []func() error
+	var cleanups []func(context.Context) error
 	for range 2 {
 		path, cleanup, err := uploadEnvProfile(t.Context(), fake, "cbx_123456789abc", "box_1", "blue", map[string]string{"FIXTURE": "synthetic"})
 		if err != nil {
@@ -1560,16 +1623,16 @@ func TestEnvProfilesOnSameBoxHaveIndependentCustody(t *testing.T) {
 		}
 		return execResult{}, errors.New("unexpected cleanup target")
 	}
-	if err := cleanups[0](); err != nil {
+	if err := cleanups[0](t.Context()); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(filepath.Join(root, filepath.Base(paths[1]))); err != nil {
 		t.Fatalf("first cleanup affected second profile: %v", err)
 	}
-	if err := cleanups[0](); err != nil {
+	if err := cleanups[0](t.Context()); err != nil {
 		t.Fatalf("Close not idempotent: %v", err)
 	}
-	if err := cleanups[1](); err != nil {
+	if err := cleanups[1](t.Context()); err != nil {
 		t.Fatal(err)
 	}
 	entries, err := os.ReadDir(root)
@@ -1582,7 +1645,7 @@ func TestRunEnvProfileThroughNativeHTTPTransport(t *testing.T) {
 	if os.PathSeparator != '/' {
 		t.Skip("native POSIX transport")
 	}
-	for _, scenario := range []string{"healthy", "lost upload acknowledgement", "canceled upload", "changed generation", "source failure", "empty source"} {
+	for _, scenario := range []string{"healthy", "lost upload acknowledgement", "canceled upload", "changed generation", "source failure", "empty source", "owned success", "owned command exit", "owned workspace failure", "owned upload failure", "owned profile cleanup failure", "owned deletion failure", "owned timing failure"} {
 		t.Run(scenario, func(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			local := t.TempDir()
@@ -1593,7 +1656,8 @@ func TestRunEnvProfileThroughNativeHTTPTransport(t *testing.T) {
 			var mu sync.Mutex
 			box := boxData{ID: "box_fixture", Name: "crabbox-blue-123456789abc", CreatedAt: 1700000000, Status: "running"}
 			var profilePath string
-			uploads, removals, workloads, deletes := 0, 0, 0, 0
+			owned := strings.HasPrefix(scenario, "owned ")
+			uploads, removals, workloads, deletes, creates := 0, 0, 0, 0, 0
 			mapPath := func(value string) string { return strings.ReplaceAll(value, workspaceRoot, remote) }
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				mu.Lock()
@@ -1607,7 +1671,34 @@ func TestRunEnvProfileThroughNativeHTTPTransport(t *testing.T) {
 				case "/v2/box/box_fixture":
 					_ = json.NewEncoder(w).Encode(box)
 				case "/v2/box":
+					if owned && r.Method == http.MethodPost {
+						var request struct{ Name string }
+						if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+							t.Error(err)
+							return
+						}
+						creates++
+						box.Name = request.Name
+						_ = json.NewEncoder(w).Encode(box)
+						return
+					}
 					deletes++
+					if owned && r.Method == http.MethodDelete {
+						var request struct {
+							IDs []string `json:"ids"`
+						}
+						if err := json.NewDecoder(r.Body).Decode(&request); err != nil || len(request.IDs) != 1 || request.IDs[0] != box.ID {
+							t.Errorf("unexpected deletion target: ids=%v err=%v", request.IDs, err)
+							http.Error(w, "target", 400)
+							return
+						}
+						if scenario == "owned deletion failure" {
+							http.Error(w, "synthetic deletion failure", 500)
+						} else {
+							w.WriteHeader(http.StatusNoContent)
+						}
+						return
+					}
 					http.Error(w, "unexpected box mutation", 400)
 				case "/v2/box/box_fixture/files/upload", "/v2/box/box_fixture/files/write":
 					var content string
@@ -1643,7 +1734,7 @@ func TestRunEnvProfileThroughNativeHTTPTransport(t *testing.T) {
 					}
 					uploads++
 					switch scenario {
-					case "lost upload acknowledgement":
+					case "lost upload acknowledgement", "owned upload failure":
 						http.Error(w, "synthetic upload acknowledgement failure", 500)
 						return
 					case "canceled upload":
@@ -1668,6 +1759,10 @@ func TestRunEnvProfileThroughNativeHTTPTransport(t *testing.T) {
 						return
 					}
 					stream := strings.HasSuffix(r.URL.Path, "exec-stream")
+					if scenario == "owned workspace failure" && strings.HasPrefix(body.Command[2], "mkdir -p ") {
+						http.Error(w, "synthetic workspace failure", 500)
+						return
+					}
 					if stream {
 						workloads++
 					}
@@ -1678,6 +1773,10 @@ func TestRunEnvProfileThroughNativeHTTPTransport(t *testing.T) {
 							return
 						}
 						removals++
+						if scenario == "owned profile cleanup failure" {
+							_ = json.NewEncoder(w).Encode(execResult{ExitCode: 9, Error: "synthetic profile cleanup failure"})
+							return
+						}
 					}
 					cmd := exec.CommandContext(r.Context(), body.Command[0], body.Command[1], mapPath(body.Command[2]))
 					cmd.Dir = filepath.Join(remote, body.Folder)
@@ -1708,7 +1807,12 @@ func TestRunEnvProfileThroughNativeHTTPTransport(t *testing.T) {
 			cfg := testConfig()
 			cfg.UpstashBox.BaseURL, cfg.UpstashBox.APIKey = server.URL, "synthetic-fixture"
 			var stdout bytes.Buffer
-			b := NewBackend(Provider{}.Spec(), cfg, Runtime{HTTP: server.Client(), Stdout: &stdout, Stderr: io.Discard}).(*backend)
+			var stderr bytes.Buffer
+			var diagnostics io.Writer = &stderr
+			if scenario == "owned timing failure" {
+				diagnostics = failingTimingWriter{errors.New("synthetic timing write failure")}
+			}
+			b := NewBackend(Provider{}.Spec(), cfg, Runtime{HTTP: server.Client(), Stdout: &stdout, Stderr: diagnostics}).(*backend)
 			command := `printf '%s\n' "$FIXTURE"`
 			if scenario == "source failure" {
 				command = "printf first; printf escaped"
@@ -1716,12 +1820,20 @@ func TestRunEnvProfileThroughNativeHTTPTransport(t *testing.T) {
 			if scenario == "empty source" {
 				command = ""
 			}
-			result, err := b.Run(ctx, RunRequest{ID: "box_fixture", Repo: Repo{Root: t.TempDir()}, NoSync: true, Command: []string{command}, ShellMode: true, Env: map[string]string{"FIXTURE": "quote ' newline\n$literal"}})
+			if scenario == "owned command exit" || scenario == "owned timing failure" {
+				command = "exit 42"
+			}
+			req := RunRequest{ID: "box_fixture", Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, TimingJSON: true, Command: []string{command}, ShellMode: true, Env: map[string]string{"FIXTURE": "quote ' newline\n$literal"}}
+			if owned {
+				req.ID, req.KeepOnFailure = "", true
+			}
+			result, err := b.Run(ctx, req)
+			result = core.FinalizeRunResult(result, err)
 			mu.Lock()
 			defer mu.Unlock()
-			wantWorkloads, wantRemovals := 1, 1
+			wantWorkloads, wantRemovals, wantUploads, wantDeletes := 1, 1, 1, 0
 			switch scenario {
-			case "lost upload acknowledgement":
+			case "lost upload acknowledgement", "owned upload failure":
 				wantWorkloads = 0
 				if err == nil || !strings.Contains(err.Error(), "synthetic upload acknowledgement failure") {
 					t.Fatalf("lost primary upload error: %v", err)
@@ -1740,6 +1852,28 @@ func TestRunEnvProfileThroughNativeHTTPTransport(t *testing.T) {
 				if err == nil || result.ExitCode != 9 || strings.Contains(stdout.String(), "escaped") {
 					t.Fatalf("source failure escaped: code=%d err=%v out=%q", result.ExitCode, err, stdout.String())
 				}
+			case "owned workspace failure":
+				wantWorkloads, wantRemovals, wantUploads = 0, 0, 0
+				if err == nil || !strings.Contains(err.Error(), "synthetic workspace failure") {
+					t.Fatalf("workspace error lost: %v", err)
+				}
+			case "owned command exit", "owned timing failure":
+				var exitErr ExitError
+				if !errors.As(err, &exitErr) || exitErr.Code != 42 || result.ExitCode != 42 || result.ErrorKind != core.RunErrorCommandExit {
+					t.Fatalf("native command outcome lost: result=%#v err=%v", result, err)
+				}
+				if scenario == "owned timing failure" && !strings.Contains(err.Error(), "synthetic timing write failure") {
+					t.Fatalf("timing diagnostic lost: %v", err)
+				}
+			case "owned profile cleanup failure":
+				if err == nil || result.ExitCode != 5 || result.ErrorKind != core.RunErrorProvider {
+					t.Fatalf("mandatory cleanup lost: result=%#v err=%v", result, err)
+				}
+			case "owned deletion failure":
+				wantDeletes = 1
+				if err == nil || result.ExitCode != 1 || result.ErrorKind != core.RunErrorProvider {
+					t.Fatalf("deletion outcome lost: result=%#v err=%v", result, err)
+				}
 			default:
 				if err != nil || result.ExitCode != 0 {
 					t.Fatalf("result=%#v err=%v", result, err)
@@ -1748,18 +1882,40 @@ func TestRunEnvProfileThroughNativeHTTPTransport(t *testing.T) {
 					t.Fatalf("profile value changed: %q", stdout.String())
 				}
 			}
-			if uploads != 1 || removals != wantRemovals || workloads != wantWorkloads || deletes != 0 {
+			if scenario == "owned success" {
+				wantDeletes = 1
+			}
+			if uploads != wantUploads || removals != wantRemovals || workloads != wantWorkloads || deletes != wantDeletes {
 				t.Fatalf("uploads=%d removals=%d workloads=%d deletes=%d", uploads, removals, workloads, deletes)
 			}
 			_, statErr := os.Stat(mapPath(profilePath))
-			if wantRemovals == 1 && !errors.Is(statErr, os.ErrNotExist) {
+			if wantRemovals == 1 && scenario != "owned profile cleanup failure" && !errors.Is(statErr, os.ErrNotExist) {
 				t.Fatalf("remote residue: %v", statErr)
 			}
-			if wantRemovals == 0 && statErr != nil {
+			if (wantUploads > 0 && wantRemovals == 0 || scenario == "owned profile cleanup failure") && statErr != nil {
 				t.Fatalf("refused cleanup changed remote file: %v", statErr)
 			}
-			if _, exists, err := core.ReadLeaseClaimWithPresence("cbx_123456789abc"); err != nil || exists {
-				t.Fatalf("discovery claim changed: exists=%v err=%v", exists, err)
+			wantKept := scenario != "owned success"
+			if result.Session == nil || result.Session.Kept != wantKept || result.Session.Reused == owned || (creates == 1) != owned {
+				t.Fatalf("session=%#v creates=%d owned=%v", result.Session, creates, owned)
+			}
+			if _, exists, err := core.ReadLeaseClaimWithPresence(result.LeaseID); err != nil || exists != (owned && wantKept) {
+				t.Fatalf("claim custody changed: exists=%v owned=%v kept=%v err=%v", exists, owned, wantKept, err)
+			}
+			if scenario != "owned timing failure" {
+				var report core.TimingReport
+				reports := 0
+				for _, line := range strings.Split(stderr.String(), "\n") {
+					if strings.HasPrefix(line, "{") {
+						if err := json.Unmarshal([]byte(line), &report); err != nil {
+							t.Fatal(err)
+						}
+						reports++
+					}
+				}
+				if reports != 1 || report.ExitCode != result.ExitCode || report.RunStatus != result.Status || report.ErrorKind != result.ErrorKind {
+					t.Fatalf("native reports=%d timing=%#v result=%#v", reports, report, result)
+				}
 			}
 			entries, err := os.ReadDir(local)
 			if err != nil || len(entries) != 0 {

--- a/internal/providers/upstashbox/core.go
+++ b/internal/providers/upstashbox/core.go
@@ -18,7 +18,6 @@ type DoctorResult = core.DoctorResult
 type WarmupRequest = core.WarmupRequest
 type RunRequest = core.RunRequest
 type RunResult = core.RunResult
-type RunSessionHandle = core.RunSessionHandle
 type ListRequest = core.ListRequest
 type LeaseView = core.LeaseView
 type StatusRequest = core.StatusRequest
@@ -75,20 +74,6 @@ func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 
 func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
-}
-
-func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
-	return core.TimingReportWithRunResult(report, result, err)
-}
-
-func timingReportWithProviderError(report timingReport) timingReport {
-	report.RunStatus = core.RunStatusFailed
-	report.ErrorKind = core.RunErrorProvider
-	return report
-}
-
-func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
-	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }
 
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {

--- a/internal/providers/upstashbox/env.go
+++ b/internal/providers/upstashbox/env.go
@@ -56,7 +56,7 @@ func (r envFileReceipt) withUnchanged(ctx context.Context, action func() error) 
 	})
 }
 
-func uploadEnvProfile(ctx context.Context, client api, leaseID, boxID, slug string, env map[string]string) (string, func() error, error) {
+func uploadEnvProfile(ctx context.Context, client api, leaseID, boxID, slug string, env map[string]string) (string, func(context.Context) error, error) {
 	receipt, err := captureEnvFileReceipt(ctx, client, leaseID, boxID, slug)
 	if err != nil {
 		return "", nil, err
@@ -65,9 +65,7 @@ func uploadEnvProfile(ctx context.Context, client api, leaseID, boxID, slug stri
 	if err != nil {
 		return "", nil, err
 	}
-	cleanup := func() error {
-		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), upstashBoxCleanupTimeout)
-		defer cancel()
+	cleanup := func(cleanupCtx context.Context) error {
 		err := profile.Close(cleanupCtx, func(removeCtx context.Context, remotePath string) error {
 			return receipt.withUnchanged(removeCtx, func() error {
 				result, err := client.Exec(removeCtx, boxID, "rm -f "+shellQuote(remotePath), "")


### PR DESCRIPTION
## Summary

Upstash Box could delete a newly created Box after workspace, sync, command-preparation, or environment-upload failure despite `--keep-on-failure`. Failed deletion could still return success, and a timing-output failure could replace a command's exit and skip retention.

Move Upstash runs to the shared delegated-sandbox lifecycle. The shared owner handles sequencing, primary error precedence, retention, cleanup, and timing. The adapter retains Box identity and deletion authorization, profile-file custody, workspace paths, multipart uploads, and native shell transport. Command cleanup can return an error, preserving Upstash's documented cleanup-only exit code 5; Modal retains its existing best-effort cleanup behavior.

Completed delegated command exits remain eligible for signed receipts when secondary cleanup fails. Receipt eligibility uses the already-normalized outcome at the current finalization stage. Provider-only failures do not produce a completed-command receipt.

Maintainer-authored change: the maintainer maintains the Unreleased entry in this PR, as required by the repository's landing policy. No dependencies or configuration options are added.

## Verification

- Baseline regression comparison at `8340044983095a739f3842c42da05e29a2fdbe64`: 16 expected failures and seven passing controls across retention, cleanup/timing outcomes, and signed receipt eligibility.
- After timing integration, full race suites passed for all 12 adapters using the shared lifecycle, the shared owner, and focused CLI receipt/timing tests. After the latest main update, full Upstash/shared/Modal races and CLI receipt/guardrail regressions passed again. Vet, docs build, formatting, and diff checks passed.
- Existing native HTTP/multipart/Unix-shell fixture extended to 13 scenarios, repeated five times: 65 passing executions. It exercises production `Backend.Run` and the HTTP client, actual profile uploads and shell execution, exact deletion requests, retained claims, file cleanup, cancellation, and injected failures.
- Native proof runs on isolated Linux with no external network or credentials. The local synthetic service validates deletion requests and local claim decisions; it does not establish hosted Upstash behavior or independent remote absence.
- Managed Codex review and independent semantic review completed. The receipt-eligibility finding from semantic review was fixed and covered by the CLI regression.

Current candidate is `330e554a64b0a9c5ee00b1f1b568718b661aa779`, tree `4624972e209d8aa66c2f0e022e00cbeab92dd197`, integrated with main `12e4d335c0b7f5b5c48ebc5ebab91395fe893755`. The 65 native cases ran at `01e84f687ae44f9afc8a33a45c95cc0fce5b184d`; its Upstash run/environment/sync and shared lifecycle implementation is byte-identical in the current candidate, whose affected tests were rechecked after integration. Published release notes remain unchanged.

## Real behavior proof

Captured at current production commit `330e554a64b0a9c5ee00b1f1b568718b661aa779` using a test-only overlay. The overlay adds one production App scenario and prints observations from the existing native fixture; production files are unchanged. The test command was:

```sh
go test -buildvcs=false -overlay /proof/overlay.json -p 1 -race -v -timeout=15m ./internal/providers/upstashbox -run TestRunEnvProfileThroughNativeHTTPTransport
```

| Scenario | Creates | Workloads | Profile removal attempts | Deletes | Exit | Status / kind | Kept | Reused |
|---|---:|---:|---:|---:|---:|---|---|---|
| healthy | 0 | 1 | 1 | 0 | 0 | succeeded /  | true | true |
| lost upload acknowledgement | 0 | 0 | 1 | 0 | 1 | failed / provider-error | true | true |
| canceled upload | 0 | 0 | 1 | 0 | 1 | canceled / canceled | true | true |
| changed generation | 0 | 1 | 0 | 0 | 5 | failed / provider-error | true | true |
| source failure | 0 | 1 | 1 | 0 | 9 | failed / command-exit | true | true |
| empty source | 0 | 1 | 1 | 0 | 0 | succeeded /  | true | true |
| owned success | 1 | 1 | 1 | 1 | 0 | succeeded /  | false | false |
| owned command exit | 1 | 1 | 1 | 0 | 42 | failed / command-exit | true | false |
| owned workspace failure | 1 | 0 | 0 | 0 | 1 | failed / provider-error | true | false |
| owned upload failure | 1 | 0 | 1 | 0 | 1 | failed / provider-error | true | false |
| owned profile cleanup failure | 1 | 1 | 1 | 0 | 5 | failed / provider-error | true | false |
| owned deletion failure | 1 | 1 | 1 | 1 | 1 | failed / provider-error | true | false |
| owned timing failure | 1 | 1 | 1 | 0 | 42 | failed / command-exit | true | false |
| owned attested cleanup timeout | 1 | 1 | 1 | 0 | 42 | failed / command-exit | true | false |

The final case calls the real CLI App with the Upstash provider and these run arguments, then calls `verify` on the generated receipt:

```text
run --provider upstash-box --no-sync --keep-on-failure --timing-json --lease-output <fixture>/lease.json --attest <fixture>/receipt.json --allow-env FIXTURE -- sh -c "exit 42"
verify <fixture>/receipt.json
APP_OBSERVED exit=42 status=failed kind=command-exit kept=true reused=false receipt_exit=42 verify=PASS
```

The server executes the actual shell command and deliberately holds profile removal until the 100 ms test cleanup budget expires. The test verifies the retained lease artifact, normalized timing outcome, deadline cause, receipt exit, cryptographic verification, exact request targets, and claim/file custody. It calls App through a race-enabled test binary; this is not a standalone CLI executable or hosted Upstash certification. Other cases use the production Backend directly. The independent evidence audit found no production substitutions.
