### PR TITLE
fix(cli): avoid coordinator connection stalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix Azure leases blocked by retained legacy shared-infrastructure fences by verifying settled resources before transactional takeover. [PR 1982](https://github.com/openclaw/crabbox/pull/1982). Thanks @steipete.
 
-- CLI: negotiate HTTP/2 for coordinator API requests and avoid waiting for idle control peers during shutdown. https://github.com/openclaw/crabbox/pull/1985. Thanks @steipete.
+- CLI: negotiate HTTP/2 for coordinator API requests, apply the shared redirect guard to control upgrades, and avoid waiting for idle control peers during shutdown. https://github.com/openclaw/crabbox/pull/1985. Thanks @steipete.
 
 - AWS: avoid duplicate access-refresh lookups for ports with matching permissions, index lease access once, and keep unnamed runner/workspace groups separate. https://github.com/openclaw/crabbox/pull/1980. Thanks @steipete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix Azure leases blocked by retained legacy shared-infrastructure fences by verifying settled resources before transactional takeover. [PR 1982](https://github.com/openclaw/crabbox/pull/1982). Thanks @steipete.
 
+- CLI: negotiate HTTP/2 for coordinator API requests and avoid waiting for idle control peers during shutdown. https://github.com/openclaw/crabbox/pull/1985. Thanks @steipete.
+
 - AWS: avoid duplicate access-refresh lookups for ports with matching permissions, index lease access once, and keep unnamed runner/workspace groups separate. https://github.com/openclaw/crabbox/pull/1980. Thanks @steipete.
 
 - AWS: overlap SSH ingress authorization in bounded batches while preserving revocation, recovery and cleanup ordering. https://github.com/openclaw/crabbox/pull/1976. Thanks @steipete.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -301,6 +301,11 @@ commands can read it back:
   The coordinator computes `durationMs`, sets state `succeeded`/`failed`, and records
   classification (`blockedStage`, `retryLikely`).
 
+Coordinator API requests negotiate HTTP/2 over TLS when the server supports it,
+so independent requests can share a connection. HTTP/1 coordinators and the
+HTTP/1 WebSocket upgrade remain supported. An ended control owner closes and
+joins its local connection without waiting for a peer close handshake.
+
 The command itself, file sync, and I/O streaming all happen **directly
 CLI → runner over SSH** and never traverse the broker.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -303,7 +303,8 @@ commands can read it back:
 
 Coordinator API requests negotiate HTTP/2 over TLS when the server supports it,
 so independent requests can share a connection. HTTP/1 coordinators and the
-HTTP/1 WebSocket upgrade remain supported. An ended control owner closes and
+HTTP/1 WebSocket upgrade remain supported; both use the coordinator's same-origin
+redirect guard. An ended control owner closes and
 joins its local connection without waiting for a peer close handshake.
 
 The command itself, file sync, and I/O streaming all happen **directly

--- a/internal/cli/control_ws.go
+++ b/internal/cli/control_ws.go
@@ -90,7 +90,9 @@ func (c *coordinatorControlConn) close() {
 	if c == nil || c.conn == nil {
 		return
 	}
-	_ = c.conn.Close(websocket.StatusNormalClosure, "")
+	// Control has no terminal message to flush. Join local I/O without making
+	// a finished or canceled owner wait for the peer's close handshake.
+	_ = c.conn.CloseNow()
 }
 
 func (c *coordinatorControlConn) write(ctx context.Context, payload any) error {

--- a/internal/cli/control_ws.go
+++ b/internal/cli/control_ws.go
@@ -50,9 +50,7 @@ func dialCoordinatorControl(ctx context.Context, coord *CoordinatorClient) (*coo
 	}
 	opts := &websocket.DialOptions{
 		HTTPHeader: headers,
-	}
-	if coord.Client != nil {
-		opts.HTTPClient = coord.Client
+		HTTPClient: coord.secureHTTPClient(),
 	}
 	dialCtx, cancel := context.WithTimeout(ctx, coordinatorControlDialTimeout)
 	defer cancel()

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -1008,7 +1008,9 @@ func newCoordinatorClient(cfg Config) (*CoordinatorClient, bool, error) {
 					Timeout:   5 * time.Second,
 					KeepAlive: 30 * time.Second,
 				}).DialContext,
-				TLSHandshakeTimeout:   10 * time.Second,
+				TLSHandshakeTimeout: 10 * time.Second,
+				// Custom dialing otherwise disables HTTP/2 and its independent streams.
+				ForceAttemptHTTP2:     true,
 				ResponseHeaderTimeout: coordinatorHTTPTimeout,
 				IdleConnTimeout:       90 * time.Second,
 			},

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -293,7 +293,7 @@ func TestCurlConfigKeepsBearerTokenInConfig(t *testing.T) {
 	}
 }
 
