### PR TITLE
refactor: share buffered JSON response decoding

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -532,6 +532,15 @@ typed API error and redaction policy, so capacity retry and purchase ambiguity
 classification remain provider-owned. This does not apply to streaming
 responses or change request construction, redirects, or client timeouts.
 
+E2B, CubeSandbox, and Azure Dynamic Sessions share unbounded buffered JSON
+decoding through `shared.DecodeUnboundedJSONResponse`. It borrows the body:
+callers retain their deferred close and any successful response-header clone.
+It reads the entire body even without an output target, returns read errors
+before interpreting status, and leaves typed API errors and body redaction to
+the adapter. Only a zero-length body skips decoding; nonempty whitespace is
+decoded, and JSON errors remain unwrapped. This separate contract adds no
+response limit and does not apply to streams or alter the bounded decoder.
+
 ## Acquisition stays adapter-owned
 
 SSH lease acquisition is a provider-owned transaction, not a shared sequence of

--- a/internal/providers/azuredynamicsessions/client.go
+++ b/internal/providers/azuredynamicsessions/client.go
@@ -382,19 +382,9 @@ func (c *azureDynamicSessionsClient) doJSONURL(ctx context.Context, method, endp
 		return err
 	}
 	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return &azureDynamicSessionsAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(summarizeJSON(data), c.token)}
-	}
-	if out != nil && len(data) > 0 {
-		if err := json.Unmarshal(data, out); err != nil {
-			return err
-		}
-	}
-	return nil
+	return shared.DecodeUnboundedJSONResponse(resp, out, func(statusCode int, status string, data []byte) error {
+		return &azureDynamicSessionsAPIError{StatusCode: statusCode, Status: status, Body: shared.RedactErrorSecrets(summarizeJSON(data), c.token)}
+	})
 }
 
 func (c *azureDynamicSessionsClient) responseError(resp *http.Response) error {

--- a/internal/providers/azuredynamicsessions/client_test.go
+++ b/internal/providers/azuredynamicsessions/client_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -882,5 +883,97 @@ func TestJSONRequestAdoptionConcreteEnvelope(t *testing.T) {
 	}
 	if !errors.Is(err, sentinel) || calls != 1 {
 		t.Fatalf("error=%v calls=%d", err, calls)
+	}
+}
+
+type responseCloseObserver struct {
+	io.Reader
+	close func() error
+}
+
+func (b responseCloseObserver) Close() error { return b.close() }
+
+func TestRawJSONResponseContract(t *testing.T) {
+	readFailure := errors.New("synthetic response read failure")
+	closeFailure := errors.New("synthetic ignored close failure")
+	for _, tc := range []struct {
+		name, data        string
+		status            int
+		nilOut, readError bool
+		wantError         string
+		wantValue         int
+	}{
+		{name: "nil output still reads invalid JSON", data: "not JSON", nilOut: true, wantValue: 99},
+		{name: "raw empty", wantValue: 99},
+		{name: "whitespace with output", data: " \t\n", wantError: "syntax", wantValue: 99},
+		{name: "whitespace without output", data: " \t\n", nilOut: true, wantValue: 99},
+		{name: "JSON object", data: `{"value":12}`, wantValue: 12},
+		{name: "JSON null", data: "null", wantValue: 99},
+		{name: "JSON trailing whitespace", data: "{\"value\":12}\n \t", wantValue: 12},
+		{name: "trailing JSON value", data: `{"value":12}{"value":13}`, wantError: "syntax", wantValue: 99},
+		{name: "wrong JSON field type", data: `{"value":"bad"}`, wantError: "type", wantValue: 99},
+		{name: "status error", data: "  unavailable \n", status: 503, wantError: "status", wantValue: 99},
+		{name: "status error with nil output", data: "  unavailable \n", status: 503, nilOut: true, wantError: "status", wantValue: 99},
+		{name: "read error beats success", data: `{"value":12}`, readError: true, wantError: "read", wantValue: 99},
+		{name: "read error beats status and nil output", data: "partial body", status: 503, nilOut: true, readError: true, wantError: "read", wantValue: 99},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := bytes.NewReader([]byte(tc.data))
+			var reader io.Reader = payload
+			if tc.readError {
+				reader = io.MultiReader(payload, iotest.ErrReader(readFailure))
+			}
+			closed, calls := 0, 0
+			responseHeaders := http.Header{"X-Trace": []string{"before-close", "second"}}
+			body := responseCloseObserver{Reader: reader, close: func() error { closed++; responseHeaders["X-Trace"][0] = "after-close"; return closeFailure }}
+			status := tc.status
+			if status == 0 {
+				status = 200
+			}
+			const base = "https://api.example.test"
+			httpClient := &http.Client{Transport: adoptionRoundTripper(func(req *http.Request) (*http.Response, error) {
+				calls++
+				return &http.Response{StatusCode: status, Status: strconv.Itoa(status) + " Synthetic", Header: responseHeaders, Body: body, Request: req}, nil
+			})}
+			client := &azureDynamicSessionsClient{endpoint: base, token: "synthetic-token", httpClient: httpClient}
+			out := struct {
+				Value int `json:"value"`
+			}{Value: 99}
+			var destination any = &out
+			if tc.nilOut {
+				destination = nil
+			}
+			err := client.doJSONURL(context.Background(), http.MethodGet, base+"/records", nil, destination)
+			if calls != 1 || closed != 1 || payload.Len() != 0 {
+				t.Fatalf("calls=%d closes=%d unread=%d", calls, closed, payload.Len())
+			}
+			if out.Value != tc.wantValue {
+				t.Fatalf("value=%d want%d", out.Value, tc.wantValue)
+			}
+			switch tc.wantError {
+			case "":
+				if err != nil {
+					t.Fatal(err)
+				}
+			case "read":
+				if err != readFailure {
+					t.Fatalf("read error=%T %v want exact sentinel", err, err)
+				}
+			case "syntax":
+				if _, ok := err.(*json.SyntaxError); !ok {
+					t.Fatalf("decode error=%T %v want unwrapped SyntaxError", err, err)
+				}
+			case "type":
+				if _, ok := err.(*json.UnmarshalTypeError); !ok {
+					t.Fatalf("decode error=%T %v want unwrapped UnmarshalTypeError", err, err)
+				}
+			case "status":
+				api, ok := err.(*azureDynamicSessionsAPIError)
+				if !ok || api.StatusCode != 503 || api.Status != "503 Synthetic" || api.Body != "unavailable" {
+					t.Fatalf("status error=%T %#v", err, err)
+				}
+			}
+
+		})
 	}
 }

