### PR TITLE
fix(aws): recover legacy cleanup from original allocation evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,43 @@ jobs:
       - name: Build Node runtime image
         run: docker build -f worker/Dockerfile.node worker
 
+  worker-postgres-recovery:
+    name: AWS recovery PostgreSQL integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      postgres:
+        # Docker Official Image; PostgreSQL 17 satisfies the supported 13+ runtime contract.
+        image: postgres:17-bookworm@sha256:051f7b7b3abdd564d5d1bd1e8c4b9c1b6e77087d1dd22020ede611c096a272e0
+        env:
+          POSTGRES_USER: crabbox_test
+          POSTGRES_PASSWORD: crabbox-test-only
+          POSTGRES_DB: crabbox_recovery_test
+        ports:
+          - 55432:5432
+        options: >-
+          --health-cmd "pg_isready -U crabbox_test -d crabbox_recovery_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: worker/package-lock.json
+      - name: Install existing dependencies
+        run: npm ci
+        working-directory: worker
+      - name: Prove recovery rollback, reopen, and scoped-lease coexistence
+        run: npm exec -- vitest run --config vitest.postgres.config.ts
+        working-directory: worker
+
   scripts:
     name: Scripts
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,10 @@ jobs:
         run: npm run build
         working-directory: worker
 
+      - name: Build container-backed Cloudflare runtime
+        run: npm run build:cloudflare
+        working-directory: worker
+
       - name: Build Cloudflare Dynamic Workers
         run: npm run build:cloudflare-dynamic-workers
         working-directory: worker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,10 +351,6 @@ jobs:
         run: npm run build
         working-directory: worker
 
