### PR TITLE
test(ssh): keep tunnel fixture ports distinct

### DIFF
--- a/internal/cli/ssh_forward_real_unix_test.go
+++ b/internal/cli/ssh_forward_real_unix_test.go
@@ -792,6 +792,9 @@ func TestSSHForwardRealPondWaitsForEveryGroup(t *testing.T) {
 			other.SSHHostKey = second.hostKey
 			members = append(members, pondMember{Lease: "second", SSH: other})
 			local, _ := strconv.Atoi(boundaryPort(t))
+			for local == summary.Forwards[0].LocalPort || local == summary.Forwards[1].LocalPort {
+				local, _ = strconv.Atoi(boundaryPort(t))
+			}
 			summary.Forwards = append(summary.Forwards, pondMeshForward{Peer: "second", LeaseID: "second", LocalPort: local, RemotePort: echo})
 			for i := range summary.Forwards {
 				summary.Forwards[i].RemotePort = echo


### PR DESCRIPTION
## What Problem This Solves

Resolves a flaky SSH lifecycle test where the third requested local port can repeat either of the two already selected ports. Two forwarding groups can then contend for one listener, causing the correct PID-ownership check to reject startup.

## Why This Change Was Made

Apply the existing distinct-port selection pattern to the third port. The production ownership check, timeouts, process cleanup, and assertions remain unchanged.

## User Impact

Test-only correction. The real SSH group-lifecycle test keeps its ownership coverage without introducing an accidental port collision between its own groups.

## Evidence

A temporary Go overlay forced the third selection to repeat the first. Original code failed through real OpenSSH with exit 255 and a listener-owner/tracked-PID mismatch; the same overlay passed after the three-line repair resampled a distinct port. The overlay is not included in this PR.

All 10 ordinary native race scenarios across the existing SSH group and detached-forward tests passed. Formatting, diff checks, and independent P2 review passed.

The [coverage failure](https://github.com/openclaw/crabbox/actions/runs/34373082286/job/102538923430) has the same adjacent-PID failure shape, but its log omitted the ports. The controlled reproduction establishes the collision defect without claiming to recover that run's unlogged port values.
