### PR TITLE
chore(release): authorize v0.50.0 source

### DIFF
--- a/release/records/v0.50.0.json
+++ b/release/records/v0.50.0.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.50.0",
+  "tagObject": "448d5a0b0528770d92c40242d8d71711f5eaa3e1",
+  "sourceCommit": "215115a450864ec96c53b0c31130facbc4190d2e",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
Authorizes the frozen v0.50.0 source for the normal release pipeline: signed tag object `448d5a0b0528770d92c40242d8d71711f5eaa3e1` points to source commit `215115a450864ec96c53b0c31130facbc4190d2e`. GitHub verified the SSH signature immediately after tag push.

The source preparation landed in https://github.com/openclaw/crabbox/pull/1890. Its merge tree exactly matches the reviewed head that passed full CI: https://github.com/openclaw/crabbox/actions/runs/33990371380. The protected Release Check also passed: https://github.com/openclaw/crabbox/actions/runs/33990371386.

Only the new version-specific authorization record is added. Direct publishability/source verification and independent Codex review passed; existing records and tags remain unchanged. This record permits candidate production, with signing, private draft proof, publication, and public installation checks still required.
