### PR TITLE
perf: reuse prepared SSH endpoints within operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reuse verified SSH endpoints within an operation, preserving advertised fallbacks when switching hosts or ports and avoiding redundant login probes across direct, proxy, and WSL execution. [PR 1941](https://github.com/openclaw/crabbox/pull/1941).
 - Report image qualification reaping as idle after clean teardown, while preserving failed recovery evidence and checking transient controller ownership before cleanup. [PR 1942](https://github.com/openclaw/crabbox/pull/1942). Thanks @vincentkoc.
 - Add `crabbox bench check` to enforce sample, failure, and p95 runner timing policy across every matched local benchmark group. [PR 1899](https://github.com/openclaw/crabbox/pull/1899). Thanks @vincentkoc.
 - Distinguish required-artifact, artifact-change, and artifact-schema validation failures from workload exits in run timing and failure digests, preserving exit 7 and artifact enforcement. [PR 1934](https://github.com/openclaw/crabbox/pull/1934), [Issue 1894](https://github.com/openclaw/crabbox/issues/1894). Thanks @coygeek.

--- a/docs/features/network.md
+++ b/docs/features/network.md
@@ -188,8 +188,11 @@ Automatic fallback behavior:
   followed by each fallback port;
 - it tries the primary first, then each fallback in order;
 - the first port that connects wins for that operation;
-- the probe is repeated per operation, so a later command re-evaluates the
-  candidates from scratch.
+- a successful readiness or transport probe prepares that host and port for
+  the current operation, so its subsequent SSH requests avoid another login
+  probe; each request still authenticates and enforces workspace ownership;
+- a fresh command or a changed host or port evaluates the advertised candidates
+  again, including when switching between public and tailnet addresses.
 
 Set `ssh.fallbackPorts: []` or `CRABBOX_SSH_FALLBACK_PORTS=none` to disable
 fallback entirely. Some networks prefer this so a misconfigured `2222` rule

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -36,6 +36,7 @@ type SSHTarget struct {
 	HostKeyAlias           string
 	Port                   string
 	FallbackPorts          []string
+	preparedEndpoint       string
 	TargetOS               string
 	WindowsMode            string
 	ReadyCheck             string
@@ -350,8 +351,8 @@ func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, p
 				if err == nil {
 					if target.Port != probe.Port {
 						fmt.Fprintf(stderr, "using ssh port %s for %s (configured %s not ready)\n", probe.Port, target.Host, target.Port)
-						target.Port = probe.Port
 					}
+					target.recordPreparedEndpoint(probe.Port)
 					return nil
 				}
 				if setupErr := sshReadinessError(err, phase); setupErr != nil {
@@ -439,7 +440,7 @@ func probeSSHReady(ctx context.Context, target *SSHTarget, timeout time.Duration
 		}
 		_ = conn.Close()
 		if runSSHQuietWithOptions(ctx, probe, sshReadyCommand(probe), profile.connectTimeout, profile.connectionAttempts) == nil {
-			target.Port = probe.Port
+			target.recordPreparedEndpoint(probe.Port)
 			return true
 		}
 	}
@@ -458,7 +459,7 @@ func probeProxySSHReady(ctx context.Context, target *SSHTarget, profile sshReadi
 			}
 			continue
 		}
-		target.Port, target.FallbackPorts = port, []string{}
+		target.recordPreparedEndpoint(port)
 		return nil
 	}
 	return lastErr
@@ -508,7 +509,7 @@ func probeWSL2SSHReady(ctx context.Context, target *SSHTarget, profile sshReadin
 			}
 		}
 		if err := run(sshReadyCommand(probe)); err == nil {
-			target.Port, target.FallbackPorts = port, []string{}
+			target.recordPreparedEndpoint(port)
 			return nil
 		} else {
 			var setupErr *workspaceOwnerSetupError
@@ -552,7 +553,7 @@ func probeSSHTransport(ctx context.Context, target *SSHTarget, timeout time.Dura
 		}
 		_ = conn.Close()
 		if runSSHQuietWithOptions(ctx, probe, sshTransportProbeCommand(probe), "2", "1") == nil {
-			target.Port = probe.Port
+			target.recordPreparedEndpoint(probe.Port)
 			return true
 		}
 	}
@@ -608,14 +609,32 @@ func uniqueSSHPorts(ports []string) []string {
 	return out
 }
 
+// A prepared endpoint avoids rediscovery within one operation. Keep every
+// advertised candidate: network selection can retarget the same lease to a
+// different host whose reachable SSH port differs.
+func (target *SSHTarget) recordPreparedEndpoint(port string) {
+	if target.Port != port {
+		target.FallbackPorts = sshPortCandidates(target.Port, target.FallbackPorts)
+	}
+	target.Port = port
+	target.preparedEndpoint = net.JoinHostPort(target.Host, port)
+}
+
 // Port probes may retry before delivery; a delivered command must never replay.
+func resolvedSSHPortCandidates(target SSHTarget) []string {
+	if target.preparedEndpoint != "" && target.preparedEndpoint == net.JoinHostPort(target.Host, target.Port) {
+		return []string{target.Port}
+	}
+	return sshPortCandidates(target.Port, target.FallbackPorts)
+}
+
 func resolveSSHPortNoInput(ctx context.Context, target *SSHTarget, connectTimeout, connectionAttempts string, stderr io.Writer) error {
-	ports := sshPortCandidates(target.Port, target.FallbackPorts)
+	ports := resolvedSSHPortCandidates(*target)
 	if len(ports) == 0 {
 		ports = []string{"22"}
 	}
 	if len(ports) == 1 {
-		target.Port, target.FallbackPorts = ports[0], []string{}
+		target.Port = ports[0]
 		return nil
 	}
 	probe := *target
@@ -627,7 +646,7 @@ func resolveSSHPortNoInput(ctx context.Context, target *SSHTarget, connectTimeou
 		var diagnostic synchronizedBuffer
 		_, err = command.runOnce(ctx, probe, connectTimeout, connectionAttempts, io.Discard, &diagnostic, false)
 		if err == nil {
-			target.Port, target.FallbackPorts = port, []string{}
+			target.recordPreparedEndpoint(port)
 			return nil
 		}
 		if !shouldRetrySSHPort(err) || index == len(ports)-1 {

--- a/internal/cli/ssh_prepared_endpoint_test.go
+++ b/internal/cli/ssh_prepared_endpoint_test.go
@@ -1,0 +1,162 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func preparedEndpointFixture(t *testing.T) (SSHTarget, string, string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX SSH process fixture")
+	}
+	dir := t.TempDir()
+	calls := filepath.Join(dir, "calls")
+	ports := make([]string, 2)
+	for i := range ports {
+		listener, err := net.Listen("tcp4", "0.0.0.0:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { listener.Close() })
+		_, ports[i], _ = net.SplitHostPort(listener.Addr().String())
+	}
+	script := `#!/bin/sh
+port="";host="";remote=""
+while [ "$#" -gt 0 ]; do
+ case "$1" in -p) shift;port="$1";; *@*) host="$1";; esac
+ remote="$1";shift
+done
+printf '%s:%s:%s\n' "$host" "$port" "$remote" >> "$CRABBOX_ENDPOINT_CALLS"
+case "$host" in
+ *@localhost) [ "$port" = "$CRABBOX_ENDPOINT_FALLBACK" ] || exit 255;;
+ *@127.0.0.1) [ -z "$CRABBOX_ENDPOINT_PUBLIC" ] || [ "$port" = "$CRABBOX_ENDPOINT_PUBLIC" ] || exit 255;;
+esac
+[ "$remote" != fail-workload ] || exit 255
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_ENDPOINT_CALLS", calls)
+	t.Setenv("CRABBOX_ENDPOINT_FALLBACK", ports[1])
+	t.Setenv("CRABBOX_ENDPOINT_PUBLIC", "")
+	return SSHTarget{User: "runner", Host: "127.0.0.1", Port: ports[0], FallbackPorts: []string{ports[1]}, ReadyCheck: "fixture-ready"}, calls, ports[1]
+}
+
+func TestSSHPreparedEndpointAvoidsRepeatedTransportProbes(t *testing.T) {
+	for _, producer := range []string{"wait", "ready probe", "transport probe"} {
+		t.Run(producer, func(t *testing.T) {
+			target, calls, _ := preparedEndpointFixture(t)
+			var ready bool
+			switch producer {
+			case "wait":
+				ready = waitForSSHReady(t.Context(), &target, io.Discard, "test", time.Second) == nil
+			case "ready probe":
+				ready = probeSSHReady(t.Context(), &target, time.Second)
+			case "transport probe":
+				ready = probeSSHTransport(t.Context(), &target, time.Second)
+			}
+			if !ready {
+				t.Fatal("fixture readiness failed")
+			}
+			for _, command := range []string{"workload-one", "workload-two"} {
+				if _, err := runSSHOutput(t.Context(), target, command); err != nil {
+					t.Fatal(err)
+				}
+			}
+			data, err := os.ReadFile(calls)
+			if err != nil {
+				t.Fatal(err)
+			}
+			lines := splitNonEmptyLines(string(data))
+			if len(lines) != 3 {
+				t.Fatalf("ready plus two commands used %d SSH requests, want3: %s", len(lines), data)
+			}
+		})
+	}
+}
+
+func TestSSHPreparedEndpointRetargetPreservesAdvertisedFallback(t *testing.T) {
+	for _, swap := range []bool{false, true} {
+		t.Run(fmt.Sprint("initial fallback=", swap), func(t *testing.T) {
+			target, calls, fallback := preparedEndpointFixture(t)
+			primary := target.Port
+			publicPort, tailnetPort := primary, fallback
+			expected := fmt.Sprintf("runner@127.0.0.1:%s:fixture-ready\n", primary)
+			if swap {
+				publicPort, tailnetPort = fallback, primary
+				t.Setenv("CRABBOX_ENDPOINT_PUBLIC", fallback)
+				t.Setenv("CRABBOX_ENDPOINT_FALLBACK", primary)
+				expected = fmt.Sprintf("runner@127.0.0.1:%s:fixture-ready\nrunner@127.0.0.1:%s:exit 0\nrunner@127.0.0.1:%s:fixture-ready\n", primary, primary, fallback)
+			}
+			if err := waitForSSHReady(t.Context(), &target, io.Discard, "test", time.Second); err != nil {
+				t.Fatal(err)
+			}
+			server := Server{Labels: map[string]string{"tailscale": "true", "tailscale_fqdn": "localhost"}}
+			resolved, err := resolveNetworkTarget(t.Context(), Config{Network: NetworkTailscale}, server, target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resolved.Target.Host != "localhost" || resolved.Target.Port != tailnetPort {
+				t.Fatalf("retarget lost advertised candidate: %+v", resolved.Target)
+			}
+			if _, err := runSSHOutput(t.Context(), resolved.Target, "tailnet-workload"); err != nil {
+				t.Fatal(err)
+			}
+			expected += fmt.Sprintf("runner@localhost:%s:exit 0\nrunner@localhost:%s:exit 0\nrunner@localhost:%s:tailnet-workload\n", publicPort, tailnetPort, tailnetPort)
+			data, _ := os.ReadFile(calls)
+			if string(data) != expected {
+				t.Fatalf("retarget request sequence=%s, want %s", data, expected)
+			}
+		})
+	}
+}
+
+func TestSSHPreparedEndpointDoesNotReuseChangedPortOrFreshDescriptor(t *testing.T) {
+	for _, change := range []string{"port", "fresh descriptor"} {
+		t.Run(change, func(t *testing.T) {
+			target, calls, fallback := preparedEndpointFixture(t)
+			if err := waitForSSHReady(t.Context(), &target, io.Discard, "test", time.Second); err != nil {
+				t.Fatal(err)
+			}
+			switch change {
+			case "port":
+				target.FallbackPorts = []string{target.Port}
+				target.Port = fallback
+			case "fresh descriptor":
+				target = SSHTarget{User: target.User, Host: target.Host, Port: target.Port, FallbackPorts: target.FallbackPorts}
+			}
+			if _, err := runSSHOutput(t.Context(), target, "workload"); err != nil {
+				t.Fatal(err)
+			}
+			data, _ := os.ReadFile(calls)
+			if len(splitNonEmptyLines(string(data))) != 3 {
+				t.Fatalf("changed endpoint did not resolve transport anew: %s", data)
+			}
+		})
+	}
+}
+
+func TestSSHPreparedEndpointDoesNotReplayWorkloadFailure(t *testing.T) {
+	target, calls, _ := preparedEndpointFixture(t)
+	if err := waitForSSHReady(t.Context(), &target, io.Discard, "test", time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runSSHOutput(context.Background(), target, "fail-workload"); exitCode(err) != 255 {
+		t.Fatalf("workload exit=%v, want255", err)
+	}
+	data, _ := os.ReadFile(calls)
+	if strings.Count(string(data), ":fail-workload\n") != 1 {
+		t.Fatalf("uncertain workload was replayed: %s", data)
+	}
+}

--- a/internal/cli/ssh_prepared_endpoint_test.go
+++ b/internal/cli/ssh_prepared_endpoint_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -37,7 +38,7 @@ while [ "$#" -gt 0 ]; do
 done
 printf '%s:%s:%s\n' "$host" "$port" "$remote" >> "$CRABBOX_ENDPOINT_CALLS"
 case "$host" in
- *@localhost) [ "$port" = "$CRABBOX_ENDPOINT_FALLBACK" ] || exit 255;;
+ *@::ffff:127.0.0.1) [ "$port" = "$CRABBOX_ENDPOINT_FALLBACK" ] || exit 255;;
  *@127.0.0.1) [ -z "$CRABBOX_ENDPOINT_PUBLIC" ] || [ "$port" = "$CRABBOX_ENDPOINT_PUBLIC" ] || exit 255;;
 esac
 [ "$remote" != fail-workload ] || exit 255
@@ -53,35 +54,39 @@ exit 0
 	return SSHTarget{User: "runner", Host: "127.0.0.1", Port: ports[0], FallbackPorts: []string{ports[1]}, ReadyCheck: "fixture-ready"}, calls, ports[1]
 }
 
+// These tests count requests, not subprocess startup time. Virtual time keeps
+// host scheduling from consuming the unrelated readiness deadline.
 func TestSSHPreparedEndpointAvoidsRepeatedTransportProbes(t *testing.T) {
 	for _, producer := range []string{"wait", "ready probe", "transport probe"} {
 		t.Run(producer, func(t *testing.T) {
-			target, calls, _ := preparedEndpointFixture(t)
-			var ready bool
-			switch producer {
-			case "wait":
-				ready = waitForSSHReady(t.Context(), &target, io.Discard, "test", time.Second) == nil
-			case "ready probe":
-				ready = probeSSHReady(t.Context(), &target, time.Second)
-			case "transport probe":
-				ready = probeSSHTransport(t.Context(), &target, time.Second)
-			}
-			if !ready {
-				t.Fatal("fixture readiness failed")
-			}
-			for _, command := range []string{"workload-one", "workload-two"} {
-				if _, err := runSSHOutput(t.Context(), target, command); err != nil {
+			synctest.Test(t, func(t *testing.T) {
+				target, calls, _ := preparedEndpointFixture(t)
+				var ready bool
+				switch producer {
+				case "wait":
+					ready = waitForSSHReady(t.Context(), &target, io.Discard, "test", time.Second) == nil
+				case "ready probe":
+					ready = probeSSHReady(t.Context(), &target, time.Second)
+				case "transport probe":
+					ready = probeSSHTransport(t.Context(), &target, time.Second)
+				}
+				if !ready {
+					t.Fatal("fixture readiness failed")
+				}
+				for _, command := range []string{"workload-one", "workload-two"} {
+					if _, err := runSSHOutput(t.Context(), target, command); err != nil {
+						t.Fatal(err)
+					}
+				}
+				data, err := os.ReadFile(calls)
+				if err != nil {
 					t.Fatal(err)
 				}
-			}
-			data, err := os.ReadFile(calls)
-			if err != nil {
-				t.Fatal(err)
-			}
-			lines := splitNonEmptyLines(string(data))
-			if len(lines) != 3 {
-				t.Fatalf("ready plus two commands used %d SSH requests, want3: %s", len(lines), data)
-			}
+				lines := splitNonEmptyLines(string(data))
+				if len(lines) != 3 {
+					t.Fatalf("ready plus two commands used %d SSH requests, want3: %s", len(lines), data)
+				}
+			})
 		})
 	}
 }
@@ -89,35 +94,37 @@ func TestSSHPreparedEndpointAvoidsRepeatedTransportProbes(t *testing.T) {
 func TestSSHPreparedEndpointRetargetPreservesAdvertisedFallback(t *testing.T) {
 	for _, swap := range []bool{false, true} {
 		t.Run(fmt.Sprint("initial fallback=", swap), func(t *testing.T) {
-			target, calls, fallback := preparedEndpointFixture(t)
-			primary := target.Port
-			publicPort, tailnetPort := primary, fallback
-			expected := fmt.Sprintf("runner@127.0.0.1:%s:fixture-ready\n", primary)
-			if swap {
-				publicPort, tailnetPort = fallback, primary
-				t.Setenv("CRABBOX_ENDPOINT_PUBLIC", fallback)
-				t.Setenv("CRABBOX_ENDPOINT_FALLBACK", primary)
-				expected = fmt.Sprintf("runner@127.0.0.1:%s:fixture-ready\nrunner@127.0.0.1:%s:exit 0\nrunner@127.0.0.1:%s:fixture-ready\n", primary, primary, fallback)
-			}
-			if err := waitForSSHReady(t.Context(), &target, io.Discard, "test", time.Second); err != nil {
-				t.Fatal(err)
-			}
-			server := Server{Labels: map[string]string{"tailscale": "true", "tailscale_fqdn": "localhost"}}
-			resolved, err := resolveNetworkTarget(t.Context(), Config{Network: NetworkTailscale}, server, target)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if resolved.Target.Host != "localhost" || resolved.Target.Port != tailnetPort {
-				t.Fatalf("retarget lost advertised candidate: %+v", resolved.Target)
-			}
-			if _, err := runSSHOutput(t.Context(), resolved.Target, "tailnet-workload"); err != nil {
-				t.Fatal(err)
-			}
-			expected += fmt.Sprintf("runner@localhost:%s:exit 0\nrunner@localhost:%s:exit 0\nrunner@localhost:%s:tailnet-workload\n", publicPort, tailnetPort, tailnetPort)
-			data, _ := os.ReadFile(calls)
-			if string(data) != expected {
-				t.Fatalf("retarget request sequence=%s, want %s", data, expected)
-			}
+			synctest.Test(t, func(t *testing.T) {
+				target, calls, fallback := preparedEndpointFixture(t)
+				primary := target.Port
+				publicPort, tailnetPort := primary, fallback
+				expected := fmt.Sprintf("runner@127.0.0.1:%s:fixture-ready\n", primary)
+				if swap {
+					publicPort, tailnetPort = fallback, primary
+					t.Setenv("CRABBOX_ENDPOINT_PUBLIC", fallback)
+					t.Setenv("CRABBOX_ENDPOINT_FALLBACK", primary)
+					expected = fmt.Sprintf("runner@127.0.0.1:%s:fixture-ready\nrunner@127.0.0.1:%s:exit 0\nrunner@127.0.0.1:%s:fixture-ready\n", primary, primary, fallback)
+				}
+				if err := waitForSSHReady(t.Context(), &target, io.Discard, "test", time.Second); err != nil {
+					t.Fatal(err)
+				}
+				server := Server{Labels: map[string]string{"tailscale": "true", "tailscale_fqdn": "::ffff:127.0.0.1"}}
+				resolved, err := resolveNetworkTarget(t.Context(), Config{Network: NetworkTailscale}, server, target)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if resolved.Target.Host != "::ffff:127.0.0.1" || resolved.Target.Port != tailnetPort {
+					t.Fatalf("retarget lost advertised candidate: %+v", resolved.Target)
+				}
+				if _, err := runSSHOutput(t.Context(), resolved.Target, "tailnet-workload"); err != nil {
+					t.Fatal(err)
+				}
+				expected += fmt.Sprintf("runner@::ffff:127.0.0.1:%s:exit 0\nrunner@::ffff:127.0.0.1:%s:exit 0\nrunner@::ffff:127.0.0.1:%s:tailnet-workload\n", publicPort, tailnetPort, tailnetPort)
+				data, _ := os.ReadFile(calls)
+				if string(data) != expected {
+					t.Fatalf("retarget request sequence=%s, want %s", data, expected)
+				}
+			})
 		})
 	}
 }
@@ -125,38 +132,42 @@ func TestSSHPreparedEndpointRetargetPreservesAdvertisedFallback(t *testing.T) {
 func TestSSHPreparedEndpointDoesNotReuseChangedPortOrFreshDescriptor(t *testing.T) {
 	for _, change := range []string{"port", "fresh descriptor"} {
 		t.Run(change, func(t *testing.T) {
-			target, calls, fallback := preparedEndpointFixture(t)
-			if err := waitForSSHReady(t.Context(), &target, io.Discard, "test", time.Second); err != nil {
-				t.Fatal(err)
-			}
-			switch change {
-			case "port":
-				target.FallbackPorts = []string{target.Port}
-				target.Port = fallback
-			case "fresh descriptor":
-				target = SSHTarget{User: target.User, Host: target.Host, Port: target.Port, FallbackPorts: target.FallbackPorts}
-			}
-			if _, err := runSSHOutput(t.Context(), target, "workload"); err != nil {
-				t.Fatal(err)
-			}
-			data, _ := os.ReadFile(calls)
-			if len(splitNonEmptyLines(string(data))) != 3 {
-				t.Fatalf("changed endpoint did not resolve transport anew: %s", data)
-			}
+			synctest.Test(t, func(t *testing.T) {
+				target, calls, fallback := preparedEndpointFixture(t)
+				if err := waitForSSHReady(t.Context(), &target, io.Discard, "test", time.Second); err != nil {
+					t.Fatal(err)
+				}
+				switch change {
+				case "port":
+					target.FallbackPorts = []string{target.Port}
+					target.Port = fallback
+				case "fresh descriptor":
+					target = SSHTarget{User: target.User, Host: target.Host, Port: target.Port, FallbackPorts: target.FallbackPorts}
+				}
+				if _, err := runSSHOutput(t.Context(), target, "workload"); err != nil {
+					t.Fatal(err)
+				}
+				data, _ := os.ReadFile(calls)
+				if len(splitNonEmptyLines(string(data))) != 3 {
+					t.Fatalf("changed endpoint did not resolve transport anew: %s", data)
+				}
+			})
 		})
 	}
 }
 
 func TestSSHPreparedEndpointDoesNotReplayWorkloadFailure(t *testing.T) {
-	target, calls, _ := preparedEndpointFixture(t)
-	if err := waitForSSHReady(t.Context(), &target, io.Discard, "test", time.Second); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := runSSHOutput(context.Background(), target, "fail-workload"); exitCode(err) != 255 {
-		t.Fatalf("workload exit=%v, want255", err)
-	}
-	data, _ := os.ReadFile(calls)
-	if strings.Count(string(data), ":fail-workload\n") != 1 {
-		t.Fatalf("uncertain workload was replayed: %s", data)
-	}
+	synctest.Test(t, func(t *testing.T) {
+		target, calls, _ := preparedEndpointFixture(t)
+		if err := waitForSSHReady(t.Context(), &target, io.Discard, "test", time.Second); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := runSSHOutput(context.Background(), target, "fail-workload"); exitCode(err) != 255 {
+			t.Fatalf("workload exit=%v, want255", err)
+		}
+		data, _ := os.ReadFile(calls)
+		if strings.Count(string(data), ":fail-workload\n") != 1 {
+			t.Fatalf("uncertain workload was replayed: %s", data)
+		}
+	})
 }

--- a/internal/cli/ssh_readiness_owner_test.go
+++ b/internal/cli/ssh_readiness_owner_test.go
@@ -130,8 +130,15 @@ esac
 	if got, want := string(calls), "2222:-n:exit 0\n22:-n:exit 0\n"; got != want {
 		t.Fatalf("SSH calls=%q, want %q", got, want)
 	}
-	if target.Port != "22" || len(target.FallbackPorts) != 0 {
-		t.Fatalf("target.Port=%q FallbackPorts=%v, want pinned port 22 with no fallbacks", target.Port, target.FallbackPorts)
+	if target.Port != "22" {
+		t.Fatalf("target.Port=%q FallbackPorts=%v, want resolved port 22", target.Port, target.FallbackPorts)
+	}
+	if err := resolveSSHPortNoInput(t.Context(), &target, "5", "1", io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(callsPath)
+	if err != nil || string(after) != string(calls) {
+		t.Fatalf("prepared target was probed again: %s error=%v", after, err)
 	}
 }
 

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -1882,7 +1882,7 @@ exit 0
 	if err := runSSHQuietWithOptionsResolvePort(t.Context(), &target, "true", "1", "1"); err != nil {
 		t.Fatal(err)
 	}
-	if target.Port != "2222" || len(target.FallbackPorts) != 0 {
+	if target.Port != "2222" {
 		t.Fatalf("successful readiness target=%#v, want pinned port 2222", target)
 	}
 	calls, err := os.ReadFile(callsPath)
@@ -1933,12 +1933,19 @@ exit 0
 				User: "crabbox", Host: "proxy.example", Port: "2222", FallbackPorts: []string{"22"},
 				SSHConfigProxy: true, ReadyCheck: "true",
 			}
-			if !test.run(t.Context(), &target) || target.Port != "22" || len(target.FallbackPorts) != 0 {
+			if !test.run(t.Context(), &target) || target.Port != "22" {
 				t.Fatalf("readiness did not pin the fully ready fallback: %+v", target)
 			}
 			calls, err := os.ReadFile(callsPath)
 			if got, want := string(calls), "2222:true\n22:true\n"; err != nil || got != want {
 				t.Fatalf("readiness calls=%q error=%v want=%q", got, err, want)
+			}
+			if err := resolveSSHPortNoInput(t.Context(), &target, "5", "1", io.Discard); err != nil {
+				t.Fatal(err)
+			}
+			after, err := os.ReadFile(callsPath)
+			if err != nil || string(after) != string(calls) {
+				t.Fatalf("proxy readiness route was rediscovered: %s error=%v", after, err)
 			}
 		})
 	}
@@ -2102,7 +2109,7 @@ func TestWSL2ReadinessUsesDirectNoInputWrapperAndPinsFullFallback(t *testing.T) 
 	if err := probeWSL2SSHReady(t.Context(), &target, sshReadinessProfileForTarget(target), io.Discard); err != nil {
 		t.Fatal(err)
 	}
-	if target.Port != "22" || len(target.FallbackPorts) != 0 {
+	if target.Port != "22" {
 		t.Fatalf("target=%+v, want fully-ready fallback pinned", target)
 	}
 	calls, err := os.ReadFile(logPath)
@@ -2111,6 +2118,13 @@ func TestWSL2ReadinessUsesDirectNoInputWrapperAndPinsFullFallback(t *testing.T) 
 	}
 	if got, want := string(calls), "ssh:2222:shell\nsftp:2222\nssh:22:shell\nsftp:22\nssh:22:ready\n"; got != want {
 		t.Fatalf("calls=%q want=%q", got, want)
+	}
+	if err := resolveSSHPortNoInput(t.Context(), &target, "10", "3", io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(logPath)
+	if err != nil || string(after) != string(calls) {
+		t.Fatalf("WSL readiness route was rediscovered: %s error=%v", after, err)
 	}
 }
 

--- a/internal/cli/ssh_wsl_stage.go
+++ b/internal/cli/ssh_wsl_stage.go
@@ -88,7 +88,7 @@ type wslStageBudgets struct {
 // A route owns preparation, size-scaled upload, process exit and exact
 // cleanup. No candidate may borrow the next candidate's complete allocation.
 func wslStageRouteBudgets(target SSHTarget, timing wslStageTiming, size int64) wslStageBudgets {
-	ports := sshPortCandidates(target.Port, target.FallbackPorts)
+	ports := resolvedSSHPortCandidates(target)
 	if len(ports) == 0 {
 		ports = []string{"22"}
 	}
@@ -149,7 +149,7 @@ func sshTransportCallBudget(target SSHTarget, size int64, limit sshCommandLimit)
 		return 0
 	}
 	if !isWindowsWSL2Target(target) {
-		routes := len(sshPortCandidates(target.Port, target.FallbackPorts))
+		routes := len(resolvedSSHPortCandidates(target))
 		attempts := 1
 		if routes > 1 {
 			attempts += routes
@@ -508,7 +508,8 @@ func (s *wslStageSpool) stage(ctx context.Context, target *SSHTarget, timing wsl
 		cleanupPhase.cancel()
 		cancelCandidate()
 		if err == nil {
-			target.Port, target.FallbackPorts, target.NoControlMaster = port, []string{}, true
+			target.recordPreparedEndpoint(port)
+			target.NoControlMaster = true
 			return nonce, nil
 		}
 		if cause := context.Cause(stageCtx); cause != nil {

--- a/internal/cli/ssh_wsl_stage_test.go
+++ b/internal/cli/ssh_wsl_stage_test.go
@@ -1042,7 +1042,7 @@ func TestWSLStagePinsOnlySuccessfulRetryableFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 	if strings.Join(ports, ",") != "2222,22" || len(nonces) != 2 || nonces[0] == nonces[1] ||
-		target.Port != "22" || len(target.FallbackPorts) != 0 || !target.NoControlMaster {
+		target.Port != "22" || !target.NoControlMaster {
 		t.Fatalf("ports=%v nonces=%v target=%+v", ports, nonces, target)
 	}
 
@@ -1118,8 +1118,25 @@ func TestWSLStagePreparesExactRouteBeforeEachUpload(t *testing.T) {
 			if _, err := spool.stage(t.Context(), &target, wslStageTiming{stage: time.Second, idle: time.Second}, "10", "3", io.Discard); err != nil {
 				t.Fatal(err)
 			}
-			if got := strings.Join(events, ","); got != test.want || len(target.FallbackPorts) != 0 {
+			if got := strings.Join(events, ","); got != test.want {
 				t.Fatalf("probe/ACL/upload route ordering=%q final target=%+v", got, target)
+			}
+			for _, retarget := range []bool{false, true} {
+				events = nil
+				probeDeadline = time.Time{}
+				if retarget {
+					target.Host = "retarget.example"
+				}
+				if _, err := spool.stage(t.Context(), &target, wslStageTiming{stage: time.Second, idle: time.Second}, "10", "3", io.Discard); err != nil {
+					t.Fatal(err)
+				}
+				want := "prepare:" + target.Port + ",upload:" + target.Port
+				if retarget && test.name == "distinct fallbacks" {
+					want = "probe:" + target.Port + "," + want
+				}
+				if got := strings.Join(events, ","); got != want {
+					t.Fatalf("retarget=%t route preparation=%s want=%s", retarget, got, want)
+				}
 			}
 		})
 	}
@@ -1188,7 +1205,7 @@ func TestWSLStageUnreachablePrimaryFallsBackWithoutProofCleanup(t *testing.T) {
 		t.Fatalf("healthy fallback blocked: prepared=%v uploaded=%v cleaned=%v error=%v", prepared, uploaded, cleaned, err)
 	}
 	if strings.Join(prepared, ",") != "22" || strings.Join(uploaded, ",") != "22" || strings.Join(cleaned, ",") != "22" ||
-		target.Port != "22" || len(target.FallbackPorts) != 0 || !target.NoControlMaster {
+		target.Port != "22" || !target.NoControlMaster {
 		t.Fatalf("route delivery: prepared=%v uploaded=%v cleaned=%v target=%+v", prepared, uploaded, cleaned, target)
 	}
 	for i, port := range []string{refusedPort, "22", "22"} {


### PR DESCRIPTION
## What Problem This Solves

Remote commands repeatedly probe a port that readiness has already verified. The captured CLI trace contained twelve such probes; ten blocked the main thread for 4.141 seconds. Switching hosts after a fallback also loses the former primary port from the advertised candidates.

## Why This Change Was Made

Carry the prepared host/port fact through the current target lifecycle while preserving every advertised candidate. Direct, proxy and WSL readiness share the same producer; normal and staged delivery use the effective candidate set. A changed host, changed port or fresh descriptor triggers discovery again. Authentication, workspace ownership, staged cleanup and the no-replay rule still apply to actual commands.

## User Impact

A readiness check followed by two commands uses three SSH operations instead of five. Host changes can still reach an advertised port that was unavailable on the previous address. No public configuration, protocol or persistent-store field is added.

## Evidence

- Parent regressions demonstrate redundant probes and loss of the former primary after host retargeting. A rejected clear-the-fallbacks-only change fails the other host-retarget case.
- Direct/proxy/WSL reuse, host/port/fresh-descriptor invalidation, staging/cleanup/control budgets, authentication and no-replay cases pass under the race detector. Full relevant SSH/WSL/owner coverage passed in 295.386 seconds.
- Build and independent P2 review pass.
- Real AWS ABBA comparison passed on one c7a.8xlarge lease with identical payload and configuration. Parent/candidate/candidate/parent wall times were 17.979 / 14.593 / 17.899 / 17.178 seconds; time to workload output was 11.453 / 9.491 / 10.074 / 11.051 seconds. Both candidate runs reached the workload sooner; whole-process completion varies. All four retained nine events, full logs and verified receipts with zero warnings. This sample is not a broad speed guarantee; the process-count regression establishes the removed requests.
- Lease cbx_df0ee5cd9fdf was released with cleanup complete. All processes joined; the actual CLI-owned SSH control directory is absent, and operator configuration and synthetic workdir were unchanged.

Production +20 lines carry the required prepared fact without discarding future fallback candidates. Tests cover observable process counts and routing; docs updated. Related: https://github.com/openclaw/crabbox/pull/1937.

## Review follow-through

ClawSweeper's input scan stopped before producing a review verdict. Maintainer inspection traced both unverified URI findings to the same pre-existing negative fixture in `internal/cli/ssh_test.go`, `TestRemoteGitSeedLocalCanary`: one occurrence in the base and one in the PR. It uses placeholder userinfo on the reserved `example.test` domain and asserts that credential-bearing Git input creates no workdir. This is an intentional test fixture, not a deployed credential. The literal was not added by this PR. No scanner rules were disabled or changed; independent managed P2 review and exact-head CI remain the validation gates.

Integration also exposed a fixture-only race: host scheduling could consume its one-second readiness budget before the request-count assertion. The fixture now uses virtual time and numeric loopback addresses, keeping production deadlines, request counts and routing assertions unchanged. A controlled 1.1-second process pause failed the old fixture and passed the corrected one; readiness cancellation tests and repeated original-order endpoint runs pass.
