### PR TITLE
refactor(providers): share stored lease key adoption

### DIFF
--- a/internal/cli/lease_test.go
+++ b/internal/cli/lease_test.go
@@ -101,6 +101,44 @@ func TestTestboxKeyPathAllowsSafeCustomIDs(t *testing.T) {
 	}
 }
 
+func TestUseStoredTestboxKeyPreservesOptionalFallback(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		leaseID  string
+		stored   bool
+		fallback string
+	}{
+		{name: "stored key overrides configured key", leaseID: "cbx_optional", stored: true, fallback: "configured-key"},
+		{name: "missing key preserves configured key", leaseID: "cbx_optional", fallback: "configured-key"},
+		{name: "invalid ID preserves configured key", leaseID: "invalid/id", fallback: "configured-key"},
+		{name: "missing key preserves empty key", leaseID: "cbx_optional"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateTestUserDirs(t)
+			t.Setenv("XDG_STATE_HOME", "")
+			want := tc.fallback
+			if tc.stored {
+				path, err := testboxKeyPath(tc.leaseID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				want = path
+			}
+			target := SSHTarget{Key: tc.fallback}
+			UseStoredTestboxKey(&target, tc.leaseID)
+			if target.Key != want {
+				t.Fatalf("key=%q want %q", target.Key, want)
+			}
+		})
+	}
+}
+
 func TestUseLeaseKnownHostsScopesAndEnforcesHostVerification(t *testing.T) {
 	isolateTestUserDirs(t)
 

--- a/internal/providers/digitalocean/backend.go
+++ b/internal/providers/digitalocean/backend.go
@@ -708,11 +708,7 @@ func (b *digitalOceanLeaseBackend) targetFromDroplet(item droplet, req core.Reso
 		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
 	}
 	ssh := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
-	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
-		if _, statErr := os.Stat(keyPath); statErr == nil {
-			ssh.Key = keyPath
-		}
-	}
+	core.UseStoredTestboxKey(&ssh, leaseID)
 	if req.Repo.Root != "" && !req.NoLocalStateMutations {
 		updated, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.Cfg, server, ssh, req.Repo.Root, b.Cfg.IdleTimeout, req.Reclaim, claim, claimExists)
 		if err != nil {

--- a/internal/providers/incus/backend.go
+++ b/internal/providers/incus/backend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -257,11 +256,7 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (lease LeaseT
 		target.Port = labelPort
 	}
 	if leaseID != "" {
-		if keyPath, keyErr := core.TestboxKeyPath(leaseID); keyErr == nil {
-			if _, statErr := os.Stat(keyPath); statErr == nil {
-				target.Key = keyPath
-			}
-		}
+		core.UseStoredTestboxKey(&target, leaseID)
 	}
 	if !req.StatusOnly {
 		if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "reuse", core.BootstrapWaitTimeout(cfg)); err != nil {

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -496,11 +496,7 @@ func (b *linodeLeaseBackend) targetFromLinode(item linodeInstance, req core.Reso
 		return target, nil
 	}
 	ssh := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
-	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
-		if _, statErr := os.Stat(keyPath); statErr == nil {
-			ssh.Key = keyPath
-		}
-	}
+	core.UseStoredTestboxKey(&ssh, leaseID)
 	if req.Repo.Root != "" && !req.NoLocalStateMutations {
 		updatedClaim, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.Cfg, server, ssh, req.Repo.Root, b.Cfg.IdleTimeout, req.Reclaim, claim, claimExists)
 		if err != nil {

--- a/internal/providers/ovh/backend.go
+++ b/internal/providers/ovh/backend.go
@@ -331,11 +331,7 @@ func (b *Backend) targetFromInstance(instance Instance, req core.ResolveRequest)
 		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
 	}
 	ssh := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
-	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
-		if _, statErr := os.Stat(keyPath); statErr == nil {
-			ssh.Key = keyPath
-		}
-	}
+	core.UseStoredTestboxKey(&ssh, leaseID)
 	if req.Repo.Root != "" {
 		if _, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.Cfg, server, ssh, req.Repo.Root, b.Cfg.IdleTimeout, req.Reclaim, claim, claimExists); err != nil {
 			return core.LeaseTarget{}, err

--- a/internal/providers/tencentcloud/backend.go
+++ b/internal/providers/tencentcloud/backend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -335,11 +334,7 @@ func (b *Backend) targetFromInstance(item instance, req core.ResolveRequest, acc
 	}
 	cfg := cfgForRun(b.Cfg)
 	ssh := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
-	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
-		if _, statErr := os.Stat(keyPath); statErr == nil {
-			ssh.Key = keyPath
-		}
-	}
+	core.UseStoredTestboxKey(&ssh, leaseID)
 	if req.Repo.Root != "" {
 		if _, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, labels["slug"], cfg, server, ssh, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, claim, claimExists); err != nil {
 			return core.LeaseTarget{}, err


### PR DESCRIPTION
## Summary

DigitalOcean, Incus, Linode, OVH, and Tencent Cloud independently repeat the same lease-key lookup, existence check, and SSH target assignment. Route those five sites through the existing core helper so stored-key adoption has one owner.

This is behavior-preserving: an existing stored path still overrides the configured key; missing paths and invalid lease IDs preserve the configured fallback. Incus retains its nonempty-lease guard. No storage layout, permissions, provider API calls, or cleanup behavior changes.

Add a table-driven test in the existing lease test suite for the shared helper's stored, missing, invalid-ID, and empty-fallback cases. The stored-path fixture is an empty local file, not a credential.

## Verification

- Go 1.26.5 race tests: 289 selected tests/subtests passed, zero failures or skips, covering the core helper and all five provider packages.
- Scoped Codex review: no accepted/actionable findings at the requested P0 threshold.
- `gofmt -l` and `git diff --check`: clean.

```sh
go test -race -p 1 -timeout=20m -run 'TestUseStoredTestboxKeyPreservesOptionalFallback|TestResolve|TestAcquire|TestRelease' ./internal/cli ./internal/providers/digitalocean ./internal/providers/linode ./internal/providers/tencentcloud ./internal/providers/ovh ./internal/providers/incus
```

The first development run was stopped to remove two stale imports; the corrected frozen candidate passed the complete command above.

No live infrastructure was provisioned for this exact refactor. Qualification uses the existing provider acquisition, resolution, and release tests plus the focused helper contract test. There are no configuration or secret changes and no user-visible changelog entry is needed.

## Post-merge verification

Merged as [ed1184206](https://github.com/openclaw/crabbox/commit/ed1184206cd2cd2975ec55d27d50ec70bbe5eacb). The same 289 selected race-test cases passed on the exact merge commit, and the isolated checkout stayed clean with its tracked source unchanged.

The merge commit also passed all jobs in [CI](https://github.com/openclaw/crabbox/actions/runs/34701177953), [connector smokes](https://github.com/openclaw/crabbox/actions/runs/34701177960), and [CodeQL](https://github.com/openclaw/crabbox/actions/runs/34701177294).
