### PR TITLE
refactor(config): move cloud provider displays into adapters

### DIFF
--- a/docs/refactor/provider-config-display.md
+++ b/docs/refactor/provider-config-display.md
@@ -56,6 +56,13 @@ either backend's runtime defaults. MXC retains JSON lists with text counts,
 Docker Sandbox retains JSON lists with comma-joined text and `%g` CPU formatting,
 and nil versus empty lists remain distinct. Internal-only fields stay omitted.
 
+AWS, Azure and GCP own their existing 24 JSON fields and 17 text fields through
+the same capability. Seven fields remain JSON-only rather than gaining new text
+output. AWS's 32-bit and GCP's 64-bit disk sizes, ordered lists and exact text
+slots are preserved. Instance-profile and service-account values remain
+configured references; these projections do not inspect SDK credentials or add
+authentication or readiness facts.
+
 ## Remaining migration
 
 The baseline census contains 81 canonical providers: 49 have both value formats,
@@ -68,11 +75,11 @@ sections**. They do not complete the migration. Existing provider projections
 also still need to move out of the parallel JSON map and text formatter so
 their field selection and transformations have one owner.
 
-The Multipass/Tart/Lume and local-container cohorts remove eight of the original
-49 canonical both-format providers from that legacy implementation, leaving 41
-in that cohort. The local cohort covers five identities through four sections
-because Apple Machine shares Apple Container's values. These migrations do not
-fill any of the missing sections above.
+The Multipass/Tart/Lume, local-container and cloud cohorts remove eleven of the
+original 49 canonical both-format providers from that legacy implementation,
+leaving 38 in that cohort. The local cohort covers five identities through four
+sections because Apple Machine shares Apple Container's values. These migrations
+do not fill any of the missing sections above.
 
 For each remaining provider, establish the explicit public field contract
 before implementation. Preserve existing keys, types, null/empty distinctions,

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -230,16 +230,6 @@ func configShowView(cfg Config) map[string]any {
 			"runnerVersion": cfg.Actions.RunnerVersion,
 			"ephemeral":     cfg.Actions.Ephemeral,
 		},
