### PR TITLE
perf: start commands without waiting for telemetry uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Start commands without waiting for best-effort telemetry uploads, and cancel and join the telemetry publisher before run completion or lease replacement while preserving baseline samples and verified terminal receipts.
+
 - Local containers: optionally omit the explicit hostname for runtimes sharing a host UTS namespace, support YAML and environment configuration, and reject incompatible fixed-ID reuse without changing existing default fingerprints. [PR 1813](https://github.com/openclaw/crabbox/pull/1813), [PR 1924](https://github.com/openclaw/crabbox/pull/1924). Thanks @atrawog.
 - Define a strict provider-neutral Linux developer-image recipe whose digest binds the executable contract and exact installer/readiness source hashes.
 - Extract protected image-qualification candidates at the canonical artifact path and avoid protected finalization when deployment never started.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Start commands without waiting for best-effort telemetry uploads, and cancel and join the telemetry publisher before run completion or lease replacement while preserving baseline samples and verified terminal receipts.
+- Start commands without waiting for best-effort telemetry uploads, and cancel and join the telemetry publisher before run completion or lease replacement while preserving baseline samples and verified terminal receipts. [PR 1931](https://github.com/openclaw/crabbox/pull/1931).
 
 - Local containers: optionally omit the explicit hostname for runtimes sharing a host UTS namespace, support YAML and environment configuration, and reject incompatible fixed-ID reuse without changing existing default fingerprints. [PR 1813](https://github.com/openclaw/crabbox/pull/1813), [PR 1924](https://github.com/openclaw/crabbox/pull/1924). Thanks @atrawog.
 - Define a strict provider-neutral Linux developer-image recipe whose digest binds the executable contract and exact installer/readiness source hashes.

--- a/docs/features/telemetry.md
+++ b/docs/features/telemetry.md
@@ -81,10 +81,13 @@ without a sample. Sampling happens in two contexts, both during a run:
    fresh sample, attaches it to the heartbeat body, and lets the coordinator
    update the lease record's `telemetry` snapshot and append to the
    `telemetryHistory` ring.
-2. **Run telemetry.** During the same run the recorder captures a `start`
-   snapshot, then samples on a 15-second ticker and posts each to
-   `POST /v1/runs/{run-id}/telemetry`. The summary is finalized on
-   `POST /v1/runs/{run-id}/finish`, which also records the `end` snapshot.
+2. **Run telemetry.** The recorder captures a `start` snapshot before work.
+   Its sampler publishes that snapshot without blocking command admission,
+   then samples and posts on a 15-second ticker through
+   `POST /v1/runs/{run-id}/telemetry`. Finish, failure, and lease replacement
+   cancel and join the sampler, including an in-flight upload. The summary is
+   finalized on `POST /v1/runs/{run-id}/finish`, which retains the captured
+   baseline even if its upload was cancelled and also records the `end` snapshot.
 
 `crabbox status` does not collect a fresh sample itself — it displays the
 `telemetry` snapshot already stored on the lease record (most recently written

--- a/internal/cli/run_recorder.go
+++ b/internal/cli/run_recorder.go
@@ -156,7 +156,6 @@ func (r *runRecorder) CaptureTelemetryStart(ctx context.Context, target SSHTarge
 	}
 	r.telemetryStart = collectLeaseTelemetryBestEffort(contextWithoutWorkspaceOwner(ctx), leaseTelemetryCollectorForTarget(target))
 	r.recordTelemetrySample(r.telemetryStart)
-	r.appendTelemetryBestEffort(r.telemetryStart)
 }
 
 func (r *runRecorder) StartTelemetrySampler(ctx context.Context, target SSHTarget) {
@@ -175,16 +174,20 @@ func (r *runRecorder) StartTelemetrySampler(ctx context.Context, target SSHTarge
 	r.telemetryMu.Unlock()
 
 	collector := leaseTelemetryCollectorForTarget(target)
+	initial := r.telemetryStart
 	go func() {
 		defer close(done)
 		ticker := time.NewTicker(runTelemetrySampleInterval)
 		defer ticker.Stop()
+		// Preserve the pre-command baseline without making workload admission wait
+		// for its best-effort publication. This owner also joins it before finish.
+		r.appendTelemetryBestEffort(sampleCtx, initial)
 		for {
 			select {
 			case <-ticker.C:
 				sample := collectLeaseTelemetryBestEffort(sampleCtx, collector)
 				r.recordTelemetrySample(sample)
-				r.appendTelemetryBestEffort(sample)
+				r.appendTelemetryBestEffort(sampleCtx, sample)
 			case <-sampleCtx.Done():
 				return
 			}
@@ -344,13 +347,13 @@ func (r *runRecorder) telemetrySnapshot() []*LeaseTelemetry {
 	return samples
 }
 
-func (r *runRecorder) appendTelemetryBestEffort(sample *LeaseTelemetry) {
+func (r *runRecorder) appendTelemetryBestEffort(ctx context.Context, sample *LeaseTelemetry) {
 	if r == nil || r.coord == nil || r.runID == "" || sample == nil {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	postCtx, cancel := context.WithTimeout(ctx, runRecorderRequestTimeout)
 	defer cancel()
-	if _, err := r.coord.AppendRunTelemetry(ctx, r.runID, sample); err != nil && !isCoordinatorNotFoundError(err) {
+	if _, err := r.coord.AppendRunTelemetry(postCtx, r.runID, sample); err != nil && ctx.Err() == nil && !isCoordinatorNotFoundError(err) {
 		r.warn("run telemetry append failed for %s: %v", r.runID, err)
 	}
 }
@@ -369,10 +372,7 @@ func (r *runRecorder) stopTelemetrySampler() {
 		return
 	}
 	cancel()
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-	}
+	<-done
 }
 
 func (r *runRecorder) resetTelemetryForLeaseReplacement() {

--- a/internal/cli/run_recorder_test.go
+++ b/internal/cli/run_recorder_test.go
@@ -40,6 +40,7 @@ func TestRunRecorderCapturesTelemetryOnlyWithRunHandle(t *testing.T) {
 			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 			t.Setenv("CRABBOX_FAKE_TELEMETRY_CALLS", callsPath)
 			posts := 0
+			posted := make(chan struct{}, 1)
 			var client *CoordinatorClient
 			if test.coordinator {
 				client = &CoordinatorClient{BaseURL: "https://example.test", Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -53,6 +54,7 @@ func TestRunRecorderCapturesTelemetryOnlyWithRunHandle(t *testing.T) {
 						t.Fatalf("telemetry=%+v error=%v", body.Telemetry, err)
 					}
 					posts++
+					posted <- struct{}{}
 					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"run":{"id":"run_123"}}`)), Header: make(http.Header)}, nil
 				})}}
 			}
@@ -61,6 +63,12 @@ func TestRunRecorderCapturesTelemetryOnlyWithRunHandle(t *testing.T) {
 			target := SSHTarget{User: "runner", Host: "example.test", Port: "22", FallbackPorts: []string{}}
 			rec.CaptureTelemetryStart(t.Context(), target)
 			rec.CaptureTelemetryStart(t.Context(), target)
+			rec.StartTelemetrySampler(t.Context(), target)
+			rec.StartTelemetrySampler(t.Context(), target)
+			if test.runID != "" {
+				<-posted
+			}
+			rec.stopTelemetrySampler()
 			calls, err := os.ReadFile(callsPath)
 			if test.runID == "" {
 				if !os.IsNotExist(err) || posts != 0 || rec.telemetryStart != nil || len(rec.telemetrySnapshot()) != 0 {
@@ -69,6 +77,197 @@ func TestRunRecorderCapturesTelemetryOnlyWithRunHandle(t *testing.T) {
 			} else if err != nil || string(calls) != "telemetry\n" || posts != 1 || len(rec.telemetrySnapshot()) != 1 {
 				t.Fatalf("recorded run needs one start sample: SSH=%q posts=%d error=%v", calls, posts, err)
 			}
+		})
+	}
+}
+
+func TestRunRecorderTelemetryUploadDoesNotBlockCommandAdmission(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell ssh fixture")
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte("#!/bin/sh\nprintf 'cpuCount=2\\n'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	synctest.Test(t, func(t *testing.T) {
+		posting := make(chan struct{})
+		release := make(chan struct{})
+		client := &CoordinatorClient{BaseURL: "https://example.test", Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodPost || req.URL.Path != "/v1/runs/run_123/telemetry" {
+				return nil, fmt.Errorf("unexpected request %s %s", req.Method, req.URL.Path)
+			}
+			close(posting)
+			<-release
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"run":{"id":"run_123"}}`)), Header: make(http.Header)}, nil
+		})}}
+		rec := newRunRecorder(t.Context(), client, Config{}, []string{"true"}, "", io.Discard, true)
+		rec.runID = "run_123"
+		target := SSHTarget{User: "runner", Host: "example.test", Port: "22", FallbackPorts: []string{}}
+		admitted := make(chan struct{})
+		go func() {
+			rec.CaptureTelemetryStart(t.Context(), target)
+			rec.StartTelemetrySampler(t.Context(), target)
+			close(admitted)
+		}()
+		<-posting
+		synctest.Wait()
+		select {
+		case <-admitted:
+		default:
+			t.Error("best-effort telemetry upload blocked command admission")
+		}
+		close(release)
+		<-admitted
+		rec.stopTelemetrySampler()
+		if rec.telemetryStart == nil || len(rec.telemetrySnapshot()) != 1 {
+			t.Fatal("command admission lost the pre-command telemetry baseline")
+		}
+	})
+}
+
+func TestRunRecorderSlowInitialUploadPreservesSamplingCadence(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell ssh fixture")
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte("#!/bin/sh\nprintf 'cpuCount=2\\n'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	synctest.Test(t, func(t *testing.T) {
+		started := time.Now()
+		var posts []time.Duration
+		sampled := make(chan struct{})
+		client := &CoordinatorClient{BaseURL: "https://example.test", Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			posts = append(posts, time.Since(started))
+			if len(posts) == 1 {
+				time.Sleep(5 * time.Second)
+			} else {
+				close(sampled)
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"run":{"id":"run_123"}}`)), Header: make(http.Header)}, nil
+		})}}
+		rec := &runRecorder{coord: client, runID: "run_123", stderr: io.Discard, telemetryStart: &LeaseTelemetry{CapturedAt: "2026-05-02T00:00:00Z"}}
+		rec.StartTelemetrySampler(t.Context(), SSHTarget{User: "runner", Host: "example.test", Port: "22", FallbackPorts: []string{}})
+		<-sampled
+		rec.stopTelemetrySampler()
+		if len(posts) != 2 || posts[0] != 0 || posts[1] != runTelemetrySampleInterval {
+			t.Fatalf("telemetry publication shifted sampling cadence: %v", posts)
+		}
+	})
+}
+
+func TestRunRecorderJoinsTelemetryBeforeTerminalOrReplacement(t *testing.T) {
+	for _, action := range []string{"finish", "failed", "replacement"} {
+		t.Run(action, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				posting := make(chan struct{})
+				cancelled := make(chan struct{})
+				release := make(chan struct{})
+				var samplerDone <-chan struct{}
+				receipt := runRecorderTestReceipt(t)
+				baseline := &LeaseTelemetry{CapturedAt: "2026-05-02T00:00:00Z"}
+				var terminalCalls []string
+				client := &CoordinatorClient{BaseURL: "https://example.test", Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					if req.URL.Path == "/v1/runs/run_123/telemetry" {
+						close(posting)
+						<-req.Context().Done()
+						close(cancelled)
+						// Cancellation alone is not a join: the transport still owns work.
+						<-release
+						return nil, req.Context().Err()
+					}
+					select {
+					case <-samplerDone:
+					default:
+						t.Error("terminal publication overtook the telemetry owner")
+					}
+					terminalCalls = append(terminalCalls, req.URL.Path)
+					body := `{"run":{"id":"run_123"}}`
+					switch req.URL.Path {
+					case "/v1/runs/run_123/finish":
+						var input struct {
+							Telemetry *RunTelemetrySummary `json:"telemetry"`
+						}
+						if err := json.NewDecoder(req.Body).Decode(&input); err != nil || input.Telemetry == nil || input.Telemetry.Start == nil || *input.Telemetry.Start != *baseline {
+							t.Errorf("terminal summary lost baseline: %+v, error=%v", input.Telemetry, err)
+						}
+					case "/v1/runs/run_123/receipt":
+						encoded, _ := json.Marshal(map[string]any{"receipt": receipt})
+						body = string(encoded)
+					case "/v1/runs/run_123/events":
+						body = `{"event":{"runID":"run_123","seq":1,"type":"run.failed"}}`
+					default:
+						t.Errorf("unexpected request %s %s", req.Method, req.URL.Path)
+					}
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+				})}}
+				rec := &runRecorder{coord: client, runID: "run_123", stderr: io.Discard, telemetryStart: baseline, telemetrySamples: []*LeaseTelemetry{baseline}}
+				rec.StartTelemetrySampler(t.Context(), SSHTarget{})
+				samplerDone = rec.telemetryDone
+				<-posting
+				completed := make(chan struct{})
+				go func() {
+					defer close(completed)
+					switch action {
+					case "finish":
+						if err := rec.Finish(t.Context(), SSHTarget{}, 1, 0, 0, "", false, nil, FailureClassification{}, &receipt); err != nil {
+							t.Errorf("Finish: %v", err)
+						}
+					case "failed":
+						rec.Failed(errors.New("command preparation failed"))
+					case "replacement":
+						rec.resetTelemetryForLeaseReplacement()
+					}
+				}()
+				<-cancelled
+				time.Sleep(2 * time.Second)
+				select {
+				case <-completed:
+					t.Error("operation returned while telemetry publication was still owned")
+				default:
+				}
+				close(release)
+				<-completed
+				select {
+				case <-samplerDone:
+				default:
+					t.Fatal("telemetry sampler was not joined")
+				}
+				if rec.warned {
+					t.Error("normal sampler cancellation consumed the diagnostic warning slot")
+				}
+				if action == "finish" && (len(terminalCalls) != 2 || terminalCalls[0] != "/v1/runs/run_123/finish" || terminalCalls[1] != "/v1/runs/run_123/receipt" || !rec.finished) {
+					t.Fatalf("terminal receipt was not committed and verified: %v", terminalCalls)
+				}
+				if action == "replacement" && (rec.telemetryStart != nil || len(rec.telemetrySnapshot()) != 0 || rec.telemetryDone != nil || len(terminalCalls) != 0) {
+					t.Fatal("replacement retained the old telemetry owner or samples")
+				}
+				if action == "replacement" {
+					nextPosted := make(chan struct{})
+					next := &LeaseTelemetry{CapturedAt: "2026-05-02T00:01:00Z"}
+					rec.UseCoordinator(&CoordinatorClient{BaseURL: "https://replacement.test", Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						var input struct {
+							Telemetry LeaseTelemetry `json:"telemetry"`
+						}
+						if err := json.NewDecoder(req.Body).Decode(&input); err != nil || input.Telemetry != *next || req.URL.Path != "/v1/runs/run_456/telemetry" {
+							t.Errorf("replacement published an old sample or run: %+v, error=%v", input.Telemetry, err)
+						}
+						close(nextPosted)
+						return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"run":{"id":"run_456"}}`)), Header: make(http.Header)}, nil
+					})}})
+					rec.runID = "run_456"
+					rec.telemetryStart = next
+					rec.recordTelemetrySample(next)
+					rec.StartTelemetrySampler(t.Context(), SSHTarget{})
+					<-nextPosted
+					rec.stopTelemetrySampler()
+					if samples := rec.telemetrySnapshot(); len(samples) != 1 || samples[0] != next {
+						t.Fatal("replacement sample set contains old lease telemetry")
+					}
+				}
+			})
 		})
 	}
 }

