### PR TITLE
feat(aws): report scoped transport diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add bounded AWS provisioning transport diagnostics for credential preparation, signing and SDK request time, including retry-loop signing counts, without changing retry behavior.
+
 ## 0.52.0 - 2026-09-07
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add bounded AWS provisioning transport diagnostics for credential preparation, signing and SDK request time, including retry-loop signing counts, without changing retry behavior.
+- Add bounded AWS provisioning transport diagnostics for credential preparation, signing and SDK request time, including retry-loop signing counts, without changing retry behavior. [PR 1968](https://github.com/openclaw/crabbox/pull/1968). Thanks @steipete.
 
 ## 0.52.0 - 2026-09-07
 

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -153,6 +153,30 @@ Windows and macOS targets use their own candidate lists (Windows WSL2 uses
 nested-virtualization families; macOS uses `mac*.metal` types). The default
 class is `beast`.
 
+## Provisioning diagnostics
+
+Coordinator AWS create logs use the `crabbox_aws_provisioning` component. Each
+fixed operation bucket can include `transport` totals for its signed requests.
+Nested operations own their own totals; concurrent creates and preparation
+branches remain separate. These are bounded log counters, not stored lease
+state or permission decisions.
+
+`requests` counts calls entering credential preparation. `credentialsMs` and
+`credentialFailures` cover that preparation; `requestMs` and `requestFailures`
+cover the inherited SDK fetch call. A returned HTTP error response is not a
+transport failure. The operation's existing error count records how its caller
+handled that response. Response-body reading and decoding remain in the outer
+operation duration.
+
+`signInvocations`, `signCompletions`, `signFailures` and `signMs` observe the
+SDK's public signing method without changing its retry policy. Repeated signing
+invocations on a request indicate retry-loop re-entry; a completed signature
+alone does not prove that a server received the request. Signing time is part
+of `requestMs`, so do not add them together. These totals cannot distinguish
+network latency from SDK retry backoff or identify intermediate response status
+codes. They do not establish throttling. Requests outside a measured create
+operation and qualification-authority RPC transport do not add these totals.
+
 ## Configuration
 
 ```yaml

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -177,6 +177,13 @@ network latency from SDK retry backoff or identify intermediate response status
 codes. They do not establish throttling. Requests outside a measured create
 operation and qualification-authority RPC transport do not add these totals.
 
+These durations use `Date.now()`. In deployed Cloudflare Workers,
+[timers advance only after I/O](https://developers.cloudflare.com/workers/runtime-apis/performance/).
+A `0` in `credentialsMs` or `signMs` therefore does not establish zero CPU work
+or zero elapsed time. Local Node fixtures use different timer behavior; their
+timings validate attribution, not deployed CPU cost. Invocation, completion and
+failure counters remain observations independent of this timer limitation.
+
 ## Configuration
 
 ```yaml

--- a/worker/src/aws-fetch-client.ts
+++ b/worker/src/aws-fetch-client.ts
@@ -1,0 +1,94 @@
+import { AwsClient } from "aws4fetch";
+
+import {
+  currentAWSTransportObserver,
+  type AWSTransportObservation,
+} from "./aws-provisioning-diagnostics";
+import type { AWSCredentialProvider } from "./types";
+
+export interface AWSFetchClient {
+  fetch(input: string, init?: RequestInit): Promise<Response>;
+}
+
+class ObservedAwsClient extends AwsClient {
+  #observation: AWSTransportObservation;
+
+  constructor(
+    options: ConstructorParameters<typeof AwsClient>[0],
+    observation: AWSTransportObservation,
+  ) {
+    super(options);
+    this.#observation = observation;
+  }
+
+  override async sign(...args: Parameters<AwsClient["sign"]>): ReturnType<AwsClient["sign"]> {
+    const startedAt = Date.now();
+    this.#observation.signInvocations += 1;
+    try {
+      const request = await super.sign(...args);
+      this.#observation.signCompletions += 1;
+      return request;
+    } catch (error) {
+      this.#observation.signFailures += 1;
+      throw error;
+    } finally {
+      this.#observation.signMs += Math.max(0, Date.now() - startedAt);
+    }
+  }
+}
+
+export class RefreshingAWSFetchClient implements AWSFetchClient {
+  constructor(
+    private readonly credentials: AWSCredentialProvider,
+    private readonly service: string,
+    private readonly region: string,
+  ) {}
+
+  async fetch(input: string, init?: RequestInit): Promise<Response> {
+    const observe = currentAWSTransportObserver();
+    const observation: AWSTransportObservation = {
+      requests: 1,
+      credentialsMs: 0,
+      credentialFailures: 0,
+      signInvocations: 0,
+      signCompletions: 0,
+      signFailures: 0,
+      signMs: 0,
+      requestMs: 0,
+      requestFailures: 0,
+    };
+    const startedAt = Date.now();
+    let requestStartedAt: number | undefined;
+    try {
+      const credentials = await this.credentials();
+      const accessKeyId = credentials.accessKeyId?.trim();
+      const secretAccessKey = credentials.secretAccessKey?.trim();
+      if (!accessKeyId || !secretAccessKey) {
+        throw new Error("AWS credential provider returned incomplete credentials");
+      }
+      const options: ConstructorParameters<typeof AwsClient>[0] = {
+        accessKeyId,
+        secretAccessKey,
+        service: this.service,
+        region: this.region,
+      };
+      const session = credentials.sessionToken?.trim();
+      if (session) options.sessionToken = session;
+      // aws4fetch 1.0.20 calls public sign() once per retry-loop invocation.
+      // Keep its fetch implementation, retry policy, signed bytes and Response intact.
+      const client = observe ? new ObservedAwsClient(options, observation) : new AwsClient(options);
+      requestStartedAt = Date.now();
+      observation.credentialsMs = Math.max(0, requestStartedAt - startedAt);
+      return await client.fetch(input, init);
+    } catch (error) {
+      if (requestStartedAt === undefined) observation.credentialFailures += 1;
+      else observation.requestFailures += 1;
+      throw error;
+    } finally {
+      if (requestStartedAt === undefined)
+        observation.credentialsMs = Math.max(0, Date.now() - startedAt);
+      else observation.requestMs = Math.max(0, Date.now() - requestStartedAt);
+      observe?.(observation);
+    }
+  }
+}

--- a/worker/src/aws-provisioning-diagnostics.ts
+++ b/worker/src/aws-provisioning-diagnostics.ts
@@ -1,3 +1,24 @@
+/// <reference types="node/async_hooks" />
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type AWSTransportObservation = {
+  requests: number;
+  credentialsMs: number;
+  credentialFailures: number;
+  signInvocations: number;
+  signCompletions: number;
+  signFailures: number;
+  signMs: number;
+  requestMs: number;
+  requestFailures: number;
+};
+
+const transportScope = new AsyncLocalStorage<(value: AWSTransportObservation) => void>();
+
+export function currentAWSTransportObserver() {
+  return transportScope.getStore();
+}
+
 const stepNames = [
   "key_pair",
   "image",
@@ -26,7 +47,16 @@ export type AWSProvisioningDiagnostics = ReturnType<typeof createAWSProvisioning
 // These observations are logs, never lease state or permission decisions.
 export function createAWSProvisioningDiagnostics(leaseId: string, region: string) {
   const startedAt = Date.now();
-  const steps = new Map(stepNames.map((name) => [name, { name, count: 0, totalMs: 0, errors: 0 }]));
+  const steps = new Map<
+    Step,
+    {
+      name: Step;
+      count: number;
+      totalMs: number;
+      errors: number;
+      transport?: AWSTransportObservation;
+    }
+  >(stepNames.map((name) => [name, { name, count: 0, totalMs: 0, errors: 0 }]));
   const record = (name: Step, durationMs: number, failed = false) => {
     const step = steps.get(name);
     if (!step) return;
@@ -40,7 +70,28 @@ export function createAWSProvisioningDiagnostics(leaseId: string, region: string
       const start = Date.now();
       let failed = true;
       try {
-        const result = await operation();
+        // Scope the deepest measured operation, not a mutable shared EC2 client.
+        // Concurrent leases and sibling preparations must never share counters.
+        const result = await transportScope.run((observation) => {
+          const step = steps.get(name);
+          if (!step) return;
+          if (!step.transport) {
+            step.transport = { ...observation };
+            return;
+          }
+          for (const key of [
+            "requests",
+            "credentialsMs",
+            "credentialFailures",
+            "signInvocations",
+            "signCompletions",
+            "signFailures",
+            "signMs",
+            "requestMs",
+            "requestFailures",
+          ] as const)
+            step.transport[key] += observation[key];
+        }, operation);
         failed = false;
         return result;
       } finally {

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -1,6 +1,6 @@
-import { AwsClient } from "aws4fetch";
 import { XMLParser } from "fast-xml-parser";
 
+import { RefreshingAWSFetchClient, type AWSFetchClient } from "./aws-fetch-client";
 import {
   createAWSProvisioningDiagnostics,
   type AWSProvisioningDiagnostics,
@@ -260,38 +260,6 @@ function assertPrivateWorkspaceSecurityGroupShape(group: Record<string, unknown>
     throw new Error(
       "AWS private workspace security group must have exactly one IPv4 TCP 443 egress rule",
     );
-  }
-}
-
-interface AWSFetchClient {
-  fetch(input: string, init?: RequestInit): Promise<Response>;
-}
-
-class RefreshingAWSFetchClient implements AWSFetchClient {
-  constructor(
-    private readonly credentials: AWSCredentialProvider,
-    private readonly service: string,
-    private readonly region: string,
-  ) {}
-
-  async fetch(input: string, init?: RequestInit): Promise<Response> {
-    const credentials = await this.credentials();
-    const accessKeyId = credentials.accessKeyId?.trim();
-    const secretAccessKey = credentials.secretAccessKey?.trim();
-    if (!accessKeyId || !secretAccessKey) {
-      throw new Error("AWS credential provider returned incomplete credentials");
-    }
-    const options: ConstructorParameters<typeof AwsClient>[0] = {
-      accessKeyId,
-      secretAccessKey,
-      service: this.service,
-      region: this.region,
-    };
-    const session = credentials.sessionToken?.trim();
-    if (session) {
-      options.sessionToken = session;
-    }
-    return await new AwsClient(options).fetch(input, init);
   }
 }
 

--- a/worker/test/aws-fetch-client.test.ts
+++ b/worker/test/aws-fetch-client.test.ts
@@ -1,0 +1,248 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+
+import { afterEach, expect, it, vi } from "vitest";
+
+import { RefreshingAWSFetchClient } from "../src/aws-fetch-client";
+import { createAWSProvisioningDiagnostics } from "../src/aws-provisioning-diagnostics";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(cleanups.splice(0).map((close) => close()));
+  vi.restoreAllMocks();
+});
+
+async function localTransport(
+  handle: (request: IncomingMessage, response: ServerResponse) => void,
+) {
+  const server = createServer(handle);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  cleanups.push(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        server.closeAllConnections();
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  );
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("missing local transport address");
+  return `http://127.0.0.1:${address.port}/`;
+}
+
+const credentials = async () => ({
+  accessKeyId: "fixture-access-canary",
+  secretAccessKey: "fixture-secret-canary",
+  sessionToken: "fixture-session-canary",
+});
+
+it("separates credential preparation from the signed request span", async () => {
+  const url = await localTransport((_request, response) => {
+    setTimeout(() => response.end("ready"), 30);
+  });
+  const { diagnostics, finish } = observe();
+  const client = new RefreshingAWSFetchClient(
+    async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return credentials();
+    },
+    "ec2",
+    "eu-west-1",
+  );
+  const response = await diagnostics.measure("key_pair", () => client.fetch(url));
+  expect(await response.text()).toBe("ready");
+  const transport = finish("success");
+  expect(transport.credentialsMs).toBeGreaterThanOrEqual(15);
+  expect(transport.requestMs).toBeGreaterThanOrEqual(25);
+  expect(transport.signMs).toBeGreaterThanOrEqual(0);
+  expect(transport.signMs).toBeLessThanOrEqual(transport.requestMs);
+});
+
+function observe() {
+  const log = vi.spyOn(console, "info").mockImplementation(() => {});
+  const diagnostics = createAWSProvisioningDiagnostics("cbx_000000000001", "eu-west-1");
+  return {
+    diagnostics,
+    log,
+    finish(outcome: "success" | "failure") {
+      diagnostics.finish(outcome);
+      const encoded = String(log.mock.calls.at(-1)![0]);
+      for (const privateValue of [
+        "fixture-access-canary",
+        "fixture-secret-canary",
+        "fixture-session-canary",
+        "payload-canary",
+        "failure-canary",
+        "127.0.0.1",
+      ])
+        expect(encoded).not.toContain(privateValue);
+      expect(encoded.length).toBeLessThan(8192);
+      return JSON.parse(encoded).steps[0].transport;
+    },
+  };
+}
+
+it.each([
+  { name: "normal success", statuses: [200], attempts: 1 },
+  { name: "original SDK retries 503 and 429", statuses: [503, 429, 200], attempts: 3 },
+  { name: "original SDK returns 400 without retry", statuses: [400], attempts: 1 },
+])("observes $name without changing request bytes or response", async ({ statuses, attempts }) => {
+  const bodies: string[] = [];
+  const url = await localTransport((request, response) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    request.on("end", () => {
+      bodies.push(body);
+      response.statusCode = statuses[bodies.length - 1] ?? 500;
+      response.end("response-canary");
+    });
+  });
+  const { diagnostics, finish } = observe();
+  const client = new RefreshingAWSFetchClient(credentials, "ec2", "eu-west-1");
+  const result = await diagnostics.measure("key_pair", () =>
+    client.fetch(url, { method: "POST", body: "payload-canary" }),
+  );
+  expect(result.status).toBe(statuses.at(-1));
+  expect(await result.text()).toBe("response-canary");
+  expect(bodies).toEqual(Array(attempts).fill("payload-canary"));
+  expect(finish("success")).toMatchObject({
+    requests: 1,
+    credentialFailures: 0,
+    signInvocations: attempts,
+    signCompletions: attempts,
+    signFailures: 0,
+    requestFailures: 0,
+  });
+});
+
+it("records credential failure before signing and preserves the original error", async () => {
+  let requests = 0;
+  const url = await localTransport((_request, response) => {
+    requests += 1;
+    response.end();
+  });
+  const failure = new Error("failure-canary");
+  const { diagnostics, finish } = observe();
+  const client = new RefreshingAWSFetchClient(
+    async () => {
+      throw failure;
+    },
+    "ec2",
+    "eu-west-1",
+  );
+  await expect(diagnostics.measure("key_pair", () => client.fetch(url))).rejects.toBe(failure);
+  expect(requests).toBe(0);
+  expect(finish("failure")).toMatchObject({
+    requests: 1,
+    credentialFailures: 1,
+    signInvocations: 0,
+    signCompletions: 0,
+    signFailures: 0,
+    requestFailures: 0,
+  });
+});
+
+it("records actual SDK signing failure without calling the local transport", async () => {
+  let requests = 0;
+  const url = await localTransport((_request, response) => {
+    requests += 1;
+    response.end();
+  });
+  const { diagnostics, finish } = observe();
+  const client = new RefreshingAWSFetchClient(credentials, "ec2", "eu-west-1");
+  await expect(
+    diagnostics.measure("key_pair", () =>
+      client.fetch(url, { headers: { "invalid\nheader": "payload-canary" } }),
+    ),
+  ).rejects.toBeInstanceOf(TypeError);
+  expect(requests).toBe(0);
+  expect(finish("failure")).toMatchObject({
+    requests: 1,
+    credentialFailures: 0,
+    signInvocations: 1,
+    signCompletions: 0,
+    signFailures: 1,
+    requestFailures: 1,
+  });
+});
+
+it("preserves a real network failure without adding retries", async () => {
+  let requests = 0;
+  const url = await localTransport((request) => {
+    requests += 1;
+    request.socket.destroy();
+  });
+  const { diagnostics, finish } = observe();
+  const client = new RefreshingAWSFetchClient(credentials, "ec2", "eu-west-1");
+  await expect(
+    diagnostics.measure("key_pair", () =>
+      client.fetch(url, { method: "POST", body: "payload-canary" }),
+    ),
+  ).rejects.toBeInstanceOf(TypeError);
+  expect(requests).toBe(1);
+  expect(finish("failure")).toMatchObject({
+    requests: 1,
+    credentialFailures: 0,
+    signInvocations: 1,
+    signCompletions: 1,
+    signFailures: 0,
+    requestFailures: 1,
+  });
+});
+
+it("attributes interleaved shared-client requests to their deepest operation and lease", async () => {
+  const entered = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  const url = await localTransport((request, response) => {
+    if (request.url === "/slow") {
+      entered.resolve();
+      void release.promise.then(() => response.end("slow"));
+    } else response.end("fast");
+  });
+  const log = vi.spyOn(console, "info").mockImplementation(() => {});
+  const first = createAWSProvisioningDiagnostics("cbx_000000000001", "eu-west-1");
+  const second = createAWSProvisioningDiagnostics("cbx_000000000002", "eu-west-1");
+  const client = new RefreshingAWSFetchClient(credentials, "ec2", "eu-west-1");
+  const slow = first.measure("security_group", () =>
+    first.measure("authorize_ingress", async () => (await client.fetch(url + "slow")).text()),
+  );
+  try {
+    await Promise.race([
+      entered.promise,
+      slow.then(() => {
+        throw new Error("slow request finished before its gate");
+      }),
+    ]);
+    expect(
+      await second.measure("quota", async () => (await client.fetch(url + "fast")).text()),
+    ).toBe("fast");
+    second.finish("success");
+    expect(JSON.parse(String(log.mock.calls[0]![0]))).toMatchObject({
+      leaseId: "cbx_000000000002",
+      steps: [{ name: "quota", transport: { requests: 1, signInvocations: 1 } }],
+    });
+    expect(
+      await first.measure("quota", async () => (await client.fetch(url + "fast")).text()),
+    ).toBe("fast");
+  } finally {
+    release.resolve();
+    expect(await slow).toBe("slow");
+  }
+  first.finish("success");
+  const record = JSON.parse(String(log.mock.calls[1]![0]));
+  expect(record.leaseId).toBe("cbx_000000000001");
+  expect(
+    record.steps.find((step: { name: string }) => step.name === "security_group").transport,
+  ).toBeUndefined();
+  expect(
+    record.steps.find((step: { name: string }) => step.name === "authorize_ingress").transport,
+  ).toMatchObject({ requests: 1, signInvocations: 1, signCompletions: 1 });
+  expect(
+    record.steps.find((step: { name: string }) => step.name === "quota").transport,
+  ).toMatchObject({ requests: 1, signInvocations: 1, signCompletions: 1 });
+  const count = log.mock.calls.length;
+  expect(await (await client.fetch(url)).text()).toBe("fast");
+  expect(log.mock.calls).toHaveLength(count);
+});

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -182,9 +182,35 @@ describe("aws provider", () => {
       });
       expect(diagnostic.steps).toEqual(
         expect.arrayContaining([
-          { name: "authorize_ingress", count: 4, totalMs: 28, errors: 4 },
+          expect.objectContaining({
+            name: "authorize_ingress",
+            count: 4,
+            totalMs: 28,
+            errors: 4,
+            transport: expect.objectContaining({
+              requests: 4,
+              requestMs: 28,
+              signInvocations: 4,
+              signCompletions: 4,
+              signFailures: 0,
+              requestFailures: 0,
+            }),
+          }),
           { name: "authorize_duplicate", count: 4, totalMs: 0, errors: 0 },
-          { name: "revoke_world", count: 2, totalMs: 6, errors: 2 },
+          expect.objectContaining({
+            name: "revoke_world",
+            count: 2,
+            totalMs: 6,
+            errors: 2,
+            transport: expect.objectContaining({
+              requests: 2,
+              requestMs: 6,
+              signInvocations: 2,
+              signCompletions: 2,
+              signFailures: 0,
+              requestFailures: 0,
+            }),
+          }),
           { name: "revoke_world_absent", count: 2, totalMs: 0, errors: 0 },
         ]),
       );
@@ -2335,12 +2361,20 @@ describe("aws provider", () => {
     expect(JSON.parse(encoded)).toMatchObject({
       outcome: failImage ? "failure" : "success",
       steps: expect.arrayContaining([
-        {
+        expect.objectContaining({
           name: "image",
           count: failImage ? 2 : 1 + awsMacOSInstanceTypeCandidates.length,
           totalMs: failImage ? 37 : 111,
           errors: failImage ? 1 : 0,
-        },
+          transport: expect.objectContaining({
+            requests: failImage ? 1 : 3,
+            requestMs: failImage ? 37 : 111,
+            signInvocations: failImage ? 1 : 3,
+            signCompletions: failImage ? 1 : 3,
+            signFailures: 0,
+            requestFailures: 0,
+          }),
+        }),
       ]),
     });
     expect(encoded).not.toContain("private-image-canary");

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -26289,7 +26289,20 @@ describe("fleet lease identity and idle", () => {
         expect.arrayContaining([
           { name: "ingress_wait", count: 1, totalMs: 41, errors: 0 },
           { name: "lifecycle_wait", count: 1, totalMs: 0, errors: 0 },
-          { name: "authorize_ingress", count: 2, totalMs: 14, errors: 0 },
+          expect.objectContaining({
+            name: "authorize_ingress",
+            count: 2,
+            totalMs: 14,
+            errors: 0,
+            transport: expect.objectContaining({
+              requests: 2,
+              requestMs: 14,
+              signInvocations: 2,
+              signCompletions: 2,
+              signFailures: 0,
+              requestFailures: 0,
+            }),
+          }),
         ]),
       );
     } finally {


### PR DESCRIPTION
AWS provisioning step timings currently combine credential preparation, signing, SDK requests and retry delays. A slow operation therefore cannot show whether the SDK re-entered its retry loop or spent its time elsewhere.

This adds bounded numeric transport totals to the existing create-operation diagnostics. Each request records credential preparation, signing invocations/completions/failures and signed-request duration. Async-local scopes attribute those observations to the deepest measured operation, keeping concurrent leases and parallel preparation branches separate even when they share an EC2 client. The existing refreshing client moves into its owning module; its observed SDK subclass delegates public signing and retains the original inherited fetch implementation.

Signing counts describe SDK invocations, not confirmed server receipt or throttling. Request duration includes signing, network and retry backoff until fetch resolves; response-body reading and decoding remain in the outer operation. Returned HTTP error responses retain their original behavior. Calls outside measured creates and qualification-authority RPC transport remain outside these totals. There are no retry, timeout, dependency, configuration, environment, schema or persistent-state changes.

Validation:

- Full Worker suite: 2,865 passed, three skipped.
- Eight original-SDK loopback transport tests cover normal success, 503/429 retry re-entry, unchanged 400 responses, credential/signing/network failures, timing placement and concurrent lease/operation attribution. No SDK retry overrides or global-fetch monkeypatching in these tests.
- Existing AWS and Fleet diagnostic assertions now include the new fields while retaining their queue and permission-operation timing checks.
- Worker and Node type checks, lint, formatting and diff checks passed.
- Main Worker, Node backend, dynamic Worker and qualification-authority builds passed.
- Independent review through P2 found no accepted actionable findings.
- [Full CI on the live-proven code](https://github.com/openclaw/crabbox/actions/runs/34154388755) passed all eleven jobs. The final docs-only commit changes only the timer qualification; its Worker tree is byte-identical, and its docs checks and separate P2 review passed.

Production grows by 113 lines for the scoped observer and numeric transport measurements; tests grow by 295 lines. Output stays in fixed operation buckets rather than retaining per-request records or request material.

After-change behavior was verified on deployed candidate `b5ea924660324a16701004c933681cdfa85eb22e` through the normal [Deploy Coordinator workflow](https://github.com/openclaw/crabbox/actions/runs/34155206972). Official Wrangler deployment readback confirmed 100% traffic to Worker version `b6911a39-6c19-4353-9c8e-e78c4880db84`; an official version-filtered Wrangler tail captured the provider's actual numeric output.

One ordinary CLI allocation on AWS in eu-west-1 became ready in 62.084 seconds. `crabbox run --id <owned-lease> --keep=true --no-sync --no-hydrate --timing-json --provider aws --network public --tailscale=false --class standard -- uname -s` returned `Linux`; its signed receipt verified. The lease was then stopped and read back as `released` with provider cleanup `complete`. All recorded original processes, the SSH control directory, the Wrangler process, and the task credential window were verified absent. The operator configuration stayed unchanged.

The actual provisioning log reported 7,324 ms total, zero ingress-queue wait, and 14 credential requests with 14 signing invocations/completions and no transport or signing failures. This observed run had no SDK retry-loop re-entry; it does not explain an earlier intermittent slow run or establish a speedup.

| Actual operation | Requests | Signing invocations | Request duration |
| --- | ---: | ---: | ---: |
| key_pair | 2 | 2 | 2,704 ms |
| security_group_lookup | 1 | 1 | 223 ms |
| authorize_ingress | 6 | 6 | 1,706 ms |
| instance_create | 1 | 1 | 1,387 ms |

These rows are excerpts from one actual log, not additive independent wall-clock stages. Its signing and credential durations were zero. [Cloudflare's deployed clocks advance only after I/O](https://developers.cloudflare.com/workers/runtime-apis/performance/), so zero does not establish zero CPU work. This limitation is documented alongside the fields.

A separate local runner exercised the production refreshing client and diagnostics with original aws4fetch 1.0.20 against a loopback server. The server actually returned 503, then 429, then 200 while preserving request bodies and the final response. The producer emitted:

```json
{"requests":1,"credentialsMs":0,"credentialFailures":0,"signInvocations":3,"signCompletions":3,"signFailures":0,"signMs":13,"requestMs":120,"requestFailures":0}
```

With two interleaved scopes sharing that client, scope B completed first and scope A second. Each scope recorded exactly one request/signature; the outer security_group operation carried no duplicate transport totals. The local server closed and its process joined. The six unmodified, privacy-checked output records have SHA-256 `4bc4363c424429c6700567e3671b95908a1c0c4b5261c4db933559cf451b58b3`. There were no SDK retry overrides or global-fetch mocks.

This supplies the observable transport and attribution proof requested by ClawSweeper, including its Rank-up move. No timing result is presented as a cloud startup speedup.

