### PR TITLE
fix(gcp): surface API error messages in lease failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix truncated GCP lease failures by surfacing bounded API error summaries and preserving quoted JSON diagnostics with credential redaction. [PR 1984](https://github.com/openclaw/crabbox/pull/1984). Thanks @steipete.
+
 - Fix Azure leases blocked by retained legacy shared-infrastructure fences by verifying settled resources before transactional takeover. [PR 1982](https://github.com/openclaw/crabbox/pull/1982). Thanks @steipete.
 
 - AWS: avoid duplicate access-refresh lookups for ports with matching permissions, index lease access once, and keep unnamed runner/workspace groups separate. https://github.com/openclaw/crabbox/pull/1980. Thanks @steipete.

--- a/worker/src/gcp.ts
+++ b/worker/src/gcp.ts
@@ -9,6 +9,7 @@ import {
   type LeaseConfig,
 } from "./config";
 import { ExpiringTokenCache, type ExpiringToken } from "./expiring-token-cache";
+import { redactDiagnosticSecrets } from "./http";
 import {
   leaseProviderLabels,
   providerLabelValue,
@@ -60,9 +61,28 @@ class GCPHTTPError extends Error {
     readonly path: string,
     readonly status: number,
     readonly body: string,
+    secrets: readonly (string | undefined)[] = [],
   ) {
-    super(`gcp ${method} ${path}: http ${status}: ${body}`);
+    super(`gcp ${method} ${path}: http ${status}: ${gcpErrorBodySummary(body, secrets)}`);
   }
+}
+
+function gcpErrorBodySummary(body: string, secrets: readonly (string | undefined)[]): string {
+  let summary = body;
+  try {
+    const parsed = JSON.parse(body) as {
+      error?: { message?: unknown; status?: unknown; errors?: { reason?: unknown }[] };
+    } | null;
+    const error = parsed?.error;
+    if (typeof error?.message === "string" && error.message.trim()) {
+      const reason = error.status || error.errors?.[0]?.reason;
+      summary = typeof reason === "string" ? `${reason}: ${error.message}` : error.message;
+    }
+  } catch {
+    // Non-JSON provider responses still carry useful diagnostics.
+  }
+  // Redact before bounding so a clipped credential cannot evade exact-secret matching.
+  return redactDiagnosticSecrets(summary, secrets).replace(/\s+/g, " ").trim().slice(0, 512);
 }
 
 class GCPOperationError extends Error {}
@@ -1124,7 +1144,11 @@ export class GCPClient {
     const response = await this.fetcher(`${computeBaseURL}/projects/${this.project}${path}`, init);
     const text = await response.text();
     if (!response.ok) {
-      throw new GCPHTTPError(method, path, response.status, text);
+      throw new GCPHTTPError(method, path, response.status, text, [
+        token,
+        this.env.GCP_CLIENT_EMAIL,
+        this.env.GCP_PRIVATE_KEY,
+      ]);
     }
     return (text ? JSON.parse(text) : {}) as T;
   }

--- a/worker/src/http.ts
+++ b/worker/src/http.ts
@@ -30,10 +30,11 @@ export function errorMessage(
   error: unknown,
   secrets: readonly (string | undefined)[] = [],
 ): string {
-  return redactDiagnosticSecrets(
-    firstLine(error instanceof Error ? error.message : String(error)),
+  const redacted = redactDiagnosticSecrets(
+    error instanceof Error ? error.message : String(error),
     secrets,
   );
+  return firstLine(redacted).slice(0, 2048);
 }
 
 const maxDiagnosticRedactionPasses = 64;
@@ -486,5 +487,15 @@ function redactStackTraceFields(value: unknown, seen = new WeakSet<object>()): u
 
 function firstLine(value: string): string {
   const index = value.indexOf("\n");
+  const bodyStart = value.indexOf("{");
+  if (index >= 0 && bodyStart >= 0 && bodyStart < index) {
+    try {
+      // A formatted JSON body is diagnostic text, not a stack trace.
+      JSON.parse(value.slice(bodyStart));
+      return value.replace(/\r?\n\s*/g, " ");
+    } catch {
+      // Preserve first-line filtering for ordinary errors and stack traces.
+    }
+  }
   return index >= 0 ? value.slice(0, index) : value;
 }

--- a/worker/test/fixtures/gcp-billing-error.ts
+++ b/worker/test/fixtures/gcp-billing-error.ts
@@ -1,0 +1,12 @@
+export const gcpBillingMessage =
+  "This API method requires billing to be enabled. Please enable billing on project #123456789 then retry";
+
+export const gcpBillingError = {
+  error: {
+    code: 403,
+    message: gcpBillingMessage,
+    errors: [{ message: gcpBillingMessage, domain: "global", reason: "forbidden" }],
+  },
+};
+
+export const gcpBillingBody = JSON.stringify(gcpBillingError, null, 2);

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -93,6 +93,7 @@ import type {
   RunEventRecord,
   RunRecord,
 } from "../src/types";
+import { gcpBillingBody, gcpBillingError, gcpBillingMessage } from "./fixtures/gcp-billing-error";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -11028,6 +11029,62 @@ describe("fleet lease identity and idle", () => {
       state: "active",
       cloudID: "crabbox-fleet-is-gcp-recovery-c80c2195",
       host: "192.0.2.10",
+    });
+  });
+
+  it.each([
+    gcpBillingBody,
+    JSON.stringify({ ...gcpBillingError, detail: "x".repeat(3000) }, null, 2),
+  ])("preserves quoted GCP billing errors in lease failures and HTTP responses", async (body) => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_abcdef123456";
+    const diagnostic = `gcp GET /global/firewalls/crabbox-ssh-8aa5859a: http 403: ${body}`;
+    const fleet = testFleet(storage, {
+      gcp: fakeProvider(undefined, {
+        provider: "gcp",
+        onPrepareLeaseCreate(config, lease) {
+          return { config, lease, provisioning: {} };
+        },
+        async onCreateProvisioning() {
+          throw new ProvisioningAttemptsError(`europe-west2-a/c4-standard-4: ${diagnostic}`, [
+            {
+              region: "europe-west2-a",
+              serverType: "c4-standard-4",
+              category: "fatal",
+              message: diagnostic,
+            },
+          ]);
+        },
+      }),
+    });
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        body: {
+          leaseID,
+          provider: "gcp",
+          target: "linux",
+          gcpProject: "proj",
+          gcpZone: "europe-west2-a",
+          serverType: "c4-standard-4",
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    const failure = (await response.json()) as { error: string };
+    expect(failure.error).toContain(gcpBillingMessage);
+    expect(failure.error).toContain('"reason": "forbidden"');
+    expect(failure.error.length).toBeLessThanOrEqual(2048);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "failed",
+      failureError: failure.error,
+    });
+    const inspected = await fleet.fetch(request("GET", `/v1/leases/${leaseID}`));
+    expect(inspected.status).toBe(200);
+    await expect(inspected.json()).resolves.toMatchObject({
+      lease: { failureError: failure.error },
     });
   });
 

