### PR TITLE
fix(aws): preserve access scopes and reuse group discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- AWS: avoid duplicate access-refresh lookups for ports with matching permissions, index lease access once, and keep unnamed runner/workspace groups separate. Thanks @steipete.
+- AWS: avoid duplicate access-refresh lookups for ports with matching permissions, index lease access once, and keep unnamed runner/workspace groups separate. https://github.com/openclaw/crabbox/pull/1980. Thanks @steipete.
 
 - AWS: overlap SSH ingress authorization in bounded batches while preserving revocation, recovery and cleanup ordering. https://github.com/openclaw/crabbox/pull/1976. Thanks @steipete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- AWS: avoid duplicate access-refresh lookups for ports with matching permissions, index lease access once, and keep unnamed runner/workspace groups separate. Thanks @steipete.
+
 - AWS: overlap SSH ingress authorization in bounded batches while preserving revocation, recovery and cleanup ordering. https://github.com/openclaw/crabbox/pull/1976. Thanks @steipete.
 
 - Overlap default-VPC and managed security-group discovery during AWS provisioning while retaining scope validation and joined failure handling. [PR 1974](https://github.com/openclaw/crabbox/pull/1974). Thanks @steipete.

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -235,6 +235,13 @@ finishes. Every batch settles before recovery, another batch or the next port;
 rule-limit recovery compacts once and retries each affected rule. Diagnostic
 request-duration totals include overlapping requests and can exceed wall time.
 
+Access refresh indexes the current and retained leases once. Ports share a
+security-group lookup only when their group, allowed source ranges and
+reconciliation mode match; different policies remain separate. Runner and
+workspace default groups retain distinct identities when stored group names
+are absent. Refresh uses the recorded ingress fields directly rather than
+rebuilding machine provisioning settings.
+
 ### Environment variables (direct mode)
 
 ```text

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -619,6 +619,19 @@ type SSHIngressRule = {
 
 type DescribedSSHIngressRule = SSHIngressRule & { description: string };
 
+export type AWSIngressConfig = Pick<
+  LeaseConfig,
+  | "awsPrivate"
+  | "awsRegion"
+  | "awsSGID"
+  | "awsSGName"
+  | "awsSubnetID"
+  | "awsSSHCIDRs"
+  | "providerKey"
+  | "sshPort"
+  | "sshFallbackPorts"
+>;
+
 interface AWSIngressOptions {
   reconcile?: "authoritative" | "additive";
   allowEmpty?: boolean;
@@ -1003,7 +1016,10 @@ export class EC2SpotClient {
     throw new Error(`${incomplete}: pagination exceeded ${awsDescribeInstancesMaxPages} pages`);
   }
 
-  async refreshSSHIngress(config: LeaseConfig, options: AWSIngressOptions = {}): Promise<void> {
+  async refreshSSHIngress(
+    config: AWSIngressConfig,
+    options: AWSIngressOptions = {},
+  ): Promise<void> {
     await this.ensureSecurityGroup(config, options);
   }
 
@@ -2345,7 +2361,7 @@ export class EC2SpotClient {
   }
 
   private async ensureSecurityGroup(
-    config: LeaseConfig,
+    config: AWSIngressConfig,
     options: AWSIngressOptions = {},
   ): Promise<string> {
     const measure = <T>(
@@ -2734,7 +2750,7 @@ export class EC2SpotClient {
     return rules.length > 0;
   }
 
-  private async securityGroupVPC(config: LeaseConfig): Promise<string> {
+  private async securityGroupVPC(config: Pick<LeaseConfig, "awsSubnetID">): Promise<string> {
     const subnetID = config.awsSubnetID || this.env.CRABBOX_AWS_SUBNET_ID || "";
     if (!subnetID) {
       const root = await this.ec2("DescribeVpcs", {
@@ -3001,7 +3017,11 @@ export function awsLeaseImageIdentity(
   return { id: imageID, source: "stock", provider: "aws", kind: "aws-ami", region };
 }
 
-function awsSSHCIDRs(config: LeaseConfig, env: Env, allowEmpty = false): string[] {
+function awsSSHCIDRs(
+  config: Pick<LeaseConfig, "awsSSHCIDRs">,
+  env: Env,
+  allowEmpty = false,
+): string[] {
   const configured = [...config.awsSSHCIDRs, ...(env.CRABBOX_AWS_SSH_CIDRS ?? "").split(",")];
   const cidrs = validatedCIDRs(configured, "CRABBOX_AWS_SSH_CIDRS");
   if (cidrs.length === 0 && !allowEmpty) {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -60,6 +60,7 @@ import {
   isRetryableAWSProvisioningError,
   isAWSSecurityGroupRuleLimitError,
   type AWSMacHost,
+  type AWSIngressConfig,
   type AWSPrivateWorkspaceConfig,
 } from "./aws";
 import { InvalidAWSRegionError, sanitizeAWSRegion } from "./aws-region";
@@ -134,6 +135,7 @@ import {
   leaseConfig,
   normalizeArchitecture,
   validCIDRs,
+  validatedCIDRs,
   workspaceProviderKeyPrefix,
   type LeaseConfig,
   type LeaseConfigDefaults,
@@ -26252,7 +26254,7 @@ function awsIngressAccessTargetKey(
     ? `sg:${securityGroupID}`
     : securityGroupName
       ? `managed:${subnetID}:${securityGroupName}`
-      : `auto:${subnetID}`;
+      : `auto:${subnetID}:${awsManagedSecurityGroupName({ providerKey: lease.providerKey })}`;
   return [region, group, ...ports.toSorted()].join("\u0000");
 }
 
@@ -28555,15 +28557,19 @@ export class AWSProvider implements CloudProvider {
     if (lease.network?.awsPrivate) return;
     const globalCIDRs = awsGlobalSSHSourceCIDRs(this.env);
     const accessLeases = context.activeLeases.filter(leaseOwnsAWSSSHAccess);
-    const targets = new Map<string, { lease: LeaseRecord; port: string; region: string }>();
+    const targets = new Map<
+      string,
+      { lease: LeaseRecord; port: string; region: string; leases: LeaseRecord[] }
+    >();
     const targetScopes = new Map<string, { identities: Set<string>; hasUnknownGroup: boolean }>();
-    for (const candidate of [lease, ...accessLeases]) {
+    for (const [index, candidate] of [lease, ...accessLeases].entries()) {
       const region = candidate.region || this.region;
       for (const port of awsLeaseSSHPorts(candidate)) {
         const key = awsIngressAccessTargetKey(candidate, region, [port], this.env);
-        if (!targets.has(key)) {
-          targets.set(key, { lease: candidate, port, region });
-        }
+        const target = targets.get(key) ?? { lease: candidate, port, region, leases: [] };
+        // The anchor identifies cleanup scope; only the access snapshot grants sources.
+        if (index > 0) target.leases.push(candidate);
+        targets.set(key, target);
         const scopeKey = awsIngressPortScopeKey(region, port);
         const scope = targetScopes.get(scopeKey) ?? {
           identities: new Set<string>(),
@@ -28579,55 +28585,48 @@ export class AWSProvider implements CloudProvider {
         .filter(([, scope]) => scope.hasUnknownGroup && scope.identities.size > 1)
         .map(([scopeKey]) => scopeKey),
     );
-    for (const [targetKey, target] of targets) {
+    const refreshes = new Map<
+      string,
+      { config: AWSIngressConfig; reconcile: "additive" | "authoritative" }
+    >();
+    for (const target of targets.values()) {
       const targetLease = target.lease;
-      const targetLeases = accessLeases.filter((candidate) => {
-        const region = candidate.region || this.region;
-        return (
-          awsLeaseSSHPorts(candidate).includes(target.port) &&
-          awsIngressAccessTargetKey(candidate, region, [target.port], this.env) === targetKey
-        );
-      });
-      const cidrs = activeAWSSSHSourceCIDRs(targetLeases, globalCIDRs);
+      const cidrs = activeAWSSSHSourceCIDRs(target.leases, globalCIDRs);
       const reconcile =
         ambiguousTargetScopes.has(awsIngressPortScopeKey(target.region, target.port)) ||
-        hasUnknownActiveAWSSSHSource(targetLeases)
+        hasUnknownActiveAWSSSHSource(target.leases)
           ? "additive"
           : "authoritative";
-      const config = {
-        ...leaseConfig({
-          provider: "aws",
-          target: targetLease.target,
-          windowsMode: targetLease.windowsMode ?? "normal",
-          class: targetLease.class,
-          serverType: targetLease.serverType,
-          awsSSHCIDRs: cidrs,
-          ...(targetLease.network?.awsSecurityGroupID
-            ? { awsSGID: targetLease.network.awsSecurityGroupID }
-            : {}),
-          ...(targetLease.network?.awsSubnetID
-            ? { awsSubnetID: targetLease.network.awsSubnetID }
-            : {}),
-          capacity: { market: targetLease.market === "spot" ? "spot" : "on-demand" },
-          providerKey: targetLease.providerKey,
-          sshUser: targetLease.sshUser,
-          sshPort: target.port,
-          sshFallbackPorts: [],
-          sshPublicKey: "ssh-ed25519 ingress-reconcile",
-          workRoot: targetLease.workRoot,
-          ...(targetLease.hostId || targetLease.hostID
-            ? { hostId: targetLease.hostId || targetLease.hostID }
-            : {}),
-        }),
+      // Sharing a read is safe only when every grouped port has the same policy.
+      // Unioning distinct CIDRs or modes would widen access or prune retained rules.
+      const key = JSON.stringify([
+        awsIngressAccessTargetKey(targetLease, target.region, [], this.env),
+        reconcile,
+        cidrs.toSorted(),
+      ]);
+      const existing = refreshes.get(key);
+      if (existing) {
+        existing.config.sshFallbackPorts.push(target.port);
+        continue;
+      }
+      const config: AWSIngressConfig = {
+        awsPrivate: false,
+        awsRegion: target.region,
+        awsSSHCIDRs: validatedCIDRs(cidrs, "awsSSHCIDRs"),
+        awsSGID: targetLease.network?.awsSecurityGroupID ?? "",
         awsSGName: targetLease.network?.awsSecurityGroupName ?? "",
+        awsSubnetID: targetLease.network?.awsSubnetID ?? "",
+        providerKey: targetLease.providerKey.trim(),
+        sshPort: target.port,
+        sshFallbackPorts: [],
       };
-      const { region } = target;
+      refreshes.set(key, { config, reconcile });
+    }
+    for (const { config, reconcile } of refreshes.values()) {
+      const region = config.awsRegion;
       const client = region === this.region ? this.client : new EC2SpotClient(this.env, region);
-      // oxlint-disable-next-line eslint/no-await-in-loop -- each regional shared group is distinct.
-      await client.refreshSSHIngress(
-        { ...config, awsRegion: region },
-        { reconcile, allowEmpty: true },
-      );
+      // oxlint-disable-next-line eslint/no-await-in-loop -- distinct policies can share a group, so keep their mutation passes ordered.
+      await client.refreshSSHIngress(config, { reconcile, allowEmpty: true });
     }
   }
 

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -25243,152 +25243,316 @@ describe("fleet lease identity and idle", () => {
     expect(revokedCIDRs).not.toContain("198.51.100.20/32");
   });
 
-  it("prunes runner ingress while a distinct managed workspace group is active", async () => {
-    const revokedRules: string[] = [];
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+  it.each([true, false])(
+    "keeps runner and workspace AWS groups separate (named metadata: %s)",
+    async (namedMetadata) => {
+      const revokedRules: string[] = [];
+      const authorizedRules: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const fetchRequest = input instanceof Request ? input : new Request(input, init);
+          const params = new URLSearchParams(await fetchRequest.clone().text());
+          const action = params.get("Action") ?? "";
+          if (action === "DescribeVpcs") {
+            return new Response(
+              "<DescribeVpcsResponse><vpcSet><item><vpcId>vpc-default</vpcId></item></vpcSet></DescribeVpcsResponse>",
+            );
+          }
+          if (action === "DescribeSecurityGroups") {
+            const groupName = params.get("GroupName.1") ?? "";
+            const groupID = groupName === "crabbox-workspaces" ? "sg-workspaces" : "sg-runners";
+            const ingress =
+              groupName === "crabbox-runners"
+                ? "<ipPermissions><item><ipProtocol>tcp</ipProtocol><fromPort>22</fromPort><toPort>22</toPort><ipRanges><item><cidrIp>198.51.100.10/32</cidrIp><description>Crabbox SSH</description></item><item><cidrIp>198.51.100.20/32</cidrIp><description>Crabbox SSH</description></item></ipRanges></item></ipPermissions>"
+                : "<ipPermissions />";
+            return new Response(
+              `<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>${groupID}</groupId><groupName>${groupName}</groupName><vpcId>vpc-default</vpcId>${ingress}</item></securityGroupInfo></DescribeSecurityGroupsResponse>`,
+            );
+          }
+          if (action === "RevokeSecurityGroupIngress") {
+            revokedRules.push(
+              `${params.get("GroupId")}:${params.get("IpPermissions.1.IpRanges.1.CidrIp")}`,
+            );
+          }
+          if (action === "AuthorizeSecurityGroupIngress") {
+            authorizedRules.push(
+              `${params.get("GroupId")}:${params.get("IpPermissions.1.IpRanges.1.CidrIp")}`,
+            );
+          }
+          return new Response("<Response />");
+        }),
+      );
+      const provider = new AWSProvider(
+        { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as Env,
+        "eu-west-1",
+        new MemoryStorage(),
+      );
+      const anchor = testLease({
+        id: "cbx_abcdef123456",
+        provider: "aws",
+        state: "released",
+        region: "eu-west-1",
+        sshPort: "22",
+        network: namedMetadata ? { awsSecurityGroupName: "crabbox-runners" } : {},
+      });
+      const runner = testLease({
+        id: "cbx_abcdef123457",
+        provider: "aws",
+        region: "eu-west-1",
+        sshPort: "22",
+        network: {
+          ...(namedMetadata ? { awsSecurityGroupName: "crabbox-runners" } : {}),
+          sshSourceCIDRs: ["198.51.100.20/32"],
+          sshSourceCIDRsComplete: true,
+        },
+      });
+      const workspace = testLease({
+        id: "cbx_abcdef123458",
+        provider: "aws",
+        providerKey: "crabbox-workspace-0123456789ab",
+        region: "eu-west-1",
+        sshPort: "22",
+        network: {
+          ...(namedMetadata ? { awsSecurityGroupName: "crabbox-workspaces" } : {}),
+          sshSourceCIDRs: ["0.0.0.0/0"],
+          sshSourceCIDRsComplete: true,
+        },
+      });
+
+      await provider.reconcileLeaseAccess(anchor, {
+        requestSourceCIDRs: [],
+        activeLeases: [runner, workspace],
+      });
+
+      expect(revokedRules.includes("sg-runners:198.51.100.10/32")).toBe(namedMetadata);
+      expect(revokedRules).not.toContain("sg-runners:198.51.100.20/32");
+      expect(new Set(authorizedRules)).toEqual(
+        new Set(["sg-runners:198.51.100.20/32", "sg-workspaces:0.0.0.0/0"]),
+      );
+    },
+  );
+
+  it.each([
+    {
+      name: "different sources",
+      complete22: true,
+      source22: ["198.51.100.20/32"],
+      source2222: ["198.51.100.21/32"],
+      reads: 2,
+    },
+    {
+      name: "equal sources",
+      complete22: true,
+      source22: ["198.51.100.20/32"],
+      source2222: ["198.51.100.20/32"],
+      reads: 1,
+    },
+    {
+      name: "reordered equal sources",
+      complete22: true,
+      source22: ["198.51.100.20/32", "2001:db8::1/128"],
+      source2222: ["2001:db8::1/128", "198.51.100.20/32"],
+      reads: 1,
+    },
+    {
+      name: "different reconciliation modes",
+      complete22: false,
+      source22: [],
+      source2222: [],
+      reads: 2,
+    },
+  ])(
+    "reconciles shared AWS group ports with $name",
+    async ({ source22, source2222, reads, complete22 }) => {
+      const authorizedRules: string[] = [];
+      const staleRevokedPorts: string[] = [];
+      let groupReads = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const fetchRequest = input instanceof Request ? input : new Request(input, init);
+          const params = new URLSearchParams(await fetchRequest.clone().text());
+          const action = params.get("Action") ?? "";
+          if (action === "DescribeSecurityGroups") {
+            groupReads++;
+            return new Response(`<?xml version="1.0" encoding="UTF-8"?>
+<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-shared</groupId><ipPermissions>${["22", "2222"].map((port) => `<item><ipProtocol>tcp</ipProtocol><fromPort>${port}</fromPort><toPort>${port}</toPort><ipRanges><item><cidrIp>203.0.113.99/32</cidrIp><description>Crabbox SSH</description></item></ipRanges></item>`).join("")}</ipPermissions></item></securityGroupInfo></DescribeSecurityGroupsResponse>`);
+          }
+          if (action === "AuthorizeSecurityGroupIngress") {
+            authorizedRules.push(
+              `${params.get("IpPermissions.1.FromPort")}:${
+                params.get("IpPermissions.1.IpRanges.1.CidrIp") ??
+                params.get("IpPermissions.1.Ipv6Ranges.1.CidrIpv6")
+              }`,
+            );
+          }
+          if (
+            action === "RevokeSecurityGroupIngress" &&
+            params.get("IpPermissions.1.IpRanges.1.CidrIp") === "203.0.113.99/32"
+          ) {
+            staleRevokedPorts.push(params.get("IpPermissions.1.FromPort")!);
+          }
+          return new Response("<Response />");
+        }),
+      );
+      const provider = new AWSProvider(
+        { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as Env,
+        "eu-west-1",
+        new MemoryStorage(),
+      );
+      const anchor = testLease({
+        id: "cbx_abcdef123456",
+        provider: "aws",
+        state: "released",
+        region: "eu-west-1",
+        sshPort: "22",
+        network: { awsSecurityGroupID: "sg-shared" },
+      });
+      const active22 = testLease({
+        id: "cbx_abcdef123457",
+        provider: "aws",
+        region: "eu-west-1",
+        sshPort: "22",
+        network: {
+          awsSecurityGroupID: "sg-shared",
+          sshSourceCIDRs: source22,
+          sshSourceCIDRsComplete: complete22,
+        },
+      });
+      const active2222 = testLease({
+        id: "cbx_abcdef123458",
+        provider: "aws",
+        region: "eu-west-1",
+        sshPort: "2222",
+        network: {
+          awsSecurityGroupID: "sg-shared",
+          sshSourceCIDRs: source2222,
+          sshSourceCIDRsComplete: true,
+        },
+      });
+
+      await provider.reconcileLeaseAccess(anchor, {
+        requestSourceCIDRs: [],
+        activeLeases: [active22, active2222],
+      });
+
+      expect(new Set(authorizedRules)).toEqual(
+        new Set([
+          ...source22.map((cidr) => `22:${cidr}`),
+          ...source2222.flatMap((cidr) => [`22:${cidr}`, `2222:${cidr}`]),
+        ]),
+      );
+      expect(groupReads).toBe(reads);
+      expect(staleRevokedPorts.toSorted()).toEqual(complete22 ? ["22", "2222"] : ["2222"]);
+    },
+  );
+
+  it.each([0, 1, 31, 97])(
+    "stress reconciles mixed AWS access without cross-group grants (rotation %s)",
+    async (rotation) => {
+      const leases: LeaseRecord[] = [];
+      const expected = new Set<string>();
+      const groups = new Map<string, { region: string; rules: Map<string, Set<string>> }>();
+      for (let group = 0; group < 64; group++) {
+        const groupID = `sg-stress-${group}`;
+        const region = group % 2 ? "us-east-1" : "eu-west-1";
+        groups.set(groupID, {
+          region,
+          rules: new Map(
+            ["22", "2222", "443"].map((port) => [port, new Set(["203.0.113.254/32"])]),
+          ),
+        });
+        for (let member = 0; member < 4; member++) {
+          const address = group % 2 ? member + 1 : 1;
+          const cidrs = [
+            `198.51.100.${((group * 4 + address) % 254) + 1}/32`,
+            `2001:db8:${group}::${address}/128`,
+          ];
+          const ports = member === 1 ? ["2222", "22"] : member === 2 ? ["443", "22"] : ["22"];
+          leases.push(
+            testLease({
+              id: `cbx_${(group * 4 + member).toString(16).padStart(12, "0")}`,
+              provider: "aws",
+              region,
+              sshPort: ports[0]!,
+              sshFallbackPorts: ports.slice(1),
+              state: member >= 2 ? "released" : "active",
+              releaseDeletesServer: member !== 2,
+              network: {
+                awsSecurityGroupID: groupID,
+                sshSourceCIDRs: cidrs,
+                sshSourceCIDRsComplete: true,
+              },
+            }),
+          );
+          if (member < 3)
+            for (const port of ports)
+              for (const cidr of cidrs) expected.add(`${groupID}|${port}|${cidr}`);
+        }
+      }
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
         const fetchRequest = input instanceof Request ? input : new Request(input, init);
         const params = new URLSearchParams(await fetchRequest.clone().text());
-        const action = params.get("Action") ?? "";
-        if (action === "DescribeVpcs") {
+        const groupID = params.get("GroupId.1") ?? params.get("GroupId")!;
+        const group = groups.get(groupID);
+        if (!group || new URL(fetchRequest.url).hostname !== `ec2.${group.region}.amazonaws.com`)
+          throw new Error("fixture group/region mismatch");
+        if (params.get("Action") === "DescribeSecurityGroups") {
+          const permissions = [...group.rules]
+            .map(([port, cidrs]) => {
+              const ranges = (ipv6: boolean) =>
+                [...cidrs]
+                  .filter((cidr) => cidr.includes(":") === ipv6)
+                  .map(
+                    (cidr) =>
+                      `<item><${ipv6 ? "cidrIpv6" : "cidrIp"}>${cidr}</${ipv6 ? "cidrIpv6" : "cidrIp"}><description>Crabbox SSH</description></item>`,
+                  )
+                  .join("");
+              return `<item><ipProtocol>tcp</ipProtocol><fromPort>${port}</fromPort><toPort>${port}</toPort><ipRanges>${ranges(false)}</ipRanges><ipv6Ranges>${ranges(true)}</ipv6Ranges></item>`;
+            })
+            .join("");
           return new Response(
-            "<DescribeVpcsResponse><vpcSet><item><vpcId>vpc-default</vpcId></item></vpcSet></DescribeVpcsResponse>",
+            `<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>${groupID}</groupId><ipPermissions>${permissions}</ipPermissions></item></securityGroupInfo></DescribeSecurityGroupsResponse>`,
           );
         }
-        if (action === "DescribeSecurityGroups") {
-          const groupName = params.get("GroupName.1") ?? "";
-          const groupID = groupName === "crabbox-workspaces" ? "sg-workspaces" : "sg-runners";
-          const ingress =
-            groupName === "crabbox-runners"
-              ? "<ipPermissions><item><ipProtocol>tcp</ipProtocol><fromPort>22</fromPort><toPort>22</toPort><ipRanges><item><cidrIp>198.51.100.10/32</cidrIp><description>Crabbox SSH</description></item><item><cidrIp>198.51.100.20/32</cidrIp><description>Crabbox SSH</description></item></ipRanges></item></ipPermissions>"
-              : "<ipPermissions />";
-          return new Response(
-            `<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>${groupID}</groupId><groupName>${groupName}</groupName><vpcId>vpc-default</vpcId>${ingress}</item></securityGroupInfo></DescribeSecurityGroupsResponse>`,
-          );
-        }
-        if (action === "RevokeSecurityGroupIngress") {
-          revokedRules.push(
-            `${params.get("GroupId")}:${params.get("IpPermissions.1.IpRanges.1.CidrIp")}`,
-          );
-        }
+        const port = params.get("IpPermissions.1.FromPort")!;
+        const cidr =
+          params.get("IpPermissions.1.IpRanges.1.CidrIp") ??
+          params.get("IpPermissions.1.Ipv6Ranges.1.CidrIpv6")!;
+        const rules = group.rules.get(port);
+        if (
+          !rules ||
+          params.get("IpPermissions.1.ToPort") !== port ||
+          params.get("IpPermissions.1.IpProtocol") !== "tcp"
+        )
+          throw new Error("fixture permission mismatch");
+        if (params.get("Action") === "AuthorizeSecurityGroupIngress") rules.add(cidr);
+        else if (params.get("Action") === "RevokeSecurityGroupIngress") rules.delete(cidr);
+        else throw new Error(`Unexpected fixture action ${params.get("Action")}`);
         return new Response("<Response />");
-      }),
-    );
-    const provider = new AWSProvider(
-      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as Env,
-      "eu-west-1",
-      new MemoryStorage(),
-    );
-    const anchor = testLease({
-      id: "cbx_abcdef123456",
-      provider: "aws",
-      state: "released",
-      region: "eu-west-1",
-      sshPort: "22",
-      network: { awsSecurityGroupName: "crabbox-runners" },
-    });
-    const runner = testLease({
-      id: "cbx_abcdef123457",
-      provider: "aws",
-      region: "eu-west-1",
-      sshPort: "22",
-      network: {
-        awsSecurityGroupName: "crabbox-runners",
-        sshSourceCIDRs: ["198.51.100.20/32"],
-        sshSourceCIDRsComplete: true,
-      },
-    });
-    const workspace = testLease({
-      id: "cbx_abcdef123458",
-      provider: "aws",
-      providerKey: "crabbox-workspace-0123456789ab",
-      region: "eu-west-1",
-      sshPort: "22",
-      network: {
-        awsSecurityGroupName: "crabbox-workspaces",
-        sshSourceCIDRs: ["0.0.0.0/0"],
-        sshSourceCIDRsComplete: true,
-      },
-    });
-
-    await provider.reconcileLeaseAccess(anchor, {
-      requestSourceCIDRs: [],
-      activeLeases: [runner, workspace],
-    });
-
-    expect(revokedRules).toContain("sg-runners:198.51.100.10/32");
-    expect(revokedRules).not.toContain("sg-runners:198.51.100.20/32");
-  });
-
-  it("reconciles distinct SSH port sets that share an AWS security group", async () => {
-    const authorizedRules: string[] = [];
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-        const fetchRequest = input instanceof Request ? input : new Request(input, init);
-        const params = new URLSearchParams(await fetchRequest.clone().text());
-        const action = params.get("Action") ?? "";
-        if (action === "DescribeSecurityGroups") {
-          return new Response(`<?xml version="1.0" encoding="UTF-8"?>
-<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-shared</groupId><ipPermissions /></item></securityGroupInfo></DescribeSecurityGroupsResponse>`);
-        }
-        if (action === "AuthorizeSecurityGroupIngress") {
-          authorizedRules.push(
-            `${params.get("IpPermissions.1.FromPort")}:${
-              params.get("IpPermissions.1.IpRanges.1.CidrIp") ??
-              params.get("IpPermissions.1.Ipv6Ranges.1.CidrIpv6")
-            }`,
-          );
-        }
-        return new Response("<Response />");
-      }),
-    );
-    const provider = new AWSProvider(
-      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as Env,
-      "eu-west-1",
-      new MemoryStorage(),
-    );
-    const anchor = testLease({
-      id: "cbx_abcdef123456",
-      provider: "aws",
-      state: "released",
-      region: "eu-west-1",
-      sshPort: "22",
-      network: { awsSecurityGroupID: "sg-shared" },
-    });
-    const active22 = testLease({
-      id: "cbx_abcdef123457",
-      provider: "aws",
-      region: "eu-west-1",
-      sshPort: "22",
-      network: {
-        awsSecurityGroupID: "sg-shared",
-        sshSourceCIDRs: ["198.51.100.20/32"],
-        sshSourceCIDRsComplete: true,
-      },
-    });
-    const active2222 = testLease({
-      id: "cbx_abcdef123458",
-      provider: "aws",
-      region: "eu-west-1",
-      sshPort: "2222",
-      network: {
-        awsSecurityGroupID: "sg-shared",
-        sshSourceCIDRs: ["198.51.100.21/32"],
-        sshSourceCIDRsComplete: true,
-      },
-    });
-
-    await provider.reconcileLeaseAccess(anchor, {
-      requestSourceCIDRs: [],
-      activeLeases: [active22, active2222],
-    });
-
-    expect(new Set(authorizedRules)).toEqual(
-      new Set(["22:198.51.100.20/32", "22:198.51.100.21/32", "2222:198.51.100.21/32"]),
-    );
-  });
+      });
+      const provider = new AWSProvider(
+        { AWS_ACCESS_KEY_ID: "fixture", AWS_SECRET_ACCESS_KEY: "fixture" } as Env,
+        "eu-west-1",
+        new MemoryStorage(),
+      );
+      const ordered = [...leases.slice(rotation), ...leases.slice(0, rotation)];
+      if (rotation % 2) ordered.reverse();
+      await provider.reconcileLeaseAccess(leases[0]!, {
+        requestSourceCIDRs: [],
+        activeLeases: ordered,
+      });
+      const actual = new Set(
+        [...groups].flatMap(([groupID, group]) =>
+          [...group.rules].flatMap(([port, cidrs]) =>
+            [...cidrs].map((cidr) => `${groupID}|${port}|${cidr}`),
+          ),
+        ),
+      );
+      expect(actual).toEqual(expected);
+    },
+  );
 
   it.each(
     [


### PR DESCRIPTION
AWS access refresh repeats group discovery for each SSH port and scans the full lease snapshot again for every target. It also gives unnamed runner and workspace groups the same internal target key, even though provisioning selects different default groups.

Keep default-group identity aligned with the existing group-name owner. Index access leases by group and port once, then share discovery only across ports with the same group, source CIDRs and reconciliation mode. Different regions, groups and policies remain separate. The anchor still identifies cleanup scope; only the current access snapshot supplies allowed sources.

Narrow the AWS ingress input to the fields it uses. Access refresh no longer rebuilds machine provisioning configuration or supplies a dummy SSH public key. CIDR validation, retained-lease protection, conservative handling of ambiguous metadata and the existing ingress fence remain in place.

No schema, stored representation, configuration option or protocol change.

Validation:

- Three regressions failed on unchanged production code: two duplicate-discovery cases and incorrect reconciliation when runner/workspace group names are absent.
- Focused tests cover equal/reordered/different CIDR sets, different reconciliation modes, default group separation and the exact permitted/revoked rules.
- Full Worker suite: 2,905 passed, three skipped.
- Twenty shuffled stress runs: 740 passing test executions. Each run includes four mixed-fleet cases with 256 lease records, 64 groups, two regions, varied ports, retained/released records and IPv4/IPv6 sources. Final permissions match an independent fixture expectation; no cross-group or cross-port grants.
- Existing ingress/release, queued refresh, readiness cancellation, propagation and shared compaction coverage passed.
- Worker/Node types, lint, formatting, Worker/Node builds and docs build passed.
- Direct source review and a diff-scoped deslop pass removed redundant configuration reconstruction and preserved the ordering/ownership comments. No additional agent review was used.

Production delta: +19 lines including the narrowed ingress type; tests +164; docs/changelog +9. There is no new test-only production seam or runtime cache. Matching two-port policies require one group read instead of two; live latency remains subject to provider conditions.

Deployed live stress passed on `8d27e21d23feaa110bab5aaabc7e482d2c4bf4bb`: ordinary public AWS warmup and ready inspection, two successful commands, an intentional `exit 7`, then successful recovery on the same lease. All four signed receipts verified the exact exit codes (0, 0, 7, 0). No source sync or hydration was used. Stop reached canonical released/cleanup-complete status; configuration stayed unchanged, all owned process births exited and the SSH control directory was absent. The official Wrangler tail was stopped and joined. Official deployment history confirmed the candidate remained active throughout the run.

Live runner durations were 13.028, 21.219, 18.563 and 11.029 seconds. AWS response latency varied substantially; these are operational proof, not a controlled before/after speed claim. The deterministic improvement is fewer group-discovery requests for equal policies and removal of the repeated full-snapshot target scan.

Follow-up observation: the CLI's existing best-effort run-event publisher sometimes exhausted its drain deadline. Command output and terminal receipts remained complete and verified. Coordinator/event-publication latency needs separate investigation; this change does not extend timeouts or weaken receipt checks.

Candidate deployment: https://github.com/openclaw/crabbox/actions/runs/34189024938. CI: https://github.com/openclaw/crabbox/actions/runs/34189012760. All candidate CI jobs passed, including the Go race suite.


Merged as `d305d43412c543192ef4fffc6f7c82228876a05d`. The normal main deployment succeeded: https://github.com/openclaw/crabbox/actions/runs/34190179374. A rebuilt, clean-main CLI repeated the full four-command sequence on a fresh lease: success, success, intentional exit 7, success. All signed receipts verified. Runner durations were 6.465, 14.269, 16.567 and 13.837 seconds; provisioning was 5.212 seconds. These remain variable live samples, not a controlled latency benchmark.

Main Stop reached released/cleanup-complete; all owned process births exited, SSH control state was absent and configuration was unchanged. The official tail joined successfully, deployment history showed no mid-run version change, and the shared secret task window was closed. The intervening main runtime-clock tests also passed.
