### PR TITLE
ci: fall back to the official rsync release asset

### DIFF
--- a/.github/workflows/connector-e2e-smokes.yml
+++ b/.github/workflows/connector-e2e-smokes.yml
@@ -123,9 +123,15 @@ jobs:
         run: |
           archive="$RUNNER_TEMP/rsync-$RSYNC_VERSION.tar.gz"
           prefix="$RUNNER_TEMP/rsync-install"
-          curl --fail --location --silent --show-error \
+          if ! curl --disable --fail --location --silent --show-error \
+            --proto '=https' --proto-redir '=https' --connect-timeout 10 --max-time 60 \
             --output "$archive" \
-            "https://download.samba.org/pub/rsync/src/rsync-$RSYNC_VERSION.tar.gz"
+            "https://download.samba.org/pub/rsync/src/rsync-$RSYNC_VERSION.tar.gz"; then
+            curl --disable --fail --location --silent --show-error \
+              --proto '=https' --proto-redir '=https' --connect-timeout 10 --max-time 60 \
+              --output "$archive" \
+              "https://github.com/RsyncProject/rsync/releases/download/v$RSYNC_VERSION/rsync-$RSYNC_VERSION.tar.gz"
+          fi
           printf '%s  %s\n' "$RSYNC_SHA256" "$archive" | sha256sum --check --strict
           tar -xzf "$archive" -C "$RUNNER_TEMP"
           cd "$RUNNER_TEMP/rsync-$RSYNC_VERSION"

--- a/scripts/connector-e2e-smokes-workflow.test.js
+++ b/scripts/connector-e2e-smokes-workflow.test.js
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -65,6 +66,86 @@ test("pull request runs cancel superseded attempts", () => {
   assert.match(workflow, /concurrency:\s*\n\s+group:/);
   assert.match(workflow, /cancel-in-progress:.*pull_request/);
 });
