### PR TITLE
refactor(cli): reuse canonical lease interpretation helpers

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -3406,19 +3406,6 @@ func pathWithinRoot(path, root string) bool {
 	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
 }
 
-func inlineSSHPublicKey(value string) bool {
-	fields := strings.Fields(value)
-	if len(fields) < 2 {
-		return false
-	}
-	switch fields[0] {
-	case "ssh-ed25519", "ssh-rsa", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp521", "sk-ssh-ed25519@openssh.com", "sk-ecdsa-sha2-nistp256@openssh.com":
-		return true
-	default:
-		return false
-	}
-}
-
 func applyFileConfigWithTrust(cfg *Config, file fileConfig, trusted bool) error {
 	source := providerSelectionRepoConfig
 	if trusted {

--- a/internal/cli/config_kubevirt.go
+++ b/internal/cli/config_kubevirt.go
@@ -49,7 +49,7 @@ func applyKubeVirtFileConfig(cfg *Config, file *fileKubeVirtConfig, trusted bool
 		return nil
 	}
 	snapshot := *file
-	if snapshot.SSHPublicKey != "" && !(trusted || inlineSSHPublicKey(snapshot.SSHPublicKey)) {
+	if snapshot.SSHPublicKey != "" && !(trusted || LooksLikeInlineSSHPublicKey(snapshot.SSHPublicKey)) {
 		snapshot.SSHPublicKey = ""
 	}
 	applied, err := cfg.KubeVirt.applyFile(&snapshot, trusted)

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -1037,7 +1037,7 @@ func (a App) webVNCStatusCommand(ctx context.Context, args []string) error {
 	if err := validateWebVNCResolvedProviderIdentity(cfg, server, target, leaseID, expectedIdentity); err != nil {
 		return err
 	}
-	commandCfg := resolvedWebVNCCommandConfig(cfg, server, target)
+	commandCfg := desktopConfigForResolvedLease(cfg, server, target)
 	if err := enforceManagedLeaseCapabilities(cfg, server, leaseID); err != nil {
 		return err
 	}
@@ -1181,7 +1181,7 @@ func (a App) webVNCResetCommand(ctx context.Context, args []string) error {
 	if err := enforceManagedLeaseCapabilities(cfg, server, leaseID); err != nil {
 		return err
 	}
-	commandCfg := resolvedWebVNCCommandConfig(cfg, server, target)
+	commandCfg := desktopConfigForResolvedLease(cfg, server, target)
 	// Resolve credentials before any portal, daemon, or remote reset mutation.
 	// A missing External desktop secret must not tear down a working bridge.
 	resetEndpoint := vncEndpoint{Managed: true}
@@ -2537,19 +2537,6 @@ func nativeVNCOpenCommand(cfg Config, target SSHTarget, leaseID string) string {
 	routing := leaseCommandRouting(cfg, target, leaseID, CommandRoutingReconnect)
 	args := append(append([]string{"crabbox", "vnc"}, routing.Args...), "--open")
 	return routing.ShellCommand(args)
-}
-
-func resolvedWebVNCCommandConfig(cfg Config, server Server, target SSHTarget) Config {
-	if provider := strings.TrimSpace(server.Provider); provider != "" {
-		cfg.Provider = provider
-	}
-	if targetOS := strings.TrimSpace(target.TargetOS); targetOS != "" {
-		cfg.TargetOS = targetOS
-	}
-	if windowsMode := strings.TrimSpace(target.WindowsMode); windowsMode != "" {
-		cfg.WindowsMode = windowsMode
-	}
-	return cfg
 }
 
 func stripLegacyWebVNCDaemonFlags(args []string) []string {

--- a/internal/cli/webvnc_test.go
+++ b/internal/cli/webvnc_test.go
@@ -2440,7 +2440,7 @@ func TestNativeVNCFallbackCommandCarriesNetworkOverride(t *testing.T) {
 }
 
 func TestResolvedWebVNCCommandConfigPrefersResolvedLeaseProvider(t *testing.T) {
-	cfg := resolvedWebVNCCommandConfig(
+	cfg := desktopConfigForResolvedLease(
 		Config{Provider: "azure", TargetOS: targetLinux},
 		Server{Provider: "aws"},
 		SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2},
@@ -2458,7 +2458,7 @@ func TestResolvedWebVNCCommandConfigPrefersResolvedLeaseProvider(t *testing.T) {
 		t.Fatalf("bridge args=%q", bridge)
 	}
 
-	legacyMac := resolvedWebVNCCommandConfig(Config{Provider: "external"}, Server{Provider: "static"}, SSHTarget{TargetOS: targetMacOS})
+	legacyMac := desktopConfigForResolvedLease(Config{Provider: "external"}, Server{Provider: "static"}, SSHTarget{TargetOS: targetMacOS})
 	username, password := webVNCPortalCredentialsForDaemon(
 		legacyMac.Provider,
 		SSHTarget{TargetOS: targetMacOS},
@@ -2470,7 +2470,7 @@ func TestResolvedWebVNCCommandConfigPrefersResolvedLeaseProvider(t *testing.T) {
 	if username != "screen-user" || password != "screen-secret" {
 		t.Fatalf("persisted static provider lost legacy portal credentials=(%q,%q)", username, password)
 	}
-	externalMac := resolvedWebVNCCommandConfig(Config{Provider: "static"}, Server{Provider: "external"}, SSHTarget{TargetOS: targetMacOS})
+	externalMac := desktopConfigForResolvedLease(Config{Provider: "static"}, Server{Provider: "external"}, SSHTarget{TargetOS: targetMacOS})
 	username, password = webVNCPortalCredentialsForDaemon(
 		externalMac.Provider,
 		SSHTarget{TargetOS: targetMacOS},


### PR DESCRIPTION
Remove two independently maintained copies of existing CLI lease interpretation rules. WebVNC now uses the same resolved provider/OS configuration helper as native VNC and macOS credential selection, and KubeVirt's repository configuration gate uses the existing OpenSSH public-key shape predicate.

Provider alias handling, Windows mode, credential routing, supported key types, and the distinction between inline keys and local key paths remain unchanged. These are internal helper consolidations with no public behavior or configuration change.

Validation: focused KubeVirt config/trust, public-key, native VNC fallback, WebVNC routing, and macOS credential-selection tests pass. Autoreview completed with no accepted/actionable findings.
