### PR TITLE
refactor(providers): share SSH proxy literal encoding

### DIFF
--- a/internal/providers/namespaceinstance/backend.go
+++ b/internal/providers/namespaceinstance/backend.go
@@ -1002,20 +1002,9 @@ func proxyCommand(cfg core.Config, instanceID string) string {
 	}
 	words = append(words, instanceID)
 	for i := range words {
-		words[i] = quoteProxyWord(words[i])
+		words[i] = shared.QuoteSSHProxyCommandWord(words[i])
 	}
 	return strings.Join(words, " ")
-}
-
-func quoteProxyWord(word string) string {
-	word = strings.ReplaceAll(word, "%", "%%")
-	if word != "" && strings.IndexFunc(word, func(r rune) bool {
-		return !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') ||
-			strings.ContainsRune("_-./:,@%+=", r))
-	}) == -1 {
-		return word
-	}
-	return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`, "$", `\$`, "`", "\\`").Replace(word) + `"`
 }
 
 func (b *backend) destroy(ctx context.Context, id string) error {

--- a/internal/providers/phala/backend.go
+++ b/internal/providers/phala/backend.go
@@ -1419,20 +1419,9 @@ func proxyCommand(cfg core.Config, cvmID, gatewayHost string) string {
 	}
 	words = append(words, cvmID)
 	for i := range words {
-		words[i] = quoteProxyWord(words[i])
+		words[i] = shared.QuoteSSHProxyCommandWord(words[i])
 	}
 	return strings.Join(words, " ")
-}
-
-func quoteProxyWord(word string) string {
-	word = strings.ReplaceAll(word, "%", "%%")
-	if word != "" && strings.IndexFunc(word, func(r rune) bool {
-		return !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') ||
-			strings.ContainsRune("_-./:,@%+=", r))
-	}) == -1 {
-		return word
-	}
-	return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`, "$", `\$`, "`", "\\`").Replace(word) + `"`
 }
 
 // missingCVMResponse reports whether the phala CLI's stdout/stderr unambiguously

--- a/internal/providers/shared/ssh.go
+++ b/internal/providers/shared/ssh.go
@@ -2,9 +2,24 @@ package shared
 
 import (
 	"os"
+	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
+
+// QuoteSSHProxyCommandWord encodes a literal argument for OpenSSH's percent
+// expansion followed by POSIX shell parsing. Intentional SSH tokens stay with
+// the caller rather than passing through this literal-word encoder.
+func QuoteSSHProxyCommandWord(word string) string {
+	word = strings.ReplaceAll(word, "%", "%%")
+	if word != "" && strings.IndexFunc(word, func(r rune) bool {
+		return !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') ||
+			strings.ContainsRune("_-./:,@%+=", r))
+	}) == -1 {
+		return word
+	}
+	return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`, "$", `\$`, "`", "\\`").Replace(word) + `"`
+}
 
 func UseStoredTestboxKey(target *core.SSHTarget, leaseID string) {
 	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {

--- a/internal/providers/shared/ssh_proxy_word_test.go
+++ b/internal/providers/shared/ssh_proxy_word_test.go
@@ -1,0 +1,39 @@
+package shared
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestQuoteSSHProxyCommandWord(t *testing.T) {
+	for _, tt := range []struct{ input, want string }{
+		{"", `""`},
+		{"safe/path:22", "safe/path:22"},
+		{"%h", "%%h"},
+		{"%%", "%%%%"},
+		{"with spaces", `"with spaces"`},
+	} {
+		if got := QuoteSSHProxyCommandWord(tt.input); got != tt.want {
+			t.Errorf("quote(%q)=%q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestSSHProxyWordsRemainLiteralAfterPercentAndShellParsing(t *testing.T) {
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("POSIX shell is unavailable")
+	}
+	for _, word := range []string{"", "with spaces", "$HOME", "$(printf unexpected)", "`printf unexpected`", `a"b\c`, "it's literal", "%h-%%-%p", "a\nb"} {
+		t.Run(word, func(t *testing.T) {
+			encoded := QuoteSSHProxyCommandWord(word)
+			// OpenSSH consumes percent escapes before invoking the shell.
+			expanded := strings.NewReplacer("%%", "%", "%h", "example.invalid", "%p", "2222").Replace(encoded)
+			out, err := exec.CommandContext(t.Context(), sh, "-c", "printf '%s' "+expanded).Output()
+			if err != nil || string(out) != word {
+				t.Fatalf("round trip=(%q, %v), want %q", out, err, word)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Namespace Instance and Phala independently encoded literal SSH ProxyCommand arguments. Share the existing percent-escaping and POSIX quoting logic in `shared.QuoteSSHProxyCommandWord`.

Provider argv construction and intentional SSH placeholders remain caller-owned. The encoded command strings retain their existing behavior.

Validation: the shared package and both provider suites pass. New tests cover empty/bare/quoted words and round-trip literal spaces, quotes, backslashes, percent tokens, variable syntax, and command substitutions through percent expansion followed by a real POSIX shell. Autoreview completed with no accepted/actionable findings.
