### PR TITLE
refactor(providers): share endpoint formatting helpers

### DIFF
--- a/internal/providers/cloudflaredynamicworkers/client.go
+++ b/internal/providers/cloudflaredynamicworkers/client.go
@@ -165,33 +165,18 @@ func loaderURL(cfg Config) (string, error) {
 	}
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return "", exit(2, "%s loader URL %q is invalid", providerName, loaderURLForError(raw))
+		return "", exit(2, "%s loader URL %q is invalid", providerName, shared.EndpointURLForError(raw))
 	}
 	if parsed.User != nil {
 		return "", exit(2, "%s loader URL must not include userinfo", providerName)
 	}
 	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
-		return "", exit(2, "%s loader URL %q must use https unless it targets localhost", providerName, loaderURLForError(raw))
+		return "", exit(2, "%s loader URL %q must use https unless it targets localhost", providerName, shared.EndpointURLForError(raw))
 	}
 	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", exit(2, "%s loader URL %q must not include query or fragment components", providerName, loaderURLForError(raw))
+		return "", exit(2, "%s loader URL %q must not include query or fragment components", providerName, shared.EndpointURLForError(raw))
 	}
 	return strings.TrimRight(parsed.String(), "/"), nil
-}
-
-func loaderURLForError(raw string) string {
-	parsed, err := url.Parse(raw)
-	if err == nil {
-		if parsed.Opaque != "" || parsed.Host == "" {
-			return "<redacted>"
-		}
-		parsed.User = nil
-		parsed.RawQuery = ""
-		parsed.ForceQuery = false
-		parsed.Fragment = ""
-		return parsed.String()
-	}
-	return "<redacted>"
 }
 
 func loaderClaimScope(cfg Config) (string, error) {

--- a/internal/providers/cloudflaresandbox/flags.go
+++ b/internal/providers/cloudflaresandbox/flags.go
@@ -2,7 +2,6 @@ package cloudflaresandbox
 
 import (
 	"flag"
-	"net"
 	"net/url"
 	"path"
 	"strings"
@@ -71,49 +70,19 @@ func bridgeURL(cfg Config) (string, error) {
 	}
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return "", exit(2, "%s bridge URL %q is invalid", providerName, bridgeURLForError(raw))
+		return "", exit(2, "%s bridge URL %q is invalid", providerName, shared.EndpointURLForError(raw))
 	}
 	if parsed.User != nil {
 		return "", exit(2, "%s bridge URL must not include userinfo", providerName)
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
 	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && shared.IsLoopbackHost(parsed.Hostname())) {
-		return "", exit(2, "%s bridge URL %q must use https unless it targets localhost", providerName, bridgeURLForError(raw))
+		return "", exit(2, "%s bridge URL %q must use https unless it targets localhost", providerName, shared.EndpointURLForError(raw))
 	}
 	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", exit(2, "%s bridge URL %q must not include query or fragment components", providerName, bridgeURLForError(raw))
+		return "", exit(2, "%s bridge URL %q must not include query or fragment components", providerName, shared.EndpointURLForError(raw))
 	}
-	parsed.Host = canonicalHostPort(parsed)
+	parsed.Host = shared.CanonicalHostPort(parsed)
 	parsed.Path = strings.TrimRight(parsed.Path, "/")
 	return strings.TrimRight(parsed.String(), "/"), nil
-}
-
-func bridgeURLForError(raw string) string {
-	parsed, err := url.Parse(raw)
-	if err == nil {
-		if parsed.Opaque != "" || parsed.Host == "" {
-			return "<redacted>"
-		}
-		parsed.User = nil
-		parsed.RawQuery = ""
-		parsed.ForceQuery = false
-		parsed.Fragment = ""
-		return parsed.String()
-	}
-	return "<redacted>"
-}
-
-func canonicalHostPort(parsed *url.URL) string {
-	host := strings.ToLower(parsed.Hostname())
-	port := parsed.Port()
-	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
-		port = ""
-	}
-	if port == "" {
-		if strings.Contains(host, ":") {
-			return "[" + host + "]"
-		}
-		return host
-	}
-	return net.JoinHostPort(host, port)
 }