--- a/internal/providers/cubesandbox/backend_test.go
+++ b/internal/providers/cubesandbox/backend_test.go
@@ -1912,3 +1912,108 @@ func TestJSONRequestAdoptionEnvelope(t *testing.T) {
 		})
 	}
 }
+
+type responseCloseObserver struct {
+	io.Reader
+	close func() error
+}
+
+func (b responseCloseObserver) Close() error { return b.close() }
+
+func TestRawJSONResponseContract(t *testing.T) {
+	readFailure := errors.New("synthetic response read failure")
+	closeFailure := errors.New("synthetic ignored close failure")
+	for _, tc := range []struct {
+		name, data        string
+		status            int
+		nilOut, readError bool
+		wantError         string
+		wantValue         int
+	}{
+		{name: "nil output still reads invalid JSON", data: "not JSON", nilOut: true, wantValue: 99},
+		{name: "raw empty", wantValue: 99},
+		{name: "whitespace with output", data: " \t\n", wantError: "syntax", wantValue: 99},
+		{name: "whitespace without output", data: " \t\n", nilOut: true, wantValue: 99},
+		{name: "JSON object", data: `{"value":12}`, wantValue: 12},
+		{name: "JSON null", data: "null", wantValue: 99},
+		{name: "JSON trailing whitespace", data: "{\"value\":12}\n \t", wantValue: 12},
+		{name: "trailing JSON value", data: `{"value":12}{"value":13}`, wantError: "syntax", wantValue: 99},
+		{name: "wrong JSON field type", data: `{"value":"bad"}`, wantError: "type", wantValue: 99},
+		{name: "status error", data: "  unavailable \n", status: 503, wantError: "status", wantValue: 99},
+		{name: "status error with nil output", data: "  unavailable \n", status: 503, nilOut: true, wantError: "status", wantValue: 99},
+		{name: "read error beats success", data: `{"value":12}`, readError: true, wantError: "read", wantValue: 99},
+		{name: "read error beats status and nil output", data: "partial body", status: 503, nilOut: true, readError: true, wantError: "read", wantValue: 99},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := bytes.NewReader([]byte(tc.data))
+			var reader io.Reader = payload
+			if tc.readError {
+				reader = io.MultiReader(payload, iotest.ErrReader(readFailure))
+			}
+			closed, calls := 0, 0
+			responseHeaders := http.Header{"X-Trace": []string{"before-close", "second"}}
+			body := responseCloseObserver{Reader: reader, close: func() error { closed++; responseHeaders["X-Trace"][0] = "after-close"; return closeFailure }}
+			status := tc.status
+			if status == 0 {
+				status = 200
+			}
+			const base = "https://api.example.test"
+			httpClient := &http.Client{Transport: cubesandboxRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				return &http.Response{StatusCode: status, Status: strconv.Itoa(status) + " Synthetic", Header: responseHeaders, Body: body, Request: req}, nil
+			})}
+			client := &cubesandboxClient{apiURL: base, apiKey: "synthetic-token", httpClient: httpClient}
+			out := struct {
+				Value int `json:"value"`
+			}{Value: 99}
+			var destination any = &out
+			if tc.nilOut {
+				destination = nil
+			}
+			headers, err := client.doJSONWithHeaders(context.Background(), http.MethodGet, "/records", nil, nil, destination)
+			if calls != 1 || closed != 1 || payload.Len() != 0 {
+				t.Fatalf("calls=%d closes=%d unread=%d", calls, closed, payload.Len())
+			}
+			if out.Value != tc.wantValue {
+				t.Fatalf("value=%d want%d", out.Value, tc.wantValue)
+			}
+			switch tc.wantError {
+			case "":
+				if err != nil {
+					t.Fatal(err)
+				}
+			case "read":
+				if err != readFailure {
+					t.Fatalf("read error=%T %v want exact sentinel", err, err)
+				}
+			case "syntax":
+				if _, ok := err.(*json.SyntaxError); !ok {
+					t.Fatalf("decode error=%T %v want unwrapped SyntaxError", err, err)
+				}
+			case "type":
+				if _, ok := err.(*json.UnmarshalTypeError); !ok {
+					t.Fatalf("decode error=%T %v want unwrapped UnmarshalTypeError", err, err)
+				}
+			case "status":
+				api, ok := err.(*cubesandboxAPIError)
+				if !ok || api.StatusCode != 503 || api.Status != "503 Synthetic" || api.Body != "unavailable" {
+					t.Fatalf("status error=%T %#v", err, err)
+				}
+			}
+			if tc.wantError != "" {
+				if headers != nil {
+					t.Fatalf("error headers=%v", headers)
+				}
+			} else {
+				want := http.Header{"X-Trace": []string{"before-close", "second"}}
+				if !reflect.DeepEqual(headers, want) {
+					t.Fatalf("headers=%v want pre-close clone%v", headers, want)
+				}
+				headers["X-Trace"][0] = "caller-change"
+				if responseHeaders["X-Trace"][0] != "after-close" {
+					t.Fatal("returned headers share backing values")
+				}
+			}
+		})
+	}
+}

