### PR TITLE
perf(aws): bound concurrent ingress authorization batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- AWS: overlap SSH ingress authorization in bounded batches while preserving revocation, recovery and cleanup ordering. Thanks @steipete.
+
 - Overlap default-VPC and managed security-group discovery during AWS provisioning while retaining scope validation and joined failure handling. [PR 1974](https://github.com/openclaw/crabbox/pull/1974). Thanks @steipete.
 - Recover lost run-admission responses using a caller-known identity and an atomic initial history record, preserving authenticated request binding and refusing remote command replay. Current clients require a coordinator supporting the new admission route. [PR 1970](https://github.com/openclaw/crabbox/pull/1970), [Issue 1962](https://github.com/openclaw/crabbox/issues/1962). Thanks @steipete.
 - Add bounded AWS provisioning transport diagnostics for credential preparation, signing and SDK request time, including retry-loop signing counts, without changing retry behavior. [PR 1968](https://github.com/openclaw/crabbox/pull/1968). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- AWS: overlap SSH ingress authorization in bounded batches while preserving revocation, recovery and cleanup ordering. Thanks @steipete.
+- AWS: overlap SSH ingress authorization in bounded batches while preserving revocation, recovery and cleanup ordering. https://github.com/openclaw/crabbox/pull/1976. Thanks @steipete.
 
 - Overlap default-VPC and managed security-group discovery during AWS provisioning while retaining scope validation and joined failure handling. [PR 1974](https://github.com/openclaw/crabbox/pull/1974). Thanks @steipete.
 - Recover lost run-admission responses using a caller-known identity and an atomic initial history record, preserving authenticated request binding and refusing remote command replay. Current clients require a coordinator supporting the new admission route. [PR 1970](https://github.com/openclaw/crabbox/pull/1970), [Issue 1962](https://github.com/openclaw/crabbox/issues/1962). Thanks @steipete.

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -230,6 +230,10 @@ source ranges, then removes exact duplicates before reconciling each SSH port.
 Whitespace is trimmed; distinct IPv4 and IPv6 ranges keep their order. This does
 not reuse observed permissions: each unique desired range is still authorized,
 and stale-rule pruning and world-access revocation keep their existing policy.
+For each port, up to four authorization requests run together after revocation
+finishes. Every batch settles before recovery, another batch or the next port;
+rule-limit recovery compacts once and retries each affected rule. Diagnostic
+request-duration totals include overlapping requests and can exceed wall time.
 
 ### Environment variables (direct mode)
 

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -84,6 +84,8 @@ const awsMacHostQuotaSpecs: Record<string, { quotaCode: string; quotaName: strin
 const snapshotDeleteBackoffMs = [1_000, 2_000, 4_000, 8_000, 15_000, 30_000];
 const securityGroupVisibilityBackoffMs = [100, 200, 400, 800, 1_600, 3_200];
 const awsInstanceVisibilityBackoffMs = [1_000, 2_000, 4_000, 8_000, 15_000, 30_000];
+// Leave room below Workers' six-connection limit for concurrent quota discovery.
+const awsIngressBatchSize = 4;
 
 class AWSQueryError extends Error {
   constructor(
@@ -2481,42 +2483,54 @@ export class EC2SpotClient {
               },
             );
           }
-          for (const cidr of cidrs) {
-            // oxlint-disable-next-line eslint/no-await-in-loop -- duplicate ingress handling is per CIDR.
-            await measure("authorize_ingress", () => this.allowTCP(groupID, port, cidr)).catch(
-              (error: unknown) => {
+          for (let offset = 0; offset < cidrs.length; offset += awsIngressBatchSize) {
+            const batch = cidrs.slice(offset, offset + awsIngressBatchSize);
+            const canCompact = options.reconcile !== "additive" && !compactedAfterRuleLimit;
+            // Join every request before compaction, propagation retry or releasing
+            // the ingress owner. One failed request must not leave writes running.
+            // oxlint-disable-next-line eslint/no-await-in-loop -- bound each batch before starting more requests.
+            const results = await Promise.allSettled(
+              batch.map((cidr) =>
+                measure("authorize_ingress", () => this.allowTCP(groupID, port, cidr)),
+              ),
+            );
+            for (const [index, result] of results.entries()) {
+              if (result.status === "rejected") {
+                const error: unknown = result.reason;
+                const cidr = batch[index]!;
                 const message = error instanceof Error ? error.message : String(error);
                 if (message.includes("InvalidPermission.Duplicate")) {
                   options.diagnostics?.record("authorize_duplicate", 0);
-                  return;
+                  continue;
                 }
-                if (
-                  options.reconcile !== "additive" &&
-                  !compactedAfterRuleLimit &&
-                  isAWSSecurityGroupRuleLimitError(message)
-                ) {
-                  compactedAfterRuleLimit = true;
-                  return measure("compact_ingress", () =>
-                    this.compactSSHIngressForRuleLimit(groupID, ports, cidrs),
-                  ).then((compacted) => {
+                if (canCompact && isAWSSecurityGroupRuleLimitError(message)) {
+                  if (!compactedAfterRuleLimit) {
+                    compactedAfterRuleLimit = true;
+                    // oxlint-disable-next-line eslint/no-await-in-loop -- compact once after the entire batch has settled.
+                    const compacted = await measure("compact_ingress", () =>
+                      this.compactSSHIngressForRuleLimit(groupID, ports, cidrs),
+                    );
                     if (!compacted) {
                       throw error;
                     }
-                    return measure("authorize_ingress", () =>
-                      this.allowTCP(groupID, port, cidr),
-                    ).catch((retryError: unknown) => {
-                      const retryMessage =
-                        retryError instanceof Error ? retryError.message : String(retryError);
-                      if (!retryMessage.includes("InvalidPermission.Duplicate")) {
-                        throw retryError;
-                      }
-                      options.diagnostics?.record("authorize_duplicate", 0);
-                    });
+                  }
+                  // Every rule rejected before this batch's compaction gets one retry.
+                  // oxlint-disable-next-line eslint/no-await-in-loop -- recovery retries remain ordered after all initial writes finish.
+                  await measure("authorize_ingress", () =>
+                    this.allowTCP(groupID, port, cidr),
+                  ).catch((retryError: unknown) => {
+                    const retryMessage =
+                      retryError instanceof Error ? retryError.message : String(retryError);
+                    if (!retryMessage.includes("InvalidPermission.Duplicate")) {
+                      throw retryError;
+                    }
+                    options.diagnostics?.record("authorize_duplicate", 0);
                   });
+                  continue;
                 }
                 throw error;
-              },
-            );
+              }
+            }
           }
         }
         return groupID;

--- a/worker/test/aws-ingress-batches.test.ts
+++ b/worker/test/aws-ingress-batches.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, expect, it, vi } from "vitest";
+
+import { EC2SpotClient } from "../src/aws";
+import { leaseConfig } from "../src/config";
+import type { Env } from "../src/types";
+
+afterEach(() => vi.unstubAllGlobals());
+
+const xml = (body = "<Response />", status = 200) =>
+  new Response(body, { status, headers: { "content-type": "text/xml" } });
+const awsError = (code: string) =>
+  xml(`<Response><Errors><Error><Code>${code}</Code></Error></Errors></Response>`, 400);
+const cidrs = [
+  "198.51.100.1/32",
+  "198.51.100.2/32",
+  "2001:db8::1/128",
+  "198.51.100.3/32",
+  "198.51.100.4/32",
+];
+
+function harness(
+  authorize: (params: URLSearchParams, index: number) => Promise<Response>,
+  permissions = "",
+) {
+  const calls: URLSearchParams[] = [];
+  let index = 0;
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    const params = new URLSearchParams(await request.clone().text());
+    calls.push(params);
+    switch (params.get("Action")) {
+      case "DescribeSecurityGroups":
+        return xml(
+          `<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-fixture</groupId><groupName>crabbox-runners</groupName><ipPermissions>${permissions}</ipPermissions></item></securityGroupInfo></DescribeSecurityGroupsResponse>`,
+        );
+      case "RevokeSecurityGroupIngress":
+        return xml();
+      case "AuthorizeSecurityGroupIngress":
+        return authorize(params, index++);
+      default:
+        throw new Error(`Unexpected fixture action ${params.get("Action")}`);
+    }
+  });
+  const client = new EC2SpotClient(
+    { AWS_ACCESS_KEY_ID: "fixture", AWS_SECRET_ACCESS_KEY: "fixture" } as Env,
+    "eu-west-1",
+  );
+  const config = leaseConfig({
+    provider: "aws",
+    awsSGID: "sg-fixture",
+    awsSSHCIDRs: cidrs,
+    sshPort: "2222",
+    sshFallbackPorts: ["22"],
+    sshPublicKey: "ssh-ed25519 fixture",
+  });
+  return { client, config, calls };
+}
+
+it.each(["additive", "authoritative"] as const)(
+  "bounds concurrent authorizations and preserves port revocation order in %s mode",
+  async (reconcile) => {
+    const gates = Array.from({ length: 10 }, () => Promise.withResolvers<void>());
+    const entered: number[] = [];
+    const completed: number[] = [];
+    const { client, config, calls } = harness(async (_, index) => {
+      entered.push(index);
+      await gates[index]!.promise;
+      completed.push(index);
+      return index % 2 ? awsError("InvalidPermission.Duplicate") : xml();
+    });
+    const refresh = client.refreshSSHIngress(config, { reconcile });
+    try {
+      await vi.waitFor(() => expect(entered).toHaveLength(4));
+      expect(calls.slice(0, 2).map((p) => p.get("Action"))).toEqual([
+        "DescribeSecurityGroups",
+        "RevokeSecurityGroupIngress",
+      ]);
+      for (const index of [3, 2, 1]) gates[index]!.resolve();
+      await vi.waitFor(() => expect(completed).toHaveLength(3));
+      expect(entered).toHaveLength(4);
+      gates[0]!.resolve();
+      await vi.waitFor(() => expect(entered).toHaveLength(5));
+      expect(calls.filter((p) => p.get("Action") === "RevokeSecurityGroupIngress")).toHaveLength(1);
+      gates[4]!.resolve();
+      await vi.waitFor(() => expect(entered).toHaveLength(9));
+      expect(calls.filter((p) => p.get("Action") === "RevokeSecurityGroupIngress")).toHaveLength(2);
+      for (const gate of gates) gate.resolve();
+      await refresh;
+      const rules = calls.filter((p) => p.get("Action") === "AuthorizeSecurityGroupIngress");
+      expect(
+        rules
+          .map((p) => [
+            p.get("IpPermissions.1.FromPort"),
+            p.get("IpPermissions.1.IpRanges.1.CidrIp") ??
+              p.get("IpPermissions.1.Ipv6Ranges.1.CidrIpv6"),
+          ])
+          .toSorted(),
+      ).toEqual(["2222", "22"].flatMap((port) => cidrs.map((cidr) => [port, cidr])).toSorted());
+      expect(
+        rules.every(
+          (p) =>
+            p.get("GroupId") === "sg-fixture" &&
+            p.get("IpPermissions.1.IpProtocol") === "tcp" &&
+            p.get("IpPermissions.1.FromPort") === p.get("IpPermissions.1.ToPort"),
+        ),
+      ).toBe(true);
+    } finally {
+      for (const gate of gates) gate.resolve();
+      await refresh;
+    }
+  },
+);
+
+it("joins a full batch before one compaction and retries every rule rejected before it", async () => {
+  const gate = Promise.withResolvers<void>();
+  let entered = 0;
+  const { client, config, calls } = harness(async (_, index) => {
+    entered++;
+    if (index === 3) await gate.promise;
+    return index < 2 ? awsError("RulesPerSecurityGroupLimitExceeded") : xml();
+  }, "<item><ipProtocol>tcp</ipProtocol><fromPort>2222</fromPort><toPort>2222</toPort><ipRanges><item><cidrIp>203.0.113.1/32</cidrIp></item></ipRanges></item>");
+  const refresh = client.refreshSSHIngress({ ...config, sshFallbackPorts: [] });
+  try {
+    await vi.waitFor(() => expect(entered).toBe(4));
+    expect(calls.filter((p) => p.get("Action") === "DescribeSecurityGroups")).toHaveLength(1);
+    expect(calls.filter((p) => p.get("Action") === "RevokeSecurityGroupIngress")).toHaveLength(1);
+    gate.resolve();
+    await refresh;
+    expect(entered).toBe(7);
+    expect(calls.filter((p) => p.get("Action") === "DescribeSecurityGroups")).toHaveLength(2);
+    const revoked = calls.filter((p) => p.get("Action") === "RevokeSecurityGroupIngress");
+    expect(revoked.map((p) => p.get("IpPermissions.1.IpRanges.1.CidrIp"))).toEqual([
+      "0.0.0.0/0",
+      "203.0.113.1/32",
+    ]);
+    const authorized = calls.filter((p) => p.get("Action") === "AuthorizeSecurityGroupIngress");
+    expect(
+      authorized
+        .slice(4, 6)
+        .map(
+          (p) =>
+            p.get("IpPermissions.1.IpRanges.1.CidrIp") ??
+            p.get("IpPermissions.1.Ipv6Ranges.1.CidrIpv6"),
+        )
+        .toSorted(),
+    ).toEqual(
+      authorized
+        .slice(0, 2)
+        .map(
+          (p) =>
+            p.get("IpPermissions.1.IpRanges.1.CidrIp") ??
+            p.get("IpPermissions.1.Ipv6Ranges.1.CidrIpv6"),
+        )
+        .toSorted(),
+    );
+  } finally {
+    gate.resolve();
+    await refresh;
+  }
+});
+
+it("reports the first desired rule's failure after every in-flight request settles", async () => {
+  const gate = Promise.withResolvers<void>();
+  let entered = 0;
+  const { client, config, calls } = harness(async (params) => {
+    entered++;
+    if (params.get("IpPermissions.1.IpRanges.1.CidrIp") === cidrs[0]) {
+      await gate.promise;
+      return awsError("UnauthorizedOperation");
+    }
+    return awsError("RulesPerSecurityGroupLimitExceeded");
+  });
+  let settled = false;
+  const refresh = client.refreshSSHIngress(config).then(
+    () => {
+      settled = true;
+      return undefined;
+    },
+    (error: unknown) => {
+      settled = true;
+      return error;
+    },
+  );
+  try {
+    await vi.waitFor(() => expect(entered).toBe(4));
+    expect(settled).toBe(false);
+    expect(calls.filter((p) => p.get("Action") === "DescribeSecurityGroups")).toHaveLength(1);
+    gate.resolve();
+    const error = await refresh;
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("UnauthorizedOperation");
+    expect(entered).toBe(4);
+    expect(calls.filter((p) => p.get("Action") === "DescribeSecurityGroups")).toHaveLength(1);
+  } finally {
+    gate.resolve();
+    await refresh;
+  }
+});
+
+it.each([
+  {
+    code: "UnauthorizedOperation",
+    expected: expect.stringContaining("UnauthorizedOperation"),
+    count: 4,
+  },
+  { code: "InvalidGroup.NotFound", expected: undefined, count: 14 },
+])(
+  "joins pending authorization before reporting or retrying $code",
+  async ({ code, expected, count }) => {
+    const gate = Promise.withResolvers<void>();
+    let entered = 0;
+    const { client, config, calls } = harness(async (_, index) => {
+      entered++;
+      if (index === 1) await gate.promise;
+      return index === 0 ? awsError(code) : xml();
+    });
+    let settled = false;
+    const refresh = client.refreshSSHIngress(config, { reconcile: "additive" }).then(
+      () => {
+        settled = true;
+        return undefined;
+      },
+      (error: unknown) => {
+        settled = true;
+        return error;
+      },
+    );
+    try {
+      await vi.waitFor(() => expect(entered).toBe(4));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(settled).toBe(false);
+      expect(calls.filter((p) => p.get("Action") === "RevokeSecurityGroupIngress")).toHaveLength(1);
+      gate.resolve();
+      const result = await refresh;
+      expect(result instanceof Error ? result.message : result).toEqual(expected);
+      expect(entered).toBe(count);
+    } finally {
+      gate.resolve();
+      await refresh;
+    }
+  },
+);

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -131,6 +131,10 @@ describe("aws provider", () => {
       const baseFetch = globalThis.fetch;
       const actions: string[] = [];
       const authorized: Array<[string | null, string | null]> = [];
+      const authorizationGates = new Map<
+        string,
+        { arrived: number; gate: ReturnType<typeof Promise.withResolvers<void>> }
+      >();
       vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
         const request = input instanceof Request ? input : new Request(input, init);
         const params = new URLSearchParams(await request.clone().text());
@@ -145,7 +149,21 @@ describe("aws provider", () => {
         if (action) actions.push(action);
         if (action === "AuthorizeSecurityGroupIngress" || action === "RevokeSecurityGroupIngress") {
           const authorize = action === "AuthorizeSecurityGroupIngress";
-          vi.setSystemTime(Date.now() + (authorize ? 7 : 3));
+          if (authorize) {
+            const port = params.get("IpPermissions.1.FromPort")!;
+            const batch = authorizationGates.get(port) ?? {
+              arrived: 0,
+              gate: Promise.withResolvers<void>(),
+            };
+            authorizationGates.set(port, batch);
+            if (++batch.arrived === 2) {
+              vi.setSystemTime(Date.now() + 7);
+              batch.gate.resolve();
+            }
+            await batch.gate.promise;
+          } else {
+            vi.setSystemTime(Date.now() + 3);
+          }
           return ec2XMLResponse(
             `<Response><Errors><Error><Code>${authorize ? "InvalidPermission.Duplicate" : "InvalidPermission.NotFound"}</Code><Message>private-rule-canary</Message></Error></Errors></Response>`,
             400,
@@ -164,12 +182,14 @@ describe("aws provider", () => {
       expect(actions.filter((action) => action === "AuthorizeSecurityGroupIngress")).toHaveLength(
         4,
       );
-      expect(authorized).toEqual([
-        ["22", "203.0.113.7/32"],
-        ["22", "2001:db8::1/128"],
-        ["443", "203.0.113.7/32"],
-        ["443", "2001:db8::1/128"],
-      ]);
+      expect(authorized.toSorted()).toEqual(
+        [
+          ["22", "203.0.113.7/32"],
+          ["22", "2001:db8::1/128"],
+          ["443", "203.0.113.7/32"],
+          ["443", "2001:db8::1/128"],
+        ].toSorted(),
+      );
       expect(actions.filter((action) => action === "RevokeSecurityGroupIngress")).toHaveLength(2);
       expect(log).toHaveBeenCalledTimes(1);
       const encoded = String(log.mock.calls[0]![0]);

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -26237,13 +26237,21 @@ describe("fleet lease identity and idle", () => {
     const refreshStarted = deferred<void>();
     const finishRefresh = deferred<void>();
     const queued = deferred<void>();
+    const finishAuthorizations = deferred<void>();
+    let authorizations = 0;
     let refreshing = true;
     const fixture = awsIngressTestFleet(async (action) => {
       if (action === "AuthorizeSecurityGroupIngress") {
         if (refreshing) {
           refreshStarted.resolve();
           await finishRefresh.promise;
-        } else vi.setSystemTime(Date.now() + 7);
+        } else {
+          if (++authorizations === 2) {
+            vi.setSystemTime(Date.now() + 7);
+            finishAuthorizations.resolve();
+          }
+          await finishAuthorizations.promise;
+        }
       }
       return undefined;
     });
@@ -26307,6 +26315,7 @@ describe("fleet lease identity and idle", () => {
       );
     } finally {
       finishRefresh.resolve();
+      finishAuthorizations.resolve();
       await Promise.allSettled([refresh, ...(creating ? [creating] : [])]);
       createSpy.mockRestore();
       log.mockRestore();


### PR DESCRIPTION
AWS provisioning reauthorizes every desired SSH rule in series, including rules already present. An ordinary live AWS run recorded six duplicate-rule responses taking 26.917 seconds in total. Reauthorization remains necessary because observed permissions can be stale.

Run each port's desired authorizations in batches of at most four. Keep stale-rule pruning, world-access revocation and port order unchanged. Join the entire batch before reporting an error, retrying propagation, compacting rules or releasing the ingress owner. Rule-limit recovery compacts once and retries every affected rule from that batch; additive mode still cannot compact. Failure precedence follows desired-rule order.

The concurrency cap leaves room below the Worker connection limit for quota discovery. It changes scheduling only: no permission widening, skipped authorization, added retry policy, configuration option, persisted state or schema change.

Validation:

- Four initial regressions failed on unchanged production code, reproducing serial execution and premature failure/retry relative to the intended joined batch.
- Six focused tests cover bounded batches, both reconciliation modes, IPv4/IPv6 payloads, per-port revocation, duplicate responses, joined failure/propagation retry, deterministic error precedence and shared compaction with multiple rejected rules.
- Full Worker suite: 2,897 passed, three skipped. Existing lifecycle/cleanup, private groups, qualification, subnet, scope and ingress recovery coverage passed.
- Worker/Node type checks, lint, formatting, Worker/Node builds, docs build and diff check passed.
- Existing diagnostics fixtures now advance their controlled clock after both concurrent requests arrive. Exact duration, request-count and privacy assertions remain intact.
- Direct source review covered the AWS owner, Fleet ingress fence and callers, access refresh siblings, historical rule-limit recovery and the provider API contract. No additional agent review was used.

Production delta: +14 lines for bounded scheduling and joined recovery, tests +271, docs +6. No test-only production seam.

Contracts: [EC2 ingress authorization](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AuthorizeSecurityGroupIngress.html), [EC2 request throttling](https://docs.aws.amazon.com/ec2/latest/devguide/ec2-api-throttling.html), [Workers connection limits](https://developers.cloudflare.com/workers/platform/limits/).

Live validation passed on deployed head `7b8493489ed86e3011d3173a12a6ae7b56295d74` through ordinary public AWS CLI warmup, ready inspection, `uname -s`, signed execution receipt, Stop and canonical released/cleanup-complete status. No source upload was used. Configuration was unchanged; all owned process births and the SSH control directory were absent after cleanup. The official Wrangler tail was stopped and joined, with its task window and processes gone.

The actual provisioning record reported 24.933 seconds total and 14.209 seconds for security-group preparation. Six authorization requests still reached EC2 and returned duplicate-rule responses, totaling 24.537 seconds of request duration. Their wall-time phase was approximately 8.179 seconds, inferred from the security-group total less the joined read phase (0.469 seconds) and revocations (5.561 seconds). This is the expected overlap without skipping permissions. No transport or signing failure occurred. Fresh warmup took 74.494 seconds; the existing-machine runner took 11.041 seconds.

The preceding unbatched sample took 61.275 seconds to provision and 111.456 seconds to warm up. AWS read latency also changed, so the entire difference cannot be attributed to batching. This validates scheduling and a real operational improvement, not a stable latency percentile.

Candidate deployment passed: https://github.com/openclaw/crabbox/actions/runs/34177903842. CI: https://github.com/openclaw/crabbox/actions/runs/34177877827 (all jobs passed).


Merged as `cf54272326a0c816b39b9529e209511f5236b167`. Normal main deployment succeeded: https://github.com/openclaw/crabbox/actions/runs/34178793849. A fresh ordinary CLI flow built from clean main passed warmup, ready inspection, Linux command execution, signed receipt and canonical released/cleanup-complete status against that deployment. Main provisioning took 6.830 seconds; fresh-machine warmup took 58.623 seconds. This sample had four desired authorizations (two new, two duplicate) and faster AWS responses, so it is operational main proof rather than a controlled comparison with the six-rule candidate sample. Configuration remained unchanged, every owned process joined/exited, SSH control state was absent, and the official tail and its task window were closed.
