### PR TITLE
feat(tenki): support retry-safe cloud worker orchestration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@
 - Install the shared Linux Node/npm baseline during managed WSL2 bootstrap and require both tools for readiness. https://github.com/openclaw/crabbox/pull/2008. Thanks @steipete.
 - Keep WSL2 workspace-owner renewal small and allow bounded workload contention without weakening token, expiry, or child-state checks. https://github.com/openclaw/crabbox/pull/2011. Thanks @steipete.
 
-- Tenki: support fixed lease IDs for retry-safe worker allocation, report SSH readiness during inspection, and keep proxy connections working when sandbox host keys change. https://github.com/openclaw/crabbox/pull/2021.
-- Keep uploaded scripts in the selected workspace when a sandbox's login-shell startup changes directories, and let canceled fixed-ID allocations stop waiting for a busy claim lock. https://github.com/openclaw/crabbox/pull/2021.
-
 - Disable the unused WSLg compositor on headless managed Windows WSL2 leases to avoid service-session crashes that stall commands and workspace-owner renewal; preserve other WSL settings and existing execution deadlines. https://github.com/openclaw/crabbox/pull/2005. Thanks @steipete.
 
 - Fix managed Windows WSL2 command timeouts by disabling redundant cloud-init discovery, verifying cold-start readiness, and allowing a target-specific status probe budget for fixed-ID orchestrators. https://github.com/openclaw/crabbox/pull/1996. Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Tenki: support fixed lease IDs for retry-safe worker allocation, report SSH readiness during inspection, and keep proxy connections working when sandbox host keys change.
+- Keep uploaded scripts in the selected workspace when a sandbox's login-shell startup changes directories, and let canceled fixed-ID allocations stop waiting for a busy claim lock.
+
 - Install the shared Linux Node/npm baseline during managed WSL2 bootstrap and require both tools for readiness. https://github.com/openclaw/crabbox/pull/2008. Thanks @steipete.
 - Keep WSL2 workspace-owner renewal small and allow bounded workload contention without weakening token, expiry, or child-state checks. https://github.com/openclaw/crabbox/pull/2011. Thanks @steipete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Unreleased
 
-- Tenki: support fixed lease IDs for retry-safe worker allocation, report SSH readiness during inspection, and keep proxy connections working when sandbox host keys change.
-- Keep uploaded scripts in the selected workspace when a sandbox's login-shell startup changes directories, and let canceled fixed-ID allocations stop waiting for a busy claim lock.
-
 - Install the shared Linux Node/npm baseline during managed WSL2 bootstrap and require both tools for readiness. https://github.com/openclaw/crabbox/pull/2008. Thanks @steipete.
 - Keep WSL2 workspace-owner renewal small and allow bounded workload contention without weakening token, expiry, or child-state checks. https://github.com/openclaw/crabbox/pull/2011. Thanks @steipete.
+
+- Tenki: support fixed lease IDs for retry-safe worker allocation, report SSH readiness during inspection, and keep proxy connections working when sandbox host keys change. https://github.com/openclaw/crabbox/pull/2021.
+- Keep uploaded scripts in the selected workspace when a sandbox's login-shell startup changes directories, and let canceled fixed-ID allocations stop waiting for a busy claim lock. https://github.com/openclaw/crabbox/pull/2021.
 
 - Disable the unused WSLg compositor on headless managed Windows WSL2 leases to avoid service-session crashes that stall commands and workspace-owner renewal; preserve other WSL settings and existing execution deadlines. https://github.com/openclaw/crabbox/pull/2005. Thanks @steipete.
 

--- a/docs/features/provider-live-smoke.md
+++ b/docs/features/provider-live-smoke.md
@@ -155,7 +155,7 @@ hermetic lifecycle tests, `scripts/live-smoke.sh`, dedicated live runners, and
 `//go:build smoke` tests. Regenerate it with
 `node scripts/generate-provider-matrix.mjs`; docs CI rejects drift.
 
-Current coverage: 81 providers; 8 with convention-named hermetic lifecycle tests, 61 with a live runner, 8 with tagged Go smoke tests, and 18 with none of those lifecycle surfaces.
+Current coverage: 81 providers; 9 with convention-named hermetic lifecycle tests, 61 with a live runner, 8 with tagged Go smoke tests, and 18 with none of those lifecycle surfaces.
 
 | Provider | Hermetic lifecycle | Live runner | Tagged Go smoke |
 | --- | --- | --- | --- |
@@ -230,7 +230,7 @@ Current coverage: 81 providers; 8 with convention-named hermetic lifecycle tests
 | [superserve](../providers/superserve.md) | — | dedicated + matrix | — |
 | [tart](../providers/tart.md) | — | matrix | — |
 | [tencentcloud](../providers/tencentcloud.md) | — | dedicated + matrix | — |
-| [tenki](../providers/tenki.md) | — | matrix | — |
+| [tenki](../providers/tenki.md) | yes (`tenki`) | matrix | — |
 | [tensorlake](../providers/tensorlake.md) | — | — | — |
 | [unikraft-cloud](../providers/unikraft-cloud.md) | — | dedicated + matrix | — |
 | [upstash-box](../providers/upstash-box.md) | — | — | — |

--- a/docs/providers/tenki.md
+++ b/docs/providers/tenki.md
@@ -31,6 +31,54 @@ crabbox stop --provider tenki swift-crab
 crabbox list --provider tenki --json
 ```
 
+## Fixed Lease IDs For Orchestration
+
+Use `warmup --lease-id` when a controller must retry allocation after an
+interrupted dispatch. Choose one canonical ID (`cbx_` plus 12 lowercase hex
+characters) per operation, and keep that ID and the same allocation settings
+for every retry:
+
+```sh
+lease="cbx_$(openssl rand -hex 6)"
+crabbox warmup --provider tenki --network public --tailscale=false \
+  --lease-id "$lease" --slug worker-job --keep=true \
+  --ttl 1h --idle-timeout 10m
+
+# Repeat the same warmup command after an interrupted dispatch.
+crabbox inspect --provider tenki --network public --id "$lease" --json
+crabbox run --provider tenki --network public --tailscale=false \
+  --id "$lease" --keep=true --no-sync --script-stdin <<'SH'
+printf 'worker-ready\n'
+SH
+crabbox heartbeat --provider tenki --id "$lease" --idle-timeout 10m --json
+crabbox stop --provider tenki --id "$lease"
+```
+
+Crabbox saves a durable create attempt before it calls Tenki. A retry verifies
+that attempt against the exact session and reuses the session; it does not
+allocate another sandbox when a create reply or readiness check is lost.
+Changed allocation settings, conflicting ownership, and multiple matching
+sessions fail closed. An empty inventory after an attempted create is not
+proof that creation failed: retain the claim and retry inspection or stop when
+the provider can confirm the session.
+
+Keep the controller's Crabbox state directory on persistent storage. Do not
+delete claims to force a retry, move the operation to another state directory,
+or switch the authenticated Tenki workspace during an operation. A successful
+stop keeps a terminal receipt for a fixed ID. Repeated stop is safe, but that
+ID cannot allocate another session; use a new ID for the next operation.
+
+For Linux worker clients, omit `class` and use Tenki-specific sizing in Crabbox
+config. Disable native warm-image/checkpoint reuse (for clients with a
+`warmImage` setting, use `false`). Desktop, browser, and native checkpoint
+features are not part of this integration. `inspect --json` checks SSH
+readiness without resuming a paused sandbox.
+
+`--keep=true` selects a sticky Tenki session. Tenki disables automatic idle
+pause and discards `--max-duration` for sticky sessions, so the controller must
+call `stop` when it is done. Heartbeat refreshes the local Crabbox lease record;
+it does not add a provider-side expiry to a sticky session.
+
 ## Auth
 
 Authenticate with the Tenki CLI's browser flow:
@@ -139,8 +187,9 @@ These map to Tenki create flags as `--cpu`, `--memory-mb`, and
 4. Let core Crabbox perform rsync, command execution, `ssh`, and artifacts.
 5. On release, verify the exact local claim, session ID, and fresh
    provider-side lease metadata, then run `tenki sandbox terminate <session-id>`
-   under the claim lock. Crabbox removes the claim only after the same session
-   reports `TERMINATING` or `TERMINATED`. A mismatched or missing session ID,
+   under the claim lock. Only after the same session reports `TERMINATING` or
+   `TERMINATED` does Crabbox remove an ordinary claim or replace a fixed-ID
+   claim with a terminal receipt. A mismatched or missing session ID,
    lookup error, or cancellation preserves the claim for a safe retry; generic
    "not found" diagnostics are not proof of session deletion.
 
@@ -161,10 +210,12 @@ proxy or reuse this policy for a direct network SSH target.
 
 - SSH: yes, through Tenki `ssh-proxy`.
 - Crabbox sync: yes, normal SSH/rsync sync.
+- Fixed lease IDs: yes, with durable local attempt recovery and single-use IDs.
 - Desktop / browser / code: no.
+- Native checkpoints / warm images: no.
 - Actions hydration: yes, as a normal Linux SSH lease.
-- Cleanup: no. Tenki TTL/idle timeout own stale-session cleanup; `stop`
-  terminates known Crabbox leases.
+- Cleanup: no. Tenki duration/idle settings apply to non-sticky sessions;
+  explicitly `stop` reusable sticky leases when they are no longer needed.
 - Coordinator (broker): no — always direct from the CLI.
 
 ## Live Smoke

--- a/docs/providers/tenki.md
+++ b/docs/providers/tenki.md
@@ -151,6 +151,11 @@ Tenki sessions cannot independently prove lost-claim ownership.
 
 The provider does not expose Tenki's internal node-agent, mesh IPs, or guest IPs.
 All SSH traffic goes through Tenki's supported cert-backed `ssh-proxy` path.
+Sandbox restores can present a different ephemeral SSH host key on consecutive
+proxy connections, so Crabbox mirrors the Tenki CLI's host-key policy and binds
+trust to the authenticated TLS proxy, exact session ID, identity key, and
+per-session SSH certificate instead of a `known_hosts` entry. Do not bypass the
+proxy or reuse this policy for a direct network SSH target.
 
 ## Capabilities
 

--- a/docs/providers/tenki.md
+++ b/docs/providers/tenki.md
@@ -201,10 +201,22 @@ Tenki sessions cannot independently prove lost-claim ownership.
 The provider does not expose Tenki's internal node-agent, mesh IPs, or guest IPs.
 All SSH traffic goes through Tenki's supported cert-backed `ssh-proxy` path.
 Sandbox restores can present a different ephemeral SSH host key on consecutive
-proxy connections, so Crabbox mirrors the Tenki CLI's host-key policy and binds
-trust to the authenticated TLS proxy, exact session ID, identity key, and
-per-session SSH certificate instead of a `known_hosts` entry. Do not bypass the
-proxy or reuse this policy for a direct network SSH target.
+proxy connections, so Crabbox mirrors the Tenki CLI's host-key policy instead
+of maintaining a `known_hosts` entry. Server authentication depends on the
+trusted TLS gateway; the SSH client certificate does not authenticate the server.
+Use a trusted `wss://` gateway. Do not bypass the proxy or reuse this policy for
+a direct network SSH target.
+
+The cert-backed gateway selects the sandbox from the signed SSH certificate.
+Changing the proxy's session URL alone does not grant access to another sandbox:
+a certificate for session A still selects A. Crabbox obtains the certificate and
+proxy command together for the requested session.
+
+An issued SSH certificate is an access credential until it expires. Expired
+certificates are rejected on new connections, but Crabbox does not guarantee
+that revoking an API key immediately invalidates a cached SSH certificate or
+closes an existing SSH connection. Do not treat an API-key authentication error
+as proof that earlier SSH access has ended.
 
 ## Capabilities
 

--- a/internal/cli/fixed_acquisition_test.go
+++ b/internal/cli/fixed_acquisition_test.go
@@ -141,6 +141,60 @@ func TestFixedAcquisitionSerializesCLIReplayAcrossProcesses(t *testing.T) {
 	}
 }
 
