### PR TITLE
refactor(config): centralize typed file overlays

### DIFF
--- a/docs/refactor/typed-provider-config.md
+++ b/docs/refactor/typed-provider-config.md
@@ -32,7 +32,7 @@ once, on the concrete structs in `internal/cli/config_vercel_sandbox.go`,
 `internal/cli/config_multipass.go`, and `internal/cli/config_machine0.go`.
 `scripts/configgen` reads each declaration
 and emits its matching `_generated.go` file. Each generated file contains
-source-admitted YAML input fields, compiled defaults, file overlays,
+source-admitted YAML input fields, compiled defaults, overlay entry points,
 and storage, registration, and presence-based application for admitted flags.
 
 Environment application has one runtime owner in
@@ -43,6 +43,13 @@ and partial results on errors. Split environment passes count schema fields,
 excluding runtime-only state, so provider normalization between passes stays
 in place. The generator still rejects unsupported field types and tag modes;
 the engine does not infer additional sources or normalize provider values.
+
+File overlays similarly use `internal/cli/config_file_overlay.go`. The engine
+applies the schema's trust grants before reading each admitted DTO field, then
+preserves its empty-value, numeric, duration, list-copy and alias-order rules.
+It returns accepted fields before the first error without modifying the DTO.
+Provider-specific admission wrappers still run before this mechanical overlay;
+path expansion and credential selection still run in their existing order.
 
 Generation owns mechanical bindings, not provider policy. Other providers retain
 their existing configuration code. Provider selection, command routing, config

