### PR TITLE
fix(windows): make managed WSL2 leases ready for POSIX runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix managed Windows WSL2 command timeouts by disabling redundant cloud-init discovery, verifying cold-start readiness, and allowing a target-specific status probe budget for fixed-ID orchestrators. https://github.com/openclaw/crabbox/pull/PR_NUMBER. Thanks @steipete.
+- Fix managed Windows WSL2 command timeouts by disabling redundant cloud-init discovery, verifying cold-start readiness, and allowing a target-specific status probe budget for fixed-ID orchestrators. https://github.com/openclaw/crabbox/pull/1996. Thanks @steipete.
 
 - Describe Anthropic Sandbox Runtime configuration bindings once, preserving inherited binary paths for empty YAML, explicit settings/debug clearing, and native runtime defaults. [PR 1993](https://github.com/openclaw/crabbox/pull/1993). Thanks @steipete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix managed Windows WSL2 command timeouts by disabling redundant cloud-init discovery, verifying cold-start readiness, and allowing a target-specific status probe budget for fixed-ID orchestrators. https://github.com/openclaw/crabbox/pull/PR_NUMBER. Thanks @steipete.
+
 - Describe Anthropic Sandbox Runtime configuration bindings once, preserving inherited binary paths for empty YAML, explicit settings/debug clearing, and native runtime defaults. [PR 1993](https://github.com/openclaw/crabbox/pull/1993). Thanks @steipete.
 
 ## 0.53.0 - 2026-09-08

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -71,6 +71,11 @@ from idling out only when an exact local claim matches the configured provider
 scope and live resource identity. Claimless or mismatched resources remain
 strictly read-only while status waits.
 
+Windows WSL2 snapshots allow up to 30 seconds for WSL startup, SFTP negotiation,
+and the Linux ready check. Other SSH targets retain a four-second probe budget.
+Readiness is checked on every request; a failed probe reports `ready: false`
+even when an earlier request succeeded.
+
 ## Flags
 
 ```text

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -317,6 +317,12 @@ readiness preflight, API, AWS-GO gate, and live canary are in
 | Windows WSL2 | `--windows-mode wsl2`; launches on nested-virtualization families (`c8i`/`m8i`/`m8i-flex`/`r8i`); POSIX sync and commands run inside WSL. |
 | macOS | Requires an available EC2 Mac Dedicated Host in the region; On-Demand only. Admin-authenticated broker requests can pin any host with `CRABBOX_HOST_ID` / `aws.macHostId` (`CRABBOX_AWS_MAC_HOST_ID` is a legacy alias); normal broker users can pin only a host from their own released lease and otherwise use automatic discovery. |
 
+Managed WSL2 distributions disable cloud-init because Crabbox owns their setup.
+This avoids WSL datasource discovery blocking systemd and root login during
+later command invocations. Bootstrap restarts the distro and verifies its Linux
+ready check before publishing the setup marker; warmup also checks the WSL SSH
+runtime. `inspect` and `status` allow a 30-second WSL2 readiness probe.
+
 ## Normal SSH lifecycle
 
 1. Import or reuse the per-lease SSH key (RSA for native Windows, ed25519

--- a/internal/cli/aws_windows_bootstrap.go
+++ b/internal/cli/aws_windows_bootstrap.go
@@ -203,7 +203,7 @@ func bootstrapManagedWindowsWSL2(ctx context.Context, cfg Config, target *SSHTar
 		}
 		target.Port = bootstrapTarget.Port
 		if probeWindowsWSL2BootstrapComplete(ctx, bootstrapTarget, target, 30*time.Second) {
-			return nil
+			return waitForSSHReady(ctx, target, stderr, "WSL2 runtime", bootstrapWaitTimeout(cfg))
 		}
 		fmt.Fprintln(stderr, "Windows WSL2 setup marker is not ready after bootstrap; retrying bootstrap")
 	}

--- a/internal/cli/aws_windows_bootstrap_test.go
+++ b/internal/cli/aws_windows_bootstrap_test.go
@@ -124,6 +124,16 @@ func TestCoordinatorFreshWindowsBootstrapDelivery(t *testing.T) {
 				t.Fatal(err)
 			}
 			logDir := installWindowsBootstrapSSH(t)
+			sftpProbes := 0
+			previous := probeWSLSFTPSubsystem
+			probeWSLSFTPSubsystem = func(_ context.Context, target SSHTarget, _, _ string, _ io.Writer) error {
+				if !isWindowsWSL2Target(target) || target.Port != "2222" {
+					t.Fatalf("runtime probe used the wrong target: %+v", target)
+				}
+				sftpProbes++
+				return nil
+			}
+			t.Cleanup(func() { probeWSLSFTPSubsystem = previous })
 			// A synthetic proxy routes all SSH to the fake executable; no guest
 			// sockets, provider credentials, or privileged local ports are needed.
 			initial.SSHConfigProxy, workload.SSH.SSHConfigProxy = true, true
@@ -135,6 +145,13 @@ func TestCoordinatorFreshWindowsBootstrapDelivery(t *testing.T) {
 			}
 			if workload.SSH.Port != "2222" || len(workload.SSH.FallbackPorts) != 0 || workload.SSH.WindowsMode != mode {
 				t.Fatalf("initial port leaked into final workload: %+v", workload.SSH)
+			}
+			wantProbes := 0
+			if mode == windowsModeWSL2 {
+				wantProbes = 1
+			}
+			if sftpProbes != wantProbes {
+				t.Fatalf("runtime SFTP probes=%d, want %d; the setup marker alone cannot establish WSL readiness", sftpProbes, wantProbes)
 			}
 			calls, err := os.ReadFile(filepath.Join(logDir, "calls"))
 			if err != nil {

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -256,6 +256,10 @@ func windowsWSL2BootstrapPowerShell(cfg Config) string {
 	$linuxSetup = @'
 set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
+mkdir -p /etc/cloud
+# Crabbox owns this distro's setup. WSL datasource discovery can block systemd
+# and root login while trying to invoke Windows tools from an SSH session.
+touch /etc/cloud/cloud-init.disabled
 mkdir -p ` + shellQuote(workRoot) + ` /var/cache/crabbox/pnpm /var/cache/crabbox/npm /var/lib/crabbox
 cat >/etc/apt/apt.conf.d/80-crabbox-retries <<'APT'
 Acquire::Retries "8";
@@ -285,6 +289,10 @@ crabbox-ready
 	[IO.File]::WriteAllText($wslSetup, $linuxSetup, (New-Object Text.UTF8Encoding($false)))
 	wsl.exe -d $wslDistro --user root --exec bash /mnt/c/ProgramData/crabbox/wsl/linux-setup.sh
 	if ($LASTEXITCODE -ne 0) { throw "WSL setup failed with exit $LASTEXITCODE" }
+	wsl.exe --terminate $wslDistro | Out-Host
+	if ($LASTEXITCODE -ne 0) { throw "WSL restart failed with exit $LASTEXITCODE" }
+	wsl.exe -d $wslDistro --user root --exec /usr/local/bin/crabbox-ready
+	if ($LASTEXITCODE -ne 0) { throw "WSL cold-start readiness failed with exit $LASTEXITCODE" }
 	Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")
 	Restart-Service sshd -Force
 	`

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -904,6 +904,37 @@ func TestAWSUserDataWindowsWSL2Profile(t *testing.T) {
 	}
 }
 
+func TestManagedWindowsWSL2BootstrapOwnsDistroInitialization(t *testing.T) {
+	for _, mode := range []string{windowsModeNormal, windowsModeWSL2} {
+		t.Run(mode, func(t *testing.T) {
+			cfg := baseConfig()
+			cfg.TargetOS, cfg.WindowsMode = targetWindows, mode
+			script := windowsBootstrapPowerShell(cfg, "ssh-ed25519 test")
+			steps := []string{
+				"touch /etc/cloud/cloud-init.disabled",
+				"wsl.exe --terminate $wslDistro",
+				"wsl.exe -d $wslDistro --user root --exec /usr/local/bin/crabbox-ready",
+				"WSL cold-start readiness failed with exit $LASTEXITCODE",
+				"Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath",
+			}
+			last := -1
+			for _, step := range steps {
+				index := strings.Index(script, step)
+				if mode == windowsModeNormal {
+					if index >= 0 && step != steps[len(steps)-1] {
+						t.Fatalf("native Windows unexpectedly configures WSL: %s", step)
+					}
+					continue
+				}
+				if index <= last {
+					t.Fatalf("missing or out-of-order WSL initialization step: %s", step)
+				}
+				last = index
+			}
+		})
+	}
+}
+
 func TestWindowsWSL2BootstrapAttemptStreamsOutput(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX fake ssh helper is only reliable on Unix hosts")

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -874,7 +874,7 @@ func (b *coordinatorLeaseBackend) Status(ctx context.Context, req StatusRequest)
 		if err := prepareLeaseSSHTrust(&target, leaseID); err != nil {
 			return statusView{}, err
 		}
-		ready = probeSSHReady(ctx, &target, 4*time.Second)
+		ready = probeSSHReady(ctx, &target, statusSSHReadinessTimeout(target))
 	}
 	return statusView{
 		ID:                           lease.ID,

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -318,6 +318,39 @@ func TestCoordinatorStatusKeepsFourSecondWindowsSSHProbe(t *testing.T) {
 	assertSSHOption(t, args, "ConnectionAttempts", "3")
 }
 
+func TestCoordinatorWSL2StatusAllowsCompleteProbe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX fake ssh helper is only reliable on Unix hosts")
+	}
+	isolateTestUserDirs(t)
+	installSSHArgsRecorder(t)
+	t.Setenv("CRABBOX_FAKE_SSH_DELAY", "2.1")
+	previous := probeWSLSFTPSubsystem
+	probeWSLSFTPSubsystem = func(context.Context, SSHTarget, string, string, io.Writer) error { return nil }
+	t.Cleanup(func() { probeWSLSFTPSubsystem = previous })
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/leases/cbx_0123456789ab" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+			ID: "cbx_0123456789ab", Provider: "aws", State: "active",
+			TargetOS: targetWindows, WindowsMode: windowsModeWSL2,
+			Host: "example.test", SSHUser: "runner", SSHPort: "22",
+		}})
+	}))
+	defer server.Close()
+	cfg := baseConfig()
+	cfg.Provider, cfg.Coordinator, cfg.CoordToken = "aws", server.URL, "user-token"
+	cfg.Network = NetworkPublic
+	backend := &coordinatorLeaseBackend{cfg: cfg, coord: mustNewCoordinatorClient(t, cfg)}
+	view, err := backend.Status(t.Context(), StatusRequest{ID: "cbx_0123456789ab"})
+	if err != nil || !view.Ready {
+		t.Fatalf("ready=%t err=%v; brokered WSL readiness must allow the complete probe", view.Ready, err)
+	}
+}
+
 func TestCoordinatorInspectJSONIncludesOptionalSSHHostKey(t *testing.T) {
 	isolateTestUserDirs(t)
 	sshHostKey := testOpenSSHPublicKey("ssh-ed25519", testBytes(32, 47))

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -183,6 +183,15 @@ func statusTerminalState(state string) bool {
 	}
 }
 
