### PR TITLE
refactor(config): share raw work-root inheritance decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@
 
 - Describe exe.dev configuration bindings once, sharing configured defaults while preserving work-root inheritance, omitted native images, CPU input rules, and notification preferences. [PR 2025](https://github.com/openclaw/crabbox/pull/2025). Thanks @steipete.
 
+- Share work-root inheritance decisions across exe.dev, Runpod, Multipass, Hyper-V, and Tart while preserving raw provider roots, portable-default handling, and later validation. Thanks @steipete.
+
 ## 0.53.0 - 2026-09-08
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 
 - Describe exe.dev configuration bindings once, sharing configured defaults while preserving work-root inheritance, omitted native images, CPU input rules, and notification preferences. [PR 2025](https://github.com/openclaw/crabbox/pull/2025). Thanks @steipete.
 
-- Share work-root inheritance decisions across exe.dev, Runpod, Multipass, Hyper-V, and Tart while preserving raw provider roots, portable-default handling, and later validation. Thanks @steipete.
+- Share work-root inheritance decisions across exe.dev, Runpod, Multipass, Hyper-V, and Tart while preserving raw provider roots, portable-default handling, and later validation. [PR 2026](https://github.com/openclaw/crabbox/pull/2026). Thanks @steipete.
 
 ## 0.53.0 - 2026-09-08
 

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -972,6 +972,15 @@ Blacksmith does) when the config type is not ready to export cleanly.
 If a provider needs durable config, add typed config fields in `Config` and env
 overrides in `config.go`.
 
+`cli.ResolveInheritedWorkRoot` shares the raw work-root decision used by exe.dev
+(core loading and backend defaults), Runpod, Multipass, Hyper-V, and Tart. A
+nonempty provider root wins; otherwise a generic root that is not an exact
+portable default is inherited, or the caller's fallback is used. The resolver
+does not trim, normalize paths, inspect markers or targets, validate directories,
+or mutate configuration. Keep subsequent generic-root copies and other default
+assignments at their existing call sites. Providers with trimmed classifiers,
+explicit-root markers, or different projection rules retain their own policy.
+
 Never pass provider secrets as command-line arguments. Use environment variables,
 local SDK config, the broker, or a credential store outside repo config.
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1839,13 +1839,7 @@ func applyProviderConfigDefaults(cfg *Config) error {
 			cfg.SSHPort = "22"
 		}
 		cfg.SSHFallbackPorts = nil
-		if cfg.ExeDev.WorkRoot == "" {
-			if !isDefaultWorkRoot(cfg.WorkRoot) {
-				cfg.ExeDev.WorkRoot = cfg.WorkRoot
-			} else {
-				cfg.ExeDev.WorkRoot = ExeDevWorkRootFallback
-			}
-		}
+		cfg.ExeDev.WorkRoot = ResolveInheritedWorkRoot(cfg.ExeDev.WorkRoot, cfg.WorkRoot, ExeDevWorkRootFallback)
 		if cfg.ExeDev.WorkRoot != "" {
 			cfg.WorkRoot = cfg.ExeDev.WorkRoot
 		}

--- a/internal/cli/config_optional_test.go
+++ b/internal/cli/config_optional_test.go
@@ -161,3 +161,17 @@ func TestApplyProfileAndJobOptionalOverlays(t *testing.T) {
 		t.Fatal("job pointer options share their copies")
 	}
 }
+
+func TestResolveInheritedWorkRootContract(t *testing.T) {
+	for _, tc := range []struct{ providerRoot, genericRoot, fallback, want string }{
+		{"", "", "fallback", "fallback"}, {"", "/work/crabbox", "fallback", "fallback"}, {"", "/Users/ec2-user/crabbox", "fallback", "fallback"}, {"", `C:\crabbox`, "fallback", "fallback"},
+		{"", " /work/crabbox ", "fallback", " /work/crabbox "}, {"", "/WORK/crabbox", "fallback", "/WORK/crabbox"}, {"", `c:\crabbox`, "fallback", `c:\crabbox`},
+		{"", "/srv/custom", "fallback", "/srv/custom"}, {"", "/Users/alice/custom", "fallback", "/Users/alice/custom"}, {"", `D:\custom`, "fallback", `D:\custom`}, {"", "  ", "fallback", "  "},
+		{" ", "/srv/custom", "fallback", " "}, {"/work/crabbox", "/srv/custom", "fallback", "/work/crabbox"}, {"relative", "/srv/custom", "fallback", "relative"},
+		{"", "/work/crabbox", "  literal fallback ", "  literal fallback "}, {"", "/work/crabbox", "", ""},
+	} {
+		if got := ResolveInheritedWorkRoot(tc.providerRoot, tc.genericRoot, tc.fallback); got != tc.want {
+			t.Fatalf("roots=%q/%q fallback=%q got=%q want=%q", tc.providerRoot, tc.genericRoot, tc.fallback, got, tc.want)
+		}
+	}
+}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -11341,3 +11341,41 @@ func TestExeDevConfigCentralFlagSource(t *testing.T) {
 		t.Fatal("explicit empty source missing")
 	}
 }
