### PR TITLE
fix: omit core metadata when reusing W&B sandboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Tensorlake: include claim-lock waiting in the bound-sandbox cleanup deadline, retaining ownership and avoiding native operations when the deadline expires before admission. [PR 1888](https://github.com/openclaw/crabbox/pull/1888). Thanks @steipete.
 - Tensorlake: share run finalization so early failures honor `--keep-on-failure`, failed cleanup reports a retained recovery session, and timing errors preserve the command outcome; retain quiet native-command error causes while keeping profile cleanup warning-only. [PR 1905](https://github.com/openclaw/crabbox/pull/1905). Thanks @steipete.
 - W&B: finalize run outcomes after automatic Stop, retain recovery sessions when cleanup fails, preserve primary command or gRPC failures and failure retention when cleanup or timing output also fails, and classify gRPC/API failures as provider errors instead of command exits. [PR 1929](https://github.com/openclaw/crabbox/pull/1929).
-- W&B: allow existing-sandbox runs to omit framework-owned run metadata while preserving explicit environment-forwarding restrictions.
+- W&B: allow existing-sandbox runs to omit framework-owned run metadata while preserving explicit environment-forwarding restrictions. [PR 1930](https://github.com/openclaw/crabbox/pull/1930).
 
 ## 0.50.0 - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Tensorlake: include claim-lock waiting in the bound-sandbox cleanup deadline, retaining ownership and avoiding native operations when the deadline expires before admission. [PR 1888](https://github.com/openclaw/crabbox/pull/1888). Thanks @steipete.
 - Tensorlake: share run finalization so early failures honor `--keep-on-failure`, failed cleanup reports a retained recovery session, and timing errors preserve the command outcome; retain quiet native-command error causes while keeping profile cleanup warning-only. [PR 1905](https://github.com/openclaw/crabbox/pull/1905). Thanks @steipete.
 - W&B: finalize run outcomes after automatic Stop, retain recovery sessions when cleanup fails, preserve primary command or gRPC failures and failure retention when cleanup or timing output also fails, and classify gRPC/API failures as provider errors instead of command exits. [PR 1929](https://github.com/openclaw/crabbox/pull/1929).
+- W&B: allow existing-sandbox runs to omit framework-owned run metadata while preserving explicit environment-forwarding restrictions.
 
 ## 0.50.0 - 2026-09-05
 

--- a/docs/providers/wandb.md
+++ b/docs/providers/wandb.md
@@ -164,9 +164,15 @@ the lesser of five minutes and the sandbox lifetime.
 - `Exec` is the unary RPC, so command output is buffered server-side and
   returned at completion rather than streamed; there is no interactive PTY.
 - Environment variables are applied at `Start` time only. When you target an
-  existing sandbox with `--id`, env vars cannot be forwarded onto it (the
-  `Exec` RPC has no env field), so an `--id` run with `--allow-env` is
-  rejected.
+  existing sandbox with `--id`, selected user env vars cannot be forwarded onto
+  it (the `Exec` RPC has no env field), so explicit `--allow-env` selections
+  containing such values are rejected, including `CI` and `NODE_OPTIONS`.
+  Crabbox's local run metadata (`CRABBOX_LEASE_ID`, `CRABBOX_RUN_ID`, and
+  `CRABBOX_SLUG`) may be omitted for reuse, including when an env summary is
+  requested. The built-in implicit `CI`/`NODE_OPTIONS` defaults retain their
+  existing omission exception. Neither exception forwards values through `Exec`
+  or refreshes the sandbox's original `Start`-time environment; similarly named
+  custom variables are not treated as reserved metadata.
 - `--reclaim`, `--shell`, `--sync-only`, `--checksum`, `--force-sync-large`,
   `--full-resync`, `--download`, `--artifact-glob`, and `--require-artifact`
   are rejected: W&B owns the sandbox lifecycle and there is no Crabbox

--- a/internal/providers/wandb/backend.go
+++ b/internal/providers/wandb/backend.go
@@ -94,12 +94,12 @@ func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (result RunResul
 			printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 		}
 	} else {
-		if len(req.Env) > 0 && !wandbExistingIDEnvIsImplicitDefault(req) {
+		if len(req.Env) > 0 && !wandbExistingIDEnvCanBeOmitted(req) {
 			// CoreWeave Sandboxes apply environment variables at Start time only;
 			// the v1beta2 Exec RPC has no env field, so we can't honour
-			// selected env on an already-running sandbox. The only exception is
-			// Crabbox's built-in implicit CI/NODE_OPTIONS allowlist, which older
-			// configs may select without the user asking for env forwarding.
+			// selected env on an already-running sandbox. Core-owned run metadata
+			// may be omitted, as can the built-in implicit CI/NODE_OPTIONS defaults;
+			// neither exception forwards new environment values through Exec.
 			return RunResult{}, exit(2, "provider=%s cannot forward env vars to an existing sandbox (--id); rerun without --id or omit --allow-env", providerName)
 		}
 		claim, sandboxID, err = requireWandbOwnership(ctx, client, sandboxID, providerScope)
@@ -488,12 +488,12 @@ func rejectWandbRunOptions(req RunRequest) error {
 	return nil
 }
 
-func wandbExistingIDEnvIsImplicitDefault(req RunRequest) bool {
-	if req.EnvSummary {
-		return false
-	}
+func wandbExistingIDEnvCanBeOmitted(req RunRequest) bool {
 	for name := range req.Env {
-		if name != "CI" && name != "NODE_OPTIONS" {
+		if core.IsRunExecutionMetadataEnvName(name) {
+			continue
+		}
+		if req.EnvSummary || (name != "CI" && name != "NODE_OPTIONS") {
 			return false
 		}
 	}

--- a/internal/providers/wandb/backend_test.go
+++ b/internal/providers/wandb/backend_test.go
@@ -400,7 +400,7 @@ func TestWandbRunWithExistingIDSkipsAcquireAndStop(t *testing.T) {
 		ID:      "sb-supplied",
 		NoSync:  true,
 		Command: []string{"echo"},
-		Env:     map[string]string{"CI": "true"},
+		Env:     map[string]string{"CI": "true", "CRABBOX_LEASE_ID": "sb-supplied", "CRABBOX_RUN_ID": "run-fixture", "CRABBOX_SLUG": "fixture"},
 	})
 	if err != nil {
 		t.Fatalf("Run err: %v", err)
@@ -1099,5 +1099,34 @@ func TestWandbRunTypedTimingWriterPreservesPublicCode(t *testing.T) {
 	}
 	if result.Session == nil || result.Session.Kept || api.stopCalls != 1 {
 		t.Fatalf("typed writer changed actual deletion: session=%+v stops=%d", result.Session, api.stopCalls)
+	}
+}
+
+func TestWandbExistingIDEnvironmentPolicy(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		env            map[string]string
+		explicit, want bool
+	}{
+		{name: "reserved-only", env: map[string]string{"CRABBOX_LEASE_ID": "sb", "CRABBOX_RUN_ID": "run", "CRABBOX_SLUG": "slug"}, want: true},
+		{name: "reserved-only-summary", env: map[string]string{"CRABBOX_RUN_ID": "run"}, explicit: true, want: true},
+		{name: "reserved-casefold", env: map[string]string{"CrAbBoX_SlUg": "slug"}, want: true},
+		{name: "implicit-defaults", env: map[string]string{"CI": "true", "NODE_OPTIONS": "fixture"}, want: true},
+		{name: "reserved-plus-implicit-defaults", env: map[string]string{"CRABBOX_RUN_ID": "run", "CI": "true", "NODE_OPTIONS": "fixture"}, want: true},
+		{name: "explicit-ci", env: map[string]string{"CRABBOX_RUN_ID": "run", "CI": "true"}, explicit: true},
+		{name: "explicit-node", env: map[string]string{"NODE_OPTIONS": "fixture"}, explicit: true},
+		{name: "custom", env: map[string]string{"CUSTOM": "fixture"}},
+		{name: "prefix-lookalike", env: map[string]string{"CRABBOX_RUN_ID_EXTRA": "fixture"}},
+		{name: "suffix-lookalike", env: map[string]string{"PREFIX_CRABBOX_RUN_ID": "fixture"}},
+		{name: "padded-lookalike", env: map[string]string{" CRABBOX_RUN_ID": "fixture"}},
+		{name: "lowercase-default-not-exception", env: map[string]string{"ci": "true"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := wandbExistingIDEnvCanBeOmitted(RunRequest{Env: tc.env, EnvSummary: tc.explicit})
+			t.Logf("actual=%t desired=%t explicit=%t", got, tc.want, tc.explicit)
+			if got != tc.want {
+				t.Errorf("reuse environment accepted=%t want=%t", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Ordinary W&B `run --id` calls were rejected before ownership lookup or execution because the CLI always injects `CRABBOX_LEASE_ID`, `CRABBOX_RUN_ID`, and `CRABBOX_SLUG`, while the existing-sandbox env guard accepted only implicit `CI`/`NODE_OPTIONS` defaults.

The private `wandbExistingIDEnvCanBeOmitted` helper uses the existing `core.IsRunExecutionMetadataEnvName` predicate to omit those exact core-owned metadata names before applying the existing env-summary/default-env rules. Metadata-only requests can proceed even when an env summary was requested. Explicitly selected `CI`, `NODE_OPTIONS`, custom variables and similarly named nonreserved variables remain rejected. The old implicit uppercase `CI`/`NODE_OPTIONS` omission exception remains intact.

This does not add env support to the CoreWeave `Exec` RPC, forward metadata through command text, or refresh the sandbox's original Start-time environment. The protobuf has no Exec env field. Existing claim/tag authorization, Start/Stop lifecycle, timing finalization, transport/TLS and auth policy are unchanged. The documentation explains that distinction; the small Unreleased entry follows the larger features and existing W&B lifecycle entry without a placeholder PR link.

### Complete captured CLI behavior

This unchanged complete capture is placed first so a shortened PR description still includes all reuse, rejection and cleanup evidence. The fixture and method details follow.

<details>
<summary>Acquire, all eight reuse controls, exact Exec payloads, claim and Stop cleanup</summary>

```json
{
  "acquire": {
    "exitCode": 0,
    "output": "provisioning provider=wandb image=ubuntu:24.04 max_lifetime=1800s\nprovisioned sandbox=sb-metadata-audit status=running\nsynthetic-rpc-proof\n"
  },
  "cases": [
    {
      "connectionsAfter": 2,
      "connectionsBefore": 1,
      "name": "metadata-only",
      "newRPC": [
        "/coreweave.sandbox.v1beta2.GatewayService/List",
        "/coreweave.sandbox.v1beta2.GatewayService/Exec"
      ],
      "run": {
        "exitCode": 0,
        "output": "synthetic-rpc-proof\n"
      }
    },
    {
      "connectionsAfter": 3,
      "connectionsBefore": 2,
      "name": "metadata-only-summary",
      "newRPC": [
        "/coreweave.sandbox.v1beta2.GatewayService/List",
        "/coreweave.sandbox.v1beta2.GatewayService/Exec"
      ],
      "run": {
        "exitCode": 0,
        "output": "synthetic-rpc-proof\n"
      }
    },
    {
      "connectionsAfter": 4,
      "connectionsBefore": 3,
      "name": "implicit-defaults",
      "newRPC": [
        "/coreweave.sandbox.v1beta2.GatewayService/List",
        "/coreweave.sandbox.v1beta2.GatewayService/Exec"
      ],
      "run": {
        "exitCode": 0,
        "output": "synthetic-rpc-proof\n"
      }
    },
    {
      "connectionsAfter": 4,
      "connectionsBefore": 4,
      "name": "explicit-ci",
      "newRPC": [],
      "run": {
        "exitCode": 2,
        "output": "provider=wandb cannot forward env vars to an existing sandbox (--id); rerun without --id or omit --allow-env\n"
      }
    },
    {
      "connectionsAfter": 4,
      "connectionsBefore": 4,
      "name": "explicit-node",
      "newRPC": [],
      "run": {
        "exitCode": 2,
        "output": "provider=wandb cannot forward env vars to an existing sandbox (--id); rerun without --id or omit --allow-env\n"
      }
    },
    {
      "connectionsAfter": 4,
      "connectionsBefore": 4,
      "name": "explicit-custom",
      "newRPC": [],
      "run": {
        "exitCode": 2,
        "output": "provider=wandb cannot forward env vars to an existing sandbox (--id); rerun without --id or omit --allow-env\n"
      }
    },
    {
      "connectionsAfter": 4,
      "connectionsBefore": 4,
      "name": "prefix-lookalike",
      "newRPC": [],
      "run": {
        "exitCode": 2,
        "output": "provider=wandb cannot forward env vars to an existing sandbox (--id); rerun without --id or omit --allow-env\n"
      }
    },
    {
      "connectionsAfter": 4,
      "connectionsBefore": 4,
      "name": "suffix-lookalike",
      "newRPC": [],
      "run": {
        "exitCode": 2,
        "output": "provider=wandb cannot forward env vars to an existing sandbox (--id); rerun without --id or omit --allow-env\n"
      }
    }
  ],
  "claimBeforeStop": {
    "claimedAt": "2026-09-06T21:58:10Z",
    "cloudID": "sb-metadata-audit",
    "idleTimeoutSeconds": 1800,
    "lastUsedAt": "2026-09-06T21:58:10Z",
    "leaseID": "sb-metadata-audit",
    "provider": "wandb",
    "providerScope": "endpoint:127.0.0.1%3A43001|entity:synthetic-entity|project:synthetic-project",
    "repoRoot": "",
    "revision": "<synthetic-claim-revision>",
    "slug": "sb-metadata-audit"
  },
  "execRequests": [
    {
      "sandboxId": "sb-metadata-audit",
      "command": [
        "true"
      ]
    },
    {
      "sandboxId": "sb-metadata-audit",
      "command": [
        "true"
      ]
    },
    {
      "sandboxId": "sb-metadata-audit",
      "command": [
        "true"
      ]
    },
    {
      "sandboxId": "sb-metadata-audit",
      "command": [
        "true"
      ]
    }
  ],
  "finalClaimCount": 0,
  "finalRPC": [
    "/coreweave.sandbox.v1beta2.GatewayService/Start",
    "/coreweave.sandbox.v1beta2.GatewayService/Get",
    "/coreweave.sandbox.v1beta2.GatewayService/Exec",
    "/coreweave.sandbox.v1beta2.GatewayService/List",
    "/coreweave.sandbox.v1beta2.GatewayService/Exec",
    "/coreweave.sandbox.v1beta2.GatewayService/List",
    "/coreweave.sandbox.v1beta2.GatewayService/Exec",
    "/coreweave.sandbox.v1beta2.GatewayService/List",
    "/coreweave.sandbox.v1beta2.GatewayService/Exec",
    "/coreweave.sandbox.v1beta2.GatewayService/List",
    "/coreweave.sandbox.v1beta2.GatewayService/Stop"
  ],
  "finalSandboxPresent": false,
  "initialRPC": [
    "/coreweave.sandbox.v1beta2.GatewayService/Start",
    "/coreweave.sandbox.v1beta2.GatewayService/Get",
    "/coreweave.sandbox.v1beta2.GatewayService/Exec"
  ],
  "portClosed": true,
  "scope": "actual unmodified CLI+production constructor using existing loopback plaintext mode; gRPC responses are synthetic, no TLS or hosted/native workload claim",
  "serverStopped": true,
  "startMetadata": {
    "CRABBOX_LEASE_ID": "",
    "CRABBOX_RUN_ID": "run_4e80eace5994",
    "CRABBOX_SLUG": ""
  },
  "stop": {
    "exitCode": 0,
    "output": ""
  }
}
```

</details>

### Tests-first evidence

Against base `69e79538dae281148ed3475329bfc6eeaf53b58f`, the new 12-case helper table failed its four metadata-positive cases before the fix. Its eight existing default/rejection controls passed. The updated seeded existing-ID backend test also failed before the fix, then passed with metadata included in its request.

The table covers metadata-only, metadata-only plus summary, owner-defined case folding, implicit defaults, metadata plus implicit defaults, explicit CI/NODE_OPTIONS, custom env, prefix/suffix/padded lookalikes, and lowercase `ci` remaining outside the old default exception. No broad `CRABBOX_*` prefix exemption was added.

An earlier preserved actual-CLI audit on `4e3df6dfc42a49bd665a92b2e2756b909122c8c3` acquired a real local ownership claim through its protocol fixture, then reproduced this rejection on the same sandbox:

```text
provider=wandb cannot forward env vars to an existing sandbox (--id); rerun without --id or omit --allow-env
```

That earlier reuse exited 2, opened no new connection, and left the RPC trace unchanged at Start/Get/Exec; explicit CLI Stop then cleaned up. It is historical negative evidence, not the current candidate's receipt.

Fresh candidate checks:

```sh
go test -race ./internal/providers/wandb ./internal/providers/shared -count=1
go vet ./internal/providers/wandb ./internal/providers/shared
go test ./internal/cli -run TestIsRunExecutionMetadataEnvName -count=1
node scripts/check-docs-links.mjs
git diff --check
```

Actual race output:

```text
ok  	github.com/openclaw/crabbox/internal/providers/wandb	2.947s
ok  	github.com/openclaw/crabbox/internal/providers/shared	2.446s
```

Fresh focused vet and diff checks passed. The canonical core predicate and 246-file documentation checks passed before the private-symbol rename; those files remain byte-identical. The complete revised four-file candidate received a fresh managed Codex review with no actionable P0 findings. That scoped threshold is not a claim of lower-priority review coverage.

### Actual built CLI and production constructor

The byte-identical fixture was replayed against a freshly built candidate after the private-helper rename; this receipt and binary are separate from the original proof. The fixture invokes the built candidate CLI by absolute path and uses its unchanged production gRPC constructor with the existing, explicitly supported plaintext **loopback-only** endpoint mode. The auth headers and responses are synthetic. No TLS/trust setting or production transport was changed. This is CLI/client protocol proof, not TLS, hosted W&B, or native sandbox-workload execution proof; the returned `synthetic-rpc-proof` text is a fixture response.

The fixture first acquires and keeps a sandbox, creating the normal exact local claim. It then runs these cases against that owned ID:

| Reuse case | CLI exit | New RPCs / connections |
| --- | --- | --- |
| Core metadata only | 0 | List → Exec; one connection |
| Core metadata only with summary requested | 0 | List → Exec; one connection |
| Implicit CI/NODE_OPTIONS defaults | 0 | List → Exec; one connection |
| Explicit CI | 2 | None |
| Explicit NODE_OPTIONS | 2 | None |
| Explicit custom variable | 2 | None |
| `CRABBOX_RUN_ID_EXTRA` lookalike | 2 | None |
| `PREFIX_CRABBOX_RUN_ID` lookalike | 2 | None |

Each successful reuse adds only List/Exec: no Acquire/Start and no automatic Stop. Each rejected case is checked for both zero new RPCs and zero new accepted connections. Finally, the actual CLI Stop adds List/Stop and removes the sandbox/claim. The fixture verifies the server exits and its port is closed; temporary state is owned by Go's `t.TempDir` cleanup.

The actual Start request contained the three injected metadata names, while **all four captured Exec requests** (initial command plus three successful reuses) were exactly:

```json
{"sandboxId":"sb-metadata-audit","command":["true"]}
```

No metadata, CI/NODE_OPTIONS, environment field or shell wrapper was added to Exec. The fixture had one compile-time assertion correction while being written: protobuf `command` is repeated, so it is compared as a one-element slice. That failed compile is preserved separately and is not provider or runtime evidence.

### Capture display substitutions

Only the ephemeral endpoint port in the claim scope and its generated revision are substituted in the complete capture above. Actual exit codes, outputs, RPCs, connection counts and metadata fields are retained. Raw proof remains unchanged and is the input to the receipt hash.



### Exact tested inputs

Base: `69e79538dae281148ed3475329bfc6eeaf53b58f` plus this four-file diff. These hashes identify the actual tested source/binary/fixture, not a later merge commit. Original negative-audit artifacts remain unchanged.

```text
f4883cfa23d873091a0a3cbc80339ebaae5b3bb562d33f4a272d2e5787a55b85  CHANGELOG.md
f6cd713def804c2066e3a66ef97acc4376956f515ca12aa85ea8dafa0d87e675  docs/providers/wandb.md
8a4c68decde77caf92479bea788a5b19ecfef06e32373d5a8f40a0d9c8e4b9c1  internal/providers/wandb/backend.go
2fd21bfa175519923a98c1e0136bcac731d17d5e133628c576d2e7123ca0c5e7  internal/providers/wandb/backend_test.go
a588050af1b2e616c03b034daf342663bba9102ec359e3abae7685a6826c5def  internal/cli/run_env_profile.go
82c1d1fb49707099088b8256ed956eea682b1dc694e35eb468e311c215df3464  internal/providers/wandb/client.go
58dfc9b689251a9af94af0fd4bd39ae0ce5f0e07552e11f4f8bddb9137c599d5  candidate.patch
9d668e12d4786a520763a9d6a65cc1283c370586806e1a32d5f51673f17c31ee  crabbox
d997c6673293dfccf55ad9fdb0cd7c496f9a60e16491e994b57f6d4bdabec3f2  fixture_test.go
baf6fedbce17876e7831ce2b1773fe085b0bd1cd7b0e808b730ec97e1a9ca70f  native-receipt.json
```

### Runnable fixture

Save the exact Go fixture below outside the repository. From the candidate checkout, build the uninstrumented CLI and add the test file through a Go overlay. Requires Go and Git on a POSIX host. Only synthetic credentials are passed to the child CLI; the fixture creates its own local state and server.

```sh
wandb_proof_dir="$(mktemp -d /tmp/crabbox-wandb-metadata.XXXXXX)"
# Save the fixture below as "$wandb_proof_dir/fixture_test.go".
python3 - "$PWD" "$wandb_proof_dir" <<'PY_OVERLAY'
from pathlib import Path
import json, sys
repo, proof = map(lambda p: Path(p).resolve(), sys.argv[1:])
(proof / 'overlay.json').write_text(json.dumps({'Replace': {
    str(repo / 'internal/providers/wandb/native_metadata_fixture_test.go'):
        str(proof / 'fixture_test.go'),
}}))
PY_OVERLAY
go build -trimpath -o "$wandb_proof_dir/crabbox" ./cmd/crabbox
WANDB_AUDIT_CLI="$wandb_proof_dir/crabbox" go test -race \
  -overlay "$wandb_proof_dir/overlay.json" ./internal/providers/wandb \
  -run TestActualCLIMetadataReuseAndRejectionControls -count=1 -v
```

The `CLI_METADATA_RECEIPT` line contains the complete capture. Archive the binary/receipt before removing the owned proof directory.

<details>
<summary>Full fixture_test.go (byte-exact fixture matching the hash above)</summary>

```go
package wandb

import (
	"context"
	"encoding/json"
	"fmt"
	sandboxv1 "github.com/openclaw/crabbox/internal/providers/wandb/gen/coreweave/sandbox/v1beta2"
	"google.golang.org/grpc"
	"google.golang.org/grpc/metadata"
	"google.golang.org/protobuf/encoding/protojson"
	"net"
	"os"
	"os/exec"
	"path/filepath"
	"strings"
	"sync"
	"sync/atomic"
	"testing"
	"time"
)

type auditCountingListener struct {
	net.Listener
	accepted atomic.Int64
}

func (l *auditCountingListener) Accept() (net.Conn, error) {
	c, e := l.Listener.Accept()
	if e == nil {
		l.accepted.Add(1)
	}
	return c, e
}

type metadataAuditGateway struct {
	sandboxv1.UnimplementedGatewayServiceServer
	mu           sync.Mutex
	rpc          []string
	present      bool
	startEnv     map[string]string
	execRequests []json.RawMessage
}

func (s *metadataAuditGateway) Start(_ context.Context, r *sandboxv1.StartSandboxRequest) (*sandboxv1.StartSandboxResponse, error) {
	s.mu.Lock()
	defer s.mu.Unlock()
	s.present = true
	s.startEnv = r.EnvironmentVariables
	return &sandboxv1.StartSandboxResponse{SandboxId: "sb-metadata-audit"}, nil
}
func (s *metadataAuditGateway) Get(context.Context, *sandboxv1.GetSandboxRequest) (*sandboxv1.GetSandboxResponse, error) {
	return &sandboxv1.GetSandboxResponse{SandboxStatus: sandboxv1.SandboxStatus_SANDBOX_STATUS_RUNNING}, nil
}
func (s *metadataAuditGateway) List(context.Context, *sandboxv1.ListSandboxesRequest) (*sandboxv1.ListSandboxesResponse, error) {
	s.mu.Lock()
	defer s.mu.Unlock()
	out := &sandboxv1.ListSandboxesResponse{}
	if s.present {
		out.Sandboxes = []*sandboxv1.SandboxInfo{{SandboxId: "sb-metadata-audit", SandboxStatus: sandboxv1.SandboxStatus_SANDBOX_STATUS_RUNNING}}
	}
	return out, nil
}
func (s *metadataAuditGateway) Exec(_ context.Context, r *sandboxv1.ExecSandboxRequest) (*sandboxv1.ExecSandboxResponse, error) {
	s.mu.Lock()
	defer s.mu.Unlock()
	data, err := protojson.Marshal(r)
	if err != nil {
		return nil, err
	}
	s.execRequests = append(s.execRequests, data)
	if (len(r.GetCommand()) != 1 || r.GetCommand()[0] != "true") || len(r.GetArgs()) != 0 {
		return nil, fmt.Errorf("unexpected Exec command")
	}
	return &sandboxv1.ExecSandboxResponse{Result: &sandboxv1.ExecResponse{ExitCode: 0, Stdout: []byte("synthetic-rpc-proof\n")}}, nil
}
func (s *metadataAuditGateway) Stop(context.Context, *sandboxv1.StopSandboxRequest) (*sandboxv1.StopSandboxResponse, error) {
	s.mu.Lock()
	defer s.mu.Unlock()
	s.present = false
	return &sandboxv1.StopSandboxResponse{Success: true}, nil
}
func (s *metadataAuditGateway) snapshot() ([]string, bool, map[string]string) {
	s.mu.Lock()
	defer s.mu.Unlock()
	env := map[string]string{}
	for k, v := range s.startEnv {
		env[k] = v
	}
	return append([]string(nil), s.rpc...), s.present, env
}

func TestActualCLIMetadataReuseAndRejectionControls(t *testing.T) {
	binary := os.Getenv("WANDB_AUDIT_CLI")
	if !filepath.IsAbs(binary) {
		t.Fatal("WANDB_AUDIT_CLI must be an absolute built CLI path")
	}
	raw, err := net.Listen("tcp", "127.0.0.1:0")
	if err != nil {
		t.Fatal(err)
	}
	listener := &auditCountingListener{Listener: raw}
	gateway := &metadataAuditGateway{}
	server := grpc.NewServer(grpc.UnaryInterceptor(func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
		md, _ := metadata.FromIncomingContext(ctx)
		if strings.Join(md.Get("x-wandb-api-key"), "") != "synthetic-fixture-only" || strings.Join(md.Get("x-entity-id"), "") != "synthetic-entity" {
			return nil, fmt.Errorf("wrong fixture auth")
		}
		gateway.mu.Lock()
		gateway.rpc = append(gateway.rpc, info.FullMethod)
		gateway.mu.Unlock()
		return handler(ctx, req)
	}))
	sandboxv1.RegisterGatewayServiceServer(server, gateway)
	done := make(chan struct{})
	go func() { defer close(done); _ = server.Serve(listener) }()
	defer func() {
		server.Stop()
		_ = listener.Close()
		select {
		case <-done:
		case <-time.After(time.Second):
			t.Error("server did not stop")
		}
	}()
	root := t.TempDir()
	repo := filepath.Join(root, "repo")
	if err := os.Mkdir(repo, 0o700); err != nil {
		t.Fatal(err)
	}
	env := []string{"PATH=" + os.Getenv("PATH"), "HOME=" + filepath.Join(root, "home"), "XDG_CONFIG_HOME=" + filepath.Join(root, "config"), "XDG_STATE_HOME=" + filepath.Join(root, "state"), "TMPDIR=" + root, "CRABBOX_WANDB_API_KEY=synthetic-fixture-only", "WANDB_ENTITY_NAME=synthetic-entity", "WANDB_PROJECT=synthetic-project", "CWSANDBOX_BASE_URL=http://" + listener.Addr().String(), "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null"}
	git := exec.Command("git", "init", "-q", repo)
	git.Env = env
	if out, err := git.CombinedOutput(); err != nil {
		t.Fatalf("git init:%v %s", err, out)
	}
	invokeEnv := func(extra []string, args ...string) map[string]any {
		ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
		defer cancel()
		cmd := exec.CommandContext(ctx, binary, args...)
		cmd.Dir = repo
		cmd.Env = append(append([]string(nil), env...), extra...)
		out, err := cmd.CombinedOutput()
		code := 0
		if err != nil {
			var ok bool
			var ee *exec.ExitError
			ee, ok = err.(*exec.ExitError)
			if !ok {
				t.Fatalf("invoke:%v", err)
			}
			code = ee.ExitCode()
		}
		return map[string]any{"exitCode": code, "output": string(out)}
	}
	invoke := func(args ...string) map[string]any { return invokeEnv(nil, args...) }
	defer func() {
		_, present, _ := gateway.snapshot()
		if present {
			_ = invoke("stop", "--provider", "wandb", "--id", "sb-metadata-audit")
		}
	}()
	acquire := invoke("run", "--provider", "wandb", "--no-sync", "--keep", "--timing-record", "off", "--", "true")
	if acquire["exitCode"] != 0 {
		t.Fatalf("acquire:%v", acquire)
	}
	before, present, startEnv := gateway.snapshot()
	if !present {
		t.Fatal("fixture not acquired")
	}
	for _, name := range []string{"CRABBOX_LEASE_ID", "CRABBOX_RUN_ID", "CRABBOX_SLUG"} {
		if _, ok := startEnv[name]; !ok {
			t.Errorf("core metadata absent from actual Start request:%s", name)
		}
	}
	var cases []map[string]any
	for _, tc := range []struct {
		name         string
		extra, flags []string
		want         int
	}{
		{name: "metadata-only", want: 0},
		{name: "metadata-only-summary", flags: []string{"--allow-env", "CRABBOX_RUN_ID"}, want: 0},
		{name: "implicit-defaults", extra: []string{"CI=true", "NODE_OPTIONS=--no-warnings"}, want: 0},
		{name: "explicit-ci", extra: []string{"CI=true"}, flags: []string{"--allow-env", "CI"}, want: 2},
		{name: "explicit-node", extra: []string{"NODE_OPTIONS=--no-warnings"}, flags: []string{"--allow-env", "NODE_OPTIONS"}, want: 2},
		{name: "explicit-custom", extra: []string{"CUSTOM=fixture"}, flags: []string{"--allow-env", "CUSTOM"}, want: 2},
		{name: "prefix-lookalike", extra: []string{"CRABBOX_RUN_ID_EXTRA=fixture"}, flags: []string{"--allow-env", "CRABBOX_RUN_ID_EXTRA"}, want: 2},
		{name: "suffix-lookalike", extra: []string{"PREFIX_CRABBOX_RUN_ID=fixture"}, flags: []string{"--allow-env", "PREFIX_CRABBOX_RUN_ID"}, want: 2},
	} {
		rpcBefore, _, _ := gateway.snapshot()
		connectionsBefore := listener.accepted.Load()
		args := []string{"run", "--provider", "wandb", "--no-sync", "--id", "sb-metadata-audit", "--timing-record", "off"}
		args = append(args, tc.flags...)
		args = append(args, "--", "true")
		run := invokeEnv(tc.extra, args...)
		rpcAfter, _, _ := gateway.snapshot()
		connectionsAfter := listener.accepted.Load()
		newRPC := rpcAfter[len(rpcBefore):]
		if run["exitCode"] != tc.want {
			t.Errorf("%s run:%v", tc.name, run)
		}
		if tc.want == 0 {
			if len(newRPC) != 2 || !strings.HasSuffix(newRPC[0], "/List") || !strings.HasSuffix(newRPC[1], "/Exec") {
				t.Errorf("%s unexpected reuse RPCs:%v", tc.name, newRPC)
			}
		} else if len(newRPC) != 0 || connectionsAfter != connectionsBefore || !strings.Contains(run["output"].(string), "cannot forward env vars to an existing sandbox") {
			t.Errorf("%s refusal reached RPC or wrong error:%v %v", tc.name, newRPC, run)
		}
		cases = append(cases, map[string]any{"name": tc.name, "run": run, "newRPC": newRPC, "connectionsBefore": connectionsBefore, "connectionsAfter": connectionsAfter})
	}
	claimsBefore, err := filepath.Glob(filepath.Join(root, "state", "crabbox", "claims", "*.json"))
	if err != nil || len(claimsBefore) != 1 {
		t.Fatalf("owned claim:%v %v", claimsBefore, err)
	}
	var claim map[string]any
	claimBytes, err := os.ReadFile(claimsBefore[0])
	if err != nil {
		t.Fatal(err)
	}
	if err := json.Unmarshal(claimBytes, &claim); err != nil {
		t.Fatal(err)
	}
	gateway.mu.Lock()
	execRequests := append([]json.RawMessage(nil), gateway.execRequests...)
	gateway.mu.Unlock()
	if len(execRequests) != 4 {
		t.Errorf("Exec requests=%d want4", len(execRequests))
	}
	for _, request := range execRequests {
		if strings.Contains(string(request), "CRABBOX_") || strings.Contains(string(request), "NODE_OPTIONS") || strings.Contains(string(request), "environment") {
			t.Errorf("metadata/env appeared in Exec request:%s", request)
		}
	}

	stop := invoke("stop", "--provider", "wandb", "--id", "sb-metadata-audit")
	if stop["exitCode"] != 0 {
		t.Errorf("stop:%v", stop)
	}
	claimsAfter, _ := filepath.Glob(filepath.Join(root, "state", "crabbox", "claims", "*.json"))
	final, present, _ := gateway.snapshot()
	if present || len(claimsAfter) != 0 {
		t.Errorf("cleanup incomplete")
	}
	server.Stop()
	_ = listener.Close()
	select {
	case <-done:
	case <-time.After(time.Second):
		t.Error("server did not stop")
	}
	conn, dialErr := net.DialTimeout("tcp", listener.Addr().String(), time.Second)
	if dialErr == nil {
		conn.Close()
		t.Error("fixture port remained open")
	}
	result := map[string]any{"scope": "actual unmodified CLI+production constructor using existing loopback plaintext mode; gRPC responses are synthetic, no TLS or hosted/native workload claim", "acquire": acquire, "cases": cases, "stop": stop, "startMetadata": startEnv, "initialRPC": before, "execRequests": execRequests, "claimBeforeStop": claim, "finalRPC": final, "finalClaimCount": len(claimsAfter), "finalSandboxPresent": present, "serverStopped": true, "portClosed": dialErr != nil}
	data, _ := json.Marshal(result)
	t.Logf("CLI_METADATA_RECEIPT %s", data)

}
```

</details>
