### PR TITLE
fix(islo): propagate streamed output delivery failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Islo: report failed stdout/stderr delivery instead of silently succeeding after losing command output; preserve remote exit codes when stream decoding and delivery finish successfully.
+
 ## 0.52.0 - 2026-09-07
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Islo: report failed stdout/stderr delivery instead of silently succeeding after losing command output; preserve remote exit codes when stream decoding and delivery finish successfully.
+- Islo: report failed stdout/stderr delivery instead of silently succeeding after losing command output; preserve remote exit codes when stream decoding and delivery finish successfully. [PR 1969](https://github.com/openclaw/crabbox/pull/1969).
 
 ## 0.52.0 - 2026-09-07
 

--- a/docs/providers/islo.md
+++ b/docs/providers/islo.md
@@ -167,8 +167,11 @@ Post-admission Tailscale errors retain their actual causes while preserving the
 existing public codes and messages, including fallback `1` for opaque validation
 errors. A status code alone does not create a context-cancellation cause.
 
-Observed SSE command exits keep their exact codes. Exec transport/cancellation
-failures return `1` with their known failure origin and reachable context cause.
+Observed SSE command exits keep their exact codes when stream decoding and output
+delivery complete successfully. A stream read, decode, or stdout/stderr delivery
+failure returns `1` even after an exit event was observed. Transport and cancellation
+failures also return `1` with their known failure origin and reachable cause.
+Closing the stream does not establish that the remote process stopped.
 Setup/helper failures preserve their public code without being mislabeled as
 user-command exits. Required-artifact and download failures after command success
 are provider errors: required-artifact failures keep `7`, and local download-write

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	gosdk "github.com/islo-labs/go-sdk"
@@ -105,6 +106,107 @@ func TestParseIsloSSERejectsInvalidExitEvent(t *testing.T) {
 	}, "\n")
 	if _, err := parseIsloSSE(strings.NewReader(body), &bytes.Buffer{}, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "invalid exit event") {
 		t.Fatalf("err=%v, want invalid exit event error", err)
+	}
+}
+
+type isloOutputFailureWriter struct{ err error }
+
+func (w isloOutputFailureWriter) Write([]byte) (int, error) { return 0, w.err }
+
+func TestParseIsloSSEPropagatesOutputWriteFailure(t *testing.T) {
+	writeErr := errors.New("output destination rejected bytes")
+	for _, stream := range []string{"stdout", "stderr"} {
+		for _, position := range []string{"before exit", "after exit", "final EOF flush"} {
+			t.Run(stream+"/"+position, func(t *testing.T) {
+				output := "event: " + stream + "\ndata: command output"
+				body := output + "\n\nevent: exit\ndata: 0\n\n"
+				if position == "after exit" {
+					body = "event: exit\ndata: 23\n\n" + output + "\n\n"
+				} else if position == "final EOF flush" {
+					body = "event: exit\ndata: 137\n\n" + output
+				}
+				var stdout, stderr io.Writer = io.Discard, io.Discard
+				if stream == "stdout" {
+					stdout = isloOutputFailureWriter{writeErr}
+				} else {
+					stderr = isloOutputFailureWriter{writeErr}
+				}
+				code, err := parseIsloSSE(strings.NewReader(body), stdout, stderr)
+				if code != 1 || err != writeErr {
+					t.Fatalf("code=%d err=%v, want code 1 and original writer error", code, err)
+				}
+			})
+		}
+	}
+}
+
+func TestParseIsloSSEReadOnlyOutputFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "output")
+	if err := os.WriteFile(path, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	_, writeErr := file.Write([]byte("probe"))
+	var pathErr *os.PathError
+	if !errors.As(writeErr, &pathErr) {
+		t.Fatalf("read-only file write error=%v", writeErr)
+	}
+	for _, stream := range []string{"stdout", "stderr"} {
+		t.Run(stream, func(t *testing.T) {
+			var stdout, stderr io.Writer = io.Discard, io.Discard
+			if stream == "stdout" {
+				stdout = file
+			} else {
+				stderr = file
+			}
+			body := "event: " + stream + "\ndata: command output\n\nevent: exit\ndata: 0\n\n"
+			code, err := parseIsloSSE(strings.NewReader(body), stdout, stderr)
+			if code != 1 || !errors.Is(err, pathErr.Err) {
+				t.Fatalf("code=%d err=%v, want code 1 and file error %v", code, err, pathErr.Err)
+			}
+		})
+	}
+}
+
+func TestParseIsloSSEPreservesCompletionRules(t *testing.T) {
+	readErr := errors.New("stream disconnected")
+	for _, tc := range []struct {
+		name    string
+		body    string
+		readErr error
+		code    int
+		output  string
+		errText string
+	}{
+		{name: "multiline comments and final EOF", body: ": keepalive\r\nevent: stdout\r\ndata: first\r\nid: ignored\r\ndata: second\r\n\r\nevent: exit\ndata: -1", code: -1, output: "first\nsecond"},
+		{name: "last exit wins", body: "event: exit\ndata: 7\n\nevent: stdout\ndata: between\n\nevent: exit\ndata: 23", code: 23, output: "between"},
+		{name: "error event with exit", body: "event: exit\ndata: 0\n\nevent: error\ndata: diagnostic", code: 0},
+		{name: "read error after exit", body: "event: exit\ndata: 23\n\n", readErr: readErr, code: 1, errText: "stream disconnected"},
+		{name: "invalid exit after exit", body: "event: exit\ndata: 23\n\nevent: exit\ndata: invalid", code: 1, errText: "invalid exit event"},
+		{name: "final decode error precedes read error", body: "event: exit\ndata: invalid", readErr: readErr, code: 1, errText: "invalid exit event"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var reader io.Reader = strings.NewReader(tc.body)
+			if tc.readErr != nil {
+				reader = io.MultiReader(reader, iotest.ErrReader(tc.readErr))
+			}
+			var stdout bytes.Buffer
+			code, err := parseIsloSSE(reader, &stdout, io.Discard)
+			if code != tc.code || stdout.String() != tc.output {
+				t.Fatalf("code=%d output=%q, want %d/%q", code, stdout.String(), tc.code, tc.output)
+			}
+			if tc.errText == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), tc.errText) {
+				t.Fatalf("err=%v, want %q", err, tc.errText)
+			}
+		})
 	}
 }
 

