### PR TITLE
fix(images): preserve the runtime user's selected pnpm default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Seed the Linux developer image user's selected pnpm default after privileged preparation and reject offline source, candidate, or promoted default drift without changing project pins.
+
 - Fix image qualification bundles to include the Linux smoke script and admit publisher cleanup-owned rollback without disarming promotion early. [PR #2062](https://github.com/openclaw/crabbox/pull/2062) Thanks @vincentkoc.
 
 - Repair stale coordinator host associations against canonical lease state during pinned creation, preserving in-flight and retained instances; add admin host reservation inspection and guarded clearing. [PR 2057](https://github.com/openclaw/crabbox/pull/2057). Thanks @steipete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Seed the Linux developer image user's selected pnpm default after privileged preparation and reject offline source, candidate, or promoted default drift without changing project pins.
+- Seed the Linux developer image user's selected pnpm default after privileged preparation and reject offline source, candidate, or promoted default drift without changing project pins. [PR #2065](https://github.com/openclaw/crabbox/pull/2065) Thanks @vincentkoc.
 
 - Fix image qualification bundles to include the Linux smoke script and admit publisher cleanup-owned rollback without disarming promotion early. [PR #2062](https://github.com/openclaw/crabbox/pull/2062) Thanks @vincentkoc.
 

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -650,10 +650,27 @@ boots independently rerun the declared probes under a sanitized system PATH
 before skipping baseline APT. Use the timing logs to compare provider request,
 network readiness, bootstrap, and end-to-end time before and after each bake.
 
-Linux source, candidate, and promoted smokes require a nonroot user and execute
-the normal `pnpm --version` command in that user's existing environment, preserving
-its readiness check and first-use cache warming. This normal command is not
-used to authenticate cached archives or skip their verification.
+Linux source, candidate, and promoted smokes require a nonroot user. After
+successful bundled Linux preparation, the wrapper activates the selected pnpm
+release as the lease user: the privileged installer only seeds root's Corepack
+cache. The existing `CRABBOX_LINUX_PNPM_VERSION` selector is passed unchanged to
+Corepack, including tags, ranges, and integrity-qualified versions.
+
+Before image capture, the wrapper records the resolved ordinary `pnpm --version`
+outside the checkout, using the lease user's normal home/cache and disabling
+Corepack network access for the probe. It also requires `corepack pnpm --version`
+to agree, rejecting version disagreement from a shadowing command. Each later
+smoke checks that same resolved default offline without reactivating it or
+resolving the selector again.
+Preparation, capture, or version mismatch failures stop publication and follow
+the existing lease cleanup and promotion rollback paths.
+
+This establishes the image user's initial default, not a permanent version lock.
+Project `packageManager` pins and existing cached releases remain usable; no
+shared Corepack home is introduced. Custom prep scripts and Windows retain their
+existing behavior, and the standalone root installer does not configure arbitrary
+users. These normal-command checks do not authenticate cached archives or skip
+their verification.
 
 For the bundled Node-24/amd64 builder, each smoke additionally revalidates public
 archive bytes in private temporary directories. It executes fresh Node and both

--- a/scripts/devtools-image-smoke-linux.sh
+++ b/scripts/devtools-image-smoke-linux.sh
@@ -18,7 +18,21 @@ command -v docker
 node --version
 node -e 'const major = process.versions.node.split(".")[0]; const expected = process.argv[1]; if (expected ? major !== expected : Number(major) < 24) throw new Error("Node.js " + (expected ? "major " + expected : "24 or newer") + " is required, found " + process.version)' -- "$expected_node_major"
 corepack --version
-pnpm --version
+if [[ -n "${expected_pnpm_version:-}" ]]; then
+  (
+    cd /
+    version="$(COREPACK_ENABLE_NETWORK=0 pnpm --version)"
+    [[ "$version" == "$expected_pnpm_version" ]] || {
+      printf 'pnpm default mismatch: expected %s, found %s\n' "$expected_pnpm_version" "$version" >&2
+      exit 1
+    }
+    corepack_version="$(COREPACK_ENABLE_NETWORK=0 corepack pnpm --version)"
+    [[ "$version" == "$corepack_version" ]] || { echo 'ordinary pnpm does not match Corepack' >&2; exit 1; }
+    printf '%s\n' "$version"
+  )
+else
+  pnpm --version
+fi
 docker_group_member() {
   if id -nG 2>/dev/null | tr ' ' '\n' | grep -qx docker; then
     return 0

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -29,6 +29,7 @@ windows_mode="${CRABBOX_WINDOWS_MODE:-normal}"
 prep_script="${CRABBOX_IMAGE_PREP_SCRIPT:-}"
 linux_node_major="${CRABBOX_LINUX_NODE_MAJOR:-24}"
 linux_pnpm_version="${CRABBOX_LINUX_PNPM_VERSION:-11.1.0}"
+linux_pnpm_default=""
 measured=0
 max_p95_runner_total_ms=""
 measurement_dir=""
@@ -804,8 +805,8 @@ smoke_script() {
       )" || return $?
       archive_probe+=$'\n'"$go_archive_probe"$'\n'"$bun_archive_probe"
     fi
-    printf -v smoke_script_value 'set -euo pipefail\nexpected_node_major=%q\ndeveloper_archive_probe() {\n%s\n}\n%s' \
-      "$expected_node_major" "$archive_probe" "$smoke_script_value"
+    printf -v smoke_script_value 'set -euo pipefail\nexpected_node_major=%q\nexpected_pnpm_version=%q\ndeveloper_archive_probe() {\n%s\n}\n%s' \
+      "$expected_node_major" "$linux_pnpm_default" "$archive_probe" "$smoke_script_value"
   fi
 }
 
@@ -849,7 +850,32 @@ run_prep() {
     # Prep and every smoke must use the same declared overrides, not ambient guest state.
     run_cmd env CRABBOX_LINUX_NODE_MAJOR="$linux_node_major" CRABBOX_LINUX_PNPM_VERSION="$linux_pnpm_version" \
       "$CRABBOX_BIN" run --provider aws --target "$target" --id "$lease" --no-sync \
-      --allow-env CRABBOX_LINUX_NODE_MAJOR,CRABBOX_LINUX_PNPM_VERSION --script "$prep_script"
+      --allow-env CRABBOX_LINUX_NODE_MAJOR,CRABBOX_LINUX_PNPM_VERSION --script "$prep_script" || return $?
+    # sudo preparation seeds root's Corepack state, not the lease user's default.
+    local pnpm_command pnpm_capture
+    printf -v pnpm_command 'set -euo pipefail\n[[ "$(id -u)" -ne 0 ]] || { echo "pnpm preparation requires a nonroot user" >&2; exit 1; }\ncd /\ncorepack prepare %q --activate >&2\n' "pnpm@$linux_pnpm_version"
+    pnpm_command+='version="$(COREPACK_ENABLE_NETWORK=0 pnpm --version)"
+corepack_version="$(COREPACK_ENABLE_NETWORK=0 corepack pnpm --version)"
+[[ "$version" == "$corepack_version" ]] || { echo "ordinary pnpm does not match Corepack" >&2; exit 1; }
+printf "%s\n" "$version"'
+    pnpm_capture="$(mktemp "$log_dir/.image-mint-pnpm-${log_id}.XXXXXX")" || return $?
+    run_cmd "$CRABBOX_BIN" run --provider aws --target linux --id "$lease" --no-sync \
+      --capture-stdout "$pnpm_capture" --shell -- "$pnpm_command" || return $?
+    # Bound the read and reject extra output before rendering it into later smokes.
+    linux_pnpm_default="$(node - "$pnpm_capture" <<'NODE'
+const fs = require("node:fs");
+const fd = fs.openSync(process.argv[2], "r");
+const bytes = Buffer.alloc(130);
+const length = fs.readSync(fd, bytes, 0, bytes.length, 0);
+fs.closeSync(fd);
+const version = bytes.subarray(0, length).toString("latin1");
+if (!/^[!-~]{1,128}\n$/.test(version)) {
+  console.error("invalid runtime-user pnpm version: expected one bounded version line");
+  process.exit(1);
+}
+process.stdout.write(version.slice(0, -1));
+NODE
+    )" || return $?
   else
     run_cmd "$CRABBOX_BIN" run --provider aws --target "$target" --id "$lease" --no-sync --script "$prep_script"
   fi

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -63,6 +63,30 @@ case "$1" in
   run)
     if [[ " $* " == *" --allow-env CRABBOX_LINUX_NODE_MAJOR,CRABBOX_LINUX_PNPM_VERSION "* ]]; then
       printf 'builder overrides node=%s pnpm=%s\\n' "\${CRABBOX_LINUX_NODE_MAJOR:-}" "\${CRABBOX_LINUX_PNPM_VERSION:-}" >>"\${CRABBOX_FAKE_LOG}"
+      [[ "\${CRABBOX_FAKE_PREP_EXIT:-0}" == "0" ]] || exit "$CRABBOX_FAKE_PREP_EXIT"
+    fi
+    capture=""
+    lease=""
+    previous=""
+    for arg in "$@"; do
+      [[ "$previous" != "--capture-stdout" ]] || capture="$arg"
+      [[ "$previous" != "--id" ]] || lease="$arg"
+      previous="$arg"
+    done
+    if [[ -n "$capture" ]]; then
+      if [[ -n "\${CRABBOX_FAKE_PNPM_RUNNER:-}" ]]; then
+        "$CRABBOX_FAKE_PNPM_RUNNER" "$lease" "\${@: -1}" >"$capture" || exit $?
+      else
+        printf '%s\\n' "\${CRABBOX_FAKE_RESOLVED_PNPM:-11.1.0}" >"$capture"
+      fi
+      if [[ -n "\${CRABBOX_FAKE_CAPTURE_BASE64+x}" ]]; then
+        node -e 'require("node:fs").writeFileSync(process.argv[1], Buffer.from(process.argv[2], "base64"))' "$capture" "$CRABBOX_FAKE_CAPTURE_BASE64"
+      fi
+      exit "\${CRABBOX_FAKE_CAPTURE_EXIT:-0}"
+    fi
+    if [[ -n "\${CRABBOX_FAKE_PNPM_RUNNER:-}" && "\${@: -1}" == *"docker_probe="* ]]; then
+      "$CRABBOX_FAKE_PNPM_RUNNER" "$lease" "\${@: -1}" || exit $?
+      exit 0
     fi
     if [[ -n "\${CRABBOX_FAKE_SMOKE_FAIL_LEASE:-}" && " $* " == *" --id \${CRABBOX_FAKE_SMOKE_FAIL_LEASE} "* && "\${@: -1}" == *"docker_probe="* ]]; then
       printf 'offline artifact smoke failed\\n' >&2
@@ -180,6 +204,167 @@ function runScript(args, env, scriptPath = script, onOutput) {
   });
 }
 
