### PR TITLE
chore: authorize v0.52.0 release source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## 0.52.0 - 2026-09-07
 
 ### Highlights

--- a/release/records/v0.52.0.json
+++ b/release/records/v0.52.0.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.52.0",
+  "tagObject": "34fed95c7077bf2dab86f4b8450cd622d8e018a5",
+  "sourceCommit": "e32b14fad7602d925a61c1bcfd4f129895645f85",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
Bind v0.52.0 to its immutable signed tag object and tested source commit, and reopen an empty Unreleased section without changing the frozen release notes.

The exact source passed full CI: https://github.com/openclaw/crabbox/actions/runs/34145724937. GitHub verified the tag signature, the repository source verifier passed, and Codex autoreview found no actionable blockers. A fresh coordinator run also passed, with attach/events/logs verified and AWS cleanup confirmed complete.
