### PR TITLE
chore: authorize v0.56.0 release source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## 0.56.0 - 2026-09-11
 
 ### Highlights

--- a/release/records/v0.56.0.json
+++ b/release/records/v0.56.0.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.56.0",
+  "tagObject": "f77f232f996a24c299e9d0536283e83cae2d26c3",
+  "sourceCommit": "2c9e78e32f924f54fca7f95ba916a0e0f4227862",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
Bind the protected v0.56.0 release record to signed tag object `f77f232f996a24c299e9d0536283e83cae2d26c3` and source commit `2c9e78e32f924f54fca7f95ba916a0e0f4227862`. Restore the empty Unreleased section for subsequent work while preserving the frozen 0.56.0 notes.

The tag verifies against the repository signer policy and GitHub reports a verified signature. Full source CI passed: https://github.com/openclaw/crabbox/actions/runs/34619482789. A coordinator-backed Linux smoke from the exact source passed execution, attach/events/logs, and confirmed cleanup.

Validation: record identities match the immutable signed tag, extracted release notes remain byte-for-byte unchanged, git diff --check, and independent autoreview. Candidate production, signing, native draft verification, and publication follow this source authorization under the explicit release request.
