### PR TITLE
fix(windows): refresh PATH for native SSH sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Refresh native Windows PowerShell command and readiness PATH from machine/user settings, and verify SSH returns on fresh connections after baseline installation restarts the service. Follow-up to [PR 2069](https://github.com/openclaw/crabbox/pull/2069).
 - Install checksum-pinned Node 24.19.0/npm on managed native Windows leases when missing or broken, require both tools for readiness, and update the developer-image default pin while preserving overrides. [PR 2069](https://github.com/openclaw/crabbox/pull/2069).
 - Add `Start-CrabboxDetachedProcess.ps1` for native Windows daemons that survive command and SSH-session exit with a private hidden console, preserving ordinary command timeouts and workspace ownership. [PR 2069](https://github.com/openclaw/crabbox/pull/2069).
 - Include the resolved `workroot` in SSH-backed inspect/status JSON, including native Windows and WSL2 leases. [PR 2069](https://github.com/openclaw/crabbox/pull/2069).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Refresh native Windows PowerShell command and readiness PATH from machine/user settings, and verify SSH returns on fresh connections after baseline installation restarts the service. Follow-up to [PR 2069](https://github.com/openclaw/crabbox/pull/2069).
+- Refresh native Windows PowerShell command and readiness PATH from machine/user settings, and verify SSH returns on fresh connections after baseline installation restarts the service. [PR 2074](https://github.com/openclaw/crabbox/pull/2074).
 - Install checksum-pinned Node 24.19.0/npm on managed native Windows leases when missing or broken, require both tools for readiness, and update the developer-image default pin while preserving overrides. [PR 2069](https://github.com/openclaw/crabbox/pull/2069).
 - Add `Start-CrabboxDetachedProcess.ps1` for native Windows daemons that survive command and SSH-session exit with a private hidden console, preserving ordinary command timeouts and workspace ownership. [PR 2069](https://github.com/openclaw/crabbox/pull/2069).
 - Include the resolved `workroot` in SSH-backed inspect/status JSON, including native Windows and WSL2 leases. [PR 2069](https://github.com/openclaw/crabbox/pull/2069).

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -407,7 +407,11 @@ reprovisioning to receive this setup.
 
 Managed native Windows bootstrap installs checksum-pinned Node 24.19.0 and npm
 in `C:\Program Files\nodejs` on the machine PATH when either is missing or
-broken, retaining healthy installations. Readiness verifies both tools. No
+broken, retaining healthy installations. Bootstrap restarts OpenSSH after the
+machine PATH updates, and client-side completion waits for stable readiness on
+fresh SSH connections. Native PowerShell commands and readiness probes refresh
+PATH from the machine and user registry values so they also work when an SSH
+session inherited an older environment. Readiness verifies both tools. No
 admin broker token or host pin is needed. For daemons across fixed-ID `run`
 invocations, use `Start-CrabboxDetachedProcess.ps1`; ordinary hidden
 `Start-Process` children remain in OpenSSH's session job. See the

--- a/internal/cli/aws_windows_bootstrap.go
+++ b/internal/cli/aws_windows_bootstrap.go
@@ -70,6 +70,12 @@ func bootstrapAWSWindowsDesktop(ctx context.Context, cfg Config, target *SSHTarg
 }
 
 func runWindowsBootstrapOverSSH(ctx context.Context, cfg Config, target *SSHTarget, bootstrapTarget SSHTarget, publicKey string, stderr io.Writer, phase string) error {
+	// Bootstrap restarts sshd after updating machine PATH. Probe new sessions,
+	// not a surviving pre-bootstrap control master with the old environment.
+	bootstrapTarget.NoControlMaster = true
+	previousNoControlMaster := target.NoControlMaster
+	target.NoControlMaster = true
+	defer func() { target.NoControlMaster = previousNoControlMaster }()
 	if err := waitForSSHReady(ctx, &bootstrapTarget, stderr, "windows openssh", 20*time.Minute); err != nil {
 		return err
 	}

--- a/internal/cli/aws_windows_bootstrap_test.go
+++ b/internal/cli/aws_windows_bootstrap_test.go
@@ -137,7 +137,11 @@ func TestCoordinatorFreshWindowsBootstrapDelivery(t *testing.T) {
 			// A synthetic proxy routes all SSH to the fake executable; no guest
 			// sockets, provider credentials, or privileged local ports are needed.
 			initial.SSHConfigProxy, workload.SSH.SSHConfigProxy = true, true
-			initial.NoControlMaster, workload.SSH.NoControlMaster = true, true
+			if mode == windowsModeWSL2 {
+				initial.NoControlMaster, workload.SSH.NoControlMaster = true, true
+			} else {
+				t.Setenv("CRABBOX_TEST_WINDOWS_REQUIRE_FRESH", "1")
+			}
 			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 			defer cancel()
 			if err := bootstrapPreparedManagedWindowsDesktop(ctx, cfg, &workload.SSH, initial, "ssh-ed25519 fixture", io.Discard); err != nil {
@@ -165,6 +169,10 @@ func TestCoordinatorFreshWindowsBootstrapDelivery(t *testing.T) {
 				t.Fatalf("bootstrap did not receive the configured final-port script: %v", err)
 			}
 			if mode == windowsModeNormal {
+				if workload.SSH.NoControlMaster {
+					t.Fatal("bootstrap changed the workload control-master policy")
+				}
+				t.Setenv("CRABBOX_TEST_WINDOWS_REQUIRE_FRESH", "")
 				t.Setenv("CRABBOX_TEST_WINDOWS_WORKLOAD_FAIL", "1")
 				err := runSSHInput(ctx, workload.SSH, powershellCommand("exit 73"), nil, io.Discard, io.Discard)
 				var exitErr *exec.ExitError
@@ -215,10 +223,13 @@ func installWindowsBootstrapSSH(t *testing.T) string {
 	dir := t.TempDir()
 	script := `#!/bin/sh
 port=
+fresh=
 while [ "$#" -gt 0 ]; do
+  if [ "$1" = ControlMaster=no ]; then fresh=1; fi
   if [ "$1" = -p ]; then shift; port=$1; fi
   shift
 done
+if [ "${CRABBOX_TEST_WINDOWS_REQUIRE_FRESH:-}" = 1 ] && [ "$fresh" != 1 ]; then exit 74; fi
 phase=initial
 if [ -f "$CRABBOX_TEST_WINDOWS_SSH/ready" ]; then phase=ready; fi
 printf '%s %s\n' "$phase" "$port" >> "$CRABBOX_TEST_WINDOWS_SSH/calls"

--- a/internal/cli/bootstrap_generated.go
+++ b/internal/cli/bootstrap_generated.go
@@ -77,7 +77,7 @@ func sharedWindowsNativePrelude() string {
 }
 
 func sharedWindowsFinalize() string {
-	return "\n\tgit --version | Out-Null\n\ttar --version | Out-Null\n\tSet-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString(\"o\")\n\tRestart-Service sshd -Force\n"
+	return "\n\tgit --version | Out-Null\n\ttar --version | Out-Null\n\tSet-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString(\"o\")\n\t# Keep this last: Node and the other baselines update machine PATH above.\n\tRestart-Service sshd -Force\n"
 }
 
 func sharedWindowsDesktop() string {

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -658,7 +658,7 @@ func sshReadyCommand(target SSHTarget) string {
 		return target.ReadyCheck
 	}
 	if isWindowsNativeTarget(target) {
-		return powershellCommand(`$ErrorActionPreference = "Stop"
+		return powershellCommand(windowsPowerShellPathRefresh + `$ErrorActionPreference = "Stop"
 git --version | Out-Null
 tar --version | Out-Null
 node --version | Out-Null
@@ -1798,8 +1798,12 @@ if ($remaining -gt 0) {
 `
 }
 
+// OpenSSH sessions can inherit PATH from before bootstrap updated the registry.
+const windowsPowerShellPathRefresh = `$env:Path = [Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [Environment]::GetEnvironmentVariable('Path', 'User')
+`
+
 func windowsPowerShellStdinScriptCommand(inputSize int) string {
-	return powershellCommand(`$ErrorActionPreference = "Stop"
+	return powershellCommand(windowsPowerShellPathRefresh + `$ErrorActionPreference = "Stop"
 $path = Join-Path $env:TEMP ("crabbox-stdin-command-" + [Guid]::NewGuid().ToString("N") + ".ps1")
 try {
 	$scriptFile = [IO.File]::Open($path, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -122,6 +122,7 @@ func TestWindowsPowerShellStdinScriptCommandUsesExactLengthFrame(t *testing.T) {
 		t.Fatalf("stdin script command length=%d exceeds cmd.exe limit", len(command))
 	}
 	decoded := decodePowerShellCommand(t, command)
+	assertWindowsPowerShellPathRefresh(t, decoded)
 	for _, want := range []string{
 		"$remaining = [Int64]12345",
 		"$stdin.ReadAsync($buffer, 0, $readSize).GetAwaiter().GetResult()",

--- a/internal/cli/windows_native_baseline_test.go
+++ b/internal/cli/windows_native_baseline_test.go
@@ -51,6 +51,11 @@ func TestWindowsNativeBaselineBootstrap(t *testing.T) {
 				if verify < 0 || expand < verify || (ready >= 0 && ready < install) {
 					t.Fatal("verification, install and readiness are out of order")
 				}
+				pathUpdate := strings.LastIndex(script, `SetEnvironmentVariable("Path", $machinePath, "Machine")`)
+				restart := strings.LastIndex(script, "Restart-Service sshd -Force")
+				if restart < pathUpdate || restart < install {
+					t.Fatal("sshd must restart after Node install and all machine PATH updates")
+				}
 			})
 		}
 	}
@@ -58,10 +63,20 @@ func TestWindowsNativeBaselineBootstrap(t *testing.T) {
 
 func TestWindowsNativeReadinessRequiresNodeAndNpm(t *testing.T) {
 	script := decodePowerShellCommand(t, sshReadyCommand(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}))
+	assertWindowsPowerShellPathRefresh(t, script)
 	for _, want := range []string{"node --version", "npm.cmd --version", `throw "node readiness failed"`, `throw "npm readiness failed"`} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("missing readiness requirement %s", want)
 		}
+	}
+}
+
+func assertWindowsPowerShellPathRefresh(t *testing.T, script string) {
+	t.Helper()
+	const prefix = "$ProgressPreference = \"SilentlyContinue\"\n" +
+		"$env:Path = [Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [Environment]::GetEnvironmentVariable('Path', 'User')\n"
+	if !strings.HasPrefix(script, prefix) {
+		t.Fatal("native PowerShell must refresh machine and user PATH before executing commands")
 	}
 }
 

--- a/recipes/bootstrap/v1/windowsFinalize.ps1
+++ b/recipes/bootstrap/v1/windowsFinalize.ps1
@@ -2,4 +2,5 @@
 	git --version | Out-Null
 	tar --version | Out-Null
 	Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString("o")
+	# Keep this last: Node and the other baselines update machine PATH above.
 	Restart-Service sshd -Force

--- a/worker/src/bootstrap.generated.ts
+++ b/worker/src/bootstrap.generated.ts
@@ -107,7 +107,7 @@ export function sharedWindowsNativePrelude(): string {
 
 // prettier-ignore
 export function sharedWindowsFinalize(): string {
-  return "\n\tgit --version | Out-Null\n\ttar --version | Out-Null\n\tSet-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString(\"o\")\n\tRestart-Service sshd -Force\n";
+  return "\n\tgit --version | Out-Null\n\ttar --version | Out-Null\n\tSet-Content -NoNewline -Encoding ASCII -Path $setupCompletePath -Value (Get-Date).ToString(\"o\")\n\t# Keep this last: Node and the other baselines update machine PATH above.\n\tRestart-Service sshd -Force\n";
 }
 
 // prettier-ignore

--- a/worker/test/bootstrap.test.ts
+++ b/worker/test/bootstrap.test.ts
@@ -835,6 +835,11 @@ describe("cloud-init bootstrap", () => {
       "Set-Content -NoNewline -Encoding ASCII -Path $setupCompletePath",
     );
     const restartIndex = got.indexOf("Restart-Service sshd -Force");
+    const nodeIndex = got.indexOf("\nEnsure-CrabboxNode\n");
+    const pathIndex = got.lastIndexOf('SetEnvironmentVariable("Path", $machinePath, "Machine")');
+    expect(nodeIndex).toBeGreaterThan(0);
+    expect(pathIndex).toBeGreaterThan(nodeIndex);
+    expect(restartIndex).toBeGreaterThan(pathIndex);
     expect(setupIndex).toBeGreaterThanOrEqual(0);
     expect(setupIndex).toBeLessThan(restartIndex);
     expect(got).not.toContain("tightvnc-2.8.85-gpl-setup-64bit.msi");


### PR DESCRIPTION
Native Windows readiness and `run --script-stdin` must find Node/npm after bootstrap registers them in the machine PATH. The reported AWS `windows/normal` tiny lease had Node 24.19.0 installed but `machinePathHasNode=True`, `sessionPathHasNode=False`, and `nodeOnPath=False` after https://github.com/openclaw/crabbox/pull/2069.

Windows OpenSSH sessions can retain the environment captured before the registry PATH update. The native readiness probe and framed PowerShell stdin wrapper previously used that inherited PATH. Both now begin by loading machine PATH followed by user PATH, before running the probe or child script.

Code inspection also confirmed that native bootstrap already ends with `Restart-Service sshd -Force`, after Node and the other PATH updates. Preserve that final restart, document its ordering, and cover it in Go and Worker regressions. Client-side bootstrap and its three stable readiness probes now use fresh SSH connections, restoring the ordinary workload connection policy afterward. Linux, WSL2, and macOS execution paths are unchanged.

Verification:

- Built with `/opt/homebrew/bin/go build -trimpath -o bin/crabbox ./cmd/crabbox`; `gofmt -l` and `git diff --check` clean; `/opt/homebrew/bin/go vet ./...` passed.
- Focused Go race tests passed for Windows bootstrap, readiness, stdin framing, fresh-session delivery, Azure bootstrap, and macOS regression coverage; shared bootstrap fixture race tests passed separately.
- Worker bootstrap/shared tests: 42 passed; formatting, lint, and TypeScript checks passed.
- Bootstrap generator checks: 12 passed, 2 skipped because local PowerShell is unavailable; generated Go/TypeScript fragments agree.
- Codex autoreview: no accepted findings at its default P0 threshold.

No dependency, credential, configuration-schema, or version changes. The coordinator is not deployed by this PR; the live test exercises the built client's completion path against the current coordinator.

Live proof (2026-09-10): one brokered AWS `windows/normal` tiny lease, `cbx_104c5ecc96fb`, using the built binary and a stock AMI. Warmup succeeded in 5m22s; `inspect --json` returned `ready: true`. `run --no-sync --script-stdin` exited 0 with Node `v24.19.0`, npm `11.17.0`, and `C:\Program Files\nodejs` in PATH. An additional fresh, non-multiplexed SSH connection without the PATH-refresh wrapper reported `machinePathHasNode=True`, `sessionPathHasNode=True`, and `nodeOnPath=True`.

Run: https://crabbox.openclaw.ai/portal/runs/run_01ba233590e01930787944c577f6a1d4

Cleanup: stopped `cbx_104c5ecc96fb`; a subsequent AWS lease listing contained no entry with slug `windows-session-path`.