--- a/internal/providers/shared/endpoint_format_test.go
+++ b/internal/providers/shared/endpoint_format_test.go
@@ -1,0 +1,40 @@
+package shared
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestCanonicalHostPort(t *testing.T) {
+	for _, tt := range []struct{ scheme, host, want string }{
+		{"https", "EXAMPLE.com:443", "example.com"},
+		{"http", "EXAMPLE.com:80", "example.com"},
+		{"https", "EXAMPLE.com:8443", "example.com:8443"},
+		{"https", "[2001:DB8::1]:443", "[2001:db8::1]"},
+		{"https", "[2001:DB8::1]:8443", "[2001:db8::1]:8443"},
+		{"custom", "EXAMPLE.com:443", "example.com:443"},
+		{"HTTPS", "EXAMPLE.com:443", "example.com:443"},
+	} {
+		parsed := &url.URL{Scheme: tt.scheme, Host: tt.host, Path: "/keep/"}
+		original := *parsed
+		if got := CanonicalHostPort(parsed); got != tt.want || *parsed != original {
+			t.Errorf("authority(%q,%q)=%q, want %q with unchanged URL", tt.scheme, tt.host, got, tt.want)
+		}
+	}
+}
+
+func TestEndpointURLForError(t *testing.T) {
+	for _, tt := range []struct{ input, want string }{
+		{"https://alice@example.com:8443/api?q=value#fragment", "https://example.com:8443/api"},
+		{"https://EXAMPLE.com/api?", "https://EXAMPLE.com/api"},
+		{"https://example.com/a%2Fb", "https://example.com/a%2Fb"},
+		{"mailto:alice@example.com", "<redacted>"},
+		{"relative/path", "<redacted>"},
+		{"https://example.com/%zz", "<redacted>"},
+		{"", "<redacted>"},
+	} {
+		if got := EndpointURLForError(tt.input); got != tt.want {
+			t.Errorf("display(%q)=%q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/providers/shared/network.go
+++ b/internal/providers/shared/network.go
@@ -30,21 +30,44 @@ func NormalizeHTTPSURL(raw string, errs EndpointURLErrors) (string, error) {
 // Callers own scheme admission and URL-component policy before canonicalizing
 // the lowercased scheme's address. Claim keys and live endpoints differ there.
 func canonicalEndpointAddress(parsed *url.URL) string {
+	parsed.Host = CanonicalHostPort(parsed)
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	parsed.RawPath = ""
+	return strings.TrimRight(parsed.String(), "/")
+}
+
+// CanonicalHostPort formats an already-parsed endpoint authority. Callers own
+// scheme validation and path policy; the complete hostname is lowercased.
+func CanonicalHostPort(parsed *url.URL) string {
 	host := strings.ToLower(parsed.Hostname())
 	port := parsed.Port()
 	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
 		port = ""
 	}
 	if port != "" {
-		parsed.Host = net.JoinHostPort(host, port)
-	} else if strings.Contains(host, ":") {
-		parsed.Host = "[" + host + "]"
-	} else {
-		parsed.Host = host
+		return net.JoinHostPort(host, port)
 	}
-	parsed.Path = strings.TrimRight(parsed.Path, "/")
-	parsed.RawPath = ""
-	return strings.TrimRight(parsed.String(), "/")
+	if strings.Contains(host, ":") {
+		return "[" + host + "]"
+	}
+	return host
+}
+
+// EndpointURLForError omits userinfo, query, and fragment components. It is an
+// endpoint display formatter, not a general diagnostic secret scrubber.
+func EndpointURLForError(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err == nil {
+		if parsed.Opaque != "" || parsed.Host == "" {
+			return "<redacted>"
+		}
+		parsed.User = nil
+		parsed.RawQuery = ""
+		parsed.ForceQuery = false
+		parsed.Fragment = ""
+		return parsed.String()
+	}
+	return "<redacted>"
 }
 
 func IsLoopbackHost(host string) bool {

--- a/internal/providers/superserve/flags.go
+++ b/internal/providers/superserve/flags.go
@@ -147,7 +147,7 @@ func validateSuperserveBaseURL(raw string) (string, error) {
 	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
 		return "", exit(2, "provider=superserve base URL must use HTTPS except for loopback development endpoints")
 	}
-	parsed.Host = canonicalHostPort(parsed)
+	parsed.Host = shared.CanonicalHostPort(parsed)
 	parsed.Path = strings.TrimRight(parsed.Path, "/")
 	return parsed.String(), nil
 }
@@ -170,21 +170,6 @@ func superserveWorkdir(cfg Config) (string, error) {
 
 func isLoopbackHost(host string) bool {
 	return shared.IsLoopbackHost(host)
-}
-
-func canonicalHostPort(parsed *url.URL) string {
-	host := strings.ToLower(parsed.Hostname())
-	port := parsed.Port()
-	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
-		port = ""
-	}
-	if port == "" {
-		if strings.Contains(host, ":") {
-			return "[" + host + "]"
-		}
-		return host
-	}
-	return net.JoinHostPort(host, port)
 }
 
 func splitSuperserveList(value string) []string {


### PR DESCRIPTION
Cloudflare Sandbox, Cloudflare Dynamic Workers, and Superserve duplicated endpoint authority formatting and diagnostic URL display. Share those helpers and reuse the authority formatter from the existing endpoint canonicalization owner.

The formatters preserve default-port handling, IPv6 brackets, complete-hostname lowercasing, escaped paths, and omission of userinfo/query/fragment from diagnostic URLs. Scheme admission, path policy, and stronger provider-specific restrictions remain outside the helpers.

Validation: the shared package and all three provider suites pass. Added tests cover authority formatting without URL mutation, uppercase/raw schemes, escaped paths, malformed input, and diagnostic component removal. Autoreview completed with no accepted/actionable findings.
