### PR TITLE
refactor(http): share provider JSON request construction

### DIFF
--- a/docs/refactor/provider-http-requests.md
+++ b/docs/refactor/provider-http-requests.md
@@ -1,0 +1,16 @@
+# Provider JSON requests
+
+DigitalOcean, Vultr and Linode use `shared.NewJSONRequest` for the same
+context-bound request envelope. It encodes non-nil bodies with `json.Encoder`
+before calling `http.NewRequestWithContext`. The helper performs no I/O.
+
+A nil interface means no body; a typed-nil value still encodes as JSON.
+Encoder's trailing newline, escaping and error precedence are intentional.
+Using its buffer directly preserves content length and `GetBody` replay.
+Callers supply their existing concatenated URL; the helper does not join paths.
+
+Provider adapters retain headers, credentials, transport, retries and response
+handling. DigitalOcean and Vultr always set JSON content type; Linode sets it
+only for a non-nil body. Vultr constructs a fresh envelope inside every attempt,
+so a retry re-encodes the body. This is not a common cloud client or pagination
+policy: those behaviors remain provider-owned.

--- a/internal/providers/digitalocean/client.go
+++ b/internal/providers/digitalocean/client.go
@@ -1,7 +1,6 @@
 package digitalocean
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -150,15 +149,7 @@ func newDigitalOceanClient(rt core.Runtime) (*digitalOceanClient, error) {
 }
 
 func (c *digitalOceanClient) do(ctx context.Context, method, path string, body any, out any) error {
-	var reader io.Reader
-	if body != nil {
-		var buf bytes.Buffer
-		if err := json.NewEncoder(&buf).Encode(body); err != nil {
-			return err
-		}
-		reader = &buf
-	}
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	req, err := shared.NewJSONRequest(ctx, method, c.baseURL+path, body)
 	if err != nil {
 		return err
 	}

--- a/internal/providers/digitalocean/client_test.go
+++ b/internal/providers/digitalocean/client_test.go
@@ -1459,3 +1459,108 @@ func TestListCrabboxDropletsFiltersAndPaginates(t *testing.T) {
 		t.Fatalf("droplets=%v", droplets)
 	}
 }
