### PR TITLE
refactor(config): centralize Local Container source state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 
 - Consolidate Lambda configuration and runtime defaults while preserving structured filesystem mounts, image precedence, and YAML diagnostics; clarify the distinct YAML and environment mount formats. [PR 2055](https://github.com/openclaw/crabbox/pull/2055). Thanks @steipete.
 
-- Consolidate Local Container settings while retaining explicit source choices, false-value overrides, and runtime-only state. Thanks @steipete.
+- Consolidate Local Container settings while retaining explicit source choices, false-value overrides, and runtime-only state. [PR 2063](https://github.com/openclaw/crabbox/pull/2063). Thanks @steipete.
 
 ## 0.54.0 - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
 
 - Consolidate Lambda configuration and runtime defaults while preserving structured filesystem mounts, image precedence, and YAML diagnostics; clarify the distinct YAML and environment mount formats. [PR 2055](https://github.com/openclaw/crabbox/pull/2055). Thanks @steipete.
 
+- Consolidate Local Container settings while retaining explicit source choices, false-value overrides, and runtime-only state. Thanks @steipete.
+
 ## 0.54.0 - 2026-09-09
 
 ### Highlights

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -246,6 +246,18 @@ CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET
 CRABBOX_LOCAL_CONTAINER_NO_HOSTNAME
 ```
 
+File strings only replace earlier values when nonempty, and file CPU values
+apply only when positive. Environment CPU parsing preserves the earlier value
+on malformed input; an explicit environment zero still applies. The two boolean
+settings distinguish omission/null from explicit `false`, so false can override
+an earlier true value. Source overlays keep string text unchanged; later
+provider defaults and runtime normalization remain separate.
+
+Explicit runtime, image and work-root input remains explicit even when it equals
+the existing value. The raw initial work root is empty; the effective
+`/work/crabbox` default is applied later. `noHostname` has no provider CLI flag,
+and volumes and checkpoint metadata are not file/environment settings.
+
 Set `localContainer.noHostname: true` or
 `CRABBOX_LOCAL_CONTAINER_NO_HOSTNAME=1` when the runtime rejects an explicit
 hostname, such as when it shares the host UTS namespace. By default Crabbox

--- a/docs/refactor/typed-provider-config.md
+++ b/docs/refactor/typed-provider-config.md
@@ -221,6 +221,27 @@ provider lookups remain separate from these raw-empty rules.
 Native mount filtering, lookup, credentials, class selection and OS mappings remain
 provider policy. The following field instructions apply to generated owners.
 
+## Local Container's concrete source owner
+
+`config_local_container.go` keeps eleven runtime members distinct from nine
+file/environment settings. The file type retains two pointer booleans and its
+existing omissions. CLI-only volumes and transient checkpoint metadata remain
+runtime data, not new persisted settings; their list/map identities survive
+ordinary source application. The initializer accepts the resolved image and
+keeps the raw work root empty without marking compiled defaults explicit.
+
+Three accepted-input operations pair Runtime, Image and WorkRoot assignments
+with their existing source markers. File/environment predicates and scalar flag
+visitation stay with their current callers. The flag work-root operation sets
+the provider bit before the independent generic root copy/snapshot; later
+observers see the same state, including the existing empty-snapshot semantics.
+No concurrency guarantee or callback layer is introduced.
+
+Flag storage, raw volume-list behavior, creation-only checks and provider
+defaults remain provider-owned. NoHostname stays file/environment-only. This
+concrete owner needs neither generated runtime-state exclusions nor a new flag
+list framework; native, socket, mount and checkpoint behavior is unchanged.
+
 ## Apple Container's shared concrete owner
 
 `config_apple_container.go` owns all seven shared settings without generated

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -891,20 +891,6 @@ type SpritesConfig struct {
 	WorkRoot string
 }
 
-type LocalContainerConfig struct {
-	Runtime            string
-	Image              string
-	User               string
-	WorkRoot           string
-	CPUs               int
-	Memory             string
-	Network            string
-	DockerSocket       bool
-	NoHostname         bool
-	Volumes            []string
-	CheckpointMetadata map[string]string `yaml:"-" json:"-"`
-}
-
 type MXCConfig struct {
 	CLIPath           string
 	Version           string
@@ -2580,12 +2566,7 @@ func baseConfig() Config {
 			APIURL:   "https://api.sprites.dev",
 			WorkRoot: "/home/sprite/crabbox",
 		},
-		LocalContainer: LocalContainerConfig{
-			Runtime: "docker",
-			Image:   containerImage,
-			User:    "crabbox",
-			Network: "bridge",
-		},
+		LocalContainer: initialLocalContainerConfig(containerImage),
 		AppleContainer: initialAppleContainerConfig(containerImage),
 		AppleVM:        initialAppleVMConfig(osImageSpecs[osImage].AppleVMImage, osImageSpecs[osImage].AppleVMSHA256),
 		MXC: MXCConfig{
@@ -3464,18 +3445,6 @@ func positiveMinimum(current, candidate int) int {
 type fileSpritesConfig struct {
 	APIURL   string `yaml:"apiUrl,omitempty"`
 	WorkRoot string `yaml:"workRoot,omitempty"`
-}
-
-type fileLocalContainerConfig struct {
-	Runtime      string `yaml:"runtime,omitempty"`
-	Image        string `yaml:"image,omitempty"`
-	User         string `yaml:"user,omitempty"`
-	WorkRoot     string `yaml:"workRoot,omitempty"`
-	CPUs         int    `yaml:"cpus,omitempty"`
-	Memory       string `yaml:"memory,omitempty"`
-	Network      string `yaml:"network,omitempty"`
-	DockerSocket *bool  `yaml:"dockerSocket,omitempty"`
-	NoHostname   *bool  `yaml:"noHostname,omitempty"`
 }
 
 type fileMXCConfig struct {
@@ -5658,38 +5627,7 @@ func applyFileConfigWithTrustAndProviderSource(cfg *Config, file fileConfig, tru
 			cfg.Sprites.WorkRoot = file.Sprites.WorkRoot
 		}
 	}
-	if file.LocalContainer != nil {
-		if file.LocalContainer.Runtime != "" {
-			cfg.LocalContainer.Runtime = file.LocalContainer.Runtime
-			cfg.localContainerRuntimeExplicit = true
-		}
-		if file.LocalContainer.Image != "" {
-			cfg.LocalContainer.Image = file.LocalContainer.Image
-			cfg.localContainerImageExplicit = true
-		}
-		if file.LocalContainer.User != "" {
-			cfg.LocalContainer.User = file.LocalContainer.User
-		}
-		if file.LocalContainer.WorkRoot != "" {
-			cfg.LocalContainer.WorkRoot = file.LocalContainer.WorkRoot
-			cfg.localContainerRootExplicit = true
-		}
-		if file.LocalContainer.CPUs > 0 {
-			cfg.LocalContainer.CPUs = file.LocalContainer.CPUs
-		}
-		if file.LocalContainer.Memory != "" {
-			cfg.LocalContainer.Memory = file.LocalContainer.Memory
-		}
-		if file.LocalContainer.Network != "" {
-			cfg.LocalContainer.Network = file.LocalContainer.Network
-		}
-		applyOptional(&cfg.LocalContainer.DockerSocket, file.LocalContainer.DockerSocket)
-		applyOptional(&cfg.LocalContainer.NoHostname, file.LocalContainer.NoHostname)
-		// NOTE: localContainer.volumes is intentionally NOT loaded from
-		// repo-local config files. Bind mounts expose host paths and must
-		// be an explicit CLI action (--local-container-volume), not
-		// something an untrusted checkout can request via .crabbox.yaml.
-	}
+	applyLocalContainerFile(cfg, file.LocalContainer)
 	if cfg.AppleContainer.applyFile(file.AppleContainer) {
 		MarkAppleContainerImageExplicit(cfg)
 	}
@@ -7377,28 +7315,7 @@ func applyEnv(cfg *Config) error {
 		cfg.credentialProvenance.spritesAPIURL = credentialSourceEnvironment
 	}
 	cfg.Sprites.WorkRoot = getenv("CRABBOX_SPRITES_WORK_ROOT", cfg.Sprites.WorkRoot)
-	if runtimeName := os.Getenv("CRABBOX_LOCAL_CONTAINER_RUNTIME"); runtimeName != "" {
-		cfg.LocalContainer.Runtime = runtimeName
-		cfg.localContainerRuntimeExplicit = true
-	}
-	if image := os.Getenv("CRABBOX_LOCAL_CONTAINER_IMAGE"); image != "" {
-		cfg.LocalContainer.Image = image
-		cfg.localContainerImageExplicit = true
-	}
-	cfg.LocalContainer.User = getenv("CRABBOX_LOCAL_CONTAINER_USER", cfg.LocalContainer.User)
-	if workRoot := os.Getenv("CRABBOX_LOCAL_CONTAINER_WORK_ROOT"); workRoot != "" {
-		cfg.LocalContainer.WorkRoot = workRoot
-		cfg.localContainerRootExplicit = true
-	}
-	cfg.LocalContainer.CPUs = getenvInt("CRABBOX_LOCAL_CONTAINER_CPUS", cfg.LocalContainer.CPUs)
-	cfg.LocalContainer.Memory = getenv("CRABBOX_LOCAL_CONTAINER_MEMORY", cfg.LocalContainer.Memory)
-	cfg.LocalContainer.Network = getenv("CRABBOX_LOCAL_CONTAINER_NETWORK", cfg.LocalContainer.Network)
-	if value, ok := getenvBool("CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET"); ok {
-		cfg.LocalContainer.DockerSocket = value
-	}
-	if value, ok := getenvBool("CRABBOX_LOCAL_CONTAINER_NO_HOSTNAME"); ok {
-		cfg.LocalContainer.NoHostname = value
-	}
+	applyLocalContainerEnv(cfg)
 	if cfg.AppleContainer.applyEnv() {
 		MarkAppleContainerImageExplicit(cfg)
 	}

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -17,6 +17,67 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func TestLocalContainerOrdinaryFileRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name, input, wantYAML string
+		present, enabled      bool
+	}{
+		{"omitted", "{}", "localContainer: {}\n", false, true},
+		{"null", "{dockerSocket: null, noHostname: null}", "localContainer: {}\n", false, true},
+		{"false", "{dockerSocket: false, noHostname: false}", "localContainer:\n    dockerSocket: false\n    noHostname: false\n", true, false},
+		{"true", "{dockerSocket: true, noHostname: true}", "localContainer:\n    dockerSocket: true\n    noHostname: true\n", true, true},
+		{"zero values", "{runtime: '', image: '', user: '', workRoot: '', cpus: 0, memory: '', network: ''}", "localContainer: {}\n", false, true},
+		{"nine values", "{runtime: custom, image: example:tag, user: runner, workRoot: '~/literal', cpus: 3, memory: 4g, network: custom, dockerSocket: false, noHostname: false}", "localContainer:\n    runtime: custom\n    image: example:tag\n    user: runner\n    workRoot: ~/literal\n    cpus: 3\n    memory: 4g\n    network: custom\n    dockerSocket: false\n    noHostname: false\n", true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := isolatedConfigPath(t)
+			if err := os.WriteFile(path, []byte("localContainer: "+tc.input+"\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			file, err := readFileConfig(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if file.LocalContainer == nil || (file.LocalContainer.DockerSocket != nil) != tc.present || (file.LocalContainer.NoHostname != nil) != tc.present {
+				t.Fatal("reader lost pointer boolean presence")
+			}
+			cfg := baseConfig()
+			cfg.Provider = "unselected-config-test"
+			cfg.LocalContainer.DockerSocket, cfg.LocalContainer.NoHostname = !tc.enabled, !tc.enabled
+			if !tc.present {
+				cfg.LocalContainer.DockerSocket, cfg.LocalContainer.NoHostname = true, true
+			}
+			if err := applyFileConfig(&cfg, file); err != nil {
+				t.Fatal(err)
+			}
+			if cfg.LocalContainer.DockerSocket != tc.enabled || cfg.LocalContainer.NoHostname != tc.enabled {
+				t.Fatal("file boolean layering changed")
+			}
+			written, err := writeUserFileConfig(file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if written != path {
+				t.Fatalf("write path=%q, want %q", written, path)
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(data) != tc.wantYAML {
+				t.Fatalf("written YAML=%q, want %q", data, tc.wantYAML)
+			}
+			again, err := readFileConfig(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(again, file) {
+				t.Fatal("file values changed on round trip")
+			}
+		})
+	}
+}
+
 type configArchitectureTestProvider struct {
 	architectureCapabilityTestProvider
 }

--- a/internal/cli/config_local_container.go
+++ b/internal/cli/config_local_container.go
@@ -1,0 +1,114 @@
+package cli
+
+import "os"
+
+type LocalContainerConfig struct {
+	Runtime            string
+	Image              string
+	User               string
+	WorkRoot           string
+	CPUs               int
+	Memory             string
+	Network            string
+	DockerSocket       bool
+	NoHostname         bool
+	Volumes            []string
+	CheckpointMetadata map[string]string `yaml:"-" json:"-"`
+}
+
+type fileLocalContainerConfig struct {
+	Runtime      string `yaml:"runtime,omitempty"`
+	Image        string `yaml:"image,omitempty"`
+	User         string `yaml:"user,omitempty"`
+	WorkRoot     string `yaml:"workRoot,omitempty"`
+	CPUs         int    `yaml:"cpus,omitempty"`
+	Memory       string `yaml:"memory,omitempty"`
+	Network      string `yaml:"network,omitempty"`
+	DockerSocket *bool  `yaml:"dockerSocket,omitempty"`
+	NoHostname   *bool  `yaml:"noHostname,omitempty"`
+}
+
+func initialLocalContainerConfig(resolvedImage string) LocalContainerConfig {
+	return LocalContainerConfig{
+		Runtime: "docker",
+		Image:   resolvedImage,
+		User:    "crabbox",
+		Network: "bridge",
+	}
+}
+
+func applyLocalContainerFile(cfg *Config, file *fileLocalContainerConfig) {
+	if file == nil {
+		return
+	}
+	if file.Runtime != "" {
+		ApplyLocalContainerRuntime(cfg, file.Runtime)
+	}
+	if file.Image != "" {
+		ApplyLocalContainerImage(cfg, file.Image)
+	}
+	if file.User != "" {
+		cfg.LocalContainer.User = file.User
+	}
+	if file.WorkRoot != "" {
+		ApplyLocalContainerWorkRoot(cfg, file.WorkRoot)
+	}
+	if file.CPUs > 0 {
+		cfg.LocalContainer.CPUs = file.CPUs
+	}
+	if file.Memory != "" {
+		cfg.LocalContainer.Memory = file.Memory
+	}
+	if file.Network != "" {
+		cfg.LocalContainer.Network = file.Network
+	}
+	applyOptional(&cfg.LocalContainer.DockerSocket, file.DockerSocket)
+	applyOptional(&cfg.LocalContainer.NoHostname, file.NoHostname)
+	// NOTE: localContainer.volumes is intentionally NOT loaded from
+	// repo-local config files. Bind mounts expose host paths and must
+	// be an explicit CLI action (--local-container-volume), not
+	// something an untrusted checkout can request via .crabbox.yaml.
+}
+
+func applyLocalContainerEnv(cfg *Config) {
+	if runtimeName := os.Getenv("CRABBOX_LOCAL_CONTAINER_RUNTIME"); runtimeName != "" {
+		ApplyLocalContainerRuntime(cfg, runtimeName)
+	}
+	if image := os.Getenv("CRABBOX_LOCAL_CONTAINER_IMAGE"); image != "" {
+		ApplyLocalContainerImage(cfg, image)
+	}
+	cfg.LocalContainer.User = getenv("CRABBOX_LOCAL_CONTAINER_USER", cfg.LocalContainer.User)
+	if workRoot := os.Getenv("CRABBOX_LOCAL_CONTAINER_WORK_ROOT"); workRoot != "" {
+		ApplyLocalContainerWorkRoot(cfg, workRoot)
+	}
+	cfg.LocalContainer.CPUs = getenvInt("CRABBOX_LOCAL_CONTAINER_CPUS", cfg.LocalContainer.CPUs)
+	cfg.LocalContainer.Memory = getenv("CRABBOX_LOCAL_CONTAINER_MEMORY", cfg.LocalContainer.Memory)
+	cfg.LocalContainer.Network = getenv("CRABBOX_LOCAL_CONTAINER_NETWORK", cfg.LocalContainer.Network)
+	if value, ok := getenvBool("CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET"); ok {
+		cfg.LocalContainer.DockerSocket = value
+	}
+	if value, ok := getenvBool("CRABBOX_LOCAL_CONTAINER_NO_HOSTNAME"); ok {
+		cfg.LocalContainer.NoHostname = value
+	}
+}
+
+// ApplyLocalContainerRuntime applies an already-accepted runtime value and sets
+// the existing marker via MarkLocalContainerRuntimeExplicit.
+func ApplyLocalContainerRuntime(cfg *Config, value string) {
+	cfg.LocalContainer.Runtime = value
+	MarkLocalContainerRuntimeExplicit(cfg)
+}
+
+// ApplyLocalContainerImage applies an already-accepted image value and sets
+// the existing marker via MarkLocalContainerImageExplicit.
+func ApplyLocalContainerImage(cfg *Config, value string) {
+	cfg.LocalContainer.Image = value
+	MarkLocalContainerImageExplicit(cfg)
+}
+
+// ApplyLocalContainerWorkRoot applies an already-accepted work-root value and sets
+// the existing marker via MarkLocalContainerWorkRootExplicit.
+func ApplyLocalContainerWorkRoot(cfg *Config, value string) {
+	cfg.LocalContainer.WorkRoot = value
+	MarkLocalContainerWorkRootExplicit(cfg)
+}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -20,6 +20,103 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func TestLocalContainerBaseConfig(t *testing.T) {
+	cfg := baseConfig()
+	_, _, _, _, _, image, _ := osImageDefaultProviderImages(cfg.OSImage)
+	want := LocalContainerConfig{Runtime: "docker", Image: image, User: "crabbox", Network: "bridge"}
+	if image == "" || !reflect.DeepEqual(cfg.LocalContainer, want) {
+		t.Fatalf("compiled local-container defaults=%#v, want %#v", cfg.LocalContainer, want)
+	}
+	if cfg.localContainerImageExplicit || LocalContainerRuntimeExplicit(cfg) || LocalContainerWorkRootExplicit(cfg) {
+		t.Fatal("compiled defaults marked explicit")
+	}
+}
+
+func TestLocalContainerOrdinarySourceLayering(t *testing.T) {
+	settings := func(text string, cpus int, enabled bool) LocalContainerConfig {
+		return LocalContainerConfig{
+			Runtime: text, Image: text, User: text, WorkRoot: text,
+			CPUs: cpus, Memory: text, Network: text, DockerSocket: enabled, NoHostname: enabled,
+		}
+	}
+	for _, source := range []string{"file", "env"} {
+		for _, tc := range []struct {
+			name, text, cpu, boolean, wantText string
+			fileCPU, envCPU                    int
+			startBool, wantBool                bool
+		}{
+			{"empty preserves", "", "", "", "prior", 5, 5, true, true},
+			{"equal accepts", "prior", "5", "true", "prior", 5, 5, true, true},
+			{"raw paths and false", "~/literal ", "7", "false", "~/literal ", 7, 7, true, false},
+			{"whitespace and zero", " \t ", "0", "", " \t ", 5, 0, true, true},
+			{"negative and true", "", "-2", "true", "prior", 5, -2, false, true},
+			{"malformed preserves", "", "bad", "invalid", "prior", 5, 5, true, true},
+			{"boolean on", "", "", " ON ", "prior", 5, 5, false, true},
+			{"boolean off", "", "", " Off ", "prior", 5, 5, true, false},
+		} {
+			t.Run(source+"/"+tc.name, func(t *testing.T) {
+				clearConfigEnv(t)
+				for _, key := range []string{"CRABBOX_PROVIDER", "CRABBOX_OS", "CRABBOX_WORK_ROOT", "CRABBOX_USER", "CRABBOX_SSH_USER"} {
+					t.Setenv(key, "")
+				}
+				cfg := baseConfig()
+				cfg.Provider = "unselected-config-test"
+				cfg.SSHUser, cfg.WorkRoot = "generic-user", "generic-root"
+				cfg.LocalContainer = settings("prior", 5, tc.startBool)
+				list := []string{"inert-list-value"}
+				metadata := map[string]string{"inert-key": "inert-value"}
+				cfg.LocalContainer.Volumes, cfg.LocalContainer.CheckpointMetadata = list, metadata
+				wantCPU := tc.fileCPU
+				if source == "file" {
+					cpu, _ := strconv.Atoi(tc.cpu)
+					var boolean *bool
+					if tc.boolean != "" && tc.boolean != "invalid" {
+						value := tc.wantBool
+						boolean = &value
+					}
+					if err := applyFileConfig(&cfg, fileConfig{LocalContainer: &fileLocalContainerConfig{
+						Runtime: tc.text, Image: tc.text, User: tc.text, WorkRoot: tc.text,
+						CPUs: cpu, Memory: tc.text, Network: tc.text, DockerSocket: boolean, NoHostname: boolean,
+					}}); err != nil {
+						t.Fatal(err)
+					}
+				} else {
+					wantCPU = tc.envCPU
+					for _, key := range []string{"RUNTIME", "IMAGE", "USER", "WORK_ROOT", "MEMORY", "NETWORK"} {
+						t.Setenv("CRABBOX_LOCAL_CONTAINER_"+key, tc.text)
+					}
+					t.Setenv("CRABBOX_LOCAL_CONTAINER_CPUS", tc.cpu)
+					t.Setenv("CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET", tc.boolean)
+					t.Setenv("CRABBOX_LOCAL_CONTAINER_NO_HOSTNAME", tc.boolean)
+					if err := applyEnv(&cfg); err != nil {
+						t.Fatal(err)
+					}
+				}
+				want := settings(tc.wantText, wantCPU, tc.wantBool)
+				want.Volumes = []string{"inert-list-value"}
+				want.CheckpointMetadata = map[string]string{"inert-key": "inert-value"}
+				if !reflect.DeepEqual(cfg.LocalContainer, want) {
+					t.Fatalf("source settings=%#v, want %#v", cfg.LocalContainer, want)
+				}
+				accepted := tc.text != ""
+				if cfg.localContainerImageExplicit != accepted || LocalContainerRuntimeExplicit(cfg) != accepted || LocalContainerWorkRootExplicit(cfg) != accepted {
+					t.Fatal("source markers did not track acceptance")
+				}
+				if cfg.SSHUser != "generic-user" || cfg.WorkRoot != "generic-root" || IsWorkRootExplicit(&cfg) {
+					t.Fatal("provider source changed generic user/root or its marker")
+				}
+				if &cfg.LocalContainer.Volumes[0] != &list[0] {
+					t.Fatal("source replaced the runtime list")
+				}
+				metadata["inert-key"] = "updated-inert-value"
+				if cfg.LocalContainer.CheckpointMetadata["inert-key"] != "updated-inert-value" {
+					t.Fatal("source replaced the runtime map")
+				}
+			})
+		}
+	}
+}
+
 func isolateTestUserDirs(t *testing.T) testutil.UserDirs {
 	t.Helper()
 	return testutil.IsolateUserDirs(t)

--- a/internal/providers/localcontainer/config_show_test.go
+++ b/internal/providers/localcontainer/config_show_test.go
@@ -1,11 +1,79 @@
 package localcontainer
 
 import (
+	"flag"
 	"reflect"
 	"testing"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
+
+func TestOrdinaryScalarFlagsUnselected(t *testing.T) {
+	initial := core.LocalContainerConfig{
+		Runtime: "prior", Image: "example:prior", User: "prior-user", WorkRoot: "prior-root",
+		CPUs: 5, Memory: "5g", Network: "prior-network", DockerSocket: true, NoHostname: true,
+	}
+	for _, tc := range []struct {
+		name                 string
+		args                 []string
+		want                 core.LocalContainerConfig
+		runtime, image, root bool
+		user                 bool
+	}{
+		{name: "unvisited", want: initial},
+		{name: "equal", args: []string{"--local-container-runtime=prior", "--local-container-image=example:prior", "--local-container-user=prior-user", "--local-container-work-root=prior-root", "--local-container-cpus=5", "--local-container-memory=5g", "--local-container-network=prior-network", "--local-container-docker-socket=true"}, want: initial, runtime: true, image: true, root: true, user: true},
+		{name: "empty zero false", args: []string{"--local-container-runtime=", "--local-container-image=", "--local-container-user=", "--local-container-work-root=", "--local-container-cpus=0", "--local-container-memory=", "--local-container-network=", "--local-container-docker-socket=false"}, want: core.LocalContainerConfig{NoHostname: true}, runtime: true, image: true, root: true, user: true},
+		{name: "raw values", args: []string{"--local-container-runtime= custom ", "--local-container-image= example:new ", "--local-container-user= new-user ", "--local-container-work-root=~/literal ", "--local-container-cpus=-2", "--local-container-memory= 7g ", "--local-container-network= custom ", "--local-container-docker-socket=false"}, want: core.LocalContainerConfig{Runtime: " custom ", Image: " example:new ", User: " new-user ", WorkRoot: "~/literal ", CPUs: -2, Memory: " 7g ", Network: " custom ", NoHostname: true}, runtime: true, image: true, root: true, user: true},
+		{name: "runtime event only", args: []string{"--local-container-runtime=prior"}, want: initial, runtime: true},
+		{name: "image event only", args: []string{"--local-container-image=example:prior"}, want: initial, image: true},
+		{name: "root event only", args: []string{"--local-container-work-root=prior-root"}, want: initial, root: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := core.Config{Provider: "unselected-config-test", SSHUser: "generic-user", WorkRoot: "generic-root", LocalContainer: initial}
+			core.MarkWorkRootExplicit(&cfg)
+			defaults := core.Config{LocalContainer: core.LocalContainerConfig{Runtime: "registration", Image: "example:registration", User: "registration", WorkRoot: "registration", CPUs: 9, Memory: "9g", Network: "registration"}}
+			fs := flag.NewFlagSet(tc.name, flag.ContinueOnError)
+			provider := Provider{}
+			values := provider.RegisterFlags(fs, defaults)
+			if err := fs.Parse(tc.args); err != nil {
+				t.Fatal(err)
+			}
+			want := cfg
+			want.LocalContainer = tc.want
+			if tc.runtime {
+				core.MarkLocalContainerRuntimeExplicit(&want)
+			}
+			if tc.image {
+				core.MarkLocalContainerImageExplicit(&want)
+			}
+			if tc.root {
+				want.WorkRoot = tc.want.WorkRoot
+				core.MarkWorkRootExplicit(&want)
+				core.MarkLocalContainerWorkRootExplicit(&want)
+			}
+			if tc.user {
+				want.SSHUser = tc.want.User
+			}
+			if err := provider.ApplyFlags(&cfg, fs, values); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(cfg, want) {
+				t.Fatal("scalar flags changed values, generic copies, or explicit-source markers")
+			}
+			wantExplicit := !tc.root || tc.want.WorkRoot != ""
+			if core.IsWorkRootExplicit(&cfg) != wantExplicit {
+				t.Fatal("generic root marker did not snapshot the accepted string")
+			}
+			cfg.WorkRoot = "later-raw-root"
+			if wantExplicit {
+				cfg.WorkRoot = ""
+			}
+			if core.IsWorkRootExplicit(&cfg) != wantExplicit {
+				t.Fatal("later raw root assignment changed the explicit snapshot")
+			}
+		})
+	}
+}
 
 func TestNormalizeConfigForShowPreservesUnrelatedSettings(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())

--- a/internal/providers/localcontainer/flags.go
+++ b/internal/providers/localcontainer/flags.go
@@ -44,7 +44,7 @@ func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
 	}
 	// CLI-only: bind mounts expose host paths and must be an explicit
 	// operator action. Not loaded from repo-local .crabbox.yaml — see
-	// the comment in config.go where YAML ingestion is blocked.
+	// the omission comment in config_local_container.go.
 	fs.Var(&volumes, "local-container-volume",
 		"bind-mount a host path into the container; host:container[:ro]; repeatable")
 	return v
@@ -56,22 +56,19 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 		return nil
 	}
 	if core.FlagWasSet(fs, "local-container-runtime") {
-		cfg.LocalContainer.Runtime = *v.Runtime
-		core.MarkLocalContainerRuntimeExplicit(cfg)
+		core.ApplyLocalContainerRuntime(cfg, *v.Runtime)
 	}
 	if core.FlagWasSet(fs, "local-container-image") {
-		cfg.LocalContainer.Image = *v.Image
-		core.MarkLocalContainerImageExplicit(cfg)
+		core.ApplyLocalContainerImage(cfg, *v.Image)
 	}
 	if core.FlagWasSet(fs, "local-container-user") {
 		cfg.LocalContainer.User = *v.User
 		cfg.SSHUser = *v.User
 	}
 	if core.FlagWasSet(fs, "local-container-work-root") {
-		cfg.LocalContainer.WorkRoot = *v.WorkRoot
+		core.ApplyLocalContainerWorkRoot(cfg, *v.WorkRoot)
 		cfg.WorkRoot = *v.WorkRoot
 		core.MarkWorkRootExplicit(cfg)
-		core.MarkLocalContainerWorkRootExplicit(cfg)
 	}
 	if core.FlagWasSet(fs, "local-container-cpus") {
 		cfg.LocalContainer.CPUs = *v.CPUs


### PR DESCRIPTION
## Summary

Give Local Container one concrete home for its complete runtime value, distinct file shape, initialization and nine file/environment settings. Three accepted-input operations pair runtime, image and work-root values with their existing source markers, so those updates no longer drift across file, environment and flags.

Keep the deliberate differences: the runtime value has eleven members, the file schema nine. Two file booleans preserve presence; NoHostname remains file/environment-only. Volumes stay CLI-only and checkpoint metadata stays transient. File CPU input remains positive-only, environment CPU parsing tolerant, raw initial WorkRoot empty, and source strings unchanged.

The provider retains flag storage, raw volume-list behavior, creation-only checks and its default hook. Only the three scalar source events delegate to the new owner. The provider work-root bit moves across independent generic assignments; the generic root copy/snapshot and later observable state remain unchanged. No callback framework, generator extension, native lifecycle change, credential change or dependency is introduced.

Provider documentation, the concrete-owner guide and changelog explain these boundaries. Existing tests and checkpoint implementation are untouched.

## Verification

Seven focused tests passed before production edits and on the candidate. They cover the eleven-member initializer, nine file/env settings, source markers, positive-file/tolerant-env CPU behavior, pointer boolean layering, runtime-only list/map preservation, writer output and eight unselected scalar flags. Existing test bodies remain unchanged.

The combination with current main passed 45 distinct configuration tests, 34 generated-file freshness checks, seven-package vet and build. One shared marker test belongs to both reference groups and ran only once. Source files, modes, index and immutable prior proof stayed unchanged. Independent source review and managed Codex reviews found no accepted actionable finding; the documentation build passed.

```sh
go test -race ./scripts/configgen -run GeneratedConfigIsCurrent$ -count=1 -timeout=3m -v
go vet ./internal/cli ./internal/providers/localcontainer ./internal/providers/applevm ./internal/providers/applecontainer ./internal/providers/applemachine ./internal/providers/kubevirt ./internal/providers/sealosdevbox
```

All 29 frozen public CLI cases matched the original baseline and first candidate exactly, including raw stdout/stderr, exit/timeout results and written bytes: 28 successes and one preserved CPU-flag parser error, no differences or timeouts. Final binary SHA256: `f45b0972a6240552941b0e71faa4d98a569cc3ce95ff47d2e6851d99b7c927be`.

Actual candidate output excerpts, extracted after comparison without changing the raw captures:

| Existing case | Observed localContainer field |
| --- | --- |
| File user | `user: "alice"` |
| Environment user override | `user: "bob"` |
| File work root | `workRoot: "/work/synthetic"` |
| Environment work-root override | `workRoot: "/work/other"` |

The writer case also retained the actual YAML line `noHostname: true`. That proves persistence only: NoHostname is not exposed in config JSON. The provider CPU flag is a local parser observation, not a runtime flag claim.

Public CLI cases kept runtime=docker, the populated default image and dockerSocket=false. No Docker daemon, socket/mount, volume, checkpoint, SSH, cloud or native-provider operation is claimed. Direct configuration tests cover field/marker state; unchanged provider code retains the native responsibilities.
