### PR TITLE
feat(bench): summarize runner phase timings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Group benchmark reports by record source and summarize successful runner totals, runner phases, sync phases, and sync skips without inventing telemetry for legacy rows.
 - Preserve requested capacity market for market-aware providers while coordinator provisioning is pending, and expose documented provisioning failure diagnostics in `crabbox inspect --json`.
 - Azure: recognize completed Location polling responses and support explicit, audited recovery of expired disk-only cleanup blocked by missing public-IP completion evidence, preserving original identities, ownership checks, and actual deletion receipts. [PR 1893](https://github.com/openclaw/crabbox/pull/1893). Thanks @steipete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Group benchmark reports by record source and summarize successful runner totals, runner phases, sync phases, and sync skips without inventing telemetry for legacy rows.
+- Group benchmark reports by record source and summarize successful runner totals, runner phases, sync phases, and sync skips without inventing telemetry for legacy rows. [PR 1896](https://github.com/openclaw/crabbox/pull/1896). Thanks @vincentkoc.
 - Preserve requested capacity market for market-aware providers while coordinator provisioning is pending, and expose documented provisioning failure diagnostics in `crabbox inspect --json`.
 - Azure: recognize completed Location polling responses and support explicit, audited recovery of expired disk-only cleanup blocked by missing public-IP completion evidence, preserving original identities, ownership checks, and actual deletion receipts. [PR 1893](https://github.com/openclaw/crabbox/pull/1893). Thanks @steipete.
 

--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -64,8 +64,9 @@ crabbox bench record --timing-json timing.json -- pnpm test
 
 ## Report local observations
 
-`bench report` reads the local store and groups observations by provider,
-provider family/kind, machine type, command fingerprint, and cold/warm bucket.
+`bench report` reads the local store and groups observations by record source,
+provider, provider family/kind, machine type, command fingerprint, and
+cold/warm bucket. Records without a source use the `unknown` source bucket.
 
 ```sh
 crabbox bench report
@@ -75,9 +76,20 @@ crabbox bench report --command-fingerprint sha256:... --json
 
 Human output includes successful sample count (`n`), median total duration, p95
 total duration when enough samples exist, median sync and command duration,
-failure count, and an evidence marker. `bench report` marks groups as
-`insufficient_successful_samples` until the group has at least `--min-samples`
-successful observations. The default is `2`.
+failure count, and an evidence marker. When records contain runner telemetry,
+the report also includes median and p95 runner totals plus deterministic runner
+and sync phase summaries. Duplicate phase names within one observation are
+summed before that observation contributes one sample. Runner phases with the
+same name remain separate when one is opaque and the other is not.
+
+Only successful observations contribute duration and phase distributions.
+Failed observations contribute to `failureCount` only. P95 values require at
+least three samples for that specific metric or phase. Sync skip counts are
+counted once per successful observation. Legacy records without runner or phase
+fields omit those summaries.
+
+`bench report` marks groups as `insufficient_successful_samples` until the
+group has at least `--min-samples` successful observations. The default is `2`.
 
 JSON output uses the same grouped data:
 
@@ -92,6 +104,7 @@ JSON output uses the same grouped data:
   },
   "groups": [
     {
+      "source": "bench-run",
       "provider": "aws",
       "providerFamily": "aws",
       "providerKind": "ssh-lease",
@@ -99,8 +112,23 @@ JSON output uses the same grouped data:
       "commandFingerprint": "sha256:...",
       "n": 2,
       "medianTotalMs": 64000,
+      "medianRunnerTotalMs": 67000,
       "medianSyncMs": 12000,
       "medianCommandMs": 45000,
+      "runnerPhases": [
+        {
+          "name": "provider.acquire",
+          "n": 2,
+          "medianMs": 8500
+        }
+      ],
+      "syncPhases": [
+        {
+          "name": "rsync",
+          "n": 2,
+          "medianMs": 9200
+        }
+      ],
       "failureCount": 0,
       "insufficientEvidence": false,
       "evidence": "sufficient_local_samples"

--- a/internal/cli/bench.go
+++ b/internal/cli/bench.go
@@ -626,8 +626,9 @@ func (b *benchmarkReportGroupBuilder) addRunnerPhases(phases []RunnerPhase) {
 
 func (b *benchmarkReportGroupBuilder) addSyncPhases(phases []TimingPhase) {
 	type observationPhase struct {
-		ms      int64
-		skipped bool
+		ms       int64
+		measured bool
+		skipped  bool
 	}
 	perObservation := map[string]observationPhase{}
 	for _, phase := range phases {
@@ -636,8 +637,9 @@ func (b *benchmarkReportGroupBuilder) addSyncPhases(phases []TimingPhase) {
 			continue
 		}
 		value := perObservation[name]
-		if phase.Ms > 0 {
+		if !phase.Skipped && phase.Ms >= 0 {
 			value.ms += phase.Ms
+			value.measured = true
 		}
 		value.skipped = value.skipped || phase.Skipped
 		perObservation[name] = value
@@ -654,7 +656,7 @@ func (b *benchmarkReportGroupBuilder) addSyncPhases(phases []TimingPhase) {
 			phase = &benchmarkSyncPhaseBuilder{}
 			b.syncPhases[name] = phase
 		}
-		if value.ms > 0 {
+		if value.measured {
 			phase.values = append(phase.values, value.ms)
 		}
 		if value.skipped {

--- a/internal/cli/bench.go
+++ b/internal/cli/bench.go
@@ -60,22 +60,44 @@ type benchmarkReportFilters struct {
 }
 
 type benchmarkReportGroup struct {
-	Provider             string `json:"provider"`
-	ProviderFamily       string `json:"providerFamily,omitempty"`
-	ProviderKind         string `json:"providerKind,omitempty"`
-	ProviderCategory     string `json:"providerCategory,omitempty"`
-	MachineType          string `json:"machineType,omitempty"`
-	CommandFingerprint   string `json:"commandFingerprint,omitempty"`
-	ColdRun              *bool  `json:"coldRun,omitempty"`
-	N                    int    `json:"n"`
-	ObservationCount     int    `json:"observationCount"`
-	FailureCount         int    `json:"failureCount"`
-	MedianTotalMs        *int64 `json:"medianTotalMs,omitempty"`
-	P95TotalMs           *int64 `json:"p95TotalMs,omitempty"`
-	MedianSyncMs         *int64 `json:"medianSyncMs,omitempty"`
-	MedianCommandMs      *int64 `json:"medianCommandMs,omitempty"`
-	InsufficientEvidence bool   `json:"insufficientEvidence"`
-	Evidence             string `json:"evidence"`
+	Source               string                        `json:"source"`
+	Provider             string                        `json:"provider"`
+	ProviderFamily       string                        `json:"providerFamily,omitempty"`
+	ProviderKind         string                        `json:"providerKind,omitempty"`
+	ProviderCategory     string                        `json:"providerCategory,omitempty"`
+	MachineType          string                        `json:"machineType,omitempty"`
+	CommandFingerprint   string                        `json:"commandFingerprint,omitempty"`
+	ColdRun              *bool                         `json:"coldRun,omitempty"`
+	N                    int                           `json:"n"`
+	ObservationCount     int                           `json:"observationCount"`
+	FailureCount         int                           `json:"failureCount"`
+	MedianTotalMs        *int64                        `json:"medianTotalMs,omitempty"`
+	P95TotalMs           *int64                        `json:"p95TotalMs,omitempty"`
+	MedianRunnerTotalMs  *int64                        `json:"medianRunnerTotalMs,omitempty"`
+	P95RunnerTotalMs     *int64                        `json:"p95RunnerTotalMs,omitempty"`
+	MedianSyncMs         *int64                        `json:"medianSyncMs,omitempty"`
+	MedianCommandMs      *int64                        `json:"medianCommandMs,omitempty"`
+	RunnerPhases         []benchmarkRunnerPhaseSummary `json:"runnerPhases,omitempty"`
+	SyncPhases           []benchmarkSyncPhaseSummary   `json:"syncPhases,omitempty"`
+	SyncSkippedCount     int                           `json:"syncSkippedCount,omitempty"`
+	InsufficientEvidence bool                          `json:"insufficientEvidence"`
+	Evidence             string                        `json:"evidence"`
+}
+
+type benchmarkRunnerPhaseSummary struct {
+	Name     string `json:"name"`
+	Opaque   bool   `json:"opaque,omitempty"`
+	N        int    `json:"n"`
+	MedianMs *int64 `json:"medianMs,omitempty"`
+	P95Ms    *int64 `json:"p95Ms,omitempty"`
+}
+
+type benchmarkSyncPhaseSummary struct {
+	Name         string `json:"name"`
+	N            int    `json:"n"`
+	MedianMs     *int64 `json:"medianMs,omitempty"`
+	P95Ms        *int64 `json:"p95Ms,omitempty"`
+	SkippedCount int    `json:"skippedCount,omitempty"`
 }
 
 type benchmarkReportOptions struct {
@@ -485,6 +507,7 @@ func buildBenchmarkReport(records []BenchmarkTimingRecord, opts benchmarkReportO
 		builder := groups[key]
 		if builder == nil {
 			group := benchmarkReportGroup{
+				Source:             benchmarkRecordSource(record.Source),
 				Provider:           record.Timing.Provider,
 				ProviderFamily:     record.Benchmark.ProviderFamily,
 				ProviderKind:       record.Benchmark.ProviderKind,
@@ -542,10 +565,23 @@ func buildBenchmarkReport(records []BenchmarkTimingRecord, opts benchmarkReportO
 }
 
 type benchmarkReportGroupBuilder struct {
-	group     benchmarkReportGroup
-	totalMs   []int64
-	syncMs    []int64
-	commandMs []int64
+	group         benchmarkReportGroup
+	totalMs       []int64
+	runnerTotalMs []int64
+	syncMs        []int64
+	commandMs     []int64
+	runnerPhases  map[benchmarkRunnerPhaseKey][]int64
+	syncPhases    map[string]*benchmarkSyncPhaseBuilder
+}
+
+type benchmarkRunnerPhaseKey struct {
+	Name   string
+	Opaque bool
+}
+
+type benchmarkSyncPhaseBuilder struct {
+	values       []int64
+	skippedCount int
 }
 
 func (b *benchmarkReportGroupBuilder) add(record BenchmarkTimingRecord) {
@@ -556,18 +592,91 @@ func (b *benchmarkReportGroupBuilder) add(record BenchmarkTimingRecord) {
 	}
 	b.group.N++
 	b.totalMs = append(b.totalMs, record.Timing.TotalMs)
+	if record.Timing.RunnerTotalMs > 0 {
+		b.runnerTotalMs = append(b.runnerTotalMs, record.Timing.RunnerTotalMs)
+	}
 	b.syncMs = append(b.syncMs, record.Timing.SyncMs)
 	b.commandMs = append(b.commandMs, record.Timing.CommandMs)
+	if record.Timing.SyncSkipped {
+		b.group.SyncSkippedCount++
+	}
+	b.addRunnerPhases(record.Timing.RunnerPhases)
+	b.addSyncPhases(record.Timing.SyncPhases)
+}
+
+func (b *benchmarkReportGroupBuilder) addRunnerPhases(phases []RunnerPhase) {
+	perObservation := map[benchmarkRunnerPhaseKey]int64{}
+	for _, phase := range phases {
+		name := strings.TrimSpace(phase.Name)
+		if name == "" || phase.Ms <= 0 {
+			continue
+		}
+		perObservation[benchmarkRunnerPhaseKey{Name: name, Opaque: phase.Opaque}] += phase.Ms
+	}
+	if len(perObservation) == 0 {
+		return
+	}
+	if b.runnerPhases == nil {
+		b.runnerPhases = map[benchmarkRunnerPhaseKey][]int64{}
+	}
+	for key, value := range perObservation {
+		b.runnerPhases[key] = append(b.runnerPhases[key], value)
+	}
+}
+
+func (b *benchmarkReportGroupBuilder) addSyncPhases(phases []TimingPhase) {
+	type observationPhase struct {
+		ms      int64
+		skipped bool
+	}
+	perObservation := map[string]observationPhase{}
+	for _, phase := range phases {
+		name := strings.TrimSpace(phase.Name)
+		if name == "" {
+			continue
+		}
+		value := perObservation[name]
+		if phase.Ms > 0 {
+			value.ms += phase.Ms
+		}
+		value.skipped = value.skipped || phase.Skipped
+		perObservation[name] = value
+	}
+	if len(perObservation) == 0 {
+		return
+	}
+	if b.syncPhases == nil {
+		b.syncPhases = map[string]*benchmarkSyncPhaseBuilder{}
+	}
+	for name, value := range perObservation {
+		phase := b.syncPhases[name]
+		if phase == nil {
+			phase = &benchmarkSyncPhaseBuilder{}
+			b.syncPhases[name] = phase
+		}
+		if value.ms > 0 {
+			phase.values = append(phase.values, value.ms)
+		}
+		if value.skipped {
+			phase.skippedCount++
+		}
+	}
 }
 
 func (b *benchmarkReportGroupBuilder) finish(minSamples int) benchmarkReportGroup {
 	group := b.group
 	group.MedianTotalMs = medianInt64(b.totalMs)
+	group.MedianRunnerTotalMs = medianInt64(b.runnerTotalMs)
 	group.MedianSyncMs = medianInt64(b.syncMs)
 	group.MedianCommandMs = medianInt64(b.commandMs)
 	if group.N >= 3 {
 		group.P95TotalMs = percentileNearestRankInt64(b.totalMs, 0.95)
 	}
+	if len(b.runnerTotalMs) >= 3 {
+		group.P95RunnerTotalMs = percentileNearestRankInt64(b.runnerTotalMs, 0.95)
+	}
+	group.RunnerPhases = finishBenchmarkRunnerPhases(b.runnerPhases)
+	group.SyncPhases = finishBenchmarkSyncPhases(b.syncPhases)
 	group.InsufficientEvidence = group.N < minSamples
 	if group.N == 0 {
 		group.Evidence = fmt.Sprintf("insufficient_successful_samples need=%d", minSamples)
@@ -577,6 +686,57 @@ func (b *benchmarkReportGroupBuilder) finish(minSamples int) benchmarkReportGrou
 		group.Evidence = "sufficient_local_samples"
 	}
 	return group
+}
+
+func finishBenchmarkRunnerPhases(phases map[benchmarkRunnerPhaseKey][]int64) []benchmarkRunnerPhaseSummary {
+	keys := make([]benchmarkRunnerPhaseKey, 0, len(phases))
+	for key := range phases {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Name != keys[j].Name {
+			return keys[i].Name < keys[j].Name
+		}
+		return !keys[i].Opaque && keys[j].Opaque
+	})
+	out := make([]benchmarkRunnerPhaseSummary, 0, len(keys))
+	for _, key := range keys {
+		values := phases[key]
+		summary := benchmarkRunnerPhaseSummary{
+			Name:     key.Name,
+			Opaque:   key.Opaque,
+			N:        len(values),
+			MedianMs: medianInt64(values),
+		}
+		if len(values) >= 3 {
+			summary.P95Ms = percentileNearestRankInt64(values, 0.95)
+		}
+		out = append(out, summary)
+	}
+	return out
+}
+
+func finishBenchmarkSyncPhases(phases map[string]*benchmarkSyncPhaseBuilder) []benchmarkSyncPhaseSummary {
+	names := make([]string, 0, len(phases))
+	for name := range phases {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]benchmarkSyncPhaseSummary, 0, len(names))
+	for _, name := range names {
+		phase := phases[name]
+		summary := benchmarkSyncPhaseSummary{
+			Name:         name,
+			N:            len(phase.values),
+			MedianMs:     medianInt64(phase.values),
+			SkippedCount: phase.skippedCount,
+		}
+		if len(phase.values) >= 3 {
+			summary.P95Ms = percentileNearestRankInt64(phase.values, 0.95)
+		}
+		out = append(out, summary)
+	}
+	return out
 }
 
 func benchmarkRecordMatches(record BenchmarkTimingRecord, opts benchmarkReportOptions) bool {
@@ -598,6 +758,7 @@ func benchmarkGroupKeyForRecord(record BenchmarkTimingRecord) string {
 		cold = strconv.FormatBool(*record.Benchmark.ColdRun)
 	}
 	parts := []string{
+		benchmarkRecordSource(record.Source),
 		normalizeProviderName(record.Timing.Provider),
 		record.Benchmark.ProviderFamily,
 		record.Benchmark.ProviderCategory,
@@ -607,6 +768,10 @@ func benchmarkGroupKeyForRecord(record BenchmarkTimingRecord) string {
 		cold,
 	}
 	return strings.Join(parts, "\x00")
+}
+
+func benchmarkRecordSource(source string) string {
+	return firstNonBlank(strings.TrimSpace(source), "unknown")
 }
 
 func printBenchmarkReport(w io.Writer, report benchmarkReport) {
@@ -620,8 +785,9 @@ func printBenchmarkReport(w io.Writer, report benchmarkReport) {
 	}
 	fmt.Fprintf(w, "benchmark report store=%s observations=%d matched=%d min_samples=%d\n", report.StorePath, report.ObservationCount, report.MatchedCount, report.Filters.MinSamples)
 	for _, group := range report.Groups {
-		fmt.Fprintf(w, "%s family=%s kind=%s machine=%s command=%s cold=%s n=%d median_total=%s p95_total=%s median_sync=%s median_command=%s failures=%d evidence=%s\n",
+		fmt.Fprintf(w, "%s source=%s family=%s kind=%s machine=%s command=%s cold=%s n=%d median_total=%s p95_total=%s median_runner_total=%s p95_runner_total=%s median_sync=%s median_command=%s sync_skipped=%d failures=%d evidence=%s\n",
 			group.Provider,
+			group.Source,
 			blank(group.ProviderFamily, "-"),
 			blank(group.ProviderKind, "-"),
 			blank(group.MachineType, "-"),
@@ -630,11 +796,22 @@ func printBenchmarkReport(w io.Writer, report benchmarkReport) {
 			group.N,
 			formatBenchmarkMs(group.MedianTotalMs),
 			formatBenchmarkMs(group.P95TotalMs),
+			formatBenchmarkMs(group.MedianRunnerTotalMs),
+			formatBenchmarkMs(group.P95RunnerTotalMs),
 			formatBenchmarkMs(group.MedianSyncMs),
 			formatBenchmarkMs(group.MedianCommandMs),
+			group.SyncSkippedCount,
 			group.FailureCount,
 			group.Evidence,
 		)
+		for _, phase := range group.RunnerPhases {
+			fmt.Fprintf(w, "  runner_phase name=%s opaque=%t n=%d median=%s p95=%s\n",
+				phase.Name, phase.Opaque, phase.N, formatBenchmarkMs(phase.MedianMs), formatBenchmarkMs(phase.P95Ms))
+		}
+		for _, phase := range group.SyncPhases {
+			fmt.Fprintf(w, "  sync_phase name=%s n=%d median=%s p95=%s skipped=%d\n",
+				phase.Name, phase.N, formatBenchmarkMs(phase.MedianMs), formatBenchmarkMs(phase.P95Ms), phase.SkippedCount)
+		}
 	}
 }
 

--- a/internal/cli/bench_test.go
+++ b/internal/cli/bench_test.go
@@ -526,6 +526,220 @@ func TestBenchmarkReportAggregatesAndMarksInsufficientEvidence(t *testing.T) {
 	}
 }
 
+func TestBenchmarkReportAggregatesRunnerAndSyncPhasesPerSuccessfulObservation(t *testing.T) {
+	now := time.Date(2026, 9, 6, 10, 0, 0, 0, time.UTC)
+	command := []string{"go", "test", "./..."}
+	records := []BenchmarkTimingRecord{
+		newBenchmarkTimingRecord(now.Add(-4*time.Minute), "bench-run", TimingReport{
+			Provider:      "aws",
+			RunnerTotalMs: 1000,
+			RunnerPhases: []RunnerPhase{
+				{Name: "workspace.sync", Ms: 100},
+				{Name: "workspace.sync", Ms: 50},
+				{Name: "provider.wait", Ms: 200, Opaque: true},
+			},
+			SyncMs:    50,
+			CommandMs: 700,
+			TotalMs:   900,
+			SyncPhases: []TimingPhase{
+				{Name: "archive", Ms: 40},
+				{Name: "archive", Ms: 10},
+				{Name: "git_hydrate", Skipped: true},
+			},
+			SyncSkipped: true,
+			ExitCode:    0,
+		}, Repo{Name: "my-app"}, command, nil, 1),
+		newBenchmarkTimingRecord(now.Add(-3*time.Minute), "bench-run", TimingReport{
+			Provider:      "aws",
+			RunnerTotalMs: 1100,
+			RunnerPhases: []RunnerPhase{
+				{Name: "workspace.sync", Ms: 75},
+				{Name: "provider.wait", Ms: 250, Opaque: true},
+			},
+			SyncMs:    60,
+			CommandMs: 750,
+			TotalMs:   950,
+			SyncPhases: []TimingPhase{
+				{Name: "archive", Ms: 60},
+				{Name: "git_hydrate", Skipped: true},
+			},
+			ExitCode: 0,
+		}, Repo{Name: "my-app"}, command, nil, 2),
+		newBenchmarkTimingRecord(now.Add(-2*time.Minute), "bench-run", TimingReport{
+			Provider:      "aws",
+			RunnerTotalMs: 1200,
+			RunnerPhases: []RunnerPhase{
+				{Name: "workspace.sync", Ms: 100},
+				{Name: "provider.wait", Ms: 25},
+				{Name: "provider.wait", Ms: 300, Opaque: true},
+			},
+			SyncMs:    70,
+			CommandMs: 800,
+			TotalMs:   1000,
+			SyncPhases: []TimingPhase{
+				{Name: "archive", Ms: 70},
+			},
+			ExitCode: 0,
+		}, Repo{Name: "my-app"}, command, nil, 3),
+		newBenchmarkTimingRecord(now.Add(-time.Minute), "bench-run", TimingReport{
+			Provider:      "aws",
+			RunnerTotalMs: 9999,
+			RunnerPhases:  []RunnerPhase{{Name: "workspace.sync", Ms: 9999}},
+			SyncMs:        9999,
+			CommandMs:     9999,
+			TotalMs:       9999,
+			SyncPhases:    []TimingPhase{{Name: "archive", Ms: 9999}},
+			SyncSkipped:   true,
+			ExitCode:      1,
+		}, Repo{Name: "my-app"}, command, nil, 4),
+	}
+
+	report := buildBenchmarkReport(records, benchmarkReportOptions{StorePath: "timings.jsonl", MinSamples: 2}, now)
+	if len(report.Groups) != 1 {
+		t.Fatalf("groups=%d want 1: %#v", len(report.Groups), report.Groups)
+	}
+	group := report.Groups[0]
+	if group.Source != "bench-run" || group.N != 3 || group.FailureCount != 1 {
+		t.Fatalf("source/counts=%q/%d/%d", group.Source, group.N, group.FailureCount)
+	}
+	if group.MedianRunnerTotalMs == nil || *group.MedianRunnerTotalMs != 1100 {
+		t.Fatalf("median runner total=%v", group.MedianRunnerTotalMs)
+	}
+	if group.P95RunnerTotalMs == nil || *group.P95RunnerTotalMs != 1200 {
+		t.Fatalf("p95 runner total=%v", group.P95RunnerTotalMs)
+	}
+	if group.SyncSkippedCount != 1 {
+		t.Fatalf("sync skipped=%d want 1", group.SyncSkippedCount)
+	}
+
+	if len(group.RunnerPhases) != 3 {
+		t.Fatalf("runner phases=%#v", group.RunnerPhases)
+	}
+	assertBenchmarkRunnerPhase(t, group.RunnerPhases[0], "provider.wait", false, 1, 25, nil)
+	p95 := int64(300)
+	assertBenchmarkRunnerPhase(t, group.RunnerPhases[1], "provider.wait", true, 3, 250, &p95)
+	p95 = 150
+	assertBenchmarkRunnerPhase(t, group.RunnerPhases[2], "workspace.sync", false, 3, 100, &p95)
+
+	if len(group.SyncPhases) != 2 {
+		t.Fatalf("sync phases=%#v", group.SyncPhases)
+	}
+	p95 = 70
+	assertBenchmarkSyncPhase(t, group.SyncPhases[0], "archive", 3, 60, &p95, 0)
+	assertBenchmarkSyncPhase(t, group.SyncPhases[1], "git_hydrate", 0, 0, nil, 2)
+}
+
+func TestBenchmarkReportGroupsBySourceAndKeepsLegacyTelemetryAbsent(t *testing.T) {
+	now := time.Date(2026, 9, 6, 10, 0, 0, 0, time.UTC)
+	command := []string{"true"}
+	records := []BenchmarkTimingRecord{
+		newBenchmarkTimingRecord(now.Add(-3*time.Minute), "run", TimingReport{Provider: "aws", TotalMs: 100, ExitCode: 0}, Repo{}, command, nil, 0),
+		{
+			SchemaVersion: benchmarkTimingSchemaVersion,
+			RecordedAt:    now.Add(-2 * time.Minute),
+			Source:        "",
+			Benchmark:     BenchmarkRecordContext{CommandFingerprint: benchmarkCommandFingerprint(command)},
+			Timing:        TimingReport{Provider: "aws", TotalMs: 200, ExitCode: 0},
+		},
+		{
+			SchemaVersion: benchmarkTimingSchemaVersion,
+			RecordedAt:    now.Add(-time.Minute),
+			Source:        " ",
+			Benchmark:     BenchmarkRecordContext{CommandFingerprint: benchmarkCommandFingerprint(command)},
+			Timing:        TimingReport{Provider: "aws", TotalMs: 300, ExitCode: 0},
+		},
+	}
+
+	report := buildBenchmarkReport(records, benchmarkReportOptions{StorePath: "timings.jsonl", MinSamples: 1}, now)
+	if len(report.Groups) != 2 {
+		t.Fatalf("groups=%d want 2: %#v", len(report.Groups), report.Groups)
+	}
+	if report.Groups[0].Source != "run" || report.Groups[1].Source != "unknown" {
+		t.Fatalf("sources=%q/%q", report.Groups[0].Source, report.Groups[1].Source)
+	}
+	legacy := report.Groups[1]
+	if legacy.N != 2 || legacy.MedianRunnerTotalMs != nil || legacy.P95RunnerTotalMs != nil || len(legacy.RunnerPhases) != 0 || len(legacy.SyncPhases) != 0 {
+		t.Fatalf("legacy group=%#v", legacy)
+	}
+	body, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"medianRunnerTotalMs", "p95RunnerTotalMs", "runnerPhases", "syncPhases", "syncSkippedCount"} {
+		if bytes.Contains(body, []byte(`"`+field+`"`)) {
+			t.Fatalf("legacy JSON unexpectedly contains %s: %s", field, body)
+		}
+	}
+}
+
+func TestPrintBenchmarkReportIncludesStructuredRunnerAndSyncSummaries(t *testing.T) {
+	median := int64(100)
+	p95 := int64(150)
+	report := benchmarkReport{
+		StorePath:        "timings.jsonl",
+		ObservationCount: 3,
+		MatchedCount:     3,
+		Filters:          benchmarkReportFilters{MinSamples: 2},
+		Groups: []benchmarkReportGroup{{
+			Source:              "bench-run",
+			Provider:            "aws",
+			N:                   3,
+			MedianRunnerTotalMs: &median,
+			P95RunnerTotalMs:    &p95,
+			RunnerPhases: []benchmarkRunnerPhaseSummary{{
+				Name: "provider.wait", Opaque: true, N: 3, MedianMs: &median, P95Ms: &p95,
+			}},
+			SyncPhases: []benchmarkSyncPhaseSummary{{
+				Name: "archive", N: 3, MedianMs: &median, P95Ms: &p95, SkippedCount: 1,
+			}},
+			SyncSkippedCount: 2,
+			Evidence:         "sufficient_local_samples",
+		}},
+	}
+	var out bytes.Buffer
+	printBenchmarkReport(&out, report)
+	text := out.String()
+	for _, want := range []string{
+		"aws source=bench-run",
+		"median_runner_total=100ms p95_runner_total=150ms",
+		"sync_skipped=2 failures=0",
+		"runner_phase name=provider.wait opaque=true n=3 median=100ms p95=150ms",
+		"sync_phase name=archive n=3 median=100ms p95=150ms skipped=1",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func assertBenchmarkRunnerPhase(t *testing.T, got benchmarkRunnerPhaseSummary, name string, opaque bool, n int, median int64, p95 *int64) {
+	t.Helper()
+	if got.Name != name || got.Opaque != opaque || got.N != n || got.MedianMs == nil || *got.MedianMs != median || !equalOptionalInt64(got.P95Ms, p95) {
+		t.Fatalf("runner phase=%#v want name=%q opaque=%t n=%d median=%d p95=%v", got, name, opaque, n, median, p95)
+	}
+}
+
+func assertBenchmarkSyncPhase(t *testing.T, got benchmarkSyncPhaseSummary, name string, n int, median int64, p95 *int64, skipped int) {
+	t.Helper()
+	if got.Name != name || got.N != n || got.SkippedCount != skipped || !equalOptionalInt64(got.P95Ms, p95) {
+		t.Fatalf("sync phase=%#v want name=%q n=%d median=%d p95=%v skipped=%d", got, name, n, median, p95, skipped)
+	}
+	if n == 0 {
+		if got.MedianMs != nil {
+			t.Fatalf("sync phase median=%v want nil", got.MedianMs)
+		}
+	} else if got.MedianMs == nil || *got.MedianMs != median {
+		t.Fatalf("sync phase median=%v want %d", got.MedianMs, median)
+	}
+}
+
+func equalOptionalInt64(got, want *int64) bool {
+	if got == nil || want == nil {
+		return got == nil && want == nil
+	}
+	return *got == *want
+}
+
 func TestBenchReportJSONFiltersStoreRows(t *testing.T) {
 	dir := t.TempDir()
 	storePath := filepath.Join(dir, "timings.jsonl")

--- a/internal/cli/bench_test.go
+++ b/internal/cli/bench_test.go
@@ -672,6 +672,36 @@ func TestBenchmarkReportGroupsBySourceAndKeepsLegacyTelemetryAbsent(t *testing.T
 	}
 }
 
+func TestBenchmarkReportRetainsCompletedZeroDurationSyncPhases(t *testing.T) {
+	now := time.Date(2026, 9, 6, 10, 0, 0, 0, time.UTC)
+	command := []string{"true"}
+	records := []BenchmarkTimingRecord{
+		newBenchmarkTimingRecord(now.Add(-3*time.Minute), "bench-run", TimingReport{
+			Provider:   "aws",
+			TotalMs:    100,
+			SyncPhases: []TimingPhase{{Name: "fingerprint"}, {Name: "fingerprint"}, {Name: "git_hydrate", Skipped: true}},
+		}, Repo{}, command, nil, 1),
+		newBenchmarkTimingRecord(now.Add(-2*time.Minute), "bench-run", TimingReport{
+			Provider:   "aws",
+			TotalMs:    100,
+			SyncPhases: []TimingPhase{{Name: "fingerprint"}, {Name: "fingerprint", Skipped: true}, {Name: "git_hydrate", Skipped: true}, {Name: "git_hydrate", Skipped: true}},
+		}, Repo{}, command, nil, 2),
+		newBenchmarkTimingRecord(now.Add(-time.Minute), "bench-run", TimingReport{
+			Provider:   "aws",
+			TotalMs:    100,
+			SyncPhases: []TimingPhase{{Name: "fingerprint", Ms: 4}, {Name: "fingerprint", Ms: 6}, {Name: "git_hydrate", Skipped: true}},
+		}, Repo{}, command, nil, 3),
+	}
+
+	report := buildBenchmarkReport(records, benchmarkReportOptions{StorePath: "timings.jsonl", MinSamples: 1}, now)
+	if len(report.Groups) != 1 || len(report.Groups[0].SyncPhases) != 2 {
+		t.Fatalf("groups=%#v", report.Groups)
+	}
+	p95 := int64(10)
+	assertBenchmarkSyncPhase(t, report.Groups[0].SyncPhases[0], "fingerprint", 3, 0, &p95, 1)
+	assertBenchmarkSyncPhase(t, report.Groups[0].SyncPhases[1], "git_hydrate", 0, 0, nil, 3)
+}
+
 func TestPrintBenchmarkReportIncludesStructuredRunnerAndSyncSummaries(t *testing.T) {
 	median := int64(100)
 	p95 := int64(150)


### PR DESCRIPTION
Related: https://github.com/openclaw/crabbox/issues/342

## What Problem This Solves

Resolves a problem where local benchmark reports discarded runner wall-time and phase telemetry, and combined observations from different record sources into one group. That made image, warm-pool, and sync comparisons less diagnostic even when the timing ledger already contained the needed evidence.

## Why This Change Was Made

Benchmark reports now group by normalized record source and summarize runner totals, runner phases, sync phases, and sync skips from successful observations. Duplicate phase names are summed once per observation, opaque runner phases retain distinct identities, failed rows only affect failure counts, and legacy rows do not gain invented telemetry.

Completed zero-millisecond sync phases are tracked as measured samples independently from their duration. Skip-only phases remain outside duration distributions.

## User Impact

Users and agents can compare where successful runner time was spent using the existing human or JSON benchmark report. P95 values remain absent until a metric has at least three samples, and old timing records remain readable without synthetic runner or phase fields.

## Evidence

- `go test -race -timeout=20m ./internal/cli -run 'TestBench|TestBenchmark|TestPrintBenchmark|TestRunDelegated'`
- `TestBenchmarkReportRetainsCompletedZeroDurationSyncPhases` proves completed `0, 0, 10` ms observations produce `n=3`, median `0`, and p95 `10`; duplicate names contribute one sample and skip-only entries contribute none.
- `go vet ./internal/cli`
- `node scripts/check-command-docs.mjs`
- `node scripts/check-docs-links.mjs`
- `git diff --check`
- Project autoreview after the review fixes: scoped-clean, no accepted or actionable findings.

No configuration, credential, provider, worker, or timing-store schema changes.
