### PR TITLE
refactor(http): share remaining default JSON request envelopes

### DIFF
--- a/docs/refactor/provider-http-requests.md
+++ b/docs/refactor/provider-http-requests.md
@@ -1,8 +1,20 @@
 # Provider JSON requests
 
-DigitalOcean, Vultr and Linode use `shared.NewJSONRequest` for the same
-context-bound request envelope. It encodes non-nil bodies with `json.Encoder`
-before calling `http.NewRequestWithContext`. The helper performs no I/O.
+Providers using default-Encoder JSON HTTP bodies share `shared.NewJSONRequest`
+for their context-bound request envelope. It encodes non-nil bodies with
+`json.Encoder` before calling `http.NewRequestWithContext`. The helper performs
+no I/O.
+
+DigitalOcean, Vultr, Linode, Lambda, Cloudflare, Cloudflare Dynamic Workers,
+Azure Dynamic Sessions, E2B, CubeSandbox and Sprites use this owner. Buffered
+JSON request construction stays separate from response streaming. Dynamic
+Workers still constructs a fresh request inside each existing attempt.
+
+URL and query composition remain adapter-owned. The existing E2B, CubeSandbox
+and Sprites query-bearing calls have no body; their body-bearing calls have no
+query. Their local URL construction retains the behavior of those callers.
+Orgo's unescaped JSON, OVH's trimmed signed payloads, Marshal-based bodies and
+binary or framed streams keep their separate encoding contracts.
 
 A nil interface means no body; a typed-nil value still encodes as JSON.
 Encoder's trailing newline, escaping and error precedence are intentional.

--- a/internal/providers/azuredynamicsessions/client.go
+++ b/internal/providers/azuredynamicsessions/client.go
@@ -238,11 +238,7 @@ func (c *azureDynamicSessionsClient) UploadFile(ctx context.Context, identifier,
 }
 
 func (c *azureDynamicSessionsClient) ExecStream(ctx context.Context, identifier string, execReq azureDynamicSessionsExecRequest, stdout, stderr io.Writer) (int, error) {
-	var body bytes.Buffer
-	if err := json.NewEncoder(&body).Encode(execReq); err != nil {
-		return 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url("/v1/exec", c.sessionQuery(identifier)), &body)
+	req, err := shared.NewJSONRequest(ctx, http.MethodPost, c.url("/v1/exec", c.sessionQuery(identifier)), execReq)
 	if err != nil {
 		return 0, err
 	}
@@ -373,15 +369,7 @@ func (c *azureDynamicSessionsClient) doJSON(ctx context.Context, method, path st
 }
 
 func (c *azureDynamicSessionsClient) doJSONURL(ctx context.Context, method, endpoint string, body any, out any) error {
-	var r io.Reader
-	if body != nil {
-		var buf bytes.Buffer
-		if err := json.NewEncoder(&buf).Encode(body); err != nil {
-			return err
-		}
-		r = &buf
-	}
-	req, err := http.NewRequestWithContext(ctx, method, endpoint, r)
+	req, err := shared.NewJSONRequest(ctx, method, endpoint, body)
 	if err != nil {
 		return err
 	}

--- a/internal/providers/azuredynamicsessions/client_test.go
+++ b/internal/providers/azuredynamicsessions/client_test.go
@@ -760,3 +760,127 @@ func TestAzureDynamicSessionsStreamCancellationAtCleanEOF(t *testing.T) {
 		})
 	}
 }