+func statusSSHReadinessTimeout(target SSHTarget) time.Duration {
+	if isWindowsWSL2Target(target) {
+		// WSL startup, SFTP negotiation, and the Linux ready check share this
+		// budget; a healthy managed guest can exceed the ordinary four seconds.
+		return 30 * time.Second
+	}
+	return 4 * time.Second
+}
+
 func statusViewFromLeaseTarget(ctx context.Context, cfg Config, lease LeaseTarget) (statusView, error) {
 	server := lease.Server
 	target := lease.SSH
@@ -199,7 +208,7 @@ func statusViewFromLeaseTarget(ctx context.Context, cfg Config, lease LeaseTarge
 	}
 	target = resolved.Target
 	state := blank(server.Labels["state"], server.Status)
-	ready := hasHost && leaseStatusStateCanBeReady(lease, state) && probeSSHReady(ctx, &target, 4*time.Second)
+	ready := hasHost && leaseStatusStateCanBeReady(lease, state) && probeSSHReady(ctx, &target, statusSSHReadinessTimeout(target))
 	meta := serverTailscaleMetadata(server)
 	var tailscale *TailscaleMetadata
 	if meta.Enabled {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -224,6 +224,43 @@ func TestStatusViewKeepsFourSecondWindowsSSHProbe(t *testing.T) {
 	assertSSHOption(t, args, "ConnectionAttempts", "3")
 }
 
+func TestStatusWSL2ReadinessAllowsCompleteProbe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX fake ssh helper is only reliable on Unix hosts")
+	}
+	installSSHArgsRecorder(t)
+	t.Setenv("CRABBOX_FAKE_SSH_DELAY", "2.1")
+	previous := probeWSLSFTPSubsystem
+	probeWSLSFTPSubsystem = func(context.Context, SSHTarget, string, string, io.Writer) error { return nil }
+	t.Cleanup(func() { probeWSLSFTPSubsystem = previous })
+	cfg := baseConfig()
+	cfg.Network = NetworkPublic
+	target := SSHTarget{Host: "example.test", User: "runner", Port: "22", FallbackPorts: []string{}, TargetOS: targetWindows, WindowsMode: windowsModeWSL2, NetworkKind: NetworkPublic, ReadyCheck: "true"}
+	view, err := statusViewFromLeaseTarget(t.Context(), cfg, LeaseTarget{
+		Server: Server{Status: "active"}, SSH: target,
+	})
+	if err != nil || !view.Ready {
+		t.Fatalf("ready=%t err=%v; two successful WSL invocations may exceed four seconds", view.Ready, err)
+	}
+}
+
+func TestStatusSSHReadinessTimeout(t *testing.T) {
+	for _, test := range []struct {
+		name, target, mode string
+		want               time.Duration
+	}{
+		{"linux", targetLinux, "", 4 * time.Second},
+		{"native Windows", targetWindows, windowsModeNormal, 4 * time.Second},
+		{"WSL2", targetWindows, windowsModeWSL2, 30 * time.Second},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := statusSSHReadinessTimeout(SSHTarget{TargetOS: test.target, WindowsMode: test.mode}); got != test.want {
+				t.Fatalf("timeout=%s, want %s", got, test.want)
+			}
+		})
+	}
+}
+
 func TestStatusWaitRequestsReadyProbe(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))


