### PR TITLE
refactor: share Freestyle sandbox run lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Shared sandbox runs: keep secondary cleanup and timing errors visible in CLI diagnostics without replacing the primary exit code. [PR 1907](https://github.com/openclaw/crabbox/pull/1907).
 - Freestyle: share sandbox run finalization so automatic deletion failures no longer report success, command failures survive later cleanup or timing errors, and transport cancellation causes remain available to callers. [PR 1907](https://github.com/openclaw/crabbox/pull/1907).
 - Require a fenced provider-cleanup completion fact before coordinator leases retire local credentials, confirm AWS instance termination before completion, and preserve provider identity while clearing stale remote access. [PR 1901](https://github.com/openclaw/crabbox/pull/1901).
 - Group benchmark reports by record source and summarize successful runner totals, runner phases, sync phases, and sync skips without inventing telemetry for legacy rows. [PR 1896](https://github.com/openclaw/crabbox/pull/1896). Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Freestyle: share sandbox run finalization so automatic deletion failures no longer report success, command failures survive later cleanup or timing errors, and transport cancellation causes remain available to callers.
+- Freestyle: share sandbox run finalization so automatic deletion failures no longer report success, command failures survive later cleanup or timing errors, and transport cancellation causes remain available to callers. [PR 1907](https://github.com/openclaw/crabbox/pull/1907).
 - Require a fenced provider-cleanup completion fact before coordinator leases retire local credentials, confirm AWS instance termination before completion, and preserve provider identity while clearing stale remote access. [PR 1901](https://github.com/openclaw/crabbox/pull/1901).
 - Group benchmark reports by record source and summarize successful runner totals, runner phases, sync phases, and sync skips without inventing telemetry for legacy rows. [PR 1896](https://github.com/openclaw/crabbox/pull/1896). Thanks @vincentkoc.
 - Preserve requested capacity market for market-aware providers while coordinator provisioning is pending, and expose documented provisioning failure diagnostics in `crabbox inspect --json`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Freestyle: share sandbox run finalization so automatic deletion failures no longer report success, command failures survive later cleanup or timing errors, and transport cancellation causes remain available to callers.
 - Require a fenced provider-cleanup completion fact before coordinator leases retire local credentials, confirm AWS instance termination before completion, and preserve provider identity while clearing stale remote access. [PR 1901](https://github.com/openclaw/crabbox/pull/1901).
 - Group benchmark reports by record source and summarize successful runner totals, runner phases, sync phases, and sync skips without inventing telemetry for legacy rows. [PR 1896](https://github.com/openclaw/crabbox/pull/1896). Thanks @vincentkoc.
 - Preserve requested capacity market for market-aware providers while coordinator provisioning is pending, and expose documented provisioning failure diagnostics in `crabbox inspect --json`.

--- a/docs/providers/freestyle.md
+++ b/docs/providers/freestyle.md
@@ -115,6 +115,16 @@ before workspace preparation and sync.
 matching `crabbox stop --provider freestyle --id ...` cleanup command for
 orchestrators that need to inspect or clean up retained VMs later.
 
+Run retention, cleanup, and timing use Crabbox's shared sandbox lifecycle.
+An automatic VM deletion failure after a successful command returns exit 1,
+reports a provider failure, and leaves the session and claim available for
+recovery; it is no longer a warning attached to a successful run. A prior
+command failure keeps its exit code even when deletion or timing output also
+fails. Transport and cancellation causes remain inspectable by callers.
+Setup failures honor `--keep-on-failure`, reused VMs remain kept, and cleanup
+uses an uncanceled 30-second budget. Freestyle still owns its HTTP transport,
+command encoding, and existing claim/reclaim rules.
+
 ## Sync
 
 Freestyle advertises archive sync (`FeatureArchiveSync`). Crabbox supports

--- a/internal/providers/freestyle/backend.go
+++ b/internal/providers/freestyle/backend.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type Config = core.Config
@@ -29,7 +30,6 @@ type LeaseView = core.LeaseView
 type StatusRequest = core.StatusRequest
 type StatusView = core.StatusView
 type StopRequest = core.StopRequest
-type RunSessionHandle = core.RunSessionHandle
 type Server = core.Server
 type Repo = core.Repo
 type ExitError = core.ExitError
@@ -129,174 +129,73 @@ func (b *freestyleBackend) Warmup(ctx context.Context, req WarmupRequest) error 
 	return nil
 }
 
-func (b *freestyleBackend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {
-	if err := delegatedSyncOptionsError(b.spec, req); err != nil {
-		return RunResult{}, err
+func (b *freestyleBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	workspace, workspaceErr := freestyleWorkspacePath(b.cfg)
+	var client freestyleAPI
+	var leaseID, name, slug string
+	session := func() shared.DelegatedSandbox {
+		return shared.DelegatedSandbox{LeaseID: leaseID, Slug: slug, CleanupCommand: freestyleCleanupCommand(leaseID)}
 	}
-	workspace, err := freestyleWorkspacePath(b.cfg)
-	if err != nil {
-		return RunResult{}, err
-	}
-	if !req.SyncOnly && (len(req.Command) == 0 || (len(req.Command) == 1 && strings.TrimSpace(req.Command[0]) == "")) {
-		return RunResult{}, exit(2, "missing command")
-	}
-	started := b.now()
-	client, err := newFreestyleClient(b.cfg, b.rt)
-	if err != nil {
-		return RunResult{}, err
-	}
-	var prepared *core.PreparedArchive
-	if req.ID == "" && !req.NoSync {
-		prepared, err = b.prepareArchive(ctx, req)
-		if err != nil {
-			return RunResult{}, err
-		}
-		defer prepared.Close()
-	}
-	leaseID, name, slug := "", "", ""
-	acquired := false
-	if req.ID == "" {
-		leaseID, name, slug, err = b.createSandbox(ctx, client, req.Repo, req.Reclaim, req.RequestedSlug)
-		if err != nil {
-			return RunResult{}, err
-		}
-		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=freestyle sandbox=%s\n", leaseID, slug, name)
-		acquired = true
-	} else {
-		leaseID, name, err = b.resolveLeaseID(ctx, client, req.ID, req.Repo.Root, req.Reclaim)
-		if err != nil {
-			return RunResult{}, err
-		}
-		slug = freestyleClaimSlug(leaseID)
-	}
-	shouldStop := acquired && !req.Keep
-	cleanedUp := false
-	session := &RunSessionHandle{
-		Provider:       freestyleProvider,
-		LeaseID:        leaseID,
-		Slug:           slug,
-		Reused:         !acquired,
-		Kept:           !shouldStop,
-		CleanupCommand: freestyleCleanupCommand(leaseID),
-	}
-	finishResult := func(result RunResult) RunResult {
-		if result.Provider == "" {
-			result.Provider = freestyleProvider
-		}
-		if result.LeaseID == "" {
-			result.LeaseID = leaseID
-		}
-		if result.Slug == "" {
-			result.Slug = slug
-		}
-		result.Session = session
-		result.Session.Kept = !cleanedUp && !shouldStop
-		return result
-	}
-	defer func() {
-		result = finishResult(result)
-	}()
-	cleanupFreestyle := func() error {
-		if !shouldStop {
-			return nil
-		}
-		if err := deleteFreestyleVMForCleanup(client, name); err != nil {
-			shouldStop = false
-			return err
-		}
-		removeLeaseClaim(leaseID)
-		cleanedUp = true
-		shouldStop = false
-		return nil
-	}
-	if shouldStop {
-		defer func() {
-			if err := cleanupFreestyle(); err != nil {
-				fmt.Fprintf(b.rt.Stderr, "warning: freestyle stop failed for %s: %v\n", name, err)
+	return shared.RunDelegatedSandbox(ctx, req, shared.DelegatedSandboxLifecycle{
+		Provider: freestyleProvider, Runtime: b.rt, Workdir: workspace,
+		IdleTimeout: b.cfg.IdleTimeout, TTL: b.cfg.TTL, CleanupTimeout: freestyleCleanupTimeout,
+		Preflight: func(context.Context) error {
+			if err := delegatedSyncOptionsError(b.spec, req); err != nil {
+				return err
 			}
-		}()
-	}
-	fmt.Fprintf(b.rt.Stderr, "provider=freestyle lease=%s sandbox=%s\n", leaseID, name)
-	syncDuration := time.Duration(0)
-	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
-	if !req.NoSync {
-		var err error
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, name, req, prepared)
-		if err != nil {
-			handleDelegatedRunFailure(b.rt.Stderr, req, freestyleProvider, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-			return RunResult{}, err
-		}
-		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
-	} else if err := b.prepareWorkspace(ctx, client, name, workspace); err != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, freestyleProvider, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return RunResult{}, err
-	}
-	if req.SyncOnly {
-		result := RunResult{
-			Total:         b.now().Sub(started),
-			SyncDelegated: true,
-		}
-		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workspace)
-		if req.TimingJSON {
-			err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
-				Provider:      freestyleProvider,
-				LeaseID:       leaseID,
-				Slug:          slug,
-				SyncDelegated: true,
-				SyncMs:        syncDuration.Milliseconds(),
-				SyncPhases:    syncPhases,
-				SyncSkipped:   req.NoSync,
-				TotalMs:       result.Total.Milliseconds(),
-				ExitCode:      0,
-				Label:         strings.TrimSpace(req.Label),
-			}, result, nil))
-			return result, err
-		}
-		return result, nil
-	}
-	if req.EnvSummary {
-		printEnvForwardingSummary(b.rt.Stderr, freestyleProvider, "forwarded", req.Options.EnvAllow, req.Env)
-	}
-	commandStart := b.now()
-	exitCode, runErr := b.exec(ctx, client, name, workspace, req.Command, req.ShellMode, req.Env)
-	commandDuration := b.now().Sub(commandStart)
-	result = RunResult{
-		ExitCode:      exitCode,
-		Command:       commandDuration,
-		Total:         b.now().Sub(started),
-		SyncDelegated: true,
-	}
-	if req.NoSync {
-		fmt.Fprintf(b.rt.Stderr, "freestyle run summary sync_skipped=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
-	} else {
-		fmt.Fprintf(b.rt.Stderr, "freestyle run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
-	}
-	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
-			Provider:      freestyleProvider,
-			LeaseID:       leaseID,
-			Slug:          slug,
-			SyncDelegated: true,
-			SyncMs:        syncDuration.Milliseconds(),
-			SyncPhases:    syncPhases,
-			SyncSkipped:   req.NoSync,
-			CommandMs:     result.Command.Milliseconds(),
-			TotalMs:       result.Total.Milliseconds(),
-			ExitCode:      exitCode,
-			Label:         strings.TrimSpace(req.Label),
-		}, result, runErr)); err != nil {
-			return result, err
-		}
-	}
-	if runErr != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, freestyleProvider, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return result, ExitError{Code: 1, Message: fmt.Sprintf("freestyle run failed: %v", runErr)}
-	}
-	if exitCode != 0 {
-		handleDelegatedRunFailure(b.rt.Stderr, req, freestyleProvider, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return result, ExitError{Code: exitCode, Message: fmt.Sprintf("freestyle run exited %d", exitCode)}
-	}
-	return result, nil
+			if workspaceErr != nil {
+				return workspaceErr
+			}
+			if !req.SyncOnly && (len(req.Command) == 0 || (len(req.Command) == 1 && strings.TrimSpace(req.Command[0]) == "")) {
+				return exit(2, "missing command")
+			}
+			var err error
+			client, err = newFreestyleClient(b.cfg, b.rt)
+			return err
+		},
+		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) { return b.prepareArchive(ctx, req) },
+		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
+			var err error
+			leaseID, name, slug, err = b.createSandbox(ctx, client, req.Repo, req.Reclaim, req.RequestedSlug)
+			if err != nil {
+				return shared.DelegatedSandbox{}, err
+			}
+			fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=freestyle sandbox=%s\n", leaseID, slug, name)
+			return session(), nil
+		},
+		Resolve: func(ctx context.Context) (shared.DelegatedSandbox, error) {
+			var err error
+			leaseID, name, err = b.resolveLeaseID(ctx, client, req.ID, req.Repo.Root, req.Reclaim)
+			if err != nil {
+				return shared.DelegatedSandbox{}, err
+			}
+			slug = freestyleClaimSlug(leaseID)
+			return session(), nil
+		},
+		Setup: func(context.Context) error {
+			fmt.Fprintf(b.rt.Stderr, "provider=freestyle lease=%s sandbox=%s\n", leaseID, name)
+			return nil
+		},
+		Sync: func(ctx context.Context, archive *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
+			return b.syncWorkspace(ctx, client, name, req, archive)
+		},
+		NoSync: func(ctx context.Context) error { return b.prepareWorkspace(ctx, client, name, workspace) },
+		Command: func(context.Context) (shared.DelegatedSandboxCommand, error) {
+			if req.EnvSummary {
+				printEnvForwardingSummary(b.rt.Stderr, freestyleProvider, "forwarded", req.Options.EnvAllow, req.Env)
+			}
+			return shared.DelegatedSandboxCommand{Run: func(ctx context.Context) (int, error) {
+				return b.exec(ctx, client, name, workspace, req.Command, req.ShellMode, req.Env)
+			}}, nil
+		},
+		Cleanup: func(ctx context.Context) error {
+			if err := client.DeleteVM(ctx, name); err != nil {
+				return err
+			}
+			removeLeaseClaim(leaseID)
+			return nil
+		},
+	})
 }
 
 func (b *freestyleBackend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {

--- a/internal/providers/freestyle/backend_test.go
+++ b/internal/providers/freestyle/backend_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -497,6 +498,7 @@ func TestFreestyleRunKeepsNewSandboxAfterPrepareFailureWhenRequested(t *testing.
 		Repo:          Repo{Root: t.TempDir(), Name: "repo"},
 		NoSync:        true,
 		KeepOnFailure: true,
+		TimingJSON:    true,
 		Command:       []string{"true"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "exec failed") {
@@ -517,6 +519,10 @@ func TestFreestyleRunKeepsNewSandboxAfterPrepareFailureWhenRequested(t *testing.
 	if result.Session.CleanupCommand == "" {
 		t.Fatal("cleanup command is empty")
 	}
+	if claim, ok, err := resolveExactFreestyleLeaseClaim(result.LeaseID); err != nil || !ok || claim.RepoRoot == "" {
+		t.Fatalf("retained claim=%#v exists=%t err=%v", claim, ok, err)
+	}
+	assertFreestyleLifecycleTiming(t, stderr.String(), result, err)
 }
 
 func TestFreestyleRunSyncOnlySkipsUserExec(t *testing.T) {
@@ -543,15 +549,17 @@ func TestFreestyleRunSyncOnlySkipsUserExec(t *testing.T) {
 	}
 	defer func() { newFreestyleClient = oldClient }()
 	var stdout bytes.Buffer
+	var stderr bytes.Buffer
 	backend := &freestyleBackend{
 		spec: Provider{}.Spec(),
 		cfg:  Config{Freestyle: FreestyleConfig{}},
-		rt:   Runtime{Stdout: &stdout, Stderr: io.Discard},
+		rt:   Runtime{Stdout: &stdout, Stderr: &stderr},
 	}
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:     Repo{Root: root, Name: "repo"},
-		SyncOnly: true,
-		Command:  []string{"printf", "unexpected-user-command"},
+	result, err := backend.Run(context.Background(), RunRequest{
+		Repo:       Repo{Root: root, Name: "repo"},
+		SyncOnly:   true,
+		TimingJSON: true,
+		Command:    []string{"printf", "unexpected-user-command"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -564,6 +572,13 @@ func TestFreestyleRunSyncOnlySkipsUserExec(t *testing.T) {
 			t.Fatalf("unexpected user exec: %q", command)
 		}
 	}
+	if result.Session == nil || result.Session.Kept || result.Session.Reused || len(client.deleteIDs) != 1 || client.deleteIDs[0] != "vm-sync" {
+		t.Fatalf("sync-only disposition: session=%#v deletes=%v", result.Session, client.deleteIDs)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(result.LeaseID); err != nil || exists {
+		t.Fatalf("sync-only claim exists=%t err=%v", exists, err)
+	}
+	assertFreestyleLifecycleTiming(t, stderr.String(), result, err)
 }
 
 func TestFreestyleRunNoSyncDoesNotDeleteExistingWorkspace(t *testing.T) {
@@ -636,18 +651,20 @@ func TestFreestyleRunCleanupFailureReportsRetainedSession(t *testing.T) {
 		rt:   Runtime{Stderr: &stderr},
 	}
 	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: t.TempDir(), Name: "repo"},
-		NoSync:  true,
-		Command: []string{"true"},
+		Repo:       Repo{Root: t.TempDir(), Name: "repo"},
+		NoSync:     true,
+		TimingJSON: true,
+		Command:    []string{"true"},
 	})
-	if err != nil {
-		t.Fatalf("Run err=%v", err)
+	var public ExitError
+	if !errors.Is(err, client.deleteErr) || !errors.As(err, &public) || public.Code != 1 || result.ExitCode != 1 || result.Status != core.RunStatusFailed || result.ErrorKind != core.RunErrorProvider {
+		t.Errorf("cleanup failure result=%#v err=%v", result, err)
 	}
 	if len(client.deleteIDs) != 1 || client.deleteIDs[0] != "vm123" {
 		t.Fatalf("deleteIDs=%#v want vm123", client.deleteIDs)
 	}
-	if !strings.Contains(stderr.String(), "warning: freestyle stop failed for vm123") {
-		t.Fatalf("stderr=%q, want cleanup warning", stderr.String())
+	if err == nil || !strings.Contains(err.Error(), "cleanup failed") || !client.deleteDeadlineSet {
+		t.Errorf("cleanup diagnostic/budget missing: err=%v bounded=%t", err, client.deleteDeadlineSet)
 	}
 	if result.Session == nil {
 		t.Fatal("session=nil")
@@ -657,6 +674,201 @@ func TestFreestyleRunCleanupFailureReportsRetainedSession(t *testing.T) {
 	}
 	if result.Session.CleanupCommand != "crabbox stop --provider freestyle --id 'fsb_vm123'" {
 		t.Fatalf("cleanup command=%q", result.Session.CleanupCommand)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(result.LeaseID); err != nil || !exists {
+		t.Fatalf("failed cleanup lost claim: exists=%t err=%v", exists, err)
+	}
+	assertFreestyleLifecycleTiming(t, stderr.String(), result, err)
+}
+
+func freestyleLifecycleBackend(t *testing.T, client *fakeFreestyleClient, stderr io.Writer) *freestyleBackend {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	original := newFreestyleClient
+	newFreestyleClient = func(Config, Runtime) (freestyleAPI, error) { return client, nil }
+	t.Cleanup(func() { newFreestyleClient = original })
+	return &freestyleBackend{spec: Provider{}.Spec(), cfg: Config{Freestyle: FreestyleConfig{}}, rt: Runtime{Stdout: io.Discard, Stderr: stderr}}
+}
+
+func assertFreestyleLifecycleTiming(t *testing.T, diagnostics string, result RunResult, runErr error) {
+	t.Helper()
+	result = core.FinalizeRunResult(result, runErr)
+	lines := strings.Split(strings.TrimSpace(diagnostics), "\n")
+	var report core.TimingReport
+	reports, finalLine := 0, -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, "{") {
+			if err := json.Unmarshal([]byte(line), &report); err != nil {
+				t.Fatal(err)
+			}
+			reports++
+			finalLine = i
+		}
+	}
+	if reports != 1 || finalLine != len(lines)-1 || report.ExitCode != result.ExitCode || report.RunStatus != result.Status || report.ErrorKind != result.ErrorKind || report.LeaseID != result.LeaseID || report.Slug != result.Slug {
+		t.Fatalf("final timing mismatch: reports=%d final_line=%d report=%#v result=%#v diagnostics=%s", reports, finalLine, report, result, diagnostics)
+	}
+}
+
+type freestyleTimingFailureWriter struct {
+	bytes.Buffer
+	cause error
+}
+
+func (w *freestyleTimingFailureWriter) Write(data []byte) (int, error) {
+	if len(data) > 0 && data[0] == '{' {
+		return 0, w.cause
+	}
+	return w.Buffer.Write(data)
+}
+
+func TestFreestyleRunFinalizationPreservesPrimaryOutcome(t *testing.T) {
+	for _, tc := range []struct {
+		name                     string
+		commandCode              int
+		keep, cleanup, badTiming bool
+	}{
+		{name: "command and cleanup", commandCode: 23, cleanup: true},
+		{name: "command cleanup and timing", commandCode: 23, cleanup: true, badTiming: true},
+		{name: "kept command and timing", commandCode: 23, keep: true, badTiming: true},
+		{name: "success then timing", keep: true, badTiming: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cleanupErr := errors.New("synthetic deletion failure")
+			writerErr := errors.New("synthetic timing failure")
+			client := &fakeFreestyleClient{createID: "vm-finalize"}
+			workloads := 0
+			client.exec = func(_ context.Context, command string) (int, error) {
+				if strings.Contains(command, "__lifecycle_workload__") {
+					workloads++
+					return tc.commandCode, nil
+				}
+				return 0, nil
+			}
+			if tc.cleanup {
+				client.deleteErr = cleanupErr
+			}
+			var stderr bytes.Buffer
+			var diagnostics io.Writer = &stderr
+			if tc.badTiming {
+				diagnostics = &freestyleTimingFailureWriter{cause: writerErr}
+			}
+			backend := freestyleLifecycleBackend(t, client, diagnostics)
+			result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: tc.keep, TimingJSON: true, Command: []string{"__lifecycle_workload__"}})
+			wantCode, wantKind := tc.commandCode, core.RunErrorCommandExit
+			if wantCode == 0 {
+				wantCode, wantKind = 1, core.RunErrorProvider
+			}
+			var public ExitError
+			if !errors.As(err, &public) || public.Code != wantCode || result.ExitCode != wantCode || result.Status != core.RunStatusFailed || result.ErrorKind != wantKind || workloads != 1 {
+				t.Errorf("primary outcome lost: result=%#v err=%v public=%#v workloads=%d", result, err, public, workloads)
+			}
+			if tc.cleanup && !errors.Is(err, cleanupErr) || tc.badTiming && !errors.Is(err, writerErr) {
+				t.Errorf("secondary failure lost: %v", err)
+			}
+			wantKept := tc.commandCode != 0 && (tc.keep || tc.cleanup)
+			wantDeletes := 1
+			if tc.commandCode != 0 && tc.keep {
+				wantDeletes = 0
+			}
+			if result.Session == nil || result.Session.Kept != wantKept || result.Session.Reused || len(client.deleteIDs) != wantDeletes {
+				t.Errorf("disposition changed: session=%#v deletes=%v", result.Session, client.deleteIDs)
+			}
+			if _, exists, err := core.ReadLeaseClaimWithPresence(result.LeaseID); err != nil || exists != wantKept {
+				t.Fatalf("claim exists=%t want=%t err=%v", exists, wantKept, err)
+			}
+			if !tc.badTiming {
+				assertFreestyleLifecycleTiming(t, stderr.String(), result, err)
+			}
+		})
+	}
+}
+
+func TestFreestyleRunPreservesTransportCauses(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		cause  error
+		status core.RunStatus
+		kind   core.RunErrorKind
+	}{
+		{"transport", io.ErrUnexpectedEOF, core.RunStatusFailed, core.RunErrorProvider},
+		{"cancellation", context.Canceled, core.RunStatusCanceled, core.RunErrorCanceled},
+		{"deadline", context.DeadlineExceeded, core.RunStatusTimedOut, core.RunErrorTimeout},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeFreestyleClient{createID: "vm-transport"}
+			workloads := 0
+			client.exec = func(_ context.Context, command string) (int, error) {
+				if strings.Contains(command, "__lifecycle_workload__") {
+					workloads++
+					return 1, fmt.Errorf("synthetic command transport: %w", tc.cause)
+				}
+				return 0, nil
+			}
+			var stderr bytes.Buffer
+			backend := freestyleLifecycleBackend(t, client, &stderr)
+			result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: true, TimingJSON: true, Command: []string{"__lifecycle_workload__"}})
+			var public ExitError
+			if !errors.Is(err, tc.cause) || !errors.As(err, &public) || public.Code != 1 || result.ExitCode != 1 || result.Status != tc.status || result.ErrorKind != tc.kind || workloads != 1 || t.Context().Err() != nil {
+				t.Errorf("transport cause/outcome lost: result=%#v err=%v workloads=%d", result, err, workloads)
+			}
+			if result.Session == nil || !result.Session.Kept || result.Session.Reused || len(client.deleteIDs) != 0 {
+				t.Fatalf("transport failure lost recovery: session=%#v deletes=%v", result.Session, client.deleteIDs)
+			}
+			if _, exists, err := core.ReadLeaseClaimWithPresence(result.LeaseID); err != nil || !exists {
+				t.Fatalf("retained claim missing: exists=%t err=%v", exists, err)
+			}
+			assertFreestyleLifecycleTiming(t, stderr.String(), result, err)
+		})
+	}
+}
+
+func TestFreestyleRunReusedLifecycleControls(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		syncOnly    bool
+		commandCode int
+	}{
+		{name: "success"},
+		{name: "command failure", commandCode: 23},
+		{name: "sync only", syncOnly: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeFreestyleClient{}
+			workloads := 0
+			client.exec = func(_ context.Context, command string) (int, error) {
+				if strings.Contains(command, "__lifecycle_workload__") {
+					workloads++
+					return tc.commandCode, nil
+				}
+				return 0, nil
+			}
+			var stderr bytes.Buffer
+			backend := freestyleLifecycleBackend(t, client, &stderr)
+			repo := Repo{Root: t.TempDir(), Name: "fixture"}
+			if tc.syncOnly {
+				repo = freestyleArchiveRepo(t)
+			}
+			const leaseID = "fsb_vm-reused"
+			if err := claimLeaseForRepoProviderPond(leaseID, "reused", freestyleProvider, "", repo.Root, time.Minute, false); err != nil {
+				t.Fatal(err)
+			}
+			result, err := backend.Run(t.Context(), RunRequest{ID: leaseID, Repo: repo, NoSync: !tc.syncOnly, SyncOnly: tc.syncOnly, TimingJSON: true, Command: []string{"__lifecycle_workload__"}})
+			if result.ExitCode != tc.commandCode || (err != nil) != (tc.commandCode != 0) || result.Session == nil || !result.Session.Kept || !result.Session.Reused || client.createReq != nil || len(client.deleteIDs) != 0 {
+				t.Fatalf("reused disposition: result=%#v err=%v creates=%#v deletes=%v", result, err, client.createReq, client.deleteIDs)
+			}
+			wantWorkloads := 1
+			if tc.syncOnly {
+				wantWorkloads = 0
+			}
+			if workloads != wantWorkloads {
+				t.Fatalf("workloads=%d want=%d", workloads, wantWorkloads)
+			}
+			if claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || !exists || claim.RepoRoot != repo.Root {
+				t.Fatalf("reused claim=%#v exists=%t err=%v", claim, exists, err)
+			}
+			assertFreestyleLifecycleTiming(t, stderr.String(), result, err)
+		})
 	}
 }
 

