### PR TITLE
refactor(config): move local provider displays into adapters

### DIFF
--- a/docs/refactor/provider-config-display.md
+++ b/docs/refactor/provider-config-display.md
@@ -44,6 +44,13 @@ missing data, or fall back to the old formatters. An absent optional section is
 a no-op for this data-only renderer; real-provider tests and whole-binary output
 comparisons establish the migrated built-ins' actual coverage and positions.
 
+Local Container, Apple Container, MXC and Docker Sandbox also own their existing
+35 display fields and retain their original text slots. Apple Container supplies
+one shared section for both Apple Container and Apple Machine; it does not apply
+either backend's runtime defaults. MXC retains JSON lists with text counts,
+Docker Sandbox retains JSON lists with comma-joined text and `%g` CPU formatting,
+and nil versus empty lists remain distinct. Internal-only fields stay omitted.
+
 ## Remaining migration
 
 The baseline census contains 81 canonical providers: 49 have both value formats,
@@ -56,9 +63,11 @@ sections**. They do not complete the migration. Existing provider projections
 also still need to move out of the parallel JSON map and text formatter so
 their field selection and transformations have one owner.
 
-The Multipass/Tart/Lume migration removes three of the original 49 canonical
-both-format providers from that legacy implementation, leaving 46 in that
-cohort. It does not fill any of the missing sections above.
+The Multipass/Tart/Lume and local-container cohorts remove eight of the original
+49 canonical both-format providers from that legacy implementation, leaving 41
+in that cohort. The local cohort covers five identities through four sections
+because Apple Machine shares Apple Container's values. These migrations do not
+fill any of the missing sections above.
 
 For each remaining provider, establish the explicit public field contract
 before implementation. Preserve existing keys, types, null/empty distinctions,

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -575,49 +575,6 @@ func configShowView(cfg Config) map[string]any {
 			"networkDenyOut":  cfg.Superserve.NetworkDenyOut,
 			"forgetMissing":   cfg.Superserve.ForgetMissing,
 		},
