### PR TITLE
fix: recover lost run admission responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Recover lost run-admission responses using a caller-known identity and an atomic initial history record, preserving authenticated request binding and refusing remote command replay. Current clients require a coordinator supporting the new admission route. [Issue 1962](https://github.com/openclaw/crabbox/issues/1962).
+
 ## 0.52.0 - 2026-09-07
 
 ### Highlights

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -233,6 +233,7 @@ Runs and observability:
 ```text
 GET  /v1/runs
 POST /v1/runs
+PUT  /v1/runs/{run-id}
 GET  /v1/runs/{run-id}
 GET  /v1/runs/{run-id}/logs
 POST /v1/runs/{run-id}/events
@@ -287,7 +288,9 @@ retries as admin.
 progress to the broker so the portal and `history`/`logs`/`events`/`results`
 commands can read it back:
 
-- `POST /v1/runs` creates a `RunRecord` in state `running`.
+- `PUT /v1/runs/{id}` atomically admits a caller-known run and its first event,
+  or returns the retained record for the same caller and original request.
+  Legacy `POST /v1/runs` creates a coordinator-issued `RunRecord` in state `running`.
 - `POST /v1/runs/{id}/events` streams phase-tagged events: `run.started`,
   `leasing.started`, `bootstrap.waiting`, `sync.started`/`finished`,
   `actions.hydrate.*`, `command.started`, stdout/stderr chunks,

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -225,6 +225,7 @@ PATCH  /v1/checkpoints/{id}/retention
 POST   /v1/checkpoints/{id}/use
 DELETE /v1/checkpoints/{id}
 POST   /v1/runs
+PUT    /v1/runs/{run-id}
 GET    /v1/runs
 GET    /v1/runs/{run-id}
 GET    /v1/runs/{run-id}/logs
@@ -525,7 +526,9 @@ provider metadata, owner/org, `createdAt`, `lastTouchedAt`, `idleTimeoutSeconds`
 In brokered mode, `crabbox run` mirrors progress to the coordinator while executing
 directly against the runner over SSH:
 
-- `POST /v1/runs` creates a `RunRecord` (state `running`).
+- `PUT /v1/runs/{id}` atomically admits a caller-known run and its first event,
+  or returns the retained record for the same caller and original request.
+  Legacy `POST /v1/runs` creates a coordinator-issued `RunRecord` (state `running`).
 - `POST /v1/runs/{id}/events` streams phase-tagged events (leasing, bootstrap,
   sync, command start/finish, stdout/stderr chunks, lease release).
 - `POST /v1/runs/{id}/telemetry` posts periodic host samples.

--- a/docs/features/history-logs.md
+++ b/docs/features/history-logs.md
@@ -30,6 +30,20 @@ ordered events as it advances:
 - `lease.released`
 - `run.failed` (if the run errors before the command finishes)
 
+Current clients admit runs through `PUT /v1/runs/<run-id>`, using a cryptographically
+random ID known before the request. The coordinator commits the record and its
+first event atomically. Matching admission replay returns the retained record;
+changed request content conflicts, and another actor cannot adopt the record.
+The original request binding remains unchanged when later events attach or
+replace a lease. Legacy clients can still use `POST /v1/runs` for coordinator-issued
+IDs, but that route cannot recover a lost create response. Upgrade an older
+coordinator before using the current client's admission route.
+
+Admission recovery is limited to the original live CLI invocation before command
+execution. A terminal or already-progressed record is a historical result, not
+permission to execute again. Record retention is unchanged; clients must never
+reuse an ID for a new invocation.
+
 Crabbox-generated event messages are redacted before they enter coordinator
 storage. The recorder removes configured and provider-discovered runtime
 credentials, authorization headers, credential-bearing URLs, and other known

--- a/docs/features/identifiers.md
+++ b/docs/features/identifiers.md
@@ -173,20 +173,26 @@ lease ID with `_` rewritten to `-`).
 Each `crabbox run` gets a run ID:
 
 ```text
-run_abcdef123456
+run_abcdef1234567890abcdef1234567890
 ```
 
-Like lease IDs, run IDs are the `run_` prefix plus 12 lowercase hex characters
-from 6 random bytes. A configured coordinator mints the durable run record; the
-CLI uses that issued ID for execution metadata. Coordinator-free runs mint the
-same shape locally before dispatch. A run ID is stable across a single
-invocation; retrying the same command produces a new run.
+Current clients mint the `run_` prefix plus 32 lowercase hex characters from
+16 random bytes before admission. The same ID identifies coordinator history
+and execution metadata. Legacy coordinator-issued IDs use 12 lowercase hex
+characters and remain valid history handles. A run ID is stable across a single
+invocation; a new invocation of the same command always produces a new ID.
 
-Coordinator-issued IDs are durable handles accepted by `crabbox history`,
+The caller-known admission route binds the ID to the initiating actor and
+original create request. Repeating that admission while its record is retained
+returns the existing record, without restarting it or adding an event. It does
+not replay remote execution, grant authority from an ID alone, or permit an
+invocation to adopt another actor's record.
+
+Admitted IDs are durable handles accepted by `crabbox history`,
 `crabbox events`, `crabbox attach`, `crabbox logs`, and `crabbox results`.
-Locally minted IDs identify the invocation in command environments, timing,
-proof, and failure artifacts but do not create coordinator history. Slugs do
-not resolve to runs — only to leases.
+Coordinator-free runs use their locally minted IDs in command environments,
+timing, proof, and failure artifacts without creating coordinator history.
+Slugs do not resolve to runs — only to leases.
 
 ## Local Claims
 
@@ -311,7 +317,7 @@ provisional lease ID  newLeaseID() before the broker call
 final lease ID        broker may return a different ID; key dir + claim re-keyed to it
 slug                  computed on first lease creation, stable for that lease
 provider name         derived from final lease ID + slug
-run ID                minted per crabbox run by the coordinator or local CLI
+run ID                minted per invocation by the CLI; legacy coordinators mint POST-created IDs
 ```
 
 Slugs are not reserved after a lease ends. The next lease that happens to hash

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -73,12 +73,19 @@ crabbox attach run_...
 crabbox results run_...
 ```
 
-If the initial run-record request fails with a transient coordinator transport
-or service error, Crabbox keeps the create retry armed while it acquires or
-replaces the lease. It retries after a lease attaches and starts recording as
-soon as creation succeeds. If history remains unavailable, the remote run can
-still proceed; the warning and failure digest identify the lease and print the
-recovery commands that remain usable without a run handle.
+The CLI chooses the run ID before admission. If an admission response is lost,
+it can recover the same record using that ID and the original request. The
+coordinator accepts recovery only for the same initiating owner, organization,
+and request; it does not append another `run.started` event. Lease replacement
+uses the existing acknowledged attribution flow after admission, rather than
+changing the original create request.
+
+Recovery never replays the remote command. The CLI refuses execution without a
+validated, still-starting run handle, and cancellation stops admission recovery.
+An older coordinator that lacks the caller-known admission route must be
+updated; the CLI does not fall back to anonymous record creation. Run IDs are
+single-invocation identities, and recovery relies on the existing record's
+retention. A new CLI invocation always uses a new ID.
 
 - **`history`** lists recorded runs. Filter with `--lease`, `--owner`, `--org`,
   `--state`, and `--limit` (default 50). It is intended for command debugging,

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -2250,8 +2251,7 @@ func imagePath(imageID, action string, refs ...CoordinatorImageRef) string {
 	return path
 }
 
-func (c *CoordinatorClient) CreateRun(ctx context.Context, leaseID string, cfg Config, command []string, label string) (CoordinatorRun, error) {
-	var res CoordinatorRunResponse
+func (c *CoordinatorClient) CreateRun(ctx context.Context, runID, leaseID string, cfg Config, command []string, label string) (CoordinatorRun, error) {
 	body := map[string]any{
 		"leaseID":     leaseID,
 		"provider":    cfg.Provider,
@@ -2264,8 +2264,33 @@ func (c *CoordinatorClient) CreateRun(ctx context.Context, leaseID string, cfg C
 	if strings.TrimSpace(label) != "" {
 		body["label"] = strings.TrimSpace(label)
 	}
-	err := c.do(ctx, http.MethodPost, "/v1/runs", body, &res)
-	return res.Run, err
+	// Only identity-bound admission is replayed, within the caller's original budget.
+	ctx, cancel := context.WithTimeout(ctx, runRecorderRequestTimeout)
+	defer cancel()
+	var err error
+	for attempt := 0; attempt < 2 && ctx.Err() == nil; attempt++ {
+		var res CoordinatorRunResponse
+		err = c.do(ctx, http.MethodPut, "/v1/runs/"+url.PathEscape(runID), body, &res)
+		if err == nil {
+			if ctx.Err() != nil {
+				return CoordinatorRun{}, ctx.Err()
+			}
+			if res.Run.ID != runID || res.Run.State != "running" || res.Run.Phase != "starting" || !slices.Equal(res.Run.Command, command) {
+				return CoordinatorRun{}, exit(7, "coordinator returned a mismatched or already-started run admission for %s", runID)
+			}
+			return res.Run, nil
+		}
+		if !runRecorderFinishRetryable(err) {
+			break
+		}
+	}
+	if ctx.Err() != nil {
+		return CoordinatorRun{}, ctx.Err()
+	}
+	if isCoordinatorNotFoundError(err) {
+		return CoordinatorRun{}, fmt.Errorf("coordinator run admission unavailable; upgrade the coordinator: %w", err)
+	}
+	return CoordinatorRun{}, err
 }
 
 func (c *CoordinatorClient) FinishRun(ctx context.Context, runID string, exitCode int, sync, command time.Duration, log string, truncated bool, results *TestResultSummary, telemetry *RunTelemetrySummary, classification FailureClassification, receipt *terminalRunReceipt) (CoordinatorRun, error) {

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -68,31 +68,31 @@ func TestCoordinatorRunEvents(t *testing.T) {
 	var eventBody map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/runs/"+admissionTestRunID:
 			if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
 				t.Fatal(err)
 			}
-			_, _ = w.Write([]byte(`{"run":{"id":"run_123","leaseID":"","owner":"peter@example.com","org":"openclaw","provider":"aws","class":"standard","serverType":"t3.small","command":["pnpm","test"],"label":"smoke","state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`))
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_123/events":
+			_, _ = w.Write([]byte(`{"run":{"id":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","leaseID":"","owner":"peter@example.com","org":"openclaw","provider":"aws","class":"standard","serverType":"t3.small","command":["pnpm","test"],"label":"smoke","state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events":
 			if err := json.NewDecoder(r.Body).Decode(&eventBody); err != nil {
 				t.Fatal(err)
 			}
-			_, _ = w.Write([]byte(`{"event":{"runID":"run_123","seq":2,"type":"sync.started","phase":"sync","createdAt":"2026-05-02T00:00:01Z"}}`))
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/runs/run_123/events":
+			_, _ = w.Write([]byte(`{"event":{"runID":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","seq":2,"type":"sync.started","phase":"sync","createdAt":"2026-05-02T00:00:01Z"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/runs/run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events":
 			if got := r.URL.Query().Get("after"); got != "4" {
 				t.Fatalf("after query=%q", got)
 			}
 			if got := r.URL.Query().Get("limit"); got != "25" {
 				t.Fatalf("limit query=%q", got)
 			}
-			_, _ = w.Write([]byte(`{"events":[{"runID":"run_123","seq":1,"type":"run.started","phase":"starting","createdAt":"2026-05-02T00:00:00Z"}]}`))
+			_, _ = w.Write([]byte(`{"events":[{"runID":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","seq":1,"type":"run.started","phase":"starting","createdAt":"2026-05-02T00:00:00Z"}]}`))
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
 	}))
 	defer server.Close()
 	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
-	run, err := client.CreateRun(context.Background(), "", Config{
+	run, err := client.CreateRun(context.Background(), admissionTestRunID, "", Config{
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
@@ -100,7 +100,7 @@ func TestCoordinatorRunEvents(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if run.ID != "run_123" || run.Phase != "starting" {
+	if run.ID != "run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" || run.Phase != "starting" {
 		t.Fatalf("run=%#v", run)
 	}
 	if got, ok := createBody["leaseID"].(string); !ok || got != "" {

--- a/internal/cli/lease.go
+++ b/internal/cli/lease.go
@@ -34,8 +34,12 @@ func NewLeaseID() string {
 	return newLeaseID()
 }
 
-func newRunID() string {
-	return "run_" + strings.TrimPrefix(newLeaseID(), "cbx_")
+func newRunID() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", err
+	}
+	return "run_" + hex.EncodeToString(value[:]), nil
 }
 
 func PublicKeyFor(privatePath string) (string, error) {

--- a/internal/cli/lease_test.go
+++ b/internal/cli/lease_test.go
@@ -10,9 +10,15 @@ import (
 )
 
 func TestNewRunIDUsesCanonicalFormatAndIsUnique(t *testing.T) {
-	first := newRunID()
-	second := newRunID()
-	pattern := regexp.MustCompile(`^run_[a-f0-9]{12}$`)
+	first, err := newRunID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := newRunID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pattern := regexp.MustCompile(`^run_[a-f0-9]{32}$`)
 	if !pattern.MatchString(first) || !pattern.MatchString(second) {
 		t.Fatalf("run IDs must use canonical format: first=%q second=%q", first, second)
 	}

--- a/internal/cli/ready_pool_test.go
+++ b/internal/cli/ready_pool_test.go
@@ -414,12 +414,12 @@ func TestRunReadyPoolEndpointPrecedesExplicitSSHPort(t *testing.T) {
 				t.Fatal(err)
 			}
 			const leaseID = "cbx_abcdef123456"
-			const runID = "run_pool_endpoint"
 			key := testOpenSSHPublicKey("ssh-ed25519", testBytes(32, 41))
 			lease := CoordinatorLease{ID: leaseID, Provider: "run-ready-pool-preflight-test", Host: "127.0.0.1", SSHUser: "lease-user", SSHPort: "2222", SSHFallbackPorts: []string{port}, SSHHostKey: key, State: "active", TargetOS: targetLinux, WorkRoot: "/work/crabbox"}
 			entry := CoordinatorReadyPoolEntry{Key: "shared-linux", LeaseID: leaseID, SSHHost: lease.Host, SSHUser: lease.SSHUser, SSHPort: port, BorrowToken: "test-borrow-token"}
 			var borrowed, returned atomic.Int32
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				runID := strings.SplitN(strings.TrimPrefix(req.URL.Path, "/v1/runs/"), "/", 2)[0]
 				switch req.Method + " " + req.URL.Path {
 				case "POST /v1/ready-pools/shared-linux/borrow":
 					borrowed.Add(1)
@@ -438,7 +438,16 @@ func TestRunReadyPoolEndpointPrecedesExplicitSSHPort(t *testing.T) {
 					_ = json.NewEncoder(w).Encode(CoordinatorReadyPoolResponse{Entry: entry, Lease: lease})
 				case "GET /v1/leases/" + leaseID, "POST /v1/leases/" + leaseID + "/heartbeat":
 					_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
-				case "POST /v1/runs", "POST /v1/runs/" + runID + "/finish":
+				case "PUT /v1/runs/" + runID:
+					var body struct {
+						Command []string `json:"command"`
+					}
+					if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return
+					}
+					_ = json.NewEncoder(w).Encode(CoordinatorRunResponse{Run: CoordinatorRun{ID: runID, LeaseID: leaseID, Provider: lease.Provider, State: "running", Phase: "starting", Command: body.Command}})
+				case "POST /v1/runs/" + runID + "/finish":
 					_ = json.NewEncoder(w).Encode(map[string]any{"run": CoordinatorRun{ID: runID, LeaseID: leaseID, Provider: lease.Provider, State: "running"}})
 				case "POST /v1/runs/" + runID + "/events":
 					_ = json.NewEncoder(w).Encode(map[string]any{"event": CoordinatorRunEvent{RunID: runID, Seq: 1}})

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -779,7 +779,10 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	envSelection.Inline = mergeEnv(envSelection.Inline, expansion.Env)
 	envSelection.Effective = mergeEnv(envSelection.Effective, expansion.Env)
 	stripExternalDesktopPasswordFromRunEnv(cfg, &envSelection)
-	executionRunID := newRunID()
+	executionRunID, err := newRunID()
+	if err != nil {
+		return exit(7, "create run identity: %v", err)
+	}
 	applyRunExecutionMetadata(&envSelection, strings.TrimSpace(*leaseIDFlag), executionRunID, requestedSlug)
 	envHelperName := strings.TrimSpace(*envHelper)
 	if envHelperName != "" && len(envSelection.Profile) == 0 {
@@ -1224,7 +1227,10 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	}
 	recordCommand := runScriptRecordCommand(script, command)
 	timingRecordCommand = recordCommand
-	recorder = newRunRecorder(ctx, coord, cfg, recordCommand, runLabelValue, a.Stderr, strings.TrimSpace(*leaseIDFlag) != "")
+	recorder = newRunRecorder(ctx, coord, cfg, recordCommand, runLabelValue, a.Stderr, strings.TrimSpace(*leaseIDFlag) != "", executionRunID)
+	if recorder.createErr != nil && !recorder.createPending && !*syncOnly {
+		return recorder.requireHandle()
+	}
 	if useCoordinator {
 		recorder.Event("leasing.started", "leasing", "")
 	}
@@ -1313,7 +1319,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return exit(2, "profile doctor is not supported for native Windows targets")
 		}
 		if useCoordinator {
-			if err := recorder.AttachLease(leaseID, serverSlug(server), cfg); err != nil {
+			if err := recorder.AttachLease(ctx, leaseID, serverSlug(server), cfg); err != nil {
 				if !*syncOnly {
 					return err
 				}
@@ -1340,7 +1346,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if lease.Coordinator != nil {
 			coord = lease.Coordinator
 			useCoordinator = true
-			recorder.UseCoordinator(coord)
+			if err := recorder.UseCoordinator(coord); err != nil {
+				return err
+			}
 		}
 		applyResolvedLeaseConfig(&cfg, server, &target)
 		if borrowedPool != nil {
@@ -1768,7 +1776,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		acquired = true
 		coord = newLease.Coordinator
 		useCoordinator = coord != nil
-		recorder.UseCoordinator(coord)
+		if err := recorder.UseCoordinator(coord); err != nil {
+			return true, err
+		}
 		applyResolvedServerConfig(&cfg, server)
 		removeEnvironmentKeys(runReq.Env, target.ChildEnvDenylist...)
 		if err := enforceManagedLeaseCapabilities(cfg, server, leaseID); err != nil {
@@ -1784,10 +1794,18 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return true, exit(2, "profile doctor is not supported for native Windows targets")
 		}
 		if useCoordinator {
-			if err := recorder.AttachLease(leaseID, serverSlug(server), cfg); err != nil {
-				return true, err
+			if err := recorder.AttachLease(ctx, leaseID, serverSlug(server), cfg); err != nil {
+				if !*syncOnly {
+					return true, err
+				}
+				recorder.warnRunHistory("sync-only run history binding unavailable: %v", err)
 			}
 			startRunHeartbeat(nil)
+		}
+		if !*syncOnly {
+			if err := recorder.requireHandle(); err != nil {
+				return true, err
+			}
 		}
 		if recorder.runID != "" {
 			executionRunID = recorder.runID

--- a/internal/cli/run_admission_recovery_test.go
+++ b/internal/cli/run_admission_recovery_test.go
@@ -1,0 +1,227 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+const admissionTestRunID = "run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+func admissionTestResponse(w http.ResponseWriter, req *http.Request, state, phase string) {
+	json.NewEncoder(w).Encode(CoordinatorRunResponse{Run: CoordinatorRun{ID: admissionTestRunID, State: state, Phase: phase, Command: []string{"true"}, LeaseID: "cbx_test"}})
+}
+
+func TestRunAdmissionUsesReplaySafeRoute(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPut || req.URL.Path != "/v1/runs/"+admissionTestRunID {
+			http.NotFound(w, req)
+			return
+		}
+		admissionTestResponse(w, req, "running", "starting")
+	}))
+	defer server.Close()
+	client := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	rec := newRunRecorder(t.Context(), client, Config{}, []string{"true"}, "", io.Discard, true, admissionTestRunID)
+	if err := rec.AttachLease(t.Context(), "cbx_test", "", Config{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rec.requireHandle(); err != nil {
+		t.Fatalf("replay-safe admission unavailable: %v", err)
+	}
+}
+
+func TestRunAdmissionRejectsTerminalAndAdvancedRecords(t *testing.T) {
+	for _, record := range []struct{ state, phase string }{{"succeeded", "completed"}, {"failed", "failed"}, {"running", "command"}} {
+		t.Run(record.state+"-"+record.phase, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				admissionTestResponse(w, req, record.state, record.phase)
+			}))
+			defer server.Close()
+			rec := newRunRecorder(t.Context(), &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}, Config{}, []string{"true"}, "", io.Discard, true, admissionTestRunID)
+			_ = rec.AttachLease(t.Context(), "cbx_test", "", Config{})
+			if rec.requireHandle() == nil {
+				t.Fatal("historical or advanced record authorized fresh execution")
+			}
+		})
+	}
+}
+
+func TestRunAdmissionRetainsInvocationCancellation(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		calls++
+		admissionTestResponse(w, req, "running", "starting")
+	}))
+	defer server.Close()
+	ctx, cancel := context.WithCancel(t.Context())
+	rec := newRunRecorder(ctx, &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}, Config{}, []string{"true"}, "", io.Discard, true, admissionTestRunID)
+	cancel()
+	_ = rec.AttachLease(ctx, "cbx_test", "", Config{})
+	if calls != 0 || rec.requireHandle() == nil {
+		t.Fatalf("canceled invocation admitted: calls=%d idPresent=%t", calls, strings.TrimSpace(rec.runID) != "")
+	}
+}
+
+func TestRunAdmissionRecoversCommittedResponseWithoutChangingBinding(t *testing.T) {
+	var mu sync.Mutex
+	var bodies [][]byte
+	committed := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/events") {
+			io.WriteString(w, `{"event":{"type":"lease.created"}}`)
+			return
+		}
+		if req.Method != http.MethodPut || req.URL.Path != "/v1/runs/"+admissionTestRunID {
+			t.Errorf("unexpected admission route %s %s", req.Method, req.URL.Path)
+			http.NotFound(w, req)
+			return
+		}
+		body, _ := io.ReadAll(req.Body)
+		mu.Lock()
+		bodies = append(bodies, body)
+		first := len(bodies) == 1
+		if first {
+			committed++
+		}
+		mu.Unlock()
+		if first {
+			conn, _, err := w.(http.Hijacker).Hijack()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			conn.Close()
+			return
+		}
+		json.NewEncoder(w).Encode(CoordinatorRunResponse{Run: CoordinatorRun{ID: admissionTestRunID, State: "running", Phase: "starting", Command: []string{"true"}}})
+	}))
+	defer server.Close()
+	original := []string{"true"}
+	rec := newRunRecorder(t.Context(), &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}, Config{Provider: "aws"}, original, "label", io.Discard, false, admissionTestRunID)
+	defer rec.Failed(nil)
+	original[0] = "changed"
+	if err := rec.AttachLease(t.Context(), "cbx_replacement", "replacement", Config{Provider: "gcp"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rec.requireHandle(); err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if committed != 1 || len(bodies) != 2 || !bytes.Equal(bodies[0], bodies[1]) {
+		t.Fatalf("admission replay changed binding: commits=%d requests=%d", committed, len(bodies))
+	}
+	var body map[string]any
+	json.Unmarshal(bodies[0], &body)
+	if body["leaseID"] != "" || body["provider"] != "aws" || rec.runID != admissionTestRunID || rec.leaseID != "cbx_replacement" {
+		t.Fatalf("immutable create or actual attribution lost: request=%v lease=%s", body, rec.leaseID)
+	}
+}
+
+func TestRunAdmissionRecoverySharesTenSecondBudget(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		started := time.Now()
+		calls := 0
+		client := &CoordinatorClient{BaseURL: "https://example.test", Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				time.Sleep(7 * time.Second)
+				return nil, io.ErrUnexpectedEOF
+			}
+			deadline, ok := req.Context().Deadline()
+			if !ok || !deadline.Equal(started.Add(10*time.Second)) {
+				t.Error("recovery reset admission budget")
+			}
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		})}}
+		_, err := client.CreateRun(t.Context(), admissionTestRunID, "cbx_test", Config{}, []string{"true"}, "")
+		if !errors.Is(err, context.DeadlineExceeded) || calls != 2 || time.Since(started) != 10*time.Second {
+			t.Fatalf("budget result calls=%d elapsed=%s err=%v", calls, time.Since(started), err)
+		}
+	})
+}
+
+func TestRunAdmissionRejectsMismatchedRepliesWithoutRetry(t *testing.T) {
+	for _, mismatch := range []string{"identity", "command"} {
+		t.Run(mismatch, func(t *testing.T) {
+			calls := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				calls++
+				run := CoordinatorRun{ID: admissionTestRunID, State: "running", Phase: "starting", Command: []string{"true"}}
+				if mismatch == "identity" {
+					run.ID = "run_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+				} else {
+					run.Command = []string{"other"}
+				}
+				json.NewEncoder(w).Encode(CoordinatorRunResponse{Run: run})
+			}))
+			defer server.Close()
+			rec := newRunRecorder(t.Context(), &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}, Config{}, []string{"true"}, "", io.Discard, false, admissionTestRunID)
+			err := rec.AttachLease(t.Context(), "cbx_test", "", Config{})
+			if calls != 1 || rec.createPending || rec.runID != "" || err == nil || !strings.Contains(err.Error(), "mismatched") {
+				t.Fatalf("mismatched reply recovered: calls=%d pending=%v err=%v", calls, rec.createPending, err)
+			}
+		})
+	}
+}
+
+func TestRunAdmissionRejectsResponseAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	client := &CoordinatorClient{BaseURL: "https://example.test", Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		cancel()
+		body, _ := json.Marshal(CoordinatorRunResponse{Run: CoordinatorRun{ID: admissionTestRunID, State: "running", Phase: "starting", Command: []string{"true"}}})
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(body)), Header: make(http.Header)}, nil
+	})}}
+	rec := newRunRecorder(ctx, client, Config{}, []string{"true"}, "", io.Discard, true, admissionTestRunID)
+	if rec.AttachLease(ctx, "cbx_test", "", Config{}) == nil || rec.runID != "" || rec.createPending {
+		t.Fatal("late response admitted canceled invocation")
+	}
+}
+
+func TestRunAdmissionCannotMoveToAnotherCoordinator(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) { admissionTestResponse(w, req, "running", "starting") }))
+	defer server.Close()
+	original := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	rec := newRunRecorder(t.Context(), original, Config{}, []string{"true"}, "", io.Discard, false, admissionTestRunID)
+	if err := rec.requireHandle(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rec.UseCoordinator(&CoordinatorClient{BaseURL: "https://replacement.invalid"}); err == nil {
+		t.Fatal("admission silently changed coordinator")
+	}
+	if rec.coord != original {
+		t.Fatal("refusal replaced the original coordinator")
+	}
+	refreshed := &CoordinatorClient{BaseURL: server.URL, Token: "refreshed-fixture", Client: server.Client()}
+	if err := rec.UseCoordinator(refreshed); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunAdmissionCannotReuseFieldsFromFailedDecode(t *testing.T) {
+	calls := 0
+	client := &CoordinatorClient{BaseURL: "https://example.test", Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		body := `{"run":{"id":"` + admissionTestRunID + `","state":"running","phase":"starting"}}`
+		if calls == 1 {
+			body = `{"run":{"id":"` + admissionTestRunID + `","state":"running","phase":"starting","command":["true"],"eventCount":"malformed"}}`
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+	})}}
+	_, err := client.CreateRun(t.Context(), admissionTestRunID, "cbx_test", Config{}, []string{"true"}, "")
+	if err == nil || calls != 2 {
+		t.Fatalf("failed response supplied later admission fields: calls=%d err=%v", calls, err)
+	}
+}

