### PR TITLE
fix: redact Tailscale diagnostics in coordinator errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Tailscale: keep provider diagnostics and OAuth credentials out of preflight and tag-ownership errors while preserving operation, HTTP status, and actionable tag guidance.
+- Tailscale: keep provider diagnostics and OAuth credentials out of preflight and tag-ownership errors while preserving operation, HTTP status, and actionable tag guidance. [PR 1940](https://github.com/openclaw/crabbox/pull/1940).
 
 ## 0.51.0 - 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Tailscale: keep provider diagnostics and OAuth credentials out of preflight and tag-ownership errors while preserving operation, HTTP status, and actionable tag guidance.
+
 ## 0.51.0 - 2026-09-06
 
 ### Highlights

--- a/docs/features/tailscale.md
+++ b/docs/features/tailscale.md
@@ -207,8 +207,9 @@ trusted authorization for a privileged tailnet operation. One-off nodes are
 ephemeral and age out in Tailscale if remote logout is unavailable.
 
 If Tailscale rejects a requested subset or unowned tag, the coordinator returns
-`invalid_tailscale_tags` with exact-match/`tagOwners` guidance and preserves the raw
-Tailscale HTTP status and response body for diagnosis.
+`invalid_tailscale_tags` with exact-match/`tagOwners` guidance, the failed
+operation, and the HTTP status. Raw Tailscale response bodies are withheld from
+coordinator responses.
 
 Preflight the coordinator without leasing a machine:
 

--- a/worker/src/tailscale.ts
+++ b/worker/src/tailscale.ts
@@ -3,6 +3,7 @@ import {
   defaultTailscaleAMD64SHA256,
   defaultTailscaleARM64SHA256,
 } from "./bootstrap.generated";
+import { errorMessage } from "./http";
 import type { Env } from "./types";
 
 export interface TailscaleKeyRequest {
@@ -49,13 +50,31 @@ export interface TailscalePreflightResult {
 type TailscaleAPIOperation = "oauth token" | "create auth key";
 
 class TailscaleAPIError extends Error {
+  // Provider diagnostics are classification-only, never public error fields.
+  readonly #responseBody: string;
+
   constructor(
     readonly operation: TailscaleAPIOperation,
     readonly status: number,
-    readonly responseBody: string,
+    responseBody: string,
   ) {
-    super(`tailscale ${operation}: http ${status}: ${responseBody}`);
+    super(`tailscale ${operation} failed: http ${status}`);
     this.name = "TailscaleAPIError";
+    this.#responseBody = trimBody(responseBody);
+  }
+
+  isTagOwnershipError(): boolean {
+    if (this.status !== 400 && this.status !== 403) {
+      return false;
+    }
+    const body = this.#responseBody.toLowerCase();
+    return (
+      (body.includes("requested tags") &&
+        (body.includes("invalid or not permitted") ||
+          body.includes("invalid or not allowed") ||
+          body.includes("not owned"))) ||
+      body.includes("tailnet-owned auth key must have tags set")
+    );
   }
 }
 
@@ -131,35 +150,46 @@ export async function createTailscaleAuthKey(
     tags: request.tags,
   });
   const tailnet = env.CRABBOX_TAILSCALE_TAILNET?.trim() || "-";
-  const response = await fetch(
-    `https://api.tailscale.com/api/v2/tailnet/${encodeURIComponent(tailnet)}/keys`,
-    {
-      method: "POST",
-      headers: {
-        authorization: `Bearer ${token}`,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({
-        capabilities: {
-          devices: {
-            create: {
-              reusable: false,
-              ephemeral: true,
-              preauthorized: true,
-              tags: request.tags,
+  let data: { key?: string };
+  try {
+    const response = await fetch(
+      `https://api.tailscale.com/api/v2/tailnet/${encodeURIComponent(tailnet)}/keys`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          capabilities: {
+            devices: {
+              create: {
+                reusable: false,
+                ephemeral: true,
+                preauthorized: true,
+                tags: request.tags,
+              },
             },
           },
-        },
-        expirySeconds: 600,
-        description: request.description,
-      }),
-    },
-  );
-  const text = await response.text();
-  if (!response.ok) {
-    throw tailscaleAPIError("create auth key", response.status, text);
+          expirySeconds: 600,
+          description: request.description,
+        }),
+      },
+    );
+    const text = await response.text();
+    if (!response.ok) {
+      throw new TailscaleAPIError("create auth key", response.status, text);
+    }
+    data = JSON.parse(text) as { key?: string };
+  } catch (error) {
+    if (error instanceof TailscaleAPIError) {
+      throw error;
+    }
+    // oxlint-disable-next-line eslint/preserve-caught-error -- Upstream causes can expose OAuth credentials.
+    throw new Error(
+      `tailscale create auth key failed: ${errorMessage(error, [clientSecret, token])}`,
+    );
   }
-  const data = JSON.parse(text) as { key?: string };
   if (!data.key) {
     throw new Error("tailscale create auth key returned no key");
   }
@@ -199,7 +229,7 @@ export async function tailscalePreflight(env: Env): Promise<TailscalePreflightRe
       tailnet,
       tags: [],
       install,
-      message: errorMessage(error),
+      message: errorMessage(error, [env.CRABBOX_TAILSCALE_CLIENT_SECRET]),
     };
   }
   try {
@@ -219,7 +249,7 @@ export async function tailscalePreflight(env: Env): Promise<TailscalePreflightRe
       tailnet,
       tags,
       install,
-      message: errorMessage(error),
+      message: errorMessage(error, [env.CRABBOX_TAILSCALE_CLIENT_SECRET]),
     };
   }
   return {
@@ -244,16 +274,25 @@ async function tailscaleOAuthToken(
   if (request.tags && request.tags.length > 0) {
     body.set("tags", request.tags.join(" "));
   }
-  const response = await fetch("https://api.tailscale.com/api/v2/oauth/token", {
-    method: "POST",
-    headers: { "content-type": "application/x-www-form-urlencoded" },
-    body,
-  });
-  const text = await response.text();
-  if (!response.ok) {
-    throw tailscaleAPIError("oauth token", response.status, text);
+  let data: { access_token?: string };
+  try {
+    const response = await fetch("https://api.tailscale.com/api/v2/oauth/token", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body,
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      throw new TailscaleAPIError("oauth token", response.status, text);
+    }
+    data = JSON.parse(text) as { access_token?: string };
+  } catch (error) {
+    if (error instanceof TailscaleAPIError) {
+      throw error;
+    }
+    // oxlint-disable-next-line eslint/preserve-caught-error -- Upstream causes can expose OAuth credentials.
+    throw new Error(`tailscale oauth token failed: ${errorMessage(error, [clientSecret])}`);
   }
-  const data = JSON.parse(text) as { access_token?: string };
   if (!data.access_token) {
     throw new Error("tailscale oauth token returned no access token");
   }
@@ -261,37 +300,15 @@ async function tailscaleOAuthToken(
 }
 
 export function tailscaleTagOwnershipErrorMessage(error: unknown): string | undefined {
-  if (!(error instanceof TailscaleAPIError) || !isTailscaleTagOwnershipError(error)) {
+  if (!(error instanceof TailscaleAPIError) || !error.isTagOwnershipError()) {
     return undefined;
   }
   return [
     "Tailscale rejected the requested tags.",
     "The requested tag set must exactly match the OAuth client's tags, or every requested tag must be owned by one of the OAuth client tags in tagOwners.",
     "For multi-tag allowlists, configure self-ownership for subset requests or use a dedicated deployment-owner tag.",
-    `Raw Tailscale error: ${error.message}`,
+    error.message,
   ].join(" ");
-}
-
-function tailscaleAPIError(
-  operation: TailscaleAPIOperation,
-  status: number,
-  responseBody: string,
-): TailscaleAPIError {
-  return new TailscaleAPIError(operation, status, trimBody(responseBody));
-}
-
-function isTailscaleTagOwnershipError(error: TailscaleAPIError): boolean {
-  if (error.status !== 400 && error.status !== 403) {
-    return false;
-  }
-  const body = error.responseBody.toLowerCase();
-  return (
-    (body.includes("requested tags") &&
-      (body.includes("invalid or not permitted") ||
-        body.includes("invalid or not allowed") ||
-        body.includes("not owned"))) ||
-    body.includes("tailnet-owned auth key must have tags set")
-  );
 }
 
 function normalizeTags(values: string[]): string[] {
@@ -302,10 +319,6 @@ function normalizeTags(values: string[]): string[] {
 
 function trimBody(value: string): string {
   return value.replaceAll(/\s+/g, " ").trim().slice(0, 500);
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 function sanitizeDNSLabel(value: string): string {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -21016,19 +21016,17 @@ describe("fleet lease identity and idle", () => {
   });
 
   it("exposes admin Tailscale preflight without leaking minted keys", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: RequestInfo | URL) => {
-        const url = String(input);
-        if (url === "https://api.tailscale.com/api/v2/oauth/token") {
-          return jsonResponse({ access_token: "oauth-token" });
-        }
-        if (url === "https://api.tailscale.com/api/v2/tailnet/-/keys") {
-          return jsonResponse({ key: "tskey-preflight-secret" });
-        }
-        return jsonResponse({ message: `unexpected ${url}` }, 500);
-      }),
-    );
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = String(input);
+      if (url === "https://api.tailscale.com/api/v2/oauth/token") {
+        return jsonResponse({ access_token: "oauth-token" });
+      }
+      if (url === "https://api.tailscale.com/api/v2/tailnet/-/keys") {
+        return jsonResponse({ key: "tskey-preflight-secret" });
+      }
+      return jsonResponse({ message: `unexpected ${url}` }, 500);
+    });
+    vi.stubGlobal("fetch", fetchMock);
     const fleet = testFleet(
       new MemoryStorage(),
       {},
@@ -21038,6 +21036,10 @@ describe("fleet lease identity and idle", () => {
         CRABBOX_TAILSCALE_TAGS: "tag:ci",
       },
     );
+
+    const forbidden = await fleet.fetch(request("POST", "/v1/admin/tailscale-preflight"));
+    expect(forbidden.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
 
     const response = await fleet.fetch(
       request("POST", "/v1/admin/tailscale-preflight", {
@@ -21050,6 +21052,67 @@ describe("fleet lease identity and idle", () => {
     expect(text).toContain('"status":"ok"');
     expect(text).not.toContain("tskey-preflight-secret");
   });
+
+  it.each([
+    { operation: "oauth token", failure: "response", status: "oauth_token_failed" },
+    { operation: "create auth key", failure: "response", status: "auth_key_mint_failed" },
+    { operation: "oauth token", failure: "fetch", status: "auth_key_mint_failed" },
+    { operation: "create auth key", failure: "fetch", status: "auth_key_mint_failed" },
+  ])(
+    "redacts admin Tailscale preflight $operation $failure diagnostics",
+    async ({ operation, failure, status }) => {
+      const clientSecret = "synthetic-client-credential";
+      const token = "synthetic-runtime-credential";
+      const diagnostic =
+        `provider unavailable ${operation === "create auth key" ? `${clientSecret} ${token}` : clientSecret}` +
+        "\n    at providerDiagnostic (provider.js:42:7)";
+      const fetchMock = vi.fn<typeof fetch>();
+      if (operation === "create auth key") {
+        fetchMock.mockResolvedValueOnce(jsonResponse({ access_token: token }));
+      }
+      if (failure === "fetch") {
+        fetchMock.mockRejectedValueOnce(new Error(diagnostic));
+      } else {
+        fetchMock.mockResolvedValueOnce(new Response(diagnostic, { status: 503 }));
+      }
+      vi.stubGlobal("fetch", fetchMock);
+      const fleet = testFleet(
+        new MemoryStorage(),
+        {},
+        {
+          CRABBOX_TAILSCALE_CLIENT_ID: "client-id",
+          CRABBOX_TAILSCALE_CLIENT_SECRET: clientSecret,
+          CRABBOX_TAILSCALE_TAGS: "tag:ci",
+        },
+      );
+
+      const response = await fleet.fetch(
+        request("POST", "/v1/admin/tailscale-preflight", {
+          headers: { "x-crabbox-admin": "true" },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const text = await response.text();
+      expect(text).not.toContain(clientSecret);
+      expect(text).not.toContain(token);
+      expect(text).not.toContain("providerDiagnostic");
+      expect(text).not.toContain("provider.js");
+      const safeDiagnostic =
+        operation === "create auth key" ? "[redacted] [redacted]" : "[redacted]";
+      const message =
+        failure === "fetch"
+          ? `tailscale ${operation} failed: provider unavailable ${safeDiagnostic}`
+          : `tailscale ${operation} failed: http 503`;
+      expect(JSON.parse(text)).toMatchObject({
+        tailscale: {
+          status,
+          message,
+        },
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(operation === "oauth token" ? 1 : 2);
+    },
+  );
 
   it("restricts Daytona snapshot bootstrap to confirmed, bounded admin requests", async () => {
     let activeProviderRequests = 0;
@@ -24469,45 +24532,60 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value("lease:cbx_abcdef123456")).toBeUndefined();
   });
 
-  it("translates brokered Tailscale tag ownership denials", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi
-        .fn()
-        .mockResolvedValue(
-          jsonResponse({ message: "requested tags [tag:ci] are invalid or not permitted" }, 400),
+  it.each(["oauth token", "create auth key"])(
+    "translates brokered Tailscale %s tag ownership denials without raw diagnostics",
+    async (operation) => {
+      const fetchMock = vi.fn<typeof fetch>();
+      if (operation === "create auth key") {
+        fetchMock.mockResolvedValueOnce(jsonResponse({ access_token: "oauth-token" }));
+      }
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse(
+          {
+            message:
+              "requested tags [tag:ci] are invalid or not permitted; client-secret oauth-token\n    at providerDiagnostic (provider.js:42:7)",
+          },
+          400,
         ),
-    );
-    const storage = new MemoryStorage();
-    const fleet = testFleet(
-      storage,
-      { hetzner: fakeProvider() },
-      {
-        CRABBOX_TAILSCALE_CLIENT_ID: "client-id",
-        CRABBOX_TAILSCALE_CLIENT_SECRET: "client-secret",
-        CRABBOX_TAILSCALE_TAGS: "tag:crabbox,tag:ci",
-      },
-    );
-    const create = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        body: {
-          leaseID: "cbx_abcdef123456",
-          provider: "hetzner",
-          tailscale: true,
-          tailscaleTags: ["tag:ci"],
-          sshPublicKey: "ssh-ed25519 test",
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const storage = new MemoryStorage();
+      const fleet = testFleet(
+        storage,
+        { hetzner: fakeProvider() },
+        {
+          CRABBOX_TAILSCALE_CLIENT_ID: "client-id",
+          CRABBOX_TAILSCALE_CLIENT_SECRET: "client-secret",
+          CRABBOX_TAILSCALE_TAGS: "tag:crabbox,tag:ci",
         },
-      }),
-    );
-    expect(create.status).toBe(400);
-    const body = (await create.json()) as { error: string; message: string };
-    expect(body).toMatchObject({
-      error: "invalid_tailscale_tags",
-      message: expect.stringContaining("must exactly match the OAuth client's tags"),
-    });
-    expect(body.message).toContain("requested tags [tag:ci] are invalid or not permitted");
-    expect(storage.value("lease:cbx_abcdef123456")).toBeUndefined();
-  });
+      );
+      const create = await fleet.fetch(
+        request("POST", "/v1/leases", {
+          body: {
+            leaseID: "cbx_abcdef123456",
+            provider: "hetzner",
+            tailscale: true,
+            tailscaleTags: ["tag:ci"],
+            sshPublicKey: "ssh-ed25519 test",
+          },
+        }),
+      );
+      expect(create.status).toBe(400);
+      const text = await create.text();
+      expect(text).not.toContain("client-secret");
+      expect(text).not.toContain("oauth-token");
+      expect(text).not.toContain("providerDiagnostic");
+      expect(text).not.toContain("provider.js");
+      const body = JSON.parse(text) as { error: string; message: string };
+      expect(body).toMatchObject({
+        error: "invalid_tailscale_tags",
+        message: expect.stringContaining("must exactly match the OAuth client's tags"),
+      });
+      expect(body.message).toContain("dedicated deployment-owner tag");
+      expect(body.message).toContain(`tailscale ${operation} failed: http 400`);
+      expect(storage.value("lease:cbx_abcdef123456")).toBeUndefined();
+    },
+  );
 
   it("reports brokered Tailscale disabled when OAuth secrets are absent", async () => {
     const storage = new MemoryStorage();

--- a/worker/test/tailscale.test.ts
+++ b/worker/test/tailscale.test.ts
@@ -35,10 +35,12 @@ describe("tailscale tag ownership errors", () => {
   it.each([
     {
       name: "OAuth token",
+      operation: "oauth token",
       responses: [
         new Response(
           JSON.stringify({
-            message: "requested tags [tag:ci] are invalid or not permitted",
+            message:
+              "requested tags [tag:ci] are invalid or not permitted; client-secret\n    at providerDiagnostic (provider.js:42:7)",
           }),
           { status: 400 },
         ),
@@ -46,17 +48,16 @@ describe("tailscale tag ownership errors", () => {
     },
     {
       name: "auth key",
+      operation: "create auth key",
       responses: [
         new Response(JSON.stringify({ access_token: "oauth-token" })),
         new Response(
-          JSON.stringify({
-            message: "requested tags [tag:ci] are invalid or not permitted",
-          }),
+          "requested tags [tag:ci] are invalid or not permitted; client-secret oauth-token\n    at providerDiagnostic (provider.js:42:7)",
           { status: 400 },
         ),
       ],
     },
-  ])("adds actionable guidance for $name tag denials", async ({ responses }) => {
+  ])("adds safe actionable guidance for $name tag denials", async ({ operation, responses }) => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => responses.shift()!),
@@ -82,8 +83,16 @@ describe("tailscale tag ownership errors", () => {
     const message = tailscaleTagOwnershipErrorMessage(caught);
     expect(message).toContain("must exactly match the OAuth client's tags");
     expect(message).toContain("dedicated deployment-owner tag");
-    expect(message).toContain("Raw Tailscale error: tailscale");
-    expect(message).toContain("requested tags [tag:ci] are invalid or not permitted");
+    expect(message).toContain(`tailscale ${operation} failed: http 400`);
+    expect(message).not.toContain("client-secret");
+    expect(message).not.toContain("oauth-token");
+    expect(message).not.toContain("providerDiagnostic");
+    expect(message).not.toContain("provider.js");
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toBe(`tailscale ${operation} failed: http 400`);
+    expect(JSON.stringify(caught)).not.toContain("client-secret");
+    expect(JSON.stringify(caught)).not.toContain("oauth-token");
+    expect(JSON.stringify(caught)).not.toContain("providerDiagnostic");
   });
 
   it("does not classify unrelated OAuth failures as tag ownership errors", async () => {
@@ -115,7 +124,7 @@ describe("tailscale tag ownership errors", () => {
 
     expect(tailscaleTagOwnershipErrorMessage(caught)).toBeUndefined();
     expect(caught).toBeInstanceOf(Error);
-    expect((caught as Error).message).toContain('http 401: {"message":"API token invalid"}');
+    expect((caught as Error).message).toBe("tailscale oauth token failed: http 401");
   });
 });
 
@@ -137,6 +146,63 @@ describe("tailscale preflight", () => {
 
     expect(result.status).toBe("missing_oauth_credentials");
     expect(result.enabled).toBe(true);
+  });
+
+  describe.each([
+    { operation: "oauth token", failureStatus: "oauth_token_failed", calls: 1 },
+    { operation: "create auth key", failureStatus: "auth_key_mint_failed", calls: 2 },
+  ])("$operation failures", ({ operation, failureStatus, calls }) => {
+    it.each(["text response", "JSON response", "fetch rejection"])(
+      "keeps diagnostics and credentials out of a %s",
+      async (failure) => {
+        const clientSecret = "synthetic-client-credential";
+        const token = "synthetic-runtime-credential";
+        const diagnostic =
+          `provider unavailable ${operation === "create auth key" ? `${clientSecret} ${token}` : clientSecret}` +
+          "\n    at providerDiagnostic (provider.js:42:7)";
+        const fetch = vi.fn<typeof globalThis.fetch>();
+        if (operation === "create auth key") {
+          fetch.mockResolvedValueOnce(new Response(JSON.stringify({ access_token: token })));
+        }
+        if (failure === "fetch rejection") {
+          fetch.mockRejectedValueOnce(new Error(diagnostic));
+        } else {
+          fetch.mockResolvedValueOnce(
+            new Response(
+              failure === "JSON response" ? JSON.stringify({ message: diagnostic }) : diagnostic,
+              { status: 503 },
+            ),
+          );
+        }
+        vi.stubGlobal("fetch", fetch);
+
+        const result = await tailscalePreflight({
+          CRABBOX_TAILSCALE_CLIENT_ID: "client-id",
+          CRABBOX_TAILSCALE_CLIENT_SECRET: clientSecret,
+          CRABBOX_TAILSCALE_TAGS: "tag:ci",
+        });
+
+        // Fetch rejections retain the existing generic key-mint failure category.
+        expect(result.status).toBe(
+          failure === "fetch rejection" ? "auth_key_mint_failed" : failureStatus,
+        );
+        expect(result).toMatchObject({ enabled: true, tailnet: "-", tags: ["tag:ci"] });
+        expect(result.install.mode).toBe("package");
+        const safeDiagnostic =
+          operation === "create auth key" ? "[redacted] [redacted]" : "[redacted]";
+        const expectedMessage =
+          failure === "fetch rejection"
+            ? `tailscale ${operation} failed: provider unavailable ${safeDiagnostic}`
+            : `tailscale ${operation} failed: http 503`;
+        expect(result.message).toBe(expectedMessage);
+        const text = JSON.stringify(result);
+        expect(text).not.toContain(clientSecret);
+        expect(text).not.toContain(token);
+        expect(text).not.toContain("providerDiagnostic");
+        expect(text).not.toContain("provider.js");
+        expect(fetch).toHaveBeenCalledTimes(calls);
+      },
+    );
   });
 
   it("mints and redacts the one-off smoke key", async () => {


### PR DESCRIPTION
Related: https://github.com/openclaw/crabbox/security/code-scanning/79

## What Problem This Solves

Resolves a problem where failed Tailscale preflights and lease tag checks could include provider diagnostic text and OAuth credentials in coordinator responses. Preflight remains admin-only; this does not claim unauthenticated exposure.

## Why This Change Was Made

Tailscale HTTP errors now expose only the operation and HTTP status. Bounded provider text stays private to tag-ownership classification, and the existing actionable tag guidance no longer repeats raw diagnostics.

The Tailscale troubleshooting documentation now describes the same operation/status and tag-guidance contract and explicitly states that raw provider response bodies are withheld.

Transport, response-read, and parse failures use the existing diagnostic sanitizer where the configured client secret and runtime OAuth token are available. Original exception causes are not retained because they can contain credentials. Preflight result categories, key requests, successful responses, authorization, and the global serializer/sanitizer are unchanged. There are no configuration, schema, dependency, or version changes.

## User Impact

Operators retain useful operation/status context and tag-ownership guidance without receiving raw provider diagnostics or OAuth credentials. Successful preflight continues to omit the minted auth key, and nonadmins still receive 403 before any provider request.

## Evidence

- Synthetic regression cases failed on the original production source: 15 failures, including full serialized preflight and tag-guidance responses containing diagnostic frames and synthetic credentials.
- After repair: 31 focused Tailscale tests passed across `worker/test/tailscale.test.ts` and `worker/test/fleet.test.ts`; 1,055 unrelated tests were skipped by the filter.
- Cases cover OAuth and key-mint non-OK responses, plain and JSON-escaped diagnostic frames, rejected fetches, configured-secret/runtime-token redaction, safe status/context, both tag-guidance paths, successful key non-disclosure, and nonadmin rejection without provider calls.
- Worker TypeScript check, targeted lint/format checks, and `git diff --check` passed.
- Independent local autoreview was scoped-clean at its default P0 threshold.
- The documentation-only review follow-up passed `node scripts/check-docs-links.mjs` (246 Markdown files) and `git diff --check`; comparison against the previously reviewed head confirms Worker source, tests, and the changelog are unchanged. Existing runtime proof was retained without rerunning it.
- No live Tailscale API calls or auth-key creation, deployment, full Worker suite, or Go suite was performed locally. Hosted CI and the CodeQL result are tracked separately.

```sh
npm test --prefix worker -- test/tailscale.test.ts test/fleet.test.ts -t '[Tt]ailscale' --maxWorkers=1 --reporter=dot
npm run check --prefix worker
# From worker/:
./node_modules/.bin/oxlint --config .oxlintrc.json src/tailscale.ts test/tailscale.test.ts test/fleet.test.ts
./node_modules/.bin/oxfmt --check src/tailscale.ts test/tailscale.test.ts test/fleet.test.ts
```

<!-- Punchcard-Session: coral-river-river-ay -->
