### PR TITLE
refactor(config): share XCP-ng selector overlays

### DIFF
--- a/docs/providers/xcp-ng.md
+++ b/docs/providers/xcp-ng.md
@@ -148,6 +148,12 @@ doctor and lifecycle commands. A template name or UUID is required before
 optional placement hints. `user` becomes the cloud-init SSH user, and
 `workRoot` becomes the remote workspace root.
 
+For each template, SR, or network name/UUID pair, file and environment layers
+replace the whole pair when either input is nonempty: name-only clears an
+inherited UUID, UUID-only clears an inherited name, and both inputs keep both
+raw values. Two empty inputs preserve the prior values. Flags remain sequential,
+and the UUID wins if both flags in a pair are visited.
+
 When `network` or `networkUuid` is set, Crabbox moves all VIFs on the copied VM
 to the selected network. Use a single-NIC template for Crabbox-managed VMs, or
 leave the setting unset when the template's network topology should be

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -814,6 +814,15 @@ type XCPNgConfig struct {
 	InsecureTLS  bool
 }
 
+// A nonempty selector replaces the whole layer's name/UUID pair; two empty inputs inherit it.
+func applyXCPNgNameUUIDPair(dstName, dstUUID *string, incomingName, incomingUUID string) {
+	if incomingName == "" && incomingUUID == "" {
+		return
+	}
+	*dstName = incomingName
+	*dstUUID = incomingUUID
+}
+
 type IncusConfig struct {
 	CheckpointMetadata map[string]string `yaml:"-" json:"-"`
 	Remote             string
@@ -4508,42 +4517,9 @@ func applyFileConfigWithTrustAndProviderSource(cfg *Config, file fileConfig, tru
 		if trusted && file.XCPNg.Password != "" {
 			cfg.XCPNg.Password = file.XCPNg.Password
 		}
-		if file.XCPNg.Template != "" {
-			cfg.XCPNg.Template = file.XCPNg.Template
-			if file.XCPNg.TemplateUUID == "" {
-				cfg.XCPNg.TemplateUUID = ""
-			}
-		}
-		if file.XCPNg.TemplateUUID != "" {
-			cfg.XCPNg.TemplateUUID = file.XCPNg.TemplateUUID
-			if file.XCPNg.Template == "" {
-				cfg.XCPNg.Template = ""
-			}
-		}
-		if file.XCPNg.SR != "" {
-			cfg.XCPNg.SR = file.XCPNg.SR
-			if file.XCPNg.SRUUID == "" {
-				cfg.XCPNg.SRUUID = ""
-			}
-		}
-		if file.XCPNg.SRUUID != "" {
-			cfg.XCPNg.SRUUID = file.XCPNg.SRUUID
-			if file.XCPNg.SR == "" {
-				cfg.XCPNg.SR = ""
-			}
-		}
-		if file.XCPNg.Network != "" {
-			cfg.XCPNg.Network = file.XCPNg.Network
-			if file.XCPNg.NetworkUUID == "" {
-				cfg.XCPNg.NetworkUUID = ""
-			}
-		}
-		if file.XCPNg.NetworkUUID != "" {
-			cfg.XCPNg.NetworkUUID = file.XCPNg.NetworkUUID
-			if file.XCPNg.Network == "" {
-				cfg.XCPNg.Network = ""
-			}
-		}
+		applyXCPNgNameUUIDPair(&cfg.XCPNg.Template, &cfg.XCPNg.TemplateUUID, file.XCPNg.Template, file.XCPNg.TemplateUUID)
+		applyXCPNgNameUUIDPair(&cfg.XCPNg.SR, &cfg.XCPNg.SRUUID, file.XCPNg.SR, file.XCPNg.SRUUID)
+		applyXCPNgNameUUIDPair(&cfg.XCPNg.Network, &cfg.XCPNg.NetworkUUID, file.XCPNg.Network, file.XCPNg.NetworkUUID)
 		if file.XCPNg.Host != "" {
 			cfg.XCPNg.Host = file.XCPNg.Host
 		}
@@ -6553,44 +6529,11 @@ func applyEnv(cfg *Config) error {
 	cfg.XCPNg.Username = getenv("CRABBOX_XCP_NG_USERNAME", cfg.XCPNg.Username)
 	cfg.XCPNg.Password = getenv("CRABBOX_XCP_NG_PASSWORD", cfg.XCPNg.Password)
 	xcpNgTemplate, xcpNgTemplateUUID := os.Getenv("CRABBOX_XCP_NG_TEMPLATE"), os.Getenv("CRABBOX_XCP_NG_TEMPLATE_UUID")
-	if xcpNgTemplate != "" {
-		cfg.XCPNg.Template = xcpNgTemplate
-		if xcpNgTemplateUUID == "" {
-			cfg.XCPNg.TemplateUUID = ""
-		}
-	}
-	if xcpNgTemplateUUID != "" {
-		cfg.XCPNg.TemplateUUID = xcpNgTemplateUUID
-		if xcpNgTemplate == "" {
-			cfg.XCPNg.Template = ""
-		}
-	}
+	applyXCPNgNameUUIDPair(&cfg.XCPNg.Template, &cfg.XCPNg.TemplateUUID, xcpNgTemplate, xcpNgTemplateUUID)
 	xcpNgSR, xcpNgSRUUID := os.Getenv("CRABBOX_XCP_NG_SR"), os.Getenv("CRABBOX_XCP_NG_SR_UUID")
-	if xcpNgSR != "" {
-		cfg.XCPNg.SR = xcpNgSR
-		if xcpNgSRUUID == "" {
-			cfg.XCPNg.SRUUID = ""
-		}
-	}
-	if xcpNgSRUUID != "" {
-		cfg.XCPNg.SRUUID = xcpNgSRUUID
-		if xcpNgSR == "" {
-			cfg.XCPNg.SR = ""
-		}
-	}
+	applyXCPNgNameUUIDPair(&cfg.XCPNg.SR, &cfg.XCPNg.SRUUID, xcpNgSR, xcpNgSRUUID)
 	xcpNgNetwork, xcpNgNetworkUUID := os.Getenv("CRABBOX_XCP_NG_NETWORK"), os.Getenv("CRABBOX_XCP_NG_NETWORK_UUID")
-	if xcpNgNetwork != "" {
-		cfg.XCPNg.Network = xcpNgNetwork
-		if xcpNgNetworkUUID == "" {
-			cfg.XCPNg.NetworkUUID = ""
-		}
-	}
-	if xcpNgNetworkUUID != "" {
-		cfg.XCPNg.NetworkUUID = xcpNgNetworkUUID
-		if xcpNgNetwork == "" {
-			cfg.XCPNg.Network = ""
-		}
-	}
+	applyXCPNgNameUUIDPair(&cfg.XCPNg.Network, &cfg.XCPNg.NetworkUUID, xcpNgNetwork, xcpNgNetworkUUID)
 	cfg.XCPNg.Host = getenv("CRABBOX_XCP_NG_HOST", cfg.XCPNg.Host)
 	cfg.XCPNg.User = getenv("CRABBOX_XCP_NG_USER", cfg.XCPNg.User)
 	cfg.XCPNg.WorkRoot = getenv("CRABBOX_XCP_NG_WORK_ROOT", cfg.XCPNg.WorkRoot)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -7672,36 +7672,128 @@ func TestRepoConfigCannotRedirectInheritedXCPNgCredentials(t *testing.T) {
 }
 
 func TestXCPNgHigherPrecedenceNamesClearInheritedUUIDs(t *testing.T) {
-	clearConfigEnv(t)
-	cfg := baseConfig()
-	cfg.XCPNg.TemplateUUID = "old-template-uuid"
-	cfg.XCPNg.SRUUID = "old-sr-uuid"
-	cfg.XCPNg.NetworkUUID = "old-network-uuid"
-	if err := applyFileConfig(&cfg, fileConfig{XCPNg: &fileXCPNgConfig{
-		Template: "new-template",
-		SR:       "new-sr",
-		Network:  "new-network",
-	}}); err != nil {
-		t.Fatal(err)
+	// Values are ordered as Template, TemplateUUID, SR, SRUUID, Network, NetworkUUID.
+	type selectors [6]string
+	prior := selectors{"old-template", "old-template-uuid", "old-sr", "old-sr-uuid", "old-network", "old-network-uuid"}
+	tests := []struct {
+		name     string
+		absent   bool
+		in, want selectors
+	}{
+		{name: "absent", absent: true, want: prior},
+		{name: "both empty", want: prior},
+		{
+			name: "name only",
+			in:   selectors{"new-template", "", "new-sr", "", "new-network", ""},
+			want: selectors{"new-template", "", "new-sr", "", "new-network", ""},
+		},
+		{
+			name: "uuid only",
+			in:   selectors{"", "new-template-uuid", "", "new-sr-uuid", "", "new-network-uuid"},
+			want: selectors{"", "new-template-uuid", "", "new-sr-uuid", "", "new-network-uuid"},
+		},
+		{
+			name: "both populated",
+			in:   selectors{"new-template", "new-template-uuid", "new-sr", "new-sr-uuid", "new-network", "new-network-uuid"},
+			want: selectors{"new-template", "new-template-uuid", "new-sr", "new-sr-uuid", "new-network", "new-network-uuid"},
+		},
+		{
+			name: "template empty with other updates",
+			in:   selectors{"", "", "new-sr", "", "", "new-network-uuid"},
+			want: selectors{"old-template", "old-template-uuid", "new-sr", "", "", "new-network-uuid"},
+		},
+		{
+			name: "sr empty with other updates",
+			in:   selectors{"", "new-template-uuid", "", "", "new-network", ""},
+			want: selectors{"", "new-template-uuid", "old-sr", "old-sr-uuid", "new-network", ""},
+		},
+		{
+			name: "network empty with other updates",
+			in:   selectors{"new-template", "", "", "new-sr-uuid", "", ""},
+			want: selectors{"new-template", "", "", "new-sr-uuid", "old-network", "old-network-uuid"},
+		},
+		{
+			name: "equal name only clears uuid",
+			in:   selectors{"old-template", "", "old-sr", "", "old-network", ""},
+			want: selectors{"old-template", "", "old-sr", "", "old-network", ""},
+		},
+		{
+			name: "equal uuid only clears name",
+			in:   selectors{"", "old-template-uuid", "", "old-sr-uuid", "", "old-network-uuid"},
+			want: selectors{"", "old-template-uuid", "", "old-sr-uuid", "", "old-network-uuid"},
+		},
+		{
+			name: "whitespace name only",
+			in:   selectors{" ", "", "\t", "", " \t ", ""},
+			want: selectors{" ", "", "\t", "", " \t ", ""},
+		},
+		{
+			name: "whitespace uuid only",
+			in:   selectors{"", "\t ", "", " \t", "", "\t\t"},
+			want: selectors{"", "\t ", "", " \t", "", "\t\t"},
+		},
+		{
+			name: "both raw padded values",
+			in:   selectors{" template ", " template-uuid\t", " sr ", " sr-uuid\t", " network ", " network-uuid\t"},
+			want: selectors{" template ", " template-uuid\t", " sr ", " sr-uuid\t", " network ", " network-uuid\t"},
+		},
 	}
-	if cfg.XCPNg.TemplateUUID != "" || cfg.XCPNg.SRUUID != "" || cfg.XCPNg.NetworkUUID != "" {
-		t.Fatalf("file names did not clear inherited UUIDs: %#v", cfg.XCPNg)
-	}
-
-	cfg.XCPNg.TemplateUUID = "old-template-uuid"
-	cfg.XCPNg.SRUUID = "old-sr-uuid"
-	cfg.XCPNg.NetworkUUID = "old-network-uuid"
-	t.Setenv("CRABBOX_XCP_NG_TEMPLATE", "env-template")
-	t.Setenv("CRABBOX_XCP_NG_TEMPLATE_UUID", "")
-	t.Setenv("CRABBOX_XCP_NG_SR", "env-sr")
-	t.Setenv("CRABBOX_XCP_NG_SR_UUID", "")
-	t.Setenv("CRABBOX_XCP_NG_NETWORK", "env-network")
-	t.Setenv("CRABBOX_XCP_NG_NETWORK_UUID", "")
-	if err := applyEnv(&cfg); err != nil {
-		t.Fatal(err)
-	}
-	if cfg.XCPNg.TemplateUUID != "" || cfg.XCPNg.SRUUID != "" || cfg.XCPNg.NetworkUUID != "" {
-		t.Fatalf("environment names did not clear inherited UUIDs: %#v", cfg.XCPNg)
+	for _, source := range []string{"file", "env"} {
+		for _, tt := range tests {
+			t.Run(source+"/"+tt.name, func(t *testing.T) {
+				clearConfigEnv(t)
+				for _, key := range []string{"CRABBOX_PROVIDER", "CRABBOX_OS", "CRABBOX_WORK_ROOT", "CRABBOX_USER", "CRABBOX_SSH_USER", "CRABBOX_XCP_NG_HOST", "CRABBOX_XCP_NG_USER", "CRABBOX_XCP_NG_WORK_ROOT"} {
+					t.Setenv(key, "")
+				}
+				cfg := baseConfig()
+				cfg.Provider = "unselected-config-test"
+				cfg.XCPNg = XCPNgConfig{
+					Template: prior[0], TemplateUUID: prior[1],
+					SR: prior[2], SRUUID: prior[3],
+					Network: prior[4], NetworkUUID: prior[5],
+					Host: "prior-host", User: "prior-user", WorkRoot: t.TempDir(),
+				}
+				want := cfg.XCPNg
+				want.Template, want.TemplateUUID = tt.want[0], tt.want[1]
+				want.SR, want.SRUUID = tt.want[2], tt.want[3]
+				want.Network, want.NetworkUUID = tt.want[4], tt.want[5]
+				if source == "file" {
+					file := fileConfig{}
+					wantFile := fileConfig{}
+					if !tt.absent {
+						input := fileXCPNgConfig{
+							Template: tt.in[0], TemplateUUID: tt.in[1],
+							SR: tt.in[2], SRUUID: tt.in[3],
+							Network: tt.in[4], NetworkUUID: tt.in[5],
+						}
+						inputCopy := input
+						file.XCPNg, wantFile.XCPNg = &input, &inputCopy
+					}
+					if err := applyFileConfig(&cfg, file); err != nil {
+						t.Fatal(err)
+					}
+					if !reflect.DeepEqual(file, wantFile) {
+						t.Fatal("file input changed")
+					}
+				} else {
+					for i, key := range []string{"TEMPLATE", "TEMPLATE_UUID", "SR", "SR_UUID", "NETWORK", "NETWORK_UUID"} {
+						key = "CRABBOX_XCP_NG_" + key
+						t.Setenv(key, tt.in[i])
+						if tt.absent {
+							if err := os.Unsetenv(key); err != nil {
+								t.Fatal(err)
+							}
+						}
+					}
+					if err := applyEnv(&cfg); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if !reflect.DeepEqual(cfg.XCPNg, want) {
+					t.Fatalf("XCPNg=%#v, want %#v", cfg.XCPNg, want)
+				}
+			})
+		}
 	}
 }
 

--- a/internal/providers/xcpng/provider_test.go
+++ b/internal/providers/xcpng/provider_test.go
@@ -140,6 +140,29 @@ func TestFlagsClearStaleNameUUIDCounterparts(t *testing.T) {
 				NetworkUUID:  "net-0002",
 			},
 		},
+		{
+			name: "both flags uuid wins after name",
+			args: []string{
+				"--xcp-ng-template", "Other Template", "--xcp-ng-template-uuid", xcpNgTestVMUUID,
+				"--xcp-ng-sr", "other-sr", "--xcp-ng-sr-uuid", "sr-0002",
+				"--xcp-ng-network", "other-network", "--xcp-ng-network-uuid", "net-0002",
+			},
+			want: core.XCPNgConfig{TemplateUUID: xcpNgTestVMUUID, SRUUID: "sr-0002", NetworkUUID: "net-0002"},
+		},
+		{
+			name: "both flags uuid wins before name",
+			args: []string{
+				"--xcp-ng-template-uuid", xcpNgTestVMUUID, "--xcp-ng-template", "Other Template",
+				"--xcp-ng-sr-uuid", "sr-0002", "--xcp-ng-sr", "other-sr",
+				"--xcp-ng-network-uuid", "net-0002", "--xcp-ng-network", "other-network",
+			},
+			want: core.XCPNgConfig{TemplateUUID: xcpNgTestVMUUID, SRUUID: "sr-0002", NetworkUUID: "net-0002"},
+		},
+		{
+			name: "empty uuid flags clear stale names",
+			args: []string{"--xcp-ng-template-uuid=", "--xcp-ng-sr-uuid=", "--xcp-ng-network-uuid="},
+			want: core.XCPNgConfig{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Replace six repeated XCP-ng name/UUID overlay blocks with one private typed helper beside the existing configuration type. Template, storage repository, and network selectors share the same whole-layer rule across file and environment input: either nonempty input replaces both members, while two empty inputs preserve the inherited pair. This removes 66 production lines without a new framework or configuration migration.

Keep the source distinction: file/environment layers retain both supplied values, while flags apply sequentially and UUID wins when both flags are visited. Equal values still clear a stale counterpart; whitespace remains raw. The helper does not trim, validate, add markers, or change source admission. Types, defaults, provider flags, generic projections, and native implementations remain unchanged. Provider documentation now explains this existing behavior.

This is an internal behavior-preserving refactor, not a new feature or user-visible fix, so no changelog or version change is included. No dependency or credential change.

## Verification

The expanded existing tests passed on the old implementation before production edits and on the candidate: two focused tests with 31 subtests. They cover all three distinct pairs, omission/empty values, name-only, UUID-only, both, mixed updates, equal values, raw whitespace, unchanged file input, and the separate flag precedence controls. The baseline test patch remained unchanged after implementation.

```sh
go test -race ./internal/cli ./internal/providers/xcpng -run '^(TestXCPNgHigherPrecedenceNamesClearInheritedUUIDs|TestFlagsClearStaleNameUUIDCounterparts)$' -count=1 -timeout=3m -v
go test -race ./scripts/configgen -run 'GeneratedConfigIsCurrent$' -count=1 -timeout=3m -v
go vet ./internal/cli ./internal/providers/xcpng
go build -trimpath -buildvcs=false -o '<task-owned-output>' ./cmd/crabbox
node scripts/build-docs-site.mjs
```

All 34 generated-file freshness checks, vet, build, and documentation build passed. The Go checks used an isolated credential-free environment with network access denied. Source bytes/modes and index remained unchanged through validation. Independent source review found no actionable issue; managed Codex review was scoped-clean at P0.

Nine frozen synthetic cases ran through `config show --provider xcp-ng --json` on the old and new built CLIs. Every case exited zero without timeout and matched its literal six-field expectation. Complete stdout, stderr, and outcomes matched byte-for-byte, with no normalization or changed expectations. Candidate binary SHA256: `c6eaaa90aaa8ca04caff0969bcbdcb44190c9b006a7826ca4a1268a2c6a53df6`.

Actual candidate observations (each cell is name / UUID):

| Case | Template | Storage repository | Network |
| --- | --- | --- | --- |
| Environment names | `"env-template" / ""` | `"env-sr" / ""` | `"env-network" / ""` |
| Environment UUIDs | `"" / "env-template-uuid"` | `"" / "env-sr-uuid"` | `"" / "env-network-uuid"` |
| Both environment values | `"env-template" / "env-template-uuid"` | `"env-sr" / "env-sr-uuid"` | `"env-network" / "env-network-uuid"` |
| Mixed environment layer | `"old-template" / "old-template-uuid"` | `"env-sr" / ""` | `"" / "env-network-uuid"` |

These are configuration-rendering observations using isolated synthetic files and environment variables, without a broker, endpoint, password, or provider discovery. No VM creation/deletion, XAPI, SSH, native lifecycle, or credential/security probe was performed or is claimed.
