### PR TITLE
test: reuse portable connection-test directory isolation

### DIFF
--- a/internal/cli/coordinator_registration_test.go
+++ b/internal/cli/coordinator_registration_test.go
@@ -284,8 +284,7 @@ func TestResolveSSHLeaseTargetAcceptsMinimalProviderClaim(t *testing.T) {
 }
 
 func TestResolveSSHLeaseTargetFindsExistingClaimByCloudID(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	t.Setenv("HOME", t.TempDir())
+	isolateTestUserDirs(t)
 	cfg := baseConfig()
 	cfg.Provider = "aws"
 	leaseID := "cbx_cloudlookup123"
@@ -573,7 +572,7 @@ func TestResolveSSHLeaseTargetPreservesProviderManagedCredentials(t *testing.T) 
 }
 
 func TestCoordinatorLeaseBackendForwardsResolvedTargetRebinding(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	isolateTestUserDirs(t)
 	leaseID := "cbx_coordinator123"
 	keyPath, err := testboxKeyPath(leaseID)
 	if err != nil {

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -6137,9 +6137,7 @@ func TestServerProviderKeyUsesOnlyCrabboxLeaseKeys(t *testing.T) {
 }
 
 func TestMoveStoredTestboxKeyHandlesCoordinatorRenamedLease(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	isolateTestUserDirs(t)
 	oldPath, err := testboxKeyPath("cbx_111111111111")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

Reuse the existing portable user-directory isolation helper in three connection-artifact tests. The tests previously set overlapping but incomplete subsets of HOME, XDG_STATE_HOME, and XDG_CONFIG_HOME; using the shared helper gives each test its own complete platform-aware directories and removes duplicated setup.

Package-wide isolation already protects real user directories. This is per-test isolation and cross-test-residue cleanup, not a claim of demonstrated user-key exposure. Existing assertions and intentional symlink/invalid-environment tests are unchanged. There is no production behavior change, so no changelog entry is needed.

## Verification

- Go 1.26.5: the three changed tests passed with the race detector (2.096s).
- Relevant Go vet and git diff checks passed.
- Independent Codex review: no accepted P0 findings for the complete two-file change; this is priority-scoped review, not an all-priority correctness certificate.

Focused test command:

```sh
GOTOOLCHAIN=go1.26.5 go test -race ./internal/cli -run '^(TestResolveSSHLeaseTargetFindsExistingClaimByCloudID|TestCoordinatorLeaseBackendForwardsResolvedTargetRebinding|TestMoveStoredTestboxKeyHandlesCoordinatorRenamedLease)$' -count=1
```

No credentials, hosted resources, native provider lifecycle changes, or new test fixtures are involved.
