### PR TITLE
fix: preserve readiness polling termination causes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Agent Sandbox, OpenSandbox, and Hyper-V: classify readiness deadlines and cancellation consistently without losing the last probe's diagnostic or changing public exit codes.
 - Report producer-confirmed checkpoint non-submission as structured JSON after verified reservation cleanup, without implying that source rollback succeeded. [PR 1952](https://github.com/openclaw/crabbox/pull/1952). Thanks @steipete.
 - Overlap the initial AWS quota lookup with security-group preparation, preserving per-candidate quota checks and joining both operations before launch or failure cleanup.
 - Preserve current-boot cloud-init completion records during Linux developer-image cleanup while still clearing cached initialization and seed data, and fail preparation if cleanup cannot complete safely. [PR 1954](https://github.com/openclaw/crabbox/pull/1954). Thanks @vincentkoc.

--- a/docs/providers/agent-sandbox.md
+++ b/docs/providers/agent-sandbox.md
@@ -247,6 +247,11 @@ activity refresh or keep-on-failure rerun hint. Explicit missing-root forgetting
 removes only local recovery state; it is not proof of controller or pod deletion.
 Creation/readiness rollback before a fresh run binds remains part of acquisition.
 
+Readiness deadlines and cancellation determine the reported run outcome even
+when the last probe returned a different error. The last diagnostic and its
+public exit code remain available; a stage timeout alone does not authorize
+TTL cleanup or missing-root forgetting.
+
 TTL expiry still forces one UID-checked release attempt even for reused or kept
 claims and when `deleteOnRelease` is false. Expiry before command admission keeps
 exit 4. Expiry after a successful command fails with code 1; an earlier command

--- a/docs/providers/hyperv.md
+++ b/docs/providers/hyperv.md
@@ -145,6 +145,10 @@ PowerShell Direct calls use the guest administrator password. Readiness and
 later guest operations have bounded retries, preventing a stalled call from
 hanging the lease.
 
+Exhausting the PowerShell Direct boot-readiness budget reports a timeout while
+preserving the last probe's diagnostic and public exit code. Caller cancellation
+still takes precedence over that provider-owned budget.
+
 Set `CRABBOX_HYPERV_GUEST_PASSWORD` or `hyperv.guestPassword` in trusted user
 config to match the administrator password in your VHDX template. The provider
 requires an explicit value and disables SSH password authentication after key

--- a/docs/providers/opensandbox.md
+++ b/docs/providers/opensandbox.md
@@ -169,6 +169,11 @@ the remaining absolute TTL, resumes if needed, and checks the budget again
 before updating the claim. Failed admission retains the authorized session
 without refreshing activity or printing a rerun hint for an unusable sandbox.
 
+Running-state and execd readiness report the terminating deadline or cancellation
+consistently, including when it happens between probes. Existing diagnostic text
+and exit codes are preserved. A discovered sandbox expiration remains a separate
+provider failure; it is not reclassified as a caller timeout.
+
 ## Capabilities
 
 - SSH: not driven by Crabbox.

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -1320,7 +1320,38 @@ func FinalizeRunResult(result RunResult, err error) RunResult {
 	return result
 }
 
+// PrimaryRunClassificationCause finds an explicit classification cause only on
+// the primary error path. Ordinary errors retain their full-graph classification;
+// joined secondary failures cannot supply an override through this lookup.
+func PrimaryRunClassificationCause(err error) error {
+	for err != nil {
+		if classified, ok := err.(interface{ RunClassificationCause() error }); ok {
+			if cause := classified.RunClassificationCause(); cause != nil {
+				return cause
+			}
+		}
+		switch wrapped := err.(type) {
+		case interface{ Unwrap() error }:
+			err = wrapped.Unwrap()
+		case interface{ Unwrap() []error }:
+			err = nil
+			for _, child := range wrapped.Unwrap() {
+				if child != nil {
+					err = child
+					break
+				}
+			}
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
 func RunStatusForResult(result RunResult, err error) RunStatus {
+	if cause := PrimaryRunClassificationCause(err); cause != nil {
+		err = cause
+	}
 	if errors.Is(err, context.DeadlineExceeded) {
 		return RunStatusTimedOut
 	}
@@ -1334,6 +1365,9 @@ func RunStatusForResult(result RunResult, err error) RunStatus {
 }
 
 func RunErrorKindForResult(result RunResult, err error) RunErrorKind {
+	if cause := PrimaryRunClassificationCause(err); cause != nil {
+		err = cause
+	}
 	if errors.Is(err, context.DeadlineExceeded) {
 		return RunErrorTimeout
 	}

--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -135,6 +137,51 @@ func TestFinalizeRunResultClassifiesStatus(t *testing.T) {
 				t.Fatalf("status/error=%q/%q want %q/%q", got.Status, got.ErrorKind, tc.want, tc.wantError)
 			}
 		})
+	}
+}
+
+type runClassificationTestError struct {
+	err   error
+	cause error
+}
+
+func (e runClassificationTestError) Error() string                 { return e.err.Error() }
+func (e runClassificationTestError) Unwrap() error                 { return e.err }
+func (e runClassificationTestError) RunClassificationCause() error { return e.cause }
+
+type runClassificationTestJoin []error
+
+func (e runClassificationTestJoin) Error() string   { return "joined failures" }
+func (e runClassificationTestJoin) Unwrap() []error { return e }
+
+func TestRunClassificationUsesOnlyPrimaryMarker(t *testing.T) {
+	primary := runClassificationTestError{err: context.DeadlineExceeded, cause: context.Canceled}
+	providerErr := errors.New("provider failed")
+	for _, tc := range []struct {
+		name   string
+		err    error
+		status RunStatus
+		kind   RunErrorKind
+	}{
+		{name: "direct", err: primary, status: RunStatusCanceled, kind: RunErrorCanceled},
+		{name: "single wrapper", err: fmt.Errorf("readiness: %w", primary), status: RunStatusCanceled, kind: RunErrorCanceled},
+		{name: "primary join", err: errors.Join(primary, context.DeadlineExceeded), status: RunStatusCanceled, kind: RunErrorCanceled},
+		{name: "first nonnil child", err: runClassificationTestJoin{nil, primary, providerErr}, status: RunStatusCanceled, kind: RunErrorCanceled},
+		{name: "nil marker continues", err: runClassificationTestError{err: primary}, status: RunStatusCanceled, kind: RunErrorCanceled},
+		{name: "secondary marker keeps legacy graph", err: errors.Join(providerErr, primary), status: RunStatusTimedOut, kind: RunErrorTimeout},
+		{name: "ordinary join unchanged", err: errors.Join(context.Canceled, context.DeadlineExceeded), status: RunStatusTimedOut, kind: RunErrorTimeout},
+		{name: "ordinary provider unchanged", err: providerErr, status: RunStatusFailed, kind: RunErrorProvider},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := FinalizeRunResult(RunResult{}, tc.err)
+			if result.Status != tc.status || result.ErrorKind != tc.kind {
+				t.Fatalf("outcome=%s/%s want=%s/%s", result.Status, result.ErrorKind, tc.status, tc.kind)
+			}
+		})
+	}
+	pinned := RunResult{ExitCode: 23, Status: RunStatusFailed, ErrorKind: RunErrorCommandExit}
+	if got := FinalizeRunResult(pinned, primary); got.ExitCode != pinned.ExitCode || got.Status != pinned.Status || got.ErrorKind != pinned.ErrorKind {
+		t.Fatalf("pinned outcome changed: %#v", got)
 	}
 }
 

--- a/internal/providers/agentsandbox/backend_test.go
+++ b/internal/providers/agentsandbox/backend_test.go
@@ -2084,11 +2084,13 @@ func TestBoundRunUnadmittedCustodyAndTiming(t *testing.T) {
 	for _, tc := range []struct {
 		name                         string
 		missing, forget, forgetFails bool
+		wantStatus                   core.RunStatus
+		wantKind                     core.RunErrorKind
 	}{
-		{name: "not ready"},
-		{name: "root missing", missing: true},
-		{name: "root forgotten", missing: true, forget: true},
-		{name: "forget failure", missing: true, forget: true, forgetFails: true},
+		{name: "not ready", wantStatus: core.RunStatusTimedOut, wantKind: core.RunErrorTimeout},
+		{name: "root missing", missing: true, wantStatus: core.RunStatusFailed, wantKind: core.RunErrorProvider},
+		{name: "root forgotten", missing: true, forget: true, wantStatus: core.RunStatusFailed, wantKind: core.RunErrorProvider},
+		{name: "forget failure", missing: true, forget: true, forgetFails: true, wantStatus: core.RunStatusFailed, wantKind: core.RunErrorProvider},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := testAgentSandboxConfig(t)
@@ -2149,7 +2151,7 @@ func TestBoundRunUnadmittedCustodyAndTiming(t *testing.T) {
 				t.Fatalf("reports=%+v", w.reports)
 			}
 			report := w.reports[0]
-			if result.ExitCode != core.ExitCodeForError(err, 1) || result.Status != core.RunStatusFailed || result.ErrorKind != core.RunErrorProvider || report.ExitCode != result.ExitCode || report.RunStatus != result.Status || report.ErrorKind != result.ErrorKind {
+			if result.ExitCode != core.ExitCodeForError(err, 1) || result.Status != tc.wantStatus || result.ErrorKind != tc.wantKind || report.ExitCode != result.ExitCode || report.RunStatus != result.Status || report.ErrorKind != result.ErrorKind {
 				t.Fatalf("result=%+v report=%+v err=%v", result, report, err)
 			}
 		})

--- a/internal/providers/agentsandbox/kubernetes.go
+++ b/internal/providers/agentsandbox/kubernetes.go
@@ -851,7 +851,8 @@ func waitForSandboxResourceReadiness(ctx context.Context, client kubernetesClien
 		if lastErr == nil {
 			lastErr = cause
 		}
-		return sandboxResourceReadiness{}, fmt.Errorf("agent-sandbox readiness timed out for claim %s: %w", claimName, lastErr)
+		diagnostic := fmt.Errorf("agent-sandbox readiness timed out for claim %s: %w", claimName, lastErr)
+		return sandboxResourceReadiness{}, shared.PollTerminationError(ctx, err, diagnostic)
 	}
 	return sandboxResourceReadiness{}, err
 }
@@ -891,7 +892,8 @@ func waitForSandboxPodReadiness(ctx context.Context, client kubernetesClient, na
 		if lastErr == nil {
 			lastErr = cause
 		}
-		return podState{}, fmt.Errorf("agent-sandbox pod readiness timed out for sandbox %s: %w", sandbox.Metadata.Name, lastErr)
+		diagnostic := fmt.Errorf("agent-sandbox pod readiness timed out for sandbox %s: %w", sandbox.Metadata.Name, lastErr)
+		return podState{}, shared.PollTerminationError(ctx, err, diagnostic)
 	}
 	return podState{}, err
 }

