### PR TITLE
fix: support pnpm setup in local Actions hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Publish run diagnostics without delaying workload admission, while preserving ordered lease attribution and joining pending publication before terminal recording. [PR 1937](https://github.com/openclaw/crabbox/pull/1937).
 - Add bounded AWS provisioning logs that separate ingress queue and lifecycle waits from create-operation costs and count redundant security-group permission calls without logging request payloads. [PR 1938](https://github.com/openclaw/crabbox/pull/1938).
 - Deduplicate validated AWS coordinator SSH ranges after combining lease and global access, avoiding repeated authorization calls for identical port/range pairs while preserving ingress reconciliation. [PR 1945](https://github.com/openclaw/crabbox/pull/1945).
-- Local Actions hydration: support `pnpm/action-setup` with an explicit exact version, including pnpm-before-Node workflows, preserve the managed pnpm for later commands, and accept setup-node's `cache: pnpm` as an explicitly uncached run.
+- Local Actions hydration: support `pnpm/action-setup` with an explicit exact version, including pnpm-before-Node workflows, preserve the managed pnpm for later commands, and accept setup-node's `cache: pnpm` as an explicitly uncached run. [PR 1953](https://github.com/openclaw/crabbox/pull/1953).
 
 ## 0.51.0 - 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Publish run diagnostics without delaying workload admission, while preserving ordered lease attribution and joining pending publication before terminal recording. [PR 1937](https://github.com/openclaw/crabbox/pull/1937).
 - Add bounded AWS provisioning logs that separate ingress queue and lifecycle waits from create-operation costs and count redundant security-group permission calls without logging request payloads. [PR 1938](https://github.com/openclaw/crabbox/pull/1938).
 - Deduplicate validated AWS coordinator SSH ranges after combining lease and global access, avoiding repeated authorization calls for identical port/range pairs while preserving ingress reconciliation. [PR 1945](https://github.com/openclaw/crabbox/pull/1945).
+- Local Actions hydration: support `pnpm/action-setup` with an explicit exact version, including pnpm-before-Node workflows, preserve the managed pnpm for later commands, and accept setup-node's `cache: pnpm` as an explicitly uncached run.
 
 ## 0.51.0 - 2026-09-06
 

--- a/docs/commands/actions.md
+++ b/docs/commands/actions.md
@@ -170,9 +170,16 @@ crabbox run --id blue-lobster -- pnpm test:changed
 
 The workflow owns repository-specific setup: checkout, dependency install,
 caches, and project tools. Local hydration supports `run` steps plus common
-setup actions: `actions/checkout`, `actions/setup-node`, `actions/setup-go`,
-`actions/setup-python`, and `actions/cache/restore|save` (cache restore reports a
-miss; save is skipped). Repo-local composite actions (`./path`) are supported.
+setup actions: `actions/checkout`, `actions/setup-node`, `pnpm/action-setup`,
+`actions/setup-go`, `actions/setup-python`, and `actions/cache/restore|save`
+(cache restore reports a miss; save is skipped). `pnpm/action-setup` requires an
+explicit exact `version` (`major.minor.patch`) and installs into the managed tool
+cache without lifecycle scripts; it bootstraps Node 24 if Node or npm is absent,
+so pnpm setup may precede setup-node. A later setup-node selects the project Node
+version without displacing the managed pnpm. Other pnpm inputs and version
+inference/ranges require `--github-runner`; install project dependencies in a
+separate `run` step. Setup-node accepts `cache: pnpm` as an explicitly uncached
+local run. Repo-local composite actions (`./path`) are supported.
 Job containers and service containers are not; `actions/checkout` options that
 change the repository, path, submodules, or LFS fail locally so you can rerun
 with `--github-runner` when you need full GitHub Actions semantics.

--- a/docs/features/actions-hydration.md
+++ b/docs/features/actions-hydration.md
@@ -89,7 +89,16 @@ Supported `uses:` steps:
   `persist-credentials`, `set-safe-directory`, and disabled `submodules`/`lfs`
   are accepted, anything else needs `--github-runner`);
 - `actions/setup-node@*`, `actions/setup-go@*`, `actions/setup-python@*` —
-  honoring `*-version` / `*-version-file`;
+  honoring `*-version` / `*-version-file`; setup-node also accepts `cache: pnpm`
+  but explicitly skips cache restore/save (local hydration runs uncached);
+- `pnpm/action-setup@*` — requires an explicit exact `version` (`major.minor.patch`,
+  including simple expressions). Installs that pnpm version into the managed
+  tool cache using npm, without lifecycle scripts. If Node or npm is absent,
+  bootstraps Node 24 so this step can precede setup-node; a later setup-node
+  still selects the requested project runtime. The selected pnpm stays on PATH
+  for hydration and subsequent commands. Version inference/ranges, custom
+  destinations, standalone mode, dependency installation, and caching inputs
+  are not supported; use a separate `run: pnpm install` step;
 - `actions/cache/restore@*` — reports a cache miss;
 - `actions/cache/save@*` — skipped;
 - repo-local composite actions (`./...`).

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -1188,6 +1188,7 @@ func interpolateLocalActionsValue(value string, inputs, env map[string]string, w
 
 var localActionsExpressionPattern = regexp.MustCompile(`\$\{\{\s*([^}]+?)\s*\}\}`)
 var localActionsDirectSecretPattern = regexp.MustCompile(`^secrets\.[A-Za-z_][A-Za-z0-9_]*$`)
+var localActionsPnpmVersionPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
 
 func shouldSkipLocalHydrateStep(expr string, inputs, env map[string]string, stepOutputs map[string]map[string]string) (bool, error) {
 	expr = strings.TrimSpace(expr)
@@ -1218,9 +1219,28 @@ func localHydrateUsesScript(step localHydrateStep, ctx localHydrateScriptContext
 			return "", nil, err
 		}
 		return "# actions/checkout handled by Crabbox sync/git seed\n", nil, nil
-	case strings.HasPrefix(uses, "actions/setup-node@"):
-		if err := validateLocalActionWithKeys("actions/setup-node", step.With, "node-version", "node-version-file", "check-latest"); err != nil {
+	case strings.HasPrefix(uses, "pnpm/action-setup@"):
+		if err := validateLocalActionWithKeys("pnpm/action-setup", step.With, "version"); err != nil {
 			return "", nil, err
+		}
+		version, err := localHydrateWithInput(step, []string{"version"}, "", ctx.Inputs, env, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
+		if err != nil {
+			return "", nil, err
+		}
+		if !localActionsPnpmVersionPattern.MatchString(version) {
+			return "", nil, exit(2, "local Actions hydration requires pnpm/action-setup to specify an explicit exact version (major.minor.patch); rerun with --github-runner for version ranges or package.json inference")
+		}
+		return "__crabbox_setup_pnpm " + shellQuote(version) + "\n", nil, nil
+	case strings.HasPrefix(uses, "actions/setup-node@"):
+		if err := validateLocalActionWithKeys("actions/setup-node", step.With, "node-version", "node-version-file", "check-latest", "cache"); err != nil {
+			return "", nil, err
+		}
+		cache, err := localHydrateWithInput(step, []string{"cache"}, "", ctx.Inputs, env, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
+		if err != nil {
+			return "", nil, err
+		}
+		if cache != "" && cache != "pnpm" {
+			return "", nil, exit(2, "local Actions hydration does not support actions/setup-node cache %q; rerun with --github-runner when the workflow needs full GitHub Actions semantics", cache)
 		}
 		version, err := localHydrateWithInput(step, []string{"node-version", "node-version-file"}, "", ctx.Inputs, env, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
 		if err != nil {
@@ -1230,7 +1250,11 @@ func localHydrateUsesScript(step localHydrateStep, ctx localHydrateScriptContext
 		if strings.TrimSpace(step.With["node-version"]) != "" && !supportedLocalNodeVersionSpec(version) {
 			return "", nil, exit(2, "local Actions hydration does not support actions/setup-node version %q; rerun with --github-runner when the workflow needs full GitHub Actions semantics", version)
 		}
-		return "__crabbox_setup_node " + shellQuote(version) + "\n", nil, nil
+		script := "__crabbox_setup_node " + shellQuote(version) + "\n"
+		if cache == "pnpm" {
+			script += "echo 'local actions: pnpm cache restore/save skipped (uncached local hydration)'\n"
+		}
+		return script, nil, nil
 	case strings.HasPrefix(uses, "actions/setup-go@"):
 		if err := validateLocalActionWithKeys("actions/setup-go", step.With, "go-version", "go-version-file"); err != nil {
 			return "", nil, err
@@ -2047,8 +2071,24 @@ __crabbox_setup_node() {
   fi
   rm -f "$RUNNER_TOOL_CACHE/node"
   ln -s "$dir" "$RUNNER_TOOL_CACHE/node"
-  export PATH="$RUNNER_TOOL_CACHE/node/bin:$PATH"
+  export PATH="$RUNNER_TOOL_CACHE/pnpm/bin:$RUNNER_TOOL_CACHE/node/bin:$PATH"
   corepack enable >/dev/null 2>&1 || true
+}
+__crabbox_setup_pnpm() {
+  local requested="$1"
+  # pnpm/action-setup can precede setup-node on a minimal runner image.
+  if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+    __crabbox_setup_node 24
+  fi
+  if ! command -v npm >/dev/null 2>&1; then
+    echo "pnpm/action-setup requires npm; install Node with npm or rerun with --github-runner" >&2
+    return 2
+  fi
+  local dir="$RUNNER_TOOL_CACHE/pnpm"
+  mkdir -p "$dir"
+  npm install --global --prefix "$dir" --ignore-scripts --no-audit --no-fund --registry=https://registry.npmjs.org "pnpm@$requested"
+  [ -x "$dir/bin/pnpm" ] || { echo "pnpm installation did not provide an executable" >&2; return 2; }
+  export PATH="$dir/bin:$PATH"
 }
 __crabbox_setup_go() {
   local requested="${1:-}"
@@ -2763,6 +2803,12 @@ if [ -f "$env_file" ]; then
     {
       printf '%s\n' '# CRABBOX_LOCAL_ACTIONS_NODE_PATH'
       printf '%s\n' 'export PATH="${RUNNER_TOOL_CACHE}/node/bin:$PATH"'
+    } >> "$env_file"
+  fi
+  if [ -n "${RUNNER_TOOL_CACHE:-}" ] && [ -x "$RUNNER_TOOL_CACHE/pnpm/bin/pnpm" ] && ! grep -q '^# CRABBOX_LOCAL_ACTIONS_PNPM_PATH$' "$env_file"; then
+    {
+      printf '%s\n' '# CRABBOX_LOCAL_ACTIONS_PNPM_PATH'
+      printf '%s\n' 'export PATH="${RUNNER_TOOL_CACHE}/pnpm/bin:$PATH"'
     } >> "$env_file"
   fi
 fi

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -1982,7 +1982,7 @@ __crabbox_ensure_xz() {
   command -v xz >/dev/null 2>&1
 }
 __crabbox_setup_node() {
-  local requested="${1:-}"
+  local requested="${1:-}" require_npm="${2:-false}"
   if [ -n "$requested" ] && [ -f "$GITHUB_WORKSPACE/$requested" ]; then
     if [ "$(basename "$requested")" = "package.json" ]; then
       requested="$(sed -nE 's/.*"node"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$GITHUB_WORKSPACE/$requested" | head -n 1 | tr -d '[:space:]')"
@@ -2009,7 +2009,7 @@ __crabbox_setup_node() {
   local want dots
   want="${requested#v}"
   dots="$(printf '%s' "$want" | tr -cd '.' | wc -c | tr -d ' ')"
-  if command -v node >/dev/null 2>&1; then
+  if command -v node >/dev/null 2>&1 && { [ "$require_npm" != true ] || command -v npm >/dev/null 2>&1; }; then
     local actual
     actual="$(node -p 'process.versions.node' 2>/dev/null || true)"
     case "$dots" in
@@ -2043,7 +2043,7 @@ __crabbox_setup_node() {
     echo "Node release checksums did not contain a valid digest for $archive" >&2
     return 2
   fi
-  if [ ! -x "$dir/bin/node" ] || [ ! -f "$marker" ] || [ "$(cat "$marker" 2>/dev/null || true)" != "$expected" ]; then
+  if [ ! -x "$dir/bin/node" ] || { [ "$require_npm" = true ] && [ ! -x "$dir/bin/npm" ]; } || [ ! -f "$marker" ] || [ "$(cat "$marker" 2>/dev/null || true)" != "$expected" ]; then
     curl -fsSL -o "$tmp" "https://nodejs.org/dist/${version}/${archive}"
     if command -v sha256sum >/dev/null 2>&1; then
       actual="$(sha256sum "$tmp" | awk '{ print $1 }')"
@@ -2064,6 +2064,10 @@ __crabbox_setup_node() {
     mkdir -p "$extract"
     tar -xJf "$tmp" -C "$extract"
     [ -x "$extract/node-${version}-linux-${arch}/bin/node" ] || { echo "Node archive has an unexpected layout" >&2; return 2; }
+    if [ "$require_npm" = true ] && [ ! -x "$extract/node-${version}-linux-${arch}/bin/npm" ]; then
+      echo "Node archive did not provide npm required by pnpm/action-setup" >&2
+      return 2
+    fi
     rm -rf "$dir"
     mv "$extract/node-${version}-linux-${arch}" "$dir"
     printf '%s\n' "$expected" >"$marker"
@@ -2078,7 +2082,7 @@ __crabbox_setup_pnpm() {
   local requested="$1"
   # pnpm/action-setup can precede setup-node on a minimal runner image.
   if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
-    __crabbox_setup_node 24
+    __crabbox_setup_node 24 true
   fi
   if ! command -v npm >/dev/null 2>&1; then
     echo "pnpm/action-setup requires npm; install Node with npm or rerun with --github-runner" >&2

--- a/internal/cli/actions_pnpm_test.go
+++ b/internal/cli/actions_pnpm_test.go
@@ -89,30 +89,70 @@ func TestLocalActionsHydrateScriptSetupNodeCache(t *testing.T) {
 }
 
 func TestLocalActionsSetupPnpmBootstrapsNode(t *testing.T) {
-	root := t.TempDir()
-	bin := filepath.Join(root, "bin")
-	if err := os.MkdirAll(bin, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	// An allowlisted PATH proves setup does not depend on an operator's Node/npm.
-	for _, name := range []string{"mkdir", "rm", "cat", "chmod"} {
-		target, err := exec.LookPath(name)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Symlink(target, filepath.Join(bin, name)); err != nil {
-			t.Fatal(err)
-		}
-	}
-	script := "set -euo pipefail\n" + localActionsRuntimeShell() + `
-__crabbox_setup_node() {
-  [ "$1" = 24 ]
-  mkdir -p "$RUNNER_TOOL_CACHE/node/bin"
-  cat >"$RUNNER_TOOL_CACHE/node/bin/node" <<'NODE'
-#!/bin/sh
-printf '24.0.0\n'
-NODE
-  cat >"$RUNNER_TOOL_CACHE/node/bin/npm" <<'NPM'
+	for _, initialNode := range []string{"absent", "system without npm", "managed without npm"} {
+		t.Run(initialNode, func(t *testing.T) {
+			root := t.TempDir()
+			bin := filepath.Join(root, "bin")
+			tools := filepath.Join(root, "tools")
+			if err := os.MkdirAll(bin, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			// Keep the real setup helper, but isolate tools and stub its downloads.
+			for _, name := range []string{"mkdir", "rm", "cat", "chmod", "tr", "wc", "awk", "ln", "mv"} {
+				target, err := exec.LookPath(name)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(target, filepath.Join(bin, name)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			node := []byte("#!/bin/sh\nprintf '24.0.0\\n'\n")
+			digest := strings.Repeat("a", 64)
+			if initialNode == "system without npm" {
+				if err := os.WriteFile(filepath.Join(bin, "node"), node, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			} else if initialNode == "managed without npm" {
+				dir := filepath.Join(tools, "node-v24.0.0-linux-x64")
+				if err := os.MkdirAll(filepath.Join(dir, "bin"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "bin", "node"), node, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, ".crabbox-node-sha256"), []byte(digest+"\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(dir, filepath.Join(tools, "node")); err != nil {
+					t.Fatal(err)
+				}
+			}
+			commands := map[string]string{
+				"uname": "#!/bin/sh\nprintf 'x86_64\\n'\n",
+				"xz":    "#!/bin/sh\nexit 0\n",
+				"curl": `#!/bin/sh
+out=
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = -o ]; then shift; out="$1"; else url="$1"; fi
+  shift
+done
+case "$url" in
+  */index.tab) printf 'version\nv24.0.0\n' ;;
+  */SHASUMS256.txt) printf '%s  node-v24.0.0-linux-x64.tar.xz\n' "$TEST_DIGEST" >"$out" ;;
+  *) printf archive >"$out" ;;
+esac
+`,
+				"sha256sum": "#!/bin/sh\nprintf '%s  %s\\n' \"$TEST_DIGEST\" \"$1\"\n",
+				"tar": `#!/bin/sh
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = -C ]; then shift; dir="$1"; fi
+  shift
+done
+dir="$dir/node-v24.0.0-linux-x64/bin"
+mkdir -p "$dir"
+printf '#!/bin/sh\nprintf "24.0.0\\n"\n' >"$dir/node"
+cat >"$dir/npm" <<'NPM'
 #!/bin/sh
 printf '%s\n' "$@" >"$NPM_ARGS"
 prefix=
@@ -124,28 +164,35 @@ mkdir -p "$prefix/bin"
 printf '#!/bin/sh\nprintf "11.25.0\\n"\n' >"$prefix/bin/pnpm"
 chmod +x "$prefix/bin/pnpm"
 NPM
-  chmod +x "$RUNNER_TOOL_CACHE/node/bin/node" "$RUNNER_TOOL_CACHE/node/bin/npm"
-  export PATH="$RUNNER_TOOL_CACHE/node/bin:$PATH"
-}
-! command -v node
+chmod +x "$dir/node" "$dir/npm"
+`,
+			}
+			for name, script := range commands {
+				if err := os.WriteFile(filepath.Join(bin, name), []byte(script), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			script := "set -euo pipefail\n" + localActionsRuntimeShell() + `
 ! command -v npm
 ! command -v corepack
 __crabbox_setup_pnpm 11.25.0
 [ "$(pnpm --version)" = 11.25.0 ]
 `
-	cmd := exec.Command("bash", "-c", script)
-	cmd.Env = []string{"PATH=" + bin, "RUNNER_TOOL_CACHE=" + filepath.Join(root, "tools"), "RUNNER_TEMP=" + filepath.Join(root, "tmp"), "NPM_ARGS=" + filepath.Join(root, "npm-args")}
-	if output, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("pnpm bootstrap: %v\n%s", err, output)
-	}
-	args, err := os.ReadFile(filepath.Join(root, "npm-args"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, want := range []string{"--global\n", "--ignore-scripts\n", "--no-audit\n", "--no-fund\n", "--registry=https://registry.npmjs.org\n", "pnpm@11.25.0\n"} {
-		if !strings.Contains(string(args), want) {
-			t.Fatalf("npm args missing %q: %s", want, args)
-		}
+			cmd := exec.Command("bash", "-c", script)
+			cmd.Env = []string{"PATH=" + filepath.Join(tools, "node", "bin") + ":" + bin, "GITHUB_WORKSPACE=" + root, "RUNNER_TOOL_CACHE=" + tools, "RUNNER_TEMP=" + filepath.Join(root, "tmp"), "NPM_ARGS=" + filepath.Join(root, "npm-args"), "TEST_DIGEST=" + digest}
+			if output, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("pnpm bootstrap: %v\n%s", err, output)
+			}
+			args, err := os.ReadFile(filepath.Join(root, "npm-args"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, want := range []string{"--global\n", "--ignore-scripts\n", "--no-audit\n", "--no-fund\n", "--registry=https://registry.npmjs.org\n", "pnpm@11.25.0\n"} {
+				if !strings.Contains(string(args), want) {
+					t.Fatalf("npm args missing %q: %s", want, args)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/cli/actions_pnpm_test.go
+++ b/internal/cli/actions_pnpm_test.go
@@ -1,0 +1,257 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestLocalActionsHydrateScriptPnpmBeforeNode(t *testing.T) {
+	var workflow localHydrateWorkflow
+	if err := yaml.Unmarshal([]byte(`env:
+  PNPM_VERSION: 11.25.0
+jobs:
+  hydrate:
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: pnpm/action-setup@v6.0.10
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+`), &workflow); err != nil {
+		t.Fatal(err)
+	}
+	got, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "my-app"}, workflow, workflow.Jobs["hydrate"], "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pnpm := strings.Index(got, "__crabbox_setup_pnpm '11.25.0'")
+	node := strings.Index(got, "__crabbox_setup_node '24'")
+	install := strings.Index(got, "pnpm install --frozen-lockfile")
+	if pnpm < 0 || node < pnpm || install < node {
+		t.Fatalf("expected pnpm setup, Node setup, then install: pnpm=%d node=%d install=%d", pnpm, node, install)
+	}
+	if !strings.Contains(got, "pnpm cache restore/save skipped") || strings.Contains(got, "${{") {
+		t.Fatalf("expected explicit uncached translation and resolved inputs:\n%s", got)
+	}
+}
+
+func TestLocalActionsHydrateScriptPnpmInputs(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		with map[string]string
+		want string
+	}{
+		{name: "missing version", want: "explicit exact version"},
+		{name: "major", with: map[string]string{"version": "11"}, want: "explicit exact version"},
+		{name: "range", with: map[string]string{"version": "^11.0.0"}, want: "explicit exact version"},
+		{name: "tag", with: map[string]string{"version": "latest"}, want: "explicit exact version"},
+		{name: "install", with: map[string]string{"version": "11.25.0", "run_install": "true"}, want: "option"},
+		{name: "standalone", with: map[string]string{"version": "11.25.0", "standalone": "true"}, want: "option"},
+		{name: "destination", with: map[string]string{"version": "11.25.0", "dest": "custom"}, want: "option"},
+		{name: "manifest", with: map[string]string{"version": "11.25.0", "package_json_file": "other.json"}, want: "option"},
+		{name: "cache", with: map[string]string{"version": "11.25.0", "cache": "true"}, want: "option"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := localHydrateUsesScript(localHydrateStep{Uses: "pnpm/action-setup@v6.0.10", With: tc.with}, localHydrateScriptContext{}, nil)
+			if err == nil || !strings.Contains(err.Error(), tc.want) || !strings.Contains(err.Error(), "--github-runner") {
+				t.Fatalf("err=%v, want %q with GitHub runner guidance", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestLocalActionsHydrateScriptSetupNodeCache(t *testing.T) {
+	for _, cache := range []string{"", "pnpm", "${{ env.CACHE }}", "npm", "yarn", "unknown"} {
+		t.Run(cache, func(t *testing.T) {
+			script, _, err := localHydrateUsesScript(localHydrateStep{Uses: "actions/setup-node@v7", With: map[string]string{"node-version": "24", "cache": cache}}, localHydrateScriptContext{}, map[string]string{"CACHE": "pnpm"})
+			if cache == "npm" || cache == "yarn" || cache == "unknown" {
+				if err == nil || !strings.Contains(err.Error(), "--github-runner") {
+					t.Fatalf("expected unsupported cache error, got %v", err)
+				}
+				return
+			}
+			if err != nil || !strings.Contains(script, "__crabbox_setup_node '24'") {
+				t.Fatalf("script=%q err=%v", script, err)
+			}
+		})
+	}
+}
+
+func TestLocalActionsSetupPnpmBootstrapsNode(t *testing.T) {
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// An allowlisted PATH proves setup does not depend on an operator's Node/npm.
+	for _, name := range []string{"mkdir", "rm", "cat", "chmod"} {
+		target, err := exec.LookPath(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, filepath.Join(bin, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	script := "set -euo pipefail\n" + localActionsRuntimeShell() + `
+__crabbox_setup_node() {
+  [ "$1" = 24 ]
+  mkdir -p "$RUNNER_TOOL_CACHE/node/bin"
+  cat >"$RUNNER_TOOL_CACHE/node/bin/node" <<'NODE'
+#!/bin/sh
+printf '24.0.0\n'
+NODE
+  cat >"$RUNNER_TOOL_CACHE/node/bin/npm" <<'NPM'
+#!/bin/sh
+printf '%s\n' "$@" >"$NPM_ARGS"
+prefix=
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = --prefix ]; then shift; prefix="$1"; fi
+  shift
+done
+mkdir -p "$prefix/bin"
+printf '#!/bin/sh\nprintf "11.25.0\\n"\n' >"$prefix/bin/pnpm"
+chmod +x "$prefix/bin/pnpm"
+NPM
+  chmod +x "$RUNNER_TOOL_CACHE/node/bin/node" "$RUNNER_TOOL_CACHE/node/bin/npm"
+  export PATH="$RUNNER_TOOL_CACHE/node/bin:$PATH"
+}
+! command -v node
+! command -v npm
+! command -v corepack
+__crabbox_setup_pnpm 11.25.0
+[ "$(pnpm --version)" = 11.25.0 ]
+`
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = []string{"PATH=" + bin, "RUNNER_TOOL_CACHE=" + filepath.Join(root, "tools"), "RUNNER_TEMP=" + filepath.Join(root, "tmp"), "NPM_ARGS=" + filepath.Join(root, "npm-args")}
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("pnpm bootstrap: %v\n%s", err, output)
+	}
+	args, err := os.ReadFile(filepath.Join(root, "npm-args"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"--global\n", "--ignore-scripts\n", "--no-audit\n", "--no-fund\n", "--registry=https://registry.npmjs.org\n", "pnpm@11.25.0\n"} {
+		if !strings.Contains(string(args), want) {
+			t.Fatalf("npm args missing %q: %s", want, args)
+		}
+	}
+}
+
+func TestLocalActionsSetupNodePreservesManagedPnpm(t *testing.T) {
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	pnpmBin := filepath.Join(root, "tools", "pnpm", "bin")
+	for _, dir := range []string{bin, pnpmBin} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	commands := map[string]string{
+		"node":  "#!/bin/sh\nprintf '22.0.0\\n'\n",
+		"uname": "#!/bin/sh\nprintf 'x86_64\\n'\n",
+		"xz":    "#!/bin/sh\nexit 0\n",
+		"curl": `#!/bin/sh
+out=
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = -o ]; then shift; out="$1"; else url="$1"; fi
+  shift
+done
+case "$url" in
+  */index.tab) printf 'version\nv24.0.0\n' ;;
+  */SHASUMS256.txt) printf '%s  node-v24.0.0-linux-x64.tar.xz\n' "$TEST_DIGEST" >"$out" ;;
+  *) printf archive >"$out" ;;
+esac
+`,
+		"sha256sum": "#!/bin/sh\nprintf '%s  %s\\n' \"$TEST_DIGEST\" \"$1\"\n",
+		"tar": `#!/bin/sh
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = -C ]; then shift; dir="$1"; fi
+  shift
+done
+dir="$dir/node-v24.0.0-linux-x64/bin"
+mkdir -p "$dir"
+printf '#!/bin/sh\nprintf "24.0.0\\n"\n' >"$dir/node"
+printf '#!/bin/sh\nprintf "wrong-corepack-pnpm\\n"\n' >"$dir/pnpm"
+printf '#!/bin/sh\nexit 0\n' >"$dir/corepack"
+chmod +x "$dir/node" "$dir/pnpm" "$dir/corepack"
+`,
+	}
+	for name, script := range commands {
+		if err := os.WriteFile(filepath.Join(bin, name), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(pnpmBin, "pnpm"), []byte("#!/bin/sh\nprintf '11.25.0\\n'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := "set -euo pipefail\n" + localActionsRuntimeShell() + `
+__crabbox_setup_node 24
+[ "$(node --version)" = 24.0.0 ]
+[ "$(pnpm --version)" = 11.25.0 ]
+`
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(), "PATH="+pnpmBin+":"+bin+":"+os.Getenv("PATH"), "GITHUB_WORKSPACE="+root,
+		"RUNNER_TOOL_CACHE="+filepath.Join(root, "tools"), "RUNNER_TEMP="+filepath.Join(root, "tmp"), "TEST_DIGEST="+strings.Repeat("a", 64))
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("setup-node displaced managed pnpm: %v\n%s", err, output)
+	}
+}
+
+func TestRemoteEnsureLocalActionsRunEnvPersistsPnpmPath(t *testing.T) {
+	for _, managedNode := range []bool{false, true} {
+		name := "system node"
+		if managedNode {
+			name = "managed node"
+		}
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			tools := filepath.Join(root, "tools")
+			for _, tool := range []string{"node", "pnpm"} {
+				if tool == "node" && !managedNode {
+					continue
+				}
+				bin := filepath.Join(tools, tool, "bin")
+				if err := os.MkdirAll(bin, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(bin, tool), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			envFile := filepath.Join(root, "run-env.sh")
+			if err := os.WriteFile(envFile, []byte("export RUNNER_TOOL_CACHE="+shellQuote(tools)+"\nexport PATH=/usr/bin:/bin\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			for range 2 {
+				cmd := exec.Command("bash", "-c", remoteEnsureLocalActionsRunEnv("cbx_123", envFile))
+				if output, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("persist env: %v\n%s", err, output)
+				}
+			}
+			content, err := os.ReadFile(envFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Count(string(content), "# CRABBOX_LOCAL_ACTIONS_PNPM_PATH") != 1 {
+				t.Fatalf("pnpm path was not persisted exactly once: %s", content)
+			}
+			cmd := exec.Command("bash", "--noprofile", "--norc", "-c", ". "+shellQuote(envFile)+"; command -v pnpm")
+			output, err := cmd.CombinedOutput()
+			if err != nil || strings.TrimSpace(string(output)) != filepath.Join(tools, "pnpm", "bin", "pnpm") {
+				t.Fatalf("fresh run pnpm=%q err=%v", output, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Local Actions hydration currently rejects maintained workflows that use `pnpm/action-setup@v6.0.10`, then rejects `actions/setup-node@v7` with `cache: pnpm` once the first blocker is removed. This is a missing interpreter capability, not an action-tag allowlist problem; downgrading the maintained actions does not address it.

Add a bounded provider-neutral translator for `pnpm/action-setup` with an explicit exact `major.minor.patch` version (including supported input/env expressions). Install the selected pnpm into the managed tool cache through npm with lifecycle scripts disabled. Bootstrap Node 24 when Node or npm is absent so pnpm setup can precede setup-node, and preserve the managed pnpm ahead of Node/Corepack shims during hydration and in later command shells.

Accept setup-node's `cache: pnpm` as an explicitly logged uncached local run. Unsupported pnpm inputs, version inference/ranges, and other setup-node cache values continue to fail clearly. Update the command/feature docs and Unreleased changelog.

The review found an incomplete-bootstrap edge case: an existing Node 24 installation without npm could be incorrectly reused. The follow-up requires a complete Node/npm runtime for pnpm bootstrap, repairs a cached Node runtime missing npm, and verifies npm is present before selecting an extracted runtime. Its regressions execute the actual Node setup helper rather than replacing it.

Maintainer note: this is a maintainer-authored PR, so its changelog entry is intentional and retained under the repository's maintainer policy. The entry includes the full PR link.

## Verification

- Regression fixture covers checkout → pnpm setup with an env-selected version → Node 24 with `cache: pnpm` → frozen-lockfile install, using the maintained action refs.
- Hermetic executable shell tests cover bootstrap without Node/npm/Corepack, system Node 24 without npm, a checksum-marked cached Node 24 without npm, managed pnpm precedence after Node replacement, and idempotent environment handoff with managed or system Node. The new missing-npm cases reproduced exit 2 before the follow-up and pass after it.
- A complete maintained workflow was checked read-only through the interpreter: the baseline reproduces the original unsupported-action error, and the patched interpreter translates the whole workflow without unresolved expressions. Workflow commands were not executed by that check.
- All Actions/hydration tests pass with the race detector; Go vet and the task CLI build pass.
- An isolated real-package smoke installed pnpm 11.25.0 and executed Node 24.20.0 successfully.
- Independent review found no actionable P0–P2 findings before submission.

The broader local CLI race suite exhausted its 20-minute package timeout. `TestRemoteGitOverlayTransportFailuresFallBack` was active during temporary-directory cleanup and passed separately in 4.85 seconds. This local attempt is not claimed as a completed full-suite pass.

The final-head [CI run](https://github.com/openclaw/crabbox/actions/runs/34100382515) passed on `2ce658afe0b99f6697738546eb6b1cf84a385774`, including the full Go race suite, Go coverage/modules, vet/build, Windows checks, Worker, docs, scripts, and connector lifecycle checks. No test budget was raised.

## Boundaries

No provider selection, credentials, lease lifecycle, consumer workflow, root-volume configuration, or installed CLI changes. No version bump or release publication.

A synthetic production-generated hydration/runtime-handoff proof was attempted on the configured AWS backend. A coordinator deployment reset interrupted provisioning, and the lease never became ready, so the attempt was stopped and release was requested. No workflow commands executed remotely; this is an infrastructure-blocked proof attempt, not a successful AWS end-to-end result. The real-package smoke above is local and is not presented as equivalent to a complete remote hydration run.
