### PR TITLE
chore(release): authorize v0.51.0 source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## 0.51.0 - 2026-09-06
 
 ### Highlights

--- a/release/records/v0.51.0.json
+++ b/release/records/v0.51.0.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.51.0",
+  "tagObject": "c38e894f9405881993c326762ff2979c5d84f9d2",
+  "sourceCommit": "745eb21f8fb97582a7e0ec176ee9671562eba2b9",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
Bind the verified signed `v0.51.0` tag to release source `745eb21f8fb97582a7e0ec176ee9671562eba2b9`, enabling the protected producer and publication checks. Reopen `Unreleased` for subsequent work while preserving the tagged release notes exactly.

The release source was prepared in https://github.com/openclaw/crabbox/pull/1935 and passed full CI: https://github.com/openclaw/crabbox/actions/runs/34072518639. GitHub reports the tag signature as verified. The coordinator-backed smoke passed, its attach/events/logs were verified, and provider cleanup was confirmed with a completion timestamp and cleared remote access.

Validation: `scripts/verify-release-source.sh` with the exact tag object and source commit, changelog extraction equality, `git diff --check`, and required autoreview. No executable code, credentials, or release assets are changed.
