### PR TITLE
refactor(telemetry): share sample ordering and deduplication

### DIFF
--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -356,6 +356,7 @@ import {
   tailscaleTagOwnershipErrorMessage,
   validateTailscaleTags,
 } from "./tailscale";
+import { orderedTelemetrySamples } from "./telemetry";
 import { timingSafeEqual } from "./timing-safe";
 import type {
   CapacityHint,
@@ -25065,15 +25066,7 @@ function appendLeaseTelemetryHistory(
 }
 
 function boundedTelemetrySamples(samples: LeaseTelemetry[], max: number): LeaseTelemetry[] {
-  const byTime = new Map<string, LeaseTelemetry>();
-  for (const sample of samples) {
-    if (sample?.capturedAt) {
-      byTime.set(sample.capturedAt, sample);
-    }
-  }
-  return [...byTime.values()]
-    .toSorted((left, right) => left.capturedAt.localeCompare(right.capturedAt))
-    .slice(-max);
+  return orderedTelemetrySamples(samples).slice(-max);
 }
 
 const fixedLeaseCreateIntentVersion = 2;

--- a/worker/src/portal.ts
+++ b/worker/src/portal.ts
@@ -1,4 +1,5 @@
 import type { PortalExternalRunnerRecord, PortalLeaseRecord } from "./org-records";
+import { orderedTelemetrySamples } from "./telemetry";
 import type {
   ExternalRunnerRecord,
   LeaseRecord,
@@ -2909,18 +2910,7 @@ function telemetrySamples(
   telemetry: LeaseRecord["telemetry"],
   history: LeaseRecord["telemetryHistory"],
 ): LeaseTelemetrySample[] {
-  const byTime = new Map<string, LeaseTelemetrySample>();
-  for (const sample of Array.isArray(history) ? history : []) {
-    if (sample?.capturedAt) {
-      byTime.set(sample.capturedAt, sample);
-    }
-  }
-  if (telemetry?.capturedAt) {
-    byTime.set(telemetry.capturedAt, telemetry);
-  }
-  return [...byTime.values()].toSorted((left, right) =>
-    left.capturedAt.localeCompare(right.capturedAt),
-  );
+  return orderedTelemetrySamples([...(Array.isArray(history) ? history : []), telemetry]);
 }
 
 type LeaseTelemetrySample = NonNullable<LeaseRecord["telemetry"]>;
@@ -3086,15 +3076,7 @@ function runTelemetrySamples(telemetry: RunRecord["telemetry"]): LeaseTelemetryS
   if (!telemetry) {
     return [];
   }
-  const byTime = new Map<string, LeaseTelemetrySample>();
-  for (const sample of [telemetry.start, ...(telemetry.samples ?? []), telemetry.end]) {
-    if (sample?.capturedAt) {
-      byTime.set(sample.capturedAt, sample);
-    }
-  }
-  return [...byTime.values()].toSorted((left, right) =>
-    left.capturedAt.localeCompare(right.capturedAt),
-  );
+  return orderedTelemetrySamples([telemetry.start, ...(telemetry.samples ?? []), telemetry.end]);
 }
 
 function telemetryDelta(start: number | undefined, end: number | undefined): string | undefined {

--- a/worker/src/telemetry.ts
+++ b/worker/src/telemetry.ts
@@ -1,0 +1,15 @@
+import type { LeaseTelemetry } from "./types";
+
+export function orderedTelemetrySamples(
+  samples: readonly (LeaseTelemetry | undefined)[],
+): LeaseTelemetry[] {
+  const byTime = new Map<string, LeaseTelemetry>();
+  for (const sample of samples) {
+    if (sample?.capturedAt) {
+      byTime.set(sample.capturedAt, sample);
+    }
+  }
+  return [...byTime.values()].toSorted((left, right) =>
+    left.capturedAt.localeCompare(right.capturedAt),
+  );
+}

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -30850,6 +30850,89 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
+  it("preserves whole-sample precedence for lease history and current telemetry ties", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        slug: "blue-lobster",
+        owner: "alice@example.com",
+        org: "example-org",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        telemetryHistory: [
+          {
+            capturedAt: "2026-05-01T00:00:20.000Z",
+            source: "ssh-linux",
+            load1: 9,
+            memoryPercent: 90,
+            diskPercent: 90,
+          },
+          {
+            capturedAt: "2026-05-01T00:00:10.000Z",
+            source: "ssh-linux",
+            load1: 1,
+            memoryPercent: 10,
+            diskPercent: 10,
+          },
+        ],
+        telemetry: {
+          capturedAt: "2026-05-01T00:00:20.000Z",
+          source: "ssh-linux",
+          load1: 2,
+        },
+      }),
+    );
+
+    const page = await fleet.fetch(request("GET", "/portal/leases/blue-lobster", { headers }));
+    expect(page.status).toBe(200);
+    const body = await page.text();
+    // Two load samples, 1 then 2; the current sample replaces all metrics at its timestamp.
+    expect(body).toContain('<polyline points="0.0,14.0 100.0,2.0" />');
+    expect(body).toContain("<span>2.00</span>");
+    expect(body).toContain(
+      '<div class="telemetry-line"><span>memory</span><span class="muted">waiting for samples</span></div>',
+    );
+    expect(body).toContain(
+      '<div class="telemetry-line"><span>disk</span><span class="muted">waiting for samples</span></div>',
+    );
+
+    const heartbeat = await fleet.fetch(
+      request("POST", "/v1/leases/blue-lobster/heartbeat", {
+        headers,
+        body: {
+          telemetry: {
+            capturedAt: "2026-05-01T00:00:20.000Z",
+            source: "ssh-linux",
+            load1: 3,
+          },
+        },
+      }),
+    );
+    expect(heartbeat.status).toBe(200);
+    const { lease } = (await heartbeat.json()) as { lease: LeaseRecord };
+    expect(lease.telemetry).toEqual({
+      capturedAt: "2026-05-01T00:00:20.000Z",
+      source: "ssh-linux",
+      load1: 3,
+    });
+    expect(lease.telemetryHistory).toEqual([
+      {
+        capturedAt: "2026-05-01T00:00:10.000Z",
+        source: "ssh-linux",
+        load1: 1,
+        memoryPercent: 10,
+        diskPercent: 10,
+      },
+      { capturedAt: "2026-05-01T00:00:20.000Z", source: "ssh-linux", load1: 3 },
+    ]);
+  });
+
   it("hides exact lease IDs and lists from other non-admin users", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);