--- a/internal/providers/freestyle/core.go
+++ b/internal/providers/freestyle/core.go
@@ -3,7 +3,6 @@ package freestyle
 import (
 	"flag"
 	"io"
-	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -20,14 +19,6 @@ func flagWasSet(fs *flag.FlagSet, name string) bool {
 
 func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
-}
-
-func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
-	return core.TimingReportWithRunResult(report, result, err)
-}
-
-func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
-	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }
 
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {

--- a/internal/providers/shared/delegated.go
+++ b/internal/providers/shared/delegated.go
@@ -154,7 +154,10 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 				result.Status, result.ErrorKind = core.RunStatusFailed, core.RunErrorProvider
 				retErr = ExitErrorWithCause(firstCode, err.Error(), err)
 			} else {
-				retErr = errors.Join(retErr, err)
+				joined := errors.Join(retErr, err)
+				// The CLI prints the selected ExitError message, not the joined
+				// error. Keep secondary diagnostics in that public envelope too.
+				retErr = ExitErrorWithCause(result.ExitCode, joined.Error(), joined)
 			}
 		}
 		if command.Close != nil {

--- a/internal/providers/shared/delegated_test.go
+++ b/internal/providers/shared/delegated_test.go
@@ -35,6 +35,29 @@ func TestExitErrorWithCausePreservesSelectedCodeAndMessage(t *testing.T) {
 	}
 }
 
