### PR TITLE
refactor: share Blaxel buffered response handling

### DIFF
--- a/docs/refactor/provider-http-requests.md
+++ b/docs/refactor/provider-http-requests.md
@@ -57,3 +57,13 @@ Stage-specific error labels, fallible checks between encoding and construction,
 signed payloads, distinct empty-reader contracts and streaming readers remain
 separate. The two named constructors describe different wire contracts, not a
 configurable provider-client framework.
+
+## Blaxel buffered responses
+
+Blaxel's JSON and multipart request paths share a private response decoder. It
+reads and closes the response body, preserves read-error precedence over HTTP
+status, and keeps Blaxel's typed API error and redaction policy. Successful
+whitespace-only bodies skip JSON decoding while retaining their original bytes;
+JSON errors remain unwrapped. Request construction, client selection, multipart
+uploads and transport-error handling stay in their existing callers. This is a
+provider-local contract, not an option added to the shared response helpers.

--- a/internal/providers/blaxel/client.go
+++ b/internal/providers/blaxel/client.go
@@ -559,20 +559,7 @@ func (c *restClient) doAt(ctx context.Context, httpClient *http.Client, baseURL,
 	if err != nil {
 		return nil, redactError(err)
 	}
-	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, apiError{StatusCode: resp.StatusCode, Body: redactString(string(data))}
-	}
-	if response != nil && len(bytes.TrimSpace(data)) > 0 {
-		if err := json.Unmarshal(data, response); err != nil {
-			return nil, err
-		}
-	}
-	return data, nil
+	return decodeBlaxelResponse(resp, response)
 }
 
 func (c *restClient) sandboxBaseURL(ctx context.Context, sandbox string) (string, error) {
@@ -645,6 +632,11 @@ func (c *restClient) doMultipartAt(ctx context.Context, baseURL, method, endpoin
 	if err != nil {
 		return nil, redactError(err)
 	}
+	return decodeBlaxelResponse(resp, response)
+}
+
+// decodeBlaxelResponse consumes buffered JSON and multipart responses alike.
+func decodeBlaxelResponse(resp *http.Response, response any) ([]byte, error) {
 	defer resp.Body.Close()
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/providers/blaxel/client_test.go
+++ b/internal/providers/blaxel/client_test.go
@@ -19,7 +19,117 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 
 	"github.com/openclaw/crabbox/internal/providers/shared"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
+
+type blaxelResponseBody struct {
+	*strings.Reader
+	readErr error
+	close   func() error
+}
+
+func (b *blaxelResponseBody) Read(p []byte) (int, error) {
+	n, err := b.Reader.Read(p)
+	if err == io.EOF && b.readErr != nil {
+		return n, b.readErr
+	}
+	return n, err
+}
+
+func (b *blaxelResponseBody) Close() error { return b.close() }
+
+func TestBlaxelBufferedResponseContract(t *testing.T) {
+	t.Setenv("CRABBOX_BLAXEL_API_KEY", "synthetic-first-key")
+	t.Setenv("BL_API_KEY", "synthetic-second-key")
+	readErr := errors.New("synthetic read failure")
+	for _, path := range []string{"json", "multipart"} {
+		t.Run(path, func(t *testing.T) {
+			for _, tc := range []struct {
+				name, body, kind, wantValue, wantErrorBody string
+				status                                     int
+				nilOutput, failRead                        bool
+			}{
+				{name: "empty", status: 200, wantValue: "initial"},
+				{name: "no-content", status: 204, wantValue: "initial"},
+				{name: "whitespace", status: 200, body: " \t\n", wantValue: "initial"},
+				{name: "nil-output-non-json", status: 200, body: "ordinary text", nilOutput: true, wantValue: "initial"},
+				{name: "raw-json", status: 200, body: " {\"value\":\"ok\"}\n", wantValue: "ok"},
+				{name: "null", status: 200, body: "null", wantValue: "initial"},
+				{name: "syntax", status: 200, body: "{", kind: "syntax", wantValue: "initial"},
+				{name: "trailing-data", status: 200, body: "{} {}", kind: "syntax", wantValue: "initial"},
+				{name: "type", status: 200, body: "{\"value\":3}", kind: "type", wantValue: "initial"},
+				{name: "read", status: 200, body: "partial", failRead: true, kind: "read", wantValue: "initial"},
+				{name: "read-before-status", status: 503, body: "partial", failRead: true, nilOutput: true, kind: "read", wantValue: "initial"},
+				{name: "status", status: 503, body: " unavailable \n", kind: "status", wantErrorBody: " unavailable \n", wantValue: "initial"},
+				{name: "status-nil-output", status: 503, body: " unavailable \n", nilOutput: true, kind: "status", wantErrorBody: " unavailable \n", wantValue: "initial"},
+				{name: "status-redaction", status: 503, body: " synthetic-first-key/synthetic-second-key \n", kind: "status", wantErrorBody: " <redacted>/<redacted> \n", wantValue: "initial"},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					out := struct {
+						Value string `json:"value"`
+					}{Value: "initial"}
+					closes, calls := 0, 0
+					body := &blaxelResponseBody{Reader: strings.NewReader(tc.body)}
+					if tc.failRead {
+						body.readErr = readErr
+					}
+					body.close = func() error {
+						closes++
+						if body.Len() != 0 || out.Value != tc.wantValue {
+							t.Errorf("close before consumption/decode: remaining=%d value=%q", body.Len(), out.Value)
+						}
+						return errors.New("ignored synthetic close failure")
+					}
+					httpClient := &http.Client{Transport: testutil.RoundTripFunc(func(*http.Request) (*http.Response, error) {
+						calls++
+						return &http.Response{StatusCode: tc.status, Body: body, Header: make(http.Header)}, nil
+					})}
+					client := &restClient{http: httpClient, dataHTTP: httpClient}
+					var target any = &out
+					if tc.nilOutput {
+						target = nil
+					}
+					var data []byte
+					var err error
+					if path == "json" {
+						data, err = client.doAt(context.Background(), httpClient, "https://example.test", http.MethodGet, "/fixture", nil, nil, target)
+					} else {
+						data, err = client.doMultipartAt(context.Background(), "https://example.test", http.MethodPut, "/fixture", nil, "application/octet-stream", strings.NewReader("fixture"), target)
+					}
+					switch tc.kind {
+					case "":
+						if err != nil || data == nil || string(data) != tc.body {
+							t.Fatalf("data=%q nil=%v error=%v", data, data == nil, err)
+						}
+					case "read":
+						if err != readErr {
+							t.Fatalf("error=%v, want exact read error", err)
+						}
+					case "syntax":
+						if _, ok := err.(*json.SyntaxError); !ok {
+							t.Fatalf("error=%T %v, want unwrapped syntax error", err, err)
+						}
+					case "type":
+						if _, ok := err.(*json.UnmarshalTypeError); !ok {
+							t.Fatalf("error=%T %v, want unwrapped type error", err, err)
+						}
+					case "status":
+						got, ok := err.(apiError)
+						if !ok || got.StatusCode != tc.status || got.Body != tc.wantErrorBody {
+							t.Fatalf("error=%T %#v", err, err)
+						}
+					}
+					if tc.kind != "" && data != nil {
+						t.Fatalf("error returned bytes %q", data)
+					}
+					if calls != 1 || closes != 1 || out.Value != tc.wantValue {
+						t.Fatalf("calls=%d closes=%d value=%q", calls, closes, out.Value)
+					}
+				})
+			}
+		})
+	}
+}
 
 func TestRedactErrorPreservesCauseAndSafeFormatting(t *testing.T) {
 	if err := redactError(nil); err != nil {


### PR DESCRIPTION
## Summary

Blaxel's JSON-request and multipart-request paths now return through one private buffered-response helper instead of maintaining identical response tails. The helper body is the original tail unchanged: read errors precede status, successful raw bytes are preserved, whitespace-only success skips decoding, read/JSON errors remain unwrapped, and body closing stays deferred with its error ignored.

The provider's value-typed API error and redactor invocation remain unchanged. Request construction, URL handling, client selection, multipart production and retries stay with their existing owners. No options-driven shared framework, credential lookup or new public behavior is introduced. The ownership distinction is documented; no release-note entry is needed.

## Verification

The frozen 28-case table passed against both the original client implementation and the candidate. A broader race-enabled gate passed six tests and 30 subtests, including existing client flows, full-document round trips and retry behavior. Go vet and the docs build passed. The independent mandatory Codex review found no P0 findings in the final scope.

A separate real-loopback proof passed 12 requests across both entrypoints with no production replacement. It ran before commit; all 2,477 tested-source fingerprints were then verified against commit `cded826b38a084c50e717c89e0fbff1e954f4afe`. This does not claim a second execution or a cloud/upload lifecycle test.

# Blaxel buffered response: real HTTP trace

Frozen candidate based on `baa6c9a783f55f7af65d7f5d1868ecaf9260f371`; source changes were uncommitted during preparation. One additive overlay exercised production `doAt` and `doMultipartAt` over real HTTP transport to loopback servers. Source bytes and modes remained unchanged, and no production file was replaced.

Targeted `-race` proof passed: 12 requests in 12.42 seconds. Every request was POST to `/base/proof/response?case=<case>` and had authorization present; no authentication value was recorded. `doAt` sent fixed JSON `{"message":"proof"}`. The multipart path sent one fixed text field, `note=proof`, using boundary `proof-boundary`; no upload lifecycle was invoked.

| Entrypoint | Response case | HTTP | Actual value | Returned raw bytes (JSON string notation) | Raw nil? | Actual error type | Provider status |
|---|---|---:|---|---|---|---|---|
| doAt | success-json | 200 | `new` | `"{\"value\":\"new\"}"` | false | (none) | (none) |
| doAt | raw-empty | 200 | `old` | `""` | false | (none) | (none) |
| doAt | whitespace | 200 | `old` | `" \t\n"` | false | (none) | (none) |
| doAt | nil-output-non-json | 200 | `old` | `"ordinary non JSON"` | false | (none) | (none) |
| doAt | ordinary-400 | 400 | `old` | `""` | true | `blaxel.apiError` | 400 |
| doAt | malformed | 200 | `old` | `""` | true | `*json.SyntaxError` | (none) |
| doMultipartAt | success-json | 200 | `new` | `"{\"value\":\"new\"}"` | false | (none) | (none) |
| doMultipartAt | raw-empty | 200 | `old` | `""` | false | (none) | (none) |
| doMultipartAt | whitespace | 200 | `old` | `" \t\n"` | false | (none) | (none) |
| doMultipartAt | nil-output-non-json | 200 | `old` | `"ordinary non JSON"` | false | (none) | (none) |
| doMultipartAt | ordinary-400 | 400 | `old` | `""` | true | `blaxel.apiError` | 400 |
| doMultipartAt | malformed | 200 | `old` | `""` | true | `*json.SyntaxError` | (none) |

The successful raw-empty response returned a non-nil zero-length byte slice. Whitespace was returned unchanged while decoding was skipped. Nil output accepted non-JSON text and returned its exact bytes. Ordinary 400 errors returned the value type `blaxel.apiError`; malformed JSON returned unwrapped `*json.SyntaxError`. Both error paths returned nil raw data.

Limits: ordinary synthetic loopback behavior only. Close/read-error ordering is separately covered by unit tests, not inferred from this trace. No native tools, cloud service, real credentials, oversized fixtures, public writes, or source edits were used. Full request/response observations are in the companion JSONL trace.
