### PR TITLE
fix: allow recovery of stale Daytona claims after sandbox deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Daytona: add explicit local recovery for ordinary missing-sandbox claims while retaining fixed replay records and rejecting brokered cleanup. [PR 2115](https://github.com/openclaw/crabbox/pull/2115). Thanks @Patrick-Erichsen.
 - Daytona: attest API-key cleanup through current-key organization metadata and retire acquired fixed leases after verified native TTL or external deletion; inspection records a terminal tombstone without issuing deletion or reusing the fixed ID. [PR 2111](https://github.com/openclaw/crabbox/pull/2111). Thanks @steipete.
 - Show Freestyle and Crownest settings through a shared offline JSON/text display path, preserving zero and false values while redacting URLs and reporting only loaded key presence. [PR 2104](https://github.com/openclaw/crabbox/pull/2104). Thanks @steipete.
 - Retain recognized workspace-owner protocol states in child and phase-witness inspection errors, improving diagnostics without changing ownership decisions or retry behavior. [PR 2106](https://github.com/openclaw/crabbox/pull/2106). Thanks @steipete.

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -101,6 +101,11 @@ Crabbox lease ID and local slug:
   the caller's cancellation and deadline. The CLI remains signal-cancelable;
   the automatic-cleanup timeout does not shorten that lifetime. Non-cancelable
   callers, including detached job cleanup, retain the 30-second fallback.
+  For an ordinary claim whose sandbox is already missing, explicit
+  `--daytona-forget-missing` queries the exact bound ID and removes only local
+  state after a structured 404. Check the original account and endpoint first:
+  this does not verify remote deletion or stop billing. Live sandboxes and fixed
+  replay-protected claims cannot be forgotten.
 - `coder` — stops the Coder workspace by default and removes the local claim.
   Set `coder.deleteOnRelease` or pass `--coder-delete-on-release` to delete the
   workspace instead.

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -177,6 +177,7 @@ Provider flags:
 --daytona-work-root
 --daytona-ssh-gateway-host
 --daytona-ssh-access-minutes
+--daytona-forget-missing # stop only; ordinary local claims only
 ```
 
 The non-auth settings can also be set through environment variables:
@@ -195,6 +196,26 @@ require operator resolution. See [managed Daytona cleanup](../features/lifecycle
 for lifetime, key-rotation, and recovery behavior.
 
 ## Direct lifecycle
+
+### Forgetting an ordinary stale claim
+
+If native TTL or an external deletion removes an ordinary sandbox, normal `stop`
+preserves its claim when the sandbox cannot be resolved. After checking the
+original Daytona account and API endpoint, explicitly forget that local record:
+
+```bash
+crabbox stop --provider daytona --daytona-forget-missing <lease-id-or-local-slug>
+```
+
+This command queries only the claim's exact sandbox ID and removes local state
+only after a structured Daytona 404. It refuses live sandboxes, authorization
+errors, malformed responses, checkpoint-held claims, and coordinator/adapter
+registrations that require normal release reconciliation. It never
+sends DELETE or reports remote release: a 404 can also mean the current credentials
+cannot access the original account, so any remaining sandbox may still be billed.
+The flag is command-only and cannot be enabled in a profile or environment variable.
+Fixed claims cannot be forgotten; use ordinary `stop` to reconcile them and retain
+their terminal replay protection as described below.
 
 ### Fixed operation IDs
 

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -214,6 +214,7 @@ registrations that require normal release reconciliation. It never
 sends DELETE or reports remote release: a 404 can also mean the current credentials
 cannot access the original account, so any remaining sandbox may still be billed.
 The flag is command-only and cannot be enabled in a profile or environment variable.
+Brokered mode and other providers reject the flag before contacting the service.
 Fixed claims cannot be forgotten; use ordinary `stop` to reconcile them and retain
 their terminal replay protection as described below.
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -449,6 +449,7 @@ type ExternalDesktopConfig struct {
 }
 
 type DaytonaConfig struct {
+	ForgetMissing    bool `yaml:"-" json:"-"`
 	APIKey           string
 	JWTToken         string
 	OrganizationID   string

--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -313,6 +313,9 @@ func (b *daytonaLeaseBackend) Stop(ctx context.Context, req StopRequest) error {
 		ctx, cancel = context.WithTimeout(ctx, daytonaCleanupTimeout)
 		defer cancel()
 	}
+	if b.cfg.Daytona.ForgetMissing {
+		return b.forgetMissing(ctx, req.ID)
+	}
 	if claim, exists, err := resolveLeaseClaimForProvider(req.ID, daytonaProvider); err != nil {
 		return err
 	} else if exists && claim.FixedCreateIntent != nil {

--- a/internal/providers/daytona/backend_ssh.go
+++ b/internal/providers/daytona/backend_ssh.go
@@ -56,6 +56,9 @@ func ApplyDaytonaProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error 
 		if fs.Name() != "stop" {
 			return exit(2, "--daytona-forget-missing is only supported by stop")
 		}
+		if *v.ForgetMissing && cfg.Provider != daytonaProvider {
+			return exit(2, "--daytona-forget-missing requires direct provider=daytona")
+		}
 		cfg.Daytona.ForgetMissing = *v.ForgetMissing
 		core.RecordProviderFlagInputs(cfg, true, "daytona")
 	}

--- a/internal/providers/daytona/backend_ssh.go
+++ b/internal/providers/daytona/backend_ssh.go
@@ -30,8 +30,7 @@ type daytonaFlagValues struct {
 }
 
 func RegisterDaytonaProviderFlags(fs *flag.FlagSet, defaults Config) any {
-	return daytonaFlagValues{
-		ForgetMissing:    fs.Bool("daytona-forget-missing", false, "remove only the local ordinary Daytona claim after a structured missing-sandbox response"),
+	values := daytonaFlagValues{
 		APIURL:           fs.String("daytona-api-url", defaults.Daytona.APIURL, "Daytona API URL"),
 		Snapshot:         fs.String("daytona-snapshot", defaults.Daytona.Snapshot, "Daytona snapshot name"),
 		Target:           fs.String("daytona-target", defaults.Daytona.Target, "Daytona compute target"),
@@ -40,6 +39,10 @@ func RegisterDaytonaProviderFlags(fs *flag.FlagSet, defaults Config) any {
 		SSHGatewayHost:   fs.String("daytona-ssh-gateway-host", defaults.Daytona.SSHGatewayHost, "Daytona SSH gateway host"),
 		SSHAccessMinutes: fs.Int("daytona-ssh-access-minutes", defaults.Daytona.SSHAccessMinutes, "Daytona SSH access token TTL in minutes"),
 	}
+	if fs.Name() == "stop" {
+		values.ForgetMissing = fs.Bool("daytona-forget-missing", false, "remove only the local ordinary Daytona claim after a structured missing-sandbox response")
+	}
+	return values
 }
 
 func ApplyDaytonaProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
@@ -53,9 +56,6 @@ func ApplyDaytonaProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error 
 		return nil
 	}
 	if core.FlagWasSet(fs, "daytona-forget-missing") {
-		if fs.Name() != "stop" {
-			return exit(2, "--daytona-forget-missing is only supported by stop")
-		}
 		if *v.ForgetMissing && cfg.Provider != daytonaProvider {
 			return exit(2, "--daytona-forget-missing requires direct provider=daytona")
 		}

--- a/internal/providers/daytona/backend_ssh.go
+++ b/internal/providers/daytona/backend_ssh.go
@@ -19,6 +19,7 @@ const (
 )
 
 type daytonaFlagValues struct {
+	ForgetMissing    *bool
 	APIURL           *string
 	Snapshot         *string
 	Target           *string
@@ -30,6 +31,7 @@ type daytonaFlagValues struct {
 
 func RegisterDaytonaProviderFlags(fs *flag.FlagSet, defaults Config) any {
 	return daytonaFlagValues{
+		ForgetMissing:    fs.Bool("daytona-forget-missing", false, "remove only the local ordinary Daytona claim after a structured missing-sandbox response"),
 		APIURL:           fs.String("daytona-api-url", defaults.Daytona.APIURL, "Daytona API URL"),
 		Snapshot:         fs.String("daytona-snapshot", defaults.Daytona.Snapshot, "Daytona snapshot name"),
 		Target:           fs.String("daytona-target", defaults.Daytona.Target, "Daytona compute target"),
@@ -49,6 +51,13 @@ func ApplyDaytonaProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error 
 	v, ok := values.(daytonaFlagValues)
 	if !ok {
 		return nil
+	}
+	if core.FlagWasSet(fs, "daytona-forget-missing") {
+		if fs.Name() != "stop" {
+			return exit(2, "--daytona-forget-missing is only supported by stop")
+		}
+		cfg.Daytona.ForgetMissing = *v.ForgetMissing
+		core.RecordProviderFlagInputs(cfg, true, "daytona")
 	}
 	if core.FlagWasSet(fs, "daytona-api-url") {
 		cfg.Daytona.APIURL = *v.APIURL

--- a/internal/providers/daytona/forget_missing.go
+++ b/internal/providers/daytona/forget_missing.go
@@ -1,0 +1,60 @@
+package daytona
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	api "github.com/daytonaio/daytona/libs/api-client-go"
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// Forgetting is an explicit local recovery operation, not proof of provider
+// deletion: even an application 404 can mean lost access to the original account.
+func (b *daytonaLeaseBackend) forgetMissing(ctx context.Context, id string) error {
+	claim, exists, err := resolveLeaseClaimForProvider(id, daytonaProvider)
+	if err != nil {
+		return err
+	}
+	if !exists || strings.TrimSpace(claim.CloudID) == "" {
+		return exit(4, "Daytona local cleanup requires a claim bound to an exact sandbox ID")
+	}
+	if claim.FixedCreateIntent != nil || claim.Labels["fixed_claim_provider"] != "" {
+		return exit(4, "Daytona fixed claims retain replay protection; use stop without --daytona-forget-missing to reconcile release")
+	}
+	if claim.CoordinatorRegistrationURL != "" || claim.RuntimeAdapterRegistrationID != "" || claim.RuntimeAdapterPendingRegistrationID != "" {
+		return exit(4, "Daytona registered claims require normal release reconciliation; retain the local record")
+	}
+	client, err := newDaytonaClient(b.cfg, b.rt)
+	if err != nil {
+		return err
+	}
+	err = core.CleanupLeaseClaimIfUnchangedAfterContext(ctx, claim.LeaseID, claim, true, func() error {
+		if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
+			return err
+		}
+		_, err := client.GetSandbox(ctx, claim.CloudID)
+		if err == nil {
+			return exit(4, "Daytona sandbox %s did not return a missing-sandbox response; retain its claim", claim.CloudID)
+		}
+		var apiErr *api.GenericOpenAPIError
+		var response struct {
+			StatusCode int    `json:"statusCode"`
+			Error      string `json:"error"`
+			Message    string `json:"message"`
+		}
+		if !daytonaIsNotFoundError(err) || !errors.As(err, &apiErr) ||
+			json.Unmarshal(apiErr.Body(), &response) != nil || response.StatusCode != 404 ||
+			response.Error != "Not Found" || strings.TrimSpace(response.Message) == "" {
+			return daytonaError("verify missing sandbox; retain its claim", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(b.rt.Stderr, "forgot local Daytona claim lease=%s sandbox=%s; provider deletion was not verified\n", claim.LeaseID, claim.CloudID)
+	return nil
+}

--- a/internal/providers/daytona/forget_missing_test.go
+++ b/internal/providers/daytona/forget_missing_test.go
@@ -131,6 +131,12 @@ func TestDaytonaForgetMissingRejectsOtherCommandsAndProviders(t *testing.T) {
 			cfg.Provider = tc.provider
 			fs := flag.NewFlagSet(tc.command, flag.ContinueOnError)
 			values := RegisterDaytonaProviderFlags(fs, cfg)
+			if tc.command != "stop" {
+				if fs.Lookup("daytona-forget-missing") != nil {
+					t.Fatal("stop-only recovery flag was registered on another command")
+				}
+				return
+			}
 			if err := fs.Parse([]string{"--daytona-forget-missing"}); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/providers/daytona/forget_missing_test.go
+++ b/internal/providers/daytona/forget_missing_test.go
@@ -2,6 +2,7 @@ package daytona
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -94,6 +95,47 @@ func TestDaytonaForgetMissing(t *testing.T) {
 			}
 			if requests.Load() != 1 || strings.Contains(stdout.String()+stderr.String(), "released") {
 				t.Errorf("requests=%d output=%q", requests.Load(), stdout.String()+stderr.String())
+			}
+		})
+	}
+}
+
+func TestDaytonaForgetMissingRejectsBrokeredStop(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	t.Chdir(t.TempDir())
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+	for _, name := range []string{"CRABBOX_COORDINATOR", "CRABBOX_COORDINATOR_MODE", "CRABBOX_COORDINATOR_TOKEN_COMMAND", "CRABBOX_POND", "CRABBOX_TAILSCALE"} {
+		t.Setenv(name, "")
+	}
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("provider: daytona\ntarget: linux\ncoordinator: "+srv.URL+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	var stdout, stderr bytes.Buffer
+	err := (core.App{Stdout: &stdout, Stderr: &stderr}).Run(t.Context(), []string{"stop", "--provider", "daytona", "--daytona-forget-missing", "cbx_123456abcdef"})
+	if err == nil || !strings.Contains(err.Error(), "requires direct provider=daytona") || requests.Load() != 0 {
+		t.Fatalf("brokered local cleanup was not rejected before requests: err=%v requests=%d", err, requests.Load())
+	}
+}
+
+func TestDaytonaForgetMissingRejectsOtherCommandsAndProviders(t *testing.T) {
+	for _, tc := range []struct{ command, provider string }{{"run", "daytona"}, {"stop", "other-provider"}} {
+		t.Run(tc.command+"/"+tc.provider, func(t *testing.T) {
+			cfg := baseConfig()
+			cfg.Provider = tc.provider
+			fs := flag.NewFlagSet(tc.command, flag.ContinueOnError)
+			values := RegisterDaytonaProviderFlags(fs, cfg)
+			if err := fs.Parse([]string{"--daytona-forget-missing"}); err != nil {
+				t.Fatal(err)
+			}
+			if err := ApplyDaytonaProviderFlags(&cfg, fs, values); err == nil || cfg.Daytona.ForgetMissing {
+				t.Fatalf("incompatible flag accepted: err=%v enabled=%t", err, cfg.Daytona.ForgetMissing)
 			}
 		})
 	}

--- a/internal/providers/daytona/forget_missing_test.go
+++ b/internal/providers/daytona/forget_missing_test.go
@@ -1,0 +1,173 @@
+package daytona
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+func TestDaytonaForgetMissing(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+		forget bool
+	}{
+		{"provider absence", 404, `{"statusCode":404,"error":"Not Found","message":"Sandbox not found"}`, true},
+		{"proxy absence", 404, `<html>Not Found</html>`, false},
+		{"empty absence", 404, ``, false},
+		{"incomplete absence", 404, `{"message":"not found"}`, false},
+		{"conflicting status", 404, `{"statusCode":403,"error":"Not Found","message":"not found"}`, false},
+		{"transport error", 0, ``, false},
+		{"unauthorized", 401, `{"statusCode":401,"error":"Unauthorized"}`, false},
+		{"forbidden", 403, `{"statusCode":403,"error":"Forbidden"}`, false},
+		{"service error", 503, `{"statusCode":503,"error":"Unavailable"}`, false},
+		{"live sandbox", 200, `{"id":"sandbox-original"}`, false},
+		{"empty success", 200, `null`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dirs := testutil.IsolateUserDirs(t)
+			repo := t.TempDir()
+			t.Chdir(repo)
+			for _, name := range []string{"CRABBOX_COORDINATOR", "CRABBOX_COORDINATOR_MODE", "CRABBOX_COORDINATOR_TOKEN_COMMAND", "CRABBOX_POND", "CRABBOX_TAILSCALE", "CRABBOX_DAYTONA_JWT_TOKEN", "DAYTONA_JWT_TOKEN", "CRABBOX_DAYTONA_ORGANIZATION_ID", "DAYTONA_ORGANIZATION_ID"} {
+				t.Setenv(name, "")
+			}
+			t.Setenv("CRABBOX_DAYTONA_API_KEY", "synthetic-credential")
+			const leaseID = "cbx_123456abcdef"
+			const resourceID = "sandbox-original"
+			var requests atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+				if r.Method != "GET" || r.URL.Path != "/sandbox/"+resourceID {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+				if tc.status == 0 {
+					conn, _, err := w.(http.Hijacker).Hijack()
+					if err != nil {
+						t.Error(err)
+						return
+					}
+					_ = conn.Close()
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = fmt.Fprint(w, tc.body)
+			}))
+			defer srv.Close()
+			t.Setenv("CRABBOX_DAYTONA_API_URL", srv.URL)
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(configPath, []byte("provider: daytona\ntarget: linux\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("CRABBOX_CONFIG", configPath)
+			if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, "missing-fixture", "daytona", "", "", repo, time.Minute, false,
+				core.Server{Provider: "daytona", CloudID: resourceID}, core.SSHTarget{}); err != nil {
+				t.Fatal(err)
+			}
+			claimPath := filepath.Join(dirs.StateHome, "crabbox", "claims", leaseID+".json")
+			before, err := os.ReadFile(claimPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var stdout, stderr bytes.Buffer
+			err = (core.App{Stdout: &stdout, Stderr: &stderr}).Run(t.Context(), []string{"stop", "--provider", "daytona", "--daytona-forget-missing", "missing-fixture"})
+			after, readErr := os.ReadFile(claimPath)
+			if tc.forget {
+				if err != nil || !os.IsNotExist(readErr) || !strings.Contains(stderr.String(), "forgot local Daytona claim") {
+					t.Fatalf("err=%v claim read=%v output=%q", err, readErr, stderr.String())
+				}
+				t.Logf("exact GET=404; claim removed; %s", strings.TrimSpace(stderr.String()))
+			} else if err == nil || readErr != nil || !bytes.Equal(before, after) {
+				t.Fatalf("expected unchanged claim: err=%v read=%v", err, readErr)
+			}
+			if requests.Load() != 1 || strings.Contains(stdout.String()+stderr.String(), "released") {
+				t.Errorf("requests=%d output=%q", requests.Load(), stdout.String()+stderr.String())
+			}
+		})
+	}
+}
+
+func TestDaytonaForgetMissingRequiresUnheldDirectClaim(t *testing.T) {
+	for _, scenario := range []string{"no claim", "no sandbox ID", "checkpoint", "coordinator", "adapter", "pending adapter"} {
+		t.Run(scenario, func(t *testing.T) {
+			f, b, repo := newDaytonaLifecycleFixture(t)
+			_, leaseID, _, err := b.createDaytonaSandbox(t.Context(), repo, true, false, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			claim, _, err := core.ReadLeaseClaimWithPresence(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			changed := claim
+			switch scenario {
+			case "no sandbox ID":
+				changed.CloudID = ""
+			case "checkpoint":
+				changed.CheckpointCapture = &core.CheckpointCaptureBinding{ID: "chk_0123456789abcdef"}
+			case "coordinator":
+				changed.CoordinatorRegistrationURL = "https://coordinator.example.test"
+			case "adapter":
+				changed.RuntimeAdapterRegistrationID = "adapter-fixture"
+			case "pending adapter":
+				changed.RuntimeAdapterPendingRegistrationID = "adapter-fixture"
+			}
+			if err := core.ReplaceLeaseClaimIfUnchanged(leaseID, claim, changed); err != nil {
+				t.Fatal(err)
+			}
+			changed, _, err = core.ReadLeaseClaimWithPresence(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if scenario == "no claim" {
+				core.RemoveLeaseClaim(leaseID)
+			}
+			requests := len(f.paths)
+			b.cfg.Daytona.ForgetMissing = true
+			err = b.Stop(t.Context(), StopRequest{ID: leaseID})
+			after, exists, readErr := core.ReadLeaseClaimWithPresence(leaseID)
+			if err == nil || readErr != nil || len(f.paths) != requests || exists != (scenario != "no claim") || exists && !reflect.DeepEqual(changed, after) {
+				t.Fatalf("unsafe local cleanup: err=%v read=%v exists=%t", err, readErr, exists)
+			}
+		})
+	}
+}
+
+func TestDaytonaForgetMissingPreservesFixedReplayProtection(t *testing.T) {
+	for _, released := range []bool{false, true} {
+		t.Run(fmt.Sprintf("released=%t", released), func(t *testing.T) {
+			f, b, req := newFixedDaytonaFixture(t)
+			if _, err := b.Acquire(t.Context(), req); err != nil {
+				t.Fatal(err)
+			}
+			if released {
+				if err := b.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			before, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			if err != nil || !exists {
+				t.Fatalf("missing fixed claim: %v", err)
+			}
+			requests := len(f.paths)
+			b.cfg.Daytona.ForgetMissing = true
+			err = b.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID})
+			after, exists, readErr := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			if err == nil || !exists || readErr != nil || !reflect.DeepEqual(before, after) || len(f.paths) != requests {
+				t.Fatalf("fixed claim changed or provider contacted: err=%v read=%v", err, readErr)
+			}
+		})
+	}
+}

--- a/internal/providers/daytona/provider.go
+++ b/internal/providers/daytona/provider.go
@@ -39,6 +39,9 @@ func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error
 	return ApplyDaytonaProviderFlags(cfg, fs, values)
 }
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	if cfg.Daytona.ForgetMissing && core.ShouldUseCoordinator(cfg, p.Spec()) {
+		return nil, core.Exit(2, "--daytona-forget-missing requires direct provider=daytona; brokered leases require normal stop")
+	}
 	return NewDaytonaLeaseBackend(p.Spec(), cfg, rt), nil
 }
 


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/2108

## What Problem This Solves

Fixes an issue where users stopping an ordinary Daytona lease after native TTL or external deletion had no supported way to remove its stale local claim. Fixed-ID release and expiry reconciliation were repaired separately in https://github.com/openclaw/crabbox/pull/2111.

## Why This Change Was Made

Add command-only `crabbox stop --provider daytona --daytona-forget-missing <lease-id-or-local-slug>`. It checks only the exact sandbox ID bound in the local claim and requires a structured Daytona 404 before removing the unchanged claim under its lock. The operation sends no DELETE and reports local forgetting rather than remote release. Normal stop remains fail closed. The recovery flag is registered only for `stop` (including its `release` alias); it is absent from other commands rather than accepted and rejected later. Brokered mode and other provider selections reject this flag before backend execution.

Fixed replay records, checkpoint-held claims and coordinator/adapter registrations retain their existing reconciliation owners. Live resources, malformed responses, auth failures and transport failures keep the local record. No credentials, dependencies or claim format change; the flag cannot be enabled through YAML or environment variables.

## User Impact

Operators can explicitly recover an ordinary stale claim after checking the original Daytona account and endpoint. A 404 can also indicate lost access; this local-only operation does not prove remote deletion or stop billing. Fixed claims continue to use normal stop and retain terminal replay protection.

## Evidence

Ran the real CLI/provider code against an HTTP fixture with isolated local claim storage, using identical recovery input before and after. No live Daytona resources were allocated.

| Observation | Baseline `2ead1eee` | Candidate |
| --- | --- | --- |
| Recovery command | `flag provided but not defined: -daytona-forget-missing` | Exit 0 after exact-ID structured 404 |
| Local claim | Remains on disk | Removed |
| Provider deletion requests | 0 | 0 |
| Output | No recovery path | `forgot local Daytona claim lease=cbx_123456abcdef sandbox=sandbox-original; provider deletion was not verified` |

- `go test -race ./internal/providers/daytona -run '^TestDaytonaForgetMissing' -count=1 -v` passes. The baseline portable recovery test fails as shown above.
- Brokered CLI regression: the initial candidate incorrectly attempted coordinator release (6 HTTP requests); the final candidate rejects the command before any request. Other command/provider flag combinations are rejected.
- Default-stop preservation tests pass for missing resources, changed endpoint/account and inventory errors.
- Regression cases preserve claims on malformed/incomplete/conflicting 404, 401/403/503, connection failure, live and empty-success responses, absent IDs, checkpoint custody, coordinator/adapter registration and acquired/released fixed IDs.
- Complete provider gate: `go test -race -timeout=10m ./internal/providers/daytona -count=1` passes (108.200s on the final implementation); latest added guard cases also separately pass with race detection.
- `go vet ./internal/providers/daytona ./internal/cli` and `node scripts/build-docs-site.mjs` pass.

- Follow-up command-scope proof on `8c999281`: compiled CLI help shows the recovery flag for `stop`/`release` only, absent from `run`, `warmup`, `status`, `ssh`, and `doctor`. `run --daytona-forget-missing` fails during parsing. Targeted race tests, scoped vet, CLI build, and independent re-review pass.

Independent Standards and Spec reviews are clear after addressing the brokered-route finding in the stale-claim change.

PR intentionally left unmerged. The branch is in the upstream repository, so maintainers can edit it directly (GitHub’s fork-collaboration toggle applies only to cross-repository PRs).
