### PR TITLE
fix(images): retain sanitized measured publication outcomes

### DIFF
--- a/.github/workflows/devtools-image-publish.yml
+++ b/.github/workflows/devtools-image-publish.yml
@@ -263,7 +263,7 @@ jobs:
                   "- Exit code: `\(.exitCode // "unavailable")`"
                 ' "$public_outcome"
               else
-                echo "- Status: `outcome_unavailable`"
+                echo '- Status: `outcome_unavailable`'
               fi
             } >>"$GITHUB_STEP_SUMMARY"
             exit 0

--- a/.github/workflows/devtools-image-publish.yml
+++ b/.github/workflows/devtools-image-publish.yml
@@ -1,5 +1,5 @@
 name: Publish Developer Image
-run-name: Publish ${{ inputs.target }} developer image in ${{ inputs.region }}
+run-name: Publish developer image
 
 on:
   workflow_dispatch:
@@ -130,6 +130,25 @@ jobs:
       MEASURED: ${{ inputs.measured }}
       MAX_P95_RUNNER_TOTAL_MS: ${{ inputs.max_p95_runner_total_ms }}
     steps:
+      - name: Check out protected source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Initialize measured publication outcome
+        if: inputs.measured
+        shell: bash
+        run: |
+          set -euo pipefail
+          public_outcome="$RUNNER_TEMP/devtools-image-proof/manifest.json"
+          mkdir -p "$(dirname "$public_outcome")"
+          node scripts/devtools-image-proof.mjs initialize \
+            "$public_outcome" \
+            scripts/install-linux-developer-tools.sh \
+            "$REGION" "$LINUX_TYPE" standard "$MAX_P95_RUNNER_TOTAL_MS" \
+            1 1 1 0 0 2h 30m
+
       - name: Verify publisher configuration
         shell: bash
         run: |
@@ -142,12 +161,6 @@ jobs:
             echo "::error::Set the CRABBOX_COORDINATOR_ADMIN_TOKEN secret on the image-publisher environment."
             exit 1
           fi
-
-      - name: Check out protected source
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.workflow_sha }}
-          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
@@ -201,24 +214,29 @@ jobs:
               )
               ;;
           esac
-          printf 'Publishing from protected commit %s\n' "$GITHUB_SHA"
-          printf 'Command:'
-          printf ' %q' "${command[@]}"
-          printf '\n'
           if [[ "$MEASURED" == true ]]; then
             umask 077
             private_dir="$(mktemp -d "$RUNNER_TEMP/devtools-image-private.XXXXXX")"
             export CRABBOX_IMAGE_LOG_DIR="$private_dir"
+            export CRABBOX_IMAGE_PUBLIC_OUTCOME="$proof_dir/manifest.json"
             status=0
             "${command[@]}" >"$private_dir/publish.log" 2>&1 || status=$?
+            proof_status=0
+            node scripts/devtools-image-proof.mjs validate \
+              "$CRABBOX_IMAGE_PUBLIC_OUTCOME" >/dev/null || proof_status=$?
             if [[ "$status" != 0 ]]; then
-              echo "::error::Measured publication failed (exit $status); no private evidence was uploaded."
+              echo "::error::Measured publication failed (exit $status)."
               exit "$status"
             fi
-            manifests=("$private_dir"/measurement-*/manifest.json)
-            [[ "${#manifests[@]}" == 1 && -f "${manifests[0]}" ]]
-            cp "${manifests[0]}" "$proof_dir/manifest.json"
+            if [[ "$proof_status" != 0 ]]; then
+              echo "::error::Measured publication outcome validation failed (exit $proof_status)."
+              exit "$proof_status"
+            fi
           else
+            printf 'Publishing from protected commit %s\n' "$GITHUB_SHA"
+            printf 'Command:'
+            printf ' %q' "${command[@]}"
+            printf '\n'
             "${command[@]}" 2>&1 | tee "$proof_dir/publish.log"
           fi
 
@@ -226,6 +244,30 @@ jobs:
         if: always()
         shell: bash
         run: |
+          if [[ "$MEASURED" == true ]]; then
+            public_outcome="$RUNNER_TEMP/devtools-image-proof/manifest.json"
+            {
+              echo "## Measured developer image publication"
+              echo
+              if node scripts/devtools-image-proof.mjs validate \
+                "$public_outcome" >/dev/null 2>&1; then
+                jq -r '
+                  "- Status: `\(.status)`",
+                  "- Stage: `\(.stage)`",
+                  "- Source revision: `\(.sourceRevision)`",
+                  "- Baseline p95 runner total: `\(.comparison.baselineP95RunnerTotalMs // "unavailable")`",
+                  "- Candidate p95 runner total: `\(.comparison.candidateP95RunnerTotalMs // "unavailable")`",
+                  "- Promoted p95 runner total: `\(.comparison.promotedP95RunnerTotalMs // "unavailable")`",
+                  "- Rollback: `\(.rollbackStatus)`",
+                  "- Cleanup: `\(.cleanupStatus)`",
+                  "- Exit code: `\(.exitCode // "unavailable")`"
+                ' "$public_outcome"
+              else
+                echo "- Status: `outcome_unavailable`"
+              fi
+            } >>"$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           {
             echo "## Developer image publication"
             echo
@@ -250,7 +292,7 @@ jobs:
           retention-days: 30
 
       - name: Upload allowlisted measurement manifest
