### PR TITLE
refactor(semaphore): remove redundant same-origin wrapper

### DIFF
--- a/internal/providers/semaphore/api.go
+++ b/internal/providers/semaphore/api.go
@@ -318,7 +318,7 @@ func (c *apiClient) resolvePaginationRef(ref string) (string, error) {
 	if resolved.User != nil {
 		return "", fmt.Errorf("semaphore pagination link contains userinfo")
 	}
-	if !sameOriginURL(base, resolved) {
+	if !core.SameHTTPOrigin(base, resolved) {
 		return "", fmt.Errorf("semaphore pagination link points outside configured host")
 	}
 	return resolved.RequestURI(), nil
@@ -350,14 +350,10 @@ func (c *apiClient) apiURL(path string) (string, error) {
 	if resolved.User != nil {
 		return "", fmt.Errorf("semaphore request URL contains userinfo")
 	}
-	if !sameOriginURL(base, resolved) {
+	if !core.SameHTTPOrigin(base, resolved) {
 		return "", fmt.Errorf("semaphore request URL points outside configured host")
 	}
 	return resolved.String(), nil
-}
-
-func sameOriginURL(a, b *url.URL) bool {
-	return core.SameHTTPOrigin(a, b)
 }
 
 func (c *apiClient) getWithHeaders(ctx context.Context, path string) ([]byte, http.Header, error) {


### PR DESCRIPTION
## What Problem This Solves

Semaphore retains a forwarding wrapper around the canonical HTTP-origin comparison at its request and pagination validation boundaries.

## Why This Change Was Made

Call `core.SameHTTPOrigin` directly at both existing checks and remove the equivalent provider-local wrapper. URL resolution, argument order, userinfo rejection, credential handling, and pagination behavior are unchanged. The canonical owner moved to core in https://github.com/openclaw/crabbox/pull/2157.

## User Impact

No user-visible behavior changes. Semaphore request and pagination origin checks now call the canonical core implementation directly.

## Evidence

- `go test -race -count=1 -p=1 -timeout=20m ./internal/providers/semaphore`
- `go test -race -count=1 -p=1 -timeout=20m ./internal/cli -run '^(TestSameHTTPOrigin|TestSameHTTPOriginEdgeCases)$'`
- `go vet ./...`
- `go build -trimpath ./cmd/crabbox`
