### PR TITLE
fix(islo): preserve workspace files during no-sync runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Publish run diagnostics without delaying workload admission, while preserving ordered lease attribution and joining pending publication before terminal recording. [PR 1937](https://github.com/openclaw/crabbox/pull/1937).
 - Add bounded AWS provisioning logs that separate ingress queue and lifecycle waits from create-operation costs and count redundant security-group permission calls without logging request payloads. [PR 1938](https://github.com/openclaw/crabbox/pull/1938).
 - Give Islo sandbox creation its own five-minute operation budget without shortening command streams or relaxing ordinary API deadlines; report failed create names as unconfirmed locators for explicit identity-checked recovery. [PR 1955](https://github.com/openclaw/crabbox/pull/1955).
+- Islo: preserve existing workspace files during `--no-sync` runs even when sync deletion is enabled, while retaining normal archive-sync replacement behavior.
 - Deduplicate validated AWS coordinator SSH ranges after combining lease and global access, avoiding repeated authorization calls for identical port/range pairs while preserving ingress reconciliation. [PR 1945](https://github.com/openclaw/crabbox/pull/1945).
 - Local Actions hydration: support `pnpm/action-setup` with an explicit exact version, including pnpm-before-Node workflows, preserve the managed pnpm for later commands, and accept setup-node's `cache: pnpm` as an explicitly uncached run. [PR 1953](https://github.com/openclaw/crabbox/pull/1953).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Publish run diagnostics without delaying workload admission, while preserving ordered lease attribution and joining pending publication before terminal recording. [PR 1937](https://github.com/openclaw/crabbox/pull/1937).
 - Add bounded AWS provisioning logs that separate ingress queue and lifecycle waits from create-operation costs and count redundant security-group permission calls without logging request payloads. [PR 1938](https://github.com/openclaw/crabbox/pull/1938).
 - Give Islo sandbox creation its own five-minute operation budget without shortening command streams or relaxing ordinary API deadlines; report failed create names as unconfirmed locators for explicit identity-checked recovery. [PR 1955](https://github.com/openclaw/crabbox/pull/1955).
-- Islo: preserve existing workspace files during `--no-sync` runs even when sync deletion is enabled, while retaining normal archive-sync replacement behavior.
+- Islo: preserve existing workspace files during `--no-sync` runs even when sync deletion is enabled, while retaining normal archive-sync replacement behavior. [PR 1959](https://github.com/openclaw/crabbox/pull/1959).
 - Deduplicate validated AWS coordinator SSH ranges after combining lease and global access, avoiding repeated authorization calls for identical port/range pairs while preserving ingress reconciliation. [PR 1945](https://github.com/openclaw/crabbox/pull/1945).
 - Local Actions hydration: support `pnpm/action-setup` with an explicit exact version, including pnpm-before-Node workflows, preserve the managed pnpm for later commands, and accept setup-node's `cache: pnpm` as an explicitly uncached run. [PR 1953](https://github.com/openclaw/crabbox/pull/1953).
 

--- a/docs/providers/islo.md
+++ b/docs/providers/islo.md
@@ -194,6 +194,9 @@ running and billable.
   [why the provider kind stays delegated-run](../features/islo.md#why-the-provider-kind-stays-delegated-run).
 - Crabbox sync: yes, archive sync through the Islo files-archive API, with a
   base64 exec-upload fallback.
+  `--no-sync` creates the workspace directory if needed without deleting
+  existing files. Workspace replacement applies only during archive sync when
+  `sync.delete` is enabled; disabling it preserves existing files before upload.
 - URL bridge: yes. Exposed ports become public HTTPS shares through Islo's
   `/sandboxes/{name}/shares` API, surfaced by `--expose` and the pond bridge
   plane. Share creation is idempotent per port. Requested TTLs are clamped

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -266,7 +266,7 @@ func (b *isloBackend) Run(ctx context.Context, req RunRequest) (RunResult, error
 			return finishResult(), err
 		}
 		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
-	} else if err := b.prepareWorkspace(ctx, client, name, workspace, workloadUser); err != nil {
+	} else if err := b.prepareWorkspace(ctx, client, name, workspace, workloadUser, false); err != nil {
 		return finishResult(), err
 	}
 	commandStart := b.now()

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -742,6 +742,83 @@ func TestNewIsloClientAcceptsExplicitClientWithUnsupportedDefault(t *testing.T) 
 	}
 }
 
+func TestIsloRunWorkspacePreparationRespectsSyncIntent(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash is required to exercise workspace preparation")
+	}
+	for _, tt := range []struct {
+		name     string
+		noSync   bool
+		delete   bool
+		preserve bool
+	}{
+		{name: "no sync preserves with delete enabled", noSync: true, delete: true, preserve: true},
+		{name: "sync replaces with delete enabled", delete: true},
+		{name: "sync preserves with delete disabled", preserve: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			client := &fakeIsloSyncClient{createName: "crabbox-workspace-abcdef"}
+			restore := swapNewIsloClient(client)
+			defer restore()
+			repo := t.TempDir()
+			init := exec.Command("git", "init", repo)
+			if output, err := init.CombinedOutput(); err != nil {
+				t.Fatalf("git init: %v\n%s", err, output)
+			}
+			if err := os.WriteFile(filepath.Join(repo, "input.txt"), []byte("sync input"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg := Config{Islo: IsloConfig{Workdir: "repo"}}
+			cfg.Sync.Delete = tt.delete
+			backend := &isloBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+			if _, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Root: repo, Name: "repo"}, Keep: true, NoSync: tt.noSync, Command: []string{"true"}}); err != nil {
+				t.Fatal(err)
+			}
+			if len(client.execRequests) != 2 {
+				t.Fatalf("exec requests=%d, want preparation and workload", len(client.execRequests))
+			}
+			if got := client.uploaded.Len() > 0; got == tt.noSync {
+				t.Fatalf("archive uploaded=%v, no-sync=%v", got, tt.noSync)
+			}
+			workspace := filepath.Join(t.TempDir(), "workspace")
+			if err := os.Mkdir(workspace, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			marker := filepath.Join(workspace, "retained.txt")
+			if err := os.WriteFile(marker, []byte("retained workspace data"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			// Replay only the emitted preparation against a test-owned directory.
+			command := client.execRequests[0].GetCommand()
+			if len(command) != 3 || command[0] != "bash" || command[1] != "-lc" {
+				t.Fatalf("unexpected preparation command: %q", command)
+			}
+			local := strings.ReplaceAll(command[2], shellQuote("/workspace/repo"), shellQuote(workspace))
+			if local == command[2] {
+				t.Fatal("preparation did not target the configured workspace")
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			if output, err := exec.CommandContext(ctx, bash, "-lc", local).CombinedOutput(); err != nil {
+				t.Fatalf("prepare workspace: %v\n%s", err, output)
+			}
+			data, err := os.ReadFile(marker)
+			if tt.preserve {
+				if err != nil || string(data) != "retained workspace data" {
+					t.Fatalf("workspace marker not preserved: data=%q err=%v", data, err)
+				}
+			} else if !os.IsNotExist(err) {
+				t.Fatalf("sync replacement left marker: err=%v", err)
+			}
+			if backend.cfg.Sync.Delete != tt.delete {
+				t.Fatal("workspace preparation changed sync configuration")
+			}
+		})
+	}
+}
+
 func TestIsloRunReturnsSessionHandleForKeptSandbox(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	client := &fakeIsloSyncClient{createName: "crabbox-repo-abcdef"}

--- a/internal/providers/islo/sync.go
+++ b/internal/providers/islo/sync.go
@@ -51,7 +51,7 @@ func (b *isloBackend) syncWorkspace(ctx context.Context, client isloAPI, name st
 		return nil, 0, err
 	}
 	prepareStarted := b.now()
-	if err := b.prepareWorkspace(ctx, client, name, workspace, user); err != nil {
+	if err := b.prepareWorkspace(ctx, client, name, workspace, user, b.cfg.Sync.Delete); err != nil {
 		return nil, 0, err
 	}
 	prepareDuration := b.now().Sub(prepareStarted)
@@ -97,9 +97,9 @@ func (b *isloBackend) syncWorkspace(ctx context.Context, client isloAPI, name st
 	}, total, nil
 }
 
-func (b *isloBackend) prepareWorkspace(ctx context.Context, client isloAPI, name, workspace, user string) error {
+func (b *isloBackend) prepareWorkspace(ctx context.Context, client isloAPI, name, workspace, user string, replace bool) error {
 	command := "mkdir -p " + shellQuote(workspace)
-	if b.cfg.Sync.Delete {
+	if replace {
 		command = "rm -rf " + shellQuote(workspace) + " && " + command
 	}
 	return b.execShellAs(ctx, client, name, command, user, io.Discard)


### PR DESCRIPTION
## Problem observed in normal hosted use

During the paired validation of https://github.com/openclaw/crabbox/pull/1947, a baseline sandbox successfully synced and ran a workload that exited 7, then was kept. The first `--no-sync` reuse failed before its intended workload. Excerpts from the kept run and subsequent reuse:

```text
PROOF workload-7
sh: 0: cannot open workload.sh: No such file
```

The reuse exited 2. The matrix stopped without executing the finalizer candidate. Both baseline sandboxes were subsequently confirmed deleted by exact immutable-ID reads, exact-name NotFound, and zero task claims. That failed comparison is preserved; cleanup success does not turn it into passing finalizer proof.

## Fix

`prepareWorkspace` previously read `sync.delete` for both archive-sync and no-sync operations. With the default replacement policy, no-sync therefore deleted the retained files it was supposed to use.

Make replacement an explicit operation-local choice: archive sync passes the configured `sync.delete` value; no-sync passes false and only creates the directory if necessary. No configuration mutation, lifecycle hook, new compatibility path, user-routing change, or containment change. Normal sync replacement and non-deleting sync retain their existing behavior. The separate create-budget fix in https://github.com/openclaw/crabbox/pull/1955 remains unchanged.

## Validation

- Tests-first regression drives the real backend Run selection through the existing fake API, then executes its emitted preparation shell solely against a test-owned temporary marker. Baseline no-sync with deletion enabled loses the marker; both ordinary-sync controls pass. All three cases pass with the fix, and archive upload occurs only for sync.
- Go 1.26.5 full Islo/shared race suites passed (9.634s / 3.326s), relevant vet passed, and links across 246 Markdown files passed.
- Independent Codex review found no accepted P0 findings; this is priority-scoped, not an all-priority correctness certificate.
- A bounded sibling source check found the existing no-sync paths in the inspected adapters already use mkdir-only preparation or an explicit operation-local replacement policy. No sibling changes were needed.

## Hosted candidate qualification passed

One frozen candidate smoke ran on exact linked head `b7dedd7d`, tree `e96e4dd9`, CLI SHA256 `9fc781a86ab9aa1545321259f99ba881038f01acafa0ef7fb99b7163ca9700f7`. It used the canonical Islo endpoint, explicit Ubuntu 26.04 image, 1 vCPU, 1024 MB RAM and 10 GB disk, with isolated neutral config and default `sync.delete=true`. No `--no-delete` override or replacement-policy workaround was used.

| Actual CLI step | Exit | Process duration |
| --- | ---: | ---: |
| Synced workload failure, kept | 7 | 30.719s |
| No-sync reuse: retained marker plus missing required artifact | 7 | 1.571s |
| No-sync reuse: successful marker, required file and download | 0 | 1.552s |
| Normal guarded Stop | 0 | 1.152s |

The first reuse printed `PROOF missing-artifact workload-exit-0`: the retained script and marker survived, so the expected required-artifact failure was reached instead of the old missing-script exit 2. The second reuse printed `PROOF reuse-success`, matched the required file and downloaded its exact 21 bytes. The existing artifact timing classification remains unchanged here; correcting it belongs to https://github.com/openclaw/crabbox/pull/1947, which is not included in this binary.

Exactly one outer create was invoked, with no fallback, adoption, or additional allocation. The acquired immutable ID, name, repository and endpoint remained bound; retained observations matched the requested image and shape. After Stop reported `proof=tombstone`, an independent exact-ID read showed deleted, the exact-name read returned HTTP 404, and zero task claims remained. All children and the temporary credential context/task window were removed. Frozen source, fixture and binary hashes were rechecked. One outer invocation is not a measured SDK HTTP-attempt count; the bounded client deadlines are not a provider TTL or billing guarantee.

The earlier baseline failure remains separately recorded. The clean combined target on main `7727af44` is tree `2c34e35c`. All 2,238 source entries and modes were verified, the five-file fix preserves incoming coordinator/installer changes and older release notes, and the rebuilt Go 1.26.5 CLI is byte-for-byte identical to the actual hosted-tested binary above. Islo/shared races (8.513s / 2.907s), vet, and all 33 changed installer tests passed. No additional hosted invocation was needed to establish executable equivalence. Current-head CI, connector smokes, release check, CodeQL and docs proof all passed. Publication here does not claim a coordinator deployment or all-provider live coverage.

Provider docs and the maintainer-owned Unreleased changelog entry are included. No credentials, access grants, endpoints, release records, or fleet deployments change.
