### PR TITLE
test: share provider request envelope assertions

### DIFF
--- a/internal/providers/azuredynamicsessions/client_test.go
+++ b/internal/providers/azuredynamicsessions/client_test.go
@@ -22,6 +22,7 @@ import (
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestAzureDynamicSessionsFlagRouteAndDeferredPoolContract(t *testing.T) {
@@ -762,51 +763,6 @@ func TestAzureDynamicSessionsStreamCancellationAtCleanEOF(t *testing.T) {
 	}
 }
 
-type adoptionRoundTripper func(*http.Request) (*http.Response, error)
-
-func (f adoptionRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
-
-func assertAdoptionRequest(t *testing.T, req *http.Request, ctx context.Context, endpoint, body string, headers http.Header) {
-	t.Helper()
-	if req.Context() != ctx || req.Method != http.MethodPost || req.URL.String() != endpoint {
-		t.Fatalf("request context/method/URL mismatch: %s %s", req.Method, req.URL)
-	}
-	if !reflect.DeepEqual(req.Header, headers) {
-		t.Fatalf("headers=%v want %v", req.Header, headers)
-	}
-	if req.ContentLength != int64(len(body)) || (req.Body == nil) != (body == "") {
-		t.Fatalf("body metadata length=%d nil=%v want length=%d", req.ContentLength, req.Body == nil, len(body))
-	}
-	if body == "" {
-		if req.GetBody != nil {
-			t.Fatal("nil body gained replay")
-		}
-		return
-	}
-	data, err := io.ReadAll(req.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != body {
-		t.Fatalf("body=%q want %q", data, body)
-	}
-	if req.GetBody == nil {
-		t.Fatal("encoded body lost replay")
-	}
-	replay, err := req.GetBody()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer replay.Close()
-	data, err = io.ReadAll(replay)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != body {
-		t.Fatalf("replay=%q want %q", data, body)
-	}
-}
-
 func TestJSONRequestAdoptionEnvelope(t *testing.T) {
 	type key struct{}
 	ctx := context.WithValue(context.Background(), key{}, "capture")
@@ -838,9 +794,9 @@ func TestJSONRequestAdoptionEnvelope(t *testing.T) {
 			if tc.body != nil {
 				headers.Set("Content-Type", "application/json")
 			}
-			transport := &http.Client{Transport: adoptionRoundTripper(func(req *http.Request) (*http.Response, error) {
+			transport := &http.Client{Transport: testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
 				calls++
-				assertAdoptionRequest(t, req, ctx, base+endpoint, tc.want, headers)
+				testutil.RequireRequestEnvelope(t, req, ctx, http.MethodPost, base+endpoint, tc.want, headers)
 				if tc.fail {
 					return nil, sentinel
 				}
@@ -871,9 +827,9 @@ func TestJSONRequestAdoptionConcreteEnvelope(t *testing.T) {
 	headers := http.Header{"Authorization": []string{"Bearer synthetic-token"}, "Content-Type": []string{"application/json"}}
 	headers.Set("Accept", "application/json")
 	headers.Set("User-Agent", "crabbox/azure-dynamic-sessions")
-	transport := &http.Client{Transport: adoptionRoundTripper(func(req *http.Request) (*http.Response, error) {
+	transport := &http.Client{Transport: testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		calls++
-		assertAdoptionRequest(t, req, ctx, "https://api.example.test/base/v1/exec?identifier=session+one", "{\"command\":\"\\u003c\\u0026\\u003e\",\"cwd\":\"/work\",\"env\":{\"A\":\"B\"},\"timeoutMs\":7}\n", headers)
+		testutil.RequireRequestEnvelope(t, req, ctx, http.MethodPost, "https://api.example.test/base/v1/exec?identifier=session+one", "{\"command\":\"\\u003c\\u0026\\u003e\",\"cwd\":\"/work\",\"env\":{\"A\":\"B\"},\"timeoutMs\":7}\n", headers)
 		return nil, sentinel
 	})}
 	c := &azureDynamicSessionsClient{endpoint: "https://api.example.test/base", token: "synthetic-token", httpClient: transport}
@@ -931,7 +887,7 @@ func TestRawJSONResponseContract(t *testing.T) {
 				status = 200
 			}
 			const base = "https://api.example.test"
-			httpClient := &http.Client{Transport: adoptionRoundTripper(func(req *http.Request) (*http.Response, error) {
+			httpClient := &http.Client{Transport: testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
 				calls++
 				return &http.Response{StatusCode: status, Status: strconv.Itoa(status) + " Synthetic", Header: responseHeaders, Body: body, Request: req}, nil
 			})}

--- a/internal/providers/cloudflare/backend_test.go
+++ b/internal/providers/cloudflare/backend_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestCloudflareProviderSpec(t *testing.T) {
@@ -2141,51 +2142,6 @@ func TestCloudflareStreamCancellationAtCleanEOF(t *testing.T) {
 	}
 }
 
-type adoptionRoundTripper func(*http.Request) (*http.Response, error)
-
-func (f adoptionRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
-
-func assertAdoptionRequest(t *testing.T, req *http.Request, ctx context.Context, endpoint, body string, headers http.Header) {
-	t.Helper()
-	if req.Context() != ctx || req.Method != http.MethodPost || req.URL.String() != endpoint {
-		t.Fatalf("request context/method/URL mismatch: %s %s", req.Method, req.URL)
-	}
-	if !reflect.DeepEqual(req.Header, headers) {
-		t.Fatalf("headers=%v want %v", req.Header, headers)
-	}
-	if req.ContentLength != int64(len(body)) || (req.Body == nil) != (body == "") {
-		t.Fatalf("body metadata length=%d nil=%v want length=%d", req.ContentLength, req.Body == nil, len(body))
-	}
-	if body == "" {
-		if req.GetBody != nil {
-			t.Fatal("nil body gained replay")
-		}
-		return
-	}
-	data, err := io.ReadAll(req.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != body {
-		t.Fatalf("body=%q want %q", data, body)
-	}
-	if req.GetBody == nil {
-		t.Fatal("encoded body lost replay")
-	}
-	replay, err := req.GetBody()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer replay.Close()
-	data, err = io.ReadAll(replay)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != body {
-		t.Fatalf("replay=%q want %q", data, body)
-	}
-}
-
 func TestJSONRequestAdoptionEnvelope(t *testing.T) {
 	type key struct{}
 	ctx := context.WithValue(context.Background(), key{}, "capture")
@@ -2216,9 +2172,9 @@ func TestJSONRequestAdoptionEnvelope(t *testing.T) {
 			if tc.body != nil {
 				headers.Set("Content-Type", "application/json")
 			}
-			transport := &http.Client{Transport: adoptionRoundTripper(func(req *http.Request) (*http.Response, error) {
+			transport := &http.Client{Transport: testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
 				calls++
-				assertAdoptionRequest(t, req, ctx, base+endpoint, tc.want, headers)
+				testutil.RequireRequestEnvelope(t, req, ctx, http.MethodPost, base+endpoint, tc.want, headers)
 				if tc.fail {
 					return nil, sentinel
 				}
@@ -2247,9 +2203,9 @@ func TestJSONRequestAdoptionConcreteEnvelope(t *testing.T) {
 	sentinel := errors.New("synthetic captured concrete request")
 	calls := 0
 	headers := http.Header{"Authorization": []string{"Bearer synthetic-token"}, "Content-Type": []string{"application/json"}}
-	transport := &http.Client{Transport: adoptionRoundTripper(func(req *http.Request) (*http.Response, error) {
+	transport := &http.Client{Transport: testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		calls++
-		assertAdoptionRequest(t, req, ctx, "https://api.example.test/base/v1/sandboxes/sandbox%20one/exec-stream?instanceType=large+size", "{\"command\":\"\\u003c\\u0026\\u003e\",\"cwd\":\"/work\",\"env\":{\"A\":\"B\"},\"timeoutMs\":7}\n", headers)
+		testutil.RequireRequestEnvelope(t, req, ctx, http.MethodPost, "https://api.example.test/base/v1/sandboxes/sandbox%20one/exec-stream?instanceType=large+size", "{\"command\":\"\\u003c\\u0026\\u003e\",\"cwd\":\"/work\",\"env\":{\"A\":\"B\"},\"timeoutMs\":7}\n", headers)
 		return nil, sentinel
 	})}
 	c := &cloudflareClient{baseURL: "https://api.example.test/base", token: "synthetic-token", instanceType: "large size", http: transport}

--- a/internal/providers/cloudflaredynamicworkers/backend_test.go
+++ b/internal/providers/cloudflaredynamicworkers/backend_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestManualConfigInputFlags(t *testing.T) {
@@ -2294,51 +2295,6 @@ func newTestFlagSet() *flag.FlagSet {
 	return flag.NewFlagSet("test", flag.ContinueOnError)
 }
 
-type adoptionRoundTripper func(*http.Request) (*http.Response, error)
-
-func (f adoptionRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
-
-func assertAdoptionRequest(t *testing.T, req *http.Request, ctx context.Context, endpoint, body string, headers http.Header) {
-	t.Helper()
-	if req.Context() != ctx || req.Method != http.MethodPost || req.URL.String() != endpoint {
-		t.Fatalf("request context/method/URL mismatch: %s %s", req.Method, req.URL)
-	}
-	if !reflect.DeepEqual(req.Header, headers) {
-		t.Fatalf("headers=%v want %v", req.Header, headers)
-	}
-	if req.ContentLength != int64(len(body)) || (req.Body == nil) != (body == "") {
-		t.Fatalf("body metadata length=%d nil=%v want length=%d", req.ContentLength, req.Body == nil, len(body))
-	}
-	if body == "" {
-		if req.GetBody != nil {
-			t.Fatal("nil body gained replay")
-		}
-		return
-	}
-	data, err := io.ReadAll(req.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != body {
-		t.Fatalf("body=%q want %q", data, body)
-	}
-	if req.GetBody == nil {
-		t.Fatal("encoded body lost replay")
-	}
-	replay, err := req.GetBody()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer replay.Close()
-	data, err = io.ReadAll(replay)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != body {
-		t.Fatalf("replay=%q want %q", data, body)
-	}
-}
-
 func TestJSONRequestAdoptionEnvelope(t *testing.T) {
 	type key struct{}
 	ctx := context.WithValue(context.Background(), key{}, "capture")
@@ -2369,9 +2325,9 @@ func TestJSONRequestAdoptionEnvelope(t *testing.T) {
 			if tc.body != nil {
 				headers.Set("Content-Type", "application/json")
 			}
-			transport := &http.Client{Transport: adoptionRoundTripper(func(req *http.Request) (*http.Response, error) {
+			transport := &http.Client{Transport: testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
 				calls++
-				assertAdoptionRequest(t, req, ctx, base+endpoint, tc.want, headers)
+				testutil.RequireRequestEnvelope(t, req, ctx, http.MethodPost, base+endpoint, tc.want, headers)
 				if tc.fail {
 					return nil, sentinel
 				}
@@ -2400,9 +2356,9 @@ func TestJSONRequestAdoptionConcreteEnvelope(t *testing.T) {
 	sentinel := errors.New("synthetic captured concrete request")
 	calls := 0
 	headers := http.Header{"Authorization": []string{"Bearer synthetic-token"}, "Content-Type": []string{"application/json"}}
-	transport := &http.Client{Transport: adoptionRoundTripper(func(req *http.Request) (*http.Response, error) {
+	transport := &http.Client{Transport: testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		calls++
-		assertAdoptionRequest(t, req, ctx, "https://api.example.test/base/v1/runs", "{\"cacheMode\":\"none\",\"retainMetadata\":true,\"module\":{\"source\":\"\\u003c\\u0026\\u003e\"},\"egress\":\"none\",\"limits\":{},\"timeoutMs\":7}\n", headers)
+		testutil.RequireRequestEnvelope(t, req, ctx, http.MethodPost, "https://api.example.test/base/v1/runs", "{\"cacheMode\":\"none\",\"retainMetadata\":true,\"module\":{\"source\":\"\\u003c\\u0026\\u003e\"},\"egress\":\"none\",\"limits\":{},\"timeoutMs\":7}\n", headers)
 		return nil, sentinel
 	})}
 	c := &client{baseURL: "https://api.example.test/base", token: "synthetic-token", http: transport}

--- a/internal/providers/cubesandbox/backend_test.go
+++ b/internal/providers/cubesandbox/backend_test.go
@@ -1812,47 +1812,6 @@ func TestCubeSandboxProcessEndDiagnosticPrecedence(t *testing.T) {
 	}
 }
 
-func assertAdoptionRequest(t *testing.T, req *http.Request, ctx context.Context, endpoint, body string, headers http.Header) {
-	t.Helper()
-	if req.Context() != ctx || req.Method != http.MethodPost || req.URL.String() != endpoint {
-		t.Fatalf("request context/method/URL mismatch: %s %s", req.Method, req.URL)
-	}
-	if !reflect.DeepEqual(req.Header, headers) {
-		t.Fatalf("headers=%v want %v", req.Header, headers)
-	}
-	if req.ContentLength != int64(len(body)) || (req.Body == nil) != (body == "") {
-		t.Fatalf("body metadata length=%d nil=%v want length=%d", req.ContentLength, req.Body == nil, len(body))
-	}
-	if body == "" {
-		if req.GetBody != nil {
-			t.Fatal("nil body gained replay")
-		}
-		return
-	}
-	data, err := io.ReadAll(req.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != body {
-		t.Fatalf("body=%q want %q", data, body)
-	}
-	if req.GetBody == nil {
-		t.Fatal("encoded body lost replay")
-	}
-	replay, err := req.GetBody()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer replay.Close()
-	data, err = io.ReadAll(replay)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != body {
-		t.Fatalf("replay=%q want %q", data, body)
-	}
-}
-
 func TestJSONRequestAdoptionEnvelope(t *testing.T) {
 	type key struct{}
 	ctx := context.WithValue(context.Background(), key{}, "capture")
@@ -1886,9 +1845,9 @@ func TestJSONRequestAdoptionEnvelope(t *testing.T) {
 			if tc.body != nil {
 				headers.Set("Content-Type", "application/json")
 			}
-			transport := &http.Client{Transport: cubesandboxRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			transport := &http.Client{Transport: testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
 				calls++
-				assertAdoptionRequest(t, req, ctx, base+endpoint, tc.want, headers)
+				testutil.RequireRequestEnvelope(t, req, ctx, http.MethodPost, base+endpoint, tc.want, headers)
 				if tc.fail {
 					return nil, sentinel
 				}

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -1961,47 +1961,6 @@ func TestE2BProcessEndDoesNotUseStatusAsDiagnostic(t *testing.T) {
 	}
 }
 
-func assertAdoptionRequest(t *testing.T, req *http.Request, ctx context.Context, endpoint, body string, headers http.Header) {
-	t.Helper()
-	if req.Context() != ctx || req.Method != http.MethodPost || req.URL.String() != endpoint {
-		t.Fatalf("request context/method/URL mismatch: %s %s", req.Method, req.URL)
-	}
-	if !reflect.DeepEqual(req.Header, headers) {
-		t.Fatalf("headers=%v want %v", req.Header, headers)
-	}
-	if req.ContentLength != int64(len(body)) || (req.Body == nil) != (body == "") {
-		t.Fatalf("body metadata length=%d nil=%v want length=%d", req.ContentLength, req.Body == nil, len(body))
-	}
-	if body == "" {
-		if req.GetBody != nil {
-			t.Fatal("nil body gained replay")
-		}
-		return
-	}
-	data, err := io.ReadAll(req.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != body {
-		t.Fatalf("body=%q want %q", data, body)
-	}
-	if req.GetBody == nil {
-		t.Fatal("encoded body lost replay")
-	}
-	replay, err := req.GetBody()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer replay.Close()
-	data, err = io.ReadAll(replay)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != body {
-		t.Fatalf("replay=%q want %q", data, body)
-	}
-}
-
 func TestJSONRequestAdoptionEnvelope(t *testing.T) {
 	type key struct{}
 	ctx := context.WithValue(context.Background(), key{}, "capture")
@@ -2035,9 +1994,9 @@ func TestJSONRequestAdoptionEnvelope(t *testing.T) {
 			if tc.body != nil {
 				headers.Set("Content-Type", "application/json")
 			}
-			transport := &http.Client{Transport: e2bRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			transport := &http.Client{Transport: testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
 				calls++
-				assertAdoptionRequest(t, req, ctx, base+endpoint, tc.want, headers)
+				testutil.RequireRequestEnvelope(t, req, ctx, http.MethodPost, base+endpoint, tc.want, headers)
 				if tc.fail {
 					return nil, sentinel
 				}

--- a/internal/providers/lambda/client_test.go
+++ b/internal/providers/lambda/client_test.go
@@ -7,11 +7,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"strings"
 	"testing"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestClientUsesBearerAndDataEnvelope(t *testing.T) {
@@ -128,51 +128,6 @@ func TestLaunchRequestShape(t *testing.T) {
 	}
 }
 
-type adoptionRoundTripper func(*http.Request) (*http.Response, error)
-
-func (f adoptionRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
-
-func assertAdoptionRequest(t *testing.T, req *http.Request, ctx context.Context, endpoint, body string, headers http.Header) {
-	t.Helper()
-	if req.Context() != ctx || req.Method != http.MethodPost || req.URL.String() != endpoint {
-		t.Fatalf("request context/method/URL mismatch: %s %s", req.Method, req.URL)
-	}
-	if !reflect.DeepEqual(req.Header, headers) {
-		t.Fatalf("headers=%v want %v", req.Header, headers)
-	}
-	if req.ContentLength != int64(len(body)) || (req.Body == nil) != (body == "") {
-		t.Fatalf("body metadata length=%d nil=%v want length=%d", req.ContentLength, req.Body == nil, len(body))
-	}
-	if body == "" {
-		if req.GetBody != nil {
-			t.Fatal("nil body gained replay")
-		}
-		return
-	}
-	data, err := io.ReadAll(req.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != body {
-		t.Fatalf("body=%q want %q", data, body)
-	}
-	if req.GetBody == nil {
-		t.Fatal("encoded body lost replay")
-	}
-	replay, err := req.GetBody()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer replay.Close()
-	data, err = io.ReadAll(replay)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != body {
-		t.Fatalf("replay=%q want %q", data, body)
-	}
-}
-
 func TestJSONRequestAdoptionEnvelope(t *testing.T) {
 	type key struct{}
 	ctx := context.WithValue(context.Background(), key{}, "capture")
@@ -203,9 +158,9 @@ func TestJSONRequestAdoptionEnvelope(t *testing.T) {
 			if tc.body != nil {
 				headers.Set("Content-Type", "application/json")
 			}
-			transport := &http.Client{Transport: adoptionRoundTripper(func(req *http.Request) (*http.Response, error) {
+			transport := &http.Client{Transport: testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
 				calls++
-				assertAdoptionRequest(t, req, ctx, base+endpoint, tc.want, headers)
+				testutil.RequireRequestEnvelope(t, req, ctx, http.MethodPost, base+endpoint, tc.want, headers)
 				if tc.fail {
 					return nil, sentinel
 				}

--- a/internal/providers/sprites/backend_test.go
+++ b/internal/providers/sprites/backend_test.go
@@ -9,12 +9,12 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestSpritesSSHTargetUsesSpriteProxy(t *testing.T) {
@@ -783,47 +783,6 @@ func (f *fakeSpritesAPI) DeleteSprite(_ context.Context, name string) error {
 	return nil
 }
 
-func assertAdoptionRequest(t *testing.T, req *http.Request, ctx context.Context, endpoint, body string, headers http.Header) {
-	t.Helper()
-	if req.Context() != ctx || req.Method != http.MethodPost || req.URL.String() != endpoint {
-		t.Fatalf("request context/method/URL mismatch: %s %s", req.Method, req.URL)
-	}
-	if !reflect.DeepEqual(req.Header, headers) {
-		t.Fatalf("headers=%v want %v", req.Header, headers)
-	}
-	if req.ContentLength != int64(len(body)) || (req.Body == nil) != (body == "") {
-		t.Fatalf("body metadata length=%d nil=%v want length=%d", req.ContentLength, req.Body == nil, len(body))
-	}
-	if body == "" {
-		if req.GetBody != nil {
-			t.Fatal("nil body gained replay")
-		}
-		return
-	}
-	data, err := io.ReadAll(req.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != body {
-		t.Fatalf("body=%q want %q", data, body)
-	}
-	if req.GetBody == nil {
-		t.Fatal("encoded body lost replay")
-	}
-	replay, err := req.GetBody()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer replay.Close()
-	data, err = io.ReadAll(replay)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != body {
-		t.Fatalf("replay=%q want %q", data, body)
-	}
-}
-
 func TestJSONRequestAdoptionEnvelope(t *testing.T) {
 	type key struct{}
 	ctx := context.WithValue(context.Background(), key{}, "capture")
@@ -857,9 +816,9 @@ func TestJSONRequestAdoptionEnvelope(t *testing.T) {
 			if tc.body != nil {
 				headers.Set("Content-Type", "application/json")
 			}
-			transport := &http.Client{Transport: spritesRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			transport := &http.Client{Transport: testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
 				calls++
-				assertAdoptionRequest(t, req, ctx, base+endpoint, tc.want, headers)
+				testutil.RequireRequestEnvelope(t, req, ctx, http.MethodPost, base+endpoint, tc.want, headers)
 				if tc.fail {
 					return nil, sentinel
 				}


### PR DESCRIPTION
## Summary

Reuse the existing exact request-envelope assertion and RoundTripper utility in seven provider test suites, deleting 300 net lines. Every request fixture, expected byte string, header comparison, context check, body-length/replay assertion and test case is preserved; POST is passed explicitly to the shared assertion.

Four duplicate transport types are removed. Azure's newly integrated response test also uses the shared adapter, while older E2B, CubeSandbox and Sprites adapters used elsewhere remain intact. Only test-failure diagnostic wording changes to the existing shared helper's wording. Production code and the shared utilities are unchanged; no new fixtures, tests, configuration or release-note entry are introduced.

## Verification

The frozen baseline and candidate passed the identical race-enabled selection: 13 tests and 74 subtests across all seven packages, including the integrated response tests. A final candidate run with a synthetic home directory and network denied passed the same selection without failures or skips.

Whole-file comparison verifies only the permitted helper, import and call-site substitutions. All fixture literals and assertion predicates remain unchanged. The independent mandatory Codex review found no P0 findings in the final scope.
