### PR TITLE
test: make workspace owner renewal fixture deterministic

### DIFF
--- a/internal/cli/workspace_owner_bsd_test.go
+++ b/internal/cli/workspace_owner_bsd_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -204,50 +203,162 @@ func testWorkspaceOwnerDetachedAndRenewingCommand(t *testing.T, path string) {
 		name, command string
 		code          int
 	}{
-		{name: "detached daemon", command: `nohup sleep 30 </dev/null >"$HOME/daemon.log" 2>&1 & echo $! >"$HOME/daemon.pid"`},
-		{name: "renewed stream", command: `i=0; while [ "$i" -lt 5 ]; do echo tick; sleep 1; i=$((i+1)); done; exit 23`, code: 23},
+		{name: "detached daemon", command: `nohup sleep 30 </dev/null >"$HOME/daemon.log" 2>&1 & daemon_pid=$!
+ps -o lstart= -p "$daemon_pid" >"$HOME/daemon.identity" || exit 74
+echo "$daemon_pid" >"$HOME/daemon.pid"`},
+		{name: "renewed stream", command: `echo started >"$HOME/started.tmp"; mv "$HOME/started.tmp" "$HOME/started"
+i=0; while [ ! -f "$HOME/continue" ]; do
+  [ "$i" -lt 3000 ] || exit 124
+  sleep .01; i=$((i+1))
+done
+i=0; while [ "$i" -lt 5 ]; do echo tick; sleep 1; i=$((i+1)); done; exit 23`, code: 23},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			home := t.TempDir()
+			clockBin := t.TempDir()
+			// Only the protocol clock is controlled; retain native/BSD gate selection.
+			if err := os.WriteFile(filepath.Join(clockBin, "date"), []byte("#!/bin/sh\n[ \"$#\" -eq 1 ] && [ \"$1\" = +%s ] || exit 64\ncat \"$HOME/clock\"\n"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			setClock := func(now int) {
+				t.Helper()
+				tmp := filepath.Join(home, "clock.tmp")
+				if err := os.WriteFile(tmp, []byte(strconv.Itoa(now)+"\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Rename(tmp, filepath.Join(home, "clock")); err != nil {
+					t.Fatal(err)
+				}
+			}
+			setClock(1000)
 			key, token := workspaceOwnerKey(tc.name), strings.Repeat("c", 64)
 			run := func(script string) (string, error) {
-				ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+				ctx, cancel := context.WithTimeout(t.Context(), 45*time.Second)
 				defer cancel()
 				cmd := exec.CommandContext(ctx, "/bin/sh", "-c", script)
-				cmd.Env = []string{"HOME=" + home, "PATH=" + path}
+				cmd.Env = []string{"HOME=" + home, "PATH=" + clockBin + string(os.PathListSeparator) + path}
+				cmd.WaitDelay = time.Second
+				if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+					configureControllerCommand(cmd)
+					cmd.Cancel = func() error { return stopControllerProcessGroup(cmd.Process.Pid) }
+				}
 				out, err := cmd.CombinedOutput()
 				return string(out), err
+			}
+			stateExpiry := func() int {
+				t.Helper()
+				data, err := os.ReadFile(filepath.Join(home, ".crabbox", "workspace-owners", key+".owner"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+				if len(lines) != 3 || lines[0] != "v1" || lines[1] != token {
+					t.Fatalf("unexpected owner state %q", data)
+				}
+				expiry, err := strconv.Atoi(lines[2])
+				if err != nil {
+					t.Fatal(err)
+				}
+				return expiry
 			}
 			req := workspaceOwnerRemoteRequest{Action: workspaceOwnerAcquire, Key: key, Token: token, TTL: 3 * time.Second}
 			if out, err := run(remoteWorkspaceOwnerPOSIX(req)); err != nil || out != "ACQUIRED" {
 				t.Fatalf("acquire=%q %v", out, err)
 			}
-			done := make(chan struct{})
-			renewed := make(chan error, 1)
-			go func() {
-				ticker := time.NewTicker(500 * time.Millisecond)
-				defer ticker.Stop()
-				renew := req
-				renew.Action = workspaceOwnerRenew
-				for {
-					select {
-					case <-done:
-						renewed <- nil
-						return
-					case <-ticker.C:
-						out, err := run(remoteWorkspaceOwnerPOSIX(renew))
-						if err != nil || out != "RENEWED" {
-							renewed <- fmt.Errorf("renew=%q %v", out, err)
-							return
-						}
-					}
+			defer func() {
+				req.Action = workspaceOwnerRelease
+				if out, err := run(remoteWorkspaceOwnerPOSIX(req)); err != nil || out != "RELEASED" {
+					t.Errorf("release=%q %v", out, err)
 				}
 			}()
-			out, err := run(remoteWorkspaceOwnerPOSIXWitness(key, token, tc.command))
-			close(done)
-			renewErr := <-renewed
-			if renewErr != nil {
-				t.Fatal(renewErr)
+			var out string
+			var err error
+			if tc.name == "renewed stream" {
+				originalExpiry := stateExpiry()
+				if originalExpiry != 1003 {
+					t.Fatalf("initial expiry=%d want 1003", originalExpiry)
+				}
+				type commandResult struct {
+					out string
+					err error
+				}
+				finished := make(chan commandResult, 1)
+				go func() {
+					out, err := run(remoteWorkspaceOwnerPOSIXWitness(key, token, tc.command))
+					finished <- commandResult{out, err}
+				}()
+				joined := false
+				// Unblock and join before test-context cancellation, including Fatal paths.
+				defer func() {
+					if !joined {
+						_ = os.WriteFile(filepath.Join(home, "continue"), nil, 0o600)
+						<-finished
+					}
+				}()
+				deadline := time.NewTimer(15 * time.Second)
+				defer deadline.Stop()
+				for {
+					if _, statErr := os.Stat(filepath.Join(home, "started")); statErr == nil {
+						break
+					} else if !os.IsNotExist(statErr) {
+						t.Fatal(statErr)
+					}
+					select {
+					case result := <-finished:
+						joined = true
+						t.Fatalf("command ended before start: %q %v", result.out, result.err)
+					case <-deadline.C:
+						t.Fatal("command did not signal start")
+					case <-time.After(10 * time.Millisecond):
+					}
+				}
+				// Advance only after user code starts, so pre-start admission is independent.
+				setClock(1002)
+				req.Action = workspaceOwnerRenew
+				if out, err := run(remoteWorkspaceOwnerPOSIX(req)); err != nil || out != "RENEWED" {
+					t.Fatalf("renew=%q %v", out, err)
+				}
+				renewedExpiry := stateExpiry()
+				if renewedExpiry != 1005 || renewedExpiry <= originalExpiry {
+					t.Fatalf("renewed expiry=%d initial=%d want 1005", renewedExpiry, originalExpiry)
+				}
+				setClock(1004)
+				req.Action = workspaceOwnerInspect
+				if out, err := run(remoteWorkspaceOwnerPOSIX(req)); err != nil || out != "CHILD" {
+					t.Fatalf("live child beyond initial expiry=%q %v", out, err)
+				}
+				if err := os.WriteFile(filepath.Join(home, "continue"), nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				result := <-finished
+				joined = true
+				out, err = result.out, result.err
+			} else {
+				// Register cleanup before spawning, so assertion failures cannot retain it.
+				defer func() {
+					data, readErr := os.ReadFile(filepath.Join(home, "daemon.pid"))
+					if readErr != nil {
+						return
+					}
+					pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+					identity, identityErr := os.ReadFile(filepath.Join(home, "daemon.identity"))
+					if parseErr != nil || identityErr != nil || len(strings.Fields(string(identity))) == 0 {
+						t.Log("daemon cleanup skipped: creation identity unavailable")
+						return
+					}
+					live, probeErr := run("ps -o lstart= -p " + strconv.Itoa(pid))
+					if probeErr != nil || strings.Join(strings.Fields(live), " ") != strings.Join(strings.Fields(string(identity)), " ") {
+						t.Log("daemon cleanup skipped: no matching live identity")
+						return
+					}
+					process, findErr := os.FindProcess(pid)
+					if findErr != nil {
+						t.Errorf("find owned daemon: %v", findErr)
+					} else if killErr := process.Kill(); killErr != nil {
+						t.Errorf("stop owned daemon: %v", killErr)
+					}
+				}()
+				out, err = run(remoteWorkspaceOwnerPOSIXWitness(key, token, tc.command))
 			}
 			code := 0
 			if err != nil {
@@ -272,19 +383,10 @@ func testWorkspaceOwnerDetachedAndRenewingCommand(t *testing.T, path string) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				process, err := os.FindProcess(pid)
-				if err != nil {
-					t.Fatal(err)
-				}
-				t.Cleanup(func() { _ = process.Kill() })
 				time.Sleep(time.Second)
 				if out, err := run(remoteWorkspaceOwnerPOSIXWitness(key, token, "kill -0 "+strconv.Itoa(pid))); err != nil {
 					t.Fatalf("daemon did not survive subsequent command: %q %v", out, err)
 				}
-			}
-			req.Action = workspaceOwnerRelease
-			if out, err := run(remoteWorkspaceOwnerPOSIX(req)); err != nil || out != "RELEASED" {
-				t.Fatalf("release=%q %v", out, err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

The post-merge coverage run for https://github.com/openclaw/crabbox/pull/1916 failed in `TestWorkspaceOwnerPOSIXDetachedAndRenewingCommand/renewed_stream` with `EXPIRED`: https://github.com/openclaw/crabbox/actions/runs/34682158837. The fixture used a three-second lease, whole-second wall time, and periodic subprocess renewal. The log does not establish the exact scheduling or lock delay.

Make this positive fixture deterministic while exercising the real POSIX owner and witness scripts. A test-owned clock and child-start barrier require renewal to extend persisted expiry from 1003 to 1005, then require a live child at 1004, beyond the original expiry. The command still streams five lines and exits 23. Bound and join test subprocesses, and identify the fixture-owned detached daemon before cleanup.

Production renewal policy, expiry/nonce guards, negative tests, and unrelated test functions are unchanged. This does not claim to fix the separate runtime report at https://github.com/openclaw/crabbox/issues/1712. No config, secrets, or user-visible changelog changes.

## Verification

On macOS with Go 1.26.5, isolated test HOME/TMP and offline module resolution:

- `go test -p=1 ./internal/cli -run '^TestWorkspaceOwner(BSD|POSIX)DetachedAndRenewingCommand$' -count=3 -timeout=3m -v`
- The same focused command with coverage instrumentation and separately with `-race`: all three modes passed six top-level executions and twelve subcases each.
- `go test -p=1 ./internal/cli -run '^$' -count=1 -timeout=3m -v`: compile-only passed.
- Managed Codex review of the complete one-file patch: P0 scoped-clean. This is not an all-priority review certificate.

These are local real-shell fixtures, not cloud-provider or network-denied proof. An initial optional sandbox run failed at its native `ps` prerequisite before renewal and was retained as failed evidence. Linux and the full repository suites are delegated to CI. The original failed main run has not been rerun or relabeled as successful.
