### PR TITLE
feat: expose AWS provisioning operation timings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Reject conflicting known provider identities before rebinding resolved SSH access, and retain alias keys unless an attested unchanged alias claim is removed. [PR 1936](https://github.com/openclaw/crabbox/pull/1936), [Issue 1900](https://github.com/openclaw/crabbox/issues/1900). Thanks @coygeek.
 - Tailscale: keep provider diagnostics and OAuth credentials out of preflight and tag-ownership errors while preserving operation, HTTP status, and actionable tag guidance. [PR 1940](https://github.com/openclaw/crabbox/pull/1940).
 - Publish run diagnostics without delaying workload admission, while preserving ordered lease attribution and joining pending publication before terminal recording. [PR 1937](https://github.com/openclaw/crabbox/pull/1937).
+- Add bounded AWS provisioning logs that separate ingress queue and lifecycle waits from create-operation costs and count redundant security-group permission calls without logging request payloads.
 
 ## 0.51.0 - 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Reject conflicting known provider identities before rebinding resolved SSH access, and retain alias keys unless an attested unchanged alias claim is removed. [PR 1936](https://github.com/openclaw/crabbox/pull/1936), [Issue 1900](https://github.com/openclaw/crabbox/issues/1900). Thanks @coygeek.
 - Tailscale: keep provider diagnostics and OAuth credentials out of preflight and tag-ownership errors while preserving operation, HTTP status, and actionable tag guidance. [PR 1940](https://github.com/openclaw/crabbox/pull/1940).
 - Publish run diagnostics without delaying workload admission, while preserving ordered lease attribution and joining pending publication before terminal recording. [PR 1937](https://github.com/openclaw/crabbox/pull/1937).
-- Add bounded AWS provisioning logs that separate ingress queue and lifecycle waits from create-operation costs and count redundant security-group permission calls without logging request payloads.
+- Add bounded AWS provisioning logs that separate ingress queue and lifecycle waits from create-operation costs and count redundant security-group permission calls without logging request payloads. [PR 1938](https://github.com/openclaw/crabbox/pull/1938).
 
 ## 0.51.0 - 2026-09-06
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1037,3 +1037,28 @@ retained alongside lease history without automatic pruning. Do not remove
 retained or unresolved histories to clear a cleanup incident. The shared Azure
 scope lock is released after settled terminal/retained completion; an unresolved
 shared-infrastructure write intentionally keeps its lock pending resolution.
+
+### AWS provisioning timing logs
+
+Each regional AWS create attempt emits one `crabbox_aws_provisioning` coordinator
+log on completion or failure. Correlate it with the lease ID and region in an
+authenticated coordinator log capture. It records total elapsed milliseconds and
+fixed step buckets with call counts, elapsed totals and error counts. No API
+payloads, credentials, addresses or exception text are included. These logs do
+not change lease timing fields or persist additional coordinator state.
+
+`ingress_wait` measures admission to the shared ingress queue; `lifecycle_wait`
+measures the subsequent lifecycle lock wait; `access_snapshot` measures the
+authoritative lease/access reread. `security_group` starts after those waits and
+contains lookup, creation, stale-rule pruning, world-rule revocation, ingress
+authorization and compaction buckets. Duplicate authorizations and absent world
+rules have separate counters, so expected API errors remain distinguishable from
+failed provisioning. Key-pair preparation, image selection, quota checks and
+instance creation have separate buckets.
+
+Durations include each operation's awaited work, including its transport and
+retries; they are not AWS service-side timings. Nested buckets overlap and must
+not be added to their parent. Missing buckets mean the step was not observed,
+and uninstrumented work can remain between steps. An interrupted request may
+not emit a completion log; use the existing lease lifecycle outcome as the
+authority for resource state.

--- a/worker/src/aws-provisioning-diagnostics.ts
+++ b/worker/src/aws-provisioning-diagnostics.ts
@@ -1,0 +1,63 @@
+const stepNames = [
+  "key_pair",
+  "image",
+  "ingress_wait",
+  "lifecycle_wait",
+  "access_snapshot",
+  "security_group",
+  "security_group_lookup",
+  "security_group_create",
+  "security_group_vpc",
+  "prune_ingress",
+  "revoke_world",
+  "revoke_world_absent",
+  "authorize_ingress",
+  "authorize_duplicate",
+  "compact_ingress",
+  "quota",
+  "instance_create",
+  "image_cleanup",
+] as const;
+
+type Step = (typeof stepNames)[number];
+export type AWSProvisioningDiagnostics = ReturnType<typeof createAWSProvisioningDiagnostics>;
+
+// Fixed buckets keep repeated permission calls bounded without losing their count.
+// These observations are logs, never lease state or permission decisions.
+export function createAWSProvisioningDiagnostics(leaseId: string, region: string) {
+  const startedAt = Date.now();
+  const steps = new Map(stepNames.map((name) => [name, { name, count: 0, totalMs: 0, errors: 0 }]));
+  const record = (name: Step, durationMs: number, failed = false) => {
+    const step = steps.get(name);
+    if (!step) return;
+    step.count += 1;
+    step.totalMs += Math.max(0, durationMs);
+    step.errors += Number(failed);
+  };
+  return {
+    record,
+    async measure<T>(name: Step, operation: () => Promise<T>): Promise<T> {
+      const start = Date.now();
+      let failed = true;
+      try {
+        const result = await operation();
+        failed = false;
+        return result;
+      } finally {
+        record(name, Date.now() - start, failed);
+      }
+    },
+    finish(outcome: "success" | "failure") {
+      console.info(
+        JSON.stringify({
+          component: "crabbox_aws_provisioning",
+          leaseId: leaseId.slice(0, 64),
+          region: region.slice(0, 32),
+          outcome,
+          totalMs: Math.max(0, Date.now() - startedAt),
+          steps: [...steps.values()].filter((step) => step.count > 0),
+        }),
+      );
+    },
+  };
+}

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -1,6 +1,10 @@
 import { AwsClient } from "aws4fetch";
 import { XMLParser } from "fast-xml-parser";
 
+import {
+  createAWSProvisioningDiagnostics,
+  type AWSProvisioningDiagnostics,
+} from "./aws-provisioning-diagnostics";
 import type {
   AWSQualificationRequest,
   AWSQualificationService,
@@ -39,6 +43,7 @@ import type {
   ProviderCheckpointOwnership,
   LeaseImageIdentity,
   ProviderMachine,
+  ProviderAccessTimingObserver,
   ProvisioningAttempt,
 } from "./types";
 
@@ -636,7 +641,11 @@ type DescribedSSHIngressRule = SSHIngressRule & { description: string };
 interface AWSIngressOptions {
   reconcile?: "authoritative" | "additive";
   allowEmpty?: boolean;
-  withIngress?: (apply: (cidrs: string[]) => Promise<string>) => Promise<string>;
+  withIngress?: (
+    apply: (cidrs: string[]) => Promise<string>,
+    observe: ProviderAccessTimingObserver,
+  ) => Promise<string>;
+  diagnostics?: AWSProvisioningDiagnostics;
 }
 
 type AWSReadinessCheck = () => Promise<void>;
@@ -1030,25 +1039,38 @@ export class EC2SpotClient {
     attempts?: ProvisioningAttempt[];
     imageID: string;
   }> {
-    if (!config.awsPrivate) {
-      await this.ensureSSHKey(config.providerKey, config.sshPublicKey, leaseID);
-    }
+    const diagnostics = createAWSProvisioningDiagnostics(leaseID, this.region);
+    options = { ...options, diagnostics };
+    let succeeded = false;
     let transientImageID = "";
     try {
+      if (!config.awsPrivate) {
+        await diagnostics.measure("key_pair", () =>
+          this.ensureSSHKey(config.providerKey, config.sshPublicKey, leaseID),
+        );
+      }
       const capabilityImageRequired = hasImageRequirements(config.imageRequirements);
-      const defaultImageID = config.awsSnapshot
-        ? await (async () => {
-            transientImageID = await this.registerSnapshotImage(config.awsSnapshot, leaseID);
-            return this.waitForImageAvailable(transientImageID);
-          })()
-        : config.target === "macos" || capabilityImageRequired
-          ? ""
-          : await this.resolveAMI(config);
+      const defaultImageID = await diagnostics.measure("image", async () =>
+        config.awsSnapshot
+          ? await (async () => {
+              transientImageID = await this.registerSnapshotImage(config.awsSnapshot, leaseID);
+              return this.waitForImageAvailable(transientImageID);
+            })()
+          : config.target === "macos" || capabilityImageRequired
+            ? ""
+            : await this.resolveAMI(config),
+      );
       const securityGroupID = options.withIngress
-        ? await options.withIngress((cidrs) =>
-            this.ensureSecurityGroup({ ...config, awsSSHCIDRs: cidrs }, options),
+        ? await options.withIngress(
+            (cidrs) =>
+              diagnostics.measure("security_group", () =>
+                this.ensureSecurityGroup({ ...config, awsSSHCIDRs: cidrs }, options),
+              ),
+            diagnostics.record,
           )
-        : await this.ensureSecurityGroup(config, options);
+        : await diagnostics.measure("security_group", () =>
+            this.ensureSecurityGroup(config, options),
+          );
       const pinnedMacHostID = config.target === "macos" ? config.hostID || config.awsMacHostID : "";
       // An explicit Mac host is tied to one hardware family. Resolve that family once so a
       // defaulted --type cannot send an incompatible instance type to the pinned host.
@@ -1107,10 +1129,8 @@ export class EC2SpotClient {
       };
       for (const serverType of candidates) {
         // oxlint-disable-next-line eslint/no-await-in-loop -- quota preflight follows sequential fallback order.
-        const preflight = await this.quotaPreflightAttempt(
-          serverType,
-          config.capacityMarket,
-          quotaCache,
+        const preflight = await diagnostics.measure("quota", () =>
+          this.quotaPreflightAttempt(serverType, config.capacityMarket, quotaCache),
         );
         if (preflight) {
           history.record(preflight, `${serverType}: ${preflight.message}`);
@@ -1123,13 +1143,15 @@ export class EC2SpotClient {
           // oxlint-disable-next-line eslint/no-await-in-loop -- instance-type fallback may need an architecture-specific AMI.
           const imageID = await resolveCandidateImageID({ ...config, serverType });
           // oxlint-disable-next-line eslint/no-await-in-loop -- instance-type fallback must stay sequential.
-          const server = await this.createServer(
-            { ...config, serverType },
-            leaseID,
-            slug,
-            owner,
-            imageID,
-            securityGroupID,
+          const server = await diagnostics.measure("instance_create", () =>
+            this.createServer(
+              { ...config, serverType },
+              leaseID,
+              slug,
+              owner,
+              imageID,
+              securityGroupID,
+            ),
           );
           const result: {
             server: ProviderMachine;
@@ -1138,6 +1160,7 @@ export class EC2SpotClient {
             attempts?: ProvisioningAttempt[];
             imageID: string;
           } = { server, serverType, market: config.capacityMarket, imageID };
+          succeeded = true;
           return { ...result, ...history.result() };
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
@@ -1164,7 +1187,9 @@ export class EC2SpotClient {
       if (marketFallbackCandidates.length > 0 && config.capacityFallback.startsWith("on-demand")) {
         for (const serverType of marketFallbackCandidates) {
           // oxlint-disable-next-line eslint/no-await-in-loop -- on-demand fallback must stay sequential.
-          const preflight = await this.quotaPreflightAttempt(serverType, "on-demand", quotaCache);
+          const preflight = await diagnostics.measure("quota", () =>
+            this.quotaPreflightAttempt(serverType, "on-demand", quotaCache),
+          );
           if (preflight) {
             history.record(preflight, `on-demand ${serverType}: ${preflight.message}`);
             continue;
@@ -1177,13 +1202,15 @@ export class EC2SpotClient {
               serverType,
             });
             // oxlint-disable-next-line eslint/no-await-in-loop -- on-demand fallback must stay sequential.
-            const server = await this.createServer(
-              { ...config, capacityMarket: "on-demand", serverType },
-              leaseID,
-              slug,
-              owner,
-              imageID,
-              securityGroupID,
+            const server = await diagnostics.measure("instance_create", () =>
+              this.createServer(
+                { ...config, capacityMarket: "on-demand", serverType },
+                leaseID,
+                slug,
+                owner,
+                imageID,
+                securityGroupID,
+              ),
             );
             const result: {
               server: ProviderMachine;
@@ -1192,6 +1219,7 @@ export class EC2SpotClient {
               attempts?: ProvisioningAttempt[];
               imageID: string;
             } = { server, serverType, market: "on-demand", imageID };
+            succeeded = true;
             return { ...result, ...history.result() };
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
@@ -1219,8 +1247,13 @@ export class EC2SpotClient {
       throw history.error();
     } finally {
       if (transientImageID) {
-        await this.ec2("DeregisterImage", { ImageId: transientImageID }).catch(() => undefined);
+        await diagnostics
+          .measure("image_cleanup", () =>
+            this.ec2("DeregisterImage", { ImageId: transientImageID }),
+          )
+          .catch(() => undefined);
       }
+      diagnostics.finish(succeeded ? "success" : "failure");
     }
   }
 
@@ -2309,14 +2342,20 @@ export class EC2SpotClient {
     config: LeaseConfig,
     options: AWSIngressOptions = {},
   ): Promise<string> {
+    const measure = <T>(
+      name: Parameters<AWSProvisioningDiagnostics["measure"]>[0],
+      operation: () => Promise<T>,
+    ) => (options.diagnostics ? options.diagnostics.measure(name, operation) : operation());
     const configuredGroupID = awsConfiguredSecurityGroupID(config, this.env);
     if (config.awsPrivate) {
       if (!configuredGroupID) {
         throw new Error("AWS private workspace security group is required");
       }
-      const existing = await this.ec2("DescribeSecurityGroups", {
-        "GroupId.1": configuredGroupID,
-      });
+      const existing = await measure("security_group_lookup", () =>
+        this.ec2("DescribeSecurityGroups", {
+          "GroupId.1": configuredGroupID,
+        }),
+      );
       const groups = items(record(existing["securityGroupInfo"])["item"]).map(record);
       const group = groups.find(
         (candidate) => asString(candidate["groupId"]) === configuredGroupID,
@@ -2332,9 +2371,11 @@ export class EC2SpotClient {
     let group: unknown;
     let groupID = configuredGroupID;
     if (groupID) {
-      const existing = await this.ec2("DescribeSecurityGroups", {
-        "GroupId.1": groupID,
-      });
+      const existing = await measure("security_group_lookup", () =>
+        this.ec2("DescribeSecurityGroups", {
+          "GroupId.1": groupID,
+        }),
+      );
       group = items(record(existing["securityGroupInfo"])["item"])[0];
       if (this.env.CRABBOX_AWS_QUALIFICATION_TRANSPORT) {
         if (asString(record(group)["groupId"]) !== groupID) {
@@ -2343,21 +2384,22 @@ export class EC2SpotClient {
         return groupID;
       }
     } else {
-      const vpcID = await this.securityGroupVPC(config);
+      const vpcID = await measure("security_group_vpc", () => this.securityGroupVPC(config));
       const name = awsManagedSecurityGroupName(config);
-      const existing = await this.ec2("DescribeSecurityGroups", {
-        "Filter.1.Name": "group-name",
-        "Filter.1.Value.1": name,
-        "Filter.2.Name": "vpc-id",
-        "Filter.2.Value.1": vpcID,
-      });
+      const existing = await measure("security_group_lookup", () =>
+        this.ec2("DescribeSecurityGroups", {
+          "Filter.1.Name": "group-name",
+          "Filter.1.Value.1": name,
+          "Filter.2.Name": "vpc-id",
+          "Filter.2.Value.1": vpcID,
+        }),
+      );
       group = items(record(existing["securityGroupInfo"])["item"])[0];
       groupID = asString(record(group)["groupId"]);
       if (!groupID) {
         try {
-          const created = await this.ec2(
-            "CreateSecurityGroup",
-            createSecurityGroupParams(name, vpcID),
+          const created = await measure("security_group_create", () =>
+            this.ec2("CreateSecurityGroup", createSecurityGroupParams(name, vpcID)),
           );
           groupID = asString(record(created)["groupId"]);
         } catch (error) {
@@ -2379,49 +2421,60 @@ export class EC2SpotClient {
       try {
         if (options.reconcile !== "additive") {
           // oxlint-disable-next-line eslint/no-await-in-loop -- the whole ingress pass retries only on group propagation.
-          await this.pruneStaleSSHIngress(groupID, group, ports, cidrs);
+          await measure("prune_ingress", () =>
+            this.pruneStaleSSHIngress(groupID, group, ports, cidrs),
+          );
         }
         let compactedAfterRuleLimit = false;
         for (const port of ports) {
           if (!cidrs.includes("0.0.0.0/0")) {
             // oxlint-disable-next-line eslint/no-await-in-loop -- cleanup is per port.
-            await this.revokeWorldTCP(groupID, port).catch((error: unknown) => {
-              const message = error instanceof Error ? error.message : String(error);
-              if (!message.includes("InvalidPermission.NotFound")) {
-                throw error;
-              }
-            });
+            await measure("revoke_world", () => this.revokeWorldTCP(groupID, port)).catch(
+              (error: unknown) => {
+                const message = error instanceof Error ? error.message : String(error);
+                if (!message.includes("InvalidPermission.NotFound")) {
+                  throw error;
+                }
+                options.diagnostics?.record("revoke_world_absent", 0);
+              },
+            );
           }
           for (const cidr of cidrs) {
             // oxlint-disable-next-line eslint/no-await-in-loop -- duplicate ingress handling is per CIDR.
-            await this.allowTCP(groupID, port, cidr).catch((error: unknown) => {
-              const message = error instanceof Error ? error.message : String(error);
-              if (message.includes("InvalidPermission.Duplicate")) {
-                return;
-              }
-              if (
-                options.reconcile !== "additive" &&
-                !compactedAfterRuleLimit &&
-                isAWSSecurityGroupRuleLimitError(message)
-              ) {
-                compactedAfterRuleLimit = true;
-                return this.compactSSHIngressForRuleLimit(groupID, ports, cidrs).then(
-                  (compacted) => {
+            await measure("authorize_ingress", () => this.allowTCP(groupID, port, cidr)).catch(
+              (error: unknown) => {
+                const message = error instanceof Error ? error.message : String(error);
+                if (message.includes("InvalidPermission.Duplicate")) {
+                  options.diagnostics?.record("authorize_duplicate", 0);
+                  return;
+                }
+                if (
+                  options.reconcile !== "additive" &&
+                  !compactedAfterRuleLimit &&
+                  isAWSSecurityGroupRuleLimitError(message)
+                ) {
+                  compactedAfterRuleLimit = true;
+                  return measure("compact_ingress", () =>
+                    this.compactSSHIngressForRuleLimit(groupID, ports, cidrs),
+                  ).then((compacted) => {
                     if (!compacted) {
                       throw error;
                     }
-                    return this.allowTCP(groupID, port, cidr).catch((retryError: unknown) => {
+                    return measure("authorize_ingress", () =>
+                      this.allowTCP(groupID, port, cidr),
+                    ).catch((retryError: unknown) => {
                       const retryMessage =
                         retryError instanceof Error ? retryError.message : String(retryError);
                       if (!retryMessage.includes("InvalidPermission.Duplicate")) {
                         throw retryError;
                       }
+                      options.diagnostics?.record("authorize_duplicate", 0);
                     });
-                  },
-                );
-              }
-              throw error;
-            });
+                  });
+                }
+                throw error;
+              },
+            );
           }
         }
         return groupID;

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -1141,7 +1141,9 @@ export class EC2SpotClient {
         }
         try {
           // oxlint-disable-next-line eslint/no-await-in-loop -- instance-type fallback may need an architecture-specific AMI.
-          const imageID = await resolveCandidateImageID({ ...config, serverType });
+          const imageID = await diagnostics.measure("image", () =>
+            resolveCandidateImageID({ ...config, serverType }),
+          );
           // oxlint-disable-next-line eslint/no-await-in-loop -- instance-type fallback must stay sequential.
           const server = await diagnostics.measure("instance_create", () =>
             this.createServer(
@@ -1196,11 +1198,13 @@ export class EC2SpotClient {
           }
           try {
             // oxlint-disable-next-line eslint/no-await-in-loop -- on-demand fallback may need an architecture-specific AMI.
-            const imageID = await resolveCandidateImageID({
-              ...config,
-              capacityMarket: "on-demand",
-              serverType,
-            });
+            const imageID = await diagnostics.measure("image", () =>
+              resolveCandidateImageID({
+                ...config,
+                capacityMarket: "on-demand",
+                serverType,
+              }),
+            );
             // oxlint-disable-next-line eslint/no-await-in-loop -- on-demand fallback must stay sequential.
             const server = await diagnostics.measure("instance_create", () =>
               this.createServer(

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -379,6 +379,7 @@ import type {
   LeaseProvisioningTiming,
   ProviderImage,
   ProviderMachine,
+  ProviderAccessTimingObserver,
   ProvisioningAttempt,
   ReadyPoolBorrowRequest,
   ReadyPoolBorrowHeartbeatRequest,
@@ -4712,30 +4713,40 @@ export class FleetCoordinator {
       ...(dispatched.providerScope ? { providerScope: dispatched.providerScope } : {}),
       onResourceCreated: (claim) => this.recordCreatedProviderResource(dispatched, claim),
       // Queued regional attempts must not restore access from their pre-provisioning snapshot.
-      withLeaseAccess: (target, operation) =>
-        this.withAWSIngressOperationLock(async () => {
+      withLeaseAccess: (target, operation, observe) => {
+        const ingressQueuedAt = Date.now();
+        return this.withAWSIngressOperationLock(async () => {
+          observe?.("ingress_wait", Date.now() - ingressQueuedAt);
+          const lifecycleQueuedAt = Date.now();
           const access = await this.state.runExclusive(async () => {
-            const current = await this.getLease(dispatched.id);
-            const attempt = createAttempt
-              ? await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org)
-              : undefined;
-            if (
-              !current ||
-              !sameLeaseReleaseIdentity(current, dispatched) ||
-              current.state !== "provisioning" ||
-              current.provisioningRequestStartedAt !== dispatched.provisioningRequestStartedAt ||
-              Date.parse(current.expiresAt) <= Date.now() ||
-              (createAttempt && (!attempt || !createAttemptMatchesLease(attempt, current)))
-            ) {
-              throw new CreateAttemptCanceledError();
+            const snapshotStartedAt = Date.now();
+            observe?.("lifecycle_wait", snapshotStartedAt - lifecycleQueuedAt);
+            try {
+              const current = await this.getLease(dispatched.id);
+              const attempt = createAttempt
+                ? await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org)
+                : undefined;
+              if (
+                !current ||
+                !sameLeaseReleaseIdentity(current, dispatched) ||
+                current.state !== "provisioning" ||
+                current.provisioningRequestStartedAt !== dispatched.provisioningRequestStartedAt ||
+                Date.parse(current.expiresAt) <= Date.now() ||
+                (createAttempt && (!attempt || !createAttemptMatchesLease(attempt, current)))
+              ) {
+                throw new CreateAttemptCanceledError();
+              }
+              return {
+                lease: { ...current, ...(target.region ? { region: target.region } : {}) },
+                context: providerAccessContext([], await this.providerAccessLeaseRecords()),
+              };
+            } finally {
+              observe?.("access_snapshot", Date.now() - snapshotStartedAt);
             }
-            return {
-              lease: { ...current, ...(target.region ? { region: target.region } : {}) },
-              context: providerAccessContext([], await this.providerAccessLeaseRecords()),
-            };
           });
           return operation(access.lease, access.context);
-        }),
+        });
+      },
     };
     const provisioned = await provider
       .createServerWithFallback(config, leaseID, slug, owner, provisioning)
@@ -26643,6 +26654,7 @@ interface ProviderProvisioningContext {
   withLeaseAccess?: <T>(
     target: ProviderProvisioningTarget,
     operation: (lease: LeaseRecord, context: ProviderAccessContext) => Promise<T>,
+    observe?: ProviderAccessTimingObserver,
   ) => Promise<T>;
 }
 
@@ -28623,29 +28635,36 @@ export class AWSProvider implements CloudProvider {
               // Only ingress writes hold the fence; image, instance and address waits do not.
               ...(!config.awsPrivate && withLeaseAccess
                 ? {
-                    withIngress: (apply: (cidrs: string[]) => Promise<string>) =>
-                      withLeaseAccess({ region }, async (lease, context) => {
-                        const cidrs = awsCreateSSHSourceCIDRs(
-                          { ...config, awsRegion: region },
-                          lease,
-                          context,
-                          this.env,
-                          this.region,
-                        );
-                        try {
-                          return await apply(cidrs);
-                        } catch (error) {
-                          if (
-                            !isAWSSecurityGroupRuleLimitError(
-                              coordinatorErrorMessage(this.env, error),
-                            )
-                          ) {
-                            throw error;
+                    withIngress: (
+                      apply: (cidrs: string[]) => Promise<string>,
+                      observe: ProviderAccessTimingObserver,
+                    ) =>
+                      withLeaseAccess(
+                        { region },
+                        async (lease, context) => {
+                          const cidrs = awsCreateSSHSourceCIDRs(
+                            { ...config, awsRegion: region },
+                            lease,
+                            context,
+                            this.env,
+                            this.region,
+                          );
+                          try {
+                            return await apply(cidrs);
+                          } catch (error) {
+                            if (
+                              !isAWSSecurityGroupRuleLimitError(
+                                coordinatorErrorMessage(this.env, error),
+                              )
+                            ) {
+                              throw error;
+                            }
+                            await this.reconcileLeaseAccess(lease, context);
+                            return apply(cidrs);
                           }
-                          await this.reconcileLeaseAccess(lease, context);
-                          return apply(cidrs);
-                        }
-                      }),
+                        },
+                        observe,
+                      ),
                   }
                 : {}),
             },

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -759,6 +759,12 @@ export interface LeaseImageIdentity {
   promotedAt?: string;
 }
 
+// Request-local observations; never persisted or used to authorize provider access.
+export type ProviderAccessTimingObserver = (
+  step: "ingress_wait" | "lifecycle_wait" | "access_snapshot",
+  durationMs: number,
+) => void;
+
 export interface LeaseProvisioningTiming {
   requestMs: number;
   networkReadyMs?: number;

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -26,6 +26,7 @@ import {
   isRetryableAWSProvisioningError,
   staleCrabboxSSHIngressRules,
 } from "../src/aws";
+import { createAWSProvisioningDiagnostics } from "../src/aws-provisioning-diagnostics";
 import {
   awsMacOSInstanceTypeCandidates,
   awsPromotedAMIConfigKey,
@@ -36,9 +37,147 @@ import {
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("aws provider", () => {
+  it("bounds repeated diagnostic buckets and records failures without error payloads", async () => {
+    const log = vi.spyOn(console, "info").mockImplementation(() => {});
+    const diagnostics = createAWSProvisioningDiagnostics("x".repeat(10_000), "r".repeat(10_000));
+    for (let index = 0; index < 10_000; index += 1) diagnostics.record("authorize_duplicate", 0);
+    const failure = new Error("private-error-canary");
+    await expect(
+      diagnostics.measure("instance_create", async () => {
+        throw failure;
+      }),
+    ).rejects.toBe(failure);
+    diagnostics.finish("failure");
+    const encoded = String(log.mock.calls[0]![0]);
+    const result = JSON.parse(encoded);
+    expect(result).toMatchObject({
+      outcome: "failure",
+      leaseId: "x".repeat(64),
+      region: "r".repeat(32),
+    });
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps).toEqual(
+      expect.arrayContaining([
+        { name: "authorize_duplicate", count: 10_000, totalMs: 0, errors: 0 },
+        expect.objectContaining({ name: "instance_create", count: 1, errors: 1 }),
+      ]),
+    );
+    expect(encoded).not.toContain("private-error-canary");
+    expect(encoded.length).toBeLessThan(8192);
+  });
+
+  it("keeps overlapping creates on a shared client in separate diagnostic records", async () => {
+    const log = vi.spyOn(console, "info").mockImplementation(() => {});
+    const { client, config } = awsMarketFallbackHarness("");
+    let release!: () => void;
+    let entered!: () => void;
+    const waiting = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const first = client.createServerWithFallback(
+      config,
+      "cbx_000000000001",
+      "first",
+      "alice@example.com",
+      {
+        withIngress: async (apply) => {
+          entered();
+          await gate;
+          return apply(["198.51.100.1/32"]);
+        },
+      },
+    );
+    try {
+      await waiting;
+      await client.createServerWithFallback(
+        config,
+        "cbx_000000000002",
+        "second",
+        "alice@example.com",
+      );
+      expect(log).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(String(log.mock.calls[0]![0])).leaseId).toBe("cbx_000000000002");
+    } finally {
+      release();
+      await first;
+    }
+    const records = log.mock.calls.map(([value]) => JSON.parse(String(value)));
+    expect(records.map((value) => value.leaseId)).toEqual(["cbx_000000000002", "cbx_000000000001"]);
+    expect(
+      records.map(
+        (value) =>
+          value.steps.find((step: { name: string }) => step.name === "authorize_ingress").count,
+      ),
+    ).toEqual([2, 4]);
+  });
+
+  it("reports request step costs and redundant ingress calls without logging payloads", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-02T00:00:00Z"));
+    const log = vi.spyOn(console, "info").mockImplementation(() => {});
+    const { client, config } = awsMarketFallbackHarness("");
+    const baseFetch = globalThis.fetch;
+    const actions: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      const action = new URLSearchParams(await request.clone().text()).get("Action") ?? "";
+      if (action) actions.push(action);
+      if (action === "AuthorizeSecurityGroupIngress" || action === "RevokeSecurityGroupIngress") {
+        const authorize = action === "AuthorizeSecurityGroupIngress";
+        vi.setSystemTime(Date.now() + (authorize ? 7 : 3));
+        return ec2XMLResponse(
+          `<Response><Errors><Error><Code>${authorize ? "InvalidPermission.Duplicate" : "InvalidPermission.NotFound"}</Code><Message>private-rule-canary</Message></Error></Errors></Response>`,
+          400,
+        );
+      }
+      return baseFetch(request);
+    });
+    const result = await client.createServerWithFallback(
+      { ...config, sshPort: "22", sshFallbackPorts: ["443"] },
+      "cbx_abcdef123456",
+      "violet-prawn",
+      "alice@example.com",
+      { withIngress: (apply) => apply(["203.0.113.7/32", "2001:db8::1/128"]) },
+    );
+    expect(result.server.id).toBeDefined();
+    expect(actions.filter((action) => action === "AuthorizeSecurityGroupIngress")).toHaveLength(6);
+    expect(actions.filter((action) => action === "RevokeSecurityGroupIngress")).toHaveLength(2);
+    expect(log).toHaveBeenCalledTimes(1);
+    const encoded = String(log.mock.calls[0]![0]);
+    const diagnostic = JSON.parse(encoded);
+    expect(diagnostic).toMatchObject({
+      component: "crabbox_aws_provisioning",
+      leaseId: "cbx_abcdef123456",
+      region: "eu-west-1",
+      outcome: "success",
+    });
+    expect(diagnostic.steps).toEqual(
+      expect.arrayContaining([
+        { name: "authorize_ingress", count: 6, totalMs: 42, errors: 6 },
+        { name: "authorize_duplicate", count: 6, totalMs: 0, errors: 0 },
+        { name: "revoke_world", count: 2, totalMs: 6, errors: 2 },
+        { name: "revoke_world_absent", count: 2, totalMs: 0, errors: 0 },
+      ]),
+    );
+    for (const privateValue of [
+      "private-rule-canary",
+      "alice@example.com",
+      "203.0.113.7",
+      "2001:db8",
+      "ssh-ed25519",
+    ])
+      expect(encoded).not.toContain(privateValue);
+    expect(encoded.length).toBeLessThan(8192);
+    log.mockRestore();
+  });
+
   it("tags every checkpoint AMI backing snapshot with its exact ownership claim", async () => {
     let submitted: URLSearchParams | undefined;
     vi.stubGlobal(

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -1471,6 +1471,7 @@ describe("aws provider", () => {
   });
 
   it("falls back from unfulfillable spot capacity to on-demand", async () => {
+    const log = vi.spyOn(console, "info").mockImplementation(() => {});
     const { client, config, markets } = awsMarketFallbackHarness("UnfulfillableCapacity");
 
     const result = await client.createServerWithFallback(
@@ -1480,6 +1481,9 @@ describe("aws provider", () => {
       "alice@example.com",
     );
 
+    expect(JSON.parse(String(log.mock.calls[0]![0])).steps).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "image", count: 3, errors: 0 })]),
+    );
     expect(markets).toEqual(["spot", "on-demand"]);
     expect(result.market).toBe("on-demand");
     expect(result.attempts?.[0]).toMatchObject({ market: "spot", category: "capacity" });
@@ -2027,7 +2031,10 @@ describe("aws provider", () => {
     expect(await gunzipBase64(userData)).not.toContain("\napt:\n");
   });
 
-  it("resolves macOS AMIs per fallback instance type", async () => {
+  it.each([false, true])("times macOS fallback AMI discovery (failure: %s)", async (failImage) => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-02T00:00:00Z"));
+    const log = vi.spyOn(console, "info").mockImplementation(() => {});
     const imageQueries: string[] = [];
     const hostTypes: string[] = [];
     const runImages: string[] = [];
@@ -2054,6 +2061,13 @@ describe("aws provider", () => {
           );
         }
         if (action === "DescribeImages") {
+          vi.setSystemTime(Date.now() + 37);
+          if (failImage) {
+            return ec2XMLResponse(
+              "<Response><Errors><Error><Code>UnauthorizedOperation</Code><Message>private-image-canary</Message></Error></Errors></Response>",
+              403,
+            );
+          }
           const architecture = params.get("Filter.1.Value.1") ?? "";
           const name = params.get("Filter.2.Value.1") ?? "";
           imageQueries.push(`${name}:${architecture}`);
@@ -2124,7 +2138,7 @@ describe("aws provider", () => {
       } as never,
       "eu-west-1",
     );
-    const result = await client.createServerWithFallback(
+    const creating = client.createServerWithFallback(
       leaseConfig({
         provider: "aws",
         target: "macos",
@@ -2136,16 +2150,38 @@ describe("aws provider", () => {
       "alice@example.com",
     );
 
-    expect(imageQueries).toEqual([
-      "amzn-ec2-macos-14.*-arm64:arm64_mac",
-      "amzn-ec2-macos-15.*-arm64:arm64_mac",
-      "amzn-ec2-macos-14.*:x86_64_mac",
-    ]);
-    expect(hostTypes).toEqual(awsMacOSInstanceTypeCandidates);
-    expect(runTypes).toEqual(["mac1.metal"]);
-    expect(runImages).toEqual(["ami-x86-mac"]);
-    expect(result.serverType).toBe("mac1.metal");
-    expect(result.server.hostID).toBe("h-mac1");
+    const outcome = await creating.then(
+      (result) => ({ result, error: "" }),
+      (error: unknown) => ({ result: undefined, error: String(error) }),
+    );
+    expect(outcome.error).toMatch(failImage ? /UnauthorizedOperation/ : /^$/);
+    const encoded = String(log.mock.calls[0]![0]);
+    expect(JSON.parse(encoded)).toMatchObject({
+      outcome: failImage ? "failure" : "success",
+      steps: expect.arrayContaining([
+        {
+          name: "image",
+          count: failImage ? 2 : 1 + awsMacOSInstanceTypeCandidates.length,
+          totalMs: failImage ? 37 : 111,
+          errors: failImage ? 1 : 0,
+        },
+      ]),
+    });
+    expect(encoded).not.toContain("private-image-canary");
+    expect(imageQueries).toEqual(
+      failImage
+        ? []
+        : [
+            "amzn-ec2-macos-14.*-arm64:arm64_mac",
+            "amzn-ec2-macos-15.*-arm64:arm64_mac",
+            "amzn-ec2-macos-14.*:x86_64_mac",
+          ],
+    );
+    expect(hostTypes).toEqual(failImage ? [] : awsMacOSInstanceTypeCandidates);
+    expect(runTypes).toEqual(failImage ? [] : ["mac1.metal"]);
+    expect(runImages).toEqual(failImage ? [] : ["ami-x86-mac"]);
+    expect(outcome.result?.serverType).toBe(failImage ? undefined : "mac1.metal");
+    expect(outcome.result?.server.hostID).toBe(failImage ? undefined : "h-mac1");
   });
 
   it("retries macOS launch on another discovered host after host capacity is exhausted", async () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -26128,6 +26128,76 @@ describe("fleet lease identity and idle", () => {
     }
   });
 
+  it("measures queued AWS ingress separately from permission API calls", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-02T00:00:00Z"));
+    const log = vi.spyOn(console, "info").mockImplementation(() => {});
+    const refreshStarted = deferred<void>();
+    const finishRefresh = deferred<void>();
+    const queued = deferred<void>();
+    let refreshing = true;
+    const fixture = awsIngressTestFleet(async (action) => {
+      if (action === "AuthorizeSecurityGroupIngress") {
+        if (refreshing) {
+          refreshStarted.resolve();
+          await finishRefresh.promise;
+        } else vi.setSystemTime(Date.now() + 7);
+      }
+      return undefined;
+    });
+    const original = EC2SpotClient.prototype.createServerWithFallback;
+    const createSpy = vi
+      .spyOn(EC2SpotClient.prototype, "createServerWithFallback")
+      .mockImplementation(function (config, id, slug, owner, options) {
+        if (!options?.withIngress) throw new Error("AWS fixture did not provide its ingress fence");
+        const withIngress = options.withIngress;
+        return original.call(this, config, id, slug, owner, {
+          ...options,
+          withIngress: (apply, observe) => {
+            const pending = withIngress(apply, observe);
+            queued.resolve();
+            return pending;
+          },
+        });
+      });
+    const refresh = fixture.fleet.fetch(
+      request("POST", `/v1/leases/${fixture.activeID}/heartbeat`, {
+        headers: { ...fixture.headers, "cf-connecting-ip": "198.51.100.30" },
+        body: { idleTimeoutSeconds: 600 },
+      }),
+    );
+    let creating: Promise<Response> | undefined;
+    try {
+      await refreshStarted.promise;
+      creating = fixture.create();
+      await queued.promise;
+      vi.setSystemTime(Date.now() + 41);
+      refreshing = false;
+      finishRefresh.resolve();
+      expect((await refresh).status).toBe(200);
+      expect((await creating).status).toBe(201);
+      const entries = log.mock.calls
+        .map(([value]) => JSON.parse(String(value)))
+        .filter(
+          (value) =>
+            value.component === "crabbox_aws_provisioning" && value.leaseId === fixture.creatingID,
+        );
+      expect(entries).toHaveLength(1);
+      expect(entries[0].steps).toEqual(
+        expect.arrayContaining([
+          { name: "ingress_wait", count: 1, totalMs: 41, errors: 0 },
+          { name: "lifecycle_wait", count: 1, totalMs: 0, errors: 0 },
+          { name: "authorize_ingress", count: 2, totalMs: 14, errors: 0 },
+        ]),
+      );
+    } finally {
+      finishRefresh.resolve();
+      await Promise.allSettled([refresh, ...(creating ? [creating] : [])]);
+      createSpy.mockRestore();
+      log.mockRestore();
+    }
+  });
+
   it("refreshes queued AWS ingress after an earlier release removes a lease", async () => {
     const refreshStarted = deferred<void>();
     const finishRefresh = deferred<void>();


### PR DESCRIPTION
## What Problem This Solves

A slow AWS startup reports one combined provider-request duration. It cannot distinguish ingress contention, lifecycle bookkeeping, security-group API calls, image lookup, quota checks or instance creation, making latency fixes guesswork.

## Why This Change Was Made

Emit one bounded, request-owned diagnostic record per completed regional create attempt. Eighteen fixed buckets separate shared access waits from AWS operations and count duplicate authorization and absent-rule responses. The observer is provider-neutral at the shared access boundary; AWS owns its labels and reporting.

## User Impact

Operators can attribute provisioning delays without logging credentials, request payloads, IP addresses or exception text. Permissions, cleanup, retries, lease timing fields, configuration and persistent-store formats stay unchanged. Nested bucket durations overlap as documented.

## Evidence

The reviewed instrumentation was deployed through the existing coordinator workflow from commit 719b3e6b5adcd19f383e277995a2c9de8c1c933f: https://github.com/openclaw/crabbox/actions/runs/34082179434. A header-correlated health probe verified serving version 6cf6bf70-3131-49f3-a9d9-0740625b7558 before admission; the same subscription captured the exact lease's HTTP and alarm events with no observed version change.

Real AWS lease cbx_663bdb6cb7e4 emitted one successful `crabbox_aws_provisioning` record in eu-west-1:

| Operation | Milliseconds |
| --- | ---: |
| Key pair | 2638 |
| Image lookups (two) | 469 |
| Ingress queue wait | 3526 |
| Lifecycle wait / access snapshot | 0 / 0 |
| Security-group work | 9153 |
| Quota | 522 |
| Instance creation | 5056 |
| Temporary-image cleanup | 5147 |
| Total | 26511 |

Security-group detail: lookup 178 ms, VPC lookup 2980 ms, two world-rule revocations 3639 ms, four authorizations 2356 ms. All four authorizations returned the expected duplicate response. That proves existing permissions, not repeated CIDR inputs. These child buckets exactly account for their parent; the top-level buckets account for the total without double-counting.

The worker booted and reused its runtime cache. Its later application turn failed at a separate execution socket; this is a provisioning-diagnostic pass, not an end-to-end application pass. Canonical cleanup confirmed the lease released with cleanup complete, its environment destroyed without attachments, and the source checkpoint deleted through the provider API. Original failure artifacts remain intact. One recycled local PID belonged to a newly started unrelated process; its original command had already exited and been joined.

The parent lacks this record. Controlled delayed API and held ingress-queue tests verify attribution, concurrent request separation, bounds, redaction and failure counts. Both per-candidate image paths, including architecture and Spot-to-On-Demand fallback, are covered. All 2,837 Worker tests, both typechecks, lint, formatting and both builds passed after integration; managed full-PR review is clean through P2. The final rebase preserves the complete instrumentation and test bytes.

Production +145 lines provide bounded diagnostics and existing-owner timing hooks; tests +245, docs/changelog +26. No schema or protocol bump. The maintainer changelog entry is retained under Unreleased as this repository requires.

## Review follow-through

The candidate-image timing finding is fixed. The live record above addresses the outstanding real-behavior request and the latest rank-up move. No permission calls are skipped based on a cached security-group snapshot. The measured temporary-image cleanup delay is a separate ownership investigation, not a reason to detach cleanup in this change.
