### PR TITLE
refactor(config): consolidate Lambda configuration ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 - Describe Linode file and environment bindings once, preserving OS-derived initial images, explicit image/type selection, flagless configuration, and saved-file omission while sharing configured fallback values. [PR 2052](https://github.com/openclaw/crabbox/pull/2052). Thanks @steipete.
 
-- Consolidate Lambda configuration and runtime defaults while preserving structured filesystem mounts, image precedence, and YAML diagnostics; clarify the distinct YAML and environment mount formats. Thanks @steipete.
+- Consolidate Lambda configuration and runtime defaults while preserving structured filesystem mounts, image precedence, and YAML diagnostics; clarify the distinct YAML and environment mount formats. [PR 2055](https://github.com/openclaw/crabbox/pull/2055). Thanks @steipete.
 
 ## 0.54.0 - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 - Describe Linode file and environment bindings once, preserving OS-derived initial images, explicit image/type selection, flagless configuration, and saved-file omission while sharing configured fallback values. [PR 2052](https://github.com/openclaw/crabbox/pull/2052). Thanks @steipete.
 
+- Consolidate Lambda configuration and runtime defaults while preserving structured filesystem mounts, image precedence, and YAML diagnostics; clarify the distinct YAML and environment mount formats. Thanks @steipete.
+
 ## 0.54.0 - 2026-09-09
 
 ### Highlights

--- a/docs/providers/lambda.md
+++ b/docs/providers/lambda.md
@@ -69,7 +69,21 @@ Config keys under `lambda:`:
 | `firewallRuleset` | `cfg.Lambda.FirewallRuleset` | empty | Optional existing Lambda firewall ruleset name. |
 | `sshCIDRs` | `cfg.Lambda.SSHCIDRs` | empty | Reserved for firewall-aware follow-up work; this phase does not create firewall rules. |
 | `filesystemNames` | `cfg.Lambda.FilesystemNames` | empty | Optional existing Lambda filesystem names to attach. |
-| `filesystemMounts` | `cfg.Lambda.FilesystemMounts` | empty | Optional existing Lambda filesystems with mount paths, e.g. `cache:/mnt/cache`. |
+| `filesystemMounts` | `cfg.Lambda.FilesystemMounts` | empty | Optional existing Lambda filesystems with mount paths; YAML entries use `name` and `mountPath` mappings. |
+
+YAML mount entries are mappings, not `name:/path` strings:
+
+```yaml
+lambda:
+  filesystemMounts:
+    - name: cache
+      mountPath: /mnt/cache
+```
+
+The environment form is comma-separated text, for example
+`CRABBOX_LAMBDA_FILESYSTEM_MOUNTS=cache:/mnt/cache,shared`. A name without a
+colon has no explicit mount path. Parsing preserves entry order and duplicates;
+native filesystem lookup remains separate.
 
 The portable `--os ubuntu:24.04` selector maps to the default
 `lambda-stack-24-04` image family. Other explicit portable OS selectors are
@@ -96,6 +110,20 @@ CRABBOX_LAMBDA_FILESYSTEM_MOUNTS       Comma-separated name[:mountPath] entries
 
 Do not pass the Lambda API key as a command-line argument. Keep it in the
 environment or in a local secret manager.
+
+### Input precedence
+
+All eight settings are owned together in `internal/cli/config_lambda.go`, with
+no provider-specific flags. Empty scalar input and omitted/null/empty file lists
+leave prior values intact. Nonempty YAML lists retain their raw entries;
+environment lists trim comma-separated entries and discard blanks.
+
+An image-only file override clears an inherited image family. A file specifying
+both keeps both for later validation; a family-only file override does not clear
+an existing image. Environment overrides apply image first and family second,
+clearing the other choice each time, so a nonempty environment family wins when
+both are set. Accepted type/image/family values remain explicit even when equal
+to a default. File decoding stays zero-valued; runtime initialization remains separate.
 
 ## Token Scope
 

--- a/docs/refactor/typed-provider-config.md
+++ b/docs/refactor/typed-provider-config.md
@@ -145,6 +145,26 @@ ignore zero. Modal's `secrets: []` deliberately remains pointer-backed so a writ
 retains the explicit clear. Positive-only numeric overlays still store negative
 inputs verbatim: ignoring an assignment is not permission to erase its file value.
 
+## Lambda's concrete owner
+
+Lambda uses `config_lambda.go` without generated bindings. Its structured mount
+list and different file/environment image-pair rules remain explicit typed code.
+`LambdaConfig` owns one eight-field YAML shape; the defined
+`type fileLambdaConfig LambdaConfig` preserves the existing file-input type name
+in decoder diagnostics without duplicating the fields. File input stays zero-valued,
+and runtime initialization is a separate function. No JSON tags or custom marshal
+methods are added; the supported file writer and config-show formats stay unchanged.
+Ad-hoc YAML serialization of the raw runtime type is not a supported contract.
+
+The source applicators and existing mount parser live with that concrete owner.
+`WithRuntimeDefaults` owns raw-empty region/type filling and the image-family
+fallback when both image and family are empty. Runtime initialization delegates
+from the zero value. Core applies the transform before its explicit OS override;
+the backend retains generic server-type projection before applying it. Trim-aware
+provider lookups remain separate from these raw-empty rules.
+Native mount filtering, lookup, credentials, class selection and OS mappings remain
+provider policy. The following field instructions apply to generated owners.
+
 ## Adding a field
 
 1. Add an exported, singly named field to the provider's config struct. Supported types

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -372,22 +372,6 @@ type GitHubCodespacesConfig struct {
 	WorkRoot         string
 }
 
-type LambdaConfig struct {
-	Region           string
-	Type             string
-	Image            string
-	ImageFamily      string
-	FirewallRuleset  string
-	SSHCIDRs         []string
-	FilesystemNames  []string
-	FilesystemMounts []LambdaFilesystemMount
-}
-
-type LambdaFilesystemMount struct {
-	Name      string `yaml:"name,omitempty" json:"name,omitempty"`
-	MountPath string `yaml:"mountPath,omitempty" json:"mountPath,omitempty"`
-}
-
 // NebiusConfig is intentionally non-secret. Authentication stays in the
 // Nebius CLI profile store and is never accepted as Crabbox config or argv.
 type NebiusConfig struct {
@@ -1506,20 +1490,13 @@ func applyProviderConfigDefaults(cfg *Config) error {
 		return validateTargetConfig(*cfg)
 	}
 	if cfg.Provider == "lambda" {
-		if cfg.Lambda.Region == "" {
-			cfg.Lambda.Region = "us-west-1"
-		}
-		if cfg.Lambda.Type == "" {
-			cfg.Lambda.Type = "gpu_1x_a10"
-		}
+		cfg.Lambda = cfg.Lambda.WithRuntimeDefaults()
 		if cfg.osImageExplicit && !cfg.lambdaImageExplicit && !cfg.lambdaImageFamilyExplicit {
 			if cfg.OSImage == "ubuntu:24.04" {
 				cfg.Lambda.ImageFamily = "lambda-stack-24-04"
 			} else {
 				cfg.Lambda.ImageFamily = ""
 			}
-		} else if cfg.Lambda.Image == "" && cfg.Lambda.ImageFamily == "" {
-			cfg.Lambda.ImageFamily = "lambda-stack-24-04"
 		}
 		applyLinuxConnectionDefaults(cfg, "ubuntu", "22")
 		cfg.SSHFallbackPorts = nil
@@ -2413,11 +2390,7 @@ func baseConfig() Config {
 			DeleteOnRelease: true,
 			WorkRoot:        "/workspaces/crabbox",
 		},
-		Lambda: LambdaConfig{
-			Region:      "us-west-1",
-			Type:        "gpu_1x_a10",
-			ImageFamily: "lambda-stack-24-04",
-		},
+		Lambda:       initialLambdaConfig(),
 		OVH:          defaultOVHConfig(),
 		Scaleway:     defaultScalewayConfig(),
 		TencentCloud: defaultTencentCloudConfig(),
@@ -2926,17 +2899,6 @@ type fileGitHubCodespacesConfig struct {
 	RetentionPeriod  string `yaml:"retentionPeriod,omitempty"`
 	DeleteOnRelease  *bool  `yaml:"deleteOnRelease,omitempty"`
 	WorkRoot         string `yaml:"workRoot,omitempty"`
-}
-
-type fileLambdaConfig struct {
-	Region           string                  `yaml:"region,omitempty"`
-	Type             string                  `yaml:"type,omitempty"`
-	Image            string                  `yaml:"image,omitempty"`
-	ImageFamily      string                  `yaml:"imageFamily,omitempty"`
-	FirewallRuleset  string                  `yaml:"firewallRuleset,omitempty"`
-	SSHCIDRs         []string                `yaml:"sshCIDRs,omitempty"`
-	FilesystemNames  []string                `yaml:"filesystemNames,omitempty"`
-	FilesystemMounts []LambdaFilesystemMount `yaml:"filesystemMounts,omitempty"`
 }
 
 type fileNebiusConfig struct {
@@ -4347,40 +4309,16 @@ func applyFileConfigWithTrustAndProviderSource(cfg *Config, file fileConfig, tru
 			cfg.GitHubCodespaces.WorkRoot = file.GitHubCodespaces.WorkRoot
 		}
 	}
-	if file.Lambda != nil {
-		lambdaImageSet := false
-		lambdaImageFamilySet := false
-		if file.Lambda.Region != "" {
-			cfg.Lambda.Region = file.Lambda.Region
-		}
-		if file.Lambda.Type != "" {
-			cfg.Lambda.Type = file.Lambda.Type
+	{
+		applied := cfg.Lambda.applyFile(file.Lambda)
+		if applied.Type {
 			cfg.lambdaTypeExplicit = true
 		}
-		if file.Lambda.Image != "" {
-			cfg.Lambda.Image = file.Lambda.Image
+		if applied.Image {
 			cfg.lambdaImageExplicit = true
-			lambdaImageSet = true
 		}
-		if file.Lambda.ImageFamily != "" {
-			cfg.Lambda.ImageFamily = file.Lambda.ImageFamily
+		if applied.ImageFamily {
 			cfg.lambdaImageFamilyExplicit = true
-			lambdaImageFamilySet = true
-		}
-		if lambdaImageSet && !lambdaImageFamilySet {
-			cfg.Lambda.ImageFamily = ""
-		}
-		if file.Lambda.FirewallRuleset != "" {
-			cfg.Lambda.FirewallRuleset = file.Lambda.FirewallRuleset
-		}
-		if len(file.Lambda.SSHCIDRs) > 0 {
-			cfg.Lambda.SSHCIDRs = file.Lambda.SSHCIDRs
-		}
-		if len(file.Lambda.FilesystemNames) > 0 {
-			cfg.Lambda.FilesystemNames = file.Lambda.FilesystemNames
-		}
-		if len(file.Lambda.FilesystemMounts) > 0 {
-			cfg.Lambda.FilesystemMounts = file.Lambda.FilesystemMounts
 		}
 	}
 	if file.Nebius != nil {
@@ -6854,30 +6792,17 @@ func applyEnv(cfg *Config) error {
 		MarkDeleteOnReleaseExplicit(cfg, "github-codespaces")
 	}
 	cfg.GitHubCodespaces.WorkRoot = getenv("CRABBOX_GITHUB_CODESPACES_WORK_ROOT", cfg.GitHubCodespaces.WorkRoot)
-	cfg.Lambda.Region = getenv("CRABBOX_LAMBDA_REGION", cfg.Lambda.Region)
-	if lambdaType := os.Getenv("CRABBOX_LAMBDA_TYPE"); lambdaType != "" {
-		cfg.Lambda.Type = lambdaType
-		cfg.lambdaTypeExplicit = true
-	}
-	if image := os.Getenv("CRABBOX_LAMBDA_IMAGE"); image != "" {
-		cfg.Lambda.Image = image
-		cfg.lambdaImageExplicit = true
-		cfg.Lambda.ImageFamily = ""
-	}
-	if imageFamily := os.Getenv("CRABBOX_LAMBDA_IMAGE_FAMILY"); imageFamily != "" {
-		cfg.Lambda.ImageFamily = imageFamily
-		cfg.lambdaImageFamilyExplicit = true
-		cfg.Lambda.Image = ""
-	}
-	cfg.Lambda.FirewallRuleset = getenv("CRABBOX_LAMBDA_FIREWALL_RULESET", cfg.Lambda.FirewallRuleset)
-	if cidrs := os.Getenv("CRABBOX_LAMBDA_SSH_CIDRS"); cidrs != "" {
-		cfg.Lambda.SSHCIDRs = splitCommaList(cidrs)
-	}
-	if names := os.Getenv("CRABBOX_LAMBDA_FILESYSTEM_NAMES"); names != "" {
-		cfg.Lambda.FilesystemNames = splitCommaList(names)
-	}
-	if mounts := os.Getenv("CRABBOX_LAMBDA_FILESYSTEM_MOUNTS"); mounts != "" {
-		cfg.Lambda.FilesystemMounts = parseLambdaFilesystemMounts(mounts)
+	{
+		applied := cfg.Lambda.applyEnv()
+		if applied.Type {
+			cfg.lambdaTypeExplicit = true
+		}
+		if applied.Image {
+			cfg.lambdaImageExplicit = true
+		}
+		if applied.ImageFamily {
+			cfg.lambdaImageFamilyExplicit = true
+		}
 	}
 	cfg.Nebius.CLI = getenv("CRABBOX_NEBIUS_CLI", cfg.Nebius.CLI)
 	cfg.Nebius.Profile = getenv("CRABBOX_NEBIUS_PROFILE", cfg.Nebius.Profile)
@@ -8542,20 +8467,6 @@ func getenvList(name string) ([]string, bool) {
 func splitCommaList(value string) []string {
 	parts := strings.Split(value, ",")
 	return normalizeList(parts)
-}
-
-func parseLambdaFilesystemMounts(value string) []LambdaFilesystemMount {
-	parts := splitCommaList(value)
-	out := make([]LambdaFilesystemMount, 0, len(parts))
-	for _, part := range parts {
-		name, mountPath, ok := strings.Cut(part, ":")
-		if !ok {
-			out = append(out, LambdaFilesystemMount{Name: strings.TrimSpace(part)})
-			continue
-		}
-		out = append(out, LambdaFilesystemMount{Name: strings.TrimSpace(name), MountPath: strings.TrimSpace(mountPath)})
-	}
-	return out
 }
 
 func normalizeList(values []string) []string {

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -2803,3 +2803,78 @@ func TestConfigShowLocalContainerExcludesInternalFields(t *testing.T) {
 		}
 	}
 }
+
+func TestLambdaBindingFileRoundTrip(t *testing.T) {
+	path := isolatedConfigPath(t)
+	for _, tc := range []struct {
+		input, want string
+		nilLambda   bool
+	}{{"{}\n", "{}\n", true}, {"lambda: null\n", "{}\n", true}, {"lambda: {}\n", "lambda: {}\n", false}, {"lambda: {sshCIDRs: [], filesystemNames: [], filesystemMounts: []}\n", "lambda: {}\n", false}, {"lambda:\n  region: west\n  type: gpu\n  image: image\n  imageFamily: family\n  firewallRuleset: rule\n  sshCIDRs: [cidr]\n  filesystemNames: [data]\n  filesystemMounts:\n    - name: data\n      mountPath: /mnt/data\n    - {}\n", "lambda:\n    region: west\n    type: gpu\n    image: image\n    imageFamily: family\n    firewallRuleset: rule\n    sshCIDRs:\n        - cidr\n    filesystemNames:\n        - data\n    filesystemMounts:\n        - name: data\n          mountPath: /mnt/data\n        - {}\n", false}} {
+		if err := os.WriteFile(path, []byte(tc.input), 0600); err != nil {
+			t.Fatal(err)
+		}
+		file, err := readFileConfig(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if (file.Lambda == nil) != tc.nilLambda {
+			t.Fatalf("decoded lambda=%#v", file.Lambda)
+		}
+		if tc.input == "lambda: {}\n" && !reflect.DeepEqual(*file.Lambda, fileLambdaConfig{}) {
+			t.Fatal("decoded file initialized runtime defaults")
+		}
+		written, err := writeUserFileConfig(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if written != path {
+			t.Fatalf("write path=%q", written)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != tc.want {
+			t.Fatalf("YAML got=%q want=%q", data, tc.want)
+		}
+		again, err := readFileConfig(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tc.input != "lambda: {sshCIDRs: [], filesystemNames: [], filesystemMounts: []}\n" && !reflect.DeepEqual(again, file) {
+			t.Fatal("roundtrip fields changed")
+		}
+	}
+	for _, tc := range []struct{ input, detail string }{{"lambda: wrong\n", "line 1: cannot unmarshal !!str `wrong` into cli.fileLambdaConfig"}, {"lambda: [wrong]\n", "line 1: cannot unmarshal !!seq into cli.fileLambdaConfig"}} {
+		if err := os.WriteFile(path, []byte(tc.input), 0600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := readFileConfig(path)
+		want := "parse config " + path + ": yaml: unmarshal errors:\n  " + tc.detail
+		if err == nil || err.Error() != want {
+			t.Fatalf("diagnostic=%v want=%q", err, want)
+		}
+	}
+}
+
+func TestLambdaBindingJSON(t *testing.T) {
+	isolatedConfigPath(t)
+	cfg := baseConfig()
+	cfg.Lambda = LambdaConfig{Region: "west", Type: "gpu", Image: "image", ImageFamily: "family", FirewallRuleset: "rule", SSHCIDRs: []string{"cidr"}, FilesystemNames: []string{"data"}, FilesystemMounts: []LambdaFilesystemMount{{Name: "data", MountPath: "/mnt/data"}, {}}}
+	data, err := json.Marshal(cfg.Lambda)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"Region":"west","Type":"gpu","Image":"image","ImageFamily":"family","FirewallRuleset":"rule","SSHCIDRs":["cidr"],"FilesystemNames":["data"],"FilesystemMounts":[{"name":"data","mountPath":"/mnt/data"},{}]}`
+	if string(data) != want {
+		t.Fatalf("runtime JSON=%s", data)
+	}
+	data, err = json.Marshal(configShowView(cfg)["lambda"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = `{"auth":"missing","filesystemMounts":[{"name":"data","mountPath":"/mnt/data"},{}],"filesystemNames":["data"],"firewallRuleset":"rule","image":"image","imageFamily":"family","region":"west","sshCIDRs":["cidr"],"type":"gpu"}`
+	if string(data) != want {
+		t.Fatalf("config-show JSON=%s", data)
+	}
+}

--- a/internal/cli/config_lambda.go
+++ b/internal/cli/config_lambda.go
@@ -1,0 +1,141 @@
+package cli
+
+import (
+	"os"
+	"strings"
+)
+
+const (
+	LambdaConfiguredRegionDefault = "us-west-1"
+	LambdaConfiguredTypeDefault   = "gpu_1x_a10"
+	LambdaImageFamilyFallback     = "lambda-stack-24-04"
+)
+
+// LambdaConfig owns the complete runtime and file field shape. Native mount
+// interpretation and portable OS selection remain separate policy.
+type LambdaConfig struct {
+	Region           string                  `yaml:"region,omitempty"`
+	Type             string                  `yaml:"type,omitempty"`
+	Image            string                  `yaml:"image,omitempty"`
+	ImageFamily      string                  `yaml:"imageFamily,omitempty"`
+	FirewallRuleset  string                  `yaml:"firewallRuleset,omitempty"`
+	SSHCIDRs         []string                `yaml:"sshCIDRs,omitempty"`
+	FilesystemNames  []string                `yaml:"filesystemNames,omitempty"`
+	FilesystemMounts []LambdaFilesystemMount `yaml:"filesystemMounts,omitempty"`
+}
+
+// Keep the defined file type's identity for existing YAML decoder diagnostics.
+type fileLambdaConfig LambdaConfig
+
+type LambdaFilesystemMount struct {
+	Name      string `yaml:"name,omitempty" json:"name,omitempty"`
+	MountPath string `yaml:"mountPath,omitempty" json:"mountPath,omitempty"`
+}
+
+type LambdaConfigApplied struct {
+	Type        bool
+	Image       bool
+	ImageFamily bool
+}
+
+func initialLambdaConfig() LambdaConfig {
+	return (LambdaConfig{}).WithRuntimeDefaults()
+}
+
+// WithRuntimeDefaults fills the raw configured defaults on a shallow copy.
+// Explicit OS policy and native trim-aware selection remain separate.
+func (cfg LambdaConfig) WithRuntimeDefaults() LambdaConfig {
+	if cfg.Region == "" {
+		cfg.Region = LambdaConfiguredRegionDefault
+	}
+	if cfg.Type == "" {
+		cfg.Type = LambdaConfiguredTypeDefault
+	}
+	if cfg.Image == "" && cfg.ImageFamily == "" {
+		cfg.ImageFamily = LambdaImageFamilyFallback
+	}
+	return cfg
+}
+
+func (cfg *LambdaConfig) applyFile(file *fileLambdaConfig) LambdaConfigApplied {
+	var applied LambdaConfigApplied
+	if file == nil {
+		return applied
+	}
+	values := LambdaConfig(*file)
+	if values.Region != "" {
+		cfg.Region = values.Region
+	}
+	if values.Type != "" {
+		cfg.Type = values.Type
+		applied.Type = true
+	}
+	if values.Image != "" {
+		cfg.Image = values.Image
+		applied.Image = true
+	}
+	if values.ImageFamily != "" {
+		cfg.ImageFamily = values.ImageFamily
+		applied.ImageFamily = true
+	}
+	if applied.Image && !applied.ImageFamily {
+		cfg.ImageFamily = ""
+	}
+	if values.FirewallRuleset != "" {
+		cfg.FirewallRuleset = values.FirewallRuleset
+	}
+	if len(values.SSHCIDRs) > 0 {
+		cfg.SSHCIDRs = values.SSHCIDRs
+	}
+	if len(values.FilesystemNames) > 0 {
+		cfg.FilesystemNames = values.FilesystemNames
+	}
+	if len(values.FilesystemMounts) > 0 {
+		cfg.FilesystemMounts = values.FilesystemMounts
+	}
+	return applied
+}
+
+func (cfg *LambdaConfig) applyEnv() LambdaConfigApplied {
+	var applied LambdaConfigApplied
+	cfg.Region = getenv("CRABBOX_LAMBDA_REGION", cfg.Region)
+	if lambdaType := os.Getenv("CRABBOX_LAMBDA_TYPE"); lambdaType != "" {
+		cfg.Type = lambdaType
+		applied.Type = true
+	}
+	if image := os.Getenv("CRABBOX_LAMBDA_IMAGE"); image != "" {
+		cfg.Image = image
+		applied.Image = true
+		cfg.ImageFamily = ""
+	}
+	if imageFamily := os.Getenv("CRABBOX_LAMBDA_IMAGE_FAMILY"); imageFamily != "" {
+		cfg.ImageFamily = imageFamily
+		applied.ImageFamily = true
+		cfg.Image = ""
+	}
+	cfg.FirewallRuleset = getenv("CRABBOX_LAMBDA_FIREWALL_RULESET", cfg.FirewallRuleset)
+	if cidrs := os.Getenv("CRABBOX_LAMBDA_SSH_CIDRS"); cidrs != "" {
+		cfg.SSHCIDRs = splitCommaList(cidrs)
+	}
+	if names := os.Getenv("CRABBOX_LAMBDA_FILESYSTEM_NAMES"); names != "" {
+		cfg.FilesystemNames = splitCommaList(names)
+	}
+	if mounts := os.Getenv("CRABBOX_LAMBDA_FILESYSTEM_MOUNTS"); mounts != "" {
+		cfg.FilesystemMounts = parseLambdaFilesystemMounts(mounts)
+	}
+	return applied
+}
+
+func parseLambdaFilesystemMounts(value string) []LambdaFilesystemMount {
+	parts := splitCommaList(value)
+	out := make([]LambdaFilesystemMount, 0, len(parts))
+	for _, part := range parts {
+		name, mountPath, ok := strings.Cut(part, ":")
+		if !ok {
+			out = append(out, LambdaFilesystemMount{Name: strings.TrimSpace(part)})
+			continue
+		}
+		out = append(out, LambdaFilesystemMount{Name: strings.TrimSpace(name), MountPath: strings.TrimSpace(mountPath)})
+	}
+	return out
+}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -13283,3 +13283,253 @@ func TestLinodeTypedInitializer(t *testing.T) {
 		}
 	}
 }
+
+func TestLambdaBindingSources(t *testing.T) {
+	for _, source := range []string{"user", "repo", "env"} {
+		for _, raw := range []string{"", "same", "  ", "custom"} {
+			t.Run(source+raw, func(t *testing.T) {
+				cfg := baseConfig()
+				cfg.Lambda = LambdaConfig{Region: "same", Type: "same", Image: "same", ImageFamily: "same", FirewallRuleset: "same"}
+				v := raw
+				if v == "" {
+					v = "same"
+				}
+				want := LambdaConfig{Region: v, Type: v, Image: v, ImageFamily: v, FirewallRuleset: v}
+				if source == "env" {
+					for _, key := range []string{"REGION", "TYPE", "IMAGE", "IMAGE_FAMILY", "FIREWALL_RULESET"} {
+						t.Setenv("CRABBOX_LAMBDA_"+key, raw)
+					}
+					if raw != "" {
+						want.Image = ""
+					}
+					if err := applyEnv(&cfg); err != nil {
+						t.Fatal(err)
+					}
+				} else {
+					data, err := yaml.Marshal(map[string]any{"lambda": map[string]any{"region": raw, "type": raw, "image": raw, "imageFamily": raw, "firewallRuleset": raw}})
+					if err != nil {
+						t.Fatal(err)
+					}
+					var file fileConfig
+					if err := yaml.Unmarshal(data, &file); err != nil {
+						t.Fatal(err)
+					}
+					if err := applyFileConfigWithTrust(&cfg, file, source == "user"); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if !reflect.DeepEqual(cfg.Lambda, want) || cfg.lambdaTypeExplicit != (raw != "") || cfg.lambdaImageExplicit != (raw != "") || cfg.lambdaImageFamilyExplicit != (raw != "") {
+					t.Fatalf("source=%s raw=%q got=%#v want=%#v", source, raw, cfg.Lambda, want)
+				}
+			})
+		}
+	}
+	for _, raw := range []string{"{}", "null", "{region: null, type: null, image: null, imageFamily: null, firewallRuleset: null}"} {
+		var file fileConfig
+		if err := yaml.Unmarshal([]byte("lambda: "+raw), &file); err != nil {
+			t.Fatal(err)
+		}
+		cfg := baseConfig()
+		before := cfg.Lambda
+		if err := applyFileConfig(&cfg, file); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(cfg.Lambda, before) || cfg.lambdaTypeExplicit || cfg.lambdaImageExplicit || cfg.lambdaImageFamilyExplicit {
+			t.Fatal("empty/null input changed config")
+		}
+	}
+}
+
+func TestLambdaBindingPairs(t *testing.T) {
+	for _, source := range []string{"user", "repo", "env"} {
+		for _, tc := range []struct{ image, family, wantImage, wantFamily string }{{"new-image", "", "new-image", ""}, {"", "new-family", "old-image", "new-family"}, {"new-image", "new-family", "new-image", "new-family"}} {
+			t.Run(source+tc.image+tc.family, func(t *testing.T) {
+				cfg := baseConfig()
+				cfg.Lambda.Image = "old-image"
+				cfg.Lambda.ImageFamily = "old-family"
+				wi, wf := tc.wantImage, tc.wantFamily
+				if source == "env" {
+					t.Setenv("CRABBOX_LAMBDA_IMAGE", tc.image)
+					t.Setenv("CRABBOX_LAMBDA_IMAGE_FAMILY", tc.family)
+					if tc.family != "" {
+						wi = ""
+					}
+					if err := applyEnv(&cfg); err != nil {
+						t.Fatal(err)
+					}
+				} else {
+					if err := applyFileConfigWithTrust(&cfg, fileConfig{Lambda: &fileLambdaConfig{Image: tc.image, ImageFamily: tc.family}}, source == "user"); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if cfg.Lambda.Image != wi || cfg.Lambda.ImageFamily != wf || cfg.lambdaImageExplicit != (tc.image != "") || cfg.lambdaImageFamilyExplicit != (tc.family != "") || cfg.lambdaTypeExplicit {
+					t.Fatalf("pair image=%q family=%q", cfg.Lambda.Image, cfg.Lambda.ImageFamily)
+				}
+			})
+		}
+	}
+}
+
+func TestLambdaBindingLists(t *testing.T) {
+	for _, trusted := range []bool{false, true} {
+		for _, empty := range []bool{false, true} {
+			file := fileConfig{Lambda: &fileLambdaConfig{SSHCIDRs: []string{" raw ", "", "raw"}, FilesystemNames: []string{" data ", "data"}, FilesystemMounts: []LambdaFilesystemMount{{Name: " data ", MountPath: " /mnt/data "}, {}}}}
+			cfg := baseConfig()
+			if empty {
+				file.Lambda.SSHCIDRs = []string{}
+				file.Lambda.FilesystemNames = []string{}
+				file.Lambda.FilesystemMounts = []LambdaFilesystemMount{}
+				cfg.Lambda.SSHCIDRs = []string{"prior"}
+				cfg.Lambda.FilesystemNames = []string{"prior"}
+				cfg.Lambda.FilesystemMounts = []LambdaFilesystemMount{{Name: "prior"}}
+			}
+			before := cfg.Lambda
+			if err := applyFileConfigWithTrust(&cfg, file, trusted); err != nil {
+				t.Fatal(err)
+			}
+			if empty {
+				if !reflect.DeepEqual(cfg.Lambda, before) {
+					t.Fatal("empty lists replaced prior")
+				}
+			} else {
+				for _, name := range []string{"SSHCIDRs", "FilesystemNames", "FilesystemMounts"} {
+					got := reflect.ValueOf(cfg.Lambda).FieldByName(name)
+					want := reflect.ValueOf(file.Lambda).Elem().FieldByName(name)
+					if !reflect.DeepEqual(got.Interface(), want.Interface()) || got.Pointer() != want.Pointer() {
+						t.Fatalf("file list %s not raw/shared", name)
+					}
+				}
+			}
+		}
+	}
+	for _, raw := range []string{"", " , ", "none", " a:/mnt/a, b, a:/mnt/a "} {
+		t.Run(raw, func(t *testing.T) {
+			for _, key := range []string{"SSH_CIDRS", "FILESYSTEM_NAMES", "FILESYSTEM_MOUNTS"} {
+				t.Setenv("CRABBOX_LAMBDA_"+key, raw)
+			}
+			cfg := baseConfig()
+			if err := applyEnv(&cfg); err != nil {
+				t.Fatal(err)
+			}
+			var strs []string
+			var mounts []LambdaFilesystemMount
+			switch raw {
+			case " , ":
+				strs = []string{}
+				mounts = []LambdaFilesystemMount{}
+			case "none":
+				strs = []string{"none"}
+				mounts = []LambdaFilesystemMount{{Name: "none"}}
+			case " a:/mnt/a, b, a:/mnt/a ":
+				strs = []string{"a:/mnt/a", "b", "a:/mnt/a"}
+				mounts = []LambdaFilesystemMount{{Name: "a", MountPath: "/mnt/a"}, {Name: "b"}, {Name: "a", MountPath: "/mnt/a"}}
+			}
+			if !reflect.DeepEqual(cfg.Lambda.SSHCIDRs, strs) || !reflect.DeepEqual(cfg.Lambda.FilesystemNames, strs) || !reflect.DeepEqual(cfg.Lambda.FilesystemMounts, mounts) {
+				t.Fatalf("env lists=%#v", cfg.Lambda)
+			}
+			if len(strs) > 0 {
+				other := baseConfig()
+				if err := applyEnv(&other); err != nil {
+					t.Fatal(err)
+				}
+				cfg.Lambda.SSHCIDRs[0] = "changed"
+				cfg.Lambda.FilesystemNames[0] = "changed"
+				cfg.Lambda.FilesystemMounts[0].Name = "changed"
+				if !reflect.DeepEqual(other.Lambda.SSHCIDRs, strs) || !reflect.DeepEqual(other.Lambda.FilesystemNames, strs) || !reflect.DeepEqual(other.Lambda.FilesystemMounts, mounts) {
+					t.Fatal("env collections unexpectedly shared")
+				}
+			}
+		})
+	}
+}
+
+func TestLambdaBindingCoreDefaults(t *testing.T) {
+	cfg := baseConfig()
+	if !reflect.DeepEqual(cfg.Lambda, LambdaConfig{Region: "us-west-1", Type: "gpu_1x_a10", ImageFamily: "lambda-stack-24-04"}) || cfg.lambdaTypeExplicit || cfg.lambdaImageExplicit || cfg.lambdaImageFamilyExplicit {
+		t.Fatalf("base=%#v", cfg.Lambda)
+	}
+	for _, tc := range []struct {
+		os       string
+		explicit bool
+		family   string
+	}{{"ubuntu:26.04", false, "lambda-stack-24-04"}, {"ubuntu:24.04", true, "lambda-stack-24-04"}, {"ubuntu:26.04", true, ""}} {
+		cfg := baseConfig()
+		cfg.Provider = "lambda"
+		cfg.OSImage = tc.os
+		cfg.osImageExplicit = tc.explicit
+		if err := applyProviderConfigDefaults(&cfg); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Lambda.ImageFamily != tc.family || cfg.Lambda.Image != "" {
+			t.Fatalf("OS=%s lambda=%#v", tc.os, cfg.Lambda)
+		}
+	}
+	for _, raw := range []string{"", "  ", "custom", "us-west-1"} {
+		for _, pair := range []struct{ image, family, wantFamily string }{{"", "", "lambda-stack-24-04"}, {"image", "", ""}, {"", "family", "family"}, {"image", "family", "family"}, {"  ", "  ", "  "}} {
+			cfg := baseConfig()
+			cfg.Provider = "lambda"
+			cfg.Class = "standard"
+			cfg.Lambda = LambdaConfig{Region: raw, Type: raw, Image: pair.image, ImageFamily: pair.family, FirewallRuleset: "rule", SSHCIDRs: []string{" raw ", ""}, FilesystemNames: []string{"data", "data"}, FilesystemMounts: []LambdaFilesystemMount{{Name: " data ", MountPath: " /mnt/data "}}}
+			cidrs, names, mounts := cfg.Lambda.SSHCIDRs, cfg.Lambda.FilesystemNames, cfg.Lambda.FilesystemMounts
+			r, typ := raw, raw
+			if raw == "" {
+				r = "us-west-1"
+				typ = "gpu_1x_a10"
+			}
+			want := LambdaConfig{Region: r, Type: typ, Image: pair.image, ImageFamily: pair.wantFamily, FirewallRuleset: "rule", SSHCIDRs: []string{" raw ", ""}, FilesystemNames: []string{"data", "data"}, FilesystemMounts: []LambdaFilesystemMount{{Name: " data ", MountPath: " /mnt/data "}}}
+			if err := applyProviderConfigDefaults(&cfg); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(cfg.Lambda, want) || &cfg.Lambda.SSHCIDRs[0] != &cidrs[0] || &cfg.Lambda.FilesystemNames[0] != &names[0] || &cfg.Lambda.FilesystemMounts[0] != &mounts[0] {
+				t.Fatalf("raw=%q pair=%#v cfg=%#v", raw, pair, cfg.Lambda)
+			}
+			if cfg.SSHUser != "ubuntu" || cfg.SSHPort != "22" || cfg.WorkRoot != "/work/crabbox" || cfg.Class != "standard" || cfg.TargetOS != targetLinux {
+				t.Fatal("core generic effects changed")
+			}
+		}
+	}
+	for _, tc := range []struct {
+		os                        string
+		imageMarker, familyMarker bool
+		want                      string
+	}{{"ubuntu:24.04", false, false, "lambda-stack-24-04"}, {"ubuntu:26.04", false, false, ""}, {"ubuntu:26.04", true, false, "family"}, {"ubuntu:26.04", false, true, "family"}, {"ubuntu:24.04", true, true, "family"}} {
+		cfg := baseConfig()
+		cfg.Provider = "lambda"
+		cfg.Lambda = LambdaConfig{Image: "image", ImageFamily: "family"}
+		cfg.OSImage = tc.os
+		cfg.osImageExplicit = true
+		cfg.lambdaImageExplicit = tc.imageMarker
+		cfg.lambdaImageFamilyExplicit = tc.familyMarker
+		cfg.SSHUser = "alice"
+		cfg.SSHPort = "2200"
+		cfg.WorkRoot = "/srv/project"
+		MarkSSHUserExplicit(&cfg)
+		MarkSSHPortExplicit(&cfg)
+		MarkWorkRootExplicit(&cfg)
+		if err := applyProviderConfigDefaults(&cfg); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Lambda.Image != "image" || cfg.Lambda.ImageFamily != tc.want || cfg.Lambda.Region != "us-west-1" || cfg.Lambda.Type != "gpu_1x_a10" || cfg.SSHUser != "alice" || cfg.SSHPort != "2200" || cfg.WorkRoot != "/srv/project" || cfg.Lambda.SSHCIDRs != nil || cfg.Lambda.FilesystemNames != nil || cfg.Lambda.FilesystemMounts != nil {
+			t.Fatalf("explicit OS case=%#v cfg=%#v", tc, cfg.Lambda)
+		}
+	}
+
+}
+
+func TestLambdaWithRuntimeDefaults(t *testing.T) {
+	fixture := func() LambdaConfig {
+		return LambdaConfig{FirewallRuleset: "rule", SSHCIDRs: []string{" raw ", ""}, FilesystemNames: []string{"data", "data"}, FilesystemMounts: []LambdaFilesystemMount{{Name: "data", MountPath: "/mnt/data"}}}
+	}
+	cfg, before, want := fixture(), fixture(), fixture()
+	want.Region, want.Type, want.ImageFamily = "us-west-1", "gpu_1x_a10", "lambda-stack-24-04"
+	got := cfg.WithRuntimeDefaults()
+	if !reflect.DeepEqual(cfg, before) || !reflect.DeepEqual(got, want) {
+		t.Fatalf("receiver=%#v result=%#v", cfg, got)
+	}
+	if &got.SSHCIDRs[0] != &cfg.SSHCIDRs[0] || &got.FilesystemNames[0] != &cfg.FilesystemNames[0] || &got.FilesystemMounts[0] != &cfg.FilesystemMounts[0] {
+		t.Fatal("runtime defaults copied collection backing arrays")
+	}
+	if !reflect.DeepEqual(got.WithRuntimeDefaults(), got) {
+		t.Fatal("runtime defaults are not idempotent")
+	}
+}

--- a/internal/providers/lambda/backend.go
+++ b/internal/providers/lambda/backend.go
@@ -66,15 +66,7 @@ func (b *backend) initDirect() {
 	if b.cfg.ServerType == "" {
 		b.cfg.ServerType = typeForConfig(b.cfg)
 	}
-	if b.cfg.Lambda.Region == "" {
-		b.cfg.Lambda.Region = defaultRegion
-	}
-	if b.cfg.Lambda.Type == "" {
-		b.cfg.Lambda.Type = defaultType
-	}
-	if b.cfg.Lambda.Image == "" && b.cfg.Lambda.ImageFamily == "" {
-		b.cfg.Lambda.ImageFamily = defaultImageFamily
-	}
+	b.cfg.Lambda = b.cfg.Lambda.WithRuntimeDefaults()
 	b.DirectSSHBackend = shared.DirectSSHBackend{
 		SpecValue:       b.spec,
 		Cfg:             b.cfg,

--- a/internal/providers/lambda/backend_test.go
+++ b/internal/providers/lambda/backend_test.go
@@ -107,15 +107,15 @@ func (f *fakeLambdaAPI) DeleteSSHKey(_ context.Context, id string) error {
 }
 
 func (f *fakeLambdaAPI) ListRegions(context.Context) ([]Region, error) {
-	return []Region{{Name: defaultRegion}}, nil
+	return []Region{{Name: "us-west-1"}}, nil
 }
 
 func (f *fakeLambdaAPI) ListInstanceTypes(context.Context) ([]InstanceType, error) {
-	return []InstanceType{{Name: defaultType, RegionsWithCapacityAvailable: []string{defaultRegion}}}, nil
+	return []InstanceType{{Name: defaultType, RegionsWithCapacityAvailable: []string{"us-west-1"}}}, nil
 }
 
 func (f *fakeLambdaAPI) ListImages(context.Context) ([]Image, error) {
-	return []Image{{Family: defaultImageFamily, Region: defaultRegion}}, nil
+	return []Image{{Family: "lambda-stack-24-04", Region: "us-west-1"}}, nil
 }
 
 func (f *fakeLambdaAPI) ListFilesystems(context.Context) ([]Filesystem, error) { return nil, nil }
@@ -134,9 +134,9 @@ func newTestBackend(t *testing.T, api *fakeLambdaAPI) *backend {
 	cfg.SSHPort = defaultPort
 	cfg.WorkRoot = "/work/crabbox"
 	cfg.ServerType = defaultType
-	cfg.Lambda.Region = defaultRegion
+	cfg.Lambda.Region = "us-west-1"
 	cfg.Lambda.Type = defaultType
-	cfg.Lambda.ImageFamily = defaultImageFamily
+	cfg.Lambda.ImageFamily = "lambda-stack-24-04"
 	b := &backend{spec: Provider{}.Spec(), cfg: cfg, rt: core.Runtime{Stderr: io.Discard}}
 	b.clientFactory = func(core.Runtime) (lambdaAPI, error) { return api, nil }
 	b.waitSSH = func(context.Context, *core.SSHTarget, string, time.Duration) error { return nil }
@@ -202,10 +202,10 @@ func TestAcquireCreatesKeyLaunchesPollsAndClaimsLease(t *testing.T) {
 		t.Fatalf("launchRequests=%#v", api.launchRequests)
 	}
 	req := api.launchRequests[0]
-	if req.RegionName != defaultRegion || req.InstanceTypeName != defaultType || req.Quantity != 1 || len(req.SSHKeyNames) != 1 || req.SSHKeyNames[0] != api.addKeyRequests[0].Name {
+	if req.RegionName != "us-west-1" || req.InstanceTypeName != defaultType || req.Quantity != 1 || len(req.SSHKeyNames) != 1 || req.SSHKeyNames[0] != api.addKeyRequests[0].Name {
 		t.Fatalf("launch request=%#v", req)
 	}
-	if req.ImageFamily != defaultImageFamily || req.ImageID != "" || req.UserData == "" || strings.Contains(req.UserData, "base64") {
+	if req.ImageFamily != "lambda-stack-24-04" || req.ImageID != "" || req.UserData == "" || strings.Contains(req.UserData, "base64") {
 		t.Fatalf("launch image/user_data shape=%#v", req)
 	}
 	if req.FirewallRulesetName != "default" || len(req.FileSystemNames) != 1 || len(req.FileSystemMounts) != 1 {

--- a/internal/providers/lambda/config.go
+++ b/internal/providers/lambda/config.go
@@ -9,14 +9,13 @@ import (
 )
 
 const (
-	providerName       = "lambda"
-	defaultAPIBaseURL  = "https://cloud.lambda.ai/api/v1"
-	defaultRegion      = "us-west-1"
-	defaultType        = "gpu_1x_a10"
-	defaultImageFamily = "lambda-stack-24-04"
-	defaultUser        = "ubuntu"
-	defaultPort        = "22"
-	tokenEnv           = "LAMBDA_API_KEY"
+	providerName      = "lambda"
+	defaultAPIBaseURL = "https://cloud.lambda.ai/api/v1"
+	// The class mapping remains independent of configured defaults.
+	defaultType = "gpu_1x_a10"
+	defaultUser = "ubuntu"
+	defaultPort = "22"
+	tokenEnv    = "LAMBDA_API_KEY"
 )
 
 func tokenFromEnv() string {
@@ -32,21 +31,21 @@ func requireToken() (string, error) {
 }
 
 func regionForConfig(cfg core.Config) string {
-	return firstNonBlank(cfg.Lambda.Region, defaultRegion)
+	return firstNonBlank(cfg.Lambda.Region, core.LambdaConfiguredRegionDefault)
 }
 
 func typeForConfig(cfg core.Config) string {
 	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
 		return strings.TrimSpace(cfg.ServerType)
 	}
-	return firstNonBlank(cfg.Lambda.Type, defaultType)
+	return firstNonBlank(cfg.Lambda.Type, core.LambdaConfiguredTypeDefault)
 }
 
 func imageFamilyForConfig(cfg core.Config) string {
 	if strings.TrimSpace(cfg.Lambda.Image) != "" {
 		return ""
 	}
-	return firstNonBlank(cfg.Lambda.ImageFamily, defaultImageFamily)
+	return firstNonBlank(cfg.Lambda.ImageFamily, core.LambdaImageFamilyFallback)
 }
 
 func imageForConfig(cfg core.Config) string {

--- a/internal/providers/lambda/provider_test.go
+++ b/internal/providers/lambda/provider_test.go
@@ -1,6 +1,8 @@
 package lambda
 
 import (
+	"flag"
+	"reflect"
 	"testing"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -35,4 +37,81 @@ func TestValidateConfigRejectsAmbiguousImage(t *testing.T) {
 	if err := (Provider{}).ValidateConfig(cfg); err == nil {
 		t.Fatal("ValidateConfig succeeded for image plus imageFamily")
 	}
+}
+
+func TestLambdaBindingRuntime(t *testing.T) {
+	cfg := core.Config{Lambda: core.LambdaConfig{Region: "prior"}}
+	before := cfg
+	fs := flag.NewFlagSet("fixture", flag.ContinueOnError)
+	v := (Provider{}).RegisterFlags(fs, cfg)
+	n := 0
+	fs.VisitAll(func(*flag.Flag) { n++ })
+	if n != 0 || !reflect.DeepEqual(v, core.NoProviderFlags()) {
+		t.Fatal("provider flags added")
+	}
+	for _, value := range []any{v, nil, struct{}{}} {
+		if err := (Provider{}).ApplyFlags(&cfg, fs, value); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(cfg, before) {
+			t.Fatal("no-op changed config")
+		}
+	}
+	for _, tc := range []struct{ raw, region, typ, family string }{{"", "us-west-1", "gpu_1x_a10", "lambda-stack-24-04"}, {"  ", "us-west-1", "gpu_1x_a10", "lambda-stack-24-04"}, {" custom ", "custom", "custom", "custom"}} {
+		cfg := core.Config{Lambda: core.LambdaConfig{Region: tc.raw, Type: tc.raw, ImageFamily: tc.raw}}
+		if regionForConfig(cfg) != tc.region || typeForConfig(cfg) != tc.typ || imageFamilyForConfig(cfg) != tc.family || imageForConfig(cfg) != "" {
+			t.Fatal("trimmed helpers")
+		}
+		b := backend{cfg: cfg}
+		b.initDirect()
+		r, typ, fam := tc.raw, tc.raw, tc.raw
+		if tc.raw == "" {
+			r = "us-west-1"
+			typ = "gpu_1x_a10"
+			fam = "lambda-stack-24-04"
+		}
+		if b.cfg.Lambda.Region != r || b.cfg.Lambda.Type != typ || b.cfg.Lambda.ImageFamily != fam || b.cfg.SSHUser != "ubuntu" || b.cfg.SSHPort != "22" || b.cfg.TargetOS != core.TargetLinux {
+			t.Fatalf("init=%#v", b.cfg.Lambda)
+		}
+	}
+	cfg = core.Config{ServerType: " explicit ", ServerTypeExplicit: true, Lambda: core.LambdaConfig{Type: "configured", Image: " image ", ImageFamily: "family"}}
+	if typeForConfig(cfg) != "explicit" || imageForConfig(cfg) != "image" || imageFamilyForConfig(cfg) != "" {
+		t.Fatal("explicit type/image precedence")
+	}
+	for _, class := range []string{"standard", " FAST ", "custom"} {
+		if serverTypeForClass(class) != "gpu_1x_a10" {
+			t.Fatal("class default")
+		}
+	}
+	b := backend{cfg: core.Config{SSHUser: "alice", SSHPort: "2200", WorkRoot: "/srv/project", Lambda: core.LambdaConfig{Image: "image"}}}
+	b.initDirect()
+	if b.cfg.SSHUser != "alice" || b.cfg.SSHPort != "2200" || b.cfg.WorkRoot != "/srv/project" || b.cfg.Lambda.ImageFamily != "" {
+		t.Fatal("init preserved fields")
+	}
+	for _, raw := range []string{"", "  ", "custom", "us-west-1"} {
+		for _, pair := range []struct{ image, family, wantFamily string }{{"", "", "lambda-stack-24-04"}, {"image", "", ""}, {"", "family", "family"}, {"image", "family", "family"}, {"  ", "  ", "  "}} {
+			cfg := core.Config{Class: "standard", SSHUser: "alice", SSHPort: "2200", WorkRoot: "/srv/project", ServerType: "explicit-type", Lambda: core.LambdaConfig{Region: raw, Type: raw, Image: pair.image, ImageFamily: pair.family, FirewallRuleset: "rule", SSHCIDRs: []string{" raw ", ""}, FilesystemNames: []string{"data", "data"}, FilesystemMounts: []core.LambdaFilesystemMount{{Name: " data ", MountPath: " /mnt/data "}}}}
+			cidrs, names, mounts := cfg.Lambda.SSHCIDRs, cfg.Lambda.FilesystemNames, cfg.Lambda.FilesystemMounts
+			r, typ := raw, raw
+			if raw == "" {
+				r = "us-west-1"
+				typ = "gpu_1x_a10"
+			}
+			want := core.LambdaConfig{Region: r, Type: typ, Image: pair.image, ImageFamily: pair.wantFamily, FirewallRuleset: "rule", SSHCIDRs: []string{" raw ", ""}, FilesystemNames: []string{"data", "data"}, FilesystemMounts: []core.LambdaFilesystemMount{{Name: " data ", MountPath: " /mnt/data "}}}
+			b := backend{cfg: cfg}
+			b.initDirect()
+			if !reflect.DeepEqual(b.cfg.Lambda, want) || &b.cfg.Lambda.SSHCIDRs[0] != &cidrs[0] || &b.cfg.Lambda.FilesystemNames[0] != &names[0] || &b.cfg.Lambda.FilesystemMounts[0] != &mounts[0] {
+				t.Fatalf("raw=%q pair=%#v cfg=%#v", raw, pair, b.cfg.Lambda)
+			}
+			if b.cfg.SSHUser != "alice" || b.cfg.SSHPort != "2200" || b.cfg.WorkRoot != "/srv/project" || b.cfg.ServerType != "explicit-type" || b.cfg.Class != "standard" || b.cfg.TargetOS != core.TargetLinux {
+				t.Fatal("backend generic effects changed")
+			}
+		}
+	}
+	zero := backend{}
+	zero.initDirect()
+	if zero.cfg.WorkRoot != "" || zero.cfg.Lambda.SSHCIDRs != nil || zero.cfg.Lambda.FilesystemNames != nil || zero.cfg.Lambda.FilesystemMounts != nil || zero.cfg.ServerType != "gpu_1x_a10" {
+		t.Fatal("raw init nil/generic state changed")
+	}
+
 }


### PR DESCRIPTION
## Summary

Consolidate Lambda's eight configuration fields and their file/environment application in one concrete owner, and share the runtime-default transform between CLI and backend initialization. This removes duplicate field declarations and defaulting policy without forcing structured filesystem mounts or the source-specific image precedence rules into generated bindings.

Preserve empty/null/list behavior, explicit image/type markers, the existing file-input type name in YAML diagnostics, supported saved YAML and JSON/config-show output, generic server-type projection, and separate OS/class/native-provider policy. Clarify YAML filesystem mount mappings versus the environment's comma-separated `name[:mountPath]` format. Update the Unreleased changelog and configuration-owner guide.

## Verification

- Ten focused configuration/writer tests and 32 generated-config freshness checks passed with the race detector on the actual main-based candidate. CLI and Lambda package vet, CLI build, and docs build passed.
- Source-blind CLI replay: all 48 frozen cases matched all four earlier references byte-for-byte for stdout/stderr, exit status, and timeout; 28 successful results and 20 expected errors, with no mismatches, timeouts, or retries.
- Independent Codex review found no accepted/actionable findings. Source comparison verified that all ten non-changelog files remained identical to the reviewed slice after rebasing onto the actual Linode merge. Source and index stayed unchanged during validation.

Focused commands: `go test -race ./internal/cli ./internal/providers/lambda -run '^(TestLambdaBinding(Sources|Pairs|Lists|CoreDefaults|FileRoundTrip|JSON|Runtime)|TestLambdaWithRuntimeDefaults|TestGeneratedFileStorage(Writer|SetBroker))$' -count=1 -timeout=3m -v`; `go test -race ./scripts/configgen -run 'GeneratedConfigIsCurrent$' -count=1 -timeout=3m -v`; `go vet ./internal/cli ./internal/providers/lambda`; `go build -trimpath -buildvcs=false -o <artifact> ./cmd/crabbox`; `node scripts/build-docs-site.mjs`. Local Go validation used the pinned toolchain, a cleared environment, and network denial.

## Scope

No new configuration keys, flags, credentials, dependencies, or provider API/lifecycle behavior. Validation is scoped to local configuration parsing, persistence, rendering, and initialization; it does not claim a new cloud lifecycle run. Existing active contributor branches are untouched. Final-head CI remains a landing gate.
