### PR TITLE
refactor(worker): share bounded coordinator storage scans

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -189,6 +189,13 @@ global nor persisted, and do not fall back to expired credentials.
 
 Runtime-specific persistence and scheduling stay behind `CoordinatorRuntime`:
 
+Fleet, host-reservation, and checkpoint scans share the ordered, bounded
+`coordinatorStorageEntries` iterator in `worker/src/storage-scan.ts`. It fetches
+the next page only after the current page is consumed. Callers retain their
+page sizes, cache policy, transaction scope, and early-exit conditions;
+checkpoint claim expiry still applies each transition sequentially. Destructive
+first-page draining and maintenance with persisted cursors remain separate.
+
 | Runtime    | Durable state               | Scheduling                                     | WebSockets                               |
 | ---------- | --------------------------- | ---------------------------------------------- | ---------------------------------------- |
 | Cloudflare | Durable Object storage      | DO alarms plus scheduled Worker reconciliation | Hibernating WebSockets                   |

--- a/worker/src/checkpoints.ts
+++ b/worker/src/checkpoints.ts
@@ -1,6 +1,7 @@
 import { sha256Hex } from "./auth";
 import type { CoordinatorStorage, CoordinatorStorageView } from "./coordinator-runtime";
 import { orgMatchesForAccounting, sameOrgIdentityKey } from "./org-identity";
