### PR TITLE
fix(wsl2): disable WSLg on headless managed leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Disable the unused WSLg compositor on headless managed Windows WSL2 leases to avoid service-session crashes that stall commands and workspace-owner renewal; preserve other WSL settings and existing execution deadlines.
+
 - Fix managed Windows WSL2 command timeouts by disabling redundant cloud-init discovery, verifying cold-start readiness, and allowing a target-specific status probe budget for fixed-ID orchestrators. https://github.com/openclaw/crabbox/pull/1996. Thanks @steipete.
 
 - Describe Anthropic Sandbox Runtime configuration bindings once, preserving inherited binary paths for empty YAML, explicit settings/debug clearing, and native runtime defaults. [PR 1993](https://github.com/openclaw/crabbox/pull/1993). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Disable the unused WSLg compositor on headless managed Windows WSL2 leases to avoid service-session crashes that stall commands and workspace-owner renewal; preserve other WSL settings and existing execution deadlines.
+- Disable the unused WSLg compositor on headless managed Windows WSL2 leases to avoid service-session crashes that stall commands and workspace-owner renewal; preserve other WSL settings and existing execution deadlines. https://github.com/openclaw/crabbox/pull/2005. Thanks @steipete.
 
 - Fix managed Windows WSL2 command timeouts by disabling redundant cloud-init discovery, verifying cold-start readiness, and allowing a target-specific status probe budget for fixed-ID orchestrators. https://github.com/openclaw/crabbox/pull/1996. Thanks @steipete.
 

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -323,6 +323,15 @@ later command invocations. Bootstrap restarts the distro and verifies its Linux
 ready check before publishing the setup marker; warmup also checks the WSL SSH
 runtime. `inspect` and `status` allow a 30-second WSL2 readiness probe.
 
+Headless managed WSL2 leases also disable WSLg with `guiApplications=false` in
+the Windows SSH user's `.wslconfig`, preserving other settings. The GUI/RDP
+compositor is unnecessary for these leases and can crash in a Windows service
+session, blocking later Linux commands and workspace-owner renewal. Explicit
+desktop or browser requests retain their existing GUI configuration. Bootstrap
+applies a changed WSL configuration before starting the distro; existing leases
+need reprovisioning to receive this policy. Command execution and owner-control
+timeout budgets are unchanged.
+
 ## Normal SSH lifecycle
 
 1. Import or reuse the per-lease SSH key (RSA for native Windows, ed25519

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -178,7 +178,13 @@ func windowsManagedCorePreludePowerShell(cfg Config) string {
 
 func windowsWSL2BootstrapPowerShell(cfg Config) string {
 	workRoot := windowsWSLWorkRoot(cfg)
+	headless := ""
+	if !cfg.Desktop && !cfg.Browser {
+		headless = windowsWSL2HeadlessConfigPowerShell
+	}
 	return `
+	$wslConfigChanged = $false
+` + headless + `
 	$wslDistro = "Crabbox"
 	$wslRoot = "C:\ProgramData\crabbox\wsl\Crabbox"
 	$wslRootfs = "C:\ProgramData\crabbox\wsl\ubuntu-noble-wsl-amd64.rootfs.tar.gz"
@@ -211,6 +217,10 @@ func windowsWSL2BootstrapPowerShell(cfg Config) string {
 	  wsl.exe --update --web-download | Out-Host
 	  if ($LASTEXITCODE -ne 0) { throw "wsl --update --web-download failed with exit $LASTEXITCODE" }
 	  Restart-CrabboxBootstrap $wslKernelMarker
+	}
+	if ($wslConfigChanged) {
+	  wsl.exe --shutdown | Out-Host
+	  if ($LASTEXITCODE -ne 0) { throw "apply headless WSL configuration failed with exit $LASTEXITCODE" }
 	}
 	wsl.exe --set-default-version 2 | Out-Host
 	if ($LASTEXITCODE -ne 0) { throw "wsl --set-default-version 2 failed with exit $LASTEXITCODE" }
@@ -297,6 +307,42 @@ crabbox-ready
 	Restart-Service sshd -Force
 	`
 }
+
+// WSLg's RDP compositor is unnecessary for headless SSH leases and can crash
+// in Windows service sessions, leaving even non-GUI distro launches blocked.
+const windowsWSL2HeadlessConfigPowerShell = `
+function ConvertTo-CrabboxHeadlessWSLConfig([string]$Text) {
+  $result = [Collections.Generic.List[string]]::new()
+  $inWSL2 = $false
+  $hasSection = $false
+  $hasKey = $false
+  if ($Text.Length -gt 0) {
+    foreach ($line in ($Text -split '\r?\n')) {
+      if ($line -match '^\s*\[([^\]]+)\]\s*(?:[;#].*)?$') {
+        if ($inWSL2 -and -not $hasKey) { $result.Add('guiApplications=false') }
+        $inWSL2 = $Matches[1].Trim() -eq 'wsl2'
+        $hasSection = $hasSection -or $inWSL2
+        $hasKey = $false
+      }
+      if ($inWSL2 -and $line -match '^\s*guiApplications\s*=') {
+        $result.Add('guiApplications=false')
+        $hasKey = $true
+      } else { $result.Add($line) }
+    }
+  }
+  if (-not $hasSection) { $result.Add('[wsl2]'); $inWSL2 = $true; $hasKey = $false }
+  if ($inWSL2 -and -not $hasKey) { $result.Add('guiApplications=false') }
+  return $result -join [char]10
+}
+$wslConfigPath = Join-Path $HOME '.wslconfig'
+$wslConfig = ''
+if (Test-Path -LiteralPath $wslConfigPath) { $wslConfig = [IO.File]::ReadAllText($wslConfigPath) }
+$headlessWSLConfig = ConvertTo-CrabboxHeadlessWSLConfig $wslConfig
+$wslConfigChanged = $headlessWSLConfig -cne $wslConfig
+if ($wslConfigChanged) {
+  [IO.File]::WriteAllText($wslConfigPath, $headlessWSLConfig, [Text.UTF8Encoding]::new($false))
+}
+`
 
 func windowsDesktopBootstrapPowerShell() string {
 	return windowsDesktopLauncherServicePowerShell() + sharedWindowsDesktop()

--- a/internal/cli/bootstrap_wsl_config_test.go
+++ b/internal/cli/bootstrap_wsl_config_test.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestManagedHeadlessWSLDisablesGUIBeforeLaunch(t *testing.T) {
+	for _, test := range []struct {
+		name, target, mode string
+		desktop, browser   bool
+		want               bool
+	}{
+		{"linux", targetLinux, "", false, false, false},
+		{"native windows", targetWindows, windowsModeNormal, false, false, false},
+		{"native desktop", targetWindows, windowsModeNormal, true, false, false},
+		{"headless wsl2", targetWindows, windowsModeWSL2, false, false, true},
+		{"wsl2 desktop", targetWindows, windowsModeWSL2, true, false, false},
+		{"wsl2 browser", targetWindows, windowsModeWSL2, false, true, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := baseConfig()
+			cfg.TargetOS, cfg.WindowsMode, cfg.Desktop, cfg.Browser = test.target, test.mode, test.desktop, test.browser
+			script := cloudInit(cfg, "ssh-ed25519 test")
+			if test.target == targetWindows {
+				script = windowsBootstrapPowerShell(cfg, "ssh-ed25519 test")
+			}
+			if got := strings.Contains(script, "guiApplications=false"); got != test.want {
+				t.Fatalf("headless WSL policy present=%t, want %t", got, test.want)
+			}
+			if test.want {
+				write := strings.Index(script, "[IO.File]::WriteAllText($wslConfigPath")
+				update := strings.Index(script, "wsl.exe --update")
+				shutdown := strings.Index(script, "wsl.exe --shutdown")
+				launch := strings.Index(script, "wsl.exe --set-default-version")
+				if write < 0 || update <= write || shutdown <= update || launch <= shutdown ||
+					!strings.Contains(script, "if ($wslConfigChanged)") {
+					t.Fatal("WSLg policy must precede installation and restart changed configurations before distro launch")
+				}
+			}
+		})
+	}
+}
+
+func TestHeadlessWSLConfigPreservesOtherSettings(t *testing.T) {
+	powerShell, err := exec.LookPath("pwsh")
+	if err != nil {
+		powerShell, err = exec.LookPath("powershell.exe")
+	}
+	if err != nil {
+		t.Skip("PowerShell is unavailable")
+	}
+	cfg := baseConfig()
+	cfg.TargetOS, cfg.WindowsMode = targetWindows, windowsModeWSL2
+	bootstrap := windowsWSL2BootstrapPowerShell(cfg)
+	start, end := strings.Index(bootstrap, "function ConvertTo-CrabboxHeadlessWSLConfig"), strings.Index(bootstrap, "$wslConfigPath =")
+	if start < 0 || end <= start {
+		t.Fatal("bootstrap does not configure the headless WSL runtime")
+	}
+	for _, test := range []struct{ name, input, want string }{
+		{"missing file", "", "[wsl2]\nguiApplications=false"},
+		{"already disabled", "[wsl2]\nguiApplications=false\n", "[wsl2]\nguiApplications=false\n"},
+		{"preserve memory", "[wsl2]\nmemory=4GB\nguiApplications=true\n", "[wsl2]\nmemory=4GB\nguiApplications=false\n"},
+		{"other section", "[experimental]\nsparseVhd=true", "[experimental]\nsparseVhd=true\n[wsl2]\nguiApplications=false"},
+		{"insert before next section", "[wsl2]\nmemory=4GB\n[experimental]\nsparseVhd=true", "[wsl2]\nmemory=4GB\nguiApplications=false\n[experimental]\nsparseVhd=true"},
+		{"case whitespace comments", "; keep\r\n [WSL2] ; keep\r\n GUIAPPLICATIONS = true\r\nprocessors=2", "; keep\n [WSL2] ; keep\nguiApplications=false\nprocessors=2"},
+		{"same key in other section", "[other]\nguiApplications=true\n[wsl2]\nguiApplications=true", "[other]\nguiApplications=true\n[wsl2]\nguiApplications=false"},
+		{"duplicate sections", "[wsl2]\nmemory=4GB\n[wsl2]\nguiApplications=true", "[wsl2]\nmemory=4GB\nguiApplications=false\n[wsl2]\nguiApplications=false"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			script := bootstrap[start:end] + "\n$first = ConvertTo-CrabboxHeadlessWSLConfig " + psQuote(test.input) + `
+$second = ConvertTo-CrabboxHeadlessWSLConfig $first
+@{first=$first;second=$second} | ConvertTo-Json -Compress`
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+			defer cancel()
+			out, err := exec.CommandContext(ctx, powerShell, "-NoProfile", "-NonInteractive", "-Command", script).CombinedOutput()
+			if err != nil {
+				t.Fatalf("config conversion: %v: %s", err, out)
+			}
+			var got struct{ First, Second string }
+			if err := json.Unmarshal(out, &got); err != nil {
+				t.Fatalf("invalid config result: %v: %s", err, out)
+			}
+			if got.First != test.want || got.Second != test.want {
+				t.Fatalf("first=%q second=%q, want %q on both passes", got.First, got.Second, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Disable WSLg for managed Windows WSL2 leases without desktop or browser requests. Preserve other settings in the Windows SSH user's `.wslconfig`, apply changed settings during bootstrap, and retain existing configuration for explicit GUI requests.

## Root cause

A headless managed lease started WSLg's GUI/RDP compositor by default. Live diagnostics captured repeated Weston `rdp-backend.so` crashes at offset `0x218` in the Windows service session. The workload distro then stopped accepting even a direct native `wsl.exe --distribution Crabbox --user root --exec /bin/uname -a`, while Windows SSH remained responsive and the WSL system distro answered in 105 ms. Crabbox's finite workspace-owner renewal consequently reported `WSL2 command timed out phase=execute`, cancelling script preparation or subsequent commands.

The ordinary workload execute budget was already unlimited. This change leaves all transport and owner-control deadlines intact and prevents the unused GUI subsystem from starting on headless leases. The crash signature matches the service-session report at https://github.com/microsoft/WSL/issues/41110. The supported configuration is documented at https://learn.microsoft.com/en-us/windows/wsl/wsl-config.

## Verification

- Build: `/opt/homebrew/bin/go build -trimpath -o bin/crabbox ./cmd/crabbox`.
- Formatting: `git ls-files -z '*.go' | xargs -0 /opt/homebrew/bin/gofmt -l` (no output).
- Static checks: `/opt/homebrew/bin/go vet ./...`.
- Focused race tests: `/opt/homebrew/bin/go test -race -timeout=10m ./internal/cli -run 'Test(WSLStage|WorkspaceOwnerWSL|SSHTransport|SSHControlBudgets|ManagedHeadlessWSL|HeadlessWSLConfig|ManagedWindowsWSL2|WindowsWSL2|CommandIntentNativeTransport)'` (passed).
- Regression: the new headless-policy test fails against original main `9dd1fea2`; it passes with this patch. Linux/native Windows and explicit GUI selection are covered by the same table.
- Native Windows PowerShell: all eight configuration preservation/idempotence cases passed using the production converter and the test fixtures.
- Fresh Linux tiny lease: `run -- uname -a` passed; lease stopped.
- Fresh AWS WSL2 `m8i.large`: warmup and inspect reported ready; one stdin script streamed 24 progress lines at 15-second intervals for six minutes, then installed build tools and compiled CPython with `make -j2`. Actual script duration was 8m39s, including 2m39s of real build work. The CLI returned the intentional exit 23 and released its workspace owner; inspect remained ready.
- Reused that WSL2 lease with normal repository sync and `run -- uname -a`: sync and command passed, CLI exit 0, owner released, final inspect ready.
- All four investigation/proof leases were stopped. A filtered `list --provider aws --json` confirmed zero task IDs or slugs remained.
- Full Linux Go CI passed for `a4a696fe`: https://github.com/openclaw/crabbox/actions/runs/34256884295.

The full macOS race suite was intentionally not run; Linux PR CI is authoritative. Both scoped autoreviews found no accepted/actionable findings. The intentional nonzero run still logged an existing optional failure-bundle cleanup deadline warning; exit 23, owner release, readiness, and subsequent reuse were preserved.

## Configuration and secrets

The managed Windows SSH user's `.wslconfig` gains `guiApplications=false` only for headless WSL2 bootstrap. Other settings are preserved. A changed configuration triggers WSL shutdown during bootstrap, before distro setup; no active `run` performs automatic guest recovery. Existing leases need reprovisioning to receive the policy. No new secret, credential, dependency, coordinator change, or version bump is required.