-        if: success() && inputs.measured
+        if: always() && inputs.measured
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: devtools-image-measurement-${{ github.run_id }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix truncated GCP lease failures by surfacing bounded API error summaries and preserving quoted JSON diagnostics with credential redaction. [PR 1984](https://github.com/openclaw/crabbox/pull/1984). Thanks @steipete.
 
-- Retain an exact-key sanitized outcome for successful, failed, and incomplete measured AWS image publications, with descriptive baseline evidence, opaque promotion binding, and rollback/cleanup state after finalization.
+- Retain an exact-key sanitized outcome for successful, failed, and incomplete measured AWS image publications, with descriptive baseline evidence, opaque promotion binding, and rollback/cleanup state after finalization. [PR 1986](https://github.com/openclaw/crabbox/pull/1986). Thanks @vincentkoc.
 
 - Fix Azure leases blocked by retained legacy shared-infrastructure fences by verifying settled resources before transactional takeover. [PR 1982](https://github.com/openclaw/crabbox/pull/1982). Thanks @steipete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix truncated GCP lease failures by surfacing bounded API error summaries and preserving quoted JSON diagnostics with credential redaction. [PR 1984](https://github.com/openclaw/crabbox/pull/1984). Thanks @steipete.
 
+- Retain an exact-key sanitized outcome for successful, failed, and incomplete measured AWS image publications, with descriptive baseline evidence, opaque promotion binding, and rollback/cleanup state after finalization.
+
 - Fix Azure leases blocked by retained legacy shared-infrastructure fences by verifying settled resources before transactional takeover. [PR 1982](https://github.com/openclaw/crabbox/pull/1982). Thanks @steipete.
 
 - AWS: avoid duplicate access-refresh lookups for ports with matching permissions, index lease access once, and keep unnamed runner/workspace groups separate. https://github.com/openclaw/crabbox/pull/1980. Thanks @steipete.

--- a/docs/commands/bench.md
+++ b/docs/commands/bench.md
@@ -165,6 +165,11 @@ is written before a policy exit of `1`. Check JSON is deterministic and excludes
 the store path, raw timing records, command text, command fingerprints, and
 lease or run IDs.
 
+Treat `bench check --json` as local, private evidence. It can still identify
+the selected provider and machine type, so it is not a publication format.
+Public workflows must project the result through a separate exact-key
+allowlist instead of uploading or copying this JSON directly.
+
 ## Privacy and interpretation
 
 Timing records can include repo paths, workdirs, command display text, labels,

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -295,17 +295,20 @@ gh workflow run devtools-image-publish.yml \
 ```
 
 Use `macos_host=allocate` only when no suitable EC2 Mac Dedicated Host is
-available. Unmeasured publication uploads its complete mint logs and macOS lifecycle
-evidence as a 30-day diagnostic Actions artifact. These diagnostics are not
-sanitized public proof. Measured Linux publication uploads only its allowlisted
-manifest; its private evidence and diagnostics are excluded. Candidate failure leaves the default
-unchanged. Publication is serialized per target; promotion atomically captures
-the current scoped default, and promoted-image smoke failure attempts a
-compare-and-swap restore. If another operator promotes a newer image first,
-rollback fails visibly rather than overwriting it. Publisher rollback explicitly
-authorizes retiring the exact failed catalog revision so capability-aware leases
-cannot select it; generic stale compare-and-swap requests leave the catalog
-unchanged.
+available. Unmeasured publication uploads its complete mint logs and macOS
+lifecycle evidence as a 30-day diagnostic Actions artifact. These diagnostics
+are not sanitized public proof. Measured Linux publication initializes one
+fixed-path `crabbox-devtools-image-proof/v2` outcome immediately after the
+protected checkout, then atomically replaces it after wrapper rollback and
+cleanup. The allowlisted outcome uploads on success or failure; private
+evidence, receipts, and diagnostics are never copied into the artifact
+directory. Candidate failure leaves the default unchanged. Publication is
+serialized per target; promotion atomically captures the current scoped
+default, and promoted-image smoke failure attempts a compare-and-swap restore.
+If another operator promotes a newer image first, rollback fails visibly rather
+than overwriting it. Publisher rollback explicitly authorizes retiring the
+exact failed catalog revision so capability-aware leases cannot select it;
+generic stale compare-and-swap requests leave the catalog unchanged.
 
 ## Developer-image wrappers
 
@@ -467,9 +470,10 @@ the separate qualification workflow's three-launch budget.
 
 Choose a positive absolute p95 runner-time cap before the campaign, based on
 the operator's acceptance policy. There is no default performance target.
-All three cohorts must pass that same cap. Their p95 values are also recorded
-side by side as a descriptive baseline comparison; passing `bench check` does
-not establish a speedup or statistical significance.
+The baseline cohort is evidence-only and does not apply the cap. The explicit
+candidate and normal-selection promoted cohorts must both pass it. All three
+p95 values are recorded side by side as a descriptive comparison; passing
+`bench check` does not establish a speedup or statistical significance.
 
 Measured mode validates the bundled Linux recipe and its exact input hashes
 before the first CLI operation. It requires clean source, an explicit region
@@ -501,10 +505,10 @@ cleanup also fails. Interruptions recover an already-published retained handle
 without waiting for a final timing record. The original runner timing excludes the subsequent evidence
 read and cleanup wait, consistently across all cohorts. Warmup timings are not
 benchmark samples, and a `--cold` label alone is not evidence of fresh acquisition.
-Existing `bench report` and
-`bench check` own the timing distributions and acceptance policy. Missing,
-mixed, reused, or insufficient observations block promotion; measured `0ms`
-sync remains valid.
+Existing `bench report` owns all three timing distributions. `bench check`
+enforces the predeclared p95 policy only for candidate and promoted cohorts.
+Missing, mixed, reused, or insufficient observations block promotion; measured
+`0ms` sync remains valid.
 
 Candidate lifecycle cleanup and all candidate measurements finish before
 transactional promotion. The original promotion receipt remains unchanged.
@@ -512,19 +516,29 @@ The baseline image is reconciled with the receipt's captured previous default
 before the post-promotion smoke and again before final acceptance.
 The normal-selection path clears the environment AMI override, and
 all promoted measurements must prove the new image was selected normally.
-Rollback remains armed through the final measurements and manifest creation.
+Rollback remains armed through the final measurements and outcome projection.
 Failure attempts the existing receipt-based restore and exact failed catalog
 revision retirement, retaining the original failure status. A concurrent
 newer promotion causes visible CAS rejection, never an overwrite.
 
-The public `manifest.json` contains only recipe/source/policy digests, fixed
-phase and outcome labels, numeric counts and measures, and check reasons.
-`plannedLeaseCount` is the campaign plan, not an observed provider-attempt count.
-Raw records, command text, paths, image/lease identities, promotion receipts,
-handles, and diagnostic logs remain in the private runner directory and are
-not uploaded for measured publication. Full config and administrative listings
-are never logged or persisted. A failed campaign does not emit a successful
-public manifest.
+The public `manifest.json` contains only fixed state labels, source,
+recipe/policy and opaque promotion-binding digests, numeric counts and
+measures, selection states, rollback/cleanup states, and the exit code.
+`plannedLeaseCount` is the campaign plan, not an observed provider-attempt
+count. The baseline records evidence with `policyApplied=false`; only candidate
+and promoted cohorts can report a passed policy. Failed and incomplete
+campaigns retain the last strictly validated partial cohorts without exposing
+raw errors. Raw records, command text, paths, image/lease identities, provider
+metadata, promotion receipts, handles, reasons, and diagnostic logs remain in
+the private runner directory and are not uploaded. Full config and
+administrative listings are never logged or persisted.
+
+Run the first measured publication as a supervised pilot. The wrapper finalizer
+can restore a captured promotion and publish the final outcome after ordinary
+errors, `SIGINT`, or `SIGTERM`, but it cannot run after runner loss or
+`SIGKILL`. In that case the initialized outcome remains conservative; inspect
+the private operator evidence, verify the current promoted default, and use the
+captured receipt for an explicit compare-and-swap rollback before retrying.
 
 ## macOS images
 

--- a/scripts/devtools-image-proof.mjs
+++ b/scripts/devtools-image-proof.mjs
@@ -2,9 +2,9 @@
 
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { createHash } from "node:crypto";
-import { readFileSync, realpathSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { createHash, randomBytes } from "node:crypto";
+import { realpathSync } from "node:fs";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -14,13 +14,93 @@ import { canonicalJSON, parseStrictJSON } from "./generate-linux-readiness.mjs";
 const scriptPath = fileURLToPath(import.meta.url);
 const root = resolve(dirname(scriptPath), "..");
 const phases = ["baseline", "candidate", "promoted"];
+const stages = [
+  "preflight",
+  "baseline",
+  "source_prepare",
+  "candidate_create",
+  "candidate_smoke",
+  "candidate_measure",
+  "promotion",
+  "promoted_smoke",
+  "promoted_measure",
+  "proof",
+  "complete",
+];
+const outcomeStatuses = ["initialized", "failed", "passed"];
+const rollbackStatuses = ["not_required", "succeeded", "failed"];
+const cleanupStatuses = ["not_started", "succeeded", "failed"];
+const policyInputKeys = [
+  "sourceRevision",
+  "recipeDigest",
+  "region",
+  "machineType",
+  "serverClass",
+  "maxP95RunnerTotalMs",
+  "ttl",
+  "idleTimeout",
+];
+const policyKeys = [
+  ...policyInputKeys,
+  "commandFingerprint",
+  "syncPolicy",
+  "capabilities",
+  "samplesPerCohort",
+  "plannedLeaseCount",
+];
+const cohortKeys = [
+  "phase",
+  "observations",
+  "successfulSamples",
+  "runnerTotalN",
+  "p95RunnerTotalMs",
+  "medianRunnerTotalMs",
+  "medianSyncMs",
+  "policyApplied",
+  "policyPassed",
+];
+const comparisonKeys = [
+  "kind",
+  "baselineP95RunnerTotalMs",
+  "candidateP95RunnerTotalMs",
+  "promotedP95RunnerTotalMs",
+];
+const outcomeKeys = [
+  "schema",
+  "status",
+  "stage",
+  "sourceRevision",
+  "recipeDigest",
+  "policyDigest",
+  "plannedLeaseCount",
+  "maxP95RunnerTotalMs",
+  "promotionBindingDigest",
+  "cohorts",
+  "comparison",
+  "candidateSelection",
+  "promotedSelection",
+  "rollbackStatus",
+  "cleanupStatus",
+  "exitCode",
+];
+
 const digest = (value) =>
   `sha256:${createHash("sha256").update(canonicalJSON(value)).digest("hex")}`;
 const isDigest = (value) => typeof value === "string" && /^sha256:[0-9a-f]{64}$/.test(value);
-const number = (value, minimum = 0) =>
+const integer = (value, minimum = 0) =>
   assert.ok(Number.isSafeInteger(value) && value >= minimum, "invalid numeric evidence");
+const nullableInteger = (value, minimum = 0) => {
+  if (value !== null) integer(value, minimum);
+};
+
+function exactKeys(value, keys, label) {
+  assert.ok(value && typeof value === "object" && !Array.isArray(value), `${label} must be an object`);
+  assert.deepEqual(Object.keys(value).sort(), [...keys].sort(), `${label} keys changed`);
+}
 
 export function measurementPolicy(input) {
+  const isPolicy = Object.hasOwn(input, "commandFingerprint");
+  exactKeys(input, isPolicy ? policyKeys : policyInputKeys, "measurement policy");
   assert.match(input.sourceRevision, /^[0-9a-f]{40}$/);
   assert.ok(isDigest(input.recipeDigest), "invalid recipe digest");
   assert.ok(
@@ -32,21 +112,23 @@ export function measurementPolicy(input) {
   for (const key of ["region", "machineType", "serverClass", "ttl", "idleTimeout"]) {
     assert.ok(typeof input[key] === "string" && input[key].length > 0, `missing policy ${key}`);
   }
-  return {
+  const policy = {
     sourceRevision: input.sourceRevision,
     recipeDigest: input.recipeDigest,
     region: input.region,
     machineType: input.machineType,
     serverClass: input.serverClass,
+    maxP95RunnerTotalMs: input.maxP95RunnerTotalMs,
     ttl: input.ttl,
     idleTimeout: input.idleTimeout,
-    maxP95RunnerTotalMs: input.maxP95RunnerTotalMs,
     commandFingerprint: digest(["true"]),
     syncPolicy: "full-resync-no-hydrate",
     capabilities: ["browser", "desktop"],
     samplesPerCohort: 3,
     plannedLeaseCount: 12,
   };
+  if (isPolicy) assert.deepEqual(input, policy, "measurement policy invariants changed");
+  return policy;
 }
 
 function durationString(milliseconds) {
@@ -82,7 +164,6 @@ export function observedSelection(leases, leaseId) {
       `missing observed image ${key}`,
     );
   }
-  // Discard other leases, owners, hosts, and provider metadata before persisting private evidence.
   return {
     id: lease.id,
     provider: lease.provider,
@@ -119,11 +200,7 @@ function validateSelection(policy, phase, selection, candidateImage, baseline) {
     );
     assert.deepEqual(selection.image, baseline.image, "mixed baseline image selection");
   } else {
-    assert.equal(
-      selection.image.id,
-      candidateImage,
-      "selected image differs from captured candidate",
-    );
+    assert.equal(selection.image.id, candidateImage, "selected image differs from captured candidate");
     assert.equal(
       selection.image.source,
       phase === "candidate" ? "explicit" : "promoted",
@@ -132,10 +209,15 @@ function validateSelection(policy, phase, selection, candidateImage, baseline) {
   }
 }
 
-export function validatePromotionReceipt(policy, baseline, receipt, candidateImage) {
+export function validatePromotionReceipt(policyInput, baseline, receipt, candidateImage) {
+  const policy = measurementPolicy(policyInput);
   validateSelection(policy, "baseline", baseline, candidateImage, baseline);
   assert.equal(receipt.image.id, candidateImage, "receipt differs from captured candidate");
   assert.equal(receipt.image.region, policy.region, "receipt image region changed");
+  assert.ok(
+    typeof receipt.image.revision === "string" && receipt.image.revision.length > 0,
+    "missing promoted image revision",
+  );
   if (baseline.image.source === "stock") {
     assert.equal(
       receipt.previous.state,
@@ -166,13 +248,38 @@ export function validatePromotionReceipt(policy, baseline, receipt, candidateIma
   }
 }
 
+function validateRecordIdentity(policy, record) {
+  assert.equal(record.schemaVersion, 1);
+  assert.equal(record.source, "run");
+  assert.equal(record.benchmark.repoHead, policy.sourceRevision, "source identity changed");
+  assert.equal(
+    record.benchmark.commandFingerprint,
+    policy.commandFingerprint,
+    "command identity changed",
+  );
+  assert.ok(isDigest(record.benchmark.repoFingerprint), "missing repository identity");
+  assert.equal(record.benchmark.coldRun, true, "measurement must acquire a fresh lease");
+  assert.equal(record.timing.provider, "aws");
+  assert.equal(record.timing.machineType, policy.machineType, "machine identity changed");
+  assert.match(record.timing.leaseId, /^cbx_[0-9a-f]{12}$/, "missing measurement lease");
+  assert.ok(
+    typeof record.timing.runId === "string" && record.timing.runId.length > 0,
+    "missing run identity",
+  );
+  assert.ok(Number.isSafeInteger(record.timing.exitCode), "missing run exit code");
+  assert.equal(record.timing.syncSkipped, false, "measurement sync was skipped");
+  if (record.timing.runnerTotalMs !== undefined) integer(record.timing.runnerTotalMs, 1);
+  if (record.timing.syncMs !== undefined) integer(record.timing.syncMs);
+}
+
 export function validateCohort(
-  policy,
+  policyInput,
   phase,
   { records, report, check, cleanupIds, selections, handles },
   priorCohorts = [],
   candidateImage,
 ) {
+  const policy = measurementPolicy(policyInput);
   assert.ok(phases.includes(phase), "invalid cohort phase");
   assert.equal(records.length, policy.samplesPerCohort, "insufficient cohort samples");
   assert.equal(selections.length, records.length, "missing sample image observations");
@@ -195,6 +302,7 @@ export function validateCohort(
   for (const [index, record] of records.entries()) {
     const handle = handles[index];
     const selection = selections[index];
+    validateRecordIdentity(policy, record);
     assert.equal(handle.provider, "aws");
     assert.equal(handle.kept, true);
     assert.equal(handle.reused, false, "measurement reused a lease");
@@ -208,28 +316,14 @@ export function validateCohort(
     assert.match(selection.cloudID, /^i-[0-9a-f]{8,17}$/, "missing observed instance identity");
     assert.ok(!clouds.has(selection.cloudID), "reused provider instance");
     assert.ok(!runs.has(handle.runId), "reused run identity");
+    assert.ok(!leases.has(record.timing.leaseId), "reused measurement lease");
     clouds.add(selection.cloudID);
     runs.add(handle.runId);
-    assert.equal(record.schemaVersion, 1);
-    assert.equal(record.source, "run");
-    assert.equal(record.benchmark.repoHead, policy.sourceRevision, "source identity changed");
-    assert.equal(
-      record.benchmark.commandFingerprint,
-      policy.commandFingerprint,
-      "command identity changed",
-    );
-    assert.ok(isDigest(record.benchmark.repoFingerprint), "missing repository identity");
-    assert.equal(record.benchmark.coldRun, true, "measurement must acquire a fresh lease");
-    assert.equal(record.timing.provider, "aws");
-    assert.equal(record.timing.machineType, policy.machineType, "machine identity changed");
-    assert.equal(cohortIdentity(record), identity, "mixed cohort identity");
-    assert.match(record.timing.leaseId, /^cbx_[0-9a-f]{12}$/, "missing measurement lease");
-    assert.ok(!leases.has(record.timing.leaseId), "reused measurement lease");
     leases.add(record.timing.leaseId);
+    assert.equal(cohortIdentity(record), identity, "mixed cohort identity");
     assert.equal(record.timing.exitCode, 0);
-    assert.equal(record.timing.syncSkipped, false, "measurement sync was skipped");
-    number(record.timing.runnerTotalMs, 1);
-    number(record.timing.syncMs);
+    integer(record.timing.runnerTotalMs, 1);
+    integer(record.timing.syncMs);
   }
   assert.equal(report.schemaVersion, 1);
   assert.equal(report.observationCount, 3);
@@ -243,97 +337,308 @@ export function validateCohort(
   assert.equal(group.coldRun, true);
   for (const key of ["n", "observationCount", "runnerTotalN"]) assert.equal(group[key], 3);
   assert.equal(group.failureCount, 0);
-  assert.equal(check.schemaVersion, 1);
-  assert.equal(check.matchedCount, 3);
-  assert.equal(check.groupCount, 1);
-  assert.equal(check.groups.length, 1);
-  assert.equal(check.passed, true, "benchmark policy failed");
-  assert.deepEqual(check.reasons, []);
-  assert.equal(check.policy.minSamples, 3);
-  assert.equal(check.policy.requiredRunnerTotalSamples, 3);
-  assert.equal(check.policy.maxFailures, 0);
-  assert.equal(
-    check.policy.maxP95RunnerTotal,
-    durationString(policy.maxP95RunnerTotalMs),
-    "benchmark threshold differs from the predeclared policy",
-  );
-  const checked = check.groups[0];
-  for (const key of [
-    "source",
-    "provider",
-    "machineType",
-    "coldRun",
-    "failureCount",
-    "runnerTotalN",
-    "observationCount",
-    "p95RunnerTotalMs",
-  ]) {
-    assert.equal(checked[key], group[key], "benchmark check/report mismatch");
+  integer(group.p95RunnerTotalMs, 1);
+  integer(group.medianRunnerTotalMs, 1);
+  integer(group.medianSyncMs);
+  if (phase === "baseline") {
+    assert.equal(check, undefined, "baseline is evidence-only");
+  } else {
+    assert.equal(check.schemaVersion, 1);
+    assert.equal(check.matchedCount, 3);
+    assert.equal(check.groupCount, 1);
+    assert.equal(check.groups.length, 1);
+    assert.equal(check.passed, true, "benchmark policy failed");
+    assert.deepEqual(check.reasons, []);
+    assert.equal(check.policy.minSamples, 3);
+    assert.equal(check.policy.requiredRunnerTotalSamples, 3);
+    assert.equal(check.policy.maxFailures, 0);
+    assert.equal(
+      check.policy.maxP95RunnerTotal,
+      durationString(policy.maxP95RunnerTotalMs),
+      "benchmark threshold differs from the predeclared policy",
+    );
+    const checked = check.groups[0];
+    for (const key of [
+      "source",
+      "provider",
+      "machineType",
+      "coldRun",
+      "failureCount",
+      "runnerTotalN",
+      "observationCount",
+      "p95RunnerTotalMs",
+    ]) {
+      assert.equal(checked[key], group[key], "benchmark check/report mismatch");
+    }
+    assert.equal(checked.successfulSamples, 3);
+    assert.equal(checked.passed, true);
+    assert.deepEqual(checked.reasons, []);
   }
-  assert.equal(checked.successfulSamples, 3);
-  assert.equal(checked.passed, true);
-  assert.deepEqual(checked.reasons, []);
-  number(group.p95RunnerTotalMs, 1);
-  number(group.medianRunnerTotalMs, 1);
-  number(group.medianSyncMs);
-  return {
+  return validateCohortSummary({
     phase,
-    status: "passed",
     observations: 3,
     successfulSamples: 3,
     runnerTotalN: 3,
     p95RunnerTotalMs: group.p95RunnerTotalMs,
     medianRunnerTotalMs: group.medianRunnerTotalMs,
     medianSyncMs: group.medianSyncMs,
-    checkReasons: [],
-  };
+    policyApplied: phase !== "baseline",
+    policyPassed: phase === "baseline" ? null : true,
+  });
 }
 
-export function projectManifest(input, cohorts) {
-  const policy = measurementPolicy(input);
-  assert.deepEqual(
-    cohorts.map((cohort) => cohort.phase),
-    phases,
-  );
-  // Never spread reports, receipts, phase labels, paths, or provider metadata into public proof.
-  const projected = cohorts.map((cohort, index) => {
-    assert.equal(cohort.status, "passed");
-    assert.deepEqual(cohort.checkReasons, []);
-    for (const key of ["observations", "successfulSamples", "runnerTotalN"])
-      assert.equal(cohort[key], 3);
-    for (const key of ["p95RunnerTotalMs", "medianRunnerTotalMs", "medianSyncMs"])
-      number(cohort[key]);
-    return {
-      phase: phases[index],
-      status: "passed",
-      observations: 3,
-      successfulSamples: 3,
-      runnerTotalN: 3,
-      p95RunnerTotalMs: cohort.p95RunnerTotalMs,
-      medianRunnerTotalMs: cohort.medianRunnerTotalMs,
-      medianSyncMs: cohort.medianSyncMs,
-      checkReasons: [],
-    };
+export function partialCohort(policyInput, phase, records) {
+  const policy = measurementPolicy(policyInput);
+  assert.ok(phases.includes(phase), "invalid cohort phase");
+  assert.ok(Array.isArray(records) && records.length <= policy.samplesPerCohort);
+  const leases = new Set();
+  const runs = new Set();
+  let identity = "";
+  for (const record of records) {
+    validateRecordIdentity(policy, record);
+    const currentIdentity = cohortIdentity(record);
+    if (!identity) identity = currentIdentity;
+    assert.equal(currentIdentity, identity, "mixed cohort identity");
+    assert.ok(!leases.has(record.timing.leaseId), "reused measurement lease");
+    assert.ok(!runs.has(record.timing.runId), "reused run identity");
+    leases.add(record.timing.leaseId);
+    runs.add(record.timing.runId);
+  }
+  const successful = records.filter((record) => record.timing.exitCode === 0);
+  return validateCohortSummary({
+    phase,
+    observations: records.length,
+    successfulSamples: successful.length,
+    runnerTotalN: successful.filter((record) => Number.isSafeInteger(record.timing.runnerTotalMs))
+      .length,
+    p95RunnerTotalMs: null,
+    medianRunnerTotalMs: null,
+    medianSyncMs: null,
+    policyApplied: phase !== "baseline",
+    policyPassed: phase === "baseline" ? null : false,
   });
-  return {
-    schema: "crabbox-devtools-image-proof/v1",
-    status: "passed",
+}
+
+export function validateCohortSummary(cohort) {
+  exactKeys(cohort, cohortKeys, "public cohort");
+  assert.ok(phases.includes(cohort.phase), "invalid cohort phase");
+  for (const key of ["observations", "successfulSamples", "runnerTotalN"]) integer(cohort[key]);
+  assert.ok(cohort.observations <= 3, "too many cohort observations");
+  assert.ok(cohort.successfulSamples <= cohort.observations, "invalid successful sample count");
+  assert.ok(cohort.runnerTotalN <= cohort.successfulSamples, "invalid runner sample count");
+  for (const key of ["p95RunnerTotalMs", "medianRunnerTotalMs", "medianSyncMs"])
+    nullableInteger(cohort[key]);
+  assert.equal(cohort.policyApplied, cohort.phase !== "baseline", "cohort policy scope changed");
+  if (cohort.phase === "baseline") {
+    assert.equal(cohort.policyPassed, null, "baseline is evidence-only");
+  } else {
+    assert.equal(typeof cohort.policyPassed, "boolean");
+  }
+  if (cohort.policyPassed === true) {
+    assert.equal(cohort.observations, 3);
+    assert.equal(cohort.successfulSamples, 3);
+    assert.equal(cohort.runnerTotalN, 3);
+    integer(cohort.p95RunnerTotalMs, 1);
+  }
+  const measures = [
+    cohort.p95RunnerTotalMs,
+    cohort.medianRunnerTotalMs,
+    cohort.medianSyncMs,
+  ];
+  if (measures.some((value) => value !== null)) {
+    assert.ok(measures.every((value) => value !== null), "incomplete cohort measures");
+    assert.equal(cohort.observations, 3);
+    assert.equal(cohort.successfulSamples, 3);
+    assert.equal(cohort.runnerTotalN, 3);
+  }
+  if (cohort.policyPassed === false)
+    assert.ok(measures.every((value) => value === null), "failed policy exposed final measures");
+  return cohort;
+}
+
+function promotionBinding(receipt) {
+  if (!receipt) return null;
+  assert.match(receipt.image?.id, /^ami-[a-z0-9]+$/, "invalid promoted image identity");
+  assert.ok(
+    typeof receipt.image?.revision === "string" && receipt.image.revision.length > 0,
+    "missing promoted image revision",
+  );
+  return digest(["aws-image-promotion", receipt.image.id, receipt.image.revision]);
+}
+
+export function projectOutcome(policyInput, state = {}) {
+  const policy = measurementPolicy(policyInput);
+  const {
+    status = "initialized",
+    stage = "preflight",
+    exitCode = null,
+    rollbackStatus = "not_required",
+    cleanupStatus = "not_started",
+    cohorts = [],
+    promotionReceipt = null,
+  } = state;
+  assert.ok(outcomeStatuses.includes(status), "invalid outcome status");
+  assert.ok(stages.includes(stage), "invalid outcome stage");
+  assert.ok(rollbackStatuses.includes(rollbackStatus), "invalid rollback status");
+  assert.ok(cleanupStatuses.includes(cleanupStatus), "invalid cleanup status");
+  if (exitCode !== null) {
+    integer(exitCode);
+    assert.ok(exitCode <= 255, "invalid outcome exit code");
+  }
+  assert.deepEqual(
+    cohorts.map((cohort) => validateCohortSummary(cohort).phase),
+    phases.slice(0, cohorts.length),
+    "cohorts must be ordered without gaps",
+  );
+  const byPhase = Object.fromEntries(cohorts.map((cohort) => [cohort.phase, cohort]));
+  const outcome = {
+    schema: "crabbox-devtools-image-proof/v2",
+    status,
+    stage,
     sourceRevision: policy.sourceRevision,
     recipeDigest: policy.recipeDigest,
     policyDigest: digest(policy),
-    plannedLeaseCount: 12,
+    plannedLeaseCount: policy.plannedLeaseCount,
     maxP95RunnerTotalMs: policy.maxP95RunnerTotalMs,
-    cohorts: projected,
+    promotionBindingDigest: promotionBinding(promotionReceipt),
+    cohorts,
     comparison: {
       kind: "descriptive_only",
-      baselineP95RunnerTotalMs: projected[0].p95RunnerTotalMs,
-      candidateP95RunnerTotalMs: projected[1].p95RunnerTotalMs,
-      promotedP95RunnerTotalMs: projected[2].p95RunnerTotalMs,
+      baselineP95RunnerTotalMs: byPhase.baseline?.p95RunnerTotalMs ?? null,
+      candidateP95RunnerTotalMs: byPhase.candidate?.p95RunnerTotalMs ?? null,
+      promotedP95RunnerTotalMs: byPhase.promoted?.p95RunnerTotalMs ?? null,
     },
-    candidateSelection: "explicit",
-    promotedSelection: "promoted",
-    rollback: "not_needed",
+    candidateSelection: byPhase.candidate?.policyPassed === true ? "explicit" : "not_observed",
+    promotedSelection: byPhase.promoted?.policyPassed === true ? "promoted" : "not_observed",
+    rollbackStatus,
+    cleanupStatus,
+    exitCode,
   };
+  return validateOutcome(outcome);
+}
+
+export function projectManifest(policy, cohorts, promotionReceipt) {
+  return projectOutcome(policy, {
+    status: "passed",
+    stage: "complete",
+    exitCode: 0,
+    rollbackStatus: "not_required",
+    cleanupStatus: "succeeded",
+    cohorts,
+    promotionReceipt,
+  });
+}
+
+export function validateOutcome(outcome) {
+  exactKeys(outcome, outcomeKeys, "public outcome");
+  assert.equal(outcome.schema, "crabbox-devtools-image-proof/v2");
+  assert.ok(outcomeStatuses.includes(outcome.status), "invalid outcome status");
+  assert.ok(stages.includes(outcome.stage), "invalid outcome stage");
+  assert.match(outcome.sourceRevision, /^[0-9a-f]{40}$/);
+  for (const key of ["recipeDigest", "policyDigest"]) assert.ok(isDigest(outcome[key]));
+  if (outcome.promotionBindingDigest !== null)
+    assert.ok(isDigest(outcome.promotionBindingDigest), "invalid promotion binding digest");
+  assert.equal(outcome.plannedLeaseCount, 12);
+  integer(outcome.maxP95RunnerTotalMs, 1);
+  assert.ok(Array.isArray(outcome.cohorts) && outcome.cohorts.length <= 3);
+  assert.deepEqual(
+    outcome.cohorts.map((cohort) => validateCohortSummary(cohort).phase),
+    phases.slice(0, outcome.cohorts.length),
+    "cohorts must be ordered without gaps",
+  );
+  exactKeys(outcome.comparison, comparisonKeys, "public comparison");
+  assert.equal(outcome.comparison.kind, "descriptive_only");
+  for (const key of comparisonKeys.slice(1)) nullableInteger(outcome.comparison[key]);
+  assert.ok(["not_observed", "explicit"].includes(outcome.candidateSelection));
+  assert.ok(["not_observed", "promoted"].includes(outcome.promotedSelection));
+  const byPhase = Object.fromEntries(outcome.cohorts.map((cohort) => [cohort.phase, cohort]));
+  assert.deepEqual(outcome.comparison, {
+    kind: "descriptive_only",
+    baselineP95RunnerTotalMs: byPhase.baseline?.p95RunnerTotalMs ?? null,
+    candidateP95RunnerTotalMs: byPhase.candidate?.p95RunnerTotalMs ?? null,
+    promotedP95RunnerTotalMs: byPhase.promoted?.p95RunnerTotalMs ?? null,
+  });
+  assert.equal(
+    outcome.candidateSelection,
+    byPhase.candidate?.policyPassed === true ? "explicit" : "not_observed",
+  );
+  assert.equal(
+    outcome.promotedSelection,
+    byPhase.promoted?.policyPassed === true ? "promoted" : "not_observed",
+  );
+  assert.ok(rollbackStatuses.includes(outcome.rollbackStatus));
+  assert.ok(cleanupStatuses.includes(outcome.cleanupStatus));
+  const cohortComplete = (cohort) =>
+    cohort.observations === 3 &&
+    cohort.successfulSamples === 3 &&
+    cohort.runnerTotalN === 3 &&
+    cohort.p95RunnerTotalMs !== null &&
+    cohort.medianRunnerTotalMs !== null &&
+    cohort.medianSyncMs !== null &&
+    (cohort.phase === "baseline" || cohort.policyPassed === true);
+  const stageIndex = stages.indexOf(outcome.stage);
+  const minimumCohorts =
+    stageIndex >= stages.indexOf("proof")
+      ? 3
+      : stageIndex >= stages.indexOf("promotion")
+        ? 2
+        : stageIndex >= stages.indexOf("source_prepare")
+          ? 1
+          : 0;
+  const maximumCohorts =
+    stageIndex >= stages.indexOf("promoted_measure")
+      ? 3
+      : stageIndex >= stages.indexOf("candidate_measure")
+        ? 2
+        : stageIndex >= stages.indexOf("baseline")
+          ? 1
+          : 0;
+  assert.ok(
+    outcome.cohorts.length >= minimumCohorts && outcome.cohorts.length <= maximumCohorts,
+    "cohort evidence conflicts with publication stage",
+  );
+  assert.ok(
+    outcome.cohorts.slice(0, minimumCohorts).every(cohortComplete),
+    "publication stage requires complete prior cohorts",
+  );
+  if (stageIndex < stages.indexOf("promotion"))
+    assert.equal(outcome.promotionBindingDigest, null, "promotion preceded its stage");
+  if (stageIndex >= stages.indexOf("promoted_smoke"))
+    assert.ok(isDigest(outcome.promotionBindingDigest), "missing promotion binding");
+  if (stageIndex < stages.indexOf("promoted_smoke"))
+    assert.equal(outcome.rollbackStatus, "not_required", "rollback preceded promotion");
+  if (outcome.status === "initialized") {
+    assert.equal(outcome.stage, "preflight");
+    assert.equal(outcome.exitCode, null);
+    assert.equal(outcome.cleanupStatus, "not_started");
+    assert.equal(outcome.rollbackStatus, "not_required");
+    assert.deepEqual(outcome.cohorts, []);
+  } else {
+    integer(outcome.exitCode, outcome.status === "failed" ? 1 : 0);
+    assert.notEqual(outcome.cleanupStatus, "not_started");
+  }
+  if (outcome.status === "passed") {
+    assert.equal(outcome.stage, "complete");
+    assert.equal(outcome.exitCode, 0);
+    assert.equal(outcome.cleanupStatus, "succeeded");
+    assert.equal(outcome.rollbackStatus, "not_required");
+    assert.ok(isDigest(outcome.promotionBindingDigest), "missing promotion binding");
+    assert.equal(outcome.cohorts.length, 3);
+    assert.equal(outcome.cohorts[1].policyPassed, true);
+    assert.equal(outcome.cohorts[2].policyPassed, true);
+    assert.equal(outcome.candidateSelection, "explicit");
+    assert.equal(outcome.promotedSelection, "promoted");
+  }
+  if (outcome.rollbackStatus === "succeeded")
+    assert.ok(isDigest(outcome.promotionBindingDigest), "rollback is not bound to a promotion");
+  return outcome;
+}
+
+async function writeAtomic(path, value) {
+  await mkdir(dirname(path), { recursive: true });
+  const pending = `${path}.tmp-${process.pid}-${randomBytes(6).toString("hex")}`;
+  await writeFile(pending, `${canonicalJSON(value)}\n`, { mode: 0o600 });
+  await rename(pending, path);
 }
 
 async function preflight(args) {
@@ -371,7 +676,8 @@ async function preflight(args) {
     process.env.CRABBOX_OWNER?.trim() && process.env.CRABBOX_ORG?.trim(),
     "measured mode requires CRABBOX_OWNER and CRABBOX_ORG for bounded lease evidence",
   );
-  const git = (args) => execFileSync("git", ["-C", root, ...args], { encoding: "utf8" }).trim();
+  const git = (gitArgs) =>
+    execFileSync("git", ["-C", root, ...gitArgs], { encoding: "utf8" }).trim();
   const sourceRevision = git(["rev-parse", "HEAD"]);
   assert.equal(
     git(["status", "--porcelain", "--untracked-files=all"]),
@@ -406,8 +712,9 @@ async function loadCohort(directory, phase) {
   const records = await recordsFrom(resolve(directory, `${phase}.jsonl`));
   const cleanupIds = (await readFile(resolve(directory, `${phase}-cleanup.ids`), "utf8"))
     .trim()
-    .split("\n");
-  return {
+    .split("\n")
+    .filter(Boolean);
+  const result = {
     records,
     cleanupIds,
     handles: await Promise.all(
@@ -417,14 +724,47 @@ async function loadCohort(directory, phase) {
       records.map((_, index) => json(resolve(directory, `${phase}-${index + 1}.selection.json`))),
     ),
     report: await json(resolve(directory, `${phase}-report.json`)),
-    check: await json(resolve(directory, `${phase}-check.json`)),
   };
+  if (phase !== "baseline") result.check = await json(resolve(directory, `${phase}-check.json`));
+  return result;
+}
+
+async function loadProjectedCohorts(directory) {
+  if (!directory || directory === "-") return [];
+  const cohorts = [];
+  for (const phase of phases) {
+    try {
+      cohorts.push(validateCohortSummary(await json(resolve(directory, `${phase}-cohort.json`))));
+    } catch (error) {
+      if (error.code === "ENOENT") break;
+      throw error;
+    }
+  }
+  return cohorts;
+}
+
+async function readStdin() {
+  let input = "";
+  process.stdin.setEncoding("utf8");
+  for await (const chunk of process.stdin) input += chunk;
+  return input;
 }
 
 async function main([command, ...args]) {
   if (command === "preflight") return preflight(args);
+  if (command === "initialize") {
+    const [output, ...preflightArgs] = args;
+    const policy = await preflight(preflightArgs);
+    await writeAtomic(output, projectOutcome(policy));
+    return;
+  }
+  if (command === "initialize-policy") {
+    const [output, policyPath] = args;
+    await writeAtomic(output, projectOutcome(await json(policyPath)));
+    return;
+  }
   if (command === "select") {
-    return observedSelection(parseStrictJSON(readFileSync(0, "utf8"), "lease listing"), args[0]);
+    return observedSelection(parseStrictJSON(await readStdin(), "lease listing"), args[0]);
   }
   if (command === "handle") return { leaseId: handleLeaseId(await json(args[0])) };
   if (command === "sample") {
@@ -435,7 +775,6 @@ async function main([command, ...args]) {
     } catch (error) {
       if (error.code !== "ENOENT") throw error;
     }
-    // Failed admission can precede handle publication; only the attempted timing row may recover it.
     let leaseId;
     if (handle) leaseId = handleLeaseId(handle);
     else {
@@ -461,39 +800,65 @@ async function main([command, ...args]) {
   if (command === "receipt") {
     const [policyPath, baselinePath, receiptPath, candidateImage] = args;
     validatePromotionReceipt(
-      measurementPolicy(await json(policyPath)),
+      await json(policyPath),
       await json(baselinePath),
       await json(receiptPath),
       candidateImage,
     );
     return { status: "passed" };
   }
-  assert.ok(command === "cohort" || command === "manifest", "unknown proof command");
-  const [policyPath, directory, phaseOrReceipt, candidateImage] = args;
-  const policy = measurementPolicy(await json(policyPath));
-  const selected =
-    command === "manifest" ? phases : phases.slice(0, phases.indexOf(phaseOrReceipt) + 1);
-  assert.ok(selected.length > 0, "invalid cohort phase");
-  const prior = [];
-  const summaries = [];
-  for (const current of selected) {
-    const input = await loadCohort(directory, current);
-    summaries.push(validateCohort(policy, current, input, prior, candidateImage));
-    prior.push(input);
+  if (command === "partial") {
+    const [policyPath, store, phase, output] = args;
+    const summary = partialCohort(await json(policyPath), phase, await recordsFrom(store));
+    await writeAtomic(output, summary);
+    return;
   }
-  if (command === "manifest") {
-    validatePromotionReceipt(
+  if (command === "cohort") {
+    const [policyPath, directory, phase, candidateImage, output] = args;
+    const policy = measurementPolicy(await json(policyPath));
+    const prior = [];
+    for (const current of phases.slice(0, phases.indexOf(phase))) {
+      prior.push(await loadCohort(directory, current));
+    }
+    const summary = validateCohort(
       policy,
-      await json(resolve(directory, "baseline-1.selection.json")),
-      await json(phaseOrReceipt),
+      phase,
+      await loadCohort(directory, phase),
+      prior,
       candidateImage,
     );
-    return projectManifest(policy, summaries);
+    if (output) await writeAtomic(output, summary);
+    return summary;
   }
-  return summaries.at(-1);
+  if (command === "finalize") {
+    const [
+      output,
+      policyPath,
+      directory,
+      stage,
+      exitCode,
+      rollbackStatus,
+      cleanupStatus,
+      receiptPath,
+    ] = args;
+    const code = Number(exitCode);
+    const outcome = projectOutcome(await json(policyPath), {
+      status: code === 0 ? "passed" : "failed",
+      stage,
+      exitCode: code,
+      rollbackStatus,
+      cleanupStatus,
+      cohorts: await loadProjectedCohorts(directory),
+      promotionReceipt: receiptPath && receiptPath !== "-" ? await json(receiptPath) : null,
+    });
+    await writeAtomic(output, outcome);
+    return;
+  }
+  if (command === "validate") return validateOutcome(await json(args[0]));
+  assert.fail("unknown proof command");
 }
 
 if (process.argv[1] && realpathSync(process.argv[1]) === realpathSync(scriptPath)) {
   const result = await main(process.argv.slice(2));
-  process.stdout.write(`${canonicalJSON(result)}\n`);
+  if (result !== undefined) process.stdout.write(`${canonicalJSON(result)}\n`);
 }

--- a/scripts/devtools-image-proof.mjs
+++ b/scripts/devtools-image-proof.mjs
@@ -629,8 +629,12 @@ export function validateOutcome(outcome) {
     assert.equal(outcome.candidateSelection, "explicit");
     assert.equal(outcome.promotedSelection, "promoted");
   }
-  if (outcome.rollbackStatus !== "not_required")
+  if (outcome.rollbackStatus === "succeeded")
     assert.ok(isDigest(outcome.promotionBindingDigest), "rollback is not bound to a promotion");
+  if (outcome.rollbackStatus === "failed" && outcome.promotionBindingDigest === null) {
+    assert.equal(outcome.status, "failed", "unbound rollback failure cannot pass");
+    assert.equal(outcome.stage, "promotion", "unbound rollback failure must be receipt-less");
+  }
   return outcome;
 }
 

--- a/scripts/devtools-image-proof.mjs
+++ b/scripts/devtools-image-proof.mjs
@@ -605,7 +605,7 @@ export function validateOutcome(outcome) {
     assert.equal(outcome.promotionBindingDigest, null, "promotion preceded its stage");
   if (stageIndex >= stages.indexOf("promoted_smoke"))
     assert.ok(isDigest(outcome.promotionBindingDigest), "missing promotion binding");
-  if (stageIndex < stages.indexOf("promoted_smoke"))
+  if (stageIndex < stages.indexOf("promotion"))
     assert.equal(outcome.rollbackStatus, "not_required", "rollback preceded promotion");
   if (outcome.status === "initialized") {
     assert.equal(outcome.stage, "preflight");
@@ -629,7 +629,7 @@ export function validateOutcome(outcome) {
     assert.equal(outcome.candidateSelection, "explicit");
     assert.equal(outcome.promotedSelection, "promoted");
   }
-  if (outcome.rollbackStatus === "succeeded")
+  if (outcome.rollbackStatus !== "not_required")
     assert.ok(isDigest(outcome.promotionBindingDigest), "rollback is not bound to a promotion");
   return outcome;
 }

--- a/scripts/devtools-image-proof.test.mjs
+++ b/scripts/devtools-image-proof.test.mjs
@@ -468,4 +468,15 @@ test("promotion-stage failures retain bound rollback outcomes", () => {
       promotionBindingDigest: null,
     }),
   );
+  const receiptUnavailable = projectOutcome(policy, {
+    status: "failed",
+    stage: "promotion",
+    exitCode: 55,
+    rollbackStatus: "failed",
+    cleanupStatus: "succeeded",
+    cohorts: [baseline, candidate],
+  });
+  assert.equal(receiptUnavailable.promotionBindingDigest, null);
+  assert.throws(() => validateOutcome({ ...receiptUnavailable, stage: "promoted_smoke" }));
+  assert.throws(() => validateOutcome({ ...receiptUnavailable, status: "passed", exitCode: 0 }));
 });

--- a/scripts/devtools-image-proof.test.mjs
+++ b/scripts/devtools-image-proof.test.mjs
@@ -5,8 +5,11 @@ import test from "node:test";
 import {
   measurementPolicy,
   observedSelection,
+  partialCohort,
   projectManifest,
+  projectOutcome,
   validateCohort,
+  validateOutcome,
   validatePromotionReceipt,
 } from "./devtools-image-proof.mjs";
 
@@ -109,7 +112,7 @@ function cohort(offset = 0) {
       promotedAt: "2026-09-01T00:00:00Z",
     },
   }));
-  return {
+  const result = {
     records,
     report,
     check,
@@ -124,6 +127,8 @@ function cohort(offset = 0) {
     })),
     cleanupIds: records.map((record) => record.timing.leaseId),
   };
+  if (offset === 0) delete result.check;
+  return result;
 }
 
 test("measured policy requires an explicit positive threshold and names 12 planned leases", () => {
@@ -167,15 +172,6 @@ test("cohorts accept measured zero-duration sync but reject missing, mixed, or r
       value.report.groups.push(value.report.groups[0]);
     },
     (value) => {
-      value.check.passed = false;
-    },
-    (value) => {
-      value.check.policy.maxP95RunnerTotal = "1h0m0s";
-    },
-    (value) => {
-      value.check.groups[0].runnerTotalN = 2;
-    },
-    (value) => {
       value.handles[0].kept = false;
     },
     (value) => {
@@ -197,6 +193,23 @@ test("cohorts accept measured zero-duration sync but reject missing, mixed, or r
     const mutated = structuredClone(input);
     mutate(mutated);
     assert.throws(() => validateCohort(policy, "baseline", mutated));
+  }
+  for (const mutate of [
+    (value) => {
+      value.check.passed = false;
+    },
+    (value) => {
+      value.check.policy.maxP95RunnerTotal = "1h0m0s";
+    },
+    (value) => {
+      value.check.groups[0].runnerTotalN = 2;
+    },
+  ]) {
+    const candidate = cohort(3);
+    mutate(candidate);
+    assert.throws(() =>
+      validateCohort(policy, "candidate", candidate, [input], "ami-candidate"),
+    );
   }
   assert.throws(() => validateCohort(policy, "baseline", input, [input]), /reused/);
   const mixed = cohort(3);
@@ -263,7 +276,7 @@ test("selection must be an actual unambiguous observation, not requested values"
 test("baseline selection reconciles with the original promotion receipt", () => {
   const baseline = cohort().selections[0];
   const receipt = {
-    image: { id: "ami-candidate", region: policy.region },
+    image: { id: "ami-candidate", region: policy.region, revision: "revision-1" },
     previous: {
       state: "present",
       imageId: baseline.image.id,
@@ -313,25 +326,110 @@ test("public proof is an allowlisted projection, not raw reports or arbitrary st
     input.report.storePath = poison;
     input.report.groups[0].providerFamily = poison;
     input.report.groups[0].runnerPhases = [{ name: poison, ms: 1000 }];
-    input.check.groups[0].providerCategory = poison;
+    if (input.check) input.check.groups[0].providerCategory = poison;
     input.records[0].benchmark.commandDisplay = poison;
     input.records[0].timing.repoPath = poison;
     return validateCohort(policy, phase, input, [], "ami-candidate");
   });
-  const manifest = projectManifest(policy, inputs);
+  const receipt = {
+    image: { id: "ami-candidate", revision: "revision-1" },
+  };
+  const manifest = projectManifest(policy, inputs, receipt);
   assert.doesNotMatch(JSON.stringify(manifest), new RegExp(poison));
+  assert.deepEqual(Object.keys(manifest), [
+    "schema",
+    "status",
+    "stage",
+    "sourceRevision",
+    "recipeDigest",
+    "policyDigest",
+    "plannedLeaseCount",
+    "maxP95RunnerTotalMs",
+    "promotionBindingDigest",
+    "cohorts",
+    "comparison",
+    "candidateSelection",
+    "promotedSelection",
+    "rollbackStatus",
+    "cleanupStatus",
+    "exitCode",
+  ]);
+  assert.deepEqual(Object.keys(manifest.cohorts[0]), [
+    "phase",
+    "observations",
+    "successfulSamples",
+    "runnerTotalN",
+    "p95RunnerTotalMs",
+    "medianRunnerTotalMs",
+    "medianSyncMs",
+    "policyApplied",
+    "policyPassed",
+  ]);
+  assert.equal(manifest.schema, "crabbox-devtools-image-proof/v2");
   assert.equal(manifest.comparison.kind, "descriptive_only");
-  assert.equal(manifest.rollback, "not_needed");
+  assert.equal(manifest.rollbackStatus, "not_required");
+  assert.equal(
+    manifest.promotionBindingDigest,
+    fingerprint(["aws-image-promotion", "ami-candidate", "revision-1"]),
+  );
   assert.equal(manifest.plannedLeaseCount, 12);
   assert.throws(() => projectManifest(policy, inputs.slice(0, 2)));
-  const bad = cohort();
-  bad.check.reasons = [poison];
-  assert.throws(() => validateCohort(policy, "baseline", bad));
   assert.throws(() => validateCohort(policy, poison, cohort()));
   assert.throws(() =>
-    projectManifest(
-      policy,
-      inputs.map((input) => ({ ...input, checkReasons: [poison] })),
-    ),
+    projectManifest(policy, inputs.map((input) => ({ ...input, poison })), receipt),
+  );
+  assert.throws(() => validateOutcome({ ...manifest, poison }));
+  assert.throws(() =>
+    validateOutcome({
+      ...manifest,
+      comparison: { ...manifest.comparison, candidateP95RunnerTotalMs: 999 },
+    }),
+  );
+  assert.throws(() => validateOutcome({ ...manifest, candidateSelection: "not_observed" }));
+  assert.throws(() => validateOutcome({ ...manifest, stage: "candidate_measure" }));
+  assert.throws(() =>
+    validateOutcome({
+      ...manifest,
+      cohorts: manifest.cohorts.map((value, index) =>
+        index === 1 ? { ...value, medianSyncMs: null } : value,
+      ),
+    }),
+  );
+  assert.doesNotMatch(JSON.stringify(manifest), /ami-candidate|revision-1/);
+});
+
+test("failed outcomes retain only validated partial cohorts", () => {
+  const early = projectOutcome(policy, {
+    status: "failed",
+    stage: "baseline",
+    exitCode: 41,
+    cleanupStatus: "succeeded",
+    cohorts: [partialCohort(policy, "baseline", cohort().records.slice(0, 2))],
+  });
+  assert.equal(early.cohorts[0].observations, 2);
+  const baseline = validateCohort(policy, "baseline", cohort(), [], "ami-candidate");
+  const candidate = partialCohort(policy, "candidate", cohort(3).records.slice(0, 1));
+  const outcome = projectOutcome(policy, {
+    status: "failed",
+    stage: "candidate_measure",
+    exitCode: 41,
+    cleanupStatus: "succeeded",
+    cohorts: [baseline, candidate],
+  });
+  assert.equal(outcome.cohorts[0].policyApplied, false);
+  assert.equal(outcome.cohorts[0].policyPassed, null);
+  assert.equal(outcome.cohorts[1].policyApplied, true);
+  assert.equal(outcome.cohorts[1].policyPassed, false);
+  assert.equal(outcome.cohorts[1].observations, 1);
+  assert.equal(outcome.comparison.candidateP95RunnerTotalMs, null);
+  assert.throws(() => validateOutcome({ ...outcome, stage: "unknown" }));
+  assert.throws(() => validateOutcome({ ...outcome, rollbackStatus: "maybe" }));
+  assert.throws(() => validateOutcome({ ...outcome, promotionBindingDigest: fingerprint("early") }));
+  assert.throws(() => validateOutcome({ ...outcome, cleanupStatus: "not_started" }));
+  assert.throws(() =>
+    validateOutcome({
+      ...outcome,
+      policyDigest: "sha256:not-a-digest",
+    }),
   );
 });

--- a/scripts/devtools-image-proof.test.mjs
+++ b/scripts/devtools-image-proof.test.mjs
@@ -433,3 +433,39 @@ test("failed outcomes retain only validated partial cohorts", () => {
     }),
   );
 });
+
+test("promotion-stage failures retain bound rollback outcomes", () => {
+  const baselineInput = cohort();
+  const candidateInput = cohort(3);
+  const baseline = validateCohort(policy, "baseline", baselineInput, [], "ami-candidate");
+  const candidate = validateCohort(
+    policy,
+    "candidate",
+    candidateInput,
+    [baselineInput],
+    "ami-candidate",
+  );
+  const receipt = {
+    image: { id: "ami-candidate", region: policy.region, revision: "revision-1" },
+  };
+  const outcome = projectOutcome(policy, {
+    status: "failed",
+    stage: "promotion",
+    exitCode: 1,
+    rollbackStatus: "succeeded",
+    cleanupStatus: "succeeded",
+    cohorts: [baseline, candidate],
+    promotionReceipt: receipt,
+  });
+  assert.equal(outcome.rollbackStatus, "succeeded");
+  assert.equal(
+    outcome.promotionBindingDigest,
+    fingerprint(["aws-image-promotion", "ami-candidate", "revision-1"]),
+  );
+  assert.throws(() =>
+    validateOutcome({
+      ...outcome,
+      promotionBindingDigest: null,
+    }),
+  );
+});

--- a/scripts/devtools-image-smoke-linux.sh
+++ b/scripts/devtools-image-smoke-linux.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+echo devtools-smoke-ok
+uname -a
+command -v git
+command -v gh
+command -v jq
+command -v rg
+command -v fd
+command -v python3
+command -v node
+command -v npm
+command -v corepack
+command -v pnpm
+command -v trufflehog
+trufflehog --no-update --version
+command -v docker
+node --version
+# shellcheck disable=SC2016
+node -e 'if (Number(process.versions.node.split(".")[0]) < 24) throw new Error(`Node.js 24 or newer is required, found ${process.version}`)'
+corepack --version
+pnpm --version
+docker_group_member() {
+  if id -nG 2>/dev/null | tr ' ' '\n' | grep -qx docker; then
+    return 0
+  fi
+  local current_user docker_entry docker_members member
+  current_user="$(whoami)"
+  docker_entry="$(getent group docker 2>/dev/null || true)"
+  [[ -n "$docker_entry" ]] || return 1
+  docker_members="${docker_entry#*:*:*:}"
+  local IFS=','
+  local -a docker_member_list
+  read -ra docker_member_list <<<"$docker_members"
+  for member in "${docker_member_list[@]}"; do
+    [[ "$member" == "$current_user" ]] && return 0
+  done
+  return 1
+}
+docker_probe='docker version && docker compose version && docker image inspect hello-world ubuntu:24.04 node:24-bookworm >/dev/null'
+if ! sh -c "$docker_probe"; then
+  if command -v sg >/dev/null 2>&1 && docker_group_member; then
+    sg docker -c "$docker_probe"
+  else
+    sudo sh -c "$docker_probe"
+  fi
+fi
+test -d /var/cache/crabbox/pnpm
+test -f /var/lib/crabbox-readiness/linux.json
+test -f /var/lib/crabbox/image-ready

--- a/scripts/devtools-image-smoke-linux.sh
+++ b/scripts/devtools-image-smoke-linux.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 set -euo pipefail
 echo devtools-smoke-ok
 uname -a
@@ -17,7 +15,6 @@ command -v trufflehog
 trufflehog --no-update --version
 command -v docker
 node --version
-# shellcheck disable=SC2016
 node -e 'if (Number(process.versions.node.split(".")[0]) < 24) throw new Error(`Node.js 24 or newer is required, found ${process.version}`)'
 corepack --version
 pnpm --version

--- a/scripts/devtools-image-smoke-windows.ps1
+++ b/scripts/devtools-image-smoke-windows.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = "Stop"
+Write-Output "devtools-smoke-ok"
+Get-ComputerInfo | Select-Object OsName, OsVersion, OsBuildNumber | Format-List
+git --version
+gh --version | Select-Object -First 1
+jq --version
+rg --version | Select-Object -First 1
+fd --version
+python --version
+node --version
+$nodeMajor = [int](node -p "process.versions.node.split('.')[0]")
+if ($nodeMajor -lt 24) { throw "Node.js 24 or newer is required, found major $nodeMajor" }
+npm --version
+corepack --version
+pnpm --version
+trufflehog --no-update --version
+docker --version
+docker version
+docker image inspect mcr.microsoft.com/windows/servercore:ltsc2022 | Out-Null

--- a/scripts/devtools-image-workflow.test.js
+++ b/scripts/devtools-image-workflow.test.js
@@ -72,6 +72,7 @@ test("measured Linux publication is explicit and declares its threshold and extr
   );
   assert.match(workflow, /public_outcome="\$RUNNER_TEMP\/devtools-image-proof\/manifest\.json"/);
   assert.match(workflow, /name: Initialize measured publication outcome/);
+  assert.match(workflow, /echo '- Status: `outcome_unavailable`'/);
   assert.match(workflow, /"\$\{command\[@\]\}" >"\$private_dir\/publish\.log" 2>&1/);
   assert.match(workflow, /devtools-image-proof\.mjs validate/);
   assert.doesNotMatch(workflow, /\bcp "\$\{manifests/);

--- a/scripts/devtools-image-workflow.test.js
+++ b/scripts/devtools-image-workflow.test.js
@@ -63,10 +63,18 @@ test("measured Linux publication is explicit and declares its threshold and extr
   );
   assert.match(
     workflow,
-    /name: Upload allowlisted measurement manifest[\s\S]*if: success\(\) && inputs\.measured/,
+    /name: Upload allowlisted measurement manifest[\s\S]*if: always\(\) && inputs\.measured/,
   );
   assert.match(workflow, /path: \$\{\{ runner\.temp \}\}\/devtools-image-proof\/manifest\.json/);
+  assert.match(
+    workflow,
+    /export CRABBOX_IMAGE_PUBLIC_OUTCOME="\$proof_dir\/manifest\.json"/,
+  );
+  assert.match(workflow, /public_outcome="\$RUNNER_TEMP\/devtools-image-proof\/manifest\.json"/);
+  assert.match(workflow, /name: Initialize measured publication outcome/);
   assert.match(workflow, /"\$\{command\[@\]\}" >"\$private_dir\/publish\.log" 2>&1/);
-  assert.match(workflow, /cp "\$\{manifests\[0\]\}" "\$proof_dir\/manifest\.json"/);
+  assert.match(workflow, /devtools-image-proof\.mjs validate/);
+  assert.doesNotMatch(workflow, /\bcp "\$\{manifests/);
+  assert.doesNotMatch(workflow, /run-name:.*\$\{\{ inputs\.(?:region|linux_type)/);
   assert.doesNotMatch(workflow, /sanitized.*(?:logs|diagnostics)/i);
 });

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -31,6 +31,10 @@ measured=0
 max_p95_runner_total_ms=""
 measurement_dir=""
 measurement_policy=""
+public_outcome="${CRABBOX_IMAGE_PUBLIC_OUTCOME:-}"
+outcome_stage="preflight"
+rollback_status="not_required"
+cleanup_status="not_started"
 windows_reboot_marker='C:\ProgramData\crabbox\image-prep-reboot-required'
 
 usage() {
@@ -232,6 +236,15 @@ if [[ "$measured" == "1" ]]; then
     "$desktop" "$browser" "$promote" "$keep_lease" "$fast_snapshot_restore" "$ttl" "$idle_timeout")"
   # Candidate selection is explicit below; baseline and promoted proof use normal selection.
   unset CRABBOX_AWS_AMI
+  umask 077
+  mkdir -p "$log_dir"
+  measurement_dir="$(mktemp -d "$log_dir/measurement-${log_id}.XXXXXX")"
+  printf '%s\n' "$measurement_policy" >"$measurement_dir/policy.json"
+  if [[ -z "$public_outcome" ]]; then
+    public_outcome="$measurement_dir/manifest.json"
+  fi
+  node "$ROOT/scripts/devtools-image-proof.mjs" initialize-policy \
+    "$public_outcome" "$measurement_dir/policy.json"
 elif [[ -n "$max_p95_runner_total_ms" ]]; then
   printf '%s\n' '--max-p95-runner-total-ms requires --measured' >&2
   exit 2
@@ -244,24 +257,63 @@ measurement_lease=""
 measurement_handle=""
 promotion_log=""
 rollback_pending=0
+publisher_pid="$BASHPID"
 
 cleanup() {
   local exit_status=$?
   trap - EXIT
+  if [[ "${BASH_SUBSHELL:-0}" != "0" || "$BASHPID" != "$publisher_pid" ]]; then
+    return "$exit_status"
+  fi
+  local finalizer_status=0
+  local proof_status=0
+  local receipt_path="-"
   # A signal can arrive after handle publication but before run returns or writes timing.
   if [[ -z "$measurement_lease" && -n "$measurement_handle" && -f "$measurement_handle" ]]; then
-    measurement_lease="$(node "$ROOT/scripts/devtools-image-proof.mjs" handle "$measurement_handle" | jq -er .leaseId)" ||
+    measurement_lease="$(node "$ROOT/scripts/devtools-image-proof.mjs" handle "$measurement_handle" | jq -er .leaseId)" || {
       printf 'could not recover the active retained measurement handle\n' >&2
+      finalizer_status=1
+    }
   fi
   if [[ "$rollback_pending" == "1" ]]; then
     rollback_pending=0
-    rollback_promoted_image "$promotion_log" || true
+    if rollback_promoted_image "$promotion_log"; then
+      rollback_status="succeeded"
+    else
+      rollback_status="failed"
+      finalizer_status=1
+    fi
   fi
   if [[ "$keep_lease" != "1" ]]; then
+    cleanup_status="succeeded"
     for lease in "$measurement_lease" "$promoted_lease" "$candidate_lease" "$source_lease"; do
       [[ -n "$lease" ]] || continue
-      "$CRABBOX_BIN" stop --provider aws --target "$target" "$lease" || true
+      if ! "$CRABBOX_BIN" stop --provider aws --target "$target" "$lease"; then
+        cleanup_status="failed"
+        finalizer_status=1
+      fi
     done
+  fi
+  if [[ "$exit_status" == "0" && "$finalizer_status" != "0" ]]; then
+    exit_status="$finalizer_status"
+  fi
+  if [[ "$measured" == "1" && -n "$measurement_dir" && -n "$public_outcome" ]]; then
+    if [[ -n "$promotion_log" ]] &&
+      jq -e '.image.id and .image.revision' "$promotion_log" >/dev/null 2>&1; then
+      receipt_path="$promotion_log"
+    fi
+    node "$ROOT/scripts/devtools-image-proof.mjs" finalize \
+      "$public_outcome" "$measurement_dir/policy.json" "$measurement_dir" \
+      "$outcome_stage" "$exit_status" "$rollback_status" "$cleanup_status" "$receipt_path" ||
+      proof_status=$?
+    if [[ "$proof_status" != "0" ]]; then
+      printf 'could not finalize public measurement outcome\n' >&2
+      if [[ "$exit_status" == "0" ]]; then
+        exit_status="$proof_status"
+      fi
+    elif [[ "$exit_status" == "0" ]]; then
+      printf 'public measurement proof: %s\n' "$public_outcome"
+    fi
   fi
   exit "$exit_status"
 }
@@ -279,10 +331,14 @@ run_cmd() {
 run_json_tee() {
   local out="$1"
   shift
+  local -a statuses
   printf '+' >&2
   printf ' %q' "$@" >&2
   printf '\n' >&2
-  "$@" | tee "$out"
+  "$@" | tee "$out" &&
+    statuses=("${PIPESTATUS[@]}") || statuses=("${PIPESTATUS[@]}")
+  [[ "${statuses[0]}" == "0" ]] || return "${statuses[0]}"
+  return "${statuses[1]}"
 }
 
 rollback_promoted_image() {
@@ -298,7 +354,7 @@ rollback_promoted_image() {
   elif [[ "$previous_state" == "absent" ]]; then
     rollback_image="none"
   else
-    printf 'promoted-image smoke failed; promotion receipt has invalid previous state\n' >&2
+    printf 'post-promotion failure; promotion receipt has invalid previous state\n' >&2
     return 1
   fi
   local -a args=(image promote --json --target "$target")
@@ -307,10 +363,10 @@ rollback_promoted_image() {
   args+=(--restore-receipt "$receipt" "$current_id")
   rollback_log="$(mktemp "$log_dir/image-mint-${log_image_name}-rollback-${log_id}.json.XXXXXX")"
   if ! run_json_tee "$rollback_log" "$CRABBOX_BIN" "${args[@]}"; then
-    printf 'promoted-image smoke failed; CAS rollback failed or was rejected; a newer default was not overwritten\n' >&2
+    printf 'post-promotion failure; CAS rollback failed or was rejected; a newer default was not overwritten\n' >&2
     return 1
   fi
-  printf 'promoted-image smoke failed; restored previous default image=%s\n' "$rollback_image" >&2
+  printf 'post-promotion failure; restored previous default image=%s\n' "$rollback_image" >&2
 }
 
 duration_seconds() {
@@ -560,6 +616,7 @@ warmup() {
     fi
     if [[ "$selection_status" != "0" ]]; then
       printf 'warmup selection evidence failed for %s\n' "$label" >&2
+      [[ ! -s "$selection.error" ]] || cat "$selection.error" >&2
       run_cmd "$CRABBOX_BIN" stop --provider aws --target "$target" "$lease" >&2 || true
       return "$selection_status"
     fi
@@ -580,7 +637,7 @@ warmup() {
 
 measure_cohort() {
   local phase="$1"
-  local sample log handle selection run_status recovery_status capture_status stop_status
+  local sample log handle selection run_status recovery_status capture_status stop_status partial_status
   local store="$measurement_dir/$phase.jsonl"
   local -a pipeline_status
   local -a env_args=(env -u CRABBOX_AWS_AMI CRABBOX_AWS_REGION="$region" AWS_REGION="$region")
@@ -602,12 +659,16 @@ measure_cohort() {
     recovery_status=0
     capture_status=0
     stop_status=0
+    partial_status=0
     # Even a failed run can allocate a lease. Recover only this attempted sample, not an older row.
     measurement_lease="$(node "$ROOT/scripts/devtools-image-proof.mjs" sample "$store" "$sample" "$handle" | jq -er .leaseId)" || recovery_status=$?
     if [[ -n "$measurement_lease" ]]; then
       if [[ "$run_status" == "0" ]]; then
         capture_selection "$measurement_lease" "$selection" || capture_status=$?
-        [[ "$capture_status" == "0" ]] || printf 'could not capture exact-lease measurement evidence\n' >&2
+        if [[ "$capture_status" != "0" ]]; then
+          printf 'could not capture exact-lease measurement evidence\n' >&2
+          [[ ! -s "$selection.error" ]] || cat "$selection.error" >&2
+        fi
       fi
       # Stop observes provider cleanup completion, outside the original runner timing.
       run_cmd "$CRABBOX_BIN" stop --provider aws --target linux "$measurement_lease" || stop_status=$?
@@ -623,105 +684,45 @@ measure_cohort() {
     else
       printf 'could not recover the attempted measurement lease; inspect %s\n' "$log" >&2
     fi
+    if [[ -f "$store" ]]; then
+      node "$ROOT/scripts/devtools-image-proof.mjs" partial \
+        "$measurement_dir/policy.json" "$store" "$phase" \
+        "$measurement_dir/$phase-cohort.json" || partial_status=$?
+    fi
     [[ "$run_status" == "0" ]] || return "$run_status"
     [[ "$recovery_status" == "0" ]] || return "$recovery_status"
     [[ "$capture_status" == "0" ]] || return "$capture_status"
     [[ "$stop_status" == "0" ]] || return "$stop_status"
+    [[ "$partial_status" == "0" ]] || return "$partial_status"
     node "$ROOT/scripts/devtools-image-proof.mjs" selection \
       "$measurement_dir/policy.json" "$selection" "$phase" "${ami_id:-}" \
       "$measurement_dir/baseline-1.selection.json"
   done
   run_json_tee "$measurement_dir/$phase-report.json" "$CRABBOX_BIN" bench report \
     --store "$store" --min-samples 3 --json
-  run_json_tee "$measurement_dir/$phase-check.json" "$CRABBOX_BIN" bench check \
-    --store "$store" --min-samples 3 --max-failures 0 \
-    --max-p95-runner-total "${max_p95_runner_total_ms}ms" --json
+  if [[ "$phase" != "baseline" ]]; then
+    run_json_tee "$measurement_dir/$phase-check.json" "$CRABBOX_BIN" bench check \
+      --store "$store" --min-samples 3 --max-failures 0 \
+      --max-p95-runner-total "${max_p95_runner_total_ms}ms" --json
+  fi
   node "$ROOT/scripts/devtools-image-proof.mjs" cohort \
-    "$measurement_dir/policy.json" "$measurement_dir" "$phase" "${ami_id:-}"
+    "$measurement_dir/policy.json" "$measurement_dir" "$phase" "${ami_id:-}" \
+    "$measurement_dir/$phase-cohort.json"
 }
 
 smoke_script() {
   if [[ "$target" == "windows" ]]; then
-    cat <<'POWERSHELL'
-$ErrorActionPreference = "Stop"
-Write-Output "devtools-smoke-ok"
-Get-ComputerInfo | Select-Object OsName, OsVersion, OsBuildNumber | Format-List
-git --version
-gh --version | Select-Object -First 1
-jq --version
-rg --version | Select-Object -First 1
-fd --version
-python --version
-node --version
-$nodeMajor = [int](node -p "process.versions.node.split('.')[0]")
-if ($nodeMajor -lt 24) { throw "Node.js 24 or newer is required, found major $nodeMajor" }
-npm --version
-corepack --version
-pnpm --version
-trufflehog --no-update --version
-docker --version
-docker version
-docker image inspect mcr.microsoft.com/windows/servercore:ltsc2022 | Out-Null
-POWERSHELL
+    smoke_script_path="$ROOT/scripts/devtools-image-smoke-windows.ps1"
   else
-    cat <<'SHELL'
-set -euo pipefail
-echo devtools-smoke-ok
-uname -a
-command -v git
-command -v gh
-command -v jq
-command -v rg
-command -v fd
-command -v python3
-command -v node
-command -v npm
-command -v corepack
-command -v pnpm
-command -v trufflehog
-trufflehog --no-update --version
-command -v docker
-node --version
-node -e 'if (Number(process.versions.node.split(".")[0]) < 24) throw new Error(`Node.js 24 or newer is required, found ${process.version}`)'
-corepack --version
-pnpm --version
-docker_group_member() {
-  if id -nG 2>/dev/null | tr ' ' '\n' | grep -qx docker; then
-    return 0
+    smoke_script_path="$ROOT/scripts/devtools-image-smoke-linux.sh"
   fi
-  local current_user docker_entry docker_members member
-  current_user="$(whoami)"
-  docker_entry="$(getent group docker 2>/dev/null || true)"
-  [[ -n "$docker_entry" ]] || return 1
-  docker_members="${docker_entry#*:*:*:}"
-  local IFS=','
-  local -a docker_member_list
-  read -ra docker_member_list <<<"$docker_members"
-  for member in "${docker_member_list[@]}"; do
-    [[ "$member" == "$current_user" ]] && return 0
-  done
-  return 1
-}
-docker_probe='docker version && docker compose version && docker image inspect hello-world ubuntu:24.04 node:24-bookworm >/dev/null'
-if ! sh -c "$docker_probe"; then
-  if command -v sg >/dev/null 2>&1 && docker_group_member; then
-    sg docker -c "$docker_probe"
-  else
-    sudo sh -c "$docker_probe"
-  fi
-fi
-test -d /var/cache/crabbox/pnpm
-test -f /var/lib/crabbox-readiness/linux.json
-test -f /var/lib/crabbox/image-ready
-SHELL
-  fi
+  IFS= read -r -d '' smoke_script_value <"$smoke_script_path" || [[ -n "$smoke_script_value" ]]
 }
 
 smoke() {
   local lease="$1"
-  local script
-  script="$(smoke_script)"
-  run_cmd "$CRABBOX_BIN" run --provider aws --target "$target" --id "$lease" --no-sync --shell -- "$script"
+  smoke_script
+  run_cmd "$CRABBOX_BIN" run --provider aws --target "$target" --id "$lease" --no-sync --shell -- "$smoke_script_value"
 }
 
 run_prep() {
@@ -828,17 +829,17 @@ EOF
 if [[ "$measured" == "1" ]]; then
   printf 'measured campaign: 12 planned leases (3 baseline + 3 candidate + 3 promoted measurements + 3 lifecycle leases)\n' >&2
   printf 'provider retries may add launch attempts; no hard attempt or dollar cap is enforced by this wrapper\n' >&2
-  printf 'absolute p95 runner threshold: %sms in every cohort; per-lease TTL: %s\n' \
+  printf 'absolute p95 runner threshold: %sms for candidate and promoted cohorts; per-lease TTL: %s\n' \
     "$max_p95_runner_total_ms" "$ttl" >&2
 fi
 
 if [[ "$run" != "1" ]]; then
   printf 'dry plan only; add --run to create source/candidate leases and AMIs.\n'
+  trap - EXIT
   exit 0
 fi
 
 if [[ "$measured" == "1" ]]; then
-  umask 077
   effective_config="$(env CRABBOX_AWS_REGION="$region" AWS_REGION="$region" \
     "$CRABBOX_BIN" config show --provider aws --json)"
   if ! jq -e --arg region "$region" \
@@ -848,12 +849,11 @@ if [[ "$measured" == "1" ]]; then
     printf 'measured publication requires a managed admin coordinator, the requested region, and no effective aws.ami override\n' >&2
     exit 2
   fi
-  mkdir -p "$log_dir"
-  measurement_dir="$(mktemp -d "$log_dir/measurement-${log_id}.XXXXXX")"
-  printf '%s\n' "$measurement_policy" >"$measurement_dir/policy.json"
+  outcome_stage="baseline"
   measure_cohort baseline
 fi
 
+outcome_stage="source_prepare"
 source_lease="$(warmup source)"
 stage_linux_readiness_producer "$source_lease"
 run_prep "$source_lease"
@@ -863,6 +863,7 @@ smoke "$source_lease"
 
 image_env=(env)
 [[ -n "$region" ]] && image_env+=(CRABBOX_AWS_REGION="$region" AWS_REGION="$region")
+outcome_stage="candidate_create"
 image_output="$("${image_env[@]}" "$CRABBOX_BIN" checkpoint create \
   --provider aws --target "$target" --id "$source_lease" --name "$image_name" \
   --mode native --strategy image --no-reboot=false --wait --wait-timeout "$wait_timeout")"
@@ -878,6 +879,7 @@ if [[ "$keep_lease" != "1" ]]; then
   source_lease=""
 fi
 
+outcome_stage="candidate_smoke"
 candidate_lease="$(warmup candidate "$ami_id")"
 smoke "$candidate_lease"
 printf 'candidate AMI smoke passed: %s\n' "$ami_id"
@@ -892,9 +894,11 @@ if [[ "$keep_lease" != "1" ]]; then
 fi
 
 if [[ "$measured" == "1" ]]; then
+  outcome_stage="candidate_measure"
   measure_cohort candidate
 fi
 
+outcome_stage="promotion"
 promote_args=(image promote --target "$target" --json --expected-current-image capture)
 [[ -n "$region" ]] && promote_args+=(--region "$region")
 if [[ "$fast_snapshot_restore" == "1" ]]; then
@@ -915,19 +919,19 @@ if [[ "$measured" == "1" ]]; then
     "$measurement_dir/policy.json" "$measurement_dir/baseline-1.selection.json" "$promotion_log" "$ami_id"
 fi
 
+outcome_stage="promoted_smoke"
 promoted_lease="$(warmup promoted)"
 smoke "$promoted_lease"
 if [[ "$measured" == "1" ]]; then
   run_cmd "$CRABBOX_BIN" stop --provider aws --target "$target" "$promoted_lease"
   promoted_lease=""
+  outcome_stage="promoted_measure"
   measure_cohort promoted
-  node "$ROOT/scripts/devtools-image-proof.mjs" manifest \
-    "$measurement_dir/policy.json" "$measurement_dir" "$promotion_log" "$ami_id" >"$measurement_dir/manifest.pending"
-  mv "$measurement_dir/manifest.pending" "$measurement_dir/manifest.json"
+  outcome_stage="proof"
+  node "$ROOT/scripts/devtools-image-proof.mjs" receipt \
+    "$measurement_dir/policy.json" "$measurement_dir/baseline-1.selection.json" "$promotion_log" "$ami_id"
 fi
 rollback_pending=0
-if [[ "$measured" == "1" ]]; then
-  printf 'public measurement proof: %s\n' "$measurement_dir/manifest.json"
-fi
+outcome_stage="complete"
 printf 'promoted image selection proved: %s\n' "$ami_id"
 printf 'promoted %s developer image passed: %s\n' "$target" "$ami_id"

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -257,6 +257,7 @@ measurement_lease=""
 measurement_handle=""
 promotion_log=""
 rollback_pending=0
+warmup_handle_dir="$log_dir/image-mint-${log_image_name}-leases-${log_id}"
 
 cleanup() {
   local exit_status=$?
@@ -267,6 +268,9 @@ cleanup() {
   local finalizer_status=0
   local proof_status=0
   local receipt_path="-"
+  local outcome_candidate=""
+  local lease handle seen_leases="|"
+  local -a cleanup_leases=()
   # A signal can arrive after handle publication but before run returns or writes timing.
   if [[ -z "$measurement_lease" && -n "$measurement_handle" && -f "$measurement_handle" ]]; then
     measurement_lease="$(node "$ROOT/scripts/devtools-image-proof.mjs" handle "$measurement_handle" | jq -er .leaseId)" || {
@@ -274,7 +278,7 @@ cleanup() {
       finalizer_status=1
     }
   fi
-  if [[ "$rollback_pending" == "1" ]]; then
+  if [[ "$rollback_pending" == "1" && "$exit_status" != "0" ]]; then
     rollback_pending=0
     if rollback_promoted_image "$promotion_log"; then
       rollback_status="succeeded"
@@ -285,8 +289,20 @@ cleanup() {
   fi
   if [[ "$keep_lease" != "1" ]]; then
     cleanup_status="succeeded"
-    for lease in "$measurement_lease" "$promoted_lease" "$candidate_lease" "$source_lease"; do
+    cleanup_leases=("$measurement_lease" "$promoted_lease" "$candidate_lease" "$source_lease")
+    if [[ -d "$warmup_handle_dir" ]]; then
+      for handle in "$warmup_handle_dir"/*.lease; do
+        [[ -f "$handle" ]] || continue
+        lease="$(cat "$handle")"
+        [[ -n "$lease" ]] && cleanup_leases+=("$lease")
+      done
+    fi
+    for lease in "${cleanup_leases[@]}"; do
       [[ -n "$lease" ]] || continue
+      case "$seen_leases" in
+        *"|$lease|"*) continue ;;
+      esac
+      seen_leases+="$lease|"
       if ! "$CRABBOX_BIN" stop --provider aws --target "$target" "$lease"; then
         cleanup_status="failed"
         finalizer_status=1
@@ -296,21 +312,47 @@ cleanup() {
   if [[ "$exit_status" == "0" && "$finalizer_status" != "0" ]]; then
     exit_status="$finalizer_status"
   fi
+  if [[ "$rollback_pending" == "1" && "$exit_status" != "0" ]]; then
+    rollback_pending=0
+    if rollback_promoted_image "$promotion_log"; then
+      rollback_status="succeeded"
+    else
+      rollback_status="failed"
+      finalizer_status=1
+    fi
+  fi
   if [[ "$measured" == "1" && -n "$measurement_dir" && -n "$public_outcome" ]]; then
     if [[ -n "$promotion_log" ]] &&
       jq -e '.image.id and .image.revision' "$promotion_log" >/dev/null 2>&1; then
       receipt_path="$promotion_log"
     fi
+    outcome_candidate="$(mktemp "${public_outcome}.candidate.XXXXXX")" || proof_status=$?
+    if [[ "$proof_status" == "0" ]]; then
     node "$ROOT/scripts/devtools-image-proof.mjs" finalize \
-      "$public_outcome" "$measurement_dir/policy.json" "$measurement_dir" \
+      "$outcome_candidate" "$measurement_dir/policy.json" "$measurement_dir" \
       "$outcome_stage" "$exit_status" "$rollback_status" "$cleanup_status" "$receipt_path" ||
       proof_status=$?
+    fi
+    if [[ "$proof_status" == "0" ]]; then
+      mv -f "$outcome_candidate" "$public_outcome" || proof_status=$?
+    fi
     if [[ "$proof_status" != "0" ]]; then
+      [[ -z "$outcome_candidate" ]] || rm -f "$outcome_candidate"
       printf 'could not finalize public measurement outcome\n' >&2
       if [[ "$exit_status" == "0" ]]; then
         exit_status="$proof_status"
       fi
+      if [[ "$rollback_pending" == "1" ]]; then
+        rollback_pending=0
+        if rollback_promoted_image "$promotion_log"; then
+          rollback_status="succeeded"
+        else
+          rollback_status="failed"
+          finalizer_status=1
+        fi
+      fi
     elif [[ "$exit_status" == "0" ]]; then
+      rollback_pending=0
       printf 'public measurement proof: %s\n' "$public_outcome"
     fi
   fi
@@ -550,6 +592,14 @@ process.exit(1);
 ' "$1"
 }
 
+warmup_handle_path() {
+  printf '%s/%s.lease\n' "$warmup_handle_dir" "$1"
+}
+
+clear_warmup_handle() {
+  rm -f "$(warmup_handle_path "$1")"
+}
+
 assert_selected_image() {
   local log="$1"
   local image_id="$2"
@@ -592,9 +642,15 @@ warmup() {
   fi
   local lease
   lease="$(lease_from_log "$log" || true)"
+  if [[ -n "$lease" ]]; then
+    mkdir -p "$warmup_handle_dir"
+    printf '%s\n' "$lease" >"$(warmup_handle_path "$label")"
+  fi
   if [[ "$warmup_status" -ne 0 ]]; then
     if [[ -n "$lease" && "$keep_lease" != "1" ]]; then
-      run_cmd "$CRABBOX_BIN" stop --provider aws --target "$target" "$lease" >&2 || true
+      if run_cmd "$CRABBOX_BIN" stop --provider aws --target "$target" "$lease" >&2; then
+        clear_warmup_handle "$label"
+      fi
     fi
     return "$warmup_status"
   fi
@@ -616,7 +672,9 @@ warmup() {
     if [[ "$selection_status" != "0" ]]; then
       printf 'warmup selection evidence failed for %s\n' "$label" >&2
       [[ ! -s "$selection.error" ]] || cat "$selection.error" >&2
-      run_cmd "$CRABBOX_BIN" stop --provider aws --target "$target" "$lease" >&2 || true
+      if run_cmd "$CRABBOX_BIN" stop --provider aws --target "$target" "$lease" >&2; then
+        clear_warmup_handle "$label"
+      fi
       return "$selection_status"
     fi
   elif [[ "$label" == "candidate" ]]; then
@@ -627,7 +685,10 @@ warmup() {
   if [[ "$target" == "windows" ]]; then
     sleep "$windows_warmup_settle_seconds"
     if ! wait_windows_ssh_probe "$lease" "$windows_warmup_wait_timeout"; then
-      [[ "$keep_lease" == "1" ]] || run_cmd "$CRABBOX_BIN" stop --provider aws --target windows "$lease" >&2 || true
+      if [[ "$keep_lease" != "1" ]] &&
+        run_cmd "$CRABBOX_BIN" stop --provider aws --target windows "$lease" >&2; then
+        clear_warmup_handle "$label"
+      fi
       return 1
     fi
   fi
@@ -875,6 +936,7 @@ fi
 
 if [[ "$keep_lease" != "1" ]]; then
   run_cmd "$CRABBOX_BIN" stop --provider aws --target "$target" "$source_lease"
+  clear_warmup_handle source
   source_lease=""
 fi
 
@@ -889,6 +951,7 @@ fi
 
 if [[ "$keep_lease" != "1" ]]; then
   run_cmd "$CRABBOX_BIN" stop --provider aws --target "$target" "$candidate_lease"
+  clear_warmup_handle candidate
   candidate_lease=""
 fi
 
@@ -923,6 +986,7 @@ promoted_lease="$(warmup promoted)"
 smoke "$promoted_lease"
 if [[ "$measured" == "1" ]]; then
   run_cmd "$CRABBOX_BIN" stop --provider aws --target "$target" "$promoted_lease"
+  clear_warmup_handle promoted
   promoted_lease=""
   outcome_stage="promoted_measure"
   measure_cohort promoted
@@ -930,7 +994,6 @@ if [[ "$measured" == "1" ]]; then
   node "$ROOT/scripts/devtools-image-proof.mjs" receipt \
     "$measurement_dir/policy.json" "$measurement_dir/baseline-1.selection.json" "$promotion_log" "$ami_id"
 fi
-rollback_pending=0
 outcome_stage="complete"
 printf 'promoted image selection proved: %s\n' "$ami_id"
 printf 'promoted %s developer image passed: %s\n' "$target" "$ami_id"

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -257,7 +257,7 @@ measurement_lease=""
 measurement_handle=""
 promotion_log=""
 rollback_pending=0
-warmup_handle_dir="$log_dir/image-mint-${log_image_name}-leases-${log_id}"
+warmup_handle_dir="$log_dir/.image-mint-${log_image_name}-leases-${log_id}"
 
 cleanup() {
   local exit_status=$?

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -257,12 +257,11 @@ measurement_lease=""
 measurement_handle=""
 promotion_log=""
 rollback_pending=0
-publisher_pid="$BASHPID"
 
 cleanup() {
   local exit_status=$?
   trap - EXIT
-  if [[ "${BASH_SUBSHELL:-0}" != "0" || "$BASHPID" != "$publisher_pid" ]]; then
+  if [[ "${BASH_SUBSHELL:-0}" != "0" ]]; then
     return "$exit_status"
   fi
   local finalizer_status=0

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -175,9 +175,14 @@ test("AWS devtools mint wrapper defaults to dry plan", async () => {
 
 test("AWS developer image smoke executes package managers and requires TruffleHog", async () => {
   const text = await readFile(script, "utf8");
-  assert.match(text, /pnpm --version\ntrufflehog --no-update --version\ndocker --version/);
+  const windowsSmoke = await readFile(
+    path.join(scriptDir, "devtools-image-smoke-windows.ps1"),
+    "utf8",
+  );
+  const linuxSmoke = await readFile(path.join(scriptDir, "devtools-image-smoke-linux.sh"), "utf8");
+  assert.match(windowsSmoke, /pnpm --version\ntrufflehog --no-update --version\ndocker --version/);
   assert.match(
-    text,
+    linuxSmoke,
     /command -v pnpm\ncommand -v trufflehog\ntrufflehog --no-update --version\ncommand -v docker\nnode --version\nnode -e .*\ncorepack --version\npnpm --version\n/,
   );
   assert.match(text, /trap 'exit 130' INT\ntrap 'exit 143' TERM/);
@@ -186,13 +191,14 @@ test("AWS developer image smoke executes package managers and requires TruffleHo
 
 test("AWS Linux image production stages and invokes only the generated readiness producer", async () => {
   const source = await readFile(script, "utf8");
+  const smoke = await readFile(path.join(scriptDir, "devtools-image-smoke-linux.sh"), "utf8");
   assert.match(source, /--script "\$ROOT\/scripts\/linux-readiness\.generated\.sh" -- --install/);
   assert.equal(
     (source.match(/--script "\$ROOT\/scripts\/linux-readiness\.generated\.sh"/g) ?? []).length,
     1,
   );
   assert.match(source, /--shell -- \/usr\/local\/libexec\/crabbox\/linux-readiness\.generated\.sh/);
-  assert.match(source, /test -f \/var\/lib\/crabbox-readiness\/linux\.json/);
+  assert.match(smoke, /test -f \/var\/lib\/crabbox-readiness\/linux\.json/);
   assert.doesNotMatch(source, /sudo tee \/var\/lib\/crabbox\/image-ready/);
   assert.doesNotMatch(source, /printf 'crabbox-devtools-v1/);
 });
@@ -672,6 +678,8 @@ async function measuredFixture(t) {
     "scripts/mint-aws-devtools-image.sh",
     "scripts/devtools-image-proof.mjs",
     "scripts/devtools-image-contract.mjs",
+    "scripts/devtools-image-smoke-linux.sh",
+    "scripts/devtools-image-smoke-windows.ps1",
     "scripts/generate-linux-readiness.mjs",
     "scripts/install-linux-developer-tools.sh",
     "scripts/linux-readiness.generated.sh",
@@ -713,7 +721,7 @@ if (args[0] === "admin") {
   if (mode === "admin-failure") process.exit(53);
   if (mode === "missing-selection") leases.pop();
   if (mode === "duplicate-selection") leases.push(leases.at(-1));
-  console.log(JSON.stringify(leases));
+  fs.writeSync(1, JSON.stringify(leases) + "\\n");
   process.exit(0);
 }
 const saveLease = (phase, sample, leaseId, index) => {
@@ -830,6 +838,7 @@ case "$1" in`,
     CRABBOX_FAKE_MEASUREMENT: mock,
     CRABBOX_FAKE_SOURCE_HEAD: git(["rev-parse", "HEAD"]),
     CRABBOX_IMAGE_LOG_DIR: path.join(fake.dir, "diagnostics"),
+    CRABBOX_IMAGE_PUBLIC_OUTCOME: path.join(fake.dir, "public", "manifest.json"),
     CRABBOX_OWNER: "publisher@example.invalid",
     CRABBOX_ORG: "example-org",
   };
@@ -851,6 +860,7 @@ case "$1" in`,
     env,
     args,
     script: path.join(root, "scripts/mint-aws-devtools-image.sh"),
+    outcome: env.CRABBOX_IMAGE_PUBLIC_OUTCOME,
   };
 }
 
@@ -866,7 +876,7 @@ test("measured Linux publication runs nine fresh samples and publishes only allo
   const log = await readFile(fake.log, "utf8");
   assert.equal((log.match(/args warmup /g) ?? []).length, 3);
   assert.equal((log.match(/args run .*--timing-record /g) ?? []).length, 9);
-  assert.equal((log.match(/args bench check /g) ?? []).length, 3);
+  assert.equal((log.match(/args bench check /g) ?? []).length, 2);
   assert.equal(
     (log.match(/args stop --provider aws --target linux cbx_[0-9a-f]{12}/g) ?? []).length,
     9,
@@ -874,9 +884,18 @@ test("measured Linux publication runs nine fresh samples and publishes only allo
   assert.match(log, /--full-resync --no-hydrate --keep --stop-after never --lease-output/);
   assert.doesNotMatch(log, /CRABBOX_AWS_AMI=ami-ambient/);
   const manifestPath = result.stdout.match(/public measurement proof: (.+)/)?.[1];
+  assert.equal(manifestPath, fake.outcome);
   const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  assert.equal(manifest.schema, "crabbox-devtools-image-proof/v2");
+  assert.equal(manifest.status, "passed");
+  assert.equal(manifest.stage, "complete");
   assert.equal(manifest.plannedLeaseCount, 12);
   assert.equal(manifest.cohorts[0].medianSyncMs, 0);
+  assert.equal(manifest.cohorts[0].policyApplied, false);
+  assert.equal(manifest.cohorts[0].policyPassed, null);
+  assert.equal(manifest.cohorts[1].policyPassed, true);
+  assert.equal(manifest.cohorts[2].policyPassed, true);
+  assert.match(manifest.promotionBindingDigest, /^sha256:[0-9a-f]{64}$/);
   assert.doesNotMatch(JSON.stringify(manifest), /ami-devtools|cbx_|m7i|us-west|diagnostics/);
   assert.doesNotMatch(result.stdout + result.stderr, /PRIVATE_(OWNER|HOST|CONFIG)_POISON|--owner/);
   for (const file of await readdir(path.dirname(manifestPath))) {
@@ -887,6 +906,32 @@ test("measured Linux publication runs nine fresh samples and publishes only allo
       );
     }
   }
+});
+
+test("measured baseline is descriptive while candidate and promoted cohorts enforce policy", async (t) => {
+  const baseline = await measuredFixture(t);
+  const baselineResult = await runScript(
+    baseline.args,
+    { ...baseline.env, CRABBOX_FAKE_CHECK_FAIL_PHASE: "baseline" },
+    baseline.script,
+  );
+  assert.equal(baselineResult.code, 0, baselineResult.stderr);
+
+  const candidate = await measuredFixture(t);
+  const candidateResult = await runScript(
+    candidate.args,
+    { ...candidate.env, CRABBOX_FAKE_CHECK_FAIL_PHASE: "candidate" },
+    candidate.script,
+  );
+  assert.equal(candidateResult.code, 37, candidateResult.stderr);
+  const candidateOutcome = JSON.parse(await readFile(candidate.outcome, "utf8"));
+  assert.equal(candidateOutcome.status, "failed");
+  assert.equal(candidateOutcome.stage, "candidate_measure");
+  assert.equal(candidateOutcome.cohorts[0].policyApplied, false);
+  assert.equal(candidateOutcome.cohorts[0].policyPassed, null);
+  assert.equal(candidateOutcome.cohorts[1].policyApplied, true);
+  assert.equal(candidateOutcome.cohorts[1].policyPassed, false);
+  assert.doesNotMatch(await readFile(candidate.log, "utf8"), /image promote/);
 });
 
 test("measured invalid recipe and changed prep fail before any CLI operation", async (t) => {
@@ -957,6 +1002,14 @@ test("measured incomplete or mixed cohorts block promotion", async (t) => {
       );
       assert.notEqual(result.code, 0);
       assert.doesNotMatch(await readFile(fake.log, "utf8"), /image promote/);
+      const outcome = JSON.parse(await readFile(fake.outcome, "utf8"));
+      assert.equal(outcome.status, "failed");
+      assert.equal(outcome.stage, "candidate_measure");
+      assert.equal(outcome.cleanupStatus, "succeeded");
+      assert.doesNotMatch(
+        JSON.stringify(outcome),
+        /ami-|cbx_|m7i|us-west|PRIVATE_|diagnostics/,
+      );
     });
   }
 });
@@ -1072,6 +1125,12 @@ if [[ "$1" == *baseline-${runFails ? 2 : 1}.log ]]; then exit 61; fi
         new RegExp(`args stop --provider aws --target linux cbx_00000000000${runFails ? 2 : 1}`),
       );
       assert.doesNotMatch(log, /image promote/);
+      const outcome = JSON.parse(await readFile(fake.outcome, "utf8"));
+      assert.equal(outcome.status, "failed");
+      assert.equal(outcome.stage, "baseline");
+      assert.equal(outcome.exitCode, runFails ? 41 : 61);
+      assert.equal(outcome.rollbackStatus, "not_required");
+      assert.equal(outcome.cleanupStatus, "succeeded");
     });
   }
 });
@@ -1110,6 +1169,12 @@ test("measured interruption recovers a retained handle without a final timing ro
       if (phase === "promoted") assert.match(log, /--restore-receipt \S+ ami-devtools/);
       else assert.doesNotMatch(log, /image promote/);
       if (stopFails) assert.match(result.stderr, /stop failed/);
+      const outcome = JSON.parse(await readFile(fake.outcome, "utf8"));
+      assert.equal(outcome.status, "failed");
+      assert.equal(outcome.stage, phase === "promoted" ? "promoted_measure" : "baseline");
+      assert.equal(outcome.exitCode, signal === "SIGINT" ? 130 : 143);
+      assert.equal(outcome.rollbackStatus, phase === "promoted" ? "succeeded" : "not_required");
+      assert.equal(outcome.cleanupStatus, stopFails ? "failed" : "succeeded");
       assert.doesNotMatch(result.stdout, /public measurement proof:/);
     });
   }
@@ -1215,28 +1280,32 @@ test("measured wrong promoted selection stops the allocated lease before rollbac
   assert.match(log, /--restore-receipt \S+ ami-devtools/);
 });
 
-test("measured post-promotion benchmark and manifest failures preserve the receipt rollback", async (t) => {
-  for (const mode of ["benchmark", "manifest", "rollback"]) {
+test("measured post-promotion failures preserve the original publisher status", async (t) => {
+  for (const mode of ["benchmark", "outcome", "rollback"]) {
     await t.test(mode, async (t) => {
       const fake = await measuredFixture(t);
       const env = { ...fake.env, CRABBOX_FAKE_CHECK_FAIL_PHASE: "promoted" };
       if (mode === "rollback") env.CRABBOX_FAKE_ROLLBACK_FAIL = "1";
-      if (mode === "manifest") {
+      if (mode === "outcome") {
         delete env.CRABBOX_FAKE_CHECK_FAIL_PHASE;
         const bin = path.join(fake.dir, "bin");
         await mkdir(bin);
         const node = path.join(bin, "node");
         await writeFile(
           node,
-          `#!/usr/bin/env bash\nif [[ "$1" == *devtools-image-proof.mjs && "\${2:-}" == manifest ]]; then exit 66; fi\nexec "${process.execPath}" "$@"\n`,
+          `#!/usr/bin/env bash\nif [[ "$1" == *devtools-image-proof.mjs && "\${2:-}" == finalize ]]; then exit 66; fi\nexec "${process.execPath}" "$@"\n`,
         );
         await chmod(node, 0o755);
         env.PATH = `${bin}${path.delimiter}${process.env.PATH}`;
       }
       const result = await runScript(fake.args, env, fake.script);
-      assert.equal(result.code, mode === "manifest" ? 66 : 37, result.stderr);
+      assert.equal(result.code, mode === "outcome" ? 66 : 37, result.stderr);
       const log = await readFile(fake.log, "utf8");
-      assert.match(log, /image promote --json --target linux .*--restore-receipt \S+ ami-devtools/);
+      if (mode === "outcome") {
+        assert.doesNotMatch(log, /--restore-receipt/);
+      } else {
+        assert.match(log, /image promote --json --target linux .*--restore-receipt \S+ ami-devtools/);
+      }
       if (mode === "rollback") assert.match(result.stderr, /newer default was not overwritten/);
       assert.doesNotMatch(result.stdout, /public measurement proof:/);
     });

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -1262,7 +1262,32 @@ test("measured baseline must match the default captured by the original promotio
   assert.notEqual(result.code, 0);
   assert.match(result.stderr, /baseline differs from the captured previous default/);
   assert.match(await readFile(fake.log, "utf8"), /--restore-receipt \S+ ami-devtools/);
+  const outcome = JSON.parse(await readFile(fake.outcome, "utf8"));
+  assert.equal(outcome.status, "failed");
+  assert.equal(outcome.stage, "promotion");
+  assert.equal(outcome.rollbackStatus, "succeeded");
+  assert.match(outcome.promotionBindingDigest, /^sha256:[0-9a-f]{64}$/);
   assert.doesNotMatch(result.stdout, /public measurement proof:/);
+});
+
+test("measured warmup cleanup failures remain visible to finalization", async (t) => {
+  const fake = await measuredFixture(t);
+  const result = await runScript(
+    fake.args,
+    {
+      ...fake.env,
+      CRABBOX_FAKE_WARMUP_FAIL_AFTER_LEASE: "1",
+      CRABBOX_FAKE_STOP_FAIL_LEASE: "cbx_source",
+    },
+    fake.script,
+  );
+  assert.equal(result.code, 23, result.stderr);
+  const log = await readFile(fake.log, "utf8");
+  assert.ok((log.match(/stop --provider aws --target linux cbx_source/g) ?? []).length >= 2);
+  const outcome = JSON.parse(await readFile(fake.outcome, "utf8"));
+  assert.equal(outcome.status, "failed");
+  assert.equal(outcome.stage, "source_prepare");
+  assert.equal(outcome.cleanupStatus, "failed");
 });
 
 test("measured wrong promoted selection stops the allocated lease before rollback", async (t) => {
@@ -1303,7 +1328,7 @@ test("measured post-promotion failures preserve the original publisher status", 
       assert.equal(result.code, mode === "outcome" ? 66 : 37, result.stderr);
       const log = await readFile(fake.log, "utf8");
       if (mode === "outcome") {
-        assert.doesNotMatch(log, /--restore-receipt/);
+        assert.match(log, /image promote --json --target linux .*--restore-receipt \S+ ami-devtools/);
       } else {
         assert.match(log, /image promote --json --target linux .*--restore-receipt \S+ ami-devtools/);
       }

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -1270,6 +1270,30 @@ test("measured baseline must match the default captured by the original promotio
   assert.doesNotMatch(result.stdout, /public measurement proof:/);
 });
 
+test("measured receipt-less promotion failures retain the completed cohorts", async (t) => {
+  const fake = await measuredFixture(t);
+  const result = await runScript(
+    fake.args,
+    {
+      ...fake.env,
+      CRABBOX_FAKE_PROMOTION_FAIL: "1",
+    },
+    fake.script,
+  );
+  assert.equal(result.code, 55, result.stderr);
+  assert.match(result.stderr, /transactional promotion receipt is unavailable for rollback/);
+  const outcome = JSON.parse(await readFile(fake.outcome, "utf8"));
+  assert.equal(outcome.status, "failed");
+  assert.equal(outcome.stage, "promotion");
+  assert.equal(outcome.exitCode, 55);
+  assert.equal(outcome.rollbackStatus, "failed");
+  assert.equal(outcome.promotionBindingDigest, null);
+  assert.deepEqual(
+    outcome.cohorts.map((cohort) => cohort.phase),
+    ["baseline", "candidate"],
+  );
+});
+
 test("measured warmup cleanup failures remain visible to finalization", async (t) => {
   const fake = await measuredFixture(t);
   const result = await runScript(

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -187,6 +187,7 @@ test("AWS developer image smoke executes package managers and requires TruffleHo
   );
   assert.match(text, /trap 'exit 130' INT\ntrap 'exit 143' TERM/);
   assert.match(text, /rollback_pending=1\nrun_json_tee "\$promotion_log"/);
+  assert.doesNotMatch(text, /\bBASHPID\b/);
 });
 
 test("AWS Linux image production stages and invokes only the generated readiness producer", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where measured AWS developer-image publications retained a public proof only after success, leaving failed or interrupted runs without a safe, useful outcome artifact.

## Why This Change Was Made

The publisher now initializes a conservative fixed-path outcome before configuration or paid work, then atomically replaces it after rollback and cleanup with an exact-key v2 projection. Baseline measurements remain descriptive; candidate and promoted cohorts enforce the predeclared p95 policy. Raw provider identifiers, commands, paths, receipts, logs, and arbitrary benchmark fields remain private.

The existing smoke payloads are stored as static scripts so the EXIT finalizer is not inherited through a large command-substitution heredoc.

## User Impact

Image operators get a sanitized outcome artifact for successful, failed, and incomplete measured publications, including validated partial cohort counts, final stage, rollback state, cleanup state, and exit code. This change does not dispatch or broaden any live image workflow.

## Evidence

- `node --test scripts/devtools-image-proof.test.mjs scripts/devtools-image-workflow.test.js` (10 passed)
- `node --test --test-name-pattern='measured' scripts/mint-aws-devtools-image.test.js` (50 passed)
- `bash -n scripts/mint-aws-devtools-image.sh scripts/devtools-image-smoke-linux.sh`
- `shellcheck scripts/mint-aws-devtools-image.sh`
- `shellcheck -s bash -e SC2016 scripts/devtools-image-smoke-linux.sh`
- `/bin/bash 3.2.57` compatibility cases for success, post-promotion failure, and rollback (7 passed)
- `actionlint -shellcheck='' .github/workflows/devtools-image-publish.yml`
- `node scripts/build-docs-site.mjs`
- `git diff --check`
- Autoreview: scoped clean, no accepted P0 findings
