### PR TITLE
fix(run): preserve evidence when remote capture fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - AWS: avoid duplicate access-refresh lookups for ports with matching permissions, index lease access once, and keep unnamed runner/workspace groups separate. https://github.com/openclaw/crabbox/pull/1980. Thanks @steipete.
 
-- Keep failure-capture scratch files outside tested checkouts, bound intermediate archive creation and streamed SSH downloads while preserving existing destinations, and diagnose unknown failures from the recorded run instead of suggesting an unchanged full rerun.
+- Keep failure-capture scratch files outside tested checkouts, bound intermediate archive creation and streamed SSH downloads while preserving existing destinations, and diagnose unknown failures from the recorded run instead of suggesting an unchanged full rerun. https://github.com/openclaw/crabbox/pull/1983. Thanks @vincentkoc.
 - AWS: overlap SSH ingress authorization in bounded batches while preserving revocation, recovery and cleanup ordering. https://github.com/openclaw/crabbox/pull/1976. Thanks @steipete.
 
 - Overlap default-VPC and managed security-group discovery during AWS provisioning while retaining scope validation and joined failure handling. [PR 1974](https://github.com/openclaw/crabbox/pull/1974). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - AWS: avoid duplicate access-refresh lookups for ports with matching permissions, index lease access once, and keep unnamed runner/workspace groups separate. https://github.com/openclaw/crabbox/pull/1980. Thanks @steipete.
 
-- Keep failure-capture scratch files outside tested checkouts, bound and stream SSH downloads while preserving existing destinations, and diagnose unknown failures from the recorded run instead of suggesting an unchanged full rerun.
+- Keep failure-capture scratch files outside tested checkouts, bound intermediate archive creation and streamed SSH downloads while preserving existing destinations, and diagnose unknown failures from the recorded run instead of suggesting an unchanged full rerun.
 - AWS: overlap SSH ingress authorization in bounded batches while preserving revocation, recovery and cleanup ordering. https://github.com/openclaw/crabbox/pull/1976. Thanks @steipete.
 
 - Overlap default-VPC and managed security-group discovery during AWS provisioning while retaining scope validation and joined failure handling. [PR 1974](https://github.com/openclaw/crabbox/pull/1974). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - AWS: avoid duplicate access-refresh lookups for ports with matching permissions, index lease access once, and keep unnamed runner/workspace groups separate. https://github.com/openclaw/crabbox/pull/1980. Thanks @steipete.
 
+- Keep failure-capture scratch files outside tested checkouts, bound and stream SSH downloads while preserving existing destinations, and diagnose unknown failures from the recorded run instead of suggesting an unchanged full rerun.
 - AWS: overlap SSH ingress authorization in bounded batches while preserving revocation, recovery and cleanup ordering. https://github.com/openclaw/crabbox/pull/1976. Thanks @steipete.
 
 - Overlap default-VPC and managed security-group discovery during AWS provisioning while retaining scope validation and joined failure handling. [PR 1974](https://github.com/openclaw/crabbox/pull/1974). Thanks @steipete.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -664,6 +664,16 @@ Unix-like hosts, Crabbox-created download, capture, proof,
 and failure-bundle files use owner-only permissions (`0600`), and newly created
 output directories use `0700`.
 
+SSH downloads stream into a private temporary file and publish atomically only
+after the remote command and advertised byte count pass. Ordinary downloads
+intentionally enforce a 1 GiB per-file limit and retain at least 1 GiB of local
+free space as an upgrade safety boundary. A failed, canceled, oversized, or
+size-mismatched transfer leaves an existing destination unchanged. Automatic
+remote failure-capture payloads use a tighter 64 MiB limit; their scratch
+manifests and file lists live outside the tested checkout and are removed on
+every exit. Failed or canceled capture preparation also removes its partial
+remote archive with bounded cleanup that does not inherit caller cancellation.
+
 Use repeatable `--download-on-failure remote=local` to retrieve explicitly
 selected evidence after a nonzero workload exit on ordinary Linux SSH runs.
 Crabbox requires a fresh owned workload-start/exit marker pair and successful
@@ -765,9 +775,11 @@ its status before reuse, or retry the printed stop command to finish cleanup.
 The digest includes the failed phase when phase markers are known, a
 likely area (provider auth, SSH/connectivity, sync, install/setup, user command,
 model/tool/provider limit, or resource exhaustion), retryability when inferable, next commands
-(`logs`, `events`, `doctor --from-run`, `ssh`, retrying, and `stop`). A retry
-preserves an explicitly requested `--no-sync`, so it does not reset the retained
-workspace. Other retries retain the `--fresh-sync` guidance above. Each original
+(`logs`, `events`, `doctor --from-run`, `ssh`, retrying, and `stop`). Unknown
+failures stop at the run-scoped diagnostic commands instead of advertising a
+full rerun. A retry is printed only when the failure is classified as retryable
+and preserves an explicitly requested `--no-sync`, so it does not reset the
+retained workspace. Other retries retain the `--fresh-sync` guidance above. Each original
 `--require-artifact` glob is retained in the retry, so missing required evidence
 still fails the rerun. After failure-bundle information and command hints, each
 stream has one

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -1570,6 +1570,7 @@ profiles:
 `), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	downloadedArtifacts := []byte("artifacts\n")
 	script := `#!/bin/sh
 cmd=""
 for arg do cmd="$arg"; done
@@ -1577,7 +1578,7 @@ input="$(cat)"
 printf '%s\n%s\n---\n' "$cmd" "$input" >> "$CRABBOX_FAKE_SSH_LOG"
 case "$cmd
 $input" in
-  *"base64 <"*) printf 'YXJ0aWZhY3RzCg=='; exit 0 ;;
+  *"base64 <"*) printf '%s' ` + shellQuote(encodedRunDownloadPayload(int64(len(downloadedArtifacts)), downloadedArtifacts)) + `; exit 0 ;;
   *"base64 -d >"*) printf 'ok      node             v22.1.0\nok      pnpm             9.0.0\nok      docker-compose   Docker Compose version v2.27.0\n'; exit 0 ;;
   *"artifacts.tgz"*) printf 'warning: no artifact matches\n'; exit 0 ;;
 esac

