### PR TITLE
fix: repair stale host reservations and add admin recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Repair stale coordinator host associations against canonical lease state during pinned creation, preserving in-flight and retained instances; add admin host reservation inspection and guarded clearing.
+- Repair stale coordinator host associations against canonical lease state during pinned creation, preserving in-flight and retained instances; add admin host reservation inspection and guarded clearing. [PR 2057](https://github.com/openclaw/crabbox/pull/2057). Thanks @steipete.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Repair stale coordinator host associations against canonical lease state during pinned creation, preserving in-flight and retained instances; add admin host reservation inspection and guarded clearing.
+
 ### Changes
 
 - Initialize managed macOS SSH sessions through PAM so stock `nohup` can detach in the user's launchd context, retaining key-only authentication and using fresh bootstrap connections. [PR 2051](https://github.com/openclaw/crabbox/pull/2051). Thanks @steipete.

--- a/docs/commands/admin.md
+++ b/docs/commands/admin.md
@@ -124,7 +124,8 @@ cleared. It preserves lease history, instance identity, and cleanup obligations;
 it does not terminate instances or release Dedicated Hosts. Active/provisioning
 and potentially retained associations require `clear --force`. A running create
 may restore its association, so inspect the lease and provider before forcing.
-Both commands require admin credentials and support the shared scope flags,
+Clear uses POST so older coordinators reject the unsupported operation without
+dispatching a Dedicated Host release. Both commands require admin credentials and support the shared scope flags,
 `--region`, and `--json`. They also work through `admin mac-hosts`.
 
 ### hosts policy

--- a/docs/commands/admin.md
+++ b/docs/commands/admin.md
@@ -101,7 +101,7 @@ The baseline AWS provider policy covers key pairs, instance launch and terminati
 
 Inspect and manage host lifecycle resources through provider- and target-scoped subcommands. Today `--provider aws --target macos` maps to AWS EC2 Mac Dedicated Host operations; the command shape is intentionally generic so other providers can add macOS host backends without introducing new top-level admin nouns.
 
-`policy`, `list`, `offerings`, `quota`, and `allocate --dry-run` are read-only. Real `allocate` and `release` require `--force`, because host resources are billed separately from leases and carry provider lifecycle constraints.
+`policy`, `list`, `offerings`, `quota`, `reservation`, and `allocate --dry-run` are read-only. Real `allocate` and `release` require `--force`, because host resources are billed separately from leases and carry provider lifecycle constraints.
 
 All subcommands share the scope flags:
 
@@ -109,6 +109,23 @@ All subcommands share the scope flags:
 --provider <provider>   host provider (default aws; currently aws)
 --target <target>       host target OS (default macos; currently macos)
 ```
+
+### hosts reservation / clear
+
+```sh
+crabbox admin hosts reservation h-0123456789abcdef0 --region eu-west-1 --json
+crabbox admin hosts clear h-0123456789abcdef0 --region eu-west-1
+```
+
+`reservation` reads coordinator host associations, with their storage keys,
+credential-free record summaries, canonical lease state (or `null`), and stale
+reason. `clear` removes those host references atomically and reports the number
+cleared. It preserves lease history, instance identity, and cleanup obligations;
+it does not terminate instances or release Dedicated Hosts. Active/provisioning
+and potentially retained associations require `clear --force`. A running create
+may restore its association, so inspect the lease and provider before forcing.
+Both commands require admin credentials and support the shared scope flags,
+`--region`, and `--json`. They also work through `admin mac-hosts`.
 
 ### hosts policy
 
@@ -195,7 +212,7 @@ These spellings remain for existing scripts and runbooks. Prefer the provider- a
 
 - `crabbox admin aws-identity` — alias for `crabbox admin providers identity --provider aws`.
 - `crabbox admin aws-policy` — alias for `crabbox admin providers policy --provider aws`; supports `--mac-hosts` for the combined macOS policy.
-- `crabbox admin mac-hosts <list|offerings|quota|allocate|release|policy>` — alias for `crabbox admin hosts --provider aws --target macos`.
+- `crabbox admin mac-hosts <list|offerings|quota|allocate|release|reservation|clear|policy>` — alias for `crabbox admin hosts --provider aws --target macos`.
 
 ## Applying a macOS IAM policy for coordinator remediation
 

--- a/docs/features/auth-admin.md
+++ b/docs/features/auth-admin.md
@@ -198,6 +198,16 @@ fixed-ID replay preserves its existing owner and intent checks. Kept leases
 remain visible to their owners and share recipients in ordinary CLI listing,
 even when released with the instance retained.
 
+Host reservation inspection and repair are admin-only, including the legacy
+Mac-host route: `GET` or `DELETE /v1/admin/hosts/<host-id>/reservation`
+(and `/v1/admin/mac-hosts/<host-id>/reservation`). Pass `region` and optionally
+`provider=aws&target=macos`. DELETE rejects live or potentially retained leases
+with `409 host_in_use` unless `force=true`; missing leases and safely ended
+associations can be cleared without force. The response includes safe summaries,
+not lease credentials. Neither operation changes EC2 resources or allocation
+ownership. Use `crabbox admin mac-hosts reservation <host-id>` to inspect and
+`crabbox admin mac-hosts clear <host-id> [--force]` to repair.
+
 ## Lease sharing
 
 Sharing grants broker and portal access to a lease without distributing the

--- a/docs/features/auth-admin.md
+++ b/docs/features/auth-admin.md
@@ -199,9 +199,9 @@ remain visible to their owners and share recipients in ordinary CLI listing,
 even when released with the instance retained.
 
 Host reservation inspection and repair are admin-only, including the legacy
-Mac-host route: `GET` or `DELETE /v1/admin/hosts/<host-id>/reservation`
+Mac-host route: `GET` or `POST /v1/admin/hosts/<host-id>/reservation`
 (and `/v1/admin/mac-hosts/<host-id>/reservation`). Pass `region` and optionally
-`provider=aws&target=macos`. DELETE rejects live or potentially retained leases
+`provider=aws&target=macos`. POST rejects live or potentially retained leases
 with `409 host_in_use` unless `force=true`; missing leases and safely ended
 associations can be cleared without force. The response includes safe summaries,
 not lease credentials. Neither operation changes EC2 resources or allocation

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -59,6 +59,27 @@ lease. Only `--lease-id` can replay the same fixed create intent; changing its
 ID or intent does not authorize reactivation. The CLI also rejects a different
 ID returned by an older coordinator, without bootstrapping or requesting cleanup.
 
+Host occupancy resolves each stored host association to its exact lease record.
+Missing leases, completed provider cleanup, and expired leases without an instance
+or unresolved launch no longer reserve the host. Create drops stale host references
+under the admission lock and emits a structured `crabbox_host_reservation` log.
+Active and provisioning leases still block, including creates that have not yet
+received an instance ID; retained or uncertain resources also remain protected.
+
+Inspect or repair the coordinator association with admin credentials:
+
+```sh
+crabbox admin mac-hosts reservation h-0123456789abcdef0 --region eu-west-1 --json
+crabbox admin mac-hosts clear h-0123456789abcdef0 --region eu-west-1
+```
+
+Inspection returns storage keys, safe reservation and canonical lease summaries,
+and the stale reason. Clear removes host references while preserving lease history
+and provider cleanup state; it does not terminate an instance or release the billed
+Dedicated Host. It refuses a live or potentially retained association unless
+`--force` is supplied. Inspect provider inventory before forcing: a running create
+can publish its host association again when provisioning finishes.
+
 Authenticated org members can pin an unused Mac Dedicated Host only when an
 exact coordinator allocation record matches the host, requested region, and
 requester's current org identity. New admin allocations record their authenticated

--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -254,7 +254,7 @@ func (a App) adminHosts(ctx context.Context, args []string) error {
 
 func (a App) adminHostsWithCommand(ctx context.Context, commandName string, args []string) error {
 	if len(args) == 0 || isHelpArg(args[0]) {
-		return exit(2, "usage: crabbox %s <list|offerings|quota|allocate|release|policy> [--provider aws] [--target macos] [flags]", commandName)
+		return exit(2, "usage: crabbox %s <list|offerings|quota|allocate|release|reservation|clear|policy> [--provider aws] [--target macos] [flags]", commandName)
 	}
 	switch args[0] {
 	case "list":
@@ -267,11 +267,45 @@ func (a App) adminHostsWithCommand(ctx context.Context, commandName string, args
 		return a.adminMacHostsAllocate(ctx, args[1:])
 	case "release":
 		return a.adminMacHostsRelease(ctx, args[1:])
+	case "reservation", "clear":
+		return a.adminHostReservation(ctx, args[0], args[1:])
 	case "policy":
 		return a.adminMacHostsPolicy(args[1:])
 	default:
-		return exit(2, "usage: crabbox %s <list|offerings|quota|allocate|release|policy> [--provider aws] [--target macos] [flags]", commandName)
+		return exit(2, "usage: crabbox %s <list|offerings|quota|allocate|release|reservation|clear|policy> [--provider aws] [--target macos] [flags]", commandName)
 	}
+}
+
+func (a App) adminHostReservation(ctx context.Context, action string, args []string) error {
+	args, force := extractBoolFlag(args, "force")
+	args, jsonOut := extractBoolFlag(args, "json")
+	args, hostID := extractFirstPositionalArg(args, map[string]bool{"provider": true, "target": true, "region": true})
+	fs := newFlagSet("admin hosts "+action, a.Stderr)
+	provider, target := adminHostScopeFlags(fs)
+	region := fs.String("region", "", "AWS region")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if err := validateAdminHostScope(*provider, *target); err != nil {
+		return err
+	}
+	if hostID == "" || fs.NArg() != 0 || (action == "reservation" && force) {
+		return exit(2, "usage: crabbox admin hosts %s <host-id> [--region <region>] [--json]%s", action, map[bool]string{true: " [--force]"}[action == "clear"])
+	}
+	coord, err := configuredAdminCoordinator()
+	if err != nil {
+		return err
+	}
+	result, err := coord.AdminHostReservation(ctx, *region, hostID, action == "clear", force)
+	if err != nil {
+		return err
+	}
+	if jsonOut {
+		return json.NewEncoder(a.Stdout).Encode(result)
+	}
+	enc := json.NewEncoder(a.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
 }
 
 func adminHostScopeFlags(fs flagSetLike) (*string, *string) {

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -237,8 +237,8 @@ func TestAdminHostReservation(t *testing.T) {
 		force                bool
 	}{
 		{"inspect", "reservation", http.MethodGet, false},
-		{"clear", "clear", http.MethodDelete, false},
-		{"force clear", "clear", http.MethodDelete, true},
+		{"clear", "clear", http.MethodPost, false},
+		{"force clear", "clear", http.MethodPost, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			clearConfigEnv(t)
@@ -309,5 +309,28 @@ func TestAdminHostReservationPreservesConflict(t *testing.T) {
 	app := App{Stdout: io.Discard, Stderr: io.Discard}
 	if err := app.adminHosts(context.Background(), []string{"clear", "h-123abc"}); err == nil || !strings.Contains(err.Error(), "host_in_use") {
 		t.Fatalf("expected host conflict, got %v", err)
+	}
+}
+
+func TestAdminHostReservationClearCannotReleaseHostOnOlderCoordinator(t *testing.T) {
+	var released bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Older coordinators dispatch host DELETE using only the first path segment.
+		if r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/v1/admin/hosts/h-") {
+			released = true
+			_, _ = io.WriteString(w, `{"released":["h-123abc"]}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"error":"not_found"}`)
+	}))
+	defer server.Close()
+	client := &CoordinatorClient{BaseURL: server.URL, Token: "synthetic-admin-token"}
+	_, err := client.AdminHostReservation(context.Background(), "eu-west-1", "h-123abc", true, true)
+	if err == nil {
+		t.Fatal("expected unsupported-route error")
+	}
+	if released {
+		t.Fatal("reservation clear released a Dedicated Host")
 	}
 }

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -230,3 +230,84 @@ func TestSanitizeMacHostDryRunChecks(t *testing.T) {
 		t.Fatalf("message leaked provider details: %q", got)
 	}
 }
+
+func TestAdminHostReservation(t *testing.T) {
+	for _, tc := range []struct {
+		name, action, method string
+		force                bool
+	}{
+		{"inspect", "reservation", http.MethodGet, false},
+		{"clear", "clear", http.MethodDelete, false},
+		{"force clear", "clear", http.MethodDelete, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != tc.method || r.URL.Path != "/v1/admin/hosts/h-123abc/reservation" {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+				if r.URL.Query().Get("region") != "eu-west-1" || r.URL.Query().Get("provider") != "aws" || r.URL.Query().Get("target") != "macos" {
+					t.Errorf("unexpected scope: %s", r.URL.RawQuery)
+				}
+				if (r.URL.Query().Get("force") == "true") != tc.force {
+					t.Error("incorrect force flag")
+				}
+				if r.Header.Get("Authorization") != "Bearer admin-token" {
+					t.Error("missing admin auth")
+				}
+				_, _ = io.WriteString(w, `{"hostID":"h-123abc","reservations":[],"cleared":0}`)
+			}))
+			defer server.Close()
+			t.Setenv("CRABBOX_COORDINATOR", server.URL)
+			t.Setenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", "admin-token")
+			args := []string{tc.action, "h-123abc", "--region", "eu-west-1", "--json"}
+			if tc.force {
+				args = append(args, "--force")
+			}
+			var stdout bytes.Buffer
+			app := App{Stdout: &stdout, Stderr: io.Discard}
+			if err := app.adminMacHosts(context.Background(), args); err != nil {
+				t.Fatal(err)
+			}
+			var result struct {
+				HostID string `json:"hostID"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &result); err != nil || result.HostID != "h-123abc" {
+				t.Fatalf("unexpected output: %s (%v)", stdout.String(), err)
+			}
+		})
+	}
+}
+
+func TestAdminHostReservationRejectsInvalidArguments(t *testing.T) {
+	for _, args := range [][]string{
+		{"reservation"}, {"clear"}, {"reservation", "h-123abc", "--force"},
+		{"clear", "h-123abc", "extra"}, {"reservation", "h-123abc", "--provider", "gcp"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			app := App{Stdout: io.Discard, Stderr: io.Discard}
+			if err := app.adminHosts(context.Background(), args); err == nil {
+				t.Fatal("expected argument error")
+			}
+		})
+	}
+}
+
+func TestAdminHostReservationPreservesConflict(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = io.WriteString(w, `{"error":"host_in_use","message":"reservation references a provisioning lease"}`)
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", "admin-token")
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	if err := app.adminHosts(context.Background(), []string{"clear", "h-123abc"}); err == nil || !strings.Contains(err.Error(), "host_in_use") {
+		t.Fatalf("expected host conflict, got %v", err)
+	}
+}

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -1920,7 +1920,8 @@ func (c *CoordinatorClient) AdminHostReservation(ctx context.Context, region, ho
 	}
 	method := http.MethodGet
 	if clear {
-		method = http.MethodDelete
+		// Older coordinators dispatch any host DELETE suffix as a Dedicated Host release.
+		method = http.MethodPost
 	}
 	path := "/v1/admin/hosts/" + url.PathEscape(hostID) + "/reservation?" + values.Encode()
 	var result json.RawMessage

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -1912,6 +1912,22 @@ func (c *CoordinatorClient) AdminDeleteLease(ctx context.Context, id string) (Co
 	return res.Lease, err
 }
 
