### PR TITLE
refactor(providers): share endpoint address canonicalization

### DIFF
--- a/internal/providers/shared/claim_scope.go
+++ b/internal/providers/shared/claim_scope.go
@@ -1,7 +1,6 @@
 package shared
 
 import (
-	"net"
 	"net/url"
 	"strings"
 
@@ -20,19 +19,5 @@ func NormalizedSandboxClaimEndpoint(raw string) string {
 	parsed.ForceQuery = false
 	parsed.Fragment = ""
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
-	host := strings.ToLower(parsed.Hostname())
-	port := parsed.Port()
-	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
-		port = ""
-	}
-	if port != "" {
-		parsed.Host = net.JoinHostPort(host, port)
-	} else if strings.Contains(host, ":") {
-		parsed.Host = "[" + host + "]"
-	} else {
-		parsed.Host = host
-	}
-	parsed.Path = strings.TrimRight(parsed.Path, "/")
-	parsed.RawPath = ""
-	return strings.TrimRight(parsed.String(), "/")
+	return canonicalEndpointAddress(parsed)
 }

--- a/internal/providers/shared/network.go
+++ b/internal/providers/shared/network.go
@@ -24,6 +24,12 @@ func NormalizeHTTPSURL(raw string, errs EndpointURLErrors) (string, error) {
 	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && IsLoopbackHost(parsed.Hostname())) {
 		return "", errs.Insecure
 	}
+	return canonicalEndpointAddress(parsed), nil
+}
+
+// Callers own scheme admission and URL-component policy before canonicalizing
+// the lowercased scheme's address. Claim keys and live endpoints differ there.
+func canonicalEndpointAddress(parsed *url.URL) string {
 	host := strings.ToLower(parsed.Hostname())
 	port := parsed.Port()
 	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
@@ -38,7 +44,7 @@ func NormalizeHTTPSURL(raw string, errs EndpointURLErrors) (string, error) {
 	}
 	parsed.Path = strings.TrimRight(parsed.Path, "/")
 	parsed.RawPath = ""
-	return strings.TrimRight(parsed.String(), "/"), nil
+	return strings.TrimRight(parsed.String(), "/")
 }
 
 func IsLoopbackHost(host string) bool {

--- a/internal/providers/shared/network_test.go
+++ b/internal/providers/shared/network_test.go
@@ -1,0 +1,53 @@
+package shared
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestEndpointAddressCanonicalization(t *testing.T) {
+	for _, tt := range []struct{ input, want string }{
+		{" https://EXAMPLE.com:443/api/// ", "https://example.com/api"},
+		{"http://LOCALHOST:80/work/", "http://localhost/work"},
+		{"http://[::1]:80/", "http://[::1]"},
+		{"https://[2001:DB8::1]:443/api/", "https://[2001:db8::1]/api"},
+		{"https://EXAMPLE.com:8443/a%2Fb/", "https://example.com:8443/a/b"},
+	} {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := NormalizeHTTPSURL(tt.input, endpointTestErrors())
+			if err != nil || got != tt.want {
+				t.Fatalf("endpoint=(%q, %v), want %q", got, err, tt.want)
+			}
+			if got := NormalizedSandboxClaimEndpoint(tt.input); got != tt.want {
+				t.Fatalf("claim endpoint=%q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEndpointAdmissionRemainsSeparateFromClaimIdentity(t *testing.T) {
+	errs := endpointTestErrors()
+	for _, tt := range []struct {
+		input, claim string
+		err          error
+	}{
+		{"https://alice:password@EXAMPLE.com:443/api/?key=value#section", "https://example.com/api", errs.Components},
+		{"https://example.com/api?", "https://example.com/api", errs.Components},
+		{"http://example.com:80/api/", "http://example.com/api", errs.Insecure},
+		{"ftp://EXAMPLE.com:21/api/", "ftp://example.com:21/api", errs.Insecure},
+		{"local-path///", "local-path", errs.Invalid},
+	} {
+		t.Run(tt.input, func(t *testing.T) {
+			if _, err := NormalizeHTTPSURL(tt.input, errs); err != tt.err {
+				t.Fatalf("admission error=%v, want %v", err, tt.err)
+			}
+			if got := NormalizedSandboxClaimEndpoint(tt.input); got != tt.claim {
+				t.Fatalf("claim endpoint=%q, want %q", got, tt.claim)
+			}
+		})
+	}
+}
+
+func endpointTestErrors() EndpointURLErrors {
+	return EndpointURLErrors{Invalid: errors.New("invalid URL"), Components: errors.New("URL components"), Insecure: errors.New("insecure URL")}
+}


### PR DESCRIPTION
Live HTTP endpoints and stored sandbox claim identities duplicated hostname, default-port, IPv6, and path canonicalization. Give those address rules one private shared owner.

Admission remains separate: live endpoints reject credentials/query/fragment components and insecure non-loopback HTTP, while legacy claim identity strips components and retains its existing fallback handling. Scheme policy and error precedence are unchanged.

Validation: the shared package and full E2B, CubeSandbox, Islo, Freestyle, and Cloud Run Sandbox suites pass. Added coverage for common canonical addresses and the deliberate admission/claim differences, including IPv6, default ports, escaped paths, query markers, and legacy inputs. Autoreview completed with no accepted/actionable findings.