+
+for (const scenario of [
+  { name: "primary success", primary: "good", calls: 1, succeeds: true },
+  { name: "partial transfer then official fallback", primary: "partial", fallback: "good", calls: 2, succeeds: true },
+  { name: "both transfers fail", primary: "partial", fallback: "partial", calls: 2 },
+  { name: "primary checksum mismatch does not fall back", primary: "corrupt", calls: 1 },
+  { name: "fallback checksum mismatch", primary: "partial", fallback: "corrupt", calls: 2 },
+]) {
+  test(`rsync download: ${scenario.name}`, (t) => {
+    const step = workflow.split("      - name: Install security-current rsync\n")[1]
+      .split("\n      - name:")[0];
+    assert.match(step, /RSYNC_VERSION: 3\.4\.4\n/);
+    assert.match(step, /RSYNC_SHA256: bd88cf82fa653da32314fb229136407c5c90f80d1758d8f4b091767877d8fa96\n/);
+    const script = step.split("        run: |\n")[1].split("\n")
+      .map((line) => line.replace(/^ {10}/, "")).join("\n");
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-rsync-download-"));
+    t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+    const bin = path.join(dir, "bin");
+    fs.mkdirSync(bin);
+    // Use the system shasum on macOS; CI uses GNU sha256sum.
+    if (process.platform === "darwin") {
+      fs.writeFileSync(path.join(bin, "sha256sum"), '#!/bin/sh\nexec /usr/bin/shasum -a 256 "$@"\n', { mode: 0o755 });
+    }
+    fs.mkdirSync(path.join(dir, "rsync-3.4.4"));
+    const calls = path.join(dir, "calls.jsonl");
+    const payload = "verified fixture bytes\n";
+    fs.writeFileSync(path.join(bin, "curl"), `#!${process.execPath}
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.FIXTURE_CALLS, JSON.stringify({tool:'curl', args})+'\\n');
+const url = args.at(-1);
+const sources = ['https://download.samba.org/pub/rsync/src/rsync-3.4.4.tar.gz', 'https://github.com/RsyncProject/rsync/releases/download/v3.4.4/rsync-3.4.4.tar.gz'];
+if (!sources.includes(url)) process.exit(99);
+const outcome = url === sources[0] ? process.env.FIXTURE_PRIMARY : process.env.FIXTURE_FALLBACK;
+const output = args[args.indexOf('--output')+1];
+fs.writeFileSync(output, outcome === 'good' ? ${JSON.stringify(payload)} : 'partial or corrupt fixture');
+process.exit(outcome === 'partial' ? 28 : 0);
+`, { mode: 0o755 });
+    const effect = `#!${process.execPath}
+const fs = require('node:fs');
+const path = require('node:path');
+fs.appendFileSync(process.env.FIXTURE_CALLS, JSON.stringify({tool:path.basename(process.argv[1]), args:process.argv.slice(2)})+'\\n');
+`;
+    for (const file of [path.join(bin, "tar"), path.join(bin, "make"), path.join(dir, "rsync-3.4.4", "configure")]) {
+      fs.writeFileSync(file, effect, { mode: 0o755 });
+    }
+    const result = spawnSync("bash", ["-euo", "pipefail", "-c", script], {
+      encoding: "utf8", timeout: 10000,
+      env: {
+        PATH: `${bin}:${process.env.PATH}`, RUNNER_TEMP: dir,
+        GITHUB_PATH: path.join(dir, "github-path"), RSYNC_VERSION: "3.4.4",
+        RSYNC_SHA256: createHash("sha256").update(payload).digest("hex"),
+        FIXTURE_CALLS: calls, FIXTURE_PRIMARY: scenario.primary,
+        FIXTURE_FALLBACK: scenario.fallback ?? "unexpected",
+      },
+    });
+    assert.equal(result.error, undefined);
+    assert.equal(result.signal, null);
+    assert.equal(result.status === 0, Boolean(scenario.succeeds), result.stdout + result.stderr);
+    if (scenario.succeeds) assert.match(result.stdout, /: OK\n/);
+    if (scenario.primary === "corrupt" || scenario.fallback === "corrupt") {
+      assert.match(result.stdout, /: FAILED\n/);
+    }
+    const observed = fs.readFileSync(calls, "utf8").trim().split("\n").map(JSON.parse);
+    const downloads = observed.filter((call) => call.tool === "curl");
+    assert.equal(downloads.length, scenario.calls);
+    const urls = ["https://download.samba.org/pub/rsync/src/rsync-3.4.4.tar.gz", "https://github.com/RsyncProject/rsync/releases/download/v3.4.4/rsync-3.4.4.tar.gz"];
+    for (let i = 0; i < downloads.length; i++) {
+      assert.deepEqual(downloads[i].args, [
+        "--disable", "--fail", "--location", "--silent", "--show-error",
+        "--proto", "=https", "--proto-redir", "=https", "--connect-timeout", "10", "--max-time", "60",
+        "--output", path.join(dir, "rsync-3.4.4.tar.gz"), urls[i],
+      ]);
+    }
+    assert.deepEqual(observed.filter((call) => call.tool !== "curl").map((call) => call.tool),
+      scenario.succeeds ? ["tar", "configure", "make", "make"] : []);
+    if (scenario.succeeds) assert.equal(fs.readFileSync(path.join(dir, "rsync-3.4.4.tar.gz"), "utf8"), payload);
+    else assert.equal(fs.existsSync(path.join(dir, "github-path")), false);
+  });
+}
 
 test("failed bootstrap diagnostics read only the unique smoke container", (t) => {
   const marker = "      - name: Diagnose local-container bootstrap\n";


### PR DESCRIPTION
## Summary

Keep the SSH-localhost connector smoke on the exact pinned rsync 3.4.4 release tarball, but add one official GitHub release-asset fallback when the canonical Samba transfer fails. Both sources use a 10-second connection limit and 60-second transfer limit, verified HTTPS including redirects, and disabled local curl configuration. There are no curl retries or alternative versions.

The existing strict SHA256 check remains after download and before extraction/build. A completed transfer with corrupt bytes fails closed without trying another source; two failed transfers also stop before extraction. Version, checksum, configure flags, matrix, permissions, and credential-free CI policy are unchanged.

This addresses two observed connection timeouts in the dependency-install step, before CLI build/tests—not a demonstrated connector regression. Samba also timed out during the local check; that corroborates reachability trouble without claiming a global outage.

## Official source and byte identity

The fallback is the project-owned [rsync 3.4.4 release asset](https://github.com/RsyncProject/rsync/releases/download/v3.4.4/rsync-3.4.4.tar.gz), not GitHub’s generated source archive. The [upstream download documentation](https://rsync.samba.org/download.html) identifies the project repository and explains why generated tag archives differ from release tarballs.

The downloaded asset is 1,223,040 bytes and matches the unchanged pin:

```text
bd88cf82fa653da32314fb229136407c5c90f80d1758d8f4b091767877d8fa96
```

## Verification

- All 12 focused Node workflow/action-pin tests passed, including five behavioral cases: primary success; partial primary transfer followed by successful fallback; both transfers failing; primary checksum mismatch without fallback; and fallback checksum mismatch. Tests execute the actual workflow shell with per-test curl/extraction/build fixtures and real checksum computation. No downloaded content is executed.
- The partial-transfer/fallback success case fails against the unchanged base workflow and passes with this patch.
- A credential-free replay of the actual new download/checksum section succeeded: Samba reached the 10-second connection deadline, GitHub supplied the tarball, and GNU sha256sum verified the exact existing digest. The archive was neither extracted nor built during this proof.
- Diff checks passed. Managed Codex review of the integrated change was scoped-clean at P0 with no accepted findings.

An initial macOS test-run fixture issue is preserved separately: the selected host checksum utility did not accept the GNU flags used by Ubuntu CI. Tests now use macOS’s system shasum for that platform and require explicit checksum OK/FAILED output. Production still uses the existing GNU checksum command on Ubuntu.

## Captured download result

The exact workflow download/checksum section, without extraction or build, returned exit 0:

```text
primary: curl 28, connection timeout after 10010 ms
fallback: official GitHub release asset
archive bytes: 1223040
SHA256: bd88cf82fa653da32314fb229136407c5c90f80d1758d8f4b091767877d8fa96
strict checksum verification: passed
```

Head `570f487be438dd0cb48d36c36ced69981fc8cb26` is based on `1d3f15ebb7f2b0efe966f2836c7ed505ede3ac82`. The workflow is byte-identical to the recorded live download input; only a test comment was clarified during main integration. Fresh root workflow tests (11) and action-pin tests (1) passed after integration.
