### PR TITLE
feat(images): define developer image recipe contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Define a strict provider-neutral Linux developer-image recipe whose digest binds the executable contract and exact installer/readiness source hashes.
 - Extract protected image-qualification candidates at the canonical artifact path and avoid protected finalization when deployment never started.
 - Stop SSH readiness promptly on host-key rejection, including WSL SFTP and split or oversized diagnostics, without changing host trust. [PR 1877](https://github.com/openclaw/crabbox/pull/1877). Thanks @shunkakinoki.
 - Apple Machine: fail runs when automatic deletion fails or remains unconfirmed, retain recovery sessions for early keep-on-failure errors, and preserve command outcomes while distinguishing native transport failures through the shared error handlers. [PR 1914](https://github.com/openclaw/crabbox/pull/1914).

--- a/recipes/devtools/v1/linux-x86_64.json
+++ b/recipes/devtools/v1/linux-x86_64.json
@@ -1,0 +1,23 @@
+{
+  "schema": "crabbox-devtools-image-recipe/v1",
+  "id": "linux-x86_64",
+  "platform": {
+    "os": "linux",
+    "architecture": "x86_64"
+  },
+  "execution": {
+    "command": "bash",
+    "arguments": ["scripts/install-linux-developer-tools.sh"],
+    "environment": {}
+  },
+  "inputs": [
+    {
+      "path": "scripts/install-linux-developer-tools.sh",
+      "sha256": "sha256:45bc70edfb4cd8e2aaf69bb562f2edde0f1a00dbcfeb2760bdba0627c5e1e86e"
+    },
+    {
+      "path": "scripts/linux-readiness.generated.sh",
+      "sha256": "sha256:d2f50feed717c99d2405165d25a37dc3c3aa19daabf1c0c1304ffd9e361ca56d"
+    }
+  ]
+}

--- a/recipes/devtools/v1/recipe.schema.json
+++ b/recipes/devtools/v1/recipe.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://crabbox.sh/schemas/devtools-image-recipe-v1.json",
+  "title": "Developer image recipe",
+  "description": "Provider-neutral executable inputs for a reproducible developer image",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "id", "platform", "execution", "inputs"],
+  "properties": {
+    "schema": { "const": "crabbox-devtools-image-recipe/v1" },
+    "id": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9_]+)*$" },
+    "platform": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["os", "architecture"],
+      "properties": {
+        "os": { "enum": ["linux"] },
+        "architecture": { "enum": ["x86_64"] }
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command", "arguments", "environment"],
+      "properties": {
+        "command": { "const": "bash" },
+        "arguments": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[A-Za-z0-9_./-]+$" }
+        },
+        "environment": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [],
+          "properties": {}
+        }
+      }
+    },
+    "inputs": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "sha256"],
+        "properties": {
+          "path": { "type": "string", "pattern": "^[A-Za-z0-9_./-]+$" },
+          "sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+        }
+      }
+    }
+  }
+}