--- a/worker/test/gcp.test.ts
+++ b/worker/test/gcp.test.ts
@@ -21,6 +21,7 @@ import {
 } from "../src/provider-provisioning";
 import { leaseProviderName } from "../src/slug";
 import type { Env, LeaseRecord, ProviderMachine } from "../src/types";
+import { gcpBillingBody, gcpBillingError, gcpBillingMessage } from "./fixtures/gcp-billing-error";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -140,6 +141,82 @@ describe("gcp provider", () => {
     expect(operationDone({ name: "operation-1", status: "PENDING" })).toBe(false);
     expect(operationDone({ name: "operation-1" })).toBe(false);
     expect(operationDone({ name: "operation-1", status: "DONE" })).toBe(true);
+  });
+
+  it.each([
+    { body: gcpBillingBody, summary: `forbidden: ${gcpBillingMessage}` },
+    {
+      body: JSON.stringify({ error: { ...gcpBillingError.error, status: "PERMISSION_DENIED" } }),
+      summary: `PERMISSION_DENIED: ${gcpBillingMessage}`,
+    },
+    { body: '{"error":{"message":"enable billing"}}', summary: "enable billing" },
+    { body: '{"error":{"code":403}}', summary: '{"error":{"code":403}}' },
+    { body: 'upstream said "billing disabled"', summary: 'upstream said "billing disabled"' },
+    { body: "null", summary: "null" },
+    {
+      body: JSON.stringify({ error: { message: 'enable "billing" ' + "x".repeat(600) } }),
+      summary: ('enable "billing" ' + "x".repeat(600)).slice(0, 512),
+    },
+    { body: "x".repeat(600), summary: "x".repeat(512) },
+  ])(
+    "summarizes GCP HTTP bodies while preserving raw error properties ($summary)",
+    async ({ body, summary }) => {
+      const client = new GCPClient(env);
+      primeAccessToken(client);
+      client.fetcher = async () => new Response(body, { status: 403 });
+
+      await expect(client.getServer("runner")).rejects.toMatchObject({
+        method: "GET",
+        path: "/zones/us-central1-a/instances/runner",
+        status: 403,
+        body,
+        message: `gcp GET /zones/us-central1-a/instances/runner: http 403: ${summary}`,
+      });
+    },
+  );
+
+  it("redacts GCP credentials and the client email before bounding the body summary", async () => {
+    const client = new GCPClient(env);
+    const token = "test-access-credential".repeat(40);
+    primeAccessToken(client, token);
+    client.fetcher = async () =>
+      new Response(
+        JSON.stringify({
+          error: {
+            message: `billing disabled ${env.GCP_CLIENT_EMAIL} ${token} ${env.GCP_PRIVATE_KEY} token=reflected-secret`,
+          },
+        }),
+        { status: 403 },
+      );
+
+    await expect(client.getServer("runner")).rejects.toThrow(
+      "http 403: billing disabled [redacted] [redacted] [redacted] token=[redacted]",
+    );
+  });
+
+  it("carries the billing reason through GCP fallback history without retrying", async () => {
+    const client = new GCPClient(env);
+    primeAccessToken(client);
+    const fetcher = vi.fn<typeof fetch>(async () => new Response(gcpBillingBody, { status: 403 }));
+    client.fetcher = fetcher;
+    const config = leaseConfig(
+      { provider: "gcp", serverType: "c4-standard-4", sshPublicKey: "ssh-ed25519 test" },
+      env,
+    );
+
+    await expect(
+      client.createServerWithFallback(config, "cbx_abcdef123456", "runner", "alice@example.com"),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining(`http 403: forbidden: ${gcpBillingMessage}`),
+      attempts: [
+        expect.objectContaining({
+          category: "fatal",
+          message: expect.stringContaining(gcpBillingMessage),
+        }),
+      ],
+      cause: expect.objectContaining({ status: 403, body: gcpBillingBody }),
+    });
+    expect(fetcher).toHaveBeenCalledTimes(1);
   });
 
   it("prefers per-request project over Worker defaults", () => {

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -14,6 +14,7 @@ import { prepareCoordinatorRequest } from "../src/coordinator-entry";
 import { errorMessage, json, redactDiagnosticSecrets, requestOwner } from "../src/http";
 import { MISSING_ORG_KEY, requestOrg, requestOrgLabel } from "../src/org-identity";
 import type { Env } from "../src/types";
+import { gcpBillingBody, gcpBillingError, gcpBillingMessage } from "./fixtures/gcp-billing-error";
 
 function proxyIdentityRequest(secret?: string): Request {
   return new Request("https://example.test/v1/whoami", {
@@ -1522,6 +1523,34 @@ describe("http responses", () => {
 
   it("keeps public error messages to the first line", () => {
     expect(errorMessage(new Error("boom\n    at hidden"))).toBe("boom");
+  });
+
+  it.each([gcpBillingBody, JSON.stringify(gcpBillingError)])(
+    "preserves quoted provider JSON in bounded diagnostics",
+    async (body) => {
+      const diagnostic = `gcp GET /global/firewalls/crabbox-ssh-8aa5859a: http 403: ${body}`;
+      const message = errorMessage(new Error(diagnostic));
+      expect(message).toContain(gcpBillingMessage);
+      expect(message).toContain('"reason":');
+      expect(message).not.toContain("\n");
+      expect(message.length).toBeLessThanOrEqual(2048);
+      await expect(json({ error: message }).json()).resolves.toEqual({ error: message });
+    },
+  );
+
+  it("redacts multiline JSON credentials before flattening and bounding diagnostics", () => {
+    const secret = "configured-credential".repeat(200);
+    const body = JSON.stringify(
+      { ...gcpBillingError, token: "reflected-secret", detail: secret, padding: "x".repeat(3000) },
+      null,
+      2,
+    );
+    const message = errorMessage(new Error(`provider failed: ${body}`), [secret]);
+    expect(message).toContain(gcpBillingMessage);
+    expect(message).toContain('"token": "[redacted]"');
+    expect(message).toContain('"detail": "[redacted]"');
+    expect(message).not.toContain("configured-credential");
+    expect(message).toHaveLength(2048);
   });
 
   it("redacts configured and structured credentials from diagnostics", () => {


### PR DESCRIPTION
A brokered GCP lease failed with a billing-disabled HTTP 403, but the coordinator response and persisted `failureError` lost the explanation. The operator saw exactly:

```text
coordinator POST /v1/leases: http 500: {"error":"europe-west2-a/c4-standard-4: gcp GET /global/firewalls/crabbox-ssh-8aa5859a: http 403: {"}
```

The root cause is `firstLine()` in `worker/src/http.ts`, called by `errorMessage()` through `coordinatorErrorMessage()`. GCP supplies pretty-printed JSON beginning with `{` and a newline; first-line filtering discarded the rest. The provider fallback history retained the text, but lease failure recording and the final HTTP 500 formatter both applied this filter. It was a newline truncation, not a quote-redaction rule.

`GCPHTTPError` now extracts `error.message`, prefixed by `error.status` or the first `errors[].reason`, into a single-line summary capped at 512 characters. Nonstandard responses retain a bounded body fallback. The HTTP status, method, path, and original body properties remain available to existing callers. Configured GCP credentials, the client email, and structured secrets are redacted before bounding.

The shared formatter preserves valid embedded JSON bodies across newlines, keeps ordinary first-line/stack-trace filtering, and caps public error text at 2,048 characters after secret redaction. AWS, Azure, and Hetzner provider message construction is unchanged. Regression coverage uses the GCP billing-error shape with synthetic project data and checks fallback history, quoted/multiline bodies, raw error properties, redaction, bounds, HTTP failures, persisted `failureError`, and lease inspection.

Verification:

- `npm run format:check --prefix worker && npm run lint --prefix worker && npm run check --prefix worker`
- `npm test --prefix worker -- test/gcp.test.ts test/http.test.ts test/fleet.test.ts` — 1,281 passed.
- `npm test --prefix worker` — 2,940 passed, 3 skipped across 54 files.
- New regressions against the original source: four failures reproduced the GCP summary and multiline-body loss; the compact-JSON case already passed.
- Required Codex autoreview completed without actionable blockers.

No configuration changes or new secrets are required.
