### PR TITLE
fix: keep WSL2 workspace-owner renewal responsive under load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Keep WSL2 workspace-owner renewal small and allow bounded workload contention without weakening token, expiry, or child-state checks. Thanks @steipete.
+- Keep WSL2 workspace-owner renewal small and allow bounded workload contention without weakening token, expiry, or child-state checks. https://github.com/openclaw/crabbox/pull/2011. Thanks @steipete.
 
 - Disable the unused WSLg compositor on headless managed Windows WSL2 leases to avoid service-session crashes that stall commands and workspace-owner renewal; preserve other WSL settings and existing execution deadlines. https://github.com/openclaw/crabbox/pull/2005. Thanks @steipete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Keep WSL2 workspace-owner renewal small and allow bounded workload contention without weakening token, expiry, or child-state checks. Thanks @steipete.
+
 - Disable the unused WSLg compositor on headless managed Windows WSL2 leases to avoid service-session crashes that stall commands and workspace-owner renewal; preserve other WSL settings and existing execution deadlines. https://github.com/openclaw/crabbox/pull/2005. Thanks @steipete.
 
 - Fix managed Windows WSL2 command timeouts by disabling redundant cloud-init discovery, verifying cold-start readiness, and allowing a target-specific status probe budget for fixed-ID orchestrators. https://github.com/openclaw/crabbox/pull/1996. Thanks @steipete.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -317,9 +317,13 @@ concurrent checkout. POSIX, WSL2, and native Windows targets implement the same
 protocol; the small sync-finalization lock remains nested inside it.
 
 Renewal errors retain recognized `MISMATCH`, `EXPIRED`, and `AMBIGUOUS` protocol
-states alongside transport errors. Unrecognized response text is omitted. These
-diagnostics do not retry renewal or permit collection or cleanup after ownership
-fails closed.
+states alongside transport errors. Unrecognized response text is omitted.
+WSL2 renewal uses a compact marker-only helper with a 60-second execution
+allowance for CPU and disk contention. It retries confirmed lock contention at
+most twice within the original bounded call deadline; that deadline is included
+in the owner expiry window. A transport failure or rejected/ambiguous owner
+state is never retried. Collection and cleanup remain blocked after ownership
+fails closed. Linux and native Windows renewal behavior is unchanged.
 
 Native Windows stages owner scripts and witnessed command input with exact byte
 counts and asynchronous pipe reads. Empty frames complete without initializing

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -82,7 +82,17 @@ type sshWorkspaceOwnerTransport struct {
 }
 
 func (t sshWorkspaceOwnerTransport) CallBudget() time.Duration {
-	return sshTransportCallBudget(t.target, sshControlMetadataLimit, sshCommandLimit{execution: workspaceOwnerRemoteTimeout, control: true})
+	return sshTransportCallBudget(t.target, sshControlMetadataLimit, workspaceOwnerCommandLimit(t.target, workspaceOwnerRenew))
+}
+
+func workspaceOwnerCommandLimit(target SSHTarget, action workspaceOwnerAction) sshCommandLimit {
+	limit := sshCommandLimit{execution: workspaceOwnerRemoteTimeout, control: true}
+	if isWindowsWSL2Target(target) && action == workspaceOwnerRenew {
+		// The distro shares CPU and disk with the workload. Keep the native
+		// watchdog finite, but allow a renewal to survive a busy scheduler.
+		limit.execution = time.Minute
+	}
+	return limit
 }
 
 func (t sshWorkspaceOwnerTransport) Do(ctx context.Context, req workspaceOwnerRemoteRequest) (string, error) {
@@ -98,10 +108,18 @@ func (t sshWorkspaceOwnerTransport) Do(ctx context.Context, req workspaceOwnerRe
 		input = []byte(script)
 		remote = windowsPowerShellStdinScriptCommand(len([]byte(script)))
 	}
-	return runWorkspaceOwnerSSHProtocol(ctx, t.target, remote, input, req.Token)
+	limit := workspaceOwnerCommandLimit(t.target, req.Action)
+	for attempt := 0; ; attempt++ {
+		response, err := runWorkspaceOwnerSSHProtocol(ctx, t.target, remote, input, req.Token, limit)
+		// BUSY certifies that the renewal did not enter the gate or mutate
+		// state. Never replay an ambiguous execution or a rejected token.
+		if !isWindowsWSL2Target(t.target) || req.Action != workspaceOwnerRenew || err != nil || response != "BUSY" || attempt == 2 {
+			return response, err
+		}
+	}
 }
 
