### PR TITLE
refactor(providers): use one stored key selection owner

### DIFF
--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -876,7 +876,7 @@ func sshTargetForBootstrap(cfg Config, publicIP, leaseID, slug string) SSHTarget
 var bootstrapAWSWindowsDesktop = core.BootstrapAWSWindowsDesktop
 
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
-	shared.UseStoredTestboxKey(target, leaseID)
+	core.UseStoredTestboxKey(target, leaseID)
 }
 func findServerByAlias(servers []Server, id string) (Server, string, error) {
 	return core.FindServerByAlias(servers, id)

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -529,7 +529,7 @@ func isAzureCleanupNotFound(err error) bool {
 }
 
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
-	shared.UseStoredTestboxKey(target, leaseID)
+	core.UseStoredTestboxKey(target, leaseID)
 }
 func findServerByAlias(servers []Server, id string) (Server, string, error) {
 	return core.FindServerByAlias(servers, id)

--- a/internal/providers/gcp/backend.go
+++ b/internal/providers/gcp/backend.go
@@ -476,7 +476,7 @@ var waitForSSHReady = core.WaitForSSHReady
 func bootstrapWaitTimeout(cfg Config) time.Duration { return core.BootstrapWaitTimeout(cfg) }
 
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
-	shared.UseStoredTestboxKey(target, leaseID)
+	core.UseStoredTestboxKey(target, leaseID)
 }
 func findServerByAlias(servers []Server, id string) (Server, string, error) {
 	return core.FindServerByAlias(servers, id)

--- a/internal/providers/hetzner/backend.go
+++ b/internal/providers/hetzner/backend.go
@@ -533,7 +533,7 @@ func rollbackHetznerAcquire(client hetznerClient, server Server, serverCreated b
 func parseServerID(s string) (int64, bool) { return core.ParseServerID(s) }
 
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
-	shared.UseStoredTestboxKey(target, leaseID)
+	core.UseStoredTestboxKey(target, leaseID)
 }
 func findServerByAlias(servers []Server, id string) (Server, string, error) {
 	return core.FindServerByAlias(servers, id)

--- a/internal/providers/parallels/backend.go
+++ b/internal/providers/parallels/backend.go
@@ -448,7 +448,7 @@ func blank(value, fallback string) string {
 }
 
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
-	shared.UseStoredTestboxKey(target, leaseID)
+	core.UseStoredTestboxKey(target, leaseID)
 }
 
 func parallelsLeaseFromVMName(name string) (string, string) {

--- a/internal/providers/proxmox/backend.go
+++ b/internal/providers/proxmox/backend.go
@@ -703,5 +703,5 @@ func exit(code int, format string, args ...any) core.ExitError {
 }
 
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
-	shared.UseStoredTestboxKey(target, leaseID)
+	core.UseStoredTestboxKey(target, leaseID)
 }

--- a/internal/providers/shared/ssh.go
+++ b/internal/providers/shared/ssh.go
@@ -1,10 +1,7 @@
 package shared
 
 import (
-	"os"
 	"strings"
-
-	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 // QuoteSSHProxyCommandWord encodes a literal argument for OpenSSH's percent
@@ -19,12 +16,4 @@ func QuoteSSHProxyCommandWord(word string) string {
 		return word
 	}
 	return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`, "$", `\$`, "`", "\\`").Replace(word) + `"`
-}
-
-func UseStoredTestboxKey(target *core.SSHTarget, leaseID string) {
-	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
-		if _, statErr := os.Stat(keyPath); statErr == nil {
-			target.Key = keyPath
-		}
-	}
 }

--- a/internal/providers/xcpng/backend.go
+++ b/internal/providers/xcpng/backend.go
@@ -845,5 +845,5 @@ var removeStoredTestboxKey = func(leaseID string) { core.RemoveStoredTestboxKey(
 var exit = func(code int, format string, args ...any) core.ExitError { return core.Exit(code, format, args...) }
 
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
-	shared.UseStoredTestboxKey(target, leaseID)
+	core.UseStoredTestboxKey(target, leaseID)
 }


### PR DESCRIPTION
Stored lease-key selection still had two implementations after the core helper adoption: the provider-shared layer kept its own lookup/stat/assignment loop. Route AWS, Azure, GCP, Hetzner, Parallels, Proxmox, and XCP-ng through the existing core helper and delete that copy.

Stored-key precedence and optional fallback remain unchanged. Provider-local bindings stay local, and stricter error-returning policies such as Hostinger's remain separate.

Validation: the shared package and all seven provider suites pass. The core optional-fallback contract and the concurrent stored-key adoption have additional race coverage. Autoreview completed with no accepted/actionable findings. No public behavior or configuration changes.