+async function runtimePnpmFixture(t, options = {}) {
+  const fake = await setupFakeCrabbox();
+  t.after(() => rm(fake.dir, { recursive: true, force: true }));
+  const bin = path.join(fake.dir, "bin");
+  await mkdir(bin);
+  const writeTool = async (name, body) => {
+    const file = path.join(bin, name);
+    await writeFile(file, `#!/usr/bin/env bash\nset -euo pipefail\n${body}\n`);
+    await chmod(file, 0o755);
+  };
+  for (const tool of ["git", "gh", "jq", "rg", "fd", "npm", "trufflehog", "docker"]) {
+    await writeTool(tool, "exit 0");
+  }
+  await writeTool("id", 'printf "1000\\n"');
+  await writeNodeVersionFixture(bin);
+  await writeTool(
+    "corepack",
+    `
+case "$*" in
+  --version) printf '0.35.0\\n' ;;
+  prepare*)
+    printf '%s\\n' "$2" >"$HOME/prepare-request"
+    [[ "$#" == "3" && "$3" == "--activate" ]] || exit 90
+    [[ "\${FIXTURE_ACTIVATION_EXIT:-0}" == "0" ]] || exit "$FIXTURE_ACTIVATION_EXIT"
+    printf '%s\\n' "$FIXTURE_RESOLVED_PNPM" >"$HOME/default"
+    printf 'Preparing package manager for immediate activation...\\n'
+    ;;
+  'pnpm --version')
+    [[ "\${COREPACK_ENABLE_NETWORK:-}" == "0" && "$PWD" == "/" ]] || exit 91
+    [[ "\${FIXTURE_COREPACK_EXIT:-0}" == "0" ]] || exit "$FIXTURE_COREPACK_EXIT"
+    cat "$HOME/default"
+    ;;
+  *) exit 92 ;;
+esac`,
+  );
+  await writeTool(
+    "pnpm",
+    `
+[[ "$*" == "--version" ]] || exit 93
+[[ "\${COREPACK_ENABLE_NETWORK:-}" == "0" && "$PWD" == "/" ]] || exit 94
+[[ "\${FIXTURE_PNPM_EXIT:-0}" == "0" ]] || exit "$FIXTURE_PNPM_EXIT"
+if [[ -n "\${FIXTURE_ACTUAL_PNPM:-}" ]]; then
+  printf '%s\\n' "$FIXTURE_ACTUAL_PNPM"
+else
+  cat "$HOME/default"
+fi`,
+  );
+  const runner = path.join(fake.dir, "runtime.cjs");
+  await writeFile(
+    runner,
+    `#!${process.execPath}
+const {spawnSync} = require("node:child_process");
+const [lease, source] = process.argv.slice(2);
+const actual = JSON.parse(process.env.FIXTURE_PNPM_VERSIONS)[lease] || "";
+// Keep the real generated tool checks; unrelated machine/artifact checks have separate proof.
+const command = source.replace("test -d /var/cache/crabbox/pnpm", "true")
+  .replace("test -f /var/lib/crabbox-readiness/linux.json", "true")
+  .replace("test -f /var/lib/crabbox/image-ready", "true")
+  .replace(/\\ndeveloper_archive_probe\\n/, "\\n:\\n");
+const result = spawnSync("bash", ["-c", command], {
+  cwd: ${JSON.stringify(fake.dir)},
+  env: {...process.env, PATH: ${JSON.stringify(bin)} + ":" + process.env.PATH,
+    HOME: ${JSON.stringify(fake.dir)}, FIXTURE_ACTUAL_PNPM: actual},
+  stdio: "inherit",
+});
+if (result.error) throw result.error;
+process.exit(result.status ?? 1);
+`,
+  );
+  await chmod(runner, 0o755);
+  const args = ["--target", "linux", "--run"];
+  if (options.customPrep) args.push("--prep-script", fake.linuxPrep);
+  const result = await runScript(args, {
+    CRABBOX_BIN: fake.fake,
+    CRABBOX_FAKE_LOG: fake.log,
+    CRABBOX_IMAGE_LOG_DIR: path.join(fake.dir, "logs"),
+    CRABBOX_FAKE_PNPM_RUNNER: runner,
+    CRABBOX_LINUX_PNPM_VERSION: options.selector ?? "11.1.0",
+    FIXTURE_RESOLVED_PNPM: options.resolved ?? "11.1.0",
+    FIXTURE_PNPM_VERSIONS: JSON.stringify(options.versions ?? {}),
+    ...options.env,
+  });
+  return { fake, result, log: await readFile(fake.log, "utf8") };
+}
+
+for (const selector of [
+  "11.1.0",
+  "latest",
+  "^11.0.0",
+  "11.1.0+sha512.deadbeef",
+  '11.1.0; touch "$HOME/injected"',
+]) {
+  test(`runtime-user pnpm freezes the resolved default for selector ${selector}`, async (t) => {
+    const { fake, result, log } = await runtimePnpmFixture(t, { selector });
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(
+      await readFile(path.join(fake.dir, "prepare-request"), "utf8"),
+      `pnpm@${selector}\n`,
+    );
+    assert.equal((log.match(/--capture-stdout /g) ?? []).length, 1);
+    assert.match(result.stdout, /promoted linux developer image passed/);
+    await assert.rejects(readFile(path.join(fake.dir, "injected")), { code: "ENOENT" });
+  });
+}
+
+for (const lease of ["cbx_candidate", "cbx_promoted"]) {
+  test(`runtime-user pnpm rejects version drift on ${lease}`, async (t) => {
+    const { result, log } = await runtimePnpmFixture(t, { versions: { [lease]: "11.22.0" } });
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /pnpm default mismatch/);
+    assert.match(log, new RegExp(`stop --provider aws --target linux ${lease}`));
+    assert.doesNotMatch(result.stdout, /promoted linux developer image passed/);
+    if (lease === "cbx_candidate") assert.doesNotMatch(log, /image promote/);
+    else assert.match(log, /--restore-receipt/);
+  });
+}
+
+for (const [name, env, status, activated] of [
+  ["privileged prep", { CRABBOX_FAKE_PREP_EXIT: "43" }, 43, false],
+  ["user activation", { FIXTURE_ACTIVATION_EXIT: "44" }, 44, true],
+  ["ordinary pnpm", { FIXTURE_PNPM_EXIT: "45" }, 45, true],
+  ["Corepack pnpm", { FIXTURE_COREPACK_EXIT: "46" }, 46, true],
+  ["capture transport", { CRABBOX_FAKE_CAPTURE_EXIT: "47" }, 47, true],
+]) {
+  test(`runtime-user pnpm preserves ${name} failure and stops before image capture`, async (t) => {
+    const { fake, result, log } = await runtimePnpmFixture(t, { env });
+    assert.equal(result.code, status, result.stderr);
+    assert.doesNotMatch(log, /checkpoint create|docker_probe=|image promote/);
+    assert.match(log, /stop --provider aws --target linux cbx_source/);
+    if (activated) await readFile(path.join(fake.dir, "prepare-request"));
+    else await assert.rejects(readFile(path.join(fake.dir, "prepare-request")), { code: "ENOENT" });
+  });
+}
+
+for (const [name, bytes] of [
+  ["empty", ""],
+  ["blank", "\n"],
+  ["extra line", "11.1.0\nextra\n"],
+  ["oversized", `${"1".repeat(129)}\n`],
+  ["missing newline", "11.1.0"],
+  ["control byte", "11.\0.0\n"],
+]) {
+  test(`runtime-user pnpm refuses ${name} version capture`, async (t) => {
+    const { result, log } = await runtimePnpmFixture(t, {
+      env: { CRABBOX_FAKE_CAPTURE_BASE64: Buffer.from(bytes).toString("base64") },
+    });
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /invalid runtime-user pnpm version/);
+    assert.doesNotMatch(log, /checkpoint create|docker_probe=|image promote/);
+    assert.match(log, /stop --provider aws --target linux cbx_source/);
+  });
+}
+
+test("runtime-user pnpm rejects a shadowing ordinary command before image capture", async (t) => {
+  const { result, log } = await runtimePnpmFixture(t, { versions: { cbx_source: "12.3.4" } });
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /pnpm.*does not match Corepack/);
+  assert.doesNotMatch(log, /checkpoint create|docker_probe=|image promote/);
+  assert.match(log, /stop --provider aws --target linux cbx_source/);
+});
+
 async function qualificationFixture(t) {
   const fake = await setupFakeCrabbox();
   t.after(() => rm(fake.dir, { recursive: true, force: true }));
@@ -291,13 +476,7 @@ test("AWS developer image smoke executes package managers and requires TruffleHo
     path.join(scriptDir, "devtools-image-smoke-windows.ps1"),
     "utf8",
   );
-  const linuxSmoke = await readFile(path.join(scriptDir, "devtools-image-smoke-linux.sh"), "utf8");
   assert.match(windowsSmoke, /pnpm --version\ntrufflehog --no-update --version\ndocker --version/);
-  assert.match(
-    linuxSmoke,
-    /command -v pnpm\ncommand -v trufflehog\ntrufflehog --no-update --version\ncommand -v docker\nnode --version\nnode -e .*\ncorepack --version\npnpm --version\n/,
-  );
-  assert.match(linuxSmoke, /corepack --version\npnpm --version\ndocker_group_member/);
   assert.match(windowsSmoke, /docker image inspect .*\nif \(\$LASTEXITCODE -ne 0\).*throw.*\nWrite-Output "devtools-smoke-ok"\n$/);
   assert.match(text, /trap 'exit 130' INT\ntrap 'exit 143' TERM/);
   assert.match(text, /rollback_pending=1\nrun_json_tee "\$promotion_log"/);
@@ -392,7 +571,6 @@ test("AWS devtools mint wrapper runs linux source candidate and promoted proof",
   );
   assert.equal((log.match(/\n  offline_bun_probe\nfi\n}/g) ?? []).length, 3);
   assert.equal((log.match(/\ndeveloper_archive_probe\necho devtools-smoke-ok/g) ?? []).length, 3);