+
+type adoptionRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f adoptionRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func assertAdoptionRequest(t *testing.T, req *http.Request, ctx context.Context, endpoint, body string, headers http.Header) {
+	t.Helper()
+	if req.Context() != ctx || req.Method != http.MethodPost || req.URL.String() != endpoint {
+		t.Fatalf("request context/method/URL mismatch: %s %s", req.Method, req.URL)
+	}
+	if !reflect.DeepEqual(req.Header, headers) {
+		t.Fatalf("headers=%v want %v", req.Header, headers)
+	}
+	if req.ContentLength != int64(len(body)) || (req.Body == nil) != (body == "") {
+		t.Fatalf("body metadata length=%d nil=%v want length=%d", req.ContentLength, req.Body == nil, len(body))
+	}
+	if body == "" {
+		if req.GetBody != nil {
+			t.Fatal("nil body gained replay")
+		}
+		return
+	}
+	data, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != body {
+		t.Fatalf("body=%q want %q", data, body)
+	}
+	if req.GetBody == nil {
+		t.Fatal("encoded body lost replay")
+	}
+	replay, err := req.GetBody()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer replay.Close()
+	data, err = io.ReadAll(replay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != body {
+		t.Fatalf("replay=%q want %q", data, body)
+	}
+}
+
+func TestJSONRequestAdoptionEnvelope(t *testing.T) {
+	type key struct{}
+	ctx := context.WithValue(context.Background(), key{}, "capture")
+	var typedNil *struct{ Value string }
+	const base = "https://api.example.test/base"
+	sentinel := errors.New("synthetic captured transport stop")
+	for _, tc := range []struct {
+		name        string
+		body        any
+		want        string
+		query, fail bool
+	}{
+		{name: "nil"},
+		{name: "typed nil", body: typedNil, want: "null\n"},
+		{name: "JSON bytes", body: map[string]string{"message": "<&>"}, want: "{\"message\":\"\\u003c\\u0026\\u003e\"}\n"},
+		{name: "query without body", query: true},
+		{name: "transport error", fail: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			endpoint := "/records"
+			if tc.query {
+				endpoint += "?limit=2&prefix=two+words"
+			}
+
+			headers := http.Header{"Authorization": []string{"Bearer synthetic-token"}}
+			headers.Set("Accept", "application/json")
+			headers.Set("User-Agent", "crabbox/azure-dynamic-sessions")
+			if tc.body != nil {
+				headers.Set("Content-Type", "application/json")
+			}
+			transport := &http.Client{Transport: adoptionRoundTripper(func(req *http.Request) (*http.Response, error) {
+				calls++
+				assertAdoptionRequest(t, req, ctx, base+endpoint, tc.want, headers)
+				if tc.fail {
+					return nil, sentinel
+				}
+				return &http.Response{StatusCode: 204, Header: http.Header{"X-Capture": []string{"yes"}}, Body: io.NopCloser(strings.NewReader("")), Request: req}, nil
+			})}
+			c := &azureDynamicSessionsClient{endpoint: base, token: "synthetic-token", httpClient: transport}
+			var gotHeaders http.Header
+			err := c.doJSONURL(ctx, http.MethodPost, base+endpoint, tc.body, nil)
+			if tc.fail {
+				if !errors.Is(err, sentinel) || gotHeaders != nil {
+					t.Fatalf("error/headers=%v %v", err, gotHeaders)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+
+			if calls != 1 {
+				t.Fatalf("calls=%d", calls)
+			}
+		})
+	}
+}
+
+func TestJSONRequestAdoptionConcreteEnvelope(t *testing.T) {
+	ctx := context.Background()
+	sentinel := errors.New("synthetic captured concrete request")
+	calls := 0
+	headers := http.Header{"Authorization": []string{"Bearer synthetic-token"}, "Content-Type": []string{"application/json"}}
+	headers.Set("Accept", "application/json")
+	headers.Set("User-Agent", "crabbox/azure-dynamic-sessions")
+	transport := &http.Client{Transport: adoptionRoundTripper(func(req *http.Request) (*http.Response, error) {
+		calls++
+		assertAdoptionRequest(t, req, ctx, "https://api.example.test/base/v1/exec?identifier=session+one", "{\"command\":\"\\u003c\\u0026\\u003e\",\"cwd\":\"/work\",\"env\":{\"A\":\"B\"},\"timeoutMs\":7}\n", headers)
+		return nil, sentinel
+	})}
+	c := &azureDynamicSessionsClient{endpoint: "https://api.example.test/base", token: "synthetic-token", httpClient: transport}
+	code, err := c.ExecStream(ctx, "session one", azureDynamicSessionsExecRequest{Command: "<&>", Cwd: "/work", Env: map[string]string{"A": "B"}, TimeoutMS: 7}, io.Discard, io.Discard)
+	if code != 0 {
+		t.Fatalf("exit=%d", code)
+	}
+	if !errors.Is(err, sentinel) || calls != 1 {
+		t.Fatalf("error=%v calls=%d", err, calls)
+	}
+}

--- a/internal/providers/cloudflare/backend_test.go
+++ b/internal/providers/cloudflare/backend_test.go
@@ -2140,3 +2140,124 @@ func TestCloudflareStreamCancellationAtCleanEOF(t *testing.T) {
 		})
 	}
 }
