### PR TITLE
fix: image qualification fails before candidate admission

### DIFF
--- a/.github/workflows/image-qualification.yml
+++ b/.github/workflows/image-qualification.yml
@@ -140,6 +140,7 @@ jobs:
         with:
           artifact-ids: ${{ needs.build-candidate.outputs.candidate_artifact_id }}
           path: ${{ runner.temp }}/image-qualification-candidate
+          merge-multiple: true
       - name: Verify manifest and rollback admission contract
         env:
           GH_TOKEN: ${{ github.token }}
@@ -187,6 +188,7 @@ jobs:
         with:
           artifact-ids: ${{ needs.build-candidate.outputs.candidate_artifact_id }}
           path: ${{ runner.temp }}/image-qualification-candidate
+          merge-multiple: true
       - name: Revalidate, deploy, read back, and enroll
         id: deploy
         env:
@@ -283,6 +285,7 @@ jobs:
         with:
           artifact-ids: ${{ needs.build-candidate.outputs.candidate_artifact_id }}
           path: ${{ runner.temp }}/image-qualification-candidate
+          merge-multiple: true
       - name: Run publisher rollback qualification
         env:
           QUALIFICATION_RELAY_URL: ${{ needs.deploy-enroll.outputs.relay_url }}
@@ -308,7 +311,7 @@ jobs:
 
   finalize:
     name: Protected finalization and zero-residue proof
-    if: always()
+    if: ${{ always() && needs.deploy-enroll.result != 'skipped' }}
     needs: [authorize, deploy-enroll, arm, execute]
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Extract protected image-qualification candidates at the canonical artifact path and avoid protected finalization when deployment never started.
 - Stop SSH readiness promptly on host-key rejection, including WSL SFTP and split or oversized diagnostics, without changing host trust. [PR 1877](https://github.com/openclaw/crabbox/pull/1877). Thanks @shunkakinoki.
 - Apple Machine: fail runs when automatic deletion fails or remains unconfirmed, retain recovery sessions for early keep-on-failure errors, and preserve command outcomes while distinguishing native transport failures through the shared error handlers. [PR 1914](https://github.com/openclaw/crabbox/pull/1914).
 - Docker Sandbox: preserve primary failures through cleanup and timing errors, report retained sessions after failed removal, honor keep-on-failure during early preparation, and preserve successful clone commits across backend reporting failures. [PR 1913](https://github.com/openclaw/crabbox/pull/1913).

--- a/scripts/image-qualification-workflow.test.js
+++ b/scripts/image-qualification-workflow.test.js
@@ -102,6 +102,37 @@ test("workflow isolates candidate execution from protected credentials", () => {
   assert.match(protectedJobs, /candidate bytes as inert data/);
 });
 
+test("candidate downloads extract the artifact at the canonical path", () => {
+  const downloadSteps = [...workflow.matchAll(
+    /^      - name: [^\n]+\n        uses: actions\/download-artifact@[^\n]+\n        with:\n((?:          .+\n)+)/gm,
+  )];
+  const candidateDownloads = downloadSteps.filter(([, inputs]) =>
+    inputs.includes("artifact-ids:"),
+  );
+
+  assert.equal(candidateDownloads.length, 3);
+  for (const [, inputs] of candidateDownloads) {
+    assert.match(
+      inputs,
+      /^          artifact-ids: \$\{\{ needs\.build-candidate\.outputs\.candidate_artifact_id \}\}$/m,
+    );
+    assert.match(
+      inputs,
+      /^          path: \$\{\{ runner\.temp \}\}\/image-qualification-candidate$/m,
+    );
+    assert.match(inputs, /^          merge-multiple: true$/m);
+  }
+});
+
+test("finalization skips protected approval when deployment never started", () => {
+  const finalizeJob = workflow.slice(workflow.indexOf("  finalize:"));
+
+  assert.match(
+    finalizeJob,
+    /^    if: \$\{\{ always\(\) && needs\.deploy-enroll\.result != 'skipped' \}\}$/m,
+  );
+});
+
 test("all workflow actions use immutable repository-standard pins", () => {
   for (const source of [workflow, reaper]) {
     for (const line of source.matchAll(/uses:\s+([^@\s]+)@([^\s]+)/g)) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where protected image qualification failed before candidate
admission because the downloaded bundle was nested below the canonical artifact
directory. The observed failure in workflow run
https://github.com/openclaw/crabbox/actions/runs/34031692511 was:

```text
ENOENT: no such file or directory, stat '/home/runner/work/_temp/image-qualification-candidate/manifest.json'
```

The failed admission also left protected finalization waiting for approval even
though deployment had never started.

## Why This Change Was Made

The three candidate downloads keep exact artifact-ID selection and now use the
download action's merge mode so bundle contents are extracted directly at the
canonical path expected by admission, deployment, and execution.

Finalization still runs after any started deployment outcome, but skips when the
deployment job never ran and therefore created no protected resources.

## User Impact

Maintainers can rerun protected image qualification without the candidate bundle
being hidden under an extra artifact-name directory. Pre-deployment failures no
longer request unnecessary protected-environment approval.

## Evidence

- Before fix: `node --test scripts/image-qualification-workflow.test.js`
  reproduced two failing contract tests for artifact layout and finalization.
- After fix: `node --test scripts/image-qualification-workflow.test.js`
  passed 19/19.
- `actionlint .github/workflows/image-qualification.yml`
- `node --test scripts/workflow-action-pins.test.js`
- `go test ./scripts`
- `git diff --check`
