### PR TITLE
chore: prepare 0.52.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Changelog
 
-## Unreleased
-
-Planned for **0.52.0**.
+## 0.52.0 - 2026-09-07
 
 ### Highlights
 

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.51.0",
+      "version": "0.52.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1120.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Finalize the approved 0.52.0 changelog with its release date and align the Worker package and lockfile versions. Highlights, upgrade notes, contributor credits, and all published changelog history remain intact.

Validation: package versions agree, published history matches v0.51.0 byte for byte, `git diff --check` passes, and the required Codex autoreview found no actionable blockers. Full CI and a fresh coordinator lifecycle smoke will gate the signed release tag.
