### PR TITLE
refactor(config): centralize Apple VM source state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Install checksum-pinned Node 24.19.0 for Intel and Apple Silicon managed macOS leases when Node/npm are missing, complete older coordinator bootstrap during warmup, and require both tools for readiness. [PR 2051](https://github.com/openclaw/crabbox/pull/2051). Thanks @steipete.
 - Close macOS command-wrapper pipe descriptors before user execution so detached daemons do not keep completed commands waiting. [PR 2051](https://github.com/openclaw/crabbox/pull/2051). Thanks @steipete.
 - Consolidate Sealos DevBox file, environment, and flag settings while preserving local versus guest path handling, explicit release choices, and saved-file omission. [PR 2056](https://github.com/openclaw/crabbox/pull/2056). Thanks @steipete.
+- Consolidate Apple VM settings and image/checksum updates while preserving legacy configuration names, explicit resource values, and ordered validation. Thanks @steipete.
 
 - Show the recorded provisioning cause when a coordinator lease fails with cleanup still pending, preserving the primary failure when present and omitting empty error details.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Install checksum-pinned Node 24.19.0 for Intel and Apple Silicon managed macOS leases when Node/npm are missing, complete older coordinator bootstrap during warmup, and require both tools for readiness. [PR 2051](https://github.com/openclaw/crabbox/pull/2051). Thanks @steipete.
 - Close macOS command-wrapper pipe descriptors before user execution so detached daemons do not keep completed commands waiting. [PR 2051](https://github.com/openclaw/crabbox/pull/2051). Thanks @steipete.
 - Consolidate Sealos DevBox file, environment, and flag settings while preserving local versus guest path handling, explicit release choices, and saved-file omission. [PR 2056](https://github.com/openclaw/crabbox/pull/2056). Thanks @steipete.
-- Consolidate Apple VM settings and image/checksum updates while preserving legacy configuration names, explicit resource values, and ordered validation. Thanks @steipete.
+- Consolidate Apple VM settings and image/checksum updates while preserving legacy configuration names, explicit resource values, and ordered validation. [PR 2061](https://github.com/openclaw/crabbox/pull/2061). Thanks @steipete.
 
 - Show the recorded provisioning cause when a coordinator lease fails with cleanup still pending, preserving the primary failure when present and omitting empty error details.
 

--- a/docs/providers/apple-vm.md
+++ b/docs/providers/apple-vm.md
@@ -186,6 +186,18 @@ CRABBOX_APPLE_VM_MEMORY
 CRABBOX_APPLE_VM_DISK
 ```
 
+When both file sections are present, `appleVM` wins as a whole, including an
+empty mapping; an omitted or null current section can fall back to `appleVZ`.
+Current environment names win when nonempty, otherwise their legacy names are
+used. A visited current flag wins over its legacy spelling regardless of argument
+order; an invalid current value is not replaced by a valid legacy value.
+
+Explicit numeric zero is not the same as an omitted setting: files retain it,
+and validation rejects it rather than silently replacing it with a default.
+File and environment strings retain their text; provider flags trim surrounding
+whitespace. Accepted image overrides clear the earlier image checksum, then an
+accompanying checksum sets the new pair.
+
 ## Images and integrity
 
 The portable `osImage` selector maps to dated Ubuntu ARM64 cloud images:

--- a/docs/refactor/typed-provider-config.md
+++ b/docs/refactor/typed-provider-config.md
@@ -174,6 +174,27 @@ ignore zero. Modal's `secrets: []` deliberately remains pointer-backed so a writ
 retains the explicit clear. Positive-only numeric overlays still store negative
 inputs verbatim: ignoring an assignment is not permission to erase its file value.
 
+## Apple VM's concrete source owner
+
+`config_apple_vm.go` owns all eight settings, initialization, and complete file
+and environment application without generated bindings. Runtime and file types
+remain distinct: three pointer-backed file integers preserve explicit zero and
+null/omitted values, so deriving the file type from runtime values would lose a
+real storage contract. Initialization accepts the already-selected image and
+checksum pair without repeating OS-image selection or setting explicit markers.
+
+Shared accepted-image and checksum operations own the associated value and
+marker changes together. File and environment callers retain their raw-input
+acceptance; flags call those operations only after their existing trimming and
+validation. Source selection, legacy precedence, signed numeric parsing, exact
+errors and earlier mutations on failure remain explicit and ordered.
+
+The provider retains its sixteen current/deprecated flag spellings, current-name
+visit precedence, image-identity display, early validation and selected-provider
+defaults call. Native behavior and default-image selection are not source-input
+events and do not use the explicit-image transition. No generic alias, callback
+or staged-validation framework is added to the generator.
+
 ## Lambda's concrete owner
 
 Lambda uses `config_lambda.go` without generated bindings. Its structured mount

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -905,17 +905,6 @@ type LocalContainerConfig struct {
 	CheckpointMetadata map[string]string `yaml:"-" json:"-"`
 }
 
-type AppleVMConfig struct {
-	HelperPath  string
-	Image       string
-	ImageSHA256 string
-	User        string
-	WorkRoot    string
-	CPUs        int
-	MemoryMiB   int
-	DiskGiB     int
-}
-
 type MXCConfig struct {
 	CLIPath           string
 	Version           string
@@ -2598,15 +2587,7 @@ func baseConfig() Config {
 			Network: "bridge",
 		},
 		AppleContainer: initialAppleContainerConfig(containerImage),
-		AppleVM: AppleVMConfig{
-			Image:       osImageSpecs[osImage].AppleVMImage,
-			ImageSHA256: osImageSpecs[osImage].AppleVMSHA256,
-			User:        "crabbox",
-			WorkRoot:    "/work/crabbox",
-			CPUs:        4,
-			MemoryMiB:   8192,
-			DiskGiB:     30,
-		},
+		AppleVM:        initialAppleVMConfig(osImageSpecs[osImage].AppleVMImage, osImageSpecs[osImage].AppleVMSHA256),
 		MXC: MXCConfig{
 			CLIPath:     "wxc-exec.exe",
 			Version:     "0.6.0-alpha",
@@ -3495,17 +3476,6 @@ type fileLocalContainerConfig struct {
 	Network      string `yaml:"network,omitempty"`
 	DockerSocket *bool  `yaml:"dockerSocket,omitempty"`
 	NoHostname   *bool  `yaml:"noHostname,omitempty"`
-}
-
-type fileAppleVMConfig struct {
-	HelperPath  string `yaml:"helperPath,omitempty"`
-	Image       string `yaml:"image,omitempty"`
-	ImageSHA256 string `yaml:"imageSHA256,omitempty"`
-	User        string `yaml:"user,omitempty"`
-	WorkRoot    string `yaml:"workRoot,omitempty"`
-	CPUs        *int   `yaml:"cpus,omitempty"`
-	MemoryMiB   *int   `yaml:"memoryMiB,omitempty"`
-	DiskGiB     *int   `yaml:"diskGiB,omitempty"`
 }
 
 type fileMXCConfig struct {
@@ -5732,39 +5702,7 @@ func applyFileConfigWithTrustAndProviderSource(cfg *Config, file fileConfig, tru
 		// Deprecated pre-rename key; appleVM wins when both are present.
 		file.AppleVM = file.AppleVZLegacy
 	}
-	if file.AppleVM != nil {
-		if file.AppleVM.HelperPath != "" {
-			cfg.AppleVM.HelperPath = file.AppleVM.HelperPath
-		}
-		if file.AppleVM.Image != "" {
-			cfg.AppleVM.Image = file.AppleVM.Image
-			cfg.AppleVM.ImageSHA256 = ""
-			cfg.appleVMImageExplicit = true
-			cfg.appleVMImageSHA256Explicit = false
-		}
-		if file.AppleVM.ImageSHA256 != "" {
-			cfg.AppleVM.ImageSHA256 = file.AppleVM.ImageSHA256
-			cfg.appleVMImageSHA256Explicit = true
-		}
-		if file.AppleVM.User != "" {
-			cfg.AppleVM.User = file.AppleVM.User
-		}
-		if file.AppleVM.WorkRoot != "" {
-			cfg.AppleVM.WorkRoot = file.AppleVM.WorkRoot
-		}
-		if file.AppleVM.CPUs != nil {
-			cfg.AppleVM.CPUs = *file.AppleVM.CPUs
-			cfg.appleVMCPUsExplicit = true
-		}
-		if file.AppleVM.MemoryMiB != nil {
-			cfg.AppleVM.MemoryMiB = *file.AppleVM.MemoryMiB
-			cfg.appleVMMemoryExplicit = true
-		}
-		if file.AppleVM.DiskGiB != nil {
-			cfg.AppleVM.DiskGiB = *file.AppleVM.DiskGiB
-			cfg.appleVMDiskExplicit = true
-		}
-	}
+	applyAppleVMFile(cfg, file.AppleVM)
 	if file.MXC != nil {
 		if file.MXC.CLIPath != "" {
 			cfg.MXC.CLIPath = file.MXC.CLIPath
@@ -6302,15 +6240,6 @@ func applyNonNegativeLeaseDuration(target *time.Duration, value string) bool {
 	}
 	*target = parsed
 	return true
-}
-
-// appleVMEnv reads a CRABBOX_APPLE_VM_* variable, falling back to the
-// deprecated CRABBOX_APPLE_VZ_* spelling from before the provider rename.
-func appleVMEnv(name string) string {
-	if value := os.Getenv("CRABBOX_APPLE_VM_" + name); value != "" {
-		return value
-	}
-	return os.Getenv("CRABBOX_APPLE_VZ_" + name)
 }
 
 func applyEnv(cfg *Config) error {
@@ -7478,42 +7407,8 @@ func applyEnv(cfg *Config) error {
 	if cfg.AppleContainer.applyEnv() {
 		MarkAppleContainerImageExplicit(cfg)
 	}
-	cfg.AppleVM.HelperPath = getenv("CRABBOX_APPLE_VM_HELPER", getenv("CRABBOX_APPLE_VZ_HELPER", cfg.AppleVM.HelperPath))
-	if image := appleVMEnv("IMAGE"); image != "" {
-		cfg.AppleVM.Image = image
-		cfg.AppleVM.ImageSHA256 = ""
-		cfg.appleVMImageExplicit = true
-		cfg.appleVMImageSHA256Explicit = false
-	}
-	if checksum := appleVMEnv("IMAGE_SHA256"); checksum != "" {
-		cfg.AppleVM.ImageSHA256 = checksum
-		cfg.appleVMImageSHA256Explicit = true
-	}
-	cfg.AppleVM.User = getenv("CRABBOX_APPLE_VM_USER", getenv("CRABBOX_APPLE_VZ_USER", cfg.AppleVM.User))
-	cfg.AppleVM.WorkRoot = getenv("CRABBOX_APPLE_VM_WORK_ROOT", getenv("CRABBOX_APPLE_VZ_WORK_ROOT", cfg.AppleVM.WorkRoot))
-	if rawCPUs := appleVMEnv("CPUS"); rawCPUs != "" {
-		cpus, err := strconv.Atoi(strings.TrimSpace(rawCPUs))
-		if err != nil {
-			return fmt.Errorf("CRABBOX_APPLE_VM_CPUS must be an integer: %w", err)
-		}
-		cfg.AppleVM.CPUs = cpus
-		cfg.appleVMCPUsExplicit = true
-	}
-	if rawMemory := appleVMEnv("MEMORY"); rawMemory != "" {
-		memoryMiB, err := strconv.Atoi(strings.TrimSpace(rawMemory))
-		if err != nil {
-			return fmt.Errorf("CRABBOX_APPLE_VM_MEMORY must be an integer: %w", err)
-		}
-		cfg.AppleVM.MemoryMiB = memoryMiB
-		cfg.appleVMMemoryExplicit = true
-	}
-	if rawDisk := appleVMEnv("DISK"); rawDisk != "" {
-		diskGiB, err := strconv.Atoi(strings.TrimSpace(rawDisk))
-		if err != nil {
-			return fmt.Errorf("CRABBOX_APPLE_VM_DISK must be an integer: %w", err)
-		}
-		cfg.AppleVM.DiskGiB = diskGiB
-		cfg.appleVMDiskExplicit = true
+	if err := applyAppleVMEnv(cfg); err != nil {
+		return err
 	}
 	cfg.MXC.CLIPath = getenv("CRABBOX_MXC_CLI", cfg.MXC.CLIPath)
 	cfg.MXC.Version = getenv("CRABBOX_MXC_VERSION", cfg.MXC.Version)

--- a/internal/cli/config_apple_vm.go
+++ b/internal/cli/config_apple_vm.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type AppleVMConfig struct {
+	HelperPath  string
+	Image       string
+	ImageSHA256 string
+	User        string
+	WorkRoot    string
+	CPUs        int
+	MemoryMiB   int
+	DiskGiB     int
+}
+
+type fileAppleVMConfig struct {
+	HelperPath  string `yaml:"helperPath,omitempty"`
+	Image       string `yaml:"image,omitempty"`
+	ImageSHA256 string `yaml:"imageSHA256,omitempty"`
+	User        string `yaml:"user,omitempty"`
+	WorkRoot    string `yaml:"workRoot,omitempty"`
+	CPUs        *int   `yaml:"cpus,omitempty"`
+	MemoryMiB   *int   `yaml:"memoryMiB,omitempty"`
+	DiskGiB     *int   `yaml:"diskGiB,omitempty"`
+}
+
+func initialAppleVMConfig(image, checksum string) AppleVMConfig {
+	return AppleVMConfig{
+		Image:       image,
+		ImageSHA256: checksum,
+		User:        "crabbox",
+		WorkRoot:    "/work/crabbox",
+		CPUs:        4,
+		MemoryMiB:   8192,
+		DiskGiB:     30,
+	}
+}
+
+// ApplyAppleVMImage records an already-accepted image and clears the prior checksum.
+func ApplyAppleVMImage(cfg *Config, image string) {
+	cfg.AppleVM.Image = image
+	cfg.AppleVM.ImageSHA256 = ""
+	MarkAppleVMImageExplicit(cfg)
+}
+
+// ApplyAppleVMImageSHA256 records an already-accepted checksum.
+func ApplyAppleVMImageSHA256(cfg *Config, checksum string) {
+	cfg.AppleVM.ImageSHA256 = checksum
+	MarkAppleVMImageSHA256Explicit(cfg)
+}
+
+func applyAppleVMFile(cfg *Config, file *fileAppleVMConfig) {
+	if file == nil {
+		return
+	}
+	if file.HelperPath != "" {
+		cfg.AppleVM.HelperPath = file.HelperPath
+	}
+	if file.Image != "" {
+		ApplyAppleVMImage(cfg, file.Image)
+	}
+	if file.ImageSHA256 != "" {
+		ApplyAppleVMImageSHA256(cfg, file.ImageSHA256)
+	}
+	if file.User != "" {
+		cfg.AppleVM.User = file.User
+	}
+	if file.WorkRoot != "" {
+		cfg.AppleVM.WorkRoot = file.WorkRoot
+	}
+	if file.CPUs != nil {
+		cfg.AppleVM.CPUs = *file.CPUs
+		MarkAppleVMCPUsExplicit(cfg)
+	}
+	if file.MemoryMiB != nil {
+		cfg.AppleVM.MemoryMiB = *file.MemoryMiB
+		MarkAppleVMMemoryExplicit(cfg)
+	}
+	if file.DiskGiB != nil {
+		cfg.AppleVM.DiskGiB = *file.DiskGiB
+		MarkAppleVMDiskExplicit(cfg)
+	}
+}
+
+// appleVMEnv reads a CRABBOX_APPLE_VM_* variable, falling back to the
+// deprecated CRABBOX_APPLE_VZ_* spelling from before the provider rename.
+func appleVMEnv(name string) string {
+	if value := os.Getenv("CRABBOX_APPLE_VM_" + name); value != "" {
+		return value
+	}
+	return os.Getenv("CRABBOX_APPLE_VZ_" + name)
+}
+
+func applyAppleVMEnv(cfg *Config) error {
+	cfg.AppleVM.HelperPath = getenv("CRABBOX_APPLE_VM_HELPER", getenv("CRABBOX_APPLE_VZ_HELPER", cfg.AppleVM.HelperPath))
+	if image := appleVMEnv("IMAGE"); image != "" {
+		ApplyAppleVMImage(cfg, image)
+	}
+	if checksum := appleVMEnv("IMAGE_SHA256"); checksum != "" {
+		ApplyAppleVMImageSHA256(cfg, checksum)
+	}
+	cfg.AppleVM.User = getenv("CRABBOX_APPLE_VM_USER", getenv("CRABBOX_APPLE_VZ_USER", cfg.AppleVM.User))
+	cfg.AppleVM.WorkRoot = getenv("CRABBOX_APPLE_VM_WORK_ROOT", getenv("CRABBOX_APPLE_VZ_WORK_ROOT", cfg.AppleVM.WorkRoot))
+	if rawCPUs := appleVMEnv("CPUS"); rawCPUs != "" {
+		cpus, err := strconv.Atoi(strings.TrimSpace(rawCPUs))
+		if err != nil {
+			return fmt.Errorf("CRABBOX_APPLE_VM_CPUS must be an integer: %w", err)
+		}
+		cfg.AppleVM.CPUs = cpus
+		MarkAppleVMCPUsExplicit(cfg)
+	}
+	if rawMemory := appleVMEnv("MEMORY"); rawMemory != "" {
+		memoryMiB, err := strconv.Atoi(strings.TrimSpace(rawMemory))
+		if err != nil {
+			return fmt.Errorf("CRABBOX_APPLE_VM_MEMORY must be an integer: %w", err)
+		}
+		cfg.AppleVM.MemoryMiB = memoryMiB
+		MarkAppleVMMemoryExplicit(cfg)
+	}
+	if rawDisk := appleVMEnv("DISK"); rawDisk != "" {
+		diskGiB, err := strconv.Atoi(strings.TrimSpace(rawDisk))
+		if err != nil {
+			return fmt.Errorf("CRABBOX_APPLE_VM_DISK must be an integer: %w", err)
+		}
+		cfg.AppleVM.DiskGiB = diskGiB
+		MarkAppleVMDiskExplicit(cfg)
+	}
+	return nil
+}

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -446,6 +446,79 @@ func TestConfigShowIncludesFirecrackerConfig(t *testing.T) {
 	}
 }
 
+func TestAppleVMOrdinaryFileRoundTrip(t *testing.T) {
+	full := "  helperPath: ' ~/helper '\n  image: ' ~/image '\n  imageSHA256: ' checksum '\n  user: ' user '\n  workRoot: ' ~/work '\n  cpus: 0\n  memoryMiB: -2\n  diskGiB: 0\n"
+	zeros := "  cpus: 0\n  memoryMiB: 0\n  diskGiB: 0\n"
+	for _, tc := range []struct {
+		name, document, serialized string
+	}{
+		{"current-all-fields", "appleVM:\n" + full, "appleVM:\n" + full},
+		{"legacy-retained", "appleVZ:\n" + full, "appleVZ:\n" + full},
+		{"both-retained", "appleVM:\n" + full + "appleVZ:\n" + zeros, "appleVM:\n" + full + "appleVZ:\n" + zeros},
+		{"empty-current-retained", "appleVM: {}\nappleVZ:\n" + full, "appleVM: {}\nappleVZ:\n" + full},
+		{"null-current-omitted", "appleVM: null\nappleVZ:\n" + full, "appleVZ:\n" + full},
+		{"value-strings-omitted-zero-pointers-retained", "appleVM:\n  helperPath: ''\n  image: ''\n  imageSHA256: ''\n  user: ''\n  workRoot: ''\n" + zeros, "appleVM:\n" + zeros},
+		{"null-numeric-pointers-omitted", "appleVM:\n  cpus: null\n  memoryMiB: null\n  diskGiB: null\n", "appleVM: {}\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := isolatedConfigPath(t)
+			if err := os.WriteFile(path, []byte(tc.document), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			file, err := readFileConfig(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var original fileConfig
+			if err := yaml.Unmarshal([]byte(tc.document), &original); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(file, original) {
+				t.Fatalf("read file=%+v, want %+v", file, original)
+			}
+			// Runtime alias selection must not normalize the persistent document.
+			cfg := Config{}
+			if err := applyFileConfig(&cfg, file); err != nil {
+				t.Fatal(err)
+			}
+			writtenPath, err := writeUserFileConfig(file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if writtenPath != path {
+				t.Fatalf("writer path=%q, want %q", writtenPath, path)
+			}
+			if !reflect.DeepEqual(file, original) {
+				t.Fatal("apply/write mutated the input file config")
+			}
+			reread, err := readFileConfig(writtenPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(reread, original) {
+				t.Fatalf("round-trip file=%+v, want %+v", reread, original)
+			}
+			data, err := os.ReadFile(writtenPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var gotMap, wantMap map[string]any
+			if err := yaml.Unmarshal(data, &gotMap); err != nil {
+				t.Fatal(err)
+			}
+			if err := yaml.Unmarshal([]byte(tc.serialized), &wantMap); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(gotMap, wantMap) {
+				t.Fatalf("serialized config=%s, want semantic YAML %s", data, tc.serialized)
+			}
+			if strings.Contains(tc.serialized, "appleVM:") && strings.Contains(tc.serialized, "appleVZ:") && strings.Index(string(data), "appleVM:") > strings.Index(string(data), "appleVZ:") {
+				t.Fatal("current section should precede legacy section")
+			}
+		})
+	}
+}
+
 func TestSealosConfigWriter(t *testing.T) {
 	for _, value := range []string{"null", "{}", "{kubectl: '', kubeconfig: '', context: '', namespace: '', image: '', templateID: '', cpu: '', memory: '', storageLimit: '', network: '', sshGatewayHost: '', sshGatewayPort: '', sshUser: '', workRoot: '', nodeHost: '', deleteOnRelease: false}"} {
 		path := isolatedConfigPath(t)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -419,6 +420,14 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_APPLE_VM_CPUS",
 		"CRABBOX_APPLE_VM_MEMORY",
 		"CRABBOX_APPLE_VM_DISK",
+		"CRABBOX_APPLE_VZ_HELPER",
+		"CRABBOX_APPLE_VZ_IMAGE",
+		"CRABBOX_APPLE_VZ_IMAGE_SHA256",
+		"CRABBOX_APPLE_VZ_USER",
+		"CRABBOX_APPLE_VZ_WORK_ROOT",
+		"CRABBOX_APPLE_VZ_CPUS",
+		"CRABBOX_APPLE_VZ_MEMORY",
+		"CRABBOX_APPLE_VZ_DISK",
 		"CRABBOX_MULTIPASS_CLI",
 		"CRABBOX_MULTIPASS_IMAGE",
 		"CRABBOX_MULTIPASS_USER",
@@ -4394,6 +4403,276 @@ func TestAppleContainerConfigDefaultsFileAndEnv(t *testing.T) {
 	applyEnv(&cfg)
 	if cfg.AppleContainer.CLIPath != "/usr/local/bin/container" || cfg.AppleContainer.Image != "example-org/other:live" || cfg.AppleContainer.User != "env-user" || cfg.AppleContainer.WorkRoot != "/work/env" || cfg.AppleContainer.CPUs != 6 || cfg.AppleContainer.Memory != "12g" || len(cfg.AppleContainer.ExtraRunArgs) != 2 {
 		t.Fatalf("env appleContainer config not applied: %#v", cfg.AppleContainer)
+	}
+}
+
+func TestAppleVMOrdinaryFileSections(t *testing.T) {
+	t.Run("initializer", func(t *testing.T) {
+		cfg := baseConfig()
+		image, err := osImageDefaultAppleVMImage(cfg.OSImage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		checksum, err := osImageDefaultAppleVMSHA256(cfg.OSImage)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := AppleVMConfig{Image: image, ImageSHA256: checksum, User: "crabbox", WorkRoot: "/work/crabbox", CPUs: 4, MemoryMiB: 8192, DiskGiB: 30}
+		if cfg.AppleVM != want {
+			t.Fatalf("initial AppleVM=%+v, want %+v", cfg.AppleVM, want)
+		}
+		if AppleVMImageExplicit(cfg) || cfg.appleVMImageSHA256Explicit || AppleVMCPUsExplicit(cfg) || AppleVMMemoryExplicit(cfg) || AppleVMDiskExplicit(cfg) {
+			t.Fatal("initializer marked source values explicit")
+		}
+	})
+	initial := AppleVMConfig{HelperPath: "before-helper", Image: "before-image", ImageSHA256: "before-checksum", User: "before-user", WorkRoot: "/before", CPUs: 4, MemoryMiB: 8192, DiskGiB: 30}
+	current := AppleVMConfig{HelperPath: " ~/current/helper ", Image: " ~/current/image ", ImageSHA256: " current-checksum ", User: " current-user ", WorkRoot: " ~/current/work ", CPUs: 0, MemoryMiB: -2, DiskGiB: -3}
+	legacy := AppleVMConfig{HelperPath: " ~/legacy/helper ", Image: " ~/legacy/image ", ImageSHA256: " legacy-checksum ", User: " legacy-user ", WorkRoot: " ~/legacy/work ", CPUs: -1, MemoryMiB: 0, DiskGiB: 0}
+	currentYAML := "appleVM:\n  helperPath: ' ~/current/helper '\n  image: ' ~/current/image '\n  imageSHA256: ' current-checksum '\n  user: ' current-user '\n  workRoot: ' ~/current/work '\n  cpus: 0\n  memoryMiB: -2\n  diskGiB: -3\n"
+	legacyYAML := "appleVZ:\n  helperPath: ' ~/legacy/helper '\n  image: ' ~/legacy/image '\n  imageSHA256: ' legacy-checksum '\n  user: ' legacy-user '\n  workRoot: ' ~/legacy/work '\n  cpus: -1\n  memoryMiB: 0\n  diskGiB: 0\n"
+	for _, tc := range []struct {
+		name, document string
+		want           AppleVMConfig
+		marked         bool
+	}{
+		{"current", currentYAML, current, true},
+		{"legacy", legacyYAML, legacy, true},
+		{"current-whole-section-wins", currentYAML + legacyYAML, current, true},
+		{"current-whole-section-wins-reversed", legacyYAML + currentYAML, current, true},
+		{"empty-current-wins", "appleVM: {}\n" + legacyYAML, initial, false},
+		{"null-current-falls-back", "appleVM: null\n" + legacyYAML, legacy, true},
+		{"both-null", "appleVM: null\nappleVZ: null\n", initial, false},
+		{"equal-values-still-explicit", "appleVM:\n  helperPath: before-helper\n  image: before-image\n  imageSHA256: before-checksum\n  user: before-user\n  workRoot: /before\n  cpus: 4\n  memoryMiB: 8192\n  diskGiB: 30\n", initial, true},
+		{"empty-values-and-null-numbers", "appleVM:\n  helperPath: ''\n  image: ''\n  imageSHA256: ''\n  user: ''\n  workRoot: ''\n  cpus: null\n  memoryMiB: null\n  diskGiB: null\n" + legacyYAML, initial, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var file, original fileConfig
+			if err := yaml.Unmarshal([]byte(tc.document), &file); err != nil {
+				t.Fatal(err)
+			}
+			if err := yaml.Unmarshal([]byte(tc.document), &original); err != nil {
+				t.Fatal(err)
+			}
+			for _, alreadyMarked := range []bool{false, true} {
+				cfg := Config{AppleVM: initial, SSHUser: "generic-user", WorkRoot: "/generic"}
+				if alreadyMarked {
+					MarkAppleVMImageExplicit(&cfg)
+					MarkAppleVMImageSHA256Explicit(&cfg)
+					MarkAppleVMCPUsExplicit(&cfg)
+					MarkAppleVMMemoryExplicit(&cfg)
+					MarkAppleVMDiskExplicit(&cfg)
+				}
+				if err := applyFileConfig(&cfg, file); err != nil {
+					t.Fatal(err)
+				}
+				if cfg.AppleVM != tc.want {
+					t.Fatalf("AppleVM=%+v, want %+v", cfg.AppleVM, tc.want)
+				}
+				wantMarker := alreadyMarked || tc.marked
+				if got := [5]bool{AppleVMImageExplicit(cfg), cfg.appleVMImageSHA256Explicit, AppleVMCPUsExplicit(cfg), AppleVMMemoryExplicit(cfg), AppleVMDiskExplicit(cfg)}; got != [5]bool{wantMarker, wantMarker, wantMarker, wantMarker, wantMarker} {
+					t.Fatalf("markers=%v, want all %v", got, wantMarker)
+				}
+				if cfg.SSHUser != "generic-user" || cfg.WorkRoot != "/generic" || IsWorkRootExplicit(&cfg) {
+					t.Fatal("file overlay changed generic user/root state")
+				}
+				if !reflect.DeepEqual(file, original) {
+					t.Fatal("file input was mutated")
+				}
+			}
+		})
+	}
+	t.Run("sparse-current-does-not-merge-legacy", func(t *testing.T) {
+		var file fileConfig
+		if err := yaml.Unmarshal([]byte("appleVM:\n  user: current-user\n"+legacyYAML), &file); err != nil {
+			t.Fatal(err)
+		}
+		cfg := Config{AppleVM: initial}
+		if err := applyFileConfig(&cfg, file); err != nil {
+			t.Fatal(err)
+		}
+		want := initial
+		want.User = "current-user"
+		if cfg.AppleVM != want || AppleVMImageExplicit(cfg) || cfg.appleVMImageSHA256Explicit || AppleVMCPUsExplicit(cfg) || AppleVMMemoryExplicit(cfg) || AppleVMDiskExplicit(cfg) {
+			t.Fatalf("sparse current merged legacy values or markers: %+v", cfg.AppleVM)
+		}
+	})
+	// Successive source events must clear an earlier explicit checksum, even
+	// when the image value itself is unchanged.
+	for _, section := range []string{"appleVM", "appleVZ"} {
+		t.Run(section+"-image-sequence", func(t *testing.T) {
+			cfg := Config{AppleVM: initial}
+			for _, step := range []struct {
+				body, image, checksum       string
+				imageMarked, checksumMarked bool
+			}{
+				{"imageSHA256: before-checksum", initial.Image, initial.ImageSHA256, false, true},
+				{"image: before-image", initial.Image, "", true, false},
+				{"imageSHA256: next-checksum", initial.Image, "next-checksum", true, true},
+				{"image: next-image\n  imageSHA256: paired-checksum", "next-image", "paired-checksum", true, true},
+				{"image: ''\n  imageSHA256: ''", "next-image", "paired-checksum", true, true},
+			} {
+				var file fileConfig
+				if err := yaml.Unmarshal([]byte(section+":\n  "+step.body+"\n"), &file); err != nil {
+					t.Fatal(err)
+				}
+				if err := applyFileConfig(&cfg, file); err != nil {
+					t.Fatal(err)
+				}
+				if cfg.AppleVM.Image != step.image || cfg.AppleVM.ImageSHA256 != step.checksum || AppleVMImageExplicit(cfg) != step.imageMarked || cfg.appleVMImageSHA256Explicit != step.checksumMarked {
+					t.Fatalf("step %q: image/checksum=%q/%q markers=%v/%v", step.body, cfg.AppleVM.Image, cfg.AppleVM.ImageSHA256, AppleVMImageExplicit(cfg), cfg.appleVMImageSHA256Explicit)
+				}
+			}
+		})
+	}
+}
+
+func TestAppleVMOrdinaryEnvironmentAliases(t *testing.T) {
+	suffixes := []string{"HELPER", "IMAGE", "IMAGE_SHA256", "USER", "WORK_ROOT", "CPUS", "MEMORY", "DISK"}
+	initial := AppleVMConfig{HelperPath: "before-helper", Image: "before-image", ImageSHA256: "before-checksum", User: "before-user", WorkRoot: "/before", CPUs: 4, MemoryMiB: 8192, DiskGiB: 30}
+	current := []string{" ~/current/helper ", " ~/current/image ", " current-checksum ", " current-user ", " ~/current/work ", " +6 ", " -2 ", " 0 "}
+	legacy := []string{" ~/legacy/helper ", " ~/legacy/image ", " legacy-checksum ", " legacy-user ", " ~/legacy/work ", " -3 ", " 0 ", " +9 "}
+	equal := []string{initial.HelperPath, initial.Image, initial.ImageSHA256, initial.User, initial.WorkRoot, "4", "8192", "30"}
+	empty := make([]string, len(suffixes))
+	for _, tc := range []struct {
+		name            string
+		current, legacy []string
+		want            AppleVMConfig
+		marked          bool
+	}{
+		{"current-only", current, empty, AppleVMConfig{current[0], current[1], current[2], current[3], current[4], 6, -2, 0}, true},
+		{"legacy-only-empty-current", empty, legacy, AppleVMConfig{legacy[0], legacy[1], legacy[2], legacy[3], legacy[4], -3, 0, 9}, true},
+		{"current-outranks-legacy", current, legacy, AppleVMConfig{current[0], current[1], current[2], current[3], current[4], 6, -2, 0}, true},
+		{"equal-current-still-explicit", equal, legacy, initial, true},
+		{"equal-legacy-still-explicit", empty, equal, initial, true},
+		{"signed-numerics-all-fields", []string{equal[0], equal[1], equal[2], equal[3], equal[4], " -4 ", " +8192 ", " -30 "}, legacy, AppleVMConfig{initial.HelperPath, initial.Image, initial.ImageSHA256, initial.User, initial.WorkRoot, -4, 8192, -30}, true},
+		{"empty-preserves", empty, empty, initial, false},
+		{"whitespace-strings-win", []string{" ", " ", " ", " ", " ", "4", "8192", "30"}, legacy, AppleVMConfig{" ", " ", " ", " ", " ", 4, 8192, 30}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			for i, suffix := range suffixes {
+				t.Setenv("CRABBOX_APPLE_VM_"+suffix, tc.current[i])
+				t.Setenv("CRABBOX_APPLE_VZ_"+suffix, tc.legacy[i])
+			}
+			cfg := Config{AppleVM: initial, SSHUser: "generic-user", WorkRoot: "/generic"}
+			if err := applyEnv(&cfg); err != nil {
+				t.Fatal(err)
+			}
+			if cfg.AppleVM != tc.want {
+				t.Fatalf("AppleVM=%+v, want %+v", cfg.AppleVM, tc.want)
+			}
+			if got := [5]bool{AppleVMImageExplicit(cfg), cfg.appleVMImageSHA256Explicit, AppleVMCPUsExplicit(cfg), AppleVMMemoryExplicit(cfg), AppleVMDiskExplicit(cfg)}; got != [5]bool{tc.marked, tc.marked, tc.marked, tc.marked, tc.marked} {
+				t.Fatalf("markers=%v, want all %v", got, tc.marked)
+			}
+			if cfg.SSHUser != "generic-user" || cfg.WorkRoot != "/generic" || IsWorkRootExplicit(&cfg) {
+				t.Fatal("environment changed generic user/root state")
+			}
+			for i, suffix := range suffixes {
+				if os.Getenv("CRABBOX_APPLE_VM_"+suffix) != tc.current[i] || os.Getenv("CRABBOX_APPLE_VZ_"+suffix) != tc.legacy[i] {
+					t.Fatalf("environment input %s mutated", suffix)
+				}
+			}
+			for _, suffix := range suffixes {
+				t.Setenv("CRABBOX_APPLE_VM_"+suffix, "")
+				t.Setenv("CRABBOX_APPLE_VZ_"+suffix, "")
+			}
+			if err := applyEnv(&cfg); err != nil {
+				t.Fatal(err)
+			}
+			if cfg.AppleVM != tc.want || [5]bool{AppleVMImageExplicit(cfg), cfg.appleVMImageSHA256Explicit, AppleVMCPUsExplicit(cfg), AppleVMMemoryExplicit(cfg), AppleVMDiskExplicit(cfg)} != [5]bool{tc.marked, tc.marked, tc.marked, tc.marked, tc.marked} {
+				t.Fatal("empty environment changed existing values or markers")
+			}
+		})
+	}
+	for _, prefix := range []string{"CRABBOX_APPLE_VM_", "CRABBOX_APPLE_VZ_"} {
+		t.Run(prefix+"image-sequence", func(t *testing.T) {
+			clearConfigEnv(t)
+			cfg := Config{AppleVM: initial}
+			for _, step := range []struct {
+				image, checksum, wantImage, wantChecksum string
+				imageMarked, checksumMarked              bool
+			}{
+				{"", initial.ImageSHA256, initial.Image, initial.ImageSHA256, false, true},
+				{initial.Image, "", initial.Image, "", true, false},
+				{"", " next-checksum ", initial.Image, " next-checksum ", true, true},
+				{" next-image ", " paired-checksum ", " next-image ", " paired-checksum ", true, true},
+				{"", "", " next-image ", " paired-checksum ", true, true},
+			} {
+				t.Setenv(prefix+"IMAGE", step.image)
+				t.Setenv(prefix+"IMAGE_SHA256", step.checksum)
+				if err := applyEnv(&cfg); err != nil {
+					t.Fatal(err)
+				}
+				if cfg.AppleVM.Image != step.wantImage || cfg.AppleVM.ImageSHA256 != step.wantChecksum || AppleVMImageExplicit(cfg) != step.imageMarked || cfg.appleVMImageSHA256Explicit != step.checksumMarked {
+					t.Fatalf("step %+v: image/checksum=%q/%q markers=%v/%v", step, cfg.AppleVM.Image, cfg.AppleVM.ImageSHA256, AppleVMImageExplicit(cfg), cfg.appleVMImageSHA256Explicit)
+				}
+			}
+		})
+	}
+}
+
+func TestAppleVMOrdinaryEnvironmentNumericErrors(t *testing.T) {
+	for _, prefix := range []string{"CRABBOX_APPLE_VM_", "CRABBOX_APPLE_VZ_"} {
+		for failed, suffix := range []string{"CPUS", "MEMORY", "DISK"} {
+			for _, raw := range []string{"garbage", " \t ", "1.5", "1_024", "9999999999999999999999999999999999999999"} {
+				for _, alreadyMarked := range []bool{false, true} {
+					t.Run(fmt.Sprintf("%s%s/%q/marked=%v", prefix, suffix, raw, alreadyMarked), func(t *testing.T) {
+						clearConfigEnv(t)
+						cfg := Config{AppleVM: AppleVMConfig{Image: "before-image", ImageSHA256: "before-checksum", CPUs: 4, MemoryMiB: 8192, DiskGiB: 30}}
+						if alreadyMarked {
+							MarkAppleVMCPUsExplicit(&cfg)
+							MarkAppleVMMemoryExplicit(&cfg)
+							MarkAppleVMDiskExplicit(&cfg)
+						}
+						MarkAppleVMImageSHA256Explicit(&cfg)
+						for key, value := range map[string]string{"HELPER": " ~/helper ", "IMAGE": " ~/image ", "USER": " user ", "WORK_ROOT": " ~/work "} {
+							t.Setenv(prefix+key, value)
+						}
+						for i, numeric := range []string{"CPUS", "MEMORY", "DISK"} {
+							value := " +6 "
+							if i == failed {
+								value = raw
+							} else if i > failed {
+								value = "later-invalid"
+							}
+							t.Setenv(prefix+numeric, value)
+							if prefix == "CRABBOX_APPLE_VM_" {
+								t.Setenv("CRABBOX_APPLE_VZ_"+numeric, "10")
+							}
+						}
+						// A later ordinary provider assignment must not be reached.
+						cfg.MXC.CLIPath = "before-cli"
+						t.Setenv("CRABBOX_MXC_CLI", "after-cli")
+						err := applyEnv(&cfg)
+						_, parseErr := strconv.Atoi(strings.TrimSpace(raw))
+						wantError := fmt.Sprintf("CRABBOX_APPLE_VM_%s must be an integer: %v", suffix, parseErr)
+						if err == nil || err.Error() != wantError {
+							t.Fatalf("error=%v, want %s", err, wantError)
+						}
+						var numericErr *strconv.NumError
+						if !errors.As(err, &numericErr) || *numericErr != *parseErr.(*strconv.NumError) {
+							t.Fatalf("error did not retain trimmed numeric parse cause: %v", err)
+						}
+						want := AppleVMConfig{HelperPath: " ~/helper ", Image: " ~/image ", User: " user ", WorkRoot: " ~/work ", CPUs: 4, MemoryMiB: 8192, DiskGiB: 30}
+						if failed > 0 {
+							want.CPUs = 6
+						}
+						if failed > 1 {
+							want.MemoryMiB = 6
+						}
+						if cfg.AppleVM != want {
+							t.Fatalf("partial AppleVM=%+v, want %+v", cfg.AppleVM, want)
+						}
+						if got := [3]bool{AppleVMCPUsExplicit(cfg), AppleVMMemoryExplicit(cfg), AppleVMDiskExplicit(cfg)}; got != [3]bool{alreadyMarked || failed > 0, alreadyMarked || failed > 1, alreadyMarked} {
+							t.Fatalf("partial numeric markers=%v", got)
+						}
+						if !AppleVMImageExplicit(cfg) || cfg.appleVMImageSHA256Explicit || cfg.MXC.CLIPath != "before-cli" {
+							t.Fatal("wrong image markers or later provider mutation")
+						}
+					})
+				}
+			}
+		}
 	}
 }
 

--- a/internal/providers/applevm/flags.go
+++ b/internal/providers/applevm/flags.go
@@ -95,13 +95,10 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 		if applevmhelper.IsRemoteImageRef(image) {
 			return exit(2, "--apple-vm-image accepts local paths only; use CRABBOX_APPLE_VM_IMAGE or configuration for remote URLs")
 		}
-		cfg.AppleVM.Image = image
-		cfg.AppleVM.ImageSHA256 = ""
-		core.MarkAppleVMImageExplicit(cfg)
+		core.ApplyAppleVMImage(cfg, image)
 	}
 	if checksum, set := stringFlag(fs, "apple-vm-image-sha256", v.ImageSHA256, "apple-vz-image-sha256", v.LegacyImageSHA256); set {
-		cfg.AppleVM.ImageSHA256 = strings.TrimSpace(checksum)
-		core.MarkAppleVMImageSHA256Explicit(cfg)
+		core.ApplyAppleVMImageSHA256(cfg, strings.TrimSpace(checksum))
 	}
 	if user, set := stringFlag(fs, "apple-vm-user", v.User, "apple-vz-user", v.LegacyUser); set {
 		cfg.AppleVM.User = strings.TrimSpace(user)

--- a/internal/providers/applevm/provider_test.go
+++ b/internal/providers/applevm/provider_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -324,6 +325,242 @@ func TestApplyDefaultsHonorsGlobalWorkRoot(t *testing.T) {
 	applyDefaults(&cfg)
 	if cfg.WorkRoot != "/work/apple-vm" || cfg.AppleVM.WorkRoot != "/work/apple-vm" {
 		t.Fatalf("specific work root=%q apple-vm=%q want /work/apple-vm", cfg.WorkRoot, cfg.AppleVM.WorkRoot)
+	}
+}
+
+func TestAppleVMOrdinaryPublicFlags(t *testing.T) {
+	// Keep successful application outside the selected-provider defaults phase.
+	// The image path is the inert path already used by TestApplyFlags.
+	initial := core.Config{Provider: "ordinary-config-test-unselected", SSHUser: "generic-user", WorkRoot: "/generic", AppleVM: core.AppleVMConfig{HelperPath: "/before/helper", Image: "/tmp/custom.img", ImageSHA256: strings.Repeat("a", 64), User: "before-user", WorkRoot: "/before", CPUs: 4, MemoryMiB: 8192, DiskGiB: 30}}
+	suffixes := []string{"helper", "image", "image-sha256", "user", "work-root", "cpus", "memory", "disk"}
+	current := []string{" ~/helper ", " /tmp/custom.img ", " " + strings.Repeat("b", 64) + " ", " current-user ", " ~/work ", "6", "12288", "64"}
+	legacy := []string{" /legacy/helper ", "/tmp/custom.img", strings.Repeat("c", 64), " legacy-user ", " /legacy/work ", "8", "16384", "80"}
+	equal := []string{initial.AppleVM.HelperPath, initial.AppleVM.Image, initial.AppleVM.ImageSHA256, initial.AppleVM.User, initial.AppleVM.WorkRoot, "4", "8192", "30"}
+	emptyStrings := []string{"", "", "", "", "", "6", "12288", "64"}
+	legacyZeros := append([]string(nil), legacy...)
+	legacyZeros[5], legacyZeros[6], legacyZeros[7] = "0", "0", "0"
+	for _, tc := range []struct {
+		name            string
+		current, legacy []string
+		want            core.AppleVMConfig
+		visited         bool
+	}{
+		{"unvisited", nil, nil, initial.AppleVM, false},
+		{"current", current, nil, core.AppleVMConfig{HelperPath: "~/helper", Image: "/tmp/custom.img", ImageSHA256: strings.Repeat("b", 64), User: "current-user", WorkRoot: "~/work", CPUs: 6, MemoryMiB: 12288, DiskGiB: 64}, true},
+		{"legacy", nil, legacy, core.AppleVMConfig{HelperPath: "/legacy/helper", Image: "/tmp/custom.img", ImageSHA256: strings.Repeat("c", 64), User: "legacy-user", WorkRoot: "/legacy/work", CPUs: 8, MemoryMiB: 16384, DiskGiB: 80}, true},
+		{"current-wins", current, legacy, core.AppleVMConfig{HelperPath: "~/helper", Image: "/tmp/custom.img", ImageSHA256: strings.Repeat("b", 64), User: "current-user", WorkRoot: "~/work", CPUs: 6, MemoryMiB: 12288, DiskGiB: 64}, true},
+		{"current-empty-strings-win", emptyStrings, legacy, core.AppleVMConfig{CPUs: 6, MemoryMiB: 12288, DiskGiB: 64}, true},
+		{"legacy-empty-strings-apply", nil, emptyStrings, core.AppleVMConfig{CPUs: 6, MemoryMiB: 12288, DiskGiB: 64}, true},
+		{"current-equal-still-explicit", equal, legacy, initial.AppleVM, true},
+		{"legacy-equal-still-explicit", nil, equal, initial.AppleVM, true},
+		{"current-valid-outranks-legacy-zero", equal, legacyZeros, initial.AppleVM, true},
+		{"minimum-numerics", []string{equal[0], equal[1], equal[2], equal[3], equal[4], "1", "1024", "1"}, nil, core.AppleVMConfig{HelperPath: initial.AppleVM.HelperPath, Image: initial.AppleVM.Image, ImageSHA256: initial.AppleVM.ImageSHA256, User: initial.AppleVM.User, WorkRoot: initial.AppleVM.WorkRoot, CPUs: 1, MemoryMiB: 1024, DiskGiB: 1}, true},
+	} {
+		for _, currentFirst := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/current-first=%v", tc.name, currentFirst), func(t *testing.T) {
+				cfg, defaults := initial, initial
+				provider := Provider{}
+				fs := flag.NewFlagSet("ordinary-applevm", flag.ContinueOnError)
+				values := provider.RegisterFlags(fs, defaults)
+				count := 0
+				fs.VisitAll(func(*flag.Flag) { count++ })
+				if count != 16 {
+					t.Fatalf("registered %d flags, want 16", count)
+				}
+				for i, suffix := range suffixes {
+					primary, old := fs.Lookup("apple-vm-"+suffix), fs.Lookup("apple-vz-"+suffix)
+					if primary == nil || old == nil {
+						t.Fatalf("missing flag pair %s", suffix)
+					}
+					// ImageIdentity remains opaque: compare the two registered defaults.
+					if primary.DefValue != old.DefValue || (suffix != "image" && primary.DefValue != equal[i]) {
+						t.Fatalf("flag defaults for %s=%q/%q", suffix, primary.DefValue, old.DefValue)
+					}
+					if primary.Usage == "" || old.Usage != "deprecated alias for --apple-vm-"+suffix {
+						t.Fatalf("flag help for %s=%q/%q", suffix, primary.Usage, old.Usage)
+					}
+				}
+				var args []string
+				appendFlags := func(prefix string, inputs []string) {
+					for i, value := range inputs {
+						args = append(args, "--"+prefix+suffixes[i]+"="+value)
+					}
+				}
+				if currentFirst {
+					appendFlags("apple-vm-", tc.current)
+					appendFlags("apple-vz-", tc.legacy)
+				} else {
+					appendFlags("apple-vz-", tc.legacy)
+					appendFlags("apple-vm-", tc.current)
+				}
+				originalArgs := append([]string(nil), args...)
+				if err := fs.Parse(args); err != nil {
+					t.Fatal(err)
+				}
+				if err := provider.ApplyFlags(&cfg, fs, values); err != nil {
+					t.Fatal(err)
+				}
+				want := initial
+				want.AppleVM = tc.want
+				if tc.visited {
+					want.SSHUser, want.WorkRoot = tc.want.User, tc.want.WorkRoot
+					core.MarkAppleVMImageExplicit(&want)
+					core.MarkAppleVMImageSHA256Explicit(&want)
+					core.MarkAppleVMCPUsExplicit(&want)
+					core.MarkAppleVMMemoryExplicit(&want)
+					core.MarkAppleVMDiskExplicit(&want)
+				}
+				// Whole-config equality also checks the opaque checksum marker and
+				// that copying WorkRoot did not mark the generic root explicit.
+				if !reflect.DeepEqual(cfg, want) {
+					t.Fatalf("flag state differs: AppleVM=%+v, want %+v; image=%v numeric=%v/%v/%v rootExplicit=%v", cfg.AppleVM, want.AppleVM, core.AppleVMImageExplicit(cfg), core.AppleVMCPUsExplicit(cfg), core.AppleVMMemoryExplicit(cfg), core.AppleVMDiskExplicit(cfg), core.IsWorkRootExplicit(&cfg))
+				}
+				if !reflect.DeepEqual(defaults, initial) || !reflect.DeepEqual(args, originalArgs) {
+					t.Fatal("registration/parse/application mutated input defaults or argv")
+				}
+			})
+		}
+	}
+	for _, foreign := range []any{nil, struct{}{}, new(int)} {
+		t.Run(fmt.Sprintf("foreign-%T", foreign), func(t *testing.T) {
+			cfg := initial
+			fs := flag.NewFlagSet("ordinary-applevm", flag.ContinueOnError)
+			provider := Provider{}
+			provider.RegisterFlags(fs, cfg)
+			if err := fs.Parse([]string{"--apple-vm-helper=/changed", "--apple-vm-cpus=0"}); err != nil {
+				t.Fatal(err)
+			}
+			if err := provider.ApplyFlags(&cfg, fs, foreign); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(cfg, initial) {
+				t.Fatal("foreign flag object mutated config")
+			}
+		})
+	}
+	for _, prefix := range []string{"apple-vm-", "apple-vz-"} {
+		t.Run(prefix+"image-sequence", func(t *testing.T) {
+			cfg, want := initial, initial
+			for _, step := range []struct {
+				args                        []string
+				image, checksum             string
+				imageMarked, checksumMarked bool
+			}{
+				{[]string{"image-sha256=" + initial.AppleVM.ImageSHA256}, "/tmp/custom.img", initial.AppleVM.ImageSHA256, false, true},
+				{[]string{"image=/tmp/custom.img"}, "/tmp/custom.img", "", true, false},
+				{[]string{"image-sha256="}, "/tmp/custom.img", "", true, true},
+				{[]string{"image-sha256=" + initial.AppleVM.ImageSHA256, "image=/tmp/custom.img"}, "/tmp/custom.img", initial.AppleVM.ImageSHA256, true, true},
+				{[]string{"image="}, "", "", true, false},
+				{nil, "", "", true, false},
+			} {
+				fs := flag.NewFlagSet("ordinary-applevm", flag.ContinueOnError)
+				provider := Provider{}
+				values := provider.RegisterFlags(fs, initial)
+				args := make([]string, len(step.args))
+				for i, arg := range step.args {
+					args[i] = "--" + prefix + arg
+				}
+				if err := fs.Parse(args); err != nil {
+					t.Fatal(err)
+				}
+				if err := provider.ApplyFlags(&cfg, fs, values); err != nil {
+					t.Fatal(err)
+				}
+				want = initial
+				want.AppleVM.Image, want.AppleVM.ImageSHA256 = step.image, step.checksum
+				if step.imageMarked {
+					core.MarkAppleVMImageExplicit(&want)
+				}
+				if step.checksumMarked {
+					core.MarkAppleVMImageSHA256Explicit(&want)
+				}
+				if !reflect.DeepEqual(cfg, want) {
+					t.Fatalf("step %v: image/checksum=%q/%q, want %q/%q with markers %v/%v", step.args, cfg.AppleVM.Image, cfg.AppleVM.ImageSHA256, step.image, step.checksum, step.imageMarked, step.checksumMarked)
+				}
+			}
+		})
+	}
+}
+
+func TestAppleVMOrdinaryPublicFlagNumericErrors(t *testing.T) {
+	for failed, suffix := range []string{"cpus", "memory", "disk"} {
+		invalids := []int{0, -1}
+		if suffix == "memory" {
+			invalids = append(invalids, 1023)
+		}
+		for _, invalid := range invalids {
+			for _, spelling := range []string{"current", "legacy", "current-first", "current-last"} {
+				for _, alreadyMarked := range []bool{false, true} {
+					t.Run(fmt.Sprintf("%s/%d/%s/marked=%v", suffix, invalid, spelling, alreadyMarked), func(t *testing.T) {
+						cfg := core.Config{Provider: "ordinary-config-test-unselected", SSHUser: "before-user", WorkRoot: "/before", AppleVM: core.AppleVMConfig{Image: "/tmp/custom.img", ImageSHA256: strings.Repeat("a", 64), CPUs: 4, MemoryMiB: 8192, DiskGiB: 30}}
+						core.MarkAppleVMImageSHA256Explicit(&cfg)
+						if alreadyMarked {
+							core.MarkAppleVMCPUsExplicit(&cfg)
+							core.MarkAppleVMMemoryExplicit(&cfg)
+							core.MarkAppleVMDiskExplicit(&cfg)
+							core.MarkWorkRootExplicit(&cfg)
+						}
+						want := cfg
+						fs := flag.NewFlagSet("ordinary-applevm", flag.ContinueOnError)
+						provider := Provider{}
+						values := provider.RegisterFlags(fs, cfg)
+						prefix := "apple-vm-"
+						if spelling == "legacy" {
+							prefix = "apple-vz-"
+						}
+						// Reverse argv order: source application still proceeds helper,
+						// image, user/root, CPUs, memory, disk.
+						var args []string
+						for i := 2; i >= 0; i-- {
+							numeric := []string{"cpus", "memory", "disk"}[i]
+							value := []int{6, 12288, 64}[i]
+							if i == failed {
+								value = invalid
+							} else if i > failed {
+								value = 0
+							}
+							primary := fmt.Sprintf("--%s%s=%d", prefix, numeric, value)
+							legacy := fmt.Sprintf("--apple-vz-%s=%d", numeric, []int{8, 16384, 80}[i])
+							if spelling == "current-last" {
+								args = append(args, legacy)
+							}
+							args = append(args, primary)
+							if spelling == "current-first" {
+								args = append(args, legacy)
+							}
+						}
+						args = append(args, "--"+prefix+"work-root= /work/ci ", "--"+prefix+"user= ci ", "--"+prefix+"image= /tmp/custom.img ", "--"+prefix+"helper= ~/helper ")
+						if err := fs.Parse(args); err != nil {
+							t.Fatal(err)
+						}
+						err := provider.ApplyFlags(&cfg, fs, values)
+						message := fmt.Sprintf("--apple-vm-%s must be positive (got %d)", suffix, invalid)
+						if suffix == "memory" {
+							message = fmt.Sprintf("--apple-vm-memory must be at least 1024 MiB (got %d)", invalid)
+						}
+						var exitErr core.ExitError
+						if !errors.As(err, &exitErr) || exitErr.Code != 2 || exitErr.Message != message {
+							t.Fatalf("error=%v, want exit 2: %s", err, message)
+						}
+						want.AppleVM.HelperPath, want.AppleVM.ImageSHA256 = "~/helper", ""
+						want.AppleVM.User, want.SSHUser = "ci", "ci"
+						want.AppleVM.WorkRoot, want.WorkRoot = "/work/ci", "/work/ci"
+						core.MarkAppleVMImageExplicit(&want)
+						if failed > 0 {
+							want.AppleVM.CPUs = 6
+							core.MarkAppleVMCPUsExplicit(&want)
+						}
+						if failed > 1 {
+							want.AppleVM.MemoryMiB = 12288
+							core.MarkAppleVMMemoryExplicit(&want)
+						}
+						if !reflect.DeepEqual(cfg, want) {
+							t.Fatalf("partial state differs: AppleVM=%+v, want %+v; numeric markers=%v/%v/%v rootExplicit=%v", cfg.AppleVM, want.AppleVM, core.AppleVMCPUsExplicit(cfg), core.AppleVMMemoryExplicit(cfg), core.AppleVMDiskExplicit(cfg), core.IsWorkRootExplicit(&cfg))
+						}
+					})
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Move all eight Apple VM settings, their distinct runtime/file types, initialization and complete file/environment application into one concrete configuration owner. Share the accepted image/checksum transitions so the value changes and explicit markers remain one operation across file, environment and flags.

Keep the actual differences explicit: whole-section current/legacy file precedence, sixteen environment names, signed numeric parsing and canonical errors, earlier state retained on errors, pointer-backed numeric presence, and the provider's sixteen current/deprecated flags. Flag trimming, current-name visit precedence, image-identity defaults, early validation and selected-provider defaults retain their original order. Existing marker APIs and native/default-image owners are unchanged; no generator extension, custom serialization or migration is introduced.

Provider documentation, the refactor guide and changelog describe these boundaries. There are no new credentials or dependencies.

## Verification

Eight paired configuration test groups are unchanged from the passing pre-production baseline and passed against the candidate. They cover all eight initialized fields, file/environment/legacy precedence, numeric presence, image/checksum markers, ordered partial errors and writer persistence. The existing selected-provider test is preserved unchanged; the focused local flag tests use an unselected provider and inert existing fixtures, not native execution.

After integrating the actual Apple Container/Machine landing, 39 distinct configuration tests (eight Apple VM plus 31 incoming preservation tests), 34 generated-file freshness checks, six-package vet and build passed. The resolved source/index stayed unchanged, and an independent binding verified both relocated owners, both initializers, all selected test bodies, existing provider/default code and generated outputs.

```sh
go test -race ./scripts/configgen -run GeneratedConfigIsCurrent$ -count=1 -timeout=3m -v
go vet ./internal/cli ./internal/providers/applevm ./internal/providers/applecontainer ./internal/providers/applemachine ./internal/providers/kubevirt ./internal/providers/sealosdevbox
```

All twelve frozen public CLI cases matched both the original baseline and first candidate exactly: raw stdout/stderr, exit/timeout and written bytes. All exited successfully; no mismatches, timeouts, new cases or retries. Final binary SHA256: `13e3640e39bb013d48e83255e68b331ba32db1a986aff807a088e6255808f1d3`.

Managed Codex reviews, independent source review and documentation builds passed. CLI evidence covers generic projections and persistence, not a dedicated Apple VM JSON block or complete runtime application. Empty checksums establish storage omission only, and positive-size writer cases do not establish zero-value semantics; direct tests cover numeric presence. No native VM/helper, image download, SSH, cloud or security-probe execution is claimed.
