### PR TITLE
refactor: share executable test fixtures

### DIFF
--- a/scripts/aws-account-guard.test.js
+++ b/scripts/aws-account-guard.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
 
 function setupFakeAWS() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-aws-account-guard-"));

--- a/scripts/aws-crabbox-orphan-audit.test.js
+++ b/scripts/aws-crabbox-orphan-audit.test.js
@@ -4,13 +4,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const root = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
 
 function setupFakes({ active = false, invalidLeases = false, regionDiscoveryFails = false } = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-aws-orphan-audit-"));

--- a/scripts/deploy-cloudflare-dynamic-workers-smoke.test.js
+++ b/scripts/deploy-cloudflare-dynamic-workers-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const root = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
 
 function runSmoke(env = {}) {
   return spawnSync("bash", ["scripts/deploy-cloudflare-dynamic-workers-smoke.sh"], {

--- a/scripts/deploy-worker-smoke.test.js
+++ b/scripts/deploy-worker-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-	fs.writeFileSync(file, body, "utf8");
-	fs.chmodSync(file, 0o755);
-}
 
 test("deploy worker smoke parses completed warmup log before cleanup", () => {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-deploy-worker-smoke-"));

--- a/scripts/herdr-plugin.test.js
+++ b/scripts/herdr-plugin.test.js
@@ -4,14 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const pluginRoot = path.join(repoRoot, "plugins", "herdr");
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
 
 test("Herdr plugin manifest exposes the supported Crabbox actions and panes", () => {
   const manifest = fs.readFileSync(path.join(pluginRoot, "herdr-plugin.toml"), "utf8");

--- a/scripts/install-linux-developer-tools.test.js
+++ b/scripts/install-linux-developer-tools.test.js
@@ -6,6 +6,7 @@ import { spawnSync } from "node:child_process";
 import test from "node:test";
 
 import { loadRecipes } from "./generate-linux-readiness.mjs";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const nodesourceSigningKeyFingerprint = "6F71F525282841EEDAF851B42F59B5F99B1BE0B4";
@@ -315,11 +316,6 @@ print_versions`;
     });
   }
 });
-
-function writeExecutable(file, body) {
-	fs.writeFileSync(file, body, "utf8");
-	fs.chmodSync(file, 0o755);
-}
 
 function writeFakeGPG(bin) {
 	writeExecutable(

--- a/scripts/live-agent-sandbox-smoke.test.js
+++ b/scripts/live-agent-sandbox-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
 
 test("Agent Sandbox smoke is non-mutating without live opt-in", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-agent-sandbox-no-live-"));

--- a/scripts/live-auth-smoke.test.js
+++ b/scripts/live-auth-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-	fs.writeFileSync(file, body, "utf8");
-	fs.chmodSync(file, 0o755);
-}
 
 test("live auth smoke removes bearer curl config after curl transport failure", () => {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-auth-smoke-"));

--- a/scripts/live-blaxel-smoke.test.js
+++ b/scripts/live-blaxel-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
 
 function prepareSmokeScript(dir) {
   const tempRoot = path.join(dir, "repo");

--- a/scripts/live-crownest-smoke.test.js
+++ b/scripts/live-crownest-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
 
 test("live Crownest smoke drives doctor, pnpm run, keep, status, reuse, and stop", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-crownest-smoke-"));

--- a/scripts/live-doctor-smoke.test.js
+++ b/scripts/live-doctor-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-	fs.writeFileSync(file, body, "utf8");
-	fs.chmodSync(file, 0o755);
-}
 
 test("live doctor smoke stops when temporary directory creation fails", () => {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-doctor-smoke-"));

--- a/scripts/live-firecracker-smoke.test.js
+++ b/scripts/live-firecracker-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-	fs.writeFileSync(file, body, "utf8");
-	fs.chmodSync(file, 0o755);
-}
 
 function setupFakeCrabbox({ stdout = "", stderr = "", exitCode = 0 }) {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-firecracker-smoke-"));

--- a/scripts/live-github-codespaces-smoke.test.js
+++ b/scripts/live-github-codespaces-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
 
 function prepareSmokeRepo(dir) {
   const tempRoot = path.join(dir, "repo");

--- a/scripts/live-nomad-smoke.test.js
+++ b/scripts/live-nomad-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
 
 function setupFakeCrabbox() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-nomad-live-smoke-"));

--- a/scripts/live-phala-smoke.test.js
+++ b/scripts/live-phala-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
 
 test("Phala smoke is non-mutating without live opt-in", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-phala-no-live-"));

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
 
 test("operations docs cover local runtime live-smoke dispatches", () => {
   const docs = fs.readFileSync(path.join(repoRoot, "docs", "operations.md"), "utf8");

--- a/scripts/live-smolvm-smoke.test.js
+++ b/scripts/live-smolvm-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-	fs.writeFileSync(file, body, "utf8");
-	fs.chmodSync(file, 0o755);
-}
 
 function setupFakeCrabbox() {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-smolvm-live-smoke-"));

--- a/scripts/live-superserve-smoke.test.js
+++ b/scripts/live-superserve-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-	fs.writeFileSync(file, body, "utf8");
-	fs.chmodSync(file, 0o755);
-}
 
 function setupFakeCrabbox() {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-superserve-live-smoke-"));

--- a/scripts/live-unikraft-cloud-smoke.test.js
+++ b/scripts/live-unikraft-cloud-smoke.test.js
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const smokeScript = path.join(repoRoot, "scripts", "live-unikraft-cloud-smoke.sh");
@@ -34,11 +35,6 @@ async function waitForFile(file, timeoutMs = 15_000) {
     await new Promise((resolve) => setTimeout(resolve, 20));
   }
   throw new Error(`timed out waiting for ${path.basename(file)}`);
-}
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
 }
 
 function embeddedRawHelper() {

--- a/scripts/live-vercel-sandbox-smoke.test.js
+++ b/scripts/live-vercel-sandbox-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-	fs.writeFileSync(file, body, "utf8");
-	fs.chmodSync(file, 0o755);
-}
 
 function setupFakeTools() {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-vercel-sandbox-live-smoke-"));

--- a/scripts/openclaw-wsl2-tests.test.js
+++ b/scripts/openclaw-wsl2-tests.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-	fs.writeFileSync(file, body, "utf8");
-	fs.chmodSync(file, 0o755);
-}
 
 test("OpenClaw WSL2 test requires an explicit repository path", () => {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-openclaw-wsl2-missing-repo-"));

--- a/scripts/proxmox-live-smoke.test.js
+++ b/scripts/proxmox-live-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-	fs.writeFileSync(file, body, "utf8");
-	fs.chmodSync(file, 0o755);
-}
 
 function setupFakeCrabbox() {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-proxmox-live-smoke-"));

--- a/scripts/test-go-modules.test.js
+++ b/scripts/test-go-modules.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
 
 function moduleFixture(t, findScript) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-test-go-modules-"));

--- a/scripts/wandb-smoke.test.js
+++ b/scripts/wandb-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-	fs.writeFileSync(file, body, "utf8");
-	fs.chmodSync(file, 0o755);
-}
 
 test("wandb smoke resolves relative CRABBOX_BIN before changing repo", () => {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-wandb-smoke-"));

--- a/scripts/xcpng-iso-e2e-smoke.test.js
+++ b/scripts/xcpng-iso-e2e-smoke.test.js
@@ -5,14 +5,10 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
 
 function makeHelper(dir, behavior) {
   const helper = path.join(dir, "helper");

--- a/scripts/xcpng-live-smoke.test.js
+++ b/scripts/xcpng-live-smoke.test.js
@@ -5,14 +5,10 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
 
 test("xcpng live smoke env file does not override existing process env", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-xcpng-smoke-test-"));


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Repeated executable setup in smoke tests makes fixture maintenance noisy and
allows equivalent helpers to drift between files.

## Why This Change Was Made

This reuses the existing shared executable fixture across 26 test files and
removes the superseded local helper definitions. The helper implementation and
the 224 existing call sites retain their established behavior.

## User Impact

There is no user-visible behavior change. This is a test-only refactor that
reduces the branch by 104 net lines.

## Evidence

- Static source checks confirmed 26 shared-helper consumers, 224 retained call
  sites, and no remaining local helper definitions.
- The shared helper source is unchanged.
- `git diff --check` passed.
- Product tests are intentionally deferred to hosted CI after publication; no
  pre-publication CI result is claimed.