+
+func TestInheritedWorkRootCallerContract(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USER", "fixture-user")
+	for _, tc := range []struct{ providerRoot, genericRoot, want string }{
+		{"", "", "/tmp/crabbox"}, {"", "/work/crabbox", "/tmp/crabbox"}, {"", "/Users/ec2-user/crabbox", "/tmp/crabbox"}, {"", `C:\crabbox`, "/tmp/crabbox"},
+		{"", " /work/crabbox ", " /work/crabbox "}, {"", "/WORK/crabbox", "/WORK/crabbox"}, {"", `c:\crabbox`, `c:\crabbox`},
+		{"", "/srv/custom", "/srv/custom"}, {"", "/Users/alice/custom", "/Users/alice/custom"}, {"", `D:\custom`, `D:\custom`}, {"", "  ", "  "},
+		{" ", "/srv/custom", " "}, {"/work/crabbox", "/srv/custom", "/work/crabbox"}, {"relative", "/srv/custom", "relative"}, {"/provider/root", "/srv/custom", "/provider/root"},
+	} {
+		for _, explicit := range []bool{false, true} {
+			cfg := baseConfig()
+			cfg.Provider = "exe-dev"
+			cfg.SSHUser = "fixture-user"
+			cfg.SSHPort = "1234"
+			cfg.SSHFallbackPorts = []string{"4567"}
+			cfg.WorkRoot = "/recorded/root"
+			if explicit {
+				MarkWorkRootExplicit(&cfg)
+			}
+			cfg.WorkRoot = tc.genericRoot
+			cfg.ExeDev.WorkRoot = tc.providerRoot
+			want := cfg
+			want.WorkRoot = tc.want
+			want.ExeDev.WorkRoot = tc.want
+			want.SSHFallbackPorts = nil
+			want.providerDefaultsApplied = "exe-dev"
+			want.inferredTargetProvider = "exe-dev"
+			want.osImageProviderDefaults = want.OSImage
+			if err := applyProviderConfigDefaults(&cfg); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(cfg, want) {
+				t.Fatalf("whole core config differs for roots=%q/%q explicit=%t: got=%#v want=%#v", tc.providerRoot, tc.genericRoot, explicit, cfg, want)
+			}
+		}
+	}
+}

