### PR TITLE
fix: avoid sibling traversal for nested artifact globs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Avoid unnecessary sibling traversal for nested artifact globs with an exact, safe literal directory prefix, preserving matching, archive membership, and collection limits. [PR 2162](https://github.com/openclaw/crabbox/pull/2162). Thanks @vincentkoc.
 - Add opt-in private local run history with bounded logs and parsed results, offline readback after lease cleanup, explicit provenance, and bounded pruning. [PR 2141](https://github.com/openclaw/crabbox/pull/2141). Thanks @coygeek.
 - Bound Nomad's finite control-plane requests while retaining durable recovery identity for uncertain registration, preserving caller cancellation and keeping established exec streams outside the request ceiling. [PR 1916](https://github.com/openclaw/crabbox/pull/1916). Thanks @SebTardif.
 - Preserve GCP capacity fallback when a bounded error summary omits retry evidence, while keeping user-visible diagnostics redacted and bounded. [PR 1987](https://github.com/openclaw/crabbox/pull/1987). Thanks @steipete.

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -5,12 +5,15 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -1261,6 +1264,350 @@ func TestArtifactGlobSearchRootUsesLiteralPrefix(t *testing.T) {
 		if got := artifactGlobSearchRoot(glob); got != want {
 			t.Fatalf("artifactGlobSearchRoot(%q)=%q, want %q", glob, got, want)
 		}
+	}
+}
+
+func TestRunArtifactNestedGlobAvoidsSiblingEnumeration(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("artifact glob scripts require a POSIX target")
+	}
+	for _, mode := range []string{"required", "collect", "delegated", "delegated-file"} {
+		t.Run(mode, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, name := range []string{
+				"reports/data/proof.txt",
+				"reports/data/nested/result.txt",
+				"reports/sibling/unrelated.txt",
+			} {
+				writeFile(t, filepath.Join(dir, name), name)
+			}
+			globs := []string{"reports/data/**/*.txt"}
+			script := runArtifactRequireScript(dir, globs)
+			archive := filepath.Join(t.TempDir(), "archive.tgz")
+			args := []string(nil)
+			switch mode {
+			case "collect":
+				archive = filepath.Join(dir, ".crabbox", "artifacts.tgz")
+				script = runArtifactCollectScript(dir, ".crabbox/artifacts.tgz", globs)
+			case "delegated":
+				script = DelegatedRunArtifactScript(globs, globs, 2, 1024*1024)
+			case "delegated-file":
+				parent, err := filepath.EvalSymlinks(filepath.Dir(archive))
+				if err != nil {
+					t.Fatal(err)
+				}
+				archive = filepath.Join(parent, "archive.tgz")
+				script = DelegatedRunArtifactFileScript(globs, globs, 2, 1024*1024)
+				args = []string{archive}
+			}
+			trace := filepath.Join(t.TempDir(), "enumerated")
+			prefix := "find() { command find \"$@\" | tee -a " + shellQuote(trace) + "; }\n"
+			cmd := exec.CommandContext(t.Context(), "bash", append([]string{"-c", prefix + script, "--"}, args...)...)
+			cmd.Dir = dir
+			cmd.Env = []string{"PATH=/usr/bin:/bin", "TMPDIR=" + t.TempDir()}
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("generated %s script failed: %v\n%s", mode, err, out)
+			}
+			if mode != "collect" && !strings.Contains(string(out), "required artifact reports/data/**/*.txt matched=2") {
+				t.Fatalf("required membership changed: %s", out)
+			}
+			if mode == "delegated" {
+				_, encoded, begin := strings.Cut(string(out), DelegatedRunArtifactBeginMarker+"\n")
+				encoded, _, end := strings.Cut(encoded, DelegatedRunArtifactEndMarker+"\n")
+				if !begin || !end {
+					t.Fatalf("missing archive framing: %s", out)
+				}
+				data, err := base64.StdEncoding.DecodeString(strings.Join(strings.Fields(encoded), ""))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(archive, data, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if mode != "required" {
+				names := tarGzNames(t, archive)
+				slices.Sort(names)
+				want := []string{"reports/data/nested/result.txt", "reports/data/proof.txt"}
+				if !slices.Equal(names, want) {
+					t.Fatalf("archive membership=%q, want %q", names, want)
+				}
+			}
+			enumerated, err := os.ReadFile(trace)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Contains(enumerated, []byte("reports/data/proof.txt\x00")) {
+				t.Fatalf("real find did not enumerate the selected file: %q", enumerated)
+			}
+			if bytes.Contains(enumerated, []byte("reports/sibling/unrelated.txt\x00")) {
+				t.Fatalf("generated %s script unnecessarily enumerated sibling file; selected membership is correct; find output=%q", mode, enumerated)
+			}
+		})
+	}
+}
+
+func TestRunArtifactNestedGlobRequiresExactDirectoryEntry(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("artifact glob scripts require a POSIX target")
+	}
+	for _, tt := range []struct {
+		name, entry, wantRoot string
+	}{
+		{name: "mismatched spelling", entry: "reports/DATA", wantRoot: "reports"},
+		{name: "exact spelling", entry: "reports/data", wantRoot: "reports/data"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, filepath.Join(dir, "reports/data/proof.txt"), "selected")
+			writeFile(t, filepath.Join(dir, "reports/sibling/unrelated.txt"), "unrelated")
+			traceDir := t.TempDir()
+			probe := filepath.Join(traceDir, "probe")
+			roots := filepath.Join(traceDir, "roots")
+			enumerated := filepath.Join(traceDir, "enumerated")
+			// Only the shallow entry spelling is controlled. Both directories and
+			// recursive discovery are real; this is not a case-insensitive volume.
+			prefix := `find() {
+  if [ "$#" -eq 8 ] && [ "$*" = 'reports -mindepth 1 -maxdepth 1 -type d -print0' ]; then
+    printf 'probe\n' >> ` + shellQuote(probe) + `
+    printf '%s\0' ` + shellQuote(tt.entry) + `
+  else
+    printf '%s\n' "$1" >> ` + shellQuote(roots) + `
+    command find "$@" | tee -a ` + shellQuote(enumerated) + `
+  fi
+}
+`
+			script := runArtifactCollectScript(dir, ".crabbox/artifacts.tgz", []string{"reports/data/**/*.txt"})
+			cmd := exec.CommandContext(t.Context(), "bash", "-c", prefix+script)
+			cmd.Env = []string{"PATH=/usr/bin:/bin", "TMPDIR=" + t.TempDir()}
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("controlled entry probe failed: %v\n%s", err, out)
+			}
+			probeCalls, err := os.ReadFile(probe)
+			if err != nil || string(probeCalls) != "probe\n" {
+				t.Fatalf("real candidate safety checks did not reach one shallow probe: %q, %v", probeCalls, err)
+			}
+			archive := filepath.Join(dir, ".crabbox", "artifacts.tgz")
+			if names := tarGzNames(t, archive); !slices.Equal(names, []string{"reports/data/proof.txt"}) {
+				t.Fatalf("controlled probe changed membership: %q", names)
+			}
+			if got := readTarGzContents(t, archive)["reports/data/proof.txt"]; string(got) != "selected" {
+				t.Fatalf("selected file content changed: %q", got)
+			}
+			actualRoots, err := os.ReadFile(roots)
+			if err != nil || string(actualRoots) != tt.wantRoot+"\n" {
+				t.Fatalf("recursive find root=%q, want %q; error=%v", actualRoots, tt.wantRoot+"\n", err)
+			}
+			paths, err := os.ReadFile(enumerated)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Contains(paths, []byte("reports/data/proof.txt\x00")) {
+				t.Fatalf("selected file was not discovered by real find: %q", paths)
+			}
+			if got := bytes.Contains(paths, []byte("reports/sibling/unrelated.txt\x00")); got != (tt.wantRoot == "reports") {
+				t.Fatalf("real sibling discovery=%t, want legacy traversal=%t: %q", got, tt.wantRoot == "reports", paths)
+			}
+		})
+	}
+}
+
+func TestArtifactGlobNarrowSearchRootAddsOneLiteralDirectory(t *testing.T) {
+	for glob, want := range map[string]string{
+		"reports/data/**/*.txt":       "reports/data",
+		"./reports/data/*.txt":        "reports/data",
+		".artifacts/run/**":           ".artifacts/run",
+		"reports/data/nested/?.txt":   "reports/data/nested",
+		"reports/**":                  "",
+		"**/*.txt":                    "",
+		"reports/da*/**/*.txt":        "",
+		"reports/data/pro*.txt":       "",
+		"reports/data/proof.txt":      "",
+		"reports/data//**/*.txt":      "",
+		"reports/./data/**/*.txt":     "",
+		"reports/data/./*.txt":        "",
+		" reports/data/**/*.txt":      "",
+		"reports/data/**/*.txt ":      "",
+		"reports/../data/**/*.txt":    "",
+		"reports/\u00a0data/**/*.txt": "",
+	} {
+		if got := artifactGlobNarrowSearchRoot(glob); got != want {
+			t.Errorf("artifactGlobNarrowSearchRoot(%q)=%q, want %q", glob, got, want)
+		}
+	}
+}
+
+func TestRunArtifactNestedGlobPreservesSelection(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("artifact glob scripts require a POSIX target")
+	}
+	dir := t.TempDir()
+	for _, name := range []string{
+		"reports/data/proof.txt",
+		"reports/data/nested/result.txt",
+		"reports/data/UPPER.TXT",
+		"reports/Mixed/proof.txt",
+		"reports/sibling/unrelated.txt",
+		"reports/data/.git/private.txt",
+		"reports/data/.crabbox/private.txt",
+	} {
+		writeFile(t, filepath.Join(dir, name), name)
+	}
+	for link, target := range map[string]string{
+		"reports/data/leaf.txt":     "proof.txt",
+		"reports/data/dangling.txt": "missing.txt",
+		"reports/link":              "data",
+	} {
+		if err := os.Symlink(target, filepath.Join(dir, link)); err != nil {
+			t.Fatalf("symlink fixture unavailable: %v", err)
+		}
+	}
+	recursive := []string{"reports/data/leaf.txt", "reports/data/nested/result.txt", "reports/data/proof.txt"}
+	for _, tt := range []struct {
+		name, glob, setup, fallbackRoot string
+		want                            []string
+	}{
+		{name: "recursive", glob: "reports/data/**/*.txt", want: recursive},
+		{name: "relative prefix", glob: "./reports/data/**/*.txt", want: recursive},
+		{name: "single level", glob: "reports/data/*.txt", want: []string{"reports/data/leaf.txt", "reports/data/proof.txt"}},
+		{name: "partial filename", glob: "reports/data/pro*.txt", fallbackRoot: "reports/data", want: []string{"reports/data/proof.txt"}},
+		{name: "partial directory", glob: "reports/da*/**/*.txt", fallbackRoot: "reports", want: recursive},
+		{name: "double slash", glob: "reports/data//**/*.txt", fallbackRoot: "reports"},
+		{name: "dot component", glob: "reports/./data/**/*.txt", fallbackRoot: "reports"},
+		{name: "leading space", glob: " reports/data/**/*.txt", fallbackRoot: "reports"},
+		{name: "case different directory", glob: "reports/mixed/**/*.txt", fallbackRoot: "reports"},
+		{name: "case folded directory", glob: "reports/mixed/**/*.txt", setup: "shopt -s nocasematch\n", fallbackRoot: "reports", want: []string{"reports/Mixed/proof.txt"}},
+		{name: "case folded filenames", glob: "reports/data/**/*.txt", setup: "shopt -s nocasematch\n", fallbackRoot: "reports", want: []string{"reports/data/UPPER.TXT", "reports/data/leaf.txt", "reports/data/nested/result.txt", "reports/data/proof.txt"}},
+		{name: "shell glob settings", glob: "reports/data/**/*.txt", setup: "GLOBIGNORE='data:*.txt'\nshopt -s nocaseglob\nset -f\n", want: recursive},
+		{name: "directory symlink", glob: "reports/link/**/*.txt", fallbackRoot: "reports"},
+		{name: "missing directory", glob: "reports/absent/**/*.txt", fallbackRoot: "reports"},
+		{name: "git component", glob: "reports/data/.git/**/*.txt", fallbackRoot: "reports/data"},
+		{name: "control component", glob: "reports/data/.crabbox/**/*.txt", fallbackRoot: "reports/data"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			trace := filepath.Join(t.TempDir(), "roots")
+			prefix := tt.setup + "find() { printf '%s\\n' \"$1\" >> " + shellQuote(trace) + "; command find \"$@\"; }\n"
+			globs := []string{tt.glob, tt.glob}
+			archive := filepath.Join(dir, ".crabbox", "artifacts.tgz")
+			cmd := exec.CommandContext(t.Context(), "bash", "-c", prefix+runArtifactCollectScript(dir, ".crabbox/artifacts.tgz", globs))
+			cmd.Env = []string{"PATH=/usr/bin:/bin", "TMPDIR=" + t.TempDir()}
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("collect failed: %v\n%s", err, out)
+			}
+			names := tarGzNames(t, archive)
+			slices.Sort(names)
+			if !slices.Equal(names, tt.want) {
+				t.Fatalf("archive membership=%q, want %q", names, tt.want)
+			}
+			if slices.Contains(names, "reports/data/leaf.txt") {
+				header := readTarGzHeaders(t, archive)["reports/data/leaf.txt"]
+				if header.Typeflag != tar.TypeSymlink || header.Linkname != "proof.txt" {
+					t.Fatalf("leaf symlink changed: %+v", header)
+				}
+				if got := readTarGzContents(t, archive)["reports/data/proof.txt"]; string(got) != "reports/data/proof.txt" {
+					t.Fatalf("selected contents changed: %q", got)
+				}
+			}
+			if tt.fallbackRoot != "" {
+				roots, err := os.ReadFile(trace)
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, root := range strings.Split(strings.TrimSpace(string(roots)), "\n") {
+					if root != tt.fallbackRoot {
+						t.Fatalf("legacy search root changed: %q, want %q", root, tt.fallbackRoot)
+					}
+				}
+			}
+			cmd = exec.CommandContext(t.Context(), "bash", "-c", tt.setup+runArtifactRequireScript(dir, globs))
+			cmd.Env = []string{"PATH=/usr/bin:/bin", "TMPDIR=" + t.TempDir()}
+			out, err = cmd.CombinedOutput()
+			if len(tt.want) > 0 {
+				want := fmt.Sprintf("required artifact %s matched=%d", tt.glob, len(tt.want))
+				if err != nil || strings.Count(string(out), want) != 2 {
+					t.Fatalf("required membership changed: %v\n%s", err, out)
+				}
+			} else {
+				var exitErr *exec.ExitError
+				if !errors.As(err, &exitErr) || exitErr.ExitCode() != 8 {
+					t.Fatalf("missing required artifact: error=%v, want exit 8; output=%s", err, out)
+				}
+			}
+		})
+	}
+}
+
+func TestRunArtifactNestedGlobKeepsFilenameNormalization(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("artifact glob scripts require a POSIX target")
+	}
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "reports/data/proof.txt\n"), "proof")
+	cmd := exec.CommandContext(t.Context(), "bash", "-c", runArtifactRequireScript(dir, []string{"reports/data/*.txt"}))
+	cmd.Env = []string{"PATH=/usr/bin:/bin"}
+	out, err := cmd.CombinedOutput()
+	if err != nil || !strings.Contains(string(out), "required artifact reports/data/*.txt matched=1") {
+		t.Fatalf("required filename normalization changed: %v\n%s", err, out)
+	}
+}
+
+func TestRunArtifactNestedGlobPreservesDelegatedLimits(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("artifact glob scripts require a POSIX target")
+	}
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "reports/data/a.txt"), "first")
+	writeFile(t, filepath.Join(dir, "reports/data/b.txt"), "second")
+	globs := []string{"reports/data/**/*.txt", "reports/data/*.txt"}
+	for _, tt := range []struct {
+		name     string
+		required []string
+		maxFiles int
+		maxBytes int64
+		wantCode int
+	}{
+		{name: "deduplicated at file cap", maxFiles: 2, maxBytes: 1024 * 1024},
+		{name: "file cap", maxFiles: 1, maxBytes: 1024 * 1024, wantCode: 9},
+		{name: "byte cap", maxFiles: 2, maxBytes: 1, wantCode: 9},
+		{name: "required missing", required: []string{"reports/absent/**/*.txt"}, maxFiles: 2, maxBytes: 1024 * 1024, wantCode: 8},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, fileMode := range []bool{false, true} {
+				script := DelegatedRunArtifactScript(tt.required, globs, tt.maxFiles, tt.maxBytes)
+				args := []string(nil)
+				directory, err := filepath.EvalSymlinks(t.TempDir())
+				if err != nil {
+					t.Fatal(err)
+				}
+				archive := filepath.Join(directory, "archive.tgz")
+				if fileMode {
+					script = DelegatedRunArtifactFileScript(tt.required, globs, tt.maxFiles, tt.maxBytes)
+					args = []string{archive}
+				}
+				cmd := exec.CommandContext(t.Context(), "bash", append([]string{"-c", script, "--"}, args...)...)
+				cmd.Dir = dir
+				cmd.Env = []string{"PATH=/usr/bin:/bin", "TMPDIR=" + t.TempDir()}
+				out, err := cmd.CombinedOutput()
+				code := 0
+				if err != nil {
+					var exitErr *exec.ExitError
+					if !errors.As(err, &exitErr) {
+						t.Fatal(err)
+					}
+					code = exitErr.ExitCode()
+				}
+				if code != tt.wantCode {
+					t.Fatalf("file mode=%t: exit=%d want=%d; output=%s", fileMode, code, tt.wantCode, out)
+				}
+				if code != 0 {
+					if _, err := os.Stat(archive); !errors.Is(err, os.ErrNotExist) || strings.Contains(string(out), DelegatedRunArtifactBeginMarker) {
+						t.Fatalf("failed collection published an archive: file mode=%t stat=%v output=%s", fileMode, err, out)
+					}
+				}
+			}
+		})
 	}
 }
 

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -198,7 +198,19 @@ func writeArtifactGlobEnumeration(b *strings.Builder, glob, addFunction string) 
 	if !strings.ContainsAny(glob, "*?") {
 		depth = " -mindepth 1 -maxdepth 1"
 	}
