### PR TITLE
fix: handle shell-sensitive checkout paths in Homebrew fixture

### DIFF
--- a/scripts/homebrew-release.test.js
+++ b/scripts/homebrew-release.test.js
@@ -530,7 +530,7 @@ test("run-free public validation and freeze bind the complete immutable asset in
     const bin = path.join(root, "bin");
     fs.mkdirSync(bin);
     writeExecutable(path.join(bin, "git"), `#!/bin/sh
-[ "$*" = "-C ${repoRoot} show ${"b".repeat(40)}:CHANGELOG.md" ] || exit 98
+[ "$*" = ${shellQuote(`-C ${repoRoot} show ${"b".repeat(40)}:CHANGELOG.md`)} ] || exit 98
 printf '## 1.2.3\\n\\nexact notes\\n'
 `);
     writeExecutable(path.join(bin, "curl"), `#!/bin/bash


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where developers running the Homebrew release fixture from a checkout path containing shell syntax get an incorrect Git-argument mismatch, and command substitutions in that path can execute inside the generated test double.

## Why This Change Was Made

Quote the complete expected Git argument string with the fixture's existing `shellQuote` helper. This is a one-line test-only change. The exact comparison, failure status 98, immutable asset inventory assertions, and production release verification remain unchanged.

## User Impact

The fixture preserves literal checkout paths containing spaces, quotes, dollar syntax, and backticks. There is no production behavior, configuration, dependency, release, or alert-disposition change.

## Evidence

- A secretless relocated copy of the trusted fixture and its dependencies reproduced the original defect: harmless command-substitution and backtick `printf` markers appeared, and the existing freeze assertion received actual status 98 instead of 0.
- With only this line changed, all seven loadable path cases executed the actual test and passed, without expansion markers. The actual copied Node executable path contained hostile characters, including a backslash; no symlink-only or mocked runtime-path proof was used.
- A backslash in the source directory was rejected by the local Node 26 ESM loader before the test could execute, both before and after the patch. That source-path case is an unexecuted limitation, not a pass.
- All 21 Homebrew tests passed in the full Scripts attempt with the required Go binary on PATH, including the repaired freeze case and credential-stripping launcher. An earlier isolated run omitted Go; correcting only PATH resolved that setup failure.
- Syntax and whitespace checks passed. Both generated Scripts contract checks passed. Focused independent review found no actionable issue.
- The complete local Scripts attempt (`node --test scripts/*.test.js scripts/*.test.mjs`) finished on macOS/Node 26: 880 tests, 865 passed, 11 failed, 4 skipped, exit 1. No assertion was weakened. The failures were outside Homebrew: five rsync fixture timeouts; two checks blocked by unavailable Go module downloads in the network-denied environment; one Python venv cleanup assertion with temporary certificate files remaining; one Boxd inventory check; and two Unikraft checks reporting an invalid API URL. The last categories are not asserted to be platform-only or fixed by this patch.
- The existing Linux/Node 24 Scripts CI lane must provide the hosted result. Full Go and Worker gates were not duplicated locally; PowerShell/native Windows cases remain skipped locally.

No real Homebrew operation, external fixture network request, release signing, or publishing was performed.

<!-- Punchcard-Session: clear-valley-timber-cp -->
