### PR TITLE
refactor: share service-control run option validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Share service-control run-option validation across FastAPI Cloud, Railway, and Unikraft Cloud while preserving rejection messages, precedence, and refusal before provider access. Thanks @steipete.
+- Share service-control run-option validation across FastAPI Cloud, Railway, and Unikraft Cloud while preserving rejection messages, precedence, and refusal before provider access. [PR 1979](https://github.com/openclaw/crabbox/pull/1979). Thanks @steipete.
 
 - AWS: overlap SSH ingress authorization in bounded batches while preserving revocation, recovery and cleanup ordering. https://github.com/openclaw/crabbox/pull/1976. Thanks @steipete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Share service-control run-option validation across FastAPI Cloud, Railway, and Unikraft Cloud while preserving rejection messages, precedence, and refusal before provider access. Thanks @steipete.
+
 - AWS: overlap SSH ingress authorization in bounded batches while preserving revocation, recovery and cleanup ordering. https://github.com/openclaw/crabbox/pull/1976. Thanks @steipete.
 
 - Overlap default-VPC and managed security-group discovery during AWS provisioning while retaining scope validation and joined failure handling. [PR 1974](https://github.com/openclaw/crabbox/pull/1974). Thanks @steipete.

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -779,6 +779,12 @@ Pick `Kind` carefully:
   hosted service instead of leasing a run surface (for example `railway` and
   `fastapi-cloud`).
 
+FastAPI Cloud, Railway, and Unikraft Cloud share their ordered unsupported-run
+option checks through `shared.RejectServiceRunOptions`. The adapters retain
+their lifecycle and shell explanations, request-ID requirements, and final
+command refusal. These checks do not grant a service an execution capability or
+contact its API.
+
 `Targets` should describe what the provider can actually satisfy. Use `linux`,
 `macos`, or `windows` only for real operating-system targets. Use
 `worker-runtime` for Worker-isolate or module-runtime providers that execute

--- a/internal/providers/fastapicloud/backend.go
+++ b/internal/providers/fastapicloud/backend.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/url"
 	"strings"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func NewFastAPICloudBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
@@ -28,7 +30,7 @@ func (b *fastAPICloudBackend) Warmup(ctx context.Context, req WarmupRequest) err
 
 func (b *fastAPICloudBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	_ = ctx
-	if err := rejectFastAPICloudRunOptions(req); err != nil {
+	if err := shared.RejectServiceRunOptions(req, providerName, "lifecycle is owned by FastAPI Cloud", "cannot open an interactive shell"); err != nil {
 		return RunResult{}, err
 	}
 	if len(req.Command) == 0 {
@@ -173,35 +175,4 @@ func hostFromAppURL(raw string) string {
 		return parsed.Hostname()
 	}
 	return strings.TrimSpace(raw)
-}
-
-func rejectFastAPICloudRunOptions(req RunRequest) error {
-	if req.Keep {
-		return exit(2, "provider=%s lifecycle is owned by FastAPI Cloud; --keep is not supported", providerName)
-	}
-	if req.Reclaim {
-		return exit(2, "provider=%s lifecycle is owned by FastAPI Cloud; --reclaim is not supported", providerName)
-	}
-	if !req.NoSync {
-		return exit(2, "provider=%s does not support workspace sync; pass --no-sync", providerName)
-	}
-	if req.SyncOnly {
-		return exit(2, "provider=%s does not support sync; --sync-only is rejected", providerName)
-	}
-	if req.ChecksumSync {
-		return exit(2, "provider=%s does not support sync; --checksum is rejected", providerName)
-	}
-	if req.ForceSyncLarge {
-		return exit(2, "provider=%s does not support sync; --force-sync-large is rejected", providerName)
-	}
-	if req.FullResync {
-		return exit(2, "provider=%s does not support sync; --full-resync is rejected", providerName)
-	}
-	if req.ShellMode {
-		return exit(2, "provider=%s cannot open an interactive shell; --shell is not supported", providerName)
-	}
-	if req.EnvSummary {
-		return exit(2, "provider=%s cannot forward per-run environment variables", providerName)
-	}
-	return nil
 }

--- a/internal/providers/fastapicloud/backend_test.go
+++ b/internal/providers/fastapicloud/backend_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -328,14 +329,31 @@ func TestFastAPICloudClientSurfacesNon2xxAsAPIError(t *testing.T) {
 }
 
 func TestFastAPICloudRunRejectsBeforeAPI(t *testing.T) {
-	backend := &fastAPICloudBackend{
-		spec:   Provider{}.Spec(),
-		cfg:    Config{},
-		client: panicFastAPICloudAPI{},
-	}
-	_, err := backend.Run(context.Background(), RunRequest{NoSync: true, Command: []string{"pytest"}})
-	if err == nil || !strings.Contains(err.Error(), "cannot execute arbitrary run commands") {
-		t.Fatalf("err = %v, want arbitrary command rejection", err)
+	for _, tc := range []struct {
+		name string
+		req  RunRequest
+		want string
+	}{
+		{name: "keep first", req: RunRequest{Keep: true, Reclaim: true}, want: "provider=fastapi-cloud lifecycle is owned by FastAPI Cloud; --keep is not supported"},
+		{name: "reclaim", req: RunRequest{Reclaim: true}, want: "provider=fastapi-cloud lifecycle is owned by FastAPI Cloud; --reclaim is not supported"},
+		{name: "no sync", req: RunRequest{}, want: "provider=fastapi-cloud does not support workspace sync; pass --no-sync"},
+		{name: "shell", req: RunRequest{NoSync: true, ShellMode: true}, want: "provider=fastapi-cloud cannot open an interactive shell; --shell is not supported"},
+		{name: "env summary without env", req: RunRequest{NoSync: true, EnvSummary: true}, want: "provider=fastapi-cloud cannot forward per-run environment variables"},
+		{name: "missing command", req: RunRequest{NoSync: true}, want: "missing command"},
+		{name: "command", req: RunRequest{NoSync: true, Command: []string{"pytest"}}, want: "provider=fastapi-cloud cannot execute arbitrary run commands; deploy with fastapi deploy or FastAPI Cloud CI"},
+		{name: "implicit env", req: RunRequest{NoSync: true, Env: map[string]string{"CI": "true"}, Command: []string{"pytest"}}, want: "provider=fastapi-cloud cannot execute arbitrary run commands; deploy with fastapi deploy or FastAPI Cloud CI"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := &fastAPICloudBackend{spec: Provider{}.Spec(), client: panicFastAPICloudAPI{}}
+			result, err := backend.Run(context.Background(), tc.req)
+			var public ExitError
+			if !errors.As(err, &public) || public.Code != 2 || public.Message != tc.want {
+				t.Fatalf("err=%v, want exit2 %q", err, tc.want)
+			}
+			if !reflect.DeepEqual(result, RunResult{}) {
+				t.Fatalf("result=%#v, want zero result", result)
+			}
+		})
 	}
 }
 

--- a/internal/providers/railway/backend.go
+++ b/internal/providers/railway/backend.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -42,7 +44,7 @@ func (b *railwayBackend) Warmup(ctx context.Context, req WarmupRequest) error {
 
 func (b *railwayBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	_ = ctx
-	if err := rejectRailwayRunOptions(req); err != nil {
+	if err := shared.RejectServiceRunOptions(req, providerName, "lifecycle is owned by Railway", "runs the Railway service start command"); err != nil {
 		return RunResult{}, err
 	}
 	if req.ID == "" {
@@ -308,39 +310,4 @@ func (b *railwayBackend) requireProjectEnv() (string, string, error) {
 		return "", "", exit(2, "provider=%s requires --railway-environment or RAILWAY_ENVIRONMENT_ID", providerName)
 	}
 	return projectID, environmentID, nil
-}
-
-func rejectRailwayRunOptions(req RunRequest) error {
-	if req.Keep {
-		return exit(2, "provider=%s lifecycle is owned by Railway; --keep is not supported", providerName)
-	}
-	if req.Reclaim {
-		return exit(2, "provider=%s lifecycle is owned by Railway; --reclaim is not supported", providerName)
-	}
-	if !req.NoSync {
-		// Railway does not expose a workspace-sync surface; mirror other
-		// delegated-only providers and require --no-sync explicitly so callers
-		// understand the deploy runs whatever the service is already configured
-		// to run.
-		return exit(2, "provider=%s does not support workspace sync; pass --no-sync", providerName)
-	}
-	if req.SyncOnly {
-		return exit(2, "provider=%s does not support sync; --sync-only is rejected", providerName)
-	}
-	if req.ChecksumSync {
-		return exit(2, "provider=%s does not support sync; --checksum is rejected", providerName)
-	}
-	if req.ForceSyncLarge {
-		return exit(2, "provider=%s does not support sync; --force-sync-large is rejected", providerName)
-	}
-	if req.FullResync {
-		return exit(2, "provider=%s does not support sync; --full-resync is rejected", providerName)
-	}
-	if req.ShellMode {
-		return exit(2, "provider=%s runs the Railway service start command; --shell is not supported", providerName)
-	}
-	if req.EnvSummary {
-		return exit(2, "provider=%s cannot forward per-run environment variables", providerName)
-	}
-	return nil
 }

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -517,7 +517,7 @@ func TestRailwayRunRequiresNoSync(t *testing.T) {
 
 func TestRailwayRunRequiresServiceID(t *testing.T) {
 	backend := &railwayBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-	_, err := backend.Run(context.Background(), RunRequest{NoSync: true, Command: []string{"pnpm", "test"}})
+	_, err := backend.Run(context.Background(), RunRequest{NoSync: true})
 	if err == nil || !strings.Contains(err.Error(), "--id") {
 		t.Fatalf("err = %v, want --id rejection", err)
 	}
@@ -565,30 +565,43 @@ func TestRailwayRunRejectsLeaseFlags(t *testing.T) {
 		req  RunRequest
 		want string
 	}{
-		{name: "keep", req: RunRequest{ID: "svc-1", Keep: true, NoSync: true, Command: []string{"pnpm", "test"}}, want: "--keep"},
-		{name: "reclaim", req: RunRequest{ID: "svc-1", Reclaim: true, NoSync: true, Command: []string{"pnpm", "test"}}, want: "--reclaim"},
-		{name: "shell", req: RunRequest{ID: "svc-1", ShellMode: true, NoSync: true, Command: []string{"pnpm test"}}, want: "--shell"},
-		{name: "env summary", req: RunRequest{ID: "svc-1", NoSync: true, Env: map[string]string{"TOKEN": "secret"}, EnvSummary: true, Command: []string{"pnpm", "test"}}, want: "environment"},
+		{name: "keep first", req: RunRequest{Keep: true, Reclaim: true}, want: "provider=railway lifecycle is owned by Railway; --keep is not supported"},
+		{name: "reclaim", req: RunRequest{Reclaim: true}, want: "provider=railway lifecycle is owned by Railway; --reclaim is not supported"},
+		{name: "sync only", req: RunRequest{NoSync: true, SyncOnly: true}, want: "provider=railway does not support sync; --sync-only is rejected"},
+		{name: "checksum", req: RunRequest{NoSync: true, ChecksumSync: true}, want: "provider=railway does not support sync; --checksum is rejected"},
+		{name: "force large", req: RunRequest{NoSync: true, ForceSyncLarge: true}, want: "provider=railway does not support sync; --force-sync-large is rejected"},
+		{name: "full resync", req: RunRequest{NoSync: true, FullResync: true}, want: "provider=railway does not support sync; --full-resync is rejected"},
+		{name: "shell before ID", req: RunRequest{NoSync: true, ShellMode: true}, want: "provider=railway runs the Railway service start command; --shell is not supported"},
+		{name: "env summary without env", req: RunRequest{NoSync: true, EnvSummary: true}, want: "provider=railway cannot forward per-run environment variables"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			backend := &railwayBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-			_, err := backend.Run(context.Background(), tc.req)
-			if err == nil || !strings.Contains(err.Error(), tc.want) {
-				t.Fatalf("err = %v, want %s rejection", err, tc.want)
+			api := &fakeRailwayAPI{}
+			backend := newRailwayBackendForTest(api)
+			result, err := backend.Run(context.Background(), tc.req)
+			var public ExitError
+			if !errors.As(err, &public) || public.Code != 2 || public.Message != tc.want {
+				t.Fatalf("err=%v, want exit2 %q", err, tc.want)
+			}
+			if !reflect.DeepEqual(result, RunResult{}) || len(api.calls) != 0 {
+				t.Fatalf("result=%#v API calls=%v", result, api.calls)
 			}
 		})
 	}
 }
 
 func TestRailwayRunAllowsImplicitDefaultEnv(t *testing.T) {
-	err := rejectRailwayRunOptions(RunRequest{
-		ID:      "svc-1",
-		NoSync:  true,
-		Env:     map[string]string{"CI": "true"},
-		Command: []string{"pnpm", "test"},
+	api := &fakeRailwayAPI{}
+	backend := newRailwayBackendForTest(api)
+	result, err := backend.Run(context.Background(), RunRequest{
+		ID: "svc-1", NoSync: true, Env: map[string]string{"CI": "true"}, Command: []string{"pnpm", "test"},
 	})
-	if err != nil {
-		t.Fatalf("rejectRailwayRunOptions err: %v", err)
+	var public ExitError
+	want := "provider=railway cannot execute arbitrary run commands; Railway only runs the service's configured start command"
+	if !errors.As(err, &public) || public.Code != 2 || public.Message != want {
+		t.Fatalf("err=%v, want command rejection after option admission", err)
+	}
+	if !reflect.DeepEqual(result, RunResult{}) || len(api.calls) != 0 {
+		t.Fatalf("result=%#v API calls=%v", result, api.calls)
 	}
 }
 

--- a/internal/providers/shared/service.go
+++ b/internal/providers/shared/service.go
@@ -1,0 +1,38 @@
+package shared
+
+import core "github.com/openclaw/crabbox/internal/cli"
+
+// RejectServiceRunOptions rejects run options that service-control backends
+// cannot honor. Command and service identity validation remain with the caller.
+func RejectServiceRunOptions(req core.RunRequest, provider, lifecycleReason, shellReason string) error {
+	if req.Keep {
+		return core.Exit(2, "provider=%s %s; --keep is not supported", provider, lifecycleReason)
+	}
+	if req.Reclaim {
+		return core.Exit(2, "provider=%s %s; --reclaim is not supported", provider, lifecycleReason)
+	}
+	if !req.NoSync {
+		// Services expose no workspace-sync surface. Require --no-sync explicitly:
+		// a deployment runs what the service is already configured to run.
+		return core.Exit(2, "provider=%s does not support workspace sync; pass --no-sync", provider)
+	}
+	if req.SyncOnly {
+		return core.Exit(2, "provider=%s does not support sync; --sync-only is rejected", provider)
+	}
+	if req.ChecksumSync {
+		return core.Exit(2, "provider=%s does not support sync; --checksum is rejected", provider)
+	}
+	if req.ForceSyncLarge {
+		return core.Exit(2, "provider=%s does not support sync; --force-sync-large is rejected", provider)
+	}
+	if req.FullResync {
+		return core.Exit(2, "provider=%s does not support sync; --full-resync is rejected", provider)
+	}
+	if req.ShellMode {
+		return core.Exit(2, "provider=%s %s; --shell is not supported", provider, shellReason)
+	}
+	if req.EnvSummary {
+		return core.Exit(2, "provider=%s cannot forward per-run environment variables", provider)
+	}
+	return nil
+}

--- a/internal/providers/shared/service_test.go
+++ b/internal/providers/shared/service_test.go
@@ -1,0 +1,44 @@
+package shared
+
+import (
+	"errors"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestRejectServiceRunOptions(t *testing.T) {
+	// Each rejection also enables every later guard, pinning the full precedence.
+	for _, tc := range []struct {
+		name string
+		req  core.RunRequest
+		want string
+	}{
+		{name: "keep", req: core.RunRequest{Keep: true, Reclaim: true, SyncOnly: true, ChecksumSync: true, ForceSyncLarge: true, FullResync: true, ShellMode: true, EnvSummary: true}, want: "lifecycle belongs to the service; --keep is not supported"},
+		{name: "reclaim", req: core.RunRequest{Reclaim: true, SyncOnly: true, ChecksumSync: true, ForceSyncLarge: true, FullResync: true, ShellMode: true, EnvSummary: true}, want: "lifecycle belongs to the service; --reclaim is not supported"},
+		{name: "no sync", req: core.RunRequest{SyncOnly: true, ChecksumSync: true, ForceSyncLarge: true, FullResync: true, ShellMode: true, EnvSummary: true}, want: "does not support workspace sync; pass --no-sync"},
+		{name: "sync only", req: core.RunRequest{NoSync: true, SyncOnly: true, ChecksumSync: true, ForceSyncLarge: true, FullResync: true, ShellMode: true, EnvSummary: true}, want: "does not support sync; --sync-only is rejected"},
+		{name: "checksum", req: core.RunRequest{NoSync: true, ChecksumSync: true, ForceSyncLarge: true, FullResync: true, ShellMode: true, EnvSummary: true}, want: "does not support sync; --checksum is rejected"},
+		{name: "force large", req: core.RunRequest{NoSync: true, ForceSyncLarge: true, FullResync: true, ShellMode: true, EnvSummary: true}, want: "does not support sync; --force-sync-large is rejected"},
+		{name: "full resync", req: core.RunRequest{NoSync: true, FullResync: true, ShellMode: true, EnvSummary: true}, want: "does not support sync; --full-resync is rejected"},
+		{name: "shell", req: core.RunRequest{NoSync: true, ShellMode: true, EnvSummary: true}, want: "runs its configured command; --shell is not supported"},
+		{name: "env summary without env", req: core.RunRequest{NoSync: true, EnvSummary: true}, want: "cannot forward per-run environment variables"},
+		{name: "later validation belongs to caller", req: core.RunRequest{NoSync: true}},
+		{name: "implicit env", req: core.RunRequest{NoSync: true, Env: map[string]string{"CI": "true"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := RejectServiceRunOptions(tc.req, "example-service", "lifecycle belongs to the service", "runs its configured command")
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("admitted options rejected: %v", err)
+				}
+				return
+			}
+			var public core.ExitError
+			want := "provider=example-service " + tc.want
+			if !errors.As(err, &public) || public.Code != 2 || public.Message != want {
+				t.Fatalf("err=%v, want exit2 %q", err, want)
+			}
+		})
+	}
+}

--- a/internal/providers/unikraftcloud/backend.go
+++ b/internal/providers/unikraftcloud/backend.go
@@ -207,7 +207,7 @@ func (b *backend) finishWarmup(started time.Time, claim LeaseClaim, instance ukc
 
 func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	_ = ctx
-	if err := rejectUnikraftCloudRunOptions(req); err != nil {
+	if err := shared.RejectServiceRunOptions(req, providerName, "cannot run commands", "cannot open an interactive shell"); err != nil {
 		return RunResult{}, err
 	}
 	if len(req.Command) == 0 {
@@ -575,37 +575,6 @@ func instanceFQDN(instance ukcInstance) string {
 
 func normalizedInstanceState(state string) string {
 	return strings.ToLower(blank(strings.TrimSpace(state), "unknown"))
-}
-
-func rejectUnikraftCloudRunOptions(req RunRequest) error {
-	if req.Keep {
-		return exit(2, "provider=%s cannot run commands; --keep is not supported", providerName)
-	}
-	if req.Reclaim {
-		return exit(2, "provider=%s cannot run commands; --reclaim is not supported", providerName)
-	}
-	if !req.NoSync {
-		return exit(2, "provider=%s does not support workspace sync; pass --no-sync", providerName)
-	}
-	if req.SyncOnly {
-		return exit(2, "provider=%s does not support sync; --sync-only is rejected", providerName)
-	}
-	if req.ChecksumSync {
-		return exit(2, "provider=%s does not support sync; --checksum is rejected", providerName)
-	}
-	if req.ForceSyncLarge {
-		return exit(2, "provider=%s does not support sync; --force-sync-large is rejected", providerName)
-	}
-	if req.FullResync {
-		return exit(2, "provider=%s does not support sync; --full-resync is rejected", providerName)
-	}
-	if req.ShellMode {
-		return exit(2, "provider=%s cannot open an interactive shell; --shell is not supported", providerName)
-	}
-	if req.EnvSummary {
-		return exit(2, "provider=%s cannot forward per-run environment variables", providerName)
-	}
-	return nil
 }
 
 func (b *backend) now() time.Time {

--- a/internal/providers/unikraftcloud/backend_test.go
+++ b/internal/providers/unikraftcloud/backend_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -319,53 +320,31 @@ func TestWarmupDoesNotCreateWhenIntentCannotBePersisted(t *testing.T) {
 }
 
 func TestRunIsRejected(t *testing.T) {
-	for _, test := range []struct {
-		name            string
-		req             RunRequest
-		wantErrContains string
+	for _, tc := range []struct {
+		name string
+		req  RunRequest
+		want string
 	}{
-		{
-			name:            "sync required off",
-			req:             RunRequest{Command: []string{"true"}},
-			wantErrContains: "pass --no-sync",
-		},
-		{
-			name:            "command rejected",
-			req:             RunRequest{NoSync: true, Command: []string{"true"}},
-			wantErrContains: "cannot execute arbitrary run commands",
-		},
-		{
-			name:            "missing command",
-			req:             RunRequest{NoSync: true},
-			wantErrContains: "missing command",
-		},
-		{
-			name:            "keep rejected",
-			req:             RunRequest{NoSync: true, Keep: true, Command: []string{"true"}},
-			wantErrContains: "--keep is not supported",
-		},
-		{
-			name:            "shell rejected",
-			req:             RunRequest{NoSync: true, ShellMode: true, Command: []string{"true"}},
-			wantErrContains: "--shell is not supported",
-		},
+		{name: "keep first", req: RunRequest{Keep: true, Reclaim: true}, want: "provider=unikraft-cloud cannot run commands; --keep is not supported"},
+		{name: "reclaim", req: RunRequest{Reclaim: true}, want: "provider=unikraft-cloud cannot run commands; --reclaim is not supported"},
+		{name: "no sync", req: RunRequest{}, want: "provider=unikraft-cloud does not support workspace sync; pass --no-sync"},
+		{name: "shell", req: RunRequest{NoSync: true, ShellMode: true}, want: "provider=unikraft-cloud cannot open an interactive shell; --shell is not supported"},
+		{name: "env summary without env", req: RunRequest{NoSync: true, EnvSummary: true}, want: "provider=unikraft-cloud cannot forward per-run environment variables"},
+		{name: "missing command", req: RunRequest{NoSync: true}, want: "missing command"},
+		{name: "command", req: RunRequest{NoSync: true, Command: []string{"true"}}, want: "provider=unikraft-cloud cannot execute arbitrary run commands; Unikraft Cloud instances run their OCI image entrypoint"},
+		{name: "implicit env", req: RunRequest{NoSync: true, Env: map[string]string{"CI": "true"}, Command: []string{"true"}}, want: "provider=unikraft-cloud cannot execute arbitrary run commands; Unikraft Cloud instances run their OCI image entrypoint"},
 	} {
-		t.Run(test.name, func(t *testing.T) {
-			api := &fakeUnikraftCloudAPI{baseURL: "https://api.fra.unikraft.cloud"}
-			b := testBackend(api, nil, nil)
-			_, err := b.Run(context.Background(), test.req)
-			if err == nil {
-				t.Fatal("Run succeeded, want rejection")
+		t.Run(tc.name, func(t *testing.T) {
+			b := &backend{newClient: func(Config, Runtime) (unikraftCloudAPI, error) {
+				panic("Run must not request a provider API client")
+			}}
+			result, err := b.Run(context.Background(), tc.req)
+			var public ExitError
+			if !errors.As(err, &public) || public.Code != 2 || public.Message != tc.want {
+				t.Fatalf("err=%v, want exit2 %q", err, tc.want)
 			}
-			if !strings.Contains(err.Error(), test.wantErrContains) {
-				t.Fatalf("err = %v, want containing %q", err, test.wantErrContains)
-			}
-			var exitErr ExitError
-			if !errors.As(err, &exitErr) || exitErr.Code != 2 {
-				t.Fatalf("err = %#v, want exit code 2", err)
-			}
-			if len(api.created) != 0 || len(api.deletedIDs) != 0 {
-				t.Fatalf("Run touched the API: %#v", api)
+			if !reflect.DeepEqual(result, RunResult{}) {
+				t.Fatalf("result=%#v, want zero result", result)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

FastAPI Cloud, Railway, and Unikraft Cloud each maintained the same nine-step validation sequence for unsupported `run` options. Move that complete sequence into `shared.RejectServiceRunOptions` and delete all three private implementations. The provider adapters retain their lifecycle/shell explanations, Railway's request-ID requirement, missing-command handling, and final arbitrary-command refusal.

All existing rejection messages, exit codes, precedence, and implicit default-environment behavior are preserved. No service gains command execution; no authentication, provider API, warmup, stop, claim, configuration, or dependency behavior changes. The production diff removes 55 lines net. Docs and the Unreleased changelog describe the shared owner.

## Verification

- Baseline-passing direct backend characterizations, followed by candidate race tests for the shared validator and all three provider Run paths. Tests cover all nine guard priorities, exact provider diagnostics, zero results, later ID/command checks, and refusal without provider API calls.
- Built the actual baseline and candidate CLIs with Go 1.26.5. All 39 credential-free local CLI cases matched exit status, stdout, and stderr exactly, with network access denied and an empty temporary HOME/repository for each binary run. Temporary fixtures were removed.
- The CLI's generic routing intercepts sync-only/checksum/force-sync/full-resync and missing-command requests before the provider. Those CLI cases are routing controls; direct backend/shared tests establish the extracted guard behavior.
- Focused `go vet` for the four affected packages passed; internal links passed across 246 Markdown files; diff checks passed.
- Independent design inspection and the required Codex review completed; the managed review was scoped to P0 findings and reported none.

The changed path rejects requests before any provider operation, so this proof is actual local CLI behavior, not a claimed hosted service lifecycle test. Existing service lifecycle implementations are unchanged.

Reviewed PR head: `879ddfad5e98f2d3cad289ef4ea1074f439ffeea`, tree `f0213ad2b9770f754239145bb2996c46a98fdef1`, based on `d305d43412c543192ef4fffc6f7c82228876a05d`. Two concurrent main landings required integration: the clock consolidation had an adjacent-function deletion conflict, and the AWS access update had a changelog insertion conflict. Both landed changes are preserved; this internal refactor entry now follows the user-facing changes.

The 39-case CLI proof was repeated on tree `f10a0dd9326248d26e971bb7e9e38d17e548ff34` (committed as `b988404a44512dfd62884a8ed42d2c466c374b64`) after the clock integration. The later AWS integration changed only Worker/docs/changelog files, not Go source. The final CLI was rebuilt and remains byte-identical: SHA-256 `cda957f61195975336e1bddcdf85c40d78e1e14141136c076baf443064553a26`. Focused race tests (including the clock tests), integrated vet, all 39 baseline comparisons, and reviews of each actual changed target passed. Initial branch conflicts deferred main CI. The final head passed all seven workflows and all 11 main CI jobs, with 25 successful checks and one skipped check. [Final main CI](https://github.com/openclaw/crabbox/actions/runs/34190838142).

Merged as `b5a1803b1c62ab2db5e5b3e802dcde794bf0c499` onto actual parent `1b1d43d0a315890086c95e0190e6956902b9ff9e`. The freshest main included an independent Azure Worker/docs change; the clean composition was inspected before landing. Actual tree `f547452cd94c0da1f2f0ab723a003fe3b6c68efb` exactly matches that preview. Post-merge focused races and docs links passed; the actual merged CLI was rebuilt and remains byte-identical to the 39-case-tested binary. No hosted service resource was created.

<details>
<summary>Inspectable 39-case CLI compatibility evidence</summary>

The driver substituted the built baseline and integrated candidate binaries for `crabbox`. Each invocation used `crabbox run --provider PROVIDER --id proof-service` followed by one of the exact argument tails below. Every case ran for all three providers. `SERVICE_PROOF=synthetic-value` was the only task value; the environment otherwise contained only temporary HOME/config/state paths, standard system PATH, and Git isolation settings. A fresh local Git fixture had no remote or credentials.

Each binary invocation was wrapped in `/usr/bin/sandbox-exec -p '(version 1)(allow default)(deny network*)'`. No provider resource was allocated. Both temporary fixtures were removed.

| Case | Argument tail |
| --- | --- |
| command | `--no-sync -- true` |
| keep | `--no-sync --keep -- true` |
| reclaim | `--no-sync --reclaim -- true` |
| sync-default | `-- true` |
| sync-only | `--no-sync --sync-only --` |
| checksum | `--no-sync --checksum -- true` |
| force-sync-large | `--no-sync --force-sync-large -- true` |
| full-resync | `--no-sync --full-resync -- true` |
| shell | `--no-sync --shell -- true` |
| environment | `--no-sync --allow-env SERVICE_PROOF -- true` |
| keep-before-reclaim | `--no-sync --keep --reclaim -- true` |
| keep-before-sync | `--keep -- true` |
| missing-command | `--no-sync --` |

Every invocation returned **2**, with **empty stdout**. The following stderr lines (each with one trailing LF) were exactly identical between the baseline and integrated candidate:

| Provider | Case | stderr |
| --- | --- | --- |
| fastapi-cloud | command | `provider=fastapi-cloud cannot execute arbitrary run commands; deploy with fastapi deploy or FastAPI Cloud CI` |
| fastapi-cloud | keep | `provider=fastapi-cloud lifecycle is owned by FastAPI Cloud; --keep is not supported` |
| fastapi-cloud | reclaim | `provider=fastapi-cloud lifecycle is owned by FastAPI Cloud; --reclaim is not supported` |
| fastapi-cloud | sync-default | `provider=fastapi-cloud does not support workspace sync; pass --no-sync` |
| fastapi-cloud | sync-only | `fastapi-cloud delegates sync; --sync-only is not supported` |
| fastapi-cloud | checksum | `fastapi-cloud delegates sync; --checksum is not supported` |
| fastapi-cloud | force-sync-large | `fastapi-cloud delegates sync; --force-sync-large is not supported` |
| fastapi-cloud | full-resync | `--full-resync cannot be combined with --no-sync` |
| fastapi-cloud | shell | `provider=fastapi-cloud cannot open an interactive shell; --shell is not supported` |
| fastapi-cloud | environment | `provider=fastapi-cloud cannot forward per-run environment variables` |
| fastapi-cloud | keep-before-reclaim | `provider=fastapi-cloud lifecycle is owned by FastAPI Cloud; --keep is not supported` |
| fastapi-cloud | keep-before-sync | `provider=fastapi-cloud lifecycle is owned by FastAPI Cloud; --keep is not supported` |
| fastapi-cloud | missing-command | `usage: crabbox run [flags] -- <command...>` |
| railway | command | `provider=railway cannot execute arbitrary run commands; Railway only runs the service's configured start command` |
| railway | keep | `provider=railway lifecycle is owned by Railway; --keep is not supported` |
| railway | reclaim | `provider=railway lifecycle is owned by Railway; --reclaim is not supported` |
| railway | sync-default | `provider=railway does not support workspace sync; pass --no-sync` |
| railway | sync-only | `railway delegates sync; --sync-only is not supported` |
| railway | checksum | `railway delegates sync; --checksum is not supported` |
| railway | force-sync-large | `railway delegates sync; --force-sync-large is not supported` |
| railway | full-resync | `--full-resync cannot be combined with --no-sync` |
| railway | shell | `provider=railway runs the Railway service start command; --shell is not supported` |
| railway | environment | `provider=railway cannot forward per-run environment variables` |
| railway | keep-before-reclaim | `provider=railway lifecycle is owned by Railway; --keep is not supported` |
| railway | keep-before-sync | `provider=railway lifecycle is owned by Railway; --keep is not supported` |
| railway | missing-command | `usage: crabbox run [flags] -- <command...>` |
| unikraft-cloud | command | `provider=unikraft-cloud cannot execute arbitrary run commands; Unikraft Cloud instances run their OCI image entrypoint` |
| unikraft-cloud | keep | `provider=unikraft-cloud cannot run commands; --keep is not supported` |
| unikraft-cloud | reclaim | `provider=unikraft-cloud cannot run commands; --reclaim is not supported` |
| unikraft-cloud | sync-default | `provider=unikraft-cloud does not support workspace sync; pass --no-sync` |
| unikraft-cloud | sync-only | `unikraft-cloud delegates sync; --sync-only is not supported` |
| unikraft-cloud | checksum | `unikraft-cloud delegates sync; --checksum is not supported` |
| unikraft-cloud | force-sync-large | `unikraft-cloud delegates sync; --force-sync-large is not supported` |
| unikraft-cloud | full-resync | `--full-resync cannot be combined with --no-sync` |
| unikraft-cloud | shell | `provider=unikraft-cloud cannot open an interactive shell; --shell is not supported` |
| unikraft-cloud | environment | `provider=unikraft-cloud cannot forward per-run environment variables` |
| unikraft-cloud | keep-before-reclaim | `provider=unikraft-cloud cannot run commands; --keep is not supported` |
| unikraft-cloud | keep-before-sync | `provider=unikraft-cloud cannot run commands; --keep is not supported` |
| unikraft-cloud | missing-command | `usage: crabbox run [flags] -- <command...>` |

The initial harness expected the backend missing-command wording; source inspection confirmed that the public CLI returns usage earlier. That oracle was corrected before the successful baseline/candidate comparisons. The product was not changed for it.

</details>
