### PR TITLE
refactor(config): share explicit provider work-root resolution

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -2203,14 +2203,7 @@ func MarkVastWorkRootExplicit(cfg *Config) {
 }
 
 func EffectiveVastWorkRoot(cfg Config) string {
-	workRoot := cfg.Vast.WorkRoot
-	if !IsVastWorkRootExplicit(&cfg) && (workRoot == "" || workRoot == VastConfigDefaultWorkRoot) && cfg.explicitWorkRoot != "" {
-		return cfg.explicitWorkRoot
-	}
-	if workRoot == "" {
-		return VastConfigDefaultWorkRoot
-	}
-	return workRoot
+	return resolveExplicitProviderWorkRoot(cfg.Vast.WorkRoot, VastConfigDefaultWorkRoot, cfg.explicitWorkRoot, IsVastWorkRootExplicit(&cfg))
 }
 
 func NormalizeVastInstanceType(value string) string {
@@ -2227,15 +2220,17 @@ func normalizeVastInstanceType(value string) string {
 }
 
 func EffectiveNvidiaBrevWorkRoot(cfg Config) string {
-	workRoot := cfg.NvidiaBrev.WorkRoot
-	providerDefault := workRoot == "" || workRoot == "/tmp/crabbox"
-	if !IsNvidiaBrevWorkRootExplicit(&cfg) && providerDefault && cfg.explicitWorkRoot != "" {
-		return cfg.explicitWorkRoot
+	return resolveExplicitProviderWorkRoot(cfg.NvidiaBrev.WorkRoot, "/tmp/crabbox", cfg.explicitWorkRoot, IsNvidiaBrevWorkRootExplicit(&cfg))
+}
+
+func resolveExplicitProviderWorkRoot(providerRoot, providerFallback, explicitGenericRoot string, providerExplicit bool) string {
+	if !providerExplicit && (providerRoot == "" || providerRoot == providerFallback) && explicitGenericRoot != "" {
+		return explicitGenericRoot
 	}
-	if workRoot == "" {
-		return "/tmp/crabbox"
+	if providerRoot == "" {
+		return providerFallback
 	}
-	return workRoot
+	return providerRoot
 }
 
 func DeleteOnReleaseExplicit(cfg Config, provider string) bool {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1141,6 +1141,59 @@ func TestEffectiveNvidiaBrevWorkRootDoesNotInheritAnotherProviderDefault(t *test
 	}
 }
 
+func TestExplicitProviderWorkRootResolution(t *testing.T) {
+	for _, tc := range []struct {
+		name                         string
+		savedGeneric, currentGeneric string
+		vastRoot, brevRoot           string
+		vastMarked, brevMarked       bool
+		wantVast, wantBrev           string
+	}{
+		{"no saved generic", "", "/generic/current", "", "/tmp/crabbox", false, false, "/work/crabbox", "/tmp/crabbox"},
+		{"no saved generic reversed roots", "", "", "/work/crabbox", "", false, false, "/work/crabbox", "/tmp/crabbox"},
+		{"saved generic snapshot", "/generic/saved", "/generic/current", "", "/tmp/crabbox", false, false, "/generic/saved", "/generic/saved"},
+		{"saved generic after current cleared", "/generic/saved", "", "/work/crabbox", "", false, false, "/generic/saved", "/generic/saved"},
+		{"explicit empty vast", "/generic/saved", "/generic/current", "", "/tmp/crabbox", true, false, "/work/crabbox", "/generic/saved"},
+		{"explicit empty brev", "/generic/saved", "/generic/current", "/work/crabbox", "", false, true, "/generic/saved", "/tmp/crabbox"},
+		{"explicit default vast", "/generic/saved", "/generic/current", "/work/crabbox", "", true, false, "/work/crabbox", "/generic/saved"},
+		{"explicit default brev", "/generic/saved", "/generic/current", "", "/tmp/crabbox", false, true, "/generic/saved", "/tmp/crabbox"},
+		{"unmarked custom roots", "/generic/saved", "/generic/current", "/vast/custom", "/brev/custom", false, false, "/vast/custom", "/brev/custom"},
+		{"marked custom roots", "/generic/saved", "/generic/current", "/vast/custom", "/brev/custom", true, true, "/vast/custom", "/brev/custom"},
+		{"padded provider defaults", "/generic/saved", "/generic/current", " /work/crabbox\t", "\t/tmp/crabbox ", false, false, " /work/crabbox\t", "\t/tmp/crabbox "},
+		{"whitespace provider roots", "/generic/saved", "/generic/current", " \t ", "\t ", true, false, " \t ", "\t "},
+		{"saved generic looks like vast default", "/work/crabbox", "/generic/current", "", "/tmp/crabbox", false, false, "/work/crabbox", "/work/crabbox"},
+		{"saved generic looks like brev default", "/tmp/crabbox", "/generic/current", "/work/crabbox", "", false, false, "/tmp/crabbox", "/tmp/crabbox"},
+		{"padded saved generic", " \t/generic/saved \t", "/generic/current", "", "/tmp/crabbox", false, false, " \t/generic/saved \t", " \t/generic/saved \t"},
+		{"whitespace saved generic", " \t ", "/generic/current", "/work/crabbox", "", false, false, " \t ", " \t "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{Provider: "unselected-config-test", WorkRoot: tc.savedGeneric}
+			MarkWorkRootExplicit(&cfg)
+			cfg.WorkRoot = tc.currentGeneric
+			cfg.Vast.WorkRoot, cfg.NvidiaBrev.WorkRoot = tc.vastRoot, tc.brevRoot
+			if tc.vastMarked {
+				MarkVastWorkRootExplicit(&cfg)
+			}
+			if tc.brevMarked {
+				MarkNvidiaBrevWorkRootExplicit(&cfg)
+			}
+			before := cfg
+			if got := EffectiveVastWorkRoot(cfg); got != tc.wantVast {
+				t.Errorf("effective vast work root=%q, want %q", got, tc.wantVast)
+			}
+			if got := EffectiveNvidiaBrevWorkRoot(cfg); got != tc.wantBrev {
+				t.Errorf("effective nvidia-brev work root=%q, want %q", got, tc.wantBrev)
+			}
+			if !reflect.DeepEqual(cfg, before) {
+				t.Error("effective work-root getters modified Config")
+			}
+			if cfg.explicitWorkRoot != tc.savedGeneric || IsVastWorkRootExplicit(&cfg) != tc.vastMarked || IsNvidiaBrevWorkRootExplicit(&cfg) != tc.brevMarked {
+				t.Error("work-root markers changed")
+			}
+		})
+	}
+}
+
 func TestCoordinatorTokenCommandEnv(t *testing.T) {
 	clearConfigEnv(t)
 	t.Setenv("CRABBOX_COORDINATOR_TOKEN_COMMAND", `["token-helper","--scope","example"]`)


### PR DESCRIPTION
## Summary

Share the identical explicit-provider work-root decision used by the Vast and NVIDIA Brev getters. Both public getters and every caller remain in place; a private pure resolver now owns the provider-marker/default-looking-root/saved-generic-root rule once.

Keep the distinctions: an unmarked empty or default-looking provider root may inherit the saved explicit generic root; a marked empty root uses its provider fallback; a custom or padded provider root remains raw. The saved `explicitWorkRoot` value matters, not a later-derived current generic root. Provider fallbacks remain with their wrappers.

The raw inheritance helper, Sealos and Hostinger rules, and Vast's different selected-provider projection remain unchanged. No marker setter, source admission, provider flag, schema, dependency, credential, native implementation, or public API changes. This is a small internal invariant consolidation, not a user-visible fix or feature, so no changelog or version change is included.

## Verification

The original and candidate code passed the same three selected tests, including sixteen new paired cases. Both existing test bodies remain unchanged, including Vast's intentionally different effective-versus-projected expectations. Tests cover both fallbacks, independent provider markers, raw/custom/padded roots, saved-versus-current generic roots, and unmodified configuration/markers.

```sh
go test -race ./internal/cli -run '^(TestExplicitProviderWorkRootResolution|TestEffectiveNvidiaBrevWorkRootDoesNotInheritAnotherProviderDefault|TestVastBindingCoreDefaultsAndMarkers)$' -count=1 -timeout=3m -v
go test -race ./scripts/configgen -run 'GeneratedConfigIsCurrent$' -count=1 -timeout=3m -v
go vet ./internal/cli
go build -trimpath -buildvcs=false -o '<task-owned-output>' ./cmd/crabbox
```

All 34 generated-file freshness checks, vet, and build passed with pinned Go 1.26.5, a credential-free environment, and network access denied. Source bytes/modes and index remained unchanged. Independent source review found no actionable issue; managed Codex review was scoped-clean at P0.

Nine fixed shipping CLI cases use `config show --provider xcp-ng --json` to observe both inactive-provider root fields. XCP-ng selection deliberately avoids Vast's distinct selected-provider projection. Every candidate case matched its literal nested-field expectation and the baseline's complete raw stdout, stderr, and exit/timeout outcome.

The baseline completed all nine cases. The original candidate run matched eight, then its 2 GiB disk preflight stopped it **before the ninth case launched**. After clearing only the task-owned Go build cache, a separately recorded continuation executed only that unrun case once and matched it exactly. The original candidate report remains incomplete/exit-1; no completed case was rerun, and no frozen input, expectation, or output was altered. Both binaries and all prior proof artifacts stayed unchanged.

Candidate binary SHA256: `617b3c70b2a9618fb4e0b81f3533b22810055fea91ce477de40cdcf73fd6aebe`.

Actual candidate observations:

| Case | Vast workRoot | NVIDIA Brev workRoot |
| --- | --- | --- |
| Defaults | `/work/crabbox` | `/tmp/crabbox` |
| Generic root only | `/generic/project` | `/generic/project` |
| Generic plus explicit Vast fallback | `/work/crabbox` | `/generic/project` |
| Generic plus explicit Brev fallback | `/generic/project` | `/tmp/crabbox` |
| Explicit portable generic root (continued case) | `/work/crabbox` | `/work/crabbox` |

These are configuration-rendering observations with isolated synthetic files/HOME, no broker, supplied endpoints, credentials or native operations. File empty/null values are ignored and cannot express an explicit-empty provider marker or an unmarked custom root; those internal states remain covered by the paired getter tests. No cloud provisioning, provider discovery, SSH, or native lifecycle proof is claimed.
