### PR TITLE
refactor: give runtime providers ownership of config display

### DIFF
--- a/docs/refactor/provider-config-display.md
+++ b/docs/refactor/provider-config-display.md
@@ -69,6 +69,12 @@ projectors retain raw boot selectors and list shapes without resolving images,
 applying SSH defaults or discovering authentication. Selected-provider defaults
 and explicit SSH settings remain the existing configuration loader's concern.
 
+Blacksmith Testbox, Agent Sandbox and Firecracker own all 33 of their existing
+JSON/text fields. Their sections retain the original text positions. Workflow,
+tool and path values remain references only; projection does not consult a CLI,
+cluster or guest assets. Raw JSON strings, empty-only text dashes, duration
+strings, integer sizes/timeouts and explicit booleans keep their existing forms.
+
 ## Remaining migration
 
 The baseline census contains 81 canonical providers: 49 have both value formats,
@@ -81,9 +87,9 @@ sections**. They do not complete the migration. Existing provider projections
 also still need to move out of the parallel JSON map and text formatter so
 their field selection and transformations have one owner.
 
-The Multipass/Tart/Lume, local-container, cloud and VPS cohorts remove fourteen
+The Multipass/Tart/Lume, local-container, cloud, VPS and runtime cohorts remove seventeen
 of the original 49 canonical both-format providers from that legacy
-implementation, leaving 35 in that cohort. The local cohort covers five
+implementation, leaving 32 in that cohort. The local cohort covers five
 identities through four sections because Apple Machine shares Apple Container's
 values. These migrations do not fill any of the missing sections above.
 

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -359,28 +359,6 @@ func configShowView(cfg Config) map[string]any {
 			"workdir":         cfg.AzureDynamicSessions.Workdir,
 			"timeoutSecs":     cfg.AzureDynamicSessions.TimeoutSecs,
 		},