--- a/internal/providers/agentsandbox/kubernetes_test.go
+++ b/internal/providers/agentsandbox/kubernetes_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -1256,4 +1257,81 @@ func testPodContainer(configured string) string {
 
 func TestMain(m *testing.M) {
 	os.Exit(m.Run())
+}
+
+func TestSandboxReadinessPollingPreservesTerminalCause(t *testing.T) {
+	for _, stage := range []string{"resource", "pod"} {
+		for _, scenario := range []string{"pending then deadline", "deadline during fetch", "stale attempt deadline then cancellation"} {
+			t.Run(stage+"/"+scenario, func(t *testing.T) {
+				synctest.Test(t, func(t *testing.T) {
+					cfg := core.BaseConfig()
+					cfg.AgentSandbox.Context = "agent-context"
+					cfg.AgentSandbox.Namespace = "sandboxes"
+					cfg.AgentSandbox.WarmPool = "linux-pool"
+					fake := readyFakeClient(cfg)
+					sandbox := cloneKubernetesObject(fake.objects[sandboxResource+"/sandboxes/sandbox-a"])
+					ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+					defer cancel()
+					wantCause := error(context.DeadlineExceeded)
+					wantStatus, wantKind := core.RunStatusTimedOut, core.RunErrorTimeout
+					wantCode, detail := 1, "ProbePending"
+					switch scenario {
+					case "pending then deadline":
+						if stage == "resource" {
+							fake.objects[sandboxResource+"/sandboxes/sandbox-a"].Status.Conditions = []conditionState{{Type: "Ready", Status: "False", Reason: detail}}
+						} else {
+							pod := fake.pods["sandboxes/app=agent-sandbox"][0]
+							pod.Ready, pod.Phase = false, "Pending"
+							pod.Conditions = []conditionState{{Type: "Ready", Status: "False", Reason: detail}}
+							fake.pods["sandboxes/app=agent-sandbox"] = []podState{pod}
+						}
+					case "deadline during fetch":
+						fake.getStarted = make(chan struct{}, 1)
+						fake.getRelease = make(chan struct{})
+						detail = context.DeadlineExceeded.Error()
+					case "stale attempt deadline then cancellation":
+						wantCause, wantStatus, wantKind = context.Canceled, core.RunStatusCanceled, core.RunErrorCanceled
+						wantCode, detail = 6, "pending Kubernetes read"
+						last := errors.Join(core.Exit(6, "%s", detail), context.DeadlineExceeded, errKubernetesNotFound)
+						if stage == "resource" {
+							// Keep the root claim present; only its downstream Sandbox read is missing.
+							fake.getErrs = []error{nil, last}
+						} else {
+							fake.getErrs = []error{last}
+						}
+						time.AfterFunc(50*time.Millisecond, cancel)
+					}
+					var err error
+					if stage == "resource" {
+						_, err = waitForSandboxResourceReadiness(ctx, fake, "sandboxes", "claim-a", fakeClaimIdentity(cfg), time.Hour)
+					} else {
+						_, err = waitForSandboxPodReadiness(ctx, fake, "sandboxes", "claim-a", sandbox, fakeClaimIdentity(cfg), time.Hour)
+					}
+					prefix := "agent-sandbox readiness timed out for claim claim-a:"
+					if stage == "pod" {
+						prefix = "agent-sandbox pod readiness timed out for sandbox sandbox-a:"
+					}
+					if err == nil || !strings.HasPrefix(err.Error(), prefix) || !strings.Contains(err.Error(), detail) || core.ExitCodeForError(err, 1) != wantCode {
+						t.Fatalf("readiness diagnostic/code changed: err=%v want prefix=%q detail=%q code=%d", err, prefix, detail, wantCode)
+					}
+					if !errors.Is(err, wantCause) || core.RunStatusForResult(core.RunResult{}, err) != wantStatus || core.RunErrorKindForResult(core.RunResult{}, err) != wantKind {
+						t.Errorf("poll termination lost: err=%v cause=%v status=%s kind=%s; want %v/%s/%s", err, errors.Is(err, wantCause), core.RunStatusForResult(core.RunResult{}, err), core.RunErrorKindForResult(core.RunResult{}, err), wantCause, wantStatus, wantKind)
+					}
+					if scenario == "stale attempt deadline then cancellation" {
+						// Diagnostic history remains reachable; terminal classification is separate.
+						if !errors.Is(err, context.DeadlineExceeded) {
+							t.Error("stale attempt deadline was removed from diagnostic history")
+						}
+						var failure core.ExitError
+						if !core.AsExitError(err, &failure) || failure.Code != 6 || failure.Message != detail {
+							t.Errorf("first typed observation changed: %#v", failure)
+						}
+						if !errors.Is(err, errKubernetesNotFound) || !isNotFound(err) {
+							t.Error("downstream not-found identity lost before exact-root recheck")
+						}
+					}
+				})
+			})
+		}
+	}
 }

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -662,7 +662,8 @@ func (b *backend) waitGuestReady(ctx context.Context, vmName, user string) error
 		if lastErr == nil {
 			lastErr = budgetCtx.Err()
 		}
-		return fmt.Errorf("guest %s did not accept PowerShell Direct within %s: %w", vmName, b.guestReadyBudget, lastErr)
+		diagnostic := fmt.Errorf("guest %s did not accept PowerShell Direct within %s: %w", vmName, b.guestReadyBudget, lastErr)
+		return shared.PollTerminationError(budgetCtx, err, diagnostic)
 	}
 	return err
 }

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -2039,5 +2040,40 @@ func TestAcquireWaitsForGuestReadyBeforeLockdown(t *testing.T) {
 	}
 	if readyIdx >= stageIdx {
 		t.Fatalf("readiness probe (%d) must precede pre-network lockdown (%d)", readyIdx, stageIdx)
+	}
+}
+
+func TestWaitGuestReadyBackoffDeadlinePreservesProbeCodeAndCause(t *testing.T) {
+	for _, code := range []int{23, -9} {
+		t.Run(fmt.Sprintf("code_%d", code), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				runner := &recordingRunner{}
+				runner.respond = func(req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+					if !readinessProbe(req) {
+						t.Fatal("unexpected non-readiness command")
+					}
+					return core.LocalCommandResult{ExitCode: code, Stderr: "guest boot pending"}, errors.New("probe unavailable"), true
+				}
+				b := testBackend(runner)
+				b.guestReadyBudget = 100 * time.Millisecond
+				b.guestReadyProbeTimeout = time.Second
+				b.guestRetryBackoff = time.Hour
+				started := time.Now()
+				err := b.waitGuestReady(context.Background(), "crabbox-blue-1234", "crabbox")
+				if err == nil || !strings.Contains(err.Error(), "did not accept PowerShell Direct within 100ms") || !strings.Contains(err.Error(), "guest boot pending") || core.ExitCodeForError(err, 1) != code {
+					t.Fatalf("boot diagnostic/code changed: err=%v want code=%d", err, code)
+				}
+				var failure core.ExitError
+				if !core.AsExitError(err, &failure) || failure.Code != code || failure.Message != "guest readiness probe failed: probe unavailable: guest boot pending" {
+					t.Errorf("first typed probe error changed: %#v", failure)
+				}
+				if len(runner.calls) != 1 || time.Since(started) != b.guestReadyBudget {
+					t.Fatalf("backoff budget/first probe changed: calls=%d elapsed=%s", len(runner.calls), time.Since(started))
+				}
+				if !errors.Is(err, context.DeadlineExceeded) || core.RunStatusForResult(core.RunResult{}, err) != core.RunStatusTimedOut || core.RunErrorKindForResult(core.RunResult{}, err) != core.RunErrorTimeout {
+					t.Errorf("owned boot deadline lost: err=%v status=%s kind=%s", err, core.RunStatusForResult(core.RunResult{}, err), core.RunErrorKindForResult(core.RunResult{}, err))
+				}
+			})
+		})
 	}
 }

