### PR TITLE
feat(images): allow explicit Ubuntu 24.04 publication selection

### DIFF
--- a/.github/workflows/devtools-image-publish.yml
+++ b/.github/workflows/devtools-image-publish.yml
@@ -22,6 +22,14 @@ on:
         required: true
         default: m7i.large
         type: string
+      linux_os:
+        description: Linux image OS selector
+        required: true
+        default: ubuntu:26.04
+        type: choice
+        options:
+          - ubuntu:26.04
+          - ubuntu:24.04
       measured:
         description: Linux only - 12 planned leases instead of 3; provider retries can add attempts
         required: false
@@ -86,6 +94,7 @@ jobs:
           TARGET: ${{ inputs.target }}
           REGION: ${{ inputs.region }}
           LINUX_TYPE: ${{ inputs.linux_type }}
+          LINUX_OS: ${{ inputs.linux_os }}
           WINDOWS_TYPE: ${{ inputs.windows_type }}
           MACOS_TYPE: ${{ inputs.macos_type }}
           MACOS_HOST: ${{ inputs.macos_host }}
@@ -96,6 +105,10 @@ jobs:
           [[ "$TARGET" =~ ^(linux|windows|macos)$ ]]
           [[ "$REGION" =~ ^[a-z]{2}(-gov)?-[a-z]+-[0-9]+$ ]]
           [[ "$LINUX_TYPE" =~ ^[A-Za-z0-9.-]+$ ]]
+          [[ "$LINUX_OS" == ubuntu:26.04 || "$LINUX_OS" == ubuntu:24.04 ]] || {
+            printf '%s\n' 'linux_os must be ubuntu:26.04 or ubuntu:24.04' >&2
+            exit 2
+          }
           [[ "$WINDOWS_TYPE" =~ ^[A-Za-z0-9.-]+$ ]]
           [[ "$MACOS_TYPE" =~ ^[A-Za-z0-9.-]+$ ]]
           [[ "$MACOS_HOST" =~ ^(use-existing|allocate)$ ]]
@@ -124,6 +137,7 @@ jobs:
       TARGET: ${{ inputs.target }}
       REGION: ${{ inputs.region }}
       LINUX_TYPE: ${{ inputs.linux_type }}
+      LINUX_OS: ${{ inputs.linux_os }}
       WINDOWS_TYPE: ${{ inputs.windows_type }}
       MACOS_TYPE: ${{ inputs.macos_type }}
       MACOS_HOST: ${{ inputs.macos_host }}
