### PR TITLE
refactor: use one HTTP origin comparison owner

### DIFF
--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -421,7 +421,7 @@ retryability, normalization, ownership checks, provider actions, claim updates,
 cleanup, and error wording in the adapter.
 
 Vanilla provider HTTP redirect guards should use `shared.SecureHTTPClient` and
-`shared.SameOrigin`. The shared policy compares scheme and hostname
+`core.SameHTTPOrigin`. The shared policy compares scheme and hostname
 case-insensitively, normalizes the default HTTP and HTTPS ports, preserves an
 injected redirect hook, and otherwise retains the standard 10-redirect cap.
 The adapter still builds its exact provider-specific refusal error. Keep a

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -519,7 +519,7 @@ unchanged. It does not prove that canceling a bridge stops its remote workload.
 
 Vanilla provider HTTP redirect policy also belongs in
 `internal/providers/shared`. `shared.SecureHTTPClient` clones an injected
-client, rejects destinations outside a trusted `shared.SameOrigin`, preserves
+client, rejects destinations outside a trusted `core.SameHTTPOrigin`, preserves
 an existing redirect hook, and otherwise applies the standard redirect limit.
 The adapter supplies the exact refusal error and retains any additional path,
 method, transport, previous-hop, or provider-specific origin policy locally.

