### PR TITLE
fix: preserve sync and artifact intent in recovery hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Preserve explicit no-sync intent and required-artifact globs in failure-digest retries, avoiding an unintended workspace reset or weakened evidence checks. [Issue 1875](https://github.com/openclaw/crabbox/issues/1875), [Issue 1895](https://github.com/openclaw/crabbox/issues/1895). Thanks @coygeek.
+- Preserve explicit no-sync intent and required-artifact globs in failure-digest retries, avoiding an unintended workspace reset or weakened evidence checks. [PR 1933](https://github.com/openclaw/crabbox/pull/1933), [Issue 1875](https://github.com/openclaw/crabbox/issues/1875), [Issue 1895](https://github.com/openclaw/crabbox/issues/1895). Thanks @coygeek.
 - Start commands without waiting for best-effort telemetry uploads, and cancel and join the telemetry publisher before run completion or lease replacement while preserving baseline samples and verified terminal receipts. [PR 1931](https://github.com/openclaw/crabbox/pull/1931).
 
 - Local containers: optionally omit the explicit hostname for runtimes sharing a host UTS namespace, support YAML and environment configuration, and reject incompatible fixed-ID reuse without changing existing default fingerprints. [PR 1813](https://github.com/openclaw/crabbox/pull/1813), [PR 1924](https://github.com/openclaw/crabbox/pull/1924). Thanks @atrawog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve explicit no-sync intent and required-artifact globs in failure-digest retries, avoiding an unintended workspace reset or weakened evidence checks. [Issue 1875](https://github.com/openclaw/crabbox/issues/1875), [Issue 1895](https://github.com/openclaw/crabbox/issues/1895). Thanks @coygeek.
 - Local containers: optionally omit the explicit hostname for runtimes sharing a host UTS namespace, support YAML and environment configuration, and reject incompatible fixed-ID reuse without changing existing default fingerprints. [PR 1813](https://github.com/openclaw/crabbox/pull/1813), [PR 1924](https://github.com/openclaw/crabbox/pull/1924). Thanks @atrawog.
 - Define a strict provider-neutral Linux developer-image recipe whose digest binds the executable contract and exact installer/readiness source hashes.
 - Extract protected image-qualification candidates at the canonical artifact path and avoid protected finalization when deployment never started.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -757,8 +757,12 @@ its status before reuse, or retry the printed stop command to finish cleanup.
 The digest includes the failed phase when phase markers are known, a
 likely area (provider auth, SSH/connectivity, sync, install/setup, user command,
 model/tool/provider limit, or resource exhaustion), retryability when inferable, next commands
-(`logs`, `events`, `doctor --from-run`, `ssh`, retrying with `--fresh-sync`, and
-`stop`). After failure-bundle information and command hints, each stream has one
+(`logs`, `events`, `doctor --from-run`, `ssh`, retrying, and `stop`). A retry
+preserves an explicitly requested `--no-sync`, so it does not reset the retained
+workspace. Other retries retain the `--fresh-sync` guidance above. Each original
+`--require-artifact` glob is retained in the retry, so missing required evidence
+still fails the rerun. After failure-bundle information and command hints, each
+stream has one
 redacted tail section of up to 40 lines, or its capture path when explicitly
 captured. Live output and failure-bundle contents are unchanged. The digest does
 not reconstruct secrets or hidden local shell state. Short-circuit explanations are limited to simple

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2892,6 +2892,8 @@ afterSync:
 			CommandDisplay:        commandDisplay,
 			ShellMode:             *shellMode || useShell,
 			ScriptMode:            script != nil,
+			NoSync:                *noSync,
+			RequiredArtifactGlobs: append([]string(nil), requiredArtifactGlobs...),
 			Routing:               CommandRoutingFor(cfg, leaseID, CommandRoutingRetry),
 			SSHRouting:            CommandRoutingFor(cfg, leaseID, CommandRoutingRetry),
 			StopRouting:           CommandRoutingFor(cfg, leaseID, CommandRoutingStop),

--- a/internal/cli/run_failure.go
+++ b/internal/cli/run_failure.go
@@ -296,6 +296,8 @@ type runFailureDigestInput struct {
 	CommandDisplay        string
 	ShellMode             bool
 	ScriptMode            bool
+	NoSync                bool
+	RequiredArtifactGlobs []string
 	Routing               CommandRouting
 	SSHRouting            CommandRouting
 	StopRouting           CommandRouting
@@ -425,7 +427,14 @@ func failureDigestNextCommands(input runFailureDigestInput, retry string) []stri
 			if len(routing.Args) == 0 {
 				routing = fallbackFailureDigestRouting(input, CommandRoutingRetry)
 			}
-			runArgs := append(append([]string{"crabbox", "run"}, routing.Args...), "--id", leaseRef, "--fresh-sync")
+			syncFlag := "--fresh-sync"
+			if input.NoSync {
+				syncFlag = "--no-sync"
+			}
+			runArgs := append(append([]string{"crabbox", "run"}, routing.Args...), "--id", leaseRef, syncFlag)
+			for _, glob := range input.RequiredArtifactGlobs {
+				runArgs = append(runArgs, "--require-artifact", glob)
+			}
 			if input.ShellMode {
 				runArgs = append(runArgs, "--shell")
 			}

--- a/internal/cli/run_failure_test.go
+++ b/internal/cli/run_failure_test.go
@@ -7,8 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -728,6 +730,96 @@ func TestFailureDigestSuppressesScriptRetryCommand(t *testing.T) {
 		if strings.Contains(command, "crabbox run") {
 			t.Fatalf("script retry command should be suppressed: %v", commands)
 		}
+	}
+}
+
+func TestFailureDigestPreservesRecoveryIntent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX rendered-shell argv fixture")
+	}
+	for _, tc := range []struct {
+		name                                    string
+		noSync, shell, script, stopped, noRetry bool
+		globs                                   []string
+	}{
+		{name: "default keeps fresh sync"},
+		{name: "no sync", noSync: true},
+		{name: "requirements", globs: []string{"reports/manifest.json", "reports/proof-*.json"}},
+		{name: "no sync requirements shell", noSync: true, shell: true, globs: []string{"reports/manifest.json", "reports/proof-*.json"}},
+		{name: "script suppressed", script: true, noSync: true, globs: []string{"proof.json"}},
+		{name: "retry suppressed", noRetry: true, noSync: true, globs: []string{"proof.json"}},
+		{name: "stopped suppressed", stopped: true, noSync: true, globs: []string{"proof.json"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.Mkdir(filepath.Join(dir, "reports"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "reports", "proof-local.json"), nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			capture := filepath.Join(dir, "argv")
+			if err := os.WriteFile(filepath.Join(dir, "crabbox"), []byte("#!/bin/sh\nprintf '%s\\000' \"$@\" > \"$FIXTURE_ARGV\"\n"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			display := "printf '%s\\n' 'two words'"
+			if tc.shell {
+				display = "printf first && printf second"
+			}
+			routing := CommandRouting{Args: []string{"--provider", "local-container", "--local-container-runtime", "docker"}}
+			input := runFailureDigestInput{LeaseID: "cbx_fixture", CommandDisplay: display, ShellMode: tc.shell, ScriptMode: tc.script, LeaseStopped: tc.stopped, NoSync: tc.noSync, RequiredArtifactGlobs: tc.globs, Routing: routing}
+			retry := "unknown"
+			if tc.noRetry {
+				retry = "false"
+			}
+			var hint string
+			for _, command := range failureDigestNextCommands(input, retry) {
+				if strings.HasPrefix(command, "crabbox run ") {
+					if hint != "" {
+						t.Fatal("multiple retry commands")
+					}
+					hint = command
+				}
+			}
+			if tc.script || tc.stopped || tc.noRetry {
+				if hint != "" {
+					t.Fatalf("unexpected retry: %s", hint)
+				}
+				return
+			}
+			if hint == "" {
+				t.Fatal("missing retry")
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, "/bin/sh", "-c", hint)
+			cmd.Dir = dir
+			cmd.Env = []string{"PATH=" + dir + ":/usr/bin:/bin", "FIXTURE_ARGV=" + capture}
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("replay: %v %s", err, out)
+			}
+			data, err := os.ReadFile(capture)
+			if err != nil {
+				t.Fatal(err)
+			}
+			args := strings.Split(strings.TrimSuffix(string(data), "\x00"), "\x00")
+			syncFlag := "--fresh-sync"
+			if tc.noSync {
+				syncFlag = "--no-sync"
+			}
+			want := append(append([]string{"run"}, routing.Args...), "--id", "cbx_fixture", syncFlag)
+			for _, glob := range tc.globs {
+				want = append(want, "--require-artifact", glob)
+			}
+			if tc.shell {
+				want = append(want, "--shell", "--", display)
+			} else {
+				want = append(want, "--", "printf", "%s\\n", "two words")
+			}
+			if !reflect.DeepEqual(args, want) {
+				t.Fatalf("args=%q want=%q", args, want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3294,6 +3294,7 @@ exit 0
 		"--keep-on-failure",
 		"--timing-json",
 		"--require-artifact", "reports/data/manifest.json",
+		"--require-artifact", "reports/proof-*.json",
 		"--download", "reports/data/manifest.json=" + downloadPath,
 		"--", "fixture-stage-success",
 	})
@@ -3318,6 +3319,20 @@ exit 0
 	}
 	if !strings.Contains(stderr.String(), "keep-on-failure: kept lease=cbx_env_profile_test") {
 		t.Fatalf("missing keep-on-failure hint after required artifact failure:\n%s", stderr.String())
+	}
+	retryHints := 0
+	for _, line := range strings.Split(stderr.String(), "\n") {
+		if strings.Contains(line, "next: crabbox run ") {
+			retryHints++
+			if !strings.Contains(line, "--no-sync") || strings.Contains(line, "--fresh-sync") ||
+				!strings.Contains(line, "--require-artifact reports/data/manifest.json") ||
+				!strings.Contains(line, "--require-artifact 'reports/proof-*.json'") {
+				t.Errorf("retry lost no-sync or required-artifact intent: %s", line)
+			}
+		}
+	}
+	if retryHints != 1 {
+		t.Errorf("retry hints=%d, want one runnable recovery", retryHints)
 	}
 	lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
 	var report TimingReport

--- a/internal/cli/run_workspace_owner_cleanup_test.go
+++ b/internal/cli/run_workspace_owner_cleanup_test.go
@@ -586,6 +586,14 @@ func TestRunFailureDigestCleanupOutcomes(t *testing.T) {
 					t.Errorf("recovery %s present=%v, stopped=%v:\n%s", command, got, test.wantStop, out)
 				}
 			}
+			if !test.wantStop {
+				for _, line := range strings.Split(out, "\n") {
+					if strings.Contains(line, "next: crabbox run ") &&
+						(!strings.Contains(line, "--no-sync") || strings.Contains(line, "--fresh-sync")) {
+						t.Errorf("retained retry lost no-sync intent: %s", line)
+					}
+				}
+			}
 			if (test.wantStop || test.stopErr != nil || test.retained) != (releaseCalls == 1) {
 				t.Errorf("release calls=%d", releaseCalls)
 			}


### PR DESCRIPTION
## Summary

Failure-digest retries now preserve an explicit `--no-sync` and every validated `--require-artifact` glob. Previously, a retained no-sync run was retried with `--fresh-sync`, which could reset its workspace, and required evidence was omitted from the suggested command.

Related reports: https://github.com/openclaw/crabbox/issues/1875 and https://github.com/openclaw/crabbox/issues/1895. Thanks @coygeek for identifying both recovery-intent gaps.

The change stays in the existing recovery-command owner: `run.go` supplies the original intent to `failureDigestNextCommands`, which renders separate, shell-quoted artifact arguments. Default retries still use the documented `--fresh-sync`; routing, workload rendering, shell mode, and script/nonretryable/stopped-lease suppression remain unchanged. No provider lifecycle, workspace reset implementation, credentials, or configuration schema changes. This is not a promise to replay every original flag.

## Fresh integrated replay — critical observations

Snapshot: main `5344e73cd47a03a5ece2c78ffce07b262c840a2d` plus the frozen seven-file patch (SHA-256 `1b5efc3060459358ded0deac968e9df5bb5a677771a7bdcca70d55918281d878`). The candidate below is the actual staged merge snapshot, not the earlier base-69 binary. These are selected literal diagnostic lines and observed file/exit states; complete captures follow below.

```text
printed-no-sync-retry
exact printed command replayed: crabbox run --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture --no-sync -- /bin/sh -c 'test -f remote-marker || exit 42; exit 23'
observed {"exit":23,"markerPresent":true,"requiredProofPresent":false,"reportProofPresent":false}

printed-proof-retry-missing
exact printed command replayed: crabbox run --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture --no-sync --require-artifact required-proof.json --require-artifact 'reports/proof-*.json' -- true
missing required artifact: required-proof.json
missing required artifact: reports/proof-*.json
missing required artifact: reports/proof-*.json
observed {"exit":7,"markerPresent":false,"requiredProofPresent":false,"reportProofPresent":false}

printed-proof-retry-partial
replayed the same printed artifact command above
required artifact required-proof.json matched=1
missing required artifact: reports/proof-*.json
missing required artifact: reports/proof-*.json
observed {"exit":7,"markerPresent":false,"requiredProofPresent":true,"reportProofPresent":false}

printed-proof-retry-complete
replayed the same printed artifact command above
required artifact required-proof.json matched=1
required artifact reports/proof-*.json matched=1
artifact kind=artifact-glob path=<case>/repo/.crabbox/runs/run_210bdce9e3ca/run_210bdce9e3ca-artifacts.tgz bytes=361
observed {"exit":0,"markerPresent":false,"requiredProofPresent":true,"reportProofPresent":true}

```

Between marker and artifact cases, the fixture deliberately runs an explicit fresh-sync reset control; later `markerPresent=false` is that control, not a retry reset.

The rebuilt main baseline returned 42 after removing the marker, then returned 0 with both required artifacts absent. Candidate cleanup and baseline cleanup each returned 0, with zero remaining claims and owned roots removed. No real SSH authentication or hosted-provider execution was involved.

## Verification

Historical tests-first evidence against original base `69e79538dae281148ed3475329bfc6eeaf53b58f` remains unchanged: the corrected baseline run exited 1 with **eight real failing behavior cases**: the required-artifact caller and seven retained-cleanup cases (`success_only`, `never`, `kept`, `keep_failed`, `failed_cleanup`, `ambiguous_cleanup`, `retained_direct_release`). Four release/suppression controls already passed (`automatic_failure_cleanup`, `always`, `failure`, `deleted_with_local_cleanup_error`). Parent test/package failure records are not counted as extra cases.

The actual integrated scoped race run passed in **19.319s**, scoped vet, docs-site build, and `git diff --check` exited 0. The new renderer matrix also executes printed commands through a real POSIX shell and captures NUL-delimited argv, including a wildcard with a matching local file to detect accidental expansion. It covers default sync behavior, no-sync, repeated requirements, shell/routing preservation, and suppression. Its POSIX fixture is skipped on Windows. Managed review reported no P0 findings (scoped-clean, confidence 0.96); it did not independently run tests. This is focused verification, not a full-suite or hosted-provider claim.

```sh
GOTOOLCHAIN=go1.26.5 GOMAXPROCS=4 go test -p=2 -race -count=1 -timeout=5m -json ./internal/cli -run '^(TestFailureDigest.*|TestPrintRunFailureDigest.*|TestRunCommandRequireArtifactFailsAfterSuccessfulCommand|TestRunFailureDigestCleanupOutcomes|TestRunCommandRejectsFullResyncWithNoSync|TestRunNoSyncRequestsExistingLeasePreparation)$'
GOTOOLCHAIN=go1.26.5 GOMAXPROCS=4 go vet -p=2 ./internal/cli
git diff --check
node scripts/build-docs-site.mjs
```

An earlier test draft used an unsupported spaced artifact glob and failed validation; that is a fixture error, not included in the eight regressions. Five native-wrapper qualification attempts are also excluded: four stopped before any workload because the wrapper did not yet parse SSH's diagnostic `-E` option correctly; the fifth qualified the corrected wrapper. All qualification roots and claims were cleaned. Those historical receipts were retained separately.

## Native printed-command proof

Both actual macOS ARM64 CLI binaries ran against the same frozen synthetic SSH shim, an owned loopback readiness listener, and task-owned local workspace/state directories. The shim executes production-generated commands using real `/bin/sh`; the installed native rsync client and server perform the actual protocol. The driver extracts the actual `next: crabbox run ...` line and executes that unchanged through `/bin/sh -c`. Marker/file observations below are fixture filesystem checks, not inferred from prose diagnostics.

**Limits:** no real SSH authentication, VM, hosted provider, remote machine, isolation, or third-party-target proof. OpenSSH is used only for local `-G` configuration inspection with owned configuration paths; all execution transport is synthetic. No account keys or tokens are needed. Each CLI invocation has a 45-second process-group timeout. The fixed finite driver has no separate global timeout. The original calls request timing JSON; printed retries do not, and their captures retain the actual normal timing summaries instead. Public captures replace only task-local path roots with `<case>`, `<proof>`, and `<binary>`; generated run IDs and loopback ports are fixture-only. These selected captures are complete stdout/stderr for the listed calls, not the entire private raw trace archive.

| Observation | Base | Candidate |
| --- | --- | --- |
| Seed marker | 0; present | 0; present |
| Original no-sync failure | 23; present | 23; present |
| Exact printed no-sync retry | **42; marker deleted** | **23; marker preserved** |
| Explicit fresh-sync control | Not run | 0; marker deleted |
| Original missing-artifact run | 7 | 7 |
| Exact printed retry, neither artifact present | **0; both absent** | **7; both absent** |
| Same printed retry, only first artifact present | Not run | **7** |
| Same printed retry, both artifacts present | Not run | **0; archive collected** |
| Explicit stop | 0; zero claims | 0; zero claims |

Both driver processes exited 0. Base mode deliberately asserts the old incorrect outcomes; its harness success is not a corrected-behavior pass. Candidate performed eleven CLI calls including two artifact-producing calls and explicit stop; base performed six. Both final runs removed their owned temporary roots after stop, with zero remaining claims.

## Complete selected native captures

These blocks contain the exact recorded invocation (or exact printed command replay), observed exit/file state, and complete stdout/stderr for each named call. Empty stdout is explicit. Fixture path placeholders are display redactions, not commands to paste independently; the full driver below recreates valid paths. The missing/partial/complete candidate cases replay the **same originally printed artifact command**. Fixture-only commands create the first file with `printf '{}' > required-proof.json`, then the second with `mkdir -p reports; printf '{}' > reports/proof-one.json`; both returned 0 before their corresponding retry.

<details>
<summary>candidate: printed-no-sync-retry — exit 23</summary>

```text
invocation: crabbox run --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture --no-sync -- /bin/sh -c 'test -f remote-marker || exit 42; exit 23'
observed: {"exit":23,"fault":null,"elapsedSeconds":3.994,"markerPresent":true,"requiredProofPresent":false,"reportProofPresent":false}
stdout:
(empty)
stderr:
static SSH architecture observed=arm64 source=ssh-uname-sysctl scope=posix-process version=1 observed_at=1788737684685 host=arm64 process=arm64 translated=false
workspace owner acquired wait=151ms recovered=false
run context:
  run=run_0a535cf1882d portal=- logs=-
  lease=recovery_fixture slug=recovery-fixture provider=ssh target=macos type=macos
  ssh=fixture@127.0.0.1:58347 ip=127.0.0.1
  workdir=<case>/remote/recovery_fixture/repo workspace=raw actions=-
running on 127.0.0.1 /bin/sh -c 'test -f remote-marker || exit 42; exit 23'
command complete in 1.56s total=2.226s
run summary lease=163ms bootstrap=269ms sync=0s command=1.56s total=2.226s end_to_end=2.73s sync_skipped=true exit=23 command_phases=user-command:1.559s blocked_stage=unknown retry_likely=unknown
run details provider=ssh lease=recovery_fixture slug=recovery-fixture run=run_0a535cf1882d type=macos repo=<case>/repo workdir=<case>/remote/recovery_fixture/repo actions=- stop_command="crabbox stop --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture" idle_timeout=30m0s
failure-bundle local=.crabbox/captures/run_0a535cf1882d-20260906T233447Z.tar.gz bytes=1479 secret_risk=caller-redacts-before-sharing
workspace owner released
failure digest
  phase: user-command
  area: user_command
  retryable: unknown
  run_history: unavailable
  failed_phase: user-command
  observed_phases: user-command
  next: crabbox ssh --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture
  next: crabbox run --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture --no-sync -- /bin/sh -c 'test -f remote-marker || exit 42; exit 23'
  next: crabbox stop --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture
stdout tail: empty
stderr tail: empty
remote command exited 23
```

</details>

<details>
<summary>candidate: printed-proof-retry-missing — exit 7</summary>

```text
invocation: crabbox run --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture --no-sync --require-artifact required-proof.json --require-artifact 'reports/proof-*.json' -- true
observed: {"exit":7,"fault":null,"elapsedSeconds":4.044,"markerPresent":false,"requiredProofPresent":false,"reportProofPresent":false}
stdout:
(empty)
stderr:
static SSH architecture observed=arm64 source=ssh-uname-sysctl scope=posix-process version=1 observed_at=1788737698032 host=arm64 process=arm64 translated=false
workspace owner acquired wait=127ms recovered=false
run context:
  run=run_b0355ada6905 portal=- logs=-
  lease=recovery_fixture slug=recovery-fixture provider=ssh target=macos type=macos
  ssh=fixture@127.0.0.1:58347 ip=127.0.0.1
  workdir=<case>/remote/recovery_fixture/repo workspace=raw actions=-
running on 127.0.0.1 true
missing required artifact: required-proof.json
missing required artifact: reports/proof-*.json
command complete in 820ms total=1.839s
run summary lease=155ms bootstrap=282ms sync=0s command=820ms total=1.839s end_to_end=2.238s sync_skipped=true exit=7 command_phases=user-command:819ms blocked_stage=unknown retry_likely=unknown
run details provider=ssh lease=recovery_fixture slug=recovery-fixture run=run_b0355ada6905 type=macos repo=<case>/repo workdir=<case>/remote/recovery_fixture/repo actions=- stop_command="crabbox stop --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture" idle_timeout=30m0s
failure-bundle local=.crabbox/captures/run_b0355ada6905-20260906T233500Z.tar.gz bytes=1464 secret_risk=caller-redacts-before-sharing
workspace owner released
failure digest
  phase: command
  area: user_command
  retryable: unknown
  run_history: unavailable
  next: crabbox ssh --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture
  next: crabbox run --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture --no-sync --require-artifact required-proof.json --require-artifact 'reports/proof-*.json' -- true
  next: crabbox stop --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture
stdout tail: empty
stderr tail: empty
require artifacts: exit status 8: missing required artifact: required-proof.json
missing required artifact: reports/proof-*.json
```

</details>

<details>
<summary>candidate: printed-proof-retry-partial — exit 7</summary>

```text
invocation: crabbox run --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture --no-sync --require-artifact required-proof.json --require-artifact 'reports/proof-*.json' -- true
observed: {"exit":7,"fault":null,"elapsedSeconds":4.261,"markerPresent":false,"requiredProofPresent":true,"reportProofPresent":false}
stdout:
(empty)
stderr:
static SSH architecture observed=arm64 source=ssh-uname-sysctl scope=posix-process version=1 observed_at=1788737704441 host=arm64 process=arm64 translated=false
workspace owner acquired wait=127ms recovered=false
run context:
  run=run_c7cb82c05f06 portal=- logs=-
  lease=recovery_fixture slug=recovery-fixture provider=ssh target=macos type=macos
  ssh=fixture@127.0.0.1:58347 ip=127.0.0.1
  workdir=<case>/remote/recovery_fixture/repo workspace=raw actions=-
running on 127.0.0.1 true
required artifact required-proof.json matched=1
missing required artifact: reports/proof-*.json
command complete in 840ms total=1.968s
run summary lease=167ms bootstrap=300ms sync=0s command=840ms total=1.968s end_to_end=2.387s sync_skipped=true exit=7 command_phases=user-command:840ms blocked_stage=unknown retry_likely=unknown
run details provider=ssh lease=recovery_fixture slug=recovery-fixture run=run_c7cb82c05f06 type=macos repo=<case>/repo workdir=<case>/remote/recovery_fixture/repo actions=- stop_command="crabbox stop --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture" idle_timeout=30m0s
failure-bundle local=.crabbox/captures/run_c7cb82c05f06-20260906T233506Z.tar.gz bytes=1466 secret_risk=caller-redacts-before-sharing
workspace owner released
failure digest
  phase: command
  area: user_command
  retryable: unknown
  run_history: unavailable
  next: crabbox ssh --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture
  next: crabbox run --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture --no-sync --require-artifact required-proof.json --require-artifact 'reports/proof-*.json' -- true
  next: crabbox stop --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture
stdout tail: empty
stderr tail: empty
require artifacts: exit status 8: required artifact required-proof.json matched=1
missing required artifact: reports/proof-*.json
```

</details>

<details>
<summary>candidate: printed-proof-retry-complete — exit 0</summary>

```text
invocation: crabbox run --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture --no-sync --require-artifact required-proof.json --require-artifact 'reports/proof-*.json' -- true
observed: {"exit":0,"fault":null,"elapsedSeconds":3.812,"markerPresent":false,"requiredProofPresent":true,"reportProofPresent":true}
stdout:
(empty)
stderr:
static SSH architecture observed=arm64 source=ssh-uname-sysctl scope=posix-process version=1 observed_at=1788737711109 host=arm64 process=arm64 translated=false
workspace owner acquired wait=232ms recovered=false
run context:
  run=run_210bdce9e3ca portal=- logs=-
  lease=recovery_fixture slug=recovery-fixture provider=ssh target=macos type=macos
  ssh=fixture@127.0.0.1:58347 ip=127.0.0.1
  workdir=<case>/remote/recovery_fixture/repo workspace=raw actions=-
running on 127.0.0.1 true
required artifact required-proof.json matched=1
required artifact reports/proof-*.json matched=1
artifact kind=artifact-glob path=<case>/repo/.crabbox/runs/run_210bdce9e3ca/run_210bdce9e3ca-artifacts.tgz bytes=361
command complete in 814ms total=2.981s
run summary lease=160ms bootstrap=262ms sync=0s command=814ms total=2.981s end_to_end=3.495s sync_skipped=true exit=0 command_phases=user-command:814ms
run details provider=ssh lease=recovery_fixture slug=recovery-fixture run=run_210bdce9e3ca type=macos repo=<case>/repo workdir=<case>/remote/recovery_fixture/repo actions=- stop_command="crabbox stop --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture" idle_timeout=30m0s
workspace owner released
```

</details>

<details>
<summary>candidate: original-no-sync-failure — exit 23</summary>

```text
invocation: '<binary>' run --provider ssh --target macos --no-sync --no-hydrate --keep --timing-json --id recovery-fixture -- /bin/sh -c 'test -f remote-marker || exit 42; exit 23'
observed: {"exit":23,"fault":null,"elapsedSeconds":3.114,"markerPresent":true,"requiredProofPresent":false,"reportProofPresent":false}
stdout:
(empty)
stderr:
static SSH architecture observed=arm64 source=ssh-uname-sysctl scope=posix-process version=1 observed_at=1788737681558 host=arm64 process=arm64 translated=false
workspace owner acquired wait=128ms recovered=false
run context:
  run=run_e25f365c0274 portal=- logs=-
  lease=recovery_fixture slug=recovery-fixture provider=ssh target=macos type=macos
  ssh=fixture@127.0.0.1:58347 ip=127.0.0.1
  workdir=<case>/remote/recovery_fixture/repo workspace=raw actions=-
running on 127.0.0.1 /bin/sh -c 'test -f remote-marker || exit 42; exit 23'
command complete in 850ms total=1.583s
run summary lease=163ms bootstrap=336ms sync=0s command=850ms total=1.583s end_to_end=1.992s sync_skipped=true exit=23 command_phases=user-command:850ms blocked_stage=unknown retry_likely=unknown
run details provider=ssh lease=recovery_fixture slug=recovery-fixture run=run_e25f365c0274 type=macos repo=<case>/repo workdir=<case>/remote/recovery_fixture/repo actions=- stop_command="crabbox stop --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture" idle_timeout=30m0s
failure-bundle local=.crabbox/captures/run_e25f365c0274-20260906T233443Z.tar.gz bytes=1481 secret_risk=caller-redacts-before-sharing
workspace owner released
failure digest
  phase: user-command
  area: user_command
  retryable: unknown
  run_history: unavailable
  failed_phase: user-command
  observed_phases: user-command
  next: crabbox ssh --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture
  next: crabbox run --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture --no-sync -- /bin/sh -c 'test -f remote-marker || exit 42; exit 23'
  next: crabbox stop --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture
stdout tail: empty
stderr tail: empty
{"provider":"ssh","leaseId":"recovery_fixture","slug":"recovery-fixture","runnerTotalMs":2964,"runnerPhases":[{"name":"provider.resolve","ms":163,"provider":"ssh","leaseId":"recovery_fixture","slug":"recovery-fixture","machineType":"macos"},{"name":"connect.ssh","ms":415,"provider":"ssh","leaseId":"recovery_fixture","slug":"recovery-fixture","machineType":"macos"},{"name":"command","ms":850,"provider":"ssh","leaseId":"recovery_fixture","slug":"recovery-fixture","runId":"run_e25f365c0274","machineType":"macos"},{"name":"cleanup","ms":139,"provider":"ssh","leaseId":"recovery_fixture","slug":"recovery-fixture","machineType":"macos"},{"name":"unattributed","ms":1397}],"leaseMs":163,"bootstrapMs":336,"syncMs":0,"syncSkipped":true,"commandMs":850,"commandPhases":[{"name":"user-command","ms":850}],"totalMs":1582,"endToEndMs":1991,"exitCode":23,"runStatus":"failed","errorKind":"command-exit","runId":"run_e25f365c0274","machineType":"macos","repoPath":"<case>/repo","workdir":"<case>/remote/recovery_fixture/repo","stopCommand":"crabbox stop --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture","idleTimeout":"30m0s","blockedStage":"unknown","retryLikely":"unknown"}
remote command exited 23
```

</details>

<details>
<summary>candidate: original-missing-proof — exit 7</summary>

```text
invocation: '<binary>' run --provider ssh --target macos --no-sync --no-hydrate --keep --timing-json --id recovery-fixture --require-artifact required-proof.json --require-artifact 'reports/proof-*.json' -- true
observed: {"exit":7,"fault":null,"elapsedSeconds":3.963,"markerPresent":false,"requiredProofPresent":false,"reportProofPresent":false}
stdout:
(empty)
stderr:
static SSH architecture observed=arm64 source=ssh-uname-sysctl scope=posix-process version=1 observed_at=1788737694064 host=arm64 process=arm64 translated=false
workspace owner acquired wait=119ms recovered=false
run context:
  run=run_7f4d0e13b540 portal=- logs=-
  lease=recovery_fixture slug=recovery-fixture provider=ssh target=macos type=macos
  ssh=fixture@127.0.0.1:58347 ip=127.0.0.1
  workdir=<case>/remote/recovery_fixture/repo workspace=raw actions=-
running on 127.0.0.1 true
missing required artifact: required-proof.json
missing required artifact: reports/proof-*.json
command complete in 810ms total=2.485s
run summary lease=153ms bootstrap=492ms sync=0s command=810ms total=2.485s end_to_end=2.874s sync_skipped=true exit=7 command_phases=user-command:809ms blocked_stage=unknown retry_likely=unknown
run details provider=ssh lease=recovery_fixture slug=recovery-fixture run=run_7f4d0e13b540 type=macos repo=<case>/repo workdir=<case>/remote/recovery_fixture/repo actions=- stop_command="crabbox stop --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture" idle_timeout=30m0s
failure-bundle local=.crabbox/captures/run_7f4d0e13b540-20260906T233456Z.tar.gz bytes=1460 secret_risk=caller-redacts-before-sharing
workspace owner released
failure digest
  phase: command
  area: user_command
  retryable: unknown
  run_history: unavailable
  next: crabbox ssh --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture
  next: crabbox run --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture --no-sync --require-artifact required-proof.json --require-artifact 'reports/proof-*.json' -- true
  next: crabbox stop --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture
stdout tail: empty
stderr tail: empty
{"provider":"ssh","leaseId":"recovery_fixture","slug":"recovery-fixture","runnerTotalMs":3820,"runnerPhases":[{"name":"provider.resolve","ms":153,"provider":"ssh","leaseId":"recovery_fixture","slug":"recovery-fixture","machineType":"macos"},{"name":"connect.ssh","ms":569,"provider":"ssh","leaseId":"recovery_fixture","slug":"recovery-fixture","machineType":"macos"},{"name":"command","ms":809,"provider":"ssh","leaseId":"recovery_fixture","slug":"recovery-fixture","runId":"run_7f4d0e13b540","machineType":"macos"},{"name":"artifacts","ms":246,"provider":"ssh","leaseId":"recovery_fixture","slug":"recovery-fixture","runId":"run_7f4d0e13b540","machineType":"macos"},{"name":"cleanup","ms":126,"provider":"ssh","leaseId":"recovery_fixture","slug":"recovery-fixture","machineType":"macos"},{"name":"unattributed","ms":1917}],"leaseMs":153,"bootstrapMs":491,"syncMs":0,"syncSkipped":true,"commandMs":809,"commandPhases":[{"name":"user-command","ms":809}],"totalMs":2484,"endToEndMs":2873,"exitCode":7,"runStatus":"failed","errorKind":"command-exit","runId":"run_7f4d0e13b540","machineType":"macos","repoPath":"<case>/repo","workdir":"<case>/remote/recovery_fixture/repo","stopCommand":"crabbox stop --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58347 --static-work-root <case>/remote --id recovery-fixture","idleTimeout":"30m0s","blockedStage":"unknown","retryLikely":"unknown"}
require artifacts: exit status 8: missing required artifact: required-proof.json
missing required artifact: reports/proof-*.json
```

</details>

<details>
<summary>candidate: explicit-stop — exit 0</summary>

```text
invocation: '<binary>' stop --provider ssh --id recovery-fixture
observed: {"exit":0,"fault":null,"elapsedSeconds":0.173,"markerPresent":false,"requiredProofPresent":true,"reportProofPresent":true}
stdout:
(empty)
stderr:
static SSH architecture historical=arm64 source=ssh-uname-sysctl scope=posix-process observed_at=1788737711109 host=arm64 process=arm64 translated=false (offline; refreshed before execution)
released static lease=recovery_fixture host=127.0.0.1
```

</details>

<details>
<summary>base: printed-no-sync-retry — exit 42</summary>

```text
invocation: crabbox run --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58349 --static-work-root <case>/remote --id recovery-fixture --fresh-sync -- /bin/sh -c 'test -f remote-marker || exit 42; exit 23'
observed: {"exit":42,"fault":null,"elapsedSeconds":6.92,"markerPresent":false,"requiredProofPresent":false,"reportProofPresent":false}
stdout:
(empty)
stderr:
static SSH architecture observed=arm64 source=ssh-uname-sysctl scope=posix-process version=1 observed_at=1788737685200 host=arm64 process=arm64 translated=false
workspace owner acquired wait=122ms recovered=false
syncing <case>/repo -> 127.0.0.1:<case>/remote/recovery_fixture/repo
run context:
  run=run_99ac5b5e5f98 portal=- logs=-
  lease=recovery_fixture slug=recovery-fixture provider=ssh target=macos type=macos
  ssh=fixture@127.0.0.1:58349 ip=127.0.0.1
  workdir=<case>/remote/recovery_fixture/repo workspace=raw actions=-
sync candidate: 1 files, 24 B
full-resync resetting remote workdir <case>/remote/recovery_fixture/repo
sync complete in 3.871s
running on 127.0.0.1 /bin/sh -c 'test -f remote-marker || exit 42; exit 23'
command complete in 291ms total=5.386s
run summary lease=160ms bootstrap=1.007s sync=3.871s command=291ms total=5.386s end_to_end=5.784s sync_skipped=false exit=42 sync_steps=ssh:758ms,mkdir:364ms,manifest:142ms,preflight:0s,reset:258ms,manifest_write:322ms,prune:356ms,rsync:1.044s,finalize:592ms command_phases=user-command:291ms blocked_stage=unknown retry_likely=unknown
run details provider=ssh lease=recovery_fixture slug=recovery-fixture run=run_99ac5b5e5f98 type=macos repo=<case>/repo workdir=<case>/remote/recovery_fixture/repo actions=- stop_command="crabbox stop --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58349 --static-work-root <case>/remote --id recovery-fixture" idle_timeout=30m0s
failure-bundle local=.crabbox/captures/run_99ac5b5e5f98-20260906T233450Z.tar.gz bytes=1595 secret_risk=caller-redacts-before-sharing
workspace owner released
failure digest
  phase: user-command
  area: user_command
  retryable: unknown
  run_history: unavailable
  failed_phase: user-command
  observed_phases: user-command
  next: crabbox ssh --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58349 --static-work-root <case>/remote --id recovery-fixture
  next: crabbox run --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58349 --static-work-root <case>/remote --id recovery-fixture --fresh-sync -- /bin/sh -c 'test -f remote-marker || exit 42; exit 23'
  next: crabbox stop --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58349 --static-work-root <case>/remote --id recovery-fixture
stdout tail: empty
stderr tail: empty
remote command exited 42
```

</details>

<details>
<summary>base: printed-proof-retry-missing — exit 0</summary>

```text
invocation: crabbox run --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58349 --static-work-root <case>/remote --id recovery-fixture --fresh-sync -- true
observed: {"exit":0,"fault":null,"elapsedSeconds":5.538,"markerPresent":false,"requiredProofPresent":false,"reportProofPresent":false}
stdout:
(empty)
stderr:
static SSH architecture observed=arm64 source=ssh-uname-sysctl scope=posix-process version=1 observed_at=1788737696164 host=arm64 process=arm64 translated=false
workspace owner acquired wait=123ms recovered=false
syncing <case>/repo -> 127.0.0.1:<case>/remote/recovery_fixture/repo
run context:
  run=run_27ca3ed82675 portal=- logs=-
  lease=recovery_fixture slug=recovery-fixture provider=ssh target=macos type=macos
  ssh=fixture@127.0.0.1:58349 ip=127.0.0.1
  workdir=<case>/remote/recovery_fixture/repo workspace=raw actions=-
sync candidate: 1 files, 24 B
full-resync resetting remote workdir <case>/remote/recovery_fixture/repo
sync complete in 3.051s
running on 127.0.0.1 true
command complete in 289ms total=4.329s
run summary lease=160ms bootstrap=547ms sync=3.051s command=289ms total=4.329s end_to_end=4.734s sync_skipped=false exit=0 sync_steps=ssh:284ms,mkdir:243ms,manifest:140ms,preflight:0s,reset:268ms,manifest_write:291ms,prune:314ms,rsync:1.13s,finalize:345ms command_phases=user-command:288ms
run details provider=ssh lease=recovery_fixture slug=recovery-fixture run=run_27ca3ed82675 type=macos repo=<case>/repo workdir=<case>/remote/recovery_fixture/repo actions=- stop_command="crabbox stop --provider ssh --target macos --static-host 127.0.0.1 --static-user fixture --static-port 58349 --static-work-root <case>/remote --id recovery-fixture" idle_timeout=30m0s
workspace owner released
```

</details>

<details>
<summary>base: explicit-stop — exit 0</summary>

```text
invocation: '<binary>' stop --provider ssh --id recovery-fixture
observed: {"exit":0,"fault":null,"elapsedSeconds":0.46,"markerPresent":false,"requiredProofPresent":false,"reportProofPresent":false}
stdout:
(empty)
stderr:
static SSH architecture historical=arm64 source=ssh-uname-sysctl scope=posix-process observed_at=1788737696164 host=arm64 process=arm64 translated=false (offline; refreshed before execution)
released static lease=recovery_fixture host=127.0.0.1
```

</details>

Both final cleanup receipts report `cleanupExit=0`, `remainingClaims=0`, and `ownedTempRemoved=true`. Full private receipts, source/build metadata, and historical qualification records remain preserved; only the selected readable captures above are embedded here.

## Frozen inputs and reconstruction

This fresh integration proof used base commit `5344e73cd47a03a5ece2c78ffce07b262c840a2d` and that exact base plus the seven-file patch embedded below. The original repair was committed as `828f5d7d1262607c2f86a41caaba80fe35cbdd0f`, then main was merged with a changelog-only conflict resolved to preserve both entries. The merge candidate was staged/uncommitted at proof time; the patch and file hashes bind the actual snapshot, rather than claiming a future PR commit was executed. All 2,226 regular archived source files were checked against both build trees, allowing only the seven recorded overrides. All six non-changelog recovery files and the fixture/shim are byte-identical to the original freeze; main adds independently landed changes, so both binaries were rebuilt and replayed. Source was unchanged after this integration review/build/replay. Prior base-69 proof, binaries, captures, and qualification history remain immutable. Both builds exited 0 with Go 1.26.5, `darwin/arm64`, `CGO_ENABLED=0`, `-trimpath`, and `-buildvcs=false`.

| Input | SHA-256 |
| --- | --- |
| `seven-file candidate.patch` | `1b5efc3060459358ded0deac968e9df5bb5a677771a7bdcca70d55918281d878` |
| `base binary` | `a97d012f6dd9592e71fef76aabbc568e7ab7c5cb7b5767fe366f1d5dcfbd8978` |
| `candidate binary` | `83abe37d9b2ab07db24f8475fa5bb697d8a883082a5795883552be405ea810f0` |
| `native/proof.py` | `857e88834e3acc09d8a9b3ce1d657da3768838c85517a26f12f9df02a5ec985a` |
| `native/ssh.py` | `360a41b5ee6991ab97e8ad69b45df01ae8ac2bbbf4d41f1adbd77f15565cc8dd` |

<details>
<summary>All seven frozen source-file hashes</summary>

```text
96d9102e08fd42fe57a4a5008d88abccc77331bbcbd482c478e3a7baa876eb3c  CHANGELOG.md
51a5fd32cf405c714b6281920d555fe93243723f427833fe0ec6c366b0280c3c  docs/commands/run.md
b2219823d3472b84d826badd5c905044e27ca996ae9487e91cab6d6ef7e8fc42  internal/cli/run.go
2e4d859ce6da2e227fb2ebca54099e68f1403dbecd7c43ccd6d2e15664e114ec  internal/cli/run_failure.go
71c9648d47f1d73641fbc64188a0b69c1d0e6a99ea009ab599d802b3a6173524  internal/cli/run_failure_test.go
e46feb8436cc94d342f36920d04a1337669315d9bff416128d96dc097df6a40c  internal/cli/run_test.go
fe77ccf0df851c95b7b23cf419950e93559ce77a3c1ffe1a5d657095b551f8f1  internal/cli/run_workspace_owner_cleanup_test.go
```

</details>

Save the three complete blocks below as `candidate.patch`, `native/proof.py`, and `native/ssh.py` in a new proof directory; preserve the trailing newline in each. From a local repository containing the pinned base, reconstruct and build in owned directories (replace only `/path/to/crabbox`):

```sh
proof_dir="$PWD"
mkdir base-source candidate-source bin
# Archive the pinned public base; no checkout switch or source mutation.
git -C /path/to/crabbox archive 5344e73cd47a03a5ece2c78ffce07b262c840a2d > base-source.tar
tar -xf base-source.tar -C base-source
tar -xf base-source.tar -C candidate-source
# Keep patch application independent of any enclosing repository.
git -C candidate-source init -q
git -C candidate-source apply "$proof_dir/candidate.patch"
shasum -a 256 candidate.patch native/proof.py native/ssh.py
(
  cd base-source
  GOTOOLCHAIN=go1.26.5 GOMAXPROCS=4 GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -p=2 -trimpath -buildvcs=false -o "$proof_dir/bin/crabbox-base" ./cmd/crabbox
)
(
  cd candidate-source
  GOTOOLCHAIN=go1.26.5 GOMAXPROCS=4 GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -p=2 -trimpath -buildvcs=false -o "$proof_dir/bin/crabbox-candidate" ./cmd/crabbox
)
shasum -a 256 bin/crabbox-base bin/crabbox-candidate
# On macOS ARM64; both result directories must be new.
python3 native/proof.py bin/crabbox-candidate candidate native/candidate-new
python3 native/proof.py bin/crabbox-base base native/base-new
```

The driver/shim require Python 3.9+ (`Path.is_relative_to`), native `/bin/sh`, Git, SSH, and rsync. The observed host supplied macOS OpenRSYNC (rsync 2.6.9-compatible/protocol 29). Save blocks and compare their hashes before running; output run IDs, temporary roots, ports, timings, and archive hashes naturally vary between executions. Build-module/toolchain downloads may require network access; the execution fixture needs no provider account or external execution target.

<details>
<summary>Complete frozen seven-file patch</summary>

```diff
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 78b08d33..575e97b0 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve explicit no-sync intent and required-artifact globs in failure-digest retries, avoiding an unintended workspace reset or weakened evidence checks. [Issue 1875](https://github.com/openclaw/crabbox/issues/1875), [Issue 1895](https://github.com/openclaw/crabbox/issues/1895). Thanks @coygeek.
 - Start commands without waiting for best-effort telemetry uploads, and cancel and join the telemetry publisher before run completion or lease replacement while preserving baseline samples and verified terminal receipts. [PR 1931](https://github.com/openclaw/crabbox/pull/1931).
 
 - Local containers: optionally omit the explicit hostname for runtimes sharing a host UTS namespace, support YAML and environment configuration, and reject incompatible fixed-ID reuse without changing existing default fingerprints. [PR 1813](https://github.com/openclaw/crabbox/pull/1813), [PR 1924](https://github.com/openclaw/crabbox/pull/1924). Thanks @atrawog.
diff --git a/docs/commands/run.md b/docs/commands/run.md
index 0dc6ff32..7226c7ba 100644
--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -757,8 +757,12 @@ its status before reuse, or retry the printed stop command to finish cleanup.
 The digest includes the failed phase when phase markers are known, a
 likely area (provider auth, SSH/connectivity, sync, install/setup, user command,
 model/tool/provider limit, or resource exhaustion), retryability when inferable, next commands
-(`logs`, `events`, `doctor --from-run`, `ssh`, retrying with `--fresh-sync`, and
-`stop`). After failure-bundle information and command hints, each stream has one
+(`logs`, `events`, `doctor --from-run`, `ssh`, retrying, and `stop`). A retry
+preserves an explicitly requested `--no-sync`, so it does not reset the retained
+workspace. Other retries retain the `--fresh-sync` guidance above. Each original
+`--require-artifact` glob is retained in the retry, so missing required evidence
+still fails the rerun. After failure-bundle information and command hints, each
+stream has one
 redacted tail section of up to 40 lines, or its capture path when explicitly
 captured. Live output and failure-bundle contents are unchanged. The digest does
 not reconstruct secrets or hidden local shell state. Short-circuit explanations are limited to simple
diff --git a/internal/cli/run.go b/internal/cli/run.go
index 897d6e02..50ec0f98 100644
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2892,6 +2892,8 @@ afterSync:
 			CommandDisplay:        commandDisplay,
 			ShellMode:             *shellMode || useShell,
 			ScriptMode:            script != nil,
+			NoSync:                *noSync,
+			RequiredArtifactGlobs: append([]string(nil), requiredArtifactGlobs...),
 			Routing:               CommandRoutingFor(cfg, leaseID, CommandRoutingRetry),
 			SSHRouting:            CommandRoutingFor(cfg, leaseID, CommandRoutingRetry),
 			StopRouting:           CommandRoutingFor(cfg, leaseID, CommandRoutingStop),
diff --git a/internal/cli/run_failure.go b/internal/cli/run_failure.go
index 7d6f09a3..1d5940ae 100644
--- a/internal/cli/run_failure.go
+++ b/internal/cli/run_failure.go
@@ -296,6 +296,8 @@ type runFailureDigestInput struct {
 	CommandDisplay        string
 	ShellMode             bool
 	ScriptMode            bool
+	NoSync                bool
+	RequiredArtifactGlobs []string
 	Routing               CommandRouting
 	SSHRouting            CommandRouting
 	StopRouting           CommandRouting
@@ -425,7 +427,14 @@ func failureDigestNextCommands(input runFailureDigestInput, retry string) []stri
 			if len(routing.Args) == 0 {
 				routing = fallbackFailureDigestRouting(input, CommandRoutingRetry)
 			}
-			runArgs := append(append([]string{"crabbox", "run"}, routing.Args...), "--id", leaseRef, "--fresh-sync")
+			syncFlag := "--fresh-sync"
+			if input.NoSync {
+				syncFlag = "--no-sync"
+			}
+			runArgs := append(append([]string{"crabbox", "run"}, routing.Args...), "--id", leaseRef, syncFlag)
+			for _, glob := range input.RequiredArtifactGlobs {
+				runArgs = append(runArgs, "--require-artifact", glob)
+			}
 			if input.ShellMode {
 				runArgs = append(runArgs, "--shell")
 			}
diff --git a/internal/cli/run_failure_test.go b/internal/cli/run_failure_test.go
index 27c767bf..86087736 100644
--- a/internal/cli/run_failure_test.go
+++ b/internal/cli/run_failure_test.go
@@ -7,8 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -731,6 +733,96 @@ func TestFailureDigestSuppressesScriptRetryCommand(t *testing.T) {
 	}
 }
 
+func TestFailureDigestPreservesRecoveryIntent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX rendered-shell argv fixture")
+	}
+	for _, tc := range []struct {
+		name                                    string
+		noSync, shell, script, stopped, noRetry bool
+		globs                                   []string
+	}{
+		{name: "default keeps fresh sync"},
+		{name: "no sync", noSync: true},
+		{name: "requirements", globs: []string{"reports/manifest.json", "reports/proof-*.json"}},
+		{name: "no sync requirements shell", noSync: true, shell: true, globs: []string{"reports/manifest.json", "reports/proof-*.json"}},
+		{name: "script suppressed", script: true, noSync: true, globs: []string{"proof.json"}},
+		{name: "retry suppressed", noRetry: true, noSync: true, globs: []string{"proof.json"}},
+		{name: "stopped suppressed", stopped: true, noSync: true, globs: []string{"proof.json"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.Mkdir(filepath.Join(dir, "reports"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "reports", "proof-local.json"), nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			capture := filepath.Join(dir, "argv")
+			if err := os.WriteFile(filepath.Join(dir, "crabbox"), []byte("#!/bin/sh\nprintf '%s\\000' \"$@\" > \"$FIXTURE_ARGV\"\n"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			display := "printf '%s\\n' 'two words'"
+			if tc.shell {
+				display = "printf first && printf second"
+			}
+			routing := CommandRouting{Args: []string{"--provider", "local-container", "--local-container-runtime", "docker"}}
+			input := runFailureDigestInput{LeaseID: "cbx_fixture", CommandDisplay: display, ShellMode: tc.shell, ScriptMode: tc.script, LeaseStopped: tc.stopped, NoSync: tc.noSync, RequiredArtifactGlobs: tc.globs, Routing: routing}
+			retry := "unknown"
+			if tc.noRetry {
+				retry = "false"
+			}
+			var hint string
+			for _, command := range failureDigestNextCommands(input, retry) {
+				if strings.HasPrefix(command, "crabbox run ") {
+					if hint != "" {
+						t.Fatal("multiple retry commands")
+					}
+					hint = command
+				}
+			}
+			if tc.script || tc.stopped || tc.noRetry {
+				if hint != "" {
+					t.Fatalf("unexpected retry: %s", hint)
+				}
+				return
+			}
+			if hint == "" {
+				t.Fatal("missing retry")
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, "/bin/sh", "-c", hint)
+			cmd.Dir = dir
+			cmd.Env = []string{"PATH=" + dir + ":/usr/bin:/bin", "FIXTURE_ARGV=" + capture}
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("replay: %v %s", err, out)
+			}
+			data, err := os.ReadFile(capture)
+			if err != nil {
+				t.Fatal(err)
+			}
+			args := strings.Split(strings.TrimSuffix(string(data), "\x00"), "\x00")
+			syncFlag := "--fresh-sync"
+			if tc.noSync {
+				syncFlag = "--no-sync"
+			}
+			want := append(append([]string{"run"}, routing.Args...), "--id", "cbx_fixture", syncFlag)
+			for _, glob := range tc.globs {
+				want = append(want, "--require-artifact", glob)
+			}
+			if tc.shell {
+				want = append(want, "--shell", "--", display)
+			} else {
+				want = append(want, "--", "printf", "%s\\n", "two words")
+			}
+			if !reflect.DeepEqual(args, want) {
+				t.Fatalf("args=%q want=%q", args, want)
+			}
+		})
+	}
+}
+
 func TestFailureDigestRoutesNextCommands(t *testing.T) {
 	commands := failureDigestNextCommands(runFailureDigestInput{
 		Provider:       "aws",
diff --git a/internal/cli/run_test.go b/internal/cli/run_test.go
index a8774d8f..58230034 100644
--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3294,6 +3294,7 @@ exit 0
 		"--keep-on-failure",
 		"--timing-json",
 		"--require-artifact", "reports/data/manifest.json",
+		"--require-artifact", "reports/proof-*.json",
 		"--download", "reports/data/manifest.json=" + downloadPath,
 		"--", "fixture-stage-success",
 	})
@@ -3319,6 +3320,20 @@ exit 0
 	if !strings.Contains(stderr.String(), "keep-on-failure: kept lease=cbx_env_profile_test") {
 		t.Fatalf("missing keep-on-failure hint after required artifact failure:\n%s", stderr.String())
 	}
+	retryHints := 0
+	for _, line := range strings.Split(stderr.String(), "\n") {
+		if strings.Contains(line, "next: crabbox run ") {
+			retryHints++
+			if !strings.Contains(line, "--no-sync") || strings.Contains(line, "--fresh-sync") ||
+				!strings.Contains(line, "--require-artifact reports/data/manifest.json") ||
+				!strings.Contains(line, "--require-artifact 'reports/proof-*.json'") {
+				t.Errorf("retry lost no-sync or required-artifact intent: %s", line)
+			}
+		}
+	}
+	if retryHints != 1 {
+		t.Errorf("retry hints=%d, want one runnable recovery", retryHints)
+	}
 	lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
 	var report TimingReport
 	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &report); err != nil {
diff --git a/internal/cli/run_workspace_owner_cleanup_test.go b/internal/cli/run_workspace_owner_cleanup_test.go
index d255bbae..e7f2d0d6 100644
--- a/internal/cli/run_workspace_owner_cleanup_test.go
+++ b/internal/cli/run_workspace_owner_cleanup_test.go
@@ -586,6 +586,14 @@ func TestRunFailureDigestCleanupOutcomes(t *testing.T) {
 					t.Errorf("recovery %s present=%v, stopped=%v:\n%s", command, got, test.wantStop, out)
 				}
 			}
+			if !test.wantStop {
+				for _, line := range strings.Split(out, "\n") {
+					if strings.Contains(line, "next: crabbox run ") &&
+						(!strings.Contains(line, "--no-sync") || strings.Contains(line, "--fresh-sync")) {
+						t.Errorf("retained retry lost no-sync intent: %s", line)
+					}
+				}
+			}
 			if (test.wantStop || test.stopErr != nil || test.retained) != (releaseCalls == 1) {
 				t.Errorf("release calls=%d", releaseCalls)
 			}
```

</details>

<details>
<summary>Complete native driver — save as native/proof.py</summary>

```python
import os,sys,pathlib,tempfile,subprocess,socket,threading,json,signal,shlex,hashlib,shutil,time
E=pathlib.Path(__file__).resolve().parent
binary=pathlib.Path(sys.argv[1]).resolve();mode=sys.argv[2];output=pathlib.Path(sys.argv[3]).resolve();assert mode in ['base','candidate'] and not output.exists();output.mkdir()
root=pathlib.Path(tempfile.mkdtemp(prefix='recovery-intent-native-')).resolve();(root/'fixture-owned').write_text('owned\n')
for d in ['home','remote-home','remote-tmp','tmp','state','config','repo','bin','remote']:(root/d).mkdir(mode=0o700)
(root/'key').write_text('synthetic unused key\n');(root/'key').chmod(0o600)
sock=socket.socket();sock.bind(('127.0.0.1',0));sock.listen();port=str(sock.getsockname()[1])
def accept():
 while True:
  try:c,_=sock.accept();c.close()
  except OSError:return
threading.Thread(target=accept,daemon=True).start()
(root/'bin/ssh').write_text('#!/bin/sh\nRECOVERY_FIXTURE_ROOT='+shlex.quote(str(root))+' RECOVERY_FIXTURE_PORT='+port+' exec '+shlex.quote(sys.executable)+' '+shlex.quote(str(E/'ssh.py'))+' "$@"\n');(root/'bin/ssh').chmod(0o700)
(root/'bin/crabbox').symlink_to(binary)
env={'HOME':str(root/'home'),'PATH':str(root/'bin')+':/usr/bin:/bin:/usr/sbin:/sbin','TMPDIR':str(root/'tmp'),'XDG_STATE_HOME':str(root/'state'),'XDG_CONFIG_HOME':str(root/'config'),'CRABBOX_CONFIG':str(root/'config.yaml'),'GIT_CONFIG_NOSYSTEM':'1','GIT_CONFIG_GLOBAL':'/dev/null','GIT_TERMINAL_PROMPT':'0','RECOVERY_FIXTURE_ROOT':str(root),'RECOVERY_FIXTURE_PORT':port,'GOMAXPROCS':'4'}
(root/'config.yaml').write_text('provider: ssh\ntarget: macos\nssh:\n  key: '+str(root/'key')+'\n  fallbackPorts: ["'+port+'"]\nstatic:\n  id: recovery_fixture\n  name: recovery-fixture\n  host: 127.0.0.1\n  port: "'+port+'"\n  user: fixture\n  workRoot: '+str(root/'remote')+'\n')
(root/'repo/README.md').write_text('synthetic fixture input\n')
for a in [['init','-q'],['add','.'],['-c','user.name=Synthetic Fixture','-c','user.email=fixture@example.invalid','-c','commit.gpgsign=false','commit','-qm','fixture']]:subprocess.run(['/usr/bin/git',*a],cwd=root/'repo',env=env,check=True,capture_output=True)
work=root/'remote/recovery_fixture/repo';claims=root/'state/crabbox/claims';records=[];active=[]
def sanitize(s):return s.replace(str(root),'<case>').replace(str(E),'<proof>').replace(str(binary),'<binary>')
def save(result):
 result['commands']=records
 (output/'results.json').write_text(sanitize(json.dumps(result,indent=2))+'\n')
def run(label,args=None,hint=None):
 assert (args is None)!=(hint is None)
 argv=[str(binary),*args] if args is not None else ['/bin/sh','-c',hint]
 started=time.monotonic();p=subprocess.Popen(argv,cwd=root/'repo',env=env,stdin=subprocess.DEVNULL,stdout=subprocess.PIPE,stderr=subprocess.PIPE,text=True,start_new_session=True);active.append(p)
 fault=None
 try:out,err=p.communicate(timeout=45)
 except subprocess.TimeoutExpired:
  fault='CLI timeout';os.killpg(p.pid,signal.SIGKILL);out,err=p.communicate(timeout=5)
 active.remove(p)
 row={'label':label,'argv':argv,'printedCommandReplayed':hint,'exit':p.returncode,'stdout':out,'stderr':err,'fault':fault,'elapsedSeconds':round(time.monotonic()-started,3),'markerPresent':(work/'remote-marker').exists(),'requiredProofPresent':(work/'required-proof.json').exists(),'reportProofPresent':(work/'reports/proof-one.json').exists()}
 records.append(row);print(json.dumps({k:row[k] for k in ['label','exit','fault','markerPresent','requiredProofPresent','reportProofPresent']}),flush=True);assert fault is None
 return row
def hint(row):
 matches=[line.strip()[len('next: '):] for line in row['stderr'].splitlines() if line.strip().startswith('next: crabbox run ')]
 assert len(matches)==1,matches
 return matches[0]
flags=['run','--provider','ssh','--target','macos','--no-sync','--no-hydrate','--keep','--timing-json']
result={'mode':mode,'binarySha256':hashlib.sha256(binary.read_bytes()).hexdigest(),'fixtureSha256':hashlib.sha256(pathlib.Path(__file__).read_bytes()).hexdigest(),'sshShimSha256':hashlib.sha256((E/'ssh.py').read_bytes()).hexdigest(),'scope':'Built CLI, simulated loopback SSH transport, real macOS shell/rsync/workspace-owner and artifact commands on owned local data; no actual SSH authentication, VM or third-party target.'}
try:
 seed=run('seed-marker',args=flags+['--','/bin/sh','-c','printf preserved > remote-marker']);assert seed['exit']==0
 failed=run('original-no-sync-failure',args=flags+['--id','recovery-fixture','--','/bin/sh','-c','test -f remote-marker || exit 42; exit 23']);assert failed['exit']==23 and failed['markerPresent']
 retry=hint(failed);result['noSyncHint']=retry
 repeated=run('printed-no-sync-retry',hint=retry)
 if mode=='candidate':assert '--no-sync' in retry and '--fresh-sync' not in retry and repeated['exit']==23 and repeated['markerPresent']
 else:assert '--fresh-sync' in retry and repeated['exit']==42 and not repeated['markerPresent']
 if mode=='candidate':
  explicit=run('explicit-reset-control',args=['run','--provider','ssh','--target','macos','--id','recovery-fixture','--fresh-sync','--keep','--timing-json','--','/bin/sh','-c','test ! -f remote-marker']);assert explicit['exit']==0 and not explicit['markerPresent']
 missing=run('original-missing-proof',args=flags+['--id','recovery-fixture','--require-artifact','required-proof.json','--require-artifact','reports/proof-*.json','--','true']);assert missing['exit']==7
 retryProof=hint(missing);result['artifactHint']=retryProof
 absent=run('printed-proof-retry-missing',hint=retryProof)
 if mode=='candidate':assert retryProof.count('--require-artifact')==2 and absent['exit']==7 and not absent['requiredProofPresent'] and not absent['reportProofPresent']
 else:assert '--require-artifact' not in retryProof and absent['exit']==0 and not absent['requiredProofPresent'] and not absent['reportProofPresent']
 if mode=='candidate':
  one=run('produce-first-proof',args=flags+['--id','recovery-fixture','--','/bin/sh','-c',"printf '{}' > required-proof.json"]);assert one['exit']==0
  partial=run('printed-proof-retry-partial',hint=retryProof);assert partial['exit']==7 and partial['requiredProofPresent'] and not partial['reportProofPresent']
  both=run('produce-second-proof',args=flags+['--id','recovery-fixture','--','/bin/sh','-c',"mkdir -p reports; printf '{}' > reports/proof-one.json"]);assert both['exit']==0
  present=run('printed-proof-retry-complete',hint=retryProof);assert present['exit']==0 and present['requiredProofPresent'] and present['reportProofPresent']
 result['passed']=True
except Exception as error:result.update(passed=False,error=str(error))
finally:
 for p in active:
  try:os.killpg(p.pid,signal.SIGKILL)
  except ProcessLookupError:pass
 try:
  stop=run('explicit-stop',args=['stop','--provider','ssh','--id','recovery-fixture']);result['cleanupExit']=stop['exit'];result['remainingClaims']=len(list(claims.glob('*.json'))) if claims.exists() else 0
 except Exception as error:result['cleanupError']=str(error)
 result['trace']=[json.loads(x) for x in (root/'ssh-trace.jsonl').read_text().splitlines()] if (root/'ssh-trace.jsonl').exists() else []
 sock.close();save(result)
 shutil.rmtree(root);result['ownedTempRemoved']=not root.exists();save(result)
sys.exit(0 if result.get('passed') and result.get('cleanupExit')==0 and result.get('remainingClaims')==0 else 1)
```

</details>

<details>
<summary>Complete synthetic SSH shim — save as native/ssh.py</summary>

```python
#!/usr/bin/env python3
import os,sys,json,pathlib,subprocess,hashlib,shlex
root=pathlib.Path(os.environ['RECOVERY_FIXTURE_ROOT']).resolve();assert (root/'fixture-owned').is_file()
args=sys.argv[1:]
with (root/'ssh-requests.jsonl').open('a') as f:f.write(json.dumps(args)+'\n')
if '-G' in args:
 query=list(args)
 if '-F' in query:
  config=pathlib.Path(query[query.index('-F')+1]).resolve()
  assert config==pathlib.Path('/dev/null') or config.is_relative_to(root), config
 else:query=['-F','/dev/null',*query]
 p=subprocess.run(['/usr/bin/ssh',*query],env={'HOME':str(root/'home'),'PATH':'/usr/bin:/bin'},stdout=sys.stdout.buffer,stderr=sys.stderr.buffer)
 sys.exit(p.returncode)
if '-V' in args:sys.stderr.write('OpenSSH_9.9 synthetic transport\n');sys.exit(0)
if '-O' in args or '-N' in args:sys.exit(0)
i=0
while i<len(args):
 a=args[i]
 if a=='--':i+=1;break
 if a in ['-o','-p','-i','-F','-S','-l','-J','-E']:i+=2;continue
 if a.startswith('-'):i+=1;continue
 break
assert i<len(args);target=args[i];assert target.split('@')[-1] in ['127.0.0.1','crabbox-resolved-target'],target
remaining=args[i+1:]
if not remaining:sys.exit(0)
command=remaining[0] if len(remaining)==1 else shlex.join(remaining)
with (root/'ssh-trace.jsonl').open('a') as f:f.write(json.dumps({'target':target,'command':command,'commandSha256':hashlib.sha256(command.encode()).hexdigest()})+'\n')
env={'HOME':str(root/'remote-home'),'PATH':str(root/'bin')+':/usr/bin:/bin:/usr/sbin:/sbin','TMPDIR':str(root/'remote-tmp'),'LC_ALL':'C','RECOVERY_FIXTURE_ROOT':str(root),'RECOVERY_FIXTURE_PORT':os.environ['RECOVERY_FIXTURE_PORT']}
p=subprocess.run(['/bin/sh','-c',command],env=env,cwd=root/'remote-home',stdin=sys.stdin.buffer,stdout=sys.stdout.buffer,stderr=sys.stderr.buffer)
sys.exit(p.returncode)
```

</details>