--- a/internal/providers/cubesandbox/client.go
+++ b/internal/providers/cubesandbox/client.go
@@ -2,7 +2,6 @@ package cubesandbox
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -366,17 +365,10 @@ func (c *cubesandboxClient) doJSONWithHeaders(ctx context.Context, method, path 
 		return nil, err
 	}
 	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
+	if err := shared.DecodeUnboundedJSONResponse(resp, out, func(statusCode int, status string, data []byte) error {
+		return &cubesandboxAPIError{StatusCode: statusCode, Status: status, Body: shared.RedactErrorSecrets(summarizeJSON(data), c.apiKey)}
+	}); err != nil {
 		return nil, err
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &cubesandboxAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(summarizeJSON(data), c.apiKey)}
-	}
-	if out != nil && len(data) > 0 {
-		if err := json.Unmarshal(data, out); err != nil {
-			return nil, err
-		}
 	}
 	return resp.Header.Clone(), nil
 }

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"testing/iotest"
@@ -2056,6 +2057,111 @@ func TestJSONRequestAdoptionEnvelope(t *testing.T) {
 			}
 			if calls != 1 {
 				t.Fatalf("calls=%d", calls)
+			}
+		})
+	}
+}
+
+type responseCloseObserver struct {
+	io.Reader
+	close func() error
+}
+
+func (b responseCloseObserver) Close() error { return b.close() }
+
+func TestRawJSONResponseContract(t *testing.T) {
+	readFailure := errors.New("synthetic response read failure")
+	closeFailure := errors.New("synthetic ignored close failure")
+	for _, tc := range []struct {
+		name, data        string
+		status            int
+		nilOut, readError bool
+		wantError         string
+		wantValue         int
+	}{
+		{name: "nil output still reads invalid JSON", data: "not JSON", nilOut: true, wantValue: 99},
+		{name: "raw empty", wantValue: 99},
+		{name: "whitespace with output", data: " \t\n", wantError: "syntax", wantValue: 99},
+		{name: "whitespace without output", data: " \t\n", nilOut: true, wantValue: 99},
+		{name: "JSON object", data: `{"value":12}`, wantValue: 12},
+		{name: "JSON null", data: "null", wantValue: 99},
+		{name: "JSON trailing whitespace", data: "{\"value\":12}\n \t", wantValue: 12},
+		{name: "trailing JSON value", data: `{"value":12}{"value":13}`, wantError: "syntax", wantValue: 99},
+		{name: "wrong JSON field type", data: `{"value":"bad"}`, wantError: "type", wantValue: 99},
+		{name: "status error", data: "  unavailable \n", status: 503, wantError: "status", wantValue: 99},
+		{name: "status error with nil output", data: "  unavailable \n", status: 503, nilOut: true, wantError: "status", wantValue: 99},
+		{name: "read error beats success", data: `{"value":12}`, readError: true, wantError: "read", wantValue: 99},
+		{name: "read error beats status and nil output", data: "partial body", status: 503, nilOut: true, readError: true, wantError: "read", wantValue: 99},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := bytes.NewReader([]byte(tc.data))
+			var reader io.Reader = payload
+			if tc.readError {
+				reader = io.MultiReader(payload, iotest.ErrReader(readFailure))
+			}
+			closed, calls := 0, 0
+			responseHeaders := http.Header{"X-Trace": []string{"before-close", "second"}}
+			body := responseCloseObserver{Reader: reader, close: func() error { closed++; responseHeaders["X-Trace"][0] = "after-close"; return closeFailure }}
+			status := tc.status
+			if status == 0 {
+				status = 200
+			}
+			const base = "https://api.example.test"
+			httpClient := &http.Client{Transport: e2bRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				return &http.Response{StatusCode: status, Status: strconv.Itoa(status) + " Synthetic", Header: responseHeaders, Body: body, Request: req}, nil
+			})}
+			client := &e2bClient{apiURL: base, apiKey: "synthetic-token", httpClient: httpClient}
+			out := struct {
+				Value int `json:"value"`
+			}{Value: 99}
+			var destination any = &out
+			if tc.nilOut {
+				destination = nil
+			}
+			headers, err := client.doJSONWithHeaders(context.Background(), http.MethodGet, "/records", nil, nil, destination)
+			if calls != 1 || closed != 1 || payload.Len() != 0 {
+				t.Fatalf("calls=%d closes=%d unread=%d", calls, closed, payload.Len())
+			}
+			if out.Value != tc.wantValue {
+				t.Fatalf("value=%d want%d", out.Value, tc.wantValue)
+			}
+			switch tc.wantError {
+			case "":
+				if err != nil {
+					t.Fatal(err)
+				}
+			case "read":
+				if err != readFailure {
+					t.Fatalf("read error=%T %v want exact sentinel", err, err)
+				}
+			case "syntax":
+				if _, ok := err.(*json.SyntaxError); !ok {
+					t.Fatalf("decode error=%T %v want unwrapped SyntaxError", err, err)
+				}
+			case "type":
+				if _, ok := err.(*json.UnmarshalTypeError); !ok {
+					t.Fatalf("decode error=%T %v want unwrapped UnmarshalTypeError", err, err)
+				}
+			case "status":
+				api, ok := err.(*e2bAPIError)
+				if !ok || api.StatusCode != 503 || api.Status != "503 Synthetic" || api.Body != "unavailable" {
+					t.Fatalf("status error=%T %#v", err, err)
+				}
+			}
+			if tc.wantError != "" {
+				if headers != nil {
+					t.Fatalf("error headers=%v", headers)
+				}
+			} else {
+				want := http.Header{"X-Trace": []string{"before-close", "second"}}
+				if !reflect.DeepEqual(headers, want) {
+					t.Fatalf("headers=%v want pre-close clone%v", headers, want)
+				}
+				headers["X-Trace"][0] = "caller-change"
+				if responseHeaders["X-Trace"][0] != "after-close" {
+					t.Fatal("returned headers share backing values")
+				}
 			}
 		})
 	}

