### PR TITLE
refactor(providers): share runtime clock fallback

### DIFF
--- a/internal/cli/runtime_clock.go
+++ b/internal/cli/runtime_clock.go
@@ -1,0 +1,11 @@
+package cli
+
+import "time"
+
+// ClockNow returns the injected time, or the system time when clock is nil.
+func ClockNow(clock Clock) time.Time {
+	if clock != nil {
+		return clock.Now()
+	}
+	return time.Now()
+}

--- a/internal/cli/runtime_clock_test.go
+++ b/internal/cli/runtime_clock_test.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"testing"
+	"time"
+)
+
+type clockNowFunc func() time.Time
+
+func (fn clockNowFunc) Now() time.Time { return fn() }
+
+type clockNowTypedNil struct{}
+
+var clockNowTypedNilSentinel = time.Date(2026, time.September, 7, 12, 34, 56, 0, time.UTC)
+
+func (*clockNowTypedNil) Now() time.Time { return clockNowTypedNilSentinel }
+
+type clockNowBackend struct {
+	rt Runtime
+}
+
+func TestClockNowNilUsesSystemTime(t *testing.T) {
+	before := time.Now()
+	got := ClockNow(nil)
+	after := time.Now()
+	if got.Before(before) || got.After(after) {
+		t.Fatalf("ClockNow(nil) = %v, want between %v and %v", got, before, after)
+	}
+}
+
+func TestClockNowCallsInjectedClockOnceAndAdvances(t *testing.T) {
+	first := time.Date(2026, time.September, 7, 1, 2, 3, 0, time.UTC)
+	calls := 0
+	clock := clockNowFunc(func() time.Time {
+		now := first.Add(time.Duration(calls) * time.Second)
+		calls++
+		return now
+	})
+	for i, want := range []time.Time{first, first.Add(time.Second)} {
+		if got := ClockNow(clock); got != want {
+			t.Fatalf("ClockNow() call %d = %v, want %v", i+1, got, want)
+		}
+		if calls != i+1 {
+			t.Fatalf("clock calls after invocation %d = %d, want %d", i+1, calls, i+1)
+		}
+	}
+}
+
+func TestClockNowDispatchesTypedNilClock(t *testing.T) {
+	var typedNil *clockNowTypedNil
+	var clock Clock = typedNil
+	if got := ClockNow(clock); got != clockNowTypedNilSentinel {
+		t.Fatalf("ClockNow(typed nil) = %v, want %v", got, clockNowTypedNilSentinel)
+	}
+}
+
+func TestClockNowPreservesExactValueAndLocation(t *testing.T) {
+	location := time.FixedZone("clock-now-test", 5*60*60+30*60)
+	want := time.Date(2026, time.September, 7, 8, 9, 10, 11, location)
+	if got := ClockNow(clockNowFunc(func() time.Time { return want })); got != want {
+		t.Fatalf("ClockNow() = %#v, want exact value %#v", got, want)
+	}
+}
+
+func TestClockNowBackendCallbackObservesRuntimeClockReplacement(t *testing.T) {
+	first := time.Date(2026, time.September, 7, 1, 0, 0, 0, time.UTC)
+	second := first.Add(time.Hour)
+	backend := &clockNowBackend{rt: Runtime{Clock: clockNowFunc(func() time.Time { return first })}}
+	now := func() time.Time { return ClockNow(backend.rt.Clock) }
+	if got := now(); got != first {
+		t.Fatalf("first callback time = %v, want %v", got, first)
+	}
+	backend.rt.Clock = clockNowFunc(func() time.Time { return second })
+	if got := now(); got != second {
+		t.Fatalf("callback after clock replacement = %v, want %v", got, second)
+	}
+}
+
+func TestRuntimeDoesNotImplementClock(t *testing.T) {
+	if _, ok := any(Runtime{}).(Clock); ok {
+		t.Fatal("Runtime unexpectedly implements Clock")
+	}
+	if _, ok := any(&Runtime{}).(Clock); ok {
+		t.Fatal("*Runtime unexpectedly implements Clock")
+	}
+}

