### PR TITLE
perf(coordinator): avoid repeated retired lease work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Describe Anthropic Sandbox Runtime configuration bindings once, preserving inherited binary paths for empty YAML, explicit settings/debug clearing, and native runtime defaults. [PR 1993](https://github.com/openclaw/crabbox/pull/1993). Thanks @steipete.
-- Reduce coordinator maintenance work for large lease histories by remembering completed egress cleanup and limiting pool and provisioning lookups to relevant leases. Thanks @steipete.
+- Reduce coordinator maintenance work for large lease histories by remembering completed egress cleanup and limiting pool and provisioning lookups to relevant leases. [PR 1997](https://github.com/openclaw/crabbox/pull/1997). Thanks @steipete.
 
 ## 0.53.0 - 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Describe Anthropic Sandbox Runtime configuration bindings once, preserving inherited binary paths for empty YAML, explicit settings/debug clearing, and native runtime defaults. [PR 1993](https://github.com/openclaw/crabbox/pull/1993). Thanks @steipete.
+- Reduce coordinator maintenance work for large lease histories by remembering completed egress cleanup and limiting pool and provisioning lookups to relevant leases. Thanks @steipete.
 
 ## 0.53.0 - 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Describe Anthropic Sandbox Runtime configuration bindings once, preserving inherited binary paths for empty YAML, explicit settings/debug clearing, and native runtime defaults. [PR 1993](https://github.com/openclaw/crabbox/pull/1993). Thanks @steipete.
-- Reduce coordinator maintenance work for large lease histories by remembering completed egress cleanup and limiting pool and provisioning lookups to relevant leases. [PR 1997](https://github.com/openclaw/crabbox/pull/1997). Thanks @steipete.
+- Reduce coordinator maintenance work for large lease histories by selecting bridge cleanup from live owners and existing records, and limiting pool and provisioning lookups to relevant leases. [PR 1997](https://github.com/openclaw/crabbox/pull/1997). Thanks @steipete.
 
 ## 0.53.0 - 2026-09-08
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -199,11 +199,11 @@ serialization and live bridge ownership are process-local. PostgreSQL and
 pg-boss are durable, but horizontal replicas need distributed locking and
 bridge routing first.
 
-Maintenance reuses the egress owner's completed cleanup result within the current
-runtime, so ended leases do not repeatedly delete already-cleared bridge state.
-New egress writes invalidate that result before persistence; failed cleanup stays
-retryable. Ready-pool maintenance reads only the leases referenced by its entries,
-and interrupted-provisioning checks read journals only for recovery candidates.
+Maintenance selects bridge cleanup from live bridge owners and existing persisted
+egress records, so ended leases with no bridge state require no repeated deletes,
+including after coordinator restarts. Failed deletes retain their cleanup evidence.
+Ready-pool maintenance reads only the leases referenced by its entries, and
+interrupted-provisioning checks read journals only for recovery candidates.
 
 ## Coordinator HTTP API
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -199,6 +199,12 @@ serialization and live bridge ownership are process-local. PostgreSQL and
 pg-boss are durable, but horizontal replicas need distributed locking and
 bridge routing first.
 
+Maintenance reuses the egress owner's completed cleanup result within the current
+runtime, so ended leases do not repeatedly delete already-cleared bridge state.
+New egress writes invalidate that result before persistence; failed cleanup stays
+retryable. Ready-pool maintenance reads only the leases referenced by its entries,
+and interrupted-provisioning checks read journals only for recovery candidates.
+
 ## Coordinator HTTP API
 
 Lease lifecycle:

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1112,7 +1112,7 @@ export class FleetCoordinator {
   // offline is accepted residual risk. Full closure would require server-bound session identity
   // (protocol change, out of scope).
   private readonly replacedEgressSessions = new Map<string, string[]>();
-  private readonly hydratedEgressSessionState = new Set<string>();
+  private readonly egressSessionState = new Map<string, "loaded" | "cleared">();
   private readonly egressSessionStateHydrations = new Map<string, Promise<void>>();
   private readonly runtimeAdapterAgents = new Map<string, WebSocket>();
   private readonly runtimeAdapterPending = new Map<string, RuntimeAdapterPendingRequest>();
@@ -2590,6 +2590,7 @@ export class FleetCoordinator {
     if (sessionProfile) {
       sessionStatus.profile = sessionProfile;
     }
+    this.egressSessionState.set(leaseID, "loaded");
     await this.state.storage.put(activeEgressSessionKey(leaseID), sessionStatus);
     this.egressSessions.set(leaseID, sessionStatus);
   }
@@ -2607,12 +2608,13 @@ export class FleetCoordinator {
     if (replaced.length > replacedEgressSessionsPerLease) {
       replaced.shift();
     }
+    this.egressSessionState.set(leaseID, "loaded");
     await this.state.storage.put(replacedEgressSessionsKey(leaseID), replaced);
     this.replacedEgressSessions.set(leaseID, replaced);
   }
 
   private async hydrateEgressSessionState(leaseID: string): Promise<void> {
-    if (this.hydratedEgressSessionState.has(leaseID)) {
+    if (this.egressSessionState.has(leaseID)) {
       return;
     }
     const existing = this.egressSessionStateHydrations.get(leaseID);
@@ -2637,7 +2639,7 @@ export class FleetCoordinator {
       } else if (active && !this.egressSessions.has(leaseID)) {
         this.egressSessions.set(leaseID, active);
       }
-      this.hydratedEgressSessionState.add(leaseID);
+      this.egressSessionState.set(leaseID, "loaded");
     })();
     this.egressSessionStateHydrations.set(leaseID, pending);
     try {
@@ -12326,13 +12328,16 @@ export class FleetCoordinator {
         this.egressClients.delete(key);
       }
     }
+    // Retirement sweeps revisit history. Only a completed delete can suppress a repeat;
+    // activation invalidates this fact before writing new state, and failures remain retryable.
+    if (this.egressSessionState.get(leaseID) === "cleared") return;
     this.egressSessions.delete(leaseID);
     await Promise.all([
       this.state.storage.delete(activeEgressSessionKey(leaseID)),
       this.state.storage.delete(replacedEgressSessionsKey(leaseID)),
     ]);
     this.replacedEgressSessions.delete(leaseID);
-    this.hydratedEgressSessionState.add(leaseID);
+    this.egressSessionState.set(leaseID, "cleared");
   }
 
   private async closeLeaseBridges(leaseID: string, code: number, reason: string): Promise<void> {
@@ -13778,10 +13783,12 @@ export class FleetCoordinator {
       this.visitStorageRecords<ReadyPoolEntry>(typedReadyPoolPrefix, async (entry) => {
         typedEntries.push(entry);
       }),
-      this.visitLeaseRecords(async (lease) => {
-        leases.set(lease.id, lease);
-      }),
     ]);
+    for (const leaseID of new Set([...entries, ...typedEntries].map((entry) => entry.leaseID))) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- bound retained-pool hydration to one referenced lease at a time.
+      const lease = await this.getLease(leaseID, { noCache: true });
+      if (lease) leases.set(leaseID, lease);
+    }
     await this.maintainReadyPoolEntries(entries, leases, nowMs);
     await this.maintainReadyPoolEntries(typedEntries, leases, nowMs, true);
     await this.visitStorageRecords<ReadyPoolFillClaim>(readyPoolFillClaimPrefix, async (claim) => {
@@ -16525,13 +16532,15 @@ export class FleetCoordinator {
         if (due.length >= interruptedProvisioningRecoveryBatchSize) {
           return;
         }
-        if (await provisioningOwnsLease(this.state.storage, lease.id)) return;
         const recoveryAt = interruptedProvisioningRecoveryAt(
           lease,
           this.coordinatorGeneration,
           now,
         );
-        if (recoveryAt === undefined) {
+        if (
+          recoveryAt === undefined ||
+          (await provisioningOwnsLease(this.state.storage, lease.id))
+        ) {
           return;
         }
         if (!Number.isFinite(Date.parse(lease.provisioningRecoveryObservedAt ?? ""))) {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -473,6 +473,8 @@ const terminalRunPruneBatchSize = 16;
 const runtimeAdapterDeleteBatchSize = 16;
 const defaultTerminalRunRetentionDays = 30;
 const runPruneCursorKey = "maintenance:run-prune-cursor";
+const activeEgressSessionPrefix = "active-egress-session:";
+const replacedEgressSessionsPrefix = "replaced-egress-sessions:";
 const providerAccessReservationTTLMS = 15 * 60 * 1000;
 const maxPendingWebVNCBytes = 1024 * 1024;
 const maxCodeWebSocketFrameChunkBytes = 15 * 1024;
@@ -1112,7 +1114,7 @@ export class FleetCoordinator {
   // offline is accepted residual risk. Full closure would require server-bound session identity
   // (protocol change, out of scope).
   private readonly replacedEgressSessions = new Map<string, string[]>();
-  private readonly egressSessionState = new Map<string, "loaded" | "cleared">();
+  private readonly hydratedEgressSessionState = new Set<string>();
   private readonly egressSessionStateHydrations = new Map<string, Promise<void>>();
   private readonly runtimeAdapterAgents = new Map<string, WebSocket>();
   private readonly runtimeAdapterPending = new Map<string, RuntimeAdapterPendingRequest>();
@@ -2332,7 +2334,7 @@ export class FleetCoordinator {
     }
   }
 
-  private adminBridgeSockets(): Set<WebSocket> {
+  private bridgeSockets(): Set<WebSocket> {
     const sockets = new Set<WebSocket>([
       ...this.controlSockets.values(),
       ...this.codeAgents.values(),
@@ -2355,7 +2357,7 @@ export class FleetCoordinator {
 
   private async reconcileAdminBridgeSockets(validation: AdminGrantValidation): Promise<void> {
     const revokedEgressSessions = new Map<string, { leaseID: string; sessionID: string }>();
-    for (const socket of this.adminBridgeSockets()) {
+    for (const socket of this.bridgeSockets()) {
       const attachment = this.bridgeAttachment(socket);
       if (
         !attachment ||
@@ -2590,7 +2592,6 @@ export class FleetCoordinator {
     if (sessionProfile) {
       sessionStatus.profile = sessionProfile;
     }
-    this.egressSessionState.set(leaseID, "loaded");
     await this.state.storage.put(activeEgressSessionKey(leaseID), sessionStatus);
     this.egressSessions.set(leaseID, sessionStatus);
   }
@@ -2608,13 +2609,12 @@ export class FleetCoordinator {
     if (replaced.length > replacedEgressSessionsPerLease) {
       replaced.shift();
     }
-    this.egressSessionState.set(leaseID, "loaded");
     await this.state.storage.put(replacedEgressSessionsKey(leaseID), replaced);
     this.replacedEgressSessions.set(leaseID, replaced);
   }
 
   private async hydrateEgressSessionState(leaseID: string): Promise<void> {
-    if (this.egressSessionState.has(leaseID)) {
+    if (this.hydratedEgressSessionState.has(leaseID)) {
       return;
     }
     const existing = this.egressSessionStateHydrations.get(leaseID);
@@ -2639,7 +2639,7 @@ export class FleetCoordinator {
       } else if (active && !this.egressSessions.has(leaseID)) {
         this.egressSessions.set(leaseID, active);
       }
-      this.egressSessionState.set(leaseID, "loaded");
+      this.hydratedEgressSessionState.add(leaseID);
     })();
     this.egressSessionStateHydrations.set(leaseID, pending);
     try {
@@ -12328,16 +12328,13 @@ export class FleetCoordinator {
         this.egressClients.delete(key);
       }
     }
-    // Retirement sweeps revisit history. Only a completed delete can suppress a repeat;
-    // activation invalidates this fact before writing new state, and failures remain retryable.
-    if (this.egressSessionState.get(leaseID) === "cleared") return;
     this.egressSessions.delete(leaseID);
     await Promise.all([
       this.state.storage.delete(activeEgressSessionKey(leaseID)),
       this.state.storage.delete(replacedEgressSessionsKey(leaseID)),
     ]);
     this.replacedEgressSessions.delete(leaseID);
-    this.egressSessionState.set(leaseID, "cleared");
+    this.hydratedEgressSessionState.add(leaseID);
   }
 
   private async closeLeaseBridges(leaseID: string, code: number, reason: string): Promise<void> {
@@ -16812,13 +16809,39 @@ export class FleetCoordinator {
     return Boolean(attempt && sameCreateAttempt(attempt, fence.attempt));
   }
 
+  private async leaseBridgeOwners(): Promise<Set<string>> {
+    const owners = new Set([
+      ...this.egressSessions.keys(),
+      ...this.replacedEgressSessions.keys(),
+      ...[...this.pendingCodeRequests.values()].map((pending) => pending.leaseID),
+      ...[...this.pendingCodeFrames.values()].map((pending) => pending.leaseID),
+    ]);
+    for (const socket of this.bridgeSockets()) {
+      const attachment = this.bridgeAttachment(socket);
+      if (attachment && "leaseID" in attachment) owners.add(attachment.leaseID);
+    }
+    for (const prefix of [activeEgressSessionPrefix, replacedEgressSessionsPrefix]) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- bounded pages find persisted egress owners after a restart.
+      await this.visitStorageRecords<unknown>(prefix, (_value, key) => {
+        owners.add(key.slice(prefix.length));
+      });
+    }
+    return owners;
+  }
+
   private async expireLeases(): Promise<void> {
     const claims = await this.state.runExclusive(async () => {
       const now = Date.now();
       const claimed: Array<{ claim: string; lease: LeaseRecord }> = [];
+      const bridgeOwners = await this.leaseBridgeOwners();
       await this.visitLeaseRecords(async (stored) => {
+        const needsCleanup = leaseNeedsCleanup(stored, now);
+        const closeBridges = !leaseIsLive(stored) && bridgeOwners.has(stored.id);
+        // Most history has neither due provider work nor bridge state. Journal reads and
+        // deletes belong to actual candidates, including persisted egress left by a restart.
+        if (!needsCleanup && !closeBridges) return;
         if (await provisioningOwnsLease(this.state.storage, stored.id)) return;
-        if (!leaseIsLive(stored)) {
+        if (closeBridges) {
           await this.closeLeaseBridges(stored.id, 1008, "lease ended");
         }
         const workspace = stored.workspaceID
@@ -16834,7 +16857,7 @@ export class FleetCoordinator {
         ) {
           return;
         }
-        if (!leaseNeedsCleanup(stored, now)) {
+        if (!needsCleanup) {
           return;
         }
         const lease = structuredClone(stored);
@@ -21138,11 +21161,11 @@ function codeViewerSessionRevocationKey(portalSessionHash: string): string {
 }
 
 function activeEgressSessionKey(leaseID: string): string {
-  return `active-egress-session:${leaseID}`;
+  return `${activeEgressSessionPrefix}${leaseID}`;
 }
 
 function replacedEgressSessionsKey(leaseID: string): string {
-  return `replaced-egress-sessions:${leaseID}`;
+  return `${replacedEgressSessionsPrefix}${leaseID}`;
 }
 
 function runtimeAdapterTicketPrefix(): string {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -34613,56 +34613,119 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
-  it("clears replaced egress session tombstones on lease release", async () => {
-    const storage = new MemoryStorage();
-    const fleet = testWebSocketCoordinator(storage);
-    const leaseID = "cbx_000000000001";
-    const headers = {
-      "x-crabbox-owner": "alice@example.com",
-      "x-crabbox-org": "example-org",
-    };
-    storage.seed(
-      `lease:${leaseID}`,
-      testLease({
-        id: leaseID,
-        slug: "released-egress",
-        provider: "external",
-        lifecycle: "registered",
-        owner: "alice@example.com",
-        org: "example-org",
-        keep: true,
-        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-      }),
-    );
-    const createTicket = (sessionID: string) =>
-      fleet.fetch(
-        request("POST", "/v1/leases/released-egress/egress/ticket", {
-          headers,
-          body: { role: "host", sessionID, allow: ["example.com"] },
+  it.each(["none", "active-egress-session", "replaced-egress-sessions", "reactivation"])(
+    "keeps egress cleanup bounded across retirement and %s storage failure",
+    async (failure) => {
+      const storage = new MemoryStorage();
+      const fleet = testWebSocketCoordinator(storage);
+      const leaseID = "cbx_000000000001";
+      const headers = {
+        "x-crabbox-owner": "alice@example.com",
+        "x-crabbox-org": "example-org",
+      };
+      storage.seed(
+        `lease:${leaseID}`,
+        testLease({
+          id: leaseID,
+          slug: "released-egress",
+          provider: "external",
+          lifecycle: "registered",
+          owner: "alice@example.com",
+          org: "example-org",
+          keep: true,
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
         }),
       );
-    expect((await createTicket("egress_release_a")).status).toBe(200);
-    expect((await createTicket("egress_release_b")).status).toBe(200);
-    const relay = fleet as unknown as { replacedEgressSessions: Map<string, string[]> };
-    expect(relay.replacedEgressSessions.get(leaseID)).toEqual(["egress_release_a"]);
-    expect(storage.value(`replaced-egress-sessions:${leaseID}`)).toEqual(["egress_release_a"]);
-    expect(storage.value(`active-egress-session:${leaseID}`)).toMatchObject({
-      leaseID,
-      sessionID: "egress_release_b",
-    });
+      const createTicket = (sessionID: string) =>
+        fleet.fetch(
+          request("POST", "/v1/leases/released-egress/egress/ticket", {
+            headers,
+            body: { role: "host", sessionID, allow: ["example.com"] },
+          }),
+        );
+      expect((await createTicket("egress_release_a")).status).toBe(200);
+      expect((await createTicket("egress_release_b")).status).toBe(200);
+      expect(storage.value(`replaced-egress-sessions:${leaseID}`)).toEqual(["egress_release_a"]);
+      expect(storage.value(`active-egress-session:${leaseID}`)).toMatchObject({
+        leaseID,
+        sessionID: "egress_release_b",
+      });
 
-    const released = await fleet.fetch(
-      request("POST", "/v1/leases/released-egress/release", {
-        headers,
-        body: { delete: false },
-      }),
-    );
-    expect(released.status).toBe(200);
-    await expect(released.json()).resolves.toMatchObject({ lease: { state: "released" } });
-    expect(relay.replacedEgressSessions.has(leaseID)).toBe(false);
-    expect(storage.value(`active-egress-session:${leaseID}`)).toBeUndefined();
-    expect(storage.value(`replaced-egress-sessions:${leaseID}`)).toBeUndefined();
-  });
+      const deletes: string[] = [];
+      const failsDelete =
+        failure === "active-egress-session" || failure === "replaced-egress-sessions";
+      let failOnce = failsDelete;
+      storage.beforeDelete = async (key) => {
+        if (!key.endsWith(leaseID) || !key.includes("egress-session")) return;
+        deletes.push(key);
+        if (failOnce && key === `${failure}:${leaseID}`) {
+          failOnce = false;
+          throw new Error("synthetic egress delete failure");
+        }
+      };
+      const release = () =>
+        fleet.fetch(
+          request("POST", "/v1/leases/released-egress/release", {
+            headers,
+            body: { delete: false },
+          }),
+        );
+      const released = await release();
+      expect(released.status).toBe(failsDelete ? 500 : 200);
+      await fleet.alarm();
+      expect(storage.value(`active-egress-session:${leaseID}`)).toBeUndefined();
+      expect(storage.value(`replaced-egress-sessions:${leaseID}`)).toBeUndefined();
+      const completedDeletes = deletes.length;
+      expect(completedDeletes).toBeGreaterThanOrEqual(2);
+      await fleet.alarm();
+      await fleet.alarm();
+      expect(deletes).toHaveLength(completedDeletes);
+
+      const refreshed = await fleet.fetch(
+        request("PUT", `/v1/leases/${leaseID}/registration`, {
+          headers,
+          body: {
+            provider: "external",
+            target: "linux",
+            host: "127.0.0.1",
+            slug: "released-egress",
+          },
+        }),
+      );
+      expect(refreshed.status).toBe(200);
+      const failsActivation = failure === "reactivation";
+      if (failsActivation) {
+        storage.beforePut = async (key, value) => {
+          if (key !== `active-egress-session:${leaseID}`) return;
+          storage.seed(key, value);
+          throw new Error("synthetic lost write acknowledgement");
+        };
+      }
+      const reactivatedSessions = failsActivation
+        ? ["egress_reactivated_a"]
+        : ["egress_reactivated_a", "egress_reactivated_b"];
+      const responses: number[] = [];
+      for (const sessionID of reactivatedSessions) {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- replacement follows the preceding activation.
+        responses.push((await createTicket(sessionID)).status);
+      }
+      storage.beforePut = undefined;
+      expect(responses).toEqual(failsActivation ? [500] : [200, 200]);
+      expect(storage.value(`active-egress-session:${leaseID}`)).toMatchObject({
+        sessionID: reactivatedSessions.at(-1),
+      });
+      expect(storage.value(`replaced-egress-sessions:${leaseID}`)).toEqual(
+        failsActivation ? undefined : ["egress_reactivated_a"],
+      );
+      expect((await release()).status).toBe(200);
+      expect(storage.value(`active-egress-session:${leaseID}`)).toBeUndefined();
+      expect(storage.value(`replaced-egress-sessions:${leaseID}`)).toBeUndefined();
+      expect(deletes.length).toBeGreaterThan(completedDeletes);
+      const reactivatedDeletes = deletes.length;
+      await fleet.alarm();
+      expect(deletes).toHaveLength(reactivatedDeletes);
+    },
+  );
 
   it("keeps replaced egress session tombstones on bridge authorization revocation", async () => {
     const storage = new MemoryStorage();

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -34617,7 +34617,7 @@ describe("fleet lease identity and idle", () => {
     "keeps egress cleanup bounded across retirement and %s storage failure",
     async (failure) => {
       const storage = new MemoryStorage();
-      const fleet = testWebSocketCoordinator(storage);
+      let fleet = testWebSocketCoordinator(storage);
       const leaseID = "cbx_000000000001";
       const headers = {
         "x-crabbox-owner": "alice@example.com",
@@ -34672,6 +34672,7 @@ describe("fleet lease identity and idle", () => {
         );
       const released = await release();
       expect(released.status).toBe(failsDelete ? 500 : 200);
+      fleet = testWebSocketCoordinator(storage);
       await fleet.alarm();
       expect(storage.value(`active-egress-session:${leaseID}`)).toBeUndefined();
       expect(storage.value(`replaced-egress-sessions:${leaseID}`)).toBeUndefined();
@@ -34722,6 +34723,9 @@ describe("fleet lease identity and idle", () => {
       expect(storage.value(`replaced-egress-sessions:${leaseID}`)).toBeUndefined();
       expect(deletes.length).toBeGreaterThan(completedDeletes);
       const reactivatedDeletes = deletes.length;
+      await fleet.alarm();
+      expect(deletes).toHaveLength(reactivatedDeletes);
+      fleet = testWebSocketCoordinator(storage);
       await fleet.alarm();
       expect(deletes).toHaveLength(reactivatedDeletes);
     },


### PR DESCRIPTION
Large histories of ended leases made coordinator maintenance repeatedly read provisioning journals and delete empty egress state for every historical lease. Ready-pool maintenance also hydrated unrelated lease history. This work competed with ordinary cloud-session startup and run publication.

Maintenance now selects bridge cleanup from live socket owners, pending code work, and the existing persisted egress records. Ended leases without bridge state or due provider cleanup require no journal lookup or delete, including immediately after a coordinator restart. Cleanup retains the existing journal ownership check and lifecycle fence. Ready pools hydrate only referenced leases; interrupted-provisioning reconciliation consults journals only after identifying a recovery candidate.

No new cache, index, database schema, version, configuration, or persisted representation. Production code grows by 32 lines for the owner-selection method and its paged reads of existing records. The shared socket inventory and canonical key prefixes are reused.

Validation:
- Reproduced redundant egress deletes on the original code and on a fresh coordinator instance.
- Public-route regressions cover successful retirement, failures of either persisted delete, reconstruction, registered-lease reactivation, and a committed activation with a lost acknowledgement.
- Full Worker suite: 2,943 passed, 3 skipped. Worker and Node typechecks, lint, both builds, and docs generation passed.
- Local workerd/SQLite profiling with 50,000 synthetic retired leases: original sweeps 1,313/1,287/1,628 ms; candidate 388/389/380 ms. These are local measurements, not production latency claims.

Exact-head [CI passed](https://github.com/openclaw/crabbox/actions/runs/34240726148) on `d177a8b25703e885a3004dc36df1834dae96a340`, including Go race tests. Candidate live validation used the ordinary CLI against AWS: fresh startup, exits 0/0/7/0, all four signed receipts verified, and normal Stop confirmed released/complete for the disposable lease. One best-effort event-publication warning remained; remaining archive-scan latency is a follow-up, not claimed resolved here. Diagnostic-only deployments used during investigation are separate from this diff; the PR contains no diagnostic instrumentation.
