### PR TITLE
refactor: centralize core prefix capture storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add bounded AWS provisioning transport diagnostics for credential preparation, signing and SDK request time, including retry-loop signing counts, without changing retry behavior. [PR 1968](https://github.com/openclaw/crabbox/pull/1968). Thanks @steipete.
 - Islo: report failed stdout/stderr delivery instead of silently succeeding after losing command output; preserve remote exit codes when stream decoding and delivery finish successfully. [PR 1969](https://github.com/openclaw/crabbox/pull/1969).
 - Enforce controller and coordinator token-command output limits consistently during pipe copying, preserving the existing overflow errors and command deadlines. [PR 1971](https://github.com/openclaw/crabbox/pull/1971).
+- Share byte-prefix storage across command capture, controller responses, and coordinator token helpers while preserving each caller's limits, cancellation, and diagnostics.
 
 ## 0.52.0 - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add bounded AWS provisioning transport diagnostics for credential preparation, signing and SDK request time, including retry-loop signing counts, without changing retry behavior. [PR 1968](https://github.com/openclaw/crabbox/pull/1968). Thanks @steipete.
 - Islo: report failed stdout/stderr delivery instead of silently succeeding after losing command output; preserve remote exit codes when stream decoding and delivery finish successfully. [PR 1969](https://github.com/openclaw/crabbox/pull/1969).
 - Enforce controller and coordinator token-command output limits consistently during pipe copying, preserving the existing overflow errors and command deadlines. [PR 1971](https://github.com/openclaw/crabbox/pull/1971).
-- Share byte-prefix storage across command capture, controller responses, and coordinator token helpers while preserving each caller's limits, cancellation, and diagnostics.
+- Share byte-prefix storage across command capture, controller responses, and coordinator token helpers while preserving each caller's limits, cancellation, and diagnostics. [PR 1972](https://github.com/openclaw/crabbox/pull/1972).
 
 ## 0.52.0 - 2026-09-07
 

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -483,6 +483,13 @@ semaphore, advisory file lock, retry cadence, and idempotent release. Adapters
 retain provider-specific lease ID validation, namespace preparation, and
 diagnostics; the provider name selects the existing on-disk lock filename.
 
+Raw byte-prefix storage lives in `internal/prefixbuffer`. Core command capture,
+controller responses, and coordinator token helpers share it. Finite nonpositive
+limits discard output; unlimited capture requires explicit construction. Callers
+retain cancellation, labelled errors, and independent file-watcher overflow.
+The buffer has no locking or truncation markers, and `Bytes` returns a borrowed
+view. Byte tails, line tails, and UTF-8-aware logs remain separate storage policies.
+
 Strict one-request/one-response JSON subprocesses may use
 `internal/providers/shared/procjson`. It owns bounded capture, cancellation
 grace, request encoding, and exact single-document decoding. Keep response

--- a/internal/cli/command_capture_unix_test.go
+++ b/internal/cli/command_capture_unix_test.go
@@ -20,6 +20,53 @@ import (
 	"time"
 )
 
+func TestCommandFileCaptureRetainsObservedOverflow(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	capture, err := newCommandFileCapture(4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer capture.close()
+	if _, err := capture.streams[0].writer.WriteString("abcde"); err != nil {
+		t.Fatal(err)
+	}
+	observed := make(chan struct{}, 1)
+	finish := capture.watch(func() {
+		select {
+		case observed <- struct{}{}:
+		default:
+		}
+	}, func() error { return nil }, time.Second)
+	finished := false
+	defer func() {
+		if !finished {
+			capture.closeWriters()
+			finish()
+		}
+	}()
+	select {
+	case <-observed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("watcher did not observe the few-byte overflow")
+	}
+	if err := capture.streams[0].writer.Truncate(3); err != nil {
+		t.Fatal(err)
+	}
+	capture.closeWriters()
+	outcome := finish()
+	finished = true
+	if !outcome.settled || !outcome.overflow || outcome.err != nil {
+		t.Fatalf("watcher outcome=%+v", outcome)
+	}
+	stdout, stderr := newCommandCaptureBuffer(4, nil), newCommandCaptureBuffer(4, nil)
+	if err := capture.read(&stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	if stdout.String() != "abc" || stderr.String() != "" || stdout.buffer.Exceeded() || stderr.buffer.Exceeded() {
+		t.Fatalf("readback=%q/%q overflow=%v/%v", stdout.String(), stderr.String(), stdout.buffer.Exceeded(), stderr.buffer.Exceeded())
+	}
+}
+
 func TestExecCommandRunnerFileCapture(t *testing.T) {
 	t.Setenv(controllerProcessTreeOwnedEnv, "")
 	for _, tc := range []struct {

--- a/internal/cli/controller_subprocess.go
+++ b/internal/cli/controller_subprocess.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/prefixbuffer"
 )
 
 type execControllerRunnerOptions struct {
@@ -42,6 +44,7 @@ type execControllerWorkspaceRunner struct {
 }
 
 const controllerChildIdentityVersion = 1
+const controllerOutputLimitBytes = 1 << 20
 
 const controllerChildWaitDelay = 250 * time.Millisecond
 
@@ -236,8 +239,7 @@ type controllerChildIdentity struct {
 }
 
 func (r *execControllerWorkspaceRunner) ProviderIdentity(ctx context.Context) (controllerProviderIdentity, error) {
-	var output controllerLimitedBuffer
-	output.limit = 1 << 20
+	output := prefixbuffer.NewLimited(controllerOutputLimitBytes)
 	args := []string{"config", "show", "--json", "--controller-provider-identity"}
 	if provider := strings.TrimSpace(r.opts.Provider); provider != "" {
 		args = append(args, "--provider", provider)
@@ -245,7 +247,7 @@ func (r *execControllerWorkspaceRunner) ProviderIdentity(ctx context.Context) (c
 	if err := r.runWithStarted(ctx, controllerWorkspaceRequest{}, args, &output, nil); err != nil {
 		return controllerProviderIdentity{}, fmt.Errorf("resolve controller provider identity: %w", err)
 	}
-	if err := output.overflowError("controller provider identity"); err != nil {
+	if err := controllerOutputOverflowError(output.Exceeded(), "controller provider identity", controllerOutputLimitBytes); err != nil {
 		return controllerProviderIdentity{}, err
 	}
 	var view struct {
@@ -282,15 +284,14 @@ func (r *execControllerWorkspaceRunner) Warmup(
 	if err != nil {
 		return controllerAcquireIdentity{}, err
 	}
-	var output controllerLimitedBuffer
-	output.limit = 1 << 20
+	output := prefixbuffer.NewLimited(controllerOutputLimitBytes)
 	warmupEnv := gate.environment()
 	warmupEnv[controllerCoordinatorRegistrationExpectedEnv] = "1"
 	warmupEnv[controllerCoordinatorRegistrationURLEnv] = request.CoordinatorRegistrationURL
 	runErr := r.runWithStartedEnv(ctx, request, r.warmupArgs(attemptLeaseID, slug, request), &output, onStarted, warmupEnv)
 	gate.close()
 	identityResult := gate.wait()
-	return identityResult.Identity, errors.Join(runErr, output.overflowError("controller provider warmup"), identityResult.Err)
+	return identityResult.Identity, errors.Join(runErr, controllerOutputOverflowError(output.Exceeded(), "controller provider warmup", controllerOutputLimitBytes), identityResult.Err)
 }
 
 func (r *execControllerWorkspaceRunner) warmupArgs(attemptLeaseID, slug string, request controllerWorkspaceRequest) []string {
@@ -332,8 +333,7 @@ func (r *execControllerWorkspaceRunner) Inspect(ctx context.Context, identifier 
 	if err != nil {
 		return StatusView{}, err
 	}
-	var output controllerLimitedBuffer
-	output.limit = 1 << 20
+	output := prefixbuffer.NewLimited(controllerOutputLimitBytes)
 	if err := r.run(ctx, request, args, &output); err != nil {
 		absent, confirmErr := r.workspaceAbsent(ctx, identifier, request)
 		if confirmErr == nil && absent {
@@ -344,7 +344,7 @@ func (r *execControllerWorkspaceRunner) Inspect(ctx context.Context, identifier 
 		}
 		return StatusView{}, err
 	}
-	if err := output.overflowError("controller provider inspection"); err != nil {
+	if err := controllerOutputOverflowError(output.Exceeded(), "controller provider inspection", controllerOutputLimitBytes); err != nil {
 		return StatusView{}, err
 	}
 	var status StatusView
@@ -434,15 +434,14 @@ func (r *execControllerWorkspaceRunner) DesktopConnection(ctx context.Context, i
 		defer cancel()
 		resultErr = errors.Join(resultErr, r.StopLocal(cleanupCtx, identifier, request))
 	}()
-	var daemonStatus controllerLimitedBuffer
-	daemonStatus.limit = 1 << 20
+	daemonStatus := prefixbuffer.NewLimited(controllerOutputLimitBytes)
 	if err := r.run(ctx, request, []string{
 		"webvnc", "daemon", "status", "--id", identifier,
 		"--controller-owner-id", ownerID,
 	}, &daemonStatus); err != nil {
 		return "", err
 	}
-	if err := daemonStatus.overflowError("controller WebVNC daemon status"); err != nil {
+	if err := controllerOutputOverflowError(daemonStatus.Exceeded(), "controller WebVNC daemon status", controllerOutputLimitBytes); err != nil {
 		return "", err
 	}
 	localPort := controllerWebVNCDaemonLocalPort(daemonStatus.String())
@@ -471,12 +470,11 @@ func (r *execControllerWorkspaceRunner) DesktopConnection(ctx context.Context, i
 		}
 		startArgs = append(startArgs, "--controller-owned=true", "--controller-owner-id", ownerID)
 		startArgs = append(startArgs, expectedIdentityArgs...)
-		var startOutput controllerLimitedBuffer
-		startOutput.limit = 1 << 20
+		startOutput := prefixbuffer.NewLimited(controllerOutputLimitBytes)
 		if err := r.run(ctx, request, startArgs, &startOutput); err != nil {
 			return "", err
 		}
-		if err := startOutput.overflowError("controller WebVNC daemon start"); err != nil {
+		if err := controllerOutputOverflowError(startOutput.Exceeded(), "controller WebVNC daemon start", controllerOutputLimitBytes); err != nil {
 			return "", err
 		}
 		startedHere = true
@@ -501,12 +499,11 @@ func (r *execControllerWorkspaceRunner) DesktopConnection(ctx context.Context, i
 		"--controller-owner-id", ownerID,
 	)
 	statusArgs = append(statusArgs, expectedIdentityArgs...)
-	var output controllerLimitedBuffer
-	output.limit = 1 << 20
+	output := prefixbuffer.NewLimited(controllerOutputLimitBytes)
 	if err := r.run(ctx, request, statusArgs, &output); err != nil {
 		return "", err
 	}
-	if err := output.overflowError("controller WebVNC status"); err != nil {
+	if err := controllerOutputOverflowError(output.Exceeded(), "controller WebVNC status", controllerOutputLimitBytes); err != nil {
 		return "", err
 	}
 	if !controllerWebVNCReady(output.String()) {
@@ -561,15 +558,14 @@ func controllerWebVNCExpectedProviderArgs(request controllerWorkspaceRequest) ([
 }
 
 func (r *execControllerWorkspaceRunner) verifyWebVNCDaemon(ctx context.Context, identifier, localPort, ownerID string, request controllerWorkspaceRequest) (int, error) {
-	var output controllerLimitedBuffer
-	output.limit = 1 << 20
+	output := prefixbuffer.NewLimited(controllerOutputLimitBytes)
 	if err := r.run(ctx, request, []string{
 		"webvnc", "daemon", "status", "--id", identifier,
 		"--controller-owner-id", ownerID,
 	}, &output); err != nil {
 		return 0, fmt.Errorf("verify WebVNC daemon: %w", err)
 	}
-	if err := output.overflowError("controller WebVNC daemon verification"); err != nil {
+	if err := controllerOutputOverflowError(output.Exceeded(), "controller WebVNC daemon verification", controllerOutputLimitBytes); err != nil {
 		return 0, err
 	}
 	verifiedPort := controllerWebVNCDaemonLocalPort(output.String())
@@ -808,12 +804,11 @@ func (r *execControllerWorkspaceRunner) workspaceAbsent(ctx context.Context, ide
 	if err != nil {
 		return false, err
 	}
-	var output controllerLimitedBuffer
-	output.limit = 1 << 20
+	output := prefixbuffer.NewLimited(controllerOutputLimitBytes)
 	if err := r.run(ctx, request, args, &output); err != nil {
 		return false, err
 	}
-	if err := output.overflowError("controller provider inventory"); err != nil {
+	if err := controllerOutputOverflowError(output.Exceeded(), "controller provider inventory", controllerOutputLimitBytes); err != nil {
 		return false, fmt.Errorf("provider absence cannot be confirmed: %w", err)
 	}
 	identities, err := controllerAbsenceIdentitySet(identifier, request)
@@ -1813,34 +1808,9 @@ func (r *execControllerWorkspaceRunner) adapterChildEnv(overrides map[string]str
 	return merged
 }
 
-// Keep storage private so optimized copies cannot bypass the capped Write.
-type controllerLimitedBuffer struct {
-	buffer   bytes.Buffer
-	limit    int
-	overflow bool
-}
-
-func (b *controllerLimitedBuffer) Bytes() []byte  { return b.buffer.Bytes() }
-func (b *controllerLimitedBuffer) String() string { return b.buffer.String() }
-
-func (b *controllerLimitedBuffer) Write(data []byte) (int, error) {
-	original := len(data)
-	remaining := b.limit - b.buffer.Len()
-	if remaining > 0 {
-		if len(data) > remaining {
-			b.overflow = true
-			data = data[:remaining]
-		}
-		_, _ = b.buffer.Write(data)
-	} else if original > 0 {
-		b.overflow = true
-	}
-	return original, nil
-}
-
-func (b *controllerLimitedBuffer) overflowError(label string) error {
-	if !b.overflow {
+func controllerOutputOverflowError(exceeded bool, label string, limit int) error {
+	if !exceeded {
 		return nil
 	}
-	return fmt.Errorf("%s exceeded %d-byte output limit", label, b.limit)
+	return fmt.Errorf("%s exceeded %d-byte output limit", label, limit)
 }

--- a/internal/cli/controller_subprocess_test.go
+++ b/internal/cli/controller_subprocess_test.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/prefixbuffer"
 )
 
 func controllerSubprocessTestTimeout(base time.Duration) time.Duration {
@@ -1678,54 +1680,19 @@ func TestControllerAbsenceIdentitySetUsesEveryPersistedIdentity(t *testing.T) {
 	}
 }
 
-func TestControllerLimitedBufferReportsOverflow(t *testing.T) {
-	var output controllerLimitedBuffer
-	output.limit = 4
-	if n, err := output.Write([]byte("12345")); err != nil || n != 5 {
-		t.Fatalf("write bytes=%d err=%v", n, err)
+func TestControllerOutputReportsOverflow(t *testing.T) {
+	output := prefixbuffer.NewLimited(4)
+	if err := controllerOutputOverflowError(output.Exceeded(), "controller provider inventory", 4); err != nil {
+		t.Fatal(err)
+	}
+	if n, err := io.Copy(&output, struct{ io.Reader }{strings.NewReader("12345")}); err != nil || n != 5 {
+		t.Fatalf("copied bytes=%d err=%v", n, err)
 	}
 	if got := output.String(); got != "1234" {
 		t.Fatalf("retained output=%q", got)
 	}
-	if err := output.overflowError("controller provider inventory"); err == nil || !strings.Contains(err.Error(), "exceeded 4-byte output limit") {
+	if err := controllerOutputOverflowError(output.Exceeded(), "controller provider inventory", 4); err == nil || err.Error() != "controller provider inventory exceeded 4-byte output limit" {
 		t.Fatalf("overflow error=%v", err)
-	}
-}
-
-func TestControllerLimitedBufferCopyRespectsLimit(t *testing.T) {
-	for _, tc := range []struct {
-		name     string
-		limit    int
-		prefix   string
-		input    string
-		want     string
-		overflow bool
-	}{
-		{name: "empty zero limit"},
-		{name: "zero limit", input: "ab", overflow: true},
-		{name: "negative limit", limit: -1, input: "ab", overflow: true},
-		{name: "exact fill", limit: 4, input: "abcd", want: "abcd"},
-		{name: "overflow", limit: 4, input: "abcde", want: "abcd", overflow: true},
-		{name: "split overflow", limit: 4, prefix: "abc", input: "de", want: "abcd", overflow: true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			output := controllerLimitedBuffer{limit: tc.limit}
-			if _, err := output.Write([]byte(tc.prefix)); err != nil {
-				t.Fatal(err)
-			}
-			// Hide the source's WriterTo so copying exercises destination dispatch.
-			n, err := io.Copy(&output, struct{ io.Reader }{strings.NewReader(tc.input)})
-			if err != nil || n != int64(len(tc.input)) {
-				t.Fatalf("copied=%d err=%v", n, err)
-			}
-			if output.String() != tc.want || string(output.Bytes()) != tc.want || output.overflow != tc.overflow {
-				t.Fatalf("output=%q overflow=%v, want %q/%v", output.String(), output.overflow, tc.want, tc.overflow)
-			}
-			_, _ = output.Write(nil)
-			if output.overflow != tc.overflow {
-				t.Fatal("empty write changed overflow observation")
-			}
-		})
 	}
 }
 

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/prefixbuffer"
 )
 
 type CoordinatorClient struct {
@@ -2527,7 +2529,7 @@ func (c *CoordinatorClient) authorizationToken(ctx context.Context) (string, err
 	cmd := exec.CommandContext(commandCtx, c.TokenCommand[0], c.TokenCommand[1:]...)
 	configureBoundedCommandCancellation(cmd)
 	c.applyChildEnvironment(cmd)
-	var output limitedCoordinatorTokenOutput
+	output := prefixbuffer.NewLimited(maxCoordinatorTokenBytes)
 	cmd.Stdout = &output
 	cmd.Stderr = io.Discard
 	if err := cmd.Run(); err != nil {
@@ -2539,7 +2541,7 @@ func (c *CoordinatorClient) authorizationToken(ctx context.Context) (string, err
 		}
 		return "", fmt.Errorf("coordinator token command failed: %w", err)
 	}
-	if output.overflow {
+	if output.Exceeded() {
 		return "", fmt.Errorf("coordinator token command output exceeds %d bytes", maxCoordinatorTokenBytes)
 	}
 	token := strings.TrimSuffix(output.String(), "\n")
@@ -2551,29 +2553,6 @@ func (c *CoordinatorClient) authorizationToken(ctx context.Context) (string, err
 		return "", errors.New("coordinator token command must return exactly one token line")
 	}
 	return token, nil
-}
-
-// Embedding bytes.Buffer would expose uncapped copy methods.
-type limitedCoordinatorTokenOutput struct {
-	buffer   bytes.Buffer
-	overflow bool
-}
-
-func (w *limitedCoordinatorTokenOutput) String() string { return w.buffer.String() }
-
-func (w *limitedCoordinatorTokenOutput) Write(p []byte) (int, error) {
-	originalLength := len(p)
-	remaining := maxCoordinatorTokenBytes - w.buffer.Len()
-	if remaining <= 0 {
-		w.overflow = w.overflow || originalLength > 0
-		return originalLength, nil
-	}
-	if len(p) > remaining {
-		p = p[:remaining]
-		w.overflow = true
-	}
-	_, _ = w.buffer.Write(p)
-	return originalLength, nil
 }
 
 func (c *CoordinatorClient) doCurl(ctx context.Context, method, path string, data []byte, hasBody bool, out any) error {

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -40,40 +40,6 @@ func TestCoordinatorMachineIDAcceptsStringOrNumber(t *testing.T) {
 	}
 }
 
-func TestCoordinatorTokenOutputCopy(t *testing.T) {
-	var output limitedCoordinatorTokenOutput
-	if n, err := io.Copy(&output, struct{ io.Reader }{strings.NewReader("ab")}); err != nil || n != 2 {
-		t.Fatalf("copied=%d err=%v", n, err)
-	}
-	if n, err := io.WriteString(&output, "cd"); err != nil || n != 2 {
-		t.Fatalf("written=%d err=%v", n, err)
-	}
-	if output.String() != "abcd" || output.overflow {
-		t.Fatalf("output=%q overflow=%v", output.String(), output.overflow)
-	}
-	output.overflow = true
-	_, _ = output.Write(nil)
-	if !output.overflow {
-		t.Fatal("empty write cleared overflow observation")
-	}
-}
-
-func TestCappedOutputBuffersDoNotPromoteMutationMethods(t *testing.T) {
-	for name, output := range map[string]io.Writer{
-		"controller": &controllerLimitedBuffer{limit: 4},
-		"token":      &limitedCoordinatorTokenOutput{},
-	} {
-		t.Run(name, func(t *testing.T) {
-			if _, ok := output.(io.ReaderFrom); ok {
-				t.Error("capture exposes ReaderFrom outside its capped Write")
-			}
-			if _, ok := output.(io.StringWriter); ok {
-				t.Error("capture exposes WriteString outside its capped Write")
-			}
-		})
-	}
-}
-
 func TestSplitCurlResponseParsesTrailingStatus(t *testing.T) {
 	body, status, err := splitCurlResponse([]byte("{\"ok\":true}\n200"))
 	if err != nil {

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"flag"
@@ -13,6 +12,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/prefixbuffer"
 )
 
 type Provider interface {
@@ -900,8 +901,8 @@ func (execCommandRunner) Run(ctx context.Context, req LocalCommandRequest) (Loca
 	cmd.Env = stripControllerAcquireIdentityEnv(env)
 	cmd.Dir = req.Dir
 	cmd.Stdin = req.Stdin
-	stdout := commandCaptureBuffer{limit: req.MaxCapturedOutputBytes, cancel: cancel}
-	stderr := commandCaptureBuffer{limit: req.MaxCapturedOutputBytes, cancel: cancel}
+	stdout := newCommandCaptureBuffer(req.MaxCapturedOutputBytes, cancel)
+	stderr := newCommandCaptureBuffer(req.MaxCapturedOutputBytes, cancel)
 	cmd.Stdout = commandOutputWriter(req.Stdout, &stdout, req.DisableOutputCapture)
 	cmd.Stderr = commandOutputWriter(req.Stderr, &stderr, req.DisableOutputCapture)
 	var files *commandFileCapture
@@ -914,6 +915,7 @@ func (execCommandRunner) Run(ctx context.Context, req LocalCommandRequest) (Loca
 		defer files.close()
 		cmd.Stdout, cmd.Stderr = files.streams[0].writer, files.streams[1].writer
 	}
+	var observedFileOverflow bool
 	err := cmd.Start()
 	if err == nil {
 		var finishCapture func() commandFileCaptureOutcome
@@ -933,8 +935,8 @@ func (execCommandRunner) Run(ctx context.Context, req LocalCommandRequest) (Loca
 				err = errors.Join(err, readErr)
 				return LocalCommandResult{ExitCode: exitCode(err)}, err
 			}
-			stdout.overflow = stdout.overflow || observed.overflow
-			if stdout.overflow || stderr.overflow || err != nil {
+			observedFileOverflow = observed.overflow
+			if stdout.buffer.Exceeded() || stderr.buffer.Exceeded() || observedFileOverflow || err != nil {
 				_ = stopCommand()
 			}
 		}
@@ -943,7 +945,7 @@ func (execCommandRunner) Run(ctx context.Context, req LocalCommandRequest) (Loca
 		_ = stopCommand()
 	}
 	result := LocalCommandResult{ExitCode: exitCode(err), Stdout: stdout.String(), Stderr: stderr.String()}
-	if stdout.overflow || stderr.overflow {
+	if stdout.buffer.Exceeded() || stderr.buffer.Exceeded() || observedFileOverflow {
 		err = fmt.Errorf("captured command output exceeded %d-byte limit", req.MaxCapturedOutputBytes)
 		result.ExitCode = 5
 	}
@@ -984,31 +986,24 @@ func configureBoundedCommandCancellation(cmd *exec.Cmd) {
 }
 
 type commandCaptureBuffer struct {
-	buffer   bytes.Buffer
-	limit    int
-	overflow bool
-	cancel   context.CancelFunc
+	buffer prefixbuffer.Buffer
+	cancel context.CancelFunc
+}
+
+func newCommandCaptureBuffer(limit int, cancel context.CancelFunc) commandCaptureBuffer {
+	buffer := prefixbuffer.NewUnlimited()
+	if limit > 0 {
+		buffer = prefixbuffer.NewLimited(limit)
+	}
+	return commandCaptureBuffer{buffer: buffer, cancel: cancel}
 }
 
 func (b *commandCaptureBuffer) Write(data []byte) (int, error) {
-	if b.limit <= 0 {
-		return b.buffer.Write(data)
-	}
-	original := len(data)
-	remaining := b.limit - b.buffer.Len()
-	if remaining > 0 {
-		if len(data) > remaining {
-			b.overflow = true
-			data = data[:remaining]
-		}
-		_, _ = b.buffer.Write(data)
-	} else if original > 0 {
-		b.overflow = true
-	}
-	if b.overflow && b.cancel != nil {
+	n, err := b.buffer.Write(data)
+	if b.buffer.Exceeded() && b.cancel != nil {
 		b.cancel()
 	}
-	return original, nil
+	return n, err
 }
 
 func (b *commandCaptureBuffer) String() string {

--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -185,6 +185,91 @@ func TestRunClassificationUsesOnlyPrimaryMarker(t *testing.T) {
 	}
 }
 
+func TestCommandCaptureBufferMethodSurface(t *testing.T) {
+	output := newCommandCaptureBuffer(4, nil)
+	var writer io.Writer = &output
+	if _, ok := writer.(io.ReaderFrom); ok {
+		t.Error("capture exposes ReaderFrom outside its cancellation-aware Write")
+	}
+	if _, ok := writer.(io.StringWriter); ok {
+		t.Error("capture exposes WriteString outside its cancellation-aware Write")
+	}
+}
+
+func TestCommandCaptureBufferCancellation(t *testing.T) {
+	for _, limit := range []int{-1, 0, 4} {
+		t.Run(strconv.Itoa(limit), func(t *testing.T) {
+			output := newCommandCaptureBuffer(limit, nil)
+			calls := 0
+			output.cancel = func() {
+				calls++
+				if output.String() != "abcd" || !output.buffer.Exceeded() {
+					t.Fatalf("cancel preceded capture: output=%q overflow=%v", output.String(), output.buffer.Exceeded())
+				}
+			}
+			for i, input := range []string{"", "abcd", "e", "", "f"} {
+				n, err := output.Write([]byte(input))
+				if n != len(input) || err != nil {
+					t.Fatalf("write=%d/%v, want %d/nil", n, err, len(input))
+				}
+				wantCalls := 0
+				if limit > 0 && i >= 2 {
+					wantCalls = i - 1
+				}
+				if calls != wantCalls {
+					t.Fatalf("write %d: cancel calls=%d, want %d", i, calls, wantCalls)
+				}
+			}
+			want := "abcdef"
+			if limit > 0 {
+				want = "abcd"
+			}
+			if output.String() != want {
+				t.Fatalf("output=%q, want %q", output.String(), want)
+			}
+		})
+	}
+}
+
+func TestCommandOutputWriterOrdering(t *testing.T) {
+	writeErr := errors.New("output unavailable")
+	for _, tc := range []struct {
+		name     string
+		disabled bool
+		err      error
+	}{
+		{name: "stream then capture"},
+		{name: "stream failure", err: writeErr},
+		{name: "capture disabled", disabled: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			output := newCommandCaptureBuffer(4, nil)
+			calls := 0
+			writer := writerFunc(func(p []byte) (int, error) {
+				calls++
+				if output.String() != "" {
+					t.Fatal("capture ran before external writer")
+				}
+				if tc.err != nil {
+					return 0, tc.err
+				}
+				return len(p), nil
+			})
+			n, err := commandOutputWriter(writer, &output, tc.disabled).Write([]byte("ab"))
+			wantCount, wantOutput := 2, "ab"
+			if tc.err != nil {
+				wantCount = 0
+			}
+			if tc.err != nil || tc.disabled {
+				wantOutput = ""
+			}
+			if calls != 1 || n != wantCount || err != tc.err || output.String() != wantOutput {
+				t.Fatalf("calls=%d write=%d/%v output=%q", calls, n, err, output.String())
+			}
+		})
+	}
+}
+
 func TestExecCommandRunnerBoundsCapturedOutputAndStopsChild(t *testing.T) {
 	executable, err := os.Executable()
 	if err != nil {

--- a/internal/prefixbuffer/buffer.go
+++ b/internal/prefixbuffer/buffer.go
@@ -1,0 +1,53 @@
+// Package prefixbuffer retains output prefixes without imposing caller error or
+// cancellation policy.
+package prefixbuffer
+
+import "bytes"
+
+// Buffer acknowledges all input while retaining a prefix. Its zero value
+// discards all input. It must not be copied after use or used concurrently.
+// Limits bound retained bytes, not allocation capacity or process memory.
+type Buffer struct {
+	buffer    bytes.Buffer
+	limit     int
+	unlimited bool
+	exceeded  bool
+}
+
+// NewLimited retains at most maxBytes; nonpositive limits discard all input.
+func NewLimited(maxBytes int) Buffer {
+	if maxBytes < 0 {
+		maxBytes = 0
+	}
+	return Buffer{limit: maxBytes}
+}
+
+// NewUnlimited retains all input without setting Exceeded.
+func NewUnlimited() Buffer {
+	return Buffer{unlimited: true}
+}
+
+// Write returns the full input length and nil, including when input is discarded.
+func (b *Buffer) Write(p []byte) (int, error) {
+	if b.unlimited {
+		return b.buffer.Write(p)
+	}
+	original := len(p)
+	remaining := b.limit - b.buffer.Len()
+	if len(p) > remaining {
+		b.exceeded = true
+		p = p[:remaining]
+	}
+	_, _ = b.buffer.Write(p)
+	return original, nil
+}
+
+// Bytes returns a borrowed view of the retained prefix. Treat it as read-only;
+// it is valid only until the next Write.
+func (b *Buffer) Bytes() []byte { return b.buffer.Bytes() }
+
+// String returns the retained prefix without a truncation marker.
+func (b *Buffer) String() string { return b.buffer.String() }
+
+// Exceeded reports whether any nonempty input has been discarded.
+func (b *Buffer) Exceeded() bool { return b.exceeded }

--- a/internal/prefixbuffer/buffer_test.go
+++ b/internal/prefixbuffer/buffer_test.go
@@ -1,0 +1,60 @@
+package prefixbuffer
+
+import (
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestBufferRetention(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		buffer Buffer
+		want   string
+	}{
+		{name: "zero value"},
+		{name: "zero limit", buffer: NewLimited(0)},
+		{name: "negative limit", buffer: NewLimited(-1)},
+		{name: "finite", buffer: NewLimited(4), want: "abcd"},
+		{name: "unlimited", buffer: NewUnlimited(), want: "abcdef"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &tc.buffer
+			input := ""
+			for _, chunk := range []string{"", "abc", "d", "e", "", "f"} {
+				n, err := b.Write([]byte(chunk))
+				if n != len(chunk) || err != nil {
+					t.Fatalf("write=%d/%v, want %d/nil", n, err, len(chunk))
+				}
+				input += chunk
+				want := tc.want[:min(len(input), len(tc.want))]
+				if b.String() != want || string(b.Bytes()) != want || b.Exceeded() != (len(input) > len(tc.want)) {
+					t.Fatalf("input=%q retained=%q exceeded=%v, want %q/%v", input, b.String(), b.Exceeded(), want, len(input) > len(tc.want))
+				}
+			}
+		})
+	}
+}
+
+func TestBufferCopyAndMethodSurface(t *testing.T) {
+	b := NewLimited(4)
+	// Hide WriterTo so io.Copy uses the destination's ordinary writer contract.
+	if n, err := io.Copy(&b, struct{ io.Reader }{strings.NewReader("abcde")}); err != nil || n != 5 {
+		t.Fatalf("copy=%d/%v", n, err)
+	}
+	if n, err := io.WriteString(&b, "f"); err != nil || n != 1 {
+		t.Fatalf("write string=%d/%v", n, err)
+	}
+	if b.String() != "abcd" || !b.Exceeded() {
+		t.Fatalf("retained=%q exceeded=%v", b.String(), b.Exceeded())
+	}
+	var methods []string
+	bufferType := reflect.TypeOf(&b)
+	for i := 0; i < bufferType.NumMethod(); i++ {
+		methods = append(methods, bufferType.Method(i).Name)
+	}
+	if want := []string{"Bytes", "Exceeded", "String", "Write"}; !reflect.DeepEqual(methods, want) {
+		t.Fatalf("method surface=%v, want %v", methods, want)
+	}
+}


### PR DESCRIPTION
## Summary

Replace three independent prefix-retention algorithms with one dependency-free `internal/prefixbuffer` storage owner. Controller responses and coordinator token helpers use it directly; command capture keeps a small wrapper for its real cancellation behavior. The old controller/token types and all three arithmetic implementations are removed, without aliases.

Finite nonpositive limits discard output; unlimited storage requires explicit construction. The command adapter preserves its existing nonpositive-unlimited convention. Writes acknowledge the full input count and remember overflow; storage exposes no uncapped mutation methods, lifecycle hooks, error formatter or locking options. Borrowed byte views and string snapshots retain their existing meaning.

Cancellation still follows storage updates, including repeated callbacks after overflow. External output still precedes capture. File-watcher overflow remains a separate runner observation and participates in both existing overflow decisions, after the original settlement/read-error early returns. Controller diagnostics, token validation, command exit codes, deadlines and cleanup stay with their current owners.

This builds on the landed encapsulation correction https://github.com/openclaw/crabbox/pull/1971. SSH, Islo, Vercel, byte-tail storage and buffered provider-result delivery are not migrated here. The change removes duplicated ownership, not a large amount of production text: production is +100/-103 before docs/tests.

## Verification

Base: `79162321519575852021d0832f8822e6a40cab9f`; head: `45803792db030085cf26c762e09f4a346dca78eb`; reviewed tree: `ea89ace80d6643c19d6106c343c5a13b3187dd0f`.

- New compatibility characterizations passed on the fixed baseline before extraction; these are not claimed as bug-red tests.
- The leaf owns finite/unlimited, zero/exact/split/overflow, full-count and method-boundary coverage. Domain tests retain controller diagnostics, normal token validation and command-wrapper cancellation/order checks; duplicate leaf matrices were removed.
- A five-byte owned-temp-file control demonstrates that a watcher can latch overflow even after later three-byte readback no longer exceeds the buffer. It does not by itself execute the full Run branch; both final decisions and early error ordering were inspected for source equivalence.
- Ten repeated focused race runs passed before parent test pruning. Final broader existing command/pipe/file-capture and normal synthetic token-helper/loopback compatibility races passed: core 12.596s, leaf 1.402s.
- Core/leaf vet, CLI build, internal links across 246 Markdown files and diff checks passed.
- Independent Codex review is scoped-clean at P0, not an all-priority certification.

Architecture docs and Unreleased describe the shared storage boundary. No provider credentials, cloud allocation, production controller fault or resource-exhaustion measurement was used. These tests do not claim a hosted provider lifecycle replay or a hard whole-process memory bound. Current-head main CI passed all 11 jobs: https://github.com/openclaw/crabbox/actions/runs/34166747656. All code-validation workflows passed without reruns. The final merge target against main `79162321519575852021d0832f8822e6a40cab9f` is exactly the reviewed/tested tree `ea89ace80d6643c19d6106c343c5a13b3187dd0f`.

## Review status

No head-bound ClawSweeper review verdict is available. Its visible public notice reports that input-safety prevented automated review, without identifying a head SHA: https://github.com/openclaw/crabbox/pull/1972#issuecomment-5576162405. This is not counted as approval. No guard override, material qualification, withheld-material investigation or explicit review retry was requested. The independently requested scoped review, complete maintainer source review, compatibility tests and exact-head CI are separate evidence for this behavior-preserving extraction. Landing uses the ordinary protected merge path without an administrative override.