--- a/internal/providers/opensandbox/backend_test.go
+++ b/internal/providers/opensandbox/backend_test.go
@@ -3029,3 +3029,150 @@ func TestRunCancellationAfterResumeDoesNotReclaim(t *testing.T) {
 		t.Fatalf("resumed=%v runs=%v deletes=%v stderr=%s", fake.resumed, fake.runs, fake.deleted, stderr.String())
 	}
 }
+
+func TestSDKClientPollingTerminationPreservesCause(t *testing.T) {
+	t.Setenv("CRABBOX_OPENSANDBOX_API_KEY", "test-key")
+	for _, readiness := range []bool{false, true} {
+		name := "running"
+		if readiness {
+			name = "execd-ready"
+		}
+		for _, termination := range []string{"deadline", "cancel", "custom-deadline", "custom-cancel"} {
+			t.Run(name+"/"+termination, func(t *testing.T) {
+				const id = "sb-poll-cause"
+				pending := sdk.ErrorResponse{Code: "PENDING", Message: "fixture pending"}
+				var server *httptest.Server
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					switch r.URL.Path {
+					case "/v1/sandboxes/" + id:
+						_, _ = io.WriteString(w, `{"id":"sb-poll-cause","status":{"state":"Pending"},"createdAt":"2026-06-11T00:00:00Z"}`)
+					case "/v1/sandboxes/" + id + "/endpoints/44772":
+						_ = json.NewEncoder(w).Encode(map[string]string{"endpoint": server.URL})
+					case "/ping":
+						w.WriteHeader(http.StatusTooEarly)
+						_ = json.NewEncoder(w).Encode(pending)
+					default:
+						t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+						http.NotFound(w, r)
+					}
+				}))
+				defer server.Close()
+
+				customCause := core.ExitError{Code: 7, Message: "fixture custom poll cause"}
+				var ctx context.Context
+				var stop, endObservation func()
+				var wantContext, wantCause error
+				wantStatus, wantKind := core.RunStatusCanceled, core.RunErrorCanceled
+				switch termination {
+				case "deadline":
+					ctx, stop = context.WithTimeout(t.Context(), time.Second)
+					wantContext = context.DeadlineExceeded
+				case "custom-deadline":
+					ctx, stop = context.WithTimeoutCause(t.Context(), time.Second, customCause)
+					wantContext, wantCause = context.DeadlineExceeded, customCause
+				case "cancel":
+					ctx, stop = context.WithCancel(t.Context())
+					endObservation = stop
+					wantContext = context.Canceled
+				case "custom-cancel":
+					var cancel context.CancelCauseFunc
+					ctx, cancel = context.WithCancelCause(t.Context())
+					stop = func() { cancel(nil) }
+					endObservation = func() { cancel(customCause) }
+					wantContext, wantCause = context.Canceled, customCause
+				}
+				defer stop()
+				if wantContext == context.DeadlineExceeded {
+					wantStatus, wantKind = core.RunStatusTimedOut, core.RunErrorTimeout
+					endObservation = func() { <-ctx.Done() }
+				}
+				responsePath := "/v1/sandboxes/" + id
+				if readiness {
+					responsePath = "/ping"
+				}
+				var observations atomic.Int32
+				transport := server.Client().Transport
+				server.Client().Transport = openSandboxObservationCloseTransport{
+					base: transport, path: responsePath, afterClose: func() {
+						observations.Add(1)
+						endObservation()
+					},
+				}
+				client := newOpenSandboxTestClient(t, server).(*sdkOpenSandboxClient)
+				var err error
+				if readiness {
+					err = client.waitUntilReady(ctx, id)
+				} else {
+					_, err = client.waitForRunning(ctx, id)
+				}
+				if got := observations.Load(); got != 1 {
+					t.Fatalf("completed pending HTTP observations=%d, want exactly one before termination", got)
+				}
+				if !errors.Is(err, wantContext) {
+					t.Errorf("lost terminal context %v: %v", wantContext, err)
+				}
+				if wantCause != nil && !errors.Is(err, wantCause) {
+					t.Errorf("lost custom cancellation/deadline cause: %v", err)
+				}
+				result := core.FinalizeRunResult(core.RunResult{}, err)
+				if result.Status != wantStatus || result.ErrorKind != wantKind {
+					t.Errorf("classification=%s/%s, want %s/%s: %v", result.Status, result.ErrorKind, wantStatus, wantKind, err)
+				}
+				if code := core.ExitCodeForError(err, 1); code != 1 {
+					t.Errorf("public code=%d, want legacy fallback 1 despite custom cause code 7", code)
+				}
+				prefix := "sandbox " + id + " did not reach Running state"
+				if readiness {
+					prefix = "sandbox " + id + " did not become ready"
+				}
+				wantDisplay := regexp.QuoteMeta(prefix + ": " + wantContext.Error())
+				if wantContext == context.DeadlineExceeded && (readiness || wantCause == nil) {
+					wantDisplay = regexp.QuoteMeta(prefix+" within ") + `[0-9.]+(?:ns|µs|ms|s)`
+					if readiness {
+						observation := &sdk.APIError{StatusCode: http.StatusTooEarly, Response: pending}
+						wantDisplay += regexp.QuoteMeta(": " + observation.Error())
+					}
+				}
+				if err == nil || !regexp.MustCompile("^"+wantDisplay+"$").MatchString(err.Error()) {
+					t.Errorf("display=%v, want legacy pattern %s", err, wantDisplay)
+				}
+				t.Logf("public=%d outcome=%s/%s display=%v", core.ExitCodeForError(err, 1), result.Status, result.ErrorKind, err)
+			})
+		}
+	}
+}
+
+// End the caller context only after the real SDK has decoded and closed a
+// pending loopback response; do not accidentally test an interrupted request.
+type openSandboxObservationCloseTransport struct {
+	base       http.RoundTripper
+	path       string
+	afterClose func()
+}
+
+func (t openSandboxObservationCloseTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	response, err := t.base.RoundTrip(r)
+	if err == nil && r.URL.Path == t.path {
+		response.Body = &openSandboxObservationCloseBody{ReadCloser: response.Body, afterClose: t.afterClose}
+	}
+	return response, err
+}
+
+func (t openSandboxObservationCloseTransport) CloseIdleConnections() {
+	if closer, ok := t.base.(interface{ CloseIdleConnections() }); ok {
+		closer.CloseIdleConnections()
+	}
+}
+
+type openSandboxObservationCloseBody struct {
+	io.ReadCloser
+	afterClose func()
+	once       sync.Once
+}
+
+func (b *openSandboxObservationCloseBody) Close() error {
+	err := b.ReadCloser.Close()
+	b.once.Do(b.afterClose)
+	return err
+}

