### PR TITLE
fix(ci): allow image qualification Node setup

### DIFF
--- a/.github/workflows/image-qualification.yml
+++ b/.github/workflows/image-qualification.yml
@@ -82,7 +82,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: false
       - name: Install protected Worker toolchain
         run: npm ci --prefix harness/worker --ignore-scripts
       - name: Build and seal with protected tooling

--- a/.github/workflows/image-qualification.yml
+++ b/.github/workflows/image-qualification.yml
@@ -82,6 +82,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+          package-manager-cache: false
       - name: Install protected Worker toolchain
         run: npm ci --prefix harness/worker --ignore-scripts
       - name: Build and seal with protected tooling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - SmolVM: share sandbox run finalization so deletion failures no longer report success, early preparation failures honor keep-on-failure, and primary outcomes survive cleanup or timing errors while preserving provider keep policy and separate profile/resource cleanup budgets. [PR 1908](https://github.com/openclaw/crabbox/pull/1908).
+- Allow protected AWS image qualification to pass Node toolchain setup by omitting the unsupported `cache: false` input while keeping Go caching disabled. [PR 1909](https://github.com/openclaw/crabbox/pull/1909).
 - Fix documentation table-of-contents links for repeated headings so each link reaches its own section, while preserving existing first-heading URLs. [PR 1787](https://github.com/openclaw/crabbox/pull/1787). Thanks @steipete.
 - Shared sandbox runs: keep secondary cleanup and timing errors visible in CLI diagnostics without replacing the primary exit code. [PR 1907](https://github.com/openclaw/crabbox/pull/1907).
 - Freestyle: share sandbox run finalization so automatic deletion failures no longer report success, command failures survive later cleanup or timing errors, and transport cancellation causes remain available to callers. [PR 1907](https://github.com/openclaw/crabbox/pull/1907).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - SmolVM: share sandbox run finalization so deletion failures no longer report success, early preparation failures honor keep-on-failure, and primary outcomes survive cleanup or timing errors while preserving provider keep policy and separate profile/resource cleanup budgets. [PR 1908](https://github.com/openclaw/crabbox/pull/1908).
-- Allow protected AWS image qualification to pass Node toolchain setup by omitting the unsupported `cache: false` input while keeping Go caching disabled. [PR 1909](https://github.com/openclaw/crabbox/pull/1909).
+- Allow protected AWS image qualification to pass Node toolchain setup by using the supported no-cache input while keeping Go caching disabled. [PR 1909](https://github.com/openclaw/crabbox/pull/1909).
 - Fix documentation table-of-contents links for repeated headings so each link reaches its own section, while preserving existing first-heading URLs. [PR 1787](https://github.com/openclaw/crabbox/pull/1787). Thanks @steipete.
 - Shared sandbox runs: keep secondary cleanup and timing errors visible in CLI diagnostics without replacing the primary exit code. [PR 1907](https://github.com/openclaw/crabbox/pull/1907).
 - Freestyle: share sandbox run finalization so automatic deletion failures no longer report success, command failures survive later cleanup or timing errors, and transport cancellation causes remain available to callers. [PR 1907](https://github.com/openclaw/crabbox/pull/1907).

--- a/scripts/image-qualification-workflow.test.js
+++ b/scripts/image-qualification-workflow.test.js
@@ -49,7 +49,8 @@ test("workflow isolates candidate execution from protected credentials", () => {
     buildJob.indexOf("      - name: Install protected Worker toolchain"),
   );
   assert.match(setupGo, /cache: false/);
-  assert.doesNotMatch(setupNode, /cache:/);
+  assert.doesNotMatch(setupNode, /^\s+cache:/m);
+  assert.match(setupNode, /package-manager-cache: false/);
   assert.match(
     buildJob,
     /AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN CLOUDFLARE_API_TOKEN QUALIFICATION_CONTROLLER_TOKEN/,

--- a/scripts/image-qualification-workflow.test.js
+++ b/scripts/image-qualification-workflow.test.js
@@ -40,7 +40,16 @@ test("workflow isolates candidate execution from protected credentials", () => {
   assert.match(buildJob, /\.\/node_modules\/\.bin\/wrangler deploy --dry-run/);
   assert.match(buildJob, /image-qualification-control\.mjs manifest/);
   assert.match(buildJob, /build-inputs\.json/);
-  assert.match(buildJob, /cache: false/g);
+  const setupGo = buildJob.slice(
+    buildJob.indexOf("      - name: Set up Go"),
+    buildJob.indexOf("      - name: Set up Node"),
+  );
+  const setupNode = buildJob.slice(
+    buildJob.indexOf("      - name: Set up Node"),
+    buildJob.indexOf("      - name: Install protected Worker toolchain"),
+  );
+  assert.match(setupGo, /cache: false/);
+  assert.doesNotMatch(setupNode, /cache:/);
   assert.match(
     buildJob,
     /AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN CLOUDFLARE_API_TOKEN QUALIFICATION_CONTROLLER_TOKEN/,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers running protected AWS image qualification would see the credentialless build fail during Node setup before the candidate could be built or evaluated.

## Why This Change Was Made

The protected workflow passed `cache: false` to `actions/setup-node`, which treats the value as an unsupported package-manager name. The workflow now uses setup-node's supported `package-manager-cache: false` input while retaining the intentional `actions/setup-go` cache disablement, and the regression test checks those two action contracts independently.

## User Impact

Protected image qualification can progress past toolchain setup and evaluate the exact candidate revision.

## Evidence

- Reproduced in protected workflow run https://github.com/openclaw/crabbox/actions/runs/34023235057, job `Build and seal candidate without credentials`, at `Set up Node`.
- `node --test scripts/image-qualification-workflow.test.js`
- 17 tests passed.
- `git diff --check`
