### PR TITLE
fix(aws): avoid duplicate SSH permission requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Tailscale: keep provider diagnostics and OAuth credentials out of preflight and tag-ownership errors while preserving operation, HTTP status, and actionable tag guidance. [PR 1940](https://github.com/openclaw/crabbox/pull/1940).
 - Publish run diagnostics without delaying workload admission, while preserving ordered lease attribution and joining pending publication before terminal recording. [PR 1937](https://github.com/openclaw/crabbox/pull/1937).
 - Add bounded AWS provisioning logs that separate ingress queue and lifecycle waits from create-operation costs and count redundant security-group permission calls without logging request payloads. [PR 1938](https://github.com/openclaw/crabbox/pull/1938).
-- Deduplicate validated AWS coordinator SSH ranges after combining lease and global access, avoiding repeated authorization calls for identical port/range pairs while preserving ingress reconciliation.
+- Deduplicate validated AWS coordinator SSH ranges after combining lease and global access, avoiding repeated authorization calls for identical port/range pairs while preserving ingress reconciliation. [PR 1945](https://github.com/openclaw/crabbox/pull/1945).
 
 ## 0.51.0 - 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Tailscale: keep provider diagnostics and OAuth credentials out of preflight and tag-ownership errors while preserving operation, HTTP status, and actionable tag guidance. [PR 1940](https://github.com/openclaw/crabbox/pull/1940).
 - Publish run diagnostics without delaying workload admission, while preserving ordered lease attribution and joining pending publication before terminal recording. [PR 1937](https://github.com/openclaw/crabbox/pull/1937).
 - Add bounded AWS provisioning logs that separate ingress queue and lifecycle waits from create-operation costs and count redundant security-group permission calls without logging request payloads. [PR 1938](https://github.com/openclaw/crabbox/pull/1938).
+- Deduplicate validated AWS coordinator SSH ranges after combining lease and global access, avoiding repeated authorization calls for identical port/range pairs while preserving ingress reconciliation.
 
 ## 0.51.0 - 2026-09-06
 

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -187,6 +187,12 @@ Explicit AMIs (including `CRABBOX_AWS_AMI`), promoted images, checkpoint forks,
 ARM64, and Ubuntu 24.04 retain their existing source policy. The private AWS
 workspace service keeps its separate SSM bootstrap and HTTPS-only source policy.
 
+For brokered SSH access, the coordinator validates the combined lease and global
+source ranges, then removes exact duplicates before reconciling each SSH port.
+Whitespace is trimmed; distinct IPv4 and IPv6 ranges keep their order. This does
+not reuse observed permissions: each unique desired range is still authorized,
+and stale-rule pruning and world-access revocation keep their existing policy.
+
 ### Environment variables (direct mode)
 
 ```text

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -2969,7 +2969,7 @@ function awsSSHCIDRs(config: LeaseConfig, env: Env, allowEmpty = false): string[
       "AWS SSH source CIDR is required; set CRABBOX_AWS_SSH_CIDRS or use Cloudflare request IP forwarding",
     );
   }
-  return cidrs;
+  return uniqueStrings(cidrs); // Access snapshots can already contain global CIDRs.
 }
 
 function reservations(root: Record<string, unknown>): Record<string, unknown>[] {

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -118,65 +118,88 @@ describe("aws provider", () => {
     ).toEqual([2, 4]);
   });
 
-  it("reports request step costs and redundant ingress calls without logging payloads", async () => {
-    vi.useFakeTimers({ toFake: ["Date"] });
-    vi.setSystemTime(new Date("2026-05-02T00:00:00Z"));
-    const log = vi.spyOn(console, "info").mockImplementation(() => {});
-    const { client, config } = awsMarketFallbackHarness("");
-    const baseFetch = globalThis.fetch;
-    const actions: string[] = [];
-    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
-      const request = input instanceof Request ? input : new Request(input, init);
-      const action = new URLSearchParams(await request.clone().text()).get("Action") ?? "";
-      if (action) actions.push(action);
-      if (action === "AuthorizeSecurityGroupIngress" || action === "RevokeSecurityGroupIngress") {
-        const authorize = action === "AuthorizeSecurityGroupIngress";
-        vi.setSystemTime(Date.now() + (authorize ? 7 : 3));
-        return ec2XMLResponse(
-          `<Response><Errors><Error><Code>${authorize ? "InvalidPermission.Duplicate" : "InvalidPermission.NotFound"}</Code><Message>private-rule-canary</Message></Error></Errors></Response>`,
-          400,
-        );
-      }
-      return baseFetch(request);
-    });
-    const result = await client.createServerWithFallback(
-      { ...config, sshPort: "22", sshFallbackPorts: ["443"] },
-      "cbx_abcdef123456",
-      "violet-prawn",
-      "alice@example.com",
-      { withIngress: (apply) => apply(["203.0.113.7/32", "2001:db8::1/128"]) },
-    );
-    expect(result.server.id).toBeDefined();
-    expect(actions.filter((action) => action === "AuthorizeSecurityGroupIngress")).toHaveLength(6);
-    expect(actions.filter((action) => action === "RevokeSecurityGroupIngress")).toHaveLength(2);
-    expect(log).toHaveBeenCalledTimes(1);
-    const encoded = String(log.mock.calls[0]![0]);
-    const diagnostic = JSON.parse(encoded);
-    expect(diagnostic).toMatchObject({
-      component: "crabbox_aws_provisioning",
-      leaseId: "cbx_abcdef123456",
-      region: "eu-west-1",
-      outcome: "success",
-    });
-    expect(diagnostic.steps).toEqual(
-      expect.arrayContaining([
-        { name: "authorize_ingress", count: 6, totalMs: 42, errors: 6 },
-        { name: "authorize_duplicate", count: 6, totalMs: 0, errors: 0 },
-        { name: "revoke_world", count: 2, totalMs: 6, errors: 2 },
-        { name: "revoke_world_absent", count: 2, totalMs: 0, errors: 0 },
-      ]),
-    );
-    for (const privateValue of [
-      "private-rule-canary",
-      "alice@example.com",
-      "203.0.113.7",
-      "2001:db8",
-      "ssh-ed25519",
-    ])
-      expect(encoded).not.toContain(privateValue);
-    expect(encoded.length).toBeLessThan(8192);
-    log.mockRestore();
-  });
+  it.each([
+    { cidrs: [" 203.0.113.7/32 ", "2001:db8::1/128"] },
+    { cidrs: ["203.0.113.7/32", "2001:db8::1/128", " 2001:db8::1/128 "] },
+  ])(
+    "reports request step costs and deduplicates desired ingress without logging payloads ($cidrs)",
+    async ({ cidrs }) => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date("2026-05-02T00:00:00Z"));
+      const log = vi.spyOn(console, "info").mockImplementation(() => {});
+      const { client, config } = awsMarketFallbackHarness("");
+      const baseFetch = globalThis.fetch;
+      const actions: string[] = [];
+      const authorized: Array<[string | null, string | null]> = [];
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const params = new URLSearchParams(await request.clone().text());
+        const action = params.get("Action") ?? "";
+        if (action === "AuthorizeSecurityGroupIngress") {
+          authorized.push([
+            params.get("IpPermissions.1.FromPort"),
+            params.get("IpPermissions.1.IpRanges.1.CidrIp") ??
+              params.get("IpPermissions.1.Ipv6Ranges.1.CidrIpv6"),
+          ]);
+        }
+        if (action) actions.push(action);
+        if (action === "AuthorizeSecurityGroupIngress" || action === "RevokeSecurityGroupIngress") {
+          const authorize = action === "AuthorizeSecurityGroupIngress";
+          vi.setSystemTime(Date.now() + (authorize ? 7 : 3));
+          return ec2XMLResponse(
+            `<Response><Errors><Error><Code>${authorize ? "InvalidPermission.Duplicate" : "InvalidPermission.NotFound"}</Code><Message>private-rule-canary</Message></Error></Errors></Response>`,
+            400,
+          );
+        }
+        return baseFetch(request);
+      });
+      const result = await client.createServerWithFallback(
+        { ...config, sshPort: "22", sshFallbackPorts: ["443"] },
+        "cbx_abcdef123456",
+        "violet-prawn",
+        "alice@example.com",
+        { withIngress: (apply) => apply(cidrs) },
+      );
+      expect(result.server.id).toBeDefined();
+      expect(actions.filter((action) => action === "AuthorizeSecurityGroupIngress")).toHaveLength(
+        4,
+      );
+      expect(authorized).toEqual([
+        ["22", "203.0.113.7/32"],
+        ["22", "2001:db8::1/128"],
+        ["443", "203.0.113.7/32"],
+        ["443", "2001:db8::1/128"],
+      ]);
+      expect(actions.filter((action) => action === "RevokeSecurityGroupIngress")).toHaveLength(2);
+      expect(log).toHaveBeenCalledTimes(1);
+      const encoded = String(log.mock.calls[0]![0]);
+      const diagnostic = JSON.parse(encoded);
+      expect(diagnostic).toMatchObject({
+        component: "crabbox_aws_provisioning",
+        leaseId: "cbx_abcdef123456",
+        region: "eu-west-1",
+        outcome: "success",
+      });
+      expect(diagnostic.steps).toEqual(
+        expect.arrayContaining([
+          { name: "authorize_ingress", count: 4, totalMs: 28, errors: 4 },
+          { name: "authorize_duplicate", count: 4, totalMs: 0, errors: 0 },
+          { name: "revoke_world", count: 2, totalMs: 6, errors: 2 },
+          { name: "revoke_world_absent", count: 2, totalMs: 0, errors: 0 },
+        ]),
+      );
+      for (const privateValue of [
+        "private-rule-canary",
+        "alice@example.com",
+        "203.0.113.7",
+        "2001:db8",
+        "ssh-ed25519",
+      ])
+        expect(encoded).not.toContain(privateValue);
+      expect(encoded.length).toBeLessThan(8192);
+      log.mockRestore();
+    },
+  );
 
   it("tags every checkpoint AMI backing snapshot with its exact ownership claim", async () => {
     let submitted: URLSearchParams | undefined;
@@ -739,14 +762,16 @@ describe("aws provider", () => {
     },
   );
 
-  it("rejects invalid configured AWS SSH CIDRs before changing ingress", async () => {
-    const calls: string[] = [];
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-        calls.push(typeof init?.body === "string" ? init.body : String(input));
-        return new Response(
-          `<DescribeSecurityGroupsResponse>
+  it.each(["999.999.999.999/32", "2001:db8::1/129", " 203.0.113.7/32 ,203.0.113.7/32,invalid"])(
+    "rejects invalid configured AWS SSH CIDRs before changing ingress: %s",
+    async (cidrs) => {
+      const calls: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          calls.push(typeof init?.body === "string" ? init.body : String(input));
+          return new Response(
+            `<DescribeSecurityGroupsResponse>
   <securityGroupInfo>
     <item>
       <groupId>sg-123</groupId>
@@ -754,29 +779,30 @@ describe("aws provider", () => {
     </item>
   </securityGroupInfo>
 </DescribeSecurityGroupsResponse>`,
-        );
-      }),
-    );
-    const client = new EC2SpotClient(
-      {
-        AWS_ACCESS_KEY_ID: "test",
-        AWS_SECRET_ACCESS_KEY: "secret",
-        CRABBOX_AWS_SECURITY_GROUP_ID: "sg-123",
-        CRABBOX_AWS_SSH_CIDRS: "999.999.999.999/32",
-      } as never,
-      "us-east-1",
-    );
-
-    await expect(
-      client.refreshSSHIngress(
-        leaseConfig({
-          provider: "aws",
-          sshPublicKey: "ssh-ed25519 test",
+          );
         }),
-      ),
-    ).rejects.toThrow("CRABBOX_AWS_SSH_CIDRS entries must be valid");
-    expect(calls).toHaveLength(1);
-  });
+      );
+      const client = new EC2SpotClient(
+        {
+          AWS_ACCESS_KEY_ID: "test",
+          AWS_SECRET_ACCESS_KEY: "secret",
+          CRABBOX_AWS_SECURITY_GROUP_ID: "sg-123",
+          CRABBOX_AWS_SSH_CIDRS: cidrs,
+        } as never,
+        "us-east-1",
+      );
+
+      await expect(
+        client.refreshSSHIngress(
+          leaseConfig({
+            provider: "aws",
+            sshPublicKey: "ssh-ed25519 test",
+          }),
+        ),
+      ).rejects.toThrow("CRABBOX_AWS_SSH_CIDRS entries must be valid");
+      expect(calls).toHaveLength(1);
+    },
+  );
 
   it("waits through transient EC2 instance visibility after RunInstances", async () => {
     vi.useFakeTimers();


### PR DESCRIPTION
## What Problem This Solves

The AWS coordinator combines lease access with global SSH ranges, but a global range can already appear in the lease snapshot. Appending it again causes repeated authorization requests for the same port/range pair.

## Why This Change Was Made

Deduplicate the complete validated list with the existing helper. Validation and empty-list errors still run first; distinct IPv4/IPv6 ranges retain their order. Each unique desired permission is still authorized. Stale-rule pruning, world-rule revocation and the authoritative access fence are unchanged.

## User Impact

Repeated input ranges no longer cause redundant AWS API calls. No new permission scope, cache, configuration option, schema or protocol change.

## Evidence

The HTTP-boundary regression produced six and eight authorization calls for four unique port/range pairs before the fix. Afterward it produces four and preserves the exact ordered tuples and invalid-input rejection. All 2,840 Worker tests, both typechecks, lint, formatting and both builds passed; independent P2 review is clean. Production delta is one line added and one removed. The rebase retains the reviewed source and tests unchanged.

Live scope: the preceding owned warm run recorded four duplicate-permission responses. That does not establish repeated input ranges or savings from this repair. Candidate `9f0a295567c9982094d69dcefd4c9778f9f4d1f6`, deployed as `34dd9655-6075-459c-8d7f-c34174ad41bb`, served a real cold session and a restored warm session with successful AWS provisioning, checkpoint capture/reuse and canonical lease cleanup. Each allocation recorded four existing-permission responses; the logs do not establish duplicate input cardinality. The cold model turn passed. The warm model turn failed later in native process initialization, independently of AWS ingress. This is live call-composition proof; the HTTP regression proves removal of repeated input calls. No end-to-end latency reduction is claimed from these runs.

This follows https://github.com/openclaw/crabbox/pull/1938. Its measured temporary-image cleanup delay remains a separate investigation; this change neither detaches cleanup nor trusts a stale permission snapshot.

Rank-up disposition: the requested candidate-specific AWS execution is now recorded above. Direct runtime observation of overlapping input cardinalities is not available in the existing bounded diagnostics. I am not changing global access configuration or adding a telemetry surface merely to manufacture overlap. The real AWS run establishes successful composed reconciliation; the existing red/green HTTP-boundary test establishes exact unique-tuple call counts. The optional overlap screenshot/log request is therefore left unclaimed, with this limitation explicit.