-func TestCoordinatorHTTPRejectsCrossOriginRedirect(t *testing.T) {
+func TestCoordinatorRejectsCrossOriginRedirect(t *testing.T) {
 	var redirected atomic.Int32
 	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		redirected.Add(1)
@@ -327,6 +327,13 @@ func TestCoordinatorHTTPRejectsCrossOriginRedirect(t *testing.T) {
 	}
 	if got := redirected.Load(); got != 0 {
 		t.Fatalf("redirect target received %d requests", got)
+	}
+	_, err = dialCoordinatorControl(t.Context(), &client)
+	if err == nil || !strings.Contains(err.Error(), "refused cross-origin redirect") {
+		t.Fatalf("control error=%v, want cross-origin redirect rejection", err)
+	}
+	if got := redirected.Load(); got != 0 {
+		t.Fatalf("control redirect target received %d requests", got)
 	}
 }
 

--- a/internal/cli/coordinator_transport_test.go
+++ b/internal/cli/coordinator_transport_test.go
@@ -1,0 +1,180 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+func TestCoordinatorNegotiatesSupportedHTTPProtocol(t *testing.T) {
+	for _, http2 := range []bool{true, false} {
+		name, want := "http1", 1
+		if http2 {
+			name, want = "http2", 2
+		}
+		t.Run(name, func(t *testing.T) {
+			protocol := make(chan int, 1)
+			server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				protocol <- r.ProtoMajor
+				io.WriteString(w, `{"ok":true}`)
+			}))
+			server.EnableHTTP2 = http2
+			server.StartTLS()
+			defer server.Close()
+			client := coordinatorTLSFixture(t, server)
+			var reply struct{ OK bool }
+			if err := client.doHTTP(t.Context(), http.MethodGet, "/probe", nil, false, &reply); err != nil {
+				t.Fatal(err)
+			}
+			if got := <-protocol; got != want || !reply.OK {
+				t.Fatalf("protocol=%d reply=%v, want HTTP/%d and a successful response", got, reply, want)
+			}
+		})
+	}
+}
+
+func TestCoordinatorCanceledEventDoesNotBlockOtherStreams(t *testing.T) {
+	started := make(chan struct{})
+	var connections atomic.Int32
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/slow" {
+			close(started)
+			<-r.Context().Done()
+			return
+		}
+		io.WriteString(w, `{"ok":true}`)
+	}))
+	server.EnableHTTP2 = true
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			connections.Add(1)
+		}
+	}
+	server.StartTLS()
+	defer server.Close()
+	client := coordinatorTLSFixture(t, server)
+	client.Client.Transport.(*http.Transport).MaxConnsPerHost = 1
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	var slowErr error
+	go func() { slowErr = client.doHTTP(ctx, http.MethodPost, "/slow", nil, false, nil); close(done) }()
+	defer func() { cancel(); <-done }()
+	<-started
+	probeCtx, stopProbe := context.WithTimeout(t.Context(), time.Second)
+	defer stopProbe()
+	var reply struct{ OK bool }
+	if err := client.doHTTP(probeCtx, http.MethodGet, "/probe", nil, false, &reply); err != nil || !reply.OK {
+		t.Fatalf("a pending event blocked an independent request: %v", err)
+	}
+	cancel()
+	<-done
+	if !errors.Is(slowErr, context.Canceled) {
+		t.Fatalf("event cancellation=%v", slowErr)
+	}
+	if err := client.doHTTP(t.Context(), http.MethodGet, "/after", nil, false, &reply); err != nil {
+		t.Fatal(err)
+	}
+	if got := connections.Load(); got != 1 {
+		t.Fatalf("canceled event discarded the shared connection: connections=%d", got)
+	}
+}
+
+func coordinatorTLSFixture(t *testing.T, server *httptest.Server) *CoordinatorClient {
+	t.Helper()
+	client, configured, err := newCoordinatorClient(Config{Coordinator: server.URL})
+	if err != nil || !configured {
+		t.Fatalf("newCoordinatorClient configured=%t err=%v", configured, err)
+	}
+	transport := client.Client.Transport.(*http.Transport)
+	transport.TLSClientConfig = server.Client().Transport.(*http.Transport).TLSClientConfig.Clone()
+	t.Cleanup(transport.CloseIdleConnections)
+	return client
+}
+
+func TestCoordinatorControlCloseDoesNotAwaitIdlePeer(t *testing.T) {
+	peerRelease := make(chan struct{})
+	peerDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(peerDone)
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer conn.CloseNow()
+		<-peerRelease
+	}))
+	defer server.Close()
+	control, err := dialCoordinatorControl(t.Context(), &CoordinatorClient{BaseURL: server.URL, Client: server.Client()})
+	if err != nil {
+		close(peerRelease)
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() { control.close(); close(done) }()
+	defer func() { close(peerRelease); <-peerDone; <-done }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("ending the control owner waited for the idle peer's close handshake")
+	}
+	if err := control.write(t.Context(), map[string]string{"type": "ping"}); err == nil {
+		t.Fatal("closed control owner still accepted a write")
+	}
+}
+
+func TestCoordinatorHTTP2ClientRetainsWebSocketUpgrade(t *testing.T) {
+	protocols := make(chan int, 2)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		protocols <- r.ProtoMajor
+		if r.URL.Path != "/v1/control" {
+			io.WriteString(w, `{"ok":true}`)
+			return
+		}
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer conn.CloseNow()
+		if _, _, err := conn.Read(r.Context()); err != nil {
+			t.Error(err)
+			return
+		}
+		_ = conn.Write(r.Context(), websocket.MessageText, []byte(`{"type":"pong"}`))
+		_, _, _ = conn.Read(r.Context())
+	}))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+	client := coordinatorTLSFixture(t, server)
+	var reply struct{ OK bool }
+	if err := client.doHTTP(t.Context(), http.MethodGet, "/probe", nil, false, &reply); err != nil {
+		t.Fatal(err)
+	}
+	if protocol := <-protocols; protocol != 2 {
+		t.Fatalf("API protocol=%d", protocol)
+	}
+	control, err := dialCoordinatorControl(t.Context(), client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer control.close()
+	if protocol := <-protocols; protocol != 1 {
+		t.Fatalf("WebSocket upgrade protocol=%d", protocol)
+	}
+	if err := control.write(t.Context(), map[string]string{"type": "ping"}); err != nil {
+		t.Fatal(err)
+	}
+	if response, err := control.read(t.Context()); err != nil || response.Type != "pong" {
+		t.Fatalf("control response=%v err=%v", response, err)
+	}
+}

