### PR TITLE
refactor: share E2B and Cube envd wire codec

### DIFF
--- a/docs/providers/cubesandbox.md
+++ b/docs/providers/cubesandbox.md
@@ -163,6 +163,9 @@ observed process exits and preserve cancellation/timeout causes. CubeSandbox's
 existing immediate return on an abnormal end is unchanged; this does not certify
 that a later stream trailer or sandbox deletion succeeded.
 
+The envd Connect wire codec is shared with E2B; this abnormal-end policy and
+CubeProxy routing remain CubeSandbox-owned.
+
 ## Gotchas
 
 - `--class` and `--type` are rejected; choose the template and CubeSandbox node

--- a/docs/providers/e2b.md
+++ b/docs/providers/e2b.md
@@ -13,6 +13,10 @@ config, repo claims, sync manifests and guardrails, slugs, timing summaries, and
 normalized `list`/`status` rendering. There is no Crabbox SSH lease and no broker
 coordinator — the CLI talks to E2B directly.
 
+E2B and CubeSandbox share the envd Connect wire codec, but retain their own
+process-end interpretation. E2B continues reading after an end event; a later
+RPC or stream-read failure takes precedence over the reported command exit.
+
 ## When to use
 
 Use E2B when the remote Linux sandbox should be owned by E2B and commands run

--- a/internal/providers/cubesandbox/backend_test.go
+++ b/internal/providers/cubesandbox/backend_test.go
@@ -6,7 +6,6 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/tls"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -72,11 +72,7 @@ func assertCubeSandboxRedactedError(t *testing.T, err error, secret string) {
 
 func TestCubeSandboxProcessStreamRedactsReflectedCredential(t *testing.T) {
 	const secret = "envd-stream-secret"
-	t.Run("end stream error", func(t *testing.T) {
-		body := cubesandboxTestEnvelope(2, map[string]any{"error": map[string]any{"code": "unauthorized", "message": "Bearer " + secret + " quota exceeded"}})
-		_, err := parseCubeSandboxProcessStream(bytes.NewReader(body), io.Discard, io.Discard, secret)
-		assertCubeSandboxRedactedError(t, err, secret)
-	})
+
 	t.Run("process end diagnostic", func(t *testing.T) {
 		body := cubesandboxTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 1, "exited": false, "error": "Bearer " + secret + " quota exceeded"}}})
 		var stderr bytes.Buffer
@@ -96,52 +92,6 @@ func TestCubeSandboxProcessStreamRedactsReflectedCredential(t *testing.T) {
 			t.Fatalf("code=%d err=%v, want abnormal termination failure", code, err)
 		}
 	})
-}
-
-func TestParseCubeSandboxProcessStream(t *testing.T) {
-	body := bytes.Join([][]byte{
-		cubesandboxTestEnvelope(0, map[string]any{"event": map[string]any{"start": map[string]any{"pid": 42}}}),
-		cubesandboxTestEnvelope(0, map[string]any{"event": map[string]any{"data": map[string]any{"stdout": base64.StdEncoding.EncodeToString([]byte("hello"))}}}),
-		cubesandboxTestEnvelope(0, map[string]any{"event": map[string]any{"data": map[string]any{"stderr": base64.StdEncoding.EncodeToString([]byte("warn"))}}}),
-		cubesandboxTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 7, "exited": true}}}),
-		cubesandboxTestEnvelope(2, map[string]any{}),
-	}, nil)
-	var stdout, stderr bytes.Buffer
-	code, err := parseCubeSandboxProcessStream(bytes.NewReader(body), &stdout, &stderr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if code != 7 || stdout.String() != "hello" || stderr.String() != "warn" {
-		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
-	}
-}
-
-func TestCubeSandboxProcessEndAndStreamFailurePrecedence(t *testing.T) {
-	for _, exited := range []bool{false, true} {
-		for _, ending := range []string{"clean", "rpc error", "truncated"} {
-			t.Run(fmt.Sprintf("exited=%t/%s", exited, ending), func(t *testing.T) {
-				body := cubesandboxTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 137, "exited": exited, "error": "fixture process end"}}})
-				switch ending {
-				case "rpc error":
-					body = append(body, cubesandboxTestEnvelope(2, map[string]any{"error": map[string]any{"code": "internal", "message": "fixture RPC failure"}})...)
-				case "truncated":
-					body = append(body, 0)
-				}
-				code, err := parseCubeSandboxProcessStream(bytes.NewReader(body), io.Discard, io.Discard)
-				if !exited {
-					if code != 137 || err == nil || !strings.Contains(err.Error(), "fixture process end") {
-						t.Fatalf("abnormal end lost precedence: code=%d err=%v", code, err)
-					}
-				} else if ending == "clean" {
-					if code != 137 || err != nil {
-						t.Fatalf("normal end: code=%d err=%v", code, err)
-					}
-				} else if code != 1 || err == nil {
-					t.Fatalf("stream failure lost precedence: code=%d err=%v", code, err)
-				}
-			})
-		}
-	}
 }
 
 func TestValidateCubeSandboxAPIURL(t *testing.T) {
@@ -278,21 +228,6 @@ func TestCubeSandboxDataPlaneStreamOutlivesControlTimeout(t *testing.T) {
 	}
 	if elapsed := time.Since(started); elapsed <= controlTimeout {
 		t.Fatalf("stream completed in %v, want it to remain active beyond %v", elapsed, controlTimeout)
-	}
-}
-
-func TestParseCubeSandboxProcessStreamRequiresEndEvent(t *testing.T) {
-	body := bytes.Join([][]byte{
-		cubesandboxTestEnvelope(0, map[string]any{"event": map[string]any{"data": map[string]any{"stdout": base64.StdEncoding.EncodeToString([]byte("partial"))}}}),
-		cubesandboxTestEnvelope(2, map[string]any{}),
-	}, nil)
-	var stdout bytes.Buffer
-	code, err := parseCubeSandboxProcessStream(bytes.NewReader(body), &stdout, io.Discard)
-	if err == nil || !strings.Contains(err.Error(), "without end event") {
-		t.Fatalf("code=%d err=%v, want missing end event error", code, err)
-	}
-	if stdout.String() != "partial" {
-		t.Fatalf("stdout=%q", stdout.String())
 	}
 }
 
