### PR TITLE
fix(ci): qualify the current CLI artifact

### DIFF
--- a/.github/workflows/image-qualification.yml
+++ b/.github/workflows/image-qualification.yml
@@ -101,7 +101,7 @@ jobs:
           (
             cd candidate
             GOTOOLCHAIN=local GOWORK=off CGO_ENABLED=0 GOFLAGS=-mod=readonly \
-              go build -trimpath -o "$ARTIFACT/bin/crabbox" ./cmd/crabbox
+              go build -trimpath -ldflags='-s -w' -o "$ARTIFACT/bin/crabbox" ./cmd/crabbox
           )
           (
             cd harness/worker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Stop SSH readiness promptly on host-key rejection, including WSL SFTP and split or oversized diagnostics, without changing host trust. [PR 1877](https://github.com/openclaw/crabbox/pull/1877). Thanks @shunkakinoki.
 - Docker Sandbox: preserve primary failures through cleanup and timing errors, report retained sessions after failed removal, honor keep-on-failure during early preparation, and preserve successful clone commits across backend reporting failures. [PR 1913](https://github.com/openclaw/crabbox/pull/1913).
+- Allow protected image qualification to seal the current CLI by stripping debug metadata and accepting one artifact file up to the existing 128 MiB bundle cap without increasing the total limit. [PR 1910](https://github.com/openclaw/crabbox/pull/1910).
 - SmolVM: share sandbox run finalization so deletion failures no longer report success, early preparation failures honor keep-on-failure, and primary outcomes survive cleanup or timing errors while preserving provider keep policy and separate profile/resource cleanup budgets. [PR 1908](https://github.com/openclaw/crabbox/pull/1908).
 - Allow protected AWS image qualification to pass Node toolchain setup by using the supported no-cache input while keeping Go caching disabled. [PR 1909](https://github.com/openclaw/crabbox/pull/1909).
 - Fix documentation table-of-contents links for repeated headings so each link reaches its own section, while preserving existing first-heading URLs. [PR 1787](https://github.com/openclaw/crabbox/pull/1787). Thanks @steipete.

--- a/scripts/image-qualification-control.mjs
+++ b/scripts/image-qualification-control.mjs
@@ -451,7 +451,7 @@ export function createManifest(candidateDir, artifactDir, candidateSha, workflow
     }));
   if (
     files.length > 1024 ||
-    files.some((file) => file.bytes > 64 * 1024 * 1024) ||
+    files.some((file) => file.bytes > 128 * 1024 * 1024) ||
     files.reduce((total, file) => total + file.bytes, 0) > 128 * 1024 * 1024
   ) {
     throw new Error("candidate artifact exceeds the file or byte limit");

--- a/scripts/image-qualification-workflow.test.js
+++ b/scripts/image-qualification-workflow.test.js
@@ -36,7 +36,7 @@ test("workflow isolates candidate execution from protected credentials", () => {
   assert.match(buildJob, /npm ci --prefix harness\/worker --ignore-scripts/);
   assert.match(buildJob, /image-qualification-control\.mjs prepare-build/);
   assert.match(buildJob, /GOTOOLCHAIN=local GOWORK=off CGO_ENABLED=0 GOFLAGS=-mod=readonly/);
-  assert.match(buildJob, /go build -trimpath/);
+  assert.match(buildJob, /go build -trimpath -ldflags='-s -w'/);
   assert.match(buildJob, /\.\/node_modules\/\.bin\/wrangler deploy --dry-run/);
   assert.match(buildJob, /image-qualification-control\.mjs manifest/);
   assert.match(buildJob, /build-inputs\.json/);
@@ -60,7 +60,7 @@ test("workflow isolates candidate execution from protected credentials", () => {
   assert.doesNotMatch(workflow, /seal-candidate|image-qualification-candidate-raw/);
   const buildOrder = [
     "image-qualification-control.mjs prepare-build",
-    "go build -trimpath",
+    "go build -trimpath -ldflags='-s -w'",
     "./node_modules/.bin/wrangler deploy --dry-run",
     "image-qualification-control.mjs manifest",
     "Upload immutable candidate bundle",
@@ -232,14 +232,25 @@ test("protected build prep binds source, rejects substitution, and seals exact b
     fs.mkdirSync(path.join(artifact, "bin"), { recursive: true });
     fs.mkdirSync(path.join(artifact, "worker"), { recursive: true });
     fs.writeFileSync(path.join(artifact, "bin", "crabbox"), "candidate-cli");
+    fs.truncateSync(path.join(artifact, "bin", "crabbox"), 65 * 1024 * 1024);
     fs.writeFileSync(path.join(artifact, "worker", "index.js"), "export default {};");
     const manifest = module.createManifest(candidate, artifact, candidateSha, workflowSha);
+    assert.equal(
+      manifest.files.find((entry) => entry.path === "bin/crabbox")?.bytes,
+      65 * 1024 * 1024,
+    );
     assert.equal(
       module.verifyManifest(artifact, candidateSha, workflowSha).manifestSha256,
       manifest.manifestSha256,
     );
     fs.writeFileSync(path.join(artifact, "unexpected"), "nope");
     assert.throws(() => module.verifyManifest(artifact, candidateSha, workflowSha), /extra files/);
+    fs.rmSync(path.join(artifact, "unexpected"));
+    fs.truncateSync(path.join(artifact, "worker", "index.js"), 64 * 1024 * 1024);
+    assert.throws(
+      () => module.createManifest(candidate, artifact, candidateSha, workflowSha),
+      /candidate artifact exceeds the file or byte limit/,
+    );
 
     fs.writeFileSync(
       path.join(candidate, "worker", "package.json"),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where protected image qualification could build the current Crabbox CLI successfully but fail before sealing the candidate because the binary exceeded the manifest's 64 MiB per-file limit.

## Why This Change Was Made

The protected build now strips Go symbol and debug metadata. The manifest accepts one file up to the existing 128 MiB total bundle cap while leaving that total cap unchanged.

## User Impact

Maintainers can qualify the current CLI through the protected image workflow without weakening the bundle's overall size boundary.

## Evidence

- Reproduced on protected qualification run `34026344920`: normal CLI `147,315,282` bytes; stripped CLI `107,183,362` bytes.
- `node --test scripts/image-qualification-control.test.js scripts/image-qualification-workflow.test.js`: 17 passed.
- Regression proves a 65 MiB CLI is accepted and an aggregate over 128 MiB is rejected.
- Independent read-only review found no blocking issues; production/tooling delta is net zero.
