### PR TITLE
refactor(cua): share configured fallback defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 - Describe OpenSandbox configuration bindings once, preserving CLI-only stale-claim cleanup, environment/flag-only API URL selection, defaults, and validation timing. [PR 1990](https://github.com/openclaw/crabbox/pull/1990). Thanks @steipete.
 
-- Keep CUA runtime and Python bridge defaults aligned with declared configuration, preserving custom SDK imports, whitespace fallback behavior, and read-only diagnostics. Thanks @steipete.
+- Keep CUA runtime and Python bridge defaults aligned with declared configuration, preserving custom SDK imports, whitespace fallback behavior, and read-only diagnostics. [PR 1992](https://github.com/openclaw/crabbox/pull/1992). Thanks @steipete.
 
 ## 0.52.0 - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 - Describe OpenSandbox configuration bindings once, preserving CLI-only stale-claim cleanup, environment/flag-only API URL selection, defaults, and validation timing. [PR 1990](https://github.com/openclaw/crabbox/pull/1990). Thanks @steipete.
 
+- Keep CUA runtime and Python bridge defaults aligned with declared configuration, preserving custom SDK imports, whitespace fallback behavior, and read-only diagnostics. Thanks @steipete.
+
 ## 0.52.0 - 2026-09-07
 
 ### Highlights

--- a/docs/refactor/typed-provider-config.md
+++ b/docs/refactor/typed-provider-config.md
@@ -112,6 +112,14 @@ settings retain trusted-file-only admission; the other nine YAML fields remain
 repository-safe. Its sizing guard still precedes the flag-value type assertion,
 unlike CodeSandbox's wrapper. Read-only lifecycle restrictions are unchanged.
 
+CUA's runtime fallbacks use the generated defaults as well. The Go bridge
+resolves an empty or whitespace-only fallback import before supplying both JSON
+and environment settings, preserving the effective SDK choice formerly supplied
+by Python. Python retains request-over-environment precedence but no longer owns
+duplicate import defaults. Other string fields retain their existing
+blank-before-trim behavior. The fixed 15-second doctor budget and the Python
+version check for the actual `cua_sandbox` module remain separate contracts.
+
 OpenSandbox's twelve runtime/flag fields include ten YAML fields and eleven
 environment fields. `APIURL` has no YAML source; `CRABBOX_OPENSANDBOX_API_URL`
 retains precedence over `OPEN_SANDBOX_API_URL`. `ForgetMissing` remains CLI-only:

--- a/internal/providers/cua/bridge.go
+++ b/internal/providers/cua/bridge.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared/procjson"
 )
 
@@ -194,7 +195,7 @@ func (c *bridgeClient) RoundTrip(ctx context.Context, req bridgeRequest) (bridge
 		return bridgeResponse{}, err
 	}
 	defer os.RemoveAll(dir)
-	command := LocalCommandRequest{Name: strings.TrimSpace(blank(c.cfg.Cua.BridgeCommand, defaultBridgeCommand)), Args: []string{"-I", "-c", bridgeScript}, Env: bridgeEnv(c.cfg, dir), Dir: dir}
+	command := LocalCommandRequest{Name: strings.TrimSpace(blank(c.cfg.Cua.BridgeCommand, core.CuaConfigDefaultBridgeCommand)), Args: []string{"-I", "-c", bridgeScript}, Env: bridgeEnv(c.cfg, dir), Dir: dir}
 	resp, result, err := procjson.Exchange[bridgeRequest, bridgeResponse](ctx, c.rt.Exec, command, req, procjson.Limits{MaxBytesPerStream: bridgeOutputLimit, CancelGrace: 2 * time.Second})
 	if err != nil {
 		failure, _ := err.(*procjson.Failure)
@@ -212,8 +213,8 @@ func bridgeConfigForConfig(cfg Config) bridgeConfig {
 	workdir, _ := cuaWorkdir(cfg)
 	return bridgeConfig{
 		APIURL:         apiURL,
-		Image:          strings.TrimSpace(blank(cfg.Cua.Image, defaultImage)),
-		Kind:           strings.ToLower(strings.TrimSpace(blank(cfg.Cua.Kind, defaultKind))),
+		Image:          strings.TrimSpace(blank(cfg.Cua.Image, core.CuaConfigDefaultImage)),
+		Kind:           strings.ToLower(strings.TrimSpace(blank(cfg.Cua.Kind, core.CuaConfigDefaultKind))),
 		Region:         strings.TrimSpace(cfg.Cua.Region),
 		Workdir:        workdir,
 		VCPUs:          cfg.Cua.VCPUs,
@@ -221,10 +222,16 @@ func bridgeConfigForConfig(cfg Config) bridgeConfig {
 		DiskGB:         cfg.Cua.DiskGB,
 		StartupTimeout: cfg.Cua.StartupTimeoutSecs,
 		ExecTimeout:    cfg.Cua.ExecTimeoutSecs,
-		SDKPackage:     strings.TrimSpace(blank(cfg.Cua.SDKPackage, defaultSDKPackage)),
-		SDKImport:      strings.TrimSpace(blank(cfg.Cua.SDKImport, defaultSDKImport)),
-		FallbackImport: strings.TrimSpace(blank(cfg.Cua.SDKFallbackImport, defaultSDKFallbackImport)),
+		SDKPackage:     strings.TrimSpace(blank(cfg.Cua.SDKPackage, core.CuaConfigDefaultSDKPackage)),
+		SDKImport:      strings.TrimSpace(blank(cfg.Cua.SDKImport, core.CuaConfigDefaultSDKImport)),
+		FallbackImport: cuaSDKFallbackImport(cfg.Cua),
 	}
+}
+
+// Whitespace fallback imports previously reached Python's terminal default.
+// Resolve that accepted value before supplying either bridge transport channel.
+func cuaSDKFallbackImport(cfg CuaConfig) string {
+	return blank(strings.TrimSpace(cfg.SDKFallbackImport), core.CuaConfigDefaultSDKFallbackImport)
 }
 
 func bridgeTimeout(cfg Config, req bridgeRequest) time.Duration {
@@ -233,7 +240,7 @@ func bridgeTimeout(cfg Config, req bridgeRequest) time.Duration {
 		seconds = 15
 	}
 	if seconds <= 0 {
-		seconds = 600
+		seconds = core.CuaConfigDefaultExecTimeoutSecs
 	}
 	return time.Duration(seconds) * time.Second
 }
@@ -270,9 +277,9 @@ func bridgeEnv(cfg Config, home string) []string {
 		// https://github.com/trycua/cua/blob/sandbox-v0.1.17/libs/python/cua-sandbox/cua_sandbox/_config.py
 		env = upsertEnv(env, "CUA_BASE_URL", apiURL)
 	}
-	env = upsertEnv(env, "CRABBOX_CUA_SDK_PACKAGE", strings.TrimSpace(blank(cfg.Cua.SDKPackage, defaultSDKPackage)))
-	env = upsertEnv(env, "CRABBOX_CUA_SDK_IMPORT", strings.TrimSpace(blank(cfg.Cua.SDKImport, defaultSDKImport)))
-	env = upsertEnv(env, "CRABBOX_CUA_SDK_FALLBACK_IMPORT", strings.TrimSpace(blank(cfg.Cua.SDKFallbackImport, defaultSDKFallbackImport)))
+	env = upsertEnv(env, "CRABBOX_CUA_SDK_PACKAGE", strings.TrimSpace(blank(cfg.Cua.SDKPackage, core.CuaConfigDefaultSDKPackage)))
+	env = upsertEnv(env, "CRABBOX_CUA_SDK_IMPORT", strings.TrimSpace(blank(cfg.Cua.SDKImport, core.CuaConfigDefaultSDKImport)))
+	env = upsertEnv(env, "CRABBOX_CUA_SDK_FALLBACK_IMPORT", cuaSDKFallbackImport(cfg.Cua))
 	return env
 }
 

--- a/internal/providers/cua/bridge_script.py
+++ b/internal/providers/cua/bridge_script.py
@@ -226,8 +226,8 @@ def main():
     try:
         req = json.load(sys.stdin)
         cfg = req.get("config") or {}
-        preferred = cfg.get("sdkImport") or os.environ.get("CRABBOX_CUA_SDK_IMPORT") or "cua"
-        fallback = cfg.get("fallbackImport") or os.environ.get("CRABBOX_CUA_SDK_FALLBACK_IMPORT") or "cua_sandbox"
+        preferred = cfg.get("sdkImport") or os.environ.get("CRABBOX_CUA_SDK_IMPORT")
+        fallback = cfg.get("fallbackImport") or os.environ.get("CRABBOX_CUA_SDK_FALLBACK_IMPORT")
         mod, import_path, import_error = import_sdk(preferred, fallback)
         if mod is not None:
             sdk_configure(mod, cfg)

--- a/internal/providers/cua/bridge_test.go
+++ b/internal/providers/cua/bridge_test.go
@@ -53,14 +53,14 @@ func (r *recordingRunner) onlyCall(t *testing.T) LocalCommandRequest {
 func testConfig() Config {
 	return Config{Provider: providerName, Cua: core.CuaConfig{
 		APIURL:            "https://api.cua.example/v1/",
-		Image:             defaultImage,
-		Kind:              defaultKind,
-		Workdir:           defaultWorkdir,
+		Image:             core.CuaConfigDefaultImage,
+		Kind:              core.CuaConfigDefaultKind,
+		Workdir:           core.CuaConfigDefaultWorkdir,
 		ExecTimeoutSecs:   60,
-		BridgeCommand:     defaultBridgeCommand,
-		SDKPackage:        defaultSDKPackage,
-		SDKImport:         defaultSDKImport,
-		SDKFallbackImport: defaultSDKFallbackImport,
+		BridgeCommand:     core.CuaConfigDefaultBridgeCommand,
+		SDKPackage:        core.CuaConfigDefaultSDKPackage,
+		SDKImport:         core.CuaConfigDefaultSDKImport,
+		SDKFallbackImport: core.CuaConfigDefaultSDKFallbackImport,
 	}}
 }
 
@@ -146,7 +146,7 @@ func TestBridgeSendsJSONOnStdinAndMapsSecretOnlyToSDKEnv(t *testing.T) {
 		t.Fatalf("resp=%#v", resp)
 	}
 	call := runner.onlyCall(t)
-	if call.Name != defaultBridgeCommand {
+	if call.Name != core.CuaConfigDefaultBridgeCommand {
 		t.Fatalf("command=%q", call.Name)
 	}
 	if !reflect.DeepEqual(call.Args[:2], []string{"-I", "-c"}) {
@@ -240,6 +240,179 @@ func TestBridgeRequiresRunner(t *testing.T) {
 	if !errors.As(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "requires Runtime.Exec") {
 		t.Fatalf("RoundTrip error=%v", err)
 	}
+}
+
+func TestCUABridgeDefaultValuesAndRawConfig(t *testing.T) {
+	defaults := core.BaseConfig().Cua
+	if defaults.Image != "ubuntu:24.04" || defaults.Kind != "container" || defaults.Workdir != "/workspace/crabbox" || defaults.BridgeCommand != "python3" || defaults.SDKPackage != "cua" || defaults.SDKImport != "cua" || defaults.SDKFallbackImport != "cua_sandbox" || defaults.ExecTimeoutSecs != 600 {
+		t.Fatalf("generated defaults changed: %#v", defaults)
+	}
+	for _, raw := range []string{"", " \t", "custom"} {
+		cfg := testConfig()
+		cfg.Cua.Image, cfg.Cua.Kind, cfg.Cua.SDKPackage, cfg.Cua.SDKImport = raw, raw, raw, raw
+		cfg.Cua.ExecTimeoutSecs = 0
+		before := cfg.Cua
+		got := bridgeConfigForConfig(cfg)
+		wantImage, wantKind, wantPackage, wantImport := "ubuntu:24.04", "container", "cua", "cua"
+		if raw != "" {
+			wantImage, wantKind, wantPackage, wantImport = strings.TrimSpace(raw), strings.TrimSpace(raw), strings.TrimSpace(raw), strings.TrimSpace(raw)
+		}
+		if got.Image != wantImage || got.Kind != wantKind || got.SDKPackage != wantPackage || got.SDKImport != wantImport || got.ExecTimeout != 0 {
+			t.Fatalf("raw=%q bridge config=%#v", raw, got)
+		}
+		if cfg.Cua != before {
+			t.Fatal("bridge config changed raw input")
+		}
+	}
+	for _, seconds := range []int{-1, 0, 60} {
+		cfg := testConfig()
+		cfg.Cua.ExecTimeoutSecs = seconds
+		want := 600 * time.Second
+		if seconds > 0 {
+			want = time.Duration(seconds) * time.Second
+		}
+		if bridgeTimeout(cfg, bridgeRequest{Action: "list"}) != want || bridgeTimeout(cfg, bridgeRequest{Action: "doctor"}) != 15*time.Second {
+			t.Fatalf("unexpected budget for %d", seconds)
+		}
+	}
+}
+
+func TestCUABridgeLauncherAndWorkdirNormalization(t *testing.T) {
+	t.Setenv("CRABBOX_CUA_API_KEY", "")
+	t.Setenv("CUA_API_KEY", "")
+	for _, tc := range []struct{ name, command, workdir, kind, wantCommand, wantWorkdir, wantKind string }{
+		{"empty", "", "", "", "python3", "/workspace/crabbox", "container"},
+		{"whitespace", " \t", " \t", " \t", "", "", ""},
+		{"custom", " /opt/example-python ", " /workspace/app/ ", " VM ", "/opt/example-python", "/workspace/app", "vm"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := testConfig()
+			cfg.Cua.BridgeCommand, cfg.Cua.Workdir, cfg.Cua.Kind = tc.command, tc.workdir, tc.kind
+			before := cfg.Cua
+			runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+				var payload bridgeRequest
+				if err := json.Unmarshal([]byte(requestBody(t, req)), &payload); err != nil {
+					t.Fatal(err)
+				}
+				if req.Name != tc.wantCommand || payload.Config.Workdir != tc.wantWorkdir || payload.Config.Kind != tc.wantKind {
+					t.Fatalf("command=%q workdir=%q kind=%q", req.Name, payload.Config.Workdir, payload.Config.Kind)
+				}
+				_, _ = io.WriteString(req.Stdout, `{"ok":true}`)
+				return LocalCommandResult{ExitCode: 0}, nil
+			}}
+			if _, err := newBridgeClient(cfg, Runtime{Exec: runner}).RoundTrip(context.Background(), bridgeRequest{Action: "list"}); err != nil {
+				t.Fatal(err)
+			}
+			_, err := cuaWorkdir(cfg)
+			if (err != nil) != (tc.name == "whitespace") {
+				t.Fatalf("workdir error=%v", err)
+			}
+			if cfg.Cua != before {
+				t.Fatal("bridge changed raw config")
+			}
+		})
+	}
+}
+
+func TestCUAEffectiveImportSelectionAcrossBridge(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 unavailable")
+	}
+	t.Setenv("CRABBOX_CUA_API_KEY", "")
+	t.Setenv("CUA_API_KEY", "")
+	for _, tc := range []struct{ name, preferred, fallback, wantPreferred, wantFallback string }{
+		{"default", "cua", "", "cua", "cua_sandbox"},
+		{"whitespace fallback", "cua", " \t", "cua", "cua_sandbox"},
+		{"custom", " example_sdk ", " example_fallback ", "example_sdk", "example_fallback"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := testConfig()
+			cfg.Cua.SDKImport, cfg.Cua.SDKFallbackImport = tc.preferred, tc.fallback
+			if err := validateProviderConfig(cfg); err != nil {
+				t.Fatal(err)
+			}
+			before := cfg.Cua
+			runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+				var payload bridgeRequest
+				if err := json.Unmarshal([]byte(requestBody(t, req)), &payload); err != nil {
+					t.Fatal(err)
+				}
+				selection := cuaScriptImportSelection(t, python, req.Args[2], payload, req.Env)
+				if selection[0] != tc.wantPreferred || selection[1] != tc.wantFallback {
+					t.Fatalf("effective imports=%v, want [%s %s]", selection, tc.wantPreferred, tc.wantFallback)
+				}
+				_, _ = io.WriteString(req.Stdout, `{"ok":true}`)
+				return LocalCommandResult{ExitCode: 0}, nil
+			}}
+			if _, err := newBridgeClient(cfg, Runtime{Exec: runner}).RoundTrip(context.Background(), bridgeRequest{Action: "list"}); err != nil {
+				t.Fatal(err)
+			}
+			if cfg.Cua != before {
+				t.Fatal("bridge changed raw config")
+			}
+		})
+	}
+	for _, fromRequest := range []bool{true, false} {
+		payload := bridgeRequest{Config: bridgeConfig{SDKImport: "request_sdk", FallbackImport: "request_fallback"}}
+		want := []string{"request_sdk", "request_fallback"}
+		if !fromRequest {
+			payload.Config.SDKImport, payload.Config.FallbackImport = "", ""
+			want = []string{"env_sdk", "env_fallback"}
+		}
+		got := cuaScriptImportSelection(t, python, bridgeScript, payload, []string{"CRABBOX_CUA_SDK_IMPORT=env_sdk", "CRABBOX_CUA_SDK_FALLBACK_IMPORT=env_fallback"})
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("request precedence=%t got=%v want=%v", fromRequest, got, want)
+		}
+	}
+}
+
+func TestCUAFallbackImportResolvedBeforeTransport(t *testing.T) {
+	t.Setenv("CRABBOX_CUA_API_KEY", "")
+	t.Setenv("CUA_API_KEY", "")
+	for _, raw := range []string{"", " \t", " example_fallback "} {
+		cfg := testConfig()
+		cfg.Cua.SDKFallbackImport = raw
+		want := "cua_sandbox"
+		if strings.TrimSpace(raw) != "" {
+			want = "example_fallback"
+		}
+		if got := bridgeConfigForConfig(cfg).FallbackImport; got != want {
+			t.Fatalf("fallback request=%q, want %q", got, want)
+		}
+		if !envContains(bridgeEnv(cfg, t.TempDir()), "CRABBOX_CUA_SDK_FALLBACK_IMPORT="+want) {
+			t.Fatal("fallback environment differs from request")
+		}
+		if cfg.Cua.SDKFallbackImport != raw {
+			t.Fatal("raw fallback config changed")
+		}
+	}
+}
+
+// Stop at import selection: this fixture never imports an SDK or contacts a provider.
+func cuaScriptImportSelection(t *testing.T, python, script string, payload bridgeRequest, env []string) []string {
+	t.Helper()
+	encodedScript, err := json.Marshal(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bootstrap := "import json\nns = {'__name__': 'contract'}\nexec(" + string(encodedScript) + ", ns)\ndef capture(preferred, fallback):\n    print(json.dumps([preferred, fallback]))\n    raise SystemExit(0)\nns['import_sdk'] = capture\nns['main']()\n"
+	encodedPayload, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(python, "-I", "-c", bootstrap)
+	cmd.Env = env
+	cmd.Stdin = bytes.NewReader(encodedPayload)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("local Python selection: %v: %s", err, output)
+	}
+	var selected []string
+	if err := json.Unmarshal(output, &selected); err != nil || len(selected) != 2 {
+		t.Fatalf("selection=%s error=%v", output, err)
+	}
+	return selected
 }
 
 func TestBridgeTimeoutBoundsDoctorAndInventory(t *testing.T) {

--- a/internal/providers/cua/claims_test.go
+++ b/internal/providers/cua/claims_test.go
@@ -16,8 +16,8 @@ func claimLabels(cfg Config, sandboxName, createdAt string, missing bool) map[st
 	workdir, _ := cuaWorkdir(cfg)
 	labels := map[string]string{
 		labelSandboxName: sandboxName,
-		labelImage:       strings.TrimSpace(blank(cfg.Cua.Image, defaultImage)),
-		labelKind:        strings.ToLower(strings.TrimSpace(blank(cfg.Cua.Kind, defaultKind))),
+		labelImage:       strings.TrimSpace(blank(cfg.Cua.Image, core.CuaConfigDefaultImage)),
+		labelKind:        strings.ToLower(strings.TrimSpace(blank(cfg.Cua.Kind, core.CuaConfigDefaultKind))),
 		labelRegion:      strings.TrimSpace(cfg.Cua.Region),
 		labelWorkdir:     workdir,
 		labelCreatedAt:   strings.TrimSpace(createdAt),

--- a/internal/providers/cua/core.go
+++ b/internal/providers/cua/core.go
@@ -31,18 +31,10 @@ type LeaseClaim = core.LeaseClaim
 type ExitError = core.ExitError
 
 const (
-	providerName             = "cua"
-	defaultImage             = "ubuntu:24.04"
-	defaultKind              = "container"
-	defaultRegion            = ""
-	defaultWorkdir           = "/workspace/crabbox"
-	defaultBridgeCommand     = "python3"
-	defaultSDKPackage        = "cua"
-	defaultSDKImport         = "cua"
-	defaultSDKFallbackImport = "cua_sandbox"
-	targetLinux              = core.TargetLinux
-	cuaTrackingIssue         = "https://github.com/openclaw/crabbox/issues/381"
-	maxBridgeTimeoutSeconds  = int64((1<<63 - 1) / int64(time.Second))
+	providerName            = "cua"
+	targetLinux             = core.TargetLinux
+	cuaTrackingIssue        = "https://github.com/openclaw/crabbox/issues/381"
+	maxBridgeTimeoutSeconds = int64((1<<63 - 1) / int64(time.Second))
 )
 
 func provisioningUnsupported() error {

--- a/internal/providers/cua/flags.go
+++ b/internal/providers/cua/flags.go
@@ -39,7 +39,7 @@ func validateProviderConfig(cfg Config) error {
 	if _, err := cuaWorkdir(cfg); err != nil {
 		return err
 	}
-	kind := strings.ToLower(strings.TrimSpace(blank(cfg.Cua.Kind, defaultKind)))
+	kind := strings.ToLower(strings.TrimSpace(blank(cfg.Cua.Kind, core.CuaConfigDefaultKind)))
 	if kind != "container" && kind != "vm" {
 		return exit(2, "%s kind must be container or vm", providerName)
 	}
@@ -74,7 +74,7 @@ func validateProviderConfig(cfg Config) error {
 }
 
 func cuaWorkdir(cfg Config) (string, error) {
-	workdir := strings.TrimSpace(blank(cfg.Cua.Workdir, defaultWorkdir))
+	workdir := strings.TrimSpace(blank(cfg.Cua.Workdir, core.CuaConfigDefaultWorkdir))
 	if !path.IsAbs(workdir) {
 		return "", exit(2, "%s workdir must be absolute", providerName)
 	}

--- a/internal/providers/cua/flags_test.go
+++ b/internal/providers/cua/flags_test.go
@@ -11,14 +11,14 @@ import (
 
 func TestProviderFlagsApplyAndValidate(t *testing.T) {
 	cfg := core.Config{Provider: providerName, Cua: core.CuaConfig{
-		Image:             defaultImage,
-		Kind:              defaultKind,
-		Workdir:           defaultWorkdir,
+		Image:             core.CuaConfigDefaultImage,
+		Kind:              core.CuaConfigDefaultKind,
+		Workdir:           core.CuaConfigDefaultWorkdir,
 		ExecTimeoutSecs:   600,
-		BridgeCommand:     defaultBridgeCommand,
-		SDKPackage:        defaultSDKPackage,
-		SDKImport:         defaultSDKImport,
-		SDKFallbackImport: defaultSDKFallbackImport,
+		BridgeCommand:     core.CuaConfigDefaultBridgeCommand,
+		SDKPackage:        core.CuaConfigDefaultSDKPackage,
+		SDKImport:         core.CuaConfigDefaultSDKImport,
+		SDKFallbackImport: core.CuaConfigDefaultSDKFallbackImport,
 	}}
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	values := Provider{}.RegisterFlags(fs, cfg)
@@ -63,13 +63,13 @@ func TestProviderFlagsApplyAndValidate(t *testing.T) {
 
 func TestValidateProviderConfigRejectsUnsafeValues(t *testing.T) {
 	base := core.CuaConfig{
-		Image:             defaultImage,
-		Kind:              defaultKind,
-		Workdir:           defaultWorkdir,
-		BridgeCommand:     defaultBridgeCommand,
-		SDKPackage:        defaultSDKPackage,
-		SDKImport:         defaultSDKImport,
-		SDKFallbackImport: defaultSDKFallbackImport,
+		Image:             core.CuaConfigDefaultImage,
+		Kind:              core.CuaConfigDefaultKind,
+		Workdir:           core.CuaConfigDefaultWorkdir,
+		BridgeCommand:     core.CuaConfigDefaultBridgeCommand,
+		SDKPackage:        core.CuaConfigDefaultSDKPackage,
+		SDKImport:         core.CuaConfigDefaultSDKImport,
+		SDKFallbackImport: core.CuaConfigDefaultSDKFallbackImport,
 	}
 	tests := []struct {
 		name string
@@ -122,13 +122,13 @@ func TestValidateProviderConfigRejectsOverflowingExecTimeout(t *testing.T) {
 func TestValidateProviderConfigAllowsLoopbackAPIURL(t *testing.T) {
 	cfg := core.Config{Cua: core.CuaConfig{
 		APIURL:            "http://localhost:8080/v1/",
-		Image:             defaultImage,
-		Kind:              defaultKind,
-		Workdir:           defaultWorkdir,
-		BridgeCommand:     defaultBridgeCommand,
-		SDKPackage:        defaultSDKPackage,
-		SDKImport:         defaultSDKImport,
-		SDKFallbackImport: defaultSDKFallbackImport,
+		Image:             core.CuaConfigDefaultImage,
+		Kind:              core.CuaConfigDefaultKind,
+		Workdir:           core.CuaConfigDefaultWorkdir,
+		BridgeCommand:     core.CuaConfigDefaultBridgeCommand,
+		SDKPackage:        core.CuaConfigDefaultSDKPackage,
+		SDKImport:         core.CuaConfigDefaultSDKImport,
+		SDKFallbackImport: core.CuaConfigDefaultSDKFallbackImport,
 	}}
 	if err := validateProviderConfig(cfg); err != nil {
 		t.Fatal(err)
@@ -156,13 +156,13 @@ func TestCUAAPIURLStripsSDKVersionPrefix(t *testing.T) {
 func TestProviderRejectsGenericClassAndTypeFlags(t *testing.T) {
 	for _, args := range [][]string{{"--class", "large"}, {"--type", "gpu"}} {
 		cfg := core.Config{Provider: providerName, Cua: core.CuaConfig{
-			Image:             defaultImage,
-			Kind:              defaultKind,
-			Workdir:           defaultWorkdir,
-			BridgeCommand:     defaultBridgeCommand,
-			SDKPackage:        defaultSDKPackage,
-			SDKImport:         defaultSDKImport,
-			SDKFallbackImport: defaultSDKFallbackImport,
+			Image:             core.CuaConfigDefaultImage,
+			Kind:              core.CuaConfigDefaultKind,
+			Workdir:           core.CuaConfigDefaultWorkdir,
+			BridgeCommand:     core.CuaConfigDefaultBridgeCommand,
+			SDKPackage:        core.CuaConfigDefaultSDKPackage,
+			SDKImport:         core.CuaConfigDefaultSDKImport,
+			SDKFallbackImport: core.CuaConfigDefaultSDKFallbackImport,
 		}}
 		fs := flag.NewFlagSet("test", flag.ContinueOnError)
 		fs.String("class", "", "")


### PR DESCRIPTION
## What changed

CUA's typed configuration already declares its defaults, but the provider repeated eight configured values and Python repeated two import defaults. Runtime consumers now use the generated constants directly; the old local aliases and unused region default are deleted.

A whitespace-only `sdkFallbackImport` is accepted configuration: previously Go trimmed it to empty and Python selected `cua_sandbox`. Resolve that effective choice in Go before both JSON and environment transport, then remove the redundant Python terminal defaults. Preserve raw configuration, request-over-environment precedence, custom imports, and every other field's existing blank-before-trim behavior.

The fixed 15-second doctor budget and Python's version check for the actual `cua_sandbox` module are separate contracts and remain unchanged. Provisioning/deletion restrictions, authentication, endpoint selection, SDK loading and read-only inventory behavior are unchanged. No new config source, credential, dependency, or deployment is required. The landing maintainer has added the changelog entry and architecture documentation.

## Verification

- Baseline `b3bf78151061501e0f51f3dd557ef5ac419bda94` and candidate pass the same five focused compatibility tests: defaults/raw input, empty/whitespace/custom launcher and workdir, mixed-case kind, effective Python import selection, request/environment precedence, and the independent doctor budget. Baseline production files were checked against Git; no skips.
- Candidate-only assertions verify the effective fallback reaches both transport channels without changing the raw input.
- `go test -race -timeout=10m ./internal/providers/cua -count=1 -v`: passed, no skips, with network access denied. The existing read-only rejection tests passed too.
- `go vet ./internal/providers/cua`, `go build -trimpath ./cmd/crabbox`, docs build, and `git diff --check`: passed.
- Managed Codex review found no accepted/actionable P0 findings in the full candidate. Maintainer source review also checked the Go producer and Python consumer together.

The actual baseline and candidate binaries were separately run through `doctor --provider cua --json` with credentials excluded, isolated config/home/state, and networking denied. Their complete JSON results, stderr and exit codes matched for all three cases:

| Settings | Before and after |
| --- | --- |
| Defaults | Exit 1; SDK diagnostic names `cua` and `cua_sandbox` as missing. |
| Whitespace-only fallback import | Same complete result as defaults. |
| Custom preferred and fallback imports | Exit 1; SDK diagnostic preserves both configured module names. |

The CLI test used the unmodified embedded Python script, not an injected SDK fixture. The separate import-selection unit test intercepts SDK import deliberately. Neither proof installs or exercises the real SDK, verifies hosted credentials, or qualifies provider inventory/lifecycle. Missing SDK is an environment result, not a passing hosted smoke.

CI passed on `10be4c2ab9280accfdcbb388527a0bc038835b65`: main CI (including Go aggregate), release checks, connector smokes, docs proof and CodeQL all succeeded. [Main CI run](https://github.com/openclaw/crabbox/actions/runs/34226836085). The original watcher exited successfully without reruns. A superseded ClawSweeper dispatch was cancelled, but its exact-head review completed separately with no findings and sufficient terminal proof. This is not a hosted-SDK qualification, release or deployment.
