### PR TITLE
fix(wsl2): run managed workloads as a non-root worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-- Run managed WSL2 workloads as the non-root `crabbox` user with passwordless sudo, writable work/cache directories, and the shared Node baseline on PATH. PR link pending.
+- Run managed WSL2 workloads as the non-root `crabbox` user with passwordless sudo, writable work/cache directories, and the shared Node baseline on PATH. https://github.com/openclaw/crabbox/pull/2016. Thanks @steipete.
 
-- Keep managed WSL2 distributions alive between commands so detached Linux daemons survive until lease cleanup; preserve command and ownership deadlines. PR link pending.
+- Keep managed WSL2 distributions alive between commands so detached Linux daemons survive until lease cleanup; preserve command and ownership deadlines. https://github.com/openclaw/crabbox/pull/2016. Thanks @steipete.
 
 - Install the shared Linux Node/npm baseline during managed WSL2 bootstrap and require both tools for readiness. https://github.com/openclaw/crabbox/pull/2008. Thanks @steipete.
 - Keep WSL2 workspace-owner renewal small and allow bounded workload contention without weakening token, expiry, or child-state checks. https://github.com/openclaw/crabbox/pull/2011. Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Run managed WSL2 workloads as the non-root `crabbox` user with passwordless sudo, writable work/cache directories, and the shared Node baseline on PATH. PR link pending.
+
 - Keep managed WSL2 distributions alive between commands so detached Linux daemons survive until lease cleanup; preserve command and ownership deadlines. PR link pending.
 
 - Install the shared Linux Node/npm baseline during managed WSL2 bootstrap and require both tools for readiness. https://github.com/openclaw/crabbox/pull/2008. Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Keep managed WSL2 distributions alive between commands so detached Linux daemons survive until lease cleanup; preserve command and ownership deadlines. PR link pending.
+
 - Install the shared Linux Node/npm baseline during managed WSL2 bootstrap and require both tools for readiness. https://github.com/openclaw/crabbox/pull/2008. Thanks @steipete.
 - Keep WSL2 workspace-owner renewal small and allow bounded workload contention without weakening token, expiry, or child-state checks. https://github.com/openclaw/crabbox/pull/2011. Thanks @steipete.
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -61,6 +61,11 @@ policy; Crabbox's staged scripts, input, and workspace-owner state remain privat
 Keeping or reusing a POSIX SSH lease also preserves the remote caller's SIGINT
 and SIGQUIT dispositions, including intentionally ignored signals.
 
+Managed WSL2 commands, sync/copy, readiness checks, and workspace-owner helpers
+run as the non-root `crabbox` distro user with `HOME=/home/crabbox`, passwordless
+sudo, and a writable work root and caches. Node and npm remain on the default
+PATH. Bootstrap alone runs as root; the Windows SSH account is unchanged.
+
 Managed WSL2 leases disable WSL's distribution idle shutdown with
 `[general] instanceIdleTimeout=-1` in the bootstrap user's `.wslconfig`.
 Detached Linux daemons can therefore outlive individual commands until the

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -61,6 +61,13 @@ policy; Crabbox's staged scripts, input, and workspace-owner state remain privat
 Keeping or reusing a POSIX SSH lease also preserves the remote caller's SIGINT
 and SIGQUIT dispositions, including intentionally ignored signals.
 
+Managed WSL2 leases disable WSL's distribution idle shutdown with
+`[general] instanceIdleTimeout=-1` in the bootstrap user's `.wslconfig`.
+Detached Linux daemons can therefore outlive individual commands until the
+lease is stopped. This does not change command deadlines, workspace ownership,
+or lease expiration. Headless leases also disable WSLg; other WSL settings,
+including the separate VM idle policy, are preserved.
+
 Local Ctrl+C cancels the CLI's non-interactive SSH connection; it does not
 guarantee that the remote foreground process has stopped. A retained lease can
 therefore remain busy until that process exits. Crabbox preserves child

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -317,6 +317,15 @@ readiness preflight, API, AWS-GO gate, and live canary are in
 | Windows WSL2 | `--windows-mode wsl2`; launches on nested-virtualization families (`c8i`/`m8i`/`m8i-flex`/`r8i`); POSIX sync and commands run inside WSL with the Linux image Node/npm baseline. |
 | macOS | Requires an available EC2 Mac Dedicated Host in the region; On-Demand only. Admin-authenticated broker requests can pin any host with `CRABBOX_HOST_ID` / `aws.macHostId` (`CRABBOX_AWS_MAC_HOST_ID` is a legacy alias); normal broker users can pin only a host from their own released lease and otherwise use automatic discovery. |
 
