### PR TITLE
fix(coordinator): avoid cleanup, heartbeat, and control queue stalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Stop SSH readiness probes and backoff at the shared deadline, reporting the active probe with authentication unknown instead of mislabeling expired checks as authentication failures. [PR 1949](https://github.com/openclaw/crabbox/pull/1949). Thanks @vincentkoc.
-- Keep AWS provider deletion and unrelated heartbeat alarm scans out of the shared ingress queue while preserving claim-validated cleanup commits, recorded reconciliation deadlines, and earlier alarms. [PR 1951](https://github.com/openclaw/crabbox/pull/1951).
+- Keep AWS deletion and unrelated heartbeat alarm scans out of the ingress queue, and admit control WebSockets independently of lifecycle work, while preserving cleanup claims, alarm deadlines, authentication, and message serialization. [PR 1951](https://github.com/openclaw/crabbox/pull/1951).
 
 - Reuse verified SSH endpoints within an operation, preserving advertised fallbacks when switching hosts or ports and avoiding redundant login probes across direct, proxy, and WSL execution. [PR 1941](https://github.com/openclaw/crabbox/pull/1941).
 - Report image qualification reaping as idle after clean teardown, while preserving failed recovery evidence and checking transient controller ownership before cleanup. [PR 1942](https://github.com/openclaw/crabbox/pull/1942). Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Stop SSH readiness probes and backoff at the shared deadline, reporting the active probe with authentication unknown instead of mislabeling expired checks as authentication failures. [PR 1949](https://github.com/openclaw/crabbox/pull/1949). Thanks @vincentkoc.
+- Keep AWS provider deletion outside the shared ingress queue while retaining serialized, claim-validated cleanup commits, so slow expiry or cancellation cleanup does not block another lease’s SSH access preparation.
+
 - Reuse verified SSH endpoints within an operation, preserving advertised fallbacks when switching hosts or ports and avoiding redundant login probes across direct, proxy, and WSL execution. [PR 1941](https://github.com/openclaw/crabbox/pull/1941).
 - Report image qualification reaping as idle after clean teardown, while preserving failed recovery evidence and checking transient controller ownership before cleanup. [PR 1942](https://github.com/openclaw/crabbox/pull/1942). Thanks @vincentkoc.
 - Add `crabbox bench check` to enforce sample, failure, and p95 runner timing policy across every matched local benchmark group. [PR 1899](https://github.com/openclaw/crabbox/pull/1899). Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Stop SSH readiness probes and backoff at the shared deadline, reporting the active probe with authentication unknown instead of mislabeling expired checks as authentication failures. [PR 1949](https://github.com/openclaw/crabbox/pull/1949). Thanks @vincentkoc.
-- Keep AWS provider deletion outside the shared ingress queue while retaining serialized, claim-validated cleanup commits, so slow expiry or cancellation cleanup does not block another lease’s SSH access preparation. [PR 1951](https://github.com/openclaw/crabbox/pull/1951).
+- Keep AWS provider deletion and unrelated heartbeat alarm scans out of the shared ingress queue while preserving claim-validated cleanup commits, recorded reconciliation deadlines, and earlier alarms. [PR 1951](https://github.com/openclaw/crabbox/pull/1951).
 
 - Reuse verified SSH endpoints within an operation, preserving advertised fallbacks when switching hosts or ports and avoiding redundant login probes across direct, proxy, and WSL execution. [PR 1941](https://github.com/openclaw/crabbox/pull/1941).
 - Report image qualification reaping as idle after clean teardown, while preserving failed recovery evidence and checking transient controller ownership before cleanup. [PR 1942](https://github.com/openclaw/crabbox/pull/1942). Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Stop SSH readiness probes and backoff at the shared deadline, reporting the active probe with authentication unknown instead of mislabeling expired checks as authentication failures. [PR 1949](https://github.com/openclaw/crabbox/pull/1949). Thanks @vincentkoc.
-- Keep AWS provider deletion outside the shared ingress queue while retaining serialized, claim-validated cleanup commits, so slow expiry or cancellation cleanup does not block another lease’s SSH access preparation.
+- Keep AWS provider deletion outside the shared ingress queue while retaining serialized, claim-validated cleanup commits, so slow expiry or cancellation cleanup does not block another lease’s SSH access preparation. [PR 1951](https://github.com/openclaw/crabbox/pull/1951).
 
 - Reuse verified SSH endpoints within an operation, preserving advertised fallbacks when switching hosts or ports and avoiding redundant login probes across direct, proxy, and WSL execution. [PR 1941](https://github.com/openclaw/crabbox/pull/1941).
 - Report image qualification reaping as idle after clean teardown, while preserving failed recovery evidence and checking transient controller ownership before cleanup. [PR 1942](https://github.com/openclaw/crabbox/pull/1942). Thanks @vincentkoc.

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -535,7 +535,9 @@ directly against the runner over SSH:
 
 Read back with `GET /v1/runs`, `/v1/runs/{id}`, `/logs`, and `/events`. The
 `/v1/control` websocket lets clients subscribe to live run events and send lease
-heartbeats. A run keeps its initiating actor in `owner`/`org` plus every backing
+heartbeats. Control socket admission does not wait for unrelated lifecycle work;
+authentication, restored bridge checks, and per-message lifecycle fences still
+apply. A run keeps its initiating actor in `owner`/`org` plus every backing
 lease identity used by replacement flows. Each backing lease owner can read and
 subscribe for audit purposes, while only the actor or an admin can append
 events or telemetry and finish the run.

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -497,6 +497,9 @@ retries preserve that wakeup, including after coordinator reconstruction.
 An already-due stored alarm time is rearmed at the earlier of that time and the
 requested deadline: a consumed runtime job can leave its timestamp behind.
 An earlier future alarm is preserved without another scheduling write.
+AWS heartbeat access refresh also arms its recorded ingress reconciliation at the
+existing one-second minimum delay instead of rescanning unrelated fleet metadata
+while holding the ingress lock. Earlier alarms remain scheduled.
 Alarm storage errors still fail the request and do not certify cleanup success.
 The existing full scheduler shares the lifecycle mutex with this arming, so a
 scan cannot race an acknowledgement's earlier wakeup. Full maintenance scans,

--- a/docs/features/lifecycle-cleanup.md
+++ b/docs/features/lifecycle-cleanup.md
@@ -190,10 +190,13 @@ artifacts. Local failure preserves the confirmed remote outcome and local claim;
 a fresh confirmed-deletion lookup retries only local cleanup, not provider deletion.
 
 For public AWS leases, shared security-group writes remain serialized with release
-and authoritative ingress reconciliation. Image selection, instance creation and
-network-address readiness do not hold that fence, so a slow new instance does
-not delay release of another lease. Every regional ingress attempt rechecks the
-creating lease and derives access from current lease records before writing.
+state changes and authoritative ingress reconciliation. Image selection, instance
+creation, network readiness and provider deletion do not hold that fence, so a
+slow instance or termination does not block another lease's ingress work. Cleanup
+still waits for its provider result, then reacquires the ingress fence and
+revalidates its exact claim before publishing success or failure. Every regional
+ingress attempt rechecks the creating lease and derives access from current lease
+records before writing.
 
 If a create attempt is canceled or its lease is released during AWS region
 preparation, the in-flight create returns `409 create_canceled` with the reason.

--- a/worker/src/coordinator-runtime.ts
+++ b/worker/src/coordinator-runtime.ts
@@ -113,6 +113,10 @@ export function coordinatorRequestQueue(request: Request): CoordinatorRequestQue
   if (path[0] === "v1" && path[1] === "workspaces") {
     return "direct";
   }
+  if (method === "GET" && path.join("/") === "v1/control") {
+    // Admission only binds this socket; control messages retain their lifecycle fences.
+    return "direct";
+  }
   if (method === "GET" && path.join("/") === "v1/native-vnc/handoff") {
     return "direct";
   }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -3546,12 +3546,7 @@ export class FleetCoordinator {
       released = cancellation.lease;
       await this.closeLeaseBridges(cancellation.lease.id, 1008, "lease ended");
       if ("cleanup" in cancellation && cancellation.cleanup) {
-        const cleanup = () => this.finishLeaseCleanupClaim(cancellation.cleanup!);
-        released =
-          managedLeaseProvider(cancellation.cleanup.lease) === "aws" &&
-          !cancellation.cleanup.lease.network?.awsPrivate
-            ? await this.withAWSIngressOperationLock(cleanup)
-            : await cleanup();
+        released = await this.finishLeaseCleanupClaim(cancellation.cleanup);
       }
     }
     if (!released?.provisioningResourceMayExist && !released?.cleanupStartedAt) {
@@ -16840,59 +16835,52 @@ export class FleetCoordinator {
     });
     await Promise.all(
       claims.map(async ({ claim, lease }) => {
-        const cleanup = async () => {
-          let failure: { error: unknown; message: string } | undefined;
-          try {
-            await this.deleteLeaseServer(lease);
-          } catch (error) {
-            failure = { error, message: coordinatorErrorMessage(this.env, error) };
-          }
-          await this.state.runExclusive(async () => {
-            const current = await this.getLease(lease.id);
-            if (
-              !current ||
-              current.cleanupStartedAt !== claim ||
-              !sameLeaseCleanupClaim(current, lease) ||
-              (await provisioningOwnsLease(this.state.storage, lease.id))
-            ) {
-              return;
-            }
-            const nowDate = new Date();
-            const nowISO = nowDate.toISOString();
-            if (failure) {
-              recordLeaseCleanupFailure(current, failure.error, failure.message, nowISO);
-              await this.putLease(current);
-              console.warn(
-                `lease cleanup failed lease=${current.id} provider=${current.provider} cloud=${current.cloudID}: ${failure.message}`,
-              );
-              return;
-            }
-            current.state = leaseIsLive(current) ? "expired" : current.state;
-            current.updatedAt = nowISO;
-            current.endedAt = nowISO;
-            if (current.provisioningResourceMayExist) {
-              if (!current.failureError && current.cleanupError) {
-                current.failureError = current.cleanupError;
-              }
-            }
-            clearProvisioningRecoveryMetadata(current);
-            delete current.releaseDeletesServer;
-            clearLeaseCleanupMetadata(current);
-            delete current.providerKeyCleanupPending;
-            delete current.providerKeyCleanupID;
-            delete current.cleanupStartedAt;
-            delete current.cleanupClaimExpiresAt;
-            completeLeaseProviderCleanup(current, nowISO);
-            await this.putLease(current);
-            await this.clearWorkspaceReleaseError(current);
-            await this.markAWSIngressReconcilePending(current);
-          });
-        };
-        if (managedLeaseProvider(lease) === "aws" && !lease.network?.awsPrivate) {
-          await this.withAWSIngressOperationLock(cleanup);
-        } else {
-          await cleanup();
+        let failure: { error: unknown; message: string } | undefined;
+        try {
+          await this.deleteLeaseServer(lease);
+        } catch (error) {
+          failure = { error, message: coordinatorErrorMessage(this.env, error) };
         }
+        await this.withLeaseCleanupState(lease, async () => {
+          const current = await this.getLease(lease.id);
+          if (
+            !current ||
+            current.cleanupStartedAt !== claim ||
+            !sameLeaseCleanupClaim(current, lease) ||
+            (await provisioningOwnsLease(this.state.storage, lease.id))
+          ) {
+            return;
+          }
+          const nowDate = new Date();
+          const nowISO = nowDate.toISOString();
+          if (failure) {
+            recordLeaseCleanupFailure(current, failure.error, failure.message, nowISO);
+            await this.putLease(current);
+            console.warn(
+              `lease cleanup failed lease=${current.id} provider=${current.provider} cloud=${current.cloudID}: ${failure.message}`,
+            );
+            return;
+          }
+          current.state = leaseIsLive(current) ? "expired" : current.state;
+          current.updatedAt = nowISO;
+          current.endedAt = nowISO;
+          if (current.provisioningResourceMayExist) {
+            if (!current.failureError && current.cleanupError) {
+              current.failureError = current.cleanupError;
+            }
+          }
+          clearProvisioningRecoveryMetadata(current);
+          delete current.releaseDeletesServer;
+          clearLeaseCleanupMetadata(current);
+          delete current.providerKeyCleanupPending;
+          delete current.providerKeyCleanupID;
+          delete current.cleanupStartedAt;
+          delete current.cleanupClaimExpiresAt;
+          completeLeaseProviderCleanup(current, nowISO);
+          await this.putLease(current);
+          await this.clearWorkspaceReleaseError(current);
+          await this.markAWSIngressReconcilePending(current);
+        });
       }),
     );
   }
@@ -19290,12 +19278,7 @@ export class FleetCoordinator {
       await this.state.runExclusive(() => this.scheduleAlarm());
       return current;
     }
-    const release = () => this.releaseResolvedLeaseOperation(current, options);
-    return managedLeaseProvider(current) === "aws" &&
-      !current.network?.awsPrivate &&
-      (current.state === "active" || Boolean(current.cloudID))
-      ? this.withAWSIngressOperationLock(release)
-      : release();
+    return this.releaseResolvedLeaseOperation(current, options);
   }
 
   private async markWorkspaceReleaseRequested(lease: LeaseRecord): Promise<void> {
@@ -19329,7 +19312,7 @@ export class FleetCoordinator {
       expectedProvider?: string;
     },
   ): Promise<LeaseRecord> {
-    const preparation = await this.state.runExclusive(async () => {
+    const prepare = async () => {
       const stored = await this.getLease(lease.id);
       if (
         stored &&
@@ -19429,7 +19412,10 @@ export class FleetCoordinator {
         claim: claimed.cleanupStartedAt,
         lease: structuredClone(claimed),
       };
-    });
+    };
+    const preparation = await (lease.state === "active" || lease.cloudID
+      ? this.withLeaseCleanupState(lease, prepare)
+      : this.state.runExclusive(prepare));
     if (preparation.blocked) {
       return preparation.lease;
     }
@@ -19444,6 +19430,15 @@ export class FleetCoordinator {
     });
   }
 
+  // Provider I/O stays outside ingress serialization; state changes still wait for
+  // active ingress writers and revalidate their cleanup claim before committing.
+  private withLeaseCleanupState<T>(lease: LeaseRecord, operation: () => Promise<T>): Promise<T> {
+    const commit = () => this.state.runExclusive(operation);
+    return managedLeaseProvider(lease) === "aws" && !lease.network?.awsPrivate
+      ? this.withAWSIngressOperationLock(commit)
+      : commit();
+  }
+
   private async finishLeaseCleanupClaim(preparation: {
     lease: LeaseRecord;
     claim: string;
@@ -19454,7 +19449,7 @@ export class FleetCoordinator {
     try {
       await this.deleteLeaseServer(preparation.lease);
     } catch (error) {
-      await this.state.runExclusive(async () => {
+      await this.withLeaseCleanupState(preparation.lease, async () => {
         const current = await this.getLease(preparation.lease.id);
         if (
           !current ||
@@ -19476,7 +19471,7 @@ export class FleetCoordinator {
       });
       throw error;
     }
-    return await this.state.runExclusive(async () => {
+    return await this.withLeaseCleanupState(preparation.lease, async () => {
       const current = await this.getLease(preparation.lease.id);
       if (
         !current ||

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -485,6 +485,7 @@ const azureOrphanSweepFirstAlarmKey = "azure-orphan-sweep:first-alarm";
 const providerReconciliationCandidatePrefix = "provider-reconciliation:";
 const providerReconciliationCircuitPrefix = "provider-reconciliation-circuit:";
 const awsIngressReconcileRecordKey = "aws-ingress-reconcile:pending";
+const awsIngressReconcileMinDelayMs = 1000;
 const azureDeferredCleanupPrefix = "azure-cleanup:";
 const readyPoolPrefix = "ready-pool:";
 const readyPoolDesiredPrefix = "ready-pool-desired:";
@@ -7874,10 +7875,14 @@ export class FleetCoordinator {
         }
         const merged = applyLeaseRecordChanges(latest, snapshot.lease, refreshed);
         await this.putLease(merged);
-        if (managedProvider === "aws") {
+        if (managedProvider === "aws" && leaseHasPublishedAWSAccess(merged)) {
           await this.markAWSIngressReconcilePending(merged);
+          // This write makes ingress reconciliation due. Preserve its scheduling floor
+          // without scanning unrelated fleet state while holding the ingress fence.
+          await this.armAlarmNoLaterThan(Date.now() + awsIngressReconcileMinDelayMs);
+        } else {
+          await this.scheduleAlarm();
         }
-        await this.scheduleAlarm();
         return merged;
       });
     };
@@ -17049,7 +17054,9 @@ export class FleetCoordinator {
     const retryTimes = awsIngressReconcileTargets(record)
       .map((target) => Date.parse(target.retryAt))
       .filter((time) => Number.isFinite(time));
-    return retryTimes.length > 0 ? Math.max(Date.now() + 1000, Math.min(...retryTimes)) : undefined;
+    return retryTimes.length > 0
+      ? Math.max(Date.now() + awsIngressReconcileMinDelayMs, Math.min(...retryTimes))
+      : undefined;
   }
 
   private async markAWSIngressReconcilePending(anchor: LeaseRecord): Promise<void> {

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -562,6 +562,7 @@ describe("coordinator runtimes", () => {
       ["POST", "/v1/workspaces"],
       ["GET", "/v1/workspaces/fleet-is-101"],
       ["DELETE", "/v1/workspaces/fleet-is-101"],
+      ["GET", "/v1/control"],
       ["GET", "/v1/native-vnc/handoff"],
       ["GET", "/v1/leases/cbx_abcdef123456"],
       ["PUT", "/v1/leases/cbx_abcdef123456"],

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -26033,6 +26033,108 @@ describe("fleet lease identity and idle", () => {
     },
   );
 
+  it.each([
+    { mode: "expiry", region: "eu-west-1", group: "sg-shared" },
+    { mode: "cancel", region: "eu-west-1", group: "sg-shared" },
+    { mode: "expiry", region: "us-east-1", group: "sg-other" },
+    { mode: "cancel", region: "us-east-1", group: "sg-other" },
+  ])(
+    "allows ingress during $region $mode deletion but fences its terminal commit",
+    async ({ mode, region, group }) => {
+      const deleteStarted = deferred<void>();
+      const finishDelete = deferred<void>();
+      const finishIngress = deferred<void>();
+      let ingressStarted = false;
+      let providerFinished = false;
+      const fixture = awsIngressTestFleet(async (action) => {
+        if (action === "AuthorizeSecurityGroupIngress") {
+          ingressStarted = true;
+          await finishIngress.promise;
+        }
+        return undefined;
+      });
+      const { storage, activeID, creatingID, fleet, headers } = fixture;
+      const cancelToken = "cat_10000000000000000000000000000000";
+      const generation = "cleanup-ingress-generation";
+      storage.seed(`lease:${activeID}`, {
+        ...storage.value<LeaseRecord>(`lease:${activeID}`)!,
+        region,
+        expiresAt: new Date(Date.now() + (mode === "expiry" ? -1_000 : 60_000)).toISOString(),
+        createAttemptID: cancelToken,
+        createAttemptGeneration: generation,
+        network: {
+          awsSecurityGroupID: group,
+          sshSourceCIDRs: ["198.51.100.10/32"],
+          sshSourceCIDRsComplete: true,
+        },
+      });
+      storage.seed(`create-attempt:${activeID}`, {
+        version: 1,
+        requestedLeaseID: activeID,
+        token: cancelToken,
+        owner: "alice@example.com",
+        org: orgKeyForLabel("example-org"),
+        state: "pending",
+        canonicalLeaseID: activeID,
+        cloudID: "i-active-instance",
+        generation,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+      const deletion = vi
+        .spyOn(AWSProvider.prototype, "releaseLease")
+        .mockImplementation(async () => {
+          deleteStarted.resolve();
+          await finishDelete.promise;
+          providerFinished = true;
+        });
+      const cleanup =
+        mode === "expiry"
+          ? fleet.alarm()
+          : fleet.fetch(
+              request("POST", `/v1/leases/${activeID}/cancel-create`, {
+                headers,
+                body: { createAttemptID: cancelToken },
+              }),
+            );
+      let creating: Promise<Response> | undefined;
+      try {
+        await deleteStarted.promise;
+        creating = fixture.create();
+        await vi.waitFor(() => expect(ingressStarted).toBe(true));
+        expect(providerFinished).toBe(false);
+        finishDelete.resolve();
+        await vi.waitFor(() => expect(providerFinished).toBe(true));
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(storage.value<LeaseRecord>(`lease:${activeID}`)).toMatchObject({
+          state: mode === "expiry" ? "active" : "released",
+          cleanupStartedAt: expect.any(String),
+        });
+        expect(storage.value<LeaseRecord>(`lease:${activeID}`)?.cleanupCompletedAt).toBeUndefined();
+        finishIngress.resolve();
+        expect((await creating).status).toBe(201);
+        const completed = await cleanup;
+        expect(completed instanceof Response ? completed.status : undefined).toBe(
+          mode === "expiry" ? undefined : 200,
+        );
+        expect(storage.value<LeaseRecord>(`lease:${activeID}`)).toMatchObject({
+          state: mode === "expiry" ? "expired" : "released",
+          cleanupCompletedAt: expect.any(String),
+        });
+        expect(storage.value<LeaseRecord>(`lease:${creatingID}`)).toMatchObject({
+          state: "active",
+          network: { sshSourceCIDRs: ["198.51.100.20/32"] },
+        });
+        expect(deletion).toHaveBeenCalledTimes(1);
+      } finally {
+        finishDelete.resolve();
+        finishIngress.resolve();
+        await Promise.allSettled([cleanup, ...(creating ? [creating] : [])]);
+        deletion.mockRestore();
+      }
+    },
+  );
+
   it("releases an unrelated AWS lease while a new instance waits for its address", async () => {
     const waitingForAddress = deferred<void>();
     const addressReady = deferred<ProviderMachine>();

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -47100,6 +47100,68 @@ describe("synthetic acknowledgement reliability", () => {
     },
   );
 
+  it.each([undefined, -100, 500, 60_000])(
+    "arms refreshed AWS ingress without scanning unrelated workspaces (prior alarm offset %s)",
+    async (priorOffset) => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      const storage = new MemoryStorage();
+      const lease = {
+        ...seedLease(storage),
+        provider: "aws" as const,
+        region: "eu-west-1",
+        network: { awsSecurityGroupID: "sg-heartbeat", sshSourceCIDRsComplete: true },
+      };
+      storage.seed(`lease:${lease.id}`, lease);
+      const fleet = testFleet(storage, {
+        aws: fakeProvider(undefined, {
+          provider: "aws",
+          onRefreshLeaseAccess(current, context) {
+            return {
+              ...current,
+              network: { ...current.network, sshSourceCIDRs: context.requestSourceCIDRs },
+            };
+          },
+        }),
+      });
+      await fleet.ready();
+      const now = Date.now();
+      if (priorOffset !== undefined) await alarmRuntime(storage).scheduleAlarm(now + priorOffset);
+      const entered = deferred<void>();
+      const resume = deferred<void>();
+      storage.beforeList = async (options) => {
+        if (options?.prefix === "workspace:") {
+          entered.resolve();
+          await resume.promise;
+        }
+      };
+      const heartbeat = fleet.fetch(
+        request("POST", `/v1/leases/${lease.id}/heartbeat`, {
+          headers: { ...headers, "cf-connecting-ip": "198.51.100.44" },
+        }),
+      );
+      try {
+        expect(
+          await Promise.race([
+            heartbeat.then(() => "acknowledged"),
+            entered.promise.then(() => "unrelated scan blocked"),
+          ]),
+        ).toBe("acknowledged");
+        expect((await heartbeat).status).toBe(200);
+        const pending = storage.value<{ targets: Array<{ anchor: LeaseRecord; retryAt: string }> }>(
+          "aws-ingress-reconcile:pending",
+        );
+        expect(pending?.targets).toHaveLength(1);
+        expect(pending?.targets[0]?.anchor.network?.sshSourceCIDRs).toEqual(["198.51.100.44/32"]);
+        expect(pending?.targets[0]?.retryAt).toBe(new Date(now).toISOString());
+        expect(storage.alarm()).toBe(Math.min(now + 1000, now + (priorOffset ?? 1000)));
+      } finally {
+        resume.resolve();
+        await heartbeat;
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it.each(["workspace:", "lease:"])(
     "keeps run and release progress during repeated heartbeats with slow unrelated %s pages",
     async (prefix) => {

--- a/worker/test/node-runtime.test.ts
+++ b/worker/test/node-runtime.test.ts
@@ -1,9 +1,14 @@
 import { EventEmitter } from "node:events";
 import { readFile } from "node:fs/promises";
+import { createServer } from "node:http";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WebSocket as NodeWebSocket } from "ws";
 
+import { routeCoordinatorRequest } from "../src/coordinator-entry";
 import type { CoordinatorStorageView } from "../src/coordinator-runtime";
+import { FleetCoordinator } from "../src/fleet";
+import type { Env } from "../src/types";
 import { ProvisioningTestStorage } from "./provisioning-fixtures";
 
 type OperationRunner = <T>(callback: () => Promise<T>) => Promise<T>;
@@ -56,7 +61,7 @@ vi.mock("../node/postgres-storage", () => ({
 }));
 
 import { NodeCoordinatorRuntime } from "../node/node-runtime";
-import { AsyncMutex } from "../node/server-support";
+import { AsyncMutex, fleetRequestQueue } from "../node/server-support";
 
 describe("NodeCoordinatorRuntime", () => {
   beforeEach(() => {
@@ -69,6 +74,79 @@ describe("NodeCoordinatorRuntime", () => {
     mocks.storage.list.mockImplementation((options) =>
       storage.list(options as Parameters<CoordinatorStorageView["list"]>[0]),
     );
+  });
+
+  it("accepts a control handshake during unrelated lifecycle work and still queues messages", async () => {
+    const runtime = new NodeCoordinatorRuntime("postgresql://example.invalid/test");
+    const mutex = new AsyncMutex();
+    runtime.setOperationRunner((callback) => mutex.run(callback));
+    const env = {
+      CRABBOX_SHARED_TOKEN: "synthetic-control-token",
+      CRABBOX_SHARED_OWNER: "alice@example.com",
+      CRABBOX_DEFAULT_ORG: "example-org",
+    } as Env;
+    const fleet = new FleetCoordinator(runtime, env);
+    const server = createServer();
+    const upgrades: Promise<unknown>[] = [];
+    server.on("upgrade", (request, socket, head) => {
+      const headers = new Headers();
+      for (let index = 0; index < request.rawHeaders.length; index += 2) {
+        headers.append(request.rawHeaders[index]!, request.rawHeaders[index + 1]!);
+      }
+      const context = { request, socket, head, upgraded: false };
+      upgrades.push(
+        runtime.runWithUpgrade(context, () =>
+          routeCoordinatorRequest(
+            new Request(`http://localhost${request.url}`, { headers }),
+            env,
+            (prepared) =>
+              fleetRequestQueue(prepared) === "direct"
+                ? fleet.fetch(prepared)
+                : mutex.run(() => fleet.fetch(prepared)),
+          ),
+        ),
+      );
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("missing fixture listener");
+    const release = deferred<void>();
+    const entered = deferred<void>();
+    const lifecycle = runtime.runExclusive(async () => {
+      entered.resolve();
+      await release.promise;
+    });
+    await entered.promise;
+    const client = new NodeWebSocket(`ws://127.0.0.1:${address.port}/v1/control`, {
+      headers: { authorization: "Bearer synthetic-control-token" },
+    });
+    const opened = new Promise<void>((resolve, reject) => {
+      client.once("open", resolve);
+      client.once("error", reject);
+    });
+    const messages: unknown[] = [];
+    client.on("message", (data) => messages.push(JSON.parse(data.toString())));
+    try {
+      await vi.waitFor(() =>
+        expect(messages).toEqual([expect.objectContaining({ type: "hello" })]),
+      );
+      client.send(JSON.stringify({ type: "ping" }));
+      const transportPong = new Promise<void>((resolve) => client.once("pong", resolve));
+      client.ping();
+      await transportPong;
+      expect(messages).toHaveLength(1);
+      release.resolve();
+      await lifecycle;
+      await vi.waitFor(() => expect(messages.at(-1)).toEqual({ type: "pong" }));
+    } finally {
+      release.resolve();
+      await lifecycle;
+      await Promise.all(upgrades);
+      await opened;
+      client.terminate();
+      await runtime.stop();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 
   it("allows an active alarm to enqueue one successor", async () => {


### PR DESCRIPTION
## What Problem This Solves

Three unrelated operations could delay lease access or control acknowledgements behind global coordinator queues:

- Provider termination and key cleanup held the shared AWS ingress fence.
- Heartbeat access refresh scanned unrelated fleet metadata after already recording a due ingress reconciliation.
- Control WebSocket admission waited for the lifecycle queue before it could acknowledge the connection.

## Why This Change Was Made

Provider deletion now runs outside the ingress queue. Preparation and terminal success/failure commits still acquire the ingress fence and revalidate the exact durable cleanup claim, resource identity and generation. Cleanup still awaits confirmed provider completion; security-group writes remain serialized and derive access from current authoritative lease records.

For published managed AWS leases, heartbeat access refresh arms the recorded reconciliation through the existing alarm owner. It preserves the one-second scheduling floor, earlier future alarms and rearming of consumed/overdue alarms. Other-provider, private-AWS and unpublished-access cases retain full deadline recomputation.

Control WebSocket admission now uses the direct route shared by the Worker and Node coordinator. Authentication, admin-grant reconciliation and restored-bridge readiness still run. Admission creates only per-connection state; subsequent messages retain their existing current-socket/grant checks and lifecycle serialization. There are no new lock keys, cached permission decisions, timeouts, retries, configuration, schemas or persistent representations.

## Local Evidence

Four before/after concurrency cases cover expiry and cancellation with shared and disjoint ingress targets. They hold provider deletion, prove another ingress operation can proceed, then prove cleanup's terminal commit still waits for an active ingress writer. All promises are joined in the original execution order.

The heartbeat regression holds unrelated workspace metadata I/O and failed before repair because acknowledgement entered that blocked scan. Four candidate cases pass with absent, overdue, earlier-future and later-future alarms, while verifying durable ingress reconciliation and the retained deadline.

A real local HTTP/WebSocket regression sends a valid synthetic client through authentication, the shared request classifier, Node upgrade handling and FleetCoordinator. Before repair the handshake cannot return hello while lifecycle work is held. After repair it returns hello before the held work is released, while an application ping still waits for the lifecycle queue. A protocol ping/pong confirms transport delivery before that assertion; all sockets and operations are joined.

All 2,849 Worker tests pass (three skipped), plus formatting, lint, Worker and Node typechecks, Worker and Node builds, and the docs build. Independent managed P2 review of the full combined range against `b5bd9586fdd9dc9fa580f7a0d9233648e9fd86ef` is clean (confidence 0.96). Exact-head CI [34107531556](https://github.com/openclaw/crabbox/actions/runs/34107531556) passed. The full PR production delta is +6 lines; tests add 243 net lines. The added routing and known-deadline branches reuse existing owners.

## Live Evidence and Remaining Checks

Ordinary native cold and warm checkpoint lifecycles passed on the preceding cleanup-only candidate. Deployed source `828e9cce933f70bc4b14933b6f3becf58587fa81` has byte-identical Worker and deployment inputs to `9610283bdfd3663afb5c0b48462c320a41b31fdd`; both runs recorded no version drift. Both leases reached released/provider-cleanup-complete, their canonical environments were destroyed, attachments were empty, and all 34/32 recorded process identities were joined.

Four subsequent ordinary CLI runs against the `7753a74f54aba66ce39a3a48be2c5d1d61698b7b` coordinator completed their commands, verified terminal receipts and retained history, then confirmed provider cleanup; all command owners joined and operator configuration remained unchanged. These runs were not warning-free: three reported control-heartbeat timeouts and all four reported diagnostic event-append timeouts. The successful receipts establish command and cleanup outcomes; they do not establish successful background heartbeats. Those control warnings prompted the added admission repair.

Final combined head `9407c5b1ca3ecc04eb46b2c967d8d5f9d9a696ca` was deployed by [34107725223](https://github.com/openclaw/crabbox/actions/runs/34107725223) as `3b01354c-c2fe-4de2-a6bb-abacfe48f691`. A fresh AWS lease completed warmup, the supported `crabbox heartbeat --json` command, two ordinary 35-second commands, verified signed receipts and retained history, and canonical release/cleanup-complete. All child owners joined, the SSH control directory was absent, and operator configuration stayed unchanged. The client was b5 main plus only two static success markers: one after successful WebSocket dial and one after the existing accepted-heartbeat checks. Warmup and each command positively recorded both markers; there were zero control-heartbeat or event-append warnings. HTTP fallback does not emit the WebSocket ACK marker. This verifies real control admission and the separate HTTP heartbeat path; it is not an end-to-end speed benchmark.

An earlier normal allocation on this deployment returned Worker error 1101; its lease was fully released. A subsequent normal allocation with live logging succeeded and returned a valid HTTP heartbeat. That harness then stopped for a missing local workload file; file presence/hash validation was moved before allocation, and the final complete run above passed. The original 1101 has no historical exception trace under the available log permission and remains unattributed.

Earlier live ingress waits of 6.562 seconds cold and 41.286 seconds warm had no captured queue holder. They are not attributed to these paths or presented as measured speedups.

## Review Follow-up

The latest review's requested precise live overlap trace remains unverified. The standard CLI exposes pending cleanup state, not an AWS deletion-dispatch timestamp. The concurrency invariant is demonstrated by the local original-order regression, with ordinary supported CLI lifecycle evidence recorded separately.

Run-event append latency remains a named follow-up. Event sequence allocation and event/run writes currently rely on the outer lifecycle queue; simply marking that route direct would make writes race. This PR preserves that serialization.

This follows https://github.com/openclaw/crabbox/pull/1938. Lifecycle/coordinator documentation and the existing changelog entry cover all three changes.