+
+type envelopeRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f envelopeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+type envelopeMarshaler func() ([]byte, error)
+
+func (f envelopeMarshaler) MarshalJSON() ([]byte, error) { return f() }
+
+func TestDigitalOceanClientRequestEnvelope(t *testing.T) {
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "envelope-context")
+	var pointer *struct{ Value string }
+	var slice []string
+	for _, tc := range []struct {
+		name    string
+		body    any
+		want    string
+		nilBody bool
+	}{
+		{"nil interface", nil, "", true},
+		{"typed nil pointer", pointer, "null\n", false},
+		{"typed nil slice", slice, "null\n", false},
+		{"JSON bytes and HTML escaping", map[string]string{"message": "<&>"}, "{\"message\":\"\\u003c\\u0026\\u003e\"}\n", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			transport := envelopeRoundTripper(func(req *http.Request) (*http.Response, error) {
+				calls++
+				if req.Context() != ctx || req.Context().Value(contextKey{}) != "envelope-context" {
+					t.Fatal("request lost caller context")
+				}
+				if req.Method != http.MethodPost || req.URL.String() != "https://api.example.test/v1/records?limit=2" {
+					t.Fatalf("request=%s %s", req.Method, req.URL)
+				}
+				if req.Header.Get("Authorization") != "Bearer synthetic-envelope-token" || req.Header.Get("Accept") != "application/json" {
+					t.Fatalf("headers=%v", req.Header)
+				}
+				contentType := "application/json"
+
+				if req.Header.Get("Content-Type") != contentType {
+					t.Fatalf("Content-Type=%q want %q", req.Header.Get("Content-Type"), contentType)
+				}
+				if (req.Body == nil) != tc.nilBody {
+					t.Fatalf("nil body=%v want %v", req.Body == nil, tc.nilBody)
+				}
+				if req.ContentLength != int64(len(tc.want)) {
+					t.Fatalf("ContentLength=%d want %d", req.ContentLength, len(tc.want))
+				}
+				if req.Body != nil {
+					data, err := io.ReadAll(req.Body)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if string(data) != tc.want {
+						t.Fatalf("body=%q want %q", data, tc.want)
+					}
+				}
+				if tc.nilBody {
+					if req.GetBody != nil {
+						t.Fatal("nil input gained GetBody")
+					}
+				} else {
+					if req.GetBody == nil {
+						t.Fatal("encoded body lost GetBody")
+					}
+					replay, err := req.GetBody()
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer replay.Close()
+					data, err := io.ReadAll(replay)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if string(data) != tc.want {
+						t.Fatalf("replay=%q want %q", data, tc.want)
+					}
+				}
+				return &http.Response{StatusCode: http.StatusNoContent, Header: make(http.Header), Body: io.NopCloser(strings.NewReader("")), Request: req}, nil
+			})
+			client := &digitalOceanClient{token: "synthetic-envelope-token", baseURL: "https://api.example.test/v1", client: &http.Client{Transport: transport}}
+			if err := client.do(ctx, http.MethodPost, "/records?limit=2", tc.body, nil); err != nil {
+				t.Fatal(err)
+			}
+			if calls != 1 {
+				t.Fatalf("transport calls=%d", calls)
+			}
+		})
+	}
+	t.Run("encoding fails before request construction and transport", func(t *testing.T) {
+		sentinel := errors.New("synthetic encoder failure")
+		calls := 0
+		client := &digitalOceanClient{baseURL: ":invalid", client: &http.Client{Transport: envelopeRoundTripper(func(*http.Request) (*http.Response, error) { calls++; return nil, errors.New("unexpected transport") })}}
+		body := envelopeMarshaler(func() ([]byte, error) { return nil, sentinel })
+		err := client.do(nil, "invalid method", "/records", body, nil)
+		var marshalerError *json.MarshalerError
+		if !errors.As(err, &marshalerError) || !errors.Is(err, sentinel) {
+			t.Fatalf("error=%T %v want original encoding cause", err, err)
+		}
+		if calls != 0 {
+			t.Fatalf("transport calls=%d", calls)
+		}
+	})
+}

