### PR TITLE
refactor(providers): use shared random suffix helper

### DIFF
--- a/internal/providers/crownest/backend.go
+++ b/internal/providers/crownest/backend.go
@@ -230,7 +230,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		SourceMeta: map[string]string{
 			"repo": repoName(req.Repo),
 		},
-	}, idempotencyKey("create", randomSuffix()))
+	}, idempotencyKey("create", shared.RandomSuffix()))
 	if err != nil {
 		if acquired && workspaceRun.SandboxID != "" {
 			return RunResult{}, b.cleanupCreateFailure(ctx, api, workspaceRun.SandboxID, err)
@@ -954,8 +954,4 @@ func repoName(repo Repo) string {
 		return repo.Name
 	}
 	return repo.Root
-}
-
-func randomSuffix() string {
-	return shared.RandomSuffix()
 }

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -495,7 +495,7 @@ func newSandboxName(repo Repo) string {
 	if base == "" {
 		base = "crabbox"
 	}
-	return namePrefix + base + "-" + randomSuffix()
+	return namePrefix + base + "-" + shared.RandomSuffix()
 }
 
 func isReadyState(state string) bool {
@@ -516,10 +516,6 @@ func isTerminalState(state string) bool {
 	default:
 		return false
 	}
-}
-
-func randomSuffix() string {
-	return shared.RandomSuffix()
 }
 
 // openComputerWorkdir returns the configured absolute workspace path inside the

--- a/internal/providers/opensandbox/backend.go
+++ b/internal/providers/opensandbox/backend.go
@@ -1011,11 +1011,7 @@ func newSandboxName(repo Repo) string {
 	if base == "" {
 		base = "crabbox"
 	}
-	return namePrefix + base + "-" + randomSuffix()
-}
-
-func randomSuffix() string {
-	return shared.RandomSuffix()
+	return namePrefix + base + "-" + shared.RandomSuffix()
 }
 
 func (b *openSandboxBackend) cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -804,7 +804,7 @@ func newSandboxName(repo Repo) string {
 	if len(base) > 40 {
 		base = strings.Trim(base[:40], "-")
 	}
-	return namePrefix + base + "-" + randomSuffix()
+	return namePrefix + base + "-" + shared.RandomSuffix()
 }
 
 func repoScope(repo Repo) string {
@@ -814,10 +814,6 @@ func repoScope(repo Repo) string {
 	}
 	sum := sha256.Sum256([]byte(value))
 	return "repo-sha256:" + hex.EncodeToString(sum[:8])
-}
-
-func randomSuffix() string {
-	return shared.RandomSuffix()
 }
 
 func timeoutOrDefault(primary, fallback time.Duration) time.Duration {

--- a/internal/providers/vercelsandbox/backend.go
+++ b/internal/providers/vercelsandbox/backend.go
@@ -802,7 +802,7 @@ func newSandboxName(repo Repo) string {
 	if len(base) > 40 {
 		base = strings.Trim(base[:40], "-")
 	}
-	return "crabbox-" + base + "-" + randomSuffix()
+	return "crabbox-" + base + "-" + shared.RandomSuffix()
 }
 
 func repoScope(repo Repo) string {
@@ -812,10 +812,6 @@ func repoScope(repo Repo) string {
 	}
 	sum := sha256.Sum256([]byte(value))
 	return "repo-sha256:" + hex.EncodeToString(sum[:8])
-}
-
-func randomSuffix() string {
-	return shared.RandomSuffix()
 }
 
 func timeoutOrDefault(primary, fallback time.Duration) time.Duration {


### PR DESCRIPTION
## What Problem This Solves

Several provider adapters duplicated the same random suffix wrapper, making naming behavior harder to audit consistently.

## Why This Change Was Made

Use the shared internal `shared.RandomSuffix` helper at the existing call sites and remove equivalent provider-local wrappers. Generation behavior and call timing are unchanged.

## User Impact

No user-visible behavior changes. Random suffix generation now uses one shared implementation across the updated providers.

## Evidence

- Race tests passed across all five changed provider packages and the shared package in two independent runs.
- `go vet ./...`
- `go build -trimpath ./cmd/crabbox`