-		"localContainer": map[string]any{
-			"runtime":      cfg.LocalContainer.Runtime,
-			"image":        cfg.LocalContainer.Image,
-			"user":         cfg.LocalContainer.User,
-			"workRoot":     cfg.LocalContainer.WorkRoot,
-			"cpus":         cfg.LocalContainer.CPUs,
-			"memory":       cfg.LocalContainer.Memory,
-			"network":      cfg.LocalContainer.Network,
-			"dockerSocket": cfg.LocalContainer.DockerSocket,
-		},
-		"appleContainer": map[string]any{
-			"cliPath":  cfg.AppleContainer.CLIPath,
-			"image":    cfg.AppleContainer.Image,
-			"user":     cfg.AppleContainer.User,
-			"workRoot": cfg.AppleContainer.WorkRoot,
-			"cpus":     cfg.AppleContainer.CPUs,
-			"memory":   cfg.AppleContainer.Memory,
-		},
-		"mxc": map[string]any{
-			"cliPath":           cfg.MXC.CLIPath,
-			"version":           cfg.MXC.Version,
-			"containment":       cfg.MXC.Containment,
-			"network":           cfg.MXC.Network,
-			"readOnlyPaths":     cfg.MXC.ReadOnlyPaths,
-			"readWritePaths":    cfg.MXC.ReadWritePaths,
-			"allowedHosts":      cfg.MXC.AllowedHosts,
-			"blockedHosts":      cfg.MXC.BlockedHosts,
-			"allowDaclMutation": cfg.MXC.AllowDACLMutation,
-			"allowWindowsUI":    cfg.MXC.AllowWindowsUI,
-			"experimental":      cfg.MXC.Experimental,
-		},
-		"dockerSandbox": map[string]any{
-			"cliPath":         cfg.DockerSandbox.CLIPath,
-			"agent":           cfg.DockerSandbox.Agent,
-			"template":        cfg.DockerSandbox.Template,
-			"cpus":            cfg.DockerSandbox.CPUs,
-			"memory":          cfg.DockerSandbox.Memory,
-			"clone":           cfg.DockerSandbox.Clone,
-			"workdir":         cfg.DockerSandbox.Workdir,
-			"extraWorkspaces": cfg.DockerSandbox.ExtraWorkspaces,
-			"mcp":             cfg.DockerSandbox.MCP,
-			"kit":             cfg.DockerSandbox.Kit,
-		},
 		"cloudRunSandbox": map[string]any{
 			"gatewayURL":  redactedConfigURL(cfg.CloudRunSandbox.GatewayURL),
 			"cliPath":     cfg.CloudRunSandbox.CLIPath,
@@ -849,10 +806,18 @@ func writeConfigShowText(w io.Writer, cfg Config) error {
 	fmt.Fprintf(w, "nomad address=%s region=%s namespace=%s auth_env=%s auth=%s tls_ca=%s tls_capath=%s tls_cert=%s tls_key=%s tls_server_name=%s skip_verify=%t task=%s driver=%s image=%s workdir=%s jobspec_template=%s node_pool=%s datacenters=%s cpu=%d memory_mb=%d disk_mb=%d alloc_ready_timeout=%s eval_timeout=%s exec_timeout_secs=%d\n", blank(redactedConfigURL(cfg.Nomad.Address), "-"), blank(cfg.Nomad.Region, "-"), blank(cfg.Nomad.Namespace, "-"), nomadTextAuthEnv(cfg), nomadAuthState(cfg), blank(cfg.Nomad.CACert, "-"), blank(cfg.Nomad.CAPath, "-"), blank(cfg.Nomad.ClientCert, "-"), blank(cfg.Nomad.ClientKey, "-"), blank(cfg.Nomad.TLSServerName, "-"), cfg.Nomad.SkipVerify, cfg.Nomad.Task, cfg.Nomad.Driver, cfg.Nomad.Image, cfg.Nomad.Workdir, blank(cfg.Nomad.JobSpecTemplate, "-"), blank(cfg.Nomad.NodePool, "-"), blank(strings.Join(cfg.Nomad.Datacenters, ","), "-"), cfg.Nomad.CPU, cfg.Nomad.MemoryMB, cfg.Nomad.DiskMB, cfg.Nomad.AllocReadyTimeout, cfg.Nomad.EvalTimeout, cfg.Nomad.ExecTimeoutSecs)
 	fmt.Fprintf(w, "ascii_box base_url=%s cli=%s workdir=%s auth=%s\n", redactedConfigURL(cfg.AsciiBox.BaseURL), cfg.AsciiBox.CLIPath, cfg.AsciiBox.Workdir, tokenState(cfg.AsciiBox.APIKey))
 	fmt.Fprintf(w, "superserve base_url=%s template=%s snapshot=%s workdir=%s timeout_secs=%d exec_timeout_secs=%d network_allow_out=%s network_deny_out=%s forget_missing=%t auth=%s\n", redactedConfigURL(cfg.Superserve.BaseURL), blank(cfg.Superserve.Template, "-"), blank(cfg.Superserve.Snapshot, "-"), cfg.Superserve.Workdir, cfg.Superserve.TimeoutSecs, cfg.Superserve.ExecTimeoutSecs, blank(strings.Join(cfg.Superserve.NetworkAllowOut, ","), "-"), blank(strings.Join(cfg.Superserve.NetworkDenyOut, ","), "-"), cfg.Superserve.ForgetMissing, superserveAuthState())
-	fmt.Fprintf(w, "local_container runtime=%s image=%s user=%s work_root=%s cpus=%d memory=%s network=%s docker_socket=%t\n", cfg.LocalContainer.Runtime, cfg.LocalContainer.Image, cfg.LocalContainer.User, blank(cfg.LocalContainer.WorkRoot, "-"), cfg.LocalContainer.CPUs, blank(cfg.LocalContainer.Memory, "-"), cfg.LocalContainer.Network, cfg.LocalContainer.DockerSocket)
-	fmt.Fprintf(w, "apple_container cli=%s image=%s user=%s work_root=%s cpus=%d memory=%s\n", cfg.AppleContainer.CLIPath, cfg.AppleContainer.Image, cfg.AppleContainer.User, cfg.AppleContainer.WorkRoot, cfg.AppleContainer.CPUs, blank(cfg.AppleContainer.Memory, "-"))
-	fmt.Fprintf(w, "mxc cli=%s version=%s containment=%s network=%s readonly_paths=%d readwrite_paths=%d allowed_hosts=%d blocked_hosts=%d allow_dacl_mutation=%t allow_windows_ui=%t experimental=%t\n", cfg.MXC.CLIPath, cfg.MXC.Version, cfg.MXC.Containment, cfg.MXC.Network, len(cfg.MXC.ReadOnlyPaths), len(cfg.MXC.ReadWritePaths), len(cfg.MXC.AllowedHosts), len(cfg.MXC.BlockedHosts), cfg.MXC.AllowDACLMutation, cfg.MXC.AllowWindowsUI, cfg.MXC.Experimental)
-	fmt.Fprintf(w, "docker_sandbox cli=%s agent=%s template=%s cpus=%g memory=%s clone=%t workdir=%s extra_workspaces=%s mcp=%s kit=%s\n", cfg.DockerSandbox.CLIPath, cfg.DockerSandbox.Agent, blank(cfg.DockerSandbox.Template, "-"), cfg.DockerSandbox.CPUs, blank(cfg.DockerSandbox.Memory, "-"), cfg.DockerSandbox.Clone, blank(cfg.DockerSandbox.Workdir, "-"), blank(strings.Join(cfg.DockerSandbox.ExtraWorkspaces, ","), "-"), blank(strings.Join(cfg.DockerSandbox.MCP, ","), "-"), blank(strings.Join(cfg.DockerSandbox.Kit, ","), "-"))
+	if err := layout.writeSlot(w, "local_container"); err != nil {
+		return err
+	}
+	if err := layout.writeSlot(w, "apple_container"); err != nil {
+		return err
+	}
+	if err := layout.writeSlot(w, "mxc"); err != nil {
+		return err
+	}
+	if err := layout.writeSlot(w, "docker_sandbox"); err != nil {
+		return err
+	}
 	if err := layout.writeSlot(w, "multipass"); err != nil {
 		return err
 	}

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -866,10 +866,6 @@ func TestAppleContainerConfigWriterAndJSON(t *testing.T) {
 	}
 	cfg := baseConfig()
 	cfg.AppleContainer = AppleContainerConfig{CLIPath: "tool", Image: "image-example", User: "user-example", WorkRoot: "/workspace/example", CPUs: 3, Memory: "6g"}
-	wantView := map[string]any{"cliPath": "tool", "image": "image-example", "user": "user-example", "workRoot": "/workspace/example", "cpus": 3, "memory": "6g"}
-	if got := configShowView(cfg)["appleContainer"]; !reflect.DeepEqual(got, wantView) {
-		t.Fatalf("view=%#v", got)
-	}
 	data, err := json.Marshal(cfg.AppleContainer)
 	if err != nil {
 		t.Fatal(err)
@@ -3098,8 +3094,12 @@ func TestRoutingSafeURLRedactsUserinfoOnMalformedURL(t *testing.T) {
 }
 
 func TestConfigShowIncludesDockerSandboxConfig(t *testing.T) {
-	configPath := isolatedConfigPath(t)
-	t.Setenv("CRABBOX_PROVIDER", "")
+	binary, err := builtCLITestBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.yaml")
 	if err := os.WriteFile(configPath, []byte(`provider: docker-sandbox
 dockerSandbox:
   cliPath: /opt/sbx
@@ -3112,13 +3112,29 @@ dockerSandbox:
 `), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("CRABBOX_DOCKER_SANDBOX_EXTRA_WORKSPACES", "/tmp/extra")
-	t.Setenv("CRABBOX_DOCKER_SANDBOX_MCP", "context7,all")
-	t.Setenv("CRABBOX_DOCKER_SANDBOX_KIT", "example-org/base")
-
 	var stdout bytes.Buffer
-	app := App{Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	if err := app.configShow(nil); err != nil {
+	runShow := func(args []string) error {
+		cmd := exec.CommandContext(t.Context(), binary, append([]string{"config", "show"}, args...)...)
+		cmd.Dir = home
+		cmd.Env = []string{
+			"HOME=" + home, "USERPROFILE=" + home, "APPDATA=" + home,
+			"XDG_CONFIG_HOME=" + home, "XDG_STATE_HOME=" + home,
+			"CRABBOX_CONFIG=" + configPath, "PATH=" + t.TempDir(),
+			"CRABBOX_DOCKER_SANDBOX_EXTRA_WORKSPACES=/tmp/extra",
+			"CRABBOX_DOCKER_SANDBOX_MCP=context7,all",
+			"CRABBOX_DOCKER_SANDBOX_KIT=example-org/base",
+		}
+		var stderr bytes.Buffer
+		cmd.Stdout, cmd.Stderr = &stdout, &stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("config show: %w: %s", err, &stderr)
+		}
+		if stderr.Len() != 0 {
+			return fmt.Errorf("config show stderr: %s", &stderr)
+		}
+		return nil
+	}
+	if err := runShow(nil); err != nil {
 		t.Fatal(err)
 	}
 	text := stdout.String()
@@ -3135,7 +3151,7 @@ dockerSandbox:
 	}
 
 	stdout.Reset()
-	if err := app.configShow([]string{"--json"}); err != nil {
+	if err := runShow([]string{"--json"}); err != nil {
 		t.Fatal(err)
 	}
 	var got struct {
@@ -3406,17 +3422,11 @@ func TestConfigShowLocalContainerSettingsOffline(t *testing.T) {
 	}
 }
 
-func TestConfigShowLocalContainerExcludesInternalFields(t *testing.T) {
+func TestConfigShowCoordinatorEndpointAndTokenStatus(t *testing.T) {
 	cfg := baseConfig()
-	cfg.LocalContainer.Volumes = []string{"/synthetic-private-volume:/mnt/data"}
-	cfg.LocalContainer.CheckpointMetadata = map[string]string{"fork_name": "synthetic-private-checkpoint"}
 	cfg.CoordToken = "synthetic-private-token"
 	cfg.Coordinator = "https://broker.example.test/api"
 	view := configShowView(cfg)
-	local, ok := view["localContainer"].(map[string]any)
-	if !ok || len(local) != 8 {
-		t.Fatalf("public localContainer fields=%#v", local)
-	}
 	data, err := json.Marshal(view)
 	if err != nil {
 		t.Fatal(err)
@@ -3424,7 +3434,7 @@ func TestConfigShowLocalContainerExcludesInternalFields(t *testing.T) {
 	var text bytes.Buffer
 	writeConfigShowText(&text, cfg)
 	for name, output := range map[string]string{"json": string(data), "text": text.String()} {
-		if strings.Contains(output, "synthetic-private") || strings.Contains(strings.ToLower(output), "checkpointmetadata") {
+		if strings.Contains(output, "synthetic-private") {
 			t.Errorf("%s exposed internal fields or credentials", name)
 		}
 		if !strings.Contains(output, "broker.example.test/api") || !strings.Contains(output, "configured") {

--- a/internal/cli/config_show_projection.go
+++ b/internal/cli/config_show_projection.go
@@ -36,7 +36,7 @@ func ConfigShowSecretState(value string) string { return tokenState(value) }
 
 // Names only: no legacy value projection or environment reads are needed to
 // protect existing text slots. Retire a name only when its legacy row migrates.
-const legacyConfigShowTextLabels = "config provider lease broker access_auth ssh sync env run capacity actions blacksmith agent_sandbox phala namespace namespace_instance morph e2b cubesandbox upstash_box smolvm blaxel nomad ascii_box superserve local_container apple_container mxc docker_sandbox machine0 cloudflare fastapi_cloud cloudflare_dynamic_workers cloudflare_sandbox static results cache jobs aws aws_lambda_microvm azure digitalocean vultr linode github_codespaces lambda vast nvidia_brev nebius hostinger ovh scaleway tencentcloud azure_dynamic_sessions gcp proxmox firecracker xcp_ng parallels inspection provider_status"
+const legacyConfigShowTextLabels = "config provider lease broker access_auth ssh sync env run capacity actions blacksmith agent_sandbox phala namespace namespace_instance morph e2b cubesandbox upstash_box smolvm blaxel nomad ascii_box superserve machine0 cloudflare fastapi_cloud cloudflare_dynamic_workers cloudflare_sandbox static results cache jobs aws aws_lambda_microvm azure digitalocean vultr linode github_codespaces lambda vast nvidia_brev nebius hostinger ovh scaleway tencentcloud azure_dynamic_sessions gcp proxmox firecracker xcp_ng parallels inspection provider_status"
 
 func collectProviderConfigShowSections(cfg Config) ([]ProviderConfigShowSection, error) {
 	return collectProviderConfigShowSectionsFrom(cfg, registeredProviders())

--- a/internal/cli/config_show_projection_test.go
+++ b/internal/cli/config_show_projection_test.go
@@ -235,13 +235,13 @@ func TestConfigShowLegacySlotPositions(t *testing.T) {
 			order = append(order, value)
 		} else if sel.Sel.Name == "Fprintf" {
 			name := strings.SplitN(value, " ", 2)[0]
-			if name == "docker_sandbox" || name == "machine0" || name == "cloudflare" {
+			if name == "superserve" || name == "local_container" || name == "apple_container" || name == "mxc" || name == "docker_sandbox" || name == "machine0" || name == "cloudflare" {
 				order = append(order, name)
 			}
 		}
 		return true
 	})
-	if got := strings.Join(order, ","); got != "docker_sandbox,multipass,machine0,tart,lume,cloudflare" {
+	if got := strings.Join(order, ","); got != "superserve,local_container,apple_container,mxc,docker_sandbox,multipass,machine0,tart,lume,cloudflare" {
 		t.Fatalf("legacy text slot positions: %s", got)
 	}
 }
@@ -250,9 +250,9 @@ func TestConfigShowTextLayoutConsumesSlotsOnce(t *testing.T) {
 	section := func(label string) ProviderConfigShowSection {
 		return ProviderConfigShowSection{TextLabel: label, Fields: []ProviderConfigShowField{{TextName: "value", TextValue: label}}}
 	}
-	layout := newConfigShowTextLayout([]ProviderConfigShowSection{section("alpha"), section("lume"), section("multipass"), section("tart"), section("zeta")})
+	layout := newConfigShowTextLayout([]ProviderConfigShowSection{section("alpha"), section("lume"), section("multipass"), section("tart"), section("zeta"), section("docker_sandbox"), section("mxc"), section("apple_container"), section("local_container")})
 	var out bytes.Buffer
-	for _, label := range []string{"absent", "multipass", "multipass", "tart", "lume"} {
+	for _, label := range []string{"absent", "local_container", "apple_container", "mxc", "docker_sandbox", "local_container", "apple_container", "mxc", "docker_sandbox", "multipass", "multipass", "tart", "lume"} {
 		if err := layout.writeSlot(&out, label); err != nil {
 			t.Fatal(err)
 		}
@@ -260,7 +260,7 @@ func TestConfigShowTextLayoutConsumesSlotsOnce(t *testing.T) {
 	if err := layout.writeRemaining(&out); err != nil {
 		t.Fatal(err)
 	}
-	if got, want := out.String(), "multipass value=multipass\ntart value=tart\nlume value=lume\nalpha value=alpha\nzeta value=zeta\n"; got != want {
+	if got, want := out.String(), "local_container value=local_container\napple_container value=apple_container\nmxc value=mxc\ndocker_sandbox value=docker_sandbox\nmultipass value=multipass\ntart value=tart\nlume value=lume\nalpha value=alpha\nzeta value=zeta\n"; got != want {
 		t.Fatalf("slot order/duplication got %q want %q", got, want)
 	}
 	out.Reset()
@@ -345,5 +345,21 @@ func TestProviderConfigShowFormattingBridges(t *testing.T) {
 	value := "https://example.invalid/path?sample=value"
 	if got := ConfigShowURL(value); got != redactedConfigURL(value) || strings.Contains(got, "sample=value") {
 		t.Fatal("URL bridge changed")
+	}
+}
+
+func TestConfigShowLocalCohortLegacyOwnershipRetired(t *testing.T) {
+	view := configShowView(Config{})
+	for _, key := range []string{"localContainer", "appleContainer", "mxc", "dockerSandbox"} {
+		if _, exists := view[key]; exists {
+			t.Errorf("core still owns %s values", key)
+		}
+	}
+	for _, label := range []string{"local_container", "apple_container", "mxc", "docker_sandbox"} {
+		for _, reserved := range strings.Fields(legacyConfigShowTextLabels) {
+			if reserved == label {
+				t.Errorf("migrated label %s still reserved as legacy", label)
+			}
+		}
 	}
 }

--- a/internal/providers/applecontainer/backend_test.go
+++ b/internal/providers/applecontainer/backend_test.go
@@ -1,7 +1,9 @@
 package applecontainer
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"io"
@@ -15,6 +17,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	_ "github.com/openclaw/crabbox/internal/providers/applemachine"
 )
 
 func TestConcreteFlagInputAttribution(t *testing.T) {
@@ -1265,3 +1268,160 @@ func TestDecodeInspectToleratesObjectStatus(t *testing.T) {
 type errFake string
 
 func (e errFake) Error() string { return string(e) }
+
+func TestAppleContainerConfigShowSection(t *testing.T) {
+	projector, ok := any(Provider{}).(core.ProviderConfigShowProjector)
+	if !ok {
+		t.Fatal("real provider is missing passive config-show ownership")
+	}
+	for _, tc := range []struct {
+		name string
+		cfg  core.AppleContainerConfig
+		want map[string]any
+		text string
+	}{
+		{name: "zero", cfg: core.AppleContainerConfig{CLIPath: "", Image: "", User: "", WorkRoot: "", CPUs: 0, Memory: "", ExtraRunArgs: []string{"internal-extra", " internal-extra "}}, want: map[string]any{"cliPath": "", "image": "", "user": "", "workRoot": "", "cpus": 0, "memory": ""}, text: "apple_container cli= image= user= work_root= cpus=0 memory=-\n"},
+		{name: "raw", cfg: core.AppleContainerConfig{CLIPath: " raw-cli ", Image: " raw-image ", User: " raw-user ", WorkRoot: "", CPUs: -2, Memory: "   ", ExtraRunArgs: []string{"internal-extra", " internal-extra "}}, want: map[string]any{"cliPath": " raw-cli ", "image": " raw-image ", "user": " raw-user ", "workRoot": "", "cpus": -2, "memory": "   "}, text: "apple_container cli= raw-cli  image= raw-image  user= raw-user  work_root= cpus=-2 memory=   \n"},
+		{name: "configured", cfg: core.AppleContainerConfig{CLIPath: "tool", Image: "image-example", User: "user-example", WorkRoot: "/workspace/example", CPUs: 3, Memory: "6g", ExtraRunArgs: []string{"internal-extra", " internal-extra "}}, want: map[string]any{"cliPath": "tool", "image": "image-example", "user": "user-example", "workRoot": "/workspace/example", "cpus": 3, "memory": "6g"}, text: "apple_container cli=tool image=image-example user=user-example work_root=/workspace/example cpus=3 memory=6g\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := core.Config{Provider: "unselected-display-test", AppleContainer: tc.cfg}
+			before, err := json.Marshal(cfg.AppleContainer)
+			if err != nil {
+				t.Fatal(err)
+			}
+			section := projector.ConfigShowSection(cfg)
+			got := map[string]any{}
+			var fields []string
+			for _, field := range section.Fields {
+				got[field.JSONName] = field.JSONValue
+				fields = append(fields, field.TextName+"="+field.TextValue)
+			}
+			if section.JSONKey != "appleContainer" || section.TextLabel != "apple_container" || !reflect.DeepEqual(section.Providers, []string{"apple-container", "apple-machine"}) || len(section.Fields) != 6 {
+				t.Fatalf("section metadata=%#v", section)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("public fields=%#v want %#v", got, tc.want)
+			}
+			if line := section.TextLabel + " " + strings.Join(fields, " ") + "\n"; line != tc.text {
+				t.Fatalf("text=%q want %q", line, tc.text)
+			}
+			after, err := json.Marshal(cfg.AppleContainer)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(before, after) {
+				t.Fatal("projection mutated original config or slice contents")
+			}
+		})
+	}
+}
+
+func TestAppleContainerConfigShowSharedCanonicalCoverage(t *testing.T) {
+	owners := 0
+	coverage := map[string]int{}
+	for _, name := range core.RegisteredProviderNames() {
+		provider, err := core.ProviderFor(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		projector, ok := provider.(core.ProviderConfigShowProjector)
+		if !ok {
+			continue
+		}
+		section := projector.ConfigShowSection(core.Config{})
+		if section.JSONKey != "appleContainer" {
+			continue
+		}
+		owners++
+		if provider.Name() != "apple-container" {
+			t.Fatalf("unexpected shared owner %s", provider.Name())
+		}
+		for _, canonical := range section.Providers {
+			coverage[canonical]++
+		}
+	}
+	if owners != 1 || !reflect.DeepEqual(coverage, map[string]int{"apple-container": 1, "apple-machine": 1}) {
+		t.Fatalf("shared owners=%d coverage=%v", owners, coverage)
+	}
+	machine, err := core.ProviderFor("apple-machine")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, duplicate := machine.(core.ProviderConfigShowProjector); duplicate {
+		t.Fatal("Machine must not emit a competing shared section")
+	}
+}
+
+func TestAppleContainerConfigShowCanonicalSelectionsOffline(t *testing.T) {
+	for _, entry := range os.Environ() {
+		name, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(name, "CRABBOX_") {
+			t.Setenv(name, "")
+		}
+	}
+	home := t.TempDir()
+	t.Chdir(home)
+	for _, name := range []string{"HOME", "USERPROFILE", "APPDATA", "LOCALAPPDATA", "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "XDG_STATE_HOME"} {
+		t.Setenv(name, home)
+	}
+	t.Setenv("PATH", t.TempDir())
+	configPath := filepath.Join(home, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(`target: linux
+appleContainer:
+  cliPath: tool
+  image: image-example
+  user: user-example
+  workRoot: /workspace/example
+  cpus: 3
+  memory: 6g
+  extraRunArgs: [internal-extra]
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	for _, selected := range []string{"apple-container", "apple-machine"} {
+		for _, format := range []string{"text", "json"} {
+			t.Run(selected+"/"+format, func(t *testing.T) {
+				var out, log bytes.Buffer
+				args := []string{"config", "show", "--provider", selected}
+				if format == "json" {
+					args = append(args, "--json")
+				}
+				if err := (core.App{Stdout: &out, Stderr: &log}).Run(t.Context(), args); err != nil || log.Len() != 0 {
+					t.Fatalf("config-only route: %v stderr=%s", err, &log)
+				}
+				if format == "json" {
+					var view map[string]any
+					if err := json.Unmarshal(out.Bytes(), &view); err != nil {
+						t.Fatal(err)
+					}
+					want := map[string]any{"cliPath": "tool", "image": "image-example", "user": "user-example", "workRoot": "/workspace/example", "cpus": float64(3), "memory": "6g"}
+					if !reflect.DeepEqual(view["appleContainer"], want) || view["provider"] != selected {
+						t.Fatalf("selected shared section=%#v provider=%v", view["appleContainer"], view["provider"])
+					}
+					if _, duplicate := view["appleMachine"]; duplicate {
+						t.Fatal("duplicate Machine section")
+					}
+				} else {
+					want := "apple_container cli=tool image=image-example user=user-example work_root=/workspace/example cpus=3 memory=6g\n"
+					count := 0
+					for _, line := range strings.SplitAfter(out.String(), "\n") {
+						if strings.HasPrefix(line, "apple_container ") {
+							count++
+							if line != want {
+								t.Fatalf("shared text=%q want %q", line, want)
+							}
+						}
+					}
+					if count != 1 || strings.Contains(out.String(), "apple_machine ") {
+						t.Fatalf("shared text section count=%d", count)
+					}
+					if !strings.Contains(out.String(), "provider="+selected+" ") {
+						t.Fatalf("selected provider not retained: %s", &out)
+					}
+				}
+			})
+		}
+	}
+}

--- a/internal/providers/applecontainer/config_show.go
+++ b/internal/providers/applecontainer/config_show.go
@@ -1,0 +1,23 @@
+package applecontainer
+
+import (
+	"strconv"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// ConfigShowSection owns the single display section shared with Apple Machine.
+func (Provider) ConfigShowSection(cfg core.Config) core.ProviderConfigShowSection {
+	c := cfg.AppleContainer
+	return core.ProviderConfigShowSection{
+		JSONKey: "appleContainer", TextLabel: "apple_container", Providers: []string{"apple-container", "apple-machine"},
+		Fields: []core.ProviderConfigShowField{
+			{JSONName: "cliPath", JSONValue: c.CLIPath, TextName: "cli", TextValue: c.CLIPath},
+			{JSONName: "image", JSONValue: c.Image, TextName: "image", TextValue: c.Image},
+			{JSONName: "user", JSONValue: c.User, TextName: "user", TextValue: c.User},
+			{JSONName: "workRoot", JSONValue: c.WorkRoot, TextName: "work_root", TextValue: c.WorkRoot},
+			{JSONName: "cpus", JSONValue: c.CPUs, TextName: "cpus", TextValue: strconv.Itoa(c.CPUs)},
+			{JSONName: "memory", JSONValue: c.Memory, TextName: "memory", TextValue: core.Blank(c.Memory, "-")},
+		},
+	}
+}

--- a/internal/providers/dockersandbox/backend_test.go
+++ b/internal/providers/dockersandbox/backend_test.go
@@ -1918,3 +1918,53 @@ func TestRunCommandIntentReachesNativeRequest(t *testing.T) {
 		return call.Args[4:]
 	})
 }
+
+func TestDockerSandboxConfigShowSection(t *testing.T) {
+	projector, ok := any(Provider{}).(core.ProviderConfigShowProjector)
+	if !ok {
+		t.Fatal("real provider is missing passive config-show ownership")
+	}
+	for _, tc := range []struct {
+		name string
+		cfg  core.DockerSandboxConfig
+		want map[string]any
+		text string
+	}{
+		{name: "nil lists", cfg: core.DockerSandboxConfig{CLIPath: "", Agent: "", Template: "", CPUs: float64(0), Memory: "", Clone: false, Workdir: "", ExtraWorkspaces: []string(nil), MCP: []string(nil), Kit: []string(nil)}, want: map[string]any{"cliPath": "", "agent": "", "template": "", "cpus": float64(0), "memory": "", "clone": false, "workdir": "", "extraWorkspaces": []string(nil), "mcp": []string(nil), "kit": []string(nil)}, text: "docker_sandbox cli= agent= template=- cpus=0 memory=- clone=false workdir=- extra_workspaces=- mcp=- kit=-\n"},
+		{name: "empty lists", cfg: core.DockerSandboxConfig{CLIPath: "", Agent: "", Template: "", CPUs: float64(0), Memory: "", Clone: false, Workdir: "", ExtraWorkspaces: []string{}, MCP: []string{}, Kit: []string{}}, want: map[string]any{"cliPath": "", "agent": "", "template": "", "cpus": float64(0), "memory": "", "clone": false, "workdir": "", "extraWorkspaces": []string{}, "mcp": []string{}, "kit": []string{}}, text: "docker_sandbox cli= agent= template=- cpus=0 memory=- clone=false workdir=- extra_workspaces=- mcp=- kit=-\n"},
+		{name: "fractional raw ordered", cfg: core.DockerSandboxConfig{CLIPath: " raw-cli ", Agent: " raw-agent ", Template: "", CPUs: float64(2.5), Memory: "   ", Clone: true, Workdir: "", ExtraWorkspaces: []string{"/example/a", " /example/b ", "/example/a"}, MCP: []string{"one", "one", " two "}, Kit: []string{""}}, want: map[string]any{"cliPath": " raw-cli ", "agent": " raw-agent ", "template": "", "cpus": float64(2.5), "memory": "   ", "clone": true, "workdir": "", "extraWorkspaces": []string{"/example/a", " /example/b ", "/example/a"}, "mcp": []string{"one", "one", " two "}, "kit": []string{""}}, text: "docker_sandbox cli= raw-cli  agent= raw-agent  template=- cpus=2.5 memory=    clone=true workdir=- extra_workspaces=/example/a, /example/b ,/example/a mcp=one,one, two  kit=-\n"},
+		{name: "large float", cfg: core.DockerSandboxConfig{CLIPath: "", Agent: "", Template: "", CPUs: float64(1e+20), Memory: "", Clone: false, Workdir: "", ExtraWorkspaces: []string(nil), MCP: []string(nil), Kit: []string(nil)}, want: map[string]any{"cliPath": "", "agent": "", "template": "", "cpus": float64(1e+20), "memory": "", "clone": false, "workdir": "", "extraWorkspaces": []string(nil), "mcp": []string(nil), "kit": []string(nil)}, text: "docker_sandbox cli= agent= template=- cpus=1e+20 memory=- clone=false workdir=- extra_workspaces=- mcp=- kit=-\n"},
+		{name: "small float", cfg: core.DockerSandboxConfig{CLIPath: "", Agent: "", Template: "", CPUs: float64(1e-09), Memory: "", Clone: false, Workdir: "", ExtraWorkspaces: []string(nil), MCP: []string(nil), Kit: []string(nil)}, want: map[string]any{"cliPath": "", "agent": "", "template": "", "cpus": float64(1e-09), "memory": "", "clone": false, "workdir": "", "extraWorkspaces": []string(nil), "mcp": []string(nil), "kit": []string(nil)}, text: "docker_sandbox cli= agent= template=- cpus=1e-09 memory=- clone=false workdir=- extra_workspaces=- mcp=- kit=-\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := core.Config{Provider: "unselected-display-test", DockerSandbox: tc.cfg}
+			before, err := json.Marshal(cfg.DockerSandbox)
+			if err != nil {
+				t.Fatal(err)
+			}
+			section := projector.ConfigShowSection(cfg)
+			got := map[string]any{}
+			var fields []string
+			for _, field := range section.Fields {
+				got[field.JSONName] = field.JSONValue
+				fields = append(fields, field.TextName+"="+field.TextValue)
+			}
+			if section.JSONKey != "dockerSandbox" || section.TextLabel != "docker_sandbox" || !reflect.DeepEqual(section.Providers, []string{"docker-sandbox"}) || len(section.Fields) != 10 {
+				t.Fatalf("section metadata=%#v", section)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("public fields=%#v want %#v", got, tc.want)
+			}
+			if line := section.TextLabel + " " + strings.Join(fields, " ") + "\n"; line != tc.text {
+				t.Fatalf("text=%q want %q", line, tc.text)
+			}
+			after, err := json.Marshal(cfg.DockerSandbox)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(before, after) {
+				t.Fatal("projection mutated original config or slice contents")
+			}
+		})
+	}
+}

--- a/internal/providers/dockersandbox/config_show.go
+++ b/internal/providers/dockersandbox/config_show.go
@@ -1,0 +1,28 @@
+package dockersandbox
+
+import (
+	"strconv"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// ConfigShowSection projects only the legacy display allowlist without normalization.
+func (Provider) ConfigShowSection(cfg core.Config) core.ProviderConfigShowSection {
+	c := cfg.DockerSandbox
+	return core.ProviderConfigShowSection{
+		JSONKey: "dockerSandbox", TextLabel: "docker_sandbox", Providers: []string{"docker-sandbox"},
+		Fields: []core.ProviderConfigShowField{
+			{JSONName: "cliPath", JSONValue: c.CLIPath, TextName: "cli", TextValue: c.CLIPath},
+			{JSONName: "agent", JSONValue: c.Agent, TextName: "agent", TextValue: c.Agent},
+			{JSONName: "template", JSONValue: c.Template, TextName: "template", TextValue: core.Blank(c.Template, "-")},
+			{JSONName: "cpus", JSONValue: c.CPUs, TextName: "cpus", TextValue: strconv.FormatFloat(c.CPUs, 'g', -1, 64)},
+			{JSONName: "memory", JSONValue: c.Memory, TextName: "memory", TextValue: core.Blank(c.Memory, "-")},
+			{JSONName: "clone", JSONValue: c.Clone, TextName: "clone", TextValue: strconv.FormatBool(c.Clone)},
+			{JSONName: "workdir", JSONValue: c.Workdir, TextName: "workdir", TextValue: core.Blank(c.Workdir, "-")},
+			{JSONName: "extraWorkspaces", JSONValue: c.ExtraWorkspaces, TextName: "extra_workspaces", TextValue: core.Blank(strings.Join(c.ExtraWorkspaces, ","), "-")},
+			{JSONName: "mcp", JSONValue: c.MCP, TextName: "mcp", TextValue: core.Blank(strings.Join(c.MCP, ","), "-")},
+			{JSONName: "kit", JSONValue: c.Kit, TextName: "kit", TextValue: core.Blank(strings.Join(c.Kit, ","), "-")},
+		},
+	}
+}

--- a/internal/providers/localcontainer/config_show.go
+++ b/internal/providers/localcontainer/config_show.go
@@ -1,0 +1,25 @@
+package localcontainer
+
+import (
+	"strconv"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// ConfigShowSection preserves the established loaded-value display without defaults.
+func (Provider) ConfigShowSection(cfg core.Config) core.ProviderConfigShowSection {
+	c := cfg.LocalContainer
+	return core.ProviderConfigShowSection{
+		JSONKey: "localContainer", TextLabel: "local_container", Providers: []string{"local-container"},
+		Fields: []core.ProviderConfigShowField{
+			{JSONName: "runtime", JSONValue: c.Runtime, TextName: "runtime", TextValue: c.Runtime},
+			{JSONName: "image", JSONValue: c.Image, TextName: "image", TextValue: c.Image},
+			{JSONName: "user", JSONValue: c.User, TextName: "user", TextValue: c.User},
+			{JSONName: "workRoot", JSONValue: c.WorkRoot, TextName: "work_root", TextValue: core.Blank(c.WorkRoot, "-")},
+			{JSONName: "cpus", JSONValue: c.CPUs, TextName: "cpus", TextValue: strconv.Itoa(c.CPUs)},
+			{JSONName: "memory", JSONValue: c.Memory, TextName: "memory", TextValue: core.Blank(c.Memory, "-")},
+			{JSONName: "network", JSONValue: c.Network, TextName: "network", TextValue: c.Network},
+			{JSONName: "dockerSocket", JSONValue: c.DockerSocket, TextName: "docker_socket", TextValue: strconv.FormatBool(c.DockerSocket)},
+		},
+	}
+}

--- a/internal/providers/localcontainer/config_show_test.go
+++ b/internal/providers/localcontainer/config_show_test.go
@@ -1,8 +1,11 @@
 package localcontainer
 
 import (
+	"bytes"
+	"encoding/json"
 	"flag"
 	"reflect"
+	"strings"
 	"testing"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -96,5 +99,53 @@ func TestNormalizeConfigForShowPreservesUnrelatedSettings(t *testing.T) {
 	}
 	if got.ServerType == "synthetic-private-checkpoint" || got.SSHUser == "test-runner" {
 		t.Fatal("display normalization exposed checkpoint metadata or changed SSH defaults")
+	}
+}
+
+func TestLocalContainerConfigShowSection(t *testing.T) {
+	projector, ok := any(Provider{}).(core.ProviderConfigShowProjector)
+	if !ok {
+		t.Fatal("real provider is missing passive config-show ownership")
+	}
+	for _, tc := range []struct {
+		name string
+		cfg  core.LocalContainerConfig
+		want map[string]any
+		text string
+	}{
+		{name: "zero", cfg: core.LocalContainerConfig{Runtime: "", Image: "", User: "", WorkRoot: "", CPUs: 0, Memory: "", Network: "", DockerSocket: false, NoHostname: true, Volumes: []string{"internal-volume"}, CheckpointMetadata: map[string]string{"internal-key": "internal-checkpoint"}}, want: map[string]any{"runtime": "", "image": "", "user": "", "workRoot": "", "cpus": 0, "memory": "", "network": "", "dockerSocket": false}, text: "local_container runtime= image= user= work_root=- cpus=0 memory=- network= docker_socket=false\n"},
+		{name: "raw", cfg: core.LocalContainerConfig{Runtime: " raw-runtime ", Image: " raw-image ", User: " raw-user ", WorkRoot: " raw-root ", CPUs: -2, Memory: "   ", Network: " raw-network ", DockerSocket: true, NoHostname: true, Volumes: []string{"internal-volume"}, CheckpointMetadata: map[string]string{"internal-key": "internal-checkpoint"}}, want: map[string]any{"runtime": " raw-runtime ", "image": " raw-image ", "user": " raw-user ", "workRoot": " raw-root ", "cpus": -2, "memory": "   ", "network": " raw-network ", "dockerSocket": true}, text: "local_container runtime= raw-runtime  image= raw-image  user= raw-user  work_root= raw-root  cpus=-2 memory=    network= raw-network  docker_socket=true\n"},
+		{name: "configured", cfg: core.LocalContainerConfig{Runtime: "docker", Image: "example:stable", User: "runner", WorkRoot: "/work/example", CPUs: 3, Memory: "6g", Network: "none", DockerSocket: true, NoHostname: true, Volumes: []string{"internal-volume"}, CheckpointMetadata: map[string]string{"internal-key": "internal-checkpoint"}}, want: map[string]any{"runtime": "docker", "image": "example:stable", "user": "runner", "workRoot": "/work/example", "cpus": 3, "memory": "6g", "network": "none", "dockerSocket": true}, text: "local_container runtime=docker image=example:stable user=runner work_root=/work/example cpus=3 memory=6g network=none docker_socket=true\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := core.Config{Provider: "unselected-display-test", LocalContainer: tc.cfg}
+			before, err := json.Marshal(cfg.LocalContainer)
+			if err != nil {
+				t.Fatal(err)
+			}
+			section := projector.ConfigShowSection(cfg)
+			got := map[string]any{}
+			var fields []string
+			for _, field := range section.Fields {
+				got[field.JSONName] = field.JSONValue
+				fields = append(fields, field.TextName+"="+field.TextValue)
+			}
+			if section.JSONKey != "localContainer" || section.TextLabel != "local_container" || !reflect.DeepEqual(section.Providers, []string{"local-container"}) || len(section.Fields) != 8 {
+				t.Fatalf("section metadata=%#v", section)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("public fields=%#v want %#v", got, tc.want)
+			}
+			if line := section.TextLabel + " " + strings.Join(fields, " ") + "\n"; line != tc.text {
+				t.Fatalf("text=%q want %q", line, tc.text)
+			}
+			after, err := json.Marshal(cfg.LocalContainer)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(before, after) {
+				t.Fatal("projection mutated original config or slice contents")
+			}
+		})
 	}
 }

--- a/internal/providers/mxc/config_show.go
+++ b/internal/providers/mxc/config_show.go
@@ -1,0 +1,28 @@
+package mxc
+
+import (
+	"strconv"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// ConfigShowSection preserves list values in JSON and their legacy text counts.
+func (Provider) ConfigShowSection(cfg core.Config) core.ProviderConfigShowSection {
+	c := cfg.MXC
+	return core.ProviderConfigShowSection{
+		JSONKey: "mxc", TextLabel: "mxc", Providers: []string{"mxc"},
+		Fields: []core.ProviderConfigShowField{
+			{JSONName: "cliPath", JSONValue: c.CLIPath, TextName: "cli", TextValue: c.CLIPath},
+			{JSONName: "version", JSONValue: c.Version, TextName: "version", TextValue: c.Version},
+			{JSONName: "containment", JSONValue: c.Containment, TextName: "containment", TextValue: c.Containment},
+			{JSONName: "network", JSONValue: c.Network, TextName: "network", TextValue: c.Network},
+			{JSONName: "readOnlyPaths", JSONValue: c.ReadOnlyPaths, TextName: "readonly_paths", TextValue: strconv.Itoa(len(c.ReadOnlyPaths))},
+			{JSONName: "readWritePaths", JSONValue: c.ReadWritePaths, TextName: "readwrite_paths", TextValue: strconv.Itoa(len(c.ReadWritePaths))},
+			{JSONName: "allowedHosts", JSONValue: c.AllowedHosts, TextName: "allowed_hosts", TextValue: strconv.Itoa(len(c.AllowedHosts))},
+			{JSONName: "blockedHosts", JSONValue: c.BlockedHosts, TextName: "blocked_hosts", TextValue: strconv.Itoa(len(c.BlockedHosts))},
+			{JSONName: "allowDaclMutation", JSONValue: c.AllowDACLMutation, TextName: "allow_dacl_mutation", TextValue: strconv.FormatBool(c.AllowDACLMutation)},
+			{JSONName: "allowWindowsUI", JSONValue: c.AllowWindowsUI, TextName: "allow_windows_ui", TextValue: strconv.FormatBool(c.AllowWindowsUI)},
+			{JSONName: "experimental", JSONValue: c.Experimental, TextName: "experimental", TextValue: strconv.FormatBool(c.Experimental)},
+		},
+	}
+}

--- a/internal/providers/mxc/config_test.go
+++ b/internal/providers/mxc/config_test.go
@@ -1,8 +1,10 @@
 package mxc
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -210,4 +212,52 @@ func containsFold(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func TestMXCConfigShowSection(t *testing.T) {
+	projector, ok := any(Provider{}).(core.ProviderConfigShowProjector)
+	if !ok {
+		t.Fatal("real provider is missing passive config-show ownership")
+	}
+	for _, tc := range []struct {
+		name string
+		cfg  core.MXCConfig
+		want map[string]any
+		text string
+	}{
+		{name: "nil lists", cfg: core.MXCConfig{CLIPath: "", Version: "", Containment: "", Network: "", ReadOnlyPaths: []string(nil), ReadWritePaths: []string(nil), AllowedHosts: []string(nil), BlockedHosts: []string(nil), AllowDACLMutation: false, AllowWindowsUI: false, Experimental: false}, want: map[string]any{"cliPath": "", "version": "", "containment": "", "network": "", "readOnlyPaths": []string(nil), "readWritePaths": []string(nil), "allowedHosts": []string(nil), "blockedHosts": []string(nil), "allowDaclMutation": false, "allowWindowsUI": false, "experimental": false}, text: "mxc cli= version= containment= network= readonly_paths=0 readwrite_paths=0 allowed_hosts=0 blocked_hosts=0 allow_dacl_mutation=false allow_windows_ui=false experimental=false\n"},
+		{name: "empty lists", cfg: core.MXCConfig{CLIPath: "", Version: "", Containment: "", Network: "", ReadOnlyPaths: []string{}, ReadWritePaths: []string{}, AllowedHosts: []string{}, BlockedHosts: []string{}, AllowDACLMutation: false, AllowWindowsUI: false, Experimental: false}, want: map[string]any{"cliPath": "", "version": "", "containment": "", "network": "", "readOnlyPaths": []string{}, "readWritePaths": []string{}, "allowedHosts": []string{}, "blockedHosts": []string{}, "allowDaclMutation": false, "allowWindowsUI": false, "experimental": false}, text: "mxc cli= version= containment= network= readonly_paths=0 readwrite_paths=0 allowed_hosts=0 blocked_hosts=0 allow_dacl_mutation=false allow_windows_ui=false experimental=false\n"},
+		{name: "ordered lists", cfg: core.MXCConfig{CLIPath: " raw-cli ", Version: " raw-version ", Containment: " raw-containment ", Network: " raw-network ", ReadOnlyPaths: []string{"/example/a", " /example/b ", "/example/a"}, ReadWritePaths: []string{"/example/c"}, AllowedHosts: []string{"example.test", " example.test "}, BlockedHosts: []string{"blocked.example", "blocked.example"}, AllowDACLMutation: true, AllowWindowsUI: true, Experimental: true}, want: map[string]any{"cliPath": " raw-cli ", "version": " raw-version ", "containment": " raw-containment ", "network": " raw-network ", "readOnlyPaths": []string{"/example/a", " /example/b ", "/example/a"}, "readWritePaths": []string{"/example/c"}, "allowedHosts": []string{"example.test", " example.test "}, "blockedHosts": []string{"blocked.example", "blocked.example"}, "allowDaclMutation": true, "allowWindowsUI": true, "experimental": true}, text: "mxc cli= raw-cli  version= raw-version  containment= raw-containment  network= raw-network  readonly_paths=3 readwrite_paths=1 allowed_hosts=2 blocked_hosts=2 allow_dacl_mutation=true allow_windows_ui=true experimental=true\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := core.Config{Provider: "unselected-display-test", MXC: tc.cfg}
+			before, err := json.Marshal(cfg.MXC)
+			if err != nil {
+				t.Fatal(err)
+			}
+			section := projector.ConfigShowSection(cfg)
+			got := map[string]any{}
+			var fields []string
+			for _, field := range section.Fields {
+				got[field.JSONName] = field.JSONValue
+				fields = append(fields, field.TextName+"="+field.TextValue)
+			}
+			if section.JSONKey != "mxc" || section.TextLabel != "mxc" || !reflect.DeepEqual(section.Providers, []string{"mxc"}) || len(section.Fields) != 11 {
+				t.Fatalf("section metadata=%#v", section)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("public fields=%#v want %#v", got, tc.want)
+			}
+			if line := section.TextLabel + " " + strings.Join(fields, " ") + "\n"; line != tc.text {
+				t.Fatalf("text=%q want %q", line, tc.text)
+			}
+			after, err := json.Marshal(cfg.MXC)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(before, after) {
+				t.Fatal("projection mutated original config or slice contents")
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Move all 35 existing Local Container, Apple Container, MXC and Docker Sandbox display fields into their provider adapters. Delete the four parallel core JSON maps and replace the four text formatters at their original layout slots. This continues https://github.com/openclaw/crabbox/pull/2110 without changing the public output.

Apple Container owns one section covering both Apple Container and Apple Machine. Neither backend's runtime defaults are applied by the projection. MXC keeps JSON lists and text counts; Docker Sandbox keeps JSON lists, comma-joined text and `%g` CPU formatting. Nil/empty lists, raw strings, text-only fallbacks, ordering and excluded internal fields remain unchanged. No provider lifecycle, configuration loading, credential or runtime-discovery algorithm moves.

The existing Apple file-writer/runtime-JSON assertions stay in core; its display assertions move to the actual provider. Docker's full text/JSON assertions now run the compiled CLI, and Local Container's existing offline matrix remains intact. Real Apple provider registration proves one shared owner rather than a duplicate Machine section. Architecture docs track the remaining work: 41 of the original canonical both-format providers still use legacy projections.

## Verification

- Immutable old-source characterization passed fourteen raw-value cases covering all 35 fields. Six expected missing-ownership failures were verified separately before comparing the new ownership contract.
- Current-parent integration passed 75 config-focused tests and 141 subtests with the race detector, with no skips. The test-preservation audit verified 200 unrelated functions unchanged and retained every original Docker output assertion.
- Full Go vet, docs checks, formatting and whitespace checks passed. Managed Codex review passed at P0 scope, including the integrated current-parent diff.
- Twelve real CLI comparisons passed with complete stdout/stderr/exit parity: eight default/list/raw-value cases plus four separately frozen Apple-selected JSON/text cases. No output removal or normalization was used. Runs used synthetic configuration, isolated environments, empty PATH, denied network access and bounded execution.

The original comparisons against `cfeb2faacc771192fb5932b3262146babd77f3e3` remain preserved. Because main subsequently gained three provider sections, a separate reference was built from the actual parent `82d8a6064d4ca1acb25758be8a4e4960570e7a62` and all twelve cases were compared again against the integrated candidate. Original fixtures, environment and working directories were unchanged; this did not overwrite or rerun the old reference. Current-parent binary SHA-256: `709cc7e4bc04f52dbf176815437fa5466f96d64ba83d6943c7f0dfcee683e2d1`; integrated candidate: `5151b6c13cf7b6707ec82ac1fcb47fa7ebba31e220a28f72b63e03be80143ea4`.

Explicit-empty YAML lists normalize to null in the existing loader; the CLI proof preserves that behavior. Raw empty slices and fractional/extreme float formatting are covered by pure projection tests, not overstated as CLI-admitted cases. These checks verify offline display, not native provider execution or authentication.