--- a/internal/cli/work_root.go
+++ b/internal/cli/work_root.go
@@ -1,0 +1,13 @@
+package cli
+
+// ResolveInheritedWorkRoot preserves a raw nonempty provider root, otherwise
+// inheriting a non-default generic root or using the caller's fallback.
+func ResolveInheritedWorkRoot(providerRoot, genericRoot, fallback string) string {
+	if providerRoot != "" {
+		return providerRoot
+	}
+	if !isDefaultWorkRoot(genericRoot) {
+		return genericRoot
+	}
+	return fallback
+}

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -390,13 +390,7 @@ func applyExeDevDefaults(cfg *Config) {
 	if cfg.ExeDev.Disk == "" {
 		cfg.ExeDev.Disk = core.ExeDevConfigDefaultDisk
 	}
-	if cfg.ExeDev.WorkRoot == "" {
-		if !isDefaultWorkRoot(cfg.WorkRoot) {
-			cfg.ExeDev.WorkRoot = cfg.WorkRoot
-		} else {
-			cfg.ExeDev.WorkRoot = core.ExeDevWorkRootFallback
-		}
-	}
+	cfg.ExeDev.WorkRoot = core.ResolveInheritedWorkRoot(cfg.ExeDev.WorkRoot, cfg.WorkRoot, core.ExeDevWorkRootFallback)
 	if cfg.ExeDev.User != "" {
 		cfg.SSHUser = cfg.ExeDev.User
 	} else if cfg.SSHUser == "" || cfg.SSHUser == "crabbox" {

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -1284,3 +1284,55 @@ func TestExeDevConfigCreateArgumentsContract(t *testing.T) {
 		})
 	}
 }
+
+func TestInheritedWorkRootCallerContract(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USER", "fixture-user")
+	for _, tc := range []struct{ providerRoot, genericRoot, want string }{
+		{"", "", "/tmp/crabbox"},
+		{"", "/work/crabbox", "/tmp/crabbox"},
+		{"", "/Users/ec2-user/crabbox", "/tmp/crabbox"},
+		{"", "C:\\crabbox", "/tmp/crabbox"},
+		{"", " /work/crabbox ", " /work/crabbox "},
+		{"", "/WORK/crabbox", "/WORK/crabbox"},
+		{"", "c:\\crabbox", "c:\\crabbox"},
+		{"", "/srv/custom", "/srv/custom"},
+		{"", "/Users/alice/custom", "/Users/alice/custom"},
+		{"", "D:\\custom", "D:\\custom"},
+		{"", "  ", "  "},
+		{" ", "/srv/custom", " "},
+		{"/work/crabbox", "/srv/custom", "/work/crabbox"},
+		{"relative", "/srv/custom", "relative"},
+		{"/provider/root", "/srv/custom", "/provider/root"},
+	} {
+		for _, explicit := range []bool{false, true} {
+			cfg := Config{Provider: "prior", WorkRoot: "/recorded/root", SSHUser: "fixture-user", SSHPort: "1234", SSHFallbackPorts: []string{"4567"}, ServerType: "prior-type", Network: "prior-network"}
+			if explicit {
+				core.MarkWorkRootExplicit(&cfg)
+				cfg.TargetOS = "existing-target"
+				cfg.WindowsMode = "prior-mode"
+			}
+			cfg.WorkRoot = tc.genericRoot
+			cfg.ExeDev.WorkRoot = tc.providerRoot
+
+			want := cfg
+			want.Provider = "exe-dev"
+			if !explicit {
+				want.TargetOS = "linux"
+			}
+			want.ExeDev.WorkRoot = tc.want
+			want.WorkRoot = tc.want
+			want.ExeDev.ControlHost = "exe.dev"
+			want.ExeDev.CPUs = 2
+			want.ExeDev.Memory = "4GB"
+			want.ExeDev.Disk = "10GB"
+			want.SSHPort = "22"
+			want.SSHFallbackPorts = nil
+			want.ServerType = "default"
+			applyExeDevDefaults(&cfg)
+			if !reflect.DeepEqual(cfg, want) {
+				t.Fatalf("whole config differs for roots=%q/%q explicit=%t: got=%#v want=%#v", tc.providerRoot, tc.genericRoot, explicit, cfg, want)
+			}
+		}
+	}
+}

