### PR TITLE
refactor(test): share run-recorder admission harness

### DIFF
--- a/internal/cli/run_recorder_test.go
+++ b/internal/cli/run_recorder_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -685,46 +686,113 @@ func TestRunRecorderHistoryAvailabilityRequiresRecordedRunID(t *testing.T) {
 	}
 }
 
-func TestRunRecorderDefersCreateForExplicitLeaseRuns(t *testing.T) {
-	var stderr bytes.Buffer
-	var createBodies []map[string]any
-	var eventBody map[string]any
+type runRecorderTestResponse struct {
+	status int
+	body   string
+}
+
+type runRecorderCreateResponder func(call int) runRecorderTestResponse
+
+type runRecorderCreateHarness struct {
+	client *CoordinatorClient
+	config Config
+	stderr bytes.Buffer
+
+	mu           sync.Mutex
+	createBodies []map[string]any
+	eventBody    map[string]any
+}
+
+func newRunRecorderCreateHarness(t *testing.T, eventResponse *runRecorderTestResponse, responder runRecorderCreateResponder) *runRecorderCreateHarness {
+	t.Helper()
+	harness := &runRecorderCreateHarness{config: Config{Provider: "aws", Class: "standard", ServerType: "t3.small"}}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var response runRecorderTestResponse
 		switch {
 		case r.Method == http.MethodPut && r.URL.Path == "/v1/runs/"+admissionTestRunID:
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				http.Error(w, "invalid request", http.StatusBadRequest)
+				return
 			}
-			createBodies = append(createBodies, body)
-			_, _ = w.Write([]byte(`{"run":{"id":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","leaseID":"cbx_abcdef123456","owner":"bob@example.com","org":"elsewhere","provider":"aws","class":"standard","serverType":"t3.small","command":["pnpm","test"],"state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`))
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events":
-			if err := json.NewDecoder(r.Body).Decode(&eventBody); err != nil {
-				t.Fatal(err)
+			harness.mu.Lock()
+			harness.createBodies = append(harness.createBodies, body)
+			call := len(harness.createBodies)
+			harness.mu.Unlock()
+			response = responder(call)
+		case eventResponse != nil && r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Error(err)
+				http.Error(w, "invalid request", http.StatusBadRequest)
+				return
 			}
-			_, _ = w.Write([]byte(`{"event":{"runID":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","seq":1,"type":"lease.created","leaseID":"cbx_abcdef123456","createdAt":"2026-05-02T00:00:01Z"}}`))
+			harness.mu.Lock()
+			harness.eventBody = body
+			harness.mu.Unlock()
+			response = *eventResponse
 		default:
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusNotFound)
+			return
 		}
+		if response.status != http.StatusOK {
+			http.Error(w, response.body, response.status)
+			return
+		}
+		_, _ = w.Write([]byte(response.body))
 	}))
-	defer server.Close()
+	t.Cleanup(server.Close)
+	harness.client = &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	return harness
+}
 