+// AdminHostReservation reads or clears coordinator host associations without changing provider resources.
+func (c *CoordinatorClient) AdminHostReservation(ctx context.Context, region, hostID string, clear, force bool) (json.RawMessage, error) {
+	values := adminHostScopeValues(region, "")
+	if clear && force {
+		values.Set("force", "true")
+	}
+	method := http.MethodGet
+	if clear {
+		method = http.MethodDelete
+	}
+	path := "/v1/admin/hosts/" + url.PathEscape(hostID) + "/reservation?" + values.Encode()
+	var result json.RawMessage
+	err := c.do(ctx, method, path, nil, &result)
+	return result, err
+}
+
 func (c *CoordinatorClient) AdminMacHosts(ctx context.Context, region, serverType, state string) ([]CoordinatorMacHost, error) {
 	var res struct {
 		Hosts []CoordinatorMacHost `json:"hosts"`

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -2,6 +2,13 @@ import ssh2, { type Client as SSHClient, type ClientChannel } from "ssh2";
 
 import { AzureResumableProvisioning } from "./azure-provisioning";
 import {
+  clearHostReservations,
+  logClearedHostReservations,
+  publicHostReservation,
+  readHostReservations,
+  type HostScope,
+} from "./host-reservations";
+import {
   clearLeaseCleanupCompletion,
   completeLeaseProviderCleanup,
   leaseHasConfirmedNoProviderResource,
@@ -1309,10 +1316,12 @@ export class FleetCoordinator {
         return await this.adminTailscalePreflight();
       }
       if (parts[0] === "v1" && parts[1] === "admin" && parts[2] === "hosts") {
-        return await this.adminHostsRoute(request, parts[3]);
+        if (parts.length > 5) return notFound();
+        return await this.adminHostsRoute(request, parts[3], parts[4]);
       }
       if (parts[0] === "v1" && parts[1] === "admin" && parts[2] === "mac-hosts") {
-        return await this.adminMacHostsRoute(request, parts[3]);
+        if (parts.length > 5) return notFound();
+        return await this.adminMacHostsRoute(request, parts[3], parts[4]);
       }
       if (
         (method === "GET" || method === "POST") &&
@@ -4092,6 +4101,7 @@ export class FleetCoordinator {
         request,
         config,
         checkpointAuthorization?.checkpoint.hostID,
+        true,
       );
       if (reservationHostError) return reservationHostError;
       const now = new Date();
@@ -4846,8 +4856,24 @@ export class FleetCoordinator {
       const storedLeases = [
         ...(await transaction.list<LeaseRecord>({ prefix: "lease:" })).values(),
       ];
-      const hostConflict = pinnedHostConflict(config, storedLeases);
+      const hostID = config.hostID || config.awsMacHostID;
+      const scope: HostScope = {
+        provider: config.provider,
+        hostID: hostID || "",
+        region: providerRegionForConfig(config),
+      };
+      const hostReservations = hostID ? await readHostReservations(transaction, scope) : [];
+      const hostConflict = pinnedHostConflict(
+        config,
+        hostReservations
+          .filter((reservation) => !reservation.staleReason && reservation.lease)
+          .map((reservation) => reservation.lease!),
+      );
       if (hostConflict) return hostConflict;
+      const clearedHostReservations = hostReservations.filter(
+        (reservation) => reservation.staleReason,
+      );
+      await clearHostReservations(transaction, clearedHostReservations);
       const providerAccess = [
         ...(await transaction.list<LeaseRecord>({ prefix: providerAccessPrefix() })).values(),
       ];
@@ -4881,9 +4907,11 @@ export class FleetCoordinator {
       await transaction.put(provisioningPlanKey(operationID), prepared.plan);
       await transaction.put(provisioningMaterialKey(operationID), sealed);
       await putProvisioningOperation(transaction, operation);
-      return { lease: record, replay: false };
+      return { lease: record, replay: false, clearedHostReservations, hostScope: scope };
     });
     if (admission instanceof Response) return admission;
+    if (admission.hostScope && admission.clearedHostReservations)
+      logClearedHostReservations(admission.hostScope, admission.clearedHostReservations);
     if (admission.replay) {
       // A concurrent release may commit before admission's acknowledgement returns.
       // Replay must observe the current attempt rather than its earlier lease snapshot.
@@ -13928,7 +13956,11 @@ export class FleetCoordinator {
     return json({ tailscale: await tailscalePreflight(this.env) });
   }
 
-  private async adminHostsRoute(request: Request, hostID?: string): Promise<Response> {
+  private async adminHostsRoute(
+    request: Request,
+    hostID?: string,
+    action?: string,
+  ): Promise<Response> {
     const url = new URL(request.url);
     const provider = (url.searchParams.get("provider") ?? "aws").trim().toLowerCase();
     const target = (url.searchParams.get("target") ?? "macos").trim().toLowerCase();
@@ -13941,10 +13973,14 @@ export class FleetCoordinator {
         { status: 400 },
       );
     }
-    return await this.adminMacHostsRoute(request, hostID);
+    return await this.adminMacHostsRoute(request, hostID, action);
   }
 
-  private async adminMacHostsRoute(request: Request, hostID?: string): Promise<Response> {
+  private async adminMacHostsRoute(
+    request: Request,
+    hostID?: string,
+    action?: string,
+  ): Promise<Response> {
     const method = request.method.toUpperCase();
     const url = new URL(request.url);
     const queryRegion = url.searchParams.get("region") ?? this.env.CRABBOX_AWS_REGION ?? "";
@@ -13955,6 +13991,41 @@ export class FleetCoordinator {
         { status: 400 },
       );
     }
+    if (action === "reservation" && hostID) {
+      if (!/^h-[a-f0-9]+$/.test(hostID)) return json({ error: "invalid_host_id" }, { status: 400 });
+      if (method !== "GET" && method !== "DELETE") return notFound();
+      const scope: HostScope = { provider: "aws", hostID, region };
+      const force = url.searchParams.get("force") === "true";
+      return this.state.runExclusive(async () => {
+        const result = await this.state.storage.transaction(async (storage) => {
+          const reservations = await readHostReservations(storage, scope);
+          const blocked = reservations.some((reservation) => !reservation.staleReason);
+          if (method === "DELETE" && blocked && !force) {
+            return json(
+              {
+                error: "host_in_use",
+                message:
+                  "host reservation references a live or potentially retained instance; use --force only after inspecting it",
+                ...scope,
+                reservations: reservations.map(publicHostReservation),
+              },
+              { status: 409 },
+            );
+          }
+          if (method === "DELETE") await clearHostReservations(storage, reservations);
+          return reservations;
+        });
+        if (result instanceof Response) return result;
+        if (method === "DELETE")
+          logClearedHostReservations(scope, result, "admin_reservation_cleared");
+        return json({
+          ...scope,
+          reservations: result.map(publicHostReservation),
+          ...(method === "DELETE" ? { cleared: result.length } : {}),
+        });
+      });
+    }
+    if (action) return notFound();
     const client = new EC2SpotClient(this.env, region);
     if (method === "GET" && hostID === "offerings") {
       const serverType = (url.searchParams.get("type") ?? "mac2.metal").trim();
@@ -17811,6 +17882,7 @@ export class FleetCoordinator {
     request: Request,
     config: LeaseConfig,
     authorizedHostID?: string,
+    repair = false,
   ): Promise<Response | undefined> {
     const hostID = config.hostID || config.awsMacHostID;
     if (!hostID) return undefined;
@@ -17833,7 +17905,27 @@ export class FleetCoordinator {
         { status: 403 },
       );
     }
-    return pinnedHostConflict(config, await this.leaseRecords());
+    const scope: HostScope = {
+      provider: config.provider,
+      hostID,
+      region: providerRegionForConfig(config),
+    };
+    const inspect = async (storage: CoordinatorStorageView) => {
+      const reservations = await readHostReservations(storage, scope);
+      const stale = reservations.filter((reservation) => reservation.staleReason);
+      if (repair) await clearHostReservations(storage, stale);
+      return {
+        stale,
+        leases: reservations
+          .filter((reservation) => !reservation.staleReason && reservation.lease)
+          .map((reservation) => reservation.lease!),
+      };
+    };
+    const result = repair
+      ? await this.state.storage.transaction(inspect)
+      : await inspect(this.state.storage);
+    if (repair) logClearedHostReservations(scope, result.stale);
+    return pinnedHostConflict(config, result.leases);
   }
 
   private async leaseAdmissionState(

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -13993,14 +13993,14 @@ export class FleetCoordinator {
     }
     if (action === "reservation" && hostID) {
       if (!/^h-[a-f0-9]+$/.test(hostID)) return json({ error: "invalid_host_id" }, { status: 400 });
-      if (method !== "GET" && method !== "DELETE") return notFound();
+      if (method !== "GET" && method !== "POST") return notFound();
       const scope: HostScope = { provider: "aws", hostID, region };
       const force = url.searchParams.get("force") === "true";
       return this.state.runExclusive(async () => {
         const result = await this.state.storage.transaction(async (storage) => {
           const reservations = await readHostReservations(storage, scope);
           const blocked = reservations.some((reservation) => !reservation.staleReason);
-          if (method === "DELETE" && blocked && !force) {
+          if (method === "POST" && blocked && !force) {
             return json(
               {
                 error: "host_in_use",
@@ -14012,16 +14012,16 @@ export class FleetCoordinator {
               { status: 409 },
             );
           }
-          if (method === "DELETE") await clearHostReservations(storage, reservations);
+          if (method === "POST") await clearHostReservations(storage, reservations);
           return reservations;
         });
         if (result instanceof Response) return result;
-        if (method === "DELETE")
+        if (method === "POST")
           logClearedHostReservations(scope, result, "admin_reservation_cleared");
         return json({
           ...scope,
           reservations: result.map(publicHostReservation),
-          ...(method === "DELETE" ? { cleared: result.length } : {}),
+          ...(method === "POST" ? { cleared: result.length } : {}),
         });
       });
     }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -4873,7 +4873,6 @@ export class FleetCoordinator {
       const clearedHostReservations = hostReservations.filter(
         (reservation) => reservation.staleReason,
       );
-      await clearHostReservations(transaction, clearedHostReservations);
       const providerAccess = [
         ...(await transaction.list<LeaseRecord>({ prefix: providerAccessPrefix() })).values(),
       ];
@@ -4896,6 +4895,7 @@ export class FleetCoordinator {
       for (const lease of merged.values()) addLeaseToCostLimitUsage(usage, lease, now);
       const limit = enforceCostLimitUsage(usage, record, costLimits(this.env));
       if (limit) return json({ error: "cost_limit_exceeded", message: limit }, { status: 429 });
+      await clearHostReservations(transaction, clearedHostReservations);
       if (currentAttempt && attempt)
         await transaction.put(createAttemptKey(leaseID), {
           ...currentAttempt,

--- a/worker/src/host-reservations.ts
+++ b/worker/src/host-reservations.ts
@@ -1,0 +1,155 @@
+import type { CoordinatorStorageView } from "./coordinator-runtime";
+import { leaseProviderCleanupConfirmed } from "./lease-cleanup";
+import { publicLeaseRecord } from "./org-records";
+import type { LeaseRecord, Provider } from "./types";
+
+export interface HostScope {
+  provider: Provider;
+  hostID: string;
+  region: string | undefined;
+}
+
+export interface HostReservation {
+  storageKey: string;
+  record: LeaseRecord;
+  lease?: LeaseRecord;
+  staleReason:
+    | undefined
+    | "lease_missing"
+    | "host_changed"
+    | "cleanup_complete"
+    | "expired_without_instance";
+}
+
+function matchesHost(lease: LeaseRecord, scope: HostScope): boolean {
+  return (
+    lease.provider === scope.provider &&
+    (lease.hostId || lease.hostID) === scope.hostID &&
+    (!lease.region || lease.region === scope.region)
+  );
+}
+
+export function hostReservationStaleReason(
+  lease: LeaseRecord | undefined,
+  scope: HostScope,
+): HostReservation["staleReason"] {
+  if (!lease) return "lease_missing";
+  if (!matchesHost(lease, scope)) return "host_changed";
+  // A create owns its host before a provider instance ID has been committed.
+  if (lease.state === "active" || lease.state === "provisioning") return undefined;
+  if (leaseProviderCleanupConfirmed(lease)) return "cleanup_complete";
+  if (
+    lease.state === "expired" &&
+    !lease.cloudID &&
+    !lease.serverID &&
+    !lease.provisioningRequestStartedAt &&
+    !lease.provisioningResourceMayExist
+  )
+    return "expired_without_instance";
+  return undefined;
+}
+
+// Host associations live on lease rows and provider-access snapshots, not in a
+// separate host index. Resolve snapshots by exact lease ID before trusting them.
+export async function readHostReservations(
+  storage: CoordinatorStorageView,
+  scope: HostScope,
+): Promise<HostReservation[]> {
+  const reservations: HostReservation[] = [];
+  for (const prefix of ["lease:", "provider-access:"]) {
+    let startAfter: string | undefined;
+    for (;;) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- bounded pages must advance in key order.
+      const page = await storage.list<LeaseRecord>({
+        prefix,
+        limit: 256,
+        noCache: true,
+        ...(startAfter ? { startAfter } : {}),
+      });
+      for (const [storageKey, record] of page) {
+        if (!matchesHost(record, scope)) continue;
+        // oxlint-disable-next-line eslint/no-await-in-loop -- resolve only matching host associations.
+        const lease = await storage.get<LeaseRecord>(`lease:${record.id}`, { noCache: true });
+        reservations.push({
+          storageKey,
+          record,
+          ...(lease ? { lease } : {}),
+          staleReason: hostReservationStaleReason(lease, scope),
+        });
+      }
+      if (page.size < 256) break;
+      const next = [...page.keys()].at(-1);
+      if (!next || next === startAfter) throw new Error("host reservation scan did not advance");
+      startAfter = next;
+    }
+  }
+  return reservations;
+}
+
+export async function clearHostReservations(
+  storage: CoordinatorStorageView,
+  reservations: HostReservation[],
+): Promise<void> {
+  for (const reservation of reservations) {
+    const record = { ...reservation.record };
+    delete record.hostId;
+    delete record.hostID;
+    // Keep lease history, cloud identity, and provider cleanup obligations intact.
+    // oxlint-disable-next-line eslint/no-await-in-loop -- callers hold the admission lock or storage transaction.
+    await storage.put(reservation.storageKey, record);
+  }
+}
+
+export function logClearedHostReservations(
+  scope: HostScope,
+  reservations: HostReservation[],
+  action = "stale_reservation_cleared",
+): void {
+  for (const reservation of reservations) {
+    console.info(
+      JSON.stringify({
+        component: "crabbox_host_reservation",
+        action,
+        ...scope,
+        leaseID: reservation.record.id,
+        storageKey: reservation.storageKey,
+        reason: reservation.staleReason ?? "admin_force",
+      }),
+    );
+  }
+}
+
+function hostReservationSummary(record: LeaseRecord) {
+  return {
+    id: record.id,
+    slug: record.slug,
+    provider: record.provider,
+    region: record.region,
+    hostId: record.hostId,
+    hostID: record.hostID,
+    state: record.state,
+    cloudID: record.cloudID,
+    createdAt: record.createdAt,
+    expiresAt: record.expiresAt,
+    keep: record.keep,
+    releaseDeletesServer: record.releaseDeletesServer,
+    cleanupStatus: publicLeaseRecord(record).cleanupStatus,
+    cleanupCompletedAt: record.cleanupCompletedAt,
+    cleanupStartedAt: record.cleanupStartedAt,
+    cleanupRetryAt: record.cleanupRetryAt,
+    cleanupFailedAt: record.cleanupFailedAt,
+    providerKeyCleanupPending: record.providerKeyCleanupPending,
+    provisioningRequestStartedAt: record.provisioningRequestStartedAt,
+    provisioningResourceMayExist: record.provisioningResourceMayExist,
+  };
+}
+
+export function publicHostReservation(reservation: HostReservation) {
+  return {
+    storageKey: reservation.storageKey,
+    reservation: hostReservationSummary(reservation.record),
+    lease: reservation.lease ? hostReservationSummary(reservation.lease) : null,
+    stale: Boolean(reservation.staleReason),
+    reason: reservation.staleReason ?? "lease_occupies_host",
+  };
+}

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -27754,6 +27754,199 @@ describe("fleet lease identity and idle", () => {
     },
   );
 
+  it.each([
+    {
+      kind: "dangling lease association",
+      state: "provisioning",
+      missing: true,
+      complete: false,
+      alias: true,
+    },
+    { kind: "dangling access snapshot", state: "provisioning", missing: true, complete: false },
+    { kind: "released cleanup complete", state: "released", missing: false, complete: true },
+    { kind: "expired without an instance", state: "expired", missing: false, complete: false },
+  ] as const)("repairs $kind during pinned create", async (testCase) => {
+    const { state, missing, complete } = testCase;
+    const storage = new MemoryStorage();
+    const held = testLease({
+      id: "cbx_000000000120",
+      provider: "aws",
+      target: "macos",
+      region: "eu-west-1",
+      hostId: "h-123abc",
+      state,
+      cloudID: complete ? "i-old" : "",
+      serverID: 0,
+      host: "",
+      keep: true,
+      provisioningResourceMayExist: false,
+      ...(complete ? { cleanupCompletedAt: new Date().toISOString() } : {}),
+    });
+    if (!missing) storage.seed(`lease:${held.id}`, held);
+    if ("alias" in testCase) storage.seed("lease:legacy-host-association", held);
+    storage.seed(`provider-access:${held.id}`, { ...held, state: "provisioning" });
+    let creates = 0;
+    const log = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      const fleet = testFleet(storage, {
+        aws: fakeProvider(() => creates++, {
+          provider: "aws",
+          hostID: "h-123abc",
+          serverType: "mac1.metal",
+        }),
+      });
+      const response = await fleet.fetch(
+        request("POST", "/v1/leases", {
+          headers: {
+            "x-crabbox-admin": "true",
+            "x-crabbox-owner": "alice@example.com",
+            "x-crabbox-org": "example-org",
+          },
+          body: {
+            leaseID: "cbx_000000000121",
+            provider: "aws",
+            target: "macos",
+            hostId: "h-123abc",
+            serverType: "mac1.metal",
+            capacity: { market: "on-demand" },
+            sshPublicKey: "ssh-ed25519 synthetic",
+          },
+        }),
+      );
+      expect(response.status).toBe(201);
+      expect(creates).toBe(1);
+      expect(storage.value<LeaseRecord>(`provider-access:${held.id}`)?.hostId).toBeUndefined();
+      expect(storage.value<LeaseRecord>(`lease:${held.id}`)?.hostId).toBeUndefined();
+      expect(storage.value<LeaseRecord>("lease:legacy-host-association")?.hostId).toBeUndefined();
+      expect(storage.value<LeaseRecord>(`lease:${held.id}`)?.cloudID).toBe(
+        missing ? undefined : held.cloudID,
+      );
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining('"action":"stale_reservation_cleared"'),
+      );
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  it.each(["active", "provisioning"] as const)(
+    "preserves an in-flight %s host association without an instance ID",
+    async (state) => {
+      const storage = new MemoryStorage();
+      const held = testLease({
+        id: "cbx_000000000120",
+        provider: "aws",
+        target: "macos",
+        region: "eu-west-1",
+        hostId: "h-123abc",
+        state,
+        cloudID: "",
+        serverID: 0,
+        host: "",
+      });
+      storage.seed(`lease:${held.id}`, held);
+      const fleet = testFleet(storage, {
+        aws: fakeProvider(
+          () => {
+            throw new Error("must not provision");
+          },
+          { provider: "aws" },
+        ),
+      });
+      const response = await fleet.fetch(
+        request("POST", "/v1/leases", {
+          headers: { "x-crabbox-admin": "true" },
+          body: {
+            provider: "aws",
+            target: "macos",
+            hostId: "h-123abc",
+            serverType: "mac1.metal",
+            capacity: { market: "on-demand" },
+            sshPublicKey: "ssh-ed25519 synthetic",
+          },
+        }),
+      );
+      expect(response.status).toBe(409);
+      await expect(response.json()).resolves.toMatchObject({ error: "host_in_use" });
+      expect(storage.value(`lease:${held.id}`)).toEqual(held);
+    },
+  );
+
+  it.each(["hosts", "mac-hosts"])(
+    "inspects and safely clears admin %s reservations",
+    async (route) => {
+      const storage = new MemoryStorage();
+      const held = testLease({
+        id: "cbx_000000000120",
+        provider: "aws",
+        target: "macos",
+        region: "eu-west-1",
+        hostId: "h-123abc",
+        state: "provisioning",
+        cloudID: "",
+        serverID: 0,
+        sshPrivateKey: "secret-not-for-response",
+      });
+      storage.seed(`lease:${held.id}`, held);
+      storage.seed(`provider-access:${held.id}`, held);
+      const fleet = testFleet(storage);
+      const path = `/v1/admin/${route}/h-123abc/reservation?region=eu-west-1`;
+      const headers = { "x-crabbox-admin": "true" };
+      for (const method of ["GET", "DELETE"]) {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- both methods must require admin auth.
+        expect((await fleet.fetch(request(method, path))).status).toBe(403);
+      }
+      const inspect = await fleet.fetch(request("GET", path, { headers }));
+      expect(inspect.status).toBe(200);
+      const body = await inspect.text();
+      expect(body).not.toContain("secret-not-for-response");
+      expect(JSON.parse(body)).toMatchObject({
+        reservations: [
+          { storageKey: `lease:${held.id}`, stale: false, lease: { id: held.id } },
+          { storageKey: `provider-access:${held.id}` },
+        ],
+      });
+      expect((await fleet.fetch(request("DELETE", path, { headers }))).status).toBe(409);
+      expect(storage.value(`lease:${held.id}`)).toEqual(held);
+      const cleared = await fleet.fetch(request("DELETE", path + "&force=true", { headers }));
+      expect(cleared.status).toBe(200);
+      await expect(cleared.json()).resolves.toMatchObject({ cleared: 2 });
+      expect(storage.value<LeaseRecord>(`lease:${held.id}`)).toMatchObject({
+        state: "provisioning",
+        sshPrivateKey: "secret-not-for-response",
+      });
+      expect(storage.value<LeaseRecord>(`lease:${held.id}`)?.hostId).toBeUndefined();
+      await expect(
+        (await fleet.fetch(request("DELETE", path, { headers }))).json(),
+      ).resolves.toMatchObject({ cleared: 0 });
+    },
+  );
+
+  it("clears a dangling host snapshot without force and leaves other hosts untouched", async () => {
+    const storage = new MemoryStorage();
+    const dangling = testLease({
+      id: "cbx_000000000120",
+      provider: "aws",
+      region: "eu-west-1",
+      hostId: "h-123abc",
+    });
+    const other = { ...dangling, id: "cbx_000000000122", hostId: "h-456def" };
+    storage.seed(`provider-access:${dangling.id}`, dangling);
+    storage.seed(`lease:${other.id}`, other);
+    const fleet = testFleet(storage);
+    const response = await fleet.fetch(
+      request("DELETE", "/v1/admin/hosts/h-123abc/reservation?region=eu-west-1", {
+        headers: { "x-crabbox-admin": "true" },
+      }),
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      cleared: 1,
+      reservations: [{ lease: null, reason: "lease_missing" }],
+    });
+    expect(storage.value(`lease:${other.id}`)).toEqual(other);
+  });
+
   it("rechecks host occupancy when concurrent creates reserve the same host", async () => {
     const storage = new MemoryStorage();
     let creates = 0;

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -27892,7 +27892,7 @@ describe("fleet lease identity and idle", () => {
       const fleet = testFleet(storage);
       const path = `/v1/admin/${route}/h-123abc/reservation?region=eu-west-1`;
       const headers = { "x-crabbox-admin": "true" };
-      for (const method of ["GET", "DELETE"]) {
+      for (const method of ["GET", "POST"]) {
         // oxlint-disable-next-line eslint/no-await-in-loop -- both methods must require admin auth.
         expect((await fleet.fetch(request(method, path))).status).toBe(403);
       }
@@ -27906,9 +27906,9 @@ describe("fleet lease identity and idle", () => {
           { storageKey: `provider-access:${held.id}` },
         ],
       });
-      expect((await fleet.fetch(request("DELETE", path, { headers }))).status).toBe(409);
+      expect((await fleet.fetch(request("POST", path, { headers }))).status).toBe(409);
       expect(storage.value(`lease:${held.id}`)).toEqual(held);
-      const cleared = await fleet.fetch(request("DELETE", path + "&force=true", { headers }));
+      const cleared = await fleet.fetch(request("POST", path + "&force=true", { headers }));
       expect(cleared.status).toBe(200);
       await expect(cleared.json()).resolves.toMatchObject({ cleared: 2 });
       expect(storage.value<LeaseRecord>(`lease:${held.id}`)).toMatchObject({
@@ -27917,7 +27917,7 @@ describe("fleet lease identity and idle", () => {
       });
       expect(storage.value<LeaseRecord>(`lease:${held.id}`)?.hostId).toBeUndefined();
       await expect(
-        (await fleet.fetch(request("DELETE", path, { headers }))).json(),
+        (await fleet.fetch(request("POST", path, { headers }))).json(),
       ).resolves.toMatchObject({ cleared: 0 });
     },
   );
@@ -27935,7 +27935,7 @@ describe("fleet lease identity and idle", () => {
     storage.seed(`lease:${other.id}`, other);
     const fleet = testFleet(storage);
     const response = await fleet.fetch(
-      request("DELETE", "/v1/admin/hosts/h-123abc/reservation?region=eu-west-1", {
+      request("POST", "/v1/admin/hosts/h-123abc/reservation?region=eu-west-1", {
         headers: { "x-crabbox-admin": "true" },
       }),
     );


### PR DESCRIPTION
Pinned creates can be blocked by stale coordinator host associations. Resolve each association against its canonical lease, repair safely ended or dangling references during admission, and add admin inspection and guarded clearing. Live/in-flight and potentially retained instances remain protected.

## Evidence and diagnosis

The reported host `h-0a2144908bf423d1b` in `eu-west-1a` is an AWS `mac1.metal` Dedicated Host. The work order records seven pinned creates returning `409 host_in_use` for `cbx_180dd125b97b` (`tidal-hermit`) between 12:47 and 14:12 PDT on 2026-09-09, despite available EC2 inventory. Its three recent Mac leases (`cbx_79ceb925fa26`, `cbx_9c9abdc3fe59`, `cbx_f154a9370b84`) were released with cleanup complete. Two other released Linux leases share the slug and are unrelated. This follows https://github.com/openclaw/crabbox/pull/2049 and https://github.com/openclaw/crabbox/pull/2051.

Read-only live checks confirmed the available host, capacity 1, those three completed leases, and the ordinary inspect 404. The admin-aware cleanup inspection route also resolved the exact ID (returning `cleanup_inspection_unsupported`, rather than `not_found`). **The missing-lease premise is incorrect:** the uncapped admin portal contains this exact older lease summary:

```json
{
  "id": "cbx_180dd125b97b",
  "slug": "tidal-hermit",
  "state": "released",
  "provider": "aws",
  "owner": "[redacted]",
  "org": "[redacted]",
  "target": "macos",
  "classAndServerType": "standard / mac1.metal",
  "updatedAt": "2026-08-24T23:21:43.014Z"
}
```

This is the exact displayed summary from authenticated `GET /portal/admin/leases?provider=aws`, **not a raw storage-record capture**. Existing admin JSON lists cap results at 500, including narrowed owner/provider/state queries; the new host reservation route is not deployed. The older row's full cleanup/resource fields could not be captured through those existing read routes. No live create, clear, release, or deployment was performed.

`worker/src/fleet.ts:25181` (`pinnedHostConflict`) treats a released row as occupying when cleanup is unconfirmed and `keep`, retained-release policy, cloud identity, or an uncertain resource remains. Before this change, `validateHostPin` fed that predicate directly from a lease-list scan. This explains why available EC2 inventory can disagree with coordinator occupancy; it does not prove which retained-field condition applies to the older live row. `worker/src/fleet.ts:14472`/`clampLimit` truncate diagnostic listings, and `worker/src/fleet.ts:7235` resolves ordinary inspect with lease visibility rather than admin inventory visibility, so the 404 is not proof of absence.

The occupancy check was introduced by https://github.com/openclaw/crabbox/pull/2049 (merge commit `6bdbb26458b05cf7eddee3c963b2d95a4cc1f01a`, merged 2026-09-09 at 18:14:29 UTC). The raw commit names parent `cd97e81831e9878e688a200979b4df5f75e33135`; their direct patch adds `pinnedHostConflict` and its preflight/admission callers. The August 24 row therefore predates this guard. This establishes the code change that made historical occupancy blocking possible, while the precise old-row cleanup condition remains unobserved.

## Change

- Add a provider-neutral host association reader in `worker/src/host-reservations.ts` that resolves exact lease IDs, scans beyond one bounded page, and classifies missing/changed leases, completed cleanup, and expired leases without instances or unresolved launches.
- Repair stale host references within ordinary serialized admission and durable admission transactions; emit structured `crabbox_host_reservation` logs after storage transactions. Preserve lease rows, cloud identity, cleanup obligations, and in-flight create blocking.
- Add admin-only `GET`/`POST /v1/admin/hosts/<host-id>/reservation`, with the existing Mac-host alias. Inspection returns credential-free reservation/canonical-lease summaries and storage keys. Clear rejects live or potentially retained associations unless explicitly forced and never changes provider resources or host allocation ownership. It uses POST so an older coordinator rejects the unsupported operation instead of interpreting a DELETE suffix as a Dedicated Host release; a regression exercises that older dispatch behavior.
- Expose `crabbox admin mac-hosts reservation <host-id>` and `crabbox admin mac-hosts clear <host-id> [--force]`, also under `admin hosts`; update AWS, admin-auth, command docs, and the changelog.

## Verification

- `npm ci --prefix worker`
- `npm run check --prefix worker`
- `npm run lint --prefix worker`
- `npm run format:check --prefix worker`
- `npm test --prefix worker`: 2,994 passed; 3 skipped across 52 passing and 2 skipped files.
- `/opt/homebrew/bin/go vet ./...`
- `/opt/homebrew/bin/go test -race ./internal/cli -run 'TestAdminHostReservation|TestAdminMacHosts|TestCoordinatorAdminMacHost|TestAdminHosts' -count=1`: passed, including the final POST rollout regression. Focused non-race unit tests also passed.
- Broad `/opt/homebrew/bin/go test ./...`: all non-CLI packages passed. The CLI package hit the default 10-minute total-package timeout. `/opt/homebrew/bin/go test -json -timeout=20m ./internal/cli` then completed 3,997 top-level tests before its total-package timeout, with no assertion failures.
- Enumerated the current CLI test list with `/opt/homebrew/bin/go test -list . ./internal/cli`, selected the 116 top-level tests without a completed result (including deferred parallel tests and the new rollout regression), and ran that exact set with `go test -json -timeout=10m ./internal/cli -run <anchored-selected-test-pattern>`. The final batch passed in 85.816 seconds. The combined audit accounts for **all 4,113 current top-level tests**, with no missing tests or assertion failures: 9,080 unique passed tests/subtests and 21 skips. This is complete batched coverage, not a passing monolithic CLI invocation.
- Final CLI build and Worker format check passed. GitHub checks for the final head remain in progress; no failed checks were reported at handoff.
- Repository-required Codex autoreview: scoped-clean, no accepted/actionable findings.

Regressions cover dangling host associations, released completed cleanup, expired instance-free leases, active/provisioning reservations without an instance ID, the existing concurrent-create exclusion, admin authorization, safe inspection output, refusal without force, forced/idempotent clear, and unrelated-host preservation.

## Operational limits

No new config or credentials are required. **The coordinator deploys automatically on merge. Do not merge as part of this work order.**

After deployment, inspect this host with the new command to capture its exact stored association and cleanup state before recovery. A historical released row with retained/uncertain resource state still needs provider verification and potentially explicit admin clearing; this PR does not treat available inventory alone as deletion proof. A forced clear can be repopulated by a still-running create. Live pinned-create success remains unverified and should be checked only after merge/deployment by the deployment owner.

Dependency installation reported three existing high-severity audit advisories; this change adds no dependencies or lockfile edits.