+func TestFixedAcquisitionCancellationDoesNotWaitForClaimLock(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const leaseID = "cbx_123456abcdef"
+	locked, release := make(chan struct{}), make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- WithDurableLeaseClaimLock(leaseID, func(*LeaseClaim, bool, func() error) error {
+			close(locked)
+			<-release
+			return nil
+		})
+	}()
+	select {
+	case <-locked:
+	case err := <-holderDone:
+		t.Fatalf("hold claim lock: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	acquireDone := make(chan error, 1)
+	go func() {
+		_, err := AcquireFixedLease(FixedAcquireOptions{
+			Kind: FixedLeaseKind{ClaimProvider: "test", IntentVersion: 1}, LeaseID: leaseID,
+		}, func(context.Context, *LeaseClaim, bool) (FixedLeaseBinding, error) {
+			return FixedLeaseBinding{}, errors.New("canceled acquisition reached prepare")
+		}, func(context.Context, *LeaseClaim, *FixedCreateIntent, func() error) (LeaseTarget, error) {
+			return LeaseTarget{}, errors.New("canceled acquisition reached provider")
+		}, ctx)
+		acquireDone <- err
+	}()
+	finished := false
+	defer func() {
+		close(release)
+		if err := <-holderDone; err != nil {
+			t.Errorf("release claim lock: %v", err)
+		}
+		if !finished {
+			<-acquireDone
+		}
+	}()
+	select {
+	case err := <-acquireDone:
+		finished = true
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("acquisition error=%v, want cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled fixed acquisition waited for the held claim lock")
+	}
+	if _, exists, err := ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
+		t.Fatalf("canceled acquisition published a claim: exists=%t err=%v", exists, err)
+	}
+}
+
 func TestWarmupFailedFixedReplayPreservesLease(t *testing.T) {
 	clearConfigEnv(t)
 	isolateRunTestUserDirs(t, t.TempDir())

--- a/internal/cli/fixed_lease.go
+++ b/internal/cli/fixed_lease.go
@@ -60,7 +60,7 @@ func AcquireFixedLease(
 		now = time.Now
 	}
 	var acquired LeaseTarget
-	err := WithDurableLeaseClaimLock(opts.LeaseID, func(claim *LeaseClaim, exists bool, persist func() error) error {
+	err := WithDurableLeaseClaimLockContext(ctx, opts.LeaseID, func(claim *LeaseClaim, exists bool, persist func() error) error {
 		if exists && opts.Kind.IsFixedClaim(*claim) && claim.FixedCreateIntent.State == "released" {
 			return exit(4, "lease_id_conflict: fixed lease %s is terminal and cannot be replayed", opts.LeaseID)
 		}

--- a/internal/cli/run_script.go
+++ b/internal/cli/run_script.go
@@ -156,11 +156,11 @@ func remoteRunScriptCommandWithEnvFiles(workdir string, env map[string]string, e
 	writeRemoteCommandPrefix(&b, workdir, env, envFiles)
 	if script.Shebang {
 		b.WriteString("bash -lc ")
-		b.WriteString(shellQuote(`exec "$@"`))
+		b.WriteString(shellQuote(remoteBashLoginScript(workdir, `exec "$@"`)))
 		b.WriteString(" bash ")
 	} else {
 		b.WriteString("bash -lc ")
-		b.WriteString(shellQuote(`exec bash "$@"`))
+		b.WriteString(shellQuote(remoteBashLoginScript(workdir, `exec bash "$@"`)))
 		b.WriteString(" bash ")
 	}
 	b.WriteString(shellQuote(script.RemotePath))

--- a/internal/cli/run_script_test.go
+++ b/internal/cli/run_script_test.go
@@ -146,6 +146,54 @@ if [ "$script_dir" = "$upload_dir" ]; then echo DIR_UPLOAD=yes; fi
 	}
 }
 
+func TestRemoteRunScriptRestoresWorkdirAfterShellStartup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell execution")
+	}
+	for _, shebang := range []bool{false, true} {
+		t.Run(fmt.Sprintf("shebang=%t", shebang), func(t *testing.T) {
+			root, err := filepath.EvalSymlinks(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			workdir := filepath.Join(root, "worker ' workspace")
+			home := filepath.Join(root, "home")
+			for _, dir := range []string{workdir, home} {
+				if err := os.MkdirAll(dir, 0700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			startup := filepath.Join(root, "shell-startup")
+			if err := os.WriteFile(startup, []byte("if shopt -q login_shell; then cd "+shellQuote(home)+"; fi\n"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			env := []string{"HOME=" + home, "PATH=" + os.Getenv("PATH"), "BASH_ENV=" + startup}
+			data := "set -eu\n[ \"$PWD\" = \"$1\" ]\n[ \"$2\" = \"argument with ' quotes\" ]\nprintf 'uploaded-script-executed\\n'\n"
+			if shebang {
+				data = "#!/bin/sh\n" + data
+			}
+			spec, err := loadRunScript("", true, strings.NewReader(data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			upload := exec.Command("sh", "-c", remoteUploadRunScriptCommand(workdir, spec.RemotePath))
+			upload.Env, upload.Stdin = env, strings.NewReader(data)
+			if output, err := upload.CombinedOutput(); err != nil {
+				t.Fatalf("upload script: %v\n%s", err, output)
+			}
+			if uploaded, err := os.ReadFile(filepath.Join(workdir, filepath.FromSlash(spec.RemotePath))); err != nil || string(uploaded) != data {
+				t.Fatalf("script upload did not reach the workdir: data=%q err=%v", uploaded, err)
+			}
+			run := exec.Command("sh", "-c", remoteRunScriptCommandWithEnvFiles(workdir, nil, nil, spec, []string{workdir, "argument with ' quotes"}))
+			run.Env = env
+			output, err := run.CombinedOutput()
+			if err != nil || !strings.Contains(string(output), "uploaded-script-executed") {
+				t.Fatalf("uploaded script execution after startup cd: %v\n%s", err, output)
+			}
+		})
+	}
+}
+
 func TestRemoteRunScriptCommandWithoutShebangUsesBash(t *testing.T) {
 	spec := &RunScriptSpec{RemotePath: ".crabbox/scripts/abc-script.sh"}
 	got := remoteRunScriptCommandWithEnvFile("/work/repo", nil, "", spec, nil)

--- a/internal/providers/tenki/backend.go
+++ b/internal/providers/tenki/backend.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	posixpath "path"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -928,26 +927,17 @@ func (b *tenkiBackend) sshTarget(output tenkiSSHCommandOutput) SSHTarget {
 		port = strconv.Itoa(output.Port)
 	}
 	return SSHTarget{
-		User:            blank(strings.TrimSpace(output.User), "tenki"),
-		Host:            blank(strings.TrimSpace(output.Host), "sandbox"),
-		Key:             output.IdentityFile,
-		CertificateFile: output.CertificateFile,
-		KnownHostsFile:  tenkiKnownHostsFile(output),
-		Port:            port,
-		TargetOS:        targetLinux,
-		NetworkKind:     networkPublic,
-		SSHConfigProxy:  true,
-		ProxyCommand:    tenkiOpenSSHProxyCommand(output.ProxyCommand),
+		User:                   blank(strings.TrimSpace(output.User), "tenki"),
+		Host:                   blank(strings.TrimSpace(output.Host), "sandbox"),
+		Key:                    output.IdentityFile,
+		CertificateFile:        output.CertificateFile,
+		Port:                   port,
+		DisableHostKeyChecking: true,
+		TargetOS:               targetLinux,
+		NetworkKind:            networkPublic,
+		SSHConfigProxy:         true,
+		ProxyCommand:           tenkiOpenSSHProxyCommand(output.ProxyCommand),
 	}
-}
-
-func tenkiKnownHostsFile(output tenkiSSHCommandOutput) string {
-	dir := filepath.Dir(output.IdentityFile)
-	session := normalizeLeaseSlug(output.SessionID)
-	if session == "" {
-		session = "sandbox"
-	}
-	return filepath.Join(dir, "known_hosts_"+session)
 }
 
 func tenkiOpenSSHProxyCommand(command string) string {

--- a/internal/providers/tenki/backend.go
+++ b/internal/providers/tenki/backend.go
@@ -202,6 +202,9 @@ func (b *tenkiBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTa
 	if err := validateTenkiAcquireScope(cfg); err != nil {
 		return LeaseTarget{}, err
 	}
+	if strings.TrimSpace(req.RequestedLeaseID) != "" {
+		return b.acquireFixed(ctx, req)
+	}
 	leaseID := newLeaseID()
 	slug, err := allocateClaimLeaseSlug(leaseID, req.RequestedSlug)
 	if err != nil {
@@ -250,14 +253,30 @@ func (b *tenkiBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTa
 }
 
 func (b *tenkiBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+	if claim, exists, err := b.fixedClaimForIdentifier(req.ID); err != nil {
+		return LeaseTarget{}, err
+	} else if exists {
+		return b.resolveFixed(ctx, req, claim)
+	}
 	cfg := b.configForRun()
 	session, leaseID, slug, err := b.resolveSession(ctx, req.ID, req.Reclaim)
 	if err != nil {
 		return LeaseTarget{}, err
 	}
+	// Remote discovery must not turn fixed evidence into an ordinary adopted claim.
+	if claim, exists, err := b.fixedClaimForIdentifier(leaseID); err != nil {
+		return LeaseTarget{}, err
+	} else if exists {
+		if err := b.validateFixedSession(claim, session); err != nil {
+			return LeaseTarget{}, err
+		}
+		return b.resolveFixed(ctx, req, claim)
+	} else if tenkiHasFixedMetadata(session) {
+		return LeaseTarget{}, exit(4, "lease_id_conflict: fixed Tenki session %s has no durable local attempt", session.ID)
+	}
 	if req.ReleaseOnly || req.StatusOnly {
 		lease := LeaseTarget{Server: b.sessionToServer(cfg, session, leaseID, slug, session.Sticky), LeaseID: leaseID}
-		if !req.ReadyProbe || !tenkiSessionReady(session) {
+		if !(req.ReadyProbe || req.IncludeDiagnostics) || !tenkiSessionReady(session) {
 			return lease, nil
 		}
 		target, err := b.resolveSSHTarget(ctx, cfg, session.ID)
@@ -356,7 +375,7 @@ func (b *tenkiBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResul
 	return inventoryDoctorResult(tenkiProvider, len(servers)), nil
 }
 
-func (b *tenkiBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *tenkiBackend) releaseOrdinaryLease(ctx context.Context, req ReleaseLeaseRequest) error {
 	sessionID := strings.TrimSpace(req.Lease.Server.CloudID)
 	if sessionID == "" && req.Lease.Server.Labels != nil {
 		sessionID = strings.TrimSpace(req.Lease.Server.Labels["tenki_session_id"])
@@ -417,7 +436,12 @@ func tenkiHasExactOwnership(session tenkiSession, leaseID, slug string) bool {
 		session.Metadata[tenkiMetadataSlug] == slug
 }
 
-func (b *tenkiBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {
+func (b *tenkiBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
+	if _, fixed, err := b.fixedClaimForIdentifier(req.Lease.LeaseID); err != nil {
+		return Server{}, err
+	} else if fixed || req.Lease.Server.Labels[tenkiFixedIntentLabel] != "" {
+		return b.touchFixed(ctx, req)
+	}
 	server := req.Lease.Server
 	if server.Labels == nil {
 		server.Labels = map[string]string{}
@@ -440,6 +464,16 @@ func (b *tenkiBackend) configForRun() Config {
 }
 
 func (b *tenkiBackend) createSession(ctx context.Context, cfg Config, name, leaseID, slug string, keep bool) (tenkiSession, error) {
+	created, err := b.submitCreateSession(ctx, cfg, name, leaseID, slug, keep, nil)
+	if err != nil {
+		return tenkiSession{}, err
+	}
+	return b.getSession(ctx, created.ID)
+}
+
+// Submission is separate from detail/readiness so fixed creates can durably
+// record a returned ID even if the subsequent lookup fails.
+func (b *tenkiBackend) submitCreateSession(ctx context.Context, cfg Config, name, leaseID, slug string, keep bool, metadata []string) (tenkiSession, error) {
 	args := b.sandboxArgs("create")
 	args = append(args,
 		"--no-wait",
@@ -450,6 +484,9 @@ func (b *tenkiBackend) createSession(ctx context.Context, cfg Config, name, leas
 		"--metadata", tenkiMetadataSlug+"="+slug,
 		"--tags", "crabbox,crabbox-provider-tenki",
 	)
+	for _, value := range metadata {
+		args = append(args, "--metadata", value)
+	}
 	labels := directLeaseLabels(cfg, leaseID, slug, tenkiProvider, "", keep, tenkiNow().UTC())
 	labels["server_type"] = tenkiConfiguredServerType(cfg)
 	for _, item := range tenkiPersistedLabelMetadata {
@@ -482,20 +519,27 @@ func (b *tenkiBackend) createSession(ctx context.Context, cfg Config, name, leas
 		args = append(args, "--snapshot", snapshot)
 	}
 	result, err := b.runTenki(ctx, args, nil, b.rt.Stderr)
+	var created tenkiSession
+	decodeErr := decodeTenkiJSON("create", result, &created)
+	if decodeErr != nil {
+		created = tenkiSession{}
+	}
 	if err != nil {
 		if isTenkiCLIContractError(err) {
-			return tenkiSession{}, err
+			return created, err
 		}
-		return tenkiSession{}, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("tenki sandbox create failed: %v%s", err, tenkiCommandOutputDetail(result))}
+		if ctx.Err() != nil {
+			return created, ctx.Err()
+		}
+		return created, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("tenki sandbox create failed: %v%s", err, tenkiCommandOutputDetail(result))}
 	}
-	var created tenkiSession
-	if err := decodeTenkiJSON("create", result, &created); err != nil {
-		return tenkiSession{}, err
+	if decodeErr != nil {
+		return tenkiSession{}, decodeErr
 	}
 	if strings.TrimSpace(created.ID) == "" {
 		return tenkiSession{}, exit(5, "tenki sandbox create JSON did not include a session id")
 	}
-	return b.getSession(ctx, created.ID)
+	return created, nil
 }
 
 func (b *tenkiBackend) prepareLease(ctx context.Context, cfg Config, session tenkiSession, leaseID, slug string, keep bool, waitSSH bool) (LeaseTarget, error) {
@@ -542,7 +586,12 @@ func (b *tenkiBackend) getSession(ctx context.Context, sessionID string) (tenkiS
 	return session, nil
 }
 
-func (b *tenkiBackend) ensureSessionReadyForSSH(ctx context.Context, cfg Config, session tenkiSession) (tenkiSession, error) {
+func (b *tenkiBackend) ensureSessionReadyForSSH(ctx context.Context, cfg Config, session tenkiSession, validators ...func(tenkiSession) error) (tenkiSession, error) {
+	for _, validate := range validators {
+		if err := validate(session); err != nil {
+			return tenkiSession{}, err
+		}
+	}
 	state := tenkiNormalizedState(session.State)
 	switch state {
 	case "", "ready", "running", "creating":
@@ -551,9 +600,9 @@ func (b *tenkiBackend) ensureSessionReadyForSSH(ctx context.Context, cfg Config,
 		if err := b.resumeSession(ctx, session.ID); err != nil {
 			return tenkiSession{}, err
 		}
-		return b.waitForSessionReady(ctx, session.ID, bootstrapWaitTimeout(cfg))
+		return b.waitForSessionReady(ctx, session.ID, bootstrapWaitTimeout(cfg), validators...)
 	case "pausing":
-		session, err := b.waitForSessionPausedOrReady(ctx, session.ID, bootstrapWaitTimeout(cfg))
+		session, err := b.waitForSessionPausedOrReady(ctx, session.ID, bootstrapWaitTimeout(cfg), validators...)
 		if err != nil {
 			return tenkiSession{}, err
 		}
@@ -563,9 +612,9 @@ func (b *tenkiBackend) ensureSessionReadyForSSH(ctx context.Context, cfg Config,
 		if err := b.resumeSession(ctx, session.ID); err != nil {
 			return tenkiSession{}, err
 		}
-		return b.waitForSessionReady(ctx, session.ID, bootstrapWaitTimeout(cfg))
+		return b.waitForSessionReady(ctx, session.ID, bootstrapWaitTimeout(cfg), validators...)
 	case "resuming":
-		return b.waitForSessionReady(ctx, session.ID, bootstrapWaitTimeout(cfg))
+		return b.waitForSessionReady(ctx, session.ID, bootstrapWaitTimeout(cfg), validators...)
 	case "terminating", "terminated":
 		return tenkiSession{}, exit(4, "tenki session %s is %s", session.ID, state)
 	default:
@@ -586,7 +635,7 @@ func (b *tenkiBackend) resumeSession(ctx context.Context, sessionID string) erro
 	return nil
 }
 
-func (b *tenkiBackend) waitForSessionPausedOrReady(ctx context.Context, sessionID string, timeout time.Duration) (tenkiSession, error) {
+func (b *tenkiBackend) waitForSessionPausedOrReady(ctx context.Context, sessionID string, timeout time.Duration, validators ...func(tenkiSession) error) (tenkiSession, error) {
 	return b.waitForSessionState(ctx, sessionID, timeout, func(session tenkiSession) (bool, error) {
 		switch tenkiNormalizedState(session.State) {
 		case "ready", "running", "paused":
@@ -596,10 +645,10 @@ func (b *tenkiBackend) waitForSessionPausedOrReady(ctx context.Context, sessionI
 		default:
 			return false, nil
 		}
-	})
+	}, validators...)
 }
 
-func (b *tenkiBackend) waitForSessionReady(ctx context.Context, sessionID string, timeout time.Duration) (tenkiSession, error) {
+func (b *tenkiBackend) waitForSessionReady(ctx context.Context, sessionID string, timeout time.Duration, validators ...func(tenkiSession) error) (tenkiSession, error) {
 	return b.waitForSessionState(ctx, sessionID, timeout, func(session tenkiSession) (bool, error) {
 		switch tenkiNormalizedState(session.State) {
 		case "ready", "running":
@@ -612,16 +661,21 @@ func (b *tenkiBackend) waitForSessionReady(ctx context.Context, sessionID string
 			return false, exit(4, "tenki session %s is %s while waiting for resume", sessionID, tenkiNormalizedState(session.State))
 		}
 		return false, nil
-	})
+	}, validators...)
 }
 
-func (b *tenkiBackend) waitForSessionState(ctx context.Context, sessionID string, timeout time.Duration, done func(tenkiSession) (bool, error)) (tenkiSession, error) {
+func (b *tenkiBackend) waitForSessionState(ctx context.Context, sessionID string, timeout time.Duration, done func(tenkiSession) (bool, error), validators ...func(tenkiSession) error) (tenkiSession, error) {
 	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	result, err := shared.Poll(waitCtx, 0, 5*time.Second, b.sleep,
 		func(ctx context.Context) (tenkiSession, error) { return b.getSession(ctx, sessionID) },
 		func(_ context.Context, session tenkiSession, fetchErr error) (bool, error) {
 			if fetchErr == nil {
+				for _, validate := range validators {
+					if err := validate(session); err != nil {
+						return false, err
+					}
+				}
 				return done(session)
 			}
 			if isTenkiCLIContractError(fetchErr) {
@@ -763,7 +817,7 @@ func (b *tenkiBackend) terminateSessionAcknowledged(ctx context.Context, session
 	return b.waitForTerminationAcknowledged(ctx, sessionID)
 }
 
-func (b *tenkiBackend) waitForTerminationAcknowledged(ctx context.Context, sessionID string) error {
+func (b *tenkiBackend) waitForTerminationAcknowledged(ctx context.Context, sessionID string, validators ...func(tenkiSession) error) error {
 	timeout := b.terminationAckTimeout
 	if timeout <= 0 {
 		timeout = 30 * time.Second
@@ -791,6 +845,11 @@ func (b *tenkiBackend) waitForTerminationAcknowledged(ctx context.Context, sessi
 			}
 			if session.ID == "" || session.ID != sessionID {
 				return false, exit(4, "refusing Tenki termination acknowledgement for session %q: live session identity is %q", sessionID, session.ID)
+			}
+			for _, validate := range validators {
+				if err := validate(session); err != nil {
+					return false, err
+				}
 			}
 			switch tenkiNormalizedState(session.State) {
 			case "terminating", "terminated":
@@ -1084,6 +1143,9 @@ func (b *tenkiBackend) sandboxArgs(command string) []string {
 }
 
 func (b *tenkiBackend) runTenki(ctx context.Context, args []string, stdout, stderr io.Writer) (LocalCommandResult, error) {
+	if err := ctx.Err(); err != nil {
+		return LocalCommandResult{}, err
+	}
 	result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{Name: tenkiCLIPath(b.cfg), Args: args, Stdout: stdout, Stderr: stderr})
 	if diagnostic := tenkiCLIContractDiagnostic(result); diagnostic != "" {
 		if result.ExitCode == 0 {

--- a/internal/providers/tenki/backend_test.go
+++ b/internal/providers/tenki/backend_test.go
@@ -881,11 +881,11 @@ func TestTenkiSSHTargetUsesProxyCommand(t *testing.T) {
 	if !target.SSHConfigProxy || target.Host != "sandbox" || target.User != "tenki" || target.Key != "/tmp/id_ed25519" || target.CertificateFile != "/tmp/session-cert.pub" {
 		t.Fatalf("unexpected target: %#v", target)
 	}
-	if target.NoControlMaster || target.DisableHostKeyChecking {
-		t.Fatalf("tenki target should keep SSH mux and host-key checks enabled: %#v", target)
+	if target.NoControlMaster || !target.DisableHostKeyChecking {
+		t.Fatalf("tenki target should keep SSH mux and use proxy-bound host trust: %#v", target)
 	}
-	if target.KnownHostsFile != "/tmp/known_hosts_00000000-0000-0000-0000-000000000001" {
-		t.Fatalf("known_hosts=%q", target.KnownHostsFile)
+	if target.KnownHostsFile != "" {
+		t.Fatalf("known_hosts=%q, want empty for proxy-bound ephemeral host keys", target.KnownHostsFile)
 	}
 	for _, want := range []string{
 		`"/opt/Tenki CLI/tenki" sandbox ssh-proxy`,

--- a/internal/providers/tenki/fixed.go
+++ b/internal/providers/tenki/fixed.go
@@ -1,0 +1,646 @@
+package tenki
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+const (
+	tenkiMetadataAttempt  = "crabbox_create_attempt"
+	tenkiMetadataIntent   = "crabbox_intent_sha256"
+	tenkiFixedIntentLabel = "fixed_intent_sha256"
+	tenkiFixedRouteLabel  = "tenki_fixed_route"
+)
+
+var tenkiFixedKind = core.FixedLeaseKind{
+	ClaimProvider: tenkiProvider, IntentVersion: 1, Label: "Tenki",
+	TerminalIdentityLabels: []string{"tenki_session_id", tenkiFixedIntentLabel, tenkiFixedRouteLabel, "project_id"},
+}
+
+var _ core.IdempotentLeaseIDBackend = (*tenkiBackend)(nil)
+var _ core.ReleaseLeaseClaimRetentionVerifier = (*tenkiBackend)(nil)
+var _ core.ReleaseLeaseOutcomeBackend = (*tenkiBackend)(nil)
+
+func (*tenkiBackend) SupportsRequestedLeaseID() bool { return true }
+
+// The Tenki CLI create contract exposes no caller ID or idempotency input.
+// The random token is evidence from a durable local submission, not permission
+// to adopt a session found by its name or lease metadata alone.
+type tenkiCreateAttempt struct {
+	Name      string `json:"name"`
+	Token     string `json:"token"`
+	Route     string `json:"route"`
+	SessionID string `json:"sessionId,omitempty"`
+	Image     string `json:"image,omitempty"`
+	Snapshot  string `json:"snapshot,omitempty"`
+	CPUs      int    `json:"cpus,omitempty"`
+	MemoryMB  int    `json:"memoryMB,omitempty"`
+	DiskGB    int    `json:"diskGB,omitempty"`
+	Keep      bool   `json:"keep"`
+}
+
+func tenkiFixedRoute(cfg Config) string {
+	data, _ := json.Marshal([]string{(Provider{}).ClaimScope(cfg), tenkiCLIPath(cfg), strings.TrimSpace(cfg.Tenki.Gateway), tenkiWorkRoot(cfg)})
+	return fmt.Sprintf("%x", sha256.Sum256(data))
+}
+
+func tenkiFixedFingerprint(cfg Config, req AcquireRequest) (string, error) {
+	// Labels are computed from configuration, never from renewed claim labels.
+	// No clock, generated provider key, credential, or SSH certificate is identity.
+	labels := directLeaseLabels(cfg, "", "", tenkiProvider, "", req.Keep, time.Unix(0, 0))
+	for _, key := range []string{"created_at", "last_touched_at", "expires_at", "provider_key"} {
+		delete(labels, key)
+	}
+	data, err := json.Marshal(struct {
+		Version                                             int
+		Slug, Route, Image, Snapshot, Architecture, OSImage string
+		CPUs, MemoryMB, DiskGB                              int
+		Keep                                                bool
+		TTL, Idle                                           time.Duration
+		Labels                                              map[string]string
+		Cache                                               core.CacheConfig
+	}{1, normalizeLeaseSlug(req.RequestedSlug), tenkiFixedRoute(cfg), cfg.Tenki.Image, cfg.Tenki.Snapshot, cfg.Architecture, cfg.OSImage,
+		cfg.Tenki.CPUs, cfg.Tenki.MemoryMB, cfg.Tenki.DiskGB, req.Keep, cfg.TTL, cfg.IdleTimeout, labels, cfg.Cache})
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", sha256.Sum256(append([]byte("crabbox-fixed-tenki-v1\x00"), data...))), nil
+}
+
+func (b *tenkiBackend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+	leaseID := strings.TrimSpace(req.RequestedLeaseID)
+	if !core.IsCanonicalLeaseID(leaseID) {
+		return LeaseTarget{}, exit(2, "invalid fixed Tenki lease ID %q", leaseID)
+	}
+	if req.RequestedCheckpointID != "" {
+		return LeaseTarget{}, exit(2, "provider=tenki does not support fixed checkpoint IDs")
+	}
+	cfg := b.configForRun()
+	freshClaim := false
+	lease, err := core.AcquireFixedLease(core.FixedAcquireOptions{
+		Kind: tenkiFixedKind, LeaseID: leaseID, RepoRoot: req.Repo.Root,
+		TargetOS: targetLinux, TTL: cfg.TTL, IdleTimeout: cfg.IdleTimeout, Now: tenkiNow,
+	}, func(ctx context.Context, claim *LeaseClaim, exists bool) (core.FixedLeaseBinding, error) {
+		if err := ctx.Err(); err != nil {
+			return core.FixedLeaseBinding{}, err
+		}
+		freshClaim = !exists
+		if exists && (claim.Provider != tenkiProvider || claim.FixedCreateIntent == nil || claim.RepoRoot != req.Repo.Root) {
+			return core.FixedLeaseBinding{}, exit(4, "lease_id_conflict: fixed Tenki lease %s belongs to another provider, repository, or create mode", leaseID)
+		}
+		fingerprint, err := tenkiFixedFingerprint(cfg, req)
+		if err != nil {
+			return core.FixedLeaseBinding{}, err
+		}
+		binding := core.FixedLeaseBinding{ProviderScope: (Provider{}).ClaimScope(cfg), Fingerprint: fingerprint}
+		if !exists {
+			binding.Slug, err = allocateClaimLeaseSlug(leaseID, req.RequestedSlug)
+		}
+		return binding, err
+	}, func(ctx context.Context, claim *LeaseClaim, intent *core.FixedCreateIntent, persist func() error) (LeaseTarget, error) {
+		if err := ctx.Err(); err != nil {
+			return LeaseTarget{}, err
+		}
+		if err := core.AuthorizeCheckpointRelease(*claim, ""); err != nil {
+			return LeaseTarget{}, err
+		}
+		session, err := b.resolveFixedSession(ctx, *claim)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		if session.ID == "" {
+			// An old prepared claim does not prove the submission never happened.
+			// Only the invocation that made this claim may submit, once.
+			if !freshClaim {
+				return LeaseTarget{}, exit(4, "lease_id_conflict: fixed Tenki lease %s has no provably unsubmitted attempt; retain its claim", leaseID)
+			}
+			var token [32]byte
+			if _, err := rand.Read(token[:]); err != nil {
+				return LeaseTarget{}, err
+			}
+			attempt := tenkiCreateAttempt{Name: leaseProviderName(leaseID, intent.Slug), Token: hex.EncodeToString(token[:]), Route: tenkiFixedRoute(cfg),
+				Image: cfg.Tenki.Image, Snapshot: cfg.Tenki.Snapshot, CPUs: cfg.Tenki.CPUs, MemoryMB: cfg.Tenki.MemoryMB, DiskGB: cfg.Tenki.DiskGB, Keep: req.Keep}
+			if err := ctx.Err(); err != nil {
+				return LeaseTarget{}, err
+			}
+			if err := saveTenkiAttempt(intent, attempt, persist); err != nil {
+				return LeaseTarget{}, err
+			}
+			fmt.Fprintf(b.rt.Stderr, "provisioning provider=tenki lease=%s slug=%s session=%s keep=%v fixed=true\n", leaseID, intent.Slug, attempt.Name, req.Keep)
+			created, createErr := b.submitCreateSession(ctx, cfg, attempt.Name, leaseID, intent.Slug, req.Keep, []string{
+				tenkiMetadataAttempt + "=" + attempt.Token, tenkiMetadataIntent + "=" + intent.Fingerprint,
+			})
+			if created.ID != "" {
+				// This is only returned-ID evidence, not an attested CloudID. Persist
+				// even on cancellation or command failure before any following get.
+				attempt.SessionID = created.ID
+				if err := saveTenkiAttempt(intent, attempt, persist); err != nil {
+					return LeaseTarget{}, errors.Join(createErr, err)
+				}
+			}
+			if createErr != nil {
+				return LeaseTarget{}, createErr
+			}
+			session, err = b.resolveFixedSession(ctx, *claim)
+			if err != nil {
+				return LeaseTarget{}, err
+			}
+		}
+		if err := rejectTerminalTenkiSession(session); err != nil {
+			return LeaseTarget{}, err
+		}
+		if err := ctx.Err(); err != nil {
+			return LeaseTarget{}, err
+		}
+		if err := b.bindFixedSession(claim, session, persist); err != nil {
+			return LeaseTarget{}, err
+		}
+		return b.prepareFixedLease(ctx, *claim, session)
+	}, ctx)
+	if err != nil {
+		fmt.Fprintf(b.rt.Stderr, "fixed Tenki lease %s acquisition failed; any recorded attempt is retained. Retry the same request or inspect/stop this ID after provider inventory converges\n", leaseID)
+		return LeaseTarget{}, err
+	}
+	// The callback can use claim APIs. It must run after the acquisition fence
+	// is released, and failure must not delete this single-use identity.
+	if req.OnAcquired != nil {
+		if err := req.OnAcquired(lease); err != nil {
+			return LeaseTarget{}, fmt.Errorf("acknowledge fixed Tenki acquisition: %w", err)
+		}
+	}
+	return lease, nil
+}
+
+func saveTenkiAttempt(intent *core.FixedCreateIntent, attempt tenkiCreateAttempt, persist func() error) error {
+	data, err := json.Marshal(attempt)
+	if err != nil {
+		return err
+	}
+	intent.Attempt = map[string]string{"tenki": string(data)}
+	return persist()
+}
+
+func tenkiSHA256(value string) bool {
+	decoded, err := hex.DecodeString(value)
+	return err == nil && len(decoded) == sha256.Size && value == strings.ToLower(value)
+}
+
+func (b *tenkiBackend) fixedAttempt(claim LeaseClaim) (*tenkiCreateAttempt, error) {
+	intent := claim.FixedCreateIntent
+	if !core.IsCanonicalLeaseID(claim.LeaseID) || !tenkiFixedKind.IsFixedClaim(claim) || intent.Version != 1 || !tenkiSHA256(intent.Fingerprint) ||
+		intent.CheckpointID != "" || intent.Slug == "" || intent.Slug != claim.Slug || intent.ProviderScope != claim.ProviderScope ||
+		claim.ProviderScope != (Provider{}).ClaimScope(b.configForRun()) || (intent.State != "prepared" && intent.State != "acquired") ||
+		claim.CloudNumericID != 0 || claim.CloudImmutableID != claim.CloudID || len(intent.FailedAttempts) != 0 {
+		return nil, exit(4, "lease_id_conflict: invalid fixed Tenki identity or provider scope for %s", claim.LeaseID)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, intent.CreatedAt); err != nil {
+		return nil, exit(4, "lease_id_conflict: invalid fixed Tenki timestamp for %s", claim.LeaseID)
+	}
+	if len(intent.Attempt) == 0 {
+		if intent.State != "prepared" || claim.CloudID != "" || len(claim.Labels) != 0 || claim.SSHHost != "" || claim.SSHPort != 0 {
+			return nil, exit(4, "lease_id_conflict: fixed Tenki lease %s has no durable attempt", claim.LeaseID)
+		}
+		return nil, nil
+	}
+	var attempt tenkiCreateAttempt
+	if len(intent.Attempt) != 1 || json.Unmarshal([]byte(intent.Attempt["tenki"]), &attempt) != nil ||
+		attempt.Name != leaseProviderName(claim.LeaseID, claim.Slug) || !tenkiSHA256(attempt.Token) || attempt.Route != tenkiFixedRoute(b.configForRun()) ||
+		(attempt.SessionID != "" && strings.TrimSpace(attempt.SessionID) != attempt.SessionID) ||
+		(claim.CloudID != "" && attempt.SessionID != claim.CloudID) ||
+		(claim.CloudID == "" && (intent.State == "acquired" || len(claim.Labels) != 0 || claim.SSHHost != "" || claim.SSHPort != 0)) {
+		return nil, exit(4, "lease_id_conflict: invalid fixed Tenki attempt or changed connection configuration for %s", claim.LeaseID)
+	}
+	if claim.CloudID != "" && (claim.Labels["tenki_session_id"] != claim.CloudID || claim.Labels[tenkiFixedIntentLabel] != intent.Fingerprint || claim.Labels[tenkiFixedRouteLabel] != attempt.Route) {
+		return nil, exit(4, "lease_id_conflict: fixed Tenki lease %s has inconsistent bound labels", claim.LeaseID)
+	}
+	return &attempt, nil
+}
+
+func (b *tenkiBackend) validateFixedSession(claim LeaseClaim, session tenkiSession) error {
+	attempt, err := b.fixedAttempt(claim)
+	if err != nil {
+		return err
+	}
+	if attempt == nil {
+		return exit(4, "lease_id_conflict: Tenki session %s has no durable local attempt", session.ID)
+	}
+	if strings.TrimSpace(session.ID) == "" || session.ID != strings.TrimSpace(session.ID) ||
+		(attempt.SessionID != "" && session.ID != attempt.SessionID) || (claim.CloudID != "" && session.ID != claim.CloudID) ||
+		session.Name != attempt.Name || !tenkiHasExactOwnership(session, claim.LeaseID, claim.Slug) ||
+		session.Metadata[tenkiMetadataAttempt] != attempt.Token || session.Metadata[tenkiMetadataIntent] != claim.FixedCreateIntent.Fingerprint {
+		return exit(4, "lease_id_conflict: fixed Tenki lease %s session identity or ownership metadata does not match its durable attempt", claim.LeaseID)
+	}
+	if (claim.Labels["project_id"] != "" && session.ProjectID != claim.Labels["project_id"]) || session.Sticky != attempt.Keep ||
+		(attempt.Image != "" && session.SourceImageRef != attempt.Image) || (attempt.Snapshot != "" && session.SourceSnapshotID != attempt.Snapshot) ||
+		(attempt.CPUs > 0 && session.CPUCores != attempt.CPUs) || (attempt.MemoryMB > 0 && session.MemoryMB != attempt.MemoryMB) || (attempt.DiskGB > 0 && session.DiskSizeGB != attempt.DiskGB) {
+		return exit(4, "lease_id_conflict: fixed Tenki lease %s session configuration differs from its durable attempt", claim.LeaseID)
+	}
+	return nil
+}
+
+func tenkiHasFixedMetadata(session tenkiSession) bool {
+	return session.Metadata[tenkiMetadataAttempt] != "" || session.Metadata[tenkiMetadataIntent] != ""
+}
+
+func rejectTerminalTenkiSession(session tenkiSession) error {
+	switch tenkiNormalizedState(session.State) {
+	case "terminating", "terminated":
+		return exit(4, "lease_id_conflict: fixed Tenki session %s is terminal (%s)", session.ID, session.State)
+	}
+	return nil
+}
+
+// Inventory is discovery only. Empty inventory, errors, or a process restart
+// never authorize another create. A known ID can still be attested by get while
+// list converges. Every matching candidate must resolve to one exact session.
+func (b *tenkiBackend) resolveFixedSession(ctx context.Context, claim LeaseClaim) (tenkiSession, error) {
+	if err := ctx.Err(); err != nil {
+		return tenkiSession{}, err
+	}
+	attempt, err := b.fixedAttempt(claim)
+	if err != nil {
+		return tenkiSession{}, err
+	}
+	sessions, err := b.listSessions(ctx, true)
+	if cause := ctx.Err(); cause != nil {
+		return tenkiSession{}, cause
+	}
+	if err != nil {
+		return tenkiSession{}, err
+	}
+	name := leaseProviderName(claim.LeaseID, claim.Slug)
+	var candidate *tenkiSession
+	for _, session := range sessions {
+		matches := session.Name == name || session.Metadata[tenkiMetadataLease] == claim.LeaseID || (claim.CloudID != "" && session.ID == claim.CloudID)
+		if attempt != nil {
+			matches = matches || session.Metadata[tenkiMetadataAttempt] == attempt.Token || (attempt.SessionID != "" && session.ID == attempt.SessionID)
+		}
+		if !matches {
+			continue
+		}
+		if candidate != nil {
+			return tenkiSession{}, exit(4, "lease_id_conflict: multiple Tenki sessions match fixed lease %s", claim.LeaseID)
+		}
+		copy := session
+		candidate = &copy
+	}
+	if attempt == nil {
+		if candidate != nil {
+			return tenkiSession{}, exit(4, "lease_id_conflict: Tenki session matches %s without a durable local attempt", claim.LeaseID)
+		}
+		return tenkiSession{}, nil
+	}
+	id := attempt.SessionID
+	if candidate != nil {
+		if candidate.ID == "" || (id != "" && candidate.ID != id) {
+			return tenkiSession{}, exit(4, "lease_id_conflict: Tenki inventory identity differs for %s", claim.LeaseID)
+		}
+		id = candidate.ID
+	}
+	if id == "" {
+		return tenkiSession{}, exit(4, "lease_id_conflict: fixed Tenki lease %s has an unresolved create attempt; retain its claim", claim.LeaseID)
+	}
+	detail, err := b.getSession(ctx, id)
+	if cause := ctx.Err(); cause != nil {
+		return tenkiSession{}, cause
+	}
+	if err != nil {
+		return tenkiSession{}, err
+	}
+	if detail.ID != id {
+		return tenkiSession{}, exit(4, "lease_id_conflict: Tenki detail session identity differs from requested ID %s", id)
+	}
+	if candidate != nil && (candidate.Name != detail.Name || !maps.Equal(candidate.Metadata, detail.Metadata)) {
+		return tenkiSession{}, exit(4, "lease_id_conflict: Tenki detail ownership differs from inventory for %s", claim.LeaseID)
+	}
+	if err := b.validateFixedSession(claim, detail); err != nil {
+		return tenkiSession{}, err
+	}
+	return detail, nil
+}
+
+func (b *tenkiBackend) bindFixedSession(claim *LeaseClaim, session tenkiSession, persist func() error) error {
+	if err := b.validateFixedSession(*claim, session); err != nil {
+		return err
+	}
+	if claim.CloudID != "" {
+		return nil
+	}
+	attempt, err := b.fixedAttempt(*claim)
+	if err != nil {
+		return err
+	}
+	attempt.SessionID = session.ID
+	claim.CloudID, claim.CloudImmutableID = session.ID, session.ID
+	claim.Labels = b.sessionToServer(b.configForRun(), session, claim.LeaseID, claim.Slug, attempt.Keep).Labels
+	claim.Labels[tenkiFixedIntentLabel], claim.Labels[tenkiFixedRouteLabel] = claim.FixedCreateIntent.Fingerprint, attempt.Route
+	return saveTenkiAttempt(claim.FixedCreateIntent, *attempt, persist)
+}
+
+func (b *tenkiBackend) fixedServer(claim LeaseClaim, session tenkiSession) Server {
+	server := b.sessionToServer(b.configForRun(), session, claim.LeaseID, claim.Slug, session.Sticky)
+	// Local heartbeat labels are newer than create-time provider metadata.
+	maps.Copy(server.Labels, claim.Labels)
+	server.Labels["state"] = tenkiState(session.State)
+	server.Labels[tenkiFixedIntentLabel] = claim.FixedCreateIntent.Fingerprint
+	server.Labels[tenkiFixedRouteLabel] = tenkiFixedRoute(b.configForRun())
+	server.ImmutableID = session.ID
+	return server
+}
+
+func (b *tenkiBackend) prepareFixedLease(ctx context.Context, claim LeaseClaim, session tenkiSession) (LeaseTarget, error) {
+	validate := func(session tenkiSession) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := b.validateFixedSession(claim, session); err != nil {
+			return err
+		}
+		return rejectTerminalTenkiSession(session)
+	}
+	cfg := b.configForRun()
+	session, err := b.ensureSessionReadyForSSH(ctx, cfg, session, validate)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if !tenkiSessionReady(session) {
+		session, err = b.waitForSessionReady(ctx, session.ID, bootstrapWaitTimeout(cfg), validate)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+	}
+	if err := validate(session); err != nil {
+		return LeaseTarget{}, err
+	}
+	target, err := b.resolveSSHTarget(ctx, cfg, session.ID)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if err := waitForSSHReadyFunc(ctx, &target, b.rt.Stderr, "tenki sandbox ssh", bootstrapWaitTimeout(cfg)); err != nil {
+		return LeaseTarget{}, err
+	}
+	session, err = b.getSession(ctx, session.ID)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if err := validate(session); err != nil {
+		return LeaseTarget{}, err
+	}
+	if !tenkiSessionReady(session) {
+		return LeaseTarget{}, exit(4, "fixed Tenki session %s is no longer ready", session.ID)
+	}
+	return LeaseTarget{LeaseID: claim.LeaseID, Server: b.fixedServer(claim, session), SSH: target}, nil
+}
+
+func fixedTenkiClaimEvidence(claim LeaseClaim) bool {
+	return claim.FixedCreateIntent != nil || claim.Labels[tenkiFixedIntentLabel] != ""
+}
+
+func (b *tenkiBackend) fixedClaimForIdentifier(identifier string) (LeaseClaim, bool, error) {
+	claim, exists, err := resolveLeaseClaim(identifier)
+	if err != nil {
+		return LeaseClaim{}, false, err
+	}
+	if !exists {
+		claim, exists, err = core.ResolveLeaseClaimForProviderCloudID(identifier, tenkiProvider)
+		if err != nil {
+			return LeaseClaim{}, false, err
+		}
+	}
+	return claim, exists && fixedTenkiClaimEvidence(claim), nil
+}
+
+func (b *tenkiBackend) resolveFixed(ctx context.Context, req ResolveRequest, expected LeaseClaim) (LeaseTarget, error) {
+	var lease LeaseTarget
+	err := core.WithDurableLeaseClaimLockContext(ctx, expected.LeaseID, func(claim *LeaseClaim, exists bool, persist func() error) error {
+		if !exists || !reflect.DeepEqual(*claim, expected) {
+			return exit(4, "lease_id_conflict: fixed Tenki claim changed during resolution; retry")
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if req.Repo.Root != "" && claim.RepoRoot != req.Repo.Root {
+			return exit(4, "lease_id_conflict: fixed Tenki lease %s belongs to another repository", claim.LeaseID)
+		}
+		if claim.FixedCreateIntent != nil && claim.FixedCreateIntent.State == "released" {
+			if err := tenkiFixedKind.ValidateTerminalClaim(*claim, LeaseClaim{}, claim.LeaseID, b.validateTerminalClaim); err != nil {
+				return err
+			}
+			if !req.StatusOnly && !req.ReleaseOnly {
+				return exit(4, "lease_id_conflict: fixed Tenki lease %s is terminal", claim.LeaseID)
+			}
+			labels := maps.Clone(claim.Labels)
+			labels["lease"], labels["slug"], labels["provider"], labels["state"] = claim.LeaseID, claim.Slug, tenkiProvider, "terminated"
+			lease = LeaseTarget{LeaseID: claim.LeaseID, Server: Server{CloudID: claim.CloudID, ImmutableID: claim.CloudImmutableID, Provider: tenkiProvider, Name: leaseProviderName(claim.LeaseID, claim.Slug), Status: "terminated", Labels: labels}}
+			core.SetServerLeaseClaimSnapshot(&lease.Server, *claim, true)
+			return nil
+		}
+		session, err := b.resolveFixedSession(ctx, *claim)
+		if err != nil {
+			return err
+		}
+		if session.ID == "" {
+			return exit(4, "lease_id_conflict: fixed Tenki lease %s has no observed session; retain its claim", claim.LeaseID)
+		}
+		if !req.StatusOnly && !req.ReleaseOnly {
+			if err := rejectTerminalTenkiSession(session); err != nil {
+				return err
+			}
+			if req.NoLocalStateMutations {
+				return exit(4, "fixed Tenki command preparation requires durable identity binding")
+			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if err := core.AuthorizeCheckpointRelease(*claim, ""); err != nil {
+				return err
+			}
+			if err := b.bindFixedSession(claim, session, persist); err != nil {
+				return err
+			}
+			lease, err = b.prepareFixedLease(ctx, *claim, session)
+			if err != nil {
+				return err
+			}
+			claim.Labels, claim.SSHHost = maps.Clone(lease.Server.Labels), lease.SSH.Host
+			claim.SSHPort, _ = strconv.Atoi(lease.SSH.Port)
+			claim.LastUsedAt = tenkiNow().UTC().Format(time.RFC3339)
+			claim.FixedCreateIntent.State = "acquired"
+			if err := persist(); err != nil {
+				return err
+			}
+		} else {
+			// Inspection and release resolution do not resume, bind, or renew a claim.
+			lease = LeaseTarget{LeaseID: claim.LeaseID, Server: b.fixedServer(*claim, session)}
+			if claim.CloudID != "" && (req.ReadyProbe || req.IncludeDiagnostics) && tenkiSessionReady(session) {
+				lease.SSH, err = b.resolveSSHTarget(ctx, b.configForRun(), session.ID)
+				if err != nil {
+					return err
+				}
+				observed, err := b.getSession(ctx, session.ID)
+				if err != nil {
+					return err
+				}
+				if observed.ID != session.ID {
+					return exit(4, "lease_id_conflict: Tenki inspection session identity changed")
+				}
+				if err := b.validateFixedSession(*claim, observed); err != nil {
+					return err
+				}
+				lease.Server = b.fixedServer(*claim, observed)
+				if !tenkiSessionReady(observed) {
+					lease.SSH = SSHTarget{}
+				}
+			}
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		core.SetServerLeaseClaimSnapshot(&lease.Server, *claim, true)
+		return nil
+	})
+	return lease, err
+}
+
+// Renew only the exact durable local claim after a fresh identity check.
+// This does not resume the session, prepare SSH, or change Tenki's idle timer.
+func (b *tenkiBackend) touchFixed(ctx context.Context, req TouchRequest) (Server, error) {
+	updated, err := shared.CommitClaimTouch(ctx, req, shared.ClaimTouchPolicy{
+		Provider: tenkiProvider,
+		Authorize: func(ctx context.Context, lease LeaseTarget, claim LeaseClaim) error {
+			if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
+				return err
+			}
+			if claim.LeaseID != lease.LeaseID || claim.CloudID == "" || lease.Server.CloudID != claim.CloudID || lease.Server.ImmutableID != claim.CloudImmutableID {
+				return exit(4, "lease_id_conflict: fixed Tenki heartbeat has no exact bound identity")
+			}
+			session, err := b.resolveFixedSession(ctx, claim)
+			if err != nil {
+				return err
+			}
+			return rejectTerminalTenkiSession(session)
+		},
+		Prepare: func(claim LeaseClaim) (map[string]string, time.Time) {
+			now := tenkiNow().UTC()
+			labels := core.TouchDirectLeaseLabelsWithIdleTimeoutOverride(claim.Labels, b.configForRun(), req.State, now, req.IdleTimeoutOverride)
+			return labels, now
+		},
+	})
+	if err != nil {
+		return Server{}, err
+	}
+	server := req.Lease.Server
+	server.Labels = maps.Clone(updated.Labels)
+	core.SetServerLeaseClaimSnapshot(&server, updated, true)
+	return server, nil
+}
+
+func (b *tenkiBackend) validateTerminalClaim(claim LeaseClaim) error {
+	if !core.IsCanonicalLeaseID(claim.LeaseID) || claim.CloudID == "" || claim.CloudImmutableID != claim.CloudID || claim.CloudNumericID != 0 ||
+		claim.ProviderScope != (Provider{}).ClaimScope(b.configForRun()) || claim.Labels["tenki_session_id"] != claim.CloudID ||
+		claim.Labels[tenkiFixedIntentLabel] != claim.FixedCreateIntent.Fingerprint || !tenkiSHA256(claim.FixedCreateIntent.Fingerprint) ||
+		claim.Labels[tenkiFixedRouteLabel] != tenkiFixedRoute(b.configForRun()) || claim.FixedCreateIntent.CheckpointID != "" {
+		return exit(4, "lease_id_conflict: fixed Tenki lease %s has an invalid terminal receipt or changed connection configuration", claim.LeaseID)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, claim.FixedCreateIntent.CreatedAt); err != nil {
+		return exit(4, "lease_id_conflict: invalid terminal Tenki create timestamp")
+	}
+	return nil
+}
+
+func (b *tenkiBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
+	return err
+}
+
+func (b *tenkiBackend) ReleaseLeaseWithOutcome(ctx context.Context, req ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+	var outcome core.ReleaseLeaseOutcome
+	expected, exists, err := core.ReadLeaseClaimWithPresence(req.Lease.LeaseID)
+	if err != nil {
+		return outcome, err
+	}
+	if !exists || !fixedTenkiClaimEvidence(expected) {
+		if req.Lease.Server.Labels[tenkiFixedIntentLabel] != "" {
+			return outcome, exit(4, "lease_id_conflict: fixed Tenki release has no durable claim")
+		}
+		err := b.releaseOrdinaryLease(ctx, req)
+		outcome.Terminal = err == nil
+		return outcome, err
+	}
+	snapshot, snapshotExists, snapshotSet := core.ServerLeaseClaimSnapshot(req.Lease.Server)
+	if !snapshotSet || !snapshotExists || !reflect.DeepEqual(snapshot, expected) {
+		return outcome, exit(4, "lease_id_conflict: fixed Tenki claim changed after resolution; resolve again before release")
+	}
+	err = core.WithDurableLeaseClaimLockContext(ctx, expected.LeaseID, func(claim *LeaseClaim, exists bool, persist func() error) error {
+		if !exists || !reflect.DeepEqual(*claim, expected) {
+			return exit(4, "lease_id_conflict: fixed Tenki claim changed before release; retry")
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := core.AuthorizeCheckpointRelease(*claim, req.CheckpointID); err != nil {
+			return err
+		}
+		if claim.FixedCreateIntent != nil && claim.FixedCreateIntent.State == "released" {
+			err := tenkiFixedKind.ValidateTerminalClaim(*claim, snapshot, claim.LeaseID, b.validateTerminalClaim)
+			outcome.Terminal = err == nil
+			return err
+		}
+		session, err := b.resolveFixedSession(ctx, *claim)
+		if err != nil {
+			return err
+		}
+		if session.ID == "" {
+			return exit(4, "lease_id_conflict: fixed Tenki session absence is unverified; retain its claim")
+		}
+		if req.Lease.Server.CloudID != session.ID || req.Lease.Server.ImmutableID != session.ID || req.Lease.Server.Labels["slug"] != claim.Slug {
+			return exit(4, "lease_id_conflict: fixed Tenki release target changed")
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := b.bindFixedSession(claim, session, persist); err != nil {
+			return err
+		}
+		// Re-attest full detail immediately before mutation under the same lock.
+		session, err = b.getSession(ctx, claim.CloudID)
+		if err != nil {
+			return err
+		}
+		if err := b.validateFixedSession(*claim, session); err != nil {
+			return err
+		}
+		if rejectTerminalTenkiSession(session) == nil {
+			if err := b.terminateSession(ctx, session.ID); err != nil {
+				return err
+			}
+			if err := b.waitForTerminationAcknowledged(ctx, session.ID, func(observed tenkiSession) error { return b.validateFixedSession(*claim, observed) }); err != nil {
+				return err
+			}
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		outcome.Terminal = true
+		*claim = tenkiFixedKind.TerminalClaim(*claim, tenkiNow().UTC())
+		return persist()
+	})
+	return outcome, err
+}
+
+func (b *tenkiBackend) RetainLeaseClaimAfterReleaseWithClaim(lease LeaseTarget, previous LeaseClaim) (bool, error) {
+	return tenkiFixedKind.RetainClaimAfterRelease(lease.LeaseID, previous, lease.Server.Labels[tenkiFixedIntentLabel] != "", b.validateTerminalClaim, nil)
+}

--- a/internal/providers/tenki/fixed_lifecycle_test.go
+++ b/internal/providers/tenki/fixed_lifecycle_test.go
@@ -1,0 +1,797 @@
+package tenki
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func requireFixedClaim(t *testing.T) LeaseClaim {
+	t.Helper()
+	claim, exists, err := core.ReadLeaseClaimWithPresence(testFixedTenkiID)
+	if err != nil || !exists || claim.FixedCreateIntent == nil {
+		t.Fatalf("fixed claim missing: %+v exists=%t err=%v", claim, exists, err)
+	}
+	return claim
+}
+
+func requireFixedConflict(t *testing.T, err error) {
+	t.Helper()
+	if err == nil || !strings.Contains(err.Error(), "lease_id_conflict") {
+		t.Fatalf("err=%v, want fixed identity conflict", err)
+	}
+}
+
+func requireFixedAcquire(t *testing.T, b *tenkiBackend, req AcquireRequest) LeaseTarget {
+	t.Helper()
+	lease, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return lease
+}
+
+func requireFixedReleaseTarget(t *testing.T, b *tenkiBackend) LeaseTarget {
+	t.Helper()
+	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: testFixedTenkiID, ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return lease
+}
+
+func TestTenkiFixedReplayRejectsRequestDrift(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		change func(*Config, *AcquireRequest)
+	}{
+		{"slug", func(_ *Config, r *AcquireRequest) { r.RequestedSlug = "different-operation" }},
+		{"keep", func(_ *Config, r *AcquireRequest) { r.Keep = false }},
+		{"ttl", func(c *Config, _ *AcquireRequest) { c.TTL += time.Second }},
+		{"idle", func(c *Config, _ *AcquireRequest) { c.IdleTimeout += time.Second }},
+		{"endpoint", func(c *Config, _ *AcquireRequest) { c.Tenki.Endpoint = "https://other.example" }},
+		{"gateway", func(c *Config, _ *AcquireRequest) { c.Tenki.Gateway = "wss://other.example" }},
+		{"cli", func(c *Config, _ *AcquireRequest) { c.Tenki.CLIPath = "/other/tenki" }},
+		{"work root", func(c *Config, _ *AcquireRequest) { c.Tenki.WorkRoot = "/home/tenki/other" }},
+		{"image", func(c *Config, _ *AcquireRequest) { c.Tenki.Image = "other/image" }},
+		{"snapshot", func(c *Config, _ *AcquireRequest) { c.Tenki.Image, c.Tenki.Snapshot = "", "snapshot-other" }},
+		{"cpu", func(c *Config, _ *AcquireRequest) { c.Tenki.CPUs++ }},
+		{"memory", func(c *Config, _ *AcquireRequest) { c.Tenki.MemoryMB++ }},
+		{"disk", func(c *Config, _ *AcquireRequest) { c.Tenki.DiskGB++ }},
+		{"profile", func(c *Config, _ *AcquireRequest) { c.Profile = "other" }},
+		{"pond", func(c *Config, _ *AcquireRequest) { c.Pond = "other" }},
+		{"desktop", func(c *Config, _ *AcquireRequest) { c.Desktop = true }},
+		{"cache", func(c *Config, _ *AcquireRequest) { c.Cache.PurgeOnRelease = true }},
+		{"foreign repo even with reclaim", func(_ *Config, r *AcquireRequest) { r.Repo.Root += "/other"; r.Reclaim = true }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, f, req := newFixedTenkiTest(t)
+			requireFixedAcquire(t, b, req)
+			before := requireFixedClaim(t)
+			calls := maps.Clone(f.calls)
+			fresh := *b
+			tc.change(&fresh.cfg, &req)
+			_, err := fresh.Acquire(context.Background(), req)
+			requireFixedConflict(t, err)
+			if !reflect.DeepEqual(before, requireFixedClaim(t)) || !maps.Equal(calls, f.calls) {
+				t.Fatalf("drift caused a claim/provider effect: calls=%v want=%v", f.calls, calls)
+			}
+		})
+	}
+}
+
+func TestTenkiFixedReplayPreservesHeartbeatLabels(t *testing.T) {
+	b, f, req := newFixedTenkiTest(t)
+	first := requireFixedAcquire(t, b, req)
+	before := requireFixedClaim(t)
+	idle := 15 * time.Minute
+	touched, err := b.Touch(context.Background(), TouchRequest{Lease: first, State: "ready", IdleTimeout: idle, IdleTimeoutOverride: &idle})
+	if err != nil {
+		t.Fatal(err)
+	}
+	labels := touched.Labels
+	if labels["idle_timeout_secs"] != "900" || requireFixedClaim(t).IdleTimeoutSeconds != 900 {
+		t.Fatalf("heartbeat did not persist the override: labels=%v claim=%+v", labels, requireFixedClaim(t))
+	}
+	req.RequestedSlug = " Build Linux " // Same normalized request, not the allocated slug.
+	second := requireFixedAcquire(t, b, req)
+	claim := requireFixedClaim(t)
+	if second.Server.CloudID != first.Server.CloudID || f.calls["create"] != 1 || !reflect.DeepEqual(before.FixedCreateIntent, claim.FixedCreateIntent) {
+		t.Fatalf("replay changed identity: claim=%+v calls=%v", claim, f.calls)
+	}
+	for _, key := range []string{"last_touched_at", "expires_at", "idle_timeout_secs", "idle_timeout"} {
+		if claim.Labels[key] != labels[key] {
+			t.Fatalf("replay reverted heartbeat %s: got=%s want=%s", key, claim.Labels[key], labels[key])
+		}
+	}
+}
+
+func TestTenkiFixedForeignClaimsAndUnownedInventory(t *testing.T) {
+	for _, mode := range []string{"foreign provider", "ordinary claim", "foreign session", "duplicate inventory", "missing local attempt", "erased attempt"} {
+		t.Run(mode, func(t *testing.T) {
+			b, f, req := newFixedTenkiTest(t)
+			switch mode {
+			case "foreign provider", "ordinary claim":
+				cfg := b.configForRun()
+				if mode == "foreign provider" {
+					cfg.Provider = "ssh"
+				}
+				if err := core.ClaimLeaseTargetForRepoConfig(req.RequestedLeaseID, req.RequestedSlug, cfg, Server{Provider: cfg.Provider, CloudID: "foreign"}, SSHTarget{}, req.Repo.Root, time.Minute, false); err != nil {
+					t.Fatal(err)
+				}
+			case "foreign session":
+				f.sessions["foreign"] = tenkiSession{ID: "foreign", Name: leaseProviderName(req.RequestedLeaseID, req.RequestedSlug), State: "RUNNING", Metadata: map[string]string{tenkiMetadataProvider: tenkiProvider, tenkiMetadataLease: req.RequestedLeaseID, tenkiMetadataSlug: req.RequestedSlug}}
+			case "duplicate inventory", "missing local attempt":
+				requireFixedAcquire(t, b, req)
+				if mode == "duplicate inventory" {
+					duplicate := cloneTenkiSession(f.sessions["session-1"])
+					duplicate.ID = "duplicate"
+					f.sessions[duplicate.ID] = duplicate
+				} else {
+					core.RemoveLeaseClaim(req.RequestedLeaseID)
+				}
+			case "erased attempt":
+				f.createError = errors.New("lost response")
+				if _, err := b.Acquire(context.Background(), req); err == nil {
+					t.Fatal("expected lost response")
+				}
+				if err := core.WithDurableLeaseClaimLock(req.RequestedLeaseID, func(claim *LeaseClaim, _ bool, persist func() error) error {
+					claim.FixedCreateIntent.Attempt = nil
+					return persist()
+				}); err != nil {
+					t.Fatal(err)
+				}
+				f.sessions = map[string]tenkiSession{}
+				f.createError = nil
+			}
+			creates, ssh := f.calls["create"], f.calls["ssh-command"]
+			req.Reclaim = true
+			_, err := b.Acquire(context.Background(), req)
+			requireFixedConflict(t, err)
+			if f.calls["create"] != creates || f.calls["terminate"] != 0 || f.calls["ssh-command"] != ssh {
+				t.Fatalf("unsafe calls: %v", f.calls)
+			}
+		})
+	}
+}
+
+func TestTenkiFixedCreateFailuresRetainAttempt(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		output       string
+		commandError bool
+		knownID      bool
+	}{
+		{"malformed JSON", "{", false, false},
+		{"missing ID", "{}", false, false},
+		{"partial JSON with ID", `{"id":"session-1","bad":`, false, false},
+		{"error with ID", `{"id":"session-1"}`, true, true},
+		{"wrong returned ID", `{"id":"other"}`, false, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, f, req := newFixedTenkiTest(t)
+			req.Keep = false
+			f.createOutput = &tc.output
+			if tc.commandError {
+				f.createError = errors.New("output failed")
+			}
+			if _, err := b.Acquire(context.Background(), req); err == nil {
+				t.Fatal("expected create failure")
+			}
+			claim := requireFixedClaim(t)
+			attempt, err := b.fixedAttempt(claim)
+			if err != nil || attempt == nil || (attempt.SessionID != "") != tc.knownID || claim.CloudID != "" {
+				t.Fatalf("attempt=%+v claim=%+v err=%v", attempt, claim, err)
+			}
+			f.createOutput, f.createError = nil, nil
+			invisible := []tenkiSession{}
+			f.listOverride = &invisible
+			f.hook = func(_ context.Context, r LocalCommandRequest) (LocalCommandResult, error, bool) {
+				if r.Args[1] == "get" {
+					return LocalCommandResult{ExitCode: 1}, errors.New("API key not found"), true
+				}
+				return LocalCommandResult{}, nil, false
+			}
+			for i := 0; i < 2; i++ {
+				fresh := *b
+				if _, err := fresh.Acquire(context.Background(), req); err == nil {
+					t.Fatal("uncertain create replay succeeded")
+				}
+			}
+			if f.calls["create"] != 1 || f.calls["terminate"] != 0 || f.calls["ssh-command"] != 0 {
+				t.Fatalf("unsafe calls=%v", f.calls)
+			}
+			if !reflect.DeepEqual(claim, requireFixedClaim(t)) {
+				t.Fatal("failed replay changed durable evidence")
+			}
+		})
+	}
+}
+
+func TestTenkiFixedGetFailureAfterCreateRetainsReturnedID(t *testing.T) {
+	b, f, req := newFixedTenkiTest(t)
+	f.hook = func(_ context.Context, r LocalCommandRequest) (LocalCommandResult, error, bool) {
+		if r.Args[1] == "get" {
+			return LocalCommandResult{ExitCode: 1}, errors.New("detail unavailable"), true
+		}
+		return LocalCommandResult{}, nil, false
+	}
+	if _, err := b.Acquire(context.Background(), req); err == nil {
+		t.Fatal("expected detail error")
+	}
+	claim := requireFixedClaim(t)
+	attempt, err := b.fixedAttempt(claim)
+	if err != nil || attempt.SessionID != "session-1" || claim.CloudID != "" {
+		t.Fatalf("claim=%+v attempt=%+v err=%v", claim, attempt, err)
+	}
+	invisible := []tenkiSession{}
+	f.listOverride = &invisible
+	if _, err := b.Acquire(context.Background(), req); err == nil {
+		t.Fatal("expected detail error on replay")
+	}
+	f.hook = nil
+	lease := requireFixedAcquire(t, b, req)
+	if lease.Server.CloudID != "session-1" || f.calls["create"] != 1 {
+		t.Fatalf("lease=%+v calls=%v", lease, f.calls)
+	}
+}
+
+func TestTenkiFixedDetailAttestationBeforeSSH(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		change func(*tenkiSession)
+	}{
+		{"ID", func(s *tenkiSession) { s.ID = "foreign" }},
+		{"empty ID", func(s *tenkiSession) { s.ID = "" }},
+		{"name", func(s *tenkiSession) { s.Name = "foreign" }},
+		{"provider", func(s *tenkiSession) { s.Metadata[tenkiMetadataProvider] = "foreign" }},
+		{"lease", func(s *tenkiSession) { s.Metadata[tenkiMetadataLease] = "cbx_000000000001" }},
+		{"slug", func(s *tenkiSession) { s.Metadata[tenkiMetadataSlug] = "foreign" }},
+		{"token", func(s *tenkiSession) { s.Metadata[tenkiMetadataAttempt] = "foreign" }},
+		{"fingerprint", func(s *tenkiSession) { s.Metadata[tenkiMetadataIntent] = "foreign" }},
+		{"image", func(s *tenkiSession) { s.SourceImageRef = "foreign" }},
+		{"CPU", func(s *tenkiSession) { s.CPUCores++ }},
+		{"memory", func(s *tenkiSession) { s.MemoryMB++ }},
+		{"disk", func(s *tenkiSession) { s.DiskSizeGB++ }},
+		{"keep", func(s *tenkiSession) { s.Sticky = false }},
+		{"terminal", func(s *tenkiSession) { s.State = "TERMINATED" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, f, req := newFixedTenkiTest(t)
+			f.hook = func(_ context.Context, r LocalCommandRequest) (LocalCommandResult, error, bool) {
+				if r.Args[1] != "get" {
+					return LocalCommandResult{}, nil, false
+				}
+				s := cloneTenkiSession(f.sessions["session-1"])
+				tc.change(&s)
+				data, _ := json.Marshal(s)
+				return LocalCommandResult{Stdout: string(data)}, nil, true
+			}
+			_, err := b.Acquire(context.Background(), req)
+			requireFixedConflict(t, err)
+			if f.calls["create"] != 1 || f.calls["ssh-command"] != 0 || f.calls["resume"] != 0 || f.calls["terminate"] != 0 || requireFixedClaim(t).CloudID != "" {
+				t.Fatalf("unattested session used: calls=%v", f.calls)
+			}
+		})
+	}
+}
+
+func TestTenkiFixedReadinessReattestsBeforeResumeAndAfterSSH(t *testing.T) {
+	for _, state := range []string{"PAUSING", "RESUMING", "PAUSED", "SSH ready"} {
+		t.Run(state, func(t *testing.T) {
+			b, f, req := newFixedTenkiTest(t)
+			req.Keep = false
+			requireFixedAcquire(t, b, req)
+			sshCalls := f.calls["ssh-command"]
+			getCalls := f.calls["get"]
+			s := f.sessions["session-1"]
+			if state == "SSH ready" {
+				waitForSSHReadyFunc = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+					s.Metadata[tenkiMetadataAttempt] = "foreign"
+					f.sessions[s.ID] = s
+					return nil
+				}
+			} else {
+				s.State = state
+				f.sessions[s.ID] = s
+				f.hook = func(_ context.Context, r LocalCommandRequest) (LocalCommandResult, error, bool) {
+					if r.Args[1] != "get" || f.calls["get"] <= getCalls+1 {
+						return LocalCommandResult{}, nil, false
+					}
+					bad := cloneTenkiSession(s)
+					bad.ID, bad.State = "wrong-session", "PAUSED"
+					data, _ := json.Marshal(bad)
+					return LocalCommandResult{Stdout: string(data)}, nil, true
+				}
+			}
+			_, err := b.Acquire(context.Background(), req)
+			requireFixedConflict(t, err)
+			if f.calls["create"] != 1 || f.calls["terminate"] != 0 || requireFixedClaim(t).CloudID != "session-1" {
+				t.Fatalf("unsafe readiness cleanup: %v", f.calls)
+			}
+			wantResume := 0
+			if state == "PAUSED" {
+				wantResume = 1
+			}
+			if state == "SSH ready" {
+				sshCalls++
+			}
+			if f.calls["resume"] != wantResume || f.calls["ssh-command"] != sshCalls {
+				t.Fatalf("unattested poll used for resume/SSH: %v", f.calls)
+			}
+		})
+	}
+}
+
+func TestTenkiFixedCancellationRetainsEvidence(t *testing.T) {
+	for _, phase := range []string{"before create", "during create", "readiness"} {
+		t.Run(phase, func(t *testing.T) {
+			b, f, req := newFixedTenkiTest(t)
+			req.Keep = false
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			switch phase {
+			case "before create":
+				cancel()
+			case "during create":
+				f.hook = func(_ context.Context, r LocalCommandRequest) (LocalCommandResult, error, bool) {
+					if r.Args[1] == "create" {
+						cancel()
+					}
+					return LocalCommandResult{}, nil, false
+				}
+			case "readiness":
+				waitForSSHReadyFunc = func(ctx context.Context, _ *SSHTarget, _ io.Writer, _ string, _ time.Duration) error {
+					cancel()
+					return ctx.Err()
+				}
+			}
+			_, err := b.Acquire(ctx, req)
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("err=%v, want cancellation", err)
+			}
+			if f.calls["terminate"] != 0 {
+				t.Fatal("cancellation deleted fixed session")
+			}
+			claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			if phase == "before create" {
+				if err != nil || exists || len(f.calls) != 0 {
+					t.Fatalf("pre-cancel mutated state: claim=%+v err=%v calls=%v", claim, err, f.calls)
+				}
+				return
+			}
+			if err != nil || !exists || claim.FixedCreateIntent == nil || len(claim.FixedCreateIntent.Attempt) == 0 {
+				t.Fatalf("lost attempt: %+v err=%v", claim, err)
+			}
+			if phase == "during create" && claim.CloudID != "" {
+				t.Fatal("bound session before detail attestation")
+			}
+			if phase == "readiness" && claim.CloudID != "session-1" {
+				t.Fatal("readiness preceded immutable binding")
+			}
+			f.hook = nil
+			waitForSSHReadyFunc = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error { return nil }
+			requireFixedAcquire(t, b, req)
+			if f.calls["create"] != 1 {
+				t.Fatalf("resubmitted after cancellation: %v", f.calls)
+			}
+		})
+	}
+}
+
+func TestTenkiFixedResolvePreservesIntentAndReadOnlyInspection(t *testing.T) {
+	for _, state := range []string{"RUNNING", "PAUSED", "TERMINATED"} {
+		t.Run(state, func(t *testing.T) {
+			b, f, req := newFixedTenkiTest(t)
+			lease := requireFixedAcquire(t, b, req)
+			s := f.sessions["session-1"]
+			s.State = state
+			f.sessions[s.ID] = s
+			before := requireFixedClaim(t)
+			sshCalls := f.calls["ssh-command"]
+			for _, id := range []string{lease.LeaseID, req.RequestedSlug, lease.Server.CloudID} {
+				got, err := b.Resolve(context.Background(), ResolveRequest{ID: id, StatusOnly: true, NoLocalStateMutations: true, IncludeDiagnostics: true})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got.LeaseID != req.RequestedLeaseID || got.Server.CloudID != "session-1" {
+					t.Fatalf("wrong inspection identity: %+v", got)
+				}
+				if state == "RUNNING" {
+					if got.SSH.Host == "" || got.SSH.NetworkKind != networkPublic {
+						t.Fatalf("missing inspection SSH: %+v", got)
+					}
+					sshCalls++
+				} else if got.SSH.Host != "" {
+					t.Fatal("nonready inspection obtained SSH")
+				}
+				if !reflect.DeepEqual(before, requireFixedClaim(t)) {
+					t.Fatal("read-only inspect changed fixed evidence")
+				}
+			}
+			if f.calls["ssh-command"] != sshCalls || f.calls["resume"] != 0 {
+				t.Fatalf("inspection side effect: %v", f.calls)
+			}
+			if state == "TERMINATED" {
+				_, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Repo: req.Repo, Reclaim: true})
+				requireFixedConflict(t, err)
+				return
+			}
+			got, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Repo: req.Repo})
+			if err != nil {
+				t.Fatal(err)
+			}
+			after := requireFixedClaim(t)
+			if got.Server.CloudID != "session-1" || !reflect.DeepEqual(before.FixedCreateIntent, after.FixedCreateIntent) || after.CloudImmutableID != before.CloudImmutableID {
+				t.Fatal("command reuse overwrote fixed identity")
+			}
+		})
+	}
+}
+
+func TestTenkiFixedResolveUnboundAttemptAndForeignMetadata(t *testing.T) {
+	b, f, req := newFixedTenkiTest(t)
+	f.createError = errors.New("lost response")
+	if _, err := b.Acquire(context.Background(), req); err == nil {
+		t.Fatal("expected error")
+	}
+	before := requireFixedClaim(t)
+	status, err := b.Resolve(context.Background(), ResolveRequest{ID: req.RequestedLeaseID, StatusOnly: true, NoLocalStateMutations: true, IncludeDiagnostics: true})
+	if err != nil || status.Server.CloudID != "session-1" || status.SSH.Host != "" || f.calls["ssh-command"] != 0 {
+		t.Fatalf("status=%+v err=%v calls=%v", status, err, f.calls)
+	}
+	if !reflect.DeepEqual(before, requireFixedClaim(t)) {
+		t.Fatal("inspection bound uncertain claim")
+	}
+	lease := requireFixedReleaseTarget(t, b)
+	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if f.calls["terminate"] != 1 {
+		t.Fatalf("release calls=%v", f.calls)
+	}
+	core.RemoveLeaseClaim(req.RequestedLeaseID)
+	for _, id := range []string{req.RequestedLeaseID, "session-1"} {
+		_, err := b.Resolve(context.Background(), ResolveRequest{ID: id, Repo: req.Repo, Reclaim: true})
+		requireFixedConflict(t, err)
+	}
+}
+
+func TestTenkiFixedReleaseRetainsSingleUseReceipt(t *testing.T) {
+	b, f, req := newFixedTenkiTest(t)
+	requireFixedAcquire(t, b, req)
+	lease := requireFixedReleaseTarget(t, b)
+	previous := requireFixedClaim(t)
+	outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: lease})
+	if err != nil || !outcome.Terminal {
+		t.Fatalf("outcome=%+v err=%v", outcome, err)
+	}
+	terminal := requireFixedClaim(t)
+	if terminal.FixedCreateIntent.State != "released" || terminal.CloudID != "session-1" || terminal.SSHHost != "" || len(terminal.FixedCreateIntent.Attempt) != 0 {
+		t.Fatalf("invalid terminal receipt: %+v", terminal)
+	}
+	if retained, err := b.RetainLeaseClaimAfterReleaseWithClaim(lease, previous); err != nil || !retained {
+		t.Fatalf("receipt not retained: retained=%t err=%v", retained, err)
+	}
+	calls := maps.Clone(f.calls)
+	f.hook = func(context.Context, LocalCommandRequest) (LocalCommandResult, error, bool) {
+		return LocalCommandResult{}, errors.New("terminal replay must not use Tenki"), true
+	}
+	for i := 0; i < 2; i++ {
+		lease = requireFixedReleaseTarget(t, b)
+		outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: lease})
+		if err != nil || !outcome.Terminal {
+			t.Fatalf("repeated stop outcome=%+v err=%v", outcome, err)
+		}
+		if retained, err := b.RetainLeaseClaimAfterReleaseWithClaim(lease, terminal); err != nil || !retained {
+			t.Fatalf("retention=%t err=%v", retained, err)
+		}
+	}
+	status, err := b.Resolve(context.Background(), ResolveRequest{ID: req.RequestedLeaseID, StatusOnly: true, IncludeDiagnostics: true, NoLocalStateMutations: true})
+	if err != nil || status.Server.Status != "terminated" || status.SSH.Host != "" {
+		t.Fatalf("status=%+v err=%v", status, err)
+	}
+	_, err = b.Acquire(context.Background(), req)
+	requireFixedConflict(t, err)
+	_, err = b.Resolve(context.Background(), ResolveRequest{ID: req.RequestedLeaseID, Reclaim: true})
+	requireFixedConflict(t, err)
+	if !maps.Equal(calls, f.calls) || !reflect.DeepEqual(terminal, requireFixedClaim(t)) {
+		t.Fatalf("terminal replay mutated state: calls=%v want=%v", f.calls, calls)
+	}
+}
+
+func TestTenkiFixedReleaseUncertaintyAndWrongAcknowledgement(t *testing.T) {
+	for _, mode := range []string{"terminate error", "get error", "running", "wrong ID", "missing ID", "wrong token", "wrong project", "canceled"} {
+		t.Run(mode, func(t *testing.T) {
+			b, f, req := newFixedTenkiTest(t)
+			requireFixedAcquire(t, b, req)
+			lease := requireFixedReleaseTarget(t, b)
+			before := requireFixedClaim(t)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			f.hook = func(_ context.Context, r LocalCommandRequest) (LocalCommandResult, error, bool) {
+				if r.Args[1] == "terminate" && mode == "terminate error" {
+					return LocalCommandResult{ExitCode: 1}, errors.New("workspace not found"), true
+				}
+				if r.Args[1] != "get" || f.calls["terminate"] == 0 {
+					return LocalCommandResult{}, nil, false
+				}
+				if mode == "get error" {
+					return LocalCommandResult{ExitCode: 1}, errors.New("API key not found"), true
+				}
+				s := cloneTenkiSession(f.sessions["session-1"])
+				switch mode {
+				case "running":
+					s.State = "RUNNING"
+				case "wrong ID":
+					s.ID = "foreign"
+				case "missing ID":
+					s.ID = ""
+				case "wrong token":
+					s.Metadata[tenkiMetadataAttempt] = "foreign"
+				case "wrong project":
+					s.ProjectID = "foreign"
+				case "canceled":
+					cancel()
+				}
+				data, _ := json.Marshal(s)
+				return LocalCommandResult{Stdout: string(data)}, nil, true
+			}
+			outcome, err := b.ReleaseLeaseWithOutcome(ctx, ReleaseLeaseRequest{Lease: lease})
+			if err == nil || outcome.Terminal {
+				t.Fatalf("uncertain release finalized: outcome=%+v err=%v", outcome, err)
+			}
+			if !reflect.DeepEqual(before, requireFixedClaim(t)) {
+				t.Fatal("uncertain release erased or changed bound evidence")
+			}
+			f.hook = nil
+			lease = requireFixedReleaseTarget(t, b)
+			if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+				t.Fatal(err)
+			}
+			want := 1
+			if mode == "terminate error" {
+				want = 2
+			}
+			if f.calls["terminate"] != want || requireFixedClaim(t).FixedCreateIntent.State != "released" {
+				t.Fatalf("unexpected retry: calls=%v", f.calls)
+			}
+		})
+	}
+}
+
+func TestTenkiFixedReleaseAndResolveRejectChangedIdentity(t *testing.T) {
+	for _, mode := range []string{"claim revision", "target ID", "target immutable ID", "target slug", "scope", "route", "live token", "live project", "bound missing", "list error"} {
+		t.Run(mode, func(t *testing.T) {
+			b, f, req := newFixedTenkiTest(t)
+			requireFixedAcquire(t, b, req)
+			lease := requireFixedReleaseTarget(t, b)
+			s := cloneTenkiSession(f.sessions["session-1"])
+			switch mode {
+			case "claim revision":
+				claim := requireFixedClaim(t)
+				labels := maps.Clone(claim.Labels)
+				labels["state"] = "busy"
+				if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(req.RequestedLeaseID, claim, labels); err != nil {
+					t.Fatal(err)
+				}
+			case "target ID":
+				lease.Server.CloudID = "foreign"
+			case "target immutable ID":
+				lease.Server.ImmutableID = "foreign"
+			case "target slug":
+				lease.Server.Labels = maps.Clone(lease.Server.Labels)
+				lease.Server.Labels["slug"] = "foreign"
+			case "scope":
+				b.cfg.Tenki.Endpoint = "https://other.example"
+			case "route":
+				b.cfg.Tenki.Gateway = "wss://other.example"
+			case "live token":
+				s.Metadata[tenkiMetadataAttempt] = "foreign"
+				f.sessions[s.ID] = s
+			case "live project":
+				s.ProjectID = "foreign"
+				f.sessions[s.ID] = s
+			case "bound missing":
+				f.sessions = map[string]tenkiSession{}
+			case "list error":
+				f.hook = func(context.Context, LocalCommandRequest) (LocalCommandResult, error, bool) {
+					return LocalCommandResult{ExitCode: 1}, errors.New("inventory unavailable"), true
+				}
+			}
+			before := requireFixedClaim(t)
+			if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err == nil {
+				t.Fatal("unsafe release succeeded")
+			}
+			if !strings.HasPrefix(mode, "target") && mode != "claim revision" {
+				if _, err := b.Resolve(context.Background(), ResolveRequest{ID: req.RequestedLeaseID, Repo: req.Repo}); err == nil {
+					t.Fatal("unsafe reuse succeeded")
+				}
+				if _, err := b.Acquire(context.Background(), req); err == nil {
+					t.Fatal("unsafe acquisition succeeded")
+				}
+			}
+			if f.calls["terminate"] != 0 || f.calls["create"] != 1 || f.calls["ssh-command"] != 1 || !reflect.DeepEqual(before, requireFixedClaim(t)) {
+				t.Fatalf("changed identity used: %v", f.calls)
+			}
+		})
+	}
+}
+
+func TestTenkiFixedCallbackRunsOutsideLockAndRetainsFailure(t *testing.T) {
+	b, f, req := newFixedTenkiTest(t)
+	req.Keep = false
+	callbackErr := errors.New("callback failed")
+	req.OnAcquired = func(lease LeaseTarget) error {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := core.WithDurableLeaseClaimLockContext(ctx, lease.LeaseID, func(claim *LeaseClaim, exists bool, _ func() error) error {
+			if !exists || claim.CloudID != lease.Server.CloudID || claim.FixedCreateIntent.State != "acquired" {
+				return fmt.Errorf("callback saw uncommitted identity")
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+		return callbackErr
+	}
+	_, err := b.Acquire(context.Background(), req)
+	if !errors.Is(err, callbackErr) {
+		t.Fatalf("callback failed or deadlocked: %v", err)
+	}
+	if requireFixedClaim(t).CloudID != "session-1" || f.calls["terminate"] != 0 {
+		t.Fatal("callback failure deleted evidence")
+	}
+	req.OnAcquired = nil
+	requireFixedAcquire(t, b, req)
+	if f.calls["create"] != 1 {
+		t.Fatal("callback retry submitted create again")
+	}
+}
+
+func TestTenkiFixedAttemptIsDurableBeforeSubmissionAndSSH(t *testing.T) {
+	b, f, req := newFixedTenkiTest(t)
+	f.hook = func(_ context.Context, r LocalCommandRequest) (LocalCommandResult, error, bool) {
+		if r.Args[1] != "create" {
+			return LocalCommandResult{}, nil, false
+		}
+		claim := requireFixedClaim(t)
+		attempt, err := b.fixedAttempt(claim)
+		if err != nil || attempt == nil || attempt.SessionID != "" || claim.CloudID != "" {
+			t.Fatalf("create preceded durable attempt: claim=%+v attempt=%+v err=%v", claim, attempt, err)
+		}
+		args := strings.Join(r.Args, " ")
+		for _, value := range []string{"--metadata " + tenkiMetadataAttempt + "=" + attempt.Token, "--metadata " + tenkiMetadataIntent + "=" + claim.FixedCreateIntent.Fingerprint, "--name " + attempt.Name} {
+			if !strings.Contains(args, value) {
+				t.Fatalf("submitted request differs from durable attempt: missing %q", value)
+			}
+		}
+		return LocalCommandResult{}, nil, false
+	}
+	waitForSSHReadyFunc = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+		claim := requireFixedClaim(t)
+		if claim.CloudID != "session-1" || claim.CloudImmutableID != "session-1" {
+			t.Fatalf("SSH preceded immutable binding: %+v", claim)
+		}
+		return nil
+	}
+	requireFixedAcquire(t, b, req)
+}
+
+func TestTenkiFixedReplayIgnoresClockAndGeneratedProviderKey(t *testing.T) {
+	b, f, req := newFixedTenkiTest(t)
+	requireFixedAcquire(t, b, req)
+	previous := tenkiNow
+	now := time.Now().Add(time.Minute)
+	tenkiNow = func() time.Time { return now }
+	t.Cleanup(func() { tenkiNow = previous })
+	b.cfg.ProviderKey = "renewed-provider-key"
+	requireFixedAcquire(t, b, req)
+	if f.calls["create"] != 1 {
+		t.Fatalf("clock changed fixed identity: %v", f.calls)
+	}
+	tenkiNow = func() time.Time { return now.Add(2 * time.Hour) }
+	calls := maps.Clone(f.calls)
+	_, err := b.Acquire(context.Background(), req)
+	requireFixedConflict(t, err)
+	if !maps.Equal(calls, f.calls) {
+		t.Fatal("expired intent called provider")
+	}
+}
+
+func TestTenkiFixedTouchRejectsStaleAndTerminalClaims(t *testing.T) {
+	b, f, req := newFixedTenkiTest(t)
+	first := requireFixedAcquire(t, b, req)
+	idle := 15 * time.Minute
+	touch := TouchRequest{Lease: first, State: "ready", IdleTimeoutOverride: &idle}
+	if _, err := b.Touch(context.Background(), touch); err != nil {
+		t.Fatal(err)
+	}
+	before := requireFixedClaim(t)
+	if _, err := b.Touch(context.Background(), touch); err == nil {
+		t.Fatal("stale heartbeat succeeded")
+	}
+	if !reflect.DeepEqual(before, requireFixedClaim(t)) {
+		t.Fatal("stale heartbeat changed evidence")
+	}
+	lease := requireFixedReleaseTarget(t, b)
+	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	terminal := requireFixedReleaseTarget(t, b)
+	before = requireFixedClaim(t)
+	if _, err := b.Touch(context.Background(), TouchRequest{Lease: terminal, State: "ready", IdleTimeoutOverride: &idle}); err == nil {
+		t.Fatal("heartbeat revived a terminal claim")
+	}
+	if !reflect.DeepEqual(before, requireFixedClaim(t)) || f.calls["create"] != 1 || f.calls["resume"] != 0 || f.calls["ssh-command"] != 1 {
+		t.Fatalf("heartbeat side effects: %v", f.calls)
+	}
+}
+
+func TestTenkiFixedTerminalReceiptRejectsTampering(t *testing.T) {
+	b, f, req := newFixedTenkiTest(t)
+	requireFixedAcquire(t, b, req)
+	lease := requireFixedReleaseTarget(t, b)
+	before := requireFixedClaim(t)
+	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if err := core.WithDurableLeaseClaimLock(req.RequestedLeaseID, func(claim *LeaseClaim, _ bool, persist func() error) error {
+		claim.CloudID, claim.CloudImmutableID, claim.Labels["tenki_session_id"] = "foreign", "foreign", "foreign"
+		return persist()
+	}); err != nil {
+		t.Fatal(err)
+	}
+	calls := maps.Clone(f.calls)
+	retained, err := b.RetainLeaseClaimAfterReleaseWithClaim(lease, before)
+	if retained {
+		t.Fatal("changed terminal receipt accepted")
+	}
+	requireFixedConflict(t, err)
+	if !maps.Equal(calls, f.calls) {
+		t.Fatal("terminal verification used provider")
+	}
+}
+
+func TestTenkiFixedConcurrentSameIDCallers(t *testing.T) {
+	b, f, req := newFixedTenkiTest(t)
+	var wg sync.WaitGroup
+	results := make(chan LeaseTarget, 4)
+	errorsCh := make(chan error, 4)
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			fresh := *b
+			lease, err := fresh.Acquire(context.Background(), req)
+			results <- lease
+			errorsCh <- err
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errorsCh)
+	for err := range errorsCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	for lease := range results {
+		if lease.LeaseID != req.RequestedLeaseID || lease.Server.CloudID != "session-1" {
+			t.Fatalf("different concurrent identity: %+v", lease)
+		}
+	}
+	if f.calls["create"] != 1 || f.calls["terminate"] != 0 {
+		t.Fatalf("concurrent calls=%v", f.calls)
+	}
+}

--- a/internal/providers/tenki/fixed_test.go
+++ b/internal/providers/tenki/fixed_test.go
@@ -1,0 +1,223 @@
+package tenki
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const testFixedTenkiID = "cbx_abcdef123456"
+
+// A command-level fake keeps tests on the public backend boundary. Its session
+// detail is independent of list output, just as it is at the provider boundary.
+type fixedTenkiRunner struct {
+	mu           sync.Mutex
+	sessions     map[string]tenkiSession
+	calls        map[string]int
+	key, cert    string
+	listOverride *[]tenkiSession
+	hook         func(context.Context, LocalCommandRequest) (LocalCommandResult, error, bool)
+	createError  error
+	createOutput *string
+}
+
+func (f *fixedTenkiRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(req.Args) < 2 {
+		return LocalCommandResult{}, fmt.Errorf("unexpected command %v", req.Args)
+	}
+	command := req.Args[1]
+	f.calls[command]++
+	if f.hook != nil {
+		if result, err, handled := f.hook(ctx, req); handled {
+			return result, err
+		}
+	}
+	out := func(value any) (LocalCommandResult, error) {
+		data, err := json.Marshal(value)
+		return LocalCommandResult{Stdout: string(data)}, err
+	}
+	arg := func(key string) string {
+		for i := 0; i+1 < len(req.Args); i++ {
+			if req.Args[i] == key {
+				return req.Args[i+1]
+			}
+		}
+		return ""
+	}
+	switch command {
+	case "create":
+		id := fmt.Sprintf("session-%d", f.calls[command])
+		s := tenkiSession{ID: id, Name: arg("--name"), State: "RUNNING", ProjectID: "project-owned", CPUCores: 2, MemoryMB: 4096, DiskSizeGB: 20, SourceImageRef: arg("--image"), SourceSnapshotID: arg("--snapshot"), Metadata: map[string]string{}}
+		for i, value := range req.Args {
+			if value == "--sticky" {
+				s.Sticky = true
+			}
+			if value == "--metadata" && i+1 < len(req.Args) {
+				k, v, _ := strings.Cut(req.Args[i+1], "=")
+				s.Metadata[k] = v
+			}
+		}
+		f.sessions[id] = s
+		if f.createOutput != nil {
+			return LocalCommandResult{Stdout: *f.createOutput}, f.createError
+		}
+		if f.createError != nil {
+			return LocalCommandResult{ExitCode: 1}, f.createError
+		}
+		return out(tenkiSession{ID: id})
+	case "list":
+		if f.listOverride != nil {
+			return out(*f.listOverride)
+		}
+		sessions := make([]tenkiSession, 0, len(f.sessions))
+		for _, s := range f.sessions {
+			sessions = append(sessions, s)
+		}
+		return out(sessions)
+	case "get":
+		if s, ok := f.sessions[req.Args[len(req.Args)-1]]; ok {
+			return out(s)
+		}
+		return LocalCommandResult{ExitCode: 1}, errors.New("session not found")
+	case "ssh-command":
+		return out(tenkiSSHCommandOutput{SessionID: arg("--session"), User: "tenki", Host: "sandbox", Port: 22, IdentityFile: f.key, CertificateFile: f.cert, ProxyCommand: "tenki sandbox ssh-proxy"})
+	case "resume", "terminate":
+		id := arg("--session")
+		if id == "" {
+			id = req.Args[len(req.Args)-1]
+		}
+		s := f.sessions[id]
+		s.State = "RUNNING"
+		if command == "terminate" {
+			s.State = "TERMINATING"
+		}
+		f.sessions[id] = s
+		return LocalCommandResult{}, nil
+	default:
+		return LocalCommandResult{}, fmt.Errorf("unexpected command %v", req.Args)
+	}
+}
+
+func newFixedTenkiTest(t *testing.T) (*tenkiBackend, *fixedTenkiRunner, AcquireRequest) {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	dir := t.TempDir()
+	f := &fixedTenkiRunner{sessions: map[string]tenkiSession{}, calls: map[string]int{}, key: filepath.Join(dir, "key"), cert: filepath.Join(dir, "cert")}
+	for _, path := range []string{f.key, f.cert} {
+		if err := os.WriteFile(path, []byte("fake SSH material"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldWait := waitForSSHReadyFunc
+	waitForSSHReadyFunc = func(ctx context.Context, _ *SSHTarget, _ io.Writer, _ string, _ time.Duration) error {
+		return ctx.Err()
+	}
+	t.Cleanup(func() { waitForSSHReadyFunc = oldWait })
+	cfg := Config{Provider: tenkiProvider, TargetOS: targetLinux, Network: networkPublic, TTL: time.Hour, IdleTimeout: 30 * time.Minute, Tenki: TenkiConfig{CLIPath: "tenki", Image: "example/image:latest", CPUs: 2, MemoryMB: 4096, DiskGB: 20}}
+	b := &tenkiBackend{cfg: cfg, spec: Provider{}.Spec(), rt: Runtime{Exec: f, Stdout: io.Discard, Stderr: io.Discard}, sleep: func(ctx context.Context, _ time.Duration) error { <-ctx.Done(); return ctx.Err() }, terminationAckTimeout: 10 * time.Millisecond}
+	return b, f, AcquireRequest{RequestedLeaseID: testFixedTenkiID, RequestedSlug: "build-linux", Keep: true, Repo: Repo{Root: t.TempDir()}}
+}
+
+func TestTenkiFixedAcquireReplay(t *testing.T) {
+	b, f, req := newFixedTenkiTest(t)
+	first, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.LeaseID != req.RequestedLeaseID {
+		t.Fatalf("lease ID = %s, want caller ID %s", first.LeaseID, req.RequestedLeaseID)
+	}
+	fresh := *b
+	second, err := fresh.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.LeaseID != first.LeaseID || second.Server.CloudID != first.Server.CloudID || second.Server.ImmutableID != first.Server.CloudID {
+		t.Fatalf("replay identity changed: first=%+v second=%+v", first, second)
+	}
+	if f.calls["create"] != 1 || f.calls["ssh-command"] != 2 {
+		t.Fatalf("calls=%v", f.calls)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists || claim.FixedCreateIntent == nil || claim.CloudID != first.Server.CloudID {
+		t.Fatalf("claim=%+v exists=%t err=%v", claim, exists, err)
+	}
+}
+
+func TestTenkiFixedLostCreateResponseDoesNotResubmit(t *testing.T) {
+	b, f, req := newFixedTenkiTest(t)
+	f.createError = errors.New("connection lost after submission")
+	if _, err := b.Acquire(context.Background(), req); err == nil {
+		t.Fatal("expected create error")
+	}
+	f.createError = nil
+	invisible := []tenkiSession{}
+	f.listOverride = &invisible
+	fresh := *b
+	if _, err := fresh.Acquire(context.Background(), req); err == nil {
+		t.Fatal("uncertain create was resubmitted or adopted")
+	}
+	if f.calls["create"] != 1 || f.calls["terminate"] != 0 {
+		t.Fatalf("unsafe calls=%v", f.calls)
+	}
+	f.listOverride = nil
+	lease, err := fresh.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != req.RequestedLeaseID || lease.Server.CloudID != "session-1" || f.calls["create"] != 1 {
+		t.Fatalf("lease=%+v calls=%v", lease, f.calls)
+	}
+}
+
+func TestTenkiInspectDiagnosticsResolvesSSHWithoutClaimMutation(t *testing.T) {
+	for _, state := range []string{"RUNNING", "PAUSED"} {
+		t.Run(state, func(t *testing.T) {
+			b, f, req := newFixedTenkiTest(t)
+			req.RequestedLeaseID = "" // Also exercises the existing generated-ID path.
+			lease, err := b.Acquire(context.Background(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			s := f.sessions[lease.Server.CloudID]
+			s.State = state
+			f.sessions[s.ID] = s
+			before, _, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sshCalls := f.calls["ssh-command"]
+			inspected, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, StatusOnly: true, NoLocalStateMutations: true, IncludeDiagnostics: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if state == "RUNNING" {
+				if inspected.SSH.Host == "" || inspected.SSH.NetworkKind != networkPublic || f.calls["ssh-command"] != sshCalls+1 {
+					t.Fatalf("ready inspection has no SSH probe target: %+v calls=%v", inspected.SSH, f.calls)
+				}
+			} else if inspected.SSH.Host != "" || f.calls["ssh-command"] != sshCalls || f.calls["resume"] != 0 {
+				t.Fatalf("paused inspection prepared SSH or resumed: %+v calls=%v", inspected, f.calls)
+			}
+			after, _, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if err != nil || !reflect.DeepEqual(before, after) {
+				t.Fatalf("read-only inspection changed claim: err=%v", err)
+			}
+		})
+	}
+}
+
+func cloneTenkiSession(s tenkiSession) tenkiSession { s.Metadata = maps.Clone(s.Metadata); return s }


### PR DESCRIPTION
## Summary

Enable retry-safe Linux worker orchestration through the Tenki provider, and include the SSH trust follow-up that was not part of https://github.com/openclaw/crabbox/pull/1741.

- Accept caller-supplied fixed lease IDs. Persist the create attempt before submission, attest the exact session on replay, reject changed requests/ownership and duplicate candidates, and never resubmit an uncertain create.
- Preserve fixed identity through inspection, command reuse, heartbeat and cancellation. Confirm exact-session termination and retain a single-use terminal receipt so repeated stop is safe and stopped IDs cannot allocate again.
- Resolve ready-session SSH material for `inspect --json`, without resuming paused sessions or rewriting their claims.
- Include the previously local proxy-bound SSH trust change (`1d936c02`, carried here as `10567542`).
- Restore the selected work directory after login-shell startup for uploaded scripts. The live integration test exposed this separate blocker: upload succeeded, but script execution otherwise failed with exit 127.
- Make the shared fixed-acquisition claim lock honor cancellation. Update provider documentation and generated lifecycle coverage.

## Scope and configuration

This is the cold Linux worker path: `warmup --lease-id`, `inspect --json`, `run --no-sync --script-stdin`, heartbeat, and stop. Omit `class` in worker profiles, configure resource sizes through Crabbox's Tenki settings, and disable native warm-image reuse (`warmImage: false`). Desktop/browser and native checkpoints are not added.

Keep the controller's Crabbox state directory persistent and use unchanged allocation settings for retries. Tenki sessions created with `--keep=true` are sticky: Tenki ignores automatic idle/max-duration expiry, so the controller must explicitly stop them. Heartbeats renew local Crabbox state, not Tenki's native idle timer.

No new credentials, secrets, coordinator configuration, or Worker deployment is required. Provider-specific reconciliation stays in the Tenki adapter; the shared changes are provider-neutral.

## Review follow-up

Detailed, redacted terminal evidence: https://github.com/openclaw/crabbox/pull/2021#issuecomment-5607130449.

- Contributor changelog entries removed in `fc776d69`.
- **Old-to-new upgrade passed:** the pre-PR binary created an ordinary claim; the new binary inspected, ran scripts, and stopped it while fixed active claims and terminal receipts shared the same state directory.
- **Real session isolation passed:** certificate A with proxy URL B executed only in A, and the reverse executed only in B. Independent marker checks in both sandboxes confirmed no cross-session execution. The gateway selects the session from the signed certificate; a URL mismatch is not itself rejected.
- **Unsigned key and expired certificate were rejected before remote effect:** fresh non-multiplexed connections failed authentication, and valid-authority controls confirmed the attempted markers were absent.
- Trust documentation corrected in `67197ea4`. The TLS gateway authenticates the server; the SSH certificate authenticates the client and selects the session.
- **Still unverified:** immediate rejection after revoking an API key while an issued SSH certificate remains valid. No API key was revoked. Certificate expiry is not offered as API-key revocation proof. Maintainer acceptance of this lifetime boundary remains required.
- All six additional review-test sandboxes are confirmed `TERMINATED`, and the original user's Tenki config is unchanged.

## Verification

- `go test -race ./internal/providers/tenki -count=1`
- Focused CLI race tests for fixed acquisition, cancellation, uploaded scripts, login-shell directory changes, and command construction.
- `go vet ./...` on a temporary Linux/amd64 Tenki sandbox with Go 1.26.5; also `go vet ./internal/providers/tenki ./internal/cli` locally.
- `scripts/check-docs.sh`
- `gofmt` and `git diff --check`
- RED/GREEN proof for fixed-ID replay and lost replies, inspection readiness, heartbeat persistence, claim-lock cancellation, script startup directory changes, and the SSH trust change. Guard-removal overlays also fail for erased attempt evidence and mismatched readiness identities.

### Live Tenki CLI proof

Run `run_309e578e216264a14a4d743731fe1cc3`, lease `cbx_259e45d1245a`, session `01a083c2-3989-7aeb-b3c8-ba24c648b61c`:

- First warmup and a fresh-process replay returned the same lease/session; inventory contained exactly one matching session.
- Inspection reported `ready: true` with no Tailscale object.
- Heartbeat succeeded; the following replay retained the same session.
- A script sent on stdin uploaded and executed successfully through the Tenki proxy.
- Stop and repeated stop succeeded; replay after stop was rejected.
- Tenki subsequently reported the session `TERMINATED`.

The first diagnostic sandbox also reports `TERMINATED`. This proves the caller's Crabbox CLI contract; an actual worker enrollment with an external gateway was not performed.

### Wider-suite limitation

A separate full-sync Linux/amd64 Tenki run (`run_a3a40d986ee218695b07fd0f2d6df516`) passed `go vet -p 2 ./...`, but **did not pass the full race suite**. `internal/cli` and `internal/providers/external` reported failures, including strict temporary-directory permission/ownership checks and tests that require Git metadata in the raw synced workspace; the CLI package also reached its 20-minute timeout. The Tenki package passed its race tests in that run. No checks were skipped or weakened to obtain a pass.

I reran the affected controller/routing, external-provider, lease-output, and script-cancellation groups in the local Git checkout with `-race`; both packages passed that targeted run. The initial remote environment causes are not fully isolated. Subsequently, GitHub CI on `dee0fff7` passed all 19 checks, including the full Go test/modules/coverage gates; one optional check was skipped: https://github.com/openclaw/crabbox/actions/runs/34301467610. CI also passed on latest head `67197ea4`: https://github.com/openclaw/crabbox/actions/runs/34391882678. All 20 completed checks succeeded and two checks skipped. There are no Go source changes since the original passing head. The September 9 re-review accepts the ordinary-claim upgrade, session isolation, and unsigned/expired credential evidence; API-key revocation with a still-valid certificate or existing connection remains the sole security/maintainer decision.

The wider-suite session `01a083c5-6166-72ac-8031-999020ed70fe` also reports `TERMINATED`. The three original integration/validation sandboxes and all six additional review-test sandboxes are confirmed terminated.

