### PR TITLE
refactor(providers): share warmup completion reporting

### DIFF
--- a/internal/providers/agentsandbox/backend.go
+++ b/internal/providers/agentsandbox/backend.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type backend struct {
@@ -90,11 +92,12 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 			fmt.Fprintf(b.rt.Stderr, "warning: agent-sandbox warmup keeps the claim until explicit stop\n")
 		}
 	}
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{Provider: providerName, LeaseID: leaseID, Slug: slug, TotalMs: total.Milliseconds(), ExitCode: 0})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {

--- a/internal/providers/applemachine/backend.go
+++ b/internal/providers/applemachine/backend.go
@@ -54,11 +54,12 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	leaseID, slug, name := claim.LeaseID, claim.Slug, claim.CloudID
 	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s machine=%s\n", leaseID, slug, providerName, name)
 	total := time.Since(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{Provider: providerName, LeaseID: leaseID, Slug: slug, TotalMs: total.Milliseconds(), ExitCode: 0})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {

--- a/internal/providers/awslambdamicrovm/backend.go
+++ b/internal/providers/awslambdamicrovm/backend.go
@@ -63,11 +63,12 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 		fmt.Fprintf(b.rt.Stderr, "warning: %s warmup keeps the MicroVM until explicit stop\n", providerName)
 	}
 	total := now(b.rt).Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{Provider: providerName, LeaseID: leaseID, Slug: slug, TotalMs: total.Milliseconds(), ExitCode: 0})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {

--- a/internal/providers/azuredynamicsessions/backend.go
+++ b/internal/providers/azuredynamicsessions/backend.go
@@ -53,17 +53,12 @@ func (b *azureDynamicSessionsBackend) Warmup(ctx context.Context, req WarmupRequ
 		fmt.Fprintf(b.rt.Stderr, "released lease=%s session=%s\n", leaseID, leaseID)
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: providerName,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *azureDynamicSessionsBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {

--- a/internal/providers/azuredynamicsessions/backend_test.go
+++ b/internal/providers/azuredynamicsessions/backend_test.go
@@ -100,7 +100,7 @@ func TestRunCleanupUsesBoundedContext(t *testing.T) {
 	if len(fake.deleted) != 1 || fake.deleted[0] != result.LeaseID {
 		t.Fatalf("deleted sessions = %#v, want %s", fake.deleted, result.LeaseID)
 	}
-	var report timingReport
+	var report core.TimingReport
 	lines := strings.Split(strings.TrimSpace(backend.rt.Stderr.(*bytes.Buffer).String()), "\n")
 	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &report); err != nil || report.ExitCode != 1 || report.ErrorKind != core.RunErrorProvider {
 		t.Fatalf("final cleanup timing=%#v err=%v", report, err)
@@ -191,7 +191,7 @@ func TestRunKeepOnFailureRetainsNewSession(t *testing.T) {
 	if claim, ok, err := resolveLeaseClaimForProvider(result.LeaseID, providerName); err != nil || !ok || claim.RepoRoot != repo {
 		t.Fatalf("retained claim ok=%t claim=%#v err=%v", ok, claim, err)
 	}
-	var report timingReport
+	var report core.TimingReport
 	found := false
 	for _, line := range strings.Split(strings.TrimSpace(backend.rt.Stderr.(*bytes.Buffer).String()), "\n") {
 		if !strings.HasPrefix(line, "{") {

--- a/internal/providers/azuredynamicsessions/core.go
+++ b/internal/providers/azuredynamicsessions/core.go
@@ -36,7 +36,6 @@ type LocalCommandRequest = core.LocalCommandRequest
 type LocalCommandResult = core.LocalCommandResult
 type ExitError = core.ExitError
 type LeaseClaim = core.LeaseClaim
-type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
 
 const (
@@ -102,10 +101,6 @@ func removeLeaseClaimIfUnchangedAfter(leaseID string, claim LeaseClaim, action f
 
 func listLeaseClaims() ([]core.LeaseClaim, error) {
 	return core.ListLeaseClaims()
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
 }
 
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -91,19 +91,12 @@ func (b *blacksmithBackend) Warmup(ctx context.Context, req WarmupRequest) error
 		req.BeforeComplete()
 	}
 	total := b.rt.Clock.Now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: blacksmithTestboxProvider,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		}); err != nil {
-			return err
-		}
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: blacksmithTestboxProvider,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *blacksmithBackend) ValidateRunOptions(req RunRequest) error {

--- a/internal/providers/cloudflare/backend.go
+++ b/internal/providers/cloudflare/backend.go
@@ -71,17 +71,12 @@ func (b *cloudflareBackend) Warmup(ctx context.Context, req WarmupRequest) error
 		fmt.Fprintf(b.rt.Stderr, "warning: %s warmup keeps the container until explicit stop\n", providerName)
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: providerName,
-			LeaseID:  claim.LeaseID,
-			Slug:     claim.Slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  claim.LeaseID,
+		Slug:     claim.Slug,
+		Total:    total,
+	})
 }
 
 func (b *cloudflareBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {

--- a/internal/providers/cloudflare/core.go
+++ b/internal/providers/cloudflare/core.go
@@ -31,7 +31,6 @@ type Repo = core.Repo
 type ExitError = core.ExitError
 type FeatureSet = core.FeatureSet
 type Feature = core.Feature
-type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
 
 const (
@@ -71,10 +70,6 @@ func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTim
 
 func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaimForProvider(identifier, provider)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
 }
 
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {

--- a/internal/providers/cloudflaresandbox/backend.go
+++ b/internal/providers/cloudflaresandbox/backend.go
@@ -101,17 +101,12 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 		fmt.Fprintf(b.rt.Stderr, "warning: cloudflare-sandbox warmup keeps the sandbox until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: providerName,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {

--- a/internal/providers/cloudflaresandbox/core.go
+++ b/internal/providers/cloudflaresandbox/core.go
@@ -30,7 +30,6 @@ type Server = core.Server
 type Repo = core.Repo
 type LeaseClaim = core.LeaseClaim
 type ExitError = core.ExitError
-type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
 
 const (
@@ -48,10 +47,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 
 func flagWasSet(fs *flag.FlagSet, name string) bool {
 	return core.FlagWasSet(fs, name)
-}
-
-func writeTimingJSON(w io.Writer, report core.TimingReport) error {
-	return core.WriteTimingJSON(w, report)
 }
 
 func newLeaseSlug(leaseID string) string {

--- a/internal/providers/cloudrunsandbox/backend.go
+++ b/internal/providers/cloudrunsandbox/backend.go
@@ -55,17 +55,12 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 		fmt.Fprintf(b.rt.Stderr, "warning: cloud-run-sandbox warmup keeps the sandbox until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: providerName,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResult, finalErr error) {

--- a/internal/providers/codesandbox/backend.go
+++ b/internal/providers/codesandbox/backend.go
@@ -41,17 +41,12 @@ func (b *codeSandboxBackend) Warmup(ctx context.Context, req WarmupRequest) erro
 		fmt.Fprintf(b.rt.Stderr, "warning: codesandbox warmup keeps the sandbox until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: providerName,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *codeSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {

--- a/internal/providers/codesandbox/core.go
+++ b/internal/providers/codesandbox/core.go
@@ -34,7 +34,6 @@ type Server = core.Server
 type Repo = core.Repo
 type LeaseClaim = core.LeaseClaim
 type ExitError = core.ExitError
-type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
 type LocalCommandRequest = core.LocalCommandRequest
 
@@ -66,10 +65,6 @@ func inventoryDoctorResult(provider string, leases int) DoctorResult {
 
 func delegatedSyncOptionsError(spec ProviderSpec, req RunRequest) error {
 	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
 }
 
 func newLeaseSlug(leaseID string) string {

--- a/internal/providers/crownest/backend.go
+++ b/internal/providers/crownest/backend.go
@@ -75,17 +75,12 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 		fmt.Fprintf(b.rt.Stderr, "warning: crownest warmup keeps the sandbox until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: providerName,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {

--- a/internal/providers/cubesandbox/backend.go
+++ b/internal/providers/cubesandbox/backend.go
@@ -111,17 +111,12 @@ func (b *cubesandboxBackend) Warmup(ctx context.Context, req WarmupRequest) erro
 		fmt.Fprintf(b.rt.Stderr, "warning: cubesandbox warmup keeps the sandbox until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: providerName,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *cubesandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {

--- a/internal/providers/cubesandbox/core.go
+++ b/internal/providers/cubesandbox/core.go
@@ -2,7 +2,6 @@ package cubesandbox
 
 import (
 	"flag"
-	"io"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -28,7 +27,6 @@ type Server = core.Server
 type SSHTarget = core.SSHTarget
 type Repo = core.Repo
 type ExitError = core.ExitError
-type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
 
 const (
@@ -96,10 +94,6 @@ func providerClaimScope(cfg Config) string {
 
 func isCanonicalLeaseID(value string) bool {
 	return core.IsCanonicalLeaseID(value)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
 }
 
 func shellQuote(s string) string {

--- a/internal/providers/dockersandbox/backend.go
+++ b/internal/providers/dockersandbox/backend.go
@@ -54,17 +54,12 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 		fmt.Fprintf(b.rt.Stderr, "warning: docker-sandbox warmup keeps the sandbox until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: providerName,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -97,17 +97,12 @@ func (b *e2bBackend) Warmup(ctx context.Context, req WarmupRequest) error {
 		fmt.Fprintf(b.rt.Stderr, "warning: e2b warmup keeps the sandbox until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: e2bProvider,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: e2bProvider,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {

--- a/internal/providers/e2b/core.go
+++ b/internal/providers/e2b/core.go
@@ -2,7 +2,6 @@ package e2b
 
 import (
 	"flag"
-	"io"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -29,7 +28,6 @@ type Server = core.Server
 type SSHTarget = core.SSHTarget
 type Repo = core.Repo
 type ExitError = core.ExitError
-type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
 
 const (
@@ -103,10 +101,6 @@ func isCanonicalLeaseID(value string) bool {
 
 func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaim(identifier)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
 }
 
 func shellQuote(s string) string {

--- a/internal/providers/modal/backend.go
+++ b/internal/providers/modal/backend.go
@@ -46,17 +46,12 @@ func (b *modalBackend) Warmup(ctx context.Context, req WarmupRequest) error {
 		fmt.Fprintf(b.rt.Stderr, "warning: modal warmup keeps the sandbox until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: providerName,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *modalBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {

--- a/internal/providers/modal/core.go
+++ b/internal/providers/modal/core.go
@@ -28,7 +28,6 @@ type Server = core.Server
 type Repo = core.Repo
 type ExitError = core.ExitError
 type LocalCommandRequest = core.LocalCommandRequest
-type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
 
 const (
@@ -68,10 +67,6 @@ func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep 
 
 func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaim(identifier)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
 }
 
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {

--- a/internal/providers/nomad/core.go
+++ b/internal/providers/nomad/core.go
@@ -29,7 +29,6 @@ type LeaseClaim = core.LeaseClaim
 type Repo = core.Repo
 type Server = core.Server
 type ExitError = core.ExitError
-type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
 
 const providerName = "nomad"
@@ -70,10 +69,6 @@ func updateLeaseClaimLabelsIfUnchanged(leaseID string, expected LeaseClaim, labe
 
 func delegatedSyncOptionsError(spec ProviderSpec, req RunRequest) error {
 	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
 }
 
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {

--- a/internal/providers/nomad/lifecycle.go
+++ b/internal/providers/nomad/lifecycle.go
@@ -62,18 +62,13 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 		fmt.Fprintf(b.rt.Stderr, "warning: nomad warmup keeps the job until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: providerName,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-			Workdir:  b.cfg.Nomad.Workdir,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Workdir:  b.cfg.Nomad.Workdir,
+		Total:    total,
+	})
 }
 
 func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -55,17 +55,12 @@ func (b *openComputerBackend) Warmup(ctx context.Context, req WarmupRequest) err
 		fmt.Fprintf(b.rt.Stderr, "warning: opencomputer warmup keeps the sandbox until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: providerName,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {

--- a/internal/providers/opencomputer/core.go
+++ b/internal/providers/opencomputer/core.go
@@ -26,7 +26,6 @@ type Server = core.Server
 type Repo = core.Repo
 type LeaseClaim = core.LeaseClaim
 type ExitError = core.ExitError
-type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
 
 const (
@@ -49,10 +48,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 
 func flagWasSet(fs *flag.FlagSet, name string) bool {
 	return core.FlagWasSet(fs, name)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
 }
 
 func newLeaseSlug(leaseID string) string {

--- a/internal/providers/opensandbox/backend.go
+++ b/internal/providers/opensandbox/backend.go
@@ -85,17 +85,12 @@ func (b *openSandboxBackend) Warmup(ctx context.Context, req WarmupRequest) erro
 		fmt.Fprintf(b.rt.Stderr, "warning: opensandbox warmup keeps the sandbox until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: providerName,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {

--- a/internal/providers/opensandbox/core.go
+++ b/internal/providers/opensandbox/core.go
@@ -27,7 +27,6 @@ type Server = core.Server
 type Repo = core.Repo
 type LeaseClaim = core.LeaseClaim
 type ExitError = core.ExitError
-type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
 
 const (
@@ -60,10 +59,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 
 func flagWasSet(fs *flag.FlagSet, name string) bool {
 	return core.FlagWasSet(fs, name)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
 }
 
 func newLeaseSlug(leaseID string) string {

--- a/internal/providers/orgo/backend.go
+++ b/internal/providers/orgo/backend.go
@@ -68,17 +68,12 @@ func (b *orgoBackend) Warmup(ctx context.Context, req WarmupRequest) error {
 		fmt.Fprintf(b.rt.Stderr, "warning: orgo warmup keeps the computer until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: providerName,
-			LeaseID:  lease.LeaseID,
-			Slug:     lease.Slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  lease.LeaseID,
+		Slug:     lease.Slug,
+		Total:    total,
+	})
 }
 
 func (b *orgoBackend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {

--- a/internal/providers/shared/warmup.go
+++ b/internal/providers/shared/warmup.go
@@ -1,0 +1,31 @@
+package shared
+
+import (
+	"fmt"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type WarmupCompletion struct {
+	Provider string
+	LeaseID  string
+	Slug     string
+	Workdir  string
+	Total    time.Duration
+}
+
+func CompleteWarmup(rt core.Runtime, timingJSON bool, result WarmupCompletion) error {
+	fmt.Fprintf(rt.Stdout, "warmup complete total=%s\n", result.Total.Round(time.Millisecond))
+	if timingJSON {
+		return core.WriteTimingJSON(rt.Stderr, core.TimingReport{
+			Provider: result.Provider,
+			LeaseID:  result.LeaseID,
+			Slug:     result.Slug,
+			TotalMs:  result.Total.Milliseconds(),
+			ExitCode: 0,
+			Workdir:  result.Workdir,
+		})
+	}
+	return nil
+}

--- a/internal/providers/shared/warmup_test.go
+++ b/internal/providers/shared/warmup_test.go
@@ -78,14 +78,16 @@ func TestCompleteWarmupWritesTimingAfterStdoutFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := core.TimingReport{
-		Provider:  result.Provider,
-		LeaseID:   result.LeaseID,
-		Slug:      result.Slug,
-		TotalMs:   result.Total.Milliseconds(),
-		ExitCode:  0,
-		RunStatus: core.RunStatusSucceeded,
-		ErrorKind: core.RunErrorNone,
-		Workdir:   result.Workdir,
+		Provider:      result.Provider,
+		LeaseID:       result.LeaseID,
+		Slug:          result.Slug,
+		TotalMs:       result.Total.Milliseconds(),
+		RunnerTotalMs: 2345,
+		RunnerPhases:  []core.RunnerPhase{{Name: "unattributed", Ms: 2345}},
+		ExitCode:      0,
+		RunStatus:     core.RunStatusSucceeded,
+		ErrorKind:     core.RunErrorNone,
+		Workdir:       result.Workdir,
 	}
 	if !reflect.DeepEqual(writer.report, want) {
 		t.Fatalf("report=%+v, want %+v", writer.report, want)

--- a/internal/providers/shared/warmup_test.go
+++ b/internal/providers/shared/warmup_test.go
@@ -1,0 +1,114 @@
+package shared
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"reflect"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestCompleteWarmupWithoutTimingJSON(t *testing.T) {
+	var stdout bytes.Buffer
+	err := CompleteWarmup(core.Runtime{Stdout: &stdout, Stderr: failingWriter{err: io.ErrClosedPipe}}, false, WarmupCompletion{
+		Total: 1500 * time.Microsecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := stdout.String(), "warmup complete total=2ms\n"; got != want {
+		t.Fatalf("stdout=%q, want %q", got, want)
+	}
+}
+
+func TestCompleteWarmupWritesTimingJSON(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := CompleteWarmup(core.Runtime{Stdout: &stdout, Stderr: &stderr}, true, WarmupCompletion{
+		Provider: "nomad",
+		LeaseID:  "cbx_123456789abc",
+		Slug:     "timed-crab",
+		Workdir:  "/workspace/crabbox",
+		Total:    1500 * time.Microsecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := stdout.String(), "warmup complete total=2ms\n"; got != want {
+		t.Fatalf("stdout=%q, want %q", got, want)
+	}
+	var report core.TimingReport
+	if err := json.Unmarshal(stderr.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.Provider != "nomad" || report.LeaseID != "cbx_123456789abc" || report.Slug != "timed-crab" ||
+		report.TotalMs != 1 || report.ExitCode != 0 || report.Workdir != "/workspace/crabbox" ||
+		report.RunStatus != core.RunStatusSucceeded || report.ErrorKind != core.RunErrorNone {
+		t.Fatalf("report=%+v", report)
+	}
+}
+
+func TestCompleteWarmupReturnsTimingWriterError(t *testing.T) {
+	want := errors.New("timing write failed")
+	err := CompleteWarmup(core.Runtime{
+		Stdout: failingWriter{err: io.ErrClosedPipe},
+		Stderr: failingWriter{err: want},
+	}, true, WarmupCompletion{})
+	if !errors.Is(err, want) {
+		t.Fatalf("err=%v, want %v", err, want)
+	}
+}
+
+func TestCompleteWarmupWritesTimingAfterStdoutFailure(t *testing.T) {
+	writer := &recordingTimingWriter{}
+	result := WarmupCompletion{
+		Provider: "example-provider",
+		LeaseID:  "cbx_abcdef123456",
+		Slug:     "example-slug",
+		Workdir:  "/workspace/example",
+		Total:    2345 * time.Millisecond,
+	}
+	if err := CompleteWarmup(core.Runtime{
+		Stdout: failingWriter{err: io.ErrClosedPipe},
+		Stderr: writer,
+	}, true, result); err != nil {
+		t.Fatal(err)
+	}
+	want := core.TimingReport{
+		Provider:  result.Provider,
+		LeaseID:   result.LeaseID,
+		Slug:      result.Slug,
+		TotalMs:   result.Total.Milliseconds(),
+		ExitCode:  0,
+		RunStatus: core.RunStatusSucceeded,
+		ErrorKind: core.RunErrorNone,
+		Workdir:   result.Workdir,
+	}
+	if !reflect.DeepEqual(writer.report, want) {
+		t.Fatalf("report=%+v, want %+v", writer.report, want)
+	}
+}
+
+type failingWriter struct {
+	err error
+}
+
+func (w failingWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+type recordingTimingWriter struct {
+	report core.TimingReport
+}
+
+func (w *recordingTimingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("unexpected byte write")
+}
+
+func (w *recordingTimingWriter) WriteTimingReport(report core.TimingReport) error {
+	w.report = report
+	return nil
+}

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -91,17 +91,12 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 		fmt.Fprintf(b.rt.Stderr, "warning: superserve warmup keeps the sandbox until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: providerName,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {

--- a/internal/providers/superserve/core.go
+++ b/internal/providers/superserve/core.go
@@ -27,7 +27,6 @@ type Server = core.Server
 type Repo = core.Repo
 type LeaseClaim = core.LeaseClaim
 type ExitError = core.ExitError
-type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
 
 const (
@@ -45,10 +44,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 
 func flagWasSet(fs *flag.FlagSet, name string) bool {
 	return core.FlagWasSet(fs, name)
-}
-
-func writeTimingJSON(w io.Writer, report core.TimingReport) error {
-	return core.WriteTimingJSON(w, report)
 }
 
 func inventoryDoctorResult(provider string, leases int) DoctorResult {

--- a/internal/providers/tensorlake/backend.go
+++ b/internal/providers/tensorlake/backend.go
@@ -42,17 +42,12 @@ func (b *tensorlakeBackend) Warmup(ctx context.Context, req WarmupRequest) error
 		fmt.Fprintf(b.rt.Stderr, "warning: tensorlake warmup keeps the sandbox until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: providerName,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {

--- a/internal/providers/tensorlake/core.go
+++ b/internal/providers/tensorlake/core.go
@@ -25,7 +25,6 @@ type StopRequest = core.StopRequest
 type Server = core.Server
 type Repo = core.Repo
 type ExitError = core.ExitError
-type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
 type LocalCommandRequest = core.LocalCommandRequest
 
@@ -48,10 +47,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 
 func flagWasSet(fs *flag.FlagSet, name string) bool {
 	return core.FlagWasSet(fs, name)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
 }
 
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {

--- a/internal/providers/unikraftcloud/backend.go
+++ b/internal/providers/unikraftcloud/backend.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -195,17 +197,12 @@ func (b *backend) finishWarmup(started time.Time, claim LeaseClaim, instance ukc
 		fmt.Fprintf(b.rt.Stderr, "warning: %s warmup keeps the instance until explicit stop or eligible cleanup\n", providerName)
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: providerName,
-			LeaseID:  claim.LeaseID,
-			Slug:     claim.Slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  claim.LeaseID,
+		Slug:     claim.Slug,
+		Total:    total,
+	})
 }
 
 func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {

--- a/internal/providers/unikraftcloud/core.go
+++ b/internal/providers/unikraftcloud/core.go
@@ -2,7 +2,6 @@ package unikraftcloud
 
 import (
 	"flag"
-	"io"
 	"strings"
 	"time"
 
@@ -99,9 +98,3 @@ var replaceLeaseClaimIfUnchangedDurable = core.ReplaceLeaseClaimIfUnchangedDurab
 func shouldCleanupServer(server Server, now time.Time) (bool, string) {
 	return core.ShouldCleanupServer(server, now)
 }
-
-func writeTimingJSON(w io.Writer, report core.TimingReport) error {
-	return core.WriteTimingJSON(w, report)
-}
-
-type timingReport = core.TimingReport

--- a/internal/providers/upstashbox/backend.go
+++ b/internal/providers/upstashbox/backend.go
@@ -44,17 +44,12 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 		fmt.Fprintf(b.rt.Stderr, "warning: upstash-box warmup keeps the box until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: providerName,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {

--- a/internal/providers/upstashbox/core.go
+++ b/internal/providers/upstashbox/core.go
@@ -26,7 +26,6 @@ type StopRequest = core.StopRequest
 type Server = core.Server
 type Repo = core.Repo
 type ExitError = core.ExitError
-type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
 
 const (
@@ -70,10 +69,6 @@ func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTim
 
 func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaim(identifier)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
 }
 
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {

--- a/internal/providers/vercelsandbox/backend.go
+++ b/internal/providers/vercelsandbox/backend.go
@@ -54,17 +54,12 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 		fmt.Fprintf(b.rt.Stderr, "warning: vercel-sandbox warmup keeps the sandbox until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider: providerName,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {

--- a/internal/providers/vercelsandbox/core.go
+++ b/internal/providers/vercelsandbox/core.go
@@ -28,7 +28,6 @@ type Server = core.Server
 type Repo = core.Repo
 type LeaseClaim = core.LeaseClaim
 type ExitError = core.ExitError
-type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
 
 const (
@@ -51,10 +50,6 @@ func flagWasSet(fs *flag.FlagSet, name string) bool {
 
 func inventoryDoctorResult(provider string, leases int) DoctorResult {
 	return core.InventoryDoctorResult(provider, leases)
-}
-
-func writeTimingJSON(w io.Writer, report core.TimingReport) error {
-	return core.WriteTimingJSON(w, report)
 }
 
 func newLeaseSlug(leaseID string) string {


### PR DESCRIPTION
## What Problem This Solves

Provider warmup completion reporting had accumulated identical output and timing JSON code across 23 adapters. That duplication made the common behavior easier to drift and left provider-local wrappers behind after shared lifecycle refactors.

## Why This Change Was Made

This routes all 23 warmup completion paths through a provider-neutral shared helper, removes 15 now-unused timing writer wrappers, and keeps provider-specific lease, slug, and workdir values in each adapter. Regression coverage verifies that timing reporting still runs when writing the human-readable completion line fails.

## User Impact

There is no user-visible behavior change. Warmup output and timing JSON contracts remain unchanged, with no configuration, secret, or security implications.

## Evidence

- Independent source and diff review cleared the exact 41-file patch and all 23 provider mappings.
- `gofmt` and diff integrity checks pass.
- Shared helper tests cover disabled timing output, timing JSON output, timing writer failure, and timing emission after a stdout failure.
- Tests were not run locally under the publication constraints; hosted CI is pending.