--- a/internal/providers/islo/client.go
+++ b/internal/providers/islo/client.go
@@ -511,9 +511,13 @@ func parseIsloSSE(r io.Reader, stdout, stderr io.Writer, secrets ...string) (int
 		payload := strings.Join(data, "\n")
 		switch event {
 		case "stdout":
-			_, _ = stdout.Write([]byte(payload))
+			if _, err := stdout.Write([]byte(payload)); err != nil {
+				return err
+			}
 		case "stderr":
-			_, _ = stderr.Write([]byte(payload))
+			if _, err := stderr.Write([]byte(payload)); err != nil {
+				return err
+			}
 		case "exit":
 			n, err := strconv.Atoi(strings.TrimSpace(payload))
 			if err != nil {


### PR DESCRIPTION
## Summary

Islo's SSE decoder ignored errors returned while writing command stdout and stderr. A run could therefore report success after its output destination rejected the bytes. Return the original writer error through the decoder's existing failure path so the run reports a delivery failure instead of a successful remote exit.

This stays inside Islo's transport adapter. SSE framing, multiline data, comments, final EOF flushing, repeated exit events, stream limits, and successful output bytes are unchanged. Existing read/decode failures already take precedence over a previously observed exit; output delivery now follows that same rule. The provider's existing run finalizer still owns retention and guarded cleanup. Closing a stream is not evidence that its remote workload stopped.

The provider documentation clarifies the completion rule, and Unreleased records the user-visible fix. No configuration, credentials, dependency, pricing, idle/reclaim, heartbeat, or other provider policy changes are included.

## Verification

Candidate head: `79ff10914e08cef124d90d562af5160480ae4261`, tree: `0b4771dbf1cc204de0e439eeda90df599866f162`, based on `4f6a77b16199fb4a31c28a164ede394b9d07e6bd`.

- Eight pre-fix regression cases failed: stdout/stderr failures before exit, after exit and during final EOF flush, plus both real read-only output-file cases. All pass after the fix, with the original writer cause preserved.
- Completion-rule controls passed before and after: multiline/comments/EOF, last exit wins, error-plus-exit, and late reader/decode failures.
- Focused parser races, full Islo race tests, Islo vet, internal-link checks across 246 Markdown files and diff checks passed.
- Independent Codex review is scoped-clean at P0; this is not an all-priority certification.

## Real-provider verification and integration

The actual before/after comparison passed all 18 CLI commands using two real Islo sandboxes: normal output/exit7 preserved, both quiet-descriptor controls passed, and rejected stdout/stderr changed from silent baseline0 to candidate1. Entry-witness reads avoid cross-channel ordering assumptions. Both owned sandboxes were explicitly stopped, with original-ID deleted tombstones, exact-name HTTP404 and no local claims. All run session handles were retained correctly. This is retained-run plus explicit Stop proof, not automatic deletion-failure or remote-cancellation testing.

Full observed output and scope: https://github.com/openclaw/crabbox/pull/1969#issuecomment-5575234055. Independent audit and parent recheck verified the 4,636-entry evidence seal. The audit also caught a task-bound credential daemon recreating an empty temporary directory after initial cleanup; that specific daemon and directory were cleaned, and the original observation remains preserved.

The real execution stays bound to the original ad2/7f7 sources. Current integration includes the separately landed AWS Worker diagnostics change and resolves only the changelog conflict. Both newly built CLIs are byte-identical to those actually executed, and the full 1,497-file Go source scope is unchanged. No hosted replay or incoming AWS feature proof is claimed. Fresh Islo/shared races, docs and independent P0-scoped review passed on this integrated tree.

Current-head CI passed all 11 main jobs: https://github.com/openclaw/crabbox/actions/runs/34158254464. All five code-validation workflows succeeded, including connector smokes and the release check; no reruns were needed. The current-head review accepts the real-provider proof and reports no actionable code findings. The final merge target against main `4f6a77b16199fb4a31c28a164ede394b9d07e6bd` is exactly the reviewed/tested integrated tree `0b4771dbf1cc204de0e439eeda90df599866f162`. Related lifecycle/heartbeat holds remain separate: https://github.com/openclaw/crabbox/pull/1706 and https://github.com/openclaw/crabbox/pull/1707.
