### PR TITLE
fix: protect retained leases and allow org-owned Mac host pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Changes
 
-- Reject occupied host pins and coordinator replies with a different lease ID before bootstrap or cleanup; show retained leases in ordinary text and JSON listing.
-- Allow authenticated org members to pin unused AWS Mac hosts backed by exact coordinator allocation evidence, while keeping unknown and other-org hosts admin-only.
+- Reject occupied host pins and coordinator replies with a different lease ID before bootstrap or cleanup; show retained leases in ordinary text and JSON listing. [PR 2049](https://github.com/openclaw/crabbox/pull/2049). Thanks @steipete.
+- Allow authenticated org members to pin unused AWS Mac hosts backed by exact coordinator allocation evidence, while keeping unknown and other-org hosts admin-only. [PR 2049](https://github.com/openclaw/crabbox/pull/2049). Thanks @steipete.
 
 
 - Transfer Blacksmith run artifacts through bounded native file download instead of bulk stdout, preserving the original collection deadline and claim while isolating each invocation's evidence. [PR 2043](https://github.com/openclaw/crabbox/pull/2043). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changes
 
 - Reject occupied host pins and coordinator replies with a different lease ID before bootstrap or cleanup; show retained leases in ordinary text and JSON listing. [PR 2049](https://github.com/openclaw/crabbox/pull/2049). Thanks @steipete.
-- Allow authenticated org members to pin unused AWS Mac hosts backed by exact coordinator allocation evidence, while keeping unknown and other-org hosts admin-only. [PR 2049](https://github.com/openclaw/crabbox/pull/2049). Thanks @steipete.
+- Require an exact coordinator host/org/region allocation record for org-member AWS Mac host pins; historical leases never grant pin access, and missing, ambiguous, or other-org records remain admin-only. [PR 2049](https://github.com/openclaw/crabbox/pull/2049). Thanks @steipete.
 
 
 - Transfer Blacksmith run artifacts through bounded native file download instead of bulk stdout, preserving the original collection deadline and claim while isolating each invocation's evidence. [PR 2043](https://github.com/openclaw/crabbox/pull/2043). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changes
 
+- Reject occupied host pins and coordinator replies with a different lease ID before bootstrap or cleanup; show retained leases in ordinary text and JSON listing.
+- Allow authenticated org members to pin unused AWS Mac hosts backed by exact coordinator allocation evidence, while keeping unknown and other-org hosts admin-only.
+
+
 - Transfer Blacksmith run artifacts through bounded native file download instead of bulk stdout, preserving the original collection deadline and claim while isolating each invocation's evidence. [PR 2043](https://github.com/openclaw/crabbox/pull/2043). Thanks @steipete.
 - Describe Scaleway configuration bindings once, sharing configured defaults while preserving explicit SDK location overrides and distinct file, environment, and flag list behavior. [PR 2036](https://github.com/openclaw/crabbox/pull/2036). Thanks @steipete.
 - Preserve recorded broker network diagnostics in inspect/status JSON, including SSH source CIDRs and AWS placement fields, without changing the resolved network mode or adding provider requests. https://github.com/openclaw/crabbox/pull/2039. Thanks @vincentkoc.

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -25,7 +25,9 @@ crabbox list --json
 The shape of the output depends on the selected `--provider`:
 
 - **Coordinator-backed providers** (`hetzner`, `aws`, `azure`, `daytona`, `gcp` with a broker
-  configured) list the leases the broker tracks for you. Add `--all` to request
+  configured) list visible active/provisioning leases and retained leases, including
+  released `keep=true` leases whose provider cleanup is not confirmed. Both text
+  and `--json` include them. Add `--all` to request
   admin-wide provider inventory when an admin token is configured.
 - **Direct cloud / hypervisor / static providers** list the machines the provider
   itself reports. In `provider=ssh` mode this prints the single configured static
@@ -35,6 +37,12 @@ The shape of the output depends on the selected `--provider`:
   view, so both human output and `--json` use the normalized Crabbox lease shape.
 
 Providers that do not implement listing exit with an error.
+
+Coordinator listing requests the current lease view and filters ended history
+locally when talking to an older coordinator. At the 1,000-row response limit,
+the CLI warns that older kept leases may be omitted; inspect a known lease with
+`crabbox inspect --provider aws --id <lease-id>`. Updating the coordinator lets
+it filter visible current/retained leases before applying that limit.
 
 ## Refreshing provider state
 

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -312,6 +312,12 @@ self-hosted GitHub Actions runner for the current repository. Most projects
 should instead prefer [`crabbox actions hydrate --id <lease>`](actions.md) after
 warmup, because it also dispatches the workflow and waits for the ready marker.
 
+A new warmup does not adopt an existing lease by slug or pinned host. An occupied
+host returns a conflict identifying its lease; inspect or explicitly stop that
+lease before requesting a new one. `--lease-id` replays only the same fixed ID
+and create intent. If a coordinator returns another ID, the CLI stops before
+bootstrap, key migration, or failure cleanup.
+
 ## Flags
 
 ```text

--- a/docs/features/auth-admin.md
+++ b/docs/features/auth-admin.md
@@ -183,12 +183,12 @@ an elevated owner limit.
 Provider host inventory is also capacity administration. Normal portal users
 see a Dedicated Host only when it backs an active lease already visible to
 them; unattached host inventory remains admin-only. Pinning an unused AWS Mac
-Dedicated Host also permits authenticated members of its recorded org in the
-same region. New admin allocations persist that org. Older hosts may use exact
-coordinator-managed Mac lease history as allocation evidence only when all
-matching host/region records belong to that current org identity. Missing or
-ambiguous evidence, registered external leases, and another org's records do
-not grant permission. Recorded allocations take precedence over history.
+Dedicated Host also permits authenticated members only when an exact coordinator
+allocation record matches that host, the requested region, and their current org
+identity. New admin allocations persist that org. Missing or ambiguous records,
+other-org records, and historical managed leases do not grant permission. Hosts
+allocated by older coordinators without a record remain admin-only; no claim or
+backfill command is added by this change.
 Other provider pins and other AWS resource selectors remain admin-only; existing
 checkpoint grants retain their exact host scope.
 

--- a/docs/features/auth-admin.md
+++ b/docs/features/auth-admin.md
@@ -164,7 +164,7 @@ GET  /v1/runs and logs/events    own runs only
 GET  /v1/usage                   own usage only
 GET  /v1/capacity                self-owner admission aggregate across months/orgs
 GET  /v1/pool                    admin token only
-POST /v1/leases with hostId      admin token only
+POST /v1/leases with hostId      admin, or matching org-owned Mac allocation
 /v1/admin/*                      admin token only
 ```
 
@@ -182,8 +182,21 @@ an elevated owner limit.
 
 Provider host inventory is also capacity administration. Normal portal users
 see a Dedicated Host only when it backs an active lease already visible to
-them; unattached host inventory and explicit host-pinned lease creation require
-admin authentication.
+them; unattached host inventory remains admin-only. Pinning an unused AWS Mac
+Dedicated Host also permits authenticated members of its recorded org in the
+same region. New admin allocations persist that org. Older hosts may use exact
+coordinator-managed Mac lease history as allocation evidence only when all
+matching host/region records belong to that current org identity. Missing or
+ambiguous evidence, registered external leases, and another org's records do
+not grant permission. Recorded allocations take precedence over history.
+Other provider pins and other AWS resource selectors remain admin-only; existing
+checkpoint grants retain their exact host scope.
+
+Host permission never authorizes adopting an occupying lease. A create request
+fails with `host_in_use` while that host has a live or retained instance. Exact
+fixed-ID replay preserves its existing owner and intent checks. Kept leases
+remain visible to their owners and share recipients in ordinary CLI listing,
+even when released with the instance retained.
 
 ## Lease sharing
 

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -49,6 +49,34 @@ crabbox warmup --provider aws --lease-id cbx_abcdef123456 --slug operation-displ
 silently substituting another instance. Use `--class` when you want capacity
 fallback across instance families.
 
+### Host pinning and retained leases
+
+A new warmup never adopts another lease by host ID or slug. If the pinned host
+carries a live or retained lease, creation returns `409 host_in_use` with its
+lease ID and slug before provisioning or bootstrap. Inspect that lease and use
+its exact ID for subsequent work, or explicitly stop it before requesting a new
+lease. Only `--lease-id` can replay the same fixed create intent; changing its
+ID or intent does not authorize reactivation. The CLI also rejects a different
+ID returned by an older coordinator, without bootstrapping or requesting cleanup.
+
+Authenticated org members can pin an unused Mac Dedicated Host with matching
+coordinator ownership evidence in the requested region. New admin allocations
+record their authenticated org; `admin mac-hosts list` includes that org when
+recorded. For hosts allocated by older coordinators, prior coordinator-managed
+Mac lease records with that exact host and region are accepted only when all
+such records belong to the same current org identity. A released lease can
+provide this evidence after its instance has been deleted. Registered external
+leases, ambiguous legacy org identities, and EC2 inventory alone cannot grant
+pin access. A recorded allocation takes precedence over historical leases.
+Hosts with no matching evidence or belonging to another org require admin auth.
+Host allocation, release, inventory, and other AWS resource selectors remain
+admin operations. Pin permission does not grant access to another member's lease.
+
+`crabbox list --provider aws`, including `--json`, shows visible retained leases
+alongside active/provisioning leases. A released lease may still hold a kept
+instance; use the lease ID and `keep`/cleanup fields to distinguish it from a
+confirmed deletion. Listing is read-only.
+
 ### Fixed-ID replay
 
 `warmup --lease-id cbx_<12 lowercase hex>` makes direct AWS acquisition
@@ -275,7 +303,7 @@ CRABBOX_AWS_SUBNET_ID
 CRABBOX_AWS_INSTANCE_PROFILE
 CRABBOX_AWS_ROOT_GB
 CRABBOX_AWS_SSH_CIDRS               # comma-separated
-CRABBOX_HOST_ID                     # brokered pin requires admin auth except owned released hosts
+CRABBOX_HOST_ID                     # brokered pin requires org allocation evidence or admin auth
 CRABBOX_AWS_MAC_HOST_ID             # legacy alias for the Mac host id
 CRABBOX_CAPACITY_REGIONS            # comma-separated fallback regions
 CRABBOX_CAPACITY_AVAILABILITY_ZONES
@@ -333,7 +361,7 @@ readiness preflight, API, AWS-GO gate, and live canary are in
 | Linux | Ubuntu bootstrap, SSH, rsync sync, optional desktop/browser/code, Tailscale, Actions hydration. |
 | Windows native | EC2Launch bootstrap, OpenSSH, Git for Windows, archive sync; optional desktop with `--desktop`. |
 | Windows WSL2 | `--windows-mode wsl2`; launches on nested-virtualization families (`c8i`/`m8i`/`m8i-flex`/`r8i`); POSIX sync and commands run inside WSL with the Linux image Node/npm baseline. |
-| macOS | Requires an available EC2 Mac Dedicated Host in the region; On-Demand only. Admin-authenticated broker requests can pin any host with `CRABBOX_HOST_ID` / `aws.macHostId` (`CRABBOX_AWS_MAC_HOST_ID` is a legacy alias); normal broker users can pin only a host from their own released lease and otherwise use automatic discovery. |
+| macOS | Requires an available EC2 Mac Dedicated Host in the region; On-Demand only. Admin-authenticated broker requests can pin any host with `CRABBOX_HOST_ID` / `aws.macHostId` (`CRABBOX_AWS_MAC_HOST_ID` is a legacy alias); normal broker users can pin a host with coordinator allocation evidence for their exact org and region, including prior managed Mac leases. See the host ownership rules below. |
 
 Managed WSL2 commands run as the non-root `crabbox` Linux user, with
 `HOME=/home/crabbox`, Bash, passwordless sudo, and membership in the `sudo` and

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -59,16 +59,14 @@ lease. Only `--lease-id` can replay the same fixed create intent; changing its
 ID or intent does not authorize reactivation. The CLI also rejects a different
 ID returned by an older coordinator, without bootstrapping or requesting cleanup.
 
-Authenticated org members can pin an unused Mac Dedicated Host with matching
-coordinator ownership evidence in the requested region. New admin allocations
-record their authenticated org; `admin mac-hosts list` includes that org when
-recorded. For hosts allocated by older coordinators, prior coordinator-managed
-Mac lease records with that exact host and region are accepted only when all
-such records belong to the same current org identity. A released lease can
-provide this evidence after its instance has been deleted. Registered external
-leases, ambiguous legacy org identities, and EC2 inventory alone cannot grant
-pin access. A recorded allocation takes precedence over historical leases.
-Hosts with no matching evidence or belonging to another org require admin auth.
+Authenticated org members can pin an unused Mac Dedicated Host only when an
+exact coordinator allocation record matches the host, requested region, and
+requester's current org identity. New admin allocations record their authenticated
+org. Historical managed leases and EC2 inventory never substitute for that record.
+Hosts allocated by older coordinators without a record remain admin-only; this
+change does not add a claim or backfill command. Missing, ambiguous, and other-org
+allocation records do not grant org-member pin access.
+
 Host allocation, release, inventory, and other AWS resource selectors remain
 admin operations. Pin permission does not grant access to another member's lease.
 
@@ -303,7 +301,7 @@ CRABBOX_AWS_SUBNET_ID
 CRABBOX_AWS_INSTANCE_PROFILE
 CRABBOX_AWS_ROOT_GB
 CRABBOX_AWS_SSH_CIDRS               # comma-separated
-CRABBOX_HOST_ID                     # brokered pin requires org allocation evidence or admin auth
+CRABBOX_HOST_ID                     # brokered pin requires an exact org allocation record or admin auth
 CRABBOX_AWS_MAC_HOST_ID             # legacy alias for the Mac host id
 CRABBOX_CAPACITY_REGIONS            # comma-separated fallback regions
 CRABBOX_CAPACITY_AVAILABILITY_ZONES
@@ -361,7 +359,7 @@ readiness preflight, API, AWS-GO gate, and live canary are in
 | Linux | Ubuntu bootstrap, SSH, rsync sync, optional desktop/browser/code, Tailscale, Actions hydration. |
 | Windows native | EC2Launch bootstrap, OpenSSH, Git for Windows, archive sync; optional desktop with `--desktop`. |
 | Windows WSL2 | `--windows-mode wsl2`; launches on nested-virtualization families (`c8i`/`m8i`/`m8i-flex`/`r8i`); POSIX sync and commands run inside WSL with the Linux image Node/npm baseline. |
-| macOS | Requires an available EC2 Mac Dedicated Host in the region; On-Demand only. Admin-authenticated broker requests can pin any host with `CRABBOX_HOST_ID` / `aws.macHostId` (`CRABBOX_AWS_MAC_HOST_ID` is a legacy alias); normal broker users can pin a host with coordinator allocation evidence for their exact org and region, including prior managed Mac leases. See the host ownership rules below. |
+| macOS | Requires an available EC2 Mac Dedicated Host in the region; On-Demand only. Admin-authenticated broker requests can pin any host with `CRABBOX_HOST_ID` / `aws.macHostId` (`CRABBOX_AWS_MAC_HOST_ID` is a legacy alias); normal broker users can pin a host with an exact coordinator allocation record for that host, their current org, and the requested region. See the host ownership rules below. |
 
 Managed WSL2 commands run as the non-root `crabbox` Linux user, with
 `HOME=/home/crabbox`, Bash, passwordless sudo, and membership in the `sudo` and

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -1474,10 +1474,20 @@ func (c *CoordinatorClient) Pool(ctx context.Context, cfg Config) ([]Coordinator
 }
 
 func (c *CoordinatorClient) Leases(ctx context.Context, state string, limit int) ([]CoordinatorLease, error) {
+	return c.listLeases(ctx, state, limit, "", "")
+}
+
+func (c *CoordinatorClient) listLeases(ctx context.Context, state string, limit int, view, provider string) ([]CoordinatorLease, error) {
 	var res struct {
 		Leases []CoordinatorLease `json:"leases"`
 	}
 	values := url.Values{}
+	if view != "" {
+		values.Set("view", view)
+	}
+	if provider != "" {
+		values.Set("provider", provider)
+	}
 	if state != "" {
 		values.Set("state", state)
 	}

--- a/internal/cli/coordinator_budget_test.go
+++ b/internal/cli/coordinator_budget_test.go
@@ -147,6 +147,8 @@ func TestCoordinatorHeartbeatHonorsCallerDeadlineWithoutReplay(t *testing.T) {
 
 func TestCoordinatorReadCurlFallbackSharesCallerDeadline(t *testing.T) {
 	clearConfigEnv(t)
+	// Keep the HTTP deadline independent of local git process startup.
+	t.Setenv("CRABBOX_OWNER", "alice@example.com")
 	if _, err := exec.LookPath("curl"); err != nil {
 		t.Skip("curl is unavailable")
 	}

--- a/internal/cli/coordinator_kept_lease_test.go
+++ b/internal/cli/coordinator_kept_lease_test.go
@@ -1,0 +1,155 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCoordinatorAcquireRejectsUnrelatedLeaseBeforeBootstrapOrCleanup(t *testing.T) {
+	for _, fixed := range []bool{false, true} {
+		for _, kept := range []bool{false, true} {
+			t.Run(fmt.Sprintf("fixed=%v/kept=%v", fixed, kept), func(t *testing.T) {
+				isolateTestUserDirs(t)
+				const heldID = "cbx_111111111111"
+				heldKey, _, err := ensureTestboxKeyForConfig(baseConfig(), heldID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				original, err := os.ReadFile(heldKey)
+				if err != nil {
+					t.Fatal(err)
+				}
+				calls := 0
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					calls++
+					if calls != 1 || (r.Method != http.MethodPost && r.Method != http.MethodPut) || strings.Contains(r.URL.Path, "release") || strings.Contains(r.URL.Path, "cancel-create") {
+						t.Errorf("unexpected request after mismatched create: %s %s", r.Method, r.URL.Path)
+						http.Error(w, "unexpected", http.StatusBadRequest)
+						return
+					}
+					_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+						ID: heldID, Slug: "kept-desktop", Provider: "aws", TargetOS: targetMacOS,
+						Keep: kept, State: "active", CloudID: "i-kept", ServerID: 0,
+						Host: "127.0.0.1", SSHPort: "1", SSHUser: "crabbox",
+					}})
+				}))
+				defer server.Close()
+				cfg := baseConfig()
+				cfg.Provider, cfg.TargetOS = "aws", targetMacOS
+				cfg.Coordinator, cfg.CoordToken = server.URL, "synthetic-token"
+				cfg.AWSSSHCIDRs = []string{"203.0.113.7/32"}
+				var stderr bytes.Buffer
+				backend := &coordinatorLeaseBackend{cfg: cfg, coord: mustNewCoordinatorClient(t, cfg), rt: Runtime{Stderr: &stderr}}
+				req := AcquireRequest{Keep: true, RequestedSlug: "new-warmup", OnAcquired: func(LeaseTarget) error { t.Error("unexpected acquisition"); return nil }}
+				if fixed {
+					req.RequestedLeaseID = "cbx_222222222222"
+				}
+				_, err = backend.Acquire(t.Context(), req)
+				if !isCoordinatorLeaseIDConflict(err) || !strings.Contains(err.Error(), heldID) || !strings.Contains(err.Error(), "kept-desktop") {
+					t.Fatalf("err=%v", err)
+				}
+				if calls != 1 || strings.Contains(stderr.String(), "leased "+heldID) {
+					t.Fatalf("calls=%d stderr=%s", calls, &stderr)
+				}
+				after, err := os.ReadFile(heldKey)
+				if err != nil || !bytes.Equal(after, original) {
+					t.Fatal("unrelated lease key changed")
+				}
+			})
+		}
+	}
+}
+
+func TestCoordinatorCreateIdentityMismatchNeverCancelsLegacyAdoption(t *testing.T) {
+	for _, stage := range []string{"initial", "recovery", "activation"} {
+		t.Run(stage, func(t *testing.T) {
+			oldInterval := coordinatorCreateLeaseRecoveryInterval
+			coordinatorCreateLeaseRecoveryInterval = time.Millisecond
+			defer func() { coordinatorCreateLeaseRecoveryInterval = oldInterval }()
+			const requestedID = "cbx_222222222222"
+			creates, gets, mutations := 0, 0, 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				lease := CoordinatorLease{ID: "cbx_111111111111", Slug: "kept-desktop", Keep: true, Provider: "aws", TargetOS: targetMacOS, State: "active", Host: "127.0.0.1"}
+				switch {
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/leases":
+					creates++
+					if stage == "recovery" && creates == 1 {
+						http.Error(w, "uncertain", http.StatusInternalServerError)
+						return
+					}
+					if stage == "activation" {
+						lease.ID, lease.State, lease.Host = requestedID, "provisioning", ""
+					}
+				case r.Method == http.MethodGet:
+					gets++
+				default:
+					mutations++
+					http.Error(w, "must not cancel a cross-ID binding", http.StatusBadRequest)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+			}))
+			defer server.Close()
+			cfg := baseConfig()
+			cfg.Provider, cfg.TargetOS = "aws", targetMacOS
+			cfg.Coordinator, cfg.CoordToken = server.URL, "synthetic-token"
+			backend := &coordinatorLeaseBackend{cfg: cfg, coord: mustNewCoordinatorClient(t, cfg), rt: Runtime{Stderr: &bytes.Buffer{}}}
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			defer cancel()
+			_, err := backend.createCoordinatorLeaseWithProgress(ctx, cfg, "ssh-ed25519 synthetic", true, requestedID, "new-warmup")
+			if !isCoordinatorLeaseIDConflict(err) || mutations != 0 {
+				t.Fatalf("err=%v mutations=%d", err, mutations)
+			}
+			if stage == "activation" && gets != 1 {
+				t.Fatalf("gets=%d", gets)
+			}
+			if stage == "recovery" && creates != 2 {
+				t.Fatalf("creates=%d", creates)
+			}
+		})
+	}
+}
+
+func TestCoordinatorListIncludesRetainedLeasesInTextAndJSON(t *testing.T) {
+	retained, deleted := false, true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("state") != "" || r.URL.Query().Get("view") != "current" || r.URL.Query().Get("provider") != "aws" {
+			t.Errorf("query=%s", r.URL.RawQuery)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"leases": []CoordinatorLease{
+			{ID: "cbx_active", Provider: "aws", State: "active"},
+			{ID: "cbx_kept", Slug: "kept-desktop", Provider: "aws", State: "released", Keep: true, ReleaseDeletesServer: &retained},
+			{ID: "cbx_retained", Provider: "aws", State: "released", ReleaseDeletesServer: &retained},
+			{ID: "cbx_deleted", Provider: "aws", State: "released", Keep: true, ReleaseDeletesServer: &deleted, CleanupStatus: "complete", CleanupCompletedAt: "2026-01-01T00:00:00Z"},
+			{ID: "cbx_ended", Provider: "aws", State: "expired"},
+			{ID: "cbx_other", Provider: "azure", State: "active", Keep: true},
+		}})
+	}))
+	defer server.Close()
+	cfg := baseConfig()
+	cfg.Provider, cfg.Coordinator, cfg.CoordToken = "aws", server.URL, "synthetic-token"
+	backend := &coordinatorLeaseBackend{cfg: cfg, coord: mustNewCoordinatorClient(t, cfg), rt: Runtime{Stderr: &bytes.Buffer{}}}
+	servers, err := backend.List(t.Context(), ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 3 || servers[1].Labels["lease"] != "cbx_kept" || servers[1].Labels["slug"] != "kept-desktop" {
+		t.Fatalf("servers=%#v", servers)
+	}
+	result, err := backend.ListJSON(t.Context(), ListRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	leases := result.([]CoordinatorLease)
+	if len(leases) != 3 || leases[1].ID != "cbx_kept" || !leases[1].Keep {
+		t.Fatalf("leases=%#v", leases)
+	}
+}

--- a/internal/cli/lease.go
+++ b/internal/cli/lease.go
@@ -275,35 +275,6 @@ func UseLeaseKnownHosts(target *SSHTarget, leaseID string) error {
 	return useLeaseKnownHosts(target, leaseID)
 }
 
-func moveStoredTestboxKey(oldLeaseID, newLeaseID string) error {
-	if oldLeaseID == "" || newLeaseID == "" || oldLeaseID == newLeaseID {
-		return nil
-	}
-	oldPath, err := testboxKeyPath(oldLeaseID)
-	if err != nil {
-		return err
-	}
-	newPath, err := testboxKeyPath(newLeaseID)
-	if err != nil {
-		return err
-	}
-	oldDir := filepath.Dir(oldPath)
-	newDir := filepath.Dir(newPath)
-	if _, err := os.Stat(oldPath); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
-		return err
-	}
-	if _, err := os.Stat(newPath); err == nil {
-		return nil
-	}
-	if err := os.MkdirAll(filepath.Dir(newDir), 0o700); err != nil {
-		return err
-	}
-	return os.Rename(oldDir, newDir)
-}
-
 func removeStoredTestboxKey(leaseID string) {
 	_ = removeStoredTestboxConnectionArtifacts(context.Background(), leaseID)
 }

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -276,11 +276,6 @@ func (b *coordinatorLeaseBackend) acquireOnceWithLeaseID(ctx context.Context, ke
 		}
 		return LeaseTarget{}, err
 	}
