### PR TITLE
refactor: share compact JSON request construction

### DIFF
--- a/docs/refactor/provider-http-requests.md
+++ b/docs/refactor/provider-http-requests.md
@@ -27,3 +27,21 @@ existing error boundaries. Later failures return previously accumulated pages,
 but never partially decoded current-page data. Ordering, duplicates and nil
 results are preserved. Empty data and the reported result count do not stop
 traversal; only the existing page-count rule does.
+
+## Compact JSON requests
+
+`shared.NewCompactJSONRequest` owns the separate Marshal-based envelope used by
+Hostinger, Vast, Morph, Upstash Box, Railway and Cloud Run Sandbox. It preserves
+compact bytes without an Encoder newline, default HTML escaping, context,
+content length and body replay. A nil interface leaves the body absent; a
+typed-nil value still produces `null`.
+
+URL construction and context lifetime remain caller-owned. Morph still reports
+its URL parsing failures before encoding. Cloud Run still establishes and
+cancels its timeout outside the constructor, and a typed-nil map remains a JSON
+body. Headers, transport, retries and response handling do not move.
+
+Stage-specific error labels, fallible checks between encoding and construction,
+signed payloads, distinct empty-reader contracts and streaming readers remain
+separate. The two named constructors describe different wire contracts, not a
+configurable provider-client framework.

--- a/internal/providers/cloudrunsandbox/client.go
+++ b/internal/providers/cloudrunsandbox/client.go
@@ -213,11 +213,7 @@ func (t *remoteTransport) authorize(req *http.Request) {
 func (t *remoteTransport) request(ctx context.Context, path string, body map[string]any) (json.RawMessage, error) {
 	ctx, cancel := contextWithDefaultTimeout(ctx, defaultExecTimeout)
 	defer cancel()
-	payload, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.baseURL+path, bytes.NewReader(payload))
+	req, err := shared.NewCompactJSONRequest(ctx, http.MethodPost, t.baseURL+path, body)
 	if err != nil {
 		return nil, err
 	}
@@ -382,11 +378,7 @@ func (t *remoteTransport) Exec(ctx context.Context, sandboxID, command string, o
 	}
 	ctx, cancel := contextWithDefaultTimeout(ctx, defaultExecTimeout)
 	defer cancel()
-	payload, err := json.Marshal(body)
-	if err != nil {
-		return 1, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.baseURL+"/v1/sandbox/exec", bytes.NewReader(payload))
+	req, err := shared.NewCompactJSONRequest(ctx, http.MethodPost, t.baseURL+"/v1/sandbox/exec", body)
 	if err != nil {
 		return 1, err
 	}

--- a/internal/providers/cloudrunsandbox/client_test.go
+++ b/internal/providers/cloudrunsandbox/client_test.go
@@ -19,6 +19,7 @@ import (
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestCloudRunNativeExitFixture(t *testing.T) {
@@ -789,4 +790,82 @@ func (r recordingLocalExec) Run(_ context.Context, req LocalCommandRequest) (Loc
 		return r.handler(req)
 	}
 	return LocalCommandResult{}, nil
+}
+
+func TestCompactJSONRemoteRequestAndExecEnvelopes(t *testing.T) {
+	type key struct{}
+	for _, parentDeadline := range []bool{false, true} {
+		for _, tc := range []struct {
+			name string
+			body map[string]any
+			want string
+			exec bool
+		}{
+			{"typed nil map", nil, "null", false}, {"empty map", map[string]any{}, "{}", false}, {"map JSON", map[string]any{"message": "<&>"}, `{"message":"\u003c\u0026\u003e"}`, false},
+			{name: "exec", exec: true, want: `{"allowEgress":false,"command":"\u003c\u0026\u003e","executionMode":"stateful","sandboxId":"box","timeout":7,"write":false}`},
+		} {
+			t.Run(tc.name+map[bool]string{false: "/default deadline", true: "/parent deadline"}[parentDeadline], func(t *testing.T) {
+				ctx := context.WithValue(context.Background(), key{}, "ctx")
+				cancel := func() {}
+				if parentDeadline {
+					ctx, cancel = context.WithTimeout(ctx, time.Minute)
+				}
+				defer cancel()
+				before := time.Now()
+				calls := 0
+				var captured context.Context
+				headers := http.Header{}
+				headers.Set("Content-Type", "application/json")
+				headers.Set("Accept", "application/json")
+				headers.Set("X-ComputeSDK-Cloud-Run-Secret", "synthetic-secret")
+				headers.Set("Authorization", "Bearer synthetic-token")
+				endpoint := "https://api.example.test/base/records"
+				if tc.exec {
+					endpoint = "https://api.example.test/base/v1/sandbox/exec"
+					headers.Set("Accept", "application/x-ndjson")
+				}
+				transport := &remoteTransport{baseURL: "https://api.example.test/base", secret: "synthetic-secret", authToken: "synthetic-token", http: &http.Client{Transport: testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+					calls++
+					captured = req.Context()
+					if captured == ctx || captured.Value(key{}) != "ctx" {
+						t.Fatal("timeout context lost parent values or was not derived")
+					}
+					testutil.RequireRequestEnvelope(t, req, captured, http.MethodPost, endpoint, tc.want, headers)
+					return nil, errors.New("synthetic-transport-stop")
+				})}}
+				var err error
+				if tc.exec {
+					var code int
+					code, err = transport.Exec(ctx, "box", "<&>", execOptions{Timeout: 7 * time.Millisecond}, io.Discard, io.Discard)
+					if code != 1 {
+						t.Fatalf("code=%d", code)
+					}
+				} else {
+					var out json.RawMessage
+					out, err = transport.request(ctx, "/records", tc.body)
+					if out != nil {
+						t.Fatalf("out=%s", out)
+					}
+				}
+				if err == nil || !strings.Contains(err.Error(), "synthetic-transport-stop") || calls != 1 {
+					t.Fatalf("error=%v calls=%d", err, calls)
+				}
+				deadline, ok := captured.Deadline()
+				if !ok {
+					t.Fatal("missing request deadline")
+				}
+				if parentDeadline {
+					want, _ := ctx.Deadline()
+					if !deadline.Equal(want) {
+						t.Fatalf("deadline=%v want%v", deadline, want)
+					}
+				} else if deadline.Before(before.Add(defaultExecTimeout)) || deadline.After(time.Now().Add(defaultExecTimeout)) {
+					t.Fatalf("default deadline=%v", deadline)
+				}
+				if captured.Err() != context.Canceled || ctx.Err() != nil {
+					t.Fatalf("cancellation child=%v parent=%v", captured.Err(), ctx.Err())
+				}
+			})
+		}
+	}
 }

