### PR TITLE
ci: retry transient checksum database seed downloads once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Show Freestyle and Crownest settings through a shared offline JSON/text display path, preserving zero and false values while redacting URLs and reporting only loaded key presence. [PR 2104](https://github.com/openclaw/crabbox/pull/2104). Thanks @steipete.
 - Retain recognized workspace-owner protocol states in child and phase-witness inspection errors, improving diagnostics without changing ownership decisions or retry behavior. [PR 2106](https://github.com/openclaw/crabbox/pull/2106). Thanks @steipete.
+- Retry a recognized checksum-service HTTP/2 interruption once during Go installation verification's dependency download, preserving checksum enforcement and the unchanged offline install checks. Thanks @steipete.
 
 ## 0.56.0 - 2026-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Show Freestyle and Crownest settings through a shared offline JSON/text display path, preserving zero and false values while redacting URLs and reporting only loaded key presence. [PR 2104](https://github.com/openclaw/crabbox/pull/2104). Thanks @steipete.
 - Retain recognized workspace-owner protocol states in child and phase-witness inspection errors, improving diagnostics without changing ownership decisions or retry behavior. [PR 2106](https://github.com/openclaw/crabbox/pull/2106). Thanks @steipete.
-- Retry a recognized checksum-service HTTP/2 interruption once during Go installation verification's dependency download, preserving checksum enforcement and the unchanged offline install checks. Thanks @steipete.
+- Retry a recognized checksum-service HTTP/2 interruption once during Go installation verification's dependency download, preserving checksum enforcement and the unchanged offline install checks. [PR 2113](https://github.com/openclaw/crabbox/pull/2113). Thanks @steipete.
 
 ## 0.56.0 - 2026-09-11
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -107,6 +107,13 @@ commit. That gate constructs a complete read-only local module proxy from the
 exact commit and verifies a cold, version-suffixed `go install` outside the
 checkout. It must pass before candidate production begins.
 
+The online dependency-seeding phase retries once, after five seconds, only for
+the recognized checksum-database tile HTTP/2 `INTERNAL_ERROR` diagnostic.
+Both attempts use the same source, isolated cache and enabled checksum
+verification. Checksum mismatches, mixed or unknown errors, and interruptions
+remain immediately fatal. Original diagnostics remain visible after recovery;
+the read-only proxy, offline install and binary checks are not retried.
+
 Run the credential-free producer first and capture its printed manifest digest:
 
 ```sh

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const read = (file) => fs.readFileSync(path.join(repoRoot, file), "utf8");
@@ -304,6 +305,159 @@ test("GoReleaser is credential-free build-only with exact binary archives", () =
   assert.match(build, /else\s+run_goreleaser\s+fi/);
   assert.match(build, /chmod -R u\+w "\$path"[\s\S]*rm -rf "\$path"/);
   assert.doesNotMatch(build, /gh release|HOMEBREW_TAP_GITHUB_TOKEN=.*\$\{/);
+});
+
+function runSeedDownloadFixture(attempts) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-seed-retry-"));
+  try {
+    const bin = path.join(root, "bin");
+    const scripts = path.join(root, "repo", "scripts");
+    const source = path.join(root, "archive-source");
+    const tmp = path.join(root, "tmp");
+    for (const directory of [bin, scripts, source, tmp, path.join(root, "home")]) fs.mkdirSync(directory, { recursive: true });
+    const entrypoint = path.join(scripts, "verify-go-install.sh");
+    fs.copyFileSync(path.join(repoRoot, "scripts/verify-go-install.sh"), entrypoint);
+    fs.writeFileSync(path.join(source, "go.mod"), "module github.com/openclaw/crabbox\n");
+    const archive = path.join(root, "source.tar");
+    execFileSync("/usr/bin/tar", ["-cf", archive, "-C", source, "."]);
+    const callsFile = path.join(root, "calls.jsonl");
+    const driver = path.join(root, "fixture.mjs");
+    const quote = (value) => `'${value.replaceAll("'", `'"'"'`)}'`;
+    const wrapper = (tool) => `#!/bin/sh\nexec ${quote(process.execPath)} ${quote(driver)} ${quote(tool)} "$@"\n`;
+    fs.writeFileSync(driver, `
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+const root = ${JSON.stringify(root)};
+const attempts = ${JSON.stringify(attempts)};
+const [tool, ...args] = process.argv.slice(2);
+const envNames = ["HOME", "PATH", "TMPDIR", "GOCACHE", "GOMODCACHE", "GOENV", "GOPROXY", "GOSUMDB", "GOTOOLCHAIN", "GOWORK", "GOPATH", "GOBIN", "GONOSUMDB", "GOPRIVATE", "GONOPROXY", "GODEBUG", "GOFLAGS"];
+const call = { tool, args, cwd: process.cwd(), env: Object.fromEntries(envNames.map(name => [name, process.env[name] ?? null])) };
+fs.appendFileSync(${JSON.stringify(callsFile)}, JSON.stringify(call) + "\\n");
+function unexpected() { console.error("unexpected inert fixture command", tool, args); process.exit(99); }
+if (tool === "git") {
+  if (args[2] === "rev-parse") console.log("a".repeat(40));
+  else if (args[2] === "archive") process.stdout.write(fs.readFileSync(${JSON.stringify(archive)}));
+  else if (args[2] === "show") console.log("2026-09-01T00:00:00Z");
+  else unexpected();
+} else if (tool === "sleep") {
+  // Record the requested delay without sleeping.
+} else if (tool === "cp") {
+  execFileSync("/bin/cp", args);
+} else if (tool === "zip") {
+  if (args.slice(0, 3).join(" ") !== "-q -X -r") unexpected();
+  fs.writeFileSync(args[3], "inert zip placeholder");
+} else if (tool === "binary") {
+  if (args.join(" ") === "--version") console.log("1.2.3");
+  else if (!["--help", "run --help"].includes(args.join(" "))) unexpected();
+} else if (tool === "go") {
+  if (args.join(" ") === "mod edit -json") console.log("{}");
+  else if (args[0] === "run" && ["source", "sanitize-zip", "binary"].includes(args[2])) {
+    // TEST ONLY: accept metadata and zip preparation to reach the shell's
+    // retry/install boundary. This is not a test of the embedded Go verifier.
+  } else if (args.join(" ") === "mod download all") {
+    const counter = path.join(root, "attempt-count");
+    const index = fs.existsSync(counter) ? Number(fs.readFileSync(counter, "utf8")) : 0;
+    fs.writeFileSync(counter, String(index + 1));
+    // Even failed attempts leave metadata, so its existence cannot mask an
+    // accidental copy/install after a failed seed command.
+    const download = path.join(process.env.GOMODCACHE, "cache", "download");
+    if (index > 0 && !fs.existsSync(path.join(download, "fixture-seed"))) unexpected();
+    fs.mkdirSync(download, { recursive: true });
+    fs.writeFileSync(path.join(download, "fixture-seed"), "inert dependency metadata");
+    const attempt = attempts[index];
+    if (!attempt) unexpected();
+    process.stderr.write(attempt.output);
+    process.exit(attempt.code);
+  } else if (args[0] === "install") {
+    const proxy = process.env.GOPROXY.slice("file://".length);
+    if (!fs.existsSync(path.join(proxy, "fixture-seed"))) unexpected();
+    if ((fs.statSync(path.join(proxy, "fixture-seed")).mode & 0o222) !== 0) unexpected();
+    fs.writeFileSync(path.join(process.env.GOBIN, "crabbox"), ${JSON.stringify(wrapper("binary"))}, { mode: 0o755 });
+  } else if (args.slice(0, 3).join(" ") === "version -m -json") console.log("{}");
+  else unexpected();
+} else unexpected();
+`);
+    for (const tool of ["git", "go", "zip", "sleep", "cp"]) writeExecutable(path.join(bin, tool), wrapper(tool));
+    const result = spawnSync("/bin/bash", [entrypoint, "v1.2.3", "fixture-source"], {
+      encoding: "utf8", timeout: 20_000,
+      env: { PATH: `${bin}:/usr/bin:/bin`, HOME: path.join(root, "home"), TMPDIR: tmp },
+    });
+    assert.equal(result.error, undefined, result.error?.message);
+    const calls = fs.readFileSync(callsFile, "utf8").trim().split("\n").map(JSON.parse);
+    assert.deepEqual(fs.readdirSync(tmp), [], "entrypoint must clean its private WORK directory");
+    return { result, calls };
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("Go install seed retry preserves bounded verified download and offline phases", async (t) => {
+  const transport = "go: github.com/openfga/go-sdk@v0.8.1: verifying go.mod: github.com/openfga/go-sdk@v0.8.1/go.mod: reading https://sum.golang.org/tile/8/0/x212/602: stream error: stream ID 885; INTERNAL_ERROR; received from peer\n";
+  const progress = "go: downloading example.com/dependency v1.0.0\n\n";
+  const mismatch = "verifying example.com/dependency@v1.0.0: checksum mismatch\nSECURITY ERROR\n";
+  const ok = { code: 0, output: "" };
+  const transient = { code: 1, output: progress + transport };
+  for (const tc of [
+    { name: "success-once", attempts: [ok], downloads: 1, delay: 0, code: 0 },
+    { name: "tile-error-then-success", attempts: [transient, ok], downloads: 2, delay: 1, code: 0 },
+    { name: "tile-error-twice", attempts: [transient, transient], downloads: 2, delay: 1, code: 1 },
+    { name: "second-error-status", attempts: [transient, { code: 7, output: "second attempt stopped\n" }], downloads: 2, delay: 1, code: 7 },
+    { name: "checksum-mismatch", attempts: [{ code: 1, output: mismatch }], downloads: 1, delay: 0, code: 1 },
+    { name: "mixed-errors", attempts: [{ code: 1, output: transport + mismatch }], downloads: 1, delay: 0, code: 1 },
+    { name: "mixed-unknown", attempts: [{ code: 1, output: transport + "go: module lookup failed\n" }], downloads: 1, delay: 0, code: 1 },
+    { name: "non-tile-endpoint", attempts: [{ code: 1, output: transport.replace("/tile/", "/lookup/") }], downloads: 1, delay: 0, code: 1 },
+    { name: "unknown-error", attempts: [{ code: 1, output: "go: module lookup failed\n" }], downloads: 1, delay: 0, code: 1 },
+    { name: "empty-error", attempts: [{ code: 1, output: "" }], downloads: 1, delay: 0, code: 1 },
+    { name: "progress-only-error", attempts: [{ code: 1, output: progress }], downloads: 1, delay: 0, code: 1 },
+    { name: "non-one-status", attempts: [{ code: 23, output: transport }], downloads: 1, delay: 0, code: 23 },
+    { name: "different-module-error", attempts: [{ code: 1, output: transport.replace("verifying go.mod: github.com/openfga", "verifying go.mod: example.com/other") }], downloads: 1, delay: 0, code: 1 },
+  ]) {
+    await t.test(tc.name, () => {
+      const { result, calls } = runSeedDownloadFixture(tc.attempts);
+      assert.equal(result.status, tc.code, result.stderr);
+      const downloads = calls.filter(c => c.tool === "go" && c.args.join(" ") === "mod download all");
+      const delays = calls.filter(c => c.tool === "sleep");
+      const installs = calls.filter(c => c.tool === "go" && c.args[0] === "install");
+      const copies = calls.filter(c => c.tool === "cp" && c.args.some(arg => arg.endsWith("seed-modcache/cache/download/.")));
+      assert.equal(downloads.length, tc.downloads);
+      assert.equal(delays.length, tc.delay);
+      for (const delay of delays) assert.deepEqual(delay.args, ["5"]);
+      for (const download of downloads) {
+        assert.deepEqual(download, downloads[0], "retry changed argv/environment/cwd/cache");
+        assert.equal(download.env.GOPROXY, "https://proxy.golang.org");
+        assert.equal(download.env.GOSUMDB, "sum.golang.org");
+        assert.equal(download.env.GOENV, "off");
+        assert.equal(download.env.GOTOOLCHAIN, "local");
+        assert.equal(download.env.GOWORK, "off");
+        assert.equal(path.basename(download.cwd), "source");
+        assert.equal(path.basename(download.env.GOMODCACHE), "seed-modcache");
+        assert.equal(path.basename(download.env.HOME), "seed-home");
+        assert.equal(path.basename(download.env.GOCACHE), "seed-gocache");
+        assert.equal(path.basename(download.env.TMPDIR), "seed-tmp");
+        for (const key of ["GONOSUMDB", "GOPRIVATE", "GONOPROXY", "GODEBUG", "GOFLAGS"]) assert.equal(download.env[key], null);
+      }
+      for (const output of new Set(tc.attempts.map(a => a.output).filter(Boolean))) {
+        assert.equal(result.stderr.split(output).length - 1, tc.attempts.filter(a => a.output === output).length, "original diagnostics were lost");
+      }
+      assert.equal(installs.length, tc.code === 0 ? 1 : 0);
+      assert.equal(copies.length, tc.code === 0 ? 1 : 0, "failed seed reached proxy copy");
+      if (tc.code === 0) {
+        const install = installs[0];
+        assert.deepEqual(install.args, ["install", "github.com/openclaw/crabbox/cmd/crabbox@v1.2.3"]);
+        assert.match(install.env.GOPROXY, /^file:\/\//);
+        assert.equal(install.env.GOSUMDB, "off");
+        for (const key of ["GOENV", "GOTOOLCHAIN", "GOWORK"]) assert.equal(install.env[key], downloads[0].env[key]);
+        for (const key of ["HOME", "GOCACHE", "GOMODCACHE", "TMPDIR"]) assert.notEqual(install.env[key], downloads[0].env[key]);
+        assert.notEqual(install.cwd, downloads[0].cwd);
+        assert.equal(path.basename(install.env.GOPATH), "gopath");
+        assert.equal(path.basename(install.env.GOBIN), "bin");
+        assert.ok(calls.indexOf(copies[0]) > calls.indexOf(downloads.at(-1)));
+        assert.ok(calls.indexOf(install) > calls.indexOf(copies[0]));
+        assert.deepEqual(calls.filter(c => c.tool === "binary").map(c => c.args), [["--version"], ["--help"], ["run", "--help"]]);
+      }
+    });
+  }
 });
 
 test("versioned Go installation is hermetic and precedes release builds", () => {

--- a/scripts/verify-go-install.sh
+++ b/scripts/verify-go-install.sh
@@ -268,15 +268,51 @@ env -i \
 
 # Download the complete selected dependency graph into an isolated cache, then
 # copy the proxy-form cache entries. Network access ends before the install.
-(
-  cd "$SOURCE"
-  env -i \
-    GOCACHE="$SEED_GOCACHE" GOMODCACHE="$SEED_MODCACHE" \
-    GOENV=off GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org \
-    GOTOOLCHAIN=local GOWORK=off \
-    HOME="$SEED_HOME" PATH="$PATH" TMPDIR="$SEED_TMP" \
-    go mod download all
-)
+seed_download_retryable() {
+  local line recognized=0
+  local progress='^go: downloading [^[:space:]]+ v[^[:space:]]+$'
+  local transient='^go: ([^[:space:]:]+@v[^[:space:]:]+): verifying go[.]mod: ([^[:space:]:]+@v[^[:space:]:]+)/go[.]mod: reading https://sum[.]golang[.]org/tile/[0-9]+/[0-9]+/(x[0-9]+/)*[0-9]+: stream error: stream ID [0-9]+; INTERNAL_ERROR; received from peer$'
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ $progress ]]; then
+      continue
+    fi
+    if [[ "$line" =~ $transient ]] && [[ "${BASH_REMATCH[1]}" == "${BASH_REMATCH[2]}" ]]; then
+      recognized=1
+    else
+      return 1
+    fi
+  done <"$1"
+  [[ "$recognized" -eq 1 ]]
+}
+
+seed_dependencies() {
+  local attempt download_status log
+  for attempt in 1 2; do
+    log="$WORK/seed-download-attempt-$attempt.log"
+    if (
+      cd "$SOURCE" || exit $?
+      env -i \
+        GOCACHE="$SEED_GOCACHE" GOMODCACHE="$SEED_MODCACHE" \
+        GOENV=off GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org \
+        GOTOOLCHAIN=local GOWORK=off \
+        HOME="$SEED_HOME" PATH="$PATH" TMPDIR="$SEED_TMP" \
+        go mod download all
+    ) >"$log" 2>&1; then
+      cat "$log" >&2
+      return 0
+    else
+      download_status=$?
+    fi
+    cat "$log" >&2
+    if [[ "$attempt" -ne 1 || "$download_status" -ne 1 ]] || ! seed_download_retryable "$log"; then
+      return "$download_status"
+    fi
+    echo "Dependency seed attempt 1 failed with a checksum-database transport error; retrying once in 5 seconds." >&2
+    sleep 5 || return $?
+  done
+}
+
+seed_dependencies
 [[ -d "$SEED_MODCACHE/cache/download" ]] || fail "dependency download did not create proxy cache metadata"
 cp -R "$SEED_MODCACHE/cache/download/." "$PROXY/"
 


### PR DESCRIPTION
## Summary

Retry only the dependency-seeding `go mod download all` once when its entire failed output is the observed sum.golang.org tile HTTP/2 INTERNAL_ERROR diagnostic plus ordinary download progress. The two total attempts use the same archived source, arguments, isolated cache and checksum-enabled environment, with one five-second delay. Each original diagnostic remains visible.

Checksum mismatches, mixed or unknown errors, unmatched module references, non-tile failures and non-one exit statuses remain immediately fatal. Failed seeding cannot reach proxy copying or installation. The read-only local proxy, separate offline install, binary metadata/version/help checks and release ordering remain unchanged. This neither retries a release nor changes its authorization or publication policy.

Two independent CI failures motivate this exact classification: https://github.com/openclaw/crabbox/actions/runs/34629079040 (DHCP module) and https://github.com/openclaw/crabbox/actions/runs/34629113487 (OpenFGA module). Both failed reading checksum-database tiles before offline installation and passed one unchanged failed-job retry. That evidence does not establish the network/server root cause or imply all download errors are transient.

## Verification

- Actual script entrypoint tested with inert Git/Go/zip fixtures and no network, dependency download, install or release operation. The fake Go metadata verifier is explicitly not proof of the embedded verifier's correctness.
- Thirteen scenarios cover initial success, transport recovery, exhaustion, second-attempt status, checksum mismatch, mixed/unknown/empty/progress-only failures, non-one status, mismatched module references and non-tile errors. They verify original diagnostics, one delay, cache continuity, unchanged environment/arguments, failed-seed exclusion from copying/install, and exactly one offline install after success.
- The immutable baseline failed only the three retry scenarios; the candidate passed all thirteen. The existing hermetic-install/static release-order test is unchanged and passes. The root focused run passed fifteen tests including the scenario parent and existing static test.
- Bash syntax, docs checks and whitespace checks passed. Managed Codex review passed at P0 scope.

Normal CI will exercise real Go installation separately; the controlled transport-error scenarios remain inert tests rather than live fault reproduction. Docs and Unreleased notes describe the narrow recovery policy.
