### PR TITLE
refactor: centralize shell environment identifier grammar

### DIFF
--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -523,6 +523,11 @@ boundary intact across those flows.
 
 ## Step 7. Use The Runtime
 
+Use `core.ValidShellEnvName` for the portable ASCII environment-name grammar
+and `core.IsShellEnvAssignment` to recognize a leading `NAME=value` argument.
+These helpers do not trim names or validate values. Keep the adapter's policy
+for invalid names, value restrictions, allowlists, quoting, and transport local.
+
 Backends receive a narrow runtime instead of touching package-level state:
 
 ```go

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -1052,7 +1052,7 @@ func appendLocalHydrateSteps(b *strings.Builder, steps []localHydrateStep, ctx l
 			return err
 		}
 		for _, key := range sortedKeys(step.Env) {
-			if !validShellEnvName(key) {
+			if !ValidShellEnvName(key) {
 				return exit(2, "local Actions hydration does not support env name %q", key)
 			}
 			value, err := interpolateLocalActionsValue(stepEnv[key], ctx.Inputs, stepEnv, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
@@ -1881,23 +1881,6 @@ func copyStringMap(values map[string]string) map[string]string {
 		out[key] = value
 	}
 	return out
-}
-
-func validShellEnvName(name string) bool {
-	if name == "" {
-		return false
-	}
-	for i, r := range name {
-		switch {
-		case r == '_':
-		case r >= 'A' && r <= 'Z':
-		case r >= 'a' && r <= 'z':
-		case i > 0 && r >= '0' && r <= '9':
-		default:
-			return false
-		}
-	}
-	return true
 }
 
 func localActionsRuntimeShell() string {

--- a/internal/cli/profiles.go
+++ b/internal/cli/profiles.go
@@ -213,7 +213,7 @@ func isPresetPlaceholderWord(word string) bool {
 
 func validateProfileEnvNames(label string, env map[string]string) error {
 	for key := range env {
-		if !validEnvName(strings.TrimSpace(key)) {
+		if !ValidShellEnvName(strings.TrimSpace(key)) {
 			return exit(2, "%s env key %q is not a valid shell environment name", label, key)
 		}
 	}

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -777,7 +777,7 @@ func allowedEnv(allow []string) map[string]string {
 		if !ok {
 			continue
 		}
-		if !validEnvName(k) {
+		if !ValidShellEnvName(k) {
 			continue
 		}
 		if envAllowed(k, allow) {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -3846,7 +3846,7 @@ func ShouldUseShell(command []string) bool {
 }
 
 func leadingEnvAssignment(command []string) bool {
-	return len(command) > 1 && isShellEnvAssignment(command[0])
+	return len(command) > 1 && IsShellEnvAssignment(command[0])
 }
 
 func LeadingEnvAssignment(command []string) bool {
@@ -3864,7 +3864,7 @@ func shellScriptFromArgvWithLiteralArgs(command []string, literalArgs map[int]bo
 			}
 			continue
 		}
-		if !literalArgs[idx] && !seenCommand && isShellEnvAssignment(word) {
+		if !literalArgs[idx] && !seenCommand && IsShellEnvAssignment(word) {
 			key, value, _ := strings.Cut(word, "=")
 			parts = append(parts, key+"="+shellQuote(value))
 			continue

--- a/internal/cli/run_env_profile.go
+++ b/internal/cli/run_env_profile.go
@@ -31,7 +31,7 @@ func loadEnvProfiles(paths []string) (map[string]string, error) {
 func allowedEnvFromProfiles(allow []string, profileEnv map[string]string) map[string]string {
 	out := allowedEnv(allow)
 	for key, value := range profileEnv {
-		if validEnvName(key) && envAllowed(key, allow) {
+		if ValidShellEnvName(key) && envAllowed(key, allow) {
 			out[key] = value
 		}
 	}
@@ -41,7 +41,7 @@ func allowedEnvFromProfiles(allow []string, profileEnv map[string]string) map[st
 func allowedProfileEnv(allow []string, profileEnv map[string]string) map[string]string {
 	out := map[string]string{}
 	for key, value := range profileEnv {
-		if validEnvName(key) && envAllowed(key, allow) {
+		if ValidShellEnvName(key) && envAllowed(key, allow) {
 			out[key] = value
 		}
 	}
@@ -184,7 +184,7 @@ func parseEnvProfile(data []byte) map[string]string {
 			continue
 		}
 		key = strings.TrimSpace(key)
-		if !validEnvName(key) {
+		if !ValidShellEnvName(key) {
 			continue
 		}
 		value = strings.TrimSpace(value)
@@ -370,7 +370,7 @@ func remoteProbeRunEnvProfileCommand(workdir, remotePath string, names []string)
 	b.WriteString(shellQuote(remotePath))
 	b.WriteByte('\n')
 	for _, name := range names {
-		if !validEnvName(name) {
+		if !ValidShellEnvName(name) {
 			continue
 		}
 		secret := "false"
@@ -452,7 +452,7 @@ func formatShellEnvFile(env map[string]string) string {
 	keys := sortedEnvNames(env)
 	var b strings.Builder
 	for _, key := range keys {
-		if !validEnvName(key) {
+		if !ValidShellEnvName(key) {
 			continue
 		}
 		fmt.Fprintf(&b, "export %s=%s\n", key, shellQuote(env[key]))
@@ -464,7 +464,7 @@ func formatPlainEnvFile(env map[string]string) string {
 	keys := sortedEnvNames(env)
 	var b strings.Builder
 	for _, key := range keys {
-		if !validEnvName(key) {
+		if !ValidShellEnvName(key) {
 			continue
 		}
 		fmt.Fprintf(&b, "%s=%s\n", key, strings.NewReplacer("\r", "", "\n", "").Replace(env[key]))
@@ -497,7 +497,7 @@ Get-Content -Encoding UTF8 -LiteralPath $profilePath | ForEach-Object {
 }
 `
 	for _, name := range names {
-		if !validEnvName(name) {
+		if !ValidShellEnvName(name) {
 			continue
 		}
 		secret := envNameLooksSecret(name)
@@ -561,22 +561,4 @@ func shellDir(path string) string {
 		return path[:idx]
 	}
 	return "."
-}
-
-func validEnvName(name string) bool {
-	if name == "" {
-		return false
-	}
-	for i, r := range name {
-		if i == 0 {
-			if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || r == '_') {
-				return false
-			}
-			continue
-		}
-		if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_') {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/cli/shell_env.go
+++ b/internal/cli/shell_env.go
@@ -1,0 +1,25 @@
+package cli
+
+import "strings"
+
+// ValidShellEnvName accepts portable ASCII shell environment identifiers without
+// trimming. Callers own whether an invalid name is rejected or omitted.
+func ValidShellEnvName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if r == '_' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' || i > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// IsShellEnvAssignment classifies the name before the first '='. Assignment
+// values are shell data and do not participate in identifier validation.
+func IsShellEnvAssignment(word string) bool {
+	name, _, assignment := strings.Cut(word, "=")
+	return assignment && ValidShellEnvName(name)
+}

--- a/internal/cli/shell_env_test.go
+++ b/internal/cli/shell_env_test.go
@@ -1,0 +1,29 @@
+package cli
+
+import "testing"
+
+func TestValidShellEnvName(t *testing.T) {
+	for _, name := range []string{"_", "A", "z", "_OK_1", "PATH", "lower_case9"} {
+		if !ValidShellEnvName(name) {
+			t.Errorf("rejected portable environment name %q", name)
+		}
+	}
+	for _, name := range []string{"", "9", "1_BAD", "BAD.NAME", "BAD-NAME", "A=B", " A", "A ", "A\n", "A\r", "A\x00", "é", "Aé", "A\xff", "A;echo"} {
+		if ValidShellEnvName(name) {
+			t.Errorf("accepted invalid environment name %q", name)
+		}
+	}
+}
+
+func TestIsShellEnvAssignment(t *testing.T) {
+	for _, word := range []string{"A=", "_OK_1=value", "A=a=b", "A= spaces \n é", "A=$(echo value)"} {
+		if !IsShellEnvAssignment(word) {
+			t.Errorf("rejected assignment %q", word)
+		}
+	}
+	for _, word := range []string{"", "A", "=value", "1_BAD=value", "A B=value", "A\n=value", "é=value", "A\xff=value"} {
+		if IsShellEnvAssignment(word) {
+			t.Errorf("accepted non-assignment %q", word)
+		}
+	}
+}

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -202,7 +202,7 @@ func applyTargetChildEnvironment(cmd *exec.Cmd, target SSHTarget) {
 	}
 	overrideNames := make([]string, 0, len(target.ChildEnv))
 	for name := range target.ChildEnv {
-		if validEnvName(name) {
+		if ValidShellEnvName(name) {
 			overrideNames = append(overrideNames, name)
 		}
 	}
@@ -1889,7 +1889,7 @@ func shellScriptFromArgv(command []string) string {
 			}
 			continue
 		}
-		if !seenCommand && isShellEnvAssignment(word) {
+		if !seenCommand && IsShellEnvAssignment(word) {
 			key, value, _ := strings.Cut(word, "=")
 			parts = append(parts, key+"="+shellQuote(value))
 			continue
@@ -1902,28 +1902,6 @@ func shellScriptFromArgv(command []string) string {
 
 func ShellScriptFromArgv(command []string) string {
 	return shellScriptFromArgv(command)
-}
-
-func isShellEnvAssignment(word string) bool {
-	if word == "" {
-		return false
-	}
-	idx := strings.IndexByte(word, '=')
-	if idx <= 0 {
-		return false
-	}
-	for i, r := range word[:idx] {
-		if i == 0 {
-			if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || r == '_') {
-				return false
-			}
-			continue
-		}
-		if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_') {
-			return false
-		}
-	}
-	return true
 }
 
 func isShellControlOperator(word string) bool {
@@ -1960,7 +1938,7 @@ func writeRemoteCommandPrefix(b *strings.Builder, workdir string, env map[string
 		b.WriteString("; fi && ")
 	}
 	for k, v := range env {
-		if !validEnvName(k) {
+		if !ValidShellEnvName(k) {
 			continue
 		}
 		b.WriteString(k)

--- a/internal/cli/sync_windows_target.go
+++ b/internal/cli/sync_windows_target.go
@@ -444,7 +444,7 @@ if (-not [string]::IsNullOrWhiteSpace($env:RUNNER_TOOL_CACHE)) {
 `)
 	}
 	for key, value := range env {
-		if !validEnvName(key) {
+		if !ValidShellEnvName(key) {
 			continue
 		}
 		b.WriteString(`$env:` + key + ` = ` + psQuote(value) + "\n")

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -1893,7 +1893,7 @@ func webVNCDaemonLogHasReady(path string) bool {
 
 func webVNCDaemonCredentialName(args []string) string {
 	credentialName := webVNCDaemonStringArg(args, "external-desktop-password-env")
-	if !validEnvName(credentialName) || normalizeTargetOS(webVNCDaemonStringArg(args, "target")) != targetMacOS {
+	if !ValidShellEnvName(credentialName) || normalizeTargetOS(webVNCDaemonStringArg(args, "target")) != targetMacOS {
 		return ""
 	}
 	return credentialName
@@ -2580,7 +2580,7 @@ func readableShellCommand(words []string) string {
 	out := make([]string, 0, len(words))
 	seenCommand := false
 	for _, word := range words {
-		if !seenCommand && isShellEnvAssignment(word) {
+		if !seenCommand && IsShellEnvAssignment(word) {
 			key, value, _ := strings.Cut(word, "=")
 			out = append(out, key+"="+shellQuote(value))
 			continue

--- a/internal/providers/blacksmith/helpers.go
+++ b/internal/providers/blacksmith/helpers.go
@@ -226,7 +226,7 @@ func blacksmithCommandString(command []string, shellMode bool) string {
 	parts := make([]string, 0, len(command))
 	seenCommand := false
 	for _, word := range command {
-		if !seenCommand && isShellEnvAssignment(word) {
+		if !seenCommand && core.IsShellEnvAssignment(word) {
 			key, value, _ := strings.Cut(word, "=")
 			parts = append(parts, key+"="+shellQuote(value))
 			continue
@@ -239,28 +239,6 @@ func blacksmithCommandString(command []string, shellMode bool) string {
 
 func trimBlacksmithShellCommand(command string) string {
 	return strings.TrimRight(command, " \t\r\n")
-}
-
-func isShellEnvAssignment(word string) bool {
-	if word == "" {
-		return false
-	}
-	idx := strings.IndexByte(word, '=')
-	if idx <= 0 {
-		return false
-	}
-	for i, r := range word[:idx] {
-		if i == 0 {
-			if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || r == '_') {
-				return false
-			}
-			continue
-		}
-		if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_') {
-			return false
-		}
-	}
-	return true
 }
 
 func exit(code int, format string, args ...any) core.ExitError {

--- a/internal/providers/cloudrunsandbox/client.go
+++ b/internal/providers/cloudrunsandbox/client.go
@@ -51,8 +51,6 @@ type execOptions struct {
 var errSandboxNotFound = errors.New("cloud-run-sandbox sandbox not found")
 var errSandboxAlreadyExists = errors.New("cloud-run-sandbox sandbox already exists")
 
-var envNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
-
 var newTransport = func(cfg Config, rt Runtime) (sandboxTransport, error) {
 	// GatewayURL is deliberately absent from fileCloudRunSandboxConfig. Only an
 	// operator-supplied flag or environment value can select the origin that
@@ -126,7 +124,7 @@ func validateSandboxID(id string) error {
 
 func validateEnv(env map[string]string) error {
 	for key := range env {
-		if !envNamePattern.MatchString(key) {
+		if !core.ValidShellEnvName(key) {
 			return exit(2, "invalid environment variable name %q", key)
 		}
 	}

--- a/internal/providers/dockersandbox/backend.go
+++ b/internal/providers/dockersandbox/backend.go
@@ -732,7 +732,7 @@ func writeDockerSandboxEnvFile(env map[string]string) (string, func(), error) {
 func formatDockerSandboxEnvFile(env map[string]string) (string, error) {
 	keys := make([]string, 0, len(env))
 	for key := range env {
-		if !validDockerSandboxEnvName(key) {
+		if !core.ValidShellEnvName(key) {
 			return "", exit(2, "docker-sandbox env name %q is not a valid shell environment name", key)
 		}
 		keys = append(keys, key)
@@ -747,17 +747,4 @@ func formatDockerSandboxEnvFile(env map[string]string) (string, error) {
 		fmt.Fprintf(&b, "%s=%s\n", key, value)
 	}
 	return b.String(), nil
-}
-
-func validDockerSandboxEnvName(name string) bool {
-	if name == "" {
-		return false
-	}
-	for i, r := range name {
-		if r == '_' || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (i > 0 && r >= '0' && r <= '9') {
-			continue
-		}
-		return false
-	}
-	return true
 }

--- a/internal/providers/dockersandbox/backend_test.go
+++ b/internal/providers/dockersandbox/backend_test.go
@@ -697,9 +697,6 @@ func TestFormatDockerSandboxEnvFile(t *testing.T) {
 	if _, err := formatDockerSandboxEnvFile(map[string]string{"SECRET_TOKEN": "carriage\rreturn"}); err == nil || !strings.Contains(err.Error(), "newlines") {
 		t.Fatalf("carriage return err=%v", err)
 	}
-	if !validDockerSandboxEnvName("_OK_1") || validDockerSandboxEnvName("1_BAD") || validDockerSandboxEnvName("BAD.NAME") || validDockerSandboxEnvName("") {
-		t.Fatal("validDockerSandboxEnvName accepted or rejected the wrong names")
-	}
 }
 
 func TestWriteDockerSandboxEnvFileCreatesAndCleansUpFile(t *testing.T) {

--- a/internal/providers/freestyle/backend.go
+++ b/internal/providers/freestyle/backend.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -342,7 +341,7 @@ func freestyleEnvExportCommand(env map[string]string) string {
 	}
 	keys := make([]string, 0, len(env))
 	for name := range env {
-		if validFreestyleEnvName(name) {
+		if core.ValidShellEnvName(name) {
 			keys = append(keys, name)
 		}
 	}
@@ -359,12 +358,6 @@ func freestyleEnvExportCommand(env map[string]string) string {
 		b.WriteString(shellQuote(env[name]))
 	}
 	return b.String()
-}
-
-var freestyleEnvNameRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
-
-func validFreestyleEnvName(name string) bool {
-	return freestyleEnvNameRE.MatchString(name)
 }
 
 func freestyleExecCommand(command []string, shellMode bool) string {

--- a/internal/providers/shared/shell_env_profile.go
+++ b/internal/providers/shared/shell_env_profile.go
@@ -78,14 +78,7 @@ func (p *PreparedShellEnvProfile) Close(ctx context.Context, remove func(context
 func sortedShellEnvNames(env map[string]string) []string {
 	keys := make([]string, 0, len(env))
 	for key := range env {
-		valid := key != ""
-		for i, r := range key {
-			if !(r == '_' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' || i > 0 && r >= '0' && r <= '9') {
-				valid = false
-				break
-			}
-		}
-		if valid {
+		if core.ValidShellEnvName(key) {
 			keys = append(keys, key)
 		}
 	}

--- a/internal/providers/windowssandbox/backend.go
+++ b/internal/providers/windowssandbox/backend.go
@@ -604,7 +604,7 @@ func powershellEnvLines(env map[string]string) (string, error) {
 	}
 	keys := make([]string, 0, len(env))
 	for key := range env {
-		if !validEnvName(key) {
+		if !core.ValidShellEnvName(key) {
 			return "", exit(2, "invalid environment variable name %q for provider=%s", key, providerName)
 		}
 		keys = append(keys, key)
@@ -886,19 +886,6 @@ func psBool(value bool) string {
 		return "$true"
 	}
 	return "$false"
-}
-
-func validEnvName(name string) bool {
-	if name == "" {
-		return false
-	}
-	for i, r := range name {
-		ok := r == '_' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' || i > 0 && r >= '0' && r <= '9'
-		if !ok {
-			return false
-		}
-	}
-	return true
 }
 
 func windowsSandboxCommandText(req RunRequest) string {


### PR DESCRIPTION
Environment names and leading shell assignments were recognized by several separate loops and regular expressions across CLI execution, Actions hydration, and sandbox adapters. Give the portable ASCII identifier grammar one owner in `internal/cli/shell_env.go`.

All consumers use `ValidShellEnvName` and `IsShellEnvAssignment`. Names are not trimmed; assignment values are not reinterpreted. Each caller retains its existing allowlist, invalid-name rejection or omission, value restrictions, quoting, and transport. The Docker Sandbox transport test remains while generic grammar cases move to the core contract tests. No public behavior or configuration changes.

Validation: the focused CLI environment, shell, command-intent, Actions, and profile tests pass (189 seconds). Full shared, Blacksmith, Cloud Run Sandbox, Docker Sandbox, Freestyle, and Windows Sandbox suites pass. Added grammar boundaries covering whitespace, Unicode, invalid UTF-8, separators, empty values, and values containing equals signs or shell source. Autoreview completed with no accepted/actionable findings.
