### PR TITLE
refactor: give Static SSH ownership of config display

### DIFF
--- a/docs/refactor/provider-config-display.md
+++ b/docs/refactor/provider-config-display.md
@@ -82,6 +82,12 @@ and host order stay unchanged. Text retains collection counts and its existing
 raw strings and empty-only fallbacks. Projection does not select templates,
 resolve hosts or read key files, and runtime-only selected-host state stays omitted.
 
+Static SSH owns its six existing string fields through the canonical `ssh`
+provider. Its published JSON key and text label remain `static`, including when
+selected through the `static` or `static-ssh` aliases. Port remains a string,
+text keeps empty-only dashes, and the section retains its original slot without
+resolving an SSH target or changing the separate generic SSH display.
+
 ## Remaining migration
 
 The baseline census contains 81 canonical providers: 49 have both value formats,
@@ -94,9 +100,9 @@ sections**. They do not complete the migration. Existing provider projections
 also still need to move out of the parallel JSON map and text formatter so
 their field selection and transformations have one owner.
 
-The Multipass/Tart/Lume, local-container, cloud, VPS, runtime and Parallels cohorts remove eighteen
+The Multipass/Tart/Lume, local-container, cloud, VPS, runtime, Parallels and Static SSH cohorts remove nineteen
 of the original 49 canonical both-format providers from that legacy
-implementation, leaving 31 in that cohort. The local cohort covers five
+implementation, leaving 30 in that cohort. The local cohort covers five
 identities through four sections because Apple Machine shares Apple Container's
 values. These migrations do not fill any of the missing sections above.
 

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -541,14 +541,6 @@ func configShowView(cfg Config) map[string]any {
 			"createTimeout": cfg.Machine0.CreateTimeout.String(),
 			"pollInterval":  cfg.Machine0.PollInterval.String(),
 		},
