### PR TITLE
refactor(providers): use shared loopback checks

### DIFF
--- a/internal/providers/cloudflaresandbox/flags.go
+++ b/internal/providers/cloudflaresandbox/flags.go
@@ -77,7 +77,7 @@ func bridgeURL(cfg Config) (string, error) {
 		return "", exit(2, "%s bridge URL must not include userinfo", providerName)
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
-	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && shared.IsLoopbackHost(parsed.Hostname())) {
 		return "", exit(2, "%s bridge URL %q must use https unless it targets localhost", providerName, bridgeURLForError(raw))
 	}
 	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
@@ -101,10 +101,6 @@ func bridgeURLForError(raw string) string {
 		return parsed.String()
 	}
 	return "<redacted>"
-}
-
-func isLoopbackHost(host string) bool {
-	return shared.IsLoopbackHost(host)
 }
 
 func canonicalHostPort(parsed *url.URL) string {

--- a/internal/providers/crownest/flags.go
+++ b/internal/providers/crownest/flags.go
@@ -58,16 +58,12 @@ func validateBaseURL(raw string) (string, error) {
 		return "", exit(2, "provider=crownest base URL must not contain userinfo, query parameters, or a fragment")
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
-	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && shared.IsLoopbackHost(parsed.Hostname())) {
 		return "", exit(2, "provider=crownest base URL must use HTTPS except for loopback development endpoints")
 	}
 	parsed.Host = canonicalHostPort(parsed)
 	parsed.Path = strings.TrimRight(parsed.Path, "/")
 	return parsed.String(), nil
-}
-
-func isLoopbackHost(host string) bool {
-	return shared.IsLoopbackHost(host)
 }
 
 func canonicalHostPort(parsed *url.URL) string {


### PR DESCRIPTION
## What Problem This Solves

Cloudflare Sandbox and Crownest each retained a provider-local forwarding wrapper around the shared loopback-host check.

## Why This Change Was Made

### Summary

Replace two provider-local loopback forwarding wrappers with the shared check in Cloudflare Sandbox and Crownest. Behavior is unchanged.

## User Impact

No user-visible impact. This is an internal behavior-preserving refactor.

## Evidence

### Tests

- `go test -race -count=1 -timeout=20m ./internal/providers/cloudflaresandbox ./internal/providers/crownest ./internal/providers/shared`
- `go vet ./...`
- `go build -trimpath -o /tmp/crabbox-loopback-rebased2-20260912 ./cmd/crabbox`

No changelog entry was added because this is an internal behavior-preserving refactor.