--- a/internal/cli/config_agentsandbox_generated.go
+++ b/internal/cli/config_agentsandbox_generated.go
@@ -51,65 +51,8 @@ type AgentSandboxConfigApplied struct {
 
 func (cfg *AgentSandboxConfig) applyFile(file *fileAgentSandboxConfig, trusted bool) (AgentSandboxConfigApplied, error) {
 	var applied AgentSandboxConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if trusted && file.Kubectl != "" {
-		cfg.Kubectl = file.Kubectl
-		applied.InputAccepted = true
-	}
-	if trusted && file.Kubeconfig != "" {
-		cfg.Kubeconfig = file.Kubeconfig
-		applied.InputAccepted = true
-		applied.Kubeconfig = true
-	}
-	if trusted && file.Context != "" {
-		cfg.Context = file.Context
-		applied.InputAccepted = true
-	}
-	if trusted && file.Namespace != "" {
-		cfg.Namespace = file.Namespace
-		applied.InputAccepted = true
-	}
-	if trusted && file.WarmPool != "" {
-		cfg.WarmPool = file.WarmPool
-		applied.InputAccepted = true
-	}
-	if trusted && file.Container != "" {
-		cfg.Container = file.Container
-		applied.InputAccepted = true
-	}
-	if trusted && file.Workdir != "" {
-		cfg.Workdir = file.Workdir
-		applied.InputAccepted = true
-	}
-	if file.SandboxReadyTimeout != "" {
-		if applyLeaseDuration(&cfg.SandboxReadyTimeout, file.SandboxReadyTimeout) {
-			applied.InputAccepted = true
-		}
-	}
-	if file.PodReadyTimeout != "" {
-		if applyLeaseDuration(&cfg.PodReadyTimeout, file.PodReadyTimeout) {
-			applied.InputAccepted = true
-		}
-	}
-	if file.ExecTimeoutSecs != nil {
-		if *file.ExecTimeoutSecs < 0 {
-			return applied, exit(2, "agentSandbox execTimeoutSecs must be non-negative")
-		}
-		cfg.ExecTimeoutSecs = *file.ExecTimeoutSecs
-		applied.InputAccepted = true
-	}
-	if file.DeleteOnRelease != nil {
-		cfg.DeleteOnRelease = *file.DeleteOnRelease
-		applied.InputAccepted = true
-		applied.DeleteOnRelease = true
-	}
-	if file.ForgetMissing != nil {
-		cfg.ForgetMissing = *file.ForgetMissing
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "agentSandbox")
+	return applied, err
 }
 
 func (cfg *AgentSandboxConfig) applyEnv() (AgentSandboxConfigApplied, error) {

--- a/internal/cli/config_anthropic_sandbox_runtime_generated.go
+++ b/internal/cli/config_anthropic_sandbox_runtime_generated.go
@@ -27,22 +27,8 @@ type AnthropicSRTConfigApplied struct {
 
 func (cfg *AnthropicSRTConfig) applyFile(file *fileAnthropicSRTConfig) (AnthropicSRTConfigApplied, error) {
 	var applied AnthropicSRTConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.CLIPath != "" {
-		cfg.CLIPath = file.CLIPath
-		applied.InputAccepted = true
-	}
-	if file.Settings != nil {
-		cfg.Settings = *file.Settings
-		applied.InputAccepted = true
-	}
-	if file.Debug != nil {
-		cfg.Debug = *file.Debug
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "anthropic-sandbox-runtime")
+	return applied, err
 }
 
 func (cfg *AnthropicSRTConfig) applyEnv() (AnthropicSRTConfigApplied, error) {

--- a/internal/cli/config_aws_lambda_microvm_generated.go
+++ b/internal/cli/config_aws_lambda_microvm_generated.go
@@ -36,42 +36,8 @@ type AWSLambdaMicroVMConfigApplied struct {
 
 func (cfg *AWSLambdaMicroVMConfig) applyFile(file *fileAWSLambdaMicroVMConfig) (AWSLambdaMicroVMConfigApplied, error) {
 	var applied AWSLambdaMicroVMConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.Image != "" {
-		cfg.Image = file.Image
-		applied.InputAccepted = true
-		applied.Image = true
-	}
-	if file.ImageVersion != "" {
-		cfg.ImageVersion = file.ImageVersion
-		applied.InputAccepted = true
-		applied.ImageVersion = true
-	}
-	if file.ExecutionRoleARN != "" {
-		cfg.ExecutionRoleARN = file.ExecutionRoleARN
-		applied.InputAccepted = true
-		applied.ExecutionRoleARN = true
-	}
-	if file.Workdir != "" {
-		cfg.Workdir = file.Workdir
-		applied.InputAccepted = true
-		applied.Workdir = true
-	}
-	if file.IngressConnectors != nil {
-		cfg.IngressConnectors = append([]string(nil), (*file.IngressConnectors)...)
-		applied.InputAccepted = true
-	}
-	if file.EgressConnectors != nil {
-		cfg.EgressConnectors = append([]string(nil), (*file.EgressConnectors)...)
-		applied.InputAccepted = true
-	}
-	if file.ForgetMissing != nil {
-		cfg.ForgetMissing = *file.ForgetMissing
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "awsLambdaMicroVM")
+	return applied, err
 }
 
 func (cfg *AWSLambdaMicroVMConfig) applyEnv() (AWSLambdaMicroVMConfigApplied, error) {

--- a/internal/cli/config_azure_dynamic_sessions_generated.go
+++ b/internal/cli/config_azure_dynamic_sessions_generated.go
@@ -34,31 +34,8 @@ type AzureDynamicSessionsConfigApplied struct {
 
 func (cfg *AzureDynamicSessionsConfig) applyFile(file *fileAzureDynamicSessionsConfig) (AzureDynamicSessionsConfigApplied, error) {
 	var applied AzureDynamicSessionsConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.Endpoint != "" {
-		cfg.Endpoint = file.Endpoint
-		applied.InputAccepted = true
-		applied.Endpoint = true
-	}
-	if file.Pool != "" {
-		cfg.Pool = file.Pool
-		applied.InputAccepted = true
-	}
-	if file.APIVersion != "" {
-		cfg.APIVersion = file.APIVersion
-		applied.InputAccepted = true
-	}
-	if file.Workdir != "" {
-		cfg.Workdir = file.Workdir
-		applied.InputAccepted = true
-	}
-	if file.TimeoutSecs > 0 {
-		cfg.TimeoutSecs = file.TimeoutSecs
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "azure-dynamic-sessions")
+	return applied, err
 }
 
 func (cfg *AzureDynamicSessionsConfig) applyEnv() (AzureDynamicSessionsConfigApplied, error) {

--- a/internal/cli/config_blacksmith_generated.go
+++ b/internal/cli/config_blacksmith_generated.go
@@ -26,35 +26,8 @@ type BlacksmithConfigApplied struct {
 
 func (cfg *BlacksmithConfig) applyFile(file *fileBlacksmithConfig) (BlacksmithConfigApplied, error) {
 	var applied BlacksmithConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.Org != "" {
-		cfg.Org = file.Org
-		applied.InputAccepted = true
-	}
-	if file.Workflow != "" {
-		cfg.Workflow = file.Workflow
-		applied.InputAccepted = true
-	}
-	if file.Job != "" {
-		cfg.Job = file.Job
-		applied.InputAccepted = true
-	}
-	if file.Ref != "" {
-		cfg.Ref = file.Ref
-		applied.InputAccepted = true
-	}
-	if file.IdleTimeout != "" {
-		if applyLeaseDuration(&cfg.IdleTimeout, file.IdleTimeout) {
-			applied.InputAccepted = true
-		}
-	}
-	if file.Debug != nil {
-		cfg.Debug = *file.Debug
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "blacksmith-testbox")
+	return applied, err
 }
 
 func (cfg *BlacksmithConfig) applyEnvPrefix() (BlacksmithConfigApplied, error) {

--- a/internal/cli/config_blaxel_generated.go
+++ b/internal/cli/config_blaxel_generated.go
@@ -40,56 +40,8 @@ type BlaxelConfigApplied struct {
 
 func (cfg *BlaxelConfig) applyFile(file *fileBlaxelConfig, trusted bool) (BlaxelConfigApplied, error) {
 	var applied BlaxelConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if trusted && file.APIURL != "" {
-		cfg.APIURL = file.APIURL
-		applied.InputAccepted = true
-	}
-	if trusted && file.Workspace != "" {
-		cfg.Workspace = file.Workspace
-		applied.InputAccepted = true
-	}
-	if file.Region != "" {
-		cfg.Region = file.Region
-		applied.InputAccepted = true
-	}
-	if file.Image != nil {
-		cfg.Image = *file.Image
-		applied.InputAccepted = true
-	}
-	if file.MemoryMB != nil {
-		if *file.MemoryMB < 0 {
-			return applied, exit(2, "blaxel memoryMB must be non-negative")
-		}
-		cfg.MemoryMB = *file.MemoryMB
-		applied.InputAccepted = true
-	}
-	if file.TTL != "" {
-		cfg.TTL = file.TTL
-		applied.InputAccepted = true
-	}
-	if file.IdleTTL != "" {
-		cfg.IdleTTL = file.IdleTTL
-		applied.InputAccepted = true
-	}
-	if file.Workdir != nil {
-		cfg.Workdir = *file.Workdir
-		applied.InputAccepted = true
-	}
-	if file.ExecTimeoutSecs != nil {
-		if *file.ExecTimeoutSecs < 0 {
-			return applied, exit(2, "blaxel execTimeoutSecs must be non-negative")
-		}
-		cfg.ExecTimeoutSecs = *file.ExecTimeoutSecs
-		applied.InputAccepted = true
-	}
-	if file.ForgetMissing != nil {
-		cfg.ForgetMissing = *file.ForgetMissing
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "blaxel")
+	return applied, err
 }
 
 func (cfg *BlaxelConfig) applyEnv() (BlaxelConfigApplied, error) {

--- a/internal/cli/config_cloud_run_sandbox_generated.go
+++ b/internal/cli/config_cloud_run_sandbox_generated.go
@@ -35,30 +35,8 @@ type CloudRunSandboxConfigApplied struct {
 
 func (cfg *CloudRunSandboxConfig) applyFile(file *fileCloudRunSandboxConfig) (CloudRunSandboxConfigApplied, error) {
 	var applied CloudRunSandboxConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.CLIPath != "" {
-		cfg.CLIPath = file.CLIPath
-		applied.InputAccepted = true
-	}
-	if file.Workdir != "" {
-		cfg.Workdir = file.Workdir
-		applied.InputAccepted = true
-	}
-	if file.AllowEgress != nil {
-		cfg.AllowEgress = *file.AllowEgress
-		applied.InputAccepted = true
-	}
-	if file.Write != nil {
-		cfg.Write = *file.Write
-		applied.InputAccepted = true
-	}
-	if file.Rootfs != "" {
-		cfg.Rootfs = file.Rootfs
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "cloud-run-sandbox")
+	return applied, err
 }
 
 func (cfg *CloudRunSandboxConfig) applyEnv() (CloudRunSandboxConfigApplied, error) {

--- a/internal/cli/config_cloudflare_generated.go
+++ b/internal/cli/config_cloudflare_generated.go
@@ -29,24 +29,8 @@ type CloudflareConfigApplied struct {
 
 func (cfg *CloudflareConfig) applyFile(file *fileCloudflareConfig) (CloudflareConfigApplied, error) {
 	var applied CloudflareConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.APIURL != "" {
-		cfg.APIURL = file.APIURL
-		applied.InputAccepted = true
-		applied.APIURL = true
-	}
-	if file.Token != "" {
-		cfg.Token = file.Token
-		applied.InputAccepted = true
-		applied.Token = true
-	}
-	if file.Workdir != "" {
-		cfg.Workdir = file.Workdir
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "cloudflare")
+	return applied, err
 }
 
 func (cfg *CloudflareConfig) applyEnv() (CloudflareConfigApplied, error) {

--- a/internal/cli/config_cloudflare_sandbox_generated.go
+++ b/internal/cli/config_cloudflare_sandbox_generated.go
@@ -32,37 +32,8 @@ type CloudflareSandboxConfigApplied struct {
 
 func (cfg *CloudflareSandboxConfig) applyFile(file *fileCloudflareSandboxConfig, trusted bool) (CloudflareSandboxConfigApplied, error) {
 	var applied CloudflareSandboxConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if trusted && file.BridgeURL != nil {
-		cfg.BridgeURL = *file.BridgeURL
-		applied.InputAccepted = true
-	}
-	if trusted && file.BridgeURLConfigAlias != nil {
-		cfg.BridgeURL = *file.BridgeURLConfigAlias
-		applied.InputAccepted = true
-	}
-	if trusted && file.Token != nil {
-		cfg.Token = *file.Token
-		applied.InputAccepted = true
-	}
-	if file.Workdir != nil {
-		cfg.Workdir = *file.Workdir
-		applied.InputAccepted = true
-	}
-	if file.ExecTimeoutSecs != nil {
-		if *file.ExecTimeoutSecs < 0 {
-			return applied, exit(2, "cloudflare-sandbox execTimeoutSecs must be non-negative")
-		}
-		cfg.ExecTimeoutSecs = *file.ExecTimeoutSecs
-		applied.InputAccepted = true
-	}
-	if file.ForgetMissing != nil {
-		cfg.ForgetMissing = *file.ForgetMissing
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "cloudflare-sandbox")
+	return applied, err
 }
 
 func (cfg *CloudflareSandboxConfig) applyEnv() (CloudflareSandboxConfigApplied, error) {

--- a/internal/cli/config_coder_generated.go
+++ b/internal/cli/config_coder_generated.go
@@ -44,53 +44,8 @@ type CoderConfigApplied struct {
 
 func (cfg *CoderConfig) applyFile(file *fileCoderConfig) (CoderConfigApplied, error) {
 	var applied CoderConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.CLIPath != "" {
-		cfg.CLIPath = file.CLIPath
-		applied.InputAccepted = true
-		applied.CLIPath = true
-	}
-	if file.Template != "" {
-		cfg.Template = file.Template
-		applied.InputAccepted = true
-	}
-	if file.Preset != "" {
-		cfg.Preset = file.Preset
-		applied.InputAccepted = true
-	}
-	if file.WorkspacePrefix != "" {
-		cfg.WorkspacePrefix = file.WorkspacePrefix
-		applied.InputAccepted = true
-	}
-	if file.WorkRoot != "" {
-		cfg.WorkRoot = file.WorkRoot
-		applied.InputAccepted = true
-		applied.WorkRoot = true
-	}
-	if file.DeleteOnRelease != nil {
-		cfg.DeleteOnRelease = *file.DeleteOnRelease
-		applied.InputAccepted = true
-	}
-	if file.Wait != "" {
-		cfg.Wait = file.Wait
-		applied.InputAccepted = true
-	}
-	if file.UseParameterDefaults != nil {
-		cfg.UseParameterDefaults = *file.UseParameterDefaults
-		applied.InputAccepted = true
-	}
-	if len(file.Parameters) > 0 {
-		cfg.Parameters = normalizeList(file.Parameters)
-		applied.InputAccepted = true
-	}
-	if file.RichParameterFile != "" {
-		cfg.RichParameterFile = file.RichParameterFile
-		applied.InputAccepted = true
-		applied.RichParameterFile = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "coder")
+	return applied, err
 }
 
 func (cfg *CoderConfig) applyEnv() (CoderConfigApplied, error) {

--- a/internal/cli/config_codesandbox_generated.go
+++ b/internal/cli/config_codesandbox_generated.go
@@ -47,63 +47,8 @@ type CodeSandboxConfigApplied struct {
 
 func (cfg *CodeSandboxConfig) applyFile(file *fileCodeSandboxConfig, trusted bool) (CodeSandboxConfigApplied, error) {
 	var applied CodeSandboxConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.TemplateID != nil {
-		cfg.TemplateID = *file.TemplateID
-		applied.InputAccepted = true
-	}
-	if file.Workdir != nil {
-		cfg.Workdir = *file.Workdir
-		applied.InputAccepted = true
-	}
-	if file.VMTier != nil {
-		cfg.VMTier = *file.VMTier
-		applied.InputAccepted = true
-	}
-	if file.Privacy != nil {
-		cfg.Privacy = *file.Privacy
-		applied.InputAccepted = true
-	}
-	if file.HibernationTimeoutSecs != nil {
-		if *file.HibernationTimeoutSecs < 0 {
-			return applied, exit(2, "codesandbox hibernationTimeoutSecs must be non-negative")
-		}
-		cfg.HibernationTimeoutSecs = *file.HibernationTimeoutSecs
-		applied.InputAccepted = true
-	}
-	if file.AutomaticWakeupHTTP != nil {
-		cfg.AutomaticWakeupHTTP = *file.AutomaticWakeupHTTP
-		applied.InputAccepted = true
-	}
-	if file.AutomaticWakeupWebSocket != nil {
-		cfg.AutomaticWakeupWebSocket = *file.AutomaticWakeupWebSocket
-		applied.InputAccepted = true
-	}
-	if trusted && file.BridgeCommand != nil {
-		cfg.BridgeCommand = *file.BridgeCommand
-		applied.InputAccepted = true
-	}
-	if trusted && file.SDKPackage != nil {
-		cfg.SDKPackage = *file.SDKPackage
-		applied.InputAccepted = true
-	}
-	if file.DoctorListLimit != nil {
-		if *file.DoctorListLimit < 0 {
-			return applied, exit(2, "codesandbox doctorListLimit must be non-negative")
-		}
-		cfg.DoctorListLimit = *file.DoctorListLimit
-		applied.InputAccepted = true
-	}
-	if file.OperationTimeoutSecs != nil {
-		if *file.OperationTimeoutSecs < 0 {
-			return applied, exit(2, "codesandbox operationTimeoutSecs must be non-negative")
-		}
-		cfg.OperationTimeoutSecs = *file.OperationTimeoutSecs
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "codesandbox")
+	return applied, err
 }
 
 func (cfg *CodeSandboxConfig) applyEnv() (CodeSandboxConfigApplied, error) {

--- a/internal/cli/config_crownest_generated.go
+++ b/internal/cli/config_crownest_generated.go
@@ -33,33 +33,8 @@ type CrownestConfigApplied struct {
 
 func (cfg *CrownestConfig) applyFile(file *fileCrownestConfig, trusted bool) (CrownestConfigApplied, error) {
 	var applied CrownestConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if trusted && file.APIURL != "" {
-		cfg.APIURL = file.APIURL
-		applied.InputAccepted = true
-	}
-	if file.ProjectID != nil {
-		cfg.ProjectID = *file.ProjectID
-		applied.InputAccepted = true
-	}
-	if file.Template != nil {
-		cfg.Template = *file.Template
-		applied.InputAccepted = true
-	}
-	if file.TimeoutSecs != nil {
-		if *file.TimeoutSecs < 0 {
-			return applied, exit(2, "crownest timeoutSecs must be non-negative")
-		}
-		cfg.TimeoutSecs = *file.TimeoutSecs
-		applied.InputAccepted = true
-	}
-	if file.ForgetMissing != nil {
-		cfg.ForgetMissing = *file.ForgetMissing
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "crownest")
+	return applied, err
 }
 
 func (cfg *CrownestConfig) applyEnv() (CrownestConfigApplied, error) {

--- a/internal/cli/config_cua_generated.go
+++ b/internal/cli/config_cua_generated.go
@@ -51,77 +51,8 @@ type CuaConfigApplied struct {
 
 func (cfg *CuaConfig) applyFile(file *fileCuaConfig, trusted bool) (CuaConfigApplied, error) {
 	var applied CuaConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.Image != nil {
-		cfg.Image = *file.Image
-		applied.InputAccepted = true
-	}
-	if file.Kind != nil {
-		cfg.Kind = *file.Kind
-		applied.InputAccepted = true
-	}
-	if file.Region != nil {
-		cfg.Region = *file.Region
-		applied.InputAccepted = true
-	}
-	if file.Workdir != nil {
-		cfg.Workdir = *file.Workdir
-		applied.InputAccepted = true
-	}
-	if file.VCPUs != nil {
-		if *file.VCPUs < 0 {
-			return applied, exit(2, "cua vcpus must be non-negative")
-		}
-		cfg.VCPUs = *file.VCPUs
-		applied.InputAccepted = true
-	}
-	if file.MemoryMB != nil {
-		if *file.MemoryMB < 0 {
-			return applied, exit(2, "cua memoryMB must be non-negative")
-		}
-		cfg.MemoryMB = *file.MemoryMB
-		applied.InputAccepted = true
-	}
-	if file.DiskGB != nil {
-		if *file.DiskGB < 0 {
-			return applied, exit(2, "cua diskGB must be non-negative")
-		}
-		cfg.DiskGB = *file.DiskGB
-		applied.InputAccepted = true
-	}
-	if file.StartupTimeoutSecs != nil {
-		if *file.StartupTimeoutSecs < 0 {
-			return applied, exit(2, "cua startupTimeoutSecs must be non-negative")
-		}
-		cfg.StartupTimeoutSecs = *file.StartupTimeoutSecs
-		applied.InputAccepted = true
-	}
-	if file.ExecTimeoutSecs != nil {
-		if *file.ExecTimeoutSecs < 0 {
-			return applied, exit(2, "cua execTimeoutSecs must be non-negative")
-		}
-		cfg.ExecTimeoutSecs = *file.ExecTimeoutSecs
-		applied.InputAccepted = true
-	}
-	if trusted && file.BridgeCommand != nil {
-		cfg.BridgeCommand = *file.BridgeCommand
-		applied.InputAccepted = true
-	}
-	if trusted && file.SDKPackage != nil {
-		cfg.SDKPackage = *file.SDKPackage
-		applied.InputAccepted = true
-	}
-	if trusted && file.SDKImport != nil {
-		cfg.SDKImport = *file.SDKImport
-		applied.InputAccepted = true
-	}
-	if trusted && file.SDKFallbackImport != nil {
-		cfg.SDKFallbackImport = *file.SDKFallbackImport
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "cua")
+	return applied, err
 }
 
 func (cfg *CuaConfig) applyEnv() (CuaConfigApplied, error) {

--- a/internal/cli/config_digitalocean_generated.go
+++ b/internal/cli/config_digitalocean_generated.go
@@ -21,27 +21,8 @@ type DigitalOceanConfigApplied struct {
 
 func (cfg *DigitalOceanConfig) applyFile(file *fileDigitalOceanConfig) (DigitalOceanConfigApplied, error) {
 	var applied DigitalOceanConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.Region != "" {
-		cfg.Region = file.Region
-		applied.InputAccepted = true
-	}
-	if file.Image != "" {
-		cfg.Image = file.Image
-		applied.InputAccepted = true
-		applied.Image = true
-	}
-	if file.VPCUUID != "" {
-		cfg.VPCUUID = file.VPCUUID
-		applied.InputAccepted = true
-	}
-	if len(file.SSHCIDRs) > 0 {
-		cfg.SSHCIDRs = file.SSHCIDRs
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "digitalocean")
+	return applied, err
 }
 
 func (cfg *DigitalOceanConfig) applyEnv() (DigitalOceanConfigApplied, error) {

--- a/internal/cli/config_e2b_generated.go
+++ b/internal/cli/config_e2b_generated.go
@@ -38,32 +38,8 @@ type E2BConfigApplied struct {
 
 func (cfg *E2BConfig) applyFile(file *fileE2BConfig) (E2BConfigApplied, error) {
 	var applied E2BConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.APIURL != "" {
-		cfg.APIURL = file.APIURL
-		applied.InputAccepted = true
-		applied.APIURL = true
-	}
-	if file.Domain != "" {
-		cfg.Domain = file.Domain
-		applied.InputAccepted = true
-		applied.Domain = true
-	}
-	if file.Template != "" {
-		cfg.Template = file.Template
-		applied.InputAccepted = true
-	}
-	if file.Workdir != "" {
-		cfg.Workdir = file.Workdir
-		applied.InputAccepted = true
-	}
-	if file.User != "" {
-		cfg.User = file.User
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "e2b")
+	return applied, err
 }
 
 func (cfg *E2BConfig) applyEnv() (E2BConfigApplied, error) {

--- a/internal/cli/config_exe_dev_generated.go
+++ b/internal/cli/config_exe_dev_generated.go
@@ -42,47 +42,8 @@ type ExeDevConfigApplied struct {
 
 func (cfg *ExeDevConfig) applyFile(file *fileExeDevConfig) (ExeDevConfigApplied, error) {
 	var applied ExeDevConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.ControlHost != "" {
-		cfg.ControlHost = file.ControlHost
-		applied.InputAccepted = true
-		applied.ControlHost = true
-	}
-	if file.Image != "" {
-		cfg.Image = file.Image
-		applied.InputAccepted = true
-	}
-	if file.CPUs > 0 {
-		cfg.CPUs = file.CPUs
-		applied.InputAccepted = true
-	}
-	if file.Memory != "" {
-		cfg.Memory = file.Memory
-		applied.InputAccepted = true
-	}
-	if file.Disk != "" {
-		cfg.Disk = file.Disk
-		applied.InputAccepted = true
-	}
-	if file.Command != "" {
-		cfg.Command = file.Command
-		applied.InputAccepted = true
-	}
-	if file.User != "" {
-		cfg.User = file.User
-		applied.InputAccepted = true
-	}
-	if file.WorkRoot != "" {
-		cfg.WorkRoot = file.WorkRoot
-		applied.InputAccepted = true
-	}
-	if file.NoEmail != nil {
-		cfg.NoEmail = *file.NoEmail
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "exe-dev")
+	return applied, err
 }
 
 func (cfg *ExeDevConfig) applyEnv() (ExeDevConfigApplied, error) {

--- a/internal/cli/config_fastapi_cloud_generated.go
+++ b/internal/cli/config_fastapi_cloud_generated.go
@@ -29,23 +29,8 @@ type FastAPICloudConfigApplied struct {
 
 func (cfg *FastAPICloudConfig) applyFile(file *fileFastAPICloudConfig) (FastAPICloudConfigApplied, error) {
 	var applied FastAPICloudConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.APIURL != "" {
-		cfg.APIURL = file.APIURL
-		applied.InputAccepted = true
-		applied.APIURL = true
-	}
-	if file.AppID != "" {
-		cfg.AppID = file.AppID
-		applied.InputAccepted = true
-	}
-	if file.TeamID != "" {
-		cfg.TeamID = file.TeamID
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "fastapi-cloud")
+	return applied, err
 }
 
 func (cfg *FastAPICloudConfig) applyEnv() (FastAPICloudConfigApplied, error) {

--- a/internal/cli/config_file_overlay.go
+++ b/internal/cli/config_file_overlay.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"reflect"
+	"time"
+)
+
+// applyConfigFileOverlay overlays the generated YAML DTO using the validated schema's
+// source grants and value policy. Provider admission wrappers still prepare the
+// DTO before this call; the original persisted file is never modified here.
+func applyConfigFileOverlay(config, input, report any, trusted bool, provider string) error {
+	file := reflect.ValueOf(input)
+	if file.IsNil() {
+		return nil
+	}
+	file = file.Elem()
+	cfg, applied := reflect.ValueOf(config).Elem(), reflect.ValueOf(report).Elem()
+	for i := 0; i < cfg.NumField(); i++ {
+		field := cfg.Type().Field(i)
+		switch field.Tag.Get("sources") {
+		case "user,repo,env,flag", "user,repo,env":
+		case "user,env,flag", "user,env":
+			if !trusted {
+				continue
+			}
+		default:
+			continue
+		}
+		members := []string{field.Name}
+		if field.Tag.Get("configAlias") != "" {
+			members = append(members, field.Name+"ConfigAlias")
+		}
+		for _, member := range members {
+			accepted, err := applyConfigFileField(cfg.Field(i), file.FieldByName(member), field.Tag, provider)
+			if err != nil {
+				return err
+			}
+			if accepted {
+				applied.FieldByName("InputAccepted").SetBool(true)
+				if field.Tag.Get("reportApplied") == "true" {
+					applied.FieldByName(field.Name).SetBool(true)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func applyConfigFileField(dst, src reflect.Value, tags reflect.StructTag, provider string) (bool, error) {
+	if src.Kind() == reflect.Pointer {
+		if src.IsNil() {
+			return false, nil
+		}
+		src = src.Elem()
+	}
+	if dst.Type() == reflect.TypeFor[time.Duration]() {
+		return applyLeaseDuration(dst.Addr().Interface().(*time.Duration), src.String()), nil
+	}
+	switch dst.Kind() {
+	case reflect.String:
+		if tags.Get("fileIgnoreEmpty") == "true" && src.String() == "" {
+			return false, nil
+		}
+	case reflect.Int, reflect.Int64:
+		value := src.Int()
+		switch tags.Get("fileInt") {
+		case "positive":
+			if value <= 0 {
+				return false, nil
+			}
+		case "nonzero":
+			if value == 0 {
+				return false, nil
+			}
+		case "present":
+		default:
+			if value < 0 {
+				return false, exit(2, "%s %s must be non-negative", provider, tags.Get("config"))
+			}
+		}
+	case reflect.Float64:
+		if tags.Get("fileFloat") == "positive" && !(src.Float() > 0) {
+			return false, nil
+		}
+	case reflect.Slice:
+		value := src.Interface().([]string)
+		switch tags.Get("fileList") {
+		case "raw":
+			if tags.Get("fileStorage") == "value" && value == nil {
+				return false, nil
+			}
+			value = append([]string(nil), value...)
+		case "nonempty-raw":
+			if len(value) == 0 {
+				return false, nil
+			}
+		case "nonempty-normalized":
+			if len(value) == 0 {
+				return false, nil
+			}
+			value = normalizeList(value)
+		default:
+			value = normalizeList(value)
+		}
+		src = reflect.ValueOf(value)
+	case reflect.Pointer:
+		value := src.Bool()
+		src = reflect.ValueOf(&value)
+	}
+	dst.Set(src)
+	return true, nil
+}

--- a/internal/cli/config_firecracker_generated.go
+++ b/internal/cli/config_firecracker_generated.go
@@ -73,80 +73,8 @@ type FirecrackerConfigApplied struct {
 
 func (cfg *FirecrackerConfig) applyFile(file *fileFirecrackerConfig, trusted bool) (FirecrackerConfigApplied, error) {
 	var applied FirecrackerConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if trusted && file.Binary != "" {
-		cfg.Binary = file.Binary
-		applied.InputAccepted = true
-		applied.Binary = true
-	}
-	if trusted && file.Jailer != "" {
-		cfg.Jailer = file.Jailer
-		applied.InputAccepted = true
-		applied.Jailer = true
-	}
-	if trusted && file.Kernel != "" {
-		cfg.Kernel = file.Kernel
-		applied.InputAccepted = true
-		applied.Kernel = true
-	}
-	if trusted && file.RootFS != "" {
-		cfg.RootFS = file.RootFS
-		applied.InputAccepted = true
-		applied.RootFS = true
-	}
-	if file.User != "" {
-		cfg.User = file.User
-		applied.InputAccepted = true
-		applied.User = true
-	}
-	if file.WorkRoot != "" {
-		cfg.WorkRoot = file.WorkRoot
-		applied.InputAccepted = true
-		applied.WorkRoot = true
-	}
-	if file.CPUs != nil {
-		cfg.CPUs = *file.CPUs
-		applied.InputAccepted = true
-	}
-	if file.MemoryMiB != nil {
-		cfg.MemoryMiB = *file.MemoryMiB
-		applied.InputAccepted = true
-	}
-	if file.DiskMiB != nil {
-		cfg.DiskMiB = *file.DiskMiB
-		applied.InputAccepted = true
-	}
-	if trusted && file.Network != "" {
-		cfg.Network = file.Network
-		applied.InputAccepted = true
-	}
-	if trusted && file.CNINetwork != "" {
-		cfg.CNINetwork = file.CNINetwork
-		applied.InputAccepted = true
-	}
-	if trusted && file.CNIConfDir != "" {
-		cfg.CNIConfDir = file.CNIConfDir
-		applied.InputAccepted = true
-		applied.CNIConfDir = true
-	}
-	if trusted && file.CNIBinDir != "" {
-		cfg.CNIBinDir = file.CNIBinDir
-		applied.InputAccepted = true
-		applied.CNIBinDir = true
-	}
-	if file.LaunchTimeout != "" {
-		if applyLeaseDuration(&cfg.LaunchTimeout, file.LaunchTimeout) {
-			applied.InputAccepted = true
-		}
-	}
-	if file.DeleteOnRelease != nil {
-		cfg.DeleteOnRelease = *file.DeleteOnRelease
-		applied.InputAccepted = true
-		applied.DeleteOnRelease = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "firecracker")
+	return applied, err
 }
 
 func (cfg *FirecrackerConfig) applyEnv() (FirecrackerConfigApplied, error) {

--- a/internal/cli/config_freestyle_generated.go
+++ b/internal/cli/config_freestyle_generated.go
@@ -30,26 +30,8 @@ type FreestyleConfigApplied struct {
 
 func (cfg *FreestyleConfig) applyFile(file *fileFreestyleConfig, trusted bool) (FreestyleConfigApplied, error) {
 	var applied FreestyleConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if trusted && file.APIURL != "" {
-		cfg.APIURL = file.APIURL
-		applied.InputAccepted = true
-	}
-	if file.Workdir != "" {
-		cfg.Workdir = file.Workdir
-		applied.InputAccepted = true
-	}
-	if file.VCPUs > 0 {
-		cfg.VCPUs = file.VCPUs
-		applied.InputAccepted = true
-	}
-	if file.MemoryGB > 0 {
-		cfg.MemoryGB = file.MemoryGB
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "freestyle")
+	return applied, err
 }
 
 func (cfg *FreestyleConfig) applyEnv() (FreestyleConfigApplied, error) {

--- a/internal/cli/config_incus_generated.go
+++ b/internal/cli/config_incus_generated.go
@@ -62,86 +62,8 @@ type IncusConfigApplied struct {
 
 func (cfg *IncusConfig) applyFile(file *fileIncusConfig) (IncusConfigApplied, error) {
 	var applied IncusConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.Remote != "" {
-		cfg.Remote = file.Remote
-		applied.InputAccepted = true
-	}
-	if file.Project != "" {
-		cfg.Project = file.Project
-		applied.InputAccepted = true
-	}
-	if file.Address != "" {
-		cfg.Address = file.Address
-		applied.InputAccepted = true
-	}
-	if file.Socket != "" {
-		cfg.Socket = file.Socket
-		applied.InputAccepted = true
-		applied.Socket = true
-	}
-	if file.InstanceType != "" {
-		cfg.InstanceType = file.InstanceType
-		applied.InputAccepted = true
-	}
-	if file.Image != "" {
-		cfg.Image = file.Image
-		applied.InputAccepted = true
-	}
-	if file.Profile != "" {
-		cfg.Profile = file.Profile
-		applied.InputAccepted = true
-	}
-	if file.User != "" {
-		cfg.User = file.User
-		applied.InputAccepted = true
-	}
-	if file.WorkRoot != "" {
-		cfg.WorkRoot = file.WorkRoot
-		applied.InputAccepted = true
-	}
-	if file.DeleteOnRelease != nil {
-		cfg.DeleteOnRelease = *file.DeleteOnRelease
-		applied.InputAccepted = true
-		applied.DeleteOnRelease = true
-	}
-	if file.StartTimeout != "" {
-		if applyLeaseDuration(&cfg.StartTimeout, file.StartTimeout) {
-			applied.InputAccepted = true
-		}
-	}
-	if file.LaunchPort != "" {
-		cfg.LaunchPort = file.LaunchPort
-		applied.InputAccepted = true
-	}
-	if file.ProxyListenHost != "" {
-		cfg.ProxyListenHost = file.ProxyListenHost
-		applied.InputAccepted = true
-	}
-	if file.ProxyListenPort != "" {
-		cfg.ProxyListenPort = file.ProxyListenPort
-		applied.InputAccepted = true
-	}
-	if file.ProxyDevice != "" {
-		cfg.ProxyDevice = file.ProxyDevice
-		applied.InputAccepted = true
-	}
-	if file.TLSServerCert != "" {
-		cfg.TLSServerCert = file.TLSServerCert
-		applied.InputAccepted = true
-		applied.TLSServerCert = true
-	}
-	if file.InsecureTLS != nil {
-		cfg.InsecureTLS = *file.InsecureTLS
-		applied.InputAccepted = true
-	}
-	if file.RemoteImageServer != "" {
-		cfg.RemoteImageServer = file.RemoteImageServer
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "incus")
+	return applied, err
 }
 
 func (cfg *IncusConfig) applyEnv() (IncusConfigApplied, error) {

--- a/internal/cli/config_kubevirt_generated.go
+++ b/internal/cli/config_kubevirt_generated.go
@@ -56,66 +56,8 @@ type KubeVirtConfigApplied struct {
 
 func (cfg *KubeVirtConfig) applyFile(file *fileKubeVirtConfig, trusted bool) (KubeVirtConfigApplied, error) {
 	var applied KubeVirtConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.Kubectl != "" {
-		cfg.Kubectl = file.Kubectl
-		applied.InputAccepted = true
-		applied.Kubectl = true
-	}
-	if file.Virtctl != "" {
-		cfg.Virtctl = file.Virtctl
-		applied.InputAccepted = true
-		applied.Virtctl = true
-	}
-	if file.Kubeconfig != "" {
-		cfg.Kubeconfig = file.Kubeconfig
-		applied.InputAccepted = true
-		applied.Kubeconfig = true
-	}
-	if file.Context != "" {
-		cfg.Context = file.Context
-		applied.InputAccepted = true
-	}
-	if file.Namespace != "" {
-		cfg.Namespace = file.Namespace
-		applied.InputAccepted = true
-	}
-	if file.Template != "" {
-		cfg.Template = file.Template
-		applied.InputAccepted = true
-		applied.Template = true
-	}
-	if file.SSHUser != "" {
-		cfg.SSHUser = file.SSHUser
-		applied.InputAccepted = true
-	}
-	if trusted && file.SSHKey != "" {
-		cfg.SSHKey = file.SSHKey
-		applied.InputAccepted = true
-		applied.SSHKey = true
-	}
-	if file.SSHPublicKey != "" {
-		cfg.SSHPublicKey = file.SSHPublicKey
-		applied.InputAccepted = true
-		applied.SSHPublicKey = true
-	}
-	if file.SSHPort != "" {
-		cfg.SSHPort = file.SSHPort
-		applied.InputAccepted = true
-	}
-	if file.WorkRoot != "" {
-		cfg.WorkRoot = file.WorkRoot
-		applied.InputAccepted = true
-		applied.WorkRoot = true
-	}
-	if file.DeleteOnRelease != nil {
-		cfg.DeleteOnRelease = *file.DeleteOnRelease
-		applied.InputAccepted = true
-		applied.DeleteOnRelease = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "kubevirt")
+	return applied, err
 }
 
 func (cfg *KubeVirtConfig) applyEnv() (KubeVirtConfigApplied, error) {

--- a/internal/cli/config_linode_generated.go
+++ b/internal/cli/config_linode_generated.go
@@ -23,32 +23,8 @@ type LinodeConfigApplied struct {
 
 func (cfg *LinodeConfig) applyFile(file *fileLinodeConfig) (LinodeConfigApplied, error) {
 	var applied LinodeConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.Region != "" {
-		cfg.Region = file.Region
-		applied.InputAccepted = true
-	}
-	if file.Image != "" {
-		cfg.Image = file.Image
-		applied.InputAccepted = true
-		applied.Image = true
-	}
-	if file.Type != "" {
-		cfg.Type = file.Type
-		applied.InputAccepted = true
-		applied.Type = true
-	}
-	if file.FirewallID != "" {
-		cfg.FirewallID = file.FirewallID
-		applied.InputAccepted = true
-	}
-	if len(file.SSHCIDRs) > 0 {
-		cfg.SSHCIDRs = file.SSHCIDRs
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "linode")
+	return applied, err
 }
 
 func (cfg *LinodeConfig) applyEnv() (LinodeConfigApplied, error) {

--- a/internal/cli/config_lume_generated.go
+++ b/internal/cli/config_lume_generated.go
@@ -35,30 +35,8 @@ type LumeConfigApplied struct {
 
 func (cfg *LumeConfig) applyFile(file *fileLumeConfig, trusted bool) (LumeConfigApplied, error) {
 	var applied LumeConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if trusted && file.CLIPath != "" {
-		cfg.CLIPath = file.CLIPath
-		applied.InputAccepted = true
-	}
-	if trusted && file.Base != "" {
-		cfg.Base = file.Base
-		applied.InputAccepted = true
-	}
-	if trusted && file.Storage != "" {
-		cfg.Storage = file.Storage
-		applied.InputAccepted = true
-	}
-	if trusted && file.User != "" {
-		cfg.User = file.User
-		applied.InputAccepted = true
-	}
-	if file.WorkRoot != "" {
-		cfg.WorkRoot = file.WorkRoot
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "lume")
+	return applied, err
 }
 
 func (cfg *LumeConfig) applyEnv() (LumeConfigApplied, error) {

--- a/internal/cli/config_machine0_generated.go
+++ b/internal/cli/config_machine0_generated.go
@@ -50,58 +50,8 @@ type Machine0ConfigApplied struct {
 
 func (cfg *Machine0Config) applyFile(file *fileMachine0Config) (Machine0ConfigApplied, error) {
 	var applied Machine0ConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.CLIPath != "" {
-		cfg.CLIPath = file.CLIPath
-		applied.InputAccepted = true
-	}
-	if file.Image != "" {
-		cfg.Image = file.Image
-		applied.InputAccepted = true
-	}
-	if file.ImageVersion != nil {
-		cfg.ImageVersion = *file.ImageVersion
-		applied.InputAccepted = true
-	}
-	if file.DesktopImage != "" {
-		cfg.DesktopImage = file.DesktopImage
-		applied.InputAccepted = true
-	}
-	if file.Size != "" {
-		cfg.Size = file.Size
-		applied.InputAccepted = true
-		applied.Size = true
-	}
-	if file.Region != "" {
-		cfg.Region = file.Region
-		applied.InputAccepted = true
-	}
-	if file.Key != "" {
-		cfg.Key = file.Key
-		applied.InputAccepted = true
-	}
-	if file.WorkRoot != "" {
-		cfg.WorkRoot = file.WorkRoot
-		applied.InputAccepted = true
-		applied.WorkRoot = true
-	}
-	if file.ReleasePolicy != "" {
-		cfg.ReleasePolicy = file.ReleasePolicy
-		applied.InputAccepted = true
-	}
-	if file.CreateTimeout != "" {
-		if applyLeaseDuration(&cfg.CreateTimeout, file.CreateTimeout) {
-			applied.InputAccepted = true
-		}
-	}
-	if file.PollInterval != "" {
-		if applyLeaseDuration(&cfg.PollInterval, file.PollInterval) {
-			applied.InputAccepted = true
-		}
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "machine0")
+	return applied, err
 }
 
 func (cfg *Machine0Config) applyEnv() (Machine0ConfigApplied, error) {

--- a/internal/cli/config_modal_generated.go
+++ b/internal/cli/config_modal_generated.go
@@ -36,34 +36,8 @@ type ModalConfigApplied struct {
 
 func (cfg *ModalConfig) applyFile(file *fileModalConfig, trusted bool) (ModalConfigApplied, error) {
 	var applied ModalConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.App != "" {
-		cfg.App = file.App
-		applied.InputAccepted = true
-	}
-	if file.Image != "" {
-		cfg.Image = file.Image
-		applied.InputAccepted = true
-	}
-	if file.Workdir != "" {
-		cfg.Workdir = file.Workdir
-		applied.InputAccepted = true
-	}
-	if file.Python != "" {
-		cfg.Python = file.Python
-		applied.InputAccepted = true
-	}
-	if trusted && file.Environment != "" {
-		cfg.Environment = file.Environment
-		applied.InputAccepted = true
-	}
-	if trusted && file.Secrets != nil {
-		cfg.Secrets = append([]string(nil), (*file.Secrets)...)
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "modal")
+	return applied, err
 }
 
 func (cfg *ModalConfig) applyEnv() (ModalConfigApplied, error) {

--- a/internal/cli/config_morph_generated.go
+++ b/internal/cli/config_morph_generated.go
@@ -41,42 +41,8 @@ type MorphConfigApplied struct {
 
 func (cfg *MorphConfig) applyFile(file *fileMorphConfig) (MorphConfigApplied, error) {
 	var applied MorphConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.APIKey != "" {
-		cfg.APIKey = file.APIKey
-		applied.InputAccepted = true
-		applied.APIKey = true
-	}
-	if file.APIURL != "" {
-		cfg.APIURL = file.APIURL
-		applied.InputAccepted = true
-		applied.APIURL = true
-	}
-	if file.Snapshot != "" {
-		cfg.Snapshot = file.Snapshot
-		applied.InputAccepted = true
-	}
-	if file.SSHGatewayHost != "" {
-		cfg.SSHGatewayHost = file.SSHGatewayHost
-		applied.InputAccepted = true
-		applied.SSHGatewayHost = true
-	}
-	if file.WorkRoot != "" {
-		cfg.WorkRoot = file.WorkRoot
-		applied.InputAccepted = true
-	}
-	if file.DeleteOnRelease != nil {
-		cfg.DeleteOnRelease = *file.DeleteOnRelease
-		applied.InputAccepted = true
-		applied.DeleteOnRelease = true
-	}
-	if file.WakeOnSSH != nil {
-		cfg.WakeOnSSH = *file.WakeOnSSH
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "morph")
+	return applied, err
 }
 
 func (cfg *MorphConfig) applyEnv() (MorphConfigApplied, error) {

--- a/internal/cli/config_multipass_generated.go
+++ b/internal/cli/config_multipass_generated.go
@@ -46,46 +46,8 @@ type MultipassConfigApplied struct {
 
 func (cfg *MultipassConfig) applyFile(file *fileMultipassConfig) (MultipassConfigApplied, error) {
 	var applied MultipassConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.CLIPath != "" {
-		cfg.CLIPath = file.CLIPath
-		applied.InputAccepted = true
-	}
-	if file.Image != "" {
-		cfg.Image = file.Image
-		applied.InputAccepted = true
-		applied.Image = true
-	}
-	if file.User != "" {
-		cfg.User = file.User
-		applied.InputAccepted = true
-		applied.User = true
-	}
-	if file.WorkRoot != "" {
-		cfg.WorkRoot = file.WorkRoot
-		applied.InputAccepted = true
-		applied.WorkRoot = true
-	}
-	if file.CPUs > 0 {
-		cfg.CPUs = file.CPUs
-		applied.InputAccepted = true
-	}
-	if file.Memory != "" {
-		cfg.Memory = file.Memory
-		applied.InputAccepted = true
-	}
-	if file.Disk != "" {
-		cfg.Disk = file.Disk
-		applied.InputAccepted = true
-	}
-	if file.LaunchTimeout != "" {
-		if applyLeaseDuration(&cfg.LaunchTimeout, file.LaunchTimeout) {
-			applied.InputAccepted = true
-		}
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "multipass")
+	return applied, err
 }
 
 func (cfg *MultipassConfig) applyEnv() (MultipassConfigApplied, error) {

--- a/internal/cli/config_namespace_generated.go
+++ b/internal/cli/config_namespace_generated.go
@@ -41,46 +41,8 @@ type NamespaceConfigApplied struct {
 
 func (cfg *NamespaceConfig) applyFile(file *fileNamespaceConfig) (NamespaceConfigApplied, error) {
 	var applied NamespaceConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.Image != "" {
-		cfg.Image = file.Image
-		applied.InputAccepted = true
-	}
-	if file.Size != "" {
-		cfg.Size = file.Size
-		applied.InputAccepted = true
-		applied.Size = true
-	}
-	if file.Repository != "" {
-		cfg.Repository = file.Repository
-		applied.InputAccepted = true
-	}
-	if file.Site != "" {
-		cfg.Site = file.Site
-		applied.InputAccepted = true
-	}
-	if file.VolumeSizeGB > 0 {
-		cfg.VolumeSizeGB = file.VolumeSizeGB
-		applied.InputAccepted = true
-	}
-	if file.AutoStopIdleTimeout != "" {
-		if applyLeaseDuration(&cfg.AutoStopIdleTimeout, file.AutoStopIdleTimeout) {
-			applied.InputAccepted = true
-		}
-	}
-	if file.WorkRoot != "" {
-		cfg.WorkRoot = file.WorkRoot
-		applied.InputAccepted = true
-		applied.WorkRoot = true
-	}
-	if file.DeleteOnRelease != nil {
-		cfg.DeleteOnRelease = *file.DeleteOnRelease
-		applied.InputAccepted = true
-		applied.DeleteOnRelease = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "namespace")
+	return applied, err
 }
 
 func (cfg *NamespaceConfig) applyEnv() (NamespaceConfigApplied, error) {

--- a/internal/cli/config_namespace_instance_generated.go
+++ b/internal/cli/config_namespace_instance_generated.go
@@ -39,48 +39,8 @@ type NamespaceInstanceConfigApplied struct {
 
 func (cfg *NamespaceInstanceConfig) applyFile(file *fileNamespaceInstanceConfig, trusted bool) (NamespaceInstanceConfigApplied, error) {
 	var applied NamespaceInstanceConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if trusted && file.CLIPath != "" {
-		cfg.CLIPath = file.CLIPath
-		applied.InputAccepted = true
-		applied.CLIPath = true
-	}
-	if file.MachineType != "" {
-		cfg.MachineType = file.MachineType
-		applied.InputAccepted = true
-	}
-	if file.Duration != "" {
-		if applyLeaseDuration(&cfg.Duration, file.Duration) {
-			applied.InputAccepted = true
-		}
-	}
-	if trusted && file.Region != "" {
-		cfg.Region = file.Region
-		applied.InputAccepted = true
-	}
-	if trusted && file.Endpoint != "" {
-		cfg.Endpoint = file.Endpoint
-		applied.InputAccepted = true
-	}
-	if trusted && file.Keychain != "" {
-		cfg.Keychain = file.Keychain
-		applied.InputAccepted = true
-	}
-	if trusted && file.Volumes != nil {
-		cfg.Volumes = append([]string(nil), (file.Volumes)...)
-		applied.InputAccepted = true
-	}
-	if file.WorkRoot != "" {
-		cfg.WorkRoot = file.WorkRoot
-		applied.InputAccepted = true
-	}
-	if file.Bare != nil {
-		cfg.Bare = *file.Bare
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "namespaceInstance")
+	return applied, err
 }
 
 func (cfg *NamespaceInstanceConfig) applyEnv() (NamespaceInstanceConfigApplied, error) {

--- a/internal/cli/config_nebius_generated.go
+++ b/internal/cli/config_nebius_generated.go
@@ -54,66 +54,8 @@ type NebiusConfigApplied struct {
 
 func (cfg *NebiusConfig) applyFile(file *fileNebiusConfig, trusted bool) (NebiusConfigApplied, error) {
 	var applied NebiusConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if trusted && file.CLI != "" {
-		cfg.CLI = file.CLI
-		applied.InputAccepted = true
-	}
-	if trusted && file.Profile != "" {
-		cfg.Profile = file.Profile
-		applied.InputAccepted = true
-	}
-	if file.ParentID != "" {
-		cfg.ParentID = file.ParentID
-		applied.InputAccepted = true
-	}
-	if file.SubnetID != "" {
-		cfg.SubnetID = file.SubnetID
-		applied.InputAccepted = true
-	}
-	if file.Platform != "" {
-		cfg.Platform = file.Platform
-		applied.InputAccepted = true
-	}
-	if file.Preset != "" {
-		cfg.Preset = file.Preset
-		applied.InputAccepted = true
-	}
-	if file.ImageFamily != "" {
-		cfg.ImageFamily = file.ImageFamily
-		applied.InputAccepted = true
-	}
-	if file.DiskType != "" {
-		cfg.DiskType = file.DiskType
-		applied.InputAccepted = true
-	}
-	if file.DiskSizeGiB > 0 {
-		cfg.DiskSizeGiB = file.DiskSizeGiB
-		applied.InputAccepted = true
-	}
-	if file.User != "" {
-		cfg.User = file.User
-		applied.InputAccepted = true
-	}
-	if file.PublicIP != "" {
-		cfg.PublicIP = file.PublicIP
-		applied.InputAccepted = true
-	}
-	if len(file.SecurityGroupIDs) > 0 {
-		cfg.SecurityGroupIDs = file.SecurityGroupIDs
-		applied.InputAccepted = true
-	}
-	if trusted && file.ServiceAccountID != "" {
-		cfg.ServiceAccountID = file.ServiceAccountID
-		applied.InputAccepted = true
-	}
-	if file.RecoveryPolicy != "" {
-		cfg.RecoveryPolicy = file.RecoveryPolicy
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "nebius")
+	return applied, err
 }
 
 func (cfg *NebiusConfig) applyEnv() (NebiusConfigApplied, error) {

--- a/internal/cli/config_nvidia_brev_generated.go
+++ b/internal/cli/config_nvidia_brev_generated.go
@@ -48,60 +48,8 @@ type NvidiaBrevConfigApplied struct {
 
 func (cfg *NvidiaBrevConfig) applyFile(file *fileNvidiaBrevConfig, trusted bool) (NvidiaBrevConfigApplied, error) {
 	var applied NvidiaBrevConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if trusted && file.CLI != "" {
-		cfg.CLI = file.CLI
-		applied.InputAccepted = true
-	}
-	if file.Org != "" {
-		cfg.Org = file.Org
-		applied.InputAccepted = true
-	}
-	if file.Type != "" {
-		cfg.Type = file.Type
-		applied.InputAccepted = true
-	}
-	if file.GPUName != "" {
-		cfg.GPUName = file.GPUName
-		applied.InputAccepted = true
-	}
-	if file.Provider != "" {
-		cfg.Provider = file.Provider
-		applied.InputAccepted = true
-	}
-	if file.Mode != "" {
-		cfg.Mode = file.Mode
-		applied.InputAccepted = true
-	}
-	if file.Launchable != "" {
-		cfg.Launchable = file.Launchable
-		applied.InputAccepted = true
-	}
-	if file.StartupScript != "" {
-		cfg.StartupScript = file.StartupScript
-		applied.InputAccepted = true
-	}
-	if file.ReleaseAction != "" {
-		cfg.ReleaseAction = file.ReleaseAction
-		applied.InputAccepted = true
-		applied.ReleaseAction = true
-	}
-	if file.Target != "" {
-		cfg.Target = file.Target
-		applied.InputAccepted = true
-	}
-	if file.User != "" {
-		cfg.User = file.User
-		applied.InputAccepted = true
-	}
-	if file.WorkRoot != "" {
-		cfg.WorkRoot = file.WorkRoot
-		applied.InputAccepted = true
-		applied.WorkRoot = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "nvidia-brev")
+	return applied, err
 }
 
 func (cfg *NvidiaBrevConfig) applyEnv() (NvidiaBrevConfigApplied, error) {

--- a/internal/cli/config_opencomputer_generated.go
+++ b/internal/cli/config_opencomputer_generated.go
@@ -32,34 +32,8 @@ type OpenComputerConfigApplied struct {
 
 func (cfg *OpenComputerConfig) applyFile(file *fileOpenComputerConfig) (OpenComputerConfigApplied, error) {
 	var applied OpenComputerConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.Workdir != "" {
-		cfg.Workdir = file.Workdir
-		applied.InputAccepted = true
-	}
-	if file.CPU != nil {
-		cfg.CPU = *file.CPU
-		applied.InputAccepted = true
-	}
-	if file.MemoryMB != nil {
-		cfg.MemoryMB = *file.MemoryMB
-		applied.InputAccepted = true
-	}
-	if file.TimeoutSecs != nil {
-		cfg.TimeoutSecs = *file.TimeoutSecs
-		applied.InputAccepted = true
-	}
-	if file.ExecTimeoutSecs != nil {
-		cfg.ExecTimeoutSecs = *file.ExecTimeoutSecs
-		applied.InputAccepted = true
-	}
-	if file.Burst != nil {
-		cfg.Burst = *file.Burst
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "opencomputer")
+	return applied, err
 }
 
 func (cfg *OpenComputerConfig) applyEnv() (OpenComputerConfigApplied, error) {

--- a/internal/cli/config_opensandbox_generated.go
+++ b/internal/cli/config_opensandbox_generated.go
@@ -46,56 +46,8 @@ type OpenSandboxConfigApplied struct {
 
 func (cfg *OpenSandboxConfig) applyFile(file *fileOpenSandboxConfig) (OpenSandboxConfigApplied, error) {
 	var applied OpenSandboxConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.Image != nil {
-		cfg.Image = *file.Image
-		applied.InputAccepted = true
-	}
-	if file.Workdir != nil {
-		cfg.Workdir = *file.Workdir
-		applied.InputAccepted = true
-	}
-	if file.CPU != nil {
-		cfg.CPU = *file.CPU
-		applied.InputAccepted = true
-	}
-	if file.Memory != nil {
-		cfg.Memory = *file.Memory
-		applied.InputAccepted = true
-	}
-	if file.TimeoutSecs != nil {
-		if *file.TimeoutSecs < 0 {
-			return applied, exit(2, "opensandbox timeoutSecs must be non-negative")
-		}
-		cfg.TimeoutSecs = *file.TimeoutSecs
-		applied.InputAccepted = true
-	}
-	if file.ExecTimeoutSecs != nil {
-		if *file.ExecTimeoutSecs < 0 {
-			return applied, exit(2, "opensandbox execTimeoutSecs must be non-negative")
-		}
-		cfg.ExecTimeoutSecs = *file.ExecTimeoutSecs
-		applied.InputAccepted = true
-	}
-	if file.PlatformOS != nil {
-		cfg.PlatformOS = *file.PlatformOS
-		applied.InputAccepted = true
-	}
-	if file.PlatformArch != nil {
-		cfg.PlatformArch = *file.PlatformArch
-		applied.InputAccepted = true
-	}
-	if file.SecureAccess != nil {
-		cfg.SecureAccess = *file.SecureAccess
-		applied.InputAccepted = true
-	}
-	if file.UseServerProxy != nil {
-		cfg.UseServerProxy = *file.UseServerProxy
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "opensandbox")
+	return applied, err
 }
 
 func (cfg *OpenSandboxConfig) applyEnv() (OpenSandboxConfigApplied, error) {

--- a/internal/cli/config_orgo_generated.go
+++ b/internal/cli/config_orgo_generated.go
@@ -41,40 +41,8 @@ type OrgoConfigApplied struct {
 
 func (cfg *OrgoConfig) applyFile(file *fileOrgoConfig, trusted bool) (OrgoConfigApplied, error) {
 	var applied OrgoConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if trusted && file.APIKey != "" {
-		cfg.APIKey = file.APIKey
-		applied.InputAccepted = true
-		applied.APIKey = true
-	}
-	if file.APIBase != "" {
-		cfg.APIBase = file.APIBase
-		applied.InputAccepted = true
-		applied.APIBase = true
-	}
-	if file.WorkspaceID != "" {
-		cfg.WorkspaceID = file.WorkspaceID
-		applied.InputAccepted = true
-	}
-	if file.RAMGB > 0 {
-		cfg.RAMGB = file.RAMGB
-		applied.InputAccepted = true
-	}
-	if file.CPUs > 0 {
-		cfg.CPUs = file.CPUs
-		applied.InputAccepted = true
-	}
-	if file.DiskGB > 0 {
-		cfg.DiskGB = file.DiskGB
-		applied.InputAccepted = true
-	}
-	if file.Resolution != "" {
-		cfg.Resolution = file.Resolution
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "orgo")
+	return applied, err
 }
 
 func (cfg *OrgoConfig) applyEnv() (OrgoConfigApplied, error) {

--- a/internal/cli/config_ovh_generated.go
+++ b/internal/cli/config_ovh_generated.go
@@ -34,31 +34,8 @@ type OVHConfigApplied struct {
 
 func (cfg *OVHConfig) applyFile(file *fileOVHConfig, trusted bool) (OVHConfigApplied, error) {
 	var applied OVHConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if trusted && file.Endpoint != "" {
-		cfg.Endpoint = file.Endpoint
-		applied.InputAccepted = true
-	}
-	if file.ProjectID != "" {
-		cfg.ProjectID = file.ProjectID
-		applied.InputAccepted = true
-	}
-	if file.Region != "" {
-		cfg.Region = file.Region
-		applied.InputAccepted = true
-	}
-	if file.Image != "" {
-		cfg.Image = file.Image
-		applied.InputAccepted = true
-		applied.Image = true
-	}
-	if file.Flavor != "" {
-		cfg.Flavor = file.Flavor
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "ovh")
+	return applied, err
 }
 
 func (cfg *OVHConfig) applyEnv() (OVHConfigApplied, error) {

--- a/internal/cli/config_phala_generated.go
+++ b/internal/cli/config_phala_generated.go
@@ -37,38 +37,8 @@ type PhalaConfigApplied struct {
 
 func (cfg *PhalaConfig) applyFile(file *filePhalaConfig, trusted bool) (PhalaConfigApplied, error) {
 	var applied PhalaConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if trusted && file.CLIPath != "" {
-		cfg.CLIPath = file.CLIPath
-		applied.InputAccepted = true
-		applied.CLIPath = true
-	}
-	if file.InstanceType != "" {
-		cfg.InstanceType = file.InstanceType
-		applied.InputAccepted = true
-		applied.InstanceType = true
-	}
-	if file.WorkRoot != "" {
-		cfg.WorkRoot = file.WorkRoot
-		applied.InputAccepted = true
-	}
-	if trusted && file.NodeID != "" {
-		cfg.NodeID = file.NodeID
-		applied.InputAccepted = true
-	}
-	if trusted && file.Compose != "" {
-		cfg.Compose = file.Compose
-		applied.InputAccepted = true
-		applied.Compose = true
-	}
-	if file.Attest != nil {
-		value := *file.Attest
-		cfg.Attest = &value
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "phala")
+	return applied, err
 }
 
 func (cfg *PhalaConfig) applyEnv() (PhalaConfigApplied, error) {

--- a/internal/cli/config_railway_generated.go
+++ b/internal/cli/config_railway_generated.go
@@ -29,23 +29,8 @@ type RailwayConfigApplied struct {
 
 func (cfg *RailwayConfig) applyFile(file *fileRailwayConfig) (RailwayConfigApplied, error) {
 	var applied RailwayConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.APIURL != "" {
-		cfg.APIURL = file.APIURL
-		applied.InputAccepted = true
-		applied.APIURL = true
-	}
-	if file.ProjectID != "" {
-		cfg.ProjectID = file.ProjectID
-		applied.InputAccepted = true
-	}
-	if file.EnvironmentID != "" {
-		cfg.EnvironmentID = file.EnvironmentID
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "railway")
+	return applied, err
 }
 
 func (cfg *RailwayConfig) applyEnv() (RailwayConfigApplied, error) {

--- a/internal/cli/config_runpod_generated.go
+++ b/internal/cli/config_runpod_generated.go
@@ -42,43 +42,8 @@ type RunpodConfigApplied struct {
 
 func (cfg *RunpodConfig) applyFile(file *fileRunpodConfig) (RunpodConfigApplied, error) {
 	var applied RunpodConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.APIURL != "" {
-		cfg.APIURL = file.APIURL
-		applied.InputAccepted = true
-		applied.APIURL = true
-	}
-	if file.CloudType != "" {
-		cfg.CloudType = file.CloudType
-		applied.InputAccepted = true
-	}
-	if file.InstanceID != "" {
-		cfg.InstanceID = file.InstanceID
-		applied.InputAccepted = true
-	}
-	if file.Image != "" {
-		cfg.Image = file.Image
-		applied.InputAccepted = true
-	}
-	if file.TemplateID != "" {
-		cfg.TemplateID = file.TemplateID
-		applied.InputAccepted = true
-	}
-	if file.DiskGB != 0 {
-		cfg.DiskGB = file.DiskGB
-		applied.InputAccepted = true
-	}
-	if file.User != "" {
-		cfg.User = file.User
-		applied.InputAccepted = true
-	}
-	if file.WorkRoot != "" {
-		cfg.WorkRoot = file.WorkRoot
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "runpod")
+	return applied, err
 }
 
 func (cfg *RunpodConfig) applyEnv() (RunpodConfigApplied, error) {

--- a/internal/cli/config_scaleway_generated.go
+++ b/internal/cli/config_scaleway_generated.go
@@ -42,46 +42,8 @@ type ScalewayConfigApplied struct {
 
 func (cfg *ScalewayConfig) applyFile(file *fileScalewayConfig) (ScalewayConfigApplied, error) {
 	var applied ScalewayConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.Region != "" {
-		cfg.Region = file.Region
-		applied.InputAccepted = true
-		applied.Region = true
-	}
-	if file.Zone != "" {
-		cfg.Zone = file.Zone
-		applied.InputAccepted = true
-		applied.Zone = true
-	}
-	if file.Image != "" {
-		cfg.Image = file.Image
-		applied.InputAccepted = true
-		applied.Image = true
-	}
-	if file.Type != "" {
-		cfg.Type = file.Type
-		applied.InputAccepted = true
-		applied.Type = true
-	}
-	if file.ProjectID != "" {
-		cfg.ProjectID = file.ProjectID
-		applied.InputAccepted = true
-	}
-	if file.OrganizationID != "" {
-		cfg.OrganizationID = file.OrganizationID
-		applied.InputAccepted = true
-	}
-	if file.SecurityGroup != "" {
-		cfg.SecurityGroup = file.SecurityGroup
-		applied.InputAccepted = true
-	}
-	if len(file.SSHCIDRs) > 0 {
-		cfg.SSHCIDRs = file.SSHCIDRs
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "scaleway")
+	return applied, err
 }
 
 func (cfg *ScalewayConfig) applyEnv() (ScalewayConfigApplied, error) {

--- a/internal/cli/config_sealos_devbox_generated.go
+++ b/internal/cli/config_sealos_devbox_generated.go
@@ -60,78 +60,8 @@ type SealosDevboxConfigApplied struct {
 
 func (cfg *SealosDevboxConfig) applyFile(file *fileSealosDevboxConfig, trusted bool) (SealosDevboxConfigApplied, error) {
 	var applied SealosDevboxConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if trusted && file.Kubectl != "" {
-		cfg.Kubectl = file.Kubectl
-		applied.InputAccepted = true
-		applied.Kubectl = true
-	}
-	if trusted && file.Kubeconfig != "" {
-		cfg.Kubeconfig = file.Kubeconfig
-		applied.InputAccepted = true
-		applied.Kubeconfig = true
-	}
-	if trusted && file.Context != "" {
-		cfg.Context = file.Context
-		applied.InputAccepted = true
-	}
-	if trusted && file.Namespace != "" {
-		cfg.Namespace = file.Namespace
-		applied.InputAccepted = true
-	}
-	if trusted && file.Image != "" {
-		cfg.Image = file.Image
-		applied.InputAccepted = true
-	}
-	if trusted && file.TemplateID != "" {
-		cfg.TemplateID = file.TemplateID
-		applied.InputAccepted = true
-	}
-	if trusted && file.CPU != "" {
-		cfg.CPU = file.CPU
-		applied.InputAccepted = true
-	}
-	if trusted && file.Memory != "" {
-		cfg.Memory = file.Memory
-		applied.InputAccepted = true
-	}
-	if trusted && file.StorageLimit != "" {
-		cfg.StorageLimit = file.StorageLimit
-		applied.InputAccepted = true
-	}
-	if trusted && file.Network != "" {
-		cfg.Network = file.Network
-		applied.InputAccepted = true
-	}
-	if trusted && file.SSHGatewayHost != "" {
-		cfg.SSHGatewayHost = file.SSHGatewayHost
-		applied.InputAccepted = true
-	}
-	if trusted && file.SSHGatewayPort != "" {
-		cfg.SSHGatewayPort = file.SSHGatewayPort
-		applied.InputAccepted = true
-	}
-	if trusted && file.SSHUser != "" {
-		cfg.SSHUser = file.SSHUser
-		applied.InputAccepted = true
-	}
-	if trusted && file.WorkRoot != "" {
-		cfg.WorkRoot = file.WorkRoot
-		applied.InputAccepted = true
-		applied.WorkRoot = true
-	}
-	if trusted && file.NodeHost != "" {
-		cfg.NodeHost = file.NodeHost
-		applied.InputAccepted = true
-	}
-	if file.DeleteOnRelease != nil {
-		cfg.DeleteOnRelease = *file.DeleteOnRelease
-		applied.InputAccepted = true
-		applied.DeleteOnRelease = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "sealos-devbox")
+	return applied, err
 }
 
 func (cfg *SealosDevboxConfig) applyEnv() (SealosDevboxConfigApplied, error) {

--- a/internal/cli/config_semaphore_generated.go
+++ b/internal/cli/config_semaphore_generated.go
@@ -32,36 +32,8 @@ type SemaphoreConfigApplied struct {
 
 func (cfg *SemaphoreConfig) applyFile(file *fileSemaphoreConfig) (SemaphoreConfigApplied, error) {
 	var applied SemaphoreConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.Host != "" {
-		cfg.Host = file.Host
-		applied.InputAccepted = true
-		applied.Host = true
-	}
-	if file.Token != "" {
-		cfg.Token = file.Token
-		applied.InputAccepted = true
-		applied.Token = true
-	}
-	if file.Project != "" {
-		cfg.Project = file.Project
-		applied.InputAccepted = true
-	}
-	if file.Machine != "" {
-		cfg.Machine = file.Machine
-		applied.InputAccepted = true
-	}
-	if file.OSImage != "" {
-		cfg.OSImage = file.OSImage
-		applied.InputAccepted = true
-	}
-	if file.IdleTimeout != "" {
-		cfg.IdleTimeout = file.IdleTimeout
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "semaphore")
+	return applied, err
 }
 
 func (cfg *SemaphoreConfig) applyEnv() (SemaphoreConfigApplied, error) {

--- a/internal/cli/config_smolvm_generated.go
+++ b/internal/cli/config_smolvm_generated.go
@@ -43,39 +43,8 @@ type SmolvmConfigApplied struct {
 
 func (cfg *SmolvmConfig) applyFile(file *fileSmolvmConfig) (SmolvmConfigApplied, error) {
 	var applied SmolvmConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.BaseURL != "" {
-		cfg.BaseURL = file.BaseURL
-		applied.InputAccepted = true
-		applied.BaseURL = true
-	}
-	if file.Image != "" {
-		cfg.Image = file.Image
-		applied.InputAccepted = true
-	}
-	if file.Workdir != "" {
-		cfg.Workdir = file.Workdir
-		applied.InputAccepted = true
-	}
-	if file.CPUs > 0 {
-		cfg.CPUs = file.CPUs
-		applied.InputAccepted = true
-	}
-	if file.MemoryMB > 0 {
-		cfg.MemoryMB = file.MemoryMB
-		applied.InputAccepted = true
-	}
-	if file.Network != "" {
-		cfg.Network = file.Network
-		applied.InputAccepted = true
-	}
-	if file.Keep != nil {
-		cfg.Keep = *file.Keep
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "smolvm")
+	return applied, err
 }
 
 func (cfg *SmolvmConfig) applyEnv() (SmolvmConfigApplied, error) {

--- a/internal/cli/config_tencentcloud_generated.go
+++ b/internal/cli/config_tencentcloud_generated.go
@@ -36,62 +36,8 @@ type TencentCloudConfigApplied struct {
 
 func (cfg *TencentCloudConfig) applyFile(file *fileTencentCloudConfig, trusted bool) (TencentCloudConfigApplied, error) {
 	var applied TencentCloudConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.Region != "" {
-		cfg.Region = file.Region
-		applied.InputAccepted = true
-		applied.Region = true
-	}
-	if file.Zone != "" {
-		cfg.Zone = file.Zone
-		applied.InputAccepted = true
-		applied.Zone = true
-	}
-	if file.Image != "" {
-		cfg.Image = file.Image
-		applied.InputAccepted = true
-		applied.Image = true
-	}
-	if file.Type != "" {
-		cfg.Type = file.Type
-		applied.InputAccepted = true
-		applied.Type = true
-	}
-	if file.VPCID != "" {
-		cfg.VPCID = file.VPCID
-		applied.InputAccepted = true
-	}
-	if file.SubnetID != "" {
-		cfg.SubnetID = file.SubnetID
-		applied.InputAccepted = true
-	}
-	if file.SecurityGroupID != "" {
-		cfg.SecurityGroupID = file.SecurityGroupID
-		applied.InputAccepted = true
-	}
-	if len(file.SSHCIDRs) > 0 {
-		cfg.SSHCIDRs = file.SSHCIDRs
-		applied.InputAccepted = true
-	}
-	if file.RootGB > 0 {
-		cfg.RootGB = file.RootGB
-		applied.InputAccepted = true
-	}
-	if file.InternetChargeType != "" {
-		cfg.InternetChargeType = file.InternetChargeType
-		applied.InputAccepted = true
-	}
-	if file.InternetMaxBandwidthOut > 0 {
-		cfg.InternetMaxBandwidthOut = file.InternetMaxBandwidthOut
-		applied.InputAccepted = true
-	}
-	if trusted && file.APIEndpoint != "" {
-		cfg.APIEndpoint = file.APIEndpoint
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, trusted, "tencentcloud")
+	return applied, err
 }
 
 func (cfg *TencentCloudConfig) applyEnv() (TencentCloudConfigApplied, error) {

--- a/internal/cli/config_tensorlake_generated.go
+++ b/internal/cli/config_tensorlake_generated.go
@@ -49,63 +49,8 @@ type TensorlakeConfigApplied struct {
 
 func (cfg *TensorlakeConfig) applyFile(file *fileTensorlakeConfig) (TensorlakeConfigApplied, error) {
 	var applied TensorlakeConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.APIURL != "" {
-		cfg.APIURL = file.APIURL
-		applied.InputAccepted = true
-		applied.APIURL = true
-	}
-	if file.CLIPath != "" {
-		cfg.CLIPath = file.CLIPath
-		applied.InputAccepted = true
-	}
-	if file.Image != "" {
-		cfg.Image = file.Image
-		applied.InputAccepted = true
-	}
-	if file.Snapshot != "" {
-		cfg.Snapshot = file.Snapshot
-		applied.InputAccepted = true
-	}
-	if file.OrganizationID != "" {
-		cfg.OrganizationID = file.OrganizationID
-		applied.InputAccepted = true
-	}
-	if file.ProjectID != "" {
-		cfg.ProjectID = file.ProjectID
-		applied.InputAccepted = true
-	}
-	if file.Namespace != "" {
-		cfg.Namespace = file.Namespace
-		applied.InputAccepted = true
-	}
-	if file.Workdir != "" {
-		cfg.Workdir = file.Workdir
-		applied.InputAccepted = true
-	}
-	if file.CPUs > 0 {
-		cfg.CPUs = file.CPUs
-		applied.InputAccepted = true
-	}
-	if file.MemoryMB > 0 {
-		cfg.MemoryMB = file.MemoryMB
-		applied.InputAccepted = true
-	}
-	if file.DiskMB > 0 {
-		cfg.DiskMB = file.DiskMB
-		applied.InputAccepted = true
-	}
-	if file.TimeoutSecs > 0 {
-		cfg.TimeoutSecs = file.TimeoutSecs
-		applied.InputAccepted = true
-	}
-	if file.NoInternet != nil {
-		cfg.NoInternet = *file.NoInternet
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "tensorlake")
+	return applied, err
 }
 
 func (cfg *TensorlakeConfig) applyEnv() (TensorlakeConfigApplied, error) {

--- a/internal/cli/config_upstash_box_generated.go
+++ b/internal/cli/config_upstash_box_generated.go
@@ -37,31 +37,8 @@ type UpstashBoxConfigApplied struct {
 
 func (cfg *UpstashBoxConfig) applyFile(file *fileUpstashBoxConfig) (UpstashBoxConfigApplied, error) {
 	var applied UpstashBoxConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.BaseURL != "" {
-		cfg.BaseURL = file.BaseURL
-		applied.InputAccepted = true
-		applied.BaseURL = true
-	}
-	if file.Runtime != "" {
-		cfg.Runtime = file.Runtime
-		applied.InputAccepted = true
-	}
-	if file.Size != "" {
-		cfg.Size = file.Size
-		applied.InputAccepted = true
-	}
-	if file.Workdir != "" {
-		cfg.Workdir = file.Workdir
-		applied.InputAccepted = true
-	}
-	if file.KeepAlive != nil {
-		cfg.KeepAlive = *file.KeepAlive
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "upstash-box")
+	return applied, err
 }
 
 func (cfg *UpstashBoxConfig) applyEnv() (UpstashBoxConfigApplied, error) {

--- a/internal/cli/config_vast_generated.go
+++ b/internal/cli/config_vast_generated.go
@@ -59,70 +59,8 @@ type VastConfigApplied struct {
 
 func (cfg *VastConfig) applyFile(file *fileVastConfig) (VastConfigApplied, error) {
 	var applied VastConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.APIURL != "" {
-		cfg.APIURL = file.APIURL
-		applied.InputAccepted = true
-		applied.APIURL = true
-	}
-	if file.InstanceType != "" {
-		cfg.InstanceType = file.InstanceType
-		applied.InputAccepted = true
-		applied.InstanceType = true
-	}
-	if file.GPUName != "" {
-		cfg.GPUName = file.GPUName
-		applied.InputAccepted = true
-	}
-	if file.GPUCount != 0 {
-		cfg.GPUCount = file.GPUCount
-		applied.InputAccepted = true
-	}
-	if file.Image != "" {
-		cfg.Image = file.Image
-		applied.InputAccepted = true
-	}
-	if file.TemplateID != "" {
-		cfg.TemplateID = file.TemplateID
-		applied.InputAccepted = true
-	}
-	if file.Runtype != "" {
-		cfg.Runtype = file.Runtype
-		applied.InputAccepted = true
-	}
-	if file.DiskGB != 0 {
-		cfg.DiskGB = file.DiskGB
-		applied.InputAccepted = true
-	}
-	if file.MaxDphTotal != nil {
-		cfg.MaxDphTotal = *file.MaxDphTotal
-		applied.InputAccepted = true
-	}
-	if file.MinReliability != nil {
-		cfg.MinReliability = *file.MinReliability
-		applied.InputAccepted = true
-	}
-	if file.Order != "" {
-		cfg.Order = file.Order
-		applied.InputAccepted = true
-	}
-	if file.User != "" {
-		cfg.User = file.User
-		applied.InputAccepted = true
-	}
-	if file.WorkRoot != "" {
-		cfg.WorkRoot = file.WorkRoot
-		applied.InputAccepted = true
-		applied.WorkRoot = true
-	}
-	if file.ReleaseAction != "" {
-		cfg.ReleaseAction = file.ReleaseAction
-		applied.InputAccepted = true
-		applied.ReleaseAction = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "vast")
+	return applied, err
 }
 
 func (cfg *VastConfig) applyEnv() (VastConfigApplied, error) {

--- a/internal/cli/config_vercel_sandbox_generated.go
+++ b/internal/cli/config_vercel_sandbox_generated.go
@@ -47,80 +47,8 @@ type VercelSandboxConfigApplied struct {
 
 func (cfg *VercelSandboxConfig) applyFile(file *fileVercelSandboxConfig) (VercelSandboxConfigApplied, error) {
 	var applied VercelSandboxConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.Runtime != nil {
-		cfg.Runtime = *file.Runtime
-		applied.InputAccepted = true
-	}
-	if file.Workdir != nil {
-		cfg.Workdir = *file.Workdir
-		applied.InputAccepted = true
-	}
-	if file.ProjectID != nil {
-		cfg.ProjectID = *file.ProjectID
-		applied.InputAccepted = true
-	}
-	if file.TeamID != nil {
-		cfg.TeamID = *file.TeamID
-		applied.InputAccepted = true
-	}
-	if file.Scope != nil {
-		cfg.Scope = *file.Scope
-		applied.InputAccepted = true
-	}
-	if file.VCPUs != nil {
-		cfg.VCPUs = *file.VCPUs
-		applied.InputAccepted = true
-	}
-	if file.TimeoutSecs != nil {
-		if *file.TimeoutSecs < 0 {
-			return applied, exit(2, "vercel-sandbox timeoutSecs must be non-negative")
-		}
-		cfg.TimeoutSecs = *file.TimeoutSecs
-		applied.InputAccepted = true
-	}
-	if file.ExecTimeoutSecs != nil {
-		if *file.ExecTimeoutSecs < 0 {
-			return applied, exit(2, "vercel-sandbox execTimeoutSecs must be non-negative")
-		}
-		cfg.ExecTimeoutSecs = *file.ExecTimeoutSecs
-		applied.InputAccepted = true
-	}
-	if file.Persistent != nil {
-		cfg.Persistent = *file.Persistent
-		applied.InputAccepted = true
-	}
-	if file.Snapshot != nil {
-		cfg.Snapshot = *file.Snapshot
-		applied.InputAccepted = true
-	}
-	if file.SnapshotMode != nil {
-		cfg.SnapshotMode = *file.SnapshotMode
-		applied.InputAccepted = true
-	}
-	if file.NetworkPolicy != nil {
-		cfg.NetworkPolicy = *file.NetworkPolicy
-		applied.InputAccepted = true
-	}
-	if file.NetworkAllow != nil {
-		cfg.NetworkAllow = normalizeList(*file.NetworkAllow)
-		applied.InputAccepted = true
-	}
-	if file.NetworkDeny != nil {
-		cfg.NetworkDeny = normalizeList(*file.NetworkDeny)
-		applied.InputAccepted = true
-	}
-	if file.Ports != nil {
-		cfg.Ports = normalizeList(*file.Ports)
-		applied.InputAccepted = true
-	}
-	if file.ForgetMissing != nil {
-		cfg.ForgetMissing = *file.ForgetMissing
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "vercel-sandbox")
+	return applied, err
 }
 
 func (cfg *VercelSandboxConfig) applyEnv() (VercelSandboxConfigApplied, error) {

--- a/internal/cli/config_vultr_generated.go
+++ b/internal/cli/config_vultr_generated.go
@@ -24,42 +24,8 @@ type VultrConfigApplied struct {
 
 func (cfg *VultrConfig) applyFile(file *fileVultrConfig) (VultrConfigApplied, error) {
 	var applied VultrConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.Region != "" {
-		cfg.Region = file.Region
-		applied.InputAccepted = true
-	}
-	if file.OS != "" {
-		cfg.OS = file.OS
-		applied.InputAccepted = true
-	}
-	if file.Image != "" {
-		cfg.Image = file.Image
-		applied.InputAccepted = true
-	}
-	if file.Snapshot != "" {
-		cfg.Snapshot = file.Snapshot
-		applied.InputAccepted = true
-	}
-	if file.FirewallGroup != "" {
-		cfg.FirewallGroup = file.FirewallGroup
-		applied.InputAccepted = true
-	}
-	if len(file.VPCIDs) > 0 {
-		cfg.VPCIDs = file.VPCIDs
-		applied.InputAccepted = true
-	}
-	if len(file.SSHCIDRs) > 0 {
-		cfg.SSHCIDRs = file.SSHCIDRs
-		applied.InputAccepted = true
-	}
-	if file.UserScheme != "" {
-		cfg.UserScheme = file.UserScheme
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "vultr")
+	return applied, err
 }
 
 func (cfg *VultrConfig) applyEnv() (VultrConfigApplied, error) {

--- a/internal/cli/config_wandb_generated.go
+++ b/internal/cli/config_wandb_generated.go
@@ -23,22 +23,8 @@ type WandbConfigApplied struct {
 
 func (cfg *WandbConfig) applyFile(file *fileWandbConfig) (WandbConfigApplied, error) {
 	var applied WandbConfigApplied
-	if file == nil {
-		return applied, nil
-	}
-	if file.APIKey != "" {
-		cfg.APIKey = file.APIKey
-		applied.InputAccepted = true
-	}
-	if file.DefaultImage != "" {
-		cfg.DefaultImage = file.DefaultImage
-		applied.InputAccepted = true
-	}
-	if file.MaxLifetimeSeconds > 0 {
-		cfg.MaxLifetimeSeconds = file.MaxLifetimeSeconds
-		applied.InputAccepted = true
-	}
-	return applied, nil
+	err := applyConfigFileOverlay(cfg, file, &applied, true, "wandb")
+	return applied, err
 }
 
 func (cfg *WandbConfig) applyEnv() (WandbConfigApplied, error) {

--- a/scripts/configgen/main.go
+++ b/scripts/configgen/main.go
@@ -597,59 +597,12 @@ func generate(s schema, source string) ([]byte, error) {
 			break
 		}
 	}
-	p("func (cfg *%s) applyFile(file *file%s%s) %s {\n%sif file == nil { return %snil }\n", s.name, s.name, trustedParameter, resultType, reportInit, resultPrefix)
-	for _, f := range s.fields {
-		for _, binding := range f.fileBindings() {
-			member := "file." + binding.member
-			value := member
-			var conditions []string
-			if f.trustedFileOnly {
-				conditions = append(conditions, "trusted")
-			}
-			if !f.fileStorageValue {
-				conditions = append(conditions, member+" != nil")
-				value = "*" + member
-			}
-			if f.fileIgnoreEmpty || f.kind == "time.Duration" {
-				conditions = append(conditions, value+" != \"\"")
-			}
-			if f.fileIntPositive || f.fileFloatPositive {
-				conditions = append(conditions, value+" > 0")
-			}
-			if f.fileIntNonzero {
-				conditions = append(conditions, value+" != 0")
-			}
-			if f.fileListNonemptyRaw || f.fileListNonemptyNormalized {
-				conditions = append(conditions, "len("+value+") > 0")
-			}
-			if f.fileListRaw && f.fileStorageValue {
-				conditions = append(conditions, value+" != nil")
-			}
-			p("if %s {\n", strings.Join(conditions, " && "))
-			if f.nonnegative && !f.fileIntPositive && !f.fileIntPresent && !f.fileIntNonzero {
-				p("if %s < 0 { return %sexit(2, %q) }\n", value, resultPrefix, s.provider+" "+f.key+" must be non-negative")
-			}
-			if f.kind == "[]string" {
-				if f.fileListRaw {
-					value = "append([]string(nil), (" + value + ")...)"
-				} else if !f.fileListNonemptyRaw {
-					value = "normalizeList(" + value + ")"
-				}
-			}
-			if f.kind == "time.Duration" {
-				p("if applyLeaseDuration(&cfg.%s, %s) { applied.InputAccepted = true }\n", f.name, value)
-			} else if f.kind == "*bool" {
-				p("value := %s\ncfg.%s = &value\napplied.InputAccepted = true\n", value, f.name)
-			} else {
-				p("cfg.%s = %s\napplied.InputAccepted = true\n", f.name, value)
-			}
-			if f.reportApplied {
-				p("applied.%s = true\n", f.name)
-			}
-			p("}\n")
-		}
+	fileTrust := "true"
+	if trustedParameter != "" {
+		fileTrust = "trusted"
 	}
-	p("return %snil\n}\n\n", resultPrefix)
+	p("func (cfg *%s) applyFile(file *file%s%s) %s {\n%s", s.name, s.name, trustedParameter, resultType, reportInit)
+	p("err := applyConfigFileOverlay(cfg, file, &applied, %s, %q)\nreturn applied, err\n}\n\n", fileTrust, s.provider)
 	emitEnv := func(name string, start, end int) {
 		p("func (cfg *%s) %s() %s {\n%s", s.name, name, resultType, reportInit)
 		p("err := applyConfigEnvironment(cfg, &applied, %d, %d)\nreturn applied, err\n}\n\n", start, end)

--- a/scripts/configgen/main_test.go
+++ b/scripts/configgen/main_test.go
@@ -39,7 +39,7 @@ func TestGenerateDeterministicTypedBindings(t *testing.T) {
 		"const PilotConfigDefaultCPUs float64 = 0.5",
 		"const PilotConfigDefaultEnabled bool = true",
 		"func (cfg *PilotConfig) applyFile(file *filePilotConfig) (PilotConfigApplied, error)",
-		"if file.Enabled != nil", "cfg.Ports = normalizeList(*file.Ports)",
+		`applyConfigFileOverlay(cfg, file, &applied, true, "pilot")`,
 		`applyConfigEnvironment(cfg, &applied, 0, 5)`,
 		`fs.String("pilot-ports", strings.Join(defaults.Ports, ","), "Ports")`,
 		`if flagWasSet(fs, "pilot-enabled")`,
@@ -313,8 +313,8 @@ func TestGenerateFileIgnoreEmpty(t *testing.T) {
 			if err != nil || !bytes.Equal(output, again) {
 				t.Fatalf("nondeterministic output: %v", err)
 			}
-			// The declaration changes only the file predicate, not env/flags or other fields.
-			want := strings.Replace(string(before), "file.Name != nil {", `file.Name != nil && *file.Name != "" {`, 1)
+			// The runtime reads the changed predicate from the schema; DTOs and bindings stay identical.
+			want := string(before)
 			if string(output) != want {
 				t.Fatalf("unexpected change beyond empty-string file predicate:\n%s", output)
 			}
@@ -663,21 +663,13 @@ func TestGenerateTrustedFileBindings(t *testing.T) {
 	previous := -1
 	for _, want := range []string{
 		"func (cfg *PilotConfig) applyFile(file *filePilotConfig, trusted bool) (PilotConfigApplied, error)",
-		"if file.Name != nil {",
-		"if trusted && file.Count != nil {\n\t\tif *file.Count < 0 {",
-		"cfg.Count = *file.Count",
-		"if file.CPUs != nil {",
-		"if file.Enabled != nil {",
-		"if trusted && file.Ports != nil {\n\t\tcfg.Ports = normalizeList(*file.Ports)",
+		`applyConfigFileOverlay(cfg, file, &applied, trusted, "pilot")`,
 	} {
 		index := strings.Index(text, want)
 		if index <= previous {
 			t.Fatalf("missing or reordered binding %q", want)
 		}
 		previous = index
-	}
-	if strings.Count(text, "trusted &&") != 2 {
-		t.Fatal("unexpected file trust guards")
 	}
 	typecheckGenerated(t, source, output)
 }
@@ -688,6 +680,7 @@ func typecheckGenerated(t *testing.T, source string, output []byte) {
 	helpers := `package cli
 import ("flag"; "time")
 func applyConfigEnvironment(any, any, int, int) error { panic("stub") }
+func applyConfigFileOverlay(any, any, any, bool, string) error { panic("stub") }
 func applyLeaseDuration(*time.Duration, string) bool { panic("stub") }
 func flagWasSet(*flag.FlagSet, string) bool { panic("stub") }
 func exit(int, string, ...any) error { panic("stub") }
@@ -860,13 +853,17 @@ func runScalarFixture(t *testing.T, source string, generated []byte, behavior st
 	if err != nil {
 		t.Fatal(err)
 	}
-	acceptance := acceptanceFixtureSource(t, source+behavior, string(generated)+string(environment))
-	for _, file := range []struct{ name, content string }{{"source.go", source}, {"generated.go", string(generated)}, {"behavior_test.go", behavior}, {"acceptance.go", acceptance}, {"environment.go", string(environment)}} {
+	fileOverlay, err := os.ReadFile("../../internal/cli/config_file_overlay.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	acceptance := acceptanceFixtureSource(t, source+behavior, string(generated)+string(environment)+string(fileOverlay))
+	for _, file := range []struct{ name, content string }{{"source.go", source}, {"generated.go", string(generated)}, {"behavior_test.go", behavior}, {"acceptance.go", acceptance}, {"environment.go", string(environment)}, {"file_overlay.go", string(fileOverlay)}} {
 		if err := os.WriteFile(filepath.Join(dir, file.name), []byte(file.content), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}
-	command := exec.Command("go", "test", "source.go", "generated.go", "behavior_test.go", "acceptance.go", "environment.go")
+	command := exec.Command("go", "test", "source.go", "generated.go", "behavior_test.go", "acceptance.go", "environment.go", "file_overlay.go")
 	command.Dir = dir
 	command.Env = []string{"GOTOOLCHAIN=local", "GOWORK=off", "GOPROXY=off", "GOSUMDB=off", "GOENV=off"}
 	for _, name := range []string{"PATH", "HOME", "USERPROFILE", "LOCALAPPDATA", "SystemRoot", "WINDIR", "TMPDIR", "TEMP", "TMP", "GOCACHE", "GOROOT", "GOFLAGS"} {
@@ -1327,7 +1324,7 @@ func TestGenerateDurationBindings(t *testing.T) {
 	if err != nil || !bytes.Equal(output, again) {
 		t.Fatal("nondeterministic duration output")
 	}
-	for _, want := range []string{`Timeout string ` + "`yaml:\"timeout,omitempty\"`", "const PilotConfigDefaultTimeout time.Duration = 180 * time.Second", "applyLeaseDuration(&cfg.Timeout, file.Timeout)", `fs.Duration("pilot-timeout", defaults.Timeout, "Timeout")`} {
+	for _, want := range []string{`Timeout string ` + "`yaml:\"timeout,omitempty\"`", "const PilotConfigDefaultTimeout time.Duration = 180 * time.Second", `applyConfigFileOverlay(cfg, file, &applied, true, "pilot")`, `fs.Duration("pilot-timeout", defaults.Timeout, "Timeout")`} {
 		if !strings.Contains(string(output), want) {
 			t.Fatalf("missing duration binding %q", want)
 		}
@@ -1546,7 +1543,7 @@ func TestGenerateFileEnvironmentOnlyBindings(t *testing.T) {
 	text := string(output)
 	for _, want := range []string{
 		`Input *string ` + "`yaml:\"input,omitempty\"`",
-		"if file.Input != nil && *file.Input != \"\" {\n\t\tcfg.Input = *file.Input\n\t\tapplied.InputAccepted = true\n\t\tapplied.Input = true",
+		`applyConfigFileOverlay(cfg, file, &applied, true, "pilot")`,
 		`applyConfigEnvironment(cfg, &applied,`,
 	} {
 		if !strings.Contains(text, want) {
@@ -1578,7 +1575,7 @@ func TestSchemaTrustedFileEnvironmentOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(output), `if trusted && file.Input != nil && *file.Input != "" {`) || strings.Contains(string(output), "values.Input") {
+	if !strings.Contains(string(output), `applyConfigFileOverlay(cfg, file, &applied, trusted, "pilot")`) || strings.Contains(string(output), "values.Input") {
 		t.Fatal("trusted no-flag emission changed")
 	}
 	typecheckGenerated(t, source+"\nfunc firstNonEmptyEnv(...string) (string, bool) { panic(\"stub\") }\n", output)
@@ -1872,10 +1869,10 @@ func TestGenerateFileIntPositive(t *testing.T) {
 		if err != nil || !bytes.Equal(output, again) {
 			t.Fatalf("nondeterministic file-int: %v", err)
 		}
-		if !strings.Contains(string(output), "if file.Count != nil && *file.Count > 0 {") || strings.Contains(string(output), "if *file.Count < 0") {
+		if !strings.Contains(string(output), `applyConfigFileOverlay(cfg, file, &applied, true, "pilot")`) || strings.Contains(string(output), "if *file.Count < 0") {
 			t.Fatal("positive admission not emitted")
 		}
-		if !strings.Contains(string(output), "if *file.Strict < 0") {
+		if !s.fields[2].nonnegative {
 			t.Fatal("unrelated strict admission changed")
 		}
 		oldEnv := strings.SplitN(string(before), "func (cfg *PilotConfig) applyEnv()", 2)[1]
@@ -2121,7 +2118,7 @@ func TestGenerateFileFloatPositive(t *testing.T) {
 	if err != nil || !bytes.Equal(output, again) {
 		t.Fatalf("nondeterministic float output: %v", err)
 	}
-	want := strings.Replace(string(before), "if file.CPUs != nil {", "if file.CPUs != nil && *file.CPUs > 0 {", 1)
+	want := string(before)
 	if string(output) != want {
 		t.Fatal("float predicate changed other file/default/env/flag semantics")
 	}
@@ -2379,7 +2376,7 @@ func TestGenerateSourceSpecificLists(t *testing.T) {
 		t.Fatalf("nondeterministic source lists: %v", err)
 	}
 	text := string(output)
-	for _, want := range []string{`cfg.Items = append([]string(nil), (*file.Items)...)`, `applyConfigEnvironment(cfg, &applied,`, `newReplaceAppendListFlag(defaults.Items)`, `cfg.Items = append([]string(nil), values.Items.values...)`} {
+	for _, want := range []string{`applyConfigFileOverlay(cfg, file, &applied, trusted, "pilot")`, `applyConfigEnvironment(cfg, &applied,`, `newReplaceAppendListFlag(defaults.Items)`, `cfg.Items = append([]string(nil), values.Items.values...)`} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("missing list binding %q", want)
 		}
@@ -2567,7 +2564,7 @@ func TestCSVSourceShapes(t *testing.T){
 	if err != nil || !bytes.Equal(output, again) {
 		t.Fatalf("nondeterministic normalized list modes: %v", err)
 	}
-	for _, want := range []string{`if len(file.Items) > 0 {`, `cfg.Items = normalizeList(file.Items)`, `applyConfigEnvironment(cfg, &applied,`, `cfg.Items = splitCSV(*values.Items)`} {
+	for _, want := range []string{`applyConfigFileOverlay(cfg, file, &applied, true, "pilot")`, `applyConfigEnvironment(cfg, &applied,`, `cfg.Items = splitCSV(*values.Items)`} {
 		if !strings.Contains(string(output), want) {
 			t.Fatalf("missing normalized list binding %q", want)
 		}
@@ -2668,7 +2665,7 @@ func TestGenerateFileIntNonzero(t *testing.T) {
 		if err != nil || !bytes.Equal(output, again) {
 			t.Fatalf("nondeterministic nonzero: %v", err)
 		}
-		want := strings.Replace(string(before), "if file.Count != nil {", "if file.Count != nil && *file.Count != 0 {", 1)
+		want := string(before)
 		want = strings.Replace(want, "\t\tif *file.Count < 0 {\n\t\t\treturn applied, exit(2, \"pilot count must be non-negative\")\n\t\t}\n", "", 1)
 		if string(output) != want {
 			t.Fatal("nonzero mode changed other file/env/default/flag behavior")
@@ -2823,7 +2820,7 @@ func TestGenerateNonemptyRawAndEmptyScalarLists(t *testing.T) {
 		t.Fatalf("nondeterministic lists: %v", err)
 	}
 	text := string(output)
-	for _, want := range []string{`if file.Items != nil && len(*file.Items) > 0 {`, `cfg.Items = *file.Items`, `fs.String("item", "", "Items")`, `applyConfigEnvironment(cfg, &applied,`, `if len(cfg.Items) == 0 {`} {
+	for _, want := range []string{`applyConfigFileOverlay(cfg, file, &applied, true, "pilot")`, `fs.String("item", "", "Items")`, `applyConfigEnvironment(cfg, &applied,`, `if len(cfg.Items) == 0 {`} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("missing fixed list binding %q", want)
 		}
@@ -3099,14 +3096,14 @@ func TestNoFlagSources(t *testing.T){
 }
 
 func TestGenerateFileStorageValue(t *testing.T) {
-	for _, tc := range []struct{ name, kind, policy, predicate string }{
-		{"string", "string", `fileIgnoreEmpty:"true"`, `file.Value != ""`},
-		{"list", "[]string", `fileList:"nonempty-raw"`, `len(file.Value) > 0`},
-		{"int-positive", "int", `nonnegative:"true" fileInt:"positive"`, `file.Value > 0`},
-		{"int-nonzero", "int", `nonnegative:"true" fileInt:"nonzero"`, `file.Value != 0`},
-		{"int64-positive", "int64", `nonnegative:"true" fileInt:"positive" envInt:"fallback"`, `file.Value > 0`},
-		{"int64-nonzero", "int64", `nonnegative:"true" fileInt:"nonzero" envInt:"fallback"`, `file.Value != 0`},
-		{"float-positive", "float64", `fileFloat:"positive"`, `file.Value > 0`},
+	for _, tc := range []struct{ name, kind, policy string }{
+		{"string", "string", `fileIgnoreEmpty:"true"`},
+		{"list", "[]string", `fileList:"nonempty-raw"`},
+		{"int-positive", "int", `nonnegative:"true" fileInt:"positive"`},
+		{"int-nonzero", "int", `nonnegative:"true" fileInt:"nonzero"`},
+		{"int64-positive", "int64", `nonnegative:"true" fileInt:"positive" envInt:"fallback"`},
+		{"int64-nonzero", "int64", `nonnegative:"true" fileInt:"nonzero" envInt:"fallback"`},
+		{"float-positive", "float64", `fileFloat:"positive"`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			source := "package cli\ntype PilotConfig struct { Value " + tc.kind + " `config:\"value\" env:\"VALUE\" flag:\"value\" sources:\"user,repo,env,flag\" help:\"Value\" " + tc.policy + " fileStorage:\"value\"` }"
@@ -3123,7 +3120,7 @@ func TestGenerateFileStorageValue(t *testing.T) {
 				t.Fatal("nondeterministic value output")
 			}
 			text := strings.Join(strings.Fields(string(output)), " ")
-			for _, want := range []string{"Value " + tc.kind + " `yaml:\"value,omitempty\"`", "if " + tc.predicate + " {", "cfg.Value = file.Value"} {
+			for _, want := range []string{"Value " + tc.kind + " `yaml:\"value,omitempty\"`", `applyConfigFileOverlay(cfg, file, &applied, true, "pilot")`} {
 				if !strings.Contains(text, want) {
 					t.Errorf("missing value storage output %q", want)
 				}
@@ -3162,13 +3159,10 @@ func TestGenerateFileStorageTrustedAlias(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := strings.Join(strings.Fields(string(out)), " ")
-	for _, want := range []string{`Name string ` + "`yaml:\"name,omitempty\"`", `NameConfigAlias string ` + "`yaml:\"nickname,omitempty\"`", `if trusted && file.Name != "" {`, `if trusted && file.NameConfigAlias != "" {`, `cfg.Name = file.Name`, `cfg.Name = file.NameConfigAlias`, `Count *int ` + "`yaml:\"count,omitempty\"`", `Enabled *bool ` + "`yaml:\"enabled,omitempty\"`"} {
+	for _, want := range []string{`Name string ` + "`yaml:\"name,omitempty\"`", `NameConfigAlias string ` + "`yaml:\"nickname,omitempty\"`", `applyConfigFileOverlay(cfg, file, &applied, trusted, "pilot")`, `Count *int ` + "`yaml:\"count,omitempty\"`", `Enabled *bool ` + "`yaml:\"enabled,omitempty\"`"} {
 		if !strings.Contains(text, want) {
 			t.Errorf("missing trusted/alias/control output %q", want)
 		}
-	}
-	if strings.Index(text, "cfg.Name = file.NameConfigAlias") < strings.Index(text, "cfg.Name = file.Name ") {
-		t.Error("alias precedes primary")
 	}
 	pointerSource := strings.Replace(source, ` fileStorage:"value"`, "", 1)
 	ps, err := parseSchema([]byte(pointerSource), "PilotConfig", "pilot")
@@ -3369,7 +3363,7 @@ func TestGenerateRawValueAndAppendTrimmedLists(t *testing.T) {
 	}
 	text := strings.Join(strings.Fields(string(output)), " ")
 	for _, want := range []string{
-		"Items []string `yaml:\"items,omitempty\"`", "if file.Items != nil {", "cfg.Items = append([]string(nil), (file.Items)...)",
+		"Items []string `yaml:\"items,omitempty\"`", `applyConfigFileOverlay(cfg, file, &applied, true, "pilot")`,
 		"Items *appendTrimmedListFlag", "listItems := newAppendTrimmedListFlag(defaults.Items)", `fs.Var(listItems, "item", "Items")`,
 		`if flagWasSet(fs, "item") {`, "cfg.Items = append([]string(nil), values.Items.stringListFlag...)",
 	} {


### PR DESCRIPTION
Consolidate generated YAML overlay implementations behind one typed-file engine. Each provider schema declares source grants and value policies; generated methods retain their typed input and acceptance reports while delegating repeated assignments. This removes 1,794 net non-test source lines.

The engine checks trusted-user admission before reading fields, processes aliases in declaration order, and preserves absent versus explicit empty input, numeric rules, duration parsing, list sharing versus copying, fresh nullable booleans, and partial results before errors. Provider-specific admission and normalization retain their existing order.

Validation: full CI passed on the PR head; core configuration/file tests and generator behavior fixtures passed; the combined configuration engines passed Go 1.26.5 vet and the complete race suite in Crabbox; scoped Autoreview passed. No new configuration, credentials, or dependencies.
