### PR TITLE
fix(config): share passive provider display fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Validate sparse-checkout and skip-worktree sync scope before SSH lease work, explain how to materialize or exclude missing tracked files, and rebuild the final manifest after acquisition. [PR 2097](https://github.com/openclaw/crabbox/pull/2097), [Issue 1567](https://github.com/openclaw/crabbox/issues/1567). Thanks @coygeek.
 - Include the resolved `workroot` in SSH-backed inspect/status JSON, including native Windows and WSL2 leases. [PR 2069](https://github.com/openclaw/crabbox/pull/2069). Thanks @steipete.
 - Show Phala settings in offline configuration text and JSON, preserving unset versus explicit attestation settings without invoking the provider CLI. [PR 2099](https://github.com/openclaw/crabbox/pull/2099). Thanks @steipete.
+- Show Freestyle and Crownest settings through a shared offline JSON/text display path, preserving zero and false values while redacting URLs and reporting only loaded key presence.
 
 ### Maintenance
 

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -64,6 +64,14 @@ means no explicit override; `true` and `false` remain distinct. This is a
 configuration value, not evidence that remote attestation has run or passed.
 Inspection does not read Phala's stored credentials or invoke its CLI.
 
+Freestyle and Crownest also have value sections in both formats, including
+when unselected. Freestyle shows the loaded URL, relative workdir, CPU/memory
+settings and API-key presence (`auth: configured` or `missing`), never the key.
+Zero sizing remains zero rather than a guessed service-plan default. Crownest
+shows its loaded URL, project, template, timeout and cleanup preference without
+looking up credentials. Zero timeout and explicit false remain visible. URLs
+are redacted; these values are configuration, not live-provider proof.
+
 ### Offline provider status
 
 JSON adds a `providerStatus` object with `schemaVersion: 1`, `kind: "offline"`,

--- a/docs/refactor/provider-config-display.md
+++ b/docs/refactor/provider-config-display.md
@@ -1,0 +1,62 @@
+# Provider configuration display
+
+`ProviderConfigShowProjector` gives a provider one passive, output-only field
+definition for JSON and text. The shared collector and renderers consume
+`ProviderConfigShowSection` and its ordered fields. Providers choose the public
+field names and already-redacted values; the renderer does not inspect runtime
+structs, infer visibility from input tags, or discover credentials or defaults.
+
+Freestyle and Crownest are the first adopters. Both sections appear even when
+another provider is selected. Freestyle reports only presence for an API key
+already loaded into configuration; Crownest does not look up its separate key.
+Zero sizes/timeouts, explicit false, and raw strings retain their configured
+meaning. Neither section establishes authentication or readiness.
+
+## Ownership
+
+- `JSONValue` is an explicitly selected public value, never a runtime-config dump.
+- `TextValue` is the corresponding explicitly formatted, already-redacted value.
+- Format-specific names are independent: published camel-case JSON and
+  snake-case text names need not match. A field may intentionally appear in one
+  format only; each section must provide both formats.
+- `Providers` declares canonical coverage. A shared configuration owner can
+  cover multiple registered providers without emitting duplicate sections.
+- Existing URL redaction and configured/missing formatting are shared through
+  `ConfigShowURL` and `ConfigShowSecretState`; presenters must not introduce
+  new environment, file, SDK, CLI, or network reads.
+
+Collection rejects duplicate keys, labels, field names and coverage. JSON
+insertion also rejects collisions with the existing top-level view before
+adding any section. Text reserves the existing line labels without evaluating
+JSON values, which would repeat legacy environment-presence reads. A source
+test keeps that label inventory aligned with the actual formatters.
+
+New sections have stable text-label order immediately before the existing
+offline inspection/status block. Existing lines and fields keep their current
+order. Output errors, including short writes, propagate from text rendering.
+
+## Remaining migration
+
+The baseline census contains 81 canonical providers: 49 have both value formats,
+three have JSON only, and 29 have neither. Apple Machine shares Apple Container's
+configuration, so complete coverage means **80 distinct sections**, not 81
+duplicate sections.
+
+The first two adopters leave **27 missing sections and three missing text
+sections**. They do not complete the migration. Existing provider projections
+also still need to move out of the parallel JSON map and text formatter so
+their field selection and transformations have one owner.
+
+For each remaining provider, establish the explicit public field contract
+before implementation. Preserve existing keys, types, null/empty distinctions,
+raw-versus-display defaults, redaction, count-versus-list text summaries and
+format-only fields. Keep nested External configuration allowlisted or summarized;
+do not expose opaque maps. Paths and secret names are references, not permission
+to read their contents. Runtime-only state stays omitted.
+
+When migrating an existing text section, render it in its original layout slot
+and retire the corresponding legacy label reservation together. Do not move
+existing sections into registry order. Preserve Apple sharing and the generic
+lines interleaved with provider sections. Built-in coverage is complete only
+when every canonical provider has exactly one intended section; test fixtures
+must not stand in for missing real providers.

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -68,10 +68,16 @@ func (a App) configShow(args []string) error {
 		view["idempotentLeaseId"] = fixedLeaseID
 		view["coordinatorRegistrationUrl"] = redactedConfigURL(coordinatorRegistrationURL)
 		view["webvncAgentBaseUrl"] = agentBaseURL
+		sections, err := collectProviderConfigShowSections(cfg)
+		if err != nil {
+			return err
+		}
+		if err := addProviderConfigShowSections(view, sections); err != nil {
+			return err
+		}
 		return json.NewEncoder(a.Stdout).Encode(view)
 	}
-	writeConfigShowText(a.Stdout, cfg)
-	return nil
+	return writeConfigShowText(a.Stdout, cfg)
 }
 
 func configArchitectureForShow(cfg Config) string {
@@ -824,7 +830,13 @@ func redactedParallelsHostConfigs(hosts []ParallelsHostConfig) []ParallelsHostCo
 	return redacted
 }
 
-func writeConfigShowText(w io.Writer, cfg Config) {
+func writeConfigShowText(w io.Writer, cfg Config) error {
+	sections, err := collectProviderConfigShowSections(cfg)
+	if err != nil {
+		return err
+	}
+	output := &configShowWriter{Writer: w}
+	w = output
 	phalaAttest := "default"
 	if cfg.Phala.Attest != nil {
 		phalaAttest = fmt.Sprint(*cfg.Phala.Attest)
@@ -905,7 +917,11 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "firecracker binary=%s jailer=%s kernel=%s rootfs=%s user=%s work_root=%s cpus=%d memory_mib=%d disk_mib=%d network=%s cni_network=%s cni_conf_dir=%s cni_bin_dir=%s launch_timeout=%s delete_on_release=%t\n", blank(cfg.Firecracker.Binary, "-"), blank(cfg.Firecracker.Jailer, "-"), blank(cfg.Firecracker.Kernel, "-"), blank(cfg.Firecracker.RootFS, "-"), blank(cfg.Firecracker.User, "-"), blank(cfg.Firecracker.WorkRoot, "-"), cfg.Firecracker.CPUs, cfg.Firecracker.MemoryMiB, cfg.Firecracker.DiskMiB, blank(cfg.Firecracker.Network, "-"), blank(cfg.Firecracker.CNINetwork, "-"), blank(cfg.Firecracker.CNIConfDir, "-"), blank(cfg.Firecracker.CNIBinDir, "-"), cfg.Firecracker.LaunchTimeout, cfg.Firecracker.DeleteOnRelease)
 	fmt.Fprintf(w, "xcp_ng api_url=%s username=%s template=%s template_uuid=%s sr=%s sr_uuid=%s network=%s network_uuid=%s host=%s user=%s work_root=%s insecure_tls=%t auth=%s\n", blank(redactedConfigURL(cfg.XCPNg.APIURL), "-"), blank(cfg.XCPNg.Username, "-"), blank(cfg.XCPNg.Template, "-"), blank(cfg.XCPNg.TemplateUUID, "-"), blank(cfg.XCPNg.SR, "-"), blank(cfg.XCPNg.SRUUID, "-"), blank(cfg.XCPNg.Network, "-"), blank(cfg.XCPNg.NetworkUUID, "-"), blank(cfg.XCPNg.Host, "-"), cfg.XCPNg.User, cfg.XCPNg.WorkRoot, cfg.XCPNg.InsecureTLS, tokenState(cfg.XCPNg.Password))
 	fmt.Fprintf(w, "parallels template=%s source=%s source_id=%s snapshot=%s snapshot_id=%s clone_mode=%s host=%s user=%s work_root=%s startup_timeout=%s templates=%d hosts=%d\n", blank(cfg.Parallels.Template, "-"), blank(cfg.Parallels.Source, "-"), blank(cfg.Parallels.SourceID, "-"), blank(cfg.Parallels.SourceSnapshot, "-"), blank(cfg.Parallels.SourceSnapshotID, "-"), cfg.Parallels.CloneMode, blank(cfg.Parallels.Host, "local"), cfg.Parallels.User, cfg.Parallels.WorkRoot, cfg.Parallels.StartupTimeout, len(cfg.Parallels.Templates), len(cfg.Parallels.Hosts))
+	if err := writeProviderConfigShowSections(w, sections); err != nil {
+		return err
+	}
 	writeProviderConfigStatus(w, providerConfigStatus(cfg))
+	return output.err
 }
 
 func redactedConfigURL(value string) string {

--- a/internal/cli/config_show_projection.go
+++ b/internal/cli/config_show_projection.go
@@ -1,0 +1,171 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// ProviderConfigShowProjector supplies passive, already-redacted display data.
+// Implementations must not resolve defaults, credentials, files or native state.
+type ProviderConfigShowProjector interface {
+	ConfigShowSection(Config) ProviderConfigShowSection
+}
+
+type ProviderConfigShowSection struct {
+	JSONKey   string
+	TextLabel string
+	Providers []string
+	Fields    []ProviderConfigShowField
+}
+
+// A field may belong to only one format by leaving the other name empty.
+type ProviderConfigShowField struct {
+	JSONName  string
+	JSONValue any
+	TextName  string
+	TextValue string
+}
+
+// ConfigShowURL uses the existing configuration-display URL redactor.
+func ConfigShowURL(value string) string { return redactedConfigURL(value) }
+
+// ConfigShowSecretState reports presence only, using the existing display owner.
+func ConfigShowSecretState(value string) string { return tokenState(value) }
+
+// Names only: no legacy value projection or environment reads are needed to
+// protect existing text slots. Retire a name only when its legacy row migrates.
+const legacyConfigShowTextLabels = "config provider lease broker access_auth ssh sync env run capacity actions blacksmith agent_sandbox phala namespace namespace_instance morph e2b cubesandbox upstash_box smolvm blaxel nomad ascii_box superserve local_container apple_container mxc docker_sandbox multipass machine0 tart lume cloudflare fastapi_cloud cloudflare_dynamic_workers cloudflare_sandbox static results cache jobs aws aws_lambda_microvm azure digitalocean vultr linode github_codespaces lambda vast nvidia_brev nebius hostinger ovh scaleway tencentcloud azure_dynamic_sessions gcp proxmox firecracker xcp_ng parallels inspection provider_status"
+
+func collectProviderConfigShowSections(cfg Config) ([]ProviderConfigShowSection, error) {
+	return collectProviderConfigShowSectionsFrom(cfg, registeredProviders())
+}
+
+func configShowNameValid(name string) bool {
+	return name != "" && !strings.ContainsAny(name, " \t\r\n=")
+}
+
+func collectProviderConfigShowSectionsFrom(cfg Config, providers []Provider) ([]ProviderConfigShowSection, error) {
+	known := make(map[string]bool, len(providers))
+	for _, provider := range providers {
+		known[provider.Name()] = true
+	}
+	keys, labels, covered := map[string]bool{}, map[string]bool{}, map[string]bool{}
+	for _, label := range strings.Fields(legacyConfigShowTextLabels) {
+		labels[label] = true
+	}
+	var sections []ProviderConfigShowSection
+	for _, provider := range providers {
+		projector, ok := provider.(ProviderConfigShowProjector)
+		if !ok {
+			continue
+		}
+		section := projector.ConfigShowSection(cfg)
+		if !configShowNameValid(section.JSONKey) || !configShowNameValid(section.TextLabel) || len(section.Providers) == 0 || len(section.Fields) == 0 {
+			return nil, fmt.Errorf("provider %s: incomplete config-show section", provider.Name())
+		}
+		if keys[section.JSONKey] || labels[section.TextLabel] {
+			return nil, fmt.Errorf("provider %s: duplicate config-show section key or text label", provider.Name())
+		}
+		keys[section.JSONKey], labels[section.TextLabel] = true, true
+		ownerIncluded := false
+		for _, name := range section.Providers {
+			if !known[name] || covered[name] {
+				return nil, fmt.Errorf("provider %s: unknown or duplicate config-show coverage %q", provider.Name(), name)
+			}
+			covered[name] = true
+			ownerIncluded = ownerIncluded || name == provider.Name()
+		}
+		if !ownerIncluded {
+			return nil, fmt.Errorf("provider %s: config-show coverage omits its owner", provider.Name())
+		}
+		jsonNames, textNames := map[string]bool{}, map[string]bool{}
+		for _, field := range section.Fields {
+			if field.JSONName == "" && field.TextName == "" {
+				return nil, fmt.Errorf("provider %s: unnamed config-show field", provider.Name())
+			}
+			if field.JSONName != "" {
+				if !configShowNameValid(field.JSONName) || jsonNames[field.JSONName] {
+					return nil, fmt.Errorf("provider %s: invalid or duplicate config-show JSON field %q", provider.Name(), field.JSONName)
+				}
+				jsonNames[field.JSONName] = true
+			}
+			if field.TextName != "" {
+				if !configShowNameValid(field.TextName) || textNames[field.TextName] {
+					return nil, fmt.Errorf("provider %s: invalid or duplicate config-show text field %q", provider.Name(), field.TextName)
+				}
+				textNames[field.TextName] = true
+			}
+		}
+		if len(jsonNames) == 0 || len(textNames) == 0 {
+			return nil, fmt.Errorf("provider %s: config-show section requires both formats", provider.Name())
+		}
+		sections = append(sections, section)
+	}
+	sort.SliceStable(sections, func(i, j int) bool { return sections[i].TextLabel < sections[j].TextLabel })
+	return sections, nil
+}
+
+func addProviderConfigShowSections(view map[string]any, sections []ProviderConfigShowSection) error {
+	seen := map[string]bool{}
+	for _, section := range sections {
+		if _, exists := view[section.JSONKey]; exists || seen[section.JSONKey] {
+			return fmt.Errorf("config-show JSON key %q already exists", section.JSONKey)
+		}
+		seen[section.JSONKey] = true
+	}
+	for _, section := range sections {
+		fields := make(map[string]any)
+		for _, field := range section.Fields {
+			if field.JSONName != "" {
+				fields[field.JSONName] = field.JSONValue
+			}
+		}
+		view[section.JSONKey] = fields
+	}
+	return nil
+}
+
+func writeProviderConfigShowSections(w io.Writer, sections []ProviderConfigShowSection) error {
+	for _, section := range sections {
+		var line strings.Builder
+		line.WriteString(section.TextLabel)
+		for _, field := range section.Fields {
+			if field.TextName == "" {
+				continue
+			}
+			line.WriteByte(' ')
+			line.WriteString(field.TextName)
+			line.WriteByte('=')
+			line.WriteString(field.TextValue)
+		}
+		line.WriteByte('\n')
+		n, err := io.WriteString(w, line.String())
+		if err != nil {
+			return err
+		}
+		if n != line.Len() {
+			return io.ErrShortWrite
+		}
+	}
+	return nil
+}
+
+// Capture legacy fmt write failures without changing its published line assembly.
+type configShowWriter struct {
+	io.Writer
+	err error
+}
+
+func (w *configShowWriter) Write(p []byte) (int, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+	n, err := w.Writer.Write(p)
+	if err == nil && n != len(p) {
+		err = io.ErrShortWrite
+	}
+	w.err = err
+	return n, err
+}

--- a/internal/cli/config_show_projection_test.go
+++ b/internal/cli/config_show_projection_test.go
@@ -1,0 +1,239 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestProviderConfigShowLegacyLabelInventoryMatchesSource(t *testing.T) {
+	actual := map[string]bool{}
+	for _, source := range []struct{ file, function string }{
+		{"config_cmd.go", "writeConfigShowText"},
+		{"config_provider_status.go", "writeProviderConfigStatus"},
+	} {
+		parsed, err := parser.ParseFile(token.NewFileSet(), source.file, nil, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var body *ast.BlockStmt
+		for _, decl := range parsed.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == source.function {
+				body = fn.Body
+			}
+		}
+		if body == nil {
+			t.Fatalf("missing formatter %s", source.function)
+		}
+		ast.Inspect(body, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkg, ok := selector.X.(*ast.Ident)
+			if !ok || pkg.Name != "fmt" || (selector.Sel.Name != "Fprintf" && selector.Sel.Name != "Fprintln") {
+				return true
+			}
+			if len(call.Args) < 2 {
+				t.Fatalf("incomplete fmt call in %s", source.function)
+			}
+			literal, ok := call.Args[1].(*ast.BasicLit)
+			if !ok || literal.Kind != token.STRING {
+				t.Fatalf("nonliteral legacy format in %s needs an explicit inventory rule", source.function)
+			}
+			format, err := strconv.Unquote(literal.Value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			end := strings.IndexAny(format, " =\t\r\n")
+			if end < 0 {
+				end = len(format)
+			}
+			label := format[:end]
+			if label == "" || strings.Contains(label, "%") {
+				t.Fatalf("nonstatic legacy label %q in %s", label, source.function)
+			}
+			actual[label] = true
+			return true
+		})
+	}
+	reserved := map[string]bool{}
+	for _, label := range strings.Fields(legacyConfigShowTextLabels) {
+		reserved[label] = true
+	}
+	if !reflect.DeepEqual(actual, reserved) {
+		t.Fatalf("legacy label inventory drift: source=%v reserved=%v", actual, reserved)
+	}
+}
+
+// Nil embedded capabilities catch any unintended provider operation by collection.
+type configShowProjectionTestProvider struct {
+	Provider
+	name    string
+	section ProviderConfigShowSection
+}
+
+func (p configShowProjectionTestProvider) Name() string { return p.name }
+func (p configShowProjectionTestProvider) ConfigShowSection(Config) ProviderConfigShowSection {
+	return p.section
+}
+
+func projectionTestSection(name string) ProviderConfigShowSection {
+	return ProviderConfigShowSection{JSONKey: name, TextLabel: name, Providers: []string{name}, Fields: []ProviderConfigShowField{
+		{JSONName: "zero", JSONValue: 0, TextName: "zero", TextValue: "0"},
+		{JSONName: "nil", JSONValue: nil},
+		{TextName: "state", TextValue: "unchecked"},
+		{JSONName: "false", JSONValue: false, TextName: "false", TextValue: "false"},
+	}}
+}
+
+func TestProviderConfigShowProjectionOrderedAndPassive(t *testing.T) {
+	a, b := projectionTestSection("alpha_projection"), projectionTestSection("beta_projection")
+	providers := []Provider{configShowProjectionTestProvider{name: b.Providers[0], section: b}, configShowProjectionTestProvider{name: a.Providers[0], section: a}}
+	sections, err := collectProviderConfigShowSectionsFrom(Config{Provider: "unselected"}, providers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var text bytes.Buffer
+	if err := writeProviderConfigShowSections(&text, sections); err != nil {
+		t.Fatal(err)
+	}
+	want := "alpha_projection zero=0 state=unchecked false=false\nbeta_projection zero=0 state=unchecked false=false\n"
+	if text.String() != want {
+		t.Fatalf("text=%q", text.String())
+	}
+	view := map[string]any{"legacy": "unchanged"}
+	if err := addProviderConfigShowSections(view, sections); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(view["alpha_projection"], map[string]any{"zero": 0, "nil": nil, "false": false}) || view["legacy"] != "unchanged" {
+		t.Fatalf("view=%#v", view)
+	}
+	if !reflect.DeepEqual(providers[0].(configShowProjectionTestProvider).section, b) {
+		t.Fatal("collection mutated provider data")
+	}
+}
+
+func TestProviderConfigShowProjectionRejectsInvalidMetadata(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		change func(*ProviderConfigShowSection)
+	}{
+		{"empty key", func(s *ProviderConfigShowSection) { s.JSONKey = "" }},
+		{"empty label", func(s *ProviderConfigShowSection) { s.TextLabel = "" }},
+		{"legacy label", func(s *ProviderConfigShowSection) { s.TextLabel = "phala" }},
+		{"generic label", func(s *ProviderConfigShowSection) { s.TextLabel = "provider" }},
+		{"missing coverage", func(s *ProviderConfigShowSection) { s.Providers = nil }},
+		{"unknown identity", func(s *ProviderConfigShowSection) { s.Providers = []string{"unknown"} }},
+		{"duplicate identity", func(s *ProviderConfigShowSection) { s.Providers = append(s.Providers, s.Providers[0]) }},
+		{"missing fields", func(s *ProviderConfigShowSection) { s.Fields = nil }},
+		{"unnamed field", func(s *ProviderConfigShowSection) { s.Fields = append(s.Fields, ProviderConfigShowField{}) }},
+		{"duplicate json", func(s *ProviderConfigShowSection) {
+			s.Fields = append(s.Fields, ProviderConfigShowField{JSONName: "zero"})
+		}},
+		{"duplicate text", func(s *ProviderConfigShowSection) {
+			s.Fields = append(s.Fields, ProviderConfigShowField{TextName: "zero"})
+		}},
+		{"bad text name", func(s *ProviderConfigShowSection) { s.Fields[0].TextName = "two fields" }},
+		{"missing text format", func(s *ProviderConfigShowSection) { s.Fields = []ProviderConfigShowField{{JSONName: "one"}} }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := projectionTestSection("test_projection")
+			tc.change(&s)
+			if _, err := collectProviderConfigShowSectionsFrom(Config{}, []Provider{configShowProjectionTestProvider{name: "test_projection", section: s}}); err == nil {
+				t.Fatal("invalid metadata accepted")
+			}
+		})
+	}
+	for _, duplicate := range []string{"key", "label", "coverage", "owner"} {
+		a, b := projectionTestSection("a_projection"), projectionTestSection("b_projection")
+		switch duplicate {
+		case "key":
+			b.JSONKey = a.JSONKey
+		case "label":
+			b.TextLabel = a.TextLabel
+		case "coverage":
+			b.Providers = append(b.Providers, a.Providers...)
+		case "owner":
+			a.Providers = b.Providers
+		}
+		if _, err := collectProviderConfigShowSectionsFrom(Config{}, []Provider{configShowProjectionTestProvider{name: "a_projection", section: a}, configShowProjectionTestProvider{name: "b_projection", section: b}}); err == nil {
+			t.Fatalf("duplicate %s accepted", duplicate)
+		}
+	}
+}
+
+func TestProviderConfigShowProjectionJSONCollisionIsAtomic(t *testing.T) {
+	a, b := projectionTestSection("a_projection"), projectionTestSection("b_projection")
+	for _, sections := range [][]ProviderConfigShowSection{{a, b}, {a, a}} {
+		view := map[string]any{"b_projection": "legacy"}
+		if err := addProviderConfigShowSections(view, sections); err == nil {
+			t.Fatal("collision accepted")
+		}
+		if !reflect.DeepEqual(view, map[string]any{"b_projection": "legacy"}) {
+			t.Fatal("collision partially mutated output")
+		}
+	}
+}
+
+type configShowFailureWriter struct {
+	err   error
+	short bool
+}
+
+func (w configShowFailureWriter) Write(p []byte) (int, error) {
+	if w.short {
+		return len(p) - 1, nil
+	}
+	return 0, w.err
+}
+
+func TestProviderConfigShowProjectionWriteErrors(t *testing.T) {
+	failure := errors.New("display write failed")
+	section := projectionTestSection("test_projection")
+	if err := writeProviderConfigShowSections(configShowFailureWriter{err: failure}, []ProviderConfigShowSection{section}); !errors.Is(err, failure) {
+		t.Fatalf("error=%v", err)
+	}
+	if err := writeProviderConfigShowSections(configShowFailureWriter{short: true}, []ProviderConfigShowSection{section}); !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("short error=%v", err)
+	}
+	w := &configShowWriter{Writer: configShowFailureWriter{err: failure}}
+	_, _ = w.Write([]byte("first"))
+	_, err := w.Write([]byte("second"))
+	if !errors.Is(err, failure) || !errors.Is(w.err, failure) {
+		t.Fatal("legacy error lost")
+	}
+}
+
+func TestProviderConfigShowProjectionCollisionBeforeTextOutput(t *testing.T) {
+	s := projectionTestSection("collision_projection")
+	s.TextLabel = "config"
+	p := configShowProjectionTestProvider{name: "collision_projection", section: s}
+	providerRegistry[p.Name()] = p
+	t.Cleanup(func() { delete(providerRegistry, p.Name()) })
+	var out bytes.Buffer
+	if err := writeConfigShowText(&out, Config{}); err == nil || out.Len() != 0 {
+		t.Fatalf("error=%v output=%q", err, out.String())
+	}
+}
+
+func TestProviderConfigShowFormattingBridges(t *testing.T) {
+	if ConfigShowSecretState("") != tokenState("") || ConfigShowSecretState("synthetic") != tokenState("synthetic") {
+		t.Fatal("secret-state owner changed")
+	}
+	value := "https://example.invalid/path?sample=value"
+	if got := ConfigShowURL(value); got != redactedConfigURL(value) || strings.Contains(got, "sample=value") {
+		t.Fatal("URL bridge changed")
+	}
+}

--- a/internal/providers/crownest/config_show.go
+++ b/internal/providers/crownest/config_show.go
@@ -1,0 +1,23 @@
+package crownest
+
+import (
+	"strconv"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// ConfigShowSection describes loaded values without discovering credentials.
+func (Provider) ConfigShowSection(cfg core.Config) core.ProviderConfigShowSection {
+	c := cfg.Crownest
+	apiURL := core.ConfigShowURL(c.APIURL)
+	return core.ProviderConfigShowSection{
+		JSONKey: "crownest", TextLabel: "crownest", Providers: []string{"crownest"},
+		Fields: []core.ProviderConfigShowField{
+			{JSONName: "apiUrl", JSONValue: apiURL, TextName: "api_url", TextValue: core.Blank(apiURL, "-")},
+			{JSONName: "projectId", JSONValue: c.ProjectID, TextName: "project_id", TextValue: core.Blank(c.ProjectID, "-")},
+			{JSONName: "template", JSONValue: c.Template, TextName: "template", TextValue: core.Blank(c.Template, "-")},
+			{JSONName: "timeoutSecs", JSONValue: c.TimeoutSecs, TextName: "timeout_secs", TextValue: strconv.Itoa(c.TimeoutSecs)},
+			{JSONName: "forgetMissing", JSONValue: c.ForgetMissing, TextName: "forget_missing", TextValue: strconv.FormatBool(c.ForgetMissing)},
+		},
+	}
+}

--- a/internal/providers/crownest/provider_test.go
+++ b/internal/providers/crownest/provider_test.go
@@ -12,6 +12,32 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
+func TestCrownestConfigShowSection(t *testing.T) {
+	for _, selected := range []string{"", "crownest"} {
+		for _, forget := range []bool{false, true} {
+			cfg := Config{Provider: selected, Crownest: core.CrownestConfig{APIURL: "https://api.example.test/path?debug=1#hint", ProjectID: "", Template: " raw-template ", TimeoutSecs: 0, ForgetMissing: forget}}
+			before := cfg.Crownest
+			section := (Provider{}).ConfigShowSection(cfg)
+			values := map[string]any{}
+			var fields []string
+			for _, field := range section.Fields {
+				values[field.JSONName] = field.JSONValue
+				fields = append(fields, field.TextName+"="+field.TextValue)
+			}
+			want := map[string]any{"apiUrl": "https://api.example.test/path", "projectId": "", "template": " raw-template ", "timeoutSecs": 0, "forgetMissing": forget}
+			if section.JSONKey != "crownest" || section.TextLabel != "crownest" || !reflect.DeepEqual(section.Providers, []string{"crownest"}) || !reflect.DeepEqual(values, want) {
+				t.Fatal("unexpected Crownest display projection")
+			}
+			if strings.Join(fields, " ") != "api_url=https://api.example.test/path project_id=- template= raw-template  timeout_secs=0 forget_missing="+strconv.FormatBool(forget) {
+				t.Fatal("text projection changed raw values or field order")
+			}
+			if cfg.Crownest != before {
+				t.Fatal("display mutated configuration")
+			}
+		}
+	}
+}
+
 func TestCrownestOrdinaryFlagOrdering(t *testing.T) {
 	for _, provider := range []string{" CROWNEST ", "other"} {
 		for _, sizing := range []string{"", "class", "type"} {

--- a/internal/providers/freestyle/backend_test.go
+++ b/internal/providers/freestyle/backend_test.go
@@ -112,6 +112,36 @@ func TestFreestyleExecForwardsEnvAfterWorkdir(t *testing.T) {
 	}
 }
 
+func TestFreestyleConfigShowSection(t *testing.T) {
+	for _, selected := range []string{"", "freestyle"} {
+		for _, key := range []string{"", "synthetic-test-key"} {
+			cfg := Config{Provider: selected, Freestyle: FreestyleConfig{APIURL: "https://api.example.test/path?debug=1#hint", APIKey: key, Workdir: " raw-workdir ", VCPUs: 0, MemoryGB: -2}}
+			before := cfg.Freestyle
+			section := (Provider{}).ConfigShowSection(cfg)
+			values := map[string]any{}
+			var fields []string
+			for _, field := range section.Fields {
+				values[field.JSONName] = field.JSONValue
+				fields = append(fields, field.TextName+"="+field.TextValue)
+			}
+			auth := "missing"
+			if key != "" {
+				auth = "configured"
+			}
+			want := map[string]any{"apiUrl": "https://api.example.test/path", "workdir": " raw-workdir ", "vcpus": 0, "memoryGB": -2, "auth": auth}
+			if section.JSONKey != "freestyle" || section.TextLabel != "freestyle" || !reflect.DeepEqual(section.Providers, []string{"freestyle"}) || !reflect.DeepEqual(values, want) {
+				t.Fatal("unexpected Freestyle display projection")
+			}
+			if strings.Join(fields, " ") != "api_url=https://api.example.test/path workdir= raw-workdir  vcpus=0 memory_gb=-2 auth="+auth {
+				t.Fatal("text projection changed raw values or field order")
+			}
+			if cfg.Freestyle != before {
+				t.Fatal("display mutated configuration")
+			}
+		}
+	}
+}
+
 func TestFreestyleOrdinaryFlagBindings(t *testing.T) {
 	for _, provider := range []string{"other", "freestyle"} {
 		for _, value := range []string{"", "same", " padded "} {

--- a/internal/providers/freestyle/config_show.go
+++ b/internal/providers/freestyle/config_show.go
@@ -1,0 +1,24 @@
+package freestyle
+
+import (
+	"strconv"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// ConfigShowSection describes loaded values without resolving provider state.
+func (Provider) ConfigShowSection(cfg core.Config) core.ProviderConfigShowSection {
+	c := cfg.Freestyle
+	apiURL := core.ConfigShowURL(c.APIURL)
+	auth := core.ConfigShowSecretState(c.APIKey)
+	return core.ProviderConfigShowSection{
+		JSONKey: "freestyle", TextLabel: "freestyle", Providers: []string{"freestyle"},
+		Fields: []core.ProviderConfigShowField{
+			{JSONName: "apiUrl", JSONValue: apiURL, TextName: "api_url", TextValue: core.Blank(apiURL, "-")},
+			{JSONName: "workdir", JSONValue: c.Workdir, TextName: "workdir", TextValue: core.Blank(c.Workdir, "-")},
+			{JSONName: "vcpus", JSONValue: c.VCPUs, TextName: "vcpus", TextValue: strconv.Itoa(c.VCPUs)},
+			{JSONName: "memoryGB", JSONValue: c.MemoryGB, TextName: "memory_gb", TextValue: strconv.Itoa(c.MemoryGB)},
+			{JSONName: "auth", JSONValue: auth, TextName: "auth", TextValue: auth},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

Fix missing Freestyle and Crownest values in offline config inspection and establish a shared provider-owned display path. Each provider returns ordered, explicitly selected and already-redacted fields for JSON and text. Core collects and renders those records without inferring visibility from runtime structs or configuration-input tags.

Both new sections appear even when another provider is selected. Freestyle preserves relative workdirs and zero sizing, with loaded API-key presence only. Crownest preserves empty project IDs, zero timeout and false cleanup preferences without looking up credentials. URL redaction reuses the existing owner. No Configure, Doctor, SDK, CLI, file or network operation is added by the presenters.

The collector rejects duplicate section keys, text labels, field names and canonical coverage. JSON insertion checks existing top-level keys before mutation; the text path reserves legacy line names without evaluating JSON values or adding environment reads. A source-derived test keeps those names aligned with the actual formatters. Text write failures and short writes now propagate through the command. Existing legacy lines keep their order, and the two new lines appear immediately before the unchanged inspection/status block.

## Verification

- 55 config-show and generic projection tests, with 101 subtests, passed under the race detector. The two actual provider presenter tests passed separately.
- Twelve actual built-CLI comparisons passed across defaults, selected/unselected providers, trusted file and environment input, raw/empty values, zero/false, synthetic key presence and URL query/fragment redaction. The baseline correctly has neither new section. After removing exactly the two approved JSON members or text lines, every remaining output byte matches baseline, including provider status and legacy line order. JSON values were not reserialized to hide differences.
- The text insertion assertion was clarified before candidate execution to place the new lines before the existing inspection notice; original preparation and baseline evidence were retained. A concurrent test-only edit was recorded separately from the immutable binary source copies.
- Go vet, 249 Markdown link checks, whitespace checks and managed Codex review passed at the requested P0 threshold.

## Remaining coverage

This is the first stage, not a complete provider-display migration. The full target remains 80 distinct sections for 81 canonical providers, preserving Apple sharing. After these two additions, 27 providers still lack value sections and three lack text sections; the existing legacy projections must also migrate without changing field names, types, redaction or text layout. The migration contract is documented in docs/refactor/provider-config-display.md.

No native-provider, authentication or readiness proof is claimed. No real credential, hosted API, deployment or release operation was performed.
