### PR TITLE
fix: share Docker Sandbox terminal failure handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Docker Sandbox: preserve primary failures through cleanup and timing errors, report retained sessions after failed removal, honor keep-on-failure during early preparation, and protect successful clone commits even when timing output fails.
+- Docker Sandbox: preserve primary failures through cleanup and timing errors, report retained sessions after failed removal, honor keep-on-failure during early preparation, and protect successful clone commits even when timing output fails. [PR 1913](https://github.com/openclaw/crabbox/pull/1913).
 - SmolVM: share sandbox run finalization so deletion failures no longer report success, early preparation failures honor keep-on-failure, and primary outcomes survive cleanup or timing errors while preserving provider keep policy and separate profile/resource cleanup budgets. [PR 1908](https://github.com/openclaw/crabbox/pull/1908).
 - Fix documentation table-of-contents links for repeated headings so each link reaches its own section, while preserving existing first-heading URLs. [PR 1787](https://github.com/openclaw/crabbox/pull/1787). Thanks @steipete.
 - Shared sandbox runs: keep secondary cleanup and timing errors visible in CLI diagnostics without replacing the primary exit code. [PR 1907](https://github.com/openclaw/crabbox/pull/1907).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Docker Sandbox: preserve primary failures through cleanup and timing errors, report retained sessions after failed removal, honor keep-on-failure during early preparation, and protect successful clone commits even when timing output fails.
 - Shared sandbox runs: keep secondary cleanup and timing errors visible in CLI diagnostics without replacing the primary exit code. [PR 1907](https://github.com/openclaw/crabbox/pull/1907).
 - Freestyle: share sandbox run finalization so automatic deletion failures no longer report success, command failures survive later cleanup or timing errors, and transport cancellation causes remain available to callers. [PR 1907](https://github.com/openclaw/crabbox/pull/1907).
 - Tensorlake: honor cancellation while waiting for run admission and ownership publication, and include claim-lock waiting in the detached failed-create rollback budget without losing the original failure or adopting a successor claim. [PR 1906](https://github.com/openclaw/crabbox/pull/1906).

--- a/docs/providers/docker-sandbox.md
+++ b/docs/providers/docker-sandbox.md
@@ -158,6 +158,22 @@ reports a nonzero code. Later cancellation does not replace an already observed
 ordinary exit. A normal CLI diagnostic exit cannot be distinguished from a remote
 workload exit without stronger native protocol evidence.
 
+Run finalization shares Crabbox's terminal error merger while keeping Docker's
+clone retention and native-workspace telemetry provider-specific. A failed
+automatic removal returns exit 1 after command success and leaves the session
+marked kept with its claim available for recovery. After a command or setup
+failure, later removal or timing errors remain visible without replacing the
+primary exit code or cause. `--keep-on-failure` also retains an acquired sandbox
+when command or environment preparation fails before execution.
+
+Clone retention is decided from successful command execution, before timing
+output: a later timing-write failure returns an error but does not discard
+unfetched commits. Failed or unexecuted clone commands are still cleaned up
+unless `--keep` or `--keep-on-failure` applies. Non-clone sandboxes already removed
+before a timing-write failure remain removed; reporting cannot retain them
+retroactively. Timing continues to mark sync skipped because the workspace is
+provider-delegated, not because Crabbox silently applies `--no-sync`.
+
 1. `warmup` or `run` without `--id` creates a Crabbox-owned sandbox name such as
    `crabbox-my-app-1a2b3c`.
 2. Crabbox runs `sbx create --name <name> ... shell <repo-root>` and records a

--- a/internal/providers/dockersandbox/backend.go
+++ b/internal/providers/dockersandbox/backend.go
@@ -67,7 +67,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	return nil
 }
 
-func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {
 	if err := rejectRunOptions(b.spec, req); err != nil {
 		return RunResult{}, err
 	}
@@ -81,44 +81,85 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		return RunResult{}, err
 	}
 	leaseID, sandboxName, slug := "", "", ""
-	acquired := false
-	if req.ID == "" {
+	acquired := req.ID == ""
+	if acquired {
 		leaseID, sandboxName, slug, err = b.createSandbox(ctx, cli, req.Repo, req.Reclaim, req.RequestedSlug)
 		if err != nil {
 			return RunResult{}, err
 		}
 		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s name=%s\n", leaseID, slug, providerName, sandboxName, sandboxName)
-		acquired = true
 	} else {
 		leaseID, sandboxName, slug, err = resolveLeaseID(req.ID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout)
 		if err != nil {
 			return RunResult{}, err
 		}
 	}
+	result = RunResult{
+		Provider: providerName, LeaseID: leaseID, Slug: slug, SyncDelegated: true,
+		Session: &core.RunSessionHandle{
+			Provider: providerName, LeaseID: leaseID, Slug: slug, Reused: !acquired, Kept: true,
+			CleanupCommand: fmt.Sprintf("crabbox stop --provider %s %s", providerName, slug),
+		},
+	}
 	shouldStop := acquired && !req.Keep
-	if shouldStop {
-		claim, err := dockerSandboxClaimForDeletion(leaseID)
-		if err != nil {
-			return RunResult{}, err
-		}
-		defer func() {
-			if !shouldStop {
-				return
+	var cleanupClaim core.LeaseClaim
+	commandRan := false
+	defer func() {
+		if retErr != nil && result.Status == "" {
+			outcome := core.FinalizeRunResult(core.RunResult{}, retErr)
+			result.Status, result.ErrorKind = outcome.Status, outcome.ErrorKind
+			result.ExitCode = 1
+			var public ExitError
+			if errors.As(retErr, &public) && public.Code != 0 {
+				result.ExitCode = public.Code
 			}
+			retErr = shared.ExitErrorWithCause(result.ExitCode, retErr.Error(), retErr)
+		}
+		if retErr != nil {
+			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		}
+		// Preserve clone commits based on command success, before reporting can fail.
+		if commandRan && retErr == nil && acquired && b.cfg.DockerSandbox.Clone && !req.Keep {
+			shouldStop = false
+			fmt.Fprintf(b.rt.Stderr, "docker-sandbox clone run kept sandbox to preserve unfetched commits; cleanup manually with: %s\n", result.Session.CleanupCommand)
+		}
+		if shouldStop {
 			cleanupCtx, cancel := context.WithTimeout(context.Background(), dockerSandboxCleanupTimeout)
-			defer cancel()
-			removeErr := core.RemoveLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
+			removeErr := core.RemoveLeaseClaimIfUnchangedAfter(leaseID, cleanupClaim, func() error {
 				return cli.remove(cleanupCtx, sandboxName)
 			})
+			cancel()
 			if removeErr != nil {
-				fmt.Fprintf(b.rt.Stderr, "warning: docker-sandbox rm failed for %s: %v\n", sandboxName, removeErr)
-				return
+				result, retErr = shared.AppendDelegatedRunFailure(result, retErr, fmt.Errorf("docker-sandbox cleanup failed for %s: %w", sandboxName, removeErr), 1)
+			} else {
+				result.Session.Kept = false
 			}
-		}()
+		}
+		result.Total = b.now().Sub(started)
+		result = core.FinalizeRunResult(result, retErr)
+		if commandRan {
+			fmt.Fprintf(b.rt.Stderr, "docker-sandbox run summary sync_delegated=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
+		}
+		if req.TimingJSON {
+			timingErr := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
+				Provider: providerName, LeaseID: leaseID, Slug: slug, SyncDelegated: true,
+				SyncPhases:  []timingPhase{{Name: "sync", Skipped: true, Reason: "provider-delegated workspace"}},
+				SyncSkipped: true, CommandMs: result.Command.Milliseconds(), TotalMs: result.Total.Milliseconds(),
+				ExitCode: result.ExitCode, Label: strings.TrimSpace(req.Label),
+			}, result, retErr))
+			result, retErr = shared.AppendDelegatedRunFailure(result, retErr, timingErr, 1)
+		}
+	}()
+	if shouldStop {
+		cleanupClaim, err = dockerSandboxClaimForDeletion(leaseID)
+		if err != nil {
+			shouldStop = false
+			return result, err
+		}
 	}
 	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
 	if err != nil {
-		return RunResult{}, err
+		return result, err
 	}
 	command := intent.Argv("sh", "-lc")
 	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
@@ -129,94 +170,25 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		var cleanup func()
 		envFile, cleanup, err = writeDockerSandboxEnvFile(req.Env)
 		if err != nil {
-			return RunResult{}, err
+			return result, err
 		}
 		defer cleanup()
 	}
 	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s sync_delegated=true\n", providerName, leaseID, sandboxName, workdir)
 	commandStart := b.now()
 	exitCode, runErr := cli.execStream(ctx, sandboxName, workdir, envFile, command, b.rt.Stdout, b.rt.Stderr)
-	commandDuration := b.now().Sub(commandStart)
+	result.Command = b.now().Sub(commandStart)
+	result.CommandText = strings.Join(req.Command, " ")
+	commandRan = true
 	outcome := shared.FinalizeDelegatedCommandOutcome(exitCode, runErr)
-	exitCode = outcome.ExitCode
-	result := RunResult{
-		ExitCode:      exitCode,
-		Status:        outcome.Status,
-		ErrorKind:     outcome.ErrorKind,
-		Command:       commandDuration,
-		Total:         b.now().Sub(started),
-		SyncDelegated: true,
-		Provider:      providerName,
-		LeaseID:       leaseID,
-		Slug:          slug,
-		CommandText:   strings.Join(req.Command, " "),
-		Session: (&coreRunSessionHandle{
-			Provider:       providerName,
-			LeaseID:        leaseID,
-			Slug:           slug,
-			Reused:         !acquired,
-			Kept:           !shouldStop,
-			CleanupCommand: fmt.Sprintf("crabbox stop --provider %s %s", providerName, slug),
-		}).handle(),
-	}
-	fmt.Fprintf(b.rt.Stderr, "docker-sandbox run summary sync_delegated=true command=%s total=%s exit=%d\n", commandDuration.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
-	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
-			Provider:      providerName,
-			LeaseID:       leaseID,
-			Slug:          slug,
-			SyncDelegated: true,
-			SyncPhases:    []timingPhase{{Name: "sync", Skipped: true, Reason: "provider-delegated workspace"}},
-			SyncSkipped:   true,
-			CommandMs:     commandDuration.Milliseconds(),
-			TotalMs:       result.Total.Milliseconds(),
-			ExitCode:      exitCode,
-			Label:         strings.TrimSpace(req.Label),
-		}, result, runErr)); err != nil {
-			if result.Status == core.RunStatusSucceeded {
-				failure := shared.FinalizeDelegatedCommandOutcome(0, err)
-				result.ExitCode, result.Status, result.ErrorKind = failure.ExitCode, failure.Status, failure.ErrorKind
-			}
-			return result, err
-		}
-	}
+	result.ExitCode, result.Status, result.ErrorKind = outcome.ExitCode, outcome.Status, outcome.ErrorKind
 	if runErr != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		result.Session.Kept = !shouldStop
-		return result, shared.ExitErrorWithCause(exitCode, fmt.Sprintf("docker-sandbox run failed: %v", shared.RedactErrorSecrets(runErr.Error())), runErr)
+		return result, shared.ExitErrorWithCause(result.ExitCode, fmt.Sprintf("docker-sandbox run failed: %v", shared.RedactErrorSecrets(runErr.Error())), runErr)
 	}
-	if exitCode != 0 {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		result.Session.Kept = !shouldStop
-		return result, exit(exitCode, "docker-sandbox run exited %d", exitCode)
+	if result.ExitCode != 0 {
+		return result, exit(result.ExitCode, "docker-sandbox run exited %d", result.ExitCode)
 	}
-	if acquired && b.cfg.DockerSandbox.Clone && !req.Keep {
-		shouldStop = false
-		result.Session.Kept = true
-		fmt.Fprintf(b.rt.Stderr, "docker-sandbox clone run kept sandbox to preserve unfetched commits; cleanup manually with: %s\n", result.Session.CleanupCommand)
-	}
-	result.Session.Kept = !shouldStop
 	return result, nil
-}
-
-type coreRunSessionHandle struct {
-	Provider       string
-	LeaseID        string
-	Slug           string
-	Reused         bool
-	Kept           bool
-	CleanupCommand string
-}
-
-func (h coreRunSessionHandle) handle() *core.RunSessionHandle {
-	return &core.RunSessionHandle{
-		Provider:       h.Provider,
-		LeaseID:        h.LeaseID,
-		Slug:           h.Slug,
-		Reused:         h.Reused,
-		Kept:           h.Kept,
-		CleanupCommand: h.CleanupCommand,
-	}
 }
 
 func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {

--- a/internal/providers/dockersandbox/backend_test.go
+++ b/internal/providers/dockersandbox/backend_test.go
@@ -271,18 +271,18 @@ func TestRunCleanupPreservesReplacedClaim(t *testing.T) {
 		Repo:    Repo{Name: "my-app", Root: t.TempDir()},
 		Command: []string{"echo", "ok"},
 	})
-	if err != nil {
-		t.Fatal(err)
+	if err == nil || result.ExitCode != 1 || result.Status != core.RunStatusFailed || result.ErrorKind != core.RunErrorProvider || result.Session == nil || !result.Session.Kept {
+		t.Fatalf("changed claim cleanup result=%+v err=%v", result, err)
 	}
 	if findCall(runner, "rm") != nil {
 		t.Fatal("cleanup removed a sandbox after its local claim was replaced")
 	}
-	claim, ok, err := resolveLeaseClaimForProvider(result.LeaseID, providerName)
-	if err != nil || !ok || claim.RepoRoot != replacementRepo {
-		t.Fatalf("replacement claim=%#v ok=%t err=%v", claim, ok, err)
+	claim, ok, claimErr := resolveLeaseClaimForProvider(result.LeaseID, providerName)
+	if claimErr != nil || !ok || claim.RepoRoot != replacementRepo {
+		t.Fatalf("replacement claim=%#v ok=%t err=%v", claim, ok, claimErr)
 	}
-	if !strings.Contains(stderr.String(), "claim changed; retry") {
-		t.Fatalf("cleanup warning=%q", stderr.String())
+	if !strings.Contains(err.Error(), "claim changed; retry") {
+		t.Fatalf("cleanup diagnostic=%v", err)
 	}
 }
 
@@ -317,6 +317,200 @@ func TestRunCloneModeKeepsSandboxAfterSuccess(t *testing.T) {
 	}
 	if claim, ok, err := resolveLeaseClaimForProvider(result.LeaseID, providerName); err != nil || !ok || claim.LeaseID == "" {
 		t.Fatalf("kept clone claim claim=%#v ok=%t err=%v", claim, ok, err)
+	}
+}
+
+type terminalTimingWriter struct {
+	bytes.Buffer
+	cause error
+}
+
+func (w *terminalTimingWriter) Write(data []byte) (int, error) {
+	if len(data) > 0 && data[0] == '{' {
+		return 0, w.cause
+	}
+	return w.Buffer.Write(data)
+}
+
+func TestRunTerminalFailuresPreserveOutcomeAndDisposition(t *testing.T) {
+	for _, tc := range []struct {
+		name                                              string
+		code                                              int
+		cause                                             error
+		clone, cleanup, timing, keepFailure, badEnv, keep bool
+	}{
+		{name: "cleanup after success", cleanup: true},
+		{name: "command and cleanup", code: 23, cleanup: true},
+		{name: "command cleanup and timing", code: 23, cleanup: true, timing: true},
+		{name: "kept command and timing", code: 23, keepFailure: true, timing: true},
+		{name: "transport cleanup and timing", cause: io.ErrUnexpectedEOF, cleanup: true, timing: true},
+		{name: "cancellation cleanup and timing", cause: context.Canceled, cleanup: true, timing: true},
+		{name: "deadline cleanup and timing", cause: context.DeadlineExceeded, cleanup: true, timing: true},
+		{name: "clone success then timing", clone: true, timing: true},
+		{name: "clone failure then timing", clone: true, code: 23, timing: true},
+		{name: "ordinary success then timing", timing: true, keepFailure: true},
+		{name: "environment failure and cleanup", badEnv: true, cleanup: true},
+		{name: "kept environment failure", badEnv: true, keep: true},
+		{name: "early environment failure retained", badEnv: true, keepFailure: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			cleanupErr, writerErr := errors.New("synthetic remove failure"), errors.New("synthetic timing failure")
+			replies := map[string]scriptedReply{"create": {}, "exec": {exitCode: tc.code, err: tc.cause}, "rm": {}}
+			if tc.cleanup {
+				replies["rm"] = scriptedReply{err: cleanupErr}
+			}
+			runner := newRunner(replies, nil)
+			var stderr bytes.Buffer
+			var diagnostics io.Writer = &stderr
+			if tc.timing {
+				diagnostics = &terminalTimingWriter{cause: writerErr}
+			}
+			cfg := newTestConfig()
+			cfg.DockerSandbox.Clone = tc.clone
+			repoRoot := t.TempDir()
+			if tc.clone {
+				runGit(t, repoRoot, "init", "-q")
+			}
+			req := RunRequest{Repo: Repo{Name: "fixture", Root: repoRoot}, Command: []string{"true"}, TimingJSON: true, KeepOnFailure: tc.keepFailure, Keep: tc.keep}
+			if tc.badEnv {
+				req.Env = map[string]string{"INVALID-NAME": "synthetic"}
+			}
+			backend := newTestBackend(cfg, runner, io.Discard, diagnostics)
+			result, err := backend.Run(t.Context(), req)
+			wantCode, wantStatus, wantKind := tc.code, core.RunStatusFailed, core.RunErrorCommandExit
+			if tc.cause != nil {
+				wantCode = 1
+				wantKind = core.RunErrorProvider
+				if tc.cause == context.Canceled {
+					wantStatus = core.RunStatusCanceled
+					wantKind = core.RunErrorCanceled
+				}
+				if tc.cause == context.DeadlineExceeded {
+					wantStatus = core.RunStatusTimedOut
+					wantKind = core.RunErrorTimeout
+				}
+			}
+			if tc.badEnv {
+				wantCode = 2
+				wantKind = core.RunErrorProvider
+			}
+			if wantCode == 0 {
+				wantCode = 1
+				wantKind = core.RunErrorProvider
+			}
+			var public ExitError
+			if !errors.As(err, &public) || public.Code != wantCode || result.ExitCode != wantCode || result.Status != wantStatus || result.ErrorKind != wantKind {
+				t.Errorf("primary outcome result=%+v err=%v public=%+v", result, err, public)
+			}
+			for _, cause := range []error{tc.cause, replies["rm"].err} {
+				if cause != nil && !errors.Is(err, cause) {
+					t.Errorf("cause %v lost: %v", cause, err)
+				}
+			}
+			if tc.cleanup && !strings.Contains(public.Message, cleanupErr.Error()) {
+				t.Errorf("cleanup diagnostic missing: %q", public.Message)
+			}
+			if tc.timing && (!errors.Is(err, writerErr) || !strings.Contains(public.Message, writerErr.Error())) {
+				t.Errorf("timing cause/diagnostic lost: %v", err)
+			}
+			commandFailed := tc.code != 0 || tc.cause != nil
+			wantStop := !tc.keep && !(tc.keepFailure && (commandFailed || tc.badEnv)) && !(tc.clone && !commandFailed && !tc.badEnv)
+			wantKept := !wantStop || tc.cleanup
+			if result.Session == nil || result.Session.Kept != wantKept || result.Session.Reused || result.Session.LeaseID != result.LeaseID {
+				t.Errorf("disposition session=%+v want kept=%t", result.Session, wantKept)
+			}
+			if (findCall(runner, "rm") != nil) != wantStop {
+				t.Errorf("remove calls=%v want stop=%t", callVerbs(runner), wantStop)
+			}
+			if claim, ok, claimErr := resolveLeaseClaimForProvider(result.LeaseID, providerName); claimErr != nil || ok != wantKept || ok && claim.RepoRoot != repoRoot {
+				t.Errorf("claim=%+v exists=%t want=%t err=%v", claim, ok, wantKept, claimErr)
+			}
+			if tc.badEnv && findCall(runner, "exec") != nil {
+				t.Error("invalid environment reached workload")
+			}
+			if tc.clone && !commandFailed && !strings.Contains(diagnostics.(*terminalTimingWriter).String(), "clone run kept sandbox") {
+				t.Error("clone preservation guidance missing")
+			}
+			if !tc.timing {
+				assertTerminalTiming(t, stderr.String(), result, err)
+			}
+		})
+	}
+}
+
+func assertTerminalTiming(t *testing.T, diagnostics string, result RunResult, err error) {
+	t.Helper()
+	var reports []core.TimingReport
+	for _, line := range strings.Split(strings.TrimSpace(diagnostics), "\n") {
+		if strings.HasPrefix(line, "{") {
+			var report core.TimingReport
+			if err := json.Unmarshal([]byte(line), &report); err != nil {
+				t.Fatal(err)
+			}
+			reports = append(reports, report)
+		}
+	}
+	if len(reports) != 1 {
+		t.Fatalf("timing records=%d diagnostics=%s", len(reports), diagnostics)
+	}
+	report := reports[0]
+	result = core.FinalizeRunResult(result, err)
+	if report.ExitCode != result.ExitCode || report.RunStatus != result.Status || report.ErrorKind != result.ErrorKind || report.LeaseID != result.LeaseID || report.Slug != result.Slug || !report.SyncDelegated || !report.SyncSkipped || !reflect.DeepEqual(report.SyncPhases, []core.TimingPhase{{Name: "sync", Skipped: true, Reason: "provider-delegated workspace"}}) {
+		t.Fatalf("timing=%+v result=%+v", report, result)
+	}
+}
+
+func TestRunCloneFailureAndNativeWorkspaceControls(t *testing.T) {
+	for _, tc := range []struct {
+		name                                            string
+		clone, keep, keepFailure, reuse, noSync, badEnv bool
+		code                                            int
+	}{
+		{name: "clone success", clone: true},
+		{name: "clone command failure", clone: true, code: 23},
+		{name: "clone kept failure", clone: true, code: 23, keepFailure: true},
+		{name: "clone explicit keep", clone: true, code: 23, keep: true},
+		{name: "native workspace"},
+		{name: "explicit no sync", noSync: true},
+		{name: "reused failure", reuse: true, code: 23},
+		{name: "early failure cleanup", badEnv: true},
+		{name: "unexecuted clone cleanup", clone: true, badEnv: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			cfg := newTestConfig()
+			cfg.DockerSandbox.Clone = tc.clone
+			repoRoot := t.TempDir()
+			if tc.clone {
+				runGit(t, repoRoot, "init", "-q")
+			}
+			runner := newRunner(map[string]scriptedReply{"create": {}, "exec": {exitCode: tc.code}, "rm": {}}, nil)
+			var stderr bytes.Buffer
+			backend := newTestBackend(cfg, runner, io.Discard, &stderr)
+			req := RunRequest{Repo: Repo{Name: "fixture", Root: repoRoot}, Command: []string{"true"}, TimingJSON: true, Keep: tc.keep, KeepOnFailure: tc.keepFailure, NoSync: tc.noSync}
+			if tc.reuse {
+				req.ID = "dsbx_crabbox-fixture-123456"
+				if err := claimLeaseForRepoProviderPond(req.ID, "fixture", providerName, "", repoRoot, time.Hour, false); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tc.badEnv {
+				req.Env = map[string]string{"INVALID-NAME": "synthetic"}
+			}
+			result, err := backend.Run(t.Context(), req)
+			wantKept := tc.keep || tc.reuse || tc.clone && tc.code == 0 && !tc.badEnv || tc.keepFailure && tc.code != 0
+			if (err != nil) != (tc.code != 0 || tc.badEnv) || (findCall(runner, "rm") != nil) == wantKept {
+				t.Fatalf("err=%v calls=%v", err, callVerbs(runner))
+			}
+			if tc.badEnv {
+				return
+			}
+			if result.ExitCode != tc.code || result.Session == nil || result.Session.Kept != wantKept || result.Session.Reused != tc.reuse {
+				t.Fatalf("result=%+v err=%v", result, err)
+			}
+			assertTerminalTiming(t, stderr.String(), result, err)
+		})
 	}
 }
 

--- a/internal/providers/shared/delegated.go
+++ b/internal/providers/shared/delegated.go
@@ -89,6 +89,24 @@ func FinalizeDelegatedCommandOutcome(exitCode int, err error) core.RunResult {
 	return outcome
 }
 
+// AppendDelegatedRunFailure adds a terminal cleanup or reporting failure to an
+// already classified primary outcome. A first failure selects firstCode and a
+// provider-error result; later failures preserve the primary code/status and
+// expose each safe error message without formatting hidden underlying causes.
+func AppendDelegatedRunFailure(result core.RunResult, primary, secondary error, firstCode int) (core.RunResult, error) {
+	if secondary == nil {
+		return result, primary
+	}
+	if primary == nil {
+		result.ExitCode = firstCode
+		result.Status, result.ErrorKind = core.RunStatusFailed, core.RunErrorProvider
+		return result, ExitErrorWithCause(firstCode, secondary.Error(), secondary)
+	}
+	joined := errors.Join(primary, secondary)
+	// The CLI prints the selected ExitError message, not the joined error.
+	return result, ExitErrorWithCause(result.ExitCode, joined.Error(), joined)
+}
+
 // RunDelegatedSandbox owns the single sandbox run sequence and finalization.
 // The first failure determines the exit code/status; later cleanup failures are
 // joined as diagnostics. Sandbox cleanup alone fails with code 1. A failed deletion
@@ -146,19 +164,7 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 			retErr = ExitErrorWithCause(result.ExitCode, retErr.Error(), retErr)
 		}
 		appendFailure := func(err error, firstCode int) {
-			if err == nil {
-				return
-			}
-			if retErr == nil {
-				result.ExitCode = firstCode
-				result.Status, result.ErrorKind = core.RunStatusFailed, core.RunErrorProvider
-				retErr = ExitErrorWithCause(firstCode, err.Error(), err)
-			} else {
-				joined := errors.Join(retErr, err)
-				// The CLI prints the selected ExitError message, not the joined
-				// error. Keep secondary diagnostics in that public envelope too.
-				retErr = ExitErrorWithCause(result.ExitCode, joined.Error(), joined)
-			}
+			result, retErr = AppendDelegatedRunFailure(result, retErr, err, firstCode)
 		}
 		if command.Close != nil {
 			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)

--- a/internal/providers/shared/delegated_test.go
+++ b/internal/providers/shared/delegated_test.go
@@ -35,6 +35,52 @@ func TestExitErrorWithCausePreservesSelectedCodeAndMessage(t *testing.T) {
 	}
 }
 