--- a/internal/providers/hostinger/client.go
+++ b/internal/providers/hostinger/client.go
@@ -1,11 +1,9 @@
 package hostinger
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -190,15 +188,7 @@ func hostingerRedirectError(destination *url.URL) error {
 }
 
 func (c *hostingerClient) do(ctx context.Context, method, path string, body any, out any) error {
-	var reader io.Reader
-	if body != nil {
-		data, err := json.Marshal(body)
-		if err != nil {
-			return err
-		}
-		reader = bytes.NewReader(data)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, c.apiURL+path, reader)
+	req, err := shared.NewCompactJSONRequest(ctx, method, c.apiURL+path, body)
 	if err != nil {
 		return err
 	}

--- a/internal/providers/hostinger/provider_test.go
+++ b/internal/providers/hostinger/provider_test.go
@@ -2745,3 +2745,40 @@ func (f *fakeAPI) StopVM(_ context.Context, id string) error {
 	}
 	return nil
 }
+
+func TestCompactJSONRequestEnvelope(t *testing.T) {
+	type key struct{}
+	ctx := context.WithValue(context.Background(), key{}, "ctx")
+	const base = "https://api.example.test/base"
+	var ptr *string
+	var slice []string
+	for _, tc := range []struct {
+		name string
+		body any
+		want string
+	}{
+		{name: "nil"}, {name: "typed nil pointer", body: ptr, want: "null"}, {name: "typed nil slice", body: slice, want: "null"}, {name: "compact escaped JSON", body: map[string]string{"message": "<&>"}, want: "{\"message\":\"\\u003c\\u0026\\u003e\"}"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			path := "/records"
+			endpoint := base + path
+			headers := http.Header{}
+			headers.Set("Authorization", "Bearer synthetic-token")
+			headers.Set("Accept", "application/json")
+			if tc.body != nil {
+				headers.Set("Content-Type", "application/json")
+			}
+			httpClient := &http.Client{Transport: testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				testutil.RequireRequestEnvelope(t, req, ctx, http.MethodPost, endpoint, tc.want, headers)
+				return nil, errors.New("synthetic-transport-stop")
+			})}
+			c := &hostingerClient{apiURL: base, token: "synthetic-token", httpClient: httpClient}
+			err := c.do(ctx, http.MethodPost, path, tc.body, nil)
+			if err == nil || !strings.Contains(err.Error(), "synthetic-transport-stop") || calls != 1 {
+				t.Fatalf("error=%v calls=%d", err, calls)
+			}
+		})
+	}
+}

