### PR TITLE
perf: avoid repeated and obsolete lease work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Describe Anthropic Sandbox Runtime configuration bindings once, preserving inherited binary paths for empty YAML, explicit settings/debug clearing, and native runtime defaults. [PR 1993](https://github.com/openclaw/crabbox/pull/1993). Thanks @steipete.
 - Linux developer images: bake verified Node 24.19.0 and reusable public pnpm 11.22.0/12.3.4 archives, verify an exact native NodeSource package before retiring owned aliases on explicit Node 24-to-22 rebakes, preserve operator-owned tool paths and public Yarn aliases, and enforce the selected Node major and nonroot offline checks before image-smoke success. [PR 1944](https://github.com/openclaw/crabbox/pull/1944). Thanks @vincentkoc.
-- Prepare pending lease identities once per maintenance pass and reject commands on confirmed-deleted coordinator leases before SSH setup, avoiding repeated history scans and long recovery waits. Thanks @steipete.
+- Prepare pending lease identities once per maintenance pass and reject commands on confirmed-deleted coordinator leases before SSH setup, avoiding repeated history scans and long recovery waits. [PR 2001](https://github.com/openclaw/crabbox/pull/2001). Thanks @steipete.
 - Reduce coordinator maintenance work for large lease histories by selecting bridge cleanup from live owners and existing records, and limiting pool and provisioning lookups to relevant leases. [PR 1997](https://github.com/openclaw/crabbox/pull/1997). Thanks @steipete.
 - Retry an exact coordinator lease read once on HTTP 5xx during run preparation, sharing the original deadline without replaying SSH, scripts, or permanent failures. [PR 1999](https://github.com/openclaw/crabbox/pull/1999).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Describe Anthropic Sandbox Runtime configuration bindings once, preserving inherited binary paths for empty YAML, explicit settings/debug clearing, and native runtime defaults. [PR 1993](https://github.com/openclaw/crabbox/pull/1993). Thanks @steipete.
 - Linux developer images: bake verified Node 24.19.0 and reusable public pnpm 11.22.0/12.3.4 archives, verify an exact native NodeSource package before retiring owned aliases on explicit Node 24-to-22 rebakes, preserve operator-owned tool paths and public Yarn aliases, and enforce the selected Node major and nonroot offline checks before image-smoke success. [PR 1944](https://github.com/openclaw/crabbox/pull/1944). Thanks @vincentkoc.
+- Prepare pending lease identities once per maintenance pass and reject commands on confirmed-deleted coordinator leases before SSH setup, avoiding repeated history scans and long recovery waits. Thanks @steipete.
 - Reduce coordinator maintenance work for large lease histories by selecting bridge cleanup from live owners and existing records, and limiting pool and provisioning lookups to relevant leases. [PR 1997](https://github.com/openclaw/crabbox/pull/1997). Thanks @steipete.
 - Retry an exact coordinator lease read once on HTTP 5xx during run preparation, sharing the original deadline without replaying SSH, scripts, or permanent failures. [PR 1999](https://github.com/openclaw/crabbox/pull/1999).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -204,6 +204,9 @@ egress records, so ended leases with no bridge state require no repeated deletes
 including after coordinator restarts. Failed deletes retain their cleanup evidence.
 Ready-pool maintenance reads only the leases referenced by its entries, and
 interrupted-provisioning checks read journals only for recovery candidates.
+Each maintenance pass collects candidate lease IDs once, then rereads their
+current records at the owning phase. Final alarm selection still scans current
+state so work admitted during provider I/O keeps its wakeup.
 
 ## Coordinator HTTP API
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -114,6 +114,10 @@ failures are not retried. This repeats only the observation before SSH and scrip
 admission; it never reruns a script. Plain status and Stop retain their existing
 observation behavior.
 
+If the coordinator has confirmed a lease's provider cleanup, `run --id` fails
+immediately instead of waiting for SSH on the deleted machine. `status` and
+`stop` remain available to inspect the outcome and finish local cleanup.
+
 For an ordinary reused coordinator lease, `--ssh-port <port>` pins one of the
 lease's advertised primary or fallback SSH ports before workspace ownership or
 command delivery. An unadvertised port is rejected; the lease's host, user,

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -873,7 +873,14 @@ func (b *coordinatorLeaseBackend) Resolve(ctx context.Context, req ResolveReques
 			return LeaseTarget{}, exit(4, "coordinator returned lease %s for requested lease %s", blank(lease.ID, "<empty>"), req.ID)
 		}
 	}
-	return b.coordinatorLeaseTargetForConfig(lease, cfg, coord)
+	target, err := b.coordinatorLeaseTargetForConfig(lease, cfg, coord)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if req.Prepare && !req.ReleaseOnly && target.providerRelease != nil {
+		return LeaseTarget{}, exit(2, "lease %s is released; start a new lease before running commands", target.LeaseID)
+	}
+	return target, nil
 }
 
 func (b *coordinatorLeaseBackend) Status(ctx context.Context, req StatusRequest) (statusView, error) {

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -2600,6 +2600,44 @@ func TestCoordinatorResolveDropsHistoricalProvisioningTiming(t *testing.T) {
 	}
 }
 
+func TestCoordinatorResolveRejectsConfirmedReleasedExecution(t *testing.T) {
+	for _, admin := range []bool{false, true} {
+		t.Run(fmt.Sprintf("admin-fallback=%t", admin), func(t *testing.T) {
+			isolateTestUserDirs(t)
+			const leaseID = "cbx_0123456789ab"
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || r.URL.Path != "/v1/leases/"+leaseID {
+					http.NotFound(w, r)
+					return
+				}
+				if admin && r.Header.Get("Authorization") != "Bearer admin-token" {
+					http.NotFound(w, r)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+					ID: leaseID, Provider: "aws", TargetOS: targetLinux,
+					State: "released", CleanupStatus: "complete",
+					CleanupCompletedAt: time.Now().UTC().Format(time.RFC3339),
+				}})
+			}))
+			defer server.Close()
+			adminToken := ""
+			if admin {
+				adminToken = "admin-token"
+			}
+			backend := newCoordinatorIdentityTestBackend(t, server.URL, adminToken)
+			_, err := backend.Resolve(t.Context(), ResolveRequest{ID: leaseID, Prepare: true})
+			if err == nil || !strings.Contains(err.Error(), leaseID) || !strings.Contains(err.Error(), "released") {
+				t.Fatalf("released execution should fail before SSH preparation: %v", err)
+			}
+			resolved, err := backend.Resolve(t.Context(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+			if err != nil || resolved.LeaseID != leaseID || resolved.Server.Status != "released" {
+				t.Fatalf("released metadata must remain available for cleanup: lease=%#v err=%v", resolved, err)
+			}
+		})
+	}
+}
+
 func TestCoordinatorProviderIdentityValidationCanonicalizesAliases(t *testing.T) {
 	backend := &coordinatorLeaseBackend{
 		spec: ProviderSpec{Name: "gcp"},

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -2630,9 +2630,15 @@ func TestCoordinatorResolveRejectsConfirmedReleasedExecution(t *testing.T) {
 			if err == nil || !strings.Contains(err.Error(), leaseID) || !strings.Contains(err.Error(), "released") {
 				t.Fatalf("released execution should fail before SSH preparation: %v", err)
 			}
-			resolved, err := backend.Resolve(t.Context(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
-			if err != nil || resolved.LeaseID != leaseID || resolved.Server.Status != "released" {
-				t.Fatalf("released metadata must remain available for cleanup: lease=%#v err=%v", resolved, err)
+			for _, req := range []ResolveRequest{
+				{ID: leaseID},
+				{ID: leaseID, ReleaseOnly: true},
+				{ID: leaseID, ReleaseOnly: true, Prepare: true},
+			} {
+				resolved, err := backend.Resolve(t.Context(), req)
+				if err != nil || resolved.LeaseID != leaseID || resolved.Server.Status != "released" {
+					t.Fatalf("released metadata must remain available for inspection and cleanup: lease=%#v err=%v", resolved, err)
+				}
 			}
 		})
 	}

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -3174,11 +3174,28 @@ export class FleetCoordinator {
     }
     await this.reconcileScheduledAdminGrants(forwardedAdminGrantVersion, preserveForwardedVersion);
     await this.quarantineLegacyWorkspaces();
-    await this.reconcileInterruptedLeaseProvisioning();
-    await this.expireLeases();
+    // Retain only candidate IDs while provider I/O yields. Each phase reads them anew;
+    // final scheduling still discovers work admitted during the pass.
+    const leaseIDs = await this.state.runExclusive(async () => {
+      const candidates = await this.leaseBridgeOwners();
+      const now = Date.now();
+      await this.visitLeaseRecords((lease) => {
+        if (
+          leaseIsLive(lease) ||
+          leaseNeedsCleanup(lease, now) ||
+          leaseMayNeedInterruptedProvisioningRecovery(lease) ||
+          lease.runtimeAdapterDeleteRequestedAt
+        ) {
+          candidates.add(lease.id);
+        }
+      });
+      return candidates;
+    });
+    await this.reconcileInterruptedLeaseProvisioning(leaseIDs);
+    await this.expireLeases(leaseIDs);
     await this.webVNCCredentialHandoffs.cleanupExpired();
     await this.cleanupExpiredWebVNCPortalViewerAuth();
-    await this.reconcileRuntimeAdapterDeletes();
+    await this.reconcileRuntimeAdapterDeletes(leaseIDs);
     await this.withReadyPoolBorrowLock(() =>
       this.state.runExclusive(() => this.maintainReadyPools(Date.now())),
     );
@@ -10113,7 +10130,7 @@ export class FleetCoordinator {
     });
   }
 
-  private async reconcileRuntimeAdapterDeletes(): Promise<void> {
+  private async reconcileRuntimeAdapterDeletes(leaseIDs: ReadonlySet<string>): Promise<void> {
     const pending = await this.state.runExclusive(async () => {
       const now = Date.now();
       const due: LeaseRecord[] = [];
@@ -10135,7 +10152,7 @@ export class FleetCoordinator {
           }
         }
         return true;
-      });
+      }, leaseIDs);
       return due;
     });
     await Promise.all(pending.map((lease) => this.reconcileRuntimeAdapterDelete(lease)));
@@ -16521,7 +16538,9 @@ export class FleetCoordinator {
     return json({ error: "not_found" }, { status: 404 });
   }
 
-  private async reconcileInterruptedLeaseProvisioning(): Promise<void> {
+  private async reconcileInterruptedLeaseProvisioning(
+    leaseIDs: ReadonlySet<string>,
+  ): Promise<void> {
     const now = Date.now();
     const candidates = await this.state.runExclusive(async () => {
       const due: LeaseRecord[] = [];
@@ -16555,7 +16574,7 @@ export class FleetCoordinator {
         if (recoveryAt <= now) {
           due.push(structuredClone(lease));
         }
-      });
+      }, leaseIDs);
       return due;
     });
     await Promise.all(candidates.map((lease) => this.reconcileInterruptedLease(lease)));
