### PR TITLE
fix: finalize W&B runs with shared failure outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- W&B: finalize run outcomes after automatic Stop, retain recovery sessions when cleanup fails, preserve primary command or gRPC failures and failure retention when cleanup or timing output also fails, and classify gRPC/API failures as provider errors instead of command exits.
 - Local containers: optionally omit the explicit hostname for runtimes sharing a host UTS namespace, support YAML and environment configuration, and reject incompatible fixed-ID reuse without changing existing default fingerprints. [PR 1813](https://github.com/openclaw/crabbox/pull/1813), [PR 1924](https://github.com/openclaw/crabbox/pull/1924). Thanks @atrawog.
 - Define a strict provider-neutral Linux developer-image recipe whose digest binds the executable contract and exact installer/readiness source hashes.
 - Extract protected image-qualification candidates at the canonical artifact path and avoid protected finalization when deployment never started.
@@ -28,6 +27,7 @@
 - AWS Lambda MicroVM: share failure finalization so termination and timing errors preserve primary outcomes, setup failures retain recovery metadata, and transport failures are not reported as command exits; keep successful claim-refresh and operation-lock semantics unchanged. [PR 1923](https://github.com/openclaw/crabbox/pull/1923).
 - Tensorlake: include claim-lock waiting in the bound-sandbox cleanup deadline, retaining ownership and avoiding native operations when the deadline expires before admission. [PR 1888](https://github.com/openclaw/crabbox/pull/1888). Thanks @steipete.
 - Tensorlake: share run finalization so early failures honor `--keep-on-failure`, failed cleanup reports a retained recovery session, and timing errors preserve the command outcome; retain quiet native-command error causes while keeping profile cleanup warning-only. [PR 1905](https://github.com/openclaw/crabbox/pull/1905). Thanks @steipete.
+- W&B: finalize run outcomes after automatic Stop, retain recovery sessions when cleanup fails, preserve primary command or gRPC failures and failure retention when cleanup or timing output also fails, and classify gRPC/API failures as provider errors instead of command exits. [PR 1929](https://github.com/openclaw/crabbox/pull/1929).
 
 ## 0.50.0 - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- W&B: finalize run outcomes after automatic Stop, retain recovery sessions when cleanup fails, preserve primary command or gRPC failures and failure retention when cleanup or timing output also fails, and classify gRPC/API failures as provider errors instead of command exits.
 - Local containers: optionally omit the explicit hostname for runtimes sharing a host UTS namespace, support YAML and environment configuration, and reject incompatible fixed-ID reuse without changing existing default fingerprints. [PR 1813](https://github.com/openclaw/crabbox/pull/1813), [PR 1924](https://github.com/openclaw/crabbox/pull/1924). Thanks @atrawog.
 - Define a strict provider-neutral Linux developer-image recipe whose digest binds the executable contract and exact installer/readiness source hashes.
 - Extract protected image-qualification candidates at the canonical artifact path and avoid protected finalization when deployment never started.

--- a/docs/providers/wandb.md
+++ b/docs/providers/wandb.md
@@ -126,7 +126,8 @@ makes an otherwise successful run fail with exit `1` and retains its recovery
 session and unchanged claim. Command failures and mapped gRPC exit codes stay
 primary when Stop or timing output also fails; secondary diagnostics remain
 visible. gRPC/API failures are classified as `provider-error`, not as observed
-command exits, while keeping their mapped numeric exit codes. `--keep-on-failure` is decided before timing output, so a reporting
+command exits, while keeping their mapped numeric exit codes. `--keep-on-failure`
+is decided before timing output, so a reporting
 failure cannot discard an already-failed run's sandbox. A timing-output failure
 after successful Stop does not claim the sandbox is retained. Closing the local
 gRPC connection remains warning-only. Command timing measures Exec separately;

--- a/docs/providers/wandb.md
+++ b/docs/providers/wandb.md
@@ -121,6 +121,17 @@ Environment overrides:
    If claim persistence fails, Crabbox rolls back the acquired sandbox before
    returning.
 
+Run outcomes and timing are finalized after automatic Stop. A Stop failure
+makes an otherwise successful run fail with exit `1` and retains its recovery
+session and unchanged claim. Command failures and mapped gRPC exit codes stay
+primary when Stop or timing output also fails; secondary diagnostics remain
+visible. gRPC/API failures are classified as `provider-error`, not as observed
+command exits, while keeping their mapped numeric exit codes. `--keep-on-failure` is decided before timing output, so a reporting
+failure cannot discard an already-failed run's sandbox. A timing-output failure
+after successful Stop does not claim the sandbox is retained. Closing the local
+gRPC connection remains warning-only. Command timing measures Exec separately;
+total timing includes acquisition and automatic cleanup.
+
 `status` and `stop` enforce the same exact claim and tagged-inventory checks
 before issuing Get or Stop. A tagged sandbox without the matching local claim,
 or a claim from another endpoint, entity, or project, fails closed. Successful

--- a/internal/providers/wandb/backend.go
+++ b/internal/providers/wandb/backend.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 	"google.golang.org/grpc/codes"
 )
@@ -38,7 +39,7 @@ func (b *wandbBackend) Warmup(ctx context.Context, req WarmupRequest) error {
 	return exit(2, "provider=%s does not support warmup; sandboxes are acquired per-run", providerName)
 }
 
-func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {
 	if err := rejectWandbRunOptions(req); err != nil {
 		return RunResult{}, err
 	}
@@ -112,32 +113,47 @@ func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 	// retain) and --keep-on-failure (retain only when the run fails) so
 	// users can debug a sandbox after a bad command.
 	shouldStop := acquired && !req.Keep
-	defer func() {
-		if !shouldStop {
-			return
-		}
-		stopCtx, cancel := context.WithTimeout(context.Background(), wandbStopTimeout)
-		defer cancel()
-		if err := removeWandbClaimAfter(claim, func() error {
-			return client.Stop(stopCtx, sandboxID, 10, true)
-		}); err != nil {
-			fmt.Fprintf(b.rt.Stderr, "warning: wandb stop failed for %s: %v\n", sandboxID, err)
-		}
-	}()
-	result := RunResult{
+	result = RunResult{
 		Session: &RunSessionHandle{
 			Provider:       providerName,
 			LeaseID:        sandboxID,
 			Slug:           sandboxID,
 			Reused:         !acquired,
-			Kept:           !shouldStop,
+			Kept:           true,
 			CleanupCommand: wandbCleanupCommand(sandboxID),
 		},
 	}
-	finishResult := func() RunResult {
-		result.Session.Kept = !shouldStop
-		return result
-	}
+	defer func() {
+		// Finalize only after the primary command or provider failure is
+		// classified; secondary diagnostics must not replace that outcome.
+		result = core.FinalizeRunResult(result, retErr)
+		if shouldStop {
+			stopCtx, cancel := context.WithTimeout(context.Background(), wandbStopTimeout)
+			cleanupErr := removeWandbClaimAfter(claim, func() error {
+				return client.Stop(stopCtx, sandboxID, 10, true)
+			})
+			cancel()
+			if cleanupErr != nil {
+				result, retErr = shared.AppendDelegatedRunFailure(result, retErr, fmt.Errorf("wandb stop failed for %s: %w", sandboxID, cleanupErr), 1)
+			} else {
+				result.Session.Kept = false
+			}
+		}
+		result.Total = b.now().Sub(started)
+		if req.TimingJSON {
+			timingErr := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
+				Provider: providerName, Slug: sandboxID,
+				CommandMs: result.Command.Milliseconds(), TotalMs: result.Total.Milliseconds(),
+				ExitCode: result.ExitCode, Label: strings.TrimSpace(req.Label),
+			}, result, retErr))
+			firstCode := 1
+			var public ExitError
+			if errors.As(timingErr, &public) && public.Code != 0 {
+				firstCode = public.Code
+			}
+			result, retErr = shared.AppendDelegatedRunFailure(result, retErr, timingErr, firstCode)
+		}
+	}()
 
 	commandStarted := b.now()
 	var exitCode int
@@ -152,47 +168,25 @@ func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 			Stderr:    b.rt.Stderr,
 		})
 	}
-	if execErr != nil && exitCode == 0 {
-		var ee ExitError
-		if errors.As(execErr, &ee) && ee.Code != 0 {
-			exitCode = ee.Code
-		} else {
-			exitCode = 1
-		}
-	}
+
 	// Command measures just the user's exec; Total includes Acquire+poll.
 	// Conflating them (the previous bug) made commandMs == totalMs on every
 	// fresh-sandbox run, hiding provisioning time from --timing-json users.
 	commandDuration := b.now().Sub(commandStarted)
 	result.ExitCode = exitCode
 	result.Command = commandDuration
-	result.Total = b.now().Sub(started)
-
-	// Emit timing JSON before any failure return so automation consuming
-	// `--timing-json` still gets a report when the user's command exits
-	// non-zero or the exec itself errors. Mirrors railway / modal / e2b.
-	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
-			Provider:  providerName,
-			Slug:      sandboxID,
-			CommandMs: commandDuration.Milliseconds(),
-			TotalMs:   result.Total.Milliseconds(),
-			ExitCode:  result.ExitCode,
-			Label:     strings.TrimSpace(req.Label),
-		}, result, execErr)); err != nil {
-			return finishResult(), err
-		}
-	}
 
 	if execErr != nil {
+		result, execErr = shared.PinDelegatedRunFailure(result, execErr)
 		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, sandboxID, sandboxID, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return finishResult(), execErr
+		return result, execErr
 	}