@@ -1889,6 +1824,72 @@ func TestCubeSandboxRejectsMissingCanonicalIDMatchingAnotherSlug(t *testing.T) {
 			after, marshalErr := json.Marshal(afterClaim)
 			if err != nil || marshalErr != nil || !exists || !bytes.Equal(before, after) {
 				t.Fatalf("unrelated claim changed: exists=%v err=%v marshal=%v", exists, err, marshalErr)
+			}
+		})
+	}
+}
+
+func parseCubeSandboxProcessStream(r io.Reader, stdout, stderr io.Writer, secrets ...string) (int, error) {
+	return shared.ParseEnvdProcessStream("cubesandbox", r, stdout, stderr, interpretCubeSandboxProcessEnd, secrets...)
+}
+
+func TestCubeSandboxProcessEndPolicy(t *testing.T) {
+	readFailure := errors.New("fixture stream read failed")
+	for _, code := range []int{0, 7, -1, 137} {
+		t.Run(fmt.Sprintf("normal/%d", code), func(t *testing.T) {
+			var diagnostic bytes.Buffer
+			got, err := interpretCubeSandboxProcessEnd(shared.EnvdProcessEnd{ExitCode: code, Exited: true, Error: "ignored normal detail"}, &diagnostic)
+			if got != code || err != nil || diagnostic.Len() != 0 {
+				t.Fatalf("code=%d err=%v diagnostic=%q", got, err, diagnostic.String())
+			}
+		})
+		for _, ending := range []string{"clean", "RPC failure", "read failure", "truncated"} {
+			t.Run(fmt.Sprintf("abnormal/%d/%s", code, ending), func(t *testing.T) {
+				body := cubesandboxTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": code, "exited": false, "error": "fixture end"}}})
+				var tailBytes []byte
+				if ending == "RPC failure" {
+					tailBytes = cubesandboxTestEnvelope(2, map[string]any{"error": map[string]any{"code": "internal", "message": "fixture RPC failure"}})
+				}
+				if ending == "truncated" {
+					tailBytes = []byte{0}
+				}
+				tail := bytes.NewReader(tailBytes)
+				var reader io.Reader = io.MultiReader(bytes.NewReader(body), tail)
+				if ending == "read failure" {
+					reader = io.MultiReader(reader, iotest.ErrReader(readFailure))
+				}
+				var diagnostic bytes.Buffer
+				got, err := parseCubeSandboxProcessStream(reader, io.Discard, &diagnostic)
+				want := code
+				if want == 0 {
+					want = 1
+				}
+				if got != want || err == nil || diagnostic.String() != "fixture end\n" {
+					t.Fatalf("code=%d err=%v diagnostic=%q", got, err, diagnostic.String())
+				}
+				outcome := shared.FinalizeDelegatedCommandOutcome(got, err)
+				if outcome.ExitCode != want || outcome.ErrorKind != core.RunErrorCommandExit {
+					t.Fatalf("lost signed observed end: %+v", outcome)
+				}
+				if errors.Is(err, readFailure) || !strings.Contains(err.Error(), "fixture end") || tail.Len() != len(tailBytes) {
+					t.Fatalf("abnormal end did not stop decoding: err=%v unread=%d/%d", err, tail.Len(), len(tailBytes))
+				}
+			})
+		}
+	}
+}
+
+func TestCubeSandboxProcessEndDiagnosticPrecedence(t *testing.T) {
+	for _, tc := range []struct{ name, detail, status, want string }{
+		{"error before status", " detail ", "status", "detail"},
+		{"status fallback", " ", " status ", "status"},
+		{"empty fallback", " ", " ", "process did not exit normally"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var diagnostic bytes.Buffer
+			code, err := interpretCubeSandboxProcessEnd(shared.EnvdProcessEnd{ExitCode: -1, Error: tc.detail, Status: tc.status}, &diagnostic)
+			if code != -1 || err == nil || diagnostic.String() != tc.want+"\n" || !strings.HasSuffix(err.Error(), ": "+tc.want) {
+				t.Fatalf("code=%d err=%v diagnostic=%q", code, err, diagnostic.String())
 			}
 		})
 	}