--- a/internal/providers/morph/client.go
+++ b/internal/providers/morph/client.go
@@ -297,15 +297,7 @@ func (c *morphClient) doRaw(ctx context.Context, method, path string, query url.
 	if len(query) > 0 {
 		endpoint.RawQuery = query.Encode()
 	}
-	var payload io.Reader
-	if body != nil {
-		data, err := json.Marshal(body)
-		if err != nil {
-			return nil, err
-		}
-		payload = bytes.NewReader(data)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, endpoint.String(), payload)
+	req, err := shared.NewCompactJSONRequest(ctx, method, endpoint.String(), body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/morph/client_test.go
+++ b/internal/providers/morph/client_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/openclaw/crabbox/internal/providers/shared"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestMorphClientRedactsReflectedCredential(t *testing.T) {
@@ -229,5 +230,54 @@ func TestMorphClientListInstancesAndWakeOnRequest(t *testing.T) {
 	}
 	if err := client.UpdateInstanceWakeOn(context.Background(), "inst_1", boolPtr(true), nil); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCompactJSONRequestEnvelope(t *testing.T) {
+	type key struct{}
+	ctx := context.WithValue(context.Background(), key{}, "ctx")
+	const base = "https://api.example.test/base"
+	var ptr *string
+	var slice []string
+	for _, tc := range []struct {
+		name string
+		body any
+		want string
+	}{
+		{name: "nil"}, {name: "typed nil pointer", body: ptr, want: "null"}, {name: "typed nil slice", body: slice, want: "null"}, {name: "compact escaped JSON", body: map[string]string{"message": "<&>"}, want: "{\"message\":\"\\u003c\\u0026\\u003e\"}"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			path := "/records"
+			endpoint := base + path
+			headers := http.Header{}
+			headers.Set("Authorization", "Bearer synthetic-token")
+			if tc.body != nil {
+				headers.Set("Content-Type", "application/json")
+			}
+			httpClient := &http.Client{Transport: testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				testutil.RequireRequestEnvelope(t, req, ctx, http.MethodPost, endpoint, tc.want, headers)
+				return nil, errors.New("synthetic-transport-stop")
+			})}
+			c := &morphClient{apiURL: base, apiKey: "synthetic-token", httpClient: httpClient}
+			out, err := c.doRaw(ctx, http.MethodPost, path, nil, tc.body)
+			if out != nil {
+				t.Fatalf("out=%v", out)
+			}
+			if err == nil || !strings.Contains(err.Error(), "synthetic-transport-stop") || calls != 1 {
+				t.Fatalf("error=%v calls=%d", err, calls)
+			}
+		})
+	}
+}
+
+func TestCompactJSONMorphURLFailurePrecedesEncoding(t *testing.T) {
+	calls := 0
+	c := &morphClient{apiURL: "https://api.example.test/%", httpClient: &http.Client{Transport: testutil.RoundTripFunc(func(*http.Request) (*http.Response, error) { calls++; return nil, errors.New("unexpected transport") })}}
+	out, err := c.doRaw(context.Background(), http.MethodPost, "/records", nil, make(chan int))
+	var urlError *url.Error
+	if out != nil || !errors.As(err, &urlError) || calls != 0 {
+		t.Fatalf("out=%v error=%T %v calls=%d", out, err, err, calls)
 	}
 }

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -17,6 +17,7 @@ import (
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestRailwayProviderSpec(t *testing.T) {
@@ -1171,6 +1172,35 @@ func TestRailwayFlagsRejectUnsupportedSizingForAliases(t *testing.T) {
 			err := ApplyRailwayProviderFlags(&cfg, fs, values)
 			if err == nil || !strings.Contains(err.Error(), "--class is not supported") {
 				t.Fatalf("err = %v, want class rejection", err)
+			}
+		})
+	}
+}
+
+func TestCompactJSONGraphQLEnvelope(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name string
+		vars map[string]any
+		want string
+	}{
+		{"nil variables", nil, `{"query":"\u003c\u0026\u003e"}`},
+		{"variables", map[string]any{"name": "<&>"}, `{"query":"\u003c\u0026\u003e","variables":{"name":"\u003c\u0026\u003e"}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			headers := http.Header{}
+			headers.Set("Authorization", "Bearer synthetic-token")
+			headers.Set("Content-Type", "application/json")
+			headers.Set("Accept", "application/json")
+			c := &railwayClient{apiURL: "https://api.example.test/graphql", apiToken: "synthetic-token", httpClient: &http.Client{Transport: testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				testutil.RequireRequestEnvelope(t, req, ctx, http.MethodPost, "https://api.example.test/graphql", tc.want, headers)
+				return nil, errors.New("synthetic-transport-stop")
+			})}}
+			err := c.do(ctx, "<&>", tc.vars, nil)
+			if err == nil || !strings.Contains(err.Error(), "synthetic-transport-stop") || calls != 1 {
+				t.Fatalf("error=%v calls=%d", err, calls)
 			}
 		})
 	}

--- a/internal/providers/railway/client.go
+++ b/internal/providers/railway/client.go
@@ -1,7 +1,6 @@
 package railway
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -209,11 +208,7 @@ type graphqlResponse struct {
 }
 
 func (c *railwayClient) do(ctx context.Context, query string, vars map[string]any, out any) error {
-	body, err := json.Marshal(graphqlRequest{Query: query, Variables: vars})
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURL, bytes.NewReader(body))
+	req, err := shared.NewCompactJSONRequest(ctx, http.MethodPost, c.apiURL, graphqlRequest{Query: query, Variables: vars})
 	if err != nil {
 		return err
 	}

--- a/internal/providers/shared/httprequest.go
+++ b/internal/providers/shared/httprequest.go
@@ -21,3 +21,17 @@ func NewJSONRequest(ctx context.Context, method, url string, body any) (*http.Re
 	}
 	return http.NewRequestWithContext(ctx, method, url, reader)
 }
+
+// NewCompactJSONRequest uses Marshal's compact wire representation without the
+// Encoder newline. A nil interface stays absent; typed-nil values encode as null.
+func NewCompactJSONRequest(ctx context.Context, method, url string, body any) (*http.Request, error) {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		reader = bytes.NewReader(data)
+	}
+	return http.NewRequestWithContext(ctx, method, url, reader)
+}

--- a/internal/providers/shared/httprequest_test.go
+++ b/internal/providers/shared/httprequest_test.go
@@ -10,26 +10,42 @@ import (
 )
 
 func TestNewJSONRequestEnvelope(t *testing.T) {
+	testJSONRequestEnvelope(t, NewJSONRequest, false)
+}
+
+func TestNewCompactJSONRequestEnvelope(t *testing.T) {
+	testJSONRequestEnvelope(t, NewCompactJSONRequest, true)
+}
+
+func testJSONRequestEnvelope(t *testing.T, newRequest func(context.Context, string, string, any) (*http.Request, error), compact bool) {
+	t.Helper()
 	type contextKey struct{}
 	ctx := context.WithValue(context.Background(), contextKey{}, "request-context")
 	var pointer *int
 	var slice []string
+	var mapping map[string]string
 	for _, tc := range []struct {
-		name string
-		body any
-		wire string
+		name        string
+		body        any
+		encoderWire string
+		compactWire string
 	}{
 		{name: "nil interface"},
-		{name: "typed nil pointer", body: pointer, wire: "null\n"},
-		{name: "typed nil slice", body: slice, wire: "null\n"},
+		{name: "typed nil pointer", body: pointer, encoderWire: "null\n", compactWire: "null"},
+		{name: "typed nil slice", body: slice, encoderWire: "null\n", compactWire: "null"},
+		{name: "typed nil map", body: mapping, encoderWire: "null\n", compactWire: "null"},
 		{name: "encoded object", body: struct {
 			Text  string `json:"text"`
 			Count int    `json:"count"`
-		}{Text: "<tag>&\n", Count: 7}, wire: "{\"text\":\"\\u003ctag\\u003e\\u0026\\n\",\"count\":7}\n"},
+		}{Text: "<tag>&\n", Count: 7}, encoderWire: "{\"text\":\"\\u003ctag\\u003e\\u0026\\n\",\"count\":7}\n", compactWire: "{\"text\":\"\\u003ctag\\u003e\\u0026\\n\",\"count\":7}"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			wire := tc.encoderWire
+			if compact {
+				wire = tc.compactWire
+			}
 			const target = "https://example.invalid/resource?part=one"
-			req, err := NewJSONRequest(ctx, http.MethodPost, target, tc.body)
+			req, err := newRequest(ctx, http.MethodPost, target, tc.body)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -39,8 +55,8 @@ func TestNewJSONRequestEnvelope(t *testing.T) {
 			if len(req.Header) != 0 {
 				t.Fatalf("constructor added headers: %v", req.Header)
 			}
-			if req.ContentLength != int64(len(tc.wire)) {
-				t.Fatalf("ContentLength=%d want %d", req.ContentLength, len(tc.wire))
+			if req.ContentLength != int64(len(wire)) {
+				t.Fatalf("ContentLength=%d want %d", req.ContentLength, len(wire))
 			}
 			if tc.body == nil {
 				if req.Body != nil || req.GetBody != nil {
@@ -58,8 +74,8 @@ func TestNewJSONRequestEnvelope(t *testing.T) {
 			if err := req.Body.Close(); err != nil {
 				t.Fatal(err)
 			}
-			if string(data) != tc.wire {
-				t.Fatalf("body=%q want %q", data, tc.wire)
+			if string(data) != wire {
+				t.Fatalf("body=%q want %q", data, wire)
 			}
 			for range 2 {
 				replay, err := req.GetBody()
@@ -73,8 +89,8 @@ func TestNewJSONRequestEnvelope(t *testing.T) {
 				if err := replay.Close(); err != nil {
 					t.Fatal(err)
 				}
-				if string(data) != tc.wire {
-					t.Fatalf("replay=%q want %q", data, tc.wire)
+				if string(data) != wire {
+					t.Fatalf("replay=%q want %q", data, wire)
 				}
 			}
 		})
@@ -82,6 +98,15 @@ func TestNewJSONRequestEnvelope(t *testing.T) {
 }
 
 func TestNewJSONRequestEncodingErrorPrecedesConstruction(t *testing.T) {
+	testJSONRequestEncodingErrorPrecedesConstruction(t, NewJSONRequest)
+}
+
+func TestNewCompactJSONRequestEncodingErrorPrecedesConstruction(t *testing.T) {
+	testJSONRequestEncodingErrorPrecedesConstruction(t, NewCompactJSONRequest)
+}
+
+func testJSONRequestEncodingErrorPrecedesConstruction(t *testing.T, newRequest func(context.Context, string, string, any) (*http.Request, error)) {
+	t.Helper()
 	body := make(chan int)
 	for _, tc := range []struct {
 		name        string
@@ -94,7 +119,7 @@ func TestNewJSONRequestEncodingErrorPrecedesConstruction(t *testing.T) {
 		{name: "nil context", method: http.MethodPost, url: "https://example.invalid"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			req, err := NewJSONRequest(tc.ctx, tc.method, tc.url, body)
+			req, err := newRequest(tc.ctx, tc.method, tc.url, body)
 			encodingErr, ok := err.(*json.UnsupportedTypeError)
 			if req != nil || !ok || encodingErr.Type != reflect.TypeOf(body) {
 				t.Fatalf("got request=%v error=%T %v", req, err, err)
@@ -104,6 +129,15 @@ func TestNewJSONRequestEncodingErrorPrecedesConstruction(t *testing.T) {
 }
 
 func TestNewJSONRequestConstructionErrorsAndCanceledContext(t *testing.T) {
+	testJSONRequestConstructionErrorsAndCanceledContext(t, NewJSONRequest)
+}
+
+func TestNewCompactJSONRequestConstructionErrorsAndCanceledContext(t *testing.T) {
+	testJSONRequestConstructionErrorsAndCanceledContext(t, NewCompactJSONRequest)
+}
+
+func testJSONRequestConstructionErrorsAndCanceledContext(t *testing.T, newRequest func(context.Context, string, string, any) (*http.Request, error)) {
+	t.Helper()
 	for _, tc := range []struct {
 		ctx         context.Context
 		method, url string
@@ -113,14 +147,14 @@ func TestNewJSONRequestConstructionErrorsAndCanceledContext(t *testing.T) {
 		{nil, http.MethodGet, "https://example.invalid"},
 	} {
 		_, want := http.NewRequestWithContext(tc.ctx, tc.method, tc.url, nil)
-		req, err := NewJSONRequest(tc.ctx, tc.method, tc.url, nil)
+		req, err := newRequest(tc.ctx, tc.method, tc.url, nil)
 		if req != nil || err == nil || want == nil || err.Error() != want.Error() || reflect.TypeOf(err) != reflect.TypeOf(want) {
 			t.Fatalf("request=%v error=%v want=%v", req, err, want)
 		}
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	req, err := NewJSONRequest(ctx, "", "https://example.invalid", nil)
+	req, err := newRequest(ctx, "", "https://example.invalid", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/upstashbox/backend_test.go
+++ b/internal/providers/upstashbox/backend_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestProviderSpecAndAliases(t *testing.T) {
@@ -2119,5 +2120,58 @@ func TestRunSourceIntentSurvivesNativeShell(t *testing.T) {
 				t.Fatalf("literal created sentinel: %v", err)
 			}
 		})
+	}
+}
+
+func TestCompactJSONRequestEnvelope(t *testing.T) {
+	type key struct{}
+	ctx := context.WithValue(context.Background(), key{}, "ctx")
+	const base = "https://api.example.test/base"
+	var ptr *string
+	var slice []string
+	for _, tc := range []struct {
+		name string
+		body any
+		want string
+	}{
+		{name: "nil"}, {name: "typed nil pointer", body: ptr, want: "null"}, {name: "typed nil slice", body: slice, want: "null"}, {name: "compact escaped JSON", body: map[string]string{"message": "<&>"}, want: "{\"message\":\"\\u003c\\u0026\\u003e\"}"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			path := "/records"
+			endpoint := base + path
+			headers := http.Header{}
+			headers.Set("X-Box-Api-Key", "synthetic-token")
+			if tc.body != nil {
+				headers.Set("Content-Type", "application/json")
+			}
+			httpClient := &http.Client{Transport: testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				testutil.RequireRequestEnvelope(t, req, ctx, http.MethodPost, endpoint, tc.want, headers)
+				return nil, errors.New("synthetic-transport-stop")
+			})}
+			c := &client{base: base, apiKey: "synthetic-token", http: httpClient}
+			err := c.doJSON(ctx, http.MethodPost, path, nil, tc.body, nil)
+			if err == nil || !strings.Contains(err.Error(), "synthetic-transport-stop") || calls != 1 {
+				t.Fatalf("error=%v calls=%d", err, calls)
+			}
+		})
+	}
+}
+
+func TestCompactJSONExecStreamEnvelope(t *testing.T) {
+	ctx := context.Background()
+	calls := 0
+	headers := http.Header{}
+	headers.Set("X-Box-Api-Key", "synthetic-token")
+	headers.Set("Content-Type", "application/json")
+	c := &client{base: "https://api.example.test/base", apiKey: "synthetic-token", http: &http.Client{Transport: testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		testutil.RequireRequestEnvelope(t, req, ctx, http.MethodPost, "https://api.example.test/base/v2/box/box%20one/exec-stream", `{"command":["sh","-c","\u003c\u0026\u003e"],"folder":"/work"}`, headers)
+		return nil, errors.New("synthetic-transport-stop")
+	})}}
+	code, err := c.ExecStream(ctx, "box one", "<&>", " /work ", io.Discard)
+	if code != 0 || err == nil || !strings.Contains(err.Error(), "synthetic-transport-stop") || calls != 1 {
+		t.Fatalf("code=%d error=%v calls=%d", code, err, calls)
 	}
 }

--- a/internal/providers/upstashbox/client.go
+++ b/internal/providers/upstashbox/client.go
@@ -203,11 +203,7 @@ func (c *client) ExecStream(ctx context.Context, boxID, command, folder string, 
 	if strings.TrimSpace(folder) != "" {
 		body["folder"] = strings.TrimSpace(folder)
 	}
-	data, err := json.Marshal(body)
-	if err != nil {
-		return 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/v2/box/"+url.PathEscape(boxID)+"/exec-stream", bytes.NewReader(data))
+	req, err := shared.NewCompactJSONRequest(ctx, http.MethodPost, c.base+"/v2/box/"+url.PathEscape(boxID)+"/exec-stream", body)
 	if err != nil {
 		return 0, err
 	}
@@ -282,19 +278,11 @@ func (c *client) UploadFile(ctx context.Context, boxID, localPath, remotePath st
 }
 
 func (c *client) doJSON(ctx context.Context, method, path string, query url.Values, body any, out any) error {
-	var input io.Reader
-	if body != nil {
-		data, err := json.Marshal(body)
-		if err != nil {
-			return err
-		}
-		input = bytes.NewReader(data)
-	}
 	u := c.base + path
 	if len(query) > 0 {
 		u += "?" + query.Encode()
 	}
-	req, err := http.NewRequestWithContext(ctx, method, u, input)
+	req, err := shared.NewCompactJSONRequest(ctx, method, u, body)
 	if err != nil {
 		return err
 	}

--- a/internal/providers/vast/client.go
+++ b/internal/providers/vast/client.go
@@ -1,7 +1,6 @@
 package vast
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -154,19 +153,11 @@ func vastRedirectError(destination *url.URL) error {
 }
 
 func (c *vastClient) do(ctx context.Context, method, path string, body any, out any) error {
-	var reader io.Reader
-	if body != nil {
-		data, err := json.Marshal(body)
-		if err != nil {
-			return err
-		}
-		reader = bytes.NewReader(data)
-	}
 	endpoint := c.apiURL + path
 	if parsed, err := url.Parse(path); err == nil && parsed.IsAbs() {
 		endpoint = path
 	}
-	req, err := http.NewRequestWithContext(ctx, method, endpoint, reader)
+	req, err := shared.NewCompactJSONRequest(ctx, method, endpoint, body)
 	if err != nil {
 		return err
 	}

--- a/internal/providers/vast/client_test.go
+++ b/internal/providers/vast/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/openclaw/crabbox/internal/testutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -345,5 +346,47 @@ func writeJSON(t *testing.T, w http.ResponseWriter, value any) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(value); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCompactJSONRequestEnvelope(t *testing.T) {
+	type key struct{}
+	ctx := context.WithValue(context.Background(), key{}, "ctx")
+	const base = "https://api.example.test/base"
+	var ptr *string
+	var slice []string
+	for _, tc := range []struct {
+		name     string
+		body     any
+		want     string
+		absolute bool
+	}{
+		{name: "nil"}, {name: "typed nil pointer", body: ptr, want: "null"}, {name: "typed nil slice", body: slice, want: "null"}, {name: "compact escaped JSON", body: map[string]string{"message": "<&>"}, want: "{\"message\":\"\\u003c\\u0026\\u003e\"}"}, {name: "absolute URL", absolute: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			path := "/records"
+			endpoint := base + path
+			if tc.absolute {
+				path = "https://api.example.test/absolute?limit=2"
+				endpoint = path
+			}
+			headers := http.Header{}
+			headers.Set("Authorization", "Bearer synthetic-token")
+			headers.Set("Accept", "application/json")
+			if tc.body != nil {
+				headers.Set("Content-Type", "application/json")
+			}
+			httpClient := &http.Client{Transport: testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				testutil.RequireRequestEnvelope(t, req, ctx, http.MethodPost, endpoint, tc.want, headers)
+				return nil, errors.New("synthetic-transport-stop")
+			})}
+			c := &vastClient{apiURL: base, apiKey: "synthetic-token", httpClient: httpClient}
+			err := c.do(ctx, http.MethodPost, path, tc.body, nil)
+			if err == nil || !strings.Contains(err.Error(), "synthetic-transport-stop") || calls != 1 {
+				t.Fatalf("error=%v calls=%d", err, calls)
+			}
+		})
 	}
 }

--- a/internal/testutil/protocol.go
+++ b/internal/testutil/protocol.go
@@ -4,11 +4,60 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"io"
+	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 )
+
+type RoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+// RequireRequestEnvelope checks exact bytes and replay; an empty body expects nil Body and GetBody.
+func RequireRequestEnvelope(t *testing.T, req *http.Request, ctx context.Context, method, endpoint, body string, headers http.Header) {
+	t.Helper()
+	if req.Context() != ctx || req.Method != method || req.URL.String() != endpoint {
+		t.Fatalf("request=%s %s context=%v", req.Method, req.URL, req.Context() == ctx)
+	}
+	if !reflect.DeepEqual(req.Header, headers) {
+		t.Fatalf("headers=%v want %v", req.Header, headers)
+	}
+	if req.ContentLength != int64(len(body)) || (req.Body == nil) != (body == "") {
+		t.Fatalf("bodymetadata=%d/%v want%d", req.ContentLength, req.Body == nil, len(body))
+	}
+	if body == "" {
+		if req.GetBody != nil {
+			t.Fatal("nil body has replay")
+		}
+		return
+	}
+	data, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != body {
+		t.Fatalf("body=%q want%q", data, body)
+	}
+	if req.GetBody == nil {
+		t.Fatal("missing replay")
+	}
+	replay, err := req.GetBody()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer replay.Close()
+	data, err = io.ReadAll(replay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != body {
+		t.Fatalf("replay=%q want%q", data, body)
+	}
+}
 
 func RequireRedactedProviderError(t *testing.T, err error, secret string) {
 	t.Helper()


### PR DESCRIPTION
## Summary

Give Hostinger, Vast, Morph, Upstash Box, Railway and Cloud Run Sandbox one owner for their compact JSON request envelope. Eight request paths now call `shared.NewCompactJSONRequest`; the existing Encoder-based helper remains a distinct wire contract.

This preserves compact bytes without a trailing newline, HTML escaping, nil-interface versus typed-nil behavior, request context, content length and replay. Morph URL errors still precede encoding; Cloud Run retains its caller-owned timeout/cancellation, including encoding a typed-nil map as `null`. Headers, transport, retries and response/stream handling remain with the providers.

The tests retain explicit provider-specific bytes and headers while sharing one exact-envelope assertion in the existing test-support package. No new dependency, configuration, credential requirement or user-visible behavior change; the refactor documentation is updated.

## Verification

Baseline adapter cases passed before extraction. The first candidate found one unused Hostinger import; that import was removed and the same expectations passed. Final focused race tests passed 33 tests and 45 subtests with no failures or skips. Adapter characterization covers all eight entrypoints; helper tests preserve both Encoder and compact contracts. Go vet and the docs build passed. The independent mandatory Codex review found no P0 findings in the final selected scope.

The committed candidate also passed 19 real loopback HTTP requests with source bytes and modes unchanged. Every observed record matched the earlier candidate run. These are inert local transport checks, not cloud lifecycle or successful streaming claims.

# Compact JSON requests: real HTTP trace

Committed source: `eb210c0c8bd99f93ba0112e5ac9b0da7b226e370`. The complete source byte/mode fingerprint and clean Git state were unchanged across this fresh run. Six byte-identical additive overlays exercised all eight compact request entrypoints with real HTTP transport and loopback servers; no production file was replaced.

Targeted race proof passed: 19 requests in 39.84 seconds. Every server returned inert `400`; every client returned its ordinary error result before stream/operation tails. Authentication is recorded only as header presence.

| Entrypoint | Case | Method / path | Query | Content-Type | Length | Actual compact body (JSON string notation) | Auth presence |
|---|---|---|---|---|---:|---|---|
| hostinger.do | nil | `POST /proof/records` | `limit=2&tag=a&tag=b` | (absent) | 0 | `""` | Authorization PRESENT |
| hostinger.do | typed-nil | `POST /proof/records` | (none) | `application/json` | 4 | `"null"` | Authorization PRESENT |
| hostinger.do | escaping | `POST /proof/records` | (none) | `application/json` | 32 | `"{\"message\":\"\\u003c\\u0026\\u003e\"}"` | Authorization PRESENT |
| vast.do | nil | `POST /proof/records` | `limit=2&tag=a&tag=b` | (absent) | 0 | `""` | Authorization PRESENT |
| vast.do | typed-nil | `POST /proof/records` | (none) | `application/json` | 4 | `"null"` | Authorization PRESENT |
| vast.do | escaping | `POST /proof/records` | (none) | `application/json` | 32 | `"{\"message\":\"\\u003c\\u0026\\u003e\"}"` | Authorization PRESENT |
| vast.do | absolute | `POST /proof/absolute` | `limit=2` | (absent) | 0 | `""` | Authorization PRESENT |
| morph.doRaw | nil | `POST /proof/records` | `limit=2&tag=a&tag=b` | (absent) | 0 | `""` | Authorization PRESENT |
| morph.doRaw | typed-nil | `POST /proof/records` | (none) | `application/json` | 4 | `"null"` | Authorization PRESENT |
| morph.doRaw | escaping | `POST /proof/records` | (none) | `application/json` | 32 | `"{\"message\":\"\\u003c\\u0026\\u003e\"}"` | Authorization PRESENT |
| upstashbox.doJSON | nil | `POST /proof/records` | `limit=2&tag=a&tag=b` | (absent) | 0 | `""` | X-Box-Api-Key PRESENT |
| upstashbox.doJSON | typed-nil | `POST /proof/records` | (none) | `application/json` | 4 | `"null"` | X-Box-Api-Key PRESENT |
| upstashbox.doJSON | escaping | `POST /proof/records` | (none) | `application/json` | 32 | `"{\"message\":\"\\u003c\\u0026\\u003e\"}"` | X-Box-Api-Key PRESENT |
| upstashbox.ExecStream | concrete | `POST /v2/box/box%20one/exec-stream` | (none) | `application/json` | 61 | `"{\"command\":[\"sh\",\"-c\",\"\\u003c\\u0026\\u003e\"],\"folder\":\"/work\"}"` | X-Box-Api-Key PRESENT |
| railway.do | nil-variables | `POST /graphql` | (none) | `application/json` | 30 | `"{\"query\":\"\\u003c\\u0026\\u003e\"}"` | Authorization PRESENT |
| railway.do | variables | `POST /graphql` | (none) | `application/json` | 72 | `"{\"query\":\"\\u003c\\u0026\\u003e\",\"variables\":{\"name\":\"\\u003c\\u0026\\u003e\"}}"` | Authorization PRESENT |
| cloudrunsandbox.request | typed-nil-map | `POST /proof/records` | (none) | `application/json` | 4 | `"null"` | Authorization PRESENT, X-ComputeSDK-Cloud-Run-Secret PRESENT |
| cloudrunsandbox.request | escaping-map | `POST /proof/records` | (none) | `application/json` | 32 | `"{\"message\":\"\\u003c\\u0026\\u003e\"}"` | Authorization PRESENT, X-ComputeSDK-Cloud-Run-Secret PRESENT |
| cloudrunsandbox.Exec | concrete | `POST /v1/sandbox/exec` | (none) | `application/json` | 123 | `"{\"allowEgress\":false,\"command\":\"\\u003c\\u0026\\u003e\",\"executionMode\":\"stateful\",\"sandboxId\":\"box\",\"timeout\":7,\"write\":false}"` | Authorization PRESENT, X-ComputeSDK-Cloud-Run-Secret PRESENT |

Every encoded body is compact and lacks an Encoder newline. Optional nil bodies are absent; typed-nil pointers encode `null`. Cloud Run’s concrete typed-nil map also arrived as `null`, not an absent body. Railway nil variables remain omitted from its concrete GraphQL envelope. Vast’s absolute path, Morph/Upstash query composition, and Upstash’s escaped box path were observed unchanged.

Limits: synthetic loopback wire behavior only—not cloud validity, successful streams, operations, retries, or native execution. Cloud Run’s existing sandbox-ID/environment checks and timeout path remained in place. No auth values, real credentials, public writes, or production changes were used.

All 19 complete observed records exactly match the earlier frozen-candidate trace. This receipt binds the fresh run to the committed source, not merely to its former base.
