### PR TITLE
refactor(config): consolidate shared Apple Container settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - Consolidate KubeVirt settings and work-root selection without changing key-source rules, path expansion, saved-file semantics, or explicit release choices. [PR 2058](https://github.com/openclaw/crabbox/pull/2058). Thanks @steipete.
+- Consolidate Apple Container and Apple Machine shared settings while preserving their distinct flag surfaces, argument-list behavior, image selection, and saved-file formats. Thanks @steipete.
 
 - Initialize managed macOS SSH sessions through PAM so stock `nohup` can detach in the user's launchd context, retaining key-only authentication and using fresh bootstrap connections. [PR 2051](https://github.com/openclaw/crabbox/pull/2051). Thanks @steipete.
 - Support POSIX workspace ownership without `flock` or `lockf`, sharing an atomic directory gate across owner updates and child witnesses while preserving fail-closed recovery. [PR 2051](https://github.com/openclaw/crabbox/pull/2051). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changes
 
 - Consolidate KubeVirt settings and work-root selection without changing key-source rules, path expansion, saved-file semantics, or explicit release choices. [PR 2058](https://github.com/openclaw/crabbox/pull/2058). Thanks @steipete.
-- Consolidate Apple Container and Apple Machine shared settings while preserving their distinct flag surfaces, argument-list behavior, image selection, and saved-file formats. Thanks @steipete.
+- Consolidate Apple Container and Apple Machine shared settings while preserving their distinct flag surfaces, argument-list behavior, image selection, and saved-file formats. [PR 2059](https://github.com/openclaw/crabbox/pull/2059). Thanks @steipete.
 
 - Initialize managed macOS SSH sessions through PAM so stock `nohup` can detach in the user's launchd context, retaining key-only authentication and using fresh bootstrap connections. [PR 2051](https://github.com/openclaw/crabbox/pull/2051). Thanks @steipete.
 - Support POSIX workspace ownership without `flock` or `lockf`, sharing an atomic directory gate across owner updates and child witnesses while preserving fail-closed recovery. [PR 2051](https://github.com/openclaw/crabbox/pull/2051). Thanks @steipete.

--- a/docs/providers/apple-container.md
+++ b/docs/providers/apple-container.md
@@ -144,6 +144,19 @@ CRABBOX_APPLE_CONTAINER_MEMORY
 CRABBOX_APPLE_CONTAINER_EXTRA_RUN_ARGS
 ```
 
+File `extraRunArgs` entries retain their text, order, and duplicates; a nonempty
+list is copied, while an omitted or empty list leaves prior values intact.
+Environment and flag strings split on whitespace, without interpreting shell
+quotes or commas. A blank environment value leaves prior arguments intact; an
+explicitly visited blank flag clears them. Use a YAML list when an individual
+argument must contain spaces.
+
+Empty file strings leave prior values intact. File CPU values apply only when
+positive; environment and flag input retain their existing zero/negative-value
+behavior. Saving configuration omits zero and empty values without changing the
+original input that was ignored during application. Image explicitness records
+accepted input, including a value equal to the current default.
+
 No secrets are passed as CLI arguments. The only key material handed to the
 container is the per-lease SSH public key, supplied through an environment
 variable consumed by the bootstrap script.

--- a/docs/providers/apple-machine.md
+++ b/docs/providers/apple-machine.md
@@ -53,6 +53,13 @@ Provider flags:
 --apple-machine-memory <size>
 ```
 
+These four flags remain separate from Apple Container's seven-flag surface;
+they do not expose its user, work-root, or extra-run-argument flags. Both surfaces
+share configuration values and image explicitness, but retain their distinct
+post-flag defaults and runtime behavior. See the [shared input rules](apple-container.md#configuration)
+for file and environment semantics; displayed configuration is not a claim about
+the native machine's defaults.
+
 ## Behavior and limits
 
 - `warmup` maps to `container machine create`.

--- a/docs/refactor/typed-provider-config.md
+++ b/docs/refactor/typed-provider-config.md
@@ -194,6 +194,27 @@ provider lookups remain separate from these raw-empty rules.
 Native mount filtering, lookup, credentials, class selection and OS mappings remain
 provider policy. The following field instructions apply to generated owners.
 
+## Apple Container's shared concrete owner
+
+`config_apple_container.go` owns all seven shared settings without generated
+bindings. A YAML-tagged `AppleContainerConfig` and distinct defined
+`fileAppleContainerConfig` retain one field roster, the existing file type name,
+and zero-valued decoding. File persistence and the six-field config-show view
+remain unchanged; raw runtime JSON retains its existing shape. Ad-hoc YAML
+serialization of the runtime type is not a supported compatibility contract.
+
+Initialization accepts the already-resolved OS image, including an empty value,
+rather than resolving it again. File input clones nonempty argument lists;
+environment input ignores empty whitespace-tokenized results; a visited flag
+clears the list to nil when tokenization is empty. These are distinct policies,
+not interchangeable list modes.
+
+The owner provides two typed flag surfaces: seven Apple Container flags and four
+Apple Machine flags with their existing names and help. They are not aliases or
+a configurable prefix factory. Provider wrappers retain image markers, generic
+user/root propagation, and the exact selected Container defaults call. OS-image
+selection and native Container/Machine behavior remain outside this owner.
+
 ## Adding a field
 
 1. Add an exported, singly named field to the provider's config struct. Supported types

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -905,16 +905,6 @@ type LocalContainerConfig struct {
 	CheckpointMetadata map[string]string `yaml:"-" json:"-"`
 }
 
-type AppleContainerConfig struct {
-	CLIPath      string
-	Image        string
-	User         string
-	WorkRoot     string
-	CPUs         int
-	Memory       string
-	ExtraRunArgs []string
-}
-
 type AppleVMConfig struct {
 	HelperPath  string
 	Image       string
@@ -2607,12 +2597,7 @@ func baseConfig() Config {
 			User:    "crabbox",
 			Network: "bridge",
 		},
-		AppleContainer: AppleContainerConfig{
-			CLIPath:  "container",
-			Image:    containerImage,
-			User:     "crabbox",
-			WorkRoot: "/work/crabbox",
-		},
+		AppleContainer: initialAppleContainerConfig(containerImage),
 		AppleVM: AppleVMConfig{
 			Image:       osImageSpecs[osImage].AppleVMImage,
 			ImageSHA256: osImageSpecs[osImage].AppleVMSHA256,
@@ -3510,16 +3495,6 @@ type fileLocalContainerConfig struct {
 	Network      string `yaml:"network,omitempty"`
 	DockerSocket *bool  `yaml:"dockerSocket,omitempty"`
 	NoHostname   *bool  `yaml:"noHostname,omitempty"`
-}
-
-type fileAppleContainerConfig struct {
-	CLIPath      string   `yaml:"cliPath,omitempty"`
-	Image        string   `yaml:"image,omitempty"`
-	User         string   `yaml:"user,omitempty"`
-	WorkRoot     string   `yaml:"workRoot,omitempty"`
-	CPUs         int      `yaml:"cpus,omitempty"`
-	Memory       string   `yaml:"memory,omitempty"`
-	ExtraRunArgs []string `yaml:"extraRunArgs,omitempty"`
 }
 
 type fileAppleVMConfig struct {
@@ -5750,29 +5725,8 @@ func applyFileConfigWithTrustAndProviderSource(cfg *Config, file fileConfig, tru
 		// be an explicit CLI action (--local-container-volume), not
 		// something an untrusted checkout can request via .crabbox.yaml.
 	}
-	if file.AppleContainer != nil {
-		if file.AppleContainer.CLIPath != "" {
-			cfg.AppleContainer.CLIPath = file.AppleContainer.CLIPath
-		}
-		if file.AppleContainer.Image != "" {
-			cfg.AppleContainer.Image = file.AppleContainer.Image
-			cfg.appleContainerImageExplicit = true
-		}
-		if file.AppleContainer.User != "" {
-			cfg.AppleContainer.User = file.AppleContainer.User
-		}
-		if file.AppleContainer.WorkRoot != "" {
-			cfg.AppleContainer.WorkRoot = file.AppleContainer.WorkRoot
-		}
-		if file.AppleContainer.CPUs > 0 {
-			cfg.AppleContainer.CPUs = file.AppleContainer.CPUs
-		}
-		if file.AppleContainer.Memory != "" {
-			cfg.AppleContainer.Memory = file.AppleContainer.Memory
-		}
-		if len(file.AppleContainer.ExtraRunArgs) > 0 {
-			cfg.AppleContainer.ExtraRunArgs = append([]string(nil), file.AppleContainer.ExtraRunArgs...)
-		}
+	if cfg.AppleContainer.applyFile(file.AppleContainer) {
+		MarkAppleContainerImageExplicit(cfg)
 	}
 	if file.AppleVM == nil {
 		// Deprecated pre-rename key; appleVM wins when both are present.
@@ -7521,17 +7475,8 @@ func applyEnv(cfg *Config) error {
 	if value, ok := getenvBool("CRABBOX_LOCAL_CONTAINER_NO_HOSTNAME"); ok {
 		cfg.LocalContainer.NoHostname = value
 	}
-	cfg.AppleContainer.CLIPath = getenv("CRABBOX_APPLE_CONTAINER_CLI", cfg.AppleContainer.CLIPath)
-	if image := os.Getenv("CRABBOX_APPLE_CONTAINER_IMAGE"); image != "" {
-		cfg.AppleContainer.Image = image
-		cfg.appleContainerImageExplicit = true
-	}
-	cfg.AppleContainer.User = getenv("CRABBOX_APPLE_CONTAINER_USER", cfg.AppleContainer.User)
-	cfg.AppleContainer.WorkRoot = getenv("CRABBOX_APPLE_CONTAINER_WORK_ROOT", cfg.AppleContainer.WorkRoot)
-	cfg.AppleContainer.CPUs = getenvInt("CRABBOX_APPLE_CONTAINER_CPUS", cfg.AppleContainer.CPUs)
-	cfg.AppleContainer.Memory = getenv("CRABBOX_APPLE_CONTAINER_MEMORY", cfg.AppleContainer.Memory)
-	if extra := strings.Fields(os.Getenv("CRABBOX_APPLE_CONTAINER_EXTRA_RUN_ARGS")); len(extra) > 0 {
-		cfg.AppleContainer.ExtraRunArgs = extra
+	if cfg.AppleContainer.applyEnv() {
+		MarkAppleContainerImageExplicit(cfg)
 	}
 	cfg.AppleVM.HelperPath = getenv("CRABBOX_APPLE_VM_HELPER", getenv("CRABBOX_APPLE_VZ_HELPER", cfg.AppleVM.HelperPath))
 	if image := appleVMEnv("IMAGE"); image != "" {

--- a/internal/cli/config_apple_container.go
+++ b/internal/cli/config_apple_container.go
@@ -1,0 +1,176 @@
+package cli
+
+import (
+	"flag"
+	"os"
+	"strings"
+)
+
+// AppleContainerConfig is shared by the distinct Container and Machine flag surfaces.
+type AppleContainerConfig struct {
+	CLIPath      string   `yaml:"cliPath,omitempty"`
+	Image        string   `yaml:"image,omitempty"`
+	User         string   `yaml:"user,omitempty"`
+	WorkRoot     string   `yaml:"workRoot,omitempty"`
+	CPUs         int      `yaml:"cpus,omitempty"`
+	Memory       string   `yaml:"memory,omitempty"`
+	ExtraRunArgs []string `yaml:"extraRunArgs,omitempty"`
+}
+
+// Keep the named file destination and zero decoding separate from runtime defaults.
+type fileAppleContainerConfig AppleContainerConfig
+
+func initialAppleContainerConfig(image string) AppleContainerConfig {
+	return AppleContainerConfig{
+		CLIPath:  "container",
+		Image:    image,
+		User:     "crabbox",
+		WorkRoot: "/work/crabbox",
+	}
+}
+
+func (cfg *AppleContainerConfig) applyFile(file *fileAppleContainerConfig) (imageApplied bool) {
+	if file == nil {
+		return false
+	}
+	if file.CLIPath != "" {
+		cfg.CLIPath = file.CLIPath
+	}
+	if file.Image != "" {
+		cfg.Image = file.Image
+		imageApplied = true
+	}
+	if file.User != "" {
+		cfg.User = file.User
+	}
+	if file.WorkRoot != "" {
+		cfg.WorkRoot = file.WorkRoot
+	}
+	if file.CPUs > 0 {
+		cfg.CPUs = file.CPUs
+	}
+	if file.Memory != "" {
+		cfg.Memory = file.Memory
+	}
+	if len(file.ExtraRunArgs) > 0 {
+		cfg.ExtraRunArgs = append([]string(nil), file.ExtraRunArgs...)
+	}
+	return imageApplied
+}
+
+func (cfg *AppleContainerConfig) applyEnv() (imageApplied bool) {
+	cfg.CLIPath = getenv("CRABBOX_APPLE_CONTAINER_CLI", cfg.CLIPath)
+	if image := os.Getenv("CRABBOX_APPLE_CONTAINER_IMAGE"); image != "" {
+		cfg.Image = image
+		imageApplied = true
+	}
+	cfg.User = getenv("CRABBOX_APPLE_CONTAINER_USER", cfg.User)
+	cfg.WorkRoot = getenv("CRABBOX_APPLE_CONTAINER_WORK_ROOT", cfg.WorkRoot)
+	cfg.CPUs = getenvInt("CRABBOX_APPLE_CONTAINER_CPUS", cfg.CPUs)
+	cfg.Memory = getenv("CRABBOX_APPLE_CONTAINER_MEMORY", cfg.Memory)
+	if extra := strings.Fields(os.Getenv("CRABBOX_APPLE_CONTAINER_EXTRA_RUN_ARGS")); len(extra) > 0 {
+		cfg.ExtraRunArgs = extra
+	}
+	return imageApplied
+}
+
+// AppleContainerConfigFlagValues holds the seven Container flags only.
+type AppleContainerConfigFlagValues struct {
+	CLIPath  *string
+	Image    *string
+	User     *string
+	WorkRoot *string
+	CPUs     *int
+	Memory   *string
+	ExtraRun *string
+}
+
+// AppleContainerConfigApplied reports accepted flag assignments for caller policy.
+type AppleContainerConfigApplied struct {
+	Image    bool
+	User     bool
+	WorkRoot bool
+}
+
+func RegisterAppleContainerConfigFlags(fs *flag.FlagSet, defaults AppleContainerConfig) AppleContainerConfigFlagValues {
+	return AppleContainerConfigFlagValues{
+		CLIPath:  fs.String("apple-container-cli", defaults.CLIPath, "path to Apple's container CLI"),
+		Image:    fs.String("apple-container-image", defaults.Image, "container image for apple-container leases"),
+		User:     fs.String("apple-container-user", defaults.User, "SSH user created inside apple-container leases"),
+		WorkRoot: fs.String("apple-container-work-root", defaults.WorkRoot, "remote Crabbox work root inside apple-container leases"),
+		CPUs:     fs.Int("apple-container-cpus", defaults.CPUs, "CPU limit for apple-container leases; 0 leaves runtime default"),
+		Memory:   fs.String("apple-container-memory", defaults.Memory, "memory limit for apple-container leases, for example 8g"),
+		ExtraRun: fs.String("apple-container-extra-run-args", strings.Join(defaults.ExtraRunArgs, " "), "extra arguments appended to container run, space separated"),
+	}
+}
+
+func (values AppleContainerConfigFlagValues) Apply(cfg *AppleContainerConfig, fs *flag.FlagSet) AppleContainerConfigApplied {
+	var applied AppleContainerConfigApplied
+	if flagWasSet(fs, "apple-container-cli") {
+		cfg.CLIPath = *values.CLIPath
+	}
+	if flagWasSet(fs, "apple-container-image") {
+		cfg.Image = *values.Image
+		applied.Image = true
+	}
+	if flagWasSet(fs, "apple-container-user") {
+		cfg.User = *values.User
+		applied.User = true
+	}
+	if flagWasSet(fs, "apple-container-work-root") {
+		cfg.WorkRoot = *values.WorkRoot
+		applied.WorkRoot = true
+	}
+	if flagWasSet(fs, "apple-container-cpus") {
+		cfg.CPUs = *values.CPUs
+	}
+	if flagWasSet(fs, "apple-container-memory") {
+		cfg.Memory = *values.Memory
+	}
+	if flagWasSet(fs, "apple-container-extra-run-args") {
+		cfg.ExtraRunArgs = splitAppleContainerExtraArgs(*values.ExtraRun)
+	}
+	return applied
+}
+
+func splitAppleContainerExtraArgs(value string) []string {
+	fields := strings.Fields(value)
+	if len(fields) == 0 {
+		return nil
+	}
+	return fields
+}
+
+// AppleMachineConfigFlagValues holds Machine's separate four-flag surface.
+type AppleMachineConfigFlagValues struct {
+	CLIPath *string
+	Image   *string
+	CPUs    *int
+	Memory  *string
+}
+
+func RegisterAppleMachineConfigFlags(fs *flag.FlagSet, defaults AppleContainerConfig) AppleMachineConfigFlagValues {
+	return AppleMachineConfigFlagValues{
+		CLIPath: fs.String("apple-machine-cli", defaults.CLIPath, "path to Apple's container CLI"),
+		Image:   fs.String("apple-machine-image", defaults.Image, "OCI image for apple-machine leases"),
+		CPUs:    fs.Int("apple-machine-cpus", defaults.CPUs, "CPU count for apple-machine leases"),
+		Memory:  fs.String("apple-machine-memory", defaults.Memory, "memory for apple-machine leases, for example 8G"),
+	}
+}
+
+func (values AppleMachineConfigFlagValues) Apply(cfg *AppleContainerConfig, fs *flag.FlagSet) (imageApplied bool) {
+	if flagWasSet(fs, "apple-machine-cli") {
+		cfg.CLIPath = *values.CLIPath
+	}
+	if flagWasSet(fs, "apple-machine-image") {
+		cfg.Image = *values.Image
+		imageApplied = true
+	}
+	if flagWasSet(fs, "apple-machine-cpus") {
+		cfg.CPUs = *values.CPUs
+	}
+	if flagWasSet(fs, "apple-machine-memory") {
+		cfg.Memory = *values.Memory
+	}
+	return imageApplied
+}

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -532,6 +532,72 @@ func TestKubeVirtConfigWriter(t *testing.T) {
 	}
 }
 
+func TestAppleContainerConfigWriterAndJSON(t *testing.T) {
+	if reflect.TypeOf(fileAppleContainerConfig{}).Name() != "fileAppleContainerConfig" {
+		t.Fatal("file decoder destination name changed")
+	}
+	for _, tc := range []struct{ input, want string }{{"null", "{}"}, {"{}", "appleContainer: {}"}, {"{cliPath: '', image: '', user: '', workRoot: '', cpus: 0, memory: '', extraRunArgs: []}", "appleContainer: {}"}, {"{cliPath: '~/literal', image: '  ', cpus: -2, extraRunArgs: [' a ', a, a]}", "appleContainer: {cliPath: '~/literal', image: '  ', cpus: -2, extraRunArgs: [' a ', a, a]}"}} {
+		path := isolatedConfigPath(t)
+		if err := os.WriteFile(path, []byte("appleContainer: "+tc.input), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		file, err := readFileConfig(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		before, err := yaml.Marshal(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cfg := baseConfig()
+		if err := applyFileConfig(&cfg, file); err != nil {
+			t.Fatal(err)
+		}
+		after, err := yaml.Marshal(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(before, after) {
+			t.Fatal("overlay mutated writer input")
+		}
+		if _, err := writeUserFileConfig(file); err != nil {
+			t.Fatal(err)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got, want map[string]any
+		if err := yaml.Unmarshal(data, &got); err != nil {
+			t.Fatal(err)
+		}
+		if err := yaml.Unmarshal([]byte(tc.want), &want); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("writer=%#v want %#v", got, want)
+		}
+	}
+	cfg := baseConfig()
+	cfg.AppleContainer = AppleContainerConfig{CLIPath: "tool", Image: "image-example", User: "user-example", WorkRoot: "/workspace/example", CPUs: 3, Memory: "6g"}
+	wantView := map[string]any{"cliPath": "tool", "image": "image-example", "user": "user-example", "workRoot": "/workspace/example", "cpus": 3, "memory": "6g"}
+	if got := configShowView(cfg)["appleContainer"]; !reflect.DeepEqual(got, wantView) {
+		t.Fatalf("view=%#v", got)
+	}
+	data, err := json.Marshal(cfg.AppleContainer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	wantJSON := map[string]any{"CLIPath": "tool", "Image": "image-example", "User": "user-example", "WorkRoot": "/workspace/example", "CPUs": float64(3), "Memory": "6g", "ExtraRunArgs": nil}
+	if !reflect.DeepEqual(got, wantJSON) {
+		t.Fatalf("runtime JSON=%#v", got)
+	}
+}
+
 func TestGeneratedFileStorageWriter(t *testing.T) {
 	for _, tc := range []struct{ name, input, want string }{
 		{"missing", "{}", "{}"},

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -4232,6 +4232,136 @@ func TestCloudflareDynamicWorkersRepositoryCapsApplyAfterEnvironment(t *testing.
 	}
 }
 
+func TestAppleContainerConfigSources(t *testing.T) {
+	clearConfigEnv(t)
+	base := baseConfig()
+	want := AppleContainerConfig{CLIPath: "container", Image: base.LocalContainer.Image, User: "crabbox", WorkRoot: "/work/crabbox"}
+	if !reflect.DeepEqual(base.AppleContainer, want) || base.AppleContainer.Image == "" {
+		t.Fatalf("defaults=%#v want %#v", base.AppleContainer, want)
+	}
+	for _, f := range []struct{ field, key, env string }{{"CLIPath", "cliPath", "CLI"}, {"Image", "image", "IMAGE"}, {"User", "user", "USER"}, {"WorkRoot", "workRoot", "WORK_ROOT"}, {"Memory", "memory", "MEMORY"}} {
+		t.Run(f.field, func(t *testing.T) {
+			for _, input := range []string{"null", "''", "'  '", "'same'", "'~/literal'"} {
+				cfg := baseConfig()
+				reflect.ValueOf(&cfg.AppleContainer).Elem().FieldByName(f.field).SetString("same")
+				var file fileConfig
+				if err := yaml.Unmarshal([]byte("appleContainer: {"+f.key+": "+input+"}"), &file); err != nil {
+					t.Fatal(err)
+				}
+				if err := applyFileConfig(&cfg, file); err != nil {
+					t.Fatal(err)
+				}
+				want := "same"
+				if input == "'  '" {
+					want = "  "
+				}
+				if input == "'~/literal'" {
+					want = "~/literal"
+				}
+				if got := reflect.ValueOf(cfg.AppleContainer).FieldByName(f.field).String(); got != want {
+					t.Fatalf("file %s=%q want %q", input, got, want)
+				}
+				if AppleContainerImageExplicit(cfg) != (f.field == "Image" && input != "null" && input != "''") {
+					t.Fatal("file image acceptance marker")
+				}
+			}
+			for _, input := range []string{"", "  ", "same", "~/literal"} {
+				t.Setenv("CRABBOX_APPLE_CONTAINER_"+f.env, input)
+				cfg := baseConfig()
+				reflect.ValueOf(&cfg.AppleContainer).Elem().FieldByName(f.field).SetString("same")
+				if err := applyEnv(&cfg); err != nil {
+					t.Fatal(err)
+				}
+				want := input
+				if input == "" {
+					want = "same"
+				}
+				if got := reflect.ValueOf(cfg.AppleContainer).FieldByName(f.field).String(); got != want {
+					t.Fatalf("env %q=%q", input, got)
+				}
+				if AppleContainerImageExplicit(cfg) != (f.field == "Image" && input != "") {
+					t.Fatal("env image acceptance marker")
+				}
+			}
+		})
+	}
+	for _, input := range []int{-2, 0, 3} {
+		cfg := baseConfig()
+		cfg.AppleContainer.CPUs = 7
+		if err := applyFileConfig(&cfg, fileConfig{AppleContainer: &fileAppleContainerConfig{CPUs: input}}); err != nil {
+			t.Fatal(err)
+		}
+		want := 7
+		if input > 0 {
+			want = input
+		}
+		if cfg.AppleContainer.CPUs != want {
+			t.Fatal("file CPU positive predicate")
+		}
+	}
+	for _, tc := range []struct {
+		input string
+		want  int
+	}{{"", 7}, {"invalid", 7}, {" 3 ", 7}, {"0", 0}, {"-2", -2}, {"3", 3}} {
+		t.Run("cpu-"+tc.input, func(t *testing.T) {
+			t.Setenv("CRABBOX_APPLE_CONTAINER_CPUS", tc.input)
+			cfg := baseConfig()
+			cfg.AppleContainer.CPUs = 7
+			if err := applyEnv(&cfg); err != nil {
+				t.Fatal(err)
+			}
+			if cfg.AppleContainer.CPUs != tc.want {
+				t.Fatalf("CPU=%d want %d", cfg.AppleContainer.CPUs, tc.want)
+			}
+		})
+	}
+}
+
+func TestAppleContainerConfigLists(t *testing.T) {
+	clearConfigEnv(t)
+	for _, source := range [][]string{nil, {}, {" alpha ", "alpha", "alpha"}} {
+		cfg := baseConfig()
+		cfg.AppleContainer.ExtraRunArgs = []string{"prior"}
+		file := fileConfig{AppleContainer: &fileAppleContainerConfig{ExtraRunArgs: source}}
+		if err := applyFileConfig(&cfg, file); err != nil {
+			t.Fatal(err)
+		}
+		want := []string{"prior"}
+		if len(source) > 0 {
+			want = []string{" alpha ", "alpha", "alpha"}
+		}
+		if !reflect.DeepEqual(cfg.AppleContainer.ExtraRunArgs, want) {
+			t.Fatal("file raw list/nonempty rule")
+		}
+		if len(source) > 0 {
+			source[0] = "source-change"
+			if cfg.AppleContainer.ExtraRunArgs[0] != " alpha " {
+				t.Fatal("accepted file list not cloned")
+			}
+			cfg.AppleContainer.ExtraRunArgs[1] = "runtime-change"
+			if source[1] != "alpha" {
+				t.Fatal("runtime list aliases file input")
+			}
+		}
+	}
+	for _, tc := range []struct {
+		input string
+		want  []string
+	}{{"", []string{"prior"}}, {" \t\n", []string{"prior"}}, {"alpha\tbeta alpha", []string{"alpha", "beta", "alpha"}}, {"\"alpha beta\" a,b", []string{"\"alpha", "beta\"", "a,b"}}} {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Setenv("CRABBOX_APPLE_CONTAINER_EXTRA_RUN_ARGS", tc.input)
+			cfg := baseConfig()
+			cfg.AppleContainer.ExtraRunArgs = []string{"prior"}
+			if err := applyEnv(&cfg); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(cfg.AppleContainer.ExtraRunArgs, tc.want) {
+				t.Fatalf("env list=%q want %q", cfg.AppleContainer.ExtraRunArgs, tc.want)
+			}
+		})
+	}
+}
+
 func TestAppleContainerConfigDefaultsFileAndEnv(t *testing.T) {
 	clearConfigEnv(t)
 	cfg := baseConfig()

--- a/internal/providers/applecontainer/backend_test.go
+++ b/internal/providers/applecontainer/backend_test.go
@@ -3,9 +3,11 @@ package applecontainer
 import (
 	"context"
 	"errors"
+	"flag"
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -143,6 +145,88 @@ func TestAliasDoesNotCollideWithLocalContainer(t *testing.T) {
 	for _, alias := range (Provider{}).Aliases() {
 		if alias == "container" {
 			t.Fatalf("apple-container must not declare the 'container' alias")
+		}
+	}
+}
+
+func TestAppleContainerConfigFlags(t *testing.T) {
+	defaults := core.Config{AppleContainer: core.AppleContainerConfig{CLIPath: "tool", Image: "image-example", User: "user-example", WorkRoot: "/workspace/example", CPUs: 3, Memory: "6g", ExtraRunArgs: []string{"alpha", " beta "}}}
+	fs := flag.NewFlagSet("config", flag.ContinueOnError)
+	v := (Provider{}).RegisterFlags(fs, defaults)
+	want := map[string]string{"apple-container-cli": "tool", "apple-container-image": "image-example", "apple-container-user": "user-example", "apple-container-work-root": "/workspace/example", "apple-container-cpus": "3", "apple-container-memory": "6g", "apple-container-extra-run-args": "alpha  beta "}
+	got := map[string]string{}
+	fs.VisitAll(func(f *flag.Flag) { got[f.Name] = f.DefValue })
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("flag surface=%#v", got)
+	}
+	cfg := defaults
+	cfg.Provider = "unselected"
+	before := cfg
+	if err := (Provider{}).ApplyFlags(&cfg, fs, v); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(cfg, before) {
+		t.Fatal("unvisited unselected flags changed config")
+	}
+	if err := fs.Parse([]string{"--apple-container-cli=~/literal", "--apple-container-image=image-example", "--apple-container-user=user-next", "--apple-container-work-root=/workspace/~/guest", "--apple-container-cpus=-2", "--apple-container-memory=8g", "--apple-container-extra-run-args=first", "--apple-container-extra-run-args=\"alpha beta\" a,b"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := (Provider{}).ApplyFlags(&cfg, fs, v); err != nil {
+		t.Fatal(err)
+	}
+	wantConfig := core.AppleContainerConfig{CLIPath: "~/literal", Image: "image-example", User: "user-next", WorkRoot: "/workspace/~/guest", CPUs: -2, Memory: "8g", ExtraRunArgs: []string{"\"alpha", "beta\"", "a,b"}}
+	if !reflect.DeepEqual(cfg.AppleContainer, wantConfig) || !core.AppleContainerImageExplicit(cfg) || cfg.SSHUser != "user-next" || cfg.WorkRoot != "/workspace/~/guest" || core.IsWorkRootExplicit(&cfg) {
+		t.Fatal("flag values/accepted image/generic copies")
+	}
+	for _, raw := range []string{"", " \t "} {
+		c := defaults
+		c.Provider = "unselected"
+		f := flag.NewFlagSet("empty", flag.ContinueOnError)
+		values := (Provider{}).RegisterFlags(f, c)
+		if err := f.Parse([]string{"--apple-container-cli=", "--apple-container-image=", "--apple-container-user=", "--apple-container-work-root=", "--apple-container-cpus=0", "--apple-container-memory=", "--apple-container-extra-run-args=" + raw}); err != nil {
+			t.Fatal(err)
+		}
+		if err := (Provider{}).ApplyFlags(&c, f, values); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(c.AppleContainer, core.AppleContainerConfig{}) || !core.AppleContainerImageExplicit(c) || c.SSHUser != "" || c.WorkRoot != "" {
+			t.Fatal("visited empty flags must clear to nil without unselected defaults")
+		}
+	}
+	for _, name := range []string{"apple-container", "apple", "applecontainer", "APPLE", " apple-container "} {
+		c := core.Config{Provider: name, WindowsMode: "fixture", WorkRoot: "/workspace/generic", AppleContainer: core.AppleContainerConfig{Image: "image-example", CPUs: -2, Memory: "8g", ExtraRunArgs: []string{"token"}}}
+		f := flag.NewFlagSet(name, flag.ContinueOnError)
+		values := (Provider{}).RegisterFlags(f, c)
+		if err := (Provider{}).ApplyFlags(&c, f, values); err != nil {
+			t.Fatal(err)
+		}
+		selected := name == "apple-container" || name == "apple" || name == "applecontainer"
+		if selected {
+			if c.Provider != "apple-container" || c.TargetOS != core.TargetLinux || c.WindowsMode != "" || c.SSHFallbackPorts == nil || len(c.SSHFallbackPorts) != 0 || c.AppleContainer.CLIPath != "container" || c.AppleContainer.User != "crabbox" || c.AppleContainer.WorkRoot != "/workspace/generic" || c.ServerType != "image-example" {
+				t.Fatal("selected postdefaults projection")
+			}
+		} else if c.AppleContainer.CLIPath != "" || c.Provider != name || c.SSHFallbackPorts != nil {
+			t.Fatal("raw nonmatching selector ran defaults")
+		}
+		if c.AppleContainer.CPUs != -2 || c.AppleContainer.Memory != "8g" || !reflect.DeepEqual(c.AppleContainer.ExtraRunArgs, []string{"token"}) {
+			t.Fatal("postdefaults changed CPU/memory/list")
+		}
+	}
+	for _, foreign := range []any{nil, struct{}{}} {
+		c := core.Config{Provider: "apple-container"}
+		before := c
+		if err := (Provider{}).ApplyFlags(&c, flag.NewFlagSet("foreign", flag.ContinueOnError), foreign); err != nil || !reflect.DeepEqual(c, before) {
+			t.Fatal("foreign values must precede defaults")
+		}
+	}
+}
+
+func TestAppleContainerConfigDefaultsPolicy(t *testing.T) {
+	for _, tc := range []struct{ generic, provider, want string }{{"", "", "/work/crabbox"}, {" /work/crabbox ", "", "/work/crabbox"}, {" /workspace/custom ", "", " /workspace/custom "}, {"/workspace/generic", "  ", "  "}, {"/workspace/generic", "/workspace/provider", "/workspace/provider"}} {
+		cfg := core.Config{WorkRoot: tc.generic, AppleContainer: core.AppleContainerConfig{Image: "image-example", WorkRoot: tc.provider, CLIPath: " ", User: " "}}
+		applyDefaults(&cfg)
+		if cfg.AppleContainer.WorkRoot != tc.want || cfg.WorkRoot != tc.want || cfg.AppleContainer.CLIPath != " " || cfg.SSHUser != " " {
+			t.Fatal("raw defaults versus trimmed root classifier")
 		}
 	}
 }

--- a/internal/providers/applecontainer/flags.go
+++ b/internal/providers/applecontainer/flags.go
@@ -2,72 +2,27 @@ package applecontainer
 
 import (
 	"flag"
-	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-type flagValues struct {
-	CLIPath  *string
-	Image    *string
-	User     *string
-	WorkRoot *string
-	CPUs     *int
-	Memory   *string
-	ExtraRun *string
-}
-
-func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
-	return flagValues{
-		CLIPath:  fs.String("apple-container-cli", defaults.AppleContainer.CLIPath, "path to Apple's container CLI"),
-		Image:    fs.String("apple-container-image", defaults.AppleContainer.Image, "container image for apple-container leases"),
-		User:     fs.String("apple-container-user", defaults.AppleContainer.User, "SSH user created inside apple-container leases"),
-		WorkRoot: fs.String("apple-container-work-root", defaults.AppleContainer.WorkRoot, "remote Crabbox work root inside apple-container leases"),
-		CPUs:     fs.Int("apple-container-cpus", defaults.AppleContainer.CPUs, "CPU limit for apple-container leases; 0 leaves runtime default"),
-		Memory:   fs.String("apple-container-memory", defaults.AppleContainer.Memory, "memory limit for apple-container leases, for example 8g"),
-		ExtraRun: fs.String("apple-container-extra-run-args", strings.Join(defaults.AppleContainer.ExtraRunArgs, " "), "extra arguments appended to container run, space separated"),
-	}
-}
-
-func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
-	v, ok := values.(flagValues)
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(core.AppleContainerConfigFlagValues)
 	if !ok {
 		return nil
 	}
-	if core.FlagWasSet(fs, "apple-container-cli") {
-		cfg.AppleContainer.CLIPath = *v.CLIPath
-	}
-	if core.FlagWasSet(fs, "apple-container-image") {
-		cfg.AppleContainer.Image = *v.Image
+	applied := v.Apply(&cfg.AppleContainer, fs)
+	if applied.Image {
 		core.MarkAppleContainerImageExplicit(cfg)
 	}
-	if core.FlagWasSet(fs, "apple-container-user") {
-		cfg.AppleContainer.User = *v.User
-		cfg.SSHUser = *v.User
+	if applied.User {
+		cfg.SSHUser = cfg.AppleContainer.User
 	}
-	if core.FlagWasSet(fs, "apple-container-work-root") {
-		cfg.AppleContainer.WorkRoot = *v.WorkRoot
-		cfg.WorkRoot = *v.WorkRoot
-	}
-	if core.FlagWasSet(fs, "apple-container-cpus") {
-		cfg.AppleContainer.CPUs = *v.CPUs
-	}
-	if core.FlagWasSet(fs, "apple-container-memory") {
-		cfg.AppleContainer.Memory = *v.Memory
-	}
-	if core.FlagWasSet(fs, "apple-container-extra-run-args") {
-		cfg.AppleContainer.ExtraRunArgs = splitExtraArgs(*v.ExtraRun)
+	if applied.WorkRoot {
+		cfg.WorkRoot = cfg.AppleContainer.WorkRoot
 	}
 	if core.ProviderNameMatchesExact(cfg.Provider, Provider{}) {
 		applyDefaults(cfg)
 	}
 	return nil
-}
-
-func splitExtraArgs(value string) []string {
-	fields := strings.Fields(value)
-	if len(fields) == 0 {
-		return nil
-	}
-	return fields
 }

--- a/internal/providers/applecontainer/provider.go
+++ b/internal/providers/applecontainer/provider.go
@@ -32,11 +32,7 @@ func (Provider) Spec() core.ProviderSpec {
 }
 
 func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
-	return registerFlags(fs, defaults)
-}
-
-func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
-	return applyFlags(cfg, fs, values)
+	return core.RegisterAppleContainerConfigFlags(fs, defaults.AppleContainer)
 }
 
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {

--- a/internal/providers/applemachine/backend_test.go
+++ b/internal/providers/applemachine/backend_test.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -57,6 +59,58 @@ func testBackend(runner *recordingRunner) *backend {
 	cfg.AppleContainer.CPUs = 4
 	cfg.AppleContainer.Memory = "8G"
 	return newBackend(Provider{}.Spec(), cfg, core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+}
+
+func TestAppleMachineConfigFlags(t *testing.T) {
+	defaults := core.Config{AppleContainer: core.AppleContainerConfig{CLIPath: "tool", Image: "image-example", User: "user-example", WorkRoot: "/workspace/example", CPUs: 3, Memory: "6g", ExtraRunArgs: []string{"token"}}}
+	fs := flag.NewFlagSet("machine", flag.ContinueOnError)
+	v := (Provider{}).RegisterFlags(fs, defaults)
+	got := map[string]string{}
+	fs.VisitAll(func(f *flag.Flag) { got[f.Name] = f.DefValue })
+	want := map[string]string{"apple-machine-cli": "tool", "apple-machine-image": "image-example", "apple-machine-cpus": "3", "apple-machine-memory": "6g"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("four-flag surface=%#v", got)
+	}
+	cfg := defaults
+	cfg.Provider = "apple-machine"
+	before := cfg
+	if err := (Provider{}).ApplyFlags(&cfg, fs, v); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(cfg, before) {
+		t.Fatal("unvisited machine flags ran defaults")
+	}
+	if err := fs.Parse([]string{"--apple-machine-cli=~/literal", "--apple-machine-image=first", "--apple-machine-image=image-example", "--apple-machine-cpus=-2", "--apple-machine-memory=8G"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := (Provider{}).ApplyFlags(&cfg, fs, v); err != nil {
+		t.Fatal(err)
+	}
+	wantConfig := defaults.AppleContainer
+	wantConfig.CLIPath = "~/literal"
+	wantConfig.CPUs = -2
+	wantConfig.Memory = "8G"
+	if !reflect.DeepEqual(cfg.AppleContainer, wantConfig) || !core.AppleContainerImageExplicit(cfg) || cfg.SSHUser != "" || cfg.WorkRoot != "" || cfg.ServerType != "" || cfg.TargetOS != "" {
+		t.Fatal("machine values/marker must not gain container projection")
+	}
+	f := flag.NewFlagSet("empty", flag.ContinueOnError)
+	values := (Provider{}).RegisterFlags(f, cfg)
+	if err := f.Parse([]string{"--apple-machine-cli=", "--apple-machine-image=", "--apple-machine-cpus=0", "--apple-machine-memory="}); err != nil {
+		t.Fatal(err)
+	}
+	if err := (Provider{}).ApplyFlags(&cfg, f, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AppleContainer.CLIPath != "" || cfg.AppleContainer.Image != "" || cfg.AppleContainer.CPUs != 0 || cfg.AppleContainer.Memory != "" || cfg.AppleContainer.User != "user-example" || !reflect.DeepEqual(cfg.AppleContainer.ExtraRunArgs, []string{"token"}) {
+		t.Fatal("machine empty assignments/no defaults")
+	}
+	for _, foreign := range []any{nil, struct{}{}} {
+		c := core.Config{Provider: "apple-machine"}
+		before := c
+		if err := (Provider{}).ApplyFlags(&c, flag.NewFlagSet("foreign", flag.ContinueOnError), foreign); err != nil || !reflect.DeepEqual(c, before) {
+			t.Fatal("foreign values changed machine config")
+		}
+	}
 }
 
 func TestCreateMachineArgs(t *testing.T) {

--- a/internal/providers/applemachine/flags.go
+++ b/internal/providers/applemachine/flags.go
@@ -6,39 +6,13 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-type flagValues struct {
-	CLIPath *string
-	Image   *string
-	CPUs    *int
-	Memory  *string
-}
-
-func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
-	return flagValues{
-		CLIPath: fs.String("apple-machine-cli", defaults.AppleContainer.CLIPath, "path to Apple's container CLI"),
-		Image:   fs.String("apple-machine-image", defaults.AppleContainer.Image, "OCI image for apple-machine leases"),
-		CPUs:    fs.Int("apple-machine-cpus", defaults.AppleContainer.CPUs, "CPU count for apple-machine leases"),
-		Memory:  fs.String("apple-machine-memory", defaults.AppleContainer.Memory, "memory for apple-machine leases, for example 8G"),
-	}
-}
-
-func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
-	v, ok := values.(flagValues)
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(core.AppleMachineConfigFlagValues)
 	if !ok {
 		return nil
 	}
-	if core.FlagWasSet(fs, "apple-machine-cli") {
-		cfg.AppleContainer.CLIPath = *v.CLIPath
-	}
-	if core.FlagWasSet(fs, "apple-machine-image") {
-		cfg.AppleContainer.Image = *v.Image
+	if v.Apply(&cfg.AppleContainer, fs) {
 		core.MarkAppleContainerImageExplicit(cfg)
-	}
-	if core.FlagWasSet(fs, "apple-machine-cpus") {
-		cfg.AppleContainer.CPUs = *v.CPUs
-	}
-	if core.FlagWasSet(fs, "apple-machine-memory") {
-		cfg.AppleContainer.Memory = *v.Memory
 	}
 	return nil
 }

--- a/internal/providers/applemachine/provider.go
+++ b/internal/providers/applemachine/provider.go
@@ -27,11 +27,7 @@ func (Provider) Spec() core.ProviderSpec {
 }
 
 func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
-	return registerFlags(fs, defaults)
-}
-
-func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
-	return applyFlags(cfg, fs, values)
+	return core.RegisterAppleMachineConfigFlags(fs, defaults.AppleContainer)
 }
 
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {


### PR DESCRIPTION
## Summary

Consolidate the seven settings shared by Apple Container and Apple Machine into one concrete configuration owner. Keep two typed flag surfaces—seven Container flags and four Machine flags—rather than hiding their differences behind a prefix factory. Remove the old registration/application forwarding helpers.

The owner preserves file presence, nonempty argument-list copying, environment tokenization, visited-empty flag clearing, CPU input rules, image explicitness and generic user/work-root propagation. The existing OS-image selection and provider-specific post-flag defaults remain outside it. The distinct file type preserves saved YAML and diagnostics; runtime JSON and the six-field public view stay unchanged. Ad-hoc YAML marshaling of the runtime type is not a supported compatibility contract.

Provider documentation, the refactor guide and the changelog describe these boundaries. No configuration migration, new credential or dependency is required.

## Verification

- Twelve focused Apple configuration, writer and provider flag tests passed against the prior implementation before production edits and against the refactor.
- After rebasing onto the actual merged KubeVirt source, 31 distinct Apple/KubeVirt/Sealos configuration tests passed with the race detector. All 34 generated-file freshness checks, five-package vet and CLI build passed. The resolved source and index remained unchanged throughout.
- The same 42 frozen source-blind local CLI cases matched both the original baseline and the first candidate exactly: raw stdout/stderr, exit/timeout results and written configuration bytes. Forty succeeded and two preserved CPU-flag parser errors. No differences, timeouts, added cases or retries.
- Candidate binary SHA256: `d51dc53fab0d63abff64d8d5ba5f1ce883feffba227667d99f81f6c9b930ebe8`.
- Documentation build passed. Independent source binding and managed Codex review found no accepted actionable finding in the reviewed scope.

CLI evidence has deliberate limits: six fields are publicly visible; `extraRunArgs` has inert-list YAML writer coverage, not public JSON or native forwarding coverage. Provider CPU flags are local parser observations. These checks make no claim about native Container/Machine, VM, SSH or cloud lifecycle execution. Existing native implementation bodies and generated bindings are unchanged.

GitHub checks will be assessed on the final PR head before landing.