--- a/internal/providers/opensandbox/backend_test.go
+++ b/internal/providers/opensandbox/backend_test.go
@@ -562,13 +562,15 @@ func TestRunDoesNotPublishClaimWhenCreationLockIsCanceled(t *testing.T) {
 	}
 	defer unlock()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
+	// Cancellation must follow creation so this case reaches unpublished-sandbox rollback.
+	fake.afterCreate = cancel
 	_, err = backend.Run(ctx, RunRequest{
 		Repo: Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"},
 	})
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("err=%v, want operation lock deadline", err)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v, want operation lock cancellation", err)
 	}
 	if len(fake.deleted) != 1 || fake.deleted[0] != fake.sandbox.ID {
 		t.Fatalf("deleted=%#v want unpublished sandbox rollback", fake.deleted)
@@ -2842,6 +2844,7 @@ type fakeOpenSandboxClient struct {
 	listEmptyCount       int
 	listErr              error
 	listErrCount         int
+	afterCreate          func()
 	afterResume          func()
 	afterRun             func(runCommandRequest)
 	runStarted           chan struct{}
@@ -2880,6 +2883,9 @@ func (f *fakeOpenSandboxClient) CreateSandbox(_ context.Context, req createSandb
 	}
 	if f.createErr != nil {
 		return sandboxInfo{}, f.createErr
+	}
+	if f.afterCreate != nil {
+		f.afterCreate()
 	}
 	return created, nil
 }


### PR DESCRIPTION
## Summary

Commands synchronously waited for the first best-effort telemetry upload after capturing their resource baseline. A slow telemetry endpoint could therefore delay workload admission even though an upload failure did not prevent execution.

Keep baseline capture before work, but publish it through the existing sampler. Start the 15-second ticker before publication, derive each upload's timeout from the sampler context, and cancel and fully join the sampler before finish, failure, or lease replacement. This also removes the one-second wait that could let an upload outlive its owner. Terminal event handling, baseline retention, and signed receipt verification remain with their existing owners.

## Validation

- The blocked-upload admission regression fails on the original code and passes after the repair. Virtual-time coverage also proves the first periodic sample remains at 15 seconds after a slow initial upload.
- Race-tested owner coverage verifies cancellation while the transport still owns work, joins before finish/failure/replacement, duplicate starts, the retained terminal baseline, exact signed receipt commit/verification, and isolation of the next run's samples.
- `go vet ./...`, baseline/candidate builds with Go 1.26.5, and independent P0–P2 review pass.
- A real AWS comparison used one fixed `c7a.8xlarge` lease in `eu-west-1`, the same working directory/configuration and identical harmless no-sync commands. Both normal commands completed, both signed receipts verified, and both stored run summaries retained Linux baseline samples (32 CPUs; two samples each). Canonical Stop confirmed released/cleanup-complete; all command processes joined, SSH control sockets were absent, and operator configuration was unchanged.
- Observed command-preparation phase: 5.366s → 4.766s; runner total: 17.172s → 16.344s; process wall time: 18.323s → 18.158s. This single pair is noisy and is not a general speed benchmark. The controlled blocked-upload regression proves removal of the admission dependency.

Live source provenance: baseline `4e3df6dfc42a49bd665a92b2e2756b909122c8c3`, candidate with telemetry patch SHA-256 `7df3fbc3976486164ab4f4e1f038626519322b023ab8d00ef077dddabc0c2633`. Both were task-built development binaries, not signed releases. The later fixture-only commit does not alter production bytes.

## CI follow-through

The local full race run first used Go's default ten-minute package budget; the rerun used the repository's prescribed `go test -race -timeout=20m ./...`. Both exceeded the aggregate CLI-package budget while progressing through other fixtures. Those local failures are retained. Linux CI subsequently passed on `d568627e629edd2f971f62394efc95ddd5ee6114`, including the full Go test step. Final head `d7396168246ccc3c9ad712fae3beaca0d2704c8a` adds only the changelog PR reference. Its exact-head CI also passed without retries: all 11 jobs succeeded, including the full Go race step in 19m15s. The final independent bot review reports no remaining findings.

The full run also exposed an unchanged OpenSandbox test race, reproduced on the clean baseline: its 20ms deadline could expire before sandbox creation, making its expected rollback deletion invalid. The fixture now cancels only after successful fake creation. It retains the real held lock, exact one-delete assertion, and no-published-claim assertion; existing coverage still tests timed lock cancellation. Its exact regression, full OpenSandbox race package, and independent P2 review pass. Provider production code is unchanged.

Production delta: 9 added / 9 removed (net zero). Docs and the Unreleased changelog describe the behavior. The existing telemetry API and stored representation are unchanged; no migration or configuration option is introduced.