--- a/internal/cli/run_cleanup_outcome_test.go
+++ b/internal/cli/run_cleanup_outcome_test.go
@@ -128,10 +128,13 @@ func TestRunCoordinatorCleanupOutcomes(t *testing.T) {
 				if len(digest) != 2 {
 					t.Fatalf("missing digest:\n%s", out)
 				}
-				for _, command := range []string{"ssh", "run", "stop"} {
+				for _, command := range []string{"ssh", "stop"} {
 					if got := strings.Contains(digest[1], "next: crabbox "+command+" "); got == tc.terminal {
 						t.Errorf("recovery %s present=%t terminal=%t\n%s", command, got, tc.terminal, out)
 					}
+				}
+				if strings.Contains(digest[1], "next: crabbox run ") {
+					t.Errorf("unknown failure advertised a blind rerun\n%s", out)
 				}
 				wantPosts := int32(1)
 				if tc.releaseError {

--- a/internal/cli/run_download.go
+++ b/internal/cli/run_download.go
@@ -1,14 +1,41 @@
 package cli
 
 import (
+	"bufio"
 	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
+
+const (
+	runDownloadMaxBytes              = maxPulledArtifactBytes
+	runDownloadDiskReserveBytes      = int64(1024 * 1024 * 1024)
+	failureCaptureDownloadMaxBytes   = int64(64 * 1024 * 1024)
+	remoteDownloadHeaderPrefix       = "CRABBOX_DOWNLOAD_SIZE="
+	remoteDownloadHeaderMaxBytes     = 128
+	remoteDownloadDiagnosticMaxBytes = 4096
+)
+
+type runDownloadLimits struct {
+	MaxBytes         int64
+	DiskReserveBytes int64
+}
+
+var defaultRunDownloadLimits = runDownloadLimits{
+	MaxBytes:         runDownloadMaxBytes,
+	DiskReserveBytes: runDownloadDiskReserveBytes,
+}
+
+var failureCaptureDownloadLimits = runDownloadLimits{
+	MaxBytes:         failureCaptureDownloadMaxBytes,
+	DiskReserveBytes: runDownloadDiskReserveBytes,
+}
 
 type runDownloadSpec struct {
 	Remote string
@@ -353,22 +380,54 @@ func checkWritableDir(label, dir string) error {
 }
 
 func downloadRemoteFile(ctx context.Context, target SSHTarget, workdir, specValue string) (int, string, error) {
+	return downloadRemoteFileWithLimits(ctx, target, workdir, specValue, defaultRunDownloadLimits)
+}
+
+func downloadRemoteFileWithLimits(ctx context.Context, target SSHTarget, workdir, specValue string, limits runDownloadLimits) (int, string, error) {
 	spec, err := parseRunDownloadSpec(specValue)
 	if err != nil {
 		return 0, "", err
 	}
-	encoded, err := runSSHOutput(ctx, target, remoteDownloadBase64Command(target, workdir, spec.Remote))
-	if err != nil {
-		return 0, spec.Local, exit(7, "download %s: %v", spec.Remote, err)
+	reader, writer := io.Pipe()
+	type stageResult struct {
+		stage *stagedRunDownload
+		err   error
 	}
-	data, err := base64.StdEncoding.DecodeString(strings.Join(strings.Fields(encoded), ""))
-	if err != nil {
-		return 0, spec.Local, exit(7, "download %s: decode base64: %v", spec.Remote, err)
+	result := make(chan stageResult, 1)
+	go func() {
+		stage, stageErr := stageRunDownload(ctx, reader, spec.Local, limits, availableRunDownloadBytes)
+		if stageErr != nil {
+			_ = reader.CloseWithError(stageErr)
+		}
+		result <- stageResult{stage: stage, err: stageErr}
+	}()
+	diagnostic := newSynchronizedBuffer(remoteDownloadDiagnosticMaxBytes)
+	code, streamErr := runSSHStreamResult(ctx, target, remoteDownloadBase64Command(target, workdir, spec.Remote), writer, &diagnostic)
+	if streamErr != nil {
+		_ = writer.CloseWithError(streamErr)
+	} else {
+		_ = writer.Close()
 	}
-	if err := writeRunDownloadFile(spec.Local, data); err != nil {
+	staged := <-result
+	if staged.err != nil {
+		var localErr runDownloadLocalError
+		if errors.As(staged.err, &localErr) {
+			return 0, spec.Local, exit(2, "download %s: write %s: %v", spec.Remote, spec.Local, localErr)
+		}
+		return 0, spec.Local, exit(7, "download %s: %v", spec.Remote, staged.err)
+	}
+	if streamErr != nil || code != 0 {
+		staged.stage.remove()
+		remoteErr := firstNonNil(streamErr, fmt.Errorf("remote command exited %d", code))
+		if detail := strings.TrimSpace(diagnostic.String()); detail != "" {
+			return 0, spec.Local, exit(7, "download %s: %v: %s", spec.Remote, remoteErr, detail)
+		}
+		return 0, spec.Local, exit(7, "download %s: %v", spec.Remote, remoteErr)
+	}
+	if err := staged.stage.publish(); err != nil {
 		return 0, spec.Local, exit(2, "download %s: write %s: %v", spec.Remote, spec.Local, err)
 	}
-	return len(data), spec.Local, nil
+	return int(staged.stage.bytes), spec.Local, nil
 }
 
 func writeRunDownloadFile(path string, data []byte) error {
@@ -380,13 +439,182 @@ func writeRunDownloadFile(path string, data []byte) error {
 	return writePrivateRunOutputFile(path, data)
 }
 
+type runDownloadLocalError struct {
+	error
+}
+
+type stagedRunDownload struct {
+	tempPath string
+	path     string
+	bytes    int64
+}
+
+func (download *stagedRunDownload) remove() {
+	if download != nil && download.tempPath != "" {
+		_ = os.Remove(download.tempPath)
+		download.tempPath = ""
+	}
+}
+
+func (download *stagedRunDownload) publish() error {
+	if download == nil || download.tempPath == "" {
+		return fmt.Errorf("download temporary file is unavailable")
+	}
+	tempPath := download.tempPath
+	download.tempPath = ""
+	if err := replacePrivateRunOutputTemp(tempPath, download.path); err != nil {
+		_ = os.Remove(tempPath)
+		return err
+	}
+	return nil
+}
+
+func stageRunDownload(ctx context.Context, source io.Reader, path string, limits runDownloadLimits, available func(string) (int64, error)) (_ *stagedRunDownload, resultErr error) {
+	if limits.MaxBytes < 0 || limits.DiskReserveBytes < 0 {
+		return nil, fmt.Errorf("invalid download limits")
+	}
+	dir := filepath.Dir(path)
+	if dir != "." && dir != "" {
+		if err := createPrivateRunOutputDir(dir); err != nil {
+			return nil, runDownloadLocalError{err}
+		}
+	}
+	file, tempPath, err := createPrivateRunOutputTemp(path)
+	if err != nil {
+		return nil, runDownloadLocalError{err}
+	}
+	defer func() {
+		if resultErr != nil {
+			_ = file.Close()
+			_ = os.Remove(tempPath)
+		}
+	}()
+	buffered := bufio.NewReaderSize(&contextRunDownloadReader{ctx: ctx, reader: source}, remoteDownloadHeaderMaxBytes)
+	advertised, err := readRemoteDownloadSize(buffered)
+	if err != nil {
+		return nil, err
+	}
+	if advertised > limits.MaxBytes {
+		return nil, fmt.Errorf("advertised size %d exceeds limit %d", advertised, limits.MaxBytes)
+	}
+	if err := checkRunDownloadDiskReserve(dir, advertised, limits.DiskReserveBytes, available); err != nil {
+		return nil, runDownloadLocalError{err}
+	}
+	destination := &runDownloadReserveWriter{
+		writer:    file,
+		path:      dir,
+		reserve:   limits.DiskReserveBytes,
+		available: available,
+	}
+	written, exceeded, err := copyArtifactResponse(destination, base64.NewDecoder(base64.StdEncoding, buffered), advertised)
+	if err != nil {
+		return nil, fmt.Errorf("decode base64 stream: %w", err)
+	}
+	if exceeded {
+		return nil, fmt.Errorf("decoded response exceeds advertised size %d", advertised)
+	}
+	if written != advertised {
+		return nil, fmt.Errorf("decoded size %d does not match advertised size %d", written, advertised)
+	}
+	if err := file.Close(); err != nil {
+		return nil, runDownloadLocalError{err}
+	}
+	return &stagedRunDownload{tempPath: tempPath, path: path, bytes: written}, nil
+}
+
+func readRemoteDownloadSize(reader *bufio.Reader) (int64, error) {
+	line, err := reader.ReadSlice('\n')
+	if errors.Is(err, bufio.ErrBufferFull) || len(line) > remoteDownloadHeaderMaxBytes {
+		return 0, fmt.Errorf("size header exceeds %d bytes", remoteDownloadHeaderMaxBytes)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read size header: %w", err)
+	}
+	value, ok := strings.CutPrefix(strings.TrimSpace(string(line)), remoteDownloadHeaderPrefix)
+	value = strings.TrimSpace(value)
+	if !ok || value == "" {
+		return 0, fmt.Errorf("invalid size header")
+	}
+	size, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || size < 0 || strconv.FormatInt(size, 10) != value {
+		return 0, fmt.Errorf("invalid advertised size %q", value)
+	}
+	return size, nil
+}
+
+func checkRunDownloadDiskReserve(path string, incoming, reserve int64, available func(string) (int64, error)) error {
+	free, err := available(firstNonBlank(path, "."))
+	if err != nil {
+		return fmt.Errorf("check available disk: %w", err)
+	}
+	if free < reserve || incoming > free-reserve {
+		return fmt.Errorf("insufficient disk: available=%d incoming=%d reserve=%d", free, incoming, reserve)
+	}
+	return nil
+}
+
+type runDownloadReserveWriter struct {
+	writer    io.Writer
+	path      string
+	reserve   int64
+	available func(string) (int64, error)
+}
+
+func (writer *runDownloadReserveWriter) Write(data []byte) (int, error) {
+	if err := checkRunDownloadDiskReserve(writer.path, int64(len(data)), writer.reserve, writer.available); err != nil {
+		return 0, err
+	}
+	return writer.writer.Write(data)
+}
+
+type contextRunDownloadReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (reader *contextRunDownloadReader) Read(data []byte) (int, error) {
+	if err := context.Cause(reader.ctx); err != nil {
+		return 0, err
+	}
+	return reader.reader.Read(data)
+}
+
+func firstNonNil(primary, fallback error) error {
+	if primary != nil {
+		return primary
+	}
+	return fallback
+}
+
 func remoteDownloadBase64Command(target SSHTarget, workdir, remotePath string) string {
 	if isWindowsNativeTarget(target) {
 		return powershellCommand(`$ErrorActionPreference = "Stop"
 Set-Location -LiteralPath ` + psQuote(workdir) + `
 $path = ` + psQuote(remotePath) + `
 if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { throw "download file not found: $path" }
-[Convert]::ToBase64String([System.IO.File]::ReadAllBytes((Resolve-Path -LiteralPath $path).Path))`)
+$file = [System.IO.File]::OpenRead((Resolve-Path -LiteralPath $path).Path)
+try {
+  [Console]::Out.WriteLine("` + remoteDownloadHeaderPrefix + `{0}", $file.Length)
+  $stdout = [Console]::OpenStandardOutput()
+  $transform = [System.Security.Cryptography.ToBase64Transform]::new()
+  $encoded = [System.Security.Cryptography.CryptoStream]::new($stdout, $transform, [System.Security.Cryptography.CryptoStreamMode]::Write, $true)
+  try {
+    $file.CopyTo($encoded)
+    $encoded.FlushFinalBlock()
+  } finally {
+    $encoded.Dispose()
+    $transform.Dispose()
+  }
+} finally {
+  $file.Dispose()
+}`)
 	}
-	return fmt.Sprintf("cd %s && test -f %s && base64 < %s", shellQuote(workdir), shellQuote(remotePath), shellQuote(remotePath))
+	return fmt.Sprintf(
+		"cd %s && test -f %s && size=$(LC_ALL=C wc -c < %s) && printf '%s%%s\\n' \"$size\" && base64 < %s",
+		shellQuote(workdir),
+		shellQuote(remotePath),
+		shellQuote(remotePath),
+		remoteDownloadHeaderPrefix,
+		shellQuote(remotePath),
+	)
 }

--- a/internal/cli/run_download.go
+++ b/internal/cli/run_download.go
@@ -562,9 +562,13 @@ type runDownloadReserveWriter struct {
 
 func (writer *runDownloadReserveWriter) Write(data []byte) (int, error) {
 	if err := checkRunDownloadDiskReserve(writer.path, int64(len(data)), writer.reserve, writer.available); err != nil {
-		return 0, err
+		return 0, runDownloadLocalError{err}
 	}
-	return writer.writer.Write(data)
+	written, err := writer.writer.Write(data)
+	if err != nil {
+		return written, runDownloadLocalError{err}
+	}
+	return written, nil
 }
 
 type contextRunDownloadReader struct {

--- a/internal/cli/run_download_space_unix.go
+++ b/internal/cli/run_download_space_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package cli
+
+import (
+	"math"
+
+	"golang.org/x/sys/unix"
+)
+
+func availableRunDownloadBytes(path string) (int64, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(path, &stat); err != nil {
+		return 0, err
+	}
+	blockSize := uint64(stat.Bsize)
+	availableBlocks := uint64(stat.Bavail)
+	if blockSize != 0 && availableBlocks > uint64(math.MaxInt64)/blockSize {
+		return math.MaxInt64, nil
+	}
+	available := availableBlocks * blockSize
+	if available > math.MaxInt64 {
+		return math.MaxInt64, nil
+	}
+	return int64(available), nil
+}

--- a/internal/cli/run_download_space_windows.go
+++ b/internal/cli/run_download_space_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package cli
+
+import (
+	"math"
+
+	"golang.org/x/sys/windows"
+)
+
+func availableRunDownloadBytes(path string) (int64, error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, err
+	}
+	var available uint64
+	if err := windows.GetDiskFreeSpaceEx(pathPtr, &available, nil, nil); err != nil {
+		return 0, err
+	}
+	if available > math.MaxInt64 {
+		return math.MaxInt64, nil
+	}
+	return int64(available), nil
+}

--- a/internal/cli/run_download_test.go
+++ b/internal/cli/run_download_test.go
@@ -1,6 +1,11 @@
 package cli
 
 import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -151,6 +156,8 @@ func TestRemoteDownloadBase64CommandPOSIX(t *testing.T) {
 	for _, want := range []string{
 		"cd '/work/repo'",
 		"test -f 'out/sixel.bin'",
+		"wc -c < 'out/sixel.bin'",
+		remoteDownloadHeaderPrefix,
 		"base64 < 'out/sixel.bin'",
 	} {
 		if !strings.Contains(got, want) {
@@ -165,11 +172,149 @@ func TestRemoteDownloadBase64CommandWindows(t *testing.T) {
 	for _, want := range []string{
 		`Set-Location -LiteralPath 'C:\crabbox\repo'`,
 		`$path = 'out\sixel.bin'`,
-		`[System.IO.File]::ReadAllBytes`,
-		`[Convert]::ToBase64String`,
+		`[System.IO.File]::OpenRead`,
+		remoteDownloadHeaderPrefix,
+		`[System.Security.Cryptography.CryptoStream]`,
+		`$file.CopyTo($encoded)`,
 	} {
 		if !strings.Contains(decoded, want) {
 			t.Fatalf("command missing %q in %q", want, decoded)
 		}
+	}
+	if strings.Contains(decoded, "ReadAllBytes") {
+		t.Fatalf("Windows download still buffers the whole file: %q", decoded)
+	}
+}
+
+func TestRunDownloadDefaultLimits(t *testing.T) {
+	if defaultRunDownloadLimits.MaxBytes != 1<<30 {
+		t.Fatalf("ordinary download max=%d want=%d", defaultRunDownloadLimits.MaxBytes, int64(1<<30))
+	}
+	if defaultRunDownloadLimits.DiskReserveBytes != 1<<30 {
+		t.Fatalf("ordinary download reserve=%d want=%d", defaultRunDownloadLimits.DiskReserveBytes, int64(1<<30))
+	}
+	if failureCaptureDownloadLimits.MaxBytes != 64<<20 {
+		t.Fatalf("failure capture max=%d want=%d", failureCaptureDownloadLimits.MaxBytes, int64(64<<20))
+	}
+	if failureCaptureDownloadLimits.DiskReserveBytes != defaultRunDownloadLimits.DiskReserveBytes {
+		t.Fatalf("failure capture reserve=%d want=%d", failureCaptureDownloadLimits.DiskReserveBytes, defaultRunDownloadLimits.DiskReserveBytes)
+	}
+}
+
+func TestStageRunDownloadBoundsAndPreservesDestination(t *testing.T) {
+	tests := []struct {
+		name       string
+		advertised int64
+		payload    []byte
+		limit      int64
+		free       int64
+		reserve    int64
+		want       string
+	}{
+		{name: "zero bytes", advertised: 0, limit: 4, free: 100, reserve: 10},
+		{name: "exact limit", advertised: 4, payload: []byte("data"), limit: 4, free: 100, reserve: 10},
+		{name: "limit plus one", advertised: 5, payload: []byte("12345"), limit: 4, free: 100, reserve: 10, want: "advertised size 5 exceeds limit 4"},
+		{name: "false remote size", advertised: 3, payload: []byte("data"), limit: 4, free: 100, reserve: 10, want: "decoded response exceeds advertised size 3"},
+		{name: "short remote size", advertised: 4, payload: []byte("abc"), limit: 4, free: 100, reserve: 10, want: "decoded size 3 does not match advertised size 4"},
+		{name: "low disk", advertised: 4, payload: []byte("data"), limit: 4, free: 13, reserve: 10, want: "insufficient disk"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "output.bin")
+			if err := os.WriteFile(path, []byte("keep"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			stage, err := stageRunDownload(t.Context(), encodedRunDownload(test.advertised, test.payload), path, runDownloadLimits{
+				MaxBytes:         test.limit,
+				DiskReserveBytes: test.reserve,
+			}, func(string) (int64, error) {
+				return test.free, nil
+			})
+			if test.want != "" {
+				if err == nil || !strings.Contains(err.Error(), test.want) {
+					t.Fatalf("err=%v want=%q", err, test.want)
+				}
+				assertRunDownloadDestinationAndTemps(t, path, "keep")
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if stage.bytes != test.advertised {
+				t.Fatalf("bytes=%d want=%d", stage.bytes, test.advertised)
+			}
+			if err := stage.publish(); err != nil {
+				t.Fatal(err)
+			}
+			assertRunDownloadDestinationAndTemps(t, path, string(test.payload))
+		})
+	}
+}
+
+func TestStageRunDownloadCancellationPreservesDestination(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.bin")
+	if err := os.WriteFile(path, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	payload := bytes.Repeat([]byte("x"), 4096)
+	headerLength := len(fmt.Sprintf("%s%8d\n", remoteDownloadHeaderPrefix, len(payload)))
+	source := &cancelingRunDownloadReader{
+		reader:      encodedRunDownload(int64(len(payload)), payload),
+		cancel:      cancel,
+		cancelAfter: headerLength + 4,
+	}
+	stage, err := stageRunDownload(ctx, source, path, runDownloadLimits{
+		MaxBytes:         int64(len(payload)),
+		DiskReserveBytes: 10,
+	}, func(string) (int64, error) {
+		return 1 << 20, nil
+	})
+	if stage != nil || !strings.Contains(fmt.Sprint(err), context.Canceled.Error()) {
+		t.Fatalf("stage=%#v err=%v", stage, err)
+	}
+	assertRunDownloadDestinationAndTemps(t, path, "keep")
+}
+
+func encodedRunDownload(advertised int64, payload []byte) io.Reader {
+	var data bytes.Buffer
+	fmt.Fprintf(&data, "%s%8d\n", remoteDownloadHeaderPrefix, advertised)
+	encoder := base64.NewEncoder(base64.StdEncoding, &data)
+	_, _ = encoder.Write(payload)
+	_ = encoder.Close()
+	return &data
+}
+
+type cancelingRunDownloadReader struct {
+	reader      io.Reader
+	cancel      context.CancelFunc
+	read        int
+	cancelAfter int
+}
+
+func (reader *cancelingRunDownloadReader) Read(data []byte) (int, error) {
+	if len(data) > 1 {
+		data = data[:1]
+	}
+	n, err := reader.reader.Read(data)
+	reader.read += n
+	if reader.read >= reader.cancelAfter {
+		reader.cancel()
+	}
+	return n, err
+}
+
+func assertRunDownloadDestinationAndTemps(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != want {
+		t.Fatalf("destination=%q err=%v want=%q", data, err, want)
+	}
+	temps, err := filepath.Glob(filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+".crabbox-*"))
+	if err != nil || len(temps) != 0 {
+		t.Fatalf("temporary downloads=%v err=%v", temps, err)
 	}
 }

--- a/internal/cli/run_download_test.go
+++ b/internal/cli/run_download_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -277,6 +278,58 @@ func TestStageRunDownloadCancellationPreservesDestination(t *testing.T) {
 		t.Fatalf("stage=%#v err=%v", stage, err)
 	}
 	assertRunDownloadDestinationAndTemps(t, path, "keep")
+}
+
+func TestStageRunDownloadClassifiesMidStreamDiskFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.bin")
+	if err := os.WriteFile(path, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var checks int
+	stage, err := stageRunDownload(t.Context(), encodedRunDownload(4, []byte("data")), path, runDownloadLimits{
+		MaxBytes:         4,
+		DiskReserveBytes: 10,
+	}, func(string) (int64, error) {
+		checks++
+		if checks == 1 {
+			return 100, nil
+		}
+		return 10, nil
+	})
+	var localErr runDownloadLocalError
+	if stage != nil || !errors.As(err, &localErr) || !strings.Contains(localErr.Error(), "insufficient disk") {
+		t.Fatalf("stage=%#v err=%v local=%v", stage, err, localErr)
+	}
+	if checks < 2 {
+		t.Fatalf("available disk checks=%d want at least 2", checks)
+	}
+	assertRunDownloadDestinationAndTemps(t, path, "keep")
+}
+
+func TestRunDownloadReserveWriterClassifiesPartialWriteFailure(t *testing.T) {
+	wantErr := errors.New("write failed")
+	writer := &runDownloadReserveWriter{
+		writer: runDownloadWriterFunc(func([]byte) (int, error) {
+			return 2, wantErr
+		}),
+		path:    ".",
+		reserve: 10,
+		available: func(string) (int64, error) {
+			return 100, nil
+		},
+	}
+	written, err := writer.Write([]byte("data"))
+	var localErr runDownloadLocalError
+	if written != 2 || !errors.As(err, &localErr) || localErr.Error() != wantErr.Error() {
+		t.Fatalf("written=%d err=%v local=%v", written, err, localErr)
+	}
+}
+
+type runDownloadWriterFunc func([]byte) (int, error)
+
+func (write runDownloadWriterFunc) Write(data []byte) (int, error) {
+	return write(data)
 }
 
 func encodedRunDownload(advertised int64, payload []byte) io.Reader {

--- a/internal/cli/run_download_test.go
+++ b/internal/cli/run_download_test.go
@@ -333,12 +333,16 @@ func (write runDownloadWriterFunc) Write(data []byte) (int, error) {
 }
 
 func encodedRunDownload(advertised int64, payload []byte) io.Reader {
+	return strings.NewReader(encodedRunDownloadPayload(advertised, payload))
+}
+
+func encodedRunDownloadPayload(advertised int64, payload []byte) string {
 	var data bytes.Buffer
 	fmt.Fprintf(&data, "%s%8d\n", remoteDownloadHeaderPrefix, advertised)
 	encoder := base64.NewEncoder(base64.StdEncoding, &data)
 	_, _ = encoder.Write(payload)
 	_ = encoder.Close()
-	return &data
+	return data.String()
 }
 
 type cancelingRunDownloadReader struct {

--- a/internal/cli/run_failure.go
+++ b/internal/cli/run_failure.go
@@ -360,7 +360,7 @@ func printRunFailureDigest(w io.Writer, input runFailureDigestInput) {
 	printFailureDigestPhases(w, input.Phases)
 	printFailureDigestShellChain(w, input)
 	printFailureDigestResults(w, input.Results)
-	for _, command := range failureDigestNextCommands(input, retry) {
+	for _, command := range classifiedFailureDigestNextCommands(input, retry) {
 		fmt.Fprintf(w, "  next: %s\n", command)
 	}
 }
@@ -463,6 +463,13 @@ func failureDigestNextCommands(input runFailureDigestInput, retry string) []stri
 		commands = append(commands, firstNonBlank(input.StopCommand, stopRouting.ShellCommand(append(append([]string{"crabbox", "stop"}, stopRouting.Args...), leaseRef))))
 	}
 	return commands
+}
+
+func classifiedFailureDigestNextCommands(input runFailureDigestInput, retry string) []string {
+	if retry != "true" {
+		retry = "false"
+	}
+	return failureDigestNextCommands(input, retry)
 }
 
 func failureDigestRetryCommand(input runFailureDigestInput) string {

--- a/internal/cli/run_failure_test.go
+++ b/internal/cli/run_failure_test.go
@@ -491,11 +491,13 @@ func TestPrintRunFailureDigest(t *testing.T) {
 		"area: user_command",
 		"next: crabbox logs run_123 --tail 80",
 		"next: crabbox doctor --from-run run_123",
-		"next: crabbox run --id blue-lobster --fresh-sync -- go test ./...",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("digest missing %q:\n%s", want, out)
 		}
+	}
+	if strings.Contains(out, "next: crabbox run ") {
+		t.Fatalf("unknown failure advertised a blind rerun:\n%s", out)
 	}
 }
 
@@ -513,7 +515,6 @@ func TestPrintRunFailureDigestExplainsUnavailableRunHistory(t *testing.T) {
 	for _, want := range []string{
 		"run_history: unavailable",
 		"next: crabbox ssh --id blue-lobster",
-		"next: crabbox run --id blue-lobster --fresh-sync -- go test ./...",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("digest missing %q:\n%s", want, out)
@@ -523,6 +524,7 @@ func TestPrintRunFailureDigestExplainsUnavailableRunHistory(t *testing.T) {
 		"crabbox logs run_",
 		"crabbox events run_",
 		"crabbox doctor --from-run run_",
+		"next: crabbox run ",
 	} {
 		if strings.Contains(out, unexpected) {
 			t.Fatalf("digest should not include run-based command %q:\n%s", unexpected, out)
@@ -553,15 +555,15 @@ func TestFailureDigestNextCommandsRespectRunHistoryAvailability(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			commands := failureDigestNextCommands(runFailureDigestInput{
+			commands := classifiedFailureDigestNextCommands(runFailureDigestInput{
 				Provider:              "local-container",
 				LeaseID:               "cbx_123",
 				Slug:                  "retained-direct",
 				RunID:                 tt.runID,
 				RunHistoryUnavailable: tt.historyUnavailable,
 				CommandDisplay:        "go test ./...",
-				Classification:        FailureClassification{RetryLikely: "unknown"},
-			}, "unknown")
+				Classification:        FailureClassification{RetryLikely: "true"},
+			}, "true")
 			joined := strings.Join(commands, "\n")
 			for _, command := range historyCommands {
 				if got := strings.Contains(joined, command); got != tt.wantHistory {
@@ -572,6 +574,32 @@ func TestFailureDigestNextCommandsRespectRunHistoryAvailability(t *testing.T) {
 				if !strings.Contains(joined, command) {
 					t.Fatalf("lease recovery command missing %q:\n%s", command, joined)
 				}
+			}
+		})
+	}
+}
+
+func TestFailureDigestRetryAdviceByClassification(t *testing.T) {
+	for _, test := range []struct {
+		retry   string
+		wantRun bool
+	}{
+		{retry: "true", wantRun: true},
+		{retry: "false"},
+		{retry: "unknown"},
+	} {
+		t.Run(test.retry, func(t *testing.T) {
+			commands := classifiedFailureDigestNextCommands(runFailureDigestInput{
+				LeaseID:        "cbx_123",
+				RunID:          "run_123",
+				CommandDisplay: "go test ./...",
+			}, test.retry)
+			joined := strings.Join(commands, "\n")
+			if got := strings.Contains(joined, "crabbox run "); got != test.wantRun {
+				t.Fatalf("retry=%s run advice=%t want=%t:\n%s", test.retry, got, test.wantRun, joined)
+			}
+			if !strings.Contains(joined, "crabbox doctor --from-run run_123") {
+				t.Fatalf("retry=%s lost run-scoped diagnosis:\n%s", test.retry, joined)
 			}
 		})
 	}
@@ -629,7 +657,7 @@ func TestPrintRunFailureDigestExplainsAndChainShortCircuit(t *testing.T) {
 		LeaseID:        "cbx_123",
 		CommandDisplay: "pnpm check && pnpm test",
 		ShellMode:      true,
-		Classification: FailureClassification{BlockedStage: "unknown", RetryLikely: "unknown"},
+		Classification: FailureClassification{BlockedStage: "unknown", RetryLikely: "true"},
 	})
 	out := buf.String()
 	for _, want := range []string{
@@ -724,8 +752,8 @@ func TestFailureDigestSuppressesScriptRetryCommand(t *testing.T) {
 		LeaseID:        "cbx_123",
 		CommandDisplay: "'--script=./smoke test.sh' arg",
 		ScriptMode:     true,
-		Classification: FailureClassification{RetryLikely: "unknown"},
-	}, "unknown")
+		Classification: FailureClassification{RetryLikely: "true"},
+	}, "true")
 	for _, command := range commands {
 		if strings.Contains(command, "crabbox run") {
 			t.Fatalf("script retry command should be suppressed: %v", commands)
@@ -768,7 +796,7 @@ func TestFailureDigestPreservesRecoveryIntent(t *testing.T) {
 			}
 			routing := CommandRouting{Args: []string{"--provider", "local-container", "--local-container-runtime", "docker"}}
 			input := runFailureDigestInput{LeaseID: "cbx_fixture", CommandDisplay: display, ShellMode: tc.shell, ScriptMode: tc.script, LeaseStopped: tc.stopped, NoSync: tc.noSync, RequiredArtifactGlobs: tc.globs, Routing: routing}
-			retry := "unknown"
+			retry := "true"
 			if tc.noRetry {
 				retry = "false"
 			}
@@ -830,9 +858,9 @@ func TestFailureDigestRoutesNextCommands(t *testing.T) {
 		WindowsMode:    windowsModeWSL2,
 		LeaseID:        "cbx_123",
 		CommandDisplay: "go test ./...",
-		Classification: FailureClassification{RetryLikely: "unknown"},
+		Classification: FailureClassification{RetryLikely: "true"},
 		StopCommand:    "crabbox stop --provider aws --target windows --windows-mode wsl2 cbx_123",
-	}, "unknown")
+	}, "true")
 	joined := strings.Join(commands, "\n")
 	for _, want := range []string{
 		"crabbox ssh --provider aws --target windows --windows-mode wsl2 --id cbx_123",
@@ -854,9 +882,9 @@ func TestFailureDigestRoutesProviderArgsToSSH(t *testing.T) {
 		Routing:        CommandRoutingFor(cfg, "cbx_123", CommandRoutingRetry),
 		SSHRouting:     CommandRoutingFor(cfg, "cbx_123", CommandRoutingRetry),
 		StopRouting:    CommandRoutingFor(cfg, "cbx_123", CommandRoutingStop),
-		Classification: FailureClassification{RetryLikely: "unknown"},
+		Classification: FailureClassification{RetryLikely: "true"},
 		StopCommand:    "crabbox stop --provider proxmox --proxmox-api-url https://pve.example cbx_123",
-	}, "unknown")
+	}, "true")
 	if len(commands) < 3 {
 		t.Fatalf("commands=%v", commands)
 	}
@@ -887,8 +915,8 @@ func TestFailureDigestPreservesInheritedKubeconfigForKubeVirt(t *testing.T) {
 		Routing:        CommandRoutingFor(cfg, "cbx_123", CommandRoutingRetry),
 		SSHRouting:     CommandRoutingFor(cfg, "cbx_123", CommandRoutingRetry),
 		StopRouting:    CommandRoutingFor(cfg, "cbx_123", CommandRoutingStop),
-		Classification: FailureClassification{RetryLikely: "unknown"},
-	}, "unknown")
+		Classification: FailureClassification{RetryLikely: "true"},
+	}, "true")
 	joined := strings.Join(commands, "\n")
 	for _, want := range []string{
 		"KUBECONFIG='/tmp/base.yaml:/tmp/cluster.yaml' crabbox ssh --provider kubevirt",
@@ -929,8 +957,8 @@ func TestFailureDigestPreservesSealosRouting(t *testing.T) {
 		Routing:        CommandRoutingFor(cfg, "cbx_123", CommandRoutingRetry),
 		SSHRouting:     CommandRoutingFor(cfg, "cbx_123", CommandRoutingRetry),
 		StopRouting:    CommandRoutingFor(cfg, "cbx_123", CommandRoutingStop),
-		Classification: FailureClassification{RetryLikely: "unknown"},
-	}, "unknown")
+		Classification: FailureClassification{RetryLikely: "true"},
+	}, "true")
 	joined := strings.Join(commands, "\n")
 	for _, want := range []string{
 		"KUBECONFIG='/tmp/base.yaml:/tmp/cluster.yaml' crabbox ssh --provider sealos-devbox",

--- a/internal/cli/run_local_output_unix.go
+++ b/internal/cli/run_local_output_unix.go
@@ -88,6 +88,10 @@ func writePrivateRunOutputFile(path string, data []byte) error {
 	return nil
 }
 
+func replacePrivateRunOutputTemp(tempPath, path string) error {
+	return os.Rename(tempPath, path)
+}
+
 func createPrivateRunOutputTemp(path string) (*os.File, string, error) {
 	dir := filepath.Dir(path)
 	file, err := os.CreateTemp(dir, "."+filepath.Base(path)+".crabbox-*")

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -1345,6 +1345,8 @@ while IFS= read -r path; do
 done < "$files.sorted" > "$archive_list"
 metadata=(.crabbox/capture-manifest.txt)
 if [ -f "$gateway_tail" ]; then metadata+=(.crabbox/gateway-log-tail.txt); fi
+capture_require_space scratch "$scratch"
+capture_require_space output "$out_dir"
 raw_archive="$scratch/capture.tar"
 (
   capture_apply_file_limit

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -858,20 +858,27 @@ func captureFailureArtifacts(ctx context.Context, target SSHTarget, workdir, lea
 	}
 	name := safeCaptureName(firstNonBlank(runID, leaseID, "run")) + "-" + time.Now().UTC().Format("20060102T150405Z") + ".tar.gz"
 	remotePath := ".crabbox/" + name
-	if out, err := runSSHCombinedOutput(ctx, target, remoteFailureCaptureCommand(workdir, remotePath, meta.RemoteScriptPath)); err != nil {
+	out, prepareErr := runSSHCombinedOutput(ctx, target, remoteFailureCaptureCommand(workdir, remotePath, meta.RemoteScriptPath))
+	if prepareErr != nil {
+		if remoteFailureCaptureOwned(out, remotePath) {
+			cleanupOut, cleanupErr := cleanupRemoteFailureCapture(ctx, target, workdir, remotePath, runSSHCombinedOutput)
+			if cleanupErr != nil {
+				out = strings.TrimSpace(out) + "; remote cleanup: " + cleanupErr.Error() + ": " + strings.TrimSpace(cleanupOut)
+			}
+		}
 		local, bytes, bundleErr := writeLocalFailureBundle(name, "", meta)
 		if bundleErr != nil {
-			return local, bytes, exit(7, "capture-on-fail prepare: %v: %s; local bundle: %v", err, strings.TrimSpace(out), bundleErr)
+			return local, bytes, exit(7, "capture-on-fail prepare: %v: %s; local bundle: %v", prepareErr, strings.TrimSpace(out), bundleErr)
 		}
-		return local, bytes, exit(7, "capture-on-fail prepare: %v: %s", err, strings.TrimSpace(out))
+		return local, bytes, exit(7, "capture-on-fail prepare: %v: %s", prepareErr, strings.TrimSpace(out))
 	}
 	defer func() {
-		if out, cleanupErr := runSSHCombinedOutput(ctx, target, remoteRemoveFailureCaptureCommand(workdir, remotePath)); cleanupErr != nil && err == nil {
+		if out, cleanupErr := cleanupRemoteFailureCapture(ctx, target, workdir, remotePath, runSSHCombinedOutput); cleanupErr != nil && err == nil {
 			err = exit(7, "capture-on-fail remote cleanup: %v: %s", cleanupErr, strings.TrimSpace(out))
 		}
 	}()
 	remoteLocalPath := filepath.Join(os.TempDir(), safeCaptureName(firstNonBlank(runID, leaseID, "run"))+"-remote-"+name)
-	_, remoteLocal, downloadErr := downloadRemoteFile(ctx, target, workdir, remotePath+"="+remoteLocalPath)
+	_, remoteLocal, downloadErr := downloadRemoteFileWithLimits(ctx, target, workdir, remotePath+"="+remoteLocalPath, failureCaptureDownloadLimits)
 	if downloadErr != nil {
 		local, bytes, bundleErr := writeLocalFailureBundle(name, "", meta)
 		if bundleErr != nil {
@@ -1237,16 +1244,32 @@ func remoteFailureCaptureCommand(workdir, remotePath, scriptPath string) string 
 	script.WriteString("mkdir -p .crabbox\n")
 	script.WriteString("out=" + shellQuote(remotePath) + "\n")
 	script.WriteString("script=" + shellQuote(scriptPath) + "\n")
-	script.WriteString(`manifest=.crabbox/capture-manifest.txt
-files=.crabbox/capture-files.txt
+	script.WriteString(`if [ -e "$out" ] || [ -L "$out" ]; then
+  printf 'failure capture destination already exists: %s\n' "$out" >&2
+  exit 7
+fi
+scratch=$(mktemp -d "${TMPDIR:-/tmp}/crabbox-failure-capture.XXXXXX")
+cleanup_capture_scratch() {
+  status=$?
+  trap - EXIT HUP INT TERM
+  if [ "$status" -ne 0 ]; then rm -f -- "$out" || true; fi
+  rm -rf -- "$scratch" || true
+}
+trap cleanup_capture_scratch EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+printf '` + remoteFailureCaptureOwnedPrefix + `%s\n' "$out"
+mkdir -p "$scratch/.crabbox"
+manifest="$scratch/.crabbox/capture-manifest.txt"
+files="$scratch/capture-files.txt"
 {
   printf 'captured_at=%s\n' "$(date -Is 2>/dev/null || date)"
   printf 'host=%s\n' "$(hostname 2>/dev/null || printf unknown)"
   printf 'pwd=%s\n' "$(pwd -P 2>/dev/null || pwd)"
   printf 'note=%s\n' 'local-only failure capture; caller owns redaction before sharing'
 } > "$manifest"
-gateway_tail=.crabbox/gateway-log-tail.txt
-rm -f "$gateway_tail"
+gateway_tail="$scratch/.crabbox/gateway-log-tail.txt"
 for path in /tmp/crabbox-gateway.log /tmp/gateway.log gateway.log logs/gateway.log .crabbox/gateway.log; do
   if [ -f "$path" ]; then
     tail -n 400 "$path" > "$gateway_tail" 2>/dev/null || true
@@ -1257,7 +1280,7 @@ done
 if [ -n "$script" ] && [ -f "$script" ] && [ ! -L "$script" ]; then
   printf '%s\n' "$script" >> "$files"
 fi
-for path in test-results playwright-report coverage junit.xml results.xml .crabbox/capture-manifest.txt .crabbox/gateway-log-tail.txt; do
+for path in test-results playwright-report coverage junit.xml results.xml; do
   if [ -e "$path" ]; then printf '%s\n' "$path" >> "$files"; fi
 done
 find . -maxdepth 3 -path './.crabbox/scripts' -prune -o \
@@ -1267,7 +1290,19 @@ find . -maxdepth 3 -path './.crabbox/scripts' -prune -o \
   ! -path './coverage/*' \
   -print 2>/dev/null | sed 's#^\./##' >> "$files" || true
 sort -u "$files" > "$files.sorted"
-tar -czf "$out" -T "$files.sorted" 2>/dev/null || tar -czf "$out" "$manifest"
+archive_list="$scratch/archive-files.txt"
+checkout=$(pwd -P 2>/dev/null || pwd)
+{
+  printf '%s\n' -C "$checkout"
+while IFS= read -r path; do
+  case "$path" in -*) path="./$path";; esac
+    printf '%s\n' "$path"
+done < "$files.sorted"
+  printf '%s\n' -C "$scratch" .crabbox/capture-manifest.txt
+  if [ -f "$gateway_tail" ]; then printf '%s\n' .crabbox/gateway-log-tail.txt; fi
+} > "$archive_list"
+COPYFILE_DISABLE=1 tar -czf "$out" -T "$archive_list" 2>/dev/null ||
+  COPYFILE_DISABLE=1 tar -czf "$out" -C "$scratch" .crabbox/capture-manifest.txt
 printf '%s\n' "$out"
 `)
 	return "bash -lc " + shellQuote(script.String())
@@ -1276,6 +1311,29 @@ printf '%s\n' "$out"
 func remoteRemoveFailureCaptureCommand(workdir, remotePath string) string {
 	script := "set -eu\ncd " + shellQuote(workdir) + "\nrm -f -- " + shellQuote(remotePath)
 	return "bash -lc " + shellQuote(script)
+}
+
+const (
+	remoteFailureCaptureOwnedPrefix = "CRABBOX_FAILURE_CAPTURE_OWNED="
+	remoteFailureCaptureCleanupTime = 10 * time.Second
+)
+
+type remoteFailureCaptureRunner func(context.Context, SSHTarget, string) (string, error)
+
+func remoteFailureCaptureOwned(output, remotePath string) bool {
+	want := remoteFailureCaptureOwnedPrefix + remotePath
+	for _, line := range strings.Split(output, "\n") {
+		if strings.TrimSpace(line) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func cleanupRemoteFailureCapture(ctx context.Context, target SSHTarget, workdir, remotePath string, run remoteFailureCaptureRunner) (string, error) {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), remoteFailureCaptureCleanupTime)
+	defer cancel()
+	return run(cleanupCtx, target, remoteRemoveFailureCaptureCommand(workdir, remotePath))
 }
 
 func printFailureTail(w io.Writer, label string, tail *streamTailBuffer, capturedPath string) {

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -16,6 +16,7 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -1238,14 +1239,24 @@ func safeCaptureName(value string) string {
 }
 
 func remoteFailureCaptureCommand(workdir, remotePath, scriptPath string) string {
+	return remoteFailureCaptureCommandWithLimits(workdir, remotePath, scriptPath, failureCaptureDownloadLimits)
+}
+
+func remoteFailureCaptureCommandWithLimits(workdir, remotePath, scriptPath string, limits runDownloadLimits) string {
 	var script bytes.Buffer
 	script.WriteString("set -eu\n")
 	script.WriteString("cd " + shellQuote(workdir) + "\n")
 	script.WriteString("mkdir -p .crabbox\n")
 	script.WriteString("out=" + shellQuote(remotePath) + "\n")
 	script.WriteString("script=" + shellQuote(scriptPath) + "\n")
+	script.WriteString("capture_max_bytes=" + strconv.FormatInt(limits.MaxBytes, 10) + "\n")
+	script.WriteString("capture_reserve_bytes=" + strconv.FormatInt(limits.DiskReserveBytes, 10) + "\n")
 	script.WriteString(`if [ -e "$out" ] || [ -L "$out" ]; then
   printf 'failure capture destination already exists: %s\n' "$out" >&2
+  exit 7
+fi
+if [ "$capture_max_bytes" -le 0 ] || [ $((capture_max_bytes % 1024)) -ne 0 ] || [ "$capture_reserve_bytes" -lt 0 ]; then
+  printf 'invalid failure capture limits: max=%s reserve=%s\n' "$capture_max_bytes" "$capture_reserve_bytes" >&2
   exit 7
 fi
 scratch=$(mktemp -d "${TMPDIR:-/tmp}/crabbox-failure-capture.XXXXXX")
@@ -1260,6 +1271,43 @@ trap 'exit 129' HUP
 trap 'exit 130' INT
 trap 'exit 143' TERM
 printf '` + remoteFailureCaptureOwnedPrefix + `%s\n' "$out"
+capture_file_blocks=$((capture_max_bytes / 1024))
+capture_required_blocks=$(((capture_reserve_bytes + 2 * capture_max_bytes + 1023) / 1024))
+capture_require_space() {
+  label=$1
+  path=$2
+  if ! blocks=$(LC_ALL=C df -Pk "$path" 2>/dev/null | awk 'NR == 2 && $4 ~ /^[0-9]+$/ { print $4; found=1; exit } END { if (!found) exit 1 }'); then
+    printf 'failure capture disk availability unknown: %s path=%s\n' "$label" "$path" >&2
+    return 7
+  fi
+  if [ "$blocks" -lt "$capture_required_blocks" ]; then
+    printf 'failure capture disk reserve unavailable: %s path=%s available_blocks=%s required_blocks=%s\n' "$label" "$path" "$blocks" "$capture_required_blocks" >&2
+    return 7
+  fi
+}
+capture_apply_file_limit() {
+  if ! inherited=$(ulimit -Sf 2>/dev/null); then
+    printf 'failure capture file limit unavailable\n' >&2
+    return 7
+  fi
+  case "$inherited" in
+    unlimited) ;;
+    ''|*[!0-9]*)
+      printf 'failure capture file limit unknown: %s\n' "$inherited" >&2
+      return 7
+      ;;
+    *)
+      if [ "$inherited" -lt "$capture_file_blocks" ]; then
+        printf 'failure capture inherited file limit is lower: inherited=%s required=%s\n' "$inherited" "$capture_file_blocks" >&2
+        return 7
+      fi
+      ;;
+  esac
+  ulimit -f "$capture_file_blocks"
+}
+out_dir=$(dirname "$out")
+capture_require_space scratch "$scratch"
+capture_require_space output "$out_dir"
 mkdir -p "$scratch/.crabbox"
 manifest="$scratch/.crabbox/capture-manifest.txt"
 files="$scratch/capture-files.txt"
@@ -1297,8 +1345,19 @@ while IFS= read -r path; do
 done < "$files.sorted" > "$archive_list"
 metadata=(.crabbox/capture-manifest.txt)
 if [ -f "$gateway_tail" ]; then metadata+=(.crabbox/gateway-log-tail.txt); fi
-COPYFILE_DISABLE=1 tar -czf "$out" -C "$checkout" --null -T "$archive_list" -C "$scratch" "${metadata[@]}" 2>/dev/null ||
-  COPYFILE_DISABLE=1 tar -czf "$out" -C "$scratch" .crabbox/capture-manifest.txt
+raw_archive="$scratch/capture.tar"
+(
+  capture_apply_file_limit
+  COPYFILE_DISABLE=1 tar -cf "$raw_archive" -C "$checkout" --null -T "$archive_list" 2>/dev/null
+)
+(
+  capture_apply_file_limit
+  COPYFILE_DISABLE=1 tar -rf "$raw_archive" -C "$scratch" "${metadata[@]}" 2>/dev/null
+)
+(
+  capture_apply_file_limit
+  gzip -c "$raw_archive"
+) > "$out"
 printf '%s\n' "$out"
 `)
 	return "bash -lc " + shellQuote(script.String())

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -1292,16 +1292,12 @@ find . -maxdepth 3 -path './.crabbox/scripts' -prune -o \
 sort -u "$files" > "$files.sorted"
 archive_list="$scratch/archive-files.txt"
 checkout=$(pwd -P 2>/dev/null || pwd)
-{
-  printf '%s\n' -C "$checkout"
 while IFS= read -r path; do
-  case "$path" in -*) path="./$path";; esac
-    printf '%s\n' "$path"
-done < "$files.sorted"
-  printf '%s\n' -C "$scratch" .crabbox/capture-manifest.txt
-  if [ -f "$gateway_tail" ]; then printf '%s\n' .crabbox/gateway-log-tail.txt; fi
-} > "$archive_list"
-COPYFILE_DISABLE=1 tar -czf "$out" -T "$archive_list" 2>/dev/null ||
+  printf '%s\0' "$path"
+done < "$files.sorted" > "$archive_list"
+metadata=(.crabbox/capture-manifest.txt)
+if [ -f "$gateway_tail" ]; then metadata+=(.crabbox/gateway-log-tail.txt); fi
+COPYFILE_DISABLE=1 tar -czf "$out" -C "$checkout" --null -T "$archive_list" -C "$scratch" "${metadata[@]}" 2>/dev/null ||
   COPYFILE_DISABLE=1 tar -czf "$out" -C "$scratch" .crabbox/capture-manifest.txt
 printf '%s\n' "$out"
 `)

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -7250,16 +7250,9 @@ func TestRemoteFailureCaptureRemovesPartialArchiveOnFailure(t *testing.T) {
 	binDir := t.TempDir()
 	t.Setenv("TMPDIR", tempRoot)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	fakeTar := filepath.Join(binDir, "tar")
-	if err := os.WriteFile(fakeTar, []byte(`#!/bin/sh
-previous=
-for argument do
-  if [ "$previous" = "-czf" ]; then
-    printf partial > "$argument"
-    exit 42
-  fi
-  previous=$argument
-done
+	fakeGzip := filepath.Join(binDir, "gzip")
+	if err := os.WriteFile(fakeGzip, []byte(`#!/bin/sh
+printf partial
 exit 42
 `), 0o700); err != nil {
 		t.Fatal(err)
@@ -7291,14 +7284,18 @@ func TestRemoteFailureCaptureKeepsLargeFileListOffArgv(t *testing.T) {
 	if err != nil {
 		t.Skip("tar is required for POSIX capture command test")
 	}
-	tarVersion, _ := exec.Command(realTar, "--version").CombinedOutput()
-	isBSDTar := bytes.Contains(tarVersion, []byte("bsdtar"))
 	workdir := t.TempDir()
 	tempRoot := t.TempDir()
 	binDir := t.TempDir()
 	t.Setenv("TMPDIR", tempRoot)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	const argumentBudget = 1024
+	dfLog := filepath.Join(binDir, "df.log")
+	fakeDF := filepath.Join(binDir, "df")
+	dfScript := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> " + shellQuote(dfLog) + "\nprintf 'Filesystem 1024-blocks Used Available Capacity Mounted on\\nfake 9999999 0 9999999 0%% /\\n'\n"
+	if err := os.WriteFile(fakeDF, []byte(dfScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
 	var fileListBytes int
 	var want []string
 	scriptPath := filepath.Join("scripts", "capture.sh ")
@@ -7332,41 +7329,33 @@ func TestRemoteFailureCaptureKeepsLargeFileListOffArgv(t *testing.T) {
 	fakeTar := filepath.Join(binDir, "tar")
 	wrapper := `#!/bin/sh
 budget=` + strconv.Itoa(argumentBudget) + `
-bsd=` + strconv.FormatBool(isBSDTar) + `
 bytes=0
+mode=
 list=no
 null=no
-output=
-checkout=
-scratch=
-list_path=
+directories=0
+manifest=no
 previous=
 for argument do
   bytes=$((bytes + ${#argument} + 1))
   case "$previous" in
-    -czf) output=$argument ;;
-    -T) list=yes; list_path=$argument ;;
-    -C)
-      if [ -z "$checkout" ]; then checkout=$argument; else scratch=$argument; fi
-      ;;
+    -T) list=yes ;;
+    -C) directories=$((directories + 1)) ;;
   esac
-  if [ "$argument" = "--null" ]; then null=yes; fi
+  case "$argument" in
+    -cf) mode=create ;;
+    -rf) mode=append ;;
+    --null) null=yes ;;
+    .crabbox/capture-manifest.txt) manifest=yes ;;
+  esac
   previous=$argument
 done
 [ "$bytes" -le "$budget" ] || exit 91
-[ "$list" = yes ] || exit 92
-[ "$null" = yes ] || exit 93
-if [ "$bsd" = true ]; then
-  combined="$list_path.bsdtar"
-  manifest="$checkout/.crabbox/capture-manifest.txt"
-  cp "$list_path" "$combined" || exit 94
-  cp "$scratch/.crabbox/capture-manifest.txt" "$manifest" || exit 95
-  printf '%s\0' .crabbox/capture-manifest.txt >> "$combined"
-  ` + shellQuote(realTar) + ` -czf "$output" -C "$checkout" --null -T "$combined"
-  result=$?
-  rm "$combined" "$manifest"
-  exit "$result"
-fi
+case "$mode" in
+  create) [ "$list" = yes ] && [ "$null" = yes ] && [ "$directories" -eq 1 ] || exit 92 ;;
+  append) [ "$list" = no ] && [ "$directories" -eq 1 ] && [ "$manifest" = yes ] || exit 93 ;;
+  *) exit 94 ;;
+esac
 exec ` + shellQuote(realTar) + ` "$@"
 `
 	if err := os.WriteFile(fakeTar, []byte(wrapper), 0o700); err != nil {
@@ -7377,11 +7366,119 @@ exec ` + shellQuote(realTar) + ` "$@"
 	if out, err := exec.Command("bash", "-c", command).CombinedOutput(); err != nil {
 		t.Fatalf("capture command failed: %v\n%s", err, out)
 	}
+	dfCalls, err := os.ReadFile(dfLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(dfCalls)), "\n")
+	if len(lines) != 2 || !strings.Contains(lines[0], tempRoot) || lines[1] != "-Pk .crabbox" {
+		t.Fatalf("disk admission calls=%q", lines)
+	}
 	contents := readTarGzContents(t, filepath.Join(workdir, ".crabbox", "capture.tar.gz"))
 	for _, name := range append(want, ".crabbox/capture-manifest.txt") {
 		if _, ok := contents[name]; !ok {
 			t.Fatalf("capture missing %q", name)
 		}
+	}
+	if entries, err := os.ReadDir(tempRoot); err != nil || len(entries) != 0 {
+		t.Fatalf("failure capture scratch retained: entries=%v err=%v", entries, err)
+	}
+}
+
+func TestRemoteFailureCaptureRejectsLowOrUnknownDiskAdmission(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is required for POSIX capture command test")
+	}
+	for _, test := range []struct {
+		name   string
+		dfBody string
+		want   string
+	}{
+		{
+			name:   "low",
+			dfBody: "printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\\nfake 100 65 35 65%% /\\n'",
+			want:   "required_blocks=36",
+		},
+		{
+			name:   "unknown",
+			dfBody: "printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\\n'",
+			want:   "disk availability unknown",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			workdir := t.TempDir()
+			tempRoot := t.TempDir()
+			binDir := t.TempDir()
+			t.Setenv("TMPDIR", tempRoot)
+			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			fakeDF := filepath.Join(binDir, "df")
+			if err := os.WriteFile(fakeDF, []byte("#!/bin/sh\n"+test.dfBody+"\n"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			command := remoteFailureCaptureCommandWithLimits(workdir, ".crabbox/capture.tar.gz", "", runDownloadLimits{
+				MaxBytes:         16 << 10,
+				DiskReserveBytes: 4 << 10,
+			})
+			command = strings.Replace(command, "bash -lc ", "bash --noprofile --norc -c ", 1)
+			out, err := exec.Command("bash", "-c", command).CombinedOutput()
+			if err == nil || !strings.Contains(string(out), test.want) {
+				t.Fatalf("capture err=%v want=%q:\n%s", err, test.want, out)
+			}
+			assertRemoteFailureCaptureFilesRemoved(t, workdir, tempRoot)
+		})
+	}
+}
+
+func TestRemoteFailureCaptureEnforcesWriterCaps(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is required for POSIX capture command test")
+	}
+	for _, test := range []struct {
+		name       string
+		maxBytes   int64
+		evidence   int
+		fakeGzip   bool
+		lowerLimit bool
+	}{
+		{name: "raw tar", maxBytes: 32 << 10, evidence: 64 << 10},
+		{name: "gzip output", maxBytes: 64 << 10, evidence: 1, fakeGzip: true},
+		{name: "lower inherited limit", maxBytes: 64 << 10, evidence: 1, lowerLimit: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			workdir := t.TempDir()
+			tempRoot := t.TempDir()
+			binDir := t.TempDir()
+			t.Setenv("TMPDIR", tempRoot)
+			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			if err := os.WriteFile(filepath.Join(workdir, "evidence.log"), bytes.Repeat([]byte("x"), test.evidence), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if test.fakeGzip {
+				fakeGzip := filepath.Join(binDir, "gzip")
+				if err := os.WriteFile(fakeGzip, []byte("#!/bin/sh\nexec dd if=/dev/zero bs=1024 count=128 2>/dev/null\n"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			command := remoteFailureCaptureCommandWithLimits(workdir, ".crabbox/capture.tar.gz", "", runDownloadLimits{
+				MaxBytes:         test.maxBytes,
+				DiskReserveBytes: 0,
+			})
+			command = strings.Replace(command, "bash -lc ", "bash --noprofile --norc -c ", 1)
+			if test.lowerLimit {
+				command = "ulimit -f 1; " + command
+			}
+			if out, err := exec.Command("bash", "-c", command).CombinedOutput(); err == nil {
+				t.Fatalf("capture unexpectedly succeeded:\n%s", out)
+			}
+			assertRemoteFailureCaptureFilesRemoved(t, workdir, tempRoot)
+		})
+	}
+}
+
+func assertRemoteFailureCaptureFilesRemoved(t *testing.T, workdir, tempRoot string) {
+	t.Helper()
+	if _, err := os.Lstat(filepath.Join(workdir, ".crabbox", "capture.tar.gz")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("partial capture remains: %v", err)
 	}
 	if entries, err := os.ReadDir(tempRoot); err != nil || len(entries) != 0 {
 		t.Fatalf("failure capture scratch retained: entries=%v err=%v", entries, err)

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -7364,7 +7364,9 @@ exec ` + shellQuote(realTar) + ` "$@"
 		t.Fatal(err)
 	}
 	lines := strings.Split(strings.TrimSpace(string(dfCalls)), "\n")
-	if len(lines) != 2 || !strings.Contains(lines[0], tempRoot) || lines[1] != "-Pk .crabbox" {
+	if len(lines) != 4 ||
+		!strings.Contains(lines[0], tempRoot) || lines[2] != lines[0] ||
+		lines[1] != "-Pk .crabbox" || lines[3] != lines[1] {
 		t.Fatalf("disk admission calls=%q", lines)
 	}
 	contents := readTarGzContents(t, filepath.Join(workdir, ".crabbox", "capture.tar.gz"))

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3281,12 +3281,13 @@ func TestRunCommandRequireArtifactFailsAfterSuccessfulCommand(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	downloaded := []byte("downloaded\n")
 	script := `#!/bin/sh
 cmd=""
 for arg do cmd="$arg"; done
 printf '%s\n---\n' "$cmd" >> "$CRABBOX_FAKE_SSH_LOG"
 case "$cmd" in
-  *"base64 <"*) printf 'ZG93bmxvYWRlZAo='; exit 0 ;;
+  *"base64 <"*) printf '%s' ` + shellQuote(encodedRunDownloadPayload(int64(len(downloaded)), downloaded)) + `; exit 0 ;;
   *"check_artifact_file()"*) printf 'missing required artifact: reports/data/manifest.json\n' >&2; exit 8 ;;
   *"fixture-stage-success"*) printf 'CRABBOX_PHASE:install\npnpm install --package-import-method=copy completed\nCRABBOX_PHASE:test\n'; exit 0 ;;
 esac
@@ -3331,19 +3332,11 @@ exit 0
 	if !strings.Contains(stderr.String(), "keep-on-failure: kept lease=cbx_env_profile_test") {
 		t.Fatalf("missing keep-on-failure hint after required artifact failure:\n%s", stderr.String())
 	}
-	retryHints := 0
-	for _, line := range strings.Split(stderr.String(), "\n") {
-		if strings.Contains(line, "next: crabbox run ") {
-			retryHints++
-			if !strings.Contains(line, "--no-sync") || strings.Contains(line, "--fresh-sync") ||
-				!strings.Contains(line, "--require-artifact reports/data/manifest.json") ||
-				!strings.Contains(line, "--require-artifact 'reports/proof-*.json'") {
-				t.Errorf("retry lost no-sync or required-artifact intent: %s", line)
-			}
-		}
+	if strings.Contains(stderr.String(), "next: crabbox run ") {
+		t.Fatalf("unknown artifact failure advertised a blind rerun:\n%s", stderr.String())
 	}
-	if retryHints != 1 {
-		t.Errorf("retry hints=%d, want one runnable recovery", retryHints)
+	if !strings.Contains(stderr.String(), "next: crabbox ssh --provider run-env-profile-test --target linux --id cbx_env_profile_test") {
+		t.Fatalf("unknown artifact failure omitted lease-scoped diagnosis:\n%s", stderr.String())
 	}
 	lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
 	var report TimingReport
@@ -7427,6 +7420,67 @@ func TestRemoteFailureCaptureRejectsLowOrUnknownDiskAdmission(t *testing.T) {
 			assertRemoteFailureCaptureFilesRemoved(t, workdir, tempRoot)
 		})
 	}
+}
+
+func TestRemoteFailureCaptureRechecksDiskAdmissionAfterScratchInputs(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is required for POSIX capture command test")
+	}
+	workdir := t.TempDir()
+	tempRoot := t.TempDir()
+	binDir := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	dfCalls := filepath.Join(binDir, "df.calls")
+	fakeDF := filepath.Join(binDir, "df")
+	dfScript := `#!/bin/sh
+calls=0
+if [ -f "$CRABBOX_TEST_DF_CALLS" ]; then calls=$(cat "$CRABBOX_TEST_DF_CALLS"); fi
+calls=$((calls + 1))
+printf '%s\n' "$calls" > "$CRABBOX_TEST_DF_CALLS"
+available=9999999
+if [ "$calls" -eq 4 ]; then available=35; fi
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+printf 'fake 9999999 0 %s 0%% /\n' "$available"
+`
+	if err := os.WriteFile(fakeDF, []byte(dfScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writerLog := filepath.Join(binDir, "writers.log")
+	for _, name := range []string{"tar", "gzip"} {
+		path := filepath.Join(binDir, name)
+		script := "#!/bin/sh\nprintf '%s\\n' " + shellQuote(name) + " >> \"$CRABBOX_TEST_WRITER_LOG\"\nexit 99\n"
+		if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("CRABBOX_TEST_DF_CALLS", dfCalls)
+	t.Setenv("CRABBOX_TEST_WRITER_LOG", writerLog)
+	if err := os.WriteFile(filepath.Join(workdir, "evidence.log"), []byte("evidence"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	command := remoteFailureCaptureCommandWithLimits(workdir, ".crabbox/capture.tar.gz", "", runDownloadLimits{
+		MaxBytes:         16 << 10,
+		DiskReserveBytes: 4 << 10,
+	})
+	command = strings.Replace(command, "bash -lc ", "bash --noprofile --norc -c ", 1)
+	out, err := exec.Command("bash", "-c", command).CombinedOutput()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 7 {
+		t.Fatalf("capture exit=%v want=7:\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "failure capture disk reserve unavailable: output") {
+		t.Fatalf("capture did not fail the late output admission:\n%s", out)
+	}
+	if calls, readErr := os.ReadFile(dfCalls); readErr != nil || string(calls) != "4\n" {
+		t.Fatalf("disk admission calls=%q err=%v, want four", calls, readErr)
+	}
+	if writers, readErr := os.ReadFile(writerLog); !errors.Is(readErr, os.ErrNotExist) {
+		t.Fatalf("archive writer ran before late admission: %q err=%v", writers, readErr)
+	}
+	assertRemoteFailureCaptureFilesRemoved(t, workdir, tempRoot)
 }
 
 func TestRemoteFailureCaptureEnforcesWriterCaps(t *testing.T) {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -7291,14 +7291,33 @@ func TestRemoteFailureCaptureKeepsLargeFileListOffArgv(t *testing.T) {
 	if err != nil {
 		t.Skip("tar is required for POSIX capture command test")
 	}
+	tarVersion, _ := exec.Command(realTar, "--version").CombinedOutput()
+	isBSDTar := bytes.Contains(tarVersion, []byte("bsdtar"))
 	workdir := t.TempDir()
 	tempRoot := t.TempDir()
 	binDir := t.TempDir()
 	t.Setenv("TMPDIR", tempRoot)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	const argumentBudget = 256
+	const argumentBudget = 1024
 	var fileListBytes int
 	var want []string
+	scriptPath := filepath.Join("scripts", "capture.sh ")
+	for _, name := range []string{
+		"-leading-dash.log",
+		`back\slash.log`,
+		" leading-whitespace.log",
+		scriptPath,
+	} {
+		path := filepath.Join(workdir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(name), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		fileListBytes += len(name) + 1
+		want = append(want, name)
+	}
 	for i := range 40 {
 		name := fmt.Sprintf("evidence-%02d-%s.log", i, strings.Repeat("x", 64))
 		if err := os.WriteFile(filepath.Join(workdir, name), []byte(name), 0o600); err != nil {
@@ -7313,22 +7332,47 @@ func TestRemoteFailureCaptureKeepsLargeFileListOffArgv(t *testing.T) {
 	fakeTar := filepath.Join(binDir, "tar")
 	wrapper := `#!/bin/sh
 budget=` + strconv.Itoa(argumentBudget) + `
+bsd=` + strconv.FormatBool(isBSDTar) + `
 bytes=0
 list=no
+null=no
+output=
+checkout=
+scratch=
+list_path=
 previous=
 for argument do
   bytes=$((bytes + ${#argument} + 1))
-  if [ "$previous" = "-T" ]; then list=yes; fi
+  case "$previous" in
+    -czf) output=$argument ;;
+    -T) list=yes; list_path=$argument ;;
+    -C)
+      if [ -z "$checkout" ]; then checkout=$argument; else scratch=$argument; fi
+      ;;
+  esac
+  if [ "$argument" = "--null" ]; then null=yes; fi
   previous=$argument
 done
 [ "$bytes" -le "$budget" ] || exit 91
 [ "$list" = yes ] || exit 92
+[ "$null" = yes ] || exit 93
+if [ "$bsd" = true ]; then
+  combined="$list_path.bsdtar"
+  manifest="$checkout/.crabbox/capture-manifest.txt"
+  cp "$list_path" "$combined" || exit 94
+  cp "$scratch/.crabbox/capture-manifest.txt" "$manifest" || exit 95
+  printf '%s\0' .crabbox/capture-manifest.txt >> "$combined"
+  ` + shellQuote(realTar) + ` -czf "$output" -C "$checkout" --null -T "$combined"
+  result=$?
+  rm "$combined" "$manifest"
+  exit "$result"
+fi
 exec ` + shellQuote(realTar) + ` "$@"
 `
 	if err := os.WriteFile(fakeTar, []byte(wrapper), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	command := remoteFailureCaptureCommand(workdir, ".crabbox/capture.tar.gz", "")
+	command := remoteFailureCaptureCommand(workdir, ".crabbox/capture.tar.gz", scriptPath)
 	command = strings.Replace(command, "bash -lc ", "bash --noprofile --norc -c ", 1)
 	if out, err := exec.Command("bash", "-c", command).CombinedOutput(); err != nil {
 		t.Fatalf("capture command failed: %v\n%s", err, out)

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -7160,6 +7161,213 @@ func TestRemoteFailureCaptureCommandAvoidsDuplicateDirectoryChildren(t *testing.
 	}
 	if counts["test-results/failure.log"] != 1 {
 		t.Fatalf("test-results/failure.log count=%d entries=%#v", counts["test-results/failure.log"], counts)
+	}
+}
+
+func TestRemoteFailureCaptureLeavesCheckoutStatusUnchanged(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is required for POSIX capture command test")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required for checkout cleanliness test")
+	}
+	workdir := t.TempDir()
+	tempRoot := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+	if out, err := exec.Command("git", "-C", workdir, "init", "-q").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	for name, data := range map[string]string{
+		".crabbox/capture-manifest.txt":     "user manifest",
+		".crabbox/capture-files.txt.sorted": "user sorted list",
+		".crabbox/gateway-log-tail.txt":     "user gateway tail",
+		"test-results/failure.log":          "failure",
+		"user-target.txt":                   "user target",
+	} {
+		path := filepath.Join(workdir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	link := filepath.Join(workdir, ".crabbox", "capture-files.txt")
+	if err := os.Symlink("../user-target.txt", link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	status := func() string {
+		t.Helper()
+		cmd := exec.Command("git", "-C", workdir, "status", "--porcelain=v1", "--untracked-files=all")
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(out)
+	}
+	before := status()
+	command := remoteFailureCaptureCommand(workdir, ".crabbox/run-capture.tar.gz", "")
+	if out, err := exec.Command("bash", "-lc", command).CombinedOutput(); err != nil {
+		t.Fatalf("capture command failed: %v\n%s", err, out)
+	}
+	archive := filepath.Join(workdir, ".crabbox", "run-capture.tar.gz")
+	contents := readTarGzContents(t, archive)
+	if manifest := contents[".crabbox/capture-manifest.txt"]; !bytes.Contains(manifest, []byte("captured_at=")) || bytes.Contains(manifest, []byte("user manifest")) {
+		t.Fatalf("capture metadata=%q", manifest)
+	}
+	cleanup := remoteRemoveFailureCaptureCommand(workdir, ".crabbox/run-capture.tar.gz")
+	if out, err := exec.Command("bash", "-lc", cleanup).CombinedOutput(); err != nil {
+		t.Fatalf("capture cleanup failed: %v\n%s", err, out)
+	}
+	if after := status(); after != before {
+		t.Fatalf("failure capture changed checkout status:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+	for name, want := range map[string]string{
+		".crabbox/capture-manifest.txt":     "user manifest",
+		".crabbox/capture-files.txt.sorted": "user sorted list",
+		".crabbox/gateway-log-tail.txt":     "user gateway tail",
+		"user-target.txt":                   "user target",
+	} {
+		data, err := os.ReadFile(filepath.Join(workdir, filepath.FromSlash(name)))
+		if err != nil || string(data) != want {
+			t.Fatalf("user path %s=%q err=%v", name, data, err)
+		}
+	}
+	if target, err := os.Readlink(link); err != nil || target != "../user-target.txt" {
+		t.Fatalf("user symlink target=%q err=%v", target, err)
+	}
+	if entries, err := os.ReadDir(tempRoot); err != nil || len(entries) != 0 {
+		t.Fatalf("failure capture scratch retained: entries=%v err=%v", entries, err)
+	}
+}
+
+func TestRemoteFailureCaptureRemovesPartialArchiveOnFailure(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is required for POSIX capture command test")
+	}
+	workdir := t.TempDir()
+	tempRoot := t.TempDir()
+	binDir := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	fakeTar := filepath.Join(binDir, "tar")
+	if err := os.WriteFile(fakeTar, []byte(`#!/bin/sh
+previous=
+for argument do
+  if [ "$previous" = "-czf" ]; then
+    printf partial > "$argument"
+    exit 42
+  fi
+  previous=$argument
+done
+exit 42
+`), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	command := remoteFailureCaptureCommand(workdir, ".crabbox/capture.tar.gz", "")
+	command = strings.Replace(command, "bash -lc ", "bash --noprofile --norc -c ", 1)
+	out, err := exec.Command("bash", "-c", command).CombinedOutput()
+	if err == nil {
+		t.Fatalf("capture unexpectedly succeeded:\n%s", out)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 42 {
+		t.Fatalf("capture exit=%v want=42:\n%s", err, out)
+	}
+	archive := filepath.Join(workdir, ".crabbox", "capture.tar.gz")
+	if _, err := os.Lstat(archive); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("partial capture remains at %s: %v", archive, err)
+	}
+	if entries, err := os.ReadDir(tempRoot); err != nil || len(entries) != 0 {
+		t.Fatalf("failure capture scratch retained: entries=%v err=%v", entries, err)
+	}
+}
+
+func TestRemoteFailureCaptureKeepsLargeFileListOffArgv(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is required for POSIX capture command test")
+	}
+	realTar, err := exec.LookPath("tar")
+	if err != nil {
+		t.Skip("tar is required for POSIX capture command test")
+	}
+	workdir := t.TempDir()
+	tempRoot := t.TempDir()
+	binDir := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	const argumentBudget = 256
+	var fileListBytes int
+	var want []string
+	for i := range 40 {
+		name := fmt.Sprintf("evidence-%02d-%s.log", i, strings.Repeat("x", 64))
+		if err := os.WriteFile(filepath.Join(workdir, name), []byte(name), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		fileListBytes += len(name) + 1
+		want = append(want, name)
+	}
+	if fileListBytes <= argumentBudget {
+		t.Fatalf("file-list fixture bytes=%d want>%d", fileListBytes, argumentBudget)
+	}
+	fakeTar := filepath.Join(binDir, "tar")
+	wrapper := `#!/bin/sh
+budget=` + strconv.Itoa(argumentBudget) + `
+bytes=0
+list=no
+previous=
+for argument do
+  bytes=$((bytes + ${#argument} + 1))
+  if [ "$previous" = "-T" ]; then list=yes; fi
+  previous=$argument
+done
+[ "$bytes" -le "$budget" ] || exit 91
+[ "$list" = yes ] || exit 92
+exec ` + shellQuote(realTar) + ` "$@"
+`
+	if err := os.WriteFile(fakeTar, []byte(wrapper), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	command := remoteFailureCaptureCommand(workdir, ".crabbox/capture.tar.gz", "")
+	command = strings.Replace(command, "bash -lc ", "bash --noprofile --norc -c ", 1)
+	if out, err := exec.Command("bash", "-c", command).CombinedOutput(); err != nil {
+		t.Fatalf("capture command failed: %v\n%s", err, out)
+	}
+	contents := readTarGzContents(t, filepath.Join(workdir, ".crabbox", "capture.tar.gz"))
+	for _, name := range append(want, ".crabbox/capture-manifest.txt") {
+		if _, ok := contents[name]; !ok {
+			t.Fatalf("capture missing %q", name)
+		}
+	}
+	if entries, err := os.ReadDir(tempRoot); err != nil || len(entries) != 0 {
+		t.Fatalf("failure capture scratch retained: entries=%v err=%v", entries, err)
+	}
+}
+
+func TestCleanupRemoteFailureCaptureUsesBoundedUncancelledContext(t *testing.T) {
+	parent, cancel := context.WithCancel(t.Context())
+	cancel()
+	called := false
+	_, err := cleanupRemoteFailureCapture(parent, SSHTarget{}, "/work", ".crabbox/capture.tar.gz", func(ctx context.Context, _ SSHTarget, command string) (string, error) {
+		called = true
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("cleanup inherited cancellation: %v", err)
+		}
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("cleanup context is not bounded")
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 || remaining > remoteFailureCaptureCleanupTime {
+			t.Fatalf("cleanup deadline remaining=%s", remaining)
+		}
+		if !strings.Contains(command, "capture.tar.gz") {
+			t.Fatalf("cleanup command=%q", command)
+		}
+		return "", nil
+	})
+	if err != nil || !called {
+		t.Fatalf("cleanup called=%t err=%v", called, err)
 	}
 }
 

--- a/internal/cli/run_workspace_owner_cleanup_test.go
+++ b/internal/cli/run_workspace_owner_cleanup_test.go
@@ -575,23 +575,22 @@ func TestRunFailureDigestCleanupOutcomes(t *testing.T) {
 			if report.ExitCode != 23 || (report.LeaseStopped != nil && *report.LeaseStopped) != test.wantStop {
 				t.Fatalf("timing outcome disagrees with cleanup: %#v", report)
 			}
-			if report.RunStatus != "failed" || (report.LeaseStopErr != "") != (test.stopErr != nil) {
+			if report.RunStatus != "failed" || report.RetryLikely != "unknown" || (report.LeaseStopErr != "") != (test.stopErr != nil) {
 				t.Errorf("run status or release error changed: %#v", report)
 			}
 			if !strings.Contains(out, "failure digest") {
 				t.Fatalf("missing failure digest:\n%s", out)
 			}
-			for _, command := range []string{"ssh", "run", "stop"} {
-				if got := strings.Contains(out, "next: crabbox "+command+" "); got == test.wantStop {
-					t.Errorf("recovery %s present=%v, stopped=%v:\n%s", command, got, test.wantStop, out)
-				}
-			}
-			if !test.wantStop {
-				for _, line := range strings.Split(out, "\n") {
-					if strings.Contains(line, "next: crabbox run ") &&
-						(!strings.Contains(line, "--no-sync") || strings.Contains(line, "--fresh-sync")) {
-						t.Errorf("retained retry lost no-sync intent: %s", line)
-					}
+			for _, command := range []struct {
+				name string
+				want bool
+			}{
+				{name: "ssh", want: !test.wantStop},
+				{name: "run"},
+				{name: "stop", want: !test.wantStop},
+			} {
+				if got := strings.Contains(out, "next: crabbox "+command.name+" "); got != command.want {
+					t.Errorf("recovery %s present=%v want=%v, stopped=%v:\n%s", command.name, got, command.want, test.wantStop, out)
 				}
 			}
 			if (test.wantStop || test.stopErr != nil || test.retained) != (releaseCalls == 1) {

--- a/internal/cli/run_workspace_owner_cleanup_test.go
+++ b/internal/cli/run_workspace_owner_cleanup_test.go
@@ -224,10 +224,11 @@ func setupRunCleanupWorkspaceOwnerTest(t *testing.T) string {
 	isolateRunTestUserDirs(t, dir)
 	t.Chdir(dir)
 	sshPath := filepath.Join(dir, "ssh")
+	downloadedProof := []byte("proof-downloaded\n")
 	commandScript := `#!/bin/sh
 printf '%s\n---\n' "$1" >> "$CRABBOX_FAKE_SSH_LOG"
 case "$1" in
-  *"base64 <"*) printf 'cHJvb2YtZG93bmxvYWRlZAo='; exit 0 ;;
+  *"base64 <"*) printf '%s' ` + shellQuote(encodedRunDownloadPayload(int64(len(downloadedProof)), downloadedProof)) + `; exit 0 ;;
   *"renewal-cleanup-exit-23"*) exit 23 ;;
 esac
 exit 0


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where SSH run evidence collection could dirty the tested checkout, retain partial remote captures, create unbounded intermediate archives, buffer an entire download in memory, or replace a local destination before transfer validation. Unknown failures could also suggest an unchanged full rerun before run-scoped diagnosis.

## Why This Change Was Made

Failure-capture bookkeeping lives in an owned temporary directory outside the checkout, with exact cleanup that preserves the original workload result. Capture creation pre-admits both scratch and output filesystems, builds its bounded scratch metadata, then rechecks both filesystems immediately before archive creation. It uses a portable two-phase raw tar plus gzip pipeline. Every raw-tar and compressed-output writer has the same hard 64 MiB file limit as automatic capture downloads. A lower inherited limit or unknown disk availability fails closed; the metadata-only success fallback is removed.

SSH downloads stream through a bounded private temporary file, validate the advertised byte count and disk reserve, and publish atomically. Remote capture cleanup receives a bounded context that does not inherit caller cancellation. Mid-stream reserve and local write failures retain the established local exit-2 classification. Retry commands are shown only for failures classified as retryable.

## User Impact

Operators keep existing local files and symlinks when evidence transfer fails, canceled or oversized downloads leave their destination unchanged, and unknown failures direct operators to recorded-run or retained-lease diagnosis rather than a blind `--fresh-sync` rerun.

Automatic remote capture creation and download are limited to 64 MiB. Before capture creation, both its scratch and output filesystems must each retain the 1 GiB reserve plus twice the 64 MiB capture limit. Ordinary SSH downloads intentionally use a 1 GiB per-file limit and retain at least 1 GiB of local free space as the reviewed upgrade safety boundary.

No configuration, secret-handling, provider-provisioning, cloud-job, or publication behavior changes. The change is limited to run evidence transport, cleanup, and retry guidance.

## Review Finding Disposition

- Ordinary-download compatibility: maintainer intent is to own the documented 1 GiB byte and free-space safety boundary from the reviewed remediation policy.
- Archive argv and literal paths: evidence names remain NUL-delimited and off argv; leading dashes, backslashes, and surrounding whitespace are covered.
- BSD tar ordering: resolved with portable raw-tar creation from the checkout followed by fixed-argv metadata append from scratch. Tests execute the actual production arguments with native BSD or GNU tar.
- Intermediate growth: raw creation, append, and gzip output each apply the 64 MiB file limit. Both filesystems are conservatively admitted before scratch construction and rechecked immediately before archive writers start. Partial files are removed on failure.
- Admission ordering: the successful-capture fixture requires exactly four ordered disk checks: scratch/output before scratch construction, then the same scratch/output pair immediately before archive creation.
- Local error classification: reserve and underlying writer failures are wrapped as local download errors while preserving partial byte counts and destination contents.
- Download protocol fixtures: every successful SSH download mock in the touched test surface emits the shared size header with a byte count computed from its payload. The intentional remote-error mock remains an error response.
- Unknown retry guidance: unknown artifact and cleanup failures do not advertise a runnable rerun. They preserve SSH/stop recovery for non-terminal leases and offer recorded-run diagnosis when history exists.
- Changelog traceability: the Unreleased entry retains its wording and now includes the full PR URL and contributor handle required by repository policy.

## Evidence

Exact head: `b409e3e9b5a6f465ccd3259d3c2c8e961b7aa873`

- Parent `2a5602ef76514c151277e53d6265acbbfdfee477`: `go test ./internal/cli -run '^(TestRunCoordinatorCleanupOutcomes|TestPrintRunFailureDigest|TestPrintRunFailureDigestExplainsUnavailableRunHistory|TestFailureDigestNextCommandsRespectRunHistoryAvailability|TestFailureDigestRetryAdviceByClassification)$' -count=1`
  - Five top-level selections passed, including all 16 `TestRunCoordinatorCleanupOutcomes` text/timing cases and both retry-classification tables. The current commit changes only `CHANGELOG.md`.
- Parent `6ff473f1e585864a20d3032ba215205f721200a9`: `go test ./internal/cli -run '^TestRemoteFailureCapture' -count=1`
  - All eight matching top-level tests passed, including `TestRemoteFailureCaptureKeepsLargeFileListOffArgv`.
- `git diff --check`
- Changelog assertion: exactly one line changed and it ends with `https://github.com/openclaw/crabbox/pull/1983. Thanks @vincentkoc.`
- Successful download-mock inventory: three fixtures use `encodedRunDownloadPayload`; the remaining bare `base64 <` mock intentionally exits with a remote error.

Current exact-head hosted CI and ClawSweeper review remain the merge gates.

No screenshots are applicable.