--- a/internal/providers/e2b/client.go
+++ b/internal/providers/e2b/client.go
@@ -2,7 +2,6 @@ package e2b
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -277,17 +276,10 @@ func (c *e2bClient) doJSONWithHeaders(ctx context.Context, method, path string, 
 		return nil, err
 	}
 	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
+	if err := shared.DecodeUnboundedJSONResponse(resp, out, func(statusCode int, status string, data []byte) error {
+		return &e2bAPIError{StatusCode: statusCode, Status: status, Body: shared.RedactErrorSecrets(summarizeJSON(data), c.apiKey)}
+	}); err != nil {
 		return nil, err
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &e2bAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(summarizeJSON(data), c.apiKey)}
-	}
-	if out != nil && len(data) > 0 {
-		if err := json.Unmarshal(data, out); err != nil {
-			return nil, err
-		}
 	}
 	return resp.Header.Clone(), nil
 }

--- a/internal/providers/shared/httpresponse.go
+++ b/internal/providers/shared/httpresponse.go
@@ -8,6 +8,26 @@ import (
 	"strings"
 )
 
+// DecodeUnboundedJSONResponse borrows the body; the caller must close it.
+// Read errors take precedence over HTTP status. Only a zero-length body skips
+// decoding, and read and JSON errors are returned unchanged. The adapter owns
+// its typed API error and any body summarization or redaction.
+func DecodeUnboundedJSONResponse(resp *http.Response, out any, apiError func(int, string, []byte) error) error {
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return apiError(resp.StatusCode, resp.Status, data)
+	}
+	if out != nil && len(data) > 0 {
+		if err := json.Unmarshal(data, out); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // DecodeBoundedJSONResponse consumes and closes a finite control-plane response.
 // Read failures and overflow take precedence over HTTP status; adapters retain
 // their typed API errors and redaction policy. limit must be positive and below

--- a/internal/providers/shared/httpresponse_test.go
+++ b/internal/providers/shared/httpresponse_test.go
@@ -1,13 +1,95 @@
 package shared
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 )
+
+func TestDecodeUnboundedJSONResponse(t *testing.T) {
+	readErr := errors.New("ordinary read failure")
+	apiErr := errors.New("original adapter error")
+	for _, tc := range []struct {
+		name, body string
+		code       int
+		nilOutput  bool
+		readErr    error
+	}{
+		{name: "json", body: `{"value":"new","extra":true}`},
+		{name: "raw empty"},
+		{name: "ASCII whitespace", body: " \t\r\n"},
+		{name: "Unicode whitespace", body: "\u2003"},
+		{name: "null", body: "null"},
+		{name: "nil output empty", nilOutput: true},
+		{name: "nil output consumes non JSON", body: strings.Repeat("ordinary text ", 400), nilOutput: true},
+		{name: "last success status", code: 299, body: `{"value":"new"}`},
+		{name: "malformed", body: "{"},
+		{name: "trailing JSON", body: "{} {}"},
+		{name: "wrong field type", body: `{"value":7}`},
+		{name: "read error before status", code: 400, body: "partial ordinary text", readErr: readErr},
+		{name: "read error with nil output", body: "ordinary text", nilOutput: true, readErr: readErr},
+		{name: "below success", code: 199, body: " raw status body \n"},
+		{name: "above success", code: 300, body: "\u2003raw status body\n", nilOutput: true},
+		{name: "empty failure", code: 400},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.code == 0 {
+				tc.code = http.StatusOK
+			}
+			body := &responseBodyProbe{Reader: strings.NewReader(tc.body), readErr: tc.readErr}
+			resp := &http.Response{StatusCode: tc.code, Status: "original status text", Body: body}
+			value := struct{ Value string }{Value: "old"}
+			wantValue := value
+			var out any = &value
+			if tc.nilOutput {
+				out = nil
+			}
+			var wantErr error
+			wantCalls := 0
+			switch {
+			case tc.readErr != nil:
+				wantErr = tc.readErr
+			case tc.code < 200 || tc.code >= 300:
+				wantErr, wantCalls = apiErr, 1
+			case !tc.nilOutput && len(tc.body) != 0:
+				wantErr = json.Unmarshal([]byte(tc.body), &wantValue)
+			}
+			calls := 0
+			err := DecodeUnboundedJSONResponse(resp, out, func(code int, status string, data []byte) error {
+				calls++
+				if code != tc.code || status != resp.Status || !bytes.Equal(data, []byte(tc.body)) {
+					t.Fatalf("factory arguments changed: code=%d status=%q data=%q", code, status, data)
+				}
+				if body.closed != 0 {
+					t.Fatal("borrowed body closed before adapter factory")
+				}
+				return apiErr
+			})
+			if tc.readErr != nil || wantCalls != 0 {
+				if err != wantErr {
+					t.Fatalf("original error not returned directly: got %T %v, want %v", err, err, wantErr)
+				}
+			} else if reflect.TypeOf(err) != reflect.TypeOf(wantErr) || !reflect.DeepEqual(err, wantErr) {
+				t.Fatalf("unmarshal result changed or wrapped: got %T %v, want %T %v", err, err, wantErr, wantErr)
+			}
+			if value != wantValue || calls != wantCalls {
+				t.Fatalf("value=%#v calls=%d, want %#v calls=%d", value, calls, wantValue, wantCalls)
+			}
+			if body.read != len(tc.body) || body.closed != 0 {
+				t.Fatalf("borrowed body read=%d close=%d, want read=%d close=0", body.read, body.closed, len(tc.body))
+			}
+			_ = body.Close()
+			if body.closed != 1 {
+				t.Fatal("caller did not retain body-close ownership")
+			}
+		})
+	}
+}
 
 type responseBodyProbe struct {
 	io.Reader


### PR DESCRIPTION
## Summary

E2B, CubeSandbox and Azure Dynamic Sessions now share the same buffered JSON response-decoding owner. The helper always reads the body first, preserves read-error precedence over HTTP status, treats only a raw zero-length body as empty, and returns JSON errors unchanged.

The helper borrows the body. Each adapter still closes it, constructs its own typed API error and applies its existing body summary/redaction. E2B and CubeSandbox still clone successful headers before closing and return nil headers on every failure. The existing bounded decoder is unchanged; no limit, retry, stream, request, credential or configuration policy changes.

The ownership contract is documented. This is a behavior-preserving refactor with no user-visible release-note entry.

## Verification

Frozen adapter expectations passed against both the original three client implementations and the candidate: 39 characterization cases plus three existing local HTTP tests. The combined race gate passed 13 tests and 87 subtests without failures or skips. Existing bounded-helper assertions remained unchanged. Go vet, the docs build and the independent mandatory P0-scoped Codex review passed.

The frozen candidate passed 21 real loopback HTTP cases. The proof ran before commit; afterward, every one of its 2,473 tracked-source fingerprints was verified against the blobs in commit `7e058b8da34f0ff0363ae98b9257fb5aaeb60669`. This binds the tested source to the committed change without claiming a second execution. No cloud lifecycle or credential-validity claim is made.

# Raw JSON response: real HTTP trace

Frozen candidate based on `58147bf06aa067d00186fff246178d85d26aef4f`; changes were uncommitted at preparation. Three additive overlays exercised production E2B/Cube `doJSONWithHeaders` and Azure Dynamic Sessions `doJSONURL` through real HTTP transport and loopback servers. Source bytes and modes were unchanged; no production file was replaced.

Targeted `-race` proof passed: 21 requests in 20.65 seconds. Every request was `GET /proof/response?case=<case>` with the synthetic auth header present (E2B: `X-API-Key`; Cube/Azure: `Authorization`). Authentication values were never recorded.

| Provider | Case | HTTP | Actual decoded value | Actual error type | Provider status | Returned header result |
|---|---|---:|---|---|---|---|
| e2b | success-json | 200 | `new` | (none) | (none) | X-Proof-Response=success-json |
| e2b | raw-empty | 200 | `old` | (none) | (none) | X-Proof-Response=raw-empty |
| e2b | whitespace | 200 | `old` | `*json.SyntaxError` | (none) | nil |
| e2b | nil-output-non-json | 200 | `old` | (none) | (none) | X-Proof-Response=nil-output-non-json |
| e2b | ordinary-400 | 400 | `old` | `*e2b.e2bAPIError` | 400 Bad Request | nil |
| e2b | malformed | 200 | `old` | `*json.SyntaxError` | (none) | nil |
| e2b | trailing-json | 200 | `old` | `*json.SyntaxError` | (none) | nil |
| cubesandbox | success-json | 200 | `new` | (none) | (none) | X-Proof-Response=success-json |
| cubesandbox | raw-empty | 200 | `old` | (none) | (none) | X-Proof-Response=raw-empty |
| cubesandbox | whitespace | 200 | `old` | `*json.SyntaxError` | (none) | nil |
| cubesandbox | nil-output-non-json | 200 | `old` | (none) | (none) | X-Proof-Response=nil-output-non-json |
| cubesandbox | ordinary-400 | 400 | `old` | `*cubesandbox.cubesandboxAPIError` | 400 Bad Request | nil |
| cubesandbox | malformed | 200 | `old` | `*json.SyntaxError` | (none) | nil |
| cubesandbox | trailing-json | 200 | `old` | `*json.SyntaxError` | (none) | nil |
| azuredynamicsessions | success-json | 200 | `new` | (none) | (none) | not in API |
| azuredynamicsessions | raw-empty | 200 | `old` | (none) | (none) | not in API |
| azuredynamicsessions | whitespace | 200 | `old` | `*json.SyntaxError` | (none) | not in API |
| azuredynamicsessions | nil-output-non-json | 200 | `old` | (none) | (none) | not in API |
| azuredynamicsessions | ordinary-400 | 400 | `old` | `*azuredynamicsessions.azureDynamicSessionsAPIError` | 400 Bad Request | not in API |
| azuredynamicsessions | malformed | 200 | `old` | `*json.SyntaxError` | (none) | not in API |
| azuredynamicsessions | trailing-json | 200 | `old` | `*json.SyntaxError` | (none) | not in API |

Fixtures: success=`{"value":"new"}`; raw empty=`""`; whitespace=`" \t\n"`; nil-output body=`ordinary non JSON`; HTTP400=`{"message":"ordinary response"}`; malformed=`{`; trailing JSON=`{} {}`. Output began as `old`. Full actual response/error/header records are retained in the companion JSONL trace. The server used a fixed Date header so captured response headers contain no changing timestamp.

Raw zero-length success skipped decoding; nonempty whitespace produced an unwrapped `*json.SyntaxError`. Nil output accepted ordinary non-JSON content after the response read. HTTP400 preserved each provider’s concrete API error type and `400 Bad Request` status. E2B/Cube returned response headers on success and nil headers on errors; Azure has no header return value.

Limits: ordinary synthetic loopback responses only, not cloud compatibility or credential validity. Body-close ownership and read-error identity are covered by separate pure unit tests, not claimed from this HTTP trace. No oversized payloads, native calls, real credentials, public writes, or source changes were used.