--- a/scripts/devtools-image-contract.mjs
+++ b/scripts/devtools-image-contract.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { realpathSync } from "node:fs";
+import { lstat, readFile, realpath } from "node:fs/promises";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  canonicalJSON,
+  parseStrictJSON,
+  validateJSONSchema,
+} from "./generate-linux-readiness.mjs";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(scriptPath), "..");
+export const devtoolsRecipeSchema = "crabbox-devtools-image-recipe/v1";
+export const defaultRecipePath = "recipes/devtools/v1/linux-x86_64.json";
+const schemaPath = "recipes/devtools/v1/recipe.schema.json";
+const requiredInputs = [
+  "scripts/install-linux-developer-tools.sh",
+  "scripts/linux-readiness.generated.sh",
+];
+const recipeKeys = ["execution", "id", "inputs", "platform", "schema"];
+const platformKeys = ["architecture", "os"];
+const executionKeys = ["arguments", "command", "environment"];
+const inputKeys = ["path", "sha256"];
+const allowedSchemaKeys = new Set([
+  "$schema", "$id", "title", "description", "type", "additionalProperties",
+  "required", "properties", "const", "enum", "minItems", "uniqueItems", "items",
+  "pattern",
+]);
+const forbiddenKey = /(?:^|_)(?:account|credential|image|instance|location|password|privatekey|project|provider|region|secret|snapshot|subscription|token|zone)(?:id|type)?(?:$|_)/iu;
+const forbiddenString = [
+  { name: "URL", pattern: /\b[a-z][a-z0-9+.-]*:\/\//iu },
+  { name: "provider resource ID", pattern: /\b(?:ami|snap)-[0-9a-f]{8,17}\b|\/subscriptions\/|projects\/[^/]+\/(?:global|regions|zones)\//iu },
+  { name: "region", pattern: /\b(?:af|ap|ca|eu|il|me|sa|us)-(?:gov-)?[a-z]+-\d\b|\b(?:africa|asia|australia|europe|me|northamerica|southamerica|us)-(?:central|east|west|north|south)\d\b/iu },
+  { name: "instance type", pattern: /\b[a-z][a-z0-9-]*\.(?:metal|micro|small|medium|large|[0-9]+xlarge)\b/iu },
+  { name: "credential", pattern: /\b(?:api[ _-]?key|credential|password|private[ _-]?key|secret|token)\b/iu },
+];
+
+function assertExactKeys(value, expected, context) {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) {
+    throw new Error(`${context} must contain exactly: ${wanted.join(", ")}`);
+  }
+}
+
+function assertRequired(schema, keys, context) {
+  if (canonicalJSON([...(schema.required ?? [])].sort()) !== canonicalJSON([...keys].sort())) {
+    throw new Error(`${context} must require every contract field`);
+  }
+}
+
+function assertSchemaNode(schema, keys, context) {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    throw new Error(`${context} must be an object`);
+  }
+  for (const key of Object.keys(schema)) {
+    if (!allowedSchemaKeys.has(key)) throw new Error(`${context} uses unsupported schema keyword ${key}`);
+  }
+  if (schema.type !== "object" || schema.additionalProperties !== false) {
+    throw new Error(`${context} must reject unknown object fields`);
+  }
+  assertExactKeys(schema.properties ?? {}, keys, `${context} properties`);
+  assertRequired(schema, keys, context);
+}
+
+export function validateRecipeSchemaDefinition(schema) {
+  assertSchemaNode(schema, recipeKeys, "recipe schema");
+  if (schema.$schema !== "https://json-schema.org/draft/2020-12/schema") {
+    throw new Error("recipe schema must declare JSON Schema draft 2020-12");
+  }
+  if (schema.properties.schema?.const !== devtoolsRecipeSchema) {
+    throw new Error("recipe schema has an invalid contract version");
+  }
+  if (schema.properties.id?.pattern !== "^[a-z0-9]+(?:-[a-z0-9_]+)*$") {
+    throw new Error("recipe schema has an invalid recipe ID contract");
+  }
+  assertSchemaNode(schema.properties.platform, platformKeys, "platform schema");
+  if (canonicalJSON(schema.properties.platform.properties.os?.enum) !== '["linux"]' ||
+      canonicalJSON(schema.properties.platform.properties.architecture?.enum) !== '["x86_64"]') {
+    throw new Error("platform schema has unsupported targets");
+  }
+  assertSchemaNode(schema.properties.execution, executionKeys, "execution schema");
+  if (schema.properties.execution.properties.command?.const !== "bash") {
+    throw new Error("execution schema must require bash");
+  }
+  const argumentsSchema = schema.properties.execution.properties.arguments;
+  if (argumentsSchema?.type !== "array" || argumentsSchema.minItems !== 1 ||
+      argumentsSchema.uniqueItems !== true || argumentsSchema.items?.type !== "string") {
+    throw new Error("execution schema has an invalid arguments contract");
+  }
+  assertSchemaNode(schema.properties.execution.properties.environment, [], "environment schema");
+  const inputsSchema = schema.properties.inputs;
+  if (inputsSchema?.type !== "array" || inputsSchema.minItems !== 1 ||
+      inputsSchema.uniqueItems !== true) {
+    throw new Error("recipe schema has an invalid inputs contract");
+  }
+  assertSchemaNode(inputsSchema.items, inputKeys, "input schema");
+  if (inputsSchema.items.properties.sha256?.pattern !== "^sha256:[0-9a-f]{64}$") {
+    throw new Error("input schema must require a lowercase SHA-256 digest");
+  }
+}
+
+export function assertProviderNeutral(value, context = "recipe") {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertProviderNeutral(item, `${context}[${index}]`));
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, item] of Object.entries(value)) {
+      if (forbiddenKey.test(key)) throw new Error(`${context}.${key} is provider-specific or credential-bearing`);
+      assertProviderNeutral(item, `${context}.${key}`);
+    }
+    return;
+  }
+  if (typeof value !== "string") return;
+  for (const forbidden of forbiddenString) {
+    if (forbidden.pattern.test(value)) throw new Error(`${context} contains a forbidden ${forbidden.name}`);
+  }
+}
+
+function assertRepoRelativePath(path, context) {
+  if (typeof path !== "string" || path.length === 0 || isAbsolute(path) ||
+      path.includes("\\") || path.split("/").some((part) => part === "" || part === "." || part === "..")) {
+    throw new Error(`${context} must be a normalized repository-relative path`);
+  }
+}
+
+async function assertRegularRepoFile(root, path, context) {
+  assertRepoRelativePath(path, context);
+  const rootPath = await realpath(root);
+  let current = rootPath;
+  for (const part of path.split("/")) {
+    current = resolve(current, part);
+    const info = await lstat(current);
+    if (info.isSymbolicLink()) throw new Error(`${context} must not traverse a symlink`);
+  }
+  const info = await lstat(current);
+  if (!info.isFile()) throw new Error(`${context} must identify a regular file`);
+  const actual = await realpath(current);
+  const rel = relative(rootPath, actual);
+  if (rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+    throw new Error(`${context} escapes the repository`);
+  }
+  return actual;
+}
+
+function sha256(bytes) {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+export function recipeDigest(recipe) {
+  return sha256(canonicalJSON({
+    execution: recipe.execution,
+    id: recipe.id,
+    inputs: recipe.inputs,
+    platform: recipe.platform,
+    schema: recipe.schema,
+  }));
+}
+
+export async function assertRecipe(recipe, schema, root = repoRoot) {
+  assertProviderNeutral(recipe);
+  if (Array.isArray(recipe?.inputs)) {
+    for (const input of recipe.inputs) {
+      if (input && typeof input === "object" && !Array.isArray(input) && typeof input.path === "string") {
+        assertRepoRelativePath(input.path, `recipe input ${input.path}`);
+      }
+    }
+  }
+  validateJSONSchema(recipe, schema, "recipe");
+  if (recipe.id !== `${recipe.platform.os}-${recipe.platform.architecture}`) {
+    throw new Error("recipe.id must match its platform");
+  }
+  if (canonicalJSON(recipe.execution.arguments) !== canonicalJSON(["scripts/install-linux-developer-tools.sh"])) {
+    throw new Error("recipe execution must use the reviewed Linux developer-tools entrypoint");
+  }
+  if (Object.keys(recipe.execution.environment).length !== 0) {
+    throw new Error("recipe execution environment must remain empty");
+  }
+  const inputPaths = recipe.inputs.map((input) => input.path);
+  if (inputPaths.some((path, index) => index > 0 && inputPaths[index - 1] >= path)) {
+    throw new Error("recipe inputs must be sorted and unique");
+  }
+  if (canonicalJSON(inputPaths) !== canonicalJSON(requiredInputs)) {
+    throw new Error(`recipe inputs must contain exactly: ${requiredInputs.join(", ")}`);
+  }
+  for (const input of recipe.inputs) {
+    const path = await assertRegularRepoFile(root, input.path, `recipe input ${input.path}`);
+    const actual = sha256(await readFile(path));
+    if (actual !== input.sha256) throw new Error(`recipe input ${input.path} SHA-256 mismatch`);
+  }
+  return recipeDigest(recipe);
+}
+
+export async function loadDevtoolsRecipe(root = repoRoot, recipePath = defaultRecipePath) {
+  const safeSchemaPath = await assertRegularRepoFile(root, schemaPath, "recipe schema path");
+  const safeRecipePath = await assertRegularRepoFile(root, recipePath, "recipe path");
+  const schema = parseStrictJSON(await readFile(safeSchemaPath, "utf8"), schemaPath);
+  validateRecipeSchemaDefinition(schema);
+  const recipe = parseStrictJSON(await readFile(safeRecipePath, "utf8"), recipePath);
+  const digest = await assertRecipe(recipe, schema, root);
+  return { digest, recipe, schema };
+}
+
+export async function main(args = process.argv.slice(2)) {
+  if (args.length > 1 || args.some((argument) => argument !== "--json")) {
+    throw new Error("usage: devtools-image-contract.mjs [--json]");
+  }
+  const { digest, recipe } = await loadDevtoolsRecipe();
+  if (args.includes("--json")) {
+    process.stdout.write(`${canonicalJSON({
+      id: recipe.id,
+      recipeDigest: digest,
+      schema: recipe.schema,
+    })}\n`);
+  } else {
+    process.stdout.write(`${digest}\n`);
+  }
+}
+
+if (process.argv[1] && realpathSync(process.argv[1]) === realpathSync(scriptPath)) {
+  await main();
+}

--- a/scripts/devtools-image-contract.test.mjs
+++ b/scripts/devtools-image-contract.test.mjs
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { cp, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  assertProviderNeutral,
+  assertRecipe,
+  defaultRecipePath,
+  loadDevtoolsRecipe,
+  recipeDigest,
+  validateRecipeSchemaDefinition,
+} from "./devtools-image-contract.mjs";
+import { canonicalJSON, parseStrictJSON } from "./generate-linux-readiness.mjs";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+async function fixture(t) {
+  const root = await mkdtemp(join(tmpdir(), "crabbox-devtools-recipe-"));
+  t.after(async () => rm(root, { force: true, recursive: true }));
+  await mkdir(join(root, "recipes/devtools/v1"), { recursive: true });
+  await mkdir(join(root, "scripts"), { recursive: true });
+  for (const path of [
+    "recipes/devtools/v1/recipe.schema.json",
+    defaultRecipePath,
+    "scripts/install-linux-developer-tools.sh",
+    "scripts/linux-readiness.generated.sh",
+  ]) {
+    await cp(join(repoRoot, path), join(root, path));
+  }
+  async function recipe() {
+    return parseStrictJSON(await readFile(join(root, defaultRecipePath), "utf8"), defaultRecipePath);
+  }
+  async function schema() {
+    return parseStrictJSON(
+      await readFile(join(root, "recipes/devtools/v1/recipe.schema.json"), "utf8"),
+      "recipe.schema.json",
+    );
+  }
+  async function writeRecipe(value) {
+    await writeFile(join(root, defaultRecipePath), `${JSON.stringify(value, null, 2)}\n`);
+  }
+  return { root, recipe, schema, writeRecipe };
+}
+
+test("repository recipe validates exact inputs and emits a deterministic digest", async () => {
+  const first = await loadDevtoolsRecipe();
+  const second = await loadDevtoolsRecipe();
+  assert.equal(first.digest, second.digest);
+  assert.match(first.digest, /^sha256:[0-9a-f]{64}$/u);
+  assert.equal(first.recipe.id, "linux-x86_64");
+  assert.deepEqual(first.recipe.execution, {
+    command: "bash",
+    arguments: ["scripts/install-linux-developer-tools.sh"],
+    environment: {},
+  });
+  assert.deepEqual(
+    first.recipe.inputs.map((input) => input.path),
+    ["scripts/install-linux-developer-tools.sh", "scripts/linux-readiness.generated.sh"],
+  );
+});
+
+test("recipe digest binds every executable field and input hash but not object key order", async () => {
+  const { recipe } = await loadDevtoolsRecipe();
+  const reordered = {
+    inputs: recipe.inputs.map(({ path, sha256 }) => ({ sha256, path })),
+    execution: {
+      environment: recipe.execution.environment,
+      arguments: recipe.execution.arguments,
+      command: recipe.execution.command,
+    },
+    platform: { architecture: recipe.platform.architecture, os: recipe.platform.os },
+    id: recipe.id,
+    schema: recipe.schema,
+  };
+  assert.equal(recipeDigest(reordered), recipeDigest(recipe));
+  for (const mutate of [
+    (value) => { value.id = "linux-altered"; },
+    (value) => { value.platform.architecture = "arm64"; },
+    (value) => { value.execution.command = "sh"; },
+    (value) => { value.execution.arguments[0] = "scripts/another.sh"; },
+    (value) => { value.execution.environment.MODE = "test"; },
+    (value) => { value.inputs[0].sha256 = `sha256:${"0".repeat(64)}`; },
+    (value) => { value.inputs[1].sha256 = `sha256:${"f".repeat(64)}`; },
+  ]) {
+    const changed = structuredClone(recipe);
+    mutate(changed);
+    assert.notEqual(recipeDigest(changed), recipeDigest(recipe));
+  }
+});
+
+test("strict loading rejects duplicate keys, trailing documents, and unknown fields", async (t) => {
+  const copy = await fixture(t);
+  const recipe = await copy.recipe();
+  await writeFile(
+    join(copy.root, defaultRecipePath),
+    `{"schema":"${recipe.schema}","schema":"${recipe.schema}"}\n`,
+  );
+  await assert.rejects(loadDevtoolsRecipe(copy.root), /duplicate key "schema"/u);
+  await copy.writeRecipe(recipe);
+  await writeFile(join(copy.root, defaultRecipePath), `${JSON.stringify(recipe)}\n{}\n`);
+  await assert.rejects(loadDevtoolsRecipe(copy.root), /trailing JSON content/u);
+  recipe.unexpected = true;
+  await copy.writeRecipe(recipe);
+  await assert.rejects(loadDevtoolsRecipe(copy.root), /recipe\.unexpected is not allowed/u);
+});
+
+test("schema validation rejects drift and unsupported keywords", async (t) => {
+  const copy = await fixture(t);
+  const schema = await copy.schema();
+  validateRecipeSchemaDefinition(schema);
+  const permissive = structuredClone(schema);
+  permissive.additionalProperties = true;
+  assert.throws(() => validateRecipeSchemaDefinition(permissive), /reject unknown object fields/u);
+  const missing = structuredClone(schema);
+  missing.required = missing.required.filter((key) => key !== "inputs");
+  assert.throws(() => validateRecipeSchemaDefinition(missing), /require every contract field/u);
+  const keyword = structuredClone(schema);
+  keyword.oneOf = [];
+  assert.throws(() => validateRecipeSchemaDefinition(keyword), /unsupported schema keyword oneOf/u);
+  const digest = structuredClone(schema);
+  digest.properties.inputs.items.properties.sha256.pattern = ".*";
+  assert.throws(() => validateRecipeSchemaDefinition(digest), /lowercase SHA-256/u);
+});
+
+test("provider-neutral policy rejects cloud placement, credentials, and URLs", () => {
+  for (const [name, value, expected] of [
+    ["provider key", { provider: "cloud" }, /provider-specific/u],
+    ["provider image", { value: "ami-1234567890abcdef0" }, /provider resource ID/u],
+    ["subscription resource", { value: "/subscriptions/example/resourceGroups/group" }, /provider resource ID/u],
+    ["project resource", { value: "projects/example/global/images/devtools" }, /provider resource ID/u],
+    ["region", { value: "us-west-2" }, /forbidden region/u],
+    ["instance type", { value: "m7i.large" }, /instance type/u],
+    ["credential", { value: "API token" }, /credential/u],
+    ["URL", { value: "https://downloads.example/devtools/latest" }, /forbidden URL/u],
+  ]) {
+    assert.throws(() => assertProviderNeutral(value), expected, name);
+  }
+});
+
+test("recipe rejects changed execution, environment, platform, and input set", async (t) => {
+  const copy = await fixture(t);
+  const schema = await copy.schema();
+  const original = await copy.recipe();
+  for (const [name, mutate, expected] of [
+    ["entrypoint", (recipe) => { recipe.execution.arguments = ["scripts/linux-readiness.generated.sh"]; }, /reviewed Linux developer-tools entrypoint/u],
+    ["environment", (recipe) => { recipe.execution.environment.MODE = "test"; }, /not allowed/u],
+    ["platform ID", (recipe) => { recipe.id = "linux-other"; }, /match its platform/u],
+    ["missing input", (recipe) => { recipe.inputs.pop(); }, /contain exactly/u],
+    ["extra input", (recipe) => { recipe.inputs.push({ path: "scripts/zz-extra.sh", sha256: `sha256:${"0".repeat(64)}` }); }, /contain exactly/u],
+  ]) {
+    const recipe = structuredClone(original);
+    mutate(recipe);
+    await assert.rejects(assertRecipe(recipe, schema, copy.root), expected, name);
+  }
+});
+
+test("recipe rejects unsorted, duplicate, escaping, absolute, and backslash input paths", async (t) => {
+  const copy = await fixture(t);
+  const schema = await copy.schema();
+  const original = await copy.recipe();
+  for (const [name, mutate, expected] of [
+    ["unsorted", (recipe) => { recipe.inputs.reverse(); }, /sorted and unique/u],
+    ["duplicate", (recipe) => { recipe.inputs[1] = structuredClone(recipe.inputs[0]); }, /duplicate items/u],
+    ["parent escape", (recipe) => { recipe.inputs[0].path = "../outside.sh"; }, /normalized repository-relative path/u],
+    ["absolute", (recipe) => { recipe.inputs[0].path = "/tmp/outside.sh"; }, /normalized repository-relative path/u],
+    ["backslash", (recipe) => { recipe.inputs[0].path = "scripts\\outside.sh"; }, /normalized repository-relative path/u],
+  ]) {
+    const recipe = structuredClone(original);
+    mutate(recipe);
+    await assert.rejects(assertRecipe(recipe, schema, copy.root), expected, name);
+  }
+});
+
+test("recipe rejects symlinked inputs and symlinked input directories", async (t) => {
+  const direct = await fixture(t);
+  await rm(join(direct.root, "scripts/install-linux-developer-tools.sh"));
+  await symlink(join(repoRoot, "scripts/install-linux-developer-tools.sh"), join(direct.root, "scripts/install-linux-developer-tools.sh"));
+  await assert.rejects(loadDevtoolsRecipe(direct.root), /must not traverse a symlink/u);
+
+  const parent = await fixture(t);
+  await rm(join(parent.root, "scripts"), { recursive: true });
+  await symlink(join(repoRoot, "scripts"), join(parent.root, "scripts"));
+  await assert.rejects(loadDevtoolsRecipe(parent.root), /must not traverse a symlink/u);
+});
+
+test("recipe rejects content changes and malformed hashes", async (t) => {
+  const changed = await fixture(t);
+  await writeFile(join(changed.root, "scripts/install-linux-developer-tools.sh"), "#!/bin/sh\nexit 0\n");
+  await assert.rejects(loadDevtoolsRecipe(changed.root), /install-linux-developer-tools\.sh SHA-256 mismatch/u);
+
+  const malformed = await fixture(t);
+  const recipe = await malformed.recipe();
+  recipe.inputs[0].sha256 = "sha256:ABC";
+  await malformed.writeRecipe(recipe);
+  await assert.rejects(loadDevtoolsRecipe(malformed.root), /recipe\.inputs\[0\]\.sha256 has an invalid format/u);
+});
+
+test("CLI is import-safe and returns stable text and JSON output", async () => {
+  const imported = spawnSync(
+    process.execPath,
+    ["--input-type=module", "--eval", "await import('./scripts/devtools-image-contract.mjs')"],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+  assert.equal(imported.status, 0, imported.stderr);
+  assert.equal(imported.stdout, "");
+
+  const text = spawnSync(process.execPath, ["scripts/devtools-image-contract.mjs"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  assert.equal(text.status, 0, text.stderr);
+  assert.match(text.stdout, /^sha256:[0-9a-f]{64}\n$/u);
+
+  const json = spawnSync(process.execPath, ["scripts/devtools-image-contract.mjs", "--json"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  assert.equal(json.status, 0, json.stderr);
+  assert.deepEqual(parseStrictJSON(json.stdout), {
+    id: "linux-x86_64",
+    recipeDigest: text.stdout.trim(),
+    schema: "crabbox-devtools-image-recipe/v1",
+  });
+  assert.equal(json.stdout, `${canonicalJSON(parseStrictJSON(json.stdout))}\n`);
+
+  const invalid = spawnSync(process.execPath, ["scripts/devtools-image-contract.mjs", "--check"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  assert.notEqual(invalid.status, 0);
+  assert.match(invalid.stderr, /usage: devtools-image-contract\.mjs/u);
+});


### PR DESCRIPTION
## What Problem This Solves

Developer-image publishers do not have one provider-neutral contract that proves which executable source bytes produced a candidate. Provider workflows can therefore describe the same intended image differently or drift from the installer and readiness producer they execute.

## Why This Change Was Made

This adds a strict versioned `linux-x86_64` recipe plus an import-safe validator and canonical digest tool. The contract binds the execution command and exact SHA-256 hashes of the Linux developer-tools installer and generated readiness producer; it rejects unknown fields, cloud placement or resource data, credentials, URLs, unsafe paths, symlinks, unsorted inputs, and content drift.

Provider publication, cloud APIs, benchmark logic, and SBOM storage remain outside this change.

## User Impact

Maintainers and future provider publishers can identify and compare the exact generic Linux developer-image recipe with one stable digest before any paid cloud work.

## Evidence

- Base: `8166af8b652721a943ca47deca3faa020aa2fdc8`
- Head: `a399e0e3e8ff9efb65a7ffcfb66264922c3ab7cf`
- Recipe digest: `sha256:31f3f683fb54317e22ec31f7aa155d91e45fb45c194574f90c828745320f7297`
- `node --test scripts/devtools-image-contract.test.mjs scripts/generate-linux-readiness.test.mjs scripts/install-linux-developer-tools.test.js` (`134` passed)
- `node scripts/devtools-image-contract.mjs --json`
- `node scripts/generate-linux-readiness.mjs --check`
- `bash scripts/check-docs.sh`
- `git diff --check`
- Privacy scan: clean.
- Project autoreview: scoped-clean with no accepted or actionable findings.