+Managed WSL2 commands run as the non-root `crabbox` Linux user, with
+`HOME=/home/crabbox`, Bash, passwordless sudo, and membership in the `sudo` and
+`docker` groups. This user owns the work root and `/var/cache/crabbox`.
+Bootstrap sets `[user] default=crabbox` in `/etc/wsl.conf`, preserving other
+distro settings, so staged commands, WSL sessions, sync/copy, readiness, and
+workspace ownership share one identity. Root is used only for distro setup;
+the Windows SSH transport account is unchanged. Existing leases need
+reprovisioning to receive this setup.
+
 Managed WSL2 bootstrap runs the Node-only entrypoint of
 `scripts/install-linux-developer-tools.sh`, bundled in the CLI/coordinator rather
 than downloaded at boot. It uses the same Node major policy and, on the managed
@@ -334,6 +343,10 @@ This avoids WSL datasource discovery blocking systemd and root login during
 later command invocations. Bootstrap restarts the distro and verifies its Linux
 ready check before publishing the setup marker; warmup also checks the WSL SSH
 runtime. `inspect` and `status` allow a 30-second WSL2 readiness probe.
+
+Managed WSL2 leases set `[general] instanceIdleTimeout=-1` in the Windows SSH
+user's `.wslconfig` so detached Linux daemons survive between commands until
+lease cleanup. Command deadlines and lease expiration still apply.
 
 Headless managed WSL2 leases also disable WSLg with `guiApplications=false` in
 the Windows SSH user's `.wslconfig`, preserving other settings. The GUI/RDP

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -279,10 +279,43 @@ Acquire::https::Timeout "30";
 APT
 rm -rf /var/lib/apt/lists/*
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl git jq python3-minimal rsync
+apt-get install -y --no-install-recommends ca-certificates curl git jq python3 rsync sudo
+if ! id -u crabbox >/dev/null 2>&1; then
+  useradd --create-home --user-group --shell /bin/bash crabbox
+fi
+groupadd -f docker
+usermod --append --groups sudo,docker --shell /bin/bash crabbox
+test "$(id -u crabbox)" -ne 0
+install -d -m 0755 /etc/sudoers.d
+printf '%s\n' 'crabbox ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/crabbox
+chmod 0440 /etc/sudoers.d/crabbox
+visudo -cf /etc/sudoers.d/crabbox
+chown -R crabbox:crabbox ` + shellQuote(workRoot) + ` /var/cache/crabbox
+# All WSL transports inherit this identity, including staged helpers and rsync.
+# Preserve the distro's boot, automount, networking, and interop settings.
+python3 - <<'WSL_USER'
+import configparser
+from pathlib import Path
+path = Path('/etc/wsl.conf')
+config = configparser.ConfigParser(interpolation=None)
+config.optionxform = str
+config.read(path)
+if not config.has_section('user'):
+    config.add_section('user')
+config.set('user', 'default', 'crabbox')
+with path.open('w') as output:
+    config.write(output, space_around_delimiters=False)
+WSL_USER
 ` + sharedLinuxNodeInstall() + sharedWslTruffleHogInstall() + `cat >/usr/local/bin/crabbox-ready <<'READY'
 #!/usr/bin/env bash
 set -euo pipefail
+test "$(id -u)" -ne 0
+test "$(id -un)" = crabbox
+test "$HOME" = /home/crabbox
+test -w "$HOME"
+sudo -n true
+test -w /var/cache/crabbox/npm
+test -w /var/cache/crabbox/pnpm
 git --version >/dev/null
 python3 --version >/dev/null
 rsync --version >/dev/null
@@ -296,7 +329,7 @@ test -w ` + shellQuote(workRoot) + `
 READY
 chmod 0755 /usr/local/bin/crabbox-ready
 touch /var/lib/crabbox/bootstrapped
-crabbox-ready
+sudo -H -u crabbox /usr/local/bin/crabbox-ready
 '@
 	$linuxSetup = $linuxSetup.Replace(([string][char]13 + [string][char]10), ([string][char]10))
 	[IO.File]::WriteAllText($wslSetup, $linuxSetup, (New-Object Text.UTF8Encoding($false)))
@@ -304,7 +337,7 @@ crabbox-ready
 	if ($LASTEXITCODE -ne 0) { throw "WSL setup failed with exit $LASTEXITCODE" }
 	wsl.exe --terminate $wslDistro | Out-Host
 	if ($LASTEXITCODE -ne 0) { throw "WSL restart failed with exit $LASTEXITCODE" }
-	wsl.exe -d $wslDistro --user root --exec /usr/local/bin/crabbox-ready
+	wsl.exe -d $wslDistro --exec /usr/local/bin/crabbox-ready
 	if ($LASTEXITCODE -ne 0) { throw "WSL cold-start readiness failed with exit $LASTEXITCODE" }
 	Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")
 	Restart-Service sshd -Force

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -180,11 +180,12 @@ func windowsWSL2BootstrapPowerShell(cfg Config) string {
 	workRoot := windowsWSLWorkRoot(cfg)
 	headless := ""
 	if !cfg.Desktop && !cfg.Browser {
-		headless = windowsWSL2HeadlessConfigPowerShell
+		// WSLg can stall headless distro launches from Windows service sessions.
+		headless = `$managedWSLConfig = Set-CrabboxWSLConfigValue $managedWSLConfig 'wsl2' 'guiApplications=false'`
 	}
 	return `
 	$wslConfigChanged = $false
-` + headless + `
+` + strings.ReplaceAll(windowsWSL2ConfigPowerShell, "@HEADLESS_CONFIG@", headless) + `
 	$wslDistro = "Crabbox"
 	$wslRoot = "C:\ProgramData\crabbox\wsl\Crabbox"
 	$wslRootfs = "C:\ProgramData\crabbox\wsl\ubuntu-noble-wsl-amd64.rootfs.tar.gz"
@@ -220,7 +221,7 @@ func windowsWSL2BootstrapPowerShell(cfg Config) string {
 	}
 	if ($wslConfigChanged) {
 	  wsl.exe --shutdown | Out-Host
-	  if ($LASTEXITCODE -ne 0) { throw "apply headless WSL configuration failed with exit $LASTEXITCODE" }
+	  if ($LASTEXITCODE -ne 0) { throw "apply managed WSL configuration failed with exit $LASTEXITCODE" }
 	}
 	wsl.exe --set-default-version 2 | Out-Host
 	if ($LASTEXITCODE -ne 0) { throw "wsl --set-default-version 2 failed with exit $LASTEXITCODE" }
@@ -310,39 +311,41 @@ crabbox-ready
 	`
 }
 
-// WSLg's RDP compositor is unnecessary for headless SSH leases and can crash
-// in Windows service sessions, leaving even non-GUI distro launches blocked.
-const windowsWSL2HeadlessConfigPowerShell = `
-function ConvertTo-CrabboxHeadlessWSLConfig([string]$Text) {
+// The lease owns distro lifetime: WSL's client-idle shutdown kills detached
+// daemons even while their Linux processes remain active. WSLg stays optional.
+const windowsWSL2ConfigPowerShell = `
+function Set-CrabboxWSLConfigValue([string]$Text, [string]$Section, [string]$Setting) {
   $result = [Collections.Generic.List[string]]::new()
-  $inWSL2 = $false
+  $inSection = $false
   $hasSection = $false
   $hasKey = $false
+  $keyPattern = '^\s*' + [Regex]::Escape(($Setting -split '=', 2)[0]) + '\s*='
   if ($Text.Length -gt 0) {
     foreach ($line in ($Text -split '\r?\n')) {
       if ($line -match '^\s*\[([^\]]+)\]\s*(?:[;#].*)?$') {
-        if ($inWSL2 -and -not $hasKey) { $result.Add('guiApplications=false') }
-        $inWSL2 = $Matches[1].Trim() -eq 'wsl2'
-        $hasSection = $hasSection -or $inWSL2
+        if ($inSection -and -not $hasKey) { $result.Add($Setting) }
+        $inSection = $Matches[1].Trim() -eq $Section
+        $hasSection = $hasSection -or $inSection
         $hasKey = $false
       }
-      if ($inWSL2 -and $line -match '^\s*guiApplications\s*=') {
-        $result.Add('guiApplications=false')
+      if ($inSection -and $line -match $keyPattern) {
+        $result.Add($Setting)
         $hasKey = $true
       } else { $result.Add($line) }
     }
   }
-  if (-not $hasSection) { $result.Add('[wsl2]'); $inWSL2 = $true; $hasKey = $false }
-  if ($inWSL2 -and -not $hasKey) { $result.Add('guiApplications=false') }
+  if (-not $hasSection) { $result.Add('[' + $Section + ']'); $inSection = $true; $hasKey = $false }
+  if ($inSection -and -not $hasKey) { $result.Add($Setting) }
   return $result -join [char]10
 }
 $wslConfigPath = Join-Path $HOME '.wslconfig'
 $wslConfig = ''
 if (Test-Path -LiteralPath $wslConfigPath) { $wslConfig = [IO.File]::ReadAllText($wslConfigPath) }
-$headlessWSLConfig = ConvertTo-CrabboxHeadlessWSLConfig $wslConfig
-$wslConfigChanged = $headlessWSLConfig -cne $wslConfig
+$managedWSLConfig = Set-CrabboxWSLConfigValue $wslConfig 'general' 'instanceIdleTimeout=-1'
+@HEADLESS_CONFIG@
+$wslConfigChanged = $managedWSLConfig -cne $wslConfig
 if ($wslConfigChanged) {
-  [IO.File]::WriteAllText($wslConfigPath, $headlessWSLConfig, [Text.UTF8Encoding]::new($false))
+  [IO.File]::WriteAllText($wslConfigPath, $managedWSLConfig, [Text.UTF8Encoding]::new($false))
 }
 `
 

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -863,7 +863,7 @@ func TestAWSUserDataWindowsWSL2Profile(t *testing.T) {
 		`$wslSetup = "C:\ProgramData\crabbox\wsl\linux-setup.sh"`,
 		"WriteAllText($wslSetup",
 		"wsl.exe -d $wslDistro --user root --exec bash /mnt/c/ProgramData/crabbox/wsl/linux-setup.sh",
-		"apt-get install -y --no-install-recommends ca-certificates curl git jq python3-minimal rsync",
+		"apt-get install -y --no-install-recommends ca-certificates curl git jq python3 rsync sudo",
 		"trufflehog_version='3.95.9'",
 		"trufflehog_${trufflehog_version}_linux_amd64.tar.gz",
 		wslTruffleHogAMD64SHA256,
@@ -942,7 +942,7 @@ func TestManagedWindowsWSL2BootstrapOwnsDistroInitialization(t *testing.T) {
 			steps := []string{
 				"touch /etc/cloud/cloud-init.disabled",
 				"wsl.exe --terminate $wslDistro",
-				"wsl.exe -d $wslDistro --user root --exec /usr/local/bin/crabbox-ready",
+				"wsl.exe -d $wslDistro --exec /usr/local/bin/crabbox-ready",
 				"WSL cold-start readiness failed with exit $LASTEXITCODE",
 				"Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath",
 			}

--- a/internal/cli/bootstrap_wsl_config_test.go
+++ b/internal/cli/bootstrap_wsl_config_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func TestManagedHeadlessWSLDisablesGUIBeforeLaunch(t *testing.T) {
+func TestManagedWSLConfigBeforeLaunch(t *testing.T) {
 	for _, test := range []struct {
 		name, target, mode string
 		desktop, browser   bool
@@ -32,21 +32,25 @@ func TestManagedHeadlessWSLDisablesGUIBeforeLaunch(t *testing.T) {
 			if got := strings.Contains(script, "guiApplications=false"); got != test.want {
 				t.Fatalf("headless WSL policy present=%t, want %t", got, test.want)
 			}
-			if test.want {
+			wsl := test.target == targetWindows && test.mode == windowsModeWSL2
+			if got := strings.Contains(script, "instanceIdleTimeout=-1"); got != wsl {
+				t.Fatalf("managed distro lifetime policy present=%t, want %t", got, wsl)
+			}
+			if wsl {
 				write := strings.Index(script, "[IO.File]::WriteAllText($wslConfigPath")
 				update := strings.Index(script, "wsl.exe --update")
 				shutdown := strings.Index(script, "wsl.exe --shutdown")
 				launch := strings.Index(script, "wsl.exe --set-default-version")
 				if write < 0 || update <= write || shutdown <= update || launch <= shutdown ||
 					!strings.Contains(script, "if ($wslConfigChanged)") {
-					t.Fatal("WSLg policy must precede installation and restart changed configurations before distro launch")
+					t.Fatal("WSL policy must precede installation and restart changed configurations before distro launch")
 				}
 			}
 		})
 	}
 }
 
-func TestHeadlessWSLConfigPreservesOtherSettings(t *testing.T) {
+func TestManagedWSLConfigPreservesOtherSettings(t *testing.T) {
 	powerShell, err := exec.LookPath("pwsh")
 	if err != nil {
 		powerShell, err = exec.LookPath("powershell.exe")
@@ -57,24 +61,33 @@ func TestHeadlessWSLConfigPreservesOtherSettings(t *testing.T) {
 	cfg := baseConfig()
 	cfg.TargetOS, cfg.WindowsMode = targetWindows, windowsModeWSL2
 	bootstrap := windowsWSL2BootstrapPowerShell(cfg)
-	start, end := strings.Index(bootstrap, "function ConvertTo-CrabboxHeadlessWSLConfig"), strings.Index(bootstrap, "$wslConfigPath =")
+	start, end := strings.Index(bootstrap, "function Set-CrabboxWSLConfigValue"), strings.Index(bootstrap, "$wslConfigPath =")
 	if start < 0 || end <= start {
-		t.Fatal("bootstrap does not configure the headless WSL runtime")
+		t.Fatal("bootstrap does not configure the managed WSL runtime")
 	}
-	for _, test := range []struct{ name, input, want string }{
-		{"missing file", "", "[wsl2]\nguiApplications=false"},
-		{"already disabled", "[wsl2]\nguiApplications=false\n", "[wsl2]\nguiApplications=false\n"},
-		{"preserve memory", "[wsl2]\nmemory=4GB\nguiApplications=true\n", "[wsl2]\nmemory=4GB\nguiApplications=false\n"},
-		{"other section", "[experimental]\nsparseVhd=true", "[experimental]\nsparseVhd=true\n[wsl2]\nguiApplications=false"},
-		{"insert before next section", "[wsl2]\nmemory=4GB\n[experimental]\nsparseVhd=true", "[wsl2]\nmemory=4GB\nguiApplications=false\n[experimental]\nsparseVhd=true"},
-		{"case whitespace comments", "; keep\r\n [WSL2] ; keep\r\n GUIAPPLICATIONS = true\r\nprocessors=2", "; keep\n [WSL2] ; keep\nguiApplications=false\nprocessors=2"},
-		{"same key in other section", "[other]\nguiApplications=true\n[wsl2]\nguiApplications=true", "[other]\nguiApplications=true\n[wsl2]\nguiApplications=false"},
-		{"duplicate sections", "[wsl2]\nmemory=4GB\n[wsl2]\nguiApplications=true", "[wsl2]\nmemory=4GB\nguiApplications=false\n[wsl2]\nguiApplications=false"},
+	for _, test := range []struct{ name, section, setting, input, want string }{
+		{"missing file", "wsl2", "guiApplications=false", "", "[wsl2]\nguiApplications=false"},
+		{"already disabled", "wsl2", "guiApplications=false", "[wsl2]\nguiApplications=false\n", "[wsl2]\nguiApplications=false\n"},
+		{"preserve memory", "wsl2", "guiApplications=false", "[wsl2]\nmemory=4GB\nguiApplications=true\n", "[wsl2]\nmemory=4GB\nguiApplications=false\n"},
+		{"other section", "wsl2", "guiApplications=false", "[experimental]\nsparseVhd=true", "[experimental]\nsparseVhd=true\n[wsl2]\nguiApplications=false"},
+		{"insert before next section", "wsl2", "guiApplications=false", "[wsl2]\nmemory=4GB\n[experimental]\nsparseVhd=true", "[wsl2]\nmemory=4GB\nguiApplications=false\n[experimental]\nsparseVhd=true"},
+		{"case whitespace comments", "wsl2", "guiApplications=false", "; keep\r\n [WSL2] ; keep\r\n GUIAPPLICATIONS = true\r\nprocessors=2", "; keep\n [WSL2] ; keep\nguiApplications=false\nprocessors=2"},
+		{"same key in other section", "wsl2", "guiApplications=false", "[other]\nguiApplications=true\n[wsl2]\nguiApplications=true", "[other]\nguiApplications=true\n[wsl2]\nguiApplications=false"},
+		{"duplicate sections", "wsl2", "guiApplications=false", "[wsl2]\nmemory=4GB\n[wsl2]\nguiApplications=true", "[wsl2]\nmemory=4GB\nguiApplications=false\n[wsl2]\nguiApplications=false"},
+		{"lifetime missing file", "general", "instanceIdleTimeout=-1", "", "[general]\ninstanceIdleTimeout=-1"},
+		{"lifetime already disabled", "general", "instanceIdleTimeout=-1", "[general]\ninstanceIdleTimeout=-1\n", "[general]\ninstanceIdleTimeout=-1\n"},
+		{"lifetime preserve VM policy", "general", "instanceIdleTimeout=-1", "[wsl2]\nvmIdleTimeout=60000\nguiApplications=true", "[wsl2]\nvmIdleTimeout=60000\nguiApplications=true\n[general]\ninstanceIdleTimeout=-1"},
+		{"lifetime replace default", "general", "instanceIdleTimeout=-1", "[general]\ninstanceIdleTimeout=15000\n[experimental]\nsparseVhd=true", "[general]\ninstanceIdleTimeout=-1\n[experimental]\nsparseVhd=true"},
+		{"lifetime insert before next section", "general", "instanceIdleTimeout=-1", "[general]\ndistributionInstallPath=C:\\distros\n[wsl2]\nmemory=4GB", "[general]\ndistributionInstallPath=C:\\distros\ninstanceIdleTimeout=-1\n[wsl2]\nmemory=4GB"},
+		{"lifetime case whitespace comments", "general", "instanceIdleTimeout=-1", "; keep\r\n [GENERAL] ; keep\r\n INSTANCEIDLETIMEOUT = 15000", "; keep\n [GENERAL] ; keep\ninstanceIdleTimeout=-1"},
+		{"lifetime same key in other section", "general", "instanceIdleTimeout=-1", "[other]\ninstanceIdleTimeout=15000\n[general]\ninstanceIdleTimeout=1000", "[other]\ninstanceIdleTimeout=15000\n[general]\ninstanceIdleTimeout=-1"},
+		{"lifetime duplicate sections and keys", "general", "instanceIdleTimeout=-1", "[general]\n[general]\ninstanceIdleTimeout=1000\ninstanceIdleTimeout=15000", "[general]\ninstanceIdleTimeout=-1\n[general]\ninstanceIdleTimeout=-1\ninstanceIdleTimeout=-1"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			script := bootstrap[start:end] + "\n$first = ConvertTo-CrabboxHeadlessWSLConfig " + psQuote(test.input) + `
-$second = ConvertTo-CrabboxHeadlessWSLConfig $first
-@{first=$first;second=$second} | ConvertTo-Json -Compress`
+			arguments := " " + psQuote(test.section) + " " + psQuote(test.setting)
+			script := bootstrap[start:end] + "\n$first = Set-CrabboxWSLConfigValue " + psQuote(test.input) + arguments +
+				"\n$second = Set-CrabboxWSLConfigValue $first" + arguments +
+				"\n@{first=$first;second=$second} | ConvertTo-Json -Compress"
 			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 			defer cancel()
 			out, err := exec.CommandContext(ctx, powerShell, "-NoProfile", "-NonInteractive", "-Command", script).CombinedOutput()

--- a/internal/cli/bootstrap_wsl_user_test.go
+++ b/internal/cli/bootstrap_wsl_user_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -76,6 +77,10 @@ func wslBootstrapHereDoc(t *testing.T, marker string) string {
 
 func TestManagedWSLDefaultUserPreservesDistroSettings(t *testing.T) {
 	script := wslBootstrapHereDoc(t, "WSL_USER")
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("Python is unavailable")
+	}
 	for _, test := range []struct{ name, input string }{
 		{"missing", ""},
 		{"existing", "[boot]\nsystemd=true\n[automount]\nmountFsTab=false\n[interop]\nappendWindowsPath=false\n[user]\ndefault=root\n"},
@@ -87,10 +92,10 @@ func TestManagedWSLDefaultUserPreservesDistroSettings(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			command := strings.Replace(script, "/etc/wsl.conf", path, 1)
+			command := strings.Replace(script, "Path('/etc/wsl.conf')", "Path(__import__('sys').argv[1])", 1)
 			var previous string
 			for pass := 0; pass < 2; pass++ {
-				if out, err := exec.CommandContext(t.Context(), "python3", "-c", command).CombinedOutput(); err != nil {
+				if out, err := exec.CommandContext(t.Context(), python, "-c", command, path).CombinedOutput(); err != nil {
 					t.Fatalf("configure default user: %v: %s", err, out)
 				}
 				data, err := os.ReadFile(path)
@@ -111,6 +116,9 @@ func TestManagedWSLDefaultUserPreservesDistroSettings(t *testing.T) {
 }
 
 func TestManagedWSLReadinessRequiresWorkerIdentity(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executes POSIX readiness fixtures locally")
+	}
 	ready := wslBootstrapHereDoc(t, "READY")
 	for _, test := range []struct{ name, uid, user, home, failingTool string }{
 		{"worker", "1001", "crabbox", "worker", ""},

--- a/internal/cli/bootstrap_wsl_user_test.go
+++ b/internal/cli/bootstrap_wsl_user_test.go
@@ -1,0 +1,153 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestManagedWSLWorkerIdentity(t *testing.T) {
+	for _, test := range []struct{ name, target, mode string }{
+		{"linux", targetLinux, ""},
+		{"native windows", targetWindows, windowsModeNormal},
+		{"wsl2", targetWindows, windowsModeWSL2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := baseConfig()
+			cfg.TargetOS, cfg.WindowsMode = test.target, test.mode
+			cfg.WorkRoot = "/work/custom root"
+			script := cloudInit(cfg, "ssh-ed25519 test")
+			if test.target == targetWindows {
+				script = windowsBootstrapPowerShell(cfg, "ssh-ed25519 test")
+			}
+			steps := []string{
+				"useradd --create-home --user-group --shell /bin/bash crabbox",
+				"groupadd -f docker",
+				"usermod --append --groups sudo,docker --shell /bin/bash crabbox",
+				"test \"$(id -u crabbox)\" -ne 0",
+				"'crabbox ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/crabbox",
+				"chmod 0440 /etc/sudoers.d/crabbox",
+				"visudo -cf /etc/sudoers.d/crabbox",
+				"chown -R crabbox:crabbox '/work/custom root' /var/cache/crabbox",
+				"config.set('user', 'default', 'crabbox')",
+				"sudo -H -u crabbox /usr/local/bin/crabbox-ready",
+				"wsl.exe -d $wslDistro --user root --exec bash /mnt/c/ProgramData/crabbox/wsl/linux-setup.sh",
+				"wsl.exe --terminate $wslDistro",
+				"wsl.exe -d $wslDistro --exec /usr/local/bin/crabbox-ready",
+			}
+			last := -1
+			for _, step := range steps {
+				index := strings.Index(script, step)
+				if test.mode != windowsModeWSL2 {
+					if index >= 0 {
+						t.Fatalf("WSL worker setup leaked into %s: %s", test.name, step)
+					}
+					continue
+				}
+				if index <= last {
+					t.Fatalf("missing or out-of-order worker setup: %s", step)
+				}
+				last = index
+			}
+			if test.mode == windowsModeWSL2 && strings.Count(script, "--user root") != 1 {
+				t.Fatal("only Linux bootstrap may explicitly select root")
+			}
+		})
+	}
+}
+
+func wslBootstrapHereDoc(t *testing.T, marker string) string {
+	t.Helper()
+	cfg := baseConfig()
+	cfg.TargetOS, cfg.WindowsMode = targetWindows, windowsModeWSL2
+	script := windowsBootstrapPowerShell(cfg, "ssh-ed25519 test")
+	_, body, ok := strings.Cut(script, "<<'"+marker+"'\n")
+	if !ok {
+		t.Fatalf("missing %s heredoc", marker)
+	}
+	body, _, ok = strings.Cut(body, "\n"+marker+"\n")
+	if !ok {
+		t.Fatalf("unterminated %s heredoc", marker)
+	}
+	return body
+}
+
+func TestManagedWSLDefaultUserPreservesDistroSettings(t *testing.T) {
+	script := wslBootstrapHereDoc(t, "WSL_USER")
+	for _, test := range []struct{ name, input string }{
+		{"missing", ""},
+		{"existing", "[boot]\nsystemd=true\n[automount]\nmountFsTab=false\n[interop]\nappendWindowsPath=false\n[user]\ndefault=root\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "wsl.conf")
+			if test.input != "" {
+				if err := os.WriteFile(path, []byte(test.input), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			command := strings.Replace(script, "/etc/wsl.conf", path, 1)
+			var previous string
+			for pass := 0; pass < 2; pass++ {
+				if out, err := exec.CommandContext(t.Context(), "python3", "-c", command).CombinedOutput(); err != nil {
+					t.Fatalf("configure default user: %v: %s", err, out)
+				}
+				data, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := "[user]\ndefault=crabbox\n\n"
+				if test.input != "" {
+					want = "[boot]\nsystemd=true\n\n[automount]\nmountFsTab=false\n\n[interop]\nappendWindowsPath=false\n\n" + want
+				}
+				if string(data) != want || (pass > 0 && string(data) != previous) {
+					t.Fatalf("pass %d config=%q, want %q", pass, data, want)
+				}
+				previous = string(data)
+			}
+		})
+	}
+}
+
+func TestManagedWSLReadinessRequiresWorkerIdentity(t *testing.T) {
+	ready := wslBootstrapHereDoc(t, "READY")
+	for _, test := range []struct{ name, uid, user, home, failingTool string }{
+		{"worker", "1001", "crabbox", "worker", ""},
+		{"root", "0", "crabbox", "worker", ""},
+		{"wrong user", "1001", "ubuntu", "worker", ""},
+		{"wrong home", "1001", "crabbox", "other", ""},
+		{"sudo unavailable", "1001", "crabbox", "worker", "sudo"},
+		{"node unavailable", "1001", "crabbox", "worker", "node"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			bin := filepath.Join(root, "bin")
+			if err := os.Mkdir(bin, 0700); err != nil {
+				t.Fatal(err)
+			}
+			for _, tool := range []string{"id", "sudo", "git", "python3", "rsync", "curl", "jq", "trufflehog", "node", "npm", "wslpath"} {
+				body := "#!/bin/sh\nexit 0\n"
+				if tool == "id" {
+					body = "#!/bin/sh\ncase $1 in -u) echo " + test.uid + ";; -un) echo " + test.user + ";; esac\n"
+				} else if tool == test.failingTool {
+					body = "#!/bin/sh\nexit 1\n"
+				}
+				if err := os.WriteFile(filepath.Join(bin, tool), []byte(body), 0700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			home := filepath.Join(root, "worker")
+			if err := os.Mkdir(home, 0700); err != nil {
+				t.Fatal(err)
+			}
+			script := strings.NewReplacer("/home/crabbox", home, "/work/crabbox", root, "/var/cache/crabbox/npm", root, "/var/cache/crabbox/pnpm", root).Replace(ready)
+			cmd := exec.CommandContext(t.Context(), "bash", "-c", script)
+			cmd.Env = []string{"PATH=" + bin, "HOME=" + filepath.Join(root, test.home)}
+			out, err := cmd.CombinedOutput()
+			if (err == nil) != (test.name == "worker") {
+				t.Fatalf("readiness error=%v output=%s", err, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Managed WSL2 workloads now run as the non-root `crabbox` user, and detached Linux daemons survive between staged commands until lease cleanup. The distro-lifetime fix remains the first commit; worker identity is the second. Follow-ups only add changelog links and portable test fixtures.

The imported distro had no managed Linux worker account, so the existing default-user WSL entry points inherited root; bootstrap also created root-owned work/cache directories and explicitly checked readiness as root. [Worker setup](https://github.com/openclaw/crabbox/blob/0aeff20e57c5c6fab2ee1c6f548e0d3c6f0d21d5/internal/cli/bootstrap.go#L283) now creates the home and Bash account, grants sudo/docker membership and passwordless sudo, owns the work/cache paths, and sets `[user] default=crabbox` in `/etc/wsl.conf` while preserving other distro settings. Cold-start readiness checks the actual default user's UID, username, HOME, sudo, caches, workroot, and Node/npm. The [staged launcher](https://github.com/openclaw/crabbox/blob/0aeff20e57c5c6fab2ee1c6f548e0d3c6f0d21d5/internal/cli/scripts/wsl-owner.ps1#L65), readiness, copy/sync, and workspace-owner paths already inherit this default, so no transport rewrite or provider-specific core branch is needed. Native Windows and Linux production paths are unchanged.

Separately, WSL's client-idle timer could stop the distro after a staged client exited even while detached Linux processes remained. [Managed configuration](https://github.com/openclaw/crabbox/blob/0aeff20e57c5c6fab2ee1c6f548e0d3c6f0d21d5/internal/cli/bootstrap.go#L377) now sets `[general] instanceIdleTimeout=-1`, preserving the VM idle setting and other configuration. Headless WSLg disabling is retained. Command deadlines, workspace-owner checks, and lease expiry are unchanged. This follows WSL's [default-user setting](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#user-settings) and [distribution idle policy](https://github.com/microsoft/WSL/issues/13291).

Verification:

- Built the CLI; `gofmt -l` clean; `go vet ./...`; `go test -race ./internal/cli/ -run 'WSL|Bootstrap'` passed. The test-only portability follow-up passed `go test -race ./internal/cli -run '^TestManagedWSL'`. No full local race suite; Linux CI is authoritative.
- New regressions fail through a Go overlay using the original bootstrap from https://github.com/openclaw/crabbox/pull/2008: missing lifetime policy/user creation and readiness incorrectly accepting root, wrong username/HOME, or unavailable sudo. Config preservation/idempotence and native Windows/Linux isolation are covered. Every commit passed autoreview at its default P0 threshold.
- Built-binary AWS WSL2 tiny/public/Tailscale-off warmup completed in 8m4s; `inspect` returned `ready: true`. The requested staged probe returned `1001`, `crabbox`, `/home/crabbox`, `sudo-ok`, Node `v24.19.0`, and `workroot-ok` with exit 0.
- Copy upload/download matched byte-for-byte. A 2,288-file/36.2-MiB sync completed. A subsequent successful staged script verified `crabbox:crabbox` ownership of the synced README, copied file, npm/pnpm caches, and workspace-owner directory; it also verified Bash, groups, Node's global PATH entry, and preserved systemd settings.
- `--script-stdin` started `setsid`/`nohup sleep 600` as UID 1001, PID 18107, and exited 0. After the CLI exited, no WSL calls were made for 76.423 seconds; the next `run --no-sync -- pgrep -f 'sleep 600'` found the same PID and exited 0. Final `run --no-sync -- uname -a` also exited 0, reporting kernel `6.18.33.2-microsoft-standard-WSL2`.
- Linux AWS tiny sanity returned UID 1000. Both task leases were stopped; the final AWS lease list contains neither task ID nor task slug.
- [CI on the final commit](https://github.com/openclaw/crabbox/actions/runs/34285732881) passed, including the full Linux race suite, executed supervision-fixture check, build, coverage, module tests, and native Windows cancellation checks. All validation checks passed.

Configuration/secret implications: no new CLI flags, credentials, secrets, or environment forwarding. Existing managed WSL2 leases need reprovisioning. Passwordless sudo is intentional Linux parity, not an additional containment boundary; the Windows SSH account stays unchanged. Documentation is updated in the AWS provider and run command guides, with both fixes in Unreleased.

Proof limitations and retries: this Mac lacked a supported rsync, so the initial copy correctly refused the WSL2 archive fallback; installing rsync 3.5.0 enabled the successful round trip. Overlapping copy/sync admission hit the claim-change guard and was retried sequentially. After the completed large sync and `uname` output, one final child-state check lost SFTP and the CLI exited 7 rather than collect/clean an ambiguous child; subsequent daemon, survival, and no-sync `uname` runs all completed normally. Tiny Windows staged runs took roughly three minutes each. Stop also logged a best-effort hydration stop-marker timeout before successfully releasing the WSL lease. No ownership guard or timeout was weakened. PowerShell-only unit fixtures skip on this Mac; live Windows bootstrap and daemon proof exercised the platform configuration.
