### PR TITLE
fix: retain causes of interrupted coordinator provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changes
 
+- Show the recorded provisioning cause when a coordinator lease fails with cleanup still pending, preserving the primary failure when present and omitting empty error details.
+
 - Reject occupied host pins and coordinator replies with a different lease ID before bootstrap or cleanup; show retained leases in ordinary text and JSON listing. [PR 2049](https://github.com/openclaw/crabbox/pull/2049). Thanks @steipete.
 - Require an exact coordinator host/org/region allocation record for org-member AWS Mac host pins; historical leases never grant pin access, and missing, ambiguous, or other-org records remain admin-only. [PR 2049](https://github.com/openclaw/crabbox/pull/2049). Thanks @steipete.
 

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -53,6 +53,12 @@ the ready lease; it does not allocate again or stop the Testbox.
 Warmup records a local claim binding the lease to the current repo checkout. Use
 `--reclaim` to overwrite an existing claim for that lease.
 
+If a coordinator lease ends while provisioning, warmup reports the lease ID,
+terminal state, and recorded failure cause. When the coordinator retains the
+cause in cleanup metadata because a resource may still exist, warmup includes
+that diagnostic. Use `crabbox inspect --id <lease>` to check the retained
+provisioning and cleanup evidence before recovery.
+
 Warmup requires an explicit provider selection from `--provider`,
 `CRABBOX_PROVIDER`, user or repository config, broker config, or an applicable
 recorded lease route. With no selection it exits before provider initialization

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -764,7 +764,12 @@ func coordinatorLeaseProvisioningError(lease CoordinatorLease) error {
 	case "active", "provisioning":
 		return nil
 	case "failed", "released", "expired":
-		return coordinatorLeaseProvisioningStateError{message: fmt.Sprintf("coordinator lease %s ended while provisioning: state=%s error=%s", lease.ID, lease.State, lease.FailureError)}
+		message := fmt.Sprintf("coordinator lease %s ended while provisioning: state=%s", lease.ID, lease.State)
+		// Provisioning failures retain their cause in cleanupError while a resource may still exist.
+		if cause := blank(lease.FailureError, lease.CleanupError); cause != "" {
+			message += " error=" + cause
+		}
+		return coordinatorLeaseProvisioningStateError{message: message}
 	default:
 		return coordinatorLeaseProvisioningStateError{message: fmt.Sprintf("coordinator lease %s returned unexpected provisioning state %q", lease.ID, lease.State)}
 	}

--- a/internal/cli/provider_coordinator_async_test.go
+++ b/internal/cli/provider_coordinator_async_test.go
@@ -507,6 +507,46 @@ func TestCoordinatorAsyncReplayedActiveLeaseRequiresEndpoint(t *testing.T) {
 	})
 }
 
+func TestCoordinatorAsyncTerminalProvisioningCause(t *testing.T) {
+	for _, stage := range []string{"initial", "poll"} {
+		for _, tc := range []struct {
+			name    string
+			failure string
+			cleanup string
+			want    string
+		}{
+			{name: "pending cleanup", cleanup: "provider SSH readiness timed out", want: "error=provider SSH readiness timed out"},
+			{name: "primary failure", failure: "provider allocation failed", cleanup: "provider cleanup retry failed", want: "error=provider allocation failed"},
+			{name: "no cause"},
+		} {
+			t.Run(stage+"/"+tc.name, func(t *testing.T) {
+				synctest.Test(t, func(t *testing.T) {
+					f := newCoordinatorAsyncFixture(t, false)
+					terminal := f.lease("failed")
+					terminal.FailureError, terminal.CleanupError = tc.failure, tc.cleanup
+					resourceMayExist := true
+					terminal.ProvisioningResourceMayExist = &resourceMayExist
+					f.onCreate = func(*http.Request) (*http.Response, error) {
+						if stage == "initial" {
+							return f.reply(terminal)
+						}
+						return f.reply(f.lease("provisioning"))
+					}
+					f.onGet = func(*http.Request) (*http.Response, error) { return f.reply(terminal) }
+					lease, err := f.acquire(context.Background())
+					want := "coordinator lease " + f.canonical + " ended while provisioning: state=failed"
+					if tc.want != "" {
+						want += " " + tc.want
+					}
+					if err == nil || err.Error() != want || lease.ID != "" || f.creates != 1 || f.cancels != 1 {
+						t.Fatalf("lease=%#v err=%v want=%q creates=%d cancels=%d", lease, err, want, f.creates, f.cancels)
+					}
+				})
+			})
+		}
+	}
+}
+
 func TestCoordinatorAsyncTerminalDiagnosticDoesNotAuthorizeFreshAllocation(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		f := newCoordinatorAsyncFixture(t, false)


### PR DESCRIPTION
## Problem

A coordinator lease can fail during provisioning while provider cleanup is still pending. The coordinator retains that cause in `cleanupError` and leaves `failureError` empty, so warmup reported `state=failed error=` and hid the reason the machine never became ready.

## Change

Report the retained cleanup cause when no primary provisioning failure is present. Preserve primary-failure precedence, and omit the empty error suffix when neither field contains a cause. Lease ownership, terminal states, and cleanup requirements are unchanged.

## Evidence

The backend regression failed before the production fix for both initial and polled terminal responses. It now passes alongside the existing asynchronous provisioning cases: `go test -race ./internal/cli -run '^TestCoordinatorAsync' -count=1`. `go vet ./internal/cli` and `git diff --check` passed. Independent isolated review found no actionable P0–P2 issues.

### Executable CLI proof

Built the exact PR head and ran it and installed 0.51.0 against the same disposable loopback HTTP coordinator. The fixture returns `provisioning` from the fixed-ID PUT, then `failed` from GET with `cleanupError` populated and `failureError` absent. Both real CLI processes exit 1 and make exactly one PUT and one GET.

```text
Before (0.51.0):
coordinator lease cbx_abcdef123456 ended while provisioning: state=failed error=

After (614a6e32):
coordinator lease cbx_abcdef123456 ended while provisioning: state=failed error=provider provisioning was interrupted; recovered provider resource for cleanup
```

This is executable CLI/HTTP boundary proof using synthetic data and isolated config/state, not live AWS after-fix proof. No provider faults were injected. It reproduces the retained-field shape observed in an actual interrupted AWS allocation; that allocation later completed normal cleanup.

### Review disposition

This is maintainer-authored work. The Unreleased entry follows the repository's maintainer changelog policy and is retained. The diagnostic-only change has observed pre-fix failure, backend regression coverage, and the executable CLI proof above; no cloud lifecycle or API contract changed.
