### PR TITLE
fix: keep capped output writes behind private storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Recover lost run-admission responses using a caller-known identity and an atomic initial history record, preserving authenticated request binding and refusing remote command replay. Current clients require a coordinator supporting the new admission route. [PR 1970](https://github.com/openclaw/crabbox/pull/1970), [Issue 1962](https://github.com/openclaw/crabbox/issues/1962). Thanks @steipete.
 - Add bounded AWS provisioning transport diagnostics for credential preparation, signing and SDK request time, including retry-loop signing counts, without changing retry behavior. [PR 1968](https://github.com/openclaw/crabbox/pull/1968). Thanks @steipete.
 - Islo: report failed stdout/stderr delivery instead of silently succeeding after losing command output; preserve remote exit codes when stream decoding and delivery finish successfully. [PR 1969](https://github.com/openclaw/crabbox/pull/1969).
-- Enforce controller and coordinator token-command output limits consistently during pipe copying, preserving the existing overflow errors and command deadlines.
+- Enforce controller and coordinator token-command output limits consistently during pipe copying, preserving the existing overflow errors and command deadlines. [PR 1971](https://github.com/openclaw/crabbox/pull/1971).
 
 ## 0.52.0 - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Recover lost run-admission responses using a caller-known identity and an atomic initial history record, preserving authenticated request binding and refusing remote command replay. Current clients require a coordinator supporting the new admission route. [PR 1970](https://github.com/openclaw/crabbox/pull/1970), [Issue 1962](https://github.com/openclaw/crabbox/issues/1962). Thanks @steipete.
 - Add bounded AWS provisioning transport diagnostics for credential preparation, signing and SDK request time, including retry-loop signing counts, without changing retry behavior. [PR 1968](https://github.com/openclaw/crabbox/pull/1968). Thanks @steipete.
 - Islo: report failed stdout/stderr delivery instead of silently succeeding after losing command output; preserve remote exit codes when stream decoding and delivery finish successfully. [PR 1969](https://github.com/openclaw/crabbox/pull/1969).
+- Enforce controller and coordinator token-command output limits consistently during pipe copying, preserving the existing overflow errors and command deadlines.
 
 ## 0.52.0 - 2026-09-07
 

--- a/docs/features/bring-your-own-infrastructure.md
+++ b/docs/features/bring-your-own-infrastructure.md
@@ -172,7 +172,8 @@ export CRABBOX_COORDINATOR_TOKEN_COMMAND='["credential-helper","read","crabbox-u
 ```
 
 The command is executed directly without a shell. It must print exactly one
-token line, complete within 15 seconds, and stay within the output limit. The
+token line and complete within 15 seconds. Crabbox retains at most 16 KiB of
+stdout, including line endings, and rejects overflow before token parsing. The
 CLI reruns it for HTTP requests and reconnecting WebSockets, so an expiring
 token does not need to be persisted. Its output must be a bearer the
 coordinator accepts, such as its shared/admin token or a signed `cbxu_` user

--- a/internal/cli/controller_subprocess.go
+++ b/internal/cli/controller_subprocess.go
@@ -1813,21 +1813,25 @@ func (r *execControllerWorkspaceRunner) adapterChildEnv(overrides map[string]str
 	return merged
 }
 
+// Keep storage private so optimized copies cannot bypass the capped Write.
 type controllerLimitedBuffer struct {
-	bytes.Buffer
+	buffer   bytes.Buffer
 	limit    int
 	overflow bool
 }
 
+func (b *controllerLimitedBuffer) Bytes() []byte  { return b.buffer.Bytes() }
+func (b *controllerLimitedBuffer) String() string { return b.buffer.String() }
+
 func (b *controllerLimitedBuffer) Write(data []byte) (int, error) {
 	original := len(data)
-	remaining := b.limit - b.Len()
+	remaining := b.limit - b.buffer.Len()
 	if remaining > 0 {
 		if len(data) > remaining {
 			b.overflow = true
 			data = data[:remaining]
 		}
-		_, _ = b.Buffer.Write(data)
+		_, _ = b.buffer.Write(data)
 	} else if original > 0 {
 		b.overflow = true
 	}

--- a/internal/cli/controller_subprocess_test.go
+++ b/internal/cli/controller_subprocess_test.go
@@ -1692,6 +1692,43 @@ func TestControllerLimitedBufferReportsOverflow(t *testing.T) {
 	}
 }
 
+func TestControllerLimitedBufferCopyRespectsLimit(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		limit    int
+		prefix   string
+		input    string
+		want     string
+		overflow bool
+	}{
+		{name: "empty zero limit"},
+		{name: "zero limit", input: "ab", overflow: true},
+		{name: "negative limit", limit: -1, input: "ab", overflow: true},
+		{name: "exact fill", limit: 4, input: "abcd", want: "abcd"},
+		{name: "overflow", limit: 4, input: "abcde", want: "abcd", overflow: true},
+		{name: "split overflow", limit: 4, prefix: "abc", input: "de", want: "abcd", overflow: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			output := controllerLimitedBuffer{limit: tc.limit}
+			if _, err := output.Write([]byte(tc.prefix)); err != nil {
+				t.Fatal(err)
+			}
+			// Hide the source's WriterTo so copying exercises destination dispatch.
+			n, err := io.Copy(&output, struct{ io.Reader }{strings.NewReader(tc.input)})
+			if err != nil || n != int64(len(tc.input)) {
+				t.Fatalf("copied=%d err=%v", n, err)
+			}
+			if output.String() != tc.want || string(output.Bytes()) != tc.want || output.overflow != tc.overflow {
+				t.Fatalf("output=%q overflow=%v, want %q/%v", output.String(), output.overflow, tc.want, tc.overflow)
+			}
+			_, _ = output.Write(nil)
+			if output.overflow != tc.overflow {
+				t.Fatal("empty write changed overflow observation")
+			}
+		})
+	}
+}
+
 func controllerDesktopTestRequest(leaseID string) controllerWorkspaceRequest {
 	suffix := strings.TrimPrefix(leaseID, "cbx_")
 	return controllerWorkspaceRequest{

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -2553,14 +2553,17 @@ func (c *CoordinatorClient) authorizationToken(ctx context.Context) (string, err
 	return token, nil
 }
 
+// Embedding bytes.Buffer would expose uncapped copy methods.
 type limitedCoordinatorTokenOutput struct {
-	bytes.Buffer
+	buffer   bytes.Buffer
 	overflow bool
 }
 
+func (w *limitedCoordinatorTokenOutput) String() string { return w.buffer.String() }
+
 func (w *limitedCoordinatorTokenOutput) Write(p []byte) (int, error) {
 	originalLength := len(p)
-	remaining := maxCoordinatorTokenBytes - w.Len()
+	remaining := maxCoordinatorTokenBytes - w.buffer.Len()
 	if remaining <= 0 {
 		w.overflow = w.overflow || originalLength > 0
 		return originalLength, nil
@@ -2569,7 +2572,7 @@ func (w *limitedCoordinatorTokenOutput) Write(p []byte) (int, error) {
 		p = p[:remaining]
 		w.overflow = true
 	}
-	_, _ = w.Buffer.Write(p)
+	_, _ = w.buffer.Write(p)
 	return originalLength, nil
 }
 

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -40,6 +40,40 @@ func TestCoordinatorMachineIDAcceptsStringOrNumber(t *testing.T) {
 	}
 }
 
+func TestCoordinatorTokenOutputCopy(t *testing.T) {
+	var output limitedCoordinatorTokenOutput
+	if n, err := io.Copy(&output, struct{ io.Reader }{strings.NewReader("ab")}); err != nil || n != 2 {
+		t.Fatalf("copied=%d err=%v", n, err)
+	}
+	if n, err := io.WriteString(&output, "cd"); err != nil || n != 2 {
+		t.Fatalf("written=%d err=%v", n, err)
+	}
+	if output.String() != "abcd" || output.overflow {
+		t.Fatalf("output=%q overflow=%v", output.String(), output.overflow)
+	}
+	output.overflow = true
+	_, _ = output.Write(nil)
+	if !output.overflow {
+		t.Fatal("empty write cleared overflow observation")
+	}
+}
+
+func TestCappedOutputBuffersDoNotPromoteMutationMethods(t *testing.T) {
+	for name, output := range map[string]io.Writer{
+		"controller": &controllerLimitedBuffer{limit: 4},
+		"token":      &limitedCoordinatorTokenOutput{},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, ok := output.(io.ReaderFrom); ok {
+				t.Error("capture exposes ReaderFrom outside its capped Write")
+			}
+			if _, ok := output.(io.StringWriter); ok {
+				t.Error("capture exposes WriteString outside its capped Write")
+			}
+		})
+	}
+}
+
 func TestSplitCurlResponseParsesTrailingStatus(t *testing.T) {
 	body, status, err := splitCurlResponse([]byte("{\"ok\":true}\n200"))
 	if err != nil {


### PR DESCRIPTION
## Summary

Controller response capture and coordinator token-command output embed `bytes.Buffer` while overriding only `Write`. That exposes other mutation methods outside the intended cap. Use private buffer storage and expose only the methods each caller needs, so normal copy dispatch goes through the capped writer.

The existing limits, retained-prefix behavior, overflow diagnostics, token parsing, command deadlines, cancellation and controller lifecycle decisions are unchanged. No response is accepted merely because a truncated prefix parses. This bounds retained output; it is not a new process-memory or process-lifetime guarantee.

The Unreleased changelog records the correction. The coordinator documentation now states the existing 16 KiB raw stdout limit, including line endings.

## Verification

Based on main `f5dfb62977ce9ba4b87d5d68da37bd110f2d8d74`; head `29ad8af81fe965ff405a69ad7ec88c19b5beb901`, reviewed tree `f2916fa7866713c1c52ac8210de69ae21ec826fb`.

- Six pre-fix regression subcases failed, using at most five bytes of in-memory input. Corrected tests cover direct writes and standard copying, empty/exact/split/overflow and nonpositive controller limits, sticky overflow, and the intended writer interface boundary.
- Focused race tests and existing normal token-helper/loopback tests passed. Existing token validation, controller overflow messages and run-admission implementation remain unchanged.
- `go vet ./internal/cli`, the CLI build, documentation links across 246 Markdown files and diff checks passed.
- Independent Codex review is scoped-clean at P0, not an all-priority certification.

This is a bounded internal storage repair. No production controller fault, large-output workload, real token acquisition, cloud allocation or resource-exhaustion measurement was performed. Current-head main CI passed all 11 jobs: https://github.com/openclaw/crabbox/actions/runs/34162287852. Code-validation workflows, including connector and release checks, passed without reruns. The final merge target against main `f5dfb62977ce9ba4b87d5d68da37bd110f2d8d74` is exactly the reviewed tree `f2916fa7866713c1c52ac8210de69ae21ec826fb`.

## Review status

The separate ClawSweeper input-safety check prevented its review, so it produced **no verdict**: https://github.com/openclaw/crabbox/pull/1971#issuecomment-5575639443. No rejected material was retrieved, qualified, repackaged or resubmitted, and no retry was requested. This notice is not counted as a passed code review. The independently requested Codex review, maintainer source review and regression checks described above completed before that notice and are separate evidence for this bounded defensive change. Landing uses the ordinary protected merge path, without an administrative override.
