### PR TITLE
refactor(worker): share lease lifecycle state predicates

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,6 +162,10 @@ One logical `FleetCoordinator` (`worker/src/fleet.ts`) owns:
   `cost_limit_exceeded`. Cost = hourly rate × TTL, where the rate comes from a
   `CRABBOX_COST_RATES_JSON` override, then a provider live price, then built-in
   defaults.
+  Shared predicates in `worker/src/lease-state.ts` keep accounting, host
+  reservations, and lifecycle handling aligned: active/provisioning rows remain
+  live until a terminal transition, even after a heartbeat deadline, and
+  registered inventory stays outside managed usage.
 - **Usage accounting** — `usageSummary` aggregates leases per
   owner/org/provider/server type for the month; served at `GET /v1/usage`.
 - **Cleanup and expiry** — runtime alarms/jobs and reconciliation run maintenance:

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -24,6 +24,7 @@ import {
   validateProvisioningRecord,
   type LeaseProvisioningOperation,
 } from "./lease-provisioning";
+import { isRegisteredLease, leaseIsLive } from "./lease-state";
 import type { ProviderResumableProvisioning } from "./provider-provisioning";
 import { ProvisioningAttemptHistory } from "./provisioning-attempts";
 import {
@@ -25382,10 +25383,6 @@ function pinnedHostConflict(config: LeaseConfig, leases: LeaseRecord[]): Respons
   );
 }
 
-function leaseIsLive(lease: LeaseRecord): boolean {
-  return lease.state === "active" || lease.state === "provisioning";
-}
-
 function leaseHeartbeatStateError(
   lease: LeaseRecord,
   now = Date.now(),
@@ -25398,10 +25395,6 @@ function leaseHeartbeatStateError(
     return "lease_expired";
   }
   return undefined;
-}
-
-function isRegisteredLease(lease: LeaseRecord): boolean {
-  return lease.lifecycle === "registered";
 }
 
 function managedLeaseProvider(lease: LeaseRecord): Provider | undefined {

--- a/worker/src/host-reservations.ts
+++ b/worker/src/host-reservations.ts
@@ -1,5 +1,6 @@
 import type { CoordinatorStorageView } from "./coordinator-runtime";
 import { leaseProviderCleanupConfirmed } from "./lease-cleanup";
+import { leaseIsLive } from "./lease-state";
 import { publicLeaseRecord } from "./org-records";
 import type { LeaseRecord, Provider } from "./types";
 
@@ -36,7 +37,7 @@ export function hostReservationStaleReason(
   if (!lease) return "lease_missing";
   if (!matchesHost(lease, scope)) return "host_changed";
   // A create owns its host before a provider instance ID has been committed.
-  if (lease.state === "active" || lease.state === "provisioning") return undefined;
+  if (leaseIsLive(lease)) return undefined;
   if (leaseProviderCleanupConfirmed(lease)) return "cleanup_complete";
   if (
     lease.state === "expired" &&

--- a/worker/src/lease-state.ts
+++ b/worker/src/lease-state.ts
@@ -1,0 +1,12 @@
+import type { LeaseRecord } from "./types";
+
+// An elapsed heartbeat deadline does not terminalize a lease or free capacity.
+// The owning lifecycle transition must commit a terminal state first.
+export function leaseIsLive(lease: Pick<LeaseRecord, "state">): boolean {
+  return lease.state === "active" || lease.state === "provisioning";
+}
+
+// Legacy rows without a lifecycle field keep their managed interpretation.
+export function isRegisteredLease(lease: Pick<LeaseRecord, "lifecycle">): boolean {
+  return lease.lifecycle === "registered";
+}

--- a/worker/src/usage.ts
+++ b/worker/src/usage.ts
@@ -1,3 +1,4 @@
+import { isRegisteredLease, leaseIsLive } from "./lease-state";
 import { orgLabelForDisplay, orgMatchesForAccounting, orgMatchesForFilter } from "./org-identity";
 import type { Env, LeaseRecord, Provider } from "./types";
 
@@ -158,12 +159,12 @@ export function addLeaseToCostLimitUsage(
   lease: LeaseRecord,
   now: Date,
 ): void {
-  if (!isManagedLease(lease)) {
+  if (isRegisteredLease(lease)) {
     return;
   }
   // A live record still owns provider capacity after its heartbeat deadline
   // until cleanup commits a terminal state.
-  if (isLiveLease(lease)) {
+  if (leaseIsLive(lease)) {
     usage.activeLeases += 1;
     if (lease.owner === usage.owner) {
       usage.ownerActiveLeases += 1;
@@ -174,7 +175,7 @@ export function addLeaseToCostLimitUsage(
   }
   // A live lease still reserves provider spend in the active budget window,
   // even when its creation month has rolled over.
-  if (!isLiveLease(lease) && monthKey(new Date(lease.createdAt)) !== usage.month) {
+  if (!leaseIsLive(lease) && monthKey(new Date(lease.createdAt)) !== usage.month) {
     return;
   }
   const reservedUSD = leaseUsage(lease, now).reservedUSD;
@@ -222,7 +223,7 @@ export function enforceCostLimitUsage(
 
 export function usageSummary(leases: LeaseRecord[], filter: UsageFilter, now: Date): UsageSummary {
   const selected = leases.filter(
-    (lease) => isManagedLease(lease) && leaseMatchesUsageFilter(lease, filter),
+    (lease) => !isRegisteredLease(lease) && leaseMatchesUsageFilter(lease, filter),
   );
   const total = newAccumulator();
   const byOwner = new Map<string, UsageAccumulator>();
@@ -314,24 +315,16 @@ function leaseMatchesUsageFilter(lease: LeaseRecord, filter: UsageFilter): boole
 function leaseUsage(lease: LeaseRecord, now: Date): UsageAccumulator {
   const created = parseTime(lease.createdAt, now);
   const ended = parseTime(lease.endedAt || lease.releasedAt || "", now);
-  const stop = isLiveLease(lease) ? now : ended;
+  const stop = leaseIsLive(lease) ? now : ended;
   const runtimeSeconds = Math.max(0, Math.trunc((stop.getTime() - created.getTime()) / 1000));
   const estimatedUSD = roundUSD((runtimeSeconds / 3600) * (lease.estimatedHourlyUSD || 0));
   return {
     leases: 1,
-    activeLeases: isLiveLease(lease) ? 1 : 0,
+    activeLeases: leaseIsLive(lease) ? 1 : 0,
     runtimeSeconds,
     estimatedUSD,
     reservedUSD: roundUSD(lease.maxEstimatedUSD || estimatedUSD),
   };
-}
-
-function isLiveLease(lease: LeaseRecord): boolean {
-  return lease.state === "active" || lease.state === "provisioning";
-}
-
-function isManagedLease(lease: LeaseRecord): boolean {
-  return lease.lifecycle !== "registered";
 }
 
 function mapAccumulator(map: Map<string, UsageAccumulator>, key: string): UsageAccumulator {


### PR DESCRIPTION
Coordinator lifecycle handling, host reservations, and usage accounting duplicated the meaning of a live lease and registered inventory. Share those predicates through a neutral `lease-state` module.

Active/provisioning records remain live until a terminal transition commits, even after their heartbeat deadline. Registered inventory remains excluded from managed usage; legacy rows without an explicit lifecycle keep their managed interpretation. No lease states, accounting rules, or API behavior change.

Validation: all 3,148 existing Worker tests pass (15 skips), including coverage for expired live records retaining capacity and registered inventory exclusion. Worker and Node typechecks/builds, formatting, lint, and Autoreview pass.
