### PR TITLE
feat(azure): expose read-only cleanup identity diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Azure: expose read-only, lease-scoped cleanup identity diagnostics so blocked deletion can be investigated without changing claims, bypassing ownership guards, or accessing provider credentials locally.
+
 - Upstash Box: share run finalization so early failures honor `--keep-on-failure`, failed deletion reports a kept recovery session, and cleanup/timing errors preserve the primary exit; keep delegated command receipts when secondary cleanup fails. [PR 1885](https://github.com/openclaw/crabbox/pull/1885). Thanks @steipete.
 - Make `sync-plan --json` preview the configured provider's full-archive or dirty-delta guardrails accurately, without credentials or provider API calls. [PR 1882](https://github.com/openclaw/crabbox/pull/1882). Thanks @steipete.
 - Blaxel: prepare and validate sync archives before fresh allocation, freeze the pre-create snapshot, and share staged workspace replacement and cleanup while retaining native upload retries. [PR 1867](https://github.com/openclaw/crabbox/pull/1867). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Unreleased
 
-- Azure: expose read-only, lease-scoped cleanup identity diagnostics so blocked deletion can be investigated without changing claims, bypassing ownership guards, or accessing provider credentials locally.
-
+- Azure: expose read-only, lease-scoped cleanup identity diagnostics so blocked deletion can be investigated without changing claims, bypassing ownership guards, or accessing provider credentials locally. [PR 1889](https://github.com/openclaw/crabbox/pull/1889). Thanks @steipete.
 - Upstash Box: share run finalization so early failures honor `--keep-on-failure`, failed deletion reports a kept recovery session, and cleanup/timing errors preserve the primary exit; keep delegated command receipts when secondary cleanup fails. [PR 1885](https://github.com/openclaw/crabbox/pull/1885). Thanks @steipete.
 - Make `sync-plan --json` preview the configured provider's full-archive or dirty-delta guardrails accurately, without credentials or provider API calls. [PR 1882](https://github.com/openclaw/crabbox/pull/1882). Thanks @steipete.
 - Blaxel: prepare and validate sync archives before fresh allocation, freeze the pre-create snapshot, and share staged workspace replacement and cleanup while retaining native upload retries. [PR 1867](https://github.com/openclaw/crabbox/pull/1867). Thanks @steipete.

--- a/docs/commands/inspect.md
+++ b/docs/commands/inspect.md
@@ -131,6 +131,28 @@ These fields report the coordinator's lifecycle observation. They are not an
 independent provider inventory check. `complete` does not override remaining
 cleanup metadata or an explicit retained-resource flag.
 
+### Azure cleanup identity diagnostics
+
+For a blocked brokered Azure lease, the authenticated coordinator API offers an
+explicit read-only `GET /v1/leases/{id}/cleanup`. Use the canonical lease ID and
+an existing owner, manage-share, or admin credential. View-only shares and device
+tokens cannot inspect cleanup identities; unsupported providers and registered
+leases return HTTP 501. This is an API diagnostic, not an `inspect` CLI flag.
+
+The response's `inspection` contains the retained cleanup claim's stable identity
+and deletion progress, fresh canonical VM/NIC/public-IP/disk identities and
+ownership-match classifications, and the original provider scope. Raw resource
+bodies, tags, bootstrap data, credentials, and operation URLs are not returned.
+`identityMatches` compares the stable resource set with recorded deletion progress;
+it is not an ownership verdict or authorization to delete. `ownership: unclaimed`
+means ownership labels are absent, not that the resource is safe to adopt.
+
+`claimUnchanged: false` means cleanup changed the claim during the reads;
+`identityMatches` is then `null`, as it is when no stable baseline was recorded.
+Provider observations are not an atomic inventory. Inspection never creates,
+updates, clears, or accepts a cleanup identity, and never issues a resource
+mutation. Keep local claims and SSH artifacts until normal stop confirms cleanup.
+
 For coordinator leases whose provider can inject an SSH host key before first
 boot, JSON also includes `sshHostKey`. Its value is exactly the public host-key
 algorithm and base64 payload, without a hostname or comment:

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -314,6 +314,25 @@ export interface AzureOwnedDeleteReleaseContext {
   resourceIdentity: string;
 }
 
+export interface AzureCleanupInspection {
+  providerScope: string;
+  observedAt: string;
+  claimUnchanged: boolean;
+  claim?: {
+    version: 1 | 2;
+    preparing?: true;
+    completed?: true;
+    stableResourceIdentity?: AzureReconciliationIdentityEntry[];
+    deletedStableResourceIdentity?: AzureReconciliationIdentityEntry[];
+    partialStableResourceIdentity?: AzureReconciliationIdentityEntry[];
+    pendingDeletion?: { kind: keyof AzureOwnedDeleteResources; deadline: number };
+  };
+  resources: Array<
+    AzureReconciliationIdentityEntry & { ownership: "matched" | "unclaimed" | "mismatched" }
+  >;
+  identityMatches: boolean | null;
+}
+
 interface AzureResourceList<T> {
   value?: T[];
   nextLink?: string;
@@ -833,6 +852,119 @@ export class AzureClient {
       // oxlint-disable-next-line eslint/no-await-in-loop -- the next delete attempt depends on this delay.
       await sleep(DELETE_RETRY_DELAY_MS);
     }
+  }
+
+  async inspectOwnedCleanup(lease: OwnedDeleteLease): Promise<AzureCleanupInspection> {
+    if (lease.providerScope !== this.providerScope()) {
+      throw new Error("Azure cleanup inspection requires the original provider scope");
+    }
+    if (!this.ownedDeleteClaimStorage) {
+      throw new Error("Azure cleanup inspection requires cleanup claim storage");
+    }
+    if (!/^[a-z0-9][a-z0-9._-]{0,63}$/i.test(lease.cloudID)) {
+      throw new Error("Azure cleanup inspection requires a canonical resource name");
+    }
+    const claimKey = azureOwnedDeleteClaimKey(this.providerScope(), lease.cloudID, lease.id);
+    const claim = await this.ownedDeleteClaimStorage.get<AzureOwnedDeleteClaim>(claimKey);
+    if (claim) this.requireOwnedDeleteClaim(lease, claim);
+    const claimSnapshot = JSON.stringify(claim);
+    const identityEntries = (value: string) =>
+      azureStableResourceIdentityEntries(value).map(({ labels: _labels, ...entry }) => entry);
+    const name = lease.cloudID;
+    const [vm, nic, pip, disk] = await Promise.all([
+      this.ownedResource<AzureVM>(
+        vmPath(this.resourceGroup, name),
+        API_VERSIONS.compute,
+        "virtualMachines",
+        name,
+      ),
+      this.ownedResource<AzureNIC>(
+        networkPath(this.resourceGroup, "networkInterfaces", `${name}-nic`),
+        API_VERSIONS.network,
+        "networkInterfaces",
+        `${name}-nic`,
+      ),
+      this.ownedResource<AzurePublicIP>(
+        networkPath(this.resourceGroup, "publicIPAddresses", `${name}-pip`),
+        API_VERSIONS.network,
+        "publicIPAddresses",
+        `${name}-pip`,
+      ),
+      this.ownedResource<AzureDisk>(
+        `/resourceGroups/${this.resourceGroup}/providers/Microsoft.Compute/disks/${name}-osdisk`,
+        API_VERSIONS.disks,
+        "disks",
+        `${name}-osdisk`,
+      ),
+    ]);
+    const resources: AzureLeaseResource[] = [
+      ...(vm ? [{ kind: "virtualMachines" as const, resource: vm }] : []),
+      ...(nic ? [{ kind: "networkInterfaces" as const, resource: nic }] : []),
+      ...(pip ? [{ kind: "publicIPAddresses" as const, resource: pip }] : []),
+      ...(disk ? [{ kind: "disks" as const, resource: disk }] : []),
+    ];
+    const currentIdentity = azureStableResourceIdentity(resources);
+    const latestClaim = await this.ownedDeleteClaimStorage.get<AzureOwnedDeleteClaim>(claimKey);
+    const claimUnchanged = claimSnapshot === JSON.stringify(latestClaim);
+    // Observations never create/advance a claim or substitute for deletion authority.
+    return {
+      providerScope: this.providerScope(),
+      observedAt: new Date().toISOString(),
+      claimUnchanged,
+      ...(claim
+        ? {
+            claim: {
+              version: claim.version,
+              ...(claim.preparing ? { preparing: claim.preparing } : {}),
+              ...(claim.completed ? { completed: claim.completed } : {}),
+              ...(claim.stableResourceIdentity !== undefined
+                ? { stableResourceIdentity: identityEntries(claim.stableResourceIdentity) }
+                : {}),
+              ...(claim.deletedStableResourceIdentity !== undefined
+                ? {
+                    deletedStableResourceIdentity: identityEntries(
+                      claim.deletedStableResourceIdentity,
+                    ),
+                  }
+                : {}),
+              ...(claim.partialStableResourceIdentity !== undefined
+                ? {
+                    partialStableResourceIdentity: identityEntries(
+                      claim.partialStableResourceIdentity,
+                    ),
+                  }
+                : {}),
+              ...(claim.pendingDeletion
+                ? {
+                    pendingDeletion: {
+                      kind: claim.pendingDeletion.kind,
+                      deadline: claim.pendingDeletion.deadline,
+                    },
+                  }
+                : {}),
+            },
+          }
+        : {}),
+      resources: azureReconciliationIdentityEntries(resources, false).map((entry, index) => {
+        const labels = azureLabelsFromTags(resources[index]!.resource.tags ?? {});
+        return {
+          ...entry,
+          ownership: providerLabelsOwnedByLease(labels, lease, "azure")
+            ? "matched"
+            : azureHasOwnershipClaims(labels)
+              ? "mismatched"
+              : "unclaimed",
+        };
+      }),
+      identityMatches:
+        claimUnchanged && claim?.stableResourceIdentity !== undefined
+          ? azureStableResourceIdentityMatches(
+              claim.stableResourceIdentity,
+              currentIdentity,
+              claim.deletedStableResourceIdentity,
+            )
+          : null,
+    };
   }
 
   async deleteOwnedServer(

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -7287,6 +7287,33 @@ export class FleetCoordinator {
     if (method === "PUT" && action === "registration") {
       return await this.registerLease(request, leaseID);
     }
+    if (method === "GET" && action === "cleanup") {
+      const admin = isAdminRequest(request);
+      const lease = await this.resolveLease(leaseID, request, admin);
+      if (!lease) return notFound();
+      if (
+        requestAuthType(request) === "device" ||
+        !this.leaseManageableByRequest(lease, request, admin)
+      ) {
+        return json(
+          { error: "forbidden", message: "lease manage access required" },
+          { status: 403 },
+        );
+      }
+      const providerID = managedLeaseProvider(lease);
+      const provider =
+        !isRegisteredLease(lease) && lease.cloudID && providerID
+          ? this.provider(providerID, lease.region, lease.providerProject)
+          : undefined;
+      if (!provider?.inspectCleanup) {
+        return json({ error: "cleanup_inspection_unsupported" }, { status: 501 });
+      }
+      return json({
+        leaseID: lease.id,
+        provider: managedLeaseProvider(lease),
+        inspection: await provider.inspectCleanup(lease),
+      });
+    }
     if (method === "GET" && action === undefined) {
       const admin = isAdminRequest(request);
       const lease = await this.resolveLease(leaseID, request, false);
@@ -25966,6 +25993,7 @@ interface CloudProvider {
   releaseLease(lease: LeaseRecord, context?: ProviderReleaseContext): Promise<void>;
   deleteServer(id: string): Promise<void>;
   deleteOwnedServer?(lease: LeaseRecord): Promise<void>;
+  inspectCleanup?(lease: LeaseRecord): Promise<unknown>;
   supportsNativeImages(): boolean;
   nativeImagesUnsupportedMessage(): string;
   defaultImageStrategy(lease: LeaseRecord): "image" | "disk-snapshot";
@@ -26410,6 +26438,19 @@ export class AzureProvider implements CloudProvider {
 
   deleteServer(id: string): Promise<void> {
     return this.client.deleteServer(id);
+  }
+
+  inspectCleanup(lease: LeaseRecord): ReturnType<AzureClient["inspectOwnedCleanup"]> {
+    const scope = azureProviderScope(lease.providerScope);
+    if (!scope) {
+      throw new Error("Azure cleanup inspection requires the original provider scope");
+    }
+    return new AzureClient(this.env, {
+      ...(lease.region ? { location: lease.region } : {}),
+      subscription: scope.subscription,
+      resourceGroup: scope.resourceGroup,
+      ...(this.storage ? { ownedDeleteClaimStorage: this.storage } : {}),
+    }).inspectOwnedCleanup(lease);
   }
 
   deleteOwnedServer(lease: LeaseRecord, context?: ProviderReleaseContext): Promise<void> {

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -5,6 +5,7 @@ import {
   azureLinuxCloudInit,
   azureLabelsFromTags,
   azureLROPollIntervalMS,
+  azureOwnedDeleteClaimKey,
   azureProvisioningErrorCategory,
   azureRegionCandidates,
   azureRegionalName,
@@ -320,6 +321,369 @@ function testLeaseConfig(overrides: Partial<LeaseConfig> = {}): LeaseConfig {
     ...overrides,
   };
 }
+
+describe("Azure cleanup inspection", () => {
+  function fixture() {
+    const lease = ownedAzureLease();
+    const scope = lease.providerScope!;
+    const ids = {
+      vm: `${scope}/providers/Microsoft.Compute/virtualMachines/${lease.cloudID}`,
+      nic: `${scope}/providers/Microsoft.Network/networkInterfaces/${lease.cloudID}-nic`,
+      pip: `${scope}/providers/Microsoft.Network/publicIPAddresses/${lease.cloudID}-pip`,
+      disk: `${scope}/providers/Microsoft.Compute/disks/${lease.cloudID}-osdisk`,
+    };
+    const resource = (id: string, properties: Record<string, unknown>) => ({
+      id,
+      name: id.split("/").at(-1)!,
+      location: "eastus",
+      tags: ownedAzureTags({ diagnostic_secret: "synthetic-tag-secret" }),
+      properties,
+    });
+    const vm = resource(ids.vm, {
+      ...ownedAzureVMProperties(),
+      osProfile: {
+        adminPassword: "synthetic-admin-password",
+        customData: "synthetic-bootstrap-data",
+      },
+      customData: "synthetic-top-level-bootstrap-data",
+    });
+    const nic = resource(ids.nic, ownedAzureNICProperties());
+    const pip = resource(ids.pip, { resourceGuid: "pip-immutable-id" });
+    const disk = resource(ids.disk, { uniqueId: "disk-immutable-id" });
+    const resources = new Map<string, unknown>([
+      [ids.vm, vm],
+      [ids.nic, nic],
+      [ids.pip, pip],
+      [ids.disk, disk],
+    ]);
+    const baseline = [
+      {
+        kind: "virtualMachines",
+        id: ids.vm.toLowerCase(),
+        immutableID: "vm-immutable-id",
+        location: "eastus",
+        topology: {
+          managedDiskID: ids.disk.toLowerCase(),
+          networkInterfaceIDs: [ids.nic.toLowerCase()],
+        },
+      },
+      {
+        kind: "networkInterfaces",
+        id: ids.nic.toLowerCase(),
+        immutableID: "nic-immutable-id",
+        location: "eastus",
+        topology: { publicIPIDs: [ids.pip.toLowerCase()] },
+      },
+      {
+        kind: "publicIPAddresses",
+        id: ids.pip.toLowerCase(),
+        immutableID: "pip-immutable-id",
+        location: "eastus",
+        topology: {},
+      },
+      {
+        kind: "disks",
+        id: ids.disk.toLowerCase(),
+        immutableID: "disk-immutable-id",
+        location: "eastus",
+        topology: {},
+      },
+    ];
+    const { records, storage } = memoryAzureDeleteClaimStorage();
+    const claimKey = azureOwnedDeleteClaimKey(scope, lease.cloudID, lease.id);
+    const claim = {
+      version: 2,
+      provider: "azure",
+      leaseID: lease.id,
+      slug: lease.slug,
+      owner: lease.owner,
+      cloudID: lease.cloudID,
+      providerScope: scope,
+      stableResourceIdentity: JSON.stringify(baseline),
+    };
+    records.set(claimKey, claim);
+    const get = vi.spyOn(storage, "get");
+    const put = vi.spyOn(storage, "put");
+    const remove = vi.spyOn(storage, "delete");
+    const client = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });
+    seedAzureAuthCache(client);
+    const fetcher = vi.fn<AzureClient["fetcher"]>(async (input, init) => {
+      const url = new URL(String(input));
+      expect(init?.method ?? "GET").toBe("GET");
+      expect(url.origin).toBe("https://management.azure.com");
+      expect(Object.values(ids)).toContain(url.pathname);
+      const value = resources.get(url.pathname);
+      return value ? Response.json(value) : azureResourceNotFoundResponse(url);
+    });
+    client.fetcher = fetcher;
+    return {
+      lease,
+      ids,
+      vm,
+      pip,
+      disk,
+      resources,
+      baseline,
+      records,
+      claimKey,
+      claim,
+      client,
+      fetcher,
+      expectReadOnly() {
+        expect(fetcher).toHaveBeenCalledTimes(4);
+        expect(get.mock.calls).toEqual([[claimKey], [claimKey]]);
+        expect(put).not.toHaveBeenCalled();
+        expect(remove).not.toHaveBeenCalled();
+      },
+    };
+  }
+
+  it("reads exact resources and projects a matching stable claim without secrets or writes", async () => {
+    const f = fixture();
+    const deadline = Date.now() + 60_000;
+    f.records.set(f.claimKey, {
+      ...f.claim,
+      pendingDeletion: {
+        kind: "vm",
+        stableResourceIdentity: f.claim.stableResourceIdentity,
+        operationURL: "https://management.azure.com/operations/synthetic-private-operation",
+        deadline,
+      },
+    });
+    const before = structuredClone(f.records);
+    const started = Date.now();
+
+    const inspection = await f.client.inspectOwnedCleanup(f.lease);
+
+    expect(inspection).toMatchObject({
+      providerScope: f.lease.providerScope,
+      claimUnchanged: true,
+      identityMatches: true,
+      claim: {
+        version: 2,
+        stableResourceIdentity: f.baseline,
+        pendingDeletion: { kind: "vm", deadline },
+      },
+      resources: f.baseline.map((entry) => ({ ...entry, ownership: "matched" })),
+    });
+    expect(Date.parse(inspection.observedAt)).toBeGreaterThanOrEqual(started);
+    expect(Date.parse(inspection.observedAt)).toBeLessThanOrEqual(Date.now());
+    const serialized = JSON.stringify(inspection);
+    for (const excluded of [
+      "synthetic-tag-secret",
+      "synthetic-admin-password",
+      "synthetic-bootstrap-data",
+      "synthetic-top-level-bootstrap-data",
+      "synthetic-private-operation",
+      "tags",
+      "labels",
+      "osProfile",
+      "customData",
+      "operationURL",
+    ]) {
+      expect(serialized).not.toContain(excluded);
+    }
+    expect(f.records).toEqual(before);
+    f.expectReadOnly();
+  });
+
+  it("reports absent resources rather than manufacturing missing members", async () => {
+    const f = fixture();
+    f.resources.delete(f.ids.vm);
+    f.records.set(f.claimKey, {
+      ...f.claim,
+      deletedStableResourceIdentity: JSON.stringify([f.baseline[0]]),
+      partialStableResourceIdentity: JSON.stringify(f.baseline.slice(1)),
+    });
+
+    const inspection = await f.client.inspectOwnedCleanup(f.lease);
+
+    expect(inspection.resources.map((entry) => entry.kind)).toEqual([
+      "networkInterfaces",
+      "publicIPAddresses",
+      "disks",
+    ]);
+    expect(inspection).toMatchObject({
+      claimUnchanged: true,
+      identityMatches: true,
+      claim: {
+        deletedStableResourceIdentity: [f.baseline[0]],
+        partialStableResourceIdentity: f.baseline.slice(1),
+      },
+    });
+    f.expectReadOnly();
+  });
+
+  it("reports a replacement generation as a mismatch without throwing", async () => {
+    const f = fixture();
+    f.vm.properties.vmId = "replacement-vm-generation";
+
+    const inspection = await f.client.inspectOwnedCleanup(f.lease);
+
+    expect(inspection.identityMatches).toBe(false);
+    expect(inspection.resources[0]).toMatchObject({
+      immutableID: "replacement-vm-generation",
+      ownership: "matched",
+    });
+    expect(inspection.claim?.stableResourceIdentity?.[0]?.immutableID).toBe("vm-immutable-id");
+    f.expectReadOnly();
+  });
+
+  it("classifies other-owner and untagged resources without revealing other-owner tags", async () => {
+    const f = fixture();
+    f.pip.tags = ownedAzureTags({ owner: "synthetic_other_owner", lease: "cbx_999999999999" });
+    f.disk.tags = {};
+
+    const inspection = await f.client.inspectOwnedCleanup(f.lease);
+
+    expect(inspection.resources.find((entry) => entry.kind === "publicIPAddresses")).toMatchObject({
+      ownership: "mismatched",
+    });
+    expect(inspection.resources.find((entry) => entry.kind === "disks")).toMatchObject({
+      ownership: "unclaimed",
+    });
+    expect(JSON.stringify(inspection)).not.toContain("synthetic_other_owner");
+    expect(JSON.stringify(inspection)).not.toContain("cbx_999999999999");
+    f.expectReadOnly();
+  });
+
+  it.each(["absent", "preparing", "legacy"] as const)(
+    "returns unknown identity for a %s claim without creating a baseline",
+    async (state) => {
+      const f = fixture();
+      if (state === "absent") f.records.delete(f.claimKey);
+      else {
+        const { stableResourceIdentity: _baseline, ...binding } = f.claim;
+        f.records.set(f.claimKey, {
+          ...binding,
+          ...(state === "preparing" ? { preparing: true } : { version: 1 }),
+        });
+      }
+      const before = structuredClone(f.records);
+
+      const inspection = await f.client.inspectOwnedCleanup(f.lease);
+
+      expect(inspection.identityMatches).toBeNull();
+      expect(inspection.claimUnchanged).toBe(true);
+      const expectedClaim = {
+        absent: undefined,
+        preparing: { version: 2, preparing: true },
+        legacy: { version: 1 },
+      }[state];
+      expect(Object.hasOwn(inspection, "claim")).toBe(state !== "absent");
+      expect(inspection.claim).toEqual(expectedClaim);
+      expect(f.records).toEqual(before);
+      f.expectReadOnly();
+    },
+  );
+
+  it.each(["replaced", "removed", "created"])(
+    "returns unknown identity when the claim is concurrently %s during resource GETs",
+    async (change) => {
+      const f = fixture();
+      if (change === "created") f.records.delete(f.claimKey);
+      const fetcher = f.client.fetcher;
+      let changed = false;
+      f.client.fetcher = async (input, init) => {
+        const response = await fetcher(input, init);
+        if (!changed) {
+          changed = true;
+          if (change === "removed") f.records.delete(f.claimKey);
+          else {
+            f.records.set(f.claimKey, {
+              ...f.claim,
+              stableResourceIdentity: f.claim.stableResourceIdentity.replace(
+                "vm-immutable-id",
+                "concurrent-vm-generation",
+              ),
+            });
+          }
+        }
+        return response;
+      };
+
+      const inspection = await f.client.inspectOwnedCleanup(f.lease);
+
+      expect(inspection.claimUnchanged).toBe(false);
+      expect(inspection.identityMatches).toBeNull();
+      expect(inspection.resources).toHaveLength(4);
+      f.expectReadOnly();
+    },
+  );
+
+  it("detects in-place claim mutation during provider reads", async () => {
+    const f = fixture();
+    const fetcher = f.client.fetcher;
+    f.client.fetcher = async (input, init) => {
+      const response = await fetcher(input, init);
+      f.claim.stableResourceIdentity = f.claim.stableResourceIdentity.replace(
+        "vm-immutable-id",
+        "concurrent-vm-generation",
+      );
+      return response;
+    };
+
+    const inspection = await f.client.inspectOwnedCleanup(f.lease);
+
+    expect(inspection.claimUnchanged).toBe(false);
+    expect(inspection.identityMatches).toBeNull();
+    f.expectReadOnly();
+  });
+
+  it("strips persisted label payloads from the projected stable baseline", async () => {
+    const f = fixture();
+    f.records.set(f.claimKey, {
+      ...f.claim,
+      stableResourceIdentity: JSON.stringify(
+        f.baseline.map((entry) => ({ ...entry, labels: "synthetic-persisted-label-secret" })),
+      ),
+    });
+
+    const inspection = await f.client.inspectOwnedCleanup(f.lease);
+
+    expect(inspection.claim?.stableResourceIdentity).toEqual(f.baseline);
+    expect(JSON.stringify(inspection)).not.toContain("synthetic-persisted-label-secret");
+    expect(JSON.stringify(inspection)).not.toContain("labels");
+    f.expectReadOnly();
+  });
+
+  it.each(["../other-vm", "crabbox-blue-lobster/child", "crabbox-blue-lobster?query=true", ""])(
+    "rejects malformed cloud ID %j before provider reads",
+    async (cloudID) => {
+      const f = fixture();
+
+      await expect(f.client.inspectOwnedCleanup({ ...f.lease, cloudID })).rejects.toThrow(
+        "Azure cleanup inspection requires a canonical resource name",
+      );
+      expect(f.fetcher).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects an original scope mismatch before any provider read", async () => {
+    const f = fixture();
+
+    await expect(
+      f.client.inspectOwnedCleanup({
+        ...f.lease,
+        providerScope: "/subscriptions/other-sub/resourceGroups/other-rg",
+      }),
+    ).rejects.toThrow(/scope/i);
+    expect(f.fetcher).not.toHaveBeenCalled();
+  });
+
+  it.each(["provider", "leaseID", "slug", "owner", "cloudID", "providerScope"])(
+    "rejects a persisted claim with a different %s before provider reads",
+    async (field) => {
+      const f = fixture();
+      f.records.set(f.claimKey, { ...f.claim, [field]: "different-binding" });
+      const before = structuredClone(f.records);
+
+      await expect(f.client.inspectOwnedCleanup(f.lease)).rejects.toThrow(/claim mismatch/i);
+      expect(f.fetcher).not.toHaveBeenCalled();
+      expect(f.records).toEqual(before);
+    },
+  );
+});
 
 describe("azure provider", () => {
   it("treats only an exact missing VM as absent", async () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -676,6 +676,271 @@ class FakeCoordinatorRuntime implements CoordinatorRuntime {
   }
 }
 
+describe("fleet cleanup inspection", () => {
+  function fixture(supported = true) {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      id: "cbx_abcdef123456",
+      slug: "blue-lobster",
+      provider: "azure",
+      cloudID: "crabbox-blue-lobster",
+      providerScope: "/subscriptions/original-sub/resourceGroups/original-rg",
+      owner: "alice@example.com",
+      org: "example-org",
+      state: "failed",
+      cleanupError: "synthetic cleanup interruption",
+      sshUser: "synthetic-private-access-token",
+      share: {
+        users: {
+          "manager@example.com": "manage",
+          "viewer@example.com": "use",
+        },
+      },
+    });
+    const inspection = {
+      providerScope: lease.providerScope,
+      observedAt: "2026-09-01T12:00:00.000Z",
+      claimUnchanged: true,
+      resources: [],
+      identityMatches: null,
+    };
+    const inspectCleanup = vi.fn<(lease: LeaseRecord) => Promise<typeof inspection>>(
+      async () => inspection,
+    );
+    const refreshLeaseAccessForResolution = vi.fn<() => Promise<undefined>>(async () => undefined);
+    const releaseLease = vi.fn<() => Promise<void>>(async () => undefined);
+    const provider = {
+      ...fakeProvider(undefined, { provider: "azure" }),
+      ...(supported ? { inspectCleanup } : {}),
+      refreshLeaseAccessForResolution,
+      releaseLease,
+    };
+    storage.seed(`lease:${lease.id}`, lease);
+    const fleet = testFleet(
+      storage,
+      { azure: provider },
+      { CRABBOX_PUBLIC_URL: "https://crabbox.test" },
+    );
+    return {
+      storage,
+      lease,
+      fleet,
+      inspection,
+      inspectCleanup,
+      expectNoLifecycleMutation() {
+        expect(refreshLeaseAccessForResolution).not.toHaveBeenCalled();
+        expect(releaseLease).not.toHaveBeenCalled();
+        expect(storage.value(`lease:${lease.id}`)).toEqual(lease);
+      },
+    };
+  }
+
+  it.each([
+    ["owner", "alice@example.com", "example-org", false],
+    ["manage share", "manager@example.com", "other-org", false],
+    ["admin", "admin@example.com", "other-org", true],
+  ] as const)(
+    "allows %s to inspect cleanup without refresh or release",
+    async (_role, owner, org, admin) => {
+      const f = fixture();
+
+      const response = await f.fleet.fetch(
+        request("GET", `/v1/leases/${f.lease.id}/cleanup`, {
+          headers: {
+            "x-crabbox-owner": owner,
+            "x-crabbox-org": org,
+            ...(admin ? { "x-crabbox-admin": "true" } : {}),
+          },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        leaseID: f.lease.id,
+        provider: "azure",
+        inspection: f.inspection,
+      });
+      expect(f.inspectCleanup).toHaveBeenCalledExactlyOnceWith(f.lease);
+      f.expectNoLifecycleMutation();
+    },
+  );
+
+  it.each([
+    ["view-only share", "viewer@example.com", "other-org", 403],
+    ["unshared org member", "member@example.com", "example-org", 404],
+    ["unrelated user", "outsider@example.com", "other-org", 404],
+    ["owner in another org", "alice@example.com", "other-org", 404],
+  ] as const)(
+    "denies cleanup inspection to a %s before provider access",
+    async (_role, owner, org, expectedStatus) => {
+      const f = fixture();
+
+      const response = await f.fleet.fetch(
+        request("GET", `/v1/leases/${f.lease.id}/cleanup`, {
+          headers: { "x-crabbox-owner": owner!, "x-crabbox-org": org! },
+        }),
+      );
+
+      expect(response.status).toBe(expectedStatus);
+      expect(f.inspectCleanup).not.toHaveBeenCalled();
+      expect(await response.text()).not.toContain("synthetic-private-access-token");
+      f.expectNoLifecycleMutation();
+    },
+  );
+
+  it("denies device tokens access to cleanup diagnostics even with owner headers", async () => {
+    const f = fixture();
+
+    const response = await f.fleet.fetch(
+      request("GET", `/v1/leases/${f.lease.id}/cleanup`, {
+        headers: {
+          authorization: `Bearer cbxd_00000000-0000-4000-8000-000000000001.${"A".repeat(43)}`,
+          origin: "https://crabbox.test",
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "device_scope_forbidden" });
+    expect(f.inspectCleanup).not.toHaveBeenCalled();
+    f.expectNoLifecycleMutation();
+  });
+
+  it("returns 404 for an unknown lease without provider access", async () => {
+    const f = fixture();
+
+    const response = await f.fleet.fetch(
+      request("GET", "/v1/leases/cbx_999999999999/cleanup", {
+        headers: { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(f.inspectCleanup).not.toHaveBeenCalled();
+    f.expectNoLifecycleMutation();
+  });
+
+  it("returns 501 for an unsupported hook only after authorization", async () => {
+    const f = fixture(false);
+    const path = `/v1/leases/${f.lease.id}/cleanup`;
+
+    const owner = await f.fleet.fetch(
+      request("GET", path, {
+        headers: { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" },
+      }),
+    );
+    const viewer = await f.fleet.fetch(
+      request("GET", path, {
+        headers: { "x-crabbox-owner": "viewer@example.com", "x-crabbox-org": "other-org" },
+      }),
+    );
+
+    expect(owner.status).toBe(501);
+    expect(viewer.status).toBe(403);
+    f.expectNoLifecycleMutation();
+  });
+
+  it.each(["registered", "unbound"])(
+    "returns 501 for a %s lease without invoking the provider",
+    async (kind) => {
+      const f = fixture();
+      if (kind === "registered") f.lease.lifecycle = "registered";
+      else f.lease.cloudID = "";
+      f.storage.seed(`lease:${f.lease.id}`, f.lease);
+
+      const response = await f.fleet.fetch(
+        request("GET", `/v1/leases/${f.lease.id}/cleanup`, {
+          headers: { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" },
+        }),
+      );
+
+      expect(response.status).toBe(501);
+      expect(f.inspectCleanup).not.toHaveBeenCalled();
+      f.expectNoLifecycleMutation();
+    },
+  );
+
+  it("routes Azure cleanup inspection to the original subscription and resource group", async () => {
+    const storage = new MemoryStorage();
+    const originalScope = "/subscriptions/original-sub/resourceGroups/original-rg";
+    const lease = testLease({
+      id: "cbx_abcdef123456",
+      slug: "blue-lobster",
+      provider: "azure",
+      cloudID: "crabbox-blue-lobster",
+      providerScope: originalScope,
+      owner: "alice@example.com",
+      org: "example-org",
+      state: "failed",
+      cleanupError: "synthetic cleanup interruption",
+    });
+    const env = {
+      AZURE_TENANT_ID: "tenant",
+      AZURE_CLIENT_ID: "client",
+      AZURE_CLIENT_SECRET: "synthetic-client-secret",
+      AZURE_SUBSCRIPTION_ID: "new-default-sub",
+      CRABBOX_AZURE_RESOURCE_GROUP: "new-default-rg",
+    };
+    const provider = new AzureProvider(env as Env, undefined, storage);
+    const release = vi.spyOn(provider, "releaseLease");
+    const reads: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const req = input instanceof Request ? input : new Request(input, init);
+        const url = new URL(req.url);
+        if (url.hostname === "login.microsoftonline.com") {
+          return Response.json({ access_token: "synthetic-azure-access-token", expires_in: 3600 });
+        }
+        expect(req.method).toBe("GET");
+        expect(url.origin).toBe("https://management.azure.com");
+        reads.push(url.pathname);
+        return Response.json(
+          {
+            error: {
+              code: "ResourceNotFound",
+              message: `The Resource '${url.pathname.slice(url.pathname.indexOf("/providers/") + 11)}' was not found.`,
+            },
+          },
+          { status: 404 },
+        );
+      }),
+    );
+    storage.seed(`lease:${lease.id}`, lease);
+    const fleet = testFleet(storage, { azure: provider }, env);
+
+    const response = await fleet.fetch(
+      request("GET", `/v1/leases/${lease.id}/cleanup`, {
+        headers: { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      leaseID: lease.id,
+      provider: "azure",
+      inspection: {
+        providerScope: originalScope,
+        claimUnchanged: true,
+        identityMatches: null,
+        resources: [],
+      },
+    });
+    expect(reads.toSorted()).toEqual(
+      [
+        `${originalScope}/providers/Microsoft.Compute/virtualMachines/${lease.cloudID}`,
+        `${originalScope}/providers/Microsoft.Network/networkInterfaces/${lease.cloudID}-nic`,
+        `${originalScope}/providers/Microsoft.Network/publicIPAddresses/${lease.cloudID}-pip`,
+        `${originalScope}/providers/Microsoft.Compute/disks/${lease.cloudID}-osdisk`,
+      ].toSorted(),
+    );
+    expect(release).not.toHaveBeenCalled();
+    expect(storage.value(`lease:${lease.id}`)).toEqual(lease);
+  });
+});
+
 describe("runtime adapter relay", () => {
   it("revalidates active admin control sockets against the current grant source", async () => {
     const oldAdminToken = "old-admin-token";


### PR DESCRIPTION
## Summary

Add an explicit read-only cleanup diagnostic for brokered Azure leases. Previously, a retained cleanup claim could disagree with live Azure resources while the public lease record exposed only `observed resource identity changed`, leaving operators unable to inspect the exact mismatch without direct provider credentials or storage access.

`GET /v1/leases/{id}/cleanup` uses the existing owner/manage-share/admin authorization and a provider-neutral inspection hook. The Azure adapter reads the retained baseline/deletion progress and the four canonical resource identities in the original subscription/resource group, not current deployment defaults. It reports concurrent claim changes without creating, updating, clearing, or accepting a claim. View-only shares, device credentials, unrelated users, registered leases, and unsupported providers do not gain provider access.

The response excludes resource bodies, raw tags, bootstrap data, credentials, and operation URLs. Stable-identity agreement and ownership classification remain distinct diagnostics: neither grants deletion authority. The existing cleanup/delete path is unchanged.

## Verification

- Worker format, lint, and TypeScript checks.
- Node coordinator TypeScript check.
- Full Worker Vitest suite: 2,636 passed, 3 skipped.
- Final complete Azure and fleet regression suites: 1,098 passed.
- 36 focused cleanup-inspection cases cover authorization, original-scope routing, mutation absence, missing/replaced resources, redaction, and claim races.
- Worker dry-run build, Node coordinator build, and Cloudflare Dynamic Workers build.
- Independent Codex review: scoped-clean, no P0/P1 findings.

No new configuration, permissions, dependency, or secret is required. CLI release/publication is not part of this change. Live read-only validation follows the normal serialized coordinator deployment; this PR does not claim a blocked cloud resource has been deleted.
