### PR TITLE
refactor(providers): use shared lease ID helper

### DIFF
--- a/internal/providers/applemachine/backend.go
+++ b/internal/providers/applemachine/backend.go
@@ -290,7 +290,7 @@ func (b *backend) createLease(ctx context.Context, repo Repo, reclaim bool, requ
 	if strings.TrimSpace(repo.Root) == "" {
 		return core.LeaseClaim{}, exit(2, "apple-machine acquisition requires a repository root for durable ownership")
 	}
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return core.LeaseClaim{}, err

--- a/internal/providers/applemachine/core.go
+++ b/internal/providers/applemachine/core.go
@@ -36,8 +36,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string { return core.NewLeaseID() }
-
 func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
 	return core.AllocateClaimLeaseSlug(leaseID, requested)
 }

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -79,7 +79,7 @@ func (b *awsLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedS
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	servers, err := b.listAcrossRegions(ctx)
 	if err != nil {
 		return LeaseTarget{}, err
@@ -838,7 +838,6 @@ var newAWSClient = func(ctx context.Context, cfg Config) (awsClient, error) {
 	return core.NewAWSClient(ctx, cfg)
 }
 
-func newLeaseID() string { return core.NewLeaseID() }
 func allocateDirectLeaseSlug(id, requested string, servers []Server) (string, error) {
 	return core.AllocateDirectLeaseSlug(id, requested, servers)
 }

--- a/internal/providers/awslambdamicrovm/backend.go
+++ b/internal/providers/awslambdamicrovm/backend.go
@@ -393,7 +393,7 @@ func (b *backend) clients(ctx context.Context) (controlPlane, runnerAPI, error) 
 }
 
 func (b *backend) create(ctx context.Context, control controlPlane, runner runnerAPI, repo Repo, requestedSlug string, keep, reclaim bool) (leaseID, slug string, vm microVM, retErr error) {
-	leaseID = newLeaseID()
+	leaseID = core.NewLeaseID()
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return "", "", microVM{}, err

--- a/internal/providers/awslambdamicrovm/core.go
+++ b/internal/providers/awslambdamicrovm/core.go
@@ -42,7 +42,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string { return core.NewLeaseID() }
 func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
 	return core.AllocateClaimLeaseSlug(leaseID, requested)
 }

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -69,7 +69,7 @@ func (b *azureLeaseBackend) acquireOnce(ctx context.Context, keep bool, requeste
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	servers, err := client.ListCrabboxServers(ctx)
 	if err != nil {
 		return LeaseTarget{}, err
@@ -437,7 +437,6 @@ var newAzureClient = func(ctx context.Context, cfg Config) (azureClient, error) 
 
 var validateAzureSSHCIDRsForAcquire = core.ValidateAzureSSHCIDRsForAcquire
 
-func newLeaseID() string { return core.NewLeaseID() }
 func allocateDirectLeaseSlug(id, requested string, servers []Server) (string, error) {
 	return core.AllocateDirectLeaseSlug(id, requested, servers)
 }

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -730,7 +730,7 @@ func (b *blacksmithBackend) warmupLease(ctx context.Context, repo Repo, reclaim 
 		return core.LeaseClaim{}, err
 	}
 	b = bound
-	pendingID := "tbx_pending_" + strings.TrimPrefix(newLeaseID(), "cbx_")
+	pendingID := "tbx_pending_" + strings.TrimPrefix(core.NewLeaseID(), "cbx_")
 	_, publicKey, err := ensureTestboxKey(pendingID)
 	if err != nil {
 		return core.LeaseClaim{}, err
@@ -1116,10 +1116,6 @@ type statusView = core.StatusView
 
 func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
-}
-
-func newLeaseID() string {
-	return core.NewLeaseID()
 }
 
 func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {

--- a/internal/providers/cloudflare/backend.go
+++ b/internal/providers/cloudflare/backend.go
@@ -323,7 +323,7 @@ func (b *cloudflareBackend) createSandbox(ctx context.Context, client *cloudflar
 	if strings.TrimSpace(repo.Root) == "" {
 		return LeaseClaim{}, cloudflareContainer{}, exit(2, "cloudflare creation requires a repository root for the recovery claim")
 	}
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return LeaseClaim{}, cloudflareContainer{}, err

--- a/internal/providers/cloudflare/core.go
+++ b/internal/providers/cloudflare/core.go
@@ -43,10 +43,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func newLeaseSlug(leaseID string) string {
 	return core.NewLeaseSlug(leaseID)
 }

--- a/internal/providers/cloudflaredynamicworkers/backend.go
+++ b/internal/providers/cloudflaredynamicworkers/backend.go
@@ -475,7 +475,7 @@ func (b *backend) runIdentity(req RunRequest, cacheMode string) (string, string,
 		if strings.TrimSpace(req.ID) == "" {
 			return "", "", "", false, exit(2, "%s cache=explicit requires --id", providerName)
 		}
-		leaseID := newLeaseID()
+		leaseID := core.NewLeaseID()
 		slug, err := allocateClaimLeaseSlug(leaseID, req.RequestedSlug)
 		if err != nil {
 			return "", "", "", false, err
@@ -486,7 +486,7 @@ func (b *backend) runIdentity(req RunRequest, cacheMode string) (string, string,
 		return "", "", "", false, exit(2, "%s --id requires cache=explicit", providerName)
 	}
 	if cacheMode == "stable" {
-		leaseID := newLeaseID()
+		leaseID := core.NewLeaseID()
 		workerID := stableRunID(workerModuleName(req.Script), req.Script.Data, b.cfg.CloudflareDynamicWorkers, req.Env)
 		slug := newLeaseSlug(leaseID)
 		if req.Keep || req.KeepOnFailure {
@@ -501,7 +501,7 @@ func (b *backend) runIdentity(req RunRequest, cacheMode string) (string, string,
 	leaseID := ""
 	slug := ""
 	if req.Keep || req.KeepOnFailure {
-		leaseID = newLeaseID()
+		leaseID = core.NewLeaseID()
 		var err error
 		slug, err = allocateClaimLeaseSlug(leaseID, req.RequestedSlug)
 		if err != nil {

--- a/internal/providers/cloudflaredynamicworkers/core.go
+++ b/internal/providers/cloudflaredynamicworkers/core.go
@@ -42,10 +42,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func newLeaseSlug(leaseID string) string {
 	return core.NewLeaseSlug(leaseID)
 }

--- a/internal/providers/coder/backend.go
+++ b/internal/providers/coder/backend.go
@@ -69,7 +69,7 @@ func (b *coderLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (Le
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, coderWorkspacesToServers(existing, b.cfg))
 	if err != nil {
 		return LeaseTarget{}, err

--- a/internal/providers/coder/core.go
+++ b/internal/providers/coder/core.go
@@ -44,10 +44,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (string, error) {
 	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
 }

--- a/internal/providers/cubesandbox/backend.go
+++ b/internal/providers/cubesandbox/backend.go
@@ -391,7 +391,7 @@ func (b *cubesandboxBackend) ReclaimAndStop(ctx context.Context, req StopRequest
 }
 
 func (b *cubesandboxBackend) createSandbox(ctx context.Context, client cubesandboxAPI, repo Repo, keep, reclaim bool, requestedSlug string) (string, cubesandboxSandbox, string, error) {
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return "", cubesandboxSandbox{}, "", err

--- a/internal/providers/cubesandbox/core.go
+++ b/internal/providers/cubesandbox/core.go
@@ -41,10 +41,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func newLeaseSlug(leaseID string) string {
 	return core.NewLeaseSlug(leaseID)
 }

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -340,7 +340,7 @@ func (b *e2bBackend) ReclaimAndStop(ctx context.Context, req StopRequest) error 
 }
 
 func (b *e2bBackend) createSandbox(ctx context.Context, client e2bAPI, repo Repo, keep, reclaim bool, requestedSlug string) (string, e2bSandbox, string, error) {
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return "", e2bSandbox{}, "", err

--- a/internal/providers/e2b/core.go
+++ b/internal/providers/e2b/core.go
@@ -42,10 +42,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func newLeaseSlug(leaseID string) string {
 	return core.NewLeaseSlug(leaseID)
 }

--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -38,7 +38,7 @@ func NewExeDevLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 func (b *exeDevLeaseBackend) Spec() ProviderSpec { return b.spec }
 
 func (b *exeDevLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	servers, err := b.listServers(ctx, false)
 	if err != nil {
 		return LeaseTarget{}, err
@@ -49,7 +49,7 @@ func (b *exeDevLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 	}
 	cfg := b.configForRun()
 	name := leaseProviderName(leaseID, slug)
-	generation := newLeaseID()
+	generation := core.NewLeaseID()
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s image=%s cpus=%d memory=%s disk=%s keep=%v\n", providerName, leaseID, slug, name, exeDevImage(cfg), cfg.ExeDev.CPUs, cfg.ExeDev.Memory, cfg.ExeDev.Disk, req.Keep)
 	vm, err := b.createVM(ctx, cfg, name, leaseID, slug, generation)
 	if err != nil {
@@ -488,7 +488,7 @@ func (b *exeDevLeaseBackend) claimResolvedVM(ctx context.Context, lease LeaseTar
 		}
 	}
 	if generation == "" {
-		generation = newLeaseID()
+		generation = core.NewLeaseID()
 	}
 	lease.Server.Labels[exeDevClaimGenerationLabel] = generation
 	claim, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, providerScope, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, previous, exists)

--- a/internal/providers/exedev/core.go
+++ b/internal/providers/exedev/core.go
@@ -44,10 +44,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func newLeaseSlug(leaseID string) string {
 	return core.NewLeaseSlug(leaseID)
 }

--- a/internal/providers/gcp/backend.go
+++ b/internal/providers/gcp/backend.go
@@ -56,7 +56,7 @@ func (b *gcpLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedS
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	servers, err := client.ListCrabboxServers(ctx)
 	if err != nil {
 		return LeaseTarget{}, err
@@ -460,7 +460,6 @@ var newGCPClient = func(ctx context.Context, cfg Config) (gcpClient, error) {
 	return core.NewGCPClient(ctx, cfg)
 }
 
-func newLeaseID() string { return core.NewLeaseID() }
 func allocateDirectLeaseSlug(id, requested string, servers []Server) (string, error) {
 	return core.AllocateDirectLeaseSlug(id, requested, servers)
 }

--- a/internal/providers/githubcodespaces/backend.go
+++ b/internal/providers/githubcodespaces/backend.go
@@ -119,7 +119,7 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	}
 	leaseID := strings.TrimSpace(req.RequestedLeaseID)
 	if leaseID == "" {
-		leaseID = newLeaseID()
+		leaseID = core.NewLeaseID()
 	}
 	unlockLease, err := lockGitHubCodespacesLeaseOperation(ctx, leaseID)
 	if err != nil {

--- a/internal/providers/githubcodespaces/core.go
+++ b/internal/providers/githubcodespaces/core.go
@@ -75,10 +75,6 @@ func markWorkRootExplicit(cfg *Config) {
 	core.MarkWorkRootExplicit(cfg)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (string, error) {
 	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
 }

--- a/internal/providers/hostinger/backend.go
+++ b/internal/providers/hostinger/backend.go
@@ -94,7 +94,7 @@ func (b *leaseBackend) Acquire(ctx context.Context, req AcquireRequest) (lease L
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	servers, err := b.listServers(ctx, client, true)
 	if err != nil {
 		return LeaseTarget{}, err

--- a/internal/providers/hostinger/core.go
+++ b/internal/providers/hostinger/core.go
@@ -40,10 +40,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (string, error) {
 	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
 }

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -133,7 +133,7 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	if strings.TrimSpace(req.Repo.Root) == "" {
 		return LeaseTarget{}, exit(2, "provider=%s requires a repository root so the VM claim can be persisted before bootstrap", providerName)
 	}
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	instances, err := b.listInstances(ctx)
 	if err != nil {
 		return LeaseTarget{}, err

--- a/internal/providers/hyperv/core.go
+++ b/internal/providers/hyperv/core.go
@@ -38,10 +38,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func leaseProviderName(leaseID, slug string) string {
 	return core.LeaseProviderName(leaseID, slug)
 }

--- a/internal/providers/lume/backend.go
+++ b/internal/providers/lume/backend.go
@@ -175,7 +175,7 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	}
 	leaseID := strings.TrimSpace(req.RequestedLeaseID)
 	if leaseID == "" {
-		leaseID = newLeaseID()
+		leaseID = core.NewLeaseID()
 	}
 	instances, err := b.listInstances(ctx)
 	if err != nil {

--- a/internal/providers/lume/core.go
+++ b/internal/providers/lume/core.go
@@ -40,10 +40,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func leaseProviderName(leaseID, slug string) string {
 	return core.LeaseProviderName(leaseID, slug)
 }

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -145,7 +145,7 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	for _, item := range machines {
 		servers = append(servers, b.serverFromMachine(item, claims[item.ID], cfg))
 	}
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
 	if err != nil {
 		return LeaseTarget{}, err
@@ -440,7 +440,7 @@ func (b *backend) resolve(ctx context.Context, req ResolveRequest, original *Lea
 		if req.Repo.Root == "" {
 			return LeaseTarget{}, exit(2, "machine0 --reclaim requires repository context")
 		}
-		leaseID = newLeaseID()
+		leaseID = core.NewLeaseID()
 		slug = core.NormalizeLeaseSlug(item.Name)
 		if slug == "" {
 			slug = core.NewLeaseSlug(leaseID)

--- a/internal/providers/machine0/core.go
+++ b/internal/providers/machine0/core.go
@@ -42,8 +42,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string { return core.NewLeaseID() }
-
 func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (string, error) {
 	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
 }

--- a/internal/providers/modal/backend.go
+++ b/internal/providers/modal/backend.go
@@ -255,7 +255,7 @@ func (b *modalBackend) createSandbox(ctx context.Context, client modalAPI, repo 
 	if err != nil {
 		return core.LeaseClaim{}, modalSandbox{}, err
 	}
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return core.LeaseClaim{}, modalSandbox{}, err

--- a/internal/providers/modal/core.go
+++ b/internal/providers/modal/core.go
@@ -40,10 +40,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func newLeaseSlug(leaseID string) string {
 	return core.NewLeaseSlug(leaseID)
 }

--- a/internal/providers/morph/backend.go
+++ b/internal/providers/morph/backend.go
@@ -148,7 +148,7 @@ func (b *morphLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (Le
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, serversFromLeaseViews(instances, cfg))
 	if err != nil {
 		return LeaseTarget{}, err

--- a/internal/providers/morph/core.go
+++ b/internal/providers/morph/core.go
@@ -45,10 +45,6 @@ func asExitError(err error, target *ExitError) bool {
 	return core.AsExitError(err, target)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func normalizeLeaseSlug(value string) string {
 	return core.NormalizeLeaseSlug(value)
 }

--- a/internal/providers/multipass/backend.go
+++ b/internal/providers/multipass/backend.go
@@ -97,7 +97,7 @@ func (b *backend) configForRun() Config {
 
 func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
 	cfg := b.configForRun()
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	instances, err := b.listInstances(ctx)
 	if err != nil {
 		return LeaseTarget{}, err

--- a/internal/providers/multipass/core.go
+++ b/internal/providers/multipass/core.go
@@ -38,10 +38,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func leaseProviderName(leaseID, slug string) string {
 	return core.LeaseProviderName(leaseID, slug)
 }

--- a/internal/providers/namespace/backend.go
+++ b/internal/providers/namespace/backend.go
@@ -36,7 +36,7 @@ func NewNamespaceLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend
 func (b *namespaceLeaseBackend) Spec() ProviderSpec { return b.spec }
 
 func (b *namespaceLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	slug, err := allocateClaimLeaseSlug(leaseID, req.RequestedSlug)
 	if err != nil {
 		return LeaseTarget{}, err

--- a/internal/providers/namespace/core.go
+++ b/internal/providers/namespace/core.go
@@ -49,10 +49,6 @@ func markDeleteOnReleaseExplicit(cfg *Config) {
 	core.MarkDeleteOnReleaseExplicit(cfg, namespaceProvider)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func newLeaseSlug(leaseID string) string {
 	return core.NewLeaseSlug(leaseID)
 }

--- a/internal/providers/orgo/backend.go
+++ b/internal/providers/orgo/backend.go
@@ -340,7 +340,7 @@ func (b *orgoBackend) api() (orgoAPI, error) {
 }
 
 func (b *orgoBackend) createComputer(ctx context.Context, client orgoAPI, repo Repo, requestedSlug string, reclaim bool) (orgoLease, error) {
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return orgoLease{}, err

--- a/internal/providers/orgo/core.go
+++ b/internal/providers/orgo/core.go
@@ -38,10 +38,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
 	return core.AllocateClaimLeaseSlug(leaseID, requested)
 }

--- a/internal/providers/runpod/backend.go
+++ b/internal/providers/runpod/backend.go
@@ -78,7 +78,7 @@ func (b *runpodLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	cfg := b.configForRun()
 	servers, err := b.listServersFromClient(ctx, client, true)
 	if err != nil {

--- a/internal/providers/runpod/core.go
+++ b/internal/providers/runpod/core.go
@@ -37,10 +37,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func publicKeyFor(privatePath string) (string, error) {
 	return core.PublicKeyFor(privatePath)
 }

--- a/internal/providers/smolvm/backend.go
+++ b/internal/providers/smolvm/backend.go
@@ -234,7 +234,7 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 }
 
 func (b *backend) createMachine(ctx context.Context, client api, repo Repo, keep bool, requestedSlug string) (claim core.LeaseClaim, machine machineData, resultErr error) {
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return core.LeaseClaim{}, machineData{}, err

--- a/internal/providers/smolvm/core.go
+++ b/internal/providers/smolvm/core.go
@@ -39,10 +39,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func newLeaseSlug(leaseID string) string {
 	return core.NewLeaseSlug(leaseID)
 }

--- a/internal/providers/sprites/backend.go
+++ b/internal/providers/sprites/backend.go
@@ -105,7 +105,7 @@ func (b *spritesBackend) Acquire(ctx context.Context, req AcquireRequest) (Lease
 	if err := b.ensureCLI(ctx); err != nil {
 		return LeaseTarget{}, err
 	}
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	slug, err := allocateClaimLeaseSlug(leaseID, req.RequestedSlug)
 	if err != nil {
 		return LeaseTarget{}, err

--- a/internal/providers/sprites/core.go
+++ b/internal/providers/sprites/core.go
@@ -44,10 +44,6 @@ func blank(value, fallback string) string {
 	return core.Blank(value, fallback)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func newLeaseSlug(leaseID string) string {
 	return core.NewLeaseSlug(leaseID)
 }

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -90,7 +90,7 @@ func (b *backend) configForRun() Config {
 
 func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (target LeaseTarget, acquireErr error) {
 	cfg := b.configForRun()
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	instances, err := b.listInstances(ctx)
 	if err != nil {
 		return LeaseTarget{}, err

--- a/internal/providers/tart/core.go
+++ b/internal/providers/tart/core.go
@@ -39,10 +39,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func leaseProviderName(leaseID, slug string) string {
 	return core.LeaseProviderName(leaseID, slug)
 }

--- a/internal/providers/upstashbox/backend.go
+++ b/internal/providers/upstashbox/backend.go
@@ -246,7 +246,7 @@ func (b *backend) deleteClaimedBox(ctx context.Context, client api, leaseID, box
 }
 
 func (b *backend) createBox(ctx context.Context, client api, repo Repo, keep, reclaim bool, requestedSlug string) (string, boxData, string, error) {
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return "", boxData{}, "", err

--- a/internal/providers/upstashbox/core.go
+++ b/internal/providers/upstashbox/core.go
@@ -38,10 +38,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 	return core.Exit(code, format, args...)
 }
 
-func newLeaseID() string {
-	return core.NewLeaseID()
-}
-
 func newLeaseSlug(leaseID string) string {
 	return core.NewLeaseSlug(leaseID)
 }


### PR DESCRIPTION
## What Problem This Solves

Provider adapters duplicated zero-argument lease ID wrappers, making identifier generation harder to audit and maintain consistently.

## Why This Change Was Made

Use the shared internal `core.NewLeaseID` helper at the existing call sites and remove equivalent provider-local wrappers. Generation behavior and surrounding expressions are unchanged; provider scopes with active overlapping work remain untouched.

## User Impact

No user-visible behavior changes. Lease ID generation now uses one shared implementation across the updated providers.

## Evidence

- Race tests passed across all 27 changed provider packages in two independent runs.
- `go vet ./...`
- `go build -trimpath ./cmd/crabbox`
