### PR TITLE
fix(daytona): release fixed leases with API keys and reconcile native expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Daytona: attest API-key cleanup through current-key organization metadata and retire acquired fixed leases after verified native TTL or external deletion; inspection records a terminal tombstone without issuing deletion or reusing the fixed ID.
 - Show Freestyle and Crownest settings through a shared offline JSON/text display path, preserving zero and false values while redacting URLs and reporting only loaded key presence. [PR 2104](https://github.com/openclaw/crabbox/pull/2104). Thanks @steipete.
 
 ## 0.56.0 - 2026-09-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Daytona: attest API-key cleanup through current-key organization metadata and retire acquired fixed leases after verified native TTL or external deletion; inspection records a terminal tombstone without issuing deletion or reusing the fixed ID.
+- Daytona: attest API-key cleanup through current-key organization metadata and retire acquired fixed leases after verified native TTL or external deletion; inspection records a terminal tombstone without issuing deletion or reusing the fixed ID. [PR 2111](https://github.com/openclaw/crabbox/pull/2111). Thanks @steipete.
 - Show Freestyle and Crownest settings through a shared offline JSON/text display path, preserving zero and false values while redacting URLs and reporting only loaded key presence. [PR 2104](https://github.com/openclaw/crabbox/pull/2104). Thanks @steipete.
 
 ## 0.56.0 - 2026-09-11

--- a/docs/commands/inspect.md
+++ b/docs/commands/inspect.md
@@ -26,6 +26,12 @@ slug selects its recorded provider before provider initialization. An explicit
 lease ID or `--provider`, while missing claims keep the configured-provider
 fallback.
 
+For an acquired fixed Daytona lease removed by native TTL or external deletion,
+inspection can persist its terminal tombstone after verifying the original
+organization and complete provider database absence. It reports `released` and
+never deletes a provider resource. Unverified absence retains the claim and
+returns an error; see [Daytona fixed lifecycle](../providers/daytona.md#fixed-operation-ids).
+
 ## Output
 
 Human output prints one `key=value` line per field, followed by any Tailscale

--- a/docs/features/identifiers.md
+++ b/docs/features/identifiers.md
@@ -80,7 +80,10 @@ prevents older clients from treating it as an ordinary lease. Submitted cleanup
 records an exact deletion acknowledgment, then reconciles a scope-attested UUID
 404 against complete failure-inclusive database inventory. Durable cleanup entry
 blocks reuse; unknown UUIDs and an unqualified 404 retain custody. The ordinary
-search index and mutable label filters do not establish absence. See
+search index and mutable label filters do not establish absence. For successfully
+acquired children removed by native TTL or external deletion, `inspect`, `status`,
+and `stop` can publish the same terminal tombstone after verifying the current
+organization and complete failure-inclusive database absence. See
 [Daytona fixed operation IDs](../providers/daytona.md#fixed-operation-ids)
 for organization discovery and recovery limits.
 
@@ -100,7 +103,7 @@ match the persisted attempt exactly. Fixed AWS
 claims use the downgrade-safe local discriminator `aws-fixed-v1`; current
 clients map it to runtime AWS, while older clients skip/refuse it.
 
-Fixed IDs are single-use operation identities. Direct AWS, Machine0, and
+Fixed IDs are single-use operation identities. Direct AWS, Daytona, Machine0, and
 local-container keep a compact terminal claim tombstone after successful
 destroy release or exact missing-resource cleanup. Tombstones contain only the
 ID, slug, provider scope, versioned intent hash, timestamps, and terminal

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -213,13 +213,18 @@ lease remains held for explicit cleanup; no replacement is created. Successfully
 acquired children can replay after their source snapshot is retired.
 
 Fixed acquisition must establish the organization before allocation. OAuth uses
-the selected organization from the existing CLI profile. API-key mode uses an
-exact existing child, its retained private checkpoint, or a visible sandbox to
-establish native organization. A private checkpoint can refill a pool after all
-live workers drain; general snapshots cannot attest the allocating organization.
-An API-key account without one of these identity sources cannot use fixed
-acquisition. Ordinary warmup without a fixed ID retains its existing API-key
-behavior. No credentials or token-derived identifiers are stored in fixed claims.
+the selected organization from the existing CLI profile. API-key mode reads the
+authenticated `organizationId` from `/api-keys/current`, including empty accounts.
+The deployed API returns this field although the pinned Go SDK retains it only
+as an additional property. Invalid or conflicting identity is rejected.
+Older servers matching the public Daytona 0.190.0 contract omit this field;
+acquisition retains their existing child, private-checkpoint, or visible-sandbox
+identity path. That compatibility path remains until those servers are no longer
+supported, and never authorizes cleanup of an absent resource. API-key cleanup
+requires the current-key organization field; older servers require an OAuth
+organization profile instead. Ordinary warmup without a fixed ID retains its
+existing API-key behavior. No credentials or token-derived identifiers are stored
+in fixed claims.
 
 Fixed claims use a distinct provider marker so older clients cannot treat them
 as ordinary Daytona claims and erase terminal replay protection. Failed or
@@ -239,16 +244,21 @@ access to the original organization, and complete database inventory showing no
 exact UUID. Required pagination metadata must be present, integral, and
 consistent; failed-deletion rows, malformed responses, and incomplete pages
 retain custody. No timed sampling or search-index fallback establishes absence.
-This confirms removal from the provider's database, not independent proof of
-physical storage reclamation.
+This confirms that the provider has no remaining nonterminal record for that
+resource, including failed destruction, not independent proof of physical storage
+reclamation.
 
 This works after deletion of the last live sandbox and accommodates the native
 rename during deletion. The durable acknowledgment survives interruption and
-same-organization credential rotation. A lost response can be reconciled only
-while the exact resource still positively reports destruction requested; a bare
-404 without that witness, or an expired create whose UUID was never observed,
-remains an explicit operator reconciliation obligation. No second create is
-submitted. A valid released claim remains available through `inspect` and
+same-organization credential rotation. Native TTL or external deletion can remove
+a successfully acquired sandbox before Crabbox requests deletion. In that case,
+`stop`, `inspect`, and `status` reconcile the recorded exact UUID against fresh
+authenticated organization identity and complete failure-inclusive database
+absence, then persist the same terminal claim. Inspection never issues DELETE.
+Neither a bare 404 nor an elapsed deadline establishes removal. Incomplete creates
+without a deletion witness, including attempts whose UUID was never observed,
+remain explicit operator reconciliation obligations. No second create is submitted.
+A valid released claim remains available through `inspect` and
 `status` as `released`, never ready, with no provider request or remote access.
 `status --wait` reports that terminal state instead of waiting for readiness.
 

--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -279,6 +279,12 @@ func (b *daytonaLeaseBackend) Status(ctx context.Context, req StatusRequest) (st
 	for {
 		sandbox, leaseID, err := resolveDaytonaSandbox(ctx, client, b.cfg, req.ID)
 		if err != nil {
+			if exists && claim.FixedCreateIntent != nil && claim.FixedCreateIntent.State == "acquired" && daytonaIsNotFoundError(err) {
+				if err := b.releaseFixed(ctx, claim, "", true); err != nil {
+					return statusView{}, err
+				}
+				return b.Status(ctx, req)
+			}
 			return statusView{}, err
 		}
 		view := daytonaStatusView(leaseID, sandbox)
@@ -337,7 +343,7 @@ func (b *daytonaLeaseBackend) Stop(ctx context.Context, req StopRequest) error {
 }
 
 func (b *daytonaLeaseBackend) stopFixed(ctx context.Context, claim LeaseClaim) error {
-	if err := b.releaseFixed(ctx, claim, ""); err != nil {
+	if err := b.releaseFixed(ctx, claim, "", false); err != nil {
 		return err
 	}
 	fmt.Fprintf(b.rt.Stderr, "released fixed lease=%s\n", claim.LeaseID)

--- a/internal/providers/daytona/backend_ssh.go
+++ b/internal/providers/daytona/backend_ssh.go
@@ -277,7 +277,7 @@ func (b *daytonaLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLease
 		if req.Lease.Server.CloudID != "" && claim.CloudID != "" && req.Lease.Server.CloudID != claim.CloudID {
 			return exit(4, "Daytona fixed release resource identity mismatch")
 		}
-		return b.releaseFixed(ctx, claim, req.CheckpointID)
+		return b.releaseFixed(ctx, claim, req.CheckpointID, false)
 	}
 	client, err := newDaytonaClient(b.cfg, b.rt)
 	if err != nil {

--- a/internal/providers/daytona/client.go
+++ b/internal/providers/daytona/client.go
@@ -87,6 +87,15 @@ func (c *daytonaSDKClient) fixedOrganization(ctx context.Context) (string, strin
 		}
 		return c.apiURL, organization.GetId(), nil
 	}
+	organization, supported, err := c.apiKeyOrganization(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	if supported {
+		return c.apiURL, organization, nil
+	}
+	// The public v0.190.0 server omits organizationId from current-key metadata.
+	// Preserve its resource-backed acquisition contract, never absence proof.
 	identity := c.api.SandboxAPI.ListSandboxes(c.ctx(ctx)).Limit(1)
 	if c.orgID != "" {
 		identity = identity.XDaytonaOrganizationID(c.orgID)
@@ -111,6 +120,30 @@ func (c *daytonaSDKClient) fixedOrganization(ctx context.Context) (string, strin
 		return "", "", exit(4, "Daytona authenticated sandbox organization does not match its selected scope")
 	}
 	return c.apiURL, sandbox.GetOrganizationId(), nil
+}
+
+func (c *daytonaSDKClient) apiKeyOrganization(ctx context.Context) (string, bool, error) {
+	key, _, err := c.api.ApiKeysAPI.GetCurrentApiKey(c.ctx(ctx)).Execute()
+	if err != nil {
+		return "", false, c.redactError(err)
+	}
+	if key == nil {
+		return "", false, exit(4, "Daytona current API-key response is missing its identity")
+	}
+	// Deployed Daytona supplies this field; the pinned SDK retains it as an
+	// additional property. Never persist or report the other key metadata.
+	value, present := key.AdditionalProperties["organizationId"]
+	if !present {
+		return "", false, nil
+	}
+	organization, valid := value.(string)
+	if !valid || strings.TrimSpace(organization) == "" || organization != strings.TrimSpace(organization) {
+		return "", false, exit(4, "Daytona current API-key response has an invalid organization identity")
+	}
+	if c.orgID != "" && c.orgID != organization {
+		return "", false, exit(4, "Daytona authenticated API-key organization differs from the selected organization")
+	}
+	return organization, true, nil
 }
 
 type daytonaAuth struct {
@@ -524,11 +557,22 @@ func (c *daytonaSDKClient) findPendingDeletion(ctx context.Context, id string) (
 	}
 }
 
-// OrganizationAuthContextGuard checks the path against an API key's intrinsic
-// organization. Unlike the optional header, this also attests an empty account.
 func (c *daytonaSDKClient) attestDeletionOrganization(ctx context.Context, expected string) error {
 	if expected == "" || c.orgID != "" && c.orgID != expected {
 		return exit(4, "Daytona deletion organization differs from the selected organization")
+	}
+	if c.apiKey {
+		organization, supported, err := c.apiKeyOrganization(ctx)
+		if err != nil {
+			return err
+		}
+		if !supported {
+			return exit(4, "Daytona current API-key response does not expose organizationId; this API deployment cannot attest fixed cleanup with an API key; use an OAuth organization profile")
+		}
+		if organization != expected {
+			return exit(4, "Daytona authenticated API-key organization differs from the fixed lease organization")
+		}
+		return nil
 	}
 	organization, _, err := c.api.OrganizationsAPI.GetOrganization(c.ctx(ctx), expected).Execute()
 	if err != nil {

--- a/internal/providers/daytona/client.go
+++ b/internal/providers/daytona/client.go
@@ -73,7 +73,7 @@ var newDaytonaClient = func(cfg Config, rt Runtime) (daytonaAPI, error) {
 // Resolve native organization identity using the same authenticated client.
 // An API key's optional organization header is not an attestation: Daytona
 // derives its organization from the key and ignores that header.
-func (c *daytonaSDKClient) fixedOrganization(ctx context.Context) (string, string, error) {
+func (c *daytonaSDKClient) fixedOrganization(ctx context.Context, allowResourceIdentity bool) (string, string, error) {
 	if !c.apiKey {
 		if c.orgID == "" {
 			return "", "", exit(4, "Daytona fixed leases require a selected organization")
@@ -87,12 +87,27 @@ func (c *daytonaSDKClient) fixedOrganization(ctx context.Context) (string, strin
 		}
 		return c.apiURL, organization.GetId(), nil
 	}
-	organization, supported, err := c.apiKeyOrganization(ctx)
+	key, _, err := c.api.ApiKeysAPI.GetCurrentApiKey(c.ctx(ctx)).Execute()
 	if err != nil {
-		return "", "", err
+		return "", "", c.redactError(err)
 	}
-	if supported {
+	if key == nil {
+		return "", "", exit(4, "Daytona current API-key response is missing its identity")
+	}
+	// Deployed Daytona supplies this field; the pinned SDK retains it as an
+	// additional property. Never persist or report the other key metadata.
+	if value, present := key.AdditionalProperties["organizationId"]; present {
+		organization, valid := value.(string)
+		if !valid || strings.TrimSpace(organization) == "" || organization != strings.TrimSpace(organization) {
+			return "", "", exit(4, "Daytona current API-key response has an invalid organization identity")
+		}
+		if c.orgID != "" && c.orgID != organization {
+			return "", "", exit(4, "Daytona authenticated API-key organization differs from the selected organization")
+		}
 		return c.apiURL, organization, nil
+	}
+	if !allowResourceIdentity {
+		return "", "", exit(4, "Daytona current API-key response does not expose organizationId; this API deployment cannot attest fixed cleanup with an API key; use an OAuth organization profile")
 	}
 	// The public v0.190.0 server omits organizationId from current-key metadata.
 	// Preserve its resource-backed acquisition contract, never absence proof.
@@ -120,30 +135,6 @@ func (c *daytonaSDKClient) fixedOrganization(ctx context.Context) (string, strin
 		return "", "", exit(4, "Daytona authenticated sandbox organization does not match its selected scope")
 	}
 	return c.apiURL, sandbox.GetOrganizationId(), nil
-}
-
-func (c *daytonaSDKClient) apiKeyOrganization(ctx context.Context) (string, bool, error) {
-	key, _, err := c.api.ApiKeysAPI.GetCurrentApiKey(c.ctx(ctx)).Execute()
-	if err != nil {
-		return "", false, c.redactError(err)
-	}
-	if key == nil {
-		return "", false, exit(4, "Daytona current API-key response is missing its identity")
-	}
-	// Deployed Daytona supplies this field; the pinned SDK retains it as an
-	// additional property. Never persist or report the other key metadata.
-	value, present := key.AdditionalProperties["organizationId"]
-	if !present {
-		return "", false, nil
-	}
-	organization, valid := value.(string)
-	if !valid || strings.TrimSpace(organization) == "" || organization != strings.TrimSpace(organization) {
-		return "", false, exit(4, "Daytona current API-key response has an invalid organization identity")
-	}
-	if c.orgID != "" && c.orgID != organization {
-		return "", false, exit(4, "Daytona authenticated API-key organization differs from the selected organization")
-	}
-	return organization, true, nil
 }
 
 type daytonaAuth struct {
@@ -561,24 +552,11 @@ func (c *daytonaSDKClient) attestDeletionOrganization(ctx context.Context, expec
 	if expected == "" || c.orgID != "" && c.orgID != expected {
 		return exit(4, "Daytona deletion organization differs from the selected organization")
 	}
-	if c.apiKey {
-		organization, supported, err := c.apiKeyOrganization(ctx)
-		if err != nil {
-			return err
-		}
-		if !supported {
-			return exit(4, "Daytona current API-key response does not expose organizationId; this API deployment cannot attest fixed cleanup with an API key; use an OAuth organization profile")
-		}
-		if organization != expected {
-			return exit(4, "Daytona authenticated API-key organization differs from the fixed lease organization")
-		}
-		return nil
-	}
-	organization, _, err := c.api.OrganizationsAPI.GetOrganization(c.ctx(ctx), expected).Execute()
+	_, organization, err := c.fixedOrganization(ctx, false)
 	if err != nil {
-		return c.redactError(err)
+		return err
 	}
-	if organization == nil || organization.GetId() != expected {
+	if organization != expected {
 		return exit(4, "Daytona deletion organization could not be attested")
 	}
 	return nil

--- a/internal/providers/daytona/fixed.go
+++ b/internal/providers/daytona/fixed.go
@@ -35,12 +35,12 @@ func (b *daytonaLeaseBackend) SupportsRequestedCheckpointID() bool {
 
 func fixedDaytonaContext(ctx context.Context, client daytonaAPI) (string, string, error) {
 	identity, ok := client.(interface {
-		fixedOrganization(context.Context) (string, string, error)
+		fixedOrganization(context.Context, bool) (string, string, error)
 	})
 	if !ok {
 		return "", "", exit(4, "Daytona client has no organization identity contract")
 	}
-	endpoint, organization, err := identity.fixedOrganization(ctx)
+	endpoint, organization, err := identity.fixedOrganization(ctx, true)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/providers/daytona/fixed.go
+++ b/internal/providers/daytona/fixed.go
@@ -349,7 +349,7 @@ func loadFixedDaytonaSandbox(ctx context.Context, client daytonaAPI, claim core.
 	return sandbox, validateFixedDaytonaSandbox(claim, sandbox)
 }
 
-func (b *daytonaLeaseBackend) releaseFixed(ctx context.Context, expected core.LeaseClaim, checkpointID string) error {
+func (b *daytonaLeaseBackend) releaseFixed(ctx context.Context, expected core.LeaseClaim, checkpointID string, absenceOnly bool) error {
 	return core.WithDurableLeaseClaimLockContext(ctx, expected.LeaseID, func(claim *LeaseClaim, exists bool, persist func() error) error {
 		if !exists || !reflect.DeepEqual(*claim, expected) {
 			return exit(4, "Daytona fixed lease claim changed before release; retry")
@@ -362,6 +362,9 @@ func (b *daytonaLeaseBackend) releaseFixed(ctx context.Context, expected core.Le
 		}
 		if err := core.AuthorizeCheckpointRelease(*claim, checkpointID); err != nil {
 			return err
+		}
+		if absenceOnly && claim.FixedCreateIntent.State != "acquired" {
+			return exit(4, "Daytona absence reconciliation requires a completed fixed acquisition")
 		}
 		if !neverSubmittedDaytonaClaim(*claim) {
 			apiClient, err := newDaytonaClient(b.cfg, b.rt)
@@ -384,7 +387,7 @@ func (b *daytonaLeaseBackend) releaseFixed(ctx context.Context, expected core.Le
 					return err
 				}
 			}
-			if err := deleteFixedDaytonaSandbox(ctx, client, claim, persist); err != nil {
+			if err := deleteFixedDaytonaSandbox(ctx, client, claim, persist, absenceOnly); err != nil {
 				return err
 			}
 		}
@@ -454,10 +457,13 @@ func validateFixedDaytonaDeletionIdentity(client fixedDaytonaDeletionAPI, claim 
 	return nil
 }
 
-func deleteFixedDaytonaSandbox(ctx context.Context, client fixedDaytonaDeletionAPI, claim *LeaseClaim, persist func() error) error {
+func deleteFixedDaytonaSandbox(ctx context.Context, client fixedDaytonaDeletionAPI, claim *LeaseClaim, persist func() error, absenceOnly bool) error {
 	intent := claim.FixedCreateIntent
 	if claim.CloudID == "" || intent == nil || (intent.State != "prepared" && intent.State != "acquired") {
 		return exit(4, "Daytona fixed cleanup requires its durably observed resource UUID")
+	}
+	if claim.ProviderScope != intent.ProviderScope || claim.Slug != intent.Slug || intent.Fingerprint == "" || intent.Attempt["nonce"] == "" {
+		return exit(4, "Daytona fixed cleanup has an invalid ownership claim")
 	}
 	for _, key := range []string{"deletion_indexed_id", "deletion_acknowledged_id"} {
 		if value := intent.Attempt[key]; value != "" && value != claim.CloudID {
@@ -472,10 +478,29 @@ func deleteFixedDaytonaSandbox(ctx context.Context, client fixedDaytonaDeletionA
 	if err := client.attestDeletionOrganization(ctx, intent.Attempt["organization"]); err != nil {
 		return err
 	}
-	if intent.Attempt["deletion_acknowledged_id"] == "" {
+	if absenceOnly || intent.Attempt["deletion_acknowledged_id"] == "" {
 		sandbox, err := client.GetSandbox(ctx, claim.CloudID)
 		if err != nil {
+			// Native TTL or external deletion can finish without our DELETE witness.
+			// Only a completed exact acquisition plus current scoped database absence
+			// can retire that claim. A clock deadline or GET alone proves neither.
+			if daytonaIsNotFoundError(err) && intent.State == "acquired" && claim.CloudImmutableID == claim.CloudID &&
+				claim.Labels["fixed_claim_provider"] == core.FixedDaytonaClaimProvider &&
+				claim.Labels["lease"] == claim.LeaseID && claim.Labels["fixed_intent_sha256"] == intent.Fingerprint &&
+				claim.Labels["fixed_attempt"] == intent.Attempt["nonce"] {
+				pending, lookupErr := client.findPendingDeletion(ctx, claim.CloudID)
+				if lookupErr != nil {
+					return lookupErr
+				}
+				if pending == nil {
+					return nil
+				}
+				return exit(4, "Daytona fixed resource remains in database inventory; retain its claim")
+			}
 			return fmt.Errorf("Daytona fixed deletion has no acknowledged outcome; retain lease %s: %w", claim.LeaseID, err)
+		}
+		if absenceOnly {
+			return exit(4, "Daytona fixed resource is still present; inspection cannot delete it")
 		}
 		if err := validateFixedDaytonaDeletionIdentity(client, *claim, sandbox); err != nil {
 			return err

--- a/internal/providers/daytona/fixed_test.go
+++ b/internal/providers/daytona/fixed_test.go
@@ -205,13 +205,38 @@ func TestDaytonaFixedInterruptedAcquisitionNeedsPinnedSource(t *testing.T) {
 }
 
 func TestDaytonaFixedAPIKeyScopeAdmissionPreservesOrdinaryMode(t *testing.T) {
-	for _, scenario := range []string{"empty inventory", "selected organization mismatch"} {
+	for _, scenario := range []string{"empty inventory", "missing organization", "selected organization mismatch", "legacy identity", "legacy empty inventory", "null organization", "numeric organization"} {
 		t.Run(scenario, func(t *testing.T) {
 			f, b, req := newFixedDaytonaFixture(t)
 			if scenario == "empty inventory" {
 				f.hideIdentitySandbox = true
-			} else {
+			} else if scenario == "missing organization" {
+				f.identityOrganization = ""
+			} else if scenario == "selected organization mismatch" {
 				b.cfg.Daytona.OrganizationID = "other-org"
+			} else {
+				f.currentKeyIdentity = func(identity map[string]any) {
+					switch scenario {
+					case "legacy identity", "legacy empty inventory":
+						delete(identity, "organizationId")
+					case "null organization":
+						identity["organizationId"] = nil
+					case "numeric organization":
+						identity["organizationId"] = 1
+					}
+				}
+				f.hideIdentitySandbox = scenario == "legacy empty inventory"
+			}
+			if scenario == "empty inventory" || scenario == "legacy identity" {
+				if _, err := b.Acquire(t.Context(), req); err != nil || f.sandboxCreates != 1 {
+					t.Fatalf("authenticated empty organization could not allocate: %v", err)
+				}
+				if scenario == "legacy identity" {
+					if err := b.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err == nil || !strings.Contains(err.Error(), "does not expose organizationId") || f.deletes != 0 {
+						t.Fatalf("legacy resource admission incorrectly authorized absence: %v", err)
+					}
+				}
+				return
 			}
 			if _, err := b.Acquire(t.Context(), req); err == nil || f.sandboxCreates != 0 {
 				t.Fatalf("unattested scope allocated: err=%v creates=%d", err, f.sandboxCreates)
@@ -219,7 +244,7 @@ func TestDaytonaFixedAPIKeyScopeAdmissionPreservesOrdinaryMode(t *testing.T) {
 			if _, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); err != nil || exists {
 				t.Fatalf("unattested scope published an intent: %v", err)
 			}
-			if scenario == "empty inventory" {
+			if scenario == "missing organization" {
 				if _, _, _, err := b.createDaytonaSandbox(t.Context(), req.Repo, true, false, "ordinary"); err != nil || f.sandboxCreates != 1 {
 					t.Fatalf("ordinary API-key mode regressed: %v", err)
 				}
@@ -531,149 +556,195 @@ func TestDaytonaFixedUncertainDeleteBlocksReuse(t *testing.T) {
 	}
 }
 
-func TestDaytonaFixedCleanupUnwitnessedAbsenceRetainsCustody(t *testing.T) {
-	for _, unknownUUID := range []bool{false, true} {
-		t.Run(fmt.Sprintf("unknown-uuid=%t", unknownUUID), func(t *testing.T) {
-			f, b, req := newFixedDaytonaFixture(t)
-			if unknownUUID {
-				f.createErrorStatus = http.StatusInternalServerError
-			}
-			_, err := b.Acquire(t.Context(), req)
-			if (err != nil) != unknownUUID {
-				t.Fatalf("unexpected acquisition result: %v", err)
-			}
-			before, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-			f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
-			f.sandbox.SetName("DESTROYED_" + f.sandbox.GetName())
-			f.hideIdentitySandbox = true
-			err = b.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID})
-			after, exists, readErr := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-			a, _ := json.Marshal(before)
-			z, _ := json.Marshal(after)
-			if err == nil || readErr != nil || !exists || !bytes.Equal(a, z) || f.deletes != 0 || f.sandboxCreates != 1 {
-				t.Fatalf("unwitnessed absence changed custody: %v %v", err, readErr)
-			}
-		})
+func TestDaytonaFixedNativeDeletionRetiresOnlyAcquiredLease(t *testing.T) {
+	for _, operation := range []string{"stop", "inspect"} {
+		for _, unknownUUID := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/unknown-uuid=%t", operation, unknownUUID), func(t *testing.T) {
+				f, b, req := newFixedDaytonaFixture(t)
+				if unknownUUID {
+					f.createErrorStatus = http.StatusInternalServerError
+				}
+				_, err := b.Acquire(t.Context(), req)
+				if (err != nil) != unknownUUID {
+					t.Fatalf("unexpected acquisition result: %v", err)
+				}
+				before, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+				f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
+				f.sandbox.SetName("DESTROYED_" + f.sandbox.GetName())
+				f.hideIdentitySandbox = true
+				if operation == "stop" {
+					err = b.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID})
+				} else {
+					config := filepath.Join(t.TempDir(), "config.yaml")
+					if err := os.WriteFile(config, []byte(fmt.Sprintf("provider: daytona\nnetwork: public\ndaytona:\n  apiUrl: %q\n", b.cfg.Daytona.APIURL)), 0600); err != nil {
+						t.Fatal(err)
+					}
+					t.Setenv("CRABBOX_CONFIG", config)
+					t.Setenv("CRABBOX_DAYTONA_API_KEY", b.cfg.Daytona.APIKey)
+					var stdout, stderr bytes.Buffer
+					err = (core.App{Stdout: &stdout, Stderr: &stderr}).Run(t.Context(), []string{"inspect", "--id", req.RequestedLeaseID, "--json"})
+					var view core.StatusView
+					if err == nil {
+						if decodeErr := json.Unmarshal(stdout.Bytes(), &view); decodeErr != nil {
+							t.Fatal(decodeErr)
+						}
+					}
+					if !unknownUUID && (view.State != "released" || view.Ready || view.ID != req.RequestedLeaseID) {
+						t.Errorf("native expiry was not reported as terminal: %+v", view)
+					}
+				}
+				after, exists, readErr := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+				a, _ := json.Marshal(before)
+				z, _ := json.Marshal(after)
+				if (err != nil) != unknownUUID || readErr != nil || !exists || f.deletes != 0 || f.sandboxCreates != 1 {
+					t.Fatalf("incorrect native deletion reconciliation: %v %v", err, readErr)
+				}
+				if unknownUUID {
+					if !bytes.Equal(a, z) {
+						t.Fatal("unresolved create lost its custody")
+					}
+				} else {
+					if after.FixedCreateIntent.State != "released" {
+						t.Fatal("native deletion did not persist a tombstone")
+					}
+					if _, err := b.Acquire(t.Context(), req); err == nil || f.sandboxCreates != 1 {
+						t.Fatal("retired fixed ID allocated again")
+					}
+				}
+			})
+		}
 	}
 }
 
 func TestDaytonaFixedCleanupFailureInclusiveInventory(t *testing.T) {
-	for _, scenario := range []string{"absent", "prefix neighbor", "stale", "error", "build failed", "later page error", "later page absent", "repeated resource", "page failure", "wrong page", "changed total", "missing items", "null items", "missing total", "null total", "fractional total", "negative total", "null page", "null total pages", "inconsistent total pages", "short page", "wrong nonce", "changed organization"} {
-		t.Run(scenario, func(t *testing.T) {
-			f, b, req := newFixedDaytonaFixture(t)
-			lease, err := b.Acquire(t.Context(), req)
-			if err != nil {
-				t.Fatal(err)
-			}
-			f.deletionPending = true
-			err = interruptDaytonaFixedCleanup(t, f, req.RequestedLeaseID, func(ctx context.Context) error {
-				return b.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease})
-			})
-			if err == nil || f.deletes != 1 {
-				t.Fatalf("missing interrupted deletion: %v", err)
-			}
-			f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
-			if scenario == "changed organization" {
-				f.identityOrganization = "other-org"
-			}
-			item := *f.sandbox
-			item.SetState(api.SANDBOXSTATE_ERROR)
-			if scenario == "build failed" {
-				item.SetState(api.SANDBOXSTATE_BUILD_FAILED)
-			}
-			if scenario == "stale" {
-				item.SetState(api.SANDBOXSTATE_STARTED)
-			}
-			if scenario == "prefix neighbor" {
-				item.SetId(item.GetId() + "-neighbor")
-			}
-			if scenario == "wrong nonce" {
-				item.Labels = map[string]string{}
-			}
-			original := f.server.Config.Handler
-			pages := 0
-			f.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.Method != http.MethodGet || r.URL.Path != "/sandbox/paginated" {
-					original.ServeHTTP(w, r)
-					return
+	for _, nativeExpiry := range []bool{false, true} {
+		for _, scenario := range []string{"absent", "prefix neighbor", "stale", "error", "build failed", "later page error", "later page absent", "repeated resource", "page failure", "wrong page", "changed total", "missing items", "null items", "missing total", "null total", "fractional total", "negative total", "null page", "null total pages", "inconsistent total pages", "short page", "wrong nonce", "changed organization"} {
+			t.Run(fmt.Sprintf("native-expiry=%t/%s", nativeExpiry, scenario), func(t *testing.T) {
+				f, b, req := newFixedDaytonaFixture(t)
+				lease, err := b.Acquire(t.Context(), req)
+				if err != nil {
+					t.Fatal(err)
 				}
-				pages++
-				if r.URL.Query().Get("states") != "" || r.URL.Query().Get("labels") != "" || r.URL.Query().Get("includeErroredDeleted") != "true" || r.URL.Query().Get("id") != lease.Server.CloudID {
-					t.Errorf("unsupported or unscoped database inventory: %s", r.URL.RawQuery)
+				wantDeletes := 0
+				if !nativeExpiry {
+					wantDeletes = 1
+					f.deletionPending = true
+					err = interruptDaytonaFixedCleanup(t, f, req.RequestedLeaseID, func(ctx context.Context) error {
+						return b.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease})
+					})
+					if err == nil || f.deletes != 1 {
+						t.Fatalf("missing interrupted deletion: %v", err)
+					}
 				}
-				w.Header().Set("Content-Type", "application/json")
-				body := map[string]any{"items": []api.Sandbox{item}, "total": 1, "page": 1, "totalPages": 1}
-				switch scenario {
-				case "absent", "missing items", "null items", "missing total", "null total", "fractional total", "negative total", "null page", "null total pages", "inconsistent total pages", "short page":
-					body = map[string]any{"items": []api.Sandbox{}, "total": 0, "page": 1, "totalPages": 0}
+				f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
+				if scenario == "changed organization" {
+					f.identityOrganization = "other-org"
+				}
+				item := *f.sandbox
+				item.SetState(api.SANDBOXSTATE_ERROR)
+				if scenario == "build failed" {
+					item.SetState(api.SANDBOXSTATE_BUILD_FAILED)
+				}
+				if scenario == "stale" {
+					item.SetState(api.SANDBOXSTATE_STARTED)
+				}
+				if scenario == "prefix neighbor" {
+					item.SetId(item.GetId() + "-neighbor")
+				}
+				if scenario == "wrong nonce" {
+					item.Labels = map[string]string{}
+				}
+				original := f.server.Config.Handler
+				pages := 0
+				f.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method != http.MethodGet || r.URL.Path != "/sandbox/paginated" {
+						original.ServeHTTP(w, r)
+						return
+					}
+					pages++
+					if r.URL.Query().Get("states") != "" || r.URL.Query().Get("labels") != "" || r.URL.Query().Get("includeErroredDeleted") != "true" || r.URL.Query().Get("id") != lease.Server.CloudID {
+						t.Errorf("unsupported or unscoped database inventory: %s", r.URL.RawQuery)
+					}
+					w.Header().Set("Content-Type", "application/json")
+					body := map[string]any{"items": []api.Sandbox{item}, "total": 1, "page": 1, "totalPages": 1}
 					switch scenario {
-					case "missing items":
-						delete(body, "items")
-					case "null items":
-						body["items"] = nil
-					case "missing total":
-						delete(body, "total")
-					case "null total":
-						body["total"] = nil
-					case "fractional total":
-						body["total"] = 0.5
-					case "negative total":
-						body["total"] = -1
-					case "null page":
-						body["page"] = nil
-					case "null total pages":
-						body["totalPages"] = nil
-					case "inconsistent total pages":
-						body["totalPages"] = 1
-					case "short page":
-						body["total"], body["totalPages"] = 1, 1
-					}
-				case "later page error", "later page absent", "repeated resource", "page failure", "wrong page", "changed total":
-					if r.URL.Query().Get("page") == "1" {
-						neighbors := make([]api.Sandbox, 100)
-						for i := range neighbors {
-							neighbors[i] = item
-							neighbors[i].SetId(fmt.Sprintf("%s-neighbor-%d", item.GetId(), i))
+					case "absent", "missing items", "null items", "missing total", "null total", "fractional total", "negative total", "null page", "null total pages", "inconsistent total pages", "short page":
+						body = map[string]any{"items": []api.Sandbox{}, "total": 0, "page": 1, "totalPages": 0}
+						switch scenario {
+						case "missing items":
+							delete(body, "items")
+						case "null items":
+							body["items"] = nil
+						case "missing total":
+							delete(body, "total")
+						case "null total":
+							body["total"] = nil
+						case "fractional total":
+							body["total"] = 0.5
+						case "negative total":
+							body["total"] = -1
+						case "null page":
+							body["page"] = nil
+						case "null total pages":
+							body["totalPages"] = nil
+						case "inconsistent total pages":
+							body["totalPages"] = 1
+						case "short page":
+							body["total"], body["totalPages"] = 1, 1
 						}
-						body = map[string]any{"items": neighbors, "total": 101, "page": 1, "totalPages": 2}
-					} else {
-						if scenario == "page failure" {
-							w.WriteHeader(http.StatusServiceUnavailable)
-							return
-						}
-						body["total"], body["page"], body["totalPages"] = 101, 2, 2
-						if scenario == "later page absent" || scenario == "repeated resource" {
-							neighbor := item
-							neighbor.SetId(item.GetId() + "-neighbor-final")
-							if scenario == "repeated resource" {
-								neighbor.SetId(item.GetId() + "-neighbor-0")
+					case "later page error", "later page absent", "repeated resource", "page failure", "wrong page", "changed total":
+						if r.URL.Query().Get("page") == "1" {
+							neighbors := make([]api.Sandbox, 100)
+							for i := range neighbors {
+								neighbors[i] = item
+								neighbors[i].SetId(fmt.Sprintf("%s-neighbor-%d", item.GetId(), i))
 							}
-							body["items"] = []api.Sandbox{neighbor}
-						}
-						if scenario == "wrong page" {
-							body["page"] = 1
-						}
-						if scenario == "changed total" {
-							body["total"] = 102
+							body = map[string]any{"items": neighbors, "total": 101, "page": 1, "totalPages": 2}
+						} else {
+							if scenario == "page failure" {
+								w.WriteHeader(http.StatusServiceUnavailable)
+								return
+							}
+							body["total"], body["page"], body["totalPages"] = 101, 2, 2
+							if scenario == "later page absent" || scenario == "repeated resource" {
+								neighbor := item
+								neighbor.SetId(item.GetId() + "-neighbor-final")
+								if scenario == "repeated resource" {
+									neighbor.SetId(item.GetId() + "-neighbor-0")
+								}
+								body["items"] = []api.Sandbox{neighbor}
+							}
+							if scenario == "wrong page" {
+								body["page"] = 1
+							}
+							if scenario == "changed total" {
+								body["total"] = 102
+							}
 						}
 					}
+					_ = json.NewEncoder(w).Encode(body)
+				})
+				if nativeExpiry {
+					var view statusView
+					view, err = b.Status(t.Context(), StatusRequest{ID: req.RequestedLeaseID})
+					if err == nil && (view.State != "released" || view.Ready) {
+						t.Fatalf("expiry observation reported usable lease: %+v", view)
+					}
+				} else if scenario == "stale" {
+					err = interruptDaytonaFixedCleanup(t, f, req.RequestedLeaseID, func(ctx context.Context) error { return b.Stop(ctx, StopRequest{ID: req.RequestedLeaseID}) })
+				} else {
+					err = b.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID})
 				}
-				_ = json.NewEncoder(w).Encode(body)
+				claim, exists, readErr := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+				wantReleased := scenario == "absent" || scenario == "prefix neighbor" || scenario == "later page absent"
+				if readErr != nil || !exists || (err == nil) != wantReleased || (claim.FixedCreateIntent.State == "released") != wantReleased || f.deletes != wantDeletes {
+					t.Fatalf("incorrect deletion reconciliation: err=%v read=%v state=%s deletes=%d", err, readErr, claim.FixedCreateIntent.State, f.deletes)
+				}
+				if (scenario == "later page error" || scenario == "later page absent" || scenario == "repeated resource" || scenario == "page failure" || scenario == "wrong page" || scenario == "changed total") && pages != 2 {
+					t.Fatalf("incomplete pagination: pages=%d", pages)
+				}
 			})
-			if scenario == "stale" {
-				err = interruptDaytonaFixedCleanup(t, f, req.RequestedLeaseID, func(ctx context.Context) error { return b.Stop(ctx, StopRequest{ID: req.RequestedLeaseID}) })
-			} else {
-				err = b.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID})
-			}
-			claim, exists, readErr := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-			wantReleased := scenario == "absent" || scenario == "prefix neighbor" || scenario == "later page absent"
-			if readErr != nil || !exists || (err == nil) != wantReleased || (claim.FixedCreateIntent.State == "released") != wantReleased || f.deletes != 1 {
-				t.Fatalf("incorrect deletion reconciliation: err=%v read=%v state=%s deletes=%d", err, readErr, claim.FixedCreateIntent.State, f.deletes)
-			}
-			if (scenario == "later page error" || scenario == "later page absent" || scenario == "repeated resource" || scenario == "page failure" || scenario == "wrong page" || scenario == "changed total") && pages != 2 {
-				t.Fatalf("incomplete pagination: pages=%d", pages)
-			}
-		})
+		}
 	}
 }
 

--- a/internal/providers/daytona/lifecycle_test.go
+++ b/internal/providers/daytona/lifecycle_test.go
@@ -47,6 +47,7 @@ type daytonaLifecycleFixture struct {
 	identityOrganization  string
 	hideIdentitySandbox   bool
 	deletionPending       bool
+	currentKeyIdentity    func(map[string]any)
 }
 
 func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *daytonaLeaseBackend, Repo) {
@@ -68,7 +69,21 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 		}
 
 		switch {
+		case r.Method == "GET" && r.URL.Path == "/api-keys/current":
+			identity := map[string]any{
+				"name": "fixture", "value": "masked", "createdAt": "2026-01-01T00:00:00Z",
+				"permissions": []string{}, "lastUsedAt": nil, "expiresAt": nil, "userId": "fixture-user",
+				"organizationId": f.identityOrganization,
+			}
+			if f.currentKeyIdentity != nil {
+				f.currentKeyIdentity(identity)
+			}
+			_ = json.NewEncoder(w).Encode(identity)
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/organizations/"):
+			if r.Header.Get("Authorization") != "Bearer synthetic-jwt" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
 			if r.URL.Path != "/organizations/"+f.identityOrganization {
 				w.WriteHeader(http.StatusForbidden)
 				return


### PR DESCRIPTION
Fixed Daytona leases could be created with an API key but could not be released: cleanup called an organization endpoint that accepts browser OAuth credentials only. Native TTL expiry also left an acquired fixed lease permanently unresolved after Daytona removed its sandbox.

Use the authenticated organization returned by the current-key endpoint for API-key cleanup and empty-account acquisition. Preserve resource-backed acquisition for older Daytona servers that omit that field. Reconcile an acquired fixed lease through the existing release owner only after checking its original organization, exact native UUID, and complete failure-inclusive database inventory. Inspection records the released tombstone without issuing a provider deletion; ambiguous creates and incomplete observations retain their claims.

Validation:
- Reproduced both failures with released Crabbox 0.56.0.
- Real Daytona CLI proof with the repaired build: fixed acquisition with an API key, explicit and repeated stop, native one-minute TTL expiry, released inspection, and rejection of replaying the retired fixed ID.
- `go test -race -timeout=10m ./internal/providers/daytona -count=1` passed (153.825s); scoped vet and docs generation passed.
- Independent Codex review found no actionable P0–P2 findings.
- The OpenClaw registered-backend live scenario also passed against this build: shared lease creation, token refresh, native pause/resume, preserved remote edits, reopen, recreate, and full cleanup.
- Extended existing HTTP-backed lifecycle coverage for JWT-only organization endpoints, old-server identity compatibility, changed or malformed identity, incomplete inventory, and expired-lease inspection.

This unblocks the lease-backed sandbox integration in https://github.com/openclaw/openclaw/pull/144454. No new configuration, dependency version, or storage format is introduced. Older servers without current-key organization metadata still require an OAuth organization profile for fixed cleanup.

### Inspectable live CLI evidence

Repeated against the final production source tree in `ca25cc1c02cd15e066813524e893c24a2cd27ede`, using an isolated HOME/workspace, the real Daytona API, and an API key. The projection below includes only lease identity, state, readiness, and command exit status; credential-bearing warmup output is omitted. No mocks were used. Both leases were released, and repeated stop also returned zero.

```text
$ crabbox warmup --provider daytona --class small --lease-id cbx_08ef6fc01684 --slug lifecycle-proof --keep --ttl 5m
exit 0
$ crabbox stop cbx_08ef6fc01684
exit 0
$ crabbox inspect --id cbx_08ef6fc01684 --json
{"id": "cbx_08ef6fc01684", "state": "released", "ready": false}
$ crabbox warmup --provider daytona --class small --lease-id cbx_b788ad47f463 --slug lifecycle-proof --keep --ttl 1m
exit 0
Daytona native TTL elapsed; exact native sandbox GET returned HTTP 404.
$ crabbox inspect --id cbx_b788ad47f463 --json
{"id": "cbx_b788ad47f463", "state": "released", "ready": false}
$ crabbox warmup --provider daytona --class small --lease-id cbx_b788ad47f463 --slug lifecycle-proof --keep --ttl 1m
exit 4 (retired fixed ID rejected)
$ crabbox stop cbx_b788ad47f463
exit 0
```
