### PR TITLE
refactor: share control and data HTTP client construction

### DIFF
--- a/internal/providers/azuredynamicsessions/client.go
+++ b/internal/providers/azuredynamicsessions/client.go
@@ -96,7 +96,7 @@ var newAzureDynamicSessionsClient = func(ctx context.Context, cfg Config, rt Run
 	if err != nil {
 		return nil, err
 	}
-	httpClient, dataHTTPClient := azureDynamicSessionsHTTPClients(rt.HTTP, azureDynamicSessionsControlTimeout)
+	httpClient, dataHTTPClient := shared.ControlAndDataHTTPClients(rt.HTTP, azureDynamicSessionsControlTimeout)
 	return &azureDynamicSessionsClient{
 		endpoint:             endpoint,
 		managementAPIVersion: blank(strings.TrimSpace(cfg.AzureDynamicSessions.APIVersion), "2025-02-02-preview"),
@@ -104,13 +104,6 @@ var newAzureDynamicSessionsClient = func(ctx context.Context, cfg Config, rt Run
 		httpClient:           httpClient,
 		dataHTTPClient:       dataHTTPClient,
 	}, nil
-}
-
-func azureDynamicSessionsHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.Client, *http.Client) {
-	if injected != nil {
-		return injected, injected
-	}
-	return &http.Client{Timeout: controlTimeout}, &http.Client{}
 }
 
 func azureDynamicSessionsEndpoint(cfg Config) (string, error) {

--- a/internal/providers/azuredynamicsessions/client_test.go
+++ b/internal/providers/azuredynamicsessions/client_test.go
@@ -17,6 +17,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func TestAzureDynamicSessionsFallbackBoundsControlAndPreservesExecStream(t *testing.T) {
@@ -42,7 +44,7 @@ func TestAzureDynamicSessionsFallbackBoundsControlAndPreservesExecStream(t *test
 	}))
 	defer server.Close()
 
-	control, data := azureDynamicSessionsHTTPClients(nil, controlTimeout)
+	control, data := shared.ControlAndDataHTTPClients(nil, controlTimeout)
 	client := &azureDynamicSessionsClient{
 		endpoint:             server.URL,
 		managementAPIVersion: "2025-02-02-preview",

--- a/internal/providers/blaxel/client.go
+++ b/internal/providers/blaxel/client.go
@@ -135,7 +135,7 @@ func newBlaxelClient(cfg Config, rt Runtime) (Client, error) {
 		return nil, exit(2, "provider=blaxel needs an API key; load CRABBOX_BLAXEL_API_KEY or BL_API_KEY from a secret manager")
 	}
 	workspace := strings.TrimSpace(cfg.Blaxel.Workspace)
-	httpClient, dataHTTPClient := blaxelHTTPClients(rt.HTTP, blaxelControlTimeout)
+	httpClient, dataHTTPClient := shared.ControlAndDataHTTPClients(rt.HTTP, blaxelControlTimeout)
 	return &restClient{
 		base:      baseURL,
 		apiKey:    apiKey,
@@ -144,13 +144,6 @@ func newBlaxelClient(cfg Config, rt Runtime) (Client, error) {
 		http:      secureHTTPClient(httpClient),
 		dataHTTP:  secureHTTPClient(dataHTTPClient),
 	}, nil
-}
-
-func blaxelHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.Client, *http.Client) {
-	if injected != nil {
-		return injected, injected
-	}
-	return &http.Client{Timeout: controlTimeout}, &http.Client{}
 }
 
 func BlaxelAPIKey(cfg Config) string {

--- a/internal/providers/blaxel/client_test.go
+++ b/internal/providers/blaxel/client_test.go
@@ -17,6 +17,8 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func TestRedactErrorPreservesCauseAndSafeFormatting(t *testing.T) {
@@ -237,7 +239,7 @@ func TestBlaxelFallbackBoundsControlAndPreservesUpload(t *testing.T) {
 	}))
 	defer server.Close()
 
