### PR TITLE
fix(images): preserve readiness after developer image cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Preserve current-boot cloud-init completion records during Linux developer-image cleanup while still clearing cached initialization and seed data, and fail preparation if cleanup cannot complete safely. Thanks @vincentkoc.
+- Preserve current-boot cloud-init completion records during Linux developer-image cleanup while still clearing cached initialization and seed data, and fail preparation if cleanup cannot complete safely. [PR 1954](https://github.com/openclaw/crabbox/pull/1954). Thanks @vincentkoc.
 - Stop SSH readiness probes and backoff at the shared deadline, reporting the active probe with authentication unknown instead of mislabeling expired checks as authentication failures. [PR 1949](https://github.com/openclaw/crabbox/pull/1949). Thanks @vincentkoc.
 - Reuse verified SSH endpoints within an operation, preserving advertised fallbacks when switching hosts or ports and avoiding redundant login probes across direct, proxy, and WSL execution. [PR 1941](https://github.com/openclaw/crabbox/pull/1941).
 - Report image qualification reaping as idle after clean teardown, while preserving failed recovery evidence and checking transient controller ownership before cleanup. [PR 1942](https://github.com/openclaw/crabbox/pull/1942). Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve current-boot cloud-init completion records during Linux developer-image cleanup while still clearing cached initialization and seed data, and fail preparation if cleanup cannot complete safely. Thanks @vincentkoc.
 - Stop SSH readiness probes and backoff at the shared deadline, reporting the active probe with authentication unknown instead of mislabeling expired checks as authentication failures. [PR 1949](https://github.com/openclaw/crabbox/pull/1949). Thanks @vincentkoc.
 - Reuse verified SSH endpoints within an operation, preserving advertised fallbacks when switching hosts or ports and avoiding redundant login probes across direct, proxy, and WSL execution. [PR 1941](https://github.com/openclaw/crabbox/pull/1941).
 - Report image qualification reaping as idle after clean teardown, while preserving failed recovery evidence and checking transient controller ownership before cleanup. [PR 1942](https://github.com/openclaw/crabbox/pull/1942). Thanks @vincentkoc.

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -384,6 +384,18 @@ scripts/mint-aws-devtools-image.sh \
   Linux TruffleHog 3.95.9 binary inside the managed WSL distro. This happens
   during environment setup and does not require autoreview-time installation.
 
+Linux preparation retains `cloud-init clean --logs --seed` while preserving
+the running source's completed initialization. Using the distro's isolated
+`/usr/bin/python3`, it requires cloud-init to report `done` and its configured
+runtime directory to be on `tmpfs`, outside the cleaned disk cache. Both
+existing completion records are atomically copied there with their original
+ownership and modes before cleaning. The source can then pass the subsequent
+readiness and smoke commands; a new boot must produce its own completion facts.
+Missing cloud-init is a no-op. Incomplete initialization, unsafe runtime storage,
+or preservation/cleanup errors stop preparation before sync and version output.
+Native checkpoint preparation and the wrapper's reboot-enabled capture remain
+unchanged.
+
 Windows developer bakes are headless by default for faster boot and fewer
 desktop-bootstrap moving parts. Pass `--desktop` only when the image must back
 interactive desktop leases. Windows container support can require one reboot

--- a/recipes/devtools/v1/linux-x86_64.json
+++ b/recipes/devtools/v1/linux-x86_64.json
@@ -13,7 +13,7 @@
   "inputs": [
     {
       "path": "scripts/install-linux-developer-tools.sh",
-      "sha256": "sha256:45bc70edfb4cd8e2aaf69bb562f2edde0f1a00dbcfeb2760bdba0627c5e1e86e"
+      "sha256": "sha256:2c2c2adc415c6fd866eb396f0907f44ec13192a68f85b9e6e2843f9e1c963b36"
     },
     {
       "path": "scripts/linux-readiness.generated.sh",

--- a/scripts/install-linux-developer-tools.sh
+++ b/scripts/install-linux-developer-tools.sh
@@ -335,6 +335,54 @@ readiness_producer_path() {
   printf '%s\n' "$producer"
 }
 
+clean_cloud_init_state() {
+  if ! command -v cloud-init >/dev/null 2>&1; then
+    return 0
+  fi
+  # Match native checkpoint preparation: preserve real completion facts only in
+  # tmpfs, so cleaning the image does not invalidate this boot or certify a clone.
+  /usr/bin/python3 -I - <<'PY'
+import json, os, pathlib, shutil, subprocess, sys, tempfile
+from cloudinit.cmd.devel import read_cfg_paths
+
+cloud_init = [sys.executable, "-I", "-m", "cloudinit.cmd.main"]
+def require_done():
+    result = subprocess.run(cloud_init + ["status", "--format=json"], check=True, capture_output=True, text=True, timeout=30)
+    if json.loads(result.stdout)["status"] != "done":
+        raise RuntimeError("developer image preparation requires completed cloud-init initialization")
+
+require_done()
+paths = read_cfg_paths()
+runtime = pathlib.Path(paths.run_dir).absolute()
+cache = pathlib.Path(paths.cloud_dir).resolve()
+for ancestor in (runtime, *runtime.parents):
+    resolved = ancestor.resolve()
+    if resolved == cache or cache in resolved.parents:
+        raise RuntimeError("cloud-init runtime directory must be outside its cleaned disk cache")
+runtime = runtime.resolve()
+filesystem = subprocess.check_output(["stat", "-f", "-c", "%T", str(runtime)], text=True).strip()
+if filesystem != "tmpfs":
+    raise RuntimeError("cloud-init runtime directory must use tmpfs to exclude completion state from the image")
+files = [runtime / "status.json", runtime / "result.json"]
+for path in files:
+    if not path.is_file():
+        raise RuntimeError("cloud-init completion file is missing: " + str(path))
+for path in files:
+    fd, temporary = tempfile.mkstemp(prefix="." + path.name + "-", dir=runtime)
+    os.close(fd)
+    try:
+        original = path.stat()
+        shutil.copy2(path, temporary)
+        os.chown(temporary, original.st_uid, original.st_gid)
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+subprocess.run(cloud_init + ["clean", "--logs", "--seed"], check=True)
+require_done()
+PY
+}
+
 prepare_fast_boot() {
   local readiness_producer
   readiness_producer="$(readiness_producer_path)" || return 1
@@ -342,7 +390,7 @@ prepare_fast_boot() {
   "$readiness_producer"
   systemctl disable --now apt-daily.timer apt-daily-upgrade.timer 2>/dev/null || true
   systemctl mask apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
-  cloud-init clean --logs --seed 2>/dev/null || true
+  clean_cloud_init_state || return $?
   sync
 }
 

--- a/scripts/install-linux-developer-tools.test.js
+++ b/scripts/install-linux-developer-tools.test.js
@@ -73,6 +73,7 @@ test("linux developer image cloud-init cleanup preserves current-boot facts", as
     path.join(repoRoot, "scripts/install-linux-developer-tools.sh"),
     "utf8",
   );
+  assert.equal(source.split("/usr/bin/python3").length, 2, "one distro Python invocation");
   for (const scenario of [
     { name: "completed boot survives cache and seed cleanup", cleaned: true },
     { name: "cleanup failure after cache deletion", failure: "clean", cleaned: true },
@@ -88,10 +89,30 @@ test("linux developer image cloud-init cleanup preserves current-boot facts", as
     { name: "runtime symlink inside cleaned cache", failure: "overlap-link" },
     { name: "second completion copy fails", failure: "copy" },
     { name: "cloud-init absent", failure: "absent" },
+    { name: "hostile fixture paths preserve completed boot", cleaned: true, hostilePath: true },
+    {
+      name: "hostile fixture paths stop after failed cleanup",
+      failure: "clean",
+      cleaned: true,
+      hostilePath: true,
+    },
   ]) {
     await t.test(scenario.name, (t) => {
-      const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-cloud-init-")));
-      t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+      const cwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-cloud-init-")));
+      t.after(() => fs.rmSync(cwd, { recursive: true, force: true }));
+      // Substitutions may only create file canaries in this fixture's working directory.
+      const root = scenario.hostilePath
+        ? path.join(cwd, "spaces $(>dollar-canary) `>backtick-canary` ' \" quotes")
+        : cwd;
+      const assertNoSubstitution = () => {
+        for (const name of ["dollar-canary", "backtick-canary"]) {
+          assert.equal(
+            fs.existsSync(path.join(cwd, name)),
+            false,
+            `fixture paths must not execute shell substitutions: ${name}`,
+          );
+        }
+      };
       const bin = path.join(root, "bin");
       const cache = path.join(root, "cloud");
       const data = path.join(cache, "data");
@@ -102,6 +123,8 @@ test("linux developer image cloud-init cleanup preserves current-boot facts", as
           : path.join(root, "run", "cloud-init");
       for (const directory of [bin, data, seed, runtime])
         fs.mkdirSync(directory, { recursive: true });
+      const interpreter = scenario.hostilePath ? path.join(root, "python") : python.stdout.trim();
+      if (scenario.hostilePath) fs.symlinkSync(python.stdout.trim(), interpreter);
       fs.writeFileSync(path.join(seed, "user-data"), "synthetic seed\n");
       let configuredRuntime = runtime;
       if (scenario.failure === "overlap-link") {
@@ -155,7 +178,7 @@ else:
       if (scenario.failure !== "absent") {
         writeExecutable(
           cloudInit,
-          `#!/bin/sh\nexec ${JSON.stringify(python.stdout.trim())} -I ${JSON.stringify(cli)} "$@"\n`,
+          '#!/bin/sh\nexec "$FIXTURE_PYTHON" -I "$FIXTURE_CLOUD_INIT_SCRIPT" "$@"\n',
         );
       }
       // Exercise the installer body with the existing checkpoint fixture's distro-module boundary.
@@ -185,7 +208,7 @@ exec(compile(sys.stdin.read(), "installer-cloud-init-preparation", "exec"))
       const wrapper = path.join(bin, "python-wrapper");
       writeExecutable(
         wrapper,
-        `#!/bin/sh\nexec ${JSON.stringify(python.stdout.trim())} -I ${JSON.stringify(fixture)} "$@"\n`,
+        '#!/bin/sh\nexec "$FIXTURE_PYTHON" -I "$FIXTURE_MODULE_SCRIPT" "$@"\n',
       );
       writeExecutable(
         path.join(bin, "stat"),
@@ -197,9 +220,9 @@ if [ "$FIXTURE_FAILURE" = disk ]; then printf 'ext4\\n'; else printf 'tmpfs\\n';
       const producer = path.join(bin, "producer");
       writeExecutable(producer, "#!/bin/sh\nexit 0\n");
       const installer = path.join(root, "install.sh");
-      fs.writeFileSync(installer, source.replaceAll("/usr/bin/python3", wrapper));
+      fs.writeFileSync(installer, source.replace("/usr/bin/python3", '"$FIXTURE_PYTHON_WRAPPER"'));
       const shell = `set -euo pipefail
-source ${JSON.stringify(installer)}
+source "$1"
 readiness_producer_path() { printf '%s\\n' "$FIXTURE_PRODUCER"; }
 install() { return 0; }
 systemctl() { return 0; }
@@ -218,26 +241,33 @@ print_versions`;
         FIXTURE_CLI: cloudInit,
         FIXTURE_EVENTS: events,
         FIXTURE_PRODUCER: producer,
+        FIXTURE_PYTHON: interpreter,
+        FIXTURE_CLOUD_INIT_SCRIPT: cli,
+        FIXTURE_MODULE_SCRIPT: fixture,
+        FIXTURE_PYTHON_WRAPPER: wrapper,
       };
       const fails = Boolean(scenario.failure && scenario.failure !== "absent");
       for (let attempt = 0; attempt < 2; attempt++) {
         fs.writeFileSync(events, "");
-        const result = spawnSync("/bin/bash", ["-c", shell], {
-          cwd: repoRoot,
+        const result = spawnSync("/bin/bash", ["-c", shell, "installer-fixture", installer], {
+          cwd,
           env,
           encoding: "utf8",
           timeout: 10000,
         });
+        assertNoSubstitution();
         assert.equal(result.error, undefined);
         assert.equal(result.signal, null);
         if (fails) assert.notEqual(result.status, 0, `${scenario.name}: cleanup must fail closed`);
         else assert.equal(result.status, 0, result.stderr || result.stdout);
         if (scenario.cleaned) {
           const status = spawnSync(cloudInit, ["status", "--format=json"], {
+            cwd,
             env: { ...env, FIXTURE_FAILURE: "" },
             encoding: "utf8",
             timeout: 10000,
           });
+          assertNoSubstitution();
           assert.equal(status.status, 0, status.stderr);
           assert.equal(
             JSON.parse(status.stdout).status,
@@ -273,10 +303,12 @@ print_versions`;
         // A new boot does not inherit tmpfs facts or the cleaned disk cache/seed.
         for (const name of Object.keys(facts)) fs.unlinkSync(path.join(runtime, name));
         const nextBoot = spawnSync(cloudInit, ["status", "--format=json"], {
+          cwd,
           env: { ...env, FIXTURE_FAILURE: "" },
           encoding: "utf8",
           timeout: 10000,
         });
+        assertNoSubstitution();
         assert.equal(nextBoot.status, 0, nextBoot.stderr);
         assert.equal(JSON.parse(nextBoot.stdout).status, "notstarted");
       }

--- a/scripts/install-linux-developer-tools.test.js
+++ b/scripts/install-linux-developer-tools.test.js
@@ -28,12 +28,17 @@ test("linux developer image installs every readiness package from the generated 
   assert.doesNotMatch(source, /(?:>|tee\s+).*\/var\/lib\/crabbox(?:\/image-ready|-readiness\/linux\.json)/);
 });
 
-test("linux developer image executes the standalone producer and stops when capability proof fails", () => {
+test("linux developer image executes the standalone producer and stops when capability proof fails", (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-linux-readiness-installer-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
   const scriptRoot = path.join(root, "scripts");
   const marker = path.join(root, "producer.called");
+  const cleaned = path.join(root, "cleanup.called");
   fs.mkdirSync(scriptRoot);
-  fs.copyFileSync(path.join(repoRoot, "scripts/install-linux-developer-tools.sh"), path.join(scriptRoot, "install.sh"));
+  fs.copyFileSync(
+    path.join(repoRoot, "scripts/install-linux-developer-tools.sh"),
+    path.join(scriptRoot, "install.sh"),
+  );
   writeExecutable(
     path.join(scriptRoot, "linux-readiness.generated.sh"),
     `#!/usr/bin/env bash\nprintf 'verified\\n' >${JSON.stringify(marker)}\nexit \"\${CRABBOX_FAKE_PRODUCER_EXIT:-0}\"\n`,
@@ -42,18 +47,241 @@ test("linux developer image executes the standalone producer and stops when capa
 source ${JSON.stringify(path.join(scriptRoot, "install.sh"))}
 install() { return 0; }
 systemctl() { return 0; }
-cloud-init() { return 0; }
+clean_cloud_init_state() { printf 'cleaned\\n' >${JSON.stringify(cleaned)}; }
 sync() { return 0; }
 prepare_fast_boot`;
   const successful = spawnSync("bash", ["-c", shell], { cwd: repoRoot, encoding: "utf8" });
   assert.equal(successful.status, 0, successful.stderr || successful.stdout);
   assert.equal(fs.readFileSync(marker, "utf8"), "verified\n");
+  assert.equal(fs.readFileSync(cleaned, "utf8"), "cleaned\n");
+  fs.unlinkSync(cleaned);
   const failed = spawnSync("bash", ["-c", shell], {
     cwd: repoRoot,
     encoding: "utf8",
     env: { ...process.env, CRABBOX_FAKE_PRODUCER_EXIT: "73" },
   });
   assert.equal(failed.status, 73, failed.stderr || failed.stdout);
+  assert.equal(fs.existsSync(cleaned), false);
+});
+
+test("linux developer image cloud-init cleanup preserves current-boot facts", async (t) => {
+  const python = spawnSync("python3", ["-c", "import sys; print(sys.executable)"], {
+    encoding: "utf8",
+  });
+  assert.equal(python.status, 0, python.stderr);
+  const source = fs.readFileSync(
+    path.join(repoRoot, "scripts/install-linux-developer-tools.sh"),
+    "utf8",
+  );
+  for (const scenario of [
+    { name: "completed boot survives cache and seed cleanup", cleaned: true },
+    { name: "cleanup failure after cache deletion", failure: "clean", cleaned: true },
+    { name: "completion status changes after cleanup", failure: "after-clean", cleaned: true },
+    { name: "initialization still running", failure: "running" },
+    { name: "initialization not started", failure: "notstarted" },
+    { name: "cloud-init disabled", failure: "disabled" },
+    { name: "status command fails", failure: "status" },
+    { name: "malformed status", failure: "malformed" },
+    { name: "persistent runtime filesystem", failure: "disk" },
+    { name: "filesystem inspection fails", failure: "stat" },
+    { name: "runtime inside cleaned cache", failure: "overlap" },
+    { name: "runtime symlink inside cleaned cache", failure: "overlap-link" },
+    { name: "second completion copy fails", failure: "copy" },
+    { name: "cloud-init absent", failure: "absent" },
+  ]) {
+    await t.test(scenario.name, (t) => {
+      const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-cloud-init-")));
+      t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+      const bin = path.join(root, "bin");
+      const cache = path.join(root, "cloud");
+      const data = path.join(cache, "data");
+      const seed = path.join(cache, "seed");
+      const runtime =
+        scenario.failure === "overlap"
+          ? path.join(cache, "runtime")
+          : path.join(root, "run", "cloud-init");
+      for (const directory of [bin, data, seed, runtime])
+        fs.mkdirSync(directory, { recursive: true });
+      fs.writeFileSync(path.join(seed, "user-data"), "synthetic seed\n");
+      let configuredRuntime = runtime;
+      if (scenario.failure === "overlap-link") {
+        configuredRuntime = path.join(cache, "runtime-link");
+        fs.symlinkSync(runtime, configuredRuntime);
+      }
+      const facts = {
+        "status.json": '{"v1":{"modules-final":{"finished":123}}}\n',
+        "result.json": '{"v1":{"errors":[]}}\n',
+      };
+      const originals = {};
+      for (const [name, contents] of Object.entries(facts)) {
+        const target = path.join(data, name);
+        fs.writeFileSync(target, contents);
+        fs.chmodSync(target, name === "status.json" ? 0o644 : 0o640);
+        originals[name] = fs.statSync(target);
+        fs.symlinkSync(path.relative(runtime, target), path.join(runtime, name));
+      }
+      const events = path.join(root, "events");
+      const cloudInit = path.join(bin, "cloud-init");
+      const cli = path.join(root, "cloud-init.py");
+      fs.writeFileSync(
+        cli,
+        `import json, os, pathlib, shutil, sys
+args = sys.argv[1:]
+runtime = pathlib.Path(os.environ["FIXTURE_RUN"])
+failure = os.environ["FIXTURE_FAILURE"]
+if args == ["status", "--format=json"]:
+    if failure == "status":
+        sys.exit(4)
+    if failure == "malformed":
+        print("not json")
+        sys.exit(0)
+    status = failure if failure in ("running", "notstarted", "disabled") else "done"
+    if failure == "after-clean" and "clean\\n" in pathlib.Path(os.environ["FIXTURE_EVENTS"]).read_text():
+        status = "notstarted"
+    if not all((runtime / name).is_file() for name in ("status.json", "result.json")):
+        status = "notstarted"
+    print(json.dumps({"status": status}))
+elif args == ["clean", "--logs", "--seed"]:
+    with open(os.environ["FIXTURE_EVENTS"], "a") as log:
+        log.write("clean\\n")
+    shutil.rmtree(os.environ["FIXTURE_DATA"], ignore_errors=True)
+    shutil.rmtree(os.environ["FIXTURE_SEED"], ignore_errors=True)
+    if failure == "clean":
+        sys.exit(7)
+else:
+    sys.exit("unexpected cloud-init arguments")
+`,
+      );
+      if (scenario.failure !== "absent") {
+        writeExecutable(
+          cloudInit,
+          `#!/bin/sh\nexec ${JSON.stringify(python.stdout.trim())} -I ${JSON.stringify(cli)} "$@"\n`,
+        );
+      }
+      // Exercise the installer body with the existing checkpoint fixture's distro-module boundary.
+      const fixture = path.join(root, "fixture.py");
+      fs.writeFileSync(
+        fixture,
+        `import os, shutil, subprocess, sys, types
+module = types.ModuleType("cloudinit.cmd.devel")
+module.read_cfg_paths = lambda: types.SimpleNamespace(run_dir=os.environ["FIXTURE_RUN"], cloud_dir=os.environ["FIXTURE_CACHE"])
+sys.modules["cloudinit.cmd.devel"] = module
+run = subprocess.run
+def fixture_run(args, **kwargs):
+    if args[:4] == [sys.executable, "-I", "-m", "cloudinit.cmd.main"]:
+        args = [os.environ["FIXTURE_CLI"]] + args[4:]
+    return run(args, **kwargs)
+subprocess.run = fixture_run
+copy = shutil.copy2
+def fixture_copy(source, target):
+    if os.environ["FIXTURE_FAILURE"] == "copy" and source.name == "result.json":
+        raise OSError("injected second-copy failure")
+    return copy(source, target)
+shutil.copy2 = fixture_copy
+assert sys.argv[1:] == ["-I", "-"]
+exec(compile(sys.stdin.read(), "installer-cloud-init-preparation", "exec"))
+`,
+      );
+      const wrapper = path.join(bin, "python-wrapper");
+      writeExecutable(
+        wrapper,
+        `#!/bin/sh\nexec ${JSON.stringify(python.stdout.trim())} -I ${JSON.stringify(fixture)} "$@"\n`,
+      );
+      writeExecutable(
+        path.join(bin, "stat"),
+        `#!/bin/sh
+if [ "$FIXTURE_FAILURE" = stat ]; then exit 9; fi
+if [ "$FIXTURE_FAILURE" = disk ]; then printf 'ext4\\n'; else printf 'tmpfs\\n'; fi
+`,
+      );
+      const producer = path.join(bin, "producer");
+      writeExecutable(producer, "#!/bin/sh\nexit 0\n");
+      const installer = path.join(root, "install.sh");
+      fs.writeFileSync(installer, source.replaceAll("/usr/bin/python3", wrapper));
+      const shell = `set -euo pipefail
+source ${JSON.stringify(installer)}
+readiness_producer_path() { printf '%s\\n' "$FIXTURE_PRODUCER"; }
+install() { return 0; }
+systemctl() { return 0; }
+sync() { printf 'sync\\n' >>"$FIXTURE_EVENTS"; }
+print_versions() { printf 'versions\\n' >>"$FIXTURE_EVENTS"; }
+prepare_fast_boot
+print_versions`;
+      const env = {
+        PATH: bin,
+        HOME: root,
+        FIXTURE_FAILURE: scenario.failure ?? "",
+        FIXTURE_RUN: configuredRuntime,
+        FIXTURE_CACHE: cache,
+        FIXTURE_DATA: data,
+        FIXTURE_SEED: seed,
+        FIXTURE_CLI: cloudInit,
+        FIXTURE_EVENTS: events,
+        FIXTURE_PRODUCER: producer,
+      };
+      const fails = Boolean(scenario.failure && scenario.failure !== "absent");
+      for (let attempt = 0; attempt < 2; attempt++) {
+        fs.writeFileSync(events, "");
+        const result = spawnSync("/bin/bash", ["-c", shell], {
+          cwd: repoRoot,
+          env,
+          encoding: "utf8",
+          timeout: 10000,
+        });
+        assert.equal(result.error, undefined);
+        assert.equal(result.signal, null);
+        if (fails) assert.notEqual(result.status, 0, `${scenario.name}: cleanup must fail closed`);
+        else assert.equal(result.status, 0, result.stderr || result.stdout);
+        if (scenario.cleaned) {
+          const status = spawnSync(cloudInit, ["status", "--format=json"], {
+            env: { ...env, FIXTURE_FAILURE: "" },
+            encoding: "utf8",
+            timeout: 10000,
+          });
+          assert.equal(status.status, 0, status.stderr);
+          assert.equal(
+            JSON.parse(status.stdout).status,
+            "done",
+            "clean must not leave dangling current-boot completion records",
+          );
+        }
+        for (const [name, contents] of Object.entries(facts)) {
+          const file = path.join(runtime, name);
+          assert.equal(fs.readFileSync(file, "utf8"), contents);
+          const original = originals[name];
+          const actual = fs.statSync(file);
+          assert.equal(actual.mode & 0o777, original.mode & 0o777);
+          assert.equal(actual.uid, original.uid);
+          assert.equal(actual.gid, original.gid);
+          if (scenario.cleaned)
+            assert.ok(fs.lstatSync(file).isFile(), "preserved facts must be regular runtime files");
+        }
+        assert.equal(fs.existsSync(data), !scenario.cleaned, "disk completion cache cleanup");
+        assert.equal(fs.existsSync(seed), !scenario.cleaned, "seed cleanup");
+        assert.deepEqual(
+          fs.readFileSync(events, "utf8").trim().split("\n").filter(Boolean),
+          [...(scenario.cleaned ? ["clean"] : []), ...(!fails ? ["sync", "versions"] : [])],
+          "failed preparation must not sync or print success versions",
+        );
+        assert.deepEqual(
+          fs.readdirSync(runtime).sort(),
+          Object.keys(facts).sort(),
+          "no temporary completion copies may remain",
+        );
+      }
+      if (scenario.cleaned) {
+        // A new boot does not inherit tmpfs facts or the cleaned disk cache/seed.
+        for (const name of Object.keys(facts)) fs.unlinkSync(path.join(runtime, name));
+        const nextBoot = spawnSync(cloudInit, ["status", "--format=json"], {
+          env: { ...env, FIXTURE_FAILURE: "" },
+          encoding: "utf8",
+          timeout: 10000,
+        });
+        assert.equal(nextBoot.status, 0, nextBoot.stderr);
+        assert.equal(JSON.parse(nextBoot.stdout).status, "notstarted");
+      }
+    });
+  }
 });
 
 function writeExecutable(file, body) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users preparing a Linux developer image could lose same-boot cloud-init readiness after a successful installer run, preventing subsequent readiness checks and smoke commands from completing.

## Why This Change Was Made

Preserve both existing cloud-init completion records as atomic regular copies in its configured runtime directory before `cloud-init clean --logs --seed`. Like native checkpoint preparation, this requires real `done` status and runtime storage on tmpfs outside the cleaned disk cache, preserves original ownership and modes, and verifies `done` again afterward.

Missing cloud-init remains a no-op. Incomplete initialization, unsafe storage, copy errors, cleanup errors, or a failed post-clean status check stop preparation before sync and version output. Seed cleanup, checkpoint behavior, and reboot-enabled image capture remain unchanged. No flags, configuration, schemas, dependencies, or credentials change.

## User Impact

The running image source retains its real completion facts through cleanup; a new boot must establish its own facts. Preparation failures are no longer silently treated as successful cleanup. Maintainer review accepts the strict `done`/tmpfs preconditions and fail-closed cleanup contract.

## Evidence

- Original installer RED: the executable filesystem fixture failed because successful cleanup left dangling completion links and `notstarted` status.
- Before the fixture quoting correction, 57 installer, recipe-contract, and mint tests passed with zero failures or skips. That result belongs to the original production candidate, not a rerun of the full group at this head.
- Current test-only correction: two hostile-path cases reproduced shell-substitution canary writes before the fix. Paths now pass through argv and quoted environment bindings rather than shell-source interpolation. All 33 installer-file tests pass with zero failures or skips, retaining the completion bytes, ownership/modes, repetition, cache/seed removal, failure, and absent-cloud-init assertions.
- These fixtures execute real Python filesystem operations but substitute cloud-init and filesystem-type responses. They are not native cloud-init, actual tmpfs, reboot, or AMI proof.
- Current test-file syntax, targeted formatting, and `git diff --check` pass. The unchanged production candidate also passed shell syntax, recipe input-digest validation, and documentation-link checks. ShellCheck's pre-existing `SC1090` warning for the nonconstant OS-release source remains unchanged.
- The production repair and the final test-only correction each received a default-P0 autoreview, scoped-clean with no findings, plus independent inspection and acceptance.

Current focused validation:

```sh
node --test --test-reporter=tap scripts/install-linux-developer-tools.test.js
node --check scripts/install-linux-developer-tools.test.js
git diff --check
```

Production code is bound to commit `f85957e5ce59ce3a2d67dc30b927f0d6953eebd9`. Head `a623866b2bf3f52cb5e6396a34d97fbf29a4c729` adds only the fixture correction after the changelog-link commit; installer, recipe, runbook, and changelog bytes are unchanged. [Exact-head CI](https://github.com/openclaw/crabbox/actions/runs/34101938509) and the required [Crabbox Release Check](https://github.com/openclaw/crabbox/actions/runs/34101938511) succeeded. The completed watch recorded 26 successful checks, three skipped, and no failures.

CodeQL completed successfully but [alert 81](https://github.com/openclaw/crabbox/security/code-scanning/81) remains open. Source and model review accepted the corrected call: the Bash `-c` program is constant, the installer path is a separate positional argument, and `source "$1"` is quoted. The reviewed [CodeQL 2.26.4 argument model](https://github.com/github/codeql/blob/codeql-cli/v2.26.4/javascript/ql/lib/semmle/javascript/security/dataflow/IndirectCommandArgument.qll#L97-L108) selects an argument-list property without constraining its index; this does not establish injection into the constant command string. No remaining injection was identified at this call. This is a source/model disposition, not a scanner-clean result or a replay of the exact hosted query pack; no alert was dismissed.

Native evidence: an earlier run of the original installer changed cloud-init from `done` to `not started` and removed its disk completion targets. The operator subsequently verified the repaired same-boot boundary on Ubuntu 24.04 with cloud-init 25.3: completion symlinks with status `done` became regular runtime files with status still `done`, disk completion records were absent, and the installer exited successfully. A subsequent same-boot SSH readiness probe also succeeded within its 120-second budget, the owned readiness-probe cgroup was absent, and a fresh cloud-init log reported `done`.

That native run used an integrated producer whose cleanup helper and `prepare_fast_boot` bodies match this PR; it was not execution of this complete PR head. It proves this same-boot cleanup/readiness boundary only, not new SSH authentication, fresh-boot behavior, AMI qualification, downstream consumer/Runner correctness, or performance. Those checks remain campaign qualification gates, not landing gates for this scoped fix. It does not retrospectively establish the cause of earlier transport failures.

<!-- Punchcard-Session: calm-lantern-orchard-dn -->
