### PR TITLE
fix: report checkpoint failures before image submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Report producer-confirmed checkpoint non-submission as structured JSON after verified reservation cleanup, without implying that source rollback succeeded.
 - Reuse verified SSH endpoints within an operation, preserving advertised fallbacks when switching hosts or ports and avoiding redundant login probes across direct, proxy, and WSL execution. [PR 1941](https://github.com/openclaw/crabbox/pull/1941).
 - Report image qualification reaping as idle after clean teardown, while preserving failed recovery evidence and checking transient controller ownership before cleanup. [PR 1942](https://github.com/openclaw/crabbox/pull/1942). Thanks @vincentkoc.
 - Add `crabbox bench check` to enforce sample, failure, and p95 runner timing policy across every matched local benchmark group. [PR 1899](https://github.com/openclaw/crabbox/pull/1899). Thanks @vincentkoc.

--- a/docs/commands/checkpoint.md
+++ b/docs/commands/checkpoint.md
@@ -136,6 +136,29 @@ crabbox checkpoint create --id swift-crab --mode native --json
 --discard-failed            Explicitly discard a verified failed capture and retire.
 ```
 
+On success, `--json` prints the checkpoint record. A direct native provider that
+can prove it never attempted image submission may instead return this failure
+object, with a nonzero exit status, after the exact local reservation is removed
+and its absence is verified:
+
+```json
+{
+  "schema": "crabbox.checkpoint.create.failure.v1",
+  "outcome": "not_submitted",
+  "provider": "machine0",
+  "leaseId": "cbx_abcdef012345",
+  "checkpointId": "chk_0123456789abcdef",
+  "localReservation": "removed"
+}
+```
+
+The provider, lease, and checkpoint identify this invocation only. This result
+does not mean the source restarted successfully or is ready for use; source
+cleanup remains the lease owner's responsibility. Failed local cleanup emits no
+such result. Coordinator-managed captures, lost replies, interrupted commands,
+and failures after submission retain their existing recovery behavior. Never
+infer non-submission from an empty image ID, a missing checkpoint, or error text.
+
 `--mode` also accepts the aliases `provider-native`/`vm` (native),
 `ami`/`image` (image), `snapshot`/`disk`/`disk-snapshot` (disk snapshot),
 `workspace`/`workspace-archive` (archive), and `recipe`. `--strategy auto`

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -248,8 +248,30 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 		}
 		dir = paths.Dir
 		recordWritten := isNativeCheckpointKind(createKind)
+		notSubmitted := false
 		defer func() {
-			cleanupUncommittedCheckpointDir(dir, recordWritten, err)
+			if cleanupErr := cleanupUncommittedCheckpointDir(dir, recordWritten, err); cleanupErr != nil {
+				err = errors.Join(err, cleanupErr)
+				var failure ExitError
+				if errors.As(err, &failure) {
+					// The CLI prints the first ExitError message; retain its code and
+					// typed cause while making reservation cleanup failure visible.
+					err = errors.Join(exit(failure.Code, "%v", err), err)
+				}
+				return
+			}
+			// The native owner attests non-submission; verified reservation cleanup
+			// permits reporting it without implying that source rollback succeeded.
+			if notSubmitted && *jsonOut {
+				err = errors.Join(err, json.NewEncoder(a.Stdout).Encode(struct {
+					Schema           string `json:"schema"`
+					Outcome          string `json:"outcome"`
+					Provider         string `json:"provider"`
+					LeaseID          string `json:"leaseId"`
+					CheckpointID     string `json:"checkpointId"`
+					LocalReservation string `json:"localReservation"`
+				}{"crabbox.checkpoint.create.failure.v1", "not_submitted", record.Provider, record.LeaseID, record.ID, "removed"}))
+			}
 		}()
 		switch createKind {
 		case checkpointKindRecipe:
@@ -289,9 +311,10 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 				}
 			}
 			if err != nil {
-				var notSubmitted NativeCheckpointNotSubmittedError
-				if record.Native.ImageID == "" && errors.As(err, &notSubmitted) && !record.coordinatorManaged() {
+				var unsubmitted NativeCheckpointNotSubmittedError
+				if record.Native.ImageID == "" && errors.As(err, &unsubmitted) && !record.coordinatorManaged() {
 					recordWritten = false
+					notSubmitted = true
 				}
 				if record.Native.ImageID != "" {
 					if writeErr := store.Write(record); writeErr != nil {
@@ -2487,11 +2510,17 @@ func newCheckpointRecord(repo Repo, cfg Config, server Server, target SSHTarget,
 	return record, dir, nil
 }
 
-func cleanupUncommittedCheckpointDir(dir string, committed bool, err error) {
+func cleanupUncommittedCheckpointDir(dir string, committed bool, err error) error {
 	if err == nil || committed || dir == "" {
-		return
+		return nil
 	}
-	_ = os.RemoveAll(dir)
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("remove incomplete checkpoint reservation: %w", err)
+	}
+	if _, err := os.Lstat(dir); !os.IsNotExist(err) {
+		return fmt.Errorf("checkpoint reservation removal could not be verified: %v", err)
+	}
+	return nil
 }
 
 func newCheckpointID() (string, error) {

--- a/internal/cli/checkpoint_capture_binary_test.go
+++ b/internal/cli/checkpoint_capture_binary_test.go
@@ -117,14 +117,29 @@ func runCheckpointCaptureRollbackContract(t *testing.T, repo, binary string) {
 func runCheckpointCaptureContract(t *testing.T, repo, binary string) {
 	t.Parallel()
 
-	for _, boundary := range []string{"flush", "stopped"} {
-		t.Run("ordinary failure before submission releases reservation after "+boundary, func(t *testing.T) {
+	for _, scenario := range []string{"flush", "stopped", "stopped-cleanup-failure"} {
+		boundary := strings.TrimSuffix(scenario, "-cleanup-failure")
+		t.Run("ordinary failure before submission releases reservation after "+scenario, func(t *testing.T) {
 			f := newCheckpointCaptureFixture(t, repo, binary)
 			s := f.state()
 			s.Pause, s.StartRunning = boundary, true
 			f.writeState(s)
 			p := f.start("", "checkpoint", "create", "--provider", "machine0", "--id", captureFixtureLease, "--mode", "native", "--wait=false", "--json")
 			f.waitEvent(p, boundary)
+			checkpointsRoot := filepath.Join(f.root, "state", "crabbox", "checkpoints")
+			if scenario == "stopped-cleanup-failure" {
+				retained := checkpointsRoot + "-retained"
+				if err := os.Rename(checkpointsRoot, retained); err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() {
+					_ = os.Remove(checkpointsRoot)
+					_ = os.Rename(retained, checkpointsRoot)
+				})
+				if err := os.WriteFile(checkpointsRoot, []byte("cleanup obstruction"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
 			s = f.state()
 			s.Pause, s.Machine["status"] = "", "ERRORED"
 			f.writeState(s)
@@ -145,6 +160,22 @@ func runCheckpointCaptureContract(t *testing.T, repo, binary string) {
 			}
 			if p.err == nil || s.Saves != 0 || s.Stops != wantTransitions || s.Starts != wantTransitions || s.Removes != 0 {
 				t.Fatalf("did not reproduce failure before image submission: err=%v stderr=%s state=%+v", p.err, p.output.stderr.String(), s)
+			}
+			if scenario == "stopped-cleanup-failure" {
+				if p.output.stdout.Len() != 0 || !strings.Contains(p.output.stderr.String(), "remove incomplete checkpoint reservation") {
+					t.Fatalf("failed reservation cleanup emitted a receipt or hid its failure: stdout=%s stderr=%s", p.output.stdout.String(), p.output.stderr.String())
+				}
+				return
+			}
+			var outcome map[string]string
+			if err := json.Unmarshal(p.output.stdout.Bytes(), &outcome); err != nil {
+				t.Fatalf("unsubmitted checkpoint failure JSON: %v\n%s", err, p.output.stdout.String())
+			}
+			if len(outcome) != 6 || outcome["schema"] != "crabbox.checkpoint.create.failure.v1" || outcome["outcome"] != "not_submitted" || outcome["provider"] != "machine0" || outcome["leaseId"] != captureFixtureLease || outcome["localReservation"] != "removed" || !strings.HasPrefix(outcome["checkpointId"], checkpointIDPrefix) {
+				t.Fatalf("unsubmitted checkpoint failure lost its exact operation: %+v", outcome)
+			}
+			if _, err := os.Lstat(filepath.Join(f.root, "state", "crabbox", "checkpoints", outcome["checkpointId"])); !os.IsNotExist(err) {
+				t.Fatalf("unsubmitted checkpoint reservation was not removed: %v", err)
 			}
 			result := f.run("stop", "--provider", "machine0", captureFixtureLease)
 			if result.err != nil || f.state().Machine != nil || f.state().Removes != 1 {

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -158,15 +158,32 @@ func TestCheckpointRecordRoundTripAndListOrder(t *testing.T) {
 
 func TestCleanupUncommittedCheckpointDirOnCreateError(t *testing.T) {
 	dir := t.TempDir()
-	cleanupUncommittedCheckpointDir(dir, false, io.ErrUnexpectedEOF)
+	if err := cleanupUncommittedCheckpointDir(dir, false, io.ErrUnexpectedEOF); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := os.Stat(dir); !os.IsNotExist(err) {
 		t.Fatalf("partial checkpoint dir still exists: err=%v", err)
 	}
 
 	committedDir := t.TempDir()
-	cleanupUncommittedCheckpointDir(committedDir, true, io.ErrUnexpectedEOF)
+	if err := cleanupUncommittedCheckpointDir(committedDir, true, io.ErrUnexpectedEOF); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := os.Stat(committedDir); err != nil {
 		t.Fatalf("committed checkpoint dir removed: %v", err)
+	}
+}
+
+func TestCleanupUncommittedCheckpointDirReportsRemovalFailure(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(file, []byte("retain"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := cleanupUncommittedCheckpointDir(filepath.Join(file, "checkpoint"), false, io.ErrUnexpectedEOF); err == nil {
+		t.Fatal("inaccessible reservation cleanup was reported successful")
+	}
+	if data, err := os.ReadFile(file); err != nil || string(data) != "retain" {
+		t.Fatalf("cleanup changed the unrelated file: %q %v", data, err)
 	}
 }
 

--- a/internal/cli/command_capture_unix_test.go
+++ b/internal/cli/command_capture_unix_test.go
@@ -249,6 +249,8 @@ func TestExecCommandRunnerFileCaptureHelper(t *testing.T) {
 		if err := child.Start(); err != nil {
 			os.Exit(97)
 		}
+		// Start the post-exit capture deadline only after the retained writer has booted.
+		awaitCaptureMarker(t, filepath.Join(dir, "leaf-pgid"))
 		os.Exit(23)
 	case "orphan-leaf":
 		parent, _ := strconv.Atoi(os.Args[index+3])
@@ -289,6 +291,7 @@ func TestExecCommandRunnerFileCaptureHelper(t *testing.T) {
 		if err := child.Start(); err != nil {
 			os.Exit(97)
 		}
+		awaitCaptureMarker(t, filepath.Join(dir, "leaf-pgid"))
 		_, _ = io.WriteString(os.Stdout, "out")
 	case "leaf":
 		_ = os.WriteFile(filepath.Join(dir, "leaf-pgid"), []byte(strconv.Itoa(syscall.Getpgrp())), 0o600)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where checkpoint automation could remain paused after a direct native capture failed before submitting any image. The provider already knew that no submission occurred, but callers received only a nonzero exit and human-readable error text.

## Why This Change Was Made

`checkpoint create --json` now emits a bounded `crabbox.checkpoint.create.failure.v1` result when the native provider explicitly attests non-submission and the exact local checkpoint reservation has been removed and verified absent. The result identifies the provider, lease, and checkpoint while preserving the nonzero exit status. Reservation-removal failures remain visible and suppress this result.

The result does not establish source rollback or readiness. Successful output is unchanged; coordinator captures, failures after submission, interrupted commands, and lost replies retain their existing recovery behavior. No new configuration or persisted state format is introduced.

## User Impact

Automation can distinguish verified non-submission from an uncertain outcome and release that invocation's capture bookkeeping while still failing the operation and cleaning up its source lease. Operators also receive the cleanup error when the local reservation cannot be removed.

## Evidence

A real direct-native Machine0 run on September 7 exercised the built CLI from `d5ec1f6deed28c9e7c058fe7c74e1a9c4083871f`, using a fresh Ubuntu 24.04 VM and a tiny committed project with a real build marker. This PR's subsequent main integration changed no feature bytes or direct Machine0 checkpoint/process contracts; its only manual conflict resolution preserved both changelog entries.

The VM became CLI-ready in 126.971 seconds and the ordinary project sync/build completed in 16.017 seconds. An unsupported `disk-snapshot` request first returned the expected non-submission receipt and exit 2. The following normal image capture encountered a real source-preparation failure:

```sh
crabbox checkpoint create --provider machine0 --id cbx_e471ae4a32b0 \
  --mode native --strategy image --wait --json
```

```text
stderr: prepare native checkpoint source: exit status 1: RuntimeError: native checkpoint requires completed cloud-init initialization
exit: 7
```

```json
{"schema":"crabbox.checkpoint.create.failure.v1","outcome":"not_submitted","provider":"machine0","leaseId":"cbx_e471ae4a32b0","checkpointId":"chk_4126ab4a84f80fe6","localReservation":"removed"}
```

The capture failed in 3.886 seconds with complete stdout and normal process exit/close. The returned reservation was absent from the local catalog, and complete native image inventories bracketed by matching account reads showed no image under its exact derived name. The source lease was destroyed and its exact VM absence verified. All 34 recorded commands and the outer process settled; temporary credential custody was removed. An independent readback verified receipt bytes/digests, command ordering, and process absence. Native inventory payloads were captured in unlinked temporary files; retained evidence contains the checked results and digests, not the raw account inventories.

The overall experiment correctly remains **failed**: it did not reach successful capture, fork, or warm-start timing. It proves this PR's failure-result and cleanup contract, not successful source rollback. The cloud-init preparation failure is a separate follow-up under investigation; the retained error does not distinguish its pre-clean and post-clean checks.

Additional validation:

- Existing built-CLI synthetic Machine0/SSH cases failed against the original implementation because JSON stdout was empty, then passed with this repair.
- Obstructed reservation cleanup emits no negative result and reports its cleanup error. Interrupted submission retains its recovery reservation. Cleanup tests preserve unrelated files and committed reservations.
- The focused boundary tests and prior full CI passed. Fresh independent review through P2 passed on the current main integration; exact-head CI is tracked on the PR.
- Production delta: +35/-6; tests: +55/-4; documentation: +24. The production growth implements the explicit failure-output contract and preserves cleanup diagnostics.

Maintainer note on the review's changelog request: the entry is intentionally retained. This is maintainer/agent-authored work, and the repository's root guidance requires maintainers and agents to record user-visible changes under Unreleased as they land.