--- a/internal/providers/cubesandbox/client.go
+++ b/internal/providers/cubesandbox/client.go
@@ -3,8 +3,6 @@ package cubesandbox
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -334,8 +332,8 @@ func (c *cubesandboxClient) StartProcess(ctx context.Context, session cubesandbo
 		HTTPClient:     c.dataPlaneHTTPClient(),
 		SetHeaders:     func(httpReq *http.Request) { c.setEnvdHeaders(httpReq, session) },
 		RedirectError:  cubeSandboxRedirectError,
-		EncodeEnvelope: encodeConnectJSONEnvelope,
-		ParseStream:    parseCubeSandboxProcessStream,
+		Provider:       "cubesandbox",
+		InterpretEnd:   interpretCubeSandboxProcessEnd,
 		SummarizeError: summarizeJSON,
 		APIError: func(statusCode int, status, body string) error {
 			return &cubesandboxAPIError{StatusCode: statusCode, Status: status, Body: body}
@@ -431,125 +429,22 @@ func (c *cubesandboxClient) dataPlaneHTTPClient() *http.Client {
 	return &http.Client{Timeout: 0}
 }
 
-type cubesandboxStartResponse struct {
-	Event struct {
-		Start *struct {
-			PID uint32 `json:"pid"`
-		} `json:"start,omitempty"`
-		Data *struct {
-			Stdout string `json:"stdout,omitempty"`
-			Stderr string `json:"stderr,omitempty"`
-			PTY    string `json:"pty,omitempty"`
-		} `json:"data,omitempty"`
-		End *struct {
-			ExitCode int    `json:"exitCode"`
-			Exited   bool   `json:"exited"`
-			Status   string `json:"status"`
-			Error    string `json:"error,omitempty"`
-		} `json:"end,omitempty"`
-		Keepalive map[string]any `json:"keepalive,omitempty"`
-	} `json:"event"`
-}
-
-type cubesandboxEndStream struct {
-	Error *struct {
-		Code    string `json:"code"`
-		Message string `json:"message"`
-	} `json:"error,omitempty"`
-}
-
-func encodeConnectJSONEnvelope(v any) ([]byte, error) {
-	data, err := json.Marshal(v)
-	if err != nil {
-		return nil, err
+func interpretCubeSandboxProcessEnd(end shared.EnvdProcessEnd, stderr io.Writer, secrets ...string) (int, error) {
+	if end.Exited {
+		return end.ExitCode, nil
 	}
-	var out bytes.Buffer
-	out.WriteByte(0)
-	var size [4]byte
-	binary.BigEndian.PutUint32(size[:], uint32(len(data)))
-	out.Write(size[:])
-	out.Write(data)
-	return out.Bytes(), nil
-}
-
-func parseCubeSandboxProcessStream(r io.Reader, stdout, stderr io.Writer, secrets ...string) (int, error) {
-	exitCode := 0
-	seenEnd := false
-	for {
-		var header [5]byte
-		if _, err := io.ReadFull(r, header[:]); err != nil {
-			if err == io.EOF {
-				break
-			}
-			return 1, err
-		}
-		flags := header[0]
-		size := binary.BigEndian.Uint32(header[1:])
-		if flags&1 != 0 {
-			return 1, fmt.Errorf("compressed connect envelopes are not supported")
-		}
-		data := make([]byte, size)
-		if _, err := io.ReadFull(r, data); err != nil {
-			return 1, err
-		}
-		if flags&2 != 0 {
-			var end cubesandboxEndStream
-			if len(data) > 0 {
-				if err := json.Unmarshal(data, &end); err != nil {
-					return 1, err
-				}
-			}
-			if end.Error != nil {
-				return 1, errors.New(shared.RedactErrorSecrets(end.Error.Code+": "+end.Error.Message, secrets...))
-			}
-			break
-		}
-		var event cubesandboxStartResponse
-		if err := json.Unmarshal(data, &event); err != nil {
-			return 1, err
-		}
-		if event.Event.Data != nil {
-			if err := writeBase64(event.Event.Data.Stdout, stdout); err != nil {
-				return 1, err
-			}
-			if err := writeBase64(event.Event.Data.Stderr, stderr); err != nil {
-				return 1, err
-			}
-		}
-		if event.Event.End != nil {
-			exitCode = event.Event.End.ExitCode
-			seenEnd = true
-			if !event.Event.End.Exited {
-				detail := strings.TrimSpace(event.Event.End.Error)
-				if detail == "" {
-					detail = strings.TrimSpace(event.Event.End.Status)
-				}
-				if detail == "" {
-					detail = "process did not exit normally"
-				}
-				detail = shared.RedactErrorSecrets(detail, secrets...)
-				fmt.Fprintln(stderr, detail)
-				if exitCode == 0 {
-					exitCode = 1
-				}
-				return exitCode, shared.ObservedProcessEndError(fmt.Sprintf("cubesandbox process did not exit normally: %s", detail))
-			}
-		}
+	detail := strings.TrimSpace(end.Error)
+	if detail == "" {
+		detail = strings.TrimSpace(end.Status)
 	}
-	if !seenEnd {
-		return 1, fmt.Errorf("cubesandbox process stream ended without end event")
+	if detail == "" {
+		detail = "process did not exit normally"
 	}
-	return exitCode, nil
-}
-
-func writeBase64(value string, w io.Writer) error {
-	if value == "" {
-		return nil
+	detail = shared.RedactErrorSecrets(detail, secrets...)
+	fmt.Fprintln(stderr, detail)
+	code := end.ExitCode
+	if code == 0 {
+		code = 1
 	}
-	data, err := base64.StdEncoding.DecodeString(value)
-	if err != nil {
-		return err
-	}
-	_, err = w.Write(data)
-	return err
+	return code, shared.ObservedProcessEndError(fmt.Sprintf("cubesandbox process did not exit normally: %s", detail))
 }

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,6 +18,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -122,11 +122,7 @@ func assertE2BRedactedError(t *testing.T, err error, secret string) {
 
 func TestE2BProcessStreamRedactsReflectedCredential(t *testing.T) {
 	const secret = "envd-stream-secret"
-	t.Run("end stream error", func(t *testing.T) {
-		body := e2bTestEnvelope(2, map[string]any{"error": map[string]any{"code": "unauthorized", "message": "Bearer " + secret + " quota exceeded"}})
-		_, err := parseE2BProcessStream(bytes.NewReader(body), io.Discard, io.Discard, secret)
-		assertE2BRedactedError(t, err, secret)
-	})
+
 	t.Run("process end diagnostic", func(t *testing.T) {
 		body := e2bTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 1, "exited": false, "error": "Bearer " + secret + " quota exceeded"}}})
 		var stderr bytes.Buffer
@@ -137,48 +133,6 @@ func TestE2BProcessStreamRedactsReflectedCredential(t *testing.T) {
 			t.Fatalf("stderr=%q, want redacted useful process diagnostic", stderr.String())
 		}
 	})
-}
-
-func TestE2BProcessEndAndStreamFailurePrecedence(t *testing.T) {
-	for _, exited := range []bool{false, true} {
-		for _, ending := range []string{"clean", "rpc error", "truncated"} {
-			t.Run(fmt.Sprintf("exited=%t/%s", exited, ending), func(t *testing.T) {
-				body := e2bTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 137, "exited": exited, "error": "fixture process end"}}})
-				switch ending {
-				case "rpc error":
-					body = append(body, e2bTestEnvelope(2, map[string]any{"error": map[string]any{"code": "internal", "message": "fixture RPC failure"}})...)
-				case "truncated":
-					body = append(body, 0)
-				}
-				code, err := parseE2BProcessStream(bytes.NewReader(body), io.Discard, io.Discard)
-				if ending == "clean" {
-					if code != 137 || err != nil {
-						t.Fatalf("observed end: code=%d err=%v", code, err)
-					}
-				} else if code != 1 || err == nil {
-					t.Fatalf("stream failure lost precedence: code=%d err=%v", code, err)
-				}
-			})
-		}
-	}
-}
-
-func TestParseE2BProcessStream(t *testing.T) {
-	body := bytes.Join([][]byte{
-		e2bTestEnvelope(0, map[string]any{"event": map[string]any{"start": map[string]any{"pid": 42}}}),
-		e2bTestEnvelope(0, map[string]any{"event": map[string]any{"data": map[string]any{"stdout": base64.StdEncoding.EncodeToString([]byte("hello"))}}}),
-		e2bTestEnvelope(0, map[string]any{"event": map[string]any{"data": map[string]any{"stderr": base64.StdEncoding.EncodeToString([]byte("warn"))}}}),
-		e2bTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 7, "exited": true}}}),
-		e2bTestEnvelope(2, map[string]any{}),
-	}, nil)
-	var stdout, stderr bytes.Buffer
-	code, err := parseE2BProcessStream(bytes.NewReader(body), &stdout, &stderr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if code != 7 || stdout.String() != "hello" || stderr.String() != "warn" {
-		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
-	}
 }
 
 func TestE2BDefaultHTTPClientsSeparateControlAndDataPlanes(t *testing.T) {
@@ -389,21 +343,6 @@ func TestValidateE2BAPIURL(t *testing.T) {
 				t.Fatalf("validateE2BAPIURL(%q) = %q, want %q", tt.raw, got, tt.want)
 			}
 		})
