### PR TITLE
refactor(providers): share raw tag set normalization

### DIFF
--- a/internal/providers/digitalocean/client.go
+++ b/internal/providers/digitalocean/client.go
@@ -703,7 +703,7 @@ func (c *digitalOceanClient) resolveCreateTagConflict(ctx context.Context, tags 
 		}
 		canonical = append(canonical, name)
 	}
-	return normalizeTags(canonical), leaseTag, changed, nil
+	return shared.NormalizeTags(canonical), leaseTag, changed, nil
 }
 
 func (c *digitalOceanClient) resolveCanonicalLeaseTag(ctx context.Context, leaseID string) (string, error) {
@@ -790,8 +790,8 @@ func (c *digitalOceanClient) EnsureTag(ctx context.Context, tag string, known ma
 }
 
 func (c *digitalOceanClient) ReplaceDropletTags(ctx context.Context, id int64, currentTags, desiredTags []string) error {
-	currentTags = normalizeTags(currentTags)
-	desiredTags = normalizeTags(desiredTags)
+	currentTags = shared.NormalizeTags(currentTags)
+	desiredTags = shared.NormalizeTags(desiredTags)
 	current := make(map[string]bool, len(currentTags))
 	for _, tag := range currentTags {
 		current[strings.ToLower(tag)] = true

--- a/internal/providers/digitalocean/tags.go
+++ b/internal/providers/digitalocean/tags.go
@@ -2,7 +2,6 @@ package digitalocean
 
 import (
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -38,7 +37,7 @@ func leaseTags(cfg core.Config, leaseID, slug, state string, keep bool, now time
 			tags = append(tags, encodeTagKV(key, value))
 		}
 	}
-	return normalizeTags(tags)
+	return shared.NormalizeTags(tags)
 }
 
 func tagsFromLabels(labels map[string]string) []string {
@@ -52,7 +51,7 @@ func tagsFromLabels(labels map[string]string) []string {
 			tags = append(tags, encodeTagKV(key, value))
 		}
 	}
-	return normalizeTags(tags)
+	return shared.NormalizeTags(tags)
 }
 
 func encodeTagKV(key, value string) string {
@@ -89,21 +88,6 @@ func legacyEncodedExactTagValueKey(key string) bool {
 	default:
 		return false
 	}
-}
-
-func normalizeTags(tags []string) []string {
-	seen := map[string]bool{}
-	out := make([]string, 0, len(tags))
-	for _, tag := range tags {
-		tag = strings.TrimSpace(tag)
-		if tag == "" || seen[tag] {
-			continue
-		}
-		seen[tag] = true
-		out = append(out, tag)
-	}
-	sort.Strings(out)
-	return out
 }
 
 func labelsFromTags(tags []string) map[string]string {

--- a/internal/providers/linode/tags.go
+++ b/internal/providers/linode/tags.go
@@ -3,7 +3,6 @@ package linode
 import (
 	"fmt"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -46,7 +45,7 @@ func tagsFromLabels(labels map[string]string) []string {
 			tags = append(tags, encodeTagKV(key, value)...)
 		}
 	}
-	return normalizeTags(tags)
+	return shared.NormalizeTags(tags)
 }
 
 func encodeTagKV(key, value string) []string {
@@ -117,21 +116,6 @@ func legacyEncodedExactTagValueKey(key string) bool {
 	default:
 		return false
 	}
-}
-
-func normalizeTags(tags []string) []string {
-	seen := map[string]bool{}
-	out := make([]string, 0, len(tags))
-	for _, tag := range tags {
-		tag = strings.TrimSpace(tag)
-		if tag == "" || seen[tag] {
-			continue
-		}
-		seen[tag] = true
-		out = append(out, tag)
-	}
-	sort.Strings(out)
-	return out
 }
 
 type tagChunkSet struct {
@@ -242,7 +226,7 @@ func replaceCrabboxTags(existing, desired []string) []string {
 		}
 		tags = append(tags, tag)
 	}
-	return normalizeTags(tags)
+	return shared.NormalizeTags(tags)
 }
 
 func isOwnedLinode(item linodeInstance) bool {

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -1174,7 +1174,7 @@ func replaceCrabboxTags(existing, desired []string) []string {
 		}
 		tags = append(tags, tag)
 	}
-	return normalizeTags(tags)
+	return shared.NormalizeTags(tags)
 }
 
 func publicIPv4(item *instance.Server) string {

--- a/internal/providers/scaleway/tags.go
+++ b/internal/providers/scaleway/tags.go
@@ -38,7 +38,7 @@ func tagsFromLabels(labels map[string]string) []string {
 			tags = append(tags, encodeTagKV(key, value))
 		}
 	}