--- a/internal/providers/opensandbox/client.go
+++ b/internal/providers/opensandbox/client.go
@@ -483,11 +483,16 @@ func (c *sdkOpenSandboxClient) waitForRunning(ctx context.Context, sandboxID str
 	if errors.Is(err, expiredErr) {
 		return nil, expiredErr
 	}
-	if result.Err == nil && errors.Is(context.Cause(ctx), context.DeadlineExceeded) && errors.Is(err, context.DeadlineExceeded) {
-		return nil, fmt.Errorf("sandbox %s did not reach Running state within %s", sandboxID, time.Since(start).Round(time.Millisecond))
-	}
-	if result.Err == nil && context.Cause(ctx) != nil && errors.Is(err, context.Cause(ctx)) {
-		return nil, fmt.Errorf("sandbox %s did not reach Running state: %w", sandboxID, ctx.Err())
+	if cause := context.Cause(ctx); cause != nil && errors.Is(err, cause) {
+		diagnostic := err
+		if result.Err == nil {
+			if errors.Is(cause, context.DeadlineExceeded) && errors.Is(err, context.DeadlineExceeded) {
+				diagnostic = fmt.Errorf("sandbox %s did not reach Running state within %s", sandboxID, time.Since(start).Round(time.Millisecond))
+			} else {
+				diagnostic = fmt.Errorf("sandbox %s did not reach Running state: %w", sandboxID, ctx.Err())
+			}
+		}
+		return nil, shared.PollTerminationError(ctx, err, diagnostic)
 	}
 	return nil, err
 }
@@ -520,10 +525,13 @@ func (c *sdkOpenSandboxClient) waitUntilReady(ctx context.Context, sandboxID str
 		return nil
 	}
 	if context.Cause(ctx) != nil && errors.Is(err, context.Cause(ctx)) {
+		var diagnostic error
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return fmt.Errorf("sandbox %s did not become ready within %s: %w", sandboxID, time.Since(start).Round(time.Millisecond), result.Err)
+			diagnostic = fmt.Errorf("sandbox %s did not become ready within %s: %w", sandboxID, time.Since(start).Round(time.Millisecond), result.Err)
+		} else {
+			diagnostic = fmt.Errorf("sandbox %s did not become ready: %w", sandboxID, ctx.Err())
 		}
-		return fmt.Errorf("sandbox %s did not become ready: %w", sandboxID, ctx.Err())
+		return shared.PollTerminationError(ctx, err, diagnostic)
 	}
 	return err
 }

