### PR TITLE
fix(coordinator): preserve read fallback after dial timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Describe Scaleway configuration bindings once, sharing configured defaults while preserving explicit SDK location overrides and distinct file, environment, and flag list behavior. [PR 2036](https://github.com/openclaw/crabbox/pull/2036). Thanks @steipete.
 - Preserve recorded broker network diagnostics in inspect/status JSON, including SSH source CIDRs and AWS placement fields, without changing the resolved network mode or adding provider requests. https://github.com/openclaw/crabbox/pull/2039. Thanks @vincentkoc.
+- Allow the existing bodyless coordinator GET/HEAD curl fallback after a dial-local timeout while the request budget remains live, without replaying mutations or extending deadlines.
 
 ## 0.54.0 - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Describe Scaleway configuration bindings once, sharing configured defaults while preserving explicit SDK location overrides and distinct file, environment, and flag list behavior. [PR 2036](https://github.com/openclaw/crabbox/pull/2036). Thanks @steipete.
 - Preserve recorded broker network diagnostics in inspect/status JSON, including SSH source CIDRs and AWS placement fields, without changing the resolved network mode or adding provider requests. https://github.com/openclaw/crabbox/pull/2039. Thanks @vincentkoc.
-- Allow the existing bodyless coordinator GET/HEAD curl fallback after a dial-local timeout while the request budget remains live, without replaying mutations or extending deadlines.
+- Allow the existing bodyless coordinator GET/HEAD curl fallback after a dial-local timeout while the request budget remains live, without replaying mutations or extending deadlines. https://github.com/openclaw/crabbox/pull/2044. Thanks @vincentkoc.
 
 ## 0.54.0 - 2026-09-09
 

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -2468,7 +2468,7 @@ func (c *CoordinatorClient) doWithHeaders(ctx context.Context, method, path stri
 		}
 	}
 	err = c.doHTTPWithHeaders(ctx, method, path, data, body != nil, out, headers)
