### PR TITLE
refactor(scaleway): share lease tag field definitions

### DIFF
--- a/internal/providers/scaleway/tags.go
+++ b/internal/providers/scaleway/tags.go
@@ -18,6 +18,17 @@ const (
 
 var tagSafeRe = regexp.MustCompile(`[^A-Za-z0-9_:\-]`)
 
+// Share field definitions while retaining Scaleway's own decoding precedence.
+var tagSchema = shared.LeaseTagSchema(append(shared.TailscaleTagFields(),
+	shared.TagLabelField{Key: "recovery"},
+	shared.TagLabelField{Key: "scaleway_project"},
+	shared.TagLabelField{Key: "scaleway_organization"},
+	shared.TagLabelField{Key: "scaleway_region"},
+	shared.TagLabelField{Key: "scaleway_zone"},
+	shared.TagLabelField{Key: "scaleway_ssh_key_id"},
+	shared.TagLabelField{Key: "scaleway_ssh_key_name"},
+)...)
+
 func leaseTags(cfg core.Config, leaseID, slug, state string, keep bool, now time.Time) []string {
 	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
 	labels["state"] = state
@@ -33,7 +44,7 @@ func tagsFromLabels(labels map[string]string) []string {
 		"crabbox:provider:" + providerName,
 		"crabbox:target:" + core.TargetLinux,
 	}
-	for _, key := range tagLabelKeys() {
+	for _, key := range tagSchema.Keys() {
 		if value := labels[key]; value != "" {
 			tags = append(tags, encodeTagKV(key, value))
 		}
@@ -41,20 +52,9 @@ func tagsFromLabels(labels map[string]string) []string {
 	return shared.NormalizeTags(tags)
 }
 
-func tagLabelKeys() []string {
-	return []string{
-		"lease", "slug", "state", "keep", "target", "class", "server_type", "provider_key",
-		"ttl_secs", "idle_timeout", "idle_timeout_secs", "expires_at", "created_at", "last_touched_at", "updated_at",
-		"profile", "market", "desktop", "desktop_env", "browser", "code", "pond", "crabbox_exposed_ports",
-		"tailscale", "tailscale_state", "tailscale_hostname", "tailscale_tags", "tailscale_ipv4", "tailscale_fqdn", "tailscale_error",
-		"tailscale_exit_node", "tailscale_exit_node_allow_lan_access",
-		"recovery", "scaleway_project", "scaleway_organization", "scaleway_region", "scaleway_zone", "scaleway_ssh_key_id", "scaleway_ssh_key_name",
-	}
-}
-
 func encodeTagKV(key, value string) string {
 	key = sanitizeTagPart(key)
-	if exactTagValueKey(key) {
+	if tagSchema.Exact(key) {
 		key += "_v1"
 		return tagPrefix + key + ":" + shared.EncodeExactTagValue(value, 255-len(tagPrefix)-len(key)-1)
 	}
@@ -74,18 +74,9 @@ func sanitizeTagPart(value string) string {
 	return value
 }
 
-func exactTagValueKey(key string) bool {
-	switch key {
-	case "tailscale_hostname", "tailscale_tags", "tailscale_ipv4", "tailscale_fqdn", "tailscale_error", "tailscale_exit_node":
-		return true
-	default:
-		return false
-	}
-}
-
 func versionedExactTagValueKey(key string) (string, bool) {
 	logical := strings.TrimSuffix(key, "_v1")
-	return logical, logical != key && exactTagValueKey(logical)
+	return logical, logical != key && tagSchema.Exact(logical)
 }
 
 func labelsFromTags(tags []string) map[string]string {

--- a/internal/providers/scaleway/tags_test.go
+++ b/internal/providers/scaleway/tags_test.go
@@ -70,3 +70,37 @@ func containsTag(tags []string, want string) bool {
 	}
 	return false
 }
+
+func TestScalewayTagDecoderRetainsProviderPrecedence(t *testing.T) {
+	labels := labelsFromTags([]string{
+		"crabbox:state:running", "crabbox:state:provisioning",
+		"crabbox:expires_at:20", "crabbox:expires_at:10",
+		"crabbox:keep:TRUE", "crabbox:unknown_metadata:retained",
+		"crabbox:provider:scaleway", "crabbox:provider:ScaleWay",
+	})
+	for key, want := range map[string]string{
+		"state": "provisioning", "expires_at": "10", "keep": "TRUE",
+		"unknown_metadata": "retained", ownershipTagConflictLabel: "provider",
+	} {
+		if labels[key] != want {
+			t.Errorf("labels[%q]=%q, want %q", key, labels[key], want)
+		}
+	}
+}
+
+func TestScalewaySchemaPreservesExactAndRecoveryFields(t *testing.T) {
+	labels := map[string]string{
+		"tailscale_hostname": "box.example.ts.net", "tailscale_tags": "tag:ci,tag:dev",
+		"tailscale_ipv4": "100.100.10.20", "tailscale_fqdn": "box.example.ts.net",
+		"tailscale_error": "a diagnostic with spaces", "tailscale_exit_node": "100.100.10.21",
+		"recovery": "pending", "scaleway_project": "project-1", "scaleway_organization": "org-1",
+		"scaleway_region": "fr-par", "scaleway_zone": "fr-par-1",
+		"scaleway_ssh_key_id": "key-1", "scaleway_ssh_key_name": "crabbox-key",
+	}
+	got := labelsFromTags(tagsFromLabels(labels))
+	for key, want := range labels {
+		if got[key] != want {
+			t.Errorf("round-trip label[%q]=%q, want %q", key, got[key], want)
+		}
+	}
+}


### PR DESCRIPTION
Scaleway copied the common lease and Tailscale tag field definitions even though those definitions already have a shared owner. Reuse `LeaseTagSchema` for field enumeration and exact-value encoding, adding only Scaleway's recovery/resource fields.

The decoder remains provider-owned. Its last-value precedence, case handling, unknown metadata retention, and historical ownership-conflict behavior are unchanged; this does not adopt the shared reducer's different semantics.

Validation: new regression tests passed against the original implementation before the refactor, then the full Scaleway and shared suites passed afterward. Tests cover the deliberate decoder differences and round trips for exact Tailscale and recovery fields. Autoreview completed with no accepted/actionable findings.
