### PR TITLE
refactor(config): move VPS provider displays into adapters

### DIFF
--- a/docs/refactor/provider-config-display.md
+++ b/docs/refactor/provider-config-display.md
@@ -56,6 +56,12 @@ either backend's runtime defaults. MXC retains JSON lists with text counts,
 Docker Sandbox retains JSON lists with comma-joined text and `%g` CPU formatting,
 and nil versus empty lists remain distinct. Internal-only fields stay omitted.
 
+DigitalOcean, Vultr and Linode own all 17 of their existing JSON/text fields.
+Their consecutive sections remain between Azure and GitHub Codespaces. The
+projectors retain raw boot selectors and list shapes without resolving images,
+applying SSH defaults or discovering authentication. Selected-provider defaults
+and explicit SSH settings remain the existing configuration loader's concern.
+
 ## Remaining migration
 
 The baseline census contains 81 canonical providers: 49 have both value formats,
@@ -68,8 +74,8 @@ sections**. They do not complete the migration. Existing provider projections
 also still need to move out of the parallel JSON map and text formatter so
 their field selection and transformations have one owner.
 
-The Multipass/Tart/Lume and local-container cohorts remove eight of the original
-49 canonical both-format providers from that legacy implementation, leaving 41
+The Multipass/Tart/Lume, local-container and VPS cohorts remove eleven of the original
+49 canonical both-format providers from that legacy implementation, leaving 38
 in that cohort. The local cohort covers five identities through four sections
 because Apple Machine shares Apple Container's values. These migrations do not
 fill any of the missing sections above.

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -240,29 +240,6 @@ func configShowView(cfg Config) map[string]any {
 			"network":       cfg.AzureNetwork,
 			"sshCIDRs":      cfg.AzureSSHCIDRs,
 		},