+func TestDelegatedSandboxSecondaryDiagnosticsKeepSafeMessages(t *testing.T) {
+	primary := errors.New("raw execution detail")
+	secondary := errors.New("raw cleanup detail")
+	result, err := RunDelegatedSandbox(t.Context(), core.RunRequest{NoSync: true, Keep: true}, DelegatedSandboxLifecycle{
+		Provider: "test",
+		Acquire:  func(context.Context) (DelegatedSandbox, error) { return DelegatedSandbox{LeaseID: "lease"}, nil },
+		NoSync:   func(context.Context) error { return nil },
+		Command: func(context.Context) (DelegatedSandboxCommand, error) {
+			return DelegatedSandboxCommand{
+				Run:   func(context.Context) (int, error) { return 1, ExitErrorWithCause(1, "safe execution", primary) },
+				Close: func(context.Context) error { return ExitErrorWithCause(5, "safe cleanup", secondary) },
+			}, nil
+		},
+	})
+	var public core.ExitError
+	if !core.AsExitError(err, &public) || public.Code != 1 || result.ExitCode != 1 || !errors.Is(err, primary) || !errors.Is(err, secondary) {
+		t.Fatalf("selected code or causes lost: result=%+v err=%v", result, err)
+	}
+	if !strings.Contains(public.Message, "safe execution") || !strings.Contains(public.Message, "safe cleanup") || strings.Contains(public.Message, "raw ") || strings.Contains(err.Error(), "raw ") {
+		t.Fatalf("safe diagnostics were lost or underlying details exposed: message=%q err=%v", public.Message, err)
+	}
+}
+
 func TestDelegatedSandboxLifecycle(t *testing.T) {
 	failure := errors.New("phase failed")
 	cleanupFailure := errors.New("delete unavailable")
@@ -227,6 +250,11 @@ func TestDelegatedSandboxLifecycle(t *testing.T) {
 				if !errors.As(err, &ee) || ee.Code != tc.wantCode {
 					t.Fatalf("exit error=%v", err)
 				}
+				for _, secondary := range []error{tc.closeErr, tc.cleanupErr} {
+					if secondary != nil && !strings.Contains(ee.Message, secondary.Error()) {
+						t.Fatalf("CLI exit message lost cleanup diagnostic: message=%q secondary=%v", ee.Message, secondary)
+					}
+				}
 			}
 			count := 0
 			for _, call := range calls {
@@ -366,6 +394,9 @@ func TestDelegatedSandboxTimingWriterFailureDoesNotSkipCleanupOrMaskExit(t *test
 			var ee core.ExitError
 			if !errors.Is(err, io.ErrClosedPipe) || !errors.As(err, &ee) || ee.Code != wantCode || result.ExitCode != wantCode || calls != wantCleanup {
 				t.Fatalf("calls=%d result=%#v err=%v", calls, result, err)
+			}
+			if !strings.Contains(ee.Message, io.ErrClosedPipe.Error()) {
+				t.Fatalf("CLI exit message lost timing diagnostic: %q", ee.Message)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Move Freestyle runs onto Crabbox's existing shared sandbox lifecycle. The adapter migration removes 110 net production lines of duplicated retention, session, cleanup, and timing finalization without adding a new shared hook or changing Freestyle's HTTP transport, command encoding, archive transaction, or claim/reclaim rules.

The duplicate ordering had observable consequences: automatic VM deletion failure still returned success, a failed timing write could replace the command failure and bypass keep-on-failure, and wrapping transport errors discarded their cancellation/deadline causes.

Shared finalization now preserves the primary command exit while retaining secondary diagnostics, reports cleanup-only failures as exit 1/provider failure, and emits final timing after cleanup. Successful deletion stays reflected as deleted even if reporting later fails. Fresh/reused and sync-only behavior retain their existing contracts; acquisition rollback stays in the adapter and automatic cleanup targets the freshly created VM.

This follows the archive ownership cleanup in https://github.com/openclaw/crabbox/pull/1880 and uses the same lifecycle owner adopted by https://github.com/openclaw/crabbox/pull/1905.

## Verification

The same regression patch against the unchanged parent produced nine failing leaves and four passing controls. Failures cover cleanup outcome/cause reporting, preservation of command exit 23 with cleanup or timing failure, timing-induced loss of keep-on-failure, transport EOF/cancellation/deadline causes, and missing final setup-failure timing. Fresh sync-only and reused success/failure/sync-only controls passed.

With this migration, the full Freestyle and shared-provider race suites passed (34.781s / 3.454s). Focused vet and docs tests passed. Independent semantic inspection found no actionable issue; managed Codex review was P0 scoped-clean, not an all-priority correctness certificate.

```sh
GOTOOLCHAIN=go1.26.5 go test -race -count=1 -timeout=3m ./internal/providers/freestyle ./internal/providers/shared
GOTOOLCHAIN=go1.26.5 go vet ./internal/providers/freestyle ./internal/providers/shared
node --test scripts/build-docs-site.test.js scripts/check-docs-links.test.js
```

### Built-CLI Linux proof

Six cases now pass through the built CLI, production HTTP client, normal archive sync, and real Linux ARM64 Bash/tar/workspace operations. The service is an owned loopback synthetic fixture; this is not hosted Freestyle deletion proof. Reused cases are seeded by real CLI warmup, not hand-written claims.

| Case | Workload exit | CLI exit | Run DELETE attempts | Claim/session kept |
| --- | ---: | ---: | ---: | --- |
| Fresh success | 0 | 0 | 1 | No |
| Command failure, keep-on-failure | 23 | 23 | 0 | Yes |
| Cleanup HTTP 500 after success | 0 | 1 | 1 | Yes |
| Command failure plus cleanup HTTP 500 | 23 | 23 | 1 | Yes |
| Reused success | 0 | 0 | 0 | Yes |
| Reused command failure | 23 | 23 | 0 | Yes |

Every workload printed its case marker and the contents of the actually synchronized payload file. Fresh success is automatically deleted; the other five cases receive a separate successful explicit stop after the run's disposition is recorded. Every case ends with zero claims and zero archive residue. The owned proof runner was also stopped, with provider-container absence and Crabbox inspect-not-found verified.

The unchanged parent exposed cleanup-after-success as CLI exit 0/premature successful timing, while five controls passed. The initial migration then exposed an additional reporting regression: command exit 23 survived cleanup failure, but the CLI printed only the primary ExitError message and hid the joined cleanup diagnostic. The final candidate passes the same unchanged fixture with both the primary exit and secondary diagnostic visible. No assertions were weakened.

That observation led to a small fix in the shared finalizer: preserve joined display-safe messages in the primary-code public ExitError envelope while retaining underlying causes. Eleven shared lifecycle/timing cases were genuinely red before that correction; safe-message coverage verifies that hidden underlying details stay hidden. Full race suites passed for all fourteen other shared-lifecycle adopters, in addition to Freestyle and the shared package. Generic CLI error selection is unchanged.

Observed final trace:

```jsonl
{"scenario":"fresh-success","exit":0,"candidateContractPassed":true,"regressionObserved":false,"expectationFailures":0,"fixtureErrors":0}
{"scenario":"command23-keep-on-failure","exit":23,"candidateContractPassed":true,"regressionObserved":false,"expectationFailures":0,"fixtureErrors":0}
{"scenario":"cleanup500-after-success","exit":1,"candidateContractPassed":true,"regressionObserved":false,"expectationFailures":0,"fixtureErrors":0}
{"scenario":"command23-cleanup500","exit":23,"candidateContractPassed":true,"regressionObserved":false,"expectationFailures":0,"fixtureErrors":0}
{"scenario":"reused-success","exit":0,"candidateContractPassed":true,"regressionObserved":false,"expectationFailures":0,"fixtureErrors":0}
{"scenario":"reused-command23","exit":23,"candidateContractPassed":true,"regressionObserved":false,"expectationFailures":0,"fixtureErrors":0}
```

The native comparison used parent `c30c78e60e4681d3c766ca060291e6d0eda7ad3f` and the Freestyle/shared source committed as `ce8fa81ca6dbb6130ca6d0dd33fdf87fb85fe985`. The fixture SHA-256 is `60a265b48b348c72281d3a778362e4356323178c0e7d30c6a7175d9e0a5edbc0`. Independent evidence inspection verified binary/result bindings and all 144 native command hashes across parent, first-candidate, and final-candidate runs. The five relevant Freestyle/shared production files are byte-identical across the later main integration; this is scoped-source equivalence, not a claim that the entire integrated binary has the same hash.

<details>
<summary>Reproducible synthetic Linux fixture</summary>

Build the parent and candidate CLIs for the disposable Linux runner. Save the following as `proof.mjs`, provide an empty user-owned `/workspace` directory, and run as a non-root user with `CRABBOX_SYNTHETIC_LINUX_PROOF=1`:

```sh
node proof.mjs --binary /proof/crabbox-candidate --output /proof-output/candidate --mode candidate
node proof.mjs --binary /proof/crabbox-parent --output /proof-output/parent --mode baseline
```

Baseline mode succeeds only when the expected regression is observed and all controls pass; its `candidateContractPassed` remains false. The service uses only a synthetic token and must never be pointed at a hosted VM.

```javascript
import fs from 'node:fs';
import path from 'node:path';
import http from 'node:http';
import crypto from 'node:crypto';
import { spawn } from 'node:child_process';
import assert from 'node:assert/strict';

// Run only inside the owner's disposable Linux fixture, never against a real VM.
const options = {};
for (let i = 2; i < process.argv.length; i += 2) {
  const key = process.argv[i];
  assert.ok(['--binary', '--output', '--mode'].includes(key), `unknown option ${key}`);
  assert.ok(process.argv[i + 1], `missing value for ${key}`);
  options[key.slice(2)] = process.argv[i + 1];
}
const mode = options.mode ?? 'candidate';
assert.ok(['candidate', 'baseline'].includes(mode), 'mode must be candidate or baseline');
assert.ok(options.binary && options.output, 'usage: node proof.mjs --binary PATH --output EMPTY_DIR --mode candidate|baseline');
assert.equal(process.platform, 'linux', 'requires disposable Linux fixture');
assert.equal(process.env.CRABBOX_SYNTHETIC_LINUX_PROOF, '1', 'explicit synthetic fixture marker required');
const mount = fs.lstatSync('/workspace');
assert.ok(mount.isDirectory() && !mount.isSymbolicLink(), 'workspace must be a real directory');
assert.equal(mount.uid, process.getuid(), 'workspace must belong to the fixture user');
assert.deepEqual(fs.readdirSync('/workspace'), [], 'workspace must initially be empty');
const binary = fs.realpathSync(options.binary);
const output = path.resolve(options.output);
assert.ok(!output.startsWith('/workspace/'), 'output must be outside the disposable workspace');
fs.mkdirSync(output, { recursive: true });
assert.deepEqual(fs.readdirSync(output), [], 'output directory must be empty');
const binarySha256 = crypto.createHash('sha256').update(fs.readFileSync(binary)).digest('hex');
const active = new Set();
const kill = child => { try { process.kill(-child.pid, 'SIGKILL'); } catch {} };
const deadline = setTimeout(() => {
  for (const child of active) kill(child);
  console.error('synthetic fixture exceeded 180 seconds');
  process.exit(124);
}, 180_000);
deadline.unref();

function run(file, args, cwd, env, timeout = 20_000) {
  return new Promise(resolve => {
    const child = spawn(file, args, { cwd, env, detached: true, stdio: ['ignore', 'pipe', 'pipe'] });
    active.add(child);
    let stdout = '', stderr = '', fault = null;
    const timer = setTimeout(() => { fault = 'process timeout'; kill(child); }, timeout);
    for (const [stream, name] of [[child.stdout, 'stdout'], [child.stderr, 'stderr']]) {
      stream.on('data', chunk => {
        if (name === 'stdout') stdout += chunk; else stderr += chunk;
        if (stdout.length + stderr.length > 512 * 1024) { fault = 'output limit'; kill(child); }
      });
    }
    child.on('error', error => { fault = error.message; });
    child.on('close', (code, signal) => {
      clearTimeout(timer); active.delete(child); resolve({ code, signal, stdout, stderr, fault });
    });
  });
}

const cases = [
  { name: 'fresh-success', code: 0 },
  { name: 'command23-keep-on-failure', code: 23, keepFailure: true },
  { name: 'cleanup500-after-success', code: 0, deleteFailure: true, regression: true },
  { name: 'command23-cleanup500', code: 23, deleteFailure: true },
  { name: 'reused-success', code: 0, reused: true },
  { name: 'reused-command23', code: 23, reused: true },
];
const results = [];

for (const scenario of cases) {
  assert.deepEqual(fs.readdirSync('/workspace'), [], 'previous case left workspace data');
  const root = fs.mkdtempSync('/tmp/freestyle-lifecycle-');
  const repo = path.join(root, 'repo'), home = path.join(root, 'home');
  const temp = path.join(root, 'temp'), state = path.join(root, 'state');
  for (const dir of [repo, home, temp, state]) fs.mkdirSync(dir);
  const baseEnv = { HOME: home, PATH: '/usr/bin:/bin', TMPDIR: temp,
    XDG_STATE_HOME: state, XDG_CONFIG_HOME: path.join(home, '.config'),
    GIT_CONFIG_NOSYSTEM: '1', GIT_CONFIG_GLOBAL: '/dev/null', GIT_TERMINAL_PROMPT: '0', GOMAXPROCS: '4' };
  const sanitize = text => String(text).split(root).join('<fixture-root>').split(binary).join('<cli>');
  const trace = [], native = [], fixtureErrors = [], contractFailures = [], expectationFailures = [];
  const vm = { id: 'fixture', name: '', state: 'running' };
  let created = false, deleted = false, phase = 'seed';
  const ownedUploadPaths = new Set();
  const claims = () => {
    const dir = path.join(state, 'crabbox', 'claims');
    if (!fs.existsSync(dir)) return [];
    return fs.readdirSync(dir).filter(name => name.endsWith('.json')).map(name => {
      const claim = JSON.parse(fs.readFileSync(path.join(dir, name), 'utf8'));
      return { leaseID: claim.leaseID, provider: claim.provider, repoRoot: sanitize(claim.repoRoot), slug: claim.slug };
    });
  };
  const check = (list, label, actual, expected) => {
    try { assert.deepEqual(actual, expected); } catch { list.push({ label, actual, expected }); }
  };
  const server = http.createServer(async (req, res) => {
    const event = { sequence: trace.length + 1, phase, method: req.method, path: new URL(req.url, 'http://localhost').pathname };
    trace.push(event);
    const reply = (status, body) => { event.responseStatus = status; res.writeHead(status, { 'content-type': 'application/json' }); res.end(JSON.stringify(body)); };
    try {
      assert.equal(req.headers.authorization, 'Bearer synthetic-fixture-only');
      let data = '';
      for await (const chunk of req) { data += chunk; assert.ok(data.length <= 2 * 1024 * 1024, 'HTTP body too large'); }
      const body = data ? JSON.parse(data) : {};
      if (req.method === 'POST' && event.path === '/v1/vms') {
        assert.equal(created, false, 'duplicate allocation'); assert.deepEqual(body.ports, []);
        assert.match(body.name, /^crabbox-/); created = true; vm.name = body.name;
        event.vmName = body.name; reply(200, { id: vm.id });
      } else if (req.method === 'GET' && event.path === '/v1/vms') {
        reply(200, { vms: created && !deleted ? [vm] : [], totalCount: created && !deleted ? 1 : 0 });
      } else if (req.method === 'GET' && event.path === '/v1/vms/fixture') {
        reply(created && !deleted ? 200 : 404, created && !deleted ? vm : {});
      } else if (req.method === 'DELETE' && event.path === '/v1/vms/fixture') {
        assert.ok(created && !deleted, 'deletion did not address active fixture VM');
        if (phase === 'run' && scenario.deleteFailure) reply(500, { error: 'synthetic delete failure' });
        else { deleted = true; reply(200, {}); }
      } else if (req.method === 'PUT' && event.path.startsWith('/v1/vms/fixture/files/')) {
        assert.ok(created && !deleted);
        const destination = decodeURIComponent(event.path.slice('/v1/vms/fixture/files/'.length));
        assert.match(destination, /^\/tmp\/crabbox-freestyle-sync-[a-f0-9]+\.tgz\.api$/);
        assert.equal(body.encoding, 'base64');
        fs.writeFileSync(destination, Buffer.from(body.content, 'base64'), { flag: 'wx', mode: 0o600 });
        ownedUploadPaths.add(destination); event.bytes = Buffer.from(body.content, 'base64').length;
        reply(200, {});
      } else if (req.method === 'POST' && event.path === '/v1/vms/fixture/exec-await') {
        assert.ok(created && !deleted); assert.match(body.command, /^bash -lc /);
        const execution = await run('/bin/sh', ['-c', body.command], '/workspace', baseEnv, 5_000);
        assert.equal(execution.fault, null); assert.equal(execution.signal, null);
        const observation = { sequence: event.sequence, phase, command: sanitize(body.command),
          commandSha256: crypto.createHash('sha256').update(body.command).digest('hex'),
          exit: execution.code, stdout: sanitize(execution.stdout), stderr: sanitize(execution.stderr) };
        native.push(observation); event.nativeExit = execution.code;
        reply(200, { statusCode: execution.code, stdout: execution.stdout, stderr: execution.stderr });
      } else throw new Error(`unexpected route ${req.method} ${event.path}`);
    } catch (error) {
      fixtureErrors.push(sanitize(error.message));
      if (!res.headersSent) reply(500, { error: 'synthetic fixture assertion failed' }); else res.end();
    }
  });
  server.requestTimeout = 10_000;
  let record;
  try {
    fs.writeFileSync(path.join(repo, 'payload.txt'), 'fixture-data\n');
    for (const args of [['init', '-q'], ['add', '.'], ['-c', 'user.name=Synthetic Fixture', '-c', 'user.email=fixture@example.invalid', '-c', 'commit.gpgsign=false', 'commit', '-qm', 'fixture']]) {
      const git = await run('/usr/bin/git', args, repo, baseEnv, 5_000);
      assert.equal(git.code, 0, git.stderr); assert.equal(git.fault, null);
    }
    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
    const config = path.join(root, 'config.yaml');
    fs.writeFileSync(config, `provider: freestyle\nfreestyle:\n  apiUrl: http://127.0.0.1:${server.address().port}\n  workdir: repo\nsync:\n  delete: true\n  timeout: 10s\n`);
    const env = { ...baseEnv, CRABBOX_CONFIG: config, FREESTYLE_API_KEY: 'synthetic-fixture-only' };
    if (scenario.reused) {
      const seed = await run(binary, ['warmup', '--provider', 'freestyle', '--keep'], repo, env);
      assert.equal(seed.code, 0, seed.stderr); assert.equal(seed.fault, null);
      assert.equal(claims().length, 1, 'CLI warmup must seed the real local claim');
    }
    phase = 'run';
    const sessionPath = path.join(root, 'session.json');
    const workload = `printf 'case=${scenario.name} payload='; cat payload.txt; exit ${scenario.code}`;
    const args = ['run', '--provider', 'freestyle', '--timing-json', '--lease-output', sessionPath,
      ...(scenario.keepFailure ? ['--keep-on-failure'] : []), ...(scenario.reused ? ['--id', 'fsb_fixture'] : []), '--shell', workload];
    const observed = await run(binary, args, repo, env);
    assert.equal(observed.fault, null, 'CLI process limit or launch failure');
    assert.equal(observed.signal, null, 'CLI unexpectedly terminated by signal');
    const session = fs.existsSync(sessionPath) ? JSON.parse(fs.readFileSync(sessionPath, 'utf8')) : null;
    const timingRecords = observed.stderr.split('\n').flatMap(line => {
      try { const row = JSON.parse(line); return row.provider === 'freestyle' && 'exitCode' in row ? [row] : []; } catch { return []; }
    });
    const timing = timingRecords.at(-1) ?? null;
    const runTrace = trace.filter(event => event.phase === 'run');
    const postRunClaims = claims();
    const kept = Boolean(scenario.reused || scenario.keepFailure || scenario.deleteFailure);
    const expectedCode = scenario.code || (scenario.deleteFailure ? 1 : 0);
    const expectedOutput = `case=${scenario.name} payload=fixture-data\n`;
    check(contractFailures, 'public exit', observed.code, expectedCode);
    check(contractFailures, 'exact command stdout', observed.stdout, expectedOutput);
    check(contractFailures, 'session provider', session?.provider, 'freestyle');
    check(contractFailures, 'session lease', session?.leaseId, 'fsb_fixture');
    check(contractFailures, 'session reused', session?.reused, Boolean(scenario.reused));
    check(contractFailures, 'session kept', session?.kept, kept);
    check(contractFailures, 'claim count after run', postRunClaims.length, kept ? 1 : 0);
    if (kept) check(contractFailures, 'retained exact claim', postRunClaims[0]?.leaseID, 'fsb_fixture');
    check(contractFailures, 'run creates', runTrace.filter(e => e.method === 'POST' && e.path === '/v1/vms').length, scenario.reused ? 0 : 1);
    check(contractFailures, 'run delete attempts', runTrace.filter(e => e.method === 'DELETE').length, kept && !scenario.deleteFailure ? 0 : 1);
    check(contractFailures, 'VM active after run', created && !deleted, kept);
    check(contractFailures, 'native workload exit observed', native.some(n => n.phase === 'run' && n.stdout === expectedOutput && n.exit === scenario.code), true);
    check(contractFailures, 'timing exit', timing?.exitCode, expectedCode);
    check(contractFailures, 'timing status', timing?.runStatus, expectedCode === 0 ? 'succeeded' : 'failed');
    if (scenario.deleteFailure && scenario.code === 0) check(contractFailures, 'timing cleanup classification', timing?.errorKind, 'provider-error');
    if (scenario.code === 23) check(contractFailures, 'timing command classification', timing?.errorKind, 'command-exit');
    if (scenario.deleteFailure) check(contractFailures, 'cleanup diagnostic', observed.stderr.includes('synthetic delete failure'), true);
    const baselineRegression = mode === 'baseline' && scenario.regression;
    if (baselineRegression) {
      check(expectationFailures, 'baseline exposes cleanup success exit', observed.code, 0);
      check(expectationFailures, 'baseline exposes premature successful timing', timing?.exitCode, 0);
      check(expectationFailures, 'candidate contract actually failed', contractFailures.length > 0, true);
      expectationFailures.push(...contractFailures.filter(f => !['public exit', 'timing exit', 'timing status', 'timing cleanup classification'].includes(f.label)));
    } else expectationFailures.push(...contractFailures);
    record = { scenario: scenario.name, mode, expectedCandidateExit: expectedCode, exit: observed.code,
      stdout: sanitize(observed.stdout), stderr: sanitize(observed.stderr), session, timing,
      claimsAfterRun: postRunClaims, vmRetainedAfterRun: created && !deleted,
      candidateContractPassed: contractFailures.length === 0, regressionObserved: baselineRegression && contractFailures.length > 0,
      contractFailures, expectationFailures, trace, native };
    // Recovery is deliberately separate from Run and never masks its disposition.
    phase = 'teardown';
    if (!deleted) {
      const stop = await run(binary, ['stop', '--provider', 'freestyle', '--id', 'fsb_fixture'], repo, env);
      assert.equal(stop.code, 0, stop.stderr); assert.equal(stop.fault, null);
      record.explicitStop = { exit: stop.code, stdout: sanitize(stop.stdout), stderr: sanitize(stop.stderr) };
    }
    assert.equal(deleted, true); assert.deepEqual(claims(), []);
    const residue = fs.readdirSync('/tmp').filter(name => name.startsWith('crabbox-freestyle-sync-'));
    assert.deepEqual(residue, [], 'remote archive residue');
    assert.deepEqual(fs.readdirSync(temp).filter(name => name.startsWith('crabbox-freestyle-sync-')), [], 'local archive residue');
    record.teardown = { exactFixtureDeleted: true, claims: 0, archiveResidue: 0 };
  } catch (error) {
    fixtureErrors.push(sanitize(error.message));
    record ??= { scenario: scenario.name, mode, candidateContractPassed: false, contractFailures, expectationFailures, trace, native };
  } finally {
    for (const child of active) kill(child);
    server.closeAllConnections();
    if (server.listening) await new Promise(resolve => server.close(resolve));
    for (const file of ownedUploadPaths) fs.rmSync(file, { force: true });
    // Only these fixture-owned directories are removed; the mount itself survives.
    fs.rmSync('/workspace/repo', { recursive: true, force: true });
    for (const name of fs.readdirSync('/workspace')) {
      if (name.startsWith('.repo.crabbox-sync-')) fs.rmSync(path.join('/workspace', name), { recursive: true, force: true });
    }
    fs.rmSync(root, { recursive: true, force: true });
  }
  record.fixtureErrors = fixtureErrors;
  const publicRecord = JSON.parse(sanitize(JSON.stringify(record)));
  fs.writeFileSync(path.join(output, `${scenario.name}.json`), JSON.stringify(publicRecord, null, 2) + '\n', { flag: 'wx' });
  results.push(publicRecord);
  console.log(JSON.stringify({ scenario: scenario.name, exit: record.exit, candidateContractPassed: record.candidateContractPassed,
    regressionObserved: record.regressionObserved ?? false, expectationFailures: expectationFailures.length, fixtureErrors: fixtureErrors.length }));
}
clearTimeout(deadline);
const fixtureFailure = results.some(r => r.fixtureErrors.length);
const expectationFailure = results.some(r => r.expectationFailures.length);
const summary = { scope: 'Built CLI, production Freestyle HTTP client and real Linux Bash/tar/workspace operations; loopback synthetic service, not hosted Freestyle.',
  mode, binarySha256, scenarioCount: results.length, candidateContractPassed: results.every(r => r.candidateContractPassed),
  baselineRegressionsObserved: results.filter(r => r.regressionObserved).map(r => r.scenario),
  modeExpectationsPassed: !fixtureFailure && !expectationFailure, fixtureFailure, results };
fs.writeFileSync(path.join(output, 'results.json'), JSON.stringify(summary, null, 2) + '\n', { flag: 'wx' });
process.exitCode = fixtureFailure ? 2 : expectationFailure ? 1 : 0;

```
</details>

## Release note and compatibility

The Unreleased entry is maintainer-added landing work. Published 0.50.0 and older release sections remain byte-identical. The intentional correction is that failed automatic VM deletion no longer counts as a successful run; the retained session/claim and cleanup command remain available for recovery. No credential, configuration, provider authorization, claim-schema, or hosted-resource policy changes.
