### PR TITLE
perf(aws): overlap default VPC network discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Unreleased
 
-- Overlap default-VPC and managed security-group discovery during AWS provisioning while retaining scope validation and joined failure handling.
-
+- Overlap default-VPC and managed security-group discovery during AWS provisioning while retaining scope validation and joined failure handling. [PR 1974](https://github.com/openclaw/crabbox/pull/1974). Thanks @steipete.
 - Recover lost run-admission responses using a caller-known identity and an atomic initial history record, preserving authenticated request binding and refusing remote command replay. Current clients require a coordinator supporting the new admission route. [PR 1970](https://github.com/openclaw/crabbox/pull/1970), [Issue 1962](https://github.com/openclaw/crabbox/issues/1962). Thanks @steipete.
 - Add bounded AWS provisioning transport diagnostics for credential preparation, signing and SDK request time, including retry-loop signing counts, without changing retry behavior. [PR 1968](https://github.com/openclaw/crabbox/pull/1968). Thanks @steipete.
 - Islo: report failed stdout/stderr delivery instead of silently succeeding after losing command output; preserve remote exit codes when stream decoding and delivery finish successfully. [PR 1969](https://github.com/openclaw/crabbox/pull/1969).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Overlap default-VPC and managed security-group discovery during AWS provisioning while retaining scope validation and joined failure handling.
+
 - Recover lost run-admission responses using a caller-known identity and an atomic initial history record, preserving authenticated request binding and refusing remote command replay. Current clients require a coordinator supporting the new admission route. [PR 1970](https://github.com/openclaw/crabbox/pull/1970), [Issue 1962](https://github.com/openclaw/crabbox/issues/1962). Thanks @steipete.
 - Add bounded AWS provisioning transport diagnostics for credential preparation, signing and SDK request time, including retry-loop signing counts, without changing retry behavior. [PR 1968](https://github.com/openclaw/crabbox/pull/1968). Thanks @steipete.
 - Islo: report failed stdout/stderr delivery instead of silently succeeding after losing command output; preserve remote exit codes when stream decoding and delivery finish successfully. [PR 1969](https://github.com/openclaw/crabbox/pull/1969).

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -155,6 +155,13 @@ class is `beast`.
 
 ## Provisioning diagnostics
 
+For coordinator-managed groups in the default VPC, VPC discovery and the
+[default-VPC group-name lookup](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html)
+run together. Both reads finish and the returned group scope is checked before
+any ingress change. Subnet-scoped discovery still resolves the subnet's VPC
+first; explicitly configured and private-workspace groups keep their existing
+lookup paths.
+
 Coordinator AWS create logs use the `crabbox_aws_provisioning` component. Each
 fixed operation bucket can include `transport` totals for its signed requests.
 Nested operations own their own totals; concurrent creates and preparation

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -85,6 +85,17 @@ const snapshotDeleteBackoffMs = [1_000, 2_000, 4_000, 8_000, 15_000, 30_000];
 const securityGroupVisibilityBackoffMs = [100, 200, 400, 800, 1_600, 3_200];
 const awsInstanceVisibilityBackoffMs = [1_000, 2_000, 4_000, 8_000, 15_000, 30_000];
 
+class AWSQueryError extends Error {
+  constructor(
+    readonly action: string,
+    readonly status: number,
+    readonly code: string,
+    detail: string,
+  ) {
+    super(`aws ${action}: http ${status}: ${detail}`);
+  }
+}
+
 export interface AWSPrivateWorkspaceConfig {
   accountID: string;
   region: string;
@@ -2377,18 +2388,56 @@ export class EC2SpotClient {
         return groupID;
       }
     } else {
-      const vpcID = await measure("security_group_vpc", () => this.securityGroupVPC(config));
       const name = awsManagedSecurityGroupName(config);
-      const existing = await measure("security_group_lookup", () =>
-        this.ec2("DescribeSecurityGroups", {
-          "Filter.1.Name": "group-name",
-          "Filter.1.Value.1": name,
-          "Filter.2.Name": "vpc-id",
-          "Filter.2.Value.1": vpcID,
-        }),
+      const scopedLookup = Boolean(
+        config.awsSubnetID ||
+        this.env.CRABBOX_AWS_SUBNET_ID ||
+        this.env.CRABBOX_AWS_QUALIFICATION_TRANSPORT,
       );
-      group = items(record(existing["securityGroupInfo"])["item"])[0];
+      const vpc = measure("security_group_vpc", () => this.securityGroupVPC(config));
+      const lookup = (params: Record<string, string>) =>
+        measure("security_group_lookup", () => this.ec2("DescribeSecurityGroups", params));
+      // EC2 GroupName selects only the default VPC. Subnet-scoped queries still
+      // depend on VPC discovery; every mutation waits for both reads and scope validation.
+      const existing = scopedLookup
+        ? vpc.then((vpcID) =>
+            lookup({
+              "Filter.1.Name": "group-name",
+              "Filter.1.Value.1": name,
+              "Filter.2.Name": "vpc-id",
+              "Filter.2.Value.1": vpcID,
+            }),
+          )
+        : lookup({ "GroupName.1": name }).catch((error: unknown): Record<string, unknown> => {
+            if (
+              !(error instanceof AWSQueryError) ||
+              error.action !== "DescribeSecurityGroups" ||
+              error.status !== 400 ||
+              error.code !== "InvalidGroup.NotFound"
+            ) {
+              throw error;
+            }
+            return {};
+          });
+      // Retain the ingress owner until both reads settle, including either failure.
+      // VPC errors keep their existing precedence over security-group lookup errors.
+      const [vpcResult, groupResult] = await Promise.allSettled([vpc, existing]);
+      if (vpcResult.status === "rejected") throw vpcResult.reason;
+      if (groupResult.status === "rejected") throw groupResult.reason;
+      const vpcID = vpcResult.value;
+      const groups = items(record(groupResult.value["securityGroupInfo"])["item"]);
+      group = groups[0];
       groupID = asString(record(group)["groupId"]);
+      if (
+        !scopedLookup &&
+        groups.length > 0 &&
+        (groups.length !== 1 ||
+          !groupID ||
+          asString(record(group)["groupName"]) !== name ||
+          asString(record(group)["vpcId"]) !== vpcID)
+      ) {
+        throw new Error("AWS default VPC security group lookup returned an unexpected group");
+      }
       if (!groupID) {
         try {
           const created = await measure("security_group_create", () =>
@@ -2740,7 +2789,7 @@ export class EC2SpotClient {
     });
     const text = await response.text();
     if (!response.ok) {
-      throw new Error(this.awsQueryErrorMessage(action, response.status, text));
+      throw this.awsQueryError(action, response.status, text);
     }
     const parsed = this.parser.parse(text) as unknown;
     const parsedRecord = record(parsed);
@@ -2760,7 +2809,7 @@ export class EC2SpotClient {
     });
     const text = await response.text();
     if (!response.ok) {
-      throw new Error(this.awsQueryErrorMessage(action, response.status, text));
+      throw this.awsQueryError(action, response.status, text);
     }
     const parsed = this.parser.parse(text) as unknown;
     const parsedRecord = record(parsed);
@@ -2797,8 +2846,9 @@ export class EC2SpotClient {
     return record(text ? JSON.parse(text) : {});
   }
 
-  private awsQueryErrorMessage(action: string, status: number, text: string): string {
+  private awsQueryError(action: string, status: number, text: string): AWSQueryError {
     let detail = "";
+    let code = "";
     try {
       const parsed = this.parser.parse(text) as unknown;
       const parsedRecord = record(parsed);
@@ -2813,13 +2863,14 @@ export class EC2SpotClient {
             record(root["Errors"])["error"],
         )[0],
       );
-      const code = asString(error["Code"] ?? error["code"]);
+      code = asString(error["Code"] ?? error["code"]);
       const message = asString(error["Message"] ?? error["message"]);
       detail = code && message ? `${code}: ${message}` : code || message;
     } catch {
       detail = "";
+      code = "";
     }
-    return `aws ${action}: http ${status}: ${detail || trimBody(text).replace(/\s+/g, " ")}`;
+    return new AWSQueryError(action, status, code, detail || trimBody(text).replace(/\s+/g, " "));
   }
 
   private async appliedServiceQuota(quotaCode: string): Promise<number | undefined> {

--- a/worker/test/aws-default-vpc.test.ts
+++ b/worker/test/aws-default-vpc.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, expect, it, vi } from "vitest";
+
+import { EC2SpotClient } from "../src/aws";
+import { leaseConfig } from "../src/config";
+import type { Env } from "../src/types";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const xml = (body: string, status = 200) =>
+  new Response(body, { status, headers: { "content-type": "text/xml" } });
+
+function response(params: URLSearchParams): Response {
+  switch (params.get("Action")) {
+    case "DescribeVpcs":
+      return xml(
+        "<DescribeVpcsResponse><vpcSet><item><vpcId>vpc-default</vpcId></item></vpcSet></DescribeVpcsResponse>",
+      );
+    case "DescribeSubnets":
+      return xml(
+        "<DescribeSubnetsResponse><subnetSet><item><vpcId>vpc-custom</vpcId></item></subnetSet></DescribeSubnetsResponse>",
+      );
+    case "DescribeSecurityGroups":
+      return xml(
+        `<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-ready</groupId><groupName>crabbox-runners</groupName><vpcId>${params.get("Filter.2.Value.1") || "vpc-default"}</vpcId><ipPermissions /></item></securityGroupInfo></DescribeSecurityGroupsResponse>`,
+      );
+    case "CreateSecurityGroup":
+      return xml(
+        "<CreateSecurityGroupResponse><groupId>sg-created</groupId></CreateSecurityGroupResponse>",
+      );
+    case "AuthorizeSecurityGroupIngress":
+    case "RevokeSecurityGroupIngress":
+      return xml("<Response />");
+    default:
+      throw new Error(`Unexpected fixture action: ${params.get("Action")}`);
+  }
+}
+
+function harness(
+  read: (params: URLSearchParams) => Promise<Response> = async (p) => response(p),
+  env: Partial<Env> = {},
+) {
+  const calls: URLSearchParams[] = [];
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    const params = new URLSearchParams(await request.clone().text());
+    calls.push(params);
+    return read(params);
+  });
+  const client = new EC2SpotClient(
+    { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret", ...env } as Env,
+    "eu-west-1",
+  );
+  const config = leaseConfig({
+    provider: "aws",
+    awsSSHCIDRs: ["198.51.100.42/32"],
+    sshPublicKey: "ssh-ed25519 fixture",
+  });
+  const mutations = () => calls.filter((p) => !p.get("Action")?.startsWith("Describe"));
+  return { client, config, calls, mutations };
+}
+
+it.each([
+  { first: "DescribeVpcs", failure: "" },
+  { first: "DescribeSecurityGroups", failure: "" },
+  { first: "DescribeVpcs", failure: "DescribeVpcs" },
+  { first: "DescribeSecurityGroups", failure: "DescribeVpcs" },
+  { first: "DescribeVpcs", failure: "DescribeSecurityGroups" },
+  { first: "DescribeSecurityGroups", failure: "DescribeSecurityGroups" },
+  { first: "DescribeVpcs", failure: "both" },
+  { first: "DescribeSecurityGroups", failure: "both" },
+])(
+  "overlaps default VPC reads and joins them before mutation or failure ($first/$failure)",
+  async ({ first, failure }) => {
+    const gates = new Map(
+      ["DescribeVpcs", "DescribeSecurityGroups"].map((action) => [
+        action,
+        Promise.withResolvers<void>(),
+      ]),
+    );
+    const entered = new Set<string>();
+    const completed = new Set<string>();
+    const fault = new Error("fixture read failure");
+    const groupFault = new Error("fixture group failure");
+    const { client, config, calls, mutations } = harness(async (params) => {
+      const action = params.get("Action")!;
+      const gate = gates.get(action);
+      if (gate) {
+        entered.add(action);
+        await gate.promise;
+        completed.add(action);
+        if (action === failure) throw fault;
+        if (failure === "both") throw action === "DescribeVpcs" ? fault : groupFault;
+      }
+      return response(params);
+    });
+    let settled = false;
+    const refreshing = client.refreshSSHIngress(config).then(
+      () => {
+        settled = true;
+        return undefined;
+      },
+      (error: unknown) => {
+        settled = true;
+        return error;
+      },
+    );
+    try {
+      await vi.waitFor(() => expect(entered.size).toBe(2));
+      expect(mutations()).toEqual([]);
+      gates.get(first)!.resolve();
+      await vi.waitFor(() => expect(completed.has(first)).toBe(true));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(settled).toBe(false);
+      expect(mutations()).toEqual([]);
+      for (const gate of gates.values()) gate.resolve();
+      expect(await refreshing).toBe(failure ? fault : undefined);
+      expect(mutations().length > 0).toBe(!failure);
+      const groupRead = calls.find((p) => p.get("Action") === "DescribeSecurityGroups")!;
+      expect(groupRead.get("GroupName.1")).toBe("crabbox-runners");
+      expect(groupRead.has("Filter.2.Value.1")).toBe(false);
+    } finally {
+      for (const gate of gates.values()) gate.resolve();
+      await refreshing;
+    }
+  },
+);
+
+it.each(["vpc", "name", "id", "multiple"])(
+  "rejects a default group with an unexpected %s before changing ingress",
+  async (field) => {
+    const group = `<item><groupId>${field === "id" ? "" : "sg-other"}</groupId><groupName>${field === "name" ? "other" : "crabbox-runners"}</groupName><vpcId>${field === "vpc" ? "vpc-other" : "vpc-default"}</vpcId></item>`;
+    const { client, config, mutations } = harness(async (p) =>
+      p.get("Action") === "DescribeSecurityGroups"
+        ? xml(
+            `<DescribeSecurityGroupsResponse><securityGroupInfo>${group}${field === "multiple" ? group : ""}</securityGroupInfo></DescribeSecurityGroupsResponse>`,
+          )
+        : response(p),
+    );
+    await expect(client.refreshSSHIngress(config)).rejects.toThrow("unexpected group");
+    expect(mutations()).toEqual([]);
+  },
+);
+
+it("requires an actual default VPC even when the name lookup succeeds", async () => {
+  const { client, config, mutations } = harness(async (p) =>
+    p.get("Action") === "DescribeVpcs"
+      ? xml("<DescribeVpcsResponse><vpcSet /></DescribeVpcsResponse>")
+      : response(p),
+  );
+  await expect(client.refreshSSHIngress(config)).rejects.toThrow("no default VPC found");
+  expect(mutations()).toEqual([]);
+});
+
+it("creates a missing named group in the discovered default VPC", async () => {
+  const { client, config, calls, mutations } = harness(async (p) =>
+    p.get("Action") === "DescribeSecurityGroups"
+      ? xml(
+          "<Response><Errors><Error><Code>InvalidGroup.NotFound</Code><Message>fixture missing group</Message></Error></Errors></Response>",
+          400,
+        )
+      : response(p),
+  );
+  await client.refreshSSHIngress(config);
+  const create = calls.find((p) => p.get("Action") === "CreateSecurityGroup")!;
+  expect(create.get("VpcId")).toBe("vpc-default");
+  expect(create.get("GroupName")).toBe("crabbox-runners");
+  expect(
+    mutations()
+      .filter((p) => p.get("GroupId"))
+      .every((p) => p.get("GroupId") === "sg-created"),
+  ).toBe(true);
+});
+
+it.each(["UnauthorizedOperation", "InvalidGroupId.Malformed"])(
+  "preserves a named-group %s even when its message mentions NotFound",
+  async (code) => {
+    const { client, config, mutations } = harness(async (p) =>
+      p.get("Action") === "DescribeSecurityGroups"
+        ? xml(
+            `<Response><Errors><Error><Code>${code}</Code><Message>fixture mentions InvalidGroup.NotFound</Message></Error></Errors></Response>`,
+            400,
+          )
+        : response(p),
+    );
+    await expect(client.refreshSSHIngress(config)).rejects.toThrow(code);
+    expect(mutations()).toEqual([]);
+  },
+);
+
+it("does not treat an unstructured error body as a missing-group code", async () => {
+  const { client, config, mutations } = harness(async (p) =>
+    p.get("Action") === "DescribeSecurityGroups" ? xml("InvalidGroup.NotFound", 400) : response(p),
+  );
+  await expect(client.refreshSSHIngress(config)).rejects.toThrow("InvalidGroup.NotFound");
+  expect(mutations()).toEqual([]);
+});
+
+it.each(["config", "environment"])(
+  "keeps a %s subnet's group lookup dependent on its VPC",
+  async (source) => {
+    const gate = Promise.withResolvers<void>();
+    let entered = false;
+    const { client, config, calls, mutations } = harness(
+      async (p) => {
+        if (p.get("Action") === "DescribeSubnets") {
+          entered = true;
+          await gate.promise;
+        }
+        return response(p);
+      },
+      source === "environment" ? { CRABBOX_AWS_SUBNET_ID: "subnet-custom" } : {},
+    );
+    const refresh = client.refreshSSHIngress(
+      source === "config" ? { ...config, awsSubnetID: "subnet-custom" } : config,
+    );
+    try {
+      await vi.waitFor(() => expect(entered).toBe(true));
+      expect(calls.map((p) => p.get("Action"))).toEqual(["DescribeSubnets"]);
+      expect(mutations()).toEqual([]);
+      gate.resolve();
+      await refresh;
+      const groupRead = calls.find((p) => p.get("Action") === "DescribeSecurityGroups")!;
+      expect(groupRead.get("Filter.2.Value.1")).toBe("vpc-custom");
+      expect(groupRead.has("GroupName.1")).toBe(false);
+    } finally {
+      gate.resolve();
+      await refresh;
+    }
+  },
+);

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -654,9 +654,9 @@ describe("aws provider", () => {
         }
         if (action === "DescribeSecurityGroups") {
           describedGroupID = params.get("GroupId.1") ?? "";
-          describedGroupName = params.get("Filter.1.Value.1") ?? "";
+          describedGroupName = params.get("GroupName.1") ?? "";
           return ec2XMLResponse(
-            "<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-workspaces</groupId><groupName>crabbox-workspaces</groupName><ipPermissions /></item></securityGroupInfo></DescribeSecurityGroupsResponse>",
+            "<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-workspaces</groupId><groupName>crabbox-workspaces</groupName><vpcId>vpc-default</vpcId><ipPermissions /></item></securityGroupInfo></DescribeSecurityGroupsResponse>",
           );
         }
         if (action === "RevokeSecurityGroupIngress") {
@@ -715,8 +715,9 @@ describe("aws provider", () => {
           describeSecurityGroups += 1;
           return ec2XMLResponse(
             describeSecurityGroups === 1
-              ? "<DescribeSecurityGroupsResponse><securityGroupInfo /></DescribeSecurityGroupsResponse>"
+              ? "<Response><Errors><Error><Code>InvalidGroup.NotFound</Code><Message>not yet visible</Message></Error></Errors></Response>"
               : "<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-raced</groupId><ipPermissions /></item></securityGroupInfo></DescribeSecurityGroupsResponse>",
+            describeSecurityGroups === 1 ? 400 : 200,
           );
         }
         if (action === "CreateSecurityGroup") {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -25137,7 +25137,7 @@ describe("fleet lease identity and idle", () => {
         }
         if (action === "DescribeSecurityGroups") {
           return new Response(`<?xml version="1.0" encoding="UTF-8"?>
-<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-shared</groupId><ipPermissions><item><ipProtocol>tcp</ipProtocol><fromPort>22</fromPort><toPort>22</toPort><ipRanges><item><cidrIp>198.51.100.10/32</cidrIp><description>Crabbox SSH</description></item><item><cidrIp>198.51.100.20/32</cidrIp><description>Crabbox SSH</description></item></ipRanges></item></ipPermissions></item></securityGroupInfo></DescribeSecurityGroupsResponse>`);
+<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-shared</groupId><groupName>crabbox-runners</groupName><vpcId>vpc-default</vpcId><ipPermissions><item><ipProtocol>tcp</ipProtocol><fromPort>22</fromPort><toPort>22</toPort><ipRanges><item><cidrIp>198.51.100.10/32</cidrIp><description>Crabbox SSH</description></item><item><cidrIp>198.51.100.20/32</cidrIp><description>Crabbox SSH</description></item></ipRanges></item></ipPermissions></item></securityGroupInfo></DescribeSecurityGroupsResponse>`);
         }
         if (action === "RevokeSecurityGroupIngress") {
           revokedCIDRs.push(params.get("IpPermissions.1.IpRanges.1.CidrIp") ?? "");
@@ -25203,7 +25203,7 @@ describe("fleet lease identity and idle", () => {
         }
         if (action === "DescribeSecurityGroups") {
           return new Response(`<?xml version="1.0" encoding="UTF-8"?>
-<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-auto</groupId><groupName>crabbox-runners</groupName><ipPermissions><item><ipProtocol>tcp</ipProtocol><fromPort>22</fromPort><toPort>22</toPort><ipRanges><item><cidrIp>198.51.100.10/32</cidrIp><description>Crabbox SSH</description></item><item><cidrIp>198.51.100.20/32</cidrIp><description>Crabbox SSH</description></item></ipRanges></item></ipPermissions></item></securityGroupInfo></DescribeSecurityGroupsResponse>`);
+<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-auto</groupId><groupName>crabbox-runners</groupName><vpcId>vpc-default</vpcId><ipPermissions><item><ipProtocol>tcp</ipProtocol><fromPort>22</fromPort><toPort>22</toPort><ipRanges><item><cidrIp>198.51.100.10/32</cidrIp><description>Crabbox SSH</description></item><item><cidrIp>198.51.100.20/32</cidrIp><description>Crabbox SSH</description></item></ipRanges></item></ipPermissions></item></securityGroupInfo></DescribeSecurityGroupsResponse>`);
         }
         if (action === "RevokeSecurityGroupIngress") {
           revokedCIDRs.push(params.get("IpPermissions.1.IpRanges.1.CidrIp") ?? "");
@@ -25257,14 +25257,14 @@ describe("fleet lease identity and idle", () => {
           );
         }
         if (action === "DescribeSecurityGroups") {
-          const groupName = params.get("Filter.1.Value.1") ?? "";
+          const groupName = params.get("GroupName.1") ?? "";
           const groupID = groupName === "crabbox-workspaces" ? "sg-workspaces" : "sg-runners";
           const ingress =
             groupName === "crabbox-runners"
               ? "<ipPermissions><item><ipProtocol>tcp</ipProtocol><fromPort>22</fromPort><toPort>22</toPort><ipRanges><item><cidrIp>198.51.100.10/32</cidrIp><description>Crabbox SSH</description></item><item><cidrIp>198.51.100.20/32</cidrIp><description>Crabbox SSH</description></item></ipRanges></item></ipPermissions>"
               : "<ipPermissions />";
           return new Response(
-            `<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>${groupID}</groupId><groupName>${groupName}</groupName>${ingress}</item></securityGroupInfo></DescribeSecurityGroupsResponse>`,
+            `<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>${groupID}</groupId><groupName>${groupName}</groupName><vpcId>vpc-default</vpcId>${ingress}</item></securityGroupInfo></DescribeSecurityGroupsResponse>`,
           );
         }
         if (action === "RevokeSecurityGroupIngress") {


### PR DESCRIPTION
Default AWS provisioning resolves the default VPC and then looks up the managed security group, so both read latencies are paid in series. In an observed slow provisioning run these two reads took about seven seconds each, without SDK retry-loop re-entry.

Use EC2's documented default-VPC `GroupName` query alongside VPC discovery. Join both reads before mutation or failure, preserve VPC-error precedence, and verify the returned group ID, name and VPC before changing ingress. Configured subnets retain their VPC-filtered lookup; explicit groups, private workspaces, qualification transport, duplicate-creation recovery and ingress mutation order retain their existing behavior.

The existing AWS query decoder now retains its action, HTTP status and parsed error code while preserving its error text. Only an actual `DescribeSecurityGroups` HTTP400 `InvalidGroup.NotFound` result means the managed group may need creation; an error message or unstructured body mentioning that code does not qualify.

No schema, stored state, configuration option, credential policy, timeout or SDK retry change.

Validation:

- Six initial concurrency regressions failed on unchanged main because only the VPC read started. The repaired tests cover both completion orders and joined failures, including deterministic VPC-error precedence.
- Nineteen focused cases cover overlap, malformed/wrong group scope, no default VPC, missing-group creation, error-code handling and unchanged subnet ordering.
- Full Worker suite: 2,891 passed, three skipped. Existing private/qualification, creation-race, ingress reconciliation and cleanup coverage passed. Three Fleet response fixtures now include the real API's group-name/VPC fields; their cleanup assertions are unchanged.
- Worker and Node type checks, lint, formatting, normal Worker/Node builds and docs build passed.
- Direct source review checked the caller's ingress fence, both lookup contracts, failure lifetime and the unchanged mutation/cleanup paths.

The runtime delta is +51 lines for joined preparation, scope validation and structured provider error facts; tests add 234 net lines. No new testing-only production seam.

API contracts: [DescribeSecurityGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html), [EC2 error codes](https://docs.aws.amazon.com/ec2/latest/devguide/errors-overview.html).

Live validation against deployed candidate `c274890fb210f55044134a8b0b1667f96b4399a2` passed through the ordinary CLI: public AWS warmup, ready inspection, `uname -s` returning Linux, signed execution receipt, Stop and canonical released/cleanup-complete status. No source upload was used. The local configuration was unchanged, all owned processes joined and exited, and the SSH control directory was absent after cleanup. The official Wrangler tail was also stopped and joined.

The actual provisioning record reported 61.275 seconds total. The default-VPC and group reads each recorded 10.927 seconds, with their combined phase occupying 10.927 seconds rather than their sum: the security-group total was 47.032 seconds, comprising that joined read phase, 9.188 seconds of revocation and 26.917 seconds of authorization. This confirms overlap in the real API path; one sample does not establish an overall before/after cloud speedup. Six authorization requests returned duplicate-rule responses, which remain a separate measured follow-up. Warmup took 111.456 seconds; the existing-machine runner took 12.315 seconds.

Candidate deployment: https://github.com/openclaw/crabbox/actions/runs/34176228258. Required Release Check passed: https://github.com/openclaw/crabbox/actions/runs/34175955014. Full CI: https://github.com/openclaw/crabbox/actions/runs/34175955060 (all jobs passed).
