### PR TITLE
chore: authorize v0.53.0 release source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## 0.53.0 - 2026-09-08
 
 ### Highlights

--- a/release/records/v0.53.0.json
+++ b/release/records/v0.53.0.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.53.0",
+  "tagObject": "c54592542d26a0e7aa3fc1e6ff8a9c68b651b7ac",
+  "sourceCommit": "f8da7cd6124bdd9e08d329834f4cd63bdd7cab3d",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
Bind v0.53.0 to its immutable signed tag object and tested source commit, and reopen Unreleased without changing the frozen release notes.

Full CI passed on the exact source: https://github.com/openclaw/crabbox/actions/runs/34232612258. GitHub verified the tag signature, the repository source verifier passed, and Codex autoreview found no actionable blockers. The fresh coordinator run, attach/events/logs, and cleanup passed; the earlier interrupted allocation also completed its required absence-confirmation cleanup.