-	if err == nil || !shouldUseCoordinatorCurlFallback(method, body != nil, err) {
+	if err == nil || !shouldUseCoordinatorCurlFallback(ctx, method, body != nil, err) {
 		return err
 	}
 	if curlErr := c.doCurl(ctx, method, path, data, body != nil, out); curlErr == nil {
@@ -2729,16 +2729,23 @@ func isCoordinatorTransportError(err error) bool {
 	return errors.As(err, &urlErr)
 }
 
-func shouldUseCoordinatorCurlFallback(method string, hasBody bool, err error) bool {
-	if hasBody {
+func shouldUseCoordinatorCurlFallback(ctx context.Context, method string, hasBody bool, err error) bool {
+	if ctx.Err() != nil || hasBody || errors.Is(err, context.Canceled) {
 		return false
 	}
 	switch method {
 	case http.MethodGet, http.MethodHead:
-		return isCoordinatorTransportError(err)
 	default:
 		return false
 	}
+	if isCoordinatorTransportError(err) {
+		return true
+	}
+	// A dial timeout can match DeadlineExceeded while the request budget is live.
+	var urlErr *url.Error
+	var dialErr *net.OpError
+	return errors.As(err, &urlErr) && errors.As(urlErr.Err, &dialErr) &&
+		dialErr.Op == "dial" && dialErr.Timeout()
 }
 
 func (c *CoordinatorClient) applyChildEnvironment(cmd *exec.Cmd) {

--- a/internal/cli/coordinator_budget_test.go
+++ b/internal/cli/coordinator_budget_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os/exec"
@@ -177,6 +178,123 @@ func TestCoordinatorReadCurlFallbackSharesCallerDeadline(t *testing.T) {
 	_, err := client.GetLease(ctx, "cbx_budget")
 	if err == nil || !strings.Contains(err.Error(), "curl fallback failed") || ctx.Err() != context.DeadlineExceeded || calls.Load() != 1 || time.Since(started) > 5*time.Second {
 		t.Fatalf("fallback err=%v parent=%v requests=%d elapsed=%s", err, ctx.Err(), calls.Load(), time.Since(started))
+	}
+}
+
+func TestCoordinatorReadCurlFallbackAfterDialTimeout(t *testing.T) {
+	clearConfigEnv(t)
+	if _, err := exec.LookPath("curl"); err != nil {
+		t.Skip("curl is unavailable")
+	}
+	t.Setenv("CRABBOX_OWNER", "alice@example.com")
+	t.Setenv("NO_PROXY", "127.0.0.1")
+	t.Setenv("no_proxy", "127.0.0.1")
+	var nativeCalls, curlCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		curlCalls.Add(1)
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/leases/cbx_dial" ||
+			r.Header.Get("Authorization") != "Bearer synthetic-dial-token" {
+			t.Errorf("unexpected fallback request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		_, _ = io.WriteString(w, `{"lease":{"id":"cbx_dial","provider":"aws","state":"released"}}`)
+	}))
+	defer server.Close()
+	client := &CoordinatorClient{BaseURL: server.URL, Token: "synthetic-dial-token", Client: &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			nativeCalls.Add(1)
+			// Expire only the dialer's own budget, not the logical request.
+			dialer := net.Dialer{Deadline: time.Now().Add(-time.Second)}
+			conn, err := dialer.DialContext(req.Context(), "tcp", server.Listener.Addr().String())
+			if conn != nil {
+				_ = conn.Close()
+				t.Fatal("expired dial unexpectedly connected")
+			}
+			var dialErr *net.OpError
+			if !errors.As(err, &dialErr) || dialErr.Op != "dial" || !dialErr.Timeout() ||
+				!errors.Is(err, context.DeadlineExceeded) || req.Context().Err() != nil {
+				t.Fatalf("dial error=%v request=%v, want dial-local deadline with live request", err, req.Context().Err())
+			}
+			return nil, err
+		}),
+	}}
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	lease, err := client.GetLease(ctx, "cbx_dial")
+	if err != nil || lease.ID != "cbx_dial" || lease.Provider != "aws" || lease.State != "released" ||
+		nativeCalls.Load() != 1 || curlCalls.Load() != 1 || ctx.Err() != nil {
+		t.Fatalf("live-parent dial fallback: err=%v lease=%s/%s/%s native=%d curl=%d parent=%v",
+			err, lease.ID, lease.Provider, lease.State, nativeCalls.Load(), curlCalls.Load(), ctx.Err())
+	}
+}
+
+func TestCoordinatorReadCurlFallbackRejectsIneligibleRequests(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("CRABBOX_OWNER", "alice@example.com")
+	t.Setenv("NO_PROXY", "127.0.0.1")
+	t.Setenv("no_proxy", "127.0.0.1")
+	dialErr := &net.OpError{Op: "dial", Net: "tcp", Err: context.DeadlineExceeded}
+	for _, test := range []struct {
+		name         string
+		method       string
+		body         any
+		err          error
+		cancelDuring bool
+		expired      bool
+	}{
+		{"canceled during native attempt", http.MethodGet, nil, io.ErrUnexpectedEOF, true, false},
+		{"expired parent", http.MethodGet, nil, dialErr, false, true},
+		{"GET with body", http.MethodGet, map[string]string{"query": "fixture"}, dialErr, false, false},
+		{"HEAD with body", http.MethodHead, map[string]string{"query": "fixture"}, dialErr, false, false},
+		{"POST", http.MethodPost, nil, dialErr, false, false},
+		{"PUT", http.MethodPut, nil, dialErr, false, false},
+		{"PATCH", http.MethodPatch, nil, dialErr, false, false},
+		{"DELETE", http.MethodDelete, nil, dialErr, false, false},
+		{"CONNECT", http.MethodConnect, nil, dialErr, false, false},
+		{"OPTIONS", http.MethodOptions, nil, dialErr, false, false},
+		{"TRACE", http.MethodTrace, nil, dialErr, false, false},
+		{"request deadline", http.MethodGet, nil, context.DeadlineExceeded, false, false},
+		{"read deadline", http.MethodGet, nil, &net.OpError{Op: "read", Net: "tcp", Err: context.DeadlineExceeded}, false, false},
+		{"dial cancellation", http.MethodGet, nil, &net.OpError{Op: "dial", Net: "tcp", Err: context.Canceled}, false, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var nativeCalls, curlCalls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				curlCalls.Add(1)
+				_, _ = io.WriteString(w, `{}`)
+			}))
+			defer server.Close()
+			deadline := time.Now().Add(5 * time.Second)
+			if test.expired {
+				deadline = time.Now().Add(-time.Second)
+			}
+			ctx, cancel := context.WithDeadline(t.Context(), deadline)
+			defer cancel()
+			client := &CoordinatorClient{BaseURL: server.URL, Client: &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					nativeCalls.Add(1)
+					if req.Context().Err() != nil {
+						t.Fatal("native attempt started with an expired context")
+					}
+					if test.cancelDuring {
+						cancel()
+					}
+					return nil, test.err
+				}),
+			}}
+			err := client.do(ctx, test.method, "/v1/health", test.body, nil)
+			wantCalls := int32(1)
+			wantErr := test.err
+			if test.expired {
+				wantCalls, wantErr = 0, context.DeadlineExceeded
+			}
+			if err == nil || !errors.Is(err, wantErr) || strings.Contains(err.Error(), "curl fallback failed") ||
+				nativeCalls.Load() != wantCalls || curlCalls.Load() != 0 {
+				t.Fatalf("err=%v native=%d curl=%d, want original error, %d native calls and no fallback",
+					err, nativeCalls.Load(), curlCalls.Load(), wantCalls)
+			}
+		})
 	}
 }
 

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1408,17 +1409,38 @@ func TestCoordinatorLeaseWatchCancelsWhenLeaseReleased(t *testing.T) {
 	}
 }
 
