### PR TITLE
fix(images): admit and bundle transactional qualification publishers

### DIFF
--- a/.github/workflows/image-qualification.yml
+++ b/.github/workflows/image-qualification.yml
@@ -109,6 +109,7 @@ jobs:
               --outdir "$ARTIFACT/worker" --config wrangler.jsonc
           )
           cp candidate/scripts/mint-aws-devtools-image.sh \
+            candidate/scripts/devtools-image-smoke-linux.sh \
             candidate/scripts/install-linux-developer-tools.sh \
             candidate/scripts/linux-readiness.generated.sh \
             "$ARTIFACT/candidate/scripts/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix image qualification bundles to include the Linux smoke script and admit publisher cleanup-owned rollback without disarming promotion early.
+
 - Repair stale coordinator host associations against canonical lease state during pinned creation, preserving in-flight and retained instances; add admin host reservation inspection and guarded clearing. [PR 2057](https://github.com/openclaw/crabbox/pull/2057). Thanks @steipete.
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix image qualification bundles to include the Linux smoke script and admit publisher cleanup-owned rollback without disarming promotion early.
+- Fix image qualification bundles to include the Linux smoke script and admit publisher cleanup-owned rollback without disarming promotion early. [PR #2062](https://github.com/openclaw/crabbox/pull/2062) Thanks @vincentkoc.
 
 - Repair stale coordinator host associations against canonical lease state during pinned creation, preserving in-flight and retained instances; add admin host reservation inspection and guarded clearing. [PR 2057](https://github.com/openclaw/crabbox/pull/2057). Thanks @steipete.
 

--- a/scripts/image-qualification-control.mjs
+++ b/scripts/image-qualification-control.mjs
@@ -533,22 +533,84 @@ export function verifyPublisherContract(source) {
   if (requiredPatterns.some((pattern) => !pattern.test(source))) {
     throw new Error("candidate publisher lacks the transactional rollback contract");
   }
-  const ordered = [
+  // Admission checks the audited publisher layout, not arbitrary shell semantics.
+  // Keep failure handling inside cleanup: promotion stays armed through teardown.
+  const cleanup = source.match(/^cleanup\(\) \{\n([\s\S]*?)^\}\ntrap cleanup EXIT$/m);
+  if (!cleanup) {
+    throw new Error("candidate publisher cleanup contract is missing");
+  }
+  const main = source.slice(cleanup.index + cleanup[0].length);
+  const rollback = `  if [[ "$rollback_pending" == "1" && "$exit_status" != "0" ]]; then
+    rollback_pending=0
+    if rollback_promoted_image "$promotion_log"; then
+      rollback_status="succeeded"
+    else
+      rollback_status="failed"
+      finalizer_status=1
+    fi
+  fi`;
+  const cleanupOrdered = [
+    "  local exit_status=$?\n  trap - EXIT",
+    rollback,
+    '  if [[ "$keep_lease" != "1" ]]; then',
+    '    cleanup_leases=("$measurement_lease" "$promoted_lease" "$candidate_lease" "$source_lease")',
+    `      if ! "$CRABBOX_BIN" stop --provider aws --target "$target" "$lease"; then
+        cleanup_status="failed"
+        finalizer_status=1
+      fi`,
+    `  if [[ "$exit_status" == "0" && "$finalizer_status" != "0" ]]; then
+    exit_status="$finalizer_status"
+  fi`,
+    rollback,
+    '  if [[ "$measured" == "1" && -n "$measurement_dir" && -n "$public_outcome" ]]; then',
+    '    outcome_candidate="$(mktemp "${public_outcome}.candidate.XXXXXX")" || proof_status=$?',
+    `    node "$ROOT/scripts/devtools-image-proof.mjs" finalize \\
+      "$outcome_candidate" "$measurement_dir/policy.json" "$measurement_dir" \\
+      "$outcome_stage" "$exit_status" "$rollback_status" "$cleanup_status" "$receipt_path" ||
+      proof_status=$?`,
+    '      mv -f "$outcome_candidate" "$public_outcome" || proof_status=$?',
+    '    if [[ "$proof_status" != "0" ]]; then',
+    `      if [[ "$exit_status" == "0" ]]; then
+        exit_status="$proof_status"
+      fi`,
+    `      if [[ "$rollback_pending" == "1" ]]; then
+        rollback_pending=0
+        if rollback_promoted_image "$promotion_log"; then
+          rollback_status="succeeded"
+        else
+          rollback_status="failed"
+          finalizer_status=1
+        fi
+      fi`,
+    '    elif [[ "$exit_status" == "0" ]]; then\n      rollback_pending=0',
+    '  exit "$exit_status"\n',
+  ];
+  const mainOrdered = [
     'run_cmd "$CRABBOX_BIN" stop --provider aws --target "$target" "$candidate_lease"',
     'candidate_lease=""',
     "rollback_pending=1",
     'run_json_tee "$promotion_log" "$CRABBOX_BIN" "${promote_args[@]}"',
     'promoted_lease="$(warmup promoted)"',
     'smoke "$promoted_lease"',
-    "rollback_pending=0",
   ];
-  let cursor = 0;
-  for (const marker of ordered) {
-    const next = source.indexOf(marker, cursor);
-    if (next === -1) {
-      throw new Error("candidate publisher rollback ordering is not admissible");
+  for (const [text, ordered] of [
+    [cleanup[1], cleanupOrdered],
+    [main, mainOrdered],
+  ]) {
+    let cursor = 0;
+    for (const marker of ordered) {
+      const next = text.indexOf(marker, cursor);
+      if (next === -1) {
+        throw new Error("candidate publisher rollback ordering is not admissible");
+      }
+      cursor = next + marker.length;
     }
-    cursor = next + marker.length;
+  }
+  if (
+    (cleanup[1].match(/^\s*rollback_pending=0$/gm) ?? []).length !== 4 ||
+    /^\s*rollback_pending=0$/m.test(main.slice(main.indexOf("rollback_pending=1")))
+  ) {
+    throw new Error("candidate publisher disarms rollback outside cleanup outcomes");
   }
 }
 

--- a/scripts/image-qualification-workflow.test.js
+++ b/scripts/image-qualification-workflow.test.js
@@ -319,45 +319,88 @@ test("protected build prep binds source, rejects substitution, and seals exact b
   }
 });
 
-test("publisher admission requires transactional rollback before paid deployment", async () => {
+test("publisher admission accepts the actual transactional publisher before paid deployment", async () => {
   const module = await import(
     `${pathToFileURL(path.join(root, "scripts/image-qualification-control.mjs"))}?admit=${Date.now()}`
   );
-  const admissible = `
-CRABBOX_BIN="\${CRABBOX_BIN:-$ROOT/bin/crabbox}"
-cleanup() {
-  rollback_promoted_image "$promotion_log"
-}
-trap cleanup EXIT
-rollback_promoted_image() {
-  args+=(--restore-receipt "$receipt" "$current_id")
-  printf 'promoted-image smoke failed; restored previous default image=%s\\n' "$rollback_image"
-}
-run_cmd "$CRABBOX_BIN" stop --provider aws --target "$target" "$candidate_lease"
-candidate_lease=""
-promote_args=(image promote --target "$target" --json --expected-current-image capture)
-rollback_pending=1
-run_json_tee "$promotion_log" "$CRABBOX_BIN" "\${promote_args[@]}"
-jq -e '.previous.aliases | length > 0' "$promotion_log"
-promoted_lease="$(warmup promoted)"
-smoke "$promoted_lease"
-rollback_pending=0
+  assert.doesNotThrow(() =>
+    module.verifyPublisherContract(read("scripts/mint-aws-devtools-image.sh")),
+  );
+});
+
+test("publisher admission rejects broken transaction and cleanup boundaries", async (t) => {
+  const { verifyPublisherContract } = await import(
+    pathToFileURL(path.join(root, "scripts/image-qualification-control.mjs"))
+  );
+  const source = read("scripts/mint-aws-devtools-image.sh");
+  const propagation = `  if [[ "$exit_status" == "0" && "$finalizer_status" != "0" ]]; then
+    exit_status="$finalizer_status"
+  fi
 `;
-  assert.doesNotThrow(() => module.verifyPublisherContract(admissible));
-  assert.throws(
-    () =>
-      module.verifyPublisherContract(
-        admissible.replace("--expected-current-image capture", "ami-candidate"),
-      ),
-    /transactional rollback contract/,
-  );
-  assert.throws(
-    () =>
-      module.verifyPublisherContract(
-        admissible.replace('candidate_lease=""', 'candidate_lease="still-running"'),
-      ),
-    /rollback ordering/,
-  );
+  const rollback = `  if [[ "$rollback_pending" == "1" && "$exit_status" != "0" ]]; then
+    rollback_pending=0
+    if rollback_promoted_image "$promotion_log"; then
+      rollback_status="succeeded"
+    else
+      rollback_status="failed"
+      finalizer_status=1
+    fi
+  fi
+`;
+  const stop = `      if ! "$CRABBOX_BIN" stop --provider aws --target "$target" "$lease"; then
+        cleanup_status="failed"
+        finalizer_status=1
+      fi`;
+  const proofRollback = `      if [[ "$rollback_pending" == "1" ]]; then
+        rollback_pending=0
+        if rollback_promoted_image "$promotion_log"; then
+          rollback_status="succeeded"
+        else
+          rollback_status="failed"
+          finalizer_status=1
+        fi
+      fi`;
+  const armAndPromote =
+    'rollback_pending=1\nrun_json_tee "$promotion_log" "$CRABBOX_BIN" "${promote_args[@]}"';
+  for (const [name, before, after] of [
+    ["CAS removed", "--expected-current-image capture", "ami-candidate"],
+    ["receipt restore removed", '--restore-receipt "$receipt" "$current_id"', '"$current_id"'],
+    ["EXIT trap removed", "trap cleanup EXIT", "trap : EXIT"],
+    [
+      "candidate still owned",
+      'clear_warmup_handle candidate\n  candidate_lease=""',
+      'clear_warmup_handle candidate\n  candidate_lease="still-running"',
+    ],
+    [
+      "arm after promotion",
+      armAndPromote,
+      'run_json_tee "$promotion_log" "$CRABBOX_BIN" "${promote_args[@]}"\nrollback_pending=1',
+    ],
+    [
+      "early main disarm",
+      'smoke "$promoted_lease"\n',
+      'smoke "$promoted_lease"\nrollback_pending=0\n',
+    ],
+    ["original failure rollback removed", rollback, ""],
+    ["cleanup failure rollback removed", propagation + rollback, propagation],
+    ["cleanup failure rollback reordered", propagation + rollback, rollback + propagation],
+    ["lease cleanup removed", stop, ":"],
+    ["lease cleanup error ignored", stop, stop.replace("finalizer_status=1", ":")],
+    ["proof failure swallowed", 'exit_status="$proof_status"', "exit_status=0"],
+    ["proof rollback removed", proofRollback, ""],
+    [
+      "proof publication error ignored",
+      'mv -f "$outcome_candidate" "$public_outcome" || proof_status=$?',
+      'mv -f "$outcome_candidate" "$public_outcome" || true',
+    ],
+    ["final status swallowed", '  exit "$exit_status"\n}', "  exit 0\n}"],
+  ]) {
+    await t.test(name, () => {
+      const changed = source.replace(before, after);
+      assert.ok(changed !== source, `mutation did not apply: ${name}`);
+      assert.throws(() => verifyPublisherContract(changed), /candidate publisher/);
+    });
+  }
 });
 
 test("authorization selects one exact same-PR candidate artifact and detects replacement", async () => {

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -8,6 +8,7 @@ import {
   readFile,
   readdir,
   rm,
+  symlink,
   writeFile,
 } from "node:fs/promises";
 import os from "node:os";
@@ -178,6 +179,100 @@ function runScript(args, env, scriptPath = script, onOutput) {
     child.on("close", (code) => resolve({ code, stdout, stderr }));
   });
 }
+
+async function qualificationFixture(t) {
+  const fake = await setupFakeCrabbox();
+  t.after(() => rm(fake.dir, { recursive: true, force: true }));
+  const workflow = await readFile(
+    path.join(repoRoot, ".github/workflows/image-qualification.yml"),
+    "utf8",
+  );
+  const copyCommand = workflow.match(
+    /^          cp candidate\/scripts\/mint-aws-devtools-image\.sh \\\n(?:            .*\n)+/m,
+  )?.[0];
+  assert.ok(copyCommand, "qualification workflow publisher copy command is missing");
+  const artifact = path.join(fake.dir, "artifact");
+  await mkdir(path.join(artifact, "candidate/scripts"), { recursive: true });
+  await symlink(repoRoot, path.join(fake.dir, "candidate"));
+  execFileSync("bash", ["-euc", copyCommand], {
+    cwd: fake.dir,
+    env: { ...process.env, ARTIFACT: artifact },
+  });
+  return {
+    ...fake,
+    script: path.join(artifact, "candidate/scripts/mint-aws-devtools-image.sh"),
+    env: {
+      CRABBOX_BIN: fake.fake,
+      CRABBOX_FAKE_LOG: fake.log,
+      CRABBOX_IMAGE_LOG_DIR: fake.dir,
+      CRABBOX_OS: undefined,
+      CRABBOX_AWS_AMI: undefined,
+    },
+  };
+}
+
+test("qualification bundle runs the bundled installer and all three Linux smokes", async (t) => {
+  const fake = await qualificationFixture(t);
+  const result = await runScript(["--target", "linux", "--run"], fake.env, fake.script);
+  const log = await readFile(fake.log, "utf8");
+  assert.match(log, /stop --provider aws --target linux cbx_source/);
+  if (result.code !== 0) {
+    assert.doesNotMatch(log, /checkpoint create|image promote/);
+  }
+  assert.equal(result.code, 0, result.stderr);
+  assert.ok(log.includes(`--script ${path.dirname(fake.script)}/install-linux-developer-tools.sh`));
+  assert.equal((log.match(/docker_probe=/g) ?? []).length, 3);
+  for (const lease of ["cbx_source", "cbx_candidate", "cbx_promoted"]) {
+    assert.match(log, new RegExp(`run .*--id ${lease} --no-sync --shell -- set -euo pipefail`));
+    assert.match(log, new RegExp(`stop --provider aws --target linux ${lease}`));
+  }
+  assert.match(log, /checkpoint create/);
+  assert.match(log, /--expected-current-image capture/);
+  assert.doesNotMatch(log, /--restore-receipt/);
+});
+
+test("qualification bundle preserves the protected promoted-smoke failure and receipt rollback", async (t) => {
+  const fake = await qualificationFixture(t);
+  const state = path.join(fake.dir, "adapter");
+  const result = await runScript(
+    ["--target", "linux", "--run"],
+    {
+      ...fake.env,
+      CRABBOX_BIN: path.join(scriptDir, "image-qualification-crabbox-adapter.sh"),
+      QUALIFICATION_REAL_CRABBOX: fake.fake,
+      QUALIFICATION_ADAPTER_STATE: state,
+    },
+    fake.script,
+  );
+  assert.equal(result.code, 86, result.stderr);
+  assert.equal(await readFile(path.join(state, "injected"), "utf8"), "after-promoted-smoke\n");
+  const promotion = JSON.parse(await readFile(path.join(state, "promotion-receipt.json"), "utf8"));
+  const rollback = JSON.parse(await readFile(path.join(state, "rollback-receipt.json"), "utf8"));
+  assert.equal(promotion.previous.imageId, rollback.image.id);
+  const log = await readFile(fake.log, "utf8");
+  assert.equal((log.match(/docker_probe=/g) ?? []).length, 3);
+  assert.match(log, /--restore-receipt \S+ ami-devtools/);
+  for (const lease of ["cbx_source", "cbx_candidate", "cbx_promoted"]) {
+    assert.match(log, new RegExp(`stop --provider aws --target linux ${lease}`));
+  }
+});
+
+test("qualification bundle rolls back when promoted lease cleanup fails after successful smoke", async (t) => {
+  const fake = await qualificationFixture(t);
+  const result = await runScript(
+    ["--target", "linux", "--run"],
+    { ...fake.env, CRABBOX_FAKE_STOP_FAIL_LEASE: "cbx_promoted" },
+    fake.script,
+  );
+  assert.equal(result.code, 1, result.stderr);
+  assert.match(result.stderr, /stop failed for cbx_promoted/);
+  assert.match(result.stderr, /restored previous default image=ami-previous/);
+  const log = await readFile(fake.log, "utf8");
+  assert.equal((log.match(/docker_probe=/g) ?? []).length, 3);
+  const stop = log.indexOf("stop --provider aws --target linux cbx_promoted");
+  const restore = log.indexOf("--restore-receipt");
+  assert.ok(stop !== -1 && restore > stop, "cleanup failure must trigger receipt rollback");
+});
 
 test("AWS devtools mint wrapper defaults to dry plan", async () => {
   const fake = await setupFakeCrabbox();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers qualifying a Linux developer image would have the current publisher rejected before execution, or encounter a missing smoke script in the candidate bundle.

## Why This Change Was Made

Include the existing Linux smoke script in the qualification bundle and recognize the publisher's cleanup-owned rollback contract. Admission still requires candidate teardown before promotion, rollback arming before promotion, CAS/receipt restoration, and EXIT cleanup. It checks original-failure, teardown-failure, and measured-proof-failure rollback and rejects premature main-path disarming.

These are bounded checks of the audited publisher layout, not arbitrary shell security verification. The publisher itself, qualification authorization, resource settings, and promotion defaults are unchanged.

## User Impact

Qualification can admit and stage the existing transactional publisher without weakening its rollback boundary. This source change does not qualify an image or authorize an image build, deployment, or promotion.

## Evidence

- Before the fix, the actual publisher failed admission, and the workflow's actual copy bundle failed on the missing Linux smoke script before capture/promotion while still cleaning up the source lease.
- New regression coverage uses the real publisher, the workflow copy command, the existing fake provider, and the protected adapter. It covers three staged smokes, injected promoted-smoke failure `86` with receipt rollback, and nonmeasured promoted-lease cleanup failure triggering rollback.
- Full local command: `node --test scripts/image-qualification-workflow.test.js scripts/mint-aws-devtools-image.test.js`. Result: **138 passed, 1 failed**. The unchanged generated-Go-smoke test received empty stderr instead of its expected missing-archive diagnostic. The original child error/status/signal were not retained, so the cause is unresolved and is not classified as a timeout.
- That one case passed twice in isolation, including a diagnostic run observing both expected child exits with no error or signal under the unchanged timeout. Its test, fixtures, and publisher inputs match the base. These later passes do not turn the original full run green.
- JavaScript syntax, workflow actionlint, and `git diff --check` passed. New code introduces no formatter drift; unrelated baseline formatting differences remain.
- One scoped P0 review found no actionable findings.
- Hosted CI on `ae48bbb6e6003d34d808c26d663f03a44c3154cf` completed with 25 successful checks and one skipped check, including the required Release Check, Scripts, Apple VM, and Go checks. The [Scripts job](https://github.com/openclaw/crabbox/actions/runs/34421835593/job/102698741623) ran the combined `node --test scripts/*.test.js scripts/*.test.mjs` suite: **1,158 passed, 0 failed, 6 skipped**. Its complete log confirms the qualification admission/bundle rollback cases and the generated-Go archive case passed.
- This independent full hosted run resolves the validation uncertainty raised in the [ClawSweeper review](https://github.com/openclaw/crabbox/pull/2062#issuecomment-5610885095). The original local 138/1 result and its unknown cause remain recorded above; no timeout, assertion, source, or test-selection change was made to obtain the hosted pass.

Validation above covers source and fake-provider behavior, including hosted CI. No Crabbox native guest/image qualification, image build, image promotion, or rollout was performed.

Punchcard-Session: coral-workshop-harbor-pt