+func TestAppendDelegatedRunFailurePreservesSelectedOutcome(t *testing.T) {
+	primaryCause := errors.New("hidden primary detail")
+	secondaryCause := errors.New("hidden secondary detail")
+	primary := ExitErrorWithCause(23, "safe primary", primaryCause)
+	secondary := ExitErrorWithCause(9, "safe secondary", secondaryCause)
+	for _, tc := range []struct {
+		name                 string
+		primary, secondary   error
+		beforeCode, wantCode int
+	}{
+		{name: "first failure", secondary: secondary, wantCode: 5},
+		{name: "secondary failure", primary: primary, secondary: secondary, beforeCode: 23, wantCode: 23},
+		{name: "no secondary", primary: primary, beforeCode: 23, wantCode: 23},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before := core.FinalizeRunResult(core.RunResult{Provider: "fixture", LeaseID: "lease", Total: time.Second, Session: &core.RunSessionHandle{Kept: true}, ExitCode: tc.beforeCode}, tc.primary)
+			result, err := AppendDelegatedRunFailure(before, tc.primary, tc.secondary, 5)
+			var public core.ExitError
+			if !errors.As(err, &public) || public.Code != tc.wantCode || result.ExitCode != tc.wantCode || result.Status != core.RunStatusFailed {
+				t.Fatalf("result=%+v err=%v", result, err)
+			}
+			if tc.primary != nil && (!errors.Is(err, primaryCause) || !strings.Contains(public.Message, "safe primary")) {
+				t.Fatalf("primary lost: %v", err)
+			}
+			if tc.secondary != nil && (!errors.Is(err, secondaryCause) || !strings.Contains(public.Message, "safe secondary")) {
+				t.Fatalf("secondary lost: %v", err)
+			}
+			if strings.Contains(err.Error(), "hidden") {
+				t.Fatalf("unsafe cause exposed: %v", err)
+			}
+			want := before
+			want.ExitCode = tc.wantCode
+			if tc.primary == nil {
+				want.Status = core.RunStatusFailed
+				want.ErrorKind = core.RunErrorProvider
+			}
+			if !reflect.DeepEqual(result, want) {
+				t.Fatalf("unrelated state changed: result=%+v want=%+v", result, want)
+			}
+			if tc.secondary == nil && err != tc.primary {
+				t.Fatal("nil failure replaced the primary error")
+			}
+		})
+	}
+}
+
 func TestDelegatedSandboxSecondaryDiagnosticsKeepSafeMessages(t *testing.T) {
 	primary := errors.New("raw execution detail")
 	secondary := errors.New("raw cleanup detail")


### PR DESCRIPTION
## Summary

Docker Sandbox could report a successful run and `kept=false` when automatic `sbx rm` failed, even though the sandbox and recovery claim remained. Cleanup now participates in the terminal result: removal failure after command success returns exit 1, while removal failure after command exit 23 preserves 23. Both failures keep the session marked retained and expose the cleanup diagnostic.

The change extracts the existing shared terminal-error merger into `AppendDelegatedRunFailure` and reuses it from Docker’s deferred finalizer. The first failure owns the exit code and status; later cleanup or reporting failures retain their messages and causes without replacing that outcome. Docker continues to own clone retention, native workspace behavior, and deletion policy. The redundant private session-handle mirror is removed.

Native-mounted workspace semantics and delegated sync telemetry remain intact. Successful clones keep unfetched commits; failed or unexecuted clone commands receive normal cleanup unless `--keep` or `--keep-on-failure` applies. Reused sandboxes are not automatically deleted. `--keep-on-failure` now also covers post-acquisition command/environment preparation failures. A sandbox already removed cannot be retained retroactively because reporting later fails.

The provider documentation and maintainer-added Unreleased entry describe these outcomes. No dependencies, configuration schema, credentials, native CLI protocol, or claim-lock policy change.

## Native behavior proof

Built parent and candidate CLIs exercised the production Docker provider and local command runner through an isolated synthetic `sbx` executable. Workloads ran as real processes, received private env files, and used normal Git checkouts; clone workloads created real unfetched commits. This proves the local native-process and ownership boundary, not hosted Docker Sandbox behavior or mount isolation.

All **14 mode-specific expectations** passed: seven scenarios against each binary. Baseline expectations deliberately include the old incorrect outcomes.

| Scenario | Parent exit / session kept | Candidate exit / session kept | Observed resource state |
| --- | --- | --- | --- |
| Fresh command succeeds | 0 / false | 0 / false | Removed; no claim |
| Clone command succeeds | 0 / true | 0 / true | Clone commit and claim retained |
| Command exits 23; removal fails | 23 / false | 23 / true | Sandbox and claim retained |
| Command succeeds; removal fails | 0 / false | 1 / true | Sandbox and claim retained |
| Keep-on-failure; command exits 23 | 23 / true | 23 / true | Sandbox and claim retained |
| Reused sandbox; command succeeds | 0 / true | 0 / true | No automatic removal |
| Clone command exits 23 | 23 / false | 23 / false | Removed; no claim |

The two removal-failure scenarios each recorded one create, one workload, one failed removal, and one surviving claim. Both versions emitted removal diagnostics; the fix makes the error part of the terminal outcome and corrects session disposition. Public timing agrees with the candidate exit and failure kind. All standard scenarios checked env-file presence with mode 0600 during execution, removal afterward, absence of the forwarded value from native arguments, and preserved delegated-workspace timing.

Parent source: `bcd8ffc9bb5f51f30c8cfefd75dfb2cea12f1164`; binary SHA-256: `13719aee92ab95f3c7b41ea9fe7f44a550cdc84463d74e774a54a4629398b1b8`.

Candidate source: `8bf36f32ff284c141528722888a83c0223736902`; binary SHA-256: `25ecb9f2e4cd89324e84d7d970e329334e8b3c389930401854aeb74dc3dbc1e9`.

The hashes match the captured rows. Source binding uses the recorded builds and frozen source comparison; the binaries do not embed VCS revisions. Both owned outer execution containers were removed after evidence collection.

## Reporting-failure scope and failed hypothesis

A separate `/dev/full` experiment **failed its hypothesis**, and its failing results are preserved. Both native workloads completed successfully and made clone commits, but **both public CLIs returned 7 and retained the clone and claim, with zero removals**. It did not reproduce a standard-CLI clone-deletion regression.

The standard CLI buffers the provider’s timing report and flushes it after backend finalization. Consequently, failing every stderr write from startup does not inject a selective late writer failure into `Backend.Run`. No timing JSON is observable through that sink. The direct-backend selective-writer unit oracle remains separate: it checks primary-error preservation and clone retention when the backend’s own timing writer fails. Early environment-preparation retention is likewise unit-tested, not claimed as native CLI proof.

## Verification

- Direct backend regression tests cover cleanup-only failure, primary command/transport/cancellation/deadline preservation, selective timing-writer failure, clone retention, and early keep-on-failure behavior. Thirteen baseline regression leaves failed before the Docker fix; candidate package tests passed.
- Race tests and vet passed for Docker Sandbox, the shared owner, and the 15 existing shared-lifecycle adopters in the recorded validation pass. After main integration, Docker Sandbox, shared, and SmolVM race tests passed again.
- Formatting and diff checks passed. The original seven-scenario native harness passed all 14 expectations. The separate all-stderr experiment remains failed and is not counted as regression proof.

## Current integration

Head `0eab7f4e2fd22a009f5980df7bf445f5cb2ecfd0` integrates main's SSH readiness fix and image-qualification CI setup fix. Docker Sandbox and shared terminal production sources are unchanged from the native-proof candidate `8bf36f32ff284c141528722888a83c0223736902`; the original binary is not relabeled as a new build. The changelog now explicitly describes the clone reporting case as a backend-boundary behavior.

After integration, `GOTOOLCHAIN=go1.26.5 go test -race -count=1 ./internal/providers/dockersandbox ./internal/providers/shared ./internal/providers/smolvm` passed (4.106s, 3.394s, and 9.072s). The complete integrated change bundle passed managed Codex autoreview with no actionable P0 findings; this is priority-scoped, not a full correctness certificate.
