### PR TITLE
fix(sync): retain protocol state in witness errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Retain recognized workspace-owner protocol states in child and phase-witness inspection errors, improving diagnostics without changing ownership decisions or retry behavior.
+
 ## 0.56.0 - 2026-09-11
 
 ### Highlights

--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -179,6 +179,12 @@ renewal and release fail closed. After a client crash, an expired owner is
 recoverable only when the exact witnessed child is no longer alive. POSIX,
 WSL2, and native Windows targets share these semantics.
 
+Transport failures during renewal, child inspection, and phase-witness waiting
+retain recognized `MISMATCH`, `EXPIRED`, or `AMBIGUOUS` protocol labels alongside
+the original error. These labels add diagnostic context, not permission to
+continue or retry; arbitrary protocol output is not added to those transport
+error messages. An ambiguous inspection still fails closed.
+
 POSIX and WSL2 children register themselves before executing the requested
 workload. Registration waits at most five seconds for the owner lock; it does
 not leave a background child waiting indefinitely for a start file. A failed

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -400,11 +400,7 @@ func (o *workspaceOwner) renewLoopWithTicks(ticks <-chan time.Time, callTimeout 
 			if err == nil {
 				err = errors.New("unexpected protocol response")
 			}
-			// Only recognized states are safe to add to transport diagnostics.
-			switch response {
-			case "MISMATCH", "EXPIRED", "AMBIGUOUS":
-				err = fmt.Errorf("protocol state %s: %w", response, err)
-			}
+			err = workspaceOwnerProtocolError(response, err)
 			o.mu.Lock()
 			o.renewErr = exit(7, "remote workspace owner renewal failed closed: %v", err)
 			o.mu.Unlock()
@@ -412,6 +408,15 @@ func (o *workspaceOwner) renewLoopWithTicks(ticks <-chan time.Time, callTimeout 
 			return
 		}
 	}
