### PR TITLE
refactor(config): share accepted local-path expansion

### DIFF
--- a/docs/refactor/typed-provider-config.md
+++ b/docs/refactor/typed-provider-config.md
@@ -62,6 +62,12 @@ provider owns the shared inherited-root decision used by configuration and
 command forwarding; its distinct routing and trim-aware fallback rules stay
 separate. No generator callback or new normalization policy is introduced.
 
+Each provider owns an `ExpandAppliedLocalPaths` method used by its file and
+flag wrappers. It consumes the actual applied report and preserves the ordered
+field transformations; it does not change acceptance, markers, or guest paths.
+Environment fallback expansion stays explicit and does not manufacture an
+all-true applied report.
+
 ## Why generation
 
 Provider packages already import `internal/cli`, which owns `Config` and file

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -4823,12 +4823,7 @@ func applyFileConfigWithTrustAndProviderSource(cfg *Config, file fileConfig, tru
 	}
 	{
 		applied, err := cfg.SealosDevbox.applyFile(file.SealosDevbox, trusted)
-		if applied.Kubectl {
-			cfg.SealosDevbox.Kubectl = expandUserPath(cfg.SealosDevbox.Kubectl)
-		}
-		if applied.Kubeconfig {
-			cfg.SealosDevbox.Kubeconfig = expandUserPath(cfg.SealosDevbox.Kubeconfig)
-		}
+		cfg.SealosDevbox.ExpandAppliedLocalPaths(applied)
 		if applied.WorkRoot {
 			MarkSealosDevboxWorkRootExplicit(cfg)
 		}

--- a/internal/cli/config_kubevirt.go
+++ b/internal/cli/config_kubevirt.go
@@ -2,8 +2,8 @@ package cli
 
 //go:generate go run ../../scripts/configgen -source config_kubevirt.go -output config_kubevirt_generated.go -type KubeVirtConfig -provider kubevirt
 
-// KubeVirtConfig owns mechanical bindings. File admission and local-path
-// expansion remain in applyKubeVirtFileConfig and the source callers.
+// KubeVirtConfig owns mechanical bindings and accepted local-path expansion.
+// File admission remains in applyKubeVirtFileConfig.
 type KubeVirtConfig struct {
 	Kubectl    string `config:"kubectl" env:"CRABBOX_KUBEVIRT_KUBECTL" flag:"kubevirt-kubectl" sources:"user,repo,env,flag" help:"kubectl executable" default:"kubectl" fileIgnoreEmpty:"true" fileStorage:"value" reportApplied:"true"`
 	Virtctl    string `config:"virtctl" env:"CRABBOX_KUBEVIRT_VIRTCTL" flag:"kubevirt-virtctl" sources:"user,repo,env,flag" help:"virtctl executable" default:"virtctl" fileIgnoreEmpty:"true" fileStorage:"value" reportApplied:"true"`
@@ -20,6 +20,28 @@ type KubeVirtConfig struct {
 	DeleteOnRelease bool   `config:"deleteOnRelease" env:"CRABBOX_KUBEVIRT_DELETE_ON_RELEASE" flag:"kubevirt-delete-on-release" sources:"user,repo,env,flag" help:"delete the VM on release instead of stopping it" default:"true" reportApplied:"true"`
 }
 
+// ExpandAppliedLocalPaths expands local paths accepted by a file or flag overlay.
+func (cfg *KubeVirtConfig) ExpandAppliedLocalPaths(applied KubeVirtConfigApplied) {
+	if applied.Kubectl {
+		cfg.Kubectl = expandUserPath(cfg.Kubectl)
+	}
+	if applied.Virtctl {
+		cfg.Virtctl = expandUserPath(cfg.Virtctl)
+	}
+	if applied.Kubeconfig {
+		cfg.Kubeconfig = expandUserPath(cfg.Kubeconfig)
+	}
+	if applied.Template {
+		cfg.Template = expandUserPath(cfg.Template)
+	}
+	if applied.SSHKey {
+		cfg.SSHKey = expandUserPath(cfg.SSHKey)
+	}
+	if applied.SSHPublicKey {
+		cfg.SSHPublicKey = expandUserPath(cfg.SSHPublicKey)
+	}
+}
+
 // applyKubeVirtFileConfig is the sole file-policy entry to the generated overlay.
 // Filter a snapshot so ignored input remains intact for configuration persistence.
 func applyKubeVirtFileConfig(cfg *Config, file *fileKubeVirtConfig, trusted bool) error {
@@ -31,24 +53,7 @@ func applyKubeVirtFileConfig(cfg *Config, file *fileKubeVirtConfig, trusted bool
 		snapshot.SSHPublicKey = ""
 	}
 	applied, err := cfg.KubeVirt.applyFile(&snapshot, trusted)
-	if applied.Kubectl {
-		cfg.KubeVirt.Kubectl = expandUserPath(cfg.KubeVirt.Kubectl)
-	}
-	if applied.Virtctl {
-		cfg.KubeVirt.Virtctl = expandUserPath(cfg.KubeVirt.Virtctl)
-	}
-	if applied.Kubeconfig {
-		cfg.KubeVirt.Kubeconfig = expandUserPath(cfg.KubeVirt.Kubeconfig)
-	}
-	if applied.Template {
-		cfg.KubeVirt.Template = expandUserPath(cfg.KubeVirt.Template)
-	}
-	if applied.SSHKey {
-		cfg.KubeVirt.SSHKey = expandUserPath(cfg.KubeVirt.SSHKey)
-	}
-	if applied.SSHPublicKey {
-		cfg.KubeVirt.SSHPublicKey = expandUserPath(cfg.KubeVirt.SSHPublicKey)
-	}
+	cfg.KubeVirt.ExpandAppliedLocalPaths(applied)
 	if applied.DeleteOnRelease {
 		MarkDeleteOnReleaseExplicit(cfg, "kubevirt")
 	}

--- a/internal/cli/config_sealos_devbox.go
+++ b/internal/cli/config_sealos_devbox.go
@@ -2,8 +2,8 @@ package cli
 
 //go:generate go run ../../scripts/configgen -source config_sealos_devbox.go -output config_sealos_devbox_generated.go -type SealosDevboxConfig -provider sealos-devbox
 
-// SealosDevboxConfig owns source bindings; local-path expansion and native
-// validation remain with the configuration callers and provider.
+// SealosDevboxConfig owns source bindings and accepted local-path expansion.
+// Native validation remains with the provider.
 type SealosDevboxConfig struct {
 	Kubectl         string `config:"kubectl" env:"CRABBOX_SEALOS_DEVBOX_KUBECTL" flag:"sealos-devbox-kubectl" sources:"user,env,flag" help:"kubectl executable" default:"kubectl" fileIgnoreEmpty:"true" fileStorage:"value" reportApplied:"true"`
 	Kubeconfig      string `config:"kubeconfig" env:"CRABBOX_SEALOS_DEVBOX_KUBECONFIG" flag:"sealos-devbox-kubeconfig" sources:"user,env,flag" help:"Kubernetes kubeconfig path" fileIgnoreEmpty:"true" fileStorage:"value" reportApplied:"true"`
@@ -21,4 +21,14 @@ type SealosDevboxConfig struct {
 	WorkRoot        string `config:"workRoot" env:"CRABBOX_SEALOS_DEVBOX_WORK_ROOT" flag:"sealos-devbox-work-root" sources:"user,env,flag" help:"DevBox Crabbox work root" default:"/home/devbox/project" fileIgnoreEmpty:"true" fileStorage:"value" reportApplied:"true"`
 	NodeHost        string `config:"nodeHost" env:"CRABBOX_SEALOS_DEVBOX_NODE_HOST" flag:"sealos-devbox-node-host" sources:"user,env,flag" help:"Node host for NodePort mode" fileIgnoreEmpty:"true" fileStorage:"value"`
 	DeleteOnRelease bool   `config:"deleteOnRelease" env:"CRABBOX_SEALOS_DEVBOX_DELETE_ON_RELEASE" flag:"sealos-devbox-delete-on-release" sources:"user,repo,env,flag" help:"delete the DevBox on release instead of retaining it" reportApplied:"true"`
+}
+
+// ExpandAppliedLocalPaths expands local paths accepted by a file or flag overlay.
+func (cfg *SealosDevboxConfig) ExpandAppliedLocalPaths(applied SealosDevboxConfigApplied) {
+	if applied.Kubectl {
+		cfg.Kubectl = expandUserPath(cfg.Kubectl)
+	}
+	if applied.Kubeconfig {
+		cfg.Kubeconfig = expandUserPath(cfg.Kubeconfig)
+	}
 }

--- a/internal/providers/kubevirt/flags.go
+++ b/internal/providers/kubevirt/flags.go
@@ -15,24 +15,7 @@ func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error
 		return nil
 	}
 	applied := v.Apply(&cfg.KubeVirt, fs)
-	if applied.Kubectl {
-		cfg.KubeVirt.Kubectl = core.ExpandUserPath(cfg.KubeVirt.Kubectl)
-	}
-	if applied.Virtctl {
-		cfg.KubeVirt.Virtctl = core.ExpandUserPath(cfg.KubeVirt.Virtctl)
-	}
-	if applied.Kubeconfig {
-		cfg.KubeVirt.Kubeconfig = core.ExpandUserPath(cfg.KubeVirt.Kubeconfig)
-	}
-	if applied.Template {
-		cfg.KubeVirt.Template = core.ExpandUserPath(cfg.KubeVirt.Template)
-	}
-	if applied.SSHKey {
-		cfg.KubeVirt.SSHKey = core.ExpandUserPath(cfg.KubeVirt.SSHKey)
-	}
-	if applied.SSHPublicKey {
-		cfg.KubeVirt.SSHPublicKey = core.ExpandUserPath(cfg.KubeVirt.SSHPublicKey)
-	}
+	cfg.KubeVirt.ExpandAppliedLocalPaths(applied)
 	if applied.WorkRoot {
 		cfg.WorkRoot = cfg.KubeVirt.WorkRoot
 	}

--- a/internal/providers/sealosdevbox/flags.go
+++ b/internal/providers/sealosdevbox/flags.go
@@ -20,12 +20,7 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 		return nil
 	}
 	applied := v.Apply(&cfg.SealosDevbox, fs)
-	if applied.Kubectl {
-		cfg.SealosDevbox.Kubectl = core.ExpandUserPath(cfg.SealosDevbox.Kubectl)
-	}
-	if applied.Kubeconfig {
-		cfg.SealosDevbox.Kubeconfig = core.ExpandUserPath(cfg.SealosDevbox.Kubeconfig)
-	}
+	cfg.SealosDevbox.ExpandAppliedLocalPaths(applied)
 	if applied.WorkRoot {
 		cfg.WorkRoot = cfg.SealosDevbox.WorkRoot
 		core.MarkSealosDevboxWorkRootExplicit(cfg)


### PR DESCRIPTION
## Summary

Give KubeVirt and Sealos DevBox one typed owner each for their accepted local-path expansion. Their file and flag wrappers now pass the actual applied-field report to the same method, removing the duplicated field lists while preserving each expansion's order and count.

Environment processing deliberately remains separate: it expands final fallback values unconditionally, even when no environment value was applied. The methods do not touch guest work roots, release markers, source acceptance, validation or error handling. No generator tags, reflection, synthetic all-true reports or generic normalization framework were added.

This is an internal refactor with no user-visible behavior, configuration, credential or dependency change. The typed-provider guide documents the boundary.

## Verification

The original configuration tests passed before the extraction. On the verified combination with main `6f1ab9f277385a9600ac48529681ec323c558ab2`, 39 focused configuration tests (19 KubeVirt/Sealos, 12 Apple Container/Machine and eight Apple VM preservation tests), 34 generated-file freshness checks, six-package vet and CLI build passed. Source files, modes, index and frozen prior evidence stayed unchanged.

```sh
go test -race ./scripts/configgen -run GeneratedConfigIsCurrent$ -count=1 -timeout=3m -v
go vet ./internal/cli ./internal/providers/kubevirt ./internal/providers/sealosdevbox ./internal/providers/applecontainer ./internal/providers/applemachine ./internal/providers/applevm
```

The same 12 KubeVirt and 66 Sealos local CLI cases matched their original baselines and prior candidates exactly, including raw streams, exit/timeout outcomes and written bytes. No new cases, retries, mismatches or timeouts. Final binary SHA256: `4c872e360c72fa4160e202035404bf6eae66fee6037df28223b7a601219d4339`.

Independent source reconstruction binds the exact six-file edit to the reviewed versions and preserves all 39 selected test bodies and 34 generated files. Managed Codex review and documentation build passed. A final receipt comparison initially treated metadata values as test-name counts; the receipt-only correction and original failure are preserved. No test or source was changed or rerun for that correction.

CLI visibility is limited: provider-specific JSON blocks are absent, many Sealos cases preserve configuration diagnostics, and empty key/template/kubeconfig cases establish omission only. Those results are not full field-application or native lifecycle proof. Direct configuration tests cover the changed behavior; no VM, SSH, kubectl, virtctl or cloud operation was performed for this refactor.

## Observable file and flag path results

In response to the [review proof request](https://github.com/openclaw/crabbox/pull/2060#issuecomment-5610071741), a separate **source-aware** trace ran against this exact PR head, `24115cd067ac2585cf1d5ef8477d95e55e6a0382`. It used three temporary Go test overlays, leaving all tracked product files and committed tests unchanged. These are real production source-processing calls, not mocked return values or config-show output.

The trusted-file cases read actual synthetic YAML with `readFileConfig` and apply it through `applyFileConfigWithTrust`. The flag cases call the public providers' `RegisterFlags`, `FlagSet.Parse` and `ApplyFlags`. Inputs are the existing ordinary tilde-path fixtures. The logger reads the resulting configuration fields; expected paths are used only for assertions. Four tests in three packages passed and emitted these 16 actual local-path values. Guest work roots remained unchanged.

<details>
<summary>Actual output rows — synthetic HOME and paths only</summary>

```jsonl
{"HOME": "/tmp/crabbox-path-observation-agyx_1n8/home", "entrypoint": "readFileConfig+applyFileConfigWithTrust(true)", "local_fields": {"Kubeconfig": "/tmp/crabbox-path-observation-agyx_1n8/home/fixture", "Kubectl": "/tmp/crabbox-path-observation-agyx_1n8/home/tool", "SSHKey": "/tmp/crabbox-path-observation-agyx_1n8/home/fixture", "SSHPublicKey": "/tmp/crabbox-path-observation-agyx_1n8/home/fixture", "Template": "/tmp/crabbox-path-observation-agyx_1n8/home/fixture", "Virtctl": "/tmp/crabbox-path-observation-agyx_1n8/home/tool"}, "observation": "kubevirt-file", "package": "github.com/openclaw/crabbox/internal/cli", "scope": "SOURCE-AWARE accepted-path observation", "selected_provider": "", "test": "TestPR2060SourceAwareKubeVirtFilePaths"}
{"HOME": "/tmp/crabbox-path-observation-agyx_1n8/home", "entrypoint": "readFileConfig+applyFileConfigWithTrust(true)", "local_fields": {"Kubeconfig": "/tmp/crabbox-path-observation-agyx_1n8/home/config", "Kubectl": "/tmp/crabbox-path-observation-agyx_1n8/home/bin/tool"}, "observation": "sealosdevbox-file", "package": "github.com/openclaw/crabbox/internal/cli", "scope": "SOURCE-AWARE accepted-path observation", "selected_provider": "", "test": "TestPR2060SourceAwareSealosDevboxFilePaths"}
{"HOME": "/tmp/crabbox-path-observation-agyx_1n8/home", "entrypoint": "Provider.RegisterFlags+FlagSet.Parse+Provider.ApplyFlags", "guest_work_root": "/workspace/~/guest", "local_fields": {"Kubeconfig": "/tmp/crabbox-path-observation-agyx_1n8/home/fixture", "Kubectl": "/tmp/crabbox-path-observation-agyx_1n8/home/tool", "SSHKey": "/tmp/crabbox-path-observation-agyx_1n8/home/fixture", "SSHPublicKey": "/tmp/crabbox-path-observation-agyx_1n8/home/fixture", "Template": "/tmp/crabbox-path-observation-agyx_1n8/home/fixture", "Virtctl": "/tmp/crabbox-path-observation-agyx_1n8/home/tool"}, "observation": "kubevirt-flags", "package": "github.com/openclaw/crabbox/internal/providers/kubevirt", "scope": "SOURCE-AWARE accepted-path observation", "selected_provider": "", "test": "TestPR2060SourceAwareKubeVirtFlagPaths"}
{"HOME": "/tmp/crabbox-path-observation-agyx_1n8/home", "entrypoint": "Provider.RegisterFlags+FlagSet.Parse+Provider.ApplyFlags", "guest_work_root": "/home/devbox/~/guest-project", "local_fields": {"Kubeconfig": "/tmp/crabbox-path-observation-agyx_1n8/home/.kube/sealos.yaml", "Kubectl": "/tmp/crabbox-path-observation-agyx_1n8/home/bin/kubectl"}, "observation": "sealosdevbox-flags", "package": "github.com/openclaw/crabbox/internal/providers/sealosdevbox", "scope": "SOURCE-AWARE accepted-path observation", "selected_provider": "", "test": "TestPR2060SourceAwareSealosDevboxFlagPaths"}
```

</details>

The temporary core-test fixture explicitly restores its runner-owned HOME after the repository's normal TestMain isolation. The first prepared bundle was corrected before any execution; the executed bundle ran once, with Go 1.26.5, an empty inherited environment and network denial. Raw output was captured by the parent and only validated actual rows were extracted. Tracked source contents/modes, index entries, overlay inputs and observations stayed bound to the reviewed head throughout. None of the configured kubectl/virtctl, kubeconfig, template or key paths was opened or executed; the file cases read their synthetic YAML fixtures.

This observes post-admission configuration processing, not trust classification or native lifecycle behavior. It is additional source-aware evidence, not a reinterpretation or rerun of the 78 limited-visibility CLI cases. The newer-main combination with the landed Apple VM refactor separately passed all 39 configuration tests, freshness/vet/build checks, the same 78 provider CLI comparisons and twelve Apple VM preservation cases. The six helper edits remain identical to this PR head; the additional Apple VM tests are preserved from main `6f1ab9f277385a9600ac48529681ec323c558ab2`.
