### PR TITLE
chore: prepare 0.56.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.56.0 - 2026-09-11
 
 ### Highlights
 

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.55.0",
+      "version": "0.56.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1120.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Finalize the reviewed changelog as 0.56.0 dated 2026-09-11 and align the Worker package version plus both root lockfile entries. The release highlights native Windows reliability, offline configuration and tool discovery, restored Linux desktop reuse, Daytona replay, and safer Sprites/sync behavior.

Validation: version consistency and unchanged-note assertions, git diff --check, documentation checks, and independent autoreview. Full hosted CI and a coordinator-backed Linux run with event/log/attach and cleanup verification gate tagging and candidate production.
