### PR TITLE
refactor(worker): separate byte encoding from authentication

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -187,6 +187,11 @@ later request can retry. Token acquisition, refresh margins, expiry calculation,
 and metadata-server trust/retry rules remain adapter-owned. Caches are neither
 global nor persisted, and do not fall back to expired credentials.
 
+Binary hex/base64 encoding and SHA-256 formatting live in `worker/src/encoding.ts`,
+independent of authentication. Text digests use UTF-8; binary digests preserve
+the supplied view and byte offsets. Token formats, validation, signing, and
+encryption key derivation remain with the protocols that own them.
+
 Runtime-specific persistence and scheduling stay behind `CoordinatorRuntime`:
 
 | Runtime    | Durable state               | Scheduling                                     | WebSockets                               |

--- a/worker/src/artifacts.ts
+++ b/worker/src/artifacts.ts
@@ -1,6 +1,6 @@
 import { AwsClient } from "aws4fetch";
 
-import { base64URL } from "./auth";
+import { base64URL } from "./encoding";
 import type { Env } from "./types";
 
 export interface ArtifactUploadRequest {

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -1,3 +1,4 @@
+import { base64URL, base64URLDecode, sha256Hex } from "./encoding";
 import {
   GitHubCredentialError,
   githubAccountID,
@@ -929,11 +930,6 @@ async function userTokenCredentialKey(secret: string): Promise<CryptoKey> {
   return crypto.subtle.importKey("raw", material, "AES-GCM", false, ["encrypt", "decrypt"]);
 }
 
-export async function sha256Hex(value: string): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(value));
-  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
-}
-
 export async function adminGrantVersion(
   env: Pick<Env, "CRABBOX_ADMIN_TOKEN" | "CRABBOX_GITHUB_ADMIN_OWNERS">,
 ): Promise<string> {
@@ -944,25 +940,4 @@ export async function adminGrantVersion(
       owners: [...new Set(envList(env.CRABBOX_GITHUB_ADMIN_OWNERS))].toSorted(),
     }),
   );
-}
-
-export function base64URL(data: Uint8Array): string {
-  let binary = "";
-  for (const byte of data) {
-    binary += String.fromCharCode(byte);
-  }
-  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
-}
-
-function base64URLDecode(value: string): Uint8Array {
-  const padded = value
-    .replaceAll("-", "+")
-    .replaceAll("_", "/")
-    .padEnd(Math.ceil(value.length / 4) * 4, "=");
-  const binary = atob(padded);
-  const out = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i += 1) {
-    out[i] = binary.charCodeAt(i);
-  }
-  return out;
 }

--- a/worker/src/aws-cleanup-recovery.ts
+++ b/worker/src/aws-cleanup-recovery.ts
@@ -1,5 +1,5 @@
-import { sha256Hex } from "./auth";
 import { sanitizeAWSRegion } from "./aws-region";
+import { sha256Hex } from "./encoding";
 import { providerKeyForLease } from "./provider-key";
 import { providerLabelsOwnedByLease } from "./provider-labels";
 import { ProviderResourceUnresolvedError } from "./provider-provisioning";

--- a/worker/src/aws-qualification-authority.ts
+++ b/worker/src/aws-qualification-authority.ts
@@ -2,7 +2,6 @@ import { AwsClient } from "aws4fetch";
 import { DurableObject, WorkerEntrypoint } from "cloudflare:workers";
 import { XMLParser } from "fast-xml-parser";
 
