### PR TITLE
refactor(providers): share local command failure formatting

### DIFF
--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -554,6 +554,9 @@ Rules:
   tests can pass a fake clock for deterministic timing assertions.
 - Use `rt.Stdout` and `rt.Stderr` for streaming and warnings. Do not write
   directly to `os.Stdout` / `os.Stderr`.
+- Use `shared.LocalCommandError` when a failed tool keeps its nonzero exit code
+  (zero becomes one) and reports trimmed stderr before stdout. Providers with
+  different exit, redaction, or cause-wrapping contracts retain their own policy.
 - Use `rt.HTTP` for outbound HTTP when the provider has a JSON API. Tests can
   inject a stubbed transport.
 

--- a/internal/providers/applecontainer/backend.go
+++ b/internal/providers/applecontainer/backend.go
@@ -478,7 +478,7 @@ func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, le
 
 	result, err := b.container(ctx, args, nil, b.rt.Stderr)
 	if err != nil {
-		return "", commandError("container run", result, err)
+		return "", shared.LocalCommandError("container run", result, err)
 	}
 	id := strings.TrimSpace(result.Stdout)
 	if id == "" {
@@ -540,7 +540,7 @@ func appleContainerCacheVolumeName(key string) string {
 func (b *backend) listContainers(ctx context.Context) ([]inspectContainer, error) {
 	result, err := b.container(ctx, []string{"ls", "--all", "--format", "json"}, nil, nil)
 	if err != nil {
-		return nil, commandError("container ls", result, err)
+		return nil, shared.LocalCommandError("container ls", result, err)
 	}
 	all, err := decodeInspect([]byte(result.Stdout))
 	if err != nil {
@@ -559,7 +559,7 @@ func (b *backend) listContainers(ctx context.Context) ([]inspectContainer, error
 func (b *backend) inspectContainer(ctx context.Context, id string) (inspectContainer, error) {
 	result, err := b.container(ctx, []string{"inspect", id}, nil, nil)
 	if err != nil {
-		return inspectContainer{}, commandError("container inspect", result, err)
+		return inspectContainer{}, shared.LocalCommandError("container inspect", result, err)
 	}
 	containers, err := decodeInspect([]byte(result.Stdout))
 	if err != nil {
@@ -698,7 +698,7 @@ func (b *backend) removeContainer(ctx context.Context, id string) error {
 	// `container delete --force <id>` removes a running or stopped container.
 	result, err := b.container(ctx, []string{"delete", "--force", id}, nil, b.rt.Stderr)
 	if err != nil {
-		return commandError("container delete", result, err)
+		return shared.LocalCommandError("container delete", result, err)
 	}
 	return nil
 }
@@ -920,14 +920,6 @@ func readyCheck(cfg core.Config) string {
 
 func shellQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
-}
-
-func commandError(action string, result core.LocalCommandResult, err error) error {
-	code := result.ExitCode
-	if code == 0 {
-		code = 1
-	}
-	return exit(code, "%s failed: %s", action, commandDetail(result, err))
 }
 
 func commandDetail(result core.LocalCommandResult, err error) string {

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -317,7 +317,7 @@ func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, 
 	script := `(Get-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V).State`
 	result, err := b.powershell(ctx, script)
 	if err != nil {
-		return DoctorResult{}, commandError("hyperv feature check", result, err)
+		return DoctorResult{}, shared.LocalCommandError("hyperv feature check", result, err)
 	}
 	state := strings.TrimSpace(result.Stdout)
 	instances, err := b.listInstances(ctx)
@@ -486,7 +486,7 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name string) error {
 	)
 	result, err := b.powershell(ctx, switchCheck)
 	if err != nil {
-		return commandError("switch validation", result, err)
+		return shared.LocalCommandError("switch validation", result, err)
 	}
 
 	memBytes := int64(cfg.HyperV.Memory) * 1024 * 1024
@@ -504,7 +504,7 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name string) error {
 	result, err = b.powershell(ctx, diffScript)
 	if err != nil {
 		os.Remove(vhdPath) //nolint:errcheck
-		return commandError("create differencing disk", result, err)
+		return shared.LocalCommandError("create differencing disk", result, err)
 	}
 
 	if cfg.HyperV.InitPassword {
@@ -521,7 +521,7 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name string) error {
 	result, err = b.powershell(ctx, createScript)
 	if err != nil {
 		os.Remove(vhdPath) //nolint:errcheck
-		return commandError("New-VM", result, err)
+		return shared.LocalCommandError("New-VM", result, err)
 	}
 
 	// Disable automatic checkpoints: client Hyper-V enables them by default, which
@@ -532,13 +532,13 @@ func (b *backend) createVM(ctx context.Context, cfg Config, name string) error {
 	cpuScript := fmt.Sprintf(`Set-VM -Name '%s' -ProcessorCount %d -AutomaticCheckpointsEnabled $false`, escapePSString(name), cfg.HyperV.CPUs)
 	result, err = b.powershell(ctx, cpuScript)
 	if err != nil {
-		return commandError("Set-VM", result, err)
+		return shared.LocalCommandError("Set-VM", result, err)
 	}
 
 	startScript := fmt.Sprintf(`Start-VM -Name '%s'`, escapePSString(name))
 	result, err = b.powershell(ctx, startScript)
 	if err != nil {
-		return commandError("Start-VM", result, err)
+		return shared.LocalCommandError("Start-VM", result, err)
 	}
 
 	return nil
@@ -551,7 +551,7 @@ func (b *backend) connectVMNetwork(ctx context.Context, name, switchName string)
 	)
 	result, err := b.powershell(ctx, script)
 	if err != nil {
-		return commandError("Connect-VMNetworkAdapter", result, err)
+		return shared.LocalCommandError("Connect-VMNetworkAdapter", result, err)
 	}
 	return nil
 }
@@ -595,7 +595,7 @@ func (b *backend) injectInitPassword(ctx context.Context, vhdPath, user string) 
 	env := append(os.Environ(), "_CRABBOX_GP="+b.guestPassword())
 	result, err := b.powershellWithEnv(ctx, script, env)
 	if err != nil {
-		return commandError("init-password injection", result, err)
+		return shared.LocalCommandError("init-password injection", result, err)
 	}
 	return nil
 }
@@ -632,7 +632,7 @@ func (b *backend) waitGuestReady(ctx context.Context, vmName, user string) error
 		func(context.Context) (struct{}, error) {
 			result, err := b.invokeGuestScript(budgetCtx, script, env, b.guestReadyProbeTimeout)
 			if err != nil {
-				return struct{}{}, commandError("guest readiness probe", result, err)
+				return struct{}{}, shared.LocalCommandError("guest readiness probe", result, err)
 			}
 			return struct{}{}, nil
 		},
@@ -689,7 +689,7 @@ func (b *backend) invokeInGuest(ctx context.Context, vmName, user, scriptBlock, 
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		lastErr = commandError(label, result, err)
+		lastErr = shared.LocalCommandError(label, result, err)
 	}
 	return lastErr
 }
@@ -921,7 +921,7 @@ func (b *backend) listInstances(ctx context.Context) ([]hypervVM, error) {
 	script := `Get-VM | Where-Object { $_.Name -like 'crabbox-*' } | Select-Object Name, State | ConvertTo-Json -Compress`
 	result, err := b.powershell(ctx, script)
 	if err != nil {
-		return nil, commandError("Get-VM list", result, err)
+		return nil, shared.LocalCommandError("Get-VM list", result, err)
 	}
 	stdout := strings.TrimSpace(result.Stdout)
 	if stdout == "" || stdout == "null" {
@@ -1019,7 +1019,7 @@ func (b *backend) removeVM(ctx context.Context, name string) error {
 		removeScript := fmt.Sprintf(`Remove-VM -Name '%s' -Force -Confirm:$false`, escapePSString(name))
 		result, removeErr := b.powershell(ctx, removeScript)
 		if removeErr != nil {
-			return commandError("Remove-VM", result, removeErr)
+			return shared.LocalCommandError("Remove-VM", result, removeErr)
 		}
 	}
 	return b.removeVMStorage(name, vhdPaths)
@@ -1168,7 +1168,7 @@ func (b *backend) queryVM(ctx context.Context, name string) (hypervVM, error) {
 	script := fmt.Sprintf(`Get-VM -ErrorAction Stop | Where-Object { $_.Name -eq '%s' } | Select-Object Name, State | ConvertTo-Json -Compress`, escapePSString(name))
 	result, err := b.powershell(ctx, script)
 	if err != nil {
-		return hypervVM{}, commandError("Get-VM query", result, err)
+		return hypervVM{}, shared.LocalCommandError("Get-VM query", result, err)
 	}
 	stdout := strings.TrimSpace(result.Stdout)
 	if stdout == "" || stdout == "null" {
@@ -1485,21 +1485,6 @@ func isUsableIPv4(s string) bool {
 
 func escapePSString(s string) string {
 	return strings.ReplaceAll(s, "'", "''")
-}
-
-func commandError(action string, result LocalCommandResult, err error) error {
-	code := result.ExitCode
-	if code == 0 {
-		code = 1
-	}
-	detail := strings.TrimSpace(result.Stderr)
-	if detail == "" {
-		detail = strings.TrimSpace(result.Stdout)
-	}
-	if detail != "" {
-		return exit(code, "%s failed: %v: %s", action, err, detail)
-	}
-	return exit(code, "%s failed: %v", action, err)
 }
 
 func firstLine(value string) string {

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -1654,7 +1654,7 @@ func (b *backend) ValidateCheckpointForkWorkdir(ctx context.Context, lease core.
 	}
 	result, err := b.docker(ctx, args, nil, nil)
 	if err != nil {
-		return commandError("validate local-container checkpoint fork workdir", result, err)
+		return shared.LocalCommandError("validate local-container checkpoint fork workdir", result, err)
 	}
 	return nil
 }
@@ -1885,14 +1885,14 @@ func (b *backend) createContainerWithFixedIntent(ctx context.Context, cfg core.C
 		containerID, owned, inspectErr := b.ownedContainerID(cleanupCtx, leaseID, bootstrapDir)
 		if owned {
 			cleanupHostLeaseWorkRoot = false
-			return containerID, bootstrapDir, commandError("container run", result, err)
+			return containerID, bootstrapDir, shared.LocalCommandError("container run", result, err)
 		}
 		if inspectErr == nil {
 			os.RemoveAll(bootstrapDir)
 		} else {
 			cleanupHostLeaseWorkRoot = false
 		}
-		return "", "", commandError("container run", result, err)
+		return "", "", shared.LocalCommandError("container run", result, err)
 	}
 	id := strings.TrimSpace(result.Stdout)
 	if id == "" {
@@ -2107,7 +2107,7 @@ func (b *backend) prepareLease(ctx context.Context, cfg core.Config, container i
 func (b *backend) listContainers(ctx context.Context) ([]inspectContainer, error) {
 	result, err := b.docker(ctx, []string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=" + providerName, "--format", "{{.ID}}"}, nil, nil)
 	if err != nil {
-		return nil, commandError("container list", result, err)
+		return nil, shared.LocalCommandError("container list", result, err)
 	}
 	ids := strings.Fields(result.Stdout)
 	containers := make([]inspectContainer, 0, len(ids))
@@ -2128,7 +2128,7 @@ func (b *backend) inspectContainer(ctx context.Context, id string) (inspectConta
 func inspectRuntimeContainer(ctx context.Context, run containerObservationCommand, id string) (inspectContainer, error) {
 	result, err := run(ctx, []string{"inspect", id})
 	if err != nil {
-		return inspectContainer{}, commandError("container inspect", result, err)
+		return inspectContainer{}, shared.LocalCommandError("container inspect", result, err)
 	}
 	var containers []inspectContainer
 	if err := json.Unmarshal([]byte(result.Stdout), &containers); err != nil {
@@ -2147,7 +2147,7 @@ func (b *backend) exactContainerAbsent(ctx context.Context, id string) (bool, er
 	}
 	detail := strings.ToLower(strings.TrimSpace(firstNonBlank(result.Stderr, result.Stdout)))
 	if localContainerRouteFailure(detail) {
-		return false, commandError("confirm local-container absence", result, err)
+		return false, shared.LocalCommandError("confirm local-container absence", result, err)
 	}
 	containerID := strings.ToLower(strings.TrimSpace(id))
 	// Accept Podman's quoted-ID spelling only as the complete diagnostic.
@@ -2168,7 +2168,7 @@ func (b *backend) exactContainerAbsent(ctx context.Context, id string) (bool, er
 			return true, nil
 		}
 	}
-	return false, commandError("confirm local-container absence", result, err)
+	return false, shared.LocalCommandError("confirm local-container absence", result, err)
 }
 
 func localContainerRouteFailure(detail string) bool {
@@ -2344,7 +2344,7 @@ func (b *backend) findContainerForClaim(ctx context.Context, claim core.LeaseCla
 func (b *backend) removeContainer(ctx context.Context, id string) error {
 	result, err := b.docker(ctx, []string{"rm", "-f", id}, nil, b.rt.Stderr)
 	if err != nil {
-		return commandError("container remove", result, err)
+		return shared.LocalCommandError("container remove", result, err)
 	}
 	return nil
 }
@@ -2529,7 +2529,7 @@ func (b *backend) assertRequestedArchitecture(ctx context.Context, cfg core.Conf
 	}
 	result, runErr := b.containerRuntime(ctx, cfg, []string{"info", "--format", format}, nil, nil)
 	if runErr != nil {
-		return "", core.Exit(2, "local-container architecture assertion failed: requested=%s available=unknown: query %s daemon architecture: %v", requested, runtimeLabel, commandError("container runtime info", result, runErr))
+		return "", core.Exit(2, "local-container architecture assertion failed: requested=%s available=unknown: query %s daemon architecture: %v", requested, runtimeLabel, shared.LocalCommandError("container runtime info", result, runErr))
 	}
 	raw := strings.TrimSpace(result.Stdout)
 	available, normalizeErr := core.NormalizeArchitecture(raw)
@@ -2658,21 +2658,6 @@ func containerSSHHostPort(container inspectContainer) (string, string, error) {
 		host = "127.0.0.1"
 	}
 	return host, strings.TrimSpace(ports[0].HostPort), nil
-}
-
-func commandError(action string, result core.LocalCommandResult, err error) error {
-	code := result.ExitCode
-	if code == 0 {
-		code = 1
-	}
-	detail := strings.TrimSpace(result.Stderr)
-	if detail == "" {
-		detail = strings.TrimSpace(result.Stdout)
-	}
-	if detail != "" {
-		return core.Exit(code, "%s failed: %v: %s", action, err, detail)
-	}
-	return core.Exit(code, "%s failed: %v", action, err)
 }
 
 func isPodmanRuntime(runtimeName string) bool {

--- a/internal/providers/lume/backend.go
+++ b/internal/providers/lume/backend.go
@@ -508,7 +508,7 @@ func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, 
 	cfg := b.configForRun()
 	version, err := b.lume(ctx, cfg, []string{"--version"}, nil, nil)
 	if err != nil {
-		return DoctorResult{}, commandError("lume --version", version, err)
+		return DoctorResult{}, shared.LocalCommandError("lume --version", version, err)
 	}
 	instances, err := b.listInstances(ctx)
 	if err != nil {
@@ -755,7 +755,7 @@ func (b *backend) cloneVM(ctx context.Context, cfg Config, name string) error {
 	}
 	result, err := b.lume(ctx, cfg, args, nil, b.rt.Stderr)
 	if err != nil {
-		return commandError("lume clone", result, err)
+		return shared.LocalCommandError("lume clone", result, err)
 	}
 	return nil
 }
@@ -1305,7 +1305,7 @@ func (b *backend) listInstancesForConfig(ctx context.Context, cfg Config) ([]lum
 	}
 	result, err := b.lume(ctx, cfg, args, nil, nil)
 	if err != nil {
-		return nil, commandError("lume ls", result, err)
+		return nil, shared.LocalCommandError("lume ls", result, err)
 	}
 	instances, err := parseLumeVMs(result.Stdout)
 	if err != nil {
@@ -1497,7 +1497,7 @@ func (b *backend) getInstance(ctx context.Context, cfg Config, name string) (lum
 	}
 	result, err := b.lume(ctx, cfg, args, nil, nil)
 	if err != nil {
-		return lumeVM{}, commandError("lume get", result, err)
+		return lumeVM{}, shared.LocalCommandError("lume get", result, err)
 	}
 	instances, err := parseLumeVMs(result.Stdout)
 	if err != nil {
@@ -1959,21 +1959,6 @@ func inactiveLumeState(state string) bool {
 }
 
 func normalizedState(state string) string { return strings.ToLower(strings.TrimSpace(state)) }
-
-func commandError(action string, result LocalCommandResult, err error) error {
-	code := result.ExitCode
-	if code == 0 {
-		code = 1
-	}
-	detail := strings.TrimSpace(result.Stderr)
-	if detail == "" {
-		detail = strings.TrimSpace(result.Stdout)
-	}
-	if detail != "" {
-		return exit(code, "%s failed: %v: %s", action, err, detail)
-	}
-	return exit(code, "%s failed: %v", action, err)
-}
 
 func firstLine(value string) string {
 	value = strings.TrimSpace(value)

--- a/internal/providers/multipass/backend.go
+++ b/internal/providers/multipass/backend.go
@@ -239,7 +239,7 @@ func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, 
 	cfg := b.configForRun()
 	version, err := b.multipass(ctx, []string{"version"}, nil, nil)
 	if err != nil {
-		return DoctorResult{}, commandError("multipass version", version, err)
+		return DoctorResult{}, shared.LocalCommandError("multipass version", version, err)
 	}
 	instances, err := b.listInstances(ctx)
 	if err != nil {
@@ -414,7 +414,7 @@ func (b *backend) createInstance(ctx context.Context, cfg Config, name, leaseID,
 	args = append(args, cfg.Multipass.Image)
 	result, err := b.multipass(ctx, args, nil, b.rt.Stderr)
 	if err != nil {
-		return commandError("multipass launch", result, err)
+		return shared.LocalCommandError("multipass launch", result, err)
 	}
 	if useNativeMounts {
 		if err := b.attachNativeMounts(ctx, name, mounts); err != nil {
@@ -450,17 +450,17 @@ func (b *backend) attachNativeMounts(ctx context.Context, name string, mounts []
 	}
 	result, err := b.multipass(ctx, []string{"stop", name}, nil, b.rt.Stderr)
 	if err != nil {
-		return commandError("multipass stop", result, err)
+		return shared.LocalCommandError("multipass stop", result, err)
 	}
 	for _, mount := range mounts {
 		result, err := b.multipass(ctx, []string{"mount", "--type", "native", mount.hostPath, name + ":" + mount.guestPath}, nil, b.rt.Stderr)
 		if err != nil {
-			return commandError("multipass mount", result, err)
+			return shared.LocalCommandError("multipass mount", result, err)
 		}
 	}
 	result, err = b.multipass(ctx, []string{"start", name}, nil, b.rt.Stderr)
 	if err != nil {
-		return commandError("multipass start", result, err)
+		return shared.LocalCommandError("multipass start", result, err)
 	}
 	return nil
 }
@@ -516,7 +516,7 @@ func multipassCacheVolumeName(key string) string {
 func (b *backend) listInstances(ctx context.Context) ([]multipassInstance, error) {
 	result, err := b.multipass(ctx, []string{"list", "--format", "json"}, nil, nil)
 	if err != nil {
-		return nil, commandError("multipass list", result, err)
+		return nil, shared.LocalCommandError("multipass list", result, err)
 	}
 	var out listResponse
 	if err := json.Unmarshal([]byte(result.Stdout), &out); err != nil {
@@ -528,7 +528,7 @@ func (b *backend) listInstances(ctx context.Context) ([]multipassInstance, error
 func (b *backend) inspectInstance(ctx context.Context, name string) (multipassInfoEntry, error) {
 	result, err := b.multipass(ctx, []string{"info", "--format", "json", name}, nil, nil)
 	if err != nil {
-		return multipassInfoEntry{}, commandError("multipass info", result, err)
+		return multipassInfoEntry{}, shared.LocalCommandError("multipass info", result, err)
 	}
 	var out infoResponse
 	if err := json.Unmarshal([]byte(result.Stdout), &out); err != nil {
@@ -622,7 +622,7 @@ func (b *backend) prepareLease(ctx context.Context, cfg Config, inst multipassIn
 func (b *backend) removeInstance(ctx context.Context, name string) error {
 	result, err := b.multipass(ctx, []string{"delete", "--purge", name}, nil, b.rt.Stderr)
 	if err != nil {
-		return commandError("multipass delete", result, err)
+		return shared.LocalCommandError("multipass delete", result, err)
 	}
 	return nil
 }
@@ -804,21 +804,6 @@ func instanceRunning(state string) bool {
 
 func multipassState(state string) string {
 	return strings.ToLower(strings.TrimSpace(state))
-}
-
-func commandError(action string, result LocalCommandResult, err error) error {
-	code := result.ExitCode
-	if code == 0 {
-		code = 1
-	}
-	detail := strings.TrimSpace(result.Stderr)
-	if detail == "" {
-		detail = strings.TrimSpace(result.Stdout)
-	}
-	if detail != "" {
-		return exit(code, "%s failed: %v: %s", action, err, detail)
-	}
-	return exit(code, "%s failed: %v", action, err)
 }
 
 func durationSecondsCeil(duration time.Duration) int {

--- a/internal/providers/shared/command_error.go
+++ b/internal/providers/shared/command_error.go
@@ -1,0 +1,24 @@
+package shared
+
+import (
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// LocalCommandError preserves a failed tool's nonzero exit code and selects
+// stderr before stdout. Callers retain execution, redaction, and retry policy.
+func LocalCommandError(action string, result core.LocalCommandResult, err error) error {
+	code := result.ExitCode
+	if code == 0 {
+		code = 1
+	}
+	detail := strings.TrimSpace(result.Stderr)
+	if detail == "" {
+		detail = strings.TrimSpace(result.Stdout)
+	}
+	if detail != "" {
+		return core.Exit(code, "%s failed: %v: %s", action, err, detail)
+	}
+	return core.Exit(code, "%s failed: %v", action, err)
+}

--- a/internal/providers/shared/command_error_test.go
+++ b/internal/providers/shared/command_error_test.go
@@ -1,0 +1,35 @@
+package shared
+
+import (
+	"errors"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestLocalCommandError(t *testing.T) {
+	cause := errors.New("process failed")
+	for _, tt := range []struct {
+		name   string
+		result core.LocalCommandResult
+		cause  error
+		code   int
+		text   string
+	}{
+		{"stderr takes precedence", core.LocalCommandResult{ExitCode: 5, Stderr: " detail\n", Stdout: "ignored"}, cause, 5, "tool failed: process failed: detail"},
+		{"stdout fallback", core.LocalCommandResult{ExitCode: 2, Stderr: "\t\n", Stdout: " output\n"}, cause, 2, "tool failed: process failed: output"},
+		{"cause only", core.LocalCommandResult{ExitCode: 7}, cause, 7, "tool failed: process failed"},
+		{"zero becomes failure", core.LocalCommandResult{}, cause, 1, "tool failed: process failed"},
+		{"signed exit preserved", core.LocalCommandResult{ExitCode: -1}, cause, -1, "tool failed: process failed"},
+		{"nil cause with output", core.LocalCommandResult{ExitCode: 3, Stderr: "detail"}, nil, 3, "tool failed: <nil>: detail"},
+		{"nil cause without output", core.LocalCommandResult{}, nil, 1, "tool failed: <nil>"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := LocalCommandError("tool", tt.result, tt.cause)
+			var exitErr core.ExitError
+			if !core.AsExitError(err, &exitErr) || exitErr.Code != tt.code || err.Error() != tt.text {
+				t.Fatalf("got %T (%d, %q), want ExitError (%d, %q)", err, exitErr.Code, err.Error(), tt.code, tt.text)
+			}
+		})
+	}
+}

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -280,7 +280,7 @@ func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, 
 	cfg := b.configForRun()
 	version, err := b.tart(ctx, []string{"--version"}, nil, nil)
 	if err != nil {
-		return DoctorResult{}, commandError("tart --version", version, err)
+		return DoctorResult{}, shared.LocalCommandError("tart --version", version, err)
 	}
 	instances, err := b.listInstances(ctx)
 	if err != nil {
@@ -497,7 +497,7 @@ func (b *backend) cloneVM(ctx context.Context, cfg Config, name string) error {
 	args := []string{"clone", cfg.Tart.Image, name}
 	result, err := b.tart(ctx, args, nil, b.rt.Stderr)
 	if err != nil {
-		return commandError("tart clone", result, err)
+		return shared.LocalCommandError("tart clone", result, err)
 	}
 	return nil
 }
@@ -588,7 +588,7 @@ func (b *backend) injectSSHKey(ctx context.Context, name string, user string, pu
 	)
 	injectResult, err := b.tart(ctx, []string{"exec", name, "bash", "-c", injectScript}, nil, b.rt.Stderr)
 	if err != nil {
-		return commandError("ssh key injection", injectResult, err)
+		return shared.LocalCommandError("ssh key injection", injectResult, err)
 	}
 	return nil
 }
@@ -618,7 +618,7 @@ func (b *backend) waitForGuestAgent(ctx context.Context, name string) error {
 			if strings.Contains(detail, "GRPCConnectionPoolError") || strings.Contains(detail, "is the Tart Guest Agent running?") {
 				return false, nil
 			}
-			return false, commandError("Tart Guest Agent readiness", current.result, current.err)
+			return false, shared.LocalCommandError("Tart Guest Agent readiness", current.result, current.err)
 		},
 		func(result shared.PollResult[observation]) {
 			if result.Attempt == 1 {
@@ -651,7 +651,7 @@ echo 'macOS Screen Sharing did not start (no VNC listener on 127.0.0.1:5900)' >&
 exit 1`
 	result, err := b.tart(ctx, []string{"exec", name, "bash", "-c", script}, nil, b.rt.Stderr)
 	if err != nil {
-		return commandError("enable screen sharing", result, err)
+		return shared.LocalCommandError("enable screen sharing", result, err)
 	}
 	return nil
 }
@@ -660,7 +660,7 @@ exit 1`
 func (b *backend) stopVM(ctx context.Context, name string) error {
 	result, err := b.tart(ctx, []string{"stop", name}, nil, b.rt.Stderr)
 	if err != nil {
-		return commandError("tart stop", result, err)
+		return shared.LocalCommandError("tart stop", result, err)
 	}
 	return nil
 }
@@ -669,7 +669,7 @@ func (b *backend) stopVM(ctx context.Context, name string) error {
 func (b *backend) deleteVM(ctx context.Context, name string) error {
 	result, err := b.tart(ctx, []string{"delete", name}, nil, b.rt.Stderr)
 	if err != nil {
-		return commandError("tart delete", result, err)
+		return shared.LocalCommandError("tart delete", result, err)
 	}
 	return nil
 }
@@ -677,7 +677,7 @@ func (b *backend) deleteVM(ctx context.Context, name string) error {
 func (b *backend) listInstances(ctx context.Context) ([]tartInstance, error) {
 	result, err := b.tart(ctx, []string{"list", "--source", "local", "--format", "json"}, nil, nil)
 	if err != nil {
-		return nil, commandError("tart list", result, err)
+		return nil, shared.LocalCommandError("tart list", result, err)
 	}
 	var instances []tartInstance
 	if err := json.Unmarshal([]byte(result.Stdout), &instances); err != nil {
@@ -930,21 +930,6 @@ func instanceRunning(state string) bool {
 
 func tartState(state string) string {
 	return strings.ToLower(strings.TrimSpace(state))
-}
-
-func commandError(action string, result LocalCommandResult, err error) error {
-	code := result.ExitCode
-	if code == 0 {
-		code = 1
-	}
-	detail := strings.TrimSpace(result.Stderr)
-	if detail == "" {
-		detail = strings.TrimSpace(result.Stdout)
-	}
-	if detail != "" {
-		return exit(code, "%s failed: %v: %s", action, err, detail)
-	}
-	return exit(code, "%s failed: %v", action, err)
 }
 
 func firstLine(value string) string {

--- a/internal/providers/tart/provider_test.go
+++ b/internal/providers/tart/provider_test.go
@@ -2146,34 +2146,6 @@ func TestFirstNonBlank(t *testing.T) {
 	}
 }
 
-func TestCommandError(t *testing.T) {
-	err := commandError("tart stop", core.LocalCommandResult{ExitCode: 1, Stderr: "VM not running"}, fmt.Errorf("exit status 1"))
-	if !strings.Contains(err.Error(), "VM not running") {
-		t.Fatalf("commandError should include stderr: %v", err)
-	}
-	if !strings.Contains(err.Error(), "tart stop") {
-		t.Fatalf("commandError should include action: %v", err)
-	}
-}
-
-func TestCommandErrorFallsBackToStdout(t *testing.T) {
-	err := commandError("tart stop", core.LocalCommandResult{ExitCode: 1, Stdout: "some output"}, fmt.Errorf("exit status 1"))
-	if !strings.Contains(err.Error(), "some output") {
-		t.Fatalf("commandError should fall back to stdout: %v", err)
-	}
-}
-
-func TestCommandErrorMinimalExitCode(t *testing.T) {
-	err := commandError("tart stop", core.LocalCommandResult{ExitCode: 0}, fmt.Errorf("exit status 1"))
-	var exitErr core.ExitError
-	if !core.AsExitError(err, &exitErr) {
-		t.Fatalf("expected ExitError, got %T", err)
-	}
-	if exitErr.Code != 1 {
-		t.Fatalf("exit code = %d, want 1 (minimum)", exitErr.Code)
-	}
-}
-
 func TestIsTartProviderName(t *testing.T) {
 	selected := func(name string) bool {
 		cfg := core.BaseConfig()
@@ -3327,60 +3299,6 @@ func TestInjectSSHKeyExecError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "ssh key injection") {
 		t.Fatalf("error should mention ssh key injection: %v", err)
-	}
-}
-
-func TestCommandErrorWithStderr(t *testing.T) {
-	result := core.LocalCommandResult{ExitCode: 5, Stderr: "some detail\n"}
-	err := commandError("test-action", result, fmt.Errorf("wrapped"))
-	if err == nil {
-		t.Fatal("commandError should return non-nil")
-	}
-	msg := err.Error()
-	if !strings.Contains(msg, "test-action failed") {
-		t.Fatalf("should mention action: %s", msg)
-	}
-	if !strings.Contains(msg, "some detail") {
-		t.Fatalf("should include stderr detail: %s", msg)
-	}
-}
-
-func TestCommandErrorWithStdoutFallback(t *testing.T) {
-	result := core.LocalCommandResult{ExitCode: 0, Stderr: "", Stdout: "stdout detail\n"}
-	err := commandError("test-action", result, fmt.Errorf("wrapped"))
-	if err == nil {
-		t.Fatal("commandError should return non-nil")
-	}
-	msg := err.Error()
-	if !strings.Contains(msg, "stdout detail") {
-		t.Fatalf("should fallback to stdout: %s", msg)
-	}
-}
-
-func TestCommandErrorNoDetail(t *testing.T) {
-	result := core.LocalCommandResult{ExitCode: 0, Stderr: "", Stdout: ""}
-	err := commandError("test-action", result, fmt.Errorf("original"))
-	if err == nil {
-		t.Fatal("commandError should return non-nil")
-	}
-	msg := err.Error()
-	if !strings.Contains(msg, "test-action failed") {
-		t.Fatalf("should mention action: %s", msg)
-	}
-	if !strings.Contains(msg, "original") {
-		t.Fatalf("should include original error: %s", msg)
-	}
-}
-
-func TestCommandErrorZeroExitCodeBecomesOne(t *testing.T) {
-	result := core.LocalCommandResult{ExitCode: 0}
-	err := commandError("action", result, fmt.Errorf("err"))
-	var exitErr core.ExitError
-	if !core.AsExitError(err, &exitErr) {
-		t.Fatalf("expected ExitError, got %T", err)
-	}
-	if exitErr.Code == 0 {
-		t.Fatal("exit code 0 should become non-zero")
 	}
 }
 


### PR DESCRIPTION
Six local VM/container adapters independently constructed the same command failure: preserve a nonzero exit code, turn zero into one, and report trimmed stderr before stdout. Centralize that rule in `shared.LocalCommandError` and remove the duplicate implementations.

Hyper-V, Multipass, Tart, Lume, local-container, and Apple Container use the shared owner. Execution, redaction, retries, and provider-specific diagnostics remain local. Adapters with different exit-code behavior are unchanged. Generic formatting tests move from Tart into the shared contract and cover signed exit codes, output precedence, and nil causes. No public behavior or configuration changes.

Validation: full suites pass for all six adapters and the shared package. The shared contract tests pass, and Tart compiles after the test move. Autoreview completed with no accepted/actionable findings.