-	return normalizeTags(tags)
+	return shared.NormalizeTags(tags)
 }
 
 func tagLabelKeys() []string {
@@ -86,21 +86,6 @@ func exactTagValueKey(key string) bool {
 func versionedExactTagValueKey(key string) (string, bool) {
 	logical := strings.TrimSuffix(key, "_v1")
 	return logical, logical != key && exactTagValueKey(logical)
-}
-
-func normalizeTags(tags []string) []string {
-	seen := map[string]bool{}
-	out := make([]string, 0, len(tags))
-	for _, tag := range tags {
-		tag = strings.TrimSpace(tag)
-		if tag == "" || seen[tag] {
-			continue
-		}
-		seen[tag] = true
-		out = append(out, tag)
-	}
-	sort.Strings(out)
-	return out
 }
 
 func labelsFromTags(tags []string) map[string]string {

--- a/internal/providers/shared/tag_labels.go
+++ b/internal/providers/shared/tag_labels.go
@@ -6,6 +6,23 @@ import (
 	"strings"
 )
 
+// NormalizeTags returns a sorted, case-sensitive set of trimmed nonempty tags.
+// It does not validate wire formats or interpret ownership metadata.
+func NormalizeTags(tags []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		tag = strings.TrimSpace(tag)
+		if tag == "" || seen[tag] {
+			continue
+		}
+		seen[tag] = true
+		out = append(out, tag)
+	}
+	sort.Strings(out)
+	return out
+}
+
 type tagMerge uint8
 
 const (

--- a/internal/providers/shared/tag_set_test.go
+++ b/internal/providers/shared/tag_set_test.go
@@ -1,0 +1,34 @@
+package shared
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestNormalizeTags(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		tags []string
+		want []string
+	}{
+		{"nil", nil, []string{}},
+		{"empty", []string{}, []string{}},
+		{"blank", []string{"", " \t\n", "\u2003"}, []string{}},
+		{"set", []string{" z ", "a", "z", " A", "\na\t", "a:b", "a:b"}, []string{"A", "a", "a:b", "z"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			original := slices.Clone(tt.tags)
+			got := NormalizeTags(tt.tags)
+			if !reflect.DeepEqual(got, tt.want) || !reflect.DeepEqual(tt.tags, original) {
+				t.Fatalf("tags=%q result=%q, want unchanged input and %q", tt.tags, got, tt.want)
+			}
+			if len(got) > 0 {
+				got[0] = "changed"
+				if !reflect.DeepEqual(tt.tags, original) {
+					t.Fatal("normalized tags alias the caller's slice")
+				}
+			}
+		})
+	}
+}

--- a/internal/providers/vultr/client.go
+++ b/internal/providers/vultr/client.go
@@ -579,7 +579,7 @@ func (c *vultrClient) DeleteSSHKey(ctx context.Context, id string) error {
 }
 
 func (c *vultrClient) UpdateInstanceTags(ctx context.Context, id string, tags []string) error {
-	body := map[string]any{"tags": normalizeTags(tags)}
+	body := map[string]any{"tags": shared.NormalizeTags(tags)}
 	return c.do(ctx, http.MethodPatch, "/instances/"+url.PathEscape(id), body, nil)
 }
 

--- a/internal/providers/vultr/tags.go
+++ b/internal/providers/vultr/tags.go
@@ -2,7 +2,6 @@ package vultr
 
 import (
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -36,7 +35,7 @@ func leaseTags(cfg core.Config, leaseID, slug, state string, keep bool, now time
 			tags = append(tags, encodeTagKV(key, value))
 		}
 	}
-	return normalizeTags(tags)
+	return shared.NormalizeTags(tags)
 }
 
 func tagsFromLabels(labels map[string]string) []string {
@@ -50,7 +49,7 @@ func tagsFromLabels(labels map[string]string) []string {
 			tags = append(tags, encodeTagKV(key, value))
 		}
 	}
-	return normalizeTags(tags)
+	return shared.NormalizeTags(tags)
 }
 
 func encodeTagKV(key, value string) string {
@@ -68,21 +67,6 @@ func sanitizeTagPart(value string) string {
 		return value[:64]
 	}
 	return value
-}
-
-func normalizeTags(tags []string) []string {
-	seen := map[string]bool{}
-	out := make([]string, 0, len(tags))
-	for _, tag := range tags {
-		tag = strings.TrimSpace(tag)
-		if tag == "" || seen[tag] {
-			continue
-		}
-		seen[tag] = true
-		out = append(out, tag)
-	}
-	sort.Strings(out)
-	return out
 }
 
 func labelsFromTags(tags []string) map[string]string {


### PR DESCRIPTION
DigitalOcean, Linode, Scaleway, and Vultr repeated the same raw tag-set normalization. Share trimming, case-sensitive deduplication, and sorting through `shared.NormalizeTags`.

The helper preserves non-nil empty results and does not mutate or alias the input slice. Provider tag encoding, length limits, ownership conflict handling, and metadata merge policy stay in their adapters.

Validation: full suites pass for the shared package and all four providers. Focused tests cover empty/blank input, case distinctions, duplicates, whitespace, ordering, and slice independence. Autoreview completed with no accepted/actionable findings.