-	if lease.ID != "" && lease.ID != leaseID {
-		if err := moveStoredTestboxKey(leaseID, lease.ID); err != nil {
-			fmt.Fprintf(b.rt.Stderr, "warning: could not move local key from %s to %s: %v\n", leaseID, lease.ID, err)
-		}
-	}
 	if err := validateCoordinatorLeaseCapabilities(cfg, lease); err != nil {
 		if requestedLeaseID == "" {
 			cleanupLeaseID := blank(lease.ID, leaseID)
@@ -509,9 +504,14 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx con
 		}
 	}()
 	cancelOnError := false
+	identityMismatch := false
 	defer func() {
 		stopProgress()
 		<-progressDone
+		if identityMismatch {
+			lease = CoordinatorLease{}
+			return
+		}
 		if ctx.Err() != nil {
 			lease = CoordinatorLease{}
 			err = b.canceledCoordinatorLeaseCreateError(ctx, leaseID, slug, createAttemptID, fixed, err)
@@ -550,16 +550,22 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx con
 			return CoordinatorLease{}, err
 		}
 	}
+	identityMismatch = lease.ID != leaseID
+	if identityMismatch {
+		return CoordinatorLease{}, b.validateCoordinatorLeaseCreateResult(cfg, lease, leaseID)
+	}
 	if err := createCtx.Err(); err != nil {
 		return CoordinatorLease{}, err
 	}
 	cancelOnError = true