-  assert.equal((log.match(/\npnpm --version\n/g) ?? []).length, 3);
   assert.match(log, /docker image inspect hello-world ubuntu:24\.04 node:24-bookworm/);
   assert.match(
     log,
@@ -437,6 +615,7 @@ for (const [target, osImage] of [
       );
       assert.equal(result.code, failPromotedSmoke ? 73 : 0, result.stderr);
       const log = await readFile(fake.log, "utf8");
+      assert.doesNotMatch(log, /--capture-stdout/);
       assert.deepEqual(
         log.split("\n").filter((line) => /^selection .* command=warmup$/.test(line)),
         ["unset", "ami-devtools", "unset"].map(
@@ -633,11 +812,13 @@ async function linuxSmokeFixture(t, { major = "24", pnpm = "11.1.0", customPrep 
   const result = await runScript(args, {
     CRABBOX_BIN: fake.fake, CRABBOX_FAKE_LOG: fake.log, CRABBOX_FAKE_CAPTURE_RUN_SCRIPT: captured,
     CRABBOX_LINUX_NODE_MAJOR: major, CRABBOX_LINUX_PNPM_VERSION: pnpm,
+    CRABBOX_FAKE_RESOLVED_PNPM: pnpm,
   });
   assert.equal(result.code, 0, result.stderr);
   const log = await readFile(fake.log, "utf8");
   if (customPrep) {
     assert.doesNotMatch(log, /builder overrides/);
+    assert.doesNotMatch(log, /--capture-stdout/);
   } else {
     assert.ok(log.includes(`builder overrides node=${major} pnpm=${pnpm}\n`));
     assert.match(log, /--allow-env CRABBOX_LINUX_NODE_MAJOR,CRABBOX_LINUX_PNPM_VERSION --script/);
@@ -664,10 +845,16 @@ async function linuxSmokeFixture(t, { major = "24", pnpm = "11.1.0", customPrep 
     'if [[ "$*" == "-s" ]]; then printf "%s\\n" "${FIXTURE_OS:-Linux}"; else printf "x86_64\\n"; fi',
   );
   await writeTool("getconf", 'printf "%s\\n" "${FIXTURE_LIBC:-glibc 2.39}"');
-  await writeTool("corepack", 'exit "${FIXTURE_TOOL_EXIT:-0}"');
+  await writeTool(
+    "corepack",
+    '[[ "${FIXTURE_TOOL_EXIT:-0}" == "0" ]] || exit "$FIXTURE_TOOL_EXIT"\nprintf "%s\\n" "$FIXTURE_RESOLVED_PNPM"',
+  );
   await writeTool("id", 'printf "%s\\n" "$FIXTURE_UID"');
   await writeTool("dpkg", '[[ "$*" == "--print-architecture" ]] || exit 65\nprintf "%s\\n" "$FIXTURE_ARCH"');
-  await writeTool("pnpm", '[[ "$*" == "--version" ]] || exit 65\nprintf "%s\\n" "$HOME" >>"$HOME/normal-pnpm.called"\nexit "${FIXTURE_PNPM_EXIT:-0}"');
+  await writeTool(
+    "pnpm",
+    '[[ "$*" == "--version" ]] || exit 65\nprintf "%s\\n" "$HOME" >>"$HOME/normal-pnpm.called"\nprintf "%s\\n" "$FIXTURE_RESOLVED_PNPM"\nexit "${FIXTURE_PNPM_EXIT:-0}"',
+  );
   const generated = (await readFile(captured, "utf8"))
     .replace("test -d /var/cache/crabbox/pnpm", "true")
     .replace("test -f /var/lib/crabbox-readiness/linux.json", "true")
@@ -680,6 +867,7 @@ async function linuxSmokeFixture(t, { major = "24", pnpm = "11.1.0", customPrep 
     cwd: fake.dir,
     env: {
       PATH: `${bin}${path.delimiter}${process.env.PATH}`, HOME: fake.dir, TMPDIR: tmp,
+      FIXTURE_RESOLVED_PNPM: pnpm,
       FIXTURE_UID: "1000", FIXTURE_ARCH: "amd64", FIXTURE_NODE_VERSION: `${major}.0.0`, ...env,
     },
     encoding: "utf8",
@@ -804,7 +992,11 @@ test("generated Linux smoke keeps required x64 archives under a pnpm override", 
   const { execute } = await linuxSmokeFixture(t, { pnpm: "12.3.4" });
   const result = execute();
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /verified public toolchain archive unavailable offline/);
+  assert.match(
+    result.stderr,
+    /verified public toolchain archive unavailable offline/,
+    JSON.stringify({ status: result.status, signal: result.signal, error: result.error?.message }),
+  );
   assert.doesNotMatch(result.stdout, /devtools-smoke-ok/);
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Linux developer-image bakes prepared the selected pnpm release for root but left the image's ordinary runtime user without that Corepack default. A successful privileged preparation did not establish which pnpm release normal image commands would use.

## Why This Change Was Made

After successful bundled Linux preparation, the image caller activates the same opaque pnpm selector as the actual nonroot lease user. It records the resolved ordinary pnpm version outside the checkout with Corepack network access disabled, requires agreement with `corepack pnpm --version`, and checks that frozen version in source, candidate, and promoted smokes.

Activation, capture, or version failures retain the existing failure status, lease cleanup, and transactional rollback behavior. Tags, ranges, and integrity-qualified selectors pass unchanged to Corepack; they are not compared literally with a resolved version.

## User Impact

Bundled Linux images establish the runtime user's selected initial pnpm default and reject later image-default drift before reporting success. Project `packageManager` pins and cached releases remain usable. Custom prep scripts, Windows, the standalone installer, Node-only bootstrap, archive pins, and configuration are unchanged. This does not permanently lock Corepack's default or introduce a shared cache.

## Evidence

- All 19 new executable pnpm cases passed, covering selector forwarding, shell-sensitive input, candidate/promoted drift, command disagreement, original failure propagation, and bounded capture validation.
- Local owner/sibling run: **297 passed, 1 failed, 5 skipped** across `mint-aws-devtools-image.test.js`, `image-qualification-workflow.test.js`, `linux-toolchain-archives.test.js`, and `install-linux-developer-tools.test.js`.
- The existing `generated Linux smoke keeps required x64 archives under a pnpm override` case produced empty stderr in that combined run. Its original child status/error/signal were not retained, so the cause is **unknown**, not established as a timeout. The exact case subsequently passed isolated. Only assertion diagnostics were added; no timeout, expected behavior, or assertion was weakened.
- The [hosted full Scripts job](https://github.com/openclaw/crabbox/actions/runs/34426668333/job/102713264210) passed on final head `927d581e0a72587868f0fda1ea34806687720cc4`: **1,177 passed, 0 failed, 6 skipped**. Its complete log confirms `node --test scripts/*.test.js scripts/*.test.mjs`, all 19 new pnpm cases, and the exact previously failed archive case passing.
- Real AWS Linux proof used checksum-verified Node 24.19.0 and bundled Corepack 0.35.0 with isolated root/nonroot homes. Root-only activation left ordinary offline execution failing. The actual generated runtime-user command then selected pnpm 11.1.0 offline on two activations. A project pinned to 11.22.0 still executed; existing project and cached-release bytes were preserved. Failed activation emitted no version receipt. Private guest state was removed and lease cleanup completed.
- Bash syntax, Bash-aware ShellCheck, documentation links, and diff whitespace checks passed. New test/documentation blocks passed formatting; inherited unrelated whole-file formatting drift was not rewritten or claimed clean.
- Independent P0 review completed without actionable findings. [Public review of the final head](https://github.com/openclaw/crabbox/pull/2065#issuecomment-5611455382) also reported no defects, security findings, or before-merge items.

No image bake, image capture, promotion, rollout, or global CLI update was performed. Native proof logs remain private; the evidence above is deidentified.

Punchcard-Session: coral-workshop-harbor-pt
