### PR TITLE
refactor(providers): share hostname case folding

### DIFF
--- a/internal/providers/blaxel/client.go
+++ b/internal/providers/blaxel/client.go
@@ -163,7 +163,7 @@ func ValidateAPIURL(raw string) (string, error) {
 	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
 		return "", exit(2, "provider=blaxel API URL must use HTTPS except for loopback development endpoints")
 	}
-	host := canonicalHostname(parsed.Hostname())
+	host := shared.LowercaseHostname(parsed.Hostname())
 	port := parsed.Port()
 	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
 		port = ""
@@ -194,7 +194,7 @@ func validateSandboxEndpoint(raw, managementBase string) (string, error) {
 		return "", exit(5, "blaxel sandbox metadata.url must not contain userinfo, query parameters, or a fragment")
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
-	host := canonicalHostname(parsed.Hostname())
+	host := shared.LowercaseHostname(parsed.Hostname())
 	if parsed.Scheme == "http" {
 		management, _ := url.Parse(managementBase)
 		if management == nil || !isLoopbackHost(management.Hostname()) || !isLoopbackHost(host) {
@@ -223,7 +223,7 @@ func validateSandboxEndpoint(raw, managementBase string) (string, error) {
 }
 
 func isBlaxelDataPlaneHost(host string) bool {
-	host = strings.TrimSuffix(canonicalHostname(host), ".")
+	host = strings.TrimSuffix(shared.LowercaseHostname(host), ".")
 	return host == "bl.run" ||
 		strings.HasSuffix(host, ".bl.run") ||
 		host == "blaxel.ai" ||
@@ -248,13 +248,6 @@ func validateBlaxelConfig(cfg Config) error {
 
 func isLoopbackHost(host string) bool {
 	return shared.IsLoopbackHost(host)
-}
-
-func canonicalHostname(host string) string {
-	if zoneAt := strings.Index(host, "%"); zoneAt > 0 && strings.Contains(host[:zoneAt], ":") {
-		return strings.ToLower(host[:zoneAt]) + host[zoneAt:]
-	}
-	return strings.ToLower(host)
 }
 
 func secureHTTPClient(source *http.Client) *http.Client {

--- a/internal/providers/opencomputer/apiclient.go
+++ b/internal/providers/opencomputer/apiclient.go
@@ -132,7 +132,7 @@ func validateOCAPIURL(raw string) (string, error) {
 	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
 		return "", exit(2, "provider=opencomputer API URL must use HTTPS except for loopback development endpoints")
 	}
-	host := canonicalOCHostname(parsed.Hostname())
+	host := shared.LowercaseHostname(parsed.Hostname())
 	port := parsed.Port()
 	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
 		port = ""
@@ -151,13 +151,6 @@ func validateOCAPIURL(raw string) (string, error) {
 	parsed.Path = cleanPath
 	parsed.RawPath = ""
 	return strings.TrimRight(parsed.String(), "/"), nil
-}
-
-func canonicalOCHostname(host string) string {
-	if zoneAt := strings.Index(host, "%"); zoneAt > 0 && strings.Contains(host[:zoneAt], ":") {
-		return strings.ToLower(host[:zoneAt]) + host[zoneAt:]
-	}
-	return strings.ToLower(host)
 }
 
 func isLoopbackHost(host string) bool {

--- a/internal/providers/opensandbox/client.go
+++ b/internal/providers/opensandbox/client.go
@@ -188,7 +188,7 @@ func validateOpenSandboxAPIURL(raw string) (string, error) {
 	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
 		return "", exit(2, "provider=opensandbox API URL must use HTTPS except for loopback development endpoints")
 	}
-	host := canonicalOpenSandboxHostname(parsed.Hostname())
+	host := shared.LowercaseHostname(parsed.Hostname())
 	port := parsed.Port()
 	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
 		port = ""
@@ -206,13 +206,6 @@ func validateOpenSandboxAPIURL(raw string) (string, error) {
 	}
 	parsed.RawPath = ""
 	return strings.TrimRight(parsed.String(), "/"), nil
-}
-
-func canonicalOpenSandboxHostname(host string) string {
-	if zoneAt := strings.Index(host, "%"); zoneAt > 0 && strings.Contains(host[:zoneAt], ":") {
-		return strings.ToLower(host[:zoneAt]) + host[zoneAt:]
-	}
-	return strings.ToLower(host)
 }
 
 func isLoopbackHost(host string) bool {

--- a/internal/providers/shared/hostname_test.go
+++ b/internal/providers/shared/hostname_test.go
@@ -1,0 +1,20 @@
+package shared
+
+import "testing"
+
+func TestLowercaseHostnamePreservesZoneIdentity(t *testing.T) {
+	for _, tt := range []struct{ input, want string }{
+		{"EXAMPLE.COM", "example.com"},
+		{"EXAMPLE.COM.", "example.com."},
+		{" EXAMPLE.COM ", " example.com "},
+		{"FE80::ABCD%enABC", "fe80::abcd%enABC"},
+		{"FE80:0:0::ABCD%EN0", "fe80:0:0::abcd%EN0"},
+		{"FE80::ABCD", "fe80::abcd"},
+		{"NAME%SUFFIX", "name%suffix"},
+		{"", ""},
+	} {
+		if got := LowercaseHostname(tt.input); got != tt.want {
+			t.Errorf("LowercaseHostname(%q)=%q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/providers/shared/network.go
+++ b/internal/providers/shared/network.go
@@ -12,6 +12,15 @@ type EndpointURLErrors struct {
 	Insecure   error
 }
 
+// LowercaseHostname preserves an IPv6 zone identifier's case. It does not
+// normalize IP spelling, strip a trailing dot, or trim whitespace.
+func LowercaseHostname(host string) string {
+	if zoneAt := strings.Index(host, "%"); zoneAt > 0 && strings.Contains(host[:zoneAt], ":") {
+		return strings.ToLower(host[:zoneAt]) + host[zoneAt:]
+	}
+	return strings.ToLower(host)
+}
+
 func NormalizeHTTPSURL(raw string, errs EndpointURLErrors) (string, error) {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {


### PR DESCRIPTION
Blaxel, OpenComputer, and OpenSandbox duplicated hostname case-folding that preserves case-sensitive IPv6 zone identifiers. Share that exact operation through `shared.LowercaseHostname`.

Endpoint admission, path cleanup, origin comparison, and provider-specific IP/trailing-dot normalization remain unchanged. The helper does not trim whitespace or normalize IP spelling.

Validation: the shared package and all three provider suites pass. Focused tests cover DNS names, IPv6 spelling, zone case, whitespace, trailing dots, and empty input. Autoreview completed with no accepted/actionable findings.
