### PR TITLE
fix: share Blaxel run finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Blaxel: share sandbox run finalization so automatic deletion failures no longer report success, early setup failures retain recovery sessions, and primary command failures survive cleanup or timing errors; recheck original claim and remote ownership before automatic deletion.
 - Extract protected image-qualification candidates at the canonical artifact path and avoid protected finalization when deployment never started.
 - Stop SSH readiness promptly on host-key rejection, including WSL SFTP and split or oversized diagnostics, without changing host trust. [PR 1877](https://github.com/openclaw/crabbox/pull/1877). Thanks @shunkakinoki.
 - Apple Machine: fail runs when automatic deletion fails or remains unconfirmed, retain recovery sessions for early keep-on-failure errors, and preserve command outcomes while distinguishing native transport failures through the shared error handlers. [PR 1914](https://github.com/openclaw/crabbox/pull/1914).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Blaxel: share sandbox run finalization so automatic deletion failures no longer report success, early setup failures retain recovery sessions, and primary command failures survive cleanup or timing errors; recheck original claim and remote ownership before automatic deletion.
+- Blaxel: share sandbox run finalization so automatic deletion failures no longer report success, early setup failures retain recovery sessions, and primary command failures survive cleanup or timing errors; recheck original claim and remote ownership before automatic deletion. [PR 1919](https://github.com/openclaw/crabbox/pull/1919).
 - Extract protected image-qualification candidates at the canonical artifact path and avoid protected finalization when deployment never started.
 - Stop SSH readiness promptly on host-key rejection, including WSL SFTP and split or oversized diagnostics, without changing host trust. [PR 1877](https://github.com/openclaw/crabbox/pull/1877). Thanks @shunkakinoki.
 - Apple Machine: fail runs when automatic deletion fails or remains unconfirmed, retain recovery sessions for early keep-on-failure errors, and preserve command outcomes while distinguishing native transport failures through the shared error handlers. [PR 1914](https://github.com/openclaw/crabbox/pull/1914).

--- a/docs/providers/blaxel.md
+++ b/docs/providers/blaxel.md
@@ -173,10 +173,19 @@ claim and remote ownership validation. `--no-sync` creates no archive.
    retains it. `stop` deletes a retained sandbox only after the local claim and
    remote ownership labels match.
 
+Run finalization is shared with other delegated sandboxes. Automatic sandbox
+deletion failures fail an otherwise successful run and retain a recovery
+session; later cleanup or timing-report errors cannot replace a primary
+command failure. Early setup failures also honor `--keep-on-failure` and retain
+their session metadata. Cleanup compares the original local claim and remote
+ownership labels before deletion, with its timeout covering the claim-lock wait.
+These run changes do not change explicit stop's `forgetMissing` policy.
+
 Sync timing counts preparation once and excludes provisioning wait. Archive
 construction uses `sync.timeout`; a prepared archive's construction time reduces
 the subsequent transfer budget. Manifest/preflight checks are outside that
-budget. Cleanup failures are warnings and preserve the primary sync error.
+budget. Archive temporary-file cleanup failures are warnings and preserve the
+primary sync error.
 
 Cancellation during process polling attempts to stop the original process with a bounded
 cleanup context, even when the interrupted HTTP request failed before response

--- a/internal/providers/blaxel/backend.go
+++ b/internal/providers/blaxel/backend.go
@@ -50,180 +50,111 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 }
 
 func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
-	workdir, err := blaxelWorkdir(b.cfg)
-	if err != nil {
-		return RunResult{}, err
-	}
-	started := now(b.rt)
-	client, err := b.client()
-	if err != nil {
-		return RunResult{}, err
-	}
-	leaseID, sandboxID, slug := "", "", ""
-	acquired := false
-	var prepared *core.PreparedArchive
-	if req.ID == "" && !req.NoSync {
-		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
-			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-			TempPattern: "crabbox-blaxel-sync-*.tgz", Stderr: b.rt.Stderr,
-			Now: func() time.Time { return now(b.rt) },
-		})
-		if err != nil {
-			return RunResult{}, err
-		}
-		defer prepared.Close()
-	}
-	if req.ID == "" {
-		var sb Sandbox
-		leaseID, sb, slug, err = b.createSandbox(ctx, client, req.Repo, req.Reclaim, req.RequestedSlug)
-		if err != nil {
-			return RunResult{}, err
-		}
-		sandboxID = sb.ID
-		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s name=%s\n", leaseID, slug, providerName, sb.ID, sb.Name)
-		acquired = true
-	} else {
-		leaseID, sandboxID, slug, err = resolveLeaseID(req.ID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout, client.BaseURL(), b.cfg.Blaxel.Workspace)
-		if err != nil {
-			return RunResult{}, err
-		}
-		if _, err := verifyBlaxelClaim(ctx, client, leaseID, sandboxID, b.cfg.Blaxel.Workspace); err != nil {
-			return RunResult{}, err
+	workdir, workdirErr := blaxelWorkdir(b.cfg)
+	var client Client
+	var leaseID, sandboxID, slug string
+	var claim LeaseClaim
+	var claimErr error
+	boundSandbox := func() shared.DelegatedSandbox {
+		return shared.DelegatedSandbox{
+			LeaseID: leaseID, Slug: slug,
+			CleanupCommand: fmt.Sprintf("crabbox stop --provider %s %s", providerName, leaseID),
 		}
 	}
-	shouldStop := acquired && !req.Keep
-	if shouldStop {
-		claim, err := readLeaseClaim(leaseID)
-		if err != nil {
-			return RunResult{}, err
-		}
-		defer func() {
-			if !shouldStop {
-				return
+	return shared.RunDelegatedSandbox(ctx, req, shared.DelegatedSandboxLifecycle{
+		Provider: providerName, Runtime: b.rt, Workdir: workdir,
+		IdleTimeout: b.cfg.IdleTimeout, TTL: b.cfg.TTL, CleanupTimeout: blaxelCleanupTimeout,
+		Preflight: func(context.Context) error {
+			if workdirErr != nil {
+				return workdirErr
 			}
-			cleanupCtx, cancel := b.cleanupContext(ctx)
-			defer cancel()
-			if err := removeLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
-				if err := client.DeleteSandbox(cleanupCtx, sandboxID); err != nil && !isBlaxelNotFound(err) {
+			var err error
+			client, err = b.client()
+			return err
+		},
+		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) {
+			return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+				Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+				TempPattern: "crabbox-blaxel-sync-*.tgz", Stderr: b.rt.Stderr,
+				Now: func() time.Time { return now(b.rt) },
+			})
+		},
+		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
+			var sb Sandbox
+			var err error
+			leaseID, sb, slug, err = b.createSandbox(ctx, client, req.Repo, req.Reclaim, req.RequestedSlug)
+			if err != nil {
+				return shared.DelegatedSandbox{}, err
+			}
+			sandboxID = sb.ID
+			// Capture the acquisition claim before any run work; cleanup must not
+			// authorize a replacement claim created while the command executes.
+			claim, claimErr = readLeaseClaim(leaseID)
+			fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s name=%s\n", leaseID, slug, providerName, sb.ID, sb.Name)
+			return boundSandbox(), nil
+		},
+		Resolve: func(ctx context.Context) (shared.DelegatedSandbox, error) {
+			var err error
+			leaseID, sandboxID, slug, err = resolveLeaseID(req.ID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout, client.BaseURL(), b.cfg.Blaxel.Workspace)
+			if err != nil {
+				return shared.DelegatedSandbox{}, err
+			}
+			if _, err := verifyBlaxelClaim(ctx, client, leaseID, sandboxID, b.cfg.Blaxel.Workspace); err != nil {
+				return shared.DelegatedSandbox{}, err
+			}
+			return boundSandbox(), nil
+		},
+		Setup: func(context.Context) error {
+			if claimErr != nil {
+				return claimErr
+			}
+			fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s\n", providerName, leaseID, sandboxID, workdir)
+			return nil
+		},
+		Sync: func(ctx context.Context, prepared *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
+			return b.syncWorkspace(ctx, client, sandboxID, req, workdir, prepared)
+		},
+		NoSync: func(ctx context.Context) error { return b.ensureWorkspace(ctx, client, sandboxID, workdir) },
+		Command: func(context.Context) (shared.DelegatedSandboxCommand, error) {
+			command, err := buildCommand(req.Command, req.ShellMode)
+			if err != nil {
+				return shared.DelegatedSandboxCommand{}, err
+			}
+			if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
+				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+			}
+			return shared.DelegatedSandboxCommand{
+				Text: strings.Join(req.Command, " "),
+				Run: func(ctx context.Context) (int, error) {
+					return b.execCommand(ctx, client, sandboxID, workdir, command, req.Env)
+				},
+			}, nil
+		},
+		Cleanup: func(ctx context.Context) error {
+			if claimErr != nil {
+				return claimErr
+			}
+			return core.CleanupLeaseClaimIfUnchangedAfterContext(ctx, leaseID, claim, true, func() error {
+				if err := validateBlaxelClaimScope(claim, client.BaseURL(), b.cfg.Blaxel.Workspace); err != nil {
+					return err
+				}
+				sb, err := client.GetSandbox(ctx, sandboxID)
+				if isBlaxelNotFound(err) {
+					return nil
+				}
+				if err != nil {
+					return err
+				}
+				if err := validateBlaxelSandboxOwnership(claim, sb); err != nil {
+					return err
+				}
+				if err := client.DeleteSandbox(ctx, sandboxID); err != nil && !isBlaxelNotFound(err) {
 					return err
 				}
 				return nil
-			}); err != nil {
-				fmt.Fprintf(b.rt.Stderr, "warning: blaxel delete failed for %s: %v\n", sandboxID, err)
-				return
-			}
-		}()
-	}
-	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s\n", providerName, leaseID, sandboxID, workdir)
-
-	syncDuration := time.Duration(0)
-	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
-	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, sandboxID, req, workdir, prepared)
-		if err != nil {
-			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-			return RunResult{Total: now(b.rt).Sub(started), SyncDelegated: true}, err
-		}
-		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
-	} else if err := b.ensureWorkspace(ctx, client, sandboxID, workdir); err != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return RunResult{}, err
-	}
-	if req.SyncOnly {
-		result := RunResult{
-			Total:         now(b.rt).Sub(started),
-			SyncDelegated: true,
-			Provider:      providerName,
-			LeaseID:       leaseID,
-			Slug:          slug,
-			Session:       blaxelRunSession(leaseID, slug, acquired, shouldStop),
-		}
-		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
-		if req.TimingJSON {
-			return result, writeTimingJSON(b.rt.Stderr, timingReport{
-				Provider:      providerName,
-				LeaseID:       leaseID,
-				Slug:          slug,
-				SyncDelegated: true,
-				SyncMs:        syncDuration.Milliseconds(),
-				SyncPhases:    syncPhases,
-				SyncSkipped:   req.NoSync,
-				TotalMs:       result.Total.Milliseconds(),
-				ExitCode:      0,
-				Label:         strings.TrimSpace(req.Label),
 			})
-		}
-		return result, nil
-	}
-
-	command, err := buildCommand(req.Command, req.ShellMode)
-	if err != nil {
-		return RunResult{}, err
-	}
-	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
-		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
-	}
-	commandStarted := now(b.rt)
-	exitCode, commandErr := b.execCommand(ctx, client, sandboxID, workdir, command, req.Env)
-	commandDuration := now(b.rt).Sub(commandStarted)
-	result := RunResult{
-		ExitCode:      exitCode,
-		Command:       commandDuration,
-		Total:         now(b.rt).Sub(started),
-		SyncDelegated: true,
-		Session:       blaxelRunSession(leaseID, slug, acquired, shouldStop),
-		Provider:      providerName,
-		LeaseID:       leaseID,
-		Slug:          slug,
-		CommandText:   strings.Join(req.Command, " "),
-	}
-	if req.NoSync {
-		fmt.Fprintf(b.rt.Stderr, "blaxel run summary sync_skipped=true command=%s total=%s exit=%d\n",
-			result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
-	} else {
-		fmt.Fprintf(b.rt.Stderr, "blaxel run summary sync=%s command=%s total=%s exit=%d\n",
-			syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
-	}
-	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider:      providerName,
-			LeaseID:       leaseID,
-			Slug:          slug,
-			SyncDelegated: true,
-			SyncMs:        syncDuration.Milliseconds(),
-			SyncPhases:    syncPhases,
-			SyncSkipped:   req.NoSync,
-			CommandMs:     result.Command.Milliseconds(),
-			TotalMs:       result.Total.Milliseconds(),
-			ExitCode:      exitCode,
-			Label:         strings.TrimSpace(req.Label),
-		}); err != nil {
-			return result, err
-		}
-	}
-	if commandErr != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		result.Session.Kept = !shouldStop
-		return result, shared.ExitErrorWithCause(1, fmt.Sprintf("blaxel run failed: %v", commandErr), commandErr)
-	}
-	if exitCode != 0 {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		result.Session.Kept = !shouldStop
-		return result, ExitError{Code: exitCode, Message: fmt.Sprintf("blaxel run exited %d", exitCode)}
-	}
-	result.Session.Kept = !shouldStop
-	return result, nil
-}
-
-func blaxelRunSession(leaseID, slug string, acquired, shouldStop bool) *RunSessionHandle {
-	return &RunSessionHandle{
-		Provider:       providerName,
-		LeaseID:        leaseID,
-		Slug:           slug,
-		Reused:         !acquired,
-		Kept:           !shouldStop,
-		CleanupCommand: fmt.Sprintf("crabbox stop --provider %s %s", providerName, leaseID),
-	}
+		},
+	})
 }
 
 func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {

--- a/internal/providers/blaxel/backend_test.go
+++ b/internal/providers/blaxel/backend_test.go
@@ -960,3 +960,105 @@ func cloneLabels(in map[string]string) map[string]string {
 }
 
 func intPtr(v int) *int { return &v }
+
+func TestRunFinalizesCleanupFailure(t *testing.T) {
+	for _, commandExit := range []int{0, 7} {
+		t.Run(fmt.Sprint(commandExit), func(t *testing.T) {
+			b, fake, _, _, stderr := newLifecycleBackend(t)
+			fake.deleteErr = errors.New("synthetic delete failure")
+			fake.onExec = func(_ context.Context, req ExecuteProcessRequest) (Process, error) {
+				code := 0
+				if req.Command == "fixture-user" {
+					code = commandExit
+				}
+				return Process{ID: "proc_1", Status: "completed", ExitCode: intPtr(code)}, nil
+			}
+			result, err := b.Run(t.Context(), RunRequest{Repo: testRepo(t), NoSync: true, TimingJSON: true, Command: []string{"fixture-user"}})
+			wantCode, wantKind := commandExit, core.RunErrorCommandExit
+			if commandExit == 0 {
+				wantCode, wantKind = 1, core.RunErrorProvider
+			}
+			if err == nil || !strings.Contains(err.Error(), "synthetic delete failure") || result.ExitCode != wantCode || result.Status != core.RunStatusFailed || result.ErrorKind != wantKind {
+				t.Errorf("result=%+v err=%v", result, err)
+			}
+			if result.Session == nil || !result.Session.Kept {
+				t.Errorf("session=%+v", result.Session)
+			}
+			if claim, err := readLeaseClaim(leasePrefix + "sbx_1"); err != nil || claim.LeaseID == "" {
+				t.Fatalf("claim=%+v err=%v", claim, err)
+			}
+			var report core.TimingReport
+			found := false
+			for _, line := range strings.Split(stderr.String(), "\n") {
+				if strings.HasPrefix(line, "{") && json.Unmarshal([]byte(line), &report) == nil {
+					found = true
+				}
+			}
+			if !found || report.ExitCode != wantCode || report.RunStatus != core.RunStatusFailed || report.ErrorKind != wantKind {
+				t.Errorf("timing=%+v stderr=%s", report, stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunSetupFailureKeepsRecoverableSession(t *testing.T) {
+	b, fake, _, _, stderr := newLifecycleBackend(t)
+	fake.processErr = errors.New("synthetic setup failure")
+	result, err := b.Run(t.Context(), RunRequest{Repo: testRepo(t), NoSync: true, KeepOnFailure: true, TimingJSON: true, Command: []string{"fixture-user"}})
+	if err == nil || result.Provider != providerName || result.LeaseID != leasePrefix+"sbx_1" || result.Status != core.RunStatusFailed || result.ErrorKind != core.RunErrorProvider {
+		t.Errorf("result=%+v err=%v", result, err)
+	}
+	if result.Session == nil || !result.Session.Kept || result.Session.CleanupCommand == "" || len(fake.deleted) != 0 {
+		t.Errorf("session=%+v deletes=%v", result.Session, fake.deleted)
+	}
+	if !strings.Contains(stderr.String(), `"exitCode":1`) {
+		t.Errorf("missing failed timing: %s", stderr.String())
+	}
+}
+
+func TestRunCleanupPreservesChangedOwnership(t *testing.T) {
+	for _, change := range []string{"local-claim", "remote-labels", "missing"} {
+		t.Run(change, func(t *testing.T) {
+			b, fake, _, _, _ := newLifecycleBackend(t)
+			replacementRepo := t.TempDir()
+			fake.onExec = func(_ context.Context, req ExecuteProcessRequest) (Process, error) {
+				if req.Command == "fixture-user" {
+					switch change {
+					case "local-claim":
+						claim, err := readLeaseClaim(leasePrefix + "sbx_1")
+						if err != nil {
+							t.Fatal(err)
+						}
+						if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, replacementRepo, time.Minute, true); err != nil {
+							t.Fatal(err)
+						}
+					case "remote-labels":
+						sb := fake.sandboxes["sbx_1"]
+						sb.Labels[blaxelClaimKey] = "successor-owner"
+						fake.sandboxes["sbx_1"] = sb
+					case "missing":
+						delete(fake.sandboxes, "sbx_1")
+					}
+				}
+				return Process{ID: "proc_1", Status: "completed", ExitCode: intPtr(0)}, nil
+			}
+			result, err := b.Run(t.Context(), RunRequest{Repo: testRepo(t), NoSync: true, Command: []string{"fixture-user"}})
+			claim, claimErr := readLeaseClaim(leasePrefix + "sbx_1")
+			if claimErr != nil {
+				t.Fatal(claimErr)
+			}
+			if change == "missing" {
+				if err != nil || result.Session == nil || result.Session.Kept || claim.LeaseID != "" {
+					t.Fatalf("result=%+v claim=%+v err=%v", result, claim, err)
+				}
+				return
+			}
+			if err == nil || result.Session == nil || !result.Session.Kept || len(fake.deleted) != 0 || claim.LeaseID == "" {
+				t.Fatalf("result=%+v claim=%+v deleted=%v err=%v", result, claim, fake.deleted, err)
+			}
+			if change == "local-claim" && claim.RepoRoot != replacementRepo {
+				t.Fatalf("successor claim lost: %+v", claim)
+			}
+		})
+	}
+}

--- a/internal/providers/blaxel/core.go
+++ b/internal/providers/blaxel/core.go
@@ -19,7 +19,6 @@ type DoctorCheck = core.DoctorCheck
 type WarmupRequest = core.WarmupRequest
 type RunRequest = core.RunRequest
 type RunResult = core.RunResult
-type RunSessionHandle = core.RunSessionHandle
 type ListRequest = core.ListRequest
 type LeaseView = core.LeaseView
 type StatusRequest = core.StatusRequest
@@ -64,10 +63,6 @@ func flagWasSet(fs *flag.FlagSet, name string) bool {
 
 func blank(value, fallback string) string {
 	return core.Blank(value, fallback)
-}
-
-func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
-	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }
 
 func writeTimingJSON(w io.Writer, report timingReport) error {


### PR DESCRIPTION
## Final integration verification

Rebuilt and rechecked the exact staged integration against main `fc34879d324733124f5aa716926775a3c49cedae`. This matters because main now constructs Blaxel control/data HTTP clients through the shared owner. The replay below proves that combination with the run-finalization fix; the earlier receipts remain historical evidence, not the final integration binding.

The index was copied by recorded Git blob IDs and file modes into an isolated directory. All 2,228 files were verified, and the staged entries remained unchanged throughout validation. Relative to that main commit, the PR still changes only `CHANGELOG.md`, the Blaxel provider docs, `backend.go`, `backend_test.go`, and `core.go`.

```sh
go test -race ./internal/providers/blaxel ./internal/providers/shared -count=1
go vet ./internal/providers/blaxel ./internal/providers/shared
go build -trimpath -o /tmp/blaxel-final-proof/crabbox ./cmd/crabbox
python3 /tmp/blaxel-final-proof/native-v2.py /tmp/blaxel-final-proof/crabbox
```

These are normalized replay commands; `/tmp/blaxel-final-proof` stands for the isolated proof directory. The build and fixture were actually invoked with absolute owned binary paths. The fixture is byte-identical to the one included in the historical section below.

Actual fresh race log:

```text
ok  	github.com/openclaw/crabbox/internal/providers/blaxel	6.646s
ok  	github.com/openclaw/crabbox/internal/providers/shared	2.577s
```

Focused vet passed with no output. The actual built CLI passed all four cases through the native HTTP client, an owned synthetic loopback Blaxel service, and real local shell commands:

| Case | Run exit / timing kind | Recovery | Verified final state |
| --- | --- | --- | --- |
| Success | 0 / none | Automatic deletion | No machine or claim |
| Cleanup-only failure | 1 / `provider-error` | Actual CLI `stop` exits 0 | No machine or claim |
| Command + cleanup failure | 7 / `command-exit` | Actual CLI `stop` exits 0 | No machine or claim |
| Retained setup failure | 1 / `provider-error` | Actual CLI `stop` exits 0 | No machine or claim |

Each failed run recorded a kept session, the exact claim, and machine presence before disabling the injected failure and invoking CLI `stop`. Every case finished with exactly one successful deletion. The fixture verified closed loopback ports, stopped server threads, and removed temporary directories. Scope remains native CLI/client integration with a synthetic service; this is not hosted Blaxel or archive-sync proof.

### Final integrated input binding

```text
9b97fc92f41edf98572839d48db6d2d74358dbdc926f2db8c45b1b07a4bffa33  internal/providers/blaxel/backend.go
4fbf95c06132b72e415e634a94a36031cfb1216dd080bdc1293eaa098a5c8867  internal/providers/blaxel/backend_test.go
0fcef686d5f79b279f1d54857be2541e65207799595088739cbe78d30f5e2d97  internal/providers/blaxel/core.go
9ce0712d5368fdfe9bd7711cd52d7c0ffdeb2f17b34b9ea9ba3c4724952a564b  internal/providers/blaxel/client.go
36b5534f5d2b20f1581a4e6695a7346655eedd566c630e291f3d5cda60ad50d9  internal/providers/shared/httpclients.go
4556baebbf21c702730603d86733177593b004cf8b2c361c1b96cd5ac9796a38  internal/providers/shared/delegated.go
f17397a110fcbebecb3cf741b3201cffc386eb3f3be02b6585f02fa0a0cbdef3  PR diff against fc34879d
fe7967b9b22090adbeed29c19d591bd772c1788c748817db945e31e50aa5a7b1  staged Git modes/blob IDs/path manifest
ca078ee7fc6348641384588ae805f0797c2bb9b66e23a80f99bf8eee7342be40  crabbox
28a56410c15aca0e7a5b1b2cec200c4bcac0d836256bc182b93d0f16c6dc4611  native-v2.py
040c4dbfc584b167d1c37c3745cdd39e8becf8e702c345441b40f5b9daf701c2  native-v2.json (final integrated replay)
```

The captures below are from this final replay. Display-only substitutions cover temporary paths, ports and synthetic ownership/revision values; raw receipts remain unchanged. Identical placeholders retain the original claim/label equality. The saved lease-output handle remains historical after a later `stop`; live claim and machine absence establish recovery.

<details>
<summary>Final replay: cleanup-failure</summary>

Run stdout:

```text
native-proof

```

Run stderr (includes full timing):

```text
leased blx_crabbox-repo-ae3810 slug=quick-hermit provider=blaxel sandbox=crabbox-repo-ae3810 name=crabbox-repo-ae3810
provider=blaxel lease=blx_crabbox-repo-ae3810 sandbox=crabbox-repo-ae3810 workdir=/tmp/blaxel-final-case-2/workspace
blaxel run summary sync_skipped=true command=10ms total=50ms exit=1
{"provider":"blaxel","leaseId":"blx_crabbox-repo-ae3810","slug":"quick-hermit","runnerTotalMs":51,"runnerPhases":[{"name":"command","ms":10,"provider":"blaxel","leaseId":"blx_crabbox-repo-ae3810","slug":"quick-hermit"},{"name":"delegated.opaque","ms":41,"opaque":true,"reason":"provider owns lifecycle work outside measured sync and command","provider":"blaxel","leaseId":"blx_crabbox-repo-ae3810","slug":"quick-hermit"}],"syncMs":0,"syncPhases":[{"name":"sync","skipped":true,"reason":"--no-sync"}],"syncSkipped":true,"syncDelegated":true,"commandMs":10,"totalMs":50,"endToEndMs":0,"exitCode":1,"runStatus":"failed","errorKind":"provider-error","workdir":"/tmp/blaxel-final-case-2/workspace"}
blaxel cleanup failed: blaxel API request failed status=400 body={"message": "synthetic delete failure"}
```

```json
{
  "beforeRecovery": {
    "session": {
      "provider": "blaxel",
      "leaseId": "blx_crabbox-repo-ae3810",
      "slug": "quick-hermit",
      "reused": false,
      "kept": true,
      "cleanupCommand": "crabbox stop --provider blaxel blx_crabbox-repo-ae3810"
    },
    "claims": {
      "blx_crabbox-repo-ae3810.json": {
        "leaseID": "blx_crabbox-repo-ae3810",
        "revision": "<synthetic-revision-2>",
        "slug": "quick-hermit",
        "provider": "blaxel",
        "providerScope": "endpoint-workspace-sha256:<synthetic-endpoint-2>/ownership:<synthetic-owner-2>",
        "repoRoot": "/tmp/blaxel-final-case-2/repo",
        "claimedAt": "2026-09-06T17:01:14Z",
        "lastUsedAt": "2026-09-06T17:01:14Z",
        "idleTimeoutSeconds": 1800
      }
    },
    "machine": {
      "metadata": {
        "labels": {
          "crabbox": "true",
          "crabbox.claim": "endpoint-workspace-sha256:<synthetic-endpoint-2>/ownership:<synthetic-owner-2>",
          "crabbox.lease": "blx_crabbox-repo-ae3810",
          "crabbox.provider": "blaxel",
          "crabbox.repo": "repo",
          "crabbox.slug": "quick-hermit"
        },
        "name": "crabbox-repo-ae3810",
        "url": "http://127.0.0.1:42002/native"
      },
      "spec": {
        "lifecycle": {
          "expirationPolicies": [
            {
              "action": "delete",
              "type": "ttl-max-age",
              "value": "2h"
            }
          ],
          "terminatedRetention": "5m"
        },
        "runtime": {
          "image": "ubuntu:24.04",
          "ttl": "2h"
        }
      },
      "status": "DEPLOYED"
    },
    "deleteAttempts": 1,
    "successfulDeletes": 0
  },
  "recoveryStop": {
    "exitCode": 0,
    "stdout": "",
    "stderr": "released lease=blx_crabbox-repo-ae3810 sandbox=crabbox-repo-ae3810\n"
  },
  "afterRecovery": {
    "session": {
      "provider": "blaxel",
      "leaseId": "blx_crabbox-repo-ae3810",
      "slug": "quick-hermit",
      "reused": false,
      "kept": true,
      "cleanupCommand": "crabbox stop --provider blaxel blx_crabbox-repo-ae3810"
    },
    "claims": {},
    "machine": null,
    "deleteAttempts": 2,
    "successfulDeletes": 1
  },
  "portClosed": true,
  "serverThreadStopped": true,
  "temporaryDirectoryRemoved": true
}
```

</details>

<details>
<summary>Final replay: setup-kept-failure</summary>

Run stdout:

```text

```

Run stderr (includes full timing):

```text
leased blx_crabbox-repo-72e940 slug=brisk-crab provider=blaxel sandbox=crabbox-repo-72e940 name=crabbox-repo-72e940
provider=blaxel lease=blx_crabbox-repo-72e940 sandbox=crabbox-repo-72e940 workdir=/tmp/blaxel-final-case-4/workspace
keep-on-failure: kept lease=blx_crabbox-repo-72e940 slug=brisk-crab expires=idle/ttl idle_timeout=30m0s ttl=1h30m0s
rerun: crabbox run --provider blaxel --id brisk-crab -- <command>
stop: crabbox stop --provider blaxel brisk-crab
{"provider":"blaxel","leaseId":"blx_crabbox-repo-72e940","slug":"brisk-crab","runnerTotalMs":23,"runnerPhases":[{"name":"delegated.opaque","ms":21,"opaque":true,"reason":"provider owns lifecycle work outside measured sync and command","provider":"blaxel","leaseId":"blx_crabbox-repo-72e940","slug":"brisk-crab"},{"name":"unattributed","ms":2}],"syncMs":0,"syncPhases":[{"name":"sync","skipped":true,"reason":"--no-sync"}],"syncSkipped":true,"syncDelegated":true,"commandMs":0,"totalMs":20,"endToEndMs":0,"exitCode":1,"runStatus":"failed","errorKind":"provider-error","workdir":"/tmp/blaxel-final-case-4/workspace"}
blaxel API request failed status=400 body={"message": "synthetic setup failure"}
```

```json
{
  "beforeRecovery": {
    "session": {
      "provider": "blaxel",
      "leaseId": "blx_crabbox-repo-72e940",
      "slug": "brisk-crab",
      "reused": false,
      "kept": true,
      "cleanupCommand": "crabbox stop --provider blaxel blx_crabbox-repo-72e940"
    },
    "claims": {
      "blx_crabbox-repo-72e940.json": {
        "leaseID": "blx_crabbox-repo-72e940",
        "revision": "<synthetic-revision-4>",
        "slug": "brisk-crab",
        "provider": "blaxel",
        "providerScope": "endpoint-workspace-sha256:<synthetic-endpoint-4>/ownership:<synthetic-owner-4>",
        "repoRoot": "/tmp/blaxel-final-case-4/repo",
        "claimedAt": "2026-09-06T17:01:15Z",
        "lastUsedAt": "2026-09-06T17:01:15Z",
        "idleTimeoutSeconds": 1800
      }
    },
    "machine": {
      "metadata": {
        "labels": {
          "crabbox": "true",
          "crabbox.claim": "endpoint-workspace-sha256:<synthetic-endpoint-4>/ownership:<synthetic-owner-4>",
          "crabbox.lease": "blx_crabbox-repo-72e940",
          "crabbox.provider": "blaxel",
          "crabbox.repo": "repo",
          "crabbox.slug": "brisk-crab"
        },
        "name": "crabbox-repo-72e940",
        "url": "http://127.0.0.1:42004/native"
      },
      "spec": {
        "lifecycle": {
          "expirationPolicies": [
            {
              "action": "delete",
              "type": "ttl-max-age",
              "value": "2h"
            }
          ],
          "terminatedRetention": "5m"
        },
        "runtime": {
          "image": "ubuntu:24.04",
          "ttl": "2h"
        }
      },
      "status": "DEPLOYED"
    },
    "deleteAttempts": 0,
    "successfulDeletes": 0
  },
  "recoveryStop": {
    "exitCode": 0,
    "stdout": "",
    "stderr": "released lease=blx_crabbox-repo-72e940 sandbox=crabbox-repo-72e940\n"
  },
  "afterRecovery": {
    "session": {
      "provider": "blaxel",
      "leaseId": "blx_crabbox-repo-72e940",
      "slug": "brisk-crab",
      "reused": false,
      "kept": true,
      "cleanupCommand": "crabbox stop --provider blaxel blx_crabbox-repo-72e940"
    },
    "claims": {},
    "machine": null,
    "deleteAttempts": 1,
    "successfulDeletes": 1
  },
  "portClosed": true,
  "serverThreadStopped": true,
  "temporaryDirectoryRemoved": true
}
```

</details>

Current head `943f48348c5dba02d140cc9cc4fb377a5aaf5e9c` commits this exact tested index. Managed Codex review of the final main integration was scoped-clean at P0 with no accepted findings. The CI fallback is already landed on main.

<details>
<summary>Historical proof and exact unchanged fixture</summary>

The following records are preserved as historical source-bound evidence; use the final verification above for current integration.

Blaxel one-shot runs could report success after sandbox deletion failed, leave a recoverable sandbox behind while reporting `kept=false`, and lose the session handle and timing record when workspace setup failed. Run assembled its result before a deferred cleanup that only printed a warning.

Use the existing `shared.RunDelegatedSandbox` owner for sequencing, retained-session reporting, archive lifetime, and final outcome/timing publication. Blaxel retains acquisition and partial-resource rollback, endpoint/workspace/ownership binding, archive upload, and native process execution. The command result stays primary: a command exit 7 plus failed deletion still exits 7 and reports both diagnostics; cleanup-only failure exits 1 and preserves a recovery handle.

Cleanup captures the original claim and uses the existing context-aware compare-and-delete transaction, including its lock wait. Remote ownership is rechecked under that transaction before deletion; a replacement claim or changed remote ownership prevents deletion. This ownership recheck is an intentional defensive correction, distinct from the reproduced reporting regressions. Fresh-owned missing-resource cleanup remains idempotent. `stop`, warmup, HTTP client construction, and archive transport are unchanged.

### Verification and scope

The new reporting regressions were run **before implementation** against source `8166af8b652721a943ca47deca3faa020aa2fdc8`, then rerun with a Go overlay restoring that baseline's Blaxel `backend.go` and `core.go`. The actual baseline returned exit 0/no error for cleanup-only failure, emitted `runStatus: succeeded`, and reported `kept=false`. Command exit 7 lost the cleanup diagnostic. Setup failure returned an empty result/session and no timing record. These are baseline test observations; the native fixture below is candidate positive proof, not a native baseline comparison.

```sh
# Baseline overlay maps only the two Blaxel implementation files to their
# contents at 8166af8b652721a943ca47deca3faa020aa2fdc8; new tests remain present.
go test -overlay baseline-overlay.json ./internal/providers/blaxel \
  -run 'TestRun(FinalizesCleanupFailure|SetupFailureKeepsRecoverableSession)' -count=1
# FAIL as expected on the original implementation.

go test -race ./internal/providers/blaxel ./internal/providers/shared -count=1
go vet ./internal/providers/blaxel ./internal/providers/shared
git diff --check
```

Actual integrated-candidate race log (base `749deb4b948bd5ec2d590661c5ff2ce8da9015ed` plus the five-file change):

```text
ok  	github.com/openclaw/crabbox/internal/providers/blaxel	6.939s
ok  	github.com/openclaw/crabbox/internal/providers/shared	2.675s
```

Focused vet and diff checks passed; vet emitted no output. The provider documentation and changelog were added, and documentation link checks passed. Existing tests also cover archive preparation before create, snapshot preservation, seekable uploads, cancellation, and process transport. New ownership cases verify replacement-claim preservation, changed remote-label refusal, and already-missing cleanup.

The frozen **built CLI** was exercised through its real Blaxel HTTP client against a synthetic loopback service. Submitted shell commands executed locally in isolated temporary workspaces; no hosted Blaxel account was used. The fixture uses `--no-sync`, so this native receipt does not establish hosted execution, external-provider network behavior, or archive-sync coverage. Only synthetic authentication is supplied; inherited account credentials/configuration are excluded.

| Case | Run exit / timing error kind | Before recovery | Actual CLI recovery | Final state |
| --- | --- | --- | --- | --- |
| Success | 0 / none | Machine deleted, claim absent | Not needed | One successful delete; no claim |
| Cleanup-only failure | 1 / `provider-error` | `kept=true`, machine and exact claim retained | `stop` exits 0 after injected failure disabled | One successful delete; no machine or claim |
| Command + cleanup failure | 7 / `command-exit` | Both diagnostics, `kept=true`, machine and claim retained | `stop` exits 0 | One successful delete; no machine or claim |
| Setup failure + keep-on-failure | 1 / `provider-error` | Timing + `kept=true` session, machine and claim retained | `stop` exits 0 | One successful delete; no machine or claim |

An initial integrated replay passed `./crabbox`; path normalization produced the bare name `crabbox`, so subprocess lookup selected an installed CLI from `PATH`. That run failed the cleanup assertion. Its receipt hash described the file read, not the executable launched, and it is excluded from both candidate and baseline proof. The source, candidate binary, and fixture were unchanged. Replaying with the **absolute candidate binary path** passed all four cases; the captures below are from that corrected replay. Public replay commands below use absolute binary paths.

All four scenarios verified closed loopback ports, stopped server threads, and removed temporary directories. Subprocesses have bounded timeouts and owned process groups are killed/reaped; the fixture's `finally` path attempts CLI recovery before closing the server. The first four-case fixture is retained as historical outcome proof; this second fixture adds explicit recovery and state observations.

### Representative captured output and recovery

These are complete selected captures from the v2 receipt, with display-only substitutions for temporary roots, ephemeral ports, generated ownership scope/revision values. Synthetic lease IDs and slugs are retained. The same placeholder in the claim and machine labels denotes the same original value. Raw evidence is retained separately; substitutions do not alter statuses, exit codes, timings, command output, or recovery observations. The saved lease-output file is a historical handle and remains `kept=true` after a later `stop`; machine absence and an empty claims map establish recovery.

<details>
<summary>cleanup-failure: full run output, retained state, and stop recovery</summary>

Run stdout:

```text
native-proof
```

Run stderr (includes timing JSON):

```text
leased blx_crabbox-repo-33493c slug=tidal-prawn provider=blaxel sandbox=crabbox-repo-33493c name=crabbox-repo-33493c
provider=blaxel lease=blx_crabbox-repo-33493c sandbox=crabbox-repo-33493c workdir=<case-cleanup>/workspace
blaxel run summary sync_skipped=true command=11ms total=46ms exit=1
{"provider":"blaxel","leaseId":"blx_crabbox-repo-33493c","slug":"tidal-prawn","runnerTotalMs":47,"runnerPhases":[{"name":"command","ms":10,"provider":"blaxel","leaseId":"blx_crabbox-repo-33493c","slug":"tidal-prawn"},{"name":"delegated.opaque","ms":37,"opaque":true,"reason":"provider owns lifecycle work outside measured sync and command","provider":"blaxel","leaseId":"blx_crabbox-repo-33493c","slug":"tidal-prawn"}],"syncMs":0,"syncPhases":[{"name":"sync","skipped":true,"reason":"--no-sync"}],"syncSkipped":true,"syncDelegated":true,"commandMs":10,"totalMs":46,"endToEndMs":0,"exitCode":1,"runStatus":"failed","errorKind":"provider-error","workdir":"<case-cleanup>/workspace"}
blaxel cleanup failed: blaxel API request failed status=400 body={"message": "synthetic delete failure"}
```

```json
{
  "beforeRecovery": {
    "session": {
      "provider": "blaxel",
      "leaseId": "blx_crabbox-repo-33493c",
      "slug": "tidal-prawn",
      "reused": false,
      "kept": true,
      "cleanupCommand": "crabbox stop --provider blaxel blx_crabbox-repo-33493c"
    },
    "claims": {
      "blx_crabbox-repo-33493c.json": {
        "leaseID": "blx_crabbox-repo-33493c",
        "revision": "<synthetic-claim-revision-2>",
        "slug": "tidal-prawn",
        "provider": "blaxel",
        "providerScope": "endpoint-workspace-sha256:<synthetic-endpoint-digest-2>/ownership:<synthetic-owner-2>",
        "repoRoot": "<case-cleanup>/repo",
        "claimedAt": "2026-09-06T15:44:47Z",
        "lastUsedAt": "2026-09-06T15:44:47Z",
        "idleTimeoutSeconds": 1800
      }
    },
    "machine": {
      "metadata": {
        "labels": {
          "crabbox": "true",
          "crabbox.claim": "endpoint-workspace-sha256:<synthetic-endpoint-digest-2>/ownership:<synthetic-owner-2>",
          "crabbox.lease": "blx_crabbox-repo-33493c",
          "crabbox.provider": "blaxel",
          "crabbox.repo": "repo",
          "crabbox.slug": "tidal-prawn"
        },
        "name": "crabbox-repo-33493c",
        "url": "http://127.0.0.1:41002/native"
      },
      "spec": {
        "lifecycle": {
          "expirationPolicies": [
            {
              "action": "delete",
              "type": "ttl-max-age",
              "value": "2h"
            }
          ],
          "terminatedRetention": "5m"
        },
        "runtime": {
          "image": "ubuntu:24.04",
          "ttl": "2h"
        }
      },
      "status": "DEPLOYED"
    },
    "deleteAttempts": 1,
    "successfulDeletes": 0
  },
  "recoveryStop": {
    "exitCode": 0,
    "stdout": "",
    "stderr": "released lease=blx_crabbox-repo-33493c sandbox=crabbox-repo-33493c\n"
  },
  "afterRecovery": {
    "session": {
      "provider": "blaxel",
      "leaseId": "blx_crabbox-repo-33493c",
      "slug": "tidal-prawn",
      "reused": false,
      "kept": true,
      "cleanupCommand": "crabbox stop --provider blaxel blx_crabbox-repo-33493c"
    },
    "claims": {},
    "machine": null,
    "deleteAttempts": 2,
    "successfulDeletes": 1
  },
  "portClosed": true,
  "serverThreadStopped": true,
  "temporaryDirectoryRemoved": true
}
```

</details>

<details>
<summary>setup-kept-failure: full run output, retained state, and stop recovery</summary>

Run stdout:

```text
```

Run stderr (includes timing JSON):

```text
leased blx_crabbox-repo-41103a slug=quick-krill provider=blaxel sandbox=crabbox-repo-41103a name=crabbox-repo-41103a
provider=blaxel lease=blx_crabbox-repo-41103a sandbox=crabbox-repo-41103a workdir=<case-setup>/workspace
keep-on-failure: kept lease=blx_crabbox-repo-41103a slug=quick-krill expires=idle/ttl idle_timeout=30m0s ttl=1h30m0s
rerun: crabbox run --provider blaxel --id quick-krill -- <command>
stop: crabbox stop --provider blaxel quick-krill
{"provider":"blaxel","leaseId":"blx_crabbox-repo-41103a","slug":"quick-krill","runnerTotalMs":17,"runnerPhases":[{"name":"delegated.opaque","ms":16,"opaque":true,"reason":"provider owns lifecycle work outside measured sync and command","provider":"blaxel","leaseId":"blx_crabbox-repo-41103a","slug":"quick-krill"},{"name":"unattributed","ms":1}],"syncMs":0,"syncPhases":[{"name":"sync","skipped":true,"reason":"--no-sync"}],"syncSkipped":true,"syncDelegated":true,"commandMs":0,"totalMs":15,"endToEndMs":0,"exitCode":1,"runStatus":"failed","errorKind":"provider-error","workdir":"<case-setup>/workspace"}
blaxel API request failed status=400 body={"message": "synthetic setup failure"}
```

```json
{
  "beforeRecovery": {
    "session": {
      "provider": "blaxel",
      "leaseId": "blx_crabbox-repo-41103a",
      "slug": "quick-krill",
      "reused": false,
      "kept": true,
      "cleanupCommand": "crabbox stop --provider blaxel blx_crabbox-repo-41103a"
    },
    "claims": {
      "blx_crabbox-repo-41103a.json": {
        "leaseID": "blx_crabbox-repo-41103a",
        "revision": "<synthetic-claim-revision-4>",
        "slug": "quick-krill",
        "provider": "blaxel",
        "providerScope": "endpoint-workspace-sha256:<synthetic-endpoint-digest-4>/ownership:<synthetic-owner-4>",
        "repoRoot": "<case-setup>/repo",
        "claimedAt": "2026-09-06T15:44:48Z",
        "lastUsedAt": "2026-09-06T15:44:48Z",
        "idleTimeoutSeconds": 1800
      }
    },
    "machine": {
      "metadata": {
        "labels": {
          "crabbox": "true",
          "crabbox.claim": "endpoint-workspace-sha256:<synthetic-endpoint-digest-4>/ownership:<synthetic-owner-4>",
          "crabbox.lease": "blx_crabbox-repo-41103a",
          "crabbox.provider": "blaxel",
          "crabbox.repo": "repo",
          "crabbox.slug": "quick-krill"
        },
        "name": "crabbox-repo-41103a",
        "url": "http://127.0.0.1:41004/native"
      },
      "spec": {
        "lifecycle": {
          "expirationPolicies": [
            {
              "action": "delete",
              "type": "ttl-max-age",
              "value": "2h"
            }
          ],
          "terminatedRetention": "5m"
        },
        "runtime": {
          "image": "ubuntu:24.04",
          "ttl": "2h"
        }
      },
      "status": "DEPLOYED"
    },
    "deleteAttempts": 0,
    "successfulDeletes": 0
  },
  "recoveryStop": {
    "exitCode": 0,
    "stdout": "",
    "stderr": "released lease=blx_crabbox-repo-41103a sandbox=crabbox-repo-41103a\n"
  },
  "afterRecovery": {
    "session": {
      "provider": "blaxel",
      "leaseId": "blx_crabbox-repo-41103a",
      "slug": "quick-krill",
      "reused": false,
      "kept": true,
      "cleanupCommand": "crabbox stop --provider blaxel blx_crabbox-repo-41103a"
    },
    "claims": {},
    "machine": null,
    "deleteAttempts": 1,
    "successfulDeletes": 1
  },
  "portClosed": true,
  "serverThreadStopped": true,
  "temporaryDirectoryRemoved": true
}
```

</details>

### Exact tested inputs

The integrated native binary was built from an isolated copy of base `749deb4b948bd5ec2d590661c5ff2ce8da9015ed` plus the five-file change (adapter, tests, helper removal, provider docs, changelog). All 2,223 source-file hashes were checked against its source manifest. The source hashes below bind that integrated candidate, not a subsequently merged commit. The corrected replay passed an absolute path to the built binary. Raw receipt hashes refer to the preserved unsanitized evidence, so the display substitutions above intentionally do not hash to that receipt.

```text
8927365f149d37172978dbdd02824e6c53e3e8d8f322cef4108d472b1ee7e1f4  CHANGELOG.md
d46c7f2e0ada4b66617d092d126152bb3b1d502b36a4ee376254685d63c8a7ee  docs/providers/blaxel.md
9b97fc92f41edf98572839d48db6d2d74358dbdc926f2db8c45b1b07a4bffa33  internal/providers/blaxel/backend.go
4fbf95c06132b72e415e634a94a36031cfb1216dd080bdc1293eaa098a5c8867  internal/providers/blaxel/backend_test.go
0fcef686d5f79b279f1d54857be2541e65207799595088739cbe78d30f5e2d97  internal/providers/blaxel/core.go
b6d0f32364acc619e93858972a9c9c5ba709fb100bb25293569d0a1e8afad390  internal/providers/blaxel/client.go
19f59055a6392452fa89281c2889fc789e4d7db9ccbde78c9db86dac625ff5f6  internal/providers/blaxel/sync.go
4556baebbf21c702730603d86733177593b004cf8b2c361c1b96cd5ac9796a38  internal/providers/shared/delegated.go
f25925acefdd84c154740be6e9320b2067e8142394e2ecee975979c49fc1a3e3  integrated-source.patch
571ec0e41bc79ce1c4101841dce496f57bf4438fae9590c59eedea3a808f7668  crabbox
28a56410c15aca0e7a5b1b2cec200c4bcac0d836256bc182b93d0f16c6dc4611  native-v2.py
dd5347743ca62edcd347efea6eb5e71910aab38c99fe0d1526be71d82749173a  native-v2.json (corrected integrated replay)
```

### Runnable native fixture

Save the exact code below as `native-v2.py` in an empty proof directory, build the candidate CLI, and pass its absolute path. Requires Python 3, Git, and a POSIX shell. It creates its own temporary repository/config/state and binds only loopback. It writes the complete `native-v2.json` receipt next to the script, including failure observations if an assertion interrupts the run.

```sh
go build -trimpath -o /tmp/crabbox-candidate ./cmd/crabbox
python3 native-v2.py /tmp/crabbox-candidate
```

<details>
<summary>Full native-v2.py (exact fixture matching the hash above)</summary>

```python
"""Built CLI protocol/recovery proof; synthetic loopback service, no hosted account."""
import copy, hashlib, http.server, json, os, pathlib, signal, socket, subprocess, sys, tempfile, threading
base = pathlib.Path(__file__).resolve().parent
binary = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else base / 'crabbox'
receipt = {'proof': __doc__, 'binarySHA256': hashlib.sha256(binary.read_bytes()).hexdigest(), 'fixtureSHA256': hashlib.sha256(pathlib.Path(__file__).read_bytes()).hexdigest(), 'results': []}

def execute(argv, *, cwd, env, timeout=30, shell=False):
    process = subprocess.Popen(argv, cwd=cwd, env=env, shell=shell, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, start_new_session=True)
    try:
        out, err = process.communicate(timeout=timeout)
        return {'exitCode': process.returncode, 'stdout': out, 'stderr': err}
    finally:
        # Kill the owned process group even if its leader exited with descendants.
        try:
            os.killpg(process.pid, signal.SIGKILL)
        except ProcessLookupError:
            pass
        if process.poll() is None:
            process.communicate(timeout=5)

try:
    for scenario in ('success', 'cleanup-failure', 'command-and-cleanup-failure', 'setup-kept-failure'):
        result = {'scenario': scenario}
        receipt['results'].append(result)
        with tempfile.TemporaryDirectory(prefix='blaxel-run-native-v2-') as tmp:
            root = pathlib.Path(tmp)
            repo, workspace = root / 'repo', root / 'workspace'
            repo.mkdir(); workspace.mkdir()
            env = {'PATH': os.environ['PATH'], 'HOME': str(root/'home'), 'XDG_CONFIG_HOME': str(root/'config'), 'XDG_STATE_HOME': str(root/'state'), 'TMPDIR': str(root), 'CRABBOX_BLAXEL_API_KEY': 'synthetic-fixture-only'}
            assert execute(['git', 'init', '-q', str(repo)], cwd=root, env=env)['exitCode'] == 0
            (repo/'sample.txt').write_text('synthetic fixture\n')
            assert execute(['git', 'add', '.'], cwd=repo, env=env)['exitCode'] == 0
            state = {'sandbox': None, 'trace': [], 'logs': {}, 'deleteAttempts': 0, 'successfulDeletes': 0, 'failureEnabled': True}
            leasefile = root/'lease.json'
            def snapshot():
                return {'session': json.loads(leasefile.read_text()) if leasefile.exists() else None,
                        'claims': {p.name: json.loads(p.read_text()) for p in (root/'state'/'crabbox'/'claims').glob('*.json')},
                        'machine': copy.deepcopy(state['sandbox']), 'deleteAttempts': state['deleteAttempts'], 'successfulDeletes': state['successfulDeletes']}
            class Handler(http.server.BaseHTTPRequestHandler):
                def log_message(self, *args): pass
                def respond(self, code, body):
                    raw = json.dumps(body).encode()
                    self.send_response(code); self.send_header('Content-Type', 'application/json'); self.send_header('Content-Length', str(len(raw))); self.end_headers(); self.wfile.write(raw)
                def dispatch(self):
                    state['trace'].append(self.command+' '+self.path)
                    if self.headers.get('Authorization') != 'Bearer synthetic-fixture-only':
                        return self.respond(401, {'message': 'wrong synthetic authentication'})
                    raw = self.rfile.read(int(self.headers.get('Content-Length', 0)))
                    body = json.loads(raw) if raw else {}
                    if self.path == '/v0/sandboxes' and self.command == 'POST':
                        state['sandbox'] = body
                        body['metadata']['url'] = f'http://127.0.0.1:{self.server.server_port}/native'
                        body['status'] = 'DEPLOYED'
                        return self.respond(200, body)
                    if self.path.startswith('/v0/sandboxes/'):
                        if state['sandbox'] is None: return self.respond(404, {'message': 'synthetic sandbox missing'})
                        if self.path != '/v0/sandboxes/'+state['sandbox']['metadata']['name']: return self.respond(404, {})
                        if self.command == 'PUT': state['sandbox'] = body; body['status'] = 'DEPLOYED'
                        if self.command == 'DELETE':
                            state['deleteAttempts'] += 1
                            if state['failureEnabled'] and 'cleanup-failure' in scenario:
                                return self.respond(400, {'message': 'synthetic delete failure'})
                            state['successfulDeletes'] += 1; state['sandbox'] = None
                            return self.respond(200, {})
                        return self.respond(200, state['sandbox'])
                    if self.path == '/native/process' and self.command == 'POST':
                        if state['failureEnabled'] and scenario == 'setup-kept-failure': return self.respond(400, {'message': 'synthetic setup failure'})
                        try:
                            command = execute(body['command'], shell=True, cwd=body.get('workingDir') or workspace, env=env, timeout=5)
                        except subprocess.TimeoutExpired:
                            return self.respond(408, {'message': 'synthetic local shell timeout'})
                        state['logs'] = {'stdout': command['stdout'], 'stderr': command['stderr']}
                        return self.respond(200, {'pid': 'fixture-process', 'status': 'completed', 'exitCode': command['exitCode']})
                    if self.path == '/native/process/fixture-process/logs': return self.respond(200, state['logs'])
                    return self.respond(404, {'message': 'unknown synthetic route'})
                do_GET = do_POST = do_PUT = do_DELETE = dispatch
            server = http.server.ThreadingHTTPServer(('127.0.0.1', 0), Handler)
            port = server.server_port
            thread = threading.Thread(target=server.serve_forever, daemon=True); thread.start()
            common = ['--provider', 'blaxel', '--blaxel-api-url', f'http://127.0.0.1:{port}']
            def stop_owned():
                state['failureEnabled'] = False
                lease_id = 'blx_'+state['sandbox']['metadata']['name']
                return execute([str(binary), 'stop']+common+[lease_id], cwd=repo, env=env)
            try:
                command = ['/bin/sh', '-c', 'echo native-command-failure >&2; exit 7'] if scenario == 'command-and-cleanup-failure' else ['/bin/echo', 'native-proof']
                argv = [str(binary), 'run']+common+['--blaxel-workdir', str(workspace), '--no-sync', '--timing-json', '--timing-record', 'off', '--lease-output', str(leasefile)]
                if scenario == 'setup-kept-failure': argv += ['--keep-on-failure']
                run = execute(argv+['--']+command, cwd=repo, env=env)
                reports = [json.loads(line) for line in run['stderr'].splitlines() if line.startswith('{')]
                result['run'] = run; result['timing'] = reports; result['beforeRecovery'] = snapshot()
                expected = 0 if scenario == 'success' else 7 if scenario == 'command-and-cleanup-failure' else 1
                expected_kind = '' if scenario == 'success' else 'command-exit' if scenario == 'command-and-cleanup-failure' else 'provider-error'
                assert run['exitCode'] == expected, run
                assert reports and reports[-1]['exitCode'] == expected, reports
                assert reports[-1]['runStatus'] == ('succeeded' if expected == 0 else 'failed'), reports
                assert reports[-1].get('errorKind', '') == expected_kind, reports
                before = result['beforeRecovery']
                if scenario == 'success':
                    assert run['stdout'] == 'native-proof\n', run
                    assert before['machine'] is None and not before['claims'] and before['successfulDeletes'] == 1, before
                else:
                    assert before['session']['kept'] and before['machine'] is not None, before
                    lease_id = before['session']['leaseId']
                    assert list(before['claims']) == [lease_id+'.json'], before
                    if 'cleanup-failure' in scenario: assert 'synthetic delete failure' in run['stderr'], run
                    if scenario == 'command-and-cleanup-failure': assert 'blaxel run exited 7' in run['stderr'] and 'native-command-failure' in run['stderr'], run
                    if scenario == 'setup-kept-failure': assert 'synthetic setup failure' in run['stderr'], run
                    result['recoveryStop'] = stop_owned()
                    result['afterRecovery'] = snapshot()
                    assert result['recoveryStop']['exitCode'] == 0, result['recoveryStop']
                    assert state['sandbox'] is None and state['successfulDeletes'] == 1 and not result['afterRecovery']['claims'], result['afterRecovery']
                result['passed'] = True
            finally:
                try:
                    if state['sandbox'] is not None:
                        result['finallyRecoveryStop'] = stop_owned()
                    result['finalState'] = snapshot()
                    result['trace'] = copy.deepcopy(state['trace'])
                finally:
                    server.shutdown(); server.server_close(); thread.join(timeout=5)
                    probe = socket.socket(); probe.settimeout(1)
                    result['portClosed'] = probe.connect_ex(('127.0.0.1', port)) != 0
                    probe.close()
                    result['serverThreadStopped'] = not thread.is_alive()
            assert result['portClosed'] and result['serverThreadStopped'], result
        result['temporaryDirectoryRemoved'] = not root.exists()
    receipt['passed'] = all(r.get('passed') and r['temporaryDirectoryRemoved'] for r in receipt['results'])
finally:
    (base/'native-v2.json').write_text(json.dumps(receipt, indent=2)+'\n')
print(json.dumps({'passed': receipt['passed'], 'scenarios': len(receipt['results']), 'receipt': str(base/'native-v2.json')}))
```

</details>

Implementation commit `a92c35607691c9ac99a8495565baead3b6a4a782` contains the tested integrated change. Follow-up `eba6b907136582b0b7caa25172085f364cee1ca6` adds only this PR’s changelog link; production and test source are unchanged. Managed Codex review of the integrated implementation was scoped-clean at P0 with no accepted findings.

Current head `517953241481d079edacf13707be524a3b08f473` integrates main `369574fea098e70038ed4cf53de7fafbfaadc154` and resolves only the changelog insertion conflict, preserving both entries. Incoming changes add developer-image recipe files; every file under `cmd` and `internal`, plus `go.mod` and `go.sum`, remains identical to the native-tested implementation. The resolved PR diff also passed managed review with no accepted P0 findings.

</details>