+
+type adoptionRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f adoptionRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func assertAdoptionRequest(t *testing.T, req *http.Request, ctx context.Context, endpoint, body string, headers http.Header) {
+	t.Helper()
+	if req.Context() != ctx || req.Method != http.MethodPost || req.URL.String() != endpoint {
+		t.Fatalf("request context/method/URL mismatch: %s %s", req.Method, req.URL)
+	}
+	if !reflect.DeepEqual(req.Header, headers) {
+		t.Fatalf("headers=%v want %v", req.Header, headers)
+	}
+	if req.ContentLength != int64(len(body)) || (req.Body == nil) != (body == "") {
+		t.Fatalf("body metadata length=%d nil=%v want length=%d", req.ContentLength, req.Body == nil, len(body))
+	}
+	if body == "" {
+		if req.GetBody != nil {
+			t.Fatal("nil body gained replay")
+		}
+		return
+	}
+	data, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != body {
+		t.Fatalf("body=%q want %q", data, body)
+	}
+	if req.GetBody == nil {
+		t.Fatal("encoded body lost replay")
+	}
+	replay, err := req.GetBody()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer replay.Close()
+	data, err = io.ReadAll(replay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != body {
+		t.Fatalf("replay=%q want %q", data, body)
+	}
+}
+
+func TestJSONRequestAdoptionEnvelope(t *testing.T) {
+	type key struct{}
+	ctx := context.WithValue(context.Background(), key{}, "capture")
+	var typedNil *struct{ Value string }
+	const base = "https://api.example.test/base"
+	sentinel := errors.New("synthetic captured transport stop")
+	for _, tc := range []struct {
+		name        string
+		body        any
+		want        string
+		query, fail bool
+	}{
+		{name: "nil"},
+		{name: "typed nil", body: typedNil, want: "null\n"},
+		{name: "JSON bytes", body: map[string]string{"message": "<&>"}, want: "{\"message\":\"\\u003c\\u0026\\u003e\"}\n"},
+		{name: "query without body", query: true},
+		{name: "transport error", fail: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			endpoint := "/records"
+			if tc.query {
+				endpoint += "?limit=2&prefix=two+words"
+			}
+
+			headers := http.Header{"Authorization": []string{"Bearer synthetic-token"}}
+
+			if tc.body != nil {
+				headers.Set("Content-Type", "application/json")
+			}
+			transport := &http.Client{Transport: adoptionRoundTripper(func(req *http.Request) (*http.Response, error) {
+				calls++
+				assertAdoptionRequest(t, req, ctx, base+endpoint, tc.want, headers)
+				if tc.fail {
+					return nil, sentinel
+				}
+				return &http.Response{StatusCode: 204, Header: http.Header{"X-Capture": []string{"yes"}}, Body: io.NopCloser(strings.NewReader("")), Request: req}, nil
+			})}
+			c := &cloudflareClient{baseURL: base, token: "synthetic-token", http: transport}
+			var gotHeaders http.Header
+			err := c.doJSON(ctx, http.MethodPost, endpoint, tc.body, nil)
+			if tc.fail {
+				if !errors.Is(err, sentinel) || gotHeaders != nil {
+					t.Fatalf("error/headers=%v %v", err, gotHeaders)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+
+			if calls != 1 {
+				t.Fatalf("calls=%d", calls)
+			}
+		})
+	}
+}
+
+func TestJSONRequestAdoptionConcreteEnvelope(t *testing.T) {
+	ctx := context.Background()
+	sentinel := errors.New("synthetic captured concrete request")
+	calls := 0
+	headers := http.Header{"Authorization": []string{"Bearer synthetic-token"}, "Content-Type": []string{"application/json"}}
+	transport := &http.Client{Transport: adoptionRoundTripper(func(req *http.Request) (*http.Response, error) {
+		calls++
+		assertAdoptionRequest(t, req, ctx, "https://api.example.test/base/v1/sandboxes/sandbox%20one/exec-stream?instanceType=large+size", "{\"command\":\"\\u003c\\u0026\\u003e\",\"cwd\":\"/work\",\"env\":{\"A\":\"B\"},\"timeoutMs\":7}\n", headers)
+		return nil, sentinel
+	})}
+	c := &cloudflareClient{baseURL: "https://api.example.test/base", token: "synthetic-token", instanceType: "large size", http: transport}
+	code, err := c.execStream(ctx, "sandbox one", execStreamRequest{Command: "<&>", Cwd: "/work", Env: map[string]string{"A": "B"}, TimeoutMS: 7}, io.Discard, io.Discard)
+	if code != 0 {
+		t.Fatalf("exit=%d", code)
+	}
+	if !errors.Is(err, sentinel) || calls != 1 {
+		t.Fatalf("error=%v calls=%d", err, calls)
+	}
+}

--- a/internal/providers/cloudflare/client.go
+++ b/internal/providers/cloudflare/client.go
@@ -203,11 +203,7 @@ func (c *cloudflareClient) uploadFile(ctx context.Context, sandboxID, localPath,
 }
 
 func (c *cloudflareClient) execStream(ctx context.Context, sandboxID string, req execStreamRequest, stdout, stderr io.Writer) (int, error) {
-	var body bytes.Buffer
-	if err := json.NewEncoder(&body).Encode(req); err != nil {
-		return 0, err
-	}
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+c.sandboxEndpoint(sandboxID, "/exec-stream"), &body)
+	httpReq, err := shared.NewJSONRequest(ctx, http.MethodPost, c.baseURL+c.sandboxEndpoint(sandboxID, "/exec-stream"), req)
 	if err != nil {
 		return 0, err
 	}
@@ -280,15 +276,7 @@ func (c *cloudflareClient) sandboxEndpoint(sandboxID, suffix string) string {
 }
 
 func (c *cloudflareClient) doJSON(ctx context.Context, method, endpoint string, input any, output any) error {
-	var body io.Reader
-	if input != nil {
-		var buf bytes.Buffer
-		if err := json.NewEncoder(&buf).Encode(input); err != nil {
-			return err
-		}
-		body = &buf
-	}
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+endpoint, body)
+	req, err := shared.NewJSONRequest(ctx, method, c.baseURL+endpoint, input)
 	if err != nil {
 		return err
 	}

--- a/internal/providers/cloudflaredynamicworkers/backend_test.go
+++ b/internal/providers/cloudflaredynamicworkers/backend_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2291,4 +2292,125 @@ func testConfig(url string) Config {
 
 func newTestFlagSet() *flag.FlagSet {
 	return flag.NewFlagSet("test", flag.ContinueOnError)
+}
+
+type adoptionRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f adoptionRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func assertAdoptionRequest(t *testing.T, req *http.Request, ctx context.Context, endpoint, body string, headers http.Header) {
+	t.Helper()
+	if req.Context() != ctx || req.Method != http.MethodPost || req.URL.String() != endpoint {
+		t.Fatalf("request context/method/URL mismatch: %s %s", req.Method, req.URL)
+	}
+	if !reflect.DeepEqual(req.Header, headers) {
+		t.Fatalf("headers=%v want %v", req.Header, headers)
+	}
+	if req.ContentLength != int64(len(body)) || (req.Body == nil) != (body == "") {
+		t.Fatalf("body metadata length=%d nil=%v want length=%d", req.ContentLength, req.Body == nil, len(body))
+	}
+	if body == "" {
+		if req.GetBody != nil {
+			t.Fatal("nil body gained replay")
+		}
+		return
+	}
+	data, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != body {
+		t.Fatalf("body=%q want %q", data, body)
+	}
+	if req.GetBody == nil {
+		t.Fatal("encoded body lost replay")
+	}
+	replay, err := req.GetBody()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer replay.Close()
+	data, err = io.ReadAll(replay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != body {
+		t.Fatalf("replay=%q want %q", data, body)
+	}
+}
+
+func TestJSONRequestAdoptionEnvelope(t *testing.T) {
+	type key struct{}
+	ctx := context.WithValue(context.Background(), key{}, "capture")
+	var typedNil *struct{ Value string }
+	const base = "https://api.example.test/base"
+	sentinel := errors.New("synthetic captured transport stop")
+	for _, tc := range []struct {
+		name        string
+		body        any
+		want        string
+		query, fail bool
+	}{
+		{name: "nil"},
+		{name: "typed nil", body: typedNil, want: "null\n"},
+		{name: "JSON bytes", body: map[string]string{"message": "<&>"}, want: "{\"message\":\"\\u003c\\u0026\\u003e\"}\n"},
+		{name: "query without body", query: true},
+		{name: "transport error", fail: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			endpoint := "/records"
+			if tc.query {
+				endpoint += "?limit=2&prefix=two+words"
+			}
+
+			headers := http.Header{"Authorization": []string{"Bearer synthetic-token"}}
+
+			if tc.body != nil {
+				headers.Set("Content-Type", "application/json")
+			}
+			transport := &http.Client{Transport: adoptionRoundTripper(func(req *http.Request) (*http.Response, error) {
+				calls++
+				assertAdoptionRequest(t, req, ctx, base+endpoint, tc.want, headers)
+				if tc.fail {
+					return nil, sentinel
+				}
+				return &http.Response{StatusCode: 204, Header: http.Header{"X-Capture": []string{"yes"}}, Body: io.NopCloser(strings.NewReader("")), Request: req}, nil
+			})}
+			c := &client{baseURL: base, token: "synthetic-token", http: transport}
+			var gotHeaders http.Header
+			err := c.doJSON(ctx, http.MethodPost, endpoint, tc.body, nil)
+			if tc.fail {
+				if !errors.Is(err, sentinel) || gotHeaders != nil {
+					t.Fatalf("error/headers=%v %v", err, gotHeaders)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+
+			if calls != 1 {
+				t.Fatalf("calls=%d", calls)
+			}
+		})
+	}
+}
+
+func TestJSONRequestAdoptionConcreteEnvelope(t *testing.T) {
+	ctx := context.Background()
+	sentinel := errors.New("synthetic captured concrete request")
+	calls := 0
+	headers := http.Header{"Authorization": []string{"Bearer synthetic-token"}, "Content-Type": []string{"application/json"}}
+	transport := &http.Client{Transport: adoptionRoundTripper(func(req *http.Request) (*http.Response, error) {
+		calls++
+		assertAdoptionRequest(t, req, ctx, "https://api.example.test/base/v1/runs", "{\"cacheMode\":\"none\",\"retainMetadata\":true,\"module\":{\"source\":\"\\u003c\\u0026\\u003e\"},\"egress\":\"none\",\"limits\":{},\"timeoutMs\":7}\n", headers)
+		return nil, sentinel
+	})}
+	c := &client{baseURL: "https://api.example.test/base", token: "synthetic-token", http: transport}
+	out, err := c.Run(ctx, runRequest{CacheMode: "none", RetainMetadata: true, Module: moduleSource{Source: "<&>"}, Egress: "none", TimeoutMS: 7})
+	if !reflect.DeepEqual(out, runResponse{}) {
+		t.Fatalf("out=%#v", out)
+	}
+	if !errors.Is(err, sentinel) || calls != 1 {
+		t.Fatalf("error=%v calls=%d", err, calls)
+	}
 }

--- a/internal/providers/cloudflaredynamicworkers/client.go
+++ b/internal/providers/cloudflaredynamicworkers/client.go
@@ -329,11 +329,7 @@ func (c *client) Readiness(ctx context.Context) (readinessResponse, error) {
 
 func (c *client) Run(ctx context.Context, req runRequest) (runResponse, error) {
 	var out runResponse
-	var body bytes.Buffer
-	if err := json.NewEncoder(&body).Encode(req); err != nil {
-		return out, err
-	}
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/runs", &body)
+	httpReq, err := shared.NewJSONRequest(ctx, http.MethodPost, c.baseURL+"/v1/runs", req)
 	if err != nil {
 		return out, err
 	}
@@ -543,15 +539,7 @@ func (c *client) DeleteAcknowledgedComplete(ctx context.Context, id string) erro
 
 func (c *client) doJSON(ctx context.Context, method, endpoint string, input any, output any) error {
 	for attempt := 0; ; attempt++ {
-		var body io.Reader
-		if input != nil {
-			var buf bytes.Buffer
-			if err := json.NewEncoder(&buf).Encode(input); err != nil {
-				return err
-			}
-			body = &buf
-		}
-		req, err := http.NewRequestWithContext(ctx, method, c.baseURL+endpoint, body)
+		req, err := shared.NewJSONRequest(ctx, method, c.baseURL+endpoint, input)
 		if err != nil {
 			return err
 		}

--- a/internal/providers/cubesandbox/backend_test.go
+++ b/internal/providers/cubesandbox/backend_test.go
@@ -1811,3 +1811,104 @@ func TestCubeSandboxProcessEndDiagnosticPrecedence(t *testing.T) {
 		})
 	}
 }
+
+func assertAdoptionRequest(t *testing.T, req *http.Request, ctx context.Context, endpoint, body string, headers http.Header) {
+	t.Helper()
+	if req.Context() != ctx || req.Method != http.MethodPost || req.URL.String() != endpoint {
+		t.Fatalf("request context/method/URL mismatch: %s %s", req.Method, req.URL)
+	}
+	if !reflect.DeepEqual(req.Header, headers) {
+		t.Fatalf("headers=%v want %v", req.Header, headers)
+	}
+	if req.ContentLength != int64(len(body)) || (req.Body == nil) != (body == "") {
+		t.Fatalf("body metadata length=%d nil=%v want length=%d", req.ContentLength, req.Body == nil, len(body))
+	}
+	if body == "" {
+		if req.GetBody != nil {
+			t.Fatal("nil body gained replay")
+		}
+		return
+	}
+	data, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != body {
+		t.Fatalf("body=%q want %q", data, body)
+	}
+	if req.GetBody == nil {
+		t.Fatal("encoded body lost replay")
+	}
+	replay, err := req.GetBody()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer replay.Close()
+	data, err = io.ReadAll(replay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != body {
+		t.Fatalf("replay=%q want %q", data, body)
+	}
+}
+
+func TestJSONRequestAdoptionEnvelope(t *testing.T) {
+	type key struct{}
+	ctx := context.WithValue(context.Background(), key{}, "capture")
+	var typedNil *struct{ Value string }
+	const base = "https://api.example.test/base"
+	sentinel := errors.New("synthetic captured transport stop")
+	for _, tc := range []struct {
+		name        string
+		body        any
+		want        string
+		query, fail bool
+	}{
+		{name: "nil"},
+		{name: "typed nil", body: typedNil, want: "null\n"},
+		{name: "JSON bytes", body: map[string]string{"message": "<&>"}, want: "{\"message\":\"\\u003c\\u0026\\u003e\"}\n"},
+		{name: "query without body", query: true},
+		{name: "transport error", fail: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			endpoint := "/records"
+			if tc.query {
+				endpoint += "?limit=2&prefix=two+words"
+			}
+			var query url.Values
+			if tc.query {
+				query = url.Values{"limit": []string{"2"}, "prefix": []string{"two words"}}
+			}
+			headers := http.Header{"Authorization": []string{"Bearer synthetic-token"}}
+			headers.Set("Accept", "application/json")
+			if tc.body != nil {
+				headers.Set("Content-Type", "application/json")
+			}
+			transport := &http.Client{Transport: cubesandboxRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				assertAdoptionRequest(t, req, ctx, base+endpoint, tc.want, headers)
+				if tc.fail {
+					return nil, sentinel
+				}
+				return &http.Response{StatusCode: 204, Header: http.Header{"X-Capture": []string{"yes"}}, Body: io.NopCloser(strings.NewReader("")), Request: req}, nil
+			})}
+			c := &cubesandboxClient{apiURL: base, apiKey: "synthetic-token", httpClient: transport}
+			gotHeaders, err := c.doJSONWithHeaders(ctx, http.MethodPost, "/records", query, tc.body, nil)
+			if tc.fail {
+				if !errors.Is(err, sentinel) || gotHeaders != nil {
+					t.Fatalf("error/headers=%v %v", err, gotHeaders)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if !tc.fail && (gotHeaders.Get("X-Capture") != "yes") {
+				t.Fatalf("response headers=%v", gotHeaders)
+			}
+			if calls != 1 {
+				t.Fatalf("calls=%d", calls)
+			}
+		})
+	}
+}

--- a/internal/providers/cubesandbox/client.go
+++ b/internal/providers/cubesandbox/client.go
@@ -1,7 +1,6 @@
 package cubesandbox
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -347,19 +346,11 @@ func (c *cubesandboxClient) doJSON(ctx context.Context, method, path string, que
 }
 
 func (c *cubesandboxClient) doJSONWithHeaders(ctx context.Context, method, path string, query url.Values, body any, out any) (http.Header, error) {
-	var r io.Reader
-	if body != nil {
-		var buf bytes.Buffer
-		if err := json.NewEncoder(&buf).Encode(body); err != nil {
-			return nil, err
-		}
-		r = &buf
-	}
 	endpoint := c.apiURL + path
 	if len(query) > 0 {
 		endpoint += "?" + query.Encode()
 	}
-	req, err := http.NewRequestWithContext(ctx, method, endpoint, r)
+	req, err := shared.NewJSONRequest(ctx, method, endpoint, body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -1959,3 +1959,104 @@ func TestE2BProcessEndDoesNotUseStatusAsDiagnostic(t *testing.T) {
 		t.Fatalf("code=%d err=%v diagnostic=%q", code, err, diagnostic.String())
 	}
 }
+
+func assertAdoptionRequest(t *testing.T, req *http.Request, ctx context.Context, endpoint, body string, headers http.Header) {
+	t.Helper()
+	if req.Context() != ctx || req.Method != http.MethodPost || req.URL.String() != endpoint {
+		t.Fatalf("request context/method/URL mismatch: %s %s", req.Method, req.URL)
+	}
+	if !reflect.DeepEqual(req.Header, headers) {
+		t.Fatalf("headers=%v want %v", req.Header, headers)
+	}
+	if req.ContentLength != int64(len(body)) || (req.Body == nil) != (body == "") {
+		t.Fatalf("body metadata length=%d nil=%v want length=%d", req.ContentLength, req.Body == nil, len(body))
+	}
+	if body == "" {
+		if req.GetBody != nil {
+			t.Fatal("nil body gained replay")
+		}
+		return
+	}
+	data, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != body {
+		t.Fatalf("body=%q want %q", data, body)
+	}
+	if req.GetBody == nil {
+		t.Fatal("encoded body lost replay")
+	}
+	replay, err := req.GetBody()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer replay.Close()
+	data, err = io.ReadAll(replay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != body {
+		t.Fatalf("replay=%q want %q", data, body)
+	}
+}
+
+func TestJSONRequestAdoptionEnvelope(t *testing.T) {
+	type key struct{}
+	ctx := context.WithValue(context.Background(), key{}, "capture")
+	var typedNil *struct{ Value string }
+	const base = "https://api.example.test/base"
+	sentinel := errors.New("synthetic captured transport stop")
+	for _, tc := range []struct {
+		name        string
+		body        any
+		want        string
+		query, fail bool
+	}{
+		{name: "nil"},
+		{name: "typed nil", body: typedNil, want: "null\n"},
+		{name: "JSON bytes", body: map[string]string{"message": "<&>"}, want: "{\"message\":\"\\u003c\\u0026\\u003e\"}\n"},
+		{name: "query without body", query: true},
+		{name: "transport error", fail: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			endpoint := "/records"
+			if tc.query {
+				endpoint += "?limit=2&prefix=two+words"
+			}
+			var query url.Values
+			if tc.query {
+				query = url.Values{"limit": []string{"2"}, "prefix": []string{"two words"}}
+			}
+			headers := http.Header{"X-Api-Key": []string{"synthetic-token"}}
+			headers.Set("Accept", "application/json")
+			if tc.body != nil {
+				headers.Set("Content-Type", "application/json")
+			}
+			transport := &http.Client{Transport: e2bRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				assertAdoptionRequest(t, req, ctx, base+endpoint, tc.want, headers)
+				if tc.fail {
+					return nil, sentinel
+				}
+				return &http.Response{StatusCode: 204, Header: http.Header{"X-Capture": []string{"yes"}}, Body: io.NopCloser(strings.NewReader("")), Request: req}, nil
+			})}
+			c := &e2bClient{apiURL: base, apiKey: "synthetic-token", httpClient: transport}
+			gotHeaders, err := c.doJSONWithHeaders(ctx, http.MethodPost, "/records", query, tc.body, nil)
+			if tc.fail {
+				if !errors.Is(err, sentinel) || gotHeaders != nil {
+					t.Fatalf("error/headers=%v %v", err, gotHeaders)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if !tc.fail && (gotHeaders.Get("X-Capture") != "yes") {
+				t.Fatalf("response headers=%v", gotHeaders)
+			}
+			if calls != 1 {
+				t.Fatalf("calls=%d", calls)
+			}
+		})
+	}
+}

--- a/internal/providers/e2b/client.go
+++ b/internal/providers/e2b/client.go
@@ -1,7 +1,6 @@
 package e2b
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -260,19 +259,11 @@ func (c *e2bClient) doJSON(ctx context.Context, method, path string, query url.V
 }
 
 func (c *e2bClient) doJSONWithHeaders(ctx context.Context, method, path string, query url.Values, body any, out any) (http.Header, error) {
-	var r io.Reader
-	if body != nil {
-		var buf bytes.Buffer
-		if err := json.NewEncoder(&buf).Encode(body); err != nil {
-			return nil, err
-		}
-		r = &buf
-	}
 	endpoint := c.apiURL + path
 	if len(query) > 0 {
 		endpoint += "?" + query.Encode()
 	}
-	req, err := http.NewRequestWithContext(ctx, method, endpoint, r)
+	req, err := shared.NewJSONRequest(ctx, method, endpoint, body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/lambda/client.go
+++ b/internal/providers/lambda/client.go
@@ -1,7 +1,6 @@
 package lambda
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type Client struct {
@@ -50,15 +50,7 @@ func newClient(rt core.Runtime) (*Client, error) {
 }
 
 func (c *Client) do(ctx context.Context, method, path string, body any, out any) error {
-	var reader io.Reader
-	if body != nil {
-		var buf bytes.Buffer
-		if err := json.NewEncoder(&buf).Encode(body); err != nil {
-			return err
-		}
-		reader = &buf
-	}
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	req, err := shared.NewJSONRequest(ctx, method, c.baseURL+path, body)
 	if err != nil {
 		return err
 	}

--- a/internal/providers/lambda/client_test.go
+++ b/internal/providers/lambda/client_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -123,5 +125,106 @@ func TestLaunchRequestShape(t *testing.T) {
 		if _, ok := got[key]; ok {
 			t.Fatalf("request should not include unsupported %s: %s", key, data)
 		}
+	}
+}
+
+type adoptionRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f adoptionRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func assertAdoptionRequest(t *testing.T, req *http.Request, ctx context.Context, endpoint, body string, headers http.Header) {
+	t.Helper()
+	if req.Context() != ctx || req.Method != http.MethodPost || req.URL.String() != endpoint {
+		t.Fatalf("request context/method/URL mismatch: %s %s", req.Method, req.URL)
+	}
+	if !reflect.DeepEqual(req.Header, headers) {
+		t.Fatalf("headers=%v want %v", req.Header, headers)
+	}
+	if req.ContentLength != int64(len(body)) || (req.Body == nil) != (body == "") {
+		t.Fatalf("body metadata length=%d nil=%v want length=%d", req.ContentLength, req.Body == nil, len(body))
+	}
+	if body == "" {
+		if req.GetBody != nil {
+			t.Fatal("nil body gained replay")
+		}
+		return
+	}
+	data, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != body {
+		t.Fatalf("body=%q want %q", data, body)
+	}
+	if req.GetBody == nil {
+		t.Fatal("encoded body lost replay")
+	}
+	replay, err := req.GetBody()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer replay.Close()
+	data, err = io.ReadAll(replay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != body {
+		t.Fatalf("replay=%q want %q", data, body)
+	}
+}
+
+func TestJSONRequestAdoptionEnvelope(t *testing.T) {
+	type key struct{}
+	ctx := context.WithValue(context.Background(), key{}, "capture")
+	var typedNil *struct{ Value string }
+	const base = "https://api.example.test/base"
+	sentinel := errors.New("synthetic captured transport stop")
+	for _, tc := range []struct {
+		name        string
+		body        any
+		want        string
+		query, fail bool
+	}{
+		{name: "nil"},
+		{name: "typed nil", body: typedNil, want: "null\n"},
+		{name: "JSON bytes", body: map[string]string{"message": "<&>"}, want: "{\"message\":\"\\u003c\\u0026\\u003e\"}\n"},
+		{name: "query without body", query: true},
+		{name: "transport error", fail: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			endpoint := "/records"
+			if tc.query {
+				endpoint += "?limit=2&prefix=two+words"
+			}
+
+			headers := http.Header{"Authorization": []string{"Bearer synthetic-token"}}
+			headers.Set("Accept", "application/json")
+			if tc.body != nil {
+				headers.Set("Content-Type", "application/json")
+			}
+			transport := &http.Client{Transport: adoptionRoundTripper(func(req *http.Request) (*http.Response, error) {
+				calls++
+				assertAdoptionRequest(t, req, ctx, base+endpoint, tc.want, headers)
+				if tc.fail {
+					return nil, sentinel
+				}
+				return &http.Response{StatusCode: 204, Header: http.Header{"X-Capture": []string{"yes"}}, Body: io.NopCloser(strings.NewReader("")), Request: req}, nil
+			})}
+			c := &Client{baseURL: base, token: "synthetic-token", client: transport}
+			var gotHeaders http.Header
+			err := c.do(ctx, http.MethodPost, endpoint, tc.body, nil)
+			if tc.fail {
+				if !errors.Is(err, sentinel) || gotHeaders != nil {
+					t.Fatalf("error/headers=%v %v", err, gotHeaders)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+
+			if calls != 1 {
+				t.Fatalf("calls=%d", calls)
+			}
+		})
 	}
 }

--- a/internal/providers/sprites/backend_test.go
+++ b/internal/providers/sprites/backend_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -780,4 +781,104 @@ func (f *fakeSpritesAPI) DeleteSprite(_ context.Context, name string) error {
 	}
 	f.deleted = name
 	return nil
+}
+
+func assertAdoptionRequest(t *testing.T, req *http.Request, ctx context.Context, endpoint, body string, headers http.Header) {
+	t.Helper()
+	if req.Context() != ctx || req.Method != http.MethodPost || req.URL.String() != endpoint {
+		t.Fatalf("request context/method/URL mismatch: %s %s", req.Method, req.URL)
+	}
+	if !reflect.DeepEqual(req.Header, headers) {
+		t.Fatalf("headers=%v want %v", req.Header, headers)
+	}
+	if req.ContentLength != int64(len(body)) || (req.Body == nil) != (body == "") {
+		t.Fatalf("body metadata length=%d nil=%v want length=%d", req.ContentLength, req.Body == nil, len(body))
+	}
+	if body == "" {
+		if req.GetBody != nil {
+			t.Fatal("nil body gained replay")
+		}
+		return
+	}
+	data, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != body {
+		t.Fatalf("body=%q want %q", data, body)
+	}
+	if req.GetBody == nil {
+		t.Fatal("encoded body lost replay")
+	}
+	replay, err := req.GetBody()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer replay.Close()
+	data, err = io.ReadAll(replay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != body {
+		t.Fatalf("replay=%q want %q", data, body)
+	}
+}
+
+func TestJSONRequestAdoptionEnvelope(t *testing.T) {
+	type key struct{}
+	ctx := context.WithValue(context.Background(), key{}, "capture")
+	var typedNil *struct{ Value string }
+	const base = "https://api.example.test/base"
+	sentinel := errors.New("synthetic captured transport stop")
+	for _, tc := range []struct {
+		name        string
+		body        any
+		want        string
+		query, fail bool
+	}{
+		{name: "nil"},
+		{name: "typed nil", body: typedNil, want: "null\n"},
+		{name: "JSON bytes", body: map[string]string{"message": "<&>"}, want: "{\"message\":\"\\u003c\\u0026\\u003e\"}\n"},
+		{name: "query without body", query: true},
+		{name: "transport error", fail: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			endpoint := "/records"
+			if tc.query {
+				endpoint += "?limit=2&prefix=two+words"
+			}
+			var query url.Values
+			if tc.query {
+				query = url.Values{"limit": []string{"2"}, "prefix": []string{"two words"}}
+			}
+			headers := http.Header{"Authorization": []string{"Bearer synthetic-token"}}
+			headers.Set("Accept", "application/json")
+			if tc.body != nil {
+				headers.Set("Content-Type", "application/json")
+			}
+			transport := &http.Client{Transport: spritesRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				assertAdoptionRequest(t, req, ctx, base+endpoint, tc.want, headers)
+				if tc.fail {
+					return nil, sentinel
+				}
+				return &http.Response{StatusCode: 204, Header: http.Header{"X-Capture": []string{"yes"}}, Body: io.NopCloser(strings.NewReader("")), Request: req}, nil
+			})}
+			c := &spritesClient{apiURL: base, token: "synthetic-token", httpClient: transport}
+			var gotHeaders http.Header
+			err := c.doJSON(ctx, http.MethodPost, "/records", query, tc.body, nil)
+			if tc.fail {
+				if !errors.Is(err, sentinel) || gotHeaders != nil {
+					t.Fatalf("error/headers=%v %v", err, gotHeaders)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+
+			if calls != 1 {
+				t.Fatalf("calls=%d", calls)
+			}
+		})
+	}
 }

--- a/internal/providers/sprites/client.go
+++ b/internal/providers/sprites/client.go
@@ -1,7 +1,6 @@
 package sprites
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -240,19 +239,11 @@ func (c *spritesClient) DeleteSprite(ctx context.Context, name string) error {
 }
 
 func (c *spritesClient) doJSON(ctx context.Context, method, requestPath string, query url.Values, body any, out any) error {
-	var r io.Reader
-	if body != nil {
-		var buf bytes.Buffer
-		if err := json.NewEncoder(&buf).Encode(body); err != nil {
-			return err
-		}
-		r = &buf
-	}
 	endpoint := c.apiURL + requestPath
 	if len(query) > 0 {
 		endpoint += "?" + query.Encode()
 	}
-	req, err := http.NewRequestWithContext(ctx, method, endpoint, r)
+	req, err := shared.NewJSONRequest(ctx, method, endpoint, body)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Use the existing shared JSON request constructor at all ten remaining default-Encoder HTTP entrypoints across Lambda, Cloudflare, Cloudflare Dynamic Workers, Azure Dynamic Sessions, E2B, CubeSandbox and Sprites. This completes that encoding class without adding options or a common cloud client.

Each adapter retains its method, URL/query construction, headers, client selection, retry placement, tuple error returns and complete response/stream handling. Dynamic Workers still builds a request inside each attempt. The three operations with streamed responses still send ordinary buffered JSON requests; their response paths are untouched.

The actual E2B/CubeSandbox/Sprites callers separate body-bearing and query-bearing requests, so keeping query construction locally before the helper preserves their behavior. Orgo's different HTML escaping, OVH's trimmed signed bytes, Marshal-based bodies and true binary/framed streams remain intentionally separate.

## Verification

- Seven pinned original client implementations and the candidate passed the same frozen tests: all ten entrypoints, 35 optional-body cases, three concrete request captures and seven existing ordinary loopback tests.
- Race-enabled verification passed 17 tests and 35 subtests across all seven packages with Go 1.26.5, without failures or skips.
- Independent managed Codex review passed at P0 scope. Docs generation and whitespace checks passed.
- Reversing the ten constructor changes and necessary imports restores all seven original client files byte-for-byte. The production Encoder census now contains only the shared HTTP constructor and the five documented incompatible or non-HTTP encoders.

Builds on https://github.com/openclaw/crabbox/pull/2122. No credentials, lifecycle rules, response policies or public CLI behavior change. Tests use synthetic data with local/inert transports, not real cloud accounts.

## Observed production-client HTTP trace

Source: `c7b68d2ad9dd194338b18bf2aef3e8d7c64e3575`. All ten request-building entrypoints across seven provider packages were exercised using seven additive test overlays, real HTTP transport, and synthetic loopback servers. No production file was replaced; source bytes/modes and clean Git state were unchanged.

Targeted race-enabled proof passed: 24 requests in 18.36 seconds. All server responses were ordinary `400` errors, and every client returned an error through its existing response path. These responses stop before specialized stream/operation tails. All authentication headers were present; values were not recorded.

| Entrypoint | Case | Method and path | Query | Content-Type | Length | Actual body (JSON string notation) | Auth header |
|---|---|---|---|---|---:|---|---|
| lambda.do | nil | `POST /proof/records` | `limit=2&tag=a&tag=b` | (absent) | 0 | `""` | Authorization PRESENT |
| lambda.do | typed-nil | `POST /proof/records` | (none) | `application/json` | 5 | `"null\n"` | Authorization PRESENT |
| lambda.do | structured | `POST /proof/records` | (none) | `application/json` | 33 | `"{\"message\":\"\\u003c\\u0026\\u003e\"}\n"` | Authorization PRESENT |
| cloudflare.doJSON | nil | `POST /proof/records` | `limit=2&tag=a&tag=b` | (absent) | 0 | `""` | Authorization PRESENT |
| cloudflare.doJSON | typed-nil | `POST /proof/records` | (none) | `application/json` | 5 | `"null\n"` | Authorization PRESENT |
| cloudflare.doJSON | structured | `POST /proof/records` | (none) | `application/json` | 33 | `"{\"message\":\"\\u003c\\u0026\\u003e\"}\n"` | Authorization PRESENT |
| cloudflare.execStream | concrete | `POST /v1/sandboxes/proof-sandbox/exec-stream` | `instanceType=proof-type` | `application/json` | 66 | `"{\"command\":\"display \\u003c\\u0026\\u003e\",\"cwd\":\"/workspace/proof\"}\n"` | Authorization PRESENT |
| cloudflaredynamicworkers.doJSON | nil | `POST /proof/records` | `limit=2&tag=a&tag=b` | (absent) | 0 | `""` | Authorization PRESENT |
| cloudflaredynamicworkers.doJSON | typed-nil | `POST /proof/records` | (none) | `application/json` | 5 | `"null\n"` | Authorization PRESENT |
| cloudflaredynamicworkers.doJSON | structured | `POST /proof/records` | (none) | `application/json` | 33 | `"{\"message\":\"\\u003c\\u0026\\u003e\"}\n"` | Authorization PRESENT |
| cloudflaredynamicworkers.Run | concrete | `POST /v1/runs` | (none) | `application/json` | 123 | `"{\"id\":\"proof-run\",\"cacheMode\":\"off\",\"retainMetadata\":false,\"module\":{\"source\":\"display-only\"},\"egress\":\"none\",\"limits\":{}}\n"` | Authorization PRESENT |
| azuredynamicsessions.doJSONURL | nil | `POST /proof/records` | `limit=2&tag=a&tag=b` | (absent) | 0 | `""` | Authorization PRESENT |
| azuredynamicsessions.doJSONURL | typed-nil | `POST /proof/records` | (none) | `application/json` | 5 | `"null\n"` | Authorization PRESENT |
| azuredynamicsessions.doJSONURL | structured | `POST /proof/records` | (none) | `application/json` | 33 | `"{\"message\":\"\\u003c\\u0026\\u003e\"}\n"` | Authorization PRESENT |
| azuredynamicsessions.ExecStream | concrete | `POST /v1/exec` | `identifier=proof-session` | `application/json` | 66 | `"{\"command\":\"display \\u003c\\u0026\\u003e\",\"cwd\":\"/workspace/proof\"}\n"` | Authorization PRESENT |
| e2b.doJSONWithHeaders | nil | `POST /proof/records` | `limit=2&tag=a&tag=b` | (absent) | 0 | `""` | X-API-Key PRESENT |
| e2b.doJSONWithHeaders | typed-nil | `POST /proof/records` | (none) | `application/json` | 5 | `"null\n"` | X-API-Key PRESENT |
| e2b.doJSONWithHeaders | structured | `POST /proof/records` | (none) | `application/json` | 33 | `"{\"message\":\"\\u003c\\u0026\\u003e\"}\n"` | X-API-Key PRESENT |
| cubesandbox.doJSONWithHeaders | nil | `POST /proof/records` | `limit=2&tag=a&tag=b` | (absent) | 0 | `""` | Authorization PRESENT |
| cubesandbox.doJSONWithHeaders | typed-nil | `POST /proof/records` | (none) | `application/json` | 5 | `"null\n"` | Authorization PRESENT |
| cubesandbox.doJSONWithHeaders | structured | `POST /proof/records` | (none) | `application/json` | 33 | `"{\"message\":\"\\u003c\\u0026\\u003e\"}\n"` | Authorization PRESENT |
| sprites.doJSON | nil | `POST /proof/records` | `limit=2&tag=a&tag=b` | (absent) | 0 | `""` | Authorization PRESENT |
| sprites.doJSON | typed-nil | `POST /proof/records` | (none) | `application/json` | 5 | `"null\n"` | Authorization PRESENT |
| sprites.doJSON | structured | `POST /proof/records` | (none) | `application/json` | 33 | `"{\"message\":\"\\u003c\\u0026\\u003e\"}\n"` | Authorization PRESENT |

The seven generic entrypoints each received nil, typed-nil, and structured inputs. Nil bodies carried the query fixture; nonnil bodies had no query, preserving the qualified E2B/Cube/Sprites input combination. The three concrete envelopes exercised Cloudflare exec-stream, Dynamic Workers Run, and Azure Dynamic Sessions ExecStream.

Limits: this proves local HTTP envelope behavior, not provider availability, credential validity, successful streaming, remote execution, or lifecycle behavior. No client retry policy, timer, transport, redirect/admission guard, or native tool was replaced. Retry behavior was not exercised. The initial unexecuted 503 harness preparation is retained separately; only the frozen 400 version ran. No public writes were performed.