-		"azure": map[string]any{
-			"location":      cfg.AzureLocation,
-			"resourceGroup": cfg.AzureResourceGroup,
-			"image":         cfg.AzureImage,
-			"osDisk":        cfg.AzureOSDisk,
-			"snapshotSKU":   cfg.AzureSnapshotSKU,
-			"osDiskSKU":     cfg.AzureOSDiskSKU,
-			"network":       cfg.AzureNetwork,
-			"sshCIDRs":      cfg.AzureSSHCIDRs,
-		},
 		"digitalocean": map[string]any{
 			"region":   cfg.DigitalOcean.Region,
 			"image":    cfg.DigitalOcean.Image,
@@ -624,15 +614,6 @@ func configShowView(cfg Config) map[string]any {
 			"image":    cfg.Image,
 			"sshKey":   cfg.ProviderKey,
 		},
-		"aws": map[string]any{
-			"region":          cfg.AWSRegion,
-			"ami":             cfg.AWSAMI,
-			"securityGroupId": cfg.AWSSGID,
-			"subnetId":        cfg.AWSSubnetID,
-			"instanceProfile": cfg.AWSProfile,
-			"rootGB":          cfg.AWSRootGB,
-			"sshCIDRs":        cfg.AWSSSHCIDRs,
-		},
 		"awsLambdaMicroVM": map[string]any{
 			"image":             cfg.AWSLambdaMicroVM.Image,
 			"imageVersion":      cfg.AWSLambdaMicroVM.ImageVersion,
@@ -641,17 +622,6 @@ func configShowView(cfg Config) map[string]any {
 			"ingressConnectors": cfg.AWSLambdaMicroVM.IngressConnectors,
 			"egressConnectors":  cfg.AWSLambdaMicroVM.EgressConnectors,
 			"forgetMissing":     cfg.AWSLambdaMicroVM.ForgetMissing,
-		},
-		"gcp": map[string]any{
-			"project":        cfg.GCPProject,
-			"zone":           cfg.GCPZone,
-			"image":          cfg.GCPImage,
-			"network":        cfg.GCPNetwork,
-			"subnet":         cfg.GCPSubnet,
-			"tags":           cfg.GCPTags,
-			"rootGB":         cfg.GCPRootGB,
-			"sshCIDRs":       cfg.GCPSSHCIDRs,
-			"serviceAccount": cfg.GCPServiceAccount,
 		},
 		"proxmox": map[string]any{
 			"apiUrl":      redactedConfigURL(cfg.Proxmox.APIURL),
@@ -843,9 +813,13 @@ func writeConfigShowText(w io.Writer, cfg Config) error {
 		sort.Strings(names)
 		fmt.Fprintf(w, "jobs=%s\n", strings.Join(names, ","))
 	}
-	fmt.Fprintf(w, "aws region=%s root_gb=%d ssh_cidrs=%s\n", cfg.AWSRegion, cfg.AWSRootGB, blank(strings.Join(cfg.AWSSSHCIDRs, ","), "-"))
+	if err := layout.writeSlot(w, "aws"); err != nil {
+		return err
+	}
 	fmt.Fprintf(w, "aws_lambda_microvm image=%s image_version=%s workdir=%s forget_missing=%t\n", blank(cfg.AWSLambdaMicroVM.Image, "-"), blank(cfg.AWSLambdaMicroVM.ImageVersion, "latest"), cfg.AWSLambdaMicroVM.Workdir, cfg.AWSLambdaMicroVM.ForgetMissing)
-	fmt.Fprintf(w, "azure location=%s resource_group=%s os_disk=%s snapshot_sku=%s os_disk_sku=%s network=%s ssh_cidrs=%s\n", cfg.AzureLocation, cfg.AzureResourceGroup, cfg.AzureOSDisk, blank(cfg.AzureSnapshotSKU, "-"), blank(cfg.AzureOSDiskSKU, "-"), blank(cfg.AzureNetwork, "-"), blank(strings.Join(cfg.AzureSSHCIDRs, ","), "-"))
+	if err := layout.writeSlot(w, "azure"); err != nil {
+		return err
+	}
 	fmt.Fprintf(w, "digitalocean region=%s image=%s vpc=%s ssh_cidrs=%s\n", cfg.DigitalOcean.Region, cfg.DigitalOcean.Image, blank(cfg.DigitalOcean.VPCUUID, "-"), blank(strings.Join(cfg.DigitalOcean.SSHCIDRs, ","), "-"))
 	fmt.Fprintf(w, "vultr region=%s os=%s image=%s snapshot=%s firewall_group=%s vpc_ids=%s ssh_cidrs=%s user_scheme=%s\n", cfg.Vultr.Region, blank(cfg.Vultr.OS, "-"), blank(cfg.Vultr.Image, "-"), blank(cfg.Vultr.Snapshot, "-"), blank(cfg.Vultr.FirewallGroup, "-"), blank(strings.Join(cfg.Vultr.VPCIDs, ","), "-"), blank(strings.Join(cfg.Vultr.SSHCIDRs, ","), "-"), blank(cfg.Vultr.UserScheme, "-"))
 	fmt.Fprintf(w, "linode region=%s image=%s type=%s firewall=%s ssh_cidrs=%s\n", cfg.Linode.Region, cfg.Linode.Image, cfg.Linode.Type, blank(cfg.Linode.FirewallID, "-"), blank(strings.Join(cfg.Linode.SSHCIDRs, ","), "-"))
@@ -859,7 +833,9 @@ func writeConfigShowText(w io.Writer, cfg Config) error {
 	fmt.Fprintf(w, "scaleway region=%s zone=%s image=%s type=%s project_id=%s organization_id=%s security_group=%s ssh_cidrs=%s auth=%s\n", blank(cfg.Scaleway.Region, "-"), blank(cfg.Scaleway.Zone, "-"), blank(cfg.Scaleway.Image, "-"), blank(cfg.Scaleway.Type, "-"), blank(cfg.Scaleway.ProjectID, "-"), blank(cfg.Scaleway.OrganizationID, "-"), blank(cfg.Scaleway.SecurityGroup, "-"), blank(strings.Join(cfg.Scaleway.SSHCIDRs, ","), "-"), scalewayAuthState())
 	fmt.Fprintf(w, "tencentcloud region=%s zone=%s image=%s type=%s vpc_id=%s subnet_id=%s security_group_id=%s root_gb=%d internet_charge_type=%s internet_max_bandwidth_out=%d ssh_cidrs=%s api_endpoint=%s auth=%s\n", blank(cfg.TencentCloud.Region, "-"), blank(cfg.TencentCloud.Zone, "-"), blank(cfg.TencentCloud.Image, "-"), blank(cfg.TencentCloud.Type, "-"), blank(cfg.TencentCloud.VPCID, "-"), blank(cfg.TencentCloud.SubnetID, "-"), blank(cfg.TencentCloud.SecurityGroupID, "-"), cfg.TencentCloud.RootGB, blank(cfg.TencentCloud.InternetChargeType, "-"), cfg.TencentCloud.InternetMaxBandwidthOut, blank(strings.Join(cfg.TencentCloud.SSHCIDRs, ","), "-"), blank(redactedConfigURL(cfg.TencentCloud.APIEndpoint), "-"), tencentCloudAuthState())
 	fmt.Fprintf(w, "azure_dynamic_sessions endpoint=%s unsupported_pool=%s api_version=%s workdir=%s timeout_secs=%d\n", blank(redactedConfigURL(cfg.AzureDynamicSessions.Endpoint), "-"), blank(cfg.AzureDynamicSessions.Pool, "-"), cfg.AzureDynamicSessions.APIVersion, cfg.AzureDynamicSessions.Workdir, cfg.AzureDynamicSessions.TimeoutSecs)
-	fmt.Fprintf(w, "gcp project=%s zone=%s image=%s network=%s subnet=%s root_gb=%d ssh_cidrs=%s\n", blank(cfg.GCPProject, "-"), cfg.GCPZone, cfg.GCPImage, cfg.GCPNetwork, blank(cfg.GCPSubnet, "-"), cfg.GCPRootGB, blank(strings.Join(cfg.GCPSSHCIDRs, ","), "-"))
+	if err := layout.writeSlot(w, "gcp"); err != nil {
+		return err
+	}
 	fmt.Fprintf(w, "proxmox api_url=%s node=%s template_id=%d storage=%s pool=%s bridge=%s user=%s work_root=%s full_clone=%t auth=%s\n", blank(redactedConfigURL(cfg.Proxmox.APIURL), "-"), blank(cfg.Proxmox.Node, "-"), cfg.Proxmox.TemplateID, blank(cfg.Proxmox.Storage, "-"), blank(cfg.Proxmox.Pool, "-"), blank(cfg.Proxmox.Bridge, "-"), cfg.Proxmox.User, cfg.Proxmox.WorkRoot, cfg.Proxmox.FullClone, tokenState(cfg.Proxmox.TokenSecret))
 	fmt.Fprintf(w, "firecracker binary=%s jailer=%s kernel=%s rootfs=%s user=%s work_root=%s cpus=%d memory_mib=%d disk_mib=%d network=%s cni_network=%s cni_conf_dir=%s cni_bin_dir=%s launch_timeout=%s delete_on_release=%t\n", blank(cfg.Firecracker.Binary, "-"), blank(cfg.Firecracker.Jailer, "-"), blank(cfg.Firecracker.Kernel, "-"), blank(cfg.Firecracker.RootFS, "-"), blank(cfg.Firecracker.User, "-"), blank(cfg.Firecracker.WorkRoot, "-"), cfg.Firecracker.CPUs, cfg.Firecracker.MemoryMiB, cfg.Firecracker.DiskMiB, blank(cfg.Firecracker.Network, "-"), blank(cfg.Firecracker.CNINetwork, "-"), blank(cfg.Firecracker.CNIConfDir, "-"), blank(cfg.Firecracker.CNIBinDir, "-"), cfg.Firecracker.LaunchTimeout, cfg.Firecracker.DeleteOnRelease)
 	fmt.Fprintf(w, "xcp_ng api_url=%s username=%s template=%s template_uuid=%s sr=%s sr_uuid=%s network=%s network_uuid=%s host=%s user=%s work_root=%s insecure_tls=%t auth=%s\n", blank(redactedConfigURL(cfg.XCPNg.APIURL), "-"), blank(cfg.XCPNg.Username, "-"), blank(cfg.XCPNg.Template, "-"), blank(cfg.XCPNg.TemplateUUID, "-"), blank(cfg.XCPNg.SR, "-"), blank(cfg.XCPNg.SRUUID, "-"), blank(cfg.XCPNg.Network, "-"), blank(cfg.XCPNg.NetworkUUID, "-"), blank(cfg.XCPNg.Host, "-"), cfg.XCPNg.User, cfg.XCPNg.WorkRoot, cfg.XCPNg.InsecureTLS, tokenState(cfg.XCPNg.Password))

--- a/internal/cli/config_show_projection.go
+++ b/internal/cli/config_show_projection.go
@@ -36,7 +36,7 @@ func ConfigShowSecretState(value string) string { return tokenState(value) }
 
 // Names only: no legacy value projection or environment reads are needed to
 // protect existing text slots. Retire a name only when its legacy row migrates.
-const legacyConfigShowTextLabels = "config provider lease broker access_auth ssh sync env run capacity actions blacksmith agent_sandbox phala namespace namespace_instance morph e2b cubesandbox upstash_box smolvm blaxel nomad ascii_box superserve machine0 cloudflare fastapi_cloud cloudflare_dynamic_workers cloudflare_sandbox static results cache jobs aws aws_lambda_microvm azure digitalocean vultr linode github_codespaces lambda vast nvidia_brev nebius hostinger ovh scaleway tencentcloud azure_dynamic_sessions gcp proxmox firecracker xcp_ng parallels inspection provider_status"
+const legacyConfigShowTextLabels = "config provider lease broker access_auth ssh sync env run capacity actions blacksmith agent_sandbox phala namespace namespace_instance morph e2b cubesandbox upstash_box smolvm blaxel nomad ascii_box superserve machine0 cloudflare fastapi_cloud cloudflare_dynamic_workers cloudflare_sandbox static results cache jobs aws_lambda_microvm digitalocean vultr linode github_codespaces lambda vast nvidia_brev nebius hostinger ovh scaleway tencentcloud azure_dynamic_sessions proxmox firecracker xcp_ng parallels inspection provider_status"
 
 func collectProviderConfigShowSections(cfg Config) ([]ProviderConfigShowSection, error) {
 	return collectProviderConfigShowSectionsFrom(cfg, registeredProviders())

--- a/internal/cli/config_show_projection_test.go
+++ b/internal/cli/config_show_projection_test.go
@@ -235,13 +235,16 @@ func TestConfigShowLegacySlotPositions(t *testing.T) {
 			order = append(order, value)
 		} else if sel.Sel.Name == "Fprintf" {
 			name := strings.SplitN(value, " ", 2)[0]
-			if name == "superserve" || name == "local_container" || name == "apple_container" || name == "mxc" || name == "docker_sandbox" || name == "machine0" || name == "cloudflare" {
+			if strings.HasPrefix(value, "jobs=") {
+				name = "jobs"
+			}
+			if name == "superserve" || name == "local_container" || name == "apple_container" || name == "mxc" || name == "docker_sandbox" || name == "machine0" || name == "cloudflare" || name == "jobs" || name == "aws" || name == "aws_lambda_microvm" || name == "azure" || name == "digitalocean" || name == "azure_dynamic_sessions" || name == "gcp" || name == "proxmox" {
 				order = append(order, name)
 			}
 		}
 		return true
 	})
-	if got := strings.Join(order, ","); got != "superserve,local_container,apple_container,mxc,docker_sandbox,multipass,machine0,tart,lume,cloudflare" {
+	if got := strings.Join(order, ","); got != "superserve,local_container,apple_container,mxc,docker_sandbox,multipass,machine0,tart,lume,cloudflare,jobs,aws,aws_lambda_microvm,azure,digitalocean,azure_dynamic_sessions,gcp,proxmox" {
 		t.Fatalf("legacy text slot positions: %s", got)
 	}
 }
@@ -250,9 +253,9 @@ func TestConfigShowTextLayoutConsumesSlotsOnce(t *testing.T) {
 	section := func(label string) ProviderConfigShowSection {
 		return ProviderConfigShowSection{TextLabel: label, Fields: []ProviderConfigShowField{{TextName: "value", TextValue: label}}}
 	}
-	layout := newConfigShowTextLayout([]ProviderConfigShowSection{section("alpha"), section("lume"), section("multipass"), section("tart"), section("zeta"), section("docker_sandbox"), section("mxc"), section("apple_container"), section("local_container")})
+	layout := newConfigShowTextLayout([]ProviderConfigShowSection{section("alpha"), section("lume"), section("multipass"), section("tart"), section("zeta"), section("docker_sandbox"), section("mxc"), section("apple_container"), section("local_container"), section("aws"), section("azure"), section("gcp")})
 	var out bytes.Buffer
-	for _, label := range []string{"absent", "local_container", "apple_container", "mxc", "docker_sandbox", "local_container", "apple_container", "mxc", "docker_sandbox", "multipass", "multipass", "tart", "lume"} {
+	for _, label := range []string{"absent", "local_container", "apple_container", "mxc", "docker_sandbox", "local_container", "apple_container", "mxc", "docker_sandbox", "multipass", "multipass", "tart", "lume", "aws", "azure", "gcp", "aws", "azure", "gcp"} {
 		if err := layout.writeSlot(&out, label); err != nil {
 			t.Fatal(err)
 		}
@@ -260,7 +263,7 @@ func TestConfigShowTextLayoutConsumesSlotsOnce(t *testing.T) {
 	if err := layout.writeRemaining(&out); err != nil {
 		t.Fatal(err)
 	}
-	if got, want := out.String(), "local_container value=local_container\napple_container value=apple_container\nmxc value=mxc\ndocker_sandbox value=docker_sandbox\nmultipass value=multipass\ntart value=tart\nlume value=lume\nalpha value=alpha\nzeta value=zeta\n"; got != want {
+	if got, want := out.String(), "local_container value=local_container\napple_container value=apple_container\nmxc value=mxc\ndocker_sandbox value=docker_sandbox\nmultipass value=multipass\ntart value=tart\nlume value=lume\naws value=aws\nazure value=azure\ngcp value=gcp\nalpha value=alpha\nzeta value=zeta\n"; got != want {
 		t.Fatalf("slot order/duplication got %q want %q", got, want)
 	}
 	out.Reset()
@@ -359,6 +362,20 @@ func TestConfigShowLocalCohortLegacyOwnershipRetired(t *testing.T) {
 		for _, reserved := range strings.Fields(legacyConfigShowTextLabels) {
 			if reserved == label {
 				t.Errorf("migrated label %s still reserved as legacy", label)
+			}
+		}
+	}
+}
+
+func TestConfigShowCloudCohortLegacyOwnershipRetired(t *testing.T) {
+	view := configShowView(Config{})
+	for _, name := range []string{"aws", "azure", "gcp"} {
+		if _, exists := view[name]; exists {
+			t.Errorf("core still owns %s values", name)
+		}
+		for _, reserved := range strings.Fields(legacyConfigShowTextLabels) {
+			if reserved == name {
+				t.Errorf("migrated label %s still reserved as legacy", name)
 			}
 		}
 	}

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -2435,5 +2436,61 @@ func TestAWSAcquireStopsFreshRetryAfterRollbackFailure(t *testing.T) {
 				t.Fatalf("cleanup debt lost: error=%v stderr=%s", err, stderr.String())
 			}
 		})
+	}
+}
+
+func TestAWSConfigShowCompletePassiveSection(t *testing.T) {
+	projector, ok := any(Provider{}).(core.ProviderConfigShowProjector)
+	if !ok {
+		t.Fatal("actual provider has no passive config-show projector")
+	}
+	for _, tc := range []struct {
+		name  string
+		input core.Config
+		want  map[string]any
+		text  string
+	}{
+		{name: "nil", input: core.Config{}, want: map[string]any{"region": "", "ami": "", "securityGroupId": "", "subnetId": "", "instanceProfile": "", "rootGB": int32(0), "sshCIDRs": []string(nil)}, text: "aws region= root_gb=0 ssh_cidrs=-\n"},
+		{name: "empty", input: core.Config{AWSSSHCIDRs: []string{}}, want: map[string]any{"region": "", "ami": "", "securityGroupId": "", "subnetId": "", "instanceProfile": "", "rootGB": int32(0), "sshCIDRs": []string{}}, text: "aws region= root_gb=0 ssh_cidrs=-\n"},
+		{name: "raw-references-list", input: core.Config{AWSRegion: "raw-region", AWSAMI: "image-reference", AWSSGID: "group-reference", AWSSubnetID: "subnet-reference", AWSProfile: "guest-profile-reference", AWSRootGB: 2147483647, AWSSSHCIDRs: []string{"second", "first", "second", " "}}, want: map[string]any{"region": "raw-region", "ami": "image-reference", "securityGroupId": "group-reference", "subnetId": "subnet-reference", "instanceProfile": "guest-profile-reference", "rootGB": int32(2147483647), "sshCIDRs": []string{"second", "first", "second", " "}}, text: "aws region=raw-region root_gb=2147483647 ssh_cidrs=second,first,second, \n"},
+		{name: "whitespace-empty-elements", input: core.Config{AWSRegion: " ", AWSAMI: " ", AWSSGID: " ", AWSSubnetID: " ", AWSProfile: " ", AWSRootGB: -1, AWSSSHCIDRs: []string{"", ""}}, want: map[string]any{"region": " ", "ami": " ", "securityGroupId": " ", "subnetId": " ", "instanceProfile": " ", "rootGB": int32(-1), "sshCIDRs": []string{"", ""}}, text: "aws region=  root_gb=-1 ssh_cidrs=,\n"},
+	} {
+		for _, selected := range []string{"aws", "static"} {
+			t.Run(tc.name+"/"+selected, func(t *testing.T) {
+				cfg := tc.input
+				cfg.Provider = selected
+				before := cfg
+				before.AWSSSHCIDRs = slices.Clone(cfg.AWSSSHCIDRs)
+				section := projector.ConfigShowSection(cfg)
+				if section.JSONKey != "aws" || section.TextLabel != "aws" || !reflect.DeepEqual(section.Providers, []string{"aws"}) {
+					t.Fatalf("section metadata=%#v", section)
+				}
+				wantOrder := []string{"region", "ami", "securityGroupId", "subnetId", "instanceProfile", "rootGB", "sshCIDRs"}
+				if len(section.Fields) != len(wantOrder) {
+					t.Fatalf("field count=%d want %d", len(section.Fields), len(wantOrder))
+				}
+				got := map[string]any{}
+				line := section.TextLabel
+				for i, field := range section.Fields {
+					if field.JSONName != wantOrder[i] {
+						t.Fatalf("field %d name=%q want %q", i, field.JSONName, wantOrder[i])
+					}
+					got[field.JSONName] = field.JSONValue
+					if field.TextName != "" {
+						line += " " + field.TextName + "=" + field.TextValue
+					}
+				}
+				line += "\n"
+				if !reflect.DeepEqual(got, tc.want) {
+					t.Fatalf("public fields=%#v want %#v", got, tc.want)
+				}
+				if line != tc.text {
+					t.Fatalf("text=%q want %q", line, tc.text)
+				}
+				if !reflect.DeepEqual(cfg, before) {
+					t.Fatal("projection mutated supplied configuration")
+				}
+			})
+		}
 	}
 }

--- a/internal/providers/aws/config_show.go
+++ b/internal/providers/aws/config_show.go
@@ -1,0 +1,24 @@
+package aws
+
+import (
+	"strconv"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// ConfigShowSection preserves loaded values and the existing format-only fields.
+func (Provider) ConfigShowSection(cfg core.Config) core.ProviderConfigShowSection {
+	return core.ProviderConfigShowSection{
+		JSONKey: "aws", TextLabel: "aws", Providers: []string{"aws"},
+		Fields: []core.ProviderConfigShowField{
+			{JSONName: "region", JSONValue: cfg.AWSRegion, TextName: "region", TextValue: cfg.AWSRegion},
+			{JSONName: "ami", JSONValue: cfg.AWSAMI},
+			{JSONName: "securityGroupId", JSONValue: cfg.AWSSGID},
+			{JSONName: "subnetId", JSONValue: cfg.AWSSubnetID},
+			{JSONName: "instanceProfile", JSONValue: cfg.AWSProfile},
+			{JSONName: "rootGB", JSONValue: cfg.AWSRootGB, TextName: "root_gb", TextValue: strconv.FormatInt(int64(cfg.AWSRootGB), 10)},
+			{JSONName: "sshCIDRs", JSONValue: cfg.AWSSSHCIDRs, TextName: "ssh_cidrs", TextValue: core.Blank(strings.Join(cfg.AWSSSHCIDRs, ","), "-")},
+		},
+	}
+}

--- a/internal/providers/azure/backend_test.go
+++ b/internal/providers/azure/backend_test.go
@@ -9,6 +9,8 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -976,5 +978,61 @@ func TestAzureAcquireRollbackKeepsOriginalBindingAndRefusesUnpreparedDelete(t *t
 				t.Fatal("prepared companion evidence lost")
 			}
 		})
+	}
+}
+
+func TestAzureConfigShowCompletePassiveSection(t *testing.T) {
+	projector, ok := any(Provider{}).(core.ProviderConfigShowProjector)
+	if !ok {
+		t.Fatal("actual provider has no passive config-show projector")
+	}
+	for _, tc := range []struct {
+		name  string
+		input core.Config
+		want  map[string]any
+		text  string
+	}{
+		{name: "nil", input: core.Config{}, want: map[string]any{"location": "", "resourceGroup": "", "image": "", "osDisk": "", "snapshotSKU": "", "osDiskSKU": "", "network": "", "sshCIDRs": []string(nil)}, text: "azure location= resource_group= os_disk= snapshot_sku=- os_disk_sku=- network=- ssh_cidrs=-\n"},
+		{name: "empty", input: core.Config{AzureSSHCIDRs: []string{}}, want: map[string]any{"location": "", "resourceGroup": "", "image": "", "osDisk": "", "snapshotSKU": "", "osDiskSKU": "", "network": "", "sshCIDRs": []string{}}, text: "azure location= resource_group= os_disk= snapshot_sku=- os_disk_sku=- network=- ssh_cidrs=-\n"},
+		{name: "raw-references-list", input: core.Config{AzureLocation: "raw-location", AzureResourceGroup: "group-reference", AzureImage: "image-reference", AzureOSDisk: "raw-disk", AzureSnapshotSKU: "raw-snapshot-sku", AzureOSDiskSKU: "raw-disk-sku", AzureNetwork: "network-reference", AzureSSHCIDRs: []string{"second", "first", "second", " "}}, want: map[string]any{"location": "raw-location", "resourceGroup": "group-reference", "image": "image-reference", "osDisk": "raw-disk", "snapshotSKU": "raw-snapshot-sku", "osDiskSKU": "raw-disk-sku", "network": "network-reference", "sshCIDRs": []string{"second", "first", "second", " "}}, text: "azure location=raw-location resource_group=group-reference os_disk=raw-disk snapshot_sku=raw-snapshot-sku os_disk_sku=raw-disk-sku network=network-reference ssh_cidrs=second,first,second, \n"},
+		{name: "whitespace-empty-elements", input: core.Config{AzureLocation: " ", AzureResourceGroup: " ", AzureImage: " ", AzureOSDisk: " ", AzureSnapshotSKU: " ", AzureOSDiskSKU: " ", AzureNetwork: " ", AzureSSHCIDRs: []string{"", ""}}, want: map[string]any{"location": " ", "resourceGroup": " ", "image": " ", "osDisk": " ", "snapshotSKU": " ", "osDiskSKU": " ", "network": " ", "sshCIDRs": []string{"", ""}}, text: "azure location=  resource_group=  os_disk=  snapshot_sku=  os_disk_sku=  network=  ssh_cidrs=,\n"},
+	} {
+		for _, selected := range []string{"azure", "static"} {
+			t.Run(tc.name+"/"+selected, func(t *testing.T) {
+				cfg := tc.input
+				cfg.Provider = selected
+				before := cfg
+				before.AzureSSHCIDRs = slices.Clone(cfg.AzureSSHCIDRs)
+				section := projector.ConfigShowSection(cfg)
+				if section.JSONKey != "azure" || section.TextLabel != "azure" || !reflect.DeepEqual(section.Providers, []string{"azure"}) {
+					t.Fatalf("section metadata=%#v", section)
+				}
+				wantOrder := []string{"location", "resourceGroup", "image", "osDisk", "snapshotSKU", "osDiskSKU", "network", "sshCIDRs"}
+				if len(section.Fields) != len(wantOrder) {
+					t.Fatalf("field count=%d want %d", len(section.Fields), len(wantOrder))
+				}
+				got := map[string]any{}
+				line := section.TextLabel
+				for i, field := range section.Fields {
+					if field.JSONName != wantOrder[i] {
+						t.Fatalf("field %d name=%q want %q", i, field.JSONName, wantOrder[i])
+					}
+					got[field.JSONName] = field.JSONValue
+					if field.TextName != "" {
+						line += " " + field.TextName + "=" + field.TextValue
+					}
+				}
+				line += "\n"
+				if !reflect.DeepEqual(got, tc.want) {
+					t.Fatalf("public fields=%#v want %#v", got, tc.want)
+				}
+				if line != tc.text {
+					t.Fatalf("text=%q want %q", line, tc.text)
+				}
+				if !reflect.DeepEqual(cfg, before) {
+					t.Fatal("projection mutated supplied configuration")
+				}
+			})
+		}
 	}
 }

--- a/internal/providers/azure/config_show.go
+++ b/internal/providers/azure/config_show.go
@@ -1,0 +1,24 @@
+package azure
+
+import (
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// ConfigShowSection reports the established fields without cloud discovery.
+func (Provider) ConfigShowSection(cfg core.Config) core.ProviderConfigShowSection {
+	return core.ProviderConfigShowSection{
+		JSONKey: "azure", TextLabel: "azure", Providers: []string{"azure"},
+		Fields: []core.ProviderConfigShowField{
+			{JSONName: "location", JSONValue: cfg.AzureLocation, TextName: "location", TextValue: cfg.AzureLocation},
+			{JSONName: "resourceGroup", JSONValue: cfg.AzureResourceGroup, TextName: "resource_group", TextValue: cfg.AzureResourceGroup},
+			{JSONName: "image", JSONValue: cfg.AzureImage},
+			{JSONName: "osDisk", JSONValue: cfg.AzureOSDisk, TextName: "os_disk", TextValue: cfg.AzureOSDisk},
+			{JSONName: "snapshotSKU", JSONValue: cfg.AzureSnapshotSKU, TextName: "snapshot_sku", TextValue: core.Blank(cfg.AzureSnapshotSKU, "-")},
+			{JSONName: "osDiskSKU", JSONValue: cfg.AzureOSDiskSKU, TextName: "os_disk_sku", TextValue: core.Blank(cfg.AzureOSDiskSKU, "-")},
+			{JSONName: "network", JSONValue: cfg.AzureNetwork, TextName: "network", TextValue: core.Blank(cfg.AzureNetwork, "-")},
+			{JSONName: "sshCIDRs", JSONValue: cfg.AzureSSHCIDRs, TextName: "ssh_cidrs", TextValue: core.Blank(strings.Join(cfg.AzureSSHCIDRs, ","), "-")},
+		},
+	}
+}

--- a/internal/providers/gcp/config_show.go
+++ b/internal/providers/gcp/config_show.go
@@ -1,0 +1,26 @@
+package gcp
+
+import (
+	"strconv"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// ConfigShowSection preserves raw references, numeric width and list shapes.
+func (Provider) ConfigShowSection(cfg core.Config) core.ProviderConfigShowSection {
+	return core.ProviderConfigShowSection{
+		JSONKey: "gcp", TextLabel: "gcp", Providers: []string{"gcp"},
+		Fields: []core.ProviderConfigShowField{
+			{JSONName: "project", JSONValue: cfg.GCPProject, TextName: "project", TextValue: core.Blank(cfg.GCPProject, "-")},
+			{JSONName: "zone", JSONValue: cfg.GCPZone, TextName: "zone", TextValue: cfg.GCPZone},
+			{JSONName: "image", JSONValue: cfg.GCPImage, TextName: "image", TextValue: cfg.GCPImage},
+			{JSONName: "network", JSONValue: cfg.GCPNetwork, TextName: "network", TextValue: cfg.GCPNetwork},
+			{JSONName: "subnet", JSONValue: cfg.GCPSubnet, TextName: "subnet", TextValue: core.Blank(cfg.GCPSubnet, "-")},
+			{JSONName: "tags", JSONValue: cfg.GCPTags},
+			{JSONName: "rootGB", JSONValue: cfg.GCPRootGB, TextName: "root_gb", TextValue: strconv.FormatInt(cfg.GCPRootGB, 10)},
+			{JSONName: "sshCIDRs", JSONValue: cfg.GCPSSHCIDRs, TextName: "ssh_cidrs", TextValue: core.Blank(strings.Join(cfg.GCPSSHCIDRs, ","), "-")},
+			{JSONName: "serviceAccount", JSONValue: cfg.GCPServiceAccount},
+		},
+	}
+}

--- a/internal/providers/gcp/provider_test.go
+++ b/internal/providers/gcp/provider_test.go
@@ -1,6 +1,8 @@
 package gcp
 
 import (
+	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -179,4 +181,61 @@ func cloneTestLabels(labels map[string]string) map[string]string {
 		cloned[key] = value
 	}
 	return cloned
+}
+
+func TestGCPConfigShowCompletePassiveSection(t *testing.T) {
+	projector, ok := any(Provider{}).(core.ProviderConfigShowProjector)
+	if !ok {
+		t.Fatal("actual provider has no passive config-show projector")
+	}
+	for _, tc := range []struct {
+		name  string
+		input core.Config
+		want  map[string]any
+		text  string
+	}{
+		{name: "nil", input: core.Config{}, want: map[string]any{"project": "", "zone": "", "image": "", "network": "", "subnet": "", "tags": []string(nil), "rootGB": int64(0), "sshCIDRs": []string(nil), "serviceAccount": ""}, text: "gcp project=- zone= image= network= subnet=- root_gb=0 ssh_cidrs=-\n"},
+		{name: "empty", input: core.Config{GCPTags: []string{}, GCPSSHCIDRs: []string{}}, want: map[string]any{"project": "", "zone": "", "image": "", "network": "", "subnet": "", "tags": []string{}, "rootGB": int64(0), "sshCIDRs": []string{}, "serviceAccount": ""}, text: "gcp project=- zone= image= network= subnet=- root_gb=0 ssh_cidrs=-\n"},
+		{name: "raw-references-list", input: core.Config{GCPProject: "project-reference", GCPZone: "raw-zone", GCPImage: "image-reference", GCPNetwork: "network-reference", GCPSubnet: "subnet-reference", GCPTags: []string{"last", "first", "last", " "}, GCPRootGB: 9007199254740993, GCPSSHCIDRs: []string{"second", "first", "second", " "}, GCPServiceAccount: "identity-reference"}, want: map[string]any{"project": "project-reference", "zone": "raw-zone", "image": "image-reference", "network": "network-reference", "subnet": "subnet-reference", "tags": []string{"last", "first", "last", " "}, "rootGB": int64(9007199254740993), "sshCIDRs": []string{"second", "first", "second", " "}, "serviceAccount": "identity-reference"}, text: "gcp project=project-reference zone=raw-zone image=image-reference network=network-reference subnet=subnet-reference root_gb=9007199254740993 ssh_cidrs=second,first,second, \n"},
+		{name: "whitespace-empty-elements", input: core.Config{GCPProject: " ", GCPZone: " ", GCPImage: " ", GCPNetwork: " ", GCPSubnet: " ", GCPTags: []string{"", ""}, GCPRootGB: -1, GCPSSHCIDRs: []string{"", ""}, GCPServiceAccount: " "}, want: map[string]any{"project": " ", "zone": " ", "image": " ", "network": " ", "subnet": " ", "tags": []string{"", ""}, "rootGB": int64(-1), "sshCIDRs": []string{"", ""}, "serviceAccount": " "}, text: "gcp project=  zone=  image=  network=  subnet=  root_gb=-1 ssh_cidrs=,\n"},
+	} {
+		for _, selected := range []string{"gcp", "static"} {
+			t.Run(tc.name+"/"+selected, func(t *testing.T) {
+				cfg := tc.input
+				cfg.Provider = selected
+				before := cfg
+				before.GCPTags = slices.Clone(cfg.GCPTags)
+				before.GCPSSHCIDRs = slices.Clone(cfg.GCPSSHCIDRs)
+				section := projector.ConfigShowSection(cfg)
+				if section.JSONKey != "gcp" || section.TextLabel != "gcp" || !reflect.DeepEqual(section.Providers, []string{"gcp"}) {
+					t.Fatalf("section metadata=%#v", section)
+				}
+				wantOrder := []string{"project", "zone", "image", "network", "subnet", "tags", "rootGB", "sshCIDRs", "serviceAccount"}
+				if len(section.Fields) != len(wantOrder) {
+					t.Fatalf("field count=%d want %d", len(section.Fields), len(wantOrder))
+				}
+				got := map[string]any{}
+				line := section.TextLabel
+				for i, field := range section.Fields {
+					if field.JSONName != wantOrder[i] {
+						t.Fatalf("field %d name=%q want %q", i, field.JSONName, wantOrder[i])
+					}
+					got[field.JSONName] = field.JSONValue
+					if field.TextName != "" {
+						line += " " + field.TextName + "=" + field.TextValue
+					}
+				}
+				line += "\n"
+				if !reflect.DeepEqual(got, tc.want) {
+					t.Fatalf("public fields=%#v want %#v", got, tc.want)
+				}
+				if line != tc.text {
+					t.Fatalf("text=%q want %q", line, tc.text)
+				}
+				if !reflect.DeepEqual(cfg, before) {
+					t.Fatal("projection mutated supplied configuration")
+				}
+			})
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Move the complete existing AWS, Azure and GCP value projections into their provider adapters: 24 JSON fields and 17 text fields. Remove the three core JSON maps and text formatters together, retire their legacy labels and retain the exact layout slots.

Seven fields remain JSON-only. AWS disk size stays int32, GCP disk size stays int64, and lists retain nil/empty distinctions, order, duplicates and comma-joined text. Empty-only text fallbacks and raw references remain unchanged. IAM instance-profile and service-account names are configuration references, not credential contents; no SDK, environment, file, authentication or readiness discovery is added.

AWS stays after the optional `jobs=` line (after `cache` when jobs are absent) and before AWS Lambda MicroVM. Azure and GCP retain their existing neighbors. Generic duration/job tests remain unchanged. Architecture docs track the remaining legacy ownership work; this is an output-preserving refactor, not a new user-visible value section.

## Verification

- Immutable baseline characterization passed all three complete field tables and 24 selected/unselected subcases. Missing-projector checks produced exactly three expected failures; candidate provider tests passed.
- Broader config-show verification passed 64 tests and 125 subtests with the race detector and no skips. Full Go vet, docs checks and whitespace checks passed. Managed Codex review passed at P0 scope.
- Eight actual built-CLI comparisons passed complete stdout/stderr/exit byte parity, with no output removal, normalization or JSON reserialization. Synthetic scenarios cover defaults, all configured fields, list states, zero/raw values and admitted integer widths; native executables and network access were unavailable.
- The initial position oracles incorrectly treated the jobs line as unconditional or space-delimited. Their failures are preserved. The correction follows unchanged source: `jobs=` is conditional. Both already-successful baseline CLI captures were retained and requalified; only the six never-executed cases then ran. No captured baseline call was rerun.

Baseline source: `4c3cd7a5c0d8110061129ce131ee4fefb19ec0d7`; baseline binary SHA-256: `5151b6c13cf7b6707ec82ac1fcb47fa7ebba31e220a28f72b63e03be80143ea4`; candidate: `443694e4314ae445aac8714d8f699d133b040500e7d3549b6bd922014bb368fe`.

These checks verify offline configuration display, not cloud credentials, resource provisioning or native provider execution. Existing source-application normalization remains separate from pure raw-value projection tests.

## Recorded CLI output

The following is extracted from the saved synthetic populated-fixture execution of `crabbox config show --provider xcp-ng`. These are the three changed provider lines, not the full output; the comparison itself checked every output byte. No provider execution or cloud credentials were used.

```text
aws region=eu-west-1 root_gb=123 ssh_cidrs=192.0.2.0/24,192.0.2.0/24
azure location=eastus resource_group=display-group os_disk=managed snapshot_sku=Standard_LRS os_disk_sku=StandardSSD_LRS network=private ssh_cidrs=198.51.100.0/24,198.51.100.0/24
gcp project=display-project zone=europe-west2-a image=display-image network=display-network subnet=display-subnet root_gb=234 ssh_cidrs=203.0.113.0/24,203.0.113.0/24
```

Rechecking the original saved baseline and candidate byte captures produced:

```text
01-defaults-json: stdout/stderr identical; stdout SHA-256 c5885df1e83d04f0048cd587b2b54e9746f88cc81fb8f24086acaa0f8e7a7c74
02-defaults-text: stdout/stderr identical; stdout SHA-256 0d6a541e48cbbd6ff3efc887ae3c3aa8f2f13b2e3ad6b4757c88694e3d0dd7f5
03-full-populated-json: stdout/stderr identical; stdout SHA-256 39e35173d20344ab7e1ea2d93e25d09acb0dcd7c07552d446a0e4b93693db3a1
04-full-populated-text: stdout/stderr identical; stdout SHA-256 5d21617c82470f8cac5679a2bee6829b86ec27e21fa91b0bdbf217f0f376da9d
05-empty-zero-lists-json: stdout/stderr identical; stdout SHA-256 223e2e32aa8c192ada747cb2d0964176124f06c0551ee656a50a3edac227319e
06-empty-zero-lists-text: stdout/stderr identical; stdout SHA-256 2b29bc589a4f9787d95e88f1f10e8d7c56bdc80907d0e55717c4a8680a33ce7b
07-raw-intwidth-json: stdout/stderr identical; stdout SHA-256 e70e99c27a53e7b16dcaa3ea942d3be2a10f5dc9f7b9a320fde72bff2c316ac5
08-raw-intwidth-text: stdout/stderr identical; stdout SHA-256 57e19734c0e67c77d1128043c67aa81121ea02a435d6d897cdb6a1777671cfb6
```