-func TestCoordinatorCurlFallbackSkipsNonIdempotentAndTimeouts(t *testing.T) {
-	transportErr := &url.Error{Op: "Get", URL: "https://broker.example.test/v1/leases", Err: io.ErrUnexpectedEOF}
-	if !shouldUseCoordinatorCurlFallback(http.MethodGet, false, transportErr) {
-		t.Fatal("GET transport error should use curl fallback")
-	}
-	if shouldUseCoordinatorCurlFallback(http.MethodPost, true, transportErr) {
-		t.Fatal("POST with body should not use curl fallback")
-	}
-	timeoutErr := &url.Error{Op: "Get", URL: "https://broker.example.test/v1/leases", Err: context.DeadlineExceeded}
-	if shouldUseCoordinatorCurlFallback(http.MethodGet, false, timeoutErr) {
-		t.Fatal("deadline exceeded should not use curl fallback")
+func TestCoordinatorCurlFallbackEligibility(t *testing.T) {
+	dialErr := &net.OpError{Op: "dial", Net: "tcp", Err: context.DeadlineExceeded}
+	for _, test := range []struct {
+		name      string
+		err       error
+		wrapped   bool
+		fallback  bool
+		transport bool
+	}{
+		{"unexpected EOF", io.ErrUnexpectedEOF, true, true, true},
+		{"dial deadline", dialErr, true, true, false},
+		{"unwrapped dial deadline", dialErr, false, false, false},
+		{"request deadline", context.DeadlineExceeded, true, false, false},
+		{"read deadline", &net.OpError{Op: "read", Net: "tcp", Err: context.DeadlineExceeded}, true, false, false},
+		{"cancellation", context.Canceled, true, false, false},
+		{"dial cancellation", &net.OpError{Op: "dial", Net: "tcp", Err: context.Canceled}, true, false, false},
+		{"no error", nil, false, false, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.err
+			if test.wrapped {
+				err = &url.Error{Op: "Get", URL: "https://broker.example.test/v1/leases", Err: err}
+			}
+			for _, method := range []string{http.MethodGet, http.MethodHead} {
+				if got := shouldUseCoordinatorCurlFallback(t.Context(), method, false, err); got != test.fallback {
+					t.Errorf("%s fallback=%t, want %t", method, got, test.fallback)
+				}
+			}
+			if got := isCoordinatorTransportError(err); got != test.transport {
+				t.Errorf("shared transport classification=%t, want unchanged %t", got, test.transport)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

A native coordinator read can hit an attempt-local dial timeout while its overall request budget is still live. The timeout can match `context.DeadlineExceeded`, so the existing classifier skipped the bodyless curl fallback as though the whole request had expired.

## Why This Change Was Made

Make fallback eligibility aware of the parent context. Keep the existing eligible transport errors, and additionally accept only URL-wrapped dial-operation timeouts while the parent remains live. The fallback retains the same context and deadlines; the shared transport-error classifier used by other recovery paths is unchanged.

## User Impact

The existing authenticated fallback remains available for bodyless coordinator GET/HEAD requests after a native dial timeout. Mutations, bodyful requests, cancellation, exhausted request budgets, and non-dial deadline errors remain excluded. No authentication, provider configuration, routing defaults, or retry budgets change.

## Evidence

- The regression uses a real expired local `net.Dialer` deadline with a live parent context. It failed before the repair because curl was never invoked.
- Focused regression and sibling checks passed, including one authenticated real-curl fixture request, cancellation during the native attempt, mutation/bodyful exclusions, non-dial deadlines, shared request budgets, redirects, and existing transport classifications.
- Go formatting, diff checks, vet, an offline candidate build, and a fresh scoped P0 review passed before the base-only reconciliation. This PR preserves those transport code/test bytes and the non-changelog diff exactly.
- One read-only inspection of a released lease succeeded with the earlier combined candidate. That is not a live result from a newly built binary at this rebased head, nor proof of effective ingress, SSH reachability, or the original network failure's cause.
- At final head `945bc9bbaf47193f794ad36fa52d2c931d494ead`, the required Release Check (https://github.com/openclaw/crabbox/actions/runs/34371317896) and relevant Go regression suite (https://github.com/openclaw/crabbox/actions/runs/34371317964) passed. No new infrastructure, image qualification, rollout, or benchmark is claimed.

The separate diagnostics pass-through landed in https://github.com/openclaw/crabbox/pull/2039 and is part of this PR's base, not duplicated in its diff.

<!-- Punchcard-Session: calm-lantern-orchard-dn -->