@@ -183,6 +197,7 @@ jobs:
           case "$TARGET" in
             linux)
               command=(
+                env CRABBOX_OS="$LINUX_OS"
                 scripts/mint-aws-devtools-image.sh
                 --target linux
                 --region "$REGION"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add an explicit Ubuntu 24.04 developer-image publication selector while retaining Ubuntu 26.04 as the default, and scope Linux promotion and receipt rollback to the selected OS. Thanks @vincentkoc.
+- Add an explicit Ubuntu 24.04 developer-image publication selector while retaining Ubuntu 26.04 as the default, and scope Linux promotion and receipt rollback to the selected OS. https://github.com/openclaw/crabbox/pull/2028. Thanks @vincentkoc.
 
 - Run managed WSL2 workloads as the non-root `crabbox` user with passwordless sudo, writable work/cache directories, and the shared Node baseline on PATH. https://github.com/openclaw/crabbox/pull/2016. Thanks @steipete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add an explicit Ubuntu 24.04 developer-image publication selector while retaining Ubuntu 26.04 as the default, and scope Linux promotion and receipt rollback to the selected OS. Thanks @vincentkoc.
+
 - Run managed WSL2 workloads as the non-root `crabbox` user with passwordless sudo, writable work/cache directories, and the shared Node baseline on PATH. https://github.com/openclaw/crabbox/pull/2016. Thanks @steipete.
 
 - Keep managed WSL2 distributions alive between commands so detached Linux daemons survive until lease cleanup; preserve command and ownership deadlines. https://github.com/openclaw/crabbox/pull/2016. Thanks @steipete.

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -280,6 +280,7 @@ platform at a time from the protected default branch:
 gh workflow run devtools-image-publish.yml \
   --ref main \
   -f target=linux \
+  -f linux_os=ubuntu:24.04 \
   -f region=eu-west-1
 
 gh workflow run devtools-image-publish.yml \
@@ -293,6 +294,13 @@ gh workflow run devtools-image-publish.yml \
   -f region=eu-west-1 \
   -f macos_host=use-existing
 ```
+
+Linux publication defaults to `linux_os=ubuntu:26.04`; the example explicitly
+selects Ubuntu 24.04. The selector applies only to the Linux mint command and
+scopes its source, candidate, and promoted proof leases, promotion, and receipt
+rollback. Windows and macOS commands do not receive this Linux selector.
+Existing explicit image overrides still take precedence; requesting an OS does
+not prove the guest's actual OS or qualify the image.
 
 Use `macos_host=allocate` only when no suitable EC2 Mac Dedicated Host is
 available. Unmeasured publication uploads its complete mint logs and macOS
@@ -319,6 +327,17 @@ instead of hand-running the prep and image commands:
 scripts/mint-aws-devtools-image.sh --target linux
 scripts/mint-aws-devtools-image.sh --target windows
 ```
+
+For an explicit Ubuntu 24.04 Linux plan, use:
+
+```bash
+CRABBOX_OS=ubuntu:24.04 scripts/mint-aws-devtools-image.sh --target linux
+```
+
+The standalone wrapper leaves existing CLI/config selection unchanged when
+`CRABBOX_OS` is unset. When it is set for Linux, promotion and receipt rollback
+receive the same explicit `--os`; final proof still uses normal image selection
+without a candidate AMI override.
 
 The default is a no-spend plan that prints what it would do and stops. Add
 `--run` only when the selected AWS account, region, quotas, and image name are

--- a/scripts/devtools-image-workflow.test.js
+++ b/scripts/devtools-image-workflow.test.js
@@ -1,13 +1,122 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { spawnSync } from "node:child_process";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const workflow = fs.readFileSync(
   path.join(repoRoot, ".github", "workflows", "devtools-image-publish.yml"),
   "utf8",
 );
+
+function stepScript(name) {
+  const step = workflow.split(`      - name: ${name}\n`)[1]?.split("\n      - name: ")[0];
+  assert.ok(step, `missing workflow step: ${name}`);
+  const run = step.match(/^        run: \|\n((?: {10}[^\n]*\n|\n)*)/m)?.[1];
+  assert.ok(run, `missing shell body: ${name}`);
+  return run
+    .split("\n")
+    .map((line) => line.slice(10))
+    .join("\n");
+}
+
+function publicationFixture(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-publish-os-test-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  fs.mkdirSync(path.join(dir, "scripts"));
+  const output = path.join(dir, "mint.args");
+  for (const name of ["mint-aws-devtools-image.sh", "mint-macos-devtools-image.sh"]) {
+    fs.writeFileSync(
+      path.join(dir, "scripts", name),
+      '#!/usr/bin/env bash\nprintf "%s\\0" "${CRABBOX_OS-unset}" "$@" >"$MINT_ARGS"\n',
+      { mode: 0o755 },
+    );
+  }
+  const env = {
+    ...process.env,
+    TARGET: "linux",
+    REGION: "eu-west-1",
+    LINUX_TYPE: "m7i.large",
+    LINUX_OS: "ubuntu:26.04",
+    WINDOWS_TYPE: "m7i.large",
+    MACOS_TYPE: "mac-m4.metal",
+    MACOS_HOST: "use-existing",
+    MEASURED: "false",
+    MAX_P95_RUNNER_TOTAL_MS: "",
+    RUNNER_TEMP: dir,
+    GITHUB_SHA: "a".repeat(40),
+    MINT_ARGS: output,
+  };
+  delete env.CRABBOX_OS;
+  return {
+    output,
+    run(overrides = {}) {
+      return spawnSync(
+        "bash",
+        [
+          "-c",
+          [
+            stepScript("Validate publication inputs"),
+            stepScript("Publish and prove image"),
+            'printf "%s" "${CRABBOX_OS-unset}" >"$RUNNER_TEMP/after-os"',
+          ].join("\n"),
+        ],
+        {
+          cwd: dir,
+          env: { ...env, ...overrides },
+          encoding: "utf8",
+          timeout: 10000,
+        },
+      );
+    },
+    inheritedOS: () => fs.readFileSync(path.join(dir, "after-os"), "utf8"),
+  };
+}
+
+test("Linux publication offers Ubuntu 24 while retaining the Ubuntu 26 default", () => {
+  const input = workflow.match(/^      linux_os:\n((?: {8}[^\n]*\n)+)/m)?.[1];
+  assert.ok(input);
+  assert.match(input, /default: ubuntu:26\.04/);
+  assert.match(input, /type: choice/);
+  assert.deepEqual(
+    [...input.matchAll(/- (ubuntu:[0-9.]+)/g)].map((match) => match[1]),
+    ["ubuntu:26.04", "ubuntu:24.04"],
+  );
+  assert.equal((workflow.match(/LINUX_OS: \$\{\{ inputs\.linux_os \}\}/g) ?? []).length, 2);
+});
+
+for (const [target, linuxOS, expectedOS] of [
+  ["linux", "ubuntu:26.04", "ubuntu:26.04"],
+  ["linux", "ubuntu:24.04", "ubuntu:24.04"],
+  ["windows", "ubuntu:24.04", "unset"],
+  ["macos", "ubuntu:24.04", "unset"],
+]) {
+  test(`publication dispatch scopes ${linuxOS} to the ${target} command`, (t) => {
+    const fixture = publicationFixture(t);
+    const result = fixture.run({ TARGET: target, LINUX_OS: linuxOS });
+    assert.equal(result.status, 0, result.stderr);
+    const args = fs.readFileSync(fixture.output, "utf8").split("\0").slice(0, -1);
+    assert.equal(args[0], expectedOS);
+    assert.equal(fixture.inheritedOS(), "unset");
+    if (target !== "macos") {
+      assert.equal(args[args.indexOf("--target") + 1], target);
+      assert.ok(args.includes("--run"));
+    }
+  });
+}
+
+for (const linuxOS of ["", "ubuntu:22.04", "ubuntu:24.04\ntrue"]) {
+  test(`publication guard rejects invalid Linux OS ${JSON.stringify(linuxOS)} before Mint`, (t) => {
+    const fixture = publicationFixture(t);
+    const result = fixture.run({ LINUX_OS: linuxOS });
+    assert.equal(result.status, 2, result.stderr);
+    assert.equal(result.signal, null);
+    assert.match(result.stderr, /linux_os must be ubuntu:26\.04 or ubuntu:24\.04/);
+    assert.equal(fs.existsSync(fixture.output), false);
+  });
+}
 
 test("developer image publication is a protected manual admin workflow", () => {
   assert.match(workflow, /^  workflow_dispatch:$/m);

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -71,6 +71,7 @@ Flags:
 
 Useful env:
   CRABBOX_BIN
+  CRABBOX_OS            Linux selector for leases, promotion, and receipt rollback
   CRABBOX_IMAGE_RUN
   CRABBOX_IMAGE_PROMOTE
   CRABBOX_IMAGE_KEEP_LEASE
@@ -407,6 +408,7 @@ rollback_promoted_image() {
   local -a args=(image promote --json --target "$target")
   [[ -n "$region" ]] && args+=(--region "$region")
   [[ -n "$server_type" ]] && args+=(--type "$server_type")
+  [[ "$target" == "linux" && -n "${CRABBOX_OS:-}" ]] && args+=(--os "$CRABBOX_OS")
   args+=(--restore-receipt "$receipt" "$current_id")
   rollback_log="$(mktemp "$log_dir/image-mint-${log_image_name}-rollback-${log_id}.json.XXXXXX")"
   if ! run_json_tee "$rollback_log" "$CRABBOX_BIN" "${args[@]}"; then
@@ -998,6 +1000,7 @@ fi
 outcome_stage="promotion"
 promote_args=(image promote --target "$target" --json --expected-current-image capture)
 [[ -n "$region" ]] && promote_args+=(--region "$region")
+[[ "$target" == "linux" && -n "${CRABBOX_OS:-}" ]] && promote_args+=(--os "$CRABBOX_OS")
 if [[ "$fast_snapshot_restore" == "1" ]]; then
   promote_args+=(--fast-snapshot-restore)
   IFS=',' read -r -a fsr_az_values <<<"$fast_snapshot_restore_azs"

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -33,6 +33,7 @@ async function setupFakeCrabbox() {
     `#!/usr/bin/env bash
 set -euo pipefail
 printf 'env CRABBOX_AWS_REGION=%s AWS_REGION=%s CRABBOX_AWS_AMI=%s args %s\\n' "\${CRABBOX_AWS_REGION:-}" "\${AWS_REGION:-}" "\${CRABBOX_AWS_AMI:-}" "$*" >>"\${CRABBOX_FAKE_LOG:?}"
+printf 'selection os=%s ami=%s command=%s\\n' "\${CRABBOX_OS-unset}" "\${CRABBOX_AWS_AMI-unset}" "$1" >>"\${CRABBOX_FAKE_LOG}"
 case "$1" in
   warmup)
     count_file="\${CRABBOX_FAKE_LOG}.count"
@@ -308,6 +309,64 @@ test("AWS devtools mint wrapper runs linux source candidate and promoted proof",
     /image promote --target linux --json --expected-current-image capture --region us-west-2 --fast-snapshot-restore --fsr-az us-west-2a ami-devtools/,
   );
 });
+
+for (const [target, osImage] of [
+  ["linux", undefined],
+  ["linux", "ubuntu:26.04"],
+  ["linux", "ubuntu:24.04"],
+  ["windows", "ubuntu:24.04"],
+]) {
+  for (const failPromotedSmoke of target === "linux" ? [false, true] : [false]) {
+    test(`AWS ${target} OS ${osImage ?? "unset"} survives ${failPromotedSmoke ? "receipt rollback" : "promotion"}`, async (t) => {
+      const fake = await setupFakeCrabbox();
+      t.after(() => rm(fake.dir, { recursive: true, force: true }));
+      const result = await runScript(
+        [
+          "--target",
+          target,
+          "--region",
+          "us-west-2",
+          "--run",
+          "--prep-script",
+          target === "linux" ? fake.linuxPrep : fake.windowsPrep,
+        ],
+        {
+          CRABBOX_BIN: fake.fake,
+          CRABBOX_FAKE_LOG: fake.log,
+          CRABBOX_IMAGE_LOG_DIR: fake.dir,
+          CRABBOX_OS: osImage,
+          CRABBOX_AWS_AMI: undefined,
+          CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS: "0",
+          CRABBOX_FAKE_SMOKE_FAIL_LEASE: failPromotedSmoke ? "cbx_promoted" : "",
+        },
+      );
+      assert.equal(result.code, failPromotedSmoke ? 73 : 0, result.stderr);
+      const log = await readFile(fake.log, "utf8");
+      assert.deepEqual(
+        log.split("\n").filter((line) => /^selection .* command=warmup$/.test(line)),
+        ["unset", "ami-devtools", "unset"].map(
+          (ami) => `selection os=${osImage ?? "unset"} ami=${ami} command=warmup`,
+        ),
+      );
+      const promotions = log.split("\n").filter((line) => line.includes("args image promote "));
+      assert.equal(promotions.length, failPromotedSmoke ? 2 : 1);
+      for (const line of promotions) {
+        assert.equal(line.match(/--os (\S+)/)?.[1], target === "linux" ? osImage : undefined);
+      }
+      assert.match(promotions[0], /--expected-current-image capture/);
+      for (const lease of ["cbx_source", "cbx_candidate", "cbx_promoted"]) {
+        assert.match(log, new RegExp(`stop --provider aws --target ${target} ${lease}`));
+      }
+      if (failPromotedSmoke) {
+        assert.match(promotions[1], /--restore-receipt \S+ ami-devtools$/);
+        assert.match(result.stderr, /restored previous default image=ami-previous/);
+        assert.doesNotMatch(result.stdout, /promoted linux developer image passed/);
+      } else {
+        assert.match(result.stdout, /promoted image selection proved: ami-devtools/);
+      }
+    });
+  }
+}
 
 for (const lease of ["cbx_source", "cbx_candidate", "cbx_promoted"]) {
   test(`AWS image mint stops at failed offline smoke on ${lease}`, async (t) => {
@@ -913,6 +972,7 @@ test("AWS devtools mint wrapper maps windows flags", async () => {
       CRABBOX_BIN: fake.fake,
       CRABBOX_FAKE_LOG: fake.log,
       CRABBOX_IMAGE_WINDOWS_WARMUP_SETTLE_SECONDS: "0",
+      CRABBOX_OS: "ubuntu:24.04",
     },
   );
   assert.equal(result.code, 0, result.stderr);
@@ -925,6 +985,7 @@ test("AWS devtools mint wrapper maps windows flags", async () => {
   assert.doesNotMatch(log, /--desktop/);
   assert.doesNotMatch(log, /--browser/);
   assert.doesNotMatch(log, /warmup .*--region us-east-1/);
+  assert.doesNotMatch(log, /--os /);
   assert.match(
     log,
     /run --provider aws --target windows --id cbx_source --no-sync --shell -- Write-Output "windows-ssh-ready"/,


### PR DESCRIPTION
## What Problem This Solves

Operators could not explicitly select Ubuntu 24.04 in the developer-image publication workflow without changing its Ubuntu 26.04 default. An explicit Linux OS also needs to stay consistent through image promotion and receipt-based rollback.

## Why This Change Was Made

Add an Ubuntu 26.04/24.04 workflow choice, defaulting to 26.04, and pass `CRABBOX_OS` only to the Linux mint command. The mint wrapper forwards an explicitly supplied Linux OS to promotion and receipt rollback; unset standalone selection, Windows/macOS routing, compare-and-swap protections, image overrides, and cleanup remain unchanged.

## User Impact

Operators can request Ubuntu 24.04 without changing the default for other runs. Existing explicit image overrides still take precedence, so a requested OS is not proof of the guest's actual OS or image qualification. This PR changes source only; it does not bake, publish, promote, or benchmark an image.

## Evidence

- Regression tests failed on the original missing selector/propagation and passed after the change.
- Both complete test files passed: **113 tests, zero failures or skips**, on local Node 26.7.0 with native Bash 3.2. CI provides the Node 24 route.
- Executable workflow fixtures cover both Linux choices, Windows/macOS isolation, and invalid input rejection before Mint. Mint lifecycle fixtures cover explicit and unset OS selection, promotion, receipt rollback, normal promoted selection without a candidate AMI override, original failure status, and cleanup.
- Bash syntax, changed workflow shell bodies, changed-line formatting, and diff checks passed. Full-workflow actionlint retains the same pre-existing SC2016 warning as the base; unrelated baseline formatting remains untouched.
- Independent default-P0 review completed with no findings. No native guest, AMI qualification, or performance proof is claimed.

Punchcard-Session: calm-lantern-orchard-dn