--- a/internal/providers/shared/delegated.go
+++ b/internal/providers/shared/delegated.go
@@ -317,6 +317,10 @@ type sandboxRunError struct {
 
 func (e sandboxRunError) Unwrap() []error { return []error{e.ExitError, e.cause} }
 
+func (e sandboxRunError) RunClassificationCause() error {
+	return core.PrimaryRunClassificationCause(e.cause)
+}
+
 // ExitErrorWithCause keeps the selected exit code and a display-safe message
 // while retaining the cause for errors.Is/As without printing it again.
 func ExitErrorWithCause(code int, message string, cause error) error {

--- a/internal/providers/shared/observer.go
+++ b/internal/providers/shared/observer.go
@@ -3,7 +3,38 @@ package shared
 import (
 	"context"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
+
+type pollTerminationError struct {
+	public         core.ExitError
+	terminal       error
+	diagnostic     error
+	classification error
+}
+
+func (e pollTerminationError) Error() string { return e.diagnostic.Error() }
+func (e pollTerminationError) Unwrap() []error {
+	return []error{e.public, e.diagnostic, e.terminal, e.classification}
+}
+func (e pollTerminationError) RunClassificationCause() error { return e.classification }
+
+// PollTerminationError preserves a nonnil, display-safe diagnostic and its
+// public ExitError while classifying a confirmed context-stop by the context's
+// final state. Call only after establishing that terminal came from ctx stopping;
+// immediate observation failures and successful polls retain their own policy.
+// Both original errors and ctx.Err() remain discoverable without exposing
+// terminal's text. Existing public codes and messages, including zero, survive.
+func PollTerminationError(ctx context.Context, terminal, diagnostic error) error {
+	var public core.ExitError
+	if !core.AsExitError(diagnostic, &public) {
+		public = core.ExitError{Code: 1, Message: diagnostic.Error()}
+	}
+	return pollTerminationError{
+		public: public, terminal: terminal, diagnostic: diagnostic, classification: ctx.Err(),
+	}
+}
 
 type PollResult[T any] struct {
 	Value     T

--- a/internal/providers/shared/observer_test.go
+++ b/internal/providers/shared/observer_test.go
@@ -3,9 +3,82 @@ package shared
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
+
+func TestPollTerminationErrorPreservesDiagnosticAndTerminalClassification(t *testing.T) {
+	observation := errors.New("not ready")
+	customTerminal := core.ExitError{Code: 7, Message: "private terminal detail"}
+	for _, tc := range []struct {
+		name       string
+		diagnostic error
+		deadline   bool
+		custom     bool
+		code       int
+	}{
+		{name: "stale attempt deadline", diagnostic: errors.Join(observation, context.DeadlineExceeded), code: 1},
+		{name: "public code", diagnostic: ExitErrorWithCause(23, "safe readiness", observation), code: 23},
+		{name: "nested public diagnostic", diagnostic: fmt.Errorf("readiness timed out: %w", ExitErrorWithCause(23, "safe probe detail", observation)), code: 23},
+		{name: "signed code", diagnostic: ExitErrorWithCause(-1, "safe readiness", observation), code: -1},
+		{name: "zero code", diagnostic: ExitErrorWithCause(0, "safe readiness", observation), code: 1},
+		{name: "custom cancellation ordinary diagnostic", diagnostic: fmt.Errorf("safe readiness: %w", observation), custom: true, code: 1},
+		{name: "custom cancellation typed diagnostic", diagnostic: ExitErrorWithCause(23, "safe readiness", observation), custom: true, code: 23},
+		{name: "custom deadline", diagnostic: fmt.Errorf("safe readiness: %w", observation), deadline: true, custom: true, code: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var ctx context.Context
+			var cancel context.CancelFunc
+			if tc.deadline {
+				ctx, cancel = context.WithDeadlineCause(context.Background(), time.Now().Add(-time.Second), customTerminal)
+			} else {
+				var stop context.CancelCauseFunc
+				ctx, stop = context.WithCancelCause(context.Background())
+				cancel = func() { stop(nil) }
+				if tc.custom {
+					stop(customTerminal)
+				} else {
+					stop(nil)
+				}
+			}
+			defer cancel()
+			terminal := context.Cause(ctx)
+			err := PollTerminationError(ctx, terminal, tc.diagnostic)
+			var oldPublic, public core.ExitError
+			if !core.AsExitError(tc.diagnostic, &oldPublic) {
+				oldPublic = core.ExitError{Code: 1, Message: tc.diagnostic.Error()}
+			}
+			if !core.AsExitError(err, &public) || public != oldPublic {
+				t.Fatalf("public CLI error=%#v want original=%#v", public, oldPublic)
+			}
+			if err.Error() != tc.diagnostic.Error() || !errors.Is(err, observation) || !errors.Is(err, terminal) {
+				t.Fatalf("diagnostic or ordinary causes lost: %v", err)
+			}
+			if !errors.Is(err, ctx.Err()) {
+				t.Fatalf("canonical context identity %v lost: %v", ctx.Err(), err)
+			}
+			if code := core.ExitCodeForError(err, 1); code != tc.code {
+				t.Fatalf("code=%d want=%d", code, tc.code)
+			}
+			if !errors.Is(err, tc.diagnostic) {
+				t.Fatal("original diagnostic is not discoverable")
+			}
+			want := core.FinalizeRunResult(core.RunResult{}, ctx.Err())
+			for _, wrapped := range []error{err, fmt.Errorf("resume: %w", err), ExitErrorWithCause(42, "safe outer", err), errors.Join(err, context.DeadlineExceeded)} {
+				got := core.FinalizeRunResult(core.RunResult{}, wrapped)
+				if got.Status != want.Status || got.ErrorKind != want.ErrorKind {
+					t.Fatalf("outcome=%s/%s want=%s/%s", got.Status, got.ErrorKind, want.Status, want.ErrorKind)
+				}
+			}
+			if tc.name == "stale attempt deadline" && !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatal("classification hid the observation deadline from ordinary errors.Is")
+			}
+		})
+	}
+}
 
 func TestPollImmediateSuccessSkipsSleepAndProgress(t *testing.T) {
 	sleeps, progress := 0, 0


### PR DESCRIPTION
## Summary

Readiness polling returns two different facts: the last probe diagnostic and the reason polling stopped. Agent Sandbox, OpenSandbox, and Hyper-V sometimes kept only the diagnostic, so the same deadline could become a provider error between probes but a timeout during a request.

Keep those facts separate with a shared termination error. Run classification follows an explicit primary termination cause, while ordinary error inspection retains the original diagnostic, custom cancellation cause, and canonical context error. Preserve the exact selected public exit code and message, including signed/zero typed codes. Ordinary error joins and already-pinned outcomes keep their existing behavior.

Provider adapters still own terminal states, expiration, first-probe behavior, admission, and cleanup. Kubernetes not-found remains discoverable for the existing exact-root recheck; a stage timeout grants no new deletion or forgetting authority. Update the three provider guides and Unreleased notes.

## Verification

- Tests-first regressions cover both Kubernetes readiness stages, pending versus interrupted requests, stale probe deadline followed by cancellation, OpenSandbox real loopback HTTP responses with custom causes, and Hyper-V's owned boot budget with signed probe codes.
- Focused core/shared and provider compatibility tests pass. Existing Agent Sandbox bound-run timing expectations now classify the deadline as timeout; custody and cleanup assertions remain unchanged.
- Full race suites pass for shared, Agent Sandbox, OpenSandbox, and Hyper-V providers. Targeted vet and the repository docs gate pass.
- Independent Codex review is scoped-clean at the repository's P0 threshold; it is not an all-priority certification.
- Initial candidate public-message and zero-code defects were found and fixed before this commit. Intermediate failures remain recorded separately from final passing results.

## Integrated built-CLI proof

Integrated main `29dc53065b6f3db9eaeefed2bd30801a25d30384` into head `36e64c63dd6c97d590c609db4a4b583127d426db` (tree `e880f2b46f53046f70113c7e0ab7bac801eb5424`). The integrated provider race suites, focused core tests, vet, docs gate, and independent P0 review pass.

Built baseline and candidate with Go 1.26.5 on Darwin/arm64 using `go build -trimpath -buildvcs=false`. Ran each actual CLI through an isolated synthetic Kubernetes boundary: fresh kept run (0), same-lease readiness deadline (1), normal Stop (0). A completed matching not-ready pod response preceded the earliest possible deadline by 374ms on baseline and 360ms on candidate; neither retried the pod probe. Baseline reported `failed/provider-error`; candidate reported `timed-out/timeout`.

Both retained the original readiness diagnostic, exit 1, matching bound recovery session, byte-identical claim and payload. Failed admission made no new exec/create/delete calls. Both normal Stops succeeded, every guarded process settled, and both fixture runtimes were removed. This proves the built CLI/adapter/local-process path, not a live Kubernetes controller, hosted OpenSandbox server, or Hyper-V guest. No real provider credentials or hosted resources were used.

CI passed: https://github.com/openclaw/crabbox/actions/runs/34134999548. Captured CLI output and proof limits: https://github.com/openclaw/crabbox/pull/1964#issuecomment-5572494855.