-	if err := b.validateCoordinatorLeaseCreateResult(cfg, lease, leaseID, fixed); err != nil {
+	if err := b.validateCoordinatorLeaseCreateResult(cfg, lease, leaseID); err != nil {
 		return CoordinatorLease{}, err
 	}
 	if lease.State == "provisioning" {
 		// Rebinding only confirms the operation. Readiness uses the original deadline.
-		return b.waitForCoordinatorLeaseActivation(createCtx, cfg, lease.ID, lease)
+		lease, err = b.waitForCoordinatorLeaseActivation(createCtx, cfg, lease.ID, lease)
+		identityMismatch = isCoordinatorLeaseIDConflict(err)
+		return lease, err
 	}
 	if rebound && lease.State == "active" && lease.Host == "" {
 		return CoordinatorLease{}, fmt.Errorf("coordinator replay returned active lease %s without an endpoint", lease.ID)
@@ -567,9 +573,18 @@ func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgressMode(ctx con
 	return lease, coordinatorLeaseProvisioningError(lease)
 }
 
-func (b *coordinatorLeaseBackend) validateCoordinatorLeaseCreateResult(cfg Config, lease CoordinatorLease, requestedLeaseID string, fixed bool) error {
-	if fixed && lease.ID != requestedLeaseID {
-		return exit(4, "lease_id_conflict: coordinator returned lease %s for operation %s", blank(lease.ID, "<empty>"), requestedLeaseID)
+type coordinatorLeaseIDConflict struct{ err error }
+
+func (e coordinatorLeaseIDConflict) Error() string { return e.err.Error() }
+func (e coordinatorLeaseIDConflict) Unwrap() error { return e.err }
+func isCoordinatorLeaseIDConflict(err error) bool {
+	var conflict coordinatorLeaseIDConflict
+	return errors.As(err, &conflict)
+}
+
+func (b *coordinatorLeaseBackend) validateCoordinatorLeaseCreateResult(cfg Config, lease CoordinatorLease, requestedLeaseID string) error {
+	if lease.ID != requestedLeaseID {
+		return coordinatorLeaseIDConflict{err: exit(4, "lease_id_conflict: coordinator returned lease %s (slug %s) for operation %s; no bootstrap or cleanup was attempted", blank(lease.ID, "<empty>"), blank(lease.Slug, "-"), requestedLeaseID)}
 	}
 	if strings.TrimSpace(lease.ID) == "" {
 		return exit(4, "coordinator create returned an empty canonical lease id for operation %s", requestedLeaseID)
@@ -728,7 +743,7 @@ func (b *coordinatorLeaseBackend) waitForCoordinatorLeaseActivation(ctx context.
 				continue
 			}
 			// GET observes the confirmed canonical lease; it cannot remap identity.
-			if err := b.validateCoordinatorLeaseCreateResult(cfg, lease, leaseID, true); err != nil {
+			if err := b.validateCoordinatorLeaseCreateResult(cfg, lease, leaseID); err != nil {
 				return CoordinatorLease{}, err
 			}
 			current = lease
@@ -992,12 +1007,23 @@ func (b *coordinatorLeaseBackend) ListJSON(ctx context.Context, req ListRequest)
 }
 
 func (b *coordinatorLeaseBackend) listUserLeases(ctx context.Context) ([]CoordinatorLease, error) {
-	leases, err := b.coord.Leases(ctx, "active", 1000)
+	leases, err := b.coord.listLeases(ctx, "", 1000, "current", b.cfg.Provider)
 	if err != nil {
 		return nil, err
 	}
+	if len(leases) >= 1000 {
+		fmt.Fprintln(b.rt.Stderr, "warning: coordinator list reached its 1000-lease limit; older kept leases may be omitted; inspect them by exact lease ID")
+	}
+	// Older coordinators ignore view=current and return ended history too.
+	current := make([]CoordinatorLease, 0, len(leases))
+	for _, lease := range leases {
+		retained := lease.Keep || lease.ReleaseDeletesServer != nil && !*lease.ReleaseDeletesServer
+		if lease.State == "active" || lease.State == "provisioning" || retained && !coordinatorProviderReleaseConfirmed(lease) {
+			current = append(current, lease)
+		}
+	}
 	return redactCoordinatorLeaseListSecrets(
-		filterCoordinatorLeasesForProvider(leases, b.cfg.Provider),
+		filterCoordinatorLeasesForProvider(current, b.cfg.Provider),
 	), nil
 }
 

--- a/internal/cli/provider_coordinator_async_test.go
+++ b/internal/cli/provider_coordinator_async_test.go
@@ -47,11 +47,8 @@ func newCoordinatorAsyncFixture(t *testing.T, fixed bool) *coordinatorAsyncFixtu
 	t.Setenv("CRABBOX_OWNER", "alice@example.com")
 	f := &coordinatorAsyncFixture{
 		t: t, fixed: fixed, started: time.Now(),
-		requested: "cbx_abcdef123456", canonical: "cbx_abcdef123457",
+		requested: "cbx_abcdef123456", canonical: "cbx_abcdef123456",
 		cfg: Config{Provider: "azure", TargetOS: targetWindows, WindowsMode: windowsModeNormal},
-	}
-	if fixed {
-		f.canonical = f.requested
 	}
 	f.backend = &coordinatorLeaseBackend{
 		cfg: f.cfg, rt: Runtime{Stderr: &f.stderr},
@@ -326,9 +323,6 @@ func TestCoordinatorAsyncRejectsIdentityMismatchBeforeFurtherPolling(t *testing.
 		for _, replay := range []bool{false, true} {
 			for _, stage := range []string{"accepted", "poll"} {
 				for _, field := range []string{"id", "empty id", "provider", "unknown provider", "target", "windows mode"} {
-					if !fixed && stage == "accepted" && field == "id" {
-						continue // Ordinary POST is authoritative for canonical remapping.
-					}
 					t.Run(fmt.Sprintf("fixed=%t/replay=%t/%s/%s", fixed, replay, stage, field), func(t *testing.T) {
 						synctest.Test(t, func(t *testing.T) {
 							f := newCoordinatorAsyncFixture(t, fixed)
@@ -369,7 +363,7 @@ func TestCoordinatorAsyncRejectsIdentityMismatchBeforeFurtherPolling(t *testing.
 							if stage == "poll" {
 								wantGets = 1
 							}
-							if fixed {
+							if fixed || field == "id" || field == "empty id" {
 								wantCancels = 0
 							}
 							if replay {

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -68,7 +68,7 @@ func TestCoordinatorListUsesUserLeasesWithoutAdminProbe(t *testing.T) {
 			t.Error("ordinary list must not probe the admin pool")
 			http.Error(w, "unexpected admin probe", http.StatusInternalServerError)
 		case "/v1/leases":
-			if got := r.URL.Query().Get("state"); got != "active" {
+			if got := r.URL.Query().Get("state"); got != "" {
 				t.Fatalf("leases state=%q", got)
 			}
 			if got := r.Header.Get("Authorization"); got != "Bearer user-token" {
@@ -175,7 +175,7 @@ func TestCoordinatorListJSONUsesUserLeasesWhenAdminTokenMissing(t *testing.T) {
 		if r.URL.Path != "/v1/leases" {
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
-		if got := r.URL.Query().Get("state"); got != "active" {
+		if got := r.URL.Query().Get("state"); got != "" {
 			t.Fatalf("leases state=%q", got)
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"leases": []CoordinatorLease{
@@ -1037,54 +1037,6 @@ func TestCoordinatorAcquireRetainsCurrentProvisioningTiming(t *testing.T) {
 	want := coordinatorRunnerTiming(lease)
 	if !reflect.DeepEqual(acquired.runnerTiming, want) {
 		t.Fatalf("runner timing=%#v want current provisioning timing %#v", acquired.runnerTiming, want)
-	}
-}
-
-func TestCoordinatorAcquirePollsCanonicalIDFromProvisioningReplay(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	oldInterval := coordinatorCreateLeaseRecoveryInterval
-	coordinatorCreateLeaseRecoveryInterval = time.Millisecond
-	defer func() { coordinatorCreateLeaseRecoveryInterval = oldInterval }()
-
-	const requestedID = "cbx_abcdef123456"
-	const canonicalID = "cbx_abcdef123457"
-	gets := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases":
-			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
-				ID: canonicalID, Slug: "retained-canonical", Provider: "aws", TargetOS: targetLinux, State: "provisioning",
-			}})
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/"+canonicalID:
-			gets++
-			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
-				ID: canonicalID, Slug: "retained-canonical", Provider: "aws", TargetOS: targetLinux,
-				State: "active", CloudID: "i-retained", Host: "203.0.113.10", SSHUser: "crabbox", SSHPort: "2222", WorkRoot: defaultPOSIXWorkRoot,
-			}})
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/"+requestedID:
-			t.Fatalf("polled provisional ID instead of canonical ID")
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer server.Close()
-
-	cfg := baseConfig()
-	cfg.Provider = "aws"
-	cfg.TargetOS = targetLinux
-	cfg.Coordinator = server.URL
-	cfg.CoordToken = "user-token"
-	coord := mustNewCoordinatorClient(t, cfg)
-	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: &bytes.Buffer{}}}
-	lease, err := backend.createCoordinatorLeaseWithProgressMode(
-		context.Background(), cfg, "ssh-ed25519 test", true, requestedID, "retained-canonical", false,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if lease.ID != canonicalID || lease.CloudID != "i-retained" || gets == 0 {
-		t.Fatalf("lease=%#v gets=%d", lease, gets)
 	}
 }
 
@@ -2106,7 +2058,7 @@ func TestCoordinatorCreateLeaseRecoversWithSameTokenBoundPost(t *testing.T) {
 	}()
 
 	var createdLeaseID string
-	const canonicalLeaseID = "cbx_recovered_canonical"
+	const canonicalLeaseID = "cbx_recover"
 	var createAttemptID string
 	posts := 0
 	gets := 0
@@ -2327,7 +2279,7 @@ func TestCoordinatorRecoveredProvisioningKeepsCreationLifetime(t *testing.T) {
 			t.Run(fmt.Sprintf("fixed=%v/%s", fixed, test.name), func(t *testing.T) {
 				synctest.Test(t, func(t *testing.T) {
 					const requestedID = "cbx_abcdef123463"
-					canonicalID := "cbx_abcdef123464"
+					canonicalID := requestedID
 					target := targetMacOS
 					createMethod, createPath := http.MethodPost, "/v1/leases"
 					if fixed {
@@ -2811,7 +2763,7 @@ func TestCoordinatorCreateCanonicalProviderMatching(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			lease := base
 			lease.Provider = test.provider
-			if got := backend.validateCoordinatorLeaseCreateResult(cfg, lease, lease.ID, false) == nil; got != test.want {
+			if got := backend.validateCoordinatorLeaseCreateResult(cfg, lease, lease.ID) == nil; got != test.want {
 				t.Fatalf("recovered=%t want %t for provider=%q", got, test.want, test.provider)
 			}
 		})

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -3070,7 +3070,7 @@ func TestCoordinatorAcquireProviderMismatchCleanupPolicy(t *testing.T) {
 					capturedRequestedID, _ = body["leaseID"].(string)
 					createAttemptID, _ = body["createAttemptID"].(string)
 					_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
-						ID: test.wantLease, Provider: "external", TargetOS: targetLinux, State: "active",
+						ID: capturedRequestedID, Provider: "external", TargetOS: targetLinux, State: "active",
 					}})
 				case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/"+capturedRequestedID+"/cancel-create":
 					cancellations++
@@ -3093,7 +3093,7 @@ func TestCoordinatorAcquireProviderMismatchCleanupPolicy(t *testing.T) {
 				operationID = test.wantLease
 			}
 			_, err := backend.acquireOnceWithLeaseID(context.Background(), false, operationID, "identity-fence")
-			assertCoordinatorProviderIdentityError(t, err, "external", test.wantLease)
+			assertCoordinatorProviderIdentityError(t, err, "external", capturedRequestedID)
 			if cancellations != test.wantCancels {
 				t.Fatalf("cancel-create requests=%d want %d", cancellations, test.wantCancels)
 			}

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -6230,36 +6230,6 @@ func TestServerProviderKeyUsesOnlyCrabboxLeaseKeys(t *testing.T) {
 	}
 }
 
-func TestMoveStoredTestboxKeyHandlesCoordinatorRenamedLease(t *testing.T) {
-	isolateTestUserDirs(t)
-	oldPath, err := testboxKeyPath("cbx_111111111111")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Dir(oldPath), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(oldPath, []byte("key"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(oldPath+".pub", []byte("pub"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := moveStoredTestboxKey("cbx_111111111111", "cbx_222222222222"); err != nil {
-		t.Fatal(err)
-	}
-	newPath, err := testboxKeyPath("cbx_222222222222")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := os.Stat(newPath); err != nil {
-		t.Fatalf("moved key missing: %v", err)
-	}
-	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
-		t.Fatalf("old key still exists or unexpected stat error: %v", err)
-	}
-}
-
 func mustWriteTestFile(t *testing.T, path, value string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/cli/sync_git_overlay_test.go
+++ b/internal/cli/sync_git_overlay_test.go
@@ -4045,7 +4045,7 @@ func TestRunMissingOriginReplacementLeaseStaysPlainManifest(t *testing.T) {
 		t.Fatal(err)
 	}
 	remoteRoot := filepath.Join(testRoot, "remote")
-	leaseIDs := []string{"cbx_missing_first", "cbx_missing_replacement"}
+	var leaseIDs [2]string
 	providerName := runReadyPoolPreflightTestProvider{}.Name()
 	var (
 		acquires atomic.Int32
@@ -4096,12 +4096,22 @@ func TestRunMissingOriginReplacementLeaseStaysPlainManifest(t *testing.T) {
 			mu.Unlock()
 			_ = json.NewEncoder(w).Encode(map[string]any{"receipt": stored})
 		case request.Method == http.MethodPost && request.URL.Path == "/v1/leases":
+			var body struct {
+				ID string `json:"leaseID"`
+			}
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil || body.ID == "" {
+				http.Error(w, "missing requested lease ID", http.StatusBadRequest)
+				return
+			}
 			index := int(acquires.Add(1)) - 1
 			if index >= len(leaseIDs) {
 				http.Error(w, "unexpected acquisition", http.StatusInternalServerError)
 				return
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease(leaseIDs[index], "active")})
+			mu.Lock()
+			leaseIDs[index] = body.ID
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease(body.ID, "active")})
 		case request.Method == http.MethodGet && strings.HasPrefix(request.URL.Path, "/v1/leases/"):
 			id := strings.TrimPrefix(request.URL.Path, "/v1/leases/")
 			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease(id, "active")})
@@ -4198,7 +4208,13 @@ done <"$tmp"
 			t.Fatalf("replacement plain manifest ran forbidden Git path %q:\n%s", forbidden, commands)
 		}
 	}
-	for _, id := range leaseIDs {
+	mu.Lock()
+	createdIDs := leaseIDs
+	mu.Unlock()
+	if createdIDs[0] == createdIDs[1] {
+		t.Fatal("replacement reused the original lease ID")
+	}
+	for _, id := range createdIDs {
 		metaDir := filepath.Join(remoteRoot, id, repo.Name, ".crabbox")
 		if _, err := os.Stat(filepath.Join(metaDir, "sync-manifest")); err != nil {
 			t.Fatalf("%s manifest: %v", id, err)

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -25096,7 +25096,10 @@ function pinnedHostConflict(config: LeaseConfig, leases: LeaseRecord[]): Respons
       (!lease.region || lease.region === providerRegionForConfig(config)) &&
       (leaseIsLive(lease) ||
         (!leaseProviderCleanupConfirmed(lease) &&
-          (Boolean(lease.cloudID) || lease.provisioningResourceMayExist === true))),
+          (lease.keep ||
+            lease.releaseDeletesServer === false ||
+            Boolean(lease.cloudID) ||
+            lease.provisioningResourceMayExist === true))),
   );
   if (!occupied) return undefined;
   return json(

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -3884,64 +3884,15 @@ export class FleetCoordinator {
       );
     }
     const requestedHostID = config.hostID || config.awsMacHostID;
-    const retainedMacHostLease =
-      !fixedLeaseID && requestedHostID && config.provider === "aws" && config.target === "macos"
-        ? await this.retainedMacHostLease(
-            owner,
-            org,
-            requestedHostID,
-            config.serverTypeExplicit ? config.serverType : undefined,
-          )
-        : undefined;
-    const reusesOwnedReleasedMacHost = Boolean(retainedMacHostLease);
-    if (
-      !isAdminRequest(request) &&
-      requestedHostID &&
-      !reusesOwnedReleasedMacHost &&
-      requestedHostID !== checkpointAuthorization?.checkpoint.hostID
-    ) {
-      return json(
-        {
-          error: "admin_required",
-          message: "provider host pinning requires admin-token auth",
-        },
-        { status: 403 },
-      );
-    }
-    if (retainedMacHostLease) {
-      if (hasImageRequirements(config.imageRequirements)) {
-        return json(
-          {
-            error: "image_capability_mismatch",
-            message: "image capability requirements cannot be verified when reusing an instance",
-          },
-          { status: 409 },
-        );
-      }
-      const missingCapabilities = [
-        config.desktop && !retainedMacHostLease.desktop ? "desktop" : "",
-        config.browser && !retainedMacHostLease.browser ? "browser" : "",
-        config.code && !retainedMacHostLease.code ? "code" : "",
-      ].filter(Boolean);
-      if (missingCapabilities.length > 0) {
-        return json(
-          {
-            error: "retained_instance_capability_mismatch",
-            message: `retained EC2 Mac instance lacks requested capabilities: ${missingCapabilities.join(", ")}`,
-          },
-          { status: 409 },
-        );
-      }
-    }
-    if (retainedMacHostLease && !config.serverTypeExplicit) {
-      config = { ...config, serverType: retainedMacHostLease.serverType };
-    }
-    if (retainedMacHostLease) {
-      config = { ...config, providerKey: retainedMacHostLease.providerKey };
-    }
+    const hostPinError = await this.validateHostPin(
+      request,
+      config,
+      checkpointAuthorization?.checkpoint.hostID,
+    );
+    if (hostPinError) return hostPinError;
     const canonicalProviderKey = providerKeyForLease(leaseID);
     const providerKeyLeaseID = leaseIDForProviderKey(config.providerKey);
-    if (!retainedMacHostLease && providerKeyLeaseID && providerKeyLeaseID !== leaseID) {
+    if (providerKeyLeaseID && providerKeyLeaseID !== leaseID) {
       return json(
         {
           error: "reserved_provider_key",
@@ -3952,7 +3903,6 @@ export class FleetCoordinator {
     }
     if (
       !workspaceID &&
-      !retainedMacHostLease &&
       !isAdminRequest(request) &&
       config.providerKey &&
       config.providerKey !== canonicalProviderKey
@@ -4091,230 +4041,6 @@ export class FleetCoordinator {
         fixedCreate,
       );
     }
-    if (!workspaceID && retainedMacHostLease) {
-      const reactivation = await this.state.runExclusive(async () => {
-        const reservedAttempt = await this.getCreateAttempt(leaseID);
-        const currentAttempt = createAttempt
-          ? await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org)
-          : undefined;
-        if (currentAttempt?.canonicalLeaseID) {
-          const replayLease = await this.getLease(currentAttempt.canonicalLeaseID);
-          if (!replayLease || !createAttemptMatchesLease(currentAttempt, replayLease)) {
-            return createAttemptBindingConflictResponse();
-          }
-          return createAttemptReplayResponse(replayLease);
-        }
-        if (createAttempt && !currentAttempt) {
-          return createCanceledResponse();
-        }
-        if (!createAttempt && reservedAttempt) {
-          return createAttemptIDConflictResponse();
-        }
-        const current = await this.getLease(retainedMacHostLease.id);
-        if (
-          !current ||
-          current.state !== "released" ||
-          current.releaseDeletesServer !== false ||
-          !current.cloudID ||
-          current.owner !== owner ||
-          current.org !== org ||
-          current.provider !== "aws" ||
-          current.target !== "macos" ||
-          leaseHostID(current) !== requestedHostID ||
-          current.serverType !== config.serverType
-        ) {
-          return undefined;
-        }
-        if (
-          (await this.getLease(leaseID)) ||
-          (await this.state.storage.get(workspaceLeaseReservationKey(leaseID)))
-        ) {
-          return createAttemptIDConflictResponse();
-        }
-        const blocked = await reservationGuard?.();
-        if (blocked) {
-          return blocked;
-        }
-        const now = new Date();
-        const admission = await this.leaseAdmissionState({ owner, org }, now, current.id);
-        const createAttemptGeneration = newCreateAttemptGeneration();
-        const boundAttempt: CreateAttemptRecord | undefined = currentAttempt
-          ? {
-              ...currentAttempt,
-              canonicalLeaseID: current.id,
-              cloudID: current.cloudID,
-              generation: createAttemptGeneration!,
-              updatedAt: now.toISOString(),
-            }
-          : undefined;
-        let reactivated: LeaseRecord = {
-          ...current,
-          ...(checkpointAuthorization
-            ? { checkpointID: checkpointAuthorization.checkpoint.id }
-            : {}),
-          createAttemptGeneration,
-          ...(boundAttempt
-            ? {
-                createAttemptID: boundAttempt.token,
-              }
-            : {}),
-          profile: config.profile,
-          class: config.class,
-          requestedServerType: config.serverType,
-          keep: config.keep,
-          ttlSeconds: config.ttlSeconds,
-          idleTimeoutSeconds: config.idleTimeoutSeconds,
-          estimatedHourlyUSD: cost.hourlyUSD,
-          maxEstimatedUSD: cost.maxUSD,
-          state: "provisioning",
-          createdAt: now.toISOString(),
-          updatedAt: now.toISOString(),
-          lastTouchedAt: now.toISOString(),
-          expiresAt: leaseExpiresAt(
-            now,
-            now,
-            config.ttlSeconds,
-            config.idleTimeoutSeconds,
-          ).toISOString(),
-        };
-        if (!boundAttempt) {
-          delete reactivated.createAttemptID;
-        }
-        const sourceCIDRs = awsLeaseSSHSourceCIDRs(
-          config,
-          providerAccessContext(requestSourceCIDRs(request), admission.accessLeases),
-        );
-        reactivated = withLeaseSSHSourceCIDRs(
-          reactivated,
-          sourceCIDRs,
-          sourceCIDRs.length > 0 || awsGlobalSSHSourceCIDRs(this.env).length > 0,
-        );
-        if (config.awsSSHCIDRsPinned) {
-          reactivated.network = {
-            ...reactivated.network,
-            sshPinnedSourceCIDRs: sourceCIDRs,
-          };
-        } else if (reactivated.network) {
-          delete reactivated.network.sshPinnedSourceCIDRs;
-        }
-        delete reactivated.releasedAt;
-        delete reactivated.endedAt;
-        delete reactivated.releaseDeletesServer;
-        delete reactivated.failureError;
-        delete reactivated.provisioningRequestStartedAt;
-        delete reactivated.provisioningCoordinatorVersion;
-        delete reactivated.provisioningRequestSettledAt;
-        delete reactivated.provisioningRecoveryObservedAt;
-        delete reactivated.provisioningRecoveryMissingSince;
-        clearLeaseCleanupMetadata(reactivated);
-        clearLeaseCleanupCompletion(reactivated);
-        const limitError = enforceCostLimitUsage(
-          admission.costUsage,
-          reactivated,
-          costLimits(this.env),
-        );
-        if (limitError) {
-          return json({ error: "cost_limit_exceeded", message: limitError }, { status: 429 });
-        }
-        if (boundAttempt) {
-          await this.putCreateAttempt(boundAttempt);
-        }
-        await this.putLease(reactivated);
-        await this.markAWSIngressReconcilePending(reactivated);
-        await this.scheduleAlarm();
-        return {
-          previous: structuredClone(current),
-          previousAttempt: currentAttempt ? structuredClone(currentAttempt) : undefined,
-          boundAttempt: boundAttempt ? structuredClone(boundAttempt) : undefined,
-          reactivated,
-        };
-      });
-      if (reactivation instanceof Response) {
-        return reactivation;
-      }
-      if (reactivation) {
-        try {
-          if (provider.reconcileLeaseAccess) {
-            const accessLeases = await this.providerAccessLeaseRecords();
-            await this.withAWSIngressOperationLock(() =>
-              provider.reconcileLeaseAccess!(
-                reactivation.reactivated,
-                providerAccessContext(requestSourceCIDRs(request), accessLeases),
-              ),
-            );
-          }
-        } catch (error) {
-          await this.state.runExclusive(async () => {
-            const current = await this.getLease(reactivation.reactivated.id);
-            if (
-              current?.state === "provisioning" &&
-              sameLeaseReleaseIdentity(current, reactivation.reactivated)
-            ) {
-              await this.putLease(reactivation.previous);
-              if (reactivation.boundAttempt) {
-                const currentAttempt = await this.getCreateAttempt(
-                  reactivation.boundAttempt.requestedLeaseID,
-                );
-                if (
-                  currentAttempt &&
-                  sameCreateAttempt(currentAttempt, reactivation.boundAttempt)
-                ) {
-                  if (reactivation.previousAttempt) {
-                    await this.putCreateAttempt(reactivation.previousAttempt);
-                  } else {
-                    await this.state.storage.delete(
-                      createAttemptKey(reactivation.boundAttempt.requestedLeaseID),
-                    );
-                  }
-                }
-              }
-              await this.scheduleAlarm();
-            }
-          });
-          throw error;
-        }
-        const activation = await this.state.runExclusive(async () => {
-          const current = await this.getLease(reactivation.reactivated.id);
-          const pending = createAttempt
-            ? await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org)
-            : undefined;
-          if (
-            !current ||
-            current.state !== "provisioning" ||
-            !sameLeaseReleaseIdentity(current, reactivation.reactivated) ||
-            (createAttempt && (!pending || !createAttemptMatchesLease(pending, current)))
-          ) {
-            return { committed: false as const, current, pending };
-          }
-          current.state = "active";
-          current.updatedAt = new Date().toISOString();
-          await this.putLease(current);
-          await this.scheduleAlarm();
-          return { committed: true as const, current };
-        });
-        if (!activation.committed) {
-          if (createAttempt && !activation.pending) {
-            return createCanceledResponse();
-          }
-          return json(
-            {
-              error: "lease_state_changed",
-              message: "retained lease changed state while access reconciliation was in progress",
-              lease: activation.current ? publicLeaseRecord(activation.current) : undefined,
-            },
-            { status: 409 },
-          );
-        }
-        return json({ lease: publicLeaseRecord(activation.current) }, { status: 201 });
-      }
-      return json(
-        {
-          error: "retained_instance_unavailable",
-          message: "retained EC2 Mac instance is no longer available for reactivation",
-        },
-        { status: 409 },
-      );
-    }
     const reservation = await this.state.runExclusive(async () => {
       const reservedAttempt = await this.getCreateAttempt(leaseID);
       const currentAttempt = createAttempt
@@ -4362,6 +4088,12 @@ export class FleetCoordinator {
           { status: 409 },
         );
       }
+      const reservationHostError = await this.validateHostPin(
+        request,
+        config,
+        checkpointAuthorization?.checkpoint.hostID,
+      );
+      if (reservationHostError) return reservationHostError;
       const now = new Date();
       const createAttemptGeneration = currentAttempt ? newCreateAttemptGeneration() : undefined;
       const admission = await this.leaseAdmissionState({ owner, org }, now);
@@ -5026,6 +4758,9 @@ export class FleetCoordinator {
         serverID: 0,
         serverName: "",
         host: "",
+        ...(config.hostID || config.awsMacHostID
+          ? { hostId: config.hostID || config.awsMacHostID }
+          : {}),
         providerKey: config.providerKey,
         sshUser: config.sshUser,
         sshPort: config.sshPort,
@@ -5111,6 +4846,8 @@ export class FleetCoordinator {
       const storedLeases = [
         ...(await transaction.list<LeaseRecord>({ prefix: "lease:" })).values(),
       ];
+      const hostConflict = pinnedHostConflict(config, storedLeases);
+      if (hostConflict) return hostConflict;
       const providerAccess = [
         ...(await transaction.list<LeaseRecord>({ prefix: providerAccessPrefix() })).values(),
       ];
@@ -14255,7 +13992,15 @@ export class FleetCoordinator {
       const serverType = (url.searchParams.get("type") ?? "").trim();
       const state = (url.searchParams.get("state") ?? "").trim();
       const hosts = await client.listMacHosts(serverType, state);
-      return json({ hosts });
+      const allocatedHosts = await Promise.all(
+        hosts.map(async (host) => {
+          const allocation = await this.state.storage.get<AWSMacHostAllocation>(
+            awsMacHostAllocationKey(region, host.id),
+          );
+          return { ...host, ...(allocation ? { org: orgLabelForDisplay(allocation.org) } : {}) };
+        }),
+      );
+      return json({ hosts: allocatedHosts });
     }
     if (method === "POST" && hostID === "dry-run") {
       const input = await readJson<{
@@ -14348,9 +14093,16 @@ export class FleetCoordinator {
               offering.availabilityZone,
               `${clientToken}-${offering.availabilityZone.replaceAll("-", "")}`,
             );
-            return json(
-              { hosts, availabilityZone: offering.availabilityZone, offerings },
-              { status: 201 },
+            // Return the persistence promise without catching failures as AWS capacity failures.
+            return recordAWSMacHostAllocations(
+              this.state.storage,
+              hosts,
+              requestOrg(request, this.env),
+            ).then(() =>
+              json(
+                { hosts, availabilityZone: offering.availabilityZone, offerings },
+                { status: 201 },
+              ),
             );
           } catch (error) {
             const message = coordinatorErrorMessage(this.env, error);
@@ -14367,6 +14119,7 @@ export class FleetCoordinator {
         );
       }
       const hosts = await client.allocateMacHost(serverType, availabilityZone, clientToken);
+      await recordAWSMacHostAllocations(this.state.storage, hosts, requestOrg(request, this.env));
       return json({ hosts }, { status: 201 });
     }
     if (method === "DELETE" && hostID) {
@@ -14654,11 +14407,19 @@ export class FleetCoordinator {
   private filterLeasesWithoutLimit(leases: LeaseRecord[], request: Request): LeaseRecord[] {
     const url = new URL(request.url);
     const state = url.searchParams.get("state") ?? "";
+    const current = url.searchParams.get("view") === "current";
     const provider = url.searchParams.get("provider") ?? "";
     const owner = url.searchParams.get("owner") ?? "";
     const org = orgFilterKey(url);
     if (org === null) return [];
     return leases
+      .filter(
+        (lease) =>
+          !current ||
+          leaseIsLive(lease) ||
+          ((lease.keep || lease.releaseDeletesServer === false) &&
+            !leaseProviderCleanupConfirmed(lease)),
+      )
       .filter((lease) => !state || lease.state === state)
       .filter((lease) => !provider || lease.provider === provider)
       .filter((lease) => !owner || lease.owner === owner)
@@ -18046,31 +17807,33 @@ export class FleetCoordinator {
     return [...leases.values()];
   }
 
-  private async retainedMacHostLease(
-    owner: string,
-    org: string,
-    hostID: string,
-    serverType?: string,
-  ): Promise<LeaseRecord | undefined> {
-    let retained: LeaseRecord | undefined;
-    await this.visitLeaseRecords((lease) => {
-      if (
-        lease.state !== "released" ||
-        lease.releaseDeletesServer !== false ||
-        !lease.cloudID ||
-        lease.owner !== owner ||
-        lease.org !== org ||
-        lease.provider !== "aws" ||
-        lease.target !== "macos" ||
-        leaseHostID(lease) !== hostID ||
-        (serverType !== undefined && lease.serverType !== serverType) ||
-        (retained !== undefined && retained.updatedAt >= lease.updatedAt)
-      ) {
-        return;
-      }
-      retained = lease;
-    });
-    return retained;
+  private async validateHostPin(
+    request: Request,
+    config: LeaseConfig,
+    authorizedHostID?: string,
+  ): Promise<Response | undefined> {
+    const hostID = config.hostID || config.awsMacHostID;
+    if (!hostID) return undefined;
+    const provider = this.provider(
+      config.provider,
+      providerRegionForConfig(config),
+      providerProjectForConfig(config),
+    );
+    if (
+      !isAdminRequest(request) &&
+      hostID !== authorizedHostID &&
+      !(await provider.authorizeHostPin?.(config, requestOrg(request, this.env)))
+    ) {
+      return json(
+        {
+          error: "admin_required",
+          message:
+            "provider host pinning requires admin-token auth or a coordinator allocation for your organization",
+        },
+        { status: 403 },
+      );
+    }
+    return pinnedHostConflict(config, await this.leaseRecords());
   }
 
   private async leaseAdmissionState(
@@ -18501,8 +18264,9 @@ export class FleetCoordinator {
   }
 
   private filterLeasesForRequest(leases: LeaseRecord[], request: Request): LeaseRecord[] {
-    return this.filterLeases(leases, request).filter((lease) =>
-      this.leaseVisibleToRequest(lease, request, false),
+    return this.filterLeases(
+      leases.filter((lease) => this.leaseVisibleToRequest(lease, request, false)),
+      request,
     );
   }
 
@@ -21665,8 +21429,7 @@ function createAttemptMatchesLease(attempt: CreateAttemptRecord, lease: LeaseRec
         attempt.fixedCreate.hash === lease.fixedCreateIntentHash &&
         attempt.fixedCreate.provider === lease.provider)) &&
     createAttemptMatchesCheckpoint(attempt, lease.checkpointID, attempt.checkpointUseClaimHash) &&
-    (attempt.requestedLeaseID === lease.id ||
-      (lease.provider === "aws" && lease.target === "macos")) &&
+    attempt.requestedLeaseID === lease.id &&
     !lease.workspaceID &&
     !isRegisteredLease(lease)
   );
@@ -25323,6 +25086,28 @@ function isActiveProviderAccessRecord(lease: LeaseRecord, now: number): boolean 
   return leaseIsLive(lease) && Date.parse(lease.expiresAt) > now;
 }
 
+function pinnedHostConflict(config: LeaseConfig, leases: LeaseRecord[]): Response | undefined {
+  const hostID = config.hostID || config.awsMacHostID;
+  if (!hostID) return undefined;
+  const occupied = leases.find(
+    (lease) =>
+      lease.provider === config.provider &&
+      leaseHostID(lease) === hostID &&
+      (!lease.region || lease.region === providerRegionForConfig(config)) &&
+      (leaseIsLive(lease) ||
+        (!leaseProviderCleanupConfirmed(lease) &&
+          (Boolean(lease.cloudID) || lease.provisioningResourceMayExist === true))),
+  );
+  if (!occupied) return undefined;
+  return json(
+    {
+      error: "host_in_use",
+      message: `host ${hostID} is occupied by lease ${occupied.id} (slug ${occupied.slug || "-"}); inspect or explicitly stop that lease before creating another`,
+    },
+    { status: 409 },
+  );
+}
+
 function leaseIsLive(lease: LeaseRecord): boolean {
   return lease.state === "active" || lease.state === "provisioning";
 }
@@ -26573,6 +26358,7 @@ interface CloudProvider {
   ): ProviderWorkspaceCapability | undefined;
   supportsSSHHostKeyInjection(config: ReturnType<typeof leaseConfig>): boolean;
   restrictedLeaseRequestFields?(input: LeaseRequest): string[];
+  authorizeHostPin?(config: LeaseConfig, org: string): Promise<boolean>;
   ownershipLabelValue?(value: string): string;
   recoveryIsAuthoritative?: true;
   recoverUnboundProvisioningResource?(lease: LeaseRecord): Promise<ProviderMachine | undefined>;
@@ -28251,6 +28037,34 @@ function awsCheckpointResourceAbsent(message: string, resourceID: string): boole
   );
 }
 
+interface AWSMacHostAllocation {
+  version: 1;
+  hostID: string;
+  region: string;
+  org: string;
+}
+
+function awsMacHostAllocationKey(region: string, hostID: string): string {
+  return `aws-mac-host-allocation:${region}:${hostID}`;
+}
+
+async function recordAWSMacHostAllocations(
+  storage: CoordinatorStorage,
+  hosts: AWSMacHost[],
+  org: string,
+): Promise<void> {
+  await Promise.all(
+    hosts.map((host) =>
+      storage.put(awsMacHostAllocationKey(host.region, host.id), {
+        version: 1,
+        hostID: host.id,
+        region: host.region,
+        org,
+      } satisfies AWSMacHostAllocation),
+    ),
+  );
+}
+
 export class AWSProvider implements CloudProvider {
   private clientValue?: EC2SpotClient;
   private readonly region: string;
@@ -28266,6 +28080,36 @@ export class AWSProvider implements CloudProvider {
   private get client(): EC2SpotClient {
     this.clientValue ??= new EC2SpotClient(this.env, this.region);
     return this.clientValue;
+  }
+
+  async authorizeHostPin(config: LeaseConfig, org: string): Promise<boolean> {
+    const hostID = config.hostID || config.awsMacHostID;
+    if (config.target !== "macos" || !hostID || org === MISSING_ORG_KEY || !isCurrentOrgKey(org))
+      return false;
+    const allocation = await this.storage.get<AWSMacHostAllocation>(
+      awsMacHostAllocationKey(this.region, hostID),
+    );
+    if (allocation) {
+      return (
+        allocation.version === 1 &&
+        allocation.region === this.region &&
+        allocation.hostID === hostID &&
+        sameOrgIdentityKey(allocation.org, org)
+      );
+    }
+    // Older coordinators recorded placement on managed leases, before host allocations were persisted.
+    const leases = [
+      ...(await this.storage.list<LeaseRecord>({ prefix: "lease:" })).values(),
+    ].filter(
+      (lease) =>
+        lease.provider === "aws" &&
+        lease.target === "macos" &&
+        !isRegisteredLease(lease) &&
+        lease.region === this.region &&
+        leaseHostID(lease) === hostID &&
+        Boolean(lease.cloudID),
+    );
+    return leases.length > 0 && leases.every((lease) => sameOrgIdentityKey(lease.org, org));
   }
 
   readyPoolImageIdentity(lease: LeaseRecord): ReadyPoolImageIdentity | undefined {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -28092,27 +28092,12 @@ export class AWSProvider implements CloudProvider {
     const allocation = await this.storage.get<AWSMacHostAllocation>(
       awsMacHostAllocationKey(this.region, hostID),
     );
-    if (allocation) {
-      return (
-        allocation.version === 1 &&
-        allocation.region === this.region &&
-        allocation.hostID === hostID &&
-        sameOrgIdentityKey(allocation.org, org)
-      );
-    }
-    // Older coordinators recorded placement on managed leases, before host allocations were persisted.
-    const leases = [
-      ...(await this.storage.list<LeaseRecord>({ prefix: "lease:" })).values(),
-    ].filter(
-      (lease) =>
-        lease.provider === "aws" &&
-        lease.target === "macos" &&
-        !isRegisteredLease(lease) &&
-        lease.region === this.region &&
-        leaseHostID(lease) === hostID &&
-        Boolean(lease.cloudID),
+    return (
+      allocation?.version === 1 &&
+      allocation.region === this.region &&
+      allocation.hostID === hostID &&
+      sameOrgIdentityKey(allocation.org, org)
     );
-    return leases.length > 0 && leases.every((lease) => sameOrgIdentityKey(lease.org, org));
   }
 
   readyPoolImageIdentity(lease: LeaseRecord): ReadyPoolImageIdentity | undefined {

--- a/worker/test/checkpoints.test.ts
+++ b/worker/test/checkpoints.test.ts
@@ -1026,7 +1026,7 @@ describe("coordinator-managed checkpoints", () => {
   );
 
   it("does not remap a fixed checkpoint fork to a retained Mac lease", async () => {
-    const { storage, checkpointID, body, begin, fork, create } = await fixedForkFixture();
+    const { storage, checkpointID, begin, fork, create } = await fixedForkFixture();
     const checkpoint = (await storage.get<CoordinatorCheckpointRecord>(
       checkpointKey(checkpointID),
     ))!;
@@ -1047,10 +1047,10 @@ describe("coordinator-managed checkpoints", () => {
       awsMacHostID: "h-0123456789abcdef0",
       capacity: { market: "on-demand" },
     });
-    expect(response.status).toBe(201);
-    await expect(response.json()).resolves.toMatchObject({ lease: { id: body.leaseID } });
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ error: "host_in_use" });
     expect(await storage.get(`lease:${leaseID}`)).toMatchObject({ state: "released" });
-    expect(create).toHaveBeenCalledOnce();
+    expect(create).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -4831,7 +4831,7 @@ describe("coordinator-managed checkpoints", () => {
         )
       ).json()) as { claim: string };
       const requestedLeaseID = "cbx_000000000002";
-      const canonicalLeaseID = macOS ? "cbx_000000000099" : requestedLeaseID;
+      const canonicalLeaseID = requestedLeaseID;
       const createAttemptID = `cat_${"8".repeat(32)}`;
       const provision = vi
         .spyOn(coordinator as never, "createLease" as never)

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -27669,14 +27669,15 @@ describe("fleet lease identity and idle", () => {
   });
 
   it.each([
-    { state: "active", keep: false },
-    { state: "active", keep: true },
-    { state: "provisioning", keep: true },
-    { state: "released", keep: true },
-    { state: "released", keep: false },
+    { state: "active", keep: false, cloudID: "i-kept" },
+    { state: "active", keep: true, cloudID: "i-kept" },
+    { state: "provisioning", keep: true, cloudID: "i-kept" },
+    { state: "released", keep: true, cloudID: "i-kept" },
+    { state: "released", keep: true, cloudID: "" },
+    { state: "released", keep: false, cloudID: "i-kept" },
   ] as const)(
-    "rejects a pinned host carrying a $state lease with keep=$keep",
-    async ({ state, keep }) => {
+    "rejects a pinned host carrying a $state lease with keep=$keep cloudID=$cloudID",
+    async ({ state, keep, cloudID }) => {
       const storage = new MemoryStorage();
       const held = testLease({
         id: "cbx_000000000100",
@@ -27685,7 +27686,7 @@ describe("fleet lease identity and idle", () => {
         target: "macos",
         region: "eu-west-1",
         hostId: "h-kept",
-        cloudID: "i-kept",
+        cloudID,
         serverID: 0,
         state,
         keep,
@@ -27694,6 +27695,13 @@ describe("fleet lease identity and idle", () => {
         org: "example-org",
       });
       storage.seed(`lease:${held.id}`, held);
+      if (!cloudID)
+        storage.seed("aws-mac-host-allocation:eu-west-1:h-kept", {
+          version: 1,
+          hostID: "h-kept",
+          region: "eu-west-1",
+          org: held.org,
+        });
       let preparations = 0;
       let creates = 0;
       let releases = 0;

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -27668,394 +27668,395 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
-  it("requires admin auth for new AWS macOS host pins but reactivates an owner's retained Mac", async () => {
-    let created = false;
-    let preparedProviderKey = "";
-    const storage = new MemoryStorage();
-    const reconciledLeaseIDs: string[][] = [];
-    storage.seed(
-      "lease:cbx_000000000098",
-      testLease({
-        id: "cbx_000000000098",
+  it.each([
+    { state: "active", keep: false },
+    { state: "active", keep: true },
+    { state: "provisioning", keep: true },
+    { state: "released", keep: true },
+    { state: "released", keep: false },
+  ] as const)(
+    "rejects a pinned host carrying a $state lease with keep=$keep",
+    async ({ state, keep }) => {
+      const storage = new MemoryStorage();
+      const held = testLease({
+        id: "cbx_000000000100",
+        slug: "kept-desktop",
         provider: "aws",
         target: "macos",
-        state: "released",
-        owner: "admin@example.com",
+        region: "eu-west-1",
+        hostId: "h-kept",
+        cloudID: "i-kept",
+        serverID: 0,
+        state,
+        keep,
+        releaseDeletesServer: false,
+        owner: "alice@example.com",
         org: "example-org",
-        hostId: "h-000000000001",
-        serverType: "mac2.metal",
-        providerKey: "crabbox-steipete",
-        updatedAt: "2026-01-01T00:00:00.000Z",
-      }),
-    );
-    const fleet = testFleet(storage, {
-      aws: fakeProvider(
-        () => {
-          created = true;
-        },
-        {
+      });
+      storage.seed(`lease:${held.id}`, held);
+      let preparations = 0;
+      let creates = 0;
+      let releases = 0;
+      const fleet = testFleet(storage, {
+        aws: fakeProvider(() => creates++, {
           provider: "aws",
-          serverType: "mac2.metal",
-          hostID: "h-000000000001",
-          onPrepareLeaseConfig: (config) => {
-            preparedProviderKey = config.providerKey;
+          onPrepareLeaseConfig(config) {
+            preparations++;
             return config;
           },
-          onReconcileLeaseAccess: (_lease, context) => {
-            reconciledLeaseIDs.push(context.activeLeases.map((candidate) => candidate.id));
-          },
-        },
-      ),
-    });
-    const body = {
-      provider: "aws" as const,
-      target: "macos" as const,
-      class: "standard",
-      serverType: "mac2.metal",
-      hostId: "h-000000000001",
-      capacity: { market: "on-demand" as const },
-      keep: true,
-      sshPublicKey: "ssh-ed25519 test",
-    };
-    const denied = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        headers: {
-          "x-crabbox-owner": "alice@example.com",
-          "cf-connecting-ip": "203.0.113.7",
-          "x-crabbox-org": "example-org",
-        },
-        body: { ...body, leaseID: "cbx_abcdef123456" },
-      }),
-    );
-    expect(denied.status).toBe(403);
-    expect(created).toBe(false);
-    await expect(denied.json()).resolves.toMatchObject({ error: "admin_required" });
+          onReleaseLease: () => releases++,
+        }),
+      });
+      for (const admin of [false, true]) {
+        for (const fixed of [false, true]) {
+          const id = `cbx_00000000010${(admin ? 2 : 4) + (fixed ? 1 : 0)}`;
+          // oxlint-disable-next-line eslint/no-await-in-loop -- each attempt verifies the same retained record remains untouched.
+          const response = await fleet.fetch(
+            request(fixed ? "PUT" : "POST", fixed ? `/v1/leases/${id}` : "/v1/leases", {
+              headers: {
+                "x-crabbox-owner": "alice@example.com",
+                "x-crabbox-org": "example-org",
+                ...(admin ? { "x-crabbox-admin": "true" } : {}),
+              },
+              body: {
+                leaseID: id,
+                provider: "aws",
+                target: "macos",
+                hostId: "h-kept",
+                slug: "new-warmup",
+                serverType: "mac1.metal",
+                capacity: { market: "on-demand" },
+                sshPublicKey: "ssh-ed25519 synthetic",
+              },
+            }),
+          );
+          expect(response.status).toBe(409);
+          // oxlint-disable-next-line eslint/no-await-in-loop -- consume the response before the next scoped request.
+          await expect(response.json()).resolves.toMatchObject({
+            error: "host_in_use",
+            message: expect.stringContaining(`${held.id} (slug kept-desktop)`),
+          });
+        }
+      }
+      expect({ preparations, creates, releases }).toEqual({
+        preparations: 0,
+        creates: 0,
+        releases: 0,
+      });
+      expect(storage.value(`lease:${held.id}`)).toEqual(held);
+    },
+  );
 
-    const create = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        headers: {
-          "x-crabbox-admin": "true",
-          "x-crabbox-owner": "admin@example.com",
-          "x-crabbox-org": "example-org",
-        },
-        body: { ...body, leaseID: "cbx_abcdef123457" },
-      }),
-    );
-
-    expect(create.status).toBe(201);
-    expect(created).toBe(true);
-    const { lease } = (await create.json()) as { lease: LeaseRecord };
-    expect(lease.hostId).toBe("h-000000000001");
-
-    const released = await fleet.fetch(
-      request("POST", `/v1/leases/${lease.id}/release`, {
-        headers: {
-          "x-crabbox-admin": "true",
-          "x-crabbox-owner": "admin@example.com",
-          "x-crabbox-org": "example-org",
-        },
-      }),
-    );
-    expect(released.status).toBe(200);
-
-    created = false;
-    reconciledLeaseIDs.length = 0;
-    storage.seed(
-      "provider-access:cbx_000000000099",
-      testLease({
-        id: "cbx_000000000099",
-        provider: "aws",
-        state: "provisioning",
-        expiresAt: new Date(Date.now() + 60_000).toISOString(),
-      }),
-    );
-    const incompatible = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        headers: {
-          "x-crabbox-owner": "admin@example.com",
-          "x-crabbox-org": "example-org",
-        },
-        body: { ...body, desktop: true, leaseID: "cbx_abcdef123458" },
-      }),
-    );
-    expect(incompatible.status).toBe(409);
-    await expect(incompatible.json()).resolves.toMatchObject({
-      error: "retained_instance_capability_mismatch",
-    });
-    expect(created).toBe(false);
-
-    const reused = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        headers: {
-          "x-crabbox-owner": "admin@example.com",
-          "x-crabbox-org": "example-org",
-        },
-        body: {
-          ...body,
-          providerKey: "crabbox-new-request",
-          leaseID: "cbx_abcdef123458",
-        },
-      }),
-    );
-    expect(reused.status).toBe(201);
-    expect(created).toBe(false);
-    expect(preparedProviderKey).toBe(lease.providerKey);
-    const { lease: reactivated } = (await reused.json()) as { lease: LeaseRecord };
-    expect(reactivated.id).toBe(lease.id);
-    expect(reactivated.state).toBe("active");
-    expect(reactivated.createdAt).toBe(reactivated.lastTouchedAt);
-    expect(reactivated.cloudID).toBe(lease.cloudID);
-    expect(reactivated.hostId).toBe("h-000000000001");
-    expect(reactivated.providerKey).toBe(lease.providerKey);
-    expect(reconciledLeaseIDs.at(-1)).toContain("cbx_000000000099");
-
-    const deleted = await fleet.fetch(
-      request("POST", `/v1/leases/${lease.id}/release`, {
-        headers: {
-          "x-crabbox-owner": "admin@example.com",
-          "x-crabbox-org": "example-org",
-        },
-        body: { delete: true },
-      }),
-    );
-    expect(deleted.status).toBe(200);
-
-    const deletedHostReuse = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        headers: {
-          "x-crabbox-owner": "admin@example.com",
-          "x-crabbox-org": "example-org",
-        },
-        body: { ...body, leaseID: "cbx_abcdef123459" },
-      }),
-    );
-    expect(deletedHostReuse.status).toBe(403);
-    await expect(deletedHostReuse.json()).resolves.toMatchObject({ error: "admin_required" });
-  });
-
-  it("rolls back a retained Mac attempt binding when access reconciliation fails", async () => {
+  it("rechecks host occupancy when concurrent creates reserve the same host", async () => {
     const storage = new MemoryStorage();
-    const canonicalLeaseID = "cbx_ca1100000020";
-    const requestedLeaseID = "cbx_ca1100000021";
-    const createAttemptID = "cat_20000000000000000000000000000020";
-    storage.seed(
-      `lease:${canonicalLeaseID}`,
-      testLease({
-        id: canonicalLeaseID,
-        provider: "aws",
-        target: "macos",
-        state: "released",
-        owner: "alice@example.com",
-        org: "example-org",
-        hostId: "h-rollback",
-        serverType: "mac2.metal",
-        cloudID: "i-rollback",
-        providerKey: "crabbox-rollback",
-        releaseDeletesServer: false,
-        updatedAt: "2026-08-01T00:00:00.000Z",
-      }),
-    );
-    let reconciliations = 0;
     let creates = 0;
+    const started = deferred<void>();
+    const finish = deferred<void>();
     const fleet = testFleet(storage, {
       aws: fakeProvider(
-        () => {
-          creates += 1;
+        async () => {
+          creates++;
+          started.resolve();
+          await finish.promise;
         },
-        {
-          provider: "aws",
-          onReconcileLeaseAccess() {
-            reconciliations += 1;
-            if (reconciliations === 1) throw new Error("temporary ingress failure");
-          },
-        },
+        { provider: "aws", hostID: "h-concurrent", serverType: "mac1.metal" },
       ),
     });
     const headers = {
+      "x-crabbox-admin": "true",
       "x-crabbox-owner": "alice@example.com",
       "x-crabbox-org": "example-org",
     };
     const body = {
-      leaseID: requestedLeaseID,
-      createAttemptID,
-      provider: "aws" as const,
-      target: "macos" as const,
-      hostId: "h-rollback",
-      serverType: "mac2.metal",
-      capacity: { market: "on-demand" as const },
-      keep: true,
-      sshPublicKey: "ssh-ed25519 retained-rollback",
+      provider: "aws",
+      target: "macos",
+      hostId: "h-concurrent",
+      serverType: "mac1.metal",
+      capacity: { market: "on-demand" },
+      sshPublicKey: "ssh-ed25519 synthetic",
     };
-
-    const failed = await fleet.fetch(request("POST", "/v1/leases", { headers, body }));
-    expect(failed.status).toBe(500);
-    expect(storage.value<LeaseRecord>(`lease:${canonicalLeaseID}`)).toMatchObject({
-      state: "released",
-      releaseDeletesServer: false,
-      cloudID: "i-rollback",
-    });
-    expect(storage.value(`create-attempt:${requestedLeaseID}`)).toMatchObject({
-      state: "pending",
-      token: createAttemptID,
-    });
-    expect(storage.value(`create-attempt:${requestedLeaseID}`)).not.toHaveProperty(
-      "canonicalLeaseID",
-    );
-
-    const retried = await fleet.fetch(request("POST", "/v1/leases", { headers, body }));
-    expect(retried.status).toBe(201);
-    await expect(retried.json()).resolves.toMatchObject({
-      lease: { id: canonicalLeaseID, state: "active", cloudID: "i-rollback" },
-    });
-    expect(reconciliations).toBe(2);
-    expect(creates).toBe(0);
-  });
-
-  it("replays a retained Mac as provisioning until access reconciliation commits", async () => {
-    const storage = new MemoryStorage();
-    const canonicalLeaseID = "cbx_ca1100000032";
-    const requestedLeaseID = "cbx_ca1100000033";
-    const createAttemptID = "cat_32000000000000000000000000000032";
-    storage.seed(
-      `lease:${canonicalLeaseID}`,
-      testLease({
-        id: canonicalLeaseID,
-        provider: "aws",
-        target: "macos",
-        state: "released",
-        owner: "alice@example.com",
-        org: "example-org",
-        hostId: "h-replay-reconcile",
-        serverType: "mac2.metal",
-        cloudID: "i-replay-reconcile",
-        providerKey: "crabbox-replay-reconcile",
-        releaseDeletesServer: false,
+    const first = fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: { ...body, leaseID: "cbx_000000000110", slug: "first" },
       }),
     );
-    const bothPrepared = deferred<void>();
-    const finishPreparation = deferred<void>();
-    const reconciliationStarted = deferred<void>();
-    const finishReconciliation = deferred<void>();
-    let preparations = 0;
-    const fleet = testFleet(storage, {
-      aws: fakeProvider(undefined, {
-        provider: "aws",
-        async onPrepareLeaseConfig(config) {
-          preparations += 1;
-          if (preparations === 2) bothPrepared.resolve();
-          await finishPreparation.promise;
-          return config;
-        },
-        async onReconcileLeaseAccess() {
-          reconciliationStarted.resolve();
-          await finishReconciliation.promise;
-        },
-      }),
+    await started.promise;
+    const second = await fleet.fetch(
+      request("POST", "/v1/leases", { headers, body: { ...body, leaseID: "cbx_000000000111" } }),
+    );
+    finish.resolve();
+    expect(second.status).toBe(409);
+    await expect(second.json()).resolves.toMatchObject({
+      error: "host_in_use",
+      message: expect.stringContaining("cbx_000000000110 (slug first)"),
     });
-    const headers = {
-      "x-crabbox-owner": "alice@example.com",
-      "x-crabbox-org": "example-org",
-    };
-    const body = {
-      leaseID: requestedLeaseID,
-      createAttemptID,
-      provider: "aws" as const,
-      target: "macos" as const,
-      hostId: "h-replay-reconcile",
-      serverType: "mac2.metal",
-      capacity: { market: "on-demand" as const },
-      keep: true,
-      sshPublicKey: "ssh-ed25519 retained-replay",
-    };
-
-    const first = fleet.fetch(request("POST", "/v1/leases", { headers, body }));
-    const second = fleet.fetch(request("POST", "/v1/leases", { headers, body }));
-    await bothPrepared.promise;
-    finishPreparation.resolve();
-    await reconciliationStarted.promise;
-
-    const inFlightReplay = await Promise.race([first, second]);
-    expect(inFlightReplay.status).toBe(200);
-    await expect(inFlightReplay.json()).resolves.toMatchObject({
-      lease: { id: canonicalLeaseID, state: "provisioning" },
-    });
-
-    finishReconciliation.resolve();
-    const statuses = await Promise.all([
-      first.then((response) => response.status),
-      second.then((response) => response.status),
-    ]);
-    expect(statuses.toSorted()).toEqual([200, 201]);
-    const committedReplay = await fleet.fetch(request("POST", "/v1/leases", { headers, body }));
-    expect(committedReplay.status).toBe(200);
-    await expect(committedReplay.json()).resolves.toMatchObject({
-      lease: { id: canonicalLeaseID, state: "active" },
-    });
+    expect((await first).status).toBe(201);
+    expect(creates).toBe(1);
   });
 
-  it("does not replay an old fixed create across retained Mac reactivation", async () => {
+  it("only replays a pinned Mac under the same fixed ID and intent", async () => {
     const storage = new MemoryStorage();
     let creates = 0;
     const fleet = testFleet(storage, {
       aws: fakeProvider(() => creates++, {
         provider: "aws",
-        serverType: "mac2.metal",
-        hostID: "h-fixed-incarnation",
-        cloudID: "i-fixed-incarnation",
+        hostID: "h-fixed",
+        serverType: "mac1.metal",
       }),
     });
     const headers = {
+      "x-crabbox-admin": "true",
       "x-crabbox-owner": "alice@example.com",
       "x-crabbox-org": "example-org",
     };
-    const leaseID = "cbx_ca1100000046";
-    const fixedBody = {
+    const body = {
       provider: "aws",
       target: "macos",
-      serverType: "mac2.metal",
-      capacity: { market: "on-demand" },
+      hostId: "h-fixed",
+      serverType: "mac1.metal",
       keep: true,
-      ttlSeconds: 1200,
-      sshPublicKey: "ssh-ed25519 fixed-incarnation",
+      capacity: { market: "on-demand" },
+      sshPublicKey: "ssh-ed25519 synthetic",
     };
-    const fixed = await fleet.fetch(
-      request("PUT", `/v1/leases/${leaseID}`, { headers, body: fixedBody }),
-    );
-    expect(fixed.status).toBe(201);
-    const retained = await fleet.fetch(
-      request("POST", `/v1/leases/${leaseID}/release`, { headers, body: { delete: false } }),
-    );
-    expect(retained.status).toBe(200);
-    await expect(retained.json()).resolves.toMatchObject({
-      lease: { id: leaseID, state: "released", cleanupStatus: "retained" },
-    });
-    const ordinaryBody = {
-      ...fixedBody,
-      leaseID: "cbx_ca1100000047",
-      createAttemptID: "cat_47000000000000000000000000000047",
-      hostId: "h-fixed-incarnation",
-      ttlSeconds: 2400,
-    };
-    const reactivated = await fleet.fetch(
-      request("POST", "/v1/leases", { headers, body: ordinaryBody }),
-    );
-    expect(reactivated.status).toBe(201);
-    await expect(reactivated.json()).resolves.toMatchObject({
-      lease: { id: leaseID, state: "active", cloudID: "i-fixed-incarnation", ttlSeconds: 2400 },
-    });
-
-    const stale = await fleet.fetch(
-      request("PUT", `/v1/leases/${leaseID}`, { headers, body: fixedBody }),
-    );
-    expect.soft(stale.status).toBe(409);
-    const replay = await fleet.fetch(
-      request("POST", "/v1/leases", { headers, body: ordinaryBody }),
-    );
+    const path = "/v1/leases/cbx_000000000120";
+    expect((await fleet.fetch(request("PUT", path, { headers, body }))).status).toBe(201);
+    const replay = await fleet.fetch(request("PUT", path, { headers, body }));
     expect(replay.status).toBe(200);
     await expect(replay.json()).resolves.toMatchObject({
-      lease: { id: leaseID, state: "active", cloudID: "i-fixed-incarnation", ttlSeconds: 2400 },
+      lease: { id: "cbx_000000000120", keep: true },
     });
+    expect(
+      (await fleet.fetch(request("PUT", path, { headers, body: { ...body, slug: "different" } })))
+        .status,
+    ).toBe(409);
     expect(creates).toBe(1);
+  });
+
+  it.each(["replay", "cancel"])(
+    "refuses legacy cross-ID adoption bindings during %s",
+    async (operation) => {
+      const storage = new MemoryStorage();
+      const requestedID = "cbx_000000000130";
+      const token = "cat_13000000000000000000000000000000";
+      const held = testLease({
+        id: "cbx_000000000131",
+        provider: "aws",
+        target: "macos",
+        keep: true,
+        owner: "alice@example.com",
+        org: "example-org",
+        createAttemptID: token,
+        createAttemptGeneration: "legacy",
+      });
+      storage.seed(`lease:${held.id}`, held);
+      storage.seed(`create-attempt:${requestedID}`, {
+        version: 1,
+        requestedLeaseID: requestedID,
+        canonicalLeaseID: held.id,
+        token,
+        generation: "legacy",
+        owner: held.owner,
+        org: held.org,
+        state: "pending",
+        createdAt: held.createdAt,
+        updatedAt: held.updatedAt,
+      });
+      let releases = 0;
+      const fleet = testFleet(storage, {
+        aws: fakeProvider(undefined, { provider: "aws", onReleaseLease: () => releases++ }),
+      });
+      const response = await fleet.fetch(
+        request(
+          "POST",
+          operation === "cancel" ? `/v1/leases/${requestedID}/cancel-create` : "/v1/leases",
+          {
+            headers: { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" },
+            body: {
+              leaseID: requestedID,
+              createAttemptID: token,
+              provider: "aws",
+              target: "macos",
+              sshPublicKey: "ssh-ed25519 synthetic",
+            },
+          },
+        ),
+      );
+      expect(response.status).toBe(409);
+      expect(releases).toBe(0);
+      expect(storage.value(`lease:${held.id}`)).toEqual(held);
+    },
+  );
+
+  it.each([
+    {
+      name: "same org allocation",
+      allocation: true,
+      org: "example-org",
+      region: "eu-west-1",
+      allowed: true,
+    },
+    {
+      name: "other org allocation",
+      allocation: true,
+      org: "other-org",
+      region: "eu-west-1",
+      allowed: false,
+    },
+    {
+      name: "other region allocation",
+      allocation: true,
+      org: "example-org",
+      region: "eu-west-2",
+      allowed: false,
+    },
+    {
+      name: "no allocation",
+      allocation: false,
+      org: "example-org",
+      region: "eu-west-1",
+      allowed: false,
+    },
+    {
+      name: "same org managed history",
+      history: true,
+      org: "example-org",
+      region: "eu-west-1",
+      allowed: true,
+    },
+    {
+      name: "other org managed history",
+      history: true,
+      org: "other-org",
+      region: "eu-west-1",
+      allowed: false,
+    },
+    {
+      name: "other region managed history",
+      history: true,
+      org: "example-org",
+      region: "eu-west-2",
+      allowed: false,
+    },
+    {
+      name: "registered history",
+      history: true,
+      registered: true,
+      org: "example-org",
+      region: "eu-west-1",
+      allowed: false,
+    },
+    {
+      name: "legacy ambiguous org",
+      history: true,
+      legacy: true,
+      org: "example-org",
+      region: "eu-west-1",
+      allowed: false,
+    },
+  ])(
+    "host pin authorization: $name",
+    async ({ allocation, history, registered, legacy, org, region, allowed }) => {
+      const storage = new MemoryStorage();
+      if (allocation)
+        storage.seed(`aws-mac-host-allocation:${region}:h-owned`, {
+          version: 1,
+          hostID: "h-owned",
+          region,
+          org: orgKeyForLabel(org),
+        });
+      if (history) {
+        const lease = testLease({
+          id: "cbx_000000000140",
+          provider: "aws",
+          target: "macos",
+          region,
+          hostId: "h-owned",
+          cloudID: "i-old",
+          owner: "previous@example.com",
+          org,
+          state: "released",
+          releaseDeletesServer: true,
+          cleanupStatus: "complete",
+          cleanupCompletedAt: "2026-01-01T00:00:00Z",
+          host: "",
+          ...(registered ? { lifecycle: "registered" } : {}),
+        });
+        storage.seed(`lease:${lease.id}`, lease);
+        if (legacy) await storage.put(`lease:${lease.id}`, { ...lease, org });
+      }
+      let creates = 0;
+      const fleet = testFleet(storage, {
+        aws: fakeProvider(() => creates++, {
+          provider: "aws",
+          hostID: "h-owned",
+          serverType: "mac1.metal",
+        }),
+      });
+      const response = await fleet.fetch(
+        request("POST", "/v1/leases", {
+          headers: { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" },
+          body: {
+            provider: "aws",
+            target: "macos",
+            hostId: "h-owned",
+            serverType: "mac1.metal",
+            capacity: { market: "on-demand" },
+            sshPublicKey: "ssh-ed25519 synthetic",
+          },
+        }),
+      );
+      expect(response.status).toBe(allowed ? 201 : 403);
+      expect(creates).toBe(allowed ? 1 : 0);
+    },
+  );
+
+  it("lists visible retained leases before applying the current-view limit", async () => {
+    const storage = new MemoryStorage();
+    const kept = testLease({
+      id: "cbx_000000000150",
+      provider: "aws",
+      owner: "alice@example.com",
+      org: "example-org",
+      state: "released",
+      keep: true,
+      releaseDeletesServer: false,
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    storage.seed(`lease:${kept.id}`, kept);
+    storage.seed(
+      "lease:cbx_000000000151",
+      testLease({
+        id: "cbx_000000000151",
+        provider: "aws",
+        owner: "other@example.com",
+        org: "example-org",
+      }),
+    );
+    storage.seed(
+      "lease:cbx_000000000152",
+      testLease({
+        id: "cbx_000000000152",
+        provider: "aws",
+        owner: "alice@example.com",
+        org: "example-org",
+        state: "released",
+        keep: true,
+        releaseDeletesServer: true,
+        cleanupStatus: "complete",
+        cleanupCompletedAt: "2026-01-01T00:00:00Z",
+        host: "",
+      }),
+    );
+    const fleet = testFleet(storage);
+    const response = await fleet.fetch(
+      request("GET", "/v1/leases?view=current&provider=aws&limit=1", {
+        headers: { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" },
+      }),
+    );
+    expect(response.status).toBe(200);
+    const { leases } = (await response.json()) as { leases: LeaseRecord[] };
+    expect(leases.map((lease) => lease.id)).toEqual([kept.id]);
   });
 
   it("persists a cancel-before-create tombstone and rejects the later create without provisioning", async () => {
@@ -29656,268 +29657,6 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.state).toBe("released");
   });
 
-  it("generation-fences retained canonical cancellation and keeps the requested ID private", async () => {
-    const storage = new MemoryStorage();
-    const canonicalID = "cbx_ca1100000006";
-    const requestedLeaseID = "cbx_ca1100000007";
-    const createAttemptID = "cat_60000000000000000000000000000006";
-    storage.seed(
-      `lease:${canonicalID}`,
-      testLease({
-        id: canonicalID,
-        provider: "aws",
-        target: "macos",
-        state: "released",
-        owner: "alice@example.com",
-        org: "example-org",
-        hostId: "h-create-attempt",
-        serverType: "mac2.metal",
-        cloudID: "i-retained",
-        providerKey: "crabbox-retained",
-        releaseDeletesServer: false,
-      }),
-    );
-    let releases = 0;
-    const fleet = testFleet(storage, {
-      aws: fakeProvider(undefined, { provider: "aws", onReleaseLease: () => releases++ }),
-    });
-    const headers = {
-      "x-crabbox-owner": "alice@example.com",
-      "x-crabbox-org": "example-org",
-    };
-    const create = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        headers,
-        body: {
-          leaseID: requestedLeaseID,
-          createAttemptID,
-          provider: "aws",
-          target: "macos",
-          hostId: "h-create-attempt",
-          serverType: "mac2.metal",
-          capacity: { market: "on-demand" },
-          keep: true,
-          sshPublicKey: "ssh-ed25519 x",
-        },
-      }),
-    );
-    expect(create.status).toBe(201);
-    const publicLease = ((await create.json()) as { lease: LeaseRecord }).lease;
-    expect(publicLease.id).toBe(canonicalID);
-    expect(publicLease.createAttemptID).toBeUndefined();
-    expect(publicLease.createAttemptGeneration).toBeUndefined();
-    const tokenBoundGeneration = storage.value<LeaseRecord>(
-      `lease:${canonicalID}`,
-    )!.createAttemptGeneration;
-    expect(tokenBoundGeneration).toEqual(expect.any(String));
-    expect(
-      (await fleet.fetch(request("GET", `/v1/leases/${requestedLeaseID}`, { headers }))).status,
-    ).toBe(404);
-
-    const retained = await fleet.fetch(
-      request("POST", `/v1/leases/${canonicalID}/release`, {
-        headers,
-        body: { delete: false },
-      }),
-    );
-    expect(retained.status).toBe(200);
-    const legacyReactivation = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        headers,
-        body: {
-          leaseID: "cbx_ca1100000014",
-          createAttemptID: undefined,
-          provider: "aws",
-          target: "macos",
-          hostId: "h-create-attempt",
-          serverType: "mac2.metal",
-          capacity: { market: "on-demand" },
-          keep: true,
-          sshPublicKey: "ssh-ed25519 legacy-reactivation",
-        },
-      }),
-    );
-    expect(legacyReactivation.status).toBe(201);
-    const legacyCanonical = storage.value<LeaseRecord>(`lease:${canonicalID}`)!;
-    expect(legacyCanonical.state).toBe("active");
-    expect(legacyCanonical.createAttemptID).toBeUndefined();
-    expect(legacyCanonical.createAttemptGeneration).toEqual(expect.any(String));
-    expect(legacyCanonical.createAttemptGeneration).not.toBe(tokenBoundGeneration);
-    const legacyPublicLease = ((await legacyReactivation.json()) as { lease: LeaseRecord }).lease;
-    expect(legacyPublicLease).not.toHaveProperty("createAttemptID");
-    expect(legacyPublicLease).not.toHaveProperty("createAttemptGeneration");
-
-    const stale = await fleet.fetch(
-      request("POST", `/v1/leases/${requestedLeaseID}/cancel-create`, {
-        headers,
-        body: { createAttemptID },
-      }),
-    );
-    expect(stale.status).toBe(409);
-    expect(storage.value<LeaseRecord>(`lease:${canonicalID}`)?.state).toBe("active");
-    expect(releases).toBe(0);
-  });
-
-  it("generation-fences canonical release across tokenless retained-Mac reactivation", async () => {
-    const storage = new MemoryStorage();
-    const canonicalID = "cbx_ca1100000036";
-    const requestedLeaseID = "cbx_ca1100000035";
-    const releasedGeneration = "released-generation";
-    storage.seed(
-      `lease:${canonicalID}`,
-      testLease({
-        id: canonicalID,
-        provider: "aws",
-        target: "macos",
-        state: "released",
-        owner: "alice@example.com",
-        org: "example-org",
-        hostId: "h-tokenless-race",
-        serverType: "mac2.metal",
-        cloudID: "i-tokenless-race",
-        providerKey: "crabbox-tokenless-race",
-        releaseDeletesServer: false,
-        createAttemptGeneration: releasedGeneration,
-      }),
-    );
-    const releaseReadStarted = deferred<void>();
-    const continueRelease = deferred<void>();
-    let canonicalReads = 0;
-    storage.beforeGet = async (key) => {
-      if (key === `lease:${canonicalID}` && ++canonicalReads === 2) {
-        releaseReadStarted.resolve();
-        await continueRelease.promise;
-      }
-    };
-    let releases = 0;
-    const fleet = testFleet(storage, {
-      aws: fakeProvider(undefined, {
-        provider: "aws",
-        onReleaseLease: () => releases++,
-      }),
-    });
-    const headers = {
-      "x-crabbox-owner": "alice@example.com",
-      "x-crabbox-org": "example-org",
-    };
-
-    const releasing = fleet.fetch(
-      request("POST", `/v1/leases/${canonicalID}/release`, {
-        headers,
-        body: { delete: true },
-      }),
-    );
-    await releaseReadStarted.promise;
-    const reactivated = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        headers,
-        body: {
-          leaseID: requestedLeaseID,
-          createAttemptID: undefined,
-          provider: "aws",
-          target: "macos",
-          hostId: "h-tokenless-race",
-          serverType: "mac2.metal",
-          capacity: { market: "on-demand" },
-          keep: true,
-          sshPublicKey: "ssh-ed25519 tokenless-race",
-        },
-      }),
-    );
-    expect(reactivated.status).toBe(201);
-    const current = storage.value<LeaseRecord>(`lease:${canonicalID}`)!;
-    expect(current).toMatchObject({ id: canonicalID, state: "active" });
-    expect(current.createAttemptID).toBeUndefined();
-    expect(current.createAttemptGeneration).toEqual(expect.any(String));
-    expect(current.createAttemptGeneration).not.toBe(releasedGeneration);
-
-    continueRelease.resolve();
-    const staleRelease = await releasing;
-    expect(staleRelease.status).toBe(409);
-    await expect(staleRelease.json()).resolves.toMatchObject({
-      error: "lease_state_changed",
-    });
-    expect(storage.value<LeaseRecord>(`lease:${canonicalID}`)).toMatchObject({
-      state: "active",
-      createAttemptGeneration: current.createAttemptGeneration,
-    });
-    expect(releases).toBe(0);
-  });
-
-  it("lets cancellation win while a retained canonical generation is being published", async () => {
-    const storage = new MemoryStorage();
-    const canonicalID = "cbx_ca1100000010";
-    const requestedLeaseID = "cbx_ca1100000011";
-    const createAttemptID = "cat_70000000000000000000000000000007";
-    storage.seed(
-      `lease:${canonicalID}`,
-      testLease({
-        id: canonicalID,
-        provider: "aws",
-        target: "macos",
-        state: "released",
-        owner: "alice@example.com",
-        org: "example-org",
-        hostId: "h-publish",
-        serverType: "mac2.metal",
-        cloudID: "i-publish",
-        providerKey: "crabbox-publish",
-        releaseDeletesServer: false,
-      }),
-    );
-    let publicationStarted!: () => void;
-    let finishPublication!: () => void;
-    const publicationStartedPromise = new Promise<void>(
-      (resolve) => (publicationStarted = resolve),
-    );
-    const finishPublicationPromise = new Promise<void>((resolve) => (finishPublication = resolve));
-    let blocked = false;
-    storage.beforePut = async (key, value) => {
-      const lease = value as Partial<LeaseRecord>;
-      if (key === `lease:${canonicalID}` && lease.createAttemptID && !blocked) {
-        blocked = true;
-        publicationStarted();
-        await finishPublicationPromise;
-      }
-    };
-    let releases = 0;
-    const fleet = testFleet(storage, {
-      aws: fakeProvider(undefined, { provider: "aws", onReleaseLease: () => releases++ }),
-    });
-    const headers = {
-      "x-crabbox-owner": "alice@example.com",
-      "x-crabbox-org": "example-org",
-    };
-    const creating = fleet.fetch(
-      request("POST", "/v1/leases", {
-        headers,
-        body: {
-          leaseID: requestedLeaseID,
-          createAttemptID,
-          provider: "aws",
-          target: "macos",
-          hostId: "h-publish",
-          serverType: "mac2.metal",
-          capacity: { market: "on-demand" },
-          keep: true,
-          sshPublicKey: "ssh-ed25519 x",
-        },
-      }),
-    );
-    await publicationStartedPromise;
-    const canceling = fleet.fetch(
-      request("POST", `/v1/leases/${requestedLeaseID}/cancel-create`, {
-        headers,
-        body: { createAttemptID },
-      }),
-    );
-    finishPublication();
-    expect((await canceling).status).toBe(200);
-    expect((await creating).status).toBe(409);
-    expect(storage.value<LeaseRecord>(`lease:${canonicalID}`)?.state).toBe("released");
-    expect(releases).toBe(1);
-  });
-
   it("does not let an unbound canceled attempt squat an ID across tenants or lifecycles", async () => {
     const storage = new MemoryStorage();
     const fixedID = "cbx_ca1100000008";
@@ -30141,145 +29880,6 @@ describe("fleet lease identity and idle", () => {
     );
     expect(workspace.status).toBe(202);
     await expect(workspace.json()).resolves.toMatchObject({ providerResourceId: freeID });
-  });
-
-  it.each([
-    {
-      name: "replaces the previous policy with pinned CIDRs",
-      previousNetwork: {
-        sshSourceCIDRs: ["198.51.100.7/32", "2001:db8::7/128"],
-        sshSourceCIDRsComplete: true,
-      },
-      requestedCIDRs: ["192.0.2.0/24", "2001:db8:1::/64"],
-      pinned: true,
-      expectedCIDRs: ["192.0.2.0/24", "2001:db8:1::/64"],
-      expectedPinnedCIDRs: ["192.0.2.0/24", "2001:db8:1::/64"],
-    },
-    {
-      name: "clears stale pins for an unpinned claimant",
-      previousNetwork: {
-        sshSourceCIDRs: ["192.0.2.0/24", "2001:db8:1::/64"],
-        sshPinnedSourceCIDRs: ["192.0.2.0/24", "2001:db8:1::/64"],
-        sshSourceCIDRsComplete: true,
-      },
-      requestedCIDRs: ["198.51.100.44/32"],
-      pinned: false,
-      expectedCIDRs: ["198.51.100.44/32", "2001:db8::9/128"],
-      expectedPinnedCIDRs: undefined,
-    },
-  ])(
-    "reactivates a retained Mac host and $name",
-    async ({ previousNetwork, requestedCIDRs, pinned, expectedCIDRs, expectedPinnedCIDRs }) => {
-      const storage = new MemoryStorage();
-      storage.seed(
-        "lease:cbx_000000000100",
-        testLease({
-          id: "cbx_000000000100",
-          provider: "aws",
-          target: "macos",
-          state: "released",
-          owner: "alice@example.com",
-          org: "example-org",
-          hostId: "h-m4",
-          serverType: "mac-m4.metal",
-          providerKey: "crabbox-steipete",
-          releaseDeletesServer: false,
-          network: previousNetwork,
-        }),
-      );
-      const fleet = testFleet(storage, {
-        aws: fakeProvider(
-          () => {
-            throw new Error("retained instance must not launch a replacement");
-          },
-          { provider: "aws" },
-        ),
-      });
-
-      const response = await fleet.fetch(
-        request("POST", "/v1/leases", {
-          headers: {
-            "x-crabbox-owner": "alice@example.com",
-            "cf-connecting-ip": "2001:db8::9",
-            "x-crabbox-org": "example-org",
-          },
-          body: {
-            createAttemptID: undefined,
-            provider: "aws",
-            target: "macos",
-            hostId: "h-m4",
-            awsSSHCIDRs: requestedCIDRs,
-            awsSSHCIDRsPinned: pinned,
-            capacity: { market: "on-demand" },
-            keep: true,
-            sshPublicKey: "ssh-ed25519 test",
-          },
-        }),
-      );
-
-      expect(response.status).toBe(201);
-      const { lease } = (await response.json()) as { lease: LeaseRecord };
-      expect(lease.id).toBe("cbx_000000000100");
-      expect(lease.serverType).toBe("mac-m4.metal");
-      expect(lease.requestedServerType).toBe("mac-m4.metal");
-      expect(lease.network?.sshSourceCIDRs).toEqual(expectedCIDRs);
-      expect(lease.network?.sshPinnedSourceCIDRs).toEqual(expectedPinnedCIDRs);
-    },
-  );
-
-  it("does not launch a replacement when a retained Mac is claimed concurrently", async () => {
-    const storage = new MemoryStorage();
-    const retained = testLease({
-      id: "cbx_000000000101",
-      provider: "aws",
-      target: "macos",
-      state: "released",
-      owner: "alice@example.com",
-      org: "example-org",
-      hostId: "h-mac2",
-      serverType: "mac2.metal",
-      providerKey: "crabbox-steipete",
-      releaseDeletesServer: false,
-    });
-    storage.seed(`lease:${retained.id}`, retained);
-    let created = false;
-    const fleet = testFleet(storage, {
-      aws: fakeProvider(
-        () => {
-          created = true;
-        },
-        {
-          provider: "aws",
-          onPrepareLeaseConfig: (config, currentStorage) => {
-            currentStorage?.seed(`lease:${retained.id}`, { ...retained, state: "active" });
-            return config;
-          },
-        },
-      ),
-    });
-
-    const response = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        headers: {
-          "x-crabbox-owner": "alice@example.com",
-          "x-crabbox-org": "example-org",
-        },
-        body: {
-          provider: "aws",
-          target: "macos",
-          hostId: "h-mac2",
-          capacity: { market: "on-demand" },
-          keep: true,
-          sshPublicKey: "ssh-ed25519 test",
-        },
-      }),
-    );
-
-    expect(response.status).toBe(409);
-    await expect(response.json()).resolves.toMatchObject({
-      error: "retained_instance_unavailable",
-    });
-    expect(created).toBe(false);
   });
 
   it("only applies target-matching promoted AWS images", async () => {
@@ -36753,8 +36353,9 @@ describe("fleet lease identity and idle", () => {
       },
     );
     vi.stubGlobal("fetch", fetchMock);
+    const storage = new MemoryStorage();
     const fleet = testFleet(
-      new MemoryStorage(),
+      storage,
       {},
       {
         AWS_ACCESS_KEY_ID: "test",
@@ -36765,12 +36366,18 @@ describe("fleet lease identity and idle", () => {
 
     const response = await fleet.fetch(
       request("POST", "/v1/admin/mac-hosts?region=eu-west-1", {
-        headers: { "x-crabbox-admin": "true" },
+        headers: { "x-crabbox-admin": "true", "x-crabbox-org": "example-org" },
         body: { type: "mac1.metal", availabilityZone: "eu-west-1a" },
       }),
     );
 
     expect(response.status).toBe(201);
+    expect(storage.value("aws-mac-host-allocation:eu-west-1:h-000000000001")).toEqual({
+      version: 1,
+      hostID: "h-000000000001",
+      region: "eu-west-1",
+      org: orgKeyForLabel("example-org"),
+    });
     expect(actions).toEqual(["AllocateHosts", "DescribeHosts"]);
     expect(seenParams[0]).toMatchObject({
       Action: "AllocateHosts",
@@ -48258,6 +47865,12 @@ function fakeProvider(
     },
     ...(result.provider === "aws"
       ? {
+          authorizeHostPin(config: LeaseConfig, org: string) {
+            return new AWSProvider({} as Env, config.awsRegion, storage!).authorizeHostPin(
+              config,
+              org,
+            );
+          },
           readyPoolImageIdentity(lease: LeaseRecord) {
             return new AWSProvider({} as Env, lease.region ?? "", storage!).readyPoolImageIdentity(
               lease,

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -27695,13 +27695,12 @@ describe("fleet lease identity and idle", () => {
         org: "example-org",
       });
       storage.seed(`lease:${held.id}`, held);
-      if (!cloudID)
-        storage.seed("aws-mac-host-allocation:eu-west-1:h-kept", {
-          version: 1,
-          hostID: "h-kept",
-          region: "eu-west-1",
-          org: held.org,
-        });
+      storage.seed("aws-mac-host-allocation:eu-west-1:h-kept", {
+        version: 1,
+        hostID: "h-kept",
+        region: "eu-west-1",
+        org: held.org,
+      });
       let preparations = 0;
       let creates = 0;
       let releases = 0;
@@ -27919,6 +27918,30 @@ describe("fleet lease identity and idle", () => {
       allowed: false,
     },
     {
+      name: "ambiguous legacy allocation org",
+      allocation: true,
+      legacy: true,
+      org: "example-org",
+      region: "eu-west-1",
+      allowed: false,
+    },
+    {
+      name: "allocation host does not match its storage key",
+      allocation: true,
+      allocationHostID: "h-other",
+      org: "example-org",
+      region: "eu-west-1",
+      allowed: false,
+    },
+    {
+      name: "unsupported allocation version",
+      allocation: true,
+      allocationVersion: 2,
+      org: "example-org",
+      region: "eu-west-1",
+      allowed: false,
+    },
+    {
       name: "no allocation",
       allocation: false,
       org: "example-org",
@@ -27926,8 +27949,16 @@ describe("fleet lease identity and idle", () => {
       allowed: false,
     },
     {
-      name: "same org managed history",
+      name: "historical leases alone do not authorize an org member",
       history: true,
+      org: "example-org",
+      region: "eu-west-1",
+      allowed: false,
+    },
+    {
+      name: "admin can pin a host with only historical leases",
+      history: true,
+      admin: true,
       org: "example-org",
       region: "eu-west-1",
       allowed: true,
@@ -27964,14 +27995,25 @@ describe("fleet lease identity and idle", () => {
     },
   ])(
     "host pin authorization: $name",
-    async ({ allocation, history, registered, legacy, org, region, allowed }) => {
+    async ({
+      allocation,
+      allocationHostID,
+      allocationVersion,
+      history,
+      admin,
+      registered,
+      legacy,
+      org,
+      region,
+      allowed,
+    }) => {
       const storage = new MemoryStorage();
       if (allocation)
-        storage.seed(`aws-mac-host-allocation:${region}:h-owned`, {
-          version: 1,
-          hostID: "h-owned",
+        await storage.put(`aws-mac-host-allocation:${region}:h-owned`, {
+          version: allocationVersion ?? 1,
+          hostID: allocationHostID ?? "h-owned",
           region,
-          org: orgKeyForLabel(org),
+          org: legacy ? org : orgKeyForLabel(org),
         });
       if (history) {
         const lease = testLease({
@@ -28003,7 +28045,11 @@ describe("fleet lease identity and idle", () => {
       });
       const response = await fleet.fetch(
         request("POST", "/v1/leases", {
-          headers: { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" },
+          headers: {
+            "x-crabbox-owner": "alice@example.com",
+            "x-crabbox-org": "example-org",
+            ...(admin ? { "x-crabbox-admin": "true" } : {}),
+          },
           body: {
             provider: "aws",
             target: "macos",
@@ -28016,6 +28062,9 @@ describe("fleet lease identity and idle", () => {
       );
       expect(response.status).toBe(allowed ? 201 : 403);
       expect(creates).toBe(allowed ? 1 : 0);
+      await expect(response.json()).resolves.toMatchObject(
+        allowed ? { lease: { hostId: "h-owned" } } : { error: "admin_required" },
+      );
     },
   );
 


### PR DESCRIPTION
A new host-pinned warmup could reactivate a different retained Mac lease, bootstrap it, then terminate its instance after bootstrap failed. This change rejects occupied host pins and cross-ID coordinator replies, keeps retained leases visible, and permits org members to pin unused Mac hosts with an exact coordinator allocation record.

### Incident and root causes

An operator requested a new Mac lease on a pinned Dedicated Host. The coordinator returned an older retained lease under its original ID instead of the requested ID. Warmup accepted that identity and released it after bootstrap failed. Ordinary listing had hidden the retained lease.

- The coordinator's [retained-host lookup](https://github.com/openclaw/crabbox/blob/642bea378ea93b8eb4a69d10f3f01ab3ee01b0f0/worker/src/fleet.ts#L3887) and [reactivation branch](https://github.com/openclaw/crabbox/blob/642bea378ea93b8eb4a69d10f3f01ab3ee01b0f0/worker/src/fleet.ts#L4094) explicitly remapped a fresh request to a released lease. Removed that path; reservation checks now reject live or retained occupancy, including server ID zero or incomplete retained-instance metadata, with the occupying lease ID and slug. Same-ID fixed replay retains its intent checks.
- The CLI [moved keys to a returned ID and used it for rollback](https://github.com/openclaw/crabbox/blob/642bea378ea93b8eb4a69d10f3f01ab3ee01b0f0/internal/cli/provider_coordinator.go#L280). It now requires the requested ID on creation, recovery, and activation before bootstrap or cleanup. An observed mismatch also suppresses cancel-create because an older coordinator can redirect that cancellation to the retained lease. Worker replay/cancel checks reject legacy cross-ID bindings.
- [Listing requested only active leases](https://github.com/openclaw/crabbox/blob/642bea378ea93b8eb4a69d10f3f01ab3ee01b0f0/internal/cli/provider_coordinator.go#L994). Text and JSON now include retained leases. The Worker filters visibility/current state before limiting; the CLI filters older-coordinator responses locally and warns at the 1,000-row cap.
- [Host authorization depended on admin auth or retained-instance adoption](https://github.com/openclaw/crabbox/blob/642bea378ea93b8eb4a69d10f3f01ab3ee01b0f0/worker/src/fleet.ts#L3896). AWS-specific authorization now lives in the provider adapter, independently of adoption. New admin allocations persist their org. Org-member pins require an exact versioned allocation record matching the host, requested region, and current org identity. Historical managed leases never authorize pinning. Missing records, ambiguous org identities, mismatched host/region, unsupported record versions, and other-org records remain admin-only. Other resource selectors and fleet administration remain admin-only.

### Verification

- `/opt/homebrew/bin/go vet ./...`
- `/opt/homebrew/bin/go test -race -timeout=20m ./internal/cli -run 'TestCoordinator' -count=1`: passed (173.1 seconds). The focused new regressions and async fixture suite also passed independently under `-race`.
- `npm ci --prefix worker`
- `npm run check --prefix worker`, `npm run lint --prefix worker`, `npm run format:check --prefix worker`
- `npm test --prefix worker`: 2,960 passed, 3 skipped; 52 test files passed, 2 skipped.
- CLI build succeeded. A fresh tiny Linux lease with `keep=true` completed warmup and appeared in text and JSON list output, then was stopped by exact ID. Inspect confirmed `state=released`, `cleanupStatus=complete`, and a provider-cleanup completion timestamp; the final list omitted the deleted lease. Warmup logged one transient heartbeat timeout and still completed successfully.
- Independent Codex autoreview: the allocation-record authorization follow-up is scoped clean through P1; the earlier lease protection changes were scoped clean at P0.

Regression coverage includes occupied active/provisioning/retained hosts, explicit fixed replay, concurrent reservation, old cross-ID cancellation bindings, exact allocation matching, historical-only member rejection/admin access, ambiguous-org and malformed-record exclusions, allocation persistence, retained listing, and CLI rejection before bootstrap/key changes/release/cancellation. The first broad runs exposed old checkpoint and Go async fixtures that assumed cross-ID adoption; those were corrected, then both broad suites passed. Checkpoint forks now obey the same occupancy and exact-ID rule.

### Rollout and limits

The coordinator change **needs a deploy after review/merge**. This PR does not deploy, merge, release, or publish anything. No new secrets are required. The CLI protection and retained listing work against older coordinators; an older coordinator's historical response cap can still omit older rows, with an explicit warning and exact-ID inspect guidance. Older hosts without exact allocation records remain admin-only even if their lease history belongs to the requester's org. The optional admin claim/backfill command was skipped: verified host lookup, ownership-conflict handling, CLI/client plumbing, and tests would exceed the approximately 150-line scope. Host permission does not grant access to another member's lease.
