### PR TITLE
refactor: reuse prefix storage for SSH capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Islo: report failed stdout/stderr delivery instead of silently succeeding after losing command output; preserve remote exit codes when stream decoding and delivery finish successfully. [PR 1969](https://github.com/openclaw/crabbox/pull/1969).
 - Enforce controller and coordinator token-command output limits consistently during pipe copying, preserving the existing overflow errors and command deadlines. [PR 1971](https://github.com/openclaw/crabbox/pull/1971).
 - Share byte-prefix storage across command capture, controller responses, and coordinator token helpers while preserving each caller's limits, cancellation, and diagnostics. [PR 1972](https://github.com/openclaw/crabbox/pull/1972).
-- Reuse shared prefix storage for SSH diagnostics and artifact capture while preserving locked, cloned snapshots and truncation visibility.
+- Reuse shared prefix storage for SSH diagnostics and artifact capture while preserving locked, cloned snapshots and truncation visibility. [PR 1973](https://github.com/openclaw/crabbox/pull/1973).
 
 ## 0.52.0 - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Islo: report failed stdout/stderr delivery instead of silently succeeding after losing command output; preserve remote exit codes when stream decoding and delivery finish successfully. [PR 1969](https://github.com/openclaw/crabbox/pull/1969).
 - Enforce controller and coordinator token-command output limits consistently during pipe copying, preserving the existing overflow errors and command deadlines. [PR 1971](https://github.com/openclaw/crabbox/pull/1971).
 - Share byte-prefix storage across command capture, controller responses, and coordinator token helpers while preserving each caller's limits, cancellation, and diagnostics. [PR 1972](https://github.com/openclaw/crabbox/pull/1972).
+- Reuse shared prefix storage for SSH diagnostics and artifact capture while preserving locked, cloned snapshots and truncation visibility.
 
 ## 0.52.0 - 2026-09-07
 

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -484,11 +484,15 @@ retain provider-specific lease ID validation, namespace preparation, and
 diagnostics; the provider name selects the existing on-disk lock filename.
 
 Raw byte-prefix storage lives in `internal/prefixbuffer`. Core command capture,
-controller responses, and coordinator token helpers share it. Finite nonpositive
-limits discard output; unlimited capture requires explicit construction. Callers
+controller responses, coordinator token helpers, and SSH capture share it. Finite
+nonpositive limits discard output; unlimited capture requires explicit construction.
+Command and SSH wrappers preserve their nonpositive-limit unlimited behavior. Callers
 retain cancellation, labelled errors, and independent file-watcher overflow.
 The buffer has no locking or truncation markers, and `Bytes` returns a borrowed
 view. Byte tails, line tails, and UTF-8-aware logs remain separate storage policies.
+SSH retains its mutex-protected cloned snapshots and hides ordinary snapshots
+after truncation; its bounded diagnostic view still exposes the retained prefix
+and overflow flag.
 
 Strict one-request/one-response JSON subprocesses may use
 `internal/providers/shared/procjson`. It owns bounded capture, cancellation

--- a/internal/cli/git_seed_diagnostics_test.go
+++ b/internal/cli/git_seed_diagnostics_test.go
@@ -140,9 +140,11 @@ func TestGitSeedCaptureLimitPreservesExecutionAndRetry(t *testing.T) {
 			}
 		})
 	}
-	capture := synchronizedBuffer{limit: gitSeedDiagnosticLimit}
-	if n, err := io.Copy(&capture, strings.NewReader(strings.Repeat("x", 1<<20))); err != nil || n != 1<<20 || capture.buf.Len() > gitSeedDiagnosticLimit || !capture.truncated || capture.String() != "" {
-		t.Fatalf("capture n=%d err=%v retained=%d truncated=%v", n, err, capture.buf.Len(), capture.truncated)
+	capture := newSynchronizedBuffer(gitSeedDiagnosticLimit)
+	n, err := io.Copy(&capture, strings.NewReader(strings.Repeat("x", 1<<20)))
+	retained, truncated := capture.boundedString()
+	if err != nil || n != 1<<20 || len(retained) > gitSeedDiagnosticLimit || !truncated || capture.String() != "" {
+		t.Fatalf("capture n=%d err=%v retained=%d truncated=%v", n, err, len(retained), truncated)
 	}
 }
 

--- a/internal/cli/proxmox.go
+++ b/internal/cli/proxmox.go
@@ -1119,7 +1119,7 @@ func (c *ProxmoxClient) bootstrapSSH(ctx context.Context, host string, cfg Confi
 	deadline := time.Now().Add(10 * time.Minute)
 	for {
 		if proxmoxRunSSHQuietWithOptions(ctx, target, sshTransportProbeCommand(target), "5", "1") == nil {
-			out := synchronizedBuffer{limit: proxmoxBootstrapDiagnosticLimit}
+			out := newSynchronizedBuffer(proxmoxBootstrapDiagnosticLimit)
 			err := proxmoxRunSSHInput(ctx, target, "sudo /bin/bash -s", strings.NewReader(proxmoxBootstrapScript(cfg)), &out, &out)
 			if err == nil {
 				return nil

--- a/internal/cli/ready_pool_test.go
+++ b/internal/cli/ready_pool_test.go
@@ -475,7 +475,7 @@ func TestRunReadyPoolEndpointPrecedesExplicitSSHPort(t *testing.T) {
 			args = append(args, "--", "true")
 			reachedOwner := errors.New("stop after exact pool endpoint reaches workspace owner")
 			ownerCalls := 0
-			var output synchronizedBuffer
+			output := newSynchronizedBuffer(0)
 			app := App{Stdout: &output, Stderr: &output, workspaceOwnerAcquirer: func(_ context.Context, target SSHTarget, id string, _ io.Writer) (*workspaceOwner, error) {
 				ownerCalls++
 				if id != leaseID || target.Port != port || target.Host != lease.Host || target.User != lease.SSHUser || target.SSHHostKey != key {

--- a/internal/cli/run_artifact_change.go
+++ b/internal/cli/run_artifact_change.go
@@ -68,10 +68,8 @@ func snapshotArtifactChanges(ctx context.Context, target SSHTarget, workdir stri
 	if len(paths) == 0 {
 		return nil, nil
 	}
-	var output synchronizedBuffer
-	output.limit = 4*((maxArtifactChangeTotalBytes+2)/3) + 1024
-	var diagnostic synchronizedBuffer
-	diagnostic.limit = 4096
+	output := newSynchronizedBuffer(4*((maxArtifactChangeTotalBytes+2)/3) + 1024)
+	diagnostic := newSynchronizedBuffer(4096)
 	script := artifactChangeSnapshotScript(workdir, paths)
 	if err := runSSHInput(ctx, target, remoteRunArtifactShellInputCommand(target), strings.NewReader(script), &output, &diagnostic); err != nil {
 		return nil, exit(7, "artifact change snapshot: %v: %s", err, strings.TrimSpace(diagnostic.String()))

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -62,7 +62,7 @@ func collectRunArtifactGlobs(ctx context.Context, target SSHTarget, workdir, rep
 	name := safeCaptureName(firstNonBlank(runID, leaseID, "run")) + "-artifacts.tgz"
 	remotePath := ".crabbox/" + name
 	script := runArtifactCollectScript(workdir, remotePath, globs)
-	var output synchronizedBuffer
+	output := newSynchronizedBuffer(0)
 	err := runSSHInput(ctx, target, remoteRunArtifactShellInputCommand(target), strings.NewReader(script), &output, &output)
 	out := output.String()
 	if err != nil {

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -23,6 +23,7 @@ import (
 	"time"
 	"unicode/utf16"
 
+	"github.com/openclaw/crabbox/internal/prefixbuffer"
 	xssh "golang.org/x/crypto/ssh"
 )
 
@@ -731,7 +732,7 @@ func resolveSSHPortNoInput(ctx context.Context, target *SSHTarget, connectTimeou
 	for index, port := range ports {
 		probe.Port = port
 		command := sshTransportPreparation{command: sshTransportProbeCommand(probe)}
-		var diagnostic synchronizedBuffer
+		diagnostic := newSynchronizedBuffer(0)
 		_, err = command.runOnce(ctx, probe, connectTimeout, connectionAttempts, io.Discard, &diagnostic, false)
 		if err == nil {
 			target.recordPreparedEndpoint(port)
@@ -988,7 +989,7 @@ func runSSHCombinedOutput(ctx context.Context, target SSHTarget, remote string) 
 }
 
 func runSSHCombinedOutputLimit(ctx context.Context, target SSHTarget, remote string, maxBytes int) (string, error) {
-	out := synchronizedBuffer{limit: maxBytes}
+	out := newSynchronizedBuffer(maxBytes)
 	err := executeSSH(ctx, &target, remote, nil, 0, 0, "10", "3", &out, &out)
 	return strings.TrimSpace(out.String()), err
 }
@@ -1017,7 +1018,7 @@ func runIdempotentSSHCombinedOutputLimit(ctx context.Context, target SSHTarget, 
 }
 
 func runWSL2ControlScriptCombinedOutput(ctx context.Context, target SSHTarget, remote string, waitTimeout time.Duration, connectTimeout, connectionAttempts string) (string, error) {
-	var out synchronizedBuffer
+	out := newSynchronizedBuffer(0)
 	err := executeSSH(ctx, &target, remote, nil, 0, waitTimeout, connectTimeout, connectionAttempts, &out, &out)
 	return strings.TrimSpace(out.String()), err
 }
@@ -1090,29 +1091,30 @@ func sameCommandStreamWriter(left, right io.Writer) bool {
 	return left == right
 }
 
+// Construct explicitly so SSH's nonpositive limits remain unlimited.
 type synchronizedBuffer struct {
-	mu        sync.Mutex
-	buf       bytes.Buffer
-	limit     int
-	truncated bool
+	mu  sync.Mutex
+	buf prefixbuffer.Buffer
+}
+
+func newSynchronizedBuffer(limit int) synchronizedBuffer {
+	buf := prefixbuffer.NewUnlimited()
+	if limit > 0 {
+		buf = prefixbuffer.NewLimited(limit)
+	}
+	return synchronizedBuffer{buf: buf}
 }
 
 func (b *synchronizedBuffer) Write(data []byte) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	n := len(data)
-	if b.limit > 0 && len(data) > b.limit-b.buf.Len() {
-		data = data[:b.limit-b.buf.Len()]
-		b.truncated = true
-	}
-	_, _ = b.buf.Write(data)
-	return n, nil
+	return b.buf.Write(data)
 }
 
 func (b *synchronizedBuffer) Bytes() []byte {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if b.truncated {
+	if b.buf.Exceeded() {
 		return nil
 	}
 	return bytes.Clone(b.buf.Bytes())
@@ -1121,7 +1123,7 @@ func (b *synchronizedBuffer) Bytes() []byte {
 func (b *synchronizedBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if b.truncated {
+	if b.buf.Exceeded() {
 		return ""
 	}
 	return b.buf.String()
@@ -1130,7 +1132,7 @@ func (b *synchronizedBuffer) String() string {
 func (b *synchronizedBuffer) boundedString() (string, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return b.buf.String(), b.truncated
+	return b.buf.String(), b.buf.Exceeded()
 }
 
 type gitOriginDiagnosticsTruncatedError struct {
@@ -1152,7 +1154,7 @@ func runIdempotentSSHGitOriginAttempt(ctx context.Context, target SSHTarget, rem
 		truncated bool
 	)
 	for attempt := 0; attempt < 2; attempt++ {
-		out = synchronizedBuffer{limit: gitSeedDiagnosticLimit}
+		out = newSynchronizedBuffer(gitSeedDiagnosticLimit)
 		lastErr = executeSSH(ctx, &target, remote, nil, 0, 0, "10", "3", &out, &out)
 		if lastErr == nil || !shouldRetrySSHPort(lastErr) || attempt == 1 {
 			break

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -29,6 +29,86 @@ import (
 
 const powerShellEncodedCommandPrefix = "powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand "
 
+func TestSynchronizedBufferSnapshots(t *testing.T) {
+	for _, limit := range []int{-1, 0, 4} {
+		t.Run(strconv.Itoa(limit), func(t *testing.T) {
+			output := newSynchronizedBuffer(limit)
+			if output.Bytes() != nil || output.String() != "" {
+				t.Fatal("new capture is not empty")
+			}
+			if n, err := output.Write([]byte("ab")); n != 2 || err != nil {
+				t.Fatalf("write=%d/%v", n, err)
+			}
+			snapshot := output.Bytes()
+			snapshot[0] = 'z'
+			if output.String() != "ab" {
+				t.Fatal("snapshot mutation changed captured bytes")
+			}
+			if n, err := output.Write([]byte("cd")); n != 2 || err != nil {
+				t.Fatalf("write=%d/%v", n, err)
+			}
+			if string(snapshot) != "zb" || string(output.Bytes()) != "abcd" {
+				t.Fatalf("snapshot=%q capture=%q", snapshot, output.Bytes())
+			}
+			if retained, truncated := output.boundedString(); retained != "abcd" || truncated {
+				t.Fatalf("exact-fill view=%q/%v", retained, truncated)
+			}
+			for _, input := range []string{"e", ""} {
+				if n, err := output.Write([]byte(input)); n != len(input) || err != nil {
+					t.Fatalf("write=%d/%v", n, err)
+				}
+				retained, truncated := output.boundedString()
+				if limit > 0 {
+					if output.Bytes() != nil || output.String() != "" || retained != "abcd" || !truncated {
+						t.Fatalf("truncated views: bytes=%q string=%q bounded=%q/%v", output.Bytes(), output.String(), retained, truncated)
+					}
+				} else if string(output.Bytes()) != "abcde" || output.String() != "abcde" || retained != "abcde" || truncated {
+					t.Fatalf("unlimited views: bytes=%q string=%q bounded=%q/%v", output.Bytes(), output.String(), retained, truncated)
+				}
+			}
+		})
+	}
+}
+
+func TestSynchronizedBufferConcurrentSnapshots(t *testing.T) {
+	for _, limit := range []int{0, 4} {
+		t.Run(strconv.Itoa(limit), func(t *testing.T) {
+			output := newSynchronizedBuffer(limit)
+			start := make(chan struct{})
+			var workers sync.WaitGroup
+			for range 4 {
+				workers.Go(func() {
+					<-start
+					for range 2 {
+						if n, err := output.Write([]byte("x")); n != 1 || err != nil {
+							t.Errorf("write=%d/%v", n, err)
+						}
+					}
+				})
+			}
+			workers.Go(func() {
+				<-start
+				for range 8 {
+					if snapshot := output.Bytes(); len(snapshot) > 0 {
+						snapshot[0] = 'z'
+					}
+					_ = output.String()
+					_, _ = output.boundedString()
+				}
+			})
+			close(start)
+			workers.Wait()
+			want := "xxxxxxxx"
+			if limit > 0 {
+				want = "xxxx"
+			}
+			if retained, truncated := output.boundedString(); retained != want || truncated != (limit > 0) {
+				t.Fatalf("final view=%q/%v, want %q/%v", retained, truncated, want, limit > 0)
+			}
+		})
+	}
+}
+
 func TestSSHCommandContextBoundsPipeDrainAfterCancellation(t *testing.T) {
 	cmd := sshCommandContext(context.Background(), SSHTarget{}, "-V")
 	if cmd.WaitDelay != sshCommandWaitDelay {

--- a/internal/cli/ssh_wsl_cleanup_linux_test.go
+++ b/internal/cli/ssh_wsl_cleanup_linux_test.go
@@ -32,7 +32,7 @@ func startWSLLinuxFixture(t *testing.T, command string, payload []byte, declared
 	if _, err := exec.LookPath("setsid"); err != nil {
 		t.Fatal("native fixture requires the documented setsid prerequisite")
 	}
-	f := &wslLinuxFixture{directory: filepath.Join(t.TempDir(), "owned"), done: make(chan error, 1)}
+	f := &wslLinuxFixture{directory: filepath.Join(t.TempDir(), "owned"), output: newSynchronizedBuffer(0), done: make(chan error, 1)}
 	reader, writer, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/sync_git_overlay_test.go
+++ b/internal/cli/sync_git_overlay_test.go
@@ -3625,7 +3625,7 @@ exit 99
 				credentialMarker = installGitOverlayCredentialCanary(t)
 			}
 			var stdout bytes.Buffer
-			var stderr synchronizedBuffer
+			stderr := newSynchronizedBuffer(0)
 			app := App{Stdout: &stdout, Stderr: &stderr}
 			runArgs := []string{"--provider", providerName, "--no-hydrate", "--sync-only"}
 			if mode == "workload-cleanup" {

--- a/internal/cli/tunnel_unix_test.go
+++ b/internal/cli/tunnel_unix_test.go
@@ -63,7 +63,7 @@ PY
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	var stdout synchronizedBuffer
+	stdout := newSynchronizedBuffer(0)
 	done := make(chan error, 1)
 	go func() {
 		done <- runSSHLocalForward(ctx, SSHTarget{User: "alice", Host: "example.test", Port: "22", DisableHostKeyChecking: true}, "", "3000", &stdout)

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -109,7 +109,7 @@ func runWorkspaceOwnerSSHProtocol(ctx context.Context, target SSHTarget, remote 
 	if input != nil {
 		source = bytes.NewReader(input)
 	}
-	var stdout, stderr synchronizedBuffer
+	stdout, stderr := newSynchronizedBuffer(0), newSynchronizedBuffer(0)
 	err = executePreparedSSH(ctx, &target, remote, source, int64(len(input)), sshCommandLimit{execution: workspaceOwnerRemoteTimeout, control: true},
 		workspaceOwnerSSHConnectTimeoutOption, workspaceOwnerSSHConnectionAttemptsOption, &stdout, &stderr)
 	output = strings.TrimSpace(stdout.String())
@@ -222,7 +222,7 @@ func stageWorkspaceOwnerWindowsWitness(ctx context.Context, target SSHTarget, ow
 		cleanup: remoteWorkspaceOwnerWindowsCleanupWitnessCommand(name),
 		name:    name,
 	}
-	var output synchronizedBuffer
+	output := newSynchronizedBuffer(0)
 	if err := runSSHInput(ctx, target, remoteWorkspaceOwnerWindowsStageWitnessCommand(owner.key, owner.token, name, int64(len([]byte(script)))), strings.NewReader(script), &output, &output); err != nil {
 		detail := trimFailureDetail(strings.TrimSpace(output.String()))
 		// The remote write may have succeeded even when its SSH result was lost.


### PR DESCRIPTION
## Summary

Reuse the landed `internal/prefixbuffer` storage owner for SSH capture instead of maintaining another retention algorithm. The SSH wrapper keeps its mutex and snapshot policy: `Bytes` clones while locked, ordinary `Bytes`/`String` hide truncated output, and the bounded diagnostic view retains its prefix and overflow flag.

All eleven production instances use explicit construction, preserving the existing nonpositive-limit unlimited behavior. No nil/lazy initialization or private-zero-value compatibility state is added. The Linux-only fixture initializes its output before publishing command streams. Retry reinitialization still occurs before each execution, after prior stream settlement.

Only storage ownership and construction change. Remote command text, limits, credentials, retries, cancellation, error codes, diagnostic formatting and artifact/workspace acceptance remain unchanged. This follows https://github.com/openclaw/crabbox/pull/1972; line tails, UTF-8 logs, provider artifact buffers and adjacent held transport/acquisition work are not migrated here. Architecture docs and Unreleased reflect this adopter.

## Verification

Base: `01a227d3efa2a9331901c67443e3aea4f5bb3603`; head: `fdff41b0a758b205b5c27a6aa79355f3a90d15fa`; reviewed tree: `8aaec65a6833f4a679080f5cc21af474dd14f81a`.

- New small snapshot/concurrency characterizations passed ten race-enabled repetitions before adoption and ten afterward. They cover explicit finite/unlimited construction, exact fill, hidden truncated snapshots, sticky overflow, full write counts, detached byte snapshots and concurrent access. These are compatibility characterizations, not bug-red claims.
- Independent source audit checked the complete reference map and construction-before-use at every site; non-wrapper code is equivalent after mechanical constructor substitutions.
- Parent races passed: core snapshot tests 2.209s and unchanged leaf tests 1.326s.
- Existing benign local success fixtures passed again in 3.060s: workspace-owner warnings in POSIX/WSL2/native-Windows target modes, shared-output serialization, and quiet Proxmox bootstrap diagnostics. These use task-owned fake SSH scripts; the bootstrap script is inert input. Ambient test-only routing switches were removed before the run. No remote SSH or Proxmox instance was contacted.
- Core vet, CLI build, docs links across 246 Markdown files, and Linux/Windows amd64 test cross-compiles passed. Cross-compilation is not native Linux/Windows execution.
- Independent Codex review is scoped-clean at P0, not an all-priority certification.

No real credentials, provider allocations, tunnel sessions, production faults or expanded large-output scenarios were used in local proof. The older broad Git diagnostic fixture was mechanically updated, not claimed as locally executed. Current-head CI is green and the final merge target is verified.

## Landing verification

All current-head checks completed successfully or were explicitly skipped; the main CI run is https://github.com/openclaw/crabbox/actions/runs/34170942439. No failed-check reruns were needed.

The separate ClawSweeper input-safety notice at https://github.com/openclaw/crabbox/pull/1973#issuecomment-5576765524 produced no review verdict and contains no explicit SHA. It is not counted as review approval. No retry, qualification, withheld-material probing or guard override was attempted. The independently requested managed Codex review completed before that notice and remains scoped-clean at P0 for the reviewed target.
