### PR TITLE
refactor(providers): share explicit machine-sizing flag policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
 
 - Describe Modal configuration bindings once, sharing configured defaults while preserving trusted Secret-name lists, environment clearing, and first-replace/later-append flags. [PR 2022](https://github.com/openclaw/crabbox/pull/2022). Thanks @steipete.
 
+- Share unsupported machine-sizing flag checks across providers, preserving explicit-input behavior, provider-specific guidance, and validation order. Thanks @steipete.
+
 ## 0.53.0 - 2026-09-08
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 
 - Describe Modal configuration bindings once, sharing configured defaults while preserving trusted Secret-name lists, environment clearing, and first-replace/later-append flags. [PR 2022](https://github.com/openclaw/crabbox/pull/2022). Thanks @steipete.
 
-- Share unsupported machine-sizing flag checks across providers, preserving explicit-input behavior, provider-specific guidance, and validation order. Thanks @steipete.
+- Share unsupported machine-sizing flag checks across providers, preserving explicit-input behavior, provider-specific guidance, and validation order. [PR 2023](https://github.com/openclaw/crabbox/pull/2023). Thanks @steipete.
 
 ## 0.53.0 - 2026-09-08
 

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -913,6 +913,19 @@ each `Provider.RegisterFlags` invocation, and treats everything else registered
 by `run` as a shared command flag. It never calls `ApplyFlags` or `Configure`.
 Do not add a parallel flag inventory.
 
+Providers that reject both explicit `--class` and `--type` can share
+`shared.RejectExplicitMachineSizingFlags`. It checks flag visits rather than
+inherited config values, rejects class before type regardless of argument order,
+and retains the caller's canonical provider name and literal guidance. An empty
+explicit value is still a visit. The helper does not select a provider, mutate
+configuration, register flags, or infer admission from class-mapping metadata.
+
+Keep its call at the provider's existing validation position. In particular,
+value-type assertions may precede the guard, and target/expose checks or field
+application may follow it. Single-flag rejection, supported type mapping, and
+providers without this rejection policy remain distinct contracts; do not use
+the pair helper to change them.
+
 Pattern for a provider with typed config fields:
 
 ```go

--- a/internal/providers/all/class_profiles_test.go
+++ b/internal/providers/all/class_profiles_test.go
@@ -1,13 +1,17 @@
 package all
 
 import (
+	"errors"
+	"flag"
 	"fmt"
+	"io"
 	"reflect"
 	"sort"
 	"strings"
 	"testing"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestProductionProviderClassCatalogCompleteness(t *testing.T) {
@@ -320,4 +324,299 @@ func specSupportsTarget(spec core.ProviderSpec, target, windowsMode string) bool
 		}
 	}
 	return false
+}
+
+// The selector and guidance table pins adapter-owned contracts independently
+// of the shared formatter and of each provider's registry aliases.
+var sizingFlagContracts = []struct {
+	name, classGuidance, typeGuidance string
+	normalized, assertionFirst        bool
+	aliases                           []string
+}{
+	{"azure-dynamic-sessions", "choose pool sizing in Azure", "choose pool sizing in Azure", false, false, nil},
+	{"blaxel", "use --blaxel-memory-mb", "use --blaxel-image", true, false, nil},
+	{"cloudflare-dynamic-workers", "", "", false, false, []string{"cf-dynamic", "cfdw"}},
+	{"cloudflare-sandbox", "", "", true, false, nil},
+	{"cloud-run-sandbox", "sandboxes share Cloud Run service CPU/memory", "sandboxes share Cloud Run service CPU/memory", true, false, []string{"gcrun-sandbox", "google-cloud-run-sandbox", "cloudrun-sandbox"}},
+	{"coder", "choose size through the Coder template or --coder-preset", "choose a Coder template with --coder-template", false, false, nil},
+	{"codesandbox", "use --codesandbox-vm-tier", "use --codesandbox-vm-tier", true, true, []string{"csb", "code-sandbox"}},
+	{"crownest", "use --crownest-template", "use --crownest-template", true, false, nil},
+	{"cua", "use --cua-vcpus and --cua-memory-mb", "use --cua-image and --cua-kind", true, false, nil},
+	{"cubesandbox", "", "", false, false, nil},
+	{"docker-sandbox", "use --docker-sandbox-cpus or --docker-sandbox-memory", "use --docker-sandbox-template", false, false, nil},
+	{"e2b", "", "", false, false, nil},
+	{"exe-dev", "use --exe-dev-cpus, --exe-dev-memory, and --exe-dev-disk", "use --exe-dev-image", false, false, []string{"exe", "exedev"}},
+	{"fastapi-cloud", "", "", true, false, []string{"fastapicloud", "fastapi"}},
+	{"firecracker", "use --firecracker-cpus, --firecracker-memory-mib, and --firecracker-disk-mib", "use explicit Firecracker kernel, rootfs, and sizing flags", true, false, nil},
+	{"modal", "", "", false, false, nil},
+	{"morph", "", "use --morph-snapshot", true, false, nil},
+	{"nvidia-brev", "use --nvidia-brev-gpu-name", "use --nvidia-brev-type", true, false, []string{"brev", "nvidia"}},
+	{"opencomputer", "use --opencomputer-cpu and --opencomputer-memory-mb", "use --opencomputer-cpu and --opencomputer-memory-mb", true, false, []string{"oc", "open-computer"}},
+	{"opensandbox", "use --opensandbox-cpu and --opensandbox-memory", "use --opensandbox-cpu and --opensandbox-memory", true, false, nil},
+	{"orgo", "", "", true, false, []string{"orgo-ai"}},
+	{"railway", "", "", true, false, []string{"rail", "railwayapp"}},
+	{"runpod", "use --runpod-instance-id", "use --runpod-image", true, false, []string{"run-pod", "runpodio"}},
+	{"smolvm", "use --smolvm-cpus/--smolvm-memory-mb", "use --smolvm-image", false, false, []string{"smol", "smolmachines", "smolfleet"}},
+	{"superserve", "use --superserve-template or --superserve-snapshot", "use --superserve-template or --superserve-snapshot", true, false, nil},
+	{"unikraft-cloud", "", "", true, false, []string{"unikraftcloud", "ukc"}},
+	{"upstash-box", "use --upstash-box-size", "use --upstash-box-runtime", false, false, []string{"upstash", "box", "upstashbox"}},
+	{"vast", "use --vast-gpu-name or --vast-gpu-count", "use --vast-image", true, false, []string{"vast-ai", "vastai"}},
+	{"vercel-sandbox", "use --vercel-sandbox-vcpus", "use --vercel-sandbox-runtime or --vercel-sandbox-vcpus", true, false, nil},
+	{"wandb", "", "", true, false, []string{"weights-and-biases"}},
+	{"windows-sandbox", "Windows Sandbox sizing is controlled by the host", "Windows Sandbox sizing is controlled by the host", false, true, []string{"wsb", "windows-sandbox-provider"}},
+}
+
+func sizingContractFlags(t *testing.T, provider core.Provider, cfg core.Config, args []string) (*flag.FlagSet, any) {
+	t.Helper()
+	fs := flag.NewFlagSet("contract", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.String("class", "", "")
+	fs.String("type", "", "")
+	fs.String("target", "", "")
+	fs.String("windows-mode", "", "")
+	fs.String("expose", "", "")
+	values := provider.RegisterFlags(fs, cfg)
+	if err := fs.Parse(args); err != nil {
+		t.Fatal(err)
+	}
+	return fs, values
+}
+
+func assertSizingContractError(t *testing.T, err error, want string) {
+	t.Helper()
+	if want == "" {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return
+	}
+	var exitErr core.ExitError
+	if err == nil || err.Error() != want || !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error=%v exit=%#v want exit2 %q", err, exitErr, want)
+	}
+}
+
+func TestProviderSizingGuardContracts(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	if len(sizingFlagContracts) != 31 {
+		t.Fatal("expected all 31 eligible adapters")
+	}
+	for _, tc := range sizingFlagContracts {
+		t.Run(tc.name, func(t *testing.T) {
+			provider, err := core.ProviderFor(tc.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, args := range [][]string{{"--class=large"}, {"--type=machine"}, {"--class=large", "--type=machine"}, {"--type=machine", "--class=large"}, {"--class="}, {"--type="}} {
+				for _, wrong := range []bool{false, true} {
+					cfg := core.BaseConfig()
+					cfg.Provider = tc.name
+					cfg.TargetOS = "linux"
+					cfg.WindowsMode = "prior-mode"
+					before := fmt.Sprintf("%#v", cfg)
+					fs, values := sizingContractFlags(t, provider, cfg, args)
+					// A visited provider value exposes any copy accidentally moved before rejection.
+					copiedFlag := ""
+					fs.VisitAll(func(f *flag.Flag) {
+						if copiedFlag != "" || f.Name == "class" || f.Name == "type" || f.Name == "target" || f.Name == "windows-mode" || f.Name == "expose" {
+							return
+						}
+						if getter, ok := f.Value.(flag.Getter); ok {
+							if _, ok := getter.Get().(string); ok {
+								copiedFlag = f.Name
+							}
+						}
+					})
+					if copiedFlag == "" {
+						t.Fatal("provider has no string flag for copy-order fixture")
+					}
+					if err := fs.Set(copiedFlag, fs.Lookup(copiedFlag).Value.String()+"-fixture"); err != nil {
+						t.Fatal(err)
+					}
+					if wrong {
+						values = struct{}{}
+					}
+					flagName, guide := "class", tc.classGuidance
+					if len(args) == 1 && strings.HasPrefix(args[0], "--type") {
+						flagName = "type"
+						guide = tc.typeGuidance
+					}
+					want := "--" + flagName + " is not supported for provider=" + tc.name
+					if guide != "" {
+						want += "; " + guide
+					}
+					if wrong && tc.assertionFirst {
+						want = ""
+					}
+					assertSizingContractError(t, provider.ApplyFlags(&cfg, fs, values), want)
+					if after := fmt.Sprintf("%#v", cfg); after != before {
+						t.Fatalf("rejection/wrong-type mutated config for args=%v", args)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestProviderSizingSelectorContracts(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	for _, tc := range sizingFlagContracts {
+		t.Run(tc.name, func(t *testing.T) {
+			provider, err := core.ProviderFor(tc.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			names := append([]string{tc.name, " " + strings.ToUpper(tc.name) + " ", "unselected"}, tc.aliases...)
+			names = append(names, provider.Aliases()...)
+			for _, selector := range names {
+				selected := selector == tc.name
+				for _, alias := range tc.aliases {
+					selected = selected || selector == alias
+				}
+				if tc.normalized {
+					normalized := strings.ToLower(strings.TrimSpace(selector))
+					selected = normalized == tc.name
+					for _, alias := range tc.aliases {
+						selected = selected || normalized == alias
+					}
+				}
+				cfg := core.BaseConfig()
+				cfg.Provider = selector
+				cfg.Class = "large"
+				cfg.ServerType = "inherited-machine"
+				fs, values := sizingContractFlags(t, provider, cfg, []string{"--class="})
+				want := ""
+				if selected {
+					want = "--class is not supported for provider=" + tc.name
+					if tc.classGuidance != "" {
+						want += "; " + tc.classGuidance
+					}
+				} else if tc.name == "cloudflare-sandbox" {
+					want = "cloudflare-sandbox requires cloudflareSandbox.url or CRABBOX_CLOUDFLARE_SANDBOX_URL"
+				}
+				assertSizingContractError(t, provider.ApplyFlags(&cfg, fs, values), want)
+			}
+			cfg := core.BaseConfig()
+			cfg.Provider = tc.name
+			cfg.Class = "large"
+			cfg.ServerType = "inherited-machine"
+			fs, values := sizingContractFlags(t, provider, cfg, nil)
+			want := ""
+			if tc.name == "cloudflare-sandbox" {
+				want = "cloudflare-sandbox requires cloudflareSandbox.url or CRABBOX_CLOUDFLARE_SANDBOX_URL"
+			}
+			assertSizingContractError(t, provider.ApplyFlags(&cfg, fs, values), want)
+		})
+	}
+}
+
+func TestProviderSizingLocalOrderContracts(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	for _, name := range []string{"coder", "morph"} {
+		provider, err := core.ProviderFor(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, args := range [][]string{{"--class="}, {"--type="}, nil} {
+			cfg := core.BaseConfig()
+			cfg.Provider = name
+			cfg.TargetOS = "windows"
+			fs, values := sizingContractFlags(t, provider, cfg, args)
+			want := "provider=" + name + " supports target=linux only"
+			if len(args) > 0 {
+				for _, tc := range sizingFlagContracts {
+					if tc.name == name {
+						flagName, guide := "class", tc.classGuidance
+						if strings.HasPrefix(args[0], "--type") {
+							flagName = "type"
+							guide = tc.typeGuidance
+						}
+						want = "--" + flagName + " is not supported for provider=" + name
+						if guide != "" {
+							want += "; " + guide
+						}
+					}
+				}
+			}
+			before := fmt.Sprintf("%#v", cfg)
+			assertSizingContractError(t, provider.ApplyFlags(&cfg, fs, values), want)
+			if fmt.Sprintf("%#v", cfg) != before {
+				t.Fatal("target/sizing rejection mutated config")
+			}
+		}
+	}
+	provider, err := core.ProviderFor("cloudflare-dynamic-workers")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		args []string
+		flag string
+	}{{[]string{"--expose=8080", "--type=machine", "--class=large"}, "class"}, {[]string{"--expose=8080", "--type="}, "type"}, {[]string{"--expose="}, "expose"}} {
+		cfg := core.BaseConfig()
+		cfg.Provider = provider.Name()
+		fs, values := sizingContractFlags(t, provider, cfg, tc.args)
+		before := fmt.Sprintf("%#v", cfg)
+		assertSizingContractError(t, provider.ApplyFlags(&cfg, fs, values), "--"+tc.flag+" is not supported for provider=cloudflare-dynamic-workers")
+		if fmt.Sprintf("%#v", cfg) != before {
+			t.Fatal("dynamic rejection mutated config")
+		}
+	}
+	provider, err = core.ProviderFor("windows-sandbox")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := core.BaseConfig()
+	cfg.Provider = provider.Name()
+	cfg.TargetOS = "linux"
+	cfg.WindowsMode = "prior-mode"
+	fs, values := sizingContractFlags(t, provider, cfg, nil)
+	assertSizingContractError(t, provider.ApplyFlags(&cfg, fs, values), "")
+	if cfg.TargetOS != "windows" || cfg.WindowsMode != "normal" {
+		t.Fatalf("Windows defaults=%s/%s", cfg.TargetOS, cfg.WindowsMode)
+	}
+}
+
+func TestProviderSizingNonAdopterControls(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	for _, name := range []string{"semaphore", "tensorlake", "srt"} {
+		provider, err := core.ProviderFor(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cfg := core.BaseConfig()
+		cfg.Provider = name
+		fs, values := sizingContractFlags(t, provider, cfg, []string{"--class=large", "--type=machine"})
+		assertSizingContractError(t, provider.ApplyFlags(&cfg, fs, values), "")
+	}
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{{"daytona", []string{"--class=large"}, ""}, {"daytona", []string{"--type="}, "--type is not supported for provider=daytona; choose CPU, memory, and disk in the Daytona snapshot"}, {"github-codespaces", []string{"--class="}, "--class is not supported for provider=github-codespaces; use --type or --github-codespaces-machine for a Codespaces machine slug"}, {"github-codespaces", []string{"--type= fixture-machine "}, ""}} {
+		provider, err := core.ProviderFor(tc.name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cfg := core.BaseConfig()
+		cfg.Provider = tc.name
+		fs, values := sizingContractFlags(t, provider, cfg, tc.args)
+		assertSizingContractError(t, provider.ApplyFlags(&cfg, fs, values), tc.want)
+		if tc.name == "github-codespaces" && tc.want == "" && cfg.GitHubCodespaces.Machine != "fixture-machine" {
+			t.Fatal("Codespaces type mapping changed")
+		}
+	}
+	provider, err := core.ProviderFor("cloudflare")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := core.BaseConfig()
+	cfg.Provider = "cloudflare"
+	cfg.Class = "tiny"
+	cfg.ServerType = ""
+	fs, values := sizingContractFlags(t, provider, cfg, []string{"--class=tiny"})
+	assertSizingContractError(t, provider.ApplyFlags(&cfg, fs, values), "")
+	if cfg.ServerType != "standard-4" {
+		t.Fatalf("Cloudflare mapped type=%q", cfg.ServerType)
+	}
 }

--- a/internal/providers/azuredynamicsessions/core.go
+++ b/internal/providers/azuredynamicsessions/core.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -53,10 +52,6 @@ type statusView = core.StatusView
 
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
-}
-
-func flagWasSet(fs *flag.FlagSet, name string) bool {
-	return core.FlagWasSet(fs, name)
 }
 
 func validateNativeCredentialDestination(cfg Config) error {

--- a/internal/providers/azuredynamicsessions/flags.go
+++ b/internal/providers/azuredynamicsessions/flags.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func RegisterAzureDynamicSessionsProviderFlags(fs *flag.FlagSet, defaults Config) any {
@@ -12,11 +13,8 @@ func RegisterAzureDynamicSessionsProviderFlags(fs *flag.FlagSet, defaults Config
 
 func ApplyAzureDynamicSessionsProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if cfg.Provider == providerName {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=%s; choose pool sizing in Azure", providerName)
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=%s; choose pool sizing in Azure", providerName)
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "choose pool sizing in Azure", "choose pool sizing in Azure"); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(core.AzureDynamicSessionsConfigFlagValues)

--- a/internal/providers/blaxel/core.go
+++ b/internal/providers/blaxel/core.go
@@ -1,7 +1,6 @@
 package blaxel
 
 import (
-	"flag"
 	"io"
 	"time"
 
@@ -50,10 +49,6 @@ const (
 
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
-}
-
-func flagWasSet(fs *flag.FlagSet, name string) bool {
-	return core.FlagWasSet(fs, name)
 }
 
 func blank(value, fallback string) string {

--- a/internal/providers/blaxel/flags.go
+++ b/internal/providers/blaxel/flags.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func RegisterBlaxelProviderFlags(fs *flag.FlagSet, defaults Config) any {
@@ -13,11 +14,8 @@ func RegisterBlaxelProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyBlaxelProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if strings.EqualFold(strings.TrimSpace(cfg.Provider), providerName) {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=blaxel; use --blaxel-memory-mb")
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=blaxel; use --blaxel-image")
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --blaxel-memory-mb", "use --blaxel-image"); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(core.BlaxelConfigFlagValues)

--- a/internal/providers/cloudflaredynamicworkers/flags.go
+++ b/internal/providers/cloudflaredynamicworkers/flags.go
@@ -3,6 +3,8 @@ package cloudflaredynamicworkers
 import (
 	"flag"
 	"strings"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type flagValues struct {
@@ -32,11 +34,8 @@ func RegisterProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if cfg.Provider == providerName || cfg.Provider == "cf-dynamic" || cfg.Provider == "cfdw" {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=%s", providerName)
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=%s", providerName)
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
+			return err
 		}
 		if flagWasSet(fs, "expose") {
 			return exit(2, "--expose is not supported for provider=%s", providerName)

--- a/internal/providers/cloudflaresandbox/core.go
+++ b/internal/providers/cloudflaresandbox/core.go
@@ -1,7 +1,6 @@
 package cloudflaresandbox
 
 import (
-	"flag"
 	"io"
 	"time"
 
@@ -42,10 +41,6 @@ const (
 
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
-}
-
-func flagWasSet(fs *flag.FlagSet, name string) bool {
-	return core.FlagWasSet(fs, name)
 }
 
 func newLeaseSlug(leaseID string) string {

--- a/internal/providers/cloudflaresandbox/flags.go
+++ b/internal/providers/cloudflaresandbox/flags.go
@@ -17,11 +17,8 @@ func RegisterProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if strings.EqualFold(strings.TrimSpace(cfg.Provider), providerName) {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=%s", providerName)
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=%s", providerName)
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(core.CloudflareSandboxConfigFlagValues)

--- a/internal/providers/cloudrunsandbox/core.go
+++ b/internal/providers/cloudrunsandbox/core.go
@@ -1,7 +1,6 @@
 package cloudrunsandbox
 
 import (
-	"flag"
 	"io"
 	"time"
 
@@ -57,10 +56,6 @@ const (
 
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
-}
-
-func flagWasSet(fs *flag.FlagSet, name string) bool {
-	return core.FlagWasSet(fs, name)
 }
 
 func writeTimingJSON(w io.Writer, report timingReport) error {

--- a/internal/providers/cloudrunsandbox/flags.go
+++ b/internal/providers/cloudrunsandbox/flags.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func RegisterCloudRunSandboxProviderFlags(fs *flag.FlagSet, defaults Config) any {
@@ -14,11 +15,8 @@ func RegisterCloudRunSandboxProviderFlags(fs *flag.FlagSet, defaults Config) any
 func ApplyCloudRunSandboxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	switch strings.ToLower(strings.TrimSpace(cfg.Provider)) {
 	case providerName, "gcrun-sandbox", "google-cloud-run-sandbox", "cloudrun-sandbox":
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=cloud-run-sandbox; sandboxes share Cloud Run service CPU/memory")
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=cloud-run-sandbox; sandboxes share Cloud Run service CPU/memory")
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "sandboxes share Cloud Run service CPU/memory", "sandboxes share Cloud Run service CPU/memory"); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(core.CloudRunSandboxConfigFlagValues)

--- a/internal/providers/coder/flags.go
+++ b/internal/providers/coder/flags.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"path"
 	"strings"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type coderFlagValues struct {
@@ -36,11 +38,8 @@ func RegisterCoderProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyCoderProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if cfg.Provider == coderProvider {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=coder; choose size through the Coder template or --coder-preset")
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=coder; choose a Coder template with --coder-template")
+		if err := shared.RejectExplicitMachineSizingFlags(fs, coderProvider, "choose size through the Coder template or --coder-preset", "choose a Coder template with --coder-template"); err != nil {
+			return err
 		}
 		if cfg.TargetOS != "" && cfg.TargetOS != targetLinux {
 			return exit(2, "provider=coder supports target=linux only")

--- a/internal/providers/codesandbox/core.go
+++ b/internal/providers/codesandbox/core.go
@@ -1,7 +1,6 @@
 package codesandbox
 
 import (
-	"flag"
 	"io"
 	"os"
 	"strings"
@@ -53,10 +52,6 @@ const (
 
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
-}
-
-func flagWasSet(fs *flag.FlagSet, name string) bool {
-	return core.FlagWasSet(fs, name)
 }
 
 func inventoryDoctorResult(provider string, leases int) DoctorResult {

--- a/internal/providers/codesandbox/flags.go
+++ b/internal/providers/codesandbox/flags.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func RegisterCodeSandboxProviderFlags(fs *flag.FlagSet, defaults Config) any {
@@ -17,11 +18,8 @@ func ApplyCodeSandboxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) er
 		return nil
 	}
 	if codeSandboxProviderSelected(cfg.Provider) {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=codesandbox; use --codesandbox-vm-tier")
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=codesandbox; use --codesandbox-vm-tier")
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --codesandbox-vm-tier", "use --codesandbox-vm-tier"); err != nil {
+			return err
 		}
 	}
 	v.Apply(&cfg.CodeSandbox, fs)

--- a/internal/providers/crownest/flags.go
+++ b/internal/providers/crownest/flags.go
@@ -28,11 +28,8 @@ func registerFlags(fs *flag.FlagSet, defaults Config) any {
 
 func applyFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if strings.EqualFold(strings.TrimSpace(cfg.Provider), providerName) {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=crownest; use --crownest-template")
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=crownest; use --crownest-template")
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --crownest-template", "use --crownest-template"); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(flagValues)

--- a/internal/providers/cua/core.go
+++ b/internal/providers/cua/core.go
@@ -1,7 +1,6 @@
 package cua
 
 import (
-	"flag"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -47,10 +46,6 @@ func mutationUnsupported() error {
 
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
-}
-
-func flagWasSet(fs *flag.FlagSet, name string) bool {
-	return core.FlagWasSet(fs, name)
 }
 
 func blank(value, fallback string) string {

--- a/internal/providers/cua/flags.go
+++ b/internal/providers/cua/flags.go
@@ -17,11 +17,8 @@ func RegisterProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if strings.EqualFold(strings.TrimSpace(cfg.Provider), providerName) {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=cua; use --cua-vcpus and --cua-memory-mb")
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=cua; use --cua-image and --cua-kind")
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --cua-vcpus and --cua-memory-mb", "use --cua-image and --cua-kind"); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(core.CuaConfigFlagValues)

--- a/internal/providers/cubesandbox/backend.go
+++ b/internal/providers/cubesandbox/backend.go
@@ -42,11 +42,8 @@ func RegisterCubeSandboxProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyCubeSandboxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if cfg.Provider == providerName {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=cubesandbox")
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=cubesandbox")
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(cubesandboxFlagValues)

--- a/internal/providers/dockersandbox/flags.go
+++ b/internal/providers/dockersandbox/flags.go
@@ -6,6 +6,8 @@ import (
 	"math"
 	"path"
 	"strings"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type stringListFlag []string
@@ -63,11 +65,8 @@ func RegisterDockerSandboxProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyDockerSandboxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if cfg.Provider == providerName {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=%s; use --docker-sandbox-cpus or --docker-sandbox-memory", providerName)
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=%s; use --docker-sandbox-template", providerName)
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --docker-sandbox-cpus or --docker-sandbox-memory", "use --docker-sandbox-template"); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(flagValues)

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -21,11 +21,8 @@ func RegisterE2BProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyE2BProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if cfg.Provider == e2bProvider {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=e2b")
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=e2b")
+		if err := shared.RejectExplicitMachineSizingFlags(fs, e2bProvider, "", ""); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(core.E2BConfigFlagValues)

--- a/internal/providers/e2b/core.go
+++ b/internal/providers/e2b/core.go
@@ -1,7 +1,6 @@
 package e2b
 
 import (
-	"flag"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -41,10 +40,6 @@ type statusView = core.StatusView
 
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
-}
-
-func flagWasSet(fs *flag.FlagSet, name string) bool {
-	return core.FlagWasSet(fs, name)
 }
 
 func blank(value, fallback string) string {

--- a/internal/providers/exedev/flags.go
+++ b/internal/providers/exedev/flags.go
@@ -1,6 +1,10 @@
 package exedev
 
-import "flag"
+import (
+	"flag"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
 
 type exeDevFlagValues struct {
 	ControlHost *string
@@ -30,11 +34,8 @@ func RegisterExeDevProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyExeDevProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if cfg.Provider == providerName || cfg.Provider == "exe" || cfg.Provider == "exedev" {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=%s; use --exe-dev-cpus, --exe-dev-memory, and --exe-dev-disk", providerName)
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=%s; use --exe-dev-image", providerName)
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --exe-dev-cpus, --exe-dev-memory, and --exe-dev-disk", "use --exe-dev-image"); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(exeDevFlagValues)

--- a/internal/providers/fastapicloud/core.go
+++ b/internal/providers/fastapicloud/core.go
@@ -1,8 +1,6 @@
 package fastapicloud
 
 import (
-	"flag"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
@@ -33,10 +31,6 @@ const (
 
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
-}
-
-func flagWasSet(fs *flag.FlagSet, name string) bool {
-	return core.FlagWasSet(fs, name)
 }
 
 func blank(value, fallback string) string {

--- a/internal/providers/fastapicloud/flags.go
+++ b/internal/providers/fastapicloud/flags.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 // RegisterFastAPICloudProviderFlags exposes only non-secret provider flags.
@@ -17,11 +18,8 @@ func RegisterFastAPICloudProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyFastAPICloudProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if isFastAPICloudProviderName(cfg.Provider) {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=%s", providerName)
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=%s", providerName)
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(core.FastAPICloudConfigFlagValues)

--- a/internal/providers/firecracker/flags.go
+++ b/internal/providers/firecracker/flags.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type flagValues struct {
@@ -47,11 +48,8 @@ func RegisterFirecrackerProviderFlags(fs *flag.FlagSet, defaults core.Config) an
 
 func ApplyFirecrackerProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if isFirecrackerProviderName(cfg.Provider) {
-		if core.FlagWasSet(fs, "class") {
-			return core.Exit(2, "--class is not supported for provider=firecracker; use --firecracker-cpus, --firecracker-memory-mib, and --firecracker-disk-mib")
-		}
-		if core.FlagWasSet(fs, "type") {
-			return core.Exit(2, "--type is not supported for provider=firecracker; use explicit Firecracker kernel, rootfs, and sizing flags")
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --firecracker-cpus, --firecracker-memory-mib, and --firecracker-disk-mib", "use explicit Firecracker kernel, rootfs, and sizing flags"); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(flagValues)

--- a/internal/providers/modal/core.go
+++ b/internal/providers/modal/core.go
@@ -1,7 +1,6 @@
 package modal
 
 import (
-	"flag"
 	"io"
 	"time"
 
@@ -39,10 +38,6 @@ const (
 
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
-}
-
-func flagWasSet(fs *flag.FlagSet, name string) bool {
-	return core.FlagWasSet(fs, name)
 }
 
 func blank(value, fallback string) string {

--- a/internal/providers/modal/flags.go
+++ b/internal/providers/modal/flags.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func RegisterModalProviderFlags(fs *flag.FlagSet, defaults Config) any {
@@ -12,11 +13,8 @@ func RegisterModalProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyModalProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if cfg.Provider == providerName {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=modal")
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=modal")
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(core.ModalConfigFlagValues)

--- a/internal/providers/morph/backend.go
+++ b/internal/providers/morph/backend.go
@@ -57,11 +57,8 @@ func RegisterMorphProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyMorphProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if isMorphProviderName(cfg.Provider) {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=morph")
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=morph; use --morph-snapshot")
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", "use --morph-snapshot"); err != nil {
+			return err
 		}
 		if cfg.TargetOS != "" && cfg.TargetOS != targetLinux {
 			return exit(2, "provider=morph supports target=linux only")

--- a/internal/providers/nvidiabrev/flags.go
+++ b/internal/providers/nvidiabrev/flags.go
@@ -1,6 +1,10 @@
 package nvidiabrev
 
-import "flag"
+import (
+	"flag"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
 
 type nvidiaBrevFlagValues struct {
 	CLI           *string
@@ -38,11 +42,8 @@ func RegisterNvidiaBrevProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyNvidiaBrevProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if isNvidiaBrevProviderName(cfg.Provider) {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=%s; use --nvidia-brev-gpu-name", providerName)
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=%s; use --nvidia-brev-type", providerName)
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --nvidia-brev-gpu-name", "use --nvidia-brev-type"); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(nvidiaBrevFlagValues)

--- a/internal/providers/opencomputer/core.go
+++ b/internal/providers/opencomputer/core.go
@@ -1,7 +1,6 @@
 package opencomputer
 
 import (
-	"flag"
 	"io"
 	"time"
 
@@ -43,10 +42,6 @@ const (
 
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
-}
-
-func flagWasSet(fs *flag.FlagSet, name string) bool {
-	return core.FlagWasSet(fs, name)
 }
 
 func newLeaseSlug(leaseID string) string {

--- a/internal/providers/opencomputer/flags.go
+++ b/internal/providers/opencomputer/flags.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func RegisterOpenComputerProviderFlags(fs *flag.FlagSet, defaults Config) any {
@@ -14,11 +15,8 @@ func RegisterOpenComputerProviderFlags(fs *flag.FlagSet, defaults Config) any {
 func ApplyOpenComputerProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	switch strings.ToLower(strings.TrimSpace(cfg.Provider)) {
 	case providerName, "oc", "open-computer":
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=opencomputer; use --opencomputer-cpu and --opencomputer-memory-mb")
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=opencomputer; use --opencomputer-cpu and --opencomputer-memory-mb")
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --opencomputer-cpu and --opencomputer-memory-mb", "use --opencomputer-cpu and --opencomputer-memory-mb"); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(core.OpenComputerConfigFlagValues)

--- a/internal/providers/opensandbox/core.go
+++ b/internal/providers/opensandbox/core.go
@@ -1,7 +1,6 @@
 package opensandbox
 
 import (
-	"flag"
 	"io"
 	"time"
 
@@ -55,10 +54,6 @@ const (
 
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
-}
-
-func flagWasSet(fs *flag.FlagSet, name string) bool {
-	return core.FlagWasSet(fs, name)
 }
 
 func newLeaseSlug(leaseID string) string {

--- a/internal/providers/opensandbox/flags.go
+++ b/internal/providers/opensandbox/flags.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func RegisterOpenSandboxProviderFlags(fs *flag.FlagSet, defaults Config) any {
@@ -14,11 +15,8 @@ func RegisterOpenSandboxProviderFlags(fs *flag.FlagSet, defaults Config) any {
 func ApplyOpenSandboxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	switch strings.ToLower(strings.TrimSpace(cfg.Provider)) {
 	case providerName:
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=opensandbox; use --opensandbox-cpu and --opensandbox-memory")
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=opensandbox; use --opensandbox-cpu and --opensandbox-memory")
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --opensandbox-cpu and --opensandbox-memory", "use --opensandbox-cpu and --opensandbox-memory"); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(core.OpenSandboxConfigFlagValues)

--- a/internal/providers/orgo/core.go
+++ b/internal/providers/orgo/core.go
@@ -1,7 +1,6 @@
 package orgo
 
 import (
-	"flag"
 	"io"
 	"time"
 
@@ -37,10 +36,6 @@ const (
 
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
-}
-
-func flagWasSet(fs *flag.FlagSet, name string) bool {
-	return core.FlagWasSet(fs, name)
 }
 
 func blank(value, fallback string) string {

--- a/internal/providers/orgo/flags.go
+++ b/internal/providers/orgo/flags.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 // RegisterOrgoProviderFlags exposes non-secret Orgo settings. The API key is
@@ -16,11 +17,8 @@ func RegisterOrgoProviderFlags(fs *flag.FlagSet, defaults Config) any {
 func ApplyOrgoProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	switch strings.ToLower(strings.TrimSpace(cfg.Provider)) {
 	case providerName, "orgo-ai":
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=%s", providerName)
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=%s", providerName)
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(core.OrgoConfigFlagValues)

--- a/internal/providers/railway/core.go
+++ b/internal/providers/railway/core.go
@@ -1,8 +1,6 @@
 package railway
 
 import (
-	"flag"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
@@ -37,10 +35,6 @@ const (
 
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
-}
-
-func flagWasSet(fs *flag.FlagSet, name string) bool {
-	return core.FlagWasSet(fs, name)
 }
 
 func blank(value, fallback string) string {

--- a/internal/providers/railway/flags.go
+++ b/internal/providers/railway/flags.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 // RegisterRailwayProviderFlags exposes railway-specific flags. The API token is
@@ -17,11 +18,8 @@ func RegisterRailwayProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyRailwayProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if isRailwayProviderName(cfg.Provider) {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=%s", providerName)
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=%s", providerName)
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(core.RailwayConfigFlagValues)

--- a/internal/providers/runpod/flags.go
+++ b/internal/providers/runpod/flags.go
@@ -1,6 +1,10 @@
 package runpod
 
-import "flag"
+import (
+	"flag"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
 
 type runpodFlagValues struct {
 	APIURL     *string
@@ -32,11 +36,8 @@ func RegisterRunpodProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyRunpodProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if isRunpodProviderName(cfg.Provider) {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=%s; use --runpod-instance-id", providerName)
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=%s; use --runpod-image", providerName)
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --runpod-instance-id", "use --runpod-image"); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(runpodFlagValues)

--- a/internal/providers/shared/delegated_test.go
+++ b/internal/providers/shared/delegated_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -628,6 +629,42 @@ func TestDelegatedSandboxReuseAdmission(t *testing.T) {
 			}
 			if strings.Contains(stage, "admission") && stage != "admission error" && !errors.Is(err, context.Canceled) {
 				t.Fatalf("lost cancellation cause: %v", err)
+			}
+		})
+	}
+}
+
+func TestRejectExplicitMachineSizingFlagsContract(t *testing.T) {
+	for _, tc := range []struct {
+		name                        string
+		args                        []string
+		classGuide, typeGuide, want string
+	}{
+		{"absent", nil, "", "", ""},
+		{"class", []string{"--class=large"}, "", "", "--class is not supported for provider=fixture"},
+		{"type", []string{"--type=machine"}, "", "", "--type is not supported for provider=fixture"},
+		{"class-first", []string{"--class=large", "--type=machine"}, "class guide", "type guide", "--class is not supported for provider=fixture; class guide"},
+		{"type-first", []string{"--type=machine", "--class=large"}, "class guide", "type guide", "--class is not supported for provider=fixture; class guide"},
+		{"empty-class", []string{"--class="}, " literal ", "", "--class is not supported for provider=fixture;  literal "},
+		{"empty-type", []string{"--type="}, "", "type guide", "--type is not supported for provider=fixture; type guide"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := flag.NewFlagSet("contract", flag.ContinueOnError)
+			fs.String("class", "inherited-class", "")
+			fs.String("type", "inherited-type", "")
+			if err := fs.Parse(tc.args); err != nil {
+				t.Fatal(err)
+			}
+			err := RejectExplicitMachineSizingFlags(fs, "fixture", tc.classGuide, tc.typeGuide)
+			if tc.want == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			var exitErr core.ExitError
+			if err == nil || err.Error() != tc.want || !errors.As(err, &exitErr) || exitErr.Code != 2 {
+				t.Fatalf("error=%v exit=%#v want=%q", err, exitErr, tc.want)
 			}
 		})
 	}

--- a/internal/providers/shared/sizing_flags.go
+++ b/internal/providers/shared/sizing_flags.go
@@ -1,0 +1,27 @@
+package shared
+
+import (
+	"flag"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// RejectExplicitMachineSizingFlags rejects visited class and type flags in that
+// order. Provider selection and the call's validation phase remain with callers.
+func RejectExplicitMachineSizingFlags(fs *flag.FlagSet, provider, classGuidance, typeGuidance string) error {
+	if core.FlagWasSet(fs, "class") {
+		suffix := ""
+		if classGuidance != "" {
+			suffix = "; " + classGuidance
+		}
+		return core.Exit(2, "--class is not supported for provider=%s%s", provider, suffix)
+	}
+	if core.FlagWasSet(fs, "type") {
+		suffix := ""
+		if typeGuidance != "" {
+			suffix = "; " + typeGuidance
+		}
+		return core.Exit(2, "--type is not supported for provider=%s%s", provider, suffix)
+	}
+	return nil
+}

--- a/internal/providers/smolvm/core.go
+++ b/internal/providers/smolvm/core.go
@@ -1,7 +1,6 @@
 package smolvm
 
 import (
-	"flag"
 	"io"
 	"time"
 
@@ -38,10 +37,6 @@ const (
 
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
-}
-
-func flagWasSet(fs *flag.FlagSet, name string) bool {
-	return core.FlagWasSet(fs, name)
 }
 
 func blank(value, fallback string) string {

--- a/internal/providers/smolvm/flags.go
+++ b/internal/providers/smolvm/flags.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func RegisterSmolvmProviderFlags(fs *flag.FlagSet, defaults Config) any {
@@ -13,11 +14,8 @@ func RegisterSmolvmProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplySmolvmProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if cfg.Provider == providerName || cfg.Provider == "smol" || cfg.Provider == "smolmachines" || cfg.Provider == "smolfleet" {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=%s; use --smolvm-cpus/--smolvm-memory-mb", providerName)
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=%s; use --smolvm-image", providerName)
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --smolvm-cpus/--smolvm-memory-mb", "use --smolvm-image"); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(core.SmolvmConfigFlagValues)

--- a/internal/providers/superserve/flags.go
+++ b/internal/providers/superserve/flags.go
@@ -41,11 +41,8 @@ func RegisterSuperserveProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplySuperserveProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if strings.EqualFold(strings.TrimSpace(cfg.Provider), providerName) {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=superserve; use --superserve-template or --superserve-snapshot")
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=superserve; use --superserve-template or --superserve-snapshot")
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --superserve-template or --superserve-snapshot", "use --superserve-template or --superserve-snapshot"); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(superserveFlagValues)

--- a/internal/providers/unikraftcloud/flags.go
+++ b/internal/providers/unikraftcloud/flags.go
@@ -3,6 +3,8 @@ package unikraftcloud
 import (
 	"flag"
 	"strings"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type unikraftCloudFlagValues struct {
@@ -27,11 +29,8 @@ func registerUnikraftCloudProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func applyUnikraftCloudProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if isUnikraftCloudProviderName(cfg.Provider) {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=%s", providerName)
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=%s", providerName)
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(unikraftCloudFlagValues)

--- a/internal/providers/upstashbox/core.go
+++ b/internal/providers/upstashbox/core.go
@@ -1,7 +1,6 @@
 package upstashbox
 
 import (
-	"flag"
 	"io"
 	"time"
 
@@ -37,10 +36,6 @@ const (
 
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
-}
-
-func flagWasSet(fs *flag.FlagSet, name string) bool {
-	return core.FlagWasSet(fs, name)
 }
 
 func blank(value, fallback string) string {

--- a/internal/providers/upstashbox/flags.go
+++ b/internal/providers/upstashbox/flags.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func RegisterUpstashBoxProviderFlags(fs *flag.FlagSet, defaults Config) any {
@@ -13,11 +14,8 @@ func RegisterUpstashBoxProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyUpstashBoxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if cfg.Provider == providerName || cfg.Provider == "upstash" || cfg.Provider == "box" || cfg.Provider == "upstashbox" {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=%s; use --upstash-box-size", providerName)
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=%s; use --upstash-box-runtime", providerName)
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --upstash-box-size", "use --upstash-box-runtime"); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(core.UpstashBoxConfigFlagValues)

--- a/internal/providers/vast/flags.go
+++ b/internal/providers/vast/flags.go
@@ -1,6 +1,10 @@
 package vast
 
-import "flag"
+import (
+	"flag"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
 
 type vastFlagValues struct {
 	APIURL         *string
@@ -42,11 +46,8 @@ func RegisterVastProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyVastProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if isVastProviderName(cfg.Provider) {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=%s; use --vast-gpu-name or --vast-gpu-count", providerName)
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=%s; use --vast-image", providerName)
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --vast-gpu-name or --vast-gpu-count", "use --vast-image"); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(vastFlagValues)

--- a/internal/providers/vercelsandbox/core.go
+++ b/internal/providers/vercelsandbox/core.go
@@ -1,7 +1,6 @@
 package vercelsandbox
 
 import (
-	"flag"
 	"io"
 	"time"
 
@@ -42,10 +41,6 @@ const (
 
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
-}
-
-func flagWasSet(fs *flag.FlagSet, name string) bool {
-	return core.FlagWasSet(fs, name)
 }
 
 func inventoryDoctorResult(provider string, leases int) DoctorResult {

--- a/internal/providers/vercelsandbox/flags.go
+++ b/internal/providers/vercelsandbox/flags.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func RegisterVercelSandboxProviderFlags(fs *flag.FlagSet, defaults Config) any {
@@ -17,11 +18,8 @@ func RegisterVercelSandboxProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyVercelSandboxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if strings.EqualFold(strings.TrimSpace(cfg.Provider), providerName) {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=vercel-sandbox; use --vercel-sandbox-vcpus")
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=vercel-sandbox; use --vercel-sandbox-runtime or --vercel-sandbox-vcpus")
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --vercel-sandbox-vcpus", "use --vercel-sandbox-runtime or --vercel-sandbox-vcpus"); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(core.VercelSandboxConfigFlagValues)

--- a/internal/providers/wandb/flags.go
+++ b/internal/providers/wandb/flags.go
@@ -3,6 +3,8 @@ package wandb
 import (
 	"flag"
 	"strings"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type wandbFlagValues struct {
@@ -23,11 +25,8 @@ func RegisterWandbProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyWandbProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if isWandbProviderName(cfg.Provider) {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=%s", providerName)
-		}
-		if flagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=%s", providerName)
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
+			return err
 		}
 	}
 	v, ok := values.(wandbFlagValues)

--- a/internal/providers/windowssandbox/flags.go
+++ b/internal/providers/windowssandbox/flags.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type flagValues struct {
@@ -41,11 +42,8 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	}
 	selected := cfg.Provider == providerName || cfg.Provider == "wsb" || cfg.Provider == "windows-sandbox-provider"
 	if selected {
-		if core.FlagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=%s; Windows Sandbox sizing is controlled by the host", providerName)
-		}
-		if core.FlagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=%s; Windows Sandbox sizing is controlled by the host", providerName)
+		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "Windows Sandbox sizing is controlled by the host", "Windows Sandbox sizing is controlled by the host"); err != nil {
+			return err
 		}
 		if !core.FlagWasSet(fs, "target") {
 			cfg.TargetOS = targetWindows


### PR DESCRIPTION
## Summary

Give 31 providers one implementation of their existing explicit machine-sizing flag rejection policy. The shared helper checks class before type, considers actual flag visits (including empty values), and retains each provider's exact canonical name, guidance and exit code. It does not select a provider or inspect/mutate configuration.

Sixteen private flag-presence forwarders that became unused are removed along with their imports.

Each adapter keeps its original selection, alias handling, values assertion, field application and validation position. CodeSandbox and Windows Sandbox still assert values before the sizing guard; Dynamic Workers keeps its later expose check, and other target/default/validation checks remain local. No ProviderSpec capability inference, callbacks, generic validation phase, or configuration-generator change is introduced.

The census found 36 equivalent pairs. Five existing owner-held providers—ASCII Box, Boxd, Nomad, Sprites and Tenki—remain unchanged. GitHub Codespaces's class-only rejection and Daytona's type-only rejection are different contracts; mapped and no-guard providers are also unchanged. This is the complete eligible neighborhood, not a claim that every provider now rejects sizing flags. Docs and an Unreleased changelog entry are included.

## Verification

The real registered provider hooks passed identical baseline/candidate race tests covering all 31 adapters, exact guidance and exit codes, canonical/alias selection, both flag orders, explicit empty values, wrong-value types, inherited config, local ordering, and non-adopter controls. Five existing central source-phase tests also passed. Candidate-only tests cover the new shared helper independently.

The initial paired tests passed; the rejection assertion was then strengthened to also visit an inert provider field, so moving the guard after copying fields becomes observable. Final baseline/candidate pairs passed again with no fixture failures or expectation corrections. Original passes remain recorded. Managed Codex P0 review of the final strengthened version found no actionable findings in scope.

A fresh final gate reran the focused paired selection, helper tests and scoped vet for the 31 adapters plus the registry/shared/core packages. All 2,311 tracked/new source, test and documentation hashes remained unchanged. CLI/docs builds and whitespace checks passed.

Independent source-blind CLI validation matched all 186 cases across 31 providers exactly in exit status, stdout and stderr; every case exited 2 before provider construction. Both flag orders selected the class diagnostic and empty flags remained explicit. Baseline captures, harness and expectations were frozen before candidate access, with no baseline rerun, changed expectations or normalization. Every matrix invocation was network-denied and bounded to five seconds. An initial isolated help discovery call lacked a timeout and completed within one second; that procedural limitation is retained.

Initial tested binary SHA-256: `65f7c37fb94188a8ea6bdee3927dbd9e0876f1b1f5e36d8c1bb88ebc2f083cde`. The private commit was rebound onto actual Modal merge `238c9c7f1dab8fea074809d5f79197c8c6f1e05b` (https://github.com/openclaw/crabbox/pull/2022). All 32 production and two test Go files stayed byte-identical; the sole inherited difference is the Modal changelog link, so complete-tree equality is not claimed. A fresh integration P0 review, focused paired/helper race tests, scoped vet and CLI/docs build passed, with all 2,311 hashes unchanged during the gate. The rebuilt binary is identical to the independently tested candidate; previous CLI proof is reused by binary identity rather than described as a new execution. The first [CI run](https://github.com/openclaw/crabbox/actions/runs/34305862479) failed its Deadcode step on those sixteen newly unused forwarding helpers, before Go tests ran. They have now been deleted without changing tests, diagnostics, or policy. The corrected source passed fresh P0 review, focused race/helper tests, scoped vet, and the pinned `deadcode@v0.45.0 -test ./...` static analysis with zero findings on Darwin. Test entry points were analyzed, not executed by that analyzer. The initial local analyzer invocation stopped at public-module metadata resolution; installing the same pinned tool in a task directory allowed the analysis to run network-denied. No suppression or gate change was made.

The corrected binary SHA-256 is `a962ef3d045dc4fa9c68b9f8f7c1534acf98aaaf6fca3b854d196518209b627e`. All 186 frozen CLI cases were freshly executed against it and match the original baseline exactly; earlier captures and seals are preserved. This corrected build is distinct from the earlier binary-identity reuse. The corrected [CI run](https://github.com/openclaw/crabbox/actions/runs/34307151610) passed all eleven main jobs, including Deadcode and the full Go tests. All observed checks passed, apart from the expected skipped check. The fresh current-main merge preview exactly matches the corrected final PR tree. The original failed run remains recorded and was not manually rerun. This is parser/admission-policy equivalence, not native provider, SDK, credential, lifecycle, deployment or release qualification. No held-provider work is superseded.