+}
+
+// Only recognized states are safe to add to transport diagnostics.
+func workspaceOwnerProtocolError(response string, err error) error {
+	switch response {
+	case "MISMATCH", "EXPIRED", "AMBIGUOUS":
+		return fmt.Errorf("protocol state %s: %w", response, err)
+	}
+	return err
 }
 
 func (o *workspaceOwner) Err() error {
@@ -440,6 +445,7 @@ func (o *workspaceOwner) inspectChild(ctx context.Context) (workspaceOwnerInspec
 	}
 	response, err := callWorkspaceOwnerTransport(ctx, o.callTimeout(), o.transport, workspaceOwnerRemoteRequest{Action: workspaceOwnerInspect, Key: o.key, Token: o.token, TTL: o.ttl})
 	if err != nil {
+		err = workspaceOwnerProtocolError(response, err)
 		return workspaceOwnerQuiescent, exit(7, "confirm remote workspace owner child state: ambiguous remote state: %v", err)
 	}
 	switch response {
@@ -460,6 +466,7 @@ func (o *workspaceOwner) WaitForChild(ctx context.Context, timeout time.Duration
 	for {
 		response, err := callWorkspaceOwnerTransport(ctx, min(o.callTimeout(), time.Until(deadline)), o.transport, workspaceOwnerRemoteRequest{Action: workspaceOwnerInspect, Key: o.key, Token: o.token, TTL: o.ttl})
 		if err != nil {
+			err = workspaceOwnerProtocolError(response, err)
 			return exit(7, "confirm remote workspace phase witness: ambiguous remote state: %v", err)
 		}
 		switch response {

--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -36,6 +36,75 @@ func (f workspaceOwnerTransportFunc) Do(ctx context.Context, req workspaceOwnerR
 	return f(ctx, req)
 }
 
+func TestWorkspaceOwnerTransportErrorDiagnostics(t *testing.T) {
+	original := errors.New("ordinary transport error")
+	for _, response := range []string{"MISMATCH", "EXPIRED", "AMBIGUOUS", "", "unrecognized response", "CHILD", "OWNED"} {
+		recognized := response == "MISMATCH" || response == "EXPIRED" || response == "AMBIGUOUS"
+		annotated := workspaceOwnerProtocolError(response, original)
+		if !errors.Is(annotated, original) {
+			t.Fatal("annotation lost original error")
+		}
+		if !recognized && annotated != original {
+			t.Fatal("unknown response changed original error")
+		}
+		for _, operation := range []string{"renew", "inspect", "wait"} {
+			t.Run(operation+"/"+response, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				calls := 0
+				owner := &workspaceOwner{
+					ctx: ctx, cancel: cancel, stop: make(chan struct{}), done: make(chan struct{}),
+					transport: workspaceOwnerTransportFunc(func(_ context.Context, req workspaceOwnerRemoteRequest) (string, error) {
+						calls++
+						wantAction := workspaceOwnerInspect
+						if operation == "renew" {
+							wantAction = workspaceOwnerRenew
+						}
+						if req.Action != wantAction {
+							t.Fatalf("action=%v", req.Action)
+						}
+						return response, original
+					}),
+				}
+				var err error
+				var prefix string
+				switch operation {
+				case "renew":
+					ticks := make(chan time.Time, 1)
+					ticks <- time.Now()
+					owner.renewLoopWithTicks(ticks, time.Second)
+					err = owner.Err()
+					prefix = "remote workspace owner renewal failed closed: "
+					if ctx.Err() != context.Canceled {
+						t.Fatal("renewal no longer cancels")
+					}
+				case "inspect":
+					var result workspaceOwnerInspectResult
+					result, err = owner.inspectChild(ctx)
+					prefix = "confirm remote workspace owner child state: ambiguous remote state: "
+					if result != workspaceOwnerQuiescent {
+						t.Fatal("inspection failure result changed")
+					}
+				case "wait":
+					err = owner.WaitForChild(ctx, time.Second)
+					prefix = "confirm remote workspace phase witness: ambiguous remote state: "
+				}
+				want := prefix + original.Error()
+				if recognized {
+					want = prefix + "protocol state " + response + ": " + original.Error()
+				}
+				var exitErr ExitError
+				if calls != 1 || !AsExitError(err, &exitErr) || exitErr.Code != 7 || err.Error() != want {
+					t.Fatalf("calls=%d err=%v want=%q", calls, err, want)
+				}
+				if operation != "renew" && ctx.Err() != nil {
+					t.Fatal("diagnostic canceled caller context")
+				}
+			})
+		}
+	}
+}
+
 func newFakeWorkspaceOwnerRemote() *fakeWorkspaceOwnerRemote {
 	return &fakeWorkspaceOwnerRemote{changed: make(chan struct{})}
 }


### PR DESCRIPTION
## Summary

Preserve recognized workspace-owner protocol labels when child inspection or phase-witness waiting also returns a transport error. The previous wrappers retained the error but discarded the separately returned response. Renewal already annotated these labels; share that exact allowlisted annotation across all three paths.

Only MISMATCH, EXPIRED and AMBIGUOUS are added. Unknown output and apparent success responses are not newly echoed or treated as success. Error codes, failure decisions, typed results, deadlines, cancellation and no-retry behavior remain unchanged. This is diagnostic context, not a reconciliation or ownership-policy change.

## Evidence and scope

The motivating [Connector E2E run](https://github.com/openclaw/crabbox/actions/runs/34614978583) reached post-rsync witness confirmation and failed with an ambiguous remote-state error. The original full run archive, including successful diagnostic steps, was inspected before any follow-up. Cleanup completed before its later container diagnostics could capture the cause.

This change does not establish or fix the underlying exit-74 cause, classify it as a flake, or certify that sync settled safely. That investigation remains open. No native fault reproduction, SSH/lease operation, guard relaxation or rerun-until-green was used.

## Verification

- Three fake-transport/typed-result/deadline tests and 25 subtests passed with the race detector. They verify recognized context and original error text, unknown-response non-disclosure, unchanged exit 7, one call without retry, and existing cancellation behavior.
- The production change is limited to the shared annotation helper and three call sites; protocol scripts and all surrounding control flow are unchanged.
- Go vet, internal Markdown links and whitespace checks passed.
- Managed Codex review found no accepted P0 findings.

Update sync documentation and Unreleased notes for the improved diagnostics. No real credential or native-provider execution is involved in the focused proof.
