### PR TITLE
refactor(providers): use shared exact tag codecs

### DIFF
--- a/internal/providers/digitalocean/tags.go
+++ b/internal/providers/digitalocean/tags.go
@@ -59,7 +59,7 @@ func encodeTagKV(key, value string) string {
 	key = sanitizeTagPart(key)
 	if tagSchema.Exact(key) {
 		key += "_v1"
-		return tagPrefix + key + ":" + encodeExactTagValue(value, 255-len(tagPrefix)-len(key)-1)
+		return tagPrefix + key + ":" + shared.EncodeExactTagValue(value, 255-len(tagPrefix)-len(key)-1)
 	}
 	return tagPrefix + key + ":" + sanitizeTagPart(value)
 }
@@ -89,14 +89,6 @@ func legacyEncodedExactTagValueKey(key string) bool {
 	default:
 		return false
 	}
-}
-
-func encodeExactTagValue(value string, maxLen int) string {
-	return shared.EncodeExactTagValue(value, maxLen)
-}
-
-func decodeExactTagValue(value string) string {
-	return shared.DecodeExactTagValue(value)
 }
 
 func normalizeTags(tags []string) []string {
@@ -129,13 +121,13 @@ func labelsFromTags(tags []string) map[string]string {
 			}
 			key := strings.ToLower(parts[0])
 			if logical, ok := versionedExactTagValueKey(key); ok {
-				versionedExact.Record(logical, decodeExactTagValue(parts[1]))
+				versionedExact.Record(logical, shared.DecodeExactTagValue(parts[1]))
 				continue
 			}
 			if tagSchema.Exact(key) {
 				value := parts[1]
 				if legacyEncodedExactTagValueKey(key) {
-					value = decodeExactTagValue(value)
+					value = shared.DecodeExactTagValue(value)
 				}
 				legacyExact.Record(key, value)
 				continue

--- a/internal/providers/linode/tags.go
+++ b/internal/providers/linode/tags.go
@@ -74,7 +74,7 @@ func encodeChunkedTagKV(key, value string) []string {
 	if chunkSize <= 0 {
 		return nil
 	}
-	encoded := encodeExactTagValue(value, maxEncodedTagValueLength)
+	encoded := shared.EncodeExactTagValue(value, maxEncodedTagValueLength)
 	chunkCount := (len(encoded) + chunkSize - 1) / chunkSize
 	if chunkCount == 0 {
 		chunkCount = 1
@@ -119,14 +119,6 @@ func legacyEncodedExactTagValueKey(key string) bool {
 	}
 }
 
-func encodeExactTagValue(value string, maxLen int) string {
-	return shared.EncodeExactTagValue(value, maxLen)
-}
-
-func decodeExactTagValue(value string) string {
-	return shared.DecodeExactTagValue(value)
-}
-
 func normalizeTags(tags []string) []string {
 	seen := map[string]bool{}
 	out := make([]string, 0, len(tags))
@@ -168,13 +160,13 @@ func labelsFromTags(tags []string) map[string]string {
 				continue
 			}
 			if logical, ok := versionedExactTagValueKey(key); ok {
-				versionedExact.Record(logical, decodeExactTagValue(parts[1]))
+				versionedExact.Record(logical, shared.DecodeExactTagValue(parts[1]))
 				continue
 			}
 			if tagSchema.Exact(key) {
 				value := parts[1]
 				if legacyEncodedExactTagValueKey(key) {
-					value = decodeExactTagValue(value)
+					value = shared.DecodeExactTagValue(value)
 				}
 				legacyExact.Record(key, value)
 				continue
@@ -197,7 +189,7 @@ func labelsFromTags(tags []string) map[string]string {
 			encoded.WriteString(part)
 		}
 		if _, _, conflict := versionedExact.Get(key); !conflict {
-			versionedExact.Record(key, decodeExactTagValue(encoded.String()))
+			versionedExact.Record(key, shared.DecodeExactTagValue(encoded.String()))
 		}
 	}
 	for _, key := range tagSchema.Keys() {

--- a/internal/providers/scaleway/tags.go
+++ b/internal/providers/scaleway/tags.go
@@ -56,7 +56,7 @@ func encodeTagKV(key, value string) string {
 	key = sanitizeTagPart(key)
 	if exactTagValueKey(key) {
 		key += "_v1"
-		return tagPrefix + key + ":" + encodeExactTagValue(value, 255-len(tagPrefix)-len(key)-1)
+		return tagPrefix + key + ":" + shared.EncodeExactTagValue(value, 255-len(tagPrefix)-len(key)-1)
 	}
 	return tagPrefix + key + ":" + sanitizeTagPart(value)
 }
@@ -86,14 +86,6 @@ func exactTagValueKey(key string) bool {
 func versionedExactTagValueKey(key string) (string, bool) {
 	logical := strings.TrimSuffix(key, "_v1")
 	return logical, logical != key && exactTagValueKey(logical)
-}
-
-func encodeExactTagValue(value string, maxLen int) string {
-	return shared.EncodeExactTagValue(value, maxLen)
-}
-
-func decodeExactTagValue(value string) string {
-	return shared.DecodeExactTagValue(value)
 }
 
 func normalizeTags(tags []string) []string {
@@ -128,7 +120,7 @@ func labelsFromTags(tags []string) map[string]string {
 			key := strings.ToLower(parts[0])
 			value := parts[1]
 			if logical, ok := versionedExactTagValueKey(key); ok {
-				labels[logical] = decodeExactTagValue(value)
+				labels[logical] = shared.DecodeExactTagValue(value)
 				continue
 			}
 			switch key {


### PR DESCRIPTION
## What Problem This Solves

DigitalOcean, Linode, and Scaleway each kept provider-local forwarding wrappers around the same exact-tag codec behavior.

## Why This Change Was Made

### Summary

Replace six provider-local forwarding wrappers in DigitalOcean, Linode, and Scaleway with the existing shared exact-tag codecs. Behavior is unchanged.

## User Impact

No user-visible behavior changes. Provider tag encoding and decoding continue to use the same shared implementation.

## Evidence

### Tests

- `go test -race -count=1 -timeout=20m ./internal/providers/digitalocean ./internal/providers/linode ./internal/providers/scaleway`
- `go vet ./...`
- `go build -trimpath -o /tmp/crabbox-exact-tags-native-20260911 ./cmd/crabbox`

No changelog entry: this is an internal behavior-preserving refactor.
