### PR TITLE
chore: authorize v0.55.0 release source

### DIFF
--- a/release/records/v0.55.0.json
+++ b/release/records/v0.55.0.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.55.0",
+  "tagObject": "5febb670be8e392af98019d630d9810e8e97684c",
+  "sourceCommit": "ab12f01d0ba3bcf2669fd6de32b53548b2ffdabf",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
Bind v0.55.0 to its verified signed tag object and tested source commit. The finalized release notes and existing Unreleased section are unchanged.

Full source CI passed: https://github.com/openclaw/crabbox/actions/runs/34435164186. The managed macOS smoke verified non-root execution, Node 24.19.0/npm 11.17.0, the launchd Background context, prompt completion with stock nohup, and daemon survival across commands. Attach/events/logs passed; AWS instance termination and local lease cleanup are confirmed.

GitHub verified the tag signature, and Codex autoreview found no actionable blockers. This record enables the credential-free producer; signing, immutable draft verification, native execution, and publication remain sequential release gates.
