### PR TITLE
refactor: share public exit-code selection

### DIFF
--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -225,7 +225,7 @@ func (a App) actionsHydrate(ctx context.Context, args []string) (err error) {
 			}
 			return nil
 		} else {
-			return exit(exitCodeForError(err, 7), "local Actions hydration failed for %s: %v; rerun with --github-runner when the workflow needs full GitHub Actions semantics", leaseID, err)
+			return exit(ExitCodeForError(err, 7), "local Actions hydration failed for %s: %v; rerun with --github-runner when the workflow needs full GitHub Actions semantics", leaseID, err)
 		}
 	}
 	ghRepo, err := resolveGitHubRepo(repo, cfg.Actions.Repo)
@@ -517,14 +517,6 @@ func dispatchGitHubActionsWorkflow(ctx context.Context, dir string, repo GitHubR
 		cmdArgs = append(cmdArgs, "-f", field)
 	}
 	return runGHWithChildEnvironment(ctx, dir, childEnvDenylist, cmdArgs...)
-}
-
-func exitCodeForError(err error, fallback int) int {
-	var exitErr ExitError
-	if AsExitError(err, &exitErr) && exitErr.Code != 0 {
-		return exitErr.Code
-	}
-	return fallback
 }
 
 type localActionsHydrationPlan struct {

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -17,6 +18,59 @@ import (
 
 	"gopkg.in/yaml.v3"
 )
+
+type exitCodeSelectionAsError struct{ code int }
+
+func (e exitCodeSelectionAsError) Error() string { return "adapted public exit" }
+
+func (e exitCodeSelectionAsError) As(target any) bool {
+	public, ok := target.(*ExitError)
+	if ok {
+		*public = ExitError{Code: e.code, Message: e.Error()}
+	}
+	return ok
+}
+
+// Preserve the behavior characterized before moving the selector to its shared owner.
+func TestExitCodeForErrorCompatibility(t *testing.T) {
+	public := ExitError{Code: 69, Message: "typed public exit"}
+	zero := ExitError{Code: 0, Message: "zero public exit"}
+	signed := ExitError{Code: -1, Message: "signed public exit"}
+	ordinary := errors.New("ordinary error")
+	var nilPublic *ExitError
+	for _, tc := range []struct {
+		name           string
+		err            error
+		fallback, want int
+	}{
+		{name: "nil with zero fallback", fallback: 0, want: 0},
+		{name: "nil with nonzero fallback", fallback: 7, want: 7},
+		{name: "ordinary error", err: ordinary, fallback: 7, want: 7},
+		{name: "signed fallback", err: ordinary, fallback: -9, want: -9},
+		{name: "nonzero value", err: public, fallback: 1, want: 69},
+		{name: "signed value", err: signed, fallback: 1, want: -1},
+		{name: "zero value", err: zero, fallback: 7, want: 7},
+		{name: "zero value with zero fallback", err: zero, fallback: 0, want: 0},
+		{name: "wrapped value", err: fmt.Errorf("wrapped: %w", public), fallback: 1, want: 69},
+		{name: "wrapped zero value", err: fmt.Errorf("wrapped: %w", zero), fallback: 7, want: 7},
+		{name: "pointer is not a value target", err: &public, fallback: 7, want: 7},
+		{name: "wrapped pointer is not a value target", err: fmt.Errorf("wrapped: %w", &public), fallback: 7, want: 7},
+		{name: "typed nil pointer", err: nilPublic, fallback: 7, want: 7},
+		{name: "custom As", err: exitCodeSelectionAsError{code: 69}, fallback: 1, want: 69},
+		{name: "wrapped custom As", err: fmt.Errorf("wrapped: %w", exitCodeSelectionAsError{code: 69}), fallback: 1, want: 69},
+		{name: "zero custom As", err: exitCodeSelectionAsError{}, fallback: 7, want: 7},
+		{name: "joined first public value", err: errors.Join(ExitError{Code: 23}, public), fallback: 1, want: 23},
+		{name: "joined first zero does not search later values", err: errors.Join(zero, public), fallback: 7, want: 7},
+		{name: "joined ordinary then public value", err: errors.Join(ordinary, public), fallback: 1, want: 69},
+		{name: "joined signed first value", err: errors.Join(signed, public), fallback: 1, want: -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ExitCodeForError(tc.err, tc.fallback); got != tc.want {
+				t.Fatalf("ExitCodeForError fallback=%d: got %d, want %d", tc.fallback, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestParseGitHubRepo(t *testing.T) {
 	tests := map[string]string{

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -15,6 +15,16 @@ func AsExitError(err error, target *ExitError) bool {
 	return errors.As(err, target)
 }
 
+// ExitCodeForError returns the first matched ExitError's nonzero code, or fallback.
+// Nil errors and matched zero codes use fallback; signed codes are preserved.
+func ExitCodeForError(err error, fallback int) int {
+	var exitErr ExitError
+	if AsExitError(err, &exitErr) && exitErr.Code != 0 {
+		return exitErr.Code
+	}
+	return fallback
+}
+
 func exit(code int, format string, args ...any) ExitError {
 	return ExitError{Code: code, Message: sprintf(format, args...)}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -507,7 +507,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 		cleanup.apply(&report)
 		if err != nil && report.ExitCode == 0 {
-			report.ExitCode = exitCodeForError(err, 7)
+			report.ExitCode = ExitCodeForError(err, 7)
 			report.RunStatus = ""
 			report.ErrorKind = ""
 		}
@@ -1077,7 +1077,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 				finalFailure = err
 			}
 			if finalResult.ExitCode == 0 && finalFailure != nil {
-				finalResult.ExitCode = exitCodeForError(finalFailure, 7)
+				finalResult.ExitCode = ExitCodeForError(finalFailure, 7)
 			}
 			if delegatedPreparationAttempted && preparedDelegatedExitCode == finalResult.ExitCode {
 				return
@@ -1560,7 +1560,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if finalTimingReport != nil || (!*timingJSON && !timingRecordEnabled) {
 			return
 		}
-		report := timingReportFromRunWithActionsURL(cfg.Provider, leaseID, serverSlug(server), timings, time.Since(timings.started), exitCodeForError(err, 7), actionsURL)
+		report := timingReportFromRunWithActionsURL(cfg.Provider, leaseID, serverSlug(server), timings, time.Since(timings.started), ExitCodeForError(err, 7), actionsURL)
 		populateRunTimingMetadata(&report, cfg, repo, server, leaseID, executionRunID, workdir, nil)
 		report.Label = runLabelValue
 		finalTimingReport = &report
@@ -2307,7 +2307,7 @@ afterSync:
 			finalCode := 0
 			classification := FailureClassification{}
 			if finalFailure != nil {
-				finalCode = exitCodeForError(finalFailure, 7)
+				finalCode = ExitCodeForError(finalFailure, 7)
 				classification = ClassifyRunFailure(finalCode, finalFailure.Error(), nil)
 			}
 			if finishErr := recorder.Finish(ctx, target, finalCode, timings.sync, 0, "", false, nil, classification, nil); finishErr != nil {
@@ -2604,7 +2604,7 @@ afterSync:
 			finalFailure = err
 		}
 		if finalCode == 0 && finalFailure != nil {
-			finalCode = exitCodeForError(finalFailure, 7)
+			finalCode = ExitCodeForError(finalFailure, 7)
 		}
 		if recorder.runID == "" && attestPath == "" {
 			return
@@ -2662,7 +2662,7 @@ afterSync:
 			if localReceiptPersisted && attestPath != "" && preparedTerminalReceipt.ExitCode == 0 {
 				// The coordinator commit is now ambiguous. Preserve the exact receipt
 				// sent remotely, but make the local CLI failure impossible to miss.
-				failedReceipt, receiptErr := buildTerminalReceipt(exitCodeForError(finishErr, 7))
+				failedReceipt, receiptErr := buildTerminalReceipt(ExitCodeForError(finishErr, 7))
 				if receiptErr != nil {
 					err = errors.Join(err, receiptErr)
 					recordRunFailure(&runFailure, receiptErr)

--- a/internal/cli/run_artifact_change_test.go
+++ b/internal/cli/run_artifact_change_test.go
@@ -39,7 +39,7 @@ func TestRunArtifactChangeRejectsBlankPathBeforeNormalization(t *testing.T) {
 			isolateRunTestUserDirs(t, dir)
 			t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "config.yaml"))
 			err := (App{Stdout: io.Discard, Stderr: io.Discard}).runCommand(context.Background(), []string{"--provider", "run-env-profile-test", "--require-artifact-change", p, "--", "true"})
-			if exitCodeForError(err, 0) != 2 || !strings.Contains(fmt.Sprint(err), "--require-artifact-change") {
+			if ExitCodeForError(err, 0) != 2 || !strings.Contains(fmt.Sprint(err), "--require-artifact-change") {
 				t.Fatalf("invalid exact path was normalized away: %v", err)
 			}
 		})
@@ -191,7 +191,7 @@ func TestRunArtifactChangeRejectsUnsupportedRoutes(t *testing.T) {
 			var stderr bytes.Buffer
 			args := append(append([]string{}, flags...), "--require-artifact-change", "proof", "--", "true")
 			err := (App{Stdout: io.Discard, Stderr: &stderr}).runCommand(context.Background(), args)
-			if exitCodeForError(err, 0) != 2 || !strings.Contains(fmt.Sprint(err), "--require-artifact-change") {
+			if ExitCodeForError(err, 0) != 2 || !strings.Contains(fmt.Sprint(err), "--require-artifact-change") {
 				t.Fatalf("err=%v stderr=%s", err, stderr.String())
 			}
 		})
@@ -323,7 +323,7 @@ exit 0
 			}
 			args = append(args, "--", "sh", "-c", command)
 			err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), args)
-			if exitCodeForError(err, 0) != tc.code {
+			if ExitCodeForError(err, 0) != tc.code {
 				t.Fatalf("err=%v stdout=%s stderr=%s", err, stdout.String(), stderr.String())
 			}
 			if strings.HasSuffix(tc.name, "before nested JUnit") {

--- a/internal/cli/run_failure_download_test.go
+++ b/internal/cli/run_failure_download_test.go
@@ -210,7 +210,7 @@ func TestFailureDownloadPreflight(t *testing.T) {
 			t.Cleanup(func() { runEnvProfileTestAcquireHook = nil })
 			args := append(append([]string{}, flags...), "--download-on-failure", "proof=out", "--", "true")
 			err := (App{Stdout: io.Discard, Stderr: io.Discard}).runCommand(context.Background(), args)
-			if exitCodeForError(err, 0) != 2 || acquired {
+			if ExitCodeForError(err, 0) != 2 || acquired {
 				t.Fatalf("preflight err=%v acquired=%t", err, acquired)
 			}
 		})
@@ -295,7 +295,7 @@ exit 0
 			command := fmt.Sprintf("mkdir -p reports; printf first > reports/first.json; printf second > reports/second.json; printf output; printf diagnostic >&2; exit %d", workloadCode)
 			var stdout, stderr bytes.Buffer
 			err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{"--provider", "run-env-profile-test", "--no-sync", "--stop-after", "always", "--download-on-failure", "reports/first.json=" + first, "--download-on-failure", "reports/missing.json=" + missing, "--download-on-failure", "reports/second.json=" + second, "--download", "reports/first.json=" + success, "--shell", "--", command})
-			if exitCodeForError(err, 0) != tc.code {
+			if ExitCodeForError(err, 0) != tc.code {
 				t.Fatalf("err=%v stderr=%s", err, stderr.String())
 			}
 			for file, want := range map[string]string{first: "first", second: "second"} {

--- a/internal/cli/run_lease_output_test.go
+++ b/internal/cli/run_lease_output_test.go
@@ -59,7 +59,7 @@ func TestRunCommandRejectsLeaseOutputCollisionsBeforeAcquire(t *testing.T) {
 					"--provider", "local-container", "--keep", "--stop-after", "never",
 					"--lease-output", " " + lease + " ", flag, value, "--", "true",
 				})
-				if exitCodeForError(err, 0) != 2 || !strings.Contains(fmt.Sprint(err), "lease output/") || !strings.Contains(fmt.Sprint(err), "paths must be different") || calls != 0 {
+				if ExitCodeForError(err, 0) != 2 || !strings.Contains(fmt.Sprint(err), "lease output/") || !strings.Contains(fmt.Sprint(err), "paths must be different") || calls != 0 {
 					t.Fatalf("error=%v acquisition calls=%d; want collision before acquisition", err, calls)
 				}
 				for _, path := range []string{lease, other} {
@@ -100,7 +100,7 @@ exec sh -c "$cmd"
 				"--lease-output", lease, flag, "report=" + report,
 				"--shell", "--", fmt.Sprintf("printf evidence > report; exit %d", code),
 			})
-			if exitCodeForError(err, 0) != code {
+			if ExitCodeForError(err, 0) != code {
 				t.Fatalf("run: %v\n%s", err, stderr.String())
 			}
 			session, _, _ := readRunSessionHandleTest(t, lease)

--- a/internal/cli/run_script_test.go
+++ b/internal/cli/run_script_test.go
@@ -343,7 +343,7 @@ exec sh -c "$cmd"
 			if mode == "failed-upload" {
 				wantCode = 7
 			}
-			if exitCodeForError(runErr, 0) != wantCode || releases != 0 {
+			if ExitCodeForError(runErr, 0) != wantCode || releases != 0 {
 				t.Fatalf("failure=%v releases=%d\n%s", runErr, releases, stderr.String())
 			}
 			bundles, err := filepath.Glob(filepath.Join(".crabbox", "captures", "*.tar.gz"))

--- a/internal/cli/run_ssh_script_test.go
+++ b/internal/cli/run_ssh_script_test.go
@@ -190,7 +190,7 @@ printf 'script-err\n' >&2
 			}
 			args = append(args, "--", "literal $arg; with spaces", "single quote ' argument")
 			err := app.runCommand(t.Context(), args)
-			if exitCodeForError(err, 0) != tc.code {
+			if ExitCodeForError(err, 0) != tc.code {
 				t.Fatalf("run=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
 			}
 			if b.acquired != 1 || len(b.requests) != 0 || b.starts != 1 || b.joined != 1 {
@@ -248,7 +248,7 @@ func TestHybridSSHScriptRejectsInvalidRouteBeforeInputOrActivity(t *testing.T) {
 			b.spec = p.spec
 			input := strings.NewReader("must remain unread")
 			err := (App{Stdout: io.Discard, Stderr: io.Discard, Stdin: input}).runCommand(t.Context(), []string{"--provider", p.Name(), "--no-sync", "--script-stdin"})
-			if exitCodeForError(err, 0) != 2 || !strings.Contains(err.Error(), "SSH") || input.Len() != len("must remain unread") || b.acquired != 0 || b.starts != 0 {
+			if ExitCodeForError(err, 0) != 2 || !strings.Contains(err.Error(), "SSH") || input.Len() != len("must remain unread") || b.acquired != 0 || b.starts != 0 {
 				t.Fatalf("error=%v unread=%d acquired=%d activity=%d", err, input.Len(), b.acquired, b.starts)
 			}
 		})
@@ -263,7 +263,7 @@ func TestHybridSSHScriptPrewarmAdmissionUsesScriptRoute(t *testing.T) {
 		t.Fatal(err)
 	}
 	p.spec.Features = FeatureSet{FeatureSSH, FeatureSSHScriptRun, FeatureModuleRun}
-	if err := admitPrewarmProbe(args); exitCodeForError(err, 0) != 2 {
+	if err := admitPrewarmProbe(args); ExitCodeForError(err, 0) != 2 {
 		t.Fatalf("invalid route accepted: %v", err)
 	}
 	if b.acquired != 0 || b.starts != 0 || len(b.requests) != 0 {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -4541,8 +4541,8 @@ exit 0
 	if decodeErr != nil {
 		t.Fatalf("decode terminal receipt: %v", decodeErr)
 	}
-	if receipt.ExitCode != exitCodeForError(err, 7) || receipt.ExitCode == 0 {
-		t.Fatalf("receipt exit=%d want=%d run error=%v", receipt.ExitCode, exitCodeForError(err, 7), err)
+	if receipt.ExitCode != ExitCodeForError(err, 7) || receipt.ExitCode == 0 {
+		t.Fatalf("receipt exit=%d want=%d run error=%v", receipt.ExitCode, ExitCodeForError(err, 7), err)
 	}
 	if !strings.Contains(stderr.String(), "artifact kind=receipt") {
 		t.Fatalf("missing terminal receipt output:\n%s", stderr.String())

--- a/internal/cli/shard.go
+++ b/internal/cli/shard.go
@@ -303,7 +303,7 @@ func (a App) shardRun(ctx context.Context, opts shardOptions, mux *shardOutputMu
 					mux.printf(a.Stderr, "shard %d/%d canceled\n", index, opts.Count)
 					return
 				}
-				results[index-1] = shardResult{Index: index, Slug: slug, ExitCode: shardErrorExitCode(err), Err: err}
+				results[index-1] = shardResult{Index: index, Slug: slug, ExitCode: ExitCodeForError(err, 1), Err: err}
 				mux.printf(a.Stderr, "shard %d/%d failed error=%q\n", index, opts.Count, err.Error())
 				if opts.FailFast {
 					cancel()
@@ -323,7 +323,7 @@ func (a App) shardRun(ctx context.Context, opts shardOptions, mux *shardOutputMu
 			if outcome.Recorded {
 				result.ExitCode = outcome.ExitCode
 			} else {
-				result.ExitCode = shardErrorExitCode(err)
+				result.ExitCode = ExitCodeForError(err, 1)
 				if err == nil {
 					err = errors.New("run finished without recording an outcome")
 				}
@@ -362,14 +362,6 @@ func (a App) printShardStatus(mux *shardOutputMux, opts shardOptions, result sha
 		return
 	}
 	mux.printf(a.Stderr, "shard %d/%d done exit=%d\n", result.Index, opts.Count, result.ExitCode)
-}
-
-func shardErrorExitCode(err error) int {
-	var exitErr ExitError
-	if AsExitError(err, &exitErr) && exitErr.Code != 0 {
-		return exitErr.Code
-	}
-	return 1
 }
 
 func shardRunArgs(leaseID string, index, total int, runArgs, command []string) []string {

--- a/internal/providers/applemachine/backend.go
+++ b/internal/providers/applemachine/backend.go
@@ -306,11 +306,7 @@ func (b *backend) createLease(ctx context.Context, repo Repo, reclaim bool, requ
 		return core.LeaseClaim{}, fmt.Errorf("%w; retained machine=%s lease=%s: inspect container machine inspect %s before manual cleanup", err, name, leaseID, shellQuote(name))
 	}
 	retainedAfterRollback := func(primary, cleanup error) (core.LeaseClaim, error) {
-		code := 1
-		var public core.ExitError
-		if errors.As(primary, &public) && public.Code != 0 {
-			code = public.Code
-		}
+		code := core.ExitCodeForError(primary, 1)
 		_, combined := retained(errors.Join(primary, cleanup))
 		return core.LeaseClaim{}, shared.ExitErrorWithCause(code, combined.Error(), combined)
 	}

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -247,7 +247,7 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 	if artifactErr != nil {
 		fmt.Fprintf(b.rt.Stderr, "blacksmith artifact retrieval failed: %v\n", artifactErr)
 		if code == 0 {
-			code = blacksmithArtifactFailureExitCode(artifactErr)
+			code = core.ExitCodeForError(artifactErr, 7)
 		}
 	}
 	if closeErr := stdoutCapture.Close(); closeErr != nil && code == 0 {
@@ -374,14 +374,6 @@ func printBlacksmithOneShotActionsWarning(w io.Writer, actionsURL string) {
 		fmt.Fprintf(w, " actions=%s", strings.TrimSpace(actionsURL))
 	}
 	fmt.Fprintln(w)
-}
-
-func blacksmithArtifactFailureExitCode(err error) int {
-	var exitErr ExitError
-	if core.AsExitError(err, &exitErr) && exitErr.Code != 0 {
-		return exitErr.Code
-	}
-	return 7
 }
 
 func blacksmithExtractArtifactArchive(output string, maxBytes int64) ([]byte, string, error) {

--- a/internal/providers/coder/backend.go
+++ b/internal/providers/coder/backend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -136,7 +136,7 @@ func (b *coderLeaseBackend) rollbackCreatedWorkspace(name, leaseID string, clien
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	if err := b.releaseWorkspace(cleanupCtx, client, name); err != nil {
-		return exit(coderExitCode(cause), "%v; coder rollback %s failed for workspace %s; manual cleanup: %s: %v", cause, coderReleaseActionFromConfig(b.cfg), name, coderManualCleanupCommand(b.cfg, name), err)
+		return exit(core.ExitCodeForError(cause, 1), "%v; coder rollback %s failed for workspace %s; manual cleanup: %s: %v", cause, coderReleaseActionFromConfig(b.cfg), name, coderManualCleanupCommand(b.cfg, name), err)
 	}
 	removeLeaseClaim(leaseID)
 	return cause
@@ -147,14 +147,6 @@ func (b *coderLeaseBackend) releaseWorkspace(ctx context.Context, client *coderC
 		return client.delete(ctx, name)
 	}
 	return client.stop(ctx, name)
-}
-
-func coderExitCode(err error) int {
-	var exitErr ExitError
-	if errors.As(err, &exitErr) && exitErr.Code != 0 {
-		return exitErr.Code
-	}
-	return 1
 }
 
 func (b *coderLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {

--- a/internal/providers/crownest/backend.go
+++ b/internal/providers/crownest/backend.go
@@ -150,12 +150,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	defer func() {
 		result, retErr = shared.PinDelegatedRunFailure(result, retErr)
 		appendFailure := func(err error) {
-			code := 1
-			var public ExitError
-			if errors.As(err, &public) && public.Code != 0 {
-				code = public.Code
-			}
-			result, retErr = shared.AppendDelegatedRunFailure(result, retErr, err, code)
+			result, retErr = shared.AppendDelegatedRunFailure(result, retErr, err, core.ExitCodeForError(err, 1))
 		}
 		if cancelActiveRun && (ctx.Err() != nil || streamErr != nil) {
 			cancelCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type exeDevLeaseBackend struct {
@@ -855,16 +857,16 @@ func (b *exeDevLeaseBackend) rollbackCreatedVM(name, leaseID, slug, generation s
 	defer cancel()
 	vm, err := b.findVMByExactName(cleanupCtx, name)
 	if err != nil {
-		return exit(exitCodeForError(cause), "%v; exe.dev cleanup could not verify VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
+		return exit(core.ExitCodeForError(cause, 1), "%v; exe.dev cleanup could not verify VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
 	}
 	if err := validateExeDevVMOwnership(vm, leaseID, slug, "provisioning rollback"); err != nil {
-		return exit(exitCodeForError(cause), "%v; exe.dev cleanup refused unverified VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
+		return exit(core.ExitCodeForError(cause, 1), "%v; exe.dev cleanup refused unverified VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
 	}
 	if err := validateExeDevClaimGeneration(vm, generation); err != nil {
-		return exit(exitCodeForError(cause), "%v; exe.dev cleanup refused replacement VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
+		return exit(core.ExitCodeForError(cause, 1), "%v; exe.dev cleanup refused replacement VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
 	}
 	if err := b.deleteVM(cleanupCtx, name); err != nil {
-		return exit(exitCodeForError(cause), "%v; exe.dev cleanup failed for VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
+		return exit(core.ExitCodeForError(cause, 1), "%v; exe.dev cleanup failed for VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
 	}
 	return cause
 }
@@ -879,14 +881,6 @@ func (b *exeDevLeaseBackend) manualDeleteCommand(name string) string {
 		args = append(args, "-p", port)
 	}
 	return shellQuoteArgs(append(args, dest, "rm", name))
-}
-
-func exitCodeForError(err error) int {
-	var exitErr ExitError
-	if errors.As(err, &exitErr) && exitErr.Code != 0 {
-		return exitErr.Code
-	}
-	return 1
 }
 
 func exeDevControlDestination(value string) (string, string, error) {

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -151,18 +151,34 @@ func TestExeDevAcquireReportsRollbackFailureAfterClaimFailure(t *testing.T) {
 }
 
 func TestExeDevProvisioningRollbackRejectsReplacementGeneration(t *testing.T) {
-	leaseID := "cbx_abcdef123456"
-	slug := "blue"
-	vm := ownedExeDevVM(leaseID, slug)
-	runner := exeDevInventoryRunner(t, vm)
-	backend := newExeDevTestBackend(Config{}, runner)
-	primaryErr := errors.New("ssh not ready")
+	for _, tc := range []struct {
+		name    string
+		primary error
+		code    int
+	}{
+		{name: "opaque", primary: errors.New("ssh not ready"), code: 1},
+		{name: "typed", primary: ExitError{Code: 69, Message: "ssh not ready"}, code: 69},
+		{name: "signed", primary: ExitError{Code: -1, Message: "ssh not ready"}, code: -1},
+		{name: "zero", primary: ExitError{Code: 0, Message: "ssh not ready"}, code: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			leaseID := "cbx_abcdef123456"
+			slug := "blue"
+			vm := ownedExeDevVM(leaseID, slug)
+			runner := exeDevInventoryRunner(t, vm)
+			backend := newExeDevTestBackend(Config{}, runner)
 
-	err := backend.rollbackCreatedVM(vm.Name(), leaseID, slug, "cbx_222222222222", primaryErr)
-	if err == nil || !strings.Contains(err.Error(), primaryErr.Error()) || !strings.Contains(err.Error(), "refused replacement VM") {
-		t.Fatalf("err=%v, want guarded rollback refusal", err)
+			err := backend.rollbackCreatedVM(vm.Name(), leaseID, slug, "cbx_222222222222", tc.primary)
+			if err == nil || !strings.Contains(err.Error(), tc.primary.Error()) || !strings.Contains(err.Error(), "refused replacement VM") {
+				t.Fatalf("err=%v, want guarded rollback refusal", err)
+			}
+			var public ExitError
+			if !errors.As(err, &public) || public.Code != tc.code {
+				t.Fatalf("rollback exit=%d, want primary code %d", public.Code, tc.code)
+			}
+			assertNoExeDevRM(t, runner)
+		})
 	}
-	assertNoExeDevRM(t, runner)
 }
 
 func newExeDevAcquireRollbackRunner() *exeDevRecordingRunner {

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -278,11 +278,7 @@ func (b *isloBackend) Run(ctx context.Context, req RunRequest) (RunResult, error
 		downloadBackend := isloRunDownloadBackend{isloBackend: b, user: workloadUser}
 		result.Artifacts, artifactErr = core.MaterializeDelegatedRunDownloads(ctx, downloadBackend, req, leaseID, b.rt.Stderr)
 		if artifactErr != nil {
-			result.ExitCode = 7
-			var exitErr ExitError
-			if core.AsExitError(artifactErr, &exitErr) && exitErr.Code != 0 {
-				result.ExitCode = exitErr.Code
-			}
+			result.ExitCode = core.ExitCodeForError(artifactErr, 7)
 		}
 	}
 	result.Total = b.now().Sub(started)

--- a/internal/providers/orgo/backend.go
+++ b/internal/providers/orgo/backend.go
@@ -137,12 +137,7 @@ func (b *orgoBackend) Run(ctx context.Context, req RunRequest) (result RunResult
 				CommandMs: result.Command.Milliseconds(), TotalMs: result.Total.Milliseconds(),
 				ExitCode: result.ExitCode, Label: strings.TrimSpace(req.Label),
 			}, result, retErr))
-			firstCode := 1
-			var timingExit ExitError
-			if core.AsExitError(timingErr, &timingExit) && timingExit.Code != 0 {
-				firstCode = timingExit.Code
-			}
-			result, retErr = shared.AppendDelegatedRunFailure(result, retErr, timingErr, firstCode)
+			result, retErr = shared.AppendDelegatedRunFailure(result, retErr, timingErr, core.ExitCodeForError(timingErr, 1))
 		}
 	}()
 

--- a/internal/providers/shared/delegated.go
+++ b/internal/providers/shared/delegated.go
@@ -99,11 +99,7 @@ func PinDelegatedRunFailure(result core.RunResult, err error) (core.RunResult, e
 	}
 	outcome := core.FinalizeRunResult(core.RunResult{}, err)
 	result.Status, result.ErrorKind = outcome.Status, outcome.ErrorKind
-	result.ExitCode = 1
-	var public core.ExitError
-	if errors.As(err, &public) && public.Code != 0 {
-		result.ExitCode = public.Code
-	}
+	result.ExitCode = core.ExitCodeForError(err, 1)
 	return result, ExitErrorWithCause(result.ExitCode, err.Error(), err)
 }
 
@@ -175,12 +171,7 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
 			closeErr := command.Close(cleanupCtx)
 			cancel()
-			code := 1
-			var ee core.ExitError
-			if errors.As(closeErr, &ee) && ee.Code != 0 {
-				code = ee.Code
-			}
-			appendFailure(closeErr, code)
+			appendFailure(closeErr, core.ExitCodeForError(closeErr, 1))
 		}
 		if result.Session != nil {
 			shouldStop := acquired && !req.Keep

--- a/internal/providers/smolvm/backend.go
+++ b/internal/providers/smolvm/backend.go
@@ -289,11 +289,7 @@ func (b *backend) createMachine(ctx context.Context, client api, repo Repo, keep
 		}
 		if cleanupErr != nil {
 			// A typed rollback error must not replace the acquisition's CLI exit.
-			code := 1
-			var primary ExitError
-			if errors.As(resultErr, &primary) && primary.Code != 0 {
-				code = primary.Code
-			}
+			code := core.ExitCodeForError(resultErr, 1)
 			joined := errors.Join(resultErr, fmt.Errorf("smolvm rollback retained machine=%s lease=%s: %w", original.ID, leaseID, cleanupErr))
 			resultErr = shared.ExitErrorWithCause(code, joined.Error(), joined)
 		}

--- a/internal/providers/wandb/backend.go
+++ b/internal/providers/wandb/backend.go
@@ -146,12 +146,7 @@ func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (result RunResul
 				CommandMs: result.Command.Milliseconds(), TotalMs: result.Total.Milliseconds(),
 				ExitCode: result.ExitCode, Label: strings.TrimSpace(req.Label),
 			}, result, retErr))
-			firstCode := 1
-			var public ExitError
-			if errors.As(timingErr, &public) && public.Code != 0 {
-				firstCode = public.Code
-			}
-			result, retErr = shared.AppendDelegatedRunFailure(result, retErr, timingErr, firstCode)
+			result, retErr = shared.AppendDelegatedRunFailure(result, retErr, timingErr, core.ExitCodeForError(timingErr, 1))
 		}
 	}()
 


### PR DESCRIPTION
## Summary

Move the existing integer selector from the private Actions helper to `core.ExitCodeForError` in `errors.go`, then reuse it at **12 exact-equivalent selector sites**. The complete change removes **64 net production lines**; the other edits characterize compatibility and update explicit test references.

This is a behavior-preserving refactor. The helper returns the nonzero code from the first `ExitError` matched by `errors.As`, otherwise the caller's fallback. It preserves signed codes, nil/zero fallback behavior, custom `As`, first-match ordering, and the existing value-target/pointer behavior. A first zero-code match still uses the fallback rather than searching a later joined error.

## Supplemental actual CLI compatibility replay

**No divergence was observed.** These are expected equivalence controls for the exit-code selector refactor, not new-bug reproductions. Signed and library-only cases remain covered by the separate unit tests; the CLI fixtures do not claim to exercise them.

The baseline is exact main `5344e73cd47a03a5ece2c78ffce07b262c840a2d`, tree `6492b9db2e0ac92cd7a0799862c4b6ed2657e396`. The candidate is the clean merge-tree of that main with PR head `3de12e4b2dc8f6cf686b0e2a339a4f3c17ebd371`, tree `43a8ee3b15289d41a919e5204ccb0e62dc237215`. Thus both builds include the metadata and telemetry integrations already on main.

Each tree was copied into its own isolated snapshot and freshly built with `go build -trimpath`; both fixtures invoked its separate CLI binary by absolute path. All 2,228 source blobs, their Git blob hashes, symlink kinds and executable bits were verified after replay in each snapshot. No production source, user checkout, index or fixture was changed during this replay. No additional source review was requested for the compatibility run.

### Exact inputs and existing fixtures

The fixtures were byte-identical to the complete published fixtures in [Orgo PR1926](https://github.com/openclaw/crabbox/pull/1926) and [W&B PR1930](https://github.com/openclaw/crabbox/pull/1930), and byte-identical between both builds. No assertion was weakened.

```text
36307ce574865f0e4957c467e700479ab2a3feab867339d1e74b071cdd318328  baseline CLI
67ea0f8bd0058beba7ec122a58159d11579ae361da6431ebc944ceaa213ef6ce  candidate CLI
dc6cf8bef1bf160a10758d396d7d92feeef4be5369ce2d1ccc2c520deba8def4  Orgo native.py (PR1926)
d997c6673293dfccf55ad9fdb0cd7c496f9a60e16491e994b57f6d4bdabec3f2  W&B fixture_test.go (PR1930)
405e38989592334bd2ffd4a13a0a33eac0ef9debcf5917378f1d6fa30941f9f0  immutable comparison.json
```

### Complete public exit vectors

| Orgo case, in fixture order | Baseline | Candidate |
| --- | ---: | ---: |
| success | 0 | 0 |
| explicit-no-sync | 0 | 0 |
| cascade-success | 0 | 0 |
| computer-cleanup-failure | 1 | 1 |
| command-and-cleanup | 7 | 7 |
| workspace-cleanup-failure | 1 | 1 |
| http403 | 77 | 77 |
| http404 | 4 | 4 |
| http429 | 69 | 69 |

Orgo vectors are both **`[0, 0, 0, 1, 7, 1, 77, 4, 69]`**. Exact stdout, final public diagnostic lines, timing exit/status/error-kind, and cleanup outcomes matched. Duration and generated identifiers are nondeterministic and were not treated as semantic differences; unnormalized raw outputs remain preserved.

| W&B reuse case, in fixture order | Baseline | Candidate |
| --- | ---: | ---: |
| metadata-only | 0 | 0 |
| metadata-only-summary | 0 | 0 |
| implicit-defaults | 0 | 0 |
| explicit-ci | 2 | 2 |
| explicit-node | 2 | 2 |
| explicit-custom | 2 | 2 |
| prefix-lookalike | 2 | 2 |
| suffix-lookalike | 2 | 2 |

W&B vectors are both **`[0, 0, 0, 2, 2, 2, 2, 2]`**, with acquire and final Stop both **0 → 0**. Each successful reuse performed List/Exec; each rejection opened no new connection and issued no RPC. The exact response text and four metadata-free Exec payloads matched.

### Representative complete diagnostic and cleanup records

These are the complete selected comparison records, rather than truncated error snippets. Orgo Stop diagnostics replace only the generated lease ID with `<lease-id>`; the underlying full receipts and their hashes remain unchanged. No private filesystem path is included here.

<details>
<summary>Orgo command exit7 plus cleanup failure: baseline and candidate</summary>

```json
{
  "case": "command-and-cleanup",
  "baseline": {
    "exitCode": 7,
    "stdout": "",
    "diagnostics": [
      "orgo computer exit=7",
      "orgo cleanup failed for computer_native: orgo API http 403: {\"message\": \"synthetic computer cleanup refusal\"}"
    ],
    "timingExitCode": 7,
    "runStatus": "failed",
    "errorKind": "command-exit",
    "syncSkipped": true,
    "recoveryStopExitCode": 0,
    "recoveryStopStdout": "",
    "recoveryStopDiagnostic": "",
    "finalClaimCount": 0,
    "finalComputerPresent": false,
    "finalWorkspacePresent": true,
    "computerDeleteAttempts": 2,
    "workspaceDeleteAttempts": 0,
    "successfulComputerDeletes": 1,
    "successfulWorkspaceDeletes": 0,
    "portClosed": true,
    "serverThreadStopped": true,
    "temporaryDirectoryRemoved": true
  },
  "candidate": {
    "exitCode": 7,
    "stdout": "",
    "diagnostics": [
      "orgo computer exit=7",
      "orgo cleanup failed for computer_native: orgo API http 403: {\"message\": \"synthetic computer cleanup refusal\"}"
    ],
    "timingExitCode": 7,
    "runStatus": "failed",
    "errorKind": "command-exit",
    "syncSkipped": true,
    "recoveryStopExitCode": 0,
    "recoveryStopStdout": "",
    "recoveryStopDiagnostic": "",
    "finalClaimCount": 0,
    "finalComputerPresent": false,
    "finalWorkspacePresent": true,
    "computerDeleteAttempts": 2,
    "workspaceDeleteAttempts": 0,
    "successfulComputerDeletes": 1,
    "successfulWorkspaceDeletes": 0,
    "portClosed": true,
    "serverThreadStopped": true,
    "temporaryDirectoryRemoved": true
  },
  "equivalent": true
}
```

</details>

<details>
<summary>W&B explicit-env rejection and final cleanup: baseline and candidate</summary>

```json
{
  "baseline": {
    "rejection": {
      "connectionsAfter": 4,
      "connectionsBefore": 4,
      "name": "explicit-ci",
      "newRPC": [],
      "run": {
        "exitCode": 2,
        "output": "provider=wandb cannot forward env vars to an existing sandbox (--id); rerun without --id or omit --allow-env\n"
      }
    },
    "stop": {
      "exitCode": 0,
      "output": ""
    },
    "finalClaimCount": 0,
    "finalSandboxPresent": false,
    "serverStopped": true,
    "portClosed": true,
    "finalCleanupRPCs": [
      "/coreweave.sandbox.v1beta2.GatewayService/List",
      "/coreweave.sandbox.v1beta2.GatewayService/Stop"
    ],
    "execRequests": [
      {
        "sandboxId": "sb-metadata-audit",
        "command": [
          "true"
        ]
      },
      {
        "sandboxId": "sb-metadata-audit",
        "command": [
          "true"
        ]
      },
      {
        "sandboxId": "sb-metadata-audit",
        "command": [
          "true"
        ]
      },
      {
        "sandboxId": "sb-metadata-audit",
        "command": [
          "true"
        ]
      }
    ]
  },
  "candidate": {
    "rejection": {
      "connectionsAfter": 4,
      "connectionsBefore": 4,
      "name": "explicit-ci",
      "newRPC": [],
      "run": {
        "exitCode": 2,
        "output": "provider=wandb cannot forward env vars to an existing sandbox (--id); rerun without --id or omit --allow-env\n"
      }
    },
    "stop": {
      "exitCode": 0,
      "output": ""
    },
    "finalClaimCount": 0,
    "finalSandboxPresent": false,
    "serverStopped": true,
    "portClosed": true,
    "finalCleanupRPCs": [
      "/coreweave.sandbox.v1beta2.GatewayService/List",
      "/coreweave.sandbox.v1beta2.GatewayService/Stop"
    ],
    "execRequests": [
      {
        "sandboxId": "sb-metadata-audit",
        "command": [
          "true"
        ]
      },
      {
        "sandboxId": "sb-metadata-audit",
        "command": [
          "true"
        ]
      },
      {
        "sandboxId": "sb-metadata-audit",
        "command": [
          "true"
        ]
      },
      {
        "sandboxId": "sb-metadata-audit",
        "command": [
          "true"
        ]
      }
    ]
  }
}
```

</details>

All Orgo cases verified actual CLI Stop recovery for retained failures, absent final claims/computers and created workspaces, preserved configured workspaces with no workspace DELETE, and the owned-workspace cascade-success rule. Its unchanged fixture verified bounded/killed/reaped local shell groups, stopped server threads, closed ports and removed temporary directories. W&B verified actual CLI Stop, zero final claims, no remaining fixture sandbox, server shutdown and a closed port; Go `t.TempDir` owns local state cleanup.

Raw receipt hashes:

```text
0f21552c2358527220bc0a7d42da39f35a2a220cfddff22787c599f47975c8c7  baseline Orgo receipt
93d7d89f2f0f5ab1a7941807e565a354d7bdc7937521a27a413ae8050fae07f5  baseline W&B receipt
65bfb758716a4a7e19407854d943360f3a86be727be230facc9219bf718e9733  candidate Orgo receipt
5e70b91b6e5937f427f7a576c5b39dfe3bb5d26038fc7c9a342d572583bc8914  candidate W&B receipt
```

**Scope:** both tests run actual built CLIs and production clients. Orgo uses an owned synthetic loopback HTTP API and benign local shell execution. W&B uses its unchanged supported plaintext-loopback gRPC constructor branch with synthetic RPC responses; its response text is not proof of native workload execution. No hosted account/resource, real credential, global TLS/trust change, or hosted/TLS proof is involved. These controls supplement—not replace—the selector's signed/library-level unit coverage.


## Adopters

| Selector site | Existing fallback |
| --- | ---: |
| Shared `PinDelegatedRunFailure` | 1 |
| Shared delegated command-close handling | 1 |
| Crownest terminal append closure | 1 |
| Orgo first timing error | 1 |
| W&B first timing error | 1 |
| exe.dev rollback helper's four callers | 1 |
| Coder rollback helper | 1 |
| Core shard helper's two callers | 1 |
| Blacksmith artifact failure | 7 |
| SmolVM acquisition rollback | 1 |
| AppleMachine creation rollback | 1 |
| Islo artifact failure | 7 |

The private core `exitCodeForError` is moved/exported, not retained as an alias. Four duplicate pure helpers are deleted: `exedev.exitCodeForError`, `coder.coderExitCode`, `cli.shardErrorExitCode`, and `blacksmith.blacksmithArtifactFailureExitCode`.

## Policies deliberately unchanged

`AppendDelegatedRunFailure` is byte-for-byte unchanged. The extraction does not classify status, join or rewrap errors, choose messages, or decide retention/cleanup. Existing fixed cleanup codes stay fixed; selecting a typed first error is not moved into the appender.

Caller guards remain in place. In particular, shard's old helper maps nil to `1`, and the missing-outcome guard still runs afterward. Artifact fallbacks remain `7`; existing core Actions/run fallbacks are unchanged. Zero-accepting report/rewrap paths, positive-only or range-normalized process exits, special-code predicates, and the unrelated boxd event-code check were excluded. The separately owned W&B metadata helper is untouched.

## Verification

Verified against base [`69e79538dae281148ed3475329bfc6eeaf53b58f`](https://github.com/openclaw/crabbox/commit/69e79538dae281148ed3475329bfc6eeaf53b58f). These are **compatibility characterization tests**, not newly discovered bug reds.

Before extraction, all 20 cases passed against the existing private core helper:

```sh
GOTOOLCHAIN=go1.26.5 go test -race ./internal/cli \
  -run '^TestExitCodeForErrorCompatibility$' -count=1 -v
# PASS: 2.277s on the refreshed base
```

Before exe.dev adoption, the existing replacement-generation test was extended with opaque, typed `69`, signed `-1`, and zero-code primary errors. All four cases passed while still verifying that replacement VMs are not deleted:

```sh
GOTOOLCHAIN=go1.26.5 go test -race ./internal/providers/exedev \
  -run '^TestExeDevProvisioningRollbackRejectsReplacementGeneration$' -count=1 -v
# PASS: 1.560s before adoption
```

Complete v2 checks:

```sh
GOTOOLCHAIN=go1.26.5 go test -race ./internal/cli \
  -run '^(TestExitCodeForErrorCompatibility|TestShard)' -count=1 -v
# PASS: 2.424s; 19 top-level tests, including the 20-case characterization table

GOTOOLCHAIN=go1.26.5 go test -race ./internal/providers/exedev \
  -run '^(TestExeDevAcquireReportsRollbackFailureAfterPrepareFailure|TestExeDevAcquireReportsRollbackFailureAfterClaimFailure|TestExeDevProvisioningRollbackRejectsReplacementGeneration|TestExeDevReleaseRunsGuardedRemoteCleanupBeforeDelete)$' \
  -count=1 -v
# PASS: 2.935s

GOTOOLCHAIN=go1.26.5 go test -race \
  ./internal/providers/shared ./internal/providers/crownest \
  ./internal/providers/orgo ./internal/providers/wandb \
  ./internal/providers/exedev ./internal/providers/coder \
  ./internal/providers/blacksmith ./internal/providers/smolvm \
  ./internal/providers/applemachine ./internal/providers/islo -count=1
# PASS: shared 3.672s; crownest 19.684s; orgo 27.116s; wandb 4.413s;
# exedev 6.841s; coder 10.776s; blacksmith 65.569s; smolvm 18.593s;
# applemachine 13.744s; islo 14.940s

GOTOOLCHAIN=go1.26.5 go vet ./internal/cli \
  ./internal/providers/shared ./internal/providers/crownest \
  ./internal/providers/orgo ./internal/providers/wandb \
  ./internal/providers/exedev ./internal/providers/coder \
  ./internal/providers/blacksmith ./internal/providers/smolvm \
  ./internal/providers/applemachine ./internal/providers/islo
# PASS

git diff --check
git diff --cached --check
# PASS
```

`gofmt -l` on all 22 changed Go files produced no output. Complete-v2 managed review was P0 scoped-clean with no findings (confidence 0.98); the tests above were executed separately from that source review.

The initial code-review phase used characterization and unit/race tests. The subsequent actual CLI compatibility replay is recorded above and remains separate from hosted service validation; no hosted-provider calls were made. No user-visible behavior or changelog entry is intended.