-	client := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
-	rec := newRunRecorder(context.Background(), client, Config{
-		Provider:   "aws",
-		Class:      "standard",
-		ServerType: "t3.small",
-	}, []string{"pnpm", "test"}, "", &stderr, true, admissionTestRunID)
+func (h *runRecorderCreateHarness) snapshot(t *testing.T) ([]map[string]any, map[string]any) {
+	t.Helper()
+	h.mu.Lock()
+	createBodies := append([]map[string]any(nil), h.createBodies...)
+	eventBody := h.eventBody
+	h.mu.Unlock()
+	for i, body := range createBodies {
+		createBodies[i] = cloneRunRecorderRequestBody(t, body)
+	}
+	return createBodies, cloneRunRecorderRequestBody(t, eventBody)
+}
+
+func cloneRunRecorderRequestBody(t *testing.T, body map[string]any) map[string]any {
+	t.Helper()
+	if body == nil {
+		return nil
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var clone map[string]any
+	if err := json.Unmarshal(data, &clone); err != nil {
+		t.Fatal(err)
+	}
+	return clone
+}
+
+func TestRunRecorderDefersCreateForExplicitLeaseRuns(t *testing.T) {
+	harness := newRunRecorderCreateHarness(
+		t,
+		&runRecorderTestResponse{status: http.StatusOK, body: `{"event":{"runID":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","seq":1,"type":"lease.created","leaseID":"cbx_abcdef123456","createdAt":"2026-05-02T00:00:01Z"}}`},
+		func(_ int) runRecorderTestResponse {
+			return runRecorderTestResponse{status: http.StatusOK, body: `{"run":{"id":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","leaseID":"cbx_abcdef123456","owner":"bob@example.com","org":"elsewhere","provider":"aws","class":"standard","serverType":"t3.small","command":["pnpm","test"],"state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`}
+		},
+	)
+	rec := newRunRecorder(context.Background(), harness.client, harness.config, []string{"pnpm", "test"}, "", &harness.stderr, true, admissionTestRunID)
 	rec.Event("leasing.started", "leasing", "")
+	createBodies, _ := harness.snapshot(t)
 	if len(createBodies) != 0 {
 		t.Fatalf("create requests before lease=%d want 0", len(createBodies))
 	}
 
-	rec.AttachLease(t.Context(), "cbx_abcdef123456", "blue-lobster", Config{
-		Provider:   "aws",
-		Class:      "standard",
-		ServerType: "t3.small",
-	})
+	rec.AttachLease(t.Context(), "cbx_abcdef123456", "blue-lobster", harness.config)
+	createBodies, _ = harness.snapshot(t)
 
 	if len(createBodies) != 1 {
 		t.Fatalf("create requests=%d want 1", len(createBodies))
@@ -733,54 +801,30 @@ func TestRunRecorderDefersCreateForExplicitLeaseRuns(t *testing.T) {
 		t.Fatalf("create leaseID=%#v", got)
 	}
 	rec.waitForEvents(time.Second)
+	_, eventBody := harness.snapshot(t)
 	if got := eventBody["type"]; got != "lease.created" {
 		t.Fatalf("event body=%#v", eventBody)
 	}
-	if text := stderr.String(); strings.Contains(text, "warning:") || !strings.Contains(text, "recording run run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
+	if text := harness.stderr.String(); strings.Contains(text, "warning:") || !strings.Contains(text, "recording run run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
 		t.Fatalf("stderr=%q", text)
 	}
 }
 
 func TestRunRecorderRecoversTransientCreateBeforeLease(t *testing.T) {
-	var stderr bytes.Buffer
-	var createBodies []map[string]any
-	var eventBody map[string]any
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPut && r.URL.Path == "/v1/runs/"+admissionTestRunID:
-			var body map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatal(err)
+	harness := newRunRecorderCreateHarness(
+		t,
+		&runRecorderTestResponse{status: http.StatusOK, body: `{"event":{"runID":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","seq":1,"type":"lease.created","createdAt":"2026-05-02T00:00:01Z"}}`},
+		func(call int) runRecorderTestResponse {
+			if call == 1 {
+				return runRecorderTestResponse{status: http.StatusInternalServerError, body: `{"error":"temporary_unavailable"}`}
 			}
-			createBodies = append(createBodies, body)
-			if len(createBodies) == 1 {
-				http.Error(w, `{"error":"temporary_unavailable"}`, http.StatusInternalServerError)
-				return
-			}
-			_, _ = w.Write([]byte(`{"run":{"id":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","leaseID":"cbx_abcdef123456","owner":"alice@example.com","org":"example-org","provider":"aws","class":"standard","serverType":"t3.small","command":["go","test"],"state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`))
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events":
-			if err := json.NewDecoder(r.Body).Decode(&eventBody); err != nil {
-				t.Fatal(err)
-			}
-			_, _ = w.Write([]byte(`{"event":{"runID":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","seq":1,"type":"lease.created","createdAt":"2026-05-02T00:00:01Z"}}`))
-		default:
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	defer server.Close()
-
-	client := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
-	rec := newRunRecorder(context.Background(), client, Config{
-		Provider:   "aws",
-		Class:      "standard",
-		ServerType: "t3.small",
-	}, []string{"go", "test"}, "", &stderr, false, admissionTestRunID)
+			return runRecorderTestResponse{status: http.StatusOK, body: `{"run":{"id":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","leaseID":"cbx_abcdef123456","owner":"alice@example.com","org":"example-org","provider":"aws","class":"standard","serverType":"t3.small","command":["go","test"],"state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`}
+		},
+	)
+	rec := newRunRecorder(context.Background(), harness.client, harness.config, []string{"go", "test"}, "", &harness.stderr, false, admissionTestRunID)
 	rec.Event("leasing.started", "leasing", "")
-	rec.AttachLease(t.Context(), "cbx_abcdef123456", "blue-lobster", Config{
-		Provider:   "aws",
-		Class:      "standard",
-		ServerType: "t3.small",
-	})
+	rec.AttachLease(t.Context(), "cbx_abcdef123456", "blue-lobster", harness.config)
+	createBodies, _ := harness.snapshot(t)
 
 	if len(createBodies) != 2 {
 		t.Fatalf("create requests=%d want 2", len(createBodies))
@@ -792,10 +836,11 @@ func TestRunRecorderRecoversTransientCreateBeforeLease(t *testing.T) {
 		t.Fatalf("second create leaseID=%#v", got)
 	}
 	rec.waitForEvents(time.Second)
+	_, eventBody := harness.snapshot(t)
 	if got := eventBody["type"]; got != "lease.created" {
 		t.Fatalf("event body=%#v", eventBody)
 	}
-	text := stderr.String()
+	text := harness.stderr.String()
 	for _, want := range []string{
 		"run admission attempt " + admissionTestRunID,
 		"recording run run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -810,36 +855,15 @@ func TestRunRecorderRecoversTransientCreateBeforeLease(t *testing.T) {
 }
 
 func TestRunRecorderMarksHistoryUnavailableAfterPersistentCreateFailure(t *testing.T) {
-	var stderr bytes.Buffer
-	var createBodies []map[string]any
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPut || r.URL.Path != "/v1/runs/"+admissionTestRunID {
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+	harness := newRunRecorderCreateHarness(t, nil, func(call int) runRecorderTestResponse {
+		if call == 1 {
+			return runRecorderTestResponse{status: http.StatusInternalServerError, body: `{"error":"temporary_unavailable"}`}
 		}
-		var body map[string]any
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatal(err)
-		}
-		createBodies = append(createBodies, body)
-		if len(createBodies) == 1 {
-			http.Error(w, `{"error":"temporary_unavailable"}`, http.StatusInternalServerError)
-			return
-		}
-		http.Error(w, `{"error":"still_unavailable"}`, http.StatusServiceUnavailable)
-	}))
-	defer server.Close()
-
-	client := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
-	rec := newRunRecorder(context.Background(), client, Config{
-		Provider:   "aws",
-		Class:      "standard",
-		ServerType: "t3.small",
-	}, []string{"go", "test"}, "", &stderr, false, admissionTestRunID)
-	rec.AttachLease(t.Context(), "cbx_abcdef123456", "blue-lobster", Config{
-		Provider:   "aws",
-		Class:      "standard",
-		ServerType: "t3.small",
+		return runRecorderTestResponse{status: http.StatusServiceUnavailable, body: `{"error":"still_unavailable"}`}
 	})
+	rec := newRunRecorder(context.Background(), harness.client, harness.config, []string{"go", "test"}, "", &harness.stderr, false, admissionTestRunID)
+	rec.AttachLease(t.Context(), "cbx_abcdef123456", "blue-lobster", harness.config)
+	createBodies, _ := harness.snapshot(t)
 
 	if len(createBodies) != 4 {
 		t.Fatalf("create requests=%d want 4", len(createBodies))
@@ -847,7 +871,7 @@ func TestRunRecorderMarksHistoryUnavailableAfterPersistentCreateFailure(t *testi
 	if rec.runID != "" || !rec.historyUnavailable {
 		t.Fatalf("recorder runID=%q historyUnavailable=%v", rec.runID, rec.historyUnavailable)
 	}
-	text := stderr.String()
+	text := harness.stderr.String()
 	for _, want := range []string{
 		"run admission attempt " + admissionTestRunID,
 		"failed before lease:",
@@ -862,53 +886,24 @@ func TestRunRecorderMarksHistoryUnavailableAfterPersistentCreateFailure(t *testi
 }
 
 func TestRunRecorderRetriesFailedLeaseCreateOnReplacementLease(t *testing.T) {
-	var stderr bytes.Buffer
-	var createBodies []map[string]any
-	var eventBody map[string]any
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPut && r.URL.Path == "/v1/runs/"+admissionTestRunID:
-			var body map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatal(err)
+	harness := newRunRecorderCreateHarness(
+		t,
+		&runRecorderTestResponse{status: http.StatusOK, body: `{"event":{"runID":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","seq":1,"type":"lease.created","createdAt":"2026-05-02T00:00:01Z"}}`},
+		func(call int) runRecorderTestResponse {
+			if call < 5 {
+				return runRecorderTestResponse{status: http.StatusServiceUnavailable, body: `{"error":"temporary_unavailable"}`}
 			}
-			createBodies = append(createBodies, body)
-			if len(createBodies) < 5 {
-				http.Error(w, `{"error":"temporary_unavailable"}`, http.StatusServiceUnavailable)
-				return
-			}
-			_, _ = w.Write([]byte(`{"run":{"id":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","leaseID":"cbx_replacement123","owner":"alice@example.com","org":"example-org","provider":"aws","class":"standard","serverType":"t3.small","command":["go","test"],"state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`))
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events":
-			if err := json.NewDecoder(r.Body).Decode(&eventBody); err != nil {
-				t.Fatal(err)
-			}
-			_, _ = w.Write([]byte(`{"event":{"runID":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","seq":1,"type":"lease.created","createdAt":"2026-05-02T00:00:01Z"}}`))
-		default:
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	defer server.Close()
-
-	client := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
-	rec := newRunRecorder(context.Background(), client, Config{
-		Provider:   "aws",
-		Class:      "standard",
-		ServerType: "t3.small",
-	}, []string{"go", "test"}, "", &stderr, false, admissionTestRunID)
-	rec.AttachLease(t.Context(), "cbx_initial123456", "blue-lobster", Config{
-		Provider:   "aws",
-		Class:      "standard",
-		ServerType: "t3.small",
-	})
+			return runRecorderTestResponse{status: http.StatusOK, body: `{"run":{"id":"run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","leaseID":"cbx_replacement123","owner":"alice@example.com","org":"example-org","provider":"aws","class":"standard","serverType":"t3.small","command":["go","test"],"state":"running","phase":"starting","logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z"}}`}
+		},
+	)
+	rec := newRunRecorder(context.Background(), harness.client, harness.config, []string{"go", "test"}, "", &harness.stderr, false, admissionTestRunID)
+	rec.AttachLease(t.Context(), "cbx_initial123456", "blue-lobster", harness.config)
 	if rec.runID != "" || !rec.createPending || !rec.historyUnavailable {
 		t.Fatalf("after failed attach runID=%q createPending=%v historyUnavailable=%v", rec.runID, rec.createPending, rec.historyUnavailable)
 	}
 
-	rec.AttachLease(t.Context(), "cbx_replacement123", "green-lobster", Config{
-		Provider:   "aws",
-		Class:      "standard",
-		ServerType: "t3.small",
-	})
+	rec.AttachLease(t.Context(), "cbx_replacement123", "green-lobster", harness.config)
+	createBodies, _ := harness.snapshot(t)
 
 	if len(createBodies) != 5 {
 		t.Fatalf("create requests=%d want 5", len(createBodies))
@@ -920,13 +915,14 @@ func TestRunRecorderRetriesFailedLeaseCreateOnReplacementLease(t *testing.T) {
 		t.Fatalf("replacement create leaseID=%#v", got)
 	}
 	rec.waitForEvents(time.Second)
+	_, eventBody := harness.snapshot(t)
 	if got := eventBody["leaseID"]; got != "cbx_replacement123" {
 		t.Fatalf("lease.created body=%#v", eventBody)
 	}
 	if rec.runID != "run_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" || rec.createPending || rec.historyUnavailable {
 		t.Fatalf("recovered recorder runID=%q createPending=%v historyUnavailable=%v", rec.runID, rec.createPending, rec.historyUnavailable)
 	}
-	text := stderr.String()
+	text := harness.stderr.String()
 	for _, want := range []string{
 		"run admission attempt " + admissionTestRunID,
 		"failed before lease:",


### PR DESCRIPTION
## What Problem This Solves

Run-recorder admission tests repeated nearly identical HTTP servers, response fixtures, and request capture logic, making retry and lease-binding behavior harder to compare.

## Why This Change Was Made

This test-only refactor introduces one mutex-protected harness with strict request routing, raw response fixtures, and deep-cloned snapshots. The four existing scenarios retain their contexts, retry counts, event waits, diagnostics, and assertion order.

## User Impact

There is no user-visible behavior, configuration, or secret-handling change. Production code is unchanged. No changelog entry is included because this is a mechanical test refactor.

## Evidence

- Preserves 4 admission scenarios and 5 `AttachLease` calls using their existing test contexts.
- Preserves 12 PUTs with the 1, 2, 4, and 5 distribution, 3 event waits, 4 background recorder contexts, 10 raw fixtures, and 33 assertions.
- Preserves strict PUT ID and optional POST event routing, fixed 400/404 error responses, callbacks outside the mutex, and deep-cloned request snapshots.
- The prepared output blob is byte-identical to the reviewed retained refactor.
- Prepared from `3f984ebf27b8509dc86e383bb04299856742ca21`; the independently pinned result tree is `f1b070ac779471250846f51c75c4ba0176d7513d`. All 2,272 other source entries are preserved.
- The final diff is net negative: 1 file, 131 additions, and 135 deletions.
- `gofmt -d`, scoped diff checks, source binding, signature verification, and privacy checks passed.
- Local product tests were not run for this preparation cycle. Hosted CI qualified source head `42b65b6c87ff0be61f17890f95acfe8743ed5e6a` using historical checkout `38499b01e9883e1d3659e2ab745c88355b2fed79` (main `56f46bc4e524c312285cacd53f10ed38651c417b` plus this source head). No execution of newer-main compositions is claimed.
