### PR TITLE
refactor(providers): use shared blank fallback helper

### DIFF
--- a/internal/providers/agentsandbox/backend.go
+++ b/internal/providers/agentsandbox/backend.go
@@ -560,13 +560,13 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 					return nil
 				}
 				if req.DryRun {
-					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing claim\n", claim.LeaseID, blank(claim.Slug, "-"))
+					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing claim\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 					return nil
 				}
 				if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 					return err
 				}
-				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing claim\n", claim.LeaseID, blank(claim.Slug, "-"))
+				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing claim\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 				claimRemovedOne = true
 				return nil
 			}
@@ -897,12 +897,12 @@ func (b *backend) claimIdentityForLiveClaim(claim LeaseClaim, live *kubernetesOb
 	}
 	expectedName := claimName(claim.LeaseID, claim.Slug)
 	if got := strings.TrimSpace(claimNameFromLocalClaim(claim)); got != expectedName {
-		return LeaseClaim{}, claimIdentity{}, exit(4, "agent-sandbox recovery lease %s claim name changed from %s to %s", claim.LeaseID, expectedName, blank(got, "<empty>"))
+		return LeaseClaim{}, claimIdentity{}, exit(4, "agent-sandbox recovery lease %s claim name changed from %s to %s", claim.LeaseID, expectedName, core.Blank(got, "<empty>"))
 	}
 	if live == nil || strings.TrimSpace(live.Metadata.Name) != expectedName {
 		got := "<empty>"
 		if live != nil {
-			got = blank(strings.TrimSpace(live.Metadata.Name), "<empty>")
+			got = core.Blank(strings.TrimSpace(live.Metadata.Name), "<empty>")
 		}
 		return LeaseClaim{}, claimIdentity{}, exit(4, "agent-sandbox recovery lease %s expected claim %s, got %s", claim.LeaseID, expectedName, got)
 	}
@@ -989,15 +989,15 @@ func validateClaimIdentity(obj *kubernetesObject, identity claimIdentity) error 
 		return resourceIdentityError{err: exit(4, "agent-sandbox lease %s has no pinned SandboxWarmPool", identity.LeaseID)}
 	}
 	if got := strings.TrimSpace(obj.Metadata.UID); got != identity.UID {
-		return resourceIdentityError{err: exit(4, "agent-sandbox SandboxClaim %s UID changed from %s to %s", obj.Metadata.Name, identity.UID, blank(got, "<empty>"))}
+		return resourceIdentityError{err: exit(4, "agent-sandbox SandboxClaim %s UID changed from %s to %s", obj.Metadata.Name, identity.UID, core.Blank(got, "<empty>"))}
 	}
 	if got := sandboxClaimWarmPool(obj); got != identity.WarmPool {
-		return resourceIdentityError{err: exit(4, "agent-sandbox SandboxClaim %s warm pool changed from %s to %s", obj.Metadata.Name, identity.WarmPool, blank(got, "<empty>"))}
+		return resourceIdentityError{err: exit(4, "agent-sandbox SandboxClaim %s warm pool changed from %s to %s", obj.Metadata.Name, identity.WarmPool, core.Blank(got, "<empty>"))}
 	}
 	if identity.ExpiresAt != "" {
 		shutdownTime, shutdownPolicy := sandboxClaimLifecycle(obj)
 		if shutdownTime != identity.ExpiresAt || shutdownPolicy != "Retain" {
-			return resourceIdentityError{err: exit(4, "agent-sandbox SandboxClaim %s lifecycle changed from shutdownTime=%s shutdownPolicy=Retain to shutdownTime=%s shutdownPolicy=%s", obj.Metadata.Name, identity.ExpiresAt, blank(shutdownTime, "<empty>"), blank(shutdownPolicy, "<empty>"))}
+			return resourceIdentityError{err: exit(4, "agent-sandbox SandboxClaim %s lifecycle changed from shutdownTime=%s shutdownPolicy=Retain to shutdownTime=%s shutdownPolicy=%s", obj.Metadata.Name, identity.ExpiresAt, core.Blank(shutdownTime, "<empty>"), core.Blank(shutdownPolicy, "<empty>"))}
 		}
 	}
 	if err := validateClaimOwnership(obj, identity.LeaseID, identity.ProviderScope); err != nil {
@@ -1017,7 +1017,7 @@ func validateClaimRecoveryNonce(obj *kubernetesObject, expected string) error {
 	if got != expected {
 		name := "<missing>"
 		if obj != nil {
-			name = blank(strings.TrimSpace(obj.Metadata.Name), "<missing>")
+			name = core.Blank(strings.TrimSpace(obj.Metadata.Name), "<missing>")
 		}
 		return resourceIdentityError{err: exit(4, "agent-sandbox SandboxClaim %s recovery nonce changed", name)}
 	}

--- a/internal/providers/agentsandbox/core.go
+++ b/internal/providers/agentsandbox/core.go
@@ -66,10 +66,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseSlug(leaseID string) string {
 	return core.NewLeaseSlug(leaseID)
 }
@@ -101,7 +97,7 @@ func handleDelegatedRunFailure(w io.Writer, cfg Config, req RunRequest, leaseID,
 	if id == "" {
 		id = leaseID
 	}
-	fmt.Fprintf(w, "keep-on-failure: kept lease=%s slug=%s expires=idle/ttl idle_timeout=%s ttl=%s\n", leaseID, blank(slug, "-"), cfg.IdleTimeout, cfg.TTL)
+	fmt.Fprintf(w, "keep-on-failure: kept lease=%s slug=%s expires=idle/ttl idle_timeout=%s ttl=%s\n", leaseID, core.Blank(slug, "-"), cfg.IdleTimeout, cfg.TTL)
 	fmt.Fprintf(w, "rerun: %s --id %s -- <command>\n", agentSandboxRecoveryCommand(cfg, "run"), shellQuote(id))
 	fmt.Fprintf(w, "stop: %s %s\n", agentSandboxRecoveryCommand(cfg, "stop"), shellQuote(id))
 }

--- a/internal/providers/agentsandbox/kubernetes.go
+++ b/internal/providers/agentsandbox/kubernetes.go
@@ -714,7 +714,7 @@ func sandboxReady(sandbox *kubernetesObject) error {
 				"agent-sandbox Sandbox %s expired reason=%s message=%s",
 				sandbox.Metadata.Name,
 				condition.Reason,
-				blank(condition.Message, "none"),
+				core.Blank(condition.Message, "none"),
 			)}
 		}
 	}
@@ -724,8 +724,8 @@ func sandboxReady(sandbox *kubernetesObject) error {
 				4,
 				"agent-sandbox Sandbox %s finished reason=%s message=%s",
 				sandbox.Metadata.Name,
-				blank(condition.Reason, "unknown"),
-				blank(condition.Message, "none"),
+				core.Blank(condition.Reason, "unknown"),
+				core.Blank(condition.Message, "none"),
 			)}
 		}
 	}
@@ -1056,7 +1056,7 @@ func validateSandboxClaimBinding(sandbox *kubernetesObject, claimName string, id
 		return resourceIdentityError{err: exit(4, "agent-sandbox Sandbox identity is missing")}
 	}
 	if got := strings.TrimSpace(sandbox.Metadata.Labels[agentSandboxClaimUIDLabel]); got != identity.UID {
-		return resourceIdentityError{err: exit(4, "agent-sandbox Sandbox %s claim UID label changed from %s to %s", sandbox.Metadata.Name, identity.UID, blank(got, "<empty>"))}
+		return resourceIdentityError{err: exit(4, "agent-sandbox Sandbox %s claim UID label changed from %s to %s", sandbox.Metadata.Name, identity.UID, core.Blank(got, "<empty>"))}
 	}
 	ref, ok := controllerOwnerReference(sandbox.Metadata.OwnerReferences)
 	if !ok ||

--- a/internal/providers/anthropicsandboxruntime/backend.go
+++ b/internal/providers/anthropicsandboxruntime/backend.go
@@ -101,7 +101,7 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	help, helpErr := cli.help(ctx)
 	helpDetails := map[string]string{
 		"cli":      cli.binary(),
-		"settings": blank(strings.TrimSpace(b.cfg.AnthropicSRT.Settings), "srt default"),
+		"settings": core.Blank(strings.TrimSpace(b.cfg.AnthropicSRT.Settings), "srt default"),
 		"debug":    fmt.Sprint(b.cfg.AnthropicSRT.Debug),
 		"mutation": "false",
 	}

--- a/internal/providers/anthropicsandboxruntime/client.go
+++ b/internal/providers/anthropicsandboxruntime/client.go
@@ -24,7 +24,7 @@ func newSRTCLI(cfg Config, rt Runtime) (*srtCLI, error) {
 }
 
 func (c *srtCLI) binary() string {
-	return blank(strings.TrimSpace(c.cfg.AnthropicSRT.CLIPath), core.AnthropicSRTConfigDefaultCLIPath)
+	return core.Blank(strings.TrimSpace(c.cfg.AnthropicSRT.CLIPath), core.AnthropicSRTConfigDefaultCLIPath)
 }
 
 func (c *srtCLI) baseArgs() []string {

--- a/internal/providers/anthropicsandboxruntime/core.go
+++ b/internal/providers/anthropicsandboxruntime/core.go
@@ -59,7 +59,3 @@ func leadingEnvAssignment(command []string) bool {
 func shellScriptFromArgv(command []string) string {
 	return core.ShellScriptFromArgv(command)
 }
-
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}

--- a/internal/providers/applecontainer/backend.go
+++ b/internal/providers/applecontainer/backend.go
@@ -311,7 +311,7 @@ func requireExactAppleContainerClaim(leaseID, containerID string) error {
 }
 
 func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
-	return fmt.Sprintf("released lease=%s container=%s", lease.LeaseID, blank(lease.Server.CloudID, lease.Server.Labels["container_id"]))
+	return fmt.Sprintf("released lease=%s container=%s", lease.LeaseID, core.Blank(lease.Server.CloudID, lease.Server.Labels["container_id"]))
 }
 
 func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
@@ -357,10 +357,10 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 			continue
 		}
 		if req.DryRun {
-			fmt.Fprintf(b.rt.Stdout, "would remove container id=%s name=%s lease=%s reason=%s\n", server.DisplayID(), server.Name, blank(leaseID, "-"), reason)
+			fmt.Fprintf(b.rt.Stdout, "would remove container id=%s name=%s lease=%s reason=%s\n", server.DisplayID(), server.Name, core.Blank(leaseID, "-"), reason)
 			continue
 		}
-		fmt.Fprintf(b.rt.Stdout, "remove container id=%s name=%s lease=%s reason=%s\n", server.DisplayID(), server.Name, blank(leaseID, "-"), reason)
+		fmt.Fprintf(b.rt.Stdout, "remove container id=%s name=%s lease=%s reason=%s\n", server.DisplayID(), server.Name, core.Blank(leaseID, "-"), reason)
 		if err := b.removeContainer(ctx, c.id()); err != nil {
 			return err
 		}
@@ -771,9 +771,9 @@ func (b *backend) exitedDuringBootstrapError(ctx context.Context, id, status str
 		hint = "; DNS failed during package bootstrap, retry with --apple-container-extra-run-args '--dns <resolver>' or configure appleContainer.extraRunArgs"
 	}
 	if strings.TrimSpace(logs) == "" {
-		return exit(5, "apple-container %s stopped during SSH bootstrap status=%s%s", id, blank(status, "unknown"), hint)
+		return exit(5, "apple-container %s stopped during SSH bootstrap status=%s%s", id, core.Blank(status, "unknown"), hint)
 	}
-	return exit(5, "apple-container %s stopped during SSH bootstrap status=%s%s\ncontainer logs:\n%s", id, blank(status, "unknown"), hint, logs)
+	return exit(5, "apple-container %s stopped during SSH bootstrap status=%s%s\ncontainer logs:\n%s", id, core.Blank(status, "unknown"), hint, logs)
 }
 
 func (b *backend) containerLogTail(ctx context.Context, id string, limit int) string {
@@ -892,7 +892,7 @@ func shouldCleanup(server core.Server, claim core.LeaseClaim, hasClaim bool, now
 		return false, "claim mismatch"
 	}
 	if !strings.EqualFold(server.Status, "running") && server.Status != "ready" {
-		return true, "container state=" + blank(server.Status, "unknown")
+		return true, "container state=" + core.Blank(server.Status, "unknown")
 	}
 	lastUsed, err := time.Parse(time.RFC3339, claim.LastUsedAt)
 	if err != nil || lastUsed.IsZero() {

--- a/internal/providers/applecontainer/core.go
+++ b/internal/providers/applecontainer/core.go
@@ -31,7 +31,3 @@ const (
 func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
-
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}

--- a/internal/providers/applemachine/backend.go
+++ b/internal/providers/applemachine/backend.go
@@ -34,7 +34,7 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	if err := requireHost(); err != nil {
 		return DoctorResult{}, err
 	}
-	result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{Name: blank(b.cfg.AppleContainer.CLIPath, "container"), Args: []string{"--version"}})
+	result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{Name: core.Blank(b.cfg.AppleContainer.CLIPath, "container"), Args: []string{"--version"}})
 	if err != nil {
 		return DoctorResult{}, exit(3, "Apple container CLI unavailable: %s", failureDetail(result, err))
 	}
