### PR TITLE
perf: keep run diagnostics off workload admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `crabbox bench check` to enforce sample, failure, and p95 runner timing policy across every matched local benchmark group. [PR 1899](https://github.com/openclaw/crabbox/pull/1899). Thanks @vincentkoc.
 - Distinguish required-artifact, artifact-change, and artifact-schema validation failures from workload exits in run timing and failure digests, preserving exit 7 and artifact enforcement. [PR 1934](https://github.com/openclaw/crabbox/pull/1934), [Issue 1894](https://github.com/openclaw/crabbox/issues/1894). Thanks @coygeek.
 - Tailscale: keep provider diagnostics and OAuth credentials out of preflight and tag-ownership errors while preserving operation, HTTP status, and actionable tag guidance. [PR 1940](https://github.com/openclaw/crabbox/pull/1940).
+- Publish run diagnostics without delaying workload admission, while preserving ordered lease attribution and joining pending publication before terminal recording. [PR 1937](https://github.com/openclaw/crabbox/pull/1937).
 
 ## 0.51.0 - 2026-09-06
 

--- a/docs/features/history-logs.md
+++ b/docs/features/history-logs.md
@@ -39,7 +39,12 @@ not automatically redacted.
 
 Phase and stream diagnostics publish through one bounded queue while the workload
 continues. An existing lease's run creation already records its binding; a new
-or replacement lease binding is acknowledged before command admission. Before
+or replacement lease binding first drains and joins diagnostics, then gets its
+own acknowledged request before command admission. Missing diagnostic endpoints
+do not block an already bound run; a changed binding must be accepted because
+the signed terminal receipt requires the exact lease, slug, and provider.
+Sync-only runs keep their optional-history behavior and warn when binding is
+unavailable. Before
 terminal recording, the CLI drains diagnostics for up to two seconds, cancels
 remaining publication, and joins the publisher. Queue overflow or drain expiry
 produces a warning; retained logs and verified terminal receipts remain the

--- a/docs/features/history-logs.md
+++ b/docs/features/history-logs.md
@@ -37,6 +37,14 @@ secret encodings while preserving useful diagnostic context. Raw `stdout` and
 `stderr` event data and retained command logs remain caller-owned output and are
 not automatically redacted.
 
+Phase and stream diagnostics publish through one bounded queue while the workload
+continues. An existing lease's run creation already records its binding; a new
+or replacement lease binding is acknowledged before command admission. Before
+terminal recording, the CLI drains diagnostics for up to two seconds, cancels
+remaining publication, and joins the publisher. Queue overflow or drain expiry
+produces a warning; retained logs and verified terminal receipts remain the
+completion record.
+
 Each event carries a sequence number, type, phase, and stream. Streamed output
 events are capped at **64 KiB total per run**; once the cap is hit the CLI emits
 a single `output.truncated` marker pointing you at `crabbox logs` for the full

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1314,7 +1314,11 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 		if useCoordinator {
 			if err := recorder.AttachLease(leaseID, serverSlug(server), cfg); err != nil {
-				return err
+				if !*syncOnly {
+					return err
+				}
+				// Sync-only has no signed command receipt and permits unavailable history.
+				recorder.warnRunHistory("sync-only run history binding unavailable: %v", err)
 			}
 		}
 		if recorder.runID != "" {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1313,7 +1313,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return exit(2, "profile doctor is not supported for native Windows targets")
 		}
 		if useCoordinator {
-			recorder.AttachLease(leaseID, serverSlug(server), cfg)
+			if err := recorder.AttachLease(leaseID, serverSlug(server), cfg); err != nil {
+				return err
+			}
 		}
 		if recorder.runID != "" {
 			executionRunID = recorder.runID
@@ -1778,7 +1780,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return true, exit(2, "profile doctor is not supported for native Windows targets")
 		}
 		if useCoordinator {
-			recorder.AttachLease(leaseID, serverSlug(server), cfg)
+			if err := recorder.AttachLease(leaseID, serverSlug(server), cfg); err != nil {
+				return true, err
+			}
 			startRunHeartbeat(nil)
 		}
 		if recorder.runID != "" {

--- a/internal/cli/run_event_publisher_test.go
+++ b/internal/cli/run_event_publisher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -179,5 +180,81 @@ func TestRunRecorderExistingLeaseCreateDoesNotWaitForDiagnostic(t *testing.T) {
 	rec.waitForEvents(time.Second)
 	if err := rec.requireHandle(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestRunRecorderBindingIgnoresDiagnosticBacklog(t *testing.T) {
+	for _, full := range []bool{false, true} {
+		t.Run(fmt.Sprint("full=", full), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				started := make(chan struct{})
+				diagnosticDone := false
+				client := &CoordinatorClient{BaseURL: "https://example.test", Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					var input CoordinatorRunEventInput
+					json.NewDecoder(req.Body).Decode(&input)
+					if input.Type == "command.started" {
+						close(started)
+						select {
+						case <-time.After(8 * time.Second):
+						case <-req.Context().Done():
+							time.Sleep(time.Second)
+						}
+						diagnosticDone = true
+						if err := req.Context().Err(); err != nil {
+							return nil, err
+						}
+					}
+					if input.Type == "lease.created" {
+						if !diagnosticDone {
+							t.Error("binding overtook diagnostic publisher join")
+						}
+						deadline, ok := req.Context().Deadline()
+						if !ok || deadline.Sub(time.Now()) != runRecorderRequestTimeout {
+							t.Error("binding did not receive its own HTTP request budget")
+						}
+						select {
+						case <-time.After(3 * time.Second):
+						case <-req.Context().Done():
+							return nil, req.Context().Err()
+						}
+					}
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"event":{"type":"accepted"}}`)), Header: make(http.Header), Request: req}, nil
+				})}}
+				rec := &runRecorder{coord: client, runID: "run_123", stderr: io.Discard}
+				rec.Event("command.started", "command", "")
+				<-started
+				if full {
+					for range runEventOutputQueueSize {
+						rec.Event("sync.finished", "synced", "")
+					}
+				}
+				if err := rec.AttachLease("cbx_replacement", "replacement", Config{Provider: "aws"}); err != nil {
+					t.Errorf("healthy binding rejected by diagnostic backlog: %v", err)
+				}
+				rec.Failed(nil)
+			})
+		})
+	}
+}
+
+func TestRunRecorderMissingBindingEndpointFailsAdmission(t *testing.T) {
+	for _, oldLease := range []string{"", "cbx_initial"} {
+		t.Run("old="+oldLease, func(t *testing.T) {
+			calls := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				calls++
+				http.Error(w, `{"error":"not_found"}`, http.StatusNotFound)
+			}))
+			defer server.Close()
+			rec := &runRecorder{coord: &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}, runID: "run_123", leaseID: oldLease, stderr: io.Discard}
+			err := rec.AttachLease("cbx_next", "next", Config{Provider: "aws"})
+			if ExitCodeForError(err, 0) != 7 || !strings.Contains(err.Error(), "lease attribution") {
+				t.Fatalf("unbound run was admitted without a valid binding: %v", err)
+			}
+			if calls != 1 || rec.leaseID != oldLease {
+				t.Fatalf("failed binding changed attribution: calls=%d lease=%q", calls, rec.leaseID)
+			}
+			rec.Failed(nil)
+		})
 	}
 }

--- a/internal/cli/run_event_publisher_test.go
+++ b/internal/cli/run_event_publisher_test.go
@@ -1,0 +1,183 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+func TestRunRecorderPhaseDoesNotDelayWorkload(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		close(started)
+		<-release
+		io.WriteString(w, `{"event":{"type":"command.started"}}`)
+	}))
+	defer server.Close()
+	rec := &runRecorder{coord: &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}, runID: "run_123", stderr: io.Discard}
+	returned := make(chan struct{})
+	go func() { rec.Event("command.started", "command", "printf hello"); close(returned) }()
+	<-started
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Error("workload admission waited for best-effort phase publication")
+	}
+	close(release)
+	<-returned
+	rec.waitForEvents(time.Second)
+}
+
+func TestRunRecorderEventPublisherJoinsBeforeTerminal(t *testing.T) {
+	for _, action := range []string{"finish", "failed", "early return"} {
+		t.Run(action, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				eventStarted := make(chan struct{})
+				canceled := make(chan struct{})
+				release := make(chan struct{})
+				finished := make(chan struct{})
+				var stderr strings.Builder
+				client := &CoordinatorClient{BaseURL: "https://example.test", Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					var input CoordinatorRunEventInput
+					if strings.HasSuffix(req.URL.Path, "/events") {
+						json.NewDecoder(req.Body).Decode(&input)
+					}
+					if input.Type == "stdout" {
+						close(eventStarted)
+						<-req.Context().Done()
+						close(canceled)
+						<-release
+						return nil, req.Context().Err()
+					}
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"run":{"id":"run_123"},"event":{"type":"run.failed"}}`)), Header: make(http.Header), Request: req}, nil
+				})}}
+				rec := &runRecorder{coord: client, runID: "run_123", stderr: &stderr}
+				writer := rec.StreamWriter("stdout")
+				writer.Write([]byte("hello"))
+				writer.Flush()
+				<-eventStarted
+				go func() {
+					if action == "finish" {
+						rec.Finish(context.Background(), SSHTarget{}, 0, 0, 0, "hello", false, nil, FailureClassification{}, nil)
+					} else if action == "failed" {
+						rec.Failed(errors.New("setup failed"))
+					} else {
+						rec.Failed(nil)
+					}
+					close(finished)
+				}()
+				<-canceled
+				time.Sleep(2 * time.Second)
+				select {
+				case <-finished:
+					t.Error("terminal operation returned while its event publisher was still running")
+				default:
+				}
+				close(release)
+				<-finished
+				if !strings.Contains(stderr.String(), "diagnostics dropped") {
+					t.Errorf("lost diagnostics have no visible outcome: %s", stderr.String())
+				}
+				rec.waitForEvents(time.Second)
+			})
+		})
+	}
+}
+
+func TestRunRecorderOrdersEventsAcrossLeaseReplacementAndFinish(t *testing.T) {
+	var mu sync.Mutex
+	var observed []string
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var input CoordinatorRunEventInput
+		if strings.HasSuffix(req.URL.Path, "/events") {
+			json.NewDecoder(req.Body).Decode(&input)
+		}
+		if input.Type == "lease.replace.started" {
+			close(started)
+			<-release
+		}
+		kind := input.Type
+		if kind == "" {
+			kind = "finish"
+		}
+		mu.Lock()
+		observed = append(observed, kind+":"+req.Header.Get("Authorization"))
+		mu.Unlock()
+		io.WriteString(w, `{"run":{"id":"run_123"},"event":{"type":"accepted"}}`)
+	}))
+	defer server.Close()
+	rec := &runRecorder{coord: &CoordinatorClient{BaseURL: server.URL, Token: "old", Client: server.Client()}, runID: "run_123", leaseID: "cbx_old", stderr: io.Discard}
+	writer := rec.StreamWriter("stdout")
+	rec.Event("lease.replace.started", "leasing", "")
+	<-started
+	rec.UseCoordinator(&CoordinatorClient{BaseURL: server.URL, Token: "new", Client: server.Client()})
+	attached := make(chan error, 1)
+	go func() { attached <- rec.AttachLease("cbx_new", "new-slug", Config{}) }()
+	select {
+	case <-attached:
+		t.Error("replacement admitted before its authoritative lease attachment")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(release)
+	if err := <-attached; err != nil {
+		t.Fatal(err)
+	}
+	rec.Event("command.started", "command", "")
+	writer.Write([]byte("hello"))
+	writer.Flush()
+	if err := rec.Finish(context.Background(), SSHTarget{}, 0, 0, 0, "hello", false, nil, FailureClassification{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	rec.Event("lease.released", "released", "")
+	mu.Lock()
+	defer mu.Unlock()
+	want := []string{"lease.replace.started:Bearer old", "lease.created:Bearer new", "command.started:Bearer new", "stdout:Bearer new", "finish:Bearer new", "lease.released:Bearer new"}
+	if !reflect.DeepEqual(observed, want) {
+		t.Fatalf("event order/coordinator=%v, want %v", observed, want)
+	}
+}
+
+func TestRunRecorderExistingLeaseCreateDoesNotWaitForDiagnostic(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/v1/runs" {
+			io.WriteString(w, `{"run":{"id":"run_123","leaseID":"cbx_existing","slug":"existing","provider":"aws"}}`)
+			return
+		}
+		close(started)
+		<-release
+		io.WriteString(w, `{"event":{"type":"lease.created"}}`)
+	}))
+	defer server.Close()
+	cfg := Config{Provider: "aws"}
+	rec := newRunRecorder(context.Background(), &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}, cfg, []string{"true"}, "", io.Discard, true)
+	attached := make(chan error, 1)
+	go func() { attached <- rec.AttachLease("cbx_existing", "existing", cfg) }()
+	<-started
+	select {
+	case err := <-attached:
+		if err != nil {
+			t.Error(err)
+		}
+	case <-time.After(time.Second):
+		t.Error("authoritative CreateRun binding waited for diagnostic publication")
+	}
+	close(release)
+	rec.waitForEvents(time.Second)
+	if err := rec.requireHandle(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/run_output_events.go
+++ b/internal/cli/run_output_events.go
@@ -18,7 +18,6 @@ const (
 type runEventPublication struct {
 	coord *CoordinatorClient
 	input CoordinatorRunEventInput
-	ack   chan error
 }
 
 type runEventPublisher struct {
@@ -52,7 +51,7 @@ func (q *runEventPublisher) Enqueue(coord *CoordinatorClient, runID, stream, dat
 		return
 	}
 	for _, input := range q.eventInputs(stream, data) {
-		q.append(coord, runID, input, false)
+		q.append(coord, runID, input)
 	}
 }
 
@@ -97,18 +96,15 @@ func outputTruncatedEventInput() CoordinatorRunEventInput {
 
 // One FIFO owns phase and stream publication so delayed output cannot overtake
 // lease attribution or terminal recording. Every queued request is joined.
-func (q *runEventPublisher) append(coord *CoordinatorClient, runID string, input CoordinatorRunEventInput, acknowledged bool) error {
+func (q *runEventPublisher) append(coord *CoordinatorClient, runID string, input CoordinatorRunEventInput) {
 	if coord == nil || runID == "" {
-		return nil
+		return
 	}
 	publication := runEventPublication{coord: coord, input: input}
-	if acknowledged {
-		publication.ack = make(chan error, 1)
-	}
 	q.queueMu.Lock()
 	if q.disabled || q.queueClosed {
 		q.queueMu.Unlock()
-		return fmt.Errorf("run event publisher is closed")
+		return
 	}
 	if q.events == nil {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -126,19 +122,21 @@ func (q *runEventPublisher) append(coord *CoordinatorClient, runID string, input
 		if q.onError != nil {
 			q.onError(input.Type, err)
 		}
+		return
+	}
+}
+
+// A binding owns admission, so queued diagnostics cannot consume its capacity
+// or HTTP budget. Drain and join before posting, then resume the same publisher.
+func (q *runEventPublisher) Bind(coord *CoordinatorClient, runID string, input CoordinatorRunEventInput) error {
+	q.CloseAndWait(runEventOutputPostWait)
+	if err := postRunEvent(context.Background(), coord, runID, input); err != nil {
 		return err
 	}
-	if publication.ack != nil {
-		timer := time.NewTimer(runRecorderRequestTimeout)
-		defer timer.Stop()
-		select {
-		case err := <-publication.ack:
-			return err
-		case <-timer.C:
-			q.CloseAndWait(0)
-			return context.DeadlineExceeded
-		}
-	}
+	q.queueMu.Lock()
+	q.events, q.done, q.cancel = nil, nil, nil
+	q.queueClosed, q.disabled = false, false
+	q.queueMu.Unlock()
 	return nil
 }
 
@@ -163,9 +161,6 @@ func (q *runEventPublisher) post(ctx context.Context, runID string) {
 		}
 		if err == nil {
 			err = postRunEvent(ctx, publication.coord, runID, publication.input)
-		}
-		if publication.ack != nil {
-			publication.ack <- err
 		}
 		if err != nil && ctx.Err() == nil && stopped == nil && q.onError != nil && !q.onError(publication.input.Type, err) {
 			stopped = err

--- a/internal/cli/run_output_events.go
+++ b/internal/cli/run_output_events.go
@@ -15,31 +15,30 @@ const (
 	runEventOutputPostWait   = 2 * time.Second
 )
 
-type runOutputEventQueue struct {
-	coord           *CoordinatorClient
-	runID           string
+type runEventPublication struct {
+	coord *CoordinatorClient
+	input CoordinatorRunEventInput
+	ack   chan error
+}
+
+type runEventPublisher struct {
 	onError         func(string, error) bool
 	outputMu        sync.Mutex
 	outputBytes     int
 	outputTruncated bool
-	queueOnce       sync.Once
-	closeOnce       sync.Once
 	queueMu         sync.Mutex
 	queueClosed     bool
 	disabled        bool
-	events          chan CoordinatorRunEventInput
-	wg              sync.WaitGroup
+	events          chan runEventPublication
+	cancel          context.CancelFunc
+	done            chan struct{}
 }
 
-func newRunOutputEventQueue(coord *CoordinatorClient, runID string, onError func(string, error) bool) *runOutputEventQueue {
-	return &runOutputEventQueue{
-		coord:   coord,
-		runID:   runID,
-		onError: onError,
-	}
+func newRunEventPublisher(onError func(string, error) bool) *runEventPublisher {
+	return &runEventPublisher{onError: onError}
 }
 
-func (q *runOutputEventQueue) Closed() bool {
+func (q *runEventPublisher) Closed() bool {
 	if q == nil {
 		return true
 	}
@@ -48,17 +47,16 @@ func (q *runOutputEventQueue) Closed() bool {
 	return q.outputTruncated
 }
 
-func (q *runOutputEventQueue) Enqueue(stream, data string) {
-	if q == nil || data == "" || q.coord == nil || q.runID == "" {
+func (q *runEventPublisher) Enqueue(coord *CoordinatorClient, runID, stream, data string) {
+	if q == nil || data == "" {
 		return
 	}
-	if q.Disabled() {
-		return
+	for _, input := range q.eventInputs(stream, data) {
+		q.append(coord, runID, input, false)
 	}
-	q.enqueue(q.eventInputs(stream, data))
 }
 
-func (q *runOutputEventQueue) eventInputs(stream, data string) []CoordinatorRunEventInput {
+func (q *runEventPublisher) eventInputs(stream, data string) []CoordinatorRunEventInput {
 	q.outputMu.Lock()
 	defer q.outputMu.Unlock()
 	if q.outputTruncated {
@@ -97,79 +95,115 @@ func outputTruncatedEventInput() CoordinatorRunEventInput {
 	}
 }
 
-func (q *runOutputEventQueue) enqueue(events []CoordinatorRunEventInput) {
-	if len(events) == 0 {
-		return
+// One FIFO owns phase and stream publication so delayed output cannot overtake
+// lease attribution or terminal recording. Every queued request is joined.
+func (q *runEventPublisher) append(coord *CoordinatorClient, runID string, input CoordinatorRunEventInput, acknowledged bool) error {
+	if coord == nil || runID == "" {
+		return nil
 	}
-	q.queueOnce.Do(func() {
-		q.events = make(chan CoordinatorRunEventInput, runEventOutputQueueSize)
-		q.wg.Add(1)
-		go q.post(q.events)
-	})
+	publication := runEventPublication{coord: coord, input: input}
+	if acknowledged {
+		publication.ack = make(chan error, 1)
+	}
 	q.queueMu.Lock()
-	defer q.queueMu.Unlock()
-	if q.queueClosed || q.disabled {
-		return
+	if q.disabled || q.queueClosed {
+		q.queueMu.Unlock()
+		return fmt.Errorf("run event publisher is closed")
 	}
-	for _, event := range events {
+	if q.events == nil {
+		ctx, cancel := context.WithCancel(context.Background())
+		q.cancel = cancel
+		q.events = make(chan runEventPublication, runEventOutputQueueSize)
+		q.done = make(chan struct{})
+		go q.post(ctx, runID)
+	}
+	select {
+	case q.events <- publication:
+		q.queueMu.Unlock()
+	default:
+		q.queueMu.Unlock()
+		err := fmt.Errorf("run event queue full; diagnostic event dropped")
+		if q.onError != nil {
+			q.onError(input.Type, err)
+		}
+		return err
+	}
+	if publication.ack != nil {
+		timer := time.NewTimer(runRecorderRequestTimeout)
+		defer timer.Stop()
 		select {
-		case q.events <- event:
-		default:
-			return
+		case err := <-publication.ack:
+			return err
+		case <-timer.C:
+			q.CloseAndWait(0)
+			return context.DeadlineExceeded
+		}
+	}
+	return nil
+}
+
+func postRunEvent(ctx context.Context, coord *CoordinatorClient, runID string, input CoordinatorRunEventInput) error {
+	timeout := runRecorderRequestTimeout
+	if input.Stream != "" || input.Type == "output.truncated" {
+		timeout = runEventOutputPostWait
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	_, err := coord.AppendRunEvent(ctx, runID, input)
+	return err
+}
+
+func (q *runEventPublisher) post(ctx context.Context, runID string) {
+	defer close(q.done)
+	var stopped error
+	for publication := range q.events {
+		err := ctx.Err()
+		if err == nil {
+			err = stopped
+		}
+		if err == nil {
+			err = postRunEvent(ctx, publication.coord, runID, publication.input)
+		}
+		if publication.ack != nil {
+			publication.ack <- err
+		}
+		if err != nil && ctx.Err() == nil && stopped == nil && q.onError != nil && !q.onError(publication.input.Type, err) {
+			stopped = err
+			q.queueMu.Lock()
+			q.disabled = true
+			q.queueMu.Unlock()
 		}
 	}
 }
 
-func (q *runOutputEventQueue) post(events <-chan CoordinatorRunEventInput) {
-	defer q.wg.Done()
-	for event := range events {
-		ctx, cancel := context.WithTimeout(context.Background(), runEventOutputPostWait)
-		_, err := q.coord.AppendRunEvent(ctx, q.runID, event)
-		cancel()
-		if err != nil && q.onError != nil && !q.onError(event.Type, err) {
-			q.Disable()
-			return
-		}
-	}
-}
-
-func (q *runOutputEventQueue) Disable() {
+func (q *runEventPublisher) CloseAndWait(timeout time.Duration) {
 	if q == nil {
 		return
 	}
 	q.queueMu.Lock()
-	q.disabled = true
-	q.queueMu.Unlock()
-}
-
-func (q *runOutputEventQueue) Disabled() bool {
-	if q == nil {
-		return true
-	}
-	q.queueMu.Lock()
-	defer q.queueMu.Unlock()
-	return q.disabled
-}
-
-func (q *runOutputEventQueue) CloseAndWait(timeout time.Duration) {
-	if q == nil || q.events == nil {
+	if q.events == nil {
+		q.queueClosed = true
+		q.queueMu.Unlock()
 		return
 	}
-	q.closeOnce.Do(func() {
-		q.queueMu.Lock()
-		defer q.queueMu.Unlock()
+	if !q.queueClosed {
 		q.queueClosed = true
 		close(q.events)
-	})
-	done := make(chan struct{})
-	go func() {
-		q.wg.Wait()
-		close(done)
-	}()
+	}
+	done, cancel := q.done, q.cancel
+	q.queueMu.Unlock()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	select {
 	case <-done:
-	case <-time.After(timeout):
+	case <-timer.C:
+		cancel()
+		if q.onError != nil {
+			q.onError("publication", fmt.Errorf("run event drain deadline expired; remaining diagnostics dropped"))
+		}
+		<-done
 	}
+	cancel()
 }
 
 type runEventStreamWriter struct {
@@ -179,11 +213,11 @@ type runEventStreamWriter struct {
 }
 
 func (w *runEventStreamWriter) Write(p []byte) (int, error) {
-	if w == nil || w.recorder == nil || w.recorder.runID == "" || w.recorder.finished || w.recorder.output == nil {
+	if w == nil || w.recorder == nil || w.recorder.runID == "" || w.recorder.finished || w.recorder.publisher == nil {
 		return len(p), nil
 	}
 	written := len(p)
-	for len(p) > 0 && !w.recorder.output.Closed() {
+	for len(p) > 0 && !w.recorder.publisher.Closed() {
 		space := runEventOutputChunkBytes - w.data.Len()
 		if space <= 0 {
 			w.Flush()
@@ -202,10 +236,10 @@ func (w *runEventStreamWriter) Write(p []byte) (int, error) {
 }
 
 func (w *runEventStreamWriter) Flush() {
-	if w == nil || w.recorder == nil || w.recorder.runID == "" || w.recorder.finished || w.recorder.output == nil || w.data.Len() == 0 {
+	if w == nil || w.recorder == nil || w.recorder.runID == "" || w.recorder.finished || w.recorder.publisher == nil || w.data.Len() == 0 {
 		return
 	}
 	data := w.data.String()
 	w.data.Reset()
-	w.recorder.output.Enqueue(w.stream, data)
+	w.recorder.publisher.Enqueue(w.recorder.coord, w.recorder.runID, w.stream, data)
 }

--- a/internal/cli/run_recorder.go
+++ b/internal/cli/run_recorder.go
@@ -31,12 +31,13 @@ type runRecorder struct {
 	diagnosticSecrets  []string
 	createPending      bool
 	historyUnavailable bool
-	eventsMu           sync.Mutex
-	eventsDisabled     bool
+	leaseID            string
+	leaseSlug          string
+	leaseProvider      string
 	finished           bool
 	warned             bool
 	warnMu             sync.Mutex
-	output             *runOutputEventQueue
+	publisher          *runEventPublisher
 	telemetryStart     *LeaseTelemetry
 	telemetryMu        sync.Mutex
 	telemetrySamples   []*LeaseTelemetry
@@ -103,7 +104,7 @@ func (r *runRecorder) Event(kind, phase, message string) {
 }
 
 func (r *runRecorder) appendEvent(kind string, input CoordinatorRunEventInput) {
-	if r == nil || r.coord == nil || r.runID == "" || !r.runEventsEnabled() {
+	if r == nil || r.coord == nil || r.runID == "" {
 		return
 	}
 	if input.Message != "" {
@@ -111,17 +112,21 @@ func (r *runRecorder) appendEvent(kind string, input CoordinatorRunEventInput) {
 		secrets = append(secrets, configuredDiagnosticSecrets(r.diagnosticConfig)...)
 		input.Message = RedactDiagnosticSecrets(input.Message, secrets...)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), runRecorderRequestTimeout)
-	defer cancel()
-	_, err := r.coord.AppendRunEvent(ctx, r.runID, input)
-	if err != nil {
-		r.handleRunEventAppendError(kind, err)
+	if r.publisher == nil {
+		r.publisher = newRunEventPublisher(r.handleRunEventAppendError)
 	}
+	if r.finished {
+		if err := postRunEvent(context.Background(), r.coord, r.runID, input); err != nil {
+			r.handleRunEventAppendError(kind, err)
+		}
+		return
+	}
+	r.publisher.append(r.coord, r.runID, input, false)
 }
 
-func (r *runRecorder) AttachLease(leaseID, slug string, cfg Config) {
+func (r *runRecorder) AttachLease(leaseID, slug string, cfg Config) error {
 	if r == nil || r.finished {
-		return
+		return nil
 	}
 	if r.runID == "" && r.createPending && r.coord != nil && leaseID != "" {
 		ctx, cancel := context.WithTimeout(context.Background(), runRecorderRequestTimeout)
@@ -130,14 +135,14 @@ func (r *runRecorder) AttachLease(leaseID, slug string, cfg Config) {
 		if err != nil {
 			r.historyUnavailable = true
 			r.warnRunHistory("run history create failed after lease; run history unavailable, use lease-based recovery commands: %v", err)
-			return
+			return nil
 		}
 		r.attachRun(run)
 	}
 	if r.runID == "" {
-		return
+		return nil
 	}
-	r.appendEvent("lease.created", CoordinatorRunEventInput{
+	input := CoordinatorRunEventInput{
 		Type:        "lease.created",
 		Phase:       "leased",
 		LeaseID:     leaseID,
@@ -147,7 +152,18 @@ func (r *runRecorder) AttachLease(leaseID, slug string, cfg Config) {
 		WindowsMode: cfg.WindowsMode,
 		Class:       cfg.Class,
 		ServerType:  cfg.ServerType,
-	})
+	}
+	if r.publisher == nil {
+		r.publisher = newRunEventPublisher(r.handleRunEventAppendError)
+	}
+	// CreateRun already binds an existing lease. Only initial attribution and
+	// replacement need acknowledgement before the command's receipt can bind it.
+	needsBinding := r.leaseID != leaseID || r.leaseSlug != slug || r.leaseProvider != cfg.Provider
+	if err := r.publisher.append(r.coord, r.runID, input, needsBinding); err != nil && needsBinding {
+		return exit(7, "run history lease attribution failed for %s: %v", r.runID, err)
+	}
+	r.leaseID, r.leaseSlug, r.leaseProvider = leaseID, slug, cfg.Provider
+	return nil
 }
 
 func (r *runRecorder) CaptureTelemetryStart(ctx context.Context, target SSHTarget) {
@@ -197,17 +213,18 @@ func (r *runRecorder) StartTelemetrySampler(ctx context.Context, target SSHTarge
 
 func (r *runRecorder) attachRun(run CoordinatorRun) {
 	r.runID = run.ID
+	r.leaseID, r.leaseSlug, r.leaseProvider = run.LeaseID, run.Slug, run.Provider
 	r.startedAt, _ = time.Parse(time.RFC3339Nano, run.StartedAt)
 	r.attachedAt = time.Now()
 	r.createPending = false
 	r.historyUnavailable = false
-	r.output = newRunOutputEventQueue(r.coord, run.ID, r.handleRunEventAppendError)
+	r.publisher = newRunEventPublisher(r.handleRunEventAppendError)
 	fmt.Fprintf(r.stderr, "recording run %s\n", run.ID)
 }
 
 func (r *runRecorder) StreamWriter(stream string) *runEventStreamWriter {
-	if r != nil && r.output == nil && r.coord != nil && r.runID != "" {
-		r.output = newRunOutputEventQueue(r.coord, r.runID, r.handleRunEventAppendError)
+	if r != nil && r.publisher == nil && r.coord != nil && r.runID != "" {
+		r.publisher = newRunEventPublisher(r.handleRunEventAppendError)
 	}
 	return &runEventStreamWriter{recorder: r, stream: stream}
 }
@@ -216,7 +233,7 @@ func (r *runRecorder) Finish(ctx context.Context, target SSHTarget, exitCode int
 	if r == nil || r.runID == "" || r.finished {
 		return nil
 	}
-	r.waitForOutputEvents(runEventOutputPostWait)
+	r.waitForEvents(runEventOutputPostWait)
 	r.stopTelemetrySampler()
 	telemetryEnd := collectLeaseTelemetryBestEffort(contextWithoutWorkspaceOwner(ctx), leaseTelemetryCollectorForTarget(target))
 	r.recordTelemetrySample(telemetryEnd)
@@ -280,12 +297,15 @@ func runRecorderFinishRetryable(err error) bool {
 }
 
 func (r *runRecorder) Failed(err error) {
-	if r == nil || r.runID == "" || r.finished || err == nil {
+	if r == nil {
 		return
 	}
-	r.waitForOutputEvents(runEventOutputPostWait)
-	r.finished = true
+	r.waitForEvents(runEventOutputPostWait)
 	r.stopTelemetrySampler()
+	if r.runID == "" || r.finished || err == nil {
+		return
+	}
+	r.finished = true
 	r.appendEvent("run.failed", CoordinatorRunEventInput{
 		Type:    "run.failed",
 		Phase:   "failed",
@@ -386,31 +406,15 @@ func (r *runRecorder) resetTelemetryForLeaseReplacement() {
 	r.telemetryMu.Unlock()
 }
 
-func (r *runRecorder) waitForOutputEvents(timeout time.Duration) {
-	if r == nil || r.output == nil {
+func (r *runRecorder) waitForEvents(timeout time.Duration) {
+	if r == nil || r.publisher == nil {
 		return
 	}
-	r.output.CloseAndWait(timeout)
-}
-
-func (r *runRecorder) runEventsEnabled() bool {
-	r.eventsMu.Lock()
-	defer r.eventsMu.Unlock()
-	return !r.eventsDisabled
-}
-
-func (r *runRecorder) disableRunEvents() {
-	r.eventsMu.Lock()
-	r.eventsDisabled = true
-	r.eventsMu.Unlock()
-	if r.output != nil {
-		r.output.Disable()
-	}
+	r.publisher.CloseAndWait(timeout)
 }
 
 func (r *runRecorder) handleRunEventAppendError(kind string, err error) bool {
 	if isCoordinatorNotFoundError(err) {
-		r.disableRunEvents()
 		return false
 	}
 	r.warn("run event append failed for %s: %v", kind, err)

--- a/internal/cli/run_recorder.go
+++ b/internal/cli/run_recorder.go
@@ -121,7 +121,7 @@ func (r *runRecorder) appendEvent(kind string, input CoordinatorRunEventInput) {
 		}
 		return
 	}
-	r.publisher.append(r.coord, r.runID, input, false)
+	r.publisher.append(r.coord, r.runID, input)
 }
 
 func (r *runRecorder) AttachLease(leaseID, slug string, cfg Config) error {
@@ -159,8 +159,12 @@ func (r *runRecorder) AttachLease(leaseID, slug string, cfg Config) error {
 	// CreateRun already binds an existing lease. Only initial attribution and
 	// replacement need acknowledgement before the command's receipt can bind it.
 	needsBinding := r.leaseID != leaseID || r.leaseSlug != slug || r.leaseProvider != cfg.Provider
-	if err := r.publisher.append(r.coord, r.runID, input, needsBinding); err != nil && needsBinding {
-		return exit(7, "run history lease attribution failed for %s: %v", r.runID, err)
+	if needsBinding {
+		if err := r.publisher.Bind(r.coord, r.runID, input); err != nil {
+			return exit(7, "run history lease attribution failed for %s: %v", r.runID, err)
+		}
+	} else {
+		r.publisher.append(r.coord, r.runID, input)
 	}
 	r.leaseID, r.leaseSlug, r.leaseProvider = leaseID, slug, cfg.Provider
 	return nil

--- a/internal/cli/run_recorder_test.go
+++ b/internal/cli/run_recorder_test.go
@@ -1020,13 +1020,13 @@ func TestRunRecorderSuppressesMissingEventEndpoint(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
-			_, _ = w.Write([]byte(`{"run":{"id":"run_123","leaseID":"","owner":"peter@example.com","org":"openclaw","provider":"aws","class":"standard","serverType":"t3.small","command":["pnpm","test"],"state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`))
+			_, _ = w.Write([]byte(`{"run":{"id":"run_123","leaseID":"cbx_abcdef123456","slug":"blue-lobster","owner":"peter@example.com","org":"openclaw","provider":"aws","class":"standard","serverType":"t3.small","command":["pnpm","test"],"state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`))
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_123/events":
 			eventRequests++
 			http.Error(w, `{"error":"not_found"}`, http.StatusNotFound)
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_123/finish":
 			finishRequests++
-			_, _ = w.Write([]byte(`{"run":{"id":"run_123","leaseID":"","owner":"peter@example.com","org":"openclaw","provider":"aws","class":"standard","serverType":"t3.small","command":["pnpm","test"],"state":"succeeded","phase":"completed","exitCode":0,"logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z","finishedAt":"2026-05-02T00:00:01Z"}}`))
+			_, _ = w.Write([]byte(`{"run":{"id":"run_123","leaseID":"cbx_abcdef123456","slug":"blue-lobster","owner":"peter@example.com","org":"openclaw","provider":"aws","class":"standard","serverType":"t3.small","command":["pnpm","test"],"state":"succeeded","phase":"completed","exitCode":0,"logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z","finishedAt":"2026-05-02T00:00:01Z"}}`))
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
@@ -1038,22 +1038,27 @@ func TestRunRecorderSuppressesMissingEventEndpoint(t *testing.T) {
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
-	}, []string{"pnpm", "test"}, "", &stderr, false)
-	if rec.runID != "run_123" || rec.finished {
-		t.Fatalf("run handle must exist before lease attach or finish: %#v", rec)
+	}, []string{"pnpm", "test"}, "", &stderr, true)
+	if rec.runID != "" || rec.finished {
+		t.Fatalf("existing-lease run must defer its handle until lease resolution: %#v", rec)
 	}
-	rec.AttachLease("cbx_abcdef123456", "blue-lobster", Config{
+	err := rec.AttachLease("cbx_abcdef123456", "blue-lobster", Config{
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
 	})
+	if err != nil {
+		t.Fatalf("existing authoritative binding needs no event endpoint: %v", err)
+	}
 	stdout := rec.StreamWriter("stdout")
 	if _, err := stdout.Write([]byte("hello")); err != nil {
 		t.Fatal(err)
 	}
 	stdout.Flush()
 	rec.waitForEvents(time.Second)
-	rec.Finish(context.Background(), SSHTarget{TargetOS: targetWindows}, 0, time.Second, time.Second, "ok", false, nil, FailureClassification{}, nil)
+	if err := rec.Finish(context.Background(), SSHTarget{TargetOS: targetWindows}, 0, time.Second, time.Second, "ok", false, nil, FailureClassification{}, nil); err != nil {
+		t.Fatal(err)
+	}
 
 	if eventRequests != 1 {
 		t.Fatalf("event requests=%d, want 1", eventRequests)

--- a/internal/cli/run_recorder_test.go
+++ b/internal/cli/run_recorder_test.go
@@ -334,6 +334,7 @@ func TestRunRecorderRedactsCoordinatorDiagnosticEvents(t *testing.T) {
 			rec.runID = "run_123"
 
 			test.record(rec)
+			rec.waitForEvents(time.Second)
 
 			if len(events) != 1 {
 				t.Fatalf("events=%v, want one posted diagnostic", events)
@@ -381,7 +382,7 @@ func TestRunRecorderPreservesRawStreamEventData(t *testing.T) {
 		t.Fatal(err)
 	}
 	stdout.Flush()
-	rec.waitForOutputEvents(time.Second)
+	rec.waitForEvents(time.Second)
 
 	if len(events) != 1 || events[0].Type != "stdout" {
 		t.Fatalf("events=%#v, want one stdout event", events)
@@ -409,6 +410,7 @@ func TestRunRecorderRedactsRefreshedRuntimeDiagnosticSecrets(t *testing.T) {
 
 	rec.Event("actions.hydrate.failed", "hydrate", "original="+originalSecret+" refreshed="+refreshedSecret+" region=eu")
 
+	rec.waitForEvents(time.Second)
 	if len(events) != 1 {
 		t.Fatalf("events=%#v, want one posted diagnostic", events)
 	}
@@ -448,6 +450,7 @@ func TestRunRecorderRedactsDiagnosticSecretsAfterLateCoordinatorAttachment(t *te
 		"region=eu",
 	}, " "))
 
+	rec.waitForEvents(time.Second)
 	if len(events) != 1 {
 		t.Fatalf("events=%#v, want one posted diagnostic", events)
 	}
@@ -499,6 +502,7 @@ func TestRunRecorderRedactsPersistedCoordinatorDiagnosticEvents(t *testing.T) {
 		"region=eu",
 	}, " "))
 
+	rec.waitForEvents(time.Second)
 	events, err := client.RunEvents(context.Background(), run.ID, 0, 20)
 	if err != nil {
 		t.Fatalf("read persisted coordinator events: %v", err)
@@ -541,7 +545,7 @@ func TestRunEventStreamWriterCapsOutputEvents(t *testing.T) {
 		}
 	}
 	stdout.Flush()
-	rec.waitForOutputEvents(time.Second)
+	rec.waitForEvents(time.Second)
 
 	var outputBytes, outputEvents, truncatedEvents int
 	for _, event := range events {
@@ -604,7 +608,7 @@ func TestRunEventStreamWriterDoesNotBlockOnCoordinatorPost(t *testing.T) {
 	var joined chan struct{}
 	t.Cleanup(func() {
 		releasePost()
-		rec.waitForOutputEvents(time.Second)
+		rec.waitForEvents(time.Second)
 		if joined != nil {
 			select {
 			case <-joined:
@@ -634,10 +638,10 @@ func TestRunEventStreamWriterDoesNotBlockOnCoordinatorPost(t *testing.T) {
 	releasePost()
 	joined = make(chan struct{})
 	go func() {
-		rec.output.wg.Wait()
+		<-rec.publisher.done
 		close(joined)
 	}()
-	rec.waitForOutputEvents(time.Second)
+	rec.waitForEvents(time.Second)
 	select {
 	case <-joined:
 	case <-time.After(time.Second):
@@ -695,6 +699,7 @@ func TestRunRecorderDefersCreateWhenCoordinatorRequiresLeaseID(t *testing.T) {
 	if got := createBodies[1]["leaseID"]; got != "cbx_abcdef123456" {
 		t.Fatalf("second create leaseID=%#v", got)
 	}
+	rec.waitForEvents(time.Second)
 	if got := eventBody["type"]; got != "lease.created" {
 		t.Fatalf("event body=%#v", eventBody)
 	}
@@ -770,6 +775,7 @@ func TestRunRecorderDefersCreateForExplicitLeaseRuns(t *testing.T) {
 	if got := createBodies[0]["leaseID"]; got != "cbx_abcdef123456" {
 		t.Fatalf("create leaseID=%#v", got)
 	}
+	rec.waitForEvents(time.Second)
 	if got := eventBody["type"]; got != "lease.created" {
 		t.Fatalf("event body=%#v", eventBody)
 	}
@@ -828,6 +834,7 @@ func TestRunRecorderRetriesTransientCreateFailureAfterLease(t *testing.T) {
 	if got := createBodies[1]["leaseID"]; got != "cbx_abcdef123456" {
 		t.Fatalf("second create leaseID=%#v", got)
 	}
+	rec.waitForEvents(time.Second)
 	if got := eventBody["type"]; got != "lease.created" {
 		t.Fatalf("event body=%#v", eventBody)
 	}
@@ -955,6 +962,7 @@ func TestRunRecorderRetriesFailedLeaseCreateOnReplacementLease(t *testing.T) {
 	if got := createBodies[2]["leaseID"]; got != "cbx_replacement123" {
 		t.Fatalf("replacement create leaseID=%#v", got)
 	}
+	rec.waitForEvents(time.Second)
 	if got := eventBody["leaseID"]; got != "cbx_replacement123" {
 		t.Fatalf("lease.created body=%#v", eventBody)
 	}
@@ -1044,7 +1052,7 @@ func TestRunRecorderSuppressesMissingEventEndpoint(t *testing.T) {
 		t.Fatal(err)
 	}
 	stdout.Flush()
-	rec.waitForOutputEvents(time.Second)
+	rec.waitForEvents(time.Second)
 	rec.Finish(context.Background(), SSHTarget{TargetOS: targetWindows}, 0, time.Second, time.Second, "ok", false, nil, FailureClassification{}, nil)
 
 	if eventRequests != 1 {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -4208,6 +4208,13 @@ func TestRunCommandDelegatedTerminalOrder(t *testing.T) {
 }
 
 func TestRunCommandSyncOnlyFinalizesAfterTiming(t *testing.T) {
+	for _, missingEvents := range []bool{false, true} {
+		t.Run(fmt.Sprint("missing-events=", missingEvents), func(t *testing.T) { runCommandSyncOnlyFinalization(t, missingEvents) })
+	}
+}
+
+func runCommandSyncOnlyFinalization(t *testing.T, missingEvents bool) {
+	t.Helper()
 	dir := t.TempDir()
 	isolateRunTestUserDirs(t, dir)
 	sshPath := filepath.Join(dir, "ssh")
@@ -4281,6 +4288,10 @@ func TestRunCommandSyncOnlyFinalizesAfterTiming(t *testing.T) {
 				StartedAt: "2026-09-04T00:00:00Z",
 			}})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/"+runID+"/events":
+			if missingEvents {
+				http.NotFound(w, r)
+				return
+			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"event": CoordinatorRunEvent{
 				RunID: runID, Seq: 1, Type: "run.event", CreatedAt: "2026-09-04T00:00:00Z",
 			}})
@@ -4312,6 +4323,9 @@ func TestRunCommandSyncOnlyFinalizesAfterTiming(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("run error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if missingEvents && !strings.Contains(stderr.String(), "warning: sync-only run history binding unavailable") {
+		t.Fatalf("optional history failure was not visible: %s", stderr.String())
 	}
 	mu.Lock()
 	gotEvents := append([]string(nil), events...)


### PR DESCRIPTION
## What Problem This Solves

Short remote commands wait for serial best-effort phase uploads before the workload can start. A real AWS diagnostic run spent 8–16 seconds on those phase calls. Output publication also used a timed wait that could return while its publisher was still running.

## Why This Change Was Made

Use one bounded, ordered publisher for phase and stream diagnostics. Existing lease bindings returned by run creation do not need another synchronous acknowledgement; initial and replacement bindings still do. Terminal recording drains diagnostics, cancels remaining requests and joins the actual publisher before committing the terminal result.

## User Impact

Workloads can start while diagnostic publication proceeds. Lease attribution, retained command logs and verified signed terminal receipts remain required; overflow and drain expiry produce a warning. This removes duplicate event state, the separate synchronous phase path and the detached wait goroutine.

## Evidence

- Real HTTP blocked-phase reproduction fails on the parent and passes with the repair.
- Original-order cancellation/join, existing binding, lease replacement, coordinator changes, output and terminal ordering checks pass under the race detector.
- Broader run lease/history/coordinator/receipt/failure race coverage passed in 213 seconds; focused final owner race passed in 5.413 seconds.
- Build passes; independent review is clean through P2.
- Real AWS ABBA comparison passed on one c7a.8xlarge lease with identical payload, configuration and workdir. Parent/candidate/candidate/parent wall times were 39.080 / 19.508 / 16.509 / 18.792 seconds; time to workload output was 22.714 / 14.480 / 8.155 / 11.247 seconds. Both candidate runs retained all nine events, complete logs and verified signed receipts, with zero warnings or diagnostic drops. The two samples per version show variance and are not a broad performance guarantee; the blocked-POST reproduction establishes the causal admission fix.
- All four runs retained the correct provider/lease/workload identity and telemetry baseline. The lease was released with cleanup complete, all owned processes joined, the SSH control directory disappeared, and operator configuration and the synthetic workdir remained unchanged.

Production delta: +45 lines for the acknowledged barrier and actual cancellation/join ownership; tests +287; docs/changelog +15. No new configuration, protocol or persistent-store fields. Related: https://github.com/openclaw/crabbox/pull/1931.

## Review follow-through

Required lease binding now drains/cancels and joins pending diagnostics before its own acknowledged HTTP request. Full diagnostic capacity and an 8-second prior diagnostic plus a healthy 3-second binding no longer reject admission; the request keeps its existing 10-second budget without sharing it with queue time.

The legacy missing-events concern is preserved where it can work: already-bound run creation remains usable without optional events, and sync-only explicitly continues with a warning when history binding is unavailable. Unbound or replacement command execution still requires a recorded lease/provider/slug tuple, as required by the signed terminal receipt contract shipped in v0.47; allowing that command would merely defer failure until receipt verification. New tests explicitly check these outcomes instead of discarding AttachLease errors. The required-binding queue findings and corresponding rank-up moves are addressed.

Final recorder/app-sync/terminal/receipt race coverage passed, broader lifecycle race coverage passed in 186.648s, and full-PR independent P2 review is clean.
