### PR TITLE
perf(aws): overlap quota and network preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Report producer-confirmed checkpoint non-submission as structured JSON after verified reservation cleanup, without implying that source rollback succeeded. [PR 1952](https://github.com/openclaw/crabbox/pull/1952). Thanks @steipete.
+- Overlap the initial AWS quota lookup with security-group preparation, preserving per-candidate quota checks and joining both operations before launch or failure cleanup.
 - Preserve current-boot cloud-init completion records during Linux developer-image cleanup while still clearing cached initialization and seed data, and fail preparation if cleanup cannot complete safely. [PR 1954](https://github.com/openclaw/crabbox/pull/1954). Thanks @vincentkoc.
 - Stop SSH readiness probes and backoff at the shared deadline, reporting the active probe with authentication unknown instead of mislabeling expired checks as authentication failures. [PR 1949](https://github.com/openclaw/crabbox/pull/1949). Thanks @vincentkoc.
 - Keep AWS deletion and unrelated heartbeat alarm scans out of the ingress queue, and admit control WebSockets independently of lifecycle work, while preserving cleanup claims, alarm deadlines, authentication, and message serialization. [PR 1951](https://github.com/openclaw/crabbox/pull/1951).

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1056,6 +1056,12 @@ rules have separate counters, so expected API errors remain distinguishable from
 failed provisioning. Key-pair preparation, image selection, quota checks and
 instance creation have separate buckets.
 
+The initial quota lookup overlaps security-group preparation within one regional
+create attempt. Its result is reused only by that attempt; every candidate still
+passes its market's quota check before launch. Both preparations settle before
+launch or failure cleanup. The quota bucket counts actual lookups, including a
+separate on-demand lookup only when that fallback is needed.
+
 Durations include each operation's awaited work, including its transport and
 retries; they are not AWS service-side timings. Nested buckets overlap and must
 not be added to their parent. Missing buckets mean the step was not observed,

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -1060,17 +1060,33 @@ export class EC2SpotClient {
             ? ""
             : await this.resolveAMI(config),
       );
-      const securityGroupID = options.withIngress
-        ? await options.withIngress(
-            (cidrs) =>
-              diagnostics.measure("security_group", () =>
-                this.ensureSecurityGroup({ ...config, awsSSHCIDRs: cidrs }, options),
-              ),
-            diagnostics.record,
-          )
-        : await diagnostics.measure("security_group", () =>
-            this.ensureSecurityGroup(config, options),
-          );
+      const quotaCache = new Map<string, Promise<number | undefined>>();
+      const quotaForMarket = (market: LeaseConfig["capacityMarket"]) => {
+        const code = awsQuotaCodeForMarket(market);
+        let quota = quotaCache.get(code);
+        if (!quota) {
+          quota = diagnostics.measure("quota", () => this.appliedServiceQuota(code));
+          quotaCache.set(code, quota);
+        }
+        return quota;
+      };
+      // Quota reads do not own ingress. Join both preparations before launch or
+      // transient-image cleanup so a failed branch cannot leave work running.
+      const [securityGroup, initialQuota] = await Promise.allSettled([
+        options.withIngress
+          ? options.withIngress(
+              (cidrs) =>
+                diagnostics.measure("security_group", () =>
+                  this.ensureSecurityGroup({ ...config, awsSSHCIDRs: cidrs }, options),
+                ),
+              diagnostics.record,
+            )
+          : diagnostics.measure("security_group", () => this.ensureSecurityGroup(config, options)),
+        quotaForMarket(config.capacityMarket),
+      ]);
+      if (securityGroup.status === "rejected") throw securityGroup.reason;
+      if (initialQuota.status === "rejected") throw initialQuota.reason;
+      const securityGroupID = securityGroup.value;
       const pinnedMacHostID = config.target === "macos" ? config.hostID || config.awsMacHostID : "";
       // An explicit Mac host is tied to one hardware family. Resolve that family once so a
       // defaulted --type cannot send an incompatible instance type to the pinned host.
@@ -1088,7 +1104,6 @@ export class EC2SpotClient {
       }
       const candidates = pinnedMacHostType ? [pinnedMacHostType] : awsLaunchCandidates(config);
       const history = new ProvisioningAttemptHistory();
-      const quotaCache = new Map<string, number | undefined>();
       const imageCache = new Map<string, string>();
       const marketFallbackCandidates: string[] = [];
       const pinnedMacOSImageID =
@@ -1128,9 +1143,12 @@ export class EC2SpotClient {
         return imageID;
       };
       for (const serverType of candidates) {
-        // oxlint-disable-next-line eslint/no-await-in-loop -- quota preflight follows sequential fallback order.
-        const preflight = await diagnostics.measure("quota", () =>
-          this.quotaPreflightAttempt(serverType, config.capacityMarket, quotaCache),
+        const preflight = awsQuotaPreflightAttempt(
+          serverType,
+          config.capacityMarket,
+          this.region,
+          // oxlint-disable-next-line eslint/no-await-in-loop -- quota preflight follows sequential fallback order.
+          await quotaForMarket(config.capacityMarket),
         );
         if (preflight) {
           history.record(preflight, `${serverType}: ${preflight.message}`);
@@ -1188,9 +1206,12 @@ export class EC2SpotClient {
       // Retry only candidates whose Spot failure can be recovered by On-Demand.
       if (marketFallbackCandidates.length > 0 && config.capacityFallback.startsWith("on-demand")) {
         for (const serverType of marketFallbackCandidates) {
-          // oxlint-disable-next-line eslint/no-await-in-loop -- on-demand fallback must stay sequential.
-          const preflight = await diagnostics.measure("quota", () =>
-            this.quotaPreflightAttempt(serverType, "on-demand", quotaCache),
+          const preflight = awsQuotaPreflightAttempt(
+            serverType,
+            "on-demand",
+            this.region,
+            // oxlint-disable-next-line eslint/no-await-in-loop -- on-demand fallback must stay sequential.
+            await quotaForMarket("on-demand"),
           );
           if (preflight) {
             history.record(preflight, `on-demand ${serverType}: ${preflight.message}`);
@@ -2831,20 +2852,6 @@ export class EC2SpotClient {
       detail = "";
     }
     return `aws ${action}: http ${status}: ${detail || trimBody(text).replace(/\s+/g, " ")}`;
-  }
-
-  private async quotaPreflightAttempt(
-    serverType: string,
-    market: LeaseConfig["capacityMarket"],
-    quotaCache: Map<string, number | undefined>,
-  ): Promise<ProvisioningAttempt | undefined> {
-    const code = awsQuotaCodeForMarket(market);
-    let quota = quotaCache.get(code);
-    if (!quotaCache.has(code)) {
-      quota = await this.appliedServiceQuota(code);
-      quotaCache.set(code, quota);
-    }
-    return awsQuotaPreflightAttempt(serverType, market, this.region, quota);
   }
 
   private async appliedServiceQuota(quotaCode: string): Promise<number | undefined> {

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -201,6 +201,156 @@ describe("aws provider", () => {
     },
   );
 
+  it.each([
+    { first: "quota", ingressFails: false },
+    { first: "ingress", ingressFails: false },
+    { first: "quota", ingressFails: true },
+    { first: "ingress", ingressFails: true },
+  ])(
+    "overlaps quota and ingress, joining both before launch or failure ($first first, failure=$ingressFails)",
+    async ({ first, ingressFails }) => {
+      const log = vi.spyOn(console, "info").mockImplementation(() => {});
+      const { client, config, markets } = awsMarketFallbackHarness("");
+      const baseFetch = globalThis.fetch;
+      const quotaGate = Promise.withResolvers<void>();
+      const ingressGate = Promise.withResolvers<void>();
+      const entered = new Set<string>();
+      const completed = new Set<string>();
+      let quotaReads = 0;
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        if (new URL(request.url).hostname.startsWith("servicequotas.")) {
+          quotaReads += 1;
+          entered.add("quota");
+          await quotaGate.promise;
+          const response = await baseFetch(request);
+          completed.add("quota");
+          return response;
+        }
+        return baseFetch(request);
+      });
+      const failure = new Error("ingress preparation failed");
+      let settled = false;
+      const creating = client
+        .createServerWithFallback(config, "cbx_abcdef123456", "violet-prawn", "alice@example.com", {
+          withIngress: async (apply) => {
+            entered.add("ingress");
+            await ingressGate.promise;
+            try {
+              if (ingressFails) throw failure;
+              return await apply(["198.51.100.1/32"]);
+            } finally {
+              completed.add("ingress");
+            }
+          },
+        })
+        .then(
+          (value) => {
+            settled = true;
+            return { value };
+          },
+          (error: unknown) => {
+            settled = true;
+            return { error };
+          },
+        );
+      try {
+        await vi.waitFor(() => expect(entered).toEqual(new Set(["quota", "ingress"])));
+        expect(markets).toEqual([]);
+        (first === "quota" ? quotaGate : ingressGate).resolve();
+        await vi.waitFor(() => expect(completed.has(first)).toBe(true));
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(settled).toBe(false);
+        expect(markets).toEqual([]);
+        expect(log).not.toHaveBeenCalled();
+        (first === "quota" ? ingressGate : quotaGate).resolve();
+        const result = await creating;
+        expect(result.error ?? result.value?.server.cloudID).toBe(
+          ingressFails ? failure : "i-fallback",
+        );
+        expect(markets).toEqual(ingressFails ? [] : ["spot"]);
+        expect(quotaReads).toBe(1);
+        expect(log).toHaveBeenCalledTimes(1);
+        const diagnostic = JSON.parse(String(log.mock.calls[0]![0]));
+        expect(diagnostic.outcome).toBe(ingressFails ? "failure" : "success");
+        expect(diagnostic.steps).toContainEqual(
+          expect.objectContaining({ name: "quota", count: 1, errors: 0 }),
+        );
+      } finally {
+        quotaGate.resolve();
+        ingressGate.resolve();
+        await creating;
+      }
+    },
+  );
+
+  it.each([
+    {
+      market: "spot" as const,
+      quota: 32,
+      types: ["c7a.48xlarge", "t3.small"],
+      attempted: ["spot:t3.small"],
+      reads: ["spot"],
+    },
+    {
+      market: "spot" as const,
+      quota: 1,
+      types: ["t3.small"],
+      attempted: ["on-demand:t3.small"],
+      reads: ["spot", "on-demand"],
+    },
+    {
+      market: "on-demand" as const,
+      quota: 1,
+      types: ["t3.small"],
+      attempted: [],
+      reads: ["on-demand"],
+    },
+    {
+      market: "spot" as const,
+      quota: undefined,
+      types: ["t3.small"],
+      attempted: ["spot:t3.small"],
+      reads: ["spot"],
+    },
+  ])("keeps quota admission and market-scoped reuse ($market, quota=$quota)", async (scenario) => {
+    const log = vi.spyOn(console, "info").mockImplementation(() => {});
+    const { client, config, attempted } = awsMarketFallbackHarness(
+      "",
+      scenario.market,
+      scenario.types,
+    );
+    const baseFetch = globalThis.fetch;
+    const reads: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      if (!new URL(request.url).hostname.startsWith("servicequotas.")) return baseFetch(request);
+      const body = (await request.json()) as { QuotaCode: string };
+      const market = body.QuotaCode === awsQuotaCodeForMarket("spot") ? "spot" : "on-demand";
+      reads.push(market);
+      return scenario.quota === undefined
+        ? new Response("quota unavailable", { status: 403 })
+        : Response.json({ Quota: { Value: market === scenario.market ? scenario.quota : 999 } });
+    });
+    const creating = client.createServerWithFallback(
+      config,
+      "cbx_abcdef123456",
+      "violet-prawn",
+      "alice@example.com",
+    );
+    const outcome = await creating.then(
+      () => "created",
+      (error: unknown) => String(error),
+    );
+    expect(outcome).toMatch(scenario.attempted.length ? /^created$/ : /quota/);
+    expect(attempted).toEqual(scenario.attempted);
+    expect(reads).toEqual(scenario.reads);
+    const diagnostic = JSON.parse(String(log.mock.calls[0]![0]));
+    expect(diagnostic.steps).toContainEqual(
+      expect.objectContaining({ name: "quota", count: reads.length }),
+    );
+  });
+
   it("tags every checkpoint AMI backing snapshot with its exact ownership claim", async () => {
     let submitted: URLSearchParams | undefined;
     vi.stubGlobal(
@@ -2939,6 +3089,11 @@ describe("aws provider", () => {
   });
 
   it("waits for transient AMIs before launching from EBS snapshots", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      expect(new URL(request.url).hostname).toBe("servicequotas.eu-west-1.amazonaws.com");
+      return Response.json({ Quota: { Value: 999 } });
+    });
     const client = new EC2SpotClient(
       { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as never,
       "eu-west-1",
@@ -2947,7 +3102,6 @@ describe("aws provider", () => {
       registerSnapshotImage: () => Promise<string>;
       waitForImageAvailable: (imageID: string) => Promise<string>;
       ensureSecurityGroup: () => Promise<string>;
-      quotaPreflightAttempt: () => Promise<undefined>;
       ec2: (action: string, params?: Record<string, string>) => Promise<unknown>;
     };
     const calls: string[] = [];
@@ -2967,7 +3121,6 @@ describe("aws provider", () => {
       calls.push("security-group");
       return "sg-123";
     };
-    client.quotaPreflightAttempt = async () => undefined;
     client.ec2 = async (action, params) => {
       calls.push(`${action}:${params?.ImageId ?? ""}`);
       if (action === "RunInstances") {
@@ -3018,7 +3171,6 @@ describe("aws provider", () => {
       ensureSSHKey: () => Promise<void>;
       registerSnapshotImage: () => Promise<string>;
       waitForImageAvailable: (imageID: string) => Promise<string>;
-      quotaPreflightAttempt: () => Promise<undefined>;
       ec2: (action: string, params?: Record<string, string>) => Promise<unknown>;
     };
     const calls: string[] = [];
@@ -3033,7 +3185,6 @@ describe("aws provider", () => {
       calls.push(`wait:${imageID}`);
       throw new Error("timed out waiting");
     };
-    client.quotaPreflightAttempt = async () => undefined;
     client.ec2 = async (action, params) => {
       calls.push(`${action}:${params?.ImageId ?? ""}`);
       return {};


### PR DESCRIPTION
## Problem

AWS creation performs its first quota lookup only after security-group preparation finishes. A captured create spent 16.7 seconds in quota lookup and 9.3 seconds preparing the security group, in addition to ingress-queue wait. These independent operations unnecessarily extend the serial startup path. The observations include transport and retries, not just AWS service time.

## Change

Start the initial market's quota read alongside security-group preparation and join both before launch or failure cleanup. Keep the cache local to one create attempt, retain each candidate's quota check, and fetch on-demand quota only when that fallback is actually needed. Existing account identity, VPC scoping, permissions, provider retries, and transient-image cleanup remain unchanged. Diagnostic quota counts now reflect actual lookups.

## Validation

- Four deterministic release-order/failure cases fail on the original code and pass with the repair; no instance launches before both preparations finish.
- Quota denial, unavailable quota, candidate reuse, and demand-driven market fallback remain covered.
- Full Worker suite after refresh over the merged coordinator fixes: 2,857 passed, 3 existing skips. AWS/private subset: 99 passed, including Mac, image, and VPC cases.
- Worker/Node types, lint, formatting, and dry-run Worker build passed.
- Independent Codex review: no actionable P0–P2 findings.
- Live candidate deployment: workflow [34117895605](https://github.com/openclaw/crabbox/actions/runs/34117895605), source `f650d3749227a6587d03967493a307edc6925072`, Worker `4797a6a7-690b-4737-8c46-0052daaa8402`. The ordinary AWS allocation succeeded with no version drift, no instance role, and no Tailscale.
- The exact-lease create trace recorded 176.025 seconds total: key preparation 16.951s, ingress wait 155.146s, security-group preparation 2.048s, quota lookup 0.241s, and instance creation 1.880s. The quota read overlapped the preparation path rather than adding a serial wait. These timings do not establish a lower end-to-end latency than the earlier sample; ingress contention dominated this run.
- CLI warmup completed in 239.23 seconds. The subsequent ordinary command refused execution after the existing `/v1/runs` handle request timed out, reproducing the separate [command-admission problem](https://github.com/openclaw/crabbox/issues/1962) also seen before this patch. No requested command was executed or retried.
- Canonical cleanup confirmed the test lease released, provider cleanup complete, instance absent, and task SSH key material removed. A late history record remains for separate attribution/recovery investigation; it was not manually rewritten.

No new configuration, credentials, permissions, persistent state, or dependency changes. Changelog and operational timing documentation are updated.

Maintainer disposition: this maintainer-owned repair includes the normal Unreleased entry. The changelog is maintained here under the repository policy; removing and re-adding it would not change the repair. The live evidence above establishes the changed AWS creation path, not a fully green command workflow or a ten-second cloud-start guarantee.

Current-main conflict resolution at `c8b2745a583da41a4b0c21f79b8455f9d338493e` preserves both Unreleased entries. The production, tests, and operations-documentation patch is identical to the reviewed/live-tested patch; all 91 focused AWS tests pass again. All exact-head checks passed. Two connector builds initially hit upstream Go module download HTTP/2 errors; only those failed jobs were rerun, and both passed without source or check changes.
