### PR TITLE
docs: prepare changelog for 0.57.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,37 @@
 
 ## Unreleased
 
-- Keep XFCE desktop components in their session, launch the visible terminal through session autostart, and refresh changed panel CSS through the existing panel owner to prevent duplicate panels and notification-area warnings; preserve released-client resets through a service alias. [PR 2117](https://github.com/openclaw/crabbox/pull/2117). Thanks @steipete.
-- Add `crabbox exec` for byte-preserving commands on completed Daytona fixed-ID leases without workspace sync or hydration, retaining repository ownership through transport cleanup; provide offline capability discovery and `stop --current-repo` cleanup after ownership checks inside the same release fence. [PR 2119](https://github.com/openclaw/crabbox/pull/2119). Thanks @steipete.
-- Daytona: attest API-key cleanup through current-key organization metadata and retire acquired fixed leases after verified native TTL or external deletion; inspection records a terminal tombstone without issuing deletion or reusing the fixed ID. [PR 2111](https://github.com/openclaw/crabbox/pull/2111). Thanks @steipete.
-- Show OpenComputer, OpenSandbox and CUA settings in offline JSON and text, including unselected providers, without discovering credentials, resolving external defaults or executing SDK bridges. [PR 2112](https://github.com/openclaw/crabbox/pull/2112). Thanks @steipete.
-- Show Freestyle and Crownest settings through a shared offline JSON/text display path, preserving zero and false values while redacting URLs and reporting only loaded key presence. [PR 2104](https://github.com/openclaw/crabbox/pull/2104). Thanks @steipete.
-- Retain recognized workspace-owner protocol states in child and phase-witness inspection errors, improving diagnostics without changing ownership decisions or retry behavior. [PR 2106](https://github.com/openclaw/crabbox/pull/2106). Thanks @steipete.
-- Retry recognized checksum-service and module-ZIP HTTP/2 interruptions once during Go installation verification's dependency download, preserving checksum enforcement and the unchanged offline install checks. [PR 2113](https://github.com/openclaw/crabbox/pull/2113), [PR 2118](https://github.com/openclaw/crabbox/pull/2118). Thanks @steipete.
+### Highlights
+
+- **Run commands on existing Daytona fixed-ID leases.** The new `crabbox exec` streams commands without workspace sync or hydration and keeps repository ownership protected until transport cleanup finishes.
+- **Smoother XFCE desktops.** Prevent duplicate panels and notification-area warnings, start the visible terminal inside the desktop session, and refresh panel styling without restarting the rest of the desktop.
+- **Safer Daytona fixed-lease cleanup and expiry recovery.** Verify API-key organization identity during cleanup, reconcile leases deleted by native TTL or external actions, and use `stop --current-repo` for repository-scoped cleanup.
+- **See more provider settings offline.** Inspect Freestyle, Crownest, OpenComputer, OpenSandbox, and CUA configuration in text and JSON, including providers that are not currently selected.
+
+### Upgrade notes
+
+- `exec` initially supports completed direct Daytona fixed-ID Linux leases; `stop --current-repo` provides repository-scoped cleanup for that direct fixed-ID route. Check capabilities with `crabbox exec --check --provider daytona` before allocating; other providers, ordinary leases, coordinator routes, and Windows targets are not supported by these execution and cleanup modes. [PR 2119](https://github.com/openclaw/crabbox/pull/2119).
+- `exec` leaves the SSH account's initial working directory unchanged and requires piped or redirected stdin; use `</dev/null` when no input is needed and an explicit shell command to change directories. Non-PTY streams preserve bytes; `--pty` uses terminal semantics. [PR 2119](https://github.com/openclaw/crabbox/pull/2119).
+- Daytona fixed-lease cleanup with API keys requires organization metadata from the current-key endpoint. Older servers that omit it require an OAuth organization profile for cleanup; a bare 404 or elapsed TTL does not prove that a sandbox has been removed. [PR 2111](https://github.com/openclaw/crabbox/pull/2111).
+- New XFCE bootstrap runs retain `crabbox-desktop-session.service` as an alias of `crabbox-desktop.service` so released clients can still reset the desktop. Panel refresh does not clear existing terminal color or menu caches. [PR 2117](https://github.com/openclaw/crabbox/pull/2117).
+
+### Changes
+
+- Add `crabbox exec` for commands on completed Daytona fixed-ID leases without workspace sync or hydration. Forward non-PTY streams without rewriting their bytes, resolve fresh SSH access, and retain the repository claim through command execution and local transport cleanup. [PR 2119](https://github.com/openclaw/crabbox/pull/2119). Thanks @steipete.
+- Add offline `exec --check` capability discovery and `stop --current-repo` cleanup for supported fixed-ID leases. Validate repository ownership under the same lock used for deletion, so cleanup waits for active `exec` commands and a previous owner cannot delete a lease after another repository reclaims it. [PR 2119](https://github.com/openclaw/crabbox/pull/2119). Thanks @steipete.
+- Let XFCE own its panel, window manager, desktop renderer, and visible-terminal autostart. Apply theme changes through the matching user session, restart only the existing panel when its CSS changes, and leave unchanged styling alone to prevent duplicate components and notification-area warnings. [PR 2117](https://github.com/openclaw/crabbox/pull/2117). Thanks @steipete.
+- Daytona: verify fixed-lease cleanup with API keys against current-key organization metadata and reconcile acquired fixed leases after confirmed native TTL or external deletion. Inspection records a terminal tombstone without issuing deletion or recreating the fixed ID; incomplete or ambiguous cleanup retains the claim. [PR 2111](https://github.com/openclaw/crabbox/pull/2111). Thanks @steipete.
+- Show Freestyle, Crownest, OpenComputer, OpenSandbox, and CUA settings in offline `config show` text and JSON, including unselected providers. Preserve explicit zero/false values and URL redaction, report only already-loaded key presence, and avoid credential discovery, external default resolution, or SDK bridge execution. [PR 2104](https://github.com/openclaw/crabbox/pull/2104), [PR 2112](https://github.com/openclaw/crabbox/pull/2112). Thanks @steipete.
+- Include recognized workspace-owner protocol states in child and phase-witness inspection errors, making ownership failures easier to diagnose while preserving ownership decisions and retry behavior. [PR 2106](https://github.com/openclaw/crabbox/pull/2106). Thanks @steipete.
+
+### Maintenance
+
+- Go installation verification: retry recognized checksum-service and module-ZIP HTTP/2 interruptions once during dependency download, retaining checksum enforcement and the unchanged offline install checks. [PR 2113](https://github.com/openclaw/crabbox/pull/2113), [PR 2118](https://github.com/openclaw/crabbox/pull/2118). Thanks @steipete.
+- Move existing local, cloud, and VPS configuration displays into provider adapters while preserving published fields, text positions, redaction, and zero/false/null/empty values. [PR 2110](https://github.com/openclaw/crabbox/pull/2110), [PR 2116](https://github.com/openclaw/crabbox/pull/2116), [PR 2120](https://github.com/openclaw/crabbox/pull/2120), [PR 2121](https://github.com/openclaw/crabbox/pull/2121). Thanks @steipete.
+- Share default and compact JSON request construction across provider adapters while retaining exact wire formats, nil-body handling, request replay, and provider-owned authentication, timeout, and retry policies. [PR 2122](https://github.com/openclaw/crabbox/pull/2122), [PR 2124](https://github.com/openclaw/crabbox/pull/2124), [PR 2125](https://github.com/openclaw/crabbox/pull/2125). Thanks @steipete.
+- Share buffered JSON response decoding for E2B, CubeSandbox, and Azure Dynamic Sessions while keeping body closing, successful header copies, and typed API errors in their adapters. [PR 2126](https://github.com/openclaw/crabbox/pull/2126). Thanks @steipete.
+- Reuse the shared exact tag codecs in DigitalOcean, Linode, and Scaleway without changing their tag formats. [PR 2091](https://github.com/openclaw/crabbox/pull/2091). Thanks @vincentkoc.
+- Select Linode paginated resource types at their call sites, preserving page traversal, ordering, duplicates, and results collected before a later page fails. [PR 2123](https://github.com/openclaw/crabbox/pull/2123). Thanks @steipete.
 
 ## 0.56.0 - 2026-09-11
 


### PR DESCRIPTION
Rewrite the pending 0.57.0 notes with user-facing highlights first: direct commands on Daytona fixed-ID leases, smoother XFCE desktops, safer Daytona cleanup, and expanded offline configuration inspection. Add the relevant scope and upgrade guidance, group the detailed changes, and move implementation maintenance last.

Preserve all published history and existing references, retain contributor credit, and keep the section under Unreleased until release preparation. Only CHANGELOG.md changes.

Validation: documentation/link/site checks, assertions that published history and existing references are preserved, git diff --check, and the required independent autoreview.
