### PR TITLE
refactor(providers): share claim idle cleanup policy

### DIFF
--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -437,6 +437,12 @@ type CleanupBackend interface {
 }
 ```
 
+Delegated adapters that expire local claims by last activity should use
+`shared.ClaimIdleCleanupDue`. It preserves the shared idle-deadline decision
+and skip reasons, including disabled timeouts and invalid timestamps. Absolute
+TTL rules, recovery deadlines, ownership validation, and deletion authorization
+remain adapter-owned; an idle deadline alone does not authorize cleanup.
+
 Cleanup must honor `CleanupRequest.DryRun`, log every skip/delete decision to
 `rt.Stderr`, and filter by Crabbox labels so it never touches unrelated
 machines. When a broker is configured, core refuses to call provider cleanup at

--- a/internal/providers/agentsandbox/claim.go
+++ b/internal/providers/agentsandbox/claim.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -322,18 +323,7 @@ func claimCleanupDue(claim LeaseClaim, now time.Time) (bool, string) {
 	if claimTTLExpired(claim, now) {
 		return true, "ttl"
 	}
-	if claim.IdleTimeoutSeconds <= 0 {
-		return false, "idle timeout disabled"
-	}
-	lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
-	if err != nil {
-		return false, "invalid last-used time"
-	}
-	deadline := lastUsed.Add(time.Duration(claim.IdleTimeoutSeconds) * time.Second)
-	if now.Before(deadline) {
-		return false, "idle timeout not reached"
-	}
-	return true, "idle timeout"
+	return shared.ClaimIdleCleanupDue(claim, now)
 }
 
 func claimTTLExpired(claim LeaseClaim, now time.Time) bool {

--- a/internal/providers/blaxel/backend.go
+++ b/internal/providers/blaxel/backend.go
@@ -371,7 +371,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			claimsRemoved++
 			continue
 		}
-		due, reason := blaxelClaimCleanupDue(claim, now)
+			due, reason := shared.ClaimIdleCleanupDue(claim, now)
 		if !due {
 			fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
 			continue

--- a/internal/providers/blaxel/backend.go
+++ b/internal/providers/blaxel/backend.go
@@ -371,7 +371,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			claimsRemoved++
 			continue
 		}
-			due, reason := shared.ClaimIdleCleanupDue(claim, now)
+		due, reason := shared.ClaimIdleCleanupDue(claim, now)
 		if !due {
 			fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
 			continue

--- a/internal/providers/blaxel/claims.go
+++ b/internal/providers/blaxel/claims.go
@@ -192,21 +192,6 @@ func validateBlaxelSandboxOwnership(claim LeaseClaim, sb Sandbox) error {
 	return nil
 }
 
-func blaxelClaimCleanupDue(claim LeaseClaim, now time.Time) (bool, string) {
-	if claim.IdleTimeoutSeconds <= 0 {
-		return false, "idle timeout disabled"
-	}
-	lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
-	if err != nil {
-		return false, "invalid last-used time"
-	}
-	deadline := lastUsed.Add(time.Duration(claim.IdleTimeoutSeconds) * time.Second)
-	if now.Before(deadline) {
-		return false, "idle timeout not reached"
-	}
-	return true, "idle timeout"
-}
-
 func timeoutOrDefault(primary, fallback time.Duration) time.Duration {
 	if primary > 0 {
 		return primary

--- a/internal/providers/cloudflaresandbox/backend.go
+++ b/internal/providers/cloudflaresandbox/backend.go
@@ -437,7 +437,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 				return "claim-removed", nil
 			}
-			due, reason := claimCleanupDue(claim, now)
+			due, reason := shared.ClaimIdleCleanupDue(claim, now)
 			if !due {
 				fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
 				return "skip", nil
@@ -703,21 +703,6 @@ func validateSandboxOwnership(claim LeaseClaim, sb sandboxSummary) error {
 		return exit(4, "cloudflare-sandbox sandbox %q ownership metadata does not match its local claim", sb.ID)
 	}
 	return nil
-}
-
-func claimCleanupDue(claim LeaseClaim, now time.Time) (bool, string) {
-	if claim.IdleTimeoutSeconds <= 0 {
-		return false, "idle timeout disabled"
-	}
-	lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
-	if err != nil {
-		return false, "invalid last-used time"
-	}
-	deadline := lastUsed.Add(time.Duration(claim.IdleTimeoutSeconds) * time.Second)
-	if now.Before(deadline) {
-		return false, "idle timeout not reached"
-	}
-	return true, "idle timeout"
 }
 
 func (b *backend) refreshLeaseActivity(leaseID string) error {

--- a/internal/providers/codesandbox/backend.go
+++ b/internal/providers/codesandbox/backend.go
@@ -300,7 +300,7 @@ func (b *codeSandboxBackend) Cleanup(ctx context.Context, req CleanupRequest) er
 			return err
 		}
 		checked++
-		due, reason := claimCleanupDue(claim, now)
+		due, reason := shared.ClaimIdleCleanupDue(claim, now)
 		sandboxID := strings.TrimPrefix(claim.LeaseID, leasePrefix)
 		if !due {
 			fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)

--- a/internal/providers/codesandbox/claims.go
+++ b/internal/providers/codesandbox/claims.go
@@ -246,21 +246,6 @@ func (b *codeSandboxBackend) cleanupCreateFailure(ctx context.Context, api codeS
 	return cause
 }
 
-func claimCleanupDue(claim LeaseClaim, now time.Time) (bool, string) {
-	if claim.IdleTimeoutSeconds <= 0 {
-		return false, "idle timeout disabled"
-	}
-	lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
-	if err != nil {
-		return false, "invalid last-used time"
-	}
-	deadline := lastUsed.Add(time.Duration(claim.IdleTimeoutSeconds) * time.Second)
-	if now.Before(deadline) {
-		return false, "idle timeout not reached"
-	}
-	return true, "idle timeout"
-}
-
 func (b *codeSandboxBackend) execTimeoutSecs() int {
 	return codeSandboxExecTimeout
 }

--- a/internal/providers/opensandbox/backend.go
+++ b/internal/providers/opensandbox/backend.go
@@ -519,7 +519,7 @@ func (b *openSandboxBackend) Cleanup(ctx context.Context, req CleanupRequest) er
 				claimRemovedOne = true
 				return nil
 			}
-			due, reason := openSandboxClaimCleanupDue(claim, now)
+			due, reason := shared.ClaimIdleCleanupDue(claim, now)
 			if !due {
 				fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
 				return nil
@@ -627,21 +627,6 @@ func openSandboxRecoveryExpired(claim LeaseClaim, now time.Time) (bool, error) {
 
 func openSandboxClaimMatchesEndpoint(claim LeaseClaim, baseURL string) bool {
 	return strings.HasPrefix(strings.TrimSpace(claim.ProviderScope), openSandboxEndpointScope(baseURL)+"-own-")
-}
-
-func openSandboxClaimCleanupDue(claim LeaseClaim, now time.Time) (bool, string) {
-	if claim.IdleTimeoutSeconds <= 0 {
-		return false, "idle timeout disabled"
-	}
-	lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
-	if err != nil {
-		return false, "invalid last-used time"
-	}
-	deadline := lastUsed.Add(time.Duration(claim.IdleTimeoutSeconds) * time.Second)
-	if now.Before(deadline) {
-		return false, "idle timeout not reached"
-	}
-	return true, "idle timeout"
 }
 
 func (b *openSandboxBackend) refreshOpenSandboxLeaseActivity(leaseID string) error {

--- a/internal/providers/shared/claim_cleanup.go
+++ b/internal/providers/shared/claim_cleanup.go
@@ -1,0 +1,25 @@
+package shared
+
+import (
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// ClaimIdleCleanupDue evaluates only the local claim's idle deadline. Provider
+// TTL policy, ownership checks, and authorization to delete remain with callers.
+func ClaimIdleCleanupDue(claim core.LeaseClaim, now time.Time) (bool, string) {
+	if claim.IdleTimeoutSeconds <= 0 {
+		return false, "idle timeout disabled"
+	}
+	lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
+	if err != nil {
+		return false, "invalid last-used time"
+	}
+	deadline := lastUsed.Add(time.Duration(claim.IdleTimeoutSeconds) * time.Second)
+	if now.Before(deadline) {
+		return false, "idle timeout not reached"
+	}
+	return true, "idle timeout"
+}

--- a/internal/providers/shared/claim_cleanup_test.go
+++ b/internal/providers/shared/claim_cleanup_test.go
@@ -1,0 +1,38 @@
+package shared
+
+import (
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestClaimIdleCleanupDue(t *testing.T) {
+	now := time.Date(2026, 9, 12, 12, 0, 0, 0, time.UTC)
+	for _, tt := range []struct {
+		name     string
+		lastUsed string
+		idle     int
+		due      bool
+		reason   string
+	}{
+		{"disabled", "invalid", 0, false, "idle timeout disabled"},
+		{"negative", "invalid", -1, false, "idle timeout disabled"},
+		{"missing timestamp", "", 60, false, "invalid last-used time"},
+		{"invalid timestamp", "invalid", 60, false, "invalid last-used time"},
+		{"future activity", "2026-09-12T12:01:00Z", 60, false, "idle timeout not reached"},
+		{"before deadline", "2026-09-12T11:59:00.000000001Z", 60, false, "idle timeout not reached"},
+		{"at deadline", "2026-09-12T11:59:00Z", 60, true, "idle timeout"},
+		{"past deadline", "2026-09-12T11:58:59Z", 60, true, "idle timeout"},
+		{"offset timestamp", "2026-09-12T13:59:00+02:00", 60, true, "idle timeout"},
+		{"trimmed timestamp", " \t2026-09-12T11:59:00Z\n", 60, true, "idle timeout"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			claim := core.LeaseClaim{IdleTimeoutSeconds: tt.idle, LastUsedAt: tt.lastUsed}
+			due, reason := ClaimIdleCleanupDue(claim, now)
+			if due != tt.due || reason != tt.reason {
+				t.Fatalf("got (%v, %q), want (%v, %q)", due, reason, tt.due, tt.reason)
+			}
+		})
+	}
+}

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -434,7 +434,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 				claimRemovedOne = true
 				return nil
 			}
-			due, reason := superserveClaimCleanupDue(claim, now)
+			due, reason := shared.ClaimIdleCleanupDue(claim, now)
 			if !due {
 				fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
 				return nil
@@ -682,21 +682,6 @@ func validateSuperserveSandboxOwnership(claim LeaseClaim, sb superserveSandbox) 
 		return exit(4, "superserve sandbox %q ownership metadata does not match its local claim", sb.ID)
 	}
 	return nil
-}
-
-func superserveClaimCleanupDue(claim LeaseClaim, now time.Time) (bool, string) {
-	if claim.IdleTimeoutSeconds <= 0 {
-		return false, "idle timeout disabled"
-	}
-	lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
-	if err != nil {
-		return false, "invalid last-used time"
-	}
-	deadline := lastUsed.Add(time.Duration(claim.IdleTimeoutSeconds) * time.Second)
-	if now.Before(deadline) {
-		return false, "idle timeout not reached"
-	}
-	return true, "idle timeout"
 }
 
 func (b *backend) refreshSuperserveLeaseActivity(leaseID string) error {

--- a/internal/providers/vercelsandbox/backend.go
+++ b/internal/providers/vercelsandbox/backend.go
@@ -418,7 +418,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 				claimRemovedOne = true
 				return nil
 			}
-			due, reason := claimCleanupDue(claim, now)
+			due, reason := shared.ClaimIdleCleanupDue(claim, now)
 			if !due {
 				fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
 				return nil
@@ -707,21 +707,6 @@ func validateSandboxOwnership(claim LeaseClaim, sb sandboxSummary) error {
 		return exit(4, "vercel-sandbox sandbox %q ownership metadata does not match its local claim", sb.ID)
 	}
 	return nil
-}
-
-func claimCleanupDue(claim LeaseClaim, now time.Time) (bool, string) {
-	if claim.IdleTimeoutSeconds <= 0 {
-		return false, "idle timeout disabled"
-	}
-	lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
-	if err != nil {
-		return false, "invalid last-used time"
-	}
-	deadline := lastUsed.Add(time.Duration(claim.IdleTimeoutSeconds) * time.Second)
-	if now.Before(deadline) {
-		return false, "idle timeout not reached"
-	}
-	return true, "idle timeout"
 }
 
 func (b *backend) refreshLeaseActivity(leaseID string) error {


### PR DESCRIPTION
Seven sandbox adapters independently computed the same idle cleanup deadline from a local lease claim. Centralize that policy in `shared.ClaimIdleCleanupDue` and remove the duplicate implementations.

The helper preserves disabled timeouts, timestamp parsing, exact-deadline behavior, and diagnostic reasons. Agent Sandbox retains its separate absolute-TTL check; provider ownership checks, operation locks, recovery paths, and deletion remain in the adapters. No public behavior, configuration, or credentials change.

Validation: the shared package and all seven affected provider suites pass. Added boundary coverage for disabled timeouts, invalid or missing timestamps, future activity, nanosecond deadline precision, offsets, and whitespace. Autoreview completed with no accepted/actionable findings. Full CI passed, including Go vet/race tests/coverage, Worker checks, docs, scripts, and platform jobs. The initial formatting failure was corrected before the successful CI run.
