### PR TITLE
refactor: share signed integer environment parsing

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -7425,15 +7425,10 @@ func getenv(name, fallback string) string {
 }
 
 func getenvInt(name string, fallback int) int {
-	v := os.Getenv(name)
-	if v == "" {
-		return fallback
+	if value, ok := lookupEnvInteger(name, strconv.IntSize); ok {
+		return int(value)
 	}
-	n, err := strconv.Atoi(v)
-	if err != nil {
-		return fallback
-	}
-	return n
+	return fallback
 }
 
 func getenvNonNegativeInt(name string, fallback int) (int, error) {
@@ -7452,27 +7447,31 @@ func getenvNonNegativeInt(name string, fallback int) (int, error) {
 }
 
 func getenvInt32(name string, fallback int32) int32 {
-	v := os.Getenv(name)
-	if v == "" {
-		return fallback
+	if value, ok := lookupEnvInteger(name, 32); ok {
+		return int32(value)
 	}
-	n, err := strconv.ParseInt(v, 10, 32)
-	if err != nil {
-		return fallback
-	}
-	return int32(n)
+	return fallback
 }
 
 func getenvInt64(name string, fallback int64) int64 {
-	v := os.Getenv(name)
-	if v == "" {
-		return fallback
+	if value, ok := lookupEnvInteger(name, 64); ok {
+		return value
 	}
-	n, err := strconv.ParseInt(v, 10, 64)
+	return fallback
+}
+
+// lookupEnvInteger reports accepted raw decimal input independently of fallback
+// policy. An explicit zero or a value equal to the fallback still counts.
+func lookupEnvInteger(name string, bitSize int) (int64, bool) {
+	value := os.Getenv(name)
+	if value == "" {
+		return 0, false
+	}
+	parsed, err := strconv.ParseInt(value, 10, bitSize)
 	if err != nil {
-		return fallback
+		return 0, false
 	}
-	return n
+	return parsed, true
 }
 
 func getenvFloat(name string, fallback float64) float64 {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -11066,6 +11066,103 @@ func TestWindowsWSLWorkRoot(t *testing.T) {
 	}
 }
 
+func envIntegerCases() []struct {
+	name, value    string
+	want32, want64 int64
+	ok32, ok64     bool
+} {
+	return []struct {
+		name, value    string
+		want32, want64 int64
+		ok32, ok64     bool
+	}{
+		{"unset", "", 7, 7, false, false},
+		{"empty", "", 7, 7, false, false},
+		{"same as fallback", "7", 7, 7, true, true},
+		{"zero", "0", 0, 0, true, true},
+		{"plus zero", "+0", 0, 0, true, true},
+		{"negative zero", "-0", 0, 0, true, true},
+		{"negative", "-12", -12, -12, true, true},
+		{"positive sign", "+12", 12, 12, true, true},
+		{"decimal leading zero", "042", 42, 42, true, true},
+		{"padded", " 12 ", 7, 7, false, false},
+		{"newline", "12\n", 7, 7, false, false},
+		{"fractional", "1.5", 7, 7, false, false},
+		{"word", "invalid", 7, 7, false, false},
+		{"hex prefix", "0x10", 7, 7, false, false},
+		{"underscore", "1_000", 7, 7, false, false},
+		{"unicode digit", "１２", 7, 7, false, false},
+		{"only sign", "+", 7, 7, false, false},
+		{"int32 max", "2147483647", 2147483647, 2147483647, true, true},
+		{"int32 min", "-2147483648", -2147483648, -2147483648, true, true},
+		{"int32 positive overflow", "2147483648", 7, 2147483648, false, true},
+		{"int32 negative overflow", "-2147483649", 7, -2147483649, false, true},
+		{"int64 max", "9223372036854775807", 7, 9223372036854775807, false, true},
+		{"int64 min", "-9223372036854775808", 7, -9223372036854775808, false, true},
+		{"int64 positive overflow", "9223372036854775808", 7, 7, false, false},
+		{"int64 negative overflow", "-9223372036854775809", 7, 7, false, false},
+	}
+}
+
+func TestEnvIntegerFallbacks(t *testing.T) {
+	const name = "CRABBOX_TEST_INTEGER"
+	for _, helper := range []struct {
+		name string
+		bits int
+		read func(string) int64
+	}{
+		{"native", strconv.IntSize, func(name string) int64 { return int64(getenvInt(name, 7)) }},
+		{"int32", 32, func(name string) int64 { return int64(getenvInt32(name, 7)) }},
+		{"int64", 64, func(name string) int64 { return getenvInt64(name, 7) }},
+	} {
+		t.Run(helper.name, func(t *testing.T) {
+			for _, tc := range envIntegerCases() {
+				t.Run(tc.name, func(t *testing.T) {
+					t.Setenv(name, tc.value)
+					if tc.name == "unset" {
+						if err := os.Unsetenv(name); err != nil {
+							t.Fatal(err)
+						}
+					}
+					want := tc.want64
+					if helper.bits == 32 {
+						want = tc.want32
+					}
+					if got := helper.read(name); got != want {
+						t.Fatalf("%q at %d bits: got %d, want %d", tc.value, helper.bits, got, want)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestLookupEnvIntegerAcceptance(t *testing.T) {
+	const name = "CRABBOX_TEST_INTEGER"
+	for _, bits := range []int{32, 64} {
+		t.Run(strconv.Itoa(bits), func(t *testing.T) {
+			for _, tc := range envIntegerCases() {
+				t.Run(tc.name, func(t *testing.T) {
+					t.Setenv(name, tc.value)
+					if tc.name == "unset" {
+						if err := os.Unsetenv(name); err != nil {
+							t.Fatal(err)
+						}
+					}
+					want, accepted := tc.want64, tc.ok64
+					if bits == 32 {
+						want, accepted = tc.want32, tc.ok32
+					}
+					got, ok := lookupEnvInteger(name, bits)
+					if ok != accepted || (ok && got != want) {
+						t.Fatalf("%q: got (%d,%v), want (%d,%v)", tc.value, got, ok, want, accepted)
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestEnvHelperBranches(t *testing.T) {
 	t.Setenv("CRABBOX_INT", "42")
 	t.Setenv("CRABBOX_BAD_INT", "oops")

--- a/scripts/configgen/main_test.go
+++ b/scripts/configgen/main_test.go
@@ -1357,23 +1357,7 @@ func TestGenerateEnvIntFallback(t *testing.T) {
 	}
 	typecheckGenerated(t, input+"\nfunc getenvInt(string,int) int { panic(\"stub\") }\n", output)
 	// Execute the existing core helpers verbatim, rather than a test-specific integer parser.
-	coreSource, err := os.ReadFile("../../internal/cli/config.go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	helpers := ""
-	for _, name := range []string{"getenvInt", "getenvNonNegativeInt"} {
-		start := strings.Index(string(coreSource), "func "+name+"(")
-		if start < 0 {
-			t.Fatalf("missing core helper %s", name)
-		}
-		rest := string(coreSource)[start:]
-		end := strings.Index(rest, "\nfunc ")
-		if end < 0 {
-			t.Fatalf("missing end for core helper %s", name)
-		}
-		helpers += rest[:end] + "\n"
-	}
+	helpers := configFixtureFunctions(t, "getenvInt", "getenvNonNegativeInt", "lookupEnvInteger")
 	const behavior = `package cli
 import ("flag";"fmt";"os";"strconv";"testing")
 func exit(_ int, pattern string, args ...any) error { return fmt.Errorf(pattern,args...) }
@@ -2237,23 +2221,7 @@ func TestGenerateFileIntNonzero(t *testing.T) {
 		" Positive int `sources:\"user,repo,env,flag\" config:\"positive\" env:\"POSITIVE\" flag:\"positive\" help:\"Positive\" nonnegative:\"true\" fileInt:\"positive\"`\n" +
 		" Present int `sources:\"user,repo,env,flag\" config:\"present\" env:\"PRESENT\" flag:\"present\" help:\"Present\" nonnegative:\"true\" fileInt:\"present\"`\n" +
 		" Strict int `sources:\"user,repo,env,flag\" config:\"strict\" env:\"STRICT\" flag:\"strict\" help:\"Strict\" nonnegative:\"true\"`\n}"
-	coreSource, err := os.ReadFile("../../internal/cli/config.go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	helpers := ""
-	for _, name := range []string{"getenvInt", "getenvNonNegativeInt"} {
-		start := strings.Index(string(coreSource), "func "+name+"(")
-		if start < 0 {
-			t.Fatalf("missing helper %s", name)
-		}
-		rest := string(coreSource)[start:]
-		end := strings.Index(rest, "\nfunc ")
-		if end < 0 {
-			t.Fatalf("missing end for %s", name)
-		}
-		helpers += rest[:end] + "\n"
-	}
+	helpers := configFixtureFunctions(t, "getenvInt", "getenvNonNegativeInt", "lookupEnvInteger")
 	for _, fallback := range []bool{false, true} {
 		input := source
 		if fallback {
@@ -2372,19 +2340,7 @@ func TestGenerateFallbackIntAlias(t *testing.T) {
 		t.Fatal("integer alias changed non-env bindings")
 	}
 	typecheckGenerated(t, source+"\nfunc getenvInt(string,int)int{panic(\"stub\")}\n", output)
-	coreSource, err := os.ReadFile("../../internal/cli/config.go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	start := strings.Index(string(coreSource), "func getenvInt(")
-	if start < 0 {
-		t.Fatal("missing getenvInt")
-	}
-	rest := string(coreSource)[start:]
-	end := strings.Index(rest, "\nfunc ")
-	if end < 0 {
-		t.Fatal("missing helper end")
-	}
+	helpers := configFixtureFunctions(t, "getenvInt", "lookupEnvInteger")
 	const behavior = `package cli
 import("flag";"os";"strconv";"testing")
 func flagWasSet(fs *flag.FlagSet,name string)bool{found:=false;fs.Visit(func(f *flag.Flag){if f.Name==name{found=true}});return found}
@@ -2399,7 +2355,7 @@ func TestNestedFallback(t *testing.T){
  if err:=fs.Parse([]string{"--count=0"});err!=nil{t.Fatal(err)};values.Apply(&cfg,fs);if cfg.Count!=0{t.Fatal("flag zero changed")}
 }
 `
-	runScalarFixture(t, source, output, behavior+rest[:end])
+	runScalarFixture(t, source, output, behavior+helpers)
 }
 
 func TestSchemaNonemptyRawAndEmptyScalarLists(t *testing.T) {
@@ -2565,19 +2521,7 @@ func TestGenerateInt64Width(t *testing.T) {
 	}
 	typecheckGenerated(t, int64Sample+"\nfunc getenvInt64(string,int64)int64{panic(\"stub\")}\n", output)
 	// Exercise the actual core ParseInt(...,64) helper rather than another parser.
-	coreSource, err := os.ReadFile("../../internal/cli/config.go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	start := strings.Index(string(coreSource), "func getenvInt64(")
-	if start < 0 {
-		t.Fatal("missing int64 helper")
-	}
-	rest := string(coreSource)[start:]
-	end := strings.Index(rest, "\nfunc ")
-	if end < 0 {
-		t.Fatal("missing helper end")
-	}
+	helpers := configFixtureFunctions(t, "getenvInt64", "lookupEnvInteger")
 	const behavior = `package cli
 import("flag";"os";"strconv";"testing")
 func flagWasSet(fs *flag.FlagSet,name string)bool{found:=false;fs.Visit(func(f *flag.Flag){if f.Name==name{found=true}});return found}
@@ -2593,7 +2537,7 @@ func TestWidth(t *testing.T){
  for _,raw:=range []string{"0","-9223372036854775808","9223372036854775807"}{cfg:=defaultPilotConfig();fs:=flag.NewFlagSet("fixture",flag.ContinueOnError);values:=RegisterPilotConfigFlags(fs,cfg);if err:=fs.Parse([]string{"--wide="+raw});err!=nil{t.Fatal(err)};values.Apply(&cfg,fs);want,_:=strconv.ParseInt(raw,10,64);if cfg.Wide!=want{t.Fatalf("flag%q: %+v",raw,cfg)}}
 }
 `
-	runScalarFixture(t, int64Sample, output, behavior+rest[:end])
+	runScalarFixture(t, int64Sample, output, behavior+helpers)
 	for _, mode := range []string{"present", "nonzero"} {
 		input := strings.Replace(int64Sample, `fileInt:"positive"`, `fileInt:"`+mode+`"`, 1)
 		s, err := parseSchema([]byte(input), "PilotConfig", "pilot")
@@ -3285,6 +3229,29 @@ func TestUntrackedPartialOrder(t *testing.T){
 }
 `
 	runScalarFixture(t, untracked, untrackedOutput, untrackedBehavior+helper)
+}
+
+func configFixtureFunctions(t *testing.T, names ...string) string {
+	t.Helper()
+	source, err := os.ReadFile("../../internal/cli/config.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var functions strings.Builder
+	for _, name := range names {
+		start := strings.Index(string(source), "func "+name+"(")
+		if start < 0 {
+			t.Fatalf("missing core helper %s", name)
+		}
+		rest := string(source)[start:]
+		end := strings.Index(rest, "\nfunc ")
+		if end < 0 {
+			t.Fatalf("missing end for core helper %s", name)
+		}
+		functions.WriteString(rest[:end])
+		functions.WriteByte('\n')
+	}
+	return functions.String()
 }
 
 func applyLeaseDurationFixtureSource(t *testing.T) string {


### PR DESCRIPTION
## Summary

Consolidate signed integer environment parsing into one raw base-10 parser, with explicit width and an acceptance result. The native-int, int32 and int64 getters keep their existing fallback policy. Empty, malformed, padded and overflowing values retain the fallback; zero, negative and fallback-equal values remain valid inputs. Strict nonnegative and floating-point policies are unchanged.

The acceptance result separates actual input from a retained fallback without parsing twice. This is a prerequisite for accurate configuration-source reporting, not implementation or closure of https://github.com/openclaw/crabbox/issues/1465.

Extend the existing config test suite with a 25-case width/fallback matrix, run against the original parsers before the refactor, and direct acceptance tests. Keep the generator execution fixtures tied to the real production helpers; consolidate their four repeated extraction paths into one small helper without weakening any behavior assertions.

No public behavior, flags, defaults, configuration grants or credential policy changes. No user-facing release-note entry is needed for this behavior-preserving refactor.

## Verification

Head `4bb055fae2317443b18eda3e80e610bfaad4626c`, tree `efd02aae357107022c88fa377cc233fdb05bd0d5`, based on main `65e60af8affb82adca03a6ea1817561c67a9b863`.

- Focused race suite: 9 tests and 175 subtests passed, including existing Machine0 configuration and lease-duration display coverage.
- Full generator race suite: 101 tests and 297 subtests passed, including all 41 generated-file freshness checks.
- Vet, pinned dead-code check (empty output) and build passed. Source hashes remained unchanged during the gates.
- Managed Codex review: scoped-clean at P0 for the final three-file change.
- Installed-CLI comparison: 13 cases, each with three independently expected public integer values; all 39 value/type assertions per binary and complete output/status comparisons passed.

```sh
go test -race -count=1 -timeout=4m ./internal/cli -run '^(TestEnvIntegerFallbacks|TestLookupEnvIntegerAcceptance|TestEnvHelperBranches|TestMachine0.*|TestConfigShowEffectiveLeaseDurations)$'
go test -race -count=1 -timeout=4m ./scripts/configgen
go vet ./internal/cli
go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...
go build -trimpath -buildvcs=false -o crabbox ./cmd/crabbox
```

Tests/build/CLI proof used a stripped environment with denied networking; the pinned dead-code tool used credential-free dependency resolution. macOS arm64 / Go 1.26.5. Native 32-bit execution and native provider lifecycle operations are not claimed. A missing closing brace in the initial new test edit was corrected before the successful original-parser baseline; the production baseline itself was unchanged.

<details>
<summary>Executed semantic CLI proof and self-contained replay</summary>

### Executed signed environment integer CLI semantic proof

The standalone script below embeds thirteen cases, exact fixtures and independently fixed expected values. It creates its own synthetic directories, manifest, captures and seals and requires no private path, source checkout or previous proof. Requirements are Python standard library, macOS sandbox-exec, a 64-bit host/build and the supplied executables.

```sh
python3 env-integer-cli-proof.py --baseline ./baseline-crabbox --candidate ./candidate-crabbox --output ./env-int-proof-results --candidate-sha256 802ce199629141211bd94953d3e462f09dfb8f9f0bc5c96360c7daaf709655a5
```

The process exited 0. Each binary executed thirteen cases once, all exit 0 with empty stderr and no timeouts. Independently expected integer values and JSON integer types passed for all three widths, followed by exact full stdout/stderr/status/timeout comparisons. Missing/empty/invalid/padded/nondecimal inputs retained the file value; zero, negative, equal and signed decimal inputs assigned; width-specific overflow fallbacks matched the frozen expectations. No normalization or retries occurred. Original preparation and both executable hashes verified before/after.

The public route is inactive `config show --provider xcp-ng --json`. Machine0 imageVersion covers native 64-bit int, AWS rootGB covers int32, and Tencent Cloud rootGB covers int64. No selected provider runtime, auth or security behavior is claimed, and native 32-bit execution remains untested.

Observed stdout:

```json
{
  "baseline_sha256": "47ec07a8279348c07fefd28780061096e0adf5caf4d4c93c3f190982f1fc4375",
  "candidate_sha256": "802ce199629141211bd94953d3e462f09dfb8f9f0bc5c96360c7daaf709655a5",
  "differences": [],
  "final_seal_sha256": "2c2b67a890c30411d09a078d2c8d254555368d290fdc05723c538a3fecbe92b4",
  "outcomes": {
    "baseline": {
      "exit0": 13,
      "exit2": 0,
      "timeouts": 0
    },
    "candidate": {
      "exit0": 13,
      "exit2": 0,
      "timeouts": 0
    }
  },
  "phase_counts": {
    "baseline": 13,
    "candidate": 13
  },
  "scope": "Source-qualified inactive public JSON for native 64-bit int, int32 and int64 environment parsing; no selected Machine0/AWS/Tencent runtime, auth or security proof. Native 32-bit execution is not covered.",
  "script_sha256": "f87403644900b90b9e779803bd86b6a2c2e502ce2b4c6621d0b4f0336d603150",
  "status": "pass"
}
```

Semantic observations:

```json
[
  {
    "case": "01-missing",
    "expected": {
      "int32": 7,
      "int64": 7,
      "native": 7
    },
    "observed": {
      "int32": 7,
      "int64": 7,
      "native": 7
    }
  },
  {
    "case": "02-empty",
    "expected": {
      "int32": 7,
      "int64": 7,
      "native": 7
    },
    "observed": {
      "int32": 7,
      "int64": 7,
      "native": 7
    }
  },
  {
    "case": "03-invalid",
    "expected": {
      "int32": 7,
      "int64": 7,
      "native": 7
    },
    "observed": {
      "int32": 7,
      "int64": 7,
      "native": 7
    }
  },
  {
    "case": "04-padded",
    "expected": {
      "int32": 7,
      "int64": 7,
      "native": 7
    },
    "observed": {
      "int32": 7,
      "int64": 7,
      "native": 7
    }
  },
  {
    "case": "05-zero",
    "expected": {
      "int32": 0,
      "int64": 0,
      "native": 0
    },
    "observed": {
      "int32": 0,
      "int64": 0,
      "native": 0
    }
  },
  {
    "case": "06-negative",
    "expected": {
      "int32": -5,
      "int64": -5,
      "native": -5
    },
    "observed": {
      "int32": -5,
      "int64": -5,
      "native": -5
    }
  },
  {
    "case": "07-equal-prior",
    "expected": {
      "int32": 7,
      "int64": 7,
      "native": 7
    },
    "observed": {
      "int32": 7,
      "int64": 7,
      "native": 7
    }
  },
  {
    "case": "08-plus-decimal",
    "expected": {
      "int32": 12,
      "int64": 12,
      "native": 12
    },
    "observed": {
      "int32": 12,
      "int64": 12,
      "native": 12
    }
  },
  {
    "case": "09-nondecimal-prefix",
    "expected": {
      "int32": 7,
      "int64": 7,
      "native": 7
    },
    "observed": {
      "int32": 7,
      "int64": 7,
      "native": 7
    }
  },
  {
    "case": "10-int32-overflow",
    "expected": {
      "int32": 7,
      "int64": 2147483648,
      "native": 2147483648
    },
    "observed": {
      "int32": 7,
      "int64": 2147483648,
      "native": 2147483648
    }
  },
  {
    "case": "11-int64-max",
    "expected": {
      "int32": 7,
      "int64": 9223372036854775807,
      "native": 9223372036854775807
    },
    "observed": {
      "int32": 7,
      "int64": 9223372036854775807,
      "native": 9223372036854775807
    }
  },
  {
    "case": "12-int64-overflow",
    "expected": {
      "int32": 7,
      "int64": 7,
      "native": 7
    },
    "observed": {
      "int32": 7,
      "int64": 7,
      "native": 7
    }
  },
  {
    "case": "13-int32-underflow",
    "expected": {
      "int32": 7,
      "int64": -2147483649,
      "native": -2147483649
    },
    "observed": {
      "int32": 7,
      "int64": -2147483649,
      "native": -2147483649
    }
  }
]
```

Full exact executed script (SHA-256 `f87403644900b90b9e779803bd86b6a2c2e502ce2b4c6621d0b4f0336d603150`):

```python
#!/usr/bin/env python3
"""macOS-only, stdlib-only Signed environment integer public CLI semantic proof."""
import argparse
import hashlib
import json
import subprocess
import struct
from pathlib import Path

# id, argv tail, exact UTF-8 config bytes, environment overrides,
# capture config after command, source-qualified baseline exit.
CASES = [
    ['01-missing', ['config', 'show', '--provider', 'xcp-ng', '--json'], '{\n  "machine0": {\n    "imageVersion": 7\n  },\n  "aws": {\n    "rootGB": 7\n  },\n  "tencentcloud": {\n    "rootGB": 7\n  }\n}\n', {}, False, 0],
    ['02-empty', ['config', 'show', '--provider', 'xcp-ng', '--json'], '{\n  "machine0": {\n    "imageVersion": 7\n  },\n  "aws": {\n    "rootGB": 7\n  },\n  "tencentcloud": {\n    "rootGB": 7\n  }\n}\n', {'CRABBOX_MACHINE0_IMAGE_VERSION': '', 'CRABBOX_AWS_ROOT_GB': '', 'CRABBOX_TENCENTCLOUD_ROOT_GB': ''}, False, 0],
    ['03-invalid', ['config', 'show', '--provider', 'xcp-ng', '--json'], '{\n  "machine0": {\n    "imageVersion": 7\n  },\n  "aws": {\n    "rootGB": 7\n  },\n  "tencentcloud": {\n    "rootGB": 7\n  }\n}\n', {'CRABBOX_MACHINE0_IMAGE_VERSION': 'many', 'CRABBOX_AWS_ROOT_GB': 'many', 'CRABBOX_TENCENTCLOUD_ROOT_GB': 'many'}, False, 0],
    ['04-padded', ['config', 'show', '--provider', 'xcp-ng', '--json'], '{\n  "machine0": {\n    "imageVersion": 7\n  },\n  "aws": {\n    "rootGB": 7\n  },\n  "tencentcloud": {\n    "rootGB": 7\n  }\n}\n', {'CRABBOX_MACHINE0_IMAGE_VERSION': ' 12 ', 'CRABBOX_AWS_ROOT_GB': ' 12 ', 'CRABBOX_TENCENTCLOUD_ROOT_GB': ' 12 '}, False, 0],
    ['05-zero', ['config', 'show', '--provider', 'xcp-ng', '--json'], '{\n  "machine0": {\n    "imageVersion": 7\n  },\n  "aws": {\n    "rootGB": 7\n  },\n  "tencentcloud": {\n    "rootGB": 7\n  }\n}\n', {'CRABBOX_MACHINE0_IMAGE_VERSION': '0', 'CRABBOX_AWS_ROOT_GB': '0', 'CRABBOX_TENCENTCLOUD_ROOT_GB': '0'}, False, 0],
    ['06-negative', ['config', 'show', '--provider', 'xcp-ng', '--json'], '{\n  "machine0": {\n    "imageVersion": 7\n  },\n  "aws": {\n    "rootGB": 7\n  },\n  "tencentcloud": {\n    "rootGB": 7\n  }\n}\n', {'CRABBOX_MACHINE0_IMAGE_VERSION': '-5', 'CRABBOX_AWS_ROOT_GB': '-5', 'CRABBOX_TENCENTCLOUD_ROOT_GB': '-5'}, False, 0],
    ['07-equal-prior', ['config', 'show', '--provider', 'xcp-ng', '--json'], '{\n  "machine0": {\n    "imageVersion": 7\n  },\n  "aws": {\n    "rootGB": 7\n  },\n  "tencentcloud": {\n    "rootGB": 7\n  }\n}\n', {'CRABBOX_MACHINE0_IMAGE_VERSION': '7', 'CRABBOX_AWS_ROOT_GB': '7', 'CRABBOX_TENCENTCLOUD_ROOT_GB': '7'}, False, 0],
    ['08-plus-decimal', ['config', 'show', '--provider', 'xcp-ng', '--json'], '{\n  "machine0": {\n    "imageVersion": 7\n  },\n  "aws": {\n    "rootGB": 7\n  },\n  "tencentcloud": {\n    "rootGB": 7\n  }\n}\n', {'CRABBOX_MACHINE0_IMAGE_VERSION': '+12', 'CRABBOX_AWS_ROOT_GB': '+12', 'CRABBOX_TENCENTCLOUD_ROOT_GB': '+12'}, False, 0],
    ['09-nondecimal-prefix', ['config', 'show', '--provider', 'xcp-ng', '--json'], '{\n  "machine0": {\n    "imageVersion": 7\n  },\n  "aws": {\n    "rootGB": 7\n  },\n  "tencentcloud": {\n    "rootGB": 7\n  }\n}\n', {'CRABBOX_MACHINE0_IMAGE_VERSION': '0x10', 'CRABBOX_AWS_ROOT_GB': '0x10', 'CRABBOX_TENCENTCLOUD_ROOT_GB': '0x10'}, False, 0],
    ['10-int32-overflow', ['config', 'show', '--provider', 'xcp-ng', '--json'], '{\n  "machine0": {\n    "imageVersion": 7\n  },\n  "aws": {\n    "rootGB": 7\n  },\n  "tencentcloud": {\n    "rootGB": 7\n  }\n}\n', {'CRABBOX_MACHINE0_IMAGE_VERSION': '2147483648', 'CRABBOX_AWS_ROOT_GB': '2147483648', 'CRABBOX_TENCENTCLOUD_ROOT_GB': '2147483648'}, False, 0],
    ['11-int64-max', ['config', 'show', '--provider', 'xcp-ng', '--json'], '{\n  "machine0": {\n    "imageVersion": 7\n  },\n  "aws": {\n    "rootGB": 7\n  },\n  "tencentcloud": {\n    "rootGB": 7\n  }\n}\n', {'CRABBOX_MACHINE0_IMAGE_VERSION': '9223372036854775807', 'CRABBOX_AWS_ROOT_GB': '9223372036854775807', 'CRABBOX_TENCENTCLOUD_ROOT_GB': '9223372036854775807'}, False, 0],
    ['12-int64-overflow', ['config', 'show', '--provider', 'xcp-ng', '--json'], '{\n  "machine0": {\n    "imageVersion": 7\n  },\n  "aws": {\n    "rootGB": 7\n  },\n  "tencentcloud": {\n    "rootGB": 7\n  }\n}\n', {'CRABBOX_MACHINE0_IMAGE_VERSION': '9223372036854775808', 'CRABBOX_AWS_ROOT_GB': '9223372036854775808', 'CRABBOX_TENCENTCLOUD_ROOT_GB': '9223372036854775808'}, False, 0],
    ['13-int32-underflow', ['config', 'show', '--provider', 'xcp-ng', '--json'], '{\n  "machine0": {\n    "imageVersion": 7\n  },\n  "aws": {\n    "rootGB": 7\n  },\n  "tencentcloud": {\n    "rootGB": 7\n  }\n}\n', {'CRABBOX_MACHINE0_IMAGE_VERSION': '-2147483649', 'CRABBOX_AWS_ROOT_GB': '-2147483649', 'CRABBOX_TENCENTCLOUD_ROOT_GB': '-2147483649'}, False, 0],
]
EXPECTED_VALUES = {'01-missing': {'native': 7, 'int32': 7, 'int64': 7}, '02-empty': {'native': 7, 'int32': 7, 'int64': 7}, '03-invalid': {'native': 7, 'int32': 7, 'int64': 7}, '04-padded': {'native': 7, 'int32': 7, 'int64': 7}, '05-zero': {'native': 0, 'int32': 0, 'int64': 0}, '06-negative': {'native': -5, 'int32': -5, 'int64': -5}, '07-equal-prior': {'native': 7, 'int32': 7, 'int64': 7}, '08-plus-decimal': {'native': 12, 'int32': 12, 'int64': 12}, '09-nondecimal-prefix': {'native': 7, 'int32': 7, 'int64': 7}, '10-int32-overflow': {'native': 2147483648, 'int32': 7, 'int64': 2147483648}, '11-int64-max': {'native': 9223372036854775807, 'int32': 7, 'int64': 9223372036854775807}, '12-int64-overflow': {'native': 7, 'int32': 7, 'int64': 7}, '13-int32-underflow': {'native': -2147483649, 'int32': 7, 'int64': -2147483649}}
EXPECTED_BASELINE = "47ec07a8279348c07fefd28780061096e0adf5caf4d4c93c3f190982f1fc4375"


def sha(data):
    return hashlib.sha256(data).hexdigest()


def file_sha(path):
    return sha(path.read_bytes())


def save(path, value):
    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")


def inventory(root):
    return {str(p.relative_to(root)): file_sha(p)
            for p in sorted(root.rglob("*")) if p.is_file()}


def verify_files(root, files):
    for name, expected in files.items():
        assert file_sha(root / name) == expected, name


def main():
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--baseline", required=True, type=Path)
    parser.add_argument("--candidate", required=True, type=Path)
    parser.add_argument("--output", required=True, type=Path)
    parser.add_argument("--candidate-sha256", help="Optional expected candidate hash supplied by the build owner")
    args = parser.parse_args()
    assert struct.calcsize("P") == 8, "This frozen native-int expectation targets 64-bit binaries/host"
    baseline = args.baseline.resolve()
    candidate = args.candidate.resolve()
    candidate_digest = file_sha(candidate)
    if args.candidate_sha256:
        assert candidate_digest == args.candidate_sha256, "supplied candidate hash"
    output = args.output.resolve()
    assert file_sha(baseline) == EXPECTED_BASELINE, "baseline hash"
    assert file_sha(candidate) == candidate_digest, "candidate hash"
    assert len(CASES) == 13 and len({c[0] for c in CASES}) == 13
    output.mkdir(parents=True, exist_ok=False)
    script = Path(__file__).read_bytes()
    (output / "executed-script.py").write_bytes(script)
    sandbox = output / "network-deny.sb"
    sandbox.write_text("(version 1)\n(allow default)\n(deny network*)\n")
    manifest = []
    for cid, tail, fixture, overrides, capture, expected_exit in CASES:
        area = output / "runtime" / cid
        home = area / "home"
        cwd = area / "cwd"
        home.mkdir(parents=True)
        cwd.mkdir()
        config = area / "config.yaml"
        config.write_bytes(fixture.encode("utf-8"))
        env = {"HOME": str(home), "XDG_CONFIG_HOME": str(home / "xdg"),
               "XDG_STATE_HOME": str(home / "state"), "TMPDIR": str(home),
               "CRABBOX_CONFIG": str(config)}
        env.update(overrides)
        manifest.append({"id": cid, "args": tail, "fixture": fixture,
                         "env": env, "cwd": str(cwd),
                         "capture_config": capture, "expected_exit": expected_exit})
    save(output / "manifest.json", manifest)
    prepared = inventory(output)
    save(output / "preparation-seal.json", {"files": prepared})
    all_results = {}
    prior_seals = {}
    for phase, executable in [("baseline", baseline), ("candidate", candidate)]:
        verify_files(output, prepared)
        for name, files in prior_seals.items():
            verify_files(output / name, files)
        assert file_sha(baseline) == EXPECTED_BASELINE
        assert file_sha(candidate) == candidate_digest
        phase_dir = output / phase
        phase_dir.mkdir()
        results = []
        for case in manifest:
            dest = phase_dir / case["id"]
            dest.mkdir()
            config = Path(case["env"]["CRABBOX_CONFIG"])
            initial = case["fixture"].encode("utf-8")
            assert config.read_bytes() == initial
            argv = ["/usr/bin/sandbox-exec", "-f", str(sandbox),
                    str(executable)] + case["args"]
            try:
                run = subprocess.run(argv, cwd=case["cwd"], env=case["env"],
                                     stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE, timeout=5)
                stdout, stderr, code, timed = run.stdout, run.stderr, run.returncode, False
            except subprocess.TimeoutExpired as error:
                stdout, stderr = error.stdout or b"", error.stderr or b""
                code, timed = None, True
            (dest / "stdout.bin").write_bytes(stdout)
            (dest / "stderr.bin").write_bytes(stderr)
            after = config.read_bytes() if config.exists() else None
            if case["capture_config"] and after is not None:
                (dest / "config-after.bin").write_bytes(after)
            record = {"argv": argv, "env": case["env"], "cwd": case["cwd"],
                      "stdin": "DEVNULL", "timeout_seconds": 5,
                      "exit_code": code, "timed_out": timed,
                      "stdout_sha256": sha(stdout), "stderr_sha256": sha(stderr),
                      "config_exists": after is not None,
                      "config_sha256": None if after is None else sha(after)}
            save(dest / "record.json", record)
            config.write_bytes(initial)
            differences = []
            observed = None
            try:
                data = json.loads(stdout)
                observed = {"native": data["machine0"]["imageVersion"],
                            "int32": data["aws"]["rootGB"],
                            "int64": data["tencentcloud"]["rootGB"]}
            except (ValueError, KeyError, TypeError):
                differences.append("missing public integer projection")
            if observed != EXPECTED_VALUES[case["id"]]:
                differences.append("semantic expected integer values")
            if observed is not None and any(type(value) is not int for value in observed.values()):
                differences.append("integer JSON type")
            if stderr:
                differences.append("expected quiet fallback")
            if phase == "baseline":
                if timed or code != case["expected_exit"]:
                    differences.append("unexpected baseline outcome")
            else:
                reference = output / "baseline" / case["id"]
                before = json.loads((reference / "record.json").read_text())
                assert before["argv"][:3] == argv[:3]
                assert before["argv"][4:] == argv[4:]
                for key in ["env", "cwd", "stdin", "timeout_seconds"]:
                    assert before[key] == record[key]
                for key in ["exit_code", "timed_out"]:
                    if before[key] != record[key]:
                        differences.append(key)
                for stream in ["stdout.bin", "stderr.bin"]:
                    if (reference / stream).read_bytes() != (dest / stream).read_bytes():
                        differences.append(stream)
                if case["capture_config"]:
                    if before["config_exists"] != record["config_exists"]:
                        differences.append("config existence")
                    elif after is not None and (reference / "config-after.bin").read_bytes() != after:
                        differences.append("config-after.bin")
            results.append({"id": case["id"], "exit_code": code,
                            "timed_out": timed, "observed": observed, "expected": EXPECTED_VALUES[case["id"]], "differences": differences})
            if differences:
                break
        verify_files(output, prepared)
        for name, files in prior_seals.items():
            verify_files(output / name, files)
        assert file_sha(baseline) == EXPECTED_BASELINE
        assert file_sha(candidate) == candidate_digest
        all_results[phase] = results
        save(phase_dir / "results.json", results)
        files = inventory(phase_dir)
        save(output / (phase + "-seal.json"), {"files": files})
        prior_seals[phase] = files
        if len(results) != 13 or any(r["differences"] for r in results):
            break
    passed = (len(all_results.get("candidate", [])) == 13 and
              not any(r["differences"] for rows in all_results.values() for r in rows))
    summary = {"status": "pass" if passed else "stopped",
               "baseline_sha256": EXPECTED_BASELINE,
               "candidate_sha256": candidate_digest,
               "script_sha256": sha(script),
               "phase_counts": {k: len(v) for k, v in all_results.items()},
               "outcomes": {k: {"exit0": sum(r["exit_code"] == 0 for r in v),
                                 "exit2": sum(r["exit_code"] == 2 for r in v),
                                 "timeouts": sum(r["timed_out"] for r in v)}
                            for k, v in all_results.items()},
               "differences": [r for rows in all_results.values() for r in rows
                               if r["differences"]],
               "scope": "Source-qualified inactive public JSON for native 64-bit int, int32 and int64 environment parsing; no selected Machine0/AWS/Tencent runtime, auth or security proof. Native 32-bit execution is not covered."}
    save(output / "report.json", summary)
    save(output / "final-seal.json", {"files": inventory(output)})
    summary["final_seal_sha256"] = file_sha(output / "final-seal.json")
    print(json.dumps(summary, indent=2, sort_keys=True))
    return 0 if passed else 1


if __name__ == "__main__":
    raise SystemExit(main())
```

</details>