--- a/internal/providers/agentsandbox/backend.go
+++ b/internal/providers/agentsandbox/backend.go
@@ -74,7 +74,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if req.Options.Tailscale.Enabled {
 		return exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	client, err := b.client(ctx)
 	if err != nil {
 		return err
@@ -84,7 +84,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 		return err
 	}
 	defer unlockOperation()
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s claim=%s sandbox=%s pod=%s\n", leaseID, slug, providerName, claimName, ready.SandboxName, ready.PodName)
 	if !req.Keep {
 		if expiresAt := strings.TrimSpace(claim.Labels[claimLabelExpiresAt]); expiresAt != "" {
@@ -115,7 +115,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		return RunResult{}, exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
 	}
 	workdir := path.Clean(b.cfg.AgentSandbox.Workdir)
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	client, err := b.client(ctx)
 	if err != nil {
 		return RunResult{}, err
@@ -143,7 +143,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		result.SyncDelegated = true
 		result, retErr = shared.PinDelegatedRunFailure(result, retErr)
 		shouldStop := acquired && !req.Keep && b.cfg.AgentSandbox.DeleteOnRelease
-		expired := claimTTLExpired(claim, b.now().UTC())
+		expired := claimTTLExpired(claim, core.ClockNow(b.rt.Clock).UTC())
 		if admitted && retErr != nil && !earlyExpiry && !expired {
 			handleDelegatedRunFailure(b.rt.Stderr, b.cfg, req, leaseID, slug, acquired, &shouldStop)
 		}
@@ -183,7 +183,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 			Provider: providerName, LeaseID: leaseID, Slug: slug, Reused: !acquired,
 			Kept: custody == runClaimRetained, CleanupCommand: agentSandboxCleanupCommand(leaseID),
 		}
-		result.Total = b.now().Sub(started)
+		result.Total = core.ClockNow(b.rt.Clock).Sub(started)
 		result = core.FinalizeRunResult(result, retErr)
 		if req.TimingJSON {
 			report := timingReportWithRunResult(timingReport{
@@ -239,7 +239,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 			return RunResult{}, err
 		}
 		custody = runClaimRetained
-		if claimTTLExpired(claim, b.now().UTC()) {
+		if claimTTLExpired(claim, core.ClockNow(b.rt.Clock).UTC()) {
 			earlyExpiry = true
 			return RunResult{}, exit(4, "agent-sandbox claim %s reached its TTL expiry; command not run", claim.LeaseID)
 		}
@@ -280,17 +280,17 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 			return RunResult{}, err
 		}
 	}
-	if claimTTLExpired(claim, b.now().UTC()) {
+	if claimTTLExpired(claim, core.ClockNow(b.rt.Clock).UTC()) {
 		return RunResult{}, exit(4, "agent-sandbox claim %s reached its TTL expiry; command not run", claim.LeaseID)
 	}
 	if req.SyncOnly {
 		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
 		return RunResult{}, nil
 	}
-	commandStart := b.now()
+	commandStart := core.ClockNow(b.rt.Clock)
 	exitCode, runErr := b.runCommand(ctx, client, ready, req, workdir)
 	result = shared.FinalizeDelegatedCommandOutcome(exitCode, runErr)
-	result.Command = b.now().Sub(commandStart)
+	result.Command = core.ClockNow(b.rt.Clock).Sub(commandStart)
 	if runErr != nil {
 		// Public callers already select typed errors through the transport wrapper;
 		// retain that code without reclassifying it as a workload exit.
@@ -342,7 +342,7 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 			if err != nil {
 				return nil, err
 			}
-			if expired, reason := sandboxClaimExpired(claim, liveClaim, b.now().UTC()); expired {
+			if expired, reason := sandboxClaimExpired(claim, liveClaim, core.ClockNow(b.rt.Clock).UTC()); expired {
 				state = "expired"
 				stateReason = reason
 			} else {
@@ -432,7 +432,7 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 		if err != nil {
 			return StatusView{}, err
 		}
-		if expired, reason := sandboxClaimExpired(claim, liveClaim, b.now().UTC()); expired {
+		if expired, reason := sandboxClaimExpired(claim, liveClaim, core.ClockNow(b.rt.Clock).UTC()); expired {
 			view := baseView
 			view.State = "expired"
 			view.Labels = cloneStringMap(baseView.Labels)
@@ -528,7 +528,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	if err != nil {
 		return err
 	}
-	now := b.now().UTC()
+	now := core.ClockNow(b.rt.Clock).UTC()
 	checked, removed, claimsRemoved := 0, 0, 0
 	for _, listedClaim := range claims {
 		if listedClaim.Provider != providerName || listedClaim.ProviderScope != claimScope(b.cfg) {
@@ -643,7 +643,7 @@ func (b *backend) createClaim(ctx context.Context, client kubernetesClient, requ
 	}
 	expiresAt := ""
 	if b.cfg.TTL > 0 {
-		deadline := b.now().UTC().Add(b.cfg.TTL)
+		deadline := core.ClockNow(b.rt.Clock).UTC().Add(b.cfg.TTL)
 		if deadline.Nanosecond() != 0 {
 			deadline = deadline.Truncate(time.Second).Add(time.Second)
 		}
@@ -705,7 +705,7 @@ func (b *backend) createClaim(ctx context.Context, client kubernetesClient, requ
 	if err != nil {
 		return "", "", "", sandboxReadiness{}, LeaseClaim{}, nil, b.rollbackCreatedClaim(client, leaseID, slug, repo, reclaim, claimResourceName, pending, expiresAt, recoveryNonce, err)
 	}
-	if claimTTLExpired(pendingClaim, b.now().UTC()) {
+	if claimTTLExpired(pendingClaim, core.ClockNow(b.rt.Clock).UTC()) {
 		cause := exit(4, "agent-sandbox claim %s reached its TTL expiry before becoming ready", leaseID)
 		return "", "", "", sandboxReadiness{}, LeaseClaim{}, nil, b.rollbackCreatedClaim(client, leaseID, slug, repo, reclaim, claimResourceName, pending, expiresAt, recoveryNonce, cause)
 	}
@@ -726,7 +726,7 @@ func (b *backend) waitForClaimReadiness(ctx context.Context, client kubernetesCl
 		if err != nil {
 			return sandboxReadiness{}, exit(4, "agent-sandbox claim %s has invalid TTL expiry %q", identity.LeaseID, identity.ExpiresAt)
 		}
-		remaining := expiresAt.Sub(b.now().UTC())
+		remaining := expiresAt.Sub(core.ClockNow(b.rt.Clock).UTC())
 		if remaining <= 0 {
 			return sandboxReadiness{}, claimTTLExpiryError{err: exit(4, "agent-sandbox claim %s reached its TTL expiry before becoming ready", identity.LeaseID)}
 		}

--- a/internal/providers/agentsandbox/backend_test.go
+++ b/internal/providers/agentsandbox/backend_test.go
@@ -1050,7 +1050,7 @@ func TestStatusReportsControllerClaimExpiredCondition(t *testing.T) {
 			liveClaim := fake.objects[sandboxClaimResource+"/"+cfg.AgentSandbox.Namespace+"/"+claimName]
 			liveClaim.Status.Conditions = append(liveClaim.Status.Conditions, conditionState{Type: "Ready", Status: "False", Reason: conditionReason})
 			wantReason := "controller reported " + conditionReason
-			if expired, reason := sandboxClaimExpired(claim, liveClaim, backend.now().UTC()); !expired || reason != wantReason {
+			if expired, reason := sandboxClaimExpired(claim, liveClaim, core.ClockNow(backend.rt.Clock).UTC()); !expired || reason != wantReason {
 				t.Fatalf("expired=%t reason=%q conditions=%#v", expired, reason, liveClaim.Status.Conditions)
 			}
 

--- a/internal/providers/agentsandbox/exec.go
+++ b/internal/providers/agentsandbox/exec.go
@@ -23,13 +23,6 @@ func (b *backend) cleanupContext(context.Context) (context.Context, context.Canc
 	return context.WithTimeout(context.Background(), agentSandboxCleanupTimeout)
 }
 
-func (b *backend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
-}
-
 func (b *backend) execShell(ctx context.Context, client kubernetesClient, ready sandboxReadiness, command string) error {
 	execCtx, cancel := b.execContext(ctx)
 	defer cancel()

--- a/internal/providers/agentsandbox/sync.go
+++ b/internal/providers/agentsandbox/sync.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (b *backend) syncWorkspace(ctx context.Context, client kubernetesClient, ready sandboxReadiness, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
-	start := b.now()
+	start := core.ClockNow(b.rt.Clock)
 	syncCtx := ctx
 	cancel := func() {}
 	if b.cfg.Sync.Timeout > 0 {
@@ -24,20 +24,20 @@ func (b *backend) syncWorkspace(ctx context.Context, client kubernetesClient, re
 	if err != nil {
 		return nil, 0, err
 	}
-	manifestStart := b.now()
+	manifestStart := core.ClockNow(b.rt.Clock)
 	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
 	if err != nil {
 		return nil, 0, exit(6, "build sync file list: %v", err)
 	}
-	manifestDuration := b.now().Sub(manifestStart)
+	manifestDuration := core.ClockNow(b.rt.Clock).Sub(manifestStart)
 
-	preflightStart := b.now()
+	preflightStart := core.ClockNow(b.rt.Clock)
 	if err := checkAgentSandboxSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
 		return nil, 0, err
 	}
-	preflightDuration := b.now().Sub(preflightStart)
+	preflightDuration := core.ClockNow(b.rt.Clock).Sub(preflightStart)
 
-	archiveStart := b.now()
+	archiveStart := core.ClockNow(b.rt.Clock)
 	archive, err := createPortableSyncArchive(syncCtx, req.Repo, manifest, "crabbox-agent-sandbox-sync-*.tgz")
 	if err != nil {
 		return nil, 0, err
@@ -46,7 +46,7 @@ func (b *backend) syncWorkspace(ctx context.Context, client kubernetesClient, re
 		_ = archive.Close()
 		_ = os.Remove(archive.Name())
 	}()
-	archiveDuration := b.now().Sub(archiveStart)
+	archiveDuration := core.ClockNow(b.rt.Clock).Sub(archiveStart)
 
 	extractDir := workdir
 	stagingDir := ""
@@ -67,7 +67,7 @@ func (b *backend) syncWorkspace(ctx context.Context, client kubernetesClient, re
 	}
 	defer cleanupRemote()
 
-	prepareStart := b.now()
+	prepareStart := core.ClockNow(b.rt.Clock)
 	if stagingDir == "" {
 		err = b.execShell(syncCtx, client, ready, "mkdir -p "+shellQuote(workdir))
 	} else {
@@ -76,9 +76,9 @@ func (b *backend) syncWorkspace(ctx context.Context, client kubernetesClient, re
 	if err != nil {
 		return nil, 0, err
 	}
-	prepareDuration := b.now().Sub(prepareStart)
+	prepareDuration := core.ClockNow(b.rt.Clock).Sub(prepareStart)
 
-	uploadStart := b.now()
+	uploadStart := core.ClockNow(b.rt.Clock)
 	if _, err := archive.Seek(0, 0); err != nil {
 		return nil, 0, exit(6, "rewind sync archive: %v", err)
 	}
@@ -93,21 +93,21 @@ func (b *backend) syncWorkspace(ctx context.Context, client kubernetesClient, re
 		}
 		return nil, 0, err
 	}
-	uploadDuration := b.now().Sub(uploadStart)
+	uploadDuration := core.ClockNow(b.rt.Clock).Sub(uploadStart)
 
 	replaceDuration := time.Duration(0)
 	if stagingDir != "" {
-		replaceStart := b.now()
+		replaceStart := core.ClockNow(b.rt.Clock)
 		if err := b.replaceWorkspace(syncCtx, client, ready, stagingDir, workdir); err != nil {
 			return nil, 0, err
 		}
-		replaceDuration = b.now().Sub(replaceStart)
+		replaceDuration = core.ClockNow(b.rt.Clock).Sub(replaceStart)
 	}
 
-	cleanupStart := b.now()
+	cleanupStart := core.ClockNow(b.rt.Clock)
 	cleanupPending = false
-	cleanupDuration := b.now().Sub(cleanupStart)
-	total := b.now().Sub(start)
+	cleanupDuration := core.ClockNow(b.rt.Clock).Sub(cleanupStart)
+	total := core.ClockNow(b.rt.Clock).Sub(start)
 	phases := []timingPhase{
 		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
 		{Name: "preflight", Ms: preflightDuration.Milliseconds()},

--- a/internal/providers/awslambdamicrovm/backend.go
+++ b/internal/providers/awslambdamicrovm/backend.go
@@ -49,7 +49,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if req.ActionsRunner {
 		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
-	started := now(b.rt)
+	started := core.ClockNow(b.rt.Clock)
 	control, runner, err := b.clients(ctx)
 	if err != nil {
 		return err
@@ -62,7 +62,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: %s warmup keeps the MicroVM until explicit stop\n", providerName)
 	}
-	total := now(b.rt).Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  leaseID,
@@ -75,7 +75,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	if err := delegatedSyncOptionsError(b.spec, req); err != nil {
 		return RunResult{}, err
 	}
-	started := now(b.rt)
+	started := core.ClockNow(b.rt.Clock)
 	control, runner, err := b.clients(ctx)
 	if err != nil {
 		return RunResult{}, err
@@ -85,7 +85,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
 			TempPattern: "crabbox-aws-lambda-microvm-sync-*.tgz", Stderr: b.rt.Stderr,
-			Now: func() time.Time { return now(b.rt) },
+			Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 		})
 		if err != nil {
 			return RunResult{}, err
@@ -123,7 +123,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 			return RunResult{}, exit(4, "%s image identity mismatch for lease %s", providerName, claim.LeaseID)
 		}
 		leaseID, slug = claim.LeaseID, claim.Slug
-		server.Labels = touchLeaseLabels(server.Labels, b.cfg, strings.ToLower(vm.State), now(b.rt))
+		server.Labels = touchLeaseLabels(server.Labels, b.cfg, strings.ToLower(vm.State), core.ClockNow(b.rt.Clock))
 		if err := claimLease(leaseID, slug, b.scope(), req.Options.Pond, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim, server); err != nil {
 			return RunResult{}, err
 		}
@@ -160,7 +160,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		} else {
 			session.Kept = true
 		}
-		result.Total = now(b.rt).Sub(started)
+		result.Total = core.ClockNow(b.rt.Clock).Sub(started)
 		result = core.FinalizeRunResult(result, retErr)
 		if commandRan {
 			fmt.Fprintf(b.rt.Stderr, "%s run summary sync=%s command=%s total=%s exit=%d\n", providerName, syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
@@ -203,9 +203,9 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	if req.EnvSummary {
 		printEnvForwardingSummary(b.rt.Stderr, req.Options.EnvAllow, req.Env)
 	}
-	commandStarted := now(b.rt)
+	commandStarted := core.ClockNow(b.rt.Clock)
 	exitCode, commandErr := runner.Exec(ctx, vm, command, b.cfg.AWSLambdaMicroVM.Workdir, req.Env, b.rt.Stdout, b.rt.Stderr)
-	result.Command = now(b.rt).Sub(commandStarted)
+	result.Command = core.ClockNow(b.rt.Clock).Sub(commandStarted)
 	result.CommandText = strings.Join(req.Command, " ")
 	commandRan = true
 	outcome := shared.FinalizeDelegatedCommandOutcome(exitCode, commandErr)
@@ -218,7 +218,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		handleDelegatedRunFailure(b.rt.Stderr, req, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 		return result, ExitError{Code: exitCode, Message: fmt.Sprintf("%s run exited %d", providerName, exitCode)}
 	}
-	server.Labels = touchLeaseLabels(server.Labels, b.cfg, strings.ToLower(vm.State), now(b.rt))
+	server.Labels = touchLeaseLabels(server.Labels, b.cfg, strings.ToLower(vm.State), core.ClockNow(b.rt.Clock))
 	if err := claimLease(leaseID, slug, b.scope(), req.Options.Pond, req.Repo.Root, b.cfg.IdleTimeout, true, server); err != nil {
 		failure, failureErr := shared.PinDelegatedRunFailure(RunResult{}, err)
 		result.ExitCode, result.Status, result.ErrorKind = failure.ExitCode, failure.Status, failure.ErrorKind
@@ -266,15 +266,15 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 	if err != nil {
 		return StatusView{}, err
 	}
-	deadline := now(b.rt).Add(req.WaitTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(req.WaitTimeout)
 	if req.WaitTimeout <= 0 {
-		deadline = now(b.rt).Add(lifecycleWaitTimeout)
+		deadline = core.ClockNow(b.rt.Clock).Add(lifecycleWaitTimeout)
 	}
 	for req.Wait && !microVMReady(vm.State) {
 		if microVMTerminal(vm.State) {
 			break
 		}
-		if now(b.rt).After(deadline) {
+		if core.ClockNow(b.rt.Clock).After(deadline) {
 			return StatusView{}, exit(5, "timed out waiting for AWS Lambda MicroVM %s", vm.ID)
 		}
 		if err := sleepContext(ctx, 2*time.Second); err != nil {
@@ -337,7 +337,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 		return err
 	}
 	for _, server := range servers {
-		shouldDelete, reason := shouldCleanupServer(server, now(b.rt))
+		shouldDelete, reason := shouldCleanupServer(server, core.ClockNow(b.rt.Clock))
 		if !shouldDelete {
 			fmt.Fprintf(b.rt.Stderr, "skip microvm id=%s reason=%s\n", server.CloudID, reason)
 			continue
@@ -453,7 +453,7 @@ func (b *backend) resolve(ctx context.Context, control controlPlane, identifier 
 }
 
 func (b *backend) waitReady(ctx context.Context, control controlPlane, runner runnerAPI, vm microVM) (microVM, error) {
-	deadline := now(b.rt).Add(lifecycleWaitTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(lifecycleWaitTimeout)
 	result, err := shared.Poll(context.WithoutCancel(ctx), 0, 2*time.Second,
 		func(context.Context, time.Duration) error { return sleepContext(ctx, 2*time.Second) },
 		func(context.Context) (microVM, error) { return control.Get(ctx, vm.ID) },
@@ -473,7 +473,7 @@ func (b *backend) waitReady(ctx context.Context, control controlPlane, runner ru
 					return true, nil
 				}
 			}
-			if now(b.rt).After(deadline) {
+			if core.ClockNow(b.rt.Clock).After(deadline) {
 				return false, exit(5, "timed out waiting for AWS Lambda MicroVM %s runner readiness", vm.ID)
 			}
 			return false, nil
@@ -513,7 +513,7 @@ func (b *backend) changeState(ctx context.Context, identifier, target string) er
 	if err != nil {
 		return err
 	}
-	deadline := now(b.rt).Add(lifecycleWaitTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(lifecycleWaitTimeout)
 	for {
 		vm, err = control.Get(ctx, vm.ID)
 		if err != nil {
@@ -523,7 +523,7 @@ func (b *backend) changeState(ctx context.Context, identifier, target string) er
 			fmt.Fprintf(b.rt.Stderr, "%s lease=%s microvm=%s\n", strings.ToLower(target), claim.LeaseID, vm.ID)
 			return nil
 		}
-		if microVMTerminal(vm.State) || now(b.rt).After(deadline) {
+		if microVMTerminal(vm.State) || core.ClockNow(b.rt.Clock).After(deadline) {
 			return exit(5, "AWS Lambda MicroVM %s did not reach %s (state=%s)", vm.ID, target, vm.State)
 		}
 		if err := sleepContext(ctx, 2*time.Second); err != nil {
@@ -558,7 +558,7 @@ func (b *backend) scope() string {
 }
 
 func (b *backend) server(vm microVM, leaseID, slug string, keep bool, existing map[string]string) Server {
-	labels := directLeaseLabels(b.cfg, leaseID, slug, keep, now(b.rt))
+	labels := directLeaseLabels(b.cfg, leaseID, slug, keep, core.ClockNow(b.rt.Clock))
 	for key, value := range existing {
 		labels[key] = value
 	}

--- a/internal/providers/awslambdamicrovm/core.go
+++ b/internal/providers/awslambdamicrovm/core.go
@@ -45,12 +45,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 
 func flagWasSet(fs *flag.FlagSet, name string) bool { return core.FlagWasSet(fs, name) }
 func newLeaseID() string                            { return core.NewLeaseID() }
-func now(rt Runtime) time.Time {
-	if rt.Clock != nil {
-		return rt.Clock.Now()
-	}
-	return time.Now()
-}
 func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
 	return core.AllocateClaimLeaseSlug(leaseID, requested)
 }

--- a/internal/providers/awslambdamicrovm/sync.go
+++ b/internal/providers/awslambdamicrovm/sync.go
@@ -20,7 +20,7 @@ func (b *backend) syncWorkspace(ctx context.Context, runner runnerAPI, vm microV
 		PhaseName:           "aws_lambda_microvm_sync",
 		Provider:            providerName,
 		Stderr:              b.rt.Stderr,
-		Now:                 func() time.Time { return now(b.rt) },
+		Now:                 func() time.Time { return core.ClockNow(b.rt.Clock) },
 		Upload: func(uploadCtx context.Context, remoteArchive string, body io.Reader) error {
 			return runner.Upload(uploadCtx, vm, remoteArchive, body)
 		},

--- a/internal/providers/azuredynamicsessions/backend.go
+++ b/internal/providers/azuredynamicsessions/backend.go
@@ -30,7 +30,7 @@ func (b *azureDynamicSessionsBackend) Warmup(ctx context.Context, req WarmupRequ
 	if req.ActionsRunner {
 		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	client, err := newAzureDynamicSessionsClient(ctx, b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -52,7 +52,7 @@ func (b *azureDynamicSessionsBackend) Warmup(ctx context.Context, req WarmupRequ
 		}
 		fmt.Fprintf(b.rt.Stderr, "released lease=%s session=%s\n", leaseID, leaseID)
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  leaseID,
@@ -86,7 +86,7 @@ func (b *azureDynamicSessionsBackend) Run(ctx context.Context, req RunRequest) (
 		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) {
 			return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 				Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-				TempPattern: "crabbox-azds-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+				TempPattern: "crabbox-azds-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 			})
 		},
 		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
@@ -194,7 +194,7 @@ func (b *azureDynamicSessionsBackend) Status(ctx context.Context, req StatusRequ
 	if waitTimeout <= 0 {
 		waitTimeout = 5 * time.Minute
 	}
-	deadline := b.now().Add(waitTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(waitTimeout)
 	pollCtx := ctx
 	cancel := func() {}
 	if req.Wait {
@@ -212,7 +212,7 @@ func (b *azureDynamicSessionsBackend) Status(ctx context.Context, req StatusRequ
 			if !req.Wait || view.Ready {
 				return view, nil
 			}
-			if b.now().After(deadline) {
+			if core.ClockNow(b.rt.Clock).After(deadline) {
 				return statusView{}, exit(5, "timed out waiting for session %s to become ready", leaseID)
 			}
 			select {
@@ -234,7 +234,7 @@ func (b *azureDynamicSessionsBackend) Status(ctx context.Context, req StatusRequ
 		if !isNotFoundError(err) || !req.Wait {
 			return statusView{}, providerError("get session", err)
 		}
-		if b.now().After(deadline) {
+		if core.ClockNow(b.rt.Clock).After(deadline) {
 			return statusView{}, exit(5, "timed out waiting for session %s to become ready", leaseID)
 		}
 		select {
@@ -472,11 +472,4 @@ func isNotFoundError(err error) bool {
 	}
 	return strings.Contains(apiErr.Body, "SessionWithIdentifierNotFound") ||
 		strings.Contains(apiErr.Body, "SessionNotFound")
-}
-
-func (b *azureDynamicSessionsBackend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }

--- a/internal/providers/azuredynamicsessions/sync.go
+++ b/internal/providers/azuredynamicsessions/sync.go
@@ -29,7 +29,7 @@ func (b *azureDynamicSessionsBackend) syncWorkspace(ctx context.Context, client 
 		PhaseName:           "azure_dynamic_sessions_sync",
 		Provider:            providerName,
 		Stderr:              b.rt.Stderr,
-		Now:                 b.now,
+		Now:                 func() time.Time { return core.ClockNow(b.rt.Clock) },
 		Upload: func(uploadCtx context.Context, remoteArchive string, body io.Reader) error {
 			archive, ok := body.(*os.File)
 			if !ok {

--- a/internal/providers/cloudflare/backend.go
+++ b/internal/providers/cloudflare/backend.go
@@ -57,7 +57,7 @@ func (b *cloudflareBackend) Warmup(ctx context.Context, req WarmupRequest) error
 	if req.ActionsRunner {
 		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	client, err := newCloudflareClient(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -70,7 +70,7 @@ func (b *cloudflareBackend) Warmup(ctx context.Context, req WarmupRequest) error
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: %s warmup keeps the container until explicit stop\n", providerName)
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  claim.LeaseID,
@@ -196,9 +196,9 @@ func (b *cloudflareBackend) Status(ctx context.Context, req StatusRequest) (Stat
 		return StatusView{}, err
 	}
 	client.useInstanceType(cloudflareClaimInstanceType(claim))
-	deadline := b.now().Add(req.WaitTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(req.WaitTimeout)
 	if req.WaitTimeout <= 0 {
-		deadline = b.now().Add(5 * time.Minute)
+		deadline = core.ClockNow(b.rt.Clock).Add(5 * time.Minute)
 	}
 	for {
 		sandbox, err := client.getSandbox(ctx, claim.LeaseID)
@@ -212,7 +212,7 @@ func (b *cloudflareBackend) Status(ctx context.Context, req StatusRequest) (Stat
 		if !req.Wait || view.Ready {
 			return view, nil
 		}
-		if b.now().After(deadline) {
+		if core.ClockNow(b.rt.Clock).After(deadline) {
 			return StatusView{}, exit(5, "timed out waiting for %s container %s to become ready", providerName, claim.LeaseID)
 		}
 		select {
@@ -501,13 +501,6 @@ func durationMillisecondsCeil(duration time.Duration) int64 {
 		return 0
 	}
 	return int64((duration + time.Millisecond - 1) / time.Millisecond)
-}
-
-func (b *cloudflareBackend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }
 
 func cloudflareClaimInstanceType(claim LeaseClaim) string {

--- a/internal/providers/cloudflare/sync.go
+++ b/internal/providers/cloudflare/sync.go
@@ -16,7 +16,7 @@ import (
 func (b *cloudflareBackend) prepareArchive(ctx context.Context, req RunRequest) (*core.PreparedArchive, error) {
 	return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-		TempPattern: "crabbox-cloudflare-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+		TempPattern: "crabbox-cloudflare-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 	})
 }
 
@@ -32,17 +32,17 @@ func (b *cloudflareBackend) syncWorkspace(ctx context.Context, client *cloudflar
 	phases, total, err := core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
 		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge, Workdir: workdir,
 		Provider: providerName, PhaseName: "cloudflare_sync", RemoteArchivePrefix: "crabbox-cloudflare-sync-",
-		Stderr: b.rt.Stderr, Now: b.now,
+		Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 		CleanupContext: func(context.Context) (context.Context, context.CancelFunc) { return cloudflareCleanupContext() },
 		Upload: func(uploadCtx context.Context, remoteArchive string, _ io.Reader) error {
-			start := b.now()
+			start := core.ClockNow(b.rt.Clock)
 			if err := b.prepareWorkspace(uploadCtx, client, sandboxID, workdir); err != nil {
 				return err
 			}
 			if err := b.checkRemoteDiskForSync(uploadCtx, client, sandboxID, workdir, prepared.Manifest.Bytes, prepared.Size); err != nil {
 				return err
 			}
-			diskDuration = b.now().Sub(start)
+			diskDuration = core.ClockNow(b.rt.Clock).Sub(start)
 			// Reopen the same owned snapshot to preserve this transport's exact Content-Length.
 			if err := client.uploadFile(uploadCtx, sandboxID, prepared.File.Name(), remoteArchive); err != nil {
 				return fmt.Errorf("upload archive: %w", err)

--- a/internal/providers/cloudflaredynamicworkers/backend.go
+++ b/internal/providers/cloudflaredynamicworkers/backend.go
@@ -12,6 +12,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type backend struct {
@@ -78,7 +80,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if req.Script == nil || len(req.Script.Data) == 0 {
 		return RunResult{}, exit(2, "%s requires --script or --script-stdin module source", providerName)
 	}
-	started := now(b.rt)
+	started := core.ClockNow(b.rt.Clock)
 	client, err := newLoaderAPI(b.cfg, b.rt)
 	if err != nil {
 		return RunResult{}, err
@@ -98,11 +100,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if req.EnvSummary {
 		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
-	commandStarted := now(b.rt)
+	commandStarted := core.ClockNow(b.rt.Clock)
 	run, err := client.Run(ctx, loaderReq)
-	commandDuration := now(b.rt).Sub(commandStarted)
+	commandDuration := core.ClockNow(b.rt.Clock).Sub(commandStarted)
 	if err != nil {
-		total := now(b.rt).Sub(started)
+		total := core.ClockNow(b.rt.Clock).Sub(started)
 		timingWritten := false
 		result := RunResult{
 			ExitCode:    1,
@@ -154,7 +156,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			fmt.Fprintf(b.rt.Stderr, "kept uncertain run=%s slug=%s after request error\n", leaseID, slug)
 			fmt.Fprintf(b.rt.Stderr, "inspect: crabbox status --provider %s --id %s\n", providerName, slug)
 			fmt.Fprintf(b.rt.Stderr, "stop: crabbox stop --provider %s --id %s\n", providerName, slug)
-			total = now(b.rt).Sub(started)
+			total = core.ClockNow(b.rt.Clock).Sub(started)
 			result.Total = total
 			if req.TimingJSON {
 				report := timingReportWithProviderError(timingReportWithRunResult(timingReport{
@@ -249,7 +251,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if exitCode != 0 {
 		runErr = ExitError{Code: exitCode, Message: fmt.Sprintf("%s run exited %d", providerName, exitCode)}
 	}
-	total := now(b.rt).Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	keepRun := req.Keep || cacheMode == "explicit" || (req.KeepOnFailure && exitCode != 0) || run.LifecycleUncertain
 	result := RunResult{
 		ExitCode:    exitCode,
@@ -359,9 +361,9 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 	if err != nil {
 		return StatusView{}, err
 	}
-	deadline := now(b.rt).Add(req.WaitTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(req.WaitTimeout)
 	if req.WaitTimeout <= 0 {
-		deadline = now(b.rt).Add(5 * time.Minute)
+		deadline = core.ClockNow(b.rt.Clock).Add(5 * time.Minute)
 	}
 	for {
 		status, err := client.Status(ctx, leaseID)
@@ -375,7 +377,7 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 		if !req.Wait || view.Ready || terminalState(view.State) {
 			return view, nil
 		}
-		if now(b.rt).After(deadline) {
+		if core.ClockNow(b.rt.Clock).After(deadline) {
 			return StatusView{}, exit(5, "timed out waiting for %s run %s to become ready", providerName, leaseID)
 		}
 		select {

--- a/internal/providers/cloudflaredynamicworkers/core.go
+++ b/internal/providers/cloudflaredynamicworkers/core.go
@@ -138,10 +138,3 @@ func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []s
 func rejectDelegatedSyncOptions(spec ProviderSpec, req RunRequest) error {
 	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
 }
-
-func now(rt Runtime) time.Time {
-	if rt.Clock != nil {
-		return rt.Clock.Now()
-	}
-	return time.Now()
-}

--- a/internal/providers/cloudflaresandbox/backend.go
+++ b/internal/providers/cloudflaresandbox/backend.go
@@ -86,7 +86,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if err != nil {
 		return err
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	api, err := b.client()
 	if err != nil {
 		return err
@@ -100,7 +100,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: cloudflare-sandbox warmup keeps the sandbox until explicit stop\n")
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  leaseID,
@@ -136,7 +136,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) {
 			return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 				Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-				TempPattern: "crabbox-cloudflare-sandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+				TempPattern: "crabbox-cloudflare-sandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 			})
 		},
 		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
@@ -272,7 +272,7 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 	if waitTimeout <= 0 {
 		waitTimeout = 5 * time.Minute
 	}
-	deadline := b.now().Add(waitTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(waitTimeout)
 	pollCtx := ctx
 	cancel := func() {}
 	if req.Wait {
@@ -318,7 +318,7 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 		if isTerminalState(state) {
 			return StatusView{}, exit(5, "cloudflare-sandbox sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
-		if b.now().After(deadline) {
+		if core.ClockNow(b.rt.Clock).After(deadline) {
 			return StatusView{}, exit(5, "timed out waiting for cloudflare-sandbox sandbox %s to become ready", sandboxID)
 		}
 		select {
@@ -387,7 +387,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 		}
 		return nil
 	}
-	now := b.now().UTC()
+	now := core.ClockNow(b.rt.Clock).UTC()
 	checked := 0
 	removed := 0
 	claimsRemoved := 0
@@ -755,13 +755,6 @@ func (b *backend) cleanupContext(ctx context.Context) (context.Context, context.
 
 func (b *backend) execTimeoutSecs() int {
 	return b.cfg.CloudflareSandbox.ExecTimeoutSecs
-}
-
-func (b *backend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }
 
 func normalizedSandboxState(sb sandboxSummary) string {

--- a/internal/providers/cloudflaresandbox/sync.go
+++ b/internal/providers/cloudflaresandbox/sync.go
@@ -21,7 +21,7 @@ func (b *backend) syncWorkspace(ctx context.Context, api bridgeClient, sandboxID
 		PhaseName:           "cloudflare_sandbox_sync",
 		Provider:            providerName,
 		Stderr:              b.rt.Stderr,
-		Now:                 b.now,
+		Now:                 func() time.Time { return core.ClockNow(b.rt.Clock) },
 		CleanupContext:      b.cleanupContext,
 		Upload: func(uploadCtx context.Context, remoteArchive string, body io.Reader) error {
 			return api.UploadFile(uploadCtx, sandboxID, remoteArchive, body)

--- a/internal/providers/cloudrunsandbox/backend.go
+++ b/internal/providers/cloudrunsandbox/backend.go
@@ -41,7 +41,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if req.Options.Tailscale.Enabled {
 		return exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	transport, err := newTransport(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -54,7 +54,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: cloud-run-sandbox warmup keeps the sandbox until explicit stop\n")
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  leaseID,
@@ -85,7 +85,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 	if err != nil {
 		return RunResult{}, err
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	transport, err := newTransport(b.cfg, b.rt)
 	if err != nil {
 		return RunResult{}, err
@@ -94,7 +94,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 	if req.ID == "" && !req.NoSync {
 		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-			TempPattern: "crabbox-cloud-run-sandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+			TempPattern: "crabbox-cloud-run-sandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 		})
 		if err != nil {
 			return RunResult{}, err
@@ -155,7 +155,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 		} else {
 			session.Kept = true
 		}
-		finalResult.Total = b.now().Sub(started)
+		finalResult.Total = core.ClockNow(b.rt.Clock).Sub(started)
 		finalResult = core.FinalizeRunResult(finalResult, finalErr)
 		if commandRan {
 			if req.NoSync {
@@ -171,7 +171,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 			finalResult, finalErr = appendRunFailure(finalResult, finalErr, writeTimingJSON(b.rt.Stderr, report))
 		}
 	}()
-	activityTimeout, err := claimOperationTimeout(claim, leaseActivityTimeout, b.now().UTC())
+	activityTimeout, err := claimOperationTimeout(claim, leaseActivityTimeout, core.ClockNow(b.rt.Clock).UTC())
 	if err != nil {
 		return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Session: session}, err
 	}
@@ -199,16 +199,16 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 				}
 				if err != nil {
 					handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-					return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: b.now().Sub(started), SyncDelegated: true, Session: session}, err
+					return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: core.ClockNow(b.rt.Clock).Sub(started), SyncDelegated: true, Session: session}, err
 				}
 				fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
 			} else if err := b.ensureWorkspace(ctx, transport, sandboxID, workdir); err != nil {
 				handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-				return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: b.now().Sub(started), SyncDelegated: true, Session: session}, err
+				return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: core.ClockNow(b.rt.Clock).Sub(started), SyncDelegated: true, Session: session}, err
 			}
 
 			if req.SyncOnly {
-				result := RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: b.now().Sub(started), SyncDelegated: true, Session: session}
+				result := RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: core.ClockNow(b.rt.Clock).Sub(started), SyncDelegated: true, Session: session}
 				fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
 				if req.TimingJSON {
 					pendingTiming = timingReport{
@@ -230,9 +230,9 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 			if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
 				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 			}
-			commandStart := b.now()
+			commandStart := core.ClockNow(b.rt.Clock)
 			exitCode, runErr := b.execCommand(ctx, transport, sandboxID, workdir, command, req.Env, b.rt.Stdout, b.rt.Stderr)
-			commandDuration := b.now().Sub(commandStart)
+			commandDuration := core.ClockNow(b.rt.Clock).Sub(commandStart)
 			commandRan = true
 			outcome := shared.FinalizeDelegatedCommandOutcome(exitCode, runErr)
 			if runErr != nil {
@@ -247,7 +247,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 				Status:        outcome.Status,
 				ErrorKind:     outcome.ErrorKind,
 				Command:       commandDuration,
-				Total:         b.now().Sub(started),
+				Total:         core.ClockNow(b.rt.Clock).Sub(started),
 				SyncDelegated: true,
 				Provider:      providerName,
 				LeaseID:       leaseID,
@@ -464,7 +464,7 @@ func (b *backend) claimStatus(claim LeaseClaim) (string, bool) {
 		ready = false
 	}
 	if expiresAt := strings.TrimSpace(claim.Labels[claimExpiresAtLabel]); expiresAt != "" {
-		if expires, parseErr := time.Parse(time.RFC3339Nano, expiresAt); parseErr != nil || !b.now().UTC().Before(expires) {
+		if expires, parseErr := time.Parse(time.RFC3339Nano, expiresAt); parseErr != nil || !core.ClockNow(b.rt.Clock).UTC().Before(expires) {
 			state = "expired"
 			ready = false
 		}
@@ -503,7 +503,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	if err != nil {
 		return err
 	}
-	now := b.now().UTC()
+	now := core.ClockNow(b.rt.Clock).UTC()
 	checked, removed, claimsRemoved := 0, 0, 0
 	var cleanupErrs []error
 	var transport sandboxTransport
@@ -621,7 +621,7 @@ func (b *backend) releaseClaimedSandboxIfUnchanged(ctx context.Context, transpor
 func (b *backend) markClaimActivity(claim LeaseClaim, state string, timeout time.Duration) (LeaseClaim, error) {
 	labels := cloneLabels(claim.Labels)
 	labels[claimStateLabel] = state
-	activeUntil := b.now().UTC().Add(timeout)
+	activeUntil := core.ClockNow(b.rt.Clock).UTC().Add(timeout)
 	if expires, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(labels[claimExpiresAtLabel])); err == nil && expires.Before(activeUntil) {
 		activeUntil = expires
 	}
@@ -633,7 +633,7 @@ func (b *backend) clearClaimActivity(claim LeaseClaim) (LeaseClaim, error) {
 	labels := cloneLabels(claim.Labels)
 	delete(labels, claimStateLabel)
 	delete(labels, claimActiveUntilLabel)
-	return updateLeaseClaimLabelsAndLastUsedIfUnchanged(claim.LeaseID, claim, labels, b.now().UTC())
+	return updateLeaseClaimLabelsAndLastUsedIfUnchanged(claim.LeaseID, claim, labels, core.ClockNow(b.rt.Clock).UTC())
 }
 
 func cloneLabels(labels map[string]string) map[string]string {
@@ -740,7 +740,7 @@ func (b *backend) createSandbox(ctx context.Context, transport sandboxTransport,
 	labels := map[string]string{}
 	labels[claimStateLabel] = "creating"
 	labels[claimOwnershipLabel] = sandboxID
-	now := b.now().UTC()
+	now := core.ClockNow(b.rt.Clock).UTC()
 	activeUntil := now.Add(defaultExecTimeout)
 	if b.cfg.TTL > 0 {
 		expiresAt := now.Add(b.cfg.TTL)
@@ -764,7 +764,7 @@ func (b *backend) createSandbox(ctx context.Context, transport sandboxTransport,
 	if err != nil {
 		return "", "", "", LeaseClaim{}, err
 	}
-	createTimeout, err := claimOperationTimeout(claim, defaultExecTimeout, b.now().UTC())
+	createTimeout, err := claimOperationTimeout(claim, defaultExecTimeout, core.ClockNow(b.rt.Clock).UTC())
 	if err != nil {
 		return "", "", "", LeaseClaim{}, err
 	}
@@ -897,13 +897,6 @@ func (b *backend) claimScope() (string, error) {
 	cli := blank(strings.TrimSpace(b.cfg.CloudRunSandbox.CLIPath), defaultCLIPath)
 	sum := sha256.Sum256([]byte("direct:" + cli))
 	return "direct:" + hex.EncodeToString(sum[:8]), nil
-}
-
-func (b *backend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }
 
 func (b *backend) cleanupContext(parent context.Context) (context.Context, context.CancelFunc) {

--- a/internal/providers/cloudrunsandbox/sync.go
+++ b/internal/providers/cloudrunsandbox/sync.go
@@ -26,7 +26,7 @@ func (b *backend) syncWorkspace(ctx context.Context, transport sandboxTransport,
 		PhaseName:           "cloud_run_sandbox_sync",
 		Provider:            providerName,
 		Stderr:              b.rt.Stderr,
-		Now:                 b.now,
+		Now:                 func() time.Time { return core.ClockNow(b.rt.Clock) },
 		CleanupContext:      b.cleanupContext,
 		Upload: func(uploadCtx context.Context, remoteArchive string, body io.Reader) error {
 			return b.uploadArchive(uploadCtx, transport, sandboxID, remoteArchive, body)

--- a/internal/providers/codesandbox/backend.go
+++ b/internal/providers/codesandbox/backend.go
@@ -27,7 +27,7 @@ func (b *codeSandboxBackend) Warmup(ctx context.Context, req WarmupRequest) erro
 	if req.ActionsRunner {
 		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	api, err := newCodeSandboxClient(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -40,7 +40,7 @@ func (b *codeSandboxBackend) Warmup(ctx context.Context, req WarmupRequest) erro
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: codesandbox warmup keeps the sandbox until explicit stop\n")
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  leaseID,
@@ -77,7 +77,7 @@ func (b *codeSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) {
 			return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 				Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-				TempPattern: "crabbox-codesandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+				TempPattern: "crabbox-codesandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 			})
 		},
 		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
@@ -189,7 +189,7 @@ func (b *codeSandboxBackend) Status(ctx context.Context, req StatusRequest) (Sta
 	if waitTimeout <= 0 {
 		waitTimeout = 5 * time.Minute
 	}
-	deadline := b.now().Add(waitTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(waitTimeout)
 	pollCtx := ctx
 	cancel := func() {}
 	if req.Wait {
@@ -235,7 +235,7 @@ func (b *codeSandboxBackend) Status(ctx context.Context, req StatusRequest) (Sta
 		if isTerminalState(state) {
 			return StatusView{}, exit(5, "codesandbox sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
-		if b.now().After(deadline) {
+		if core.ClockNow(b.rt.Clock).After(deadline) {
 			return StatusView{}, exit(5, "timed out waiting for codesandbox sandbox %s to become ready", sandboxID)
 		}
 		select {
@@ -282,7 +282,7 @@ func (b *codeSandboxBackend) Cleanup(ctx context.Context, req CleanupRequest) er
 	if err != nil {
 		return err
 	}
-	now := b.now().UTC()
+	now := core.ClockNow(b.rt.Clock).UTC()
 	checked := 0
 	removed := 0
 	for _, listed := range claims {

--- a/internal/providers/codesandbox/claims.go
+++ b/internal/providers/codesandbox/claims.go
@@ -233,13 +233,6 @@ func randomSuffix() string {
 	return shared.RandomSuffix()
 }
 
-func (b *codeSandboxBackend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
-}
-
 func (b *codeSandboxBackend) cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.WithoutCancel(ctx), codeSandboxCleanupTimeout)
 }

--- a/internal/providers/codesandbox/sync.go
+++ b/internal/providers/codesandbox/sync.go
@@ -22,7 +22,7 @@ func (b *codeSandboxBackend) syncWorkspace(ctx context.Context, api codeSandboxA
 		PhaseName:           "codesandbox_sync",
 		Provider:            providerName,
 		Stderr:              b.rt.Stderr,
-		Now:                 b.now,
+		Now:                 func() time.Time { return core.ClockNow(b.rt.Clock) },
 		CleanupContext:      b.cleanupContext,
 		Upload: func(uploadCtx context.Context, remoteArchive string, body io.Reader) error {
 			return api.UploadFile(uploadCtx, sandboxID, remoteArchive, body)

--- a/internal/providers/crownest/backend.go
+++ b/internal/providers/crownest/backend.go
@@ -61,7 +61,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if req.Options.Tailscale.Enabled {
 		return exit(2, "provider=crownest is delegated-run only and does not support Tailscale options")
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	api, err := b.client()
 	if err != nil {
 		return err
@@ -74,7 +74,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: crownest warmup keeps the sandbox until explicit stop\n")
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  leaseID,
@@ -96,7 +96,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	if req.Options.Tailscale.Enabled {
 		return RunResult{}, exit(2, "provider=crownest is delegated-run only and does not support Tailscale options")
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	api, err := b.client()
 	if err != nil {
 		return RunResult{}, err
@@ -168,7 +168,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 			}
 			appendFailure(cleanupErr)
 		}
-		result.Total = b.now().Sub(started)
+		result.Total = core.ClockNow(b.rt.Clock).Sub(started)
 		result = core.FinalizeRunResult(result, retErr)
 		if !commandRan {
 			return
@@ -202,7 +202,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	archive, archiveSHA, archiveBytes, phases, duration, err := b.prepareArchive(ctx, req)
 	syncPhases, syncDuration = phases, duration
 	if err != nil {
-		return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, err
+		return RunResult{Total: core.ClockNow(b.rt.Clock).Sub(started), SyncDelegated: true}, err
 	}
 	defer func() {
 		_ = archive.Close()
@@ -280,11 +280,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		}
 	}
 	session := b.crownestRunSession(leaseID, slug, !acquired, req.Keep || !acquired)
-	commandStart := b.now()
+	commandStart := core.ClockNow(b.rt.Clock)
 	commandRan, cancelActiveRun = true, true
 	cancelRunID = workspaceRun.ID
 	terminal, streamErr := b.streamRun(ctx, api, workspaceRun.ID)
-	commandDuration := b.now().Sub(commandStart)
+	commandDuration := core.ClockNow(b.rt.Clock).Sub(commandStart)
 	if terminal.ID == "" && ctx.Err() == nil {
 		if latest, getErr := api.GetWorkspaceRun(ctx, workspaceRun.ID); getErr == nil {
 			terminal = latest
@@ -308,7 +308,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		CommandText:   commandText,
 		ExitCode:      exitCode,
 		Command:       commandDuration,
-		Total:         b.now().Sub(started),
+		Total:         core.ClockNow(b.rt.Clock).Sub(started),
 		SyncDelegated: true,
 		Session:       session,
 	}
@@ -365,7 +365,7 @@ func (b *backend) claimAcquiredSandbox(ctx context.Context, api client, req RunR
 func (b *backend) setupFailure(ctx context.Context, req RunRequest, api client, cause error, started time.Time, acquired bool, leaseID, sandboxID, slug string, shouldStop *bool) (RunResult, error) {
 	if acquired && sandboxID != "" && leaseID == "" {
 		if err := b.claimAcquiredSandbox(ctx, api, req, leaseID, sandboxID, slug, &leaseID, &slug); err != nil {
-			return RunResult{Provider: providerName, ExitCode: 1, Total: b.now().Sub(started), SyncDelegated: true}, errors.Join(cause, err)
+			return RunResult{Provider: providerName, ExitCode: 1, Total: core.ClockNow(b.rt.Clock).Sub(started), SyncDelegated: true}, errors.Join(cause, err)
 		}
 	}
 	if leaseID != "" {
@@ -376,7 +376,7 @@ func (b *backend) setupFailure(ctx context.Context, req RunRequest, api client, 
 		LeaseID:       leaseID,
 		Slug:          slug,
 		ExitCode:      1,
-		Total:         b.now().Sub(started),
+		Total:         core.ClockNow(b.rt.Clock).Sub(started),
 		SyncDelegated: true,
 		Session:       b.crownestRunSession(leaseID, slug, !acquired, leaseID != "" && !*shouldStop),
 	}, cause
@@ -539,7 +539,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 		return err
 	}
 	scope := claimScope(api.BaseURL(), b.cfg)
-	now := b.now().UTC()
+	now := core.ClockNow(b.rt.Clock).UTC()
 	checked := 0
 	removed := 0
 	claimsRemoved := 0
@@ -658,7 +658,7 @@ func (b *backend) cleanupCreateFailure(ctx context.Context, api client, sandboxI
 }
 
 func (b *backend) prepareArchive(ctx context.Context, req RunRequest) (*os.File, string, int64, []timingPhase, time.Duration, error) {
-	start := b.now()
+	start := core.ClockNow(b.rt.Clock)
 	syncCtx := ctx
 	cancel := func() {}
 	if b.cfg.Sync.Timeout > 0 {
@@ -669,30 +669,30 @@ func (b *backend) prepareArchive(ctx context.Context, req RunRequest) (*os.File,
 	if err != nil {
 		return nil, "", 0, nil, 0, err
 	}
-	manifestStart := b.now()
+	manifestStart := core.ClockNow(b.rt.Clock)
 	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
 	if err != nil {
 		return nil, "", 0, nil, 0, exit(6, "build sync file list: %v", err)
 	}
-	manifestDuration := b.now().Sub(manifestStart)
-	preflightStart := b.now()
+	manifestDuration := core.ClockNow(b.rt.Clock).Sub(manifestStart)
+	preflightStart := core.ClockNow(b.rt.Clock)
 	if err := checkSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
 		return nil, "", 0, nil, 0, err
 	}
-	preflightDuration := b.now().Sub(preflightStart)
-	archiveStart := b.now()
+	preflightDuration := core.ClockNow(b.rt.Clock).Sub(preflightStart)
+	archiveStart := core.ClockNow(b.rt.Clock)
 	archive, err := createPortableSyncArchive(syncCtx, req.Repo, manifest, "crabbox-crownest-sync-*.tgz")
 	if err != nil {
 		return nil, "", 0, nil, 0, err
 	}
-	archiveDuration := b.now().Sub(archiveStart)
+	archiveDuration := core.ClockNow(b.rt.Clock).Sub(archiveStart)
 	sum, size, err := hashArchive(archive)
 	if err != nil {
 		_ = archive.Close()
 		_ = os.Remove(archive.Name())
 		return nil, "", 0, nil, 0, err
 	}
-	total := b.now().Sub(start)
+	total := core.ClockNow(b.rt.Clock).Sub(start)
 	return archive, sum, size, []timingPhase{
 		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
 		{Name: "preflight", Ms: preflightDuration.Milliseconds()},
@@ -956,11 +956,4 @@ func repoName(repo Repo) string {
 
 func randomSuffix() string {
 	return shared.RandomSuffix()
-}
-
-func (b *backend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }

--- a/internal/providers/cua/backend.go
+++ b/internal/providers/cua/backend.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type backend struct {
@@ -115,7 +117,7 @@ func (b backend) Status(ctx context.Context, req StatusRequest) (StatusView, err
 		pollCtx, cancel = context.WithTimeout(ctx, waitTimeout)
 	}
 	defer cancel()
-	deadline := b.now().Add(waitTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(waitTimeout)
 	for {
 		sb, getErr := b.client().GetSandbox(pollCtx, sandboxID)
 		if getErr == nil && claimed {
@@ -160,7 +162,7 @@ func (b backend) Status(ctx context.Context, req StatusRequest) (StatusView, err
 		if isTerminalState(state) {
 			return StatusView{}, exit(5, "CUA sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
-		if b.now().After(deadline) {
+		if core.ClockNow(b.rt.Clock).After(deadline) {
 			return StatusView{}, exit(5, "timed out waiting for CUA sandbox %s to become ready", sandboxID)
 		}
 		select {
@@ -207,13 +209,6 @@ func (b backend) serverFromSandbox(claim LeaseClaim, sb bridgeSandboxSummary) Se
 func (b backend) claimMatchesActiveScope(claim LeaseClaim) bool {
 	scope, err := cuaScope(b.cfg)
 	return err == nil && claim.ProviderScope == scope
-}
-
-func (b backend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }
 
 func normalizedSandboxState(sb bridgeSandboxSummary) string {

--- a/internal/providers/cubesandbox/backend.go
+++ b/internal/providers/cubesandbox/backend.go
@@ -97,7 +97,7 @@ func (b *cubesandboxBackend) Warmup(ctx context.Context, req WarmupRequest) erro
 	if err := validateCubeSandboxUser(b.cfg.CubeSandbox.User); err != nil {
 		return err
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	client, err := newCubeSandboxClient(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -110,7 +110,7 @@ func (b *cubesandboxBackend) Warmup(ctx context.Context, req WarmupRequest) erro
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: cubesandbox warmup keeps the sandbox until explicit stop\n")
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  leaseID,
@@ -145,7 +145,7 @@ func (b *cubesandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) {
 			return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 				Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-				TempPattern: "crabbox-cubesandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+				TempPattern: "crabbox-cubesandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 			})
 		},
 		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
@@ -260,9 +260,9 @@ func (b *cubesandboxBackend) Status(ctx context.Context, req StatusRequest) (sta
 	if err != nil {
 		return statusView{}, err
 	}
-	deadline := b.now().Add(req.WaitTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(req.WaitTimeout)
 	if req.WaitTimeout <= 0 {
-		deadline = b.now().Add(5 * time.Minute)
+		deadline = core.ClockNow(b.rt.Clock).Add(5 * time.Minute)
 	}
 	for {
 		sandbox, err := client.GetSandbox(ctx, sandboxID)
@@ -273,7 +273,7 @@ func (b *cubesandboxBackend) Status(ctx context.Context, req StatusRequest) (sta
 		if !req.Wait || view.Ready {
 			return view, nil
 		}
-		if b.now().After(deadline) {
+		if core.ClockNow(b.rt.Clock).After(deadline) {
 			return statusView{}, exit(5, "timed out waiting for sandbox %s to become ready", sandboxID)
 		}
 		select {
@@ -402,7 +402,7 @@ func (b *cubesandboxBackend) createSandbox(ctx context.Context, client cubesandb
 	}
 	cfg.TTL = cubesandboxTimeoutDuration(cfg.TTL)
 	cfg.ServerType = template
-	labels := directLeaseLabels(cfg, leaseID, slug, providerName, "", keep, b.now().UTC())
+	labels := directLeaseLabels(cfg, leaseID, slug, providerName, "", keep, core.ClockNow(b.rt.Clock).UTC())
 	labels["state"] = "ready"
 	labels["workdir"] = workspace
 	labels["template"] = template
@@ -796,11 +796,4 @@ func cubesandboxError(action string, err error) error {
 		return nil
 	}
 	return fmt.Errorf("cubesandbox %s: %w", action, err)
-}
-
-func (b *cubesandboxBackend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }

--- a/internal/providers/cubesandbox/sync.go
+++ b/internal/providers/cubesandbox/sync.go
@@ -27,7 +27,7 @@ func (b *cubesandboxBackend) syncWorkspace(ctx context.Context, client cubesandb
 		PhaseName:           "cubesandbox_sync",
 		Provider:            providerName,
 		Stderr:              b.rt.Stderr,
-		Now:                 b.now,
+		Now:                 func() time.Time { return core.ClockNow(b.rt.Clock) },
 		Upload: func(uploadCtx context.Context, remoteArchive string, body io.Reader) error {
 			if err := client.UploadFile(uploadCtx, session, remoteArchive, body); err != nil {
 				return cubesandboxError("upload archive", err)

--- a/internal/providers/digitalocean/backend.go
+++ b/internal/providers/digitalocean/backend.go
@@ -106,7 +106,7 @@ func (b *digitalOceanLeaseBackend) acquireOnce(ctx context.Context, req core.Acq
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
-	now := b.now()
+	now := core.ClockNow(b.RT.Clock).UTC()
 	created := droplet{}
 	committed := false
 	defer func() {
@@ -426,7 +426,7 @@ func (b *digitalOceanLeaseBackend) releaseTargetFromClaim(ctx context.Context, c
 		if recoveryName == "" {
 			recoveryName = "ambiguous-create"
 		}
-		if createdAt <= 0 || b.now().Before(time.Unix(createdAt, 0).Add(grace)) {
+		if createdAt <= 0 || core.ClockNow(b.RT.Clock).UTC().Before(time.Unix(createdAt, 0).Add(grace)) {
 			return core.LeaseTarget{}, core.Exit(4, "digitalocean %s recovery is still pending for lease=%s; retry stop later", recoveryName, claim.LeaseID)
 		}
 		if recovery == "ambiguous-key-create" {
@@ -807,7 +807,7 @@ func (b *digitalOceanLeaseBackend) Touch(ctx context.Context, req core.TouchRequ
 		delete(labels, "idle_timeout")
 		delete(labels, "idle_timeout_secs")
 	}
-	labels = core.TouchDirectLeaseLabels(labels, cfg, req.State, b.now())
+	labels = core.TouchDirectLeaseLabels(labels, cfg, req.State, core.ClockNow(b.RT.Clock).UTC())
 	for key, value := range liveTailscale {
 		labels[key] = value
 	}
@@ -1285,13 +1285,6 @@ func (b *digitalOceanLeaseBackend) waitForDropletIP(ctx context.Context, client 
 		return droplet{}, err
 	}
 	return result.Value, nil
-}
-
-func (b *digitalOceanLeaseBackend) now() time.Time {
-	if b.RT.Clock != nil {
-		return b.RT.Clock.Now().UTC()
-	}
-	return time.Now().UTC()
 }
 
 func rollbackDigitalOceanAcquire(client digitalOceanAPI, dropletID, keyID int64) error {

--- a/internal/providers/dockersandbox/backend.go
+++ b/internal/providers/dockersandbox/backend.go
@@ -40,7 +40,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if req.ActionsRunner {
 		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	cli, err := newSBXCLI(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -53,7 +53,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: docker-sandbox warmup keeps the sandbox until explicit stop\n")
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  leaseID,
@@ -70,7 +70,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	if err != nil {
 		return RunResult{}, err
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	cli, err := newSBXCLI(b.cfg, b.rt)
 	if err != nil {
 		return RunResult{}, err
@@ -121,7 +121,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 				result.Session.Kept = false
 			}
 		}
-		result.Total = b.now().Sub(started)
+		result.Total = core.ClockNow(b.rt.Clock).Sub(started)
 		result = core.FinalizeRunResult(result, retErr)
 		if commandRan {
 			fmt.Fprintf(b.rt.Stderr, "docker-sandbox run summary sync_delegated=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
@@ -161,9 +161,9 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		defer cleanup()
 	}
 	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s sync_delegated=true\n", providerName, leaseID, sandboxName, workdir)
-	commandStart := b.now()
+	commandStart := core.ClockNow(b.rt.Clock)
 	exitCode, runErr := cli.execStream(ctx, sandboxName, workdir, envFile, command, b.rt.Stdout, b.rt.Stderr)
-	result.Command = b.now().Sub(commandStart)
+	result.Command = core.ClockNow(b.rt.Clock).Sub(commandStart)
 	result.CommandText = strings.Join(req.Command, " ")
 	commandRan = true
 	outcome := shared.FinalizeDelegatedCommandOutcome(exitCode, runErr)
@@ -251,9 +251,9 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 	if err != nil {
 		return StatusView{}, err
 	}
-	deadline := b.now().Add(req.WaitTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(req.WaitTimeout)
 	if req.WaitTimeout <= 0 {
-		deadline = b.now().Add(5 * time.Minute)
+		deadline = core.ClockNow(b.rt.Clock).Add(5 * time.Minute)
 	}
 	for {
 		records, err := cli.list(ctx)
@@ -268,7 +268,7 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 		if !req.Wait || view.Ready || dockerSandboxTerminalState(view.State) {
 			return view, nil
 		}
-		remaining := deadline.Sub(b.now())
+		remaining := deadline.Sub(core.ClockNow(b.rt.Clock))
 		if remaining <= 0 {
 			return StatusView{}, exit(5, "timed out waiting for docker-sandbox sandbox %s to become ready", sandboxName)
 		}
@@ -697,13 +697,6 @@ func sbxVersionMatchesBaseline(version string) bool {
 		}
 	}
 	return false
-}
-
-func (b *backend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }
 
 func writeDockerSandboxEnvFile(env map[string]string) (string, func(), error) {

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -83,7 +83,7 @@ func (b *e2bBackend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if err := validateE2BUser(b.cfg.E2B.User); err != nil {
 		return err
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	client, err := newE2BClient(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -96,7 +96,7 @@ func (b *e2bBackend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: e2b warmup keeps the sandbox until explicit stop\n")
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: e2bProvider,
 		LeaseID:  leaseID,
@@ -132,7 +132,7 @@ func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error)
 		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) {
 			return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 				Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-				TempPattern: "crabbox-e2b-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+				TempPattern: "crabbox-e2b-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 			})
 		},
 		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
@@ -215,7 +215,7 @@ func (b *e2bBackend) Status(ctx context.Context, req StatusRequest) (statusView,
 	if waitTimeout <= 0 {
 		waitTimeout = 5 * time.Minute
 	}
-	deadline := b.now().Add(waitTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(waitTimeout)
 	pollCtx := ctx
 	cancel := func() {}
 	if req.Wait {
@@ -247,7 +247,7 @@ func (b *e2bBackend) Status(ctx context.Context, req StatusRequest) (statusView,
 		if !req.Wait || view.Ready {
 			return view, nil
 		}
-		if b.now().After(deadline) {
+		if core.ClockNow(b.rt.Clock).After(deadline) {
 			return statusView{}, exit(5, "timed out waiting for sandbox %s to become ready", sandboxID)
 		}
 		select {
@@ -383,7 +383,7 @@ func (b *e2bBackend) createSandbox(ctx context.Context, client e2bAPI, repo Repo
 	}
 	cfg.TTL = e2bTimeoutDuration(cfg.TTL)
 	cfg.ServerType = template
-	labels := directLeaseLabels(cfg, leaseID, slug, e2bProvider, "", keep, b.now().UTC())
+	labels := directLeaseLabels(cfg, leaseID, slug, e2bProvider, "", keep, core.ClockNow(b.rt.Clock).UTC())
 	labels["state"] = "ready"
 	labels["workdir"] = workspace
 	labels["template"] = template
@@ -802,11 +802,4 @@ func e2bError(action string, err error) error {
 		return nil
 	}
 	return fmt.Errorf("e2b %s: %w", action, err)
-}
-
-func (b *e2bBackend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }

--- a/internal/providers/e2b/sync.go
+++ b/internal/providers/e2b/sync.go
@@ -27,7 +27,7 @@ func (b *e2bBackend) syncWorkspace(ctx context.Context, client e2bAPI, session e
 		PhaseName:           "e2b_sync",
 		Provider:            e2bProvider,
 		Stderr:              b.rt.Stderr,
-		Now:                 b.now,
+		Now:                 func() time.Time { return core.ClockNow(b.rt.Clock) },
 		Upload: func(uploadCtx context.Context, remoteArchive string, archive io.Reader) error {
 			return e2bError("upload archive", client.UploadFile(uploadCtx, session, remoteArchive, archive))
 		},

--- a/internal/providers/lambda/backend.go
+++ b/internal/providers/lambda/backend.go
@@ -142,7 +142,7 @@ func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 	if cfg.Tailscale.Enabled && cfg.Tailscale.Hostname == "" {
 		cfg.Tailscale.Hostname = core.RenderTailscaleHostname(cfg.Tailscale.HostnameTemplate, leaseID, slug, cfg.Provider)
 	}
-	now := b.now()
+	now := core.ClockNow(b.rt.Clock).UTC()
 	var (
 		key        lambdaSSHKeyIdentity
 		instanceID string
@@ -295,7 +295,7 @@ func (b *backend) ensureSSHKey(ctx context.Context, client lambdaAPI, name, publ
 }
 
 func (b *backend) waitForInstanceReady(ctx context.Context, client lambdaAPI, id string) (Instance, error) {
-	deadline := b.now().Add(5 * time.Minute)
+	deadline := core.ClockNow(b.rt.Clock).UTC().Add(5 * time.Minute)
 	result, err := shared.Poll(context.WithoutCancel(ctx), 0, 3*time.Second,
 		func(context.Context, time.Duration) error {
 			if err := shared.SleepContext(ctx, 3*time.Second); err != nil {
@@ -314,7 +314,7 @@ func (b *backend) waitForInstanceReady(ctx context.Context, client lambdaAPI, id
 			if isTerminalInstanceStatus(item.Status) {
 				return false, core.Exit(5, "lambda instance %s reached terminal status %s", id, item.Status)
 			}
-			if b.now().After(deadline) {
+			if core.ClockNow(b.rt.Clock).UTC().After(deadline) {
 				return false, core.Exit(5, "timed out waiting for Lambda instance %s to become active with public IP", id)
 			}
 			return false, nil
@@ -471,7 +471,7 @@ func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server
 	if req.IdleTimeout > 0 {
 		cfg.IdleTimeout = req.IdleTimeout
 	}
-	labels := core.TouchDirectLeaseLabels(server.Labels, cfg, req.State, b.now())
+	labels := core.TouchDirectLeaseLabels(server.Labels, cfg, req.State, core.ClockNow(b.rt.Clock).UTC())
 	labels[lambdaTouchLocalLabel] = "true"
 	server.Labels = labels
 	updated, err := core.UpdateLeaseClaimLabelsIfUnchanged(req.Lease.LeaseID, claim, labels)
@@ -928,11 +928,4 @@ func providerKeyForLease(leaseID string) string {
 		key = key[:64]
 	}
 	return strings.TrimRight(key, "-")
-}
-
-func (b *backend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now().UTC()
-	}
-	return time.Now().UTC()
 }

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -127,7 +127,7 @@ func (b *linodeLeaseBackend) acquireOnce(ctx context.Context, req core.AcquireRe
 	if err != nil {
 		return core.LeaseTarget{}, fmt.Errorf("generate linode root password: %w", err)
 	}
-	now := b.now()
+	now := core.ClockNow(b.RT.Clock).UTC()
 	created := linodeInstance{}
 	committed := false
 	defer func() {
@@ -365,7 +365,7 @@ func (b *linodeLeaseBackend) releaseTargetFromClaim(ctx context.Context, client 
 			grace = ambiguousCreateRecoveryGrace
 		}
 		createdAt, _ := strconv.ParseInt(claim.Labels["created_at"], 10, 64)
-		if createdAt <= 0 || b.now().Before(time.Unix(createdAt, 0).Add(grace)) {
+		if createdAt <= 0 || core.ClockNow(b.RT.Clock).UTC().Before(time.Unix(createdAt, 0).Add(grace)) {
 			return core.LeaseTarget{}, core.Exit(4, "linode ambiguous-create recovery is still pending for lease=%s; retry stop later", claim.LeaseID)
 		}
 		if target, found, err := b.reconcilePendingRecovery(ctx, client, claim, accountID); err != nil {
@@ -603,7 +603,7 @@ func (b *linodeLeaseBackend) updateFencedLinodeMetadata(ctx context.Context, lea
 	}
 	providerCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
-	now := b.now()
+	now := core.ClockNow(b.RT.Clock).UTC()
 	action := func() (core.Server, core.SSHTarget, bool, error) {
 		if err := providerCtx.Err(); err != nil {
 			return core.Server{}, core.SSHTarget{}, false, err
@@ -948,13 +948,6 @@ func (b *linodeLeaseBackend) waitForLinodeIP(ctx context.Context, client linodeA
 		result.Value = linodeInstance{}
 	}
 	return result.Value, err
-}
-
-func (b *linodeLeaseBackend) now() time.Time {
-	if b.RT.Clock != nil {
-		return b.RT.Clock.Now().UTC()
-	}
-	return time.Now().UTC()
 }
 
 func rollbackLinodeAcquire(client linodeAPI, linodeID int64) error {

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -94,13 +94,6 @@ func (b *backend) SupportsRequestedLeaseID() bool { return true }
 
 func (b *backend) SupportsRequestedCheckpointID() bool { return true }
 
-func (b *backend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now().UTC()
-	}
-	return time.Now().UTC()
-}
-
 func (b *backend) configForRun() Config {
 	cfg := b.cfg
 	applyDefaults(&cfg)
@@ -167,7 +160,7 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		return LeaseTarget{}, err
 	}
 	pendingMachine := machine{Name: name, Status: "CREATING", Size: cfg.Machine0.Size, Region: cfg.Machine0.Region, Image: image, ImageVersion: cfg.Machine0.ImageVersion}
-	pendingServer := Server{Provider: providerName, Name: name, Status: "provisioning", Labels: machineLabels(cfg, pendingMachine, leaseID, slug, req.Keep, b.now())}
+	pendingServer := Server{Provider: providerName, Name: name, Status: "provisioning", Labels: machineLabels(cfg, pendingMachine, leaseID, slug, req.Keep, core.ClockNow(b.rt.Clock).UTC())}
 	pendingServer.Labels["recovery"] = "create-pending"
 	recoveryClaim, claimErr := core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurable(
 		leaseID, slug, cfg, machine0NameScope(name), pendingServer, SSHTarget{}, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, LeaseClaim{}, false,
@@ -211,7 +204,7 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	recoveryClaim = boundClaim
 	claim := LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: machineScope(item.ID)}
 	server := b.serverFromMachine(item, claim, cfg)
-	server.Labels = machineLabels(cfg, item, leaseID, slug, req.Keep, b.now())
+	server.Labels = machineLabels(cfg, item, leaseID, slug, req.Keep, core.ClockNow(b.rt.Clock).UTC())
 	lease, err := b.prepareLease(ctx, item, server, leaseID, true)
 	if err != nil {
 		return LeaseTarget{}, rollback(err)
@@ -514,7 +507,7 @@ func (b *backend) resolve(ctx context.Context, req ResolveRequest, original *Lea
 		return LeaseTarget{}, err
 	}
 	if !claimed && req.Reclaim {
-		lease.Server.Labels = machineLabels(cfg, item, leaseID, slug, true, b.now())
+		lease.Server.Labels = machineLabels(cfg, item, leaseID, slug, true, core.ClockNow(b.rt.Clock).UTC())
 		if err := claimLease(leaseID, slug, cfg, req.Repo.Root, true, lease.Server, lease.SSH); err != nil {
 			return LeaseTarget{}, err
 		}
@@ -576,7 +569,7 @@ func (b *backend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
 					labels[key] = value
 				}
 			}
-			now := b.now()
+			now := core.ClockNow(b.rt.Clock).UTC()
 			return core.TouchDirectLeaseLabelsWithIdleTimeoutOverride(labels, cfg, req.State, now, req.IdleTimeoutOverride), now
 		},
 	})
@@ -670,7 +663,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			continue
 		}
 		server := b.serverFromMachine(item, claim, cfg)
-		should, reason := shouldCleanupMachine0(server, claim, claim.LeaseID != "", b.now())
+		should, reason := shouldCleanupMachine0(server, claim, claim.LeaseID != "", core.ClockNow(b.rt.Clock).UTC())
 		if !should {
 			fmt.Fprintf(b.rt.Stderr, "skip machine name=%s reason=%s\n", item.Name, reason)
 			continue
@@ -1314,7 +1307,7 @@ func (b *backend) serverFromMachine(item machine, claim LeaseClaim, cfg Config) 
 	labels := shared.CloneLabels(claim.Labels)
 	leaseID, slug := claim.LeaseID, claim.Slug
 	if len(labels) == 0 {
-		labels = machineLabels(cfg, item, leaseID, slug, false, b.now())
+		labels = machineLabels(cfg, item, leaseID, slug, false, core.ClockNow(b.rt.Clock).UTC())
 	}
 	for key, value := range machineDynamicLabels(item) {
 		labels[key] = value

--- a/internal/providers/machine0/fixed.go
+++ b/internal/providers/machine0/fixed.go
@@ -50,7 +50,7 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 		WindowsMode:  cfg.WindowsMode,
 		TTL:          cfg.TTL,
 		IdleTimeout:  cfg.IdleTimeout,
-		Now:          b.now,
+		Now:          func() time.Time { return core.ClockNow(b.rt.Clock).UTC() },
 	}, func(ctx context.Context, claim *core.LeaseClaim, exists bool) (core.FixedLeaseBinding, error) {
 		freshClaim = !exists
 		var err error
@@ -126,7 +126,7 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 			attempt := machine0CreateAttempt{
 				Name: name, Size: cfg.Machine0.Size, Region: cfg.Machine0.Region,
 				Image: image, ImageVersion: cfg.Machine0.ImageVersion, Key: cfg.Machine0.Key,
-				CreatedAt: b.now().Format(time.RFC3339Nano),
+				CreatedAt: core.ClockNow(b.rt.Clock).UTC().Format(time.RFC3339Nano),
 			}
 			data, err := json.Marshal(attempt)
 			if err != nil {
@@ -164,7 +164,7 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 			return LeaseTarget{}, err
 		}
 		server := b.serverFromMachine(item, *claim, cfg)
-		server.Labels = machineLabels(cfg, item, leaseID, intent.Slug, req.Keep, b.now())
+		server.Labels = machineLabels(cfg, item, leaseID, intent.Slug, req.Keep, core.ClockNow(b.rt.Clock).UTC())
 		return b.prepareLease(ctx, item, server, leaseID, true)
 	}, ctx)
 	if err != nil {
@@ -294,7 +294,7 @@ func (b *backend) bindFixedMachine0(claim *LeaseClaim, item machine, keep bool, 
 	}
 	claim.CloudID, claim.CloudImmutableID = item.ID, item.ID
 	claim.ProviderScope = machineScope(item.ID)
-	claim.Labels = machineLabels(b.configForRun(), item, claim.LeaseID, claim.Slug, keep, b.now())
+	claim.Labels = machineLabels(b.configForRun(), item, claim.LeaseID, claim.Slug, keep, core.ClockNow(b.rt.Clock).UTC())
 	return persist()
 }
 
@@ -367,7 +367,7 @@ func (b *backend) destroyClaimedMachineWithOutcome(ctx context.Context, expected
 		} else {
 			return exit(4, "fixed Machine0 lease %s is not visible in the current account; absence is unverified, retain its claim and inspect the original account", claim.LeaseID)
 		}
-		*claim = fixedMachine0LeaseKind.TerminalClaim(*claim, b.now())
+		*claim = fixedMachine0LeaseKind.TerminalClaim(*claim, core.ClockNow(b.rt.Clock).UTC())
 		return persist()
 	})
 }

--- a/internal/providers/modal/backend.go
+++ b/internal/providers/modal/backend.go
@@ -31,7 +31,7 @@ const (
 func (b *modalBackend) Spec() ProviderSpec { return b.spec }
 
 func (b *modalBackend) Warmup(ctx context.Context, req WarmupRequest) error {
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	client, err := newModalAPI(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -45,7 +45,7 @@ func (b *modalBackend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: modal warmup keeps the sandbox until explicit stop\n")
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  leaseID,
@@ -91,7 +91,7 @@ func (b *modalBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) {
 			return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 				Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-				TempPattern: "crabbox-modal-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+				TempPattern: "crabbox-modal-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 			})
 		},
 		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
@@ -207,9 +207,9 @@ func (b *modalBackend) Status(ctx context.Context, req StatusRequest) (StatusVie
 	if err != nil {
 		return StatusView{}, err
 	}
-	deadline := b.now().Add(req.WaitTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(req.WaitTimeout)
 	if req.WaitTimeout <= 0 {
-		deadline = b.now().Add(5 * time.Minute)
+		deadline = core.ClockNow(b.rt.Clock).Add(5 * time.Minute)
 	}
 	for {
 		sandbox, err := client.GetSandbox(ctx, sandboxID)
@@ -220,7 +220,7 @@ func (b *modalBackend) Status(ctx context.Context, req StatusRequest) (StatusVie
 		if !req.Wait || view.Ready {
 			return view, nil
 		}
-		if b.now().After(deadline) {
+		if core.ClockNow(b.rt.Clock).After(deadline) {
 			return StatusView{}, exit(5, "timed out waiting for modal sandbox %s to become ready", sandboxID)
 		}
 		select {
@@ -263,7 +263,7 @@ func (b *modalBackend) createSandbox(ctx context.Context, client modalAPI, repo 
 	cfg := b.cfg
 	cfg.TTL = modalTimeoutDuration(cfg.TTL)
 	cfg.ServerType = modalImage(cfg)
-	labels := modalSandboxTags(cfg, leaseID, slug, repo.Name, keep, b.now().UTC())
+	labels := modalSandboxTags(cfg, leaseID, slug, repo.Name, keep, core.ClockNow(b.rt.Clock).UTC())
 	timeoutSeconds := durationSecondsCeil(cfg.TTL)
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=modal lease=%s slug=%s app=%s image=%s timeout=%ds\n", leaseID, slug, modalApp(cfg), modalImage(cfg), timeoutSeconds)
 	sandbox, err := client.CreateSandbox(ctx, modalCreateSandboxRequest{
@@ -524,11 +524,4 @@ func modalError(action string, err error) error {
 		return nil
 	}
 	return fmt.Errorf("modal %s: %w", action, err)
-}
-
-func (b *modalBackend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }

--- a/internal/providers/modal/sync.go
+++ b/internal/providers/modal/sync.go
@@ -19,7 +19,7 @@ func (b *modalBackend) syncWorkspace(ctx context.Context, client modalAPI, sandb
 	return shared.RunSandboxArchiveSync(ctx, shared.SandboxArchiveSyncRequest{
 		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge, Workdir: workdir,
 		TempPattern: "crabbox-modal-sync-*.tgz", RemoteArchivePrefix: "crabbox-modal-sync-",
-		PhaseName: "modal_sync", Provider: providerName, Stderr: b.rt.Stderr, Now: b.now,
+		PhaseName: "modal_sync", Provider: providerName, Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 		Upload: func(ctx context.Context, remoteArchive string, archive io.Reader) error {
 			// The Modal SDK upload requires a local path. The shared archive
 			// transport owns this file and keeps it open until upload completes.

--- a/internal/providers/namespaceinstance/backend.go
+++ b/internal/providers/namespaceinstance/backend.go
@@ -157,7 +157,7 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 		}
 	}()
 
-	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", req.Keep, b.now())
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", req.Keep, core.ClockNow(b.rt.Clock).UTC())
 	labels["namespace_tenant"] = cfg.NamespaceInstance.TenantID
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s machine_type=%s keep=%v\n", providerName, leaseID, slug, cfg.ServerType, req.Keep)
 	id, err := b.create(ctx, cfg, keyPath+".pub", labels)
@@ -407,7 +407,7 @@ func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server
 	if err != nil {
 		return core.Server{}, err
 	}
-	now := b.now()
+	now := core.ClockNow(b.rt.Clock).UTC()
 	if remaining := namespaceRemainingLifetime(req.Lease.Server.Labels, now); remaining > 0 {
 		result, err := b.nsc(ctx, cfg, []string{"extend", req.Lease.Server.CloudID, "--ensure_minimum", remaining.String()}, b.rt.Stderr)
 		if err != nil {
@@ -474,8 +474,8 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		}
 		server := b.server(item, cfg)
 		mergeClaimLabels(&server, claim)
-		remove, reason := core.ShouldCleanupServer(server, b.now())
-		if recoveryRemove, recoveryReason, handled := namespaceRecoveryCleanup(claim, b.now()); handled {
+		remove, reason := core.ShouldCleanupServer(server, core.ClockNow(b.rt.Clock).UTC())
+		if recoveryRemove, recoveryReason, handled := namespaceRecoveryCleanup(claim, core.ClockNow(b.rt.Clock).UTC()); handled {
 			remove, reason = recoveryRemove, recoveryReason
 		}
 		if !remove {
@@ -511,7 +511,7 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		if _, ok := live[leaseID]; ok || claim.LeaseID == "" {
 			continue
 		}
-		if claim.Labels["recovery"] == "ambiguous-create" && namespaceRecoveryPending(claim, b.now()) {
+		if claim.Labels["recovery"] == "ambiguous-create" && namespaceRecoveryPending(claim, core.ClockNow(b.rt.Clock).UTC()) {
 			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s reason=ambiguous create recovery pending\n", claim.LeaseID)
 			continue
 		}
@@ -1083,13 +1083,6 @@ func (b *backend) nsc(ctx context.Context, cfg core.Config, args []string, stder
 		Args:   global,
 		Stderr: stderr,
 	})
-}
-
-func (b *backend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now().UTC()
-	}
-	return time.Now().UTC()
 }
 
 func commandError(action string, result core.LocalCommandResult, err error) error {

--- a/internal/providers/nomad/cleanup_ownership_test.go
+++ b/internal/providers/nomad/cleanup_ownership_test.go
@@ -61,7 +61,7 @@ func TestNomadDestructionFencesValidationPurgeAndAbsence(t *testing.T) {
 			b, _, _ := testBackend(t, fake)
 			claim := createClaim(t, b, "cbx_a11111111111", "fence-crab", "crabbox-a11111111111", "alloc-a")
 			if operation == "cleanup" {
-				expireClaim(t, claim, b.now().Add(-time.Hour))
+				expireClaim(t, claim, core.ClockNow(b.rt.Clock).Add(-time.Hour))
 				claim, _ = readLeaseClaim(claim.LeaseID)
 			}
 			expectedJob := cloneJob(fake.jobs[claim.Labels[claimLabelJobID]])
@@ -134,7 +134,7 @@ func TestNomadCleanupRejectsClaimChangeAfterPreflight(t *testing.T) {
 					fake := newLifecycleFakeClient()
 					b, stdout, _ := testBackend(t, fake)
 					claim := createClaim(t, b, "cbx_a22222222222", "race-crab", "crabbox-a22222222222", "alloc-a")
-					expireClaim(t, claim, b.now().Add(-time.Hour))
+					expireClaim(t, claim, core.ClockNow(b.rt.Clock).Add(-time.Hour))
 					claim, _ = readLeaseClaim(claim.LeaseID)
 					if missing {
 						delete(fake.jobs, claim.Labels[claimLabelJobID])

--- a/internal/providers/nomad/lifecycle.go
+++ b/internal/providers/nomad/lifecycle.go
@@ -48,7 +48,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if req.Options.Tailscale.Enabled {
 		return exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	client, err := b.client()
 	if err != nil {
 		return err
@@ -61,7 +61,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: nomad warmup keeps the job until explicit stop\n")
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  leaseID,
@@ -103,7 +103,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) {
 			return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 				Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-				TempPattern: "crabbox-nomad-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+				TempPattern: "crabbox-nomad-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 			})
 		},
 		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
@@ -193,7 +193,7 @@ func (b *backend) createJob(ctx context.Context, client Client, repo Repo, reque
 	}
 	expiresAt := time.Time{}
 	if b.cfg.TTL > 0 {
-		expiresAt = b.now().UTC().Add(b.cfg.TTL)
+		expiresAt = core.ClockNow(b.rt.Clock).UTC().Add(b.cfg.TTL)
 	}
 	jobID := jobIDForLease(leaseID)
 	job, err := buildJobSpec(b.cfg, jobSpecInput{LeaseID: leaseID, Slug: slug, JobID: jobID, ExpiresAt: expiresAt})
@@ -451,7 +451,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	if err != nil {
 		return err
 	}
-	now := b.now().UTC()
+	now := core.ClockNow(b.rt.Clock).UTC()
 	checked, removed := 0, 0
 	for _, listed := range claims {
 		if listed.Provider != providerName || listed.ProviderScope != claimScope(b.cfg) {
@@ -712,13 +712,6 @@ func (b *backend) client() (Client, error) {
 		return b.clientFactory(b.cfg, b.rt)
 	}
 	return newNomadClient(b.cfg, b.rt)
-}
-
-func (b *backend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }
 
 func (b *backend) allocReadyTimeout() time.Duration {

--- a/internal/providers/nomad/lifecycle_test.go
+++ b/internal/providers/nomad/lifecycle_test.go
@@ -996,7 +996,7 @@ func createClaim(t *testing.T, b *backend, leaseID, slug, jobID, allocID string)
 		DesiredStatus: nomadapi.AllocDesiredStatusRun,
 		TaskState:     "running",
 	}
-	expiresAt := b.now().Add(time.Hour)
+	expiresAt := core.ClockNow(b.rt.Clock).Add(time.Hour)
 	claim, err := writeNomadClaim(b.cfg, leaseID, slug, Repo{Root: filepath.Join(t.TempDir(), "repo"), Name: "repo"}, false, ready, expiresAt)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/providers/nomad/sync.go
+++ b/internal/providers/nomad/sync.go
@@ -20,7 +20,7 @@ func (b *backend) syncWorkspace(ctx context.Context, client Client, ready alloca
 		PhaseName:           "nomad_sync",
 		Provider:            providerName,
 		Stderr:              b.rt.Stderr,
-		Now:                 b.now,
+		Now:                 func() time.Time { return core.ClockNow(b.rt.Clock) },
 		CleanupContext:      b.cleanupContext,
 		Upload: func(uploadCtx context.Context, remoteArchive string, body io.Reader) error {
 			return b.uploadArchive(uploadCtx, client, ready, remoteArchive, body)

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -41,7 +41,7 @@ func (b *openComputerBackend) Warmup(ctx context.Context, req WarmupRequest) err
 	if req.ActionsRunner {
 		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	api, err := newOCAPIClient(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -54,7 +54,7 @@ func (b *openComputerBackend) Warmup(ctx context.Context, req WarmupRequest) err
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: opencomputer warmup keeps the sandbox until explicit stop\n")
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  leaseID,
@@ -85,7 +85,7 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) {
 			return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 				Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-				TempPattern: "crabbox-opencomputer-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+				TempPattern: "crabbox-opencomputer-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 			})
 		},
 		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
@@ -241,7 +241,7 @@ func (b *openComputerBackend) Status(ctx context.Context, req StatusRequest) (St
 	if waitTimeout <= 0 {
 		waitTimeout = 5 * time.Minute
 	}
-	deadline := b.now().Add(waitTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(waitTimeout)
 	pollCtx := ctx
 	cancel := func() {}
 	if req.Wait {
@@ -288,7 +288,7 @@ func (b *openComputerBackend) Status(ctx context.Context, req StatusRequest) (St
 		if isTerminalState(state) {
 			return StatusView{}, exit(5, "opencomputer sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
-		if b.now().After(deadline) {
+		if core.ClockNow(b.rt.Clock).After(deadline) {
 			return StatusView{}, exit(5, "timed out waiting for opencomputer sandbox %s to become ready", sandboxID)
 		}
 		select {
@@ -539,13 +539,6 @@ func openComputerWorkdir(cfg Config) (string, error) {
 		return "", exit(2, "opencomputer workdir %q is too broad; choose a dedicated subdirectory", clean)
 	}
 	return clean, nil
-}
-
-func (b *openComputerBackend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }
 
 func (b *openComputerBackend) cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/internal/providers/opencomputer/sync.go
+++ b/internal/providers/opencomputer/sync.go
@@ -21,7 +21,7 @@ func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClien
 		PhaseName:           "opencomputer_sync",
 		Provider:            providerName,
 		Stderr:              b.rt.Stderr,
-		Now:                 b.now,
+		Now:                 func() time.Time { return core.ClockNow(b.rt.Clock) },
 		CleanupContext:      b.cleanupContext,
 		Upload: func(uploadCtx context.Context, remoteArchive string, body io.Reader) error {
 			return api.uploadFile(uploadCtx, sandboxID, remoteArchive, body)

--- a/internal/providers/opensandbox/backend.go
+++ b/internal/providers/opensandbox/backend.go
@@ -55,7 +55,7 @@ func (b *openSandboxBackend) Warmup(ctx context.Context, req WarmupRequest) erro
 	if _, err := openSandboxWorkdir(b.cfg); err != nil {
 		return err
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	api, err := b.client()
 	if err != nil {
 		return err
@@ -76,7 +76,7 @@ func (b *openSandboxBackend) Warmup(ctx context.Context, req WarmupRequest) erro
 		return b.cleanupClaimedSandboxFailure(ctx, api, leaseID, sandboxID, err)
 	}
 	required := openSandboxRunBudgetForConfig(b.cfg, false, false)
-	if remaining := deadline.Sub(b.now()); remaining < required {
+	if remaining := deadline.Sub(core.ClockNow(b.rt.Clock)); remaining < required {
 		return b.cleanupClaimedSandboxFailure(ctx, api, leaseID, sandboxID,
 			exit(5, "opensandbox sandbox %s has %s remaining after warmup, less than the %s default run budget", sandboxID, remaining.Round(time.Second), required))
 	}
@@ -84,7 +84,7 @@ func (b *openSandboxBackend) Warmup(ctx context.Context, req WarmupRequest) erro
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: opensandbox warmup keeps the sandbox until explicit stop\n")
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  leaseID,
@@ -116,10 +116,10 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 		if err != nil {
 			return err
 		}
-		if !deadline.After(b.now()) {
+		if !deadline.After(core.ClockNow(b.rt.Clock)) {
 			return exit(5, "opensandbox sandbox %s exceeded its absolute Crabbox TTL", sandboxID)
 		}
-		if remaining, required := deadline.Sub(b.now()), b.runLifetimeBudget(req); remaining < required {
+		if remaining, required := deadline.Sub(core.ClockNow(b.rt.Clock)), b.runLifetimeBudget(req); remaining < required {
 			return exit(5, "opensandbox sandbox %s has %s remaining before its absolute TTL, less than the %s sync/command budget; create a new sandbox", sandboxID, remaining.Round(time.Second), required)
 		}
 		return nil
@@ -146,7 +146,7 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) {
 			return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 				Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-				TempPattern: "crabbox-opensandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+				TempPattern: "crabbox-opensandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 			})
 		},
 		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
@@ -199,10 +199,10 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 			if err := b.ensureReusableSandbox(ctx, api, sandboxID, sb); err != nil {
 				return err
 			}
-			if !deadline.After(b.now()) {
+			if !deadline.After(core.ClockNow(b.rt.Clock)) {
 				return exit(5, "opensandbox sandbox %s exceeded its absolute Crabbox TTL while resuming", sandboxID)
 			}
-			if remaining, required := deadline.Sub(b.now()), b.runLifetimeBudget(req); remaining < required {
+			if remaining, required := deadline.Sub(core.ClockNow(b.rt.Clock)), b.runLifetimeBudget(req); remaining < required {
 				return exit(5, "opensandbox sandbox %s has %s remaining after resume before its absolute TTL, less than the %s sync/command budget; create a new sandbox", sandboxID, remaining.Round(time.Second), required)
 			}
 			if err := ctx.Err(); err != nil {
@@ -234,7 +234,7 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 			if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
 				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 			}
-			if remaining := deadline.Sub(b.now()); remaining < b.commandLifetime() {
+			if remaining := deadline.Sub(core.ClockNow(b.rt.Clock)); remaining < b.commandLifetime() {
 				return shared.DelegatedSandboxCommand{}, exit(5, "opensandbox sandbox %s has %s remaining before its absolute TTL, less than the %s command budget; create a new sandbox", sandboxID, remaining.Round(time.Second), b.commandLifetime())
 			}
 			text := intent.ShellCommand("bash", "-lc")
@@ -349,7 +349,7 @@ func (b *openSandboxBackend) Status(ctx context.Context, req StatusRequest) (Sta
 	if waitTimeout <= 0 {
 		waitTimeout = 5 * time.Minute
 	}
-	deadline := b.now().Add(waitTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(waitTimeout)
 	pollCtx := ctx
 	cancel := func() {}
 	if req.Wait {
@@ -410,7 +410,7 @@ func (b *openSandboxBackend) Status(ctx context.Context, req StatusRequest) (Sta
 		if isTerminalState(state) {
 			return StatusView{}, exit(5, "opensandbox sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
-		if b.now().After(deadline) {
+		if core.ClockNow(b.rt.Clock).After(deadline) {
 			return StatusView{}, exit(5, "timed out waiting for opensandbox sandbox %s to become ready", sandboxID)
 		}
 		select {
@@ -470,7 +470,7 @@ func (b *openSandboxBackend) Cleanup(ctx context.Context, req CleanupRequest) er
 	if err != nil {
 		return err
 	}
-	now := b.now().UTC()
+	now := core.ClockNow(b.rt.Clock).UTC()
 	checked := 0
 	removed := 0
 	claimsRemoved := 0
@@ -1015,13 +1015,6 @@ func newSandboxName(repo Repo) string {
 
 func randomSuffix() string {
 	return shared.RandomSuffix()
-}
-
-func (b *openSandboxBackend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }
 
 func (b *openSandboxBackend) cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/internal/providers/opensandbox/sync.go
+++ b/internal/providers/opensandbox/sync.go
@@ -20,7 +20,7 @@ func (b *openSandboxBackend) syncWorkspace(ctx context.Context, api openSandboxC
 		PhaseName:           "opensandbox_sync",
 		Provider:            providerName,
 		Stderr:              b.rt.Stderr,
-		Now:                 b.now,
+		Now:                 func() time.Time { return core.ClockNow(b.rt.Clock) },
 		CleanupContext:      b.cleanupContext,
 		Upload: func(uploadCtx context.Context, remoteArchive string, body io.Reader) error {
 			return api.UploadFile(uploadCtx, sandboxID, remoteArchive, body)

--- a/internal/providers/orgo/backend.go
+++ b/internal/providers/orgo/backend.go
@@ -54,7 +54,7 @@ func (b *orgoBackend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if req.Options.Tailscale.Enabled {
 		return exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	client, err := b.api()
 	if err != nil {
 		return err
@@ -67,7 +67,7 @@ func (b *orgoBackend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: orgo warmup keeps the computer until explicit stop\n")
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  lease.LeaseID,
@@ -83,7 +83,7 @@ func (b *orgoBackend) Run(ctx context.Context, req RunRequest) (result RunResult
 	if len(req.Command) == 0 {
 		return RunResult{}, exit(2, "missing command")
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	client, err := b.api()
 	if err != nil {
 		return RunResult{}, err
@@ -120,7 +120,7 @@ func (b *orgoBackend) Run(ctx context.Context, req RunRequest) (result RunResult
 				result, retErr = shared.AppendDelegatedRunFailure(result, retErr, fmt.Errorf("orgo cleanup failed for %s: %w", lease.Computer.ID, cleanupErr), 1)
 			}
 		}
-		result.Total = b.now().Sub(started)
+		result.Total = core.ClockNow(b.rt.Clock).Sub(started)
 		result = core.FinalizeRunResult(result, retErr)
 		if commandRan {
 			fmt.Fprintf(b.rt.Stderr, "orgo run summary sync_delegated=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
@@ -144,9 +144,9 @@ func (b *orgoBackend) Run(ctx context.Context, req RunRequest) (result RunResult
 	if req.EnvSummary {
 		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
-	commandStarted := b.now()
+	commandStarted := core.ClockNow(b.rt.Clock)
 	exitCode, runErr := client.RunBash(ctx, lease.Computer.ID, command, b.rt.Stdout, b.rt.Stderr)
-	result.Command = b.now().Sub(commandStarted)
+	result.Command = core.ClockNow(b.rt.Clock).Sub(commandStarted)
 	commandRan = true
 	if runErr != nil {
 		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, lease.LeaseID, lease.Slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
@@ -202,7 +202,7 @@ func (b *orgoBackend) Status(ctx context.Context, req StatusRequest) (StatusView
 	if timeout <= 0 {
 		timeout = 5 * time.Minute
 	}
-	deadline := b.now().Add(timeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(timeout)
 	for {
 		view := orgoStatusView(lease)
 		if !req.Wait || view.Ready {
@@ -212,7 +212,7 @@ func (b *orgoBackend) Status(ctx context.Context, req StatusRequest) (StatusView
 		case "error", "failed", "deleted":
 			return view, exit(5, "orgo computer %s entered %s state", lease.Computer.ID, view.State)
 		}
-		if b.now().After(deadline) {
+		if core.ClockNow(b.rt.Clock).After(deadline) {
 			return StatusView{}, exit(5, "timed out waiting for orgo computer %s to become ready", lease.Computer.ID)
 		}
 		select {
@@ -399,7 +399,7 @@ func (b *orgoBackend) ensureComputerRunning(ctx context.Context, client orgoAPI,
 }
 
 func (b *orgoBackend) waitForComputerRunning(ctx context.Context, client orgoAPI, computer orgoComputer, startStopped bool) (orgoComputer, error) {
-	deadline := b.now().Add(orgoReadyTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(orgoReadyTimeout)
 	startRequested := false
 	initial := true
 	_, err := shared.Poll(context.WithoutCancel(ctx), 0, orgoReadyPollInterval,
@@ -444,7 +444,7 @@ func (b *orgoBackend) waitForComputerRunning(ctx context.Context, client orgoAPI
 					state = "starting"
 				}
 			}
-			if !b.now().Before(deadline) {
+			if !core.ClockNow(b.rt.Clock).Before(deadline) {
 				return false, exit(5, "timed out waiting for orgo computer %s to become running (last state=%s)", computer.ID, state)
 			}
 			return false, nil
@@ -809,11 +809,4 @@ func applyOrgoDefaults(cfg *Config) {
 	if strings.TrimSpace(cfg.Orgo.Resolution) == "" {
 		cfg.Orgo.Resolution = "1280x720x24"
 	}
-}
-
-func (b *orgoBackend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }

--- a/internal/providers/ovh/backend.go
+++ b/internal/providers/ovh/backend.go
@@ -169,7 +169,7 @@ func (b *Backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 	if cfg.Tailscale.Enabled && cfg.Tailscale.Hostname == "" {
 		cfg.Tailscale.Hostname = core.RenderTailscaleHostname(cfg.Tailscale.HostnameTemplate, leaseID, slug, cfg.Provider)
 	}
-	now := b.now()
+	now := core.ClockNow(b.RT.Clock).UTC()
 	labels := ovhLeaseLabels(cfg, leaseID, slug, req.Keep, now, "provisioning")
 	committed := false
 	recovery := ""
@@ -257,7 +257,7 @@ func (b *Backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 	if err := b.waitSSH(ctx, &ssh, "ovh bootstrap", core.BootstrapWaitTimeout(cfg)); err != nil {
 		return core.LeaseTarget{}, err
 	}
-	server.Labels = core.TouchDirectLeaseLabels(server.Labels, cfg, "ready", b.now())
+	server.Labels = core.TouchDirectLeaseLabels(server.Labels, cfg, "ready", core.ClockNow(b.RT.Clock).UTC())
 	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, ssh, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
 		return core.LeaseTarget{}, err
 	}
@@ -498,7 +498,7 @@ func (b *Backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server
 		delete(labels, "idle_timeout_secs")
 	}
 	tailscaleLabels := exactTailscaleLabels(labels)
-	labels = core.TouchDirectLeaseLabels(labels, cfg, req.State, b.now())
+	labels = core.TouchDirectLeaseLabels(labels, cfg, req.State, core.ClockNow(b.RT.Clock).UTC())
 	for key, value := range tailscaleLabels {
 		labels[key] = value
 	}
@@ -566,7 +566,7 @@ func (b *Backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	if err != nil {
 		return fmt.Errorf("list ovh cleanup claims: %w", err)
 	}
-	now := b.now()
+	now := core.ClockNow(b.RT.Clock).UTC()
 	for _, claim := range claims {
 		if claim.Provider != providerName || claim.Slug == "" || !claimMatchesOVHProject(claim, b.Cfg.OVH.ProjectID) {
 			continue
@@ -880,7 +880,7 @@ func (b *Backend) recoveryStillPending(claim core.LeaseClaim) bool {
 	if grace <= 0 {
 		grace = ambiguousCreateRecoveryGrace
 	}
-	return b.now().Before(time.Unix(createdAt, 0).Add(grace))
+	return core.ClockNow(b.RT.Clock).UTC().Before(time.Unix(createdAt, 0).Add(grace))
 }
 
 func (b *Backend) reconcileCreatedInstance(ctx context.Context, client API, claim core.LeaseClaim) (Instance, bool, error) {
@@ -1012,9 +1012,9 @@ func claimOnlyServer(claim core.LeaseClaim) core.Server {
 }
 
 func (b *Backend) waitForInstanceIP(ctx context.Context, client API, projectID, instanceID string) (Instance, error) {
-	deadline := b.now().Add(5 * time.Minute)
+	deadline := core.ClockNow(b.RT.Clock).UTC().Add(5 * time.Minute)
 	if b.ipWaitTimeout > 0 {
-		deadline = b.now().Add(b.ipWaitTimeout)
+		deadline = core.ClockNow(b.RT.Clock).UTC().Add(b.ipWaitTimeout)
 	}
 	interval := 3 * time.Second
 	if b.ipWaitInterval > 0 {
@@ -1035,7 +1035,7 @@ func (b *Backend) waitForInstanceIP(ctx context.Context, client API, projectID, 
 			if fetchErr != nil && !isTransientOVHControlPlaneError(fetchErr) {
 				return false, fetchErr
 			}
-			if b.now().After(deadline) {
+			if core.ClockNow(b.RT.Clock).UTC().After(deadline) {
 				if fetchErr != nil {
 					return false, core.Exit(5, "timed out waiting for OVH instance IP after transient error: %v", fetchErr)
 				}
@@ -1047,13 +1047,6 @@ func (b *Backend) waitForInstanceIP(ctx context.Context, client API, projectID, 
 		return Instance{}, err
 	}
 	return result.Value, nil
-}
-
-func (b *Backend) now() time.Time {
-	if b.RT.Clock != nil {
-		return b.RT.Clock.Now().UTC()
-	}
-	return time.Now().UTC()
 }
 
 func ovhLeaseLabels(cfg core.Config, leaseID, slug string, keep bool, now time.Time, state string) map[string]string {

--- a/internal/providers/phala/backend.go
+++ b/internal/providers/phala/backend.go
@@ -296,7 +296,7 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 		}
 	}()
 
-	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", req.Keep, b.now())
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", req.Keep, core.ClockNow(b.rt.Clock).UTC())
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s instance_type=%s keep=%v\n", providerName, leaseID, slug, cfg.ServerType, req.Keep)
 	composePath, err := composeFileForDeploy(cfg, keyPath+".pub")
 	if err != nil {
@@ -601,7 +601,7 @@ func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 
 func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
 	cfg := b.configForRun()
-	now := b.now()
+	now := core.ClockNow(b.rt.Clock).UTC()
 	server := req.Lease.Server
 	gatewayHost := strings.TrimSpace(server.Labels["gateway_host"])
 	server.Labels = core.TouchDirectLeaseLabels(server.Labels, cfg, req.State, now)
@@ -677,8 +677,8 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		}
 		server := b.server(item, cfg)
 		mergeClaimLabels(&server, claim)
-		remove, reason := core.ShouldCleanupServer(server, b.now())
-		if recoveryRemove, recoveryReason, handled := phalaRecoveryCleanup(claim, b.now()); handled {
+		remove, reason := core.ShouldCleanupServer(server, core.ClockNow(b.rt.Clock).UTC())
+		if recoveryRemove, recoveryReason, handled := phalaRecoveryCleanup(claim, core.ClockNow(b.rt.Clock).UTC()); handled {
 			remove, reason = recoveryRemove, recoveryReason
 		}
 		if !remove {
@@ -740,7 +740,7 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		if _, ok := live[leaseID]; ok || claim.LeaseID == "" {
 			continue
 		}
-		if claim.Labels["recovery"] == "ambiguous-create" && phalaRecoveryPending(claim, b.now()) {
+		if claim.Labels["recovery"] == "ambiguous-create" && phalaRecoveryPending(claim, core.ClockNow(b.rt.Clock).UTC()) {
 			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s reason=ambiguous create recovery pending\n", claim.LeaseID)
 			continue
 		}
@@ -1683,13 +1683,6 @@ func (b *backend) phala(ctx context.Context, cfg core.Config, args []string, std
 		Args:   append([]string(nil), args...),
 		Stderr: stderr,
 	})
-}
-
-func (b *backend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now().UTC()
-	}
-	return time.Now().UTC()
 }
 
 func commandError(action string, result core.LocalCommandResult, err error) error {

--- a/internal/providers/shared/delegated.go
+++ b/internal/providers/shared/delegated.go
@@ -126,10 +126,8 @@ func AppendDelegatedRunFailure(result core.RunResult, primary, secondary error, 
 // joined as diagnostics. Sandbox cleanup alone fails with code 1. A failed deletion
 // leaves the session kept (and its claim intact in the adapter) for recovery.
 func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle DelegatedSandboxLifecycle) (result core.RunResult, retErr error) {
-	now := time.Now
-	if lifecycle.Runtime.Clock != nil {
-		now = lifecycle.Runtime.Clock.Now
-	}
+	clock := lifecycle.Runtime.Clock
+	now := func() time.Time { return core.ClockNow(clock) }
 	stdout, stderr := lifecycle.Runtime.Stdout, lifecycle.Runtime.Stderr
 	if stdout == nil {
 		stdout = io.Discard

--- a/internal/providers/shared/direct.go
+++ b/internal/providers/shared/direct.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -36,10 +35,7 @@ func (b *DirectSSHBackend) CleanupServers(ctx context.Context, req core.CleanupR
 	if b.PrepareCleanup != nil && b.CleanupEligible != nil {
 		return core.Exit(2, "provider=%s cleanup backend cannot configure both PrepareCleanup and CleanupEligible", b.SpecValue.Name)
 	}
-	now := time.Now().UTC()
-	if b.RT.Clock != nil {
-		now = b.RT.Clock.Now().UTC()
-	}
+	now := core.ClockNow(b.RT.Clock).UTC()
 	for _, s := range servers {
 		shouldDelete, reason := core.ShouldCleanupServer(s, now)
 		if !shouldDelete {

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -76,7 +76,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if _, err := superserveWorkdir(b.cfg); err != nil {
 		return err
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	api, err := b.client()
 	if err != nil {
 		return err
@@ -90,7 +90,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: superserve warmup keeps the sandbox until explicit stop\n")
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  leaseID,
@@ -140,7 +140,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) {
 			return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 				Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-				TempPattern: "crabbox-superserve-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+				TempPattern: "crabbox-superserve-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 			})
 		},
 		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
@@ -283,7 +283,7 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 	if waitTimeout <= 0 {
 		waitTimeout = 5 * time.Minute
 	}
-	deadline := b.now().Add(waitTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(waitTimeout)
 	pollCtx := ctx
 	cancel := func() {}
 	if req.Wait {
@@ -329,7 +329,7 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 		if isTerminalState(state) {
 			return StatusView{}, exit(5, "superserve sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
-		if b.now().After(deadline) {
+		if core.ClockNow(b.rt.Clock).After(deadline) {
 			return StatusView{}, exit(5, "timed out waiting for superserve sandbox %s to become ready", sandboxID)
 		}
 		select {
@@ -389,7 +389,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	if err != nil {
 		return err
 	}
-	now := b.now().UTC()
+	now := core.ClockNow(b.rt.Clock).UTC()
 	checked := 0
 	removed := 0
 	claimsRemoved := 0
@@ -767,13 +767,6 @@ func superserveCommandEnv(env map[string]string) (map[string]string, []string) {
 	}
 	slices.Sort(stripped)
 	return out, stripped
-}
-
-func (b *backend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }
 
 func normalizedSandboxState(sb superserveSandbox) string {

--- a/internal/providers/superserve/sync.go
+++ b/internal/providers/superserve/sync.go
@@ -21,7 +21,7 @@ func (b *backend) syncWorkspace(ctx context.Context, api superserveClient, acces
 		PhaseName:           "superserve_sync",
 		Provider:            providerName,
 		Stderr:              b.rt.Stderr,
-		Now:                 b.now,
+		Now:                 func() time.Time { return core.ClockNow(b.rt.Clock) },
 		CleanupContext:      b.cleanupContext,
 		Upload: func(uploadCtx context.Context, remoteArchive string, body io.Reader) error {
 			return api.UploadFile(uploadCtx, access, remoteArchive, body)

--- a/internal/providers/tensorlake/backend.go
+++ b/internal/providers/tensorlake/backend.go
@@ -27,7 +27,7 @@ type tensorlakeBackend struct {
 func (b *tensorlakeBackend) Spec() ProviderSpec { return b.spec }
 
 func (b *tensorlakeBackend) Warmup(ctx context.Context, req WarmupRequest) error {
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	cli, err := newTensorlakeCLI(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -41,7 +41,7 @@ func (b *tensorlakeBackend) Warmup(ctx context.Context, req WarmupRequest) error
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: tensorlake warmup keeps the sandbox until explicit stop\n")
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  leaseID,
@@ -225,9 +225,9 @@ func (b *tensorlakeBackend) Status(ctx context.Context, req StatusRequest) (Stat
 	if err != nil {
 		return StatusView{}, err
 	}
-	deadline := b.now().Add(req.WaitTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(req.WaitTimeout)
 	if req.WaitTimeout <= 0 {
-		deadline = b.now().Add(5 * time.Minute)
+		deadline = core.ClockNow(b.rt.Clock).Add(5 * time.Minute)
 	}
 	var lastDescribeErr error
 	for {
@@ -265,7 +265,7 @@ func (b *tensorlakeBackend) Status(ctx context.Context, req StatusRequest) (Stat
 		if !req.Wait || view.Ready {
 			return view, nil
 		}
-		if b.now().After(deadline) {
+		if core.ClockNow(b.rt.Clock).After(deadline) {
 			err := exit(5, "timed out waiting for tensorlake sandbox %s to become ready", sandboxID)
 			if lastDescribeErr != nil {
 				return StatusView{}, errors.Join(err, fmt.Errorf("last tensorlake describe failed: %w", lastDescribeErr))
@@ -442,11 +442,4 @@ func tensorlakeWorkdir(cfg Config) (string, error) {
 		return "", exit(2, "tensorlake workdir %q is too broad; choose a dedicated subdirectory", clean)
 	}
 	return clean, nil
-}
-
-func (b *tensorlakeBackend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }

--- a/internal/providers/tensorlake/sync.go
+++ b/internal/providers/tensorlake/sync.go
@@ -23,7 +23,7 @@ func rejectIncompatibleSyncOptions(req RunRequest) error {
 func (b *tensorlakeBackend) prepareArchive(ctx context.Context, req RunRequest) (*core.PreparedArchive, error) {
 	return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-		TempPattern: "crabbox-tensorlake-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+		TempPattern: "crabbox-tensorlake-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 	})
 }
 
@@ -42,7 +42,7 @@ func (b *tensorlakeBackend) syncWorkspace(ctx context.Context, cli *tensorlakeCL
 	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
 		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
 		Workdir: workdir, RemoteArchivePrefix: "crabbox-tensorlake-sync-",
-		Provider: providerName, PhaseName: "tensorlake_sync", Stderr: b.rt.Stderr, Now: b.now,
+		Provider: providerName, PhaseName: "tensorlake_sync", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 		Upload: func(uploadCtx context.Context, remoteArchive string, _ io.Reader) error {
 			return cli.uploadFile(uploadCtx, sandboxID, archive.File.Name(), remoteArchive)
 		},

--- a/internal/providers/unikraftcloud/backend.go
+++ b/internal/providers/unikraftcloud/backend.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -81,7 +82,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if b.cfg.UnikraftCloud.MemoryMB < 0 {
 		return exit(2, "provider=%s memory must be zero or greater", providerName)
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	api, err := b.client()
 	if err != nil {
 		return err
@@ -196,7 +197,7 @@ func (b *backend) finishWarmup(started time.Time, claim LeaseClaim, instance ukc
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: %s warmup keeps the instance until explicit stop or eligible cleanup\n", providerName)
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  claim.LeaseID,
@@ -606,11 +607,4 @@ func rejectUnikraftCloudRunOptions(req RunRequest) error {
 		return exit(2, "provider=%s cannot forward per-run environment variables", providerName)
 	}
 	return nil
-}
-
-func (b *backend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }

--- a/internal/providers/unikraftcloud/lifecycle.go
+++ b/internal/providers/unikraftcloud/lifecycle.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 const (
@@ -53,7 +55,7 @@ func cloneLabels(labels map[string]string) map[string]string {
 }
 
 func (b *backend) createIntentClaim(leaseID, slug, scope, accountUUID string, req WarmupRequest, createReq createInstanceRequest) (LeaseClaim, error) {
-	labels := directLeaseLabels(b.cfg, leaseID, slug, req.Keep, b.now())
+	labels := directLeaseLabels(b.cfg, leaseID, slug, req.Keep, core.ClockNow(b.rt.Clock))
 	labels["state"] = ukcStateCreatePreflight
 	labels[ukcLabelResourceName] = createReq.Name
 	labels[ukcLabelRequestHash] = unikraftCloudCreateRequestHash(createReq)
@@ -718,7 +720,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			return err
 		}
 		state := current.Labels["state"]
-		remove, reason := shouldCleanupServer(serverFromClaim(current), b.now())
+		remove, reason := shouldCleanupServer(serverFromClaim(current), core.ClockNow(b.rt.Clock))
 		if state == ukcStateDeleteAttempt || state == ukcStateDeleteAccepted || state == ukcStateCreatePreflight || state == ukcStateCreateConflict {
 			remove, reason = true, "resume "+state
 		}

--- a/internal/providers/upstashbox/backend.go
+++ b/internal/providers/upstashbox/backend.go
@@ -30,7 +30,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if req.ActionsRunner {
 		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	client, err := newAPI(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -43,7 +43,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: upstash-box warmup keeps the box until explicit stop\n")
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  leaseID,
@@ -177,7 +177,7 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 		Network:     networkPublic,
 		Wait:        req.Wait,
 		WaitTimeout: req.WaitTimeout,
-		Now:         b.now,
+		Now:         func() time.Time { return core.ClockNow(b.rt.Clock) },
 		Resolve: func(id string) (string, string, string, error) {
 			return b.resolveBoxID(ctx, client, id, "", false)
 		},
@@ -344,10 +344,6 @@ func resolveBoxBySlug(ctx context.Context, client api, slug string) (boxData, er
 		}
 	}
 	return boxData{}, exit(4, "upstash-box %q was not found", slug)
-}
-
-func (b *backend) now() time.Time {
-	return now(b.rt)
 }
 
 func boxToServer(cfg Config, box boxData) Server {

--- a/internal/providers/upstashbox/core.go
+++ b/internal/providers/upstashbox/core.go
@@ -86,10 +86,3 @@ func upstashBoxCleanupCommand(leaseID string) string {
 func inventoryDoctorResult(provider string, leases int) DoctorResult {
 	return core.InventoryDoctorResult(provider, leases)
 }
-
-func now(rt Runtime) time.Time {
-	if rt.Clock != nil {
-		return rt.Clock.Now()
-	}
-	return time.Now()
-}

--- a/internal/providers/upstashbox/sync.go
+++ b/internal/providers/upstashbox/sync.go
@@ -13,7 +13,7 @@ import (
 func (b *backend) prepareArchive(ctx context.Context, req RunRequest) (*core.PreparedArchive, error) {
 	return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-		TempPattern: "crabbox-upstash-box-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+		TempPattern: "crabbox-upstash-box-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 	})
 }
 
@@ -40,7 +40,7 @@ func (b *backend) syncWorkspace(ctx context.Context, client api, boxID string, r
 	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
 		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
 		Workdir: folder, RemoteArchiveDir: ".", RemoteArchivePrefix: ".crabbox-upstash-box-sync-",
-		Provider: providerName, PhaseName: "upstash_box_sync", Stderr: b.rt.Stderr, Now: b.now,
+		Provider: providerName, PhaseName: "upstash_box_sync", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 		CleanupContext: func(context.Context) (context.Context, context.CancelFunc) { return upstashBoxCleanupContext() },
 		Upload: func(uploadCtx context.Context, remoteArchive string, _ io.Reader) error {
 			if err := client.UploadFile(uploadCtx, boxID, archive.File.Name(), workspacePath(remoteArchive)); err != nil {

--- a/internal/providers/vercelsandbox/backend.go
+++ b/internal/providers/vercelsandbox/backend.go
@@ -36,7 +36,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if _, err := vercelSandboxWorkdir(b.cfg); err != nil {
 		return err
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	api, err := b.client()
 	if err != nil {
 		return err
@@ -53,7 +53,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: vercel-sandbox warmup keeps the sandbox until explicit stop\n")
 	}
-	total := b.now().Sub(started)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
 		Provider: providerName,
 		LeaseID:  leaseID,
@@ -86,7 +86,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) {
 			return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 				Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-				TempPattern: "crabbox-vercel-sandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+				TempPattern: "crabbox-vercel-sandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 			})
 		},
 		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
@@ -252,7 +252,7 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 	if waitTimeout <= 0 {
 		waitTimeout = 5 * time.Minute
 	}
-	deadline := b.now().Add(waitTimeout)
+	deadline := core.ClockNow(b.rt.Clock).Add(waitTimeout)
 	pollCtx := ctx
 	cancel := func() {}
 	if req.Wait {
@@ -298,7 +298,7 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 		if isTerminalState(state) {
 			return StatusView{}, exit(5, "vercel-sandbox sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
-		if b.now().After(deadline) {
+		if core.ClockNow(b.rt.Clock).After(deadline) {
 			return StatusView{}, exit(5, "timed out waiting for vercel-sandbox sandbox %s to become ready", sandboxID)
 		}
 		select {
@@ -373,7 +373,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	if err := b.bindProviderScope(ctx, api, true); err != nil {
 		return err
 	}
-	now := b.now().UTC()
+	now := core.ClockNow(b.rt.Clock).UTC()
 	checked := 0
 	removed := 0
 	claimsRemoved := 0
@@ -761,13 +761,6 @@ func (b *backend) cleanupContext(ctx context.Context) (context.Context, context.
 
 func (b *backend) execTimeoutSecs() int {
 	return b.cfg.VercelSandbox.ExecTimeoutSecs
-}
-
-func (b *backend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }
 
 func normalizedSandboxState(sb sandboxSummary) string {

--- a/internal/providers/vercelsandbox/sync.go
+++ b/internal/providers/vercelsandbox/sync.go
@@ -21,7 +21,7 @@ func (b *backend) syncWorkspace(ctx context.Context, api vercelSandboxClient, sa
 		PhaseName:           "vercel_sandbox_sync",
 		Provider:            providerName,
 		Stderr:              b.rt.Stderr,
-		Now:                 b.now,
+		Now:                 func() time.Time { return core.ClockNow(b.rt.Clock) },
 		CleanupContext:      b.cleanupContext,
 		Upload: func(uploadCtx context.Context, remoteArchive string, body io.Reader) error {
 			return api.UploadFile(uploadCtx, sandboxID, remoteArchive, body)

--- a/internal/providers/vultr/backend.go
+++ b/internal/providers/vultr/backend.go
@@ -88,7 +88,7 @@ func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 	}
 	cfg.SSHKey = keyPath
 	cfg.ProviderKey = providerKeyForLease(leaseID)
-	now := b.now()
+	now := core.ClockNow(b.RT.Clock).UTC()
 	committed := false
 	created := vultrInstance{}
 	defer func() {
@@ -275,7 +275,7 @@ func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server
 		delete(labels, "idle_timeout")
 		delete(labels, "idle_timeout_secs")
 	}
-	labels = core.TouchDirectLeaseLabels(labels, cfg, req.State, b.now())
+	labels = core.TouchDirectLeaseLabels(labels, cfg, req.State, core.ClockNow(b.RT.Clock).UTC())
 	preserveVultrIdentity(labels, server.Labels)
 	if err := client.UpdateInstanceTags(ctx, item.ID, tagsFromLabels(labels)); err != nil {
 		return core.Server{}, err
@@ -907,13 +907,6 @@ func applyVultrDefaults(cfg *core.Config) {
 	if cfg.ServerType == "" {
 		cfg.ServerType = vultrServerTypeForClass(cfg.Class)
 	}
-}
-
-func (b *backend) now() time.Time {
-	if b.RT.Clock != nil {
-		return b.RT.Clock.Now().UTC()
-	}
-	return time.Now().UTC()
 }
 
 func isVultrInstanceID(value string) bool {

--- a/internal/providers/wandb/backend.go
+++ b/internal/providers/wandb/backend.go
@@ -59,7 +59,7 @@ func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (result RunResul
 	if err != nil {
 		return RunResult{}, err
 	}
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	cfg := b.cfg
 	image := blank(strings.TrimSpace(cfg.Wandb.DefaultImage), "ubuntu:24.04")
 	maxLifetime := wandbMaxLifetimeSeconds(cfg)
@@ -139,7 +139,7 @@ func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (result RunResul
 				result.Session.Kept = false
 			}
 		}
-		result.Total = b.now().Sub(started)
+		result.Total = core.ClockNow(b.rt.Clock).Sub(started)
 		if req.TimingJSON {
 			timingErr := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
 				Provider: providerName, Slug: sandboxID,
@@ -150,7 +150,7 @@ func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (result RunResul
 		}
 	}()
 
-	commandStarted := b.now()
+	commandStarted := core.ClockNow(b.rt.Clock)
 	var exitCode int
 	var execErr error
 	if err := verifyWandbClaim(claim); err != nil {
@@ -167,7 +167,7 @@ func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (result RunResul
 	// Command measures just the user's exec; Total includes Acquire+poll.
 	// Conflating them (the previous bug) made commandMs == totalMs on every
 	// fresh-sandbox run, hiding provisioning time from --timing-json users.
-	commandDuration := b.now().Sub(commandStarted)
+	commandDuration := core.ClockNow(b.rt.Clock).Sub(commandStarted)
 	result.ExitCode = exitCode
 	result.Command = commandDuration
 
@@ -416,13 +416,6 @@ func (b *wandbBackend) closeClientAfterOperation() {
 	if err := b.Close(); err != nil {
 		fmt.Fprintf(b.rt.Stderr, "warning: wandb client close failed: %v\n", err)
 	}
-}
-
-func (b *wandbBackend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
 }
 
 // applyWandbDefaults fills in interpreter / image / lifetime defaults without

--- a/internal/providers/windowssandbox/backend.go
+++ b/internal/providers/windowssandbox/backend.go
@@ -12,6 +12,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type backend struct {
@@ -97,11 +99,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		return RunResult{}, err
 	}
 
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	cfg := b.configForRun()
 	run, syncPhases, syncDuration, err := b.prepareRun(ctx, cfg, req)
 	if err != nil {
-		return RunResult{Total: b.now().Sub(started), SyncDelegated: true, Provider: providerName}, err
+		return RunResult{Total: core.ClockNow(b.rt.Clock).Sub(started), SyncDelegated: true, Provider: providerName}, err
 	}
 	keepWorkspace := req.Keep
 	defer func() {
@@ -118,7 +120,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	fmt.Fprintf(b.rt.Stderr, "provider=%s workdir=%s host_workspace=%s networking=%s vgpu=%s\n", providerName, cfg.WindowsSandbox.Workdir, run.hostWorkspace, cfg.WindowsSandbox.Networking, cfg.WindowsSandbox.VGPU)
 
-	commandStarted := b.now()
+	commandStarted := core.ClockNow(b.rt.Clock)
 	execResult, execErr := b.runHostRunner(ctx, LocalCommandRequest{
 		Name:                 "powershell.exe",
 		Args:                 hostRunnerArgs(run, cfg, req),
@@ -126,7 +128,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		Stderr:               b.rt.Stderr,
 		DisableOutputCapture: true,
 	}, filepath.Join(run.hostControl, "cancel.txt"), req.Keep || req.KeepOnFailure)
-	commandDuration := b.now().Sub(commandStarted)
+	commandDuration := core.ClockNow(b.rt.Clock).Sub(commandStarted)
 	exitCode := execResult.ExitCode
 	if execErr != nil && exitCode == 0 {
 		exitCode = 1
@@ -139,7 +141,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	result := RunResult{
 		ExitCode:      exitCode,
 		Command:       commandDuration,
-		Total:         b.now().Sub(started),
+		Total:         core.ClockNow(b.rt.Clock).Sub(started),
 		SyncDelegated: true,
 		Provider:      providerName,
 		Slug:          filepath.Base(run.root),
@@ -218,13 +220,6 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	return DoctorResult{Provider: providerName, Message: msg}, nil
 }
 
-func (b *backend) now() time.Time {
-	if b.rt.Clock != nil {
-		return b.rt.Clock.Now()
-	}
-	return time.Now()
-}
-
 type preparedRun struct {
 	root          string
 	hostWorkspace string
@@ -285,7 +280,7 @@ func (b *backend) prepareRun(ctx context.Context, cfg Config, req RunRequest) (p
 }
 
 func (b *backend) syncWorkspace(ctx context.Context, cfg Config, req RunRequest, hostWorkspace string) ([]timingPhase, time.Duration, error) {
-	started := b.now()
+	started := core.ClockNow(b.rt.Clock)
 	if req.NoSync {
 		if err := os.MkdirAll(hostWorkspace, 0o700); err != nil {
 			return nil, 0, fmt.Errorf("create windows-sandbox workspace: %w", err)
@@ -303,18 +298,18 @@ func (b *backend) syncWorkspace(ctx context.Context, cfg Config, req RunRequest,
 	if err != nil {
 		return nil, 0, err
 	}
-	manifestStarted := b.now()
+	manifestStarted := core.ClockNow(b.rt.Clock)
 	manifest, err := syncManifest(req.Repo.Root, excludes, cfg.Sync.Includes)
 	if err != nil {
 		return nil, 0, exit(6, "build sync file list: %v", err)
 	}
-	manifestDuration := b.now().Sub(manifestStarted)
-	preflightStarted := b.now()
+	manifestDuration := core.ClockNow(b.rt.Clock).Sub(manifestStarted)
+	preflightStarted := core.ClockNow(b.rt.Clock)
 	if err := checkSyncPreflight(manifest, cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
 		return nil, 0, err
 	}
-	preflightDuration := b.now().Sub(preflightStarted)
-	copyStarted := b.now()
+	preflightDuration := core.ClockNow(b.rt.Clock).Sub(preflightStarted)
+	copyStarted := core.ClockNow(b.rt.Clock)
 	if cfg.Sync.Delete {
 		if err := os.RemoveAll(hostWorkspace); err != nil {
 			return nil, 0, fmt.Errorf("reset windows-sandbox workspace: %w", err)
@@ -326,8 +321,8 @@ func (b *backend) syncWorkspace(ctx context.Context, cfg Config, req RunRequest,
 	if err := copyManifest(syncCtx, req.Repo.Root, hostWorkspace, manifest); err != nil {
 		return nil, 0, err
 	}
-	copyDuration := b.now().Sub(copyStarted)
-	total := b.now().Sub(started)
+	copyDuration := core.ClockNow(b.rt.Clock).Sub(copyStarted)
+	total := core.ClockNow(b.rt.Clock).Sub(started)
 	return []timingPhase{
 		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
 		{Name: "preflight", Ms: preflightDuration.Milliseconds()},


### PR DESCRIPTION
## What Problem This Solves

Provider implementations repeated the same runtime clock fallback helper, making a simple invariant harder to audit and maintain consistently.

## Why This Change Was Made

This mechanical refactor adds the provider-neutral `ClockNow(Clock)` helper and reuses it across 33 provider packages. It preserves nil and typed-nil dispatch, exact time values and locations, dynamic runtime clock replacement, delegated clock snapshots, and the existing UTC normalization points without making `Runtime` implement `Clock`.

## User Impact

There is no user-visible behavior, configuration, or secret-handling change. The duplicated provider helpers are removed while existing timing and lifecycle contracts remain unchanged. No changelog entry is included because this is a mechanical refactor.

## Evidence

- Added focused tests for nil fallback, typed-nil dispatch, single-call behavior, advancing clocks, exact location preservation, runtime clock replacement, and the `Runtime` interface boundary.
- `gofmt`, diff checks, import review, and static callback/call-site census passed.
- The diff removes 34 helpers across 33 packages and is net negative: 64 files, 397 additions, and 531 deletions.
- Hosted qualification passed 22/22 canonical jobs on attempt 1: [CI](https://github.com/openclaw/crabbox/actions/runs/34187260493), [Connector E2E Smokes](https://github.com/openclaw/crabbox/actions/runs/34187260430), [Crabbox Release Check](https://github.com/openclaw/crabbox/actions/runs/34187260456), [CodeQL](https://github.com/openclaw/crabbox/actions/runs/34187258896), and [ClawSweeper Dispatch](https://github.com/openclaw/crabbox/actions/runs/34187260688).
- The CI Go job passed formatting, Vet, Deadcode with empty guarded output, Test, all nine required Linux supervision fixtures without skips, and Build.
- Local product tests were not run for this preparation cycle. The lightweight callback regression test validates replacement semantics, but the hosted matrix does not independently execute every provider callback against every live provider service.