-		"static": map[string]any{
-			"id":       cfg.Static.ID,
-			"name":     cfg.Static.Name,
-			"host":     cfg.Static.Host,
-			"user":     cfg.Static.User,
-			"port":     cfg.Static.Port,
-			"workRoot": cfg.Static.WorkRoot,
-		},
 		"results": map[string]any{
 			"junit":          cfg.Results.JUnit,
 			"auto":           cfg.Results.Auto,
@@ -704,7 +696,9 @@ func writeConfigShowText(w io.Writer, cfg Config) error {
 	fmt.Fprintf(w, "fastapi_cloud api_url=%s app_id=%s team_id=%s auth=%s\n", blank(redactedConfigURL(cfg.FastAPICloud.APIURL), "-"), blank(cfg.FastAPICloud.AppID, "-"), blank(cfg.FastAPICloud.TeamID, "-"), tokenState(cfg.FastAPICloud.Token))
 	fmt.Fprintf(w, "cloudflare_dynamic_workers loader_url=%s compatibility_date=%s compatibility_flags=%s cache_mode=%s egress=%s cpu_ms=%d subrequests=%d timeout_secs=%d metadata=%d auth=%s\n", blank(redactedConfigURL(cfg.CloudflareDynamicWorkers.LoaderURL), "-"), blank(cfg.CloudflareDynamicWorkers.CompatibilityDate, "-"), blank(strings.Join(cfg.CloudflareDynamicWorkers.CompatibilityFlags, ","), "-"), cfg.CloudflareDynamicWorkers.CacheMode, cfg.CloudflareDynamicWorkers.Egress, cfg.CloudflareDynamicWorkers.CPUMs, cfg.CloudflareDynamicWorkers.Subrequests, cfg.CloudflareDynamicWorkers.TimeoutSecs, len(cfg.CloudflareDynamicWorkers.Metadata), tokenState(cfg.CloudflareDynamicWorkers.Token))
 	fmt.Fprintf(w, "cloudflare_sandbox url=%s workdir=%s exec_timeout_secs=%d forget_missing=%t auth=%s\n", blank(redactedConfigURL(cfg.CloudflareSandbox.BridgeURL), "-"), cfg.CloudflareSandbox.Workdir, cfg.CloudflareSandbox.ExecTimeoutSecs, cfg.CloudflareSandbox.ForgetMissing, tokenState(cfg.CloudflareSandbox.Token))
-	fmt.Fprintf(w, "static id=%s name=%s host=%s user=%s port=%s work_root=%s\n", blank(cfg.Static.ID, "-"), blank(cfg.Static.Name, "-"), blank(cfg.Static.Host, "-"), blank(cfg.Static.User, "-"), blank(cfg.Static.Port, "-"), blank(cfg.Static.WorkRoot, "-"))
+	if err := layout.writeSlot(w, "static"); err != nil {
+		return err
+	}
 	fmt.Fprintf(w, "results junit=%s auto=%t fail_on_failures=%t\n", blank(strings.Join(cfg.Results.JUnit, ","), "-"), cfg.Results.Auto, cfg.Results.FailOnFailures)
 	fmt.Fprintf(w, "cache pnpm=%t npm=%t docker=%t git=%t max_gb=%d purge_on_release=%t volumes=%d\n", cfg.Cache.Pnpm, cfg.Cache.Npm, cfg.Cache.Docker, cfg.Cache.Git, cfg.Cache.MaxGB, cfg.Cache.PurgeOnRelease, len(cfg.Cache.Volumes))
 	if len(cfg.Jobs) > 0 {

--- a/internal/cli/config_show_projection.go
+++ b/internal/cli/config_show_projection.go
@@ -36,7 +36,7 @@ func ConfigShowSecretState(value string) string { return tokenState(value) }
 
 // Names only: no legacy value projection or environment reads are needed to
 // protect existing text slots. Retire a name only when its legacy row migrates.
-const legacyConfigShowTextLabels = "config provider lease broker access_auth ssh sync env run capacity actions phala namespace namespace_instance morph e2b cubesandbox upstash_box smolvm blaxel nomad ascii_box superserve machine0 cloudflare fastapi_cloud cloudflare_dynamic_workers cloudflare_sandbox static results cache jobs aws_lambda_microvm github_codespaces lambda vast nvidia_brev nebius hostinger ovh scaleway tencentcloud azure_dynamic_sessions proxmox xcp_ng inspection provider_status"
+const legacyConfigShowTextLabels = "config provider lease broker access_auth ssh sync env run capacity actions phala namespace namespace_instance morph e2b cubesandbox upstash_box smolvm blaxel nomad ascii_box superserve machine0 cloudflare fastapi_cloud cloudflare_dynamic_workers cloudflare_sandbox results cache jobs aws_lambda_microvm github_codespaces lambda vast nvidia_brev nebius hostinger ovh scaleway tencentcloud azure_dynamic_sessions proxmox xcp_ng inspection provider_status"
 
 func collectProviderConfigShowSections(cfg Config) ([]ProviderConfigShowSection, error) {
 	return collectProviderConfigShowSectionsFrom(cfg, registeredProviders())

--- a/internal/cli/config_show_projection_test.go
+++ b/internal/cli/config_show_projection_test.go
@@ -239,13 +239,13 @@ func TestConfigShowLegacySlotPositions(t *testing.T) {
 				name = "jobs"
 			}
 			switch name {
-			case "actions", "phala", "superserve", "local_container", "apple_container", "mxc", "docker_sandbox", "machine0", "cloudflare", "jobs", "aws", "aws_lambda_microvm", "azure", "digitalocean", "vultr", "linode", "github_codespaces", "azure_dynamic_sessions", "gcp", "proxmox", "xcp_ng":
+			case "actions", "phala", "superserve", "local_container", "apple_container", "mxc", "docker_sandbox", "machine0", "cloudflare", "cloudflare_sandbox", "results", "jobs", "aws", "aws_lambda_microvm", "azure", "digitalocean", "vultr", "linode", "github_codespaces", "azure_dynamic_sessions", "gcp", "proxmox", "xcp_ng":
 				order = append(order, name)
 			}
 		}
 		return true
 	})
-	if got := strings.Join(order, ","); got != "actions,blacksmith,agent_sandbox,phala,superserve,local_container,apple_container,mxc,docker_sandbox,multipass,machine0,tart,lume,cloudflare,jobs,aws,aws_lambda_microvm,azure,digitalocean,vultr,linode,github_codespaces,azure_dynamic_sessions,gcp,proxmox,firecracker,xcp_ng,parallels" {
+	if got := strings.Join(order, ","); got != "actions,blacksmith,agent_sandbox,phala,superserve,local_container,apple_container,mxc,docker_sandbox,multipass,machine0,tart,lume,cloudflare,cloudflare_sandbox,static,results,jobs,aws,aws_lambda_microvm,azure,digitalocean,vultr,linode,github_codespaces,azure_dynamic_sessions,gcp,proxmox,firecracker,xcp_ng,parallels" {
 		t.Fatalf("legacy text slot positions: %s", got)
 	}
 }
@@ -360,6 +360,7 @@ func TestConfigShowMigratedLegacyOwnershipRetired(t *testing.T) {
 		{"digitalocean", "digitalocean"}, {"vultr", "vultr"}, {"linode", "linode"},
 		{"blacksmith", "blacksmith"}, {"agentSandbox", "agent_sandbox"}, {"firecracker", "firecracker"},
 		{"parallels", "parallels"},
+		{"static", "static"},
 	} {
 		t.Run(tc.key, func(t *testing.T) {
 			if _, exists := view[tc.key]; exists {

--- a/internal/providers/ssh/config_show.go
+++ b/internal/providers/ssh/config_show.go
@@ -1,0 +1,19 @@
+package ssh
+
+import core "github.com/openclaw/crabbox/internal/cli"
+
+// ConfigShowSection describes loaded values without resolving an SSH target.
+func (Provider) ConfigShowSection(cfg core.Config) core.ProviderConfigShowSection {
+	c := cfg.Static
+	return core.ProviderConfigShowSection{
+		JSONKey: "static", TextLabel: "static", Providers: []string{"ssh"},
+		Fields: []core.ProviderConfigShowField{
+			{JSONName: "id", JSONValue: c.ID, TextName: "id", TextValue: core.Blank(c.ID, "-")},
+			{JSONName: "name", JSONValue: c.Name, TextName: "name", TextValue: core.Blank(c.Name, "-")},
+			{JSONName: "host", JSONValue: c.Host, TextName: "host", TextValue: core.Blank(c.Host, "-")},
+			{JSONName: "user", JSONValue: c.User, TextName: "user", TextValue: core.Blank(c.User, "-")},
+			{JSONName: "port", JSONValue: c.Port, TextName: "port", TextValue: core.Blank(c.Port, "-")},
+			{JSONName: "workRoot", JSONValue: c.WorkRoot, TextName: "work_root", TextValue: core.Blank(c.WorkRoot, "-")},
+		},
+	}
+}

--- a/internal/providers/ssh/config_show_test.go
+++ b/internal/providers/ssh/config_show_test.go
@@ -1,0 +1,85 @@
+package ssh
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestStaticConfigShowRawStrings(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		config core.StaticConfig
+		values [6]string
+		text   string
+	}{
+		{
+			name: "empty",
+			text: "static id=- name=- host=- user=- port=- work_root=-\n",
+		},
+		{
+			name:   "configured and leading-zero port",
+			config: core.StaticConfig{ID: "box-id", Name: "box-name", Host: "offline.example.test", User: "alice", Port: "0022", WorkRoot: " /srv/raw "},
+			values: [6]string{"box-id", "box-name", "offline.example.test", "alice", "0022", " /srv/raw "},
+			text:   "static id=box-id name=box-name host=offline.example.test user=alice port=0022 work_root= /srv/raw \n",
+		},
+		{
+			name:   "whitespace is not empty",
+			config: core.StaticConfig{ID: " \t ", Name: " \t ", Host: " \t ", User: " \t ", Port: " \t ", WorkRoot: " \t "},
+			values: [6]string{" \t ", " \t ", " \t ", " \t ", " \t ", " \t "},
+			text:   "static id= \t  name= \t  host= \t  user= \t  port= \t  work_root= \t \n",
+		},
+		{
+			name:   "no ID-host fallback or numeric port conversion",
+			config: core.StaticConfig{ID: "only-id", Port: "0"},
+			values: [6]string{"only-id", "", "", "", "0", ""},
+			text:   "static id=only-id name=- host=- user=- port=0 work_root=-\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, selection := range []string{"ssh", "static", "static-ssh", "unselected-display"} {
+				cfg := core.Config{Provider: selection, Static: tc.config, SSHUser: "generic-user", SSHPort: "9999", WorkRoot: "/generic"}
+				before := cfg
+				section := (Provider{}).ConfigShowSection(cfg)
+				if section.JSONKey != "static" || section.TextLabel != "static" || !reflect.DeepEqual(section.Providers, []string{"ssh"}) {
+					t.Fatalf("selection=%s section identity=%#v", selection, section)
+				}
+				jsonNames := []string{"id", "name", "host", "user", "port", "workRoot"}
+				textNames := []string{"id", "name", "host", "user", "port", "work_root"}
+				if len(section.Fields) != len(jsonNames) {
+					t.Fatalf("fields=%d want 6", len(section.Fields))
+				}
+				values := make(map[string]any, len(jsonNames))
+				want := make(map[string]string, len(jsonNames))
+				var text strings.Builder
+				text.WriteString(section.TextLabel)
+				for i, field := range section.Fields {
+					if field.JSONName != jsonNames[i] || field.TextName != textNames[i] || field.JSONValue != tc.values[i] {
+						t.Fatalf("field %d=%#v want %s/%s raw string %q", i, field, jsonNames[i], textNames[i], tc.values[i])
+					}
+					values[field.JSONName] = field.JSONValue
+					want[field.JSONName] = tc.values[i]
+					text.WriteString(" " + field.TextName + "=" + field.TextValue)
+				}
+				text.WriteByte('\n')
+				if text.String() != tc.text {
+					t.Fatalf("text=%q want %q", text.String(), tc.text)
+				}
+				encoded, err := json.Marshal(values)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var decoded map[string]string
+				if err := json.Unmarshal(encoded, &decoded); err != nil {
+					t.Fatalf("JSON fields must remain strings: %v", err)
+				}
+				if !reflect.DeepEqual(decoded, want) || !reflect.DeepEqual(cfg, before) {
+					t.Fatal("raw JSON values or source configuration changed")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Move Static SSH's complete six-field configuration display to its existing provider. The published JSON/text section remains `static`, while canonical coverage is `ssh`; the `static` and `static-ssh` aliases do not add duplicate sections.

All six values remain raw JSON strings, including `port`. Text retains empty-only dash placeholders, field order and the original slot between `cloudflare_sandbox` and `results`. Generic SSH display/defaults, ID/host fallback, routing and target resolution are unchanged. No lookup, native call, new field or new presentation API is added.

The core map, positional row and legacy label reservation are removed together. Documentation records the ownership change and 30 remaining original both-format providers in the legacy implementation; missing-format counts are unchanged. No user-visible output or release-note change is intended.

## Verification

Provider race tests cover all six fields across four value cases and four selections, including leading-zero string ports, empty strings, whitespace and unselected visibility. Core race tests passed 12 tests and 56 subtests, including the unchanged generic SSH-default tests. The independent mandatory Codex review found no P0 findings; Go vet and the docs build passed.

Real baseline and candidate CLI binaries passed all 12 JSON/text comparisons with exact full stdout, stderr and exit-status parity. The cases cover `ssh`, `static`, `static-ssh` and unselected/default/empty-input views, with no normalization, recapture or expectation correction. No SSH or target-resolution invocation occurred.

All 2,479 source files used for the candidate build were unchanged during proof and verified against commit `3a955524d7be59f56cf17c2605cc1b87717c15f7`. Tested CLI SHA-256: `02f64a8fc9d1a3a9dba95e00a421946c47e0931d20d1b1510fa3b1f06715440e`. These are credential-free, network-denied display checks, not remote-host lifecycle proof.
