### PR TITLE
refactor: share raw byte-tail storage across providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Enforce controller and coordinator token-command output limits consistently during pipe copying, preserving the existing overflow errors and command deadlines. [PR 1971](https://github.com/openclaw/crabbox/pull/1971).
 - Share byte-prefix storage across command capture, controller responses, and coordinator token helpers while preserving each caller's limits, cancellation, and diagnostics. [PR 1972](https://github.com/openclaw/crabbox/pull/1972).
 - Reuse shared prefix storage for SSH diagnostics and artifact capture while preserving locked, cloned snapshots and truncation visibility. [PR 1973](https://github.com/openclaw/crabbox/pull/1973).
-- Share raw byte-tail storage for Agent Sandbox stderr and Blacksmith proof streams while preserving native exit handling, Actions URL discovery, and cloned snapshots.
+- Share raw byte-tail storage for Agent Sandbox stderr and Blacksmith proof streams while preserving native exit handling, Actions URL discovery, and cloned snapshots. [PR 1977](https://github.com/openclaw/crabbox/pull/1977).
 
 ## 0.52.0 - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Enforce controller and coordinator token-command output limits consistently during pipe copying, preserving the existing overflow errors and command deadlines. [PR 1971](https://github.com/openclaw/crabbox/pull/1971).
 - Share byte-prefix storage across command capture, controller responses, and coordinator token helpers while preserving each caller's limits, cancellation, and diagnostics. [PR 1972](https://github.com/openclaw/crabbox/pull/1972).
 - Reuse shared prefix storage for SSH diagnostics and artifact capture while preserving locked, cloned snapshots and truncation visibility. [PR 1973](https://github.com/openclaw/crabbox/pull/1973).
+- Share raw byte-tail storage for Agent Sandbox stderr and Blacksmith proof streams while preserving native exit handling, Actions URL discovery, and cloned snapshots.
 
 ## 0.52.0 - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Enforce controller and coordinator token-command output limits consistently during pipe copying, preserving the existing overflow errors and command deadlines. [PR 1971](https://github.com/openclaw/crabbox/pull/1971).
 - Share byte-prefix storage across command capture, controller responses, and coordinator token helpers while preserving each caller's limits, cancellation, and diagnostics. [PR 1972](https://github.com/openclaw/crabbox/pull/1972).
 - Reuse shared prefix storage for SSH diagnostics and artifact capture while preserving locked, cloned snapshots and truncation visibility. [PR 1973](https://github.com/openclaw/crabbox/pull/1973).
-- Share raw byte-tail storage for Agent Sandbox stderr and Blacksmith proof streams while preserving native exit handling, Actions URL discovery, and cloned snapshots. [PR 1977](https://github.com/openclaw/crabbox/pull/1977).
+- Share raw byte-tail storage for Agent Sandbox stderr and Blacksmith proof streams while preserving native exit handling, Actions URL discovery, and cloned snapshots. [PR 1977](https://github.com/openclaw/crabbox/pull/1977). Thanks @steipete.
 
 ## 0.52.0 - 2026-09-07
 

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -494,6 +494,14 @@ SSH retains its mutex-protected cloned snapshots and hides ordinary snapshots
 after truncation; its bounded diagnostic view still exposes the retained prefix
 and overflow flag.
 
+Raw byte-tail storage lives in `internal/tailbuffer`. Agent Sandbox stderr and
+Blacksmith proof streams share its finite last-N-byte retention and discard
+observation; it does not normalize text, lock, or add markers. Agent Sandbox
+retains stderr delivery order and native exit classification. Blacksmith keeps
+its mutex, cloned snapshots, first Actions URL detection before eviction, and
+the historical proof marker for a full-sized incoming chunk. Its URL scan carry
+uses the same storage owner without sharing URL policy with the leaf.
+
 Strict one-request/one-response JSON subprocesses may use
 `internal/providers/shared/procjson`. It owns bounded capture, cancellation
 grace, request encoding, and exact single-document decoding. Keep response

--- a/internal/providers/agentsandbox/kubernetes.go
+++ b/internal/providers/agentsandbox/kubernetes.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/openclaw/crabbox/internal/providers/shared"
+	"github.com/openclaw/crabbox/internal/tailbuffer"
 )
 
 var (
@@ -519,8 +520,7 @@ func (c *kubectlKubernetesClient) Exec(ctx context.Context, req podExecRequest) 
 	args = append(args, "--")
 	args = append(args, req.Command...)
 
-	var stderrTail tailBuffer
-	stderrTail.limit = kubectlErrorDetailLimitBytes
+	stderrTail := tailbuffer.NewLimited(kubectlErrorDetailLimitBytes)
 	stderr := io.Writer(&stderrTail)
 	if req.Stderr != nil {
 		stderr = io.MultiWriter(req.Stderr, &stderrTail)
@@ -603,32 +603,6 @@ func kubectlRemoteExitStatus(stderr string, processExitCode int) (int, bool) {
 		return 0, false
 	}
 	return code, true
-}
-
-type tailBuffer struct {
-	data  []byte
-	limit int
-}
-
-func (b *tailBuffer) Write(p []byte) (int, error) {
-	if b.limit <= 0 {
-		return len(p), nil
-	}
-	if len(p) >= b.limit {
-		b.data = append(b.data[:0], p[len(p)-b.limit:]...)
-		return len(p), nil
-	}
-	overflow := len(b.data) + len(p) - b.limit
-	if overflow > 0 {
-		copy(b.data, b.data[overflow:])
-		b.data = b.data[:len(b.data)-overflow]
-	}
-	b.data = append(b.data, p...)
-	return len(p), nil
-}
-
-func (b *tailBuffer) String() string {
-	return string(b.data)
 }
 
 func podStateFromObject(object kubernetesObject) podState {

--- a/internal/providers/agentsandbox/kubernetes_test.go
+++ b/internal/providers/agentsandbox/kubernetes_test.go
@@ -1163,13 +1163,21 @@ func TestKubectlExecOnlyMapsProvenRemoteExitStatus(t *testing.T) {
 				errors:  []error{errors.New("kubectl failed")},
 			}
 			client := &kubectlKubernetesClient{runner: runner, kubectl: "kubectl"}
+			var delivered bytes.Buffer
 			err := client.Exec(context.Background(), podExecRequest{
 				Namespace: "sandboxes",
 				Pod:       "sandbox-a",
 				Command:   []string{"false"},
+				Stderr:    &delivered,
 			})
 			if err == nil {
 				t.Fatal("exec unexpectedly succeeded")
+			}
+			if delivered.String() != tt.result.Stderr || !strings.Contains(err.Error(), strings.TrimSpace(tt.result.Stderr)) {
+				t.Fatalf("stderr delivery/capture changed: delivered=%q error=%v", delivered.String(), err)
+			}
+			if !runner.requests[0].DisableOutputCapture {
+				t.Fatal("exec unexpectedly requested runner output capture")
 			}
 			_, remote := remoteExitStatus(err)
 			if remote != tt.wantRemote {

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -1,6 +1,7 @@
 package blacksmith
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -19,6 +20,7 @@ import (
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
+	"github.com/openclaw/crabbox/internal/tailbuffer"
 )
 
 type Config = core.Config
@@ -451,10 +453,10 @@ func blacksmithArtifactOutputCaptureLimit(maxBytes int64) int64 {
 
 type blacksmithProofTailBuffer struct {
 	mu         sync.Mutex
-	data       []byte
-	scanTail   string
+	data       tailbuffer.Buffer
+	scanTail   tailbuffer.Buffer
 	actionsURL string
-	truncated  bool
+	fullChunk  bool
 }
 
 func firstNonBlank(values ...string) string {
@@ -462,43 +464,33 @@ func firstNonBlank(values ...string) string {
 }
 
 func newBlacksmithProofTailBuffer() *blacksmithProofTailBuffer {
-	return &blacksmithProofTailBuffer{data: make([]byte, 0, 32*1024)}
+	return &blacksmithProofTailBuffer{
+		data:     tailbuffer.NewLimited(blacksmithProofStreamCaptureBytes),
+		scanTail: tailbuffer.NewLimited(2048),
+	}
 }
 
 func (b *blacksmithProofTailBuffer) Write(p []byte) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.actionsURL == "" {
-		probe := b.scanTail + string(p)
+		probe := b.scanTail.String() + string(p)
 		if match := firstBlacksmithActionsURL(probe); match != "" {
 			b.actionsURL = match
 		}
-		if len(probe) > 2048 {
-			b.scanTail = probe[len(probe)-2048:]
-		} else {
-			b.scanTail = probe
-		}
+		_, _ = b.scanTail.Write(p)
 	}
-	if len(p) >= blacksmithProofStreamCaptureBytes {
-		b.data = append(b.data[:0], p[len(p)-blacksmithProofStreamCaptureBytes:]...)
-		b.truncated = true
-		return len(p), nil
-	}
-	overflow := len(b.data) + len(p) - blacksmithProofStreamCaptureBytes
-	if overflow > 0 {
-		copy(b.data, b.data[overflow:])
-		b.data = b.data[:len(b.data)-overflow]
-		b.truncated = true
-	}
-	b.data = append(b.data, p...)
-	return len(p), nil
+	// Proof artifacts historically mark a full-sized incoming chunk, even
+	// when it exactly fills an empty tail without discarding earlier bytes.
+	b.fullChunk = b.fullChunk || len(p) >= blacksmithProofStreamCaptureBytes
+	return b.data.Write(p)
 }
 
 func (b *blacksmithProofTailBuffer) Bytes() []byte {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	data := append([]byte(nil), b.data...)
-	if !b.truncated {
+	data := bytes.Clone(b.data.Bytes())
+	if !b.fullChunk && !b.data.Exceeded() {
 		return data
 	}
 	prefix := fmt.Appendf(nil, "[crabbox: proof stream kept last %d bytes]\n", blacksmithProofStreamCaptureBytes)

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"text/tabwriter"
 	"time"
@@ -889,6 +890,60 @@ func TestBlacksmithRunFailureStagesLocalCommand(t *testing.T) {
 				t.Error("summary lost exit or failure stage")
 			}
 		})
+	}
+}
+
+func TestBlacksmithProofTailPreservesRawBytesURLAndSnapshots(t *testing.T) {
+	b := newBlacksmithProofTailBuffer()
+	var expected []byte
+	for _, chunk := range [][]byte{
+		{}, []byte(strings.Repeat("setup\n", 350)),
+		[]byte("https://github.com/example-org/my-app/actions/"),
+		[]byte("runs/123\n"), {'x', 0xff, '\n'},
+		[]byte("https://github.com/example-org/my-app/actions/runs/456\n"),
+	} {
+		n, err := b.Write(chunk)
+		if n != len(chunk) || err != nil {
+			t.Fatalf("write=%d/%v, want %d/nil", n, err, len(chunk))
+		}
+		expected = append(expected, chunk...)
+		if got := b.Bytes(); !bytes.Equal(got, expected) {
+			t.Fatalf("raw snapshot=%q want=%q", got, expected)
+		}
+	}
+	if got := b.ActionsURL(); got != "https://github.com/example-org/my-app/actions/runs/123" {
+		t.Fatalf("first split URL=%q", got)
+	}
+	snapshot := b.Bytes()
+	snapshot[0] = '!'
+	if !bytes.Equal(b.Bytes(), expected) {
+		t.Fatal("returned snapshot aliases retained bytes")
+	}
+	if _, err := b.Write([]byte("later")); err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot) != len(expected) || string(snapshot[len(snapshot)-4:]) != "456\n" {
+		t.Fatal("later write changed the earlier snapshot")
+	}
+}
+
+func TestBlacksmithProofTailSerializesSmallWritesAndSnapshots(t *testing.T) {
+	b := newBlacksmithProofTailBuffer()
+	var group sync.WaitGroup
+	for range 2 {
+		group.Go(func() {
+			for range 8 {
+				if n, err := b.Write([]byte("line\n")); err != nil || n != 5 {
+					t.Errorf("write=%d/%v", n, err)
+				}
+				_ = b.Bytes()
+				_ = b.ActionsURL()
+			}
+		})
+	}
+	group.Wait()
+	if got := b.Bytes(); !bytes.Equal(got, []byte(strings.Repeat("line\n", 16))) {
+		t.Fatalf("serialized output=%q", got)
 	}
 }
 

--- a/internal/tailbuffer/buffer.go
+++ b/internal/tailbuffer/buffer.go
@@ -1,0 +1,49 @@
+// Package tailbuffer retains raw output tails without imposing caller error,
+// presentation or synchronization policy.
+package tailbuffer
+
+// Buffer acknowledges all input while retaining the last limited bytes. Its
+// zero value discards all input. Do not copy it after use or use it concurrently.
+// Limits bound retained bytes, not allocation capacity or process memory.
+type Buffer struct {
+	data     []byte
+	limit    int
+	exceeded bool
+}
+
+// NewLimited retains at most maxBytes; nonpositive limits discard all input.
+func NewLimited(maxBytes int) Buffer {
+	return Buffer{limit: max(0, maxBytes)}
+}
+
+// Write returns the full input length and nil, including when bytes are evicted.
+func (b *Buffer) Write(p []byte) (int, error) {
+	n := len(p)
+	if b.limit == 0 {
+		b.exceeded = b.exceeded || n > 0
+		return n, nil
+	}
+	if n >= b.limit {
+		b.exceeded = b.exceeded || len(b.data) > 0 || n > b.limit
+		b.data = append(b.data[:0], p[n-b.limit:]...)
+		return n, nil
+	}
+	if overflow := n - (b.limit - len(b.data)); overflow > 0 {
+		copy(b.data, b.data[overflow:])
+		b.data = b.data[:len(b.data)-overflow]
+		b.exceeded = true
+	}
+	b.data = append(b.data, p...)
+	return n, nil
+}
+
+// Bytes returns a borrowed view of the retained raw tail. Treat it as read-only;
+// it is valid only until the next Write.
+func (b *Buffer) Bytes() []byte { return b.data }
+
+// String returns the raw retained bytes without text normalization or a marker.
+func (b *Buffer) String() string { return string(b.data) }
+
+// Exceeded reports whether any input bytes have been discarded, including bytes
+// evicted by a later Write. Exact fill alone does not exceed the limit.
+func (b *Buffer) Exceeded() bool { return b.exceeded }

--- a/internal/tailbuffer/buffer_test.go
+++ b/internal/tailbuffer/buffer_test.go
@@ -1,0 +1,63 @@
+package tailbuffer
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestBufferRetention(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		buffer Buffer
+		limit  int
+		chunks [][]byte
+	}{
+		{name: "zero value", chunks: [][]byte{nil, []byte("a"), nil}},
+		{name: "zero limit", buffer: NewLimited(0), chunks: [][]byte{nil, []byte("ab"), nil}},
+		{name: "negative limit", buffer: NewLimited(-1), chunks: [][]byte{[]byte("ab"), nil}},
+		{name: "split crossing", buffer: NewLimited(4), limit: 4, chunks: [][]byte{nil, []byte("ab"), []byte("cd"), nil, []byte("e"), []byte("fg"), nil}},
+		{name: "exact single write", buffer: NewLimited(4), limit: 4, chunks: [][]byte{[]byte("abcd"), nil}},
+		{name: "exact replaces previous", buffer: NewLimited(4), limit: 4, chunks: [][]byte{[]byte("a"), []byte("bcde"), nil}},
+		{name: "larger chunk", buffer: NewLimited(3), limit: 3, chunks: [][]byte{[]byte("ab"), []byte("cdefghi"), []byte("j")}},
+		{name: "raw bytes", buffer: NewLimited(3), limit: 3, chunks: [][]byte{{'a', 0xf0, 0x9f}, {0x98, 0x80}, {0xff, 0}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var input []byte
+			for _, chunk := range tc.chunks {
+				n, err := tc.buffer.Write(chunk)
+				if n != len(chunk) || err != nil {
+					t.Fatalf("write=%d/%v, want %d/nil", n, err, len(chunk))
+				}
+				input = append(input, chunk...)
+				want := input[max(0, len(input)-tc.limit):]
+				if !bytes.Equal(tc.buffer.Bytes(), want) || tc.buffer.String() != string(want) || tc.buffer.Exceeded() != (len(input) > tc.limit) {
+					t.Fatalf("input=%q retained=%q exceeded=%v, want %q/%v", input, tc.buffer.Bytes(), tc.buffer.Exceeded(), want, len(input) > tc.limit)
+				}
+			}
+		})
+	}
+}
+
+func TestBufferCopyAndMethodSurface(t *testing.T) {
+	b := NewLimited(4)
+	if n, err := io.Copy(&b, struct{ io.Reader }{strings.NewReader("abcde")}); err != nil || n != 5 {
+		t.Fatalf("copy=%d/%v", n, err)
+	}
+	if n, err := io.WriteString(&b, "f"); err != nil || n != 1 {
+		t.Fatalf("write string=%d/%v", n, err)
+	}
+	if b.String() != "cdef" || !b.Exceeded() {
+		t.Fatalf("retained=%q exceeded=%v", b.String(), b.Exceeded())
+	}
+	var methods []string
+	bufferType := reflect.TypeOf(&b)
+	for i := 0; i < bufferType.NumMethod(); i++ {
+		methods = append(methods, bufferType.Method(i).Name)
+	}
+	if want := []string{"Bytes", "Exceeded", "String", "Write"}; !reflect.DeepEqual(methods, want) {
+		t.Fatalf("method surface=%v, want %v", methods, want)
+	}
+}


### PR DESCRIPTION
## Summary

Share raw byte-tail storage across Agent Sandbox stderr, Blacksmith proof streams, and Blacksmith's URL-scan carry. Delete the Agent Sandbox wrapper and all three local retention algorithms. The new `internal/tailbuffer` owns only finite last-N-byte retention and discard tracking.

Provider policy stays local. Agent Sandbox keeps stderr delivery order and native exit classification. Blacksmith keeps its mutex, cloned snapshots, first Actions URL scan before eviction, and its historical marker for a full-sized incoming chunk. No provider requests, authentication, configuration, lifecycle, cleanup, or output formats change. Prefix capture, line tails, UTF-8 logs, and file-backed capture remain separate policies.

This centralizes three algorithms and their storage-contract tests; it is not a net line-count reduction. Adapter production code shrinks by 34 lines, while the new 49-line leaf makes production net +15. Architecture documentation and Unreleased are updated.

## Verification

Reviewed branch base: `cf54272326a0c816b39b9529e209511f5236b167`. Current PR head: `98a9e8f0f034ce2ff97e72996e2824f5efae2d86`; tree: `2ffee492d049e80cb11177c0bc7e5f543df9d5ba`. CLI SHA-256: `267d679eb38e5d316891e75c3989a2faeeb19a936dd717e451fd773fd0f5ab44`.

- Baseline/candidate compatibility characterizations passed. Full race suites passed for the leaf, Agent Sandbox, and Blacksmith; vet and docs links passed. Parent-focused races passed again. The leaf covers tiny finite/zero/raw-byte/split/exact/over-cap cases and writer-method dispatch; provider tests retain URL, snapshot, locking, and exit-policy coverage. These are compatibility checks, not new bug-red claims.
- Independent Codex review is scoped-clean at P0 for both the original candidate and the current-base integration, not an all-priority certification.
- **Real Blacksmith Testbox:** one fresh native CLI-backed Testbox ran the healthy workload. Each saved stream contains exactly one complete expected marker line. Native same-ID status reached `completed` after explicit Stop; validated active inventory, local claims, connection keys, and all five local process groups were clear. The actual Actions repository, workflow path, branch, and dispatch event were independently verified at https://github.com/openclaw/crabbox/actions/runs/34178941415. That control workflow finished **cancelled**, with no failed steps; cancellation actor/cause was not established, and this is not described as CI success. Native authentication stayed in the existing CLI; a fixed HOME-only shim isolated Crabbox state without substituting provider responses.
- **Real Agent Sandbox/Kubernetes:** the candidate synced and verified source hashes in a real upstream-controller pod, completed a healthy command, then reused the same claim/Sandbox/pod UIDs for an ordinary command returning `7`. Timing classified it as `command-exit` with sync skipped. Explicit Stop and native garbage collection removed the exact claim, Sandbox, and pod; local claims and all 23 local process groups were clear. This used an owned local kind cluster, not a fake API, cloud-cluster qualification, or hostile-workload isolation test. The lab node, anonymous volume, new network, private kubeconfig, temporary lab HOME/Docker directories, and API listener were subsequently removed and independently checked.

Blacksmith executed the original `d2984c5eadde171a0ec2c80a12534cc66518ea4a` source. Integrating the two later AWS Worker changes preserved all 1,492 Go/module files and produced a byte-identical rebuilt CLI. This is explicit code/binary equivalence, not a claim that the integrated source tree was replayed on Blacksmith. Agent Sandbox ran the integrated `596a2759c583391eaa71f97e932a4882d762691f` candidate. Subsequent commits only add this PR link and contributor thanks to the changelog; all Go/module files remain unchanged. Native runs are not relabeled as replays of those documentation-only commits.

Two preparation/harness corrections are preserved in the evidence: Docker required RAM and swap limits to be updated together (the rejected preparation was fully cleaned), and the first Agent harness incorrectly compared a native SHA-256 scope annotation to the raw local scope. That partial run completed its workload and Stop, but did not test reuse. The source-backed one-line oracle correction was independently reviewed, and a second complete Agent lifecycle passed. Product code was unchanged by either correction. No live overflow, provider fault, identity-tampering, or remote-cancellation scenario was used.

Exact-head PR CI is verified: all seven workflows and all eleven main CI jobs passed; 28 checks completed (27 success, one skipped). No release, coordinator deployment, or fleet update is included.

The automated review's sole P3 request—contributor thanks in the changelog—has been addressed with `Thanks @steipete`. The current-head automated verdict is ready for maintainer review with no remaining findings; the maintainer source/native-proof review is complete.

## Landed result

Merged as `676f798dea15a867f5e6aa39cec8ec0e06474005`, with actual parent `f39f3eb29efe2fdeee2099210c1cadae04b5da2f` and tree `b3e1d0725e37b8baeed9738ac1f5adaebb691f8e`. The parent includes https://github.com/openclaw/crabbox/pull/1957, whose 26 test-only helper hoists were checked. The actual tree matches the exact composition of the reviewed head and that parent; it is not the isolated PR-head tree listed above. Merged-main Go/module files remain unchanged, its rebuilt CLI is byte-identical to both native proof binaries, and post-merge focused races plus three non-mutating script controls passed. Full closeout: https://github.com/openclaw/crabbox/pull/1977#issuecomment-5579115149.