-		"blacksmith": map[string]any{
-			"org":         cfg.Blacksmith.Org,
-			"workflow":    cfg.Blacksmith.Workflow,
-			"job":         cfg.Blacksmith.Job,
-			"ref":         cfg.Blacksmith.Ref,
-			"idleTimeout": cfg.Blacksmith.IdleTimeout.String(),
-			"debug":       cfg.Blacksmith.Debug,
-		},
-		"agentSandbox": map[string]any{
-			"kubectl":             cfg.AgentSandbox.Kubectl,
-			"kubeconfig":          cfg.AgentSandbox.Kubeconfig,
-			"context":             cfg.AgentSandbox.Context,
-			"namespace":           cfg.AgentSandbox.Namespace,
-			"warmPool":            cfg.AgentSandbox.WarmPool,
-			"container":           cfg.AgentSandbox.Container,
-			"workdir":             cfg.AgentSandbox.Workdir,
-			"sandboxReadyTimeout": cfg.AgentSandbox.SandboxReadyTimeout.String(),
-			"podReadyTimeout":     cfg.AgentSandbox.PodReadyTimeout.String(),
-			"execTimeoutSecs":     cfg.AgentSandbox.ExecTimeoutSecs,
-			"deleteOnRelease":     cfg.AgentSandbox.DeleteOnRelease,
-			"forgetMissing":       cfg.AgentSandbox.ForgetMissing,
-		},
 		"namespace": map[string]any{
 			"image":               cfg.Namespace.Image,
 			"size":                cfg.Namespace.Size,
@@ -634,23 +612,6 @@ func configShowView(cfg Config) map[string]any {
 			"insecureTLS":       cfg.Incus.InsecureTLS,
 			"remoteImageServer": redactedConfigURL(cfg.Incus.RemoteImageServer),
 		},
-		"firecracker": map[string]any{
-			"binary":          cfg.Firecracker.Binary,
-			"jailer":          cfg.Firecracker.Jailer,
-			"kernel":          cfg.Firecracker.Kernel,
-			"rootfs":          cfg.Firecracker.RootFS,
-			"user":            cfg.Firecracker.User,
-			"workRoot":        cfg.Firecracker.WorkRoot,
-			"cpus":            cfg.Firecracker.CPUs,
-			"memoryMiB":       cfg.Firecracker.MemoryMiB,
-			"diskMiB":         cfg.Firecracker.DiskMiB,
-			"network":         cfg.Firecracker.Network,
-			"cniNetwork":      cfg.Firecracker.CNINetwork,
-			"cniConfDir":      cfg.Firecracker.CNIConfDir,
-			"cniBinDir":       cfg.Firecracker.CNIBinDir,
-			"launchTimeout":   cfg.Firecracker.LaunchTimeout.String(),
-			"deleteOnRelease": cfg.Firecracker.DeleteOnRelease,
-		},
 		"xcpNg": map[string]any{
 			"apiUrl":       redactedConfigURL(cfg.XCPNg.APIURL),
 			"username":     cfg.XCPNg.Username,
@@ -739,8 +700,12 @@ func writeConfigShowText(w io.Writer, cfg Config) error {
 	fmt.Fprintf(w, "run preflight_tools=%s\n", blank(strings.Join(cfg.Run.PreflightTools, ","), "-"))
 	fmt.Fprintf(w, "capacity market=%s strategy=%s fallback=%s regions=%s hints=%t\n", cfg.Capacity.Market, cfg.Capacity.Strategy, cfg.Capacity.Fallback, blank(strings.Join(cfg.Capacity.Regions, ","), "-"), cfg.Capacity.Hints)
 	fmt.Fprintf(w, "actions repo=%s workflow=%s job=%s ref=%s runner_version=%s ephemeral=%t labels=%s\n", blank(cfg.Actions.Repo, "-"), blank(cfg.Actions.Workflow, "-"), blank(cfg.Actions.Job, "-"), blank(cfg.Actions.Ref, "-"), cfg.Actions.RunnerVersion, cfg.Actions.Ephemeral, blank(strings.Join(cfg.Actions.RunnerLabels, ","), "-"))
-	fmt.Fprintf(w, "blacksmith org=%s workflow=%s job=%s ref=%s idle_timeout=%s debug=%t\n", blank(cfg.Blacksmith.Org, "-"), blank(cfg.Blacksmith.Workflow, "-"), blank(cfg.Blacksmith.Job, "-"), blank(cfg.Blacksmith.Ref, "-"), cfg.Blacksmith.IdleTimeout, cfg.Blacksmith.Debug)
-	fmt.Fprintf(w, "agent_sandbox kubectl=%s kubeconfig=%s context=%s namespace=%s warm_pool=%s container=%s workdir=%s sandbox_ready_timeout=%s pod_ready_timeout=%s exec_timeout_secs=%d delete_on_release=%t forget_missing=%t\n", blank(cfg.AgentSandbox.Kubectl, "-"), blank(cfg.AgentSandbox.Kubeconfig, "-"), blank(cfg.AgentSandbox.Context, "-"), blank(cfg.AgentSandbox.Namespace, "-"), blank(cfg.AgentSandbox.WarmPool, "-"), blank(cfg.AgentSandbox.Container, "-"), blank(cfg.AgentSandbox.Workdir, "-"), cfg.AgentSandbox.SandboxReadyTimeout, cfg.AgentSandbox.PodReadyTimeout, cfg.AgentSandbox.ExecTimeoutSecs, cfg.AgentSandbox.DeleteOnRelease, cfg.AgentSandbox.ForgetMissing)
+	if err := layout.writeSlot(w, "blacksmith"); err != nil {
+		return err
+	}
+	if err := layout.writeSlot(w, "agent_sandbox"); err != nil {
+		return err
+	}
 	fmt.Fprintf(w, "phala cli=%s instance_type=%s work_root=%s node_id=%s compose=%s attest=%s\n", blank(cfg.Phala.CLIPath, "-"), blank(cfg.Phala.InstanceType, "-"), blank(cfg.Phala.WorkRoot, "-"), blank(cfg.Phala.NodeID, "-"), blank(cfg.Phala.Compose, "-"), phalaAttest)
 	fmt.Fprintf(w, "namespace image=%s size=%s repository=%s site=%s volume_size_gb=%d auto_stop_idle_timeout=%s work_root=%s delete_on_release=%t\n", cfg.Namespace.Image, blank(cfg.Namespace.Size, "-"), blank(cfg.Namespace.Repository, "-"), blank(cfg.Namespace.Site, "-"), cfg.Namespace.VolumeSizeGB, cfg.Namespace.AutoStopIdleTimeout, cfg.Namespace.WorkRoot, cfg.Namespace.DeleteOnRelease)
 	fmt.Fprintf(w, "namespace_instance cli=%s machine_type=%s duration=%s region=%s endpoint=%s keychain=%s volumes=%d work_root=%s bare=%t\n", cfg.NamespaceInstance.CLIPath, blank(cfg.NamespaceInstance.MachineType, "-"), cfg.NamespaceInstance.Duration, blank(cfg.NamespaceInstance.Region, "-"), blank(redactedConfigURL(cfg.NamespaceInstance.Endpoint), "-"), blank(cfg.NamespaceInstance.Keychain, "-"), len(cfg.NamespaceInstance.Volumes), cfg.NamespaceInstance.WorkRoot, cfg.NamespaceInstance.Bare)
@@ -820,7 +785,9 @@ func writeConfigShowText(w io.Writer, cfg Config) error {
 		return err
 	}
 	fmt.Fprintf(w, "proxmox api_url=%s node=%s template_id=%d storage=%s pool=%s bridge=%s user=%s work_root=%s full_clone=%t auth=%s\n", blank(redactedConfigURL(cfg.Proxmox.APIURL), "-"), blank(cfg.Proxmox.Node, "-"), cfg.Proxmox.TemplateID, blank(cfg.Proxmox.Storage, "-"), blank(cfg.Proxmox.Pool, "-"), blank(cfg.Proxmox.Bridge, "-"), cfg.Proxmox.User, cfg.Proxmox.WorkRoot, cfg.Proxmox.FullClone, tokenState(cfg.Proxmox.TokenSecret))
-	fmt.Fprintf(w, "firecracker binary=%s jailer=%s kernel=%s rootfs=%s user=%s work_root=%s cpus=%d memory_mib=%d disk_mib=%d network=%s cni_network=%s cni_conf_dir=%s cni_bin_dir=%s launch_timeout=%s delete_on_release=%t\n", blank(cfg.Firecracker.Binary, "-"), blank(cfg.Firecracker.Jailer, "-"), blank(cfg.Firecracker.Kernel, "-"), blank(cfg.Firecracker.RootFS, "-"), blank(cfg.Firecracker.User, "-"), blank(cfg.Firecracker.WorkRoot, "-"), cfg.Firecracker.CPUs, cfg.Firecracker.MemoryMiB, cfg.Firecracker.DiskMiB, blank(cfg.Firecracker.Network, "-"), blank(cfg.Firecracker.CNINetwork, "-"), blank(cfg.Firecracker.CNIConfDir, "-"), blank(cfg.Firecracker.CNIBinDir, "-"), cfg.Firecracker.LaunchTimeout, cfg.Firecracker.DeleteOnRelease)
+	if err := layout.writeSlot(w, "firecracker"); err != nil {
+		return err
+	}
 	fmt.Fprintf(w, "xcp_ng api_url=%s username=%s template=%s template_uuid=%s sr=%s sr_uuid=%s network=%s network_uuid=%s host=%s user=%s work_root=%s insecure_tls=%t auth=%s\n", blank(redactedConfigURL(cfg.XCPNg.APIURL), "-"), blank(cfg.XCPNg.Username, "-"), blank(cfg.XCPNg.Template, "-"), blank(cfg.XCPNg.TemplateUUID, "-"), blank(cfg.XCPNg.SR, "-"), blank(cfg.XCPNg.SRUUID, "-"), blank(cfg.XCPNg.Network, "-"), blank(cfg.XCPNg.NetworkUUID, "-"), blank(cfg.XCPNg.Host, "-"), cfg.XCPNg.User, cfg.XCPNg.WorkRoot, cfg.XCPNg.InsecureTLS, tokenState(cfg.XCPNg.Password))
 	fmt.Fprintf(w, "parallels template=%s source=%s source_id=%s snapshot=%s snapshot_id=%s clone_mode=%s host=%s user=%s work_root=%s startup_timeout=%s templates=%d hosts=%d\n", blank(cfg.Parallels.Template, "-"), blank(cfg.Parallels.Source, "-"), blank(cfg.Parallels.SourceID, "-"), blank(cfg.Parallels.SourceSnapshot, "-"), blank(cfg.Parallels.SourceSnapshotID, "-"), cfg.Parallels.CloneMode, blank(cfg.Parallels.Host, "local"), cfg.Parallels.User, cfg.Parallels.WorkRoot, cfg.Parallels.StartupTimeout, len(cfg.Parallels.Templates), len(cfg.Parallels.Hosts))
 	if err := layout.writeRemaining(w); err != nil {

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -485,49 +485,6 @@ func TestNamespaceInstanceConfigShowRedactsEndpointCredentials(t *testing.T) {
 	}
 }
 
-func TestConfigShowIncludesAgentSandboxRoute(t *testing.T) {
-	cfg := baseConfig()
-	cfg.AgentSandbox.Kubectl = "/opt/bin/kubectl"
-	cfg.AgentSandbox.Kubeconfig = "/tmp/agent-kubeconfig"
-	cfg.AgentSandbox.Context = "agent-context"
-	cfg.AgentSandbox.Namespace = "sandboxes"
-	cfg.AgentSandbox.WarmPool = "linux-pool"
-	cfg.AgentSandbox.Container = "worker"
-	cfg.AgentSandbox.Workdir = "/workspace/my-app"
-	cfg.AgentSandbox.SandboxReadyTimeout = 2 * time.Minute
-	cfg.AgentSandbox.PodReadyTimeout = 45 * time.Second
-	cfg.AgentSandbox.ExecTimeoutSecs = 42
-	cfg.AgentSandbox.DeleteOnRelease = false
-	cfg.AgentSandbox.ForgetMissing = true
-
-	view := configShowView(cfg)
-	agent, ok := view["agentSandbox"].(map[string]any)
-	if !ok || agent["kubeconfig"] != "/tmp/agent-kubeconfig" || agent["warmPool"] != "linux-pool" ||
-		agent["sandboxReadyTimeout"] != "2m0s" || agent["deleteOnRelease"] != false || agent["forgetMissing"] != true {
-		t.Fatalf("agentSandbox view=%#v", agent)
-	}
-	var text bytes.Buffer
-	writeConfigShowText(&text, cfg)
-	for _, want := range []string{
-		"agent_sandbox kubectl=/opt/bin/kubectl",
-		"kubeconfig=/tmp/agent-kubeconfig",
-		"context=agent-context",
-		"namespace=sandboxes",
-		"warm_pool=linux-pool",
-		"container=worker",
-		"workdir=/workspace/my-app",
-		"sandbox_ready_timeout=2m0s",
-		"pod_ready_timeout=45s",
-		"exec_timeout_secs=42",
-		"delete_on_release=false",
-		"forget_missing=true",
-	} {
-		if !strings.Contains(text.String(), want) {
-			t.Fatalf("config show missing %q: %q", want, text.String())
-		}
-	}
-}
-
 func TestConfigShowIncludesCubeSandboxWithoutSecret(t *testing.T) {
 	const secret = "cubesandbox-secret"
 	cfg := baseConfig()
@@ -602,7 +559,7 @@ func TestConfigShowIncludesPhalaConfig(t *testing.T) {
 	}
 }
 
-func TestConfigShowIncludesFirecrackerConfig(t *testing.T) {
+func TestFirecrackerConfigDefaultsPreserveConfiguredValues(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Provider = "firecracker"
 	cfg.Firecracker.Binary = "/opt/bin/firecracker"
@@ -620,42 +577,12 @@ func TestConfigShowIncludesFirecrackerConfig(t *testing.T) {
 	cfg.Firecracker.CNIBinDir = "/opt/cni/lab"
 	cfg.Firecracker.LaunchTimeout = 3 * time.Minute
 	cfg.Firecracker.DeleteOnRelease = false
+	before := cfg.Firecracker
 	if err := applyProviderConfigDefaults(&cfg); err != nil {
 		t.Fatal(err)
 	}
-
-	view := configShowView(cfg)
-	firecracker, ok := view["firecracker"].(map[string]any)
-	if !ok || firecracker["binary"] != "/opt/bin/firecracker" || firecracker["jailer"] != "/opt/bin/jailer" ||
-		firecracker["kernel"] != "/var/lib/firecracker/vmlinux" || firecracker["rootfs"] != "/var/lib/firecracker/rootfs.ext4" ||
-		firecracker["workRoot"] != "/workspace/firecracker" || firecracker["cpus"] != 6 ||
-		firecracker["memoryMiB"] != 12288 || firecracker["diskMiB"] != 32768 ||
-		firecracker["cniNetwork"] != "lab-firecracker" || firecracker["launchTimeout"] != "3m0s" ||
-		firecracker["deleteOnRelease"] != false {
-		t.Fatalf("firecracker view=%#v", firecracker)
-	}
-	var text bytes.Buffer
-	writeConfigShowText(&text, cfg)
-	for _, want := range []string{
-		"firecracker binary=/opt/bin/firecracker",
-		"jailer=/opt/bin/jailer",
-		"kernel=/var/lib/firecracker/vmlinux",
-		"rootfs=/var/lib/firecracker/rootfs.ext4",
-		"user=runner",
-		"work_root=/workspace/firecracker",
-		"cpus=6",
-		"memory_mib=12288",
-		"disk_mib=32768",
-		"network=cni",
-		"cni_network=lab-firecracker",
-		"cni_conf_dir=/etc/cni/lab",
-		"cni_bin_dir=/opt/cni/lab",
-		"launch_timeout=3m0s",
-		"delete_on_release=false",
-	} {
-		if !strings.Contains(text.String(), want) {
-			t.Fatalf("config show missing %q: %q", want, text.String())
-		}
+	if cfg.Firecracker != before {
+		t.Fatalf("defaults changed explicitly configured Firecracker values: got %#v, want %#v", cfg.Firecracker, before)
 	}
 }
 

--- a/internal/cli/config_show_projection.go
+++ b/internal/cli/config_show_projection.go
@@ -36,7 +36,7 @@ func ConfigShowSecretState(value string) string { return tokenState(value) }
 
 // Names only: no legacy value projection or environment reads are needed to
 // protect existing text slots. Retire a name only when its legacy row migrates.
-const legacyConfigShowTextLabels = "config provider lease broker access_auth ssh sync env run capacity actions blacksmith agent_sandbox phala namespace namespace_instance morph e2b cubesandbox upstash_box smolvm blaxel nomad ascii_box superserve machine0 cloudflare fastapi_cloud cloudflare_dynamic_workers cloudflare_sandbox static results cache jobs aws_lambda_microvm github_codespaces lambda vast nvidia_brev nebius hostinger ovh scaleway tencentcloud azure_dynamic_sessions proxmox firecracker xcp_ng parallels inspection provider_status"
+const legacyConfigShowTextLabels = "config provider lease broker access_auth ssh sync env run capacity actions phala namespace namespace_instance morph e2b cubesandbox upstash_box smolvm blaxel nomad ascii_box superserve machine0 cloudflare fastapi_cloud cloudflare_dynamic_workers cloudflare_sandbox static results cache jobs aws_lambda_microvm github_codespaces lambda vast nvidia_brev nebius hostinger ovh scaleway tencentcloud azure_dynamic_sessions proxmox xcp_ng parallels inspection provider_status"
 
 func collectProviderConfigShowSections(cfg Config) ([]ProviderConfigShowSection, error) {
 	return collectProviderConfigShowSectionsFrom(cfg, registeredProviders())

--- a/internal/cli/config_show_projection_test.go
+++ b/internal/cli/config_show_projection_test.go
@@ -238,13 +238,14 @@ func TestConfigShowLegacySlotPositions(t *testing.T) {
 			if strings.HasPrefix(value, "jobs=") {
 				name = "jobs"
 			}
-			if name == "superserve" || name == "local_container" || name == "apple_container" || name == "mxc" || name == "docker_sandbox" || name == "machine0" || name == "cloudflare" || name == "jobs" || name == "aws" || name == "aws_lambda_microvm" || name == "azure" || name == "digitalocean" || name == "vultr" || name == "linode" || name == "github_codespaces" || name == "azure_dynamic_sessions" || name == "gcp" || name == "proxmox" {
+			switch name {
+			case "actions", "phala", "superserve", "local_container", "apple_container", "mxc", "docker_sandbox", "machine0", "cloudflare", "jobs", "aws", "aws_lambda_microvm", "azure", "digitalocean", "vultr", "linode", "github_codespaces", "azure_dynamic_sessions", "gcp", "proxmox", "xcp_ng":
 				order = append(order, name)
 			}
 		}
 		return true
 	})
-	if got := strings.Join(order, ","); got != "superserve,local_container,apple_container,mxc,docker_sandbox,multipass,machine0,tart,lume,cloudflare,jobs,aws,aws_lambda_microvm,azure,digitalocean,vultr,linode,github_codespaces,azure_dynamic_sessions,gcp,proxmox" {
+	if got := strings.Join(order, ","); got != "actions,blacksmith,agent_sandbox,phala,superserve,local_container,apple_container,mxc,docker_sandbox,multipass,machine0,tart,lume,cloudflare,jobs,aws,aws_lambda_microvm,azure,digitalocean,vultr,linode,github_codespaces,azure_dynamic_sessions,gcp,proxmox,firecracker,xcp_ng" {
 		t.Fatalf("legacy text slot positions: %s", got)
 	}
 }
@@ -351,46 +352,23 @@ func TestProviderConfigShowFormattingBridges(t *testing.T) {
 	}
 }
 
-func TestConfigShowLocalCohortLegacyOwnershipRetired(t *testing.T) {
+func TestConfigShowMigratedLegacyOwnershipRetired(t *testing.T) {
 	view := configShowView(Config{})
-	for _, key := range []string{"localContainer", "appleContainer", "mxc", "dockerSandbox"} {
-		if _, exists := view[key]; exists {
-			t.Errorf("core still owns %s values", key)
-		}
-	}
-	for _, label := range []string{"local_container", "apple_container", "mxc", "docker_sandbox"} {
-		for _, reserved := range strings.Fields(legacyConfigShowTextLabels) {
-			if reserved == label {
-				t.Errorf("migrated label %s still reserved as legacy", label)
+	for _, tc := range []struct{ key, label string }{
+		{"localContainer", "local_container"}, {"appleContainer", "apple_container"}, {"mxc", "mxc"}, {"dockerSandbox", "docker_sandbox"},
+		{"aws", "aws"}, {"azure", "azure"}, {"gcp", "gcp"},
+		{"digitalocean", "digitalocean"}, {"vultr", "vultr"}, {"linode", "linode"},
+		{"blacksmith", "blacksmith"}, {"agentSandbox", "agent_sandbox"}, {"firecracker", "firecracker"},
+	} {
+		t.Run(tc.key, func(t *testing.T) {
+			if _, exists := view[tc.key]; exists {
+				t.Errorf("core still owns %s values", tc.key)
 			}
-		}
-	}
-}
-
-func TestConfigShowCloudCohortLegacyOwnershipRetired(t *testing.T) {
-	view := configShowView(Config{})
-	for _, name := range []string{"aws", "azure", "gcp"} {
-		if _, exists := view[name]; exists {
-			t.Errorf("core still owns %s values", name)
-		}
-		for _, reserved := range strings.Fields(legacyConfigShowTextLabels) {
-			if reserved == name {
-				t.Errorf("migrated label %s still reserved as legacy", name)
+			for _, reserved := range strings.Fields(legacyConfigShowTextLabels) {
+				if reserved == tc.label {
+					t.Errorf("migrated label %s still reserved as legacy", tc.label)
+				}
 			}
-		}
-	}
-}
-
-func TestConfigShowVPSCohortLegacyOwnershipRetired(t *testing.T) {
-	view := configShowView(Config{})
-	for _, name := range []string{"digitalocean", "vultr", "linode"} {
-		if _, exists := view[name]; exists {
-			t.Errorf("core still owns %s values", name)
-		}
-		for _, reserved := range strings.Fields(legacyConfigShowTextLabels) {
-			if reserved == name {
-				t.Errorf("migrated label %s still reserved as legacy", name)
-			}
-		}
+		})
 	}
 }

--- a/internal/providers/agentsandbox/config_show.go
+++ b/internal/providers/agentsandbox/config_show.go
@@ -1,0 +1,29 @@
+package agentsandbox
+
+import (
+	"strconv"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// ConfigShowSection describes loaded values without consulting Kubernetes.
+func (Provider) ConfigShowSection(cfg core.Config) core.ProviderConfigShowSection {
+	c := cfg.AgentSandbox
+	return core.ProviderConfigShowSection{
+		JSONKey: "agentSandbox", TextLabel: "agent_sandbox", Providers: []string{"agent-sandbox"},
+		Fields: []core.ProviderConfigShowField{
+			{JSONName: "kubectl", JSONValue: c.Kubectl, TextName: "kubectl", TextValue: core.Blank(c.Kubectl, "-")},
+			{JSONName: "kubeconfig", JSONValue: c.Kubeconfig, TextName: "kubeconfig", TextValue: core.Blank(c.Kubeconfig, "-")},
+			{JSONName: "context", JSONValue: c.Context, TextName: "context", TextValue: core.Blank(c.Context, "-")},
+			{JSONName: "namespace", JSONValue: c.Namespace, TextName: "namespace", TextValue: core.Blank(c.Namespace, "-")},
+			{JSONName: "warmPool", JSONValue: c.WarmPool, TextName: "warm_pool", TextValue: core.Blank(c.WarmPool, "-")},
+			{JSONName: "container", JSONValue: c.Container, TextName: "container", TextValue: core.Blank(c.Container, "-")},
+			{JSONName: "workdir", JSONValue: c.Workdir, TextName: "workdir", TextValue: core.Blank(c.Workdir, "-")},
+			{JSONName: "sandboxReadyTimeout", JSONValue: c.SandboxReadyTimeout.String(), TextName: "sandbox_ready_timeout", TextValue: c.SandboxReadyTimeout.String()},
+			{JSONName: "podReadyTimeout", JSONValue: c.PodReadyTimeout.String(), TextName: "pod_ready_timeout", TextValue: c.PodReadyTimeout.String()},
+			{JSONName: "execTimeoutSecs", JSONValue: c.ExecTimeoutSecs, TextName: "exec_timeout_secs", TextValue: strconv.Itoa(c.ExecTimeoutSecs)},
+			{JSONName: "deleteOnRelease", JSONValue: c.DeleteOnRelease, TextName: "delete_on_release", TextValue: strconv.FormatBool(c.DeleteOnRelease)},
+			{JSONName: "forgetMissing", JSONValue: c.ForgetMissing, TextName: "forget_missing", TextValue: strconv.FormatBool(c.ForgetMissing)},
+		},
+	}
+}

--- a/internal/providers/agentsandbox/provider_test.go
+++ b/internal/providers/agentsandbox/provider_test.go
@@ -1,9 +1,11 @@
 package agentsandbox
 
 import (
+	"bytes"
 	"flag"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -187,5 +189,84 @@ func TestConfigureUsesLinuxDelegatedBackend(t *testing.T) {
 	}
 	if _, ok := backend.(core.DoctorBackend); !ok {
 		t.Fatal("backend does not implement doctor")
+	}
+}
+
+func TestConfigShowCompleteRawContract(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		config core.AgentSandboxConfig
+		fields []core.ProviderConfigShowField
+	}{{name: "zero", config: core.AgentSandboxConfig{Kubectl: "", Kubeconfig: "", Context: "", Namespace: "", WarmPool: "", Container: "", Workdir: "", SandboxReadyTimeout: 0, PodReadyTimeout: 0, ExecTimeoutSecs: 0, DeleteOnRelease: false, ForgetMissing: false}, fields: []core.ProviderConfigShowField{{JSONName: "kubectl", JSONValue: "", TextName: "kubectl", TextValue: "-"}, {JSONName: "kubeconfig", JSONValue: "", TextName: "kubeconfig", TextValue: "-"}, {JSONName: "context", JSONValue: "", TextName: "context", TextValue: "-"}, {JSONName: "namespace", JSONValue: "", TextName: "namespace", TextValue: "-"}, {JSONName: "warmPool", JSONValue: "", TextName: "warm_pool", TextValue: "-"}, {JSONName: "container", JSONValue: "", TextName: "container", TextValue: "-"}, {JSONName: "workdir", JSONValue: "", TextName: "workdir", TextValue: "-"}, {JSONName: "sandboxReadyTimeout", JSONValue: "0s", TextName: "sandbox_ready_timeout", TextValue: "0s"}, {JSONName: "podReadyTimeout", JSONValue: "0s", TextName: "pod_ready_timeout", TextValue: "0s"}, {JSONName: "execTimeoutSecs", JSONValue: int(0), TextName: "exec_timeout_secs", TextValue: "0"}, {JSONName: "deleteOnRelease", JSONValue: false, TextName: "delete_on_release", TextValue: "false"}, {JSONName: "forgetMissing", JSONValue: false, TextName: "forget_missing", TextValue: "false"}}},
+		{name: "raw", config: core.AgentSandboxConfig{Kubectl: " Kubectl reference ", Kubeconfig: " Kubeconfig reference ", Context: " Context reference ", Namespace: " Namespace reference ", WarmPool: " WarmPool reference ", Container: " Container reference ", Workdir: " Workdir reference ", SandboxReadyTimeout: -1500 * time.Millisecond, PodReadyTimeout: -1500 * time.Millisecond, ExecTimeoutSecs: -7, DeleteOnRelease: true, ForgetMissing: true}, fields: []core.ProviderConfigShowField{{JSONName: "kubectl", JSONValue: " Kubectl reference ", TextName: "kubectl", TextValue: " Kubectl reference "}, {JSONName: "kubeconfig", JSONValue: " Kubeconfig reference ", TextName: "kubeconfig", TextValue: " Kubeconfig reference "}, {JSONName: "context", JSONValue: " Context reference ", TextName: "context", TextValue: " Context reference "}, {JSONName: "namespace", JSONValue: " Namespace reference ", TextName: "namespace", TextValue: " Namespace reference "}, {JSONName: "warmPool", JSONValue: " WarmPool reference ", TextName: "warm_pool", TextValue: " WarmPool reference "}, {JSONName: "container", JSONValue: " Container reference ", TextName: "container", TextValue: " Container reference "}, {JSONName: "workdir", JSONValue: " Workdir reference ", TextName: "workdir", TextValue: " Workdir reference "}, {JSONName: "sandboxReadyTimeout", JSONValue: "-1.5s", TextName: "sandbox_ready_timeout", TextValue: "-1.5s"}, {JSONName: "podReadyTimeout", JSONValue: "-1.5s", TextName: "pod_ready_timeout", TextValue: "-1.5s"}, {JSONName: "execTimeoutSecs", JSONValue: int(-7), TextName: "exec_timeout_secs", TextValue: "-7"}, {JSONName: "deleteOnRelease", JSONValue: true, TextName: "delete_on_release", TextValue: "true"}, {JSONName: "forgetMissing", JSONValue: true, TextName: "forget_missing", TextValue: "true"}}},
+		{name: "whitespace", config: core.AgentSandboxConfig{Kubectl: " \t ", Kubeconfig: " \t ", Context: " \t ", Namespace: " \t ", WarmPool: " \t ", Container: " \t ", Workdir: " \t ", SandboxReadyTimeout: -1500 * time.Millisecond, PodReadyTimeout: -1500 * time.Millisecond, ExecTimeoutSecs: -7, DeleteOnRelease: true, ForgetMissing: true}, fields: []core.ProviderConfigShowField{{JSONName: "kubectl", JSONValue: " \t ", TextName: "kubectl", TextValue: " \t "}, {JSONName: "kubeconfig", JSONValue: " \t ", TextName: "kubeconfig", TextValue: " \t "}, {JSONName: "context", JSONValue: " \t ", TextName: "context", TextValue: " \t "}, {JSONName: "namespace", JSONValue: " \t ", TextName: "namespace", TextValue: " \t "}, {JSONName: "warmPool", JSONValue: " \t ", TextName: "warm_pool", TextValue: " \t "}, {JSONName: "container", JSONValue: " \t ", TextName: "container", TextValue: " \t "}, {JSONName: "workdir", JSONValue: " \t ", TextName: "workdir", TextValue: " \t "}, {JSONName: "sandboxReadyTimeout", JSONValue: "-1.5s", TextName: "sandbox_ready_timeout", TextValue: "-1.5s"}, {JSONName: "podReadyTimeout", JSONValue: "-1.5s", TextName: "pod_ready_timeout", TextValue: "-1.5s"}, {JSONName: "execTimeoutSecs", JSONValue: int(-7), TextName: "exec_timeout_secs", TextValue: "-7"}, {JSONName: "deleteOnRelease", JSONValue: true, TextName: "delete_on_release", TextValue: "true"}, {JSONName: "forgetMissing", JSONValue: true, TextName: "forget_missing", TextValue: "true"}}}} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := core.Config{Provider: "unselected-display"}
+			cfg.AgentSandbox = tc.config
+			want := core.ProviderConfigShowSection{JSONKey: "agentSandbox", TextLabel: "agent_sandbox", Providers: []string{"agent-sandbox"}, Fields: tc.fields}
+			for _, selection := range []string{"unselected-display", "agent-sandbox"} {
+				cfg.Provider = selection
+				before := cfg
+				got := (Provider{}).ConfigShowSection(cfg)
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("selection=%s section=%#v want%#v", selection, got, want)
+				}
+				if !reflect.DeepEqual(cfg, before) {
+					t.Fatal("passive projector mutated config")
+				}
+			}
+		})
+	}
+}
+
+func TestConfigShowIncludesAgentSandboxRoute(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.AgentSandbox.Kubectl = "/opt/bin/kubectl"
+	cfg.AgentSandbox.Kubeconfig = "/tmp/agent-kubeconfig"
+	cfg.AgentSandbox.Context = "agent-context"
+	cfg.AgentSandbox.Namespace = "sandboxes"
+	cfg.AgentSandbox.WarmPool = "linux-pool"
+	cfg.AgentSandbox.Container = "worker"
+	cfg.AgentSandbox.Workdir = "/workspace/my-app"
+	cfg.AgentSandbox.SandboxReadyTimeout = 2 * time.Minute
+	cfg.AgentSandbox.PodReadyTimeout = 45 * time.Second
+	cfg.AgentSandbox.ExecTimeoutSecs = 42
+	cfg.AgentSandbox.DeleteOnRelease = false
+	cfg.AgentSandbox.ForgetMissing = true
+
+	section := (Provider{}).ConfigShowSection(cfg)
+	values := map[string]any{}
+	var projected strings.Builder
+	projected.WriteString(section.TextLabel)
+	for _, field := range section.Fields {
+		values[field.JSONName] = field.JSONValue
+		projected.WriteString(" " + field.TextName + "=" + field.TextValue)
+	}
+	projected.WriteByte('\n')
+	view := map[string]any{section.JSONKey: values}
+	agent, ok := view["agentSandbox"].(map[string]any)
+	if !ok || agent["kubeconfig"] != "/tmp/agent-kubeconfig" || agent["warmPool"] != "linux-pool" ||
+		agent["sandboxReadyTimeout"] != "2m0s" || agent["deleteOnRelease"] != false || agent["forgetMissing"] != true {
+		t.Fatalf("agentSandbox view=%#v", agent)
+	}
+	var text bytes.Buffer
+	text.WriteString(projected.String())
+	for _, want := range []string{
+		"agent_sandbox kubectl=/opt/bin/kubectl",
+		"kubeconfig=/tmp/agent-kubeconfig",
+		"context=agent-context",
+		"namespace=sandboxes",
+		"warm_pool=linux-pool",
+		"container=worker",
+		"workdir=/workspace/my-app",
+		"sandbox_ready_timeout=2m0s",
+		"pod_ready_timeout=45s",
+		"exec_timeout_secs=42",
+		"delete_on_release=false",
+		"forget_missing=true",
+	} {
+		if !strings.Contains(text.String(), want) {
+			t.Fatalf("config show missing %q: %q", want, text.String())
+		}
 	}
 }

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -1663,3 +1663,30 @@ func TestResolveBlacksmithDiscoveryID(t *testing.T) {
 		t.Fatalf("slug read-only discovery=%q err=%v", got, err)
 	}
 }
+
+func TestConfigShowCompleteRawContract(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		config core.BlacksmithConfig
+		fields []core.ProviderConfigShowField
+	}{{name: "zero", config: core.BlacksmithConfig{Org: "", Workflow: "", Job: "", Ref: "", IdleTimeout: 0, Debug: false}, fields: []core.ProviderConfigShowField{{JSONName: "org", JSONValue: "", TextName: "org", TextValue: "-"}, {JSONName: "workflow", JSONValue: "", TextName: "workflow", TextValue: "-"}, {JSONName: "job", JSONValue: "", TextName: "job", TextValue: "-"}, {JSONName: "ref", JSONValue: "", TextName: "ref", TextValue: "-"}, {JSONName: "idleTimeout", JSONValue: "0s", TextName: "idle_timeout", TextValue: "0s"}, {JSONName: "debug", JSONValue: false, TextName: "debug", TextValue: "false"}}},
+		{name: "raw", config: core.BlacksmithConfig{Org: " Org reference ", Workflow: " Workflow reference ", Job: " Job reference ", Ref: " Ref reference ", IdleTimeout: -1500 * time.Millisecond, Debug: true}, fields: []core.ProviderConfigShowField{{JSONName: "org", JSONValue: " Org reference ", TextName: "org", TextValue: " Org reference "}, {JSONName: "workflow", JSONValue: " Workflow reference ", TextName: "workflow", TextValue: " Workflow reference "}, {JSONName: "job", JSONValue: " Job reference ", TextName: "job", TextValue: " Job reference "}, {JSONName: "ref", JSONValue: " Ref reference ", TextName: "ref", TextValue: " Ref reference "}, {JSONName: "idleTimeout", JSONValue: "-1.5s", TextName: "idle_timeout", TextValue: "-1.5s"}, {JSONName: "debug", JSONValue: true, TextName: "debug", TextValue: "true"}}},
+		{name: "whitespace", config: core.BlacksmithConfig{Org: " \t ", Workflow: " \t ", Job: " \t ", Ref: " \t ", IdleTimeout: -1500 * time.Millisecond, Debug: true}, fields: []core.ProviderConfigShowField{{JSONName: "org", JSONValue: " \t ", TextName: "org", TextValue: " \t "}, {JSONName: "workflow", JSONValue: " \t ", TextName: "workflow", TextValue: " \t "}, {JSONName: "job", JSONValue: " \t ", TextName: "job", TextValue: " \t "}, {JSONName: "ref", JSONValue: " \t ", TextName: "ref", TextValue: " \t "}, {JSONName: "idleTimeout", JSONValue: "-1.5s", TextName: "idle_timeout", TextValue: "-1.5s"}, {JSONName: "debug", JSONValue: true, TextName: "debug", TextValue: "true"}}}} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := core.Config{Provider: "unselected-display"}
+			cfg.Blacksmith = tc.config
+			want := core.ProviderConfigShowSection{JSONKey: "blacksmith", TextLabel: "blacksmith", Providers: []string{"blacksmith-testbox"}, Fields: tc.fields}
+			for _, selection := range []string{"unselected-display", "blacksmith-testbox"} {
+				cfg.Provider = selection
+				before := cfg
+				got := (Provider{}).ConfigShowSection(cfg)
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("selection=%s section=%#v want%#v", selection, got, want)
+				}
+				if !reflect.DeepEqual(cfg, before) {
+					t.Fatal("passive projector mutated config")
+				}
+			}
+		})
+	}
+}

