### PR TITLE
fix(aws): avoid slow fallback when an instance type has no capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+- AWS: hand definitive instance-capacity rejections directly to an already configured type or market fallback, avoiding repeated requests to the unavailable capacity while retaining exact-type, macOS, private-workspace, and transient-error retries.
 - Describe Scaleway configuration bindings once, sharing configured defaults while preserving explicit SDK location overrides and distinct file, environment, and flag list behavior. [PR 2036](https://github.com/openclaw/crabbox/pull/2036). Thanks @steipete.
 - Preserve recorded broker network diagnostics in inspect/status JSON, including SSH source CIDRs and AWS placement fields, without changing the resolved network mode or adding provider requests. https://github.com/openclaw/crabbox/pull/2039. Thanks @vincentkoc.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-- AWS: hand definitive instance-capacity rejections directly to an already configured type or market fallback, avoiding repeated requests to the unavailable capacity while retaining exact-type, macOS, private-workspace, and transient-error retries.
+- AWS: hand definitive instance-capacity rejections directly to an already configured type or market fallback, avoiding repeated requests to the unavailable capacity while retaining exact-type, macOS, private-workspace, and transient-error retries. [PR 2046](https://github.com/openclaw/crabbox/pull/2046). Thanks @steipete.
 - Describe Scaleway configuration bindings once, sharing configured defaults while preserving explicit SDK location overrides and distinct file, environment, and flag list behavior. [PR 2036](https://github.com/openclaw/crabbox/pull/2036). Thanks @steipete.
 - Preserve recorded broker network diagnostics in inspect/status JSON, including SSH source CIDRs and AWS placement fields, without changing the resolved network mode or adding provider requests. https://github.com/openclaw/crabbox/pull/2039. Thanks @vincentkoc.
 

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -153,6 +153,22 @@ Windows and macOS targets use their own candidate lists (Windows WSL2 uses
 nested-virtualization families; macOS uses `mac*.metal` types). The default
 class is `beast`.
 
+For coordinator-managed public Linux and Windows runners, a complete
+`RunInstances` error with code `InsufficientInstanceCapacity` goes directly to
+the next configured instance type or permitted On-Demand fallback. The client
+does not spend its HTTP retry budget repeating that capacity rejection first.
+Exact `--type` requests, macOS launches, private workspaces, and attempts with no
+remaining alternative that passes quota preflight retain their normal retries.
+The early handoff checks On-Demand quota only after a capacity rejection needs
+that alternative; the normal pass reuses the quota result and attempt order.
+Other server errors and HTTP 429 still use the SDK's retry budget and backoff;
+an opaque or incomplete response never triggers this early handoff. The lease's
+existing client token and resource-outcome checks remain unchanged.
+
+Each capacity probe reads at most 64 KiB and waits at most one second for the
+complete response body. An oversized, stalled, or unreadable body retains normal
+retries without consuming the original response.
+
 ## Provisioning diagnostics
 
 For coordinator-managed groups in the default VPC, VPC discovery and the
@@ -170,19 +186,21 @@ state or permission decisions.
 
 `requests` counts calls entering credential preparation. `credentialsMs` and
 `credentialFailures` cover that preparation; `requestMs` and `requestFailures`
-cover the inherited SDK fetch call. A returned HTTP error response is not a
-transport failure. The operation's existing error count records how its caller
-handled that response. Response-body reading and decoding remain in the outer
+cover signing, transport, and HTTP retry handling. A returned HTTP error response
+is not a transport failure. The operation's existing error count records how its
+caller handled that response. Capacity classification before a retry is included
+in `requestMs`; final response-body reading and decoding remain in the outer
 operation duration.
 
 `signInvocations`, `signCompletions`, `signFailures` and `signMs` observe the
-SDK's public signing method without changing its retry policy. Repeated signing
-invocations on a request indicate retry-loop re-entry; a completed signature
-alone does not prove that a server received the request. Signing time is part
-of `requestMs`, so do not add them together. These totals cannot distinguish
-network latency from SDK retry backoff or identify intermediate response status
-codes. They do not establish throttling. Requests outside a measured create
-operation and qualification-authority RPC transport do not add these totals.
+SDK's public signing method. Except for the capacity handoff described above,
+the SDK retry policy is unchanged. Repeated signing invocations on a request
+indicate retry-loop re-entry; a completed signature alone does not prove that a
+server received the request. Signing time is part of `requestMs`, so do not add
+them together. These totals cannot distinguish network latency from SDK retry
+backoff or identify intermediate response status codes. They do not establish
+throttling. Requests outside a measured create operation and
+qualification-authority RPC transport do not add these totals.
 
 These durations use `Date.now()`. In deployed Cloudflare Workers,
 [timers advance only after I/O](https://developers.cloudflare.com/workers/runtime-apis/performance/).

--- a/worker/src/aws-fetch-client.ts
+++ b/worker/src/aws-fetch-client.ts
@@ -6,8 +6,10 @@ import {
 } from "./aws-provisioning-diagnostics";
 import type { AWSCredentialProvider } from "./types";
 
+type StopAWSResponseRetry = (response: Response) => Promise<boolean>;
+
 export interface AWSFetchClient {
-  fetch(input: string, init?: RequestInit): Promise<Response>;
+  fetch(input: string, init?: RequestInit, stopRetrying?: StopAWSResponseRetry): Promise<Response>;
 }
 
 class ObservedAwsClient extends AwsClient {
@@ -44,7 +46,11 @@ export class RefreshingAWSFetchClient implements AWSFetchClient {
     private readonly region: string,
   ) {}
 
-  async fetch(input: string, init?: RequestInit): Promise<Response> {
+  async fetch(
+    input: string,
+    init?: RequestInit,
+    stopRetrying?: StopAWSResponseRetry,
+  ): Promise<Response> {
     const observe = currentAWSTransportObserver();
     const observation: AWSTransportObservation = {
       requests: 1,
@@ -75,11 +81,27 @@ export class RefreshingAWSFetchClient implements AWSFetchClient {
       const session = credentials.sessionToken?.trim();
       if (session) options.sessionToken = session;
       // aws4fetch 1.0.20 calls public sign() once per retry-loop invocation.
-      // Keep its fetch implementation, retry policy, signed bytes and Response intact.
       const client = observe ? new ObservedAwsClient(options, observation) : new AwsClient(options);
       requestStartedAt = Date.now();
       observation.credentialsMs = Math.max(0, requestStartedAt - startedAt);
-      return await client.fetch(input, init);
+      if (!stopRetrying) return await client.fetch(input, init);
+      // aws4fetch has no response-policy hook. Preserve its budget, jitter, signing and
+      // thrown errors while allowing the operation owner to handle a definitive rejection.
+      /* oxlint-disable eslint/no-await-in-loop -- Each signed attempt and its backoff must settle before retry or handoff. */
+      for (let attempt = 0; ; attempt += 1) {
+        const response = await fetch(await client.sign(input, init));
+        if (
+          attempt === client.retries ||
+          (response.status < 500 && response.status !== 429) ||
+          (await stopRetrying(response))
+        ) {
+          return response;
+        }
+        await new Promise((resolve) =>
+          setTimeout(resolve, Math.random() * client.initRetryMs * 2 ** attempt),
+        );
+      }
+      /* oxlint-enable eslint/no-await-in-loop */
     } catch (error) {
       if (requestStartedAt === undefined) observation.credentialFailures += 1;
       else observation.requestFailures += 1;

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -1,4 +1,4 @@
-import { XMLParser } from "fast-xml-parser";
+import { XMLParser, XMLValidator } from "fast-xml-parser";
 
 import { RefreshingAWSFetchClient, type AWSFetchClient } from "./aws-fetch-client";
 import {
@@ -55,6 +55,8 @@ const awsSpotQuotaCode = "L-34B43A08";
 const awsOnDemandQuotaCode = "L-1216C47A";
 const awsSSHIngressDescription = "Crabbox SSH";
 const awsRunInstancesOutcomeUncertain = "crabbox_aws_run_instances_outcome_uncertain";
+const awsCapacityErrorMaxBytes = 64 * 1024;
+const awsCapacityErrorReadTimeoutMs = 1_000;
 const awsMacHostQuotaSpecs: Record<string, { quotaCode: string; quotaName: string }> = {
   mac1: { quotaCode: "L-A8448DC5", quotaName: "Running Dedicated mac1 Hosts" },
   mac2: { quotaCode: "L-5D8DADF5", quotaName: "Running Dedicated mac2 Hosts" },
@@ -95,6 +97,36 @@ class AWSQueryError extends Error {
     detail: string,
   ) {
     super(`aws ${action}: http ${status}: ${detail}`);
+  }
+}
+
+async function readAWSCapacityErrorBody(response: Response): Promise<string | undefined> {
+  const reader = response.clone().body?.getReader();
+  if (!reader) return undefined;
+  const decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: false });
+  let text = "";
+  let bytes = 0;
+  const deadline = Date.now() + awsCapacityErrorReadTimeoutMs;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expired = new Promise<undefined>((resolve) => {
+    timer = setTimeout(() => resolve(undefined), awsCapacityErrorReadTimeoutMs);
+  });
+  try {
+    for (;;) {
+      // One deadline covers the whole body, including streams that keep dripping chunks.
+      if (Date.now() >= deadline) return undefined;
+      // oxlint-disable-next-line eslint/no-await-in-loop -- Bound each sequential read before buffering it.
+      const chunk = await Promise.race([reader.read(), expired]);
+      if (!chunk) return undefined;
+      if (chunk.done) return text + decoder.decode();
+      bytes += chunk.value.byteLength;
+      if (bytes > awsCapacityErrorMaxBytes) return undefined;
+      text += decoder.decode(chunk.value, { stream: true });
+    }
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+    // Cancel only the probe branch. Awaiting tee cancellation can wait for the untouched original.
+    void reader.cancel().catch(() => undefined);
   }
 }
 
@@ -1100,6 +1132,16 @@ export class EC2SpotClient {
         );
       }
       const candidates = pinnedMacHostType ? [pinnedMacHostType] : awsLaunchCandidates(config);
+      const allowCapacityHandoff =
+        !config.awsPrivate && !config.serverTypeExplicit && config.target !== "macos";
+      const hasQuotaEligibleCandidate = (
+        serverTypes: string[],
+        market: LeaseConfig["capacityMarket"],
+        quota: number | undefined,
+      ) =>
+        serverTypes.some(
+          (serverType) => !awsQuotaPreflightAttempt(serverType, market, this.region, quota),
+        );
       const history = new ProvisioningAttemptHistory();
       const imageCache = new Map<string, string>();
       const marketFallbackCandidates: string[] = [];
@@ -1139,13 +1181,12 @@ export class EC2SpotClient {
         imageCache.set(cacheKey, imageID);
         return imageID;
       };
-      for (const serverType of candidates) {
+      for (const [candidateIndex, serverType] of candidates.entries()) {
         const preflight = awsQuotaPreflightAttempt(
           serverType,
           config.capacityMarket,
           this.region,
-          // oxlint-disable-next-line eslint/no-await-in-loop -- quota preflight follows sequential fallback order.
-          await quotaForMarket(config.capacityMarket),
+          initialQuota.value,
         );
         if (preflight) {
           history.record(preflight, `${serverType}: ${preflight.message}`);
@@ -1154,6 +1195,27 @@ export class EC2SpotClient {
           }
           continue;
         }
+        const laterCandidates = candidates.slice(candidateIndex + 1);
+        const canHandoffWithinMarket =
+          allowCapacityHandoff &&
+          hasQuotaEligibleCandidate(laterCandidates, config.capacityMarket, initialQuota.value);
+        const canCheckFallbackMarket =
+          allowCapacityHandoff &&
+          config.capacityMarket === "spot" &&
+          config.capacityFallback.startsWith("on-demand");
+        const capacityHandoff =
+          canHandoffWithinMarket || canCheckFallbackMarket
+            ? async () => {
+                if (canHandoffWithinMarket) return true;
+                // Extra-market quota I/O belongs only to an actual capacity rejection.
+                const quota = await quotaForMarket("on-demand");
+                return hasQuotaEligibleCandidate(
+                  [...marketFallbackCandidates, serverType, ...laterCandidates],
+                  "on-demand",
+                  quota,
+                );
+              }
+            : undefined;
         try {
           // oxlint-disable-next-line eslint/no-await-in-loop -- instance-type fallback may need an architecture-specific AMI.
           const imageID = await diagnostics.measure("image", () =>
@@ -1168,6 +1230,7 @@ export class EC2SpotClient {
               owner,
               imageID,
               securityGroupID,
+              capacityHandoff,
             ),
           );
           const result: {
@@ -1202,14 +1265,10 @@ export class EC2SpotClient {
       }
       // Retry only candidates whose Spot failure can be recovered by On-Demand.
       if (marketFallbackCandidates.length > 0 && config.capacityFallback.startsWith("on-demand")) {
-        for (const serverType of marketFallbackCandidates) {
-          const preflight = awsQuotaPreflightAttempt(
-            serverType,
-            "on-demand",
-            this.region,
-            // oxlint-disable-next-line eslint/no-await-in-loop -- on-demand fallback must stay sequential.
-            await quotaForMarket("on-demand"),
-          );
+        for (const [candidateIndex, serverType] of marketFallbackCandidates.entries()) {
+          // oxlint-disable-next-line eslint/no-await-in-loop -- on-demand fallback follows its admitted candidate order.
+          const quota = await quotaForMarket("on-demand");
+          const preflight = awsQuotaPreflightAttempt(serverType, "on-demand", this.region, quota);
           if (preflight) {
             history.record(preflight, `on-demand ${serverType}: ${preflight.message}`);
             continue;
@@ -1232,6 +1291,14 @@ export class EC2SpotClient {
                 owner,
                 imageID,
                 securityGroupID,
+                allowCapacityHandoff &&
+                  hasQuotaEligibleCandidate(
+                    marketFallbackCandidates.slice(candidateIndex + 1),
+                    "on-demand",
+                    quota,
+                  )
+                  ? async () => true
+                  : undefined,
               ),
             );
             const result: {
@@ -2204,6 +2271,7 @@ export class EC2SpotClient {
     owner: string,
     imageID: string,
     securityGroupID: string,
+    capacityHandoff?: () => Promise<boolean>,
   ): Promise<ProviderMachine> {
     const now = new Date();
     const name = leaseProviderName(leaseID, slug);
@@ -2264,7 +2332,7 @@ export class EC2SpotClient {
       }
       let root: Record<string, unknown>;
       try {
-        root = await this.ec2("RunInstances", params);
+        root = await this.ec2("RunInstances", params, capacityHandoff);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         if (!config.awsPrivate || message.includes("aws RunInstances: http 4")) {
@@ -2809,14 +2877,36 @@ export class EC2SpotClient {
   private async ec2(
     action: string,
     params: Record<string, string>,
+    capacityHandoff?: () => Promise<boolean>,
   ): Promise<Record<string, unknown>> {
     await this.ensureExpectedIdentity();
     const body = new URLSearchParams({ Action: action, Version: ec2Version, ...params });
-    const response = await this.aws.fetch(this.endpoint, {
-      method: "POST",
-      headers: { "content-type": "application/x-www-form-urlencoded; charset=utf-8" },
-      body: body.toString(),
-    });
+    const response = await this.aws.fetch(
+      this.endpoint,
+      {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded; charset=utf-8" },
+        body: body.toString(),
+      },
+      capacityHandoff && action === "RunInstances"
+        ? async (candidate) => {
+            if (candidate.status < 500) return false;
+            try {
+              const text = await readAWSCapacityErrorBody(candidate);
+              return (
+                text !== undefined &&
+                XMLValidator.validate(text) === true &&
+                this.awsQueryError(action, candidate.status, text).code ===
+                  "InsufficientInstanceCapacity" &&
+                (await capacityHandoff())
+              );
+            } catch {
+              // Missing response or fallback-preflight evidence retains normal retries.
+              return false;
+            }
+          }
+        : undefined,
+    );
     const text = await response.text();
     if (!response.ok) {
       throw this.awsQueryError(action, response.status, text);

--- a/worker/test/aws-fetch-client.test.ts
+++ b/worker/test/aws-fetch-client.test.ts
@@ -2,13 +2,17 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 
 import { afterEach, expect, it, vi } from "vitest";
 
+import { EC2SpotClient } from "../src/aws";
 import { RefreshingAWSFetchClient } from "../src/aws-fetch-client";
 import { createAWSProvisioningDiagnostics } from "../src/aws-provisioning-diagnostics";
+import { leaseConfig, type LeaseConfig } from "../src/config";
+import type { Env } from "../src/types";
 
 const cleanups: Array<() => Promise<void>> = [];
 
 afterEach(async () => {
   await Promise.all(cleanups.splice(0).map((close) => close()));
+  vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
 
@@ -34,6 +38,429 @@ const credentials = async () => ({
   secretAccessKey: "fixture-secret-canary",
   sessionToken: "fixture-session-canary",
 });
+
+it.each([500, 503])(
+  "hands a parsed HTTP %i capacity rejection to the next configured type without retrying it",
+  async (status) => {
+    const { launch, requests } = await capacityTransport({
+      status,
+      reject: (request) => request.get("InstanceType") === "t3.small",
+    });
+    const result = await launch();
+    expect(requests.map((request) => request.get("InstanceType"))).toEqual([
+      "t3.small",
+      "t3.medium",
+    ]);
+    expect(result.serverType).toBe("t3.medium");
+    expect(result.attempts).toEqual([
+      expect.objectContaining({ serverType: "t3.small", category: "capacity" }),
+    ]);
+    expect(requests.map((request) => request.get("ClientToken"))).toEqual([
+      "cbx_000000000001",
+      "cbx_000000000001",
+    ]);
+  },
+);
+
+it.each([
+  {
+    name: "generic 500",
+    status: 500,
+    body: "<Response><Errors><Error><Code>InternalError</Code></Error></Errors></Response>",
+  },
+  { name: "opaque 503", status: 503, body: "InsufficientInstanceCapacity" },
+  {
+    name: "incomplete XML",
+    status: 503,
+    body: "<Response><Errors><Error><Code>InsufficientInstanceCapacity</Code>",
+  },
+  {
+    name: "capacity mentioned only in the message",
+    status: 500,
+    body: "<Response><Errors><Error><Code>InternalError</Code><Message>InsufficientInstanceCapacity</Message></Error></Errors></Response>",
+  },
+  { name: "429", status: 429 },
+])("preserves the SDK retry budget for $name with alternatives", async ({ status, body }) => {
+  const { launch, requests } = await capacityTransport({
+    status,
+    errorBody: body,
+    reject: (_request, index) => index < 10,
+  });
+  const result = await launch();
+  expect(requests.map((request) => request.get("InstanceType"))).toEqual(
+    Array(11).fill("t3.small"),
+  );
+  expect(result.serverType).toBe("t3.small");
+  expect(result.attempts).toBeUndefined();
+});
+
+it.each([
+  { name: "explicit exact type", overrides: { serverTypeExplicit: true }, type: "t3.small" },
+  {
+    name: "no alternate type or market",
+    overrides: { awsInstanceTypes: ["t3.small"] },
+    type: "t3.small",
+  },
+  {
+    name: "pinned Mac host",
+    overrides: {
+      target: "macos",
+      hostID: "h-pinned",
+      serverType: "mac1.metal",
+      capacityMarket: "on-demand",
+    },
+    type: "mac1.metal",
+  },
+] satisfies Array<{ name: string; overrides: Partial<LeaseConfig>; type: string }>)(
+  "preserves capacity retries for $name",
+  async ({ overrides, type }) => {
+    const { launch, requests } = await capacityTransport({
+      status: 500,
+      reject: (_request, index) => index < 10,
+    });
+    const result = await launch(overrides);
+    expect(requests.map((request) => request.get("InstanceType"))).toEqual(Array(11).fill(type));
+    expect(result.serverType).toBe(type);
+    expect(requests.map((request) => request.get("Placement.HostId"))).toEqual(
+      Array(11).fill(overrides.hostID ?? null),
+    );
+  },
+);
+
+it("hands capacity rejection to the configured market without retrying Spot", async () => {
+  const { launch, requests } = await capacityTransport({
+    status: 500,
+    reject: (request) => request.has("InstanceMarketOptions.MarketType"),
+  });
+  const result = await launch({
+    awsInstanceTypes: ["t3.small"],
+    capacityFallback: "on-demand-after-120s",
+  });
+  expect(requests.map((request) => request.has("InstanceMarketOptions.MarketType"))).toEqual([
+    true,
+    false,
+  ]);
+  expect(result.market).toBe("on-demand");
+});
+
+it("also hands off capacity between eligible On-Demand candidates", async () => {
+  const { launch, requests } = await capacityTransport({
+    status: 500,
+    reject: (request) =>
+      request.has("InstanceMarketOptions.MarketType") || request.get("InstanceType") === "t3.small",
+  });
+  const result = await launch({ capacityFallback: "on-demand-after-120s" });
+  expect(
+    requests.map(
+      (request) =>
+        `${request.has("InstanceMarketOptions.MarketType") ? "spot" : "on-demand"}:${request.get("InstanceType")}`,
+    ),
+  ).toEqual(["spot:t3.small", "spot:t3.medium", "on-demand:t3.small", "on-demand:t3.medium"]);
+  expect(result.market).toBe("on-demand");
+  expect(result.serverType).toBe("t3.medium");
+});
+
+it("keeps the final candidate's capacity retries after an earlier handoff", async () => {
+  const { launch, requests } = await capacityTransport({
+    status: 500,
+    reject: (_request, index) => index < 11,
+  });
+  const result = await launch();
+  expect(requests.map((request) => request.get("InstanceType"))).toEqual([
+    "t3.small",
+    ...Array(11).fill("t3.medium"),
+  ]);
+  expect(result.serverType).toBe("t3.medium");
+});
+
+it.each([
+  {
+    name: "larger later type",
+    spot: 2,
+    onDemand: 999,
+    marketFallback: false,
+    types: ["t3.small", "c7i.2xlarge"],
+  },
+  {
+    name: "larger type and On-Demand market",
+    spot: 2,
+    onDemand: 1,
+    marketFallback: true,
+    types: ["t3.small", "c7i.2xlarge"],
+  },
+  {
+    name: "On-Demand market only",
+    spot: 2,
+    onDemand: 1,
+    marketFallback: true,
+    types: ["t3.small"],
+  },
+  {
+    name: "larger later On-Demand type",
+    spot: 1,
+    onDemand: 2,
+    marketFallback: true,
+    types: ["t3.small", "c7i.2xlarge"],
+  },
+])(
+  "retains full retries when preflight blocks the $name",
+  async ({ spot, onDemand, marketFallback, types }) => {
+    const { launch, requests, quotaRequests } = await capacityTransport({
+      status: 500,
+      reject: (_request, index) => index < 10,
+      quotas: { spot, onDemand },
+    });
+    const result = await launch({
+      awsInstanceTypes: types,
+      capacityFallback: marketFallback ? "on-demand-after-120s" : "none",
+    });
+    expect(requests.map((request) => request.get("InstanceType"))).toEqual(
+      Array(11).fill("t3.small"),
+    );
+    expect(result.serverType).toBe("t3.small");
+    expect(quotaRequests).toEqual(marketFallback ? ["L-34B43A08", "L-1216C47A"] : ["L-34B43A08"]);
+  },
+);
+
+it("does not query On-Demand quota when the current Spot candidate succeeds", async () => {
+  const { launch, quotaRequests } = await capacityTransport({
+    status: 500,
+    reject: () => false,
+    quotas: { spot: 2, onDemand: 1 },
+  });
+  const result = await launch({
+    awsInstanceTypes: ["t3.small", "c7i.2xlarge"],
+    capacityFallback: "on-demand-after-120s",
+  });
+  expect(result.serverType).toBe("t3.small");
+  expect(quotaRequests).toEqual(["L-34B43A08"]);
+});
+
+it("hands off past a quota-blocked type without changing attempt history order", async () => {
+  const { launch, requests, quotaRequests } = await capacityTransport({
+    status: 500,
+    reject: (request) => request.get("InstanceType") === "t3.small",
+    quotas: { spot: 2, onDemand: 1 },
+  });
+  const result = await launch({ awsInstanceTypes: ["t3.small", "c7i.2xlarge", "t3.medium"] });
+  expect(requests.map((request) => request.get("InstanceType"))).toEqual(["t3.small", "t3.medium"]);
+  expect(result.attempts?.map(({ serverType, category }) => ({ serverType, category }))).toEqual([
+    { serverType: "t3.small", category: "capacity" },
+    { serverType: "c7i.2xlarge", category: "quota" },
+  ]);
+  expect(quotaRequests).toEqual(["L-34B43A08"]);
+});
+
+it("does not use an oversized UTF-8 capacity body to skip retrying, and preserves its response", async () => {
+  const body = `<Response><Errors><Error><Code>InsufficientInstanceCapacity</Code><Message>${"é".repeat(40_000)}</Message></Error></Errors></Response>`;
+  const { launch, requests, responses } = await capacityTransport({
+    status: 500,
+    reject: (_request, index) => index === 0,
+    writeError: (response) => {
+      response.write(body);
+      response.end();
+    },
+  });
+  const result = await launch();
+  expect(requests.map((request) => request.get("InstanceType"))).toEqual(["t3.small", "t3.small"]);
+  expect(result.server.cloudID).toBe("i-fallback");
+  expect(responses[0]!.bodyUsed).toBe(false);
+  expect(await responses[0]!.text()).toBe(body);
+});
+
+it.each([false, true])(
+  "bounds the whole response probe without consuming the original (drip=%s)",
+  async (drip) => {
+    let guard: ReturnType<typeof setTimeout> | undefined;
+    let interval: ReturnType<typeof setInterval> | undefined;
+    let guardReleasedBody = false;
+    let finishBody: (() => void) | undefined;
+    const chunks = ["<Response>"];
+    const { launch, requests, responses } = await capacityTransport({
+      status: 503,
+      reject: (_request, index) => index === 0,
+      writeError: (response) => {
+        response.write(chunks[0]);
+        let finished = false;
+        finishBody = () => {
+          if (finished) return;
+          finished = true;
+          clearInterval(interval);
+          chunks.push("</Response>");
+          response.end(chunks.at(-1));
+        };
+        if (drip)
+          interval = setInterval(() => {
+            chunks.push(" ");
+            response.write(" ");
+          }, 100);
+        // Release a regressed unbounded reader so the test can still settle its HTTP request.
+        guard = setTimeout(() => {
+          guardReleasedBody = true;
+          finishBody?.();
+        }, 2_000);
+      },
+    });
+    try {
+      const result = await launch();
+      expect(guardReleasedBody).toBe(false);
+      expect(requests.map((request) => request.get("InstanceType"))).toEqual([
+        "t3.small",
+        "t3.small",
+      ]);
+      expect(result.server.cloudID).toBe("i-fallback");
+      expect(responses[0]!.bodyUsed).toBe(false);
+      finishBody?.();
+      expect(await responses[0]!.text()).toBe(chunks.join(""));
+    } finally {
+      clearTimeout(guard);
+      finishBody?.();
+    }
+  },
+);
+
+it("keeps normal retries when the intermediate response body becomes unreadable", async () => {
+  let disconnect: (() => void) | undefined;
+  const { launch, requests, firstResponse } = await capacityTransport({
+    status: 500,
+    reject: (_request, index) => index === 0,
+    writeError: (response) => {
+      response.write("<Response>");
+      disconnect = () => response.destroy();
+    },
+  });
+  const launched = launch();
+  const response = await firstResponse;
+  expect(disconnect).toBeTypeOf("function");
+  disconnect!();
+  const result = await launched;
+  expect(requests.map((request) => request.get("InstanceType"))).toEqual(["t3.small", "t3.small"]);
+  expect(result.server.cloudID).toBe("i-fallback");
+  expect(response.bodyUsed).toBe(false);
+});
+
+async function capacityTransport(options: {
+  status: number;
+  reject: (request: URLSearchParams, index: number) => boolean;
+  errorBody?: string;
+  writeError?: (response: ServerResponse) => void;
+  quotas?: { spot: number; onDemand: number };
+}) {
+  vi.spyOn(Math, "random").mockReturnValue(0);
+  vi.spyOn(console, "info").mockImplementation(() => {});
+  const requests: URLSearchParams[] = [];
+  const quotaRequests: string[] = [];
+  const responses: Response[] = [];
+  const firstResponse = Promise.withResolvers<Response>();
+  const errorBody =
+    options.errorBody ??
+    "<Response><Errors><Error><Code>InsufficientInstanceCapacity</Code><Message>No capacity</Message></Error></Errors></Response>";
+  const url = await localTransport((request, response) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    request.on("end", () => {
+      const params = new URLSearchParams(body);
+      const action = params.get("Action");
+      response.setHeader("content-type", "application/xml");
+      if (!action) {
+        const { QuotaCode } = JSON.parse(body);
+        quotaRequests.push(QuotaCode);
+        const quota = options.quotas?.[QuotaCode === "L-34B43A08" ? "spot" : "onDemand"] ?? 999;
+        response.setHeader("content-type", "application/json");
+        response.end(JSON.stringify({ Quota: { Value: quota } }));
+      } else if (action === "DescribeKeyPairs") {
+        response.end(
+          "<DescribeKeyPairsResponse><keySet><item><keyName>test-key</keyName><publicKey>ssh-ed25519 test</publicKey></item></keySet></DescribeKeyPairsResponse>",
+        );
+      } else if (action === "DescribeSecurityGroups") {
+        response.end(
+          "<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-123</groupId></item></securityGroupInfo></DescribeSecurityGroupsResponse>",
+        );
+      } else if (
+        action === "RevokeSecurityGroupIngress" ||
+        action === "AuthorizeSecurityGroupIngress"
+      ) {
+        response.end(`<${action}Response />`);
+      } else if (action === "DescribeHosts") {
+        response.end(
+          "<DescribeHostsResponse><hostSet><item><hostId>h-pinned</hostId><hostState>available</hostState><hostProperties><instanceType>mac1.metal</instanceType></hostProperties></item></hostSet></DescribeHostsResponse>",
+        );
+      } else if (action === "RunInstances") {
+        requests.push(params);
+        if (options.reject(params, requests.length - 1)) {
+          response.statusCode = options.status;
+          if (options.writeError) options.writeError(response);
+          else response.end(errorBody);
+        } else {
+          response.end(
+            `<RunInstancesResponse><instancesSet><item><instanceId>i-fallback</instanceId><instanceType>${params.get("InstanceType")}</instanceType><instanceState><name>pending</name></instanceState></item></instancesSet></RunInstancesResponse>`,
+          );
+        }
+      } else {
+        response.statusCode = 400;
+        response.end(
+          `<Response><Errors><Error><Code>Unexpected</Code><Message>${action}</Message></Error></Errors></Response>`,
+        );
+      }
+    });
+  });
+  const actualFetch = globalThis.fetch;
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    expect(request.headers.get("authorization")).toMatch(
+      /^AWS4-HMAC-SHA256 Credential=fixture-access-canary\//,
+    );
+    expect(new URL(request.url).hostname).toMatch(
+      /^(ec2|servicequotas)\.eu-west-1\.amazonaws\.com$/,
+    );
+    // The real signer, fetch implementation and HTTP response handling still run; only the destination is local.
+    const body = await request.text();
+    const response = await actualFetch(url, {
+      method: request.method,
+      headers: request.headers,
+      body,
+    });
+    if (new URLSearchParams(body).get("Action") === "RunInstances") {
+      responses.push(response);
+      firstResponse.resolve(response);
+    }
+    return response;
+  });
+  const client = new EC2SpotClient(
+    {
+      awsCredentialProvider: credentials,
+      CRABBOX_AWS_SECURITY_GROUP_ID: "sg-123",
+      CRABBOX_AWS_SSH_CIDRS: "203.0.113.7/32",
+      CRABBOX_AWS_AMI: "ami-test",
+    } as Env,
+    "eu-west-1",
+  );
+  const config = leaseConfig({
+    provider: "aws",
+    serverType: "t3.small",
+    serverTypeExplicit: false,
+    awsInstanceTypes: ["t3.small", "t3.medium"],
+    capacity: { market: "spot", fallback: "none" },
+    providerKey: "test-key",
+    sshPublicKey: "ssh-ed25519 test",
+  });
+  return {
+    requests,
+    quotaRequests,
+    responses,
+    firstResponse: firstResponse.promise,
+    launch: (overrides: Partial<LeaseConfig> = {}) =>
+      client.createServerWithFallback(
+        { ...config, ...overrides },
+        "cbx_000000000001",
+        "violet-prawn",
+        "alice@example.com",
+      ),
+  };
+}
 
 it("separates credential preparation from the signed request span", async () => {
   const url = await localTransport((_request, response) => {
@@ -144,53 +571,67 @@ it("records credential failure before signing and preserves the original error",
   });
 });
 
-it("records actual SDK signing failure without calling the local transport", async () => {
-  let requests = 0;
-  const url = await localTransport((_request, response) => {
-    requests += 1;
-    response.end();
-  });
-  const { diagnostics, finish } = observe();
-  const client = new RefreshingAWSFetchClient(credentials, "ec2", "eu-west-1");
-  await expect(
-    diagnostics.measure("key_pair", () =>
-      client.fetch(url, { headers: { "invalid\nheader": "payload-canary" } }),
-    ),
-  ).rejects.toBeInstanceOf(TypeError);
-  expect(requests).toBe(0);
-  expect(finish("failure")).toMatchObject({
-    requests: 1,
-    credentialFailures: 0,
-    signInvocations: 1,
-    signCompletions: 0,
-    signFailures: 1,
-    requestFailures: 1,
-  });
-});
+it.each([false, true])(
+  "records signing failure without calling the transport (response policy=%s)",
+  async (responsePolicy) => {
+    let requests = 0;
+    const url = await localTransport((_request, response) => {
+      requests += 1;
+      response.end();
+    });
+    const { diagnostics, finish } = observe();
+    const client = new RefreshingAWSFetchClient(credentials, "ec2", "eu-west-1");
+    await expect(
+      diagnostics.measure("key_pair", () =>
+        client.fetch(
+          url,
+          { headers: { "invalid\nheader": "payload-canary" } },
+          responsePolicy ? async () => false : undefined,
+        ),
+      ),
+    ).rejects.toBeInstanceOf(TypeError);
+    expect(requests).toBe(0);
+    expect(finish("failure")).toMatchObject({
+      requests: 1,
+      credentialFailures: 0,
+      signInvocations: 1,
+      signCompletions: 0,
+      signFailures: 1,
+      requestFailures: 1,
+    });
+  },
+);
 
-it("preserves a real network failure without adding retries", async () => {
-  let requests = 0;
-  const url = await localTransport((request) => {
-    requests += 1;
-    request.socket.destroy();
-  });
-  const { diagnostics, finish } = observe();
-  const client = new RefreshingAWSFetchClient(credentials, "ec2", "eu-west-1");
-  await expect(
-    diagnostics.measure("key_pair", () =>
-      client.fetch(url, { method: "POST", body: "payload-canary" }),
-    ),
-  ).rejects.toBeInstanceOf(TypeError);
-  expect(requests).toBe(1);
-  expect(finish("failure")).toMatchObject({
-    requests: 1,
-    credentialFailures: 0,
-    signInvocations: 1,
-    signCompletions: 1,
-    signFailures: 0,
-    requestFailures: 1,
-  });
-});
+it.each([false, true])(
+  "preserves a network failure without adding retries (response policy=%s)",
+  async (responsePolicy) => {
+    let requests = 0;
+    const url = await localTransport((request) => {
+      requests += 1;
+      request.socket.destroy();
+    });
+    const { diagnostics, finish } = observe();
+    const client = new RefreshingAWSFetchClient(credentials, "ec2", "eu-west-1");
+    await expect(
+      diagnostics.measure("key_pair", () =>
+        client.fetch(
+          url,
+          { method: "POST", body: "payload-canary" },
+          responsePolicy ? async () => false : undefined,
+        ),
+      ),
+    ).rejects.toBeInstanceOf(TypeError);
+    expect(requests).toBe(1);
+    expect(finish("failure")).toMatchObject({
+      requests: 1,
+      credentialFailures: 0,
+      signInvocations: 1,
+      signCompletions: 1,
+      signFailures: 0,
+      requestFailures: 1,
+    });
+  },
+);
 
 it("attributes interleaved shared-client requests to their deepest operation and lease", async () => {
   const entered = Promise.withResolvers<void>();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users creating a public AWS runner would wait through repeated requests to an unavailable instance type before an already configured alternative was tried. A live allocation returned `InsufficientInstanceCapacity` for its preferred Spot type; the transport recorded twelve signing attempts across two instance-creation operations, taking 43.2 seconds in that stage.

## Why This Change Was Made

The AWS HTTP client retries server errors before the provisioning owner can inspect their AWS error codes. This change hands a complete, exact `RunInstances` capacity rejection back to that owner when another permitted type or market passes the existing quota preflight. It preserves the existing candidate selection, client token and resource-outcome handling.

The capacity probe is limited to 64 KiB and one second. Opaque, malformed, oversized, stalled or unreadable bodies keep normal retry handling. Generic server errors, rate limits, transport failures, exact types, macOS, private workspaces and final candidates retain their existing behavior.

## User Impact

Eligible allocations reach a configured fallback sooner instead of repeatedly requesting unavailable capacity. A permitted alternative may therefore win earlier; no new fallback, configuration option or dependency is introduced.

## Evidence

- Real local HTTP plus the production AWS signer/client and full candidate fallback reproduced eleven requests to the unavailable type before the next candidate. The repaired HTTP 500 and 503 capacity cases make one request per candidate.
- 191 focused tests passed, including retry preservation, exact/pinned/private launches, candidate and market boundaries, signing/network failures, and bounded response probes that leave the original body readable.
- Worker lint, formatting, typechecking and Wrangler dry-run build passed.
- Two fresh cloud desktop runs passed Computer input while WebVNC remained connected. Each had 150 health samples with the node continuously present and no OOM kills; both were reclaimed and provider cleanup verified. These establish the live baseline, not deployed performance of this patch.
