### PR TITLE
refactor(providers): use shared first non-empty helper

### DIFF
--- a/internal/providers/gcp/provider.go
+++ b/internal/providers/gcp/provider.go
@@ -252,7 +252,7 @@ func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (co
 	if req.Config.Coordinator == "" || req.Server.CloudID == "" {
 		return core.NativeCheckpointCapability{}, false
 	}
-	if firstNonBlank(req.Target.TargetOS, req.Config.TargetOS) != core.TargetLinux {
+	if shared.FirstNonEmpty(req.Target.TargetOS, req.Config.TargetOS) != core.TargetLinux {
 		return core.NativeCheckpointCapability{}, false
 	}
 	if core.NormalizeCheckpointStrategy(req.Strategy) == core.CheckpointStrategyImage {
@@ -261,17 +261,13 @@ func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (co
 	return core.NativeCheckpointCapability{Kind: core.CheckpointKindGCPDisk, RetireSource: true}, true
 }
 
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonEmpty(values...)
-}
-
 func (Provider) ApplyNativeCheckpointForkConfig(req core.NativeCheckpointForkRequest) error {
 	cfg := req.Config
 	switch req.Record.Kind {
 	case core.CheckpointKindGCP:
-		cfg.GCPMachineImage = firstNonBlank(req.Record.Resource, req.Record.ImageID)
+		cfg.GCPMachineImage = shared.FirstNonEmpty(req.Record.Resource, req.Record.ImageID)
 	case core.CheckpointKindGCPDisk:
-		cfg.GCPSnapshot = firstNonBlank(req.Record.Resource, req.Record.ImageID)
+		cfg.GCPSnapshot = shared.FirstNonEmpty(req.Record.Resource, req.Record.ImageID)
 	default:
 		return core.Exit(2, "provider=gcp does not support checkpoint kind=%s", req.Record.Kind)
 	}


### PR DESCRIPTION
## What Problem This Solves

The GCP provider duplicated first-non-empty fallback handling, making checkpoint target and resource precedence harder to audit consistently.

## Why This Change Was Made

Use the shared internal `shared.FirstNonEmpty` helper at the three existing call sites and remove the equivalent provider-local wrapper. Non-trimming behavior, argument order, and target, resource, and image precedence are unchanged.

## User Impact

No user-visible behavior changes. GCP checkpoint fallback handling now uses the shared implementation.

## Evidence

- `go test -race -count=1 -p=1 -timeout=20m ./internal/providers/gcp ./internal/providers/shared`
- `go test -race -count=1 -p=1 -timeout=20m ./internal/cli -run '^(TestCheckpointCreateModeSupportsAzureAndGCPNative|TestApplyNativeCheckpointForkConfigForAzureAndGCP)$'`
- `go vet ./...`
- `go build -trimpath ./cmd/crabbox`


## Maintainer closeout

Merged as `f7343725479ee43e671a1ceab7b2f8507131cf94`, retaining Vincent Koc's contributor credit. The unchanged patch passed 130 tests and 409 subtests with race detection plus scoped vet on the PR head, on a current-main integration candidate, and again on the actual merge. Scoped Codex review found no accepted/actionable P0 findings.

The actual merge passed all 12 [CI jobs](https://github.com/openclaw/crabbox/actions/runs/34711341830), four [CodeQL analyses](https://github.com/openclaw/crabbox/actions/runs/34711341401), and five [Connector smokes](https://github.com/openclaw/crabbox/actions/runs/34711341841), without retries. No user-visible behavior changed, so no changelog entry or live GCP allocation was needed.
