### PR TITLE
fix(azure): resolve retained shared-infrastructure fences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix Azure leases blocked by retained legacy shared-infrastructure fences by verifying settled resources before transactional takeover. [PR 1982](https://github.com/openclaw/crabbox/pull/1982). Thanks @steipete.
+
 - AWS: avoid duplicate access-refresh lookups for ports with matching permissions, index lease access once, and keep unnamed runner/workspace groups separate. https://github.com/openclaw/crabbox/pull/1980. Thanks @steipete.
 
 - AWS: overlap SSH ingress authorization in bounded batches while preserving revocation, recovery and cleanup ordering. https://github.com/openclaw/crabbox/pull/1976. Thanks @steipete.

--- a/docs/features/azure.md
+++ b/docs/features/azure.md
@@ -228,6 +228,11 @@ group, set `azure.location` / `CRABBOX_AZURE_LOCATION` to the same region as the
 existing vnet and NSG, or pick distinct `azure.vnet`, `azure.subnet`, and
 `azure.nsg` names for a new region.
 
+A failed shared-infrastructure write retains its legacy fence. The next lease
+automatically resolves it once the resource group, location's vnet, and NSG read
+back as absent or in a settled provisioning state (`Succeeded`, `Failed`, or
+`Canceled`). A durable provisioning operation's fence is never taken over.
+
 The default location is `eastus`. The default Linux image is
 `Canonical:ubuntu-26_04-lts:server:latest`; native Windows defaults to
 `MicrosoftWindowsServer:windowsserver2022:2022-datacenter-smalldisk-g2:latest`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1036,7 +1036,10 @@ Nonsecret plan/attempt histories and exact completed Azure deletion claims are
 retained alongside lease history without automatic pruning. Do not remove
 retained or unresolved histories to clear a cleanup incident. The shared Azure
 scope lock is released after settled terminal/retained completion; an unresolved
-shared-infrastructure write intentionally keeps its lock pending resolution.
+shared-infrastructure write retains its lock. A retained legacy fence is resolved
+automatically on the next lease once the resource group, location's vnet, and NSG
+read back as absent or in a settled provisioning state (`Succeeded`, `Failed`, or
+`Canceled`). A durable provisioning operation's fence is never taken over.
 
 ### AWS provisioning timing logs
 

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -2319,17 +2319,60 @@ export class AzureClient {
     if (!storage?.transaction) return this.ensureSharedInfraUnlocked(location, config);
     const key = `provisioning-lock:${this.providerScope().toLowerCase()}`;
     const owner = `legacy:${crypto.randomUUID()}`;
-    await storage.transaction(async (transaction) => {
-      if (await transaction.get(key))
-        throw new Error("Azure shared infrastructure has an unresolved operation");
+    const staleOwner = await storage.transaction(async (transaction) => {
+      const held = await transaction.get<string>(key);
+      if (held) {
+        if (!held.startsWith("legacy:"))
+          throw new Error("Azure shared infrastructure has an unresolved operation");
+        return held;
+      }
       await transaction.put(key, owner);
+      return undefined;
     });
+    if (staleOwner) {
+      if (!(await this.sharedInfraSettled(location)))
+        throw new Error("Azure shared infrastructure has an unresolved operation");
+      await storage.transaction(async (transaction) => {
+        if ((await transaction.get(key)) !== staleOwner)
+          throw new Error("Azure shared infrastructure has an unresolved operation");
+        await transaction.put(key, owner);
+      });
+    }
     // A failed legacy call retains the fence: no LRO journal proves its last write settled.
     const result = await this.ensureSharedInfraUnlocked(location, config);
     await storage.transaction(async (transaction) => {
       if ((await transaction.get(key)) === owner) await transaction.delete(key);
     });
     return result;
+  }
+
+  private async sharedInfraSettled(location: string): Promise<boolean> {
+    try {
+      const infra = await this.sharedInfraNamesForLocation(location);
+      const resources = [
+        [`/resourceGroups/${this.resourceGroup}`, API_VERSIONS.resources],
+        [networkPath(this.resourceGroup, "virtualNetworks", infra.vnet), API_VERSIONS.network],
+        [networkPath(this.resourceGroup, "networkSecurityGroups", infra.nsg), API_VERSIONS.network],
+      ] as const;
+      const settled = await Promise.all(
+        resources.map(async ([path, apiVersion]) => {
+          try {
+            const resource = await this.arm<{ properties?: { provisioningState?: string } }>(
+              "GET",
+              path,
+              apiVersion,
+            );
+            const state = resource?.properties?.provisioningState?.toLowerCase();
+            return state === "succeeded" || state === "failed" || state === "canceled";
+          } catch (error) {
+            return error instanceof AzureHTTPError && error.status === 404;
+          }
+        }),
+      );
+      return settled.every(Boolean);
+    } catch {
+      return false;
+    }
   }
 
   private async ensureSharedInfraUnlocked(

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -5215,6 +5215,218 @@ describe("azure provider", () => {
     expect(nsgWrites).toEqual([]);
   });
 
+  describe("legacy shared infrastructure fence resolution", () => {
+    function fixture() {
+      const { storage, records } = memoryAzureDeleteClaimStorage();
+      const client = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });
+      const key = `provisioning-lock:${client.providerScope().toLowerCase()}`;
+      const staleOwner = "legacy:stale-operation";
+      records.set(key, staleOwner);
+      const paths = [
+        "/subscriptions/sub/resourceGroups/crabbox-leases",
+        "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/virtualNetworks/crabbox-vnet",
+        "/subscriptions/sub/resourceGroups/crabbox-leases/providers/Microsoft.Network/networkSecurityGroups/crabbox-nsg",
+      ];
+      const resources = new Map(
+        paths.map((path) => [
+          path,
+          {
+            location: "eastus",
+            tags: { managed_by: "crabbox" },
+            properties: { provisioningState: "Succeeded" as string | undefined, securityRules: [] },
+          },
+        ]),
+      );
+      const reads: string[] = [];
+      const writes: Array<{ path: string; body: unknown }> = [];
+      let inTransaction = false;
+      const transaction = storage.transaction!;
+      storage.transaction = (callback) =>
+        transaction(async (tx) => {
+          inTransaction = true;
+          try {
+            return await callback(tx);
+          } finally {
+            inTransaction = false;
+          }
+        });
+      const fetcher = vi.fn<typeof fetch>(async (input, init) => {
+        expect(inTransaction).toBe(false);
+        const url = String(input);
+        if (isAzureLoginURL(url)) {
+          return Response.json({ access_token: "tkn", expires_in: 3600 });
+        }
+        const path = new URL(url).pathname;
+        if (init?.method === "GET") {
+          reads.push(path);
+          const resource = resources.get(path);
+          return resource
+            ? Response.json(resource)
+            : Response.json({ error: "missing" }, { status: 404 });
+        }
+        expect(init?.method).toBe("PUT");
+        writes.push({ path, body: JSON.parse(String(init?.body)) });
+        return Response.json({});
+      });
+      client.fetcher = fetcher;
+      return {
+        client,
+        key,
+        staleOwner,
+        storage,
+        records,
+        paths,
+        resources,
+        reads,
+        writes,
+        fetcher,
+      };
+    }
+
+    it.each(["Succeeded", "sUcCeEdEd", "Failed", "cAnCeLeD", "absent"])(
+      "resolves a retained legacy fence when all resources are %s",
+      async (state) => {
+        const f = fixture();
+        for (const resource of f.resources.values()) resource.properties.provisioningState = state;
+        if (state === "absent") f.resources.clear();
+
+        await expect(f.client.ensureSharedInfra("eastus", testLeaseConfig())).resolves.toEqual({
+          vnet: "crabbox-vnet",
+          nsg: "crabbox-nsg",
+        });
+
+        expect(f.reads).toEqual(expect.arrayContaining(f.paths));
+        expect(f.writes).toContainEqual({
+          path: f.paths[2],
+          body: expect.objectContaining({
+            properties: {
+              securityRules: [
+                expect.objectContaining({ name: "crabbox-ssh-2222-0" }),
+                expect.objectContaining({ name: "crabbox-ssh-22-0" }),
+              ],
+            },
+          }),
+        });
+        expect(f.records.has(f.key)).toBe(false);
+      },
+    );
+
+    it.each(["Updating", "Creating", "Deleting", "Accepted", "unknown", undefined])(
+      "retains a legacy fence while the NSG state is %s",
+      async (state) => {
+        const f = fixture();
+        f.resources.get(f.paths[2]!)!.properties.provisioningState = state;
+
+        await expect(f.client.ensureSharedInfra("eastus", testLeaseConfig())).rejects.toThrow(
+          "Azure shared infrastructure has an unresolved operation",
+        );
+
+        expect(f.writes).toEqual([]);
+        expect(f.records.get(f.key)).toBe(f.staleOwner);
+      },
+    );
+
+    it.each([0, 1])("retains a legacy fence while resource %i is Updating", async (index) => {
+      const f = fixture();
+      f.resources.get(f.paths[index]!)!.properties.provisioningState = "Updating";
+
+      await expect(f.client.ensureSharedInfra("eastus", testLeaseConfig())).rejects.toThrow(
+        "Azure shared infrastructure has an unresolved operation",
+      );
+
+      expect(f.writes).toEqual([]);
+      expect(f.records.get(f.key)).toBe(f.staleOwner);
+    });
+
+    it("never probes or takes over a durable operation fence", async () => {
+      const f = fixture();
+      f.records.set(f.key, "provisioning-operation-id");
+
+      await expect(f.client.ensureSharedInfra("eastus", testLeaseConfig())).rejects.toThrow(
+        "Azure shared infrastructure has an unresolved operation",
+      );
+
+      expect(f.fetcher).not.toHaveBeenCalled();
+      expect(f.records.get(f.key)).toBe("provisioning-operation-id");
+    });
+
+    it.each([0, 1, 2])("retains a legacy fence when resource %i cannot be read", async (index) => {
+      const f = fixture();
+      f.client.fetcher = async (input, init) => {
+        if (init?.method === "GET" && new URL(String(input)).pathname === f.paths[index]) {
+          return Response.json({ error: { code: "ResourceNotFound" } }, { status: 500 });
+        }
+        return f.fetcher(input, init);
+      };
+
+      await expect(f.client.ensureSharedInfra("eastus", testLeaseConfig())).rejects.toThrow(
+        "Azure shared infrastructure has an unresolved operation",
+      );
+
+      expect(f.writes).toEqual([]);
+      expect(f.records.get(f.key)).toBe(f.staleOwner);
+    });
+
+    it("probes the location's settled regional network resources", async () => {
+      const f = fixture();
+      for (const path of f.paths.slice(1)) {
+        f.resources.set(`${path}-westus3`, {
+          location: "westus3",
+          tags: { managed_by: "crabbox" },
+          properties: { provisioningState: "Succeeded", securityRules: [] },
+        });
+      }
+
+      await expect(f.client.ensureSharedInfra("westus3", testLeaseConfig())).resolves.toEqual({
+        vnet: "crabbox-vnet-westus3",
+        nsg: "crabbox-nsg-westus3",
+      });
+
+      expect(f.writes.map((write) => write.path)).toEqual([`${f.paths[2]}-westus3`]);
+      expect(f.records.has(f.key)).toBe(false);
+      expect(f.reads).toEqual(
+        expect.arrayContaining(f.paths.slice(1).map((path) => `${path}-westus3`)),
+      );
+    });
+
+    it("retains the new legacy fence after a failed write and resolves it on retry", async () => {
+      const f = fixture();
+      f.client.fetcher = async (input, init) => {
+        if (init?.method === "PUT") throw new Error("synthetic ARM write failure");
+        return f.fetcher(input, init);
+      };
+
+      await expect(f.client.ensureSharedInfra("eastus", testLeaseConfig())).rejects.toThrow(
+        "synthetic ARM write failure",
+      );
+
+      expect(f.records.get(f.key)).toMatch(/^legacy:[\da-f-]{36}$/);
+      expect(f.records.get(f.key)).not.toBe(f.staleOwner);
+      f.client.fetcher = f.fetcher;
+      await f.client.ensureSharedInfra("eastus", testLeaseConfig());
+      expect(f.records.has(f.key)).toBe(false);
+    });
+
+    it("preserves a newer fence owner when takeover loses the CAS race", async () => {
+      const f = fixture();
+      const transaction = f.storage.transaction!;
+      f.storage.transaction = (callback) => {
+        if (f.paths.every((path) => f.reads.includes(path))) {
+          f.records.set(f.key, "legacy:newer-operation");
+        }
+        return transaction(callback);
+      };
+
+      await expect(f.client.ensureSharedInfra("eastus", testLeaseConfig())).rejects.toThrow(
+        "Azure shared infrastructure has an unresolved operation",
+      );
+
+      expect(f.reads).toEqual(expect.arrayContaining(f.paths));
+      expect(f.writes).toEqual([]);
+      expect(f.records.get(f.key)).toBe("legacy:newer-operation");
+    });
+  });
+
   it("uses regional shared network names when defaults already exist elsewhere", async () => {
     const client = new AzureClient({ ...baseEnv, CRABBOX_AZURE_LOCATION: "westus3" });
     let puts: string[] = [];


### PR DESCRIPTION
Brokered Azure leases could remain blocked permanently by `Azure shared infrastructure has an unresolved operation` after a failed legacy shared-infrastructure write. The bare-string `legacy:<uuid>` fence was deliberately retained on failure, but there was no path to resolve it.

Resolve a retained legacy fence automatically on the next lease by reading the resource group and the location-specific vnet and NSG outside storage transactions. All three must be absent (HTTP 404) or report `Succeeded`, `Failed`, or `Canceled`, case-insensitively. A transaction then replaces the fence only if its owner still exactly matches the owner observed before probing. Nonterminal or missing states, read failures, and ownership races leave the fence intact. Durable operation owners cause zero ARM requests and are never taken over. The existing bare-string format, failure retention, resource writes, and no-transaction fallback remain unchanged; there is no timer or expiry.

Regression coverage includes terminal and absent resources, nonterminal and missing states, non-404 read errors, regional resource names, durable owners, the CAS race, and a failed write followed by successful recovery. The `Succeeded` recovery test was run before the source fix and failed with the intended unresolved-operation error. Both Azure documentation sections describe automatic recovery.

Verification (all run from the repository root):

```sh
npm run format:check --prefix worker
npm run lint --prefix worker
npm run check --prefix worker
npm test --prefix worker -- test/azure.test.ts
npm test --prefix worker
```

Formatting, lint, and typechecking pass. Focused Azure suite: `1 passed (1)` test file, `234 passed (234)` tests. Full Worker suite: `52 passed | 2 skipped (54)` test files, `2925 passed | 3 skipped (2928)` tests.

Config/secret implications: none.
