### PR TITLE
refactor: share Tart environment integer validation

### DIFF
--- a/internal/providers/tart/flags.go
+++ b/internal/providers/tart/flags.go
@@ -81,7 +81,7 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 		if err := validateTartEnvInt("CRABBOX_TART_MEMORY", 4096, "tart memory must be at least 4096 MB"); err != nil {
 			return err
 		}
-		if err := validateTartEnvIntNonNegative("CRABBOX_TART_DISK", "tart disk size must be non-negative"); err != nil {
+		if err := validateTartEnvInt("CRABBOX_TART_DISK", 0, "tart disk size must be non-negative"); err != nil {
 			return err
 		}
 		applyDefaults(cfg)
@@ -100,21 +100,6 @@ func validateTartEnvInt(name string, floor int, floorMsg string) error {
 	}
 	if n < floor {
 		return exit(2, "%s (got %d)", floorMsg, n)
-	}
-	return nil
-}
-
-func validateTartEnvIntNonNegative(name string, msg string) error {
-	v := os.Getenv(name)
-	if v == "" {
-		return nil
-	}
-	n, err := strconv.Atoi(v)
-	if err != nil {
-		return exit(2, "%s must be a valid integer (got %q)", name, v)
-	}
-	if n < 0 {
-		return exit(2, "%s (got %d)", msg, n)
 	}
 	return nil
 }

--- a/internal/providers/tart/provider_test.go
+++ b/internal/providers/tart/provider_test.go
@@ -3017,29 +3017,25 @@ func TestConfigureVMSkipsDiskWhenNotExplicit(t *testing.T) {
 	}
 }
 