+import { coordinatorStorageEntries } from "./storage-scan";
 import type {
   CoordinatorCheckpointCreateClaim,
   CoordinatorCheckpointDeleteClaim,
@@ -443,20 +444,12 @@ async function scanCheckpointRecords(
   batchSize: number,
   visit: (record: CoordinatorCheckpointRecord) => boolean,
 ): Promise<void> {
-  const scan = async (startAfter?: string): Promise<void> => {
-    const records = await transaction.list<CoordinatorCheckpointRecord>({
-      prefix: "checkpoint:",
-      limit: batchSize,
-      ...(startAfter ? { startAfter } : {}),
-    });
-    let lastKey: string | undefined;
-    for (const [key, record] of records) {
-      if (visit(record)) return;
-      lastKey = key;
-    }
-    if (records.size === batchSize && lastKey) await scan(lastKey);
-  };
-  await scan();
+  for await (const [, record] of coordinatorStorageEntries<CoordinatorCheckpointRecord>(
+    transaction,
+    { prefix: "checkpoint:", limit: batchSize },
+  )) {
+    if (visit(record)) return;
+  }
 }
 
 export async function backfillFailedCheckpointCreateRecovery(
@@ -1146,31 +1139,22 @@ async function expireAvailableCheckpointClaims(
   limits: CheckpointLimits,
 ): Promise<CoordinatorCheckpointRecord> {
   const batchSize = Math.min(limits.useClaimsPerCheckpoint, limits.useClaimsTotal);
-  const expirePage = async (
-    current: CoordinatorCheckpointRecord,
-    startAfter?: string,
-  ): Promise<CoordinatorCheckpointRecord> => {
-    const claims = await transaction.list<CoordinatorCheckpointUseClaim>({
-      prefix: `checkpoint-use:${checkpoint.id}:`,
-      limit: batchSize,
-      ...(startAfter ? { startAfter } : {}),
-    });
-    const updated = await [...claims].reduce(async (pending, [key, claim]) => {
-      const record = await pending;
-      if (claim.state === "provisioning" || Date.parse(claim.expiresAt) > now) return record;
-      await transaction.delete(key);
-      return await writeCheckpointTransition(
-        transaction,
-        record,
-        { ...record, activeUseCount: Math.max(0, record.activeUseCount - 1) },
-        "checkpoint.use.expired",
-        "system",
-      );
-    }, Promise.resolve(current));
-    const lastKey = [...claims.keys()].at(-1);
-    return claims.size === batchSize && lastKey ? await expirePage(updated, lastKey) : updated;
-  };
-  return await expirePage(checkpoint);
+  let current = checkpoint;
+  for await (const [key, claim] of coordinatorStorageEntries<CoordinatorCheckpointUseClaim>(
+    transaction,
+    { prefix: `checkpoint-use:${checkpoint.id}:`, limit: batchSize },
+  )) {
+    if (claim.state === "provisioning" || Date.parse(claim.expiresAt) > now) continue;
+    await transaction.delete(key);
+    current = await writeCheckpointTransition(
+      transaction,
+      current,
+      { ...current, activeUseCount: Math.max(0, current.activeUseCount - 1) },
+      "checkpoint.use.expired",
+      "system",
+    );
+  }
+  return current;
 }
 
 async function validatedUseClaim(

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -31,6 +31,7 @@ import {
   provisioningMaterialKey,
   sealProvisioningMaterial,
 } from "./provisioning-material";
+import { coordinatorStorageEntries } from "./storage-scan";
 
 const { Client: SSHClientConstructor, utils: sshUtils } = ssh2;
 
@@ -18209,32 +18210,13 @@ export class FleetCoordinator {
     prefix: string,
     visitor: (record: T, key: string) => Promise<boolean | void> | boolean | void,
   ): Promise<void> {
-    let startAfter: string | undefined;
-    for (;;) {
-      // oxlint-disable-next-line eslint/no-await-in-loop -- each bounded page starts after the previous page.
-      const page = await this.state.storage.list<T>({
-        prefix,
-        limit: storageRecordScanBatchSize,
-        noCache: true,
-        ...(startAfter ? { startAfter } : {}),
-      });
-      if (page.size === 0) {
-        break;
-      }
-      for (const [key, record] of page) {
-        // oxlint-disable-next-line eslint/no-await-in-loop -- sequential visits bound legacy record hydration.
-        const shouldContinue = await visitor(record, key);
-        if (shouldContinue === false) {
-          return;
-        }
-      }
-      const nextStartAfter = [...page.keys()].at(-1);
-      if (!nextStartAfter || nextStartAfter === startAfter) {
-        throw new Error(`${prefix} record scan did not advance`);
-      }
-      startAfter = nextStartAfter;
-      if (page.size < storageRecordScanBatchSize) {
-        break;
+    for await (const [key, record] of coordinatorStorageEntries<T>(this.state.storage, {
+      prefix,
+      limit: storageRecordScanBatchSize,
+      noCache: true,
+    })) {
+      if ((await visitor(record, key)) === false) {
+        return;
       }
     }
   }

--- a/worker/src/host-reservations.ts
+++ b/worker/src/host-reservations.ts
@@ -1,6 +1,7 @@
 import type { CoordinatorStorageView } from "./coordinator-runtime";
 import { leaseProviderCleanupConfirmed } from "./lease-cleanup";
 import { publicLeaseRecord } from "./org-records";
+import { coordinatorStorageEntries } from "./storage-scan";
 import type { LeaseRecord, Provider } from "./types";
 
 export interface HostScope {
@@ -57,30 +58,20 @@ export async function readHostReservations(
 ): Promise<HostReservation[]> {
   const reservations: HostReservation[] = [];
   for (const prefix of ["lease:", "provider-access:"]) {
-    let startAfter: string | undefined;
-    for (;;) {
-      // oxlint-disable-next-line eslint/no-await-in-loop -- bounded pages must advance in key order.
-      const page = await storage.list<LeaseRecord>({
-        prefix,
-        limit: 256,
-        noCache: true,
-        ...(startAfter ? { startAfter } : {}),
+    // oxlint-disable-next-line eslint/no-await-in-loop -- finish one association namespace before reading the next.
+    for await (const [storageKey, record] of coordinatorStorageEntries<LeaseRecord>(storage, {
+      prefix,
+      limit: 256,
+      noCache: true,
+    })) {
+      if (!matchesHost(record, scope)) continue;
+      const lease = await storage.get<LeaseRecord>(`lease:${record.id}`, { noCache: true });
+      reservations.push({
+        storageKey,
+        record,
+        ...(lease ? { lease } : {}),
+        staleReason: hostReservationStaleReason(lease, scope),
       });
-      for (const [storageKey, record] of page) {
-        if (!matchesHost(record, scope)) continue;
-        // oxlint-disable-next-line eslint/no-await-in-loop -- resolve only matching host associations.
-        const lease = await storage.get<LeaseRecord>(`lease:${record.id}`, { noCache: true });
-        reservations.push({
-          storageKey,
-          record,
-          ...(lease ? { lease } : {}),
-          staleReason: hostReservationStaleReason(lease, scope),
-        });
-      }
-      if (page.size < 256) break;
-      const next = [...page.keys()].at(-1);
-      if (!next || next === startAfter) throw new Error("host reservation scan did not advance");
-      startAfter = next;
     }
   }
   return reservations;

--- a/worker/src/storage-scan.ts
+++ b/worker/src/storage-scan.ts
@@ -1,0 +1,25 @@
+import type { CoordinatorStorageView } from "./coordinator-runtime";
+
+// Read ordered, bounded pages lazily. Callers own transactions, record policy,
+// and early termination; a consumer that stops never fetches another page.
+export async function* coordinatorStorageEntries<T>(
+  storage: Pick<CoordinatorStorageView, "list">,
+  options: { prefix: string; limit: number; noCache?: boolean },
+): AsyncGenerator<[string, T]> {
+  let startAfter: string | undefined;
+  for (;;) {
+    // oxlint-disable-next-line eslint/no-await-in-loop -- each page follows the previous page's final key.
+    const page = await storage.list<T>({
+      ...options,
+      ...(startAfter ? { startAfter } : {}),
+    });
+    if (page.size === 0) return;
+    yield* page;
+    const next = [...page.keys()].at(-1);
+    if (!next || next === startAfter) {
+      throw new Error(`${options.prefix} record scan did not advance`);
+    }
+    startAfter = next;
+    if (page.size < options.limit) return;
+  }
+}

--- a/worker/test/storage-scan.test.ts
+++ b/worker/test/storage-scan.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { coordinatorStorageEntries } from "../src/storage-scan";
+import { ProvisioningTestStorage } from "./provisioning-fixtures";
+
+function records(count: number): ProvisioningTestStorage {
+  const storage = new ProvisioningTestStorage();
+  for (let index = 0; index < count; index++) storage.values.set(`record:${index}`, index);
+  storage.values.set("unrelated:0", "untouched");
+  return storage;
+}
+
+async function collect(storage: ProvisioningTestStorage): Promise<number[]> {
+  const values: number[] = [];
+  for await (const [, value] of coordinatorStorageEntries<number>(storage, {
+    prefix: "record:",
+    limit: 2,
+    noCache: true,
+  })) {
+    values.push(value);
+  }
+  return values;
+}
+
+describe("coordinator storage scans", () => {
+  it("preserves key order, bounds, and cache policy across partial pages", async () => {
+    const storage = records(5);
+    expect(await collect(storage)).toEqual([0, 1, 2, 3, 4]);
+    expect(storage.listOptions).toEqual([
+      { prefix: "record:", limit: 2, noCache: true },
+      { prefix: "record:", limit: 2, noCache: true, startAfter: "record:1" },
+      { prefix: "record:", limit: 2, noCache: true, startAfter: "record:3" },
+    ]);
+  });
+
+  it("terminates an empty scan and checks the page after an exact multiple", async () => {
+    const empty = records(0);
+    expect(await collect(empty)).toEqual([]);
+    expect(empty.listOptions).toHaveLength(1);
+    const exact = records(4);
+    expect(await collect(exact)).toEqual([0, 1, 2, 3]);
+    expect(exact.listOptions).toHaveLength(3);
+  });
+
+  it("does not prefetch when the consumer stops at a page boundary", async () => {
+    const storage = records(5);
+    const seen: number[] = [];
+    for await (const [, value] of coordinatorStorageEntries<number>(storage, {
+      prefix: "record:",
+      limit: 2,
+    })) {
+      seen.push(value);
+      if (seen.length === 2) break;
+    }
+    expect(seen).toEqual([0, 1]);
+    expect(storage.listOptions).toEqual([{ prefix: "record:", limit: 2 }]);
+  });
+
+  it("continues after deleted keys within the caller's transaction", async () => {
+    const storage = records(5);
+    await storage.transaction(async (transaction) => {
+      for await (const [key] of coordinatorStorageEntries(transaction, {
+        prefix: "record:",
+        limit: 2,
+      })) {
+        await transaction.delete(key);
+      }
+    });
+    expect([...storage.values]).toEqual([["unrelated:0", "untouched"]]);
+    expect(storage.listOptions).toHaveLength(3);
+  });
+
+  it("does not publish transaction mutations when the consumer fails", async () => {
+    const storage = records(2);
+    const failure = new Error("consumer failed");
+    await expect(
+      storage.transaction(async (transaction) => {
+        for await (const [key] of coordinatorStorageEntries(transaction, {
+          prefix: "record:",
+          limit: 2,
+        })) {
+          await transaction.delete(key);
+          throw failure;
+        }
+      }),
+    ).rejects.toBe(failure);
+    expect([...storage.values.keys()]).toEqual(["record:0", "record:1", "unrelated:0"]);
+  });
+
+  it("rejects a backing store that repeats a full page", async () => {
+    const storage = records(1);
+    const list = vi.spyOn(storage, "list").mockResolvedValue(
+      new Map([
+        ["record:0", 0],
+        ["record:1", 1],
+      ]),
+    );
+    await expect(collect(storage)).rejects.toThrow("record: record scan did not advance");
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves storage read failures", async () => {
+    const storage = records(1);
+    const failure = new Error("read failed");
+    vi.spyOn(storage, "list").mockRejectedValue(failure);
+    await expect(collect(storage)).rejects.toBe(failure);
+  });
+});


### PR DESCRIPTION
Fleet maintenance, host reservations, checkpoint inventory, and checkpoint-use expiry independently implemented ordered storage pagination. Share that traversal through a lazy `coordinatorStorageEntries` iterator and replace recursive checkpoint expiry with sequential transitions over it.

Callers retain page sizes, cache policy, transaction boundaries, and early-stop rules. The iterator never prefetches after a consumer stops, retains key-based progress when visited rows are deleted, and rejects a storage backend that repeats its cursor. First-page deletion drains and persisted maintenance cursors keep their separate contracts. No schema or configuration change.

Validation: all 3,155 Worker tests pass (15 existing skips), including 354 targeted scan/checkpoint/runtime tests. The new scan tests cover partial and exact page boundaries, early exit, deletion during traversal, transaction rollback, read errors, and stalled cursors. Worker and Node typechecks/builds, formatting, lint, and Autoreview pass.