-      - name: Build container-backed Cloudflare runtime
-        run: npm run build:cloudflare
-        working-directory: worker
-
       - name: Build Cloudflare Dynamic Workers
         run: npm run build:cloudflare-dynamic-workers
         working-directory: worker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- AWS: add administrator-only legacy cleanup recovery backed by authenticated original CloudTrail allocation evidence, preserving remaining key and access cleanup and recording an atomic scope-recovery audit without force-success. [PR 1975](https://github.com/openclaw/crabbox/pull/1975).
 - AWS: complete cleanup after a verified empty instance response without skipping owned keys, bind new leases to the original account and Region, and retain unresolved historical cleanup when that authority is missing. [PR 1904](https://github.com/openclaw/crabbox/pull/1904). Thanks @vincentkoc.
 
 ## 0.57.0 - 2026-09-11

--- a/docs/commands/inspect.md
+++ b/docs/commands/inspect.md
@@ -250,6 +250,53 @@ claim; consult `recoveryAudit` for its basis. It is still not deletion authority
 Orphan/provisioning continuation paths cannot replace the recovered baseline;
 only ordinary release consumes this recovery.
 
+### Audited legacy AWS cleanup recovery
+
+An administrator can recover the original account scope of an expired, released
+AWS lease whose instance is already absent. Use the existing authenticated
+`GET /v1/leases/{id}/cleanup` and `POST /v1/leases/{id}/cleanup` API, with the
+canonical lease ID. Ordinary owners, shares, and device credentials cannot use
+AWS scope recovery. This does not add a CLI flag or a force-success override.
+
+Recovery requires explicit `releaseDeletesServer: true`. The acquisition's
+`keep` default can remain true after an explicit delete request; recovery does
+not change that flag. A retained disposition (`releaseDeletesServer: false`) or
+missing delete intent refuses recovery, including if it changes during inspection.
+
+Inspection requires a retained instance ID, Region, creation and release times,
+and the canonical owned SSH key. It reads CloudTrail `LookupEvents` in that
+Region using the same fixed credentials as STS and the exact EC2 observation.
+One successful original `RunInstances` event must bind the instance to the
+recorded lease labels, owner, slug, and key. Both its `keyName` request field
+and creation-time `provider_key` instance tag must match the canonical key.
+Its recipient account and Region must match the authenticated observation. Current credentials or an empty EC2
+lookup alone do not establish the original account.
+
+CloudTrail event history is limited to 90 days. Lookup is bounded to ten pages
+and 2 MiB, and incomplete pagination, malformed or truncated events, conflicting
+identities, missing evidence, denied permissions, and transport failures all
+refuse recovery. Crabbox does not add IAM permissions, accept pasted event
+JSON, or fall back to inference. The response contains only the proposed scope,
+event ID and time, an unchanged-binding indicator, and a claim fingerprint;
+raw event bodies and bootstrap data are never returned or retained.
+
+After reviewing an inspection with `claimUnchanged: true`, send the same
+`acknowledge-missing-resource` request shown above with its `claimFingerprint`.
+The administrator acknowledgement selects the recovery; it is not evidence.
+Crabbox rereads authoritative allocation evidence and confirms exact current
+instance absence. Immediately before committing, it rechecks administrator
+access, the unchanged lease binding, and the absence of active cleanup or
+provisioning owners.
+
+One existing-store transaction restores `providerScope`, records a bounded
+provider-specific audit, resolves only the proven instance-existence uncertainty,
+and schedules ordinary cleanup. It does not record `cleanupCompletedAt`, erase
+errors or access evidence, or delete resources. Normal cleanup still verifies
+the bound account and Region and must finish remaining owned-key and access
+cleanup before reporting completion. Failed key deletion retains the lease and
+local recovery artifacts. Repeating an acknowledged fingerprint returns its
+existing audit rather than rewriting the original allocation evidence.
+
 ### Additional provider metadata
 
 For coordinator leases whose provider can inject an SSH host key before first

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -740,8 +740,11 @@ credentials between operations. Empty inventory can complete direct cleanup
 only for leases that persisted the matching 12-digit account scope and explicit
 Region. Historical unbound leases remain cleanupable when the instance is still
 present with exact Crabbox lease labels, but an empty lookup is intentionally
-inconclusive. There is no override that turns missing account or Region evidence
-into proof of deletion.
+inconclusive. Administrators can use [audited legacy AWS recovery](commands/inspect.md#audited-legacy-aws-cleanup-recovery)
+when authenticated CloudTrail allocation evidence proves the original scope and
+an exact current read confirms absence. It restores scope and schedules normal
+remaining cleanup, not a deletion receipt. There is no override that turns
+missing account or Region evidence into proof of deletion.
 
 After AWS credential or account rotation, scan old provider accounts directly
 for Crabbox-tagged EC2 instances that the current coordinator can no longer see:

--- a/worker/src/aws-cleanup-recovery.ts
+++ b/worker/src/aws-cleanup-recovery.ts
@@ -1,0 +1,322 @@
+import { sha256Hex } from "./auth";
+import { sanitizeAWSRegion } from "./aws-region";
+import { providerKeyForLease } from "./provider-key";
+import { providerLabelsOwnedByLease } from "./provider-labels";
+import { ProviderResourceUnresolvedError } from "./provider-provisioning";
+import type { LeaseRecord } from "./types";
+
+export interface AWSLegacyCleanupAudit {
+  leaseID: string;
+  region: string;
+  providerScope: string;
+  cloudID: string;
+  eventID: string;
+  eventTime: string;
+  actor: string;
+  recoveredAt: string;
+  claimFingerprint: string;
+}
+
+export type AWSLegacyAllocationEvidence = Pick<
+  AWSLegacyCleanupAudit,
+  "region" | "providerScope" | "eventID" | "eventTime"
+>;
+
+const eventHistoryMs = 90 * 24 * 60 * 60_000;
+const maxLookupPages = 10;
+const maxLookupBytes = 2 * 1024 * 1024;
+
+export function awsCleanupRecoveryAuditKey(leaseID: string): string {
+  return `aws-cleanup-recovery-audit:${leaseID}`;
+}
+
+// Exclude mutable cleanup/access progress so the audit remains bound after normal cleanup.
+export function awsCleanupRecoveryFingerprint(lease: LeaseRecord): Promise<string> {
+  return sha256Hex(
+    JSON.stringify([
+      lease.id,
+      lease.provider,
+      lease.lifecycle,
+      lease.cloudID,
+      lease.region,
+      lease.owner,
+      lease.org,
+      lease.providerOwner,
+      lease.slug,
+      lease.createdAt,
+      lease.providerKey,
+      lease.providerKeyCleanupOwned,
+      lease.hostId,
+      lease.hostID,
+      lease.createAttemptID,
+      lease.createAttemptGeneration,
+    ]),
+  );
+}
+
+export function requireAWSLegacyCleanupLease(lease: LeaseRecord): void {
+  if (
+    lease.provider !== "aws" ||
+    lease.lifecycle === "registered" ||
+    !/^cbx_[a-f0-9]{12}$/.test(lease.id) ||
+    !/^i-[a-f0-9]{8,17}$/.test(lease.cloudID) ||
+    !lease.region ||
+    sanitizeAWSRegion(lease.region) !== lease.region ||
+    lease.providerScope != null ||
+    lease.state !== "released" ||
+    // Explicit release deletion supersedes the acquisition's default retention flag.
+    lease.releaseDeletesServer !== true ||
+    lease.cleanupStartedAt ||
+    lease.provisioningRequestStartedAt ||
+    lease.cleanupCompletedAt ||
+    !lease.cleanupError ||
+    !(Date.parse(lease.expiresAt) <= Date.now()) ||
+    lease.providerKey !== providerKeyForLease(lease.id) ||
+    lease.providerKeyCleanupOwned !== true
+  ) {
+    throw new ProviderResourceUnresolvedError(
+      "AWS scope recovery requires an expired, released legacy lease with exact instance, Region, owned key, and no active cleanup or allocation",
+    );
+  }
+}
+
+export async function awsCleanupAuditMatchesLease(
+  audit: AWSLegacyCleanupAudit,
+  lease: LeaseRecord,
+): Promise<boolean> {
+  return (
+    audit.leaseID === lease.id &&
+    audit.cloudID === lease.cloudID &&
+    audit.region === lease.region &&
+    audit.providerScope === lease.providerScope &&
+    /^aws:account:\d{12}$/.test(audit.providerScope) &&
+    /^[a-f0-9-]{36}$/.test(audit.eventID) &&
+    Number.isFinite(Date.parse(audit.eventTime)) &&
+    Number.isFinite(Date.parse(audit.recoveredAt)) &&
+    typeof audit.actor === "string" &&
+    audit.actor.trim().length > 0 &&
+    audit.actor.length <= 256 &&
+    audit.claimFingerprint === (await awsCleanupRecoveryFingerprint(lease))
+  );
+}
+
+export function awsCleanupAuditView(audit: AWSLegacyCleanupAudit): AWSLegacyCleanupAudit {
+  return {
+    leaseID: audit.leaseID,
+    region: audit.region,
+    providerScope: audit.providerScope,
+    cloudID: audit.cloudID,
+    eventID: audit.eventID,
+    eventTime: audit.eventTime,
+    actor: audit.actor,
+    recoveredAt: audit.recoveredAt,
+    claimFingerprint: audit.claimFingerprint,
+  };
+}
+
+export async function lookupAWSLegacyAllocation(
+  lease: LeaseRecord,
+  account: string,
+  fetch: (input: string, init: RequestInit) => Promise<Response>,
+): Promise<AWSLegacyAllocationEvidence> {
+  requireAWSLegacyCleanupLease(lease);
+  const start = Math.floor(Date.parse(lease.createdAt) / 1000) * 1000;
+  const end = Date.parse(lease.releasedAt ?? lease.endedAt ?? "");
+  if (
+    !/^\d{12}$/.test(account) ||
+    !Number.isFinite(start) ||
+    !Number.isFinite(end) ||
+    start < Date.now() - eventHistoryMs ||
+    end < start ||
+    end > Date.now()
+  ) {
+    throw new ProviderResourceUnresolvedError(
+      "AWS scope recovery requires an original allocation interval within CloudTrail's 90-day event history",
+    );
+  }
+  const body = {
+    LookupAttributes: [{ AttributeKey: "ResourceName", AttributeValue: lease.cloudID }],
+    StartTime: start / 1000,
+    EndTime: end / 1000,
+    MaxResults: 50,
+  };
+  const evidence = new Map<string, AWSLegacyAllocationEvidence>();
+  const tokens = new Set<string>();
+  let nextToken: string | undefined;
+  let remainingBytes = maxLookupBytes;
+  for (let page = 0; page < maxLookupPages; page++) {
+    // oxlint-disable-next-line eslint/no-await-in-loop -- CloudTrail pagination must retain one exact lookup and credential snapshot.
+    const response = await fetch(`https://cloudtrail.${lease.region}.amazonaws.com/`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-amz-json-1.1",
+        "x-amz-target": "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.LookupEvents",
+      },
+      body: JSON.stringify({ ...body, ...(nextToken ? { NextToken: nextToken } : {}) }),
+      signal: AbortSignal.timeout(15_000),
+    }).catch(() => {
+      throw new ProviderResourceUnresolvedError(
+        "AWS CloudTrail lookup could not be completed; no scope was recovered",
+      );
+    });
+    if (!response.ok) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- Close the failed page before refusing this serial evidence lookup.
+      await response.body?.cancel();
+      // CloudTrail errors and event payloads can contain credentials or user data; never echo them.
+      throw new ProviderResourceUnresolvedError(
+        `AWS CloudTrail LookupEvents failed (HTTP ${response.status}); verify existing read permission and original account evidence`,
+      );
+    }
+    // oxlint-disable-next-line eslint/no-await-in-loop -- Each response is bounded before its next page is admitted.
+    const payload = await readLookupResponse(response, remainingBytes);
+    remainingBytes -= payload.bytes;
+    const result = record(payload.value);
+    if (!Array.isArray(result["Events"]) || result["Events"].length > 50) invalidEvidence();
+    for (const value of result["Events"]) {
+      const summary = record(value);
+      if (summary["EventName"] !== "RunInstances") continue;
+      const observed = allocationEvidence(summary, lease, account, start, end);
+      const previous = evidence.get(observed.eventID);
+      if (previous && JSON.stringify(previous) !== JSON.stringify(observed)) invalidEvidence();
+      evidence.set(observed.eventID, observed);
+    }
+    if (result["NextToken"] === undefined || result["NextToken"] === "") {
+      if (evidence.size !== 1) {
+        throw new ProviderResourceUnresolvedError(
+          "AWS CloudTrail did not establish one unambiguous original allocation; no scope was recovered",
+        );
+      }
+      return evidence.values().next().value!;
+    }
+    if (
+      typeof result["NextToken"] !== "string" ||
+      result["NextToken"].length > 16_384 ||
+      tokens.has(result["NextToken"])
+    )
+      invalidEvidence();
+    nextToken = result["NextToken"];
+    tokens.add(nextToken);
+    // oxlint-disable-next-line eslint/no-await-in-loop -- CloudTrail permits two lookups per second per account and Region.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new ProviderResourceUnresolvedError(
+    "AWS CloudTrail lookup exceeded the bounded evidence window; no scope was recovered",
+  );
+}
+
+function allocationEvidence(
+  summary: Record<string, unknown>,
+  lease: LeaseRecord,
+  account: string,
+  start: number,
+  end: number,
+): AWSLegacyAllocationEvidence {
+  if (typeof summary["CloudTrailEvent"] !== "string") invalidEvidence();
+  let event: Record<string, unknown>;
+  try {
+    event = record(JSON.parse(summary["CloudTrailEvent"]));
+  } catch {
+    return invalidEvidence();
+  }
+  const eventTime = typeof event["eventTime"] === "string" ? Date.parse(event["eventTime"]) : NaN;
+  const response = record(event["responseElements"]);
+  const instances = record(response["instancesSet"])["items"];
+  const request = record(event["requestParameters"]);
+  const specifications = record(request["tagSpecificationSet"])["items"];
+  if (
+    event["eventName"] !== "RunInstances" ||
+    event["eventSource"] !== "ec2.amazonaws.com" ||
+    event["eventType"] !== "AwsApiCall" ||
+    event["errorCode"] ||
+    event["errorMessage"] ||
+    event["recipientAccountId"] !== account ||
+    event["awsRegion"] !== lease.region ||
+    typeof event["eventID"] !== "string" ||
+    !/^[a-f0-9-]{36}$/.test(event["eventID"]) ||
+    summary["EventId"] !== event["eventID"] ||
+    summary["EventSource"] !== event["eventSource"] ||
+    !Number.isFinite(eventTime) ||
+    eventTime < start ||
+    eventTime > end ||
+    !Array.isArray(instances) ||
+    instances.length !== 1 ||
+    record(instances[0])["instanceId"] !== lease.cloudID ||
+    request["keyName"] !== lease.providerKey ||
+    !Array.isArray(specifications)
+  )
+    invalidEvidence();
+  const instanceSpecifications = specifications
+    .map(record)
+    .filter((item) => item["resourceType"] === "instance");
+  if (instanceSpecifications.length !== 1) invalidEvidence();
+  const tags = instanceSpecifications[0]!["tags"];
+  if (!Array.isArray(tags) || tags.length > 100) invalidEvidence();
+  const labels: Record<string, string> = Object.create(null) as Record<string, string>;
+  for (const value of tags) {
+    const tag = record(value);
+    if (
+      typeof tag["key"] !== "string" ||
+      typeof tag["value"] !== "string" ||
+      Object.hasOwn(labels, tag["key"])
+    )
+      invalidEvidence();
+    labels[tag["key"]] = tag["value"];
+  }
+  if (
+    !providerLabelsOwnedByLease(labels, lease, "aws") ||
+    labels["provider_key"] !== lease.providerKey
+  )
+    invalidEvidence();
+  return {
+    region: lease.region!,
+    providerScope: `aws:account:${account}`,
+    eventID: event["eventID"],
+    eventTime: new Date(eventTime).toISOString(),
+  };
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function invalidEvidence(): never {
+  throw new ProviderResourceUnresolvedError(
+    "AWS CloudTrail allocation evidence is incomplete or conflicts with the retained lease; no scope was recovered",
+  );
+}
+
+async function readLookupResponse(
+  response: Response,
+  limit: number,
+): Promise<{ value: unknown; bytes: number }> {
+  if (!response.body || limit <= 0) invalidEvidence();
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let bytes = 0;
+  try {
+    while (true) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- Bound the streamed CloudTrail response before JSON parsing.
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      bytes += chunk.value.byteLength;
+      if (bytes > limit) invalidEvidence();
+      chunks.push(chunk.value);
+    }
+  } finally {
+    await reader.cancel();
+    reader.releaseLock();
+  }
+  const data = new Uint8Array(bytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    data.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return { value: JSON.parse(new TextDecoder().decode(data)), bytes };
+  } catch {
+    return invalidEvidence();
+  }
+}

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -1,6 +1,10 @@
 import { XMLParser, XMLValidator } from "fast-xml-parser";
 
 import {
+  lookupAWSLegacyAllocation,
+  type AWSLegacyAllocationEvidence,
+} from "./aws-cleanup-recovery";
+import {
   FixedAWSFetchClient,
   RefreshingAWSFetchClient,
   resolvedAWSCredentials,
@@ -48,6 +52,7 @@ import type {
   ProviderImage,
   ProviderCheckpointOwnership,
   LeaseImageIdentity,
+  LeaseRecord,
   ProviderMachine,
   ProviderAccessTimingObserver,
   ProvisioningAttempt,
@@ -763,7 +768,7 @@ export class EC2SpotClient {
   constructor(
     private readonly env: Env,
     region: string,
-    credentialSnapshot?: ResolvedAWSCredentials,
+    private readonly credentialSnapshot?: ResolvedAWSCredentials,
   ) {
     this.region = requireAWSRegion(region || env.CRABBOX_AWS_REGION || "eu-west-1");
     const expected = awsExpectedIdentityConfig(env);
@@ -803,6 +808,21 @@ export class EC2SpotClient {
       this.stsClient = new RefreshingAWSFetchClient(credentials, "sts", this.region);
       this.ssmClient = new RefreshingAWSFetchClient(credentials, "ssm", this.region);
     }
+  }
+
+  async legacyAllocationEvidence(
+    lease: LeaseRecord,
+    account: string,
+  ): Promise<AWSLegacyAllocationEvidence> {
+    if (!this.credentialSnapshot || this.env.CRABBOX_AWS_QUALIFICATION_TRANSPORT) {
+      throw new AWSLeaseAuthorityError(
+        "AWS scope recovery requires a fixed direct-provider credential snapshot",
+      );
+    }
+    const cloudtrail = new FixedAWSFetchClient(this.credentialSnapshot, "cloudtrail", this.region);
+    return lookupAWSLegacyAllocation(lease, account, (input, init) =>
+      cloudtrail.fetch(input, init),
+    );
   }
 
   async withLeaseOperation<T>(operation: (session: AWSLeaseOperation) => Promise<T>): Promise<T> {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -70,6 +70,14 @@ import {
   type AWSIngressConfig,
   type AWSPrivateWorkspaceConfig,
 } from "./aws";
+import {
+  awsCleanupAuditMatchesLease,
+  awsCleanupAuditView,
+  awsCleanupRecoveryAuditKey,
+  awsCleanupRecoveryFingerprint,
+  requireAWSLegacyCleanupLease,
+  type AWSLegacyCleanupAudit,
+} from "./aws-cleanup-recovery";
 import { InvalidAWSRegionError, sanitizeAWSRegion } from "./aws-region";
 import {
   AzureClient,
@@ -7194,7 +7202,61 @@ export class FleetCoordinator {
       lease.createAttemptID,
       lease.createAttemptGeneration,
       lease.lifecycle,
+      lease.slug,
+      lease.providerOwner,
+      lease.providerKey,
+      lease.providerKeyCleanupOwned,
+      lease.hostId,
+      lease.hostID,
     ]);
+  }
+
+  private async commitRecoveredLeaseScope<T>(
+    request: Request,
+    leaseID: string,
+    expectedBinding: string,
+    observation: { providerScope: string; resourceAbsent: true },
+    persistAudit: (transaction: CoordinatorStorageView) => Promise<T>,
+  ): Promise<T> {
+    const runtime = this.state.provisioning;
+    if (!runtime)
+      throw new ProviderResourceUnresolvedError("Atomic cleanup recovery is unavailable");
+    return this.state.runExclusive(() =>
+      runtime.commitAndWake(async (transaction) => {
+        const current = await transaction.get<LeaseRecord>(leaseKey(leaseID));
+        if (
+          !isAdminRequest(request) ||
+          requestAuthType(request) === "device" ||
+          !current ||
+          this.cleanupRecoveryLeaseBinding(current) !== expectedBinding ||
+          !this.cleanupRecoveryLeaseEligible(current) ||
+          current.providerScope != null ||
+          current.provisioningRequestStartedAt ||
+          current.cleanupCompletedAt ||
+          !current.cleanupError ||
+          current.state !== "released" ||
+          current.releaseDeletesServer !== true ||
+          (await provisioningOwnsLease(transaction, leaseID))
+        ) {
+          throw new ProviderResourceUnresolvedError(
+            "Cleanup recovery lease or administrator authority changed before commit",
+          );
+        }
+        const audit = await persistAudit(transaction);
+        const now = Date.now();
+        await transaction.put(leaseKey(leaseID), {
+          ...current,
+          providerScope: observation.providerScope,
+          provisioningResourceMayExist: false,
+          cleanupRetryAt: new Date(now).toISOString(),
+          updatedAt: new Date(now).toISOString(),
+        });
+        // This records the next cleanup wake, not provider cleanup completion.
+        const previousWake = await transaction.get<number | null>(legacyAlarmKey);
+        await setLegacyWake(transaction, Math.min(previousWake ?? now, now));
+        return audit;
+      }),
+    );
   }
 
   private async leaseRoute(request: Request, leaseID: string, action?: string): Promise<Response> {
@@ -7234,10 +7296,29 @@ export class FleetCoordinator {
           : undefined;
       if (!provider?.recoverCleanup)
         return json({ error: "cleanup_recovery_unsupported" }, { status: 501 });
-      if (!this.cleanupRecoveryLeaseEligible(lease)) {
+      if (provider.supportsCleanupScopeRecovery && !admin) {
+        return json(
+          { error: "forbidden", message: "administrator cleanup recovery required" },
+          { status: 403 },
+        );
+      }
+      if (
+        !this.cleanupRecoveryLeaseEligible(lease) ||
+        (await provisioningOwnsLease(this.state.storage, lease.id))
+      ) {
         return json({ error: "cleanup_recovery_requires_expired_blocked_lease" }, { status: 409 });
       }
       const expectedBinding = this.cleanupRecoveryLeaseBinding(lease);
+      const commitScopeRecovery: ProviderScopeRecoveryCommit = (observation, persistAudit) =>
+        this.commitRecoveredLeaseScope(
+          request,
+          lease.id,
+          expectedBinding,
+          observation,
+          persistAudit,
+        );
+      const scopeRecoveryArgs: [] | [ProviderScopeRecoveryCommit] =
+        provider.supportsCleanupScopeRecovery ? [commitScopeRecovery] : [];
       try {
         const recovery = await provider.recoverCleanup(
           lease,
@@ -7257,6 +7338,7 @@ export class FleetCoordinator {
               }
               return await commit();
             }),
+          ...scopeRecoveryArgs,
         );
         return json({ leaseID: lease.id, provider: providerID, recovery });
       } catch (error) {
@@ -7289,6 +7371,12 @@ export class FleetCoordinator {
           : undefined;
       if (!provider?.inspectCleanup) {
         return json({ error: "cleanup_inspection_unsupported" }, { status: 501 });
+      }
+      if (provider.supportsCleanupScopeRecovery && !admin) {
+        return json(
+          { error: "forbidden", message: "administrator cleanup inspection required" },
+          { status: 403 },
+        );
       }
       return json({
         leaseID: lease.id,
@@ -26619,12 +26707,15 @@ interface CloudProvider {
   deleteServer(id: string): Promise<void>;
   deleteOwnedServer?(lease: LeaseRecord): Promise<void>;
   inspectCleanup?(lease: LeaseRecord): Promise<unknown>;
+  // Scope repair requires admin authorization and its own lifecycle commit capability.
+  supportsCleanupScopeRecovery?: true;
   // Revalidate the lease after provider reads, before committing any recovery writes.
   recoverCleanup?(
     lease: LeaseRecord,
     expectedClaimFingerprint: string,
     actor: string,
     commitGuard: <T>(commit: () => Promise<T>) => Promise<T>,
+    commitScopeRecovery?: ProviderScopeRecoveryCommit,
   ): Promise<unknown>;
   supportsNativeImages(): boolean;
   nativeImagesUnsupportedMessage(): string;
@@ -26723,6 +26814,12 @@ interface ProviderWorkspaceCapability {
 
 type ProviderStateStorage = CoordinatorStorage;
 type ProviderStateStorageView = CoordinatorStorageView;
+
+// The lifecycle owner accepts a proved scope binding, never an arbitrary lease patch.
+type ProviderScopeRecoveryCommit = <T>(
+  observation: { providerScope: string; resourceAbsent: true },
+  persistAudit: (transaction: CoordinatorStorageView) => Promise<T>,
+) => Promise<T>;
 
 interface ProviderAccessContext {
   requestSourceCIDRs: string[];
@@ -28294,6 +28391,7 @@ async function recordAWSMacHostAllocations(
 
 export class AWSProvider implements CloudProvider {
   readonly recoveryIsAuthoritative = true;
+  readonly supportsCleanupScopeRecovery = true;
 
   private clientValue?: EC2SpotClient;
   private readonly region: string;
@@ -28407,6 +28505,113 @@ export class AWSProvider implements CloudProvider {
 
   findServer(id: string): Promise<ProviderMachine | undefined> {
     return this.client.findServer(id);
+  }
+
+  private async recordedCleanupRecovery(
+    lease: LeaseRecord,
+  ): Promise<AWSLegacyCleanupAudit | undefined> {
+    const audit = await this.storage.get<AWSLegacyCleanupAudit>(
+      awsCleanupRecoveryAuditKey(lease.id),
+    );
+    if (audit && !(await awsCleanupAuditMatchesLease(audit, lease))) {
+      throw new ProviderResourceUnresolvedError(
+        "AWS cleanup recovery audit does not match the retained lease",
+      );
+    }
+    return audit ? awsCleanupAuditView(audit) : undefined;
+  }
+
+  private async observeLegacyCleanupScope(lease: LeaseRecord) {
+    requireAWSLegacyCleanupLease(lease);
+    return this.withLeaseOperation(async (session) => {
+      if (session.region !== lease.region) {
+        throw new ProviderResourceUnresolvedError(
+          "AWS recovery Region does not match the retained lease",
+        );
+      }
+      const identity = await session.verifiedIdentity();
+      const evidence = await session.client.legacyAllocationEvidence(lease, identity.account);
+      if (await session.findServer(lease.cloudID)) {
+        throw new ProviderResourceUnresolvedError(
+          "AWS instance is still visible; use normal owned-resource cleanup instead of scope recovery",
+        );
+      }
+      return evidence;
+    });
+  }
+
+  async inspectCleanup(lease: LeaseRecord): Promise<unknown> {
+    const recoveryAudit = await this.recordedCleanupRecovery(lease);
+    if (recoveryAudit) return { recoveryAudit };
+    const claimFingerprint = await awsCleanupRecoveryFingerprint(lease);
+    const evidence = await this.observeLegacyCleanupScope(lease);
+    const current = await this.storage.get<LeaseRecord>(leaseKey(lease.id));
+    const claimUnchanged = Boolean(
+      current &&
+      current.providerScope == null &&
+      !current.cleanupStartedAt &&
+      !current.provisioningRequestStartedAt &&
+      (await awsCleanupRecoveryFingerprint(current)) === claimFingerprint,
+    );
+    return {
+      basis: "aws-cloudtrail-run-instances",
+      ...evidence,
+      resourceAbsent: true,
+      remainingCleanup: ["owned-key", "provider-access"],
+      claimUnchanged,
+      ...(claimUnchanged ? { claimFingerprint } : {}),
+    };
+  }
+
+  async recoverCleanup(
+    lease: LeaseRecord,
+    expectedClaimFingerprint: string,
+    actor: string,
+    commitGuard: <T>(commit: () => Promise<T>) => Promise<T>,
+    commitScopeRecovery?: ProviderScopeRecoveryCommit,
+  ): Promise<AWSLegacyCleanupAudit> {
+    const existing = await this.recordedCleanupRecovery(lease);
+    if (existing) {
+      if (existing.claimFingerprint !== expectedClaimFingerprint) {
+        throw new ProviderResourceUnresolvedError(
+          "AWS cleanup recovery was recorded for another binding",
+        );
+      }
+      return commitGuard(async () => existing);
+    }
+    if (
+      !commitScopeRecovery ||
+      !actor.trim() ||
+      actor.length > 256 ||
+      (await awsCleanupRecoveryFingerprint(lease)) !== expectedClaimFingerprint
+    ) {
+      throw new ProviderResourceUnresolvedError(
+        "AWS recovery binding changed; inspect cleanup again",
+      );
+    }
+    const evidence = await this.observeLegacyCleanupScope(lease);
+    const audit: AWSLegacyCleanupAudit = {
+      leaseID: lease.id,
+      region: evidence.region,
+      providerScope: evidence.providerScope,
+      cloudID: lease.cloudID,
+      eventID: evidence.eventID,
+      eventTime: evidence.eventTime,
+      actor,
+      recoveredAt: new Date().toISOString(),
+      claimFingerprint: expectedClaimFingerprint,
+    };
+    return commitScopeRecovery(
+      { providerScope: evidence.providerScope, resourceAbsent: true },
+      async (transaction) => {
+        const key = awsCleanupRecoveryAuditKey(lease.id);
+        if (await transaction.get(key)) {
+          throw new ProviderResourceUnresolvedError("AWS recovery evidence changed before commit");
+        }
+        await transaction.put(key, audit);
+        return audit;
+      },
+    );
   }
 
   private async verifyLeaseOperationAuthority(

--- a/worker/test/aws-cleanup-recovery.postgres.test.ts
+++ b/worker/test/aws-cleanup-recovery.postgres.test.ts
@@ -1,0 +1,353 @@
+import { afterEach, expect, it, vi } from "vitest";
+
+import { NodeCoordinatorRuntime } from "../node/node-runtime";
+import { AsyncMutex } from "../node/server-support";
+import type { AWSLegacyCleanupAudit } from "../src/aws-cleanup-recovery";
+import type { CoordinatorStorageView } from "../src/coordinator-runtime";
+import { AWSProvider, FleetCoordinator } from "../src/fleet";
+import { orgKeyForLabel } from "../src/org-identity";
+import { providerKeyForLease } from "../src/provider-key";
+import type { Env, LeaseRecord } from "../src/types";
+
+// Deliberately ignore DATABASE_URL: this proof may only connect to its fixed CI fixture.
+const database = new URL("postgresql://127.0.0.1:55432/crabbox_recovery_test");
+database.username = "crabbox_test";
+database.password = "crabbox-test-only";
+const scope = "aws:account:123456789012";
+const region = "eu-west-1";
+const headers = {
+  "content-type": "application/json",
+  "x-crabbox-owner": "alice@example.com",
+  "x-crabbox-org": "example-org",
+  "x-crabbox-admin": "true",
+};
+
+const env = {
+  CRABBOX_DEFAULT_ORG: "example-org",
+  CRABBOX_AWS_REGION: region,
+  CRABBOX_AWS_ORPHAN_SWEEP_ENABLED: "0",
+  AWS_ACCESS_KEY_ID: "synthetic-key",
+  AWS_SECRET_ACCESS_KEY: "synthetic-secret",
+} as Env;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+it("persists atomic AWS scope recovery across real PostgreSQL reopen beside a scoped lease (synthetic AWS)", async () => {
+  const legacy: LeaseRecord = {
+    ...lease("cbx_000000000001", "i-00000000000000001", "legacy-runner"),
+    state: "released",
+    releaseDeletesServer: true,
+    releasedAt: new Date(Date.now() - 30_000).toISOString(),
+    expiresAt: new Date(Date.now() - 30_000).toISOString(),
+    cleanupError: "original AWS account scope was not persisted",
+    failureError: "original AWS account scope was not persisted",
+    provisioningResourceMayExist: true,
+    provisioningFailureRetryable: false,
+  };
+  const ordinary: LeaseRecord = {
+    ...lease("cbx_000000000002", "i-00000000000000002", "scoped-runner"),
+    providerScope: scope,
+  };
+  const aws = syntheticAWS(legacy, ordinary);
+  // This test proves durable state, not AWS ingress or cloud authority. Those remain separate proof.
+  vi.spyOn(AWSProvider.prototype, "reconcileLeaseAccess").mockResolvedValue();
+  let active: ReturnType<typeof coordinator> | undefined = coordinator();
+  try {
+    const existing = await active.runtime.storage.pool.query<{ existing: string | null }>(
+      "select to_regclass('crabbox.coordinator_kv')::text as existing",
+    );
+    expect(existing.rows[0]?.existing).toBeNull();
+    // Hold the job runner offline initially: a failed wake hint must not lose committed due work.
+    await active.runtime.storage.initialize();
+    await active.runtime.storage.put(`lease:${legacy.id}`, legacy);
+    await active.runtime.storage.put(`lease:${ordinary.id}`, ordinary);
+    const before = await active.runtime.storage.get<LeaseRecord>(`lease:${legacy.id}`);
+    const ordinaryBefore = await active.runtime.storage.get<LeaseRecord>(`lease:${ordinary.id}`);
+    const beforeWake = await active.runtime.getAlarm();
+    const auditKey = `aws-cleanup-recovery-audit:${legacy.id}`;
+    const inspected = await active.fleet.fetch(request(legacy.id, "cleanup"));
+    expect(inspected.status).toBe(200);
+    const { inspection } = (await inspected.json()) as { inspection: { claimFingerprint: string } };
+
+    // Wrap the existing real transaction. Observe both writes, then force its actual SQL ROLLBACK.
+    const transact = active.runtime.storage.transaction.bind(active.runtime.storage);
+    let stagedPair = false;
+    const abort = vi
+      .spyOn(active.runtime.storage, "transaction")
+      .mockImplementation(
+        async <T>(callback: (transaction: CoordinatorStorageView) => Promise<T>): Promise<T> =>
+          transact(async (transaction) => {
+            const result = await callback(transaction);
+            const stagedLease = await transaction.get<LeaseRecord>(`lease:${legacy.id}`);
+            const stagedAudit = await transaction.get<AWSLegacyCleanupAudit>(auditKey);
+            if (stagedLease?.providerScope === scope && stagedAudit?.providerScope === scope) {
+              stagedPair = true;
+              throw new Error("synthetic failure after writes before PostgreSQL commit");
+            }
+            return result;
+          }),
+      );
+    try {
+      const failed = await active.fleet.fetch(acknowledge(legacy.id, inspection.claimFingerprint));
+      expect(failed.status).toBe(500);
+      expect(stagedPair).toBe(true);
+    } finally {
+      abort.mockRestore();
+    }
+    await active.runtime.stop();
+    active = undefined;
+
+    // A new runtime owns a new real pg Pool; no fake store or shared in-memory records survive.
+    active = coordinator();
+    expect(await active.runtime.storage.get(`lease:${legacy.id}`)).toEqual(before);
+    expect(await active.runtime.storage.get(auditKey)).toBeUndefined();
+    expect(await physicalScopes(active.runtime, [auditKey, `lease:${legacy.id}`])).toEqual([
+      { key: `lease:${legacy.id}`, scope: null },
+    ]);
+    expect(await active.runtime.getAlarm()).toBe(beforeWake);
+    expect(await active.runtime.storage.get(`lease:${ordinary.id}`)).toEqual(ordinaryBefore);
+    const recovered = await active.fleet.fetch(acknowledge(legacy.id, inspection.claimFingerprint));
+    expect(recovered.status).toBe(200);
+    const { recovery } = (await recovered.json()) as { recovery: AWSLegacyCleanupAudit };
+    const committedWake = await active.runtime.getAlarm();
+    expect(committedWake).toBeTypeOf("number");
+    expect(committedWake).toBeLessThanOrEqual(Date.now());
+    await active.runtime.stop();
+    active = undefined;
+
+    active = coordinator();
+    expect(await active.runtime.storage.get(auditKey)).toEqual(recovery);
+    expect(await physicalScopes(active.runtime, [auditKey, `lease:${legacy.id}`])).toEqual([
+      { key: auditKey, scope },
+      { key: `lease:${legacy.id}`, scope },
+    ]);
+    expect(await active.runtime.getAlarm()).toBe(committedWake);
+    const durable = await active.runtime.storage.get<LeaseRecord>(`lease:${legacy.id}`);
+    expect(durable).toMatchObject({
+      keep: true,
+      releaseDeletesServer: true,
+      providerScope: scope,
+      provisioningResourceMayExist: false,
+      cleanupError: legacy.cleanupError,
+      host: legacy.host,
+      sshHostKey: legacy.sshHostKey,
+    });
+    expect(durable?.cleanupCompletedAt).toBeUndefined();
+    expect(await active.runtime.storage.get(`lease:${ordinary.id}`)).toEqual(ordinaryBefore);
+
+    // Start the supported pg-boss runtime only after the persisted recovery has been reread.
+    const resumed = active;
+    await resumed.runtime.start(() => resumed.fleet.alarm());
+    await vi.waitFor(
+      async () => {
+        const completed = await resumed.runtime.storage.get<LeaseRecord>(`lease:${legacy.id}`);
+        expect(Number.isFinite(Date.parse(completed?.cleanupCompletedAt ?? ""))).toBe(true);
+      },
+      { timeout: 10_000, interval: 100 },
+    );
+    expect(await resumed.runtime.storage.get(auditKey)).toEqual(recovery);
+    expect(await resumed.runtime.storage.get(`lease:${ordinary.id}`)).toEqual(ordinaryBefore);
+    expect(aws.deletedKeys).toEqual(["key-00000000000000001"]);
+    expect(aws.terminated).toEqual([]);
+    const auditInspection = await resumed.fleet.fetch(request(legacy.id, "cleanup"));
+    expect(auditInspection.status).toBe(200);
+    await expect(auditInspection.json()).resolves.toMatchObject({
+      inspection: { recoveryAudit: recovery },
+    });
+    const replay = await resumed.fleet.fetch(acknowledge(legacy.id, inspection.claimFingerprint));
+    expect(replay.status).toBe(200);
+    await expect(replay.json()).resolves.toMatchObject({ recovery });
+
+    // An ordinary account-bound lease still uses normal release; it needs no legacy repair audit.
+    const ownerRelease = request(ordinary.id, "release", { delete: true });
+    ownerRelease.headers.delete("x-crabbox-admin");
+    const released = await resumed.fleet.fetch(ownerRelease);
+    expect(released.status).toBe(200);
+    await vi.waitFor(
+      async () => {
+        const completed = await resumed.runtime.storage.get<LeaseRecord>(`lease:${ordinary.id}`);
+        expect(Number.isFinite(Date.parse(completed?.cleanupCompletedAt ?? ""))).toBe(true);
+      },
+      { timeout: 10_000, interval: 100 },
+    );
+    expect(aws.terminated).toEqual([ordinary.cloudID]);
+    expect(aws.deletedKeys).toEqual(["key-00000000000000001", "key-00000000000000002"]);
+    expect(
+      await resumed.runtime.storage.get(`aws-cleanup-recovery-audit:${ordinary.id}`),
+    ).toBeUndefined();
+    expect(await resumed.runtime.storage.get(auditKey)).toEqual(recovery);
+  } finally {
+    await active?.runtime.stop();
+  }
+}, 60_000);
+
+async function physicalScopes(runtime: NodeCoordinatorRuntime, keys: string[]) {
+  // Independently inspect the real compatibility table, not a coordinator cache or a fake Pool.
+  const result = await runtime.storage.pool.query<{ key: string; scope: string | null }>(
+    "select key, value ->> 'providerScope' as scope from crabbox.coordinator_kv where key = any($1::text[]) order by key",
+    [keys],
+  );
+  return result.rows;
+}
+
+function coordinator() {
+  const runtime = new NodeCoordinatorRuntime(database.toString());
+  const mutex = new AsyncMutex();
+  runtime.setOperationRunner((callback) => mutex.run(callback));
+  return { runtime, fleet: new FleetCoordinator(runtime, env) };
+}
+
+function request(id: string, action: string, body?: unknown): Request {
+  return new Request(`https://coordinator.test/v1/leases/${id}/${action}`, {
+    method: body === undefined ? "GET" : "POST",
+    headers,
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+function acknowledge(id: string, fingerprint: string): Request {
+  return request(id, "cleanup", {
+    action: "acknowledge-missing-resource",
+    expectedClaimFingerprint: fingerprint,
+  });
+}
+
+function lease(id: string, cloudID: string, slug: string): LeaseRecord {
+  return {
+    id,
+    cloudID,
+    slug,
+    provider: "aws",
+    region,
+    owner: "alice@example.com",
+    org: orgKeyForLabel("example-org"),
+    profile: "default",
+    class: "tiny",
+    serverType: "t3.micro",
+    serverID: 0,
+    serverName: `crabbox-${slug}`,
+    providerKey: providerKeyForLease(id),
+    providerKeyCleanupOwned: true,
+    host: "192.0.2.10",
+    sshUser: "ubuntu",
+    sshPort: "22",
+    workRoot: "/work/crabbox",
+    sshHostKey: "ssh-ed25519 synthetic-host-key",
+    keep: true,
+    ttlSeconds: 3600,
+    estimatedHourlyUSD: 0.01,
+    maxEstimatedUSD: 1,
+    state: "active",
+    createdAt: new Date(Date.now() - 60_000).toISOString(),
+    updatedAt: new Date(Date.now() - 60_000).toISOString(),
+    expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+  };
+}
+
+function ownershipTags(value: LeaseRecord) {
+  return [
+    { key: "crabbox", value: "true" },
+    { key: "created_by", value: "crabbox" },
+    { key: "lease", value: value.id },
+    { key: "owner", value: "alice_example.com" },
+    { key: "provider", value: "aws" },
+    { key: "slug", value: value.slug! },
+    { key: "provider_key", value: value.providerKey },
+  ];
+}
+
+function xml(body: string) {
+  return new Response(body, { headers: { "content-type": "text/xml" } });
+}
+
+function syntheticAWS(legacy: LeaseRecord, ordinary: LeaseRecord) {
+  const deletedKeys: string[] = [];
+  const terminated: string[] = [];
+  const resources = new Map([
+    [legacy.providerKey, { lease: legacy, keyID: "key-00000000000000001" }],
+    [ordinary.providerKey, { lease: ordinary, keyID: "key-00000000000000002" }],
+  ]);
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const outgoing = input instanceof Request ? input : new Request(input, init);
+      if (outgoing.headers.get("x-amz-target")?.endsWith(".LookupEvents")) {
+        return Response.json({
+          Events: [
+            {
+              EventName: "RunInstances",
+              EventSource: "ec2.amazonaws.com",
+              EventId: "00000000-0000-4000-8000-000000000001",
+              CloudTrailEvent: JSON.stringify({
+                eventName: "RunInstances",
+                eventSource: "ec2.amazonaws.com",
+                eventType: "AwsApiCall",
+                eventID: "00000000-0000-4000-8000-000000000001",
+                eventTime: new Date(Date.parse(legacy.createdAt) + 15_000).toISOString(),
+                recipientAccountId: "123456789012",
+                awsRegion: region,
+                requestParameters: {
+                  keyName: legacy.providerKey,
+                  tagSpecificationSet: {
+                    items: [{ resourceType: "instance", tags: ownershipTags(legacy) }],
+                  },
+                },
+                responseElements: { instancesSet: { items: [{ instanceId: legacy.cloudID }] } },
+              }),
+            },
+          ],
+        });
+      }
+      const params = new URLSearchParams(await outgoing.clone().text());
+      switch (params.get("Action")) {
+        case "GetCallerIdentity":
+          return xml(
+            "<GetCallerIdentityResponse><GetCallerIdentityResult><Account>123456789012</Account><Arn>arn:aws:iam::123456789012:user/synthetic</Arn><UserId>synthetic</UserId></GetCallerIdentityResult></GetCallerIdentityResponse>",
+          );
+        case "DescribeInstances": {
+          if (
+            params.get("InstanceId.1") !== ordinary.cloudID ||
+            terminated.includes(ordinary.cloudID)
+          ) {
+            return xml(
+              "<DescribeInstancesResponse><requestId>synthetic-read</requestId><reservationSet /></DescribeInstancesResponse>",
+            );
+          }
+          const tags = ownershipTags(ordinary)
+            .map((tag) => `<item><key>${tag.key}</key><value>${tag.value}</value></item>`)
+            .join("");
+          return xml(
+            `<DescribeInstancesResponse><requestId>synthetic-read</requestId><reservationSet><item><instancesSet><item><instanceId>${ordinary.cloudID}</instanceId><instanceState><name>running</name></instanceState><tagSet>${tags}</tagSet></item></instancesSet></item></reservationSet></DescribeInstancesResponse>`,
+          );
+        }
+        case "TerminateInstances": {
+          const id = params.get("InstanceId.1") ?? "";
+          if (id !== ordinary.cloudID) throw new Error("unexpected synthetic termination");
+          terminated.push(id);
+          return xml(
+            `<TerminateInstancesResponse><instancesSet><item><instanceId>${id}</instanceId></item></instancesSet></TerminateInstancesResponse>`,
+          );
+        }
+        case "DescribeKeyPairs": {
+          const resource = resources.get(params.get("KeyName.1") ?? "");
+          if (!resource) throw new Error("unexpected synthetic key lookup");
+          const tags = ownershipTags(resource.lease)
+            .map((tag) => `<item><key>${tag.key}</key><value>${tag.value}</value></item>`)
+            .join("");
+          return xml(
+            `<DescribeKeyPairsResponse><keySet><item><keyPairId>${resource.keyID}</keyPairId><tagSet>${tags}</tagSet></item></keySet></DescribeKeyPairsResponse>`,
+          );
+        }
+        case "DeleteKeyPair":
+          deletedKeys.push(params.get("KeyPairId") ?? "");
+          return xml("<DeleteKeyPairResponse />");
+        default:
+          throw new Error("unexpected network operation in synthetic AWS fixture");
+      }
+    }),
+  );
+  return { deletedKeys, terminated };
+}

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -26612,6 +26612,304 @@ describe("fleet lease identity and idle", () => {
     },
   );
 
+  it.each([false, true])(
+    "recovers legacy AWS scope after the forward cleanup refusal without skipping failed key cleanup (keep=%s)",
+    async (keep) => {
+      const f = awsLegacyRecoveryFixture(keep);
+      const key = `lease:${f.lease.id}`;
+      const auditKey = `aws-cleanup-recovery-audit:${f.lease.id}`;
+      await f.fleet.alarm();
+      const refused = structuredClone(f.storage.value<LeaseRecord>(key)!);
+      expect(refused).toMatchObject({
+        keep,
+        releaseDeletesServer: true,
+        provisioningResourceMayExist: true,
+        provisioningFailureRetryable: false,
+      });
+      expect(refused.cleanupCompletedAt).toBeUndefined();
+      expect(refused.cleanupRetryAt).toBeUndefined();
+
+      const inspection = await f.inspect();
+      expect(inspection.status).toBe(200);
+      const inspected = (await inspection.json()) as {
+        inspection: { claimFingerprint: string; providerScope: string; claimUnchanged: boolean };
+      };
+      expect(inspected.inspection).toMatchObject({
+        providerScope: "aws:account:123456789012",
+        claimUnchanged: true,
+      });
+      expect(f.storage.value(key)).toEqual(refused);
+      expect(JSON.stringify(inspected)).not.toContain("private-bootstrap-canary");
+
+      const recovered = await f.recover(inspected.inspection.claimFingerprint);
+      expect(recovered.status).toBe(200);
+      expect(f.lookupAttributes).toEqual([
+        [{ AttributeKey: "ResourceName", AttributeValue: f.lease.cloudID }],
+        [{ AttributeKey: "ResourceName", AttributeValue: f.lease.cloudID }],
+      ]);
+      const repair = (await recovered.json()) as { recovery: Record<string, unknown> };
+      expect(Object.keys(repair.recovery).toSorted()).toEqual([
+        "actor",
+        "claimFingerprint",
+        "cloudID",
+        "eventID",
+        "eventTime",
+        "leaseID",
+        "providerScope",
+        "recoveredAt",
+        "region",
+      ]);
+      expect(f.storage.value(key)).toMatchObject({
+        keep,
+        releaseDeletesServer: true,
+        providerScope: "aws:account:123456789012",
+        provisioningResourceMayExist: false,
+        cleanupRetryAt: expect.any(String),
+        cleanupError: refused.cleanupError,
+        failureError: refused.failureError,
+        host: f.lease.host,
+        sshHostKey: f.lease.sshHostKey,
+        providerAccessExpiresAt: f.lease.providerAccessExpiresAt,
+      });
+      expect(f.storage.value<LeaseRecord>(key)?.cleanupCompletedAt).toBeUndefined();
+      expect(f.storage.value(auditKey)).toEqual(repair.recovery);
+      expect(f.storage.alarm()).toBeLessThanOrEqual(Date.now());
+
+      f.state.keyFailure = true;
+      await f.fleet.alarm();
+      const failedKey = f.storage.value<LeaseRecord>(key)!;
+      expect(failedKey.cleanupError).toContain("UnauthorizedOperation");
+      expect(failedKey.cleanupCompletedAt).toBeUndefined();
+      expect(failedKey.sshHostKey).toBe(f.lease.sshHostKey);
+      expect(f.state.keyDeleted).toBe(false);
+      f.state.keyFailure = false;
+      f.storage.seed(key, {
+        ...failedKey,
+        cleanupRetryAt: new Date(Date.now() - 1_000).toISOString(),
+      });
+      await f.fleet.alarm();
+      expect(f.state.keyDeleted).toBe(true);
+      expect(f.deletedKeyIDs).toEqual(["key-0123456789abcdef0", "key-0123456789abcdef0"]);
+      expect(f.storage.value(key)).toMatchObject({
+        state: "released",
+        keep,
+        host: "",
+        cleanupCompletedAt: expect.any(String),
+      });
+      expect(f.storage.value<LeaseRecord>(key)?.cleanupError).toBeUndefined();
+      expect(f.storage.value<LeaseRecord>(key)?.sshHostKey).toBeUndefined();
+      expect(f.storage.value<LeaseRecord>(key)?.providerAccessExpiresAt).toBeUndefined();
+      expect(f.actions).not.toContain("TerminateInstances");
+      const lookupCount = f.actions.filter((action) => action === "LookupEvents").length;
+      expect((await f.recover(inspected.inspection.claimFingerprint)).status).toBe(200);
+      expect(f.actions.filter((action) => action === "LookupEvents")).toHaveLength(lookupCount);
+      expect(f.storage.value(auditKey)).toEqual(repair.recovery);
+    },
+  );
+
+  it.each([false, undefined])(
+    "refuses legacy AWS recovery without explicit delete intent (%s)",
+    async (releaseDeletesServer) => {
+      const f = awsLegacyRecoveryFixture(true);
+      const key = `lease:${f.lease.id}`;
+      f.storage.seed(key, { ...f.lease, releaseDeletesServer });
+      const before = structuredClone(f.storage.value(key));
+      expect((await f.inspect()).status).not.toBe(200);
+      expect((await f.recover("a".repeat(64))).status).not.toBe(200);
+      expect(f.actions).toEqual([]);
+      expect(f.storage.value(key)).toEqual(before);
+      expect(f.storage.value(`aws-cleanup-recovery-audit:${f.lease.id}`)).toBeUndefined();
+    },
+  );
+
+  it.each(["GET", "POST"])(
+    "requires admin authority before %s AWS recovery evidence reads",
+    async (method) => {
+      const f = awsLegacyRecoveryFixture();
+      const response = await f.fleet.fetch(
+        request(method, `/v1/leases/${f.lease.id}/cleanup`, {
+          headers: { ...f.headers, "x-crabbox-admin": "false" },
+          ...(method === "POST"
+            ? {
+                body: {
+                  action: "acknowledge-missing-resource",
+                  expectedClaimFingerprint: "a".repeat(64),
+                },
+              }
+            : {}),
+        }),
+      );
+      expect(response.status).toBe(403);
+      expect(f.actions).toEqual([]);
+    },
+  );
+
+  it.each([
+    "missing event",
+    "conflicting events",
+    "incomplete pagination",
+    "truncated event",
+    "wrong account",
+    "wrong Region",
+    "wrong instance",
+    "wrong lease tags",
+    "wrong key",
+    "missing provider-key tag",
+    "access denied",
+    "network failure",
+    "oversized response",
+  ])("refuses AWS legacy recovery with %s and preserves cleanup evidence", async (failure) => {
+    const f = awsLegacyRecoveryFixture();
+    const before = structuredClone(f.storage.value(`lease:${f.lease.id}`));
+    switch (failure) {
+      case "missing event":
+        f.state.lookupBody = JSON.stringify({ Events: [] });
+        break;
+      case "conflicting events":
+      case "incomplete pagination": {
+        const events = [
+          f.event,
+          ...(failure === "conflicting events"
+            ? [{ ...f.event, eventID: "00000000-0000-4000-8000-000000000002" }]
+            : []),
+        ];
+        f.state.lookupBody = JSON.stringify({
+          Events: events.map((event) => ({
+            EventName: event.eventName,
+            EventSource: event.eventSource,
+            EventId: event.eventID,
+            CloudTrailEvent: JSON.stringify(event),
+          })),
+          ...(failure === "incomplete pagination" ? { NextToken: "repeated-token" } : {}),
+        });
+        break;
+      }
+      case "truncated event":
+        f.state.event = { ...f.event, responseElements: null };
+        break;
+      case "wrong account":
+        f.state.event = { ...f.event, recipientAccountId: "999999999999" };
+        break;
+      case "wrong Region":
+        f.state.event = { ...f.event, awsRegion: "us-east-1" };
+        break;
+      case "wrong instance":
+        f.state.event = {
+          ...f.event,
+          responseElements: { instancesSet: { items: [{ instanceId: "i-99999999999999999" }] } },
+        };
+        break;
+      case "wrong lease tags":
+        f.state.event = {
+          ...f.event,
+          requestParameters: { ...f.event.requestParameters, tagSpecificationSet: { items: [] } },
+        };
+        break;
+      case "wrong key":
+        f.state.event = {
+          ...f.event,
+          requestParameters: { ...f.event.requestParameters, keyName: "foreign-key" },
+        };
+        break;
+      case "missing provider-key tag":
+        f.state.event = {
+          ...f.event,
+          requestParameters: {
+            ...f.event.requestParameters,
+            tagSpecificationSet: {
+              items: f.event.requestParameters.tagSpecificationSet.items.map((item) => ({
+                ...item,
+                tags: item.tags.filter((tag) => tag.key !== "provider_key"),
+              })),
+            },
+          },
+        };
+        break;
+      case "access denied":
+        f.state.lookupStatus = 403;
+        break;
+      case "network failure":
+        f.state.lookupError = true;
+        break;
+      case "oversized response":
+        f.state.lookupBody = "x".repeat(2 * 1024 * 1024 + 1);
+        break;
+    }
+    const response = await f.inspect();
+    expect(response.status).not.toBe(200);
+    expect(await response.text()).not.toContain("private-bootstrap-canary");
+    expect(f.storage.value(`lease:${f.lease.id}`)).toEqual(before);
+    expect(f.storage.value(`aws-cleanup-recovery-audit:${f.lease.id}`)).toBeUndefined();
+    expect(f.actions).not.toContain("DeleteKeyPair");
+  });
+
+  it("uses one AWS credential snapshot for STS, CloudTrail, and current instance absence", async () => {
+    const f = awsLegacyRecoveryFixture();
+    expect((await f.inspect()).status).toBe(200);
+    expect(f.actions).toEqual(["GetCallerIdentity", "LookupEvents", "DescribeInstances"]);
+    expect(f.credentials).toHaveBeenCalledOnce();
+    expect(f.credentialKeys).toEqual(["test-1", "test-1", "test-1"]);
+  });
+
+  it("revalidates AWS allocation evidence instead of trusting an inspected fingerprint", async () => {
+    const f = awsLegacyRecoveryFixture();
+    const response = await f.inspect();
+    expect(response.status).toBe(200);
+    const { inspection } = (await response.json()) as { inspection: { claimFingerprint: string } };
+    const before = structuredClone(f.storage.value(`lease:${f.lease.id}`));
+    f.state.event = { ...f.event, recipientAccountId: "999999999999" };
+    expect((await f.recover(inspection.claimFingerprint)).status).toBe(409);
+    expect(f.actions.filter((action) => action === "LookupEvents")).toHaveLength(2);
+    expect(f.storage.value(`lease:${f.lease.id}`)).toEqual(before);
+    expect(f.storage.value(`aws-cleanup-recovery-audit:${f.lease.id}`)).toBeUndefined();
+  });
+
+  it.each([
+    "key replacement",
+    "active allocation",
+    "active cleanup",
+    "completed cleanup",
+    "retained disposition",
+    "audit transaction failure",
+  ])("fences AWS recovery after refreshed reads observe %s", async (change) => {
+    const f = awsLegacyRecoveryFixture();
+    const response = await f.inspect();
+    expect(response.status).toBe(200);
+    const { inspection } = (await response.json()) as {
+      inspection: { claimFingerprint: string };
+    };
+    const key = `lease:${f.lease.id}`;
+    f.state.beforeLookup = () => {
+      if (change === "audit transaction failure") {
+        f.storage.beforePut = async (writtenKey, value) => {
+          if (writtenKey === key && (value as LeaseRecord).providerScope)
+            throw new Error("synthetic storage unavailable");
+        };
+      } else {
+        f.storage.seed(key, {
+          ...f.storage.value<LeaseRecord>(key)!,
+          ...(change === "key replacement" ? { providerKey: "replacement-key" } : {}),
+          ...(change === "active allocation"
+            ? { provisioningRequestStartedAt: new Date().toISOString() }
+            : {}),
+          ...(change === "active cleanup" ? { cleanupStartedAt: new Date().toISOString() } : {}),
+          ...(change === "retained disposition" ? { releaseDeletesServer: false } : {}),
+          ...(change === "completed cleanup"
+            ? { cleanupCompletedAt: new Date().toISOString() }
+            : {}),
+        });
+      }
+    };
+    const recovery = await f.recover(inspection.claimFingerprint);
+    expect(recovery.status).not.toBe(200);
+    expect(f.storage.value<LeaseRecord>(key)?.providerScope).toBeUndefined();
+    expect(Boolean(f.storage.value<LeaseRecord>(key)?.cleanupCompletedAt)).toBe(
+      change === "completed cleanup",
+    );
+    expect(f.storage.value(`aws-cleanup-recovery-audit:${f.lease.id}`)).toBeUndefined();
+    expect(f.actions).not.toContain("DeleteKeyPair");
+  });
+
   it("completes matching account-bound AWS cleanup when the historical instance lookup is empty", async () => {
     const credentials = vi.fn<
       () => Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken: string }>
@@ -50042,6 +50340,172 @@ async function requestBodyForTest(input: RequestInfo | URL, init?: RequestInit):
     return await input.clone().text();
   }
   return "";
+}
+
+function awsLegacyRecoveryFixture(keep = false) {
+  const storage = new MemoryStorage();
+  const lease = testLease({
+    id: "cbx_abcdef123456",
+    provider: "aws",
+    cloudID: "i-0123456789abcdef0",
+    owner: "alice@example.com",
+    org: "example-org",
+    slug: "blue-lobster",
+    region: "eu-west-1",
+    providerScope: undefined,
+    providerKey: "crabbox-cbx-abcdef123456",
+    providerKeyCleanupOwned: true,
+    state: "released",
+    keep,
+    releaseDeletesServer: true,
+    createdAt: new Date(Date.now() - 60_000).toISOString(),
+    releasedAt: new Date(Date.now() - 30_000).toISOString(),
+    expiresAt: new Date(Date.now() - 30_000).toISOString(),
+    cleanupError: "prior instance observation failed",
+    cleanupRetryAt: new Date(Date.now() - 1_000).toISOString(),
+    sshHostKey: "ssh-ed25519 synthetic-host-key",
+    providerAccessExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+  });
+  const event = {
+    eventID: "00000000-0000-4000-8000-000000000001",
+    eventTime: new Date(Date.now() - 45_000).toISOString(),
+    eventName: "RunInstances",
+    eventSource: "ec2.amazonaws.com",
+    eventType: "AwsApiCall",
+    recipientAccountId: "123456789012",
+    awsRegion: "eu-west-1",
+    requestParameters: {
+      keyName: lease.providerKey,
+      userData: "private-bootstrap-canary",
+      tagSpecificationSet: {
+        items: [
+          {
+            resourceType: "instance",
+            tags: [
+              { key: "crabbox", value: "true" },
+              { key: "created_by", value: "crabbox" },
+              { key: "lease", value: lease.id },
+              { key: "slug", value: lease.slug! },
+              { key: "provider", value: "aws" },
+              { key: "owner", value: "alice_example.com" },
+              { key: "provider_key", value: lease.providerKey },
+            ],
+          },
+        ],
+      },
+    },
+    responseElements: { instancesSet: { items: [{ instanceId: lease.cloudID }] } },
+  };
+  const state = {
+    event: event as unknown,
+    lookupStatus: 200,
+    lookupBody: undefined as string | undefined,
+    lookupError: false,
+    beforeLookup: undefined as (() => void) | undefined,
+    keyFailure: false,
+    keyDeleted: false,
+  };
+  const actions: string[] = [];
+  const credentialKeys: string[] = [];
+  const lookupAttributes: unknown[] = [];
+  const deletedKeyIDs: Array<string | null> = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const outgoing = input instanceof Request ? input : new Request(input, init);
+      credentialKeys.push(
+        /Credential=([^/]+)/.exec(outgoing.headers.get("authorization") ?? "")?.[1] ?? "",
+      );
+      if (outgoing.headers.get("x-amz-target")?.endsWith(".LookupEvents")) {
+        actions.push("LookupEvents");
+        const lookup = (await outgoing.json()) as Record<string, unknown>;
+        lookupAttributes.push(lookup.LookupAttributes);
+        state.beforeLookup?.();
+        if (state.lookupError) throw new Error("private-bootstrap-canary");
+        return new Response(
+          state.lookupBody ??
+            JSON.stringify({
+              Events: [
+                {
+                  EventName: "RunInstances",
+                  EventSource: "ec2.amazonaws.com",
+                  EventId: event.eventID,
+                  CloudTrailEvent: JSON.stringify(state.event),
+                },
+              ],
+            }),
+          { status: state.lookupStatus },
+        );
+      }
+      const params = new URLSearchParams(await outgoing.clone().text());
+      const action = params.get("Action") ?? "";
+      actions.push(action);
+      if (action === "GetCallerIdentity") return awsIdentityResponse("123456789012");
+      if (action === "DescribeInstances") return awsEmptyDescribeInstancesResponse();
+      if (action === "DescribeKeyPairs") {
+        if (state.keyDeleted)
+          return ec2XMLResponse(
+            "<Response><Errors><Error><Code>InvalidKeyPair.NotFound</Code></Error></Errors></Response>",
+            400,
+          );
+        return ec2XMLResponse(
+          `<DescribeKeyPairsResponse><keySet><item><keyPairId>key-0123456789abcdef0</keyPairId><keyName>${lease.providerKey}</keyName><tagSet><item><key>crabbox</key><value>true</value></item><item><key>created_by</key><value>crabbox</value></item><item><key>lease</key><value>${lease.id}</value></item></tagSet></item></keySet></DescribeKeyPairsResponse>`,
+        );
+      }
+      if (action === "DeleteKeyPair") {
+        deletedKeyIDs.push(params.get("KeyPairId"));
+        if (state.keyFailure)
+          return ec2XMLResponse(
+            "<Response><Errors><Error><Code>UnauthorizedOperation</Code></Error></Errors></Response>",
+            403,
+          );
+        state.keyDeleted = true;
+        return ec2XMLResponse("<DeleteKeyPairResponse />");
+      }
+      throw new Error(`unexpected fixture operation ${action}`);
+    }),
+  );
+  let credentialGeneration = 0;
+  const credentials = vi.fn<NonNullable<Env["awsCredentialProvider"]>>(async () => ({
+    accessKeyId: `test-${++credentialGeneration}`,
+    secretAccessKey: "test",
+  }));
+  const env = { awsCredentialProvider: credentials } as Env;
+  const provider = new AWSProvider(env, lease.region!, storage);
+  vi.spyOn(provider, "reconcileLeaseAccess").mockResolvedValue();
+  const fleet = testFleet(storage, { aws: provider }, env);
+  storage.seed(`lease:${lease.id}`, lease);
+  const headers = {
+    "x-crabbox-owner": lease.owner,
+    "x-crabbox-org": "example-org",
+    "x-crabbox-admin": "true",
+  };
+  const inspect = () => fleet.fetch(request("GET", `/v1/leases/${lease.id}/cleanup`, { headers }));
+  const recover = (claimFingerprint: string) =>
+    fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/cleanup`, {
+        headers,
+        body: {
+          action: "acknowledge-missing-resource",
+          expectedClaimFingerprint: claimFingerprint,
+        },
+      }),
+    );
+  return {
+    storage,
+    lease,
+    event,
+    state,
+    actions,
+    credentialKeys,
+    credentials,
+    lookupAttributes,
+    deletedKeyIDs,
+    fleet,
+    headers,
+    inspect,
+    recover,
+  };
 }
 
 function testFleet(

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -656,29 +656,41 @@ describe("coordinator auth", () => {
     ).toEqual([null, null, null, null]);
   });
 
-  it("replaces caller-supplied admin grant versions after authentication", async () => {
-    const env = {
-      CRABBOX_ADMIN_TOKEN: "admin-secret",
-      CRABBOX_DEFAULT_ORG: "example-org",
-    } as Env;
-    const forgedVersion = "a".repeat(64);
-    const prepared = await prepareCoordinatorRequest(
-      new Request("https://example.test/v1/admin/leases", {
-        headers: {
-          authorization: "Bearer admin-secret",
-          "x-crabbox-admin-grant-version": forgedVersion,
-        },
-      }),
-      env,
-    );
+  it.each([
+    ["GET", "/v1/admin/leases", "admin-secret", "true"],
+    ["GET", "/v1/leases/cbx_abcdef123456/cleanup", "shared-secret", "false"],
+    ["POST", "/v1/leases/cbx_abcdef123456/cleanup", "shared-secret", "false"],
+  ])(
+    "replaces caller-supplied admin authority after authentication for %s %s",
+    async (method, path, token, admin) => {
+      const env = {
+        CRABBOX_ADMIN_TOKEN: "admin-secret",
+        CRABBOX_SHARED_TOKEN: "shared-secret",
+        CRABBOX_SHARED_OWNER: "alice@example.com",
+        CRABBOX_DEFAULT_ORG: "example-org",
+      } as Env;
+      const forgedVersion = "a".repeat(64);
+      const prepared = await prepareCoordinatorRequest(
+        new Request(`https://example.test${path}`, {
+          method,
+          headers: {
+            authorization: `Bearer ${token}`,
+            "x-crabbox-admin": "true",
+            "x-crabbox-admin-grant-version": forgedVersion,
+          },
+        }),
+        env,
+      );
 
-    expect(prepared).toMatchObject({ authenticated: true });
-    if ("response" in prepared) throw new Error("admin request was rejected");
-    expect(prepared.request.headers.get("x-crabbox-admin-grant-version")).toBe(
-      await adminGrantVersion(env),
-    );
-    expect(prepared.request.headers.get("x-crabbox-admin-grant-version")).not.toBe(forgedVersion);
-  });
+      expect(prepared).toMatchObject({ authenticated: true });
+      if ("response" in prepared) throw new Error("authenticated request was rejected");
+      expect(prepared.request.headers.get("x-crabbox-admin")).toBe(admin);
+      expect(prepared.request.headers.get("x-crabbox-admin-grant-version")).toBe(
+        await adminGrantVersion(env),
+      );
+      expect(prepared.request.headers.get("x-crabbox-admin-grant-version")).not.toBe(forgedVersion);
+    },
+  );
 
   it("requires normal coordinator authentication for workspace terminals", async () => {
     const unauthorized = await prepareCoordinatorRequest(

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
@@ -13,5 +13,7 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: false,
+    // The real-store proof runs separately against its job-local PostgreSQL service.
+    exclude: [...configDefaults.exclude, "test/aws-cleanup-recovery.postgres.test.ts"],
   },
 });

--- a/worker/vitest.postgres.config.ts
+++ b/worker/vitest.postgres.config.ts
@@ -1,0 +1,12 @@
+import { configDefaults, defineConfig } from "vitest/config";
+
+import base from "./vitest.config";
+
+export default defineConfig({
+  ...base,
+  test: {
+    ...base.test,
+    include: ["test/aws-cleanup-recovery.postgres.test.ts"],
+    exclude: configDefaults.exclude,
+  },
+});


### PR DESCRIPTION
## What Problem This Solves

The forward cleanup repair is now merged in https://github.com/openclaw/crabbox/pull/1904. It intentionally refuses to manufacture cleanup completion for an already-absent historical AWS instance whose original account scope was never recorded. This PR supplies the distinct, evidence-backed administrator recovery path.

Current incremental head: `d3f25520586461ef516b12ac7d398990f761c04d`, based on the merged forward repair `1efb91002f245683cfa4374a101c51c73b1601a9`. It does not reintroduce the forward changes as a separate implementation.

## Owner-Level Recovery

The existing cleanup inspection/acknowledgement API gains an AWS capability. One fixed credential snapshot verifies STS identity, reads bounded regional CloudTrail `LookupEvents`, and observes exact instance absence. A successful original `RunInstances` event must bind the account, Region, instance ID, canonical lease labels, and key. Both the creation-time `keyName` and `provider_key` tag are required.

After refreshed reads, the lifecycle owner rechecks administrator authority, retained lease binding, explicit deletion intent, and absence of active cleanup/provisioning owners. One existing transaction restores scope, records the bounded audit, and schedules ordinary cleanup. It does not manufacture a completion timestamp or discard remaining keys/access evidence. Explicit `releaseDeletesServer: true` remains authoritative when acquisition-time `keep` is true; recovery preserves `keep`.

The implementation reuses the current fixed-credential transport, preserves Azure's existing capability/argument contract, and does not change production schemas, application configuration, permissions, or dependencies.

## Verification

The integrated runtime and tests are byte-identical to the freshly reviewed candidate after rebasing onto the merged forward repair; only upstream release metadata changed.

- Worker format, lint, TypeScript and Node checks passed.
- Focused fleet/AWS/transport/HTTP tests: **1,451 passed**.
- Full unit suite: **3,145 passed, 15 skipped; 55 files passed, 2 skipped**.
- Both `keep` variants failed on the pre-integration base with the intended HTTP **501 versus 200** inspection failure, then passed with recovery installed.
- The existing public-ingress authentication table now covers cleanup GET/POST requests: caller-supplied administrator markers are replaced by authenticated authority rather than trusted.
- Worker, dynamic-worker, qualification-authority and Node builds passed. These are build checks, not deployment proof.
- Focused documentation validation and **16 documentation tests** passed.
- Fresh isolated Codex P0–P2 review of the complete incremental change plus consequential source context: **scoped-clean, no actionable findings**.

Exact-head CI passed at https://github.com/openclaw/crabbox/actions/runs/34672669895, including the existing coordinator/runtime checks and the real PostgreSQL integration. The PostgreSQL job executed its one focused test successfully in 6.292 seconds: https://github.com/openclaw/crabbox/actions/runs/34672669895/job/103496883945. The enforced Release Check also passed: https://github.com/openclaw/crabbox/actions/runs/34672669920. All results apply to current head `d3f25520586461ef516b12ac7d398990f761c04d`.

### Build scope and local limitation

An extra local `build:cloudflare` attempt first lacked Buildx discovery and then reached an amd64 container stage that could not execute on the ARM host. That attempt failed; it is not reported as a passing build. Direct source inspection established that this target is the separate `cloudflare-container-runner.ts` and Go sandbox image, with no FleetCoordinator dependency. The transient additional CI step was therefore removed from this AWS coordinator repair rather than expanding unrelated runner coverage. The reviewed coordinator builds and PostgreSQL integration remain unchanged. No architecture, service, credentials, or runtime code were changed to mask the host limitation.

### PostgreSQL proof and history

The dedicated test uses real PostgreSQL transactions and fresh runtime/connection pools. It forces rollback after scope/audit writes, checks physical SQL rows across reopen, verifies atomic scope/audit/wake persistence, resumes ordinary cleanup, and preserves then releases a separate scoped lease using its non-admin owner path. AWS transport and ingress fixtures are synthetic.

The previous candidate's all-12-jobs passing run is retained as historical evidence, not current-head proof: https://github.com/openclaw/crabbox/actions/runs/34193866641. Its PostgreSQL job used version 17.11 and passed in 6.394 seconds: https://github.com/openclaw/crabbox/actions/runs/34193866641/job/101957286450. The earlier fixture failure was corrected by sending the raw organization label on the wire, without weakening assertions.

Original test-first proof remains at https://github.com/openclaw/crabbox/actions/runs/34178407188: both principal cases reached the unsupported AWS cleanup path before implementation; that run recorded 12 failed, 2,958 passed, and 3 skipped.

## Qualification Limits

**Real AWS/CloudTrail final-effect tests and deployed Cloudflare Durable Object/SQLite upgrade/restart qualification remain UNRUN.** PostgreSQL proof and Linux container builds do not establish those results. The checked sandbox qualification configuration is unavailable, and its existing image-specific contract is not a general credential bridge. No production secrets were exported, shared credentials rotated, or qualification admission weakened.

The landing evidence is source review, public-ingress/boundary regression coverage, builds, and exact-head CI, with these residual live-qualification limits explicitly retained. This PR does not claim that any operator's historical lease has been repaired or cleaned up.
