### PR TITLE
fix(islo): give sandbox creation a bounded operation budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Tailscale: keep provider diagnostics and OAuth credentials out of preflight and tag-ownership errors while preserving operation, HTTP status, and actionable tag guidance. [PR 1940](https://github.com/openclaw/crabbox/pull/1940).
 - Publish run diagnostics without delaying workload admission, while preserving ordered lease attribution and joining pending publication before terminal recording. [PR 1937](https://github.com/openclaw/crabbox/pull/1937).
 - Add bounded AWS provisioning logs that separate ingress queue and lifecycle waits from create-operation costs and count redundant security-group permission calls without logging request payloads. [PR 1938](https://github.com/openclaw/crabbox/pull/1938).
-- Give Islo sandbox creation its own five-minute operation budget without shortening command streams or relaxing ordinary API deadlines; report failed create names as unconfirmed locators for explicit identity-checked recovery.
+- Give Islo sandbox creation its own five-minute operation budget without shortening command streams or relaxing ordinary API deadlines; report failed create names as unconfirmed locators for explicit identity-checked recovery. [PR 1955](https://github.com/openclaw/crabbox/pull/1955).
 - Deduplicate validated AWS coordinator SSH ranges after combining lease and global access, avoiding repeated authorization calls for identical port/range pairs while preserving ingress reconciliation. [PR 1945](https://github.com/openclaw/crabbox/pull/1945).
 
 ## 0.51.0 - 2026-09-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Give Islo sandbox creation its own five-minute operation budget without shortening command streams or relaxing ordinary API deadlines; report failed create names as unconfirmed locators for explicit identity-checked recovery.
 - Reuse verified SSH endpoints within an operation, preserving advertised fallbacks when switching hosts or ports and avoiding redundant login probes across direct, proxy, and WSL execution. [PR 1941](https://github.com/openclaw/crabbox/pull/1941).
 - Report image qualification reaping as idle after clean teardown, while preserving failed recovery evidence and checking transient controller ownership before cleanup. [PR 1942](https://github.com/openclaw/crabbox/pull/1942). Thanks @vincentkoc.
 - Add `crabbox bench check` to enforce sample, failure, and p95 runner timing policy across every matched local benchmark group. [PR 1899](https://github.com/openclaw/crabbox/pull/1899). Thanks @vincentkoc.

--- a/docs/features/islo.md
+++ b/docs/features/islo.md
@@ -143,6 +143,13 @@ crabbox stop --provider islo blue-lobster
 - The sandbox is deleted on release unless kept. `--keep-on-failure` keeps a
   newly created failed sandbox until an explicit `stop` or provider-side expiry.
 
+## Create deadlines and uncertain responses
+
+Creation has a five-minute client budget; an earlier caller deadline still wins.
+A failed or incomplete create response reports an unconfirmed name, not an
+acquired lease. See [create deadlines and uncertain responses](../providers/islo.md#create-deadlines-and-uncertain-responses)
+for transport boundaries and explicit identity-checked recovery.
+
 ## URL bridge (per-port shares)
 
 Islo declares the `url-bridge` capability. Crabbox publishes a per-port public

--- a/docs/providers/islo.md
+++ b/docs/providers/islo.md
@@ -235,6 +235,25 @@ running and billable.
   claim. Names that require case, whitespace, or punctuation normalization and
   non-Crabbox sandboxes are rejected.
 
+## Create deadlines and uncertain responses
+
+Sandbox creation has a five-minute total client budget, including authentication,
+response headers, response body, and existing SDK retries. An earlier caller
+cancellation or deadline still wins. The internally owned create transport does
+not apply the ordinary 30-second response-header cutoff; ordinary API and auth
+requests retain it. Command streams remain governed by their caller context,
+cleanup retains its separate 15-second budget, and bounded run-file reads retain
+20 seconds. Explicitly supplied HTTP clients keep their own transport/timeouts.
+
+These are client limits, not a provider provisioning SLA, resource TTL, or
+billing cap. A create timeout, lost response, or incomplete response can leave a sandbox running even
+though Crabbox has no acquired lease. The error reports the requested name as an
+**unconfirmed attempt locator**, not an ownership claim. Inspect the resource's
+identity and the intended repository/account before explicitly using the
+existing `--reclaim` adoption flow and `crabbox stop`. Crabbox does not
+invent a pending claim, automatically adopt/delete by that name, or add a create
+retry. The locator is not a crash-safe journal or an exactly-once guarantee.
+
 ## Live testing
 
 Two opt-in smoke tests in `internal/providers/islo/backend_live_test.go`

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -14,6 +14,7 @@ import (
 
 	gosdk "github.com/islo-labs/go-sdk"
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type Config = core.Config
@@ -669,10 +670,10 @@ func (b *isloBackend) createSandbox(ctx context.Context, client isloAPI, repo Re
 	}
 	sandbox, err := client.CreateSandbox(ctx, create)
 	if err != nil {
-		return "", "", "", core.LeaseClaim{}, isloError("create sandbox", err)
+		return "", "", "", core.LeaseClaim{}, b.unconfirmedCreateError(name, isloError("create sandbox", err))
 	}
 	if sandbox == nil || sandbox.GetName() == "" {
-		return "", "", "", core.LeaseClaim{}, exit(5, "islo create sandbox returned no name")
+		return "", "", "", core.LeaseClaim{}, b.unconfirmedCreateError(name, exit(5, "islo create sandbox returned no name"))
 	}
 	leaseID := isloLeasePrefix + sandbox.GetName()
 	identity := isloIdentityFromSandbox(sandbox)
@@ -701,6 +702,14 @@ func (b *isloBackend) createSandbox(ctx context.Context, client isloAPI, repo Re
 		return "", "", "", core.LeaseClaim{}, err
 	}
 	return leaseID, sandbox.GetName(), slug, acquired, nil
+}
+
+// The requested name is an operator-review locator, never acquisition or
+// adoption/deletion authority after a failed or incomplete create response.
+func (b *isloBackend) unconfirmedCreateError(name string, cause error) error {
+	message := fmt.Sprintf("%v; unconfirmed create attempt name=%q: a sandbox may exist, but no lease was acquired; verify its identity before explicit --reclaim and stop", cause, name)
+	message = shared.RedactErrorSecrets(message, b.cfg.Islo.APIKey)
+	return shared.ExitErrorWithCause(core.ExitCodeForError(cause, 1), message, cause)
 }
 
 func isloUnclaimedCleanupError(cause error, name string, cleanupErr error) error {

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -1991,6 +1991,7 @@ type fakeIsloSyncClient struct {
 	rejectCanceledContext    bool
 	closeUploadReader        bool
 	createRequest            *gosdk.CreateSandboxRequest
+	createErr                error
 	createSandboxHook        func()
 	createName               string
 	createID                 string
@@ -2065,6 +2066,9 @@ func (f *fakeIsloSyncClient) liveSandbox(name string) *gosdk.SandboxResponse {
 
 func (f *fakeIsloSyncClient) CreateSandbox(_ context.Context, req *gosdk.CreateSandboxRequest) (*gosdk.SandboxResponse, error) {
 	f.createRequest = req
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
 	if f.createID == "" {
 		f.createID = isloTestResourceID
 	}
@@ -2343,5 +2347,96 @@ func tarGzipContains(t *testing.T, data []byte, name string) bool {
 		if header.Name == name {
 			return true
 		}
+	}
+}
+
+func TestIsloCreateFailureReportsUnconfirmedAttemptWithoutAcquisition(t *testing.T) {
+	for _, mode := range []string{"run", "warmup"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			isolateIsloTestHome(t)
+			cause := errors.Join(ExitError{Code: 69, Message: "synthetic create failure with synthetic-key"}, context.DeadlineExceeded)
+			client := &fakeIsloSyncClient{createErr: cause}
+			restore := swapNewIsloClient(client)
+			defer restore()
+			cfg := core.BaseConfig()
+			cfg.Islo.APIKey = "synthetic-key"
+			var output bytes.Buffer
+			backend := &isloBackend{cfg: cfg, rt: Runtime{Stdout: &output, Stderr: &output}}
+			repo := Repo{Root: t.TempDir(), Name: "proof"}
+			var result RunResult
+			var err error
+			if mode == "run" {
+				result, err = backend.Run(context.Background(), RunRequest{Repo: repo, Command: []string{"true"}})
+			} else {
+				err = backend.Warmup(context.Background(), WarmupRequest{Repo: repo})
+			}
+			if err == nil || core.ExitCodeForError(err, 1) != 69 || !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("typed cause/code lost: %v", err)
+			}
+			name := *client.createRequest.Name
+			if !strings.Contains(err.Error(), name) || !strings.Contains(err.Error(), "unconfirmed") || strings.Contains(err.Error(), cfg.Islo.APIKey) {
+				t.Fatalf("missing unconfirmed attempt locator: %v", err)
+			}
+			if result.LeaseID != "" || result.Session != nil || strings.Contains(output.String(), "leased ") {
+				t.Fatalf("failed create reported acquired result: %#v %s", result, output.String())
+			}
+			if client.deleteCalls != 0 || len(client.execRequests) != 0 || client.uploadPath != "" {
+				t.Fatal("failed create caused cleanup or workload")
+			}
+			entries, readErr := os.ReadDir(filepath.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims"))
+			if !errors.Is(readErr, os.ErrNotExist) && (readErr != nil || len(entries) != 0) {
+				t.Fatalf("failed create published claim: %v %v", entries, readErr)
+			}
+		})
+	}
+}
+
+type incompleteIsloCreateClient struct {
+	fakeIsloSyncClient
+	response *gosdk.SandboxResponse
+}
+
+func (f *incompleteIsloCreateClient) CreateSandbox(_ context.Context, req *gosdk.CreateSandboxRequest) (*gosdk.SandboxResponse, error) {
+	f.createRequest = req
+	return f.response, nil
+}
+
+func TestIsloIncompleteCreateResponseReportsUnconfirmedAttempt(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		response *gosdk.SandboxResponse
+	}{
+		{"nil response", nil},
+		{"missing name", &gosdk.SandboxResponse{ID: "synthetic-id"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			isolateIsloTestHome(t)
+			client := &incompleteIsloCreateClient{response: tc.response}
+			restore := swapNewIsloClient(client)
+			defer restore()
+			cfg := core.BaseConfig()
+			cfg.Islo.APIKey = "synthetic-key"
+			var output bytes.Buffer
+			backend := &isloBackend{cfg: cfg, rt: Runtime{Stdout: &output, Stderr: &output}}
+			result, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Root: t.TempDir(), Name: cfg.Islo.APIKey}, Command: []string{"true"}})
+			if err == nil || core.ExitCodeForError(err, 1) != 5 {
+				t.Fatalf("incomplete response changed exit5: %v", err)
+			}
+			if !strings.Contains(err.Error(), "unconfirmed") || !strings.Contains(err.Error(), "name=\"crabbox-") || strings.Contains(err.Error(), cfg.Islo.APIKey) {
+				t.Fatalf("missing safe unconfirmed name: %v", err)
+			}
+			if result.LeaseID != "" || result.Session != nil || strings.Contains(output.String(), "leased ") {
+				t.Fatalf("incomplete response reported acquisition: %#v %s", result, output.String())
+			}
+			if client.deleteCalls != 0 || len(client.execRequests) != 0 || client.uploadPath != "" {
+				t.Fatal("incomplete response caused cleanup or workload")
+			}
+			entries, readErr := os.ReadDir(filepath.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims"))
+			if !errors.Is(readErr, os.ErrNotExist) && (readErr != nil || len(entries) != 0) {
+				t.Fatalf("incomplete response published claim: %v %v", entries, readErr)
+			}
+		})
 	}
 }

--- a/internal/providers/islo/client.go
+++ b/internal/providers/islo/client.go
@@ -51,13 +51,15 @@ type IsloShare struct {
 }
 
 type isloSDKClient struct {
-	sdk        *client.Client
-	auth       *customauth.Provider
-	baseURL    string
-	httpClient *http.Client
+	sdk              *client.Client
+	auth             *customauth.Provider
+	baseURL          string
+	httpClient       *http.Client
+	createHTTPClient *http.Client
 }
 
 const isloDefaultResponseHeaderTimeout = 30 * time.Second
+const isloCreateTimeout = 5 * time.Minute
 
 // isloDefaultBaseURL is the Islo control-plane host. It is the default endpoint
 // the SDK client and the claim scope are both built from.
@@ -95,8 +97,18 @@ var newIsloClient = func(cfg Config, rt Runtime) (isloAPI, error) {
 		Timeout:       timeout,
 		CheckRedirect: isloSameOriginRedirectGuard(baseURL, nil),
 	}
+	var createHTTPClient *http.Client
+	if rt.HTTP == nil {
+		// Provisioning can outlast ordinary API headers. Only our private create
+		// transport delegates that wait to the bounded operation context.
+		transport := httpClient.Transport.(*http.Transport).Clone()
+		transport.ResponseHeaderTimeout = 0
+		createClient := *sdkHTTPClient
+		createClient.Transport = customauth.NewTransport(transport, auth)
+		createHTTPClient = &createClient
+	}
 	sdk := client.NewClient(option.WithBaseURL(baseURL), option.WithHTTPClient(sdkHTTPClient))
-	return &isloSDKClient{sdk: sdk, auth: auth, baseURL: baseURL, httpClient: httpClient}, nil
+	return &isloSDKClient{sdk: sdk, auth: auth, baseURL: baseURL, httpClient: httpClient, createHTTPClient: createHTTPClient}, nil
 }
 
 func isloCleanupContext() (context.Context, context.CancelFunc) {
@@ -191,7 +203,13 @@ func isloURLEffectiveOrigin(value *url.URL) string {
 }
 
 func (c *isloSDKClient) CreateSandbox(ctx context.Context, req *gosdk.CreateSandboxRequest) (*gosdk.SandboxResponse, error) {
-	sandbox, err := c.sdk.Sandboxes.CreateSandbox(ctx, req)
+	ctx, cancel := context.WithTimeout(ctx, isloCreateTimeout)
+	defer cancel()
+	var opts []option.RequestOption
+	if c.createHTTPClient != nil {
+		opts = append(opts, option.WithHTTPClient(c.createHTTPClient))
+	}
+	sandbox, err := c.sdk.Sandboxes.CreateSandbox(ctx, req, opts...)
 	if err != nil {
 		return nil, isloSanitizeRedirectError(err)
 	}

--- a/internal/providers/islo/client_test.go
+++ b/internal/providers/islo/client_test.go
@@ -2,12 +2,15 @@ package islo
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	gosdk "github.com/islo-labs/go-sdk"
@@ -137,6 +140,8 @@ func TestIsloRedirectErrorsHideRejectedLocation(t *testing.T) {
 			_, _ = io.WriteString(w, `{"session_token":"test-token"}`)
 		case r.URL.Path == "/sandboxes/raw-location":
 			http.Redirect(w, r, crossOrigin.URL+"/stolen?token=redirect-secret#fragment-secret", http.StatusTemporaryRedirect)
+		case r.URL.Path == "/sandboxes":
+			http.Redirect(w, r, crossOrigin.URL+"/sdk-stolen?token=redirect-secret#fragment-secret", http.StatusTemporaryRedirect)
 		case r.URL.Path == "/sandboxes/sdk-location":
 			http.Redirect(w, r, crossOrigin.URL+"/sdk-stolen?token=redirect-secret#fragment-secret", http.StatusTemporaryRedirect)
 		case r.URL.Path == "/sandboxes/redirect-limit":
@@ -172,6 +177,17 @@ func TestIsloRedirectErrorsHideRejectedLocation(t *testing.T) {
 	}{
 		"raw delete": {
 			call: func() error { return client.DeleteSandbox(context.Background(), "raw-location") },
+			want: "refusing islo redirect",
+		},
+		"default create override": {
+			call: func() error {
+				defaultClient, err := newIsloClient(cfg, Runtime{})
+				if err != nil {
+					return err
+				}
+				_, err = defaultClient.CreateSandbox(context.Background(), &gosdk.CreateSandboxRequest{})
+				return err
+			},
 			want: "refusing islo redirect",
 		},
 		"sdk get": {
@@ -290,5 +306,199 @@ func TestIsloShareFromAPIMarksInvalidExpiryAsSet(t *testing.T) {
 	}
 	if !share.ExpiresAt.IsZero() {
 		t.Fatalf("ExpiresAt=%s want zero for invalid expiry", share.ExpiresAt.Format(time.RFC3339))
+	}
+}
+
+type isloCreateRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f isloCreateRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+type isloCreateContextBody struct{ ctx context.Context }
+
+func (b isloCreateContextBody) Read([]byte) (int, error) { <-b.ctx.Done(); return 0, b.ctx.Err() }
+func (isloCreateContextBody) Close() error               { return nil }
+
+func TestIsloCreateHasBoundedOperationContext(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		parent time.Duration
+		body   bool
+		want   time.Duration
+	}{
+		{"headers", 6 * time.Minute, false, 5 * time.Minute},
+		{"body", 6 * time.Minute, true, 5 * time.Minute},
+		{"earlier caller deadline", time.Minute, false, time.Minute},
+		{"earlier body deadline", time.Minute, true, time.Minute},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				creates := 0
+				transport := isloCreateRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+					if r.URL.Path == "/auth/token" {
+						return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(`{"session_token":"synthetic-token"}`)), Header: http.Header{}}, nil
+					}
+					creates++
+					if tc.body {
+						return &http.Response{StatusCode: 201, Body: isloCreateContextBody{r.Context()}, Header: http.Header{}}, nil
+					}
+					<-r.Context().Done()
+					return nil, r.Context().Err()
+				})
+				api, err := newIsloClient(Config{Islo: IsloConfig{APIKey: "synthetic-key", BaseURL: "https://example.invalid"}}, Runtime{HTTP: &http.Client{Transport: transport}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), tc.parent)
+				defer cancel()
+				start := time.Now()
+				_, err = api.CreateSandbox(ctx, &gosdk.CreateSandboxRequest{})
+				if !errors.Is(err, context.DeadlineExceeded) || time.Since(start) != tc.want || creates != 1 {
+					t.Fatalf("error=%v elapsed=%s creates=%d; want deadline after %s, one create", err, time.Since(start), creates, tc.want)
+				}
+			})
+		})
+	}
+}
+
+func TestIsloCreateSeparatesDefaultHeaderBudget(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/auth/token" {
+			io.WriteString(w, `{"session_token":"synthetic-token"}`)
+			return
+		}
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(100 * time.Millisecond):
+		}
+		io.WriteString(w, `{"id":"synthetic-id","name":"crabbox-proof-abcdef"}`)
+	}))
+	defer server.Close()
+	api, err := newIsloClient(Config{Islo: IsloConfig{APIKey: "synthetic-key", BaseURL: server.URL}}, Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := api.(*isloSDKClient)
+	if _, err := client.auth.Token(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// Scale the ordinary API guard without weakening the create transport.
+	normal := client.httpClient.Transport.(*http.Transport)
+	normal.ResponseHeaderTimeout = 10 * time.Millisecond
+	sandbox, err := client.CreateSandbox(context.Background(), &gosdk.CreateSandboxRequest{})
+	if err != nil || sandbox.GetID() != "synthetic-id" {
+		t.Fatalf("create did not survive ordinary header bound: sandbox=%v err=%v", sandbox, err)
+	}
+	if _, err := client.GetSandbox(context.Background(), "crabbox-proof-abcdef"); err == nil {
+		t.Fatal("ordinary read lost header bound")
+	}
+	if normal.ResponseHeaderTimeout != 10*time.Millisecond {
+		t.Fatal("create mutated ordinary transport")
+	}
+}
+
+func TestIsloCreatePreservesAuthAndInjectedTimeouts(t *testing.T) {
+	for _, mode := range []string{"default auth", "injected create"} {
+		t.Run(mode, func(t *testing.T) {
+			var creates atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/auth/token" {
+					creates.Add(1)
+				}
+				if (mode == "default auth" && r.URL.Path == "/auth/token") || r.URL.Path != "/auth/token" {
+					select {
+					case <-r.Context().Done():
+						return
+					case <-time.After(100 * time.Millisecond):
+					}
+				}
+				if r.URL.Path == "/auth/token" {
+					io.WriteString(w, `{"session_token":"synthetic-token"}`)
+				} else {
+					io.WriteString(w, `{"id":"synthetic-id","name":"crabbox-proof-abcdef"}`)
+				}
+			}))
+			defer server.Close()
+			rt := Runtime{}
+			var injected *http.Client
+			if mode == "injected create" {
+				injected = server.Client()
+				injected.Timeout = 10 * time.Millisecond
+				rt.HTTP = injected
+			}
+			api, err := newIsloClient(Config{Islo: IsloConfig{APIKey: "synthetic-key", BaseURL: server.URL}}, rt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			client := api.(*isloSDKClient)
+			if injected == nil {
+				client.httpClient.Transport.(*http.Transport).ResponseHeaderTimeout = 10 * time.Millisecond
+			} else {
+				if client.createHTTPClient != nil || client.httpClient.Transport != injected.Transport || injected.Timeout != 10*time.Millisecond {
+					t.Fatal("explicit HTTP client changed")
+				}
+				if _, err := client.auth.Token(context.Background()); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, err := client.CreateSandbox(context.Background(), &gosdk.CreateSandboxRequest{}); err == nil {
+				t.Fatal("create relaxed existing auth/injected timeout")
+			}
+			if mode == "default auth" && creates.Load() != 0 {
+				t.Fatal("create followed failed authentication")
+			}
+		})
+	}
+}
+
+func TestIsloCreateCallerCancellationBeforeRequest(t *testing.T) {
+	calls := 0
+	api, err := newIsloClient(Config{Islo: IsloConfig{APIKey: "synthetic-key", BaseURL: "https://example.invalid"}}, Runtime{HTTP: &http.Client{Transport: isloCreateRoundTripFunc(func(*http.Request) (*http.Response, error) { calls++; return nil, errors.New("unexpected request") })}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := api.CreateSandbox(ctx, &gosdk.CreateSandboxRequest{}); !errors.Is(err, context.Canceled) || calls != 0 {
+		t.Fatalf("cancellation err=%v calls=%d", err, calls)
+	}
+}
+
+func TestIsloCreateTransportKeepsStreamingBodyUnbounded(t *testing.T) {
+	original := http.DefaultTransport
+	originalHeader := original.(*http.Transport).ResponseHeaderTimeout
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/auth/token" {
+			io.WriteString(w, `{"session_token":"synthetic-token"}`)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "event: stdout\ndata: started\n\n")
+		w.(http.Flusher).Flush()
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(100 * time.Millisecond):
+		}
+		io.WriteString(w, "event: exit\ndata: 0\n\n")
+	}))
+	defer server.Close()
+	api, err := newIsloClient(Config{Islo: IsloConfig{APIKey: "synthetic-key", BaseURL: server.URL}}, Runtime{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := api.(*isloSDKClient)
+	if _, err := client.auth.Token(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	client.httpClient.Transport.(*http.Transport).ResponseHeaderTimeout = 10 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	code, err := client.ExecStream(ctx, "crabbox-proof-abcdef", &gosdk.ExecRequest{}, io.Discard, io.Discard)
+	if err != nil || code != 0 {
+		t.Fatalf("stream body stopped at header bound: %d %v", code, err)
+	}
+	if http.DefaultTransport != original || original.(*http.Transport).ResponseHeaderTimeout != originalHeader {
+		t.Fatal("global transport mutated")
 	}
 }


### PR DESCRIPTION
## Observed problem

A normal Islo create during validation of https://github.com/openclaw/crabbox/pull/1947 timed out after 30.593 seconds waiting for response headers. No acquisition claim was published, but a matching allocation was later found. Separately authorized, identity-checked recovery through the existing reclaim/Stop path confirmed cleanup. The failed comparison remains failed; no provider-side latency explanation or successful original acquisition is inferred.

The default Islo transport applies a 30-second header cutoff to every operation. Sandbox creation can exceed it even while the caller still has time available. Its generic error also loses the requested-name locator, making a response-loss failure harder to investigate.

## Provider-local fix and boundaries

Give CreateSandbox a five-minute total operation context, including authentication, headers, body and existing SDK backoff. An earlier caller cancellation/deadline wins. Only the internally owned default create transport skips the shorter header cutoff; the SDK override retains the same authentication provider and same-origin redirect guard. Ordinary/auth deadlines, caller-controlled streams, injected HTTP clients, detached 15-second cleanup, and 20-second run-file reads remain unchanged.

Failed or incomplete create responses now use one display-safe helper that reports the requested name as an **unconfirmed attempt locator** and retains original causes/public codes. Nil/missing-name responses still exit 5. This does not report a leased session, publish a pending claim, issue workload/sync/cleanup, automatically adopt/delete by name, or add a retry.

Five minutes is a maintainer-selected client policy—not an Islo SLA, resource TTL, billing cap, crash-safe journal, or exactly-once guarantee. General accepted-request/lost-response recovery remains explicitly unresolved. The opt-in idle-policy feature in https://github.com/openclaw/crabbox/pull/1706 is separate and untouched.

## Completed validation

- Tests-first established the premature header cutoff, absent create/body total budget, and missing locators; earlier caller deadline behavior was a passing control. Two additional nil/missing-name controls failed before the helper was completed, then passed with original exit 5 and no acquisition side effects.
- An identical external fixture used the real production client with isolated, trusted-loopback HTTP/2 and synthetic credentials. A server delayed create headers for 32 seconds: baseline timed out at 30.005s; the final candidate succeeded at 32.007s. Each sent one auth request and one create. No hosted resource was involved in this transport proof.
- Virtual-time tests cover the exact five-minute header/body cap. Other controls cover caller cancellation, auth/injected-client limits, unchanged streaming behavior and global transport, redirect refusal/redaction, and safe unconfirmed diagnostics.
- Integrated Go 1.26.5 races passed: Islo 7.403s, shared 3.181s; vet passed; four docs-checker tests and 246 Markdown links passed.
- Independent Codex review of the complete integrated candidate returned no accepted P0 findings; priority-scoped, not an all-priority certificate.

The integration changed only changelog placement; all six other patch files match the reviewed fix. Existing main changes and frozen release notes are preserved. The feature page links to one canonical deadline/recovery section instead of duplicating the full policy.

## Hosted qualification completed

One normal hosted smoke ran on combined tree `abd346d6` (PR head `f26ddd9c` with main `079a97a6`), CLI SHA256 `b5cca74debebf965a61aa678e639a0953fd86fa600cca755fe717a751c6e6930`. It used the existing canonical Islo endpoint, an explicit Ubuntu 26.04 image, 1 vCPU, 1024 MB RAM and a 10 GB disk, with one allocation and isolated key-free config/state.

| Actual CLI operation | Exit | Process duration |
| --- | ---: | ---: |
| Warmup | 0 | 33.268s |
| Status with 60-second wait limit | 0 | 0.654s |
| Reused no-sync marker command | 0 | 1.254s |
| Normal guarded Stop | 0 | 1.176s |

Observed output excerpts (owned identifiers omitted):

```text
warmup complete total=33.163s
state=running ... ready=true
ISLO_CREATE_BUDGET_SMOKE_OK
islo run summary sync_skipped=true command=286ms total=1.134s exit=0
released lease=<owned-lease> sandbox=<owned-sandbox> proof=tombstone
```

The acquired claim and subsequent read matched the immutable ID, name, endpoint, repository, image and shape. After Stop, an independent exact-ID read showed deleted, the exact-name read returned HTTP404, and no local claim remained. All children were reaped; credentials and the task window were removed. One outer Warmup was invoked; this is not an instrumented count of SDK HTTP retries. No discovery, adoption, alternate route/image or additional allocation was used.

The 33-second duration is whole CLI/provider Warmup time, **not an instrumented hosted header wait**. The separate local HTTP/2 comparison remains the direct old-30s/new-32s header-cutoff evidence. This smoke qualifies create/status/no-sync/Stop compatibility, not the pending finalizer in https://github.com/openclaw/crabbox/pull/1947. The earlier failed baseline and separate operator cleanup remain unchanged historical evidence.

## Latest-main integration and evidence boundary

Main subsequently added the independent warmup-reporting refactor. The latest clean combined target on `87489604` is `db943c0e`. All Islo files, the entire CLI and command-entrypoint trees, and every existing shared file are identical to the hosted-tested target. Shared additions contain only the new warmup types/function and tests, with no initialization side effects or Islo callers. Incoming provider work is preserved and excluded from this seven-file patch.

The latest target built successfully, passed Islo/shared races (13.354s/4.232s) and vet, and had all 2,238 source entries/modes reverified. Its whole binary differs from the hosted-tested binary; **no binary equivalence or fresh hosted execution of this later build is claimed**. The maintainer accepts this scoped source-boundary and integration evidence alongside the hosted Islo smoke and direct HTTP/2 transport proof. It is not an all-provider runtime certificate.

No provider credentials, permission grants, endpoints, release records, or fleet deployments are changed. The new fixture also distinguishes unavailable observations or metadata mismatches on a known resource from a positive foreign identity: only the latter blocks guarded cleanup. Cleanup confirmation does not require image/spec fields to survive in a tombstone. Those fixture checks do not add a production mutation path or recovery authority.