--- a/internal/providers/linode/client.go
+++ b/internal/providers/linode/client.go
@@ -1,7 +1,6 @@
 package linode
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -14,6 +13,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const apiBaseURL = "https://api.linode.com/v4"
@@ -47,15 +47,7 @@ func newLinodeClient(rt core.Runtime) (*linodeClient, error) {
 }
 
 func (c *linodeClient) do(ctx context.Context, method, path string, body any, out any) error {
-	var reader io.Reader
-	if body != nil {
-		var buf bytes.Buffer
-		if err := json.NewEncoder(&buf).Encode(body); err != nil {
-			return err
-		}
-		reader = &buf
-	}
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	req, err := shared.NewJSONRequest(ctx, method, c.baseURL+path, body)
 	if err != nil {
 		return err
 	}

--- a/internal/providers/linode/client_test.go
+++ b/internal/providers/linode/client_test.go
@@ -3,6 +3,8 @@ package linode
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -218,4 +220,111 @@ func TestLinodeClientErrorRedaction(t *testing.T) {
 	if !strings.Contains(text, "<redacted>") {
 		t.Fatalf("error not redacted: %s", text)
 	}
+}
+
+type envelopeRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f envelopeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+type envelopeMarshaler func() ([]byte, error)
+
+func (f envelopeMarshaler) MarshalJSON() ([]byte, error) { return f() }
+
+func TestLinodeClientRequestEnvelope(t *testing.T) {
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "envelope-context")
+	var pointer *struct{ Value string }
+	var slice []string
+	for _, tc := range []struct {
+		name    string
+		body    any
+		want    string
+		nilBody bool
+	}{
+		{"nil interface", nil, "", true},
+		{"typed nil pointer", pointer, "null\n", false},
+		{"typed nil slice", slice, "null\n", false},
+		{"JSON bytes and HTML escaping", map[string]string{"message": "<&>"}, "{\"message\":\"\\u003c\\u0026\\u003e\"}\n", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			transport := envelopeRoundTripper(func(req *http.Request) (*http.Response, error) {
+				calls++
+				if req.Context() != ctx || req.Context().Value(contextKey{}) != "envelope-context" {
+					t.Fatal("request lost caller context")
+				}
+				if req.Method != http.MethodPost || req.URL.String() != "https://api.example.test/v1/records?limit=2" {
+					t.Fatalf("request=%s %s", req.Method, req.URL)
+				}
+				if req.Header.Get("Authorization") != "Bearer synthetic-envelope-token" || req.Header.Get("Accept") != "application/json" {
+					t.Fatalf("headers=%v", req.Header)
+				}
+				contentType := "application/json"
+				if tc.nilBody {
+					contentType = ""
+				}
+				if req.Header.Get("Content-Type") != contentType {
+					t.Fatalf("Content-Type=%q want %q", req.Header.Get("Content-Type"), contentType)
+				}
+				if (req.Body == nil) != tc.nilBody {
+					t.Fatalf("nil body=%v want %v", req.Body == nil, tc.nilBody)
+				}
+				if req.ContentLength != int64(len(tc.want)) {
+					t.Fatalf("ContentLength=%d want %d", req.ContentLength, len(tc.want))
+				}
+				if req.Body != nil {
+					data, err := io.ReadAll(req.Body)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if string(data) != tc.want {
+						t.Fatalf("body=%q want %q", data, tc.want)
+					}
+				}
+				if tc.nilBody {
+					if req.GetBody != nil {
+						t.Fatal("nil input gained GetBody")
+					}
+				} else {
+					if req.GetBody == nil {
+						t.Fatal("encoded body lost GetBody")
+					}
+					replay, err := req.GetBody()
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer replay.Close()
+					data, err := io.ReadAll(replay)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if string(data) != tc.want {
+						t.Fatalf("replay=%q want %q", data, tc.want)
+					}
+				}
+				return &http.Response{StatusCode: http.StatusNoContent, Header: make(http.Header), Body: io.NopCloser(strings.NewReader("")), Request: req}, nil
+			})
+			client := &linodeClient{token: "synthetic-envelope-token", baseURL: "https://api.example.test/v1", client: &http.Client{Transport: transport}}
+			if err := client.do(ctx, http.MethodPost, "/records?limit=2", tc.body, nil); err != nil {
+				t.Fatal(err)
+			}
+			if calls != 1 {
+				t.Fatalf("transport calls=%d", calls)
+			}
+		})
+	}
+	t.Run("encoding fails before request construction and transport", func(t *testing.T) {
+		sentinel := errors.New("synthetic encoder failure")
+		calls := 0
+		client := &linodeClient{baseURL: ":invalid", client: &http.Client{Transport: envelopeRoundTripper(func(*http.Request) (*http.Response, error) { calls++; return nil, errors.New("unexpected transport") })}}
+		body := envelopeMarshaler(func() ([]byte, error) { return nil, sentinel })
+		err := client.do(nil, "invalid method", "/records", body, nil)
+		var marshalerError *json.MarshalerError
+		if !errors.As(err, &marshalerError) || !errors.Is(err, sentinel) {
+			t.Fatalf("error=%T %v want original encoding cause", err, err)
+		}
+		if calls != 0 {
+			t.Fatalf("transport calls=%d", calls)
+		}
+	})
 }

--- a/internal/providers/shared/httprequest.go
+++ b/internal/providers/shared/httprequest.go
@@ -1,0 +1,23 @@
+package shared
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// NewJSONRequest preserves Encoder's bytes and errors before constructing the
+// request. Callers own headers, transport and retries; a nil body stays absent.
+func NewJSONRequest(ctx context.Context, method, url string, body any) (*http.Request, error) {
+	var reader io.Reader
+	if body != nil {
+		var buf bytes.Buffer
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			return nil, err
+		}
+		reader = &buf
+	}
+	return http.NewRequestWithContext(ctx, method, url, reader)
+}