--- a/internal/providers/blacksmith/config_show.go
+++ b/internal/providers/blacksmith/config_show.go
@@ -1,0 +1,23 @@
+package blacksmith
+
+import (
+	"strconv"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// ConfigShowSection describes loaded values without resolving workflow references.
+func (Provider) ConfigShowSection(cfg core.Config) core.ProviderConfigShowSection {
+	c := cfg.Blacksmith
+	return core.ProviderConfigShowSection{
+		JSONKey: "blacksmith", TextLabel: "blacksmith", Providers: []string{"blacksmith-testbox"},
+		Fields: []core.ProviderConfigShowField{
+			{JSONName: "org", JSONValue: c.Org, TextName: "org", TextValue: core.Blank(c.Org, "-")},
+			{JSONName: "workflow", JSONValue: c.Workflow, TextName: "workflow", TextValue: core.Blank(c.Workflow, "-")},
+			{JSONName: "job", JSONValue: c.Job, TextName: "job", TextValue: core.Blank(c.Job, "-")},
+			{JSONName: "ref", JSONValue: c.Ref, TextName: "ref", TextValue: core.Blank(c.Ref, "-")},
+			{JSONName: "idleTimeout", JSONValue: c.IdleTimeout.String(), TextName: "idle_timeout", TextValue: c.IdleTimeout.String()},
+			{JSONName: "debug", JSONValue: c.Debug, TextName: "debug", TextValue: strconv.FormatBool(c.Debug)},
+		},
+	}
+}

--- a/internal/providers/firecracker/backend_test.go
+++ b/internal/providers/firecracker/backend_test.go
@@ -1,6 +1,7 @@
 package firecracker
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
@@ -493,4 +494,94 @@ func (f fakeFileInfo) Mode() os.FileMode {
 		return os.ModeDir | 0o755
 	}
 	return 0o644
+}
+
+func TestConfigShowCompleteRawContract(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		config core.FirecrackerConfig
+		fields []core.ProviderConfigShowField
+	}{{name: "zero", config: core.FirecrackerConfig{Binary: "", Jailer: "", Kernel: "", RootFS: "", User: "", WorkRoot: "", CPUs: 0, MemoryMiB: 0, DiskMiB: 0, Network: "", CNINetwork: "", CNIConfDir: "", CNIBinDir: "", LaunchTimeout: 0, DeleteOnRelease: false}, fields: []core.ProviderConfigShowField{{JSONName: "binary", JSONValue: "", TextName: "binary", TextValue: "-"}, {JSONName: "jailer", JSONValue: "", TextName: "jailer", TextValue: "-"}, {JSONName: "kernel", JSONValue: "", TextName: "kernel", TextValue: "-"}, {JSONName: "rootfs", JSONValue: "", TextName: "rootfs", TextValue: "-"}, {JSONName: "user", JSONValue: "", TextName: "user", TextValue: "-"}, {JSONName: "workRoot", JSONValue: "", TextName: "work_root", TextValue: "-"}, {JSONName: "cpus", JSONValue: int(0), TextName: "cpus", TextValue: "0"}, {JSONName: "memoryMiB", JSONValue: int(0), TextName: "memory_mib", TextValue: "0"}, {JSONName: "diskMiB", JSONValue: int(0), TextName: "disk_mib", TextValue: "0"}, {JSONName: "network", JSONValue: "", TextName: "network", TextValue: "-"}, {JSONName: "cniNetwork", JSONValue: "", TextName: "cni_network", TextValue: "-"}, {JSONName: "cniConfDir", JSONValue: "", TextName: "cni_conf_dir", TextValue: "-"}, {JSONName: "cniBinDir", JSONValue: "", TextName: "cni_bin_dir", TextValue: "-"}, {JSONName: "launchTimeout", JSONValue: "0s", TextName: "launch_timeout", TextValue: "0s"}, {JSONName: "deleteOnRelease", JSONValue: false, TextName: "delete_on_release", TextValue: "false"}}},
+		{name: "raw", config: core.FirecrackerConfig{Binary: " Binary reference ", Jailer: " Jailer reference ", Kernel: " Kernel reference ", RootFS: " RootFS reference ", User: " User reference ", WorkRoot: " WorkRoot reference ", CPUs: -7, MemoryMiB: -7, DiskMiB: -7, Network: " Network reference ", CNINetwork: " CNINetwork reference ", CNIConfDir: " CNIConfDir reference ", CNIBinDir: " CNIBinDir reference ", LaunchTimeout: -1500 * time.Millisecond, DeleteOnRelease: true}, fields: []core.ProviderConfigShowField{{JSONName: "binary", JSONValue: " Binary reference ", TextName: "binary", TextValue: " Binary reference "}, {JSONName: "jailer", JSONValue: " Jailer reference ", TextName: "jailer", TextValue: " Jailer reference "}, {JSONName: "kernel", JSONValue: " Kernel reference ", TextName: "kernel", TextValue: " Kernel reference "}, {JSONName: "rootfs", JSONValue: " RootFS reference ", TextName: "rootfs", TextValue: " RootFS reference "}, {JSONName: "user", JSONValue: " User reference ", TextName: "user", TextValue: " User reference "}, {JSONName: "workRoot", JSONValue: " WorkRoot reference ", TextName: "work_root", TextValue: " WorkRoot reference "}, {JSONName: "cpus", JSONValue: int(-7), TextName: "cpus", TextValue: "-7"}, {JSONName: "memoryMiB", JSONValue: int(-7), TextName: "memory_mib", TextValue: "-7"}, {JSONName: "diskMiB", JSONValue: int(-7), TextName: "disk_mib", TextValue: "-7"}, {JSONName: "network", JSONValue: " Network reference ", TextName: "network", TextValue: " Network reference "}, {JSONName: "cniNetwork", JSONValue: " CNINetwork reference ", TextName: "cni_network", TextValue: " CNINetwork reference "}, {JSONName: "cniConfDir", JSONValue: " CNIConfDir reference ", TextName: "cni_conf_dir", TextValue: " CNIConfDir reference "}, {JSONName: "cniBinDir", JSONValue: " CNIBinDir reference ", TextName: "cni_bin_dir", TextValue: " CNIBinDir reference "}, {JSONName: "launchTimeout", JSONValue: "-1.5s", TextName: "launch_timeout", TextValue: "-1.5s"}, {JSONName: "deleteOnRelease", JSONValue: true, TextName: "delete_on_release", TextValue: "true"}}},
+		{name: "whitespace", config: core.FirecrackerConfig{Binary: " \t ", Jailer: " \t ", Kernel: " \t ", RootFS: " \t ", User: " \t ", WorkRoot: " \t ", CPUs: -7, MemoryMiB: -7, DiskMiB: -7, Network: " \t ", CNINetwork: " \t ", CNIConfDir: " \t ", CNIBinDir: " \t ", LaunchTimeout: -1500 * time.Millisecond, DeleteOnRelease: true}, fields: []core.ProviderConfigShowField{{JSONName: "binary", JSONValue: " \t ", TextName: "binary", TextValue: " \t "}, {JSONName: "jailer", JSONValue: " \t ", TextName: "jailer", TextValue: " \t "}, {JSONName: "kernel", JSONValue: " \t ", TextName: "kernel", TextValue: " \t "}, {JSONName: "rootfs", JSONValue: " \t ", TextName: "rootfs", TextValue: " \t "}, {JSONName: "user", JSONValue: " \t ", TextName: "user", TextValue: " \t "}, {JSONName: "workRoot", JSONValue: " \t ", TextName: "work_root", TextValue: " \t "}, {JSONName: "cpus", JSONValue: int(-7), TextName: "cpus", TextValue: "-7"}, {JSONName: "memoryMiB", JSONValue: int(-7), TextName: "memory_mib", TextValue: "-7"}, {JSONName: "diskMiB", JSONValue: int(-7), TextName: "disk_mib", TextValue: "-7"}, {JSONName: "network", JSONValue: " \t ", TextName: "network", TextValue: " \t "}, {JSONName: "cniNetwork", JSONValue: " \t ", TextName: "cni_network", TextValue: " \t "}, {JSONName: "cniConfDir", JSONValue: " \t ", TextName: "cni_conf_dir", TextValue: " \t "}, {JSONName: "cniBinDir", JSONValue: " \t ", TextName: "cni_bin_dir", TextValue: " \t "}, {JSONName: "launchTimeout", JSONValue: "-1.5s", TextName: "launch_timeout", TextValue: "-1.5s"}, {JSONName: "deleteOnRelease", JSONValue: true, TextName: "delete_on_release", TextValue: "true"}}}} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := core.Config{Provider: "unselected-display"}
+			cfg.Firecracker = tc.config
+			want := core.ProviderConfigShowSection{JSONKey: "firecracker", TextLabel: "firecracker", Providers: []string{"firecracker"}, Fields: tc.fields}
+			for _, selection := range []string{"unselected-display", "firecracker"} {
+				cfg.Provider = selection
+				before := cfg
+				got := (Provider{}).ConfigShowSection(cfg)
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("selection=%s section=%#v want%#v", selection, got, want)
+				}
+				if !reflect.DeepEqual(cfg, before) {
+					t.Fatal("passive projector mutated config")
+				}
+			}
+		})
+	}
+}
+
+func TestConfigShowIncludesFirecrackerConfig(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = "firecracker"
+	cfg.Firecracker.Binary = "/opt/bin/firecracker"
+	cfg.Firecracker.Jailer = "/opt/bin/jailer"
+	cfg.Firecracker.Kernel = "/var/lib/firecracker/vmlinux"
+	cfg.Firecracker.RootFS = "/var/lib/firecracker/rootfs.ext4"
+	cfg.Firecracker.User = "runner"
+	cfg.Firecracker.WorkRoot = "/workspace/firecracker"
+	cfg.Firecracker.CPUs = 6
+	cfg.Firecracker.MemoryMiB = 12288
+	cfg.Firecracker.DiskMiB = 32768
+	cfg.Firecracker.Network = "cni"
+	cfg.Firecracker.CNINetwork = "lab-firecracker"
+	cfg.Firecracker.CNIConfDir = "/etc/cni/lab"
+	cfg.Firecracker.CNIBinDir = "/opt/cni/lab"
+	cfg.Firecracker.LaunchTimeout = 3 * time.Minute
+	cfg.Firecracker.DeleteOnRelease = false
+
+	section := (Provider{}).ConfigShowSection(cfg)
+	values := map[string]any{}
+	var projected strings.Builder
+	projected.WriteString(section.TextLabel)
+	for _, field := range section.Fields {
+		values[field.JSONName] = field.JSONValue
+		projected.WriteString(" " + field.TextName + "=" + field.TextValue)
+	}
+	projected.WriteByte('\n')
+	view := map[string]any{section.JSONKey: values}
+	firecracker, ok := view["firecracker"].(map[string]any)
+	if !ok || firecracker["binary"] != "/opt/bin/firecracker" || firecracker["jailer"] != "/opt/bin/jailer" ||
+		firecracker["kernel"] != "/var/lib/firecracker/vmlinux" || firecracker["rootfs"] != "/var/lib/firecracker/rootfs.ext4" ||
+		firecracker["workRoot"] != "/workspace/firecracker" || firecracker["cpus"] != 6 ||
+		firecracker["memoryMiB"] != 12288 || firecracker["diskMiB"] != 32768 ||
+		firecracker["cniNetwork"] != "lab-firecracker" || firecracker["launchTimeout"] != "3m0s" ||
+		firecracker["deleteOnRelease"] != false {
+		t.Fatalf("firecracker view=%#v", firecracker)
+	}
+	var text bytes.Buffer
+	text.WriteString(projected.String())
+	for _, want := range []string{
+		"firecracker binary=/opt/bin/firecracker",
+		"jailer=/opt/bin/jailer",
+		"kernel=/var/lib/firecracker/vmlinux",
+		"rootfs=/var/lib/firecracker/rootfs.ext4",
+		"user=runner",
+		"work_root=/workspace/firecracker",
+		"cpus=6",
+		"memory_mib=12288",
+		"disk_mib=32768",
+		"network=cni",
+		"cni_network=lab-firecracker",
+		"cni_conf_dir=/etc/cni/lab",
+		"cni_bin_dir=/opt/cni/lab",
+		"launch_timeout=3m0s",
+		"delete_on_release=false",
+	} {
+		if !strings.Contains(text.String(), want) {
+			t.Fatalf("config show missing %q: %q", want, text.String())
+		}
+	}
 }

