### PR TITLE
refactor(codesandbox): share configured fallback defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 - Describe OpenSandbox configuration bindings once, preserving CLI-only stale-claim cleanup, environment/flag-only API URL selection, defaults, and validation timing. [PR 1990](https://github.com/openclaw/crabbox/pull/1990). Thanks @steipete.
 
+- Keep CodeSandbox runtime fallback defaults aligned with declared configuration while preserving the fixed SDK workspace boundary and operation-specific budgets.
+
 ## 0.52.0 - 2026-09-07
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 - Describe OpenSandbox configuration bindings once, preserving CLI-only stale-claim cleanup, environment/flag-only API URL selection, defaults, and validation timing. [PR 1990](https://github.com/openclaw/crabbox/pull/1990). Thanks @steipete.
 
-- Keep CodeSandbox runtime fallback defaults aligned with declared configuration while preserving the fixed SDK workspace boundary and operation-specific budgets.
+- Keep CodeSandbox runtime fallback defaults aligned with declared configuration while preserving the fixed SDK workspace boundary and operation-specific budgets. [PR 1991](https://github.com/openclaw/crabbox/pull/1991). Thanks @steipete.
 
 ## 0.52.0 - 2026-09-07
 

--- a/docs/refactor/typed-provider-config.md
+++ b/docs/refactor/typed-provider-config.md
@@ -105,6 +105,16 @@ infer trust from filenames. The other nine fields retain repository support.
 CodeSandbox's provider aliases, generic sizing rejection, and semantic validation
 remain in the provider wrapper, including their existing order.
 
+Its runtime fallback helpers also use the generated bridge-command, SDK-package,
+operation-timeout, doctor-list-limit, and workdir defaults. The provider still
+owns when to apply them: strings are trimmed before falling back, and the two
+integer helpers fall back for nonpositive values. The fixed SDK workspace mount
+`/project/workspace` is a separate platform boundary, not a configurable default;
+changing the default workdir must not move archive staging or mount-replacement
+behavior. Cleanup budgets and command-timeout extensions remain independent.
+The Go list producer sends the resolved positive limit to the embedded bridge;
+the bridge does not choose a second list default.
+
 CUA's fourteen runtime/flag fields include thirteen YAML fields. Its `APIURL`
 retains environment/flag-only input and is absent even from trusted user YAML.
 `CRABBOX_CUA_API_URL` retains precedence over `CUA_BASE_URL`. The four bridge/SDK

--- a/internal/providers/codesandbox/bridge.go
+++ b/internal/providers/codesandbox/bridge.go
@@ -547,7 +547,7 @@ try {
     const { CodeSandbox, VMTier } = sdkModule;
     const sdk = new CodeSandbox(token);
     if (req.operation === "list_sandboxes") {
-      const listed = await callAny(sdk.sandboxes || sdk, ["list", "listSandboxes"], { limit: Number(req.limit || 1) });
+      const listed = await callAny(sdk.sandboxes || sdk, ["list", "listSandboxes"], { limit: Number(req.limit) });
       const items = listed.sandboxes || listed.items || listed.results || listed || [];
       const runningIDs = await runningSandboxIDs(sdk);
       const sandboxes = Array.from(items).map((sandbox) => normalizeSandbox(sandbox, runningIDs.has(String(sandbox && sandbox.id || "")) ? "running" : ""));

--- a/internal/providers/codesandbox/bridge_test.go
+++ b/internal/providers/codesandbox/bridge_test.go
@@ -84,6 +84,56 @@ func TestSDKBridgeSendsJSONOnStdinAndTokenOnlyInEnv(t *testing.T) {
 	}
 }
 
+func TestSDKBridgeEffectiveDefaultsUseRecordingRunner(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		cfg          CodeSandboxConfig
+		command, pkg string
+		seconds      int
+	}{
+		{name: "blank", command: "node", pkg: "@codesandbox/sdk@2.4.2", seconds: 30},
+		{name: "whitespace", cfg: CodeSandboxConfig{BridgeCommand: " \t", SDKPackage: " \t", OperationTimeoutSecs: -1}, command: "node", pkg: "@codesandbox/sdk@2.4.2", seconds: 30},
+		{name: "custom", cfg: CodeSandboxConfig{BridgeCommand: " /opt/example-node ", SDKPackage: " @codesandbox/sdk@2.4.1 ", OperationTimeoutSecs: 45}, command: "/opt/example-node", pkg: "@codesandbox/sdk@2.4.1", seconds: 45},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setBridgeTestCacheDir(t)
+			runner := &recordingBridgeRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+				_, _ = io.WriteString(req.Stdout, `{"ok":true,"sandboxes":[]}`)
+				return LocalCommandResult{ExitCode: 0}, nil
+			}}
+			before := tc.cfg
+			started := time.Now()
+			if _, err := NewSDKBridge(tc.cfg, Runtime{Exec: runner}).RoundTrip(context.Background(), "", BridgeRequest{Operation: "list_sandboxes", Limit: doctorListLimit(tc.cfg)}); err != nil {
+				t.Fatal(err)
+			}
+			setup, call := runner.onlySetupCall(t), runner.onlyCall(t)
+			if setup.Args[len(setup.Args)-1] != tc.pkg || call.Name != tc.command || !envContains(call.Env, "CRABBOX_CODESANDBOX_SDK_PACKAGE="+tc.pkg) {
+				t.Fatalf("effective launcher/package mismatch: setup=%v command=%q", setup.Args, call.Name)
+			}
+			var request BridgeRequest
+			if err := json.NewDecoder(call.Stdin).Decode(&request); err != nil {
+				t.Fatal(err)
+			}
+			if request.Limit != 1 {
+				t.Fatalf("default request list limit=%d, want 1", request.Limit)
+			}
+			if len(runner.deadlines) != 2 {
+				t.Fatalf("deadline count=%d", len(runner.deadlines))
+			}
+			finished := time.Now()
+			for _, deadline := range runner.deadlines {
+				budget := time.Duration(tc.seconds) * time.Second
+				if deadline.Before(started.Add(budget)) || deadline.After(finished.Add(budget)) {
+					t.Fatalf("deadline does not use %s budget", budget)
+				}
+			}
+			if tc.cfg != before {
+				t.Fatal("bridge changed input config")
+			}
+		})
+	}
+}
+
 func TestSDKBridgeRequiresRunnerBeforeSDKSetup(t *testing.T) {
 	var exitErr ExitError
 	_, err := NewSDKBridge(newTestConfig().CodeSandbox, Runtime{}).RoundTrip(context.Background(), "secret", BridgeRequest{Operation: "list_sandboxes"})
@@ -244,6 +294,49 @@ func TestSDKBridgeScriptAwaitsAsyncPortListing(t *testing.T) {
 	}
 	if !strings.Contains(codeSandboxBridgeScript, "process.env.CRABBOX_CODESANDBOX_SDK_IMPORT") {
 		t.Fatalf("bridge script must import the resolved SDK package name from the trusted cache package")
+	}
+}
+
+func TestCodeSandboxClientListLimitReachesEmbeddedSDK(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node is required")
+	}
+	modulePath := filepath.Join(t.TempDir(), "list-only-sdk.mjs")
+	const module = `
+export class CodeSandbox {
+  constructor() {
+    this.sandboxes = {
+      list: async ({ limit }) => ({ sandboxes: [], totalCount: limit }),
+      listRunning: async () => ({ vms: [] })
+    };
+  }
+}
+`
+	if err := os.WriteFile(modulePath, []byte(module), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name                        string
+		configured, requested, want int
+	}{
+		{name: "default", want: 1},
+		{name: "configured", configured: 3, want: 3},
+		{name: "explicit", configured: 3, requested: 5, want: 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := newTestConfig().CodeSandbox
+			cfg.DoctorListLimit = tc.configured
+			cfg.SDKPackage = (&url.URL{Scheme: "file", Path: modulePath}).String()
+			rt := Runtime{Exec: actualBridgeRunner{}}
+			client := &codeSandboxClient{cfg: cfg, rt: rt, bridge: NewSDKBridge(cfg, rt), token: "synthetic-list-test"}
+			result, err := client.ListSandboxes(context.Background(), ListSandboxesRequest{Limit: tc.requested})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.TotalCount != tc.want {
+				t.Fatalf("SDK received limit=%d, want %d", result.TotalCount, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/providers/codesandbox/claims.go
+++ b/internal/providers/codesandbox/claims.go
@@ -11,6 +11,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -192,7 +193,7 @@ func newSandboxTitle(repo Repo) string {
 func codeSandboxWorkdir(cfg Config) (string, error) {
 	workdir := strings.TrimSpace(cfg.CodeSandbox.Workdir)
 	if workdir == "" {
-		workdir = defaultWorkdir
+		workdir = core.CodeSandboxConfigDefaultWorkdir
 	}
 	if strings.IndexFunc(workdir, func(r rune) bool { return r == 0 || (!utf8.ValidRune(r)) || (r < 0x20) }) >= 0 {
 		return "", exit(2, "codesandbox workdir contains control characters")
@@ -203,10 +204,10 @@ func codeSandboxWorkdir(cfg Config) (string, error) {
 	}
 	switch clean {
 	case "/", "/project":
-		return "", exit(2, "codesandbox workdir %q is too broad; choose a path under %s", clean, defaultWorkdir)
+		return "", exit(2, "codesandbox workdir %q is too broad; choose a path under %s", clean, codeSandboxWorkspaceRoot)
 	}
-	if clean != defaultWorkdir && !strings.HasPrefix(clean, defaultWorkdir+"/") {
-		return "", exit(2, "codesandbox workdir %q must be under %s", clean, defaultWorkdir)
+	if clean != codeSandboxWorkspaceRoot && !strings.HasPrefix(clean, codeSandboxWorkspaceRoot+"/") {
+		return "", exit(2, "codesandbox workdir %q must be under %s", clean, codeSandboxWorkspaceRoot)
 	}
 	return clean, nil
 }

--- a/internal/providers/codesandbox/core.go
+++ b/internal/providers/codesandbox/core.go
@@ -38,14 +38,13 @@ type timingPhase = core.TimingPhase
 type LocalCommandRequest = core.LocalCommandRequest
 
 const (
-	providerName         = "codesandbox"
-	providerFamily       = "codesandbox"
-	leasePrefix          = "csbx_"
-	defaultWorkdir       = "/project/workspace"
-	defaultBridgeCommand = "node"
-	defaultSDKPackage    = "@codesandbox/sdk@2.4.2"
-	targetLinux          = core.TargetLinux
-	NetworkPublic        = core.NetworkPublic
+	providerName   = "codesandbox"
+	providerFamily = "codesandbox"
+	leasePrefix    = "csbx_"
+	// This SDK mount does not move when the configured workdir default changes.
+	codeSandboxWorkspaceRoot = "/project/workspace"
+	targetLinux              = core.TargetLinux
+	NetworkPublic            = core.NetworkPublic
 
 	codesandboxPrimaryAPIKeyEnv  = "CRABBOX_CODESANDBOX_API_KEY"
 	codesandboxFallbackAPIKeyEnv = "CSB_API_KEY"
@@ -114,7 +113,7 @@ func codeSandboxCleanupCommand(leaseID string) string {
 func operationTimeout(cfg CodeSandboxConfig) time.Duration {
 	seconds := cfg.OperationTimeoutSecs
 	if seconds <= 0 {
-		seconds = 30
+		seconds = core.CodeSandboxConfigDefaultOperationTimeoutSecs
 	}
 	return time.Duration(seconds) * time.Second
 }
@@ -123,19 +122,19 @@ func bridgeCommand(cfg CodeSandboxConfig) string {
 	if command := strings.TrimSpace(cfg.BridgeCommand); command != "" {
 		return command
 	}
-	return defaultBridgeCommand
+	return core.CodeSandboxConfigDefaultBridgeCommand
 }
 
 func sdkPackage(cfg CodeSandboxConfig) string {
 	if pkg := strings.TrimSpace(cfg.SDKPackage); pkg != "" {
 		return pkg
 	}
-	return defaultSDKPackage
+	return core.CodeSandboxConfigDefaultSDKPackage
 }
 
 func doctorListLimit(cfg CodeSandboxConfig) int {
 	if cfg.DoctorListLimit <= 0 {
-		return 1
+		return core.CodeSandboxConfigDefaultDoctorListLimit
 	}
 	return cfg.DoctorListLimit
 }

--- a/internal/providers/codesandbox/provider_test.go
+++ b/internal/providers/codesandbox/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -118,6 +119,39 @@ func TestValidateCodeSandboxConfigRejectsUnsafeValues(t *testing.T) {
 			err := validateCodeSandboxConfig(cfg)
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("validate err=%v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestCodeSandboxEffectiveDefaults(t *testing.T) {
+	defaults := newTestConfig().CodeSandbox
+	for _, tc := range []struct {
+		name                  string
+		cfg                   CodeSandboxConfig
+		seconds, limit        int
+		command, sdk, workdir string
+	}{
+		{name: "empty", seconds: 30, limit: 1, command: "node", sdk: "@codesandbox/sdk@2.4.2", workdir: "/project/workspace"},
+		{name: "whitespace and negative", cfg: CodeSandboxConfig{BridgeCommand: " \t", SDKPackage: " \t", Workdir: " \t", OperationTimeoutSecs: -1, DoctorListLimit: -1}, seconds: 30, limit: 1, command: "node", sdk: "@codesandbox/sdk@2.4.2", workdir: "/project/workspace"},
+		{name: "custom trimmed", cfg: CodeSandboxConfig{BridgeCommand: " /opt/example-node ", SDKPackage: " @codesandbox/sdk@2.4.1 ", Workdir: " /project/workspace/app/ ", OperationTimeoutSecs: 45, DoctorListLimit: 3}, seconds: 45, limit: 3, command: "/opt/example-node", sdk: "@codesandbox/sdk@2.4.1", workdir: "/project/workspace/app"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := newTestConfig()
+			cfg.CodeSandbox = tc.cfg
+			before := cfg.CodeSandbox
+			workdir, err := codeSandboxWorkdir(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if operationTimeout(cfg.CodeSandbox) != time.Duration(tc.seconds)*time.Second || doctorListLimit(cfg.CodeSandbox) != tc.limit || bridgeCommand(cfg.CodeSandbox) != tc.command || sdkPackage(cfg.CodeSandbox) != tc.sdk || workdir != tc.workdir {
+				t.Fatalf("effective values differ from literal contract for %#v", tc.cfg)
+			}
+			if tc.name != "custom trimmed" && (tc.seconds != defaults.OperationTimeoutSecs || tc.limit != defaults.DoctorListLimit || tc.command != defaults.BridgeCommand || tc.sdk != defaults.SDKPackage || tc.workdir != defaults.Workdir) {
+				t.Fatalf("fallbacks differ from generated defaults: %#v", defaults)
+			}
+			if cfg.CodeSandbox != before {
+				t.Fatal("effective reads changed config")
 			}
 		})
 	}

--- a/internal/providers/codesandbox/sync.go
+++ b/internal/providers/codesandbox/sync.go
@@ -17,7 +17,7 @@ func (b *codeSandboxBackend) syncWorkspace(ctx context.Context, api codeSandboxA
 		ForceSyncLarge:      req.ForceSyncLarge,
 		Workdir:             workdir,
 		TempPattern:         "crabbox-codesandbox-sync-*.tgz",
-		RemoteArchiveDir:    defaultWorkdir,
+		RemoteArchiveDir:    codeSandboxWorkspaceRoot,
 		RemoteArchivePrefix: ".crabbox-codesandbox-sync-",
 		PhaseName:           "codesandbox_sync",
 		Provider:            providerName,
@@ -31,7 +31,7 @@ func (b *codeSandboxBackend) syncWorkspace(ctx context.Context, api codeSandboxA
 			return b.execShell(execCtx, api, sandboxID, command)
 		},
 	}
-	if workdir == defaultWorkdir {
+	if workdir == codeSandboxWorkspaceRoot {
 		syncReq.Replace = func(replaceCtx context.Context, stagingDir, workdir string) error {
 			return b.execShell(replaceCtx, api, sandboxID, codeSandboxMountReplaceCommand(stagingDir, workdir))
 		}

--- a/internal/providers/codesandbox/sync_test.go
+++ b/internal/providers/codesandbox/sync_test.go
@@ -63,7 +63,7 @@ func TestSpecAllowsArchiveSyncOptionsButRejectsUnsupportedDelegatedOptions(t *te
 }
 
 func TestCodeSandboxMountReplaceCommandReplacesContentsNotMount(t *testing.T) {
-	command := codeSandboxMountReplaceCommand("/project/.workspace.crabbox-sync-fixed", defaultWorkdir)
+	command := codeSandboxMountReplaceCommand("/project/.workspace.crabbox-sync-fixed", codeSandboxWorkspaceRoot)
 	for _, want := range []string{
 		"rollback()",
 		"mv -- \"$entry\" '/project/workspace/.workspace.crabbox-sync-fixed.previous/'",


### PR DESCRIPTION
## Summary

Use the generated CodeSandbox configuration defaults as the single owner for bridge command, SDK package, operation timeout, diagnostic list limit, and workdir fallbacks. Preserve trim-before-fallback and nonpositive-number behavior. The fixed `/project/workspace` SDK mount remains separate from the configurable workdir default; archive staging, mount replacement, cleanup budgets, and operation-specific extensions are unchanged.

The Go list producer always supplies a positive resolved limit, so the embedded JavaScript bridge no longer chooses a second default. Current-main integration retains the shared `ArchiveWorkspace` implementation rather than restoring older provider-local orchestration.

This is maintainer-owned refactor work. The changelog entry is maintained under Unreleased; the prior contributor-only changelog concern does not apply.

## Current-source verification

[Actual SDK diagnostic evidence](https://github.com/openclaw/crabbox/pull/1991#issuecomment-5692711259).

Head `287deab991d0d990d21436886de02dac8233939c`, tree `8c91ca3484867a477b7c774f75405b6c7144b357`.

- Full CodeSandbox Go race tests passed; current-main CLI build passed.
- Applicable independent Codex reviews were scoped-clean at P0-only priority, not a claim that every lower-priority concern is excluded.
- The actual published `@codesandbox/sdk@2.4.2` was installed credential-free with install scripts and optional dependencies disabled. Its archive integrity and installed ESM entrypoint bytes were checked against the published archive; no SDK patch or fake module was used for native proof.
- Ordinary candidate `doctor --provider codesandbox --json` succeeded with the default list limit **1**, and with `--codesandbox-doctor-list-limit 3` using the default Node bridge.
- Supplemental runs selected an explicitly disclosed supported Node bridge wrapper that observed requests/responses without replacing them. The actual SDK sent `page_size=1` and `page_size=3`; both returned HTTP 200 and zero records. The inventory was empty: this proves actual SDK diagnostic/request compatibility, not populated pagination enforcement, a strict client-side count ceiling, or an atomic inventory snapshot.
- Before/after local claims were empty. Temporary runtimes and the credential-task window were removed. Only read-only diagnostics ran; no sandbox lifecycle is required or claimed for this list-only refactor.
- An independent source-blind readout confirmed the observed ordinary diagnostics and separate supplemental observations. Source/build/SDK provenance and credential handling remain complementary operator evidence.

Candidate SHA-256: `a2c85ff874b013c9a1ce51b205f1908c0a9ea5985602374c0a976213f9cd2be8`. SDK ESM SHA-256: `dd628cb976e500bb902d3fca1f276c8c2b3ce9181c06f2538d10a9a23ce24152`.

An initial harness incorrectly expected the plain CLI to expose returned page length; its real default diagnostic succeeded, then that assertion failed. The failed qualification remains recorded. Final proof separately records the CLI's total inventory count and observer-measured page length; no initial result was relabeled as a complete pass.

Exact-head [CI](https://github.com/openclaw/crabbox/actions/runs/35060935301), [Release](https://github.com/openclaw/crabbox/actions/runs/35060935320), [Connector](https://github.com/openclaw/crabbox/actions/runs/35060935483), [CodeQL](https://github.com/openclaw/crabbox/actions/runs/35060932999), and [Docs UI](https://github.com/openclaw/crabbox/actions/runs/35060935432) passed and were independently read back before landing. The previous actual-SDK proof hold is now supported by current-source native evidence rather than the older local fixture results. No new authentication, installation, timeout, privacy, or wakeup policy is introduced.
