### PR TITLE
refactor(test): share command-intent assertions

### DIFF
--- a/internal/providers/codesandbox/backend_test.go
+++ b/internal/providers/codesandbox/backend_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestWarmupCreatesSandboxClaim(t *testing.T) {
@@ -794,40 +795,25 @@ func initGitRepo(t *testing.T, dir string) {
 }
 
 func TestRunCommandIntentReachesNativeRequest(t *testing.T) {
-	for _, tc := range []struct {
-		name    string
-		command []string
-		literal map[int]bool
-		shell   bool
-		want    []string
-	}{
-		{"ordinary", []string{"printf", "%s", "hello"}, nil, false, []string{"printf", "%s", "hello"}},
-		{"literal separator", []string{"printf", "%s", ";", "touch", "sentinel"}, map[int]bool{2: true}, false, []string{"printf", "%s", ";", "touch", "sentinel"}},
-		{"literal assignment executable", []string{"FOO=x", "argument"}, map[int]bool{0: true}, false, []string{"FOO=x", "argument"}},
-		{"literal singleton", []string{"literal command $(echo x)"}, map[int]bool{0: true}, false, []string{"literal command $(echo x)"}},
-		{"invalid assignment executable", []string{"bad-name=x", "argument"}, nil, false, []string{"bad-name=x", "argument"}},
-		{"mixed operators", []string{"printf", "%s", ";", "&&", "printf", "%s", "done"}, map[int]bool{2: true}, false, []string{"bash", "-lc", "'printf' '%s' ';' && 'printf' '%s' 'done'"}},
-		{"inferred source", []string{"printf one && printf two"}, nil, false, []string{"bash", "-lc", "printf one && printf two"}},
-		{"explicit source", []string{"printf one; exit 7"}, nil, true, []string{"bash", "-lc", "printf one; exit 7"}},
-		{"leading assignment", []string{"GREETING=hello world", "printf", "%s", "$GREETING"}, nil, false, []string{"bash", "-lc", "GREETING='hello world' 'printf' '%s' '$GREETING'"}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("XDG_STATE_HOME", t.TempDir())
-			fake := newFakeCodeSandboxAPI()
-			backend, _, _ := newFakeBackend(t, fake)
-			_, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "my-app", Root: t.TempDir()}, NoSync: true, Command: tc.command, ShellMode: tc.shell, CommandLiteralArgs: tc.literal})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if len(fake.commands) != 2 {
-				t.Fatalf("commands=%#v", fake.commands)
-			}
-			got := fake.commands[1].Command
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Fatalf("native command=%#v want %#v", got, tc.want)
-			}
+	testutil.VerifyNativeCommandIntent(t, "bash", false, func(t *testing.T, intent testutil.CommandIntent) []string {
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		fake := newFakeCodeSandboxAPI()
+		backend, _, _ := newFakeBackend(t, fake)
+		_, err := backend.Run(t.Context(), RunRequest{
+			Repo:               Repo{Name: "my-app", Root: t.TempDir()},
+			NoSync:             true,
+			Command:            intent.Command,
+			ShellMode:          intent.ShellMode,
+			CommandLiteralArgs: intent.LiteralArgs,
 		})
-	}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(fake.commands) != 2 {
+			t.Fatalf("commands=%#v", fake.commands)
+		}
+		return fake.commands[1].Command
+	})
 }
 
 func TestRunRejectsEmptyCommandBeforeCreate(t *testing.T) {

--- a/internal/providers/cubesandbox/backend_test.go
+++ b/internal/providers/cubesandbox/backend_test.go
@@ -1,9 +1,7 @@
 package cubesandbox
 
 import (
-	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -15,7 +13,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -25,6 +22,7 @@ import (
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 type cubesandboxRoundTripFunc func(*http.Request) (*http.Response, error)
@@ -43,7 +41,7 @@ func TestCubeSandboxClientRedactsReflectedCredentials(t *testing.T) {
 		defer server.Close()
 		client := &cubesandboxClient{apiKey: secret, apiURL: server.URL, httpClient: server.Client()}
 		_, err := client.ListSandboxes(context.Background(), nil)
-		assertCubeSandboxRedactedError(t, err, secret)
+		testutil.RequireRedactedProviderError(t, err, secret)
 	})
 
 	t.Run("envd access token", func(t *testing.T) {
@@ -59,34 +57,27 @@ func TestCubeSandboxClientRedactsReflectedCredentials(t *testing.T) {
 		})}
 		client := &cubesandboxClient{envdClient: httpClient}
 		_, err := client.StartProcess(context.Background(), cubesandboxSession{SandboxID: "sbx_1", Domain: "example.test", EnvdAccessToken: secret}, cubesandboxProcessRequest{Command: "true"})
-		assertCubeSandboxRedactedError(t, err, secret)
+		testutil.RequireRedactedProviderError(t, err, secret)
 	})
-}
-
-func assertCubeSandboxRedactedError(t *testing.T, err error, secret string) {
-	t.Helper()
-	if err == nil || strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[redacted]") || !strings.Contains(err.Error(), "quota exceeded") {
-		t.Fatalf("error=%v, want redacted useful provider error", err)
-	}
 }
 
 func TestCubeSandboxProcessStreamRedactsReflectedCredential(t *testing.T) {
 	const secret = "envd-stream-secret"
 
 	t.Run("process end diagnostic", func(t *testing.T) {
-		body := cubesandboxTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 1, "exited": false, "error": "Bearer " + secret + " quota exceeded"}}})
+		body := testutil.GRPCWebEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 1, "exited": false, "error": "Bearer " + secret + " quota exceeded"}}})
 		var stderr bytes.Buffer
 		code, err := parseCubeSandboxProcessStream(bytes.NewReader(body), io.Discard, &stderr, secret)
 		if code != 1 {
 			t.Fatalf("code=%d, want 1", code)
 		}