--- a/internal/providers/exedev/core.go
+++ b/internal/providers/exedev/core.go
@@ -116,10 +116,6 @@ func sshTargetFromConfig(cfg Config, host string) SSHTarget {
 	return core.SSHTargetFromConfig(cfg, host)
 }
 
-func isDefaultWorkRoot(value string) bool {
-	return core.IsDefaultWorkRoot(value)
-}
-
 var waitForSSHReady = func(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
 	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
 }

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -72,13 +72,7 @@ func applyDefaults(cfg *Config) {
 			cfg.HyperV.User = "crabbox"
 		}
 	}
-	if cfg.HyperV.WorkRoot == "" {
-		if !core.IsDefaultWorkRoot(cfg.WorkRoot) {
-			cfg.HyperV.WorkRoot = cfg.WorkRoot
-		} else {
-			cfg.HyperV.WorkRoot = `C:\crabbox`
-		}
-	}
+	cfg.HyperV.WorkRoot = core.ResolveInheritedWorkRoot(cfg.HyperV.WorkRoot, cfg.WorkRoot, `C:\crabbox`)
 	if cfg.HyperV.CPUs <= 0 {
 		cfg.HyperV.CPUs = 4
 	}

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"testing/synctest"
@@ -2075,5 +2076,57 @@ func TestWaitGuestReadyBackoffDeadlinePreservesProbeCodeAndCause(t *testing.T) {
 				}
 			})
 		})
+	}
+}
+
+func TestInheritedWorkRootCallerContract(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USER", "fixture-user")
+	for _, tc := range []struct{ providerRoot, genericRoot, want string }{
+		{"", "", "C:\\crabbox"},
+		{"", "/work/crabbox", "C:\\crabbox"},
+		{"", "/Users/ec2-user/crabbox", "C:\\crabbox"},
+		{"", "C:\\crabbox", "C:\\crabbox"},
+		{"", " /work/crabbox ", " /work/crabbox "},
+		{"", "/WORK/crabbox", "/WORK/crabbox"},
+		{"", "c:\\crabbox", "c:\\crabbox"},
+		{"", "/srv/custom", "/srv/custom"},
+		{"", "/Users/alice/custom", "/Users/alice/custom"},
+		{"", "D:\\custom", "D:\\custom"},
+		{"", "  ", "  "},
+		{" ", "/srv/custom", " "},
+		{"/work/crabbox", "/srv/custom", "/work/crabbox"},
+		{"relative", "/srv/custom", "relative"},
+		{"/provider/root", "/srv/custom", "/provider/root"},
+	} {
+		for _, explicit := range []bool{false, true} {
+			cfg := Config{Provider: "prior", WorkRoot: "/recorded/root", SSHUser: "fixture-user", SSHPort: "1234", SSHFallbackPorts: []string{"4567"}, ServerType: "prior-type", Network: "prior-network"}
+			if explicit {
+				core.MarkWorkRootExplicit(&cfg)
+				cfg.TargetOS = "existing-target"
+				cfg.WindowsMode = "prior-mode"
+			}
+			cfg.WorkRoot = tc.genericRoot
+			cfg.HyperV.WorkRoot = tc.providerRoot
+
+			want := cfg
+			want.Provider = "hyperv"
+			if !explicit {
+				want.TargetOS = "windows"
+				want.WindowsMode = "normal"
+			}
+			want.HyperV.WorkRoot = tc.want
+			want.WorkRoot = tc.want
+			want.HyperV.User = "fixture-user"
+			want.HyperV.CPUs = 4
+			want.HyperV.Memory = 8192
+			want.HyperV.Switch = "Default Switch"
+			want.SSHPort = "22"
+			want.SSHFallbackPorts = []string{}
+			applyDefaults(&cfg)
+			if !reflect.DeepEqual(cfg, want) {
+				t.Fatalf("whole config differs for roots=%q/%q explicit=%t: got=%#v want=%#v", tc.providerRoot, tc.genericRoot, explicit, cfg, want)
+			}
+		}
 	}
 }

