### PR TITLE
fix(daytona): preserve caller-owned stop lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Daytona: let signal- or deadline-owned `stop` and its `release` alias wait for confirmed deletion without the 30-second automatic-cleanup cap; preserve the bounded fallback for non-cancelable job callers and existing run/watch cleanup and rollback budgets.
 - Discover accepted preflight names, defaults, and target support offline with `crabbox preflight-tools [--json]`; unknown names now point to that installed-binary catalog before lease acquisition. [PR 2081](https://github.com/openclaw/crabbox/pull/2081), [Issue 1589](https://github.com/openclaw/crabbox/issues/1589). Thanks @coygeek.
 - Keep Sprites API, bootstrap, and SSH commands on the configured account and endpoint; validate ownership before reuse, require explicit adoption without a local claim, keep plain status observational, use native tool checks for readiness, and safely recover already-deleted resources. [PR 1776](https://github.com/openclaw/crabbox/pull/1776), [PR 2077](https://github.com/openclaw/crabbox/pull/2077). Thanks @aezell.
 

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -97,7 +97,10 @@ Crabbox lease ID and local slug:
   fresh matching session ownership metadata before terminating the sandbox.
   Failed termination keeps the claim; claimless sessions require explicit
   `--reclaim` reuse.
-- `daytona` — deletes the Daytona sandbox.
+- `daytona` — deletes the Daytona sandbox and waits for confirmed deletion under
+  the caller's cancellation and deadline. The CLI remains signal-cancelable;
+  the automatic-cleanup timeout does not shorten that lifetime. Non-cancelable
+  callers, including detached job cleanup, retain the 30-second fallback.
 - `coder` — stops the Coder workspace by default and removes the local claim.
   Set `coder.deleteOnRelease` or pass `--coder-delete-on-release` to delete the
   workspace instead.

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -301,8 +301,13 @@ Daytona lifetime settings use whole minutes, so positive durations are rounded
 up. Idle auto-stop preserves the sandbox filesystem; native TTL ultimately
 deletes the sandbox. `heartbeat --idle-timeout` changes the provider's auto-stop
 policy as well as Crabbox metadata. Status readiness comes from Daytona's live
-state, never a previously stored `ready` label. Explicit stop and rollback wait
-for confirmed provider deletion, with a bounded cleanup deadline.
+state, never a previously stored `ready` label. Explicit `crabbox stop` (and its
+`release` alias) waits for confirmed provider deletion under the caller's
+cancellation and deadline. The CLI remains interruptible by signal; a supervising
+process owns its command budget. Non-cancelable callers, including detached job
+cleanup, retain the 30-second fallback. Individual control-plane requests retain
+their 60-second limit. Automatic run/watch cleanup and detached rollback keep
+their separate 30-second budget.
 If `stop` cannot resolve the claimed sandbox, it returns the lookup error and
 preserves the local recovery claim. A missing sandbox in the current account or
 API endpoint does not prove deletion in the original scope, even after native TTL.

--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -300,8 +300,13 @@ func (b *daytonaLeaseBackend) Status(ctx context.Context, req StatusRequest) (st
 }
 
 func (b *daytonaLeaseBackend) Stop(ctx context.Context, req StopRequest) error {
-	ctx, cancel := context.WithTimeout(ctx, daytonaCleanupTimeout)
-	defer cancel()
+	// Detached callers such as job cleanup have no cancellation owner. Keep
+	// their bounded fallback without shortening an owned CLI/controller lifetime.
+	if ctx.Done() == nil {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, daytonaCleanupTimeout)
+		defer cancel()
+	}
 	if claim, exists, err := resolveLeaseClaimForProvider(req.ID, daytonaProvider); err != nil {
 		return err
 	} else if exists && claim.FixedCreateIntent != nil {

--- a/internal/providers/daytona/stop_lifetime_test.go
+++ b/internal/providers/daytona/stop_lifetime_test.go
@@ -1,0 +1,136 @@
+package daytona
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	api "github.com/daytonaio/daytona/libs/api-client-go"
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type observingDaytonaContextAPI struct {
+	fixedDaytonaDeletionAPI
+	beforeGet func(context.Context) error
+}
+
+func (a *observingDaytonaContextAPI) GetSandbox(ctx context.Context, id string) (*api.Sandbox, error) {
+	if err := a.beforeGet(ctx); err != nil {
+		return nil, err
+	}
+	return a.fixedDaytonaDeletionAPI.GetSandbox(ctx, id)
+}
+
+func observeDaytonaDeletionContext(t *testing.T, beforeGet func(context.Context) error) {
+	t.Helper()
+	original := newDaytonaClient
+	newDaytonaClient = func(cfg Config, rt Runtime) (daytonaAPI, error) {
+		client, err := original(cfg, rt)
+		if err != nil {
+			return nil, err
+		}
+		return &observingDaytonaContextAPI{fixedDaytonaDeletionAPI: client.(fixedDaytonaDeletionAPI), beforeGet: beforeGet}, nil
+	}
+	t.Cleanup(func() { newDaytonaClient = original })
+}
+
+func TestDaytonaStopAndCleanupContextOwnership(t *testing.T) {
+	for _, fixed := range []bool{false, true} {
+		for _, operation := range []string{"stop", "release", "background", "without-cancel"} {
+			for _, deadline := range []bool{false, true} {
+				if operation != "stop" && deadline {
+					continue
+				}
+				t.Run(fmt.Sprintf("fixed=%t/%s/deadline=%t", fixed, operation, deadline), func(t *testing.T) {
+					_, b, req := newFixedDaytonaFixture(t)
+					if !fixed {
+						req.RequestedLeaseID = ""
+					}
+					lease, err := b.Acquire(t.Context(), req)
+					if err != nil {
+						t.Fatal(err)
+					}
+					ctx, cancel := context.WithCancel(context.Background())
+					if deadline {
+						cancel()
+						ctx, cancel = context.WithTimeout(context.Background(), 2*time.Minute)
+					}
+					if operation == "background" {
+						cancel()
+						ctx = context.Background()
+					} else if operation == "without-cancel" {
+						ctx = context.WithoutCancel(ctx)
+					}
+					defer cancel()
+					wantDeadline, wantBound := ctx.Deadline()
+					reads := 0
+					observeDaytonaDeletionContext(t, func(actual context.Context) error {
+						reads++
+						gotDeadline, gotBound := actual.Deadline()
+						if operation == "stop" {
+							if gotBound != wantBound || gotBound && !gotDeadline.Equal(wantDeadline) {
+								t.Errorf("explicit stop replaced caller deadline: got=%v bounded=%t want=%v bounded=%t", gotDeadline, gotBound, wantDeadline, wantBound)
+							}
+						} else if !gotBound || time.Until(gotDeadline) > 30*time.Second {
+							t.Errorf("non-cancelable stop or automatic release lost its bounded cleanup lifetime: deadline=%v bounded=%t", gotDeadline, gotBound)
+						}
+						return nil
+					})
+					if operation != "release" {
+						err = b.Stop(ctx, StopRequest{ID: lease.LeaseID})
+					} else {
+						err = b.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease})
+					}
+					if err != nil || reads == 0 {
+						t.Fatalf("explicit %s did not finish confirmed cleanup: reads=%d err=%v", operation, reads, err)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestDaytonaInterruptedExplicitStopRetainsAcknowledgment(t *testing.T) {
+	for _, deadline := range []bool{false, true} {
+		t.Run(fmt.Sprintf("deadline=%t", deadline), func(t *testing.T) {
+			f, b, req := newFixedDaytonaFixture(t)
+			lease, err := b.Acquire(t.Context(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			f.deletionPending = true
+			ctx, cancel := context.WithCancel(context.Background())
+			wantErr := context.Canceled
+			if deadline {
+				cancel()
+				ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+				wantErr = context.DeadlineExceeded
+			}
+			defer cancel()
+			observeDaytonaDeletionContext(t, func(actual context.Context) error {
+				f.mu.Lock()
+				deletionSubmitted := f.deletes != 0
+				f.mu.Unlock()
+				if !deletionSubmitted {
+					return nil
+				}
+				if !deadline {
+					cancel()
+				}
+				<-actual.Done()
+				return actual.Err()
+			})
+			err = b.Stop(ctx, StopRequest{ID: lease.LeaseID})
+			if !errors.Is(err, wantErr) {
+				t.Fatalf("stop did not honor caller termination: %v", err)
+			}
+			claim, exists, readErr := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if readErr != nil || !exists || claim.FixedCreateIntent.State == "released" ||
+				claim.FixedCreateIntent.Attempt["deletion_acknowledged_id"] != lease.Server.CloudID || f.deletes != 1 {
+				t.Fatalf("interrupted deletion lost acknowledgment or retired custody: claim=%+v err=%v", claim, readErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

An explicit Daytona stop could fail after 30 seconds even when its supervising caller allowed more time. In a native idle-worker test, deletion took 35.662 seconds from destroying to destroyed; the stop exited after 30.069 seconds with `context deadline exceeded`, retaining cleanup responsibility for recovery.

## Why This Change Was Made

Stop now preserves a caller context that can be canceled or has a deadline. The CLI's signal context and controller deadlines can therefore govern the complete deletion operation. Non-cancelable callers retain the existing 30-second fallback, including the automatic job cleanup shipped in v0.55.0. Internal ReleaseLease and detached rollback retain their existing bounds.

The fixed lease still requires the original organization, a recorded deletion acknowledgement, and confirmed absence before terminal state is recorded. Cancellation keeps the acknowledgement and cleanup responsibility available for recovery.

## User Impact

Explicit `crabbox stop` and its `release` alias can finish legitimate slow Daytona deletion under their caller-owned lifetime. Existing background job and automatic release cleanup remain bounded.

## Evidence

- Four ordinary/fixed Stop lifetime cases failed on the original code and pass with the repair. Non-cancelable Background/WithoutCancel fallback, automatic release bounds, cancellation and deadline expiry with a retained deletion acknowledgement are covered.
- Final lifetime race tests passed in 9.981 seconds and the full Daytona race suite passed in 116.854 seconds. Vet, docs generation, whitespace checks and fresh independent P2 review passed.
- The earlier native campaign verified cold preparation, capture, ready reuse, isolation, restoration and restart, then failed at this stop cutoff. Recovery removed all four sandboxes and the snapshot; independent API reads and native destroyed-state notifications confirmed removal. That run remains recorded as failed.
- The fresh native run used the reviewed task-local build `0.55.0+stop-lifetime.bce8f9c36a5f`. All native CLI commands and all four explicit Stop calls completed successfully, including automatic idle expiry after Gateway restart. Independent exact-ID database/GET reads, snapshot GET, process checks and four native destroyed-state events confirm cleanup. The consumer harness subsequently hit a separate observation race: it sampled the Gateway row 2 milliseconds before terminal bookkeeping completed. Its failed result is retained; that harness correction and supplemental consumer qualification are separate from this Stop fix. No release was published.

Related lifecycle support: https://github.com/openclaw/crabbox/pull/1700