--- a/internal/cli/coordinator_transport_test.go
+++ b/internal/cli/coordinator_transport_test.go
@@ -132,10 +132,14 @@ func TestCoordinatorControlCloseDoesNotAwaitIdlePeer(t *testing.T) {
 }
 
 func TestCoordinatorHTTP2ClientRetainsWebSocketUpgrade(t *testing.T) {
-	protocols := make(chan int, 2)
+	protocols := make(chan int, 3)
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		protocols <- r.ProtoMajor
-		if r.URL.Path != "/v1/control" {
+		if r.URL.Path == "/v1/control" {
+			http.Redirect(w, r, "/control-target", http.StatusFound)
+			return
+		}
+		if r.URL.Path != "/control-target" {
 			io.WriteString(w, `{"ok":true}`)
 			return
 		}
@@ -170,6 +174,9 @@ func TestCoordinatorHTTP2ClientRetainsWebSocketUpgrade(t *testing.T) {
 	defer control.close()
 	if protocol := <-protocols; protocol != 1 {
 		t.Fatalf("WebSocket upgrade protocol=%d", protocol)
+	}
+	if protocol := <-protocols; protocol != 1 {
+		t.Fatalf("same-origin WebSocket redirect protocol=%d", protocol)
 	}
 	if err := control.write(t.Context(), map[string]string{"type": "ping"}); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Coordinator API traffic silently used HTTP/1 because the custom Go dialer omitted HTTP/2 opt-in. Separately, ending a control connection waited for the WebSocket peer's close handshake, adding up to five seconds after the local owner had finished.

Enable HTTP/2 negotiation for coordinator API requests and close/join ended control connections locally. Route WebSocket upgrades through the same origin-checked client used by coordinator HTTP requests; previously the upgrade bypassed that existing redirect policy. HTTP/1 servers remain supported, and WebSocket upgrades still use HTTP/1. The server's control-disconnect handler only removes the ended connection; it does not interpret the close code as a lease or run outcome.

No timeout increases, event-order changes, receipt-check changes, new retries, configuration options or schema changes. The patch adds two net production lines, including the ownership comments.

Validation:

- The original transport failed real TLS negotiation and single-connection multiplexing regressions. The original control close failed the idle-peer shutdown regression.
- Real TLS/TCP tests cover HTTP/2, HTTP/1 compatibility, independent requests during a pending stream, cancellation without discarding the shared HTTP/2 connection, HTTP/1 WebSocket upgrades after HTTP/2 use, prompt close with an unresponsive peer, rejection of cross-origin control redirects, and preservation of same-origin redirects.
- Focused coordinator, recorder and event tests passed with the race detector. The control/heartbeat suite passed after the close change.
- Thirty shuffled race repetitions of the transport/lifecycle cases passed.
- Go vet and docs build passed; the diff-scoped cleanup review preserved only the short comments explaining the protocol and lifetime requirements.
- Direct dependency inspection checked Go's Transport protocol selection and the pinned WebSocket library's Close/CloseNow behavior. [Go Transport contract](https://pkg.go.dev/net/http#Transport), [WebSocket close contract](https://pkg.go.dev/nhooyr.io/websocket#Conn.CloseNow).

A task-local, timing-only profile compared HTTP/1 and HTTP/2 in ABBA order on one disposable AWS lease. It confirmed HTTP/2 negotiation against the live coordinator and verified all four command receipts. Auth preparation was about 8–11 ms; coordinator response waits varied from hundreds of milliseconds to several seconds on both protocols. These measurements do not establish a uniform end-to-end speedup. The profile also exposed the separate five-second close-handshake stall addressed here. Profiling overlays are not part of this PR.

The profiling lease reached canonical released/cleanup-complete status through ordinary Stop after its existing cleanup claim expired. The initial timeout evidence is preserved. Deployment history shows a coordinator rollout 32 seconds after cleanup began; no claim was edited or bypassed. The uninstrumented candidate `678d507b61a2d37fc3e10cf63a50968dd7e6b606` passed the ordinary AWS CLI sequence: two successful runs, an intentional exit 7, then successful recovery on the same lease. All four signed receipts verified. Runner durations were 6.541, 6.149, 14.095 and 6.083 seconds. One best-effort event drain warning remained; server response latency is variable and no stable speedup percentage is claimed.

Normal Stop completed provider cleanup without a retry. Canonical state is released/cleanup-complete, configuration was unchanged, every owned process birth exited and SSH control state was absent. The official tail stopped and joined. Full CI passed, including the Go race suite: https://github.com/openclaw/crabbox/actions/runs/34196375468.

Follow-up to https://github.com/openclaw/crabbox/pull/1980.


Merged as `bfc6acf021acef44a0b12aa712d2c1dd90b35795`. A clean CLI rebuilt from that main commit repeated the full live success/success/exit-7/recovery sequence against coordinator version `eb21d263-b13d-4860-ba54-23c6d5efe456` (unchanged server code; no deployment needed for this CLI change). All four signed receipts verified. Runner measurements were 8.687, 5.675, 7.559 and 6.250 seconds. One best-effort event-drain warning occurred; the existing deadline remains unchanged.

Normal Stop completed without retry. Canonical provider cleanup was released/complete; all owned process births and SSH control state were absent; configuration was unchanged. The official tail joined, deployment history stayed unchanged during the main run, and the secret task window was closed.