-		"digitalocean": map[string]any{
-			"region":   cfg.DigitalOcean.Region,
-			"image":    cfg.DigitalOcean.Image,
-			"vpc":      cfg.DigitalOcean.VPCUUID,
-			"sshCIDRs": cfg.DigitalOcean.SSHCIDRs,
-		},
-		"vultr": map[string]any{
-			"region":        cfg.Vultr.Region,
-			"os":            cfg.Vultr.OS,
-			"image":         cfg.Vultr.Image,
-			"snapshot":      cfg.Vultr.Snapshot,
-			"firewallGroup": cfg.Vultr.FirewallGroup,
-			"vpcIds":        cfg.Vultr.VPCIDs,
-			"sshCIDRs":      cfg.Vultr.SSHCIDRs,
-			"userScheme":    cfg.Vultr.UserScheme,
-		},
-		"linode": map[string]any{
-			"region":   cfg.Linode.Region,
-			"image":    cfg.Linode.Image,
-			"type":     cfg.Linode.Type,
-			"firewall": cfg.Linode.FirewallID,
-			"sshCIDRs": cfg.Linode.SSHCIDRs,
-		},
 		"githubCodespaces": map[string]any{
 			"apiUrl":           redactedConfigURL(cfg.GitHubCodespaces.APIURL),
 			"ghPath":           cfg.GitHubCodespaces.GHPath,
@@ -846,9 +823,15 @@ func writeConfigShowText(w io.Writer, cfg Config) error {
 	fmt.Fprintf(w, "aws region=%s root_gb=%d ssh_cidrs=%s\n", cfg.AWSRegion, cfg.AWSRootGB, blank(strings.Join(cfg.AWSSSHCIDRs, ","), "-"))
 	fmt.Fprintf(w, "aws_lambda_microvm image=%s image_version=%s workdir=%s forget_missing=%t\n", blank(cfg.AWSLambdaMicroVM.Image, "-"), blank(cfg.AWSLambdaMicroVM.ImageVersion, "latest"), cfg.AWSLambdaMicroVM.Workdir, cfg.AWSLambdaMicroVM.ForgetMissing)
 	fmt.Fprintf(w, "azure location=%s resource_group=%s os_disk=%s snapshot_sku=%s os_disk_sku=%s network=%s ssh_cidrs=%s\n", cfg.AzureLocation, cfg.AzureResourceGroup, cfg.AzureOSDisk, blank(cfg.AzureSnapshotSKU, "-"), blank(cfg.AzureOSDiskSKU, "-"), blank(cfg.AzureNetwork, "-"), blank(strings.Join(cfg.AzureSSHCIDRs, ","), "-"))
-	fmt.Fprintf(w, "digitalocean region=%s image=%s vpc=%s ssh_cidrs=%s\n", cfg.DigitalOcean.Region, cfg.DigitalOcean.Image, blank(cfg.DigitalOcean.VPCUUID, "-"), blank(strings.Join(cfg.DigitalOcean.SSHCIDRs, ","), "-"))
-	fmt.Fprintf(w, "vultr region=%s os=%s image=%s snapshot=%s firewall_group=%s vpc_ids=%s ssh_cidrs=%s user_scheme=%s\n", cfg.Vultr.Region, blank(cfg.Vultr.OS, "-"), blank(cfg.Vultr.Image, "-"), blank(cfg.Vultr.Snapshot, "-"), blank(cfg.Vultr.FirewallGroup, "-"), blank(strings.Join(cfg.Vultr.VPCIDs, ","), "-"), blank(strings.Join(cfg.Vultr.SSHCIDRs, ","), "-"), blank(cfg.Vultr.UserScheme, "-"))
-	fmt.Fprintf(w, "linode region=%s image=%s type=%s firewall=%s ssh_cidrs=%s\n", cfg.Linode.Region, cfg.Linode.Image, cfg.Linode.Type, blank(cfg.Linode.FirewallID, "-"), blank(strings.Join(cfg.Linode.SSHCIDRs, ","), "-"))
+	if err := layout.writeSlot(w, "digitalocean"); err != nil {
+		return err
+	}
+	if err := layout.writeSlot(w, "vultr"); err != nil {
+		return err
+	}
+	if err := layout.writeSlot(w, "linode"); err != nil {
+		return err
+	}
 	fmt.Fprintf(w, "github_codespaces api_url=%s gh_path=%s repo=%s ref=%s machine=%s devcontainer_path=%s working_directory=%s geo=%s idle_timeout=%s retention_period=%s delete_on_release=%t work_root=%s auth_mode=cli auth_status=unchecked readiness=unchecked\n", blank(redactedConfigURL(cfg.GitHubCodespaces.APIURL), "-"), blank(cfg.GitHubCodespaces.GHPath, "-"), blank(cfg.GitHubCodespaces.Repo, "-"), blank(cfg.GitHubCodespaces.Ref, "-"), blank(cfg.GitHubCodespaces.Machine, "-"), blank(cfg.GitHubCodespaces.DevcontainerPath, "-"), blank(cfg.GitHubCodespaces.WorkingDirectory, "-"), blank(cfg.GitHubCodespaces.Geo, "-"), cfg.GitHubCodespaces.IdleTimeout, cfg.GitHubCodespaces.RetentionPeriod, cfg.GitHubCodespaces.DeleteOnRelease, blank(cfg.GitHubCodespaces.WorkRoot, "-"))
 	fmt.Fprintf(w, "lambda region=%s type=%s image=%s image_family=%s firewall_ruleset=%s ssh_cidrs=%s filesystems=%s mounts=%d auth=%s\n", cfg.Lambda.Region, cfg.Lambda.Type, blank(cfg.Lambda.Image, "-"), blank(cfg.Lambda.ImageFamily, "-"), blank(cfg.Lambda.FirewallRuleset, "-"), blank(strings.Join(cfg.Lambda.SSHCIDRs, ","), "-"), blank(strings.Join(cfg.Lambda.FilesystemNames, ","), "-"), len(cfg.Lambda.FilesystemMounts), lambdaAuthState())
 	fmt.Fprintf(w, "vast api_url=%s instance_type=%s gpu_name=%s gpu_count=%d image=%s template_id=%s runtype=%s disk_gb=%d max_dph_total=%.4g min_reliability=%.4g order=%s user=%s work_root=%s release_action=%s auth=%s\n", blank(redactedConfigURL(cfg.Vast.APIURL), "-"), blank(cfg.Vast.InstanceType, "-"), blank(cfg.Vast.GPUName, "-"), cfg.Vast.GPUCount, blank(cfg.Vast.Image, "-"), blank(cfg.Vast.TemplateID, "-"), blank(cfg.Vast.Runtype, "-"), cfg.Vast.DiskGB, cfg.Vast.MaxDphTotal, cfg.Vast.MinReliability, blank(cfg.Vast.Order, "-"), blank(cfg.Vast.User, "-"), blank(cfg.Vast.WorkRoot, "-"), blank(cfg.Vast.ReleaseAction, "-"), tokenState(cfg.Vast.APIKey))

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -1602,9 +1602,27 @@ func TestConfigShowIncludesDigitalOceanProviderConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	binary, err := builtCLITestBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
 	var stdout bytes.Buffer
-	app := App{Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	if err := app.configShow(nil); err != nil {
+	runShow := func(args []string) error {
+		cmd := exec.CommandContext(t.Context(), binary, append([]string{"config", "show"}, args...)...)
+		cmd.Dir = home
+		cmd.Env = []string{"HOME=" + home, "USERPROFILE=" + home, "APPDATA=" + home, "XDG_CONFIG_HOME=" + home, "XDG_STATE_HOME=" + home, "CRABBOX_CONFIG=" + configPath, "PATH=" + t.TempDir()}
+		var stderr bytes.Buffer
+		cmd.Stdout, cmd.Stderr = &stdout, &stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("config show: %w: %s", err, &stderr)
+		}
+		if stderr.Len() != 0 {
+			return fmt.Errorf("config show stderr: %s", &stderr)
+		}
+		return nil
+	}
+	if err := runShow(nil); err != nil {
 		t.Fatal(err)
 	}
 	text := stdout.String()
@@ -1616,7 +1634,7 @@ func TestConfigShowIncludesDigitalOceanProviderConfig(t *testing.T) {
 	}
 
 	stdout.Reset()
-	if err := app.configShow([]string{"--json"}); err != nil {
+	if err := runShow([]string{"--json"}); err != nil {
 		t.Fatal(err)
 	}
 	var got struct {
@@ -1651,9 +1669,27 @@ func TestConfigShowIncludesVultrProviderConfigWithoutSecret(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	binary, err := builtCLITestBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
 	var stdout bytes.Buffer
-	app := App{Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	if err := app.configShow(nil); err != nil {
+	runShow := func(args []string) error {
+		cmd := exec.CommandContext(t.Context(), binary, append([]string{"config", "show"}, args...)...)
+		cmd.Dir = home
+		cmd.Env = []string{"HOME=" + home, "USERPROFILE=" + home, "APPDATA=" + home, "XDG_CONFIG_HOME=" + home, "XDG_STATE_HOME=" + home, "CRABBOX_CONFIG=" + configPath, "PATH=" + t.TempDir(), "VULTR_API_KEY=" + os.Getenv("VULTR_API_KEY")}
+		var stderr bytes.Buffer
+		cmd.Stdout, cmd.Stderr = &stdout, &stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("config show: %w: %s", err, &stderr)
+		}
+		if stderr.Len() != 0 {
+			return fmt.Errorf("config show stderr: %s", &stderr)
+		}
+		return nil
+	}
+	if err := runShow(nil); err != nil {
 		t.Fatal(err)
 	}
 	text := stdout.String()
@@ -1668,7 +1704,7 @@ func TestConfigShowIncludesVultrProviderConfigWithoutSecret(t *testing.T) {
 	}
 
 	stdout.Reset()
-	if err := app.configShow([]string{"--json"}); err != nil {
+	if err := runShow([]string{"--json"}); err != nil {
 		t.Fatal(err)
 	}
 	var got struct {

--- a/internal/cli/config_show_projection.go
+++ b/internal/cli/config_show_projection.go
@@ -36,7 +36,7 @@ func ConfigShowSecretState(value string) string { return tokenState(value) }
 
 // Names only: no legacy value projection or environment reads are needed to
 // protect existing text slots. Retire a name only when its legacy row migrates.
-const legacyConfigShowTextLabels = "config provider lease broker access_auth ssh sync env run capacity actions blacksmith agent_sandbox phala namespace namespace_instance morph e2b cubesandbox upstash_box smolvm blaxel nomad ascii_box superserve machine0 cloudflare fastapi_cloud cloudflare_dynamic_workers cloudflare_sandbox static results cache jobs aws aws_lambda_microvm azure digitalocean vultr linode github_codespaces lambda vast nvidia_brev nebius hostinger ovh scaleway tencentcloud azure_dynamic_sessions gcp proxmox firecracker xcp_ng parallels inspection provider_status"
+const legacyConfigShowTextLabels = "config provider lease broker access_auth ssh sync env run capacity actions blacksmith agent_sandbox phala namespace namespace_instance morph e2b cubesandbox upstash_box smolvm blaxel nomad ascii_box superserve machine0 cloudflare fastapi_cloud cloudflare_dynamic_workers cloudflare_sandbox static results cache jobs aws aws_lambda_microvm azure github_codespaces lambda vast nvidia_brev nebius hostinger ovh scaleway tencentcloud azure_dynamic_sessions gcp proxmox firecracker xcp_ng parallels inspection provider_status"
 
 func collectProviderConfigShowSections(cfg Config) ([]ProviderConfigShowSection, error) {
 	return collectProviderConfigShowSectionsFrom(cfg, registeredProviders())

--- a/internal/cli/config_show_projection_test.go
+++ b/internal/cli/config_show_projection_test.go
@@ -235,13 +235,13 @@ func TestConfigShowLegacySlotPositions(t *testing.T) {
 			order = append(order, value)
 		} else if sel.Sel.Name == "Fprintf" {
 			name := strings.SplitN(value, " ", 2)[0]
-			if name == "superserve" || name == "local_container" || name == "apple_container" || name == "mxc" || name == "docker_sandbox" || name == "machine0" || name == "cloudflare" {
+			if name == "superserve" || name == "local_container" || name == "apple_container" || name == "mxc" || name == "docker_sandbox" || name == "machine0" || name == "cloudflare" || name == "azure" || name == "digitalocean" || name == "vultr" || name == "linode" || name == "github_codespaces" {
 				order = append(order, name)
 			}
 		}
 		return true
 	})
-	if got := strings.Join(order, ","); got != "superserve,local_container,apple_container,mxc,docker_sandbox,multipass,machine0,tart,lume,cloudflare" {
+	if got := strings.Join(order, ","); got != "superserve,local_container,apple_container,mxc,docker_sandbox,multipass,machine0,tart,lume,cloudflare,azure,digitalocean,vultr,linode,github_codespaces" {
 		t.Fatalf("legacy text slot positions: %s", got)
 	}
 }
@@ -250,9 +250,9 @@ func TestConfigShowTextLayoutConsumesSlotsOnce(t *testing.T) {
 	section := func(label string) ProviderConfigShowSection {
 		return ProviderConfigShowSection{TextLabel: label, Fields: []ProviderConfigShowField{{TextName: "value", TextValue: label}}}
 	}
-	layout := newConfigShowTextLayout([]ProviderConfigShowSection{section("alpha"), section("lume"), section("multipass"), section("tart"), section("zeta"), section("docker_sandbox"), section("mxc"), section("apple_container"), section("local_container")})
+	layout := newConfigShowTextLayout([]ProviderConfigShowSection{section("alpha"), section("lume"), section("multipass"), section("tart"), section("zeta"), section("docker_sandbox"), section("mxc"), section("apple_container"), section("local_container"), section("digitalocean"), section("vultr"), section("linode")})
 	var out bytes.Buffer
-	for _, label := range []string{"absent", "local_container", "apple_container", "mxc", "docker_sandbox", "local_container", "apple_container", "mxc", "docker_sandbox", "multipass", "multipass", "tart", "lume"} {
+	for _, label := range []string{"absent", "local_container", "apple_container", "mxc", "docker_sandbox", "local_container", "apple_container", "mxc", "docker_sandbox", "multipass", "multipass", "tart", "lume", "digitalocean", "vultr", "linode", "digitalocean", "vultr", "linode"} {
 		if err := layout.writeSlot(&out, label); err != nil {
 			t.Fatal(err)
 		}
@@ -260,7 +260,7 @@ func TestConfigShowTextLayoutConsumesSlotsOnce(t *testing.T) {
 	if err := layout.writeRemaining(&out); err != nil {
 		t.Fatal(err)
 	}
-	if got, want := out.String(), "local_container value=local_container\napple_container value=apple_container\nmxc value=mxc\ndocker_sandbox value=docker_sandbox\nmultipass value=multipass\ntart value=tart\nlume value=lume\nalpha value=alpha\nzeta value=zeta\n"; got != want {
+	if got, want := out.String(), "local_container value=local_container\napple_container value=apple_container\nmxc value=mxc\ndocker_sandbox value=docker_sandbox\nmultipass value=multipass\ntart value=tart\nlume value=lume\ndigitalocean value=digitalocean\nvultr value=vultr\nlinode value=linode\nalpha value=alpha\nzeta value=zeta\n"; got != want {
 		t.Fatalf("slot order/duplication got %q want %q", got, want)
 	}
 	out.Reset()
@@ -359,6 +359,20 @@ func TestConfigShowLocalCohortLegacyOwnershipRetired(t *testing.T) {
 		for _, reserved := range strings.Fields(legacyConfigShowTextLabels) {
 			if reserved == label {
 				t.Errorf("migrated label %s still reserved as legacy", label)
+			}
+		}
+	}
+}
+
+func TestConfigShowVPSCohortLegacyOwnershipRetired(t *testing.T) {
+	view := configShowView(Config{})
+	for _, name := range []string{"digitalocean", "vultr", "linode"} {
+		if _, exists := view[name]; exists {
+			t.Errorf("core still owns %s values", name)
+		}
+		for _, reserved := range strings.Fields(legacyConfigShowTextLabels) {
+			if reserved == name {
+				t.Errorf("migrated label %s still reserved as legacy", name)
 			}
 		}
 	}

--- a/internal/providers/digitalocean/backend_test.go
+++ b/internal/providers/digitalocean/backend_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -3733,4 +3734,59 @@ func (c fixedClock) Now() time.Time { return c.t }
 
 func TestMain(m *testing.M) {
 	os.Exit(testutil.RunWithIsolatedUserDirs(m))
+}
+
+func TestDigitalOceanConfigShowCompletePassiveSection(t *testing.T) {
+	projector, ok := any(Provider{}).(core.ProviderConfigShowProjector)
+	if !ok {
+		t.Fatal("actual provider has no passive config-show projector")
+	}
+	for _, tc := range []struct {
+		name  string
+		input core.DigitalOceanConfig
+		want  map[string]any
+		text  string
+	}{
+		{name: "nil", input: core.DigitalOceanConfig{}, want: map[string]any{"region": "", "image": "", "vpc": "", "sshCIDRs": []string(nil)}, text: "digitalocean region= image= vpc=- ssh_cidrs=-\n"},
+		{name: "empty", input: core.DigitalOceanConfig{SSHCIDRs: []string{}}, want: map[string]any{"region": "", "image": "", "vpc": "", "sshCIDRs": []string{}}, text: "digitalocean region= image= vpc=- ssh_cidrs=-\n"},
+		{name: "raw-references-list", input: core.DigitalOceanConfig{Region: "raw-region", Image: "image reference", VPCUUID: "vpc reference", SSHCIDRs: []string{"second", "first", "second", " "}}, want: map[string]any{"region": "raw-region", "image": "image reference", "vpc": "vpc reference", "sshCIDRs": []string{"second", "first", "second", " "}}, text: "digitalocean region=raw-region image=image reference vpc=vpc reference ssh_cidrs=second,first,second, \n"},
+		{name: "whitespace-empty-elements", input: core.DigitalOceanConfig{Region: " ", Image: " ", VPCUUID: " ", SSHCIDRs: []string{"", ""}}, want: map[string]any{"region": " ", "image": " ", "vpc": " ", "sshCIDRs": []string{"", ""}}, text: "digitalocean region=  image=  vpc=  ssh_cidrs=,\n"},
+	} {
+		for _, selected := range []string{"digitalocean", "static"} {
+			t.Run(tc.name+"/"+selected, func(t *testing.T) {
+				cfg := core.Config{Provider: selected, DigitalOcean: tc.input}
+				before := cfg.DigitalOcean
+				before.SSHCIDRs = slices.Clone(cfg.DigitalOcean.SSHCIDRs)
+				section := projector.ConfigShowSection(cfg)
+				if section.JSONKey != "digitalocean" || section.TextLabel != "digitalocean" || !reflect.DeepEqual(section.Providers, []string{"digitalocean"}) {
+					t.Fatalf("section metadata=%#v", section)
+				}
+				wantOrder := []string{"region", "image", "vpc", "sshCIDRs"}
+				if len(section.Fields) != len(wantOrder) {
+					t.Fatalf("field count=%d want %d", len(section.Fields), len(wantOrder))
+				}
+				got := map[string]any{}
+				line := section.TextLabel
+				for i, field := range section.Fields {
+					if field.JSONName != wantOrder[i] {
+						t.Fatalf("field %d name=%q want %q", i, field.JSONName, wantOrder[i])
+					}
+					got[field.JSONName] = field.JSONValue
+					if field.TextName != "" {
+						line += " " + field.TextName + "=" + field.TextValue
+					}
+				}
+				line += "\n"
+				if !reflect.DeepEqual(got, tc.want) {
+					t.Fatalf("public fields=%#v want %#v", got, tc.want)
+				}
+				if line != tc.text {
+					t.Fatalf("text=%q want %q", line, tc.text)
+				}
+				if !reflect.DeepEqual(cfg.DigitalOcean, before) {
+					t.Fatal("projection mutated supplied configuration")
+				}
+			})
+		}
+	}
 }

--- a/internal/providers/digitalocean/config_show.go
+++ b/internal/providers/digitalocean/config_show.go
@@ -1,0 +1,21 @@
+package digitalocean
+
+import (
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// ConfigShowSection preserves the loaded provider values without applying defaults.
+func (Provider) ConfigShowSection(cfg core.Config) core.ProviderConfigShowSection {
+	c := cfg.DigitalOcean
+	return core.ProviderConfigShowSection{
+		JSONKey: "digitalocean", TextLabel: "digitalocean", Providers: []string{"digitalocean"},
+		Fields: []core.ProviderConfigShowField{
+			{JSONName: "region", JSONValue: c.Region, TextName: "region", TextValue: c.Region},
+			{JSONName: "image", JSONValue: c.Image, TextName: "image", TextValue: c.Image},
+			{JSONName: "vpc", JSONValue: c.VPCUUID, TextName: "vpc", TextValue: core.Blank(c.VPCUUID, "-")},
+			{JSONName: "sshCIDRs", JSONValue: c.SSHCIDRs, TextName: "ssh_cidrs", TextValue: core.Blank(strings.Join(c.SSHCIDRs, ","), "-")},
+		},
+	}
+}

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"os"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -1536,5 +1537,60 @@ func TestRollbackCleanupClaimResolvesWithSnapshotAndReleases(t *testing.T) {
 	}
 	if _, err := os.Stat(keyPath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("stored key retained after rollback cleanup: %v", err)
+	}
+}
+
+func TestLinodeConfigShowCompletePassiveSection(t *testing.T) {
+	projector, ok := any(Provider{}).(core.ProviderConfigShowProjector)
+	if !ok {
+		t.Fatal("actual provider has no passive config-show projector")
+	}
+	for _, tc := range []struct {
+		name  string
+		input core.LinodeConfig
+		want  map[string]any
+		text  string
+	}{
+		{name: "nil", input: core.LinodeConfig{}, want: map[string]any{"region": "", "image": "", "type": "", "firewall": "", "sshCIDRs": []string(nil)}, text: "linode region= image= type= firewall=- ssh_cidrs=-\n"},
+		{name: "empty", input: core.LinodeConfig{SSHCIDRs: []string{}}, want: map[string]any{"region": "", "image": "", "type": "", "firewall": "", "sshCIDRs": []string{}}, text: "linode region= image= type= firewall=- ssh_cidrs=-\n"},
+		{name: "raw-references-list", input: core.LinodeConfig{Region: "raw-region", Image: "image reference", Type: "raw-type", FirewallID: "firewall reference", SSHCIDRs: []string{"second", "first", "second", " "}}, want: map[string]any{"region": "raw-region", "image": "image reference", "type": "raw-type", "firewall": "firewall reference", "sshCIDRs": []string{"second", "first", "second", " "}}, text: "linode region=raw-region image=image reference type=raw-type firewall=firewall reference ssh_cidrs=second,first,second, \n"},
+		{name: "whitespace-empty-elements", input: core.LinodeConfig{Region: " ", Image: " ", Type: " ", FirewallID: " ", SSHCIDRs: []string{"", ""}}, want: map[string]any{"region": " ", "image": " ", "type": " ", "firewall": " ", "sshCIDRs": []string{"", ""}}, text: "linode region=  image=  type=  firewall=  ssh_cidrs=,\n"},
+	} {
+		for _, selected := range []string{"linode", "static"} {
+			t.Run(tc.name+"/"+selected, func(t *testing.T) {
+				cfg := core.Config{Provider: selected, Linode: tc.input}
+				before := cfg.Linode
+				before.SSHCIDRs = slices.Clone(cfg.Linode.SSHCIDRs)
+				section := projector.ConfigShowSection(cfg)
+				if section.JSONKey != "linode" || section.TextLabel != "linode" || !reflect.DeepEqual(section.Providers, []string{"linode"}) {
+					t.Fatalf("section metadata=%#v", section)
+				}
+				wantOrder := []string{"region", "image", "type", "firewall", "sshCIDRs"}
+				if len(section.Fields) != len(wantOrder) {
+					t.Fatalf("field count=%d want %d", len(section.Fields), len(wantOrder))
+				}
+				got := map[string]any{}
+				line := section.TextLabel
+				for i, field := range section.Fields {
+					if field.JSONName != wantOrder[i] {
+						t.Fatalf("field %d name=%q want %q", i, field.JSONName, wantOrder[i])
+					}
+					got[field.JSONName] = field.JSONValue
+					if field.TextName != "" {
+						line += " " + field.TextName + "=" + field.TextValue
+					}
+				}
+				line += "\n"
+				if !reflect.DeepEqual(got, tc.want) {
+					t.Fatalf("public fields=%#v want %#v", got, tc.want)
+				}
+				if line != tc.text {
+					t.Fatalf("text=%q want %q", line, tc.text)
+				}
+				if !reflect.DeepEqual(cfg.Linode, before) {
+					t.Fatal("projection mutated supplied configuration")
+				}
+			})
+		}
 	}
 }

--- a/internal/providers/linode/config_show.go
+++ b/internal/providers/linode/config_show.go
@@ -1,0 +1,22 @@
+package linode
+
+import (
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// ConfigShowSection reports the existing fields without image or SSH resolution.
+func (Provider) ConfigShowSection(cfg core.Config) core.ProviderConfigShowSection {
+	c := cfg.Linode
+	return core.ProviderConfigShowSection{
+		JSONKey: "linode", TextLabel: "linode", Providers: []string{"linode"},
+		Fields: []core.ProviderConfigShowField{
+			{JSONName: "region", JSONValue: c.Region, TextName: "region", TextValue: c.Region},
+			{JSONName: "image", JSONValue: c.Image, TextName: "image", TextValue: c.Image},
+			{JSONName: "type", JSONValue: c.Type, TextName: "type", TextValue: c.Type},
+			{JSONName: "firewall", JSONValue: c.FirewallID, TextName: "firewall", TextValue: core.Blank(c.FirewallID, "-")},
+			{JSONName: "sshCIDRs", JSONValue: c.SSHCIDRs, TextName: "ssh_cidrs", TextValue: core.Blank(strings.Join(c.SSHCIDRs, ","), "-")},
+		},
+	}
+}

--- a/internal/providers/vultr/backend_test.go
+++ b/internal/providers/vultr/backend_test.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1771,4 +1772,60 @@ func attachCurrentVultrClaim(t *testing.T, server *core.Server, leaseID string) 
 	}
 	core.SetServerLeaseClaimSnapshot(server, claim, true)
 	return claim
+}
+
+func TestVultrConfigShowCompletePassiveSection(t *testing.T) {
+	projector, ok := any(Provider{}).(core.ProviderConfigShowProjector)
+	if !ok {
+		t.Fatal("actual provider has no passive config-show projector")
+	}
+	for _, tc := range []struct {
+		name  string
+		input core.VultrConfig
+		want  map[string]any
+		text  string
+	}{
+		{name: "nil", input: core.VultrConfig{}, want: map[string]any{"region": "", "os": "", "image": "", "snapshot": "", "firewallGroup": "", "vpcIds": []string(nil), "sshCIDRs": []string(nil), "userScheme": ""}, text: "vultr region= os=- image=- snapshot=- firewall_group=- vpc_ids=- ssh_cidrs=- user_scheme=-\n"},
+		{name: "empty", input: core.VultrConfig{VPCIDs: []string{}, SSHCIDRs: []string{}}, want: map[string]any{"region": "", "os": "", "image": "", "snapshot": "", "firewallGroup": "", "vpcIds": []string{}, "sshCIDRs": []string{}, "userScheme": ""}, text: "vultr region= os=- image=- snapshot=- firewall_group=- vpc_ids=- ssh_cidrs=- user_scheme=-\n"},
+		{name: "simultaneous-raw-boot-strings", input: core.VultrConfig{Region: "raw-region", OS: "002284", Image: "image reference", Snapshot: "snapshot reference", FirewallGroup: "firewall reference", VPCIDs: []string{"last", "first", "last", " "}, SSHCIDRs: []string{"second", "first", "second", " "}, UserScheme: "raw-scheme"}, want: map[string]any{"region": "raw-region", "os": "002284", "image": "image reference", "snapshot": "snapshot reference", "firewallGroup": "firewall reference", "vpcIds": []string{"last", "first", "last", " "}, "sshCIDRs": []string{"second", "first", "second", " "}, "userScheme": "raw-scheme"}, text: "vultr region=raw-region os=002284 image=image reference snapshot=snapshot reference firewall_group=firewall reference vpc_ids=last,first,last,  ssh_cidrs=second,first,second,  user_scheme=raw-scheme\n"},
+		{name: "whitespace-empty-elements", input: core.VultrConfig{Region: " ", OS: " ", Image: " ", Snapshot: " ", FirewallGroup: " ", VPCIDs: []string{"", ""}, SSHCIDRs: []string{"", ""}, UserScheme: " "}, want: map[string]any{"region": " ", "os": " ", "image": " ", "snapshot": " ", "firewallGroup": " ", "vpcIds": []string{"", ""}, "sshCIDRs": []string{"", ""}, "userScheme": " "}, text: "vultr region=  os=  image=  snapshot=  firewall_group=  vpc_ids=, ssh_cidrs=, user_scheme= \n"},
+	} {
+		for _, selected := range []string{"vultr", "static"} {
+			t.Run(tc.name+"/"+selected, func(t *testing.T) {
+				cfg := core.Config{Provider: selected, Vultr: tc.input}
+				before := cfg.Vultr
+				before.VPCIDs = slices.Clone(cfg.Vultr.VPCIDs)
+				before.SSHCIDRs = slices.Clone(cfg.Vultr.SSHCIDRs)
+				section := projector.ConfigShowSection(cfg)
+				if section.JSONKey != "vultr" || section.TextLabel != "vultr" || !reflect.DeepEqual(section.Providers, []string{"vultr"}) {
+					t.Fatalf("section metadata=%#v", section)
+				}
+				wantOrder := []string{"region", "os", "image", "snapshot", "firewallGroup", "vpcIds", "sshCIDRs", "userScheme"}
+				if len(section.Fields) != len(wantOrder) {
+					t.Fatalf("field count=%d want %d", len(section.Fields), len(wantOrder))
+				}
+				got := map[string]any{}
+				line := section.TextLabel
+				for i, field := range section.Fields {
+					if field.JSONName != wantOrder[i] {
+						t.Fatalf("field %d name=%q want %q", i, field.JSONName, wantOrder[i])
+					}
+					got[field.JSONName] = field.JSONValue
+					if field.TextName != "" {
+						line += " " + field.TextName + "=" + field.TextValue
+					}
+				}
+				line += "\n"
+				if !reflect.DeepEqual(got, tc.want) {
+					t.Fatalf("public fields=%#v want %#v", got, tc.want)
+				}
+				if line != tc.text {
+					t.Fatalf("text=%q want %q", line, tc.text)
+				}
+				if !reflect.DeepEqual(cfg.Vultr, before) {
+					t.Fatal("projection mutated supplied configuration")
+				}
+			})
+		}
+	}
 }

--- a/internal/providers/vultr/config_show.go
+++ b/internal/providers/vultr/config_show.go
@@ -1,0 +1,25 @@
+package vultr
+
+import (
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// ConfigShowSection keeps independent boot selectors and raw list shapes visible.
+func (Provider) ConfigShowSection(cfg core.Config) core.ProviderConfigShowSection {
+	c := cfg.Vultr
+	return core.ProviderConfigShowSection{
+		JSONKey: "vultr", TextLabel: "vultr", Providers: []string{"vultr"},
+		Fields: []core.ProviderConfigShowField{
+			{JSONName: "region", JSONValue: c.Region, TextName: "region", TextValue: c.Region},
+			{JSONName: "os", JSONValue: c.OS, TextName: "os", TextValue: core.Blank(c.OS, "-")},
+			{JSONName: "image", JSONValue: c.Image, TextName: "image", TextValue: core.Blank(c.Image, "-")},
+			{JSONName: "snapshot", JSONValue: c.Snapshot, TextName: "snapshot", TextValue: core.Blank(c.Snapshot, "-")},
+			{JSONName: "firewallGroup", JSONValue: c.FirewallGroup, TextName: "firewall_group", TextValue: core.Blank(c.FirewallGroup, "-")},
+			{JSONName: "vpcIds", JSONValue: c.VPCIDs, TextName: "vpc_ids", TextValue: core.Blank(strings.Join(c.VPCIDs, ","), "-")},
+			{JSONName: "sshCIDRs", JSONValue: c.SSHCIDRs, TextName: "ssh_cidrs", TextValue: core.Blank(strings.Join(c.SSHCIDRs, ","), "-")},
+			{JSONName: "userScheme", JSONValue: c.UserScheme, TextName: "user_scheme", TextValue: core.Blank(c.UserScheme, "-")},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

Move all 17 existing DigitalOcean, Vultr and Linode configuration-display fields into their provider adapters. JSON and text share one explicit field definition; the duplicate core maps and formatters are deleted together. Existing section positions, list order and null/empty distinctions, raw boot selectors and empty-only text fallbacks are unchanged.

The adapters do not resolve images, discover credentials, apply SSH defaults or invoke provider tools. Existing selected-provider defaults and explicit SSH user/port handling stay in the configuration loader. Original DigitalOcean/Vultr assertions remain intact and exercise the fully registered CLI; the generic explicit-SSH regression is unchanged.

Integrates the landed cloud cohort from https://github.com/openclaw/crabbox/pull/2120. Four overlapping layout/docs changes were resolved by retaining both migrations and both sets of assertions. The remaining legacy display census is 35 canonical providers; missing sections are a separate backlog. This is an output-preserving refactor, not a new feature.

## Verification

The standalone candidate passed 64 config-show tests and 125 subtests with the race detector, full Go vet, docs generation and whitespace checks. Independent managed Codex review passed at P0 scope. Immutable-baseline characterization passed; absence checks failed specifically for the three missing projectors before implementation.

The integrated candidate also passed 68 tests and 149 subtests across the CLI and all six affected provider packages with the race detector, with no failures or skips. A separate managed Codex review of the integrated patch passed at P0 scope.

## Integrated VPS/cloud config-display CLI proof

All 12 original VPS config-show cases passed complete stdout/stderr/exit-byte comparison against the same immutable baseline. The integrated candidate contains both output-preserving display refactors. No output removal, normalization, fixture change or baseline recapture was used. Source-qualified selected DigitalOcean/Vultr/Linode cases preserve explicit SSH user and port; no SDK, credential, native or provisioning operations ran.

The original standalone candidate first hit a five-second harness timeout with no output; that failure remains retained and its cause is unknown. This integrated comparison used the separately authorized 30-second per-case deadline. All calls exited 0; observed durations were 0.051–7.051 seconds, so no five-second performance guarantee is claimed.

Candidate SHA256: `fed7567aca5b7a6ab8270a3c27ebf7d76ff003ae1e5f4d65bd975b9ecab4d48b`

| Case | Seconds |
|---|---:|
| 01-defaults-json | 7.051126 |
| 02-defaults-text | 0.058149 |
| 03-full-unselected-json | 0.075923 |
| 04-full-unselected-text | 0.051041 |
| 05-raw-empty-unselected-json | 0.080873 |
| 06-raw-empty-unselected-text | 0.162164 |
| 07-selected-digitalocean-json | 0.123158 |
| 08-selected-digitalocean-text | 0.066906 |
| 09-selected-vultr-json | 0.055084 |
| 10-selected-vultr-text | 0.058231 |
| 11-selected-linode-json | 0.062262 |
| 12-selected-linode-text | 0.066053 |

Synthetic populated excerpts (presentation only; actual comparison used complete raw outputs):

```text
digitalocean region=synthetic-region image=synthetic-image vpc=display-vpc ssh_cidrs=192.0.2.0/24,192.0.2.0/24
vultr region=synthetic-region os=387 image=display-image snapshot=display-snapshot firewall_group=display-firewall vpc_ids=display-vpc-a,display-vpc-a ssh_cidrs=198.51.100.0/24,198.51.100.0/24 user_scheme=limited
linode region=synthetic-region image=synthetic-image type=g6-standard-1 firewall=123 ssh_cidrs=203.0.113.0/24,203.0.113.0/24
```

Baseline source: `4c3cd7a5c0d8110061129ce131ee4fefb19ec0d7`; baseline binary SHA-256: `5151b6c13cf7b6707ec82ac1fcb47fa7ebba31e220a28f72b63e03be80143ea4`. These are offline configuration-display checks, not provider lifecycle proof.