@@ -44095,6 +44178,71 @@ describe("fleet run history", () => {
     const finished = (await finish.json()) as { run: RunRecord };
     expect(finished.run.telemetry?.end).toMatchObject({ load1: 1.2, memoryPercent: 60 });
     expect(finished.run.telemetry?.samples?.map((sample) => sample.load1)).toEqual([0.4, 0.9]);
+  });
+
+  it("renders run telemetry ties with stored samples over start and end over stored samples", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    storage.seed(
+      "lease:cbx_000000000001",
+      testLease({
+        id: "cbx_000000000001",
+        owner: "alice@example.com",
+        org: "example-org",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    storage.seed(
+      "run:run_000000000001",
+      testRun({
+        id: "run_000000000001",
+        leaseID: "cbx_000000000001",
+        owner: "alice@example.com",
+        org: "example-org",
+        telemetry: {
+          start: {
+            capturedAt: "2026-05-01T00:00:10.000Z",
+            load1: 1,
+            memoryPercent: 10,
+            diskPercent: 10,
+          },
+          samples: [
+            {
+              capturedAt: "2026-05-01T00:00:30.000Z",
+              load1: 8,
+              memoryPercent: 80,
+              diskPercent: 80,
+            },
+            { capturedAt: "2026-05-01T00:00:10.000Z", load1: 2 },
+            {
+              capturedAt: "2026-05-01T00:00:20.000Z",
+              load1: 3,
+              memoryPercent: 30,
+              diskPercent: 30,
+            },
+          ],
+          end: { capturedAt: "2026-05-01T00:00:30.000Z", load1: 4 },
+        },
+      }),
+    );
+
+    const page = await fleet.fetch(request("GET", "/portal/runs/run_000000000001", { headers }));
+    expect(page.status).toBe(200);
+    const body = await page.text();
+    // Load is 2, 3, 4; only the middle sample retains memory and disk metrics.
+    expect(body).toContain("<small>3 samples</small>");
+    expect(body).toContain('<polyline points="0.0,14.0 50.0,8.0 100.0,2.0" />');
+    expect(body).toContain("<span>4.00</span>");
+    expect(body).toContain(
+      '<div class="telemetry-line"><span>memory</span><span class="muted">waiting for samples</span></div>',
+    );
+    expect(body).toContain(
+      '<div class="telemetry-line"><span>disk</span><span class="muted">waiting for samples</span></div>',
+    );
   });
 
   it("accepts Go nil slices in passing test results", async () => {

--- a/worker/test/telemetry.test.ts
+++ b/worker/test/telemetry.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import { orderedTelemetrySamples } from "../src/telemetry";
+
+describe("orderedTelemetrySamples", () => {
+  it("orders out-of-order timestamps", () => {
+    const samples = [
+      { capturedAt: "2026-05-01T00:00:30.000Z", load1: 3 },
+      { capturedAt: "2026-05-01T00:00:10.000Z", load1: 1 },
+      { capturedAt: "2026-05-01T00:00:20.000Z", load1: 2 },
+    ];
+
+    expect(orderedTelemetrySamples(samples)).toEqual([
+      { capturedAt: "2026-05-01T00:00:10.000Z", load1: 1 },
+      { capturedAt: "2026-05-01T00:00:20.000Z", load1: 2 },
+      { capturedAt: "2026-05-01T00:00:30.000Z", load1: 3 },
+    ]);
+  });
+
+  it("keeps the last whole sample for duplicate timestamps", () => {
+    const samples = [
+      {
+        capturedAt: "2026-05-01T00:00:10.000Z",
+        load1: 1,
+        memoryPercent: 10,
+        diskPercent: 20,
+      },
+      { capturedAt: "2026-05-01T00:00:20.000Z", load1: 2 },
+      { capturedAt: "2026-05-01T00:00:10.000Z", load1: 3 },
+    ];
+
+    expect(orderedTelemetrySamples(samples)).toEqual([
+      { capturedAt: "2026-05-01T00:00:10.000Z", load1: 3 },
+      { capturedAt: "2026-05-01T00:00:20.000Z", load1: 2 },
+    ]);
+  });
+
+  it("preserves sample object identity", () => {
+    const first = { capturedAt: "2026-05-01T00:00:10.000Z", load1: 1 };
+    const replaced = { capturedAt: "2026-05-01T00:00:20.000Z", load1: 2 };
+    const winner = { capturedAt: "2026-05-01T00:00:20.000Z", load1: 3 };
+
+    const result = orderedTelemetrySamples([replaced, first, winner]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(first);
+    expect(result[1]).toBe(winner);
+  });
+
+  it("returns a fresh array without changing frozen inputs", () => {
+    const samples = Object.freeze([
+      Object.freeze({ capturedAt: "2026-05-01T00:00:20.000Z", load1: 2 }),
+      Object.freeze({ capturedAt: "2026-05-01T00:00:10.000Z", load1: 1 }),
+    ]);
+
+    const result = orderedTelemetrySamples(samples);
+
+    expect(result).not.toBe(samples);
+    expect(orderedTelemetrySamples(samples)).not.toBe(result);
+    expect(result).toEqual([
+      { capturedAt: "2026-05-01T00:00:10.000Z", load1: 1 },
+      { capturedAt: "2026-05-01T00:00:20.000Z", load1: 2 },
+    ]);
+    expect(samples).toEqual([
+      { capturedAt: "2026-05-01T00:00:20.000Z", load1: 2 },
+      { capturedAt: "2026-05-01T00:00:10.000Z", load1: 1 },
+    ]);
+  });
+
+  it("filters undefined samples and empty timestamps", () => {
+    expect(
+      orderedTelemetrySamples([
+        undefined,
+        { capturedAt: "", load1: 9 },
+        { capturedAt: "2026-05-01T00:00:10.000Z", load1: 1 },
+        undefined,
+      ]),
+    ).toEqual([{ capturedAt: "2026-05-01T00:00:10.000Z", load1: 1 }]);
+    expect(orderedTelemetrySamples([undefined, { capturedAt: "" }])).toEqual([]);
+  });
+
+  it("does not cap the number of samples", () => {
+    const samples = Array.from({ length: 1_000 }, (_, index) => ({
+      capturedAt: new Date(Date.UTC(2026, 4, 1, 0, 0, index)).toISOString(),
+      load1: index,
+    }));
+
+    const result = orderedTelemetrySamples(samples);
+
+    expect(result).toHaveLength(1_000);
+    expect(result).toEqual(samples);
+    expect(result[0]).toBe(samples[0]);
+    expect(result.at(-1)).toBe(samples.at(-1));
+  });
+});


### PR DESCRIPTION
## Summary

Share telemetry timestamp deduplication and ordering across stored histories, lease portal timelines, and run portal timelines. A small shared module now owns the complete existing rule: ignore entries without a timestamp, keep the last whole sample for each exact timestamp, and sort with the same `localeCompare` comparator. Sample references are preserved and input arrays are not mutated.

All three duplicated Map/sort implementations are removed. Their distinct policies stay local: fleet applies its existing `.slice(-max)` limit; lease history precedes current telemetry; run start precedes stored samples, then end. Equal timestamps therefore retain their current whole-sample precedence. The helper does not parse dates, trim timestamps, merge metrics, sanitize input, or impose a portal limit.

This is an internal behavior-preserving refactor. No API, schema, dependency, provider operation, display format, changelog, or version change is included. Existing contributor changes in these large files were checked at their exact heads; the selected sections are disjoint.

## Verification

The three existing storage/run/portal tests passed before implementation. All old fleet test bodies remain byte-identical. The candidate passed those three tests, six focused helper tests, and two new in-memory route tests covering lease history/current ties and run start/stored/end ties. The tests verify whole-object replacement, object identity, frozen-input preservation, ordering, filtering, storage limits, and uncapped helper output.

All 11 selected tests passed; 1,120 unrelated tests were intentionally excluded, not claimed as a full-suite pass. Formatting, lint, Worker and Node typechecks, Worker dry-run build, and Node build also passed. Source bytes/modes, new files, and the index stayed unchanged during validation.

Independent source review found no actionable findings; managed Codex review was scoped-clean at P0. Local test and build checks used Node 26.8.1, isolated HOME, no credentials, and denied network access. Route tests use in-memory storage and fake providers: they are not production deployment or native/cloud lifecycle proof.

The complete candidate was then fast-forwarded unchanged onto the separate [release-preparation commit](https://github.com/openclaw/crabbox/pull/2068). Package manifests differed only in their three root version fields; dependencies and scripts were unchanged. The same seven validation stages were repeated on that combination.

Both bundles and their source maps were byte-identical across that integration. Worker bundle SHA256: `44d0496a22167108d68b732ed4401407115e89115cc641f12514038cc1176650`; Node bundle SHA256: `acf32f6c0d9165e818ea8adf1435b0cae816d69192f7a35884c48769bee847ce`.

```sh
npm test --prefix worker -- test/fleet.test.ts test/telemetry.test.ts -t 'orderedTelemetrySamples|keeps lease telemetry history bounded to the latest samples|appends live run telemetry samples and preserves them on finish|renders lease detail pages with run logs and stop controls|preserves whole-sample precedence for lease history and current telemetry ties|renders run telemetry ties with stored samples over start and end over stored samples'
npm run format:check --prefix worker
npm run lint --prefix worker
npm run check --prefix worker
npm run check:node --prefix worker
npm run build --prefix worker
npm run build:node --prefix worker
```

## Real coordinator persistence and portal proof

The reviewed head `50b2f113e96fc14cfc78f788fe38c2a17139a382` was also tested in the repository's actual Node coordinator image against a fresh PostgreSQL instance. The exact integrated source tree was `56cd7fbd99c8dea29fbc0685b3ccc7f7e6bfe2be` (main `6dad5216a624cb2b4d59c04e77d0314b0709a268` plus this unchanged PR). Node reported `v22.22.3`; the running server bundle SHA256 was `7ab19d004c7de015516d74da919ea0db8f0e3ba3b6bbab821b39dfd948a7ef5e`, matching the locally built bundle. Image ID: `sha256:94553349b103367e8996e930414625009913070f1a99af56e4bdfd23d6612fea`.

This used real HTTP routing, database storage, and served portal HTML, with the normal shared-operator Bearer configuration and disposable fixture credentials. Containers shared an isolated internal network with no published host ports. A synthetic direct lease was registered through the ordinary registration API; run `run_a4eda7927519` recorded synthetic metadata only. No direct database seeding, fake storage/provider, renderer import, or authentication bypass was used.

Fourteen authenticated requests in the write/initial-observation phase (ten mutations and four GETs) and four GETs after an orderly Node restart all returned their expected 201/200 status. PostgreSQL remained running across that restart. The captured observations were:

| Surface | Actual observation before and after restart |
| --- | --- |
| Lease API | Out-of-order samples sorted by timestamp; the later whole sample at the duplicate timestamp replaced the earlier one, including removing its absent memory/disk fields. Current load was 2. |
| Run API | Stored samples had loads 2, 3, and 8 in timestamp order; start load remained 1 and end load was 4. |
| Lease portal | Actual served load polyline `0.0,14.0 100.0,2.0`; displayed current value `2.00`. |
| Run portal | Three samples; actual served load polyline `0.0,14.0 50.0,8.0 100.0,2.0`; displayed current value `4.00`, confirming end-over-stored precedence. |
| Memory/disk portal timelines | Both displayed “waiting for samples”, consistent with whole-object replacement leaving only one surviving value for each metric. |

Relevant telemetry projections and retained raw HTML telemetry sections matched before and after restart. Whole pages were hashed at capture time but not retained; no claim of whole-page byte equality is made. Independent evidence validation checked the frozen client/contract hashes, all 18 authenticated request records, observed values, exact retained snippets, source/runtime bindings, and preserved failure history. The successful report SHA256 is `e78e93d8d50b90c4375f4b466666d4ea66f693a712efa596b60acc140c4564f2`.

Two earlier setup attempts failed on optional Docker inspect fields before any telemetry HTTP case ran. Their failed reports were preserved; one unstarted, task-owned container needed separate verified cleanup. Only the optional-field inspection handling was corrected; telemetry inputs and expectations were unchanged. The successful attempt removed both containers, its network, and disposable credential files, with a separate final absence readback.

This proves the changed coordinator storage/portal path and orderly-restart persistence with synthetic inputs. It does not claim cloud provisioning, SSH, workload execution, a live host collector, crash recovery, or the storage-cap boundary. The metadata run's recorded success is not a command-execution receipt. The previous in-memory tests remain the focused boundary/identity/cap checks.