@@ -418,7 +418,7 @@ func machineName(leaseID string) string {
 func machineServer(item machine, leaseID, slug string, cfg Config) Server {
 	labels := map[string]string{"crabbox": "true", "provider": providerName, "lease": leaseID, "slug": slug, "target": targetLinux}
 	server := Server{Provider: providerName, CloudID: item.ID, Name: item.ID, Status: item.Status, Labels: labels}
-	server.ServerType.Name = blank(cfg.AppleContainer.Image, "ubuntu:26.04")
+	server.ServerType.Name = core.Blank(cfg.AppleContainer.Image, "ubuntu:26.04")
 	return server
 }
 

--- a/internal/providers/applemachine/client.go
+++ b/internal/providers/applemachine/client.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -20,7 +21,7 @@ type machine struct {
 
 func (b *backend) command(ctx context.Context, args []string, dir string) (LocalCommandResult, error) {
 	return b.rt.Exec.Run(ctx, LocalCommandRequest{
-		Name:   blank(strings.TrimSpace(b.cfg.AppleContainer.CLIPath), "container"),
+		Name:   core.Blank(strings.TrimSpace(b.cfg.AppleContainer.CLIPath), "container"),
 		Args:   args,
 		Dir:    dir,
 		Stdout: b.rt.Stdout,
@@ -36,7 +37,7 @@ func (b *backend) createMachine(ctx context.Context, name string) error {
 	if memory := strings.TrimSpace(b.cfg.AppleContainer.Memory); memory != "" {
 		args = append(args, "--memory", memory)
 	}
-	args = append(args, blank(strings.TrimSpace(b.cfg.AppleContainer.Image), "ubuntu:26.04"))
+	args = append(args, core.Blank(strings.TrimSpace(b.cfg.AppleContainer.Image), "ubuntu:26.04"))
 	result, err := b.command(ctx, args, "")
 	if err != nil {
 		return shared.ExitErrorWithCause(5, fmt.Sprintf("create Apple container machine: %s", failureDetail(result, err)), err)
@@ -92,7 +93,7 @@ func (b *backend) control(ctx context.Context, args []string) (LocalCommandResul
 	defer cancel()
 	const limit = 1024 * 1024
 	result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{
-		Name: blank(strings.TrimSpace(b.cfg.AppleContainer.CLIPath), "container"), Args: args,
+		Name: core.Blank(strings.TrimSpace(b.cfg.AppleContainer.CLIPath), "container"), Args: args,
 		MaxCapturedOutputBytes: limit, CancelGracePeriod: time.Second,
 	})
 	if ctx.Err() != nil {

--- a/internal/providers/applemachine/core.go
+++ b/internal/providers/applemachine/core.go
@@ -36,8 +36,7 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string { return core.Blank(value, fallback) }
-func newLeaseID() string                  { return core.NewLeaseID() }
+func newLeaseID() string { return core.NewLeaseID() }
 
 func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
 	return core.AllocateClaimLeaseSlug(leaseID, requested)

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -244,7 +244,7 @@ func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) 
 				server = matching[0]
 				if intent.State == fixedAWSIntentAcquired || claim.CloudID != "" {
 					if claim.CloudID == "" || server.CloudID != claim.CloudID {
-						return exit(4, "lease_id_conflict: fixed lease %s resource %s does not match acquired CloudID %s", leaseID, blank(server.CloudID, "<empty>"), blank(claim.CloudID, "<empty>"))
+						return exit(4, "lease_id_conflict: fixed lease %s resource %s does not match acquired CloudID %s", leaseID, core.Blank(server.CloudID, "<empty>"), core.Blank(claim.CloudID, "<empty>"))
 					}
 				}
 				resolvedCfg = awsConfigForServer(cfg, server)
@@ -478,7 +478,7 @@ func (b *awsLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (Leas
 			if !isCrabboxAWSLease(server) {
 				return LeaseTarget{}, exit(4, "lease/server not found: %s (instance exists but is not Crabbox-managed)", req.ID)
 			}
-			leaseID := blank(server.Labels["lease"], req.ID)
+			leaseID := core.Blank(server.Labels["lease"], req.ID)
 			target := sshTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
 			useStoredTestboxKey(&target, leaseID)
 			return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
@@ -876,7 +876,6 @@ func sshTargetForBootstrap(cfg Config, publicIP, leaseID, slug string) SSHTarget
 
 var bootstrapAWSWindowsDesktop = core.BootstrapAWSWindowsDesktop
 
-func blank(value, fallback string) string { return core.Blank(value, fallback) }
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
 	shared.UseStoredTestboxKey(target, leaseID)
 }

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -352,7 +352,7 @@ func TestAWSFixedAcquireReplaysSameLeaseAndRejectsIntentDrift(t *testing.T) {
 		drifted := req
 		drifted.RequestedCheckpointID = checkpointID
 		_, err := second.Acquire(context.Background(), drifted)
-		if err == nil || !strings.Contains(err.Error(), req.RequestedCheckpointID) || !strings.Contains(err.Error(), blank(checkpointID, "<none>")) {
+		if err == nil || !strings.Contains(err.Error(), req.RequestedCheckpointID) || !strings.Contains(err.Error(), core.Blank(checkpointID, "<none>")) {
 			t.Fatalf("checkpoint drift=%q err=%v", checkpointID, err)
 		}
 		if fake.createCalls != 1 {

--- a/internal/providers/aws/stop_replay_test.go
+++ b/internal/providers/aws/stop_replay_test.go
@@ -265,10 +265,10 @@ func TestAWSFixedStopReplayAfterInventoryDisappears(t *testing.T) {
 			}
 			if tc.expectedLease != "" || tc.expectedAttempt != "" || tc.expectedSlug != "" || tc.expectedCloud != "" || tc.expectedExact {
 				args = append(args,
-					"--expected-provider-lease-id", blank(tc.expectedLease, lease.LeaseID),
-					"--expected-provider-attempt-lease-id", blank(tc.expectedAttempt, lease.LeaseID),
-					"--expected-provider-slug", blank(tc.expectedSlug, req.RequestedSlug),
-					"--expected-provider-resource-id", blank(tc.expectedCloud, lease.Server.CloudID),
+					"--expected-provider-lease-id", core.Blank(tc.expectedLease, lease.LeaseID),
+					"--expected-provider-attempt-lease-id", core.Blank(tc.expectedAttempt, lease.LeaseID),
+					"--expected-provider-slug", core.Blank(tc.expectedSlug, req.RequestedSlug),
+					"--expected-provider-resource-id", core.Blank(tc.expectedCloud, lease.Server.CloudID),
 				)
 			}
 			var output bytes.Buffer

--- a/internal/providers/azuredynamicsessions/backend.go
+++ b/internal/providers/azuredynamicsessions/backend.go
@@ -395,7 +395,7 @@ func (b *azureDynamicSessionsBackend) sessionToServer(session azureDynamicSessio
 		"lease":    identifier,
 		"slug":     normalizeLeaseSlug(slug),
 		"target":   targetLinux,
-		"state":    blank(status, "ready"),
+		"state":    core.Blank(status, "ready"),
 	}
 	if claim.RepoRoot != "" {
 		labels["claimed"] = "true"
@@ -407,7 +407,7 @@ func (b *azureDynamicSessionsBackend) sessionToServer(session azureDynamicSessio
 		Provider: providerName,
 		CloudID:  identifier,
 		Name:     identifier,
-		Status:   blank(status, "ready"),
+		Status:   core.Blank(status, "ready"),
 		Labels:   labels,
 	}
 	server.ServerType.Name = "custom-container"
@@ -421,7 +421,7 @@ func (b *azureDynamicSessionsBackend) statusView(leaseID, slug string, session a
 		Slug:       slug,
 		Provider:   providerName,
 		TargetOS:   targetLinux,
-		State:      blank(status, "ready"),
+		State:      core.Blank(status, "ready"),
 		ServerID:   leaseID,
 		ServerType: "custom-container",
 		Network:    networkPublic,

--- a/internal/providers/azuredynamicsessions/client.go
+++ b/internal/providers/azuredynamicsessions/client.go
@@ -100,7 +100,7 @@ var newAzureDynamicSessionsClient = func(ctx context.Context, cfg Config, rt Run
 	httpClient, dataHTTPClient := shared.ControlAndDataHTTPClients(rt.HTTP, azureDynamicSessionsControlTimeout)
 	return &azureDynamicSessionsClient{
 		endpoint:             endpoint,
-		managementAPIVersion: blank(strings.TrimSpace(cfg.AzureDynamicSessions.APIVersion), core.AzureDynamicSessionsConfigDefaultAPIVersion),
+		managementAPIVersion: core.Blank(strings.TrimSpace(cfg.AzureDynamicSessions.APIVersion), core.AzureDynamicSessionsConfigDefaultAPIVersion),
 		token:                token,
 		httpClient:           httpClient,
 		dataHTTPClient:       dataHTTPClient,

--- a/internal/providers/azuredynamicsessions/core.go
+++ b/internal/providers/azuredynamicsessions/core.go
@@ -58,10 +58,6 @@ func validateNativeCredentialDestination(cfg Config) error {
 	return core.ValidateNativeCredentialDestination(cfg, providerName)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newSessionID() string {
 	var b [6]byte
 	if _, err := rand.Read(b[:]); err != nil {

--- a/internal/providers/azuredynamicsessions/sync.go
+++ b/internal/providers/azuredynamicsessions/sync.go
@@ -71,7 +71,7 @@ func createAzureDynamicSessionsSyncArchive(ctx context.Context, repo Repo, manif
 }
 
 func azureDynamicSessionsWorkspace(cfg Config) (string, error) {
-	return cleanAzureDynamicSessionsWorkspacePath(blank(strings.TrimSpace(cfg.AzureDynamicSessions.Workdir), core.AzureDynamicSessionsConfigDefaultWorkdir))
+	return cleanAzureDynamicSessionsWorkspacePath(core.Blank(strings.TrimSpace(cfg.AzureDynamicSessions.Workdir), core.AzureDynamicSessionsConfigDefaultWorkdir))
 }
 
 func cleanAzureDynamicSessionsWorkspacePath(workspace string) (string, error) {

--- a/internal/providers/blaxel/backend.go
+++ b/internal/providers/blaxel/backend.go
@@ -182,7 +182,7 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 			if err := validateBlaxelSandboxOwnership(claim, sb); err != nil {
 				return nil, err
 			}
-			state = blank(sb.Status, "unknown")
+			state = core.Blank(sb.Status, "unknown")
 		}
 		servers = append(servers, Server{
 			Provider: providerName,
@@ -361,13 +361,13 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 				continue
 			}
 			if req.DryRun {
-				fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+				fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 				continue
 			}
 			if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 				return err
 			}
-			fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+			fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 			claimsRemoved++
 			continue
 		}
@@ -496,12 +496,12 @@ func (b *backend) createSandbox(ctx context.Context, client Client, repo Repo, r
 	slug := ""
 	req := CreateSandboxRequest{
 		Name:       newSandboxName(repo),
-		Image:      blank(b.cfg.Blaxel.Image, core.BlaxelConfigDefaultImage),
+		Image:      core.Blank(b.cfg.Blaxel.Image, core.BlaxelConfigDefaultImage),
 		Region:     b.cfg.Blaxel.Region,
 		MemoryMB:   b.cfg.Blaxel.MemoryMB,
 		TTL:        b.cfg.Blaxel.TTL,
 		IdleTTL:    b.cfg.Blaxel.IdleTTL,
-		WorkingDir: blank(b.cfg.Blaxel.Workdir, core.BlaxelConfigDefaultWorkdir),
+		WorkingDir: core.Blank(b.cfg.Blaxel.Workdir, core.BlaxelConfigDefaultWorkdir),
 		Labels: map[string]string{
 			"crabbox":          "true",
 			"crabbox.provider": providerName,
@@ -710,7 +710,7 @@ func buildCommand(command []string, shellMode bool) ([]string, error) {
 }
 
 func blaxelWorkdir(cfg Config) (string, error) {
-	workdir := strings.TrimSpace(blank(cfg.Blaxel.Workdir, core.BlaxelConfigDefaultWorkdir))
+	workdir := strings.TrimSpace(core.Blank(cfg.Blaxel.Workdir, core.BlaxelConfigDefaultWorkdir))
 	clean := path.Clean(workdir)
 	if workdir == "" || !strings.HasPrefix(clean, "/") || strings.Contains(workdir, "\x00") {
 		return "", exit(2, "blaxel workdir %q must be an absolute path", workdir)

--- a/internal/providers/blaxel/client.go
+++ b/internal/providers/blaxel/client.go
@@ -231,7 +231,7 @@ func isBlaxelDataPlaneHost(host string) bool {
 }
 
 func validateBlaxelConfig(cfg Config) error {
-	if _, err := ValidateAPIURL(blank(cfg.Blaxel.APIURL, core.BlaxelConfigDefaultAPIURL)); err != nil {
+	if _, err := ValidateAPIURL(core.Blank(cfg.Blaxel.APIURL, core.BlaxelConfigDefaultAPIURL)); err != nil {
 		return err
 	}
 	if cfg.Blaxel.MemoryMB < 0 {

--- a/internal/providers/blaxel/core.go
+++ b/internal/providers/blaxel/core.go
@@ -51,10 +51,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
 }

--- a/internal/providers/blaxel/doctor.go
+++ b/internal/providers/blaxel/doctor.go
@@ -17,7 +17,7 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 			Details: map[string]string{"provider": providerName},
 		})
 	}
-	if _, err := ValidateAPIURL(blank(b.cfg.Blaxel.APIURL, core.BlaxelConfigDefaultAPIURL)); err != nil {
+	if _, err := ValidateAPIURL(core.Blank(b.cfg.Blaxel.APIURL, core.BlaxelConfigDefaultAPIURL)); err != nil {
 		record("failed", "api_url", err.Error())
 		return DoctorResult{Provider: providerName, Status: "failed", Message: "api_url=failed mutation=false", Checks: checks}, err
 	}

--- a/internal/providers/cloudflare/backend.go
+++ b/internal/providers/cloudflare/backend.go
@@ -88,7 +88,7 @@ func (b *cloudflareBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 	var claim LeaseClaim
 	var command string
 	bound := func() shared.DelegatedSandbox {
-		return shared.DelegatedSandbox{LeaseID: claim.LeaseID, Slug: blank(claim.Slug, newLeaseSlug(claim.LeaseID)), CleanupCommand: cloudflareCleanupCommand(claim.LeaseID)}
+		return shared.DelegatedSandbox{LeaseID: claim.LeaseID, Slug: core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID)), CleanupCommand: cloudflareCleanupCommand(claim.LeaseID)}
 	}
 	return shared.RunDelegatedSandbox(ctx, req, shared.DelegatedSandboxLifecycle{
 		Provider: providerName, Runtime: b.rt, Workdir: workdir,
@@ -278,14 +278,14 @@ func (b *cloudflareBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 		if err != nil {
 			if cloudflareNotFoundError(err) {
 				if req.DryRun {
-					fmt.Fprintf(b.rt.Stdout, "would remove stale %s claim %s slug=%s reason=not-found\n", providerName, claim.LeaseID, blank(claim.Slug, "-"))
+					fmt.Fprintf(b.rt.Stdout, "would remove stale %s claim %s slug=%s reason=not-found\n", providerName, claim.LeaseID, core.Blank(claim.Slug, "-"))
 					continue
 				}
 				if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 					return err
 				}
 				removed++
-				fmt.Fprintf(b.rt.Stdout, "removed stale %s claim %s slug=%s reason=not-found\n", providerName, claim.LeaseID, blank(claim.Slug, "-"))
+				fmt.Fprintf(b.rt.Stdout, "removed stale %s claim %s slug=%s reason=not-found\n", providerName, claim.LeaseID, core.Blank(claim.Slug, "-"))
 				continue
 			}
 			fmt.Fprintf(b.rt.Stderr, "warning: %s status failed for %s: %v\n", providerName, claim.LeaseID, err)
@@ -295,14 +295,14 @@ func (b *cloudflareBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 			continue
 		}
 		if req.DryRun {
-			fmt.Fprintf(b.rt.Stdout, "would confirm cleanup of %s claim %s slug=%s state=%s\n", providerName, claim.LeaseID, blank(claim.Slug, "-"), sandbox.State)
+			fmt.Fprintf(b.rt.Stdout, "would confirm cleanup of %s claim %s slug=%s state=%s\n", providerName, claim.LeaseID, core.Blank(claim.Slug, "-"), sandbox.State)
 			continue
 		}
 		if _, err := destroyClaimedSandbox(ctx, client, claim); err != nil {
 			return err
 		}
 		removed++
-		fmt.Fprintf(b.rt.Stdout, "removed stale %s claim %s slug=%s state=%s\n", providerName, claim.LeaseID, blank(claim.Slug, "-"), sandbox.State)
+		fmt.Fprintf(b.rt.Stdout, "removed stale %s claim %s slug=%s state=%s\n", providerName, claim.LeaseID, core.Blank(claim.Slug, "-"), sandbox.State)
 	}
 	if !req.DryRun {
 		fmt.Fprintf(b.rt.Stdout, "%s cleanup removed=%d checked=%d\n", providerName, removed, len(claims))
@@ -404,7 +404,7 @@ func rejectCloudflareSyncOptions(req RunRequest) error {
 }
 
 func cloudflareWorkdir(cfg Config) (string, error) {
-	workdir := blank(strings.TrimSpace(cfg.Cloudflare.Workdir), core.CloudflareConfigDefaultWorkdir)
+	workdir := core.Blank(strings.TrimSpace(cfg.Cloudflare.Workdir), core.CloudflareConfigDefaultWorkdir)
 	clean := path.Clean(workdir)
 	if !strings.HasPrefix(clean, "/") {
 		return "", exit(2, "%s workdir %q must resolve to an absolute path", providerName, workdir)
@@ -420,7 +420,7 @@ func sandboxStatusView(leaseID, slug string, sandbox cloudflareContainer) Status
 	server := sandboxToServer(leaseID, slug, sandbox)
 	return StatusView{
 		ID:         leaseID,
-		Slug:       blank(slug, newLeaseSlug(leaseID)),
+		Slug:       core.Blank(slug, newLeaseSlug(leaseID)),
 		Provider:   providerName,
 		TargetOS:   targetLinux,
 		State:      server.Status,
@@ -439,10 +439,10 @@ func sandboxToServer(leaseID, slug string, sandbox cloudflareContainer) Server {
 	}
 	labels["provider"] = providerName
 	labels["lease"] = leaseID
-	labels["slug"] = blank(slug, newLeaseSlug(leaseID))
+	labels["slug"] = core.Blank(slug, newLeaseSlug(leaseID))
 	labels["target"] = targetLinux
-	state := blank(sandbox.State, "running")
-	instanceType := blank(sandbox.InstanceType, providerName)
+	state := core.Blank(sandbox.State, "running")
+	instanceType := core.Blank(sandbox.InstanceType, providerName)
 	labels["state"] = state
 	labels["instance_type"] = instanceType
 	server := Server{
@@ -460,7 +460,7 @@ func claimToServer(claim LeaseClaim, state string) Server {
 	labels := map[string]string{
 		"provider": providerName,
 		"lease":    claim.LeaseID,
-		"slug":     blank(claim.Slug, newLeaseSlug(claim.LeaseID)),
+		"slug":     core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID)),
 		"target":   targetLinux,
 		"state":    state,
 	}

--- a/internal/providers/cloudflare/client.go
+++ b/internal/providers/cloudflare/client.go
@@ -77,7 +77,7 @@ func newCloudflareClient(cfg Config, rt Runtime) (*cloudflareClient, error) {
 	if token == "" {
 		return nil, exit(2, "%s requires CRABBOX_CLOUDFLARE_RUNNER_TOKEN or user-level config", providerName)
 	}
-	instanceType, ok := normalizeCloudflareContainerInstanceType(blank(cfg.ServerType, cloudflareContainerInstanceTypeForClass(cfg.Class)))
+	instanceType, ok := normalizeCloudflareContainerInstanceType(core.Blank(cfg.ServerType, cloudflareContainerInstanceTypeForClass(cfg.Class)))
 	if !ok {
 		if cfg.ServerTypeExplicit {
 			return nil, exit(2, "%s --type must be one of %s", providerName, strings.Join(cloudflareContainerInstanceTypes(), ", "))

--- a/internal/providers/cloudflare/core.go
+++ b/internal/providers/cloudflare/core.go
@@ -43,10 +43,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseID() string {
 	return core.NewLeaseID()
 }

--- a/internal/providers/cloudflaredynamicworkers/backend.go
+++ b/internal/providers/cloudflaredynamicworkers/backend.go
@@ -49,7 +49,7 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 			checks = append(checks, DoctorCheck{Status: "fail", Check: "ok", Message: "readiness did not report ok=true"})
 		}
 		if readiness.Runner != providerName {
-			checks = append(checks, DoctorCheck{Status: "fail", Check: "runner", Message: fmt.Sprintf("readiness runner=%s", blank(readiness.Runner, "-"))})
+			checks = append(checks, DoctorCheck{Status: "fail", Check: "runner", Message: fmt.Sprintf("readiness runner=%s", core.Blank(readiness.Runner, "-"))})
 		}
 		if !readiness.LoaderBinding {
 			checks = append(checks, DoctorCheck{Status: "fail", Check: "loader-binding", Message: "Dynamic Workers binding unavailable"})
@@ -64,7 +64,7 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	return DoctorResult{
 		Provider: providerName,
 		Status:   status,
-		Message:  fmt.Sprintf("auth=ready control_plane=ready api=readiness mutation=false runner=%s loader_binding=%t coordinator_binding=%t durable_run_metadata=%t compatibility_date=%s egress=%s", blank(readiness.Runner, "-"), readiness.LoaderBinding, readiness.CoordinatorBinding, readiness.DurableRunMetadata, blank(readiness.CompatibilityDate, "-"), blank(readiness.Egress, "-")),
+		Message:  fmt.Sprintf("auth=ready control_plane=ready api=readiness mutation=false runner=%s loader_binding=%t coordinator_binding=%t durable_run_metadata=%t compatibility_date=%s egress=%s", core.Blank(readiness.Runner, "-"), readiness.LoaderBinding, readiness.CoordinatorBinding, readiness.DurableRunMetadata, core.Blank(readiness.CompatibilityDate, "-"), core.Blank(readiness.Egress, "-")),
 		Checks:   checks,
 	}, nil
 }
@@ -347,7 +347,7 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 			views = append(views, claimServer(claim, "unknown"))
 			continue
 		}
-		views = append(views, runServer(claim.LeaseID, blank(claim.Slug, newLeaseSlug(claim.LeaseID)), status, mergeRunLabels(claim.Labels, status.Metadata)))
+		views = append(views, runServer(claim.LeaseID, core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID)), status, mergeRunLabels(claim.Labels, status.Metadata)))
 	}
 	return views, nil
 }
@@ -435,7 +435,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 				continue
 			}
 			if req.DryRun {
-				fmt.Fprintf(b.rt.Stdout, "would remove stale %s claim %s slug=%s reason=not-found\n", providerName, claim.LeaseID, blank(claim.Slug, "-"))
+				fmt.Fprintf(b.rt.Stdout, "would remove stale %s claim %s slug=%s reason=not-found\n", providerName, claim.LeaseID, core.Blank(claim.Slug, "-"))
 				continue
 			}
 			if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
@@ -443,14 +443,14 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 				continue
 			}
 			removed++
-			fmt.Fprintf(b.rt.Stdout, "removed stale %s claim %s slug=%s reason=not-found\n", providerName, claim.LeaseID, blank(claim.Slug, "-"))
+			fmt.Fprintf(b.rt.Stdout, "removed stale %s claim %s slug=%s reason=not-found\n", providerName, claim.LeaseID, core.Blank(claim.Slug, "-"))
 			continue
 		}
 		if !terminalState(status.Status) {
 			continue
 		}
 		if req.DryRun {
-			fmt.Fprintf(b.rt.Stdout, "would delete terminal %s metadata and remove claim %s slug=%s state=%s\n", providerName, claim.LeaseID, blank(claim.Slug, "-"), status.Status)
+			fmt.Fprintf(b.rt.Stdout, "would delete terminal %s metadata and remove claim %s slug=%s state=%s\n", providerName, claim.LeaseID, core.Blank(claim.Slug, "-"), status.Status)
 			continue
 		}
 		if err := client.Delete(ctx, claim.LeaseID); err != nil && !notFoundError(err) {
@@ -462,7 +462,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			continue
 		}
 		removed++
-		fmt.Fprintf(b.rt.Stdout, "deleted terminal %s metadata and removed claim %s slug=%s state=%s\n", providerName, claim.LeaseID, blank(claim.Slug, "-"), status.Status)
+		fmt.Fprintf(b.rt.Stdout, "deleted terminal %s metadata and removed claim %s slug=%s state=%s\n", providerName, claim.LeaseID, core.Blank(claim.Slug, "-"), status.Status)
 	}
 	if !req.DryRun {
 		fmt.Fprintf(b.rt.Stdout, "%s cleanup removed=%d checked=%d\n", providerName, removed, len(claims))
@@ -518,12 +518,12 @@ func (b *backend) resolveRunID(identifier, repoRoot string, reclaim bool) (strin
 	}
 	if ok {
 		if repoRoot != "" {
-			server := claimServer(claim, blank(claim.Labels["state"], "unknown"))
+			server := claimServer(claim, core.Blank(claim.Labels["state"], "unknown"))
 			if err := claimLease(claim.LeaseID, claim.Slug, b.cfg, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim, server); err != nil {
 				return "", "", LeaseClaim{}, false, err
 			}
 		}
-		return claim.LeaseID, blank(claim.Slug, newLeaseSlug(claim.LeaseID)), claim, true, nil
+		return claim.LeaseID, core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID)), claim, true, nil
 	}
 	value := strings.TrimSpace(identifier)
 	if value == "" {
@@ -684,7 +684,7 @@ func normalizeCacheMode(value string) string {
 }
 
 func effectiveCompatibilityDate(value string) string {
-	return blank(strings.TrimSpace(value), defaultCompatibilityDate)
+	return core.Blank(strings.TrimSpace(value), defaultCompatibilityDate)
 }
 
 func normalizeEgress(value string) string {
@@ -720,16 +720,16 @@ func providerClaims(cfg Config) ([]LeaseClaim, error) {
 }
 
 func claimServer(claim LeaseClaim, state string) Server {
-	return runServer(claim.LeaseID, blank(claim.Slug, newLeaseSlug(claim.LeaseID)), runStatus{ID: claim.LeaseID, Status: state}, claim.Labels)
+	return runServer(claim.LeaseID, core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID)), runStatus{ID: claim.LeaseID, Status: state}, claim.Labels)
 }
 
 func runServer(leaseID, slug string, status runStatus, extra map[string]string) Server {
 	labels := map[string]string{
 		"provider": providerName,
 		"lease":    leaseID,
-		"slug":     blank(slug, newLeaseSlug(leaseID)),
+		"slug":     core.Blank(slug, newLeaseSlug(leaseID)),
 		"target":   targetWorker,
-		"state":    blank(status.Status, "unknown"),
+		"state":    core.Blank(status.Status, "unknown"),
 	}
 	if strings.TrimSpace(status.WorkerID) != "" {
 		labels["worker_id"] = status.WorkerID
@@ -741,9 +741,9 @@ func runServer(leaseID, slug string, status runStatus, extra map[string]string) 
 	}
 	labels["provider"] = providerName
 	labels["lease"] = leaseID
-	labels["slug"] = blank(slug, newLeaseSlug(leaseID))
+	labels["slug"] = core.Blank(slug, newLeaseSlug(leaseID))
 	labels["target"] = targetWorker
-	labels["state"] = blank(status.Status, "unknown")
+	labels["state"] = core.Blank(status.Status, "unknown")
 	if strings.TrimSpace(status.WorkerID) != "" {
 		labels["worker_id"] = status.WorkerID
 	} else {
@@ -764,11 +764,11 @@ func statusView(leaseID, slug string, status runStatus) StatusView {
 	server := runServer(leaseID, slug, status, status.Metadata)
 	return StatusView{
 		ID:         leaseID,
-		Slug:       blank(slug, newLeaseSlug(leaseID)),
+		Slug:       core.Blank(slug, newLeaseSlug(leaseID)),
 		Provider:   providerName,
 		TargetOS:   targetWorker,
 		State:      server.Status,
-		ServerID:   blank(status.ID, leaseID),
+		ServerID:   core.Blank(status.ID, leaseID),
 		ServerType: server.ServerType.Name,
 		Ready:      readyState(server.Status),
 		Labels:     server.Labels,

--- a/internal/providers/cloudflaredynamicworkers/core.go
+++ b/internal/providers/cloudflaredynamicworkers/core.go
@@ -42,10 +42,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseID() string {
 	return core.NewLeaseID()
 }

--- a/internal/providers/cloudflaresandbox/backend.go
+++ b/internal/providers/cloudflaresandbox/backend.go
@@ -57,7 +57,7 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	if err != nil {
 		checks = append(checks, DoctorCheck{Status: "failed", Check: "health", Message: redactSecrets(err.Error()), Details: map[string]string{"mutation": "false"}})
 	} else if !health.OK {
-		checks = append(checks, DoctorCheck{Status: "failed", Check: "health", Message: fmt.Sprintf("bridge=unhealthy status=%s ok=false mutation=false", blank(health.Status, "-")), Details: map[string]string{"mutation": "false"}})
+		checks = append(checks, DoctorCheck{Status: "failed", Check: "health", Message: fmt.Sprintf("bridge=unhealthy status=%s ok=false mutation=false", core.Blank(health.Status, "-")), Details: map[string]string{"mutation": "false"}})
 	} else {
 		checks = append(checks, DoctorCheck{Status: "ok", Check: "health", Message: fmt.Sprintf("bridge=ready ok=%t mutation=false", health.OK), Details: map[string]string{"mutation": "false"}})
 	}
@@ -65,7 +65,7 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	if err != nil {
 		checks = append(checks, DoctorCheck{Status: "failed", Check: "openapi", Message: redactSecrets(err.Error()), Details: map[string]string{"mutation": "false"}})
 	} else {
-		checks = append(checks, DoctorCheck{Status: "ok", Check: "openapi", Message: fmt.Sprintf("openapi=ready title=%s mutation=false", blank(openapi.Info.Title, "-")), Details: map[string]string{"mutation": "false"}})
+		checks = append(checks, DoctorCheck{Status: "ok", Check: "openapi", Message: fmt.Sprintf("openapi=ready title=%s mutation=false", core.Blank(openapi.Info.Title, "-")), Details: map[string]string{"mutation": "false"}})
 	}
 	return DoctorResult{
 		Provider: providerName,
@@ -427,13 +427,13 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 					return "skip", nil
 				}
 				if req.DryRun {
-					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 					return "skip", nil
 				}
 				if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 					return "", err
 				}
-				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 				return "claim-removed", nil
 			}
 			due, reason := claimCleanupDue(claim, now)
@@ -758,7 +758,7 @@ func (b *backend) execTimeoutSecs() int {
 }
 
 func normalizedSandboxState(sb sandboxSummary) string {
-	return strings.ToLower(blank(strings.TrimSpace(sb.Status), "unknown"))
+	return strings.ToLower(core.Blank(strings.TrimSpace(sb.Status), "unknown"))
 }
 
 func isReadyState(state string) bool {

--- a/internal/providers/cloudflaresandbox/client.go
+++ b/internal/providers/cloudflaresandbox/client.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -246,7 +247,7 @@ func (c *client) parseExecSSE(body io.Reader, stdout, stderr io.Writer) (execRes
 		if err := json.Unmarshal([]byte(data), &frame); err != nil {
 			return fmt.Errorf("decode cloudflare-sandbox exec SSE event: %w", err)
 		}
-		kind := strings.ToLower(blank(frame.Type, ev))
+		kind := strings.ToLower(core.Blank(frame.Type, ev))
 		stream := strings.ToLower(frame.Stream)
 		switch kind {
 		case "stdout", "stderr", "output":

--- a/internal/providers/cloudflaresandbox/core.go
+++ b/internal/providers/cloudflaresandbox/core.go
@@ -90,7 +90,3 @@ func cloudflareSandboxCleanupCommand(leaseID string) string {
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
 	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
 }
-
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}

--- a/internal/providers/cloudrunsandbox/backend.go
+++ b/internal/providers/cloudrunsandbox/backend.go
@@ -382,8 +382,8 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	healthErr := transport.Health(ctx)
 	details := map[string]string{
 		"mode":    transport.Mode(),
-		"cli":     blank(strings.TrimSpace(b.cfg.CloudRunSandbox.CLIPath), core.CloudRunSandboxConfigDefaultCLIPath),
-		"workdir": blank(strings.TrimSpace(b.cfg.CloudRunSandbox.Workdir), core.CloudRunSandboxConfigDefaultWorkdir),
+		"cli":     core.Blank(strings.TrimSpace(b.cfg.CloudRunSandbox.CLIPath), core.CloudRunSandboxConfigDefaultCLIPath),
+		"workdir": core.Blank(strings.TrimSpace(b.cfg.CloudRunSandbox.Workdir), core.CloudRunSandboxConfigDefaultWorkdir),
 	}
 	if transport.Mode() == "remote" {
 		details["gateway"] = strings.TrimSpace(b.cfg.CloudRunSandbox.GatewayURL)
@@ -894,7 +894,7 @@ func (b *backend) claimScope() (string, error) {
 		sum := sha256.Sum256([]byte(validated))
 		return "gateway:" + hex.EncodeToString(sum[:8]), nil
 	}
-	cli := blank(strings.TrimSpace(b.cfg.CloudRunSandbox.CLIPath), core.CloudRunSandboxConfigDefaultCLIPath)
+	cli := core.Blank(strings.TrimSpace(b.cfg.CloudRunSandbox.CLIPath), core.CloudRunSandboxConfigDefaultCLIPath)
 	sum := sha256.Sum256([]byte("direct:" + cli))
 	return "direct:" + hex.EncodeToString(sum[:8]), nil
 }
@@ -904,7 +904,7 @@ func (b *backend) cleanupContext(parent context.Context) (context.Context, conte
 }
 
 func cloudRunSandboxWorkdir(cfg Config) (string, error) {
-	workdir := blank(strings.TrimSpace(cfg.CloudRunSandbox.Workdir), core.CloudRunSandboxConfigDefaultWorkdir)
+	workdir := core.Blank(strings.TrimSpace(cfg.CloudRunSandbox.Workdir), core.CloudRunSandboxConfigDefaultWorkdir)
 	if !path.IsAbs(workdir) {
 		return "", exit(2, "cloudRunSandbox.workdir must be an absolute path")
 	}

--- a/internal/providers/cloudrunsandbox/client.go
+++ b/internal/providers/cloudrunsandbox/client.go
@@ -269,10 +269,10 @@ func (t *remoteTransport) requestBody(sandboxID string, opts runOptions, extra m
 	if opts.OwnershipToken != "" {
 		body["ownershipToken"] = opts.OwnershipToken
 	}
-	if rootfs := blank(opts.Rootfs, t.cfg.CloudRunSandbox.Rootfs); rootfs != "" {
+	if rootfs := core.Blank(opts.Rootfs, t.cfg.CloudRunSandbox.Rootfs); rootfs != "" {
 		body["rootfs"] = rootfs
 	}
-	if workdir := blank(opts.Workdir, t.cfg.CloudRunSandbox.Workdir); workdir != "" {
+	if workdir := core.Blank(opts.Workdir, t.cfg.CloudRunSandbox.Workdir); workdir != "" {
 		body["workdir"] = workdir
 		body["cwd"] = workdir
 	}
@@ -512,7 +512,7 @@ type directTransport struct {
 func (t *directTransport) Mode() string { return "direct" }
 
 func (t *directTransport) binary() string {
-	return blank(strings.TrimSpace(t.cfg.CloudRunSandbox.CLIPath), core.CloudRunSandboxConfigDefaultCLIPath)
+	return core.Blank(strings.TrimSpace(t.cfg.CloudRunSandbox.CLIPath), core.CloudRunSandboxConfigDefaultCLIPath)
 }
 
 func (t *directTransport) baseArgs() []string { return nil }
@@ -521,11 +521,11 @@ func (t *directTransport) pushRunArgs(args []string, opts runOptions) []string {
 	if opts.AllowEgress || t.cfg.CloudRunSandbox.AllowEgress {
 		args = append(args, "--allow-egress")
 	}
-	if rootfs := blank(opts.Rootfs, t.cfg.CloudRunSandbox.Rootfs); rootfs != "" {
+	if rootfs := core.Blank(opts.Rootfs, t.cfg.CloudRunSandbox.Rootfs); rootfs != "" {
 		args = append(args, "--rootfs", rootfs)
 	}
 	if !opts.OmitWorkdir {
-		if workdir := blank(opts.Workdir, t.cfg.CloudRunSandbox.Workdir); workdir != "" {
+		if workdir := core.Blank(opts.Workdir, t.cfg.CloudRunSandbox.Workdir); workdir != "" {
 			args = append(args, "--workdir", workdir)
 		}
 	}
@@ -536,7 +536,7 @@ func (t *directTransport) pushRunArgs(args []string, opts runOptions) []string {
 }
 
 func (t *directTransport) pushExecArgs(args []string, opts execOptions) []string {
-	if workdir := blank(opts.Workdir, t.cfg.CloudRunSandbox.Workdir); workdir != "" {
+	if workdir := core.Blank(opts.Workdir, t.cfg.CloudRunSandbox.Workdir); workdir != "" {
 		args = append(args, "--workdir", workdir)
 	}
 	return args

--- a/internal/providers/cloudrunsandbox/core.go
+++ b/internal/providers/cloudrunsandbox/core.go
@@ -74,10 +74,6 @@ func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
 	return core.AllocateClaimLeaseSlug(leaseID, requested)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
 	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
 }

--- a/internal/providers/coder/backend.go
+++ b/internal/providers/coder/backend.go
@@ -451,7 +451,7 @@ func (b *coderLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 			continue
 		}
 		action := coderCleanupReleaseAction(claim, hasClaim)
-		fmt.Fprintf(b.rt.Stdout, "coder cleanup %s workspace=%s lease=%s reason=%s dry_run=%t\n", action, workspace.Name, blank(leaseID, "-"), reason, req.DryRun)
+		fmt.Fprintf(b.rt.Stdout, "coder cleanup %s workspace=%s lease=%s reason=%s dry_run=%t\n", action, workspace.Name, core.Blank(leaseID, "-"), reason, req.DryRun)
 		if req.DryRun {
 			continue
 		}
@@ -825,7 +825,7 @@ func coderWorkspaceToServerWithClaim(workspace coderWorkspace, cfg Config, lease
 	labels["work_root"] = coderWorkRoot(cfg)
 	labels["state"] = coderWorkspaceState(workspace)
 	server := Server{CloudID: coderWorkspaceCommandName(workspace), Provider: coderProvider, Name: workspace.Name, Status: labels["state"], Labels: labels}
-	server.ServerType.Name = blank(workspace.Template, "coder-workspace")
+	server.ServerType.Name = core.Blank(workspace.Template, "coder-workspace")
 	return server
 }
 
@@ -893,7 +893,7 @@ func coderSSHTarget(cfg Config, workspaceName, workspaceID string) SSHTarget {
 		NetworkKind:    networkPublic,
 		ReadyCheck:     "command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null",
 		SSHConfigProxy: true,
-		ProxyCommand:   shellQuote(cfg.Coder.CLIPath) + " ssh --stdio --wait " + shellQuote(blank(cfg.Coder.Wait, core.CoderConfigDefaultWait)) + " " + shellQuote(workspaceName),
+		ProxyCommand:   shellQuote(cfg.Coder.CLIPath) + " ssh --stdio --wait " + shellQuote(core.Blank(cfg.Coder.Wait, core.CoderConfigDefaultWait)) + " " + shellQuote(workspaceName),
 	}
 }
 
@@ -915,7 +915,7 @@ func coderKnownHostsFile(workspaceName, workspaceID string) string {
 func coderWorkspaceSSHHost(ref string) string {
 	ref = strings.TrimSpace(ref)
 	if !strings.Contains(ref, "/") {
-		return blank(coderWorkspaceNameFromRef(ref), "coder-workspace")
+		return core.Blank(coderWorkspaceNameFromRef(ref), "coder-workspace")
 	}
 	base := normalizeLeaseSlug(ref)
 	hash := coderWorkspaceHash(ref)
@@ -962,7 +962,7 @@ func coderWorkspaceState(workspace coderWorkspace) string {
 			return value
 		}
 	}
-	return blank(strings.ToLower(strings.TrimSpace(workspace.Status)), "unknown")
+	return core.Blank(strings.ToLower(strings.TrimSpace(workspace.Status)), "unknown")
 }
 
 func findCoderWorkspace(workspaces []coderWorkspace, name string) (coderWorkspace, bool) {

--- a/internal/providers/coder/core.go
+++ b/internal/providers/coder/core.go
@@ -44,10 +44,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseID() string {
 	return core.NewLeaseID()
 }

--- a/internal/providers/crownest/backend.go
+++ b/internal/providers/crownest/backend.go
@@ -318,9 +318,9 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	case streamErr != nil:
 		retErr = shared.ExitErrorWithCause(1, fmt.Sprintf("crownest stream failed: %v", streamErr), streamErr)
 	case missingExitStatusFailure:
-		retErr = exit(5, "crownest workspace run ended status=%s reason=%s class=%s without command exit code", blank(terminalStatus, "unknown"), blank(terminal.FailureReason, "unknown"), blank(terminal.FailureClass, "unknown"))
+		retErr = exit(5, "crownest workspace run ended status=%s reason=%s class=%s without command exit code", core.Blank(terminalStatus, "unknown"), core.Blank(terminal.FailureReason, "unknown"), core.Blank(terminal.FailureClass, "unknown"))
 	case terminalStatus == "failed" && terminal.FailureReason != "command_exit":
-		retErr = exit(5, "crownest workspace run failed reason=%s class=%s", blank(terminal.FailureReason, "unknown"), blank(terminal.FailureClass, "unknown"))
+		retErr = exit(5, "crownest workspace run failed reason=%s class=%s", core.Blank(terminal.FailureReason, "unknown"), core.Blank(terminal.FailureClass, "unknown"))
 	default:
 		result = core.FinalizeRunResult(result, nil)
 		if result.ExitCode != 0 {
@@ -392,7 +392,7 @@ func (b *backend) crownestRunSession(leaseID, slug string, reused, kept bool) *R
 		Slug:           slug,
 		Reused:         reused,
 		Kept:           kept,
-		CleanupCommand: crownestCleanupCommand(b.cfg, blank(slug, leaseID)),
+		CleanupCommand: crownestCleanupCommand(b.cfg, core.Blank(slug, leaseID)),
 	}
 }
 
@@ -573,13 +573,13 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 					return nil
 				}
 				if req.DryRun {
-					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 					return nil
 				}
 				if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 					return err
 				}
-				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 				claimRemovedOne = true
 				return nil
 			}
@@ -736,7 +736,7 @@ func (b *backend) streamRun(ctx context.Context, api client, workspaceRunID stri
 			case "terminal":
 				terminal = event.WorkspaceRun
 			case "error":
-				return exit(5, "crownest event error %s: %s", blank(event.Code, "error"), event.Message)
+				return exit(5, "crownest event error %s: %s", core.Blank(event.Code, "error"), event.Message)
 			}
 			return nil
 		})
@@ -913,7 +913,7 @@ func timeoutOrDefault(primary, fallback time.Duration) time.Duration {
 }
 
 func normalizedSandboxState(sb sandbox) string {
-	return strings.ToLower(blank(strings.TrimSpace(sb.Status), "unknown"))
+	return strings.ToLower(core.Blank(strings.TrimSpace(sb.Status), "unknown"))
 }
 
 func isReadyState(state string) bool {

--- a/internal/providers/crownest/backend_test.go
+++ b/internal/providers/crownest/backend_test.go
@@ -352,7 +352,7 @@ func TestRunRejectsWorkspaceEnvUntilCrownestSupportsIt(t *testing.T) {
 
 func TestRunDistinguishesFrameworkMetadataFromUnsupportedUserEnv(t *testing.T) {
 	for _, userName := range []string{"", "FOO", "CRABBOX_CUSTOM", "CRABBOX_RUN_ID_EXTRA", "CRABBOX_SLUG_PREFIX", "CRABBOX_LEASE_ID_SUFFIX"} {
-		t.Run(blank(userName, "framework-only"), func(t *testing.T) {
+		t.Run(core.Blank(userName, "framework-only"), func(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			api := &fakeCrownestClient{baseURL: "https://api.crownest.dev"}
 			var stderr bytes.Buffer
@@ -977,7 +977,7 @@ type fakeCrownestClient struct {
 func (f *fakeCrownestClient) BaseURL() string { return f.baseURL }
 
 func (f *fakeCrownestClient) CreateSandbox(context.Context, createSandboxRequest) (sandbox, error) {
-	return sandbox{ID: blank(f.createSandboxID, "sbx_123"), Status: "running"}, nil
+	return sandbox{ID: core.Blank(f.createSandboxID, "sbx_123"), Status: "running"}, nil
 }
 
 func (f *fakeCrownestClient) GetSandbox(context.Context, string) (sandbox, error) {
@@ -1032,7 +1032,7 @@ func (f *fakeCrownestClient) FinalizeArchive(_ context.Context, _ string, req fi
 
 func (f *fakeCrownestClient) StartWorkspaceRun(context.Context, string, string) (workspaceRun, error) {
 	f.started = true
-	sandboxID := blank(f.startSandboxID, "sbx_123")
+	sandboxID := core.Blank(f.startSandboxID, "sbx_123")
 	return workspaceRun{ID: "wsr_123", Status: "running", SandboxID: sandboxID}, nil
 }
 

--- a/internal/providers/crownest/core.go
+++ b/internal/providers/crownest/core.go
@@ -44,10 +44,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseSlug(leaseID string) string {
 	return core.NewLeaseSlug(leaseID)
 }

--- a/internal/providers/cua/backend.go
+++ b/internal/providers/cua/backend.go
@@ -56,7 +56,7 @@ func (b backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
 	views := make([]LeaseView, 0, len(sandboxes)+len(claimsBySandbox))
 	seen := make(map[string]bool, len(sandboxes))
 	for _, sb := range sandboxes {
-		sandboxName := strings.TrimSpace(blank(sb.Name, sb.ID))
+		sandboxName := strings.TrimSpace(core.Blank(sb.Name, sb.ID))
 		if sandboxName == "" {
 			continue
 		}
@@ -133,7 +133,7 @@ func (b backend) Status(ctx context.Context, req StatusRequest) (StatusView, err
 		leaseID, slug, pond := sandboxID, "", ""
 		if claimed {
 			leaseID = claim.LeaseID
-			slug = blank(claim.Slug, newLeaseSlug(claim.LeaseID))
+			slug = core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID))
 			pond = claim.Pond
 		}
 		view := StatusView{
@@ -186,7 +186,7 @@ func (b backend) Cleanup(context.Context, CleanupRequest) error {
 
 func (b backend) serverFromSandbox(claim LeaseClaim, sb bridgeSandboxSummary) Server {
 	state := normalizedSandboxState(sb)
-	sandboxName := strings.TrimSpace(blank(sb.Name, sb.ID))
+	sandboxName := strings.TrimSpace(core.Blank(sb.Name, sb.ID))
 	if sandboxName == "" {
 		sandboxName = claimSandboxName(claim)
 	}
@@ -212,7 +212,7 @@ func (b backend) claimMatchesActiveScope(claim LeaseClaim) bool {
 }
 
 func normalizedSandboxState(sb bridgeSandboxSummary) string {
-	return strings.ToLower(blank(strings.TrimSpace(blank(sb.Status, sb.State)), "unknown"))
+	return strings.ToLower(core.Blank(strings.TrimSpace(core.Blank(sb.Status, sb.State)), "unknown"))
 }
 
 func isReadyState(state string) bool {
@@ -234,7 +234,7 @@ func isTerminalState(state string) bool {
 }
 
 func sandboxTargetOS(claim LeaseClaim, sb bridgeSandboxSummary) string {
-	value := strings.ToLower(strings.TrimSpace(blank(sb.OSType, sb.Metadata["osType"])))
+	value := strings.ToLower(strings.TrimSpace(core.Blank(sb.OSType, sb.Metadata["osType"])))
 	if value == "" {
 		value = strings.ToLower(strings.TrimSpace(claim.TargetOS))
 	}

--- a/internal/providers/cua/bridge.go
+++ b/internal/providers/cua/bridge.go
@@ -157,7 +157,7 @@ func bridgeResponseError(action string, resp bridgeResponse) error {
 	return &bridgeActionError{
 		action: action,
 		code:   strings.TrimSpace(resp.Error.Code),
-		class:  strings.TrimSpace(blank(resp.Error.Class, resp.Class)),
+		class:  strings.TrimSpace(core.Blank(resp.Error.Class, resp.Class)),
 		msg:    strings.TrimSpace(resp.Error.Message),
 	}
 }
@@ -195,7 +195,7 @@ func (c *bridgeClient) RoundTrip(ctx context.Context, req bridgeRequest) (bridge
 		return bridgeResponse{}, err
 	}
 	defer os.RemoveAll(dir)
-	command := LocalCommandRequest{Name: strings.TrimSpace(blank(c.cfg.Cua.BridgeCommand, core.CuaConfigDefaultBridgeCommand)), Args: []string{"-I", "-c", bridgeScript}, Env: bridgeEnv(c.cfg, dir), Dir: dir}
+	command := LocalCommandRequest{Name: strings.TrimSpace(core.Blank(c.cfg.Cua.BridgeCommand, core.CuaConfigDefaultBridgeCommand)), Args: []string{"-I", "-c", bridgeScript}, Env: bridgeEnv(c.cfg, dir), Dir: dir}
 	resp, result, err := procjson.Exchange[bridgeRequest, bridgeResponse](ctx, c.rt.Exec, command, req, procjson.Limits{MaxBytesPerStream: bridgeOutputLimit, CancelGrace: 2 * time.Second})
 	if err != nil {
 		failure, _ := err.(*procjson.Failure)
@@ -213,8 +213,8 @@ func bridgeConfigForConfig(cfg Config) bridgeConfig {
 	workdir, _ := cuaWorkdir(cfg)
 	return bridgeConfig{
 		APIURL:         apiURL,
-		Image:          strings.TrimSpace(blank(cfg.Cua.Image, core.CuaConfigDefaultImage)),
-		Kind:           strings.ToLower(strings.TrimSpace(blank(cfg.Cua.Kind, core.CuaConfigDefaultKind))),
+		Image:          strings.TrimSpace(core.Blank(cfg.Cua.Image, core.CuaConfigDefaultImage)),
+		Kind:           strings.ToLower(strings.TrimSpace(core.Blank(cfg.Cua.Kind, core.CuaConfigDefaultKind))),
 		Region:         strings.TrimSpace(cfg.Cua.Region),
 		Workdir:        workdir,
 		VCPUs:          cfg.Cua.VCPUs,
@@ -222,8 +222,8 @@ func bridgeConfigForConfig(cfg Config) bridgeConfig {
 		DiskGB:         cfg.Cua.DiskGB,
 		StartupTimeout: cfg.Cua.StartupTimeoutSecs,
 		ExecTimeout:    cfg.Cua.ExecTimeoutSecs,
-		SDKPackage:     strings.TrimSpace(blank(cfg.Cua.SDKPackage, core.CuaConfigDefaultSDKPackage)),
-		SDKImport:      strings.TrimSpace(blank(cfg.Cua.SDKImport, core.CuaConfigDefaultSDKImport)),
+		SDKPackage:     strings.TrimSpace(core.Blank(cfg.Cua.SDKPackage, core.CuaConfigDefaultSDKPackage)),
+		SDKImport:      strings.TrimSpace(core.Blank(cfg.Cua.SDKImport, core.CuaConfigDefaultSDKImport)),
 		FallbackImport: cuaSDKFallbackImport(cfg.Cua),
 	}
 }
@@ -231,7 +231,7 @@ func bridgeConfigForConfig(cfg Config) bridgeConfig {
 // Whitespace fallback imports previously reached Python's terminal default.
 // Resolve that accepted value before supplying either bridge transport channel.
 func cuaSDKFallbackImport(cfg CuaConfig) string {
-	return blank(strings.TrimSpace(cfg.SDKFallbackImport), core.CuaConfigDefaultSDKFallbackImport)
+	return core.Blank(strings.TrimSpace(cfg.SDKFallbackImport), core.CuaConfigDefaultSDKFallbackImport)
 }
 
 func bridgeTimeout(cfg Config, req bridgeRequest) time.Duration {
@@ -277,8 +277,8 @@ func bridgeEnv(cfg Config, home string) []string {
 		// https://github.com/trycua/cua/blob/sandbox-v0.1.17/libs/python/cua-sandbox/cua_sandbox/_config.py
 		env = upsertEnv(env, "CUA_BASE_URL", apiURL)
 	}
-	env = upsertEnv(env, "CRABBOX_CUA_SDK_PACKAGE", strings.TrimSpace(blank(cfg.Cua.SDKPackage, core.CuaConfigDefaultSDKPackage)))
-	env = upsertEnv(env, "CRABBOX_CUA_SDK_IMPORT", strings.TrimSpace(blank(cfg.Cua.SDKImport, core.CuaConfigDefaultSDKImport)))
+	env = upsertEnv(env, "CRABBOX_CUA_SDK_PACKAGE", strings.TrimSpace(core.Blank(cfg.Cua.SDKPackage, core.CuaConfigDefaultSDKPackage)))
+	env = upsertEnv(env, "CRABBOX_CUA_SDK_IMPORT", strings.TrimSpace(core.Blank(cfg.Cua.SDKImport, core.CuaConfigDefaultSDKImport)))
 	env = upsertEnv(env, "CRABBOX_CUA_SDK_FALLBACK_IMPORT", cuaSDKFallbackImport(cfg.Cua))
 	return env
 }

--- a/internal/providers/cua/claims_test.go
+++ b/internal/providers/cua/claims_test.go
@@ -16,8 +16,8 @@ func claimLabels(cfg Config, sandboxName, createdAt string, missing bool) map[st
 	workdir, _ := cuaWorkdir(cfg)
 	labels := map[string]string{
 		labelSandboxName: sandboxName,
-		labelImage:       strings.TrimSpace(blank(cfg.Cua.Image, core.CuaConfigDefaultImage)),
-		labelKind:        strings.ToLower(strings.TrimSpace(blank(cfg.Cua.Kind, core.CuaConfigDefaultKind))),
+		labelImage:       strings.TrimSpace(core.Blank(cfg.Cua.Image, core.CuaConfigDefaultImage)),
+		labelKind:        strings.ToLower(strings.TrimSpace(core.Blank(cfg.Cua.Kind, core.CuaConfigDefaultKind))),
 		labelRegion:      strings.TrimSpace(cfg.Cua.Region),
 		labelWorkdir:     workdir,
 		labelCreatedAt:   strings.TrimSpace(createdAt),

--- a/internal/providers/cua/core.go
+++ b/internal/providers/cua/core.go
@@ -48,10 +48,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseSlug(leaseID string) string {
 	return core.NewLeaseSlug(leaseID)
 }

--- a/internal/providers/cua/doctor.go
+++ b/internal/providers/cua/doctor.go
@@ -44,7 +44,7 @@ func (b backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, err
 		}
 		checks = append(checks, DoctorCheck{
 			Status:  status,
-			Check:   strings.TrimSpace(blank(item.Check, "bridge")),
+			Check:   strings.TrimSpace(core.Blank(item.Check, "bridge")),
 			Message: redactSecrets(item.Message),
 			Details: details,
 		})
@@ -52,9 +52,9 @@ func (b backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, err
 	if resp.Error != nil {
 		checks = append(checks, DoctorCheck{
 			Status:  "failed",
-			Check:   strings.TrimSpace(blank(resp.Error.Code, "bridge")),
+			Check:   strings.TrimSpace(core.Blank(resp.Error.Code, "bridge")),
 			Message: redactSecrets(resp.Error.Message),
-			Details: map[string]string{"provider": providerName, "class": blank(resp.Error.Class, "environment_blocked"), "mutation": "false"},
+			Details: map[string]string{"provider": providerName, "class": core.Blank(resp.Error.Class, "environment_blocked"), "mutation": "false"},
 		})
 	}
 	status := core.DoctorChecksStatus(checks)

--- a/internal/providers/cua/flags.go
+++ b/internal/providers/cua/flags.go
@@ -40,7 +40,7 @@ func validateProviderConfig(cfg Config) error {
 	if _, err := cuaWorkdir(cfg); err != nil {
 		return err
 	}
-	kind := strings.ToLower(strings.TrimSpace(blank(cfg.Cua.Kind, core.CuaConfigDefaultKind)))
+	kind := strings.ToLower(strings.TrimSpace(core.Blank(cfg.Cua.Kind, core.CuaConfigDefaultKind)))
 	if kind != "container" && kind != "vm" {
 		return exit(2, "%s kind must be container or vm", providerName)
 	}
@@ -75,7 +75,7 @@ func validateProviderConfig(cfg Config) error {
 }
 
 func cuaWorkdir(cfg Config) (string, error) {
-	workdir := strings.TrimSpace(blank(cfg.Cua.Workdir, core.CuaConfigDefaultWorkdir))
+	workdir := strings.TrimSpace(core.Blank(cfg.Cua.Workdir, core.CuaConfigDefaultWorkdir))
 	if !path.IsAbs(workdir) {
 		return "", exit(2, "%s workdir must be absolute", providerName)
 	}

--- a/internal/providers/cubesandbox/backend.go
+++ b/internal/providers/cubesandbox/backend.go
@@ -666,7 +666,7 @@ func cubesandboxSandboxToServer(sandbox cubesandboxSandbox) Server {
 		Status:   sandbox.State,
 		Labels:   labels,
 	}
-	server.ServerType.Name = blank(sandbox.Alias, sandbox.TemplateID)
+	server.ServerType.Name = core.Blank(sandbox.Alias, sandbox.TemplateID)
 	if server.ServerType.Name == "" {
 		server.ServerType.Name = "base"
 	}

--- a/internal/providers/cubesandbox/client.go
+++ b/internal/providers/cubesandbox/client.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -98,11 +99,11 @@ func (e *cubesandboxAPIError) Error() string {
 var newCubeSandboxClient = func(cfg Config, rt Runtime) (cubesandboxAPI, error) {
 	apiKey := strings.TrimSpace(cfg.CubeSandbox.APIKey)
 	httpClient, dataPlaneClient := shared.ControlAndDataHTTPClients(rt.HTTP, cubesandboxControlTimeout)
-	apiURL, err := validateCubeSandboxAPIURL(blank(cfg.CubeSandbox.APIURL, "http://127.0.0.1:3000"))
+	apiURL, err := validateCubeSandboxAPIURL(core.Blank(cfg.CubeSandbox.APIURL, "http://127.0.0.1:3000"))
 	if err != nil {
 		return nil, err
 	}
-	domain := strings.TrimSpace(blank(cfg.CubeSandbox.Domain, "cube.app"))
+	domain := strings.TrimSpace(core.Blank(cfg.CubeSandbox.Domain, "cube.app"))
 	proxyScheme, err := cubeSandboxProxyScheme(cfg.CubeSandbox.ProxyScheme, cfg.CubeSandbox.ProxyPortHTTP)
 	if err != nil {
 		return nil, err

--- a/internal/providers/cubesandbox/core.go
+++ b/internal/providers/cubesandbox/core.go
@@ -41,10 +41,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseID() string {
 	return core.NewLeaseID()
 }

--- a/internal/providers/dockersandbox/backend.go
+++ b/internal/providers/dockersandbox/backend.go
@@ -571,7 +571,7 @@ func randomSuffix() string {
 }
 
 func serverFromClaimRecord(claim core.LeaseClaim, record sandboxRecord) Server {
-	state := blank(record.State, "unknown")
+	state := core.Blank(record.State, "unknown")
 	labels := map[string]string{
 		"provider":  providerName,
 		"lease":     claim.LeaseID,
@@ -579,7 +579,7 @@ func serverFromClaimRecord(claim core.LeaseClaim, record sandboxRecord) Server {
 		"target":    targetLinux,
 		"state":     state,
 		"sandbox":   record.Name,
-		"agent":     blank(record.Agent, defaultAgent),
+		"agent":     core.Blank(record.Agent, defaultAgent),
 		"workspace": record.Workspace,
 	}
 	server := Server{
@@ -594,7 +594,7 @@ func serverFromClaimRecord(claim core.LeaseClaim, record sandboxRecord) Server {
 }
 
 func statusFromRecord(leaseID, slug string, record sandboxRecord) StatusView {
-	state := blank(record.State, "unknown")
+	state := core.Blank(record.State, "unknown")
 	return StatusView{
 		ID:         leaseID,
 		Slug:       slug,
@@ -611,7 +611,7 @@ func statusFromRecord(leaseID, slug string, record sandboxRecord) StatusView {
 			"slug":      slug,
 			"state":     state,
 			"sandbox":   record.Name,
-			"agent":     blank(record.Agent, defaultAgent),
+			"agent":     core.Blank(record.Agent, defaultAgent),
 			"workspace": record.Workspace,
 		},
 	}

--- a/internal/providers/dockersandbox/client.go
+++ b/internal/providers/dockersandbox/client.go
@@ -27,7 +27,7 @@ func newSBXCLI(cfg Config, rt Runtime) (*sbxCLI, error) {
 }
 
 func (c *sbxCLI) binary() string {
-	return blank(strings.TrimSpace(c.cfg.DockerSandbox.CLIPath), defaultCLIPath)
+	return core.Blank(strings.TrimSpace(c.cfg.DockerSandbox.CLIPath), defaultCLIPath)
 }
 
 func (c *sbxCLI) env() []string {

--- a/internal/providers/dockersandbox/core.go
+++ b/internal/providers/dockersandbox/core.go
@@ -91,7 +91,3 @@ func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim,
 func listLeaseClaims() ([]core.LeaseClaim, error) {
 	return core.ListLeaseClaims()
 }
-
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -345,7 +345,7 @@ func (b *e2bBackend) createSandbox(ctx context.Context, client e2bAPI, repo Repo
 	if err != nil {
 		return "", e2bSandbox{}, "", err
 	}
-	template := blank(b.cfg.E2B.Template, core.E2BConfigDefaultTemplate)
+	template := core.Blank(b.cfg.E2B.Template, core.E2BConfigDefaultTemplate)
 	cfg := b.cfg
 	workspace, err := cleanE2BWorkspacePath(e2bWorkspacePath(cfg))
 	if err != nil {
@@ -634,7 +634,7 @@ func e2bSandboxToServer(sandbox e2bSandbox) Server {
 		Status:   sandbox.State,
 		Labels:   labels,
 	}
-	server.ServerType.Name = blank(sandbox.Alias, sandbox.TemplateID)
+	server.ServerType.Name = core.Blank(sandbox.Alias, sandbox.TemplateID)
 	if server.ServerType.Name == "" {
 		server.ServerType.Name = "base"
 	}

--- a/internal/providers/e2b/bridge.go
+++ b/internal/providers/e2b/bridge.go
@@ -89,7 +89,7 @@ func (b *e2bBackend) bridgeSandboxCoords(ctx context.Context, leaseID string) (s
 	}
 	domain := strings.TrimSpace(sandbox.Domain)
 	if domain == "" {
-		domain = strings.TrimSpace(blank(b.cfg.E2B.Domain, core.E2BConfigDefaultDomain))
+		domain = strings.TrimSpace(core.Blank(b.cfg.E2B.Domain, core.E2BConfigDefaultDomain))
 	}
 	return sandbox.SandboxID, domain, nil
 }

--- a/internal/providers/e2b/client.go
+++ b/internal/providers/e2b/client.go
@@ -96,11 +96,11 @@ var newE2BClient = func(cfg Config, rt Runtime) (e2bAPI, error) {
 		return nil, exit(2, "provider=e2b requires E2B_API_KEY")
 	}
 	httpClient, envdClient := shared.ControlAndDataHTTPClients(rt.HTTP, e2bControlTimeout)
-	apiURL, err := validateE2BAPIURL(blank(cfg.E2B.APIURL, core.E2BConfigDefaultAPIURL))
+	apiURL, err := validateE2BAPIURL(core.Blank(cfg.E2B.APIURL, core.E2BConfigDefaultAPIURL))
 	if err != nil {
 		return nil, err
 	}
-	domain := strings.TrimSpace(blank(cfg.E2B.Domain, core.E2BConfigDefaultDomain))
+	domain := strings.TrimSpace(core.Blank(cfg.E2B.Domain, core.E2BConfigDefaultDomain))
 	return &e2bClient{
 		apiKey:     apiKey,
 		apiURL:     apiURL,

--- a/internal/providers/e2b/core.go
+++ b/internal/providers/e2b/core.go
@@ -42,10 +42,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseID() string {
 	return core.NewLeaseID()
 }

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -394,7 +394,7 @@ func applyExeDevDefaults(cfg *Config) {
 	if cfg.ExeDev.User != "" {
 		cfg.SSHUser = cfg.ExeDev.User
 	} else if cfg.SSHUser == "" || cfg.SSHUser == "crabbox" {
-		cfg.SSHUser = blank(os.Getenv("USER"), "root")
+		cfg.SSHUser = core.Blank(os.Getenv("USER"), "root")
 	}
 	if cfg.ExeDev.WorkRoot != "" {
 		cfg.WorkRoot = cfg.ExeDev.WorkRoot
@@ -679,7 +679,7 @@ func (b *exeDevLeaseBackend) resolveVM(ctx context.Context, identifier string) (
 	if claim, ok, err := resolveLeaseClaimForProvider(identifier, providerName); err != nil {
 		return exeDevVM{}, "", "", err
 	} else if ok {
-		slug := blank(claim.Slug, newLeaseSlug(claim.LeaseID))
+		slug := core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID))
 		name := leaseProviderName(claim.LeaseID, slug)
 		vm, err := b.findVM(ctx, name)
 		return vm, claim.LeaseID, slug, err
@@ -1004,13 +1004,13 @@ func exeDevControlScope(cfg Config, accountFingerprint string) (string, error) {
 	if accountFingerprint == "" {
 		return "", exit(2, "exe.dev account fingerprint is empty")
 	}
-	return "ssh:" + destination + "|port:" + blank(port, "default") + "|account:sha256:" + accountFingerprint, nil
+	return "ssh:" + destination + "|port:" + core.Blank(port, "default") + "|account:sha256:" + accountFingerprint, nil
 }
 
 func exeDevServer(vm exeDevVM, leaseID, slug string, cfg Config, keep bool) Server {
 	labels := directLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
 	labels["name"] = vm.Name()
-	labels["state"] = blank(vm.Status, "unknown")
+	labels["state"] = core.Blank(vm.Status, "unknown")
 	labels["work_root"] = cfg.WorkRoot
 	if vm.Region != "" {
 		labels["region"] = vm.Region
@@ -1085,7 +1085,7 @@ func (b *exeDevLeaseBackend) leaseIdentityForVM(vm exeDevVM) (string, string, er
 		if claim, ok, err := resolveLeaseClaimForProvider(slug, providerName); err != nil {
 			return "", "", err
 		} else if ok {
-			claimSlug := blank(claim.Slug, newLeaseSlug(claim.LeaseID))
+			claimSlug := core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID))
 			if leaseProviderName(claim.LeaseID, claimSlug) == vm.Name() {
 				return claim.LeaseID, claimSlug, nil
 			}
@@ -1191,5 +1191,5 @@ func isLowerHex(value string) bool {
 }
 
 func exeDevImage(cfg Config) string {
-	return blank(strings.TrimSpace(cfg.ExeDev.Image), core.ExeDevDefaultImageLabel)
+	return core.Blank(strings.TrimSpace(cfg.ExeDev.Image), core.ExeDevDefaultImageLabel)
 }

--- a/internal/providers/exedev/client.go
+++ b/internal/providers/exedev/client.go
@@ -2,6 +2,7 @@ package exedev
 
 import (
 	"encoding/json"
+	core "github.com/openclaw/crabbox/internal/cli"
 	"net"
 	"strings"
 )
@@ -28,7 +29,7 @@ type exeDevSSHAddress struct {
 }
 
 func (vm exeDevVM) Name() string {
-	return blank(strings.TrimSpace(vm.VMName), strings.TrimSpace(vm.NameValue))
+	return core.Blank(strings.TrimSpace(vm.VMName), strings.TrimSpace(vm.NameValue))
 }
 
 func (vm exeDevVM) SSHHost() string {

--- a/internal/providers/exedev/core.go
+++ b/internal/providers/exedev/core.go
@@ -44,10 +44,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseID() string {
 	return core.NewLeaseID()
 }

--- a/internal/providers/fastapicloud/backend.go
+++ b/internal/providers/fastapicloud/backend.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strings"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -139,7 +140,7 @@ func fastAPICloudServer(app fastAPICloudApp) Server {
 	return Server{
 		CloudID:  app.ID,
 		Provider: providerName,
-		Name:     blank(app.Name, app.Slug),
+		Name:     core.Blank(app.Name, app.Slug),
 		Labels:   fastAPICloudLabels(app, fastAPICloudDeployment{}, false),
 	}
 }

--- a/internal/providers/fastapicloud/client.go
+++ b/internal/providers/fastapicloud/client.go
@@ -136,7 +136,7 @@ func newFastAPICloudClient(cfg Config, rt Runtime) (fastAPICloudAPI, error) {
 	if token == "" {
 		return nil, exit(2, "provider=%s requires FASTAPI_CLOUD_TOKEN", providerName)
 	}
-	apiURL, err := validateFastAPICloudAPIURL(blank(cfg.FastAPICloud.APIURL, core.FastAPICloudConfigDefaultAPIURL))
+	apiURL, err := validateFastAPICloudAPIURL(core.Blank(cfg.FastAPICloud.APIURL, core.FastAPICloudConfigDefaultAPIURL))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/fastapicloud/core.go
+++ b/internal/providers/fastapicloud/core.go
@@ -33,10 +33,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func inventoryDoctorResult(provider string, leases int) DoctorResult {
 	return core.InventoryDoctorResult(provider, leases)
 }

--- a/internal/providers/freestyle/backend.go
+++ b/internal/providers/freestyle/backend.go
@@ -452,7 +452,7 @@ func (b *freestyleBackend) resolveLeaseID(ctx context.Context, client freestyleA
 			return "", "", err
 		}
 	}
-	return leaseID, blank(vm.ID, vmID), nil
+	return leaseID, core.Blank(vm.ID, vmID), nil
 }
 
 func resolveExactFreestyleLeaseClaim(leaseID string) (core.LeaseClaim, bool, error) {

--- a/internal/providers/freestyle/client.go
+++ b/internal/providers/freestyle/client.go
@@ -92,7 +92,7 @@ var newFreestyleClient = func(cfg Config, rt Runtime) (freestyleAPI, error) {
 	if apiKey == "" {
 		return nil, exit(2, "provider=freestyle requires FREESTYLE_API_KEY")
 	}
-	apiURL, err := validateFreestyleAPIURL(blank(cfg.Freestyle.APIURL, core.FreestyleConfigDefaultAPIURL))
+	apiURL, err := validateFreestyleAPIURL(core.Blank(cfg.Freestyle.APIURL, core.FreestyleConfigDefaultAPIURL))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/freestyle/core.go
+++ b/internal/providers/freestyle/core.go
@@ -48,10 +48,6 @@ func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
 	return core.AllocateClaimLeaseSlug(leaseID, requested)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 var claimLeaseForRepoProviderPond = core.ClaimLeaseForRepoProviderPond
 
 func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {

--- a/internal/providers/gcp/backend.go
+++ b/internal/providers/gcp/backend.go
@@ -137,7 +137,7 @@ func (b *gcpLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (Leas
 			if !isCrabboxGCPLease(server) {
 				return LeaseTarget{}, exit(4, "lease/server not found: %s (instance exists but is not Crabbox-managed)", req.ID)
 			}
-			leaseID := blank(server.Labels["lease"], req.ID)
+			leaseID := core.Blank(server.Labels["lease"], req.ID)
 			target := sshTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
 			useStoredTestboxKey(&target, leaseID)
 			return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
@@ -222,7 +222,7 @@ func (b *gcpLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequ
 		return exit(4, "refusing to delete gcp instance %q for lease=%s: live instance is not canonical Crabbox-owned", cloudID, req.Lease.LeaseID)
 	}
 	if liveLeaseID := strings.TrimSpace(live.Labels["lease"]); liveLeaseID != req.Lease.LeaseID {
-		return exit(4, "refusing to delete gcp instance %q for lease=%s: live instance belongs to lease=%s", cloudID, req.Lease.LeaseID, blank(liveLeaseID, "-"))
+		return exit(4, "refusing to delete gcp instance %q for lease=%s: live instance belongs to lease=%s", cloudID, req.Lease.LeaseID, core.Blank(liveLeaseID, "-"))
 	}
 	if err := validateExactGCPClaim(claim, live, req.Lease.LeaseID, b.Cfg); err != nil {
 		return err
@@ -427,13 +427,13 @@ func (b *gcpLeaseBackend) pruneStaleClaims(ctx context.Context, liveLeaseIDs map
 				return err
 			}
 			if _, err := client.GetServer(ctx, claim.CloudID); err == nil {
-				fmt.Fprintf(b.RT.Stderr, "retain stale claim lease=%s slug=%s provider=gcp reason=cloud resource still exists\n", claim.LeaseID, blank(claim.Slug, "-"))
+				fmt.Fprintf(b.RT.Stderr, "retain stale claim lease=%s slug=%s provider=gcp reason=cloud resource still exists\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 				continue
 			} else if !core.IsGCPNotFound(err) {
 				return fmt.Errorf("re-read GCP stale claim %s: %w", claim.LeaseID, err)
 			}
 		}
-		fmt.Fprintf(b.RT.Stderr, "remove stale claim lease=%s slug=%s provider=gcp\n", claim.LeaseID, blank(claim.Slug, "-"))
+		fmt.Fprintf(b.RT.Stderr, "remove stale claim lease=%s slug=%s provider=gcp\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 		if !dryRun {
 			removeLeaseClaim(claim.LeaseID)
 		}
@@ -475,7 +475,7 @@ func sshTargetFromConfig(cfg Config, host string) SSHTarget {
 var waitForSSHReady = core.WaitForSSHReady
 
 func bootstrapWaitTimeout(cfg Config) time.Duration { return core.BootstrapWaitTimeout(cfg) }
-func blank(value, fallback string) string           { return core.Blank(value, fallback) }
+
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
 	shared.UseStoredTestboxKey(target, leaseID)
 }

--- a/internal/providers/hetzner/backend.go
+++ b/internal/providers/hetzner/backend.go
@@ -182,7 +182,7 @@ func (b *hetznerLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (
 		if err := validateHetznerResolveOwnership(server, req); err != nil {
 			return LeaseTarget{}, err
 		}
-		leaseID := blank(server.Labels["lease"], req.ID)
+		leaseID := core.Blank(server.Labels["lease"], req.ID)
 		target := sshTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
 		useStoredTestboxKey(&target, leaseID)
 		return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
@@ -531,7 +531,7 @@ func rollbackHetznerAcquire(client hetznerClient, server Server, serverCreated b
 	return nil
 }
 func parseServerID(s string) (int64, bool) { return core.ParseServerID(s) }
-func blank(value, fallback string) string  { return core.Blank(value, fallback) }
+
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
 	shared.UseStoredTestboxKey(target, leaseID)
 }

--- a/internal/providers/hetzner/checkpoint.go
+++ b/internal/providers/hetzner/checkpoint.go
@@ -176,7 +176,7 @@ func (Provider) VerifyNativeCheckpoint(ctx context.Context, req core.NativeCheck
 	} else if failedHetznerSnapshotState(state) {
 		next = "delete"
 	}
-	return core.NativeCheckpointVerifyResult{ProviderState: blank(state, "unknown"), NextAction: next}, nil
+	return core.NativeCheckpointVerifyResult{ProviderState: core.Blank(state, "unknown"), NextAction: next}, nil
 }
 
 func (Provider) DeleteNativeCheckpoint(ctx context.Context, req core.NativeCheckpointResourceRequest) error {
@@ -220,7 +220,7 @@ func validateHetznerSnapshot(req core.NativeCheckpointResourceRequest, snapshot 
 		return core.Exit(2, "refusing to operate on a non-direct Hetzner checkpoint record")
 	}
 	if snapshot.Type != "snapshot" {
-		return core.Exit(2, "refusing to operate on Hetzner image %d with type=%s", snapshot.ID, blank(snapshot.Type, "unknown"))
+		return core.Exit(2, "refusing to operate on Hetzner image %d with type=%s", snapshot.ID, core.Blank(snapshot.Type, "unknown"))
 	}
 	if strconv.FormatInt(snapshot.ID, 10) != strings.TrimSpace(req.Image.ID) {
 		return core.Exit(2, "refusing to operate on a mismatched Hetzner snapshot identity")
@@ -287,7 +287,7 @@ func waitForHetznerSnapshot(ctx context.Context, client hetznerSnapshotClient, i
 	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	timeoutError := func() error {
-		return core.Exit(5, "timed out waiting for Hetzner snapshot %d; last state=%s", last.ID, blank(last.Status, "unknown"))
+		return core.Exit(5, "timed out waiting for Hetzner snapshot %d; last state=%s", last.ID, core.Blank(last.Status, "unknown"))
 	}
 	waitError := func(err error) error {
 		if parentErr := ctx.Err(); parentErr != nil {
@@ -347,7 +347,7 @@ func waitForHetznerSnapshot(ctx context.Context, client hetznerSnapshotClient, i
 				return true, nil
 			}
 			if failedHetznerSnapshotState(state) {
-				return false, core.Exit(5, "Hetzner snapshot %d failed; last state=%s", last.ID, blank(last.Status, "unknown"))
+				return false, core.Exit(5, "Hetzner snapshot %d failed; last state=%s", last.ID, core.Blank(last.Status, "unknown"))
 			}
 			if parentErr := ctx.Err(); parentErr != nil {
 				return false, parentErr
@@ -364,7 +364,7 @@ func waitForHetznerSnapshot(ctx context.Context, client hetznerSnapshotClient, i
 		},
 		func(shared.PollResult[core.HetznerImage]) {
 			if stderr != nil {
-				fmt.Fprintf(stderr, "waiting image=%d state=%s\n", last.ID, blank(last.Status, "creating"))
+				fmt.Fprintf(stderr, "waiting image=%d state=%s\n", last.ID, core.Blank(last.Status, "creating"))
 			}
 		})
 	if err != nil {
@@ -378,7 +378,7 @@ func validateCreatedHetznerSnapshot(snapshot core.HetznerImage, expectedArchitec
 		return core.Exit(5, "Hetzner returned image %d with unexpected type=%s", snapshot.ID, snapshot.Type)
 	}
 	if snapshot.Architecture != expectedArchitecture {
-		return core.Exit(5, "Hetzner snapshot %d architecture=%s does not match source architecture=%s", snapshot.ID, blank(snapshot.Architecture, "unknown"), expectedArchitecture)
+		return core.Exit(5, "Hetzner snapshot %d architecture=%s does not match source architecture=%s", snapshot.ID, core.Blank(snapshot.Architecture, "unknown"), expectedArchitecture)
 	}
 	return nil
 }
@@ -404,7 +404,7 @@ func hetznerServerArchitecture(server Server) (string, error) {
 	case "arm", "arm64", "aarch64":
 		return "arm", nil
 	default:
-		return "", core.Exit(2, "Hetzner source server %s has unsupported architecture=%s", server.DisplayID(), blank(value, "unknown"))
+		return "", core.Exit(2, "Hetzner source server %s has unsupported architecture=%s", server.DisplayID(), core.Blank(value, "unknown"))
 	}
 }
 
@@ -415,7 +415,7 @@ func coreArchitectureFromHetzner(value string) (string, error) {
 	case "arm":
 		return core.ArchitectureARM64, nil
 	default:
-		return "", core.Exit(2, "unsupported Hetzner snapshot architecture=%s", blank(value, "unknown"))
+		return "", core.Exit(2, "unsupported Hetzner snapshot architecture=%s", core.Blank(value, "unknown"))
 	}
 }
 

--- a/internal/providers/hostinger/backend.go
+++ b/internal/providers/hostinger/backend.go
@@ -763,10 +763,10 @@ func (b *leaseBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResul
 		Check:   "purchase-options",
 		Message: purchaseMessage,
 		Details: map[string]string{
-			"configured_item_id":           blank(strings.TrimSpace(b.cfg.Hostinger.ItemID), "missing"),
-			"configured_payment_method_id": blank(strings.TrimSpace(b.cfg.Hostinger.PaymentMethodID), "auto"),
-			"configured_template_id":       blank(strings.TrimSpace(b.cfg.Hostinger.TemplateID), "missing"),
-			"configured_data_center_id":    blank(strings.TrimSpace(b.cfg.Hostinger.DataCenterID), "missing"),
+			"configured_item_id":           core.Blank(strings.TrimSpace(b.cfg.Hostinger.ItemID), "missing"),
+			"configured_payment_method_id": core.Blank(strings.TrimSpace(b.cfg.Hostinger.PaymentMethodID), "auto"),
+			"configured_template_id":       core.Blank(strings.TrimSpace(b.cfg.Hostinger.TemplateID), "missing"),
+			"configured_data_center_id":    core.Blank(strings.TrimSpace(b.cfg.Hostinger.DataCenterID), "missing"),
 			"priced_items":                 summarizeHostingerCatalog(options.catalog),
 			"payment_methods":              summarizeHostingerPaymentMethods(options.paymentMethods),
 			"templates":                    summarizeHostingerTemplates(options.templates),
@@ -918,17 +918,17 @@ func validateHostingerPurchaseOptions(cfg Config, options hostingerPurchaseOptio
 	}
 	itemID := strings.TrimSpace(cfg.Hostinger.ItemID)
 	if itemID == "" {
-		return 0, exit(2, "provider=%s configured item id %q is not a current priced VPS item; available=%s", providerName, blank(itemID, "missing"), blank(summarizeHostingerCatalog(options.catalog), "none"))
+		return 0, exit(2, "provider=%s configured item id %q is not a current priced VPS item; available=%s", providerName, core.Blank(itemID, "missing"), core.Blank(summarizeHostingerCatalog(options.catalog), "none"))
 	}
 
 	templateID := strings.TrimSpace(cfg.Hostinger.TemplateID)
 	if templateID == "" {
-		return 0, exit(2, "provider=%s configured template id %q is unavailable; available=%s", providerName, blank(templateID, "missing"), blank(summarizeHostingerTemplates(options.templates), "none"))
+		return 0, exit(2, "provider=%s configured template id %q is unavailable; available=%s", providerName, core.Blank(templateID, "missing"), core.Blank(summarizeHostingerTemplates(options.templates), "none"))
 	}
 
 	dataCenterID := strings.TrimSpace(cfg.Hostinger.DataCenterID)
 	if dataCenterID == "" {
-		return 0, exit(2, "provider=%s configured data center id %q is unavailable; available=%s", providerName, blank(dataCenterID, "missing"), blank(summarizeHostingerDataCenters(options.dataCenters), "none"))
+		return 0, exit(2, "provider=%s configured data center id %q is unavailable; available=%s", providerName, core.Blank(dataCenterID, "missing"), core.Blank(summarizeHostingerDataCenters(options.dataCenters), "none"))
 	}
 
 	configuredPaymentID := strings.TrimSpace(cfg.Hostinger.PaymentMethodID)
@@ -950,7 +950,7 @@ func validateHostingerPurchaseOptions(cfg Config, options hostingerPurchaseOptio
 		selected = id
 	}
 	if selected == "" {
-		return 0, exit(2, "provider=%s requires an active default Hostinger payment method or --hostinger-payment-method-id; available=%s", providerName, blank(summarizeHostingerPaymentMethods(options.paymentMethods), "none"))
+		return 0, exit(2, "provider=%s requires an active default Hostinger payment method or --hostinger-payment-method-id; available=%s", providerName, core.Blank(summarizeHostingerPaymentMethods(options.paymentMethods), "none"))
 	}
 	return hostingerIntegerID("payment method id", selected)
 }
@@ -968,7 +968,7 @@ func validateHostingerConfiguredPurchaseOptions(cfg Config, options hostingerPur
 			}
 		}
 		if !found {
-			return exit(2, "provider=%s configured item id %q is not a current priced VPS item; available=%s", providerName, itemID, blank(summarizeHostingerCatalog(options.catalog), "none"))
+			return exit(2, "provider=%s configured item id %q is not a current priced VPS item; available=%s", providerName, itemID, core.Blank(summarizeHostingerCatalog(options.catalog), "none"))
 		}
 	}
 
@@ -982,7 +982,7 @@ func validateHostingerConfiguredPurchaseOptions(cfg Config, options hostingerPur
 			}
 		}
 		if hostingerIDString(selected.ID) == "" {
-			return exit(2, "provider=%s configured template id %q is unavailable; available=%s", providerName, templateID, blank(summarizeHostingerTemplates(options.templates), "none"))
+			return exit(2, "provider=%s configured template id %q is unavailable; available=%s", providerName, templateID, core.Blank(summarizeHostingerTemplates(options.templates), "none"))
 		}
 		if !hostingerTemplateSupported(selected) {
 			return exit(2, "provider=%s template %s=%s is unsupported; choose an Ubuntu or Debian template so Crabbox can install required SSH tools before readiness", providerName, templateID, firstNonBlank(selected.Name, selected.OS))
@@ -999,7 +999,7 @@ func validateHostingerConfiguredPurchaseOptions(cfg Config, options hostingerPur
 			}
 		}
 		if !found {
-			return exit(2, "provider=%s configured data center id %q is unavailable; available=%s", providerName, dataCenterID, blank(summarizeHostingerDataCenters(options.dataCenters), "none"))
+			return exit(2, "provider=%s configured data center id %q is unavailable; available=%s", providerName, dataCenterID, core.Blank(summarizeHostingerDataCenters(options.dataCenters), "none"))
 		}
 	}
 
@@ -1015,11 +1015,11 @@ func validateHostingerConfiguredPurchaseOptions(cfg Config, options hostingerPur
 			continue
 		}
 		if method.IsExpired || method.IsSuspended {
-			return exit(2, "provider=%s configured payment method id %q is not active; available=%s", providerName, paymentID, blank(summarizeHostingerPaymentMethods(options.paymentMethods), "none"))
+			return exit(2, "provider=%s configured payment method id %q is not active; available=%s", providerName, paymentID, core.Blank(summarizeHostingerPaymentMethods(options.paymentMethods), "none"))
 		}
 		return nil
 	}
-	return exit(2, "provider=%s configured payment method id %q is unavailable; available=%s", providerName, paymentID, blank(summarizeHostingerPaymentMethods(options.paymentMethods), "none"))
+	return exit(2, "provider=%s configured payment method id %q is unavailable; available=%s", providerName, paymentID, core.Blank(summarizeHostingerPaymentMethods(options.paymentMethods), "none"))
 }
 
 func hostingerTemplateSupported(template hostingerTemplate) bool {

--- a/internal/providers/hostinger/client.go
+++ b/internal/providers/hostinger/client.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -159,7 +160,7 @@ func newClient(cfg Config, rt Runtime) (hostingerAPI, error) {
 	if token == "" {
 		return nil, exit(2, "provider=%s requires HOSTINGER_API_TOKEN (CRABBOX_HOSTINGER_API_TOKEN also accepted)", providerName)
 	}
-	apiURL := strings.TrimRight(strings.TrimSpace(blank(cfg.Hostinger.APIURL, "https://developers.hostinger.com")), "/")
+	apiURL := strings.TrimRight(strings.TrimSpace(core.Blank(cfg.Hostinger.APIURL, "https://developers.hostinger.com")), "/")
 	parsed, err := url.Parse(apiURL)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return nil, exit(2, "%s url %q is invalid", providerName, apiURL)

--- a/internal/providers/hostinger/core.go
+++ b/internal/providers/hostinger/core.go
@@ -40,10 +40,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseID() string {
 	return core.NewLeaseID()
 }

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -368,7 +368,7 @@ func pruneLeaseState(leaseID string) {
 }
 
 func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
-	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, blank(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
+	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, core.Blank(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
 }
 
 func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
@@ -408,10 +408,10 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 			continue
 		}
 		if req.DryRun {
-			fmt.Fprintf(b.rt.Stdout, "would remove instance name=%s lease=%s reason=%s\n", inst.Name, blank(claim.LeaseID, "-"), reason)
+			fmt.Fprintf(b.rt.Stdout, "would remove instance name=%s lease=%s reason=%s\n", inst.Name, core.Blank(claim.LeaseID, "-"), reason)
 			continue
 		}
-		fmt.Fprintf(b.rt.Stdout, "remove instance name=%s lease=%s reason=%s\n", inst.Name, blank(claim.LeaseID, "-"), reason)
+		fmt.Fprintf(b.rt.Stdout, "remove instance name=%s lease=%s reason=%s\n", inst.Name, core.Blank(claim.LeaseID, "-"), reason)
 		if err := b.removeVM(ctx, inst.Name); err != nil {
 			return err
 		}
@@ -430,14 +430,14 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 			continue
 		}
 		if ready, reason := missingClaimCleanupReady(claim, now); !ready {
-			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s slug=%s reason=%s\n", claim.LeaseID, blank(claim.Slug, "-"), reason)
+			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s slug=%s reason=%s\n", claim.LeaseID, core.Blank(claim.Slug, "-"), reason)
 			continue
 		}
 		if req.DryRun {
-			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing instance\n", claim.LeaseID, blank(claim.Slug, "-"))
+			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing instance\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 			continue
 		}
-		fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing instance\n", claim.LeaseID, blank(claim.Slug, "-"))
+		fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing instance\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 		if name := instanceNameFromClaim(claim); name != "" {
 			if err := b.removeVMStorage(name, nil); err != nil {
 				return err
@@ -1354,7 +1354,7 @@ func shouldCleanup(server Server, claim core.LeaseClaim, hasClaim bool, now time
 		return false, "missing claim"
 	}
 	if server.Status != "running" && server.Status != "ready" {
-		return true, "instance state=" + blank(server.Status, "unknown")
+		return true, "instance state=" + core.Blank(server.Status, "unknown")
 	}
 	expiresAt := strings.TrimSpace(server.Labels["expires_at"])
 	if expiresAt == "" {

--- a/internal/providers/hyperv/core.go
+++ b/internal/providers/hyperv/core.go
@@ -38,10 +38,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseID() string {
 	return core.NewLeaseID()
 }

--- a/internal/providers/lume/backend.go
+++ b/internal/providers/lume/backend.go
@@ -210,7 +210,7 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		}
 	}()
 	cfg.SSHKey = keyPath
-	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s base=%s storage=%s keep=%v\n", providerName, leaseID, slug, cfg.Lume.Base, blank(cfg.Lume.Storage, "home"), req.Keep)
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s base=%s storage=%s keep=%v\n", providerName, leaseID, slug, cfg.Lume.Base, core.Blank(cfg.Lume.Storage, "home"), req.Keep)
 	launchToken, err := newLaunchToken()
 	if err != nil {
 		return LeaseTarget{}, err
@@ -450,7 +450,7 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 		return lease, nil
 	}
 	if !instanceRunning(inst.Status) {
-		return LeaseTarget{}, exit(5, "Lume VM %s is %s; start a new lease or clean it up", inst.Name, blank(inst.Status, "not running"))
+		return LeaseTarget{}, exit(5, "Lume VM %s is %s; start a new lease or clean it up", inst.Name, core.Blank(inst.Status, "not running"))
 	}
 	lease, err = b.prepareLease(ctx, cfg, inst, claim, false)
 	if err != nil {
@@ -537,7 +537,7 @@ func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, 
 		return DoctorResult{}, exit(2, "Lume base VM %q must be stopped, found %s", cfg.Lume.Base, baseState)
 	}
 	if !strings.EqualFold(baseOS, targetMacOS) {
-		return DoctorResult{}, exit(2, "Lume base VM %q must run macOS, found %s", cfg.Lume.Base, blank(baseOS, "unknown"))
+		return DoctorResult{}, exit(2, "Lume base VM %q must run macOS, found %s", cfg.Lume.Base, core.Blank(baseOS, "unknown"))
 	}
 	probe := "unchecked"
 	if req.ProbeSSH {
@@ -628,7 +628,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 }
 
 func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
-	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, blank(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
+	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, core.Blank(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
 }
 
 func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
@@ -697,7 +697,7 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 					return observeErr
 				}
 				if !stillMissing {
-					return exit(4, "refusing to remove Lume claim %s after VM %q reappeared in state %s", claim.LeaseID, name, blank(state, "unknown"))
+					return exit(4, "refusing to remove Lume claim %s after VM %q reappeared in state %s", claim.LeaseID, name, core.Blank(state, "unknown"))
 				}
 				if ownerProcessMatches(owner) {
 					return exit(5, "refusing to remove missing Lume claim %s while owner pid %d is still running", claim.LeaseID, owner.PID)
@@ -1980,7 +1980,7 @@ func firstLine(value string) string {
 	if idx := strings.IndexByte(value, '\n'); idx >= 0 {
 		value = value[:idx]
 	}
-	return blank(strings.TrimSpace(value), "unknown")
+	return core.Blank(strings.TrimSpace(value), "unknown")
 }
 
 func firstNonBlank(values ...string) string {

--- a/internal/providers/lume/core.go
+++ b/internal/providers/lume/core.go
@@ -40,10 +40,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseID() string {
 	return core.NewLeaseID()
 }

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -249,11 +249,11 @@ func (b *backend) preflightSSHKey(ctx context.Context, name string) error {
 	}
 	fileName := strings.TrimSpace(key.FileName)
 	if fileName == "" || filepath.IsAbs(fileName) || fileName == "." || fileName == ".." || strings.ContainsAny(fileName, `/\`) || filepath.Base(fileName) != fileName {
-		return exit(2, "Machine0 PUBLIC SSH key %q has no usable local private-key filename; select a managed key with --machine0-key <managed-key-name>", blank(key.Name, "<default>"))
+		return exit(2, "Machine0 PUBLIC SSH key %q has no usable local private-key filename; select a managed key with --machine0-key <managed-key-name>", core.Blank(key.Name, "<default>"))
 	}
 	keyRoot, err := machine0SSHKeyDirectory()
 	if err != nil {
-		return exit(2, "resolve private key for Machine0 PUBLIC SSH key %q: set SSH_KEY_PATH or select --machine0-key <managed-key-name>", blank(key.Name, "<default>"))
+		return exit(2, "resolve private key for Machine0 PUBLIC SSH key %q: set SSH_KEY_PATH or select --machine0-key <managed-key-name>", core.Blank(key.Name, "<default>"))
 	}
 	keyPath := filepath.Join(keyRoot, fileName)
 	info, err := b.stat(keyPath)
@@ -283,9 +283,9 @@ func (b *backend) preflightSSHKey(ctx context.Context, name string) error {
 		return nil
 	}
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return exit(2, "inspect private key for Machine0 PUBLIC SSH key %q at %q: %v", blank(key.Name, "<default>"), keyPath, err)
+		return exit(2, "inspect private key for Machine0 PUBLIC SSH key %q at %q: %v", core.Blank(key.Name, "<default>"), keyPath, err)
 	}
-	return exit(2, "Machine0 PUBLIC SSH key %q has no local private key at %q; select a managed key with --machine0-key <managed-key-name>", blank(key.Name, "<default>"), keyPath)
+	return exit(2, "Machine0 PUBLIC SSH key %q has no local private key at %q; select a managed key with --machine0-key <managed-key-name>", core.Blank(key.Name, "<default>"), keyPath)
 }
 
 func machine0SSHKeyDirectory() (string, error) {
@@ -547,7 +547,7 @@ func (b *backend) AuthorizeStatusTouchClaim(_ context.Context, lease LeaseTarget
 	if !core.IsCanonicalLeaseID(lease.LeaseID) || claim.LeaseID != lease.LeaseID ||
 		lease.Server.Provider != providerName || !isMachine0ClaimProvider(claim.Provider) ||
 		resourceID == "" || lease.Server.ImmutableID != resourceID || claim.CloudImmutableID != resourceID {
-		return exit(4, "refusing machine0 lifecycle touch for lease=%s resource=%s: claim does not match the canonical lease, provider, or immutable Machine0 identity", lease.LeaseID, blank(resourceID, "<empty>"))
+		return exit(4, "refusing machine0 lifecycle touch for lease=%s resource=%s: claim does not match the canonical lease, provider, or immutable Machine0 identity", lease.LeaseID, core.Blank(resourceID, "<empty>"))
 	}
 	if err := validateMachineClaimOwnership(claim, machine{ID: resourceID}); err != nil {
 		return exit(4, "refusing machine0 lifecycle touch for lease=%s resource=%s: %v", lease.LeaseID, resourceID, err)
@@ -735,7 +735,7 @@ func (b *backend) RetainLeaseClaimAfterReleaseWithClaim(lease LeaseTarget, previ
 
 func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
 	action := normalizeReleasePolicy(b.configForRun().Machine0.ReleasePolicy)
-	return fmt.Sprintf("released lease=%s machine=%s action=%s", lease.LeaseID, blank(lease.Server.Name, "-"), action)
+	return fmt.Sprintf("released lease=%s machine=%s action=%s", lease.LeaseID, core.Blank(lease.Server.Name, "-"), action)
 }
 
 func (b *backend) Pause(ctx context.Context, req PauseRequest) error {
@@ -890,7 +890,7 @@ func (b *backend) validateCatalogSelection(ctx context.Context, sizeName, region
 				return nil
 			}
 		}
-		return exit(2, "machine0 size %q is not currently available in region %q; available regions: %s", sizeName, region, blank(strings.Join(size.Regions, ","), "none"))
+		return exit(2, "machine0 size %q is not currently available in region %q; available regions: %s", sizeName, region, core.Blank(strings.Join(size.Regions, ","), "none"))
 	}
 	available := make([]string, 0, len(sizes))
 	for _, size := range sizes {
@@ -1038,9 +1038,9 @@ func (b *backend) pollMachine(
 	}, nil)
 	if err != nil && context.Cause(ctx) == nil && errors.Is(context.Cause(waitCtx), context.DeadlineExceeded) && errors.Is(err, context.DeadlineExceeded) {
 		if target == "" {
-			err = exit(5, "timed out waiting for machine0 machine %s; last state=%s", name, blank(result.Value.Status, "unknown"))
+			err = exit(5, "timed out waiting for machine0 machine %s; last state=%s", name, core.Blank(result.Value.Status, "unknown"))
 		} else {
-			err = exit(5, "timed out waiting for machine0 machine %s to reach %s; last state=%s", name, target, blank(result.Value.Status, "unknown"))
+			err = exit(5, "timed out waiting for machine0 machine %s to reach %s; last state=%s", name, target, core.Blank(result.Value.Status, "unknown"))
 		}
 	}
 	return result.Value, err
@@ -1277,7 +1277,7 @@ func validateMachineClaimOwnership(claim LeaseClaim, item machine) error {
 		return fmt.Errorf("Machine0 id mismatch: claim=%s machine=%s", claim.CloudID, item.ID)
 	}
 	if claim.ProviderScope != machineScope(item.ID) {
-		return fmt.Errorf("provider scope mismatch: claim=%s machine=%s", blank(claim.ProviderScope, "missing"), machineScope(item.ID))
+		return fmt.Errorf("provider scope mismatch: claim=%s machine=%s", core.Blank(claim.ProviderScope, "missing"), machineScope(item.ID))
 	}
 	return nil
 }
@@ -1381,7 +1381,7 @@ func shouldCleanupMachine0(server Server, claim LeaseClaim, hasClaim bool, now t
 		return false, "missing claim"
 	}
 	if machineStopped(server.Labels["machine0_status"]) || machineTerminal(server.Labels["machine0_status"]) {
-		return true, "machine state=" + blank(server.Labels["machine0_status"], "unknown")
+		return true, "machine state=" + core.Blank(server.Labels["machine0_status"], "unknown")
 	}
 	lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
 	if err != nil || lastUsed.IsZero() || claim.IdleTimeoutSeconds <= 0 {
@@ -1442,7 +1442,7 @@ func machineTerminal(value string) bool {
 	return value == "ERRORED" || value == "UNAVAILABLE"
 }
 func terminalMachineError(item machine) error {
-	return exit(5, "machine0 machine %s entered terminal state %s: %s", item.Name, item.Status, blank(item.LastErrorMessage, "run `machine0 get "+item.Name+" --json` for diagnostics"))
+	return exit(5, "machine0 machine %s entered terminal state %s: %s", item.Name, item.Status, core.Blank(item.LastErrorMessage, "run `machine0 get "+item.Name+" --json` for diagnostics"))
 }
 func sleepContext(ctx context.Context, delay time.Duration) error {
 	timer := time.NewTimer(delay)

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -214,7 +214,7 @@ func (f *fakeAPI) GetImage(ctx context.Context, name string) (machineImageDetail
 func (f *fakeAPI) recordImageSnapshot(detail machineImageDetail) {
 	state := "MISSING"
 	if len(detail.Versions) > 0 {
-		state = strings.ToUpper(blank(detail.Versions[0].SnapshotStatus, "UNKNOWN"))
+		state = strings.ToUpper(core.Blank(detail.Versions[0].SnapshotStatus, "UNKNOWN"))
 	}
 	f.actions = append(f.actions, "image:"+state)
 	if state == "READY" {
@@ -873,7 +873,7 @@ func TestAcquirePreflightsPublicSSHKeyBeforeCreate(t *testing.T) {
 		{name: "managed key can materialize later", key: machineKey{Name: "managed-key", Type: "MANAGED", FileName: "machine0__managed-key"}},
 	} {
 		for _, leaseID := range []string{"", fixedMachine0TestLeaseID} {
-			t.Run(tc.name+"/"+blank(leaseID, "ordinary"), func(t *testing.T) {
+			t.Run(tc.name+"/"+core.Blank(leaseID, "ordinary"), func(t *testing.T) {
 				repo := setupState(t)
 				keyPath := filepath.Join(os.Getenv("SSH_KEY_PATH"), tc.key.FileName)
 				if tc.private != nil {
@@ -987,7 +987,7 @@ func TestAcquirePublicSSHKeyFileKinds(t *testing.T) {
 	}
 	for _, kind := range []string{"fifo", "symlink fifo", "device", "symlink regular"} {
 		for _, leaseID := range []string{"", fixedMachine0TestLeaseID} {
-			t.Run(kind+"/"+blank(leaseID, "ordinary"), func(t *testing.T) {
+			t.Run(kind+"/"+core.Blank(leaseID, "ordinary"), func(t *testing.T) {
 				repo := setupState(t)
 				keyPath := filepath.Join(os.Getenv("SSH_KEY_PATH"), "local-key")
 				target := keyPath + "-target"

--- a/internal/providers/machine0/client.go
+++ b/internal/providers/machine0/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	core "github.com/openclaw/crabbox/internal/cli"
 	"io"
 	"os/exec"
 	"regexp"
@@ -173,7 +174,7 @@ func (c *client) run(ctx context.Context, args ...string) (LocalCommandResult, e
 	if strings.Contains(lower, "not logged in") || strings.Contains(lower, "not authenticated") || strings.Contains(lower, "unauthorized") {
 		return result, exit(3, "Machine0 authentication is required; run `machine0 login` or set MACHINE0_API_TOKEN: %s", detail)
 	}
-	return result, exit(5, "machine0 %s failed: %s", strings.Join(args, " "), blank(detail, "unknown error"))
+	return result, exit(5, "machine0 %s failed: %s", strings.Join(args, " "), core.Blank(detail, "unknown error"))
 }
 
 func (c *client) runRead(ctx context.Context, args ...string) (LocalCommandResult, error) {
@@ -369,7 +370,7 @@ func (c *client) SelectedKey(ctx context.Context, name string) (*machineKey, err
 		return nil, exit(5, "parse machine0 keys get %s --json: %v", name, err)
 	}
 	if strings.TrimSpace(key.Name) != name {
-		return nil, exit(5, "machine0 key lookup returned mismatched key name: expected %s, found %s", name, blank(key.Name, "<empty>"))
+		return nil, exit(5, "machine0 key lookup returned mismatched key name: expected %s, found %s", name, core.Blank(key.Name, "<empty>"))
 	}
 	return &key, nil
 }

--- a/internal/providers/machine0/core.go
+++ b/internal/providers/machine0/core.go
@@ -42,8 +42,7 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string { return core.Blank(value, fallback) }
-func newLeaseID() string                  { return core.NewLeaseID() }
+func newLeaseID() string { return core.NewLeaseID() }
 
 func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (string, error) {
 	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)

--- a/internal/providers/machine0/fixed.go
+++ b/internal/providers/machine0/fixed.go
@@ -274,7 +274,7 @@ func validateFixedMachine0Ownership(claim LeaseClaim, item machine) error {
 		return exit(4, "lease_id_conflict: Machine0 machine %s has no durable create attempt", item.Name)
 	}
 	if strings.TrimSpace(item.ID) == "" || (claim.CloudID != "" && item.ID != claim.CloudID) {
-		return exit(4, "lease_id_conflict: fixed lease %s machine %s does not match acquired CloudID %s", claim.LeaseID, blank(item.ID, "<empty>"), blank(claim.CloudID, "<empty>"))
+		return exit(4, "lease_id_conflict: fixed lease %s machine %s does not match acquired CloudID %s", claim.LeaseID, core.Blank(item.ID, "<empty>"), core.Blank(claim.CloudID, "<empty>"))
 	}
 	if strings.TrimSpace(attempt.Key) != "" && (item.Key == nil || strings.TrimSpace(item.Key.Name) != strings.TrimSpace(attempt.Key)) {
 		return exit(4, "lease_id_conflict: Machine0 machine detail for fixed lease %s does not match its durable selected SSH key %q", claim.LeaseID, attempt.Key)

--- a/internal/providers/machine0/fixed_cleanup_test.go
+++ b/internal/providers/machine0/fixed_cleanup_test.go
@@ -264,7 +264,7 @@ func TestMachine0FixedPreparedStopCommand(t *testing.T) {
 			attempt := machine0CreateAttempt{Name: machine0MachineName(req.RequestedLeaseID, req.RequestedSlug), Size: cfg.Machine0.Size, Region: cfg.Machine0.Region, Image: cfg.Machine0.Image, Key: cfg.Machine0.Key, CreatedAt: time.Now().UTC().Format(time.RFC3339Nano)}
 			seedFixedMachine0PreparedClaim(t, b, req, &attempt)
 			item := fixedMachine0TestMachine(createMachineRequest{Name: attempt.Name, Size: attempt.Size, Region: attempt.Region, Image: attempt.Image})
-			item.Status, item.IP = blank(tc.state, "CREATING"), ""
+			item.Status, item.IP = core.Blank(tc.state, "CREATING"), ""
 			initial := readFixedMachine0Claim(t, req.RequestedLeaseID)
 			replacement := initial
 			intent := *initial.FixedCreateIntent

--- a/internal/providers/modal/backend.go
+++ b/internal/providers/modal/backend.go
@@ -390,11 +390,11 @@ func modalSandboxToServer(sandbox modalSandbox) Server {
 	server := Server{
 		Provider: providerName,
 		CloudID:  sandbox.ID,
-		Name:     blank(sandbox.Name, sandbox.ID),
+		Name:     core.Blank(sandbox.Name, sandbox.ID),
 		Status:   sandbox.Status,
 		Labels:   labels,
 	}
-	server.ServerType.Name = blank(labels["image"], "python:3.13-slim")
+	server.ServerType.Name = core.Blank(labels["image"], "python:3.13-slim")
 	return server
 }
 
@@ -402,7 +402,7 @@ func modalStatusView(leaseID, slug string, sandbox modalSandbox) StatusView {
 	server := modalSandboxToServer(sandbox)
 	return StatusView{
 		ID:         leaseID,
-		Slug:       blank(slug, modalSlug(leaseID, sandbox)),
+		Slug:       core.Blank(slug, modalSlug(leaseID, sandbox)),
 		Provider:   providerName,
 		TargetOS:   targetLinux,
 		State:      sandbox.Status,
@@ -442,15 +442,15 @@ func isCrabboxModalSandbox(sandbox modalSandbox) bool {
 }
 
 func modalApp(cfg Config) string {
-	return blank(strings.TrimSpace(cfg.Modal.App), core.ModalConfigDefaultApp)
+	return core.Blank(strings.TrimSpace(cfg.Modal.App), core.ModalConfigDefaultApp)
 }
 
 func modalImage(cfg Config) string {
-	return blank(strings.TrimSpace(cfg.Modal.Image), core.ModalConfigDefaultImage)
+	return core.Blank(strings.TrimSpace(cfg.Modal.Image), core.ModalConfigDefaultImage)
 }
 
 func modalWorkdir(cfg Config) string {
-	return blank(strings.TrimSpace(cfg.Modal.Workdir), core.ModalConfigDefaultWorkdir)
+	return core.Blank(strings.TrimSpace(cfg.Modal.Workdir), core.ModalConfigDefaultWorkdir)
 }
 
 func cleanModalWorkdir(workdir string) (string, error) {

--- a/internal/providers/modal/client.go
+++ b/internal/providers/modal/client.go
@@ -223,11 +223,11 @@ func (c *modalPythonClient) runStreamed(ctx context.Context, script string, payl
 }
 
 func (c *modalPythonClient) python() string {
-	return blank(strings.TrimSpace(c.cfg.Modal.Python), core.ModalConfigDefaultPython)
+	return core.Blank(strings.TrimSpace(c.cfg.Modal.Python), core.ModalConfigDefaultPython)
 }
 
 func (c *modalPythonClient) app() string {
-	return blank(strings.TrimSpace(c.cfg.Modal.App), core.ModalConfigDefaultApp)
+	return core.Blank(strings.TrimSpace(c.cfg.Modal.App), core.ModalConfigDefaultApp)
 }
 
 func (c *modalPythonClient) env() []string {

--- a/internal/providers/modal/core.go
+++ b/internal/providers/modal/core.go
@@ -40,10 +40,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseID() string {
 	return core.NewLeaseID()
 }

--- a/internal/providers/morph/backend.go
+++ b/internal/providers/morph/backend.go
@@ -330,8 +330,8 @@ func (b *morphLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseV
 		views = append(views, morphServer(instance, cfg, leaseID, slug))
 	}
 	sort.Slice(views, func(i, j int) bool {
-		left := blank(views[i].Labels["lease"], views[i].CloudID)
-		right := blank(views[j].Labels["lease"], views[j].CloudID)
+		left := core.Blank(views[i].Labels["lease"], views[i].CloudID)
+		right := core.Blank(views[j].Labels["lease"], views[j].CloudID)
 		return left < right
 	})
 	return views, nil
@@ -360,7 +360,7 @@ func (b *morphLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRe
 		instanceID = strings.TrimSpace(req.Lease.Server.Labels["instance_id"])
 	}
 	removeMissingInstance := func() error {
-		claim, ok, claimErr := resolveLeaseClaimForProvider(blank(leaseID, instanceID), providerName)
+		claim, ok, claimErr := resolveLeaseClaimForProvider(core.Blank(leaseID, instanceID), providerName)
 		if claimErr != nil {
 			return claimErr
 		}
@@ -369,7 +369,7 @@ func (b *morphLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRe
 		}
 		binding := shared.ClaimBinding{
 			Provider: providerName, ProviderScope: Provider{}.ClaimScope(cfg), ExactProviderScope: true,
-			LeaseID: claim.LeaseID, CloudID: blank(instanceID, claim.CloudID),
+			LeaseID: claim.LeaseID, CloudID: core.Blank(instanceID, claim.CloudID),
 		}
 		exact, claimErr := shared.RequireExactClaim(binding)
 		if claimErr != nil {
@@ -395,7 +395,7 @@ func (b *morphLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRe
 		}
 	}
 	if instance.ID == "" {
-		resolveID := blank(leaseID, instanceID)
+		resolveID := core.Blank(leaseID, instanceID)
 		if resolveID != "" {
 			resolved, resolvedLeaseID, _, resolveErr := b.resolveInstance(ctx, client, resolveID)
 			if resolveErr != nil {
@@ -483,7 +483,7 @@ func (b *morphLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRe
 		}); err != nil {
 			return err
 		}
-		removeStoredTestboxKey(blank(leaseID, instance.ID))
+		removeStoredTestboxKey(core.Blank(leaseID, instance.ID))
 		return nil
 	}
 	wasPaused := morphInstancePaused(instance)
@@ -511,7 +511,7 @@ func (b *morphLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRe
 }
 
 func (b *morphLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
-	instance := blank(blank(lease.Server.CloudID, lease.Server.Labels["instance_id"]), "-")
+	instance := core.Blank(core.Blank(lease.Server.CloudID, lease.Server.Labels["instance_id"]), "-")
 	if morphDeleteOnRelease(lease, b.configForRun()) {
 		return fmt.Sprintf("deleted lease=%s instance=%s", lease.LeaseID, instance)
 	}
@@ -539,7 +539,7 @@ func (b *morphLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server
 		instance, err = client.GetInstance(ctx, instanceID)
 		if err != nil {
 			if isMorphNotFound(err) {
-				return Server{}, exit(4, "lease %s not found for provider=%s", blank(leaseID, instanceID), providerName)
+				return Server{}, exit(4, "lease %s not found for provider=%s", core.Blank(leaseID, instanceID), providerName)
 			}
 			return Server{}, exit(1, "morph get instance %s failed: %v", instanceID, err)
 		}
@@ -547,7 +547,7 @@ func (b *morphLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server
 			return Server{}, exit(4, "morph instance %s is not managed by Crabbox", instance.ID)
 		}
 	} else {
-		instance, leaseID, slug, err = b.resolveInstance(ctx, client, blank(leaseID, slug))
+		instance, leaseID, slug, err = b.resolveInstance(ctx, client, core.Blank(leaseID, slug))
 		if err != nil {
 			return Server{}, err
 		}
@@ -559,7 +559,7 @@ func (b *morphLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server
 		instance.Metadata["idle_timeout"] = strconv.Itoa(int(req.IdleTimeout.Seconds()))
 		instance.Metadata["idle_timeout_secs"] = strconv.Itoa(int(req.IdleTimeout.Seconds()))
 	}
-	labels := morphLeaseMetadata(cfg, instance, blank(leaseID, instance.ID), slug, req.State, false, b.now().UTC(), true)
+	labels := morphLeaseMetadata(cfg, instance, core.Blank(leaseID, instance.ID), slug, req.State, false, b.now().UTC(), true)
 	if err := client.SetInstanceMetadata(ctx, instance.ID, labels); err != nil {
 		return Server{}, exit(1, "morph set metadata for %s failed: %v", instance.ID, err)
 	}
@@ -572,7 +572,7 @@ func (b *morphLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server
 		return Server{}, exit(1, "morph update wake-on for %s failed: %v", instance.ID, err)
 	}
 	instance.Metadata = labels
-	return morphServer(instance, cfg, blank(leaseID, instance.ID), slug), nil
+	return morphServer(instance, cfg, core.Blank(leaseID, instance.ID), slug), nil
 }
 
 func (b *morphLeaseBackend) api() (morphAPI, error) {
@@ -677,7 +677,7 @@ func (b *morphLeaseBackend) waitForInstanceReady(ctx context.Context, client mor
 			case morphInstanceReady(instance) || allowPaused && morphInstancePaused(instance):
 				return true, nil
 			case morphInstanceTerminal(instance):
-				return false, exit(1, "morph instance %s entered terminal state %q", instanceID, blank(instance.Status, "unknown"))
+				return false, exit(1, "morph instance %s entered terminal state %q", instanceID, core.Blank(instance.Status, "unknown"))
 			}
 			return false, nil
 		}, nil)
@@ -739,7 +739,7 @@ func applyMorphDefaults(cfg *Config) {
 	}
 	cfg.SSHPort = "22"
 	cfg.SSHFallbackPorts = nil
-	cfg.ServerType = blank(strings.TrimSpace(cfg.Morph.Snapshot), "snapshot")
+	cfg.ServerType = core.Blank(strings.TrimSpace(cfg.Morph.Snapshot), "snapshot")
 }
 
 func validateMorphConfig(cfg Config) error {
@@ -828,7 +828,7 @@ func morphLeaseMetadata(cfg Config, instance morphInstance, leaseID, slug, state
 	} else if strings.TrimSpace(labels["server_type"]) == "" && snapshotID != "" {
 		labels["server_type"] = snapshotID
 	}
-	if name := leaseProviderName(blank(leaseID, instance.ID), slug); name != "" {
+	if name := leaseProviderName(core.Blank(leaseID, instance.ID), slug); name != "" {
 		labels["lease_name"] = name
 	}
 	if strings.TrimSpace(labels["release"]) == "" {
@@ -840,7 +840,7 @@ func morphLeaseMetadata(cfg Config, instance morphInstance, leaseID, slug, state
 func morphServer(instance morphInstance, cfg Config, leaseID, slug string) Server {
 	labels := instance.Metadata.Clone()
 	if leaseID == "" {
-		leaseID = blank(strings.TrimSpace(labels["lease"]), instance.ID)
+		leaseID = core.Blank(strings.TrimSpace(labels["lease"]), instance.ID)
 	}
 	if slug == "" {
 		slug = strings.TrimSpace(labels["slug"])
@@ -885,18 +885,18 @@ func morphServer(instance morphInstance, cfg Config, leaseID, slug string) Serve
 	server := Server{
 		CloudID:  instance.ID,
 		Provider: providerName,
-		Name:     blank(labels["lease_name"], instance.ID),
+		Name:     core.Blank(labels["lease_name"], instance.ID),
 		Status:   state,
 		Labels:   labels,
 	}
-	server.ServerType.Name = blank(labels["server_type"], blank(labels["snapshot_id"], blank(cfg.ServerType, "snapshot")))
-	server.PublicNet.IPv4.IP = blank(strings.TrimSpace(cfg.Morph.SSHGatewayHost), core.MorphConfigDefaultSSHGatewayHost)
+	server.ServerType.Name = core.Blank(labels["server_type"], core.Blank(labels["snapshot_id"], core.Blank(cfg.ServerType, "snapshot")))
+	server.PublicNet.IPv4.IP = core.Blank(strings.TrimSpace(cfg.Morph.SSHGatewayHost), core.MorphConfigDefaultSSHGatewayHost)
 	return server
 }
 
 func morphSSHTarget(cfg Config, instance morphInstance, keyPath, knownHostsPath string) SSHTarget {
-	target := sshTargetFromConfig(cfg, blank(strings.TrimSpace(cfg.Morph.SSHGatewayHost), core.MorphConfigDefaultSSHGatewayHost))
-	target.Host = blank(strings.TrimSpace(cfg.Morph.SSHGatewayHost), core.MorphConfigDefaultSSHGatewayHost)
+	target := sshTargetFromConfig(cfg, core.Blank(strings.TrimSpace(cfg.Morph.SSHGatewayHost), core.MorphConfigDefaultSSHGatewayHost))
+	target.Host = core.Blank(strings.TrimSpace(cfg.Morph.SSHGatewayHost), core.MorphConfigDefaultSSHGatewayHost)
 	target.Port = "22"
 	target.User = instance.ID
 	target.Key = keyPath

--- a/internal/providers/morph/core.go
+++ b/internal/providers/morph/core.go
@@ -45,10 +45,6 @@ func asExitError(err error, target *ExitError) bool {
 	return core.AsExitError(err, target)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseID() string {
 	return core.NewLeaseID()
 }

--- a/internal/providers/multipass/backend.go
+++ b/internal/providers/multipass/backend.go
@@ -126,7 +126,7 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	}()
 	cfg.SSHKey = keyPath
 	name := leaseProviderName(leaseID, slug)
-	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%s disk=%s keep=%v\n", providerName, leaseID, slug, cfg.Multipass.Image, cfg.Multipass.CPUs, blank(cfg.Multipass.Memory, "-"), blank(cfg.Multipass.Disk, "-"), req.Keep)
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%s disk=%s keep=%v\n", providerName, leaseID, slug, cfg.Multipass.Image, cfg.Multipass.CPUs, core.Blank(cfg.Multipass.Memory, "-"), core.Blank(cfg.Multipass.Disk, "-"), req.Keep)
 	if err := b.createInstance(ctx, cfg, name, leaseID, slug, publicKey); err != nil {
 		_ = b.removeInstance(context.Background(), name)
 		return LeaseTarget{}, err
@@ -286,7 +286,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 }
 
 func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
-	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, blank(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
+	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, core.Blank(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
 }
 
 func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
@@ -322,10 +322,10 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 			continue
 		}
 		if req.DryRun {
-			fmt.Fprintf(b.rt.Stdout, "would remove instance name=%s lease=%s reason=%s\n", inst.Name, blank(claim.LeaseID, "-"), reason)
+			fmt.Fprintf(b.rt.Stdout, "would remove instance name=%s lease=%s reason=%s\n", inst.Name, core.Blank(claim.LeaseID, "-"), reason)
 			continue
 		}
-		fmt.Fprintf(b.rt.Stdout, "remove instance name=%s lease=%s reason=%s\n", inst.Name, blank(claim.LeaseID, "-"), reason)
+		fmt.Fprintf(b.rt.Stdout, "remove instance name=%s lease=%s reason=%s\n", inst.Name, core.Blank(claim.LeaseID, "-"), reason)
 		if err := b.removeInstance(ctx, inst.Name); err != nil {
 			return err
 		}
@@ -344,10 +344,10 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 			continue
 		}
 		if req.DryRun {
-			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing instance\n", claim.LeaseID, blank(claim.Slug, "-"))
+			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing instance\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 			continue
 		}
-		fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing instance\n", claim.LeaseID, blank(claim.Slug, "-"))
+		fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing instance\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 		removeLeaseClaim(claim.LeaseID)
 		removeStoredTestboxKey(claim.LeaseID)
 		claimsRemoved++
@@ -727,7 +727,7 @@ func shouldCleanup(server Server, claim core.LeaseClaim, hasClaim bool, now time
 		return false, "missing claim"
 	}
 	if !instanceRunning(server.Status) && server.Status != "ready" {
-		return true, "instance state=" + blank(server.Status, "unknown")
+		return true, "instance state=" + core.Blank(server.Status, "unknown")
 	}
 	lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
 	if err != nil || lastUsed.IsZero() {

--- a/internal/providers/multipass/core.go
+++ b/internal/providers/multipass/core.go
@@ -38,10 +38,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseID() string {
 	return core.NewLeaseID()
 }

--- a/internal/providers/namespace/backend.go
+++ b/internal/providers/namespace/backend.go
@@ -143,7 +143,7 @@ func restoreNamespaceClaimLabels(server *Server, claim LeaseClaim, claimOK bool,
 	}
 	state := "ready"
 	if server.Labels != nil {
-		state = blank(strings.TrimSpace(server.Labels["state"]), state)
+		state = core.Blank(strings.TrimSpace(server.Labels["state"]), state)
 	}
 	labels := touchDirectLeaseLabels(claim.Labels, cfg, state, time.Now().UTC())
 	for _, key := range []string{"lease", "name", "provider", "slug", "target"} {
@@ -618,12 +618,12 @@ func namespaceServer(name, leaseID, slug string, cfg Config, keep bool) Server {
 }
 
 func namespaceItemToServer(item namespaceListItem, cfg Config) Server {
-	name := blank(item.Name, item.ID)
+	name := core.Blank(item.Name, item.ID)
 	slug := namespaceSlugFromName(name)
 	leaseID := namespaceLeaseIDFromName(name)
 	labels := directLeaseLabels(cfg, leaseID, slug, namespaceProvider, "", true, time.Now().UTC())
 	labels["name"] = name
-	labels["state"] = blank(item.Status, "unknown")
+	labels["state"] = core.Blank(item.Status, "unknown")
 	labels["release"] = namespaceReleaseAction(cfg)
 	if item.Repository != "" {
 		labels["repo"] = item.Repository
@@ -638,7 +638,7 @@ func namespaceItemToServer(item namespaceListItem, cfg Config) Server {
 		Status:   labels["state"],
 		Labels:   labels,
 	}
-	server.ServerType.Name = blank(item.Size, namespaceSize(cfg))
+	server.ServerType.Name = core.Blank(item.Size, namespaceSize(cfg))
 	return server
 }
 
@@ -696,7 +696,7 @@ func resolveNamespaceDevboxName(identifier string, reclaim bool) (string, string
 			return "", "", "", exit(4, "%q is claimed by provider %s", identifier, claim.Provider)
 		}
 		_ = reclaim
-		slug := blank(claim.Slug, newLeaseSlug(claim.LeaseID))
+		slug := core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID))
 		if strings.HasPrefix(claim.LeaseID, "nsd_") {
 			return slug, claim.LeaseID, slug, nil
 		}
@@ -711,7 +711,7 @@ func resolveNamespaceDevboxName(identifier string, reclaim bool) (string, string
 }
 
 func namespaceImage(cfg Config) string {
-	return blank(strings.TrimSpace(cfg.Namespace.Image), core.NamespaceConfigDefaultImage)
+	return core.Blank(strings.TrimSpace(cfg.Namespace.Image), core.NamespaceConfigDefaultImage)
 }
 
 func namespaceSize(cfg Config) string {
@@ -739,7 +739,7 @@ func namespaceValidSize(value string) string {
 }
 
 func namespaceWorkRoot(cfg Config) string {
-	return blank(strings.TrimSpace(cfg.Namespace.WorkRoot), core.NamespaceConfigDefaultWorkRoot)
+	return core.Blank(strings.TrimSpace(cfg.Namespace.WorkRoot), core.NamespaceConfigDefaultWorkRoot)
 }
 
 func namespaceAutoStopIdleTimeout(cfg Config) time.Duration {

--- a/internal/providers/namespace/core.go
+++ b/internal/providers/namespace/core.go
@@ -41,10 +41,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func deleteOnReleaseExplicit(cfg Config) bool {
 	return core.DeleteOnReleaseExplicit(cfg, namespaceProvider)
 }

--- a/internal/providers/opencomputer/apiclient.go
+++ b/internal/providers/opencomputer/apiclient.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -99,7 +100,7 @@ func newOCAPIClient(cfg Config, rt Runtime) (*ocAPIClient, error) {
 	// API URL precedence: an explicit trusted Crabbox setting, then the `oc` CLI
 	// config file's api_url, then the built-in default. Repository YAML cannot
 	// populate cfg.OpenComputer.APIURL.
-	baseURL, err := validateOCAPIURL(blank(strings.TrimSpace(cfg.OpenComputer.APIURL), blank(strings.TrimSpace(fileCfg.APIURL), defaultAPIURL)))
+	baseURL, err := validateOCAPIURL(core.Blank(strings.TrimSpace(cfg.OpenComputer.APIURL), core.Blank(strings.TrimSpace(fileCfg.APIURL), defaultAPIURL)))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -185,7 +185,7 @@ func (b *openComputerBackend) List(ctx context.Context, req ListRequest) ([]Leas
 			if err := validateOpenComputerSandboxOwnership(claim, sb); err != nil {
 				return nil, err
 			}
-			state = blank(sb.Status, statusViewReady)
+			state = core.Blank(sb.Status, statusViewReady)
 		}
 		servers = append(servers, Server{
 			Provider: providerName,

--- a/internal/providers/opencomputer/core.go
+++ b/internal/providers/opencomputer/core.go
@@ -56,10 +56,6 @@ func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
 	return core.AllocateClaimLeaseSlug(leaseID, requested)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
 	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
 }

--- a/internal/providers/opensandbox/backend.go
+++ b/internal/providers/opensandbox/backend.go
@@ -294,7 +294,7 @@ func (b *openSandboxBackend) List(ctx context.Context, req ListRequest) ([]Lease
 			if err := validateOpenSandboxOwnership(claim, sb); err != nil {
 				return nil, err
 			}
-			state = blank(strings.ToLower(sb.State), statusViewReady)
+			state = core.Blank(strings.ToLower(sb.State), statusViewReady)
 		}
 		servers = append(servers, Server{
 			Provider: providerName,
@@ -508,13 +508,13 @@ func (b *openSandboxBackend) Cleanup(ctx context.Context, req CleanupRequest) er
 					return nil
 				}
 				if req.DryRun {
-					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 					return nil
 				}
 				if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 					return err
 				}
-				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 				claimRemovedOne = true
 				return nil
 			}

--- a/internal/providers/opensandbox/core.go
+++ b/internal/providers/opensandbox/core.go
@@ -68,10 +68,6 @@ func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
 	return core.AllocateClaimLeaseSlug(leaseID, requested)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
 	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
 }

--- a/internal/providers/orgo/backend.go
+++ b/internal/providers/orgo/backend.go
@@ -488,7 +488,7 @@ func (b *orgoBackend) claimLease(repo Repo, lease orgoLease, reclaim bool) error
 }
 
 func orgoClaimScope(cfg Config, workspaceID string) string {
-	endpoint := strings.TrimRight(strings.TrimSpace(blank(cfg.Orgo.APIBase, core.OrgoConfigDefaultAPIBase)), "/")
+	endpoint := strings.TrimRight(strings.TrimSpace(core.Blank(cfg.Orgo.APIBase, core.OrgoConfigDefaultAPIBase)), "/")
 	if parsed, err := url.Parse(endpoint); err == nil && parsed.Host != "" {
 		parsed.Scheme = strings.ToLower(parsed.Scheme)
 		parsed.Host = strings.ToLower(parsed.Host)
@@ -574,8 +574,8 @@ func (b *orgoBackend) deleteLease(ctx context.Context, client orgoAPI, lease org
 	if !exists {
 		return exit(2, "provider=%s lease=%s has no exact local ownership claim", providerName, lease.LeaseID)
 	}
-	computerID := blank(strings.TrimSpace(lease.Computer.ID), claim.CloudID)
-	workspaceID := blank(strings.TrimSpace(lease.Computer.WorkspaceID), claim.Labels[orgoWorkspaceLabel])
+	computerID := core.Blank(strings.TrimSpace(lease.Computer.ID), claim.CloudID)
+	workspaceID := core.Blank(strings.TrimSpace(lease.Computer.WorkspaceID), claim.Labels[orgoWorkspaceLabel])
 	binding := b.orgoClaimBinding(lease.LeaseID, lease.Slug, computerID, workspaceID)
 	claim, err = shared.RequireExactClaim(binding)
 	if err != nil {
@@ -748,7 +748,7 @@ func orgoComputerServer(computer orgoComputer, claim LeaseClaim) Server {
 	server := Server{
 		CloudID:  computer.ID,
 		Provider: providerName,
-		Name:     blank(computer.Name, computer.ID),
+		Name:     core.Blank(computer.Name, computer.ID),
 		Status:   normalizeOrgoStatus(computer.Status),
 		Labels:   labels,
 	}
@@ -764,14 +764,14 @@ func orgoComputerServer(computer orgoComputer, claim LeaseClaim) Server {
 func orgoStatusView(lease orgoLease) StatusView {
 	state := normalizeOrgoStatus(lease.Computer.Status)
 	return StatusView{
-		ID:         blank(lease.LeaseID, lease.Computer.ID),
+		ID:         core.Blank(lease.LeaseID, lease.Computer.ID),
 		Slug:       lease.Slug,
 		Provider:   providerName,
 		TargetOS:   targetLinux,
 		State:      state,
 		ServerID:   lease.Computer.ID,
 		ServerType: "orgo-computer",
-		Host:       blank(lease.Computer.ConnectionURL, lease.Computer.Hostname),
+		Host:       core.Blank(lease.Computer.ConnectionURL, lease.Computer.Hostname),
 		Network:    networkPublic,
 		Ready:      state == "running",
 		Labels: map[string]string{

--- a/internal/providers/orgo/backend_test.go
+++ b/internal/providers/orgo/backend_test.go
@@ -484,7 +484,7 @@ func TestStopRequiresExactOrgoEndpointWorkspaceAndComputerIdentity(t *testing.T)
 			currentAPI.computers[computer.ID] = computer
 			current := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{
 				APIKey:      "test-key",
-				APIBase:     blank(test.endpoint, "https://one.example.test/api"),
+				APIBase:     core.Blank(test.endpoint, "https://one.example.test/api"),
 				WorkspaceID: test.workspace,
 			}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 			current.client = currentAPI

--- a/internal/providers/orgo/core.go
+++ b/internal/providers/orgo/core.go
@@ -38,10 +38,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseID() string {
 	return core.NewLeaseID()
 }

--- a/internal/providers/railway/client.go
+++ b/internal/providers/railway/client.go
@@ -159,7 +159,7 @@ func newRailwayClient(cfg Config, rt Runtime) (railwayAPI, error) {
 	if apiToken == "" {
 		return nil, exit(2, "provider=%s requires RAILWAY_API_TOKEN", providerName)
 	}
-	apiURL := strings.TrimRight(strings.TrimSpace(blank(cfg.Railway.APIURL, core.RailwayConfigDefaultAPIURL)), "/")
+	apiURL := strings.TrimRight(strings.TrimSpace(core.Blank(cfg.Railway.APIURL, core.RailwayConfigDefaultAPIURL)), "/")
 	parsed, err := url.Parse(apiURL)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return nil, exit(2, "%s url %q is invalid", providerName, apiURL)

--- a/internal/providers/railway/core.go
+++ b/internal/providers/railway/core.go
@@ -37,10 +37,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func inventoryDoctorResult(provider string, leases int) DoctorResult {
 	return core.InventoryDoctorResult(provider, leases)
 }

--- a/internal/providers/runpod/backend.go
+++ b/internal/providers/runpod/backend.go
@@ -186,7 +186,7 @@ func (b *runpodLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (L
 	if claimed {
 		pod, err = b.resolveClaimedPod(ctx, client, claim, false)
 		leaseID = claim.LeaseID
-		slug = blank(claim.Slug, newLeaseSlug(claim.LeaseID))
+		slug = core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID))
 	} else {
 		pod, leaseID, slug, err = b.resolveUnclaimedPod(ctx, client, req.ID)
 		if err == nil {
@@ -449,7 +449,7 @@ func resolveRunpodClaim(identifier string) (LeaseClaim, bool, error) {
 	if claim, ok, exact, err := resolveLeaseClaimForProviderWithExact(identifier, providerName); err != nil {
 		return LeaseClaim{}, false, err
 	} else if exact && !ok {
-		return LeaseClaim{}, false, exit(2, "local claim %s belongs to provider=%s, not provider=%s", identifier, blank(claim.Provider, "<unknown>"), providerName)
+		return LeaseClaim{}, false, exit(2, "local claim %s belongs to provider=%s, not provider=%s", identifier, core.Blank(claim.Provider, "<unknown>"), providerName)
 	} else if exact {
 		return claim, true, nil
 	} else if ok {
@@ -512,7 +512,7 @@ func ensureRunpodAdoptionDoesNotRetargetClaim(leaseID string, pod runpodPod) err
 		return nil
 	}
 	if !ok {
-		return exit(2, "cannot adopt RunPod pod %s as lease %s because that local claim belongs to provider=%s", pod.ID, leaseID, blank(claim.Provider, "<unknown>"))
+		return exit(2, "cannot adopt RunPod pod %s as lease %s because that local claim belongs to provider=%s", pod.ID, leaseID, core.Blank(claim.Provider, "<unknown>"))
 	}
 	if !runpodClaimIsBound(claim) {
 		return nil
@@ -542,7 +542,7 @@ func (b *runpodLeaseBackend) resolveClaimedPod(ctx context.Context, client runpo
 	if strings.TrimSpace(claim.CloudID) != "" {
 		pod, err = client.GetPod(ctx, claim.CloudID)
 	} else {
-		slug := blank(claim.Slug, newLeaseSlug(claim.LeaseID))
+		slug := core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID))
 		pod, err = b.findPodByName(ctx, client, leaseProviderName(claim.LeaseID, slug))
 	}
 	if err != nil {
@@ -552,10 +552,10 @@ func (b *runpodLeaseBackend) resolveClaimedPod(ctx context.Context, client runpo
 		return pod, nil
 	}
 	if pod.ID != claim.CloudID {
-		return runpodPod{}, exit(2, "runpod claim %s expects pod %s but provider returned %s", claim.LeaseID, claim.CloudID, blank(pod.ID, "<empty>"))
+		return runpodPod{}, exit(2, "runpod claim %s expects pod %s but provider returned %s", claim.LeaseID, claim.CloudID, core.Blank(pod.ID, "<empty>"))
 	}
 	if name := strings.TrimSpace(claim.Labels["name"]); pod.Name != name {
-		return runpodPod{}, exit(2, "runpod claim %s expects pod name %s but provider returned %s", claim.LeaseID, name, blank(pod.Name, "<empty>"))
+		return runpodPod{}, exit(2, "runpod claim %s expects pod name %s but provider returned %s", claim.LeaseID, name, core.Blank(pod.Name, "<empty>"))
 	}
 	return pod, nil
 }
@@ -594,7 +594,7 @@ func (b *runpodLeaseBackend) resolveUnclaimedPod(ctx context.Context, client run
 }
 
 func unclaimedRunpodError(identifier string) error {
-	return exit(2, "runpod pod %s has no exact resource-bound local claim; adopt it from a reuse command with --reclaim before stopping it", blank(strings.TrimSpace(identifier), "<unknown>"))
+	return exit(2, "runpod pod %s has no exact resource-bound local claim; adopt it from a reuse command with --reclaim before stopping it", core.Blank(strings.TrimSpace(identifier), "<unknown>"))
 }
 
 func validateCreatedRunpodPod(pod runpodPod, expectedID, expectedName string) error {
@@ -604,9 +604,9 @@ func validateCreatedRunpodPod(pod runpodPod, expectedID, expectedName string) er
 		return nil
 	}
 	if mismatch.Field == "ID" {
-		return exit(1, "runpod create returned pod %s but readiness resolved %s", blank(expectedID, "<empty>"), blank(pod.ID, "<empty>"))
+		return exit(1, "runpod create returned pod %s but readiness resolved %s", core.Blank(expectedID, "<empty>"), core.Blank(pod.ID, "<empty>"))
 	}
-	return exit(1, "runpod create expected pod name %s but readiness returned %s", blank(expectedName, "<empty>"), blank(pod.Name, "<empty>"))
+	return exit(1, "runpod create expected pod name %s but readiness returned %s", core.Blank(expectedName, "<empty>"), core.Blank(pod.Name, "<empty>"))
 }
 
 func (b *runpodLeaseBackend) findPodByName(ctx context.Context, client runpodAPI, name string) (runpodPod, error) {
@@ -744,7 +744,7 @@ func runpodLeaseIdentity(name string) (string, string) {
 	name = strings.TrimSpace(name)
 	const prefix = "crabbox-"
 	if !strings.HasPrefix(name, prefix) {
-		slug := normalizeLeaseSlug(blank(name, "manual"))
+		slug := normalizeLeaseSlug(core.Blank(name, "manual"))
 		return "rpod_" + slug, slug
 	}
 	rest := strings.TrimPrefix(name, prefix)

--- a/internal/providers/runpod/core.go
+++ b/internal/providers/runpod/core.go
@@ -37,10 +37,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseID() string {
 	return core.NewLeaseID()
 }

--- a/internal/providers/smolvm/backend.go
+++ b/internal/providers/smolvm/backend.go
@@ -409,7 +409,7 @@ func machineToServer(cfg Config, m machineData) Server {
 	labels := directLeaseLabels(cfg, leaseID, machineSlug(leaseID, m), providerName, "", cfg.Smolvm.Keep, time.Now().UTC())
 	labels["machine_id"] = m.ID
 	labels["machine_name"] = m.Name
-	labels["image"] = blank(m.Source.Reference, imageName(cfg))
+	labels["image"] = core.Blank(m.Source.Reference, imageName(cfg))
 	if m.Resources.CPUs > 0 {
 		labels["cpus"] = fmt.Sprintf("%d", m.Resources.CPUs)
 	}
@@ -420,7 +420,7 @@ func machineToServer(cfg Config, m machineData) Server {
 	server := Server{
 		Provider: providerName,
 		CloudID:  m.ID,
-		Name:     blank(m.Name, m.ID),
+		Name:     core.Blank(m.Name, m.ID),
 		Status:   m.State,
 		Labels:   labels,
 	}
@@ -430,7 +430,7 @@ func machineToServer(cfg Config, m machineData) Server {
 }
 
 func machineBaseHost(cfg Config) string {
-	raw := blank(strings.TrimSpace(cfg.Smolvm.BaseURL), core.SmolvmConfigDefaultBaseURL)
+	raw := core.Blank(strings.TrimSpace(cfg.Smolvm.BaseURL), core.SmolvmConfigDefaultBaseURL)
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Host == "" {
 		return raw
@@ -468,7 +468,7 @@ func statusReady(status string) bool {
 }
 
 func imageName(cfg Config) string {
-	return blank(strings.TrimSpace(cfg.Smolvm.Image), core.SmolvmConfigDefaultImage)
+	return core.Blank(strings.TrimSpace(cfg.Smolvm.Image), core.SmolvmConfigDefaultImage)
 }
 
 func machineName(leaseID, slug string) string {
@@ -505,7 +505,7 @@ func networkMode(cfg Config) string {
 }
 
 func workdir(cfg Config) string {
-	return blank(strings.TrimSpace(cfg.Smolvm.Workdir), core.SmolvmConfigDefaultWorkdir)
+	return core.Blank(strings.TrimSpace(cfg.Smolvm.Workdir), core.SmolvmConfigDefaultWorkdir)
 }
 
 func cleanWorkdir(workdir string) (string, error) {

--- a/internal/providers/smolvm/client.go
+++ b/internal/providers/smolvm/client.go
@@ -160,7 +160,7 @@ var newAPI = func(cfg Config, rt Runtime) (api, error) {
 }
 
 func smolvmEndpoint(cfg Config) (string, error) {
-	base := blank(strings.TrimSpace(cfg.Smolvm.BaseURL), core.SmolvmConfigDefaultBaseURL)
+	base := core.Blank(strings.TrimSpace(cfg.Smolvm.BaseURL), core.SmolvmConfigDefaultBaseURL)
 	parsed, err := url.Parse(base)
 	if err != nil {
 		return "", exit(2, "%s url %q is invalid", providerName, base)

--- a/internal/providers/smolvm/core.go
+++ b/internal/providers/smolvm/core.go
@@ -39,10 +39,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseID() string {
 	return core.NewLeaseID()
 }

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -423,13 +423,13 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 					return nil
 				}
 				if req.DryRun {
-					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 					return nil
 				}
 				if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 					return err
 				}
-				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 				claimRemovedOne = true
 				return nil
 			}
@@ -770,7 +770,7 @@ func superserveCommandEnv(env map[string]string) (map[string]string, []string) {
 }
 
 func normalizedSandboxState(sb superserveSandbox) string {
-	return strings.ToLower(blank(strings.TrimSpace(sb.Status), blank(strings.TrimSpace(sb.State), "unknown")))
+	return strings.ToLower(core.Blank(strings.TrimSpace(sb.Status), core.Blank(strings.TrimSpace(sb.State), "unknown")))
 }
 
 func isReadyState(state string) bool {

--- a/internal/providers/superserve/client.go
+++ b/internal/providers/superserve/client.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -330,7 +331,7 @@ func (c *httpSuperserveClient) postAccess(ctx context.Context, apiPath string) (
 	if err := c.doJSON(ctx, http.MethodPost, apiPath, nil, &raw); err != nil {
 		return sandboxAccess{}, err
 	}
-	token := blank(raw.AccessToken, raw.Token)
+	token := core.Blank(raw.AccessToken, raw.Token)
 	if token == "" {
 		return sandboxAccess{}, exit(5, "superserve %s returned no access token", apiPath)
 	}
@@ -641,10 +642,10 @@ func (c *httpSuperserveClient) apiError(method, apiPath string, resp *http.Respo
 	if json.Unmarshal(body, &wrapped) == nil {
 		switch value := wrapped.Error.(type) {
 		case string:
-			msg = blank(value, blank(wrapped.Message, msg))
+			msg = core.Blank(value, core.Blank(wrapped.Message, msg))
 		case map[string]any:
 			if message, ok := value["message"].(string); ok {
-				msg = blank(message, blank(wrapped.Message, msg))
+				msg = core.Blank(message, core.Blank(wrapped.Message, msg))
 			}
 		}
 	}

--- a/internal/providers/superserve/core.go
+++ b/internal/providers/superserve/core.go
@@ -53,10 +53,6 @@ func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
 	return core.AllocateClaimLeaseSlug(leaseID, requested)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
 	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
 }

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -343,7 +343,7 @@ func pruneLeaseState(leaseID string) {
 }
 
 func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
-	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, blank(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
+	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, core.Blank(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
 }
 
 func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
@@ -402,7 +402,7 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 			continue
 		}
 		if req.DryRun {
-			fmt.Fprintf(b.rt.Stdout, "would remove instance name=%s lease=%s reason=%s\n", inst.Name, blank(claim.LeaseID, "-"), reason)
+			fmt.Fprintf(b.rt.Stdout, "would remove instance name=%s lease=%s reason=%s\n", inst.Name, core.Blank(claim.LeaseID, "-"), reason)
 			continue
 		}
 		if err := b.cleanupInstance(ctx, cfg, inst, claim, storage); err != nil {
@@ -428,16 +428,16 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		}
 		reason := "missing instance"
 		if req.DryRun {
-			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=%s\n", claim.LeaseID, blank(claim.Slug, "-"), reason)
+			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=%s\n", claim.LeaseID, core.Blank(claim.Slug, "-"), reason)
 			continue
 		}
 		// Acquisition creates or reuses the key before publishing its claim, so
 		// missing-instance cleanup cannot safely delete that key without a wider fence.
 		if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
-			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s slug=%s reason=changed-during-cleanup err=%v\n", claim.LeaseID, blank(claim.Slug, "-"), err)
+			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s slug=%s reason=changed-during-cleanup err=%v\n", claim.LeaseID, core.Blank(claim.Slug, "-"), err)
 			continue
 		}
-		fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=%s\n", claim.LeaseID, blank(claim.Slug, "-"), reason)
+		fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=%s\n", claim.LeaseID, core.Blank(claim.Slug, "-"), reason)
 		claimsRemoved++
 	}
 	if !req.DryRun {
@@ -886,7 +886,7 @@ func shouldCleanup(server Server, claim core.LeaseClaim, hasClaim bool, now time
 		return false, "missing claim"
 	}
 	if !instanceRunning(server.Status) && server.Status != "ready" {
-		return true, "instance state=" + blank(server.Status, "unknown")
+		return true, "instance state=" + core.Blank(server.Status, "unknown")
 	}
 	if hasClaim {
 		lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))

--- a/internal/providers/tart/core.go
+++ b/internal/providers/tart/core.go
@@ -39,10 +39,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseID() string {
 	return core.NewLeaseID()
 }

--- a/internal/providers/tart/provider_test.go
+++ b/internal/providers/tart/provider_test.go
@@ -4199,10 +4199,10 @@ func TestShouldCleanupEmptyStatus(t *testing.T) {
 }
 
 func TestBlankHelper(t *testing.T) {
-	if got := blank("value", "fallback"); got != "value" {
+	if got := core.Blank("value", "fallback"); got != "value" {
 		t.Fatalf("blank(\"value\", \"fallback\") = %q", got)
 	}
-	if got := blank("", "fallback"); got != "fallback" {
+	if got := core.Blank("", "fallback"); got != "fallback" {
 		t.Fatalf("blank(\"\", \"fallback\") = %q", got)
 	}
 }

--- a/internal/providers/tensorlake/cli.go
+++ b/internal/providers/tensorlake/cli.go
@@ -24,12 +24,12 @@ func newTensorlakeCLI(cfg Config, rt Runtime) (*tensorlakeCLI, error) {
 	if rt.Exec == nil {
 		return nil, exit(2, "provider=tensorlake requires Runtime.Exec")
 	}
-	apiURL, err := canonicalTensorlakeURL(blank(cfg.Tensorlake.APIURL, core.TensorlakeConfigDefaultAPIURL))
+	apiURL, err := canonicalTensorlakeURL(core.Blank(cfg.Tensorlake.APIURL, core.TensorlakeConfigDefaultAPIURL))
 	if err != nil {
 		return nil, err
 	}
 	cfg.Tensorlake.APIURL = apiURL
-	cfg.Tensorlake.Namespace = blank(strings.TrimSpace(cfg.Tensorlake.Namespace), "default")
+	cfg.Tensorlake.Namespace = core.Blank(strings.TrimSpace(cfg.Tensorlake.Namespace), "default")
 	if !validScopeValue(cfg.Tensorlake.Namespace) {
 		return nil, exit(2, "invalid Tensorlake namespace")
 	}
@@ -37,7 +37,7 @@ func newTensorlakeCLI(cfg Config, rt Runtime) (*tensorlakeCLI, error) {
 }
 
 func (c *tensorlakeCLI) binary() string {
-	return blank(strings.TrimSpace(c.cfg.Tensorlake.CLIPath), core.TensorlakeConfigDefaultCLIPath)
+	return core.Blank(strings.TrimSpace(c.cfg.Tensorlake.CLIPath), core.TensorlakeConfigDefaultCLIPath)
 }
 
 func (c *tensorlakeCLI) globalArgs() []string {

--- a/internal/providers/tensorlake/core.go
+++ b/internal/providers/tensorlake/core.go
@@ -58,10 +58,6 @@ func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
 	return core.AllocateClaimLeaseSlug(leaseID, requested)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func shellQuote(s string) string {
 	return core.ShellQuote(s)
 }

--- a/internal/providers/unikraftcloud/backend.go
+++ b/internal/providers/unikraftcloud/backend.go
@@ -193,7 +193,7 @@ func (b *backend) preflightCreateIntent(ctx context.Context, api unikraftCloudAP
 
 func (b *backend) finishWarmup(started time.Time, claim LeaseClaim, instance ukcInstance, req WarmupRequest) error {
 	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s instance=%s state=%s fqdn=%s\n",
-		claim.LeaseID, claim.Slug, providerName, instance.UUID, normalizedInstanceState(instance.State), blank(instanceFQDN(instance), "-"))
+		claim.LeaseID, claim.Slug, providerName, instance.UUID, normalizedInstanceState(instance.State), core.Blank(instanceFQDN(instance), "-"))
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: %s warmup keeps the instance until explicit stop or eligible cleanup\n", providerName)
 	}
@@ -438,7 +438,7 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 			labels[ukcLabelProviderState] = state
 		}
 		view := StatusView{
-			ID:         blank(leaseID, instance.UUID),
+			ID:         core.Blank(leaseID, instance.UUID),
 			Slug:       slug,
 			Provider:   providerName,
 			TargetOS:   targetLinux,
@@ -515,9 +515,9 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 		return err
 	}
 	if missing {
-		fmt.Fprintf(b.rt.Stderr, "warning: %s instance=%s was already gone; removed local claim\n", providerName, blank(instanceID, "pending"))
+		fmt.Fprintf(b.rt.Stderr, "warning: %s instance=%s was already gone; removed local claim\n", providerName, core.Blank(instanceID, "pending"))
 	}
-	fmt.Fprintf(b.rt.Stderr, "released lease=%s instance=%s\n", claim.LeaseID, blank(instanceID, "pending"))
+	fmt.Fprintf(b.rt.Stderr, "released lease=%s instance=%s\n", claim.LeaseID, core.Blank(instanceID, "pending"))
 	return nil
 }
 
@@ -533,7 +533,7 @@ func unikraftCloudServer(instance ukcInstance, claim LeaseClaim) Server {
 	return Server{
 		CloudID:  instance.UUID,
 		Provider: providerName,
-		Name:     blank(instance.Name, instance.UUID),
+		Name:     core.Blank(instance.Name, instance.UUID),
 		Status:   normalizedInstanceState(instance.State),
 		Labels:   labels,
 	}
@@ -575,5 +575,5 @@ func instanceFQDN(instance ukcInstance) string {
 }
 
 func normalizedInstanceState(state string) string {
-	return strings.ToLower(blank(strings.TrimSpace(state), "unknown"))
+	return strings.ToLower(core.Blank(strings.TrimSpace(state), "unknown"))
 }

--- a/internal/providers/unikraftcloud/client.go
+++ b/internal/providers/unikraftcloud/client.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -427,7 +428,7 @@ func (c *unikraftCloudClient) doInstances(ctx context.Context, method, apiPath s
 		return nil, c.unikraftCloudResponseError(envelope.Errors[0], unikraftCloudEnvelopeMessage(envelope))
 	}
 	if status == "partial_success" {
-		message := blank(strings.TrimSpace(envelope.Message), "instance operation only partially succeeded")
+		message := core.Blank(strings.TrimSpace(envelope.Message), "instance operation only partially succeeded")
 		return nil, &unikraftCloudAPIError{StatusCode: http.StatusInternalServerError, Message: redactSecret(message, c.apiKey)}
 	}
 	return envelope.Data.Instances, nil
@@ -519,7 +520,7 @@ func (c *unikraftCloudClient) unikraftCloudInstanceError(envelope ukcResponse) e
 		status := strings.ToLower(strings.TrimSpace(instance.ItemStatus))
 		if status == "error" || instance.ItemError != 0 {
 			statusCode := unikraftCloudHTTPStatus(instance.ItemError)
-			return &unikraftCloudAPIError{StatusCode: statusCode, Message: redactSecret(blank(instance.ItemMessage, "instance operation failed"), c.apiKey)}
+			return &unikraftCloudAPIError{StatusCode: statusCode, Message: redactSecret(core.Blank(instance.ItemMessage, "instance operation failed"), c.apiKey)}
 		}
 		if status != "" && status != "success" {
 			return fmt.Errorf("%s instance result has invalid status %q", providerName, redactSecret(instance.ItemStatus, c.apiKey))
@@ -533,7 +534,7 @@ func (c *unikraftCloudClient) unikraftCloudQuotaError(envelope ukcQuotasResponse
 		status := strings.ToLower(strings.TrimSpace(quota.ItemStatus))
 		if status == "error" || quota.ItemError != 0 {
 			statusCode := unikraftCloudHTTPStatus(quota.ItemError)
-			return &unikraftCloudAPIError{StatusCode: statusCode, Message: redactSecret(blank(quota.ItemMessage, "quota lookup failed"), c.apiKey)}
+			return &unikraftCloudAPIError{StatusCode: statusCode, Message: redactSecret(core.Blank(quota.ItemMessage, "quota lookup failed"), c.apiKey)}
 		}
 		if status != "" && status != "success" {
 			return fmt.Errorf("%s quota result has invalid status %q", providerName, redactSecret(quota.ItemStatus, c.apiKey))
@@ -543,7 +544,7 @@ func (c *unikraftCloudClient) unikraftCloudQuotaError(envelope ukcQuotasResponse
 }
 
 func (c *unikraftCloudClient) unikraftCloudResponseError(responseErr ukcResponseError, fallback string) error {
-	message := blank(strings.TrimSpace(responseErr.Message), fallback)
+	message := core.Blank(strings.TrimSpace(responseErr.Message), fallback)
 	return &unikraftCloudAPIError{
 		StatusCode: unikraftCloudHTTPStatus(responseErr.Status),
 		Message:    redactSecret(message, c.apiKey),

--- a/internal/providers/unikraftcloud/core.go
+++ b/internal/providers/unikraftcloud/core.go
@@ -40,10 +40,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func inventoryDoctorResult(provider string, leases int) DoctorResult {
 	return core.InventoryDoctorResult(provider, leases)
 }

--- a/internal/providers/unikraftcloud/lifecycle.go
+++ b/internal/providers/unikraftcloud/lifecycle.go
@@ -672,7 +672,7 @@ func serverFromClaim(claim LeaseClaim) Server {
 	return Server{
 		CloudID:  claim.CloudID,
 		Provider: providerName,
-		Name:     blank(labels[ukcLabelResourceName], claim.CloudID),
+		Name:     core.Blank(labels[ukcLabelResourceName], claim.CloudID),
 		Status:   labels["state"],
 		Labels:   labels,
 	}
@@ -739,11 +739,11 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			action = "reconcile"
 		}
 		if req.DryRun {
-			fmt.Fprintf(b.rt.Stdout, "would %s %s lease=%s instance=%s reason=%s\n", action, providerName, current.LeaseID, blank(current.CloudID, "pending"), reason)
+			fmt.Fprintf(b.rt.Stdout, "would %s %s lease=%s instance=%s reason=%s\n", action, providerName, current.LeaseID, core.Blank(current.CloudID, "pending"), reason)
 			unlock()
 			continue
 		}
-		fmt.Fprintf(b.rt.Stdout, "%s %s lease=%s instance=%s reason=%s\n", action, providerName, current.LeaseID, blank(current.CloudID, "pending"), reason)
+		fmt.Fprintf(b.rt.Stdout, "%s %s lease=%s instance=%s reason=%s\n", action, providerName, current.LeaseID, core.Blank(current.CloudID, "pending"), reason)
 		_, deleteErr := b.deleteClaimedInstance(ctx, api, current)
 		unlock()
 		if deleteErr != nil {

--- a/internal/providers/upstashbox/backend.go
+++ b/internal/providers/upstashbox/backend.go
@@ -351,23 +351,23 @@ func boxToServer(cfg Config, box boxData) Server {
 	labels := directLeaseLabels(cfg, leaseID, boxSlug(leaseID, box), providerName, "", box.KeepAlive, time.Now().UTC())
 	labels["box_id"] = box.ID
 	labels["box_name"] = box.Name
-	labels["runtime"] = blank(box.Runtime, runtimeName(cfg))
-	labels["size"] = blank(box.Size, sizeName(cfg))
+	labels["runtime"] = core.Blank(box.Runtime, runtimeName(cfg))
+	labels["size"] = core.Blank(box.Size, sizeName(cfg))
 	labels["state"] = box.Status
 	server := Server{
 		Provider: providerName,
 		CloudID:  box.ID,
-		Name:     blank(box.Name, box.ID),
+		Name:     core.Blank(box.Name, box.ID),
 		Status:   box.Status,
 		Labels:   labels,
 	}
-	server.ServerType.Name = blank(box.Size, sizeName(cfg))
+	server.ServerType.Name = core.Blank(box.Size, sizeName(cfg))
 	server.PublicNet.IPv4.IP = boxBaseHost(cfg)
 	return server
 }
 
 func boxBaseHost(cfg Config) string {
-	raw := blank(strings.TrimSpace(cfg.UpstashBox.BaseURL), core.UpstashBoxConfigDefaultBaseURL)
+	raw := core.Blank(strings.TrimSpace(cfg.UpstashBox.BaseURL), core.UpstashBoxConfigDefaultBaseURL)
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Host == "" {
 		return raw
@@ -376,7 +376,7 @@ func boxBaseHost(cfg Config) string {
 }
 
 func upstashBoxClaimScope(cfg Config) string {
-	raw := blank(strings.TrimSpace(cfg.UpstashBox.BaseURL), core.UpstashBoxConfigDefaultBaseURL)
+	raw := core.Blank(strings.TrimSpace(cfg.UpstashBox.BaseURL), core.UpstashBoxConfigDefaultBaseURL)
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Host == "" {
 		return "endpoint:" + strings.TrimRight(raw, "/")
@@ -425,7 +425,7 @@ func isNotFound(err error) bool {
 }
 
 func runtimeName(cfg Config) string {
-	return blank(strings.TrimSpace(cfg.UpstashBox.Runtime), core.UpstashBoxConfigDefaultRuntime)
+	return core.Blank(strings.TrimSpace(cfg.UpstashBox.Runtime), core.UpstashBoxConfigDefaultRuntime)
 }
 
 func upstashBoxName(leaseID, slug string) string {
@@ -437,11 +437,11 @@ func upstashBoxName(leaseID, slug string) string {
 }
 
 func sizeName(cfg Config) string {
-	return blank(strings.TrimSpace(cfg.UpstashBox.Size), core.UpstashBoxConfigDefaultSize)
+	return core.Blank(strings.TrimSpace(cfg.UpstashBox.Size), core.UpstashBoxConfigDefaultSize)
 }
 
 func workdir(cfg Config) string {
-	return blank(strings.TrimSpace(cfg.UpstashBox.Workdir), core.UpstashBoxConfigDefaultWorkdir)
+	return core.Blank(strings.TrimSpace(cfg.UpstashBox.Workdir), core.UpstashBoxConfigDefaultWorkdir)
 }
 
 func cleanWorkdir(workdir string) (string, error) {

--- a/internal/providers/upstashbox/backend_test.go
+++ b/internal/providers/upstashbox/backend_test.go
@@ -986,7 +986,7 @@ func TestSyncWorkspaceCleansRemoteArchiveWhenExtractFails(t *testing.T) {
 
 func TestSyncWorkspaceNativePreservesExistingFilesOnTransferFailure(t *testing.T) {
 	for _, failure := range []string{"upload", "extract", ""} {
-		t.Run(blank(failure, "success"), func(t *testing.T) {
+		t.Run(core.Blank(failure, "success"), func(t *testing.T) {
 			root := t.TempDir()
 			work := filepath.Join(root, "crabbox")
 			if err := os.Mkdir(work, 0o755); err != nil {

--- a/internal/providers/upstashbox/client.go
+++ b/internal/providers/upstashbox/client.go
@@ -78,7 +78,7 @@ var newAPI = func(cfg Config, rt Runtime) (api, error) {
 			return nil, fmt.Errorf("%s HTTP client setup: %w", providerName, err)
 		}
 	}
-	base := strings.TrimRight(blank(strings.TrimSpace(cfg.UpstashBox.BaseURL), core.UpstashBoxConfigDefaultBaseURL), "/")
+	base := strings.TrimRight(core.Blank(strings.TrimSpace(cfg.UpstashBox.BaseURL), core.UpstashBoxConfigDefaultBaseURL), "/")
 	trusted, _ := url.Parse(base)
 	return &client{apiKey: apiKey, base: base, http: shared.SecureHTTPClient(httpClient, trusted, upstashBoxRedirectError)}, nil
 }
@@ -131,7 +131,7 @@ func (c *client) CreateBox(ctx context.Context, req createRequest) (boxData, err
 			return boxData{}, c.cleanupCreatedBox(box.ID, exit(5, "upstash-box creation failed for %s", box.ID))
 		}
 		if time.Now().After(deadline) {
-			return boxData{}, c.cleanupCreatedBox(box.ID, exit(5, "upstash-box creation timed out for %s status=%s", box.ID, blank(box.Status, "unknown")))
+			return boxData{}, c.cleanupCreatedBox(box.ID, exit(5, "upstash-box creation timed out for %s status=%s", box.ID, core.Blank(box.Status, "unknown")))
 		}
 		select {
 		case <-ctx.Done():

--- a/internal/providers/upstashbox/core.go
+++ b/internal/providers/upstashbox/core.go
@@ -38,10 +38,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func newLeaseID() string {
 	return core.NewLeaseID()
 }

--- a/internal/providers/vercelsandbox/backend.go
+++ b/internal/providers/vercelsandbox/backend.go
@@ -407,13 +407,13 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 					return nil
 				}
 				if req.DryRun {
-					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 					return nil
 				}
 				if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 					return err
 				}
-				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, blank(claim.Slug, "-"))
+				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 				claimRemovedOne = true
 				return nil
 			}
@@ -648,12 +648,12 @@ func (b *backend) bindProviderScope(ctx context.Context, api vercelSandboxClient
 }
 
 func (b *backend) providerScopeBase() string {
-	projectID := blank(strings.TrimSpace(b.resolvedProject), strings.TrimSpace(b.cfg.VercelSandbox.ProjectID))
-	teamID := blank(strings.TrimSpace(b.resolvedTeam), strings.TrimSpace(b.cfg.VercelSandbox.TeamID))
+	projectID := core.Blank(strings.TrimSpace(b.resolvedProject), strings.TrimSpace(b.cfg.VercelSandbox.ProjectID))
+	teamID := core.Blank(strings.TrimSpace(b.resolvedTeam), strings.TrimSpace(b.cfg.VercelSandbox.TeamID))
 	parts := []string{
-		"scope:" + blank(strings.TrimSpace(b.cfg.VercelSandbox.Scope), "-"),
-		"team:" + blank(teamID, "-"),
-		"project:" + blank(projectID, "-"),
+		"scope:" + core.Blank(strings.TrimSpace(b.cfg.VercelSandbox.Scope), "-"),
+		"team:" + core.Blank(teamID, "-"),
+		"project:" + core.Blank(projectID, "-"),
 	}
 	return strings.Join(parts, "/")
 }
@@ -764,7 +764,7 @@ func (b *backend) execTimeoutSecs() int {
 }
 
 func normalizedSandboxState(sb sandboxSummary) string {
-	return strings.ToLower(blank(strings.TrimSpace(sb.Status), blank(strings.TrimSpace(sb.State), "unknown")))
+	return strings.ToLower(core.Blank(strings.TrimSpace(sb.Status), core.Blank(strings.TrimSpace(sb.State), "unknown")))
 }
 
 func isReadyState(state string) bool {
@@ -786,7 +786,7 @@ func isTerminalState(state string) bool {
 }
 
 func vercelSandboxRuntime(cfg Config) string {
-	return blank(strings.TrimSpace(cfg.VercelSandbox.Runtime), defaultRuntime)
+	return core.Blank(strings.TrimSpace(cfg.VercelSandbox.Runtime), defaultRuntime)
 }
 
 func newSandboxName(repo Repo) string {

--- a/internal/providers/vercelsandbox/client.go
+++ b/internal/providers/vercelsandbox/client.go
@@ -186,10 +186,10 @@ type bridgeConfig struct {
 }
 
 func (c *bridgeClient) CreateSandbox(ctx context.Context, req createSandboxRequest) (sandboxSummary, error) {
-	req.Runtime = blank(req.Runtime, vercelSandboxRuntime(c.cfg))
-	req.ProjectID = blank(req.ProjectID, strings.TrimSpace(c.cfg.VercelSandbox.ProjectID))
-	req.TeamID = blank(req.TeamID, strings.TrimSpace(c.cfg.VercelSandbox.TeamID))
-	req.Scope = blank(req.Scope, strings.TrimSpace(c.cfg.VercelSandbox.Scope))
+	req.Runtime = core.Blank(req.Runtime, vercelSandboxRuntime(c.cfg))
+	req.ProjectID = core.Blank(req.ProjectID, strings.TrimSpace(c.cfg.VercelSandbox.ProjectID))
+	req.TeamID = core.Blank(req.TeamID, strings.TrimSpace(c.cfg.VercelSandbox.TeamID))
+	req.Scope = core.Blank(req.Scope, strings.TrimSpace(c.cfg.VercelSandbox.Scope))
 	req.VCPUs = c.cfg.VercelSandbox.VCPUs
 	req.TimeoutSeconds = c.cfg.VercelSandbox.TimeoutSecs
 	req.Persistent = c.cfg.VercelSandbox.Persistent || req.Persistent

--- a/internal/providers/vercelsandbox/core.go
+++ b/internal/providers/vercelsandbox/core.go
@@ -59,10 +59,6 @@ func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
 	return core.AllocateClaimLeaseSlug(leaseID, requested)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
 	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
 }

--- a/internal/providers/wandb/backend.go
+++ b/internal/providers/wandb/backend.go
@@ -61,7 +61,7 @@ func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (result RunResul
 	}
 	started := core.ClockNow(b.rt.Clock)
 	cfg := b.cfg
-	image := blank(strings.TrimSpace(cfg.Wandb.DefaultImage), core.WandbDefaultImageFallback)
+	image := core.Blank(strings.TrimSpace(cfg.Wandb.DefaultImage), core.WandbDefaultImageFallback)
 	maxLifetime := wandbMaxLifetimeSeconds(cfg)
 
 	sandboxID := strings.TrimSpace(req.ID)

--- a/internal/providers/wandb/core.go
+++ b/internal/providers/wandb/core.go
@@ -45,10 +45,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func shellQuote(value string) string {
 	return core.ShellQuote(value)
 }

--- a/internal/providers/windowssandbox/backend.go
+++ b/internal/providers/windowssandbox/backend.go
@@ -921,5 +921,5 @@ func commandDetail(result LocalCommandResult, err error) string {
 	if text == "" && err != nil {
 		text = err.Error()
 	}
-	return blank(text, "unknown error")
+	return core.Blank(text, "unknown error")
 }

--- a/internal/providers/windowssandbox/core.go
+++ b/internal/providers/windowssandbox/core.go
@@ -39,10 +39,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
 func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
 }


### PR DESCRIPTION
## What Problem This Solves

Provider adapters duplicated blank-string fallback wrappers, making default handling harder to audit and maintain consistently.

## Why This Change Was Made

Use the shared internal `core.Blank` helper at the existing call sites and remove equivalent provider-local wrappers. Argument order and fallback behavior are unchanged.

## User Impact

No user-visible behavior changes. Provider fallback handling now uses one shared implementation.

## Evidence

- `go test -race -count=1 -p=1 -timeout=20m ./internal/providers/blaxel`
- `go vet ./...`
- `go build -trimpath ./cmd/crabbox`
- Race validation passed across all 44 selected provider packages in two independent runs before the disjoint main rebase; the overlapping Blaxel package was rerun afterward.