--- a/internal/providers/firecracker/config_show.go
+++ b/internal/providers/firecracker/config_show.go
@@ -1,0 +1,32 @@
+package firecracker
+
+import (
+	"strconv"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// ConfigShowSection describes loaded values without inspecting guest assets.
+func (Provider) ConfigShowSection(cfg core.Config) core.ProviderConfigShowSection {
+	c := cfg.Firecracker
+	return core.ProviderConfigShowSection{
+		JSONKey: "firecracker", TextLabel: "firecracker", Providers: []string{"firecracker"},
+		Fields: []core.ProviderConfigShowField{
+			{JSONName: "binary", JSONValue: c.Binary, TextName: "binary", TextValue: core.Blank(c.Binary, "-")},
+			{JSONName: "jailer", JSONValue: c.Jailer, TextName: "jailer", TextValue: core.Blank(c.Jailer, "-")},
+			{JSONName: "kernel", JSONValue: c.Kernel, TextName: "kernel", TextValue: core.Blank(c.Kernel, "-")},
+			{JSONName: "rootfs", JSONValue: c.RootFS, TextName: "rootfs", TextValue: core.Blank(c.RootFS, "-")},
+			{JSONName: "user", JSONValue: c.User, TextName: "user", TextValue: core.Blank(c.User, "-")},
+			{JSONName: "workRoot", JSONValue: c.WorkRoot, TextName: "work_root", TextValue: core.Blank(c.WorkRoot, "-")},
+			{JSONName: "cpus", JSONValue: c.CPUs, TextName: "cpus", TextValue: strconv.Itoa(c.CPUs)},
+			{JSONName: "memoryMiB", JSONValue: c.MemoryMiB, TextName: "memory_mib", TextValue: strconv.Itoa(c.MemoryMiB)},
+			{JSONName: "diskMiB", JSONValue: c.DiskMiB, TextName: "disk_mib", TextValue: strconv.Itoa(c.DiskMiB)},
+			{JSONName: "network", JSONValue: c.Network, TextName: "network", TextValue: core.Blank(c.Network, "-")},
+			{JSONName: "cniNetwork", JSONValue: c.CNINetwork, TextName: "cni_network", TextValue: core.Blank(c.CNINetwork, "-")},
+			{JSONName: "cniConfDir", JSONValue: c.CNIConfDir, TextName: "cni_conf_dir", TextValue: core.Blank(c.CNIConfDir, "-")},
+			{JSONName: "cniBinDir", JSONValue: c.CNIBinDir, TextName: "cni_bin_dir", TextValue: core.Blank(c.CNIBinDir, "-")},
+			{JSONName: "launchTimeout", JSONValue: c.LaunchTimeout.String(), TextName: "launch_timeout", TextValue: c.LaunchTimeout.String()},
+			{JSONName: "deleteOnRelease", JSONValue: c.DeleteOnRelease, TextName: "delete_on_release", TextValue: strconv.FormatBool(c.DeleteOnRelease)},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

Core maintained separate JSON maps and positional text arguments for Blacksmith, Agent Sandbox and Firecracker. Each provider now supplies one passive, ordered projection; together these cover all 33 existing fields. The shared collector renders those projections at the original text slots; the three old maps, rows and label reservations are removed.

Raw JSON strings, empty-only text placeholders, integer and boolean types, duration formatting and selected/unselected visibility remain unchanged. Tool names, workflow references and guest paths are displayed without resolving or executing them. This adds no default, credential, file, environment, native or network lookup.

The original Agent Sandbox and Firecracker raw display assertions now exercise their real provider owners. Firecracker's generic default-dispatch check remains in core. Existing ownership guards are consolidated and extended, and text-slot adjacency remains explicitly checked. No production fallback or fake provider substitutes for built-in coverage.

Documentation now records this ownership boundary and the remaining migration: 32 of the original both-format providers still use the legacy implementation. The 24 missing sections and three missing text sections are unchanged. This refactor changes no user-visible output and needs no release-note entry.

## Verification

The independent mandatory Codex review found no P0 findings in the complete final scope. Core race tests passed 12 tests and 26 subtests; all three provider packages passed their focused race tests, covering every field, nine table cases, selected/unselected calls and both preserved legacy fixtures. Go vet and the docs build passed.

Two real CLI binaries were built from the original source and the frozen candidate. All 12 calls matched complete stdout, stderr and exit status byte-for-byte, without normalization, baseline recapture or fixture corrections:

| Scenario | JSON | Text |
|---|---|---|
| Defaults, another provider selected | Match | Match |
| Populated values, another provider selected | Match | Match |
| Blacksmith selected | Match | Match |
| Agent Sandbox selected | Match | Match |
| Firecracker selected | Match | Match |
| Empty strings, zero values and false, another provider selected | Match | Match |

All 33 keys, value types, field order and original text-slot adjacency were checked. Candidate binary SHA-256: `7569cc29e79e95c78a249ff386e4bca2cecb377369e48a5d30973a014f04a80b`. The proof ran before commit; afterward, all 2,476 source fingerprints used for that build were verified against commit `bfd7347d171abd3e28bddaeafaec70b581813c66`.

These are credential-free, network-denied configuration-display checks. They do not claim cloud, Kubernetes or VM lifecycle execution.