-func runWorkspaceOwnerSSHProtocol(ctx context.Context, target SSHTarget, remote string, input []byte, requestToken string) (output string, err error) {
+func runWorkspaceOwnerSSHProtocol(ctx context.Context, target SSHTarget, remote string, input []byte, requestToken string, limit sshCommandLimit) (output string, err error) {
 	if len(remote)+len(input) > sshControlMetadataLimit {
 		return "", errors.New("workspace owner metadata exceeds its accounted transport budget")
 	}
@@ -110,7 +128,7 @@ func runWorkspaceOwnerSSHProtocol(ctx context.Context, target SSHTarget, remote 
 		source = bytes.NewReader(input)
 	}
 	stdout, stderr := newSynchronizedBuffer(0), newSynchronizedBuffer(0)
-	err = executePreparedSSH(ctx, &target, remote, source, int64(len(input)), sshCommandLimit{execution: workspaceOwnerRemoteTimeout, control: true},
+	err = executePreparedSSH(ctx, &target, remote, source, int64(len(input)), limit,
 		workspaceOwnerSSHConnectTimeoutOption, workspaceOwnerSSHConnectionAttemptsOption, &stdout, &stderr)
 	output = strings.TrimSpace(stdout.String())
 	if err != nil {
@@ -574,6 +592,9 @@ done
 func remoteWorkspaceOwnerCommand(target SSHTarget, req workspaceOwnerRemoteRequest) string {
 	if isWindowsNativeTarget(target) {
 		return windowsPowerShellStdinScriptCommand(len([]byte(remoteWorkspaceOwnerWindows(req))))
+	}
+	if isWindowsWSL2Target(target) && req.Action == workspaceOwnerRenew {
+		return remoteWorkspaceOwnerWSL2Renew(req)
 	}
 	return remoteWorkspaceOwnerPOSIXLauncher(req.Key, req.Token, remoteWorkspaceOwnerPOSIX(req))
 }

--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -964,10 +964,10 @@ func TestWorkspaceOwnerWSL2StagesThenExecutesOnceWithoutStdin(t *testing.T) {
 		if len(data) != int(spool.size) || string(data[:8]) != "CBXFLAT2" {
 			t.Fatalf("invalid staged owner spool bytes=%d", len(data))
 		}
-		if spool.size > 1<<20 || wslStageBudget(timing.stage, timing.idle, spool.size) != sshTransportTiming(sshCommandLimit{execution: workspaceOwnerRemoteTimeout, control: true}).stage {
+		if spool.size > 1<<20 || wslStageBudget(timing.stage, timing.idle, spool.size) != wantTiming.stage {
 			t.Fatalf("owner spool exceeds its accounted upload phase: bytes=%d budget=%s", spool.size, wslStageBudget(timing.stage, timing.idle, spool.size))
 		}
-		if binary.LittleEndian.Uint64(data[32:]) != uint64(timing.operation.Milliseconds()) || timing.operation != 38*time.Second {
+		if binary.LittleEndian.Uint64(data[32:]) != uint64(wantTiming.operation.Milliseconds()) {
 			t.Fatal("derived control operation guard missing")
 		}
 		launchers = append(launchers, wslStageLauncherCommand(nonce, spool.size, spool.digest(), wslStageCMD))
@@ -976,6 +976,7 @@ func TestWorkspaceOwnerWSL2StagesThenExecutesOnceWithoutStdin(t *testing.T) {
 	target := SSHTarget{User: "crabbox", Host: "127.0.0.1", Port: "22", TargetOS: targetWindows, WindowsMode: windowsModeWSL2}
 	key, token := workspaceOwnerKey("cbx_wsl2_staged_protocol"), strings.Repeat("6", 64)
 	for index, action := range []workspaceOwnerAction{workspaceOwnerAcquire, workspaceOwnerRenew, workspaceOwnerInspect, workspaceOwnerRelease} {
+		wantTiming = sshTransportTiming(workspaceOwnerCommandLimit(target, action))
 		want := map[workspaceOwnerAction]string{
 			workspaceOwnerAcquire: "ACQUIRED", workspaceOwnerRenew: "RENEWED",
 			workspaceOwnerInspect: "OWNED", workspaceOwnerRelease: "RELEASED",
@@ -1069,7 +1070,8 @@ func TestWorkspaceOwnerWANBudgetContract(t *testing.T) {
 				t.Fatalf("call=%s lifecycle=%s", call, lifecycle)
 			}
 			owner := &workspaceOwner{transport: sshWorkspaceOwnerTransport{target: target}}
-			if owner.callTimeout() != call || owner.quiesceTimeout() != 2*call+time.Second {
+			ownerCall := sshTransportCallBudget(target, sshControlMetadataLimit, workspaceOwnerCommandLimit(target, workspaceOwnerRenew))
+			if owner.callTimeout() != ownerCall || owner.quiesceTimeout() != 2*ownerCall+time.Second {
 				t.Fatal("owner caller lost dynamic route allocation")
 			}
 			ttl := workspaceOwnerRenewInterval + call + workspaceOwnerRenewMargin

--- a/internal/cli/workspace_owner_wsl.go
+++ b/internal/cli/workspace_owner_wsl.go
@@ -1,0 +1,37 @@
+package cli
+
+import "strconv"
+
+// The WSL transport already stages this script privately. Renewal needs only
+// the existing gate and owner marker, not another launcher or child inspection.
+func remoteWorkspaceOwnerWSL2Renew(req workspaceOwnerRemoteRequest) string {
+	return `set -eu
+umask 077
+root="$HOME/.crabbox/workspace-owners"
+state="$root/` + req.Key + `.owner"
+token=` + shellQuote(req.Token) + `
+ttl=` + strconv.FormatInt(workspaceOwnerTTLSeconds(req.TTL), 10) + `
+exec 9>"$root/` + req.Key + `.gate"
+if flock -x -w 5 -E 75 9; then :; else
+  code=$?
+  if [ "$code" -eq 75 ]; then printf BUSY; exit 0; fi
+  printf AMBIGUOUS; exit 74
+fi
+read_state() {
+  IFS= read -r version && IFS= read -r state_token && IFS= read -r expiry
+}
+if ! read_state <"$state"; then printf AMBIGUOUS; exit 74; fi
+[ "$version" = v1 ] || { printf AMBIGUOUS; exit 74; }
+case "$state_token" in ''|*[!0-9a-f]*) printf AMBIGUOUS; exit 74;; esac
+[ "${#state_token}" -eq 64 ] || { printf AMBIGUOUS; exit 74; }
+case "$expiry" in ''|*[!0-9]*) printf AMBIGUOUS; exit 74;; esac
+[ "$state_token" = "$token" ] || { printf MISMATCH; exit 75; }
+now=$(date +%s)
+[ "$expiry" -gt "$now" ] || { printf EXPIRED; exit 75; }
+tmp="$state.tmp.$$"
+trap 'rm -f "$tmp"' EXIT
+printf 'v1\n%s\n%s\n' "$token" "$((now + ttl))" >"$tmp"
+mv "$tmp" "$state"
+printf RENEWED
+`
+}

--- a/internal/cli/workspace_owner_wsl_test.go
+++ b/internal/cli/workspace_owner_wsl_test.go
@@ -1,0 +1,162 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+type budgetedWSL2OwnerTestTransport struct {
+	workspaceOwnerTransportFunc
+	budget time.Duration
+}
+
+func (t budgetedWSL2OwnerTestTransport) CallBudget() time.Duration { return t.budget }
+
+func TestWorkspaceOwnerWSL2RenewalBudgetAndPayload(t *testing.T) {
+	target := SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}
+	req := workspaceOwnerRemoteRequest{Action: workspaceOwnerRenew, Key: workspaceOwnerKey("cbx_busy"), Token: strings.Repeat("a", 64), TTL: 10 * time.Minute}
+	captureWSLStage(t, strings.Repeat("a", 32), func(spool *wslStageSpool, _ *SSHTarget, timing wslStageTiming, data []byte) {
+		_, _, command, _ := decodeWSLStage(t, data)
+		if len(command) > 1800 {
+			t.Fatalf("renewal stages %d bytes; want compact marker-only helper", len(command))
+		}
+		if timing.operation < 86*time.Second {
+			t.Fatalf("renewal guard=%s; want load allowance", timing.operation)
+		}
+		if strings.Contains(command, "base64") || strings.Contains(command, "ps -") {
+			t.Fatal("renewal repeats script staging or inspects processes")
+		}
+	})
+	installWorkspaceOwnerRecordingSSH(t)
+	t.Setenv("CRABBOX_OWNER_SSH_SUCCESS_STDOUT", "RENEWED")
+	if got, err := (sshWorkspaceOwnerTransport{target: target}).Do(t.Context(), req); err != nil || got != "RENEWED" {
+		t.Fatalf("response=%q err=%v", got, err)
+	}
+}
+
+func TestWorkspaceOwnerWSL2RenewalRetriesOnlyConfirmedContention(t *testing.T) {
+	for _, tc := range []struct {
+		name, response, code string
+		calls                int
+		recovered            bool
+	}{
+		{"slow lock recovers", "BUSY", "0", 2, true},
+		{"lock remains busy", "BUSY", "0", 3, false},
+		{"transport lost", "", "255", 1, false},
+		{"busy with failed transport", "BUSY", "1", 1, false},
+		{"token lost", "MISMATCH", "75", 1, false},
+		{"expired", "EXPIRED", "75", 1, false},
+		{"ambiguous", "AMBIGUOUS", "74", 1, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := installWorkspaceOwnerRecordingSSH(t)
+			t.Setenv("CRABBOX_OWNER_SSH_FAIL_CALL", "1")
+			t.Setenv("CRABBOX_OWNER_SSH_FAIL_CODE", tc.code)
+			t.Setenv("CRABBOX_OWNER_SSH_FAIL_STDOUT", tc.response)
+			next := tc.response
+			if tc.recovered {
+				next = "RENEWED"
+			}
+			t.Setenv("CRABBOX_OWNER_SSH_SUCCESS_STDOUT", next)
+			stages := 0
+			var deadline time.Time
+			captureWSLStage(t, strings.Repeat("a", 32), func(_ *wslStageSpool, _ *SSHTarget, _ wslStageTiming, _ []byte) { stages++ })
+			target := SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2, Port: "22", FallbackPorts: []string{}}
+			transport := sshWorkspaceOwnerTransport{target: target}
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			owner := &workspaceOwner{target: target, key: workspaceOwnerKey("cbx_busy"), token: strings.Repeat("a", 64), ttl: 10 * time.Minute, ctx: ctx, cancel: cancel, stop: make(chan struct{}), done: make(chan struct{})}
+			owner.transport = budgetedWSL2OwnerTestTransport{workspaceOwnerTransportFunc(func(ctx context.Context, req workspaceOwnerRemoteRequest) (string, error) {
+				deadline, _ = ctx.Deadline()
+				got, err := transport.Do(ctx, req)
+				if tc.recovered {
+					close(owner.stop)
+				}
+				return got, err
+			}), transport.CallBudget()}
+			ticks := make(chan time.Time, 1)
+			ticks <- time.Now()
+			owner.renewLoopWithTicks(ticks, transport.CallBudget())
+			count, err := os.ReadFile(filepath.Join(dir, "count"))
+			sshCalls := tc.calls
+			if tc.code != "0" {
+				sshCalls++
+			} // Exact stage cleanup after failed execution.
+			if err != nil || string(count) != fmt.Sprint(sshCalls) || stages != tc.calls {
+				t.Fatalf("SSH=%s stages=%d err=%v", count, stages, err)
+			}
+			if deadline.IsZero() || time.Until(deadline) > owner.ttl {
+				t.Fatal("retry escaped owner expiry window")
+			}
+			if tc.recovered {
+				if owner.Err() != nil || ctx.Err() != nil {
+					t.Fatalf("successful retry canceled owner: %v", owner.Err())
+				}
+			} else {
+				if owner.Err() == nil || ctx.Err() != context.Canceled {
+					t.Fatalf("failed renewal did not cancel workload: %v", owner.Err())
+				}
+				if owner.ConfirmNoChild(t.Context()) != owner.Err() {
+					t.Fatal("collection ignored lost ownership")
+				}
+			}
+		})
+	}
+}
+
+func TestWorkspaceOwnerWSL2RenewalMarkerProtocol(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX shell")
+	}
+	token := strings.Repeat("a", 64)
+	for _, tc := range []struct {
+		name, marker, lockCode, want string
+		changes                      bool
+	}{
+		{"owned", "v1\n" + token + "\n4102444800\n", "0", "RENEWED", true},
+		{"mismatch", "v1\n" + strings.Repeat("b", 64) + "\n4102444800\n", "0", "MISMATCH", false},
+		{"expired", "v1\n" + token + "\n1\n", "0", "EXPIRED", false},
+		{"malformed", "v1\n" + token + "\ninvalid\n", "0", "AMBIGUOUS", false},
+		{"missing expiry", "v1\n" + token + "\n", "0", "AMBIGUOUS", false},
+		{"busy", "v1\n" + token + "\n4102444800\n", "75", "BUSY", false},
+		{"lock failure", "v1\n" + token + "\n4102444800\n", "73", "AMBIGUOUS", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			root := filepath.Join(home, ".crabbox", "workspace-owners")
+			if err := os.MkdirAll(root, 0700); err != nil {
+				t.Fatal(err)
+			}
+			key := workspaceOwnerKey("cbx_marker")
+			state := filepath.Join(root, key+".owner")
+			if err := os.WriteFile(state, []byte(tc.marker), 0600); err != nil {
+				t.Fatal(err)
+			}
+			bin := t.TempDir()
+			writeExecutable(t, filepath.Join(bin, "flock"), "#!/bin/sh\nexit "+tc.lockCode+"\n")
+			t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+			command := remoteWorkspaceOwnerCommand(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, workspaceOwnerRemoteRequest{Action: workspaceOwnerRenew, Key: key, Token: token, TTL: time.Minute})
+			got, err := runPOSIXWorkspaceOwnerScript(t, home, command)
+			if got != tc.want || (err == nil) != (tc.want == "RENEWED" || tc.want == "BUSY") {
+				t.Fatalf("got=%q err=%v want=%s", got, err, tc.want)
+			}
+			after, err := os.ReadFile(state)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if (string(after) != tc.marker) != tc.changes {
+				t.Fatal("unexpected marker mutation")
+			}
+			info, err := os.Stat(state)
+			if err != nil || info.Mode().Perm() != 0600 {
+				t.Fatal("marker permissions changed")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Keep workspace-owner renewal responsive while a WSL2 workload consumes CPU and disk. Use a compact marker-only renewal helper with a finite 60-second execution allowance, preserving the existing gate, fencing token, expiry, and child-ownership checks. Retry confirmed gate contention at most twice within one call deadline. Transport failures, lost/expired tokens, and ambiguous state still cancel the workload and prevent collection.

## Root cause

Renewal used the complete 6,795-byte POSIX owner protocol inside a secondary encoded script launcher. The 12-second control work allowance became a 38-second guest operation watchdog including startup/cleanup allowances (`internal/cli/ssh_wsl_stage.go:126-142`, enforced by `internal/cli/scripts/wsl-owner.ps1:100-110`). Heavy WSL2 workloads could exhaust that watchdog despite the larger outer transport deadline. One failed renewal then canceled the owner context and blocked result collection.

The WSL2-specific helper removes redundant script staging and unrelated child-inspection code, reads the marker with shell builtins, and renews atomically under the same lock. Its 60-second allowance becomes an 86-second guest operation guard and is included in caller/owner TTL accounting. Confirmed lock contention can retry only inside the original finite call. Linux and native Windows paths are unchanged; no provider or Node-bootstrap changes.

## Verification

- Clean committed CLI build with `/opt/homebrew/bin/go build -trimpath`; `gofmt -l` over all tracked Go files was empty; `go vet ./...` passed.
- Focused race tests passed: `go test -race ./internal/cli -run 'TestWorkspaceOwner|TestWSLStage|TestSSHTransportTiming' -count=1 -timeout=10m` (55.766s). No full local race suite.
- Regression tests copied onto original main fail on the 6,795-byte payload and missing bounded lock-contention retries. Token mismatch, expiry, transport loss, ambiguous state, exhausted contention, and collection refusal remain covered.
- Live AWS tiny `m8i.large`, Windows WSL2, public network, Tailscale disabled: warmup and inspect ready; `run --script-stdin` installed `build-essential`, then performed 267 C compile/run plus 2 GiB `dd` iterations over 7m00.65s. Output streamed, `uname -a` printed, the CLI returned **23**, and owner release succeeded. Post-run inspect reports ready.
- Post-run `run -- uname -a` returned **0** and released its owner. Both AWS leases were stopped; the final AWS list contains **zero** leases with the task slug prefix or either lease ID.
- AWS Linux tiny sanity `run -- uname -a` returned 0 and its lease was released.
- Autoreview completed with no accepted/actionable P0 findings. Full Linux CI passed on the final head, including the race suite and coverage: https://github.com/openclaw/crabbox/actions/runs/34266457688.

## Configuration, secrets, and limitations

No new configuration, permissions, secrets, bootstrap runtimes, or version changes. WSL2 owner expiry/call budgets include the longer finite renewal allowance, increasing the bounded stale-owner recovery window. Tokens remain in private staged input with existing diagnostic redaction.

The deliberate nonzero workload triggered the existing automatic failure bundle. Its remote script and manifest downloaded successfully, but the separate 10-second remote-cleanup deadline timed out (`internal/cli/run_observability.go:1375-1393`). This emitted a warning without changing exit 23 or preventing owner release; lease destruction removes the remaining temporary data. Coordinator heartbeat transport warnings and a hydration stop-marker timeout also occurred; provider deletion and the empty task inventory were independently confirmed. These warnings are recorded in the local redacted proof transcript.
