### PR TITLE
feat: add opt-in private local run history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,9 @@ jobs:
       - name: Test native Windows archive preparation ownership
         run: go test ./internal/providers/blaxel -run '^TestRunPreparesArchiveBeforeCreate$' -count=1 -v
 
+      - name: Test native Windows local history store, readers, and observation
+        run: go test ./internal/cli/ -run '^(TestLocalHistory|TestRunObservation(DelegatedAppRoundTrip|DisabledHasNoLedger|CapturesOnlyCommandWriters|AdoptsExistingCaptureOmissions|FinalFailureOnlyWarns|NeverEntersWireRequest|CoordinatorReferenceExcludesCredentials|CoordinatorTerminalAcknowledgment|PolicyIgnoresRepositoryFiles)$)' -count=1 -timeout=5m -v
+
       - name: Test concurrent claim discovery and ownership
         run: go test ./internal/cli/ -run '^Test(ClaimMetadata|ClaimTransaction|RemoveControllerFile|ConfirmedAbsentStateCleanup|PrivateRunOutput)' -count=1 -v
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add opt-in private local run history with bounded logs and parsed results, offline readback after lease cleanup, explicit provenance, and bounded pruning. [Issue 1515](https://github.com/openclaw/crabbox/issues/1515). Thanks @coygeek.
 - Bound Nomad's finite control-plane requests while retaining durable recovery identity for uncertain registration, preserving caller cancellation and keeping established exec streams outside the request ceiling. [PR 1916](https://github.com/openclaw/crabbox/pull/1916). Thanks @SebTardif.
 - Preserve GCP capacity fallback when a bounded error summary omits retry evidence, while keeping user-visible diagnostics redacted and bounded. [PR 1987](https://github.com/openclaw/crabbox/pull/1987). Thanks @steipete.
 - AWS: add administrator-only legacy cleanup recovery backed by authenticated original CloudTrail allocation evidence, preserving remaining key and access cleanup and recording an atomic scope-recovery audit without force-success. [PR 1975](https://github.com/openclaw/crabbox/pull/1975).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add opt-in private local run history with bounded logs and parsed results, offline readback after lease cleanup, explicit provenance, and bounded pruning. [Issue 1515](https://github.com/openclaw/crabbox/issues/1515). Thanks @coygeek.
+- Add opt-in private local run history with bounded logs and parsed results, offline readback after lease cleanup, explicit provenance, and bounded pruning. [PR 2141](https://github.com/openclaw/crabbox/pull/2141). Thanks @coygeek.
 - Bound Nomad's finite control-plane requests while retaining durable recovery identity for uncertain registration, preserving caller cancellation and keeping established exec streams outside the request ceiling. [PR 1916](https://github.com/openclaw/crabbox/pull/1916). Thanks @SebTardif.
 - Preserve GCP capacity fallback when a bounded error summary omits retry evidence, while keeping user-visible diagnostics redacted and bounded. [PR 1987](https://github.com/openclaw/crabbox/pull/1987). Thanks @steipete.
 - AWS: add administrator-only legacy cleanup recovery backed by authenticated original CloudTrail allocation evidence, preserving remaining key and access cleanup and recording an atomic scope-recovery audit without force-success. [PR 1975](https://github.com/openclaw/crabbox/pull/1975).

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -279,6 +279,12 @@ permissions are broader than that.
 
 ## Repo-local config
 
+Private local run recording is off by default. Set `history.local.enabled: true`
+only in your user config to enable it for runs; repository files cannot change
+this policy. An explicit `run --record-local=false` overrides the user setting.
+See [local history](../features/history-logs.md#private-local-history) for storage
+bounds, output scope, and offline readers.
+
 User config holds machine-wide defaults and secrets; repo-local config holds
 project-specific, checkout-shareable settings. Keep sync rules, environment
 allow-lists, capacity policy, and Actions hydration settings in repo config so

--- a/docs/commands/history.md
+++ b/docs/commands/history.md
@@ -4,7 +4,8 @@
 created by [`crabbox run`](run.md) (and run-backed flows such as
 [`crabbox job run`](job.md) or `capsule replay`) and persists its state, phase,
 exit code, duration, and telemetry on the coordinator. This command requires a
-configured broker; without one it returns an error.
+configured broker by default. Existing opt-in local records are also readable
+without a broker; use `--source local` to select local data explicitly.
 
 ```sh
 crabbox history
@@ -23,6 +24,7 @@ crabbox history --state failed --limit 100
 --state <state>      Filter by state: running, succeeded, or failed.
 --limit <n>          Maximum runs to return (default 50, broker-capped at 500).
 --json               Print the raw run records as JSON.
+--source <source>     local, coordinator, or all; configured-broker default is unchanged.
 ```
 
 ## Output
@@ -45,6 +47,13 @@ Use a run ID from this list with [`logs`](logs.md), [`events`](events.md), or
 [`attach`](attach.md) to inspect a specific run.
 
 ## Related docs
+
+Local records are created by `run --record-local`, not by reading history.
+`history prune --source local` applies the bounded retention policy, and
+`history delete <run-id> --source local` removes one inactive local record.
+Neither operation stops a lease or changes coordinator records. Active writers
+are not pruned. Local source output includes provenance and incomplete status;
+see [private local history](../features/history-logs.md#private-local-history).
 
 - [logs](logs.md) — print captured run logs.
 - [events](events.md) — print phase and stream events.

--- a/docs/commands/logs.md
+++ b/docs/commands/logs.md
@@ -2,6 +2,12 @@
 
 `crabbox logs` prints the retained command output for a recorded run.
 
+For opted-in local runs, use `--source local` (or read an existing local record
+without a coordinator). `--source coordinator|all` selects other recorded data.
+Configured-coordinator defaults are unchanged. Local readback exposes retained
+stream scope, omission, and truncation separately from log text, and works after
+the lease is removed. See [private local history](../features/history-logs.md#private-local-history).
+
 ```sh
 crabbox logs run_abcdef123456
 crabbox logs --id run_abcdef123456

--- a/docs/commands/results.md
+++ b/docs/commands/results.md
@@ -12,9 +12,14 @@ crabbox results run_abcdef123456 --failed-only
 crabbox results run_abcdef123456 --json
 ```
 
-The run id is accepted as a positional argument or via `--id`. A coordinator
-must be configured (`CRABBOX_COORDINATOR` or `config set-broker`), because
-results are read back from the recorded run, not from the live box.
+The run id is accepted as a positional argument or via `--id`. Results are read
+from recorded runs, not from the live box. A configured coordinator
+(`CRABBOX_COORDINATOR` or `config set-broker`) remains the default source.
+Opted-in local records also work without a coordinator: use `--source local`, or
+`--source coordinator|all` for explicit source selection. Existing configured
+broker defaults are unchanged. Local results preserve collected summary totals
+and disclose unavailable results or clipped/omitted details; they do not retain
+raw XML or claim coordinator attestation.
 
 ## How results get attached
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -938,6 +938,15 @@ logs <run-id>`](logs.md) prints retained remote output (retention is bounded so
 a noisy command cannot fill storage). See
 [history and logs](../features/history-logs.md).
 
+Use `--record-local` to retain private, bounded local history for this run,
+including coordinator-free and delegated execution. Trusted user configuration
+can enable `history.local.enabled`; an explicit `--record-local=false` disables
+it for one run. Repository policy cannot silently enable this storage. The
+printed run ID works with local history/logs/results after lease cleanup.
+Local history finalization runs after the existing timing/receipt operations;
+failure warns and leaves incomplete metadata without changing their result or
+the original process exit. It never uploads a direct run or creates attestation.
+
 ## Pond
 
 Use `--pond <name>` to tag a new lease into a named pond. Pond is a reserved
@@ -1066,4 +1075,5 @@ Run-specific flags:
 --label <text>
 --timing-json
 --timing-record default|off|path
+--record-local
 ```

--- a/docs/features/history-logs.md
+++ b/docs/features/history-logs.md
@@ -6,12 +6,63 @@ Read when:
 - debugging a failed remote command after the fact;
 - deciding what belongs in coordinator-stored run history.
 
-History and logs are a **brokered-mode** feature. When `crabbox run` executes
+Shared history and logs are a **brokered-mode** feature. When `crabbox run` executes
 against a brokered provider (`aws`, `azure`, `daytona`, `gcp`, `hetzner` with a
 coordinator configured), the CLI mirrors the run into coordinator storage as a
 durable, queryable record. Direct-provider runs and delegated runs do not produce
 central history — there you have only the live terminal output and any local
-captures you ask for.
+captures you ask for, unless you explicitly enable private local history.
+
+## Private local history
+
+`crabbox run --record-local -- <command>` retains a bounded local record keyed
+by the same printed `run_...` ID. The record survives normal lease removal and
+does not require or upload to a coordinator. The default is off. Enable it for
+future runs in trusted user configuration with `history.local.enabled: true`;
+repository configuration cannot enable or disable that policy. An explicit
+`--record-local=false` overrides the user policy.
+
+```sh
+crabbox run --provider local-container --record-local -- printf 'example\n'
+crabbox history --source local
+crabbox logs run_<id> --source local
+crabbox results run_<id> --source local --json
+crabbox history prune --source local
+crabbox history delete run_<id> --source local
+```
+
+Local history lives under the existing state directory's `history` directory,
+separate from lease claims. Files and directories are private to their owner.
+It retains up to 100 inactive records, 256 MiB overall, and 30 days; abandoned
+incomplete records are included. Active writers hold a lock and reserve bounded
+space. Admission fails before acquisition if private storage cannot be reserved.
+An unavailable final write warns without changing the command's existing exit,
+timing, or receipt. An interrupted or uncommitted record is marked incomplete,
+not successful; its output may be unavailable.
+
+The log uses the same 8 MiB UTF-8 tail and capture-omission policy described
+below. Metadata is capped at 256 KiB and serialized parsed results at 1 MiB.
+Result totals remain intact when detailed entries are omitted or clipped; local
+readback exposes those limits. Raw JUnit XML and arbitrary remote files are not
+retained. Caller output is not automatically secret-redacted: opt in only when
+private retention is appropriate. Command/display diagnostics use the existing
+diagnostic redactor.
+
+Workload writers are observed separately from Crabbox's own diagnostic output.
+Some delegated native CLIs mix command and provider messages; those retained
+streams are labelled `provider-run`, not a pure workload transcript. Streams a
+provider does not expose and streams directed exclusively to captures remain
+explicitly unavailable or omitted. Unsupported delegated JUnit collection is
+not fabricated into a passing result.
+
+`history`, `logs`, and `results` accept `--source local|coordinator|all`.
+With a coordinator configured, the existing default broker route and JSON stay
+unchanged. Without one, existing local history is readable, including after
+retention is disabled. Explicit local reads stay offline. Source-qualified
+output distinguishes local-only data, acknowledged coordinator records, and
+both; correlation includes a noncredential endpoint reference, not just an ID.
+A local self-record is never coordinator-attested evidence. `events`, `attach`,
+and `receipt` retain their coordinator-only contract.
 
 ## What a recorded run contains
 

--- a/docs/features/history-logs.md
+++ b/docs/features/history-logs.md
@@ -49,8 +49,9 @@ private retention is appropriate. Command/display diagnostics use the existing
 diagnostic redactor.
 
 Workload writers are observed separately from Crabbox's own diagnostic output.
-Some delegated native CLIs mix command and provider messages; those retained
-streams are labelled `provider-run`, not a pure workload transcript. Streams a
+Direct SSH transports and some delegated native CLIs mix command and provider
+messages; those retained streams are labelled `provider-run`, not a pure workload
+transcript. Streams a
 provider does not expose and streams directed exclusively to captures remain
 explicitly unavailable or omitted. Unsupported delegated JUnit collection is
 not fabricated into a passing result.

--- a/internal/cli/artifacts_private_windows.go
+++ b/internal/cli/artifacts_private_windows.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"errors"
 	"os"
 
 	"golang.org/x/sys/windows"
@@ -17,5 +18,10 @@ func openArtifactBundleTemp(root *os.Root, name string, perm os.FileMode, privat
 		return nil, err
 	}
 	defer directory.Close()
-	return createPrivateWindowsFileAt(windows.Handle(directory.Fd()), name)
+	file, err := createPrivateWindowsFileAt(windows.Handle(directory.Fd()), name)
+	if errors.Is(err, windows.STATUS_OBJECT_NAME_COLLISION) {
+		// Match OpenFile's exclusive-create contract for callers opening existing locks.
+		return nil, &os.PathError{Op: "open", Path: name, Err: os.ErrExist}
+	}
+	return file, err
 }

--- a/internal/cli/aws_fixed_create_intent_test.go
+++ b/internal/cli/aws_fixed_create_intent_test.go
@@ -203,7 +203,7 @@ func TestFixedAWSCreateIntentClassifiesEveryExportedConfigField(t *testing.T) {
 		AppleContainer AppleVM MXC Multipass Machine0 Tart Lume HyperV WindowsSandbox Static
 	`)
 	classify("post-acquisition command, transport, or reporting behavior", `
-		Sync Run EnvAllow Actions Results Shard Profiles Presets ProofTemplates Jobs
+		Sync Run EnvAllow Actions Results Shard Profiles Presets ProofTemplates Jobs RecordLocal
 	`)
 
 	configType := reflect.TypeOf(Config{})

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -16,6 +16,7 @@ import (
 )
 
 type Config struct {
+	RecordLocal                   bool `json:"-" yaml:"-"`
 	Profile                       string
 	Provider                      string
 	providerSelectionSource       providerSelectionSource
@@ -2307,6 +2308,7 @@ func baseConfig() Config {
 }
 
 type fileConfig struct {
+	History                  *fileLocalHistoryPolicy             `yaml:"history,omitempty"`
 	Profile                  string                              `yaml:"profile,omitempty"`
 	Provider                 string                              `yaml:"provider,omitempty"`
 	Target                   string                              `yaml:"target,omitempty"`
@@ -3426,6 +3428,9 @@ func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error 
 }
 
 func applyFileConfigWithTrustAndProviderSource(cfg *Config, file fileConfig, trusted bool, providerSource providerSelectionSource) error {
+	if trusted && file.History != nil && file.History.Local != nil && file.History.Local.Enabled != nil {
+		cfg.RecordLocal = *file.History.Local.Enabled
+	}
 	credentialSource := credentialSourceForFile(trusted)
 	inputSource := configInputSourceForFile(providerSource)
 	if !trusted && cfg.credentialProvenance.repositoryRoot == "" {

--- a/internal/cli/history.go
+++ b/internal/cli/history.go
@@ -10,7 +10,11 @@ import (
 )
 
 func (a App) history(ctx context.Context, args []string) error {
+	if len(args) > 0 && (args[0] == "prune" || args[0] == "delete") {
+		return a.localHistoryMaintenance(args)
+	}
 	fs := newFlagSet("history", a.Stderr)
+	source := fs.String("source", "", "record source: local, coordinator, or all")
 	leaseID := fs.String("lease", "", "filter by lease id")
 	owner := fs.String("owner", "", "filter by owner")
 	org := fs.String("org", "", "filter by org")
@@ -20,9 +24,12 @@ func (a App) history(ctx context.Context, args []string) error {
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
-	coord, err := configuredCoordinator()
-	if err != nil {
+	sourceName, coord, err := resolveHistorySource(*source)
+	if err != nil && sourceName != "all" {
 		return err
+	}
+	if sourceName != "" {
+		return a.historyFromSources(ctx, sourceName, coord, localHistoryFilter{LeaseID: *leaseID, State: *state, Limit: *limit}, *owner, *org, *jsonOut, err)
 	}
 	runs, err := coord.Runs(ctx, *leaseID, *owner, *org, *state, *limit)
 	if err != nil {
@@ -45,6 +52,7 @@ func (a App) history(ctx context.Context, args []string) error {
 func (a App) logs(ctx context.Context, args []string) error {
 	args, jsonAnywhere := extractBoolFlag(args, "json")
 	fs := newFlagSet("logs", a.Stderr)
+	source := fs.String("source", "", "record source: local, coordinator, or all")
 	runIDValue, args := popLeadingRunID(args)
 	runID := fs.String("id", runIDValue, "run id")
 	tail := fs.Int("tail", 0, "print only the last N log lines")
@@ -64,9 +72,12 @@ func (a App) logs(ctx context.Context, args []string) error {
 	if *tail < 0 {
 		return exit(2, "tail must be >= 0")
 	}
-	coord, err := configuredCoordinator()
-	if err != nil {
+	sourceName, coord, err := resolveHistorySource(*source)
+	if err != nil && sourceName != "all" {
 		return err
+	}
+	if sourceName != "" {
+		return a.localHistoryRead(ctx, sourceName, coord, *runID, "logs", *tail, false, *jsonOut, err)
 	}
 	logText, err := coord.RunLogs(ctx, *runID)
 	if err != nil {

--- a/internal/cli/local_history_read.go
+++ b/internal/cli/local_history_read.go
@@ -1,0 +1,339 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// An empty source selects the unchanged coordinator wire representation.
+func resolveHistorySource(source string) (string, *CoordinatorClient, error) {
+	switch source {
+	case "local":
+		return source, nil, nil
+	case "", "coordinator", "all":
+	default:
+		return "", nil, exit(2, "source must be local, coordinator, or all")
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		if source == "all" {
+			return source, nil, err
+		}
+		return "", nil, err
+	}
+	coord, ok, err := newCoordinatorClient(cfg)
+	if err != nil {
+		if source == "all" {
+			return source, nil, err
+		}
+		return "", nil, err
+	}
+	if source == "all" {
+		return source, coord, nil
+	}
+	if ok {
+		return source, coord, nil
+	}
+	if source == "" {
+		available, err := localHistoryAvailable()
+		if err != nil {
+			return "", nil, err
+		}
+		if available {
+			return "local", nil, nil
+		}
+	}
+	return "", nil, exit(2, "command requires a configured coordinator (or existing local history)")
+}
+
+type historyReadRow struct {
+	renderResults *TestResultSummary
+	Source        string              `json:"source"`
+	Local         *localHistoryRecord `json:"local,omitempty"`
+	Coordinator   *CoordinatorRun     `json:"coordinator,omitempty"`
+	Log           *string             `json:"log,omitempty"`
+	Results       *TestResultSummary  `json:"results,omitempty"`
+	Failed        []TestFailure       `json:"failed,omitempty"`
+}
+
+type historyReadEnvelope struct {
+	Records []historyReadRow  `json:"records"`
+	Errors  map[string]string `json:"errors,omitempty"`
+}
+
+func (e *historyReadEnvelope) failure(source string, err error) {
+	if e.Errors == nil {
+		e.Errors = make(map[string]string)
+	}
+	e.Errors[source] = err.Error()
+}
+
+func (a App) finishHistoryRead(e historyReadEnvelope, jsonOut bool) error {
+	if jsonOut {
+		if err := json.NewEncoder(a.Stdout).Encode(e); err != nil {
+			return err
+		}
+	} else {
+		for _, source := range []string{"local", "coordinator"} {
+			if message, ok := e.Errors[source]; ok {
+				fmt.Fprintf(a.Stderr, "%s history: %s\n", source, message)
+			}
+		}
+	}
+	if len(e.Errors) != 0 {
+		return exit(1, "one or more requested history sources failed")
+	}
+	return nil
+}
+
+func (a App) historyFromSources(ctx context.Context, source string, coord *CoordinatorClient, filter localHistoryFilter, owner, org string, jsonOut bool, sourceErr error) error {
+	if filter.Limit <= 0 {
+		return exit(2, "limit must be positive")
+	}
+	e := historyReadEnvelope{Records: []historyReadRow{}}
+	if source != "coordinator" {
+		// Local records contain no authenticated actor attribution.
+		if owner != "" || org != "" {
+			e.failure("local", errors.New("owner and org filters require coordinator attribution"))
+		} else {
+			records, err := listLocalHistory(filter)
+			if err != nil {
+				e.failure("local", err)
+			} else {
+				for i := range records {
+					e.Records = append(e.Records, historyReadRow{Source: "local", Local: &records[i]})
+				}
+			}
+		}
+	}
+	if source != "local" {
+		if coord == nil {
+			if sourceErr == nil {
+				sourceErr = errors.New("coordinator is not configured")
+			}
+			e.failure("coordinator", sourceErr)
+		} else {
+			runs, err := coord.Runs(ctx, filter.LeaseID, owner, org, filter.State, filter.Limit)
+			if err != nil {
+				e.failure("coordinator", err)
+			} else {
+				for i := range runs {
+					matched := false
+					for j := range e.Records {
+						local := e.Records[j].Local
+						if local != nil && local.CoordinatorState == "recorded" && local.CoordinatorRunID == runs[i].ID && local.CoordinatorReference != "" && local.CoordinatorReference == coordinatorHistoryReference(coord.BaseURL) {
+							e.Records[j].Source = "both"
+							e.Records[j].Coordinator = &runs[i]
+							matched = true
+							break
+						}
+					}
+					if !matched {
+						e.Records = append(e.Records, historyReadRow{Source: "coordinator", Coordinator: &runs[i]})
+					}
+				}
+			}
+		}
+	}
+	sort.SliceStable(e.Records, func(i, j int) bool { return historyRowBefore(e.Records[i], e.Records[j]) })
+	if len(e.Records) > filter.Limit {
+		e.Records = e.Records[:filter.Limit]
+	}
+	if !jsonOut {
+		for _, row := range e.Records {
+			if r := row.Local; r != nil {
+				fmt.Fprintf(a.Stdout, "source=%s provenance=%s coordinator=%s %s lease=%s state=%s phase=%s exit=%s duration=%s started=%s command=%s\n", row.Source, terminalSafeResultField(r.Source), terminalSafeResultField(r.CoordinatorState), terminalSafeResultField(r.ID), terminalSafeResultField(blank(r.LeaseID, "-")), r.RecordingState, r.Phase, formatRunExit(r.ExitCode), formatMs(r.TotalMs), r.StartedAt, terminalSafeResultField(r.CommandDisplay))
+			} else {
+				r := row.Coordinator
+				fmt.Fprintf(a.Stdout, "source=coordinator %s lease=%s state=%s phase=%s exit=%s duration=%s started=%s\n", r.ID, blank(r.LeaseID, "-"), r.State, r.Phase, formatRunExit(r.ExitCode), formatMs(r.DurationMs), r.StartedAt)
+			}
+		}
+	}
+	return a.finishHistoryRead(e, jsonOut)
+}
+
+func historyRowStart(row historyReadRow) string {
+	if row.Local != nil {
+		return row.Local.StartedAt
+	}
+	return row.Coordinator.StartedAt
+}
+
+// Compare instants, not their RFC3339 spellings; invalid remote timestamps sort last.
+func historyRowBefore(a, b historyReadRow) bool {
+	at, ae := time.Parse(time.RFC3339Nano, historyRowStart(a))
+	bt, be := time.Parse(time.RFC3339Nano, historyRowStart(b))
+	if (ae == nil) != (be == nil) {
+		return ae == nil
+	}
+	if ae == nil && !at.Equal(bt) {
+		return at.After(bt)
+	}
+	aid, bid := historyRowID(a), historyRowID(b)
+	if aid != bid {
+		return aid < bid
+	}
+	return a.Source < b.Source
+}
+
+func historyRowID(row historyReadRow) string {
+	if row.Local != nil {
+		return row.Local.ID
+	}
+	return row.Coordinator.ID
+}
+
+func (a App) localHistoryRead(ctx context.Context, source string, coord *CoordinatorClient, id, kind string, tail int, failedOnly, jsonOut bool, sourceErr error) error {
+	e := historyReadEnvelope{Records: []historyReadRow{}}
+	if source != "coordinator" {
+		record, log, results, err := readLocalHistory(id)
+		if err != nil {
+			e.failure("local", err)
+		} else {
+			row := historyReadRow{Source: "local", Local: &record, Results: results, renderResults: results}
+			if kind == "logs" {
+				if tail > 0 {
+					log = tailLogLines(log, tail)
+				}
+				row.Log = &log
+				row.Results = nil
+			}
+			if kind == "results" && failedOnly {
+				row.Results = nil
+				row.Failed = []TestFailure{}
+				if results != nil {
+					row.Failed = nonNilTestFailures(results.Failed)
+				}
+			}
+			e.Records = append(e.Records, row)
+		}
+	}
+	if source != "local" {
+		if coord == nil {
+			if sourceErr == nil {
+				sourceErr = errors.New("coordinator is not configured")
+			}
+			e.failure("coordinator", sourceErr)
+		} else {
+			run, err := coord.Run(ctx, id)
+			if err != nil {
+				e.failure("coordinator", err)
+			} else {
+				row := historyReadRow{Source: "coordinator", Coordinator: &run, Results: run.Results, renderResults: run.Results}
+				if kind == "logs" {
+					log, err := coord.RunLogs(ctx, id)
+					if err != nil {
+						e.failure("coordinator", err)
+					} else {
+						if tail > 0 {
+							log = tailLogLines(log, tail)
+						}
+						row.Log = &log
+					}
+					row.Results = nil
+				}
+				if kind == "results" && failedOnly {
+					row.Results = nil
+					row.Failed = []TestFailure{}
+					if run.Results != nil {
+						row.Failed = nonNilTestFailures(run.Results.Failed)
+					}
+				}
+				e.Records = append(e.Records, row)
+			}
+		}
+	}
+	if !jsonOut {
+		for _, row := range e.Records {
+			fmt.Fprintf(a.Stderr, "source=%s run=%s\n", row.Source, terminalSafeResultField(id))
+			if row.Local != nil {
+				a.printLocalHistoryAvailability(*row.Local, kind)
+			}
+			if kind == "logs" {
+				if row.Log != nil {
+					fmt.Fprint(a.Stdout, *row.Log)
+				}
+				continue
+			}
+			results := row.renderResults
+			if results == nil {
+				fmt.Fprintf(a.Stdout, "no test results recorded for %s\n", terminalSafeResultField(id))
+			} else if failedOnly {
+				printTestFailuresOnly(a.Stdout, *results)
+			} else {
+				printTestResults(a.Stdout, *results)
+			}
+		}
+	}
+	return a.finishHistoryRead(e, jsonOut)
+}
+
+func (a App) printLocalHistoryAvailability(r localHistoryRecord, kind string) {
+	fmt.Fprintf(a.Stderr, "local provenance=%s coordinator=%s\n", terminalSafeResultField(r.Source), terminalSafeResultField(r.CoordinatorState))
+	if kind == "logs" {
+		fmt.Fprintf(a.Stderr, "local recording=%s scope=%s stdout=%s stderr=%s truncated=%t\n", r.RecordingState, r.CaptureScope, r.Stdout.Availability, r.Stderr.Availability, r.LogTruncated)
+		for _, stream := range []struct {
+			name  string
+			value localHistoryStream
+		}{{"stdout", r.Stdout}, {"stderr", r.Stderr}} {
+			if stream.value.Reason != "" {
+				fmt.Fprintf(a.Stderr, "%s: %s\n", stream.name, terminalSafeResultField(stream.value.Reason))
+			}
+		}
+	} else {
+		fmt.Fprintf(a.Stderr, "local results=%s detailsTruncated=%t omittedFiles=%d omittedFailures=%d clippedFields=%d\n", r.ResultsState, r.ResultsDetailsTruncated, r.ResultsOmittedFiles, r.ResultsOmittedFailures, r.ResultsClippedFields)
+	}
+}
+
+func (a App) localHistoryMaintenance(args []string) error {
+	action := args[0]
+	fs := newFlagSet("history "+action, a.Stderr)
+	source := fs.String("source", "local", "record source (local only)")
+	jsonOut := fs.Bool("json", false, "print JSON")
+	id, rest := popLeadingRunID(args[1:])
+	if err := parseFlags(fs, rest); err != nil {
+		return err
+	}
+	if *source != "local" {
+		return exit(2, "history %s supports only --source local", action)
+	}
+	positionals := fs.Args()
+	if id != "" {
+		positionals = append([]string{id}, positionals...)
+	}
+	if len(positionals) > 1 {
+		return exit(2, "history %s accepts at most one run id", action)
+	}
+	if len(positionals) == 1 {
+		id = positionals[0]
+	}
+	if action == "prune" {
+		if id != "" {
+			return exit(2, "usage: crabbox history prune [--source local]")
+		}
+		n, err := pruneLocalHistory()
+		if err != nil {
+			return err
+		}
+		if *jsonOut {
+			return json.NewEncoder(a.Stdout).Encode(map[string]any{"source": "local", "pruned": n})
+		}
+		fmt.Fprintf(a.Stdout, "pruned %d local history records\n", n)
+		return nil
+	}
+	if id == "" {
+		return exit(2, "usage: crabbox history delete <run-id> [--source local]")
+	}
+	if err := deleteLocalHistory(id); err != nil {
+		return err
+	}
+	if *jsonOut {
+		return json.NewEncoder(a.Stdout).Encode(map[string]any{"source": "local", "deleted": id})
+	}
+	fmt.Fprintf(a.Stdout, "deleted local history %s\n", terminalSafeResultField(id))
+	return nil
+}

--- a/internal/cli/local_history_read_test.go
+++ b/internal/cli/local_history_read_test.go
@@ -1,0 +1,250 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+func readerLocalRecord(t *testing.T, modify ...func(*localHistoryRecord)) localHistoryRecord {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	r := localHistoryRecord{Version: 1, ID: "run_0123456789abcdef0123456789abcdef", RecordingState: "active", Source: "local", CoordinatorState: "none", Provider: "local-container", CommandDisplay: "test", Phase: "admitted", StartedAt: now, UpdatedAt: now, ResultsState: "collected", CaptureScope: "workload", Stdout: localHistoryStream{Availability: "retained"}, Stderr: localHistoryStream{Availability: "omitted", Reason: "capture-only"}}
+	for _, f := range modify {
+		f(&r)
+	}
+	writer, err := beginLocalHistory(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.RecordingState = "terminal"
+	r.Phase = "finalizing"
+	r.EndedAt = now
+	code := 0
+	r.ExitCode = &code
+	err = writer.Commit(r, runLogSnapshot{Log: "first\nlast\n", Truncated: true}, &TestResultSummary{Format: "junit", Tests: 3, Failures: 1})
+	closeErr := writer.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	return r
+}
+
+func TestLocalHistoryReadersOffline(t *testing.T) {
+	r := readerLocalRecord(t)
+	// Explicit local must not even parse an invalid coordinator configuration.
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN_COMMAND", "not-json")
+	var out, diag bytes.Buffer
+	a := App{Stdout: &out, Stderr: &diag}
+	if err := a.logs(context.Background(), []string{r.ID, "--source", "local", "--tail", "1"}); err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != "last\n" {
+		t.Fatalf("log=%q", out.String())
+	}
+	if !strings.Contains(diag.String(), "stderr=omitted") || !strings.Contains(diag.String(), "capture-only") || !strings.Contains(diag.String(), "source=local") {
+		t.Fatalf("diagnostics=%q", diag.String())
+	}
+	out.Reset()
+	diag.Reset()
+	if err := a.results(context.Background(), []string{r.ID, "--source", "local"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "tests=3 failures=1") {
+		t.Fatalf("results=%q", out.String())
+	}
+	out.Reset()
+	if err := a.history(context.Background(), []string{"--source", "local", "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var e historyReadEnvelope
+	if err := json.Unmarshal(out.Bytes(), &e); err != nil {
+		t.Fatal(err)
+	}
+	if len(e.Records) != 1 || e.Records[0].Local.ID != r.ID || e.Records[0].Coordinator != nil {
+		t.Fatalf("envelope=%+v", e)
+	}
+}
+
+func TestLocalHistoryAllPreservesUnacknowledgedCollision(t *testing.T) {
+	r := readerLocalRecord(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"runs": []CoordinatorRun{{ID: r.ID, StartedAt: r.StartedAt}}})
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	var out, diag bytes.Buffer
+	a := App{Stdout: &out, Stderr: &diag}
+	if err := a.history(context.Background(), []string{"--source", "all", "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var e historyReadEnvelope
+	if err := json.Unmarshal(out.Bytes(), &e); err != nil {
+		t.Fatal(err)
+	}
+	if len(e.Records) != 2 || e.Records[0].Source == "both" || e.Records[1].Source == "both" {
+		t.Fatalf("collision=%+v", e)
+	}
+}
+
+func TestLocalHistoryAllReportsSourceFailure(t *testing.T) {
+	readerLocalRecord(t)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN_COMMAND", "not-json")
+	var out, diag bytes.Buffer
+	a := App{Stdout: &out, Stderr: &diag}
+	if err := a.history(context.Background(), []string{"--source", "all", "--json"}); err == nil {
+		t.Fatal("expected source failure")
+	}
+	var e historyReadEnvelope
+	if err := json.Unmarshal(out.Bytes(), &e); err != nil {
+		t.Fatal(err)
+	}
+	if len(e.Records) != 1 || e.Errors["coordinator"] == "" {
+		t.Fatalf("partial=%+v", e)
+	}
+}
+
+func TestLocalHistoryReaderMaintenance(t *testing.T) {
+	r := readerLocalRecord(t)
+	var out, diag bytes.Buffer
+	a := App{Stdout: &out, Stderr: &diag}
+	if err := a.history(context.Background(), []string{"delete", r.ID, "--source", "coordinator"}); err == nil {
+		t.Fatal("remote delete accepted")
+	}
+	if _, _, _, err := readLocalHistory(r.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.history(context.Background(), []string{"delete", r.ID, "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := readLocalHistory(r.ID); err == nil {
+		t.Fatal("record survived delete")
+	}
+}
+
+func TestLocalHistoryReaderDefaultWithoutCoordinator(t *testing.T) {
+	r := readerLocalRecord(t)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN_COMMAND", "")
+	var out, diag bytes.Buffer
+	a := App{Stdout: &out, Stderr: &diag}
+	if err := a.logs(context.Background(), []string{r.ID}); err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != "first\nlast\n" {
+		t.Fatalf("log=%q", out.String())
+	}
+}
+
+func TestLocalHistoryReaderEmptyDoesNotCreateStore(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", root)
+	var out, diag bytes.Buffer
+	a := App{Stdout: &out, Stderr: &diag}
+	if err := a.history(context.Background(), []string{"--source", "local", "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("read created entries: %v", entries)
+	}
+}
+
+func TestLocalHistoryAllCoalescesOnlyAcknowledgedReference(t *testing.T) {
+	for _, binding := range []string{"matching", "different", "missing"} {
+		t.Run(binding, func(t *testing.T) {
+			var r localHistoryRecord
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]any{"runs": []CoordinatorRun{{ID: r.ID, StartedAt: r.StartedAt}}})
+			}))
+			defer server.Close()
+			r = readerLocalRecord(t, func(r *localHistoryRecord) {
+				r.CoordinatorState = "recorded"
+				r.CoordinatorRunID = r.ID
+				r.Source = "both"
+				switch binding {
+				case "matching":
+					r.CoordinatorReference = coordinatorHistoryReference(server.URL)
+				case "different":
+					r.CoordinatorReference = coordinatorHistoryReference("https://other.example.invalid/broker")
+				}
+			})
+			t.Setenv("CRABBOX_COORDINATOR", server.URL)
+			var out, diag bytes.Buffer
+			a := App{Stdout: &out, Stderr: &diag}
+			if err := a.history(context.Background(), []string{"--source", "all", "--json"}); err != nil {
+				t.Fatal(err)
+			}
+			var e historyReadEnvelope
+			if err := json.Unmarshal(out.Bytes(), &e); err != nil {
+				t.Fatal(err)
+			}
+			if binding == "matching" {
+				if len(e.Records) != 1 || e.Records[0].Source != "both" || e.Records[0].Local == nil || e.Records[0].Coordinator == nil {
+					t.Fatalf("acknowledged=%+v", e)
+				}
+			} else if len(e.Records) != 2 {
+				t.Fatalf("unbound records coalesced: %+v", e)
+			}
+			out.Reset()
+			if err := a.history(context.Background(), []string{"--source", "local"}); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(out.String(), "source=local provenance=both coordinator=recorded") {
+				t.Fatalf("provenance missing: %q", out.String())
+			}
+		})
+	}
+}
+
+func TestLocalHistoryReaderDeleteRejectsExtraIDs(t *testing.T) {
+	r := readerLocalRecord(t)
+	var out, diag bytes.Buffer
+	a := App{Stdout: &out, Stderr: &diag}
+	for _, args := range [][]string{
+		{"delete", r.ID, "extra"},
+		{"delete", r.ID, "--source", "local", "extra"},
+		{"delete", "--source", "local", r.ID, "extra"},
+	} {
+		if err := a.history(context.Background(), args); err == nil {
+			t.Fatalf("accepted extra ID: %v", args)
+		}
+		if _, _, _, err := readLocalHistory(r.ID); err != nil {
+			t.Fatalf("invalid command deleted record: %v", err)
+		}
+	}
+}
+
+func TestLocalHistoryReaderSortsInstantsAndTies(t *testing.T) {
+	rows := []historyReadRow{
+		{Source: "local", Local: &localHistoryRecord{ID: "b", StartedAt: "2026-09-12T10:00:00Z"}},
+		{Source: "coordinator", Coordinator: &CoordinatorRun{ID: "fraction", StartedAt: "2026-09-12T10:00:00.1Z"}},
+		{Source: "coordinator", Coordinator: &CoordinatorRun{ID: "offset", StartedAt: "2026-09-12T09:00:00-02:00"}},
+		{Source: "local", Local: &localHistoryRecord{ID: "a", StartedAt: "2026-09-12T12:00:00+02:00"}},
+		{Source: "coordinator", Coordinator: &CoordinatorRun{ID: "a", StartedAt: "2026-09-12T10:00:00.000Z"}},
+		{Source: "coordinator", Coordinator: &CoordinatorRun{ID: "invalid", StartedAt: "unknown"}},
+	}
+	sort.SliceStable(rows, func(i, j int) bool { return historyRowBefore(rows[i], rows[j]) })
+	want := []string{"offset/coordinator", "fraction/coordinator", "a/coordinator", "a/local", "b/local", "invalid/coordinator"}
+	for i, row := range rows {
+		if got := historyRowID(row) + "/" + row.Source; got != want[i] {
+			t.Fatalf("row %d=%s want %s", i, got, want[i])
+		}
+	}
+}

--- a/internal/cli/local_history_reference.go
+++ b/internal/cli/local_history_reference.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// A local correlation key is not an attestation or a persisted credential URL.
+func coordinatorHistoryReference(base string) string {
+	u, err := url.Parse(strings.TrimSpace(base))
+	if err != nil || u.Hostname() == "" {
+		return ""
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return ""
+	}
+	host := strings.ToLower(u.Hostname())
+	port := u.Port()
+	if port != "" && !(scheme == "https" && port == "443") && !(scheme == "http" && port == "80") {
+		host = net.JoinHostPort(host, port)
+	} else if strings.Contains(host, ":") {
+		host = "[" + host + "]"
+	}
+	endpoint := scheme + "://" + host + strings.TrimRight(u.EscapedPath(), "/")
+	digest := sha256.Sum256([]byte(endpoint))
+	return "sha256:" + hex.EncodeToString(digest[:])
+}

--- a/internal/cli/local_history_store.go
+++ b/internal/cli/local_history_store.go
@@ -1,0 +1,1106 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	localHistoryMetadataLimit = 256 << 10
+	localHistoryResultsLimit  = 1 << 20
+	localHistoryReservation   = 10 << 20
+	localHistoryCapacity      = 256 << 20
+	localHistoryInactiveLimit = 100
+	localHistoryMaxAge        = 30 * 24 * time.Hour
+)
+
+var errLocalHistoryBusy = errors.New("local history record is busy")
+
+type localHistoryWriter struct {
+	mu     sync.Mutex
+	root   *os.Root
+	lock   *os.File
+	record localHistoryRecord
+	done   bool
+}
+
+func localHistoryID(id string) bool {
+	if len(id) != 36 || !strings.HasPrefix(id, "run_") {
+		return false
+	}
+	for _, c := range id[4:] {
+		if !(c >= '0' && c <= '9') && !(c >= 'a' && c <= 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// The state namespace is separate from lease claims. Opening a reader never creates it.
+func localHistoryRoot(create bool) (*os.Root, error) {
+	state, err := crabboxStateDir()
+	if err != nil {
+		return nil, err
+	}
+	if !filepath.IsAbs(state) {
+		return nil, fmt.Errorf("local history state path must be absolute")
+	}
+	logicalRoot, err := crabboxStateRootDir()
+	if err != nil {
+		return nil, err
+	}
+	for current := filepath.Clean(state); ; current = filepath.Dir(current) {
+		if info, err := os.Lstat(current); err == nil {
+			if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+				return nil, fmt.Errorf("invalid local history state directory")
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		if current == filepath.Clean(logicalRoot) {
+			break
+		}
+		if filepath.Dir(current) == current {
+			return nil, fmt.Errorf("invalid local history state root")
+		}
+	}
+	path := filepath.Join(state, "history")
+	if create {
+		if err := ensurePrivateDirectoryDurableWithSync(state, state, syncControllerDirectory); err != nil {
+			return nil, err
+		}
+		if info, err := os.Lstat(path); err == nil {
+			if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+				return nil, fmt.Errorf("invalid local history directory")
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		} else if err := ensurePrivateRunOutputDir(path); err != nil {
+			return nil, err
+		}
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("invalid local history directory")
+	}
+	root, err := os.OpenRoot(path)
+	if err != nil {
+		return nil, err
+	}
+	file, err := root.Open(".")
+	if err == nil {
+		err = localHistoryPrivate(file, true)
+		file.Close()
+	}
+	if err != nil {
+		root.Close()
+		return nil, err
+	}
+	if create {
+		if err := localHistoryMkdir(root, "runs"); err != nil {
+			root.Close()
+			return nil, err
+		}
+		if err := syncControllerDirectory(state); err != nil {
+			root.Close()
+			return nil, err
+		}
+	}
+	return root, nil
+}
+
+func localHistoryMkdir(root *os.Root, name string) error {
+	err := root.Mkdir(name, 0o700)
+	if err != nil && !errors.Is(err, os.ErrExist) {
+		return err
+	}
+	// Windows private directories need a non-inheriting DACL at creation.
+	if err == nil {
+		if err := ensurePrivateRunOutputDir(filepath.Join(root.Name(), name)); err != nil {
+			return err
+		}
+	}
+	child, err := localHistoryChild(root, name)
+	if err != nil {
+		return err
+	}
+	child.Close()
+	return localHistorySync(root)
+}
+func localHistoryChild(root *os.Root, name string) (*os.Root, error) {
+	info, err := root.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("invalid local history directory %s", name)
+	}
+	child, err := root.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	file, err := child.Open(".")
+	if err == nil {
+		err = localHistoryPrivate(file, true)
+		file.Close()
+	}
+	if err != nil {
+		child.Close()
+		return nil, err
+	}
+	return child, nil
+}
+
+func localHistoryLock(root *os.Root, create, wait bool) (*os.File, error) {
+	if create {
+		f, err := openArtifactBundleTemp(root, "write.lock", 0o600, true)
+		if err == nil {
+			err = f.Sync()
+			f.Close()
+			if err != nil {
+				return nil, err
+			}
+		} else if !errors.Is(err, os.ErrExist) {
+			return nil, err
+		}
+	}
+	info, err := root.Lstat("write.lock")
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || info.Size() != 0 {
+		return nil, fmt.Errorf("invalid local history lock")
+	}
+	file, err := localHistoryOpen(root, "write.lock", true)
+	if err != nil {
+		return nil, err
+	}
+	if err := localHistoryPrivate(file, false); err != nil {
+		file.Close()
+		return nil, err
+	}
+	actual, err := file.Stat()
+	if err != nil || !os.SameFile(info, actual) {
+		file.Close()
+		return nil, fmt.Errorf("local history lock changed while opening")
+	}
+	// Namespace waits are bounded; record locks are always attempted without waiting.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		locked, err := tryLockWebVNCDaemonFile(file)
+		if err != nil {
+			file.Close()
+			return nil, err
+		}
+		if locked {
+			return file, nil
+		}
+		if !wait || time.Now().After(deadline) {
+			file.Close()
+			return nil, errLocalHistoryBusy
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+func localHistoryUnlock(file *os.File) error {
+	if file == nil {
+		return nil
+	}
+	return errors.Join(unlockWebVNCDaemonFile(file), file.Close())
+}
+
+func beginLocalHistory(record localHistoryRecord) (*localHistoryWriter, error) {
+	if !localHistoryID(record.ID) {
+		return nil, fmt.Errorf("invalid local history run ID")
+	}
+	root, err := localHistoryRoot(true)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+	lock, err := localHistoryLock(root, true, true)
+	if err != nil {
+		return nil, err
+	}
+	defer localHistoryUnlock(lock)
+	if _, err := localHistoryPruneLocked(root, localHistoryReservation); err != nil {
+		return nil, err
+	}
+	runs, err := localHistoryChild(root, "runs")
+	if err != nil {
+		return nil, err
+	}
+	defer runs.Close()
+	if err := runs.Mkdir(record.ID, 0o700); err != nil {
+		return nil, err
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = runs.RemoveAll(record.ID)
+		}
+	}()
+	if err := ensurePrivateRunOutputDir(filepath.Join(runs.Name(), record.ID)); err != nil {
+		return nil, err
+	}
+	dir, err := localHistoryChild(runs, record.ID)
+	if err != nil {
+		return nil, err
+	}
+	held, err := localHistoryLock(dir, true, false)
+	if err != nil {
+		dir.Close()
+		return nil, err
+	}
+	writer := &localHistoryWriter{root: dir, lock: held}
+	record.Version = 1
+	record.RecordingState = "active"
+	record.Phase = "admitted"
+	if record.StartedAt == "" {
+		record.StartedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	record.UpdatedAt = record.StartedAt
+	if err := writer.Checkpoint(record); err != nil {
+		localHistoryUnlock(held)
+		dir.Close()
+		return nil, err
+	}
+	if err := localHistorySync(runs); err != nil {
+		localHistoryUnlock(held)
+		dir.Close()
+		return nil, err
+	}
+	cleanup = false
+	return writer, nil
+}
+
+func (w *localHistoryWriter) Checkpoint(record localHistoryRecord) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.root == nil || w.done {
+		return fmt.Errorf("local history writer is closed")
+	}
+	if w.record.ID != "" && record.ID != w.record.ID {
+		return fmt.Errorf("local history run ID changed")
+	}
+	record.Version = 1
+	record.RecordingState = "active"
+	record.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	record.LogSHA256 = ""
+	record.ResultsSHA256 = ""
+	bounded, data, err := localHistoryRecordBytes(record)
+	if err != nil {
+		return err
+	}
+	if err := localHistoryWrite(w.root, "record.json", data); err != nil {
+		return err
+	}
+	w.record = bounded
+	return nil
+}
+
+// Payloads are published first; only the last metadata replacement makes them terminal.
+func (w *localHistoryWriter) Commit(record localHistoryRecord, log runLogSnapshot, results *TestResultSummary) (err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.root == nil || w.done {
+		return fmt.Errorf("local history writer is closed")
+	}
+	if record.ID != w.record.ID {
+		return fmt.Errorf("local history run ID changed")
+	}
+	defer func() {
+		if err != nil {
+			incomplete := w.record
+			incomplete.RecordingState = "incomplete"
+			incomplete.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+			if _, data, encodeErr := localHistoryRecordBytes(incomplete); encodeErr == nil {
+				_ = localHistoryWrite(w.root, "record.json", data)
+			}
+		}
+		w.done = true
+	}()
+	if len(log.Log) > maxRunLogBytes || !utf8.ValidString(log.Log) {
+		return fmt.Errorf("local history log exceeds bounded UTF-8 snapshot")
+	}
+	record.Version = 1
+	record.RecordingState = "terminal"
+	record.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	if record.EndedAt == "" {
+		record.EndedAt = record.UpdatedAt
+	}
+	record.LogBytes = len(log.Log)
+	record.LogTruncated = log.Truncated
+	record.LogFullSHA256 = log.FullSHA256
+	record.LogSHA256 = localHistoryDigest([]byte(log.Log))
+	record.ResultsSHA256 = ""
+	resultData, err := localHistoryResultBytes(results, &record)
+	if err != nil {
+		return err
+	}
+	if resultData != nil {
+		record.ResultsSHA256 = localHistoryDigest(resultData)
+	}
+	bounded, data, err := localHistoryRecordBytes(record)
+	if err != nil {
+		return err
+	}
+	if err := localHistoryWrite(w.root, "log.txt", []byte(log.Log)); err != nil {
+		return err
+	}
+	if resultData != nil {
+		if err := localHistoryWrite(w.root, "results.json", resultData); err != nil {
+			return err
+		}
+	}
+	if err := localHistoryWrite(w.root, "record.json", data); err != nil {
+		return err
+	}
+	w.record = bounded
+	return nil
+}
+func (w *localHistoryWriter) Close() error {
+	if w == nil {
+		return nil
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.root == nil {
+		return nil
+	}
+	err := errors.Join(localHistoryUnlock(w.lock), w.root.Close())
+	w.root = nil
+	w.lock = nil
+	_, pruneErr := pruneLocalHistory()
+	return errors.Join(err, pruneErr)
+}
+func localHistoryDigest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// Each fixed temporary name is exclusive and bounded. A crash leaves at most one
+// payload temporary of each kind; abandoned entries participate in ordinary pruning.
+func localHistoryWrite(root *os.Root, name string, data []byte) error {
+	tmp := "." + name + ".tmp"
+	file, err := openArtifactBundleTemp(root, tmp, 0o600, true)
+	if err != nil {
+		return err
+	}
+	defer root.Remove(tmp)
+	if _, err := file.Write(data); err != nil {
+		file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := root.Rename(tmp, name); err != nil {
+		return err
+	}
+	return localHistorySync(root)
+}
+
+func localHistoryReadBytes(root *os.Root, name string, maximum int64) ([]byte, error) {
+	before, err := root.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if !before.Mode().IsRegular() || before.Size() > maximum {
+		return nil, fmt.Errorf("invalid or oversized local history %s", name)
+	}
+	file, err := localHistoryOpen(root, name, false)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	if err := localHistoryPrivate(file, false); err != nil {
+		return nil, err
+	}
+	actual, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !os.SameFile(before, actual) {
+		return nil, fmt.Errorf("local history file changed")
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maximum+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maximum {
+		return nil, fmt.Errorf("oversized local history %s", name)
+	}
+	return data, nil
+}
+func localHistoryReadRecord(dir *os.Root, id string) (localHistoryRecord, error) {
+	var record localHistoryRecord
+	data, err := localHistoryReadBytes(dir, "record.json", localHistoryMetadataLimit)
+	if err != nil {
+		return record, err
+	}
+	if err := json.Unmarshal(data, &record); err != nil {
+		return record, err
+	}
+	if record.ID != id || record.Version != 1 {
+		return record, fmt.Errorf("invalid local history metadata identity/version")
+	}
+	if _, _, err := localHistoryRecordBytes(record); err != nil {
+		return record, err
+	}
+	return record, nil
+}
+
+func localHistoryClip(value string, maximum int) (string, bool) {
+	if maximum <= 0 {
+		return "", len(value) > 0
+	}
+	changed := len(value) > maximum
+	// A bounded lookahead completes a rune crossing the byte limit. Normalize
+	// before clipping so an earlier malformed byte cannot erase a valid suffix.
+	prefix := value[:min(len(value), maximum+utf8.UTFMax-1)]
+	if !utf8.ValidString(prefix) {
+		changed = true
+		prefix = strings.ToValidUTF8(prefix, "�")
+	}
+	if len(prefix) > maximum {
+		end := maximum
+		for end > 0 && !utf8.RuneStart(prefix[end]) {
+			end--
+		}
+		prefix = prefix[:end]
+	}
+	return strings.Clone(prefix), changed
+}
+
+func localHistoryRecordBytes(r localHistoryRecord) (localHistoryRecord, []byte, error) {
+	fail := func() (localHistoryRecord, []byte, error) {
+		return r, nil, fmt.Errorf("invalid local history metadata")
+	}
+	if !localHistoryID(r.ID) || r.Version != 1 {
+		return fail()
+	}
+	if r.LeaseID != "" && (!validLeaseClaimPathID(r.LeaseID) || len(r.LeaseID) > 1024) {
+		return fail()
+	}
+	if r.CoordinatorRunID != "" && (!validLeaseClaimPathID(r.CoordinatorRunID) || len(r.CoordinatorRunID) > 128) {
+		return fail()
+	}
+	if r.CoordinatorReference != "" {
+		reference := strings.TrimPrefix(r.CoordinatorReference, "sha256:")
+		if len(reference) != 64 {
+			return fail()
+		}
+		if _, err := hex.DecodeString(reference); err != nil {
+			return fail()
+		}
+	}
+	for _, value := range []string{r.StartedAt, r.UpdatedAt} {
+		if _, err := time.Parse(time.RFC3339Nano, value); err != nil {
+			return fail()
+		}
+	}
+	if r.EndedAt != "" {
+		if _, err := time.Parse(time.RFC3339Nano, r.EndedAt); err != nil {
+			return fail()
+		}
+	}
+	if r.RecordingState != "active" && r.RecordingState != "incomplete" && r.RecordingState != "terminal" {
+		return fail()
+	}
+	if r.Source == "" {
+		r.Source = "local"
+	}
+	if r.Source != "local" && r.Source != "both" {
+		return fail()
+	}
+	if r.CoordinatorState == "" {
+		r.CoordinatorState = "none"
+	}
+	if r.CoordinatorState != "none" && r.CoordinatorState != "recorded" && r.CoordinatorState != "unknown" {
+		return fail()
+	}
+	if r.ResultsState == "" {
+		r.ResultsState = "unavailable"
+	}
+	if r.ResultsState != "collected" && r.ResultsState != "no-results" && r.ResultsState != "unsupported" && r.ResultsState != "unavailable" {
+		return fail()
+	}
+	for _, stream := range []*localHistoryStream{&r.Stdout, &r.Stderr} {
+		if stream.Availability == "" {
+			stream.Availability = "unavailable"
+		}
+		if stream.Availability != "retained" && stream.Availability != "omitted" && stream.Availability != "unavailable" {
+			return fail()
+		}
+		stream.Reason, _ = localHistoryClip(stream.Reason, 4096)
+	}
+	var clipped bool
+	r.CommandDisplay, clipped = localHistoryClip(r.CommandDisplay, 16<<10)
+	r.CommandDisplayTruncated = r.CommandDisplayTruncated || clipped
+	r.Diagnostic, clipped = localHistoryClip(r.Diagnostic, 16<<10)
+	r.DiagnosticTruncated = r.DiagnosticTruncated || clipped
+	for _, value := range []*string{&r.Provider, &r.Slug, &r.Target} {
+		*value, _ = localHistoryClip(*value, 1024)
+	}
+	if len(r.Phase) > 64 || len(r.CaptureScope) > 64 || len(r.RunStatus) > 64 || len(r.ErrorKind) > 64 {
+		return fail()
+	}
+	for _, digest := range []string{r.LogSHA256, r.ResultsSHA256} {
+		if digest != "" {
+			if len(digest) != 64 {
+				return fail()
+			}
+			decoded, err := hex.DecodeString(digest)
+			if err != nil || len(decoded) != 32 {
+				return fail()
+			}
+		}
+	}
+	if r.LogFullSHA256 != "" {
+		if len(r.LogFullSHA256) != len("sha256:")+64 || !strings.HasPrefix(r.LogFullSHA256, "sha256:") {
+			return fail()
+		}
+		if _, err := hex.DecodeString(strings.TrimPrefix(r.LogFullSHA256, "sha256:")); err != nil {
+			return fail()
+		}
+	}
+	data, err := json.Marshal(r)
+	if err != nil {
+		return r, nil, err
+	}
+	if len(data) > localHistoryMetadataLimit {
+		return fail()
+	}
+	return r, data, nil
+}
+
+func localHistoryResultBytes(summary *TestResultSummary, record *localHistoryRecord) ([]byte, error) {
+	if summary == nil {
+		return nil, nil
+	}
+	out := *summary
+	out.Files = []string{}
+	out.Failed = []TestFailure{}
+	record.ResultsClippedFields = 0
+	record.ResultsOmittedFiles = 0
+	record.ResultsOmittedFailures = 0
+	clip := func(value string) string {
+		result, clipped := localHistoryClip(value, 4096)
+		if clipped {
+			record.ResultsClippedFields++
+		}
+		return result
+	}
+	out.Format = clip(out.Format)
+	data, err := json.Marshal(out)
+	if err != nil {
+		return nil, err
+	}
+	size := len(data)
+	// Incremental encoded sizes avoid repeatedly serializing the growing summary.
+	// Only bounded details are encoded, and scalar totals never depend on retention.
+	for i, value := range summary.Files {
+		priorClipped := record.ResultsClippedFields
+		value = clip(value)
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return nil, err
+		}
+		extra := len(encoded)
+		if len(out.Files) > 0 {
+			extra++
+		}
+		if size+extra > localHistoryResultsLimit {
+			record.ResultsClippedFields = priorClipped
+			record.ResultsOmittedFiles = len(summary.Files) - i
+			break
+		}
+		out.Files = append(out.Files, value)
+		size += extra
+	}
+	for i, value := range summary.Failed {
+		priorClipped := record.ResultsClippedFields
+		value.Suite = clip(value.Suite)
+		value.Name = clip(value.Name)
+		value.Classname = clip(value.Classname)
+		value.File = clip(value.File)
+		value.Message = clip(value.Message)
+		value.Type = clip(value.Type)
+		value.Kind = clip(value.Kind)
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return nil, err
+		}
+		extra := len(encoded)
+		if len(out.Failed) > 0 {
+			extra++
+		}
+		if size+extra > localHistoryResultsLimit {
+			record.ResultsClippedFields = priorClipped
+			record.ResultsOmittedFailures = len(summary.Failed) - i
+			break
+		}
+		out.Failed = append(out.Failed, value)
+		size += extra
+	}
+	record.ResultsDetailsTruncated = record.ResultsOmittedFiles > 0 || record.ResultsOmittedFailures > 0 || record.ResultsClippedFields > 0
+	data, err = json.Marshal(out)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > localHistoryResultsLimit {
+		return nil, fmt.Errorf("local history result projection exceeds budget")
+	}
+	return data, nil
+}
+
+type localHistoryEntry struct {
+	id     string
+	size   int64
+	stamp  time.Time
+	active bool
+}
+
+// Called only with the namespace lock. Never wait on a record lock here: a
+// finisher may be about to release it and run this same retention pass.
+func localHistoryScan(root *os.Root) ([]localHistoryEntry, int64, error) {
+	top, err := root.Open(".")
+	if err != nil {
+		return nil, 0, err
+	}
+	names, err := top.ReadDir(-1)
+	top.Close()
+	if err != nil {
+		return nil, 0, err
+	}
+	for _, entry := range names {
+		if entry.Name() != "write.lock" && entry.Name() != "runs" {
+			return nil, 0, fmt.Errorf("unmanaged local history entry %s", entry.Name())
+		}
+	}
+	runs, err := localHistoryChild(root, "runs")
+	if err != nil {
+		return nil, 0, err
+	}
+	defer runs.Close()
+	file, err := runs.Open(".")
+	if err != nil {
+		return nil, 0, err
+	}
+	entries, err := file.ReadDir(-1)
+	file.Close()
+	if err != nil {
+		return nil, 0, err
+	}
+	var out []localHistoryEntry
+	var total int64 = 3 * 4096
+	for _, entry := range entries {
+		id := entry.Name()
+		if !localHistoryID(id) {
+			return nil, 0, fmt.Errorf("unmanaged local history run directory %s", id)
+		}
+		dir, err := localHistoryChild(runs, id)
+		if err != nil {
+			return nil, 0, err
+		}
+		held, lockErr := localHistoryLock(dir, false, false)
+		if lockErr != nil && !errors.Is(lockErr, errLocalHistoryBusy) && !errors.Is(lockErr, os.ErrNotExist) {
+			dir.Close()
+			return nil, 0, lockErr
+		}
+		item := localHistoryEntry{id: id, size: 4096, active: errors.Is(lockErr, errLocalHistoryBusy)}
+		inspect, err := dir.Open(".")
+		if err != nil {
+			localHistoryUnlock(held)
+			dir.Close()
+			return nil, 0, err
+		}
+		info, err := inspect.Stat()
+		if err != nil {
+			inspect.Close()
+			localHistoryUnlock(held)
+			dir.Close()
+			return nil, 0, err
+		}
+		item.stamp = info.ModTime()
+		children, err := inspect.ReadDir(-1)
+		inspect.Close()
+		if err == nil {
+			for _, child := range children {
+				name := child.Name()
+				if name != "record.json" && name != "log.txt" && name != "results.json" && name != "write.lock" && name != ".record.json.tmp" && name != ".log.txt.tmp" && name != ".results.json.tmp" {
+					err = fmt.Errorf("unmanaged local history payload %s", name)
+					break
+				}
+				info, e := dir.Lstat(name)
+				if e != nil {
+					if item.active && errors.Is(e, os.ErrNotExist) {
+						continue
+					}
+					err = e
+					break
+				}
+				if !info.Mode().IsRegular() {
+					err = fmt.Errorf("invalid local history payload %s", name)
+					break
+				}
+				item.size += max(int64(4096), (info.Size()+4095)/4096*4096)
+			}
+		}
+		if err == nil && !item.active {
+			record, e := localHistoryReadRecord(dir, id)
+			if e == nil {
+				item.stamp, _ = time.Parse(time.RFC3339Nano, record.UpdatedAt)
+			} else if !errors.Is(e, os.ErrNotExist) {
+				err = fmt.Errorf("corrupt local history %s: %w", id, e)
+			}
+		}
+		localHistoryUnlock(held)
+		dir.Close()
+		if err != nil {
+			return nil, 0, err
+		}
+		if item.active {
+			item.size = max(item.size, int64(localHistoryReservation))
+		}
+		total += item.size
+		out = append(out, item)
+	}
+	return out, total, nil
+}
+func localHistoryPruneLocked(root *os.Root, reserve int64) (int, error) {
+	entries, total, err := localHistoryScan(root)
+	if err != nil {
+		return 0, err
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].stamp.Equal(entries[j].stamp) {
+			return entries[i].id < entries[j].id
+		}
+		return entries[i].stamp.Before(entries[j].stamp)
+	})
+	inactive := 0
+	for _, entry := range entries {
+		if !entry.active {
+			inactive++
+		}
+	}
+	runs, err := localHistoryChild(root, "runs")
+	if err != nil {
+		return 0, err
+	}
+	defer runs.Close()
+	removed := 0
+	for _, entry := range entries {
+		if entry.active {
+			continue
+		}
+		if inactive <= localHistoryInactiveLimit && total+reserve <= localHistoryCapacity && time.Since(entry.stamp) <= localHistoryMaxAge {
+			continue
+		}
+		dir, err := localHistoryChild(runs, entry.id)
+		if err != nil {
+			return removed, err
+		}
+		held, err := localHistoryLock(dir, true, false)
+		if errors.Is(err, errLocalHistoryBusy) {
+			dir.Close()
+			continue
+		}
+		if err != nil {
+			dir.Close()
+			return removed, err
+		}
+		// All readers acquire under the namespace lock, so no new lock waiter can
+		// retain a deleted inode and later write through a recreated directory.
+		err = localHistoryRemoveRecord(dir)
+		localHistoryUnlock(held)
+		dir.Close()
+		if err == nil {
+			err = runs.Remove(filepath.Join(entry.id, "write.lock"))
+		}
+		if err == nil {
+			err = runs.Remove(entry.id)
+		}
+		if err != nil {
+			return removed, err
+		}
+		total -= entry.size
+		inactive--
+		removed++
+	}
+	if err := localHistorySync(runs); err != nil {
+		return removed, err
+	}
+	if total+reserve > localHistoryCapacity {
+		return removed, fmt.Errorf("local history capacity unavailable: active reservations or retained data fill store")
+	}
+	return removed, nil
+}
+func localHistoryRemoveRecord(dir *os.Root) error {
+	f, err := dir.Open(".")
+	if err != nil {
+		return err
+	}
+	entries, err := f.ReadDir(-1)
+	f.Close()
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.Name() == "write.lock" {
+			continue
+		}
+		switch entry.Name() {
+		case "record.json", "log.txt", "results.json", ".record.json.tmp", ".log.txt.tmp", ".results.json.tmp":
+		default:
+			return fmt.Errorf("unmanaged local history payload %s", entry.Name())
+		}
+		info, err := dir.Lstat(entry.Name())
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("invalid local history payload")
+		}
+		if err := dir.Remove(entry.Name()); err != nil {
+			return err
+		}
+	}
+	// Windows cannot unlink an open lock; caller closes it before removing it.
+	return nil
+}
+
+func localHistoryAvailable() (bool, error) {
+	root, err := localHistoryRoot(false)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	defer root.Close()
+	return true, nil
+}
+func pruneLocalHistory() (int, error) {
+	root, err := localHistoryRoot(false)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	defer root.Close()
+	held, err := localHistoryLock(root, true, true)
+	if err != nil {
+		return 0, err
+	}
+	defer localHistoryUnlock(held)
+	return localHistoryPruneLocked(root, 0)
+}
+
+func listLocalHistory(filter localHistoryFilter) ([]localHistoryRecord, error) {
+	switch filter.State {
+	case "", "active", "incomplete", "terminal", string(RunStatusSucceeded), string(RunStatusFailed), string(RunStatusTimedOut), string(RunStatusCanceled):
+	default:
+		return nil, fmt.Errorf("invalid local history state %q", filter.State)
+	}
+	records := []localHistoryRecord{}
+	root, err := localHistoryRoot(false)
+	if errors.Is(err, os.ErrNotExist) {
+		return records, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+	held, err := localHistoryLock(root, true, true)
+	if err != nil {
+		return nil, err
+	}
+	defer localHistoryUnlock(held)
+	runs, err := localHistoryChild(root, "runs")
+	if err != nil {
+		return nil, err
+	}
+	defer runs.Close()
+	f, err := runs.Open(".")
+	if err != nil {
+		return nil, err
+	}
+	entries, err := f.ReadDir(-1)
+	f.Close()
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range entries {
+		if !localHistoryID(entry.Name()) {
+			return nil, fmt.Errorf("invalid local history run ID")
+		}
+		dir, err := localHistoryChild(runs, entry.Name())
+		if err != nil {
+			return nil, err
+		}
+		lock, lockErr := localHistoryLock(dir, false, false)
+		if lockErr != nil && !errors.Is(lockErr, errLocalHistoryBusy) {
+			dir.Close()
+			return nil, lockErr
+		}
+		record, err := localHistoryReadRecord(dir, entry.Name())
+		if err == nil && lockErr == nil && record.RecordingState == "active" {
+			record.RecordingState = "incomplete"
+			record.Stdout.Availability = "unavailable"
+			record.Stderr.Availability = "unavailable"
+		}
+		localHistoryUnlock(lock)
+		dir.Close()
+		if err != nil {
+			return nil, err
+		}
+		if filter.LeaseID != "" && filter.LeaseID != record.LeaseID {
+			continue
+		}
+		if filter.State != "" && filter.State != record.RecordingState && filter.State != string(record.RunStatus) {
+			continue
+		}
+		records = append(records, record)
+	}
+	sort.Slice(records, func(i, j int) bool {
+		a, _ := time.Parse(time.RFC3339Nano, records[i].StartedAt)
+		b, _ := time.Parse(time.RFC3339Nano, records[j].StartedAt)
+		if a.Equal(b) {
+			return records[i].ID < records[j].ID
+		}
+		return a.After(b)
+	})
+	if filter.Limit > 0 && len(records) > filter.Limit {
+		records = records[:filter.Limit]
+	}
+	return records, nil
+}
+func readLocalHistory(id string) (localHistoryRecord, string, *TestResultSummary, error) {
+	var record localHistoryRecord
+	if !localHistoryID(id) {
+		return record, "", nil, fmt.Errorf("invalid local history run ID")
+	}
+	root, err := localHistoryRoot(false)
+	if err != nil {
+		return record, "", nil, err
+	}
+	defer root.Close()
+	held, err := localHistoryLock(root, true, true)
+	if err != nil {
+		return record, "", nil, err
+	}
+	defer localHistoryUnlock(held)
+	runs, err := localHistoryChild(root, "runs")
+	if err != nil {
+		return record, "", nil, err
+	}
+	defer runs.Close()
+	dir, err := localHistoryChild(runs, id)
+	if err != nil {
+		return record, "", nil, err
+	}
+	defer dir.Close()
+	lock, lockErr := localHistoryLock(dir, false, false)
+	if lockErr != nil && !errors.Is(lockErr, errLocalHistoryBusy) {
+		return record, "", nil, lockErr
+	}
+	defer localHistoryUnlock(lock)
+	record, err = localHistoryReadRecord(dir, id)
+	if err != nil {
+		return record, "", nil, err
+	}
+	if record.RecordingState != "terminal" {
+		if lockErr == nil {
+			record.RecordingState = "incomplete"
+		}
+		record.Stdout.Availability = "unavailable"
+		record.Stderr.Availability = "unavailable"
+		return record, "", nil, nil
+	}
+	data, err := localHistoryReadBytes(dir, "log.txt", maxRunLogBytes)
+	if err != nil {
+		return record, "", nil, err
+	}
+	if !utf8.Valid(data) || localHistoryDigest(data) != record.LogSHA256 || len(data) != record.LogBytes {
+		return record, "", nil, fmt.Errorf("local history log integrity mismatch")
+	}
+	var summary *TestResultSummary
+	if record.ResultsSHA256 != "" {
+		resultData, err := localHistoryReadBytes(dir, "results.json", localHistoryResultsLimit)
+		if err != nil {
+			return record, "", nil, err
+		}
+		if localHistoryDigest(resultData) != record.ResultsSHA256 {
+			return record, "", nil, fmt.Errorf("local history results integrity mismatch")
+		}
+		summary = &TestResultSummary{}
+		if err := json.Unmarshal(resultData, summary); err != nil {
+			return record, "", nil, err
+		}
+	}
+	return record, string(data), summary, nil
+}
+func deleteLocalHistory(id string) error {
+	if !localHistoryID(id) {
+		return fmt.Errorf("invalid local history run ID")
+	}
+	root, err := localHistoryRoot(false)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	held, err := localHistoryLock(root, true, true)
+	if err != nil {
+		return err
+	}
+	defer localHistoryUnlock(held)
+	runs, err := localHistoryChild(root, "runs")
+	if err != nil {
+		return err
+	}
+	defer runs.Close()
+	dir, err := localHistoryChild(runs, id)
+	if err != nil {
+		return err
+	}
+	lock, err := localHistoryLock(dir, true, false)
+	if err != nil {
+		dir.Close()
+		return err
+	}
+	err = localHistoryRemoveRecord(dir)
+	localHistoryUnlock(lock)
+	dir.Close()
+	if err != nil {
+		return err
+	}
+	if err := runs.Remove(filepath.Join(id, "write.lock")); err != nil {
+		return err
+	}
+	if err := runs.Remove(id); err != nil {
+		return err
+	}
+	return localHistorySync(runs)
+}

--- a/internal/cli/local_history_store.go
+++ b/internal/cli/local_history_store.go
@@ -469,6 +469,33 @@ func localHistoryReadRecord(dir *os.Root, id string) (localHistoryRecord, error)
 	return record, nil
 }
 
+// A process may stop after creating its directory but before publishing its
+// first metadata. Represent only that absent-file window, never corrupt data.
+func localHistoryReadInitialRecord(dir *os.Root, id string, missingLock bool) (localHistoryRecord, error) {
+	record, err := localHistoryReadRecord(dir, id)
+	if err == nil {
+		if missingLock {
+			return record, fmt.Errorf("local history metadata has no write lock")
+		}
+		return record, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return record, err
+	}
+	info, err := dir.Stat(".")
+	if err != nil {
+		return record, err
+	}
+	return localHistoryRecord{
+		Version: 1, ID: id, RecordingState: "incomplete", Source: "local",
+		CoordinatorState: "unknown", Phase: "initialization-incomplete",
+		UpdatedAt:    info.ModTime().UTC().Format(time.RFC3339Nano),
+		CaptureScope: "unavailable", ResultsState: "unavailable",
+		Stdout: localHistoryStream{Availability: "unavailable"},
+		Stderr: localHistoryStream{Availability: "unavailable"},
+	}, nil
+}
+
 func localHistoryClip(value string, maximum int) (string, bool) {
 	if maximum <= 0 {
 		return "", len(value) > 0
@@ -961,11 +988,11 @@ func listLocalHistory(filter localHistoryFilter) ([]localHistoryRecord, error) {
 			return nil, err
 		}
 		lock, lockErr := localHistoryLock(dir, false, false)
-		if lockErr != nil && !errors.Is(lockErr, errLocalHistoryBusy) {
+		if lockErr != nil && !errors.Is(lockErr, errLocalHistoryBusy) && !errors.Is(lockErr, os.ErrNotExist) {
 			dir.Close()
 			return nil, lockErr
 		}
-		record, err := localHistoryReadRecord(dir, entry.Name())
+		record, err := localHistoryReadInitialRecord(dir, entry.Name(), errors.Is(lockErr, os.ErrNotExist))
 		if err == nil && lockErr == nil && record.RecordingState == "active" {
 			record.RecordingState = "incomplete"
 			record.Stdout.Availability = "unavailable"
@@ -1023,11 +1050,11 @@ func readLocalHistory(id string) (localHistoryRecord, string, *TestResultSummary
 	}
 	defer dir.Close()
 	lock, lockErr := localHistoryLock(dir, false, false)
-	if lockErr != nil && !errors.Is(lockErr, errLocalHistoryBusy) {
+	if lockErr != nil && !errors.Is(lockErr, errLocalHistoryBusy) && !errors.Is(lockErr, os.ErrNotExist) {
 		return record, "", nil, lockErr
 	}
 	defer localHistoryUnlock(lock)
-	record, err = localHistoryReadRecord(dir, id)
+	record, err = localHistoryReadInitialRecord(dir, id, errors.Is(lockErr, os.ErrNotExist))
 	if err != nil {
 		return record, "", nil, err
 	}

--- a/internal/cli/local_history_store.go
+++ b/internal/cli/local_history_store.go
@@ -124,15 +124,8 @@ func localHistoryRoot(create bool) (*os.Root, error) {
 }
 
 func localHistoryMkdir(root *os.Root, name string) error {
-	err := root.Mkdir(name, 0o700)
-	if err != nil && !errors.Is(err, os.ErrExist) {
+	if _, err := localHistoryCreateDirectory(root, name); err != nil {
 		return err
-	}
-	// Windows private directories need a non-inheriting DACL at creation.
-	if err == nil {
-		if err := ensurePrivateRunOutputDir(filepath.Join(root.Name(), name)); err != nil {
-			return err
-		}
 	}
 	child, err := localHistoryChild(root, name)
 	if err != nil {
@@ -245,17 +238,18 @@ func beginLocalHistory(record localHistoryRecord) (*localHistoryWriter, error) {
 		return nil, err
 	}
 	defer runs.Close()
-	if err := runs.Mkdir(record.ID, 0o700); err != nil {
-		return nil, err
-	}
-	cleanup := true
+	created, err := localHistoryCreateDirectory(runs, record.ID)
+	cleanup := created
 	defer func() {
 		if cleanup {
 			_ = runs.RemoveAll(record.ID)
 		}
 	}()
-	if err := ensurePrivateRunOutputDir(filepath.Join(runs.Name(), record.ID)); err != nil {
+	if err != nil {
 		return nil, err
+	}
+	if !created {
+		return nil, &os.PathError{Op: "mkdir", Path: record.ID, Err: os.ErrExist}
 	}
 	dir, err := localHistoryChild(runs, record.ID)
 	if err != nil {

--- a/internal/cli/local_history_store_test.go
+++ b/internal/cli/local_history_store_test.go
@@ -190,6 +190,91 @@ func TestLocalHistoryStoreAbandonedAndPartialAreNotTerminal(t *testing.T) {
 		t.Fatalf("abandoned %+v %q %+v", got, log, summary)
 	}
 }
+
+func TestLocalHistoryStoreInterruptedInitializationKeepsHealthyRows(t *testing.T) {
+	for _, withLock := range []bool{false, true} {
+		t.Run(fmt.Sprintf("lock=%t", withLock), func(t *testing.T) {
+			localHistoryTestHome(t)
+			healthy := localHistoryTestRecord(910)
+			writer, err := beginLocalHistory(healthy)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := writer.Commit(healthy, runLogSnapshot{Log: "healthy\n"}, nil); err != nil {
+				t.Fatal(err)
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatal(err)
+			}
+			root, err := localHistoryRoot(false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer root.Close()
+			runs, err := localHistoryChild(root, "runs")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer runs.Close()
+			id := localHistoryTestRecord(911).ID
+			if err := localHistoryMkdir(runs, id); err != nil {
+				t.Fatal(err)
+			}
+			if withLock {
+				dir, err := localHistoryChild(runs, id)
+				if err != nil {
+					t.Fatal(err)
+				}
+				lock, err := localHistoryLock(dir, true, false)
+				if err != nil {
+					dir.Close()
+					t.Fatal(err)
+				}
+				err = localHistoryUnlock(lock)
+				dir.Close()
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			rows, err := listLocalHistory(localHistoryFilter{})
+			if err != nil || len(rows) != 2 || rows[0].ID != healthy.ID {
+				t.Fatalf("rows=%+v err=%v", rows, err)
+			}
+			incomplete, log, results, err := readLocalHistory(id)
+			if err != nil || incomplete.RecordingState != "incomplete" || incomplete.Provider != "" || incomplete.CommandDisplay != "" || incomplete.ExitCode != nil || incomplete.StartedAt != "" || incomplete.Stdout.Availability != "unavailable" || incomplete.Stderr.Availability != "unavailable" || incomplete.ResultsState != "unavailable" || log != "" || results != nil {
+				t.Fatalf("incomplete=%+v log=%q results=%+v err=%v", incomplete, log, results, err)
+			}
+			filtered, err := listLocalHistory(localHistoryFilter{State: "incomplete"})
+			if err != nil || len(filtered) != 1 || filtered[0].ID != id {
+				t.Fatalf("incomplete filter=%+v err=%v", filtered, err)
+			}
+			if _, log, _, err := readLocalHistory(healthy.ID); err != nil || log != "healthy\n" {
+				t.Fatalf("healthy log=%q err=%v", log, err)
+			}
+		})
+	}
+}
+
+func TestLocalHistoryStoreMissingLockWithPublishedMetadataRemainsError(t *testing.T) {
+	path := localHistoryTestHome(t)
+	record := localHistoryTestRecord(912)
+	writer, err := beginLocalHistory(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(path, "runs", record.ID, "write.lock")); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := readLocalHistory(record.ID); err == nil {
+		t.Fatal("published metadata without a lock was accepted")
+	}
+	if _, err := listLocalHistory(localHistoryFilter{}); err == nil {
+		t.Fatal("listing accepted published metadata without a lock")
+	}
+}
 func TestLocalHistoryStoreCommitFailureLeavesIncomplete(t *testing.T) {
 	path := localHistoryTestHome(t)
 	record := localHistoryTestRecord(3)

--- a/internal/cli/local_history_store_test.go
+++ b/internal/cli/local_history_store_test.go
@@ -161,6 +161,17 @@ func TestLocalHistoryStoreLifecycle(t *testing.T) {
 	if got.RecordingState != "terminal" || log != "out\nerr\n" || results.Tests != 7 || results.Failures != 2 || got.LogSHA256 == "" || got.ResultsSHA256 == "" {
 		t.Fatalf("terminal %+v %q %+v", got, log, results)
 	}
+	duplicate, err := beginLocalHistory(record)
+	if duplicate != nil {
+		duplicate.Close()
+		t.Fatal("duplicate run ID admitted")
+	}
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("duplicate admission=%v, want os.ErrExist", err)
+	}
+	if retained, text, _, err := readLocalHistory(record.ID); err != nil || retained.RecordingState != "terminal" || text != log {
+		t.Fatalf("duplicate admission changed record=%+v log=%q err=%v", retained, text, err)
+	}
 	if err := deleteLocalHistory(record.ID); err != nil {
 		t.Fatal(err)
 	}
@@ -438,7 +449,12 @@ func TestLocalHistoryStoreMissingMetadataPrunesAsIncomplete(t *testing.T) {
 		t.Fatal(err)
 	}
 	orphan := filepath.Join(path, "runs", localHistoryTestRecord(601).ID)
-	if err := os.Mkdir(orphan, 0o700); err != nil {
+	runs, err := os.OpenRoot(filepath.Join(path, "runs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer runs.Close()
+	if err := localHistoryMkdir(runs, localHistoryTestRecord(601).ID); err != nil {
 		t.Fatal(err)
 	}
 	old := time.Now().Add(-31 * 24 * time.Hour)

--- a/internal/cli/local_history_store_test.go
+++ b/internal/cli/local_history_store_test.go
@@ -1,0 +1,630 @@
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+func localHistoryTestRecord(n int) localHistoryRecord {
+	return localHistoryRecord{Version: 1, RecordingState: "active", ID: fmt.Sprintf("run_%032x", n), Source: "local", Provider: "synthetic", Phase: "admitted", StartedAt: time.Now().UTC().Format(time.RFC3339Nano), Stdout: localHistoryStream{Availability: "retained"}, Stderr: localHistoryStream{Availability: "retained"}, ResultsState: "no-results"}
+}
+func localHistoryTestHome(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", root)
+	return filepath.Join(root, "crabbox", "history")
+}
+
+func TestLocalHistoryStorePrivateCreation(t *testing.T) {
+	path := localHistoryTestHome(t)
+	record := localHistoryTestRecord(900)
+	writer, err := beginLocalHistory(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	if err := writer.Commit(record, runLogSnapshot{Log: "ordinary output\n"}, &TestResultSummary{Format: "junit", Tests: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	err = filepath.WalkDir(path, func(name string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		file, err := os.Open(name)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		if err := localHistoryPrivate(file, entry.IsDir()); err != nil {
+			return fmt.Errorf("created %s: %w", filepath.Base(name), err)
+		}
+		if runtime.GOOS != "windows" {
+			info, err := file.Stat()
+			if err != nil {
+				return err
+			}
+			want := os.FileMode(0o600)
+			if entry.IsDir() {
+				want = 0o700
+			}
+			if info.Mode().Perm() != want {
+				return fmt.Errorf("created mode %o, want %o", info.Mode().Perm(), want)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLocalHistoryStoreRejectsUnixAliasesAndPublicMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix mode and link-count contract; Windows creation ACLs run separately")
+	}
+	for _, kind := range []string{"symlink", "hardlink", "public-mode"} {
+		t.Run(kind, func(t *testing.T) {
+			path := localHistoryTestHome(t)
+			record := localHistoryTestRecord(901)
+			writer, err := beginLocalHistory(record)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatal(err)
+			}
+			name := filepath.Join(path, "runs", record.ID, "record.json")
+			original, err := os.ReadFile(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ownedCopy := filepath.Join(t.TempDir(), "record-copy.json")
+			switch kind {
+			case "symlink":
+				err = os.Rename(name, ownedCopy)
+				if err == nil {
+					err = os.Symlink(ownedCopy, name)
+				}
+			case "hardlink":
+				err = os.Link(name, ownedCopy)
+			case "public-mode":
+				err = os.Chmod(name, 0o644)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, _, _, err := readLocalHistory(record.ID); err == nil {
+				t.Fatal("expected private record admission rejection")
+			}
+			data, err := os.ReadFile(name)
+			if err != nil || string(data) != string(original) {
+				t.Fatalf("fixture modified: %v", err)
+			}
+		})
+	}
+}
+func TestLocalHistoryStoreLifecycle(t *testing.T) {
+	localHistoryTestHome(t)
+	available, err := localHistoryAvailable()
+	if err != nil || available {
+		t.Fatalf("initial availability %v %v", available, err)
+	}
+	records, err := listLocalHistory(localHistoryFilter{})
+	if err != nil || len(records) != 0 {
+		t.Fatalf("initial list %v %v", records, err)
+	}
+	record := localHistoryTestRecord(1)
+	writer, err := beginLocalHistory(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	records, err = listLocalHistory(localHistoryFilter{})
+	if err != nil || len(records) != 1 || records[0].RecordingState != "active" {
+		t.Fatalf("active list %+v %v", records, err)
+	}
+	if err := deleteLocalHistory(record.ID); !errors.Is(err, errLocalHistoryBusy) {
+		t.Fatalf("active delete %v", err)
+	}
+	record.Phase = "command"
+	if err := writer.Checkpoint(record); err != nil {
+		t.Fatal(err)
+	}
+	summary := &TestResultSummary{Format: "junit", Tests: 7, Failures: 2, Failed: []TestFailure{{Name: "one", Message: "failure"}}}
+	record.ResultsState = "collected"
+	zero := 0
+	record.ExitCode = &zero
+	if err := writer.Commit(record, runLogSnapshot{Log: "out\nerr\n"}, summary); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got, log, results, err := readLocalHistory(record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RecordingState != "terminal" || log != "out\nerr\n" || results.Tests != 7 || results.Failures != 2 || got.LogSHA256 == "" || got.ResultsSHA256 == "" {
+		t.Fatalf("terminal %+v %q %+v", got, log, results)
+	}
+	if err := deleteLocalHistory(record.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := readLocalHistory(record.ID); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("deleted read %v", err)
+	}
+}
+func TestLocalHistoryStoreAbandonedAndPartialAreNotTerminal(t *testing.T) {
+	path := localHistoryTestHome(t)
+	record := localHistoryTestRecord(2)
+	writer, err := beginLocalHistory(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Closing without committing models the lock release on process death.
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "runs", record.ID, "log.txt"), []byte("orphan"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, log, summary, err := readLocalHistory(record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RecordingState != "incomplete" || got.Stdout.Availability != "unavailable" || log != "" || summary != nil {
+		t.Fatalf("abandoned %+v %q %+v", got, log, summary)
+	}
+}
+func TestLocalHistoryStoreCommitFailureLeavesIncomplete(t *testing.T) {
+	path := localHistoryTestHome(t)
+	record := localHistoryTestRecord(3)
+	writer, err := beginLocalHistory(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A known leftover temporary is never overwritten by a later publication.
+	if err := os.WriteFile(filepath.Join(path, "runs", record.ID, ".log.txt.tmp"), []byte("previous"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Commit(record, runLogSnapshot{Log: "new"}, nil); err == nil {
+		t.Fatal("wanted persistence failure")
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got, log, _, err := readLocalHistory(record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RecordingState != "incomplete" || log != "" {
+		t.Fatalf("failed commit %+v %q", got, log)
+	}
+}
+func TestLocalHistoryStoreRetentionIncludesIncomplete(t *testing.T) {
+	path := localHistoryTestHome(t)
+	for i := 0; i < localHistoryInactiveLimit+2; i++ {
+		record := localHistoryTestRecord(i + 10)
+		writer, err := beginLocalHistory(record)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	records, err := listLocalHistory(localHistoryFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != localHistoryInactiveLimit {
+		t.Fatalf("retained %d", len(records))
+	}
+	if _, err := os.Stat(filepath.Join(path, "runs", localHistoryTestRecord(10).ID)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("oldest retained: %v", err)
+	}
+	old := records[0]
+	old.UpdatedAt = time.Now().Add(-31 * 24 * time.Hour).UTC().Format(time.RFC3339Nano)
+	data, err := json.Marshal(old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "runs", old.ID, "record.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := pruneLocalHistory()
+	if err != nil || removed != 1 {
+		t.Fatalf("age prune %d %v", removed, err)
+	}
+}
+func TestLocalHistoryStoreActiveReservationAndPrune(t *testing.T) {
+	localHistoryTestHome(t)
+	var writers []*localHistoryWriter
+	defer func() {
+		for _, writer := range writers {
+			writer.Close()
+		}
+	}()
+	for i := 0; i < 25; i++ {
+		writer, err := beginLocalHistory(localHistoryTestRecord(i + 200))
+		if err != nil {
+			t.Fatalf("admit %d: %v", i, err)
+		}
+		writers = append(writers, writer)
+	}
+	if writer, err := beginLocalHistory(localHistoryTestRecord(300)); err == nil {
+		writer.Close()
+		t.Fatal("active reservations exceeded store capacity")
+	}
+	if removed, err := pruneLocalHistory(); err != nil || removed != 0 {
+		t.Fatalf("active prune %d %v", removed, err)
+	}
+	if err := writers[0].Close(); err != nil {
+		t.Fatal(err)
+	}
+	writer, err := beginLocalHistory(localHistoryTestRecord(301))
+	if err != nil {
+		t.Fatal(err)
+	}
+	writers = append(writers, writer)
+}
+func TestLocalHistoryStoreBoundedProjection(t *testing.T) {
+	record := localHistoryTestRecord(400)
+	record.UpdatedAt = record.StartedAt
+	record.CommandDisplay = strings.Repeat("🙂", 10000)
+	record.Diagnostic = strings.Repeat("\x00", 30000)
+	bounded, data, err := localHistoryRecordBytes(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) > localHistoryMetadataLimit || !bounded.CommandDisplayTruncated || !bounded.DiagnosticTruncated || !utf8.ValidString(bounded.CommandDisplay) {
+		t.Fatalf("metadata bounds %+v %d", bounded, len(data))
+	}
+	input := &TestResultSummary{Format: "junit", Tests: 100000, Failures: 9999, TimeSeconds: 100.25}
+	for i := 0; i < 500; i++ {
+		input.Files = append(input.Files, fmt.Sprintf("file-%d.xml", i))
+		input.Failed = append(input.Failed, TestFailure{Name: fmt.Sprintf("test-%d", i), Message: strings.Repeat("\x00", 9000)})
+	}
+	resultData, err := localHistoryResultBytes(input, &record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got TestResultSummary
+	if err := json.Unmarshal(resultData, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(resultData) > localHistoryResultsLimit || got.Tests != input.Tests || got.Failures != input.Failures || got.TimeSeconds != input.TimeSeconds || !record.ResultsDetailsTruncated || record.ResultsOmittedFailures != len(input.Failed)-len(got.Failed) || record.ResultsClippedFields == 0 {
+		t.Fatalf("projection bytes=%d totals=%+v markers=%+v", len(resultData), got, record)
+	}
+	if input.Failed[0].Message != strings.Repeat("\x00", 9000) {
+		t.Fatal("mutated parser output")
+	}
+}
+func TestLocalHistoryStoreIntegrityAndUnmanagedEntries(t *testing.T) {
+	path := localHistoryTestHome(t)
+	record := localHistoryTestRecord(500)
+	writer, err := beginLocalHistory(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Commit(record, runLogSnapshot{Log: "original"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "runs", record.ID, "log.txt"), []byte("modified"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := readLocalHistory(record.ID); err == nil {
+		t.Fatal("accepted corrupt payload")
+	}
+	if err := os.WriteFile(filepath.Join(path, "unmanaged"), []byte("preserve"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := beginLocalHistory(localHistoryTestRecord(501)); err == nil {
+		t.Fatal("admitted unmanaged footprint")
+	}
+	if data, err := os.ReadFile(filepath.Join(path, "unmanaged")); err != nil || string(data) != "preserve" {
+		t.Fatalf("unmanaged changed %q %v", data, err)
+	}
+}
+func TestLocalHistoryStoreMissingMetadataPrunesAsIncomplete(t *testing.T) {
+	path := localHistoryTestHome(t)
+	writer, err := beginLocalHistory(localHistoryTestRecord(600))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	orphan := filepath.Join(path, "runs", localHistoryTestRecord(601).ID)
+	if err := os.Mkdir(orphan, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-31 * 24 * time.Hour)
+	if err := os.Chtimes(orphan, old, old); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := pruneLocalHistory()
+	if err != nil || removed != 1 {
+		t.Fatalf("orphan prune %d %v", removed, err)
+	}
+}
+
+func TestLocalHistoryStoreConcurrentCheckpointPrune(t *testing.T) {
+	localHistoryTestHome(t)
+	record := localHistoryTestRecord(700)
+	writer, err := beginLocalHistory(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	var wg sync.WaitGroup
+	failures := make(chan error, 2)
+	wg.Go(func() {
+		for i := 0; i < 40; i++ {
+			record.Phase = "command"
+			if err := writer.Checkpoint(record); err != nil {
+				failures <- err
+				return
+			}
+		}
+	})
+	wg.Go(func() {
+		for i := 0; i < 40; i++ {
+			removed, err := pruneLocalHistory()
+			if err != nil {
+				failures <- err
+				return
+			}
+			if removed != 0 {
+				failures <- fmt.Errorf("pruned active writer")
+				return
+			}
+		}
+	})
+	wg.Wait()
+	close(failures)
+	for err := range failures {
+		t.Error(err)
+	}
+}
+func TestLocalHistoryStoreProcessLockHelper(t *testing.T) {
+	if os.Getenv("CRABBOX_LOCAL_HISTORY_LOCK_HELPER") != "1" {
+		return
+	}
+	t.Setenv("XDG_STATE_HOME", os.Getenv("CRABBOX_LOCAL_HISTORY_LOCK_ROOT"))
+	writer, err := beginLocalHistory(localHistoryTestRecord(800))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Fprintln(os.Stdout, "locked")
+	_, _ = bufio.NewReader(os.Stdin).ReadString('\n')
+	runtime.KeepAlive(writer) // No Close: the process releases the active OS lock.
+}
+func TestLocalHistoryStoreProcessExitReleasesLock(t *testing.T) {
+	localHistoryTestHome(t)
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(executable, "-test.run=^TestLocalHistoryStoreProcessLockHelper$")
+	cmd.Env = append(os.Environ(), "CRABBOX_LOCAL_HISTORY_LOCK_HELPER=1", "CRABBOX_LOCAL_HISTORY_LOCK_ROOT="+os.Getenv("XDG_STATE_HOME"))
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	finished := false
+	defer func() {
+		if !finished {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	}()
+	ready := make(chan string, 1)
+	go func() { line, _ := bufio.NewReader(stdout).ReadString('\n'); ready <- line }()
+	select {
+	case line := <-ready:
+		if line != "locked\n" {
+			t.Fatalf("child readiness %q", line)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("child readiness timed out")
+	}
+	id := localHistoryTestRecord(800).ID
+	if err := deleteLocalHistory(id); !errors.Is(err, errLocalHistoryBusy) {
+		t.Fatalf("child lock ignored: %v", err)
+	}
+	_ = stdin.Close()
+	if err := cmd.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	finished = true
+	record, _, _, err := readLocalHistory(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.RecordingState != "incomplete" {
+		t.Fatalf("abandoned state %s", record.RecordingState)
+	}
+	if err := deleteLocalHistory(id); err != nil {
+		t.Fatal(err)
+	}
+}
+func TestLocalHistoryStoreDeleteCorruptMetadata(t *testing.T) {
+	path := localHistoryTestHome(t)
+	record := localHistoryTestRecord(900)
+	writer, err := beginLocalHistory(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "runs", record.ID, "record.json"), []byte("invalid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := listLocalHistory(localHistoryFilter{}); err == nil {
+		t.Fatal("corruption not reported")
+	}
+	if err := deleteLocalHistory(record.ID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLocalHistoryStoreStateFilters(t *testing.T) {
+	localHistoryTestHome(t)
+	for i, status := range []RunStatus{RunStatusSucceeded, RunStatusFailed, RunStatusCanceled, RunStatusTimedOut} {
+		record := localHistoryTestRecord(950 + i)
+		record.RunStatus = status
+		writer, err := beginLocalHistory(record)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := writer.Commit(record, runLogSnapshot{}, nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, state := range []string{"succeeded", "failed", "canceled", "timed-out", "terminal", "active", "incomplete"} {
+		records, err := listLocalHistory(localHistoryFilter{State: state})
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := 1
+		if state == "terminal" {
+			want = 4
+		}
+		if state == "active" || state == "incomplete" {
+			want = 0
+		}
+		if len(records) != want {
+			t.Fatalf("state %s got %d want %d", state, len(records), want)
+		}
+	}
+	if _, err := listLocalHistory(localHistoryFilter{State: "bogus"}); err == nil {
+		t.Fatal("invalid state accepted")
+	}
+}
+
+func TestLocalHistoryStoreRealRunLogSnapshot(t *testing.T) {
+	localHistoryTestHome(t)
+	var buffer runLogBuffer
+	if _, err := buffer.Write([]byte(strings.Repeat("x", maxRunLogBytes+100))); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := (capturedRunLogWriter{buffer: &buffer}).Write([]byte("capture-only-marker")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := buffer.Write([]byte{0xff}); err != nil {
+		t.Fatal(err)
+	}
+	snapshot := buffer.Snapshot()
+	record := localHistoryTestRecord(1000)
+	writer, err := beginLocalHistory(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Commit(record, snapshot, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got, log, _, err := readLocalHistory(record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if log != snapshot.Log || got.LogFullSHA256 != snapshot.FullSHA256 || !got.LogTruncated || len(log) > maxRunLogBytes || !utf8.ValidString(log) || strings.Contains(log, "capture-only-marker") {
+		t.Fatalf("actual bounded snapshot changed: logBytes=%d rawDigest=%s truncated=%v", len(log), got.LogFullSHA256, got.LogTruncated)
+	}
+}
+
+func TestLocalHistoryStoreClipMalformedPrefix(t *testing.T) {
+	cases := []struct {
+		name, input, want string
+		limit             int
+		changed           bool
+	}{
+		{"long ASCII after invalid byte", "\xff" + strings.Repeat("a", 100), "�" + strings.Repeat("a", 29), 32, true},
+		{"long Unicode after invalid byte", "\xff" + strings.Repeat("界", 100), "�" + strings.Repeat("界", 9), 32, true},
+		{"short malformed text", "a\xffz", "a�z", 32, true},
+		{"valid crossing rune", "🙂rest", "", 2, true},
+		{"valid exact boundary", "🙂rest", "🙂r", 5, true},
+		{"unchanged", "hello", "hello", 32, false},
+		{"zero budget", "x", "", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, changed := localHistoryClip(tc.input, tc.limit)
+			if got != tc.want || changed != tc.changed || len(got) > tc.limit || !utf8.ValidString(got) {
+				t.Fatalf("got %q changed=%v, want %q changed=%v", got, changed, tc.want, tc.changed)
+			}
+		})
+	}
+}
+func TestLocalHistoryStoreCoordinatorReferenceValidation(t *testing.T) {
+	digest := strings.Repeat("a", 64)
+	for _, reference := range []string{"", digest, "sha256:" + digest} {
+		record := localHistoryTestRecord(1100)
+		record.UpdatedAt = record.StartedAt
+		record.CoordinatorReference = reference
+		got, _, err := localHistoryRecordBytes(record)
+		if err != nil || got.CoordinatorReference != reference {
+			t.Fatalf("valid reference rejected: %v", err)
+		}
+	}
+	for _, reference := range []string{"sha256:", "https://example.invalid/", strings.Repeat("g", 64), strings.Repeat("a", localHistoryMetadataLimit+1)} {
+		record := localHistoryTestRecord(1100)
+		record.UpdatedAt = record.StartedAt
+		record.CoordinatorReference = reference
+		if _, _, err := localHistoryRecordBytes(record); err == nil {
+			t.Fatal("invalid reference accepted")
+		}
+	}
+}
+func TestLocalHistoryStoreEquivalentTimestampTie(t *testing.T) {
+	localHistoryTestHome(t)
+	for i, stamp := range []string{"2026-01-01T01:00:00+01:00", "2026-01-01T00:00:00.000Z"} {
+		record := localHistoryTestRecord(1201 - i)
+		record.StartedAt = stamp
+		writer, err := beginLocalHistory(record)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	records, err := listLocalHistory(localHistoryFilter{Limit: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].ID != localHistoryTestRecord(1200).ID {
+		t.Fatalf("timestamp tie %+v", records)
+	}
+}

--- a/internal/cli/local_history_store_unix.go
+++ b/internal/cli/local_history_store_unix.go
@@ -3,10 +3,34 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
-	"golang.org/x/sys/unix"
 	"os"
+
+	"golang.org/x/sys/unix"
 )
+
+func localHistoryCreateDirectory(root *os.Root, name string) (bool, error) {
+	err := root.Mkdir(name, 0o700)
+	created := err == nil
+	if err != nil && !errors.Is(err, os.ErrExist) {
+		return false, err
+	}
+	file, err := root.OpenFile(name, os.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return created, err
+	}
+	defer file.Close()
+	if created {
+		if err := securePrivateRunOutputDirFD(int(file.Fd())); err != nil {
+			return created, err
+		}
+	}
+	if err := localHistoryPrivate(file, true); err != nil {
+		return created, err
+	}
+	return created, nil
+}
 
 func localHistoryOpen(root *os.Root, name string, writable bool) (*os.File, error) {
 	flags := os.O_RDONLY

--- a/internal/cli/local_history_store_unix.go
+++ b/internal/cli/local_history_store_unix.go
@@ -1,0 +1,44 @@
+//go:build !windows
+
+package cli
+
+import (
+	"fmt"
+	"golang.org/x/sys/unix"
+	"os"
+)
+
+func localHistoryOpen(root *os.Root, name string, writable bool) (*os.File, error) {
+	flags := os.O_RDONLY
+	if writable {
+		flags = os.O_RDWR
+	}
+	return root.OpenFile(name, flags|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+}
+func localHistoryPrivate(file *os.File, directory bool) error {
+	var s unix.Stat_t
+	if err := unix.Fstat(int(file.Fd()), &s); err != nil {
+		return err
+	}
+	mode := uint32(unix.S_IFREG)
+	perm := uint32(0o600)
+	if directory {
+		mode = unix.S_IFDIR
+		perm = 0o700
+	}
+	if uint32(s.Mode)&unix.S_IFMT != mode || uint32(s.Mode)&0o777 != perm || s.Uid != uint32(os.Geteuid()) {
+		return fmt.Errorf("local history requires current-user private files and directories")
+	}
+	if !directory && s.Nlink != 1 {
+		return fmt.Errorf("local history file must have a single link")
+	}
+	return nil
+}
+func localHistorySync(root *os.Root) error {
+	file, err := root.Open(".")
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return file.Sync()
+}

--- a/internal/cli/local_history_store_windows.go
+++ b/internal/cli/local_history_store_windows.go
@@ -3,9 +3,32 @@
 package cli
 
 import (
-	"golang.org/x/sys/windows"
 	"os"
+
+	"golang.org/x/sys/windows"
 )
+
+func localHistoryCreateDirectory(root *os.Root, name string) (bool, error) {
+	descriptor, user, err := privateWindowsSecurityDescriptor(true)
+	if err != nil {
+		return false, err
+	}
+	parent, err := root.Open(".")
+	if err != nil {
+		return false, err
+	}
+	defer parent.Close()
+	// Existing directories are opened for validation only, never re-owned or secured.
+	handle, created, err := openOrCreatePrivateWindowsDirectoryAt(windows.Handle(parent.Fd()), name, descriptor, false)
+	if err != nil {
+		return false, err
+	}
+	defer windows.CloseHandle(handle)
+	if err := verifyPrivateWindowsHandle(handle, true, user); err != nil {
+		return created, err
+	}
+	return created, nil
+}
 
 func localHistoryOpen(root *os.Root, name string, writable bool) (*os.File, error) {
 	flags := os.O_RDONLY

--- a/internal/cli/local_history_store_windows.go
+++ b/internal/cli/local_history_store_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package cli
+
+import (
+	"golang.org/x/sys/windows"
+	"os"
+)
+
+func localHistoryOpen(root *os.Root, name string, writable bool) (*os.File, error) {
+	flags := os.O_RDONLY
+	if writable {
+		flags = os.O_RDWR
+	}
+	return root.OpenFile(name, flags, 0)
+}
+func localHistoryPrivate(file *os.File, directory bool) error {
+	user, err := currentWindowsUserSID()
+	if err != nil {
+		return err
+	}
+	return verifyPrivateWindowsHandle(windows.Handle(file.Fd()), directory, user)
+}
+func localHistorySync(root *os.Root) error { return syncControllerDirectory(root.Name()) }

--- a/internal/cli/local_history_types.go
+++ b/internal/cli/local_history_types.go
@@ -1,0 +1,60 @@
+package cli
+
+type fileLocalHistoryPolicy struct {
+	Local *struct {
+		Enabled *bool `yaml:"enabled,omitempty"`
+	} `yaml:"local,omitempty"`
+}
+
+// Local history is self-recorded evidence, never coordinator attestation.
+type localHistoryRecord struct {
+	Version                 int                `json:"schemaVersion"`
+	ID                      string             `json:"id"`
+	RecordingState          string             `json:"recordingState"`
+	Source                  string             `json:"source"`
+	CoordinatorState        string             `json:"coordinatorState"`
+	CoordinatorRunID        string             `json:"coordinatorRunId,omitempty"`
+	CoordinatorReference    string             `json:"coordinatorReference,omitempty"`
+	Provider                string             `json:"provider"`
+	LeaseID                 string             `json:"leaseId,omitempty"`
+	Slug                    string             `json:"slug,omitempty"`
+	Target                  string             `json:"target,omitempty"`
+	CommandDisplay          string             `json:"commandDisplay"`
+	CommandDisplayTruncated bool               `json:"commandDisplayTruncated,omitempty"`
+	Phase                   string             `json:"phase"`
+	StartedAt               string             `json:"startedAt"`
+	UpdatedAt               string             `json:"updatedAt"`
+	EndedAt                 string             `json:"endedAt,omitempty"`
+	ExitCode                *int               `json:"exitCode,omitempty"`
+	RunStatus               RunStatus          `json:"runStatus,omitempty"`
+	ErrorKind               RunErrorKind       `json:"errorKind,omitempty"`
+	SyncMs                  int64              `json:"syncMs"`
+	CommandMs               int64              `json:"commandMs"`
+	TotalMs                 int64              `json:"totalMs"`
+	Diagnostic              string             `json:"diagnostic,omitempty"`
+	DiagnosticTruncated     bool               `json:"diagnosticTruncated,omitempty"`
+	CaptureScope            string             `json:"captureScope"`
+	Stdout                  localHistoryStream `json:"stdout"`
+	Stderr                  localHistoryStream `json:"stderr"`
+	LogBytes                int                `json:"logBytes"`
+	LogTruncated            bool               `json:"logTruncated"`
+	LogFullSHA256           string             `json:"logFullSha256,omitempty"`
+	LogSHA256               string             `json:"logSha256,omitempty"`
+	ResultsSHA256           string             `json:"resultsSha256,omitempty"`
+	ResultsState            string             `json:"resultsState"`
+	ResultsDetailsTruncated bool               `json:"resultsDetailsTruncated,omitempty"`
+	ResultsOmittedFiles     int                `json:"resultsOmittedFiles,omitempty"`
+	ResultsOmittedFailures  int                `json:"resultsOmittedFailures,omitempty"`
+	ResultsClippedFields    int                `json:"resultsClippedFields,omitempty"`
+}
+
+type localHistoryStream struct {
+	Availability string `json:"availability"`
+	Reason       string `json:"reason,omitempty"`
+}
+
+type localHistoryFilter struct {
+	LeaseID string
+	State   string
+	Limit   int
+}

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -1230,6 +1230,7 @@ type ListRequest struct {
 }
 
 type RunRequest struct {
+	Observation           *RunObservation `json:"-" yaml:"-"`
 	Repo                  Repo
 	ID                    string
 	ReuseLease            bool // Planned reuse without an ID; a nonempty ID also implies reuse.

--- a/internal/cli/providers_describe_binary_test.go
+++ b/internal/cli/providers_describe_binary_test.go
@@ -182,8 +182,8 @@ func TestProvidersDescribeBuiltBinaryContract(t *testing.T) {
 		t.Fatalf("run --help exit=%d stdout=%q stderr=%q", helpCode, helpStdout, helpStderr)
 	}
 	digest := sha256.Sum256(helpStderr)
-	const baselineSHA256 = "5028d70b45ecfec25197e7e401762cfcc7e8ed5fd17f3370268d8f2a3b082acf"
-	const baselineBytes = 61940
+	const baselineSHA256 = "28ec85dcd2c88add70206ef379ee3cd02d5fc24cb9642a5801402bd808b93d8d"
+	const baselineBytes = 62002
 	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != baselineBytes {
 		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=%d", got, len(helpStderr), baselineSHA256, baselineBytes)
 	}

--- a/internal/cli/results.go
+++ b/internal/cli/results.go
@@ -12,6 +12,7 @@ import (
 func (a App) results(ctx context.Context, args []string) error {
 	args, jsonAnywhere := extractBoolFlag(args, "json")
 	fs := newFlagSet("results", a.Stderr)
+	source := fs.String("source", "", "record source: local, coordinator, or all")
 	runIDValue, args := popLeadingRunID(args)
 	runID := fs.String("id", runIDValue, "run id")
 	failedOnly := fs.Bool("failed-only", false, "print only failed test cases")
@@ -28,9 +29,12 @@ func (a App) results(ctx context.Context, args []string) error {
 	if jsonAnywhere {
 		*jsonOut = true
 	}
-	coord, err := configuredCoordinator()
-	if err != nil {
+	sourceName, coord, err := resolveHistorySource(*source)
+	if err != nil && sourceName != "all" {
 		return err
+	}
+	if sourceName != "" {
+		return a.localHistoryRead(ctx, sourceName, coord, *runID, "results", 0, *failedOnly, *jsonOut, err)
 	}
 	run, err := coord.Run(ctx, *runID)
 	if err != nil {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -260,6 +260,7 @@ type runFlagValues struct {
 	Reclaim                *bool
 	TimingJSON             *bool
 	TimingRecord           *string
+	RecordLocal            *bool
 }
 
 func registerRunFlags(fs *flag.FlagSet, defaults Config, options leaseCreateFlagRegistrationOptions) runFlagValues {
@@ -322,6 +323,7 @@ func registerRunFlags(fs *flag.FlagSet, defaults Config, options leaseCreateFlag
 	values.Reclaim = fs.Bool("reclaim", false, "claim this lease for the current repo")
 	values.TimingJSON = fs.Bool("timing-json", false, "print final timing as JSON")
 	values.TimingRecord = fs.String("timing-record", "", "append final timing to benchmark JSONL store: default, off, or path")
+	values.RecordLocal = fs.Bool("record-local", false, "retain private bounded local run history")
 	return values
 }
 
@@ -348,6 +350,9 @@ func loadRunConfig(fs *flag.FlagSet, flags runFlagValues, target leaseFlagTarget
 		if err := validateReadyPoolIdentityProviderConfig(cfg, *identity); err != nil {
 			return Config{}, err
 		}
+	}
+	if flagWasSet(fs, "record-local") {
+		cfg.RecordLocal = *flags.RecordLocal
 	}
 	return cfg, nil
 }
@@ -483,6 +488,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	var runFailure error
 	returnedRunError := &err
 	recorder := &runRecorder{}
+	var observation *RunObservation
 	var prepareTerminalRun func()
 	var finalizeTerminalRun func()
 	var finalTimingReport *timingReport
@@ -565,6 +571,10 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			finalizeTerminalRun()
 		}
 		recorder.Failed(runFailure)
+		if observation != nil {
+			localReport, localHasReport := snapshotFinalTimingReport(frozenAt)
+			observation.finish(localReport, localHasReport, err, recorder)
+		}
 	}()
 	command := fs.Args()
 	if len(command) > 0 && command[0] == "--" {
@@ -873,6 +883,11 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		// The borrowed pool owns its proven endpoint, including before Resolve.
 		cfg.explicitSSHPort = ""
 	}
+	observation, err = beginRunObservation(cfg, executionRunID, runScriptRecordCommand(script, command), a.Stderr)
+	if err != nil {
+		return err
+	}
+	runReq.Observation = observation
 	backendRuntime := runtimeForApp(a)
 	if timingRecordEnabled || *timingJSON {
 		delegatedTimingCapture = &capturedTimingReportWriter{writer: a.Stderr}
@@ -911,6 +926,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return
 		}
 		cleanupStartedAt := time.Now()
+		observation.Phase(RunPhaseCleanup)
 		defer func() {
 			cleanup.Duration += time.Since(cleanupStartedAt)
 		}()
@@ -1031,6 +1047,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	}
 	if delegated, ok := backend.(DelegatedRunBackend); ok && !sshScriptRun {
 		delegatedRoute = true
+		if cfg.Results.Auto || len(cfg.Results.JUnit) > 0 {
+			observation.Results(nil, "unsupported")
+		}
 		if err := validateDelegatedRunRouting(backend.Spec(), runReq, *readyPool, len(requiredArtifactSchemas) > 0, expansion.Profile.Doctor.Enabled); err != nil {
 			return err
 		}
@@ -1065,9 +1084,11 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			}
 		}
 		runnerObservedStartedAt = time.Now()
+		observation.Phase(RunPhaseOpaque)
 		result, runErr := delegated.Run(ctx, runReq)
+		observation.BindLease(result.LeaseID, result.Slug)
 		delegatedProviderEndedAt = time.Now()
-		if *timingJSON || timingRecordEnabled {
+		if *timingJSON || timingRecordEnabled || observation != nil {
 			report := timingReportFromDelegatedRunResult(runReq, result, backend.Spec().Name, runErr)
 			if delegatedTimingCapture != nil && delegatedTimingCapture.report != nil {
 				report = *delegatedTimingCapture.report
@@ -1259,6 +1280,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if !releaseResolvedLease || (!releaseUnreportedLease && !shouldReleaseRunLease(acquired, *keep, keepFailedLease, *stopAfter, runFailure)) {
 			return
 		}
+		observation.Phase(RunPhaseCleanup)
 		cleanupStartedAt := time.Now()
 		defer func() {
 			cleanup.Duration += time.Since(cleanupStartedAt)
@@ -1306,6 +1328,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	}()
 	admitLease := func(lease *LeaseTarget) error {
 		server, target, leaseID = lease.Server, lease.SSH, lease.LeaseID
+		observation.BindLease(leaseID, serverSlug(server))
 		applyResolvedServerConfig(&cfg, server)
 		stripTargetCredentialsFromRunEnv(&envSelection, target)
 		if borrowedPool != nil && strings.TrimSpace(borrowedPool.Entry.WorkRoot) != "" {
@@ -1389,6 +1412,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	}
 	if *leaseIDFlag != "" {
 		leasePhase = "provider.resolve"
+		observation.Phase(RunPhaseResolve)
 		var lease LeaseTarget
 		req := ResolveRequest{Repo: repo, Options: options, ID: *leaseIDFlag, Reclaim: *reclaim, Prepare: true}
 		if borrowedPool == nil {
@@ -1413,6 +1437,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 
 	} else {
 		var lease LeaseTarget
+		observation.Phase(RunPhaseAcquire)
 		lease, err = sshBackend.Acquire(ctx, AcquireRequest{Repo: repo, Options: options, Keep: *keep, Reclaim: *reclaim, RequestedSlug: requestedSlug})
 		if err == nil {
 			server, target, leaseID = lease.Server, lease.SSH, lease.LeaseID
@@ -1425,6 +1450,8 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	}
 	releaseResolvedLease = true
 	releaseUnreportedLease = acquired && leaseOutputPath != ""
+	observation.BindLease(leaseID, serverSlug(server))
+	observation.Phase(RunPhaseSetup)
 
 	leaseDuration := time.Since(leaseStartedAt)
 	if timingRecordEnabled {
@@ -1582,7 +1609,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	profileEnvFile := ""
 	actionsURL := ""
 	defer func() {
-		if finalTimingReport != nil || (!*timingJSON && !timingRecordEnabled) {
+		if finalTimingReport != nil || (!*timingJSON && !timingRecordEnabled && observation == nil) {
 			return
 		}
 		report := timingReportFromRunWithActionsURL(cfg.Provider, leaseID, serverSlug(server), timings, time.Since(timings.started), ExitCodeForError(err, 7), actionsURL)
@@ -1871,6 +1898,7 @@ retrySync:
 	}
 	if !*noSync {
 		syncStart := time.Now()
+		observation.Phase(RunPhaseSync)
 		if freshPR.Empty() {
 			fmt.Fprintf(a.Stderr, "syncing %s -> %s:%s\n", repo.Root, target.Host, workdir)
 		} else {
@@ -2329,7 +2357,7 @@ afterSync:
 		printPreflight(target)
 		fmt.Fprintf(a.Stdout, "synced %s\n", workdir)
 		fmt.Fprintln(a.Stderr, formatRunSummary(timings, time.Since(timings.started), 0))
-		if *timingJSON || timingRecordEnabled {
+		if *timingJSON || timingRecordEnabled || observation != nil {
 			total := time.Since(timings.started)
 			report := timingReportFromRunWithActionsURL(cfg.Provider, leaseID, serverSlug(server), timings, total, 0, actionsURL)
 			populateRunTimingMetadata(&report, cfg, repo, server, leaseID, executionRunID, workdir, nil)
@@ -2545,6 +2573,8 @@ afterSync:
 		stderrEvents = nil
 		stderr = io.MultiWriter(stderr, capturedRunLogWriter{&logBuffer})
 	}
+	observation.adoptDirectLog(&logBuffer, stdoutCaptured, stderrCaptured)
+	observation.Phase(RunPhaseCommand)
 	resultsMarker := ""
 	if cfg.Results.Auto {
 		resultsMarker = remoteResultsMarker
@@ -2765,6 +2795,11 @@ afterSync:
 	}
 	if cfg.Results.Auto || len(cfg.Results.JUnit) > 0 {
 		results, err = collectRemoteJUnitResults(ctx, target, workdir, cfg.Results, resultsMarker)
+		if results != nil {
+			observation.Results(results, "collected")
+		} else if err != nil {
+			observation.Results(nil, "unavailable")
+		}
 		if err != nil {
 			fmt.Fprintf(a.Stderr, "warning: collect test results incomplete: %v\n", err)
 		}
@@ -2920,7 +2955,7 @@ afterSync:
 		labelField = fmt.Sprintf(" label=%q", runLabelValue)
 	}
 	fmt.Fprintf(a.Stderr, "run details provider=%s lease=%s slug=%s run=%s%s type=%s repo=%s workdir=%s actions=%s stop_command=%q idle_timeout=%s\n", cfg.Provider, leaseID, blank(serverSlug(server), "-"), executionRunID, labelField, blank(server.ServerType.Name, "-"), repo.Root, workdir, blank(actionsURL, "-"), report.StopCommand, cfg.IdleTimeout)
-	if *timingJSON || timingRecordEnabled {
+	if *timingJSON || timingRecordEnabled || observation != nil {
 		finalTimingReport = &report
 	}
 	if code != 0 {

--- a/internal/cli/run_local_output_windows_test.go
+++ b/internal/cli/run_local_output_windows_test.go
@@ -494,6 +494,24 @@ func TestArtifactOutputWindowsPrivacyFollowsSignedURLs(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer file.Close()
+		if _, err := file.WriteString("ordinary fixture\n"); err != nil {
+			t.Fatal(err)
+		}
+		if err := file.Close(); err != nil {
+			t.Fatal(err)
+		}
+		duplicate, err := openArtifactBundleTemp(root, ".private.crabbox-test", privateRunOutputFileMode, true)
+		if duplicate != nil {
+			duplicate.Close()
+			t.Fatal("exclusive creation returned an existing file")
+		}
+		if !errors.Is(err, os.ErrExist) {
+			t.Fatalf("duplicate creation error=%v, want os.ErrExist", err)
+		}
+		data, err := root.ReadFile(".private.crabbox-test")
+		if err != nil || string(data) != "ordinary fixture\n" {
+			t.Fatalf("duplicate creation changed bytes: %q, %v", data, err)
+		}
 		assertWindowsPathPrivateFromSID(t, filepath.Join(dir, ".private.crabbox-test"), false, testSID)
 	})
 

--- a/internal/cli/run_local_output_windows_test.go
+++ b/internal/cli/run_local_output_windows_test.go
@@ -463,6 +463,39 @@ func TestManagedAttestKeyWindowsRepairsPermissiveDACL(t *testing.T) {
 	})
 }
 
+func TestLocalHistoryStoreWindowsPrivateDirectoryCreation(t *testing.T) {
+	dir := t.TempDir()
+	testSID := makeWindowsTestParentPermissive(t, dir)
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	created, err := localHistoryCreateDirectory(root, "initial")
+	if err != nil || !created {
+		t.Fatalf("create=%t err=%v", created, err)
+	}
+	// Inspect immediately: no later checkpoint or securing call may establish privacy.
+	assertWindowsPathPrivateFromSID(t, filepath.Join(dir, "initial"), true, testSID)
+	entries, err := os.ReadDir(filepath.Join(dir, "initial"))
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("initial directory entries=%v err=%v", entries, err)
+	}
+	created, err = localHistoryCreateDirectory(root, "initial")
+	if err != nil || created {
+		t.Fatalf("existing private directory create=%t err=%v", created, err)
+	}
+	if err := root.Mkdir("existing", 0o700); err != nil {
+		t.Fatal(err)
+	}
+	existing := filepath.Join(dir, "existing")
+	assertWindowsPathGrantsSID(t, existing, testSID)
+	if created, err := localHistoryCreateDirectory(root, "existing"); err == nil || created {
+		t.Fatalf("nonprivate existing directory create=%t err=%v", created, err)
+	}
+	assertWindowsPathGrantsSID(t, existing, testSID)
+}
+
 func TestArtifactOutputWindowsPrivacyFollowsSignedURLs(t *testing.T) {
 	signedFile := artifactFile{
 		Kind:          "proof",

--- a/internal/cli/run_observation.go
+++ b/internal/cli/run_observation.go
@@ -1,0 +1,207 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+)
+
+type RunPhase string
+
+const (
+	RunPhaseAcquire RunPhase = "acquire"
+	RunPhaseResolve RunPhase = "resolve"
+	RunPhaseSetup   RunPhase = "setup"
+	RunPhaseSync    RunPhase = "sync"
+	RunPhaseCommand RunPhase = "command"
+	RunPhaseCleanup RunPhase = "cleanup"
+	RunPhaseOpaque  RunPhase = "opaque-provider-run"
+)
+
+type RunOutputScope string
+
+const (
+	RunOutputWorkload RunOutputScope = "workload"
+	RunOutputProvider RunOutputScope = "provider-run"
+)
+
+// RunObservation retains local evidence only; it grants no provider or receipt authority.
+// A nil observation preserves the original terminal and capture writers.
+type RunObservation struct {
+	mu        sync.Mutex
+	record    localHistoryRecord
+	writer    *localHistoryWriter
+	log       runLogBuffer
+	directLog *runLogBuffer
+	results   *TestResultSummary
+	warnings  io.Writer
+	warned    bool
+	secrets   []string
+}
+
+func beginRunObservation(cfg Config, id string, command []string, warnings io.Writer) (*RunObservation, error) {
+	if !cfg.RecordLocal {
+		return nil, nil
+	}
+	if warnings == nil {
+		warnings = io.Discard
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	record := localHistoryRecord{Version: 1, ID: id, RecordingState: "active", Source: "local", CoordinatorState: "none", Provider: cfg.Provider, Target: cfg.TargetOS, CommandDisplay: strings.Join(command, " "), Phase: "admitted", StartedAt: now, UpdatedAt: now, CaptureScope: "unavailable", Stdout: localHistoryStream{Availability: "unavailable"}, Stderr: localHistoryStream{Availability: "unavailable"}, ResultsState: "no-results"}
+	secrets := configuredDiagnosticSecrets(cfg)
+	record.CommandDisplay = RedactDiagnosticSecrets(record.CommandDisplay, secrets...)
+	writer, err := beginLocalHistory(record)
+	if err != nil {
+		return nil, fmt.Errorf("local history preflight: %w", err)
+	}
+	return &RunObservation{record: record, writer: writer, warnings: warnings, secrets: secrets}, nil
+}
+
+func (o *RunObservation) warn(err error) {
+	if err != nil && !o.warned {
+		o.warned = true
+		fmt.Fprintf(o.warnings, "warning: local history %s may be incomplete: %v\n", o.record.ID, err)
+	}
+}
+
+func (o *RunObservation) Phase(phase RunPhase) {
+	if o == nil {
+		return
+	}
+	switch phase {
+	case RunPhaseAcquire, RunPhaseResolve, RunPhaseSetup, RunPhaseSync, RunPhaseCommand, RunPhaseCleanup, RunPhaseOpaque:
+	default:
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.record.Phase == string(phase) {
+		return
+	}
+	o.record.Phase = string(phase)
+	o.record.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	o.warn(o.writer.Checkpoint(o.record))
+}
+
+func (o *RunObservation) BindLease(leaseID, slug string) {
+	if o == nil || leaseID == "" {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.record.LeaseID, o.record.Slug = leaseID, slug
+	if err := o.writer.Checkpoint(o.record); err != nil {
+		o.warn(err)
+	}
+}
+
+func (o *RunObservation) CommandWriters(stdout, stderr io.Writer, scope RunOutputScope) (io.Writer, io.Writer) {
+	if o == nil {
+		return stdout, stderr
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.record.CaptureScope = string(scope)
+	wrap := func(w io.Writer, stream *localHistoryStream) io.Writer {
+		if w == nil || stream.Availability == "omitted" {
+			return w
+		}
+		stream.Availability = "retained"
+		return io.MultiWriter(w, &o.log)
+	}
+	return wrap(stdout, &o.record.Stdout), wrap(stderr, &o.record.Stderr)
+}
+
+func (o *RunObservation) OmitStream(stream, reason string) {
+	if o == nil {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	value := localHistoryStream{Availability: "omitted", Reason: reason}
+	if stream == "stdout" {
+		o.record.Stdout = value
+	}
+	if stream == "stderr" {
+		o.record.Stderr = value
+	}
+}
+
+func (o *RunObservation) Results(results *TestResultSummary, availability string) {
+	if o == nil {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.results = results
+	o.record.ResultsState = availability
+}
+
+func (o *RunObservation) adoptDirectLog(log *runLogBuffer, stdoutOmitted, stderrOmitted bool) {
+	if o == nil {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.directLog = log
+	o.record.CaptureScope = string(RunOutputWorkload)
+	o.record.Stdout = localHistoryStream{Availability: "retained"}
+	o.record.Stderr = localHistoryStream{Availability: "retained"}
+	if stdoutOmitted {
+		o.record.Stdout = localHistoryStream{Availability: "omitted", Reason: "local-capture"}
+	}
+	if stderrOmitted {
+		o.record.Stderr = localHistoryStream{Availability: "omitted", Reason: "local-capture"}
+	}
+}
+
+func (o *RunObservation) finish(report timingReport, hasReport bool, err error, recorder *runRecorder) {
+	if o == nil {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	defer func() { o.warn(o.writer.Close()) }()
+	o.record.EndedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	o.record.UpdatedAt = o.record.EndedAt
+	if hasReport {
+		if report.Provider != "" {
+			o.record.Provider = report.Provider
+		}
+		if report.LeaseID != "" {
+			o.record.LeaseID = report.LeaseID
+		}
+		if report.Slug != "" {
+			o.record.Slug = report.Slug
+		}
+		o.record.ExitCode = &report.ExitCode
+		o.record.RunStatus, o.record.ErrorKind = report.RunStatus, report.ErrorKind
+		o.record.SyncMs, o.record.CommandMs, o.record.TotalMs = report.SyncMs, report.CommandMs, report.TotalMs
+	} else {
+		result := FinalizeRunResult(RunResult{}, err)
+		o.record.ExitCode = &result.ExitCode
+		o.record.RunStatus, o.record.ErrorKind = result.Status, result.ErrorKind
+	}
+	if err != nil {
+		o.record.Diagnostic = RedactDiagnosticSecrets(err.Error(), o.secrets...)
+	}
+	if recorder != nil && recorder.coord != nil {
+		o.record.CoordinatorState = "unknown"
+		reference := coordinatorHistoryReference(recorder.coord.BaseURL)
+		if recorder.runID != "" && reference != "" {
+			o.record.CoordinatorRunID = recorder.runID
+			o.record.CoordinatorReference = reference
+		}
+		if recorder.runID != "" && recorder.terminalConfirmed && reference != "" {
+			o.record.Source, o.record.CoordinatorState = "both", "recorded"
+		}
+	}
+	log := o.log.Snapshot()
+	if o.directLog != nil {
+		log = o.directLog.Snapshot()
+	}
+	o.record.RecordingState = "terminal"
+	o.warn(o.writer.Commit(o.record, log, o.results))
+}

--- a/internal/cli/run_observation.go
+++ b/internal/cli/run_observation.go
@@ -146,7 +146,8 @@ func (o *RunObservation) adoptDirectLog(log *runLogBuffer, stdoutOmitted, stderr
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.directLog = log
-	o.record.CaptureScope = string(RunOutputWorkload)
+	// The direct buffer also receives diagnostics from the SSH transport.
+	o.record.CaptureScope = string(RunOutputProvider)
 	o.record.Stdout = localHistoryStream{Availability: "retained"}
 	o.record.Stderr = localHistoryStream{Availability: "retained"}
 	if stdoutOmitted {

--- a/internal/cli/run_observation_test.go
+++ b/internal/cli/run_observation_test.go
@@ -1,0 +1,269 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunObservationDelegatedAppRoundTrip(t *testing.T) {
+	clearConfigEnv(t)
+	isolateRunTestUserDirs(t, t.TempDir())
+	runModuleRuntimeTestRequests = nil
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr, Stdin: strings.NewReader("export default {}\n")}).runCommand(context.Background(), []string{
+		"--record-local", "--provider", "module-runtime-test", "--script-stdin",
+	})
+	if err != nil {
+		t.Fatalf("run=%v stderr=%q", err, stderr.String())
+	}
+	if len(runModuleRuntimeTestRequests) != 1 {
+		t.Fatalf("requests=%d", len(runModuleRuntimeTestRequests))
+	}
+	record, log, _, err := readLocalHistory(runModuleRuntimeTestRequests[0].RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.RecordingState != "terminal" || record.LeaseID != "mod_test" || record.Slug != "module-runtime-test" || record.ExitCode == nil || *record.ExitCode != 0 || record.CaptureScope != "provider-run" {
+		t.Fatalf("record=%+v", record)
+	}
+	if log != "fixture command stdout\nfixture command stderr\n" || !strings.Contains(stderr.String(), "fixture provider planning") {
+		t.Fatalf("log=%q terminal stderr=%q", log, stderr.String())
+	}
+}
+
+func TestRunObservationDirectAppWithoutTimingOutput(t *testing.T) {
+	setupLocalContainerRunSessionTest(t, "")
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(t.Context(), []string{
+		"--record-local", "--provider", "local-container", "--keep", "--no-sync", "--no-hydrate", "--", "true",
+	})
+	if err != nil {
+		t.Fatalf("run=%v stderr=%q", err, stderr.String())
+	}
+	records, err := listLocalHistory(localHistoryFilter{})
+	if err != nil || len(records) != 1 {
+		t.Fatalf("records=%+v err=%v", records, err)
+	}
+	record := records[0]
+	if record.LeaseID != localContainerRunSessionTestLeaseID || record.Slug != "session-slug" || record.RecordingState != "terminal" || record.ExitCode == nil || *record.ExitCode != 0 || record.TotalMs <= 0 || record.CaptureScope != "workload" {
+		t.Fatalf("record=%+v", record)
+	}
+	if !strings.Contains(stderr.String(), "run="+record.ID) || strings.Contains(stderr.String(), `"commandMs"`) {
+		t.Fatalf("run identity or timing output changed: %q", stderr.String())
+	}
+}
+
+func TestRunObservationDisabledHasNoLedger(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", root)
+	o, err := beginRunObservation(Config{}, "run_00000000000000000000000000000001", []string{"true"}, io.Discard)
+	if err != nil || o != nil {
+		t.Fatalf("disabled=%v %v", o, err)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("disabled created state: %v %v", entries, err)
+	}
+}
+
+func TestRunObservationCapturesOnlyCommandWriters(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	var terminalOut, terminalErr bytes.Buffer
+	id := "run_00000000000000000000000000000002"
+	o, err := beginRunObservation(Config{RecordLocal: true, Provider: "fixture", TargetOS: "linux"}, id, []string{"printf", "sample"}, &terminalErr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	io.WriteString(&terminalErr, "unrelated provider hint\n")
+	o.Phase(RunPhaseCommand)
+	out, stderr := o.CommandWriters(&terminalOut, &terminalErr, RunOutputWorkload)
+	io.WriteString(out, "stdout marker\n")
+	io.WriteString(stderr, "stderr marker\n")
+	o.finish(timingReport{Provider: "fixture", LeaseID: "lease-fixture", Slug: "fixture", RunStatus: RunStatusSucceeded, CommandMs: 2, TotalMs: 3}, true, nil, nil)
+	record, log, _, err := readLocalHistory(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if log != "stdout marker\nstderr marker\n" {
+		t.Fatalf("command log=%q", log)
+	}
+	if !strings.Contains(terminalErr.String(), "unrelated provider hint") || terminalOut.String() != "stdout marker\n" {
+		t.Fatal("terminal behavior changed")
+	}
+	if record.LeaseID != "lease-fixture" || record.CaptureScope != "workload" || record.RecordingState != "terminal" || record.Source != "local" {
+		t.Fatalf("record=%+v", record)
+	}
+}
+
+func TestRunObservationAdoptsExistingCaptureOmissions(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	id := "run_00000000000000000000000000000003"
+	o, err := beginRunObservation(Config{RecordLocal: true, Provider: "fixture"}, id, []string{"true"}, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var log runLogBuffer
+	io.WriteString(capturedRunLogWriter{buffer: &log}, "capture-only bytes")
+	io.WriteString(&log, "retained stderr")
+	o.adoptDirectLog(&log, true, false)
+	o.Results(&TestResultSummary{Format: "junit", Tests: 2, Failures: 1}, "collected")
+	o.finish(timingReport{Provider: "fixture", ExitCode: 23, RunStatus: RunStatusFailed, ErrorKind: RunErrorCommandExit}, true, ExitError{Code: 23, Message: "command failed"}, nil)
+	record, text, results, err := readLocalHistory(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text != "retained stderr" || !record.LogTruncated || record.Stdout.Availability != "omitted" || record.LogFullSHA256 != log.Snapshot().FullSHA256 {
+		t.Fatalf("capture metadata=%+v text=%q", record, text)
+	}
+	if results == nil || results.Tests != 2 || results.Failures != 1 || *record.ExitCode != 23 {
+		t.Fatal("result/exit lost")
+	}
+}
+
+func TestRunObservationFinalFailureOnlyWarns(t *testing.T) {
+	for _, code := range []int{0, 23} {
+		t.Run(fmt.Sprint(code), func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			var warnings bytes.Buffer
+			id := "run_00000000000000000000000000000004"
+			o, err := beginRunObservation(Config{RecordLocal: true, Provider: "fixture"}, id, []string{"true"}, &warnings)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := o.writer.Close(); err != nil {
+				t.Fatal(err)
+			}
+			report := timingReport{Provider: "fixture", ExitCode: code, RunStatus: RunStatusSucceeded}
+			var primary error
+			if code != 0 {
+				report.RunStatus, report.ErrorKind = RunStatusFailed, RunErrorCommandExit
+				primary = ExitError{Code: code, Message: "primary"}
+			}
+			o.finish(report, true, primary, nil)
+			if report.ExitCode != code || !strings.Contains(warnings.String(), "may be incomplete") {
+				t.Fatalf("report=%+v warning=%q", report, warnings.String())
+			}
+			record, _, _, err := readLocalHistory(id)
+			if err != nil || record.RecordingState != "incomplete" {
+				t.Fatalf("record=%+v err=%v", record, err)
+			}
+		})
+	}
+}
+
+func TestRunObservationNeverEntersWireRequest(t *testing.T) {
+	plain, err := json.Marshal(RunRequest{Command: []string{"true"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	observed, err := json.Marshal(RunRequest{Command: []string{"true"}, Observation: &RunObservation{warnings: io.Discard}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(plain, observed) {
+		t.Fatalf("local observation entered request: %s", observed)
+	}
+}
+
+func TestRunObservationCoordinatorReferenceExcludesCredentials(t *testing.T) {
+	base := &url.URL{Scheme: "https", Host: "EXAMPLE.invalid:443", Path: "/coordinator/", User: url.UserPassword("fixture", "fixture"), RawQuery: "sample=ignored", Fragment: "ignored"}
+	got := coordinatorHistoryReference(base.String())
+	if got == "" || got != coordinatorHistoryReference("https://example.invalid/coordinator") {
+		t.Fatal("noncredential endpoint identity differs")
+	}
+	if got == coordinatorHistoryReference("https://example.invalid/other") {
+		t.Fatal("basepath identity lost")
+	}
+}
+
+func TestRunObservationCoordinatorTerminalAcknowledgment(t *testing.T) {
+	for _, mode := range []string{"failed-event", "verified-receipt", "missing-receipt"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			receipt := runRecorderTestReceipt(t)
+			client := &CoordinatorClient{BaseURL: "https://example.invalid", Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				code, body := http.StatusOK, `{"run":{"id":"run_123"}}`
+				switch {
+				case strings.HasSuffix(req.URL.Path, "/events") && mode == "failed-event":
+					code, body = http.StatusBadRequest, `{"error":"ordinary fixture error"}`
+				case strings.HasSuffix(req.URL.Path, "/finish"):
+				case strings.HasSuffix(req.URL.Path, "/receipt"):
+					if mode == "verified-receipt" {
+						data, err := json.Marshal(map[string]any{"receipt": receipt})
+						if err != nil {
+							t.Fatal(err)
+						}
+						body = string(data)
+					} else {
+						code, body = http.StatusNotFound, `{"error":"not recorded"}`
+					}
+				default:
+					t.Fatalf("unexpected request %s", req.URL.Path)
+				}
+				return &http.Response{StatusCode: code, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body))}, nil
+			})}}
+			recorder := &runRecorder{coord: client, runID: "run_123", stderr: io.Discard}
+			if mode == "failed-event" {
+				recorder.Failed(fmt.Errorf("ordinary command failure"))
+				if !recorder.finished {
+					t.Fatal("existing failure lifecycle changed")
+				}
+			} else {
+				err := recorder.Finish(t.Context(), SSHTarget{}, 1, 0, 0, "", false, nil, FailureClassification{}, &receipt)
+				if (err == nil) != (mode == "verified-receipt") {
+					t.Fatalf("Finish=%v", err)
+				}
+			}
+			id := "run_00000000000000000000000000000005"
+			o, err := beginRunObservation(Config{RecordLocal: true}, id, []string{"true"}, io.Discard)
+			if err != nil {
+				t.Fatal(err)
+			}
+			o.finish(timingReport{ExitCode: 1}, true, nil, recorder)
+			record, _, _, err := readLocalHistory(id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantSource, wantState := "local", "unknown"
+			if mode == "verified-receipt" {
+				wantSource, wantState = "both", "recorded"
+			}
+			if record.Source != wantSource || record.CoordinatorState != wantState {
+				t.Fatalf("source=%s coordinator=%s", record.Source, record.CoordinatorState)
+			}
+		})
+	}
+}
+
+func TestRunObservationPolicyIgnoresRepositoryFiles(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("history:\n  local:\n    enabled: true\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	file, err := readFileConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg Config
+	if err := applyFileConfigWithTrust(&cfg, file, false); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.RecordLocal {
+		t.Fatal("repository enabled history")
+	}
+	if err := applyFileConfigWithTrust(&cfg, file, true); err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.RecordLocal {
+		t.Fatal("trusted user policy not applied")
+	}
+}

--- a/internal/cli/run_observation_test.go
+++ b/internal/cli/run_observation_test.go
@@ -54,7 +54,7 @@ func TestRunObservationDirectAppWithoutTimingOutput(t *testing.T) {
 		t.Fatalf("records=%+v err=%v", records, err)
 	}
 	record := records[0]
-	if record.LeaseID != localContainerRunSessionTestLeaseID || record.Slug != "session-slug" || record.RecordingState != "terminal" || record.ExitCode == nil || *record.ExitCode != 0 || record.TotalMs <= 0 || record.CaptureScope != "workload" {
+	if record.LeaseID != localContainerRunSessionTestLeaseID || record.Slug != "session-slug" || record.RecordingState != "terminal" || record.ExitCode == nil || *record.ExitCode != 0 || record.TotalMs <= 0 || record.CaptureScope != "provider-run" {
 		t.Fatalf("record=%+v", record)
 	}
 	if !strings.Contains(stderr.String(), "run="+record.ID) || strings.Contains(stderr.String(), `"commandMs"`) {

--- a/internal/cli/run_recorder.go
+++ b/internal/cli/run_recorder.go
@@ -40,6 +40,7 @@ type runRecorder struct {
 	leaseSlug          string
 	leaseProvider      string
 	finished           bool
+	terminalConfirmed  bool
 	warned             bool
 	warnMu             sync.Mutex
 	publisher          *runEventPublisher
@@ -276,6 +277,7 @@ func (r *runRecorder) Finish(ctx context.Context, target SSHTarget, exitCode int
 		_, finishErr := r.coord.FinishRun(ctx, r.runID, exitCode, sync, command, log, truncated, results, telemetry, classification, receipt)
 		if finishErr == nil && receipt == nil {
 			r.finished = true
+			r.terminalConfirmed = true
 			return nil
 		}
 		lastErr = nil
@@ -288,6 +290,7 @@ func (r *runRecorder) Finish(ctx context.Context, target SSHTarget, exitCode int
 			if receiptErr == nil {
 				if committed == *receipt {
 					r.finished = true
+					r.terminalConfirmed = true
 					return nil
 				}
 				lastErr = fmt.Errorf("stored terminal receipt differs from the signed finish payload")

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1480,12 +1480,13 @@ func (runModuleRuntimeTestProvider) RegisterFlags(*flag.FlagSet, Config) any {
 func (runModuleRuntimeTestProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 	return nil
 }
-func (p runModuleRuntimeTestProvider) Configure(Config, Runtime) (Backend, error) {
-	return runModuleRuntimeTestBackend{spec: p.Spec()}, nil
+func (p runModuleRuntimeTestProvider) Configure(_ Config, rt Runtime) (Backend, error) {
+	return runModuleRuntimeTestBackend{spec: p.Spec(), rt: rt}, nil
 }
 
 type runModuleRuntimeTestBackend struct {
 	spec ProviderSpec
+	rt   Runtime
 }
 
 var runModuleRuntimeTestRequests []RunRequest
@@ -1511,6 +1512,13 @@ func (b runModuleRuntimeTestBackend) Warmup(context.Context, WarmupRequest) erro
 }
 func (b runModuleRuntimeTestBackend) Run(_ context.Context, req RunRequest) (RunResult, error) {
 	runModuleRuntimeTestRequests = append(runModuleRuntimeTestRequests, req)
+	if req.Observation != nil {
+		fmt.Fprintln(b.rt.Stderr, "fixture provider planning")
+		req.Observation.Phase(RunPhaseCommand)
+		stdout, stderr := req.Observation.CommandWriters(b.rt.Stdout, b.rt.Stderr, RunOutputProvider)
+		fmt.Fprintln(stdout, "fixture command stdout")
+		fmt.Fprintln(stderr, "fixture command stderr")
+	}
 	return RunResult{Provider: b.spec.Name, LeaseID: "mod_test", Slug: "module-runtime-test"}, nil
 }
 func (b runModuleRuntimeTestBackend) List(context.Context, ListRequest) ([]LeaseView, error) {

--- a/internal/providers/agentsandbox/backend_test.go
+++ b/internal/providers/agentsandbox/backend_test.go
@@ -895,7 +895,6 @@ func (e testExitError) ExitStatus() int {
 func TestRunExistingLeaseReadinessIsBounded(t *testing.T) {
 	cfg := testAgentSandboxConfig(t)
 	cfg.AgentSandbox.SandboxReadyTimeout = time.Minute
-	cfg.AgentSandbox.PodReadyTimeout = time.Millisecond
 	fake := readyFakeClient(cfg)
 	backend := testBackend(cfg, fake, nil, nil)
 	repo := testGitRepo(t)
@@ -916,6 +915,7 @@ func TestRunExistingLeaseReadinessIsBounded(t *testing.T) {
 	pod.Phase = "Pending"
 	pod.Ready = false
 	fake.pods[podKey] = []podState{pod}
+	backend.cfg.AgentSandbox.PodReadyTimeout = time.Millisecond
 	start := time.Now()
 	_, err = backend.Run(context.Background(), RunRequest{Repo: repo, ID: claim.LeaseID, NoSync: true, Command: []string{"true"}})
 	if err == nil || !strings.Contains(err.Error(), "readiness timed out") {

--- a/internal/providers/agentsandbox/exec.go
+++ b/internal/providers/agentsandbox/exec.go
@@ -40,6 +40,8 @@ func (b *backend) execShell(ctx context.Context, client kubernetesClient, ready 
 }
 
 func (b *backend) runCommand(ctx context.Context, client kubernetesClient, ready sandboxReadiness, req RunRequest, workdir string) (int, error) {
+	req.Observation.Phase(core.RunPhaseCommand)
+	stdout, stderr := req.Observation.CommandWriters(b.rt.Stdout, b.rt.Stderr, core.RunOutputProvider)
 	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
 	if err != nil {
 		return 0, err
@@ -53,8 +55,8 @@ func (b *backend) runCommand(ctx context.Context, client kubernetesClient, ready
 	err = b.execPod(execCtx, client, ready, podExecRequest{
 		Command: []string{"sh", "-s"},
 		Stdin:   strings.NewReader(script),
-		Stdout:  b.rt.Stdout,
-		Stderr:  b.rt.Stderr,
+		Stdout:  stdout,
+		Stderr:  stderr,
 	})
 	if err == nil {
 		return 0, nil

--- a/internal/providers/anthropicsandboxruntime/backend.go
+++ b/internal/providers/anthropicsandboxruntime/backend.go
@@ -45,7 +45,9 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	fmt.Fprintf(b.rt.Stderr, "provider=%s cli=%s sync_delegated=true lifecycle=one-shot\n", providerName, cli.binary())
 	commandStart := time.Now()
-	exitCode, runErr := cli.runCommand(ctx, req.Repo.Root, commandText, req.Env, b.rt.Stdout, b.rt.Stderr)
+	req.Observation.Phase(core.RunPhaseCommand)
+	stdout, stderr := req.Observation.CommandWriters(b.rt.Stdout, b.rt.Stderr, core.RunOutputProvider)
+	exitCode, runErr := cli.runCommand(ctx, req.Repo.Root, commandText, req.Env, stdout, stderr)
 	commandDuration := time.Since(commandStart)
 	result := RunResult{
 		ExitCode:      exitCode,

--- a/internal/providers/applemachine/backend.go
+++ b/internal/providers/applemachine/backend.go
@@ -139,7 +139,10 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	}
 	args = append(args, command...)
 	commandStarted := time.Now()
-	native, runErr := b.command(ctx, args, req.Repo.Root)
+	req.Observation.Phase(core.RunPhaseCommand)
+	commandBackend := *b
+	commandBackend.rt.Stdout, commandBackend.rt.Stderr = req.Observation.CommandWriters(b.rt.Stdout, b.rt.Stderr, core.RunOutputProvider)
+	native, runErr := commandBackend.command(ctx, args, req.Repo.Root)
 	result.Command = time.Since(commandStarted)
 	result.CommandText = strings.Join(req.Command, " ")
 	classificationErr := runErr

--- a/internal/providers/awslambdamicrovm/backend.go
+++ b/internal/providers/awslambdamicrovm/backend.go
@@ -204,7 +204,9 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		printEnvForwardingSummary(b.rt.Stderr, req.Options.EnvAllow, req.Env)
 	}
 	commandStarted := core.ClockNow(b.rt.Clock)
-	exitCode, commandErr := runner.Exec(ctx, vm, command, b.cfg.AWSLambdaMicroVM.Workdir, req.Env, b.rt.Stdout, b.rt.Stderr)
+	req.Observation.Phase(core.RunPhaseCommand)
+	stdout, stderr := req.Observation.CommandWriters(b.rt.Stdout, b.rt.Stderr, core.RunOutputWorkload)
+	exitCode, commandErr := runner.Exec(ctx, vm, command, b.cfg.AWSLambdaMicroVM.Workdir, req.Env, stdout, stderr)
 	result.Command = core.ClockNow(b.rt.Clock).Sub(commandStarted)
 	result.CommandText = strings.Join(req.Command, " ")
 	commandRan = true

--- a/internal/providers/azuredynamicsessions/backend.go
+++ b/internal/providers/azuredynamicsessions/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -123,12 +124,12 @@ func (b *azureDynamicSessionsBackend) Run(ctx context.Context, req RunRequest) (
 			if req.EnvSummary {
 				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 			}
-			return shared.DelegatedSandboxCommand{Text: command, Run: func(ctx context.Context) (int, error) {
+			return shared.DelegatedSandboxCommand{Text: command, Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
 				fmt.Fprintf(b.rt.Stderr, "running on %s %s\n", providerName, strings.Join(req.Command, " "))
 				return client.ExecStream(ctx, leaseID, azureDynamicSessionsExecRequest{
 					Command: command, Cwd: workspace, Env: req.Env,
 					TimeoutMS: durationMillisecondsCeil(azureDynamicSessionsTimeout(b.cfg)),
-				}, b.rt.Stdout, b.rt.Stderr)
+				}, stdout, stderr)
 			}}, nil
 		},
 		Cleanup: func(ctx context.Context) error {

--- a/internal/providers/blacksmith/artifact_run.go
+++ b/internal/providers/blacksmith/artifact_run.go
@@ -336,6 +336,8 @@ func (b *blacksmithBackend) runArtifactTestbox(ctx context.Context, req RunReque
 	var out, diagnostic *blacksmithControlDemux
 	var outGuard, errGuard *blacksmithArchiveGuard
 	filter := func(stdout, stderr io.Writer) (io.Writer, io.Writer) {
+		// Both native streams may include provider diagnostics even with control framing.
+		stdout, stderr = req.Observation.CommandWriters(stdout, stderr, core.RunOutputProvider)
 		outGuard, errGuard = &blacksmithArchiveGuard{output: stdout}, &blacksmithArchiveGuard{output: stderr}
 		r.output = outGuard
 		out = &blacksmithControlDemux{data: r.data, record: r.record, cancel: cancel}

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -217,6 +217,7 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 	stdoutProof := newBlacksmithProofTailBuffer()
 	stderrProof := newBlacksmithProofTailBuffer()
 	commandStart := b.rt.Clock.Now()
+	req.Observation.Phase(core.RunPhaseCommand)
 	phaseTracker := core.NewCommandPhaseTracker(commandStart)
 	code := 0
 	var commandEnd time.Time
@@ -237,6 +238,7 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 			phaseTracker,
 			mergeWriters(stdoutCapture, stdoutProof),
 			mergeWriters(stderrCapture, stderrProof),
+			req.Observation,
 		)
 		return nil
 	}); err != nil {
@@ -814,15 +816,16 @@ func (b *blacksmithBackend) openFailureStreamCapture(label string) (io.WriteClos
 	return core.NewCappedFailureBundleStream(file), path, cleanup, nil
 }
 
-func (b *blacksmithBackend) runTestbox(ctx context.Context, leaseID string, command []string, debug, shellMode bool, phaseTracker *core.CommandPhaseTracker, stdoutExtra, stderrExtra io.Writer) int {
+func (b *blacksmithBackend) runTestbox(ctx context.Context, leaseID string, command []string, debug, shellMode bool, phaseTracker *core.CommandPhaseTracker, stdoutExtra, stderrExtra io.Writer, observation *core.RunObservation) int {
 	keyPath, err := testboxKeyPath(leaseID)
 	if err != nil {
 		fmt.Fprintf(b.rt.Stderr, "blacksmith key path failed: %v\n", err)
 		return 2
 	}
 	args := blacksmithRunArgs(b.cfg, leaseID, keyPath, command, debug || b.cfg.Blacksmith.Debug, shellMode)
-	stdout, stdoutPhaseWriter := commandPhaseWriter(mergeWriters(b.rt.Stdout, stdoutExtra), phaseTracker)
-	stderr, stderrPhaseWriter := commandPhaseWriter(mergeWriters(b.rt.Stderr, stderrExtra), phaseTracker)
+	stdoutTarget, stderrTarget := observation.CommandWriters(mergeWriters(b.rt.Stdout, stdoutExtra), mergeWriters(b.rt.Stderr, stderrExtra), core.RunOutputProvider)
+	stdout, stdoutPhaseWriter := commandPhaseWriter(stdoutTarget, phaseTracker)
+	stderr, stderrPhaseWriter := commandPhaseWriter(stderrTarget, phaseTracker)
 	result, timedOut, err := b.runCommandWithSyncGuard(ctx, args, stdout, stderr)
 	stdoutPhaseWriter.Flush()
 	stderrPhaseWriter.Flush()

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -1336,7 +1336,7 @@ func TestBlacksmithRunTerminatesSyncStall(t *testing.T) {
 			Exec:   blockingSyncRunner{},
 		},
 	}
-	code := backend.runTestbox(context.Background(), "tbx_syncstall", []string{"pnpm", "test"}, false, false, nil, nil, nil)
+	code := backend.runTestbox(context.Background(), "tbx_syncstall", []string{"pnpm", "test"}, false, false, nil, nil, nil, nil)
 	if code != 124 {
 		t.Fatalf("exit=%d want 124", code)
 	}

--- a/internal/providers/blaxel/backend.go
+++ b/internal/providers/blaxel/backend.go
@@ -125,8 +125,8 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			}
 			return shared.DelegatedSandboxCommand{
 				Text: strings.Join(req.Command, " "),
-				Run: func(ctx context.Context) (int, error) {
-					return b.execCommand(ctx, client, sandboxID, workdir, command, req.Env)
+				Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
+					return b.execCommand(ctx, client, sandboxID, workdir, command, req.Env, stdout, stderr)
 				},
 			}, nil
 		},
@@ -576,7 +576,7 @@ func (b *backend) waitSandboxReady(ctx context.Context, client Client, sandboxID
 	return result.Value, nil
 }
 
-func (b *backend) execCommand(ctx context.Context, client Client, sandboxID, workdir string, command []string, env map[string]string) (int, error) {
+func (b *backend) execCommand(ctx context.Context, client Client, sandboxID, workdir string, command []string, env map[string]string, stdout, stderr io.Writer) (int, error) {
 	if len(command) == 0 {
 		return 2, errors.New("missing command")
 	}
@@ -602,10 +602,10 @@ func (b *backend) execCommand(ctx context.Context, client Client, sandboxID, wor
 		return 1, err
 	}
 	if logs.Stdout != "" {
-		_, _ = io.WriteString(b.rt.Stdout, logs.Stdout)
+		_, _ = io.WriteString(stdout, logs.Stdout)
 	}
 	if logs.Stderr != "" {
-		_, _ = io.WriteString(b.rt.Stderr, logs.Stderr)
+		_, _ = io.WriteString(stderr, logs.Stderr)
 	}
 	if process.ExitCode == nil {
 		return 1, fmt.Errorf("blaxel process %s completed without an exit code", process.ID)

--- a/internal/providers/blaxel/backend_test.go
+++ b/internal/providers/blaxel/backend_test.go
@@ -626,7 +626,7 @@ func TestRunSyncOnlyUploadsArchiveAndSkipsUserCommand(t *testing.T) {
 func TestExecCommandReturnsWhenTerminalProcessOmitsExitCode(t *testing.T) {
 	backend, fake, _, _, _ := newLifecycleBackend(t)
 	fake.omitExitCode = true
-	code, err := backend.execCommand(context.Background(), fake, "sbx_1", "/workspace/crabbox", []string{"true"}, nil)
+	code, err := backend.execCommand(context.Background(), fake, "sbx_1", "/workspace/crabbox", []string{"true"}, nil, backend.rt.Stdout, backend.rt.Stderr)
 	if err == nil || !strings.Contains(err.Error(), "without an exit code") {
 		t.Fatalf("execCommand code=%d err=%v, want missing exit code error", code, err)
 	}
@@ -655,7 +655,7 @@ func TestExecCommandEnforcesLocalProcessWaitTimeout(t *testing.T) {
 	backend.cfg.Blaxel.ExecTimeoutSecs = 1
 	fake.processStatus = "running"
 	fake.omitExitCode = true
-	code, err := backend.execCommand(context.Background(), fake, "sbx_1", "/workspace/crabbox", []string{"sleep", "600"}, nil)
+	code, err := backend.execCommand(context.Background(), fake, "sbx_1", "/workspace/crabbox", []string{"sleep", "600"}, nil, backend.rt.Stdout, backend.rt.Stderr)
 	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("execCommand code=%d err=%v, want deadline exceeded", code, err)
 	}

--- a/internal/providers/cloudflare/backend.go
+++ b/internal/providers/cloudflare/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"path"
 	"strings"
@@ -135,8 +136,8 @@ func (b *cloudflareBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 			if req.EnvSummary {
 				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 			}
-			return shared.DelegatedSandboxCommand{Text: command, Run: func(ctx context.Context) (int, error) {
-				return client.execStream(ctx, claim.LeaseID, execStreamRequest{Command: command, Cwd: workdir, Env: req.Env, TimeoutMS: durationMillisecondsCeil(b.cfg.TTL)}, b.rt.Stdout, b.rt.Stderr)
+			return shared.DelegatedSandboxCommand{Text: command, Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
+				return client.execStream(ctx, claim.LeaseID, execStreamRequest{Command: command, Cwd: workdir, Env: req.Env, TimeoutMS: durationMillisecondsCeil(b.cfg.TTL)}, stdout, stderr)
 			}}, nil
 		},
 		Cleanup: func(ctx context.Context) error { _, err := destroyClaimedSandbox(ctx, client, claim); return err },

--- a/internal/providers/cloudflaredynamicworkers/backend.go
+++ b/internal/providers/cloudflaredynamicworkers/backend.go
@@ -101,6 +101,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
 	commandStarted := core.ClockNow(b.rt.Clock)
+	req.Observation.Phase(core.RunPhaseCommand)
 	run, err := client.Run(ctx, loaderReq)
 	commandDuration := core.ClockNow(b.rt.Clock).Sub(commandStarted)
 	if err != nil {
@@ -214,7 +215,8 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if cacheMode == "explicit" {
 		fmt.Fprintf(b.rt.Stderr, "dynamic worker run=%s worker=%s\n", leaseID, run.WorkerID)
 	}
-	writeRunOutput(b.rt.Stdout, b.rt.Stderr, run)
+	stdout, stderr := req.Observation.CommandWriters(b.rt.Stdout, b.rt.Stderr, core.RunOutputWorkload)
+	writeRunOutput(stdout, stderr, run)
 	claimStatus := runStatus{
 		ID:       leaseID,
 		WorkerID: run.WorkerID,

--- a/internal/providers/cloudflaresandbox/backend.go
+++ b/internal/providers/cloudflaresandbox/backend.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"slices"
@@ -186,10 +187,10 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
 				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, commandEnv)
 			}
-			return shared.DelegatedSandboxCommand{Text: commandText, Run: func(ctx context.Context) (int, error) {
+			return shared.DelegatedSandboxCommand{Text: commandText, Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
 				res, err := api.Exec(ctx, sandboxID, execRequest{
 					Command: commandText, WorkingDir: workdir, Env: commandEnv, TimeoutSecs: b.execTimeoutSecs(),
-				}, b.rt.Stdout, b.rt.Stderr)
+				}, stdout, stderr)
 				return res.ExitCode, err
 			}}, nil
 		},

--- a/internal/providers/cloudrunsandbox/backend.go
+++ b/internal/providers/cloudrunsandbox/backend.go
@@ -231,7 +231,9 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 			}
 			commandStart := core.ClockNow(b.rt.Clock)
-			exitCode, runErr := b.execCommand(ctx, transport, sandboxID, workdir, command, req.Env, b.rt.Stdout, b.rt.Stderr)
+			req.Observation.Phase(core.RunPhaseCommand)
+			stdout, stderr := req.Observation.CommandWriters(b.rt.Stdout, b.rt.Stderr, core.RunOutputProvider)
+			exitCode, runErr := b.execCommand(ctx, transport, sandboxID, workdir, command, req.Env, stdout, stderr)
 			commandDuration := core.ClockNow(b.rt.Clock).Sub(commandStart)
 			commandRan = true
 			outcome := shared.FinalizeDelegatedCommandOutcome(exitCode, runErr)

--- a/internal/providers/codesandbox/backend.go
+++ b/internal/providers/codesandbox/backend.go
@@ -128,8 +128,8 @@ func (b *codeSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 			}
 			return shared.DelegatedSandboxCommand{
 				Text: strings.Join(command, " "),
-				Run: func(ctx context.Context) (int, error) {
-					return b.execCommand(ctx, api, sandboxID, workdir, command, req.Env)
+				Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
+					return b.execCommand(ctx, api, sandboxID, workdir, command, req.Env, stdout, stderr)
 				},
 			}, nil
 		},
@@ -480,7 +480,7 @@ func (b *codeSandboxBackend) Doctor(ctx context.Context, _ DoctorRequest) (Docto
 	return result, nil
 }
 
-func (b *codeSandboxBackend) execCommand(ctx context.Context, api codeSandboxAPI, sandboxID, workdir string, command []string, env map[string]string) (int, error) {
+func (b *codeSandboxBackend) execCommand(ctx context.Context, api codeSandboxAPI, sandboxID, workdir string, command []string, env map[string]string, stdout, stderr io.Writer) (int, error) {
 	if len(command) == 0 {
 		return 2, errors.New("missing command")
 	}
@@ -494,10 +494,10 @@ func (b *codeSandboxBackend) execCommand(ctx context.Context, api codeSandboxAPI
 		return 1, err
 	}
 	if res.Stdout != "" {
-		_, _ = io.WriteString(b.rt.Stdout, res.Stdout)
+		_, _ = io.WriteString(stdout, res.Stdout)
 	}
 	if res.Stderr != "" {
-		_, _ = io.WriteString(b.rt.Stderr, res.Stderr)
+		_, _ = io.WriteString(stderr, res.Stderr)
 	}
 	return res.ExitCode, nil
 }

--- a/internal/providers/crownest/backend.go
+++ b/internal/providers/crownest/backend.go
@@ -283,7 +283,9 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	commandStart := core.ClockNow(b.rt.Clock)
 	commandRan, cancelActiveRun = true, true
 	cancelRunID = workspaceRun.ID
-	terminal, streamErr := b.streamRun(ctx, api, workspaceRun.ID)
+	req.Observation.Phase(core.RunPhaseCommand)
+	stdout, stderr := req.Observation.CommandWriters(b.rt.Stdout, b.rt.Stderr, core.RunOutputWorkload)
+	terminal, streamErr := b.streamRun(ctx, api, workspaceRun.ID, stdout, stderr)
 	commandDuration := core.ClockNow(b.rt.Clock).Sub(commandStart)
 	if terminal.ID == "" && ctx.Err() == nil {
 		if latest, getErr := api.GetWorkspaceRun(ctx, workspaceRun.ID); getErr == nil {
@@ -716,7 +718,7 @@ func hashArchive(file *os.File) (string, int64, error) {
 	return hex.EncodeToString(h.Sum(nil)), size, nil
 }
 
-func (b *backend) streamRun(ctx context.Context, api client, workspaceRunID string) (workspaceRun, error) {
+func (b *backend) streamRun(ctx context.Context, api client, workspaceRunID string, stdout, stderr io.Writer) (workspaceRun, error) {
 	var afterSeq int64
 	for attempts := 0; attempts < 3; attempts++ {
 		body, err := api.StreamWorkspaceRunEvents(ctx, workspaceRunID, afterSeq)
@@ -730,9 +732,9 @@ func (b *backend) streamRun(ctx context.Context, api client, workspaceRunID stri
 			}
 			switch event.Type {
 			case "stdout":
-				_, _ = io.WriteString(b.rt.Stdout, event.Data)
+				_, _ = io.WriteString(stdout, event.Data)
 			case "stderr":
-				_, _ = io.WriteString(b.rt.Stderr, event.Data)
+				_, _ = io.WriteString(stderr, event.Data)
 			case "terminal":
 				terminal = event.WorkspaceRun
 			case "error":

--- a/internal/providers/cubesandbox/backend.go
+++ b/internal/providers/cubesandbox/backend.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"path"
 	"slices"
 	"strings"
@@ -199,10 +200,10 @@ func (b *cubesandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 			}
 			return shared.DelegatedSandboxCommand{
 				Text: strings.Join(req.Command, " "),
-				Run: func(ctx context.Context) (int, error) {
+				Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
 					return client.StartProcess(ctx, session, cubesandboxProcessRequest{
 						Command: command, CWD: workspace, Env: commandEnv, User: processUser,
-						Timeout: cubesandboxTimeoutDuration(b.cfg.TTL), Stdout: b.rt.Stdout, Stderr: b.rt.Stderr,
+						Timeout: cubesandboxTimeoutDuration(b.cfg.TTL), Stdout: stdout, Stderr: stderr,
 					})
 				},
 			}, nil

--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -201,6 +201,9 @@ func (b *daytonaLeaseBackend) run(ctx context.Context, req RunRequest, original 
 		return RunResult{}, exit(2, "missing command")
 	}
 	commandStarted := time.Now()
+	req.Observation.Phase(core.RunPhaseCommand)
+	req.Observation.OmitStream("stderr", "provider-combines-output")
+	stdout, _ := req.Observation.CommandWriters(b.rt.Stdout, nil, core.RunOutputWorkload)
 	fmt.Fprintf(b.rt.Stderr, "running on daytona %s\n", strings.Join(req.Command, " "))
 	execOpts := []func(*sdkoptions.ExecuteCommand){sdkoptions.WithCwd(workdir)}
 	if env := req.Env; len(env) > 0 {
@@ -215,9 +218,9 @@ func (b *daytonaLeaseBackend) run(ctx context.Context, req RunRequest, original 
 		SyncDelegated: true,
 	}
 	if response != nil && response.Result != "" {
-		fmt.Fprint(b.rt.Stdout, response.Result)
+		fmt.Fprint(stdout, response.Result)
 		if !strings.HasSuffix(response.Result, "\n") {
-			fmt.Fprintln(b.rt.Stdout)
+			fmt.Fprintln(stdout)
 		}
 	}
 	fmt.Fprintf(b.rt.Stderr, "daytona run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)

--- a/internal/providers/dockersandbox/backend.go
+++ b/internal/providers/dockersandbox/backend.go
@@ -162,7 +162,9 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	}
 	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s sync_delegated=true\n", providerName, leaseID, sandboxName, workdir)
 	commandStart := core.ClockNow(b.rt.Clock)
-	exitCode, runErr := cli.execStream(ctx, sandboxName, workdir, envFile, command, b.rt.Stdout, b.rt.Stderr)
+	req.Observation.Phase(core.RunPhaseCommand)
+	stdout, stderr := req.Observation.CommandWriters(b.rt.Stdout, b.rt.Stderr, core.RunOutputProvider)
+	exitCode, runErr := cli.execStream(ctx, sandboxName, workdir, envFile, command, stdout, stderr)
 	result.Command = core.ClockNow(b.rt.Clock).Sub(commandStart)
 	result.CommandText = strings.Join(req.Command, " ")
 	commandRan = true

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"path"
 	"strings"
 	"time"
@@ -137,11 +138,11 @@ func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error)
 				return shared.DelegatedSandboxCommand{}, exit(2, "%v", err)
 			}
 			command := intent.ShellSource()
-			return shared.DelegatedSandboxCommand{Run: func(ctx context.Context) (int, error) {
+			return shared.DelegatedSandboxCommand{Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
 				fmt.Fprintf(b.rt.Stderr, "running on e2b %s\n", strings.Join(req.Command, " "))
 				return client.StartProcess(ctx, session, e2bProcessRequest{
 					Command: command, CWD: workspace, Env: req.Env, User: processUser,
-					Timeout: e2bTimeoutDuration(b.cfg.TTL), Stdout: b.rt.Stdout, Stderr: b.rt.Stderr,
+					Timeout: e2bTimeoutDuration(b.cfg.TTL), Stdout: stdout, Stderr: stderr,
 				})
 			}}, nil
 		},

--- a/internal/providers/freestyle/backend.go
+++ b/internal/providers/freestyle/backend.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"regexp"
 	"sort"
 	"strings"
@@ -162,8 +163,8 @@ func (b *freestyleBackend) Run(ctx context.Context, req RunRequest) (RunResult, 
 			if req.EnvSummary {
 				printEnvForwardingSummary(b.rt.Stderr, freestyleProvider, "forwarded", req.Options.EnvAllow, req.Env)
 			}
-			return shared.DelegatedSandboxCommand{Run: func(ctx context.Context) (int, error) {
-				return b.exec(ctx, client, name, workspace, req.Command, req.ShellMode, req.Env)
+			return shared.DelegatedSandboxCommand{Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
+				return b.exec(ctx, client, name, workspace, req.Command, req.ShellMode, req.Env, stdout, stderr)
 			}}, nil
 		},
 		Cleanup: func(ctx context.Context) error {
@@ -321,7 +322,7 @@ func freestyleCleanupCommand(leaseID string) string {
 	return fmt.Sprintf("crabbox stop --provider %s --id %s", freestyleProvider, shellQuote(leaseID))
 }
 
-func (b *freestyleBackend) exec(ctx context.Context, client freestyleAPI, id, workdir string, command []string, shellMode bool, env map[string]string) (int, error) {
+func (b *freestyleBackend) exec(ctx context.Context, client freestyleAPI, id, workdir string, command []string, shellMode bool, env map[string]string, stdout, stderr io.Writer) (int, error) {
 	execCommand := freestyleExecCommand(command, shellMode)
 	parts := make([]string, 0, 3)
 	if workdir != "" {
@@ -332,7 +333,7 @@ func (b *freestyleBackend) exec(ctx context.Context, client freestyleAPI, id, wo
 	}
 	parts = append(parts, execCommand)
 	fullCommand := strings.Join(parts, " && ")
-	return client.Exec(ctx, id, "bash -lc "+shellQuote(fullCommand), b.rt.Stdout, b.rt.Stderr)
+	return client.Exec(ctx, id, "bash -lc "+shellQuote(fullCommand), stdout, stderr)
 }
 
 func freestyleEnvExportCommand(env map[string]string) string {

--- a/internal/providers/freestyle/backend_test.go
+++ b/internal/providers/freestyle/backend_test.go
@@ -92,7 +92,7 @@ func TestFreestyleExecForwardsEnvAfterWorkdir(t *testing.T) {
 	backend := &freestyleBackend{rt: Runtime{Stderr: io.Discard}}
 	code, err := backend.exec(context.Background(), client, "vm123", "/workspace/repo", []string{`echo "$GREETING"`}, false, map[string]string{
 		"GREETING": "hello world",
-	})
+	}, backend.rt.Stdout, backend.rt.Stderr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -297,7 +298,9 @@ func (b *isloBackend) Run(ctx context.Context, req RunRequest) (result RunResult
 		return result, err
 	}
 	commandStart := b.now()
-	exitCode, runErr := b.exec(ctx, client, name, workspace, req.Command, req.ShellMode, isloWorkloadEnv(req.Env, tailnetReady), workloadUser)
+	req.Observation.Phase(core.RunPhaseCommand)
+	stdout, stderr := req.Observation.CommandWriters(b.rt.Stdout, b.rt.Stderr, core.RunOutputWorkload)
+	exitCode, runErr := b.exec(ctx, client, name, workspace, req.Command, req.ShellMode, isloWorkloadEnv(req.Env, tailnetReady), workloadUser, stdout, stderr)
 	commandDuration := b.now().Sub(commandStart)
 	commandRan = true
 	result.Command = commandDuration
@@ -728,7 +731,7 @@ func (b *isloBackend) cleanupCreatedIsloSandbox(client isloAPI, identity isloIde
 	return nil
 }
 
-func (b *isloBackend) exec(ctx context.Context, client isloAPI, name, workdir string, command []string, shellMode bool, env map[string]string, user string) (int, error) {
+func (b *isloBackend) exec(ctx context.Context, client isloAPI, name, workdir string, command []string, shellMode bool, env map[string]string, user string, stdout, stderr io.Writer) (int, error) {
 	execCommand, err := isloExecCommand(command, shellMode)
 	if err != nil {
 		return 2, err
@@ -747,7 +750,7 @@ func (b *isloBackend) exec(ctx context.Context, client isloAPI, name, workdir st
 			req.Env[name] = &value
 		}
 	}
-	return client.ExecStream(ctx, name, req, b.rt.Stdout, b.rt.Stderr)
+	return client.ExecStream(ctx, name, req, stdout, stderr)
 }
 
 func isloExecCommand(command []string, shellMode bool) ([]string, error) {

--- a/internal/providers/islo/backend_test.go
+++ b/internal/providers/islo/backend_test.go
@@ -1968,7 +1968,7 @@ func TestIsloExecForwardsEnv(t *testing.T) {
 	code, err := backend.exec(context.Background(), client, "crabbox-test", "/workspace/repo", []string{"env"}, false, map[string]string{
 		"API_TOKEN": "secret",
 		"CI":        "1",
-	}, "")
+	}, "", backend.rt.Stdout, backend.rt.Stderr)
 	if err != nil || code != 0 {
 		t.Fatalf("exec code=%d err=%v", code, err)
 	}

--- a/internal/providers/modal/backend.go
+++ b/internal/providers/modal/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"path"
 	"strings"
 	"time"
@@ -154,13 +155,13 @@ func (b *modalBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 				}
 				command = shared.WrapCommandWithShellEnvProfile(command, envPath)
 			}
-			return shared.DelegatedSandboxCommand{Close: closeCommand, Run: func(ctx context.Context) (int, error) {
+			return shared.DelegatedSandboxCommand{OutputScope: core.RunOutputProvider, Close: closeCommand, Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
 				var code int
 				err := fenced(func() error {
 					var err error
 					code, err = client.Exec(ctx, modalExecRequest{
 						SandboxID: sandboxID, Command: command,
-						Timeout: durationSecondsCeil(modalTimeoutDuration(b.cfg.TTL)), Stdout: b.rt.Stdout, Stderr: b.rt.Stderr,
+						Timeout: durationSecondsCeil(modalTimeoutDuration(b.cfg.TTL)), Stdout: stdout, Stderr: stderr,
 					})
 					return err
 				})

--- a/internal/providers/mxc/backend.go
+++ b/internal/providers/mxc/backend.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 var windowsBuildPattern = regexp.MustCompile(`(?m)CurrentBuildNumber\s+REG_SZ\s+(\d+)`)
@@ -94,7 +96,9 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	args = append(args, path)
 	commandStarted := time.Now()
-	result, runErr := b.rt.Exec.Run(ctx, LocalCommandRequest{Name: defaultString(b.cfg.MXC.CLIPath, "wxc-exec.exe"), Args: args, Dir: req.Repo.Root, Stdout: b.rt.Stdout, Stderr: b.rt.Stderr})
+	req.Observation.Phase(core.RunPhaseCommand)
+	stdout, stderr := req.Observation.CommandWriters(b.rt.Stdout, b.rt.Stderr, core.RunOutputProvider)
+	result, runErr := b.rt.Exec.Run(ctx, LocalCommandRequest{Name: defaultString(b.cfg.MXC.CLIPath, "wxc-exec.exe"), Args: args, Dir: req.Repo.Root, Stdout: stdout, Stderr: stderr})
 	out := RunResult{ExitCode: result.ExitCode, Command: time.Since(commandStarted), Total: time.Since(started), SyncDelegated: true, Provider: providerName, CommandText: strings.Join(req.Command, " ")}
 	if req.TimingJSON {
 		_ = writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{Provider: providerName, CommandMs: out.Command.Milliseconds(), TotalMs: out.Total.Milliseconds(), ExitCode: out.ExitCode, SyncDelegated: true, SyncSkipped: true}, out, runErr))

--- a/internal/providers/nomad/exec.go
+++ b/internal/providers/nomad/exec.go
@@ -49,7 +49,7 @@ func (b *backend) execShell(ctx context.Context, client Client, ready allocation
 	return nil
 }
 
-func (b *backend) runCommand(ctx context.Context, client Client, ready allocationReadiness, req RunRequest, workdir string) (int, error) {
+func (b *backend) runCommand(ctx context.Context, client Client, ready allocationReadiness, req RunRequest, workdir string, stdout, stderr io.Writer) (int, error) {
 	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
 	if err != nil {
 		return 0, err
@@ -60,7 +60,7 @@ func (b *backend) runCommand(ctx context.Context, client Client, ready allocatio
 	script := shared.ShellWorkspaceCommand(workdir, req.Env, intent, "bash", "-lc")
 	execCtx, cancel := b.execContext(ctx)
 	defer cancel()
-	exitCode, err := b.allocationExec(execCtx, client, ready, []string{"sh", "-s"}, strings.NewReader(script), b.rt.Stdout, b.rt.Stderr)
+	exitCode, err := b.allocationExec(execCtx, client, ready, []string{"sh", "-s"}, strings.NewReader(script), stdout, stderr)
 	if err != nil {
 		exitCode = normalizeExitCode(exitCode)
 		if exitCode == 0 {

--- a/internal/providers/nomad/lifecycle.go
+++ b/internal/providers/nomad/lifecycle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"net/http"
 	"strings"
@@ -192,8 +193,8 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		Command: func(context.Context) (shared.DelegatedSandboxCommand, error) {
 			return shared.DelegatedSandboxCommand{
 				Text: strings.Join(req.Command, " "),
-				Run: func(ctx context.Context) (int, error) {
-					return b.runCommand(ctx, client, ready, req, workdir)
+				Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
+					return b.runCommand(ctx, client, ready, req, workdir, stdout, stderr)
 				},
 			}, nil
 		},

--- a/internal/providers/nomad/lifecycle_test.go
+++ b/internal/providers/nomad/lifecycle_test.go
@@ -1166,7 +1166,7 @@ func TestRunLiteralArgumentsSurviveNativeStdinTransport(t *testing.T) {
 	b, _, _ := testBackend(t, fake)
 	workdir := t.TempDir()
 	marker := filepath.Join(workdir, "must-not-exist")
-	_, err = b.runCommand(context.Background(), fake, allocationReadiness{JobID: "job", AllocationID: "alloc", Task: "task"}, RunRequest{Command: []string{"printf", "%s", ";", "touch", marker}, CommandLiteralArgs: map[int]bool{2: true}}, workdir)
+	_, err = b.runCommand(context.Background(), fake, allocationReadiness{JobID: "job", AllocationID: "alloc", Task: "task"}, RunRequest{Command: []string{"printf", "%s", ";", "touch", marker}, CommandLiteralArgs: map[int]bool{2: true}}, workdir, b.rt.Stdout, b.rt.Stderr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -132,8 +132,8 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 			}
 			return shared.DelegatedSandboxCommand{
 				Text: strings.Join(req.Command, " "),
-				Run: func(ctx context.Context) (int, error) {
-					return b.execCommand(ctx, api, sandboxID, workdir, command, req.Env)
+				Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
+					return b.execCommand(ctx, api, sandboxID, workdir, command, req.Env, stdout, stderr)
 				},
 			}, nil
 		},
@@ -331,7 +331,7 @@ func (b *openComputerBackend) Stop(ctx context.Context, req StopRequest) error {
 
 // execCommand runs the user command via POST /exec/run, forwarding env in the
 // request body and streaming the buffered stdout/stderr back to the caller.
-func (b *openComputerBackend) execCommand(ctx context.Context, api *ocAPIClient, sandboxID, workdir string, command []string, env map[string]string) (int, error) {
+func (b *openComputerBackend) execCommand(ctx context.Context, api *ocAPIClient, sandboxID, workdir string, command []string, env map[string]string, stdout, stderr io.Writer) (int, error) {
 	if len(command) == 0 {
 		return 2, errors.New("missing command")
 	}
@@ -346,10 +346,10 @@ func (b *openComputerBackend) execCommand(ctx context.Context, api *ocAPIClient,
 		return 1, err
 	}
 	if res.Stdout != "" {
-		_, _ = io.WriteString(b.rt.Stdout, res.Stdout)
+		_, _ = io.WriteString(stdout, res.Stdout)
 	}
 	if res.Stderr != "" {
-		_, _ = io.WriteString(b.rt.Stderr, res.Stderr)
+		_, _ = io.WriteString(stderr, res.Stderr)
 	}
 	return res.ExitCode, nil
 }

--- a/internal/providers/opensandbox/backend.go
+++ b/internal/providers/opensandbox/backend.go
@@ -239,10 +239,11 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 			}
 			text := intent.ShellCommand("bash", "-lc")
 			return shared.DelegatedSandboxCommand{
-				Text: text,
-				Run: func(ctx context.Context) (int, error) {
+				Text: text, OutputScope: core.RunOutputProvider,
+				Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
 					return api.RunCommand(ctx, sandboxID, runCommandRequest{
 						Command: text, Workdir: workdir, Env: req.Env, TimeoutSecs: b.execTimeoutSecs(),
+						Stdout: stdout, Stderr: stderr,
 					})
 				},
 			}, nil

--- a/internal/providers/opensandbox/client.go
+++ b/internal/providers/opensandbox/client.go
@@ -68,6 +68,8 @@ type sandboxInfo struct {
 }
 
 type runCommandRequest struct {
+	Stdout      io.Writer `json:"-"`
+	Stderr      io.Writer `json:"-"`
 	Command     string
 	Workdir     string
 	Env         map[string]string
@@ -575,6 +577,14 @@ func (c *sdkOpenSandboxClient) UploadFile(ctx context.Context, sandboxID, remote
 }
 
 func (c *sdkOpenSandboxClient) RunCommand(ctx context.Context, sandboxID string, req runCommandRequest) (int, error) {
+	commandClient := *c
+	if req.Stdout != nil {
+		commandClient.rt.Stdout = req.Stdout
+	}
+	if req.Stderr != nil {
+		commandClient.rt.Stderr = req.Stderr
+	}
+	c = &commandClient
 	if timeout := c.execRequestTimeout(req.TimeoutSecs); timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, timeout)

--- a/internal/providers/orgo/backend.go
+++ b/internal/providers/orgo/backend.go
@@ -145,7 +145,9 @@ func (b *orgoBackend) Run(ctx context.Context, req RunRequest) (result RunResult
 		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
 	commandStarted := core.ClockNow(b.rt.Clock)
-	exitCode, runErr := client.RunBash(ctx, lease.Computer.ID, command, b.rt.Stdout, b.rt.Stderr)
+	req.Observation.Phase(core.RunPhaseCommand)
+	stdout, stderr := req.Observation.CommandWriters(b.rt.Stdout, b.rt.Stderr, core.RunOutputWorkload)
+	exitCode, runErr := client.RunBash(ctx, lease.Computer.ID, command, stdout, stderr)
 	result.Command = core.ClockNow(b.rt.Clock).Sub(commandStarted)
 	commandRan = true
 	if runErr != nil {

--- a/internal/providers/shared/delegated.go
+++ b/internal/providers/shared/delegated.go
@@ -39,9 +39,11 @@ type DelegatedSandboxRecovery struct {
 // Adapters may return a mandatory cleanup failure, or warn and return nil for
 // best-effort cleanup. An explicit ExitError preserves its cleanup-only code.
 type DelegatedSandboxCommand struct {
-	Text  string
-	Run   func(context.Context) (int, error)
-	Close func(context.Context) error
+	Text string
+	// OutputScope names the adapter's actual stream boundary, not inferred workload purity.
+	OutputScope core.RunOutputScope
+	Run         func(context.Context, io.Writer, io.Writer) (int, error)
+	Close       func(context.Context) error
 }
 
 type observedProcessEndError struct{ message string }
@@ -191,6 +193,7 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 			result.Session.Kept = true
 			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
 			if shouldStop {
+				req.Observation.Phase(core.RunPhaseCleanup)
 				if err := lifecycle.Cleanup(cleanupCtx); err != nil {
 					appendFailure(fmt.Errorf("%s cleanup failed: %w", lifecycle.Provider, err), 1)
 				} else {
@@ -245,14 +248,17 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 		return result, err
 	}
 	if acquired {
+		req.Observation.Phase(core.RunPhaseAcquire)
 		sandbox, err = lifecycle.Acquire(ctx)
 	} else {
+		req.Observation.Phase(core.RunPhaseResolve)
 		sandbox, err = lifecycle.Resolve(ctx)
 	}
 	if err != nil {
 		acquireFailed = acquired
 		if recovery := sandbox.Recovery; acquired && recovery != nil && recovery.LeaseID != "" {
 			result.LeaseID, result.Slug = recovery.LeaseID, recovery.Slug
+			req.Observation.BindLease(recovery.LeaseID, recovery.Slug)
 			result.Session = &core.RunSessionHandle{
 				Provider: lifecycle.Provider, LeaseID: recovery.LeaseID, Slug: recovery.Slug,
 				Kept: true, CleanupCommand: recovery.CleanupCommand,
@@ -261,6 +267,7 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 		return result, err
 	}
 	result.LeaseID, result.Slug = sandbox.LeaseID, sandbox.Slug
+	req.Observation.BindLease(sandbox.LeaseID, sandbox.Slug)
 	result.Session = &core.RunSessionHandle{
 		Provider: lifecycle.Provider, LeaseID: sandbox.LeaseID, Slug: sandbox.Slug,
 		Reused: !acquired, CleanupCommand: sandbox.CleanupCommand,
@@ -278,6 +285,7 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 		return result, err
 	}
 	if lifecycle.Setup != nil {
+		req.Observation.Phase(core.RunPhaseSetup)
 		if err := lifecycle.Setup(ctx); err != nil {
 			return result, err
 		}
@@ -285,6 +293,7 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 	if err := ctx.Err(); err != nil {
 		return result, err
 	}
+	req.Observation.Phase(core.RunPhaseSync)
 	if req.NoSync {
 		if err := lifecycle.NoSync(ctx); err != nil {
 			return result, err
@@ -311,8 +320,14 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 		return result, err
 	}
 	result.CommandText = command.Text
+	req.Observation.Phase(core.RunPhaseCommand)
+	scope := command.OutputScope
+	if scope == "" {
+		scope = core.RunOutputWorkload
+	}
+	commandStdout, commandStderr := req.Observation.CommandWriters(stdout, stderr, scope)
 	commandStarted := now()
-	result.ExitCode, err = command.Run(ctx)
+	result.ExitCode, err = command.Run(ctx, commandStdout, commandStderr)
 	result.Command = now().Sub(commandStarted)
 	commandRan = true
 	outcome := FinalizeDelegatedCommandOutcome(result.ExitCode, err)

--- a/internal/providers/shared/delegated_test.go
+++ b/internal/providers/shared/delegated_test.go
@@ -164,7 +164,9 @@ func TestDelegatedSandboxSecondaryDiagnosticsKeepSafeMessages(t *testing.T) {
 		NoSync:   func(context.Context) error { return nil },
 		Command: func(context.Context) (DelegatedSandboxCommand, error) {
 			return DelegatedSandboxCommand{
-				Run:   func(context.Context) (int, error) { return 1, ExitErrorWithCause(1, "safe execution", primary) },
+				Run: func(context.Context, io.Writer, io.Writer) (int, error) {
+					return 1, ExitErrorWithCause(1, "safe execution", primary)
+				},
 				Close: func(context.Context) error { return ExitErrorWithCause(5, "safe cleanup", secondary) },
 			}, nil
 		},
@@ -311,7 +313,7 @@ func TestDelegatedSandboxLifecycle(t *testing.T) {
 				},
 				NoSync: func(context.Context) error { return step("workspace") },
 				Command: func(context.Context) (DelegatedSandboxCommand, error) {
-					return DelegatedSandboxCommand{Text: "true", Run: func(context.Context) (int, error) {
+					return DelegatedSandboxCommand{Text: "true", Run: func(context.Context, io.Writer, io.Writer) (int, error) {
 						if !locked {
 							t.Fatal("command without lock")
 						}
@@ -457,7 +459,7 @@ func TestDelegatedSandboxSequence(t *testing.T) {
 		},
 		Command: func(context.Context) (DelegatedSandboxCommand, error) {
 			add("command")
-			return DelegatedSandboxCommand{Run: func(context.Context) (int, error) { add("exec"); return 0, nil }, Close: func(context.Context) error { add("close-command"); return nil }}, nil
+			return DelegatedSandboxCommand{Run: func(context.Context, io.Writer, io.Writer) (int, error) { add("exec"); return 0, nil }, Close: func(context.Context) error { add("close-command"); return nil }}, nil
 		},
 		Cleanup: func(context.Context) error { add("cleanup"); return nil },
 	}
@@ -541,7 +543,7 @@ func TestDelegatedSandboxAcquisitionRecovery(t *testing.T) {
 				Acquire: acquire, Resolve: acquire, Setup: step("setup"), NoSync: step("workspace"),
 				Command: func(context.Context) (DelegatedSandboxCommand, error) {
 					calls = append(calls, "command")
-					return DelegatedSandboxCommand{Run: func(context.Context) (int, error) { calls = append(calls, "run"); return 0, nil }}, nil
+					return DelegatedSandboxCommand{Run: func(context.Context, io.Writer, io.Writer) (int, error) { calls = append(calls, "run"); return 0, nil }}, nil
 				},
 				Cleanup: step("cleanup"), Retained: step("retained"),
 			})
@@ -629,7 +631,7 @@ func TestDelegatedSandboxTimingWriterFailureDoesNotSkipCleanupOrMaskExit(t *test
 				Acquire: func(context.Context) (DelegatedSandbox, error) { return DelegatedSandbox{LeaseID: "lease"}, nil },
 				NoSync:  func(context.Context) error { return nil },
 				Command: func(context.Context) (DelegatedSandboxCommand, error) {
-					return DelegatedSandboxCommand{Run: func(context.Context) (int, error) { return code, nil }}, nil
+					return DelegatedSandboxCommand{Run: func(context.Context, io.Writer, io.Writer) (int, error) { return code, nil }}, nil
 				},
 				Cleanup: func(context.Context) error { calls++; return nil },
 			})
@@ -679,7 +681,10 @@ func TestDelegatedSandboxCancellationBetweenPhases(t *testing.T) {
 				},
 				Command: func(context.Context) (DelegatedSandboxCommand, error) {
 					step("command")
-					return DelegatedSandboxCommand{Run: func(context.Context) (int, error) { t.Fatal("command ran after cancellation"); return 0, nil }}, nil
+					return DelegatedSandboxCommand{Run: func(context.Context, io.Writer, io.Writer) (int, error) {
+						t.Fatal("command ran after cancellation")
+						return 0, nil
+					}}, nil
 				},
 				Cleanup: func(ctx context.Context) error {
 					if ctx.Err() != nil {

--- a/internal/providers/smolvm/backend.go
+++ b/internal/providers/smolvm/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"path"
 	"regexp"
@@ -139,8 +140,9 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			return shared.DelegatedSandboxCommand{
 				Text:  strings.Join(req.Command, " "),
 				Close: closeCommand,
-				Run: func(ctx context.Context) (int, error) {
-					return client.ExecStream(ctx, claim.CloudID, command, folder, b.rt.Stdout)
+				Run: func(ctx context.Context, stdout, _ io.Writer) (int, error) {
+					req.Observation.OmitStream("stderr", "provider-combines-output")
+					return client.ExecStream(ctx, claim.CloudID, command, folder, stdout)
 				},
 			}, nil
 		},

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"slices"
 	"strings"
@@ -207,10 +208,10 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			}
 			return shared.DelegatedSandboxCommand{
 				Text: commandText,
-				Run: func(ctx context.Context) (int, error) {
+				Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
 					res, err := api.Exec(ctx, &access, execRequest{
 						Command: commandText, WorkingDir: workdir, Env: commandEnv, TimeoutSecs: b.execTimeoutSecs(),
-					}, b.rt.Stdout, b.rt.Stderr)
+					}, stdout, stderr)
 					return res.ExitCode, err
 				},
 			}, nil

--- a/internal/providers/tensorlake/backend.go
+++ b/internal/providers/tensorlake/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"strings"
@@ -126,7 +127,7 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 			if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
 				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 			}
-			var command shared.DelegatedSandboxCommand
+			command := shared.DelegatedSandboxCommand{OutputScope: core.RunOutputProvider}
 			if len(req.Env) > 0 {
 				envPath, cleanup, err := b.uploadEnvProfile(ctx, cli, claim, req.Env)
 				if cleanup != nil {
@@ -140,8 +141,8 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 				}
 				args = shared.WrapCommandWithShellEnvProfile(args, envPath)
 			}
-			command.Run = func(ctx context.Context) (int, error) {
-				code, err := cli.execStream(ctx, claim.CloudID, workdir, args, b.rt.Stdout, b.rt.Stderr)
+			command.Run = func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
+				code, err := cli.execStream(ctx, claim.CloudID, workdir, args, stdout, stderr)
 				if err != nil {
 					return code, shared.ExitErrorWithCause(1, shared.RedactErrorSecrets(err.Error(), b.cfg.Tensorlake.APIKey), err)
 				}

--- a/internal/providers/upstashbox/backend.go
+++ b/internal/providers/upstashbox/backend.go
@@ -3,6 +3,7 @@ package upstashbox
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"path"
 	"regexp"
@@ -128,8 +129,9 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 				command = shared.ShellScriptWithEnvProfile(command, envPath)
 			}
 			return shared.DelegatedSandboxCommand{Text: strings.Join(req.Command, " "), Close: closeCommand,
-				Run: func(ctx context.Context) (int, error) {
-					return client.ExecStream(ctx, boxID, command, folder, b.rt.Stdout)
+				Run: func(ctx context.Context, stdout, _ io.Writer) (int, error) {
+					req.Observation.OmitStream("stderr", "provider-combines-output")
+					return client.ExecStream(ctx, boxID, command, folder, stdout)
 				}}, nil
 		},
 		Cleanup: func(ctx context.Context) error {

--- a/internal/providers/vercelsandbox/backend.go
+++ b/internal/providers/vercelsandbox/backend.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"slices"
 	"strings"
@@ -154,8 +155,8 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
 				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, commandEnv)
 			}
-			return shared.DelegatedSandboxCommand{Text: commandText, Run: func(ctx context.Context) (int, error) {
-				result, err := api.Exec(ctx, sandboxID, execRequest{Command: commandText, WorkingDir: workdir, Env: commandEnv, TimeoutSecs: b.execTimeoutSecs()}, b.rt.Stdout, b.rt.Stderr)
+			return shared.DelegatedSandboxCommand{Text: commandText, Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
+				result, err := api.Exec(ctx, sandboxID, execRequest{Command: commandText, WorkingDir: workdir, Env: commandEnv, TimeoutSecs: b.execTimeoutSecs()}, stdout, stderr)
 				if err != nil {
 					return result.ExitCode, shared.ExitErrorWithCause(1, redactSecrets(err.Error()), err)
 				}

--- a/internal/providers/wandb/backend.go
+++ b/internal/providers/wandb/backend.go
@@ -151,6 +151,8 @@ func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (result RunResul
 	}()
 
 	commandStarted := core.ClockNow(b.rt.Clock)
+	req.Observation.Phase(core.RunPhaseCommand)
+	stdout, stderr := req.Observation.CommandWriters(b.rt.Stdout, b.rt.Stderr, core.RunOutputWorkload)
 	var exitCode int
 	var execErr error
 	if err := verifyWandbClaim(claim); err != nil {
@@ -159,8 +161,8 @@ func (b *wandbBackend) Run(ctx context.Context, req RunRequest) (result RunResul
 		exitCode, execErr = client.Exec(ctx, wandbExecRequest{
 			SandboxID: sandboxID,
 			Command:   req.Command,
-			Stdout:    b.rt.Stdout,
-			Stderr:    b.rt.Stderr,
+			Stdout:    stdout,
+			Stderr:    stderr,
 		})
 	}
 

--- a/internal/providers/windowssandbox/backend.go
+++ b/internal/providers/windowssandbox/backend.go
@@ -121,11 +121,13 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	fmt.Fprintf(b.rt.Stderr, "provider=%s workdir=%s host_workspace=%s networking=%s vgpu=%s\n", providerName, cfg.WindowsSandbox.Workdir, run.hostWorkspace, cfg.WindowsSandbox.Networking, cfg.WindowsSandbox.VGPU)
 
 	commandStarted := core.ClockNow(b.rt.Clock)
+	req.Observation.Phase(core.RunPhaseCommand)
+	stdout, stderr := req.Observation.CommandWriters(b.rt.Stdout, b.rt.Stderr, core.RunOutputProvider)
 	execResult, execErr := b.runHostRunner(ctx, LocalCommandRequest{
 		Name:                 "powershell.exe",
 		Args:                 hostRunnerArgs(run, cfg, req),
-		Stdout:               b.rt.Stdout,
-		Stderr:               b.rt.Stderr,
+		Stdout:               stdout,
+		Stderr:               stderr,
 		DisableOutputCapture: true,
 	}, filepath.Join(run.hostControl, "cancel.txt"), req.Keep || req.KeepOnFailure)
 	commandDuration := core.ClockNow(b.rt.Clock).Sub(commandStarted)


### PR DESCRIPTION
## Summary

Add opt-in, coordinator-free local run history for https://github.com/openclaw/crabbox/issues/1515. Thanks @coygeek for the feature request and follow-up requirements.

`run --record-local` or trusted user configuration records a private local run ID, bounded output and selected parsed results. Fresh CLI processes can read `history`, `logs`, and `results` with `--source local` after lease cleanup. Local records are not coordinator attestations; combined history only correlates acknowledged coordinator records against the same endpoint reference.

A single core run observation owns recording, while provider adapters supply command-output writers and truthful output scope. Native wrapper and SSH transport diagnostics remain labeled `provider-run`. Recording stays disabled by default, repository configuration cannot enable it, and final local write failures warn without changing the primary command exit or coordinator receipt. Retention is bounded, with explicit local prune/delete commands. Interrupted initialization remains visibly incomplete without hiding healthy history rows. Documentation and the unreleased changelog are included.

## Verification completed

- Focused Go tests: 71 top-level tests and 111 subtests passed, no skips; affected provider packages compiled.
- CLI build, scoped vet, docs generation, whitespace checks, and Windows core-test cross-compilation passed. Cross-compilation is not Windows runtime proof.
- A timing-fragile agent-sandbox fixture passed 20 normal and 20 race runs after moving its one-millisecond deadline from warmup to the operation under test. Production deadlines are unchanged.
- Managed Codex reviews passed at the requested P0 reporting threshold; this is not an all-priority correctness certificate.
- Actual local Docker/SSH lifecycle: one fresh fixed-ID lease, default-disabled run, recorded exit-23 workload, stdout capture omission, 9 MiB output bounded to an 8 MiB UTF-8 tail, selected JUnit results (2 tests/1 failure, excluding a separate 9-test report), trusted-user enablement and explicit disablement. Supported failure downloads retrieved the marker and both XML files through Crabbox.
- After container and key removal, all five recorded runs were readable through fresh network-denied CLI processes. Private-file bounds, local delete, and missing-record exit 1 were verified. Native prune was a no-op on fresh records; retention eviction is covered separately by deterministic unit tests. Native capture omission covered stdout; stderr omission remains unit/source coverage.

Both native lifecycles were rerun against a fresh build of the current private-at-creation candidate. The final local run completed end to end, verifying its released fixed-ID tombstone and absence of container, key, bootstrap and active claim ownership. An earlier harness incorrectly expected tombstone deletion; that failed result and its corrected offline continuation remain preserved, not substituted for this final run.

Actual Blacksmith Testbox proof also passed: one fresh owned Testbox, ordinary and framed artifact runs, exit 23 preservation, bounded output, trusted-user opt-in and explicit disablement, exact claim/key cleanup, and fresh network-denied history/log/result readers after native completion. The framed run retrieved the synthetic marker and both XML artifacts while correctly reporting delegated parsed JUnit as unsupported. The native workflow was https://github.com/openclaw/crabbox/actions/runs/34693526040.

## CI corrections and verification

Historical CI runs https://github.com/openclaw/crabbox/actions/runs/34691005415 and https://github.com/openclaw/crabbox/actions/runs/34691263118 exposed an unclassified local-only config field, a stale help-output checksum, Windows exclusive-create error mapping, and the warmup timeout fixture. These are corrected in the current head; only the new flag changes the help baseline. The Windows wrapper now maps only the native name collision to the portable file-exists contract, preserving private creation, no-clobber and ACL checks.

A subsequent Windows run, https://github.com/openclaw/crabbox/actions/runs/34692332832, exposed an interruption window between directory creation and applying private ownership. Both creation paths now use a platform-specific private-at-creation helper. Windows supplies the current-user owner and protected ACL to native creation; existing directories are validated without re-owning or changing permissions. Immediate-privacy, duplicate-ID preservation and private incomplete-directory regressions are included.

Current full CI: https://github.com/openclaw/crabbox/actions/runs/34693427980. Both native lifecycle/readback paths have passed. All 12 CI jobs and required companion checks passed. The full Windows job executed the new private-directory/orphan-pruning cases and existing private-output/artifact tests successfully. Blacksmith requested JUnit remains explicitly unsupported by its existing delegated result path, even when XML artifacts are retrieved; no passing parsed result is fabricated.

## Configuration and privacy

No new service credentials or coordinator deployment are needed. Logs are opt-in and are not automatically secret-redacted; users should record only appropriate output. Local files are private and bounded; existing broker/default-disabled behavior is preserved.

## Merged closeout

Merged as https://github.com/openclaw/crabbox/commit/b26f057a6cf26df69d9c92c7769d9da29b58e88a; its tree exactly matches the reviewed and native-tested candidate. Actual-main focused tests, fresh CLI build and vet passed. The fresh main binary matched the native-tested bytes and reread all retained local/Testbox records in network-denied processes without state changes; previously deleted records remained missing.

Post-merge CI https://github.com/openclaw/crabbox/actions/runs/34694758679 passed all 12 jobs, with Connector and CodeQL also green. Actual-main Windows history/private-directory/pruning/private-artifact tests executed successfully; the one Unix-only history test remained intentionally skipped. CI failures were addressed by new commits; no workflow reruns or publication/deployment overrides were used. Test leases were cleaned up. No new release or fleet rollout was performed.