-		assertCubeSandboxRedactedError(t, err, secret)
+		testutil.RequireRedactedProviderError(t, err, secret)
 		if strings.Contains(stderr.String(), secret) || !strings.Contains(stderr.String(), "[redacted]") || !strings.Contains(stderr.String(), "quota exceeded") {
 			t.Fatalf("stderr=%q, want redacted useful process diagnostic", stderr.String())
 		}
 	})
 	t.Run("process end without diagnostic", func(t *testing.T) {
-		body := cubesandboxTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 0, "exited": false}}})
+		body := testutil.GRPCWebEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 0, "exited": false}}})
 		code, err := parseCubeSandboxProcessStream(bytes.NewReader(body), io.Discard, io.Discard)
 		if code != 1 || err == nil || !strings.Contains(err.Error(), "did not exit normally") {
 			t.Fatalf("code=%d err=%v, want abnormal termination failure", code, err)
@@ -194,13 +185,13 @@ func TestCubeSandboxDataPlaneStreamOutlivesControlTimeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.Copy(io.Discard, r.Body)
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(cubesandboxTestEnvelope(0, map[string]any{"event": map[string]any{"start": map[string]any{"pid": 42}}}))
+		_, _ = w.Write(testutil.GRPCWebEnvelope(0, map[string]any{"event": map[string]any{"start": map[string]any{"pid": 42}}}))
 		if flusher, ok := w.(http.Flusher); ok {
 			flusher.Flush()
 		}
 		time.Sleep(3 * controlTimeout)
-		_, _ = w.Write(cubesandboxTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 0, "exited": true}}}))
-		_, _ = w.Write(cubesandboxTestEnvelope(2, map[string]any{}))
+		_, _ = w.Write(testutil.GRPCWebEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 0, "exited": true}}}))
+		_, _ = w.Write(testutil.GRPCWebEnvelope(2, map[string]any{}))
 	}))
 	defer server.Close()
 	serverURL, err := url.Parse(server.URL)