--- a/internal/providers/shared/httprequest_test.go
+++ b/internal/providers/shared/httprequest_test.go
@@ -1,0 +1,130 @@
+package shared
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestNewJSONRequestEnvelope(t *testing.T) {
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "request-context")
+	var pointer *int
+	var slice []string
+	for _, tc := range []struct {
+		name string
+		body any
+		wire string
+	}{
+		{name: "nil interface"},
+		{name: "typed nil pointer", body: pointer, wire: "null\n"},
+		{name: "typed nil slice", body: slice, wire: "null\n"},
+		{name: "encoded object", body: struct {
+			Text  string `json:"text"`
+			Count int    `json:"count"`
+		}{Text: "<tag>&\n", Count: 7}, wire: "{\"text\":\"\\u003ctag\\u003e\\u0026\\n\",\"count\":7}\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const target = "https://example.invalid/resource?part=one"
+			req, err := NewJSONRequest(ctx, http.MethodPost, target, tc.body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if req.Context() != ctx || req.Method != http.MethodPost || req.URL.String() != target {
+				t.Fatalf("request context/method/URL changed: %v", req)
+			}
+			if len(req.Header) != 0 {
+				t.Fatalf("constructor added headers: %v", req.Header)
+			}
+			if req.ContentLength != int64(len(tc.wire)) {
+				t.Fatalf("ContentLength=%d want %d", req.ContentLength, len(tc.wire))
+			}
+			if tc.body == nil {
+				if req.Body != nil || req.GetBody != nil {
+					t.Fatal("nil interface gained a body or replay closure")
+				}
+				return
+			}
+			if req.Body == nil || req.GetBody == nil {
+				t.Fatal("encoded body or replay closure missing")
+			}
+			data, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := req.Body.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if string(data) != tc.wire {
+				t.Fatalf("body=%q want %q", data, tc.wire)
+			}
+			for range 2 {
+				replay, err := req.GetBody()
+				if err != nil {
+					t.Fatal(err)
+				}
+				data, err := io.ReadAll(replay)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := replay.Close(); err != nil {
+					t.Fatal(err)
+				}
+				if string(data) != tc.wire {
+					t.Fatalf("replay=%q want %q", data, tc.wire)
+				}
+			}
+		})
+	}
+}
+
+func TestNewJSONRequestEncodingErrorPrecedesConstruction(t *testing.T) {
+	body := make(chan int)
+	for _, tc := range []struct {
+		name        string
+		ctx         context.Context
+		method, url string
+	}{
+		{name: "ordinary request", ctx: context.Background(), method: http.MethodPost, url: "https://example.invalid"},
+		{name: "invalid method", ctx: context.Background(), method: "invalid method", url: "https://example.invalid"},
+		{name: "invalid URL", ctx: context.Background(), method: http.MethodPost, url: "http://[::1"},
+		{name: "nil context", method: http.MethodPost, url: "https://example.invalid"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := NewJSONRequest(tc.ctx, tc.method, tc.url, body)
+			encodingErr, ok := err.(*json.UnsupportedTypeError)
+			if req != nil || !ok || encodingErr.Type != reflect.TypeOf(body) {
+				t.Fatalf("got request=%v error=%T %v", req, err, err)
+			}
+		})
+	}
+}
+
+func TestNewJSONRequestConstructionErrorsAndCanceledContext(t *testing.T) {
+	for _, tc := range []struct {
+		ctx         context.Context
+		method, url string
+	}{
+		{context.Background(), "invalid method", "https://example.invalid"},
+		{context.Background(), http.MethodGet, "http://[::1"},
+		{nil, http.MethodGet, "https://example.invalid"},
+	} {
+		_, want := http.NewRequestWithContext(tc.ctx, tc.method, tc.url, nil)
+		req, err := NewJSONRequest(tc.ctx, tc.method, tc.url, nil)
+		if req != nil || err == nil || want == nil || err.Error() != want.Error() || reflect.TypeOf(err) != reflect.TypeOf(want) {
+			t.Fatalf("request=%v error=%v want=%v", req, err, want)
+		}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req, err := NewJSONRequest(ctx, "", "https://example.invalid", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.Context() != ctx || req.Context().Err() != context.Canceled || req.Method != http.MethodGet {
+		t.Fatal("constructor changed canceled-context or empty-method behavior")
+	}
+}

--- a/internal/providers/vultr/client.go
+++ b/internal/providers/vultr/client.go
@@ -1,7 +1,6 @@
 package vultr
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
@@ -18,6 +17,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const vultrAPIBaseURL = "https://api.vultr.com/v2"
@@ -172,15 +172,7 @@ func (c *vultrClient) do(ctx context.Context, method, path string, body any, out
 }
 
 func (c *vultrClient) doAttempt(ctx context.Context, method, path string, body any, out any, allowRetry bool) error {
-	var reader io.Reader
-	if body != nil {
-		var buf bytes.Buffer
-		if err := json.NewEncoder(&buf).Encode(body); err != nil {
-			return err
-		}
-		reader = &buf
-	}
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	req, err := shared.NewJSONRequest(ctx, method, c.baseURL+path, body)
 	if err != nil {
 		return err
 	}

--- a/internal/providers/vultr/client_test.go
+++ b/internal/providers/vultr/client_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -144,6 +147,43 @@ func TestVultrClientCursorPaginationAndRateLimit(t *testing.T) {
 	if len(instances) != 1 || instances[0].ID != "two" {
 		t.Fatalf("instances=%#v", instances)
 	}
+
+	t.Run("reencode body on retry", func(t *testing.T) {
+		ctx := context.Background()
+		encodes, calls, delays := 0, 0, 0
+		body := envelopeMarshaler(func() ([]byte, error) { encodes++; return []byte(`{"attempt":` + strconv.Itoa(encodes) + `}`), nil })
+		client := &vultrClient{token: "synthetic-envelope-token", baseURL: "https://api.example.test", sleep: func(got context.Context, d time.Duration) error {
+			delays++
+			if got != ctx || d != time.Second {
+				t.Fatalf("retry delay context/duration=%v %v", got, d)
+			}
+			return nil
+		}}
+		client.client = &http.Client{Transport: envelopeRoundTripper(func(req *http.Request) (*http.Response, error) {
+			calls++
+			data, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := `{"attempt":` + strconv.Itoa(calls) + "}\n"
+			if string(data) != want {
+				t.Fatalf("attempt%d body=%q want %q", calls, data, want)
+			}
+			status := http.StatusNoContent
+			header := make(http.Header)
+			if calls == 1 {
+				status = http.StatusTooManyRequests
+				header.Set("Retry-After", "1")
+			}
+			return &http.Response{StatusCode: status, Header: header, Body: io.NopCloser(strings.NewReader("")), Request: req}, nil
+		})}
+		if err := client.do(ctx, http.MethodPost, "/records", body, nil); err != nil {
+			t.Fatal(err)
+		}
+		if encodes != 2 || calls != 2 || delays != 1 {
+			t.Fatalf("encodes=%d calls=%d delays=%d", encodes, calls, delays)
+		}
+	})
 }
 
 func TestVultrClientRedactsSecretsFromErrors(t *testing.T) {
@@ -249,4 +289,109 @@ func containsVultrTag(tags []any, want string) bool {
 		}
 	}
 	return false
+}
+
+type envelopeRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f envelopeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+type envelopeMarshaler func() ([]byte, error)
+
+func (f envelopeMarshaler) MarshalJSON() ([]byte, error) { return f() }
+
+func TestVultrClientRequestEnvelope(t *testing.T) {
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "envelope-context")
+	var pointer *struct{ Value string }
+	var slice []string
+	for _, tc := range []struct {
+		name    string
+		body    any
+		want    string
+		nilBody bool
+	}{
+		{"nil interface", nil, "", true},
+		{"typed nil pointer", pointer, "null\n", false},
+		{"typed nil slice", slice, "null\n", false},
+		{"JSON bytes and HTML escaping", map[string]string{"message": "<&>"}, "{\"message\":\"\\u003c\\u0026\\u003e\"}\n", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			transport := envelopeRoundTripper(func(req *http.Request) (*http.Response, error) {
+				calls++
+				if req.Context() != ctx || req.Context().Value(contextKey{}) != "envelope-context" {
+					t.Fatal("request lost caller context")
+				}
+				if req.Method != http.MethodPost || req.URL.String() != "https://api.example.test/v1/records?limit=2" {
+					t.Fatalf("request=%s %s", req.Method, req.URL)
+				}
+				if req.Header.Get("Authorization") != "Bearer synthetic-envelope-token" || req.Header.Get("Accept") != "application/json" {
+					t.Fatalf("headers=%v", req.Header)
+				}
+				contentType := "application/json"
+
+				if req.Header.Get("Content-Type") != contentType {
+					t.Fatalf("Content-Type=%q want %q", req.Header.Get("Content-Type"), contentType)
+				}
+				if (req.Body == nil) != tc.nilBody {
+					t.Fatalf("nil body=%v want %v", req.Body == nil, tc.nilBody)
+				}
+				if req.ContentLength != int64(len(tc.want)) {
+					t.Fatalf("ContentLength=%d want %d", req.ContentLength, len(tc.want))
+				}
+				if req.Body != nil {
+					data, err := io.ReadAll(req.Body)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if string(data) != tc.want {
+						t.Fatalf("body=%q want %q", data, tc.want)
+					}
+				}
+				if tc.nilBody {
+					if req.GetBody != nil {
+						t.Fatal("nil input gained GetBody")
+					}
+				} else {
+					if req.GetBody == nil {
+						t.Fatal("encoded body lost GetBody")
+					}
+					replay, err := req.GetBody()
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer replay.Close()
+					data, err := io.ReadAll(replay)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if string(data) != tc.want {
+						t.Fatalf("replay=%q want %q", data, tc.want)
+					}
+				}
+				return &http.Response{StatusCode: http.StatusNoContent, Header: make(http.Header), Body: io.NopCloser(strings.NewReader("")), Request: req}, nil
+			})
+			client := &vultrClient{token: "synthetic-envelope-token", baseURL: "https://api.example.test/v1", client: &http.Client{Transport: transport}}
+			if err := client.do(ctx, http.MethodPost, "/records?limit=2", tc.body, nil); err != nil {
+				t.Fatal(err)
+			}
+			if calls != 1 {
+				t.Fatalf("transport calls=%d", calls)
+			}
+		})
+	}
+	t.Run("encoding fails before request construction and transport", func(t *testing.T) {
+		sentinel := errors.New("synthetic encoder failure")
+		calls := 0
+		client := &vultrClient{baseURL: ":invalid", client: &http.Client{Transport: envelopeRoundTripper(func(*http.Request) (*http.Response, error) { calls++; return nil, errors.New("unexpected transport") })}}
+		body := envelopeMarshaler(func() ([]byte, error) { return nil, sentinel })
+		err := client.do(nil, "invalid method", "/records", body, nil)
+		var marshalerError *json.MarshalerError
+		if !errors.As(err, &marshalerError) || !errors.Is(err, sentinel) {
+			t.Fatalf("error=%T %v want original encoding cause", err, err)
+		}
+		if calls != 0 {
+			t.Fatalf("transport calls=%d", calls)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Share the complete context-bound JSON request-envelope constructor across DigitalOcean, Linode and Vultr. Remove the three duplicated encoding/request prefixes without introducing a common cloud client.

The helper preserves nil versus typed-nil bodies, Encoder's newline and HTML escaping, encoding-error precedence, context association, content length and replay via GetBody. Each provider keeps its existing URL concatenation, headers, credentials, transport, retries and response interpretation. Linode still omits Content-Type for a nil body; DigitalOcean and Vultr still set it. Vultr constructs and encodes again inside each retry attempt.

## Verification

- Pinned-original client implementations passed the new focused regressions through a Go test overlay, including existing loopback HTTP request-shape tests. The same candidate tests passed after fixing two missing shared imports caught by the first build.
- Broader client and helper regressions passed 49 tests and 30 subtests across four packages with Go 1.26.5 and the race detector, without failures or skips. Inert transports check exact request bytes and headers; existing local HTTP handlers check real request dispatch. The Vultr retry test verifies a fresh encoding on the second attempt without real delay or cloud traffic.
- Independent managed Codex review passed at P0 scope. Docs generation and whitespace checks passed.
- Reversing only the three prefix substitutions and necessary import changes restores the original client files byte-for-byte; all header, retry and response code remains unchanged.

This is a behavior-preserving internal refactor. It adds no new provider credentials, network destinations or public CLI behavior. Tests use synthetic inputs and local/inert transports, not live cloud accounts.

## Observed production-client HTTP trace

Source: `f66ca6080c79e3233cc2a4957e41e9472976020d` (clean before and after). Three additive, uncommitted test overlays exercised the production DigitalOcean, Linode, and Vultr request clients through real HTTP transport and loopback `httptest` servers. No production file was replaced.

Race-enabled targeted proof passed: 3 tests, 10 subcases, 11 actual HTTP requests; 13.73 seconds total. Authorization was present for every request; only presence was recorded. Caller-context association was verified in a wrapper that delegated to the real transport.

| Provider | Case | Method / path | Content-Type | Content-Length | Actual body (JSON string notation) | Server response |
|---|---|---|---|---:|---|---:|
| digitalocean | nil | `POST /proof/records?limit=2` | `application/json` | 0 | `""` | 204 |
| digitalocean | typed-nil | `POST /proof/records?limit=2` | `application/json` | 5 | `"null\n"` | 204 |
| digitalocean | structured | `POST /proof/records?limit=2` | `application/json` | 33 | `"{\"message\":\"\\u003c\\u0026\\u003e\"}\n"` | 204 |
| linode | nil | `POST /proof/records?limit=2` | (absent) | 0 | `""` | 204 |
| linode | typed-nil | `POST /proof/records?limit=2` | `application/json` | 5 | `"null\n"` | 204 |
| linode | structured | `POST /proof/records?limit=2` | `application/json` | 33 | `"{\"message\":\"\\u003c\\u0026\\u003e\"}\n"` | 204 |
| vultr | nil | `POST /proof/records?limit=2` | `application/json` | 0 | `""` | 204 |
| vultr | typed-nil | `POST /proof/records?limit=2` | `application/json` | 5 | `"null\n"` | 204 |
| vultr | structured | `POST /proof/records?limit=2` | `application/json` | 33 | `"{\"message\":\"\\u003c\\u0026\\u003e\"}\n"` | 204 |
| vultr | retry-attempt-1 | `POST /proof/retry` | `application/json` | 14 | `"{\"attempt\":1}\n"` | 429 |
| vultr | retry-attempt-2 | `POST /proof/retry` | `application/json` | 14 | `"{\"attempt\":2}\n"` | 204 |

Vultr’s first response was `429` with `Retry-After: 1`; the second was `204`. The unchanged production timer was used. Server arrivals were at least one second apart; the measured client operation took 1,003 ms. The custom marshaler ran twice, and the server recorded `{"attempt":1}\n` followed by `{"attempt":2}\n`, proving fresh encoding on the actual retry.

Limits: these are synthetic local-server observations, not cloud-service or credential-validity tests. Context identity is a client-side transport observation, not a value transmitted to the server. No native tools, cloud resources, real credentials, or public writes were used.
