### PR TITLE
refactor(providers): share selection name matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@
 
 - Describe Lume configuration bindings once, sharing configured defaults while preserving trusted host settings, user-dependent work roots, and provider validation order. [PR 2029](https://github.com/openclaw/crabbox/pull/2029). Thanks @steipete.
 
+- Keep normalized provider selection aligned with declared names and aliases, sharing metadata across flag/default guards while preserving validation order and separate claim-matching rules. Thanks @steipete.
+
 ## 0.53.0 - 2026-09-08
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
 
 - Describe Lume configuration bindings once, sharing configured defaults while preserving trusted host settings, user-dependent work roots, and provider validation order. [PR 2029](https://github.com/openclaw/crabbox/pull/2029). Thanks @steipete.
 
-- Keep normalized provider selection aligned with declared names and aliases, sharing metadata across flag/default guards while preserving validation order and separate claim-matching rules. Thanks @steipete.
+- Keep normalized provider selection aligned with declared names and aliases, sharing metadata across flag/default guards while preserving validation order and separate claim-matching rules. [PR 2030](https://github.com/openclaw/crabbox/pull/2030). Thanks @steipete.
 
 ## 0.53.0 - 2026-09-08
 

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -404,6 +404,7 @@ The core provider contract lives in `internal/cli`:
 
 ```text
 internal/cli/provider_backend.go      # interfaces, registry, request/result types
+internal/cli/provider_name.go         # pure normalized name/alias membership
 internal/cli/provider_coordinator.go  # brokered coordinator lease wrapper
 internal/cli/provider_labels.go       # shared direct-provider label helpers
 ```
@@ -685,6 +686,17 @@ type Provider interface {
 	Configure(cfg Config, rt Runtime) (Backend, error)
 }
 ```
+
+Normalized selection guards use `cli.ProviderNameMatches(name, Provider{})` so
+`Name()` and `Aliases()` remain the single name-set owner. The matcher reads only
+that metadata and uses the existing name normalizer; it does not look up or
+register a provider, call `Spec` or `Configure`, or mutate configuration. Keep
+the check at its existing position relative to flag copying and validation.
+
+This is not a replacement for raw comparisons, case-fold-only comparisons,
+provider-family routing, or historical claim-provider interpretation. Those
+callers retain their own contracts rather than automatically accepting future
+selection aliases.
 
 A minimal SSH provider package:
 

--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -1974,3 +1974,35 @@ func TestServerLeaseClaimSnapshotIsExplicitAndCloned(t *testing.T) {
 		t.Fatalf("snapshot alias=%#v", again)
 	}
 }
+
+// The nil embedded provider makes any non-metadata method call fail this test.
+type nameMetadataOnlyTestProvider struct {
+	Provider
+	nameCalls, aliasCalls *int
+}
+
+func (p nameMetadataOnlyTestProvider) Name() string { *p.nameCalls++; return " Metadata-Only " }
+func (p nameMetadataOnlyTestProvider) Aliases() []string {
+	*p.aliasCalls++
+	return []string{" Alias-One ", "SECOND"}
+}
+
+func TestProviderNameMatchesMetadataOnly(t *testing.T) {
+	if _, registered := providerRegistry["metadata-only"]; registered {
+		t.Fatal("fixture must not be registered")
+	}
+	registrySize := len(providerRegistry)
+	nameCalls, aliasCalls := 0, 0
+	p := nameMetadataOnlyTestProvider{nameCalls: &nameCalls, aliasCalls: &aliasCalls}
+	for _, tc := range []struct {
+		name string
+		want bool
+	}{{"metadata-only", true}, {" METADATA-ONLY ", true}, {"alias-one", true}, {"\tALIAS-ONE\n", true}, {"second", true}, {"", false}, {" \t ", false}, {"unrelated", false}, {"metadata-only-extra", false}} {
+		if got := ProviderNameMatches(tc.name, p); got != tc.want {
+			t.Fatalf("name=%q got=%t want=%t", tc.name, got, tc.want)
+		}
+	}
+	if nameCalls == 0 || aliasCalls == 0 || len(providerRegistry) != registrySize {
+		t.Fatal("metadata consultation or registry boundary changed")
+	}
+}

--- a/internal/cli/provider_name.go
+++ b/internal/cli/provider_name.go
@@ -1,0 +1,19 @@
+package cli
+
+// ProviderNameMatches compares a name with provider metadata without consulting
+// the registry or configuring a backend.
+func ProviderNameMatches(name string, provider Provider) bool {
+	name = normalizeProviderName(name)
+	if name == "" {
+		return false
+	}
+	if name == normalizeProviderName(provider.Name()) {
+		return true
+	}
+	for _, alias := range provider.Aliases() {
+		if name == normalizeProviderName(alias) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/all/class_profiles_test.go
+++ b/internal/providers/all/class_profiles_test.go
@@ -620,3 +620,217 @@ func TestProviderSizingNonAdopterControls(t *testing.T) {
 		t.Fatalf("Cloudflare mapped type=%q", cfg.ServerType)
 	}
 }
+
+var providerNameLiteralContracts = []struct {
+	name    string
+	aliases []string
+}{
+	{"cloudflare", []string{"cf"}}, {"codesandbox", []string{"csb", "code-sandbox"}}, {"fastapi-cloud", []string{"fastapicloud", "fastapi"}},
+	{"github-codespaces", []string{"codespaces", "gh-codespaces"}}, {"hyperv", nil}, {"lume", []string{"local-lume", "lume-macos"}},
+	{"multipass", []string{"mp", "canonical-multipass"}}, {"namespace-instance", []string{"namespace-compute"}}, {"nvidia-brev", []string{"brev", "nvidia"}},
+	{"phala", []string{"phala-cloud", "dstack"}}, {"railway", []string{"rail", "railwayapp"}}, {"runpod", []string{"run-pod", "runpodio"}},
+	{"tart", []string{"local-tart", "macos-vm"}}, {"unikraft-cloud", []string{"unikraftcloud", "ukc"}}, {"vast", []string{"vast-ai", "vastai"}},
+	{"wandb", []string{"weights-and-biases"}}, {"cloud-run-sandbox", []string{"gcrun-sandbox", "google-cloud-run-sandbox", "cloudrun-sandbox"}},
+	{"opencomputer", []string{"oc", "open-computer"}}, {"orgo", []string{"orgo-ai"}},
+}
+
+func TestProviderNameSelectionContracts(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	aliases := 0
+	for _, tc := range providerNameLiteralContracts {
+		aliases += len(tc.aliases)
+	}
+	if len(providerNameLiteralContracts) != 19 || aliases != 33 {
+		t.Fatal("literal cohort changed")
+	}
+	for _, tc := range providerNameLiteralContracts {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := core.ProviderFor(tc.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cases := []struct {
+				name     string
+				selected bool
+			}{{"", false}, {"  ", false}, {"unrelated-provider", false}, {"not-" + tc.name, false}}
+			for _, name := range append([]string{tc.name}, tc.aliases...) {
+				cases = append(cases, struct {
+					name     string
+					selected bool
+				}{name, true}, struct {
+					name     string
+					selected bool
+				}{strings.ToUpper(name), true}, struct {
+					name     string
+					selected bool
+				}{" \t" + strings.ToUpper(name) + " \n", true})
+			}
+			for _, item := range cases {
+				for _, wrong := range []bool{false, true} {
+					cfg := core.BaseConfig()
+					cfg.Provider = item.name
+					cfg.TargetOS = "linux"
+					cfg.Class = "tiny"
+					cfg.ServerType = ""
+					var args []string
+					classError := ""
+					field := ""
+					selectedValue := ""
+					unselectedValue := ""
+					switch tc.name {
+					case "cloudflare":
+						args = []string{"--class=tiny"}
+						field = "server-type"
+						selectedValue = "standard-4"
+					case "hyperv":
+						args = []string{"--hyperv-cpu=0"}
+						field = "hyperv-cpu"
+						selectedValue = "4"
+						unselectedValue = "0"
+					case "lume":
+						args = []string{"--lume-cli="}
+						field = "lume-cli"
+						selectedValue = "lume"
+					case "multipass":
+						args = []string{"--multipass-cli="}
+						field = "multipass-cli"
+						selectedValue = "multipass"
+					case "namespace-instance":
+						args = []string{"--namespace-instance-cli="}
+						field = "namespace-instance-cli"
+						selectedValue = "nsc"
+					case "phala":
+						args = []string{"--phala-cli="}
+						field = "phala-cli"
+						selectedValue = "phala"
+					case "tart":
+						field = "tart-target"
+						selectedValue = "macos"
+						unselectedValue = "linux"
+					default:
+						args = []string{"--class="}
+						classError = "--class is not supported for provider=" + tc.name
+						if tc.name == "github-codespaces" {
+							classError += "; use --type or --github-codespaces-machine for a Codespaces machine slug"
+						} else {
+							for _, sizing := range sizingFlagContracts {
+								if sizing.name == tc.name && sizing.classGuidance != "" {
+									classError += "; " + sizing.classGuidance
+								}
+							}
+						}
+					}
+					fs, values := sizingContractFlags(t, p, cfg, args)
+					if wrong {
+						values = struct{}{}
+					}
+					before := fmt.Sprintf("%#v", cfg)
+					wantErr := ""
+					if item.selected && classError != "" && !(wrong && tc.name == "codesandbox") {
+						wantErr = classError
+					}
+					assertSizingContractError(t, p.ApplyFlags(&cfg, fs, values), wantErr)
+					if wantErr != "" || (wrong && tc.name != "cloudflare") {
+						if fmt.Sprintf("%#v", cfg) != before {
+							t.Fatalf("selector=%q wrong=%t changed config before return", item.name, wrong)
+						}
+					}
+					if field != "" && (!wrong || tc.name == "cloudflare") {
+						got := ""
+						switch field {
+						case "server-type":
+							got = cfg.ServerType
+						case "hyperv-cpu":
+							got = fmt.Sprint(cfg.HyperV.CPUs)
+						case "lume-cli":
+							got = cfg.Lume.CLIPath
+						case "multipass-cli":
+							got = cfg.Multipass.CLIPath
+						case "namespace-instance-cli":
+							got = cfg.NamespaceInstance.CLIPath
+						case "phala-cli":
+							got = cfg.Phala.CLIPath
+						case "tart-target":
+							got = cfg.TargetOS
+						}
+						want := unselectedValue
+						if item.selected {
+							want = selectedValue
+						}
+						if got != want {
+							t.Fatalf("selector=%q field=%s got=%q want=%q wrong=%t", item.name, field, got, want, wrong)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestProviderNameSecondGuardContracts(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	for _, tc := range providerNameLiteralContracts {
+		if tc.name != "nvidia-brev" && tc.name != "runpod" && tc.name != "vast" && tc.name != "github-codespaces" {
+			continue
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := core.ProviderFor(tc.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			names := append([]string{tc.name}, tc.aliases...)
+			for _, name := range names {
+				for _, selected := range []bool{false, true} {
+					cfg := core.BaseConfig()
+					cfg.Provider = "unrelated-provider"
+					if selected {
+						cfg.Provider = " " + strings.ToUpper(name) + " "
+					}
+					if tc.name == "github-codespaces" {
+						cfg.TargetOS = "windows"
+						core.MarkTargetExplicit(&cfg)
+						want := ""
+						if selected {
+							want = "provider=github-codespaces supports target=linux only"
+						}
+						defaulter, ok := p.(core.ProviderConfigDefaulter)
+						if !ok {
+							t.Fatal("missing existing pure config defaulter")
+						}
+						assertSizingContractError(t, defaulter.ApplyConfigDefaults(&cfg), want)
+						continue
+					}
+					flagName, want := "nvidia-brev-release-action", "delete"
+					if tc.name == "runpod" {
+						flagName = "runpod-cloud-type"
+						want = "SECURE"
+					}
+					value := ""
+					if tc.name == "vast" {
+						flagName = "vast-instance-type"
+						value = "unknown-type"
+					}
+					fs, values := sizingContractFlags(t, p, cfg, []string{"--" + flagName + "=" + value})
+					wantErr := ""
+					if tc.name == "vast" && selected {
+						wantErr = "vast.instanceType must be ondemand or interruptible"
+					}
+					assertSizingContractError(t, p.ApplyFlags(&cfg, fs, values), wantErr)
+					got := cfg.NvidiaBrev.ReleaseAction
+					if tc.name == "runpod" {
+						got = cfg.Runpod.CloudType
+					}
+					if tc.name == "vast" {
+						got = cfg.Vast.InstanceType
+						want = "unknown-type"
+					} else if !selected {
+						want = ""
+					}
+					if got != want {
+						t.Fatalf("selector=%q copied/default value=%q want=%q", cfg.Provider, got, want)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/providers/cloudflare/flags.go
+++ b/internal/providers/cloudflare/flags.go
@@ -12,7 +12,7 @@ func RegisterCloudflareProviderFlags(fs *flag.FlagSet, defaults Config) any {
 }
 
 func ApplyCloudflareProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
-	if isCloudflareProviderName(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		instanceType := strings.TrimSpace(cfg.ServerType)
 		if instanceType == "" {
 			instanceType = cloudflareContainerInstanceTypeForClass(cfg.Class)
@@ -33,13 +33,4 @@ func ApplyCloudflareProviderFlags(cfg *Config, fs *flag.FlagSet, values any) err
 	}
 	v.Apply(&cfg.Cloudflare, fs)
 	return nil
-}
-
-func isCloudflareProviderName(provider string) bool {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case providerName, providerAlias:
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/providers/cloudrunsandbox/flags.go
+++ b/internal/providers/cloudrunsandbox/flags.go
@@ -2,7 +2,6 @@ package cloudrunsandbox
 
 import (
 	"flag"
-	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
@@ -13,8 +12,7 @@ func RegisterCloudRunSandboxProviderFlags(fs *flag.FlagSet, defaults Config) any
 }
 
 func ApplyCloudRunSandboxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
-	switch strings.ToLower(strings.TrimSpace(cfg.Provider)) {
-	case providerName, "gcrun-sandbox", "google-cloud-run-sandbox", "cloudrun-sandbox":
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "sandboxes share Cloud Run service CPU/memory", "sandboxes share Cloud Run service CPU/memory"); err != nil {
 			return err
 		}

--- a/internal/providers/codesandbox/flags.go
+++ b/internal/providers/codesandbox/flags.go
@@ -2,7 +2,6 @@ package codesandbox
 
 import (
 	"flag"
-	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
@@ -17,20 +16,11 @@ func ApplyCodeSandboxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) er
 	if !ok {
 		return nil
 	}
-	if codeSandboxProviderSelected(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --codesandbox-vm-tier", "use --codesandbox-vm-tier"); err != nil {
 			return err
 		}
 	}
 	v.Apply(&cfg.CodeSandbox, fs)
 	return validateCodeSandboxConfig(*cfg)
-}
-
-func codeSandboxProviderSelected(provider string) bool {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case providerName, "csb", "code-sandbox":
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/providers/fastapicloud/flags.go
+++ b/internal/providers/fastapicloud/flags.go
@@ -2,7 +2,6 @@ package fastapicloud
 
 import (
 	"flag"
-	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
@@ -17,7 +16,7 @@ func RegisterFastAPICloudProviderFlags(fs *flag.FlagSet, defaults Config) any {
 }
 
 func ApplyFastAPICloudProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
-	if isFastAPICloudProviderName(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
 			return err
 		}
@@ -28,13 +27,4 @@ func ApplyFastAPICloudProviderFlags(cfg *Config, fs *flag.FlagSet, values any) e
 	}
 	v.Apply(&cfg.FastAPICloud, fs)
 	return nil
-}
-
-func isFastAPICloudProviderName(provider string) bool {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case providerName, "fastapicloud", "fastapi":
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/providers/githubcodespaces/flags.go
+++ b/internal/providers/githubcodespaces/flags.go
@@ -5,6 +5,8 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type flagValues struct {
@@ -38,7 +40,7 @@ func RegisterGitHubCodespacesProviderFlags(fs *flag.FlagSet, defaults Config) an
 }
 
 func ApplyGitHubCodespacesProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
-	if isGitHubCodespacesProviderName(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if flagWasSet(fs, "class") {
 			return exit(2, "--class is not supported for provider=github-codespaces; use --type or --github-codespaces-machine for a Codespaces machine slug")
 		}
@@ -98,7 +100,7 @@ func ApplyGitHubCodespacesProviderFlags(cfg *Config, fs *flag.FlagSet, values an
 }
 
 func ValidateGitHubCodespacesConfig(cfg Config) error {
-	if isGitHubCodespacesProviderName(cfg.Provider) && strings.TrimSpace(cfg.TargetOS) != "" && strings.ToLower(strings.TrimSpace(cfg.TargetOS)) != targetLinux {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) && strings.TrimSpace(cfg.TargetOS) != "" && strings.ToLower(strings.TrimSpace(cfg.TargetOS)) != targetLinux {
 		return exit(2, "provider=github-codespaces supports target=linux only")
 	}
 	c := cfg.GitHubCodespaces
@@ -151,15 +153,6 @@ func validateGitHubCodespacesWorkRoot(label, value string) error {
 func validRepo(repo string) bool {
 	owner, name, ok := strings.Cut(strings.TrimSpace(repo), "/")
 	return ok && validRepoOwner(owner) && validRepoName(name)
-}
-
-func isGitHubCodespacesProviderName(provider string) bool {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case providerName, "codespaces", "gh-codespaces":
-		return true
-	default:
-		return false
-	}
 }
 
 func validRepoOwner(value string) bool {

--- a/internal/providers/hyperv/flags.go
+++ b/internal/providers/hyperv/flags.go
@@ -2,7 +2,6 @@ package hyperv
 
 import (
 	"flag"
-	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -55,7 +54,7 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if flagWasSet(fs, "hyperv-init-password") {
 		cfg.HyperV.InitPassword = *v.InitPassword
 	}
-	if isHyperVProviderName(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		// Target flags are applied after provider flags on several lifecycle
 		// commands. Leave target validation to the centralized provider-target
 		// check after all flag sources have been applied. When no target source
@@ -66,13 +65,4 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 		applyDefaults(cfg)
 	}
 	return nil
-}
-
-func isHyperVProviderName(provider string) bool {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case providerName:
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/providers/lume/flags.go
+++ b/internal/providers/lume/flags.go
@@ -18,7 +18,7 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 		return nil
 	}
 	v.Apply(&cfg.Lume, fs)
-	if isLumeProviderName(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		applyDefaults(cfg)
 		return validateConfig(cfg)
 	}
@@ -45,13 +45,4 @@ func validateConfig(cfg *core.Config) error {
 		return exit(2, "lume work root must be beneath /Users/%s", cfg.Lume.User)
 	}
 	return nil
-}
-
-func isLumeProviderName(provider string) bool {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case providerName, "local-lume", "lume-macos":
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/providers/multipass/flags.go
+++ b/internal/providers/multipass/flags.go
@@ -2,7 +2,6 @@ package multipass
 
 import (
 	"flag"
-	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -65,17 +64,8 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 			return err
 		}
 	}
-	if isMultipassProviderName(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		applyDefaults(cfg)
 	}
 	return nil
-}
-
-func isMultipassProviderName(provider string) bool {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case providerName, "mp", "canonical-multipass":
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/providers/namespaceinstance/flags.go
+++ b/internal/providers/namespaceinstance/flags.go
@@ -81,17 +81,8 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if core.FlagWasSet(fs, "namespace-instance-bare") {
 		cfg.NamespaceInstance.Bare = *v.Bare
 	}
-	if isProviderName(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		applyDefaults(cfg)
 	}
 	return nil
-}
-
-func isProviderName(provider string) bool {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case providerName, "namespace-compute":
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/providers/nvidiabrev/core.go
+++ b/internal/providers/nvidiabrev/core.go
@@ -2,7 +2,6 @@ package nvidiabrev
 
 import (
 	"flag"
-	"strings"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -120,12 +119,3 @@ func removeLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
 }
 
 var waitForSSH = core.WaitForSSH
-
-func isNvidiaBrevProviderName(provider string) bool {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case providerName, "brev", "nvidia":
-		return true
-	default:
-		return false
-	}
-}

--- a/internal/providers/nvidiabrev/flags.go
+++ b/internal/providers/nvidiabrev/flags.go
@@ -3,6 +3,7 @@ package nvidiabrev
 import (
 	"flag"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -41,7 +42,7 @@ func RegisterNvidiaBrevProviderFlags(fs *flag.FlagSet, defaults Config) any {
 }
 
 func ApplyNvidiaBrevProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
-	if isNvidiaBrevProviderName(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --nvidia-brev-gpu-name", "use --nvidia-brev-type"); err != nil {
 			return err
 		}
@@ -88,7 +89,7 @@ func ApplyNvidiaBrevProviderFlags(cfg *Config, fs *flag.FlagSet, values any) err
 		cfg.NvidiaBrev.WorkRoot = *v.WorkRoot
 		markNvidiaBrevWorkRootExplicit(cfg)
 	}
-	if isNvidiaBrevProviderName(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		applyNvidiaBrevDefaults(cfg)
 		return Provider{}.ValidateConfig(*cfg)
 	}

--- a/internal/providers/opencomputer/flags.go
+++ b/internal/providers/opencomputer/flags.go
@@ -2,7 +2,6 @@ package opencomputer
 
 import (
 	"flag"
-	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
@@ -13,8 +12,7 @@ func RegisterOpenComputerProviderFlags(fs *flag.FlagSet, defaults Config) any {
 }
 
 func ApplyOpenComputerProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
-	switch strings.ToLower(strings.TrimSpace(cfg.Provider)) {
-	case providerName, "oc", "open-computer":
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --opencomputer-cpu and --opencomputer-memory-mb", "use --opencomputer-cpu and --opencomputer-memory-mb"); err != nil {
 			return err
 		}

--- a/internal/providers/orgo/flags.go
+++ b/internal/providers/orgo/flags.go
@@ -2,7 +2,6 @@ package orgo
 
 import (
 	"flag"
-	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
@@ -15,8 +14,7 @@ func RegisterOrgoProviderFlags(fs *flag.FlagSet, defaults Config) any {
 }
 
 func ApplyOrgoProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
-	switch strings.ToLower(strings.TrimSpace(cfg.Provider)) {
-	case providerName, "orgo-ai":
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
 			return err
 		}

--- a/internal/providers/phala/flags.go
+++ b/internal/providers/phala/flags.go
@@ -2,7 +2,6 @@ package phala
 
 import (
 	"flag"
-	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -60,7 +59,7 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 		value := *v.Attest
 		cfg.Phala.Attest = &value
 	}
-	if isProviderName(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		applyDefaults(cfg)
 	}
 	return nil
@@ -70,13 +69,4 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 // ON by default (nil config => true); only an explicit false value disables it.
 func attestEnabled(cfg core.Config) bool {
 	return cfg.Phala.Attest == nil || *cfg.Phala.Attest
-}
-
-func isProviderName(provider string) bool {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case providerName, "phala-cloud", "dstack":
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/providers/railway/flags.go
+++ b/internal/providers/railway/flags.go
@@ -2,7 +2,6 @@ package railway
 
 import (
 	"flag"
-	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
@@ -17,7 +16,7 @@ func RegisterRailwayProviderFlags(fs *flag.FlagSet, defaults Config) any {
 }
 
 func ApplyRailwayProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
-	if isRailwayProviderName(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
 			return err
 		}
@@ -28,13 +27,4 @@ func ApplyRailwayProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error 
 	}
 	v.Apply(&cfg.Railway, fs)
 	return nil
-}
-
-func isRailwayProviderName(provider string) bool {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case providerName, "rail", "railwayapp":
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/providers/runpod/backend_test.go
+++ b/internal/providers/runpod/backend_test.go
@@ -56,13 +56,27 @@ func TestRunpodClientRedactsReflectedCredential(t *testing.T) {
 }
 
 func TestRunpodIsRunpodProviderNameAcceptsAliases(t *testing.T) {
+	selected := func(name string) bool {
+		cfg := core.BaseConfig()
+		cfg.Provider = name
+		fs := flag.NewFlagSet("name-contract", flag.ContinueOnError)
+		p := Provider{}
+		values := p.RegisterFlags(fs, cfg)
+		if err := fs.Parse([]string{"--runpod-cloud-type="}); err != nil {
+			t.Fatal(err)
+		}
+		if err := p.ApplyFlags(&cfg, fs, values); err != nil {
+			t.Fatal(err)
+		}
+		return cfg.Runpod.CloudType == "SECURE"
+	}
 	for _, name := range []string{"runpod", "Run-Pod", "  runpodio  ", "RUNPOD"} {
-		if !isRunpodProviderName(name) {
+		if !selected(name) {
 			t.Fatalf("isRunpodProviderName(%q) = false, want true", name)
 		}
 	}
 	for _, name := range []string{"", "exe-dev", "railway", "runpods"} {
-		if isRunpodProviderName(name) {
+		if selected(name) {
 			t.Fatalf("isRunpodProviderName(%q) = true, want false", name)
 		}
 	}

--- a/internal/providers/runpod/core.go
+++ b/internal/providers/runpod/core.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"io"
-	"strings"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -125,16 +124,4 @@ func bootstrapWaitTimeout(cfg Config) time.Duration {
 
 func inventoryDoctorResult(provider string, leases int) DoctorResult {
 	return core.InventoryDoctorResult(provider, leases)
-}
-
-// isRunpodProviderName reports whether the configured provider string refers to
-// the runpod provider, accepting the canonical name and the documented aliases
-// in a case- and whitespace-tolerant way.
-func isRunpodProviderName(provider string) bool {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case providerName, "run-pod", "runpodio":
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/providers/runpod/flags.go
+++ b/internal/providers/runpod/flags.go
@@ -3,6 +3,7 @@ package runpod
 import (
 	"flag"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -35,7 +36,7 @@ func RegisterRunpodProviderFlags(fs *flag.FlagSet, defaults Config) any {
 }
 
 func ApplyRunpodProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
-	if isRunpodProviderName(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --runpod-instance-id", "use --runpod-image"); err != nil {
 			return err
 		}
@@ -68,7 +69,7 @@ func ApplyRunpodProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if flagWasSet(fs, "runpod-work-root") {
 		cfg.Runpod.WorkRoot = *v.WorkRoot
 	}
-	if isRunpodProviderName(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		applyRunpodDefaults(cfg)
 	}
 	return nil

--- a/internal/providers/tart/flags.go
+++ b/internal/providers/tart/flags.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"os"
 	"strconv"
-	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -60,7 +59,7 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 			core.MarkTartDiskExplicit(cfg)
 		}
 	}
-	if isTartProviderName(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if core.IsTargetExplicit(cfg) && cfg.TargetOS != targetMacOS {
 			return exit(2, "provider=%s supports target=%s only (got %s)", providerName, targetMacOS, cfg.TargetOS)
 		}
@@ -118,13 +117,4 @@ func validateTartEnvIntNonNegative(name string, msg string) error {
 		return exit(2, "%s (got %d)", msg, n)
 	}
 	return nil
-}
-
-func isTartProviderName(provider string) bool {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case providerName, "local-tart", "macos-vm":
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/providers/tart/provider_test.go
+++ b/internal/providers/tart/provider_test.go
@@ -2153,13 +2153,25 @@ func TestCommandErrorMinimalExitCode(t *testing.T) {
 }
 
 func TestIsTartProviderName(t *testing.T) {
+	selected := func(name string) bool {
+		cfg := core.BaseConfig()
+		cfg.Provider = name
+		cfg.TargetOS = "linux"
+		fs := flag.NewFlagSet("name-contract", flag.ContinueOnError)
+		p := Provider{}
+		values := p.RegisterFlags(fs, cfg)
+		if err := p.ApplyFlags(&cfg, fs, values); err != nil {
+			t.Fatal(err)
+		}
+		return cfg.TargetOS == "macos"
+	}
 	for _, name := range []string{"tart", "Tart", "TART", "local-tart", "macos-vm", " tart "} {
-		if !isTartProviderName(name) {
+		if !selected(name) {
 			t.Errorf("isTartProviderName(%q) = false, want true", name)
 		}
 	}
 	for _, name := range []string{"docker", "aws", "hyperv", ""} {
-		if isTartProviderName(name) {
+		if selected(name) {
 			t.Errorf("isTartProviderName(%q) = true, want false", name)
 		}
 	}

--- a/internal/providers/unikraftcloud/flags.go
+++ b/internal/providers/unikraftcloud/flags.go
@@ -2,8 +2,8 @@ package unikraftcloud
 
 import (
 	"flag"
-	"strings"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -28,7 +28,7 @@ func registerUnikraftCloudProviderFlags(fs *flag.FlagSet, defaults Config) any {
 }
 
 func applyUnikraftCloudProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
-	if isUnikraftCloudProviderName(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
 			return err
 		}
@@ -50,13 +50,4 @@ func applyUnikraftCloudProviderFlags(cfg *Config, fs *flag.FlagSet, values any) 
 		cfg.UnikraftCloud.MemoryMB = *v.MemoryMB
 	}
 	return nil
-}
-
-func isUnikraftCloudProviderName(provider string) bool {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case providerName, "unikraftcloud", "ukc":
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/providers/vast/core.go
+++ b/internal/providers/vast/core.go
@@ -2,7 +2,6 @@ package vast
 
 import (
 	"flag"
-	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -46,13 +45,4 @@ func markReleaseActionExplicit(cfg *Config) {
 
 func normalizeInstanceType(value string) string {
 	return core.NormalizeVastInstanceType(value)
-}
-
-func isVastProviderName(provider string) bool {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case providerName, "vast-ai", "vastai":
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/providers/vast/flags.go
+++ b/internal/providers/vast/flags.go
@@ -3,6 +3,7 @@ package vast
 import (
 	"flag"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -45,7 +46,7 @@ func RegisterVastProviderFlags(fs *flag.FlagSet, defaults Config) any {
 }
 
 func ApplyVastProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
-	if isVastProviderName(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --vast-gpu-name or --vast-gpu-count", "use --vast-image"); err != nil {
 			return err
 		}
@@ -98,7 +99,7 @@ func ApplyVastProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 		cfg.Vast.ReleaseAction = *v.ReleaseAction
 		markReleaseActionExplicit(cfg)
 	}
-	if isVastProviderName(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		return Provider{}.ValidateConfig(*cfg)
 	}
 	return nil

--- a/internal/providers/wandb/backend_test.go
+++ b/internal/providers/wandb/backend_test.go
@@ -40,13 +40,32 @@ func TestWandbProviderSpec(t *testing.T) {
 }
 
 func TestWandbIsProviderName(t *testing.T) {
+	selected := func(name string) bool {
+		cfg := core.BaseConfig()
+		cfg.Provider = name
+		fs := flag.NewFlagSet("name-contract", flag.ContinueOnError)
+		fs.String("class", "", "")
+		p := Provider{}
+		values := p.RegisterFlags(fs, cfg)
+		if err := fs.Parse([]string{"--class=standard"}); err != nil {
+			t.Fatal(err)
+		}
+		err := p.ApplyFlags(&cfg, fs, values)
+		if err == nil {
+			return false
+		}
+		if err.Error() != "--class is not supported for provider=wandb" {
+			t.Fatalf("unexpected selection error: %v", err)
+		}
+		return true
+	}
 	for _, name := range []string{"wandb", "WANDB", "  wandb  ", "weights-and-biases"} {
-		if !isWandbProviderName(name) {
+		if !selected(name) {
 			t.Fatalf("isWandbProviderName(%q) = false, want true", name)
 		}
 	}
 	for _, name := range []string{"", "railway", "wandbx"} {
-		if isWandbProviderName(name) {
+		if selected(name) {
 			t.Fatalf("isWandbProviderName(%q) = true, want false", name)
 		}
 	}

--- a/internal/providers/wandb/flags.go
+++ b/internal/providers/wandb/flags.go
@@ -2,8 +2,8 @@ package wandb
 
 import (
 	"flag"
-	"strings"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -24,7 +24,7 @@ func RegisterWandbProviderFlags(fs *flag.FlagSet, defaults Config) any {
 }
 
 func ApplyWandbProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
-	if isWandbProviderName(cfg.Provider) {
+	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
 			return err
 		}
@@ -40,15 +40,4 @@ func ApplyWandbProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 		cfg.Wandb.MaxLifetimeSeconds = *v.MaxLifetimeSeconds
 	}
 	return nil
-}
-
-// isWandbProviderName is consulted from every routing switch (provider_backend,
-// flags, run, stop) so aliases share a single source of truth.
-func isWandbProviderName(provider string) bool {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case providerName, "weights-and-biases":
-		return true
-	default:
-		return false
-	}
 }


### PR DESCRIPTION
## Summary

Make `Provider.Name()` and `Aliases()` the single name-set owner for normalized provider selection. A pure core matcher replaces sixteen duplicate helper lists and three inline lists across nineteen providers and twenty-three selection sites. All declared names/aliases remain unchanged.

The matcher uses the existing name normalizer and reads only provider metadata. It does not consult or mutate the registry, call `Spec` or `Configure`, cache results, or configure a backend. Each guard stays at its original position relative to values assertions, flag copying, class/type handling, defaults and validation; both guards remain for providers that have separate before/after-copy decisions.

Raw comparisons, case-fold-only comparisons, provider-family/legacy routing and claim-provider interpretation remain separate. Apple VM's shared selection/claim helper is deliberately excluded rather than letting future selection aliases widen historical claim acceptance. No alias, source grant, parser mode, callback framework or private compatibility wrapper is added. Docs and an Unreleased entry explain the ownership boundary.

## Verification

Paired race tests cover nineteen providers and thirty-three independently frozen literal aliases, normalization, all twenty-three guard locations, and the original Tart, W&B and Runpod name cases through existing public flag behavior. Four caller test files are identical between the passing baseline and candidate. A candidate-only core test verifies an unregistered metadata provider without invoking registry/configuration methods.

The first baseline fixture incorrectly used Tart's explicitly invalid zero-CPU flag to observe its later selector; Tart validates that flag earlier. Only that new fixture was corrected to observe ordinary target defaulting before any candidate run. The original failure and fixture bytes remain recorded. The complete corrected baseline, identical candidate and helper races passed; no production change or post-candidate expectation adjustment accommodated the test.

The final local gate passed both frozen race-test commands and scoped vet for core, the provider registry and all nineteen adopters. All six selected top-level tests ran. All 2,321 source/test/doc files retained identical bytes and modes, including all twenty-three production files and five frozen test files. Managed Codex review through P1 found no actionable findings; independent source review verified complete substitutions, imports, metadata and excluded policies. CLI/docs builds, whitespace checks and pinned Deadcode v0.45.0 static analysis passed; test entry points were analyzed, not broadly executed.

A source-blind validator matched all 326 frozen CLI invocations exactly in complete stdout, stderr and exit status: 324 successes and two expected unknown-provider errors, with no differences, timeouts, normalization or baseline rerun. It covered canonical names, declared aliases, uppercase/padded variants, metadata, text/JSON config display and help/parser behavior. Config/listing can canonicalize names before internal guards, so that proof does not establish every runtime guard phase; direct caller contracts cover those separately. No native provider, credential, SSH, VM, claim or security-fault workflow was exercised.

The private commit was rebound onto actual Lume merge `2d33b1d2031f3d96b101ff0c629dc11ba9b74f65` (https://github.com/openclaw/crabbox/pull/2029). This also inherits image-owner https://github.com/openclaw/crabbox/pull/2028: six non-Go files differ from the original base, including the changelog. All twenty-eight owned Go files and the other owned document remain identical; full-tree identity is not claimed. Fresh integration races, vet, P1 review, static analysis and docs/build checks passed with all current file hashes stable. The actual-main executable still has the tested SHA-256 `a106fa9d70f53536c4204e38eef41eb1f9269a62d491eb66e0ca5ea1f3fed020`. Independent binding reverified all 326 output pairs and retained evidence; those CLI results are reused by executable identity, not called new executions. Hosted CI remains pending.
