### PR TITLE
refactor(providers): share exact selection name matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 
 - Keep normalized provider selection aligned with declared names and aliases, sharing metadata across flag/default guards while preserving validation order and separate claim-matching rules. [PR 2030](https://github.com/openclaw/crabbox/pull/2030). Thanks @steipete.
 
-- Keep raw-exact provider selection aligned with declared names and aliases without normalizing inputs or changing flag/default validation order. Thanks @steipete.
+- Keep raw-exact provider selection aligned with declared names and aliases without normalizing inputs or changing flag/default validation order. [PR 2031](https://github.com/openclaw/crabbox/pull/2031). Thanks @steipete.
 
 ## 0.53.0 - 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@
 
 - Keep normalized provider selection aligned with declared names and aliases, sharing metadata across flag/default guards while preserving validation order and separate claim-matching rules. [PR 2030](https://github.com/openclaw/crabbox/pull/2030). Thanks @steipete.
 
+- Keep raw-exact provider selection aligned with declared names and aliases without normalizing inputs or changing flag/default validation order. Thanks @steipete.
+
 ## 0.53.0 - 2026-09-08
 
 ### Highlights

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -404,7 +404,7 @@ The core provider contract lives in `internal/cli`:
 
 ```text
 internal/cli/provider_backend.go      # interfaces, registry, request/result types
-internal/cli/provider_name.go         # pure normalized name/alias membership
+internal/cli/provider_name.go         # pure normalized/exact name membership
 internal/cli/provider_coordinator.go  # brokered coordinator lease wrapper
 internal/cli/provider_labels.go       # shared direct-provider label helpers
 ```
@@ -697,6 +697,12 @@ This is not a replacement for raw comparisons, case-fold-only comparisons,
 provider-family routing, or historical claim-provider interpretation. Those
 callers retain their own contracts rather than automatically accepting future
 selection aliases.
+
+For a guard whose contract is raw equality against the complete declared name
+set, use `cli.ProviderNameMatchesExact(name, Provider{})`. It compares both the
+input and metadata unchanged: case and surrounding whitespace remain significant.
+Keep canonical-only constant checks as they are when there is no duplicated alias
+set. Neither matcher changes claim/history interpretation or owns validation order.
 
 A minimal SSH provider package:
 

--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -2006,3 +2006,23 @@ func TestProviderNameMatchesMetadataOnly(t *testing.T) {
 		t.Fatal("metadata consultation or registry boundary changed")
 	}
 }
+
+func TestProviderNameMatchesExactMetadataOnly(t *testing.T) {
+	if _, registered := providerRegistry["metadata-only"]; registered {
+		t.Fatal("fixture must not be registered")
+	}
+	registrySize := len(providerRegistry)
+	nameCalls, aliasCalls := 0, 0
+	p := nameMetadataOnlyTestProvider{nameCalls: &nameCalls, aliasCalls: &aliasCalls}
+	for _, tc := range []struct {
+		name string
+		want bool
+	}{{" Metadata-Only ", true}, {"Metadata-Only", false}, {" metadata-only ", false}, {"  Metadata-Only  ", false}, {" Alias-One ", true}, {"Alias-One", false}, {" ALIAS-ONE ", false}, {"SECOND", true}, {"second", false}, {" SECOND ", false}, {"", false}, {" ", false}, {"unknown", false}} {
+		if got := ProviderNameMatchesExact(tc.name, p); got != tc.want {
+			t.Fatalf("exact name=%q got=%t want=%t", tc.name, got, tc.want)
+		}
+	}
+	if nameCalls == 0 || aliasCalls == 0 || len(providerRegistry) != registrySize {
+		t.Fatal("metadata consultation or registry boundary changed")
+	}
+}

--- a/internal/cli/provider_name.go
+++ b/internal/cli/provider_name.go
@@ -17,3 +17,17 @@ func ProviderNameMatches(name string, provider Provider) bool {
 	}
 	return false
 }
+
+// ProviderNameMatchesExact compares raw names with provider metadata without
+// normalization, registry lookup, or backend configuration.
+func ProviderNameMatchesExact(name string, provider Provider) bool {
+	if name == provider.Name() {
+		return true
+	}
+	for _, alias := range provider.Aliases() {
+		if name == alias {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/all/class_profiles_test.go
+++ b/internal/providers/all/class_profiles_test.go
@@ -834,3 +834,222 @@ func TestProviderNameSecondGuardContracts(t *testing.T) {
 		})
 	}
 }
+
+var providerNameExactLiteralContracts = []struct {
+	name    string
+	aliases []string
+}{
+	{"exe-dev", []string{"exe", "exedev"}}, {"smolvm", []string{"smol", "smolmachines", "smolfleet"}}, {"upstash-box", []string{"upstash", "box", "upstashbox"}},
+	{"windows-sandbox", []string{"wsb", "windows-sandbox-provider"}}, {"cloudflare-dynamic-workers", []string{"cf-dynamic", "cfdw"}},
+	{"apple-container", []string{"apple", "applecontainer"}}, {"local-container", []string{"docker", "container", "local-docker"}},
+}
+
+func TestProviderNameExactGuardContracts(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	count := 0
+	for _, tc := range providerNameExactLiteralContracts {
+		count += len(tc.aliases)
+	}
+	if len(providerNameExactLiteralContracts) != 7 || count != 17 {
+		t.Fatal("literal cohort changed")
+	}
+	for _, tc := range providerNameExactLiteralContracts {
+		if tc.name == "apple-container" || tc.name == "local-container" {
+			continue
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := core.ProviderFor(tc.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cases := []struct {
+				name     string
+				selected bool
+			}{{"", false}, {"unrelated-provider", false}}
+			for _, name := range append([]string{tc.name}, tc.aliases...) {
+				cases = append(cases, struct {
+					name     string
+					selected bool
+				}{name, true}, struct {
+					name     string
+					selected bool
+				}{strings.ToUpper(name), false}, struct {
+					name     string
+					selected bool
+				}{" " + name + " ", false})
+			}
+			for _, item := range cases {
+				for _, args := range [][]string{{"--class=standard", "--type=fixture"}, {"--type=fixture", "--class=standard"}, {"--class="}, {"--type="}} {
+					for _, wrong := range []bool{false, true} {
+						cfg := core.BaseConfig()
+						cfg.Provider = item.name
+						cfg.TargetOS = "linux"
+						cfg.WindowsMode = "prior-mode"
+						fs, values := sizingContractFlags(t, p, cfg, args)
+						copyFlag, copyValue := "exe-dev-image", "fixture-image"
+						switch tc.name {
+						case "smolvm":
+							copyFlag = "smolvm-image"
+						case "upstash-box":
+							copyFlag = "upstash-box-workdir"
+							copyValue = "/workspace/home/fixture"
+						case "windows-sandbox":
+							copyFlag = "windows-sandbox-workdir"
+							copyValue = `C:\fixture`
+						case "cloudflare-dynamic-workers":
+							copyFlag = "cloudflare-dynamic-workers-cache"
+							copyValue = "one-shot"
+						}
+						if item.selected {
+							if err := fs.Set(copyFlag, copyValue); err != nil {
+								t.Fatal(err)
+							}
+						}
+						if wrong {
+							values = struct{}{}
+						}
+						before := fmt.Sprintf("%#v", cfg)
+						want := ""
+						if item.selected && !(wrong && tc.name == "windows-sandbox") {
+							flagName := "class"
+							if len(args) == 1 && strings.HasPrefix(args[0], "--type") {
+								flagName = "type"
+							}
+							want = "--" + flagName + " is not supported for provider=" + tc.name
+							for _, sizing := range sizingFlagContracts {
+								if sizing.name == tc.name {
+									guide := sizing.classGuidance
+									if flagName == "type" {
+										guide = sizing.typeGuidance
+									}
+									if guide != "" {
+										want += "; " + guide
+									}
+								}
+							}
+						}
+						assertSizingContractError(t, p.ApplyFlags(&cfg, fs, values), want)
+						if want != "" || wrong {
+							if fmt.Sprintf("%#v", cfg) != before {
+								t.Fatalf("selector=%q args=%v wrong=%t mutated before return", item.name, args, wrong)
+							}
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestProviderNameExactDefaultContracts(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	for _, tc := range providerNameExactLiteralContracts {
+		if tc.name != "exe-dev" && tc.name != "apple-container" && tc.name != "local-container" && tc.name != "windows-sandbox" {
+			continue
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := core.ProviderFor(tc.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cases := []struct {
+				name     string
+				selected bool
+			}{{"", false}, {"unrelated-provider", false}}
+			for _, name := range append([]string{tc.name}, tc.aliases...) {
+				cases = append(cases, struct {
+					name     string
+					selected bool
+				}{name, true}, struct {
+					name     string
+					selected bool
+				}{strings.ToUpper(name), false}, struct {
+					name     string
+					selected bool
+				}{" " + name + " ", false})
+			}
+			for _, item := range cases {
+				for _, wrong := range []bool{false, true} {
+					cfg := core.BaseConfig()
+					cfg.Provider = item.name
+					cfg.TargetOS = "linux"
+					cfg.WindowsMode = "prior-mode"
+					cfg.LocalContainer.DockerSocket = false
+					flagName, selectedValue := "exe-dev-memory", "4GB"
+					switch tc.name {
+					case "apple-container":
+						flagName = "apple-container-cli"
+						selectedValue = "container"
+					case "local-container":
+						flagName = "local-container-runtime"
+						selectedValue = "docker"
+					case "windows-sandbox":
+						flagName = "windows-sandbox-workdir"
+						selectedValue = `C:\crabbox-work`
+					}
+					fs, values := sizingContractFlags(t, p, cfg, []string{"--" + flagName + "="})
+					if wrong {
+						values = struct{}{}
+					}
+					before := fmt.Sprintf("%#v", cfg)
+					assertSizingContractError(t, p.ApplyFlags(&cfg, fs, values), "")
+					if wrong {
+						if fmt.Sprintf("%#v", cfg) != before {
+							t.Fatal("wrong values type mutated config")
+						}
+						continue
+					}
+					got := cfg.ExeDev.Memory
+					switch tc.name {
+					case "apple-container":
+						got = cfg.AppleContainer.CLIPath
+					case "local-container":
+						got = cfg.LocalContainer.Runtime
+					case "windows-sandbox":
+						got = cfg.WindowsSandbox.Workdir
+					}
+					want := ""
+					if item.selected {
+						want = selectedValue
+					}
+					if got != want {
+						t.Fatalf("selector=%q field=%s got=%q want=%q", item.name, flagName, got, want)
+					}
+					if tc.name == "windows-sandbox" {
+						target, mode := "linux", "prior-mode"
+						if item.selected {
+							target = "windows"
+							mode = "normal"
+						}
+						if cfg.TargetOS != target || cfg.WindowsMode != mode {
+							t.Fatalf("Windows selected target/mode=%s/%s", cfg.TargetOS, cfg.WindowsMode)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestProviderNameExactDynamicOrder(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	p, err := core.ProviderFor("cloudflare-dynamic-workers")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"cloudflare-dynamic-workers", "cf-dynamic", "cfdw"} {
+		for _, tc := range []struct {
+			args []string
+			flag string
+		}{{[]string{"--expose=8080", "--type=fixture", "--class=standard"}, "class"}, {[]string{"--expose=8080", "--type="}, "type"}, {[]string{"--expose="}, "expose"}} {
+			cfg := core.BaseConfig()
+			cfg.Provider = name
+			fs, values := sizingContractFlags(t, p, cfg, tc.args)
+			before := fmt.Sprintf("%#v", cfg)
+			assertSizingContractError(t, p.ApplyFlags(&cfg, fs, values), "--"+tc.flag+" is not supported for provider=cloudflare-dynamic-workers")
+			if fmt.Sprintf("%#v", cfg) != before {
+				t.Fatal("ordered rejection mutated config")
+			}
+		}
+	}
+}

--- a/internal/providers/applecontainer/backend.go
+++ b/internal/providers/applecontainer/backend.go
@@ -28,15 +28,6 @@ func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.B
 	return &backend{spec: spec, cfg: cfg, rt: rt}
 }
 
-func isAppleContainerProvider(name string) bool {
-	switch name {
-	case providerName, "apple", "applecontainer":
-		return true
-	default:
-		return false
-	}
-}
-
 func applyDefaults(cfg *core.Config) {
 	cfg.Provider = providerName
 	if cfg.TargetOS == "" {

--- a/internal/providers/applecontainer/flags.go
+++ b/internal/providers/applecontainer/flags.go
@@ -58,7 +58,7 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if core.FlagWasSet(fs, "apple-container-extra-run-args") {
 		cfg.AppleContainer.ExtraRunArgs = splitExtraArgs(*v.ExtraRun)
 	}
-	if isAppleContainerProvider(cfg.Provider) {
+	if core.ProviderNameMatchesExact(cfg.Provider, Provider{}) {
 		applyDefaults(cfg)
 	}
 	return nil

--- a/internal/providers/cloudflaredynamicworkers/flags.go
+++ b/internal/providers/cloudflaredynamicworkers/flags.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"strings"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -33,7 +34,7 @@ func RegisterProviderFlags(fs *flag.FlagSet, defaults Config) any {
 }
 
 func ApplyProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
-	if cfg.Provider == providerName || cfg.Provider == "cf-dynamic" || cfg.Provider == "cfdw" {
+	if core.ProviderNameMatchesExact(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
 			return err
 		}

--- a/internal/providers/exedev/flags.go
+++ b/internal/providers/exedev/flags.go
@@ -12,7 +12,7 @@ func RegisterExeDevProviderFlags(fs *flag.FlagSet, defaults Config) any {
 }
 
 func ApplyExeDevProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
-	if cfg.Provider == providerName || cfg.Provider == "exe" || cfg.Provider == "exedev" {
+	if core.ProviderNameMatchesExact(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --exe-dev-cpus, --exe-dev-memory, and --exe-dev-disk", "use --exe-dev-image"); err != nil {
 			return err
 		}
@@ -22,7 +22,7 @@ func ApplyExeDevProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 		return nil
 	}
 	v.Apply(&cfg.ExeDev, fs)
-	if cfg.Provider == providerName || cfg.Provider == "exe" || cfg.Provider == "exedev" {
+	if core.ProviderNameMatchesExact(cfg.Provider, Provider{}) {
 		applyExeDevDefaults(cfg)
 	}
 	return nil

--- a/internal/providers/localcontainer/flags.go
+++ b/internal/providers/localcontainer/flags.go
@@ -94,7 +94,7 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 		}
 		cfg.LocalContainer.Volumes = []string(*v.Volumes)
 	}
-	if cfg.Provider == providerName || cfg.Provider == "docker" || cfg.Provider == "container" || cfg.Provider == "local-docker" {
+	if core.ProviderNameMatchesExact(cfg.Provider, Provider{}) {
 		applyDefaults(cfg)
 	}
 	return nil

--- a/internal/providers/smolvm/flags.go
+++ b/internal/providers/smolvm/flags.go
@@ -13,7 +13,7 @@ func RegisterSmolvmProviderFlags(fs *flag.FlagSet, defaults Config) any {
 }
 
 func ApplySmolvmProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
-	if cfg.Provider == providerName || cfg.Provider == "smol" || cfg.Provider == "smolmachines" || cfg.Provider == "smolfleet" {
+	if core.ProviderNameMatchesExact(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --smolvm-cpus/--smolvm-memory-mb", "use --smolvm-image"); err != nil {
 			return err
 		}

--- a/internal/providers/upstashbox/flags.go
+++ b/internal/providers/upstashbox/flags.go
@@ -13,7 +13,7 @@ func RegisterUpstashBoxProviderFlags(fs *flag.FlagSet, defaults Config) any {
 }
 
 func ApplyUpstashBoxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
-	if cfg.Provider == providerName || cfg.Provider == "upstash" || cfg.Provider == "box" || cfg.Provider == "upstashbox" {
+	if core.ProviderNameMatchesExact(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --upstash-box-size", "use --upstash-box-runtime"); err != nil {
 			return err
 		}

--- a/internal/providers/windowssandbox/flags.go
+++ b/internal/providers/windowssandbox/flags.go
@@ -40,7 +40,7 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if !ok {
 		return nil
 	}
-	selected := cfg.Provider == providerName || cfg.Provider == "wsb" || cfg.Provider == "windows-sandbox-provider"
+	selected := core.ProviderNameMatchesExact(cfg.Provider, Provider{})
 	if selected {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "Windows Sandbox sizing is controlled by the host", "Windows Sandbox sizing is controlled by the host"); err != nil {
 			return err


### PR DESCRIPTION
## Summary

Give seven providers' raw-exact selection guards the existing `Name()`/`Aliases()` metadata as their single name-set owner. `ProviderNameMatchesExact` compares raw strings with `==`; it neither trims nor changes case, consults the registry, calls `Spec`/`Configure`, or adds a mode/callback framework. The normalized matcher remains byte-for-byte unchanged.

Replace all eight predicates across exe.dev, SmolVM, Upstash Box, Windows Sandbox, Cloudflare Dynamic Workers, Apple Container and Local Container. Preserve both exe.dev phases, Windows' reused selected value, assertion and class/type/expose ordering, explicit assignments, defaults and validation. Remove Apple Container's private selection helper, whose sole production caller is its flag adapter. No declared name/alias or claim/history/native policy changes. Canonical-only constant checks and case-fold-only guards remain separate; Local Container's adjacent checkpoint work is untouched.

Update the architecture guide and Unreleased changelog.

## Verification

Paired race tests passed for seven independently specified canonical names, seventeen aliases and all eight predicates. They verify that uppercase/padded inputs do not gain selected effects, preserve sizing/assertion order and later defaults, and exercise Windows target/mode handling plus Dynamic Workers' expose ordering. The caller file is identical on baseline and candidate. Candidate-only exact metadata tests and the existing unchanged normalized test also passed; metadata stubs do not require registration or native operations. No product/test failure or expectation correction occurred in these direct contracts.

The final local gate passed both frozen race selections and scoped vet; all five selected top-level tests ran. All 2,321 source/test/doc file bytes and modes stayed unchanged. Independent source reconstruction verified all nine production files, unchanged metadata/normalized matching, and native/claim/checkpoint exclusions. Managed Codex review through P1 found no actionable findings. CLI/docs builds, whitespace checks and pinned Deadcode v0.45.0 static analysis passed; test entry points were analyzed, not broadly executed.

The source-blind CLI harness initially had 310 definitions but 308 captured IDs: two optional empty-file controls collided with provider-empty YAML controls. Before any candidate access, it proved their inputs were distinct and that no captures or fixtures were overwritten, preserved the original run, and captured only the two missing zero-byte inputs under unique IDs. The corrected manifest binds 310 unique cases. All 310 candidate cases then ran once and matched complete stdout, stderr and exit status exactly: 304 successes and six expected parser errors, no timeouts, output normalization, expectation edits or baseline reruns. Original and corrected evidence remain separately sealed.

That CLI comparison covers metadata, names/aliases, case/padding, flag/config-file selection, text/JSON display and help/parser behavior. Public CLI routing can normalize names, so it does not prove internal exact predicates or native behavior; direct caller contracts cover the predicates separately. No native CLI, VM, SSH/container, checkpoint, claim/recovery, credential or security-fault workflow was exercised.

The private commit was rebound onto actual normalized-name merge `333c06bd4b6eb1773577c5e23a7dc036681bb13d` (https://github.com/openclaw/crabbox/pull/2030). Complete base/candidate trees and modes, all thirteen owned files and the finalized release tail remained identical. A fresh actual-main build produced the same tested SHA-256: `be9ed46fa0edc59cd67889c6bbbefd9c05ec65a53c7cdf03ea52d32f38ee81c4`. Independent binding reverified all 310 corrected pairs and original correction receipts; earlier results are reused by source/executable identity, not called new executions. Hosted CI remains pending.