@@ -16829,7 +16848,7 @@ export class FleetCoordinator {
     return owners;
   }
 
-  private async expireLeases(): Promise<void> {
+  private async expireLeases(leaseIDs: ReadonlySet<string>): Promise<void> {
     const claims = await this.state.runExclusive(async () => {
       const now = Date.now();
       const claimed: Array<{ claim: string; lease: LeaseRecord }> = [];
@@ -16916,7 +16935,7 @@ export class FleetCoordinator {
         lease.updatedAt = nowISO;
         await this.putLease(lease, { noCache: true });
         claimed.push({ claim: nowISO, lease });
-      });
+      }, leaseIDs);
       return claimed;
     });
     await Promise.all(
@@ -18109,8 +18128,15 @@ export class FleetCoordinator {
 
   private async visitLeaseRecords(
     visitor: (lease: LeaseRecord) => Promise<boolean | void> | boolean | void,
+    leaseIDs?: ReadonlySet<string>,
   ): Promise<void> {
-    await this.visitStorageRecords("lease:", visitor);
+    if (leaseIDs === undefined) return this.visitStorageRecords("lease:", visitor);
+    for (const id of [...leaseIDs].toSorted()) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- hydrate one current candidate at a time in storage-key order.
+      const lease = await this.getLease(id, { noCache: true });
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each owner completes before advancing to the next candidate.
+      if (lease && (await visitor(lease)) === false) return;
+    }
   }
 
   private async observeStoredProviderReconciliationCandidate(input: {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -16849,6 +16849,57 @@ describe("fleet lease identity and idle", () => {
         ),
       ).toBe(true);
     }
+    storage.resetListOptions();
+    await fleet.alarm();
+    const steadyLeaseScans = storage.listOptions.filter(
+      ({ prefix, startAfter }) => prefix === "lease:" && startAfter === undefined,
+    );
+    // Preparation and final scheduling may scan history; individual maintenance phases must not.
+    expect(steadyLeaseScans.length).toBeLessThanOrEqual(2);
+    expect(reconciliations).toEqual([[anchor.id]]);
+  });
+
+  it("schedules leases admitted while prepared maintenance waits for provider cleanup", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    const storage = new MemoryStorage();
+    const entered = deferred<void>();
+    const resume = deferred<void>();
+    const oldLease = testLease({ expiresAt: new Date(Date.now() - 1000).toISOString() });
+    storage.seed(`lease:${oldLease.id}`, oldLease);
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(undefined, {}, async () => {
+        entered.resolve();
+        await resume.promise;
+      }),
+    });
+    const maintenance = fleet.alarm();
+    try {
+      await Promise.race([
+        entered.promise,
+        maintenance.then(() => {
+          throw new Error("provider cleanup did not start");
+        }),
+      ]);
+      const id = "cbx_aaaaaaaaaaaa";
+      const registered = await fleet.fetch(
+        request("PUT", `/v1/leases/${id}/registration`, {
+          headers: { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" },
+          body: { provider: "external", target: "linux", host: "198.51.100.20", ttlSeconds: 60 },
+        }),
+      );
+      expect(registered.status).toBe(201);
+      const lease = storage.value<LeaseRecord>(`lease:${id}`)!;
+      vi.setSystemTime(Date.parse(lease.expiresAt) + 1);
+      resume.resolve();
+      await maintenance;
+      expect(storage.alarm()).toBeLessThanOrEqual(Date.now());
+      await fleet.alarm();
+      expect(storage.value<LeaseRecord>(`lease:${id}`)?.state).toBe("expired");
+    } finally {
+      resume.resolve();
+      await Promise.allSettled([maintenance]);
+      vi.useRealTimers();
+    }
   });
 
   it("registers, borrows, and returns ready-pool leases", async () => {


### PR DESCRIPTION
Coordinator maintenance still rescanned ended lease history before multiple phases, and command preparation accepted a lease whose provider deletion had already been confirmed. The latter sent recovery scripts into an SSH timeout with no live endpoint.

Maintenance now prepares candidate lease IDs once per pass. Each phase rereads the current records under its existing owner fence; the final alarm calculation still scans current state so admissions during provider I/O retain their wakeups. Permission and access reconciliation retain their complete current-state reads. The CLI now rejects execution preparation for a confirmed-deleted lease while keeping read and release operations available, including through the existing admin fallback.

No schema, stored representation, new cache/index, configuration option, timeout, or retry changes. Production grows by 33 lines for prepared selection and execution admission; tests add 95 lines.

Validation:
- Red regressions: steady maintenance started four history scans instead of at most two; normal and admin-fallback resolution accepted a confirmed-deleted execution target.
- Full Worker suite: 2,944 passed, 3 skipped. Includes a new lease admitted during blocked provider cleanup and processed by the retained next wakeup.
- Go race coverage passed for coordinator resolution, provider identity, existing-lease execution, Pond Mesh, and Stop; vet, Worker/Node types, lint, both builds, and docs generation passed.
- Local workerd/SQLite benchmark, 50,000 synthetic ended leases: 388/389/380 ms before this follow-up, 166/166/175 ms afterward.
- A diagnostic binary rejected the actual already-cleaned test lease in 4.2 seconds, including coordinator lookup, with no SSH wait; the prior recovery had exhausted the two-minute SSH probe.
- Final rebased CLI: the same confirmed-deleted execution rejection completed in 3.43 seconds. Sixteen ordinary exact-ID inspections at concurrency four all passed (median 1.26 seconds, slowest 1.93 seconds).

Live repository cloud-session validation passed against candidate `2b2bed5f545cf535854d595326a8b6fe1b3b9b18`: both worker-turn and remote-exec runtimes completed actual model/tool turns, remote file readback, Stop, Gateway restart, workspace restore, and a second turn. All four environments were destroyed through ordinary cleanup; Gateway/tunnel/tail processes exited and joined. Neither session creation nor restore materialized a local Git checkout. The serving Worker stayed unchanged throughout the run.

The earlier attempt failed during native checkpoint creation (HTTP 500/1101). Its retained checkpoint and source lease were cleaned through the canonical CLI, then the original accepted file was recovered and reused in the successful run. This failure is retained as recovery evidence, not counted as a passing run.

After rebasing, the CLI preserves the exact-ID HTTP 5xx read recovery from PR 1999 and the original shared deadline. Preparation still rejects confirmed deletion; plain reads and ReleaseOnly requests (including Prepare plus ReleaseOnly) remain valid. Focused Go race coverage passed after this merge. The Worker runtime is unchanged from the live-tested candidate. All 25 checks passed on final head `15b62e78c19f750241b07e0970a0fbe0514ceaba`, including the full Go race suite. Merged as `128b2e5510110a93ffb284775d2026234615f68e`; the normal coordinator deployment passed.

Full provisioning is not instantaneous: observed dispatches were 132–170 seconds, and model turns were 17–60 seconds. These are end-to-end timings, distinct from the synthetic maintenance benchmark.