-	b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; artifact_root=" + shellQuote(artifactGlobSearchRoot(glob)) + "; if artifact_safe_search_root \"$artifact_root\"; then while IFS= read -r -d '' f; do rel=$(artifact_rel_path \"$f\") || continue; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then " + addFunction + " \"$f\"; fi; done < <(find \"$artifact_root\"" + depth + " \\( -name .git -o -name .crabbox \\) -prune -o \\( -type f -o -type l \\) -print0); fi\n")
+	b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; artifact_root=" + shellQuote(artifactGlobSearchRoot(glob)) + "\n")
+	if candidate := artifactGlobNarrowSearchRoot(glob); candidate != "" {
+		// A successful directory lookup alone can hide spelling differences on
+		// case-insensitive filesystems. Match an actual entry before narrowing.
+		b.WriteString("artifact_candidate=" + shellQuote(candidate) + "\n")
+		b.WriteString(`if ! shopt -q nocasematch && artifact_safe_search_root "$artifact_root" && artifact_safe_search_root "$artifact_candidate"; then
+  while IFS= read -r -d '' artifact_entry; do
+    if [ "$artifact_entry" = "$artifact_candidate" ]; then artifact_root=$artifact_candidate; break; fi
+  done < <(find "$artifact_root" -mindepth 1 -maxdepth 1 -type d -print0)
+fi
+`)
+	}
+	b.WriteString("if artifact_safe_search_root \"$artifact_root\"; then while IFS= read -r -d '' f; do rel=$(artifact_rel_path \"$f\") || continue; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then " + addFunction + " \"$f\"; fi; done < <(find \"$artifact_root\"" + depth + " \\( -name .git -o -name .crabbox \\) -prune -o \\( -type f -o -type l \\) -print0); fi\n")
 }
 
 func runArtifactRequireScript(workdir string, globs []string) string {
@@ -332,6 +344,22 @@ func artifactGlobSearchRoot(glob string) string {
 		return "."
 	}
 	return dir
+}
+
+func artifactGlobNarrowSearchRoot(glob string) string {
+	if glob != strings.TrimSpace(glob) || !safeArtifactGlob(glob) {
+		return ""
+	}
+	firstMeta := strings.IndexAny(glob, "*?")
+	if firstMeta <= 0 || glob[firstMeta-1] != '/' {
+		return ""
+	}
+	candidate := strings.TrimPrefix(glob[:firstMeta-1], "./")
+	root := artifactGlobSearchRoot(glob)
+	if candidate != filepath.ToSlash(filepath.Clean(candidate)) || candidate != root+"/"+filepath.Base(candidate) {
+		return ""
+	}
+	return candidate
 }
 
 func artifactGlobRegex(glob string) string {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users collecting artifacts with nested literal-prefix globs would unnecessarily traverse unrelated sibling directory trees.

## Why This Change Was Made

Narrow discovery by one literal directory only when the existing path-safety checks pass, `nocasematch` is off, and an actual immediate directory entry has exactly the requested spelling. Other cases retain the legacy search root; matching, archive membership, required-artifact failures, deduplication, and collection limits are unchanged.

## User Impact

Eligible nested globs avoid unrelated sibling traversal without new configuration, dependencies, or changes to credentials and providers. This is a bounded collector improvement, not evidence of resolving a transport timeout.

## Evidence

- Before the production change, generated-script regressions failed in all four modes: required artifacts, collection, delegated inline collection, and delegated file collection. Archive membership was correct, but real recursive discovery still visited an unrelated sibling file.
- After the change, the focused suite passed: 5 top-level tests and 24 subtests. The broader collector race selection passed: 31 top-level tests and 65 subtests, with no failures or skips.
- A subsequent controlled directory-entry test exercises the exact-spelling guard while leaving recursive `find` real. Removing only the emitted equality guard made the mismatched-spelling case fail and the exact-spelling control pass. Restoring it made both cases pass, including a focused race run.
- `go vet -p=4 ./internal/cli`, formatting, and diff checks passed. An independent review found no actionable issues in the production change and original tests; the subsequent coverage-only addition received separate review.

Validation used Linux and a controlled shallow-directory probe. Native macOS and a native case-insensitive filesystem were not exercised locally; the controlled test is branch-coverage evidence, not a claim of native filesystem qualification.

Scoped commands used Go's read-only module mode, `GOTOOLCHAIN=local`, `GOPROXY=off`, and `GOSUMDB=off`:

```sh
go test -p=4 -run '^(TestRunArtifactNestedGlob.*|TestArtifactGlobNarrowSearchRootAddsOneLiteralDirectory)$' -count=1 -timeout=20m ./internal/cli
go test -race -p=4 -run '^(TestSafeArtifactGlob|TestRunArtifactGlobsValidateComponents|TestRunArtifact(CollectScript.*|RequireScript.*|Scripts.*|Literal.*|NestedGlob.*)|TestArtifactGlob.*|TestArtifactScriptGeneratorsNeverExpandUserGlobs|TestDelegatedRunArtifact(Script.*|FileScript.*))$' -count=1 -timeout=20m ./internal/cli
go test -race -p=4 -run '^TestRunArtifactNestedGlobRequiresExactDirectoryEntry$' -count=1 -timeout=20m ./internal/cli
go vet -p=4 ./internal/cli
gofmt -l internal/cli/run_artifacts.go internal/cli/profiles_test.go
git diff --check
```