-func TestValidateTartEnvIntNonNegative(t *testing.T) {
-	t.Setenv("CRABBOX_TART_DISK", "0")
-	err := validateTartEnvIntNonNegative("CRABBOX_TART_DISK", "disk must be non-negative")
-	if err != nil {
-		t.Fatalf("should accept 0: %v", err)
-	}
-
-	t.Setenv("CRABBOX_TART_DISK", "50")
-	err = validateTartEnvIntNonNegative("CRABBOX_TART_DISK", "disk must be non-negative")
-	if err != nil {
-		t.Fatalf("should accept 50: %v", err)
-	}
-
-	t.Setenv("CRABBOX_TART_DISK", "-1")
-	err = validateTartEnvIntNonNegative("CRABBOX_TART_DISK", "disk must be non-negative")
-	if err == nil {
-		t.Fatal("should reject negative disk")
-	}
-
-	t.Setenv("CRABBOX_TART_DISK", "abc")
-	err = validateTartEnvIntNonNegative("CRABBOX_TART_DISK", "disk must be non-negative")
-	if err == nil {
-		t.Fatal("should reject non-integer")
+func TestValidateTartEnvIntZeroMinimum(t *testing.T) {
+	for _, tc := range []struct{ raw, want string }{
+		{"", ""}, {"0", ""}, {"+0", ""}, {"50", ""},
+		{"-1", "disk must be non-negative (got -1)"},
+		{"abc", `CRABBOX_TART_DISK must be a valid integer (got "abc")`},
+		{" 50 ", `CRABBOX_TART_DISK must be a valid integer (got " 50 ")`},
+		{"99999999999999999999999", `CRABBOX_TART_DISK must be a valid integer (got "99999999999999999999999")`},
+	} {
+		t.Run(fmt.Sprintf("%q", tc.raw), func(t *testing.T) {
+			t.Setenv("CRABBOX_TART_DISK", tc.raw)
+			err := validateTartEnvInt("CRABBOX_TART_DISK", 0, "disk must be non-negative")
+			if tc.want == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else if err == nil || err.Error() != tc.want || core.ExitCodeForError(err, 1) != 2 {
+				t.Fatalf("error=%v, want exit2 %q", err, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Use one minimum-bound integer validator for Tart's CPU, memory and disk environment values. Disk now calls the existing validator with a minimum of zero; delete the duplicate nonnegative validator instead of retaining an alias.

The three calls stay in the same order and retain their existing messages. Raw empty input still skips validation, whitespace is not trimmed, malformed/overflowing integers still return the same exit-2 diagnostic, and negative disk values retain the nonnegative error. Selected-provider validation, defaults, resource explicitness, native execution and credential handling are unchanged. This is a complete consolidation of this one validation algorithm, not a claim that Tart's broader configuration migration is complete. No user-visible contract changes, so no changelog entry is needed.

Extend the existing zero-minimum test to retain its original cases and verify exact messages/codes for empty, explicit plus-zero, padded and overflowing input. The same assertions passed against the original helper before migration and the shared validator afterward; existing CPU and selected flag-validation tests remain.

## Verification

The PR head remains `9eb87cc615e73e11652645c1d2daffa50be57101`. An isolated integration with current main `ed5475d2ca05e81cf51c9f406f0f3973d119a914` has tree `06020e6a49894425c06f114b0de59c92a89fa75e`. It merges without conflicts and preserves the exact original Tart patch. Four focused race tests and 18 subtests, vet, the pinned dead-code check with empty output, rebuild, managed P0 review, and the targeted four-case CLI comparison passed on this combined tree. Source/index snapshots remained unchanged. The ordinary head-bound review also found no issues, but is not formal GitHub approval.

```sh
go test -race -count=1 -timeout=4m ./internal/providers/tart -run '^(TestValidateTartEnvIntZeroMinimum|TestValidateTartEnvInt|TestApplyFlagsRejectsInvalidEnvValues|TestApplyFlagsAcceptsDiskEnvValues)$'
go vet ./internal/providers/tart
go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...
go build -trimpath -buildvcs=false -o crabbox ./cmd/crabbox
```

Tests/build used a stripped environment with denied networking; the pinned dead-code tool used credential-free dependency resolution. The executed CLI proof below uses macOS arm64 / Go 1.26.5 and explicitly asserts the targeted disk-integer diagnostic before comparing binaries. A generic usage error cannot satisfy that proof. No native Tart VM, image/credential operation, release or fleet rollout was performed.

<details>
<summary>Executed current-main CLI proof and self-contained replay</summary>

### Executed Tart integer-parser current-main proof

The unchanged four embedded cases compare main `ed5475d2` with candidate tree `06020e6a49894425c06f114b0de59c92a89fa75e`. Only the standalone script's baseline hash binding changed. It creates every fixture, manifest, capture and seal itself, with no private-path or prior-proof dependency.

```sh
python3 tart-env-int-cli-proof.py --baseline ./baseline-crabbox --candidate ./candidate-crabbox --output ./tart-int-proof-results --candidate-sha256 47ec07a8279348c07fefd28780061096e0adf5caf4d4c93c3f190982f1fc4375
```

Process exit was 0. Each phase executed four cases once: one help success and three exit-2 errors. Every error produced the frozen targeted `CRABBOX_TART_DISK must be a valid integer (got ...)` diagnostic with empty stdout; generic missing-workload usage did not substitute. Complete raw streams/status/timeouts matched, with no timeouts, normalization or retries. Prior proof remained unchanged.

Scope is early local environment-integer validation and installed help only. No successful run, native Tart, image, credential or security behavior is claimed.

Observed targeted diagnostics:

```json
[
  {
    "id": "02-disk-word",
    "stderr": "CRABBOX_TART_DISK must be a valid integer (got \"not-an-int\")\n"
  },
  {
    "id": "03-disk-fractional",
    "stderr": "CRABBOX_TART_DISK must be a valid integer (got \"1.5\")\n"
  },
  {
    "id": "04-disk-padded",
    "stderr": "CRABBOX_TART_DISK must be a valid integer (got \" 4 \")\n"
  }
]
```

Observed stdout:

```json
{
  "baseline_sha256": "dbd33fc3590f2813c4f071d1a03b06e235250925f7b87f12251c4aff12e6940b",
  "candidate_sha256": "47ec07a8279348c07fefd28780061096e0adf5caf4d4c93c3f190982f1fc4375",
  "differences": [],
  "final_seal_sha256": "1cec74513be13d442788305d7c674f0ed34091139b4d2e58628ec53b0d615b4c",
  "outcomes": {
    "baseline": {
      "exit0": 1,
      "exit2": 3,
      "timeouts": 0
    },
    "candidate": {
      "exit0": 1,
      "exit2": 3,
      "timeouts": 0
    }
  },
  "phase_counts": {
    "baseline": 4,
    "candidate": 4
  },
  "scope": "Source-qualified early malformed Tart disk environment integer diagnostics and installed help only; no config-show, successful run, native Tart, image, credential or security proof.",
  "script_sha256": "5ebf97146fcd4ea97945bebdab59a878e478dd2828708e19910e9c012b836548",
  "status": "pass"
}
```

Full exact executed script (SHA-256 `5ebf97146fcd4ea97945bebdab59a878e478dd2828708e19910e9c012b836548`):

```python
#!/usr/bin/env python3
"""macOS-only, stdlib-only Tart disk environment integer parser CLI preservation proof."""
import argparse
import hashlib
import json
import subprocess
from pathlib import Path

# id, argv tail, exact UTF-8 config bytes, environment overrides,
# capture config after command, source-qualified baseline exit.
CASES = [
    ['01-installed-help', ['run', '--help'], '{}\n', {}, False, 0],
    ['02-disk-word', ['run', '--provider', 'tart', '--timing-record', 'off'], '{}\n', {'CRABBOX_TART_DISK': 'not-an-int'}, False, 2],
    ['03-disk-fractional', ['run', '--provider', 'tart', '--timing-record', 'off'], '{}\n', {'CRABBOX_TART_DISK': '1.5'}, False, 2],
    ['04-disk-padded', ['run', '--provider', 'tart', '--timing-record', 'off'], '{}\n', {'CRABBOX_TART_DISK': ' 4 '}, False, 2],
]
EXPECTED_BASELINE = "dbd33fc3590f2813c4f071d1a03b06e235250925f7b87f12251c4aff12e6940b"


def sha(data):
    return hashlib.sha256(data).hexdigest()


def file_sha(path):
    return sha(path.read_bytes())


def save(path, value):
    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")


def inventory(root):
    return {str(p.relative_to(root)): file_sha(p)
            for p in sorted(root.rglob("*")) if p.is_file()}


def verify_files(root, files):
    for name, expected in files.items():
        assert file_sha(root / name) == expected, name


def main():
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--baseline", required=True, type=Path)
    parser.add_argument("--candidate", required=True, type=Path)
    parser.add_argument("--output", required=True, type=Path)
    parser.add_argument("--candidate-sha256", help="Optional expected candidate hash supplied by the build owner")
    args = parser.parse_args()
    baseline = args.baseline.resolve()
    candidate = args.candidate.resolve()
    candidate_digest = file_sha(candidate)
    if args.candidate_sha256:
        assert candidate_digest == args.candidate_sha256, "supplied candidate hash"
    output = args.output.resolve()
    assert file_sha(baseline) == EXPECTED_BASELINE, "baseline hash"
    assert file_sha(candidate) == candidate_digest, "candidate hash"
    assert len(CASES) == 4 and len({c[0] for c in CASES}) == 4
    output.mkdir(parents=True, exist_ok=False)
    script = Path(__file__).read_bytes()
    (output / "executed-script.py").write_bytes(script)
    sandbox = output / "network-deny.sb"
    sandbox.write_text("(version 1)\n(allow default)\n(deny network*)\n")
    manifest = []
    for cid, tail, fixture, overrides, capture, expected_exit in CASES:
        area = output / "runtime" / cid
        home = area / "home"
        cwd = area / "cwd"
        home.mkdir(parents=True)
        cwd.mkdir()
        config = area / "config.yaml"
        config.write_bytes(fixture.encode("utf-8"))
        env = {"HOME": str(home), "XDG_CONFIG_HOME": str(home / "xdg"),
               "XDG_STATE_HOME": str(home / "state"), "TMPDIR": str(home),
               "CRABBOX_CONFIG": str(config)}
        env.update(overrides)
        manifest.append({"id": cid, "args": tail, "fixture": fixture,
                         "env": env, "cwd": str(cwd),
                         "capture_config": capture, "expected_exit": expected_exit})
    save(output / "manifest.json", manifest)
    prepared = inventory(output)
    save(output / "preparation-seal.json", {"files": prepared})
    all_results = {}
    prior_seals = {}
    for phase, executable in [("baseline", baseline), ("candidate", candidate)]:
        verify_files(output, prepared)
        for name, files in prior_seals.items():
            verify_files(output / name, files)
        assert file_sha(baseline) == EXPECTED_BASELINE
        assert file_sha(candidate) == candidate_digest
        phase_dir = output / phase
        phase_dir.mkdir()
        results = []
        for case in manifest:
            dest = phase_dir / case["id"]
            dest.mkdir()
            config = Path(case["env"]["CRABBOX_CONFIG"])
            initial = case["fixture"].encode("utf-8")
            assert config.read_bytes() == initial
            argv = ["/usr/bin/sandbox-exec", "-f", str(sandbox),
                    str(executable)] + case["args"]
            try:
                run = subprocess.run(argv, cwd=case["cwd"], env=case["env"],
                                     stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE, timeout=5)
                stdout, stderr, code, timed = run.stdout, run.stderr, run.returncode, False
            except subprocess.TimeoutExpired as error:
                stdout, stderr = error.stdout or b"", error.stderr or b""
                code, timed = None, True
            (dest / "stdout.bin").write_bytes(stdout)
            (dest / "stderr.bin").write_bytes(stderr)
            after = config.read_bytes() if config.exists() else None
            if case["capture_config"] and after is not None:
                (dest / "config-after.bin").write_bytes(after)
            record = {"argv": argv, "env": case["env"], "cwd": case["cwd"],
                      "stdin": "DEVNULL", "timeout_seconds": 5,
                      "exit_code": code, "timed_out": timed,
                      "stdout_sha256": sha(stdout), "stderr_sha256": sha(stderr),
                      "config_exists": after is not None,
                      "config_sha256": None if after is None else sha(after)}
            save(dest / "record.json", record)
            config.write_bytes(initial)
            differences = []
            if case["expected_exit"] == 2:
                expected_message = b"CRABBOX_TART_DISK must be a valid integer (got "
                if expected_message not in stderr:
                    differences.append("expected early disk integer diagnostic")
                if stdout:
                    differences.append("unexpected stdout on early parser error")
            if phase == "baseline":
                if timed or code != case["expected_exit"]:
                    differences.append("unexpected baseline outcome")
            else:
                reference = output / "baseline" / case["id"]
                before = json.loads((reference / "record.json").read_text())
                assert before["argv"][:3] == argv[:3]
                assert before["argv"][4:] == argv[4:]
                for key in ["env", "cwd", "stdin", "timeout_seconds"]:
                    assert before[key] == record[key]
                for key in ["exit_code", "timed_out"]:
                    if before[key] != record[key]:
                        differences.append(key)
                for stream in ["stdout.bin", "stderr.bin"]:
                    if (reference / stream).read_bytes() != (dest / stream).read_bytes():
                        differences.append(stream)
                if case["capture_config"]:
                    if before["config_exists"] != record["config_exists"]:
                        differences.append("config existence")
                    elif after is not None and (reference / "config-after.bin").read_bytes() != after:
                        differences.append("config-after.bin")
            results.append({"id": case["id"], "exit_code": code,
                            "timed_out": timed, "differences": differences})
            if differences:
                break
        verify_files(output, prepared)
        for name, files in prior_seals.items():
            verify_files(output / name, files)
        assert file_sha(baseline) == EXPECTED_BASELINE
        assert file_sha(candidate) == candidate_digest
        all_results[phase] = results
        save(phase_dir / "results.json", results)
        files = inventory(phase_dir)
        save(output / (phase + "-seal.json"), {"files": files})
        prior_seals[phase] = files
        if len(results) != 4 or any(r["differences"] for r in results):
            break
    passed = (len(all_results.get("candidate", [])) == 4 and
              not any(r["differences"] for rows in all_results.values() for r in rows))
    summary = {"status": "pass" if passed else "stopped",
               "baseline_sha256": EXPECTED_BASELINE,
               "candidate_sha256": candidate_digest,
               "script_sha256": sha(script),
               "phase_counts": {k: len(v) for k, v in all_results.items()},
               "outcomes": {k: {"exit0": sum(r["exit_code"] == 0 for r in v),
                                 "exit2": sum(r["exit_code"] == 2 for r in v),
                                 "timeouts": sum(r["timed_out"] for r in v)}
                            for k, v in all_results.items()},
               "differences": [r for rows in all_results.values() for r in rows
                               if r["differences"]],
               "scope": "Source-qualified early malformed Tart disk environment integer diagnostics and installed help only; no config-show, successful run, native Tart, image, credential or security proof."}
    save(output / "report.json", summary)
    save(output / "final-seal.json", {"files": inventory(output)})
    summary["final_seal_sha256"] = file_sha(output / "final-seal.json")
    print(json.dumps(summary, indent=2, sort_keys=True))
    return 0 if passed else 1


if __name__ == "__main__":
    raise SystemExit(main())
```

</details>