@@ -707,7 +698,7 @@ func TestCubeSandboxSyncWorkspaceUploadsRepoArchive(t *testing.T) {
 	if client.uploadPath == "" || !strings.HasPrefix(client.uploadPath, "/tmp/crabbox-") {
 		t.Fatalf("upload path=%q", client.uploadPath)
 	}
-	if !tarGzipContains(t, client.uploaded.Bytes(), "go.mod") {
+	if !testutil.TarGzipContains(t, client.uploaded.Bytes(), "go.mod") {
 		t.Fatal("uploaded archive missing go.mod")
 	}
 	if !client.commandContains("mkdir -p '/home/ubuntu/.repo.crabbox-sync-") || !client.commandContains("tar -xzf") {
@@ -1131,7 +1122,7 @@ func TestCubeSandboxRunPreservesAbnormalProcessExitCode(t *testing.T) {
 	for _, reported := range []int{137, -1, 0} {
 		t.Run(fmt.Sprint(reported), func(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
-			body := cubesandboxTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": reported, "exited": false, "error": "fixture process interrupted"}}})
+			body := testutil.GRPCWebEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": reported, "exited": false, "error": "fixture process interrupted"}}})
 			code, processErr := parseCubeSandboxProcessStream(bytes.NewReader(body), io.Discard, io.Discard)
 			client := &fakeCubeSandboxSyncClient{processCodes: []int{0, code}, processErrs: []error{nil, processErr}}
 			restore := swapNewCubeSandboxClient(client)
@@ -1644,139 +1635,31 @@ func (f *fakeCubeSandboxSyncClient) userContains(value string) bool {
 	return false
 }
 
-func cubesandboxTestEnvelope(flags byte, v any) []byte {
-	data, err := json.Marshal(v)
-	if err != nil {
-		panic(err)
-	}
-	var out bytes.Buffer
-	out.WriteByte(flags)
-	out.Write([]byte{byte(len(data) >> 24), byte(len(data) >> 16), byte(len(data) >> 8), byte(len(data))})
-	out.Write(data)
-	return out.Bytes()
-}
-
-func tarGzipContains(t *testing.T, data []byte, name string) bool {
-	t.Helper()
-	gz, err := gzip.NewReader(bytes.NewReader(data))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer gz.Close()
-	tr := tar.NewReader(gz)
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			return false
-		}
-		if err != nil {
-			t.Fatal(err)
-		}
-		if header.Name == name {
-			return true
-		}
-	}
-}
-
 func TestRunCommandIntentReachesExistingShell(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("POSIX shell contract")
-	}
-	bash, err := exec.LookPath("bash")
-	if err != nil {
-		t.Skip("bash unavailable")
-	}
-	for _, name := range []string{"literal separator", "literal assignment", "literal singleton", "mixed operators", "quoted argv", "unmarked assignment", "explicit source", "empty source", "inferred source", "missing command"} {
-		t.Run(name, func(t *testing.T) {
-			t.Setenv("XDG_STATE_HOME", t.TempDir())
-			root := t.TempDir()
-			marker := filepath.Join(root, "must-not-exist")
-			program := filepath.Join(root, "FOO=x")
-			if err := os.WriteFile(program, []byte("#!/bin/sh\nprintf 'literal:%s' \"$*\"\nexit 42\n"), 0o700); err != nil {
-				t.Fatal(err)
-			}
-			client := &fakeCubeSandboxSyncClient{}
-			restore := swapNewCubeSandboxClient(client)
-			defer restore()
-			backend := &cubesandboxBackend{cfg: Config{CubeSandbox: CubeSandboxConfig{Template: "base", Workdir: root}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-			req := RunRequest{Repo: Repo{Root: root}, NoSync: true, Keep: true}
-			want, wantExit := "", 0
-			switch name {
-			case "literal separator":
-				req.Command = []string{"printf", "<%s>", ";", "touch", marker}
-				req.CommandLiteralArgs = map[int]bool{2: true}
-				want = "<;><touch><" + marker + ">"
-			case "literal assignment":
-				req.Command = []string{"FOO=x", "argument"}
-				req.CommandLiteralArgs = map[int]bool{0: true}
-				want, wantExit = "literal:argument", 42
-			case "literal singleton":
-				req.Command = []string{"FOO=x"}
-				req.CommandLiteralArgs = map[int]bool{0: true}
-				want, wantExit = "literal:", 42
-			case "mixed operators":
-				req.Command = []string{"printf", "%s", ";", "&&", "printf", "%s", "tail"}
-				req.CommandLiteralArgs = map[int]bool{2: true}
-				want = ";tail"
-			case "quoted argv":
-				req.Command = []string{"printf", "<%s>", "", "$literal", "a'b"}
-				want = "<><$literal><a'b>"
-			case "unmarked assignment":
-				req.Command = []string{"CBX_PROBE=value", "sh", "-c", `printf %s "$CBX_PROBE"`}
-				want = "value"
-			case "explicit source":
-				req.Command = []string{`printf %s "$unexported_fixture_state"; exit 7`}
-				req.ShellMode = true
-				want, wantExit = "existing-shell", 7
-			case "empty source":
-				req.Command = []string{""}
-				req.ShellMode = true
-			case "inferred source":
-				req.Command = []string{"printf %s inferred"}
-				want = "inferred"
-			}
-			_, runErr := backend.Run(t.Context(), req)
-			if name == "missing command" {
-				var ee core.ExitError
-				if !errors.As(runErr, &ee) || ee.Code != 2 {
-					t.Fatalf("missing command error=%v", runErr)
-				}
-				if len(client.commands) != 1 {
-					t.Fatalf("missing command reached workload: %v", client.commands)
-				}
-				return
-			}
-			if runErr != nil {
-				t.Fatal(runErr)
-			}
-			if len(client.commands) != 2 {
-				t.Fatalf("commands=%v want preparation and workload", client.commands)
-			}
-			// Exercise the captured workload in an existing shell; the separate
-			// native envd fixture verifies its actual login-shell transport.
-			source := "unexported_fixture_state=existing-shell\n" + client.commands[1]
-			cmd := exec.CommandContext(t.Context(), bash, "--noprofile", "--norc", "-c", source)
-			cmd.Dir = root
-			cmd.Env = []string{"HOME=" + root, "PATH=" + root + ":/usr/bin:/bin"}
-			var stdout, stderr bytes.Buffer
-			cmd.Stdout, cmd.Stderr = &stdout, &stderr
-			commandErr := cmd.Run()
-			code := 0
-			if commandErr != nil {
-				var ee *exec.ExitError
-				if !errors.As(commandErr, &ee) {
-					t.Fatal(commandErr)
-				}
-				code = ee.ExitCode()
-			}
-			if code != wantExit || stdout.String() != want {
-				t.Fatalf("source=%q stdout=%q stderr=%q exit=%d; want %q/%d", source, stdout.String(), stderr.String(), code, want, wantExit)
-			}
-			if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
-				t.Fatalf("literal separator ran touch: %v", err)
-			}
+	testutil.VerifyExistingShellCommandIntent(t, func(t *testing.T, root string, intent testutil.CommandIntent) testutil.ExistingShellResult {
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		client := &fakeCubeSandboxSyncClient{}
+		restore := swapNewCubeSandboxClient(client)
+		t.Cleanup(restore)
+		backend := &cubesandboxBackend{cfg: Config{CubeSandbox: CubeSandboxConfig{Template: "base", Workdir: root}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+		_, runErr := backend.Run(t.Context(), RunRequest{
+			Repo:               Repo{Root: root},
+			NoSync:             true,
+			Keep:               true,
+			Command:            intent.Command,
+			CommandLiteralArgs: intent.LiteralArgs,
+			ShellMode:          intent.ShellMode,
 		})
-	}
+		result := testutil.ExistingShellResult{
+			Commands: append([]string(nil), client.commands...),
+			Err:      runErr,
+		}
+		var exitErr core.ExitError
+		if errors.As(runErr, &exitErr) {
+			result.ErrorCode = exitErr.Code
+		}
+		return result
+	})
 }
 
 func TestCubeSandboxRejectsMissingCanonicalIDMatchingAnotherSlug(t *testing.T) {
@@ -1845,10 +1728,10 @@ func TestCubeSandboxProcessEndPolicy(t *testing.T) {
 		})
 		for _, ending := range []string{"clean", "RPC failure", "read failure", "truncated"} {
 			t.Run(fmt.Sprintf("abnormal/%d/%s", code, ending), func(t *testing.T) {
-				body := cubesandboxTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": code, "exited": false, "error": "fixture end"}}})
+				body := testutil.GRPCWebEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": code, "exited": false, "error": "fixture end"}}})
 				var tailBytes []byte
 				if ending == "RPC failure" {
-					tailBytes = cubesandboxTestEnvelope(2, map[string]any{"error": map[string]any{"code": "internal", "message": "fixture RPC failure"}})
+					tailBytes = testutil.GRPCWebEnvelope(2, map[string]any{"error": map[string]any{"code": "internal", "message": "fixture RPC failure"}})
 				}
 				if ending == "truncated" {
 					tailBytes = []byte{0}

--- a/internal/providers/dockersandbox/backend_test.go
+++ b/internal/providers/dockersandbox/backend_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestProviderSpecIsDelegatedLinuxAndAliasFree(t *testing.T) {
@@ -1864,40 +1865,23 @@ func TestRunTimingFailureDoesNotReportSuccess(t *testing.T) {
 }
 
 func TestRunCommandIntentReachesNativeRequest(t *testing.T) {
-	for _, tc := range []struct {
-		name    string
-		command []string
-		literal map[int]bool
-		shell   bool
-		want    []string
-	}{
-		{"empty explicit source", []string{""}, nil, true, []string{"sh", "-lc", ""}},
-		{"ordinary", []string{"printf", "%s", "hello"}, nil, false, []string{"printf", "%s", "hello"}},
-		{"literal separator", []string{"printf", "%s", ";", "touch", "sentinel"}, map[int]bool{2: true}, false, []string{"printf", "%s", ";", "touch", "sentinel"}},
-		{"literal assignment executable", []string{"FOO=x", "argument"}, map[int]bool{0: true}, false, []string{"FOO=x", "argument"}},
-		{"literal singleton", []string{"literal command $(echo x)"}, map[int]bool{0: true}, false, []string{"literal command $(echo x)"}},
-		{"invalid assignment executable", []string{"bad-name=x", "argument"}, nil, false, []string{"bad-name=x", "argument"}},
-		{"mixed operators", []string{"printf", "%s", ";", "&&", "printf", "%s", "done"}, map[int]bool{2: true}, false, []string{"sh", "-lc", "'printf' '%s' ';' && 'printf' '%s' 'done'"}},
-		{"inferred source", []string{"printf one && printf two"}, nil, false, []string{"sh", "-lc", "printf one && printf two"}},
-		{"explicit source", []string{"printf one; exit 7"}, nil, true, []string{"sh", "-lc", "printf one; exit 7"}},
-		{"leading assignment", []string{"GREETING=hello world", "printf", "%s", "$GREETING"}, nil, false, []string{"sh", "-lc", "GREETING='hello world' 'printf' '%s' '$GREETING'"}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("XDG_STATE_HOME", t.TempDir())
-			runner := newRunner(nil, nil)
-			backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-			_, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "my-app", Root: t.TempDir()}, Command: tc.command, ShellMode: tc.shell, CommandLiteralArgs: tc.literal})
-			if err != nil {
-				t.Fatal(err)
-			}
-			call := findCall(runner, "exec")
-			if call == nil || len(call.Args) < 5 || call.Args[1] != "--workdir" {
-				t.Fatalf("exec=%#v", call)
-			}
-			got := call.Args[4:]
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Fatalf("native command=%#v want %#v", got, tc.want)
-			}
+	testutil.VerifyNativeCommandIntent(t, "sh", true, func(t *testing.T, intent testutil.CommandIntent) []string {
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		runner := newRunner(nil, nil)
+		backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
+		_, err := backend.Run(t.Context(), RunRequest{
+			Repo:               Repo{Name: "my-app", Root: t.TempDir()},
+			Command:            intent.Command,
+			ShellMode:          intent.ShellMode,
+			CommandLiteralArgs: intent.LiteralArgs,
 		})
-	}
+		if err != nil {
+			t.Fatal(err)
+		}
+		call := findCall(runner, "exec")
+		if call == nil || len(call.Args) < 5 || call.Args[1] != "--workdir" {
+			t.Fatalf("exec=%#v", call)
+		}
+		return call.Args[4:]
+	})
 }

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -1,9 +1,7 @@
 package e2b
 
 import (
-	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -23,6 +21,7 @@ import (
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 type e2bRoundTripFunc func(*http.Request) (*http.Response, error)
@@ -93,7 +92,7 @@ func TestE2BClientRedactsReflectedCredentials(t *testing.T) {
 		defer server.Close()
 		client := &e2bClient{apiKey: secret, apiURL: server.URL, httpClient: server.Client()}
 		_, err := client.ListSandboxes(context.Background(), nil)
-		assertE2BRedactedError(t, err, secret)
+		testutil.RequireRedactedProviderError(t, err, secret)
 	})
 
 	t.Run("envd access token", func(t *testing.T) {
@@ -109,22 +108,15 @@ func TestE2BClientRedactsReflectedCredentials(t *testing.T) {
 		})}
 		client := &e2bClient{envdClient: httpClient}
 		_, err := client.StartProcess(context.Background(), e2bSession{SandboxID: "sbx_1", Domain: "example.test", EnvdAccessToken: secret}, e2bProcessRequest{Command: "true"})
-		assertE2BRedactedError(t, err, secret)
+		testutil.RequireRedactedProviderError(t, err, secret)
 	})
-}
-
-func assertE2BRedactedError(t *testing.T, err error, secret string) {
-	t.Helper()
-	if err == nil || strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[redacted]") || !strings.Contains(err.Error(), "quota exceeded") {
-		t.Fatalf("error=%v, want redacted useful provider error", err)
-	}
 }
 
 func TestE2BProcessStreamRedactsReflectedCredential(t *testing.T) {
 	const secret = "envd-stream-secret"
 
 	t.Run("process end diagnostic", func(t *testing.T) {
-		body := e2bTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 1, "exited": false, "error": "Bearer " + secret + " quota exceeded"}}})
+		body := testutil.GRPCWebEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 1, "exited": false, "error": "Bearer " + secret + " quota exceeded"}}})
 		var stderr bytes.Buffer
 		if _, err := parseE2BProcessStream(bytes.NewReader(body), io.Discard, &stderr, secret); err != nil {
 			t.Fatal(err)
@@ -227,11 +219,11 @@ func TestE2BDataPlaneStreamOutlivesControlTimeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		_, _ = io.Copy(io.Discard, req.Body)
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(e2bTestEnvelope(0, map[string]any{"event": map[string]any{"start": map[string]any{"pid": 42}}}))
+		_, _ = w.Write(testutil.GRPCWebEnvelope(0, map[string]any{"event": map[string]any{"start": map[string]any{"pid": 42}}}))
 		w.(http.Flusher).Flush()
 		time.Sleep(3 * controlTimeout)
-		_, _ = w.Write(e2bTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 0, "exited": true}}}))
-		_, _ = w.Write(e2bTestEnvelope(2, map[string]any{}))
+		_, _ = w.Write(testutil.GRPCWebEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": 0, "exited": true}}}))
+		_, _ = w.Write(testutil.GRPCWebEnvelope(2, map[string]any{}))
 	}))
 	defer server.Close()
 