### PR DESCRIPTION
## Summary

Make managed Windows WSL2 leases usable by fixed-ID orchestrators that warm a lease, poll JSON readiness, and run POSIX commands or stdin scripts.

Managed WSL setup disables redundant cloud-init discovery, restarts the distro, and verifies Linux readiness before publishing its setup marker. Warmup also checks the WSL runtime afterward. Direct and coordinator-backed status paths share a bounded 30-second WSL2 probe budget; Linux and native Windows retain four seconds.

## Root cause

A live AWS m8i.large successfully hosted WSL2. The imported Ubuntu distro's cloud-init WSL datasource blocked systemd and root login: one discovery took 40 seconds, 61 boot jobs waited, and staged owner renewal timed out after all 6,795 command bytes were written. Disabling cloud-init reduced isolated staged execution from 26.5 seconds to 5.6 seconds and made a complete POSIX run succeed with the original CLI.

Separately, a healthy readiness probe needed 9.4 seconds, exceeding the independent four-second budgets in both status paths. Warmup previously accepted the Windows setup marker without subsequently checking the WSL runtime. The OpenSSH post-quantum warning also appeared on successful commands; SSH algorithms and launcher quoting are unchanged.

## Verification

- Passed: `go build -trimpath -o bin/crabbox ./cmd/crabbox` and `go vet ./...`.
- Passed: `go test -race ./internal/cli -run 'Test.*(WSL|WSL2|Windows.*Bootstrap|PowerShell|StatusSSHReadinessTimeout|Status.*FourSecondWindowsSSHProbe)' -count=1` (242.939 seconds).
- Passed: `go test -race -timeout=20m ./...` on the final commit in [Linux CI](https://github.com/openclaw/crabbox/actions/runs/34233623720) (19m20s); the complete workflow succeeded. The unmodified macOS baseline exhausted its aggregate 20-minute package budget during artifact tests.
- Passed: fresh fixed-ID AWS Windows WSL2 tiny warmup; three `inspect --json` reads 20 seconds apart, all ready; `uname -a` and `cat /proc/version`, both exit 0 with WSL2 kernel output; stdin script with distinct stdout/stderr markers; deliberate remote exit 23 returned as 23; post-run `status --json` still ready.
- Passed: Linux tiny warmup, JSON readiness, POSIX run, and stop. All task leases have confirmed cleanup, and the final provider list contains none of their slugs. An interrupted optional test allocation completed the coordinator's absence-confirmation window with no resource found.
- Autoreview: no accepted/actionable findings. Regression tests cover both status paths, runtime checks after the setup marker, distro initialization order, and native Windows behavior.

Config/secret implications: none. No new flags or credentials. Existing managed WSL leases need reprovisioning to receive the bootstrap fix. Intermittent broker heartbeat/event timeouts remain a separate latency concern; the live runs still completed with correct output and exit codes.