--- a/internal/providers/multipass/backend.go
+++ b/internal/providers/multipass/backend.go
@@ -72,13 +72,7 @@ func applyDefaults(cfg *Config) {
 	if cfg.Multipass.User == "" {
 		cfg.Multipass.User = "crabbox"
 	}
-	if cfg.Multipass.WorkRoot == "" {
-		if !core.IsDefaultWorkRoot(cfg.WorkRoot) {
-			cfg.Multipass.WorkRoot = cfg.WorkRoot
-		} else {
-			cfg.Multipass.WorkRoot = "/work/crabbox"
-		}
-	}
+	cfg.Multipass.WorkRoot = core.ResolveInheritedWorkRoot(cfg.Multipass.WorkRoot, cfg.WorkRoot, "/work/crabbox")
 	if cfg.Multipass.LaunchTimeout <= 0 {
 		cfg.Multipass.LaunchTimeout = 20 * time.Minute
 	}

--- a/internal/providers/multipass/backend_test.go
+++ b/internal/providers/multipass/backend_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -733,5 +734,61 @@ func TestReleaseRequiresExactClaim(t *testing.T) {
 func TestLaunchArgTimeoutValueIsNumeric(t *testing.T) {
 	if _, err := strconv.Atoi(strconv.Itoa(durationSecondsCeil(10 * time.Minute))); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestInheritedWorkRootCallerContract(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USER", "fixture-user")
+	for _, tc := range []struct{ providerRoot, genericRoot, want string }{
+		{"", "", "/work/crabbox"},
+		{"", "/work/crabbox", "/work/crabbox"},
+		{"", "/Users/ec2-user/crabbox", "/work/crabbox"},
+		{"", "C:\\crabbox", "/work/crabbox"},
+		{"", " /work/crabbox ", " /work/crabbox "},
+		{"", "/WORK/crabbox", "/WORK/crabbox"},
+		{"", "c:\\crabbox", "c:\\crabbox"},
+		{"", "/srv/custom", "/srv/custom"},
+		{"", "/Users/alice/custom", "/Users/alice/custom"},
+		{"", "D:\\custom", "D:\\custom"},
+		{"", "  ", "  "},
+		{" ", "/srv/custom", " "},
+		{"/work/crabbox", "/srv/custom", "/work/crabbox"},
+		{"relative", "/srv/custom", "relative"},
+		{"/provider/root", "/srv/custom", "/provider/root"},
+	} {
+		for _, explicit := range []bool{false, true} {
+			cfg := Config{Provider: "prior", WorkRoot: "/recorded/root", SSHUser: "fixture-user", SSHPort: "1234", SSHFallbackPorts: []string{"4567"}, ServerType: "prior-type", Network: "prior-network"}
+			if explicit {
+				core.MarkWorkRootExplicit(&cfg)
+				cfg.TargetOS = "existing-target"
+				cfg.WindowsMode = "prior-mode"
+			}
+			cfg.WorkRoot = tc.genericRoot
+			cfg.Multipass.WorkRoot = tc.providerRoot
+
+			want := cfg
+			want.Provider = "multipass"
+			if !explicit {
+				want.TargetOS = "linux"
+			}
+			want.Multipass.WorkRoot = tc.want
+			want.WorkRoot = tc.want
+			want.Multipass.CLIPath = "multipass"
+			want.Multipass.Image = "26.04"
+			want.Multipass.User = "crabbox"
+			want.Multipass.LaunchTimeout = 20 * time.Minute
+			want.SSHUser = "crabbox"
+			want.SSHPort = "22"
+			want.SSHFallbackPorts = []string{}
+			want.ServerType = "26.04"
+			if !explicit {
+				want.WindowsMode = ""
+			}
+			applyDefaults(&cfg)
+			if !reflect.DeepEqual(cfg, want) {
+				t.Fatalf("whole config differs for roots=%q/%q explicit=%t: got=%#v want=%#v", tc.providerRoot, tc.genericRoot, explicit, cfg, want)
+			}
+		}
 	}
 }

--- a/internal/providers/runpod/backend.go
+++ b/internal/providers/runpod/backend.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -332,13 +333,7 @@ func applyRunpodDefaults(cfg *Config) {
 	if cfg.Runpod.DiskGB <= 0 {
 		cfg.Runpod.DiskGB = 20
 	}
-	if cfg.Runpod.WorkRoot == "" {
-		if !isDefaultWorkRoot(cfg.WorkRoot) {
-			cfg.Runpod.WorkRoot = cfg.WorkRoot
-		} else {
-			cfg.Runpod.WorkRoot = "/tmp/crabbox"
-		}
-	}
+	cfg.Runpod.WorkRoot = core.ResolveInheritedWorkRoot(cfg.Runpod.WorkRoot, cfg.WorkRoot, "/tmp/crabbox")
 	if cfg.Runpod.User != "" {
 		cfg.SSHUser = cfg.Runpod.User
 	} else if cfg.SSHUser == "" || cfg.SSHUser == "crabbox" {

--- a/internal/providers/runpod/backend_test.go
+++ b/internal/providers/runpod/backend_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -1127,5 +1128,57 @@ func TestRunpodClientRetriesGPUCapacityFallbacks(t *testing.T) {
 	}
 	if len(seen) != 2 || seen[0] != "NVIDIA L4" || seen[1] != "NVIDIA RTX 4000 Ada Generation" {
 		t.Fatalf("seen=%v", seen)
+	}
+}
+
+func TestInheritedWorkRootCallerContract(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USER", "fixture-user")
+	for _, tc := range []struct{ providerRoot, genericRoot, want string }{
+		{"", "", "/tmp/crabbox"},
+		{"", "/work/crabbox", "/tmp/crabbox"},
+		{"", "/Users/ec2-user/crabbox", "/tmp/crabbox"},
+		{"", "C:\\crabbox", "/tmp/crabbox"},
+		{"", " /work/crabbox ", " /work/crabbox "},
+		{"", "/WORK/crabbox", "/WORK/crabbox"},
+		{"", "c:\\crabbox", "c:\\crabbox"},
+		{"", "/srv/custom", "/srv/custom"},
+		{"", "/Users/alice/custom", "/Users/alice/custom"},
+		{"", "D:\\custom", "D:\\custom"},
+		{"", "  ", "  "},
+		{" ", "/srv/custom", " "},
+		{"/work/crabbox", "/srv/custom", "/work/crabbox"},
+		{"relative", "/srv/custom", "relative"},
+		{"/provider/root", "/srv/custom", "/provider/root"},
+	} {
+		for _, explicit := range []bool{false, true} {
+			cfg := Config{Provider: "prior", WorkRoot: "/recorded/root", SSHUser: "fixture-user", SSHPort: "1234", SSHFallbackPorts: []string{"4567"}, ServerType: "prior-type", Network: "prior-network"}
+			if explicit {
+				core.MarkWorkRootExplicit(&cfg)
+				cfg.TargetOS = "existing-target"
+				cfg.WindowsMode = "prior-mode"
+			}
+			cfg.WorkRoot = tc.genericRoot
+			cfg.Runpod.WorkRoot = tc.providerRoot
+			cfg.Runpod.APIURL = "https://fixture.invalid"
+			cfg.Runpod.CloudType = "SECURE"
+			cfg.Runpod.InstanceID = "fixture-instance"
+			cfg.Runpod.Image = "fixture-image"
+			want := cfg
+			want.Provider = "runpod"
+			if !explicit {
+				want.TargetOS = "linux"
+			}
+			want.Runpod.WorkRoot = tc.want
+			want.WorkRoot = tc.want
+			want.Runpod.DiskGB = 20
+			want.SSHPort = ""
+			want.SSHFallbackPorts = nil
+			want.ServerType = "fixture-instance"
+			applyRunpodDefaults(&cfg)
+			if !reflect.DeepEqual(cfg, want) {
+				t.Fatalf("whole config differs for roots=%q/%q explicit=%t: got=%#v want=%#v", tc.providerRoot, tc.genericRoot, explicit, cfg, want)
+			}
+		}
 	}
 }

--- a/internal/providers/runpod/core.go
+++ b/internal/providers/runpod/core.go
@@ -111,10 +111,6 @@ func sshTargetFromConfig(cfg Config, host string) SSHTarget {
 	return core.SSHTargetFromConfig(cfg, host)
 }
 
-func isDefaultWorkRoot(value string) bool {
-	return core.IsDefaultWorkRoot(value)
-}
-
 func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
 	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
 }

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -62,13 +62,7 @@ func applyDefaults(cfg *Config) {
 	if cfg.Tart.Password == "" {
 		cfg.Tart.Password = "admin" // cirruslabs base-image default; WebVNC viewer credential only
 	}
-	if cfg.Tart.WorkRoot == "" {
-		if !core.IsDefaultWorkRoot(cfg.WorkRoot) {
-			cfg.Tart.WorkRoot = cfg.WorkRoot
-		} else {
-			cfg.Tart.WorkRoot = "/Users/admin/crabbox"
-		}
-	}
+	cfg.Tart.WorkRoot = core.ResolveInheritedWorkRoot(cfg.Tart.WorkRoot, cfg.WorkRoot, "/Users/admin/crabbox")
 	if cfg.Tart.CPUs <= 0 {
 		cfg.Tart.CPUs = 4
 	}

--- a/internal/providers/tart/provider_test.go
+++ b/internal/providers/tart/provider_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -4249,5 +4250,58 @@ func TestNormalizeLeaseSlugWithPrefix(t *testing.T) {
 	result := normalizeLeaseSlug("my-slug")
 	if result == "" {
 		t.Fatal("normalizeLeaseSlug should return non-empty for valid slug")
+	}
+}
+
+func TestInheritedWorkRootCallerContract(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USER", "fixture-user")
+	for _, tc := range []struct{ providerRoot, genericRoot, want string }{
+		{"", "", "/Users/admin/crabbox"},
+		{"", "/work/crabbox", "/Users/admin/crabbox"},
+		{"", "/Users/ec2-user/crabbox", "/Users/admin/crabbox"},
+		{"", "C:\\crabbox", "/Users/admin/crabbox"},
+		{"", " /work/crabbox ", " /work/crabbox "},
+		{"", "/WORK/crabbox", "/WORK/crabbox"},
+		{"", "c:\\crabbox", "c:\\crabbox"},
+		{"", "/srv/custom", "/srv/custom"},
+		{"", "/Users/alice/custom", "/Users/alice/custom"},
+		{"", "D:\\custom", "D:\\custom"},
+		{"", "  ", "  "},
+		{" ", "/srv/custom", " "},
+		{"/work/crabbox", "/srv/custom", "/work/crabbox"},
+		{"relative", "/srv/custom", "relative"},
+		{"/provider/root", "/srv/custom", "/provider/root"},
+	} {
+		for _, explicit := range []bool{false, true} {
+			cfg := Config{Provider: "prior", WorkRoot: "/recorded/root", SSHUser: "fixture-user", SSHPort: "1234", SSHFallbackPorts: []string{"4567"}, ServerType: "prior-type", Network: "prior-network"}
+			if explicit {
+				core.MarkWorkRootExplicit(&cfg)
+				cfg.TargetOS = "existing-target"
+				cfg.WindowsMode = "prior-mode"
+			}
+			cfg.WorkRoot = tc.genericRoot
+			cfg.Tart.WorkRoot = tc.providerRoot
+			cfg.Tart.Image = "fixture-image"
+			want := cfg
+			want.Provider = "tart"
+			if !explicit {
+				want.TargetOS = "macos"
+			}
+			want.Tart.WorkRoot = tc.want
+			want.WorkRoot = tc.want
+			want.Tart.User = "fixture-user"
+			want.Tart.Password = "admin"
+			want.Tart.CPUs = 4
+			want.Tart.Memory = 8192
+			want.SSHPort = "22"
+			want.SSHFallbackPorts = []string{}
+			want.WindowsMode = ""
+			want.ServerType = "fixture-image"
+			applyDefaults(&cfg)
+			if !reflect.DeepEqual(cfg, want) {
+				t.Fatalf("whole config differs for roots=%q/%q explicit=%t: got=%#v want=%#v", tc.providerRoot, tc.genericRoot, explicit, cfg, want)
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Give six work-root decisions one pure owner: core and backend exe.dev defaults, plus Runpod, Multipass, Hyper-V and Tart. A raw nonempty provider root wins; otherwise a generic root that is not an exact portable default is inherited, or the caller's fallback is returned. The existing classifier remains unchanged.

The resolver does not trim, normalize, validate, inspect markers/targets, access files, or mutate configuration. Each caller retains its original mutation position, generic-root propagation and surrounding defaults/SSH/sizing behavior. Fallback values remain provider-owned. Two newly unused classifier forwarders are removed. Different trimmed classifiers, explicit-root-marker policies, projections and held providers stay separate; no callback or generic policy language is introduced.

Docs and an Unreleased entry are included. The active target.go owner is untouched. This internal extraction neither implements nor resolves the separate closed unified-workdir feature request (https://github.com/openclaw/crabbox/issues/1269).

## Verification

Six existing caller test files characterize 180 whole-Config snapshots with independently expected raw-root tables; the new helper has a separate candidate-only sixteen-case table in an existing core test file. Final baseline/candidate caller races and helper races passed.

The first baseline fixture omitted three existing core bookkeeping updates; its expectation was corrected before the passing baseline. The first candidate compile caught one missing Runpod import; only that import was added, and the same candidate tests passed afterward. Both original failures and corrected passes are preserved separately. No test expectation changed to accommodate the import fix.

Managed Codex P0 review found no actionable findings in the final supplied scope. A fresh root gate passed caller tests in six packages, the helper test and scoped vet, with all 2,316 source/test/doc byte/mode hashes unchanged. The classifier and all twenty-two generated outputs stayed unchanged. CLI/docs builds, whitespace checks and pinned Deadcode v0.45.0 static analysis passed; static analysis considers test entry points without executing the broad tests.

Independent source-blind CLI comparison matched all 1,003 frozen config/help cases exactly in exit status, complete stdout and complete stderr. All exited 0; no timeouts, normalization, changed expectations or baseline rerun. All 510 original evidence seals remained intact. This proves observable configuration preservation, not every provider's runtime fallback or native behavior; the direct caller tests cover the local decisions separately.

The private commit was rebound onto actual exe.dev merge `d319af1f634f939ba48d295dda27c64b25e48f8a` (https://github.com/openclaw/crabbox/pull/2025). Complete base and candidate trees, including modes, remained identical. Independent binding verified all eighteen files, saved gates/seals, raw ancestry, 1,003 output pairs and executable identity; earlier results are reused, not described as new executions. A fresh build on actual main produced the identical tested SHA-256: `134f7890802fd642fb0831f65c7aa2d827311aa2988a109ec81fa7fd1e055312`. Hosted CI remains pending.

No real SSH, hypervisor, VM, key/account access, native provider request, filesystem cleanup, lifecycle, deployment or release qualification is claimed.
