### PR TITLE
refactor(applevm): share diagnostic log tail reader

### DIFF
--- a/internal/applevmhelper/cli_darwin_arm64.go
+++ b/internal/applevmhelper/cli_darwin_arm64.go
@@ -427,7 +427,7 @@ func startupDiagnostics(stateRoot, name string) error {
 		{label: HelperLogFileName, path: HelperLogPath(stateRoot, name)},
 		{label: ConsoleLogFileName, path: ConsoleLogPath(stateRoot, name)},
 	} {
-		data, err := readTail(log.path, 8*1024)
+		data, err := ReadDiagnosticTail(log.path, 8*1024)
 		if err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
 				parts = append(parts, fmt.Sprintf("%s unavailable: %v", log.label, err))
@@ -442,30 +442,6 @@ func startupDiagnostics(stateRoot, name string) error {
 		return nil
 	}
 	return fmt.Errorf("startup diagnostics for %s:\n%s", name, strings.Join(parts, "\n"))
-}
-
-func readTail(path string, limit int64) (string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-	info, err := file.Stat()
-	if err != nil {
-		return "", err
-	}
-	offset := info.Size() - limit
-	if offset < 0 {
-		offset = 0
-	}
-	if _, err := file.Seek(offset, io.SeekStart); err != nil {
-		return "", err
-	}
-	data, err := io.ReadAll(io.LimitReader(file, limit))
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(data)), nil
 }
 
 func cleanupStartedHelper(ctx context.Context, inst Instance, instanceRoot string) error {

--- a/internal/applevmhelper/diagnostics.go
+++ b/internal/applevmhelper/diagnostics.go
@@ -1,0 +1,33 @@
+package applevmhelper
+
+import (
+	"io"
+	"os"
+	"strings"
+)
+
+// ReadDiagnosticTail reads a byte-bounded file tail and trims its surrounding
+// whitespace. Callers retain diagnostic labels, error handling, and redaction.
+func ReadDiagnosticTail(path string, limit int64) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return "", err
+	}
+	offset := info.Size() - limit
+	if offset < 0 {
+		offset = 0
+	}
+	if _, err := file.Seek(offset, io.SeekStart); err != nil {
+		return "", err
+	}
+	data, err := io.ReadAll(io.LimitReader(file, limit))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}

--- a/internal/applevmhelper/diagnostics_test.go
+++ b/internal/applevmhelper/diagnostics_test.go
@@ -1,0 +1,42 @@
+package applevmhelper
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadDiagnosticTail(t *testing.T) {
+	for _, tt := range []struct {
+		name, contents string
+		limit          int64
+		want           string
+	}{
+		{"empty", "", 8, ""},
+		{"whole file", " message\n", 100, "message"},
+		{"bounded tail", "prefix-tail", 4, "tail"},
+		{"trim after bounding", "prefix end \n", 5, "end"},
+		{"raw bytes", "\xfe\xffx", 2, "\xffx"},
+		{"zero limit", "message", 0, ""},
+		{"negative limit", "message", -1, ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "diagnostic.log")
+			if err := os.WriteFile(path, []byte(tt.contents), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			got, err := ReadDiagnosticTail(path, tt.limit)
+			if err != nil || got != tt.want {
+				t.Fatalf("tail=(%q, %v), want %q", got, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadDiagnosticTailPreservesFileError(t *testing.T) {
+	_, err := ReadDiagnosticTail(filepath.Join(t.TempDir(), "missing.log"), 100)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("missing file error=%v", err)
+	}
+}

--- a/internal/providers/applevm/backend.go
+++ b/internal/providers/applevm/backend.go
@@ -606,7 +606,7 @@ func instanceDiagnostics(stateRoot, name string) error {
 		{label: applevmhelper.HelperLogFileName, path: applevmhelper.HelperLogPath(stateRoot, name)},
 		{label: applevmhelper.ConsoleLogFileName, path: applevmhelper.ConsoleLogPath(stateRoot, name)},
 	} {
-		tail, err := readFileTail(log.path, diagnosticTailBytes)
+		tail, err := applevmhelper.ReadDiagnosticTail(log.path, diagnosticTailBytes)
 		if err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
 				parts = append(parts, fmt.Sprintf("%s unavailable: %v", log.label, err))
@@ -621,30 +621,6 @@ func instanceDiagnostics(stateRoot, name string) error {
 		return nil
 	}
 	return fmt.Errorf("apple-vm diagnostics for %s:\n%s", name, strings.Join(parts, "\n"))
-}
-
-func readFileTail(path string, limit int64) (string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-	info, err := file.Stat()
-	if err != nil {
-		return "", err
-	}
-	offset := info.Size() - limit
-	if offset < 0 {
-		offset = 0
-	}
-	if _, err := file.Seek(offset, io.SeekStart); err != nil {
-		return "", err
-	}
-	data, err := io.ReadAll(io.LimitReader(file, limit))
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(data)), nil
 }
 
 func (b *backend) deleteInstance(ctx context.Context, cfg core.Config, name string) error {


### PR DESCRIPTION
The Apple VM provider and helper executable independently read bounded diagnostic log tails. Move that reader into the helper's common package and call it from both diagnostic paths.

Byte limits, whitespace trimming, raw byte preservation, file errors, diagnostic labels, and caller-owned redaction remain unchanged. The reader is now covered on every platform instead of living partly behind the Darwin/ARM64 build tag.

Validation: the full Apple VM helper and provider suites pass. New filesystem tests cover bounded tails, trimming, empty/nonpositive limits, raw bytes, and missing-file error identity. Autoreview completed with no accepted/actionable findings.