-	control, data := blaxelHTTPClients(nil, controlTimeout)
+	control, data := shared.ControlAndDataHTTPClients(nil, controlTimeout)
 	client := &restClient{
 		base:     server.URL,
 		apiKey:   "test-key",

--- a/internal/providers/cloudflaresandbox/client.go
+++ b/internal/providers/cloudflaresandbox/client.go
@@ -106,7 +106,7 @@ func newBridgeClient(cfg Config, rt Runtime) (bridgeClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	httpClient, dataHTTPClient := cloudflareSandboxHTTPClients(rt.HTTP, cloudflareSandboxControlTimeout)
+	httpClient, dataHTTPClient := shared.ControlAndDataHTTPClients(rt.HTTP, cloudflareSandboxControlTimeout)
 	trusted, _ := url.Parse(baseURL)
 	return &client{
 		baseURL:  baseURL,
@@ -114,13 +114,6 @@ func newBridgeClient(cfg Config, rt Runtime) (bridgeClient, error) {
 		http:     shared.SecureHTTPClient(httpClient, trusted, cloudflareSandboxRedirectError),
 		dataHTTP: shared.SecureHTTPClient(dataHTTPClient, trusted, cloudflareSandboxRedirectError),
 	}, nil
-}
-
-func cloudflareSandboxHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.Client, *http.Client) {
-	if injected != nil {
-		return injected, injected
-	}
-	return &http.Client{Timeout: controlTimeout}, &http.Client{}
 }
 
 func cloudflareSandboxRedirectError(destination *url.URL) error {

--- a/internal/providers/cloudflaresandbox/client_test.go
+++ b/internal/providers/cloudflaresandbox/client_test.go
@@ -39,7 +39,7 @@ func TestBridgeFallbackBoundsControlAndPreservesExecStream(t *testing.T) {
 	}))
 	defer server.Close()
 
-	control, data := cloudflareSandboxHTTPClients(nil, controlTimeout)
+	control, data := shared.ControlAndDataHTTPClients(nil, controlTimeout)
 	trusted, _ := url.Parse(server.URL)
 	client := &client{
 		baseURL:  server.URL,

--- a/internal/providers/cubesandbox/backend_test.go
+++ b/internal/providers/cubesandbox/backend_test.go
@@ -239,7 +239,7 @@ func TestCubeSandboxInjectedHTTPClientIsPreservedForBothPlanes(t *testing.T) {
 
 func TestCubeSandboxDataPlaneStreamOutlivesControlTimeout(t *testing.T) {
 	const controlTimeout = 20 * time.Millisecond
-	managementClient, dataPlaneClient := cubeSandboxHTTPClients(nil, controlTimeout)
+	managementClient, dataPlaneClient := shared.ControlAndDataHTTPClients(nil, controlTimeout)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.Copy(io.Discard, r.Body)

--- a/internal/providers/cubesandbox/client.go
+++ b/internal/providers/cubesandbox/client.go
@@ -101,7 +101,7 @@ func (e *cubesandboxAPIError) Error() string {
 
 var newCubeSandboxClient = func(cfg Config, rt Runtime) (cubesandboxAPI, error) {
 	apiKey := strings.TrimSpace(cfg.CubeSandbox.APIKey)
-	httpClient, dataPlaneClient := cubeSandboxHTTPClients(rt.HTTP, cubesandboxControlTimeout)
+	httpClient, dataPlaneClient := shared.ControlAndDataHTTPClients(rt.HTTP, cubesandboxControlTimeout)
 	apiURL, err := validateCubeSandboxAPIURL(blank(cfg.CubeSandbox.APIURL, "http://127.0.0.1:3000"))
 	if err != nil {
 		return nil, err
@@ -132,13 +132,6 @@ var newCubeSandboxClient = func(cfg Config, rt Runtime) (cubesandboxAPI, error) 
 		httpClient:  httpClient,
 		envdClient:  envdClient,
 	}, nil
-}
-
-func cubeSandboxHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.Client, *http.Client) {
-	if injected != nil {
-		return injected, injected
-	}
-	return &http.Client{Timeout: controlTimeout}, &http.Client{Timeout: 0}
 }
 
 func cubeSandboxDataPlaneHTTPClient(source *http.Client, proxyHost string, proxyPort int) (*http.Client, error) {

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -233,7 +233,7 @@ func TestE2BControlClientBoundsStalledResponseBody(t *testing.T) {
 	}))
 	defer server.Close()
 
-	controlClient, _ := e2bHTTPClients(nil, controlTimeout)
+	controlClient, _ := shared.ControlAndDataHTTPClients(nil, controlTimeout)
 	client := &e2bClient{apiKey: "e2b_test", apiURL: server.URL, httpClient: controlClient}
 	started := time.Now()
 	_, err := client.GetSandbox(context.Background(), "sbx_1")
@@ -254,7 +254,7 @@ func TestE2BControlClientBoundsWithheldHeaders(t *testing.T) {
 	}))
 	defer server.Close()
 