--- a/internal/cli/run_cleanup_outcome_test.go
+++ b/internal/cli/run_cleanup_outcome_test.go
@@ -83,8 +83,17 @@ func TestRunCoordinatorCleanupOutcomes(t *testing.T) {
 						_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
 					case strings.HasPrefix(r.URL.Path, "/v1/leases/"):
 						_ = json.NewEncoder(w).Encode(map[string]any{"lease": active})
-					case r.URL.Path == "/v1/runs" || strings.HasSuffix(r.URL.Path, "/finish"):
-						_ = json.NewEncoder(w).Encode(map[string]any{"run": map[string]any{"id": "run_abcdef123456"}})
+					case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/v1/runs/"):
+						var body struct {
+							Command []string `json:"command"`
+						}
+						if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+							http.Error(w, err.Error(), http.StatusBadRequest)
+							return
+						}
+						_ = json.NewEncoder(w).Encode(CoordinatorRunResponse{Run: CoordinatorRun{ID: strings.TrimPrefix(r.URL.Path, "/v1/runs/"), LeaseID: id, State: "running", Phase: "starting", Command: body.Command}})
+					case strings.HasSuffix(r.URL.Path, "/finish"):
+						_ = json.NewEncoder(w).Encode(map[string]any{"run": map[string]any{"id": strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v1/runs/"), "/finish")}})
 					case strings.HasSuffix(r.URL.Path, "/events"):
 						_, _ = io.WriteString(w, `{"event":{"seq":1}}`)
 					default:

--- a/internal/cli/run_event_publisher_test.go
+++ b/internal/cli/run_event_publisher_test.go
@@ -125,7 +125,7 @@ func TestRunRecorderOrdersEventsAcrossLeaseReplacementAndFinish(t *testing.T) {
 	<-started
 	rec.UseCoordinator(&CoordinatorClient{BaseURL: server.URL, Token: "new", Client: server.Client()})
 	attached := make(chan error, 1)
-	go func() { attached <- rec.AttachLease("cbx_new", "new-slug", Config{}) }()
+	go func() { attached <- rec.AttachLease(t.Context(), "cbx_new", "new-slug", Config{}) }()
 	select {
 	case <-attached:
 		t.Error("replacement admitted before its authoritative lease attachment")
@@ -154,8 +154,8 @@ func TestRunRecorderExistingLeaseCreateDoesNotWaitForDiagnostic(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.URL.Path == "/v1/runs" {
-			io.WriteString(w, `{"run":{"id":"run_123","leaseID":"cbx_existing","slug":"existing","provider":"aws"}}`)
+		if req.URL.Path == "/v1/runs/"+admissionTestRunID {
+			io.WriteString(w, `{"run":{"id":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","leaseID":"cbx_existing","slug":"existing","provider":"aws","state":"running","phase":"starting","command":["true"]}}`)
 			return
 		}
 		close(started)
@@ -164,9 +164,9 @@ func TestRunRecorderExistingLeaseCreateDoesNotWaitForDiagnostic(t *testing.T) {
 	}))
 	defer server.Close()
 	cfg := Config{Provider: "aws"}
-	rec := newRunRecorder(context.Background(), &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}, cfg, []string{"true"}, "", io.Discard, true)
+	rec := newRunRecorder(context.Background(), &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}, cfg, []string{"true"}, "", io.Discard, true, admissionTestRunID)
 	attached := make(chan error, 1)
-	go func() { attached <- rec.AttachLease("cbx_existing", "existing", cfg) }()
+	go func() { attached <- rec.AttachLease(t.Context(), "cbx_existing", "existing", cfg) }()
 	<-started
 	select {
 	case err := <-attached:
@@ -228,7 +228,7 @@ func TestRunRecorderBindingIgnoresDiagnosticBacklog(t *testing.T) {
 						rec.Event("sync.finished", "synced", "")
 					}
 				}
-				if err := rec.AttachLease("cbx_replacement", "replacement", Config{Provider: "aws"}); err != nil {
+				if err := rec.AttachLease(t.Context(), "cbx_replacement", "replacement", Config{Provider: "aws"}); err != nil {
 					t.Errorf("healthy binding rejected by diagnostic backlog: %v", err)
 				}
 				rec.Failed(nil)
@@ -247,7 +247,7 @@ func TestRunRecorderMissingBindingEndpointFailsAdmission(t *testing.T) {
 			}))
 			defer server.Close()
 			rec := &runRecorder{coord: &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}, runID: "run_123", leaseID: oldLease, stderr: io.Discard}
-			err := rec.AttachLease("cbx_next", "next", Config{Provider: "aws"})
+			err := rec.AttachLease(t.Context(), "cbx_next", "next", Config{Provider: "aws"})
 			if ExitCodeForError(err, 0) != 7 || !strings.Contains(err.Error(), "lease attribution") {
 				t.Fatalf("unbound run was admitted without a valid binding: %v", err)
 			}

--- a/internal/cli/run_output_events.go
+++ b/internal/cli/run_output_events.go
@@ -128,9 +128,9 @@ func (q *runEventPublisher) append(coord *CoordinatorClient, runID string, input
 
 // A binding owns admission, so queued diagnostics cannot consume its capacity
 // or HTTP budget. Drain and join before posting, then resume the same publisher.
-func (q *runEventPublisher) Bind(coord *CoordinatorClient, runID string, input CoordinatorRunEventInput) error {
+func (q *runEventPublisher) Bind(ctx context.Context, coord *CoordinatorClient, runID string, input CoordinatorRunEventInput) error {
 	q.CloseAndWait(runEventOutputPostWait)
-	if err := postRunEvent(context.Background(), coord, runID, input); err != nil {
+	if err := postRunEvent(ctx, coord, runID, input); err != nil {
 		return err
 	}
 	q.queueMu.Lock()

--- a/internal/cli/run_recorder.go
+++ b/internal/cli/run_recorder.go
@@ -24,6 +24,11 @@ type runRecorder struct {
 	command            []string
 	label              string
 	runID              string
+	requestedRunID     string
+	createLeaseID      string
+	createConfig       *Config
+	createBaseURL      string
+	createErr          error
 	startedAt          time.Time
 	attachedAt         time.Time
 	stderr             io.Writer
@@ -45,40 +50,56 @@ type runRecorder struct {
 	telemetryDone      chan struct{}
 }
 
-func newRunRecorder(ctx context.Context, coord *CoordinatorClient, cfg Config, command []string, label string, stderr io.Writer, createAfterLease bool) *runRecorder {
+func newRunRecorder(ctx context.Context, coord *CoordinatorClient, cfg Config, command []string, label string, stderr io.Writer, createAfterLease bool, requestedRunID string) *runRecorder {
 	rec := &runRecorder{
 		coord:             coord,
-		command:           command,
+		command:           append([]string(nil), command...),
+		requestedRunID:    requestedRunID,
+		createPending:     true,
 		label:             strings.TrimSpace(label),
 		stderr:            stderr,
 		diagnosticConfig:  cfg,
 		diagnosticSecrets: configuredDiagnosticSecrets(cfg),
 	}
-	if coord == nil {
-		return rec
-	}
-	if createAfterLease {
-		rec.createPending = true
-		return rec
-	}
-	run, err := coord.CreateRun(ctx, "", cfg, command, rec.label)
-	if err != nil {
-		rec.createPending = true
-		if isInvalidLeaseIDCoordinatorError(err) {
-			return rec
+	if coord != nil && !createAfterLease {
+		if err := rec.createRun(ctx, "", cfg); err != nil {
+			rec.warnRunHistory("run admission %s failed before lease: %v", requestedRunID, err)
 		}
-		rec.warnRunHistory("run history create failed before lease; will retry after lease is available: %v", err)
-		return rec
 	}
-	rec.attachRun(run)
+
 	return rec
 }
 
-func (r *runRecorder) UseCoordinator(coord *CoordinatorClient) {
+func (r *runRecorder) UseCoordinator(coord *CoordinatorClient) error {
 	if r == nil || coord == nil {
-		return
+		return nil
+	}
+	if r.createBaseURL != "" && strings.TrimRight(coord.BaseURL, "/") != r.createBaseURL {
+		return exit(7, "run admission %s belongs to a different coordinator; restore the original route", r.requestedRunID)
 	}
 	r.coord = coord
+	return nil
+}
+
+func (r *runRecorder) createRun(ctx context.Context, leaseID string, cfg Config) error {
+	// Replay the first admission payload; lease.created owns later lease attribution.
+	if r.createConfig == nil {
+		r.createLeaseID = leaseID
+		r.createConfig = &Config{Provider: cfg.Provider, TargetOS: cfg.TargetOS, WindowsMode: cfg.WindowsMode, Class: cfg.Class, ServerType: cfg.ServerType}
+		r.createBaseURL = strings.TrimRight(r.coord.BaseURL, "/")
+		fmt.Fprintf(r.stderr, "run admission attempt %s\n", r.requestedRunID)
+	}
+	run, err := r.coord.CreateRun(ctx, r.requestedRunID, r.createLeaseID, *r.createConfig, r.command, r.label)
+	if err != nil {
+		r.historyUnavailable = true
+		r.createErr = err
+		var refusal ExitError
+		r.createPending = !AsExitError(err, &refusal) && runRecorderFinishRetryable(err)
+		return err
+	}
+	r.createErr = nil
+	r.attachRun(run)
+	return nil
 }
 
 func (r *runRecorder) historyIsUnavailable() bool {
@@ -88,6 +109,9 @@ func (r *runRecorder) historyIsUnavailable() bool {
 func (r *runRecorder) requireHandle() error {
 	if r == nil || r.coord == nil || r.runID != "" {
 		return nil
+	}
+	if r.createErr != nil {
+		return exit(7, "run admission %s unavailable before command: %v", r.requestedRunID, r.createErr)
 	}
 	return exit(7, "run history unavailable before command; refusing execution without a coordinator run handle")
 }
@@ -124,23 +148,21 @@ func (r *runRecorder) appendEvent(kind string, input CoordinatorRunEventInput) {
 	r.publisher.append(r.coord, r.runID, input)
 }
 
-func (r *runRecorder) AttachLease(leaseID, slug string, cfg Config) error {
+func (r *runRecorder) AttachLease(ctx context.Context, leaseID, slug string, cfg Config) error {
 	if r == nil || r.finished {
 		return nil
 	}
-	if r.runID == "" && r.createPending && r.coord != nil && leaseID != "" {
-		ctx, cancel := context.WithTimeout(context.Background(), runRecorderRequestTimeout)
-		defer cancel()
-		run, err := r.coord.CreateRun(ctx, leaseID, cfg, r.command, r.label)
-		if err != nil {
-			r.historyUnavailable = true
-			r.warnRunHistory("run history create failed after lease; run history unavailable, use lease-based recovery commands: %v", err)
-			return nil
-		}
-		r.attachRun(run)
+	if err := ctx.Err(); err != nil {
+		return err
 	}
+	if r.runID == "" && r.createPending && r.coord != nil && leaseID != "" {
+		if err := r.createRun(ctx, leaseID, cfg); err != nil {
+			return exit(7, "run admission %s unavailable before command: %v", r.requestedRunID, err)
+		}
+	}
+
 	if r.runID == "" {
-		return nil
+		return r.requireHandle()
 	}
 	input := CoordinatorRunEventInput{
 		Type:        "lease.created",
@@ -160,11 +182,14 @@ func (r *runRecorder) AttachLease(leaseID, slug string, cfg Config) error {
 	// replacement need acknowledgement before the command's receipt can bind it.
 	needsBinding := r.leaseID != leaseID || r.leaseSlug != slug || r.leaseProvider != cfg.Provider
 	if needsBinding {
-		if err := r.publisher.Bind(r.coord, r.runID, input); err != nil {
+		if err := r.publisher.Bind(ctx, r.coord, r.runID, input); err != nil {
 			return exit(7, "run history lease attribution failed for %s: %v", r.runID, err)
 		}
 	} else {
 		r.publisher.append(r.coord, r.runID, input)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	r.leaseID, r.leaseSlug, r.leaseProvider = leaseID, slug, cfg.Provider
 	return nil
@@ -423,8 +448,4 @@ func (r *runRecorder) handleRunEventAppendError(kind string, err error) bool {
 	}
 	r.warn("run event append failed for %s: %v", kind, err)
 	return true
-}
-
-func isInvalidLeaseIDCoordinatorError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "invalid_lease_id")
 }

--- a/internal/cli/run_recorder_test.go
+++ b/internal/cli/run_recorder_test.go
@@ -58,7 +58,7 @@ func TestRunRecorderCapturesTelemetryOnlyWithRunHandle(t *testing.T) {
 					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"run":{"id":"run_123"}}`)), Header: make(http.Header)}, nil
 				})}}
 			}
-			rec := newRunRecorder(t.Context(), client, Config{}, []string{"true"}, "", io.Discard, true)
+			rec := newRunRecorder(t.Context(), client, Config{}, []string{"true"}, "", io.Discard, true, admissionTestRunID)
 			rec.runID = test.runID
 			target := SSHTarget{User: "runner", Host: "example.test", Port: "22", FallbackPorts: []string{}}
 			rec.CaptureTelemetryStart(t.Context(), target)
@@ -101,7 +101,7 @@ func TestRunRecorderTelemetryUploadDoesNotBlockCommandAdmission(t *testing.T) {
 			<-release
 			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"run":{"id":"run_123"}}`)), Header: make(http.Header)}, nil
 		})}}
-		rec := newRunRecorder(t.Context(), client, Config{}, []string{"true"}, "", io.Discard, true)
+		rec := newRunRecorder(t.Context(), client, Config{}, []string{"true"}, "", io.Discard, true, admissionTestRunID)
 		rec.runID = "run_123"
 		target := SSHTarget{User: "runner", Host: "example.test", Port: "22", FallbackPorts: []string{}}
 		admitted := make(chan struct{})
@@ -330,7 +330,7 @@ func TestRunRecorderRedactsCoordinatorDiagnosticEvents(t *testing.T) {
 			}
 			rec := newRunRecorder(context.Background(), client, Config{
 				Morph: MorphConfig{APIKey: configuredSecret},
-			}, []string{"go", "test"}, "", io.Discard, true)
+			}, []string{"go", "test"}, "", io.Discard, true, admissionTestRunID)
 			rec.runID = "run_123"
 
 			test.record(rec)
@@ -374,7 +374,7 @@ func TestRunRecorderPreservesRawStreamEventData(t *testing.T) {
 	}
 	rec := newRunRecorder(context.Background(), client, Config{
 		Morph: MorphConfig{APIKey: configuredSecret},
-	}, []string{"go", "test"}, "", io.Discard, true)
+	}, []string{"go", "test"}, "", io.Discard, true, admissionTestRunID)
 	rec.runID = "run_123"
 
 	stdout := rec.StreamWriter("stdout")
@@ -404,7 +404,7 @@ func TestRunRecorderRedactsRefreshedRuntimeDiagnosticSecrets(t *testing.T) {
 		BaseURL: "https://example.test",
 		Client:  &http.Client{Transport: runEventRecordingRoundTripper{events: &events}},
 	}
-	rec := newRunRecorder(context.Background(), client, Config{}, []string{"go", "test"}, "", io.Discard, true)
+	rec := newRunRecorder(context.Background(), client, Config{}, []string{"go", "test"}, "", io.Discard, true, admissionTestRunID)
 	rec.runID = "run_123"
 	t.Setenv("AWS_SESSION_TOKEN", refreshedSecret)
 
@@ -434,7 +434,7 @@ func TestRunRecorderRedactsDiagnosticSecretsAfterLateCoordinatorAttachment(t *te
 
 	rec := newRunRecorder(context.Background(), nil, Config{
 		Morph: MorphConfig{APIKey: configuredSecret},
-	}, []string{"go", "test"}, "", io.Discard, true)
+	}, []string{"go", "test"}, "", io.Discard, true, admissionTestRunID)
 	t.Setenv("AWS_SESSION_TOKEN", refreshedSecret)
 
 	var events []CoordinatorRunEventInput
@@ -476,6 +476,10 @@ func TestRunRecorderRedactsPersistedCoordinatorDiagnosticEvents(t *testing.T) {
 		refreshedSecret  = "persisted-refreshed-runtime-fixture-value"
 	)
 	t.Setenv("AWS_SESSION_TOKEN", originalSecret)
+	requestedRunID, identityErr := newRunID()
+	if identityErr != nil {
+		t.Fatal(identityErr)
+	}
 	cfg := Config{
 		Provider:   "aws",
 		Class:      "standard",
@@ -487,10 +491,10 @@ func TestRunRecorderRedactsPersistedCoordinatorDiagnosticEvents(t *testing.T) {
 		Token:   os.Getenv("CRABBOX_RUN_RECORDER_PROOF_TOKEN"),
 		Client:  &http.Client{Timeout: 10 * time.Second},
 	}
-	rec := newRunRecorder(context.Background(), nil, cfg, []string{"go", "test"}, "security-redaction-proof", io.Discard, true)
+	rec := newRunRecorder(context.Background(), nil, cfg, []string{"go", "test"}, "security-redaction-proof", io.Discard, true, requestedRunID)
 	t.Setenv("AWS_SESSION_TOKEN", refreshedSecret)
 	rec.UseCoordinator(client)
-	run, err := client.CreateRun(context.Background(), "", cfg, rec.command, rec.label)
+	run, err := client.CreateRun(context.Background(), requestedRunID, "", cfg, rec.command, rec.label)
 	if err != nil {
 		t.Fatalf("create coordinator run: %v", err)
 	}
@@ -649,67 +653,20 @@ func TestRunEventStreamWriterDoesNotBlockOnCoordinatorPost(t *testing.T) {
 	}
 }
 
-func TestRunRecorderDefersCreateWhenCoordinatorRequiresLeaseID(t *testing.T) {
-	var stderr bytes.Buffer
-	var createBodies []map[string]any
-	var eventBody map[string]any
+func TestRunRecorderDoesNotRetryUnsupportedAdmissionAfterLease(t *testing.T) {
+	calls := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
-			var body map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatal(err)
-			}
-			createBodies = append(createBodies, body)
-			if body["leaseID"] == "" {
-				http.Error(w, `{"error":"invalid_lease_id"}`, http.StatusBadRequest)
-				return
-			}
-			_, _ = w.Write([]byte(`{"run":{"id":"run_123","leaseID":"cbx_abcdef123456","owner":"peter@example.com","org":"openclaw","provider":"aws","class":"standard","serverType":"t3.small","command":["pnpm","test"],"state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`))
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_123/events":
-			if err := json.NewDecoder(r.Body).Decode(&eventBody); err != nil {
-				t.Fatal(err)
-			}
-			_, _ = w.Write([]byte(`{"event":{"runID":"run_123","seq":1,"type":"lease.created","createdAt":"2026-05-02T00:00:01Z"}}`))
-		default:
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		calls++
+		if r.Method != http.MethodPut {
+			t.Errorf("anonymous admission request: %s", r.Method)
 		}
+		http.Error(w, `{"error":"not_found"}`, http.StatusNotFound)
 	}))
 	defer server.Close()
-
-	client := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
-	rec := newRunRecorder(context.Background(), client, Config{
-		Provider:   "aws",
-		Class:      "standard",
-		ServerType: "t3.small",
-	}, []string{"pnpm", "test"}, "", &stderr, false)
-	rec.Event("leasing.started", "leasing", "")
-	rec.AttachLease("cbx_abcdef123456", "blue-lobster", Config{
-		Provider:   "aws",
-		Class:      "standard",
-		ServerType: "t3.small",
-	})
-
-	if len(createBodies) != 2 {
-		t.Fatalf("create requests=%d want 2", len(createBodies))
-	}
-	if got := createBodies[0]["leaseID"]; got != "" {
-		t.Fatalf("first create leaseID=%#v want empty", got)
-	}
-	if got := createBodies[1]["leaseID"]; got != "cbx_abcdef123456" {
-		t.Fatalf("second create leaseID=%#v", got)
-	}
-	rec.waitForEvents(time.Second)
-	if got := eventBody["type"]; got != "lease.created" {
-		t.Fatalf("event body=%#v", eventBody)
-	}
-	if text := stderr.String(); strings.Contains(text, "warning:") || !strings.Contains(text, "recording run run_123") {
-		t.Fatalf("stderr=%q", text)
-	}
-	selection := runEnvSelection{Inline: map[string]string{}, Effective: map[string]string{}}
-	applyRunExecutionMetadata(&selection, "cbx_abcdef123456", rec.runID, "blue-lobster")
-	if selection.Effective[runEnvRunID] != "run_123" {
-		t.Fatalf("execution metadata run ID=%q, want coordinator-issued run_123", selection.Effective[runEnvRunID])
+	rec := newRunRecorder(t.Context(), &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}, Config{}, []string{"true"}, "", io.Discard, false, admissionTestRunID)
+	err := rec.AttachLease(t.Context(), "cbx_target", "target", Config{})
+	if calls != 1 || rec.createPending || err == nil || !strings.Contains(err.Error(), "upgrade the coordinator") || !strings.Contains(err.Error(), admissionTestRunID) {
+		t.Fatalf("unsupported admission was retried or lost diagnosis: calls=%d pending=%v err=%v", calls, rec.createPending, err)
 	}
 }
 
@@ -734,18 +691,18 @@ func TestRunRecorderDefersCreateForExplicitLeaseRuns(t *testing.T) {
 	var eventBody map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/runs/"+admissionTestRunID:
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatal(err)
 			}
 			createBodies = append(createBodies, body)
-			_, _ = w.Write([]byte(`{"run":{"id":"run_123","leaseID":"cbx_abcdef123456","owner":"bob@example.com","org":"elsewhere","provider":"aws","class":"standard","serverType":"t3.small","command":["pnpm","test"],"state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`))
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_123/events":
+			_, _ = w.Write([]byte(`{"run":{"id":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","leaseID":"cbx_abcdef123456","owner":"bob@example.com","org":"elsewhere","provider":"aws","class":"standard","serverType":"t3.small","command":["pnpm","test"],"state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events":
 			if err := json.NewDecoder(r.Body).Decode(&eventBody); err != nil {
 				t.Fatal(err)
 			}
-			_, _ = w.Write([]byte(`{"event":{"runID":"run_123","seq":1,"type":"lease.created","leaseID":"cbx_abcdef123456","createdAt":"2026-05-02T00:00:01Z"}}`))
+			_, _ = w.Write([]byte(`{"event":{"runID":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","seq":1,"type":"lease.created","leaseID":"cbx_abcdef123456","createdAt":"2026-05-02T00:00:01Z"}}`))
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
@@ -757,13 +714,13 @@ func TestRunRecorderDefersCreateForExplicitLeaseRuns(t *testing.T) {
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
-	}, []string{"pnpm", "test"}, "", &stderr, true)
+	}, []string{"pnpm", "test"}, "", &stderr, true, admissionTestRunID)
 	rec.Event("leasing.started", "leasing", "")
 	if len(createBodies) != 0 {
 		t.Fatalf("create requests before lease=%d want 0", len(createBodies))
 	}
 
-	rec.AttachLease("cbx_abcdef123456", "blue-lobster", Config{
+	rec.AttachLease(t.Context(), "cbx_abcdef123456", "blue-lobster", Config{
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
@@ -779,18 +736,18 @@ func TestRunRecorderDefersCreateForExplicitLeaseRuns(t *testing.T) {
 	if got := eventBody["type"]; got != "lease.created" {
 		t.Fatalf("event body=%#v", eventBody)
 	}
-	if text := stderr.String(); strings.Contains(text, "warning:") || !strings.Contains(text, "recording run run_123") {
+	if text := stderr.String(); strings.Contains(text, "warning:") || !strings.Contains(text, "recording run run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
 		t.Fatalf("stderr=%q", text)
 	}
 }
 
-func TestRunRecorderRetriesTransientCreateFailureAfterLease(t *testing.T) {
+func TestRunRecorderRecoversTransientCreateBeforeLease(t *testing.T) {
 	var stderr bytes.Buffer
 	var createBodies []map[string]any
 	var eventBody map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/runs/"+admissionTestRunID:
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatal(err)
@@ -800,12 +757,12 @@ func TestRunRecorderRetriesTransientCreateFailureAfterLease(t *testing.T) {
 				http.Error(w, `{"error":"temporary_unavailable"}`, http.StatusInternalServerError)
 				return
 			}
-			_, _ = w.Write([]byte(`{"run":{"id":"run_123","leaseID":"cbx_abcdef123456","owner":"alice@example.com","org":"example-org","provider":"aws","class":"standard","serverType":"t3.small","command":["go","test"],"state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`))
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_123/events":
+			_, _ = w.Write([]byte(`{"run":{"id":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","leaseID":"cbx_abcdef123456","owner":"alice@example.com","org":"example-org","provider":"aws","class":"standard","serverType":"t3.small","command":["go","test"],"state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events":
 			if err := json.NewDecoder(r.Body).Decode(&eventBody); err != nil {
 				t.Fatal(err)
 			}
-			_, _ = w.Write([]byte(`{"event":{"runID":"run_123","seq":1,"type":"lease.created","createdAt":"2026-05-02T00:00:01Z"}}`))
+			_, _ = w.Write([]byte(`{"event":{"runID":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","seq":1,"type":"lease.created","createdAt":"2026-05-02T00:00:01Z"}}`))
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
@@ -817,9 +774,9 @@ func TestRunRecorderRetriesTransientCreateFailureAfterLease(t *testing.T) {
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
-	}, []string{"go", "test"}, "", &stderr, false)
+	}, []string{"go", "test"}, "", &stderr, false, admissionTestRunID)
 	rec.Event("leasing.started", "leasing", "")
-	rec.AttachLease("cbx_abcdef123456", "blue-lobster", Config{
+	rec.AttachLease(t.Context(), "cbx_abcdef123456", "blue-lobster", Config{
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
@@ -831,7 +788,7 @@ func TestRunRecorderRetriesTransientCreateFailureAfterLease(t *testing.T) {
 	if got := createBodies[0]["leaseID"]; got != "" {
 		t.Fatalf("first create leaseID=%#v want empty", got)
 	}
-	if got := createBodies[1]["leaseID"]; got != "cbx_abcdef123456" {
+	if got := createBodies[1]["leaseID"]; got != "" {
 		t.Fatalf("second create leaseID=%#v", got)
 	}
 	rec.waitForEvents(time.Second)
@@ -840,8 +797,8 @@ func TestRunRecorderRetriesTransientCreateFailureAfterLease(t *testing.T) {
 	}
 	text := stderr.String()
 	for _, want := range []string{
-		"warning: run history create failed before lease; will retry after lease is available:",
-		"recording run run_123",
+		"run admission attempt " + admissionTestRunID,
+		"recording run run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("stderr missing %q:\n%s", want, text)
@@ -856,7 +813,7 @@ func TestRunRecorderMarksHistoryUnavailableAfterPersistentCreateFailure(t *testi
 	var stderr bytes.Buffer
 	var createBodies []map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.URL.Path != "/v1/runs" {
+		if r.Method != http.MethodPut || r.URL.Path != "/v1/runs/"+admissionTestRunID {
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
 		var body map[string]any
@@ -877,23 +834,23 @@ func TestRunRecorderMarksHistoryUnavailableAfterPersistentCreateFailure(t *testi
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
-	}, []string{"go", "test"}, "", &stderr, false)
-	rec.AttachLease("cbx_abcdef123456", "blue-lobster", Config{
+	}, []string{"go", "test"}, "", &stderr, false, admissionTestRunID)
+	rec.AttachLease(t.Context(), "cbx_abcdef123456", "blue-lobster", Config{
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
 	})
 
-	if len(createBodies) != 2 {
-		t.Fatalf("create requests=%d want 2", len(createBodies))
+	if len(createBodies) != 4 {
+		t.Fatalf("create requests=%d want 4", len(createBodies))
 	}
 	if rec.runID != "" || !rec.historyUnavailable {
 		t.Fatalf("recorder runID=%q historyUnavailable=%v", rec.runID, rec.historyUnavailable)
 	}
 	text := stderr.String()
 	for _, want := range []string{
-		"warning: run history create failed before lease; will retry after lease is available:",
-		"warning: run history create failed after lease; run history unavailable, use lease-based recovery commands:",
+		"run admission attempt " + admissionTestRunID,
+		"failed before lease:",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("stderr missing %q:\n%s", want, text)
@@ -910,22 +867,22 @@ func TestRunRecorderRetriesFailedLeaseCreateOnReplacementLease(t *testing.T) {
 	var eventBody map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/runs/"+admissionTestRunID:
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatal(err)
 			}
 			createBodies = append(createBodies, body)
-			if len(createBodies) < 3 {
+			if len(createBodies) < 5 {
 				http.Error(w, `{"error":"temporary_unavailable"}`, http.StatusServiceUnavailable)
 				return
 			}
-			_, _ = w.Write([]byte(`{"run":{"id":"run_123","leaseID":"cbx_replacement123","owner":"alice@example.com","org":"example-org","provider":"aws","class":"standard","serverType":"t3.small","command":["go","test"],"state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`))
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_123/events":
+			_, _ = w.Write([]byte(`{"run":{"id":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","leaseID":"cbx_replacement123","owner":"alice@example.com","org":"example-org","provider":"aws","class":"standard","serverType":"t3.small","command":["go","test"],"state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events":
 			if err := json.NewDecoder(r.Body).Decode(&eventBody); err != nil {
 				t.Fatal(err)
 			}
-			_, _ = w.Write([]byte(`{"event":{"runID":"run_123","seq":1,"type":"lease.created","createdAt":"2026-05-02T00:00:01Z"}}`))
+			_, _ = w.Write([]byte(`{"event":{"runID":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","seq":1,"type":"lease.created","createdAt":"2026-05-02T00:00:01Z"}}`))
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
@@ -937,8 +894,8 @@ func TestRunRecorderRetriesFailedLeaseCreateOnReplacementLease(t *testing.T) {
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
-	}, []string{"go", "test"}, "", &stderr, false)
-	rec.AttachLease("cbx_initial123456", "blue-lobster", Config{
+	}, []string{"go", "test"}, "", &stderr, false, admissionTestRunID)
+	rec.AttachLease(t.Context(), "cbx_initial123456", "blue-lobster", Config{
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
@@ -947,33 +904,33 @@ func TestRunRecorderRetriesFailedLeaseCreateOnReplacementLease(t *testing.T) {
 		t.Fatalf("after failed attach runID=%q createPending=%v historyUnavailable=%v", rec.runID, rec.createPending, rec.historyUnavailable)
 	}
 
-	rec.AttachLease("cbx_replacement123", "green-lobster", Config{
+	rec.AttachLease(t.Context(), "cbx_replacement123", "green-lobster", Config{
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
 	})
 
-	if len(createBodies) != 3 {
-		t.Fatalf("create requests=%d want 3", len(createBodies))
+	if len(createBodies) != 5 {
+		t.Fatalf("create requests=%d want 5", len(createBodies))
 	}
-	if got := createBodies[1]["leaseID"]; got != "cbx_initial123456" {
+	if got := createBodies[2]["leaseID"]; got != "" {
 		t.Fatalf("first lease-time create leaseID=%#v", got)
 	}
-	if got := createBodies[2]["leaseID"]; got != "cbx_replacement123" {
+	if got := createBodies[4]["leaseID"]; got != "" {
 		t.Fatalf("replacement create leaseID=%#v", got)
 	}
 	rec.waitForEvents(time.Second)
 	if got := eventBody["leaseID"]; got != "cbx_replacement123" {
 		t.Fatalf("lease.created body=%#v", eventBody)
 	}
-	if rec.runID != "run_123" || rec.createPending || rec.historyUnavailable {
+	if rec.runID != "run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" || rec.createPending || rec.historyUnavailable {
 		t.Fatalf("recovered recorder runID=%q createPending=%v historyUnavailable=%v", rec.runID, rec.createPending, rec.historyUnavailable)
 	}
 	text := stderr.String()
 	for _, want := range []string{
-		"warning: run history create failed before lease; will retry after lease is available:",
-		"warning: run history create failed after lease; run history unavailable, use lease-based recovery commands:",
-		"recording run run_123",
+		"run admission attempt " + admissionTestRunID,
+		"failed before lease:",
+		"recording run run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("stderr missing %q:\n%s", want, text)
@@ -1002,7 +959,7 @@ func TestRunRecorderAttachLeaseUsesResolvedCoordinator(t *testing.T) {
 		Token:   "admin-token",
 		Client:  server.Client(),
 	})
-	rec.AttachLease("cbx_abcdef123456", "blue-lobster", Config{
+	rec.AttachLease(t.Context(), "cbx_abcdef123456", "blue-lobster", Config{
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
@@ -1019,14 +976,14 @@ func TestRunRecorderSuppressesMissingEventEndpoint(t *testing.T) {
 	var finishRequests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
-			_, _ = w.Write([]byte(`{"run":{"id":"run_123","leaseID":"cbx_abcdef123456","slug":"blue-lobster","owner":"peter@example.com","org":"openclaw","provider":"aws","class":"standard","serverType":"t3.small","command":["pnpm","test"],"state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`))
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_123/events":
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/runs/"+admissionTestRunID:
+			_, _ = w.Write([]byte(`{"run":{"id":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","leaseID":"cbx_abcdef123456","slug":"blue-lobster","owner":"peter@example.com","org":"openclaw","provider":"aws","class":"standard","serverType":"t3.small","command":["pnpm","test"],"state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events":
 			eventRequests++
 			http.Error(w, `{"error":"not_found"}`, http.StatusNotFound)
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_123/finish":
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/finish":
 			finishRequests++
-			_, _ = w.Write([]byte(`{"run":{"id":"run_123","leaseID":"cbx_abcdef123456","slug":"blue-lobster","owner":"peter@example.com","org":"openclaw","provider":"aws","class":"standard","serverType":"t3.small","command":["pnpm","test"],"state":"succeeded","phase":"completed","exitCode":0,"logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z","finishedAt":"2026-05-02T00:00:01Z"}}`))
+			_, _ = w.Write([]byte(`{"run":{"id":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","leaseID":"cbx_abcdef123456","slug":"blue-lobster","owner":"peter@example.com","org":"openclaw","provider":"aws","class":"standard","serverType":"t3.small","command":["pnpm","test"],"state":"succeeded","phase":"completed","exitCode":0,"logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z","finishedAt":"2026-05-02T00:00:01Z"}}`))
 		default:
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
@@ -1038,11 +995,11 @@ func TestRunRecorderSuppressesMissingEventEndpoint(t *testing.T) {
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
-	}, []string{"pnpm", "test"}, "", &stderr, true)
+	}, []string{"pnpm", "test"}, "", &stderr, true, admissionTestRunID)
 	if rec.runID != "" || rec.finished {
 		t.Fatalf("existing-lease run must defer its handle until lease resolution: %#v", rec)
 	}
-	err := rec.AttachLease("cbx_abcdef123456", "blue-lobster", Config{
+	err := rec.AttachLease(t.Context(), "cbx_abcdef123456", "blue-lobster", Config{
 		Provider:   "aws",
 		Class:      "standard",
 		ServerType: "t3.small",
@@ -1066,7 +1023,7 @@ func TestRunRecorderSuppressesMissingEventEndpoint(t *testing.T) {
 	if finishRequests != 1 {
 		t.Fatalf("finish requests=%d, want 1", finishRequests)
 	}
-	if text := stderr.String(); strings.Contains(text, "warning:") || !strings.Contains(text, "recording run run_123") {
+	if text := stderr.String(); strings.Contains(text, "warning:") || !strings.Contains(text, "recording run run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
 		t.Fatalf("stderr=%q", text)
 	}
 }

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -539,7 +539,7 @@ func TestRunCommandInjectsReservedMetadataAcrossSSHCommandModes(t *testing.T) {
 			if !strings.Contains(logText, "CRABBOX_SLUG=''") {
 				t.Fatalf("empty slug metadata missing from SSH command:\n%s", logText)
 			}
-			runIDMatch := regexp.MustCompile(`CRABBOX_RUN_ID='(run_[a-f0-9]{12})'`).FindStringSubmatch(logText)
+			runIDMatch := regexp.MustCompile(`CRABBOX_RUN_ID='(run_[a-f0-9]{32})'`).FindStringSubmatch(logText)
 			if len(runIDMatch) != 2 {
 				t.Fatalf("CLI-generated run metadata missing from SSH command:\n%s", logText)
 			}
@@ -2001,7 +2001,7 @@ func TestRunCommandWritesFreshLocalContainerLeaseOutputAfterClaim(t *testing.T) 
 	if session.Provider != "local-container" || session.LeaseID != localContainerRunSessionTestLeaseID || session.Slug != "session-slug" || session.Reused || !session.Kept {
 		t.Fatalf("session=%#v", session)
 	}
-	if !regexp.MustCompile(`^run_[a-f0-9]{12}$`).MatchString(session.RunID) {
+	if !regexp.MustCompile(`^run_[a-f0-9]{32}$`).MatchString(session.RunID) {
 		t.Fatalf("runId=%q", session.RunID)
 	}
 	if want := "crabbox stop --provider local-container --target linux --id " + localContainerRunSessionTestLeaseID; session.CleanupCommand != want {
@@ -2083,7 +2083,6 @@ func TestRunCommandWritesBrokeredReusedAWSLeaseOutputBeforeCommand(t *testing.T)
 
 			const (
 				leaseID = "cbx_aws_session"
-				runID   = "run_aws_session"
 				slug    = "aws-session"
 			)
 			sessionPath := filepath.Join(dir, "session.json")
@@ -2117,33 +2116,39 @@ exit 0
 				IdleTimeoutSeconds: 1800,
 			}
 			var (
+				admittedRunID  atomic.Value
 				mu             sync.Mutex
 				createRunCalls atomic.Int32
 				storedReceipt  terminalRunReceipt
 			)
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				runID := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/v1/runs/"), "/", 2)[0]
 				switch {
 				case r.Method == http.MethodGet && r.URL.Path == "/v1/control":
 					http.NotFound(w, r)
 				case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/"+leaseID:
 					_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
-				case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+				case r.Method == http.MethodPut && r.URL.Path == "/v1/runs/"+runID:
 					createRunCalls.Add(1)
 					if tc.createRunFail {
 						http.Error(w, "run store unavailable", http.StatusServiceUnavailable)
 						return
 					}
-					var body map[string]any
+					var body struct {
+						LeaseID string   `json:"leaseID"`
+						Command []string `json:"command"`
+					}
 					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 						http.Error(w, err.Error(), http.StatusBadRequest)
 						return
 					}
-					if body["leaseID"] != leaseID {
+					if body.LeaseID != leaseID {
 						http.Error(w, "wrong lease", http.StatusBadRequest)
 						return
 					}
+					admittedRunID.Store(runID)
 					_ = json.NewEncoder(w).Encode(map[string]any{"run": CoordinatorRun{
-						ID: runID, LeaseID: leaseID, Provider: "aws", State: "running",
+						ID: runID, LeaseID: leaseID, Provider: "aws", State: "running", Phase: "starting", Command: body.Command,
 						StartedAt: "2026-08-24T00:00:00Z",
 					}})
 				case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/"+runID+"/events":
@@ -2194,12 +2199,16 @@ exit 0
 				"--lease-output", sessionPath,
 				"--", "session-command-sentinel",
 			})
-			if calls := createRunCalls.Load(); calls != 1 {
-				t.Fatalf("create run calls=%d, want 1; error=%v\nstdout=%s\nstderr=%s", calls, err, stdout.String(), stderr.String())
+			wantCalls := int32(1)
+			if tc.createRunFail {
+				wantCalls = 2
+			}
+			if calls := createRunCalls.Load(); calls != wantCalls {
+				t.Fatalf("create run calls=%d, wrong bounded count; error=%v\nstdout=%s\nstderr=%s", calls, err, stdout.String(), stderr.String())
 			}
 			if tc.createRunFail {
 				var exitErr ExitError
-				if !AsExitError(err, &exitErr) || exitErr.Code != 7 || !strings.Contains(exitErr.Message, "coordinator run handle") {
+				if !AsExitError(err, &exitErr) || exitErr.Code != 7 || !strings.Contains(exitErr.Message, "unavailable before command") {
 					t.Fatalf("error=%v, want exit 7 coordinator handle failure\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
 				}
 				assertRunSessionValidationStoppedBeforeWork(t, sessionPath, commandMarker, filepath.Join(dir, "unused-sync-marker"))
@@ -2215,7 +2224,8 @@ exit 0
 			if session.Provider != "aws" || session.LeaseID != leaseID || session.Slug != slug || !session.Reused || !session.Kept {
 				t.Fatalf("session=%#v", session)
 			}
-			if session.RunID != runID {
+			runID, _ := admittedRunID.Load().(string)
+			if session.RunID != runID || len(runID) != 36 {
 				t.Fatalf("runId=%q want %q", session.RunID, runID)
 			}
 			if want := "crabbox stop --provider aws --target linux --id " + leaseID; session.CleanupCommand != want {
@@ -2706,7 +2716,7 @@ func TestRunCommandInjectsReservedMetadataIntoDelegatedRequest(t *testing.T) {
 	if env[runEnvLeaseID] != "cbx_delegated" || env[runEnvSlug] != "" {
 		t.Fatalf("delegated lease metadata=%#v", env)
 	}
-	if !regexp.MustCompile(`^run_[a-f0-9]{12}$`).MatchString(env[runEnvRunID]) {
+	if !regexp.MustCompile(`^run_[a-f0-9]{32}$`).MatchString(env[runEnvRunID]) {
 		t.Fatalf("delegated run ID=%q", env[runEnvRunID])
 	}
 	if runModuleRuntimeTestRequests[0].RunID != env[runEnvRunID] {
@@ -3925,7 +3935,6 @@ func TestRunCommandReceiptPersistenceFailureFinishesWithRefreshedReceipt(t *test
 
 	const (
 		leaseID = "cbx_receipt_write_failure"
-		runID   = "run_receipt_write_failure"
 	)
 	lease := CoordinatorLease{
 		ID:         leaseID,
@@ -3951,6 +3960,7 @@ func TestRunCommandReceiptPersistenceFailureFinishesWithRefreshedReceipt(t *test
 		finishReceipt terminalRunReceipt
 	)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		runID := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/v1/runs/"), "/", 2)[0]
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/control":
 			http.NotFound(w, r)
@@ -3958,7 +3968,15 @@ func TestRunCommandReceiptPersistenceFailureFinishesWithRefreshedReceipt(t *test
 			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/"+leaseID+"/heartbeat":
 			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/runs/"+runID:
+			var body struct {
+				Command []string `json:"command"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
 			if err := os.Remove(keyPath); err != nil {
 				t.Errorf("remove original signer: %v", err)
 			}
@@ -3969,7 +3987,7 @@ func TestRunCommandReceiptPersistenceFailureFinishesWithRefreshedReceipt(t *test
 				t.Errorf("replace receipt path with directory: %v", err)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"run": CoordinatorRun{
-				ID: runID, LeaseID: leaseID, Provider: lease.Provider, State: "running",
+				ID: runID, LeaseID: leaseID, Provider: lease.Provider, State: "running", Phase: "starting", Command: body.Command,
 				StartedAt: "2026-09-05T00:00:00Z",
 			}})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/"+runID+"/events":
@@ -4242,7 +4260,6 @@ func runCommandSyncOnlyFinalization(t *testing.T, missingEvents bool) {
 
 	const (
 		leaseID = "cbx_sync_only"
-		runID   = "run_sync_only"
 	)
 	lease := CoordinatorLease{
 		ID:         leaseID,
@@ -4274,6 +4291,7 @@ func runCommandSyncOnlyFinalization(t *testing.T, missingEvents bool) {
 		events []string
 	)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		runID := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/v1/runs/"), "/", 2)[0]
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/control":
 			http.NotFound(w, r)
@@ -4282,9 +4300,17 @@ func runCommandSyncOnlyFinalization(t *testing.T, missingEvents bool) {
 			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/"+leaseID+"/heartbeat":
 			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/runs/"+runID:
+			var body struct {
+				Command []string `json:"command"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
 			_ = json.NewEncoder(w).Encode(map[string]any{"run": CoordinatorRun{
-				ID: runID, LeaseID: leaseID, Provider: lease.Provider, State: "running",
+				ID: runID, LeaseID: leaseID, Provider: lease.Provider, State: "running", Phase: "starting", Command: body.Command,
 				StartedAt: "2026-09-04T00:00:00Z",
 			}})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/"+runID+"/events":
@@ -4392,7 +4418,6 @@ func TestRunCommandTerminalReceiptMarksCoordinatorFinishFailureLocally(t *testin
 
 	const (
 		leaseID = "cbx_finish_failure"
-		runID   = "run_finish_failure"
 	)
 	lease := CoordinatorLease{
 		ID:         leaseID,
@@ -4417,6 +4442,7 @@ func TestRunCommandTerminalReceiptMarksCoordinatorFinishFailureLocally(t *testin
 		unexpectedCalls     []string
 	)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		runID := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/v1/runs/"), "/", 2)[0]
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/control":
 			http.NotFound(w, r)
@@ -4424,9 +4450,17 @@ func TestRunCommandTerminalReceiptMarksCoordinatorFinishFailureLocally(t *testin
 			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/"+leaseID+"/heartbeat":
 			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/runs/"+runID:
+			var body struct {
+				Command []string `json:"command"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
 			_ = json.NewEncoder(w).Encode(map[string]any{"run": CoordinatorRun{
-				ID: runID, LeaseID: leaseID, Provider: lease.Provider, State: "running",
+				ID: runID, LeaseID: leaseID, Provider: lease.Provider, State: "running", Phase: "starting", Command: body.Command,
 				StartedAt: "2026-08-24T00:00:00Z",
 			}})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/"+runID+"/events":
@@ -5016,7 +5050,7 @@ exit 0
 	if readErr != nil {
 		t.Fatal(readErr)
 	}
-	if !strings.Contains(string(logData), "rm -f --") || !regexp.MustCompile(`\.crabbox/env/run_[a-f0-9]{12}\.env`).Match(logData) {
+	if !strings.Contains(string(logData), "rm -f --") || !regexp.MustCompile(`\.crabbox/env/run_[a-f0-9]{32}\.env`).Match(logData) {
 		t.Fatalf("cleanup command missing from ssh log:\n%s", logData)
 	}
 }

--- a/internal/cli/sync_git_overlay_test.go
+++ b/internal/cli/sync_git_overlay_test.go
@@ -4052,8 +4052,8 @@ func TestRunMissingOriginReplacementLeaseStaysPlainManifest(t *testing.T) {
 		receipt  terminalRunReceipt
 		mu       sync.Mutex
 	)
-	const runID = "run_missing_origin_replacement"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		runID := strings.SplitN(strings.TrimPrefix(request.URL.Path, "/v1/runs/"), "/", 2)[0]
 		lease := func(id, state string) CoordinatorLease {
 			return CoordinatorLease{
 				ID: id, Provider: providerName, TargetOS: targetLinux, State: state,
@@ -4061,9 +4061,16 @@ func TestRunMissingOriginReplacementLeaseStaysPlainManifest(t *testing.T) {
 			}
 		}
 		switch {
-		case request.Method == http.MethodPost && request.URL.Path == "/v1/runs":
+		case request.Method == http.MethodPut && request.URL.Path == "/v1/runs/"+runID:
+			var body struct {
+				Command []string `json:"command"`
+			}
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"run": CoordinatorRun{
-				ID: runID, Provider: providerName, State: "running", StartedAt: "2026-08-29T00:00:00Z",
+				ID: runID, Provider: providerName, State: "running", Phase: "starting", Command: body.Command, StartedAt: "2026-08-29T00:00:00Z",
 			}})
 		case request.Method == http.MethodPost && request.URL.Path == "/v1/runs/"+runID+"/events":
 			_ = json.NewEncoder(w).Encode(map[string]any{"event": CoordinatorRunEvent{

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -14643,7 +14643,10 @@ export class FleetCoordinator {
       .toSorted((a, b) => b.createdAt.localeCompare(a.createdAt));
   }
 
-  private async createRun(request: Request): Promise<Response> {
+  private async createRun(request: Request, requestedRunID?: string): Promise<Response> {
+    if (requestedRunID !== undefined && !/^run_[a-f0-9]{32}$/.test(requestedRunID)) {
+      return json({ error: "invalid_run_id" }, { status: 400 });
+    }
     const owner = requestOwner(request);
     const org = requestOrg(request, this.env);
     const input = await readJson<RunCreateRequest>(request);
@@ -14651,48 +14654,89 @@ export class FleetCoordinator {
     if (leaseID && !validLeaseID(leaseID)) {
       return json({ error: "invalid_lease_id" }, { status: 400 });
     }
-    const lease = leaseID ? await this.getLease(leaseID) : undefined;
-    if (lease && !this.leaseVisibleToRequest(lease, request, false)) {
-      return json({ error: "not_found" }, { status: 404 });
-    }
-    const now = new Date().toISOString();
-    const run: RunRecord = {
-      id: newRunID(),
-      leaseID,
-      leaseIDs: [],
-      owner,
-      org,
-      leaseOwners: [],
-      provider: lease?.provider ?? input.provider ?? "hetzner",
-      target: lease?.target ?? input.target ?? "linux",
-      class: lease?.class ?? input.class ?? "",
-      serverType: lease?.serverType ?? input.serverType ?? "",
-      command: Array.isArray(input.command) ? input.command.map(String) : [],
-      state: "running",
-      phase: "starting",
-      logBytes: 0,
-      logTruncated: false,
-      startedAt: now,
-      lastEventAt: now,
-      eventCount: 0,
-    };
-    if (lease) {
-      this.setRunLeaseAttribution(run, lease);
-    }
-    const windowsMode = lease?.windowsMode ?? input.windowsMode;
-    if (windowsMode) {
-      run.windowsMode = windowsMode;
-    }
-    if (lease?.slug) {
-      run.slug = lease.slug;
-    }
+    const command = Array.isArray(input.command) ? input.command.map(String) : [];
     const label = sanitizeRunLabel(input.label);
-    if (label) {
-      run.label = label;
+    // Bind the original request, not mutable lease attribution or provider-resolved fields.
+    const createRequestSHA256 = requestedRunID
+      ? await sha256Hex(
+          JSON.stringify([
+            "run-create-v1",
+            leaseID,
+            input.provider ?? "hetzner",
+            input.target ?? "linux",
+            input.windowsMode ?? "",
+            input.class ?? "",
+            input.serverType ?? "",
+            command,
+            label ?? "",
+          ]),
+        )
+      : undefined;
+    const id = requestedRunID ?? newRunID();
+    const now = new Date().toISOString();
+    const committed = await this.state.storage.transaction(async (storage) => {
+      const existing = await storage.get<RunRecord>(runKey(id));
+      if (existing) {
+        if (existing.owner !== owner || existing.org !== org) return { kind: "missing" as const };
+        if (!createRequestSHA256 || existing.createRequestSHA256 !== createRequestSHA256) {
+          return { kind: "conflict" as const };
+        }
+        return { kind: "replay" as const, run: existing };
+      }
+      const lease = leaseID ? await storage.get<LeaseRecord>(leaseKey(leaseID)) : undefined;
+      if (lease && !this.leaseVisibleToRequest(lease, request, false)) {
+        return { kind: "missing" as const };
+      }
+      const run: RunRecord = {
+        id,
+        leaseID,
+        leaseIDs: [],
+        owner,
+        org,
+        leaseOwners: [],
+        provider: lease?.provider ?? input.provider ?? "hetzner",
+        target: lease?.target ?? input.target ?? "linux",
+        class: lease?.class ?? input.class ?? "",
+        serverType: lease?.serverType ?? input.serverType ?? "",
+        command,
+        state: "running",
+        phase: "starting",
+        logBytes: 0,
+        logTruncated: false,
+        startedAt: now,
+        lastEventAt: now,
+        eventCount: 1,
+      };
+      if (lease) {
+        this.setRunLeaseAttribution(run, lease);
+      }
+      const windowsMode = lease?.windowsMode ?? input.windowsMode;
+      if (windowsMode) {
+        run.windowsMode = windowsMode;
+      }
+      if (lease?.slug) {
+        run.slug = lease.slug;
+      }
+      if (label) {
+        run.label = label;
+      }
+      if (createRequestSHA256) run.createRequestSHA256 = createRequestSHA256;
+      const event = boundedRunEvent(id, 1, now, { type: "run.started", phase: "starting" });
+      await storage.put(runKey(id), run);
+      await storage.put(runEventKey(id, 1), event);
+      return { kind: "created" as const, run, event };
+    });
+    if (committed.kind === "missing") return notFound();
+    if (committed.kind === "conflict") {
+      return json({ error: "run_id_conflict" }, { status: 409 });
     }
-    await this.putRun(run);
-    await this.appendRunEventRecord(run, { type: "run.started", phase: "starting" });
-    return json({ run: publicRunRecord(run) }, { status: 201 });
+    if (committed.kind === "created") await this.broadcastRunEvent(committed.run, committed.event);
+    return json(
+      { run: publicRunRecord(committed.run) },
+      {
+        status: committed.kind === "created" ? 201 : 200,
+      },
+    );
   }
 
   private async createArtifactUploads(request: Request): Promise<Response> {
@@ -14724,6 +14768,9 @@ export class FleetCoordinator {
 
   private async runRoute(request: Request, runID: string, action?: string): Promise<Response> {
     const method = request.method.toUpperCase();
+    if (method === "PUT" && action === undefined) {
+      return this.createRun(request, runID);
+    }
     if (method === "GET" && action === undefined) {
       const run = await this.getRun(runID);
       const lease = run ? await this.ensureRunLeaseAttribution(run) : undefined;

--- a/worker/src/org-records.ts
+++ b/worker/src/org-records.ts
@@ -87,6 +87,7 @@ export function publicRunRecord(record: RunRecord): RunRecord {
   delete publicRecord.terminalReceipt;
   delete publicRecord.terminalFinishSHA256;
   delete publicRecord.terminalLogPrefix;
+  delete publicRecord.createRequestSHA256;
   if (!record.leaseOwners) {
     return publicRecord;
   }

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -1012,6 +1012,7 @@ export interface RunRecord {
   terminalReceipt?: TerminalRunReceipt;
   terminalFinishSHA256?: string;
   terminalLogPrefix?: string;
+  createRequestSHA256?: string;
 }
 
 export interface TerminalRunReceipt {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -42265,7 +42265,7 @@ describe("fleet run history", () => {
     const body = { runID: `run_${"a".repeat(32)}`, provider: "aws", command: ["echo", "hello"] };
     const create = () => fleet.fetch(request("PUT", `/v1/runs/${body.runID}`, { headers, body }));
     const [first, second] = await Promise.all([create(), create()]);
-    expect([first.status, second.status].sort()).toEqual([200, 201]);
+    expect([first.status, second.status].toSorted()).toEqual([200, 201]);
     const { run } = (await first.json()) as { run: RunRecord };
     expect(run.id).toBe(body.runID);
     expect(run).not.toHaveProperty("createRequestSHA256");

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -42258,6 +42258,123 @@ describe("fleet run history", () => {
     expect(storage.value("run:run_still_running")).toBeDefined();
   });
 
+  it("recovers a caller-known run admission without restarting its history", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" };
+    const body = { runID: `run_${"a".repeat(32)}`, provider: "aws", command: ["echo", "hello"] };
+    const create = () => fleet.fetch(request("PUT", `/v1/runs/${body.runID}`, { headers, body }));
+    const [first, second] = await Promise.all([create(), create()]);
+    expect([first.status, second.status].sort()).toEqual([200, 201]);
+    const { run } = (await first.json()) as { run: RunRecord };
+    expect(run.id).toBe(body.runID);
+    expect(run).not.toHaveProperty("createRequestSHA256");
+    const replay = await create();
+    expect(replay.status).toBe(200);
+    expect(await replay.json()).toEqual({ run });
+    const finish = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/finish`, {
+        headers,
+        body: { exitCode: 0, log: "hello" },
+      }),
+    );
+    expect(finish.status).toBe(200);
+    const terminal = await create();
+    expect(terminal.status).toBe(200);
+    expect(await terminal.json()).toEqual(await finish.json());
+    const events = await fleet.fetch(request("GET", `/v1/runs/${run.id}/events`, { headers }));
+    expect(
+      ((await events.json()) as { events: RunEventRecord[] }).events.map((event) => event.type),
+    ).toEqual(["run.started", "command.finished"]);
+  });
+
+  it("keeps run admission bound to its original caller and request after lease attribution", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" };
+    const body = { runID: `run_${"b".repeat(32)}`, provider: "aws", command: ["true"] };
+    const first = await fleet.fetch(request("PUT", `/v1/runs/${body.runID}`, { headers, body }));
+    expect(first.status).toBe(201);
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        owner: "alice@example.com",
+        org: "example-org",
+        provider: "aws",
+      }),
+    );
+    const attached = await fleet.fetch(
+      request("POST", `/v1/runs/${body.runID}/events`, {
+        headers,
+        body: { type: "lease.created", leaseID: "cbx_000000000001", provider: "aws" },
+      }),
+    );
+    expect(attached.status).toBe(201);
+    const replay = await fleet.fetch(request("PUT", `/v1/runs/${body.runID}`, { headers, body }));
+    expect(replay.status).toBe(200);
+    expect(((await replay.json()) as { run: RunRecord }).run.leaseID).toBe("cbx_000000000001");
+    const changed = await fleet.fetch(
+      request("PUT", `/v1/runs/${body.runID}`, {
+        headers,
+        body: { ...body, leaseID: "cbx_000000000001" },
+      }),
+    );
+    expect(changed.status).toBe(409);
+    const otherCaller = await fleet.fetch(
+      request("PUT", `/v1/runs/${body.runID}`, {
+        headers: { ...headers, "x-crabbox-owner": "bob@example.com" },
+        body,
+      }),
+    );
+    expect(otherCaller.status).toBe(404);
+    const otherOrg = await fleet.fetch(
+      request("PUT", `/v1/runs/${body.runID}`, {
+        headers: { ...headers, "x-crabbox-org": "other-org" },
+        body,
+      }),
+    );
+    expect(otherOrg.status).toBe(404);
+    const changedCommand = await fleet.fetch(
+      request("PUT", `/v1/runs/${body.runID}`, {
+        headers,
+        body: { ...body, command: ["echo", "changed"] },
+      }),
+    );
+    expect(changedCommand.status).toBe(409);
+    const events = await fleet.fetch(request("GET", `/v1/runs/${body.runID}/events`, { headers }));
+    expect(
+      ((await events.json()) as { events: RunEventRecord[] }).events.map((event) => event.type),
+    ).toEqual(["run.started", "lease.created"]);
+  });
+
+  it.each(["POST", "PUT"])(
+    "commits %s run admission and its first event together",
+    async (method) => {
+      const storage = new MemoryStorage();
+      const fleet = testFleet(storage);
+      const body = { runID: `run_${"c".repeat(32)}`, command: ["true"] };
+      const path = method === "POST" ? "/v1/runs" : `/v1/runs/${body.runID}`;
+      storage.beforePut = async (key) => {
+        if (key.startsWith("runevent:")) throw new Error("event storage unavailable");
+      };
+      expect((await fleet.fetch(request(method, path, { body }))).status).toBe(500);
+      expect((await storage.list({ prefix: "run:" })).size).toBe(0);
+      expect((await storage.list({ prefix: "runevent:" })).size).toBe(0);
+      storage.beforePut = undefined;
+      expect((await fleet.fetch(request(method, path, { body }))).status).toBe(201);
+    },
+  );
+
+  it.each(["run_short", `run_${"a".repeat(33)}`, "42"])(
+    "rejects invalid requested run identity %j",
+    async (runID) => {
+      const fleet = testFleet(new MemoryStorage());
+      const response = await fleet.fetch(request("PUT", `/v1/runs/${runID}`, { body: {} }));
+      expect(response.status).toBe(400);
+    },
+  );
+
   it("creates early run sessions and appends durable events", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an ordinary command could lose its coordinator run identity when admission committed but the response was lost. The CLI could only fail without a handle, and later history could not reliably identify the exact attempt.

Related: https://github.com/openclaw/crabbox/issues/1962.

## Why This Change Was Made

The CLI now chooses a cryptographically random run ID before admission and uses a dedicated PUT route that supports recovery of the exact original request. The coordinator binds that request to its initiating owner and organization and commits the run and first event together. Recovery returns the existing record without appending another start event. A separate acknowledged event retains the existing lease-attribution and replacement behavior.

The CLI accepts only a matching, still-starting record within the live invocation. Admission recovery stays within the existing ten-second request budget and never retries remote execution. Cancellation, deterministic refusals, mismatched replies, terminal records, and coordinator-origin changes fail closed. Sync-only runs retain optional history.

## User Impact

Lost admission responses can be recovered without creating another run or replaying the command. The attempt ID is printed before admission for correlation. Current CLI builds require the new coordinator route; old coordinators reject it without anonymous creation. Existing clients retain POST support, and legacy run IDs remain readable. No configuration option, schema-version bump, dependency, provider policy, or retention change is introduced.

This does not promise ten-second cloud startup or remove the lifecycle queue. Existing historical records are not rewritten.

## Evidence

- Original-main regressions demonstrated the absent caller-known route, partial run persistence when initial-event storage failed, terminal/advanced record admission, and lost cancellation.
- Worker after refreshing over current main: 2,872 passed, three existing skips; Cloudflare and Node types, lint, formatting, deployment dry run, and docs build passed.
- Controlled client proof drops a committed admission response, then verifies identical identity/body recovery, one record, cancellation, unsupported coordinators, and a shared ten-second budget.
- Focused Go race checks and all six affected CLI integrations passed. Independent formal review found no actionable P0–P2 findings.
- Full local Go race run: 91 packages passed; CLI hit its unchanged twenty-minute package cap and reported five stale route/ID fixtures. All five were corrected and passed a focused race rerun. This is not a passing full local suite.
- Windows amd64 CLI test binary cross-compilation and `go vet ./...` passed.
- Live AWS on the reviewed candidate: ordinary Linux warmup passed (128.812s), `uname -s` returned one `Linux` line (12.685s for the run), and the same 128-bit ID matched acknowledgment, lease handle, verified signed receipt, and successful terminal history. There was one initial run event. Canonical Stop confirmed released/provider cleanup complete and removed owned keys. No workload was replayed.
- The first private proof harness read `runID` instead of the documented `runId`; read-only receipt/events/history checks recovered the proof without rerunning the command. The original harness failure is retained.
- Exact-head CI passed on `bdafeade5e76a73990709f574a45ebc9a0b32683`, including the full hosted Go race gate, coverage, all Go modules, Worker builds/tests, Windows checks, connector smokes, and the release check. The failed local full run remains documented above.
