### PR TITLE
refactor(worker): share machine-class candidate tables

### DIFF
--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -861,42 +861,40 @@ export function serverTypeForConfig(
   return serverTypeForClass(machineClass);
 }
 
-export function gcpMachineTypeCandidatesForClass(machineClass: string): string[] {
-  switch (machineClass) {
-    case "tiny":
-      return ["c4-standard-4", "c3-standard-4", "n2-standard-4", "n2d-standard-4"];
-    case "small":
-      return ["c4-standard-8", "c3-standard-8", "n2-standard-8", "n2d-standard-8", "c4-standard-4"];
-    case "standard":
-      return ["c4-standard-32", "c3-standard-22", "n2-standard-32", "n2d-standard-32"];
-    case "fast":
-      return [
-        "c4-standard-64",
-        "c3-standard-44",
-        "n2-standard-64",
-        "n2d-standard-64",
-        "c4-standard-32",
-      ];
-    case "large":
-      return [
-        "c4-standard-96",
-        "c3-standard-88",
-        "n2-standard-80",
-        "n2d-standard-96",
-        "c4-standard-64",
-      ];
-    case "beast":
-      return [
-        "c4-standard-192",
-        "c4-standard-96",
-        "c3-standard-176",
-        "c3-standard-88",
-        "n2d-standard-224",
-        "n2-standard-128",
-      ];
-    default:
-      return [machineClass];
+function candidatesForClass(
+  table: Readonly<Record<string, readonly string[]>>,
+  machineClass: string,
+): string[] {
+  if (typeof machineClass !== "string" || !Object.hasOwn(table, machineClass)) {
+    return [machineClass];
   }
+  return [...(table[machineClass] ?? [])];
+}
+
+const gcpMachineTypeCandidates: Readonly<Record<string, readonly string[]>> = {
+  tiny: ["c4-standard-4", "c3-standard-4", "n2-standard-4", "n2d-standard-4"],
+  small: ["c4-standard-8", "c3-standard-8", "n2-standard-8", "n2d-standard-8", "c4-standard-4"],
+  standard: ["c4-standard-32", "c3-standard-22", "n2-standard-32", "n2d-standard-32"],
+  fast: ["c4-standard-64", "c3-standard-44", "n2-standard-64", "n2d-standard-64", "c4-standard-32"],
+  large: [
+    "c4-standard-96",
+    "c3-standard-88",
+    "n2-standard-80",
+    "n2d-standard-96",
+    "c4-standard-64",
+  ],
+  beast: [
+    "c4-standard-192",
+    "c4-standard-96",
+    "c3-standard-176",
+    "c3-standard-88",
+    "n2d-standard-224",
+    "n2-standard-128",
+  ],
+};
+
+export function gcpMachineTypeCandidatesForClass(machineClass: string): string[] {
+  return candidatesForClass(gcpMachineTypeCandidates, machineClass);
 }
 
 export function azureVMSizeCandidatesForTargetClass(
@@ -929,6 +927,72 @@ export function azureVMSizeCandidatesForClass(machineClass: string): string[] {
   return azureVMSizeCandidatesForArchitectureClass("amd64", machineClass);
 }
 
+const azureVMSizeCandidates: Readonly<Record<string, readonly string[]>> = {
+  tiny: [
+    "Standard_D2ads_v6",
+    "Standard_D2ds_v6",
+    "Standard_D2ads_v5",
+    "Standard_D2ds_v5",
+    "Standard_F2s_v2",
+  ],
+  small: [
+    "Standard_D8ads_v6",
+    "Standard_D8ds_v6",
+    "Standard_F8s_v2",
+    "Standard_D8ads_v5",
+    "Standard_D8ds_v5",
+    "Standard_D4ads_v6",
+    "Standard_D4ds_v6",
+    "Standard_F4s_v2",
+  ],
+  standard: [
+    "Standard_D32ads_v6",
+    "Standard_D32ds_v6",
+    "Standard_F32s_v2",
+    "Standard_D32ads_v5",
+    "Standard_D32ds_v5",
+    "Standard_D16ads_v6",
+    "Standard_D16ds_v6",
+    "Standard_F16s_v2",
+  ],
+  fast: [
+    "Standard_D64ads_v6",
+    "Standard_D64ds_v6",
+    "Standard_F64s_v2",
+    "Standard_D64ads_v5",
+    "Standard_D64ds_v5",
+    "Standard_D48ads_v6",
+    "Standard_D48ds_v6",
+    "Standard_F48s_v2",
+    "Standard_D32ads_v6",
+    "Standard_D32ds_v6",
+    "Standard_F32s_v2",
+  ],
+  large: [
+    "Standard_D96ads_v6",
+    "Standard_D96ds_v6",
+    "Standard_D96ads_v5",
+    "Standard_D96ds_v5",
+    "Standard_D64ads_v6",
+    "Standard_D64ds_v6",
+    "Standard_F64s_v2",
+    "Standard_D48ads_v6",
+    "Standard_D48ds_v6",
+    "Standard_F48s_v2",
+  ],
+  beast: [
+    "Standard_D192ds_v6",
+    "Standard_D128ds_v6",
+    "Standard_D96ads_v6",
+    "Standard_D96ds_v6",
+    "Standard_D96ads_v5",
+    "Standard_D96ds_v5",
+    "Standard_D64ads_v6",
+    "Standard_D64ds_v6",
+    "Standard_F64s_v2",
+  ],
+};
+
 export function azureVMSizeCandidatesForArchitectureClass(
   architecture: Architecture,
   machineClass: string,
@@ -936,112 +1000,34 @@ export function azureVMSizeCandidatesForArchitectureClass(
   if (architecture === "arm64") {
     return azureARM64VMSizeCandidatesForClass(machineClass);
   }
-  switch (machineClass) {
-    case "tiny":
-      return [
-        "Standard_D2ads_v6",
-        "Standard_D2ds_v6",
-        "Standard_D2ads_v5",
-        "Standard_D2ds_v5",
-        "Standard_F2s_v2",
-      ];
-    case "small":
-      return [
-        "Standard_D8ads_v6",
-        "Standard_D8ds_v6",
-        "Standard_F8s_v2",
-        "Standard_D8ads_v5",
-        "Standard_D8ds_v5",
-        "Standard_D4ads_v6",
-        "Standard_D4ds_v6",
-        "Standard_F4s_v2",
-      ];
-    case "standard":
-      return [
-        "Standard_D32ads_v6",
-        "Standard_D32ds_v6",
-        "Standard_F32s_v2",
-        "Standard_D32ads_v5",
-        "Standard_D32ds_v5",
-        "Standard_D16ads_v6",
-        "Standard_D16ds_v6",
-        "Standard_F16s_v2",
-      ];
-    case "fast":
-      return [
-        "Standard_D64ads_v6",
-        "Standard_D64ds_v6",
-        "Standard_F64s_v2",
-        "Standard_D64ads_v5",
-        "Standard_D64ds_v5",
-        "Standard_D48ads_v6",
-        "Standard_D48ds_v6",
-        "Standard_F48s_v2",
-        "Standard_D32ads_v6",
-        "Standard_D32ds_v6",
-        "Standard_F32s_v2",
-      ];
-    case "large":
-      return [
-        "Standard_D96ads_v6",
-        "Standard_D96ds_v6",
-        "Standard_D96ads_v5",
-        "Standard_D96ds_v5",
-        "Standard_D64ads_v6",
-        "Standard_D64ds_v6",
-        "Standard_F64s_v2",
-        "Standard_D48ads_v6",
-        "Standard_D48ds_v6",
-        "Standard_F48s_v2",
-      ];
-    case "beast":
-      return [
-        "Standard_D192ds_v6",
-        "Standard_D128ds_v6",
-        "Standard_D96ads_v6",
-        "Standard_D96ds_v6",
-        "Standard_D96ads_v5",
-        "Standard_D96ds_v5",
-        "Standard_D64ads_v6",
-        "Standard_D64ds_v6",
-        "Standard_F64s_v2",
-      ];
-    default:
-      return [machineClass];
-  }
+  return candidatesForClass(azureVMSizeCandidates, machineClass);
 }
 
+const azureARM64VMSizeCandidates: Readonly<Record<string, readonly string[]>> = {
+  tiny: ["Standard_D2pds_v6", "Standard_D2ps_v6"],
+  small: ["Standard_D8pds_v6", "Standard_D8ps_v6", "Standard_D4pds_v6", "Standard_D4ps_v6"],
+  standard: ["Standard_D32pds_v6", "Standard_D32ps_v6", "Standard_D16pds_v6", "Standard_D16ps_v6"],
+  fast: [
+    "Standard_D64pds_v6",
+    "Standard_D64ps_v6",
+    "Standard_D48pds_v6",
+    "Standard_D48ps_v6",
+    "Standard_D32pds_v6",
+    "Standard_D32ps_v6",
+  ],
+  large: [
+    "Standard_D96pds_v6",
+    "Standard_D96ps_v6",
+    "Standard_D64pds_v6",
+    "Standard_D64ps_v6",
+    "Standard_D48pds_v6",
+    "Standard_D48ps_v6",
+  ],
+  beast: ["Standard_D96pds_v6", "Standard_D96ps_v6", "Standard_D64pds_v6", "Standard_D64ps_v6"],
+};
+
 export function azureARM64VMSizeCandidatesForClass(machineClass: string): string[] {
-  switch (machineClass) {
-    case "tiny":
-      return ["Standard_D2pds_v6", "Standard_D2ps_v6"];
-    case "small":
-      return ["Standard_D8pds_v6", "Standard_D8ps_v6", "Standard_D4pds_v6", "Standard_D4ps_v6"];
-    case "standard":
-      return ["Standard_D32pds_v6", "Standard_D32ps_v6", "Standard_D16pds_v6", "Standard_D16ps_v6"];
-    case "fast":
-      return [
-        "Standard_D64pds_v6",
-        "Standard_D64ps_v6",
-        "Standard_D48pds_v6",
-        "Standard_D48ps_v6",
-        "Standard_D32pds_v6",
-        "Standard_D32ps_v6",
-      ];
-    case "large":
-      return [
-        "Standard_D96pds_v6",
-        "Standard_D96ps_v6",
-        "Standard_D64pds_v6",
-        "Standard_D64ps_v6",
-        "Standard_D48pds_v6",
-        "Standard_D48ps_v6",
-      ];
-    case "beast":
-      return ["Standard_D96pds_v6", "Standard_D96ps_v6", "Standard_D64pds_v6", "Standard_D64ps_v6"];
-    default:
-      return [machineClass];
-  }
+  return candidatesForClass(azureARM64VMSizeCandidates, machineClass);
 }
 
 export function azureVMSizeIsARM64(vmSize: string): boolean {
@@ -1105,59 +1091,53 @@ function azureEphemeralFullCachingCandidates(
   return candidates;
 }
 
+const azureWindowsVMSizeCandidates: Readonly<Record<string, readonly string[]>> = {
+  tiny: [
+    "Standard_D2ads_v6",
+    "Standard_D2ds_v6",
+    "Standard_D2ads_v5",
+    "Standard_D2ds_v5",
+    "Standard_D2as_v6",
+  ],
+  small: [
+    "Standard_D8ads_v6",
+    "Standard_D8ds_v6",
+    "Standard_D8ads_v5",
+    "Standard_D8ds_v5",
+    "Standard_D8as_v6",
+  ],
+  standard: [
+    "Standard_D2ads_v6",
+    "Standard_D2ds_v6",
+    "Standard_D2ads_v5",
+    "Standard_D2ds_v5",
+    "Standard_D2as_v6",
+  ],
+  fast: [
+    "Standard_D4ads_v6",
+    "Standard_D4ds_v6",
+    "Standard_D4ads_v5",
+    "Standard_D4ds_v5",
+    "Standard_D4as_v6",
+  ],
+  large: [
+    "Standard_D8ads_v6",
+    "Standard_D8ds_v6",
+    "Standard_D8ads_v5",
+    "Standard_D8ds_v5",
+    "Standard_D8as_v6",
+  ],
+  beast: [
+    "Standard_D16ads_v6",
+    "Standard_D16ds_v6",
+    "Standard_D16ads_v5",
+    "Standard_D16ds_v5",
+    "Standard_D8ads_v6",
+  ],
+};
+
 export function azureWindowsVMSizeCandidatesForClass(machineClass: string): string[] {
-  switch (machineClass) {
-    case "tiny":
-      return [
-        "Standard_D2ads_v6",
-        "Standard_D2ds_v6",
-        "Standard_D2ads_v5",
-        "Standard_D2ds_v5",
-        "Standard_D2as_v6",
-      ];
-    case "small":
-      return [
-        "Standard_D8ads_v6",
-        "Standard_D8ds_v6",
-        "Standard_D8ads_v5",
-        "Standard_D8ds_v5",
-        "Standard_D8as_v6",
-      ];
-    case "standard":
-      return [
-        "Standard_D2ads_v6",
-        "Standard_D2ds_v6",
-        "Standard_D2ads_v5",
-        "Standard_D2ds_v5",
-        "Standard_D2as_v6",
-      ];
-    case "fast":
-      return [
-        "Standard_D4ads_v6",
-        "Standard_D4ds_v6",
-        "Standard_D4ads_v5",
-        "Standard_D4ds_v5",
-        "Standard_D4as_v6",
-      ];
-    case "large":
-      return [
-        "Standard_D8ads_v6",
-        "Standard_D8ds_v6",
-        "Standard_D8ads_v5",
-        "Standard_D8ds_v5",
-        "Standard_D8as_v6",
-      ];
-    case "beast":
-      return [
-        "Standard_D16ads_v6",
-        "Standard_D16ds_v6",
-        "Standard_D16ads_v5",
-        "Standard_D16ds_v5",
-        "Standard_D8ads_v6",
-      ];
-    default:
-      return [machineClass];
-  }
+  return candidatesForClass(azureWindowsVMSizeCandidates, machineClass);
 }
 
 export function awsInstanceTypeCandidatesForTargetClass(
@@ -1252,28 +1232,60 @@ function providerClassLiteralCandidates(machineClass: string): string[] {
   return isCanonicalProviderClass(machineClass) ? [] : [machineClass];
 }
 
+const serverTypeCandidates: Readonly<Record<string, readonly string[]>> = {
+  tiny: ["ccx13", "cpx22", "cx23"],
+  small: ["ccx23", "cpx32", "cx33"],
+  standard: ["ccx33", "cpx62", "cx53"],
+  fast: ["ccx43", "cpx62", "cx53"],
+  large: ["ccx53", "ccx43", "cpx62", "cx53"],
+  beast: ["ccx63", "ccx53", "ccx43", "cpx62", "cx53"],
+};
+
 export function serverTypeCandidatesForClass(machineClass: string): string[] {
-  switch (machineClass) {
-    case "tiny":
-      return ["ccx13", "cpx22", "cx23"];
-    case "small":
-      return ["ccx23", "cpx32", "cx33"];
-    case "standard":
-      return ["ccx33", "cpx62", "cx53"];
-    case "fast":
-      return ["ccx43", "cpx62", "cx53"];
-    case "large":
-      return ["ccx53", "ccx43", "cpx62", "cx53"];
-    case "beast":
-      return ["ccx63", "ccx53", "ccx43", "cpx62", "cx53"];
-    default:
-      return [machineClass];
-  }
+  return candidatesForClass(serverTypeCandidates, machineClass);
 }
 
 export function awsInstanceTypeCandidatesForClass(machineClass: string): string[] {
   return awsInstanceTypeCandidatesForArchitectureClass("amd64", machineClass);
 }
+
+const awsInstanceTypeCandidates: Readonly<Record<string, readonly string[]>> = {
+  tiny: ["m7a.large", "m7i.large", "c7a.xlarge", "c7i.xlarge", "t3.small"],
+  small: ["c7a.2xlarge", "c7i.2xlarge", "m7a.xlarge", "m7i.xlarge", "c7a.xlarge", "t3.small"],
+  standard: ["c7a.8xlarge", "c7i.8xlarge", "m7a.8xlarge", "m7i.8xlarge", "c7a.4xlarge", "t3.small"],
+  fast: [
+    "c7a.16xlarge",
+    "c7i.16xlarge",
+    "m7a.16xlarge",
+    "m7i.16xlarge",
+    "c7a.12xlarge",
+    "c7a.8xlarge",
+    "t3.small",
+  ],
+  large: [
+    "c7a.24xlarge",
+    "c7i.24xlarge",
+    "m7a.24xlarge",
+    "m7i.24xlarge",
+    "r7a.24xlarge",
+    "c7a.16xlarge",
+    "c7a.12xlarge",
+    "t3.small",
+  ],
+  beast: [
+    "c7a.48xlarge",
+    "c7i.48xlarge",
+    "m7a.48xlarge",
+    "m7i.48xlarge",
+    "r7a.48xlarge",
+    "c7a.32xlarge",
+    "c7i.32xlarge",
+    "m7a.32xlarge",
+    "c7a.24xlarge",
+    "c7a.16xlarge",
+    "t3.small",
+  ],
+};
 
 export function awsInstanceTypeCandidatesForArchitectureClass(
   architecture: Architecture,
@@ -1282,84 +1294,27 @@ export function awsInstanceTypeCandidatesForArchitectureClass(
   if (architecture === "arm64") {
     return awsARM64InstanceTypeCandidatesForClass(machineClass);
   }
-  switch (machineClass) {
-    case "tiny":
-      return ["m7a.large", "m7i.large", "c7a.xlarge", "c7i.xlarge", "t3.small"];
-    case "small":
-      return ["c7a.2xlarge", "c7i.2xlarge", "m7a.xlarge", "m7i.xlarge", "c7a.xlarge", "t3.small"];
-    case "standard":
-      return [
-        "c7a.8xlarge",
-        "c7i.8xlarge",
-        "m7a.8xlarge",
-        "m7i.8xlarge",
-        "c7a.4xlarge",
-        "t3.small",
-      ];
-    case "fast":
-      return [
-        "c7a.16xlarge",
-        "c7i.16xlarge",
-        "m7a.16xlarge",
-        "m7i.16xlarge",
-        "c7a.12xlarge",
-        "c7a.8xlarge",
-        "t3.small",
-      ];
-    case "large":
-      return [
-        "c7a.24xlarge",
-        "c7i.24xlarge",
-        "m7a.24xlarge",
-        "m7i.24xlarge",
-        "r7a.24xlarge",
-        "c7a.16xlarge",
-        "c7a.12xlarge",
-        "t3.small",
-      ];
-    case "beast":
-      return [
-        "c7a.48xlarge",
-        "c7i.48xlarge",
-        "m7a.48xlarge",
-        "m7i.48xlarge",
-        "r7a.48xlarge",
-        "c7a.32xlarge",
-        "c7i.32xlarge",
-        "m7a.32xlarge",
-        "c7a.24xlarge",
-        "c7a.16xlarge",
-        "t3.small",
-      ];
-    default:
-      return [machineClass];
-  }
+  return candidatesForClass(awsInstanceTypeCandidates, machineClass);
 }
 
+const awsARM64InstanceTypeCandidates: Readonly<Record<string, readonly string[]>> = {
+  tiny: ["m7g.large", "c7g.xlarge", "r7g.large", "t4g.small"],
+  small: ["c7g.2xlarge", "m7g.xlarge", "r7g.large", "c7g.xlarge", "t4g.small"],
+  standard: ["c7g.8xlarge", "m7g.8xlarge", "r7g.8xlarge", "c7g.4xlarge", "t4g.small"],
+  fast: [
+    "c7g.16xlarge",
+    "m7g.16xlarge",
+    "r7g.16xlarge",
+    "c7g.12xlarge",
+    "c7g.8xlarge",
+    "t4g.small",
+  ],
+  large: ["c7g.16xlarge", "m7g.16xlarge", "r7g.16xlarge", "c7g.12xlarge", "t4g.small"],
+  beast: ["c7g.16xlarge", "m7g.16xlarge", "r7g.16xlarge", "c7g.12xlarge", "t4g.small"],
+};
+
 export function awsARM64InstanceTypeCandidatesForClass(machineClass: string): string[] {
-  switch (machineClass) {
-    case "tiny":
-      return ["m7g.large", "c7g.xlarge", "r7g.large", "t4g.small"];
-    case "small":
-      return ["c7g.2xlarge", "m7g.xlarge", "r7g.large", "c7g.xlarge", "t4g.small"];
-    case "standard":
-      return ["c7g.8xlarge", "m7g.8xlarge", "r7g.8xlarge", "c7g.4xlarge", "t4g.small"];
-    case "fast":
-      return [
-        "c7g.16xlarge",
-        "m7g.16xlarge",
-        "r7g.16xlarge",
-        "c7g.12xlarge",
-        "c7g.8xlarge",
-        "t4g.small",
-      ];
-    case "large":
-      return ["c7g.16xlarge", "m7g.16xlarge", "r7g.16xlarge", "c7g.12xlarge", "t4g.small"];
-    case "beast":
-      return ["c7g.16xlarge", "m7g.16xlarge", "r7g.16xlarge", "c7g.12xlarge", "t4g.small"];
-    default:
-      return [machineClass];
-  }
+  return candidatesForClass(awsARM64InstanceTypeCandidates, machineClass);
 }
 
 export function awsInstanceTypeIsARM64(instanceType: string): boolean {

--- a/worker/test/config.test.ts
+++ b/worker/test/config.test.ts
@@ -7,10 +7,12 @@ import { azureProvisioningCandidatesForConfig } from "../src/azure";
 import {
   awsMacOSInstanceTypeCandidates,
   awsARM64InstanceTypeCandidatesForClass,
+  awsInstanceTypeCandidatesForArchitectureClass,
   awsInstanceTypeCandidatesForClass,
   awsInstanceTypeCandidatesForTargetClass,
   azureARM64VMSizeCandidatesForClass,
   azureWindowsVMSizeCandidatesForClass,
+  azureVMSizeCandidatesForArchitectureClass,
   azureVMSizeCandidatesForClass,
   azureVMSizeCandidatesForTargetClass,
   gcpMachineTypeCandidatesForClass,
@@ -25,6 +27,16 @@ import { gcpProvisioningCandidatesForConfig } from "../src/gcp";
 import { hetznerProvisioningCandidatesForConfig } from "../src/hetzner";
 
 describe("machine class config", () => {
+  const classCandidateSelectors = [
+    serverTypeCandidatesForClass,
+    (value: string) => awsInstanceTypeCandidatesForArchitectureClass("amd64", value),
+    awsARM64InstanceTypeCandidatesForClass,
+    (value: string) => azureVMSizeCandidatesForArchitectureClass("amd64", value),
+    azureARM64VMSizeCandidatesForClass,
+    azureWindowsVMSizeCandidatesForClass,
+    gcpMachineTypeCandidatesForClass,
+  ];
+
   it("maps known classes to preferred Hetzner candidates", () => {
     expect(serverTypeForClass("beast")).toBe("ccx63");
     expect(serverTypeCandidatesForClass("beast")).toEqual([
@@ -41,11 +53,12 @@ describe("machine class config", () => {
   });
 
   it("preserves uppercase, padded, and unknown class literals", () => {
+    for (const machineClass of ["", "FAST", " fast ", "custom-shape", "constructor", "__proto__"]) {
+      for (const selector of classCandidateSelectors) {
+        expect(selector(machineClass)).toEqual([machineClass]);
+      }
+    }
     for (const machineClass of ["FAST", " fast ", "custom-shape"]) {
-      expect(serverTypeCandidatesForClass(machineClass)).toEqual([machineClass]);
-      expect(awsInstanceTypeCandidatesForClass(machineClass)).toEqual([machineClass]);
-      expect(azureVMSizeCandidatesForClass(machineClass)).toEqual([machineClass]);
-      expect(gcpMachineTypeCandidatesForClass(machineClass)).toEqual([machineClass]);
       expect(
         awsLaunchCandidates({
           serverType: "",
@@ -56,6 +69,27 @@ describe("machine class config", () => {
           architecture: "amd64",
         }),
       ).toEqual([machineClass, "t3.small"]);
+    }
+  });
+
+  it("returns fresh candidate arrays for known and custom classes", () => {
+    for (const selector of classCandidateSelectors) {
+      for (const machineClass of ["tiny", "custom-shape"]) {
+        const candidates = selector(machineClass);
+        const saved = [...candidates];
+        candidates[0] = "mutated";
+        expect(selector(machineClass)).toEqual(saved);
+      }
+    }
+  });
+
+  it("preserves runtime-invalid class values without coercion", () => {
+    for (const selector of classCandidateSelectors) {
+      for (const value of [null, undefined, {}, Symbol("fixture")]) {
+        const candidates = selector(value as unknown as string);
+        expect(candidates).toHaveLength(1);
+        expect(candidates[0]).toBe(value);
+      }
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

Worker machine-class selectors repeated large candidate lists in branching code, making ordering and cross-provider consistency harder to audit.

## Why This Change Was Made

This mechanical refactor moves the existing machine-class candidates into shared lookup tables while preserving selector behavior, ordering, custom-value pass-through, and fresh-array semantics.

## User Impact

There is no user-visible behavior, configuration, or secret-handling change. The same machine candidates remain in the same order. No changelog entry is included because this is a mechanical refactor.

## Evidence

- Preserves 7 selectors, 42 class cases, and 230 ordered candidates.
- Preserves noncoercing `typeof` and `Object.hasOwn` guards, prototype fallback, fresh arrays, and parsing, explicit-priority, stored-fallback, architecture, target, default, and empty-value behavior.
- Both prepared output blobs are byte-identical to the reviewed retained refactor.
- Prepared from `3f984ebf27b8509dc86e383bb04299856742ca21`; the independently pinned result tree is `320c68991f703d2e6c0a9e1720ab2f1334386356`. All 2,271 other source entries are preserved.
- The final diff is net negative: 2 files, 274 additions, and 285 deletions.
- Scoped diff, signature, source-binding, and privacy checks passed.
- TypeScript formatting tools and local product tests were not run for this preparation cycle. Hosted CI qualified source head `5818c34c5cf5527244b41da87408cc1ccc5d487f` using historical checkout `837b13a81a0ff124f554377fb64b01bc404a01e2` (main `56f46bc4e524c312285cacd53f10ed38651c417b` plus this source head), after one Direct Go install retry. Ten earlier job results and 107 steps were preserved, not rerun. No execution of newer-main compositions is claimed.