+	result = core.FinalizeRunResult(result, nil)
 	if result.ExitCode != 0 {
 		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, sandboxID, sandboxID, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return finishResult(), ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s sandbox exit=%d", providerName, result.ExitCode)}
+		return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s sandbox exit=%d", providerName, result.ExitCode)}
 	}
-	return finishResult(), nil
+	return result, nil
 }
 
 func wandbCleanupCommand(sandboxID string) string {

--- a/internal/providers/wandb/backend_test.go
+++ b/internal/providers/wandb/backend_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"google.golang.org/grpc/codes"
 )
 
@@ -200,6 +201,7 @@ type fakeWandbAPI struct {
 	stopID           string
 	stopMissingOK    bool
 	stopErr          error
+	stopCalls        int
 	listValue        []wandbSandbox
 	listErr          error
 	listTags         []string
@@ -238,6 +240,7 @@ func (f *fakeWandbAPI) Exec(_ context.Context, req wandbExecRequest) (int, error
 }
 
 func (f *fakeWandbAPI) Stop(_ context.Context, id string, _ int, missingOK bool) error {
+	f.stopCalls++
 	f.stopID = id
 	f.stopMissingOK = missingOK
 	return f.stopErr
@@ -365,6 +368,7 @@ func TestWandbRunClosesCachedClientAfterOperation(t *testing.T) {
 			acquired: wandbSandbox{ID: "sb-abc", Status: "RUNNING"},
 			execCode: 0,
 		},
+		closeErr: errors.New("connection close failed"),
 	}
 	backend := newWandbBackendForTest(t, api)
 	if _, err := backend.Run(context.Background(), RunRequest{NoSync: true, Command: []string{"echo", "hello"}}); err != nil {
@@ -937,7 +941,7 @@ func TestWandbRunTimingJSONUsesExecErrorCode(t *testing.T) {
 	if report.ExitCode != 69 {
 		t.Fatalf("timing exit = %d, want 69; stderr=%s", report.ExitCode, stderr.String())
 	}
-	if report.RunStatus != "failed" || report.ErrorKind != "command-exit" {
+	if report.RunStatus != "failed" || report.ErrorKind != "provider-error" {
 		t.Fatalf("timing outcome status=%q kind=%q", report.RunStatus, report.ErrorKind)
 	}
 }
@@ -971,4 +975,129 @@ func contains(haystack []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+// Fail only the timing record, so provisioning and recovery diagnostics remain observable.
+type wandbTimingWriter struct {
+	bytes.Buffer
+	err error
+}
+
+func (w *wandbTimingWriter) Write(p []byte) (int, error) {
+	if w.err != nil && bytes.HasPrefix(p, []byte("{")) {
+		return 0, w.err
+	}
+	return w.Buffer.Write(p)
+}
+
+func TestWandbRunTerminalFailures(t *testing.T) {
+	cleanupErr := errors.New("owned stop failed")
+	writerErr := errors.New("timing output failed")
+	transportErr := errors.New("exec transport failed")
+	for _, tc := range []struct {
+		name                     string
+		commandCode              int
+		execErr                  error
+		cleanupErr               error
+		writerErr                error
+		keep, keepFailure, reuse bool
+		wantCode                 int
+		wantKind                 core.RunErrorKind
+		wantKept                 bool
+		wantStops                int
+	}{
+		{name: "success", wantKind: core.RunErrorNone, wantStops: 1},
+		{name: "success cleanup fails", cleanupErr: cleanupErr, wantCode: 1, wantKind: core.RunErrorProvider, wantKept: true, wantStops: 1},
+		{name: "command cleanup fails", commandCode: 7, cleanupErr: cleanupErr, wantCode: 7, wantKind: core.RunErrorCommandExit, wantKept: true, wantStops: 1},
+		{name: "command writer fails", commandCode: 7, writerErr: writerErr, wantCode: 7, wantKind: core.RunErrorCommandExit, wantStops: 1},
+		{name: "command cleanup and writer fail", commandCode: 7, cleanupErr: cleanupErr, writerErr: writerErr, wantCode: 7, wantKind: core.RunErrorCommandExit, wantKept: true, wantStops: 1},
+		{name: "failure retention survives writer", commandCode: 7, writerErr: writerErr, keepFailure: true, wantCode: 7, wantKind: core.RunErrorCommandExit, wantKept: true},
+		{name: "success writer fails after deletion", writerErr: writerErr, wantCode: 1, wantKind: core.RunErrorProvider, wantStops: 1},
+		{name: "transport cleanup and writer fail", execErr: transportErr, cleanupErr: cleanupErr, writerErr: writerErr, wantCode: 1, wantKind: core.RunErrorProvider, wantKept: true, wantStops: 1},
+		{name: "cancellation writer fails", execErr: context.Canceled, writerErr: writerErr, keepFailure: true, wantCode: 1, wantKind: core.RunErrorCanceled, wantKept: true},
+		{name: "deadline writer fails", execErr: context.DeadlineExceeded, writerErr: writerErr, keepFailure: true, wantCode: 1, wantKind: core.RunErrorTimeout, wantKept: true},
+		{name: "keep success", keep: true, wantKind: core.RunErrorNone, wantKept: true},
+		{name: "reuse failure", reuse: true, commandCode: 7, wantCode: 7, wantKind: core.RunErrorCommandExit, wantKept: true},
+		{name: "grpc unavailable", execErr: &wandbAPIError{ExitCode: 69, Code: codes.Unavailable}, writerErr: writerErr, keepFailure: true, wantCode: 69, wantKind: core.RunErrorProvider, wantKept: true},
+		{name: "grpc permission", execErr: &wandbAPIError{ExitCode: 77, Code: codes.PermissionDenied}, cleanupErr: cleanupErr, wantCode: 77, wantKind: core.RunErrorProvider, wantKept: true, wantStops: 1},
+		{name: "grpc deadline", execErr: &wandbAPIError{ExitCode: 124, Code: codes.DeadlineExceeded}, cleanupErr: cleanupErr, wantCode: 124, wantKind: core.RunErrorProvider, wantKept: true, wantStops: 1},
+		{name: "grpc missing", execErr: &wandbAPIError{ExitCode: 4, Code: codes.NotFound}, cleanupErr: cleanupErr, wantCode: 4, wantKind: core.RunErrorProvider, wantKept: true, wantStops: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			api := &fakeWandbAPI{acquired: wandbSandbox{ID: "sb-terminal", Status: "running"}, execCode: tc.commandCode, execErr: tc.execErr, stopErr: tc.cleanupErr}
+			b := newWandbBackendForTest(t, api)
+			writer := &wandbTimingWriter{err: tc.writerErr}
+			b.rt.Stderr = writer
+			req := RunRequest{NoSync: true, TimingJSON: true, Command: []string{"true"}, Keep: tc.keep, KeepOnFailure: tc.keepFailure}
+			if tc.reuse {
+				seedWandbClaim(t, b, "sb-terminal")
+				req.ID = "sb-terminal"
+				api.listValue = []wandbSandbox{{ID: "sb-terminal", Status: "running"}}
+			}
+			result, err := b.Run(context.Background(), req)
+			// Match core's public normalization boundary for baseline controls.
+			result = core.FinalizeRunResult(result, err)
+			if result.ExitCode != tc.wantCode || result.ErrorKind != tc.wantKind {
+				t.Errorf("outcome code=%d kind=%q want code=%d kind=%q; err=%v", result.ExitCode, result.ErrorKind, tc.wantCode, tc.wantKind, err)
+			}
+			if result.Session == nil || result.Session.Kept != tc.wantKept || result.Session.Reused != tc.reuse {
+				t.Errorf("session=%+v want kept=%v reused=%v", result.Session, tc.wantKept, tc.reuse)
+			}
+			if api.stopCalls != tc.wantStops {
+				t.Errorf("stop calls=%d want=%d", api.stopCalls, tc.wantStops)
+			}
+			_, exists, claimErr := resolveWandbClaim("sb-terminal")
+			if claimErr != nil || exists != tc.wantKept {
+				t.Errorf("claim exists=%v err=%v want=%v", exists, claimErr, tc.wantKept)
+			}
+			if tc.wantCode == 0 {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			} else {
+				var public ExitError
+				if !errors.As(err, &public) || public.Code != tc.wantCode {
+					t.Errorf("public=%+v err=%v want code=%d", public, err, tc.wantCode)
+				}
+				for _, cause := range []error{tc.execErr, tc.cleanupErr, tc.writerErr} {
+					if cause != nil && (!errors.Is(err, cause) || !strings.Contains(public.Message, cause.Error())) {
+						t.Errorf("missing cause/display %q: public=%q err=%v", cause, public.Message, err)
+					}
+				}
+				if tc.commandCode != 0 && !strings.Contains(public.Message, "sandbox exit=7") {
+					t.Errorf("primary command diagnostic missing: %q", public.Message)
+				}
+			}
+			if tc.writerErr == nil {
+				var report timingReport
+				found := false
+				for _, line := range strings.Split(writer.String(), "\n") {
+					if strings.HasPrefix(line, "{") {
+						if decodeErr := json.Unmarshal([]byte(line), &report); decodeErr != nil {
+							t.Fatal(decodeErr)
+						}
+						found = true
+					}
+				}
+				if !found || report.ExitCode != result.ExitCode || report.RunStatus != result.Status || report.ErrorKind != result.ErrorKind {
+					t.Errorf("timing found=%v report=%+v result=%+v", found, report, result)
+				}
+			}
+		})
+	}
+}
+
+func TestWandbRunTypedTimingWriterPreservesPublicCode(t *testing.T) {
+	writerErr := ExitError{Code: 69, Message: "custom timing writer unavailable"}
+	api := &fakeWandbAPI{acquired: wandbSandbox{ID: "sb-writer", Status: "running"}}
+	b := newWandbBackendForTest(t, api)
+	b.rt.Stderr = &wandbTimingWriter{err: writerErr}
+	result, err := b.Run(context.Background(), RunRequest{NoSync: true, TimingJSON: true, Command: []string{"true"}})
+	var public ExitError
+	if !errors.As(err, &public) || public.Code != 69 || !errors.Is(err, writerErr) {
+		t.Fatalf("publicCode=%d err=%v; want original writer code69 and cause", public.Code, err)
+	}
+	if result.Session == nil || result.Session.Kept || api.stopCalls != 1 {
+		t.Fatalf("typed writer changed actual deletion: session=%+v stops=%d", result.Session, api.stopCalls)
+	}
 }


### PR DESCRIPTION
## Summary

Finalize W&B runs after automatic Stop, so failed cleanup cannot report a successful, discarded sandbox. Keep primary command or gRPC errors when cleanup or timing output also fails, and decide failure retention before the timing writer. Classify gRPC/API failures as provider errors while preserving documented numeric exit codes 77, 69, 124, and 4.

This is a narrow reuse of shared failure-value owners. W&B keeps its production gRPC client, acquisition/ownership sequence, exact endpoint/entity/project claim binding, 15-second automatic Stop budget, observed command exits, and warning-only local connection Close. A successful Stop is not undone by a later timing-writer failure. A first typed custom timing-writer error retains its own public code; cleanup-only failure intentionally uses 1.

## Validation and boundaries

- Tests-first terminal matrix: 13 genuine baseline failures and 3 controls; the existing timing-code test was extended to correct API-error classification rather than preserve an accidental command-exit label.
- The maintainer identified an introduced typed-writer compatibility regression before publication: the original backend returned public code 69, the first candidate returned 1. The focused baseline passed and candidate failed; the final candidate preserves 69. Historical receipts were retained.
- Six classification regressions were also reproduced against the earlier candidate before replacing its duplicate numeric mapping with the shared classifier.
- Full W&B/shared race suites passed (2.606s / 3.039s); focused package vet and all 20 documentation-script tests passed.
- Final managed Codex review: scoped-clean at P0, confidence 0.98. This is the requested review scope, not a claim that every possible lower-priority concern was audited.

The native proof invokes built Go **test binaries**, not the Crabbox CLI. It uses the actual W&B backend, production gRPC constructor/client, real loopback gRPC transport, real filesystem claims, and a synthetic service that executes real local `sh` subprocesses. The service controls acquisition/inventory/Stop responses and injected RPC faults. There are no hosted W&B/CoreWeave resources, TLS, real credentials, or remote-kill claims.

`publicCode` below is the backend error's `ExitError` conversion, not an observed CLI process exit. The reused control passes empty `Env` directly to `Backend.Run`; it does not validate App/CLI reserved-metadata injection or normal CLI reuse. A gRPC DeadlineExceeded response preserves code 124 and is a provider error; this does not add a Go context cause. Reachable Go context cancellation/deadline causes are covered separately by the unit matrix.

## Source and build binding

Recorded candidate source is now committed as `4297fe67915e08b501dd58d22d19ccfb48076d31`; all four committed file hashes match the frozen v3 manifest. Base: `c86c3c03a9726c5223f71e7110b35adec092bd64`. Candidate production file `internal/providers/wandb/backend.go` SHA-256: `cdae892e710832caa99d4a6187e787a35ef3dea8f2c2a177d4f507a5fb00f4b2`. Candidate patch SHA-256: `3b75aa897ce48eec3f68c71dbc467172566cc8b8b292987b37e8035a1f65f8b4`. The worktree remained byte-identical to its frozen four-file manifest after both runs.

Both test binaries built successfully. Candidate binary SHA-256 `7ddc07b34b8892ad6c3a974bf388c49158e2a67fbdd7c9946b171032aa562e82` exited 0; baseline binary SHA-256 `4217b898fc6e4bc9081a24a5695f7fcdd6466cf9298a3a5449b29de29c859903` exited 1 as expected. Both use the identical **full replacement `client_test.go` file**, SHA-256 `64bd6d21195277ac3a07dd36688147265095ae9558b7e3aa8316408659260ff0`. This is not the hash of either overlay JSON descriptor: those differ because the baseline descriptor additionally replaces `backend.go`, and their absolute paths depend on the owned proof directory. The baseline restores only the original `backend.go` from the pinned base; the client, shared owners, and test fixture remain identical.

## Observed comparison

Candidate: 9/9 passing cases. Baseline: 7 failing cases and 2 passing controls. Each mode executed five real shell processes; the four RPC-error cases did not launch a workload. All retained resources were recovered with the actual backend Stop path; all 18 observations ended with no claim or owned sandbox directory remaining. Servers were stopped and their serving goroutines joined by fixture cleanup.

The phase labels differ deliberately: `claimPresent`, `syntheticSandboxPresent`, and `sessionKept` describe the state immediately after `Run`, **before explicit recovery**. `cleanupComplete` is checked afterward, following successful automatic Stop or explicit recovery through `Backend.Stop`. Thus a retained claim and `cleanupComplete=true` in the same observation describe successive phases, not simultaneous states.

| Case | Baseline public code / kind / kept | Candidate public code / kind / kept | Automatic Stop RPCs, baseline → candidate |
|---|---|---|---|
| success cleanup fails | 0 / none / false | 1 / provider-error / true | 1 → 1 |
| command cleanup fails | 7 / command-exit / false | 7 / command-exit / true | 1 → 1 |
| command writer retains | 1 / command-exit / false | 7 / command-exit / true | 1 → 0 |
| grpc primary cleanup fails | 69 / command-exit / false | 69 / provider-error / true | 1 → 1 |
| grpc permission classification | 77 / command-exit / true | 77 / provider-error / true | 0 → 0 |
| grpc deadline classification | 124 / command-exit / true | 124 / provider-error / true | 0 → 0 |
| grpc missing classification | 4 / command-exit / true | 4 / provider-error / true | 0 → 0 |
| ordinary success | 0 / none / false | 0 / none / false | 1 → 1 |
| reused command failure | 7 / command-exit / true | 7 / command-exit / true | 0 → 0 |

The writer-failure row has no timing record because the fixture deliberately rejects the timing write. The returned primary code and recovery state are still checked. The successful-cleanup/writer-failure and typed-writer cases are additionally covered in committed unit tests.

<details>
<summary>Captured observations from both native test binaries</summary>

```text
baseline
OBSERVED {"automaticRPCs":{"Exec":1,"Get":1,"Start":1,"Stop":1},"case":"success cleanup fails","claimPresent":true,"cleanupComplete":true,"diagnostic":"","kind":"","nativeExit":0,"nativeMarker":true,"nativeProcesses":1,"publicCode":0,"resultCode":0,"sessionKept":false,"status":"succeeded","syntheticSandboxPresent":true,"timingCode":0,"timingFound":true}
OBSERVED {"automaticRPCs":{"Exec":1,"Get":1,"Start":1,"Stop":1},"case":"command cleanup fails","claimPresent":true,"cleanupComplete":true,"diagnostic":"wandb sandbox exit=7","kind":"command-exit","nativeExit":7,"nativeMarker":true,"nativeProcesses":1,"publicCode":7,"resultCode":7,"sessionKept":false,"status":"failed","syntheticSandboxPresent":true,"timingCode":7,"timingFound":true}
OBSERVED {"automaticRPCs":{"Exec":1,"Get":1,"Start":1,"Stop":1},"case":"command writer retains","claimPresent":false,"cleanupComplete":true,"diagnostic":"injected timing writer failure","kind":"command-exit","nativeExit":7,"nativeMarker":true,"nativeProcesses":1,"publicCode":1,"resultCode":7,"sessionKept":false,"status":"failed","syntheticSandboxPresent":false,"timingCode":0,"timingFound":false}
OBSERVED {"automaticRPCs":{"Exec":1,"Get":1,"Start":1,"Stop":1},"case":"grpc primary cleanup fails","claimPresent":true,"cleanupComplete":true,"diagnostic":"wandb sandbox API error code=Unavailable: Exec: injected exec transport failure [redacted]","kind":"command-exit","nativeExit":0,"nativeMarker":false,"nativeProcesses":0,"publicCode":69,"resultCode":69,"sessionKept":false,"status":"failed","syntheticSandboxPresent":true,"timingCode":69,"timingFound":true}
OBSERVED {"automaticRPCs":{"Exec":1,"Get":1,"Start":1},"case":"grpc permission classification","claimPresent":true,"cleanupComplete":true,"diagnostic":"wandb sandbox API error code=PermissionDenied: Exec: injected exec transport failure [redacted]","kind":"command-exit","nativeExit":0,"nativeMarker":false,"nativeProcesses":0,"publicCode":77,"resultCode":77,"sessionKept":true,"status":"failed","syntheticSandboxPresent":true,"timingCode":77,"timingFound":true}
OBSERVED {"automaticRPCs":{"Exec":1,"Get":1,"Start":1},"case":"grpc deadline classification","claimPresent":true,"cleanupComplete":true,"diagnostic":"wandb sandbox API error code=DeadlineExceeded: Exec: injected exec transport failure [redacted]","kind":"command-exit","nativeExit":0,"nativeMarker":false,"nativeProcesses":0,"publicCode":124,"resultCode":124,"sessionKept":true,"status":"failed","syntheticSandboxPresent":true,"timingCode":124,"timingFound":true}
OBSERVED {"automaticRPCs":{"Exec":1,"Get":1,"Start":1},"case":"grpc missing classification","claimPresent":true,"cleanupComplete":true,"diagnostic":"wandb sandbox API error code=NotFound: Exec: injected exec transport failure [redacted]","kind":"command-exit","nativeExit":0,"nativeMarker":false,"nativeProcesses":0,"publicCode":4,"resultCode":4,"sessionKept":true,"status":"failed","syntheticSandboxPresent":true,"timingCode":4,"timingFound":true}
OBSERVED {"automaticRPCs":{"Exec":1,"Get":1,"Start":1,"Stop":1},"case":"ordinary success","claimPresent":false,"cleanupComplete":true,"diagnostic":"","kind":"","nativeExit":0,"nativeMarker":true,"nativeProcesses":1,"publicCode":0,"resultCode":0,"sessionKept":false,"status":"succeeded","syntheticSandboxPresent":false,"timingCode":0,"timingFound":true}
OBSERVED {"automaticRPCs":{"Exec":1,"List":1},"case":"reused command failure","claimPresent":true,"cleanupComplete":true,"diagnostic":"wandb sandbox exit=7","kind":"command-exit","nativeExit":7,"nativeMarker":true,"nativeProcesses":1,"publicCode":7,"resultCode":7,"sessionKept":true,"status":"failed","syntheticSandboxPresent":true,"timingCode":7,"timingFound":true}
candidate
OBSERVED {"automaticRPCs":{"Exec":1,"Get":1,"Start":1,"Stop":1},"case":"success cleanup fails","claimPresent":true,"cleanupComplete":true,"diagnostic":"wandb stop failed for sb-native-proof: wandb sandbox API error code=PermissionDenied: Stop: injected stop failure [redacted]","kind":"provider-error","nativeExit":0,"nativeMarker":true,"nativeProcesses":1,"publicCode":1,"resultCode":1,"sessionKept":true,"status":"failed","syntheticSandboxPresent":true,"timingCode":1,"timingFound":true}
OBSERVED {"automaticRPCs":{"Exec":1,"Get":1,"Start":1,"Stop":1},"case":"command cleanup fails","claimPresent":true,"cleanupComplete":true,"diagnostic":"wandb sandbox exit=7\nwandb stop failed for sb-native-proof: wandb sandbox API error code=PermissionDenied: Stop: injected stop failure [redacted]","kind":"command-exit","nativeExit":7,"nativeMarker":true,"nativeProcesses":1,"publicCode":7,"resultCode":7,"sessionKept":true,"status":"failed","syntheticSandboxPresent":true,"timingCode":7,"timingFound":true}
OBSERVED {"automaticRPCs":{"Exec":1,"Get":1,"Start":1},"case":"command writer retains","claimPresent":true,"cleanupComplete":true,"diagnostic":"wandb sandbox exit=7\ninjected timing writer failure","kind":"command-exit","nativeExit":7,"nativeMarker":true,"nativeProcesses":1,"publicCode":7,"resultCode":7,"sessionKept":true,"status":"failed","syntheticSandboxPresent":true,"timingCode":0,"timingFound":false}
OBSERVED {"automaticRPCs":{"Exec":1,"Get":1,"Start":1,"Stop":1},"case":"grpc primary cleanup fails","claimPresent":true,"cleanupComplete":true,"diagnostic":"wandb sandbox API error code=Unavailable: Exec: injected exec transport failure [redacted]\nwandb stop failed for sb-native-proof: wandb sandbox API error code=PermissionDenied: Stop: injected stop failure [redacted]","kind":"provider-error","nativeExit":0,"nativeMarker":false,"nativeProcesses":0,"publicCode":69,"resultCode":69,"sessionKept":true,"status":"failed","syntheticSandboxPresent":true,"timingCode":69,"timingFound":true}
OBSERVED {"automaticRPCs":{"Exec":1,"Get":1,"Start":1},"case":"grpc permission classification","claimPresent":true,"cleanupComplete":true,"diagnostic":"wandb sandbox API error code=PermissionDenied: Exec: injected exec transport failure [redacted]","kind":"provider-error","nativeExit":0,"nativeMarker":false,"nativeProcesses":0,"publicCode":77,"resultCode":77,"sessionKept":true,"status":"failed","syntheticSandboxPresent":true,"timingCode":77,"timingFound":true}
OBSERVED {"automaticRPCs":{"Exec":1,"Get":1,"Start":1},"case":"grpc deadline classification","claimPresent":true,"cleanupComplete":true,"diagnostic":"wandb sandbox API error code=DeadlineExceeded: Exec: injected exec transport failure [redacted]","kind":"provider-error","nativeExit":0,"nativeMarker":false,"nativeProcesses":0,"publicCode":124,"resultCode":124,"sessionKept":true,"status":"failed","syntheticSandboxPresent":true,"timingCode":124,"timingFound":true}
OBSERVED {"automaticRPCs":{"Exec":1,"Get":1,"Start":1},"case":"grpc missing classification","claimPresent":true,"cleanupComplete":true,"diagnostic":"wandb sandbox API error code=NotFound: Exec: injected exec transport failure [redacted]","kind":"provider-error","nativeExit":0,"nativeMarker":false,"nativeProcesses":0,"publicCode":4,"resultCode":4,"sessionKept":true,"status":"failed","syntheticSandboxPresent":true,"timingCode":4,"timingFound":true}
OBSERVED {"automaticRPCs":{"Exec":1,"Get":1,"Start":1,"Stop":1},"case":"ordinary success","claimPresent":false,"cleanupComplete":true,"diagnostic":"","kind":"","nativeExit":0,"nativeMarker":true,"nativeProcesses":1,"publicCode":0,"resultCode":0,"sessionKept":false,"status":"succeeded","syntheticSandboxPresent":false,"timingCode":0,"timingFound":true}
OBSERVED {"automaticRPCs":{"Exec":1,"List":1},"case":"reused command failure","claimPresent":true,"cleanupComplete":true,"diagnostic":"wandb sandbox exit=7","kind":"command-exit","nativeExit":7,"nativeMarker":true,"nativeProcesses":1,"publicCode":7,"resultCode":7,"sessionKept":true,"status":"failed","syntheticSandboxPresent":true,"timingCode":7,"timingFound":true}
```
</details>

## Reproduction commands

Run from the PR checkout root. This setup creates an owned temporary directory; save the complete appended Go fixture from the final details block below as `$proof_dir/native-snippet.go` before the Python step. The exact reconstruction was validated separately against both recorded file hashes; it did **not** rerun or replace the already-recorded native proof. If the current existing `client_test.go` has changed, the hash assertion fails rather than silently claiming the old receipt. The fixture also uses `newWandbBackendForTest`, `seedWandbClaim`, and the timing writer in this PR's `backend_test.go`.

```sh
proof_dir="$(mktemp -d "${TMPDIR:-/tmp}/wandb-proof.XXXXXX")"
trap 'rm -rf -- "$proof_dir"' EXIT
# Save the complete Go fixture below as "$proof_dir/native-snippet.go" now.
python3 - "$proof_dir" <<'PY'
import hashlib, json, pathlib, subprocess, sys
proof = pathlib.Path(sys.argv[1]).resolve()
root = pathlib.Path.cwd()
relative = "internal/providers/wandb/client_test.go"
source = (root / relative).read_text()
fixture = (proof / "native-snippet.go").read_text()
imports = ''' "bytes"
 "encoding/json"
 "fmt"
 "os/exec"
 "sync"
 core "github.com/openclaw/crabbox/internal/cli"
 "google.golang.org/grpc/metadata"'''
replacement = proof / "native-client-test-v3.go"
replacement.write_text(source.replace("import (", "import (\n" + imports, 1) + "\n" + fixture)
subprocess.run(["gofmt", "-w", str(replacement)], check=True)
assert hashlib.sha256(replacement.read_bytes()).hexdigest() == "64bd6d21195277ac3a07dd36688147265095ae9558b7e3aa8316408659260ff0"
baseline = proof / "baseline-backend.go"
baseline.write_bytes(subprocess.check_output([
    "git", "show", "c86c3c03a9726c5223f71e7110b35adec092bd64:internal/providers/wandb/backend.go"
]))
assert hashlib.sha256(baseline.read_bytes()).hexdigest() == "826afa31f6304e36446d7cacc2a0449dda52767ec90f170f5cac2590e77ee765"
candidate = {str(root / relative): str(replacement)}
original = dict(candidate)
original[str(root / "internal/providers/wandb/backend.go")] = str(baseline)
for name, mapping in [("candidate", candidate), ("baseline", original)]:
    (proof / f"native-{name}-v3-overlay.json").write_text(json.dumps({"Replace": mapping}, indent=2))
print("reconstructed replacement and original backend: SHA-256 checks passed")
PY
```

The candidate descriptor replaces only `client_test.go`; the baseline descriptor uses the same replacement and additionally restores the original `backend.go`. No production timeout or protocol is patched for the proof.

```sh
GOTOOLCHAIN=go1.26.5 go test -race ./internal/providers/wandb ./internal/providers/shared -count=1 -timeout=5m
GOTOOLCHAIN=go1.26.5 go vet ./internal/providers/wandb ./internal/providers/shared
node --test scripts/build-docs-site.test.js scripts/check-docs-links.test.js scripts/enhance-docs-site.test.mjs
GOTOOLCHAIN=go1.26.5 go test -c -overlay="$proof_dir/native-candidate-v3-overlay.json" -o "$proof_dir/native-candidate-v3.test" ./internal/providers/wandb
GOTOOLCHAIN=go1.26.5 go test -c -overlay="$proof_dir/native-baseline-v3-overlay.json" -o "$proof_dir/native-baseline-v3.test" ./internal/providers/wandb
"$proof_dir/native-candidate-v3.test" -test.run='^TestWandbNativeTerminalProof$' -test.v -test.count=1 -test.timeout=3m
"$proof_dir/native-baseline-v3.test" -test.run='^TestWandbNativeTerminalProof$' -test.v -test.count=1 -test.timeout=3m
```

<details>
<summary>Full appended native fixture (synthetic control plane, real local workload)</summary>

```go
// Test-only loopback service; actual production client/backend, synthetic control plane.
const proofKey = "synthetic-proof-key"
const proofID = "sb-native-proof"

type terminalProofGateway struct {
	sandboxv1.UnimplementedGatewayServiceServer
	mu               sync.Mutex
	calls            map[string]int
	dir              string
	active, failStop bool
	rpcError         codes.Code
	nativeCount      int
	nativeExit       int
	marker           bool
	autoBudget       time.Duration
}

func (g *terminalProofGateway) Start(ctx context.Context, r *sandboxv1.StartSandboxRequest) (*sandboxv1.StartSandboxResponse, error) {
	g.mu.Lock()
	defer g.mu.Unlock()
	g.calls["Start"]++
	if len(r.Tags) != 1 || r.Tags[0] != "crabbox" {
		return nil, status.Error(codes.InvalidArgument, "missing ownership tag")
	}
	if err := os.Mkdir(g.dir, 0700); err != nil {
		return nil, err
	}
	g.active = true
	return &sandboxv1.StartSandboxResponse{SandboxId: proofID}, nil
}
func (g *terminalProofGateway) Get(ctx context.Context, r *sandboxv1.GetSandboxRequest) (*sandboxv1.GetSandboxResponse, error) {
	g.mu.Lock()
	defer g.mu.Unlock()
	g.calls["Get"]++
	if r.SandboxId != proofID || !g.active {
		return nil, status.Error(codes.NotFound, "absent")
	}
	return &sandboxv1.GetSandboxResponse{SandboxId: proofID, SandboxStatus: sandboxv1.SandboxStatus_SANDBOX_STATUS_RUNNING}, nil
}
func (g *terminalProofGateway) List(ctx context.Context, r *sandboxv1.ListSandboxesRequest) (*sandboxv1.ListSandboxesResponse, error) {
	g.mu.Lock()
	defer g.mu.Unlock()
	g.calls["List"]++
	if len(r.Tags) != 1 || r.Tags[0] != "crabbox" {
		return nil, status.Error(codes.InvalidArgument, "unscoped inventory")
	}
	if !g.active {
		return &sandboxv1.ListSandboxesResponse{}, nil
	}
	return &sandboxv1.ListSandboxesResponse{Sandboxes: []*sandboxv1.SandboxInfo{{SandboxId: proofID, SandboxStatus: sandboxv1.SandboxStatus_SANDBOX_STATUS_RUNNING}}}, nil
}
func (g *terminalProofGateway) Exec(ctx context.Context, r *sandboxv1.ExecSandboxRequest) (*sandboxv1.ExecSandboxResponse, error) {
	g.mu.Lock()
	g.calls["Exec"]++
	active := g.active
	rpcCode := g.rpcError
	g.mu.Unlock()
	if r.SandboxId != proofID || !active {
		return nil, status.Error(codes.NotFound, "absent")
	}
	if rpcCode != codes.OK {
		return nil, status.Error(rpcCode, "injected exec transport failure "+proofKey)
	}
	cmd := exec.CommandContext(ctx, r.Command[0], r.Command[1:]...)
	cmd.Dir = g.dir
	var out, errout bytes.Buffer
	cmd.Stdout = &out
	cmd.Stderr = &errout
	runErr := cmd.Run()
	code := 0
	if runErr != nil {
		var ee *exec.ExitError
		if !errors.As(runErr, &ee) {
			return nil, runErr
		}
		code = ee.ExitCode()
	}
	marker, readErr := os.ReadFile(filepath.Join(g.dir, "native-marker"))
	g.mu.Lock()
	g.nativeCount++
	g.nativeExit = code
	g.marker = readErr == nil && string(marker) == "native"
	g.mu.Unlock()
	return &sandboxv1.ExecSandboxResponse{Result: &sandboxv1.ExecResponse{ExitCode: int32(code), Stdout: out.Bytes(), Stderr: errout.Bytes()}}, nil
}
func (g *terminalProofGateway) Stop(ctx context.Context, r *sandboxv1.StopSandboxRequest) (*sandboxv1.StopSandboxResponse, error) {
	g.mu.Lock()
	defer g.mu.Unlock()
	g.calls["Stop"]++
	if r.SandboxId != proofID {
		return nil, status.Error(codes.InvalidArgument, "wrong identity")
	}
	if deadline, ok := ctx.Deadline(); ok && g.calls["Stop"] == 1 {
		g.autoBudget = time.Until(deadline)
	}
	if g.failStop {
		return nil, status.Error(codes.PermissionDenied, "injected stop failure "+proofKey)
	}
	if err := os.RemoveAll(g.dir); err != nil {
		return nil, err
	}
	g.active = false
	return &sandboxv1.StopSandboxResponse{Success: true}, nil
}

func TestWandbNativeTerminalProof(t *testing.T) {
	for _, tc := range []struct {
		name                                     string
		commandCode                              int
		failStop, failWriter, keepFailure, reuse bool
		rpcCode                                  codes.Code
		wantCode                                 int
		wantKept                                 bool
		wantStops                                int
	}{
		{name: "success cleanup fails", failStop: true, wantCode: 1, wantKept: true, wantStops: 1},
		{name: "command cleanup fails", commandCode: 7, failStop: true, wantCode: 7, wantKept: true, wantStops: 1},
		{name: "command writer retains", commandCode: 7, failWriter: true, keepFailure: true, wantCode: 7, wantKept: true},
		{name: "grpc primary cleanup fails", rpcCode: codes.Unavailable, failStop: true, wantCode: 69, wantKept: true, wantStops: 1},
		{name: "grpc permission classification", rpcCode: codes.PermissionDenied, keepFailure: true, wantCode: 77, wantKept: true},
		{name: "grpc deadline classification", rpcCode: codes.DeadlineExceeded, keepFailure: true, wantCode: 124, wantKept: true},
		{name: "grpc missing classification", rpcCode: codes.NotFound, keepFailure: true, wantCode: 4, wantKept: true},
		{name: "ordinary success", wantStops: 1},
		{name: "reused command failure", commandCode: 7, reuse: true, wantCode: 7, wantKept: true},
	} {
		t.Run(tc.name, func(t *testing.T) {
			g := &terminalProofGateway{calls: map[string]int{}, dir: filepath.Join(t.TempDir(), "owned-sandbox"), failStop: tc.failStop, rpcError: tc.rpcCode}
			lis, err := net.Listen("tcp", "127.0.0.1:0")
			if err != nil {
				t.Fatal(err)
			}
			server := grpc.NewServer(grpc.UnaryInterceptor(func(ctx context.Context, r any, info *grpc.UnaryServerInfo, h grpc.UnaryHandler) (any, error) {
				md, _ := metadata.FromIncomingContext(ctx)
				if strings.Join(md.Get("x-wandb-api-key"), "") != proofKey || strings.Join(md.Get("x-entity-id"), "") != "test-entity" || strings.Join(md.Get("x-project-name"), "") != "test-project" {
					return nil, status.Error(codes.Unauthenticated, "synthetic metadata missing")
				}
				return h(ctx, r)
			}))
			sandboxv1.RegisterGatewayServiceServer(server, g)
			done := make(chan struct{})
			go func() { defer close(done); _ = server.Serve(lis) }()
			t.Cleanup(func() { server.Stop(); <-done })
			t.Setenv("CRABBOX_WANDB_API_KEY", proofKey)
			t.Setenv("CWSANDBOX_BASE_URL", "http://"+lis.Addr().String())
			b := newWandbBackendForTest(t, nil)
			t.Cleanup(func() { _ = b.Close() })
			writer := &wandbTimingWriter{}
			if tc.failWriter {
				writer.err = errors.New("injected timing writer failure")
			}
			b.rt.Stderr = writer
			var stdout bytes.Buffer
			b.rt.Stdout = &stdout
			req := RunRequest{NoSync: true, TimingJSON: true, KeepOnFailure: tc.keepFailure, Command: []string{"sh", "-c", fmt.Sprintf("printf native > native-marker; printf 'native-command\\n'; exit %d", tc.commandCode)}}
			if tc.reuse {
				g.active = true
				if err := os.Mkdir(g.dir, 0700); err != nil {
					t.Fatal(err)
				}
				seedWandbClaim(t, b, proofID)
				req.ID = proofID
			}
			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
			defer cancel()
			result, runErr := b.Run(ctx, req)
			result = core.FinalizeRunResult(result, runErr)
			publicCode := 0
			message := ""
			if runErr != nil {
				var ee ExitError
				if errors.As(runErr, &ee) {
					publicCode = ee.Code
					message = ee.Message
				} else {
					publicCode = 1
					message = runErr.Error()
				}
			}
			claim, exists, claimErr := resolveWandbClaim(proofID)
			if claimErr != nil {
				t.Fatal(claimErr)
			}
			scope, scopeErr := wandbProviderScope()
			if scopeErr != nil {
				t.Fatal(scopeErr)
			}
			if exists && (claim.ProviderScope != scope || claim.CloudID != proofID) {
				t.Error("retained claim lost original identity/scope")
			}
			g.mu.Lock()
			calls := map[string]int{}
			for k, v := range g.calls {
				calls[k] = v
			}
			nativeCount, nativeExit, marker, active, budget := g.nativeCount, g.nativeExit, g.marker, g.active, g.autoBudget
			g.failStop = false
			g.mu.Unlock()
			kept := result.Session != nil && result.Session.Kept
			var timing timingReport
			timingFound := false
			for _, line := range strings.Split(writer.String(), "\n") {
				if strings.HasPrefix(line, "{") {
					if err := json.Unmarshal([]byte(line), &timing); err != nil {
						t.Fatal(err)
					}
					timingFound = true
				}
			}
			row := map[string]any{"case": tc.name, "resultCode": result.ExitCode, "publicCode": publicCode, "status": result.Status, "kind": result.ErrorKind, "sessionKept": kept, "claimPresent": exists, "syntheticSandboxPresent": active, "automaticRPCs": calls, "nativeProcesses": nativeCount, "nativeExit": nativeExit, "nativeMarker": marker, "timingFound": timingFound, "timingCode": timing.ExitCode, "diagnostic": message}
			// Cleanup follows observed ownership, never the candidate's reported Kept bit.
			if exists {
				if err := b.Stop(ctx, StopRequest{ID: proofID}); err != nil {
					t.Fatalf("owned explicit recovery stop: %v", err)
				}
			}
			_, existsAfter, err := resolveWandbClaim(proofID)
			if err != nil || existsAfter {
				t.Errorf("claim cleanup exists=%v err=%v", existsAfter, err)
			}
			if _, err := os.Stat(g.dir); !os.IsNotExist(err) {
				t.Errorf("owned sandbox directory not removed: %v", err)
			}
			row["cleanupComplete"] = !existsAfter
			data, _ := json.Marshal(row)
			t.Logf("OBSERVED %s", data)
			wantKind := core.RunErrorNone
			wantStatus := core.RunStatusSucceeded
			if tc.commandCode != 0 {
				wantKind = core.RunErrorCommandExit
			} else if tc.rpcCode != codes.OK || tc.failStop || tc.failWriter {
				wantKind = core.RunErrorProvider
			}
			if tc.wantCode != 0 {
				wantStatus = core.RunStatusFailed
			}
			if result.ErrorKind != wantKind || result.Status != wantStatus {
				t.Errorf("classification got=%s/%s want=%s/%s", result.Status, result.ErrorKind, wantStatus, wantKind)
			}
			if result.ExitCode != tc.wantCode || publicCode != tc.wantCode || kept != tc.wantKept || exists != tc.wantKept || active != tc.wantKept || calls["Stop"] != tc.wantStops {
				t.Errorf("terminal outcome/disposition mismatch: %s", data)
			}
			wantStarts, wantGets, wantLists := 1, 1, 0
			if tc.reuse {
				wantStarts, wantGets, wantLists = 0, 0, 1
			}
			if calls["Start"] != wantStarts || calls["Get"] != wantGets || calls["List"] != wantLists || calls["Exec"] != 1 {
				t.Errorf("unexpected RPC path: %v", calls)
			}
			if tc.wantStops == 1 && (budget < 13*time.Second || budget > 15*time.Second) {
				t.Errorf("automatic Stop budget=%s", budget)
			}
			wantNative := 1
			if tc.rpcCode != codes.OK {
				wantNative = 0
			}
			if nativeCount != wantNative || (wantNative == 1 && (!marker || nativeExit != tc.commandCode || !strings.Contains(stdout.String(), "native-command"))) {
				t.Errorf("native command evidence mismatch: %s", data)
			}
			if !tc.failWriter && (!timingFound || timing.ExitCode != tc.wantCode || timing.RunStatus != result.Status || timing.ErrorKind != result.ErrorKind) {
				t.Errorf("timing outcome mismatch: %+v", timing)
			}
			if strings.Contains(message, proofKey) || strings.Contains(writer.String(), proofKey) {
				t.Error("synthetic provider key exposed")
			}
			if tc.commandCode == 7 && !strings.Contains(message, "sandbox exit=7") {
				t.Error("primary command diagnostic lost")
			}
			if tc.failStop && !strings.Contains(message, "stop failure") {
				t.Error("secondary Stop diagnostic absent")
			}
			if tc.failWriter && !strings.Contains(message, "timing writer failure") {
				t.Error("timing diagnostic absent")
			}
		})
	}
}

```
</details>