--- a/internal/cli/artifacts_manifest.go
+++ b/internal/cli/artifacts_manifest.go
@@ -411,7 +411,7 @@ func downloadArtifactURL(ctx context.Context, file artifactManifestFile, outPath
 
 func artifactHTTPClient(origin *url.URL) *http.Client {
 	return redirectCheckedHTTPClient(nil, func(req *http.Request) error {
-		if !sameHTTPOrigin(origin, req.URL) {
+		if !SameHTTPOrigin(origin, req.URL) {
 			return errArtifactCrossOriginRedirect
 		}
 		return nil

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -2534,7 +2534,7 @@ func (c *CoordinatorClient) doHTTPWithHeaders(ctx context.Context, method, path 
 func (c *CoordinatorClient) secureHTTPClient() *http.Client {
 	trusted, _ := url.Parse(c.BaseURL)
 	return redirectCheckedHTTPClient(c.Client, func(req *http.Request) error {
-		if !sameHTTPOrigin(trusted, req.URL) {
+		if !SameHTTPOrigin(trusted, req.URL) {
 			return fmt.Errorf("coordinator refused cross-origin redirect to %s", req.URL.Redacted())
 		}
 		return nil

--- a/internal/cli/http_origin_test.go
+++ b/internal/cli/http_origin_test.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestSameHTTPOrigin(t *testing.T) {
+	t.Parallel()
+
+	base := parseOriginTestURL(t, "https://Example.COM/api")
+	tests := []struct {
+		name      string
+		candidate string
+		want      bool
+	}{
+		{name: "identical", candidate: "https://example.com/api", want: true},
+		{name: "default port", candidate: "HTTPS://EXAMPLE.COM:443/other", want: true},
+		{name: "other scheme", candidate: "http://example.com/api", want: false},
+		{name: "other host", candidate: "https://other.example.com/api", want: false},
+		{name: "other port", candidate: "https://example.com:8443/api", want: false},
+		{name: "userinfo ignored", candidate: "https://alice@example.com/api", want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := parseOriginTestURL(t, test.candidate)
+			if got := SameHTTPOrigin(base, candidate); got != test.want {
+				t.Fatalf("SameHTTPOrigin(%q, %q) = %v, want %v", base, candidate, got, test.want)
+			}
+		})
+	}
+	if SameHTTPOrigin(nil, base) || SameHTTPOrigin(base, nil) || SameHTTPOrigin(nil, nil) {
+		t.Fatal("SameHTTPOrigin accepted a nil URL")
+	}
+}
+
+func TestSameHTTPOriginEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{name: "http default port", a: "http://example.com", b: "HTTP://EXAMPLE.COM:80", want: true},
+		{name: "empty URLs", want: true},
+		{name: "unknown scheme", a: "custom://example.com", b: "CUSTOM://EXAMPLE.COM", want: true},
+		{name: "unknown scheme explicit port", a: "custom://example.com", b: "custom://example.com:443"},
+		{name: "zero padded port", a: "https://example.com:0443", b: "https://example.com:443"},
+		{name: "IPv6 textual difference", a: "https://[2001:db8::1]", b: "https://[2001:0db8::1]"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			a, b := parseOriginTestURL(t, test.a), parseOriginTestURL(t, test.b)
+			if got := SameHTTPOrigin(a, b); got != test.want {
+				t.Fatalf("SameHTTPOrigin(%q, %q) = %v, want %v", a, b, got, test.want)
+			}
+		})
+	}
+}
+
+func parseOriginTestURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}

--- a/internal/cli/http_redirect.go
+++ b/internal/cli/http_redirect.go
@@ -43,7 +43,9 @@ func redirectCheckedHTTPClient(source *http.Client, check func(*http.Request) er
 	return &client
 }
 
-func sameHTTPOrigin(a, b *url.URL) bool {
+// SameHTTPOrigin compares scheme, hostname, and effective port. Callers retain
+// URL admission and any redirect restrictions beyond origin equality.
+func SameHTTPOrigin(a, b *url.URL) bool {
 	return a != nil && b != nil &&
 		strings.EqualFold(a.Scheme, b.Scheme) &&
 		strings.EqualFold(a.Hostname(), b.Hostname()) &&

--- a/internal/providers/azuredynamicsessions/client.go
+++ b/internal/providers/azuredynamicsessions/client.go
@@ -462,7 +462,7 @@ func (c *azureDynamicSessionsClient) nextURL(next string) (string, error) {
 }
 
 func sameOriginURL(a, b *url.URL) bool {
-	return shared.SameOrigin(a, b)
+	return core.SameHTTPOrigin(a, b)
 }
 
 func (c *azureDynamicSessionsClient) url(path string, query url.Values) string {

--- a/internal/providers/blaxel/client.go
+++ b/internal/providers/blaxel/client.go
@@ -276,7 +276,7 @@ func secureHTTPClient(source *http.Client) *http.Client {
 }
 
 func sameOrigin(a, b *url.URL) bool {
-	return shared.SameOrigin(a, b)
+	return core.SameHTTPOrigin(a, b)
 }
 
 func (c *restClient) BaseURL() string { return c.base }

--- a/internal/providers/cloudrunsandbox/client_test.go
+++ b/internal/providers/cloudrunsandbox/client_test.go
@@ -749,16 +749,16 @@ func TestSecureHTTPClientSameOrigin(t *testing.T) {
 	t.Parallel()
 	trusted, _ := url.Parse("https://gw.example.run.app")
 	other, _ := url.Parse("https://evil.example")
-	if !shared.SameOrigin(trusted, trusted) || shared.SameOrigin(trusted, other) {
+	if !core.SameHTTPOrigin(trusted, trusted) || core.SameHTTPOrigin(trusted, other) {
 		t.Fatal("sameOrigin mismatch")
 	}
 	explicitHTTPS, _ := url.Parse("https://gw.example.run.app:443")
-	if !shared.SameOrigin(trusted, explicitHTTPS) {
+	if !core.SameHTTPOrigin(trusted, explicitHTTPS) {
 		t.Fatal("default HTTPS port mismatch")
 	}
 	httpURL, _ := url.Parse("http://127.0.0.1")
 	explicitHTTP, _ := url.Parse("http://127.0.0.1:80")
-	if !shared.SameOrigin(httpURL, explicitHTTP) {
+	if !core.SameHTTPOrigin(httpURL, explicitHTTP) {
 		t.Fatal("default HTTP port mismatch")
 	}
 	client := shared.SecureHTTPClient(http.DefaultClient, trusted, cloudRunSandboxRedirectError)

--- a/internal/providers/crownest/client.go
+++ b/internal/providers/crownest/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	core "github.com/openclaw/crabbox/internal/cli"
 	"io"
 	"net/http"
 	"net/url"
@@ -122,7 +123,7 @@ func crownestRedirectError(destination *url.URL) error {
 }
 
 func sameOrigin(a, b *url.URL) bool {
-	return shared.SameOrigin(a, b)
+	return core.SameHTTPOrigin(a, b)
 }
 
 func (c *httpClient) BaseURL() string { return c.baseURL }

--- a/internal/providers/morph/client_test.go
+++ b/internal/providers/morph/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	core "github.com/openclaw/crabbox/internal/cli"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,7 +12,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openclaw/crabbox/internal/providers/shared"
 	"github.com/openclaw/crabbox/internal/testutil"
 )
 
@@ -170,8 +170,8 @@ func TestSameMorphOrigin(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			candidate, _ := url.Parse(test.raw)
-			if got := shared.SameOrigin(trusted, candidate); got != test.want {
-				t.Fatalf("shared.SameOrigin(%q)=%v, want %v", test.raw, got, test.want)
+			if got := core.SameHTTPOrigin(trusted, candidate); got != test.want {
+				t.Fatalf("core.SameHTTPOrigin(%q)=%v, want %v", test.raw, got, test.want)
 			}
 		})
 	}

--- a/internal/providers/nomad/client.go
+++ b/internal/providers/nomad/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	core "github.com/openclaw/crabbox/internal/cli"
 	"io"
 	"net"
 	"net/http"
@@ -16,7 +17,6 @@ import (
 
 	"github.com/hashicorp/go-cleanhttp"
 	nomadapi "github.com/hashicorp/nomad/api"
-	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type Client interface {
@@ -132,7 +132,7 @@ func secureNomadHTTPClient(source *http.Client, trusted *url.URL) *http.Client {
 }
 
 func sameNomadOrigin(a, b *url.URL) bool {
-	return shared.SameOrigin(a, b)
+	return core.SameHTTPOrigin(a, b)
 }
 
 func sanitizeNomadClientError(err error) error {

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
-	"github.com/openclaw/crabbox/internal/providers/shared"
 	"github.com/openclaw/crabbox/internal/testutil"
 )
 
@@ -1517,8 +1516,8 @@ func TestSameOCOriginNormalizesDefaultPorts(t *testing.T) {
 		{a: "https://api.example.test", b: "http://api.example.test:443", want: false},
 		{a: "https://api.example.test", b: "https://other.example.test", want: false},
 	} {
-		if got := shared.SameOrigin(parse(tc.a), parse(tc.b)); got != tc.want {
-			t.Errorf("shared.SameOrigin(%q, %q)=%t want %t", tc.a, tc.b, got, tc.want)
+		if got := core.SameHTTPOrigin(parse(tc.a), parse(tc.b)); got != tc.want {
+			t.Errorf("core.SameHTTPOrigin(%q, %q)=%t want %t", tc.a, tc.b, got, tc.want)
 		}
 	}
 }

--- a/internal/providers/opensandbox/client.go
+++ b/internal/providers/opensandbox/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	core "github.com/openclaw/crabbox/internal/cli"
 	"io"
 	"net"
 	"net/http"
@@ -239,7 +240,7 @@ func secureOpenSandboxHTTPClient(source *http.Client) *http.Client {
 }
 
 func sameOpenSandboxOrigin(a, b *url.URL) bool {
-	return shared.SameOrigin(a, b)
+	return core.SameHTTPOrigin(a, b)
 }
 
 func (c *sdkOpenSandboxClient) BaseURL() string { return c.base }

--- a/internal/providers/ovh/client.go
+++ b/internal/providers/ovh/client.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
-	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 var (
@@ -267,7 +266,7 @@ func secureOVHHTTPClient(source *http.Client, trusted *url.URL) *http.Client {
 }
 
 func sameOVHOrigin(a, b *url.URL) bool {
-	return shared.SameOrigin(a, b)
+	return core.SameHTTPOrigin(a, b)
 }
 
 func sanitizeOVHClientError(err error) error {

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 
 	core "github.com/openclaw/crabbox/internal/cli"
-	"github.com/openclaw/crabbox/internal/providers/shared"
 	"github.com/openclaw/crabbox/internal/testutil"
 )
 
@@ -355,8 +354,8 @@ func TestSameRailwayOrigin(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			candidate, _ := url.Parse(test.raw)
-			if got := shared.SameOrigin(trusted, candidate); got != test.want {
-				t.Fatalf("shared.SameOrigin(%q)=%v, want %v", test.raw, got, test.want)
+			if got := core.SameHTTPOrigin(trusted, candidate); got != test.want {
+				t.Fatalf("core.SameHTTPOrigin(%q)=%v, want %v", test.raw, got, test.want)
 			}
 		})
 	}

--- a/internal/providers/scaleway/client.go
+++ b/internal/providers/scaleway/client.go
@@ -19,7 +19,6 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 
 	core "github.com/openclaw/crabbox/internal/cli"
-	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const defaultScalewayAPIURL = "https://api.scaleway.com"
@@ -280,7 +279,7 @@ func isScalewayRedirect(status int) bool {
 }
 
 func sameScalewayOrigin(a, b *url.URL) bool {
-	return shared.SameOrigin(a, b)
+	return core.SameHTTPOrigin(a, b)
 }
 
 func scalewayProfileFromSDKConfig() (*scw.Profile, error) {

--- a/internal/providers/semaphore/api.go
+++ b/internal/providers/semaphore/api.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
-	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type apiClient struct {
@@ -358,7 +357,7 @@ func (c *apiClient) apiURL(path string) (string, error) {
 }
 
 func sameOriginURL(a, b *url.URL) bool {
-	return shared.SameOrigin(a, b)
+	return core.SameHTTPOrigin(a, b)
 }
 
 func (c *apiClient) getWithHeaders(ctx context.Context, path string) ([]byte, http.Header, error) {

--- a/internal/providers/shared/httpredirect.go
+++ b/internal/providers/shared/httpredirect.go
@@ -4,30 +4,9 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
-	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-// SameOrigin reports whether two URLs share scheme, host, and effective port.
-func SameOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectivePort(a) == effectivePort(b)
-}
-
-func effectivePort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
-}
 
 // SecureHTTPClient returns a copy of source whose CheckRedirect refuses
 // redirects leaving the trusted origin, preserves source's CheckRedirect, and
@@ -37,7 +16,7 @@ func SecureHTTPClient(source *http.Client, trusted *url.URL, newError func(dest 
 	client := *source
 	originalCheckRedirect := source.CheckRedirect
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !SameOrigin(trusted, req.URL) {
+		if !core.SameHTTPOrigin(trusted, req.URL) {
 			return newError(req.URL)
 		}
 		if originalCheckRedirect != nil {

--- a/internal/providers/shared/httpredirect_test.go
+++ b/internal/providers/shared/httpredirect_test.go
@@ -46,59 +46,6 @@ func TestControlAndDataHTTPClients(t *testing.T) {
 	}
 }
 
-func TestSameOrigin(t *testing.T) {
-	t.Parallel()
-
-	base := mustParseURL(t, "https://Example.COM/api")
-	tests := []struct {
-		name      string
-		candidate string
-		want      bool
-	}{
-		{name: "identical", candidate: "https://example.com/api", want: true},
-		{name: "default port", candidate: "HTTPS://EXAMPLE.COM:443/other", want: true},
-		{name: "other scheme", candidate: "http://example.com/api", want: false},
-		{name: "other host", candidate: "https://other.example.com/api", want: false},
-		{name: "other port", candidate: "https://example.com:8443/api", want: false},
-		{name: "userinfo ignored", candidate: "https://alice@example.com/api", want: true},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			candidate := mustParseURL(t, test.candidate)
-			if got := SameOrigin(base, candidate); got != test.want {
-				t.Fatalf("SameOrigin(%q, %q) = %v, want %v", base, candidate, got, test.want)
-			}
-		})
-	}
-	if SameOrigin(nil, base) || SameOrigin(base, nil) || SameOrigin(nil, nil) {
-		t.Fatal("SameOrigin accepted a nil URL")
-	}
-}
-
-func TestSameOriginEdgeCases(t *testing.T) {
-	t.Parallel()
-
-	for _, test := range []struct {
-		name string
-		a, b string
-		want bool
-	}{
-		{name: "http default port", a: "http://example.com", b: "HTTP://EXAMPLE.COM:80", want: true},
-		{name: "empty URLs", want: true},
-		{name: "unknown scheme", a: "custom://example.com", b: "CUSTOM://EXAMPLE.COM", want: true},
-		{name: "unknown scheme explicit port", a: "custom://example.com", b: "custom://example.com:443"},
-		{name: "zero padded port", a: "https://example.com:0443", b: "https://example.com:443"},
-		{name: "IPv6 textual difference", a: "https://[2001:db8::1]", b: "https://[2001:0db8::1]"},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			a, b := mustParseURL(t, test.a), mustParseURL(t, test.b)
-			if got := SameOrigin(a, b); got != test.want {
-				t.Fatalf("SameOrigin(%q, %q) = %v, want %v", a, b, got, test.want)
-			}
-		})
-	}
-}
-
 func TestSecureHTTPClient(t *testing.T) {
 	t.Parallel()
 

--- a/internal/providers/smolvm/backend_test.go
+++ b/internal/providers/smolvm/backend_test.go
@@ -553,8 +553,8 @@ func TestSameSmolvmOrigin(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got := shared.SameOrigin(base, redirected); got != tc.want {
-				t.Fatalf("shared.SameOrigin(%q) = %v, want %v", tc.url, got, tc.want)
+			if got := core.SameHTTPOrigin(base, redirected); got != tc.want {
+				t.Fatalf("core.SameHTTPOrigin(%q) = %v, want %v", tc.url, got, tc.want)
 			}
 		})
 	}

--- a/internal/providers/unikraftcloud/client.go
+++ b/internal/providers/unikraftcloud/client.go
@@ -254,7 +254,7 @@ func isUnikraftCloudMutation(method string) bool {
 }
 
 func sameUnikraftCloudOrigin(a, b *url.URL) bool {
-	return shared.SameOrigin(a, b)
+	return core.SameHTTPOrigin(a, b)
 }
 
 type unikraftCloudRedirectError struct {


### PR DESCRIPTION
The CLI and provider library duplicated HTTP-origin comparison and default-port handling under different helper names. Use one `core.SameHTTPOrigin` owner for coordinator requests, artifact downloads, and provider redirect guards, and remove the provider-library copy.

Nil handling, case-folding, explicit/default ports, and URL comparison behavior remain unchanged. Clients retain their redirect callbacks, limits, error messages, and stricter provider-specific restrictions. Generic comparison tests move to core; provider transport tests keep exercising their real guard paths.

Validation: core redirect/origin tests and the full shared plus 14 affected provider suites pass. Existing vectors include nil URLs, default ports, unknown schemes, zero-padded ports, and IPv6 textual differences. Autoreview completed with no accepted/actionable findings.
