### PR TITLE
refactor: share delegated setup failure classification

### DIFF
--- a/internal/providers/applemachine/backend.go
+++ b/internal/providers/applemachine/backend.go
@@ -93,16 +93,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		},
 	}
 	defer func() {
-		if retErr != nil && result.Status == "" {
-			outcome := core.FinalizeRunResult(core.RunResult{}, retErr)
-			result.Status, result.ErrorKind = outcome.Status, outcome.ErrorKind
-			result.ExitCode = 1
-			var public core.ExitError
-			if errors.As(retErr, &public) && public.Code > 0 {
-				result.ExitCode = public.Code
-			}
-			retErr = shared.ExitErrorWithCause(result.ExitCode, retErr.Error(), retErr)
-		}
+		result, retErr = shared.PinDelegatedRunFailure(result, retErr)
 		shouldStop := acquired && !req.Keep
 		if shouldStop && retErr != nil && req.KeepOnFailure {
 			shouldStop = false

--- a/internal/providers/dockersandbox/backend.go
+++ b/internal/providers/dockersandbox/backend.go
@@ -105,16 +105,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	var cleanupClaim core.LeaseClaim
 	commandRan := false
 	defer func() {
-		if retErr != nil && result.Status == "" {
-			outcome := core.FinalizeRunResult(core.RunResult{}, retErr)
-			result.Status, result.ErrorKind = outcome.Status, outcome.ErrorKind
-			result.ExitCode = 1
-			var public ExitError
-			if errors.As(retErr, &public) && public.Code != 0 {
-				result.ExitCode = public.Code
-			}
-			retErr = shared.ExitErrorWithCause(result.ExitCode, retErr.Error(), retErr)
-		}
+		result, retErr = shared.PinDelegatedRunFailure(result, retErr)
 		if retErr != nil {
 			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 		}

--- a/internal/providers/shared/delegated.go
+++ b/internal/providers/shared/delegated.go
@@ -89,6 +89,24 @@ func FinalizeDelegatedCommandOutcome(exitCode int, err error) core.RunResult {
 	return outcome
 }
 
+// PinDelegatedRunFailure classifies an unclassified setup failure before cleanup.
+// Nonzero public setup codes (including signed process exits) survive without
+// becoming user command exits. Already classified outcomes and their error
+// identities are left unchanged.
+func PinDelegatedRunFailure(result core.RunResult, err error) (core.RunResult, error) {
+	if err == nil || result.Status != "" {
+		return result, err
+	}
+	outcome := core.FinalizeRunResult(core.RunResult{}, err)
+	result.Status, result.ErrorKind = outcome.Status, outcome.ErrorKind
+	result.ExitCode = 1
+	var public core.ExitError
+	if errors.As(err, &public) && public.Code != 0 {
+		result.ExitCode = public.Code
+	}
+	return result, ExitErrorWithCause(result.ExitCode, err.Error(), err)
+}
+
 // AppendDelegatedRunFailure adds a terminal cleanup or reporting failure to an
 // already classified primary outcome. A first failure selects firstCode and a
 // provider-error result; later failures preserve the primary code/status and
@@ -149,20 +167,7 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 		if prepared != nil {
 			defer prepared.Close()
 		}
-		// Classify before secondary cleanup errors can obscure command/cancel
-		// outcomes. Setup exit codes are CLI failures, not user command exits.
-		if retErr != nil && result.Status == "" {
-			outcome := core.FinalizeRunResult(core.RunResult{}, retErr)
-			result.Status, result.ErrorKind = outcome.Status, outcome.ErrorKind
-			var ee core.ExitError
-			result.ExitCode = 1
-			if errors.As(retErr, &ee) && ee.Code != 0 {
-				result.ExitCode = ee.Code
-			}
-			// Pin the primary exit before joining cleanup errors, which may
-			// themselves contain an ExitError with a different code.
-			retErr = ExitErrorWithCause(result.ExitCode, retErr.Error(), retErr)
-		}
+		result, retErr = PinDelegatedRunFailure(result, retErr)
 		appendFailure := func(err error, firstCode int) {
 			result, retErr = AppendDelegatedRunFailure(result, retErr, err, firstCode)
 		}

--- a/internal/providers/shared/delegated_test.go
+++ b/internal/providers/shared/delegated_test.go
@@ -35,6 +35,79 @@ func TestExitErrorWithCausePreservesSelectedCodeAndMessage(t *testing.T) {
 	}
 }
 
+func TestPinDelegatedRunFailure(t *testing.T) {
+	hidden := errors.New("hidden setup detail")
+	for _, tc := range []struct {
+		name   string
+		err    error
+		code   int
+		status core.RunStatus
+		kind   core.RunErrorKind
+	}{
+		{name: "opaque", err: errors.New("setup failed"), code: 1, status: core.RunStatusFailed, kind: core.RunErrorProvider},
+		{name: "public two", err: ExitErrorWithCause(2, "safe setup", hidden), code: 2, status: core.RunStatusFailed, kind: core.RunErrorProvider},
+		{name: "public six", err: ExitErrorWithCause(6, "safe setup", hidden), code: 6, status: core.RunStatusFailed, kind: core.RunErrorProvider},
+		{name: "zero setup code", err: ExitErrorWithCause(0, "safe setup", hidden), code: 1, status: core.RunStatusFailed, kind: core.RunErrorProvider},
+		{name: "signed setup process exit", err: ExitErrorWithCause(-1, "safe setup", hidden), code: -1, status: core.RunStatusFailed, kind: core.RunErrorProvider},
+		{name: "canceled", err: context.Canceled, code: 1, status: core.RunStatusCanceled, kind: core.RunErrorCanceled},
+		{name: "deadline", err: context.DeadlineExceeded, code: 1, status: core.RunStatusTimedOut, kind: core.RunErrorTimeout},
+		{name: "safe canceled", err: ExitErrorWithCause(2, "safe setup", errors.Join(hidden, context.Canceled)), code: 2, status: core.RunStatusCanceled, kind: core.RunErrorCanceled},
+		{name: "safe deadline", err: ExitErrorWithCause(6, "safe setup", errors.Join(hidden, context.DeadlineExceeded)), code: 6, status: core.RunStatusTimedOut, kind: core.RunErrorTimeout},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before := core.RunResult{Provider: "fixture", LeaseID: "lease", Slug: "slug", Total: time.Second, Command: time.Millisecond, CommandText: "fixture", SyncDelegated: true, Session: &core.RunSessionHandle{Kept: true}}
+			result, err := PinDelegatedRunFailure(before, tc.err)
+			want := before
+			want.ExitCode, want.Status, want.ErrorKind = tc.code, tc.status, tc.kind
+			if !reflect.DeepEqual(result, want) || result.Session != before.Session {
+				t.Fatalf("result=%+v, want %+v", result, want)
+			}
+			var public core.ExitError
+			if !errors.As(err, &public) || public.Code != tc.code || public.Message != tc.err.Error() || !errors.Is(err, tc.err) {
+				t.Fatalf("primary code/message/cause lost: %v", err)
+			}
+			pinned, sameErr := PinDelegatedRunFailure(result, err)
+			if !reflect.DeepEqual(pinned, result) || sameErr != err {
+				t.Fatal("pinning was not idempotent")
+			}
+			secondaryCause := errors.Join(errors.New("hidden cleanup detail"), context.DeadlineExceeded)
+			secondary := ExitErrorWithCause(9, "safe cleanup", secondaryCause)
+			result, err = AppendDelegatedRunFailure(result, err, secondary, 1)
+			if !reflect.DeepEqual(result, want) || !errors.As(err, &public) || public.Code != tc.code {
+				t.Fatalf("secondary replaced pinned outcome: %+v %v", result, err)
+			}
+			if public.Message != tc.err.Error()+"\nsafe cleanup" || strings.Contains(err.Error(), "hidden") || !errors.Is(err, tc.err) || !errors.Is(err, secondaryCause) {
+				t.Fatalf("safe messages or inspectable causes lost: %v", err)
+			}
+		})
+	}
+}
+
+func TestPinDelegatedRunFailureLeavesSelectedOutcomesUntouched(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		result core.RunResult
+		err    error
+	}{
+		{name: "nil unclassified"},
+		{name: "nil selected success", result: core.RunResult{Status: core.RunStatusSucceeded}},
+		{name: "command", result: core.RunResult{ExitCode: 23, Status: core.RunStatusFailed, ErrorKind: core.RunErrorCommandExit}, err: ExitErrorWithCause(23, "command failed", errors.New("cause"))},
+		{name: "negative observed command", result: FinalizeDelegatedCommandOutcome(-1, ObservedProcessEndError("signal")), err: ExitErrorWithCause(-1, "signal", errors.New("cause"))},
+		{name: "transport", result: FinalizeDelegatedCommandOutcome(23, io.ErrUnexpectedEOF), err: io.ErrUnexpectedEOF},
+		{name: "canceled", result: FinalizeDelegatedCommandOutcome(0, context.Canceled), err: context.Canceled},
+		{name: "deadline", result: FinalizeDelegatedCommandOutcome(0, context.DeadlineExceeded), err: context.DeadlineExceeded},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.result.Provider = "fixture"
+			tc.result.Session = &core.RunSessionHandle{Kept: true}
+			result, err := PinDelegatedRunFailure(tc.result, tc.err)
+			if !reflect.DeepEqual(result, tc.result) || result.Session != tc.result.Session || err != tc.err {
+				t.Fatalf("selected result/error changed: %+v %v", result, err)
+			}
+		})
+	}
+}
+
 func TestAppendDelegatedRunFailurePreservesSelectedOutcome(t *testing.T) {
 	primaryCause := errors.New("hidden primary detail")
 	secondaryCause := errors.New("hidden secondary detail")
@@ -128,6 +201,7 @@ func TestDelegatedSandboxLifecycle(t *testing.T) {
 		{name: "acquire", phase: "acquire", err: failure, keepOnFailure: true, wantCode: 1, wantKind: core.RunErrorProvider},
 		{name: "resolve ownership", reuse: true, phase: "resolve", err: core.ExitError{Code: 4, Message: "not owned"}, wantCode: 4, wantKind: core.RunErrorProvider},
 		{name: "setup", phase: "setup", err: failure, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantCleanup: true},
+		{name: "signed workspace helper and typed cleanup", phase: "workspace", noSync: true, err: core.ExitError{Code: -15, Message: "workspace helper signaled"}, cleanupErr: core.ExitError{Code: 4, Message: "claim changed"}, wantCode: -15, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true, wantCleanup: true},
 		{name: "kept setup", phase: "setup", err: failure, keepOnFailure: true, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true},
 		{name: "sync", phase: "sync", err: core.ExitError{Code: 6, Message: "sync failed"}, wantCode: 6, wantKind: core.RunErrorProvider, wantSession: true, wantCleanup: true},
 		{name: "kept sync", phase: "sync", err: failure, keepOnFailure: true, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true},


### PR DESCRIPTION
## Summary

Replace three copies of setup-failure classification and primary-outcome pinning with `shared.PinDelegatedRunFailure`, used by the shared sandbox lifecycle, Docker Sandbox Run, and Apple Machine Run. This removes 13 production lines overall without adding callbacks, policy flags, configuration, or dependencies.

The helper preserves the selected public code, status, safe message, inspectable cause, and session metadata before secondary cleanup/reporting errors arrive. Nil errors and already classified outcomes retain their original identity. Signed nonzero setup codes remain supported: Modal carries signed process-wait results through workspace helpers, so positive-only normalization was rejected after caller inspection. Apple’s reachable pre-command setup failures use code 2.

Retention, clone-commit preservation, native command classification, mounted/archive workspace behavior, timing schemas, ownership authorization, and claim-lock contexts stay with their existing owners. This is a refactor with characterization—not a new baseline-red bug claim.

## Verification

- Sixteen helper characterization cases plus one lifecycle case cover public setup codes 2/6, signed setup codes, cancellation/deadline, safe causes, metadata/error identity, and differently typed secondary cleanup. The signed workspace-helper exit -15 remains provider-error/-15 after cleanup code 4 on both untouched parent shared production and candidate.
- Go 1.26.5 fresh race suites (`-count=1`) passed on the integrated source: shared 2.204s, Docker Sandbox 3.200s, Apple Machine 3.740s, Modal 3.960s. Vet and diff checks passed.
- Managed autoreview completed scoped-clean at P0 with no accepted findings.
- Native Apple characterization used exact base `33728a992cc9320e814ab1ff9fd7db7a91cb611a` and the frozen candidate patch. Both built Darwin ARM64 CLIs passed all seven correct contracts using identical fixture/shim bytes in candidate mode: success/deletion, cleanup-only failure, command exit 23 plus cleanup failure, keep-on-failure, reuse, unconfirmed removal, and early environment-failure retention. Both builds/replays exited 0; explicit-stop recovery left zero machines, claims, and temporary roots.

Current integration base is `8166af8b652721a943ca47deca3faa020aa2fdc8`, including the landed Apple claim-context changes. Apple Run and Warmup bodies, Docker backend, and shared helper/tests remain byte-identical to the recorded native candidate; the new Apple claim-context code outside those bodies is preserved. This is scoped source equivalence, not whole-tree native proof: the earlier native binaries do not cover the subsequently landed claim-context changes. Fresh Go checks and managed review cover the actual integrated source; no native replay or long-budget native tests were repeated.

The native fixture uses a synthetic configured container executable with real shell workloads, private env files, and owned bundle/marker files. It does not prove real VM execution, home-mount isolation, or provider resources. Signed codes and typed error identity remain Go coverage. The optional Docker native replay was omitted because its frozen harness hardcodes obsolete baseline expectations; no oracle was changed and no native writer/early-env coverage is claimed.

## Captured native setup-failure characterization

This supplements the existing proof with inspectable output; **nothing was rerun**. Both binaries passed the same seven candidate-mode contracts. The setup case creates and binds an owned synthetic machine, then the production provider rejects `FIXTURE_VALUE` containing a newline before the user workload starts. `--keep-on-failure` returns exit **2**, status **failed**, kind **provider-error**, and a kept recovery session with its exact bound claim. Explicit stop occurs only after those observations are recorded.

The setup fixture uses an owned synthetic `container` executable and real bundle/marker files; other cases execute real `/bin/sh` workloads. This is not a real daemon, VM, home-mount isolation, hosted-provider, or credentialed proof. Typed error identity and signed setup-code contracts remain Go characterization. There is no new baseline-red bug claim.

### Frozen source and artifact binding

The captured base is `33728a992cc9320e814ab1ff9fd7db7a91cb611a`; candidate is that exact base plus the complete patch included below. Go 1.26.5 built Darwin ARM64 with CGO disabled, `-p=2 -trimpath -buildvcs=false`. Both builds and both complete replay commands exited 0. All 2,221 regular source files per side were checked before and after proof, allowing only the four recorded candidate files.

These binaries predate integration of the later Apple claim-context changes. Subsequent integration established that the Apple Run/Warmup bodies and shared helper remain unchanged; it did not turn this capture into whole-tree native proof for the later source.

| Artifact | SHA256 |
| --- | --- |
| Base source tar | `ec4eb6b6b619016439cab992b355927fd4b8e5512600fda181bbaa723e6e6123` |
| Candidate patch | `1ef1b27dfb75b47716ccb311a44fd5de7ba0a89557ca069114070e066d762835` |
| Base binary | `ffc77ada9b5f85ecbd1c1d536718ec20454551ea19037a38a67ceb41e8920d72` |
| Candidate binary | `d9a6c94e19d360927ea673e88041ece706934ab43953d34e43c7569b72341d47` |
| proof.mjs | `2ef425af2348de0b897a4cafbb5724f558fc0c1727454a9456aaadea184f6d87` |
| container.mjs | `24c89cdd01b91c31d412a0ec8b36fe16a83b17b795daadb73c07a861a90fcbfa` |
| Base complete results.json | `f15b2e2862af811307fecfd3e870b6e7b2664d7edc814244bc6b5ec6a4f78572` |
| Candidate complete results.json | `2fb7106a211f905d8c239271cf12115bdb064fa80d4cdb9e9e09bf21a9390063` |

Candidate source-file SHA256 values:

```json
{
  "internal/providers/applemachine/backend.go": "3fc8caa98bc7ff4c533dfc38d217f64acb01024f25aa8123efa80e66b0297016",
  "internal/providers/dockersandbox/backend.go": "516e160e10de96d824ed5bf477b04319ab0ac5ce8e35a7cef5d1f4e28ce2b88a",
  "internal/providers/shared/delegated.go": "4556baebbf21c702730603d86733177593b004cf8b2c361c1b96cd5ac9796a38",
  "internal/providers/shared/delegated_test.go": "33f294ebbe002a9d7434c40c3677024703767664fe8eb5d21ff8aee007d17bca"
}
```

### Replay commands

Save the exact fenced contents below as `proof.mjs`, `container.mjs`, and `candidate.patch` in a new owned proof directory. Node 24, Git, Go 1.26.5, and Apple Silicon macOS are required; no container installation or daemon is required. Use an existing Crabbox checkout containing the recorded base. Replace only the two neutral absolute directory values below. These are the captured build/replay arguments and launcher environment with task-specific directory prefixes normalized; output directories must be new/empty.

```sh
REPO_ROOT=/absolute/path/to/crabbox
PROOF_ROOT=/absolute/path/to/new-proof
mkdir -p "$PROOF_ROOT/base-source" "$PROOF_ROOT/candidate-source" "$PROOF_ROOT/bin"
git -C "$REPO_ROOT" archive --format=tar --output="$PROOF_ROOT/base-source.tar" 33728a992cc9320e814ab1ff9fd7db7a91cb611a
tar -xf "$PROOF_ROOT/base-source.tar" -C "$PROOF_ROOT/base-source"
tar -xf "$PROOF_ROOT/base-source.tar" -C "$PROOF_ROOT/candidate-source"
(cd "$PROOF_ROOT/candidate-source" && git apply "$PROOF_ROOT/candidate.patch")
chmod 700 "$PROOF_ROOT/container.mjs"
(cd "$PROOF_ROOT/base-source" && GOTOOLCHAIN=go1.26.5 GOCACHE="$PROOF_ROOT/go-cache" GOMAXPROCS=4 GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -p=2 -trimpath -buildvcs=false -o "$PROOF_ROOT/bin/crabbox-base" ./cmd/crabbox)
(cd "$PROOF_ROOT/candidate-source" && GOTOOLCHAIN=go1.26.5 GOCACHE="$PROOF_ROOT/go-cache" GOMAXPROCS=4 GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -p=2 -trimpath -buildvcs=false -o "$PROOF_ROOT/bin/crabbox-candidate" ./cmd/crabbox)
env -i PATH=/opt/homebrew/opt/node@24/bin:/usr/bin:/bin:/usr/sbin:/sbin /opt/homebrew/opt/node@24/bin/node "$PROOF_ROOT/proof.mjs" --binary "$PROOF_ROOT/bin/crabbox-base" --output "$PROOF_ROOT/base" --mode candidate > "$PROOF_ROOT/apple-base.log" 2>&1
env -i PATH=/opt/homebrew/opt/node@24/bin:/usr/bin:/bin:/usr/sbin:/sbin /opt/homebrew/opt/node@24/bin/node "$PROOF_ROOT/proof.mjs" --binary "$PROOF_ROOT/bin/crabbox-candidate" --output "$PROOF_ROOT/candidate" --mode candidate > "$PROOF_ROOT/apple-candidate.log" 2>&1
```

The original candidate build used hash-verified copies of the four frozen files; the included patch reproduces those bytes. The harness uses isolated allowlisted child environments, private HOME/config/state/temp paths, a 20-second CLI limit, 5-second workload limit, 180-second whole-run limit, and bounded output/process groups. Do **not** use `--mode baseline`: that historical mode expects older terminal bugs which neither refactor-side binary should exhibit.

### All seven captured outcomes

Both sides below use candidate mode. `claims` and `kept` are observed **before** separate recovery; every case subsequently records zero machines and zero claims.

| Case | Base exit / status / kind / kept / claims | Candidate exit / status / kind / kept / claims |
| --- | --- | --- |
| `success` | 0 / succeeded / none / false / 0 | 0 / succeeded / none / false / 0 |
| `success-remove-error` | 1 / failed / provider-error / true / 1 | 1 / failed / provider-error / true / 1 |
| `command23-remove-error` | 23 / failed / command-exit / true / 1 | 23 / failed / command-exit / true / 1 |
| `keep-failed-command23` | 23 / failed / command-exit / true / 1 | 23 / failed / command-exit / true / 1 |
| `reused-success` | 0 / succeeded / none / true / 1 | 0 / succeeded / none / true / 1 |
| `removal-unconfirmed` | 1 / failed / provider-error / true / 1 | 1 / failed / provider-error / true / 1 |
| `early-env-keep-failure` | 2 / failed / provider-error / true / 1 | 2 / failed / provider-error / true / 1 |

All fourteen case assertions passed, with zero fixture errors and no oracle changes. The setup trace contains one create/readiness sequence and no user workload or automatic remove. Its `recovery` phase contains the later native removal and confirming inventory read; the harness asserts explicit CLI stop exits 0, then records zero machines/claims. Stop stdout/stderr were not separately retained in this fixture; the native recovery trace and asserted/recorded recovery state below are the captured evidence, not a reconstructed stop transcript.

Only owned temporary path prefixes were redacted to `<case>` / `<proof>`. Lease IDs, slugs, hashes, durations, messages, and native arguments below are the actual synthetic fixture observations. `mode: candidate` in both records is intentional. Complete records include the pre-stop session/claims, raw stderr/timing, and post-stop recovery trace.

<details>
<summary>Base: exact setup stderr and complete sanitized observation (SHA256 069c2c20fee972d24a6235cdd53f3768097a0672b68ef1695b0c692edff0ac15)</summary>

CLI exit: `2`. Stdout: empty. Stderr, unescaped:

```text
kept failed apple-machine lease=cbx_7f14847bd2e9 slug=tidal-krill
{"provider":"apple-machine","leaseId":"cbx_7f14847bd2e9","slug":"tidal-krill","runnerTotalMs":512,"runnerPhases":[{"name":"delegated.opaque","ms":512,"opaque":true,"reason":"provider owns lifecycle work outside measured sync and command","provider":"apple-machine","leaseId":"cbx_7f14847bd2e9","slug":"tidal-krill"}],"syncMs":0,"syncSkipped":true,"syncDelegated":true,"commandMs":0,"totalMs":511,"endToEndMs":0,"exitCode":2,"runStatus":"failed","errorKind":"provider-error"}
apple-machine environment values cannot contain newlines
```

Complete captured JSON:

```json
{
  "scenario": "early-env-keep-failure",
  "mode": "candidate",
  "exit": 2,
  "stdout": "",
  "stderr": "kept failed apple-machine lease=cbx_7f14847bd2e9 slug=tidal-krill\n{\"provider\":\"apple-machine\",\"leaseId\":\"cbx_7f14847bd2e9\",\"slug\":\"tidal-krill\",\"runnerTotalMs\":512,\"runnerPhases\":[{\"name\":\"delegated.opaque\",\"ms\":512,\"opaque\":true,\"reason\":\"provider owns lifecycle work outside measured sync and command\",\"provider\":\"apple-machine\",\"leaseId\":\"cbx_7f14847bd2e9\",\"slug\":\"tidal-krill\"}],\"syncMs\":0,\"syncSkipped\":true,\"syncDelegated\":true,\"commandMs\":0,\"totalMs\":511,\"endToEndMs\":0,\"exitCode\":2,\"runStatus\":\"failed\",\"errorKind\":\"provider-error\"}\napple-machine environment values cannot contain newlines\n",
  "session": {
    "provider": "apple-machine",
    "leaseId": "cbx_7f14847bd2e9",
    "slug": "tidal-krill",
    "reused": false,
    "kept": true,
    "cleanupCommand": "crabbox stop --provider apple-machine --id 'cbx_7f14847bd2e9'"
  },
  "timing": {
    "provider": "apple-machine",
    "leaseId": "cbx_7f14847bd2e9",
    "slug": "tidal-krill",
    "runnerTotalMs": 512,
    "runnerPhases": [
      {
        "name": "delegated.opaque",
        "ms": 512,
        "opaque": true,
        "reason": "provider owns lifecycle work outside measured sync and command",
        "provider": "apple-machine",
        "leaseId": "cbx_7f14847bd2e9",
        "slug": "tidal-krill"
      }
    ],
    "syncMs": 0,
    "syncSkipped": true,
    "syncDelegated": true,
    "commandMs": 0,
    "totalMs": 511,
    "endToEndMs": 0,
    "exitCode": 2,
    "runStatus": "failed",
    "errorKind": "provider-error"
  },
  "claimsAfterRun": [
    {
      "leaseID": "cbx_7f14847bd2e9",
      "provider": "apple-machine",
      "repoRoot": "<case>/home/repo",
      "scope": "<case>/storage",
      "cloudID": "crabbox-7f14847bd2e9",
      "markerSha256": "94796f23eb27d868ee16766307ff0bc296508fa644ff2f5aa6f156ce04c9a1d3",
      "identityMatches": true
    }
  ],
  "machineCountAfterRun": 1,
  "candidateContractPassed": true,
  "regressionObserved": false,
  "contractFailures": [],
  "expectationFailures": [],
  "trace": [
    {
      "phase": "run",
      "args": [
        "system",
        "status",
        "--format",
        "json"
      ],
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "machine",
        "create",
        "--name",
        "crabbox-7f14847bd2e9",
        "--home-mount",
        "rw",
        "fixture:synthetic"
      ],
      "operation": "create",
      "name": "crabbox-7f14847bd2e9",
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "system",
        "status",
        "--format",
        "json"
      ],
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "machine",
        "inspect",
        "crabbox-7f14847bd2e9"
      ],
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "system",
        "status",
        "--format",
        "json"
      ],
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "machine",
        "inspect",
        "crabbox-7f14847bd2e9"
      ],
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "system",
        "status",
        "--format",
        "json"
      ],
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "machine",
        "inspect",
        "crabbox-7f14847bd2e9"
      ],
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "system",
        "status",
        "--format",
        "json"
      ],
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "machine",
        "inspect",
        "crabbox-7f14847bd2e9"
      ],
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "machine",
        "run",
        "--name",
        "crabbox-7f14847bd2e9",
        ":"
      ],
      "operation": "readiness",
      "exit": 0
    },
    {
      "phase": "recovery",
      "args": [
        "system",
        "status",
        "--format",
        "json"
      ],
      "exit": 0
    },
    {
      "phase": "recovery",
      "args": [
        "machine",
        "list",
        "--format",
        "json"
      ],
      "exit": 0
    },
    {
      "phase": "recovery",
      "args": [
        "system",
        "status",
        "--format",
        "json"
      ],
      "exit": 0
    },
    {
      "phase": "recovery",
      "args": [
        "machine",
        "inspect",
        "crabbox-7f14847bd2e9"
      ],
      "exit": 0
    },
    {
      "phase": "recovery",
      "args": [
        "machine",
        "rm",
        "crabbox-7f14847bd2e9"
      ],
      "operation": "remove",
      "name": "crabbox-7f14847bd2e9",
      "exit": 0
    },
    {
      "phase": "recovery",
      "args": [
        "system",
        "status",
        "--format",
        "json"
      ],
      "exit": 0
    },
    {
      "phase": "recovery",
      "args": [
        "machine",
        "list",
        "--format",
        "json"
      ],
      "exit": 0
    }
  ],
  "fixtureErrors": [],
  "recovery": {
    "machines": 0,
    "claims": 0
  }
}
```

</details>

<details>
<summary>Candidate: exact setup stderr and complete sanitized observation (SHA256 80ceef2935abafb5464a3ffb61aa992d78082760441793951a0201e1022e85df)</summary>

CLI exit: `2`. Stdout: empty. Stderr, unescaped:

```text
kept failed apple-machine lease=cbx_6f6176531560 slug=quick-crayfish
{"provider":"apple-machine","leaseId":"cbx_6f6176531560","slug":"quick-crayfish","runnerTotalMs":583,"runnerPhases":[{"name":"delegated.opaque","ms":583,"opaque":true,"reason":"provider owns lifecycle work outside measured sync and command","provider":"apple-machine","leaseId":"cbx_6f6176531560","slug":"quick-crayfish"}],"syncMs":0,"syncSkipped":true,"syncDelegated":true,"commandMs":0,"totalMs":582,"endToEndMs":0,"exitCode":2,"runStatus":"failed","errorKind":"provider-error"}
apple-machine environment values cannot contain newlines
```

Complete captured JSON:

```json
{
  "scenario": "early-env-keep-failure",
  "mode": "candidate",
  "exit": 2,
  "stdout": "",
  "stderr": "kept failed apple-machine lease=cbx_6f6176531560 slug=quick-crayfish\n{\"provider\":\"apple-machine\",\"leaseId\":\"cbx_6f6176531560\",\"slug\":\"quick-crayfish\",\"runnerTotalMs\":583,\"runnerPhases\":[{\"name\":\"delegated.opaque\",\"ms\":583,\"opaque\":true,\"reason\":\"provider owns lifecycle work outside measured sync and command\",\"provider\":\"apple-machine\",\"leaseId\":\"cbx_6f6176531560\",\"slug\":\"quick-crayfish\"}],\"syncMs\":0,\"syncSkipped\":true,\"syncDelegated\":true,\"commandMs\":0,\"totalMs\":582,\"endToEndMs\":0,\"exitCode\":2,\"runStatus\":\"failed\",\"errorKind\":\"provider-error\"}\napple-machine environment values cannot contain newlines\n",
  "session": {
    "provider": "apple-machine",
    "leaseId": "cbx_6f6176531560",
    "slug": "quick-crayfish",
    "reused": false,
    "kept": true,
    "cleanupCommand": "crabbox stop --provider apple-machine --id 'cbx_6f6176531560'"
  },
  "timing": {
    "provider": "apple-machine",
    "leaseId": "cbx_6f6176531560",
    "slug": "quick-crayfish",
    "runnerTotalMs": 583,
    "runnerPhases": [
      {
        "name": "delegated.opaque",
        "ms": 583,
        "opaque": true,
        "reason": "provider owns lifecycle work outside measured sync and command",
        "provider": "apple-machine",
        "leaseId": "cbx_6f6176531560",
        "slug": "quick-crayfish"
      }
    ],
    "syncMs": 0,
    "syncSkipped": true,
    "syncDelegated": true,
    "commandMs": 0,
    "totalMs": 582,
    "endToEndMs": 0,
    "exitCode": 2,
    "runStatus": "failed",
    "errorKind": "provider-error"
  },
  "claimsAfterRun": [
    {
      "leaseID": "cbx_6f6176531560",
      "provider": "apple-machine",
      "repoRoot": "<case>/home/repo",
      "scope": "<case>/storage",
      "cloudID": "crabbox-6f6176531560",
      "markerSha256": "e6c50e5562e40c237e8574edde5ee84d8ef49023742782781b51476c4f51c03e",
      "identityMatches": true
    }
  ],
  "machineCountAfterRun": 1,
  "candidateContractPassed": true,
  "regressionObserved": false,
  "contractFailures": [],
  "expectationFailures": [],
  "trace": [
    {
      "phase": "run",
      "args": [
        "system",
        "status",
        "--format",
        "json"
      ],
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "machine",
        "create",
        "--name",
        "crabbox-6f6176531560",
        "--home-mount",
        "rw",
        "fixture:synthetic"
      ],
      "operation": "create",
      "name": "crabbox-6f6176531560",
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "system",
        "status",
        "--format",
        "json"
      ],
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "machine",
        "inspect",
        "crabbox-6f6176531560"
      ],
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "system",
        "status",
        "--format",
        "json"
      ],
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "machine",
        "inspect",
        "crabbox-6f6176531560"
      ],
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "system",
        "status",
        "--format",
        "json"
      ],
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "machine",
        "inspect",
        "crabbox-6f6176531560"
      ],
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "system",
        "status",
        "--format",
        "json"
      ],
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "machine",
        "inspect",
        "crabbox-6f6176531560"
      ],
      "exit": 0
    },
    {
      "phase": "run",
      "args": [
        "machine",
        "run",
        "--name",
        "crabbox-6f6176531560",
        ":"
      ],
      "operation": "readiness",
      "exit": 0
    },
    {
      "phase": "recovery",
      "args": [
        "system",
        "status",
        "--format",
        "json"
      ],
      "exit": 0
    },
    {
      "phase": "recovery",
      "args": [
        "machine",
        "list",
        "--format",
        "json"
      ],
      "exit": 0
    },
    {
      "phase": "recovery",
      "args": [
        "system",
        "status",
        "--format",
        "json"
      ],
      "exit": 0
    },
    {
      "phase": "recovery",
      "args": [
        "machine",
        "inspect",
        "crabbox-6f6176531560"
      ],
      "exit": 0
    },
    {
      "phase": "recovery",
      "args": [
        "machine",
        "rm",
        "crabbox-6f6176531560"
      ],
      "operation": "remove",
      "name": "crabbox-6f6176531560",
      "exit": 0
    },
    {
      "phase": "recovery",
      "args": [
        "system",
        "status",
        "--format",
        "json"
      ],
      "exit": 0
    },
    {
      "phase": "recovery",
      "args": [
        "machine",
        "list",
        "--format",
        "json"
      ],
      "exit": 0
    }
  ],
  "fixtureErrors": [],
  "recovery": {
    "machines": 0,
    "claims": 0
  }
}
```

</details>

Recovery across the complete comparison left zero machines, zero claims, and zero `apple-machine-native-*` fixture roots. Existing build/source receipts also preserve an initial read-only receipt-path typo; it was corrected without source, fixture, oracle, build, or proof-result changes. No failed proof attempt is hidden in this comparison.

### Complete unchanged fixture and source patch

Save each block without adding indentation and retain its final newline; the SHA256 values above bind the exact contents. The shim is selected explicitly by the production provider flag and never calls a real container executable. The full candidate patch makes the historical source comparison independently reconstructible rather than relying on an unverified external fixture link.

<details>
<summary>proof.mjs — complete exact bytes</summary>

```javascript
import fs from 'node:fs';
import path from 'node:path';
import os from 'node:os';
import crypto from 'node:crypto';
import assert from 'node:assert/strict';
import { spawn } from 'node:child_process';
import { fileURLToPath } from 'node:url';

assert.equal(process.platform, 'darwin'); assert.equal(process.arch, 'arm64');
const options = {};
for (let i = 2; i < process.argv.length; i += 2) {
  assert.ok(['--binary', '--output', '--mode'].includes(process.argv[i]));
  assert.ok(process.argv[i + 1]); options[process.argv[i].slice(2)] = process.argv[i + 1];
}
assert.ok(options.binary && options.output && ['candidate', 'baseline'].includes(options.mode));
const proofRoot = path.dirname(fileURLToPath(import.meta.url));
const shim = path.join(proofRoot, 'container.mjs');
const binary = fs.realpathSync(options.binary), output = path.resolve(options.output);
fs.mkdirSync(output, { recursive: true }); assert.deepEqual(fs.readdirSync(output), []);
const digest = file => crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
const active = new Set();
const kill = child => { try { process.kill(-child.pid, 'SIGKILL'); } catch {} };
const deadline = setTimeout(() => { for (const child of active) kill(child); process.exit(124); }, 180_000);
deadline.unref();
function run(file, args, cwd, env, timeout = 20_000) {
  return new Promise(resolve => {
    const child = spawn(file, args, { cwd, env, detached: true, stdio: ['ignore', 'pipe', 'pipe'] });
    active.add(child); let stdout = '', stderr = '', fault = null;
    const timer = setTimeout(() => { fault = 'process timeout'; kill(child); }, timeout);
    for (const [stream, which] of [[child.stdout, 'stdout'], [child.stderr, 'stderr']]) stream.on('data', data => {
      if (which === 'stdout') stdout += data; else stderr += data;
      if (stdout.length + stderr.length > 512 * 1024) { fault = 'output limit'; kill(child); }
    });
    child.on('error', error => { fault = error.message; });
    child.on('close', (code, signal) => { clearTimeout(timer); active.delete(child); resolve({ code, signal, stdout, stderr, fault }); });
  });
}
const cases = [
  { name: 'success', commandCode: 0 },
  { name: 'success-remove-error', commandCode: 0, fault: 'remove-error', regression: true },
  { name: 'command23-remove-error', commandCode: 23, fault: 'remove-error' },
  { name: 'keep-failed-command23', commandCode: 23, keepFailure: true },
  { name: 'reused-success', commandCode: 0, reused: true },
  { name: 'removal-unconfirmed', commandCode: 0, fault: 'remove-unconfirmed', regression: true },
  { name: 'early-env-keep-failure', commandCode: 0, badEnv: true, keepFailure: true, regression: true },
];
const results = [];
for (const scenario of cases) {
  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'apple-machine-native-')));
  const home = path.join(root, 'home'), repo = path.join(home, 'repo'), temp = path.join(root, 'temp');
  const stateDir = path.join(root, 'state'), storage = path.join(root, 'storage');
  for (const dir of [home, repo, temp, stateDir, storage]) fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
  const statePath = path.join(root, 'fixture.json'), sessionPath = path.join(root, 'session.json');
  const sanitize = value => String(value).split(root).join('<case>').split(proofRoot).join('<proof>');
  const writeState = state => fs.writeFileSync(statePath, JSON.stringify(state), { mode: 0o600 });
  const readState = () => JSON.parse(fs.readFileSync(statePath, 'utf8'));
  writeState({ fixture: 'apple-machine-native-v1', root, home, repo, temp, storage, phase: 'seed', fault: scenario.fault, machines: {}, trace: [], fixtureErrors: [] });
  const config = path.join(root, 'config.yaml');
  fs.writeFileSync(config, 'provider: apple-machine\nappleContainer:\n  image: fixture:synthetic\n', { mode: 0o600 });
  const env = { HOME: home, TMPDIR: temp, XDG_STATE_HOME: stateDir, XDG_CONFIG_HOME: path.join(home, '.config'),
    PATH: `${path.dirname(process.execPath)}:/usr/bin:/bin:/usr/sbin:/sbin`, GOMAXPROCS: '4',
    CRABBOX_CONFIG: config, APPLE_MACHINE_FIXTURE_STATE: statePath,
    GIT_CONFIG_NOSYSTEM: '1', GIT_CONFIG_GLOBAL: '/dev/null', GIT_TERMINAL_PROMPT: '0',
    FIXTURE_VALUE: scenario.badEnv ? 'invalid\nvalue' : 'synthetic-forwarded-value' };
  const claims = () => {
    const dir = path.join(stateDir, 'crabbox', 'claims');
    if (!fs.existsSync(dir)) return [];
    return fs.readdirSync(dir).filter(name => name.endsWith('.json')).map(name => JSON.parse(fs.readFileSync(path.join(dir, name), 'utf8')));
  };
  let record;
  try {
    fs.writeFileSync(path.join(repo, 'payload.txt'), 'fixture-data\n');
    for (const args of [['init', '-q'], ['add', '.'], ['-c', 'user.name=Synthetic Fixture', '-c', 'user.email=fixture@example.invalid', '-c', 'commit.gpgsign=false', 'commit', '-qm', 'fixture']]) {
      const git = await run('/usr/bin/git', args, repo, env, 5_000); assert.equal(git.code, 0, git.stderr);
    }
    let leaseID;
    if (scenario.reused) {
      const seed = await run(binary, ['warmup', '--provider', 'apple-machine', '--apple-machine-cli', shim, '--keep'], repo, env);
      assert.equal(seed.fault, null); assert.equal(seed.code, 0, seed.stderr);
      assert.equal(claims().length, 1); leaseID = claims()[0].leaseID;
    }
    writeState({ ...readState(), phase: 'run' });
    const source = `printf 'case=${scenario.name} env=%s payload=' "$FIXTURE_VALUE"; cat payload.txt; ${scenario.commandCode ? "printf 'synthetic workload failed\\n' >&2; " : ''}exit ${scenario.commandCode}`;
    const args = ['run', '--provider', 'apple-machine', '--apple-machine-cli', shim, '--timing-json', '--lease-output', sessionPath,
      '--allow-env', 'FIXTURE_VALUE', ...(scenario.keepFailure ? ['--keep-on-failure'] : []), ...(leaseID ? ['--id', leaseID] : []), '--', '/bin/sh', '-c', source];
    const observed = await run(binary, args, repo, env);
    assert.equal(observed.fault, null); assert.equal(observed.signal, null);
    const state = readState(); assert.deepEqual(state.fixtureErrors, []);
    const afterClaims = claims(); const session = fs.existsSync(sessionPath) ? JSON.parse(fs.readFileSync(sessionPath, 'utf8')) : null;
    const reports = observed.stderr.split('\n').flatMap(line => { try { const row = JSON.parse(line); return row.provider === 'apple-machine' && 'exitCode' in row ? [row] : []; } catch { return []; } });
    const timing = reports.at(-1) ?? null;
    const trace = state.trace.filter(e => e.phase === 'run');
    const machineCount = Object.keys(state.machines).length;
    const present = afterClaims.map(claim => {
      const marker = path.join(storage, 'plugin-state', 'machine-apiserver', 'machines', claim.cloudID, '.crabbox-owner');
      return { leaseID: claim.leaseID, provider: claim.provider, repoRoot: claim.repoRoot, scope: claim.providerScope,
        cloudID: claim.cloudID, markerSha256: fs.existsSync(marker) ? digest(marker) : null,
        identityMatches: fs.existsSync(marker) && fs.readFileSync(marker, 'utf8').trim() === claim.cloudImmutableID };
    });
    const candidateCode = scenario.badEnv ? 2 : scenario.commandCode || (scenario.fault ? 1 : 0);
    const candidateKept = Boolean(scenario.reused || scenario.keepFailure && (scenario.commandCode || scenario.badEnv) || scenario.fault);
    const expected = { code: candidateCode, kept: candidateKept, session: true, claims: candidateKept ? 1 : 0,
      removes: scenario.reused || scenario.keepFailure && (scenario.commandCode || scenario.badEnv) ? 0 : 1,
      timing: candidateCode, mountedSync: true, kind: scenario.badEnv || scenario.fault && !scenario.commandCode ? 'provider-error' : scenario.commandCode ? 'command-exit' : '' };
    const oracle = { ...expected };
    if (options.mode === 'baseline' && scenario.regression) {
      if (scenario.badEnv) Object.assign(oracle, { kept: false, session: false, claims: 0, removes: 1, mountedSync: false });
      else Object.assign(oracle, { code: 0, timing: 0, kind: '' });
    }
    const evaluate = want => {
      const failures = [];
      const check = (label, actual, desired) => { try { assert.deepEqual(actual, desired); } catch { failures.push({ label, actual, expected: desired }); } };
      check('public exit', observed.code, want.code);
      check('exact stdout', observed.stdout, scenario.badEnv ? '' : `case=${scenario.name} env=synthetic-forwarded-value payload=fixture-data\n`);
      check('session presence', Boolean(session), want.session);
      if (want.session) { check('session kept', session?.kept, want.kept); check('session reuse', session?.reused, Boolean(scenario.reused)); check('session provider', session?.provider, 'apple-machine'); }
      check('claim count', afterClaims.length, want.claims); check('machine count', machineCount, want.claims);
      check('run removes', trace.filter(e => e.operation === 'remove').length, want.removes);
      check('run creates', trace.filter(e => e.operation === 'create').length, scenario.reused ? 0 : 1);
      check('native workload count', trace.filter(e => e.operation === 'workload').length, scenario.badEnv ? 0 : 1);
      for (const claim of present) { check('retained marker binding', claim.identityMatches, true); if (session) check('session claim identity', session.leaseId, claim.leaseID); }
      check('timing exit', timing?.exitCode, want.timing); check('timing status', timing?.runStatus, want.timing ? 'failed' : 'succeeded');
      check('timing kind', timing?.errorKind ?? '', want.kind); check('mounted sync', Boolean(timing?.syncSkipped), want.mountedSync);
      check('delegated sync', Boolean(timing?.syncDelegated), want.mountedSync); check('no invented sync phases', timing?.syncPhases ?? [], []);
      if (want.session) check('timing lease identity', timing?.leaseId, session?.leaseId);
      const workload = trace.find(e => e.operation === 'workload');
      if (workload) { check('native workload exit', workload.exit, scenario.commandCode); check('private env mode', workload.envMode, 0o600); check('forwarded value', workload.forwardedValue, 'synthetic-forwarded-value'); check('env file removed', fs.existsSync(workload.envPath), false); }
      if (scenario.fault === 'remove-error') check('cleanup diagnostic', observed.stderr.includes('synthetic removal failed'), true);
      if (scenario.fault === 'remove-unconfirmed') check('uncertain deletion diagnostic', observed.stderr.includes('still present after deletion'), true);
      if (scenario.commandCode) check('primary diagnostic', observed.stderr.includes('synthetic workload failed'), true);
      if (scenario.badEnv) check('actual environment failure', observed.stderr.includes('environment values cannot contain newlines'), true);
      return failures;
    };
    const contractFailures = evaluate(expected), expectationFailures = evaluate(oracle);
    if (options.mode === 'baseline' && scenario.regression && contractFailures.length === 0) expectationFailures.push({ label: 'expected baseline regression not observed' });
    record = { scenario: scenario.name, mode: options.mode, exit: observed.code, stdout: observed.stdout, stderr: observed.stderr,
      session, timing, claimsAfterRun: present, machineCountAfterRun: machineCount, candidateContractPassed: contractFailures.length === 0,
      regressionObserved: options.mode === 'baseline' && scenario.regression && contractFailures.length > 0,
      contractFailures, expectationFailures, trace: state.trace, fixtureErrors: [] };
    writeState({ ...state, phase: 'recovery' });
    for (const claim of afterClaims) {
      const stop = await run(binary, ['stop', '--provider', 'apple-machine', '--apple-machine-cli', shim, '--id', claim.leaseID], repo, env);
      assert.equal(stop.fault, null); assert.equal(stop.code, 0, stop.stderr);
    }
    const recovered = readState(); assert.deepEqual(recovered.fixtureErrors, []); assert.equal(Object.keys(recovered.machines).length, 0); assert.deepEqual(claims(), []);
    record.trace = recovered.trace; record.recovery = { machines: 0, claims: 0 };
  } catch (error) {
    record ??= { scenario: scenario.name, mode: options.mode, candidateContractPassed: false, expectationFailures: [], fixtureErrors: [], trace: readState().trace };
    record.fixtureErrors.push(error.message, ...readState().fixtureErrors);
  } finally {
    for (const child of active) kill(child);
    fs.rmSync(root, { recursive: true, force: true });
  }
  record = JSON.parse(sanitize(JSON.stringify(record)));
  results.push(record); fs.writeFileSync(path.join(output, `${scenario.name}.json`), JSON.stringify(record, null, 2) + '\n', { flag: 'wx' });
  console.log(JSON.stringify({ scenario: scenario.name, exit: record.exit, candidateContractPassed: record.candidateContractPassed,
    regressionObserved: record.regressionObserved ?? false, expectationFailures: record.expectationFailures.length, fixtureErrors: record.fixtureErrors.length }));
}
clearTimeout(deadline);
const fixtureFailure = results.some(r => r.fixtureErrors.length), expectationFailure = results.some(r => r.expectationFailures.length);
const summary = { mode: options.mode, platform: `${process.platform}/${process.arch}`, binarySha256: digest(binary), fixtureSha256: digest(fileURLToPath(import.meta.url)), shimSha256: digest(shim),
  scope: 'Built CLI, production Apple Machine provider and local command runner, synthetic container control with real bundle/marker files and native subprocess workloads. No real container daemon, VM, home mount or mount-isolation proof.',
  modeExpectationsPassed: !fixtureFailure && !expectationFailure, candidateContractPassed: results.every(r => r.candidateContractPassed),
  baselineRegressionsObserved: results.filter(r => r.regressionObserved).map(r => r.scenario), results };
fs.writeFileSync(path.join(output, 'results.json'), JSON.stringify(summary, null, 2) + '\n', { flag: 'wx' });
process.exitCode = fixtureFailure ? 2 : expectationFailure ? 1 : 0;
```

</details>

<details>
<summary>container.mjs — complete exact bytes</summary>

```javascript
#!/usr/bin/env node
import fs from 'node:fs';
import path from 'node:path';
import assert from 'node:assert/strict';
import { spawnSync } from 'node:child_process';

// No native container executable is called. This is an owned filesystem fixture.
const statePath = process.env.APPLE_MACHINE_FIXTURE_STATE;
assert.ok(statePath && path.isAbsolute(statePath), 'fixture state required');
const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
assert.equal(state.fixture, 'apple-machine-native-v1');
assert.equal(fs.realpathSync(state.root), state.root);
assert.equal(path.dirname(statePath), state.root);
const args = process.argv.slice(2);
const event = { phase: state.phase, args };
let code = 0, stdout = '', stderr = '';
const bundle = name => {
  assert.match(name, /^crabbox-[a-f0-9]{12}$/);
  return path.join(state.storage, 'plugin-state', 'machine-apiserver', 'machines', name);
};
try {
  if (args.join(' ') === 'system status --format json') {
    stdout = JSON.stringify({ status: 'running', appRoot: state.storage });
  } else {
    assert.equal(args[0], 'machine');
    switch (args[1]) {
      case 'create': {
        const name = args[args.indexOf('--name') + 1];
        assert.equal(args[args.indexOf('--home-mount') + 1], 'rw');
        assert.ok(!state.machines[name]);
        fs.mkdirSync(bundle(name), { recursive: true, mode: 0o700 });
        state.machines[name] = { id: name, status: 'stopped' };
        event.operation = 'create'; event.name = name;
        break;
      }
      case 'inspect':
        assert.ok(state.machines[args[2]], 'inspect must address the fixture machine');
        stdout = JSON.stringify([state.machines[args[2]]]);
        break;
      case 'list':
        assert.deepEqual(args.slice(2), ['--format', 'json']);
        stdout = JSON.stringify(Object.values(state.machines));
        break;
      case 'rm': {
        const name = args[2];
        assert.ok(state.machines[name]);
        event.operation = 'remove'; event.name = name;
        if (state.phase === 'run' && state.fault === 'remove-error') {
          code = 5; stderr = 'synthetic removal failed\n';
        } else if (state.phase === 'run' && state.fault === 'remove-unconfirmed') {
          event.acknowledgedWithoutRemoval = true;
        } else {
          fs.rmSync(bundle(name), { recursive: true });
          delete state.machines[name];
        }
        break;
      }
      case 'run': {
        assert.equal(args[2], '--name');
        const name = args[3]; assert.ok(state.machines[name]);
        if (args.length === 5 && args[4] === ':') { event.operation = 'readiness'; break; }
        assert.equal(args[4], '--cwd'); assert.equal(args[5], state.repo);
        let index = 6;
        const forwarded = {};
        if (args[index] === '--env-file') {
          const envPath = args[index + 1];
          assert.ok(envPath.startsWith(state.temp + path.sep));
          const info = fs.lstatSync(envPath);
          assert.ok(info.isFile()); assert.equal(info.mode & 0o777, 0o600);
          for (const line of fs.readFileSync(envPath, 'utf8').trimEnd().split('\n')) {
            const equals = line.indexOf('='); assert.ok(equals > 0);
            forwarded[line.slice(0, equals)] = line.slice(equals + 1);
          }
          event.envPath = envPath; event.envMode = info.mode & 0o777;
          event.forwardedValue = forwarded.FIXTURE_VALUE;
          assert.ok(!args.some(arg => arg.includes('synthetic-forwarded-value')));
          index += 2;
        }
        const command = args.slice(index); assert.ok(command.length > 0);
        event.operation = 'workload'; event.name = name;
        const result = spawnSync(command[0], command.slice(1), {
          cwd: state.repo, encoding: 'utf8', timeout: 5_000, maxBuffer: 256 * 1024,
          env: { HOME: state.home, TMPDIR: state.temp, PATH: '/usr/bin:/bin', ...forwarded },
        });
        assert.equal(result.error, undefined, 'native workload launch/budget failure');
        assert.equal(result.signal, null, 'native workload must finish normally');
        code = result.status; stdout = result.stdout; stderr = result.stderr;
        event.stdout = stdout; event.stderr = stderr;
        break;
      }
      default: throw new Error('unknown machine operation');
    }
  }
} catch (error) {
  state.fixtureErrors.push(error.message);
  code = 70; stderr = 'synthetic container fixture failed\n';
}
event.exit = code;
state.trace.push(event);
fs.writeFileSync(statePath + '.next', JSON.stringify(state), { mode: 0o600 });
fs.renameSync(statePath + '.next', statePath);
process.stdout.write(stdout); process.stderr.write(stderr); process.exitCode = code;
```

</details>

<details>
<summary>candidate.patch — complete exact bytes</summary>

```diff
diff --git a/internal/providers/applemachine/backend.go b/internal/providers/applemachine/backend.go
index 8dfa8b12..451d1d4d 100644
--- a/internal/providers/applemachine/backend.go
+++ b/internal/providers/applemachine/backend.go
@@ -93,16 +93,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		},
 	}
 	defer func() {
-		if retErr != nil && result.Status == "" {
-			outcome := core.FinalizeRunResult(core.RunResult{}, retErr)
-			result.Status, result.ErrorKind = outcome.Status, outcome.ErrorKind
-			result.ExitCode = 1
-			var public core.ExitError
-			if errors.As(retErr, &public) && public.Code > 0 {
-				result.ExitCode = public.Code
-			}
-			retErr = shared.ExitErrorWithCause(result.ExitCode, retErr.Error(), retErr)
-		}
+		result, retErr = shared.PinDelegatedRunFailure(result, retErr)
 		shouldStop := acquired && !req.Keep
 		if shouldStop && retErr != nil && req.KeepOnFailure {
 			shouldStop = false
diff --git a/internal/providers/dockersandbox/backend.go b/internal/providers/dockersandbox/backend.go
index e3f113ab..7bfde476 100644
--- a/internal/providers/dockersandbox/backend.go
+++ b/internal/providers/dockersandbox/backend.go
@@ -105,16 +105,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	var cleanupClaim core.LeaseClaim
 	commandRan := false
 	defer func() {
-		if retErr != nil && result.Status == "" {
-			outcome := core.FinalizeRunResult(core.RunResult{}, retErr)
-			result.Status, result.ErrorKind = outcome.Status, outcome.ErrorKind
-			result.ExitCode = 1
-			var public ExitError
-			if errors.As(retErr, &public) && public.Code != 0 {
-				result.ExitCode = public.Code
-			}
-			retErr = shared.ExitErrorWithCause(result.ExitCode, retErr.Error(), retErr)
-		}
+		result, retErr = shared.PinDelegatedRunFailure(result, retErr)
 		if retErr != nil {
 			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 		}
diff --git a/internal/providers/shared/delegated.go b/internal/providers/shared/delegated.go
index 344303eb..752be193 100644
--- a/internal/providers/shared/delegated.go
+++ b/internal/providers/shared/delegated.go
@@ -89,6 +89,24 @@ func FinalizeDelegatedCommandOutcome(exitCode int, err error) core.RunResult {
 	return outcome
 }
 
+// PinDelegatedRunFailure classifies an unclassified setup failure before cleanup.
+// Nonzero public setup codes (including signed process exits) survive without
+// becoming user command exits. Already classified outcomes and their error
+// identities are left unchanged.
+func PinDelegatedRunFailure(result core.RunResult, err error) (core.RunResult, error) {
+	if err == nil || result.Status != "" {
+		return result, err
+	}
+	outcome := core.FinalizeRunResult(core.RunResult{}, err)
+	result.Status, result.ErrorKind = outcome.Status, outcome.ErrorKind
+	result.ExitCode = 1
+	var public core.ExitError
+	if errors.As(err, &public) && public.Code != 0 {
+		result.ExitCode = public.Code
+	}
+	return result, ExitErrorWithCause(result.ExitCode, err.Error(), err)
+}
+
 // AppendDelegatedRunFailure adds a terminal cleanup or reporting failure to an
 // already classified primary outcome. A first failure selects firstCode and a
 // provider-error result; later failures preserve the primary code/status and
@@ -149,20 +167,7 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 		if prepared != nil {
 			defer prepared.Close()
 		}
-		// Classify before secondary cleanup errors can obscure command/cancel
-		// outcomes. Setup exit codes are CLI failures, not user command exits.
-		if retErr != nil && result.Status == "" {
-			outcome := core.FinalizeRunResult(core.RunResult{}, retErr)
-			result.Status, result.ErrorKind = outcome.Status, outcome.ErrorKind
-			var ee core.ExitError
-			result.ExitCode = 1
-			if errors.As(retErr, &ee) && ee.Code != 0 {
-				result.ExitCode = ee.Code
-			}
-			// Pin the primary exit before joining cleanup errors, which may
-			// themselves contain an ExitError with a different code.
-			retErr = ExitErrorWithCause(result.ExitCode, retErr.Error(), retErr)
-		}
+		result, retErr = PinDelegatedRunFailure(result, retErr)
 		appendFailure := func(err error, firstCode int) {
 			result, retErr = AppendDelegatedRunFailure(result, retErr, err, firstCode)
 		}
diff --git a/internal/providers/shared/delegated_test.go b/internal/providers/shared/delegated_test.go
index 5dc3a3d6..d3c6ae82 100644
--- a/internal/providers/shared/delegated_test.go
+++ b/internal/providers/shared/delegated_test.go
@@ -35,6 +35,79 @@ func TestExitErrorWithCausePreservesSelectedCodeAndMessage(t *testing.T) {
 	}
 }
 
+func TestPinDelegatedRunFailure(t *testing.T) {
+	hidden := errors.New("hidden setup detail")
+	for _, tc := range []struct {
+		name   string
+		err    error
+		code   int
+		status core.RunStatus
+		kind   core.RunErrorKind
+	}{
+		{name: "opaque", err: errors.New("setup failed"), code: 1, status: core.RunStatusFailed, kind: core.RunErrorProvider},
+		{name: "public two", err: ExitErrorWithCause(2, "safe setup", hidden), code: 2, status: core.RunStatusFailed, kind: core.RunErrorProvider},
+		{name: "public six", err: ExitErrorWithCause(6, "safe setup", hidden), code: 6, status: core.RunStatusFailed, kind: core.RunErrorProvider},
+		{name: "zero setup code", err: ExitErrorWithCause(0, "safe setup", hidden), code: 1, status: core.RunStatusFailed, kind: core.RunErrorProvider},
+		{name: "signed setup process exit", err: ExitErrorWithCause(-1, "safe setup", hidden), code: -1, status: core.RunStatusFailed, kind: core.RunErrorProvider},
+		{name: "canceled", err: context.Canceled, code: 1, status: core.RunStatusCanceled, kind: core.RunErrorCanceled},
+		{name: "deadline", err: context.DeadlineExceeded, code: 1, status: core.RunStatusTimedOut, kind: core.RunErrorTimeout},
+		{name: "safe canceled", err: ExitErrorWithCause(2, "safe setup", errors.Join(hidden, context.Canceled)), code: 2, status: core.RunStatusCanceled, kind: core.RunErrorCanceled},
+		{name: "safe deadline", err: ExitErrorWithCause(6, "safe setup", errors.Join(hidden, context.DeadlineExceeded)), code: 6, status: core.RunStatusTimedOut, kind: core.RunErrorTimeout},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before := core.RunResult{Provider: "fixture", LeaseID: "lease", Slug: "slug", Total: time.Second, Command: time.Millisecond, CommandText: "fixture", SyncDelegated: true, Session: &core.RunSessionHandle{Kept: true}}
+			result, err := PinDelegatedRunFailure(before, tc.err)
+			want := before
+			want.ExitCode, want.Status, want.ErrorKind = tc.code, tc.status, tc.kind
+			if !reflect.DeepEqual(result, want) || result.Session != before.Session {
+				t.Fatalf("result=%+v, want %+v", result, want)
+			}
+			var public core.ExitError
+			if !errors.As(err, &public) || public.Code != tc.code || public.Message != tc.err.Error() || !errors.Is(err, tc.err) {
+				t.Fatalf("primary code/message/cause lost: %v", err)
+			}
+			pinned, sameErr := PinDelegatedRunFailure(result, err)
+			if !reflect.DeepEqual(pinned, result) || sameErr != err {
+				t.Fatal("pinning was not idempotent")
+			}
+			secondaryCause := errors.Join(errors.New("hidden cleanup detail"), context.DeadlineExceeded)
+			secondary := ExitErrorWithCause(9, "safe cleanup", secondaryCause)
+			result, err = AppendDelegatedRunFailure(result, err, secondary, 1)
+			if !reflect.DeepEqual(result, want) || !errors.As(err, &public) || public.Code != tc.code {
+				t.Fatalf("secondary replaced pinned outcome: %+v %v", result, err)
+			}
+			if public.Message != tc.err.Error()+"\nsafe cleanup" || strings.Contains(err.Error(), "hidden") || !errors.Is(err, tc.err) || !errors.Is(err, secondaryCause) {
+				t.Fatalf("safe messages or inspectable causes lost: %v", err)
+			}
+		})
+	}
+}
+
+func TestPinDelegatedRunFailureLeavesSelectedOutcomesUntouched(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		result core.RunResult
+		err    error
+	}{
+		{name: "nil unclassified"},
+		{name: "nil selected success", result: core.RunResult{Status: core.RunStatusSucceeded}},
+		{name: "command", result: core.RunResult{ExitCode: 23, Status: core.RunStatusFailed, ErrorKind: core.RunErrorCommandExit}, err: ExitErrorWithCause(23, "command failed", errors.New("cause"))},
+		{name: "negative observed command", result: FinalizeDelegatedCommandOutcome(-1, ObservedProcessEndError("signal")), err: ExitErrorWithCause(-1, "signal", errors.New("cause"))},
+		{name: "transport", result: FinalizeDelegatedCommandOutcome(23, io.ErrUnexpectedEOF), err: io.ErrUnexpectedEOF},
+		{name: "canceled", result: FinalizeDelegatedCommandOutcome(0, context.Canceled), err: context.Canceled},
+		{name: "deadline", result: FinalizeDelegatedCommandOutcome(0, context.DeadlineExceeded), err: context.DeadlineExceeded},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.result.Provider = "fixture"
+			tc.result.Session = &core.RunSessionHandle{Kept: true}
+			result, err := PinDelegatedRunFailure(tc.result, tc.err)
+			if !reflect.DeepEqual(result, tc.result) || result.Session != tc.result.Session || err != tc.err {
+				t.Fatalf("selected result/error changed: %+v %v", result, err)
+			}
+		})
+	}
+}
+
 func TestAppendDelegatedRunFailurePreservesSelectedOutcome(t *testing.T) {
 	primaryCause := errors.New("hidden primary detail")
 	secondaryCause := errors.New("hidden secondary detail")
@@ -128,6 +201,7 @@ func TestDelegatedSandboxLifecycle(t *testing.T) {
 		{name: "acquire", phase: "acquire", err: failure, keepOnFailure: true, wantCode: 1, wantKind: core.RunErrorProvider},
 		{name: "resolve ownership", reuse: true, phase: "resolve", err: core.ExitError{Code: 4, Message: "not owned"}, wantCode: 4, wantKind: core.RunErrorProvider},
 		{name: "setup", phase: "setup", err: failure, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantCleanup: true},
+		{name: "signed workspace helper and typed cleanup", phase: "workspace", noSync: true, err: core.ExitError{Code: -15, Message: "workspace helper signaled"}, cleanupErr: core.ExitError{Code: 4, Message: "claim changed"}, wantCode: -15, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true, wantCleanup: true},
 		{name: "kept setup", phase: "setup", err: failure, keepOnFailure: true, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true},
 		{name: "sync", phase: "sync", err: core.ExitError{Code: 6, Message: "sync failed"}, wantCode: 6, wantKind: core.RunErrorProvider, wantSession: true, wantCleanup: true},
 		{name: "kept sync", phase: "sync", err: failure, keepOnFailure: true, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true},
```

</details>
