### PR TITLE
refactor(providers): remove redundant same-origin wrappers

### DIFF
--- a/internal/providers/blaxel/client.go
+++ b/internal/providers/blaxel/client.go
@@ -257,7 +257,7 @@ func secureHTTPClient(source *http.Client) *http.Client {
 		if len(via) >= 10 {
 			return errors.New("stopped after 10 redirects")
 		}
-		if len(via) > 0 && !sameOrigin(via[len(via)-1].URL, req.URL) {
+		if len(via) > 0 && !core.SameHTTPOrigin(via[len(via)-1].URL, req.URL) {
 			return fmt.Errorf("blaxel refused cross-origin redirect to %s://%s", req.URL.Scheme, req.URL.Host)
 		}
 		if originalCheckRedirect != nil {
@@ -266,10 +266,6 @@ func secureHTTPClient(source *http.Client) *http.Client {
 		return nil
 	}
 	return &client
-}
-
-func sameOrigin(a, b *url.URL) bool {
-	return core.SameHTTPOrigin(a, b)
 }
 
 func (c *restClient) BaseURL() string { return c.base }

--- a/internal/providers/unikraftcloud/client.go
+++ b/internal/providers/unikraftcloud/client.go
@@ -206,7 +206,7 @@ func secureUnikraftCloudHTTPClient(source *http.Client, baseURL string) *http.Cl
 	trusted, _ := url.Parse(baseURL)
 	originalCheckRedirect := source.CheckRedirect
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameUnikraftCloudOrigin(trusted, req.URL) {
+		if !core.SameHTTPOrigin(trusted, req.URL) {
 			return &unikraftCloudRedirectError{origin: unikraftCloudRedirectOrigin(req.URL)}
 		}
 		if !withinUnikraftCloudAPIPath(trusted, req.URL) {
@@ -251,10 +251,6 @@ func isUnikraftCloudMutation(method string) bool {
 	default:
 		return false
 	}
-}
-
-func sameUnikraftCloudOrigin(a, b *url.URL) bool {
-	return core.SameHTTPOrigin(a, b)
 }
 
 type unikraftCloudRedirectError struct {


### PR DESCRIPTION
## What Problem This Solves

Blaxel and UnikraftCloud retained redundant same-origin forwarding wrappers, making redirect validation ownership harder to audit consistently.

## Why This Change Was Made

Use the canonical `core.SameHTTPOrigin` helper directly at the existing redirect checks and remove the equivalent provider-local wrappers. Redirect limits, authentication boundaries, path and method checks, argument order, and behavior are unchanged.

## User Impact

No user-visible behavior changes. Same-origin redirect checks now call the canonical core implementation directly.

## Evidence

- `go test -race -count=1 -p=1 -timeout=20m ./internal/providers/blaxel ./internal/providers/unikraftcloud`
- `go test -race -count=1 -p=1 -timeout=20m ./internal/cli -run '^(TestSameHTTPOrigin|TestSameHTTPOriginEdgeCases)$'`
- `go vet ./...`
- `go build -trimpath ./cmd/crabbox`
