### PR TITLE
fix(ssh): stop probes when the readiness deadline expires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Stop SSH readiness probes and backoff at the shared deadline, reporting the active probe with authentication unknown instead of mislabeling expired checks as authentication failures. Thanks @vincentkoc.
+- Stop SSH readiness probes and backoff at the shared deadline, reporting the active probe with authentication unknown instead of mislabeling expired checks as authentication failures. [PR 1949](https://github.com/openclaw/crabbox/pull/1949). Thanks @vincentkoc.
 - Reuse verified SSH endpoints within an operation, preserving advertised fallbacks when switching hosts or ports and avoiding redundant login probes across direct, proxy, and WSL execution. [PR 1941](https://github.com/openclaw/crabbox/pull/1941).
 - Report image qualification reaping as idle after clean teardown, while preserving failed recovery evidence and checking transient controller ownership before cleanup. [PR 1942](https://github.com/openclaw/crabbox/pull/1942). Thanks @vincentkoc.
 - Add `crabbox bench check` to enforce sample, failure, and p95 runner timing policy across every matched local benchmark group. [PR 1899](https://github.com/openclaw/crabbox/pull/1899). Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Stop SSH readiness probes and backoff at the shared deadline, reporting the active probe with authentication unknown instead of mislabeling expired checks as authentication failures. Thanks @vincentkoc.
 - Reuse verified SSH endpoints within an operation, preserving advertised fallbacks when switching hosts or ports and avoiding redundant login probes across direct, proxy, and WSL execution. [PR 1941](https://github.com/openclaw/crabbox/pull/1941).
 - Report image qualification reaping as idle after clean teardown, while preserving failed recovery evidence and checking transient controller ownership before cleanup. [PR 1942](https://github.com/openclaw/crabbox/pull/1942). Thanks @vincentkoc.
 - Add `crabbox bench check` to enforce sample, failure, and p95 runner timing policy across every matched local benchmark group. [PR 1899](https://github.com/openclaw/crabbox/pull/1899). Thanks @vincentkoc.

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -295,18 +295,34 @@ func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, p
 	probeCtx, cancel := context.WithDeadline(ctx, deadline)
 	defer cancel()
 	lastPorts := ""
-	for {
-		if ctx.Err() != nil {
-			return context.Cause(ctx)
+	lastProbe := "transport"
+	check := func(probeErr error) error {
+		if stopped := sshReadinessProbeContextError(ctx, lastProbe); stopped != nil {
+			return stopped.cause
 		}
-		if time.Until(deadline) <= 0 {
-			if lastPorts != "" {
-				return exit(5, "timed out waiting for SSH on %s during %s ports=%s; %s", target.Host, phase, lastPorts, sshWaitNextAction(phase))
+		if sshReadinessProbeContextError(probeCtx, lastProbe) != nil {
+			var stopped *sshReadinessProbeStopped
+			if errors.As(probeErr, &stopped) {
+				lastProbe = stopped.probe
 			}
-			return exit(5, "timed out waiting for SSH on %s during %s; %s", target.Host, phase, sshWaitNextAction(phase))
+			ports := ""
+			if lastPorts != "" {
+				ports = " ports=" + lastPorts
+			}
+			return exit(5, "timed out waiting for SSH on %s during %s probe=%s cause=deadline_exceeded authentication=unknown%s; %s", target.Host, phase, lastProbe, ports, sshWaitNextAction(phase))
+		}
+		return nil
+	}
+	for {
+		if err := check(nil); err != nil {
+			return err
 		}
 		if isWindowsWSL2Target(*target) {
+			lastProbe = "transport"
 			err := probeWSL2SSHReady(probeCtx, target, profile, stderr)
+			if stopped := check(err); stopped != nil {
+				return stopped
+			}
 			if err == nil {
 				return nil
 			}
@@ -319,7 +335,11 @@ func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, p
 			lastPorts = "wsl2"
 			fmt.Fprintln(stderr, sshWaitProgressMessage(target, phase, "", "", lastPorts, time.Since(start), time.Until(deadline)))
 		} else if target.SSHConfigProxy {
+			lastProbe = "readiness"
 			err := probeProxySSHReady(probeCtx, target, profile)
+			if stopped := check(err); stopped != nil {
+				return stopped
+			}
 			if err == nil {
 				return nil
 			}
@@ -333,11 +353,19 @@ func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, p
 			transportPort := ""
 			probes := make([]string, 0, len(sshPortCandidates(target.Port, target.FallbackPorts)))
 			for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
+				lastProbe = "transport"
+				if err := check(nil); err != nil {
+					return err
+				}
 				probe := *target
 				probe.Port = port
 				probe.FallbackPorts = []string{}
-				conn, err := net.DialTimeout("tcp", net.JoinHostPort(probe.Host, probe.Port), 5*time.Second)
+				dialer := net.Dialer{Timeout: 5 * time.Second}
+				conn, err := dialer.DialContext(probeCtx, "tcp", net.JoinHostPort(probe.Host, probe.Port))
 				if err != nil {
+					if stopped := check(err); stopped != nil {
+						return stopped
+					}
 					probes = append(probes, port+":closed")
 					continue
 				}
@@ -345,9 +373,16 @@ func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, p
 				if reachablePort == "" {
 					reachablePort = probe.Port
 				}
-				// Successful readiness also proves transport. Diagnose authentication
+				// Successful readiness also proves transport. Diagnose transport
 				// separately only when readiness fails, avoiding a healthy-path SSH call.
+				lastProbe = "readiness"
+				if err := check(nil); err != nil {
+					return err
+				}
 				err = runSSHReadinessProbe(probeCtx, probe, sshReadyCommand(probe), profile.connectTimeout, profile.connectionAttempts)
+				if stopped := check(err); stopped != nil {
+					return stopped
+				}
 				if err == nil {
 					if target.Port != probe.Port {
 						fmt.Fprintf(stderr, "using ssh port %s for %s (configured %s not ready)\n", probe.Port, target.Host, target.Port)
@@ -358,7 +393,14 @@ func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, p
 				if setupErr := sshReadinessError(err, phase); setupErr != nil {
 					return setupErr
 				}
+				lastProbe = "transport"
+				if err := check(nil); err != nil {
+					return err
+				}
 				if err := runSSHReadinessProbe(probeCtx, probe, sshTransportProbeCommand(probe), profile.connectTimeout, profile.connectionAttempts); err != nil {
+					if stopped := check(err); stopped != nil {
+						return stopped
+					}
 					if setupErr := sshReadinessError(err, phase); setupErr != nil {
 						return setupErr
 					}
@@ -373,11 +415,11 @@ func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, p
 			lastPorts = strings.Join(probes, ",")
 			fmt.Fprintln(stderr, sshWaitProgressMessage(target, phase, reachablePort, transportPort, lastPorts, time.Since(start), time.Until(deadline)))
 		}
-		if time.Until(deadline) <= 0 {
-			continue
+		if err := check(nil); err != nil {
+			return err
 		}
-		if err := sleepContext(ctx, 10*time.Second); err != nil {
-			return context.Cause(ctx)
+		if err := sleepContext(probeCtx, 10*time.Second); err != nil {
+			return check(err)
 		}
 	}
 }
@@ -411,7 +453,7 @@ func sshWaitProgressMessage(target *SSHTarget, phase, reachablePort, transportPo
 		return fmt.Sprintf("waiting for %s:%s %s ready-check... elapsed=%s remaining=%s%s", target.Host, transportPort, phase, elapsed, remaining, suffix)
 	}
 	if reachablePort != "" {
-		return fmt.Sprintf("waiting for %s:%s %s ssh-auth... elapsed=%s remaining=%s%s", target.Host, reachablePort, phase, elapsed, remaining, suffix)
+		return fmt.Sprintf("waiting for %s:%s %s ssh-transport... elapsed=%s remaining=%s%s", target.Host, reachablePort, phase, elapsed, remaining, suffix)
 	}
 	return fmt.Sprintf("waiting for %s:%s %s... elapsed=%s remaining=%s%s", target.Host, target.Port, phase, elapsed, remaining, suffix)
 }
@@ -430,6 +472,9 @@ func probeSSHReady(ctx context.Context, target *SSHTarget, timeout time.Duration
 		return probeProxySSHReady(ctx, target, profile) == nil
 	}
 	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
+		if sshReadinessProbeContextError(ctx, "transport") != nil {
+			return false
+		}
 		probe := *target
 		probe.Port = port
 		probe.FallbackPorts = []string{}
@@ -439,6 +484,9 @@ func probeSSHReady(ctx context.Context, target *SSHTarget, timeout time.Duration
 			continue
 		}
 		_ = conn.Close()
+		if sshReadinessProbeContextError(ctx, "readiness") != nil {
+			return false
+		}
 		if runSSHQuietWithOptions(ctx, probe, sshReadyCommand(probe), profile.connectTimeout, profile.connectionAttempts) == nil {
 			target.recordPreparedEndpoint(probe.Port)
 			return true
@@ -448,11 +496,20 @@ func probeSSHReady(ctx context.Context, target *SSHTarget, timeout time.Duration
 }
 
 func probeProxySSHReady(ctx context.Context, target *SSHTarget, profile sshReadinessProfile) error {
+	if stopped := sshReadinessProbeContextError(ctx, "readiness"); stopped != nil {
+		return stopped
+	}
 	var lastErr error
 	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
+		if stopped := sshReadinessProbeContextError(ctx, "readiness"); stopped != nil {
+			return stopped
+		}
 		candidate := *target
 		candidate.Port, candidate.FallbackPorts = port, []string{}
 		if lastErr = runSSHReadinessProbe(ctx, candidate, sshReadyCommand(candidate), profile.connectTimeout, profile.connectionAttempts); lastErr != nil {
+			if stopped := sshReadinessProbeContextError(ctx, "readiness"); stopped != nil {
+				return stopped
+			}
 			var setupErr *workspaceOwnerSetupError
 			if errors.As(lastErr, &setupErr) || errors.Is(lastErr, errSSHHostKeyVerification) {
 				return lastErr
@@ -466,6 +523,9 @@ func probeProxySSHReady(ctx context.Context, target *SSHTarget, profile sshReadi
 }
 
 func probeWSL2SSHReady(ctx context.Context, target *SSHTarget, profile sshReadinessProfile, stderr io.Writer) error {
+	if stopped := sshReadinessProbeContextError(ctx, "transport"); stopped != nil {
+		return stopped
+	}
 	ports := sshPortCandidates(target.Port, target.FallbackPorts)
 	type outcome struct {
 		err         error
@@ -473,6 +533,9 @@ func probeWSL2SSHReady(ctx context.Context, target *SSHTarget, profile sshReadin
 	}
 	outcomes := make([]outcome, 0, len(ports))
 	for _, port := range ports {
+		if stopped := sshReadinessProbeContextError(ctx, "transport"); stopped != nil {
+			return stopped
+		}
 		probe := *target
 		probe.Port, probe.FallbackPorts = port, []string{}
 		run := func(remote string) error {
@@ -482,11 +545,17 @@ func probeWSL2SSHReady(ctx context.Context, target *SSHTarget, profile sshReadin
 			return sshReadinessProbeError(ctx, err, diagnostic.hostKeyRejected())
 		}
 		if err := run(sshTransportProbeCommand(probe)); err != nil {
+			if stopped := sshReadinessProbeContextError(ctx, "transport"); stopped != nil {
+				return stopped
+			}
 			if errors.Is(err, errSSHHostKeyVerification) {
 				return err
 			}
 			outcomes = append(outcomes, outcome{err: err})
 			continue
+		}
+		if stopped := sshReadinessProbeContextError(ctx, "transport"); stopped != nil {
+			return stopped
 		}
 		var diagnostic sshReadinessDiagnostic
 		var diagnosticOutput io.Writer = &diagnostic
@@ -495,11 +564,17 @@ func probeWSL2SSHReady(ctx context.Context, target *SSHTarget, profile sshReadin
 		}
 		sftpErr := probeWSLSFTPSubsystem(ctx, probe, profile.connectTimeout, profile.connectionAttempts, diagnosticOutput)
 		if err := sshReadinessProbeError(ctx, sftpErr, diagnostic.hostKeyRejected()); err != nil {
+			if stopped := sshReadinessProbeContextError(ctx, "transport"); stopped != nil {
+				return stopped
+			}
 			if errors.Is(err, errSSHHostKeyVerification) {
 				return err
 			}
 			outcomes = append(outcomes, outcome{err: err, missingSFTP: IsWSLSFTPUnavailable(err)})
 			continue
+		}
+		if stopped := sshReadinessProbeContextError(ctx, "readiness"); stopped != nil {
+			return stopped
 		}
 		// Transport/SFTP probes stay lightweight. An owned readiness command
 		// must pass the same staged witness setup as the subsequent workload.
@@ -512,6 +587,9 @@ func probeWSL2SSHReady(ctx context.Context, target *SSHTarget, profile sshReadin
 			target.recordPreparedEndpoint(port)
 			return nil
 		} else {
+			if stopped := sshReadinessProbeContextError(ctx, "readiness"); stopped != nil {
+				return stopped
+			}
 			var setupErr *workspaceOwnerSetupError
 			if errors.As(err, &setupErr) || errors.Is(err, errSSHHostKeyVerification) {
 				return err
@@ -543,6 +621,9 @@ func probeSSHTransport(ctx context.Context, target *SSHTarget, timeout time.Dura
 		return runSSHQuietWithOptionsResolvePort(ctx, target, sshTransportProbeCommand(*target), "2", "1") == nil
 	}
 	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
+		if sshReadinessProbeContextError(ctx, "transport") != nil {
+			return false
+		}
 		probe := *target
 		probe.Port = port
 		probe.FallbackPorts = []string{}
@@ -552,6 +633,9 @@ func probeSSHTransport(ctx context.Context, target *SSHTarget, timeout time.Dura
 			continue
 		}
 		_ = conn.Close()
+		if sshReadinessProbeContextError(ctx, "transport") != nil {
+			return false
+		}
 		if runSSHQuietWithOptions(ctx, probe, sshTransportProbeCommand(probe), "2", "1") == nil {
 			target.recordPreparedEndpoint(probe.Port)
 			return true

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -291,9 +291,13 @@ func sshReadinessProfileForTarget(target SSHTarget) sshReadinessProfile {
 func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
 	start := time.Now()
 	deadline := time.Now().Add(timeout)
-	profile := sshReadinessProfileForTarget(*target)
 	probeCtx, cancel := context.WithDeadline(ctx, deadline)
 	defer cancel()
+	return waitForSSHReadyWithProbeContext(ctx, probeCtx, target, stderr, phase, start, deadline)
+}
+
+func waitForSSHReadyWithProbeContext(ctx, probeCtx context.Context, target *SSHTarget, stderr io.Writer, phase string, start, deadline time.Time) error {
+	profile := sshReadinessProfileForTarget(*target)
 	lastPorts := ""
 	lastProbe := "transport"
 	check := func(probeErr error) error {

--- a/internal/cli/ssh_readiness.go
+++ b/internal/cli/ssh_readiness.go
@@ -6,7 +6,29 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"time"
 )
+
+type sshReadinessProbeStopped struct {
+	probe string
+	cause error
+}
+
+func (e *sshReadinessProbeStopped) Error() string { return e.cause.Error() }
+func (e *sshReadinessProbeStopped) Unwrap() error { return e.cause }
+
+// The stage names the local invocation, not evidence that remote code started.
+func sshReadinessProbeContextError(ctx context.Context, probe string) *sshReadinessProbeStopped {
+	cause := context.Cause(ctx)
+	if cause == nil {
+		deadline, ok := ctx.Deadline()
+		if !ok || time.Until(deadline) > 0 {
+			return nil
+		}
+		cause = context.DeadlineExceeded
+	}
+	return &sshReadinessProbeStopped{probe: probe, cause: cause}
+}
 
 var errSSHHostKeyVerification = errors.New("SSH host-key verification failed; verify the lease identity and its SSH host trust before reconnecting")
 

--- a/internal/cli/ssh_readiness_owner_test.go
+++ b/internal/cli/ssh_readiness_owner_test.go
@@ -83,6 +83,29 @@ exit "$CRABBOX_FAKE_TRANSPORT_EXIT"
 	}
 }
 
+func sshReadinessDeadlineFixture(t *testing.T, blocked string) string {
+	t.Helper()
+	dir := t.TempDir()
+	callsPath := filepath.Join(dir, "calls")
+	script := `#!/bin/sh
+for remote; do :; done
+kind=transport
+if [ "$remote" = "$CRABBOX_FAKE_READY_COMMAND" ]; then kind=readiness; fi
+printf 'private-readiness-stderr\n' >&2
+printf '%s\n' "$kind" >> "$CRABBOX_FAKE_SSH_OWNER_CALLS"
+if [ "$kind" = "$CRABBOX_FAKE_BLOCKED_PROBE" ]; then exec sleep 30; fi
+if [ "$kind" = readiness ]; then exit 1; fi
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_OWNER_CALLS", callsPath)
+	t.Setenv("CRABBOX_FAKE_BLOCKED_PROBE", blocked)
+	return callsPath
+}
+
 func TestWaitForSSHReadyDeadlineStopsAtActiveProbe(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell ssh fixture")
@@ -98,24 +121,7 @@ func TestWaitForSSHReadyDeadlineStopsAtActiveProbe(t *testing.T) {
 		{"WSL readiness", "wsl", "readiness", "readiness", "transport\nreadiness\n"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			dir := t.TempDir()
-			callsPath := filepath.Join(dir, "calls")
-			script := `#!/bin/sh
-for remote; do :; done
-kind=transport
-if [ "$remote" = "$CRABBOX_FAKE_READY_COMMAND" ]; then kind=readiness; fi
-printf '%s\n' "$kind" >> "$CRABBOX_FAKE_SSH_OWNER_CALLS"
-printf 'private-readiness-stderr\n' >&2
-if [ "$kind" = "$CRABBOX_FAKE_BLOCKED_PROBE" ]; then exec sleep 30; fi
-if [ "$kind" = readiness ]; then exit 1; fi
-exit 0
-`
-			if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte(script), 0o755); err != nil {
-				t.Fatal(err)
-			}
-			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
-			t.Setenv("CRABBOX_FAKE_SSH_OWNER_CALLS", callsPath)
-			t.Setenv("CRABBOX_FAKE_BLOCKED_PROBE", test.blocked)
+			callsPath := sshReadinessDeadlineFixture(t, test.blocked)
 			listener, err := net.Listen("tcp", "127.0.0.1:0")
 			if err != nil {
 				t.Fatal(err)
@@ -142,13 +148,20 @@ exit 0
 				}
 				dialed <- err == nil
 			}()
-			defer fallback.Close()
+			fallbackJoined := false
+			defer func() {
+				fallback.Close()
+				if !fallbackJoined {
+					<-dialed
+				}
+			}()
 			target := SSHTarget{
 				User: "runner", Host: host, Port: port, FallbackPorts: []string{fallbackPort},
 				ReadyCheck: "fixture-ready", NoControlMaster: true,
 			}
 			readyCommand := target.ReadyCheck
 			sftpCalls := 0
+			sftpEntered := make(chan struct{})
 			switch test.route {
 			case "proxy":
 				target.SSHConfigProxy = true
@@ -159,6 +172,7 @@ exit 0
 				probeWSLSFTPSubsystem = func(ctx context.Context, _ SSHTarget, _, _ string, _ io.Writer) error {
 					sftpCalls++
 					if test.blocked == "sftp" {
+						close(sftpEntered)
 						<-ctx.Done()
 						return ctx.Err()
 					}
@@ -169,13 +183,57 @@ exit 0
 			t.Setenv("CRABBOX_FAKE_READY_COMMAND", readyCommand)
 			ctx, cancel := context.WithCancelCause(t.Context())
 			defer cancel(nil)
+			probeCtx, stopProbe := context.WithCancelCause(ctx)
 			var progress bytes.Buffer
-			err = waitForSSHReady(ctx, &target, &progress, "before sync", 250*time.Millisecond)
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				start := time.Now()
+				err = waitForSSHReadyWithProbeContext(ctx, probeCtx, &target, &progress, "before sync", start, start.Add(250*time.Millisecond))
+			}()
+			defer func() {
+				stopProbe(nil)
+				<-done
+			}()
+			// Establish the active stage independently of startup latency.
+			// The wrapper's actual deadline is covered separately below.
+			poll := time.NewTicker(time.Millisecond)
+			defer poll.Stop()
+		waitForProbe:
+			for {
+				select {
+				case <-done:
+					t.Fatalf("readiness returned before the selected probe: %v", err)
+				case <-poll.C:
+					calls, readErr := os.ReadFile(callsPath)
+					if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+						t.Fatal(readErr)
+					}
+					if !strings.HasPrefix(test.wantCalls, string(calls)) {
+						t.Fatalf("unexpected SSH calls before the selected probe: %q", calls)
+					}
+					if string(calls) != test.wantCalls {
+						continue
+					}
+					if test.blocked == "sftp" {
+						select {
+						case <-sftpEntered:
+						default:
+							continue
+						}
+					}
+					break waitForProbe
+				}
+			}
+			stopProbe(context.DeadlineExceeded)
+			<-done
 			if deadlineErr := fallback.(*net.TCPListener).SetDeadline(time.Now().Add(10 * time.Millisecond)); deadlineErr != nil {
 				t.Error(deadlineErr)
 				fallback.Close()
 			}
-			if <-dialed {
+			fallbackDialed := <-dialed
+			fallbackJoined = true
+			if fallbackDialed {
 				t.Error("dialed a fallback after the active probe exhausted the deadline")
 			}
 			fallback.Close()
@@ -209,6 +267,70 @@ exit 0
 			}
 		})
 	}
+}
+
+func TestWaitForSSHReadyLocalDeadlineAtActiveProbe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell ssh fixture")
+	}
+	synctest.Test(t, func(t *testing.T) {
+		callsPath := sshReadinessDeadlineFixture(t, "")
+		target := SSHTarget{
+			User: "runner", Host: "ssh-readiness.example", Port: "2222", FallbackPorts: []string{"22"},
+			ReadyCheck: "fixture-ready", NoControlMaster: true, TargetOS: targetWindows, WindowsMode: windowsModeWSL2,
+		}
+		t.Setenv("CRABBOX_FAKE_READY_COMMAND", wsl2ReadinessCommand(target.ReadyCheck))
+		original := probeWSLSFTPSubsystem
+		t.Cleanup(func() { probeWSLSFTPSubsystem = original })
+		sftpCalls := 0
+		var activeCtx context.Context
+		probeWSLSFTPSubsystem = func(ctx context.Context, _ SSHTarget, _, _ string, _ io.Writer) error {
+			sftpCalls++
+			activeCtx = ctx
+			// The preceding SSH process is joined before this hook. Only the
+			// local deadline blocks here, so virtual time can advance.
+			<-ctx.Done()
+			return ctx.Err()
+		}
+		ctx, cancel := context.WithCancelCause(t.Context())
+		defer cancel(nil)
+		var progress bytes.Buffer
+		start := time.Now()
+		err := waitForSSHReady(ctx, &target, &progress, "before sync", 250*time.Millisecond)
+		var exitErr ExitError
+		if !AsExitError(err, &exitErr) || exitErr.Code != 5 || !isBootstrapWaitError(err) {
+			t.Fatalf("readiness=%v, want retry-classified exit 5", err)
+		}
+		for _, want := range []string{
+			"timed out waiting for SSH", "probe=transport", "cause=deadline_exceeded", "authentication=unknown",
+		} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error=%q, missing %q", err, want)
+			}
+		}
+		for _, forbidden := range []string{"ssh-auth", "private-readiness-stderr", "fixture-ready", "2222:tcp"} {
+			if strings.Contains(err.Error()+progress.String(), forbidden) {
+				t.Errorf("deadline misclassification or disclosure: %q", forbidden)
+			}
+		}
+		if elapsed := time.Since(start); elapsed != 250*time.Millisecond {
+			t.Errorf("active probe consumed %s, want the 250ms local deadline", elapsed)
+		}
+		if sftpCalls != 1 || activeCtx == nil {
+			t.Fatalf("sftp=%d context=%v, want one active SFTP probe", sftpCalls, activeCtx)
+		}
+		deadline, ok := activeCtx.Deadline()
+		if !ok || deadline.Sub(start) != 250*time.Millisecond || activeCtx.Err() != context.DeadlineExceeded || context.Cause(activeCtx) != context.DeadlineExceeded {
+			t.Errorf("probe deadline=%v error=%v cause=%v, want the wrapper's elapsed local deadline", deadline, activeCtx.Err(), context.Cause(activeCtx))
+		}
+		calls, readErr := os.ReadFile(callsPath)
+		if readErr != nil || string(calls) != "transport\n" {
+			t.Errorf("SSH calls=%q error=%v, want only the initial transport", calls, readErr)
+		}
+		if target.Port != "2222" || target.preparedEndpoint != "" || ctx.Err() != nil {
+			t.Errorf("target=%+v parent=%v, want unchanged target and live parent", target, ctx.Err())
+		}
+	})
 }
 
 func TestWaitForSSHReadyLocalDeadlineDuringBackoff(t *testing.T) {

--- a/internal/cli/ssh_readiness_owner_test.go
+++ b/internal/cli/ssh_readiness_owner_test.go
@@ -24,7 +24,7 @@ func TestWaitForSSHReadyOnlyDiagnosesFailedReadiness(t *testing.T) {
 	}{
 		{name: "ready", readyExit: "0", transportExit: "0", wantCalls: "fixture-ready\n"},
 		{name: "toolchain pending", readyExit: "1", transportExit: "0", wantCalls: "fixture-ready\nexit 0\n", wantProgress: "test ready-check"},
-		{name: "transport pending", readyExit: "255", transportExit: "255", wantCalls: "fixture-ready\nexit 0\n", wantProgress: "test ssh-auth"},
+		{name: "transport pending", readyExit: "255", transportExit: "255", wantCalls: "fixture-ready\nexit 0\n", wantProgress: "test ssh-transport"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
@@ -80,6 +80,169 @@ exit "$CRABBOX_FAKE_TRANSPORT_EXIT"
 				t.Fatalf("SSH calls=%q error=%v, want %q", calls, err, test.wantCalls)
 			}
 		})
+	}
+}
+
+func TestWaitForSSHReadyDeadlineStopsAtActiveProbe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell ssh fixture")
+	}
+	for _, test := range []struct {
+		name, route, blocked, wantProbe, wantCalls string
+	}{
+		{"direct readiness", "direct", "readiness", "readiness", "readiness\n"},
+		{"direct transport", "direct", "transport", "transport", "readiness\ntransport\n"},
+		{"proxy readiness", "proxy", "readiness", "readiness", "readiness\n"},
+		{"WSL transport", "wsl", "transport", "transport", "transport\n"},
+		{"WSL SFTP", "wsl", "sftp", "transport", "transport\n"},
+		{"WSL readiness", "wsl", "readiness", "readiness", "transport\nreadiness\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			callsPath := filepath.Join(dir, "calls")
+			script := `#!/bin/sh
+for remote; do :; done
+kind=transport
+if [ "$remote" = "$CRABBOX_FAKE_READY_COMMAND" ]; then kind=readiness; fi
+printf '%s\n' "$kind" >> "$CRABBOX_FAKE_SSH_OWNER_CALLS"
+printf 'private-readiness-stderr\n' >&2
+if [ "$kind" = "$CRABBOX_FAKE_BLOCKED_PROBE" ]; then exec sleep 30; fi
+if [ "$kind" = readiness ]; then exit 1; fi
+exit 0
+`
+			if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("CRABBOX_FAKE_SSH_OWNER_CALLS", callsPath)
+			t.Setenv("CRABBOX_FAKE_BLOCKED_PROBE", test.blocked)
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer listener.Close()
+			host, port, err := net.SplitHostPort(listener.Addr().String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			fallback, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, fallbackPort, err := net.SplitHostPort(fallback.Addr().String())
+			if err != nil {
+				fallback.Close()
+				t.Fatal(err)
+			}
+			dialed := make(chan bool, 1)
+			go func() {
+				conn, err := fallback.Accept()
+				if err == nil {
+					conn.Close()
+				}
+				dialed <- err == nil
+			}()
+			defer fallback.Close()
+			target := SSHTarget{
+				User: "runner", Host: host, Port: port, FallbackPorts: []string{fallbackPort},
+				ReadyCheck: "fixture-ready", NoControlMaster: true,
+			}
+			readyCommand := target.ReadyCheck
+			sftpCalls := 0
+			switch test.route {
+			case "proxy":
+				target.SSHConfigProxy = true
+			case "wsl":
+				target.TargetOS, target.WindowsMode = targetWindows, windowsModeWSL2
+				readyCommand = wsl2ReadinessCommand(target.ReadyCheck)
+				original := probeWSLSFTPSubsystem
+				probeWSLSFTPSubsystem = func(ctx context.Context, _ SSHTarget, _, _ string, _ io.Writer) error {
+					sftpCalls++
+					if test.blocked == "sftp" {
+						<-ctx.Done()
+						return ctx.Err()
+					}
+					return nil
+				}
+				t.Cleanup(func() { probeWSLSFTPSubsystem = original })
+			}
+			t.Setenv("CRABBOX_FAKE_READY_COMMAND", readyCommand)
+			ctx, cancel := context.WithCancelCause(t.Context())
+			defer cancel(nil)
+			var progress bytes.Buffer
+			err = waitForSSHReady(ctx, &target, &progress, "before sync", 250*time.Millisecond)
+			if deadlineErr := fallback.(*net.TCPListener).SetDeadline(time.Now().Add(10 * time.Millisecond)); deadlineErr != nil {
+				t.Error(deadlineErr)
+				fallback.Close()
+			}
+			if <-dialed {
+				t.Error("dialed a fallback after the active probe exhausted the deadline")
+			}
+			fallback.Close()
+			var exitErr ExitError
+			if !AsExitError(err, &exitErr) || exitErr.Code != 5 || !isBootstrapWaitError(err) {
+				t.Fatalf("readiness=%v, want retry-classified exit 5", err)
+			}
+			for _, want := range []string{
+				"timed out waiting for SSH", "probe=" + test.wantProbe,
+				"cause=deadline_exceeded", "authentication=unknown",
+			} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error=%q, missing %q", err, want)
+				}
+			}
+			for _, forbidden := range []string{"ssh-auth", "private-readiness-stderr", "fixture-ready", port + ":tcp"} {
+				if strings.Contains(err.Error()+progress.String(), forbidden) {
+					t.Errorf("deadline misclassification or disclosure: %q", forbidden)
+				}
+			}
+			calls, readErr := os.ReadFile(callsPath)
+			if readErr != nil || string(calls) != test.wantCalls {
+				t.Errorf("SSH calls=%q error=%v, want %q", calls, readErr, test.wantCalls)
+			}
+			wantSFTP := 0
+			if test.route == "wsl" && test.blocked != "transport" {
+				wantSFTP = 1
+			}
+			if sftpCalls != wantSFTP || target.Port != port || target.preparedEndpoint != "" || ctx.Err() != nil {
+				t.Errorf("sftp=%d target=%+v parent=%v, want unchanged target and live parent", sftpCalls, target, ctx.Err())
+			}
+		})
+	}
+}
+
+func TestWaitForSSHReadyLocalDeadlineDuringBackoff(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		target := SSHTarget{Host: "ssh-readiness.example", FallbackPorts: []string{}}
+		ctx, cancel := context.WithCancelCause(t.Context())
+		defer cancel(nil)
+		var progress bytes.Buffer
+		start := time.Now()
+		err := waitForSSHReady(ctx, &target, &progress, "test", time.Second)
+		var exitErr ExitError
+		if !AsExitError(err, &exitErr) || exitErr.Code != 5 || !isBootstrapWaitError(err) || ctx.Err() != nil {
+			t.Fatalf("readiness=%v parent=%v, want exit 5 with an uncancelled parent", err, ctx.Err())
+		}
+		for _, want := range []string{"probe=transport", "cause=deadline_exceeded", "authentication=unknown"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error=%q missing %q", err, want)
+			}
+		}
+		if elapsed := time.Since(start); elapsed != time.Second {
+			t.Errorf("backoff consumed %s, want the one-second local deadline", elapsed)
+		}
+	})
+}
+
+func TestWaitForSSHReadyCanceledParentWinsDeadline(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(t.Context())
+	cause := errors.New("fixture lease authority revoked")
+	cancel(cause)
+	target := SSHTarget{Host: "ssh-readiness.example", FallbackPorts: []string{}}
+	var progress bytes.Buffer
+	err := waitForSSHReady(ctx, &target, &progress, "test", 0)
+	if err != cause || progress.Len() != 0 {
+		t.Fatalf("error=%v progress=%q, want original cancellation and no probe progress", err, progress.String())
 	}
 }
 

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -2655,11 +2655,11 @@ func TestSSHWaitProgressIncludesElapsedAndRemaining(t *testing.T) {
 	}
 }
 
-func TestSSHWaitProgressDistinguishesAuthFromReadiness(t *testing.T) {
+func TestSSHWaitProgressDistinguishesTransportFromReadiness(t *testing.T) {
 	target := &SSHTarget{Host: "203.0.113.10", Port: "2222"}
 	got := sshWaitProgressMessage(target, "bootstrap", "2222", "", "2222:tcp", 5*time.Second, time.Minute)
-	if !strings.Contains(got, "bootstrap ssh-auth") {
-		t.Fatalf("TCP-only progress should report ssh-auth stage: %q", got)
+	if !strings.Contains(got, "bootstrap ssh-transport") {
+		t.Fatalf("TCP-only progress should report ssh-transport stage: %q", got)
 	}
 	got = sshWaitProgressMessage(target, "bootstrap", "2222", "2222", "2222:auth", 5*time.Second, time.Minute)
 	if !strings.Contains(got, "bootstrap ready-check") {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users waiting for SSH could receive misleading TCP or authentication diagnostics after readiness exhausted the shared deadline. Expired checks could still attempt fallback candidates, and backoff could outlast the local deadline.

## Why This Change Was Made

The readiness owner checks parent cancellation before local deadline expiry around dialing, probes, fallback candidates, proxy/WSL subprobes, and backoff. TCP dialing and backoff use the shared probe context without increasing connection caps, attempts, or budgets.

Timeouts retain exit code 5 and the `timed out waiting for SSH` prefix, with `probe=readiness|transport`, `cause=deadline_exceeded`, and `authentication=unknown`. The probe field describes the local invocation stage, not proof that remote code started. Progress uses `ssh-transport`; `ready-check` follows a positive transport result. No raw stderr or remote commands are added to diagnostics.

## User Impact

SSH waits stop at their deadline without misdiagnosing expired work as an authentication failure. Parent cancellation causes, healthy readiness-first single-call success, prepared endpoints, host-key rejection, workspace-owner errors, and SFTP behavior are preserved. No configuration or secret changes.

## Evidence

- Source head: `0aaa3e7e6ccc7011c83d14d13342770ec25ff146`. Its two-file follow-up extracts the private readiness loop without changing its body, and repairs the deadline test fixture. The wrapper still creates and cancels the same deadline; other runtime code, sibling tests, and the existing changelog entry are unchanged.
- Original-source regression reproduced actual fallback dialing after deadline expiry, incorrect TCP/authentication classification, and ten-second backoff under a one-second local deadline.
- A later combined local run exposed a fixture precondition gap: its 250ms wall-clock timer could expire before the expected fake-SSH call was recorded. The specific startup-delay cause was not established. The six active-probe cases now observe the selected stage before canceling only the local context with `DeadlineExceeded`; the parent remains live. A separate normal-wrapper test proves actual 250ms deadline expiry under `synctest` after the native transport process has finished.
- Current-head focused local Go checks: **40 top-level tests plus 56 subtests passed**, zero failures or skips. Assertions retain exact direct/proxy/WSL calls, no later fallback, exit-5 retry classification, stage formatting, private-stderr nondisclosure, unchanged target, and live parent. Healthy readiness-first behavior, backoff expiry, parent cancellation, and owner/host-key/SFTP/prepared-endpoint contracts remain covered.
- Tests used loopback/fake-SSH and `synctest` fixtures, plus real local OpenSSH host-key rejection. Formatting, diff checks, reviewed-source hash checks, and added-line privacy inspection passed.
- Current-head review: one completed default-P0 automated review was scoped-clean with no findings. Independent final review and maintainer inspection accepted this exact two-file follow-up.
- Exact-head [CI](https://github.com/openclaw/crabbox/actions/runs/34093583270) and required [Release Check](https://github.com/openclaw/crabbox/actions/runs/34093583121) passed for `0aaa3e7e6ccc7011c83d14d13342770ec25ff146`. All attached checks completed: 24 succeeded and one was skipped.
- The [current-head hosted ClawSweeper review](https://github.com/openclaw/clawsweeper/actions/runs/34093765628) did not run: the input-safety scan refused material in this revision, with review exit 79. The triggering input is unknown; no review verdict was produced. This is not a review pass or an identified code finding, and successful dispatch checks do not establish a review verdict.
- Limits: the underlying remote readiness failure remains unknown. This repairs the local deadline/diagnostic invariant, not a proven remote root cause. No new native CLI, AMI, AWS, or Windows/WSL proof is claimed; local checks were focused, not full-suite or race-suite runs.
- Existing changelog link and contributor credit are preserved: https://github.com/openclaw/crabbox/pull/1949. Thanks @vincentkoc.

Punchcard-Session: calm-lantern-orchard-dn
