### PR TITLE
chore: authorize v0.57.0 release source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## 0.57.0 - 2026-09-11
 
 ### Highlights

--- a/release/records/v0.57.0.json
+++ b/release/records/v0.57.0.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.57.0",
+  "tagObject": "a57d956766076368baa0e67f1f21f1de4f0517b0",
+  "sourceCommit": "baa6c9a783f55f7af65d7f5d1868ecaf9260f371",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
Bind the protected v0.57.0 release record to signed tag object a57d956766076368baa0e67f1f21f1de4f0517b0 and source baa6c9a783f55f7af65d7f5d1868ecaf9260f371. Restore the empty Unreleased section for subsequent work while preserving the frozen 0.57.0 notes.

The tag verifies against the repository signer policy and GitHub recognizes its signature. Full source CI passed: https://github.com/openclaw/crabbox/actions/runs/34667094884. The exact-source coordinator-backed Linux run, attach/events/logs, and confirmed cleanup also passed.

Validation: exact tag/record identity checks, unchanged extracted release notes, git diff --check, and independent autoreview. Candidate production, signing, native draft verification, and publication follow this source authorization under the explicit release request.
