### PR TITLE
ci: retry matched Go module ZIP transport errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Show OpenComputer, OpenSandbox and CUA settings in offline JSON and text, including unselected providers, without discovering credentials, resolving external defaults or executing SDK bridges. [PR 2112](https://github.com/openclaw/crabbox/pull/2112). Thanks @steipete.
 - Show Freestyle and Crownest settings through a shared offline JSON/text display path, preserving zero and false values while redacting URLs and reporting only loaded key presence. [PR 2104](https://github.com/openclaw/crabbox/pull/2104). Thanks @steipete.
 - Retain recognized workspace-owner protocol states in child and phase-witness inspection errors, improving diagnostics without changing ownership decisions or retry behavior. [PR 2106](https://github.com/openclaw/crabbox/pull/2106). Thanks @steipete.
-- Retry recognized checksum-service and module-ZIP HTTP/2 interruptions once during Go installation verification's dependency download, preserving checksum enforcement and the unchanged offline install checks. [PR 2113](https://github.com/openclaw/crabbox/pull/2113). Thanks @steipete.
+- Retry recognized checksum-service and module-ZIP HTTP/2 interruptions once during Go installation verification's dependency download, preserving checksum enforcement and the unchanged offline install checks. [PR 2113](https://github.com/openclaw/crabbox/pull/2113), [PR 2118](https://github.com/openclaw/crabbox/pull/2118). Thanks @steipete.
 
 ## 0.56.0 - 2026-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Show OpenComputer, OpenSandbox and CUA settings in offline JSON and text, including unselected providers, without discovering credentials, resolving external defaults or executing SDK bridges. [PR 2112](https://github.com/openclaw/crabbox/pull/2112). Thanks @steipete.
 - Show Freestyle and Crownest settings through a shared offline JSON/text display path, preserving zero and false values while redacting URLs and reporting only loaded key presence. [PR 2104](https://github.com/openclaw/crabbox/pull/2104). Thanks @steipete.
 - Retain recognized workspace-owner protocol states in child and phase-witness inspection errors, improving diagnostics without changing ownership decisions or retry behavior. [PR 2106](https://github.com/openclaw/crabbox/pull/2106). Thanks @steipete.
-- Retry a recognized checksum-service HTTP/2 interruption once during Go installation verification's dependency download, preserving checksum enforcement and the unchanged offline install checks. [PR 2113](https://github.com/openclaw/crabbox/pull/2113). Thanks @steipete.
+- Retry recognized checksum-service and module-ZIP HTTP/2 interruptions once during Go installation verification's dependency download, preserving checksum enforcement and the unchanged offline install checks. [PR 2113](https://github.com/openclaw/crabbox/pull/2113). Thanks @steipete.
 
 ## 0.56.0 - 2026-09-11
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -108,11 +108,14 @@ exact commit and verifies a cold, version-suffixed `go install` outside the
 checkout. It must pass before candidate production begins.
 
 The online dependency-seeding phase retries once, after five seconds, only for
-the recognized checksum-database tile HTTP/2 `INTERNAL_ERROR` diagnostic.
+recognized HTTP/2 `INTERNAL_ERROR` diagnostics from checksum-database tile reads
+or `proxy.golang.org` module-ZIP reads with the exact matching module/version URL.
 Both attempts use the same source, isolated cache and enabled checksum
-verification. Checksum mismatches, mixed or unknown errors, and interruptions
-remain immediately fatal. Original diagnostics remain visible after recovery;
-the read-only proxy, offline install and binary checks are not retried.
+verification. Any unknown or checksum-mismatch diagnostic remains fatal, even
+alongside a recognized transport error; interruptions also remain fatal.
+Multiple recognized errors still permit only one retry. Original diagnostics
+remain visible after recovery; the read-only proxy, offline install and binary
+checks are not retried.
 
 Run the credential-free producer first and capture its printed manifest digest:
 

--- a/scripts/release-workflow.test.js
+++ b/scripts/release-workflow.test.js
@@ -307,7 +307,7 @@ test("GoReleaser is credential-free build-only with exact binary archives", () =
   assert.doesNotMatch(build, /gh release|HOMEBREW_TAP_GITHUB_TOKEN=.*\$\{/);
 });
 
-function runSeedDownloadFixture(attempts) {
+function runSeedDownloadFixture(attempts, escapeToolFailure = false) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-seed-retry-"));
   try {
     const bin = path.join(root, "bin");
@@ -342,6 +342,9 @@ if (tool === "git") {
   else unexpected();
 } else if (tool === "sleep") {
   // Record the requested delay without sleeping.
+} else if (tool === "sed") {
+  // TEST ONLY: fail the encoder pipeline without changing the Go command's status.
+  process.exit(42);
 } else if (tool === "cp") {
   execFileSync("/bin/cp", args);
 } else if (tool === "zip") {
@@ -379,6 +382,7 @@ if (tool === "git") {
 } else unexpected();
 `);
     for (const tool of ["git", "go", "zip", "sleep", "cp"]) writeExecutable(path.join(bin, tool), wrapper(tool));
+    if (escapeToolFailure) writeExecutable(path.join(bin, "sed"), wrapper("sed"));
     const result = spawnSync("/bin/bash", [entrypoint, "v1.2.3", "fixture-source"], {
       encoding: "utf8", timeout: 20_000,
       env: { PATH: `${bin}:/usr/bin:/bin`, HOME: path.join(root, "home"), TMPDIR: tmp },
@@ -398,6 +402,12 @@ test("Go install seed retry preserves bounded verified download and offline phas
   const mismatch = "verifying example.com/dependency@v1.0.0: checksum mismatch\nSECURITY ERROR\n";
   const ok = { code: 0, output: "" };
   const transient = { code: 1, output: progress + transport };
+  const zip = 'go: github.com/gobuffalo/attrs@v0.0.0-20190224210810-a9411de4debd: read "https://proxy.golang.org/github.com/gobuffalo/attrs/@v/v0.0.0-20190224210810-a9411de4debd.zip": stream error: stream ID 5057; INTERNAL_ERROR; received from peer\n';
+  const zipURL = "https://proxy.golang.org/github.com/gobuffalo/attrs/@v/v0.0.0-20190224210810-a9411de4debd.zip";
+  const uppercasePath = 'go: example.com/Example/Module@v1.2.3: read "https://proxy.golang.org/example.com/!example/!module/@v/v1.2.3.zip": stream error: stream ID 12; INTERNAL_ERROR; received from peer\n';
+  const uppercaseVersion = 'go: example.com/dependency@v1.2.3-RC1: read "https://proxy.golang.org/example.com/dependency/@v/v1.2.3-!r!c1.zip": stream error: stream ID 13; INTERNAL_ERROR; received from peer\n';
+  const zipFailure = { code: 1, output: progress + zip };
+  const mixedTransport = { code: 1, output: transport + zip };
   for (const tc of [
     { name: "success-once", attempts: [ok], downloads: 1, delay: 0, code: 0 },
     { name: "tile-error-then-success", attempts: [transient, ok], downloads: 2, delay: 1, code: 0 },
@@ -412,10 +422,45 @@ test("Go install seed retry preserves bounded verified download and offline phas
     { name: "progress-only-error", attempts: [{ code: 1, output: progress }], downloads: 1, delay: 0, code: 1 },
     { name: "non-one-status", attempts: [{ code: 23, output: transport }], downloads: 1, delay: 0, code: 23 },
     { name: "different-module-error", attempts: [{ code: 1, output: transport.replace("verifying go.mod: github.com/openfga", "verifying go.mod: example.com/other") }], downloads: 1, delay: 0, code: 1 },
+    { name: "observed-zip-then-success", attempts: [zipFailure, ok], downloads: 2, delay: 1, code: 0 },
+    { name: "observed-zip-exhausted", attempts: [zipFailure, zipFailure], downloads: 2, delay: 1, code: 1 },
+    { name: "zip-uppercase-path", attempts: [{ code: 1, output: uppercasePath }, ok], downloads: 2, delay: 1, code: 0 },
+    { name: "zip-uppercase-version", attempts: [{ code: 1, output: uppercaseVersion }, ok], downloads: 2, delay: 1, code: 0 },
+    { name: "tile-and-zip-then-success", attempts: [mixedTransport, ok], downloads: 2, delay: 1, code: 0 },
+    { name: "tile-and-zip-share-retry-budget", attempts: [mixedTransport, mixedTransport], downloads: 2, delay: 1, code: 1 },
+    { name: "zip-second-error-status", attempts: [zipFailure, { code: 7, output: "second attempt stopped\n" }], downloads: 2, delay: 1, code: 7 },
+    { name: "zip-mixed-checksum", attempts: [{ code: 1, output: zip + mismatch }], downloads: 1, delay: 0, code: 1 },
+    { name: "zip-mixed-unknown", attempts: [{ code: 1, output: zip + "go: module lookup failed\n" }], downloads: 1, delay: 0, code: 1 },
+    { name: "zip-non-one-status", attempts: [{ code: 23, output: zip }], downloads: 1, delay: 0, code: 23 },
+    { name: "zip-encoder-failure-keeps-download-status", attempts: [zipFailure], downloads: 1, delay: 0, code: 1, escapeToolFailure: true },
+    ...[
+      ["module", zip.replace(zipURL, zipURL.replace("gobuffalo/attrs", "gobuffalo/other"))],
+      ["version", zip.replace(zipURL, zipURL.replace("v0.0.0-20190224210810-a9411de4debd", "v1.2.3"))],
+      ["escaped-other-module", uppercasePath.replace("/!module/", "/!other/")],
+      ["escaped-other-version", uppercaseVersion.replace("-!r!c1.zip", "-!r!c2.zip")],
+      ["lowercase-without-bangs", uppercasePath.replace("/!example/!module/", "/example/module/")],
+      ["raw-uppercase-url", uppercasePath.replace("/!example/!module/", "/Example/Module/")],
+      ["raw-uppercase-version-url", uppercaseVersion.replace("-!r!c1.zip", "-RC1.zip")],
+      ["host", zip.replace("https://proxy.golang.org/", "https://proxy.example.com/")],
+      ["host-suffix", zip.replace("https://proxy.golang.org/", "https://proxy.golang.org.example.com/")],
+      ["scheme", zip.replace("https://", "http://")],
+      ["port", zip.replace("proxy.golang.org/", "proxy.golang.org:443/")],
+      ["suffix", zip.replace('.zip"', '.mod"')],
+      ["query", zip.replace('.zip"', '.zip?download=1"')],
+      ["fragment", zip.replace('.zip"', '.zip#archive"')],
+      ["extra-path", zip.replace('/@v/', '/extra/@v/')],
+      ["encoded-url", uppercasePath.replace("/!example/", "/%21example/")],
+      ["encoded-module", zip.replace("go: github.com/", "go: github%2ecom/")],
+      ["raw-bang-module", uppercasePath.replace("go: example.com/Example/", "go: example.com/!example/")],
+      ["extra-delimiter", zip.replace("attrs@v", "attrs@other@v")],
+      ["missing-quotes", zip.replaceAll('"', "")],
+      ["extra-text", zip.replace("received from peer", "received from peer trailing text")],
+    ].map(([name, output]) => ({ name: `zip-rejects-${name}`, attempts: [{ code: 1, output }], downloads: 1, delay: 0, code: 1 })),
   ]) {
     await t.test(tc.name, () => {
-      const { result, calls } = runSeedDownloadFixture(tc.attempts);
+      const { result, calls } = runSeedDownloadFixture(tc.attempts, tc.escapeToolFailure);
       assert.equal(result.status, tc.code, result.stderr);
+      if (tc.escapeToolFailure) assert.equal(calls.filter(c => c.tool === "sed").length, 1, "encoder failure fixture was not reached");
       const downloads = calls.filter(c => c.tool === "go" && c.args.join(" ") === "mod download all");
       const delays = calls.filter(c => c.tool === "sleep");
       const installs = calls.filter(c => c.tool === "go" && c.args[0] === "install");

--- a/scripts/verify-go-install.sh
+++ b/scripts/verify-go-install.sh
@@ -268,15 +268,30 @@ env -i \
 
 # Download the complete selected dependency graph into an isolated cache, then
 # copy the proxy-form cache entries. Network access ends before the install.
+seed_proxy_escape() {
+  printf '%s' "$1" | LC_ALL=C sed 's/[A-Z]/!&/g' | LC_ALL=C tr 'A-Z' 'a-z'
+}
+
 seed_download_retryable() {
+  local LC_ALL=C
   local line recognized=0
+  local module version url escaped_module escaped_version
   local progress='^go: downloading [^[:space:]]+ v[^[:space:]]+$'
   local transient='^go: ([^[:space:]:]+@v[^[:space:]:]+): verifying go[.]mod: ([^[:space:]:]+@v[^[:space:]:]+)/go[.]mod: reading https://sum[.]golang[.]org/tile/[0-9]+/[0-9]+/(x[0-9]+/)*[0-9]+: stream error: stream ID [0-9]+; INTERNAL_ERROR; received from peer$'
+  local zip_transient='^go: ([A-Za-z0-9][A-Za-z0-9._~/-]*)@(v[0-9][0-9A-Za-z.+-]*): read "([^"]+)": stream error: stream ID [0-9]+; INTERNAL_ERROR; received from peer$'
   while IFS= read -r line || [[ -n "$line" ]]; do
     if [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ $progress ]]; then
       continue
     fi
     if [[ "$line" =~ $transient ]] && [[ "${BASH_REMATCH[1]}" == "${BASH_REMATCH[2]}" ]]; then
+      recognized=1
+    elif [[ "$line" =~ $zip_transient ]]; then
+      module=${BASH_REMATCH[1]}
+      version=${BASH_REMATCH[2]}
+      url=${BASH_REMATCH[3]}
+      escaped_module=$(seed_proxy_escape "$module") || return 1
+      escaped_version=$(seed_proxy_escape "$version") || return 1
+      [[ "$url" == "https://proxy.golang.org/$escaped_module/@v/$escaped_version.zip" ]] || return 1
       recognized=1
     else
       return 1
@@ -307,7 +322,7 @@ seed_dependencies() {
     if [[ "$attempt" -ne 1 || "$download_status" -ne 1 ]] || ! seed_download_retryable "$log"; then
       return "$download_status"
     fi
-    echo "Dependency seed attempt 1 failed with a checksum-database transport error; retrying once in 5 seconds." >&2
+    echo "Dependency seed attempt 1 failed with a dependency-download transport error; retrying once in 5 seconds." >&2
     sleep 5 || return $?
   done
 }


### PR DESCRIPTION
## Summary

Extend the existing dependency-seed retry predicate to the exact module-ZIP HTTP/2 transport error observed in https://github.com/openclaw/crabbox/actions/runs/34638958133. That failure was a quoted `proxy.golang.org` ZIP read, outside the checksum-database tile shape added in https://github.com/openclaw/crabbox/pull/2113. One unchanged failed-job retry subsequently passed; no source defect in the provider-display PR was established.

The new alternative requires the complete diagnostic and an exact URL matching the same module and version. A small private encoder applies Go's ASCII uppercase-to-`!`-lowercase escaping to both, so current uppercase dependencies are handled correctly. Captured input is compared literally, never evaluated or fetched by the classifier.

Both recognized transport shapes share the existing maximum of two seed attempts and one five-second delay. Unknown or checksum-mismatch lines, even alongside a recognized error, remain fatal; non-one exit statuses remain fatal too. The seed command, source, environment, cache, checksum enforcement, offline installation and binary checks are unchanged. Docs and the existing changelog entry now describe both shapes.

## Verification

- The same actual-entrypoint inert fixture now covers 45 scenarios, retaining all 13 originals and their assertions. New cases cover observed ZIP recovery/exhaustion, uppercase module/version escaping, mismatched or malformed URLs, mixed diagnostics, the shared retry budget, and encoder failure preserving the original download status.
- Identical tests against immutable main `9798fccba5add381ac40989daa5e1879bd13a34d` produced eight expected failures; the candidate passed all scenarios. Root verification passed 47 tests including the scenario parent and the existing hermetic-install test.
- Bash syntax, docs and whitespace checks passed. Managed Codex review passed at P0 scope. Source-boundary checks preserve the existing sumdb recognizer, retry loop, seed environment and offline tail apart from the clarified notice.

The fixture substitutes Git/Go/zip commands and does not establish Go metadata-verifier correctness or live transport recovery. No real network fault was induced, no checksum setting was weakened, and no release/publication operation was performed. Normal CI verifies real installation separately.