-	}
-}
-
-func TestParseE2BProcessStreamRequiresEndEvent(t *testing.T) {
-	body := bytes.Join([][]byte{
-		e2bTestEnvelope(0, map[string]any{"event": map[string]any{"data": map[string]any{"stdout": base64.StdEncoding.EncodeToString([]byte("partial"))}}}),
-		e2bTestEnvelope(2, map[string]any{}),
-	}, nil)
-	var stdout bytes.Buffer
-	code, err := parseE2BProcessStream(bytes.NewReader(body), &stdout, io.Discard)
-	if err == nil || !strings.Contains(err.Error(), "without end event") {
-		t.Fatalf("code=%d err=%v, want missing end event error", code, err)
-	}
-	if stdout.String() != "partial" {
-		t.Fatalf("stdout=%q", stdout.String())
 	}
 }
 
@@ -1905,5 +1844,63 @@ func TestE2BStopRejectsMissingCanonicalIDMatchingAnotherSlug(t *testing.T) {
 	}
 	if len(client.deleteIDs) != 1 || client.deleteIDs[0] != sandbox.SandboxID {
 		t.Fatalf("exact positive target=%v", client.deleteIDs)
+	}
+}
+
+func parseE2BProcessStream(r io.Reader, stdout, stderr io.Writer, secrets ...string) (int, error) {
+	return shared.ParseEnvdProcessStream("e2b", r, stdout, stderr, interpretE2BProcessEnd, secrets...)
+}
+
+func TestE2BProcessEndPolicy(t *testing.T) {
+	readFailure := errors.New("fixture stream read failed")
+	for _, code := range []int{0, 7, -1, 137} {
+		t.Run(fmt.Sprintf("normal/%d", code), func(t *testing.T) {
+			var diagnostic bytes.Buffer
+			got, err := interpretE2BProcessEnd(shared.EnvdProcessEnd{ExitCode: code, Exited: true, Error: "ignored normal detail"}, &diagnostic)
+			if got != code || err != nil || diagnostic.Len() != 0 {
+				t.Fatalf("code=%d err=%v diagnostic=%q", got, err, diagnostic.String())
+			}
+		})
+		for _, ending := range []string{"clean", "RPC failure", "read failure", "truncated"} {
+			t.Run(fmt.Sprintf("abnormal/%d/%s", code, ending), func(t *testing.T) {
+				body := e2bTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": code, "exited": false, "error": "fixture end"}}})
+				if ending == "RPC failure" {
+					body = append(body, e2bTestEnvelope(2, map[string]any{"error": map[string]any{"code": "internal", "message": "fixture RPC failure"}})...)
+				}
+				if ending == "truncated" {
+					body = append(body, 0)
+				}
+				var reader io.Reader = bytes.NewReader(body)
+				if ending == "read failure" {
+					reader = io.MultiReader(reader, iotest.ErrReader(readFailure))
+				}
+				var diagnostic bytes.Buffer
+				got, err := parseE2BProcessStream(reader, io.Discard, &diagnostic)
+				want := code
+				if ending != "clean" {
+					want = 1
+				}
+				if got != want || (err != nil) != (ending != "clean") || diagnostic.String() != "fixture end\n" {
+					t.Fatalf("code=%d err=%v diagnostic=%q", got, err, diagnostic.String())
+				}
+				if ending == "RPC failure" && !strings.Contains(err.Error(), "fixture RPC failure") {
+					t.Fatalf("did not drain RPC error: %v", err)
+				}
+				if ending == "read failure" && !errors.Is(err, readFailure) {
+					t.Fatalf("did not preserve later read error: %v", err)
+				}
+				if ending == "truncated" && !errors.Is(err, io.ErrUnexpectedEOF) {
+					t.Fatalf("did not read later frame: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestE2BProcessEndDoesNotUseStatusAsDiagnostic(t *testing.T) {
+	var diagnostic bytes.Buffer
+	code, err := interpretE2BProcessEnd(shared.EnvdProcessEnd{ExitCode: -1, Status: "fixture status"}, &diagnostic)
+	if code != -1 || err != nil || diagnostic.Len() != 0 {
+		t.Fatalf("code=%d err=%v diagnostic=%q", code, err, diagnostic.String())
 	}
 }

--- a/internal/providers/e2b/client.go
+++ b/internal/providers/e2b/client.go
@@ -3,8 +3,6 @@ package e2b
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -246,8 +244,8 @@ func (c *e2bClient) StartProcess(ctx context.Context, session e2bSession, req e2
 		HTTPClient:     c.dataPlaneHTTPClient(),
 		SetHeaders:     func(httpReq *http.Request) { c.setEnvdHeaders(httpReq, session) },
 		RedirectError:  e2bRedirectError,
-		EncodeEnvelope: encodeConnectJSONEnvelope,
-		ParseStream:    parseE2BProcessStream,
+		Provider:       "e2b",
+		InterpretEnd:   interpretE2BProcessEnd,
 		SummarizeError: summarizeJSON,
 		APIError: func(statusCode int, status, body string) error {
 			return &e2bAPIError{StatusCode: statusCode, Status: status, Body: body}
@@ -336,113 +334,9 @@ func (c *e2bClient) dataPlaneHTTPClient() *http.Client {
 	return &http.Client{Timeout: 0}
 }
 
-type e2bStartResponse struct {
-	Event struct {
-		Start *struct {
-			PID uint32 `json:"pid"`
-		} `json:"start,omitempty"`
-		Data *struct {
-			Stdout string `json:"stdout,omitempty"`
-			Stderr string `json:"stderr,omitempty"`
-			PTY    string `json:"pty,omitempty"`
-		} `json:"data,omitempty"`
-		End *struct {
-			ExitCode int    `json:"exitCode"`
-			Exited   bool   `json:"exited"`
-			Status   string `json:"status"`
-			Error    string `json:"error,omitempty"`
-		} `json:"end,omitempty"`
-		Keepalive map[string]any `json:"keepalive,omitempty"`
-	} `json:"event"`
-}
-
-type e2bEndStream struct {
-	Error *struct {
-		Code    string `json:"code"`
-		Message string `json:"message"`
-	} `json:"error,omitempty"`
-}
-
-func encodeConnectJSONEnvelope(v any) ([]byte, error) {
-	data, err := json.Marshal(v)
-	if err != nil {
-		return nil, err
+func interpretE2BProcessEnd(end shared.EnvdProcessEnd, stderr io.Writer, secrets ...string) (int, error) {
+	if !end.Exited && end.Error != "" {
+		fmt.Fprintln(stderr, shared.RedactErrorSecrets(end.Error, secrets...))
 	}
-	var out bytes.Buffer
-	out.WriteByte(0)
-	var size [4]byte
-	binary.BigEndian.PutUint32(size[:], uint32(len(data)))
-	out.Write(size[:])
-	out.Write(data)
-	return out.Bytes(), nil
-}
-
-func parseE2BProcessStream(r io.Reader, stdout, stderr io.Writer, secrets ...string) (int, error) {
-	exitCode := 0
-	seenEnd := false
-	for {
-		var header [5]byte
-		if _, err := io.ReadFull(r, header[:]); err != nil {
-			if err == io.EOF {
-				break
-			}
-			return 1, err
-		}
-		flags := header[0]
-		size := binary.BigEndian.Uint32(header[1:])
-		if flags&1 != 0 {
-			return 1, fmt.Errorf("compressed connect envelopes are not supported")
-		}
-		data := make([]byte, size)
-		if _, err := io.ReadFull(r, data); err != nil {
-			return 1, err
-		}
-		if flags&2 != 0 {
-			var end e2bEndStream
-			if len(data) > 0 {
-				if err := json.Unmarshal(data, &end); err != nil {
-					return 1, err
-				}
-			}
-			if end.Error != nil {
-				return 1, errors.New(shared.RedactErrorSecrets(end.Error.Code+": "+end.Error.Message, secrets...))
-			}
-			break
-		}
-		var event e2bStartResponse
-		if err := json.Unmarshal(data, &event); err != nil {
-			return 1, err
-		}
-		if event.Event.Data != nil {
-			if err := writeBase64(event.Event.Data.Stdout, stdout); err != nil {
-				return 1, err
-			}
-			if err := writeBase64(event.Event.Data.Stderr, stderr); err != nil {
-				return 1, err
-			}
-		}
-		if event.Event.End != nil {
-			exitCode = event.Event.End.ExitCode
-			seenEnd = true
-			if !event.Event.End.Exited && event.Event.End.Error != "" {
-				fmt.Fprintln(stderr, shared.RedactErrorSecrets(event.Event.End.Error, secrets...))
-			}
-		}
-	}
-	if !seenEnd {
-		return 1, fmt.Errorf("e2b process stream ended without end event")
-	}
-	return exitCode, nil
-}
-
-func writeBase64(value string, w io.Writer) error {
-	if value == "" {
-		return nil
-	}
-	data, err := base64.StdEncoding.DecodeString(value)
-	if err != nil {
-		return err
-	}
-	_, err = w.Write(data)
-	return err
+	return end.ExitCode, nil
 }

--- a/internal/providers/shared/envd.go
+++ b/internal/providers/shared/envd.go
@@ -80,20 +80,22 @@ func UploadEnvdFile(ctx context.Context, upload EnvdUploadFileRequest) error {
 }
 
 type EnvdProcessRequest struct {
-	Endpoint       string
-	Command        string
-	CWD            string
-	Env            map[string]string
-	User           string
-	Timeout        time.Duration
-	Stdout         io.Writer
-	Stderr         io.Writer
-	AccessToken    string
-	HTTPClient     *http.Client
-	SetHeaders     func(*http.Request)
-	RedirectError  func(*url.URL) error
-	EncodeEnvelope func(any) ([]byte, error)
-	ParseStream    func(io.Reader, io.Writer, io.Writer, ...string) (int, error)
+	Provider      string
+	Endpoint      string
+	Command       string
+	CWD           string
+	Env           map[string]string
+	User          string
+	Timeout       time.Duration
+	Stdout        io.Writer
+	Stderr        io.Writer
+	AccessToken   string
+	HTTPClient    *http.Client
+	SetHeaders    func(*http.Request)
+	RedirectError func(*url.URL) error
+	// InterpretEnd retains the provider's completion policy. A returned error
+	// stops decoding immediately with that code; nil continues the RPC stream.
+	InterpretEnd   func(EnvdProcessEnd, io.Writer, ...string) (int, error)
 	SummarizeError func([]byte) string
 	APIError       func(int, string, string) error
 }
@@ -118,7 +120,7 @@ func StartEnvdProcess(ctx context.Context, process EnvdProcessRequest) (int, err
 		},
 		"stdin": false,
 	}
-	body, err := process.EncodeEnvelope(start)
+	body, err := encodeConnectJSONEnvelope(start)
 	if err != nil {
 		return 1, err
 	}
@@ -147,7 +149,7 @@ func StartEnvdProcess(ctx context.Context, process EnvdProcessRequest) (int, err
 		body := RedactErrorSecrets(process.SummarizeError(data), process.AccessToken)
 		return 1, process.APIError(resp.StatusCode, resp.Status, body)
 	}
-	return process.ParseStream(resp.Body, process.Stdout, process.Stderr, process.AccessToken)
+	return ParseEnvdProcessStream(process.Provider, resp.Body, process.Stdout, process.Stderr, process.InterpretEnd, process.AccessToken)
 }
 
 func durationMillisCeil(duration time.Duration) int64 {

--- a/internal/providers/shared/envd_wire.go
+++ b/internal/providers/shared/envd_wire.go
@@ -1,0 +1,126 @@
+package shared
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// EnvdProcessEnd is a process event, not the final Connect RPC envelope.
+type EnvdProcessEnd struct {
+	ExitCode int    `json:"exitCode"`
+	Exited   bool   `json:"exited"`
+	Status   string `json:"status"`
+	Error    string `json:"error"`
+}
+
+type envdProcessResponse struct {
+	Event struct {
+		Start *struct {
+			PID uint32 `json:"pid"`
+		} `json:"start,omitempty"`
+		Data *struct {
+			Stdout string `json:"stdout"`
+			Stderr string `json:"stderr"`
+			PTY    string `json:"pty"`
+		} `json:"data,omitempty"`
+		End       *EnvdProcessEnd `json:"end,omitempty"`
+		Keepalive map[string]any  `json:"keepalive,omitempty"`
+	} `json:"event"`
+}
+
+func encodeConnectJSONEnvelope(v any) ([]byte, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var out bytes.Buffer
+	out.WriteByte(0)
+	var size [4]byte
+	binary.BigEndian.PutUint32(size[:], uint32(len(data)))
+	out.Write(size[:])
+	out.Write(data)
+	return out.Bytes(), nil
+}
+
+// ParseEnvdProcessStream owns wire decoding and delivery. An interpreter error
+// stops at that process end with its code; otherwise later RPC/read errors win.
+func ParseEnvdProcessStream(provider string, r io.Reader, stdout, stderr io.Writer, interpretEnd func(EnvdProcessEnd, io.Writer, ...string) (int, error), secrets ...string) (int, error) {
+	exitCode := 0
+	seenEnd := false
+	for {
+		var header [5]byte
+		if _, err := io.ReadFull(r, header[:]); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return 1, err
+		}
+		flags := header[0]
+		size := binary.BigEndian.Uint32(header[1:])
+		if flags&1 != 0 {
+			return 1, fmt.Errorf("compressed connect envelopes are not supported")
+		}
+		data := make([]byte, size)
+		if _, err := io.ReadFull(r, data); err != nil {
+			return 1, err
+		}
+		if flags&2 != 0 {
+			var end struct {
+				Error *struct {
+					Code    string `json:"code"`
+					Message string `json:"message"`
+				} `json:"error,omitempty"`
+			}
+			if len(data) > 0 {
+				if err := json.Unmarshal(data, &end); err != nil {
+					return 1, err
+				}
+			}
+			if end.Error != nil {
+				return 1, errors.New(RedactErrorSecrets(end.Error.Code+": "+end.Error.Message, secrets...))
+			}
+			break
+		}
+		var event envdProcessResponse
+		if err := json.Unmarshal(data, &event); err != nil {
+			return 1, err
+		}
+		if event.Event.Data != nil {
+			if err := writeEnvdBase64(event.Event.Data.Stdout, stdout); err != nil {
+				return 1, err
+			}
+			if err := writeEnvdBase64(event.Event.Data.Stderr, stderr); err != nil {
+				return 1, err
+			}
+		}
+		if event.Event.End != nil {
+			code, err := interpretEnd(*event.Event.End, stderr, secrets...)
+			exitCode = code
+			seenEnd = true
+			if err != nil {
+				return code, err
+			}
+		}
+	}
+	if !seenEnd {
+		return 1, fmt.Errorf("%s process stream ended without end event", provider)
+	}
+	return exitCode, nil
+}
+
+func writeEnvdBase64(value string, w io.Writer) error {
+	if value == "" {
+		return nil
+	}
+	data, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}

--- a/internal/providers/shared/envd_wire_test.go
+++ b/internal/providers/shared/envd_wire_test.go
@@ -1,0 +1,161 @@
+package shared
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"testing/iotest"
+)
+
+func TestEncodeConnectJSONEnvelope(t *testing.T) {
+	got, err := encodeConnectJSONEnvelope(map[string]string{"command": "ok"})
+	want := append([]byte{0, 0, 0, 0, 16}, []byte(`{"command":"ok"}`)...)
+	if err != nil || !bytes.Equal(got, want) {
+		t.Fatalf("frame=%q err=%v, want %q", got, err, want)
+	}
+	_, err = encodeConnectJSONEnvelope(make(chan int))
+	var unsupported *json.UnsupportedTypeError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("marshal error=%v", err)
+	}
+}
+
+func TestEnvdProcessStreamDelivery(t *testing.T) {
+	for _, code := range []int{0, 7, -1, 137} {
+		for _, chunked := range []bool{false, true} {
+			t.Run(fmt.Sprintf("code=%d/chunked=%t", code, chunked), func(t *testing.T) {
+				body := bytes.Join([][]byte{
+					envdTestEnvelope(t, 0, map[string]any{"event": map[string]any{"start": map[string]any{"pid": 42}}}),
+					envdTestEnvelope(t, 0, map[string]any{"event": map[string]any{"data": map[string]any{"stdout": "aGU=", "stderr": "d2E="}}}),
+					envdTestEnvelope(t, 0, map[string]any{"event": map[string]any{"data": map[string]any{"stdout": "bGxv"}}}),
+					envdTestEnvelope(t, 0, map[string]any{"event": map[string]any{"data": map[string]any{"stderr": "cm4="}}}),
+					envdTestEnvelope(t, 0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": code, "exited": true}}}),
+					envdTestEnvelope(t, 2, map[string]any{}),
+				}, nil)
+				var reader io.Reader = bytes.NewReader(body)
+				if chunked {
+					reader = iotest.OneByteReader(reader)
+				}
+				var stdout, stderr bytes.Buffer
+				endCalls := 0
+				got, err := ParseEnvdProcessStream("fixture", reader, &stdout, &stderr, func(end EnvdProcessEnd, _ io.Writer, _ ...string) (int, error) {
+					endCalls++
+					if end != (EnvdProcessEnd{ExitCode: code, Exited: true}) {
+						t.Fatalf("end=%+v", end)
+					}
+					return end.ExitCode, nil
+				})
+				if got != code || err != nil || endCalls != 1 || stdout.String() != "hello" || stderr.String() != "warn" {
+					t.Fatalf("code=%d err=%v ends=%d stdout=%q stderr=%q", got, err, endCalls, stdout.String(), stderr.String())
+				}
+			})
+		}
+	}
+}
+
+func TestEnvdProcessStreamNormalEndAndLaterFailure(t *testing.T) {
+	readFailure := errors.New("fixture read failed")
+	for _, code := range []int{0, 7, -1, 137} {
+		for _, ending := range []string{"EOF", "RPC failure", "read failure", "truncated"} {
+			t.Run(fmt.Sprintf("code=%d/%s", code, ending), func(t *testing.T) {
+				body := envdTestEnvelope(t, 0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": code, "exited": true}}})
+				if ending == "RPC failure" {
+					body = append(body, envdTestEnvelope(t, 2, map[string]any{"error": map[string]any{"code": "internal", "message": "fixture RPC failure"}})...)
+				}
+				if ending == "truncated" {
+					body = append(body, 0)
+				}
+				var reader io.Reader = bytes.NewReader(body)
+				if ending == "read failure" {
+					reader = io.MultiReader(reader, iotest.ErrReader(readFailure))
+				}
+				got, err := ParseEnvdProcessStream("fixture", reader, io.Discard, io.Discard, envdTestEndCode)
+				if ending == "EOF" {
+					if got != code || err != nil {
+						t.Fatalf("clean EOF code=%d err=%v", got, err)
+					}
+					return
+				}
+				if got != 1 || err == nil {
+					t.Fatalf("later failure lost precedence: code=%d err=%v", got, err)
+				}
+				if ending == "RPC failure" && !strings.Contains(err.Error(), "fixture RPC failure") {
+					t.Fatalf("RPC error=%v", err)
+				}
+				if ending == "read failure" && !errors.Is(err, readFailure) {
+					t.Fatalf("read error=%v", err)
+				}
+				if ending == "truncated" && !errors.Is(err, io.ErrUnexpectedEOF) {
+					t.Fatalf("truncated frame error=%v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestEnvdProcessStreamWriterFailure(t *testing.T) {
+	writeFailure := errors.New("fixture output write failed")
+	for _, stream := range []string{"stdout", "stderr"} {
+		t.Run(stream, func(t *testing.T) {
+			body := append(envdTestEnvelope(t, 0, map[string]any{"event": map[string]any{"data": map[string]any{stream: "b3V0cHV0"}}}), envdTestEnvelope(t, 0, map[string]any{"event": map[string]any{"end": map[string]any{"exited": true}}})...)
+			var stdout, stderr io.Writer = io.Discard, io.Discard
+			if stream == "stdout" {
+				stdout = envdWireFailureWriter{writeFailure}
+			} else {
+				stderr = envdWireFailureWriter{writeFailure}
+			}
+			endCalled := false
+			code, err := ParseEnvdProcessStream("fixture", bytes.NewReader(body), stdout, stderr, func(EnvdProcessEnd, io.Writer, ...string) (int, error) { endCalled = true; return 0, nil })
+			if code != 1 || !errors.Is(err, writeFailure) || endCalled {
+				t.Fatalf("code=%d err=%v end=%t", code, err, endCalled)
+			}
+		})
+	}
+}
+
+func TestEnvdProcessStreamRequiresProcessEnd(t *testing.T) {
+	for _, trailer := range []bool{false, true} {
+		t.Run(fmt.Sprintf("RPC trailer=%t", trailer), func(t *testing.T) {
+			body := envdTestEnvelope(t, 0, map[string]any{"event": map[string]any{"data": map[string]any{"stdout": "cGFydGlhbA=="}}})
+			if trailer {
+				body = append(body, envdTestEnvelope(t, 2, map[string]any{})...)
+			}
+			var stdout bytes.Buffer
+			code, err := ParseEnvdProcessStream("fixture", bytes.NewReader(body), &stdout, io.Discard, envdTestEndCode)
+			if code != 1 || err == nil || err.Error() != "fixture process stream ended without end event" || stdout.String() != "partial" {
+				t.Fatalf("code=%d err=%v stdout=%q", code, err, stdout.String())
+			}
+		})
+	}
+}
+
+func TestEnvdProcessStreamRedactsRPCError(t *testing.T) {
+	const secret = "envd-stream-secret"
+	body := envdTestEnvelope(t, 2, map[string]any{"error": map[string]any{"code": "unauthorized", "message": "Bearer " + secret + " quota exceeded"}})
+	code, err := ParseEnvdProcessStream("fixture", bytes.NewReader(body), io.Discard, io.Discard, envdTestEndCode, secret)
+	if code != 1 || err == nil || strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[redacted]") || !strings.Contains(err.Error(), "quota exceeded") {
+		t.Fatalf("code=%d err=%v", code, err)
+	}
+}
+
+func envdTestEnvelope(t *testing.T, flags byte, value any) []byte {
+	t.Helper()
+	frame, err := encodeConnectJSONEnvelope(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frame[0] = flags
+	return frame
+}
+
+func envdTestEndCode(end EnvdProcessEnd, _ io.Writer, _ ...string) (int, error) {
+	return end.ExitCode, nil
+}
+
+type envdWireFailureWriter struct{ err error }
+
+func (w envdWireFailureWriter) Write([]byte) (int, error) { return 0, w.err }


### PR DESCRIPTION
## Shared wire format, separate provider policy

E2B and CubeSandbox already shared the envd HTTP request layer, but each still maintained its own framing loop, JSON envelope structures, encoder, RPC-error handling, and base64 output delivery. Move those mechanics into the existing shared envd owner and remove both duplicate implementations, along with the non-variable encoder and whole-parser callbacks.

This removes 83 production lines. The remaining provider hook interprets a decoded process-end event: E2B prints its existing abnormal-end diagnostic and continues reading; CubeSandbox returns immediately with its existing signed code, zero-to-one normalization, and observed-process-end marker. Later RPC/read errors after a normal end retain their existing precedence. No new EOF/trailer, frame-size, routing, authentication, claim, or lifecycle policy is introduced.

Common codec tests now live once in the shared package. Provider tests retain only their distinct end interpretation and diagnostic precedence. Old parser names exist only as small test adapters; no unused production compatibility wrappers remain. Provider docs describe the ownership boundary. This is a behavior-preserving internal refactor, not a new feature or bugfix, so there is no user-visible changelog entry.

## Completed verification

- Final Go 1.26.5 package races passed: shared 2.370s, E2B 6.665s, CubeSandbox 4.410s. Relevant vet and diff checks passed.
- Characterization before extraction covered normal and signed exits, ordinary chunked reads, output delivery, writer errors, missing end events, later RPC/read errors, and each provider's different abnormal-end behavior. Those invariants are retained under the new test owners; the old test-name count is not presented as a current count.
- Identical strict-loopback HTTP/Connect fixtures exercised the compiled production backend/client with real Bash workloads. Fresh baseline and candidate runs passed all 14 paired cases, preserving output, codes, request/cleanup counts, non-kept sessions, and absence of fixture claims. This is not a full CLI or hosted-provider proof. Protocol-error cases are separate bounded Go controls, not induced cloud failures.
- Independent Codex review of the complete final candidate returned no accepted P0 findings. This is priority-scoped review, not an all-priority correctness certificate.
- Provider documentation is unchanged from its passing documentation build. The final test-layout cleanup changed no production or documentation bytes. Its initial unused-test-import build error is preserved as a failed qualification attempt; imports were corrected without relaxing assertions.

## Hosted E2B qualification completed

The final combined-tree CLI (`38ddb111`, source head `0c4f676e` plus main `aad75aed`; SHA256 `36bbf38d18b85c1449bf6b39c53328ac3dcb37e566a5f052c95af64fda03adfa`) ran against the canonical hosted E2B service. One `base` sandbox was created with a requested five-minute TTL. The same bound lease handled both ordinary workloads; no keys were forwarded to those workloads.

| Actual CLI operation | Exit | Observed result |
| --- | ---: | --- |
| Warmup | 0 | Bound one native sandbox and local claim |
| Status with 30-second wait limit | 0 | Matching native identity, running and ready |
| Reused no-sync command | 0 | Distinct expected stdout/stderr markers; succeeded timing |
| Reused ordinary nonzero command | 7 | Expected marker; failed timing classified command-exit |
| Normal Stop | 0 | Release completed and claim removed |
| Subsequent exact-native-ID lookup | 1 | Provider GET returned HTTP 404 |

The service's 404 response retains its normal “does not exist or no access” wording; it is recorded following successful Stop with the same credential, not rewritten into stronger API semantics. Task state, credential environment/window, and all local children were cleaned up. There was no second allocation, create retry, or reclaim. The earlier read-only Doctor's failed config check remains separate and was not relabeled; its precise cause was not captured. This live fixture explicitly used a 0600 config.

The final clean merge target on main `aad75aed` is `38ddb111`. The nine-file codec patch is unchanged, and the incoming SSH-readiness fix is preserved. All 2,235 source entries and modes were checked, and the combined-target E2B/Cube/shared races and vet passed. Because that incoming Go change altered the executable, a fresh hosted smoke was run on this exact combined build. The earlier `0c4f676e` hosted pass remains historical; no binary equivalence is claimed between the two builds.

## Evidence scope and maintainer decision

Hosted evidence covers the candidate E2B CLI and normal envd output/exit handling. It does not claim Cube hosting, upload qualification, a hosted baseline comparison, or cloud fault injection. Cube's routing and lifecycle are unchanged; its distinct completion policy is covered by its local tests and paired compiled-client/loopback/native-shell evidence. A new Cube deployment is not being invented to test this shared-code extraction.

The maintainer accepts this combined evidence for the behavior-preserving refactor. The separate automated bot review did not run because its input-safety gate rejected material; no bot verdict, retry, or qualification is claimed. Independent pre-commit Codex review and the original failed qualification records remain intact. No access grants, credential values, release records, or fleet deployments change in this PR.