-	controlClient, _ := e2bHTTPClients(nil, controlTimeout)
+	controlClient, _ := shared.ControlAndDataHTTPClients(nil, controlTimeout)
 	client := &e2bClient{apiKey: "e2b_test", apiURL: server.URL, httpClient: controlClient}
 	started := time.Now()
 	_, err := client.GetSandbox(context.Background(), "sbx_1")
@@ -281,7 +281,7 @@ func TestE2BDataPlaneStreamOutlivesControlTimeout(t *testing.T) {
 	}))
 	defer server.Close()
 
-	controlClient, _ := e2bHTTPClients(nil, controlTimeout)
+	controlClient, _ := shared.ControlAndDataHTTPClients(nil, controlTimeout)
 	client := &e2bClient{
 		domain:     "e2b.test",
 		httpClient: controlClient,
@@ -330,7 +330,7 @@ func TestE2BDataPlaneUploadOutlivesControlTimeout(t *testing.T) {
 	defer server.Close()
 
 	payload := []byte("before-after")
-	controlClient, _ := e2bHTTPClients(nil, controlTimeout)
+	controlClient, _ := shared.ControlAndDataHTTPClients(nil, controlTimeout)
 	client := &e2bClient{
 		domain:     "e2b.test",
 		httpClient: controlClient,

--- a/internal/providers/e2b/client.go
+++ b/internal/providers/e2b/client.go
@@ -98,7 +98,7 @@ var newE2BClient = func(cfg Config, rt Runtime) (e2bAPI, error) {
 	if apiKey == "" {
 		return nil, exit(2, "provider=e2b requires E2B_API_KEY")
 	}
-	httpClient, envdClient := e2bHTTPClients(rt.HTTP, e2bControlTimeout)
+	httpClient, envdClient := shared.ControlAndDataHTTPClients(rt.HTTP, e2bControlTimeout)
 	apiURL, err := validateE2BAPIURL(blank(cfg.E2B.APIURL, "https://api.e2b.app"))
 	if err != nil {
 		return nil, err
@@ -120,13 +120,6 @@ func validateE2BAPIURL(raw string) (string, error) {
 		Components: exit(2, "provider=e2b API URL must not contain userinfo, query parameters, or a fragment"),
 		Insecure:   exit(2, "provider=e2b API URL must use HTTPS except for loopback development endpoints"),
 	})
-}
-
-func e2bHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.Client, *http.Client) {
-	if injected != nil {
-		return injected, injected
-	}
-	return &http.Client{Timeout: controlTimeout}, &http.Client{Timeout: 0}
 }
 
 func e2bRedirectError(destination *url.URL) error {

--- a/internal/providers/freestyle/client.go
+++ b/internal/providers/freestyle/client.go
@@ -95,7 +95,7 @@ var newFreestyleClient = func(cfg Config, rt Runtime) (freestyleAPI, error) {
 	if err != nil {
 		return nil, err
 	}
-	httpClient, dataHTTPClient := freestyleHTTPClients(rt.HTTP, freestyleControlTimeout)
+	httpClient, dataHTTPClient := shared.ControlAndDataHTTPClients(rt.HTTP, freestyleControlTimeout)
 	trusted, _ := url.Parse(apiURL)
 	return &freestyleHTTPClient{
 		apiKey:         apiKey,
@@ -103,13 +103,6 @@ var newFreestyleClient = func(cfg Config, rt Runtime) (freestyleAPI, error) {
 		httpClient:     shared.SecureHTTPClient(httpClient, trusted, freestyleRedirectError),
 		dataHTTPClient: shared.SecureHTTPClient(dataHTTPClient, trusted, freestyleRedirectError),
 	}, nil
-}
-
-func freestyleHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.Client, *http.Client) {
-	if injected != nil {
-		return injected, injected
-	}
-	return &http.Client{Timeout: controlTimeout}, &http.Client{}
 }
 
 func validateFreestyleAPIURL(raw string) (string, error) {

--- a/internal/providers/freestyle/client_test.go
+++ b/internal/providers/freestyle/client_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
 	"strings"
@@ -33,7 +34,7 @@ func TestFreestyleFallbackBoundsControlAndPreservesCommand(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	control, data := freestyleHTTPClients(nil, controlTimeout)
+	control, data := shared.ControlAndDataHTTPClients(nil, controlTimeout)
 	trusted, _ := url.Parse(server.URL)
 	client := &freestyleHTTPClient{
 		apiKey:         "test-key",
@@ -65,7 +66,16 @@ func TestFreestyleFallbackBoundsControlAndPreservesCommand(t *testing.T) {
 
 func TestFreestyleInjectedHTTPSettingsArePreservedForBothPlanes(t *testing.T) {
 	transport := &http.Transport{DisableKeepAlives: true}
-	injected := &http.Client{Transport: transport, Timeout: 17 * time.Second}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	redirectErr := errors.New("caller redirect policy")
+	redirectCalls := 0
+	injected := &http.Client{Transport: transport, Jar: jar, Timeout: 17 * time.Second, CheckRedirect: func(*http.Request, []*http.Request) error {
+		redirectCalls++
+		return redirectErr
+	}}
 	api, err := newFreestyleClient(Config{Freestyle: FreestyleConfig{
 		APIKey: "test-key",
 		APIURL: "http://127.0.0.1:8787",
@@ -74,11 +84,24 @@ func TestFreestyleInjectedHTTPSettingsArePreservedForBothPlanes(t *testing.T) {
 		t.Fatal(err)
 	}
 	client := api.(*freestyleHTTPClient)
-	if client.httpClient.Transport != transport || client.dataHTTPClient.Transport != transport || client.httpClient.Timeout != injected.Timeout || client.dataHTTPClient.Timeout != injected.Timeout {
+	if client.httpClient.Transport != transport || client.dataHTTPClient.Transport != transport || client.httpClient.Jar != jar || client.dataHTTPClient.Jar != jar || client.httpClient.Timeout != injected.Timeout || client.dataHTTPClient.Timeout != injected.Timeout {
 		t.Fatalf("settings=control:(%T,%s) data:(%T,%s)", client.httpClient.Transport, client.httpClient.Timeout, client.dataHTTPClient.Transport, client.dataHTTPClient.Timeout)
 	}
-	if injected.CheckRedirect != nil {
-		t.Fatal("constructor mutated injected redirect policy")
+	if client.httpClient == injected || client.dataHTTPClient == injected || client.httpClient == client.dataHTTPClient {
+		t.Fatal("secure wrappers must isolate their redirect policies")
+	}
+	sameOrigin := &http.Request{URL: &url.URL{Scheme: "http", Host: "127.0.0.1:8787", Path: "/next"}}
+	crossOrigin := &http.Request{URL: &url.URL{Scheme: "https", Host: "example.invalid"}}
+	for _, secured := range []*http.Client{client.httpClient, client.dataHTTPClient} {
+		if !errors.Is(secured.CheckRedirect(sameOrigin, nil), redirectErr) {
+			t.Fatal("secure wrapper lost caller redirect policy")
+		}
+		if err := secured.CheckRedirect(crossOrigin, nil); err == nil || errors.Is(err, redirectErr) {
+			t.Fatal("cross-origin rejection no longer precedes the caller policy")
+		}
+	}
+	if !errors.Is(injected.CheckRedirect(crossOrigin, nil), redirectErr) || redirectCalls != 3 {
+		t.Fatalf("source redirect policy mutated: calls=%d", redirectCalls)
 	}
 }
 

--- a/internal/providers/orgo/client.go
+++ b/internal/providers/orgo/client.go
@@ -154,20 +154,13 @@ func newOrgoClient(cfg Config, rt Runtime) (orgoAPI, error) {
 	if parsed.Scheme != "https" && !isOrgoLoopbackHTTP(parsed) {
 		return nil, exit(2, "provider=%s API base URL %q must use https unless it targets localhost", providerName, baseURL)
 	}
-	client, dataClient := orgoHTTPClients(rt.HTTP, orgoControlTimeout)
+	client, dataClient := shared.ControlAndDataHTTPClients(rt.HTTP, orgoControlTimeout)
 	return &orgoHTTPClient{
 		baseURL:  strings.TrimRight(baseURL, "/"),
 		apiKey:   apiKey,
 		http:     client,
 		dataHTTP: dataClient,
 	}, nil
-}
-
-func orgoHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.Client, *http.Client) {
-	if injected != nil {
-		return injected, injected
-	}
-	return &http.Client{Timeout: controlTimeout}, &http.Client{}
 }
 
 func isOrgoLoopbackHTTP(parsed *url.URL) bool {

--- a/internal/providers/orgo/client_test.go
+++ b/internal/providers/orgo/client_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func TestRunBashExitCodeFieldPresence(t *testing.T) {
@@ -445,7 +447,7 @@ func TestOrgoFallbackBoundsControlAndPreservesCommand(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	control, data := orgoHTTPClients(nil, controlTimeout)
+	control, data := shared.ControlAndDataHTTPClients(nil, controlTimeout)
 	client := &orgoHTTPClient{baseURL: server.URL, apiKey: "test-key", http: control, dataHTTP: data}
 	started := time.Now()
 	_, err := client.GetComputer(context.Background(), "computer-1")

--- a/internal/providers/shared/httpclients.go
+++ b/internal/providers/shared/httpclients.go
@@ -1,0 +1,16 @@
+package shared
+
+import (
+	"net/http"
+	"time"
+)
+
+// ControlAndDataHTTPClients gives default control requests a whole-request
+// timeout while data requests use their operation contexts. An injected client
+// overrides both planes unchanged, including its timeout and redirect policy.
+func ControlAndDataHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.Client, *http.Client) {
+	if injected != nil {
+		return injected, injected
+	}
+	return &http.Client{Timeout: controlTimeout}, &http.Client{}
+}

--- a/internal/providers/shared/httpredirect_test.go
+++ b/internal/providers/shared/httpredirect_test.go
@@ -3,9 +3,48 @@ package shared
 import (
 	"errors"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
+	"reflect"
 	"testing"
+	"time"
 )
+
+func TestControlAndDataHTTPClients(t *testing.T) {
+	control, data := ControlAndDataHTTPClients(nil, 23*time.Second)
+	if control == nil || data == nil || control == data || control.Timeout != 23*time.Second || data.Timeout != 0 {
+		t.Fatalf("default clients control=%+v data=%+v", control, data)
+	}
+	control.Timeout = time.Second
+	if data.Timeout != 0 {
+		t.Fatal("default control and data settings are coupled")
+	}
+
+	transport := &http.Transport{DisableKeepAlives: true}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	redirectErr := errors.New("caller redirect policy")
+	redirectCalls := 0
+	redirect := func(*http.Request, []*http.Request) error { redirectCalls++; return redirectErr }
+	injected := &http.Client{Transport: transport, Jar: jar, Timeout: 17 * time.Second, CheckRedirect: redirect}
+	control, data = ControlAndDataHTTPClients(injected, time.Second)
+	if control != injected || data != injected {
+		t.Fatal("injected client identity changed")
+	}
+	if injected.Transport != transport || injected.Jar != jar || injected.Timeout != 17*time.Second || reflect.ValueOf(injected.CheckRedirect).Pointer() != reflect.ValueOf(redirect).Pointer() {
+		t.Fatal("constructor mutated the injected client")
+	}
+	for _, client := range []*http.Client{control, data, injected} {
+		if !errors.Is(client.CheckRedirect(nil, nil), redirectErr) {
+			t.Fatal("caller redirect policy changed")
+		}
+	}
+	if redirectCalls != 3 {
+		t.Fatalf("redirect calls=%d", redirectCalls)
+	}
+}
 
 func TestSameOrigin(t *testing.T) {
 	t.Parallel()

--- a/internal/providers/smolvm/backend_test.go
+++ b/internal/providers/smolvm/backend_test.go
@@ -263,7 +263,7 @@ func TestSmolVMFallbackBoundsControlAndPreservesCommand(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	control, data := smolvmHTTPClients(nil, controlTimeout)
+	control, data := shared.ControlAndDataHTTPClients(nil, controlTimeout)
 	trusted, _ := url.Parse(server.URL)
 	client := &client{
 		apiKey:   "smk_key",

--- a/internal/providers/smolvm/client.go
+++ b/internal/providers/smolvm/client.go
@@ -145,7 +145,7 @@ var newAPI = func(cfg Config, rt Runtime) (api, error) {
 	// server), so this client talks net/http directly to the documented
 	// OpenAPI, like other direct-API providers. If an official Go client
 	// appears, the transport can be swapped behind the api interface.
-	httpClient, dataHTTPClient := smolvmHTTPClients(rt.HTTP, smolvmControlTimeout)
+	httpClient, dataHTTPClient := shared.ControlAndDataHTTPClients(rt.HTTP, smolvmControlTimeout)
 	base, err := smolvmEndpoint(cfg)
 	if err != nil {
 		return nil, err
@@ -181,13 +181,6 @@ func smolvmEndpoint(cfg Config) (string, error) {
 	}
 	base = strings.TrimRight(parsed.String(), "/")
 	return base, nil
-}
-
-func smolvmHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.Client, *http.Client) {
-	if injected != nil {
-		return injected, injected
-	}
-	return &http.Client{Timeout: controlTimeout}, &http.Client{}
 }
 
 func smolvmRedirectError(destination *url.URL) error {


### PR DESCRIPTION
## Summary

Give eight adapters one owner for control/data HTTP client construction. With no override, it returns separate clients: the provider-supplied whole-request control timeout and no client-wide data timeout. With an injected `Runtime.HTTP`, it returns that exact pointer for both planes without mutating timeout, transport, cookie jar or redirect callback.

Delete the eight private copies and call the simple shared helper directly. Provider endpoint admission, authentication, request routing and secure wrappers remain local. Secure wrappers may intentionally clone the returned clients; the new Freestyle assertions verify their independent redirect guards while preserving caller settings, rather than incorrectly requiring final wrapped-pointer identity.

This is behavior-preserving internal ownership cleanup, not a timeout policy change. No global `Runtime.HTTP` default changes, policy flags, framework, new dependency or changelog entry. Daytona's toolbox cloning/timeout policy and Lambda's response-header-timeout contract are excluded. Azure/E2B/Cube lazy accessors retain their existing distinct fallbacks; five accessor bodies were checked byte-for-byte against the base.

## Validation

Source input: integrated base `749deb4b948bd5ec2d590661c5ff2ce8da9015ed` plus the reviewed extraction patch SHA-256 `d22da05eb0f9ad5506f7bd233ef870e8b8c24018591e4c28e4d1e9850625df41`. All 18 source/test files and the complete HTTP patch remained byte-identical through the fast-forward from `8166af8b652721a943ca47deca3faa020aa2fdc8` to the landed Pin helper. Actual integrated full races/vet and the 20-case loopback run all passed. This is working-tree test evidence, not a committed-head or binary provenance claim.

- Baseline HTTP/timeout/redirect checks passed for all eight providers. No regression reds are claimed for this behavior-preserving refactor.
- Full shared + eight-provider race suites passed; vet passed for the same nine packages.
- The focused proof run passed 20 cases: nine real loopback HTTP behavior cases and eleven constructor/override checks. Shared coverage verifies exact injected pointer identity, timeout/transport/jar/redirect preservation, and independent default clients. Existing provider constructor and routing coverage remains in place.

The loopback servers stall a control response after headers, and delay data streaming/upload beyond the control timeout. Captured runs show bounded control reads near the 30ms fixture deadline while data operations complete beyond it with unchanged successful outcomes. These are deliberate 20/30ms test arguments to the existing constructor seam, not changes to production timeout constants or performance benchmarks. The tests exercise native Go HTTP and provider parsers over owned loopback endpoints with synthetic responses—not real commands in hosted sandboxes. E2B's stream/upload fixtures use an explicit loopback data client, so those rows are routing compatibility evidence; separate constructor tests verify its default data-client settings.

Commands (Go1.26.5; task-owned Go cache):

```sh
go test -race -timeout=10m ./internal/providers/{shared,azuredynamicsessions,blaxel,cloudflaresandbox,cubesandbox,e2b,freestyle,orgo,smolvm} -count=1
go vet ./internal/providers/{shared,azuredynamicsessions,blaxel,cloudflaresandbox,cubesandbox,e2b,freestyle,orgo,smolvm}
go test -race -timeout=5m ./internal/providers/{shared,azuredynamicsessions,blaxel,cloudflaresandbox,cubesandbox,e2b,freestyle,orgo,smolvm} -run 'ControlAndDataHTTPClients|FallbackBoundsControl|DataPlane(Stream|Upload)OutlivesControlTimeout|InjectedHTTP|DefaultHTTPClientsSeparate' -count=1 -v
```

<details>
<summary>Observed loopback and constructor output</summary>

```text
=== RUN   TestControlAndDataHTTPClients
--- PASS: TestControlAndDataHTTPClients (0.00s)
PASS
ok  	github.com/openclaw/crabbox/internal/providers/shared	2.759s
=== RUN   TestAzureDynamicSessionsFallbackBoundsControlAndPreservesExecStream
    client_test.go:74: Azure Dynamic Sessions control body bounded in 32ms; exec stream completed in 94ms beyond 30ms control deadline
--- PASS: TestAzureDynamicSessionsFallbackBoundsControlAndPreservesExecStream (0.13s)
=== RUN   TestAzureDynamicSessionsInjectedHTTPClientIsPreservedForBothPlanes
--- PASS: TestAzureDynamicSessionsInjectedHTTPClientIsPreservedForBothPlanes (0.00s)
PASS
ok  	github.com/openclaw/crabbox/internal/providers/azuredynamicsessions	2.495s
=== RUN   TestBlaxelFallbackBoundsControlAndPreservesUpload
    client_test.go:268: Blaxel control body bounded in 32ms; multipart upload completed in 95ms beyond 30ms control deadline
--- PASS: TestBlaxelFallbackBoundsControlAndPreservesUpload (0.13s)
=== RUN   TestBlaxelInjectedHTTPSettingsArePreservedForBothPlanes
--- PASS: TestBlaxelInjectedHTTPSettingsArePreservedForBothPlanes (0.00s)
PASS
ok  	github.com/openclaw/crabbox/internal/providers/blaxel	3.451s
=== RUN   TestBridgeFallbackBoundsControlAndPreservesExecStream
    client_test.go:69: Cloudflare Sandbox control body bounded in 32ms; SSE exec completed in 92ms beyond 30ms control deadline
--- PASS: TestBridgeFallbackBoundsControlAndPreservesExecStream (0.12s)
=== RUN   TestBridgeInjectedHTTPSettingsArePreservedForBothPlanes
--- PASS: TestBridgeInjectedHTTPSettingsArePreservedForBothPlanes (0.00s)
PASS
ok  	github.com/openclaw/crabbox/internal/providers/cloudflaresandbox	3.903s
=== RUN   TestCubeSandboxDefaultHTTPClientsSeparateControlAndDataPlanes
--- PASS: TestCubeSandboxDefaultHTTPClientsSeparateControlAndDataPlanes (0.00s)
=== RUN   TestCubeSandboxInjectedHTTPClientIsPreservedForBothPlanes
--- PASS: TestCubeSandboxInjectedHTTPClientIsPreservedForBothPlanes (0.00s)
=== RUN   TestCubeSandboxDataPlaneStreamOutlivesControlTimeout
--- PASS: TestCubeSandboxDataPlaneStreamOutlivesControlTimeout (0.06s)
PASS
ok  	github.com/openclaw/crabbox/internal/providers/cubesandbox	5.220s
=== RUN   TestE2BDefaultHTTPClientsSeparateControlAndDataPlanes
--- PASS: TestE2BDefaultHTTPClientsSeparateControlAndDataPlanes (0.00s)
=== RUN   TestE2BInjectedHTTPClientIsPreservedForBothPlanes
--- PASS: TestE2BInjectedHTTPClientIsPreservedForBothPlanes (0.00s)
=== RUN   TestE2BDataPlaneStreamOutlivesControlTimeout
    backend_test.go:299: envd stream survived control deadline: elapsed=93ms control_timeout=30ms
--- PASS: TestE2BDataPlaneStreamOutlivesControlTimeout (0.09s)
=== RUN   TestE2BDataPlaneUploadOutlivesControlTimeout
    backend_test.go:356: envd upload completed without truncation: bytes=12 elapsed=93ms control_timeout=30ms
--- PASS: TestE2BDataPlaneUploadOutlivesControlTimeout (0.09s)
PASS
ok  	github.com/openclaw/crabbox/internal/providers/e2b	4.841s
=== RUN   TestFreestyleFallbackBoundsControlAndPreservesCommand
    client_test.go:64: Freestyle control body bounded in 32ms; synchronous command completed in 93ms beyond 30ms control deadline
--- PASS: TestFreestyleFallbackBoundsControlAndPreservesCommand (0.13s)
=== RUN   TestFreestyleInjectedHTTPSettingsArePreservedForBothPlanes
--- PASS: TestFreestyleInjectedHTTPSettingsArePreservedForBothPlanes (0.00s)
PASS
ok  	github.com/openclaw/crabbox/internal/providers/freestyle	8.201s
=== RUN   TestOrgoFallbackBoundsControlAndPreservesCommand
    client_test.go:471: Orgo control body bounded in 31ms; synchronous command completed in 92ms beyond 30ms control deadline
--- PASS: TestOrgoFallbackBoundsControlAndPreservesCommand (0.12s)
=== RUN   TestOrgoInjectedHTTPClientIsPreservedForBothPlanes
--- PASS: TestOrgoInjectedHTTPClientIsPreservedForBothPlanes (0.00s)
PASS
ok  	github.com/openclaw/crabbox/internal/providers/orgo	6.661s
=== RUN   TestSmolVMFallbackBoundsControlAndPreservesCommand
    backend_test.go:293: SmolVM control body bounded in 32ms; synchronous command completed in 93ms beyond 30ms control deadline
--- PASS: TestSmolVMFallbackBoundsControlAndPreservesCommand (0.13s)
=== RUN   TestSmolVMInjectedHTTPSettingsArePreservedForBothPlanes
--- PASS: TestSmolVMInjectedHTTPSettingsArePreservedForBothPlanes (0.00s)
PASS
ok  	github.com/openclaw/crabbox/internal/providers/smolvm	9.220s
```

</details>

No account configuration, real provider resources or live credentials are needed by these synthetic fixtures. Each loopback server is test-owned and closes on return.

Committed head `b116a20295803a5578b00b0171fab48af6a1b9f7` contains those exact 18 source/test files; their hashes were checked against the tested manifest. Managed Codex review of the integrated change was scoped-clean at P0 with no accepted findings.
