### PR TITLE
fix(images): reaper fails after clean qualification teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Report image qualification reaping as idle after clean teardown, while preserving failed recovery evidence and checking transient controller ownership before cleanup. Thanks @vincentkoc.
+- Report image qualification reaping as idle after clean teardown, while preserving failed recovery evidence and checking transient controller ownership before cleanup. [PR 1942](https://github.com/openclaw/crabbox/pull/1942). Thanks @vincentkoc.
 
 ## 0.51.0 - 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Report image qualification reaping as idle after clean teardown, while preserving failed recovery evidence and checking transient controller ownership before cleanup. Thanks @vincentkoc.
+
 ## 0.51.0 - 2026-09-06
 
 ### Highlights

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -762,6 +762,24 @@ deployment hash from the isolated candidate's service-binding settings,
 recreates only the protected controller, and performs the same idempotent
 finalization and zero-residue checks.
 
+After clean teardown, both the controller and candidate are absent. The reaper
+then creates a transient controller solely to ask the authority registry whether
+it is empty. Only an authenticated `{ "run": null }` response establishes idle;
+an active run, malformed response, or failed request remains a failure. The
+probe cannot finalize or retire a run.
+
+The reaper checks controller absence before recovery and never replaces an
+existing controller because authentication or discovery failed. Each idle
+probe or candidate-recovery controller carries a unique ownership tag;
+cleanup rechecks its version, tag, and bindings before deletion and verifies
+absence before reporting idle. Partial
+deployment failures still attempt owned cleanup. Changed or unverifiable
+ownership preserves the Worker and reports failure for operator investigation,
+including both discovery and cleanup errors when applicable. Inspect the
+reaper's `finalization.json` before retrying; do not delete an unfamiliar
+controller to force recovery. A stale candidate hash can be skipped only after
+its owned recovery controller has been deleted and absence verified.
+
 Before enabling the workflow, maintainers must create the protected
 `image-qualification` GitHub environment and configure:
 

--- a/scripts/image-qualification-control.mjs
+++ b/scripts/image-qualification-control.mjs
@@ -575,6 +575,9 @@ class Cloudflare {
     if (!response.ok || parsed.success === false) {
       throw new Error(`Cloudflare API ${pathname} returned ${response.status}`);
     }
+    if (allow404 && (init.method ?? "GET") === "GET" && parsed.result === undefined) {
+      throw new Error(`Cloudflare API ${pathname} did not confirm existence or absence`);
+    }
     return parsed.result;
   }
 
@@ -1387,6 +1390,96 @@ async function qualificationRelays(cf) {
   return relays;
 }
 
+function discoveredRun(value) {
+  const response = objectAt(value, "authority registry discovery");
+  if (Object.keys(response).length !== 1 || !Object.hasOwn(response, "run")) {
+    throw new Error("authority registry discovery is invalid");
+  }
+  if (response.run === null) return null;
+  const run = objectAt(response.run, "authority registry run");
+  if (
+    !runIdPattern.test(run.runId ?? "") ||
+    !workerNamePattern.test(run.candidateWorker ?? "") ||
+    !sha64.test(run.deploymentHash ?? "")
+  ) {
+    throw new Error("authority registry run identity is invalid");
+  }
+  return run;
+}
+
+async function requireControllerAbsent(cf) {
+  const settings = await cf.request(
+    `/workers/scripts/${controllerName}/settings`,
+    {},
+    { allow404: true },
+  );
+  if (settings !== undefined) {
+    throw new Error("qualification controller exists; refusing to replace it");
+  }
+}
+
+async function discoveryControllerVersion(cf, metadata, expectedVersion) {
+  const version = await cf.latestVersion(controllerName);
+  const settings = await cf.settings(controllerName);
+  if (
+    (expectedVersion !== undefined && version !== expectedVersion) ||
+    canonical(settings.tags) !== canonical(metadata.tags) ||
+    canonical(publicBindingShape(settings.bindings ?? [])) !==
+      canonical(publicBindingShape(metadata.bindings)) ||
+    (await cf.latestVersion(controllerName)) !== version
+  ) {
+    throw new Error("discovery controller ownership changed or is unverified");
+  }
+  return version;
+}
+
+async function discoverWithOwnedController(cf, deploymentHash, token, { idleOnly = false } = {}) {
+  const metadata = {
+    ...controllerMetadata(deploymentHash, token),
+    tags: [`qualification-discovery-${crypto.randomUUID()}`],
+  };
+  await requireControllerAbsent(cf);
+  let version;
+  let failure;
+  let controllerURL;
+  let discovered;
+  let retainForFinalization = false;
+  // Arm cleanup before upload: an API response can be lost after deployment.
+  try {
+    await cf.upload(controllerName, controllerSource, metadata);
+    version = await discoveryControllerVersion(cf, metadata);
+    controllerURL = await cf.enableSubdomain(controllerName);
+    await discoveryControllerVersion(cf, metadata, version);
+    discovered = await controllerCall(controllerURL, token, "discover");
+    const run = discoveredRun(discovered);
+    if (idleOnly && run !== null) {
+      throw new Error("idle discovery found an active authority registry run");
+    }
+    retainForFinalization = !idleOnly;
+  } catch (error) {
+    failure = error instanceof Error ? error.message : String(error);
+  } finally {
+    if (!retainForFinalization) {
+      try {
+        const settings = await cf.request(
+          `/workers/scripts/${controllerName}/settings`,
+          {},
+          { allow404: true },
+        );
+        if (settings !== undefined) {
+          await discoveryControllerVersion(cf, metadata, version);
+          await cf.deleteScript(controllerName);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        failure = failure ? `${failure}; probe cleanup: ${message}` : `probe cleanup: ${message}`;
+      }
+    }
+  }
+  if (failure) throw new Error(failure);
+  return { controllerURL, discovered };
+}
+
 async function cleanupRun({
   reaper = false,
   requireProof = false,
@@ -1397,42 +1490,76 @@ async function cleanupRun({
   const token = required("QUALIFICATION_CONTROLLER_TOKEN");
   let controllerURL;
   let discovered;
+  let idleProbe = false;
   try {
-    controllerURL = await cf.enableSubdomain(controllerName);
-    discovered = await controllerCall(controllerURL, token, "discover");
-  } catch {
-    controllerURL = undefined;
-  }
-  if (!controllerURL || !discovered) {
-    if (!reaper) throw new Error("qualification controller is unavailable");
-    const candidates = await qualificationCandidates(cf);
-    for (const candidate of candidates) {
-      if (sha64.test(candidate.deploymentHash)) {
-        const candidateControllerURL = await deployController(cf, candidate.deploymentHash, token);
+    const settings = await cf.request(
+      `/workers/scripts/${controllerName}/settings`,
+      {},
+      { allow404: true },
+    );
+    if (settings !== undefined) {
+      controllerURL = await cf.enableSubdomain(controllerName);
+      discovered = await controllerCall(controllerURL, token, "discover");
+    } else {
+      if (!reaper) throw new Error("qualification controller is unavailable");
+      const candidates = await qualificationCandidates(cf);
+      for (const candidate of candidates) {
         try {
-          discovered = await controllerCall(candidateControllerURL, token, "discover");
-          controllerURL = candidateControllerURL;
+          ({ controllerURL, discovered } = await discoverWithOwnedController(
+            cf,
+            candidate.deploymentHash,
+            token,
+          ));
           break;
-        } catch {
-          // Try the next isolated candidate. Registry validation rejects the wrong hash.
+        } catch (error) {
+          // A failed recovery may have left a controller. Do not overwrite it
+          // with another candidate or an idle probe without confirmed absence.
+          try {
+            await requireControllerAbsent(cf);
+          } catch (ownershipError) {
+            throw new Error(`${error.message}; recovery: ${ownershipError.message}`);
+          }
+          if (candidate === candidates.at(-1)) throw error;
         }
       }
+      if (candidates.length === 0) {
+        // A shape-valid controller can discover only an empty registry. Never
+        // use this domain-separated hash to finalize an active run.
+        ({ discovered } = await discoverWithOwnedController(
+          cf,
+          digest("crabbox/image-qualification/idle-discovery/v1"),
+          token,
+          { idleOnly: true },
+        ));
+        idleProbe = true;
+      }
     }
-    if (!discovered) {
+    discoveredRun(discovered);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      result: "failed",
+      failure: initialQualificationFailure
+        ? `${initialQualificationFailure}; discovery: ${message}`
+        : message,
+    };
+  }
+  if (discovered.run === null) {
+    try {
+      for (const relay of await qualificationRelays(cf)) {
+        await deleteRelay(cf, relay.worker);
+      }
+      for (const candidate of await qualificationCandidates(cf)) {
+        await deleteCandidate(cf, candidate.worker);
+      }
+      if (!idleProbe) await cf.deleteScript(controllerName);
+    } catch (error) {
+      const message = `idle cleanup: ${error instanceof Error ? error.message : String(error)}`;
       return {
         result: "failed",
-        failure: "authority registry could not be queried with any verified candidate binding",
+        failure: initialQualificationFailure ? `${initialQualificationFailure}; ${message}` : message,
       };
     }
-  }
-  if (!discovered.run) {
-    for (const relay of await qualificationRelays(cf)) {
-      await deleteRelay(cf, relay.worker);
-    }
-    for (const candidate of await qualificationCandidates(cf)) {
-      await deleteCandidate(cf, candidate.worker);
-    }
-    await cf.deleteScript(controllerName);
     if (initialQualificationFailure || requireProof) {
       return {
         result: "failed",

--- a/scripts/image-qualification-reaper.test.js
+++ b/scripts/image-qualification-reaper.test.js
@@ -1,0 +1,447 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import crypto from "node:crypto";
+import test from "node:test";
+
+const controller = "crabbox-image-qualification-controller";
+const candidate = "crabbox-image-qualification-42-1";
+const staleCandidate = "crabbox-image-qualification-41-1";
+const authority = "crabbox-aws-qualification-authority";
+const deploymentHash = "b".repeat(64);
+const version = "11111111-1111-4111-8111-111111111111";
+const changedVersion = "22222222-2222-4222-8222-222222222222";
+const token = "synthetic-controller-token-for-tests";
+const control = path.join(import.meta.dirname, "image-qualification-control.mjs");
+
+function bindings(hash) {
+  return [
+    { name: "CONTROLLER_TOKEN", type: "secret_text" },
+    {
+      name: "AUTHORITY",
+      type: "service",
+      service: authority,
+      entrypoint: "AWSQualificationController",
+      props: { deploymentHash: hash },
+    },
+  ];
+}
+
+function initialState(options = {}) {
+  return {
+    options,
+    events: [],
+    candidate: options.candidate ?? false,
+    staleCandidate: options.staleCandidate ?? false,
+    controller: options.controller
+      ? { bindings: bindings(deploymentHash), version, tags: [] }
+      : null,
+    run: options.active
+      ? {
+          runId: "image-qualification-42-1",
+          candidateWorker: candidate,
+          deploymentHash,
+        }
+      : null,
+  };
+}
+
+function installAPI(file) {
+  const state = JSON.parse(fs.readFileSync(file, "utf8"));
+  const { options, events } = state;
+  const json = (value, status = 200) => new Response(JSON.stringify(value), { status });
+  const api = (result, status = 200) => json({ success: status === 200, result }, status);
+  const missing = () => api(null, 404);
+  let controllerReads = 0;
+  let scriptLists = 0;
+  process.on("exit", () => fs.writeFileSync(file, JSON.stringify(state)));
+  globalThis.fetch = async (input, init = {}) => {
+    const url = new URL(input);
+    const method = init.method ?? "GET";
+    const route = url.pathname.replace(/^\/client\/v4\/accounts\/a{32}/, "");
+    events.push(`${method} ${route}`);
+    if (url.hostname === `${controller}.example.workers.dev`) {
+      assert.equal(init.headers.authorization, `Bearer ${token}`);
+      assert.equal(method, "POST");
+      if (options.discoveryStatus) return json({ error: "forbidden" }, options.discoveryStatus);
+      if (Object.hasOwn(options, "discovery")) return json(options.discovery);
+      assert.ok(state.controller);
+      const hash = state.controller.bindings.find((item) => item.name === "AUTHORITY").props
+        .deploymentHash;
+      if (state.run && hash !== state.run.deploymentHash) {
+        return json({ error: "controller_error" }, 409);
+      }
+      if (route === "/discover") {
+        const result = { run: state.run };
+        if (options.changeAfterDiscovery) state.controller.version = changedVersion;
+        if (options.changeBindingsAfterDiscovery)
+          state.controller.bindings = bindings("c".repeat(64));
+        return json(result);
+      }
+      assert.ok(state.run, "no active mutation without a registered run");
+      if (route === "/begin-finalization") return json({ finalizing: true });
+      if (route === "/finalize") return json({ finalized: true });
+      if (route === "/attest") {
+        return json({ finalized: true, finalReceipt: { finalCounts: { instances: 0 } } });
+      }
+      if (route === "/retire") {
+        state.run = null;
+        return json({ retired: true });
+      }
+      throw new Error(`unexpected controller request ${route}`);
+    }
+    assert.equal(url.hostname, "api.cloudflare.com", "no real network access");
+    assert.equal(init.headers.authorization, "Bearer synthetic-cloudflare-token");
+    if (route === "/workers/subdomain") return api({ subdomain: "example" });
+    if (route === "/workers/durable_objects/namespaces") return api([]);
+    if (route === "/workers/scripts") {
+      scriptLists += 1;
+      if (options.idleCleanupFailure && scriptLists > 1) return api(null, 503);
+      return api([
+        ...(state.staleCandidate ? [{ id: staleCandidate }] : []),
+        ...(state.candidate ? [{ id: candidate }] : []),
+      ]);
+    }
+    if (route === `/workers/scripts/${staleCandidate}/settings`) {
+      return api({
+        bindings: [
+          {
+            name: "CRABBOX_AWS_QUALIFICATION_TRANSPORT",
+            type: "service",
+            service: authority,
+            props: { candidateWorker: staleCandidate, deploymentHash: "c".repeat(64) },
+          },
+        ],
+      });
+    }
+    if (route === `/workers/scripts/${candidate}/settings`) {
+      return state.candidate
+        ? api({
+            bindings: [
+              {
+                name: "CRABBOX_AWS_QUALIFICATION_TRANSPORT",
+                type: "service",
+                service: authority,
+                props: { candidateWorker: candidate, deploymentHash },
+              },
+            ],
+          })
+        : missing();
+    }
+    if (route === `/workers/scripts/${candidate}`) {
+      if (method === "PUT") return api({});
+      assert.equal(method, "DELETE");
+      state.candidate = false;
+      return new Response(null, { status: 204 });
+    }
+    if (route === "/workers/scripts/crabbox-image-qualification-relay-42-1/settings") {
+      return missing();
+    }
+    if (route === `/workers/scripts/${controller}/settings`) {
+      if (options.settingsStatus) return api(null, options.settingsStatus);
+      if (options.settingsMalformed) return json({ success: true });
+      controllerReads += 1;
+      if (options.controllerAppears && controllerReads === 2) {
+        state.controller = {
+          bindings: bindings(deploymentHash),
+          version: changedVersion,
+          tags: [],
+        };
+      }
+      return state.controller ? api(state.controller) : missing();
+    }
+    if (route === `/workers/scripts/${controller}/versions`) {
+      if (options.versionStatus) return api(null, options.versionStatus);
+      return api({ items: [{ id: state.controller.version }] });
+    }
+    if (route === `/workers/scripts/${controller}/subdomain`) {
+      if (!state.controller) return missing();
+      if (options.enableFailure && method === "POST") return api(null, 503);
+      if (method === "POST") state.controller.subdomain = JSON.parse(init.body);
+      return api(state.controller.subdomain ?? { enabled: false, previews_enabled: false });
+    }
+    if (route === `/workers/scripts/${controller}`) {
+      if (method === "PUT") {
+        if (options.uploadFailure === "before") throw new Error("upload response lost");
+        const metadata = JSON.parse(await init.body.get("metadata").text());
+        state.controller = {
+          bindings: metadata.bindings.map(({ text, ...binding }) => binding),
+          version,
+          tags: metadata.tags ?? [],
+        };
+        if (options.uploadOwnershipLost) {
+          state.controller.tags = [];
+          state.controller.version = changedVersion;
+          throw new Error("upload response lost");
+        }
+        if (options.uploadFailure === "after") throw new Error("upload response lost");
+        return api({ id: controller });
+      }
+      assert.equal(method, "DELETE");
+      if (options.deleteFailure) return api(null, 503);
+      if (!options.deleteResidue) state.controller = null;
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected Cloudflare request ${method} ${route}`);
+  };
+}
+
+if (process.env.QUALIFICATION_TEST_STATE) {
+  installAPI(process.env.QUALIFICATION_TEST_STATE);
+} else {
+  function fixture(t, options) {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-reaper-test-"));
+    t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+    const stateFile = path.join(directory, "state.json");
+    fs.writeFileSync(stateFile, JSON.stringify(initialState(options)));
+    return (command = "reap") => {
+      const proofDirectory = path.join(directory, "proof");
+      fs.rmSync(proofDirectory, { recursive: true, force: true });
+      const child = spawnSync(process.execPath, ["--import", import.meta.url, control, command], {
+        encoding: "utf8",
+        timeout: 10_000,
+        env: {
+          HOME: directory,
+          RUNNER_TEMP: directory,
+          CLOUDFLARE_ACCOUNT_ID: "a".repeat(32),
+          CLOUDFLARE_API_TOKEN: "synthetic-cloudflare-token",
+          QUALIFICATION_CONTROLLER_TOKEN: token,
+          QUALIFICATION_PROOF_DIR: proofDirectory,
+          QUALIFICATION_TEST_STATE: stateFile,
+        },
+      });
+      assert.equal(child.error, undefined);
+      const state = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+      const proof = path.join(proofDirectory, "finalization.json");
+      return {
+        ...child,
+        state,
+        result: fs.existsSync(proof) ? JSON.parse(fs.readFileSync(proof, "utf8")) : undefined,
+      };
+    };
+  }
+
+  const uploads = (state) =>
+    state.events.filter((event) => event === `PUT /workers/scripts/${controller}`);
+  const deletes = (state) =>
+    state.events.filter((event) => event === `DELETE /workers/scripts/${controller}`);
+  const calls = (state) => state.events.filter((event) => /^POST \/(?!workers)/.test(event));
+
+  test("a second reap is idle after successful finalization removed the controller", (t) => {
+    const reap = fixture(t, { active: true, controller: true, candidate: true });
+    const first = reap();
+    assert.equal(first.status, 0, first.stderr);
+    assert.equal(first.result.result, "finalized");
+    assert.equal(first.state.controller, null);
+    assert.equal(first.state.candidate, false);
+    assert.equal(first.state.run, null);
+    const second = reap();
+    assert.equal(second.status, 0, second.stderr);
+    assert.equal(second.result.result, "idle");
+    assert.equal(second.state.controller, null);
+    assert.deepEqual(calls(second.state).slice(calls(first.state).length), ["POST /discover"]);
+  });
+
+  test("empty registry discovery leaves no temporary controller", (t) => {
+    const result = fixture(t)();
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.result.result, "idle");
+    assert.equal(result.state.controller, null);
+    assert.equal(uploads(result.state).length, 1);
+    assert.equal(deletes(result.state).length, 1);
+    assert.deepEqual(calls(result.state), ["POST /discover"]);
+    assert.ok(
+      result.state.events.indexOf(`GET /workers/scripts/${controller}/settings`) <
+        result.state.events.indexOf(`PUT /workers/scripts/${controller}`),
+    );
+  });
+
+  test("a candidate binding still recovers an active run", (t) => {
+    const result = fixture(t, { active: true, candidate: true })();
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.result.result, "finalized");
+    assert.equal(result.state.run, null);
+    assert.equal(result.state.candidate, false);
+    assert.deepEqual(calls(result.state), [
+      "POST /discover",
+      "POST /begin-finalization",
+      "POST /finalize",
+      "POST /attest",
+      "POST /finalize",
+      "POST /attest",
+      "POST /retire",
+      "POST /discover",
+    ]);
+  });
+
+  test("a stale candidate hash cannot prevent recovery of the active candidate", (t) => {
+    const result = fixture(t, { active: true, candidate: true, staleCandidate: true })();
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.result.result, "finalized");
+    assert.equal(result.state.run, null);
+    assert.equal(result.state.candidate, false);
+    assert.equal(result.state.staleCandidate, true);
+    assert.equal(uploads(result.state).length, 2);
+    assert.equal(deletes(result.state).length, 2);
+    assert.deepEqual(calls(result.state).slice(0, 3), [
+      "POST /discover",
+      "POST /discover",
+      "POST /begin-finalization",
+    ]);
+    const firstDelete = result.state.events.indexOf(`DELETE /workers/scripts/${controller}`);
+    const secondUpload = result.state.events.lastIndexOf(`PUT /workers/scripts/${controller}`);
+    assert.ok(firstDelete < secondUpload);
+    assert.ok(
+      result.state.events
+        .slice(firstDelete, secondUpload)
+        .includes(`GET /workers/scripts/${controller}/settings`),
+    );
+  });
+
+  for (const options of [
+    { active: true },
+    { discoveryStatus: 403 },
+    { discoveryStatus: 503 },
+    { discovery: [] },
+    { discovery: {} },
+    { discovery: null },
+    { discovery: { run: false } },
+    { discovery: { run: null, unexpected: true } },
+    { discovery: { run: { deploymentHash } } },
+    {
+      discovery: {
+        run: {
+          runId: "image-qualification-42-1",
+          candidateWorker: candidate,
+          deploymentHash: crypto
+            .createHash("sha256")
+            .update("crabbox/image-qualification/idle-discovery/v1")
+            .digest("hex"),
+        },
+      },
+    },
+  ]) {
+    test(`idle probe fails closed: ${JSON.stringify(options)}`, (t) => {
+      const result = fixture(t, options)();
+      assert.equal(result.status, 1);
+      assert.equal(result.result.result, "failed");
+      assert.equal(result.state.controller, null);
+      assert.equal(uploads(result.state).length, 1);
+      assert.deepEqual(calls(result.state), ["POST /discover"]);
+      if (options.active) assert.ok(result.state.run);
+    });
+  }
+
+  for (const options of [
+    { controller: true, candidate: true, discoveryStatus: 403 },
+    { controller: true, candidate: true, enableFailure: true },
+    { settingsStatus: 403 },
+    { settingsStatus: 503 },
+    { settingsMalformed: true },
+    { controllerAppears: true },
+    { controller: true, discovery: {} },
+    { controller: true, discovery: { run: false } },
+  ]) {
+    test(`controller uncertainty never authorizes replacement: ${JSON.stringify(options)}`, (t) => {
+      const result = fixture(t, options)();
+      assert.equal(result.status, 1);
+      assert.equal(uploads(result.state).length, 0);
+      assert.equal(deletes(result.state).length, 0);
+    });
+  }
+
+  for (const options of [
+    { uploadFailure: "before" },
+    { uploadFailure: "after" },
+    { enableFailure: true },
+  ]) {
+    test(`partial idle deployment is cleaned but remains failed: ${JSON.stringify(options)}`, (t) => {
+      const result = fixture(t, options)();
+      assert.equal(result.status, 1);
+      assert.equal(result.result.result, "failed");
+      assert.equal(result.state.controller, null);
+      assert.equal(uploads(result.state).length, 1);
+      assert.deepEqual(calls(result.state), []);
+    });
+  }
+
+  for (const options of [
+    { changeAfterDiscovery: true },
+    { changeBindingsAfterDiscovery: true },
+    { versionStatus: 503 },
+    { uploadOwnershipLost: true },
+  ]) {
+    test(`uncertain probe ownership preserves evidence: ${JSON.stringify(options)}`, (t) => {
+      const result = fixture(t, options)();
+      assert.equal(result.status, 1);
+      assert.equal(result.result.result, "failed");
+      assert.ok(result.state.controller);
+      assert.equal(deletes(result.state).length, 0);
+    });
+  }
+
+  test("failed candidate recovery with lost ownership cannot be overwritten", (t) => {
+    const result = fixture(t, {
+      candidate: true,
+      active: true,
+      staleCandidate: true,
+      uploadOwnershipLost: true,
+    })();
+    assert.equal(result.status, 1);
+    assert.equal(result.result.result, "failed");
+    assert.match(result.result.failure, /upload response lost.*ownership.*refusing to replace/);
+    assert.ok(result.state.controller);
+    assert.ok(result.state.run);
+    assert.equal(result.state.candidate, true);
+    assert.equal(uploads(result.state).length, 1);
+    assert.equal(deletes(result.state).length, 0);
+    assert.deepEqual(calls(result.state), []);
+  });
+
+  test("failed owned candidate discovery is cleaned without claiming idle", (t) => {
+    const result = fixture(t, { candidate: true, active: true, discoveryStatus: 403 })();
+    assert.equal(result.status, 1);
+    assert.match(result.result.failure, /discover failed: 403/);
+    assert.equal(result.state.controller, null);
+    assert.ok(result.state.run);
+    assert.equal(result.state.candidate, true);
+    assert.equal(uploads(result.state).length, 1);
+    assert.equal(deletes(result.state).length, 1);
+    assert.deepEqual(calls(result.state), ["POST /discover"]);
+  });
+
+  test("idle cleanup failure retains a finalization evidence artifact", (t) => {
+    const result = fixture(t, { idleCleanupFailure: true })();
+    assert.equal(result.status, 1);
+    assert.equal(result.result.result, "failed");
+    assert.match(result.result.failure, /idle cleanup:.*503/);
+    assert.equal(result.state.controller, null);
+  });
+
+  test("finalize retains both identity and discovery failures", (t) => {
+    const result = fixture(t, { controller: true, discoveryStatus: 403 })("finalize");
+    assert.equal(result.status, 1);
+    assert.equal(result.result.result, "failed");
+    assert.match(result.result.failure, /invalid or missing GITHUB_REPOSITORY/);
+    assert.match(result.result.failure, /discover failed: 403/);
+    assert.equal(uploads(result.state).length, 0);
+    assert.equal(deletes(result.state).length, 0);
+  });
+
+  test("discovery and cleanup failures are both reported", (t) => {
+    const result = fixture(t, { discoveryStatus: 403, deleteFailure: true })();
+    assert.equal(result.status, 1);
+    assert.match(result.result.failure, /discover failed: 403/);
+    assert.match(result.result.failure, /cleanup:.*503/);
+    assert.ok(result.state.controller);
+  });
+
+  test("successful delete response without observable absence is not idle", (t) => {
+    const result = fixture(t, { deleteResidue: true })();
+    assert.equal(result.status, 1);
+    assert.match(result.result.failure, /deletion was not observable/);
+    assert.ok(result.state.controller);
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where image qualification reaping fails after successful teardown removed both the controller and candidate Workers. The durable registry is empty, but the reaper has no candidate binding from which to recreate a controller and confirm that state.

## Why This Change Was Made

After confirmed controller absence, an owned transient controller can discover an empty registry using a domain-separated hash. Only the authenticated `{ "run": null }` response establishes idle. The probe never finalizes or retires a run, and cleanup verifies the controller's version, unique tag, bindings, and subsequent absence.

Candidate-bound recovery uses the same ownership checks, allowing a stale candidate hash to be skipped only after its owned controller is cleaned up. Authentication, malformed responses, uncertain ownership, and cleanup errors remain failures with evidence. Qualification identity failures are preserved alongside discovery failures.

## User Impact

Clean qualification teardown can be reaped repeatedly without a false failure. Recovery does not replace an existing controller merely because a request failed, and operators retain useful failure evidence when cleanup cannot be completed.

No qualification authority, registry, schema, IAM, GitHub environment, or concurrency policy changes. No cloud resources were created or modified for this PR.

## Evidence

- Reproduced successful finalization followed by a failing second reap on the original code; the same lifecycle now reports idle.
- `node --test scripts/image-qualification-reaper.test.js scripts/image-qualification-workflow.test.js`: 54 passing tests.
- Stateful executable CLI coverage includes stale-candidate-first recovery, hidden active state, malformed and unauthorized discovery, partial upload and response loss, enablement failure, changed ownership, bodyless DELETE responses, verified absence, and retained failure evidence.
- `finalize retains both identity and discovery failures` failed before the error-preservation fix and passes afterward.
- `node scripts/check-docs-links.mjs`, `node scripts/build-docs-site.mjs`, `node --check scripts/image-qualification-control.mjs`, test-file formatting, and `git diff --check` passed.
- Three accepted P2 review findings were resolved and the final diff independently inspected.

These are local lifecycle proofs using a stateful fake API, not live Cloudflare or AWS qualification.

<!--
Punchcard-Session: calm-lantern-orchard-dn
-->