-import { sha256Hex } from "./auth";
 import {
   awsQualificationAttestationVersion,
   awsQualificationInstanceTypes,
@@ -19,6 +18,7 @@ import {
   type AWSQualificationService,
 } from "./aws-qualification-contract";
 import { requireAWSRegion } from "./aws-region";
+import { sha256Hex } from "./encoding";
 import type { AWSCredentials } from "./types";
 
 const ec2Version = "2016-11-15";

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -1,4 +1,3 @@
-import { sha256Hex } from "./auth";
 import { azureWindowsBootstrapPowerShell, cloudInit } from "./bootstrap";
 import {
   azureSupportsEphemeralFullCaching,
@@ -11,6 +10,7 @@ import {
   validatedCIDRs,
   type LeaseConfig,
 } from "./config";
+import { sha256Hex } from "./encoding";
 import { ExpiringTokenCache, type ExpiringToken } from "./expiring-token-cache";
 import { leaseProviderLabels, providerLabelsOwnedByLease } from "./provider-labels";
 import {

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -29,6 +29,7 @@ import {
   googleLinuxSigningKeyFingerprint,
 } from "./bootstrap.generated";
 import { sshPorts, type LeaseConfig } from "./config";
+import { bytesToBase64 } from "./encoding";
 import { linuxMinimalReadinessBootstrap } from "./linux-readiness.generated";
 
 export function awsUserData(config: LeaseConfig): string {
@@ -62,21 +63,12 @@ export async function awsRunInstancesUserData(config: LeaseConfig): Promise<stri
   const userData = awsUserData(config);
   const bytes =
     config.target === "linux" ? await gzip(userData) : new TextEncoder().encode(userData);
-  return base64Encode(bytes);
+  return bytesToBase64(bytes);
 }
 
 async function gzip(value: string): Promise<Uint8Array> {
   const stream = new Blob([value]).stream().pipeThrough(new CompressionStream("gzip"));
   return new Uint8Array(await new Response(stream).arrayBuffer());
-}
-
-function base64Encode(bytes: Uint8Array): string {
-  const chunks: string[] = [];
-  const chunkSize = 0x8000;
-  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
-    chunks.push(String.fromCharCode(...bytes.subarray(offset, offset + chunkSize)));
-  }
-  return btoa(chunks.join(""));
 }
 
 export function cloudInit(

--- a/worker/src/bridge-tickets.ts
+++ b/worker/src/bridge-tickets.ts
@@ -126,7 +126,7 @@ export class BridgeTickets {
     const bytes = crypto.getRandomValues(new Uint8Array(16));
     const ticket = {
       ...input,
-      ticket: `${policy.tokenPrefix}${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`,
+      ticket: `${policy.tokenPrefix}${bytesToHex(bytes)}`,
       createdAt: now.toISOString(),
       expiresAt: new Date(now.getTime() + policy.ttlSeconds * 1000).toISOString(),
     } as BridgeTicketRecord<K>;
@@ -194,3 +194,4 @@ export class BridgeTickets {
     );
   }
 }
+import { bytesToHex } from "./encoding";

--- a/worker/src/checkpoints.ts
+++ b/worker/src/checkpoints.ts
@@ -1,5 +1,5 @@
-import { sha256Hex } from "./auth";
 import type { CoordinatorStorage, CoordinatorStorageView } from "./coordinator-runtime";
+import { sha256Hex } from "./encoding";
 import { orgMatchesForAccounting, sameOrgIdentityKey } from "./org-identity";
 import type {
   CoordinatorCheckpointCreateClaim,

--- a/worker/src/code-origin.ts
+++ b/worker/src/code-origin.ts
@@ -1,4 +1,4 @@
-import { sha256Hex } from "./auth";
+import { sha256Hex } from "./encoding";
 import type { Env } from "./types";
 
 const placeholder = "{lease}";

--- a/worker/src/daytona.ts
+++ b/worker/src/daytona.ts
@@ -1,5 +1,5 @@
-import { sha256Hex } from "./auth";
 import type { LeaseConfig } from "./config";
+import { sha256Hex } from "./encoding";
 import { redactDiagnosticSecrets } from "./http";
 import { leaseProviderLabels, providerMachineOwnedByLease } from "./provider-labels";
 import {

--- a/worker/src/encoding.ts
+++ b/worker/src/encoding.ts
@@ -1,0 +1,37 @@
+const encoder = new TextEncoder();
+
+export function bytesToHex(bytes: Uint8Array): string {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+// Text is UTF-8; binary views are hashed as supplied, including their offsets.
+export async function sha256Hex(value: string | BufferSource): Promise<string> {
+  const bytes = typeof value === "string" ? encoder.encode(value) : value;
+  return bytesToHex(new Uint8Array(await crypto.subtle.digest("SHA-256", bytes)));
+}
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  const chunks: string[] = [];
+  const chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    chunks.push(String.fromCharCode(...bytes.subarray(offset, offset + chunkSize)));
+  }
+  return btoa(chunks.join(""));
+}
+
+export function base64ToBytes(value: string): Uint8Array<ArrayBuffer> {
+  return Uint8Array.from(atob(value), (character) => character.charCodeAt(0));
+}
+
+export function base64URL(bytes: Uint8Array): string {
+  return bytesToBase64(bytes).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
+export function base64URLDecode(value: string): Uint8Array<ArrayBuffer> {
+  return base64ToBytes(
+    value
+      .replaceAll("-", "+")
+      .replaceAll("_", "/")
+      .padEnd(Math.ceil(value.length / 4) * 4, "="),
+  );
+}

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -42,7 +42,6 @@ import {
   githubUserIsAdmin,
   isAdminRequest,
   requestWithAuthContext,
-  sha256Hex,
   verifiedPortalTokenExpiresAtForRevocation,
   verifiedUserTokenExpiresAtForRevocation,
   type AuthContext,
@@ -178,6 +177,7 @@ import {
   isDaytonaNotFound,
   type DaytonaSSHEndpoint,
 } from "./daytona";
+import { base64ToBytes, bytesToBase64, bytesToHex, sha256Hex } from "./encoding";
 import {
   GCPClient,
   gcpMachineImageNotFound,
@@ -19961,8 +19961,7 @@ async function readyPoolTaggedDigest(
     payload.set(field.encoded, offset);
     offset += field.encoded.byteLength;
   }
-  const digest = await crypto.subtle.digest("SHA-256", payload);
-  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  return sha256Hex(payload);
 }
 
 function validUnicodeScalarString(value: string): boolean {
@@ -21346,7 +21345,7 @@ function runtimeAdapterLegacyDeleteCompletion(
 function newLeaseID(): string {
   const bytes = new Uint8Array(6);
   crypto.getRandomValues(bytes);
-  return `cbx_${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  return `cbx_${bytesToHex(bytes)}`;
 }
 
 function newCreateAttemptGeneration(): string {
@@ -22848,13 +22847,13 @@ async function workspaceResponseError(response: Response, fallback: string): Pro
 function newRunID(): string {
   const bytes = new Uint8Array(6);
   crypto.getRandomValues(bytes);
-  return `run_${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  return `run_${bytesToHex(bytes)}`;
 }
 
 function newWebVNCSessionID(prefix: "agent" | "viewer"): string {
   const bytes = new Uint8Array(8);
   crypto.getRandomValues(bytes);
-  return `${prefix}_${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  return `${prefix}_${bytesToHex(bytes)}`;
 }
 
 function newWebVNCPortalViewerTicket(): string {
@@ -22868,7 +22867,7 @@ function newWebVNCPortalViewerSession(): string {
 function newRuntimeAdapterTicket(): string {
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
-  return `adapter_${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  return `adapter_${bytesToHex(bytes)}`;
 }
 
 function newNativeVNCTicket(): string {
@@ -22890,13 +22889,13 @@ function newCodeViewerSession(): string {
 function randomHexToken(prefix: string): string {
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
-  return `${prefix}${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  return `${prefix}${bytesToHex(bytes)}`;
 }
 
 function newEgressSessionID(): string {
   const bytes = new Uint8Array(6);
   crypto.getRandomValues(bytes);
-  return `egress_${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  return `egress_${bytesToHex(bytes)}`;
 }
 
 function egressSocketKey(leaseID: string, sessionID: string): string {
@@ -24510,23 +24509,6 @@ function sendControl(socket: WebSocket, payload: unknown): void {
   }
 }
 
-function bytesToBase64(bytes: Uint8Array): string {
-  let binary = "";
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  return btoa(binary);
-}
-
-function base64ToBytes(value: string): Uint8Array {
-  const binary = atob(value);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i += 1) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
-}
-
 function identifierMatchesLease(identifier: string, lease: LeaseRecord): boolean {
   return (
     identifier === lease.id || normalizeLeaseSlug(identifier) === normalizeLeaseSlug(lease.slug)
@@ -24704,8 +24686,7 @@ async function workspaceSSHHostKeyFingerprint(publicKey: string): Promise<string
     throw new Error("workspace SSH host public key is invalid");
   }
   const raw = Uint8Array.from(atob(encoded), (character) => character.charCodeAt(0));
-  const digest = await crypto.subtle.digest("SHA-256", raw);
-  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  return sha256Hex(raw);
 }
 
 function requestSourceCIDRs(request: Request): string[] {

--- a/worker/src/gcp.ts
+++ b/worker/src/gcp.ts
@@ -8,6 +8,7 @@ import {
   uniqueProviderMachineCandidates,
   type LeaseConfig,
 } from "./config";
+import { base64URL } from "./encoding";
 import { ExpiringTokenCache, type ExpiringToken } from "./expiring-token-cache";
 import { redactDiagnosticSecrets } from "./http";
 import {
@@ -1904,9 +1905,7 @@ function utf8(value: string): Uint8Array {
 
 function base64url(value: string | ArrayBuffer): string {
   const bytes = typeof value === "string" ? utf8(value) : new Uint8Array(value);
-  let binary = "";
-  for (const byte of bytes) binary += String.fromCharCode(byte);
-  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+  return base64URL(bytes);
 }
 
 function sleep(ms: number): Promise<void> {

--- a/worker/src/oauth.ts
+++ b/worker/src/oauth.ts
@@ -4,12 +4,12 @@ import {
   openPendingGitHubCredential,
   portalTokenExpiresAt,
   sealPendingGitHubCredential,
-  sha256Hex,
   userTokenExpiresAt,
   userTokenSigningConfigurationError,
 } from "./auth";
 import { legacyPortalSessionCookieName, portalSessionCookieName } from "./cookies";
 import type { CoordinatorRuntime, CoordinatorStorage } from "./coordinator-runtime";
+import { bytesToHex, sha256Hex } from "./encoding";
 import {
   GitHubAuthorizationError,
   GitHubTransientError,
@@ -858,7 +858,7 @@ function oauthStateKey(state: string): string {
 function randomID(prefix: string): string {
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
-  return `${prefix}_${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  return `${prefix}_${bytesToHex(bytes)}`;
 }
 
 function html(

--- a/worker/src/pairing.ts
+++ b/worker/src/pairing.ts
@@ -1,4 +1,5 @@
-import { base64URL, sha256Hex, type GitHubUserGrant } from "./auth";
+import type { GitHubUserGrant } from "./auth";
+import { base64URL, sha256Hex } from "./encoding";
 import { bearerToken, pathParts } from "./http";
 import { timingSafeEqual } from "./timing-safe";
 import type { Env } from "./types";

--- a/worker/src/provisioning-material.ts
+++ b/worker/src/provisioning-material.ts
@@ -1,3 +1,4 @@
+import { base64ToBytes, bytesToBase64 } from "./encoding";
 import type { Env } from "./types";
 
 const encoder = new TextEncoder();
@@ -54,7 +55,11 @@ export async function sealProvisioningMaterial(
       JSON.stringify({ adminPassword: material.adminPassword, bootstrap: material.bootstrap }),
     ),
   );
-  return { schema: 1, iv: encode(iv), ciphertext: encode(new Uint8Array(ciphertext)) };
+  return {
+    schema: 1,
+    iv: bytesToBase64(iv),
+    ciphertext: bytesToBase64(new Uint8Array(ciphertext)),
+  };
 }
 
 export async function openProvisioningMaterial(
@@ -73,9 +78,9 @@ export async function openProvisioningMaterial(
     }
     const key = await encryptionKey(env, ["decrypt"]);
     const plaintext = await crypto.subtle.decrypt(
-      { name: "AES-GCM", iv: decode(sealed.iv), additionalData: aad(binding) },
+      { name: "AES-GCM", iv: base64ToBytes(sealed.iv), additionalData: aad(binding) },
       key,
-      decode(sealed.ciphertext),
+      base64ToBytes(sealed.ciphertext),
     );
     const material: ProvisioningMaterial = JSON.parse(
       new TextDecoder("utf-8", { fatal: true, ignoreBOM: false }).decode(plaintext),
@@ -122,12 +127,4 @@ async function encryptionKey(env: Env, usages: ("encrypt" | "decrypt")[]): Promi
     encoder.encode(`crabbox/provisioning/aes-gcm/v1\0${env.CRABBOX_SESSION_SECRET}`),
   );
   return crypto.subtle.importKey("raw", material, "AES-GCM", false, usages);
-}
-
-function encode(bytes: Uint8Array): string {
-  return btoa(Array.from(bytes, (byte) => String.fromCharCode(byte)).join(""));
-}
-
-function decode(value: string): Uint8Array<ArrayBuffer> {
-  return Uint8Array.from(atob(value), (character) => character.charCodeAt(0));
 }

--- a/worker/src/run-receipt.ts
+++ b/worker/src/run-receipt.ts
@@ -1,3 +1,4 @@
+import { base64ToBytes, sha256Hex } from "./encoding";
 import type { RunRecord, TerminalRunReceipt } from "./types";
 
 const terminalReceiptMaxBytes = 16 * 1024;
@@ -238,13 +239,12 @@ function lengthPrefixedPayload(prefix: string, values: string[]): Uint8Array {
 }
 
 async function sha256Digest(value: BufferSource): Promise<string> {
-  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", value));
-  return `sha256:${[...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  return `sha256:${await sha256Hex(value)}`;
 }
 
 function decodeBase64(value: string, length: number, field: string): Uint8Array {
   try {
-    const decoded = Uint8Array.from(atob(value), (character) => character.charCodeAt(0));
+    const decoded = base64ToBytes(value);
     if (decoded.byteLength === length) return decoded;
   } catch {
     // Report one stable validation error below.

--- a/worker/src/webvnc-handoff.ts
+++ b/worker/src/webvnc-handoff.ts
@@ -1,5 +1,5 @@
-import { sha256Hex } from "./auth";
 import type { CoordinatorRuntime } from "./coordinator-runtime";
+import { bytesToHex, sha256Hex } from "./encoding";
 
 const ticketPrefix = "vnc_handoff_";
 const storagePrefix = "webvnc-credential-handoff:";
@@ -88,7 +88,7 @@ export class WebVNCCredentialHandoffs {
 function newTicket(): string {
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
-  return `${ticketPrefix}${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  return `${ticketPrefix}${bytesToHex(bytes)}`;
 }
 
 function validTicket(value: string): boolean {
@@ -113,7 +113,7 @@ async function sealCredentials(
     await credentialKey(ticket, ["encrypt"]),
     encoder.encode(JSON.stringify(credentials)),
   );
-  return { iv: encodeHex(iv), ciphertext: encodeHex(new Uint8Array(ciphertext)) };
+  return { iv: bytesToHex(iv), ciphertext: bytesToHex(new Uint8Array(ciphertext)) };
 }
 
 async function openCredentials(
@@ -188,10 +188,6 @@ function validHex(value: unknown, exactLength?: number): value is string {
     value.length % 2 === 0 &&
     /^[a-f0-9]+$/.test(value)
   );
-}
-
-function encodeHex(value: Uint8Array): string {
-  return [...value].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 function decodeHex(value: string): Uint8Array {

--- a/worker/test/artifacts.live.test.ts
+++ b/worker/test/artifacts.live.test.ts
@@ -2,7 +2,7 @@ import { AwsClient } from "aws4fetch";
 import { describe, expect, it } from "vitest";
 
 import { artifactUploadResponse } from "../src/artifacts";
-import { sha256Hex } from "../src/auth";
+import { sha256Hex } from "../src/encoding";
 import type { Env } from "../src/types";
 
 const liveAccessKeyID = process.env.CRABBOX_ARTIFACTS_ACCESS_KEY_ID;

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { sha256Hex } from "../src/auth";
 import {
   AzureClient,
   azureCleanupRecoveryAuditKey,
@@ -25,6 +24,7 @@ import {
   type AzureDeferredCleanupRequest,
 } from "../src/azure";
 import type { LeaseConfig } from "../src/config";
+import { sha256Hex } from "../src/encoding";
 import { providerProvisioningCleanupClaim } from "../src/provider-provisioning";
 import type { Env, LeaseRecord, ProviderMachine } from "../src/types";
 

--- a/worker/test/bridge-tickets.test.ts
+++ b/worker/test/bridge-tickets.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { adminGrantVersion, issueUserToken, sha256Hex } from "../src/auth";
+import { adminGrantVersion, issueUserToken } from "../src/auth";
 import type { BridgeTicketKind, LeaseBridgeTicketRecord } from "../src/bridge-tickets";
 import { CloudflareCoordinatorRuntime } from "../src/coordinator-runtime";
+import { sha256Hex } from "../src/encoding";
 import { FleetCoordinator } from "../src/fleet";
 import { orgKeyForLabel } from "../src/org-identity";
 import type { Env, LeaseRecord } from "../src/types";

--- a/worker/test/checkpoints.test.ts
+++ b/worker/test/checkpoints.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { sha256Hex } from "../src/auth";
 import {
   CheckpointError,
   expireCheckpointClaims,
@@ -36,6 +35,7 @@ import type {
   CoordinatorStorageView,
   CoordinatorWebSocketUpgrade,
 } from "../src/coordinator-runtime";
+import { sha256Hex } from "../src/encoding";
 import { AWSProvider, AzureProvider, FleetCoordinator, GCPProvider } from "../src/fleet";
 import { orgKeyForLabel } from "../src/org-identity";
 import type {

--- a/worker/test/encoding.test.ts
+++ b/worker/test/encoding.test.ts
@@ -1,0 +1,63 @@
+import { createHash } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  base64ToBytes,
+  base64URL,
+  base64URLDecode,
+  bytesToBase64,
+  bytesToHex,
+  sha256Hex,
+} from "../src/encoding";
+
+describe("binary encoding", () => {
+  it("matches standard base64 and hex for every byte value", () => {
+    const bytes = Uint8Array.from({ length: 256 }, (_, index) => index);
+    expect(bytesToBase64(bytes)).toBe(Buffer.from(bytes).toString("base64"));
+    expect(bytesToHex(bytes)).toBe(Buffer.from(bytes).toString("hex"));
+    expect(base64ToBytes(bytesToBase64(bytes))).toEqual(bytes);
+    expect(base64URL(bytes)).toBe(Buffer.from(bytes).toString("base64url"));
+    expect(base64URLDecode(base64URL(bytes))).toEqual(bytes);
+  });
+
+  it("encodes large and sliced views without including bytes outside the view", () => {
+    const data = Uint8Array.from({ length: 200_003 }, (_, index) => index % 256);
+    const view = data.subarray(1, -1);
+    expect(bytesToBase64(view)).toBe(Buffer.from(view).toString("base64"));
+    expect(base64ToBytes(bytesToBase64(view))).toEqual(view);
+  });
+
+  it("preserves empty values and padded or unpadded URL base64", () => {
+    expect(bytesToHex(new Uint8Array())).toBe("");
+    expect(bytesToBase64(new Uint8Array())).toBe("");
+    expect(base64URLDecode("")).toEqual(new Uint8Array());
+    for (const encoded of ["YQ", "YQ=="]) {
+      expect(base64URLDecode(encoded)).toEqual(new Uint8Array([97]));
+    }
+    expect(() => base64ToBytes("!")).toThrow(DOMException);
+    expect(() => base64URLDecode("A")).toThrow(DOMException);
+  });
+});
+
+describe("SHA-256 encoding", () => {
+  it("matches known text vectors and UTF-8", async () => {
+    expect(await sha256Hex("")).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+    expect(await sha256Hex("abc")).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+    const text = "é🦀\u0000";
+    expect(await sha256Hex(text)).toBe(createHash("sha256").update(text, "utf8").digest("hex"));
+  });
+
+  it("hashes binary views as bytes, including offsets and invalid UTF-8", async () => {
+    const bytes = new Uint8Array([0, 255, 128, 97, 0]);
+    const view = bytes.subarray(1, 4);
+    const expected = createHash("sha256").update(view).digest("hex");
+    expect(await sha256Hex(view)).toBe(expected);
+    expect(await sha256Hex(new DataView(bytes.buffer, 1, 3))).toBe(expected);
+    expect(await sha256Hex(bytes.buffer)).toBe(createHash("sha256").update(bytes).digest("hex"));
+  });
+});

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -4,7 +4,7 @@ import { Script, createContext } from "node:vm";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { adminGrantVersion, issueUserToken, sha256Hex } from "../src/auth";
+import { adminGrantVersion, issueUserToken } from "../src/auth";
 import { EC2SpotClient, AWSLeaseAuthorityError } from "../src/aws";
 import { AzureClient, azureOwnedDeleteClaimKey } from "../src/azure";
 import { codeOriginForLease } from "../src/code-origin";
@@ -26,6 +26,7 @@ import {
   type CoordinatorStorageView,
   type CoordinatorWebSocketUpgradeOptions,
 } from "../src/coordinator-runtime";
+import { sha256Hex } from "../src/encoding";
 import {
   AWSProvider,
   AzureProvider,

--- a/worker/test/http.test.ts
+++ b/worker/test/http.test.ts
@@ -4,13 +4,13 @@ import coordinator, { isAuthorized } from "../src";
 import {
   adminGrantVersion,
   authenticateRequest,
-  base64URL,
   githubUserGrantIsCurrent,
   issueUserToken,
   requestWithAuthContext,
 } from "../src/auth";
 import { codeOriginForLease } from "../src/code-origin";
 import { prepareCoordinatorRequest } from "../src/coordinator-entry";
+import { base64URL } from "../src/encoding";
 import { errorMessage, json, redactDiagnosticSecrets, requestOwner } from "../src/http";
 import { MISSING_ORG_KEY, requestOrg, requestOrgLabel } from "../src/org-identity";
 import type { Env } from "../src/types";

--- a/worker/test/oauth-browser-binding.test.ts
+++ b/worker/test/oauth-browser-binding.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { sha256Hex } from "../src/auth";
 import type { CoordinatorStorage, CoordinatorStorageView } from "../src/coordinator-runtime";
+import { sha256Hex } from "../src/encoding";
 import { githubAuthRoute, githubPortalLogin } from "../src/oauth";
 import type { Env } from "../src/types";
 

--- a/worker/test/postgres-storage.test.ts
+++ b/worker/test/postgres-storage.test.ts
@@ -2,7 +2,6 @@ import type { Pool, PoolClient, QueryResult, QueryResultRow } from "pg";
 import { describe, expect, it, vi } from "vitest";
 
 import { PostgresCoordinatorStorage } from "../node/postgres-storage";
-import { sha256Hex } from "../src/auth";
 import {
   CheckpointError,
   acquireCheckpointUse,
@@ -21,6 +20,7 @@ import {
   reserveCheckpointCreate,
 } from "../src/checkpoints";
 import type { CoordinatorRuntime } from "../src/coordinator-runtime";
+import { sha256Hex } from "../src/encoding";
 import {
   FleetCoordinator,
   readyPoolDesiredCapacityKeyV2,


### PR DESCRIPTION
Move shared byte encoding and SHA-256 formatting out of authentication so provisioning, artifacts, checkpoints, receipts, and bridge protocols use a neutral owner. Remove duplicated byte/base64 loops and digest formatting, preserving the existing chunked encoder for large inputs.

Text digests remain UTF-8; binary digests use the supplied bytes and view offsets. Base64/base64url handling, token lengths and prefixes, receipt prefixes, validation, signing, and encryption key derivation retain their existing contracts. Binary-string codecs with different input semantics stay local. No schema, credential, or configuration change.

Validation: all 3,153 Worker tests pass (15 existing skips), with new known SHA-256 vectors, all-byte hex/base64 checks, large buffers, offset views, DataView hashing, and malformed base64 exceptions. Worker and Node typechecks/builds, formatting, lint, and Autoreview pass.