@@ -756,7 +748,7 @@ func TestE2BSyncWorkspaceUploadsRepoArchive(t *testing.T) {
 	if client.uploadPath == "" || !strings.HasPrefix(client.uploadPath, "/tmp/crabbox-") {
 		t.Fatalf("upload path=%q", client.uploadPath)
 	}
-	if !tarGzipContains(t, client.uploaded.Bytes(), "go.mod") {
+	if !testutil.TarGzipContains(t, client.uploaded.Bytes(), "go.mod") {
 		t.Fatal("uploaded archive missing go.mod")
 	}
 	if !client.commandContains("mkdir -p '/home/ubuntu/repo'") || !client.commandContains("tar -xzf") {
@@ -1570,40 +1562,6 @@ func (f *fakeE2BSyncClient) userContains(value string) bool {
 	return false
 }
 
-func e2bTestEnvelope(flags byte, v any) []byte {
-	data, err := json.Marshal(v)
-	if err != nil {
-		panic(err)
-	}
-	var out bytes.Buffer
-	out.WriteByte(flags)
-	out.Write([]byte{byte(len(data) >> 24), byte(len(data) >> 16), byte(len(data) >> 8), byte(len(data))})
-	out.Write(data)
-	return out.Bytes()
-}
-
-func tarGzipContains(t *testing.T, data []byte, name string) bool {
-	t.Helper()
-	gz, err := gzip.NewReader(bytes.NewReader(data))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer gz.Close()
-	tr := tar.NewReader(gz)
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			return false
-		}
-		if err != nil {
-			t.Fatal(err)
-		}
-		if header.Name == name {
-			return true
-		}
-	}
-}
-
 func TestE2BRunLifecycleArchiveGuardrailBeforeCreation(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	client := &fakeE2BSyncClient{}
@@ -1655,104 +1613,30 @@ func TestE2BRunLifecycleCleanupOutcomeAndTiming(t *testing.T) {
 }
 
 func TestRunCommandIntentReachesExistingShell(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("POSIX shell contract")
-	}
-	bash, err := exec.LookPath("bash")
-	if err != nil {
-		t.Skip("bash unavailable")
-	}
-	for _, name := range []string{"literal separator", "literal assignment", "literal singleton", "mixed operators", "quoted argv", "unmarked assignment", "explicit source", "empty source", "inferred source", "missing command"} {
-		t.Run(name, func(t *testing.T) {
-			t.Setenv("XDG_STATE_HOME", t.TempDir())
-			root := t.TempDir()
-			marker := filepath.Join(root, "must-not-exist")
-			program := filepath.Join(root, "FOO=x")
-			if err := os.WriteFile(program, []byte("#!/bin/sh\nprintf 'literal:%s' \"$*\"\nexit 42\n"), 0o700); err != nil {
-				t.Fatal(err)
-			}
-			client := &fakeE2BSyncClient{}
-			restore := swapNewE2BClient(client)
-			defer restore()
-			backend := &e2bBackend{cfg: Config{E2B: E2BConfig{Template: "base", Workdir: root}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-			req := RunRequest{Repo: Repo{Root: root}, NoSync: true, Keep: true}
-			want, wantExit := "", 0
-			switch name {
-			case "literal separator":
-				req.Command = []string{"printf", "<%s>", ";", "touch", marker}
-				req.CommandLiteralArgs = map[int]bool{2: true}
-				want = "<;><touch><" + marker + ">"
-			case "literal assignment":
-				req.Command = []string{"FOO=x", "argument"}
-				req.CommandLiteralArgs = map[int]bool{0: true}
-				want, wantExit = "literal:argument", 42
-			case "literal singleton":
-				req.Command = []string{"FOO=x"}
-				req.CommandLiteralArgs = map[int]bool{0: true}
-				want, wantExit = "literal:", 42
-			case "mixed operators":
-				req.Command = []string{"printf", "%s", ";", "&&", "printf", "%s", "tail"}
-				req.CommandLiteralArgs = map[int]bool{2: true}
-				want = ";tail"
-			case "quoted argv":
-				req.Command = []string{"printf", "<%s>", "", "$literal", "a'b"}
-				want = "<><$literal><a'b>"
-			case "unmarked assignment":
-				req.Command = []string{"CBX_PROBE=value", "sh", "-c", `printf %s "$CBX_PROBE"`}
-				want = "value"
-			case "explicit source":
-				req.Command = []string{`printf %s "$unexported_fixture_state"; exit 7`}
-				req.ShellMode = true
-				want, wantExit = "existing-shell", 7
-			case "empty source":
-				req.Command = []string{""}
-				req.ShellMode = true
-			case "inferred source":
-				req.Command = []string{"printf %s inferred"}
-				want = "inferred"
-			}
-			_, runErr := backend.Run(t.Context(), req)
-			if name == "missing command" {
-				var ee core.ExitError
-				if !errors.As(runErr, &ee) || ee.Code != 2 {
-					t.Fatalf("missing command error=%v", runErr)
-				}
-				if len(client.commands) != 1 {
-					t.Fatalf("missing command reached workload: %v", client.commands)
-				}
-				return
-			}
-			if runErr != nil {
-				t.Fatal(runErr)
-			}
-			if len(client.commands) != 2 {
-				t.Fatalf("commands=%v want preparation and workload", client.commands)
-			}
-			// Exercise the captured workload in an existing shell; the separate
-			// native envd fixture verifies its actual login-shell transport.
-			source := "unexported_fixture_state=existing-shell\n" + client.commands[1]
-			cmd := exec.CommandContext(t.Context(), bash, "--noprofile", "--norc", "-c", source)
-			cmd.Dir = root
-			cmd.Env = []string{"HOME=" + root, "PATH=" + root + ":/usr/bin:/bin"}
-			var stdout, stderr bytes.Buffer
-			cmd.Stdout, cmd.Stderr = &stdout, &stderr
-			commandErr := cmd.Run()
-			code := 0
-			if commandErr != nil {
-				var ee *exec.ExitError
-				if !errors.As(commandErr, &ee) {
-					t.Fatal(commandErr)
-				}
-				code = ee.ExitCode()
-			}
-			if code != wantExit || stdout.String() != want {
-				t.Fatalf("source=%q stdout=%q stderr=%q exit=%d; want %q/%d", source, stdout.String(), stderr.String(), code, want, wantExit)
-			}
-			if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
-				t.Fatalf("literal separator ran touch: %v", err)
-			}
+	testutil.VerifyExistingShellCommandIntent(t, func(t *testing.T, root string, intent testutil.CommandIntent) testutil.ExistingShellResult {
+		t.Setenv("XDG_STATE_HOME", t.TempDir())
+		client := &fakeE2BSyncClient{}
+		restore := swapNewE2BClient(client)
+		t.Cleanup(restore)
+		backend := &e2bBackend{cfg: Config{E2B: E2BConfig{Template: "base", Workdir: root}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+		_, runErr := backend.Run(t.Context(), RunRequest{
+			Repo:               Repo{Root: root},
+			NoSync:             true,
+			Keep:               true,
+			Command:            intent.Command,
+			CommandLiteralArgs: intent.LiteralArgs,
+			ShellMode:          intent.ShellMode,
 		})
-	}
+		result := testutil.ExistingShellResult{
+			Commands: append([]string(nil), client.commands...),
+			Err:      runErr,
+		}
+		var exitErr core.ExitError
+		if errors.As(runErr, &exitErr) {
+			result.ErrorCode = exitErr.Code
+		}
+		return result
+	})
 }
 
 func TestE2BRunCanonicalIDPreservesInventoryRecovery(t *testing.T) {
@@ -1863,9 +1747,9 @@ func TestE2BProcessEndPolicy(t *testing.T) {
 		})
 		for _, ending := range []string{"clean", "RPC failure", "read failure", "truncated"} {
 			t.Run(fmt.Sprintf("abnormal/%d/%s", code, ending), func(t *testing.T) {
-				body := e2bTestEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": code, "exited": false, "error": "fixture end"}}})
+				body := testutil.GRPCWebEnvelope(0, map[string]any{"event": map[string]any{"end": map[string]any{"exitCode": code, "exited": false, "error": "fixture end"}}})
 				if ending == "RPC failure" {
-					body = append(body, e2bTestEnvelope(2, map[string]any{"error": map[string]any{"code": "internal", "message": "fixture RPC failure"}})...)
+					body = append(body, testutil.GRPCWebEnvelope(2, map[string]any{"error": map[string]any{"code": "internal", "message": "fixture RPC failure"}})...)
 				}
 				if ending == "truncated" {
 					body = append(body, 0)

--- a/internal/providers/freestyle/backend_test.go
+++ b/internal/providers/freestyle/backend_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestFreestyleProviderSpec(t *testing.T) {
@@ -1194,10 +1195,10 @@ func TestFreestyleSyncWorkspaceHonorsIncludes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !tarGzipContains(t, archive, "keep/file.txt") {
+	if !testutil.TarGzipContains(t, archive, "keep/file.txt") {
 		t.Fatal("archive missing included file")
 	}
-	if tarGzipContains(t, archive, "skip/file.txt") {
+	if testutil.TarGzipContains(t, archive, "skip/file.txt") {
 		t.Fatal("archive contains file outside sync.include")
 	}
 }
@@ -1550,28 +1551,6 @@ func (f *fakeFreestyleClient) commandContains(value string) bool {
 		}
 	}
 	return false
-}
-
-func tarGzipContains(t *testing.T, data []byte, name string) bool {
-	t.Helper()
-	gz, err := gzip.NewReader(bytes.NewReader(data))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer gz.Close()
-	tr := tar.NewReader(gz)
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			return false
-		}
-		if err != nil {
-			t.Fatal(err)
-		}
-		if header.Name == name {
-			return true
-		}
-	}
 }
 
 func freestyleArchiveRepo(t *testing.T) Repo {

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -1,9 +1,7 @@
 package islo
 
 import (
-	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -26,6 +24,7 @@ import (
 	gosdk "github.com/islo-labs/go-sdk"
 	sdkcore "github.com/islo-labs/go-sdk/core"
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func isolateIsloTestHome(t *testing.T) {
@@ -1871,7 +1870,7 @@ func TestIsloSyncWorkspaceUploadsRepoArchive(t *testing.T) {
 	if repair.GetUser() == nil || *repair.GetUser() != isloAdminUser || !strings.Contains(client.prepareCommands[1], "chown -R 'islo:islo' '/workspace/repo'") {
 		t.Fatalf("ownership repair request=%#v command=%q", repair, client.prepareCommands[1])
 	}
-	if !tarGzipContains(t, client.uploaded.Bytes(), "go.mod") {
+	if !testutil.TarGzipContains(t, client.uploaded.Bytes(), "go.mod") {
 		t.Fatal("uploaded archive missing go.mod")
 	}
 }
@@ -2517,28 +2516,6 @@ func withIsloCleanupTimeout(t *testing.T, timeout time.Duration) {
 	original := isloCleanupTimeout
 	isloCleanupTimeout = timeout
 	t.Cleanup(func() { isloCleanupTimeout = original })
-}
-
-func tarGzipContains(t *testing.T, data []byte, name string) bool {
-	t.Helper()
-	gz, err := gzip.NewReader(bytes.NewReader(data))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer gz.Close()
-	tr := tar.NewReader(gz)
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			return false
-		}
-		if err != nil {
-			t.Fatal(err)
-		}
-		if header.Name == name {
-			return true
-		}
-	}
 }
 
 // This writer fails only timing serialization, not earlier human diagnostics.

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -21,6 +21,7 @@ import (
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -1668,41 +1669,25 @@ func newGitRepo(t *testing.T) string {
 }
 
 func TestRunCommandIntentReachesNativeRequest(t *testing.T) {
-	for _, tc := range []struct {
-		name    string
-		command []string
-		literal map[int]bool
-		shell   bool
-		want    []string
-	}{
-		{"empty explicit source", []string{""}, nil, true, []string{"bash", "-lc", ""}},
-		{"ordinary", []string{"printf", "%s", "hello"}, nil, false, []string{"printf", "%s", "hello"}},
-		{"literal separator", []string{"printf", "%s", ";", "touch", "sentinel"}, map[int]bool{2: true}, false, []string{"printf", "%s", ";", "touch", "sentinel"}},
-		{"literal assignment executable", []string{"FOO=x", "argument"}, map[int]bool{0: true}, false, []string{"FOO=x", "argument"}},
-		{"literal singleton", []string{"literal command $(echo x)"}, map[int]bool{0: true}, false, []string{"literal command $(echo x)"}},
-		{"invalid assignment executable", []string{"bad-name=x", "argument"}, nil, false, []string{"bad-name=x", "argument"}},
-		{"mixed operators", []string{"printf", "%s", ";", "&&", "printf", "%s", "done"}, map[int]bool{2: true}, false, []string{"bash", "-lc", "'printf' '%s' ';' && 'printf' '%s' 'done'"}},
-		{"inferred source", []string{"printf one && printf two"}, nil, false, []string{"bash", "-lc", "printf one && printf two"}},
-		{"explicit source", []string{"printf one; exit 7"}, nil, true, []string{"bash", "-lc", "printf one; exit 7"}},
-		{"leading assignment", []string{"GREETING=hello world", "printf", "%s", "$GREETING"}, nil, false, []string{"bash", "-lc", "GREETING='hello world' 'printf' '%s' '$GREETING'"}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			fake := newFakeAPI(t)
-			backend := newAPIBackend(t, fake)
-			_, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "my-app", Root: t.TempDir()}, NoSync: true, Command: tc.command, ShellMode: tc.shell, CommandLiteralArgs: tc.literal})
-			if err != nil {
-				t.Fatal(err)
-			}
-			calls := fake.allExecs()
-			if len(calls) != 2 {
-				t.Fatalf("execs=%#v", calls)
-			}
-			got := append([]string{calls[1].req.Cmd}, calls[1].req.Args...)
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Fatalf("native command=%#v want %#v", got, tc.want)
-			}
+	testutil.VerifyNativeCommandIntent(t, "bash", true, func(t *testing.T, intent testutil.CommandIntent) []string {
+		fake := newFakeAPI(t)
+		backend := newAPIBackend(t, fake)
+		_, err := backend.Run(t.Context(), RunRequest{
+			Repo:               Repo{Name: "my-app", Root: t.TempDir()},
+			NoSync:             true,
+			Command:            intent.Command,
+			ShellMode:          intent.ShellMode,
+			CommandLiteralArgs: intent.LiteralArgs,
 		})
-	}
+		if err != nil {
+			t.Fatal(err)
+		}
+		calls := fake.allExecs()
+		if len(calls) != 2 {
+			t.Fatalf("execs=%#v", calls)
+		}
+		return append([]string{calls[1].req.Cmd}, calls[1].req.Args...)
+	})
 }
 
 func TestRunMissingCommandRetainsCleanup(t *testing.T) {

--- a/internal/testutil/command_intent.go
+++ b/internal/testutil/command_intent.go
@@ -1,0 +1,154 @@
+package testutil
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+type CommandIntent struct {
+	Command     []string
+	LiteralArgs map[int]bool
+	ShellMode   bool
+}
+
+type ExistingShellResult struct {
+	Commands  []string
+	ErrorCode int
+	Err       error
+}
+
+type ExistingShellRunner func(*testing.T, string, CommandIntent) ExistingShellResult
+
+func VerifyExistingShellCommandIntent(t *testing.T, run ExistingShellRunner) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell contract")
+	}
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash unavailable")
+	}
+	for _, name := range []string{"literal separator", "literal assignment", "literal singleton", "mixed operators", "quoted argv", "unmarked assignment", "explicit source", "empty source", "inferred source", "missing command"} {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			marker := filepath.Join(root, "must-not-exist")
+			program := filepath.Join(root, "FOO=x")
+			if err := os.WriteFile(program, []byte("#!/bin/sh\nprintf 'literal:%s' \"$*\"\nexit 42\n"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			intent := CommandIntent{}
+			want, wantExit := "", 0
+			switch name {
+			case "literal separator":
+				intent.Command = []string{"printf", "<%s>", ";", "touch", marker}
+				intent.LiteralArgs = map[int]bool{2: true}
+				want = "<;><touch><" + marker + ">"
+			case "literal assignment":
+				intent.Command = []string{"FOO=x", "argument"}
+				intent.LiteralArgs = map[int]bool{0: true}
+				want, wantExit = "literal:argument", 42
+			case "literal singleton":
+				intent.Command = []string{"FOO=x"}
+				intent.LiteralArgs = map[int]bool{0: true}
+				want, wantExit = "literal:", 42
+			case "mixed operators":
+				intent.Command = []string{"printf", "%s", ";", "&&", "printf", "%s", "tail"}
+				intent.LiteralArgs = map[int]bool{2: true}
+				want = ";tail"
+			case "quoted argv":
+				intent.Command = []string{"printf", "<%s>", "", "$literal", "a'b"}
+				want = "<><$literal><a'b>"
+			case "unmarked assignment":
+				intent.Command = []string{"CBX_PROBE=value", "sh", "-c", `printf %s "$CBX_PROBE"`}
+				want = "value"
+			case "explicit source":
+				intent.Command = []string{`printf %s "$unexported_fixture_state"; exit 7`}
+				intent.ShellMode = true
+				want, wantExit = "existing-shell", 7
+			case "empty source":
+				intent.Command = []string{""}
+				intent.ShellMode = true
+			case "inferred source":
+				intent.Command = []string{"printf %s inferred"}
+				want = "inferred"
+			}
+			result := run(t, root, intent)
+			if name == "missing command" {
+				if result.ErrorCode != 2 {
+					t.Fatalf("missing command error=%v", result.Err)
+				}
+				if len(result.Commands) != 1 {
+					t.Fatalf("missing command reached workload: %v", result.Commands)
+				}
+				return
+			}
+			if result.Err != nil {
+				t.Fatal(result.Err)
+			}
+			if len(result.Commands) != 2 {
+				t.Fatalf("commands=%v want preparation and workload", result.Commands)
+			}
+			source := "unexported_fixture_state=existing-shell\n" + result.Commands[1]
+			cmd := exec.CommandContext(t.Context(), bash, "--noprofile", "--norc", "-c", source)
+			cmd.Dir = root
+			cmd.Env = []string{"HOME=" + root, "PATH=" + root + ":/usr/bin:/bin"}
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout, cmd.Stderr = &stdout, &stderr
+			commandErr := cmd.Run()
+			code := 0
+			if commandErr != nil {
+				var exitErr *exec.ExitError
+				if !errors.As(commandErr, &exitErr) {
+					t.Fatal(commandErr)
+				}
+				code = exitErr.ExitCode()
+			}
+			if code != wantExit || stdout.String() != want {
+				t.Fatalf("source=%q stdout=%q stderr=%q exit=%d; want %q/%d", source, stdout.String(), stderr.String(), code, want, wantExit)
+			}
+			if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("literal separator ran touch: %v", err)
+			}
+		})
+	}
+}
+
+func VerifyNativeCommandIntent(t *testing.T, shell string, includeEmptySource bool, run func(*testing.T, CommandIntent) []string) {
+	t.Helper()
+	tests := []struct {
+		name   string
+		intent CommandIntent
+		want   []string
+	}{
+		{"ordinary", CommandIntent{Command: []string{"printf", "%s", "hello"}}, []string{"printf", "%s", "hello"}},
+		{"literal separator", CommandIntent{Command: []string{"printf", "%s", ";", "touch", "sentinel"}, LiteralArgs: map[int]bool{2: true}}, []string{"printf", "%s", ";", "touch", "sentinel"}},
+		{"literal assignment executable", CommandIntent{Command: []string{"FOO=x", "argument"}, LiteralArgs: map[int]bool{0: true}}, []string{"FOO=x", "argument"}},
+		{"literal singleton", CommandIntent{Command: []string{"literal command $(echo x)"}, LiteralArgs: map[int]bool{0: true}}, []string{"literal command $(echo x)"}},
+		{"invalid assignment executable", CommandIntent{Command: []string{"bad-name=x", "argument"}}, []string{"bad-name=x", "argument"}},
+		{"mixed operators", CommandIntent{Command: []string{"printf", "%s", ";", "&&", "printf", "%s", "done"}, LiteralArgs: map[int]bool{2: true}}, []string{shell, "-lc", "'printf' '%s' ';' && 'printf' '%s' 'done'"}},
+		{"inferred source", CommandIntent{Command: []string{"printf one && printf two"}}, []string{shell, "-lc", "printf one && printf two"}},
+		{"explicit source", CommandIntent{Command: []string{"printf one; exit 7"}, ShellMode: true}, []string{shell, "-lc", "printf one; exit 7"}},
+		{"leading assignment", CommandIntent{Command: []string{"GREETING=hello world", "printf", "%s", "$GREETING"}}, []string{shell, "-lc", "GREETING='hello world' 'printf' '%s' '$GREETING'"}},
+	}
+	if includeEmptySource {
+		tests = append([]struct {
+			name   string
+			intent CommandIntent
+			want   []string
+		}{{"empty explicit source", CommandIntent{Command: []string{""}, ShellMode: true}, []string{shell, "-lc", ""}}}, tests...)
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := run(t, tc.intent)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("native command=%#v want %#v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/testutil/protocol.go
+++ b/internal/testutil/protocol.go
@@ -1,0 +1,52 @@
+package testutil
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+func RequireRedactedProviderError(t *testing.T, err error, secret string) {
+	t.Helper()
+	if err == nil || strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[redacted]") || !strings.Contains(err.Error(), "quota exceeded") {
+		t.Fatalf("error=%v, want redacted useful provider error", err)
+	}
+}
+
+func GRPCWebEnvelope(flags byte, value any) []byte {
+	data, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	var out bytes.Buffer
+	out.WriteByte(flags)
+	out.Write([]byte{byte(len(data) >> 24), byte(len(data) >> 16), byte(len(data) >> 8), byte(len(data))})
+	out.Write(data)
+	return out.Bytes()
+}
+
+func TarGzipContains(t *testing.T, data []byte, name string) bool {
+	t.Helper()
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			return false
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if header.Name == name {
+			return true
+		}
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

Provider tests repeated large command-intent and protocol fixtures, making the same behavioral contract harder to review and keep aligned.

## Why This Change Was Made

This test-only refactor moves the shared command-intent and protocol assertions into `internal/testutil` and keeps each provider adapter focused on translating its own request shape. It preserves the existing ordered test roster and all provider-specific setup, request inspection, and failure assertions.

## User Impact

There is no user-visible behavior, configuration, or secret-handling change. Production code is unchanged. No changelog entry is included because this is a mechanical test refactor.

## Evidence

- Preserves 376 ordered test functions across the affected provider suites.
- Preserves 49 command-intent cases across five integrations with the existing `9+10+10+10+10` distribution.
- Preserves all 11 newer Islo tests and their I/O failure fixtures while replacing only the duplicated archive inspection helper.
- The final diff is net negative: 9 files, 337 additions, and 453 deletions.
- `gofmt`, diff checks, static source inspection, output-blob binding, and privacy checks passed.
- Local product tests were not run for this preparation cycle. Hosted source-head qualification passed for `46ff27d21276047f1623cf689a5293c84e082cb1` (22 canonical jobs); the current-main composition was independently verified, not executed.
