### PR TITLE
refactor(providers): call core directly from sandbox adapters

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -541,6 +541,13 @@ the adapter. Only a zero-length body skips decoding; nonempty whitespace is
 decoded, and JSON errors remain unwrapped. This separate contract adds no
 response limit and does not apply to streams or alter the bounded decoder.
 
+Provider adapters refer to core types and primitives directly, for example
+`core.Config`, `core.RunRequest`, and `core.ShellQuote`. Local helpers own
+provider-specific decisions such as claim scopes, recovery prefixes, and
+credential admission. Exact forwarding functions and type aliases only add a
+second name for an existing owner; use the core definition at the call site.
+Mutable injection hooks retain their explicit adapter boundary.
+
 ## Acquisition stays adapter-owned
 
 SSH lease acquisition is a provider-owned transaction, not a shared sequence of

--- a/internal/providers/blaxel/backend.go
+++ b/internal/providers/blaxel/backend.go
@@ -18,9 +18,9 @@ type processPoller interface {
 	After(time.Duration) <-chan time.Time
 }
 
-func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *backend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if req.ActionsRunner {
-		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+		return core.Exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
 	started := now(b.rt)
 	client, err := b.client()
@@ -38,7 +38,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	total := now(b.rt).Sub(started)
 	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
 	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
+		return core.WriteTimingJSON(b.rt.Stderr, core.TimingReport{
 			Provider: providerName,
 			LeaseID:  leaseID,
 			Slug:     slug,
@@ -49,11 +49,11 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	return nil
 }
 
-func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *backend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	workdir, workdirErr := blaxelWorkdir(b.cfg)
 	var client Client
 	var leaseID, sandboxID, slug string
-	var claim LeaseClaim
+	var claim core.LeaseClaim
 	var claimErr error
 	boundSandbox := func() shared.DelegatedSandbox {
 		return shared.DelegatedSandbox{
@@ -89,7 +89,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			sandboxID = sb.ID
 			// Capture the acquisition claim before any run work; cleanup must not
 			// authorize a replacement claim created while the command executes.
-			claim, claimErr = readLeaseClaim(leaseID)
+			claim, claimErr = core.ReadLeaseClaim(leaseID)
 			fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s name=%s\n", leaseID, slug, providerName, sb.ID, sb.Name)
 			return boundSandbox(), nil
 		},
@@ -121,7 +121,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 				return shared.DelegatedSandboxCommand{}, err
 			}
 			if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
-				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+				core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 			}
 			return shared.DelegatedSandboxCommand{
 				Text: strings.Join(req.Command, " "),
@@ -157,7 +157,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	})
 }
 
-func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	client, err := b.client()
 	if err != nil {
@@ -167,7 +167,7 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 	if err != nil {
 		return nil, err
 	}
-	servers := make([]Server, 0, len(claims))
+	servers := make([]core.Server, 0, len(claims))
 	for _, claim := range claims {
 		if claim.Provider != providerName || !blaxelClaimMatchesEndpointWorkspace(claim, client.BaseURL(), b.cfg.Blaxel.Workspace) {
 			continue
@@ -184,7 +184,7 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 			}
 			state = core.Blank(sb.Status, "unknown")
 		}
-		servers = append(servers, Server{
+		servers = append(servers, core.Server{
 			Provider: providerName,
 			CloudID:  sandboxID,
 			Name:     sandboxID,
@@ -202,18 +202,18 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 	return servers, nil
 }
 
-func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	client, err := b.client()
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	leaseID, sandboxID, slug, err := resolveLeaseID(req.ID, "", false, 0, client.BaseURL(), b.cfg.Blaxel.Workspace)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	waitTimeout := req.WaitTimeout
 	if waitTimeout <= 0 {
@@ -230,18 +230,18 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 		sb, getErr := client.GetSandbox(pollCtx, sandboxID)
 		if getErr != nil {
 			if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return StatusView{}, exit(5, "timed out waiting for blaxel sandbox %s to become ready", sandboxID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for blaxel sandbox %s to become ready", sandboxID)
 			}
 			if ctx.Err() != nil {
-				return StatusView{}, ctx.Err()
+				return core.StatusView{}, ctx.Err()
 			}
-			return StatusView{}, getErr
+			return core.StatusView{}, getErr
 		}
 		if err := validateBlaxelSandboxOwnership(claim, sb); err != nil {
-			return StatusView{}, err
+			return core.StatusView{}, err
 		}
 		state := strings.ToLower(strings.TrimSpace(sb.Status))
-		view := StatusView{
+		view := core.StatusView{
 			ID:       leaseID,
 			Slug:     slug,
 			Provider: providerName,
@@ -263,23 +263,23 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 			return view, nil
 		}
 		if isTerminalState(state) {
-			return StatusView{}, exit(5, "blaxel sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
+			return core.StatusView{}, core.Exit(5, "blaxel sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
 		if now(b.rt).After(deadline) {
-			return StatusView{}, exit(5, "timed out waiting for blaxel sandbox %s to become ready", sandboxID)
+			return core.StatusView{}, core.Exit(5, "timed out waiting for blaxel sandbox %s to become ready", sandboxID)
 		}
 		select {
 		case <-pollCtx.Done():
 			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return StatusView{}, exit(5, "timed out waiting for blaxel sandbox %s to become ready", sandboxID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for blaxel sandbox %s to become ready", sandboxID)
 			}
-			return StatusView{}, pollCtx.Err()
+			return core.StatusView{}, pollCtx.Err()
 		case <-time.After(blaxelStatusPoll):
 		}
 	}
 }
 
-func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+func (b *backend) Stop(ctx context.Context, req core.StopRequest) error {
 	client, err := b.client()
 	if err != nil {
 		return err
@@ -288,7 +288,7 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		return err
 	}
@@ -296,14 +296,14 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 		if !isBlaxelNotFound(err) || !b.cfg.Blaxel.ForgetMissing {
 			return err
 		}
-		if err := removeLeaseClaimIfUnchangedAfter(leaseID, claim, nil); err != nil {
+		if err := core.RemoveLeaseClaimIfUnchangedAfter(leaseID, claim, nil); err != nil {
 			return err
 		}
 		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing blaxel sandbox=%s after explicit request\n", sandboxID)
 		return nil
 	}
 	missing := false
-	if err := removeLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
+	if err := core.RemoveLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
 		if err := client.DeleteSandbox(ctx, sandboxID); err != nil {
 			if !isBlaxelNotFound(err) || !b.cfg.Blaxel.ForgetMissing {
 				return err
@@ -321,7 +321,7 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 	return nil
 }
 
-func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
+func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	client, err := b.client()
 	if err != nil {
 		return err
@@ -364,7 +364,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 				fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 				continue
 			}
-			if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+			if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 				return err
 			}
 			fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
@@ -383,7 +383,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			fmt.Fprintf(b.rt.Stdout, "would delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
 			continue
 		}
-		if err := removeLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+		if err := core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
 			if err := client.DeleteSandbox(ctx, sandboxID); err != nil && !isBlaxelNotFound(err) {
 				return err
 			}
@@ -400,7 +400,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	return nil
 }
 
-func (b *backend) cleanupBlaxelRecovery(ctx context.Context, client Client, claim LeaseClaim, now time.Time, dryRun bool) (bool, bool, error) {
+func (b *backend) cleanupBlaxelRecovery(ctx context.Context, client Client, claim core.LeaseClaim, now time.Time, dryRun bool) (bool, bool, error) {
 	matches := []Sandbox{}
 	cursor := ""
 	for {
@@ -419,7 +419,7 @@ func (b *backend) cleanupBlaxelRecovery(ctx context.Context, client Client, clai
 				continue
 			}
 			if strings.TrimSpace(sb.ID) == "" {
-				return false, false, exit(5, "blaxel recovery %s matched a sandbox without an id", claim.LeaseID)
+				return false, false, core.Exit(5, "blaxel recovery %s matched a sandbox without an id", claim.LeaseID)
 			}
 			matches = append(matches, sb)
 		}
@@ -441,7 +441,7 @@ func (b *backend) cleanupBlaxelRecovery(ctx context.Context, client Client, clai
 			fmt.Fprintf(b.rt.Stdout, "would remove recovery=%s reason=sandbox lifetime elapsed\n", claim.LeaseID)
 			return false, false, nil
 		}
-		if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+		if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 			return false, false, err
 		}
 		fmt.Fprintf(b.rt.Stdout, "remove recovery=%s reason=sandbox lifetime elapsed\n", claim.LeaseID)
@@ -453,7 +453,7 @@ func (b *backend) cleanupBlaxelRecovery(ctx context.Context, client Client, clai
 		}
 		return false, false, nil
 	}
-	if err := removeLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+	if err := core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
 		for _, sb := range matches {
 			if err := client.DeleteSandbox(ctx, sb.ID); err != nil && !isBlaxelNotFound(err) {
 				return err
@@ -469,25 +469,25 @@ func (b *backend) cleanupBlaxelRecovery(ctx context.Context, client Client, clai
 	return true, false, nil
 }
 
-func blaxelRecoveryExpired(claim LeaseClaim, now time.Time) (bool, error) {
+func blaxelRecoveryExpired(claim core.LeaseClaim, now time.Time) (bool, error) {
 	createdAt, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.ClaimedAt))
 	if err != nil {
-		return false, exit(5, "blaxel recovery %s has invalid claimed time", claim.LeaseID)
+		return false, core.Exit(5, "blaxel recovery %s has invalid claimed time", claim.LeaseID)
 	}
 	if claim.IdleTimeoutSeconds <= 0 {
-		return false, exit(5, "blaxel recovery %s has no sandbox lifetime", claim.LeaseID)
+		return false, core.Exit(5, "blaxel recovery %s has no sandbox lifetime", claim.LeaseID)
 	}
 	return !now.Before(createdAt.Add(time.Duration(claim.IdleTimeoutSeconds) * time.Second)), nil
 }
 
 func (b *backend) client() (Client, error) {
 	if b.clientFactory == nil {
-		return nil, exit(2, "blaxel client factory unavailable")
+		return nil, core.Exit(2, "blaxel client factory unavailable")
 	}
 	return b.clientFactory(b.cfg, b.rt)
 }
 
-func (b *backend) createSandbox(ctx context.Context, client Client, repo Repo, reclaim bool, requestedSlug string) (string, Sandbox, string, error) {
+func (b *backend) createSandbox(ctx context.Context, client Client, repo core.Repo, reclaim bool, requestedSlug string) (string, Sandbox, string, error) {
 	claimScope, err := newBlaxelClaimScope(client.BaseURL(), b.cfg.Blaxel.Workspace)
 	if err != nil {
 		return "", Sandbox{}, "", err
@@ -517,7 +517,7 @@ func (b *backend) createSandbox(ctx context.Context, client Client, repo Repo, r
 	}
 	sandboxID := sb.ID
 	leaseID = blaxelLeaseID(sandboxID)
-	slug, err = allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err = core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return leaseID, sb, "", b.cleanupCreateFailure(ctx, client, sandboxID, "", claimScope, repo, err)
 	}
@@ -529,7 +529,7 @@ func (b *backend) createSandbox(ctx context.Context, client Client, repo Repo, r
 	if strings.TrimSpace(sb.ID) == "" {
 		sb.ID = sandboxID
 	}
-	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, claimScope, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, providerName, claimScope, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
 		return leaseID, sb, slug, b.cleanupCreateFailure(ctx, client, sandboxID, "", claimScope, repo, err)
 	}
 	ready, err := b.waitSandboxReady(ctx, client, sandboxID)
@@ -563,13 +563,13 @@ func (b *backend) waitSandboxReady(ctx context.Context, client Client, sandboxID
 				return true, nil
 			}
 			if isTerminalState(state) {
-				return false, exit(5, "blaxel sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
+				return false, core.Exit(5, "blaxel sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 			}
 			return false, nil
 		}, nil)
 	if err != nil {
 		if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil && (result.Err != nil || errors.Is(err, context.DeadlineExceeded)) {
-			return Sandbox{}, exit(5, "timed out waiting for blaxel sandbox %s to become ready", sandboxID)
+			return Sandbox{}, core.Exit(5, "timed out waiting for blaxel sandbox %s to become ready", sandboxID)
 		}
 		return Sandbox{}, err
 	}
@@ -643,7 +643,7 @@ func (b *backend) cleanupContext(ctx context.Context) (context.Context, context.
 	return context.WithTimeout(context.WithoutCancel(ctx), timeout)
 }
 
-func (b *backend) cleanupCreateFailure(ctx context.Context, client Client, sandboxID, localLeaseID, claimScope string, repo Repo, cause error) error {
+func (b *backend) cleanupCreateFailure(ctx context.Context, client Client, sandboxID, localLeaseID, claimScope string, repo core.Repo, cause error) error {
 	if strings.TrimSpace(sandboxID) == "" {
 		return cause
 	}
@@ -657,11 +657,11 @@ func (b *backend) cleanupCreateFailure(ctx context.Context, client Client, sandb
 	}
 	var cleanupErr error
 	if strings.TrimSpace(localLeaseID) != "" {
-		claim, err := readLeaseClaim(localLeaseID)
+		claim, err := core.ReadLeaseClaim(localLeaseID)
 		if err != nil {
 			cleanupErr = err
 		} else {
-			cleanupErr = removeLeaseClaimIfUnchangedAfter(localLeaseID, claim, deleteSandbox)
+			cleanupErr = core.RemoveLeaseClaimIfUnchangedAfter(localLeaseID, claim, deleteSandbox)
 		}
 	} else {
 		cleanupErr = deleteSandbox()
@@ -671,7 +671,7 @@ func (b *backend) cleanupCreateFailure(ctx context.Context, client Client, sandb
 			return errors.Join(cause, fmt.Errorf("blaxel cleanup failed for sandbox %s; local claim %s remains for cleanup: %w", sandboxID, localLeaseID, cleanupErr))
 		}
 		recoveryID := recoveryPrefix + randomSuffix()
-		if claimErr := claimLeaseForRepoProviderScopePond(recoveryID, "", providerName, claimScope, "", repo.Root, blaxelRecoveryLifetime(b.cfg), true); claimErr != nil {
+		if claimErr := core.ClaimLeaseForRepoProviderScopePond(recoveryID, "", providerName, claimScope, "", repo.Root, blaxelRecoveryLifetime(b.cfg), true); claimErr != nil {
 			return errors.Join(cause, fmt.Errorf("blaxel cleanup failed for sandbox %s and recovery claim failed: %v; delete it in the Blaxel console: %w", sandboxID, claimErr, cleanupErr))
 		}
 		return errors.Join(cause, fmt.Errorf("blaxel cleanup failed for sandbox %s; recovery claim %s recorded for cleanup: %w", sandboxID, recoveryID, cleanupErr))
@@ -679,7 +679,7 @@ func (b *backend) cleanupCreateFailure(ctx context.Context, client Client, sandb
 	return cause
 }
 
-func blaxelRecoveryLifetime(cfg Config) time.Duration {
+func blaxelRecoveryLifetime(cfg core.Config) time.Duration {
 	if cfg.TTL > 0 {
 		return cfg.TTL
 	}
@@ -698,26 +698,26 @@ func (b *backend) execTimeoutSecs() int {
 
 func buildCommand(command []string, shellMode bool) ([]string, error) {
 	if len(command) == 0 {
-		return nil, exit(2, "missing command")
+		return nil, core.Exit(2, "missing command")
 	}
 	if shellMode {
 		return []string{"bash", "-lc", strings.Join(command, " ")}, nil
 	}
-	if shouldUseShell(command) {
-		return []string{"bash", "-lc", shellScriptFromArgv(command)}, nil
+	if core.ShouldUseShell(command) {
+		return []string{"bash", "-lc", core.ShellScriptFromArgv(command)}, nil
 	}
 	return command, nil
 }
 
-func blaxelWorkdir(cfg Config) (string, error) {
+func blaxelWorkdir(cfg core.Config) (string, error) {
 	workdir := strings.TrimSpace(core.Blank(cfg.Blaxel.Workdir, core.BlaxelConfigDefaultWorkdir))
 	clean := path.Clean(workdir)
 	if workdir == "" || !strings.HasPrefix(clean, "/") || strings.Contains(workdir, "\x00") {
-		return "", exit(2, "blaxel workdir %q must be an absolute path", workdir)
+		return "", core.Exit(2, "blaxel workdir %q must be an absolute path", workdir)
 	}
 	switch clean {
 	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspace":
-		return "", exit(2, "blaxel workdir %q is too broad; choose a dedicated subdirectory", clean)
+		return "", core.Exit(2, "blaxel workdir %q is too broad; choose a dedicated subdirectory", clean)
 	}
 	return clean, nil
 }

--- a/internal/providers/blaxel/backend_test.go
+++ b/internal/providers/blaxel/backend_test.go
@@ -53,8 +53,8 @@ type lifecycleFakeClient struct {
 
 func TestBlaxelConfiguredDefaultPredicates(t *testing.T) {
 	for _, raw := range []string{"", "  ", " https://example.invalid/api/ "} {
-		cfg := Config{Blaxel: BlaxelConfig{APIKey: "inert", APIURL: raw}}
-		api, err := newBlaxelClient(cfg, Runtime{HTTP: &http.Client{}})
+		cfg := core.Config{Blaxel: core.BlaxelConfig{APIKey: "inert", APIURL: raw}}
+		api, err := newBlaxelClient(cfg, core.Runtime{HTTP: &http.Client{}})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -71,7 +71,7 @@ func TestBlaxelConfiguredDefaultPredicates(t *testing.T) {
 		}
 	}
 	for _, seconds := range []int{-1, 0, 17} {
-		b := backend{cfg: Config{Blaxel: BlaxelConfig{ExecTimeoutSecs: seconds}}}
+		b := backend{cfg: core.Config{Blaxel: core.BlaxelConfig{ExecTimeoutSecs: seconds}}}
 		want := 600
 		if seconds > 0 {
 			want = seconds
@@ -81,7 +81,7 @@ func TestBlaxelConfiguredDefaultPredicates(t *testing.T) {
 		}
 	}
 	for _, raw := range []string{"", "  ", " /workspace/app/ "} {
-		cfg := Config{Blaxel: BlaxelConfig{Workdir: raw}}
+		cfg := core.Config{Blaxel: core.BlaxelConfig{Workdir: raw}}
 		got, err := blaxelWorkdir(cfg)
 		if raw == "  " {
 			if err == nil {
@@ -110,8 +110,8 @@ func TestBlaxelCreatePreservesRawDefaultPredicates(t *testing.T) {
 				cfg.Blaxel.Workdir = "/workspace/custom"
 			}
 			fake := newLifecycleFakeClient()
-			b := &backend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-			if _, _, _, err := b.createSandbox(context.Background(), fake, Repo{Name: "example", Root: t.TempDir()}, false, ""); err != nil {
+			b := &backend{cfg: cfg, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+			if _, _, _, err := b.createSandbox(context.Background(), fake, core.Repo{Name: "example", Root: t.TempDir()}, false, ""); err != nil {
 				t.Fatal(err)
 			}
 			image, dir := raw, raw
@@ -263,7 +263,7 @@ func (f *lifecycleFakeClient) effectiveProcessStatus() string {
 
 func TestWarmupCreatesClaimAndCompletesRemoteLabels(t *testing.T) {
 	backend, fake, _, stdout, _ := newLifecycleBackend(t)
-	err := backend.Warmup(context.Background(), WarmupRequest{Repo: testRepo(t), RequestedSlug: "warm-one"})
+	err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: testRepo(t), RequestedSlug: "warm-one"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -279,7 +279,7 @@ func TestWarmupCreatesClaimAndCompletesRemoteLabels(t *testing.T) {
 		labels[blaxelClaimKey] == "" || labels["crabbox.repo"] == "" {
 		t.Fatalf("labels=%#v", labels)
 	}
-	claim, err := readLeaseClaim(leasePrefix + "sbx_1")
+	claim, err := core.ReadLeaseClaim(leasePrefix + "sbx_1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,14 +294,14 @@ func TestWarmupCreatesClaimAndCompletesRemoteLabels(t *testing.T) {
 func TestWarmupPreservesCreateIDWhenLabelUpdateOmitsID(t *testing.T) {
 	backend, fake, _, stdout, _ := newLifecycleBackend(t)
 	fake.updateEmptyID = true
-	err := backend.Warmup(context.Background(), WarmupRequest{Repo: testRepo(t), RequestedSlug: "empty-update"})
+	err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: testRepo(t), RequestedSlug: "empty-update"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deleted) != 0 {
 		t.Fatalf("deleted=%#v", fake.deleted)
 	}
-	if claim, err := readLeaseClaim(leasePrefix + "sbx_1"); err != nil || claim.LeaseID != leasePrefix+"sbx_1" {
+	if claim, err := core.ReadLeaseClaim(leasePrefix + "sbx_1"); err != nil || claim.LeaseID != leasePrefix+"sbx_1" {
 		t.Fatalf("claim=%#v err=%v", claim, err)
 	}
 	if !strings.Contains(stdout.String(), "sandbox=sbx_1") {
@@ -311,7 +311,7 @@ func TestWarmupPreservesCreateIDWhenLabelUpdateOmitsID(t *testing.T) {
 
 func TestBlaxelWorkdirRejectsBroadPaths(t *testing.T) {
 	for _, workdir := range []string{"/", "/tmp", "/workspace", "/home", "/root", "/usr", "/var"} {
-		cfg := Config{Blaxel: BlaxelConfig{Workdir: workdir}}
+		cfg := core.Config{Blaxel: core.BlaxelConfig{Workdir: workdir}}
 		if _, err := blaxelWorkdir(cfg); err == nil || !strings.Contains(err.Error(), "too broad") {
 			t.Fatalf("blaxelWorkdir(%q) err=%v, want too broad", workdir, err)
 		}
@@ -319,7 +319,7 @@ func TestBlaxelWorkdirRejectsBroadPaths(t *testing.T) {
 			t.Fatalf("validateBlaxelConfig(%q) err=%v, want too broad", workdir, err)
 		}
 	}
-	cfg := Config{Blaxel: BlaxelConfig{Workdir: " /workspace/crabbox/../project "}}
+	cfg := core.Config{Blaxel: core.BlaxelConfig{Workdir: " /workspace/crabbox/../project "}}
 	if got, err := blaxelWorkdir(cfg); err != nil || got != "/workspace/project" {
 		t.Fatalf("blaxelWorkdir cleaned=%q err=%v", got, err)
 	}
@@ -327,7 +327,7 @@ func TestBlaxelWorkdirRejectsBroadPaths(t *testing.T) {
 
 func TestRunForwardsEnvInProcessBodyAndReturnsRemoteExit(t *testing.T) {
 	backend, fake, _, stdout, stderr := newLifecycleBackend(t)
-	result, err := backend.Run(context.Background(), RunRequest{
+	result, err := backend.Run(context.Background(), core.RunRequest{
 		Repo:       testRepo(t),
 		NoSync:     true,
 		Keep:       true,
@@ -377,7 +377,7 @@ func TestRunPreservesCancellationAfterStoppingProcess(t *testing.T) {
 		cancel()
 		return Process{}, redactError(fmt.Errorf("fixture polling: %w", ctx.Err()))
 	}
-	result, err := b.Run(ctx, RunRequest{Repo: testRepo(t), NoSync: true, KeepOnFailure: true, Command: []string{"fixture-user"}})
+	result, err := b.Run(ctx, core.RunRequest{Repo: testRepo(t), NoSync: true, KeepOnFailure: true, Command: []string{"fixture-user"}})
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("Run error %v lost cancellation", err)
 	}
@@ -395,7 +395,7 @@ func TestRunPreservesCancellationAfterStoppingProcess(t *testing.T) {
 	if result.Session == nil || !result.Session.Kept || len(fake.deleted) != 0 {
 		t.Fatalf("session=%#v, deletes=%v", result.Session, fake.deleted)
 	}
-	if err := b.Stop(context.Background(), StopRequest{ID: result.LeaseID}); err != nil {
+	if err := b.Stop(context.Background(), core.StopRequest{ID: result.LeaseID}); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -414,7 +414,7 @@ func TestRunPreparesArchiveBeforeCreate(t *testing.T) {
 				t.Fatalf("prepared archives at create=%v err=%v", files, err)
 			}
 		}
-		if _, err := b.Run(t.Context(), RunRequest{Repo: testRepo(t), SyncOnly: true}); err == nil {
+		if _, err := b.Run(t.Context(), core.RunRequest{Repo: testRepo(t), SyncOnly: true}); err == nil {
 			t.Fatal("create failure was hidden")
 		}
 		files, err := filepath.Glob(filepath.Join(temp, "crabbox-blaxel-sync-*.tgz"))
@@ -425,7 +425,7 @@ func TestRunPreparesArchiveBeforeCreate(t *testing.T) {
 	t.Run("guardrail", func(t *testing.T) {
 		b, fake, _, _, _ := newLifecycleBackend(t)
 		b.cfg.Sync.FailFiles = 1
-		_, err := b.Run(t.Context(), RunRequest{Repo: testRepo(t), SyncOnly: true})
+		_, err := b.Run(t.Context(), core.RunRequest{Repo: testRepo(t), SyncOnly: true})
 		if err == nil || len(fake.createReqs) != 0 {
 			t.Fatalf("preflight err=%v creates=%d, want refusal before allocation", err, len(fake.createReqs))
 		}
@@ -466,7 +466,7 @@ func TestRunPreparesArchiveBeforeCreate(t *testing.T) {
 				}
 			}
 		}
-		if _, err := b.Run(t.Context(), RunRequest{Repo: repo, SyncOnly: true}); err != nil {
+		if _, err := b.Run(t.Context(), core.RunRequest{Repo: repo, SyncOnly: true}); err != nil {
 			t.Fatal(err)
 		}
 		if uploaded != "package main\n" {
@@ -542,7 +542,7 @@ func TestSharedArchiveSyncNativeWorkspace(t *testing.T) {
 					return err
 				}
 			}}
-			_, _, err := b.syncWorkspace(ctx, client, "sbx-owned", RunRequest{Repo: repo}, workspace, nil)
+			_, _, err := b.syncWorkspace(ctx, client, "sbx-owned", core.RunRequest{Repo: repo}, workspace, nil)
 			success := scenario == "replace" || scenario == "merge"
 			if (err == nil) != success {
 				t.Fatalf("sync err=%v success=%t", err, success)
@@ -595,7 +595,7 @@ func (c *nativeArchiveClient) UploadFile(ctx context.Context, _ string, remote s
 
 func TestRunSyncOnlyUploadsArchiveAndSkipsUserCommand(t *testing.T) {
 	backend, fake, _, stdout, _ := newLifecycleBackend(t)
-	result, err := backend.Run(context.Background(), RunRequest{
+	result, err := backend.Run(context.Background(), core.RunRequest{
 		Repo:     testRepo(t),
 		SyncOnly: true,
 		Keep:     true,
@@ -724,14 +724,14 @@ func TestBuildCommandPreservesExplicitShellScript(t *testing.T) {
 
 func TestStopRequiresMatchingRemoteOwnershipLabels(t *testing.T) {
 	backend, fake, _, _, _ := newLifecycleBackend(t)
-	err := backend.Warmup(context.Background(), WarmupRequest{Repo: testRepo(t), RequestedSlug: "owned"})
+	err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: testRepo(t), RequestedSlug: "owned"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	sb := fake.sandboxes["sbx_1"]
 	sb.Labels[blaxelClaimKey] = "foreign"
 	fake.sandboxes["sbx_1"] = sb
-	err = backend.Stop(context.Background(), StopRequest{ID: "owned"})
+	err = backend.Stop(context.Background(), core.StopRequest{ID: "owned"})
 	if err == nil || !strings.Contains(err.Error(), "ownership labels") {
 		t.Fatalf("Stop err=%v, want ownership mismatch", err)
 	}
@@ -742,11 +742,11 @@ func TestStopRequiresMatchingRemoteOwnershipLabels(t *testing.T) {
 
 func TestCleanupDryRunSkipsFreshAndDoesNotDelete(t *testing.T) {
 	backend, fake, _, stdout, stderr := newLifecycleBackend(t)
-	err := backend.Warmup(context.Background(), WarmupRequest{Repo: testRepo(t), RequestedSlug: "fresh"})
+	err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: testRepo(t), RequestedSlug: "fresh"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := backend.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deleted) != 0 {
@@ -762,81 +762,81 @@ func TestCleanupDryRunSkipsFreshAndDoesNotDelete(t *testing.T) {
 
 func TestCleanupDeletesDueOwnedClaimOnly(t *testing.T) {
 	backend, fake, _, _, _ := newLifecycleBackend(t)
-	err := backend.Warmup(context.Background(), WarmupRequest{Repo: testRepo(t), RequestedSlug: "due"})
+	err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: testRepo(t), RequestedSlug: "due"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	claim, err := readLeaseClaim(leasePrefix + "sbx_1")
+	claim, err := core.ReadLeaseClaim(leasePrefix + "sbx_1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	old := time.Now().UTC().Add(-2 * time.Hour)
-	if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, "", testRepo(t).Root, time.Second, true); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, "", testRepo(t).Root, time.Second, true); err != nil {
 		t.Fatal(err)
 	}
-	claim, err = readLeaseClaim(claim.LeaseID)
+	claim, err = core.ReadLeaseClaim(claim.LeaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	claim.LastUsedAt = old.Format(time.RFC3339)
 	writeClaimForTest(t, claim)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deleted) != 1 || fake.deleted[0] != "sbx_1" {
 		t.Fatalf("deleted=%#v", fake.deleted)
 	}
-	if claim, err := readLeaseClaim(leasePrefix + "sbx_1"); err != nil || claim.LeaseID != "" {
+	if claim, err := core.ReadLeaseClaim(leasePrefix + "sbx_1"); err != nil || claim.LeaseID != "" {
 		t.Fatalf("claim=%#v err=%v, want removed", claim, err)
 	}
 }
 
 func TestStopPreservesMissingClaimUnlessForgetMissing(t *testing.T) {
 	backend, fake, _, _, _ := newLifecycleBackend(t)
-	err := backend.Warmup(context.Background(), WarmupRequest{Repo: testRepo(t), RequestedSlug: "missing"})
+	err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: testRepo(t), RequestedSlug: "missing"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	delete(fake.sandboxes, "sbx_1")
-	err = backend.Stop(context.Background(), StopRequest{ID: "missing"})
+	err = backend.Stop(context.Background(), core.StopRequest{ID: "missing"})
 	if err == nil || !strings.Contains(err.Error(), "status=404") {
 		t.Fatalf("Stop err=%v, want preserved 404", err)
 	}
-	if _, err := readLeaseClaim(leasePrefix + "sbx_1"); err != nil {
+	if _, err := core.ReadLeaseClaim(leasePrefix + "sbx_1"); err != nil {
 		t.Fatalf("claim should be preserved: %v", err)
 	}
 	backend.cfg.Blaxel.ForgetMissing = true
-	if err := backend.Stop(context.Background(), StopRequest{ID: "missing"}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: "missing"}); err != nil {
 		t.Fatal(err)
 	}
-	if claim, err := readLeaseClaim(leasePrefix + "sbx_1"); err != nil || claim.LeaseID != "" {
+	if claim, err := core.ReadLeaseClaim(leasePrefix + "sbx_1"); err != nil || claim.LeaseID != "" {
 		t.Fatalf("claim=%#v err=%v, want removed", claim, err)
 	}
 }
 
 func TestStopPreservesReplacedClaimBeforeSandboxDeletion(t *testing.T) {
 	backend, fake, _, _, _ := newLifecycleBackend(t)
-	if err := backend.Warmup(t.Context(), WarmupRequest{Repo: testRepo(t), RequestedSlug: "replaced"}); err != nil {
+	if err := backend.Warmup(t.Context(), core.WarmupRequest{Repo: testRepo(t), RequestedSlug: "replaced"}); err != nil {
 		t.Fatal(err)
 	}
 	replacementRepo := t.TempDir()
 	fake.onGetSandbox = func() {
-		claim, err := readLeaseClaim(leasePrefix + "sbx_1")
+		claim, err := core.ReadLeaseClaim(leasePrefix + "sbx_1")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, replacementRepo, time.Minute, true); err != nil {
+		if err := core.ClaimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, replacementRepo, time.Minute, true); err != nil {
 			t.Fatal(err)
 		}
 	}
-	err := backend.Stop(t.Context(), StopRequest{ID: "replaced"})
+	err := backend.Stop(t.Context(), core.StopRequest{ID: "replaced"})
 	if err == nil || !strings.Contains(err.Error(), "claim changed; retry") {
 		t.Fatalf("stop err=%v, want replaced-claim refusal", err)
 	}
 	if len(fake.deleted) != 0 {
 		t.Fatalf("deleted=%#v, want replaced sandbox claim protected", fake.deleted)
 	}
-	claim, err := readLeaseClaim(leasePrefix + "sbx_1")
+	claim, err := core.ReadLeaseClaim(leasePrefix + "sbx_1")
 	if err != nil || claim.RepoRoot != replacementRepo {
 		t.Fatalf("replacement claim=%#v err=%v", claim, err)
 	}
@@ -845,7 +845,7 @@ func TestStopPreservesReplacedClaimBeforeSandboxDeletion(t *testing.T) {
 func TestCreateLabelUpdateFailureCleansRemote(t *testing.T) {
 	backend, fake, _, _, _ := newLifecycleBackend(t)
 	fake.updateErr = errors.New("label denied")
-	err := backend.Warmup(context.Background(), WarmupRequest{Repo: testRepo(t)})
+	err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: testRepo(t)})
 	if err == nil || !strings.Contains(err.Error(), "label denied") {
 		t.Fatalf("Warmup err=%v", err)
 	}
@@ -858,7 +858,7 @@ func TestCreateCleanupFailureWritesRecoveryClaimAndCleanupDeletesMatch(t *testin
 	backend, fake, _, stdout, _ := newLifecycleBackend(t)
 	fake.updateErr = errors.New("label denied")
 	fake.deleteErr = errors.New("delete denied")
-	err := backend.Warmup(context.Background(), WarmupRequest{Repo: testRepo(t)})
+	err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: testRepo(t)})
 	if err == nil || !strings.Contains(err.Error(), "recovery") {
 		t.Fatalf("Warmup err=%v, want recovery claim failure context", err)
 	}
@@ -866,7 +866,7 @@ func TestCreateCleanupFailureWritesRecoveryClaimAndCleanupDeletesMatch(t *testin
 	if err != nil {
 		t.Fatal(err)
 	}
-	var recovery LeaseClaim
+	var recovery core.LeaseClaim
 	for _, claim := range recoveries {
 		if strings.HasPrefix(claim.LeaseID, recoveryPrefix) {
 			recovery = claim
@@ -884,7 +884,7 @@ func TestCreateCleanupFailureWritesRecoveryClaimAndCleanupDeletesMatch(t *testin
 	fake.sandboxes["sbx_1"] = sb
 	fake.updateErr = nil
 	fake.deleteErr = nil
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deleted) < 2 || fake.deleted[len(fake.deleted)-1] != "sbx_1" {
@@ -893,7 +893,7 @@ func TestCreateCleanupFailureWritesRecoveryClaimAndCleanupDeletesMatch(t *testin
 	if !strings.Contains(stdout.String(), "reason=ambiguous create") {
 		t.Fatalf("stdout=%q", stdout.String())
 	}
-	if claim, err := readLeaseClaim(recovery.LeaseID); err != nil || claim.LeaseID != "" {
+	if claim, err := core.ReadLeaseClaim(recovery.LeaseID); err != nil || claim.LeaseID != "" {
 		t.Fatalf("recovery claim=%#v err=%v, want removed", claim, err)
 	}
 }
@@ -904,7 +904,7 @@ func TestRecoveryCleanupPaginatesBeforeRemovingRecoveryClaim(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	recovery := LeaseClaim{
+	recovery := core.LeaseClaim{
 		LeaseID:            recoveryPrefix + "abc123",
 		Provider:           providerName,
 		ProviderScope:      scope,
@@ -923,7 +923,7 @@ func TestRecoveryCleanupPaginatesBeforeRemovingRecoveryClaim(t *testing.T) {
 			},
 		}}},
 	}
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.listReqs) != 2 || fake.listReqs[0].Limit != 200 || fake.listReqs[1].Cursor != "page-2" {
@@ -932,7 +932,7 @@ func TestRecoveryCleanupPaginatesBeforeRemovingRecoveryClaim(t *testing.T) {
 	if len(fake.deleted) != 1 || fake.deleted[0] != "sbx_2" {
 		t.Fatalf("deleted=%#v", fake.deleted)
 	}
-	if claim, err := readLeaseClaim(recovery.LeaseID); err != nil || claim.LeaseID != "" {
+	if claim, err := core.ReadLeaseClaim(recovery.LeaseID); err != nil || claim.LeaseID != "" {
 		t.Fatalf("recovery claim=%#v err=%v, want removed", claim, err)
 	}
 }
@@ -946,7 +946,7 @@ func TestStandbySandboxStateIsReady(t *testing.T) {
 func TestCreateReadinessFailureDeletesOneShotSandboxAndClaim(t *testing.T) {
 	backend, fake, _, _, _ := newLifecycleBackend(t)
 	fake.createStatus = "failed"
-	_, err := backend.Run(context.Background(), RunRequest{
+	_, err := backend.Run(context.Background(), core.RunRequest{
 		Repo:    testRepo(t),
 		NoSync:  true,
 		Command: []string{"true"},
@@ -957,7 +957,7 @@ func TestCreateReadinessFailureDeletesOneShotSandboxAndClaim(t *testing.T) {
 	if len(fake.deleted) != 1 || fake.deleted[0] != "sbx_1" {
 		t.Fatalf("deleted=%#v", fake.deleted)
 	}
-	if claim, err := readLeaseClaim(leasePrefix + "sbx_1"); err != nil || claim.LeaseID != "" {
+	if claim, err := core.ReadLeaseClaim(leasePrefix + "sbx_1"); err != nil || claim.LeaseID != "" {
 		t.Fatalf("claim=%#v err=%v, want removed", claim, err)
 	}
 }
@@ -981,15 +981,15 @@ func newLifecycleBackend(t *testing.T) (*backend, *lifecycleFakeClient, string, 
 				Workspace: "workspace-test",
 			},
 		},
-		rt: Runtime{Stdout: stdout, Stderr: stderr},
-		clientFactory: func(Config, Runtime) (Client, error) {
+		rt: core.Runtime{Stdout: stdout, Stderr: stderr},
+		clientFactory: func(core.Config, core.Runtime) (Client, error) {
 			return fake, nil
 		},
 	}
 	return backend, fake, state, stdout, stderr
 }
 
-func testRepo(t *testing.T) Repo {
+func testRepo(t *testing.T) core.Repo {
 	t.Helper()
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.org/repo\n"), 0o600); err != nil {
@@ -1001,7 +1001,7 @@ func testRepo(t *testing.T) Repo {
 	runGit(t, root, "init")
 	runGit(t, root, "add", ".")
 	runGit(t, root, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init")
-	return Repo{Root: root, Name: "my-app", Head: "abc123"}
+	return core.Repo{Root: root, Name: "my-app", Head: "abc123"}
 }
 
 func runGit(t *testing.T, dir string, args ...string) {
@@ -1013,7 +1013,7 @@ func runGit(t *testing.T, dir string, args ...string) {
 	}
 }
 
-func writeClaimForTest(t *testing.T, claim LeaseClaim) {
+func writeClaimForTest(t *testing.T, claim core.LeaseClaim) {
 	t.Helper()
 	claimsDir := filepath.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims")
 	if err := os.MkdirAll(claimsDir, 0o700); err != nil {
@@ -1050,7 +1050,7 @@ func TestRunFinalizesCleanupFailure(t *testing.T) {
 				}
 				return Process{ID: "proc_1", Status: "completed", ExitCode: intPtr(code)}, nil
 			}
-			result, err := b.Run(t.Context(), RunRequest{Repo: testRepo(t), NoSync: true, TimingJSON: true, Command: []string{"fixture-user"}})
+			result, err := b.Run(t.Context(), core.RunRequest{Repo: testRepo(t), NoSync: true, TimingJSON: true, Command: []string{"fixture-user"}})
 			wantCode, wantKind := commandExit, core.RunErrorCommandExit
 			if commandExit == 0 {
 				wantCode, wantKind = 1, core.RunErrorProvider
@@ -1061,7 +1061,7 @@ func TestRunFinalizesCleanupFailure(t *testing.T) {
 			if result.Session == nil || !result.Session.Kept {
 				t.Errorf("session=%+v", result.Session)
 			}
-			if claim, err := readLeaseClaim(leasePrefix + "sbx_1"); err != nil || claim.LeaseID == "" {
+			if claim, err := core.ReadLeaseClaim(leasePrefix + "sbx_1"); err != nil || claim.LeaseID == "" {
 				t.Fatalf("claim=%+v err=%v", claim, err)
 			}
 			var report core.TimingReport
@@ -1081,7 +1081,7 @@ func TestRunFinalizesCleanupFailure(t *testing.T) {
 func TestRunSetupFailureKeepsRecoverableSession(t *testing.T) {
 	b, fake, _, _, stderr := newLifecycleBackend(t)
 	fake.processErr = errors.New("synthetic setup failure")
-	result, err := b.Run(t.Context(), RunRequest{Repo: testRepo(t), NoSync: true, KeepOnFailure: true, TimingJSON: true, Command: []string{"fixture-user"}})
+	result, err := b.Run(t.Context(), core.RunRequest{Repo: testRepo(t), NoSync: true, KeepOnFailure: true, TimingJSON: true, Command: []string{"fixture-user"}})
 	if err == nil || result.Provider != providerName || result.LeaseID != leasePrefix+"sbx_1" || result.Status != core.RunStatusFailed || result.ErrorKind != core.RunErrorProvider {
 		t.Errorf("result=%+v err=%v", result, err)
 	}
@@ -1102,11 +1102,11 @@ func TestRunCleanupPreservesChangedOwnership(t *testing.T) {
 				if req.Command == "fixture-user" {
 					switch change {
 					case "local-claim":
-						claim, err := readLeaseClaim(leasePrefix + "sbx_1")
+						claim, err := core.ReadLeaseClaim(leasePrefix + "sbx_1")
 						if err != nil {
 							t.Fatal(err)
 						}
-						if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, replacementRepo, time.Minute, true); err != nil {
+						if err := core.ClaimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, replacementRepo, time.Minute, true); err != nil {
 							t.Fatal(err)
 						}
 					case "remote-labels":
@@ -1119,8 +1119,8 @@ func TestRunCleanupPreservesChangedOwnership(t *testing.T) {
 				}
 				return Process{ID: "proc_1", Status: "completed", ExitCode: intPtr(0)}, nil
 			}
-			result, err := b.Run(t.Context(), RunRequest{Repo: testRepo(t), NoSync: true, Command: []string{"fixture-user"}})
-			claim, claimErr := readLeaseClaim(leasePrefix + "sbx_1")
+			result, err := b.Run(t.Context(), core.RunRequest{Repo: testRepo(t), NoSync: true, Command: []string{"fixture-user"}})
+			claim, claimErr := core.ReadLeaseClaim(leasePrefix + "sbx_1")
 			if claimErr != nil {
 				t.Fatal(claimErr)
 			}

--- a/internal/providers/blaxel/claims.go
+++ b/internal/providers/blaxel/claims.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -19,18 +20,18 @@ func blaxelEndpointWorkspaceScope(baseURL, workspace string) string {
 func newBlaxelClaimScope(baseURL, workspace string) (string, error) {
 	var token [16]byte
 	if _, err := rand.Read(token[:]); err != nil {
-		return "", exit(5, "generate blaxel ownership token: %v", err)
+		return "", core.Exit(5, "generate blaxel ownership token: %v", err)
 	}
 	return blaxelEndpointWorkspaceScope(baseURL, workspace) + "/ownership:" + hex.EncodeToString(token[:]), nil
 }
 
-func blaxelClaimMatchesEndpointWorkspace(claim LeaseClaim, baseURL, workspace string) bool {
+func blaxelClaimMatchesEndpointWorkspace(claim core.LeaseClaim, baseURL, workspace string) bool {
 	return strings.HasPrefix(strings.TrimSpace(claim.ProviderScope), blaxelEndpointWorkspaceScope(baseURL, workspace)+"/ownership:")
 }
 
-func validateBlaxelClaimScope(claim LeaseClaim, baseURL, workspace string) error {
+func validateBlaxelClaimScope(claim core.LeaseClaim, baseURL, workspace string) error {
 	if !blaxelClaimMatchesEndpointWorkspace(claim, baseURL, workspace) {
-		return exit(4, "blaxel lease %q belongs to a different API endpoint or workspace; restore the settings used to create it", claim.LeaseID)
+		return core.Exit(4, "blaxel lease %q belongs to a different API endpoint or workspace; restore the settings used to create it", claim.LeaseID)
 	}
 	return nil
 }
@@ -43,7 +44,7 @@ func blaxelSandboxID(leaseID string) string {
 	return strings.TrimPrefix(strings.TrimSpace(leaseID), leasePrefix)
 }
 
-func blaxelLabels(leaseID, slug, claimScope string, repo Repo) map[string]string {
+func blaxelLabels(leaseID, slug, claimScope string, repo core.Repo) map[string]string {
 	labels := map[string]string{
 		"crabbox":          "true",
 		"crabbox.provider": providerName,
@@ -57,8 +58,8 @@ func blaxelLabels(leaseID, slug, claimScope string, repo Repo) map[string]string
 	return labels
 }
 
-func repoLabel(repo Repo) string {
-	if slug := normalizeLeaseSlug(repo.Name); slug != "" {
+func repoLabel(repo core.Repo) string {
+	if slug := core.NormalizeLeaseSlug(repo.Name); slug != "" {
 		return slug
 	}
 	if strings.TrimSpace(repo.Head) != "" {
@@ -72,8 +73,8 @@ func repoLabel(repo Repo) string {
 	return ""
 }
 
-func newSandboxName(repo Repo) string {
-	base := normalizeLeaseSlug(repo.Name)
+func newSandboxName(repo core.Repo) string {
+	base := core.NormalizeLeaseSlug(repo.Name)
 	if base == "" {
 		base = "crabbox"
 	}
@@ -92,13 +93,13 @@ func newSandboxName(repo Repo) string {
 func resolveLeaseID(identifier, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL, workspace string) (string, string, string, error) {
 	identifier = strings.TrimSpace(identifier)
 	if identifier == "" {
-		return "", "", "", exit(2, "provider=blaxel requires a Crabbox-created sandbox slug or lease id")
+		return "", "", "", core.Exit(2, "provider=blaxel requires a Crabbox-created sandbox slug or lease id")
 	}
 	exactLeaseID := identifier
 	if !strings.HasPrefix(exactLeaseID, leasePrefix) && !strings.HasPrefix(exactLeaseID, recoveryPrefix) {
 		exactLeaseID = leasePrefix + exactLeaseID
 	}
-	if claim, err := readLeaseClaim(exactLeaseID); err != nil {
+	if claim, err := core.ReadLeaseClaim(exactLeaseID); err != nil {
 		return "", "", "", err
 	} else if claim.LeaseID == exactLeaseID && claim.Provider == providerName {
 		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, baseURL, workspace)
@@ -110,55 +111,55 @@ func resolveLeaseID(identifier, repoRoot string, reclaim bool, idleTimeout time.
 	if ok {
 		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, baseURL, workspace)
 	}
-	return "", "", "", exit(4, "blaxel sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", identifier, leasePrefix)
+	return "", "", "", core.Exit(4, "blaxel sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", identifier, leasePrefix)
 }
 
-func resolveBlaxelLeaseClaim(identifier, baseURL, workspace string) (LeaseClaim, bool, error) {
+func resolveBlaxelLeaseClaim(identifier, baseURL, workspace string) (core.LeaseClaim, bool, error) {
 	claims, err := listBlaxelLeaseClaims()
 	if err != nil {
-		return LeaseClaim{}, false, err
+		return core.LeaseClaim{}, false, err
 	}
 	for _, claim := range claims {
 		if claim.Provider == providerName && claim.LeaseID == identifier {
 			if err := validateBlaxelClaimScope(claim, baseURL, workspace); err != nil {
-				return LeaseClaim{}, false, err
+				return core.LeaseClaim{}, false, err
 			}
 			return claim, true, nil
 		}
 	}
-	slug := normalizeLeaseSlug(identifier)
+	slug := core.NormalizeLeaseSlug(identifier)
 	if slug != "" {
 		for _, claim := range claims {
-			if claim.Provider == providerName && normalizeLeaseSlug(claim.Slug) == slug {
+			if claim.Provider == providerName && core.NormalizeLeaseSlug(claim.Slug) == slug {
 				if err := validateBlaxelClaimScope(claim, baseURL, workspace); err != nil {
-					return LeaseClaim{}, false, err
+					return core.LeaseClaim{}, false, err
 				}
 				return claim, true, nil
 			}
 		}
 	}
-	return LeaseClaim{}, false, nil
+	return core.LeaseClaim{}, false, nil
 }
 
-func finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL, workspace string) (string, string, string, error) {
+func finishResolvedLease(claim core.LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL, workspace string) (string, string, string, error) {
 	if err := validateBlaxelClaimScope(claim, baseURL, workspace); err != nil {
 		return "", "", "", err
 	}
 	if repoRoot != "" {
-		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, repoRoot,
+		if err := core.ClaimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, repoRoot,
 			timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
 			return "", "", "", err
 		}
 	}
 	slug := claim.Slug
 	if strings.TrimSpace(slug) == "" {
-		slug = newLeaseSlug(claim.LeaseID)
+		slug = core.NewLeaseSlug(claim.LeaseID)
 	}
 	return claim.LeaseID, blaxelSandboxID(claim.LeaseID), slug, nil
 }
 
 func verifyBlaxelClaim(ctx context.Context, client Client, leaseID, sandboxID, workspace string) (Sandbox, error) {
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		return Sandbox{}, err
 	}
@@ -175,9 +176,9 @@ func verifyBlaxelClaim(ctx context.Context, client Client, leaseID, sandboxID, w
 	return sb, nil
 }
 
-func validateBlaxelSandboxOwnership(claim LeaseClaim, sb Sandbox) error {
+func validateBlaxelSandboxOwnership(claim core.LeaseClaim, sb Sandbox) error {
 	if strings.TrimSpace(sb.ID) == "" {
-		return exit(5, "blaxel sandbox for lease %q omitted its id", claim.LeaseID)
+		return core.Exit(5, "blaxel sandbox for lease %q omitted its id", claim.LeaseID)
 	}
 	labels := sb.Labels
 	if labels == nil {
@@ -187,7 +188,7 @@ func validateBlaxelSandboxOwnership(claim LeaseClaim, sb Sandbox) error {
 		labels["crabbox.provider"] != providerName ||
 		labels["crabbox.lease"] != claim.LeaseID ||
 		labels[blaxelClaimKey] != claim.ProviderScope {
-		return exit(4, "blaxel sandbox %q ownership labels do not match its local claim", sb.ID)
+		return core.Exit(4, "blaxel sandbox %q ownership labels do not match its local claim", sb.ID)
 	}
 	return nil
 }

--- a/internal/providers/blaxel/claims_test.go
+++ b/internal/providers/blaxel/claims_test.go
@@ -3,10 +3,12 @@ package blaxel
 import (
 	"strings"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestNewSandboxNameFitsBlaxelLimit(t *testing.T) {
-	name := newSandboxName(Repo{Name: "this-is-a-very-long-repository-name-that-would-exceed-the-blaxel-sandbox-name-limit"})
+	name := newSandboxName(core.Repo{Name: "this-is-a-very-long-repository-name-that-would-exceed-the-blaxel-sandbox-name-limit"})
 	if len(name) > sandboxNameMaxLen {
 		t.Fatalf("name length=%d name=%q, want <= %d", len(name), name, sandboxNameMaxLen)
 	}

--- a/internal/providers/blaxel/client.go
+++ b/internal/providers/blaxel/client.go
@@ -122,7 +122,7 @@ type restClient struct {
 
 const blaxelControlTimeout = 60 * time.Second
 
-func newBlaxelClient(cfg Config, rt Runtime) (Client, error) {
+func newBlaxelClient(cfg core.Config, rt core.Runtime) (Client, error) {
 	baseURL := strings.TrimSpace(cfg.Blaxel.APIURL)
 	if baseURL == "" {
 		baseURL = core.BlaxelConfigDefaultAPIURL
@@ -133,7 +133,7 @@ func newBlaxelClient(cfg Config, rt Runtime) (Client, error) {
 	}
 	apiKey := BlaxelAPIKey(cfg)
 	if apiKey == "" {
-		return nil, exit(2, "provider=blaxel needs an API key; load CRABBOX_BLAXEL_API_KEY or BL_API_KEY from a secret manager")
+		return nil, core.Exit(2, "provider=blaxel needs an API key; load CRABBOX_BLAXEL_API_KEY or BL_API_KEY from a secret manager")
 	}
 	workspace := strings.TrimSpace(cfg.Blaxel.Workspace)
 	httpClient, dataHTTPClient := shared.ControlAndDataHTTPClients(rt.HTTP, blaxelControlTimeout)
@@ -147,21 +147,21 @@ func newBlaxelClient(cfg Config, rt Runtime) (Client, error) {
 	}, nil
 }
 
-func BlaxelAPIKey(cfg Config) string {
+func BlaxelAPIKey(cfg core.Config) string {
 	return strings.TrimSpace(cfg.Blaxel.APIKey)
 }
 
 func ValidateAPIURL(raw string) (string, error) {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {
-		return "", exit(2, "provider=blaxel API URL must be an absolute HTTP(S) URL")
+		return "", core.Exit(2, "provider=blaxel API URL must be an absolute HTTP(S) URL")
 	}
 	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", exit(2, "provider=blaxel API URL must not contain userinfo, query parameters, or a fragment")
+		return "", core.Exit(2, "provider=blaxel API URL must not contain userinfo, query parameters, or a fragment")
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
 	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
-		return "", exit(2, "provider=blaxel API URL must use HTTPS except for loopback development endpoints")
+		return "", core.Exit(2, "provider=blaxel API URL must use HTTPS except for loopback development endpoints")
 	}
 	host := shared.LowercaseHostname(parsed.Hostname())
 	port := parsed.Port()
@@ -188,23 +188,23 @@ func ValidateAPIURL(raw string) (string, error) {
 func validateSandboxEndpoint(raw, managementBase string) (string, error) {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {
-		return "", exit(5, "blaxel sandbox metadata.url must be an absolute HTTP(S) URL")
+		return "", core.Exit(5, "blaxel sandbox metadata.url must be an absolute HTTP(S) URL")
 	}
 	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", exit(5, "blaxel sandbox metadata.url must not contain userinfo, query parameters, or a fragment")
+		return "", core.Exit(5, "blaxel sandbox metadata.url must not contain userinfo, query parameters, or a fragment")
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
 	host := shared.LowercaseHostname(parsed.Hostname())
 	if parsed.Scheme == "http" {
 		management, _ := url.Parse(managementBase)
 		if management == nil || !isLoopbackHost(management.Hostname()) || !isLoopbackHost(host) {
-			return "", exit(5, "blaxel sandbox metadata.url must use HTTPS except for loopback development endpoints")
+			return "", core.Exit(5, "blaxel sandbox metadata.url must use HTTPS except for loopback development endpoints")
 		}
 	} else if parsed.Scheme != "https" {
-		return "", exit(5, "blaxel sandbox metadata.url must use HTTPS")
+		return "", core.Exit(5, "blaxel sandbox metadata.url must use HTTPS")
 	}
 	if !isLoopbackHost(host) && !isBlaxelDataPlaneHost(host) {
-		return "", exit(5, "blaxel sandbox metadata.url host %q is not a trusted Blaxel data-plane origin", host)
+		return "", core.Exit(5, "blaxel sandbox metadata.url host %q is not a trusted Blaxel data-plane origin", host)
 	}
 	port := parsed.Port()
 	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
@@ -230,15 +230,15 @@ func isBlaxelDataPlaneHost(host string) bool {
 		strings.HasSuffix(host, ".blaxel.ai")
 }
 
-func validateBlaxelConfig(cfg Config) error {
+func validateBlaxelConfig(cfg core.Config) error {
 	if _, err := ValidateAPIURL(core.Blank(cfg.Blaxel.APIURL, core.BlaxelConfigDefaultAPIURL)); err != nil {
 		return err
 	}
 	if cfg.Blaxel.MemoryMB < 0 {
-		return exit(2, "blaxel memory-mb must be >= 0")
+		return core.Exit(2, "blaxel memory-mb must be >= 0")
 	}
 	if cfg.Blaxel.ExecTimeoutSecs < 0 {
-		return exit(2, "blaxel execTimeoutSecs must be non-negative")
+		return core.Exit(2, "blaxel execTimeoutSecs must be non-negative")
 	}
 	if _, err := blaxelWorkdir(cfg); err != nil {
 		return err
@@ -257,7 +257,7 @@ func secureHTTPClient(source *http.Client) *http.Client {
 		if len(via) >= 10 {
 			return errors.New("stopped after 10 redirects")
 		}
-		if len(via) > 0 && !sameOrigin(via[len(via)-1].URL, req.URL) {
+		if len(via) > 0 && !core.SameHTTPOrigin(via[len(via)-1].URL, req.URL) {
 			return fmt.Errorf("blaxel refused cross-origin redirect to %s://%s", req.URL.Scheme, req.URL.Host)
 		}
 		if originalCheckRedirect != nil {
@@ -266,10 +266,6 @@ func secureHTTPClient(source *http.Client) *http.Client {
 		return nil
 	}
 	return &client
-}
-
-func sameOrigin(a, b *url.URL) bool {
-	return core.SameHTTPOrigin(a, b)
 }
 
 func (c *restClient) BaseURL() string { return c.base }
@@ -561,7 +557,7 @@ func (c *restClient) sandboxBaseURL(ctx context.Context, sandbox string) (string
 		return "", err
 	}
 	if strings.TrimSpace(sb.Endpoint) == "" {
-		return "", exit(5, "blaxel sandbox %q response omitted metadata.url", sandbox)
+		return "", core.Exit(5, "blaxel sandbox %q response omitted metadata.url", sandbox)
 	}
 	return validateSandboxEndpoint(sb.Endpoint, c.base)
 }
@@ -781,7 +777,7 @@ type blaxelAPIProcessRequest struct {
 func apiProcessRequest(req ExecuteProcessRequest) blaxelAPIProcessRequest {
 	command := req.Command
 	if len(req.Args) > 0 {
-		command = shellScriptFromArgv(append([]string{req.Command}, req.Args...))
+		command = core.ShellScriptFromArgv(append([]string{req.Command}, req.Args...))
 	}
 	return blaxelAPIProcessRequest{
 		Command:           command,

--- a/internal/providers/blaxel/core.go
+++ b/internal/providers/blaxel/core.go
@@ -1,35 +1,10 @@
 package blaxel
 
 import (
-	"io"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type BlaxelConfig = core.BlaxelConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type DoctorCheck = core.DoctorCheck
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type CleanupRequest = core.CleanupRequest
-type Server = core.Server
-type Repo = core.Repo
-type LeaseClaim = core.LeaseClaim
-type ExitError = core.ExitError
-type timingReport = core.TimingReport
-type timingPhase = core.TimingPhase
 
 const (
 	providerName      = "blaxel"
@@ -47,51 +22,11 @@ const (
 	blaxelClaimKey       = "crabbox.claim"
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
-}
-
-func inventoryDoctorResult(provider string, leases int) DoctorResult {
-	return core.InventoryDoctorResult(provider, leases)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
-}
-
-func readLeaseClaim(leaseID string) (LeaseClaim, error) {
-	return core.ReadLeaseClaim(leaseID)
-}
-
-func removeLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
-	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
-}
-
-func removeLeaseClaimIfUnchangedAfter(leaseID string, expected LeaseClaim, action func() error) error {
-	return core.RemoveLeaseClaimIfUnchangedAfter(leaseID, expected, action)
-}
-
-func listBlaxelLeaseClaims() ([]LeaseClaim, error) {
+func listBlaxelLeaseClaims() ([]core.LeaseClaim, error) {
 	return core.ListLeaseClaimsWithPrefix(leasePrefix)
 }
 
-func listBlaxelCleanupClaims() ([]LeaseClaim, error) {
+func listBlaxelCleanupClaims() ([]core.LeaseClaim, error) {
 	claims, err := listBlaxelLeaseClaims()
 	if err != nil {
 		return nil, err
@@ -103,23 +38,7 @@ func listBlaxelCleanupClaims() ([]LeaseClaim, error) {
 	return append(claims, recoveries...), nil
 }
 
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
-func shellQuote(s string) string {
-	return core.ShellQuote(s)
-}
-
-func now(rt Runtime) time.Time {
+func now(rt core.Runtime) time.Time {
 	if rt.Clock != nil {
 		return rt.Clock.Now()
 	}

--- a/internal/providers/blaxel/doctor.go
+++ b/internal/providers/blaxel/doctor.go
@@ -7,10 +7,10 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
-	checks := []DoctorCheck{}
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
+	checks := []core.DoctorCheck{}
 	record := func(status, check, message string) {
-		checks = append(checks, DoctorCheck{
+		checks = append(checks, core.DoctorCheck{
 			Status:  status,
 			Check:   check,
 			Message: message,
@@ -19,13 +19,13 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	}
 	if _, err := ValidateAPIURL(core.Blank(b.cfg.Blaxel.APIURL, core.BlaxelConfigDefaultAPIURL)); err != nil {
 		record("failed", "api_url", err.Error())
-		return DoctorResult{Provider: providerName, Status: "failed", Message: "api_url=failed mutation=false", Checks: checks}, err
+		return core.DoctorResult{Provider: providerName, Status: "failed", Message: "api_url=failed mutation=false", Checks: checks}, err
 	}
 	record("ok", "api_url", "api_url=ready mutation=false")
 	if BlaxelAPIKey(b.cfg) == "" {
-		err := exit(1, "provider=blaxel needs an API key; load CRABBOX_BLAXEL_API_KEY or BL_API_KEY from a secret manager")
+		err := core.Exit(1, "provider=blaxel needs an API key; load CRABBOX_BLAXEL_API_KEY or BL_API_KEY from a secret manager")
 		record("failed", "auth", err.Error())
-		return DoctorResult{Provider: providerName, Status: "failed", Message: "auth=missing mutation=false", Checks: checks}, err
+		return core.DoctorResult{Provider: providerName, Status: "failed", Message: "auth=missing mutation=false", Checks: checks}, err
 	}
 	record("ok", "auth", "auth=configured")
 	if b.cfg.Blaxel.Workspace == "" {
@@ -36,19 +36,19 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	client, err := b.clientFactory(b.cfg, b.rt)
 	if err != nil {
 		record("failed", "client", err.Error())
-		return DoctorResult{Provider: providerName, Status: "failed", Message: "client=failed mutation=false", Checks: checks}, err
+		return core.DoctorResult{Provider: providerName, Status: "failed", Message: "client=failed mutation=false", Checks: checks}, err
 	}
 	if err := client.Probe(ctx); err != nil {
 		record("failed", "api", err.Error())
-		return DoctorResult{Provider: providerName, Status: "failed", Message: "api=failed mutation=false", Checks: checks}, err
+		return core.DoctorResult{Provider: providerName, Status: "failed", Message: "api=failed mutation=false", Checks: checks}, err
 	}
 	record("ok", "api", "api=list mutation=false")
 	result, err := client.ListSandboxes(ctx, ListSandboxesRequest{Limit: 100})
 	if err != nil {
 		record("failed", "inventory", err.Error())
-		return DoctorResult{Provider: providerName, Status: "failed", Message: "inventory=failed mutation=false", Checks: checks}, err
+		return core.DoctorResult{Provider: providerName, Status: "failed", Message: "inventory=failed mutation=false", Checks: checks}, err
 	}
-	doctor := inventoryDoctorResult(providerName, len(result.Sandboxes))
+	doctor := core.InventoryDoctorResult(providerName, len(result.Sandboxes))
 	doctor.Checks = checks
 	if doctor.Message == "" {
 		return doctor, errors.New("blaxel doctor did not produce a summary")

--- a/internal/providers/blaxel/doctor_test.go
+++ b/internal/providers/blaxel/doctor_test.go
@@ -63,8 +63,8 @@ func (f *fakeClient) GetDirectoryTree(context.Context, string, string) (Director
 func TestBlaxelDoctorEndpointDefaultPredicate(t *testing.T) {
 	for _, raw := range []string{"", "  ", "https://example.invalid/api"} {
 		fake := &fakeClient{}
-		b := &backend{spec: Provider{}.Spec(), cfg: Config{Blaxel: BlaxelConfig{APIURL: raw, APIKey: "inert"}}, clientFactory: func(Config, Runtime) (Client, error) { return fake, nil }}
-		_, err := b.Doctor(context.Background(), DoctorRequest{})
+		b := &backend{spec: Provider{}.Spec(), cfg: core.Config{Blaxel: core.BlaxelConfig{APIURL: raw, APIKey: "inert"}}, clientFactory: func(core.Config, core.Runtime) (Client, error) { return fake, nil }}
+		_, err := b.Doctor(context.Background(), core.DoctorRequest{})
 		if raw == "  " {
 			if err == nil || fake.probeCalls != 0 || fake.listCalls != 0 {
 				t.Fatal("doctor whitespace endpoint defaulted")
@@ -80,11 +80,11 @@ func TestDoctorMissingCredentialsIsRedactedAndNonMutating(t *testing.T) {
 	backend := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  core.Config{Blaxel: core.BlaxelConfig{APIURL: "https://api.blaxel.ai"}},
-		clientFactory: func(Config, Runtime) (Client, error) {
+		clientFactory: func(core.Config, core.Runtime) (Client, error) {
 			return fake, nil
 		},
 	}
-	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err == nil {
 		t.Fatal("Doctor succeeded without credentials")
 	}
@@ -105,11 +105,11 @@ func TestDoctorUsesOnlyProbeAndList(t *testing.T) {
 			APIKey:    "test-key",
 			Workspace: "workspace-test",
 		}},
-		clientFactory: func(Config, Runtime) (Client, error) {
+		clientFactory: func(core.Config, core.Runtime) (Client, error) {
 			return fake, nil
 		},
 	}
-	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/blaxel/flags.go
+++ b/internal/providers/blaxel/flags.go
@@ -8,11 +8,11 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func RegisterBlaxelProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterBlaxelProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterBlaxelConfigFlags(fs, defaults.Blaxel)
 }
 
-func ApplyBlaxelProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyBlaxelProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if strings.EqualFold(strings.TrimSpace(cfg.Provider), providerName) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --blaxel-memory-mb", "use --blaxel-image"); err != nil {
 			return err

--- a/internal/providers/blaxel/provider.go
+++ b/internal/providers/blaxel/provider.go
@@ -58,10 +58,10 @@ func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.Doctor
 }
 
 type backend struct {
-	spec          ProviderSpec
-	cfg           Config
-	rt            Runtime
-	clientFactory func(Config, Runtime) (Client, error)
+	spec          core.ProviderSpec
+	cfg           core.Config
+	rt            core.Runtime
+	clientFactory func(core.Config, core.Runtime) (Client, error)
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }

--- a/internal/providers/blaxel/provider_test.go
+++ b/internal/providers/blaxel/provider_test.go
@@ -109,7 +109,7 @@ func TestBlaxelFlagPresenceAndValidationOrder(t *testing.T) {
 		t.Fatal("explicit zeros not copied")
 	}
 	for _, name := range []string{"blaxel", " Blaxel "} {
-		cfg := Config{Provider: name}
+		cfg := core.Config{Provider: name}
 		fs := flag.NewFlagSet("guard", flag.ContinueOnError)
 		fs.String("class", "", "")
 		fs.String("type", "", "")
@@ -130,7 +130,7 @@ func TestBlaxelFlagPresenceAndValidationOrder(t *testing.T) {
 			}
 		}
 	}
-	cfg = Config{Blaxel: BlaxelConfig{APIURL: " ", MemoryMB: -1, ExecTimeoutSecs: -1, Workdir: "relative"}}
+	cfg = core.Config{Blaxel: core.BlaxelConfig{APIURL: " ", MemoryMB: -1, ExecTimeoutSecs: -1, Workdir: "relative"}}
 	if err := ApplyBlaxelProviderFlags(&cfg, flag.NewFlagSet("foreign", flag.ContinueOnError), struct{}{}); err != nil {
 		t.Fatal("foreign values reached validation")
 	}

--- a/internal/providers/blaxel/sync.go
+++ b/internal/providers/blaxel/sync.go
@@ -10,7 +10,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *backend) syncWorkspace(ctx context.Context, client Client, sandboxID string, req RunRequest, workdir string, prepared *core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+func (b *backend) syncWorkspace(ctx context.Context, client Client, sandboxID string, req core.RunRequest, workdir string, prepared *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
 		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
 		Workdir: workdir, TempPattern: "crabbox-blaxel-sync-*.tgz",
@@ -30,7 +30,7 @@ func (b *backend) syncWorkspace(ctx context.Context, client Client, sandboxID st
 }
 
 func (b *backend) ensureWorkspace(ctx context.Context, client Client, sandboxID, workdir string) error {
-	return b.execShell(ctx, client, sandboxID, "mkdir -p "+shellQuote(workdir))
+	return b.execShell(ctx, client, sandboxID, "mkdir -p "+core.ShellQuote(workdir))
 }
 
 func (b *backend) execShell(ctx context.Context, client Client, sandboxID, command string) error {
@@ -57,5 +57,5 @@ func (b *backend) execShell(ctx context.Context, client Client, sandboxID, comma
 	if res.ExitCode != nil {
 		code = *res.ExitCode
 	}
-	return exit(code, "blaxel exec %q exited %d: %s", command, code, strings.TrimSpace(logs.Stderr))
+	return core.Exit(code, "blaxel exec %q exited %d: %s", command, code, strings.TrimSpace(logs.Stderr))
 }

--- a/internal/providers/cloudflaresandbox/backend.go
+++ b/internal/providers/cloudflaresandbox/backend.go
@@ -28,18 +28,18 @@ const (
 )
 
 type backend struct {
-	spec      ProviderSpec
-	cfg       Config
-	rt        Runtime
-	newClient func(Config, Runtime) (bridgeClient, error)
+	spec      core.ProviderSpec
+	cfg       core.Config
+	rt        core.Runtime
+	newClient func(core.Config, core.Runtime) (bridgeClient, error)
 }
 
-func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	return &backend{spec: spec, cfg: cfg, rt: rt, newClient: newBridgeClient}
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
 func (b *backend) client() (bridgeClient, error) {
 	if b.newClient != nil {
@@ -48,27 +48,27 @@ func (b *backend) client() (bridgeClient, error) {
 	return newBridgeClient(b.cfg, b.rt)
 }
 
-func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	api, err := b.client()
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	checks := []DoctorCheck{}
+	checks := []core.DoctorCheck{}
 	health, err := api.Health(ctx)
 	if err != nil {
-		checks = append(checks, DoctorCheck{Status: "failed", Check: "health", Message: redactSecrets(err.Error()), Details: map[string]string{"mutation": "false"}})
+		checks = append(checks, core.DoctorCheck{Status: "failed", Check: "health", Message: redactSecrets(err.Error()), Details: map[string]string{"mutation": "false"}})
 	} else if !health.OK {
-		checks = append(checks, DoctorCheck{Status: "failed", Check: "health", Message: fmt.Sprintf("bridge=unhealthy status=%s ok=false mutation=false", core.Blank(health.Status, "-")), Details: map[string]string{"mutation": "false"}})
+		checks = append(checks, core.DoctorCheck{Status: "failed", Check: "health", Message: fmt.Sprintf("bridge=unhealthy status=%s ok=false mutation=false", core.Blank(health.Status, "-")), Details: map[string]string{"mutation": "false"}})
 	} else {
-		checks = append(checks, DoctorCheck{Status: "ok", Check: "health", Message: fmt.Sprintf("bridge=ready ok=%t mutation=false", health.OK), Details: map[string]string{"mutation": "false"}})
+		checks = append(checks, core.DoctorCheck{Status: "ok", Check: "health", Message: fmt.Sprintf("bridge=ready ok=%t mutation=false", health.OK), Details: map[string]string{"mutation": "false"}})
 	}
 	openapi, err := api.OpenAPI(ctx)
 	if err != nil {
-		checks = append(checks, DoctorCheck{Status: "failed", Check: "openapi", Message: redactSecrets(err.Error()), Details: map[string]string{"mutation": "false"}})
+		checks = append(checks, core.DoctorCheck{Status: "failed", Check: "openapi", Message: redactSecrets(err.Error()), Details: map[string]string{"mutation": "false"}})
 	} else {
-		checks = append(checks, DoctorCheck{Status: "ok", Check: "openapi", Message: fmt.Sprintf("openapi=ready title=%s mutation=false", core.Blank(openapi.Info.Title, "-")), Details: map[string]string{"mutation": "false"}})
+		checks = append(checks, core.DoctorCheck{Status: "ok", Check: "openapi", Message: fmt.Sprintf("openapi=ready title=%s mutation=false", core.Blank(openapi.Info.Title, "-")), Details: map[string]string{"mutation": "false"}})
 	}
-	return DoctorResult{
+	return core.DoctorResult{
 		Provider: providerName,
 		Status:   core.DoctorChecksStatus(checks),
 		Message:  "bridge=checked mutation=false",
@@ -76,12 +76,12 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	}, nil
 }
 
-func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *backend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if req.ActionsRunner {
-		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+		return core.Exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
 	if req.Options.Tailscale.Enabled {
-		return exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
+		return core.Exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
 	}
 	workdir, err := cloudflareSandboxWorkdir(b.cfg)
 	if err != nil {
@@ -110,7 +110,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	})
 }
 
-func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *backend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	workdir, workdirErr := cloudflareSandboxWorkdir(b.cfg)
 	var api bridgeClient
 	var leaseID, sandboxID, slug string
@@ -125,7 +125,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		IdleTimeout: b.cfg.IdleTimeout, TTL: b.cfg.TTL, CleanupTimeout: cloudflareSandboxCleanupTimeout,
 		Preflight: func(context.Context) error {
 			if req.Options.Tailscale.Enabled {
-				return exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
+				return core.Exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
 			}
 			if workdirErr != nil {
 				return workdirErr
@@ -185,7 +185,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 				fmt.Fprintf(b.rt.Stderr, "warning: provider=%s did not forward provider authentication variables: %s\n", providerName, strings.Join(strippedAuthEnv, ","))
 			}
 			if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
-				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, commandEnv)
+				core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, commandEnv)
 			}
 			return shared.DelegatedSandboxCommand{Text: commandText, Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
 				res, err := api.Exec(ctx, sandboxID, execRequest{
@@ -201,13 +201,13 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			if err := api.DeleteSandbox(ctx, sandboxID); err != nil && !isCloudflareSandboxNotFound(err) {
 				return fmt.Errorf("cloudflare-sandbox delete failed for %s: %w", sandboxID, err)
 			}
-			removeLeaseClaim(leaseID)
+			core.RemoveLeaseClaim(leaseID)
 			return nil
 		},
 	})
 }
 
-func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
 	api, err := b.client()
 	if err != nil {
 		return nil, err
@@ -216,7 +216,7 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 	if err != nil {
 		return nil, err
 	}
-	views := make([]LeaseView, 0, len(sandboxes))
+	views := make([]core.LeaseView, 0, len(sandboxes))
 	for _, sb := range sandboxes {
 		leaseID := strings.TrimSpace(sb.Metadata[metadataClaimKey])
 		if leaseID == "" && strings.HasPrefix(sb.ID, leasePrefix) {
@@ -234,7 +234,7 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 		if leaseID == "" {
 			continue
 		}
-		claim, err := readLeaseClaim(leaseID)
+		claim, err := core.ReadLeaseClaim(leaseID)
 		if err != nil {
 			return nil, err
 		}
@@ -253,21 +253,21 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 	return views, nil
 }
 
-func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	api, err := b.client()
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	leaseID, sandboxID, slug, err := b.resolveLeaseID(req.ID, "", false, 0)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	claim, ok, err := b.resolveCloudflareSandboxLeaseClaim(leaseID)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	if !ok {
-		return StatusView{}, exit(4, "cloudflare-sandbox sandbox %q is not claimed by Crabbox", req.ID)
+		return core.StatusView{}, core.Exit(4, "cloudflare-sandbox sandbox %q is not claimed by Crabbox", req.ID)
 	}
 	waitTimeout := req.WaitTimeout
 	if waitTimeout <= 0 {
@@ -284,18 +284,18 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 		sb, getErr := api.GetSandbox(pollCtx, sandboxID)
 		if getErr != nil {
 			if req.Wait && ctx.Err() == nil && pollCtx.Err() != nil {
-				return StatusView{}, exit(5, "timed out waiting for cloudflare-sandbox sandbox %s to become ready", sandboxID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for cloudflare-sandbox sandbox %s to become ready", sandboxID)
 			}
 			if ctx.Err() != nil {
-				return StatusView{}, ctx.Err()
+				return core.StatusView{}, ctx.Err()
 			}
-			return StatusView{}, getErr
+			return core.StatusView{}, getErr
 		}
 		if err := validateSandboxOwnership(claim, sb); err != nil {
-			return StatusView{}, err
+			return core.StatusView{}, err
 		}
 		state := normalizedSandboxState(sb)
-		view := StatusView{
+		view := core.StatusView{
 			ID:       leaseID,
 			Slug:     slug,
 			Provider: providerName,
@@ -317,23 +317,23 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 			return view, nil
 		}
 		if isTerminalState(state) {
-			return StatusView{}, exit(5, "cloudflare-sandbox sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
+			return core.StatusView{}, core.Exit(5, "cloudflare-sandbox sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
 		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return StatusView{}, exit(5, "timed out waiting for cloudflare-sandbox sandbox %s to become ready", sandboxID)
+			return core.StatusView{}, core.Exit(5, "timed out waiting for cloudflare-sandbox sandbox %s to become ready", sandboxID)
 		}
 		select {
 		case <-pollCtx.Done():
 			if ctx.Err() == nil {
-				return StatusView{}, exit(5, "timed out waiting for cloudflare-sandbox sandbox %s to become ready", sandboxID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for cloudflare-sandbox sandbox %s to become ready", sandboxID)
 			}
-			return StatusView{}, pollCtx.Err()
+			return core.StatusView{}, pollCtx.Err()
 		case <-time.After(2 * time.Second):
 		}
 	}
 }
 
-func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+func (b *backend) Stop(ctx context.Context, req core.StopRequest) error {
 	api, err := b.client()
 	if err != nil {
 		return err
@@ -356,7 +356,7 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 			return err
 		}
 		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing cloudflare-sandbox sandbox=%s after explicit request\n", sandboxID)
-		removeLeaseClaim(leaseID)
+		core.RemoveLeaseClaim(leaseID)
 		return nil
 	}
 	if err := api.DeleteSandbox(ctx, sandboxID); err != nil {
@@ -365,12 +365,12 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 		}
 		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing cloudflare-sandbox sandbox=%s after explicit request\n", sandboxID)
 	}
-	removeLeaseClaim(leaseID)
+	core.RemoveLeaseClaim(leaseID)
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, sandboxID)
 	return nil
 }
 
-func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
+func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	api, err := b.client()
 	if err != nil {
 		return err
@@ -379,7 +379,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	if err != nil {
 		return err
 	}
-	hasProviderClaims := slices.ContainsFunc(claims, func(claim LeaseClaim) bool {
+	hasProviderClaims := slices.ContainsFunc(claims, func(claim core.LeaseClaim) bool {
 		return claim.Provider == providerName
 	})
 	if !hasProviderClaims {
@@ -397,7 +397,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			continue
 		}
 		action, err := func() (string, error) {
-			claim, err := readLeaseClaim(listed.LeaseID)
+			claim, err := core.ReadLeaseClaim(listed.LeaseID)
 			if err != nil {
 				return "", err
 			}
@@ -409,7 +409,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 				return "", err
 			}
 			defer unlockOperation()
-			claim, err = readLeaseClaim(listed.LeaseID)
+			claim, err = core.ReadLeaseClaim(listed.LeaseID)
 			if err != nil {
 				return "", err
 			}
@@ -431,7 +431,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 					return "skip", nil
 				}
-				if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+				if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 					return "", err
 				}
 				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
@@ -452,7 +452,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			if err := api.DeleteSandbox(ctx, sandboxID); err != nil && !isCloudflareSandboxNotFound(err) {
 				return "", err
 			}
-			if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+			if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 				return "", err
 			}
 			fmt.Fprintf(b.rt.Stdout, "delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
@@ -474,7 +474,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	return nil
 }
 
-func (b *backend) createSandbox(ctx context.Context, api bridgeClient, repo Repo, reclaim bool, requestedSlug string) (string, string, string, func(), error) {
+func (b *backend) createSandbox(ctx context.Context, api bridgeClient, repo core.Repo, reclaim bool, requestedSlug string) (string, string, string, func(), error) {
 	if err := validateProviderConfig(b.cfg); err != nil {
 		return "", "", "", nil, err
 	}
@@ -484,7 +484,7 @@ func (b *backend) createSandbox(ctx context.Context, api bridgeClient, repo Repo
 	}
 	name := newSandboxName(repo)
 	leaseID := leasePrefix + name
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return "", "", "", nil, err
 	}
@@ -498,7 +498,7 @@ func (b *backend) createSandbox(ctx context.Context, api bridgeClient, repo Repo
 		return "", "", "", nil, err
 	}
 	if sb.ID == "" {
-		return "", "", "", nil, b.cleanupCreateFailure(ctx, api, "", exit(5, "cloudflare-sandbox create returned no sandbox id"))
+		return "", "", "", nil, b.cleanupCreateFailure(ctx, api, "", core.Exit(5, "cloudflare-sandbox create returned no sandbox id"))
 	}
 	if !sandboxHasOwnershipMetadata(sb, metadata) {
 		remote, err := api.GetSandbox(ctx, sb.ID)
@@ -512,15 +512,15 @@ func (b *backend) createSandbox(ctx context.Context, api bridgeClient, repo Repo
 	}
 	if returnedLeaseID := strings.TrimSpace(sb.Metadata[metadataClaimKey]); returnedLeaseID == leasePrefix+sb.ID {
 		leaseID = leasePrefix + sb.ID
-		slug, err = allocateClaimLeaseSlug(leaseID, requestedSlug)
+		slug, err = core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 		if err != nil {
 			return "", "", "", nil, b.cleanupCreateFailure(ctx, api, sb.ID, err)
 		}
 	}
-	if err := validateSandboxOwnership(LeaseClaim{LeaseID: leaseID, Provider: providerName, ProviderScope: providerScope}, sb); err != nil {
+	if err := validateSandboxOwnership(core.LeaseClaim{LeaseID: leaseID, Provider: providerName, ProviderScope: providerScope}, sb); err != nil {
 		return "", "", "", nil, b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
-	if err := claimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, providerScope, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim, Server{
+	if err := claimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, providerScope, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim, core.Server{
 		CloudID:  sb.ID,
 		Provider: providerName,
 		Labels: map[string]string{
@@ -533,7 +533,7 @@ func (b *backend) createSandbox(ctx context.Context, api bridgeClient, repo Repo
 	return leaseID, sb.ID, slug, func() {}, nil
 }
 
-func (b *backend) ownershipMetadata(providerScope, leaseID, slug string, repo Repo) map[string]string {
+func (b *backend) ownershipMetadata(providerScope, leaseID, slug string, repo core.Repo) map[string]string {
 	out := map[string]string{
 		metadataProviderKey: providerName,
 		metadataScopeKey:    providerScope,
@@ -554,9 +554,9 @@ func sandboxHasOwnershipMetadata(sb sandboxSummary, metadata map[string]string) 
 		sb.Metadata[metadataClaimKey] == metadata[metadataClaimKey]
 }
 
-func (b *backend) serverFromSandbox(claim LeaseClaim, sb sandboxSummary) Server {
+func (b *backend) serverFromSandbox(claim core.LeaseClaim, sb sandboxSummary) core.Server {
 	state := normalizedSandboxState(sb)
-	return Server{
+	return core.Server{
 		Provider: providerName,
 		CloudID:  sb.ID,
 		Name:     sb.ID,
@@ -575,13 +575,13 @@ func (b *backend) serverFromSandbox(claim LeaseClaim, sb sandboxSummary) Server 
 func (b *backend) resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration) (string, string, string, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return "", "", "", exit(2, "provider=cloudflare-sandbox requires a Crabbox-created sandbox slug or lease id")
+		return "", "", "", core.Exit(2, "provider=cloudflare-sandbox requires a Crabbox-created sandbox slug or lease id")
 	}
 	exactLeaseID := id
 	if !strings.HasPrefix(exactLeaseID, leasePrefix) {
 		exactLeaseID = leasePrefix + exactLeaseID
 	}
-	if claim, err := readLeaseClaim(exactLeaseID); err != nil {
+	if claim, err := core.ReadLeaseClaim(exactLeaseID); err != nil {
 		return "", "", "", err
 	} else if claim.LeaseID == exactLeaseID && claim.Provider == providerName {
 		return b.finishResolvedLease(claim, repoRoot, reclaim, idleTimeout)
@@ -593,35 +593,35 @@ func (b *backend) resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout 
 	if ok {
 		return b.finishResolvedLease(claim, repoRoot, reclaim, idleTimeout)
 	}
-	return "", "", "", exit(4, "cloudflare-sandbox sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
+	return "", "", "", core.Exit(4, "cloudflare-sandbox sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
 }
 
-func (b *backend) resolveCloudflareSandboxLeaseClaim(identifier string) (LeaseClaim, bool, error) {
+func (b *backend) resolveCloudflareSandboxLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 	claims, err := listCloudflareSandboxLeaseClaims()
 	if err != nil {
-		return LeaseClaim{}, false, err
+		return core.LeaseClaim{}, false, err
 	}
 	for _, claim := range claims {
 		if claim.Provider == providerName && claim.LeaseID == identifier {
 			if err := b.validateClaimScope(claim); err != nil {
-				return LeaseClaim{}, false, err
+				return core.LeaseClaim{}, false, err
 			}
 			return claim, true, nil
 		}
 	}
-	slug := normalizeLeaseSlug(identifier)
+	slug := core.NormalizeLeaseSlug(identifier)
 	if slug != "" {
 		for _, claim := range claims {
-			if claim.Provider != providerName || normalizeLeaseSlug(claim.Slug) != slug || !b.claimMatchesActiveScope(claim) {
+			if claim.Provider != providerName || core.NormalizeLeaseSlug(claim.Slug) != slug || !b.claimMatchesActiveScope(claim) {
 				continue
 			}
 			return claim, true, nil
 		}
 	}
-	return LeaseClaim{}, false, nil
+	return core.LeaseClaim{}, false, nil
 }
 
-func (b *backend) finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration) (string, string, string, error) {
+func (b *backend) finishResolvedLease(claim core.LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration) (string, string, string, error) {
 	if err := b.validateClaimScope(claim); err != nil {
 		return "", "", "", err
 	}
@@ -630,18 +630,18 @@ func (b *backend) finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim
 		if timeout <= 0 && claim.IdleTimeoutSeconds > 0 {
 			timeout = time.Duration(claim.IdleTimeoutSeconds) * time.Second
 		}
-		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, repoRoot, timeout, reclaim); err != nil {
+		if err := core.ClaimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, repoRoot, timeout, reclaim); err != nil {
 			return "", "", "", err
 		}
 	}
 	slug := claim.Slug
 	if strings.TrimSpace(slug) == "" {
-		slug = newLeaseSlug(claim.LeaseID)
+		slug = core.NewLeaseSlug(claim.LeaseID)
 	}
 	return claim.LeaseID, claimSandboxID(claim), slug, nil
 }
 
-func claimSandboxID(claim LeaseClaim) string {
+func claimSandboxID(claim core.LeaseClaim) string {
 	if id := strings.TrimSpace(claim.CloudID); id != "" {
 		return id
 	}
@@ -651,7 +651,7 @@ func claimSandboxID(claim LeaseClaim) string {
 func (b *backend) newClaimScope() (string, error) {
 	var token [16]byte
 	if _, err := rand.Read(token[:]); err != nil {
-		return "", exit(5, "generate cloudflare-sandbox ownership token: %v", err)
+		return "", core.Exit(5, "generate cloudflare-sandbox ownership token: %v", err)
 	}
 	return b.providerScopeBase() + "/ownership:" + hex.EncodeToString(token[:]), nil
 }
@@ -664,19 +664,19 @@ func (b *backend) providerScopeBase() string {
 	return "bridge:" + bridge
 }
 
-func (b *backend) validateClaimScope(claim LeaseClaim) error {
+func (b *backend) validateClaimScope(claim core.LeaseClaim) error {
 	if !b.claimMatchesActiveScope(claim) {
-		return exit(4, "cloudflare-sandbox lease %q belongs to a different bridge scope; restore the configuration used to create it", claim.LeaseID)
+		return core.Exit(4, "cloudflare-sandbox lease %q belongs to a different bridge scope; restore the configuration used to create it", claim.LeaseID)
 	}
 	return nil
 }
 
-func (b *backend) claimMatchesActiveScope(claim LeaseClaim) bool {
+func (b *backend) claimMatchesActiveScope(claim core.LeaseClaim) bool {
 	return strings.HasPrefix(strings.TrimSpace(claim.ProviderScope), b.providerScopeBase()+"/ownership:")
 }
 
 func (b *backend) verifyClaim(ctx context.Context, api bridgeClient, leaseID, sandboxID string) (sandboxSummary, error) {
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		return sandboxSummary{}, err
 	}
@@ -693,20 +693,20 @@ func (b *backend) verifyClaim(ctx context.Context, api bridgeClient, leaseID, sa
 	return sb, nil
 }
 
-func validateSandboxOwnership(claim LeaseClaim, sb sandboxSummary) error {
+func validateSandboxOwnership(claim core.LeaseClaim, sb sandboxSummary) error {
 	if sb.ID == "" {
-		return exit(5, "cloudflare-sandbox returned a sandbox without an id")
+		return core.Exit(5, "cloudflare-sandbox returned a sandbox without an id")
 	}
 	if sb.Metadata[metadataProviderKey] != providerName ||
 		sb.Metadata[metadataScopeKey] != claim.ProviderScope ||
 		sb.Metadata[metadataClaimKey] != claim.LeaseID {
-		return exit(4, "cloudflare-sandbox sandbox %q ownership metadata does not match its local claim", sb.ID)
+		return core.Exit(4, "cloudflare-sandbox sandbox %q ownership metadata does not match its local claim", sb.ID)
 	}
 	return nil
 }
 
 func (b *backend) refreshLeaseActivity(leaseID string) error {
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		return err
 	}
@@ -717,7 +717,7 @@ func (b *backend) refreshLeaseActivity(leaseID string) error {
 	if idleTimeout <= 0 && claim.IdleTimeoutSeconds > 0 {
 		idleTimeout = time.Duration(claim.IdleTimeoutSeconds) * time.Second
 	}
-	return claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, claim.RepoRoot, idleTimeout, false)
+	return core.ClaimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, claim.RepoRoot, idleTimeout, false)
 }
 
 func (b *backend) cleanupCreateFailure(ctx context.Context, api bridgeClient, sandboxID string, cause error) error {
@@ -765,7 +765,7 @@ func isTerminalState(state string) bool {
 	}
 }
 
-func repoScope(repo Repo) string {
+func repoScope(repo core.Repo) string {
 	if strings.TrimSpace(repo.RemoteURL) != "" {
 		return strings.TrimSpace(repo.RemoteURL)
 	}
@@ -775,7 +775,7 @@ func repoScope(repo Repo) string {
 	return strings.TrimSpace(repo.Name)
 }
 
-func bridgeMetadataRepoScope(repo Repo) string {
+func bridgeMetadataRepoScope(repo core.Repo) string {
 	scope := repoScope(repo)
 	parsed, err := url.Parse(scope)
 	if err != nil || parsed.User == nil || parsed.Scheme == "" || parsed.Host == "" {
@@ -785,7 +785,7 @@ func bridgeMetadataRepoScope(repo Repo) string {
 	return parsed.String()
 }
 
-func newSandboxName(repo Repo) string {
+func newSandboxName(repo core.Repo) string {
 	source := repo.Name
 	if strings.TrimSpace(source) == "" {
 		source = "sandbox"

--- a/internal/providers/cloudflaresandbox/backend_test.go
+++ b/internal/providers/cloudflaresandbox/backend_test.go
@@ -152,7 +152,7 @@ func TestWarmupCreatesOwnedClaim(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, &stdout, &stderr)
-	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.sandboxes) != 1 {
@@ -163,7 +163,7 @@ func TestWarmupCreatesOwnedClaim(t *testing.T) {
 		sb = value
 	}
 	leaseID := leasePrefix + sb.ID
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,12 +182,12 @@ func TestCreateMetadataRedactsRemoteURLCredentials(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
-	repo := Repo{
+	repo := core.Repo{
 		Name:      "my-app",
 		Root:      "/repo",
 		RemoteURL: "https://oauth2:secret-token@github.com/openclaw/crabbox.git",
 	}
-	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: repo, Keep: true}); err != nil {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: repo, Keep: true}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.creates) != 1 {
@@ -206,7 +206,7 @@ func TestDoctorFailsUnhealthyBridgeResponse(t *testing.T) {
 	fake := newLifecycleFakeClient()
 	fake.healthOK = false
 	backend := testBackend(fake, io.Discard, io.Discard)
-	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +222,7 @@ func TestDoctorFailsWhenOpenAPIReadinessFails(t *testing.T) {
 	fake := newLifecycleFakeClient()
 	fake.openAPIErr = errors.New("401 Unauthorized")
 	backend := testBackend(fake, io.Discard, io.Discard)
-	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +240,7 @@ func TestWarmupAcceptsGeneratedSandboxIDWithEchoedMetadata(t *testing.T) {
 	fake := newLifecycleFakeClient()
 	fake.generateIDs = true
 	backend := testBackend(fake, &stdout, &stderr)
-	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.creates) != 1 {
@@ -250,21 +250,21 @@ func TestWarmupAcceptsGeneratedSandboxIDWithEchoedMetadata(t *testing.T) {
 	if leaseID == "" {
 		t.Fatalf("request metadata=%#v", fake.creates[0].Metadata)
 	}
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if claim.CloudID != "cf-sandbox-a" {
 		t.Fatalf("claim CloudID=%q want generated sandbox id", claim.CloudID)
 	}
-	status, err := backend.Status(context.Background(), StatusRequest{ID: claim.Slug})
+	status, err := backend.Status(context.Background(), core.StatusRequest{ID: claim.Slug})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if status.ID != leaseID || status.ServerID != claim.CloudID {
 		t.Fatalf("status=%#v claim=%#v", status, claim)
 	}
-	views, err := backend.List(context.Background(), ListRequest{})
+	views, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,14 +278,14 @@ func TestWarmupVerifiesOwnershipMetadataWhenCreateOmitsIt(t *testing.T) {
 	fake := newLifecycleFakeClient()
 	fake.omitCreateMetadata = true
 	backend := testBackend(fake, io.Discard, io.Discard)
-	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
 		t.Fatal(err)
 	}
 	if !slices.Contains(fake.calls, "get:"+fake.creates[0].Name) {
 		t.Fatalf("calls=%#v, want create metadata verification fetch", fake.calls)
 	}
 	leaseID := fake.creates[0].Metadata[metadataClaimKey]
-	if _, err := readLeaseClaim(leaseID); err != nil {
+	if _, err := core.ReadLeaseClaim(leaseID); err != nil {
 		t.Fatalf("claim not created after verified metadata fetch: %v", err)
 	}
 }
@@ -296,7 +296,7 @@ func TestWarmupRejectsCreateWhenRemoteMetadataMissing(t *testing.T) {
 	fake.omitCreateMetadata = true
 	fake.dropMetadata = true
 	backend := testBackend(fake, io.Discard, io.Discard)
-	err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: "/repo"}, Keep: true})
+	err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "my-app", Root: "/repo"}, Keep: true})
 	if err == nil || !strings.Contains(err.Error(), "ownership metadata") {
 		t.Fatalf("err=%v, want ownership metadata failure", err)
 	}
@@ -312,8 +312,8 @@ func TestRunOneShotSyncsExecutesAndDeletes(t *testing.T) {
 	fake := newLifecycleFakeClient()
 	fake.stdout = "ok\n"
 	backend := testBackend(fake, &stdout, &stderr)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:               Repo{Name: "my-app", Root: repo},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:               core.Repo{Name: "my-app", Root: repo},
 		Command:            []string{"echo", "ok", "&&"},
 		CommandLiteralArgs: map[int]bool{2: true},
 	})
@@ -353,8 +353,8 @@ func TestRunKeepPublishesReusableSessionAndCleanupStopsSandbox(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: tempRepo(t)},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: tempRepo(t)},
 		NoSync:  true,
 		Keep:    true,
 		Command: []string{"true"},
@@ -374,13 +374,13 @@ func TestRunKeepPublishesReusableSessionAndCleanupStopsSandbox(t *testing.T) {
 	if result.Session.CleanupCommand != cloudflareSandboxCleanupCommand(result.LeaseID) {
 		t.Fatalf("cleanup command=%q", result.Session.CleanupCommand)
 	}
-	if err := backend.Stop(context.Background(), StopRequest{ID: result.Session.LeaseID}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: result.Session.LeaseID}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.sandboxes) != 0 {
 		t.Fatalf("cleanup left sandboxes: %#v", fake.sandboxes)
 	}
-	claim, err := readLeaseClaim(result.Session.LeaseID)
+	claim, err := core.ReadLeaseClaim(result.Session.LeaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -394,15 +394,15 @@ func TestRetainedRunByIDVerifiesOwnershipAndKeepsClaim(t *testing.T) {
 	repo := tempRepo(t)
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
-	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: repo}, Keep: true}); err != nil {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "my-app", Root: repo}, Keep: true}); err != nil {
 		t.Fatal(err)
 	}
 	var leaseID string
 	for id := range fake.sandboxes {
 		leaseID = leasePrefix + id
 	}
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: repo},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: repo},
 		ID:      leaseID,
 		NoSync:  true,
 		Keep:    true,
@@ -417,7 +417,7 @@ func TestRetainedRunByIDVerifiesOwnershipAndKeepsClaim(t *testing.T) {
 	if result.Session == nil || !result.Session.Reused || !result.Session.Kept || result.Session.LeaseID != leaseID || result.Session.Slug != result.Slug {
 		t.Fatalf("session=%#v result=%#v", result.Session, result)
 	}
-	if _, err := readLeaseClaim(leaseID); err != nil {
+	if _, err := core.ReadLeaseClaim(leaseID); err != nil {
 		t.Fatalf("claim not retained: %v", err)
 	}
 	if len(fake.sandboxes) != 1 {
@@ -429,7 +429,7 @@ func TestStopRejectsOwnershipMismatch(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
-	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
 		t.Fatal(err)
 	}
 	var leaseID, sandboxID string
@@ -439,7 +439,7 @@ func TestStopRejectsOwnershipMismatch(t *testing.T) {
 		sb.Metadata[metadataProviderKey] = "foreign"
 		fake.sandboxes[id] = sb
 	}
-	err := backend.Stop(context.Background(), StopRequest{ID: leaseID})
+	err := backend.Stop(context.Background(), core.StopRequest{ID: leaseID})
 	if err == nil || !strings.Contains(err.Error(), "ownership metadata") {
 		t.Fatalf("err=%v", err)
 	}
@@ -452,7 +452,7 @@ func TestStopHonorsLeaseOperationLock(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
-	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
 		t.Fatal(err)
 	}
 	var leaseID string
@@ -467,7 +467,7 @@ func TestStopHonorsLeaseOperationLock(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
 	defer cancel()
-	err = backend.Stop(ctx, StopRequest{ID: leaseID})
+	err = backend.Stop(ctx, core.StopRequest{ID: leaseID})
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("Stop err=%v, want context deadline", err)
 	}
@@ -480,7 +480,7 @@ func TestCleanupPreservesMissingClaimUnlessForgetMissing(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
-	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
 		t.Fatal(err)
 	}
 	var leaseID string
@@ -488,17 +488,17 @@ func TestCleanupPreservesMissingClaimUnlessForgetMissing(t *testing.T) {
 		leaseID = leasePrefix + id
 		delete(fake.sandboxes, id)
 	}
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := readLeaseClaim(leaseID); err != nil {
+	if _, err := core.ReadLeaseClaim(leaseID); err != nil {
 		t.Fatalf("claim should be preserved without forget-missing: %v", err)
 	}
 	backend.cfg.CloudflareSandbox.ForgetMissing = true
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -512,8 +512,8 @@ func TestRunForwardsAllowedEnvOffArgvAndStripsProviderSecrets(t *testing.T) {
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
 	secretValue := "secret-token-value"
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: tempRepo(t)},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: tempRepo(t)},
 		Keep:    true,
 		NoSync:  true,
 		Command: []string{"env"},
@@ -556,8 +556,8 @@ func TestSyncDeleteUsesStagingReplace(t *testing.T) {
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
 	backend.cfg.Sync.Delete = true
-	if _, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: repo},
+	if _, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: repo},
 		Command: []string{"true"},
 	}); err != nil {
 		t.Fatal(err)
@@ -572,8 +572,8 @@ func TestRunKeepOnFailureRetainsClaim(t *testing.T) {
 	fake := newLifecycleFakeClient()
 	fake.exitCode = 7
 	backend := testBackend(fake, io.Discard, io.Discard)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:          Repo{Name: "my-app", Root: tempRepo(t)},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:          core.Repo{Name: "my-app", Root: tempRepo(t)},
 		NoSync:        true,
 		KeepOnFailure: true,
 		Command:       []string{"false"},
@@ -591,7 +591,7 @@ func TestRunKeepOnFailureRetainsClaim(t *testing.T) {
 	for id := range fake.sandboxes {
 		leaseID = leasePrefix + id
 	}
-	if claim, err := readLeaseClaim(leaseID); err != nil || claim.LeaseID == "" {
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil || claim.LeaseID == "" {
 		t.Fatalf("claim should be retained: claim=%#v err=%v", claim, err)
 	}
 }
@@ -600,8 +600,8 @@ func TestRunKeepOnFailureStillDeletesSuccessfulOneShot(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:          Repo{Name: "my-app", Root: tempRepo(t)},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:          core.Repo{Name: "my-app", Root: tempRepo(t)},
 		NoSync:        true,
 		KeepOnFailure: true,
 		Command:       []string{"true"},
@@ -622,8 +622,8 @@ func TestRunCleanupFailureReturnsRetainedSession(t *testing.T) {
 	fake := newLifecycleFakeClient()
 	fake.deleteErr = errors.New("bridge delete unavailable")
 	backend := testBackend(fake, io.Discard, io.Discard)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: tempRepo(t)},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: tempRepo(t)},
 		NoSync:  true,
 		Command: []string{"true"},
 	})
@@ -650,11 +650,11 @@ func TestListReturnsOwnedSandboxesOnly(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
-	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandboxes["foreign"] = sandboxSummary{ID: "foreign", Status: "running"}
-	views, err := backend.List(context.Background(), ListRequest{})
+	views, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -676,7 +676,7 @@ func TestCloudflareSandboxCreateKeepsRawConfiguredWorkdir(t *testing.T) {
 		b := testBackend(fake, io.Discard, io.Discard)
 		b.cfg.CloudflareSandbox.Workdir = raw
 		root := t.TempDir()
-		_, _, _, release, err := b.createSandbox(context.Background(), fake, Repo{Name: "example", Root: root}, false, "")
+		_, _, _, release, err := b.createSandbox(context.Background(), fake, core.Repo{Name: "example", Root: root}, false, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -710,11 +710,11 @@ func testBackend(fake *lifecycleFakeClient, stdout, stderr io.Writer) *backend {
 	return &backend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt: Runtime{
+		rt: core.Runtime{
 			Stdout: stdout,
 			Stderr: stderr,
 		},
-		newClient: func(Config, Runtime) (bridgeClient, error) {
+		newClient: func(core.Config, core.Runtime) (bridgeClient, error) {
 			return fake, nil
 		},
 	}
@@ -760,8 +760,8 @@ func TestRunLifecycleArchiveGuardrailBeforeCreation(t *testing.T) {
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
 	backend.cfg.Sync.FailFiles = 1
-	result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: tempRepo(t)}, Command: []string{"true"}})
-	var ee ExitError
+	result, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Name: "repo", Root: tempRepo(t)}, Command: []string{"true"}})
+	var ee core.ExitError
 	if !errors.As(err, &ee) || ee.Code != 6 || result.ExitCode != 6 || len(fake.creates) != 0 || result.Session != nil {
 		t.Fatalf("result=%#v err=%v creates=%v", result, err, fake.creates)
 	}
@@ -775,12 +775,12 @@ func TestRunLifecycleCleanupOutcomeAndTiming(t *testing.T) {
 			fake.exitCode, fake.deleteErr = code, errors.New("delete unavailable")
 			var stderr bytes.Buffer
 			backend := testBackend(fake, io.Discard, &stderr)
-			result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, TimingJSON: true})
+			result, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, TimingJSON: true})
 			wantCode, wantKind := code, core.RunErrorCommandExit
 			if code == 0 {
 				wantCode, wantKind = 1, core.RunErrorProvider
 			}
-			var ee ExitError
+			var ee core.ExitError
 			if !errors.As(err, &ee) || ee.Code != wantCode || result.ExitCode != wantCode || result.ErrorKind != wantKind || result.Session == nil || !result.Session.Kept {
 				t.Fatalf("result=%#v err=%v", result, err)
 			}
@@ -812,8 +812,8 @@ func TestRunLifecycleHonorsOperationLockAndReleasesOnOwnershipFailure(t *testing
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
-	repo := Repo{Name: "repo", Root: t.TempDir()}
-	kept, err := backend.Run(t.Context(), RunRequest{Repo: repo, NoSync: true, Keep: true, SyncOnly: true})
+	repo := core.Repo{Name: "repo", Root: t.TempDir()}
+	kept, err := backend.Run(t.Context(), core.RunRequest{Repo: repo, NoSync: true, Keep: true, SyncOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -823,7 +823,7 @@ func TestRunLifecycleHonorsOperationLockAndReleasesOnOwnershipFailure(t *testing
 	}
 	callsBefore := len(fake.calls)
 	ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
-	result, err := backend.Run(ctx, RunRequest{Repo: repo, ID: kept.LeaseID, NoSync: true, Command: []string{"true"}})
+	result, err := backend.Run(ctx, core.RunRequest{Repo: repo, ID: kept.LeaseID, NoSync: true, Command: []string{"true"}})
 	cancel()
 	unlock()
 	if !errors.Is(err, context.DeadlineExceeded) || result.Session != nil || len(fake.calls) != callsBefore {
@@ -833,7 +833,7 @@ func TestRunLifecycleHonorsOperationLockAndReleasesOnOwnershipFailure(t *testing
 		sandbox.Metadata[metadataClaimKey] = "foreign"
 		fake.sandboxes[id] = sandbox
 	}
-	result, err = backend.Run(t.Context(), RunRequest{Repo: repo, ID: kept.LeaseID, NoSync: true, Command: []string{"true"}})
+	result, err = backend.Run(t.Context(), core.RunRequest{Repo: repo, ID: kept.LeaseID, NoSync: true, Command: []string{"true"}})
 	if err == nil || result.Session != nil || len(fake.execs) != 1 || len(fake.sandboxes) != 1 {
 		t.Fatalf("ownership check bypassed: result=%#v err=%v execs=%v", result, err, fake.execs)
 	}

--- a/internal/providers/cloudflaresandbox/client.go
+++ b/internal/providers/cloudflaresandbox/client.go
@@ -102,7 +102,7 @@ type warmPoolResponse struct {
 	Total int `json:"total,omitempty"`
 }
 
-func newBridgeClient(cfg Config, rt Runtime) (bridgeClient, error) {
+func newBridgeClient(cfg core.Config, rt core.Runtime) (bridgeClient, error) {
 	baseURL, err := bridgeURL(cfg)
 	if err != nil {
 		return nil, err

--- a/internal/providers/cloudflaresandbox/client_test.go
+++ b/internal/providers/cloudflaresandbox/client_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -74,7 +75,7 @@ func TestBridgeInjectedHTTPSettingsArePreservedForBothPlanes(t *testing.T) {
 	injected := &http.Client{Transport: transport, Timeout: 17 * time.Second}
 	cfg := testConfig()
 	cfg.CloudflareSandbox.BridgeURL = "http://127.0.0.1:8787"
-	api, err := newBridgeClient(cfg, Runtime{HTTP: injected})
+	api, err := newBridgeClient(cfg, core.Runtime{HTTP: injected})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,8 +120,8 @@ func TestBridgeClientHealthOpenAPIAuthAndNonMutatingDoctorRoutes(t *testing.T) {
 	cfg := testConfig()
 	cfg.CloudflareSandbox.BridgeURL = server.URL
 	cfg.CloudflareSandbox.Token = "cf_sandbox_test_token"
-	backend := NewBackend((Provider{}).Spec(), cfg, Runtime{HTTP: server.Client()}).(*backend)
-	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	backend := NewBackend((Provider{}).Spec(), cfg, core.Runtime{HTTP: server.Client()}).(*backend)
+	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +151,7 @@ func TestBridgeClientClassifiesOnlyHTTP404AsNotFound(t *testing.T) {
 
 	cfg := testConfig()
 	cfg.CloudflareSandbox.BridgeURL = server.URL
-	api, err := newBridgeClient(cfg, Runtime{HTTP: server.Client()})
+	api, err := newBridgeClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,7 +183,7 @@ func TestBridgeClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
 	cfg := testConfig()
 	cfg.CloudflareSandbox.BridgeURL = trusted.URL
 	cfg.CloudflareSandbox.Token = "cf_sandbox_test_token"
-	api, err := newBridgeClient(cfg, Runtime{HTTP: trusted.Client()})
+	api, err := newBridgeClient(cfg, core.Runtime{HTTP: trusted.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -220,7 +221,7 @@ func TestBridgeClientFollowsSameOriginRedirect(t *testing.T) {
 	cfg := testConfig()
 	cfg.CloudflareSandbox.BridgeURL = server.URL
 	cfg.CloudflareSandbox.Token = "cf_sandbox_test_token"
-	api, err := newBridgeClient(cfg, Runtime{HTTP: server.Client()})
+	api, err := newBridgeClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -248,7 +249,7 @@ func TestBridgeClientPreservesCallerRedirectPolicy(t *testing.T) {
 	}
 	cfg := testConfig()
 	cfg.CloudflareSandbox.BridgeURL = server.URL
-	api, err := newBridgeClient(cfg, Runtime{HTTP: httpClient})
+	api, err := newBridgeClient(cfg, core.Runtime{HTTP: httpClient})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +322,7 @@ func TestBridgeClientRuntimeEndpointShapeIsTypedForPlan02(t *testing.T) {
 	cfg := testConfig()
 	cfg.CloudflareSandbox.BridgeURL = server.URL
 	cfg.CloudflareSandbox.Token = "cf_sandbox_test_token"
-	api, err := newBridgeClient(cfg, Runtime{HTTP: server.Client()})
+	api, err := newBridgeClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -385,7 +386,7 @@ func TestBridgeClientExecParsesSSEOutputBeforeExit(t *testing.T) {
 
 	cfg := testConfig()
 	cfg.CloudflareSandbox.BridgeURL = server.URL
-	api, err := newBridgeClient(cfg, Runtime{HTTP: server.Client()})
+	api, err := newBridgeClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -416,7 +417,7 @@ func TestBridgeClientExecLeavesPlainSSEChunksUntouched(t *testing.T) {
 
 	cfg := testConfig()
 	cfg.CloudflareSandbox.BridgeURL = server.URL
-	api, err := newBridgeClient(cfg, Runtime{HTTP: server.Client()})
+	api, err := newBridgeClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -440,7 +441,7 @@ func TestBridgeClientRedactsTokenFromErrors(t *testing.T) {
 	cfg := testConfig()
 	cfg.CloudflareSandbox.BridgeURL = server.URL
 	cfg.CloudflareSandbox.Token = "cf_sandbox_test_token"
-	api, err := newBridgeClient(cfg, Runtime{HTTP: server.Client()})
+	api, err := newBridgeClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/cloudflaresandbox/core.go
+++ b/internal/providers/cloudflaresandbox/core.go
@@ -1,35 +1,10 @@
 package cloudflaresandbox
 
 import (
-	"io"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type CloudflareSandboxConfig = core.CloudflareSandboxConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type DoctorCheck = core.DoctorCheck
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type RunSessionHandle = core.RunSessionHandle
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type CleanupRequest = core.CleanupRequest
-type Server = core.Server
-type Repo = core.Repo
-type LeaseClaim = core.LeaseClaim
-type ExitError = core.ExitError
-type timingPhase = core.TimingPhase
 
 const (
 	providerName   = "cloudflare-sandbox"
@@ -39,54 +14,14 @@ const (
 	NetworkPublic  = "public"
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
-}
-
-func claimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool, server Server) error {
+func claimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool, server core.Server) error {
 	return core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim, server, core.SSHTarget{})
-}
-
-func readLeaseClaim(leaseID string) (LeaseClaim, error) {
-	return core.ReadLeaseClaim(leaseID)
 }
 
 func listCloudflareSandboxLeaseClaims() ([]core.LeaseClaim, error) {
 	return core.ListLeaseClaimsWithPrefix(leasePrefix)
 }
 
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
-func removeLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
-	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
-}
-
-func shellQuote(value string) string {
-	return core.ShellQuote(value)
-}
-
 func cloudflareSandboxCleanupCommand(leaseID string) string {
-	return "crabbox stop --provider " + providerName + " --id " + shellQuote(leaseID)
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
+	return "crabbox stop --provider " + providerName + " --id " + core.ShellQuote(leaseID)
 }

--- a/internal/providers/cloudflaresandbox/flags.go
+++ b/internal/providers/cloudflaresandbox/flags.go
@@ -10,11 +10,11 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func RegisterProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterCloudflareSandboxConfigFlags(fs, defaults.CloudflareSandbox)
 }
 
-func ApplyProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if strings.EqualFold(strings.TrimSpace(cfg.Provider), providerName) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
 			return err
@@ -32,7 +32,7 @@ func ApplyProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	return validateProviderConfig(*cfg)
 }
 
-func validateProviderConfig(cfg Config) error {
+func validateProviderConfig(cfg core.Config) error {
 	if _, err := bridgeURL(cfg); err != nil {
 		return err
 	}
@@ -40,47 +40,47 @@ func validateProviderConfig(cfg Config) error {
 		return err
 	}
 	if cfg.CloudflareSandbox.ExecTimeoutSecs < 0 {
-		return exit(2, "%s execTimeoutSecs must be non-negative", providerName)
+		return core.Exit(2, "%s execTimeoutSecs must be non-negative", providerName)
 	}
 	return nil
 }
 
-func cloudflareSandboxWorkdir(cfg Config) (string, error) {
+func cloudflareSandboxWorkdir(cfg core.Config) (string, error) {
 	workdir := strings.TrimSpace(cfg.CloudflareSandbox.Workdir)
 	if workdir == "" {
 		workdir = core.CloudflareSandboxConfigDefaultWorkdir
 	}
 	if !path.IsAbs(workdir) {
-		return "", exit(2, "%s workdir must be absolute", providerName)
+		return "", core.Exit(2, "%s workdir must be absolute", providerName)
 	}
 	clean := path.Clean(workdir)
 	if clean == "/workspace" {
-		return "", exit(2, "%s workdir %q is too broad; choose a dedicated subdirectory", providerName, clean)
+		return "", core.Exit(2, "%s workdir %q is too broad; choose a dedicated subdirectory", providerName, clean)
 	}
 	if !strings.HasPrefix(clean, "/workspace/") {
-		return "", exit(2, "%s workdir %q must be under /workspace/<dedicated-subdir>", providerName, clean)
+		return "", core.Exit(2, "%s workdir %q must be under /workspace/<dedicated-subdir>", providerName, clean)
 	}
 	return clean, nil
 }
 
-func bridgeURL(cfg Config) (string, error) {
+func bridgeURL(cfg core.Config) (string, error) {
 	raw := strings.TrimSpace(cfg.CloudflareSandbox.BridgeURL)
 	if raw == "" {
-		return "", exit(2, "%s requires cloudflareSandbox.url or CRABBOX_CLOUDFLARE_SANDBOX_URL", providerName)
+		return "", core.Exit(2, "%s requires cloudflareSandbox.url or CRABBOX_CLOUDFLARE_SANDBOX_URL", providerName)
 	}
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return "", exit(2, "%s bridge URL %q is invalid", providerName, shared.EndpointURLForError(raw))
+		return "", core.Exit(2, "%s bridge URL %q is invalid", providerName, shared.EndpointURLForError(raw))
 	}
 	if parsed.User != nil {
-		return "", exit(2, "%s bridge URL must not include userinfo", providerName)
+		return "", core.Exit(2, "%s bridge URL must not include userinfo", providerName)
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
 	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && shared.IsLoopbackHost(parsed.Hostname())) {
-		return "", exit(2, "%s bridge URL %q must use https unless it targets localhost", providerName, shared.EndpointURLForError(raw))
+		return "", core.Exit(2, "%s bridge URL %q must use https unless it targets localhost", providerName, shared.EndpointURLForError(raw))
 	}
 	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", exit(2, "%s bridge URL %q must not include query or fragment components", providerName, shared.EndpointURLForError(raw))
+		return "", core.Exit(2, "%s bridge URL %q must not include query or fragment components", providerName, shared.EndpointURLForError(raw))
 	}
 	parsed.Host = shared.CanonicalHostPort(parsed)
 	parsed.Path = strings.TrimRight(parsed.Path, "/")

--- a/internal/providers/cloudflaresandbox/operation_lock.go
+++ b/internal/providers/cloudflaresandbox/operation_lock.go
@@ -5,12 +5,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func lockCloudflareSandboxLeaseOperation(ctx context.Context, leaseID string) (func(), error) {
 	if !strings.HasPrefix(leaseID, leasePrefix) || strings.TrimPrefix(leaseID, leasePrefix) == "" || filepath.Base(leaseID) != leaseID || leaseID == "." {
-		return nil, exit(2, "invalid cloudflare-sandbox lease id %q", leaseID)
+		return nil, core.Exit(2, "invalid cloudflare-sandbox lease id %q", leaseID)
 	}
 	return shared.LockLeaseOperation(ctx, "cloudflare-sandbox", leaseID)
 }

--- a/internal/providers/cloudflaresandbox/provider_test.go
+++ b/internal/providers/cloudflaresandbox/provider_test.go
@@ -153,7 +153,7 @@ func TestCloudflareSandboxOptionalTokenAndRawTimeout(t *testing.T) {
 		if err := validateProviderConfig(cfg); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := newBridgeClient(cfg, Runtime{HTTP: &http.Client{}}); err != nil {
+		if _, err := newBridgeClient(cfg, core.Runtime{HTTP: &http.Client{}}); err != nil {
 			t.Fatalf("optional token=%v", err)
 		}
 		got, err := cloudflareSandboxWorkdir(cfg)
@@ -217,14 +217,14 @@ func TestValidateBridgeURL(t *testing.T) {
 func TestValidateConfigRejectsBadValues(t *testing.T) {
 	tests := []struct {
 		name    string
-		mutate  func(*Config)
+		mutate  func(*core.Config)
 		wantErr string
 	}{
-		{name: "relative workdir", mutate: func(cfg *Config) { cfg.CloudflareSandbox.Workdir = "workspace" }, wantErr: "workdir must be absolute"},
-		{name: "broad workdir", mutate: func(cfg *Config) { cfg.CloudflareSandbox.Workdir = "/workspace" }, wantErr: "too broad"},
-		{name: "outside workspace workdir", mutate: func(cfg *Config) { cfg.CloudflareSandbox.Workdir = "/etc/crabbox" }, wantErr: "must be under /workspace/<dedicated-subdir>"},
-		{name: "workspace traversal workdir", mutate: func(cfg *Config) { cfg.CloudflareSandbox.Workdir = "/workspace/../etc/crabbox" }, wantErr: "must be under /workspace/<dedicated-subdir>"},
-		{name: "negative exec timeout", mutate: func(cfg *Config) { cfg.CloudflareSandbox.ExecTimeoutSecs = -1 }, wantErr: "execTimeoutSecs must be non-negative"},
+		{name: "relative workdir", mutate: func(cfg *core.Config) { cfg.CloudflareSandbox.Workdir = "workspace" }, wantErr: "workdir must be absolute"},
+		{name: "broad workdir", mutate: func(cfg *core.Config) { cfg.CloudflareSandbox.Workdir = "/workspace" }, wantErr: "too broad"},
+		{name: "outside workspace workdir", mutate: func(cfg *core.Config) { cfg.CloudflareSandbox.Workdir = "/etc/crabbox" }, wantErr: "must be under /workspace/<dedicated-subdir>"},
+		{name: "workspace traversal workdir", mutate: func(cfg *core.Config) { cfg.CloudflareSandbox.Workdir = "/workspace/../etc/crabbox" }, wantErr: "must be under /workspace/<dedicated-subdir>"},
+		{name: "negative exec timeout", mutate: func(cfg *core.Config) { cfg.CloudflareSandbox.ExecTimeoutSecs = -1 }, wantErr: "execTimeoutSecs must be non-negative"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -241,7 +241,7 @@ func TestValidateConfigRejectsBadValues(t *testing.T) {
 func TestConfigureReturnsRuntimeBackends(t *testing.T) {
 	provider := Provider{}
 	cfg := testConfig()
-	configured, err := provider.Configure(cfg, Runtime{})
+	configured, err := provider.Configure(cfg, core.Runtime{})
 	if err != nil {
 		t.Fatalf("Configure err=%v", err)
 	}
@@ -261,8 +261,8 @@ func TestConfigureReturnsRuntimeBackends(t *testing.T) {
 	}
 }
 
-func testConfig() Config {
-	cfg := Config{}
+func testConfig() core.Config {
+	cfg := core.Config{}
 	cfg.CloudflareSandbox.BridgeURL = "https://bridge.example.test"
 	cfg.CloudflareSandbox.Workdir = "/workspace/crabbox"
 	cfg.CloudflareSandbox.ExecTimeoutSecs = 600

--- a/internal/providers/cloudflaresandbox/sync.go
+++ b/internal/providers/cloudflaresandbox/sync.go
@@ -9,7 +9,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *backend) syncWorkspace(ctx context.Context, api bridgeClient, sandboxID string, req RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+func (b *backend) syncWorkspace(ctx context.Context, api bridgeClient, sandboxID string, req core.RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
@@ -33,18 +33,18 @@ func (b *backend) syncWorkspace(ctx context.Context, api bridgeClient, sandboxID
 
 func (b *backend) execShell(ctx context.Context, api bridgeClient, sandboxID, command string) error {
 	res, err := api.Exec(ctx, sandboxID, execRequest{
-		Command:     "sh -lc " + shellQuote(command),
+		Command:     "sh -lc " + core.ShellQuote(command),
 		TimeoutSecs: b.execTimeoutSecs(),
 	}, io.Discard, io.Discard)
 	if err != nil {
 		return err
 	}
 	if res.ExitCode != 0 {
-		return exit(res.ExitCode, "cloudflare-sandbox exec %q exited %d: %s", command, res.ExitCode, strings.TrimSpace(res.Stderr))
+		return core.Exit(res.ExitCode, "cloudflare-sandbox exec %q exited %d: %s", command, res.ExitCode, strings.TrimSpace(res.Stderr))
 	}
 	return nil
 }
 
 func (b *backend) ensureWorkspace(ctx context.Context, api bridgeClient, sandboxID, workdir string) error {
-	return b.execShell(ctx, api, sandboxID, "mkdir -p "+shellQuote(workdir))
+	return b.execShell(ctx, api, sandboxID, "mkdir -p "+core.ShellQuote(workdir))
 }

--- a/internal/providers/codesandbox/backend.go
+++ b/internal/providers/codesandbox/backend.go
@@ -16,16 +16,16 @@ import (
 )
 
 type codeSandboxBackend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
-func (b *codeSandboxBackend) Spec() ProviderSpec { return b.spec }
+func (b *codeSandboxBackend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *codeSandboxBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *codeSandboxBackend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if req.ActionsRunner {
-		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+		return core.Exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
 	started := core.ClockNow(b.rt.Clock)
 	api, err := newCodeSandboxClient(b.cfg, b.rt)
@@ -49,16 +49,16 @@ func (b *codeSandboxBackend) Warmup(ctx context.Context, req WarmupRequest) erro
 	})
 }
 
-func (b *codeSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
-	if err := delegatedSyncOptionsError(b.spec, req); err != nil {
-		return RunResult{}, err
+func (b *codeSandboxBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
+	if err := core.RejectDelegatedSyncOptionsForSpec(b.spec, req); err != nil {
+		return core.RunResult{}, err
 	}
 	workdir, err := codeSandboxWorkdir(b.cfg)
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	if !req.SyncOnly && (len(req.Command) == 0 || (len(req.Command) == 1 && strings.TrimSpace(req.Command[0]) == "")) {
-		return RunResult{}, exit(2, "missing command")
+		return core.RunResult{}, core.Exit(2, "missing command")
 	}
 	var api codeSandboxAPI
 	var leaseID, sandboxID, slug string
@@ -90,7 +90,7 @@ func (b *codeSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 			return boundSandbox(), nil
 		},
 		Resolve: func(ctx context.Context) (shared.DelegatedSandbox, error) {
-			var claim LeaseClaim
+			var claim core.LeaseClaim
 			var err error
 			leaseID, sandboxID, slug, claim, err = resolveLeaseID(req.ID)
 			if err != nil {
@@ -104,7 +104,7 @@ func (b *codeSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 				return shared.DelegatedSandbox{}, err
 			}
 			if req.Repo.Root != "" {
-				if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, claim.ProviderScope, b.cfg.Pond, req.Repo.Root,
+				if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, providerName, claim.ProviderScope, b.cfg.Pond, req.Repo.Root,
 					timeoutOrDefault(b.cfg.IdleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), req.Reclaim); err != nil {
 					return shared.DelegatedSandbox{}, err
 				}
@@ -124,7 +124,7 @@ func (b *codeSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 			}
 			command := intent.Argv("bash", "-lc")
 			if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
-				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+				core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 			}
 			return shared.DelegatedSandboxCommand{
 				Text: strings.Join(command, " "),
@@ -137,13 +137,13 @@ func (b *codeSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 			if err := api.DeleteSandbox(ctx, sandboxID); err != nil {
 				return err
 			}
-			removeLeaseClaim(leaseID)
+			core.RemoveLeaseClaim(leaseID)
 			return nil
 		},
 	})
 }
 
-func (b *codeSandboxBackend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+func (b *codeSandboxBackend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
 	api, err := newCodeSandboxClient(b.cfg, b.rt)
 	if err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ func (b *codeSandboxBackend) List(ctx context.Context, _ ListRequest) ([]LeaseVi
 	if err != nil {
 		return nil, err
 	}
-	servers := make([]Server, 0, len(claims))
+	servers := make([]core.Server, 0, len(claims))
 	for _, claim := range claims {
 		if claim.Provider != providerName || !strings.HasPrefix(claim.LeaseID, leasePrefix) {
 			continue
@@ -176,14 +176,14 @@ func (b *codeSandboxBackend) List(ctx context.Context, _ ListRequest) ([]LeaseVi
 	return servers, nil
 }
 
-func (b *codeSandboxBackend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *codeSandboxBackend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	api, err := newCodeSandboxClient(b.cfg, b.rt)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	leaseID, sandboxID, slug, claim, err := resolveLeaseID(req.ID)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	waitTimeout := req.WaitTimeout
 	if waitTimeout <= 0 {
@@ -200,18 +200,18 @@ func (b *codeSandboxBackend) Status(ctx context.Context, req StatusRequest) (Sta
 		sb, getErr := api.GetSandbox(pollCtx, sandboxID)
 		if getErr != nil {
 			if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return StatusView{}, exit(5, "timed out waiting for codesandbox sandbox %s to become ready", sandboxID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for codesandbox sandbox %s to become ready", sandboxID)
 			}
 			if ctx.Err() != nil {
-				return StatusView{}, ctx.Err()
+				return core.StatusView{}, ctx.Err()
 			}
-			return StatusView{}, getErr
+			return core.StatusView{}, getErr
 		}
 		if err := validateCodeSandboxSandboxOwnership(claim, sb); err != nil {
-			return StatusView{}, err
+			return core.StatusView{}, err
 		}
 		state := strings.ToLower(strings.TrimSpace(blank(sb.State, "unknown")))
-		view := StatusView{
+		view := core.StatusView{
 			ID:       leaseID,
 			Slug:     slug,
 			Provider: providerName,
@@ -233,23 +233,23 @@ func (b *codeSandboxBackend) Status(ctx context.Context, req StatusRequest) (Sta
 			return view, nil
 		}
 		if isTerminalState(state) {
-			return StatusView{}, exit(5, "codesandbox sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
+			return core.StatusView{}, core.Exit(5, "codesandbox sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
 		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return StatusView{}, exit(5, "timed out waiting for codesandbox sandbox %s to become ready", sandboxID)
+			return core.StatusView{}, core.Exit(5, "timed out waiting for codesandbox sandbox %s to become ready", sandboxID)
 		}
 		select {
 		case <-pollCtx.Done():
 			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return StatusView{}, exit(5, "timed out waiting for codesandbox sandbox %s to become ready", sandboxID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for codesandbox sandbox %s to become ready", sandboxID)
 			}
-			return StatusView{}, pollCtx.Err()
+			return core.StatusView{}, pollCtx.Err()
 		case <-time.After(2 * time.Second):
 		}
 	}
 }
 
-func (b *codeSandboxBackend) Stop(ctx context.Context, req StopRequest) error {
+func (b *codeSandboxBackend) Stop(ctx context.Context, req core.StopRequest) error {
 	api, err := newCodeSandboxClient(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -268,12 +268,12 @@ func (b *codeSandboxBackend) Stop(ctx context.Context, req StopRequest) error {
 	if err := api.DeleteSandbox(ctx, sandboxID); err != nil {
 		return err
 	}
-	removeLeaseClaim(leaseID)
+	core.RemoveLeaseClaim(leaseID)
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, sandboxID)
 	return nil
 }
 
-func (b *codeSandboxBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
+func (b *codeSandboxBackend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	api, err := newCodeSandboxClient(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -289,7 +289,7 @@ func (b *codeSandboxBackend) Cleanup(ctx context.Context, req CleanupRequest) er
 		if listed.Provider != providerName || !strings.HasPrefix(listed.LeaseID, leasePrefix) {
 			continue
 		}
-		claim, err := readLeaseClaim(listed.LeaseID)
+		claim, err := core.ReadLeaseClaim(listed.LeaseID)
 		if err != nil {
 			return err
 		}
@@ -320,7 +320,7 @@ func (b *codeSandboxBackend) Cleanup(ctx context.Context, req CleanupRequest) er
 		if err := api.DeleteSandbox(ctx, sandboxID); err != nil {
 			return err
 		}
-		if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+		if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 			return err
 		}
 		fmt.Fprintf(b.rt.Stdout, "delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
@@ -332,7 +332,7 @@ func (b *codeSandboxBackend) Cleanup(ctx context.Context, req CleanupRequest) er
 	return nil
 }
 
-func (b *codeSandboxBackend) Pause(ctx context.Context, req PauseRequest) error {
+func (b *codeSandboxBackend) Pause(ctx context.Context, req core.PauseRequest) error {
 	api, err := newCodeSandboxClient(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -355,7 +355,7 @@ func (b *codeSandboxBackend) Pause(ctx context.Context, req PauseRequest) error 
 	return nil
 }
 
-func (b *codeSandboxBackend) Resume(ctx context.Context, req ResumeRequest) error {
+func (b *codeSandboxBackend) Resume(ctx context.Context, req core.ResumeRequest) error {
 	api, err := newCodeSandboxClient(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -376,15 +376,15 @@ func (b *codeSandboxBackend) Resume(ctx context.Context, req ResumeRequest) erro
 		return err
 	}
 	if strings.TrimSpace(resumed.ID) != "" && strings.TrimSpace(resumed.ID) != sandboxID {
-		return exit(4, "codesandbox resumed sandbox %q does not match local claim %q", resumed.ID, claim.LeaseID)
+		return core.Exit(4, "codesandbox resumed sandbox %q does not match local claim %q", resumed.ID, claim.LeaseID)
 	}
 	fmt.Fprintf(b.rt.Stderr, "resumed lease=%s sandbox=%s\n", leaseID, sandboxID)
 	return nil
 }
 
-func (b *codeSandboxBackend) Ports(ctx context.Context, req PortsRequest) (string, error) {
+func (b *codeSandboxBackend) Ports(ctx context.Context, req core.PortsRequest) (string, error) {
 	if len(req.Unpublish) > 0 {
-		return "", exit(2, "provider=codesandbox does not support ports --unpublish; stop the process inside the sandbox instead")
+		return "", core.Exit(2, "provider=codesandbox does not support ports --unpublish; stop the process inside the sandbox instead")
 	}
 	api, err := newCodeSandboxClient(b.cfg, b.rt)
 	if err != nil {
@@ -441,18 +441,18 @@ func (b *codeSandboxBackend) Ports(ctx context.Context, req PortsRequest) (strin
 	return strings.Join(lines, "\n"), nil
 }
 
-func (b *codeSandboxBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *codeSandboxBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	token, source, ok := authFromEnv()
 	if !ok {
-		return DoctorResult{}, missingAuthError{}
+		return core.DoctorResult{}, missingAuthError{}
 	}
 	client, err := newCodeSandboxClient(b.cfg, b.rt)
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	result := DoctorResult{
+	result := core.DoctorResult{
 		Provider: providerName,
-		Checks: []DoctorCheck{
+		Checks: []core.DoctorCheck{
 			doctorCheck("codesandbox_auth", nil, map[string]string{
 				"source":   source,
 				"redacted": "true",
@@ -476,7 +476,7 @@ func (b *codeSandboxBackend) Doctor(ctx context.Context, _ DoctorRequest) (Docto
 		"totalCount": fmt.Sprint(listed.TotalCount),
 	}))
 	result.Status = "ok"
-	result.Message = inventoryDoctorResult(providerName, len(listed.Sandboxes)).Message
+	result.Message = core.InventoryDoctorResult(providerName, len(listed.Sandboxes)).Message
 	return result, nil
 }
 
@@ -502,14 +502,14 @@ func (b *codeSandboxBackend) execCommand(ctx context.Context, api codeSandboxAPI
 	return res.ExitCode, nil
 }
 
-func codeSandboxServerView(claim LeaseClaim, sb SandboxSummary) Server {
+func codeSandboxServerView(claim core.LeaseClaim, sb SandboxSummary) core.Server {
 	state := blank(sb.State, "unknown")
 	sandboxID := strings.TrimPrefix(claim.LeaseID, leasePrefix)
 	if strings.TrimSpace(sb.ID) != "" {
 		sandboxID = sb.ID
 	}
 	name := blank(sb.Title, sandboxID)
-	return Server{
+	return core.Server{
 		Provider: providerName,
 		CloudID:  sandboxID,
 		Name:     name,
@@ -533,29 +533,29 @@ func timeoutOrDefault(primary, fallback time.Duration) time.Duration {
 }
 
 var _ interface {
-	Warmup(context.Context, WarmupRequest) error
-	Run(context.Context, RunRequest) (RunResult, error)
-	List(context.Context, ListRequest) ([]LeaseView, error)
-	Status(context.Context, StatusRequest) (StatusView, error)
-	Stop(context.Context, StopRequest) error
-	Cleanup(context.Context, CleanupRequest) error
-	Pause(context.Context, PauseRequest) error
-	Resume(context.Context, ResumeRequest) error
-	Ports(context.Context, PortsRequest) (string, error)
-	Doctor(context.Context, DoctorRequest) (DoctorResult, error)
+	Warmup(context.Context, core.WarmupRequest) error
+	Run(context.Context, core.RunRequest) (core.RunResult, error)
+	List(context.Context, core.ListRequest) ([]core.LeaseView, error)
+	Status(context.Context, core.StatusRequest) (core.StatusView, error)
+	Stop(context.Context, core.StopRequest) error
+	Cleanup(context.Context, core.CleanupRequest) error
+	Pause(context.Context, core.PauseRequest) error
+	Resume(context.Context, core.ResumeRequest) error
+	Ports(context.Context, core.PortsRequest) (string, error)
+	Doctor(context.Context, core.DoctorRequest) (core.DoctorResult, error)
 } = (*codeSandboxBackend)(nil)
 
 func parseCodeSandboxPortSpec(spec string) (int, error) {
 	value := strings.TrimSpace(spec)
 	if value == "" {
-		return 0, exit(2, "codesandbox port spec must not be empty")
+		return 0, core.Exit(2, "codesandbox port spec must not be empty")
 	}
 	if strings.ContainsAny(value, ":/") {
-		return 0, exit(2, "codesandbox ports only support a sandbox port number, got %q", spec)
+		return 0, core.Exit(2, "codesandbox ports only support a sandbox port number, got %q", spec)
 	}
 	port, err := strconv.Atoi(value)
 	if err != nil || port < 1 || port > 65535 {
-		return 0, exit(2, "codesandbox port must be an integer between 1 and 65535, got %q", spec)
+		return 0, core.Exit(2, "codesandbox port must be an integer between 1 and 65535, got %q", spec)
 	}
 	return port, nil
 }

--- a/internal/providers/codesandbox/backend_test.go
+++ b/internal/providers/codesandbox/backend_test.go
@@ -24,8 +24,8 @@ func TestWarmupCreatesSandboxClaim(t *testing.T) {
 	fake := newFakeCodeSandboxAPI()
 	backend, stdout, stderr := newFakeBackend(t, fake)
 
-	if err := backend.Warmup(context.Background(), WarmupRequest{
-		Repo:          Repo{Name: "my-app", Root: "/repo"},
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{
+		Repo:          core.Repo{Name: "my-app", Root: "/repo"},
 		RequestedSlug: "codesandbox-blue",
 		TimingJSON:    true,
 	}); err != nil {
@@ -38,7 +38,7 @@ func TestWarmupCreatesSandboxClaim(t *testing.T) {
 		t.Fatalf("create tags=%v missing ownership tags", got)
 	}
 	leaseID := leasePrefix + fake.sandboxID
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatalf("read claim: %v", err)
 	}
@@ -76,12 +76,12 @@ func TestStopRejectsOwnershipMismatchBeforeDelete(t *testing.T) {
 	fake := newFakeCodeSandboxAPI()
 	backend, _, _ := newFakeBackend(t, fake)
 	leaseID := leasePrefix + fake.sandboxID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, codeSandboxClaimScopePrefix+"local", "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, codeSandboxClaimScopePrefix+"local", "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Tags = []string{codeSandboxClaimTag, codeSandboxScopeTag(codeSandboxClaimScopePrefix + "remote")}
 
-	err := backend.Stop(context.Background(), StopRequest{ID: leaseID})
+	err := backend.Stop(context.Background(), core.StopRequest{ID: leaseID})
 	if err == nil || !strings.Contains(err.Error(), "ownership tag") {
 		t.Fatalf("Stop err=%v, want ownership rejection", err)
 	}
@@ -95,12 +95,12 @@ func TestStopRejectsMissingOwnershipTagBeforeDelete(t *testing.T) {
 	fake := newFakeCodeSandboxAPI()
 	backend, _, _ := newFakeBackend(t, fake)
 	leaseID := leasePrefix + fake.sandboxID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, fake.scope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, fake.scope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Tags = []string{codeSandboxClaimTag}
 
-	err := backend.Stop(context.Background(), StopRequest{ID: leaseID})
+	err := backend.Stop(context.Background(), core.StopRequest{ID: leaseID})
 	if err == nil || !strings.Contains(err.Error(), "missing its Crabbox ownership tag") {
 		t.Fatalf("Stop err=%v, want missing ownership tag rejection", err)
 	}
@@ -115,17 +115,17 @@ func TestCleanupDeletesDueOwnedClaims(t *testing.T) {
 	backend, stdout, _ := newFakeBackend(t, fake)
 	backend.rt.Clock = fixedClock{t: time.Now().UTC().Add(2 * time.Second)}
 	leaseID := leasePrefix + fake.sandboxID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "old", providerName, fake.scope, "", "/repo", time.Second, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "old", providerName, fake.scope, "", "/repo", time.Second, false); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatalf("Cleanup err=%v", err)
 	}
 	if !reflect.DeepEqual(fake.deleted, []string{fake.sandboxID}) {
 		t.Fatalf("deleted=%v, want sandbox delete", fake.deleted)
 	}
-	if claim, err := readLeaseClaim(leaseID); err != nil || claim.LeaseID != "" {
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil || claim.LeaseID != "" {
 		t.Fatalf("claim after cleanup=%#v err=%v, want removed", claim, err)
 	}
 	if got := stdout.String(); !strings.Contains(got, "delete sandbox="+fake.sandboxID+" lease="+leaseID+" reason=idle timeout") ||
@@ -140,17 +140,17 @@ func TestCleanupDryRunKeepsDueOwnedClaims(t *testing.T) {
 	backend, stdout, _ := newFakeBackend(t, fake)
 	backend.rt.Clock = fixedClock{t: time.Now().UTC().Add(2 * time.Second)}
 	leaseID := leasePrefix + fake.sandboxID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "old", providerName, fake.scope, "", "/repo", time.Second, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "old", providerName, fake.scope, "", "/repo", time.Second, false); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := backend.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
 		t.Fatalf("Cleanup dry-run err=%v", err)
 	}
 	if len(fake.deleted) != 0 {
 		t.Fatalf("deleted=%v, want dry-run to skip delete", fake.deleted)
 	}
-	if claim, err := readLeaseClaim(leaseID); err != nil || claim.LeaseID != leaseID {
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil || claim.LeaseID != leaseID {
 		t.Fatalf("claim after dry-run=%#v err=%v, want retained", claim, err)
 	}
 	if got := stdout.String(); !strings.Contains(got, "would delete sandbox="+fake.sandboxID+" lease="+leaseID+" reason=idle timeout") {
@@ -163,17 +163,17 @@ func TestCleanupSkipsClaimsBeforeIdleDeadline(t *testing.T) {
 	fake := newFakeCodeSandboxAPI()
 	backend, _, stderr := newFakeBackend(t, fake)
 	leaseID := leasePrefix + fake.sandboxID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "fresh", providerName, fake.scope, "", "/repo", time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "fresh", providerName, fake.scope, "", "/repo", time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatalf("Cleanup err=%v", err)
 	}
 	if len(fake.deleted) != 0 {
 		t.Fatalf("deleted=%v, want not-due claim retained", fake.deleted)
 	}
-	if claim, err := readLeaseClaim(leaseID); err != nil || claim.LeaseID != leaseID {
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil || claim.LeaseID != leaseID {
 		t.Fatalf("claim after cleanup=%#v err=%v, want retained", claim, err)
 	}
 	if got := stderr.String(); !strings.Contains(got, "skip sandbox="+fake.sandboxID+" lease="+leaseID+" reason=idle timeout not reached") {
@@ -186,14 +186,14 @@ func TestPauseResumeUseSDKLifecycleAndKeepClaim(t *testing.T) {
 	fake := newFakeCodeSandboxAPI()
 	backend, _, stderr := newFakeBackend(t, fake)
 	leaseID := leasePrefix + fake.sandboxID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "nap", providerName, fake.scope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "nap", providerName, fake.scope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := backend.Pause(context.Background(), PauseRequest{ID: "nap"}); err != nil {
+	if err := backend.Pause(context.Background(), core.PauseRequest{ID: "nap"}); err != nil {
 		t.Fatalf("Pause err=%v", err)
 	}
-	if err := backend.Resume(context.Background(), ResumeRequest{ID: leaseID}); err != nil {
+	if err := backend.Resume(context.Background(), core.ResumeRequest{ID: leaseID}); err != nil {
 		t.Fatalf("Resume err=%v", err)
 	}
 	if !reflect.DeepEqual(fake.hibernated, []string{fake.sandboxID}) || !reflect.DeepEqual(fake.resumed, []string{fake.sandboxID}) {
@@ -212,12 +212,12 @@ func TestPauseRejectsOwnershipMismatchBeforeHibernate(t *testing.T) {
 	fake := newFakeCodeSandboxAPI()
 	backend, _, _ := newFakeBackend(t, fake)
 	leaseID := leasePrefix + fake.sandboxID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, codeSandboxClaimScopePrefix+"local", "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, codeSandboxClaimScopePrefix+"local", "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Tags = []string{codeSandboxClaimTag, codeSandboxScopeTag(codeSandboxClaimScopePrefix + "remote")}
 
-	err := backend.Pause(context.Background(), PauseRequest{ID: leaseID})
+	err := backend.Pause(context.Background(), core.PauseRequest{ID: leaseID})
 	if err == nil || !strings.Contains(err.Error(), "ownership tag") {
 		t.Fatalf("Pause err=%v, want ownership rejection", err)
 	}
@@ -232,18 +232,18 @@ func TestPortsListPublishAndRejectUnsupportedUnpublish(t *testing.T) {
 	fake.ports = []PortInfo{{Port: 3000, Host: "https://sb-test01-3000.csb.app"}}
 	backend, _, _ := newFakeBackend(t, fake)
 	leaseID := leasePrefix + fake.sandboxID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "web", providerName, fake.scope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "web", providerName, fake.scope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 
-	out, err := backend.Ports(context.Background(), PortsRequest{ID: "web"})
+	out, err := backend.Ports(context.Background(), core.PortsRequest{ID: "web"})
 	if err != nil {
 		t.Fatalf("Ports list err=%v", err)
 	}
 	if out != "3000 https://sb-test01-3000.csb.app" {
 		t.Fatalf("list output=%q", out)
 	}
-	out, err = backend.Ports(context.Background(), PortsRequest{ID: leaseID, JSON: true, Publish: []string{"5173"}})
+	out, err = backend.Ports(context.Background(), core.PortsRequest{ID: leaseID, JSON: true, Publish: []string{"5173"}})
 	if err != nil {
 		t.Fatalf("Ports publish err=%v", err)
 	}
@@ -258,11 +258,11 @@ func TestPortsListPublishAndRejectUnsupportedUnpublish(t *testing.T) {
 		t.Fatalf("waited ports=%v", fake.waitedPorts)
 	}
 
-	_, err = backend.Ports(context.Background(), PortsRequest{ID: "web", Publish: []string{"127.0.0.1:41000:3000"}})
+	_, err = backend.Ports(context.Background(), core.PortsRequest{ID: "web", Publish: []string{"127.0.0.1:41000:3000"}})
 	if err == nil || !strings.Contains(err.Error(), "only support a sandbox port number") {
 		t.Fatalf("complex port spec err=%v", err)
 	}
-	_, err = backend.Ports(context.Background(), PortsRequest{ID: "web", Unpublish: []string{"3000"}})
+	_, err = backend.Ports(context.Background(), core.PortsRequest{ID: "web", Unpublish: []string{"3000"}})
 	if err == nil || !strings.Contains(err.Error(), "does not support ports --unpublish") {
 		t.Fatalf("unpublish err=%v", err)
 	}
@@ -273,21 +273,21 @@ func TestListAndStatusUseOwnedClaims(t *testing.T) {
 	fake := newFakeCodeSandboxAPI()
 	backend, _, _ := newFakeBackend(t, fake)
 	leaseID := leasePrefix + fake.sandboxID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "listed", providerName, fake.scope, "pond-a", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "listed", providerName, fake.scope, "pond-a", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := claimLeaseForRepoProviderScopePond("csbx_other", "other", "other-provider", fake.scope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond("csbx_other", "other", "other-provider", fake.scope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 
-	leases, err := backend.List(context.Background(), ListRequest{})
+	leases, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatalf("List err=%v", err)
 	}
 	if len(leases) != 1 || leases[0].CloudID != fake.sandboxID || leases[0].Labels["slug"] != "listed" {
 		t.Fatalf("leases=%#v", leases)
 	}
-	status, err := backend.Status(context.Background(), StatusRequest{ID: "listed"})
+	status, err := backend.Status(context.Background(), core.StatusRequest{ID: "listed"})
 	if err != nil {
 		t.Fatalf("Status err=%v", err)
 	}
@@ -302,18 +302,18 @@ func TestListAndStatusDoNotTreatMissingStateAsReady(t *testing.T) {
 	fake.sandbox.State = ""
 	backend, _, _ := newFakeBackend(t, fake)
 	leaseID := leasePrefix + fake.sandboxID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "unknown-state", providerName, fake.scope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "unknown-state", providerName, fake.scope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 
-	leases, err := backend.List(context.Background(), ListRequest{})
+	leases, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(leases) != 1 || leases[0].Status != "unknown" {
 		t.Fatalf("leases=%#v", leases)
 	}
-	status, err := backend.Status(context.Background(), StatusRequest{ID: "unknown-state"})
+	status, err := backend.Status(context.Background(), core.StatusRequest{ID: "unknown-state"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -331,8 +331,8 @@ func TestRunStreamsOutputAndCleansUpOneShot(t *testing.T) {
 	}
 	backend, stdout, stderr := newFakeBackend(t, fake)
 
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:       Repo{Name: "my-app", Root: "/repo"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Name: "my-app", Root: "/repo"},
 		NoSync:     true,
 		Command:    []string{"echo", "hello"},
 		Env:        map[string]string{"SECRET_TOKEN": "super-secret"},
@@ -370,8 +370,8 @@ func TestRunPropagatesExitAndKeepOnFailureRetainsSandbox(t *testing.T) {
 	}
 	backend, _, stderr := newFakeBackend(t, fake)
 
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:          Repo{Name: "my-app", Root: "/repo"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:          core.Repo{Name: "my-app", Root: "/repo"},
 		NoSync:        true,
 		Command:       []string{"false"},
 		KeepOnFailure: true,
@@ -380,7 +380,7 @@ func TestRunPropagatesExitAndKeepOnFailureRetainsSandbox(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected non-zero exit error")
 	}
-	var exitErr ExitError
+	var exitErr core.ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 7 || result.ExitCode != 7 {
 		t.Fatalf("err=%v result=%#v", err, result)
 	}
@@ -417,12 +417,12 @@ func TestRunByIDReturnsReusedSessionHandle(t *testing.T) {
 	}
 	backend, stdout, _ := newFakeBackend(t, fake)
 	leaseID := leasePrefix + fake.sandboxID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "reused", providerName, fake.scope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "reused", providerName, fake.scope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: "/repo"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: "/repo"},
 		ID:      "reused",
 		NoSync:  true,
 		Command: []string{"echo", "reused"},
@@ -492,8 +492,8 @@ func TestRunLifecycleFinalization(t *testing.T) {
 				}
 				return CommandResult{ExitCode: tc.code}, tc.commandErr
 			}
-			result, err := backend.Run(ctx, RunRequest{Repo: Repo{Root: t.TempDir()}, NoSync: true, SyncOnly: tc.syncOnly, Command: []string{"true"}, KeepOnFailure: tc.keepOnFailure, TimingJSON: true})
-			var exitErr ExitError
+			result, err := backend.Run(ctx, core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, NoSync: true, SyncOnly: tc.syncOnly, Command: []string{"true"}, KeepOnFailure: tc.keepOnFailure, TimingJSON: true})
+			var exitErr core.ExitError
 			if !errors.As(err, &exitErr) || exitErr.Code != tc.wantCode || result.ExitCode != tc.wantCode || result.ErrorKind != tc.wantKind {
 				t.Errorf("result=%#v error=%v, want %d/%s", result, err, tc.wantCode, tc.wantKind)
 			}
@@ -540,8 +540,8 @@ func TestRunCancellationPropagates(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := backend.Run(ctx, RunRequest{
-		Repo:    Repo{Name: "my-app", Root: "/repo"},
+	_, err := backend.Run(ctx, core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: "/repo"},
 		NoSync:  true,
 		Command: []string{"sleep", "10"},
 	})
@@ -565,8 +565,8 @@ func TestRunSyncOnlyUploadsArchiveAndExtracts(t *testing.T) {
 	backend, stdout, _ := newFakeBackend(t, fake)
 	backend.cfg.CodeSandbox.Workdir = "/project/workspace/my-app"
 
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:           Repo{Name: "my-app", Root: repoRoot},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:           core.Repo{Name: "my-app", Root: repoRoot},
 		SyncOnly:       true,
 		ForceSyncLarge: true,
 	})
@@ -594,8 +594,8 @@ func TestRunSyncOnlyReplacesDefaultWorkspaceMountContents(t *testing.T) {
 	fake := newFakeCodeSandboxAPI()
 	backend, _, _ := newFakeBackend(t, fake)
 
-	if _, err := backend.Run(context.Background(), RunRequest{
-		Repo:           Repo{Name: "my-app", Root: repoRoot},
+	if _, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:           core.Repo{Name: "my-app", Root: repoRoot},
 		SyncOnly:       true,
 		ForceSyncLarge: true,
 	}); err != nil {
@@ -614,14 +614,14 @@ func newFakeBackend(t *testing.T, api *fakeCodeSandboxAPI) (*codeSandboxBackend,
 	t.Helper()
 	cfg := newTestConfig()
 	var stdout, stderr bytes.Buffer
-	restore := replaceClientFactory(func(Config, Runtime) (codeSandboxAPI, error) {
+	restore := replaceClientFactory(func(core.Config, core.Runtime) (codeSandboxAPI, error) {
 		return api, nil
 	})
 	t.Cleanup(restore)
 	return &codeSandboxBackend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt: Runtime{
+		rt: core.Runtime{
 			Stdout: &stdout,
 			Stderr: &stderr,
 		},
@@ -799,8 +799,8 @@ func TestRunCommandIntentReachesNativeRequest(t *testing.T) {
 		t.Setenv("XDG_STATE_HOME", t.TempDir())
 		fake := newFakeCodeSandboxAPI()
 		backend, _, _ := newFakeBackend(t, fake)
-		_, err := backend.Run(t.Context(), RunRequest{
-			Repo:               Repo{Name: "my-app", Root: t.TempDir()},
+		_, err := backend.Run(t.Context(), core.RunRequest{
+			Repo:               core.Repo{Name: "my-app", Root: t.TempDir()},
 			NoSync:             true,
 			Command:            intent.Command,
 			ShellMode:          intent.ShellMode,
@@ -821,7 +821,7 @@ func TestRunRejectsEmptyCommandBeforeCreate(t *testing.T) {
 		for _, command := range [][]string{nil, {""}, {"  "}} {
 			fake := newFakeCodeSandboxAPI()
 			backend, _, _ := newFakeBackend(t, fake)
-			_, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "my-app", Root: t.TempDir()}, NoSync: true, ShellMode: shellMode, Command: command})
+			_, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Name: "my-app", Root: t.TempDir()}, NoSync: true, ShellMode: shellMode, Command: command})
 			if err == nil || !strings.Contains(err.Error(), "missing command") {
 				t.Fatalf("command=%#v shell=%v err=%v", command, shellMode, err)
 			}

--- a/internal/providers/codesandbox/bridge.go
+++ b/internal/providers/codesandbox/bridge.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared/procjson"
 )
 
@@ -58,17 +59,17 @@ type BridgeError struct {
 }
 
 type SDKBridge struct {
-	cfg CodeSandboxConfig
-	rt  Runtime
+	cfg core.CodeSandboxConfig
+	rt  core.Runtime
 }
 
-func NewSDKBridge(cfg CodeSandboxConfig, rt Runtime) *SDKBridge {
+func NewSDKBridge(cfg core.CodeSandboxConfig, rt core.Runtime) *SDKBridge {
 	return &SDKBridge{cfg: cfg, rt: rt}
 }
 
 func (b *SDKBridge) RoundTrip(ctx context.Context, token string, req BridgeRequest) (BridgeResponse, error) {
 	if b.rt.Exec == nil {
-		return BridgeResponse{}, exit(2, "codesandbox bridge requires Runtime.Exec")
+		return BridgeResponse{}, core.Exit(2, "codesandbox bridge requires Runtime.Exec")
 	}
 	dir, err := bridgeWorkingDir()
 	if err != nil {
@@ -88,7 +89,7 @@ func (b *SDKBridge) RoundTrip(ctx context.Context, token string, req BridgeReque
 	if req.Operation == "run_command" {
 		limit = codeSandboxRunCommandOutputLimit
 	}
-	command := LocalCommandRequest{Name: bridgeCommand(b.cfg), Args: []string{"--input-type=module", "-e", codeSandboxBridgeScript}, Env: bridgeEnv(b.cfg, token, spec.ImportSpec), Dir: dir}
+	command := core.LocalCommandRequest{Name: bridgeCommand(b.cfg), Args: []string{"--input-type=module", "-e", codeSandboxBridgeScript}, Env: bridgeEnv(b.cfg, token, spec.ImportSpec), Dir: dir}
 	resp, result, err := procjson.Exchange[BridgeRequest, BridgeResponse](ctx, b.rt.Exec, command, req, procjson.Limits{MaxBytesPerStream: limit, CancelGrace: 2 * time.Second})
 	if err != nil {
 		failure, _ := err.(*procjson.Failure)
@@ -119,7 +120,7 @@ func (b *SDKBridge) ensureBridgeSDK(ctx context.Context, dir string, spec bridge
 	setupCtx, cancel := context.WithTimeout(ctx, operationTimeout(b.cfg))
 	defer cancel()
 	var stdout, stderr bytes.Buffer
-	result, runErr := b.rt.Exec.Run(setupCtx, LocalCommandRequest{
+	result, runErr := b.rt.Exec.Run(setupCtx, core.LocalCommandRequest{
 		Name:                   "npm",
 		Args:                   []string{"install", "--no-audit", "--no-fund", "--ignore-scripts", "--omit=optional", "--save-exact", "--loglevel=error", spec.InstallSpec},
 		Env:                    bridgeSetupEnv(),
@@ -141,7 +142,7 @@ func (b *SDKBridge) ensureBridgeSDK(ctx context.Context, dir string, spec bridge
 	return nil
 }
 
-func bridgeEnv(cfg CodeSandboxConfig, token, importSpec string) []string {
+func bridgeEnv(cfg core.CodeSandboxConfig, token, importSpec string) []string {
 	env := make([]string, 0, 8)
 	for _, key := range []string{"PATH", "HOME", "TMPDIR", "TEMP", "TMP", "SystemRoot", "SYSTEMROOT", "COMSPEC", "PATHEXT"} {
 		if value := os.Getenv(key); value != "" {
@@ -188,7 +189,7 @@ type bridgeSDKSpec struct {
 	Install         bool
 }
 
-func bridgeSDKSpecFor(cfg CodeSandboxConfig) bridgeSDKSpec {
+func bridgeSDKSpecFor(cfg core.CodeSandboxConfig) bridgeSDKSpec {
 	installSpec := sdkPackage(cfg)
 	importSpec, ok := npmPackageName(installSpec)
 	if !ok {

--- a/internal/providers/codesandbox/bridge_test.go
+++ b/internal/providers/codesandbox/bridge_test.go
@@ -19,13 +19,11 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-type LocalCommandResult = core.LocalCommandResult
-
 func TestSDKBridgeSendsJSONOnStdinAndTokenOnlyInEnv(t *testing.T) {
 	setBridgeTestCacheDir(t)
 	secret := "csb-secret-value"
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "ambient-secret")
-	runner := &recordingBridgeRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &recordingBridgeRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		for _, arg := range req.Args {
 			if strings.Contains(arg, secret) {
 				t.Fatalf("secret leaked into argv: %#v", req.Args)
@@ -54,9 +52,9 @@ func TestSDKBridgeSendsJSONOnStdinAndTokenOnlyInEnv(t *testing.T) {
 			t.Fatalf("payload=%#v", payload)
 		}
 		_, _ = io.WriteString(req.Stdout, `{"ok":true,"sandboxes":[{"id":"csb_1","title":"my-app","privacy":"private","tags":["crabbox"]}],"totalCount":1}`)
-		return LocalCommandResult{ExitCode: 0}, nil
+		return core.LocalCommandResult{ExitCode: 0}, nil
 	}}
-	bridge := NewSDKBridge(newTestConfig().CodeSandbox, Runtime{Exec: runner})
+	bridge := NewSDKBridge(newTestConfig().CodeSandbox, core.Runtime{Exec: runner})
 	resp, err := bridge.RoundTrip(context.Background(), secret, BridgeRequest{Operation: "list_sandboxes", Limit: 2})
 	if err != nil {
 		t.Fatalf("RoundTrip err=%v", err)
@@ -85,8 +83,8 @@ func TestSDKBridgeSendsJSONOnStdinAndTokenOnlyInEnv(t *testing.T) {
 }
 
 func TestSDKBridgeRequiresRunnerBeforeSDKSetup(t *testing.T) {
-	var exitErr ExitError
-	_, err := NewSDKBridge(newTestConfig().CodeSandbox, Runtime{}).RoundTrip(context.Background(), "secret", BridgeRequest{Operation: "list_sandboxes"})
+	var exitErr core.ExitError
+	_, err := NewSDKBridge(newTestConfig().CodeSandbox, core.Runtime{}).RoundTrip(context.Background(), "secret", BridgeRequest{Operation: "list_sandboxes"})
 	if !errors.As(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "requires Runtime.Exec") {
 		t.Fatalf("RoundTrip error=%v", err)
 	}
@@ -95,13 +93,13 @@ func TestSDKBridgeRequiresRunnerBeforeSDKSetup(t *testing.T) {
 func TestSDKBridgeRunCommandUsesCommandTimeoutAndLargerCaptureLimit(t *testing.T) {
 	setBridgeTestCacheDir(t)
 	secret := "csb-secret-value"
-	runner := &recordingBridgeRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &recordingBridgeRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		_, _ = io.WriteString(req.Stdout, `{"ok":true,"command":{"exitCode":0}}`)
-		return LocalCommandResult{ExitCode: 0}, nil
+		return core.LocalCommandResult{ExitCode: 0}, nil
 	}}
 	cfg := newTestConfig().CodeSandbox
 	cfg.OperationTimeoutSecs = 30
-	bridge := NewSDKBridge(cfg, Runtime{Exec: runner})
+	bridge := NewSDKBridge(cfg, core.Runtime{Exec: runner})
 	if _, err := bridge.RoundTrip(context.Background(), secret, BridgeRequest{
 		Operation: "run_command",
 		SandboxID: "sb_1",
@@ -126,11 +124,11 @@ func TestSDKBridgeRunCommandUsesCommandTimeoutAndLargerCaptureLimit(t *testing.T
 func TestSDKBridgeRedactsTokenFromCommandFailures(t *testing.T) {
 	setBridgeTestCacheDir(t)
 	secret := "csb-secret-value"
-	runner := &recordingBridgeRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &recordingBridgeRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		_, _ = io.WriteString(req.Stderr, "denied "+secret)
-		return LocalCommandResult{ExitCode: 1}, errors.New("exit status 1")
+		return core.LocalCommandResult{ExitCode: 1}, errors.New("exit status 1")
 	}}
-	bridge := NewSDKBridge(newTestConfig().CodeSandbox, Runtime{Exec: runner})
+	bridge := NewSDKBridge(newTestConfig().CodeSandbox, core.Runtime{Exec: runner})
 	_, err := bridge.RoundTrip(context.Background(), secret, BridgeRequest{Operation: "list_sandboxes"})
 	if err == nil {
 		t.Fatal("expected bridge failure")
@@ -144,10 +142,10 @@ func TestSDKBridgeRedactsTokenFromRunnerError(t *testing.T) {
 	setBridgeTestCacheDir(t)
 	secret := "csb-secret-value"
 	cause := errors.New("denied " + secret)
-	runner := &recordingBridgeRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
-		return LocalCommandResult{ExitCode: 1}, cause
+	runner := &recordingBridgeRunner{fn: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		return core.LocalCommandResult{ExitCode: 1}, cause
 	}}
-	_, err := NewSDKBridge(newTestConfig().CodeSandbox, Runtime{Exec: runner}).RoundTrip(context.Background(), secret, BridgeRequest{Operation: "list_sandboxes"})
+	_, err := NewSDKBridge(newTestConfig().CodeSandbox, core.Runtime{Exec: runner}).RoundTrip(context.Background(), secret, BridgeRequest{Operation: "list_sandboxes"})
 	if err == nil || strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[redacted]") || !errors.Is(err, cause) {
 		t.Fatalf("runner error was not redacted: %v", err)
 	}
@@ -156,11 +154,11 @@ func TestSDKBridgeRedactsTokenFromRunnerError(t *testing.T) {
 func TestSDKBridgeRedactsTokenFromBridgeErrorResponse(t *testing.T) {
 	setBridgeTestCacheDir(t)
 	secret := "csb-secret-value"
-	runner := &recordingBridgeRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &recordingBridgeRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		_, _ = io.WriteString(req.Stdout, `{"ok":false,"error":{"code":"auth_denied","message":"bad `+secret+`"}}`)
-		return LocalCommandResult{ExitCode: 0}, nil
+		return core.LocalCommandResult{ExitCode: 0}, nil
 	}}
-	bridge := NewSDKBridge(newTestConfig().CodeSandbox, Runtime{Exec: runner})
+	bridge := NewSDKBridge(newTestConfig().CodeSandbox, core.Runtime{Exec: runner})
 	_, err := bridge.RoundTrip(context.Background(), secret, BridgeRequest{Operation: "list_sandboxes"})
 	if err == nil {
 		t.Fatal("expected bridge error response")
@@ -302,7 +300,7 @@ export class CodeSandbox {
 	}
 	cfg := newTestConfig().CodeSandbox
 	cfg.SDKPackage = (&url.URL{Scheme: "file", Path: modulePath}).String()
-	bridge := NewSDKBridge(cfg, Runtime{Exec: actualBridgeRunner{}})
+	bridge := NewSDKBridge(cfg, core.Runtime{Exec: actualBridgeRunner{}})
 
 	created, err := bridge.RoundTrip(context.Background(), "secret", BridgeRequest{Operation: "create_sandbox", VMTier: "micro"})
 	if err != nil {
@@ -362,7 +360,7 @@ export class CodeSandbox {
 
 func TestBridgeSDKInstalledRejectsWrongPinnedVersion(t *testing.T) {
 	dir := t.TempDir()
-	spec := bridgeSDKSpecFor(CodeSandboxConfig{SDKPackage: "@codesandbox/sdk@2.4.2"})
+	spec := bridgeSDKSpecFor(core.CodeSandboxConfig{SDKPackage: "@codesandbox/sdk@2.4.2"})
 	packageDir := filepath.Join(dir, "node_modules", "@codesandbox", "sdk")
 	if err := os.MkdirAll(packageDir, 0o700); err != nil {
 		t.Fatal(err)
@@ -386,11 +384,11 @@ func TestBridgeSDKInstalledRejectsWrongPinnedVersion(t *testing.T) {
 
 func TestSDKBridgeClassifiesMalformedJSON(t *testing.T) {
 	setBridgeTestCacheDir(t)
-	runner := &recordingBridgeRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &recordingBridgeRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		_, _ = io.WriteString(req.Stdout, `not-json`)
-		return LocalCommandResult{ExitCode: 0}, nil
+		return core.LocalCommandResult{ExitCode: 0}, nil
 	}}
-	bridge := NewSDKBridge(newTestConfig().CodeSandbox, Runtime{Exec: runner})
+	bridge := NewSDKBridge(newTestConfig().CodeSandbox, core.Runtime{Exec: runner})
 	_, err := bridge.RoundTrip(context.Background(), "secret", BridgeRequest{Operation: "list_sandboxes"})
 	if err == nil || !strings.Contains(err.Error(), "decode codesandbox bridge JSON") {
 		t.Fatalf("RoundTrip err=%v", err)
@@ -400,14 +398,14 @@ func TestSDKBridgeClassifiesMalformedJSON(t *testing.T) {
 func TestCodeSandboxClientListsThroughBridge(t *testing.T) {
 	setBridgeTestCacheDir(t)
 	secret := "csb-secret-value"
-	runner := &recordingBridgeRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &recordingBridgeRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		_, _ = io.WriteString(req.Stdout, `{"ok":true,"sandboxes":[{"id":"csb_1"}],"totalCount":7}`)
-		return LocalCommandResult{ExitCode: 0}, nil
+		return core.LocalCommandResult{ExitCode: 0}, nil
 	}}
 	client := &codeSandboxClient{
 		cfg:    newTestConfig().CodeSandbox,
-		rt:     Runtime{Exec: runner},
-		bridge: NewSDKBridge(newTestConfig().CodeSandbox, Runtime{Exec: runner}),
+		rt:     core.Runtime{Exec: runner},
+		bridge: NewSDKBridge(newTestConfig().CodeSandbox, core.Runtime{Exec: runner}),
 		token:  secret,
 	}
 	result, err := client.ListSandboxes(context.Background(), ListSandboxesRequest{Limit: 3})
@@ -422,7 +420,7 @@ func TestCodeSandboxClientListsThroughBridge(t *testing.T) {
 func TestCodeSandboxClientLifecycleOperationsUseBridgePayloads(t *testing.T) {
 	setBridgeTestCacheDir(t)
 	seen := []BridgeRequest{}
-	runner := &recordingBridgeRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &recordingBridgeRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		var payload BridgeRequest
 		if err := json.Unmarshal([]byte(readRequestBody(req)), &payload); err != nil {
 			t.Fatalf("stdin payload: %v", err)
@@ -453,12 +451,12 @@ func TestCodeSandboxClientLifecycleOperationsUseBridgePayloads(t *testing.T) {
 		default:
 			t.Fatalf("unexpected operation %q", payload.Operation)
 		}
-		return LocalCommandResult{ExitCode: 0}, nil
+		return core.LocalCommandResult{ExitCode: 0}, nil
 	}}
 	client := &codeSandboxClient{
 		cfg:    newTestConfig().CodeSandbox,
-		rt:     Runtime{Exec: runner},
-		bridge: NewSDKBridge(newTestConfig().CodeSandbox, Runtime{Exec: runner}),
+		rt:     core.Runtime{Exec: runner},
+		bridge: NewSDKBridge(newTestConfig().CodeSandbox, core.Runtime{Exec: runner}),
 		token:  "secret",
 	}
 
@@ -522,12 +520,12 @@ func TestCodeSandboxClientLifecycleOperationsUseBridgePayloads(t *testing.T) {
 }
 
 type recordingBridgeRunner struct {
-	calls     []LocalCommandRequest
+	calls     []core.LocalCommandRequest
 	deadlines []time.Time
-	fn        func(LocalCommandRequest) (LocalCommandResult, error)
+	fn        func(core.LocalCommandRequest) (core.LocalCommandResult, error)
 }
 
-func (r *recordingBridgeRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (r *recordingBridgeRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.calls = append(r.calls, req)
 	if deadline, ok := ctx.Deadline(); ok {
 		r.deadlines = append(r.deadlines, deadline)
@@ -536,17 +534,17 @@ func (r *recordingBridgeRunner) Run(ctx context.Context, req LocalCommandRequest
 		spec := req.Args[len(req.Args)-1]
 		name, ok := npmPackageName(spec)
 		if !ok {
-			return LocalCommandResult{ExitCode: 1}, errors.New("invalid package spec")
+			return core.LocalCommandResult{ExitCode: 1}, errors.New("invalid package spec")
 		}
 		version, _ := npmExactPackageVersion(spec, name)
 		packageDir := filepath.Join(req.Dir, "node_modules", filepath.FromSlash(name))
 		if err := os.MkdirAll(packageDir, 0o700); err != nil {
-			return LocalCommandResult{ExitCode: 1}, err
+			return core.LocalCommandResult{ExitCode: 1}, err
 		}
 		if err := os.WriteFile(filepath.Join(packageDir, "package.json"), []byte(`{"version":"`+version+`"}`), 0o600); err != nil {
-			return LocalCommandResult{ExitCode: 1}, err
+			return core.LocalCommandResult{ExitCode: 1}, err
 		}
-		return LocalCommandResult{ExitCode: 0}, nil
+		return core.LocalCommandResult{ExitCode: 0}, nil
 	}
 	if r.fn != nil {
 		var stdout, stderr bytes.Buffer
@@ -560,12 +558,12 @@ func (r *recordingBridgeRunner) Run(ctx context.Context, req LocalCommandRequest
 		}
 		return result, err
 	}
-	return LocalCommandResult{ExitCode: 0}, nil
+	return core.LocalCommandResult{ExitCode: 0}, nil
 }
 
 type actualBridgeRunner struct{}
 
-func (actualBridgeRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (actualBridgeRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	cmd := exec.CommandContext(ctx, req.Name, req.Args...)
 	cmd.Dir = req.Dir
 	cmd.Env = req.Env
@@ -574,14 +572,14 @@ func (actualBridgeRunner) Run(ctx context.Context, req LocalCommandRequest) (Loc
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	result := LocalCommandResult{Stdout: stdout.String(), Stderr: stderr.String()}
+	result := core.LocalCommandResult{Stdout: stdout.String(), Stderr: stderr.String()}
 	if cmd.ProcessState != nil {
 		result.ExitCode = cmd.ProcessState.ExitCode()
 	}
 	return result, err
 }
 
-func (r *recordingBridgeRunner) onlyCall(t *testing.T) LocalCommandRequest {
+func (r *recordingBridgeRunner) onlyCall(t *testing.T) core.LocalCommandRequest {
 	t.Helper()
 	calls := r.bridgeCalls()
 	if len(calls) != 1 {
@@ -590,7 +588,7 @@ func (r *recordingBridgeRunner) onlyCall(t *testing.T) LocalCommandRequest {
 	return calls[0]
 }
 
-func (r *recordingBridgeRunner) onlySetupCall(t *testing.T) LocalCommandRequest {
+func (r *recordingBridgeRunner) onlySetupCall(t *testing.T) core.LocalCommandRequest {
 	t.Helper()
 	calls := r.setupCalls()
 	if len(calls) != 1 {
@@ -599,8 +597,8 @@ func (r *recordingBridgeRunner) onlySetupCall(t *testing.T) LocalCommandRequest 
 	return calls[0]
 }
 
-func (r *recordingBridgeRunner) bridgeCalls() []LocalCommandRequest {
-	var calls []LocalCommandRequest
+func (r *recordingBridgeRunner) bridgeCalls() []core.LocalCommandRequest {
+	var calls []core.LocalCommandRequest
 	for _, call := range r.calls {
 		if call.Stdin != nil {
 			calls = append(calls, call)
@@ -609,8 +607,8 @@ func (r *recordingBridgeRunner) bridgeCalls() []LocalCommandRequest {
 	return calls
 }
 
-func (r *recordingBridgeRunner) setupCalls() []LocalCommandRequest {
-	var calls []LocalCommandRequest
+func (r *recordingBridgeRunner) setupCalls() []core.LocalCommandRequest {
+	var calls []core.LocalCommandRequest
 	for _, call := range r.calls {
 		if call.Name == "npm" {
 			calls = append(calls, call)
@@ -619,7 +617,7 @@ func (r *recordingBridgeRunner) setupCalls() []LocalCommandRequest {
 	return calls
 }
 
-func readRequestBody(req LocalCommandRequest) string {
+func readRequestBody(req core.LocalCommandRequest) string {
 	if req.Stdin == nil {
 		return ""
 	}

--- a/internal/providers/codesandbox/claims.go
+++ b/internal/providers/codesandbox/claims.go
@@ -11,6 +11,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -23,7 +24,7 @@ const (
 	codeSandboxScopeTagPrefix   = "crabboxscope"
 )
 
-func (b *codeSandboxBackend) createSandbox(ctx context.Context, api codeSandboxAPI, repo Repo, reclaim bool, requestedSlug string) (string, string, string, error) {
+func (b *codeSandboxBackend) createSandbox(ctx context.Context, api codeSandboxAPI, repo core.Repo, reclaim bool, requestedSlug string) (string, string, string, error) {
 	scope, err := newCodeSandboxClaimScope()
 	if err != nil {
 		return "", "", "", err
@@ -42,98 +43,98 @@ func (b *codeSandboxBackend) createSandbox(ctx context.Context, api codeSandboxA
 		return "", "", "", err
 	}
 	if strings.TrimSpace(sb.ID) == "" {
-		return "", "", "", exit(5, "codesandbox create returned an empty sandbox id")
+		return "", "", "", core.Exit(5, "codesandbox create returned an empty sandbox id")
 	}
 	leaseID := leasePrefix + sb.ID
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return leaseID, sb.ID, "", b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
-	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, scope, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, providerName, scope, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
 		return leaseID, sb.ID, slug, b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
 	return leaseID, sb.ID, slug, nil
 }
 
-func resolveLeaseID(id string) (string, string, string, LeaseClaim, error) {
+func resolveLeaseID(id string) (string, string, string, core.LeaseClaim, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return "", "", "", LeaseClaim{}, exit(2, "provider=codesandbox requires a Crabbox-created sandbox slug or lease id")
+		return "", "", "", core.LeaseClaim{}, core.Exit(2, "provider=codesandbox requires a Crabbox-created sandbox slug or lease id")
 	}
 	exactLeaseID := id
 	if !strings.HasPrefix(exactLeaseID, leasePrefix) {
 		exactLeaseID = leasePrefix + exactLeaseID
 	}
-	if claim, err := readLeaseClaim(exactLeaseID); err != nil {
-		return "", "", "", LeaseClaim{}, err
+	if claim, err := core.ReadLeaseClaim(exactLeaseID); err != nil {
+		return "", "", "", core.LeaseClaim{}, err
 	} else if claim.LeaseID == exactLeaseID && claim.Provider == providerName {
 		return finishResolvedLease(claim)
 	}
 	claim, ok, err := resolveCodeSandboxLeaseClaim(id)
 	if err != nil {
-		return "", "", "", LeaseClaim{}, err
+		return "", "", "", core.LeaseClaim{}, err
 	}
 	if ok {
 		return finishResolvedLease(claim)
 	}
-	return "", "", "", LeaseClaim{}, exit(4, "codesandbox sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
+	return "", "", "", core.LeaseClaim{}, core.Exit(4, "codesandbox sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
 }
 
-func resolveCodeSandboxLeaseClaim(identifier string) (LeaseClaim, bool, error) {
+func resolveCodeSandboxLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 	claims, err := listCodeSandboxLeaseClaims()
 	if err != nil {
-		return LeaseClaim{}, false, err
+		return core.LeaseClaim{}, false, err
 	}
 	for _, claim := range claims {
 		if claim.Provider == providerName && claim.LeaseID == identifier {
 			if err := validateCodeSandboxClaimScope(claim); err != nil {
-				return LeaseClaim{}, false, err
+				return core.LeaseClaim{}, false, err
 			}
 			return claim, true, nil
 		}
 	}
-	slug := normalizeLeaseSlug(identifier)
+	slug := core.NormalizeLeaseSlug(identifier)
 	if slug != "" {
 		for _, claim := range claims {
-			if claim.Provider == providerName && normalizeLeaseSlug(claim.Slug) == slug {
+			if claim.Provider == providerName && core.NormalizeLeaseSlug(claim.Slug) == slug {
 				if err := validateCodeSandboxClaimScope(claim); err != nil {
-					return LeaseClaim{}, false, err
+					return core.LeaseClaim{}, false, err
 				}
 				return claim, true, nil
 			}
 		}
 	}
-	return LeaseClaim{}, false, nil
+	return core.LeaseClaim{}, false, nil
 }
 
-func finishResolvedLease(claim LeaseClaim) (string, string, string, LeaseClaim, error) {
+func finishResolvedLease(claim core.LeaseClaim) (string, string, string, core.LeaseClaim, error) {
 	if err := validateCodeSandboxClaimScope(claim); err != nil {
-		return "", "", "", LeaseClaim{}, err
+		return "", "", "", core.LeaseClaim{}, err
 	}
 	sandboxID := strings.TrimPrefix(claim.LeaseID, leasePrefix)
 	if sandboxID == "" {
-		return "", "", "", LeaseClaim{}, exit(4, "codesandbox lease %q has no provider sandbox id", claim.LeaseID)
+		return "", "", "", core.LeaseClaim{}, core.Exit(4, "codesandbox lease %q has no provider sandbox id", claim.LeaseID)
 	}
 	slug := claim.Slug
 	if strings.TrimSpace(slug) == "" {
-		slug = newLeaseSlug(claim.LeaseID)
+		slug = core.NewLeaseSlug(claim.LeaseID)
 	}
 	return claim.LeaseID, sandboxID, slug, claim, nil
 }
 
-func validateCodeSandboxClaimScope(claim LeaseClaim) error {
+func validateCodeSandboxClaimScope(claim core.LeaseClaim) error {
 	if claim.Provider != providerName || !strings.HasPrefix(claim.LeaseID, leasePrefix) {
-		return exit(4, "codesandbox lease %q is not a CodeSandbox Crabbox claim", claim.LeaseID)
+		return core.Exit(4, "codesandbox lease %q is not a CodeSandbox Crabbox claim", claim.LeaseID)
 	}
 	if !strings.HasPrefix(strings.TrimSpace(claim.ProviderScope), codeSandboxClaimScopePrefix) {
-		return exit(4, "codesandbox lease %q has an invalid ownership scope", claim.LeaseID)
+		return core.Exit(4, "codesandbox lease %q has an invalid ownership scope", claim.LeaseID)
 	}
 	return nil
 }
 
-func validateCodeSandboxSandboxOwnership(claim LeaseClaim, sb SandboxSummary) error {
+func validateCodeSandboxSandboxOwnership(claim core.LeaseClaim, sb SandboxSummary) error {
 	if strings.TrimSpace(sb.ID) != "" && strings.TrimSpace(sb.ID) != strings.TrimPrefix(claim.LeaseID, leasePrefix) {
-		return exit(4, "codesandbox sandbox %q does not match local claim %q", sb.ID, claim.LeaseID)
+		return core.Exit(4, "codesandbox sandbox %q does not match local claim %q", sb.ID, claim.LeaseID)
 	}
 	remoteScope := ""
 	for _, tag := range sb.Tags {
@@ -143,10 +144,10 @@ func validateCodeSandboxSandboxOwnership(claim LeaseClaim, sb SandboxSummary) er
 		}
 	}
 	if remoteScope == "" {
-		return exit(4, "codesandbox sandbox %q is missing its Crabbox ownership tag", sb.ID)
+		return core.Exit(4, "codesandbox sandbox %q is missing its Crabbox ownership tag", sb.ID)
 	}
 	if remoteScope != claim.ProviderScope {
-		return exit(4, "codesandbox sandbox %q ownership tag does not match its local claim", sb.ID)
+		return core.Exit(4, "codesandbox sandbox %q ownership tag does not match its local claim", sb.ID)
 	}
 	return nil
 }
@@ -169,13 +170,13 @@ func codeSandboxScopeFromTag(tag string) (string, bool) {
 func newCodeSandboxClaimScope() (string, error) {
 	var token [16]byte
 	if _, err := rand.Read(token[:]); err != nil {
-		return "", exit(5, "generate codesandbox ownership token: %v", err)
+		return "", core.Exit(5, "generate codesandbox ownership token: %v", err)
 	}
 	return codeSandboxClaimScopePrefix + hex.EncodeToString(token[:]), nil
 }
 
-func newSandboxTitle(repo Repo) string {
-	base := normalizeLeaseSlug(repo.Name)
+func newSandboxTitle(repo core.Repo) string {
+	base := core.NormalizeLeaseSlug(repo.Name)
 	if base == "" {
 		base = "workspace"
 	}
@@ -189,24 +190,24 @@ func newSandboxTitle(repo Repo) string {
 	return codeSandboxNamePrefix + base + "-" + randomSuffix()
 }
 
-func codeSandboxWorkdir(cfg Config) (string, error) {
+func codeSandboxWorkdir(cfg core.Config) (string, error) {
 	workdir := strings.TrimSpace(cfg.CodeSandbox.Workdir)
 	if workdir == "" {
 		workdir = defaultWorkdir
 	}
 	if strings.IndexFunc(workdir, func(r rune) bool { return r == 0 || (!utf8.ValidRune(r)) || (r < 0x20) }) >= 0 {
-		return "", exit(2, "codesandbox workdir contains control characters")
+		return "", core.Exit(2, "codesandbox workdir contains control characters")
 	}
 	clean := path.Clean(workdir)
 	if !strings.HasPrefix(clean, "/") {
-		return "", exit(2, "codesandbox workdir %q must be an absolute path", workdir)
+		return "", core.Exit(2, "codesandbox workdir %q must be an absolute path", workdir)
 	}
 	switch clean {
 	case "/", "/project":
-		return "", exit(2, "codesandbox workdir %q is too broad; choose a path under %s", clean, defaultWorkdir)
+		return "", core.Exit(2, "codesandbox workdir %q is too broad; choose a path under %s", clean, defaultWorkdir)
 	}
 	if clean != defaultWorkdir && !strings.HasPrefix(clean, defaultWorkdir+"/") {
-		return "", exit(2, "codesandbox workdir %q must be under %s", clean, defaultWorkdir)
+		return "", core.Exit(2, "codesandbox workdir %q must be under %s", clean, defaultWorkdir)
 	}
 	return clean, nil
 }

--- a/internal/providers/codesandbox/client.go
+++ b/internal/providers/codesandbox/client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"io"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type SandboxSummary struct {
@@ -68,13 +70,13 @@ type codeSandboxAPI interface {
 }
 
 type codeSandboxClient struct {
-	cfg    CodeSandboxConfig
-	rt     Runtime
+	cfg    core.CodeSandboxConfig
+	rt     core.Runtime
 	bridge *SDKBridge
 	token  string
 }
 
-var newCodeSandboxClient = func(cfg Config, rt Runtime) (codeSandboxAPI, error) {
+var newCodeSandboxClient = func(cfg core.Config, rt core.Runtime) (codeSandboxAPI, error) {
 	token, _, ok := authFromEnv()
 	if !ok {
 		return nil, missingAuthError{}

--- a/internal/providers/codesandbox/core.go
+++ b/internal/providers/codesandbox/core.go
@@ -9,33 +9,6 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-type Config = core.Config
-type CodeSandboxConfig = core.CodeSandboxConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type DoctorCheck = core.DoctorCheck
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type CleanupRequest = core.CleanupRequest
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type PauseRequest = core.PauseRequest
-type ResumeRequest = core.ResumeRequest
-type PortsRequest = core.PortsRequest
-type Server = core.Server
-type Repo = core.Repo
-type LeaseClaim = core.LeaseClaim
-type ExitError = core.ExitError
-type timingPhase = core.TimingPhase
-type LocalCommandRequest = core.LocalCommandRequest
-
 const (
 	providerName         = "codesandbox"
 	providerFamily       = "codesandbox"
@@ -50,63 +23,15 @@ const (
 	codesandboxFallbackAPIKeyEnv = "CSB_API_KEY"
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func inventoryDoctorResult(provider string, leases int) DoctorResult {
-	return core.InventoryDoctorResult(provider, leases)
-}
-
-func delegatedSyncOptionsError(spec ProviderSpec, req RunRequest) error {
-	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
-}
-
-func readLeaseClaim(leaseID string) (LeaseClaim, error) {
-	return core.ReadLeaseClaim(leaseID)
-}
-
-func listCodeSandboxLeaseClaims() ([]LeaseClaim, error) {
+func listCodeSandboxLeaseClaims() ([]core.LeaseClaim, error) {
 	return core.ListLeaseClaimsWithPrefix(leasePrefix)
 }
 
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
-func removeLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
-	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
-func shellQuote(s string) string {
-	return core.ShellQuote(s)
-}
-
 func codeSandboxCleanupCommand(leaseID string) string {
-	return "crabbox stop --provider " + providerName + " " + shellQuote(leaseID)
+	return "crabbox stop --provider " + providerName + " " + core.ShellQuote(leaseID)
 }
 
-func operationTimeout(cfg CodeSandboxConfig) time.Duration {
+func operationTimeout(cfg core.CodeSandboxConfig) time.Duration {
 	seconds := cfg.OperationTimeoutSecs
 	if seconds <= 0 {
 		seconds = 30
@@ -114,21 +39,21 @@ func operationTimeout(cfg CodeSandboxConfig) time.Duration {
 	return time.Duration(seconds) * time.Second
 }
 
-func bridgeCommand(cfg CodeSandboxConfig) string {
+func bridgeCommand(cfg core.CodeSandboxConfig) string {
 	if command := strings.TrimSpace(cfg.BridgeCommand); command != "" {
 		return command
 	}
 	return defaultBridgeCommand
 }
 
-func sdkPackage(cfg CodeSandboxConfig) string {
+func sdkPackage(cfg core.CodeSandboxConfig) string {
 	if pkg := strings.TrimSpace(cfg.SDKPackage); pkg != "" {
 		return pkg
 	}
 	return defaultSDKPackage
 }
 
-func doctorListLimit(cfg CodeSandboxConfig) int {
+func doctorListLimit(cfg core.CodeSandboxConfig) int {
 	if cfg.DoctorListLimit <= 0 {
 		return 1
 	}
@@ -152,13 +77,13 @@ func redactToken(text, token string) string {
 	return strings.ReplaceAll(text, token, "[redacted]")
 }
 
-func doctorCheck(name string, err error, details map[string]string) DoctorCheck {
+func doctorCheck(name string, err error, details map[string]string) core.DoctorCheck {
 	if err != nil {
-		return DoctorCheck{Status: "error", Check: name, Message: err.Error(), Details: details}
+		return core.DoctorCheck{Status: "error", Check: name, Message: err.Error(), Details: details}
 	}
-	return DoctorCheck{Status: "ok", Check: name, Message: "ready", Details: details}
+	return core.DoctorCheck{Status: "ok", Check: name, Message: "ready", Details: details}
 }
 
-func discardRuntime() Runtime {
-	return Runtime{Stdout: io.Discard, Stderr: io.Discard}
+func discardRuntime() core.Runtime {
+	return core.Runtime{Stdout: io.Discard, Stderr: io.Discard}
 }

--- a/internal/providers/codesandbox/flags.go
+++ b/internal/providers/codesandbox/flags.go
@@ -7,11 +7,11 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func RegisterCodeSandboxProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterCodeSandboxProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterCodeSandboxConfigFlags(fs, defaults.CodeSandbox)
 }
 
-func ApplyCodeSandboxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyCodeSandboxProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	v, ok := values.(core.CodeSandboxConfigFlagValues)
 	if !ok {
 		return nil

--- a/internal/providers/codesandbox/provider.go
+++ b/internal/providers/codesandbox/provider.go
@@ -51,42 +51,42 @@ func (Provider) ValidateConfig(cfg core.Config) error {
 	return validateCodeSandboxConfig(cfg)
 }
 
-func validateCodeSandboxConfig(cfg Config) error {
+func validateCodeSandboxConfig(cfg core.Config) error {
 	csb := cfg.CodeSandbox
 	if strings.TrimSpace(csb.Workdir) == "" {
-		return exit(2, "codesandbox workdir must not be empty")
+		return core.Exit(2, "codesandbox workdir must not be empty")
 	}
 	cfg.Provider = providerName
 	if _, err := codeSandboxWorkdir(cfg); err != nil {
 		return err
 	}
 	if strings.TrimSpace(csb.BridgeCommand) == "" {
-		return exit(2, "codesandbox bridgeCommand must not be empty")
+		return core.Exit(2, "codesandbox bridgeCommand must not be empty")
 	}
 	if strings.TrimSpace(csb.SDKPackage) == "" {
-		return exit(2, "codesandbox sdkPackage must not be empty")
+		return core.Exit(2, "codesandbox sdkPackage must not be empty")
 	}
 	if csb.HibernationTimeoutSecs < 0 {
-		return exit(2, "codesandbox hibernationTimeoutSecs must be non-negative")
+		return core.Exit(2, "codesandbox hibernationTimeoutSecs must be non-negative")
 	}
 	if csb.DoctorListLimit < 0 {
-		return exit(2, "codesandbox doctorListLimit must be non-negative")
+		return core.Exit(2, "codesandbox doctorListLimit must be non-negative")
 	}
 	if csb.OperationTimeoutSecs < 0 {
-		return exit(2, "codesandbox operationTimeoutSecs must be non-negative")
+		return core.Exit(2, "codesandbox operationTimeoutSecs must be non-negative")
 	}
 	if privacy := strings.ToLower(strings.TrimSpace(csb.Privacy)); privacy != "" {
 		switch privacy {
 		case "public", "unlisted", "private", "public-hosts":
 		default:
-			return exit(2, "codesandbox privacy must be public, unlisted, private, or public-hosts")
+			return core.Exit(2, "codesandbox privacy must be public, unlisted, private, or public-hosts")
 		}
 	}
 	if tier := strings.ToLower(strings.TrimSpace(csb.VMTier)); tier != "" {
 		switch tier {
 		case "pico", "nano", "micro", "small", "medium", "large", "xlarge":
 		default:
-			return exit(2, "codesandbox vmTier must be pico, nano, micro, small, medium, large, or xlarge")
+			return core.Exit(2, "codesandbox vmTier must be pico, nano, micro, small, medium, large, or xlarge")
 		}
 	}
 	return nil

--- a/internal/providers/codesandbox/provider_test.go
+++ b/internal/providers/codesandbox/provider_test.go
@@ -67,7 +67,7 @@ func TestProviderFlagsApplyAndValidateNonSecretFields(t *testing.T) {
 	if got.HibernationTimeoutSecs != 900 || got.AutomaticWakeupHTTP || !got.AutomaticWakeupWebSocket || got.BridgeCommand != "/opt/node" || got.SDKPackage != "@codesandbox/sdk@2.4.2" || got.DoctorListLimit != 2 || got.OperationTimeoutSecs != 45 {
 		t.Fatalf("codesandbox config=%#v", got)
 	}
-	if _, ok := reflect.TypeOf(CodeSandboxConfig{}).FieldByName("APIKey"); ok {
+	if _, ok := reflect.TypeOf(core.CodeSandboxConfig{}).FieldByName("APIKey"); ok {
 		t.Fatal("CodeSandboxConfig must not persist API keys")
 	}
 }
@@ -102,14 +102,14 @@ func TestProviderFlagsRejectGenericSizingForAliases(t *testing.T) {
 func TestValidateCodeSandboxConfigRejectsUnsafeValues(t *testing.T) {
 	tests := []struct {
 		name   string
-		mutate func(*Config)
+		mutate func(*core.Config)
 		want   string
 	}{
-		{name: "workdir outside project workspace", mutate: func(cfg *Config) { cfg.CodeSandbox.Workdir = "/tmp/app" }, want: "under /project/workspace"},
-		{name: "empty bridge command", mutate: func(cfg *Config) { cfg.CodeSandbox.BridgeCommand = " " }, want: "bridgeCommand"},
-		{name: "invalid privacy", mutate: func(cfg *Config) { cfg.CodeSandbox.Privacy = "team-only" }, want: "privacy"},
-		{name: "invalid vm tier", mutate: func(cfg *Config) { cfg.CodeSandbox.VMTier = "huge" }, want: "vmTier"},
-		{name: "negative timeout", mutate: func(cfg *Config) { cfg.CodeSandbox.OperationTimeoutSecs = -1 }, want: "operationTimeoutSecs"},
+		{name: "workdir outside project workspace", mutate: func(cfg *core.Config) { cfg.CodeSandbox.Workdir = "/tmp/app" }, want: "under /project/workspace"},
+		{name: "empty bridge command", mutate: func(cfg *core.Config) { cfg.CodeSandbox.BridgeCommand = " " }, want: "bridgeCommand"},
+		{name: "invalid privacy", mutate: func(cfg *core.Config) { cfg.CodeSandbox.Privacy = "team-only" }, want: "privacy"},
+		{name: "invalid vm tier", mutate: func(cfg *core.Config) { cfg.CodeSandbox.VMTier = "huge" }, want: "vmTier"},
+		{name: "negative timeout", mutate: func(cfg *core.Config) { cfg.CodeSandbox.OperationTimeoutSecs = -1 }, want: "operationTimeoutSecs"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -141,13 +141,13 @@ func TestDoctorRequiresEnvOnlyAuthBeforeBridge(t *testing.T) {
 	t.Setenv(codesandboxPrimaryAPIKeyEnv, "")
 	t.Setenv(codesandboxFallbackAPIKeyEnv, "")
 	calls := 0
-	restore := replaceClientFactory(func(Config, Runtime) (codeSandboxAPI, error) {
+	restore := replaceClientFactory(func(core.Config, core.Runtime) (codeSandboxAPI, error) {
 		calls++
 		return &fakeSandboxLister{}, nil
 	})
 	defer restore()
 	backend := newTestBackend(newTestConfig())
-	_, err := backend.Doctor(context.Background(), DoctorRequest{})
+	_, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err == nil || !strings.Contains(err.Error(), codesandboxPrimaryAPIKeyEnv) || strings.Contains(err.Error(), "secret") {
 		t.Fatalf("Doctor err=%v", err)
 	}
@@ -164,12 +164,12 @@ func TestDoctorIsNonMutatingListReadiness(t *testing.T) {
 			TotalCount: 1,
 		},
 	}
-	restore := replaceClientFactory(func(Config, Runtime) (codeSandboxAPI, error) {
+	restore := replaceClientFactory(func(core.Config, core.Runtime) (codeSandboxAPI, error) {
 		return fake, nil
 	})
 	defer restore()
 	backend := newTestBackend(newTestConfig())
-	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatalf("Doctor err=%v", err)
 	}
@@ -181,13 +181,13 @@ func TestDoctorIsNonMutatingListReadiness(t *testing.T) {
 	}
 }
 
-func newTestConfig() Config {
+func newTestConfig() core.Config {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	return cfg
 }
 
-func newTestBackend(cfg Config) *codeSandboxBackend {
+func newTestBackend(cfg core.Config) *codeSandboxBackend {
 	backend, err := Provider{}.Configure(cfg, discardRuntime())
 	if err != nil {
 		panic(err)
@@ -195,7 +195,7 @@ func newTestBackend(cfg Config) *codeSandboxBackend {
 	return backend.(*codeSandboxBackend)
 }
 
-func replaceClientFactory(fn func(Config, Runtime) (codeSandboxAPI, error)) func() {
+func replaceClientFactory(fn func(core.Config, core.Runtime) (codeSandboxAPI, error)) func() {
 	prev := newCodeSandboxClient
 	newCodeSandboxClient = fn
 	return func() { newCodeSandboxClient = prev }
@@ -285,7 +285,7 @@ func TestProviderFlagPresenceBeforeValidation(t *testing.T) {
 	if err := ApplyCodeSandboxProviderFlags(&cfg, fs, values); err == nil {
 		t.Fatal("expected semantic validation failure")
 	}
-	if cfg.CodeSandbox != (CodeSandboxConfig{}) {
+	if cfg.CodeSandbox != (core.CodeSandboxConfig{}) {
 		t.Fatalf("explicit zero values not copied before validation: %#v", cfg.CodeSandbox)
 	}
 }

--- a/internal/providers/codesandbox/sync.go
+++ b/internal/providers/codesandbox/sync.go
@@ -10,7 +10,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *codeSandboxBackend) syncWorkspace(ctx context.Context, api codeSandboxAPI, sandboxID string, req RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+func (b *codeSandboxBackend) syncWorkspace(ctx context.Context, api codeSandboxAPI, sandboxID string, req core.RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	syncReq := core.DelegatedArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
@@ -52,34 +52,34 @@ func (b *codeSandboxBackend) execShell(ctx context.Context, api codeSandboxAPI, 
 		if detail == "" {
 			detail = strings.TrimSpace(res.Stdout)
 		}
-		return exit(res.ExitCode, "codesandbox exec %q exited %d: %s", command, res.ExitCode, detail)
+		return core.Exit(res.ExitCode, "codesandbox exec %q exited %d: %s", command, res.ExitCode, detail)
 	}
 	return nil
 }
 
 func codeSandboxMountReplaceCommand(stagingDir, workdir string) string {
 	backupDir := path.Join(workdir, path.Base(stagingDir)+".previous")
-	workdirGlob := shellQuote(workdir) + "/*"
-	backupGlob := shellQuote(backupDir) + "/*"
+	workdirGlob := core.ShellQuote(workdir) + "/*"
+	backupGlob := core.ShellQuote(backupDir) + "/*"
 	rollback := "rollback() { original_rc=$?; trap - EXIT HUP INT TERM; rollback_rc=0; " +
 		"for entry in " + workdirGlob + "; do " +
-		"if [ \"$entry\" != " + shellQuote(backupDir) + " ]; then rm -rf -- \"$entry\" || rollback_rc=$?; fi; done; " +
+		"if [ \"$entry\" != " + core.ShellQuote(backupDir) + " ]; then rm -rf -- \"$entry\" || rollback_rc=$?; fi; done; " +
 		"if [ \"$rollback_rc\" -eq 0 ]; then for entry in " + backupGlob + "; do " +
-		"mv -- \"$entry\" " + shellQuote(workdir+"/") + " || { rollback_rc=$?; break; }; done; fi; " +
-		"if [ \"$rollback_rc\" -eq 0 ]; then rmdir " + shellQuote(backupDir) + " || rollback_rc=$?; fi; " +
+		"mv -- \"$entry\" " + core.ShellQuote(workdir+"/") + " || { rollback_rc=$?; break; }; done; fi; " +
+		"if [ \"$rollback_rc\" -eq 0 ]; then rmdir " + core.ShellQuote(backupDir) + " || rollback_rc=$?; fi; " +
 		"if [ \"$rollback_rc\" -ne 0 ]; then exit \"$rollback_rc\"; fi; exit \"$original_rc\"; }"
 	return "shopt -s dotglob nullglob; " + rollback +
-		"; mkdir -p " + shellQuote(workdir) +
-		" && rm -rf " + shellQuote(backupDir) +
-		" && mkdir -p " + shellQuote(backupDir) +
+		"; mkdir -p " + core.ShellQuote(workdir) +
+		" && rm -rf " + core.ShellQuote(backupDir) +
+		" && mkdir -p " + core.ShellQuote(backupDir) +
 		" && trap rollback EXIT HUP INT TERM" +
 		" && for entry in " + workdirGlob + "; do " +
-		"if [ \"$entry\" != " + shellQuote(backupDir) + " ]; then mv -- \"$entry\" " + shellQuote(backupDir+"/") + " || exit 1; fi; done" +
-		" && cp -a " + shellQuote(stagingDir+"/.") + " " + shellQuote(workdir+"/") +
+		"if [ \"$entry\" != " + core.ShellQuote(backupDir) + " ]; then mv -- \"$entry\" " + core.ShellQuote(backupDir+"/") + " || exit 1; fi; done" +
+		" && cp -a " + core.ShellQuote(stagingDir+"/.") + " " + core.ShellQuote(workdir+"/") +
 		" && trap - EXIT HUP INT TERM" +
-		" && rm -rf " + shellQuote(backupDir) + " " + shellQuote(stagingDir)
+		" && rm -rf " + core.ShellQuote(backupDir) + " " + core.ShellQuote(stagingDir)
 }
 
 func (b *codeSandboxBackend) ensureWorkspace(ctx context.Context, api codeSandboxAPI, sandboxID, workdir string) error {
-	return b.execShell(ctx, api, sandboxID, "mkdir -p "+shellQuote(workdir))
+	return b.execShell(ctx, api, sandboxID, "mkdir -p "+core.ShellQuote(workdir))
 }

--- a/internal/providers/codesandbox/sync_test.go
+++ b/internal/providers/codesandbox/sync_test.go
@@ -48,16 +48,16 @@ func TestCodeSandboxWorkdirValidation(t *testing.T) {
 
 func TestSpecAllowsArchiveSyncOptionsButRejectsUnsupportedDelegatedOptions(t *testing.T) {
 	spec := Provider{}.Spec()
-	if err := core.RejectDelegatedSyncOptionsForSpec(spec, RunRequest{SyncOnly: true}); err != nil {
+	if err := core.RejectDelegatedSyncOptionsForSpec(spec, core.RunRequest{SyncOnly: true}); err != nil {
 		t.Fatalf("--sync-only should be allowed: %v", err)
 	}
-	if err := core.RejectDelegatedSyncOptionsForSpec(spec, RunRequest{ForceSyncLarge: true}); err != nil {
+	if err := core.RejectDelegatedSyncOptionsForSpec(spec, core.RunRequest{ForceSyncLarge: true}); err != nil {
 		t.Fatalf("--force-sync-large should be allowed: %v", err)
 	}
-	if err := core.RejectDelegatedSyncOptionsForSpec(spec, RunRequest{ChecksumSync: true}); err == nil {
+	if err := core.RejectDelegatedSyncOptionsForSpec(spec, core.RunRequest{ChecksumSync: true}); err == nil {
 		t.Fatal("--checksum should be rejected for delegated archive sync")
 	}
-	if err := core.RejectDelegatedSyncOptionsForSpec(spec, RunRequest{FullResync: true}); err == nil {
+	if err := core.RejectDelegatedSyncOptionsForSpec(spec, core.RunRequest{FullResync: true}); err == nil {
 		t.Fatal("--full-resync should be rejected for delegated archive sync")
 	}
 }

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -16,11 +16,11 @@ import (
 
 const e2bCleanupTimeout = 30 * time.Second
 
-func RegisterE2BProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterE2BProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterE2BConfigFlags(fs, defaults.E2B)
 }
 
-func ApplyE2BProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyE2BProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if cfg.Provider == e2bProvider {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, e2bProvider, "", ""); err != nil {
 			return err
@@ -35,22 +35,22 @@ func ApplyE2BProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	return err
 }
 
-func NewE2BBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewE2BBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = e2bProvider
 	return &e2bBackend{spec: spec, cfg: cfg, rt: rt}
 }
 
 type e2bBackend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
 const e2bMaxSandboxTimeout = time.Hour
 
-func (b *e2bBackend) Spec() ProviderSpec { return b.spec }
+func (b *e2bBackend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *e2bBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *e2bBackend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if err := validateE2BUser(b.cfg.E2B.User); err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func (b *e2bBackend) Warmup(ctx context.Context, req WarmupRequest) error {
 	})
 }
 
-func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *e2bBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	var processUser string
 	workspace := e2bWorkspacePath(b.cfg)
 	var client e2bAPI
@@ -135,7 +135,7 @@ func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error)
 		Command: func(context.Context) (shared.DelegatedSandboxCommand, error) {
 			intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
 			if err != nil {
-				return shared.DelegatedSandboxCommand{}, exit(2, "%v", err)
+				return shared.DelegatedSandboxCommand{}, core.Exit(2, "%v", err)
 			}
 			command := intent.ShellSource()
 			return shared.DelegatedSandboxCommand{Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
@@ -152,7 +152,7 @@ func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error)
 	})
 }
 
-func (b *e2bBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *e2bBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	client, err := newE2BClient(b.cfg, b.rt)
 	if err != nil {
@@ -162,25 +162,25 @@ func (b *e2bBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, er
 	if err != nil {
 		return nil, e2bError("list sandboxes", err)
 	}
-	servers := make([]Server, 0, len(sandboxes))
+	servers := make([]core.Server, 0, len(sandboxes))
 	for _, sandbox := range sandboxes {
 		servers = append(servers, e2bSandboxToServer(sandbox))
 	}
 	return servers, nil
 }
 
-func (b *e2bBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
-	servers, err := b.List(ctx, ListRequest{})
+func (b *e2bBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
+	servers, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return inventoryDoctorResult(e2bProvider, len(servers)), nil
+	return core.InventoryDoctorResult(e2bProvider, len(servers)), nil
 }
 
-func (b *e2bBackend) Status(ctx context.Context, req StatusRequest) (statusView, error) {
+func (b *e2bBackend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	client, err := newE2BClient(b.cfg, b.rt)
 	if err != nil {
-		return statusView{}, err
+		return core.StatusView{}, err
 	}
 	waitTimeout := req.WaitTimeout
 	if waitTimeout <= 0 {
@@ -196,43 +196,43 @@ func (b *e2bBackend) Status(ctx context.Context, req StatusRequest) (statusView,
 	leaseID, sandboxID, _, err := b.resolveSandboxID(pollCtx, client, req.ID, "", false)
 	if err != nil {
 		if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-			return statusView{}, exit(5, "timed out waiting for sandbox %s to become ready", req.ID)
+			return core.StatusView{}, core.Exit(5, "timed out waiting for sandbox %s to become ready", req.ID)
 		}
 		if ctx.Err() != nil {
-			return statusView{}, ctx.Err()
+			return core.StatusView{}, ctx.Err()
 		}
-		return statusView{}, err
+		return core.StatusView{}, err
 	}
 	for {
 		sandbox, err := client.GetSandbox(pollCtx, sandboxID)
 		if err != nil {
 			if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return statusView{}, exit(5, "timed out waiting for sandbox %s to become ready", sandboxID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for sandbox %s to become ready", sandboxID)
 			}
 			if ctx.Err() != nil {
-				return statusView{}, ctx.Err()
+				return core.StatusView{}, ctx.Err()
 			}
-			return statusView{}, e2bError("get sandbox", err)
+			return core.StatusView{}, e2bError("get sandbox", err)
 		}
 		view := e2bStatusView(leaseID, sandbox)
 		if !req.Wait || view.Ready {
 			return view, nil
 		}
 		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return statusView{}, exit(5, "timed out waiting for sandbox %s to become ready", sandboxID)
+			return core.StatusView{}, core.Exit(5, "timed out waiting for sandbox %s to become ready", sandboxID)
 		}
 		select {
 		case <-pollCtx.Done():
 			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return statusView{}, exit(5, "timed out waiting for sandbox %s to become ready", sandboxID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for sandbox %s to become ready", sandboxID)
 			}
-			return statusView{}, pollCtx.Err()
+			return core.StatusView{}, pollCtx.Err()
 		case <-time.After(2 * time.Second):
 		}
 	}
 }
 
-func (b *e2bBackend) Stop(ctx context.Context, req StopRequest) error {
+func (b *e2bBackend) Stop(ctx context.Context, req core.StopRequest) error {
 	client, err := newE2BClient(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -241,7 +241,7 @@ func (b *e2bBackend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		var missing *e2bClaimedSandboxMissingError
 		if errors.As(err, &missing) {
-			if removeErr := removeLeaseClaimIfUnchangedAfter(missing.claim.LeaseID, missing.claim, nil); removeErr != nil {
+			if removeErr := core.RemoveLeaseClaimIfUnchangedAfter(missing.claim.LeaseID, missing.claim, nil); removeErr != nil {
 				return removeErr
 			}
 			fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s (already absent)\n", missing.claim.LeaseID, missing.claim.CloudID)
@@ -256,15 +256,15 @@ func (b *e2bBackend) Stop(ctx context.Context, req StopRequest) error {
 	return nil
 }
 
-func (b *e2bBackend) ReclaimAndStop(ctx context.Context, req StopRequest) error {
+func (b *e2bBackend) ReclaimAndStop(ctx context.Context, req core.StopRequest) error {
 	if req.ID == "" {
-		return exit(2, "provider=e2b stop --reclaim requires an exact E2B sandbox id")
+		return core.Exit(2, "provider=e2b stop --reclaim requires an exact E2B sandbox id")
 	}
 	sandboxID := req.ID
 	if isE2BSyntheticID(sandboxID) {
 		sandboxID = strings.TrimPrefix(sandboxID, "e2b_")
 	} else if strings.HasPrefix(sandboxID, "cbx_") {
-		return exit(2, "provider=e2b stop --reclaim requires an exact E2B sandbox id, not lease %q", req.ID)
+		return core.Exit(2, "provider=e2b stop --reclaim requires an exact E2B sandbox id, not lease %q", req.ID)
 	}
 	client, err := newE2BClient(b.cfg, b.rt)
 	if err != nil {
@@ -275,41 +275,39 @@ func (b *e2bBackend) ReclaimAndStop(ctx context.Context, req StopRequest) error 
 		return e2bError("get sandbox", err)
 	}
 	if sandbox.SandboxID != sandboxID {
-		return exit(4, "e2b sandbox lookup for %q returned a different sandbox %q", sandboxID, sandbox.SandboxID)
+		return core.Exit(4, "e2b sandbox lookup for %q returned a different sandbox %q", sandboxID, sandbox.SandboxID)
 	}
 	if !isCrabboxE2BSandbox(sandbox) {
-		return exit(4, "e2b sandbox %q is not claimed by Crabbox", req.ID)
+		return core.Exit(4, "e2b sandbox %q is not claimed by Crabbox", req.ID)
 	}
 	leaseID := strings.TrimSpace(sandbox.Metadata["lease"])
-	if !isCanonicalLeaseID(leaseID) {
-		return exit(4, "e2b sandbox %q lacks a canonical Crabbox lease id", req.ID)
+	if !core.IsCanonicalLeaseID(leaseID) {
+		return core.Exit(4, "e2b sandbox %q lacks a canonical Crabbox lease id", req.ID)
 	}
 	slug := strings.TrimSpace(sandbox.Metadata["slug"])
 	if slug == "" {
-		return exit(4, "e2b sandbox %q lacks a canonical Crabbox slug", req.ID)
+		return core.Exit(4, "e2b sandbox %q lacks a canonical Crabbox slug", req.ID)
 	}
 	cfg := e2bClaimConfig(b.cfg)
 	if existing, ok, err := resolveLeaseClaimForProviderCloudIDScope(sandbox.SandboxID, providerClaimScope(cfg)); err != nil {
 		return err
 	} else if ok && existing.LeaseID != leaseID {
-		return exit(4, "e2b sandbox %q is already bound to lease %q", sandbox.SandboxID, existing.LeaseID)
+		return core.Exit(4, "e2b sandbox %q is already bound to lease %q", sandbox.SandboxID, existing.LeaseID)
 	}
-	previous, previousExists, err := readLeaseClaimWithPresence(leaseID)
+	previous, previousExists, err := core.ReadLeaseClaimWithPresence(leaseID)
 	if err != nil {
 		return err
 	}
 	if err := validateE2BReclaimCollision(leaseID, sandbox.SandboxID, previous, previousExists); err != nil {
 		return err
 	}
-	var claim LeaseClaim
+	var claim core.LeaseClaim
 	if previousExists && previous.RepoRoot != "" {
 		claim, err = claimLeaseTargetForRepoConfigIfUnchanged(
 			leaseID,
 			slug,
 			cfg,
-			e2bSandboxToServer(sandbox),
-			SSHTarget{},
-			previous.RepoRoot,
+			e2bSandboxToServer(sandbox), core.SSHTarget{}, previous.RepoRoot,
 			cfg.IdleTimeout,
 			true,
 			previous,
@@ -320,9 +318,7 @@ func (b *e2bBackend) ReclaimAndStop(ctx context.Context, req StopRequest) error 
 			leaseID,
 			slug,
 			cfg,
-			e2bSandboxToServer(sandbox),
-			SSHTarget{},
-			cfg.IdleTimeout,
+			e2bSandboxToServer(sandbox), core.SSHTarget{}, cfg.IdleTimeout,
 			previous,
 			previousExists,
 		)
@@ -340,9 +336,9 @@ func (b *e2bBackend) ReclaimAndStop(ctx context.Context, req StopRequest) error 
 	return nil
 }
 
-func (b *e2bBackend) createSandbox(ctx context.Context, client e2bAPI, repo Repo, keep, reclaim bool, requestedSlug string) (string, e2bSandbox, string, error) {
+func (b *e2bBackend) createSandbox(ctx context.Context, client e2bAPI, repo core.Repo, keep, reclaim bool, requestedSlug string) (string, e2bSandbox, string, error) {
 	leaseID := core.NewLeaseID()
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return "", e2bSandbox{}, "", err
 	}
@@ -354,7 +350,7 @@ func (b *e2bBackend) createSandbox(ctx context.Context, client e2bAPI, repo Repo
 	}
 	cfg.TTL = e2bTimeoutDuration(cfg.TTL)
 	cfg.ServerType = template
-	labels := directLeaseLabels(cfg, leaseID, slug, e2bProvider, "", keep, core.ClockNow(b.rt.Clock).UTC())
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, e2bProvider, "", keep, core.ClockNow(b.rt.Clock).UTC())
 	labels["state"] = "ready"
 	labels["workdir"] = workspace
 	labels["template"] = template
@@ -373,10 +369,10 @@ func (b *e2bBackend) createSandbox(ctx context.Context, client e2bAPI, repo Repo
 		return "", e2bSandbox{}, "", e2bError("create sandbox", err)
 	}
 	if sandbox.SandboxID == "" {
-		return "", e2bSandbox{}, "", exit(5, "e2b create sandbox returned no sandbox id")
+		return "", e2bSandbox{}, "", core.Exit(5, "e2b create sandbox returned no sandbox id")
 	}
 	cfg = e2bClaimConfig(cfg)
-	if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, e2bSandboxToServer(sandbox), SSHTarget{}, repo.Root, cfg.IdleTimeout, reclaim); err != nil {
+	if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, e2bSandboxToServer(sandbox), core.SSHTarget{}, repo.Root, cfg.IdleTimeout, reclaim); err != nil {
 		if cleanupErr := b.deleteSandboxForCleanup(client, sandbox.SandboxID); cleanupErr != nil {
 			leakErr := fmt.Errorf("cleanup e2b sandbox %s after claim failure: %w; run `crabbox stop --provider e2b --id %s --reclaim` to retry cleanup", sandbox.SandboxID, cleanupErr, sandbox.SandboxID)
 			fmt.Fprintf(b.rt.Stderr, "warning: %v\n", leakErr)
@@ -394,27 +390,27 @@ func (b *e2bBackend) deleteSandboxForCleanup(client e2bAPI, sandboxID string) er
 }
 
 func e2bCleanupCommand(leaseID string) string {
-	return fmt.Sprintf("crabbox stop --provider %s --id %s", e2bProvider, shellQuote(leaseID))
+	return fmt.Sprintf("crabbox stop --provider %s --id %s", e2bProvider, core.ShellQuote(leaseID))
 }
 
-func (b *e2bBackend) resolveStopTarget(ctx context.Context, client e2bAPI, id string) (LeaseClaim, e2bSandbox, error) {
+func (b *e2bBackend) resolveStopTarget(ctx context.Context, client e2bAPI, id string) (core.LeaseClaim, e2bSandbox, error) {
 	if id == "" {
-		return LeaseClaim{}, e2bSandbox{}, exit(2, "provider=e2b requires a Crabbox lease id, slug, or E2B sandbox id")
+		return core.LeaseClaim{}, e2bSandbox{}, core.Exit(2, "provider=e2b requires a Crabbox lease id, slug, or E2B sandbox id")
 	}
 	cfg := e2bClaimConfig(b.cfg)
 	claim, ok, exact, err := resolveLeaseClaimForProviderScopeWithExact(id, providerClaimScope(cfg))
 	if err != nil {
-		return LeaseClaim{}, e2bSandbox{}, err
+		return core.LeaseClaim{}, e2bSandbox{}, err
 	}
 	if exact && !ok {
 		if claim.Provider != e2bProvider {
-			return LeaseClaim{}, e2bSandbox{}, exit(4, "e2b identifier %q is claimed by a different provider", id)
+			return core.LeaseClaim{}, e2bSandbox{}, core.Exit(4, "e2b identifier %q is claimed by a different provider", id)
 		}
-		return LeaseClaim{}, e2bSandbox{}, exit(4, "e2b identifier %q is claimed for a different API endpoint", id)
+		return core.LeaseClaim{}, e2bSandbox{}, core.Exit(4, "e2b identifier %q is claimed for a different API endpoint", id)
 	}
 	if !ok {
 		if strings.HasPrefix(id, "cbx_") {
-			return LeaseClaim{}, e2bSandbox{}, exit(4, "e2b lease %q has no exact local claim", id)
+			return core.LeaseClaim{}, e2bSandbox{}, core.Exit(4, "e2b lease %q has no exact local claim", id)
 		}
 		sandboxID := id
 		if isE2BSyntheticID(id) {
@@ -422,27 +418,27 @@ func (b *e2bBackend) resolveStopTarget(ctx context.Context, client e2bAPI, id st
 		}
 		claim, ok, err = resolveLeaseClaimForProviderCloudIDScope(sandboxID, providerClaimScope(cfg))
 		if err != nil {
-			return LeaseClaim{}, e2bSandbox{}, err
+			return core.LeaseClaim{}, e2bSandbox{}, err
 		}
 		if !ok {
-			return LeaseClaim{}, e2bSandbox{}, exit(4, "e2b sandbox %q has no exact local claim; use --reclaim to adopt it explicitly", id)
+			return core.LeaseClaim{}, e2bSandbox{}, core.Exit(4, "e2b sandbox %q has no exact local claim; use --reclaim to adopt it explicitly", id)
 		}
 	}
 	if claim.ProviderScope != providerClaimScope(cfg) {
-		return LeaseClaim{}, e2bSandbox{}, exit(4, "e2b lease %q belongs to a different API endpoint; use --reclaim with the exact sandbox id to adopt it", claim.LeaseID)
+		return core.LeaseClaim{}, e2bSandbox{}, core.Exit(4, "e2b lease %q belongs to a different API endpoint; use --reclaim with the exact sandbox id to adopt it", claim.LeaseID)
 	}
 	if strings.TrimSpace(claim.CloudID) == "" {
-		return LeaseClaim{}, e2bSandbox{}, exit(4, "e2b lease %q has a legacy claim not bound to an exact sandbox; use --reclaim with the exact sandbox id to adopt it", claim.LeaseID)
+		return core.LeaseClaim{}, e2bSandbox{}, core.Exit(4, "e2b lease %q has a legacy claim not bound to an exact sandbox; use --reclaim with the exact sandbox id to adopt it", claim.LeaseID)
 	}
 	sandbox, err := client.GetSandbox(ctx, claim.CloudID)
 	if err != nil {
 		if isNotFoundError(err) {
-			return LeaseClaim{}, e2bSandbox{}, &e2bClaimedSandboxMissingError{claim: claim}
+			return core.LeaseClaim{}, e2bSandbox{}, &e2bClaimedSandboxMissingError{claim: claim}
 		}
-		return LeaseClaim{}, e2bSandbox{}, e2bError("get sandbox", err)
+		return core.LeaseClaim{}, e2bSandbox{}, e2bError("get sandbox", err)
 	}
 	if err := validateE2BClaim(cfg, claim, sandbox); err != nil {
-		return LeaseClaim{}, e2bSandbox{}, err
+		return core.LeaseClaim{}, e2bSandbox{}, err
 	}
 	return claim, sandbox, nil
 }
@@ -454,12 +450,12 @@ func (b *e2bBackend) deleteClaimedSandbox(ctx context.Context, client e2bAPI, le
 		return err
 	}
 	if !ok || !exact {
-		return exit(4, "e2b lease %q has no exact local claim; refusing deletion", leaseID)
+		return core.Exit(4, "e2b lease %q has no exact local claim; refusing deletion", leaseID)
 	}
 	if claim.ProviderScope != providerClaimScope(cfg) || claim.CloudID != sandboxID {
-		return exit(4, "e2b lease %q is not bound to sandbox %q on this API endpoint; refusing deletion", leaseID, sandboxID)
+		return core.Exit(4, "e2b lease %q is not bound to sandbox %q on this API endpoint; refusing deletion", leaseID, sandboxID)
 	}
-	return removeLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
+	return core.RemoveLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
 		sandbox, err := client.GetSandbox(ctx, sandboxID)
 		if err != nil {
 			if isNotFoundError(err) {
@@ -480,41 +476,41 @@ func (b *e2bBackend) deleteClaimedSandbox(ctx context.Context, client e2bAPI, le
 	})
 }
 
-func validateE2BReclaimCollision(leaseID, sandboxID string, previous LeaseClaim, previousExists bool) error {
+func validateE2BReclaimCollision(leaseID, sandboxID string, previous core.LeaseClaim, previousExists bool) error {
 	if !previousExists {
 		return nil
 	}
 	if previous.Provider != e2bProvider {
-		return exit(4, "e2b lease %q is already claimed by provider %q; refusing reclaim", leaseID, previous.Provider)
+		return core.Exit(4, "e2b lease %q is already claimed by provider %q; refusing reclaim", leaseID, previous.Provider)
 	}
 	if previous.CloudID != "" && previous.CloudID != sandboxID {
-		return exit(4, "e2b lease %q is already bound to sandbox %q; refusing retarget to %q", leaseID, previous.CloudID, sandboxID)
+		return core.Exit(4, "e2b lease %q is already bound to sandbox %q; refusing retarget to %q", leaseID, previous.CloudID, sandboxID)
 	}
 	return nil
 }
 
 type e2bClaimedSandboxMissingError struct {
-	claim LeaseClaim
+	claim core.LeaseClaim
 }
 
 func (e *e2bClaimedSandboxMissingError) Error() string {
 	return fmt.Sprintf("e2b sandbox %q for lease %q no longer exists", e.claim.CloudID, e.claim.LeaseID)
 }
 
-func validateE2BClaim(cfg Config, claim LeaseClaim, sandbox e2bSandbox) error {
+func validateE2BClaim(cfg core.Config, claim core.LeaseClaim, sandbox e2bSandbox) error {
 	if claim.Provider != e2bProvider || claim.ProviderScope != providerClaimScope(e2bClaimConfig(cfg)) {
-		return exit(4, "e2b lease %q belongs to a different provider or API endpoint", claim.LeaseID)
+		return core.Exit(4, "e2b lease %q belongs to a different provider or API endpoint", claim.LeaseID)
 	}
 	if claim.CloudID == "" || claim.CloudID != sandbox.SandboxID {
-		return exit(4, "e2b lease %q is not bound to sandbox %q", claim.LeaseID, sandbox.SandboxID)
+		return core.Exit(4, "e2b lease %q is not bound to sandbox %q", claim.LeaseID, sandbox.SandboxID)
 	}
 	if !isCrabboxE2BSandbox(sandbox) || strings.TrimSpace(sandbox.Metadata["lease"]) != claim.LeaseID || strings.TrimSpace(sandbox.Metadata["slug"]) != claim.Slug {
-		return exit(4, "e2b sandbox %q no longer has canonical ownership metadata for lease %q", sandbox.SandboxID, claim.LeaseID)
+		return core.Exit(4, "e2b sandbox %q no longer has canonical ownership metadata for lease %q", sandbox.SandboxID, claim.LeaseID)
 	}
 	return nil
 }
 
-func e2bClaimConfig(cfg Config) Config {
+func e2bClaimConfig(cfg core.Config) core.Config {
 	cfg.Provider = e2bProvider
 	if strings.TrimSpace(cfg.E2B.APIURL) == "" {
 		cfg.E2B.APIURL = core.E2BConfigDefaultAPIURL
@@ -524,15 +520,15 @@ func e2bClaimConfig(cfg Config) Config {
 
 func (b *e2bBackend) resolveSandboxID(ctx context.Context, client e2bAPI, id, repoRoot string, reclaim bool) (string, string, string, error) {
 	if id == "" {
-		return "", "", "", exit(2, "provider=e2b requires a Crabbox lease id, slug, or E2B sandbox id")
+		return "", "", "", core.Exit(2, "provider=e2b requires a Crabbox lease id, slug, or E2B sandbox id")
 	}
-	if claim, ok, err := resolveLeaseClaim(id); err != nil {
+	if claim, ok, err := core.ResolveLeaseClaim(id); err != nil {
 		return "", "", "", err
 	} else if ok && claim.Provider == e2bProvider {
 		if claim.CloudID != "" {
 			cfg := e2bClaimConfig(b.cfg)
 			if claim.ProviderScope != providerClaimScope(cfg) {
-				return "", "", "", exit(4, "e2b lease %q belongs to a different API endpoint", claim.LeaseID)
+				return "", "", "", core.Exit(4, "e2b lease %q belongs to a different API endpoint", claim.LeaseID)
 			}
 			sandbox, err := client.GetSandbox(ctx, claim.CloudID)
 			if err != nil {
@@ -546,9 +542,7 @@ func (b *e2bBackend) resolveSandboxID(ctx context.Context, client e2bAPI, id, re
 					claim.LeaseID,
 					claim.Slug,
 					cfg,
-					e2bSandboxToServer(sandbox),
-					SSHTarget{},
-					repoRoot,
+					e2bSandboxToServer(sandbox), core.SSHTarget{}, repoRoot,
 					time.Duration(claim.IdleTimeoutSeconds)*time.Second,
 					reclaim,
 					claim,
@@ -578,7 +572,7 @@ func (b *e2bBackend) resolveSandboxID(ctx context.Context, client e2bAPI, id, re
 			return "", "", "", e2bError("get sandbox", err)
 		}
 		if !isCrabboxE2BSandbox(sandbox) {
-			return "", "", "", exit(4, "e2b sandbox %q is not claimed by Crabbox", id)
+			return "", "", "", core.Exit(4, "e2b sandbox %q is not claimed by Crabbox", id)
 		}
 		leaseID := e2bLeaseID(sandbox)
 		return leaseID, sandbox.SandboxID, e2bSlug(leaseID, sandbox), nil
@@ -598,7 +592,7 @@ func (b *e2bBackend) resolveSandboxID(ctx context.Context, client e2bAPI, id, re
 	if err != nil && !isNotFoundError(err) {
 		return "", "", "", e2bError("get sandbox", err)
 	}
-	return "", "", "", exit(4, "e2b sandbox or claim %q was not found", id)
+	return "", "", "", core.Exit(4, "e2b sandbox or claim %q was not found", id)
 }
 
 func resolveE2BSandboxByLease(ctx context.Context, client e2bAPI, leaseID string) (e2bSandbox, error) {
@@ -611,10 +605,10 @@ func resolveE2BSandboxByLease(ctx context.Context, client e2bAPI, leaseID string
 			return sandbox, nil
 		}
 	}
-	return e2bSandbox{}, exit(4, "e2b lease %q was not found", leaseID)
+	return e2bSandbox{}, core.Exit(4, "e2b lease %q was not found", leaseID)
 }
 
-func e2bSandboxToServer(sandbox e2bSandbox) Server {
+func e2bSandboxToServer(sandbox e2bSandbox) core.Server {
 	labels := map[string]string{}
 	for k, v := range sandbox.Metadata {
 		labels[k] = v
@@ -622,13 +616,13 @@ func e2bSandboxToServer(sandbox e2bSandbox) Server {
 	labels["provider"] = e2bProvider
 	labels["lease"] = e2bLeaseID(sandbox)
 	if labels["slug"] == "" {
-		labels["slug"] = newLeaseSlug(labels["lease"])
+		labels["slug"] = core.NewLeaseSlug(labels["lease"])
 	}
 	labels["target"] = targetLinux
 	if labels["state"] == "" {
 		labels["state"] = sandbox.State
 	}
-	server := Server{
+	server := core.Server{
 		Provider: e2bProvider,
 		CloudID:  sandbox.SandboxID,
 		Name:     sandbox.SandboxID,
@@ -642,9 +636,9 @@ func e2bSandboxToServer(sandbox e2bSandbox) Server {
 	return server
 }
 
-func e2bStatusView(leaseID string, sandbox e2bSandbox) statusView {
+func e2bStatusView(leaseID string, sandbox e2bSandbox) core.StatusView {
 	server := e2bSandboxToServer(sandbox)
-	return statusView{
+	return core.StatusView{
 		ID:         leaseID,
 		Slug:       e2bSlug(leaseID, sandbox),
 		Provider:   e2bProvider,
@@ -678,7 +672,7 @@ func e2bSlug(leaseID string, sandbox e2bSandbox) string {
 	if slug := strings.TrimSpace(sandbox.Metadata["slug"]); slug != "" {
 		return slug
 	}
-	return newLeaseSlug(leaseID)
+	return core.NewLeaseSlug(leaseID)
 }
 
 func isE2BSyntheticID(id string) bool {
@@ -703,7 +697,7 @@ func e2bTimeoutSeconds(ttl time.Duration) int {
 	return durationSecondsCeil(e2bTimeoutDuration(ttl))
 }
 
-func e2bWorkspacePath(cfg Config) string {
+func e2bWorkspacePath(cfg core.Config) string {
 	workdir := strings.TrimSpace(cfg.E2B.Workdir)
 	if workdir == "" {
 		workdir = core.E2BConfigDefaultWorkdir
@@ -744,14 +738,14 @@ func e2bProcessUser(user string) (string, error) {
 		return "", nil
 	}
 	if clean == "." || clean == ".." || strings.ContainsAny(clean, `/\`) || strings.ContainsRune(clean, 0) {
-		return "", exit(2, "invalid e2b.user %q: use a login name, not a path", user)
+		return "", core.Exit(2, "invalid e2b.user %q: use a login name, not a path", user)
 	}
 	return clean, nil
 }
 
-func rejectE2BSyncOptions(req RunRequest) error {
+func rejectE2BSyncOptions(req core.RunRequest) error {
 	if req.ChecksumSync {
-		return exit(2, "%s uses E2B archive sync; --checksum is not supported", e2bProvider)
+		return core.Exit(2, "%s uses E2B archive sync; --checksum is not supported", e2bProvider)
 	}
 	return nil
 }

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -131,7 +131,7 @@ func TestE2BProcessStreamRedactsReflectedCredential(t *testing.T) {
 }
 
 func TestE2BDefaultHTTPClientsSeparateControlAndDataPlanes(t *testing.T) {
-	api, err := newE2BClient(Config{E2B: E2BConfig{APIKey: "e2b_test"}}, Runtime{})
+	api, err := newE2BClient(core.Config{E2B: core.E2BConfig{APIKey: "e2b_test"}}, core.Runtime{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestE2BInjectedHTTPClientIsPreservedForBothPlanes(t *testing.T) {
 		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
 		Timeout:       17 * time.Second,
 	}
-	api, err := newE2BClient(Config{E2B: E2BConfig{APIKey: "e2b_test"}}, Runtime{HTTP: injected})
+	api, err := newE2BClient(core.Config{E2B: core.E2BConfig{APIKey: "e2b_test"}}, core.Runtime{HTTP: injected})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -342,7 +342,7 @@ func TestValidateE2BAPIURL(t *testing.T) {
 }
 
 func TestE2BFlagsPreserveExactGuardAndDeferredValidation(t *testing.T) {
-	cfg := Config{Provider: "e2b"}
+	cfg := core.Config{Provider: "e2b"}
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	values := RegisterE2BProviderFlags(fs, cfg)
 	fs.VisitAll(func(f *flag.Flag) {
@@ -350,7 +350,7 @@ func TestE2BFlagsPreserveExactGuardAndDeferredValidation(t *testing.T) {
 			t.Fatal("API key flag introduced")
 		}
 	})
-	cfg.E2B = E2BConfig{APIURL: "https://example.invalid/api", Domain: "example.invalid", Template: "custom", Workdir: "work", User: "alice"}
+	cfg.E2B = core.E2BConfig{APIURL: "https://example.invalid/api", Domain: "example.invalid", Template: "custom", Workdir: "work", User: "alice"}
 	before := cfg
 	if err := ApplyE2BProviderFlags(&cfg, fs, values); err != nil {
 		t.Fatal(err)
@@ -361,7 +361,7 @@ func TestE2BFlagsPreserveExactGuardAndDeferredValidation(t *testing.T) {
 	if err := fs.Parse([]string{"--e2b-api-url=https://example.invalid/api", "--e2b-domain=example.invalid", "--e2b-template=custom", "--e2b-workdir=work", "--e2b-user=alice"}); err != nil {
 		t.Fatal(err)
 	}
-	cfg.E2B = E2BConfig{}
+	cfg.E2B = core.E2BConfig{}
 	if err := ApplyE2BProviderFlags(&cfg, fs, values); err != nil {
 		t.Fatal(err)
 	}
@@ -376,15 +376,15 @@ func TestE2BFlagsPreserveExactGuardAndDeferredValidation(t *testing.T) {
 	if err := ApplyE2BProviderFlags(&cfg, fs, values); err != nil {
 		t.Fatal("wrapper added client validation")
 	}
-	before.E2B = E2BConfig{}
+	before.E2B = core.E2BConfig{}
 	if !reflect.DeepEqual(cfg, before) {
 		t.Fatal("explicit empty values or central provenance side effects changed")
 	}
-	if _, err := (Provider{}).Configure(cfg, Runtime{}); err != nil {
+	if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err != nil {
 		t.Fatalf("Configure added client validation: %v", err)
 	}
 	for _, name := range []string{"e2b", "E2B", " e2b "} {
-		cfg := Config{Provider: name}
+		cfg := core.Config{Provider: name}
 		fs := flag.NewFlagSet("guard", flag.ContinueOnError)
 		fs.String("class", "", "")
 		fs.String("type", "", "")
@@ -415,9 +415,9 @@ func TestE2BFlagsPreserveExactGuardAndDeferredValidation(t *testing.T) {
 
 func TestE2BConfiguredEndpointDefaultsAndRawScope(t *testing.T) {
 	for _, raw := range []string{"", "  ", " https://example.invalid/api/ "} {
-		cfg := Config{E2B: E2BConfig{APIKey: "inert", APIURL: raw}}
+		cfg := core.Config{E2B: core.E2BConfig{APIKey: "inert", APIURL: raw}}
 		before := cfg.E2B
-		api, err := newE2BClient(cfg, Runtime{HTTP: &http.Client{}})
+		api, err := newE2BClient(cfg, core.Runtime{HTTP: &http.Client{}})
 		if raw == "  " {
 			if err == nil {
 				t.Fatal("whitespace client endpoint unexpectedly defaulted")
@@ -454,8 +454,8 @@ func TestE2BConfiguredEndpointDefaultsAndRawScope(t *testing.T) {
 		}
 	}
 	for _, raw := range []string{"", "  ", " sandbox.example.invalid "} {
-		cfg := Config{E2B: E2BConfig{APIKey: "inert", APIURL: "https://example.invalid/api", Domain: raw, User: " alice "}}
-		api, err := newE2BClient(cfg, Runtime{HTTP: &http.Client{}})
+		cfg := core.Config{E2B: core.E2BConfig{APIKey: "inert", APIURL: "https://example.invalid/api", Domain: raw, User: " alice "}}
+		api, err := newE2BClient(cfg, core.Runtime{HTTP: &http.Client{}})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -468,11 +468,11 @@ func TestE2BConfiguredEndpointDefaultsAndRawScope(t *testing.T) {
 		}
 	}
 	for _, rawKey := range []string{"", "  "} {
-		if _, err := newE2BClient(Config{E2B: E2BConfig{APIKey: rawKey, APIURL: "relative"}}, Runtime{HTTP: &http.Client{}}); err == nil || err.Error() != "provider=e2b requires E2B_API_KEY" {
+		if _, err := newE2BClient(core.Config{E2B: core.E2BConfig{APIKey: rawKey, APIURL: "relative"}}, core.Runtime{HTTP: &http.Client{}}); err == nil || err.Error() != "provider=e2b requires E2B_API_KEY" {
 			t.Fatalf("key-first=%v", err)
 		}
 	}
-	cfg := Config{E2B: E2BConfig{APIURL: "https://example.invalid/api", Domain: " sandbox.example.invalid ", User: " alice ", Workdir: " project "}}
+	cfg := core.Config{E2B: core.E2BConfig{APIURL: "https://example.invalid/api", Domain: " sandbox.example.invalid ", User: " alice ", Workdir: " project "}}
 	got := (Provider{}).CommandRouting(cfg, core.CommandRoutingRequest{}).Args
 	want := []string{"--e2b-api-url", "https://example.invalid/api", "--e2b-domain", " sandbox.example.invalid ", "--e2b-user", " alice ", "--e2b-workdir", " project "}
 	if !reflect.DeepEqual(got, want) {
@@ -487,9 +487,9 @@ func TestE2BTemplateAcquisitionAndMetadataDefaultAreDistinct(t *testing.T) {
 			cfg := core.BaseConfig()
 			cfg.Provider = "e2b"
 			cfg.E2B.Template = raw
-			b := &e2bBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+			b := &e2bBackend{cfg: cfg, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
 			fake := &fakeE2BSyncClient{}
-			_, sandbox, _, err := b.createSandbox(context.Background(), fake, Repo{Name: "example", Root: t.TempDir()}, false, false, "")
+			_, sandbox, _, err := b.createSandbox(context.Background(), fake, core.Repo{Name: "example", Root: t.TempDir()}, false, false, "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -508,22 +508,22 @@ func TestE2BTemplateAcquisitionAndMetadataDefaultAreDistinct(t *testing.T) {
 }
 
 func TestE2BWorkspacePath(t *testing.T) {
-	if got := e2bWorkspacePath(Config{E2B: E2BConfig{User: " alice ", Workdir: "  "}}); got != "/home/alice/crabbox" {
+	if got := e2bWorkspacePath(core.Config{E2B: core.E2BConfig{User: " alice ", Workdir: "  "}}); got != "/home/alice/crabbox" {
 		t.Fatalf("whitespace/default workspace=%q", got)
 	}
-	if got := e2bWorkspacePath(Config{}); got != "/home/user/crabbox" {
+	if got := e2bWorkspacePath(core.Config{}); got != "/home/user/crabbox" {
 		t.Fatalf("workspace=%q", got)
 	}
-	if got := e2bWorkspacePath(Config{E2B: E2BConfig{Workdir: "repo"}}); got != "/home/user/repo" {
+	if got := e2bWorkspacePath(core.Config{E2B: core.E2BConfig{Workdir: "repo"}}); got != "/home/user/repo" {
 		t.Fatalf("workspace=%q", got)
 	}
-	if got := e2bWorkspacePath(Config{E2B: E2BConfig{User: "ubuntu", Workdir: "repo"}}); got != "/home/ubuntu/repo" {
+	if got := e2bWorkspacePath(core.Config{E2B: core.E2BConfig{User: "ubuntu", Workdir: "repo"}}); got != "/home/ubuntu/repo" {
 		t.Fatalf("workspace=%q", got)
 	}
-	if got := e2bWorkspacePath(Config{E2B: E2BConfig{User: "root", Workdir: "repo"}}); got != "/root/repo" {
+	if got := e2bWorkspacePath(core.Config{E2B: core.E2BConfig{User: "root", Workdir: "repo"}}); got != "/root/repo" {
 		t.Fatalf("workspace=%q", got)
 	}
-	if got := e2bWorkspacePath(Config{E2B: E2BConfig{Workdir: "/work/repo"}}); got != "/work/repo" {
+	if got := e2bWorkspacePath(core.Config{E2B: core.E2BConfig{Workdir: "/work/repo"}}); got != "/work/repo" {
 		t.Fatalf("workspace=%q", got)
 	}
 }
@@ -563,10 +563,10 @@ func TestE2BProcessUser(t *testing.T) {
 
 func TestE2BWarmupRejectsUnsafeUserBeforeClient(t *testing.T) {
 	backend := &e2bBackend{
-		cfg: Config{E2B: E2BConfig{User: "../tmp"}},
-		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		cfg: core.Config{E2B: core.E2BConfig{User: "../tmp"}},
+		rt:  core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 	}
-	err := backend.Warmup(context.Background(), WarmupRequest{})
+	err := backend.Warmup(context.Background(), core.WarmupRequest{})
 	if err == nil || !strings.Contains(err.Error(), "invalid e2b.user") {
 		t.Fatalf("err=%v, want invalid e2b.user", err)
 	}
@@ -631,7 +631,7 @@ func TestE2BClientBindsObservedSandboxID(t *testing.T) {
 					_ = json.NewEncoder(w).Encode(map[string]any{"sandboxID": observed, "alias": "different-template-alias", "envdAccessToken": "synthetic-envd-token", "domain": "sandbox.example.test"})
 				}))
 				defer server.Close()
-				client, err := newE2BClient(Config{E2B: E2BConfig{APIKey: "synthetic-api-token", APIURL: server.URL}}, Runtime{HTTP: server.Client()})
+				client, err := newE2BClient(core.Config{E2B: core.E2BConfig{APIKey: "synthetic-api-token", APIURL: server.URL}}, core.Runtime{HTTP: server.Client()})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -722,7 +722,7 @@ func TestE2BClientCreateConnectListAndDeleteUseOfficialRESTShape(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	api, err := newE2BClient(Config{E2B: E2BConfig{APIKey: "e2b_test", APIURL: srv.URL}}, Runtime{HTTP: srv.Client()})
+	api, err := newE2BClient(core.Config{E2B: core.E2BConfig{APIKey: "e2b_test", APIURL: srv.URL}}, core.Runtime{HTTP: srv.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -777,7 +777,7 @@ func TestE2BAPIClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
 	}))
 	defer trusted.Close()
 
-	api, err := newE2BClient(Config{E2B: E2BConfig{APIKey: "e2b_test", APIURL: trusted.URL}}, Runtime{HTTP: trusted.Client()})
+	api, err := newE2BClient(core.Config{E2B: core.E2BConfig{APIKey: "e2b_test", APIURL: trusted.URL}}, core.Runtime{HTTP: trusted.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -839,7 +839,7 @@ func TestE2BClientFollowsSameOriginRedirect(t *testing.T) {
 	}))
 	defer server.Close()
 
-	api, err := newE2BClient(Config{E2B: E2BConfig{APIKey: "e2b_test", APIURL: server.URL}}, Runtime{HTTP: server.Client()})
+	api, err := newE2BClient(core.Config{E2B: core.E2BConfig{APIKey: "e2b_test", APIURL: server.URL}}, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -864,7 +864,7 @@ func TestE2BClientPreservesCallerRedirectPolicy(t *testing.T) {
 		callerChecks++
 		return callerErr
 	}
-	api, err := newE2BClient(Config{E2B: E2BConfig{APIKey: "e2b_test", APIURL: server.URL}}, Runtime{HTTP: httpClient})
+	api, err := newE2BClient(core.Config{E2B: core.E2BConfig{APIKey: "e2b_test", APIURL: server.URL}}, core.Runtime{HTTP: httpClient})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -907,12 +907,12 @@ func TestE2BSyncWorkspaceUploadsRepoArchive(t *testing.T) {
 	}
 	client := &fakeE2BSyncClient{}
 	backend := &e2bBackend{
-		cfg: Config{E2B: E2BConfig{User: "ubuntu", Workdir: "repo"}},
-		rt:  Runtime{Stderr: io.Discard},
+		cfg: core.Config{E2B: core.E2BConfig{User: "ubuntu", Workdir: "repo"}},
+		rt:  core.Runtime{Stderr: io.Discard},
 	}
 	workspace := e2bWorkspacePath(backend.cfg)
-	_, _, err := backend.syncWorkspace(context.Background(), client, e2bSession{SandboxID: "sbx_1"}, RunRequest{
-		Repo: Repo{Root: root, Name: "repo"},
+	_, _, err := backend.syncWorkspace(context.Background(), client, e2bSession{SandboxID: "sbx_1"}, core.RunRequest{
+		Repo: core.Repo{Root: root, Name: "repo"},
 	}, workspace)
 	if err != nil {
 		t.Fatal(err)
@@ -949,12 +949,12 @@ func TestE2BSyncWorkspaceCleansRemoteArchiveWhenExtractFails(t *testing.T) {
 	}
 	client := &fakeE2BSyncClient{processCodes: []int{0, 7, 0}}
 	backend := &e2bBackend{
-		cfg: Config{E2B: E2BConfig{User: "ubuntu", Workdir: "repo"}},
-		rt:  Runtime{Stderr: io.Discard},
+		cfg: core.Config{E2B: core.E2BConfig{User: "ubuntu", Workdir: "repo"}},
+		rt:  core.Runtime{Stderr: io.Discard},
 	}
 	workspace := e2bWorkspacePath(backend.cfg)
-	_, _, err := backend.syncWorkspace(context.Background(), client, e2bSession{SandboxID: "sbx_1"}, RunRequest{
-		Repo: Repo{Root: root, Name: "repo"},
+	_, _, err := backend.syncWorkspace(context.Background(), client, e2bSession{SandboxID: "sbx_1"}, core.RunRequest{
+		Repo: core.Repo{Root: root, Name: "repo"},
 	}, workspace)
 	if err == nil {
 		t.Fatalf("expected extract failure")
@@ -992,11 +992,11 @@ func TestE2BSyncDeletePreservesWorkspaceWhenReplacementFails(t *testing.T) {
 				failExtract:  tc.failExtract,
 				executeShell: true,
 			}
-			backend := &e2bBackend{rt: Runtime{Stderr: io.Discard}}
+			backend := &e2bBackend{rt: core.Runtime{Stderr: io.Discard}}
 			backend.cfg.Sync.Delete = true
 
-			_, _, err := backend.syncWorkspace(t.Context(), client, e2bSession{SandboxID: "sbx_1"}, RunRequest{
-				Repo: Repo{Root: root, Name: "repo"},
+			_, _, err := backend.syncWorkspace(t.Context(), client, e2bSession{SandboxID: "sbx_1"}, core.RunRequest{
+				Repo: core.Repo{Root: root, Name: "repo"},
 			}, workspace)
 			if err == nil {
 				t.Fatal("sync unexpectedly succeeded")
@@ -1018,12 +1018,12 @@ func TestE2BSyncDeletePreservesWorkspaceWhenReplacementFails(t *testing.T) {
 func TestE2BSyncWorkspaceHonorsConfiguredTimeout(t *testing.T) {
 	root := newE2BSyncTestRepo(t)
 	client := &fakeE2BSyncClient{uploadWaitForCancel: true}
-	backend := &e2bBackend{rt: Runtime{Stderr: io.Discard}}
+	backend := &e2bBackend{rt: core.Runtime{Stderr: io.Discard}}
 	backend.cfg.Sync.Timeout = 500 * time.Millisecond
 	started := time.Now()
 
-	_, _, err := backend.syncWorkspace(t.Context(), client, e2bSession{SandboxID: "sbx_1"}, RunRequest{
-		Repo: Repo{Root: root, Name: "repo"},
+	_, _, err := backend.syncWorkspace(t.Context(), client, e2bSession{SandboxID: "sbx_1"}, core.RunRequest{
+		Repo: core.Repo{Root: root, Name: "repo"},
 	}, "/home/user/repo")
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("sync err=%v, want deadline exceeded", err)
@@ -1041,11 +1041,11 @@ func TestE2BSyncWorkspaceHonorsConfiguredTimeout(t *testing.T) {
 
 func TestE2BPrepareWorkspaceRejectsUnsafePath(t *testing.T) {
 	client := &fakeE2BSyncClient{}
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Sync.Delete = true
 	backend := &e2bBackend{
 		cfg: cfg,
-		rt:  Runtime{Stderr: io.Discard},
+		rt:  core.Runtime{Stderr: io.Discard},
 	}
 	err := backend.prepareWorkspace(context.Background(), client, e2bSession{SandboxID: "sbx_1"}, "/")
 	if err == nil || !strings.Contains(err.Error(), "too broad") {
@@ -1059,10 +1059,10 @@ func TestE2BPrepareWorkspaceRejectsUnsafePath(t *testing.T) {
 func TestE2BCreateSandboxRejectsUnsafeWorkdirBeforeAPI(t *testing.T) {
 	client := &fakeE2BSyncClient{}
 	backend := &e2bBackend{
-		cfg: Config{E2B: E2BConfig{Workdir: "/"}},
-		rt:  Runtime{Stderr: io.Discard},
+		cfg: core.Config{E2B: core.E2BConfig{Workdir: "/"}},
+		rt:  core.Runtime{Stderr: io.Discard},
 	}
-	_, _, _, err := backend.createSandbox(context.Background(), client, Repo{}, false, false, "")
+	_, _, _, err := backend.createSandbox(context.Background(), client, core.Repo{}, false, false, "")
 	if err == nil || !strings.Contains(err.Error(), "too broad") {
 		t.Fatalf("err=%v, want unsafe workspace error", err)
 	}
@@ -1096,10 +1096,10 @@ func TestE2BStatusWaitBoundsInFlightSandboxLookup(t *testing.T) {
 			restore := swapNewE2BClient(client)
 			defer restore()
 			backend := &e2bBackend{
-				cfg: Config{E2B: E2BConfig{APIURL: "https://api.example.test", Template: "base"}},
-				rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+				cfg: core.Config{E2B: core.E2BConfig{APIURL: "https://api.example.test", Template: "base"}},
+				rt:  core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 			}
-			leaseID, _, _, err := backend.createSandbox(t.Context(), client, Repo{Root: t.TempDir()}, true, false, "")
+			leaseID, _, _, err := backend.createSandbox(t.Context(), client, core.Repo{Root: t.TempDir()}, true, false, "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1107,8 +1107,8 @@ func TestE2BStatusWaitBoundsInFlightSandboxLookup(t *testing.T) {
 			client.getWaitAfterCalls = tc.getWaitAfterCalls
 			started := time.Now()
 
-			_, err = backend.Status(t.Context(), StatusRequest{ID: leaseID, Wait: true, WaitTimeout: 30 * time.Millisecond})
-			var exitErr ExitError
+			_, err = backend.Status(t.Context(), core.StatusRequest{ID: leaseID, Wait: true, WaitTimeout: 30 * time.Millisecond})
+			var exitErr core.ExitError
 			if !errors.As(err, &exitErr) || exitErr.Code != 5 || !strings.Contains(err.Error(), "timed out waiting for sandbox") {
 				t.Fatalf("status err=%v, want sandbox wait timeout with exit code 5", err)
 			}
@@ -1135,14 +1135,14 @@ func TestE2BCreateSandboxCapsDefaultTTL(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	client := &fakeE2BSyncClient{}
 	backend := &e2bBackend{
-		cfg: Config{
+		cfg: core.Config{
 			TTL:         90 * time.Minute,
 			IdleTimeout: 30 * time.Minute,
-			E2B:         E2BConfig{Template: "base"},
+			E2B:         core.E2BConfig{Template: "base"},
 		},
-		rt: Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 	}
-	_, _, _, err := backend.createSandbox(context.Background(), client, Repo{Root: t.TempDir(), Name: "repo"}, true, false, "")
+	_, _, _, err := backend.createSandbox(context.Background(), client, core.Repo{Root: t.TempDir(), Name: "repo"}, true, false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1156,7 +1156,7 @@ func TestE2BCreateSandboxCapsDefaultTTL(t *testing.T) {
 
 func TestE2BCreateSandboxReportsCleanupFailureAfterClaimFailure(t *testing.T) {
 	origClaim := claimLeaseTargetForRepoConfig
-	claimLeaseTargetForRepoConfig = func(_, _ string, _ Config, _ Server, _ SSHTarget, _ string, _ time.Duration, _ bool) error {
+	claimLeaseTargetForRepoConfig = func(_, _ string, _ core.Config, _ core.Server, _ core.SSHTarget, _ string, _ time.Duration, _ bool) error {
 		return errors.New("claim write failed")
 	}
 	t.Cleanup(func() { claimLeaseTargetForRepoConfig = origClaim })
@@ -1164,10 +1164,10 @@ func TestE2BCreateSandboxReportsCleanupFailureAfterClaimFailure(t *testing.T) {
 	client := &fakeE2BSyncClient{deleteErr: errors.New("delete failed")}
 	var stderr bytes.Buffer
 	backend := &e2bBackend{
-		cfg: Config{E2B: E2BConfig{Template: "base"}},
-		rt:  Runtime{Stdout: io.Discard, Stderr: &stderr},
+		cfg: core.Config{E2B: core.E2BConfig{Template: "base"}},
+		rt:  core.Runtime{Stdout: io.Discard, Stderr: &stderr},
 	}
-	_, _, _, err := backend.createSandbox(context.Background(), client, Repo{Root: t.TempDir(), Name: "repo"}, false, false, "")
+	_, _, _, err := backend.createSandbox(context.Background(), client, core.Repo{Root: t.TempDir(), Name: "repo"}, false, false, "")
 	if err == nil {
 		t.Fatal("expected claim failure")
 	}
@@ -1198,16 +1198,16 @@ func TestE2BRunReturnsSessionHandleForKeptSandbox(t *testing.T) {
 	restore := swapNewE2BClient(client)
 	defer restore()
 	backend := &e2bBackend{
-		cfg: Config{
+		cfg: core.Config{
 			IdleTimeout: 30 * time.Minute,
 			TTL:         2 * time.Minute,
-			E2B:         E2BConfig{APIKey: "test", Workdir: "repo"},
+			E2B:         core.E2BConfig{APIKey: "test", Workdir: "repo"},
 		},
-		rt: Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 	}
 
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "repo", Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "repo", Root: t.TempDir()},
 		Command: []string{"true"},
 		Keep:    true,
 		NoSync:  true,
@@ -1222,7 +1222,7 @@ func TestE2BRunReturnsSessionHandleForKeptSandbox(t *testing.T) {
 	if got.Provider != e2bProvider || got.LeaseID == "" || got.Slug == "" || got.Reused || !got.Kept {
 		t.Fatalf("session=%#v", got)
 	}
-	if got.CleanupCommand != "crabbox stop --provider e2b --id "+shellQuote(got.LeaseID) {
+	if got.CleanupCommand != "crabbox stop --provider e2b --id "+core.ShellQuote(got.LeaseID) {
 		t.Fatalf("cleanup command=%q", got.CleanupCommand)
 	}
 	if len(client.deleteIDs) != 0 {
@@ -1237,22 +1237,22 @@ func TestE2BRunReturnsSessionHandleWhenKeepOnFailureRetainsSandbox(t *testing.T)
 	defer restore()
 	var stderr bytes.Buffer
 	backend := &e2bBackend{
-		cfg: Config{
+		cfg: core.Config{
 			IdleTimeout: 30 * time.Minute,
 			TTL:         2 * time.Minute,
-			E2B:         E2BConfig{APIKey: "test", Workdir: "repo"},
+			E2B:         core.E2BConfig{APIKey: "test", Workdir: "repo"},
 		},
-		rt: Runtime{Stdout: io.Discard, Stderr: &stderr},
+		rt: core.Runtime{Stdout: io.Discard, Stderr: &stderr},
 	}
 
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:          Repo{Name: "repo", Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:          core.Repo{Name: "repo", Root: t.TempDir()},
 		Command:       []string{"false"},
 		KeepOnFailure: true,
 		NoSync:        true,
 		TimingJSON:    true,
 	})
-	var ee ExitError
+	var ee core.ExitError
 	if !errors.As(err, &ee) || ee.Code != 7 {
 		t.Fatalf("err=%v want ExitError code 7", err)
 	}
@@ -1300,16 +1300,16 @@ func TestE2BRunKeepOnFailureRetainsSandboxAfterSetupFailure(t *testing.T) {
 			defer restore()
 			var stderr bytes.Buffer
 			backend := &e2bBackend{
-				cfg: Config{
+				cfg: core.Config{
 					IdleTimeout: 30 * time.Minute,
 					TTL:         2 * time.Minute,
-					E2B:         E2BConfig{APIKey: "test", Workdir: "repo"},
+					E2B:         core.E2BConfig{APIKey: "test", Workdir: "repo"},
 				},
-				rt: Runtime{Stdout: io.Discard, Stderr: &stderr},
+				rt: core.Runtime{Stdout: io.Discard, Stderr: &stderr},
 			}
 
-			result, err := backend.Run(t.Context(), RunRequest{
-				Repo:          Repo{Name: "repo", Root: newE2BSyncTestRepo(t)},
+			result, err := backend.Run(t.Context(), core.RunRequest{
+				Repo:          core.Repo{Name: "repo", Root: newE2BSyncTestRepo(t)},
 				Command:       []string{"true"},
 				KeepOnFailure: true,
 				NoSync:        tc.noSync,
@@ -1323,7 +1323,7 @@ func TestE2BRunKeepOnFailureRetainsSandboxAfterSetupFailure(t *testing.T) {
 			if len(client.deleteIDs) != 0 {
 				t.Fatalf("deleted sandbox=%v, want retained sandbox", client.deleteIDs)
 			}
-			if _, exists, claimErr := readLeaseClaimWithPresence(result.Session.LeaseID); claimErr != nil || !exists {
+			if _, exists, claimErr := core.ReadLeaseClaimWithPresence(result.Session.LeaseID); claimErr != nil || !exists {
 				t.Fatalf("retained sandbox claim exists=%t err=%v", exists, claimErr)
 			}
 			if !strings.Contains(stderr.String(), "keep-on-failure") {
@@ -1339,16 +1339,16 @@ func TestE2BRunCleanupUsesExactClaim(t *testing.T) {
 	restore := swapNewE2BClient(client)
 	defer restore()
 	backend := &e2bBackend{
-		cfg: Config{
+		cfg: core.Config{
 			IdleTimeout: 30 * time.Minute,
 			TTL:         2 * time.Minute,
-			E2B:         E2BConfig{APIKey: "test", Workdir: "repo"},
+			E2B:         core.E2BConfig{APIKey: "test", Workdir: "repo"},
 		},
-		rt: Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 	}
 
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "repo", Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "repo", Root: t.TempDir()},
 		Command: []string{"true"},
 		NoSync:  true,
 	})
@@ -1364,7 +1364,7 @@ func TestE2BRunCleanupUsesExactClaim(t *testing.T) {
 	if !client.deleteDeadlineSet {
 		t.Fatal("run cleanup did not use a bounded context")
 	}
-	if _, exists, err := readLeaseClaimWithPresence(result.Session.LeaseID); err != nil || exists {
+	if _, exists, err := core.ReadLeaseClaimWithPresence(result.Session.LeaseID); err != nil || exists {
 		t.Fatalf("cleanup claim exists=%t err=%v", exists, err)
 	}
 }
@@ -1421,16 +1421,16 @@ func TestE2BCreateBindsExactSandboxAndEndpoint(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	client := &fakeE2BSyncClient{}
 	backend := &e2bBackend{
-		cfg: Config{
+		cfg: core.Config{
 			IdleTimeout: 30 * time.Minute,
-			E2B: E2BConfig{
+			E2B: core.E2BConfig{
 				APIURL:   "https://api.example.test/root/",
 				Template: "base",
 			},
 		},
-		rt: Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 	}
-	leaseID, sandbox, _, err := backend.createSandbox(context.Background(), client, Repo{Root: t.TempDir()}, true, false, "")
+	leaseID, sandbox, _, err := backend.createSandbox(context.Background(), client, core.Repo{Root: t.TempDir()}, true, false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1456,8 +1456,8 @@ func TestE2BStopRejectsLabelledButUnclaimedSandbox(t *testing.T) {
 	}}
 	restore := swapNewE2BClient(client)
 	defer restore()
-	backend := &e2bBackend{cfg: e2bClaimConfig(Config{}), rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-	err := backend.Stop(context.Background(), StopRequest{ID: "sbx_unclaimed"})
+	backend := &e2bBackend{cfg: e2bClaimConfig(core.Config{}), rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	err := backend.Stop(context.Background(), core.StopRequest{ID: "sbx_unclaimed"})
 	if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
 		t.Fatalf("Stop err=%v, want exact-claim rejection", err)
 	}
@@ -1472,33 +1472,33 @@ func TestE2BStopChecksLiveOwnershipAndRemovesClaimAtomically(t *testing.T) {
 	restore := swapNewE2BClient(client)
 	defer restore()
 	backend := &e2bBackend{
-		cfg: Config{E2B: E2BConfig{APIURL: "https://api.example.test", Template: "base"}},
-		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		cfg: core.Config{E2B: core.E2BConfig{APIURL: "https://api.example.test", Template: "base"}},
+		rt:  core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 	}
-	leaseID, sandbox, _, err := backend.createSandbox(context.Background(), client, Repo{Root: t.TempDir()}, true, false, "")
+	leaseID, sandbox, _, err := backend.createSandbox(context.Background(), client, core.Repo{Root: t.TempDir()}, true, false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	client.sandbox.Metadata["lease"] = "cbx_ffffffffffff"
-	err = backend.Stop(context.Background(), StopRequest{ID: leaseID})
+	err = backend.Stop(context.Background(), core.StopRequest{ID: leaseID})
 	if err == nil || !strings.Contains(err.Error(), "no longer has canonical ownership metadata") {
 		t.Fatalf("mismatched Stop err=%v", err)
 	}
 	if len(client.deleteIDs) != 0 {
 		t.Fatalf("mismatched Stop deleted %#v", client.deleteIDs)
 	}
-	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || !exists {
+	if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || !exists {
 		t.Fatalf("mismatched Stop lost recovery claim: exists=%t err=%v", exists, err)
 	}
 
 	client.sandbox.Metadata["lease"] = leaseID
-	if err := backend.Stop(context.Background(), StopRequest{ID: leaseID}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: leaseID}); err != nil {
 		t.Fatalf("Stop exact claim: %v", err)
 	}
 	if len(client.deleteIDs) != 1 || client.deleteIDs[0] != sandbox.SandboxID {
 		t.Fatalf("deleteIDs=%#v", client.deleteIDs)
 	}
-	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
+	if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
 		t.Fatalf("successful Stop claim exists=%t err=%v", exists, err)
 	}
 }
@@ -1509,21 +1509,21 @@ func TestE2BStopRetainsClaimWhenDeleteFails(t *testing.T) {
 	restore := swapNewE2BClient(client)
 	defer restore()
 	backend := &e2bBackend{
-		cfg: Config{E2B: E2BConfig{APIURL: "https://api.example.test", Template: "base"}},
-		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		cfg: core.Config{E2B: core.E2BConfig{APIURL: "https://api.example.test", Template: "base"}},
+		rt:  core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 	}
-	leaseID, sandbox, _, err := backend.createSandbox(context.Background(), client, Repo{Root: t.TempDir()}, true, false, "")
+	leaseID, sandbox, _, err := backend.createSandbox(context.Background(), client, core.Repo{Root: t.TempDir()}, true, false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = backend.Stop(context.Background(), StopRequest{ID: leaseID})
+	err = backend.Stop(context.Background(), core.StopRequest{ID: leaseID})
 	if err == nil || !strings.Contains(err.Error(), "delete failed") {
 		t.Fatalf("Stop err=%v, want delete failure", err)
 	}
 	if len(client.deleteIDs) != 1 || client.deleteIDs[0] != sandbox.SandboxID {
 		t.Fatalf("deleteIDs=%#v", client.deleteIDs)
 	}
-	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || !exists {
+	if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || !exists {
 		t.Fatalf("failed Stop lost recovery claim: exists=%t err=%v", exists, err)
 	}
 }
@@ -1532,10 +1532,10 @@ func TestE2BStopRejectsDifferentAPIEndpointBeforeRemoteRead(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	client := &fakeE2BSyncClient{}
 	creator := &e2bBackend{
-		cfg: Config{E2B: E2BConfig{APIURL: "https://api-a.example.test", Template: "base"}},
-		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		cfg: core.Config{E2B: core.E2BConfig{APIURL: "https://api-a.example.test", Template: "base"}},
+		rt:  core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 	}
-	leaseID, _, _, err := creator.createSandbox(context.Background(), client, Repo{Root: t.TempDir()}, true, false, "")
+	leaseID, _, _, err := creator.createSandbox(context.Background(), client, core.Repo{Root: t.TempDir()}, true, false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1543,10 +1543,10 @@ func TestE2BStopRejectsDifferentAPIEndpointBeforeRemoteRead(t *testing.T) {
 	restore := swapNewE2BClient(client)
 	defer restore()
 	other := &e2bBackend{
-		cfg: Config{E2B: E2BConfig{APIURL: "https://api-b.example.test"}},
-		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		cfg: core.Config{E2B: core.E2BConfig{APIURL: "https://api-b.example.test"}},
+		rt:  core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 	}
-	err = other.Stop(context.Background(), StopRequest{ID: leaseID})
+	err = other.Stop(context.Background(), core.StopRequest{ID: leaseID})
 	if err == nil || !strings.Contains(err.Error(), "different API endpoint") {
 		t.Fatalf("Stop err=%v, want endpoint rejection", err)
 	}
@@ -1568,14 +1568,14 @@ func TestE2BReclaimAndStopAdoptsExactSandbox(t *testing.T) {
 	}}
 	restore := swapNewE2BClient(client)
 	defer restore()
-	backend := &e2bBackend{cfg: e2bClaimConfig(Config{}), rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-	if err := backend.ReclaimAndStop(context.Background(), StopRequest{ID: "sbx_reclaim"}); err != nil {
+	backend := &e2bBackend{cfg: e2bClaimConfig(core.Config{}), rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	if err := backend.ReclaimAndStop(context.Background(), core.StopRequest{ID: "sbx_reclaim"}); err != nil {
 		t.Fatalf("ReclaimAndStop: %v", err)
 	}
 	if len(client.deleteIDs) != 1 || client.deleteIDs[0] != "sbx_reclaim" {
 		t.Fatalf("deleteIDs=%#v", client.deleteIDs)
 	}
-	if _, exists, err := readLeaseClaimWithPresence("cbx_123456789abc"); err != nil || exists {
+	if _, exists, err := core.ReadLeaseClaimWithPresence("cbx_123456789abc"); err != nil || exists {
 		t.Fatalf("successful reclaim claim exists=%t err=%v", exists, err)
 	}
 }
@@ -1610,7 +1610,7 @@ type fakeE2BSyncClient struct {
 
 func swapNewE2BClient(fake e2bAPI) func() {
 	prev := newE2BClient
-	newE2BClient = func(Config, Runtime) (e2bAPI, error) { return fake, nil }
+	newE2BClient = func(core.Config, core.Runtime) (e2bAPI, error) { return fake, nil }
 	return func() { newE2BClient = prev }
 }
 
@@ -1739,10 +1739,10 @@ func TestE2BRunLifecycleArchiveGuardrailBeforeCreation(t *testing.T) {
 	client := &fakeE2BSyncClient{}
 	restore := swapNewE2BClient(client)
 	defer restore()
-	backend := &e2bBackend{cfg: Config{E2B: E2BConfig{Workdir: "repo"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	backend := &e2bBackend{cfg: core.Config{E2B: core.E2BConfig{Workdir: "repo"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
 	backend.cfg.Sync.FailFiles = 1
-	result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: newE2BSyncTestRepo(t)}, Command: []string{"true"}})
-	var ee ExitError
+	result, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Name: "repo", Root: newE2BSyncTestRepo(t)}, Command: []string{"true"}})
+	var ee core.ExitError
 	if !errors.As(err, &ee) || ee.Code != 6 || result.ExitCode != 6 || client.createCalls != 0 || result.Session != nil {
 		t.Fatalf("result=%#v err=%v creates=%d", result, err, client.createCalls)
 	}
@@ -1756,17 +1756,17 @@ func TestE2BRunLifecycleCleanupOutcomeAndTiming(t *testing.T) {
 			restore := swapNewE2BClient(client)
 			defer restore()
 			var stderr bytes.Buffer
-			backend := &e2bBackend{cfg: Config{TTL: time.Minute, E2B: E2BConfig{Workdir: "repo"}}, rt: Runtime{Stdout: io.Discard, Stderr: &stderr}}
-			result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, TimingJSON: true})
+			backend := &e2bBackend{cfg: core.Config{TTL: time.Minute, E2B: core.E2BConfig{Workdir: "repo"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: &stderr}}
+			result, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, TimingJSON: true})
 			wantCode, wantKind := code, core.RunErrorCommandExit
 			if code == 0 {
 				wantCode, wantKind = 1, core.RunErrorProvider
 			}
-			var ee ExitError
+			var ee core.ExitError
 			if !errors.As(err, &ee) || ee.Code != wantCode || result.ExitCode != wantCode || result.ErrorKind != wantKind || result.Session == nil || !result.Session.Kept || len(client.deleteIDs) != 1 || !client.deleteDeadlineSet {
 				t.Fatalf("result=%#v err=%v deletes=%v", result, err, client.deleteIDs)
 			}
-			if _, exists, claimErr := readLeaseClaimWithPresence(result.LeaseID); claimErr != nil || !exists {
+			if _, exists, claimErr := core.ReadLeaseClaimWithPresence(result.LeaseID); claimErr != nil || !exists {
 				t.Fatalf("cleanup failure lost claim: exists=%t err=%v", exists, claimErr)
 			}
 			var report core.TimingReport
@@ -1790,9 +1790,9 @@ func TestRunCommandIntentReachesExistingShell(t *testing.T) {
 		client := &fakeE2BSyncClient{}
 		restore := swapNewE2BClient(client)
 		t.Cleanup(restore)
-		backend := &e2bBackend{cfg: Config{E2B: E2BConfig{Template: "base", Workdir: root}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-		_, runErr := backend.Run(t.Context(), RunRequest{
-			Repo:               Repo{Root: root},
+		backend := &e2bBackend{cfg: core.Config{E2B: core.E2BConfig{Template: "base", Workdir: root}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+		_, runErr := backend.Run(t.Context(), core.RunRequest{
+			Repo:               core.Repo{Root: root},
 			NoSync:             true,
 			Keep:               true,
 			Command:            intent.Command,
@@ -1819,8 +1819,8 @@ func TestE2BRunCanonicalIDPreservesInventoryRecovery(t *testing.T) {
 			client := &fakeE2BSyncClient{}
 			restore := swapNewE2BClient(client)
 			defer restore()
-			backend := &e2bBackend{cfg: Config{E2B: E2BConfig{APIURL: "https://api.example.test", Template: "base"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-			repo := Repo{Root: t.TempDir()}
+			backend := &e2bBackend{cfg: core.Config{E2B: core.E2BConfig{APIURL: "https://api.example.test", Template: "base"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+			repo := core.Repo{Root: t.TempDir()}
 			otherID, _, _, err := backend.createSandbox(t.Context(), client, repo, true, false, "cbx-aaaaaaaaaaaa")
 			if err != nil {
 				t.Fatal(err)
@@ -1837,7 +1837,7 @@ func TestE2BRunCanonicalIDPreservesInventoryRecovery(t *testing.T) {
 			if err != nil || !exists {
 				t.Fatal(err)
 			}
-			result, err := backend.Run(t.Context(), RunRequest{ID: requestedID, Repo: repo, Command: []string{"true"}, NoSync: true, Keep: true})
+			result, err := backend.Run(t.Context(), core.RunRequest{ID: requestedID, Repo: repo, Command: []string{"true"}, NoSync: true, Keep: true})
 			if state == "missing" {
 				var ee core.ExitError
 				if !errors.As(err, &ee) || ee.Code != 4 || len(client.connectIDs) != 0 || len(client.commands) != 0 {
@@ -1864,9 +1864,9 @@ func TestE2BStopRejectsMissingCanonicalIDMatchingAnotherSlug(t *testing.T) {
 	client := &fakeE2BSyncClient{}
 	restore := swapNewE2BClient(client)
 	defer restore()
-	backend := &e2bBackend{cfg: Config{E2B: E2BConfig{APIURL: "https://api.example.test", Template: "base"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	backend := &e2bBackend{cfg: core.Config{E2B: core.E2BConfig{APIURL: "https://api.example.test", Template: "base"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
 	const missingID = "cbx_aaaaaaaaaaaa"
-	leaseID, sandbox, _, err := backend.createSandbox(t.Context(), client, Repo{Root: t.TempDir()}, true, false, "cbx-aaaaaaaaaaaa")
+	leaseID, sandbox, _, err := backend.createSandbox(t.Context(), client, core.Repo{Root: t.TempDir()}, true, false, "cbx-aaaaaaaaaaaa")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1882,7 +1882,7 @@ func TestE2BStopRejectsMissingCanonicalIDMatchingAnotherSlug(t *testing.T) {
 		t.Fatal(err)
 	}
 	client.getIDs = nil
-	err = backend.Stop(t.Context(), StopRequest{ID: missingID})
+	err = backend.Stop(t.Context(), core.StopRequest{ID: missingID})
 	var ee core.ExitError
 	if !errors.As(err, &ee) || ee.Code != 4 {
 		t.Errorf("missing canonical ID selected a slug: err=%v", err)
@@ -1895,7 +1895,7 @@ func TestE2BStopRejectsMissingCanonicalIDMatchingAnotherSlug(t *testing.T) {
 	if err != nil || marshalErr != nil || !exists || !bytes.Equal(before, after) {
 		t.Fatalf("unrelated claim changed: exists=%v err=%v marshal=%v", exists, err, marshalErr)
 	}
-	if err := backend.Stop(t.Context(), StopRequest{ID: leaseID}); err != nil {
+	if err := backend.Stop(t.Context(), core.StopRequest{ID: leaseID}); err != nil {
 		t.Fatal(err)
 	}
 	if len(client.deleteIDs) != 1 || client.deleteIDs[0] != sandbox.SandboxID {

--- a/internal/providers/e2b/bridge.go
+++ b/internal/providers/e2b/bridge.go
@@ -29,7 +29,7 @@ import (
 func (b *e2bBackend) PublishPeer(ctx context.Context, leaseID string, port int, ttl time.Duration) (core.BridgePeerTarget, error) {
 	_ = ttl
 	if port <= 0 || port > 65535 {
-		return core.BridgePeerTarget{}, exit(2, "e2b bridge: port %d out of range", port)
+		return core.BridgePeerTarget{}, core.Exit(2, "e2b bridge: port %d out of range", port)
 	}
 	sandboxID, domain, err := b.bridgeSandboxCoords(ctx, leaseID)
 	if err != nil {
@@ -59,10 +59,10 @@ func (b *e2bBackend) ListPeerTargets(ctx context.Context, leaseID string) ([]cor
 func (b *e2bBackend) bridgeSandboxCoords(ctx context.Context, leaseID string) (string, string, error) {
 	leaseID = strings.TrimSpace(leaseID)
 	if leaseID == "" {
-		return "", "", exit(2, "e2b bridge: missing lease id")
+		return "", "", core.Exit(2, "e2b bridge: missing lease id")
 	}
 	if !strings.HasPrefix(leaseID, "cbx_") && !strings.HasPrefix(leaseID, "e2b_") {
-		return "", "", exit(2, "e2b bridge: lease %q is not an E2B-claimed Crabbox lease", leaseID)
+		return "", "", core.Exit(2, "e2b bridge: lease %q is not an E2B-claimed Crabbox lease", leaseID)
 	}
 	client, err := newE2BClient(b.cfg, b.rt)
 	if err != nil {
@@ -76,7 +76,7 @@ func (b *e2bBackend) bridgeSandboxCoords(ctx context.Context, leaseID string) (s
 			return "", "", e2bError("get sandbox", err)
 		}
 		if !isCrabboxE2BSandbox(sandbox) {
-			return "", "", exit(4, "e2b sandbox %q is not claimed by Crabbox", leaseID)
+			return "", "", core.Exit(4, "e2b sandbox %q is not claimed by Crabbox", leaseID)
 		}
 	} else {
 		sandbox, err = resolveE2BSandboxByLease(ctx, client, leaseID)
@@ -85,7 +85,7 @@ func (b *e2bBackend) bridgeSandboxCoords(ctx context.Context, leaseID string) (s
 		return "", "", err
 	}
 	if sandbox.SandboxID == "" {
-		return "", "", exit(4, "e2b bridge: no sandbox bound to lease %q", leaseID)
+		return "", "", core.Exit(4, "e2b bridge: no sandbox bound to lease %q", leaseID)
 	}
 	domain := strings.TrimSpace(sandbox.Domain)
 	if domain == "" {

--- a/internal/providers/e2b/bridge_test.go
+++ b/internal/providers/e2b/bridge_test.go
@@ -26,11 +26,11 @@ func (f *fakeBridgeAPI) ListSandboxes(_ context.Context, _ map[string]string) ([
 func newBridgeBackend(t *testing.T, fake *fakeBridgeAPI) *e2bBackend {
 	t.Helper()
 	prev := newE2BClient
-	newE2BClient = func(Config, Runtime) (e2bAPI, error) { return fake, nil }
+	newE2BClient = func(core.Config, core.Runtime) (e2bAPI, error) { return fake, nil }
 	t.Cleanup(func() { newE2BClient = prev })
 	return &e2bBackend{
-		cfg: Config{Provider: e2bProvider, E2B: E2BConfig{APIKey: "key", Domain: "e2b.app"}},
-		rt:  Runtime{},
+		cfg: core.Config{Provider: e2bProvider, E2B: core.E2BConfig{APIKey: "key", Domain: "e2b.app"}},
+		rt:  core.Runtime{},
 	}
 }
 

--- a/internal/providers/e2b/client.go
+++ b/internal/providers/e2b/client.go
@@ -90,10 +90,10 @@ func (e *e2bAPIError) Error() string {
 	return e.Status + ": " + e.Body
 }
 
-var newE2BClient = func(cfg Config, rt Runtime) (e2bAPI, error) {
+var newE2BClient = func(cfg core.Config, rt core.Runtime) (e2bAPI, error) {
 	apiKey := strings.TrimSpace(cfg.E2B.APIKey)
 	if apiKey == "" {
-		return nil, exit(2, "provider=e2b requires E2B_API_KEY")
+		return nil, core.Exit(2, "provider=e2b requires E2B_API_KEY")
 	}
 	httpClient, envdClient := shared.ControlAndDataHTTPClients(rt.HTTP, e2bControlTimeout)
 	apiURL, err := validateE2BAPIURL(core.Blank(cfg.E2B.APIURL, core.E2BConfigDefaultAPIURL))
@@ -113,9 +113,9 @@ var newE2BClient = func(cfg Config, rt Runtime) (e2bAPI, error) {
 
 func validateE2BAPIURL(raw string) (string, error) {
 	return shared.NormalizeHTTPSURL(raw, shared.EndpointURLErrors{
-		Invalid:    exit(2, "provider=e2b API URL must be an absolute HTTPS URL"),
-		Components: exit(2, "provider=e2b API URL must not contain userinfo, query parameters, or a fragment"),
-		Insecure:   exit(2, "provider=e2b API URL must use HTTPS except for loopback development endpoints"),
+		Invalid:    core.Exit(2, "provider=e2b API URL must be an absolute HTTPS URL"),
+		Components: core.Exit(2, "provider=e2b API URL must not contain userinfo, query parameters, or a fragment"),
+		Insecure:   core.Exit(2, "provider=e2b API URL must use HTTPS except for loopback development endpoints"),
 	})
 }
 
@@ -222,7 +222,7 @@ func (c *e2bClient) UploadFile(ctx context.Context, session e2bSession, targetPa
 		HTTPClient:     c.dataPlaneHTTPClient(),
 		SetHeaders:     func(req *http.Request) { c.setEnvdHeaders(req, session) },
 		RedirectError:  e2bRedirectError,
-		SummarizeError: summarizeJSON,
+		SummarizeError: core.SummarizeJSON,
 		APIError: func(statusCode int, status, body string) error {
 			return &e2bAPIError{StatusCode: statusCode, Status: status, Body: body}
 		},
@@ -245,7 +245,7 @@ func (c *e2bClient) StartProcess(ctx context.Context, session e2bSession, req e2
 		RedirectError:  e2bRedirectError,
 		Provider:       "e2b",
 		InterpretEnd:   interpretE2BProcessEnd,
-		SummarizeError: summarizeJSON,
+		SummarizeError: core.SummarizeJSON,
 		APIError: func(statusCode int, status, body string) error {
 			return &e2bAPIError{StatusCode: statusCode, Status: status, Body: body}
 		},
@@ -277,7 +277,7 @@ func (c *e2bClient) doJSONWithHeaders(ctx context.Context, method, path string, 
 	}
 	defer resp.Body.Close()
 	if err := shared.DecodeUnboundedJSONResponse(resp, out, func(statusCode int, status string, data []byte) error {
-		return &e2bAPIError{StatusCode: statusCode, Status: status, Body: shared.RedactErrorSecrets(summarizeJSON(data), c.apiKey)}
+		return &e2bAPIError{StatusCode: statusCode, Status: status, Body: shared.RedactErrorSecrets(core.SummarizeJSON(data), c.apiKey)}
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/providers/e2b/core.go
+++ b/internal/providers/e2b/core.go
@@ -1,33 +1,8 @@
 package e2b
 
 import (
-	"time"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type E2BConfig = core.E2BConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type RunSessionHandle = core.RunSessionHandle
-type LeaseClaim = core.LeaseClaim
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-type Repo = core.Repo
-type ExitError = core.ExitError
-type timingPhase = core.TimingPhase
 
 const (
 	e2bProvider = "e2b"
@@ -35,24 +10,6 @@ const (
 
 	NetworkPublic = core.NetworkPublic
 )
-
-type statusView = core.StatusView
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
-	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
-}
 
 var claimLeaseForRepoProvider = core.ClaimLeaseForRepoProvider
 
@@ -62,42 +19,14 @@ var claimLeaseTargetForRepoConfigIfUnchanged = core.ClaimLeaseTargetForRepoConfi
 
 var claimLeaseTargetForConfigIfUnchanged = core.ClaimLeaseTargetForConfigIfUnchanged
 
-func resolveLeaseClaimForProviderScopeWithExact(identifier, providerScope string) (LeaseClaim, bool, bool, error) {
+func resolveLeaseClaimForProviderScopeWithExact(identifier, providerScope string) (core.LeaseClaim, bool, bool, error) {
 	return core.ResolveLeaseClaimForProviderScopeWithExact(identifier, e2bProvider, providerScope)
 }
 
-func resolveLeaseClaimForProviderCloudIDScope(cloudID, providerScope string) (LeaseClaim, bool, error) {
+func resolveLeaseClaimForProviderCloudIDScope(cloudID, providerScope string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaimForProviderCloudIDScope(cloudID, e2bProvider, providerScope)
 }
 
-func readLeaseClaimWithPresence(leaseID string) (LeaseClaim, bool, error) {
-	return core.ReadLeaseClaimWithPresence(leaseID)
-}
-
-func removeLeaseClaimIfUnchangedAfter(leaseID string, expected LeaseClaim, action func() error) error {
-	return core.RemoveLeaseClaimIfUnchangedAfter(leaseID, expected, action)
-}
-
-func providerClaimScope(cfg Config) string {
+func providerClaimScope(cfg core.Config) string {
 	return core.ProviderClaimScope(e2bProvider, cfg)
-}
-
-func isCanonicalLeaseID(value string) bool {
-	return core.IsCanonicalLeaseID(value)
-}
-
-func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaim(identifier)
-}
-
-func shellQuote(s string) string {
-	return core.ShellQuote(s)
-}
-
-func summarizeJSON(data []byte) string {
-	return core.SummarizeJSON(data)
-}
-
-func inventoryDoctorResult(provider string, leases int) DoctorResult {
-	return core.InventoryDoctorResult(provider, leases)
 }

--- a/internal/providers/e2b/sync.go
+++ b/internal/providers/e2b/sync.go
@@ -11,7 +11,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *e2bBackend) syncWorkspace(ctx context.Context, client e2bAPI, session e2bSession, req RunRequest, workspace string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+func (b *e2bBackend) syncWorkspace(ctx context.Context, client e2bAPI, session e2bSession, req core.RunRequest, workspace string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	workspace, err := cleanE2BWorkspacePath(workspace)
 	if err != nil {
 		return nil, 0, err
@@ -41,21 +41,21 @@ func (b *e2bBackend) prepareWorkspace(ctx context.Context, client e2bAPI, sessio
 	if err != nil {
 		return err
 	}
-	return b.execShell(ctx, client, session, "mkdir -p "+shellQuote(workspace), io.Discard)
+	return b.execShell(ctx, client, session, "mkdir -p "+core.ShellQuote(workspace), io.Discard)
 }
 
 func cleanE2BWorkspacePath(workspace string) (string, error) {
 	trimmed := strings.TrimSpace(workspace)
 	if trimmed == "" {
-		return "", exit(2, "e2b workspace path is empty")
+		return "", core.Exit(2, "e2b workspace path is empty")
 	}
 	clean := path.Clean(trimmed)
 	if !strings.HasPrefix(clean, "/") {
-		return "", exit(2, "e2b workspace path %q must resolve to an absolute path", workspace)
+		return "", core.Exit(2, "e2b workspace path %q must resolve to an absolute path", workspace)
 	}
 	switch clean {
 	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var":
-		return "", exit(2, "e2b workspace path %q is too broad; choose a dedicated subdirectory", clean)
+		return "", core.Exit(2, "e2b workspace path %q is too broad; choose a dedicated subdirectory", clean)
 	}
 	return clean, nil
 }
@@ -76,7 +76,7 @@ func (b *e2bBackend) execShell(ctx context.Context, client e2bAPI, session e2bSe
 		return fmt.Errorf("e2b exec %q: %w", command, err)
 	}
 	if code != 0 {
-		return exit(code, "e2b exec %q exited %d", command, code)
+		return core.Exit(code, "e2b exec %q exited %d", command, code)
 	}
 	return nil
 }

--- a/internal/providers/modal/backend.go
+++ b/internal/providers/modal/backend.go
@@ -13,15 +13,15 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func NewModalBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewModalBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	return &modalBackend{spec: spec, cfg: cfg, rt: rt}
 }
 
 type modalBackend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
 const (
@@ -29,9 +29,9 @@ const (
 	modalCleanupTimeout    = 2 * time.Minute
 )
 
-func (b *modalBackend) Spec() ProviderSpec { return b.spec }
+func (b *modalBackend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *modalBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *modalBackend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	started := core.ClockNow(b.rt.Clock)
 	client, err := newModalAPI(b.cfg, b.rt)
 	if err != nil {
@@ -55,7 +55,7 @@ func (b *modalBackend) Warmup(ctx context.Context, req WarmupRequest) error {
 	})
 }
 
-func (b *modalBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *modalBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	workdir, workdirErr := cleanModalWorkdir(modalWorkdir(b.cfg))
 	var client modalAPI
 	var claim core.LeaseClaim
@@ -133,7 +133,7 @@ func (b *modalBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 				return shared.DelegatedSandboxCommand{}, err
 			}
 			if req.EnvSummary {
-				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+				core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 			}
 			var cleanup func(context.Context)
 			var closeCommand func(context.Context) error
@@ -174,7 +174,7 @@ func (b *modalBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 	})
 }
 
-func (b *modalBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *modalBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	client, err := newModalAPI(b.cfg, b.rt)
 	if err != nil {
@@ -184,29 +184,29 @@ func (b *modalBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, 
 	if err != nil {
 		return nil, modalError("list sandboxes", err)
 	}
-	servers := make([]Server, 0, len(sandboxes))
+	servers := make([]core.Server, 0, len(sandboxes))
 	for _, sandbox := range sandboxes {
 		servers = append(servers, modalSandboxToServer(sandbox))
 	}
 	return servers, nil
 }
 
-func (b *modalBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
-	servers, err := b.List(ctx, ListRequest{})
+func (b *modalBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
+	servers, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return inventoryDoctorResult(providerName, len(servers)), nil
+	return core.InventoryDoctorResult(providerName, len(servers)), nil
 }
 
-func (b *modalBackend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *modalBackend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	client, err := newModalAPI(b.cfg, b.rt)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	leaseID, sandboxID, slug, err := b.resolveSandboxID(ctx, client, req.ID)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	deadline := core.ClockNow(b.rt.Clock).Add(req.WaitTimeout)
 	if req.WaitTimeout <= 0 {
@@ -215,24 +215,24 @@ func (b *modalBackend) Status(ctx context.Context, req StatusRequest) (StatusVie
 	for {
 		sandbox, err := client.GetSandbox(ctx, sandboxID)
 		if err != nil {
-			return StatusView{}, modalError("get sandbox", err)
+			return core.StatusView{}, modalError("get sandbox", err)
 		}
 		view := modalStatusView(leaseID, slug, sandbox)
 		if !req.Wait || view.Ready {
 			return view, nil
 		}
 		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return StatusView{}, exit(5, "timed out waiting for modal sandbox %s to become ready", sandboxID)
+			return core.StatusView{}, core.Exit(5, "timed out waiting for modal sandbox %s to become ready", sandboxID)
 		}
 		select {
 		case <-ctx.Done():
-			return StatusView{}, ctx.Err()
+			return core.StatusView{}, ctx.Err()
 		case <-time.After(2 * time.Second):
 		}
 	}
 }
 
-func (b *modalBackend) Stop(ctx context.Context, req StopRequest) error {
+func (b *modalBackend) Stop(ctx context.Context, req core.StopRequest) error {
 	claim, err := resolveModalClaim(req.ID)
 	if err != nil {
 		return err
@@ -248,16 +248,16 @@ func (b *modalBackend) Stop(ctx context.Context, req StopRequest) error {
 	return nil
 }
 
-func (b *modalBackend) createSandbox(ctx context.Context, client modalAPI, repo Repo, keep, reclaim bool, requestedSlug string) (core.LeaseClaim, modalSandbox, error) {
+func (b *modalBackend) createSandbox(ctx context.Context, client modalAPI, repo core.Repo, keep, reclaim bool, requestedSlug string) (core.LeaseClaim, modalSandbox, error) {
 	if strings.TrimSpace(repo.Root) == "" {
-		return core.LeaseClaim{}, modalSandbox{}, exit(2, "Modal acquisition requires a repository root for durable ownership")
+		return core.LeaseClaim{}, modalSandbox{}, core.Exit(2, "Modal acquisition requires a repository root for durable ownership")
 	}
 	workspace, err := cleanModalWorkdir(modalWorkdir(b.cfg))
 	if err != nil {
 		return core.LeaseClaim{}, modalSandbox{}, err
 	}
 	leaseID := core.NewLeaseID()
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return core.LeaseClaim{}, modalSandbox{}, err
 	}
@@ -280,7 +280,7 @@ func (b *modalBackend) createSandbox(ctx context.Context, client modalAPI, repo 
 		return core.LeaseClaim{}, modalSandbox{}, fmt.Errorf("%w; inspect Modal app=%s lease=%s before native cleanup of an uncertain creation", modalError("create sandbox", err), modalApp(cfg), leaseID)
 	}
 	if sandbox.ID == "" {
-		return core.LeaseClaim{}, modalSandbox{}, exit(5, "modal create sandbox returned no sandbox id; inspect Modal app=%s lease=%s", modalApp(cfg), leaseID)
+		return core.LeaseClaim{}, modalSandbox{}, core.Exit(5, "modal create sandbox returned no sandbox id; inspect Modal app=%s lease=%s", modalApp(cfg), leaseID)
 	}
 	binding := modalBinding{ID: sandbox.ID, LeaseID: leaseID, Slug: slug, Scope: sandbox.Scope}
 	if err := binding.validate(sandbox); err != nil {
@@ -302,11 +302,11 @@ func (b *modalBackend) createSandbox(ctx context.Context, client modalAPI, repo 
 }
 
 func modalCleanupCommand(leaseID string) string {
-	return fmt.Sprintf("crabbox stop --provider %s --id %s", providerName, shellQuote(leaseID))
+	return fmt.Sprintf("crabbox stop --provider %s --id %s", providerName, core.ShellQuote(leaseID))
 }
 
-func modalSandboxTags(cfg Config, leaseID, slug, repoName string, keep bool, now time.Time) map[string]string {
-	base := directLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
+func modalSandboxTags(cfg core.Config, leaseID, slug, repoName string, keep bool, now time.Time) map[string]string {
+	base := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
 	tags := map[string]string{
 		"crabbox":    "true",
 		"provider":   providerName,
@@ -327,9 +327,9 @@ func modalSandboxTags(cfg Config, leaseID, slug, repoName string, keep bool, now
 func (b *modalBackend) resolveSandboxID(ctx context.Context, client modalAPI, id string) (string, string, string, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return "", "", "", exit(2, "provider=modal requires a Crabbox lease id, slug, or Modal sandbox id")
+		return "", "", "", core.Exit(2, "provider=modal requires a Crabbox lease id, slug, or Modal sandbox id")
 	}
-	if claim, ok, err := resolveLeaseClaim(id); err != nil {
+	if claim, ok, err := core.ResolveLeaseClaim(id); err != nil {
 		return "", "", "", err
 	} else if ok && claim.Provider == providerName {
 		if claim.CloudID != "" {
@@ -358,7 +358,7 @@ func (b *modalBackend) resolveSandboxID(ctx context.Context, client modalAPI, id
 	if err != nil && !isModalNotFoundError(err) {
 		return "", "", "", modalError("get sandbox", err)
 	}
-	return "", "", "", exit(4, "modal sandbox or claim %q was not found", id)
+	return "", "", "", core.Exit(4, "modal sandbox or claim %q was not found", id)
 }
 
 func resolveModalSandboxByLease(ctx context.Context, client modalAPI, leaseID string) (modalSandbox, error) {
@@ -371,10 +371,10 @@ func resolveModalSandboxByLease(ctx context.Context, client modalAPI, leaseID st
 			return sandbox, nil
 		}
 	}
-	return modalSandbox{}, exit(4, "modal lease %q was not found", leaseID)
+	return modalSandbox{}, core.Exit(4, "modal lease %q was not found", leaseID)
 }
 
-func modalSandboxToServer(sandbox modalSandbox) Server {
+func modalSandboxToServer(sandbox modalSandbox) core.Server {
 	labels := map[string]string{}
 	for k, v := range sandbox.Tags {
 		labels[k] = v
@@ -382,13 +382,13 @@ func modalSandboxToServer(sandbox modalSandbox) Server {
 	labels["provider"] = providerName
 	labels["lease"] = modalLeaseID(sandbox)
 	if labels["slug"] == "" {
-		labels["slug"] = newLeaseSlug(labels["lease"])
+		labels["slug"] = core.NewLeaseSlug(labels["lease"])
 	}
 	labels["target"] = targetLinux
 	if labels["state"] == "" {
 		labels["state"] = sandbox.Status
 	}
-	server := Server{
+	server := core.Server{
 		Provider: providerName,
 		CloudID:  sandbox.ID,
 		Name:     core.Blank(sandbox.Name, sandbox.ID),
@@ -399,9 +399,9 @@ func modalSandboxToServer(sandbox modalSandbox) Server {
 	return server
 }
 
-func modalStatusView(leaseID, slug string, sandbox modalSandbox) StatusView {
+func modalStatusView(leaseID, slug string, sandbox modalSandbox) core.StatusView {
 	server := modalSandboxToServer(sandbox)
-	return StatusView{
+	return core.StatusView{
 		ID:         leaseID,
 		Slug:       core.Blank(slug, modalSlug(leaseID, sandbox)),
 		Provider:   providerName,
@@ -435,37 +435,37 @@ func modalSlug(leaseID string, sandbox modalSandbox) string {
 	if slug := strings.TrimSpace(sandbox.Tags["slug"]); slug != "" {
 		return slug
 	}
-	return newLeaseSlug(leaseID)
+	return core.NewLeaseSlug(leaseID)
 }
 
 func isCrabboxModalSandbox(sandbox modalSandbox) bool {
 	return sandbox.Tags["provider"] == providerName && sandbox.Tags["crabbox"] == "true"
 }
 
-func modalApp(cfg Config) string {
+func modalApp(cfg core.Config) string {
 	return core.Blank(strings.TrimSpace(cfg.Modal.App), core.ModalConfigDefaultApp)
 }
 
-func modalImage(cfg Config) string {
+func modalImage(cfg core.Config) string {
 	return core.Blank(strings.TrimSpace(cfg.Modal.Image), core.ModalConfigDefaultImage)
 }
 
-func modalWorkdir(cfg Config) string {
+func modalWorkdir(cfg core.Config) string {
 	return core.Blank(strings.TrimSpace(cfg.Modal.Workdir), core.ModalConfigDefaultWorkdir)
 }
 
 func cleanModalWorkdir(workdir string) (string, error) {
 	trimmed := strings.TrimSpace(workdir)
 	if trimmed == "" {
-		return "", exit(2, "modal workdir is empty")
+		return "", core.Exit(2, "modal workdir is empty")
 	}
 	clean := path.Clean(trimmed)
 	if !strings.HasPrefix(clean, "/") {
-		return "", exit(2, "modal workdir %q must resolve to an absolute path", workdir)
+		return "", core.Exit(2, "modal workdir %q must resolve to an absolute path", workdir)
 	}
 	switch clean {
 	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspace":
-		return "", exit(2, "modal workdir %q is too broad; choose a dedicated subdirectory", clean)
+		return "", core.Exit(2, "modal workdir %q is too broad; choose a dedicated subdirectory", clean)
 	}
 	return clean, nil
 }
@@ -494,20 +494,20 @@ func buildModalCommand(command []string, shellMode bool, workdir string) ([]stri
 	var script string
 	if shellMode {
 		script = strings.Join(command, " ")
-	} else if shouldUseShell(command) || leadingEnvAssignment(command) {
-		script = shellScriptFromArgv(command)
+	} else if core.ShouldUseShell(command) || core.LeadingEnvAssignment(command) {
+		script = core.ShellScriptFromArgv(command)
 	} else {
-		script = "exec " + strings.Join(shellWords(command), " ")
+		script = "exec " + strings.Join(core.ShellWords(command), " ")
 	}
 	if strings.TrimSpace(workdir) != "" {
-		script = "cd " + shellQuote(workdir) + " && " + script
+		script = "cd " + core.ShellQuote(workdir) + " && " + script
 	}
 	return []string{"bash", "-lc", script}, nil
 }
 
-func rejectModalSyncOptions(req RunRequest) error {
+func rejectModalSyncOptions(req core.RunRequest) error {
 	if req.ChecksumSync {
-		return exit(2, "%s uses Modal archive sync; --checksum is not supported", providerName)
+		return core.Exit(2, "%s uses Modal archive sync; --checksum is not supported", providerName)
 	}
 	return nil
 }

--- a/internal/providers/modal/backend_test.go
+++ b/internal/providers/modal/backend_test.go
@@ -139,8 +139,8 @@ func TestRunCreatesExecsAndTerminatesEphemeralSandbox(t *testing.T) {
 	cfg.Modal.Environment = "my-app-dev"
 	cfg.Modal.Secrets = []string{"example", "sample"}
 	backend := NewModalBackend(Provider{}.Spec(), cfg, testRuntime()).(*modalBackend)
-	req := RunRequest{
-		Repo:    Repo{Name: "repo", Root: t.TempDir()},
+	req := core.RunRequest{
+		Repo:    core.Repo{Name: "repo", Root: t.TempDir()},
 		Command: []string{"echo", "hello"},
 		NoSync:  true,
 	}
@@ -176,11 +176,11 @@ func TestRunNoSyncDoesNotDeleteExistingWorkspace(t *testing.T) {
 	cfg := newTestConfig()
 	cfg.Sync.Delete = true
 	backend := NewModalBackend(Provider{}.Spec(), cfg, testRuntime()).(*modalBackend)
-	repo := Repo{Name: "repo", Root: t.TempDir()}
+	repo := core.Repo{Name: "repo", Root: t.TempDir()}
 	if _, _, err := backend.createSandbox(t.Context(), fake, repo, true, false, ""); err != nil {
 		t.Fatal(err)
 	}
-	req := RunRequest{
+	req := core.RunRequest{
 		ID:      "sb-123",
 		Repo:    repo,
 		Command: []string{"test", "-f", "kept.txt"},
@@ -206,8 +206,8 @@ func TestRunReturnsSessionHandleForKeptSandbox(t *testing.T) {
 	fake := &fakeModalAPI{}
 	withFakeModalAPI(t, fake)
 	backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "repo", Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "repo", Root: t.TempDir()},
 		Command: []string{"true"},
 		Keep:    true,
 		NoSync:  true,
@@ -222,7 +222,7 @@ func TestRunReturnsSessionHandleForKeptSandbox(t *testing.T) {
 	if got.Provider != providerName || got.LeaseID == "" || got.Slug == "" || got.Reused || !got.Kept {
 		t.Fatalf("session=%#v", got)
 	}
-	if got.CleanupCommand != "crabbox stop --provider modal --id "+shellQuote(got.LeaseID) {
+	if got.CleanupCommand != "crabbox stop --provider modal --id "+core.ShellQuote(got.LeaseID) {
 		t.Fatalf("cleanup command=%q", got.CleanupCommand)
 	}
 	if containsVerb(fake.verbs, "terminate") {
@@ -257,9 +257,9 @@ func TestRunByRemoteIdentifierRejectsForeignClaimEvenWithReclaim(t *testing.T) {
 			}}
 			withFakeModalAPI(t, fake)
 			backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
-			_, err := backend.Run(context.Background(), RunRequest{
+			_, err := backend.Run(context.Background(), core.RunRequest{
 				ID:      tt.id,
-				Repo:    Repo{Name: "new", Root: newRepo},
+				Repo:    core.Repo{Name: "new", Root: newRepo},
 				Command: []string{"true"},
 				NoSync:  true,
 			})
@@ -270,9 +270,9 @@ func TestRunByRemoteIdentifierRejectsForeignClaimEvenWithReclaim(t *testing.T) {
 				t.Fatalf("run executed despite claim rejection: %v", fake.verbs)
 			}
 
-			if _, err := backend.Run(context.Background(), RunRequest{
+			if _, err := backend.Run(context.Background(), core.RunRequest{
 				ID:      tt.id,
-				Repo:    Repo{Name: "new", Root: newRepo},
+				Repo:    core.Repo{Name: "new", Root: newRepo},
 				Command: []string{"true"},
 				NoSync:  true,
 				Reclaim: true,
@@ -294,7 +294,7 @@ func TestCreateSandboxReportsCleanupFailureAfterClaimFailure(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	claimErr := errors.New("claim write failed")
 	oldClaim := publishModalClaim
-	publishModalClaim = func(*modalBackend, context.Context, modalAPI, modalBinding, modalSandbox, Repo, bool) (core.LeaseClaim, error) {
+	publishModalClaim = func(*modalBackend, context.Context, modalAPI, modalBinding, modalSandbox, core.Repo, bool) (core.LeaseClaim, error) {
 		return core.LeaseClaim{}, claimErr
 	}
 	t.Cleanup(func() { publishModalClaim = oldClaim })
@@ -305,7 +305,7 @@ func TestCreateSandboxReportsCleanupFailureAfterClaimFailure(t *testing.T) {
 	rt.Stderr = &stderr
 	backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), rt).(*modalBackend)
 
-	_, _, err := backend.createSandbox(context.Background(), fake, Repo{Name: "repo", Root: t.TempDir()}, false, false, "")
+	_, _, err := backend.createSandbox(context.Background(), fake, core.Repo{Name: "repo", Root: t.TempDir()}, false, false, "")
 	if err == nil {
 		t.Fatal("createSandbox err=nil, want claim and cleanup failure")
 	}
@@ -327,8 +327,8 @@ func TestSyncWorkspaceCleansRemoteArchiveWhenExtractFails(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repoRoot, "hello.txt"), []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	_, _, err := backend.syncWorkspace(context.Background(), fake, "sb-123", RunRequest{
-		Repo: Repo{Name: "repo", Root: repoRoot},
+	_, _, err := backend.syncWorkspace(context.Background(), fake, "sb-123", core.RunRequest{
+		Repo: core.Repo{Name: "repo", Root: repoRoot},
 	}, "/workspace/crabbox")
 	if err == nil {
 		t.Fatalf("expected extract failure")
@@ -352,8 +352,8 @@ func TestKeepOnFailureRetainsSandbox(t *testing.T) {
 	rt := testRuntime()
 	rt.Stderr = &stderr
 	backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), rt).(*modalBackend)
-	req := RunRequest{
-		Repo:          Repo{Name: "repo", Root: t.TempDir()},
+	req := core.RunRequest{
+		Repo:          core.Repo{Name: "repo", Root: t.TempDir()},
 		Command:       []string{"false"},
 		NoSync:        true,
 		KeepOnFailure: true,
@@ -363,7 +363,7 @@ func TestKeepOnFailureRetainsSandbox(t *testing.T) {
 	if result.ExitCode != 7 {
 		t.Fatalf("exit=%d want 7", result.ExitCode)
 	}
-	var ee ExitError
+	var ee core.ExitError
 	if !errors.As(err, &ee) || ee.Code != 7 {
 		t.Fatalf("err=%v want ExitError code 7", err)
 	}
@@ -406,7 +406,7 @@ func TestStatusMapsSandboxTags(t *testing.T) {
 		},
 	}
 	withFakeModalAPI(t, fake)
-	view, err := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend).Status(context.Background(), StatusRequest{ID: "cbx_123"})
+	view, err := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend).Status(context.Background(), core.StatusRequest{ID: "cbx_123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -415,12 +415,12 @@ func TestStatusMapsSandboxTags(t *testing.T) {
 	}
 }
 
-func newTestConfig() Config {
-	return Config{
+func newTestConfig() core.Config {
+	return core.Config{
 		Provider:    providerName,
 		TTL:         90 * time.Minute,
 		IdleTimeout: 30 * time.Minute,
-		Modal: ModalConfig{
+		Modal: core.ModalConfig{
 			App:     "crabbox",
 			Image:   "python:3.13-slim",
 			Workdir: "/workspace/crabbox",
@@ -429,14 +429,14 @@ func newTestConfig() Config {
 	}
 }
 
-func testRuntime() Runtime {
-	return Runtime{Stdout: io.Discard, Stderr: io.Discard}
+func testRuntime() core.Runtime {
+	return core.Runtime{Stdout: io.Discard, Stderr: io.Discard}
 }
 
 func withFakeModalAPI(t *testing.T, fake *fakeModalAPI) {
 	t.Helper()
 	old := newModalAPI
-	newModalAPI = func(Config, Runtime) (modalAPI, error) { return fake, nil }
+	newModalAPI = func(core.Config, core.Runtime) (modalAPI, error) { return fake, nil }
 	t.Cleanup(func() { newModalAPI = old })
 }
 
@@ -591,8 +591,8 @@ func TestRunLifecycleRetainsSetupFailure(t *testing.T) {
 	fake := &fakeModalAPI{execCodes: []int{7}}
 	withFakeModalAPI(t, fake)
 	backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
-	result, err := backend.Run(t.Context(), RunRequest{
-		Repo: Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"},
+	result, err := backend.Run(t.Context(), core.RunRequest{
+		Repo: core.Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"},
 		NoSync: true, KeepOnFailure: true,
 	})
 	if err == nil || result.Session == nil || !result.Session.Kept || containsVerb(fake.verbs, "terminate") {
@@ -605,8 +605,8 @@ func TestRunLifecycleReportsCleanupFailure(t *testing.T) {
 	fake := &fakeModalAPI{terminateErr: errors.New("terminate unavailable")}
 	withFakeModalAPI(t, fake)
 	backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
-	result, err := backend.Run(t.Context(), RunRequest{
-		Repo: Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true,
+	result, err := backend.Run(t.Context(), core.RunRequest{
+		Repo: core.Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true,
 	})
 	if err == nil || result.ExitCode != 1 || result.Session == nil || !result.Session.Kept {
 		t.Fatalf("cleanup failure must fail with retained handle: result=%#v session=%#v err=%v", result, result.Session, err)
@@ -624,8 +624,8 @@ func TestRunLifecycleArchiveGuardrailBeforeCreation(t *testing.T) {
 		t.Fatal(err)
 	}
 	backend := NewModalBackend(Provider{}.Spec(), cfg, testRuntime()).(*modalBackend)
-	result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: repo}, Command: []string{"true"}})
-	var ee ExitError
+	result, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Name: "repo", Root: repo}, Command: []string{"true"}})
+	var ee core.ExitError
 	if !errors.As(err, &ee) || ee.Code != 6 || result.ExitCode != 6 || containsVerb(fake.verbs, "create") || result.Session != nil {
 		t.Fatalf("result=%#v err=%v verbs=%v", result, err, fake.verbs)
 	}
@@ -636,7 +636,7 @@ func TestRunLifecycleRetainsSyncFailure(t *testing.T) {
 	fake := &fakeModalAPI{uploadErr: errors.New("upload unavailable")}
 	withFakeModalAPI(t, fake)
 	backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
-	result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: newGitRepo(t)}, Command: []string{"true"}, KeepOnFailure: true})
+	result, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Name: "repo", Root: newGitRepo(t)}, Command: []string{"true"}, KeepOnFailure: true})
 	if err == nil || result.Session == nil || !result.Session.Kept || containsVerb(fake.verbs, "terminate") || !fake.cleanupDeadlineSet {
 		t.Fatalf("result=%#v err=%v verbs=%v cleanupBounded=%t", result, err, fake.verbs, fake.cleanupDeadlineSet)
 	}
@@ -649,15 +649,15 @@ func TestRunLifecycleCleanupOutcomeAndTiming(t *testing.T) {
 			fake := &fakeModalAPI{execCodes: []int{0, code}, terminateErr: errors.New("terminate unavailable")}
 			withFakeModalAPI(t, fake)
 			var stderr bytes.Buffer
-			backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), Runtime{Stdout: io.Discard, Stderr: &stderr}).(*modalBackend)
-			result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, TimingJSON: true})
+			backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), core.Runtime{Stdout: io.Discard, Stderr: &stderr}).(*modalBackend)
+			result, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, TimingJSON: true})
 			wantCode := code
 			wantKind := "command-exit"
 			if code == 0 {
 				wantCode = 1
 				wantKind = "provider-error"
 			}
-			var ee ExitError
+			var ee core.ExitError
 			if !errors.As(err, &ee) || ee.Code != wantCode || result.ExitCode != wantCode || !fake.terminateDeadlineSet || result.Session == nil || !result.Session.Kept {
 				t.Fatalf("result=%#v err=%v bounded=%t", result, err, fake.terminateDeadlineSet)
 			}
@@ -679,7 +679,7 @@ func TestRunLifecycleCleanupOutcomeAndTiming(t *testing.T) {
 func TestSyncWorkspaceUsesSharedTimeoutAndStaging(t *testing.T) {
 	fake := &fakeModalAPI{uploadWaitForCancel: true}
 	cfg := newTestConfig()
-	repo := Repo{Name: "repo", Root: newGitRepo(t)}
+	repo := core.Repo{Name: "repo", Root: newGitRepo(t)}
 	prepared, err := core.PrepareDelegatedArchive(t.Context(), core.DelegatedArchivePreparationRequest{Config: cfg, Repo: repo})
 	if err != nil {
 		t.Fatal(err)
@@ -690,7 +690,7 @@ func TestSyncWorkspaceUsesSharedTimeoutAndStaging(t *testing.T) {
 	cfg.Sync.Timeout = time.Millisecond
 	cfg.Sync.Delete = true
 	backend := NewModalBackend(Provider{}.Spec(), cfg, testRuntime()).(*modalBackend)
-	_, _, err = backend.syncWorkspace(t.Context(), fake, "sb-123", RunRequest{Repo: repo}, "/workspace/crabbox", prepared)
+	_, _, err = backend.syncWorkspace(t.Context(), fake, "sb-123", core.RunRequest{Repo: repo}, "/workspace/crabbox", prepared)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected transfer timeout, got %v", err)
 	}
@@ -709,7 +709,7 @@ func TestRunEnvCleanupPrecedesSandboxTermination(t *testing.T) {
 	fake := &fakeModalAPI{}
 	withFakeModalAPI(t, fake)
 	backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
-	_, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, Env: map[string]string{"EXAMPLE": "value"}})
+	_, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, Env: map[string]string{"EXAMPLE": "value"}})
 	want := []string{"create", "inspect", "exec", "upload", "exec", "exec", "terminate"}
 	if err != nil || !reflect.DeepEqual(fake.verbs, want) || !fake.cleanupDeadlineSet {
 		t.Fatalf("err=%v verbs=%v bounded=%t", err, fake.verbs, fake.cleanupDeadlineSet)
@@ -721,7 +721,7 @@ func TestRunCleansPartialEnvUploadBeforeRetainingSandbox(t *testing.T) {
 	fake := &fakeModalAPI{uploadErr: errors.New("partial upload failed")}
 	withFakeModalAPI(t, fake)
 	backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
-	result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, KeepOnFailure: true, Env: map[string]string{"EXAMPLE": "value"}})
+	result, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, KeepOnFailure: true, Env: map[string]string{"EXAMPLE": "value"}})
 	want := []string{"create", "inspect", "exec", "upload", "exec"}
 	if err == nil || result.Session == nil || !result.Session.Kept || !reflect.DeepEqual(fake.verbs, want) || !fake.cleanupDeadlineSet {
 		t.Fatalf("result=%#v err=%v verbs=%v bounded=%t", result, err, fake.verbs, fake.cleanupDeadlineSet)
@@ -733,7 +733,7 @@ func TestRunCleansPartialEnvUploadBeforeRetainingSandbox(t *testing.T) {
 
 func TestModalConfigEffectiveFallbacksAndDisplay(t *testing.T) {
 	for _, tc := range []struct{ raw, app, image, workdir, python string }{{"", "crabbox", "python:3.13-slim", "/workspace/crabbox", "python3"}, {"  ", "crabbox", "python:3.13-slim", "/workspace/crabbox", "python3"}, {" custom ", "custom", "custom", "custom", "custom"}} {
-		cfg := Config{Modal: ModalConfig{App: tc.raw, Image: tc.raw, Workdir: tc.raw, Python: tc.raw}}
+		cfg := core.Config{Modal: core.ModalConfig{App: tc.raw, Image: tc.raw, Workdir: tc.raw, Python: tc.raw}}
 		client := &modalPythonClient{cfg: cfg}
 		if modalApp(cfg) != tc.app || modalImage(cfg) != tc.image || modalWorkdir(cfg) != tc.workdir || client.app() != tc.app || client.python() != tc.python {
 			t.Fatalf("effective fallback mismatch for %q", tc.raw)
@@ -756,14 +756,14 @@ func TestModalConfigCreateImageBridgePayload(t *testing.T) {
 			cfg.Modal.Image = tc.raw
 			fake := &fakeModalAPI{}
 			backend := NewModalBackend(Provider{}.Spec(), cfg, testRuntime()).(*modalBackend)
-			if _, _, err := backend.createSandbox(t.Context(), fake, Repo{Name: "fixture", Root: t.TempDir()}, true, false, ""); err != nil {
+			if _, _, err := backend.createSandbox(t.Context(), fake, core.Repo{Name: "fixture", Root: t.TempDir()}, true, false, ""); err != nil {
 				t.Fatal(err)
 			}
 			if fake.createReq.Image != tc.want || fake.createReq.Image == "" {
 				t.Fatalf("production create image=%q want=%q", fake.createReq.Image, tc.want)
 			}
 			runner := &modalClientRunner{stdout: "{}"}
-			client := &modalPythonClient{cfg: cfg, rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
+			client := &modalPythonClient{cfg: cfg, rt: core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
 			if _, err := client.CreateSandbox(t.Context(), fake.createReq); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/providers/modal/client.go
+++ b/internal/providers/modal/client.go
@@ -54,14 +54,14 @@ type modalSandbox struct {
 }
 
 type modalPythonClient struct {
-	cfg     Config
-	rt      Runtime
+	cfg     core.Config
+	rt      core.Runtime
 	binding *modalBinding
 }
 
-var newModalAPI = func(cfg Config, rt Runtime) (modalAPI, error) {
+var newModalAPI = func(cfg core.Config, rt core.Runtime) (modalAPI, error) {
 	if rt.Exec == nil {
-		return nil, exit(2, "provider=modal requires Runtime.Exec")
+		return nil, core.Exit(2, "provider=modal requires Runtime.Exec")
 	}
 	return &modalPythonClient{cfg: cfg, rt: rt}, nil
 }
@@ -177,7 +177,7 @@ func (c *modalPythonClient) Terminate(ctx context.Context, binding modalBinding)
 		return err
 	}
 	if sandbox.Status != "finished" {
-		return exit(5, "Modal termination did not confirm terminal state")
+		return core.Exit(5, "Modal termination did not confirm terminal state")
 	}
 	return nil
 }
@@ -188,7 +188,7 @@ func (c *modalPythonClient) runJSON(ctx context.Context, script string, payload 
 		return err
 	}
 	var stdout, stderr bytes.Buffer
-	res, err := c.rt.Exec.Run(ctx, LocalCommandRequest{
+	res, err := c.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name:   c.python(),
 		Args:   []string{"-c", script, string(data)},
 		Env:    c.env(),
@@ -213,7 +213,7 @@ func (c *modalPythonClient) runStreamed(ctx context.Context, script string, payl
 	if err != nil {
 		return core.LocalCommandResult{}, err
 	}
-	return c.rt.Exec.Run(ctx, LocalCommandRequest{
+	return c.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name:   c.python(),
 		Args:   []string{"-c", script, string(data)},
 		Env:    c.env(),

--- a/internal/providers/modal/client_test.go
+++ b/internal/providers/modal/client_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestModalExecPreservesRemoteExit125(t *testing.T) {
 	runner := &modalClientRunner{writeResult: "125"}
-	client := &modalPythonClient{cfg: newTestConfig(), rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
+	client := &modalPythonClient{cfg: newTestConfig(), rt: core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
 
 	code, err := client.Exec(context.Background(), modalExecRequest{
 		SandboxID: "sb-123",
@@ -40,7 +40,7 @@ func TestModalTransportErrorsPreserveCauses(t *testing.T) {
 		for _, operation := range []string{"exec", "upload", "json"} {
 			t.Run(operation+"/"+cause.Error(), func(t *testing.T) {
 				runner := &modalClientRunner{result: core.LocalCommandResult{ExitCode: 1}, err: cause}
-				client := &modalPythonClient{cfg: newTestConfig(), rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
+				client := &modalPythonClient{cfg: newTestConfig(), rt: core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
 				var err error
 				switch operation {
 				case "exec":
@@ -176,7 +176,7 @@ func TestModalListCarriesConfiguredEnvironment(t *testing.T) {
 	runner := &modalClientRunner{stdout: "[]\n"}
 	cfg := newTestConfig()
 	cfg.Modal.Environment = "my-app-dev"
-	client := &modalPythonClient{cfg: cfg, rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
+	client := &modalPythonClient{cfg: cfg, rt: core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
 
 	if _, err := client.ListSandboxes(context.Background(), map[string]string{"crabbox": "true"}); err != nil {
 		t.Fatal(err)
@@ -229,7 +229,7 @@ class Sandbox:
 
 func TestModalExecReportsTransportExit125(t *testing.T) {
 	runner := &modalClientRunner{result: core.LocalCommandResult{ExitCode: modalTransportExitCode}}
-	client := &modalPythonClient{cfg: newTestConfig(), rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
+	client := &modalPythonClient{cfg: newTestConfig(), rt: core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
 
 	code, err := client.Exec(context.Background(), modalExecRequest{
 		SandboxID: "sb-123",
@@ -314,7 +314,7 @@ type modalClientRunner struct {
 	err         error
 }
 
-func (r *modalClientRunner) Run(_ context.Context, req LocalCommandRequest) (core.LocalCommandResult, error) {
+func (r *modalClientRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	if len(req.Args) >= 3 {
 		if err := json.Unmarshal([]byte(req.Args[2]), &r.payload); err == nil {
 			r.resultPath, _ = r.payload["result_path"].(string)

--- a/internal/providers/modal/core.go
+++ b/internal/providers/modal/core.go
@@ -1,33 +1,8 @@
 package modal
 
 import (
-	"io"
-	"time"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type ModalConfig = core.ModalConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type RunSessionHandle = core.RunSessionHandle
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type Server = core.Server
-type Repo = core.Repo
-type ExitError = core.ExitError
-type LocalCommandRequest = core.LocalCommandRequest
-type timingPhase = core.TimingPhase
 
 const (
 	providerName = "modal"
@@ -35,51 +10,3 @@ const (
 
 	networkPublic = core.NetworkPublic
 )
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
-	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
-}
-
-func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaim(identifier)
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
-func shellQuote(s string) string {
-	return core.ShellQuote(s)
-}
-
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
-func shellWords(words []string) []string {
-	return core.ShellWords(words)
-}
-
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func leadingEnvAssignment(command []string) bool {
-	return core.LeadingEnvAssignment(command)
-}
-
-func inventoryDoctorResult(provider string, leases int) DoctorResult {
-	return core.InventoryDoctorResult(provider, leases)
-}

--- a/internal/providers/modal/env.go
+++ b/internal/providers/modal/env.go
@@ -3,6 +3,7 @@ package modal
 import (
 	"context"
 	"fmt"
+
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
@@ -17,7 +18,7 @@ func (b *modalBackend) uploadEnvProfile(ctx context.Context, client modalAPI, cl
 			// Each operation owns a unique path; shared fencing excludes claim writers
 			// without allowing lock contention to outlive the cleanup deadline.
 			return core.WithLeaseClaimUnchangedShared(removeCtx, claim.LeaseID, claim, func() error {
-				return b.execShell(removeCtx, client, claim.CloudID, "rm -f "+shellQuote(remotePath), nil)
+				return b.execShell(removeCtx, client, claim.CloudID, "rm -f "+core.ShellQuote(remotePath), nil)
 			})
 		})
 		if err != nil {

--- a/internal/providers/modal/flags.go
+++ b/internal/providers/modal/flags.go
@@ -7,11 +7,11 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func RegisterModalProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterModalProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterModalConfigFlags(fs, defaults.Modal)
 }
 
-func ApplyModalProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyModalProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if cfg.Provider == providerName {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
 			return err

--- a/internal/providers/modal/flags_test.go
+++ b/internal/providers/modal/flags_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestModalSecretFlagsReplaceConfiguredDefaults(t *testing.T) {
@@ -53,7 +55,7 @@ func TestModalConfigFlagContract(t *testing.T) {
 			t.Fatalf("flag %s=%#v", tc.name, f)
 		}
 	}
-	cfg.Modal = ModalConfig{App: "layered-app", Image: "layered-image", Workdir: "/workspace/layered", Python: "layered-python", Environment: "layered-env", Secrets: []string{"layered"}}
+	cfg.Modal = core.ModalConfig{App: "layered-app", Image: "layered-image", Workdir: "/workspace/layered", Python: "layered-python", Environment: "layered-env", Secrets: []string{"layered"}}
 	want := cfg.Modal
 	if err := ApplyModalProviderFlags(&cfg, fs, values); err != nil {
 		t.Fatal(err)
@@ -73,7 +75,7 @@ func TestModalConfigFlagContract(t *testing.T) {
 	if err := ApplyModalProviderFlags(&cfg, fs, values); err != nil {
 		t.Fatal(err)
 	}
-	want = ModalConfig{Image: "  ", Workdir: "/workspace/flag", Python: "flag-python", Environment: "flag-env", Secrets: []string{"alpha", "beta", "alpha"}}
+	want = core.ModalConfig{Image: "  ", Workdir: "/workspace/flag", Python: "flag-python", Environment: "flag-env", Secrets: []string{"alpha", "beta", "alpha"}}
 	if !reflect.DeepEqual(cfg.Modal, want) {
 		t.Fatalf("flags=%#v want=%#v", cfg.Modal, want)
 	}
@@ -142,7 +144,7 @@ func TestModalConfigListFlagCopies(t *testing.T) {
 func TestModalConfigFlagGuardOrder(t *testing.T) {
 	for _, provider := range []string{"modal", " MODAL ", "aws"} {
 		for _, args := range [][]string{{"--class=large", "--type=machine"}, {"--type=machine"}} {
-			cfg := Config{Provider: provider}
+			cfg := core.Config{Provider: provider}
 			fs := flag.NewFlagSet("contract", flag.ContinueOnError)
 			fs.String("class", "", "")
 			fs.String("type", "", "")

--- a/internal/providers/modal/identity.go
+++ b/internal/providers/modal/identity.go
@@ -44,15 +44,15 @@ func (s modalScope) canonical() (string, error) {
 	for _, endpoint := range strings.Split(s.Endpoint, ",") {
 		u, err := url.Parse(endpoint)
 		if err != nil || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Opaque != "" || (u.Scheme != "https" && u.Scheme != "http") {
-			return "", exit(2, "Modal ownership requires API endpoints without credentials, query, or fragment")
+			return "", core.Exit(2, "Modal ownership requires API endpoints without credentials, query, or fragment")
 		}
 	}
 	if !modalObjectID(s.EnvironmentID, "en-") || !modalObjectID(s.AppID, "ap-") {
-		return "", exit(2, "Modal ownership requires native environment and app IDs")
+		return "", core.Exit(2, "Modal ownership requires native environment and app IDs")
 	}
 	for _, value := range []string{s.Workspace, s.Environment, s.App} {
 		if value == "" || len(value) > 256 || strings.TrimSpace(value) != value || strings.ContainsAny(value, "\r\n\x00") {
-			return "", exit(2, "Modal ownership requires an authenticated workspace and resolved environment/app names")
+			return "", core.Exit(2, "Modal ownership requires an authenticated workspace and resolved environment/app names")
 		}
 	}
 	data, err := json.Marshal(s)
@@ -61,21 +61,21 @@ func (s modalScope) canonical() (string, error) {
 
 func (b modalBinding) validate(sandbox modalSandbox) error {
 	if !modalObjectID(b.ID, "sb-") || !core.IsCanonicalLeaseID(b.LeaseID) || b.Slug == "" {
-		return exit(2, "Modal ownership requires an exact sandbox, lease, and slug")
+		return core.Exit(2, "Modal ownership requires an exact sandbox, lease, and slug")
 	}
 	if _, err := b.Scope.canonical(); err != nil {
 		return err
 	}
 	if sandbox.ID != b.ID || sandbox.Scope != b.Scope {
-		return exit(2, "Modal sandbox identity or authority changed; retaining resource")
+		return core.Exit(2, "Modal sandbox identity or authority changed; retaining resource")
 	}
 	for key, want := range map[string]string{"provider": providerName, "crabbox": "true", "lease": b.LeaseID, "slug": b.Slug, "app": b.Scope.App} {
 		if sandbox.Tags[key] != want {
-			return exit(2, "Modal sandbox ownership tag %s does not match the exact claim", key)
+			return core.Exit(2, "Modal sandbox ownership tag %s does not match the exact claim", key)
 		}
 	}
 	if sandbox.Status != "running" && sandbox.Status != "finished" {
-		return exit(2, "Modal sandbox terminal state is unknown")
+		return core.Exit(2, "Modal sandbox terminal state is unknown")
 	}
 	return nil
 }
@@ -84,11 +84,11 @@ func modalClaimBinding(claim core.LeaseClaim) (modalBinding, shared.ClaimBinding
 	binding := modalBinding{ID: claim.CloudID, LeaseID: claim.LeaseID, Slug: claim.Slug}
 	want := shared.ClaimBinding{Provider: providerName, LeaseID: claim.LeaseID, Slug: claim.Slug, CloudID: claim.CloudID, ProviderScope: claim.ProviderScope, ExactProviderScope: true}
 	if json.Unmarshal([]byte(claim.ProviderScope), &binding.Scope) != nil || claim.Revision == "" {
-		return binding, want, exit(2, "Modal lease %q has no exact sandbox/scope binding; inspect and clean up through Modal directly; --reclaim cannot adopt legacy ownership", claim.LeaseID)
+		return binding, want, core.Exit(2, "Modal lease %q has no exact sandbox/scope binding; inspect and clean up through Modal directly; --reclaim cannot adopt legacy ownership", claim.LeaseID)
 	}
 	scope, err := binding.Scope.canonical()
 	if err != nil || scope != claim.ProviderScope {
-		return binding, want, exit(2, "Modal lease %q has an incomplete or invalid authority binding", claim.LeaseID)
+		return binding, want, core.Exit(2, "Modal lease %q has an incomplete or invalid authority binding", claim.LeaseID)
 	}
 	if err := binding.validate(modalSandbox{ID: claim.CloudID, Scope: binding.Scope, Tags: claim.Labels, Status: "running"}); err != nil {
 		return binding, want, err
@@ -99,7 +99,7 @@ func modalClaimBinding(claim core.LeaseClaim) (modalBinding, shared.ClaimBinding
 func resolveModalClaim(id string) (core.LeaseClaim, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return core.LeaseClaim{}, exit(2, "provider=modal requires a claimed lease id, slug, or sandbox id")
+		return core.LeaseClaim{}, core.Exit(2, "provider=modal requires a claimed lease id, slug, or sandbox id")
 	}
 	var claim core.LeaseClaim
 	var ok bool
@@ -112,7 +112,7 @@ func resolveModalClaim(id string) (core.LeaseClaim, error) {
 		for _, candidate := range claims {
 			if candidate.CloudID == id {
 				if ok {
-					return claim, exit(2, "Modal sandbox %q has ambiguous local claims", id)
+					return claim, core.Exit(2, "Modal sandbox %q has ambiguous local claims", id)
 				}
 				claim, ok = candidate, true
 			}
@@ -128,7 +128,7 @@ func resolveModalClaim(id string) (core.LeaseClaim, error) {
 		return claim, err
 	}
 	if !ok {
-		return claim, exit(4, "Modal resource %q has no exact local ownership claim; use read-only status/list and inspect or clean up through Modal directly", id)
+		return claim, core.Exit(4, "Modal resource %q has no exact local ownership claim; use read-only status/list and inspect or clean up through Modal directly", id)
 	}
 	_, _, err = modalClaimBinding(claim)
 	return claim, err
@@ -152,7 +152,7 @@ func (b *modalBackend) resolveOwnedSandbox(ctx context.Context, client modalAPI,
 			return err
 		}
 		if sandbox.Status != "running" {
-			return exit(2, "Modal sandbox has finished; create a new lease")
+			return core.Exit(2, "Modal sandbox has finished; create a new lease")
 		}
 		return nil
 	}
@@ -163,7 +163,7 @@ func (b *modalBackend) resolveOwnedSandbox(ctx context.Context, client modalAPI,
 	if idleTimeout <= 0 {
 		idleTimeout = time.Duration(claim.IdleTimeoutSeconds) * time.Second
 	}
-	server := Server{Provider: providerName, CloudID: claim.CloudID, Labels: shared.CloneLabels(claim.Labels)}
+	server := core.Server{Provider: providerName, CloudID: claim.CloudID, Labels: shared.CloneLabels(claim.Labels)}
 	return core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfter(claim.LeaseID, claim.Slug, b.cfg, claim.ProviderScope, server, core.SSHTarget{}, repoRoot, idleTimeout, reclaim, claim, true, verify)
 }
 
@@ -182,12 +182,12 @@ func removeModalClaim(ctx context.Context, client modalAPI, claim core.LeaseClai
 	})
 }
 
-var publishModalClaim = func(b *modalBackend, ctx context.Context, client modalAPI, binding modalBinding, sandbox modalSandbox, repo Repo, reclaim bool) (core.LeaseClaim, error) {
+var publishModalClaim = func(b *modalBackend, ctx context.Context, client modalAPI, binding modalBinding, sandbox modalSandbox, repo core.Repo, reclaim bool) (core.LeaseClaim, error) {
 	scope, err := binding.Scope.canonical()
 	if err != nil {
 		return core.LeaseClaim{}, err
 	}
-	server := Server{Provider: providerName, CloudID: sandbox.ID, Labels: shared.CloneLabels(sandbox.Tags)}
+	server := core.Server{Provider: providerName, CloudID: sandbox.ID, Labels: shared.CloneLabels(sandbox.Tags)}
 	return core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfter(binding.LeaseID, binding.Slug, b.cfg, scope, server, core.SSHTarget{}, repo.Root, b.cfg.IdleTimeout, reclaim, core.LeaseClaim{}, false, func() error {
 		current, err := client.InspectSandbox(ctx, binding)
 		if err != nil {
@@ -197,7 +197,7 @@ var publishModalClaim = func(b *modalBackend, ctx context.Context, client modalA
 			return err
 		}
 		if current.Status != "running" {
-			return exit(2, "Modal sandbox finished before ownership publication")
+			return core.Exit(2, "Modal sandbox finished before ownership publication")
 		}
 		return nil
 	})

--- a/internal/providers/modal/identity_test.go
+++ b/internal/providers/modal/identity_test.go
@@ -15,13 +15,13 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func ownedModalFixture(t *testing.T) (*modalBackend, *fakeModalAPI, core.LeaseClaim, Repo) {
+func ownedModalFixture(t *testing.T) (*modalBackend, *fakeModalAPI, core.LeaseClaim, core.Repo) {
 	t.Helper()
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := &fakeModalAPI{}
 	withFakeModalAPI(t, fake)
 	b := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
-	repo := Repo{Name: "repo", Root: t.TempDir()}
+	repo := core.Repo{Name: "repo", Root: t.TempDir()}
 	claim, _, err := b.createSandbox(t.Context(), fake, repo, true, false, "")
 	if err != nil {
 		t.Fatal(err)
@@ -57,7 +57,7 @@ func TestModalStopRequiresExactClaimBeforeProviderAccess(t *testing.T) {
 			fake := &fakeModalAPI{}
 			withFakeModalAPI(t, fake)
 			b := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
-			if err := b.Stop(t.Context(), StopRequest{ID: id}); err == nil || len(fake.verbs) != 0 {
+			if err := b.Stop(t.Context(), core.StopRequest{ID: id}); err == nil || len(fake.verbs) != 0 {
 				t.Fatalf("claimless stop err=%v verbs=%v", err, fake.verbs)
 			}
 		})
@@ -80,7 +80,7 @@ func TestModalCreatedClaimAndStopBindExactResource(t *testing.T) {
 				return nil
 			}
 			id := map[string]string{"lease": claim.LeaseID, "slug": claim.Slug, "raw": claim.CloudID}[idKind]
-			if err := b.Stop(t.Context(), StopRequest{ID: id}); err != nil {
+			if err := b.Stop(t.Context(), core.StopRequest{ID: id}); err != nil {
 				t.Fatal(err)
 			}
 			if fake.terminateRemaining < 90*time.Second || fake.terminateRemaining > modalCleanupTimeout {
@@ -97,11 +97,11 @@ func TestModalRawIDRejectsDuplicateClaims(t *testing.T) {
 	b, fake, claim, _ := ownedModalFixture(t)
 	labels := maps.Clone(claim.Labels)
 	labels["lease"], labels["slug"] = "cbx_0123456789ab", "duplicate-crab"
-	server := Server{Provider: providerName, CloudID: claim.CloudID, Labels: labels}
+	server := core.Server{Provider: providerName, CloudID: claim.CloudID, Labels: labels}
 	if _, err := core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfter(labels["lease"], labels["slug"], b.cfg, claim.ProviderScope, server, core.SSHTarget{}, t.TempDir(), 0, false, core.LeaseClaim{}, false, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Stop(t.Context(), StopRequest{ID: claim.CloudID}); err == nil || !strings.Contains(err.Error(), "ambiguous") || len(fake.verbs) != 0 {
+	if err := b.Stop(t.Context(), core.StopRequest{ID: claim.CloudID}); err == nil || !strings.Contains(err.Error(), "ambiguous") || len(fake.verbs) != 0 {
 		t.Fatalf("duplicate sandbox claims accepted: err=%v verbs=%v", err, fake.verbs)
 	}
 	assertModalClaim(t, claim)
@@ -129,7 +129,7 @@ func TestModalStopRejectsIncompleteAndConflictingClaims(t *testing.T) {
 				t.Fatal(err)
 			}
 			changed, _, _ = core.ReadLeaseClaimWithPresence(claim.LeaseID)
-			if err := b.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err == nil || len(fake.verbs) != 0 {
+			if err := b.Stop(t.Context(), core.StopRequest{ID: claim.LeaseID}); err == nil || len(fake.verbs) != 0 {
 				t.Fatalf("invalid claim accepted: err=%v verbs=%v", err, fake.verbs)
 			}
 			assertModalClaim(t, changed)
@@ -156,7 +156,7 @@ func TestModalTerminationFailureRetainsExactClaim(t *testing.T) {
 		t.Run(failure.Error(), func(t *testing.T) {
 			b, fake, claim, _ := ownedModalFixture(t)
 			fake.terminateErr = failure
-			if err := b.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err == nil {
+			if err := b.Stop(t.Context(), core.StopRequest{ID: claim.LeaseID}); err == nil {
 				t.Fatal("uncertain termination accepted")
 			}
 			assertModalClaim(t, claim)
@@ -187,7 +187,7 @@ func TestModalRollbackPreservesAppearingClaim(t *testing.T) {
 	b := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
 	old := publishModalClaim
 	var successor core.LeaseClaim
-	publishModalClaim = func(_ *modalBackend, _ context.Context, _ modalAPI, binding modalBinding, _ modalSandbox, repo Repo, _ bool) (core.LeaseClaim, error) {
+	publishModalClaim = func(_ *modalBackend, _ context.Context, _ modalAPI, binding modalBinding, _ modalSandbox, repo core.Repo, _ bool) (core.LeaseClaim, error) {
 		if err := core.ClaimLeaseForRepoProvider(binding.LeaseID, binding.Slug, "other", repo.Root, 0, false); err != nil {
 			t.Fatal(err)
 		}
@@ -195,7 +195,7 @@ func TestModalRollbackPreservesAppearingClaim(t *testing.T) {
 		return core.LeaseClaim{}, errors.New("claim publication failed")
 	}
 	t.Cleanup(func() { publishModalClaim = old })
-	_, _, err := b.createSandbox(t.Context(), fake, Repo{Name: "repo", Root: t.TempDir()}, true, false, "")
+	_, _, err := b.createSandbox(t.Context(), fake, core.Repo{Name: "repo", Root: t.TempDir()}, true, false, "")
 	if err == nil || containsVerb(fake.verbs, "terminate") {
 		t.Fatalf("rollback destroyed a newly claimed resource: err=%v verbs=%v", err, fake.verbs)
 	}
@@ -215,7 +215,7 @@ func TestModalClaimPublicationAndAbsentRollbackAreFenced(t *testing.T) {
 		assertModalFence(t, binding.LeaseID)
 		return nil
 	}
-	_, _, err := b.createSandbox(t.Context(), fake, Repo{Name: "repo", Root: t.TempDir()}, false, false, "")
+	_, _, err := b.createSandbox(t.Context(), fake, core.Repo{Name: "repo", Root: t.TempDir()}, false, false, "")
 	if err == nil || !strings.Contains(err.Error(), "inspection failed") || !reflect.DeepEqual(fake.verbs, []string{"create", "inspect", "terminate"}) {
 		t.Fatalf("rollback err=%v verbs=%v", err, fake.verbs)
 	}

--- a/internal/providers/modal/sync.go
+++ b/internal/providers/modal/sync.go
@@ -10,7 +10,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *modalBackend) syncWorkspace(ctx context.Context, client modalAPI, sandboxID string, req RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+func (b *modalBackend) syncWorkspace(ctx context.Context, client modalAPI, sandboxID string, req core.RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	workdir, err := cleanModalWorkdir(workdir)
 	if err != nil {
 		return nil, 0, err
@@ -39,7 +39,7 @@ func (b *modalBackend) prepareWorkspace(ctx context.Context, client modalAPI, sa
 	if err != nil {
 		return err
 	}
-	return b.execShell(ctx, client, sandboxID, "mkdir -p "+shellQuote(workdir), io.Discard)
+	return b.execShell(ctx, client, sandboxID, "mkdir -p "+core.ShellQuote(workdir), io.Discard)
 }
 
 func (b *modalBackend) execShell(ctx context.Context, client modalAPI, sandboxID, command string, stdout io.Writer) error {
@@ -54,7 +54,7 @@ func (b *modalBackend) execShell(ctx context.Context, client modalAPI, sandboxID
 		return fmt.Errorf("modal exec %q: %w", command, err)
 	}
 	if code != 0 {
-		return exit(code, "modal exec %q exited %d", command, code)
+		return core.Exit(code, "modal exec %q exited %d", command, code)
 	}
 	return nil
 }

--- a/internal/providers/opensandbox/backend.go
+++ b/internal/providers/opensandbox/backend.go
@@ -23,17 +23,17 @@ import (
 )
 
 type openSandboxBackend struct {
-	spec                   ProviderSpec
-	cfg                    Config
-	rt                     Runtime
-	newClient              func(Config, Runtime) (openSandboxClient, error)
+	spec                   core.ProviderSpec
+	cfg                    core.Config
+	rt                     core.Runtime
+	newClient              func(core.Config, core.Runtime) (openSandboxClient, error)
 	cleanupTimeoutOverride time.Duration
 	reconcilePollOverride  time.Duration
 	statusPollOverride     time.Duration
 	statusProbeOverride    time.Duration
 }
 
-func (b *openSandboxBackend) Spec() ProviderSpec { return b.spec }
+func (b *openSandboxBackend) Spec() core.ProviderSpec { return b.spec }
 
 func (b *openSandboxBackend) client() (openSandboxClient, error) {
 	if b.newClient != nil {
@@ -42,12 +42,12 @@ func (b *openSandboxBackend) client() (openSandboxClient, error) {
 	return newOpenSandboxClient(b.cfg, b.rt)
 }
 
-func (b *openSandboxBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *openSandboxBackend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if req.ActionsRunner {
-		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+		return core.Exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
 	if req.Options.Tailscale.Enabled {
-		return exit(2, "provider=opensandbox is delegated-run only and does not support Tailscale options")
+		return core.Exit(2, "provider=opensandbox is delegated-run only and does not support Tailscale options")
 	}
 	if err := validateOpenSandboxRunConfig(b.cfg); err != nil {
 		return err
@@ -77,8 +77,7 @@ func (b *openSandboxBackend) Warmup(ctx context.Context, req WarmupRequest) erro
 	}
 	required := openSandboxRunBudgetForConfig(b.cfg, false, false)
 	if remaining := deadline.Sub(core.ClockNow(b.rt.Clock)); remaining < required {
-		return b.cleanupClaimedSandboxFailure(ctx, api, leaseID, sandboxID,
-			exit(5, "opensandbox sandbox %s has %s remaining after warmup, less than the %s default run budget", sandboxID, remaining.Round(time.Second), required))
+		return b.cleanupClaimedSandboxFailure(ctx, api, leaseID, sandboxID, core.Exit(5, "opensandbox sandbox %s has %s remaining after warmup, less than the %s default run budget", sandboxID, remaining.Round(time.Second), required))
 	}
 	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, sandboxID)
 	if !req.Keep {
@@ -93,12 +92,12 @@ func (b *openSandboxBackend) Warmup(ctx context.Context, req WarmupRequest) erro
 	})
 }
 
-func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *openSandboxBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	workdir, workdirErr := openSandboxWorkdir(b.cfg)
 	var api openSandboxClient
 	var leaseID, sandboxID, slug string
 	var sb sandboxInfo
-	var claim LeaseClaim
+	var claim core.LeaseClaim
 	var deadline time.Time
 	cleanupTimeout := openSandboxCleanupTimeout
 	if b.cleanupTimeoutOverride > 0 {
@@ -117,10 +116,10 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 			return err
 		}
 		if !deadline.After(core.ClockNow(b.rt.Clock)) {
-			return exit(5, "opensandbox sandbox %s exceeded its absolute Crabbox TTL", sandboxID)
+			return core.Exit(5, "opensandbox sandbox %s exceeded its absolute Crabbox TTL", sandboxID)
 		}
 		if remaining, required := deadline.Sub(core.ClockNow(b.rt.Clock)), b.runLifetimeBudget(req); remaining < required {
-			return exit(5, "opensandbox sandbox %s has %s remaining before its absolute TTL, less than the %s sync/command budget; create a new sandbox", sandboxID, remaining.Round(time.Second), required)
+			return core.Exit(5, "opensandbox sandbox %s has %s remaining before its absolute TTL, less than the %s sync/command budget; create a new sandbox", sandboxID, remaining.Round(time.Second), required)
 		}
 		return nil
 	}
@@ -129,7 +128,7 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 		IdleTimeout: b.cfg.IdleTimeout, TTL: b.cfg.TTL, CleanupTimeout: cleanupTimeout,
 		Preflight: func(context.Context) error {
 			if req.Options.Tailscale.Enabled {
-				return exit(2, "provider=opensandbox is delegated-run only and does not support Tailscale options")
+				return core.Exit(2, "provider=opensandbox is delegated-run only and does not support Tailscale options")
 			}
 			if req.ID == "" {
 				if err := validateOpenSandboxRequestConfig(b.cfg, req); err != nil {
@@ -177,7 +176,7 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 			if err != nil {
 				return resolved, err
 			}
-			claim, err = readLeaseClaim(leaseID)
+			claim, err = core.ReadLeaseClaim(leaseID)
 			if err != nil {
 				return resolved, err
 			}
@@ -186,7 +185,7 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 			}
 			slug = claim.Slug
 			if strings.TrimSpace(slug) == "" {
-				slug = newLeaseSlug(leaseID)
+				slug = core.NewLeaseSlug(leaseID)
 			}
 			resolved.LeaseID, resolved.Slug = leaseID, slug
 			resolved.CleanupCommand = openSandboxCleanupCommand(leaseID)
@@ -200,10 +199,10 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 				return err
 			}
 			if !deadline.After(core.ClockNow(b.rt.Clock)) {
-				return exit(5, "opensandbox sandbox %s exceeded its absolute Crabbox TTL while resuming", sandboxID)
+				return core.Exit(5, "opensandbox sandbox %s exceeded its absolute Crabbox TTL while resuming", sandboxID)
 			}
 			if remaining, required := deadline.Sub(core.ClockNow(b.rt.Clock)), b.runLifetimeBudget(req); remaining < required {
-				return exit(5, "opensandbox sandbox %s has %s remaining after resume before its absolute TTL, less than the %s sync/command budget; create a new sandbox", sandboxID, remaining.Round(time.Second), required)
+				return core.Exit(5, "opensandbox sandbox %s has %s remaining after resume before its absolute TTL, less than the %s sync/command budget; create a new sandbox", sandboxID, remaining.Round(time.Second), required)
 			}
 			if err := ctx.Err(); err != nil {
 				return err
@@ -232,10 +231,10 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 				return shared.DelegatedSandboxCommand{}, err
 			}
 			if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
-				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+				core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 			}
 			if remaining := deadline.Sub(core.ClockNow(b.rt.Clock)); remaining < b.commandLifetime() {
-				return shared.DelegatedSandboxCommand{}, exit(5, "opensandbox sandbox %s has %s remaining before its absolute TTL, less than the %s command budget; create a new sandbox", sandboxID, remaining.Round(time.Second), b.commandLifetime())
+				return shared.DelegatedSandboxCommand{}, core.Exit(5, "opensandbox sandbox %s has %s remaining before its absolute TTL, less than the %s command budget; create a new sandbox", sandboxID, remaining.Round(time.Second), b.commandLifetime())
 			}
 			text := intent.ShellCommand("bash", "-lc")
 			return shared.DelegatedSandboxCommand{
@@ -255,13 +254,13 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 			if err := api.DeleteSandbox(ctx, sandboxID); err != nil && !isOpenSandboxNotFound(err) {
 				return fmt.Errorf("opensandbox delete failed for %s: %w", sandboxID, err)
 			}
-			removeLeaseClaim(leaseID)
+			core.RemoveLeaseClaim(leaseID)
 			return nil
 		},
 	})
 }
 
-func (b *openSandboxBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *openSandboxBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	api, err := b.client()
 	if err != nil {
@@ -271,7 +270,7 @@ func (b *openSandboxBackend) List(ctx context.Context, req ListRequest) ([]Lease
 	if err != nil {
 		return nil, err
 	}
-	servers := make([]Server, 0, len(claims))
+	servers := make([]core.Server, 0, len(claims))
 	for _, claim := range claims {
 		if claim.Provider != providerName || !strings.HasPrefix(claim.LeaseID, leasePrefix) {
 			continue
@@ -297,7 +296,7 @@ func (b *openSandboxBackend) List(ctx context.Context, req ListRequest) ([]Lease
 			}
 			state = core.Blank(strings.ToLower(sb.State), statusViewReady)
 		}
-		servers = append(servers, Server{
+		servers = append(servers, core.Server{
 			Provider: providerName,
 			CloudID:  sandboxID,
 			Name:     sandboxID,
@@ -315,36 +314,36 @@ func (b *openSandboxBackend) List(ctx context.Context, req ListRequest) ([]Lease
 	return servers, nil
 }
 
-func (b *openSandboxBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *openSandboxBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	api, err := b.client()
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
 	if err := api.Probe(ctx); err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	servers, err := b.List(ctx, ListRequest{})
+	servers, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return inventoryDoctorResult(providerName, len(servers)), nil
+	return core.InventoryDoctorResult(providerName, len(servers)), nil
 }
 
-func (b *openSandboxBackend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *openSandboxBackend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	api, err := b.client()
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	leaseID, sandboxID, slug, err := resolveLeaseID(req.ID, "", false, 0, api.BaseURL())
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	claim, ok, err := resolveOpenSandboxLeaseClaim(leaseID, api.BaseURL())
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	if !ok {
-		return StatusView{}, exit(4, "opensandbox sandbox %q is not claimed by Crabbox", req.ID)
+		return core.StatusView{}, core.Exit(4, "opensandbox sandbox %q is not claimed by Crabbox", req.ID)
 	}
 	waitTimeout := req.WaitTimeout
 	if waitTimeout <= 0 {
@@ -361,15 +360,15 @@ func (b *openSandboxBackend) Status(ctx context.Context, req StatusRequest) (Sta
 		sb, getErr := api.GetSandbox(pollCtx, sandboxID)
 		if getErr != nil {
 			if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return StatusView{}, exit(5, "timed out waiting for opensandbox sandbox %s to become ready", sandboxID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for opensandbox sandbox %s to become ready", sandboxID)
 			}
 			if ctx.Err() != nil {
-				return StatusView{}, ctx.Err()
+				return core.StatusView{}, ctx.Err()
 			}
-			return StatusView{}, getErr
+			return core.StatusView{}, getErr
 		}
 		if err := validateOpenSandboxOwnership(claim, sb); err != nil {
-			return StatusView{}, err
+			return core.StatusView{}, err
 		}
 		state := strings.ToLower(strings.TrimSpace(sb.State))
 		ready := false
@@ -380,15 +379,15 @@ func (b *openSandboxBackend) Status(ctx context.Context, req StatusRequest) (Sta
 			ready = pingErr == nil
 			if pingErr != nil && pollCtx.Err() != nil {
 				if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-					return StatusView{}, exit(5, "timed out waiting for opensandbox sandbox %s to become ready", sandboxID)
+					return core.StatusView{}, core.Exit(5, "timed out waiting for opensandbox sandbox %s to become ready", sandboxID)
 				}
-				return StatusView{}, pollCtx.Err()
+				return core.StatusView{}, pollCtx.Err()
 			}
 			if pingErr != nil && !isOpenSandboxReadinessPending(pingErr) {
-				return StatusView{}, fmt.Errorf("opensandbox status execd health: %w", pingErr)
+				return core.StatusView{}, fmt.Errorf("opensandbox status execd health: %w", pingErr)
 			}
 		}
-		view := StatusView{
+		view := core.StatusView{
 			ID:       leaseID,
 			Slug:     slug,
 			Provider: providerName,
@@ -409,23 +408,23 @@ func (b *openSandboxBackend) Status(ctx context.Context, req StatusRequest) (Sta
 			return view, nil
 		}
 		if isTerminalState(state) {
-			return StatusView{}, exit(5, "opensandbox sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
+			return core.StatusView{}, core.Exit(5, "opensandbox sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
 		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return StatusView{}, exit(5, "timed out waiting for opensandbox sandbox %s to become ready", sandboxID)
+			return core.StatusView{}, core.Exit(5, "timed out waiting for opensandbox sandbox %s to become ready", sandboxID)
 		}
 		select {
 		case <-pollCtx.Done():
 			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return StatusView{}, exit(5, "timed out waiting for opensandbox sandbox %s to become ready", sandboxID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for opensandbox sandbox %s to become ready", sandboxID)
 			}
-			return StatusView{}, pollCtx.Err()
+			return core.StatusView{}, pollCtx.Err()
 		case <-time.After(b.statusPollInterval()):
 		}
 	}
 }
 
-func (b *openSandboxBackend) Stop(ctx context.Context, req StopRequest) error {
+func (b *openSandboxBackend) Stop(ctx context.Context, req core.StopRequest) error {
 	api, err := b.client()
 	if err != nil {
 		return err
@@ -448,7 +447,7 @@ func (b *openSandboxBackend) Stop(ctx context.Context, req StopRequest) error {
 			return err
 		}
 		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing opensandbox sandbox=%s after explicit request\n", sandboxID)
-		removeLeaseClaim(leaseID)
+		core.RemoveLeaseClaim(leaseID)
 		return nil
 	}
 	if err := api.DeleteSandbox(ctx, sandboxID); err != nil {
@@ -457,12 +456,12 @@ func (b *openSandboxBackend) Stop(ctx context.Context, req StopRequest) error {
 		}
 		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing opensandbox sandbox=%s after explicit request\n", sandboxID)
 	}
-	removeLeaseClaim(leaseID)
+	core.RemoveLeaseClaim(leaseID)
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, sandboxID)
 	return nil
 }
 
-func (b *openSandboxBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
+func (b *openSandboxBackend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	api, err := b.client()
 	if err != nil {
 		return err
@@ -486,7 +485,7 @@ func (b *openSandboxBackend) Cleanup(ctx context.Context, req CleanupRequest) er
 				return err
 			}
 			defer unlock()
-			claim, err := readLeaseClaim(listedClaim.LeaseID)
+			claim, err := core.ReadLeaseClaim(listedClaim.LeaseID)
 			if err != nil {
 				return err
 			}
@@ -512,7 +511,7 @@ func (b *openSandboxBackend) Cleanup(ctx context.Context, req CleanupRequest) er
 					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 					return nil
 				}
-				if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+				if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 					return err
 				}
 				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
@@ -534,7 +533,7 @@ func (b *openSandboxBackend) Cleanup(ctx context.Context, req CleanupRequest) er
 			if err := api.DeleteSandbox(ctx, sandboxID); err != nil && !isOpenSandboxNotFound(err) {
 				return err
 			}
-			if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+			if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 				return err
 			}
 			fmt.Fprintf(b.rt.Stdout, "delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
@@ -560,7 +559,7 @@ func (b *openSandboxBackend) Cleanup(ctx context.Context, req CleanupRequest) er
 	return nil
 }
 
-func (b *openSandboxBackend) cleanupOpenSandboxRecovery(ctx context.Context, api openSandboxClient, claim LeaseClaim, now time.Time, dryRun bool) (bool, bool, error) {
+func (b *openSandboxBackend) cleanupOpenSandboxRecovery(ctx context.Context, api openSandboxClient, claim core.LeaseClaim, now time.Time, dryRun bool) (bool, bool, error) {
 	sandboxes, err := api.ListSandboxes(ctx, map[string]string{openSandboxClaimKey: claim.ProviderScope})
 	if err != nil {
 		return false, false, err
@@ -571,7 +570,7 @@ func (b *openSandboxBackend) cleanupOpenSandboxRecovery(ctx context.Context, api
 			continue
 		}
 		if strings.TrimSpace(sb.ID) == "" {
-			return false, false, exit(5, "opensandbox recovery %s matched a sandbox without an id", claim.LeaseID)
+			return false, false, core.Exit(5, "opensandbox recovery %s matched a sandbox without an id", claim.LeaseID)
 		}
 		matches = append(matches, sb)
 	}
@@ -588,7 +587,7 @@ func (b *openSandboxBackend) cleanupOpenSandboxRecovery(ctx context.Context, api
 			fmt.Fprintf(b.rt.Stdout, "would remove recovery=%s reason=sandbox lifetime elapsed\n", claim.LeaseID)
 			return false, false, nil
 		}
-		if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+		if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 			return false, false, err
 		}
 		fmt.Fprintf(b.rt.Stdout, "remove recovery=%s reason=sandbox lifetime elapsed\n", claim.LeaseID)
@@ -605,7 +604,7 @@ func (b *openSandboxBackend) cleanupOpenSandboxRecovery(ctx context.Context, api
 			return false, false, err
 		}
 	}
-	if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+	if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 		return false, false, err
 	}
 	for _, sb := range matches {
@@ -614,23 +613,23 @@ func (b *openSandboxBackend) cleanupOpenSandboxRecovery(ctx context.Context, api
 	return true, false, nil
 }
 
-func openSandboxRecoveryExpired(claim LeaseClaim, now time.Time) (bool, error) {
+func openSandboxRecoveryExpired(claim core.LeaseClaim, now time.Time) (bool, error) {
 	createdAt, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.ClaimedAt))
 	if err != nil {
-		return false, exit(5, "opensandbox recovery %s has invalid claimed time", claim.LeaseID)
+		return false, core.Exit(5, "opensandbox recovery %s has invalid claimed time", claim.LeaseID)
 	}
 	if claim.IdleTimeoutSeconds <= 0 {
-		return false, exit(5, "opensandbox recovery %s has no sandbox lifetime", claim.LeaseID)
+		return false, core.Exit(5, "opensandbox recovery %s has no sandbox lifetime", claim.LeaseID)
 	}
 	return !now.Before(createdAt.Add(time.Duration(claim.IdleTimeoutSeconds) * time.Second)), nil
 }
 
-func openSandboxClaimMatchesEndpoint(claim LeaseClaim, baseURL string) bool {
+func openSandboxClaimMatchesEndpoint(claim core.LeaseClaim, baseURL string) bool {
 	return strings.HasPrefix(strings.TrimSpace(claim.ProviderScope), openSandboxEndpointScope(baseURL)+"-own-")
 }
 
 func (b *openSandboxBackend) refreshOpenSandboxLeaseActivity(leaseID string) error {
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		return err
 	}
@@ -638,7 +637,7 @@ func (b *openSandboxBackend) refreshOpenSandboxLeaseActivity(leaseID string) err
 		return nil
 	}
 	idleTimeout := timeoutOrDefault(b.cfg.IdleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second)
-	return claimLeaseForRepoProviderScopePond(
+	return core.ClaimLeaseForRepoProviderScopePond(
 		claim.LeaseID,
 		claim.Slug,
 		providerName,
@@ -650,7 +649,7 @@ func (b *openSandboxBackend) refreshOpenSandboxLeaseActivity(leaseID string) err
 	)
 }
 
-func (b *openSandboxBackend) createSandbox(ctx context.Context, api openSandboxClient, repo Repo, reclaim bool, requestedSlug string) (string, string, string, sandboxInfo, func(), error) {
+func (b *openSandboxBackend) createSandbox(ctx context.Context, api openSandboxClient, repo core.Repo, reclaim bool, requestedSlug string) (string, string, string, sandboxInfo, func(), error) {
 	providerScope, err := newOpenSandboxClaimScope(api.BaseURL())
 	if err != nil {
 		return "", "", "", sandboxInfo{}, nil, err
@@ -694,13 +693,13 @@ func (b *openSandboxBackend) createSandbox(ctx context.Context, api openSandboxC
 	if err != nil {
 		return leaseID, sb.ID, "", sandboxInfo{}, nil, b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		cleanupErr := b.cleanupCreateFailure(ctx, api, sb.ID, err)
 		unlockOperation()
 		return leaseID, sb.ID, "", sandboxInfo{}, nil, cleanupErr
 	}
-	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, providerScope, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, providerName, providerScope, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
 		cleanupErr := b.cleanupCreateFailure(ctx, api, sb.ID, err)
 		unlockOperation()
 		return leaseID, sb.ID, slug, sandboxInfo{}, nil, cleanupErr
@@ -708,12 +707,12 @@ func (b *openSandboxBackend) createSandbox(ctx context.Context, api openSandboxC
 	return leaseID, sb.ID, slug, sb, unlockOperation, nil
 }
 
-func (b *openSandboxBackend) recordAmbiguousCreate(providerScope string, repo Repo) (string, error) {
+func (b *openSandboxBackend) recordAmbiguousCreate(providerScope string, repo core.Repo) (string, error) {
 	if strings.TrimSpace(repo.Root) == "" {
 		return "", errors.New("repository root is required")
 	}
 	recoveryLeaseID := openSandboxRecoveryLeaseID(providerScope)
-	if err := claimLeaseForRepoProviderScopePond(
+	if err := core.ClaimLeaseForRepoProviderScopePond(
 		recoveryLeaseID,
 		"",
 		providerName,
@@ -736,7 +735,7 @@ func (b *openSandboxBackend) reconcileAmbiguousCreateFailure(ctx context.Context
 		return fmt.Errorf("%w; lock opensandbox create recovery=%s: %v", cause, recoveryLeaseID, err)
 	}
 	defer unlockOperation()
-	recoveryClaim, err := readLeaseClaim(recoveryLeaseID)
+	recoveryClaim, err := core.ReadLeaseClaim(recoveryLeaseID)
 	if err != nil {
 		return fmt.Errorf("%w; read opensandbox create recovery=%s: %v", cause, recoveryLeaseID, err)
 	}
@@ -806,62 +805,62 @@ func openSandboxRecoveryLeaseID(providerScope string) string {
 }
 
 func removeOpenSandboxRecoveryClaim(leaseID, providerScope string) error {
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		return err
 	}
 	if claim.LeaseID == "" || claim.Provider != providerName || claim.ProviderScope != providerScope {
 		return nil
 	}
-	return removeLeaseClaimIfUnchanged(leaseID, claim)
+	return core.RemoveLeaseClaimIfUnchanged(leaseID, claim)
 }
 
 func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL string) (string, string, string, error) {
 	return shared.ResolveScopedLeaseID(id, shared.ScopedLeaseResolver{
 		Provider:      providerName,
 		LeasePrefix:   leasePrefix,
-		ReadClaim:     readLeaseClaim,
+		ReadClaim:     core.ReadLeaseClaim,
 		ListClaims:    listOpenSandboxLeaseClaims,
-		ValidateClaim: func(claim LeaseClaim) error { return validateOpenSandboxClaimScope(claim, baseURL) },
-		FinishClaim: func(claim LeaseClaim) (string, string, string, error) {
+		ValidateClaim: func(claim core.LeaseClaim) error { return validateOpenSandboxClaimScope(claim, baseURL) },
+		FinishClaim: func(claim core.LeaseClaim) (string, string, string, error) {
 			return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, baseURL)
 		},
 		EmptyIdentifierError: func() error {
-			return exit(2, "provider=opensandbox requires a Crabbox-created sandbox slug or lease id")
+			return core.Exit(2, "provider=opensandbox requires a Crabbox-created sandbox slug or lease id")
 		},
 		UnclaimedIdentifierError: func(identifier string) error {
-			return exit(4, "opensandbox sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", identifier, leasePrefix)
+			return core.Exit(4, "opensandbox sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", identifier, leasePrefix)
 		},
 	})
 }
 
-func resolveOpenSandboxLeaseClaim(identifier, baseURL string) (LeaseClaim, bool, error) {
-	return shared.ResolveScopedLeaseClaim(identifier, providerName, listOpenSandboxLeaseClaims, func(claim LeaseClaim) error {
+func resolveOpenSandboxLeaseClaim(identifier, baseURL string) (core.LeaseClaim, bool, error) {
+	return shared.ResolveScopedLeaseClaim(identifier, providerName, listOpenSandboxLeaseClaims, func(claim core.LeaseClaim) error {
 		return validateOpenSandboxClaimScope(claim, baseURL)
 	})
 }
 
-func finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL string) (string, string, string, error) {
+func finishResolvedLease(claim core.LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL string) (string, string, string, error) {
 	return shared.FinishScopedLease(claim, shared.ScopedLeaseFinishOptions{
 		Provider:      providerName,
 		LeasePrefix:   leasePrefix,
 		RepoRoot:      repoRoot,
 		Reclaim:       reclaim,
 		IdleTimeout:   idleTimeout,
-		ValidateClaim: func(claim LeaseClaim) error { return validateOpenSandboxClaimScope(claim, baseURL) },
+		ValidateClaim: func(claim core.LeaseClaim) error { return validateOpenSandboxClaimScope(claim, baseURL) },
 	})
 }
 
-func authorizeOpenSandboxRepoClaim(claim LeaseClaim, repoRoot string, reclaim bool) error {
+func authorizeOpenSandboxRepoClaim(claim core.LeaseClaim, repoRoot string, reclaim bool) error {
 	if repoRoot == "" || claim.RepoRoot == "" || claim.RepoRoot == repoRoot || reclaim {
 		return nil
 	}
-	return exit(2, "lease %s is claimed by repo %s; use --reclaim to claim it for %s", claim.LeaseID, claim.RepoRoot, repoRoot)
+	return core.Exit(2, "lease %s is claimed by repo %s; use --reclaim to claim it for %s", claim.LeaseID, claim.RepoRoot, repoRoot)
 }
 
-func validateOpenSandboxClaimScope(claim LeaseClaim, baseURL string) error {
+func validateOpenSandboxClaimScope(claim core.LeaseClaim, baseURL string) error {
 	if !strings.HasPrefix(strings.TrimSpace(claim.ProviderScope), openSandboxEndpointScope(baseURL)+"-own-") {
-		return exit(4, "opensandbox lease %q belongs to a different API endpoint; restore the endpoint used to create it", claim.LeaseID)
+		return core.Exit(4, "opensandbox lease %q belongs to a different API endpoint; restore the endpoint used to create it", claim.LeaseID)
 	}
 	return nil
 }
@@ -872,7 +871,7 @@ func openSandboxPlatformOS(value string) (string, error) {
 		return "", nil
 	}
 	if !strings.EqualFold(value, "linux") {
-		return "", exit(2, "provider=opensandbox only supports Linux sandboxes; set openSandbox.platformOS to linux or leave it empty")
+		return "", core.Exit(2, "provider=opensandbox only supports Linux sandboxes; set openSandbox.platformOS to linux or leave it empty")
 	}
 	return "linux", nil
 }
@@ -884,7 +883,7 @@ func openSandboxPlatform(osValue, archValue string) (string, string, error) {
 	}
 	archValue = strings.TrimSpace(archValue)
 	if (osValue == "") != (archValue == "") {
-		return "", "", exit(2, "openSandbox.platformOS and openSandbox.platformArch must be set together or both left empty")
+		return "", "", core.Exit(2, "openSandbox.platformOS and openSandbox.platformArch must be set together or both left empty")
 	}
 	return osValue, archValue, nil
 }
@@ -892,7 +891,7 @@ func openSandboxPlatform(osValue, archValue string) (string, string, error) {
 func newOpenSandboxClaimScope(baseURL string) (string, error) {
 	var token [16]byte
 	if _, err := rand.Read(token[:]); err != nil {
-		return "", exit(5, "generate opensandbox ownership token: %v", err)
+		return "", core.Exit(5, "generate opensandbox ownership token: %v", err)
 	}
 	return openSandboxEndpointScope(baseURL) + "-own-" + hex.EncodeToString(token[:]), nil
 }
@@ -903,7 +902,7 @@ func openSandboxEndpointScope(baseURL string) string {
 }
 
 func verifyOpenSandboxClaim(ctx context.Context, api openSandboxClient, leaseID, sandboxID string) (sandboxInfo, error) {
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		return sandboxInfo{}, err
 	}
@@ -920,9 +919,9 @@ func verifyOpenSandboxClaim(ctx context.Context, api openSandboxClient, leaseID,
 	return sb, nil
 }
 
-func validateOpenSandboxOwnership(claim LeaseClaim, sb sandboxInfo) error {
+func validateOpenSandboxOwnership(claim core.LeaseClaim, sb sandboxInfo) error {
 	if sb.Metadata[openSandboxClaimKey] != claim.ProviderScope {
-		return exit(4, "opensandbox sandbox %q ownership metadata does not match its local claim", sb.ID)
+		return core.Exit(4, "opensandbox sandbox %q ownership metadata does not match its local claim", sb.ID)
 	}
 	return nil
 }
@@ -935,22 +934,22 @@ func (b *openSandboxBackend) ensureReusableSandbox(ctx context.Context, api open
 		fmt.Fprintf(b.rt.Stderr, "resuming opensandbox sandbox=%s\n", sandboxID)
 		return api.ResumeSandbox(ctx, sandboxID)
 	default:
-		return exit(4, "opensandbox sandbox %q is %s and cannot be reused until it is running", sandboxID, sb.State)
+		return core.Exit(4, "opensandbox sandbox %q is %s and cannot be reused until it is running", sandboxID, sb.State)
 	}
 }
 
-func openSandboxWorkdir(cfg Config) (string, error) {
+func openSandboxWorkdir(cfg core.Config) (string, error) {
 	workdir := strings.TrimSpace(cfg.OpenSandbox.Workdir)
 	if workdir == "" {
 		workdir = defaultWorkdir
 	}
 	clean := path.Clean(workdir)
 	if !strings.HasPrefix(clean, "/") {
-		return "", exit(2, "opensandbox workdir %q must be an absolute path", workdir)
+		return "", core.Exit(2, "opensandbox workdir %q must be an absolute path", workdir)
 	}
 	switch clean {
 	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspace":
-		return "", exit(2, "opensandbox workdir %q is too broad; choose a dedicated subdirectory", clean)
+		return "", core.Exit(2, "opensandbox workdir %q is too broad; choose a dedicated subdirectory", clean)
 	}
 	return clean, nil
 }
@@ -980,8 +979,8 @@ func timeoutOrDefault(primary, fallback time.Duration) time.Duration {
 	return fallback
 }
 
-func newSandboxName(repo Repo) string {
-	base := normalizeLeaseSlug(repo.Name)
+func newSandboxName(repo core.Repo) string {
+	base := core.NormalizeLeaseSlug(repo.Name)
 	if base == "" {
 		base = "crabbox"
 	}
@@ -1025,7 +1024,7 @@ func (b *openSandboxBackend) cleanupClaimedSandboxFailure(ctx context.Context, a
 	if err := api.DeleteSandbox(cleanupCtx, sandboxID); err != nil && !isOpenSandboxNotFound(err) {
 		return fmt.Errorf("%w; cleanup opensandbox sandbox %s failed: %v", cause, sandboxID, err)
 	}
-	removeLeaseClaim(leaseID)
+	core.RemoveLeaseClaim(leaseID)
 	return cause
 }
 
@@ -1044,13 +1043,13 @@ func (b *openSandboxBackend) commandLifetime() time.Duration {
 	return openSandboxCommandBudgetForConfig(b.cfg)
 }
 
-func (b *openSandboxBackend) runLifetimeBudget(req RunRequest) time.Duration {
+func (b *openSandboxBackend) runLifetimeBudget(req core.RunRequest) time.Duration {
 	return openSandboxRunBudgetForConfig(b.cfg, req.NoSync, req.SyncOnly)
 }
 
 func openSandboxExpiration(sb sandboxInfo) (time.Time, error) {
 	if sb.ExpiresAt == nil || sb.ExpiresAt.IsZero() {
-		return time.Time{}, exit(5, "opensandbox sandbox %s did not report an expiration", sb.ID)
+		return time.Time{}, core.Exit(5, "opensandbox sandbox %s did not report an expiration", sb.ID)
 	}
 	return sb.ExpiresAt.UTC(), nil
 }

--- a/internal/providers/opensandbox/backend_test.go
+++ b/internal/providers/opensandbox/backend_test.go
@@ -35,7 +35,7 @@ func newOpenSandboxTestClient(t *testing.T, server *httptest.Server) openSandbox
 	t.Helper()
 	cfg := testConfig()
 	cfg.OpenSandbox.APIURL = server.URL
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
+	client, err := newOpenSandboxClient(cfg, core.Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,7 +264,7 @@ func TestWarmupRejectsUnusableLifetimeBeforeCreate(t *testing.T) {
 	fake := newFakeClient()
 	backend := newTestBackend(fake)
 	backend.cfg.TTL = 10 * time.Minute
-	err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: "/repo"}})
+	err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "my-app", Root: "/repo"}})
 	if err == nil || !strings.Contains(err.Error(), "effective lifetime") {
 		t.Fatalf("err=%v, want unusable lifetime rejection", err)
 	}
@@ -277,7 +277,7 @@ func TestWarmupRejectsInvalidWorkdirBeforeCreate(t *testing.T) {
 	fake := newFakeClient()
 	backend := newTestBackend(fake)
 	backend.cfg.OpenSandbox.Workdir = "/workspace"
-	err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: "/repo"}})
+	err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "my-app", Root: "/repo"}})
 	if err == nil || !strings.Contains(err.Error(), "too broad") {
 		t.Fatalf("err=%v, want workdir rejection", err)
 	}
@@ -290,8 +290,8 @@ func TestRunAndWarmupRejectTailscaleBeforeCreate(t *testing.T) {
 	t.Run("run", func(t *testing.T) {
 		fake := newFakeClient()
 		backend := newTestBackend(fake)
-		_, err := backend.Run(context.Background(), RunRequest{
-			Repo: Repo{Name: "my-app", Root: "/repo"},
+		_, err := backend.Run(context.Background(), core.RunRequest{
+			Repo: core.Repo{Name: "my-app", Root: "/repo"},
 			Options: core.LeaseOptions{
 				Tailscale: core.TailscaleConfig{Enabled: true},
 			},
@@ -308,8 +308,8 @@ func TestRunAndWarmupRejectTailscaleBeforeCreate(t *testing.T) {
 	t.Run("warmup", func(t *testing.T) {
 		fake := newFakeClient()
 		backend := newTestBackend(fake)
-		err := backend.Warmup(context.Background(), WarmupRequest{
-			Repo: Repo{Name: "my-app", Root: "/repo"},
+		err := backend.Warmup(context.Background(), core.WarmupRequest{
+			Repo: core.Repo{Name: "my-app", Root: "/repo"},
 			Options: core.LeaseOptions{
 				Tailscale: core.TailscaleConfig{Enabled: true},
 			},
@@ -328,8 +328,8 @@ func TestWarmupCleansUpWhenActualExpirationCannotFitRun(t *testing.T) {
 	fake := newFakeClient()
 	fake.createExpiresIn = 20 * time.Minute
 	backend := newTestBackend(fake)
-	err := backend.Warmup(context.Background(), WarmupRequest{
-		Repo: Repo{Name: "my-app", Root: tempGitRepo(t)},
+	err := backend.Warmup(context.Background(), core.WarmupRequest{
+		Repo: core.Repo{Name: "my-app", Root: tempGitRepo(t)},
 	})
 	if err == nil || !strings.Contains(err.Error(), "less than the") {
 		t.Fatalf("err=%v, want actual expiration rejection", err)
@@ -337,7 +337,7 @@ func TestWarmupCleansUpWhenActualExpirationCannotFitRun(t *testing.T) {
 	if len(fake.deleted) != 1 || fake.deleted[0] != fake.sandbox.ID {
 		t.Fatalf("deleted=%#v want warmup rollback", fake.deleted)
 	}
-	if claim, err := readLeaseClaim(leasePrefix + fake.sandbox.ID); err != nil {
+	if claim, err := core.ReadLeaseClaim(leasePrefix + fake.sandbox.ID); err != nil {
 		t.Fatal(err)
 	} else if claim.LeaseID != "" {
 		t.Fatalf("claim=%#v want rollback removal", claim)
@@ -370,8 +370,8 @@ func TestRunRejectsRequestBudgetBeforeCreate(t *testing.T) {
 	fake := newFakeClient()
 	backend := newTestBackend(fake)
 	backend.cfg.OpenSandbox.TimeoutSecs = 1200
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo: Repo{Name: "my-app", Root: "/repo"}, Command: []string{"true"},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo: core.Repo{Name: "my-app", Root: "/repo"}, Command: []string{"true"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "sync/command budget") {
 		t.Fatalf("err=%v, want request budget rejection", err)
@@ -387,8 +387,8 @@ func TestRunReconcilesAmbiguousCreateFailureByOwnershipMetadata(t *testing.T) {
 	fake.createErr = &ambiguousOpenSandboxCreateError{cause: context.DeadlineExceeded}
 	backend := newTestBackend(fake)
 
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo: Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo: core.Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"},
 	})
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("err=%v, want ambiguous create cause", err)
@@ -403,7 +403,7 @@ func TestRunReconcilesAmbiguousCreateFailureByOwnershipMetadata(t *testing.T) {
 	if len(fake.deleted) != 1 || fake.deleted[0] != fake.sandbox.ID {
 		t.Fatalf("deleted=%#v, want ambiguous sandbox cleanup", fake.deleted)
 	}
-	if claim, claimErr := readLeaseClaim(leasePrefix + fake.sandbox.ID); claimErr != nil {
+	if claim, claimErr := core.ReadLeaseClaim(leasePrefix + fake.sandbox.ID); claimErr != nil {
 		t.Fatal(claimErr)
 	} else if claim.LeaseID != "" {
 		t.Fatalf("claim=%#v, want no local claim after ambiguous create", claim)
@@ -424,8 +424,8 @@ func TestRunReconcilesAmbiguousCreateAfterDelayedVisibility(t *testing.T) {
 	backend.cleanupTimeoutOverride = openSandboxCleanupTimeout
 	backend.reconcilePollOverride = time.Nanosecond
 
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo: Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo: core.Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"},
 	})
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("err=%v, want ambiguous create cause", err)
@@ -450,8 +450,8 @@ func TestRunRetriesTransientAmbiguousCreateReconciliationFailures(t *testing.T) 
 	backend.cleanupTimeoutOverride = 200 * time.Millisecond
 	backend.reconcilePollOverride = time.Millisecond
 
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo: Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo: core.Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"},
 	})
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("err=%v, want ambiguous create cause", err)
@@ -470,8 +470,8 @@ func TestRunDoesNotReconcileUnmarkedCreateFailure(t *testing.T) {
 	fake.createErr = context.DeadlineExceeded
 	backend := newTestBackend(fake)
 
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo: Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo: core.Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"},
 	})
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("err=%v, want create cause", err)
@@ -490,8 +490,8 @@ func TestRunRetainsAmbiguousCreateRecoveryForLaterCleanup(t *testing.T) {
 	backend.cleanupTimeoutOverride = 5 * time.Millisecond
 	backend.reconcilePollOverride = time.Millisecond
 
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo: Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo: core.Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"},
 	})
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("err=%v, want ambiguous create cause", err)
@@ -519,7 +519,7 @@ func TestRunRetainsAmbiguousCreateRecoveryForLaterCleanup(t *testing.T) {
 	}
 
 	fake.listEmptyCount = 0
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deleted) != 1 || fake.deleted[0] != fake.sandbox.ID {
@@ -538,7 +538,7 @@ func TestAmbiguousCreateReconciliationUsesRecoveryOperationLock(t *testing.T) {
 	backend := newTestBackend(fake)
 	backend.cleanupTimeoutOverride = 5 * time.Millisecond
 	scope := testOpenSandboxScope(t, fake.BaseURL())
-	recoveryLeaseID, err := backend.recordAmbiguousCreate(scope, Repo{Root: tempGitRepo(t)})
+	recoveryLeaseID, err := backend.recordAmbiguousCreate(scope, core.Repo{Root: tempGitRepo(t)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -622,8 +622,8 @@ func TestRunCreatesSandboxForwardsEnvAndCleansUp(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeClient()
 	backend := newTestBackend(fake)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: tempGitRepo(t)},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: tempGitRepo(t)},
 		NoSync:  true,
 		Command: []string{"printenv", "API_TOKEN"},
 		Env:     map[string]string{"API_TOKEN": "secret-value"},
@@ -673,8 +673,8 @@ func TestRunRefreshesMissingCreateExpirationAfterCleanupIsArmed(t *testing.T) {
 	fake := newFakeClient()
 	fake.omitCreateExpiration = true
 	backend := newTestBackend(fake)
-	if _, err := backend.Run(context.Background(), RunRequest{
-		Repo: Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"},
+	if _, err := backend.Run(context.Background(), core.RunRequest{
+		Repo: core.Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -701,8 +701,8 @@ func TestRunDoesNotPublishClaimWhenCreationLockIsCanceled(t *testing.T) {
 	defer cancel()
 	// Cancellation must follow creation so this case reaches unpublished-sandbox rollback.
 	fake.afterCreate = cancel
-	_, err = backend.Run(ctx, RunRequest{
-		Repo: Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"},
+	_, err = backend.Run(ctx, core.RunRequest{
+		Repo: core.Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"},
 	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("err=%v, want operation lock cancellation", err)
@@ -710,7 +710,7 @@ func TestRunDoesNotPublishClaimWhenCreationLockIsCanceled(t *testing.T) {
 	if len(fake.deleted) != 1 || fake.deleted[0] != fake.sandbox.ID {
 		t.Fatalf("deleted=%#v want unpublished sandbox rollback", fake.deleted)
 	}
-	if claim, err := readLeaseClaim(leaseID); err != nil {
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil {
 		t.Fatal(err)
 	} else if claim.LeaseID != "" {
 		t.Fatalf("claim=%#v must not be published without operation lock", claim)
@@ -721,8 +721,8 @@ func TestRunNoSyncEnsuresWorkspaceWithPortableShell(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeClient()
 	backend := newTestBackend(fake)
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: tempGitRepo(t)},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: tempGitRepo(t)},
 		NoSync:  true,
 		Command: []string{"true"},
 	})
@@ -745,7 +745,7 @@ func TestRunTimingJSONRemainsFinalLineWhenActivityRefreshFails(t *testing.T) {
 	backend.rt.Stderr = &stderr
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "timing", providerName, scope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "timing", providerName, scope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
@@ -759,8 +759,8 @@ func TestRunTimingJSONRemainsFinalLineWhenActivityRefreshFails(t *testing.T) {
 		}
 	}
 
-	_, err = backend.Run(context.Background(), RunRequest{
-		ID: "timing", Repo: Repo{Name: "my-app", Root: "/repo"}, NoSync: true, Command: []string{"true"}, TimingJSON: true,
+	_, err = backend.Run(context.Background(), core.RunRequest{
+		ID: "timing", Repo: core.Repo{Name: "my-app", Root: "/repo"}, NoSync: true, Command: []string{"true"}, TimingJSON: true,
 	})
 	if err == nil {
 		t.Fatal("expected activity refresh failure")
@@ -792,8 +792,8 @@ func TestRunTimingJSONRemainsFinalLineWhenCleanupFails(t *testing.T) {
 			backend := newTestBackend(fake)
 			var stderr bytes.Buffer
 			backend.rt.Stderr = &stderr
-			result, err := backend.Run(context.Background(), RunRequest{
-				Repo: Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"}, TimingJSON: true,
+			result, err := backend.Run(context.Background(), core.RunRequest{
+				Repo: core.Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"}, TimingJSON: true,
 			})
 			wantCode := commandCode
 			if wantCode == 0 {
@@ -806,7 +806,7 @@ func TestRunTimingJSONRemainsFinalLineWhenCleanupFails(t *testing.T) {
 			if result.Session == nil || !result.Session.Kept || len(fake.deleted) != 1 {
 				t.Fatalf("session=%#v deletes=%v", result.Session, fake.deleted)
 			}
-			claim, err := readLeaseClaim(result.LeaseID)
+			claim, err := core.ReadLeaseClaim(result.LeaseID)
 			if err != nil || claim.LeaseID != result.LeaseID {
 				t.Fatalf("failed cleanup lost recovery claim: %#v %v", claim, err)
 			}
@@ -826,8 +826,8 @@ func TestRunPreservesBashLoginShellForExplicitInvocation(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeClient()
 	backend := newTestBackend(fake)
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: tempGitRepo(t)},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: tempGitRepo(t)},
 		NoSync:  true,
 		Command: []string{"bash", "-lc", "echo hello"},
 	})
@@ -853,7 +853,7 @@ func TestRunCommandIntentSurvivesNativeExecdSource(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(root, "FOO=x"), []byte("#!/bin/sh\nprintf 'literal:%s' \"$*\"\nexit 42\n"), 0o700); err != nil {
 				t.Fatal(err)
 			}
-			request := RunRequest{Repo: Repo{Name: "fixture", Root: t.TempDir()}, NoSync: true, Keep: true, Command: []string{"printf", "%s", "|", "touch", marker}, CommandLiteralArgs: map[int]bool{2: true}, Env: map[string]string{"FIXTURE": "synthetic"}}
+			request := core.RunRequest{Repo: core.Repo{Name: "fixture", Root: t.TempDir()}, NoSync: true, Keep: true, Command: []string{"printf", "%s", "|", "touch", marker}, CommandLiteralArgs: map[int]bool{2: true}, Env: map[string]string{"FIXTURE": "synthetic"}}
 			want, wantCode := "|touch"+marker, 0
 			switch scenario {
 			case "literal assignment":
@@ -920,8 +920,8 @@ func TestRunPreservesBashLoginShellForAutoWrappedMetachars(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeClient()
 	backend := newTestBackend(fake)
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: tempGitRepo(t)},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: tempGitRepo(t)},
 		NoSync:  true,
 		Command: []string{"pnpm", "install", "&&", "pnpm", "test"},
 	})
@@ -941,8 +941,8 @@ func TestRunKeepsSandboxOnFailureWhenRequested(t *testing.T) {
 	fake := newFakeClient()
 	fake.runExit = 7
 	backend := newTestBackend(fake)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:          Repo{Name: "my-app", Root: tempGitRepo(t)},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:          core.Repo{Name: "my-app", Root: tempGitRepo(t)},
 		NoSync:        true,
 		Command:       []string{"false"},
 		KeepOnFailure: true,
@@ -956,7 +956,7 @@ func TestRunKeepsSandboxOnFailureWhenRequested(t *testing.T) {
 	if result.Session == nil || !result.Session.Kept || result.Session.Reused {
 		t.Fatalf("session=%#v, want retained new sandbox", result.Session)
 	}
-	claim, err := readLeaseClaim(leasePrefix + fake.sandbox.ID)
+	claim, err := core.ReadLeaseClaim(leasePrefix + fake.sandbox.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -970,8 +970,8 @@ func TestRunRejectsNonLinuxPlatformOS(t *testing.T) {
 	fake := newFakeClient()
 	backend := newTestBackend(fake)
 	backend.cfg.OpenSandbox.PlatformOS = "windows"
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: tempGitRepo(t)},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: tempGitRepo(t)},
 		NoSync:  true,
 		Command: []string{"true"},
 	})
@@ -998,8 +998,8 @@ func TestRunRejectsPartialPlatformConstraint(t *testing.T) {
 			backend := newTestBackend(fake)
 			backend.cfg.OpenSandbox.PlatformOS = tc.os
 			backend.cfg.OpenSandbox.PlatformArch = tc.arch
-			_, err := backend.Run(context.Background(), RunRequest{
-				Repo:    Repo{Name: "my-app", Root: tempGitRepo(t)},
+			_, err := backend.Run(context.Background(), core.RunRequest{
+				Repo:    core.Repo{Name: "my-app", Root: tempGitRepo(t)},
 				NoSync:  true,
 				Command: []string{"true"},
 			})
@@ -1018,17 +1018,17 @@ func TestRunVerifiesOwnershipBeforeReclaim(t *testing.T) {
 	fake := newFakeClient()
 	backend := newTestBackend(fake)
 	leaseID := leasePrefix + fake.sandbox.ID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, testOpenSandboxScope(t, fake.baseURL), "", "/original", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, testOpenSandboxScope(t, fake.baseURL), "", "/original", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = "different"
-	_, err := backend.Run(context.Background(), RunRequest{
-		ID: leaseID, Repo: Repo{Name: "my-app", Root: "/replacement"}, Reclaim: true, NoSync: true, Command: []string{"true"},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		ID: leaseID, Repo: core.Repo{Name: "my-app", Root: "/replacement"}, Reclaim: true, NoSync: true, Command: []string{"true"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "ownership metadata") {
 		t.Fatalf("err=%v, want ownership mismatch", err)
 	}
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1044,12 +1044,12 @@ func TestRunResumesPausedSandboxBeforeReuse(t *testing.T) {
 	backend := newTestBackend(fake)
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, scope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, scope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
-	result, err := backend.Run(context.Background(), RunRequest{
-		ID: leaseID, Repo: Repo{Name: "my-app", Root: "/repo"}, NoSync: true, Command: []string{"true"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		ID: leaseID, Repo: core.Repo{Name: "my-app", Root: "/repo"}, NoSync: true, Command: []string{"true"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1072,13 +1072,13 @@ func TestRunReuseUsesActualExpirationInsteadOfCreationConfig(t *testing.T) {
 	backend.cfg.OpenSandbox.TimeoutSecs = 1200
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "actual-expiration", providerName, scope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "actual-expiration", providerName, scope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
 
-	if _, err := backend.Run(context.Background(), RunRequest{
-		ID: leaseID, Repo: Repo{Name: "my-app", Root: "/repo"}, NoSync: true, Command: []string{"true"},
+	if _, err := backend.Run(context.Background(), core.RunRequest{
+		ID: leaseID, Repo: core.Repo{Name: "my-app", Root: "/repo"}, NoSync: true, Command: []string{"true"},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1091,13 +1091,13 @@ func TestRunDoesNotResumePausedSandboxBeforeRepoAuthorization(t *testing.T) {
 	backend := newTestBackend(fake)
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, scope, "", "/original", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, scope, "", "/original", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
 
-	_, err := backend.Run(context.Background(), RunRequest{
-		ID: leaseID, Repo: Repo{Name: "my-app", Root: "/other"}, NoSync: true, Command: []string{"true"},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		ID: leaseID, Repo: core.Repo{Name: "my-app", Root: "/other"}, NoSync: true, Command: []string{"true"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "is claimed by repo /original") {
 		t.Fatalf("err=%v, want repository claim rejection", err)
@@ -1118,17 +1118,17 @@ func TestRunDoesNotResumeOrReclaimPausedSandboxBeforeLifetimePreflight(t *testin
 	backend.rt.Stderr = stderr
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, scope, "", "/original", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, scope, "", "/original", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
-	before, err := readLeaseClaim(leaseID)
+	before, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	result, err := backend.Run(context.Background(), RunRequest{
-		ID: leaseID, Repo: Repo{Name: "my-app", Root: "/other"}, Reclaim: true, NoSync: true, KeepOnFailure: true, Command: []string{"true"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		ID: leaseID, Repo: core.Repo{Name: "my-app", Root: "/other"}, Reclaim: true, NoSync: true, KeepOnFailure: true, Command: []string{"true"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "sync/command budget") {
 		t.Fatalf("err=%v, want lifetime preflight rejection", err)
@@ -1142,7 +1142,7 @@ func TestRunDoesNotResumeOrReclaimPausedSandboxBeforeLifetimePreflight(t *testin
 	if result.Session == nil || !result.Session.Reused || !result.Session.Kept {
 		t.Fatalf("session=%#v", result.Session)
 	}
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1168,17 +1168,17 @@ func TestRunRechecksLifetimeAfterResumeBeforeReclaim(t *testing.T) {
 	}
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, scope, "", "/original", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, scope, "", "/original", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
-	before, err := readLeaseClaim(leaseID)
+	before, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	result, err := backend.Run(context.Background(), RunRequest{
-		ID: leaseID, Repo: Repo{Name: "my-app", Root: "/other"}, Reclaim: true, NoSync: true, Command: []string{"true"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		ID: leaseID, Repo: core.Repo{Name: "my-app", Root: "/other"}, Reclaim: true, NoSync: true, Command: []string{"true"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "remaining after resume") {
 		t.Fatalf("err=%v, want post-resume lifetime rejection", err)
@@ -1192,7 +1192,7 @@ func TestRunRechecksLifetimeAfterResumeBeforeReclaim(t *testing.T) {
 	if result.Session == nil || !result.Session.Reused || !result.Session.Kept {
 		t.Fatalf("session=%#v", result.Session)
 	}
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1211,17 +1211,17 @@ func TestRunReclaimPersistsOnlyAfterReusableSandboxValidation(t *testing.T) {
 	backend := newTestBackend(fake)
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, scope, "", "/original", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, scope, "", "/original", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
-	before, err := readLeaseClaim(leaseID)
+	before, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	result, err := backend.Run(context.Background(), RunRequest{
-		ID: leaseID, Repo: Repo{Name: "my-app", Root: "/other"}, Reclaim: true, NoSync: true, Command: []string{"true"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		ID: leaseID, Repo: core.Repo{Name: "my-app", Root: "/other"}, Reclaim: true, NoSync: true, Command: []string{"true"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "cannot be reused") {
 		t.Fatalf("err=%v, want reusable sandbox rejection", err)
@@ -1229,7 +1229,7 @@ func TestRunReclaimPersistsOnlyAfterReusableSandboxValidation(t *testing.T) {
 	if result.Session == nil || !result.Session.Reused || !result.Session.Kept {
 		t.Fatalf("session=%#v", result.Session)
 	}
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1246,11 +1246,11 @@ func TestStopRejectsOwnershipMismatch(t *testing.T) {
 	fake := newFakeClient()
 	backend := newTestBackend(fake)
 	leaseID := leasePrefix + fake.sandbox.ID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, testOpenSandboxScope(t, fake.baseURL), "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, testOpenSandboxScope(t, fake.baseURL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = "different"
-	err := backend.Stop(context.Background(), StopRequest{ID: "mine"})
+	err := backend.Stop(context.Background(), core.StopRequest{ID: "mine"})
 	if err == nil || !strings.Contains(err.Error(), "ownership metadata") {
 		t.Fatalf("err=%v, want ownership mismatch", err)
 	}
@@ -1265,17 +1265,17 @@ func TestStopForgetMissingRemovesClaimOnlyWhenExplicit(t *testing.T) {
 	fake.notFound = true
 	backend := newTestBackend(fake)
 	leaseID := leasePrefix + fake.sandbox.ID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "stale", providerName, testOpenSandboxScope(t, fake.baseURL), "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "stale", providerName, testOpenSandboxScope(t, fake.baseURL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := backend.Stop(context.Background(), StopRequest{ID: "stale"}); err == nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: "stale"}); err == nil {
 		t.Fatal("expected missing sandbox to fail without forget flag")
 	}
 	backend.cfg.OpenSandbox.ForgetMissing = true
-	if err := backend.Stop(context.Background(), StopRequest{ID: "stale"}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: "stale"}); err != nil {
 		t.Fatal(err)
 	}
-	if claim, err := readLeaseClaim(leaseID); err != nil {
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil {
 		t.Fatal(err)
 	} else if claim.LeaseID != "" {
 		t.Fatalf("claim still present after forget-missing: %#v", claim)
@@ -1292,15 +1292,15 @@ func TestStopSerializesWithActiveLeaseRun(t *testing.T) {
 	backend.rt.Stderr = io.Discard
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "active", providerName, scope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "active", providerName, scope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
 
 	runDone := make(chan error, 1)
 	go func() {
-		_, err := backend.Run(context.Background(), RunRequest{
-			ID: "active", Repo: Repo{Name: "my-app", Root: "/repo"}, NoSync: true, Command: []string{"true"},
+		_, err := backend.Run(context.Background(), core.RunRequest{
+			ID: "active", Repo: core.Repo{Name: "my-app", Root: "/repo"}, NoSync: true, Command: []string{"true"},
 		})
 		runDone <- err
 	}()
@@ -1312,7 +1312,7 @@ func TestStopSerializesWithActiveLeaseRun(t *testing.T) {
 
 	stopDone := make(chan error, 1)
 	go func() {
-		stopDone <- backend.Stop(context.Background(), StopRequest{ID: "active"})
+		stopDone <- backend.Stop(context.Background(), core.StopRequest{ID: "active"})
 	}()
 	select {
 	case err := <-stopDone:
@@ -1339,18 +1339,18 @@ func TestCleanupDeletesOwnedIdleSandbox(t *testing.T) {
 	backend.rt.Clock = fixedClock{now: time.Now().Add(2 * time.Hour)}
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "idle", providerName, scope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "idle", providerName, scope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
 
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deleted) != 1 || fake.deleted[0] != fake.sandbox.ID {
 		t.Fatalf("deleted=%#v want idle sandbox", fake.deleted)
 	}
-	if claim, err := readLeaseClaim(leaseID); err != nil {
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil {
 		t.Fatal(err)
 	} else if claim.LeaseID != "" {
 		t.Fatalf("claim=%#v want removed", claim)
@@ -1364,18 +1364,18 @@ func TestCleanupDryRunPreservesOwnedIdleSandbox(t *testing.T) {
 	backend.rt.Clock = fixedClock{now: time.Now().Add(2 * time.Hour)}
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "idle", providerName, scope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "idle", providerName, scope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
 
-	if err := backend.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deleted) != 0 {
 		t.Fatalf("deleted=%#v after dry run", fake.deleted)
 	}
-	if claim, err := readLeaseClaim(leaseID); err != nil {
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil {
 		t.Fatal(err)
 	} else if claim.LeaseID == "" {
 		t.Fatal("claim removed during dry run")
@@ -1389,12 +1389,12 @@ func TestCleanupRejectsIdleSandboxOwnershipMismatch(t *testing.T) {
 	backend.rt.Clock = fixedClock{now: time.Now().Add(2 * time.Hour)}
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "idle", providerName, scope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "idle", providerName, scope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = "different"
 
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err == nil || !strings.Contains(err.Error(), "ownership metadata") {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err == nil || !strings.Contains(err.Error(), "ownership metadata") {
 		t.Fatalf("err=%v, want ownership mismatch", err)
 	}
 	if len(fake.deleted) != 0 {
@@ -1410,14 +1410,14 @@ func TestCleanupRemovesMissingSandboxClaim(t *testing.T) {
 	backend.cfg.OpenSandbox.ForgetMissing = true
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "missing", providerName, scope, "", "/repo", time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "missing", providerName, scope, "", "/repo", time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	if claim, err := readLeaseClaim(leaseID); err != nil {
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil {
 		t.Fatal(err)
 	} else if claim.LeaseID != "" {
 		t.Fatalf("claim=%#v want stale claim removed", claim)
@@ -1431,14 +1431,14 @@ func TestCleanupPreservesAmbiguousMissingSandboxClaimByDefault(t *testing.T) {
 	backend := newTestBackend(fake)
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "missing", providerName, scope, "", "/repo", time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "missing", providerName, scope, "", "/repo", time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	if claim, err := readLeaseClaim(leaseID); err != nil {
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil {
 		t.Fatal(err)
 	} else if claim.LeaseID == "" {
 		t.Fatal("ambiguous missing claim was removed without forget-missing")
@@ -1454,14 +1454,14 @@ func TestCleanupSerializesWithLeaseReuse(t *testing.T) {
 	backend.rt.Clock = fixedClock{now: time.Now().Add(2 * time.Hour)}
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "idle", providerName, scope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "idle", providerName, scope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
 
 	cleanupDone := make(chan error, 1)
 	go func() {
-		cleanupDone <- backend.Cleanup(context.Background(), CleanupRequest{})
+		cleanupDone <- backend.Cleanup(context.Background(), core.CleanupRequest{})
 	}()
 	select {
 	case <-fake.deleteStarted:
@@ -1471,8 +1471,8 @@ func TestCleanupSerializesWithLeaseReuse(t *testing.T) {
 
 	runDone := make(chan error, 1)
 	go func() {
-		_, err := backend.Run(context.Background(), RunRequest{
-			ID: "idle", Repo: Repo{Name: "my-app", Root: "/repo"}, NoSync: true, Command: []string{"true"},
+		_, err := backend.Run(context.Background(), core.RunRequest{
+			ID: "idle", Repo: core.Repo{Name: "my-app", Root: "/repo"}, NoSync: true, Command: []string{"true"},
 		})
 		runDone <- err
 	}()
@@ -1521,12 +1521,12 @@ func TestStatusWaitsForExecdHealth(t *testing.T) {
 	backend.statusPollOverride = time.Millisecond
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "status-test", providerName, scope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "status-test", providerName, scope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
 
-	view, err := backend.Status(context.Background(), StatusRequest{
+	view, err := backend.Status(context.Background(), core.StatusRequest{
 		ID: "status-test", Wait: true, WaitTimeout: time.Second,
 	})
 	if err != nil {
@@ -1545,13 +1545,13 @@ func TestStatusWithoutWaitBoundsExecdHealthProbe(t *testing.T) {
 	backend.statusProbeOverride = 20 * time.Millisecond
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "status-bounded", providerName, scope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "status-bounded", providerName, scope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
 
 	start := time.Now()
-	view, err := backend.Status(context.Background(), StatusRequest{ID: "status-bounded"})
+	view, err := backend.Status(context.Background(), core.StatusRequest{ID: "status-bounded"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1570,12 +1570,12 @@ func TestStatusSurfacesHardExecdHealthFailure(t *testing.T) {
 	backend := newTestBackend(fake)
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "status-hard-failure", providerName, scope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "status-hard-failure", providerName, scope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
 
-	_, err := backend.Status(context.Background(), StatusRequest{ID: "status-hard-failure"})
+	_, err := backend.Status(context.Background(), core.StatusRequest{ID: "status-hard-failure"})
 	if err == nil || !strings.Contains(err.Error(), "malformed execd endpoint") {
 		t.Fatalf("err=%v, want hard health failure", err)
 	}
@@ -1592,12 +1592,12 @@ func TestStatusSurfacesTLSExecdHealthFailure(t *testing.T) {
 	backend := newTestBackend(fake)
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "status-tls-failure", providerName, scope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "status-tls-failure", providerName, scope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
 
-	_, err := backend.Status(context.Background(), StatusRequest{
+	_, err := backend.Status(context.Background(), core.StatusRequest{
 		ID: "status-tls-failure", Wait: true, WaitTimeout: time.Second,
 	})
 	if err == nil || !strings.Contains(err.Error(), "failed to verify certificate") {
@@ -1624,7 +1624,7 @@ func TestOpenSandboxReadinessRetriesTransientTransportErrors(t *testing.T) {
 
 func TestNewOpenSandboxClientRequiresExplicitAPIURL(t *testing.T) {
 	t.Setenv("CRABBOX_OPENSANDBOX_API_KEY", "test-key")
-	_, err := newOpenSandboxClient(testConfig(), Runtime{Stdout: io.Discard, Stderr: io.Discard})
+	_, err := newOpenSandboxClient(testConfig(), core.Runtime{Stdout: io.Discard, Stderr: io.Discard})
 	if err == nil || !strings.Contains(err.Error(), "trusted API URL") {
 		t.Fatalf("err=%v, want trusted API URL requirement", err)
 	}
@@ -2193,7 +2193,7 @@ func TestSDKClientProxyExecdAddsAccessTokenWhenEndpointOmitsIt(t *testing.T) {
 	cfg := testConfig()
 	cfg.OpenSandbox.APIURL = server.URL
 	cfg.OpenSandbox.UseServerProxy = true
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
+	client, err := newOpenSandboxClient(cfg, core.Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2234,7 +2234,7 @@ func TestSDKClientProxyExecdHonorsCaseInsensitiveAccessTokenHeader(t *testing.T)
 	cfg := testConfig()
 	cfg.OpenSandbox.APIURL = server.URL
 	cfg.OpenSandbox.UseServerProxy = true
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
+	client, err := newOpenSandboxClient(cfg, core.Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2447,7 +2447,7 @@ func TestSDKClientRunCommandBoundsStreamingRequest(t *testing.T) {
 				}
 				cfg := testConfig()
 				cfg.OpenSandbox.APIURL = server.URL
-				client, err := newOpenSandboxClient(cfg, Runtime{HTTP: httpClient, Stdout: io.Discard, Stderr: io.Discard})
+				client, err := newOpenSandboxClient(cfg, core.Runtime{HTTP: httpClient, Stdout: io.Discard, Stderr: io.Discard})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -2596,7 +2596,7 @@ func TestSDKClientRunCommandAddsConfiguredSchemeToBareEndpoint(t *testing.T) {
 
 func TestCommandEventErrorDefaultsToFailureExit(t *testing.T) {
 	var stderr bytes.Buffer
-	client := &sdkOpenSandboxClient{rt: Runtime{Stdout: io.Discard, Stderr: &stderr}}
+	client := &sdkOpenSandboxClient{rt: core.Runtime{Stdout: io.Discard, Stderr: &stderr}}
 	result, err := client.handleCommandEvent(streamEvent(`{"type":"error","error":{"evalue":"command failed"}}`))
 	if err != nil {
 		t.Fatal(err)
@@ -2614,7 +2614,7 @@ func TestCommandEventErrorDefaultsToFailureExit(t *testing.T) {
 
 func TestCommandNumericErrorEventDoesNotWriteExitMetadataToStderr(t *testing.T) {
 	var stderr bytes.Buffer
-	client := &sdkOpenSandboxClient{rt: Runtime{Stdout: io.Discard, Stderr: &stderr}}
+	client := &sdkOpenSandboxClient{rt: core.Runtime{Stdout: io.Discard, Stderr: &stderr}}
 	result, err := client.handleCommandEvent(streamEvent(`{"type":"error","error":{"evalue":"7"}}`))
 	if err != nil {
 		t.Fatal(err)
@@ -2629,7 +2629,7 @@ func TestCommandNumericErrorEventDoesNotWriteExitMetadataToStderr(t *testing.T) 
 
 func TestCommandNumericPrefixErrorRemainsVisibleDiagnostic(t *testing.T) {
 	var stderr bytes.Buffer
-	client := &sdkOpenSandboxClient{rt: Runtime{Stdout: io.Discard, Stderr: &stderr}}
+	client := &sdkOpenSandboxClient{rt: core.Runtime{Stdout: io.Discard, Stderr: &stderr}}
 	result, err := client.handleCommandEvent(streamEvent(`{"type":"error","error":{"evalue":"7 files failed"}}`))
 	if err != nil {
 		t.Fatal(err)
@@ -2643,7 +2643,7 @@ func TestCommandNumericPrefixErrorRemainsVisibleDiagnostic(t *testing.T) {
 }
 
 func TestCommandEventHonorsExplicitExitCode(t *testing.T) {
-	client := &sdkOpenSandboxClient{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	client := &sdkOpenSandboxClient{rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
 	result, err := client.handleCommandEvent(streamEvent(`{"type":"execution_complete","exit_code":42}`))
 	if err != nil {
 		t.Fatal(err)
@@ -2657,7 +2657,7 @@ func TestCommandEventHonorsExplicitExitCode(t *testing.T) {
 }
 
 func TestCommandEventCapturesExecutionID(t *testing.T) {
-	client := &sdkOpenSandboxClient{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	client := &sdkOpenSandboxClient{rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
 	result, err := client.handleCommandEvent(streamEvent(`{"type":"init","text":"cmd-123"}`))
 	if err != nil {
 		t.Fatal(err)
@@ -2668,7 +2668,7 @@ func TestCommandEventCapturesExecutionID(t *testing.T) {
 }
 
 func TestCommandResultWithoutExitCodeIsNotTerminal(t *testing.T) {
-	client := &sdkOpenSandboxClient{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	client := &sdkOpenSandboxClient{rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
 	result, err := client.handleCommandEvent(streamEvent(`{"type":"result","data":"intermediate"}`))
 	if err != nil {
 		t.Fatal(err)
@@ -2680,7 +2680,7 @@ func TestCommandResultWithoutExitCodeIsNotTerminal(t *testing.T) {
 
 func TestCommandEventRoutesRawStderrEvent(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	client := &sdkOpenSandboxClient{rt: Runtime{Stdout: &stdout, Stderr: &stderr}}
+	client := &sdkOpenSandboxClient{rt: core.Runtime{Stdout: &stdout, Stderr: &stderr}}
 	if _, err := client.handleCommandEvent(commandStreamEvent{Event: "stderr", Data: "warn"}); err != nil {
 		t.Fatal(err)
 	}
@@ -2691,7 +2691,7 @@ func TestCommandEventRoutesRawStderrEvent(t *testing.T) {
 
 func TestCommandEventPreservesJSONLookingRawStdoutStderr(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	client := &sdkOpenSandboxClient{rt: Runtime{Stdout: &stdout, Stderr: &stderr}}
+	client := &sdkOpenSandboxClient{rt: core.Runtime{Stdout: &stdout, Stderr: &stderr}}
 	stdoutPayload := `{"type":"stdout","exit_code":0}`
 	stderrPayload := `{"type":"stderr","exit_code":0}`
 	if result, err := client.handleCommandEvent(commandStreamEvent{Event: "stdout", Data: stdoutPayload}); err != nil {
@@ -2711,7 +2711,7 @@ func TestCommandEventPreservesJSONLookingRawStdoutStderr(t *testing.T) {
 
 func TestCommandEventUsesStructuredJSONWhenTypePresent(t *testing.T) {
 	var stdout bytes.Buffer
-	client := &sdkOpenSandboxClient{rt: Runtime{Stdout: &stdout, Stderr: io.Discard}}
+	client := &sdkOpenSandboxClient{rt: core.Runtime{Stdout: &stdout, Stderr: io.Discard}}
 	if _, err := client.handleCommandEvent(commandStreamEvent{Event: "stdout", Data: `{"type":"stdout","text":"hello"}`, Structured: true}); err != nil {
 		t.Fatal(err)
 	}
@@ -2722,7 +2722,7 @@ func TestCommandEventUsesStructuredJSONWhenTypePresent(t *testing.T) {
 
 func TestCommandEventUsesDataFieldForOutput(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	client := &sdkOpenSandboxClient{rt: Runtime{Stdout: &stdout, Stderr: &stderr}}
+	client := &sdkOpenSandboxClient{rt: core.Runtime{Stdout: &stdout, Stderr: &stderr}}
 	if _, err := client.handleCommandEvent(streamEvent(`{"type":"stdout","data":"hello"}`)); err != nil {
 		t.Fatal(err)
 	}
@@ -2736,7 +2736,7 @@ func TestCommandEventUsesDataFieldForOutput(t *testing.T) {
 
 func TestCommandEventReconstructsStructuredOutputLines(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	client := &sdkOpenSandboxClient{rt: Runtime{Stdout: &stdout, Stderr: &stderr}}
+	client := &sdkOpenSandboxClient{rt: core.Runtime{Stdout: &stdout, Stderr: &stderr}}
 	state := commandOutputState{}
 	for _, event := range []commandStreamEvent{
 		streamEvent(`{"type":"stdout","text":"line1"}`),
@@ -2755,7 +2755,7 @@ func TestCommandEventReconstructsStructuredOutputLines(t *testing.T) {
 
 func TestCommandEventDoesNotDuplicateStructuredLineTerminators(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	client := &sdkOpenSandboxClient{rt: Runtime{Stdout: &stdout, Stderr: &stderr}}
+	client := &sdkOpenSandboxClient{rt: core.Runtime{Stdout: &stdout, Stderr: &stderr}}
 	state := commandOutputState{}
 	for _, event := range []commandStreamEvent{
 		streamEvent("{\"type\":\"stdout\",\"text\":\"line1\\n\"}"),
@@ -2774,7 +2774,7 @@ func TestCommandEventDoesNotDuplicateStructuredLineTerminators(t *testing.T) {
 
 func TestCommandEventReconstructsRawSSEOutputLines(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	client := &sdkOpenSandboxClient{rt: Runtime{Stdout: &stdout, Stderr: &stderr}}
+	client := &sdkOpenSandboxClient{rt: core.Runtime{Stdout: &stdout, Stderr: &stderr}}
 	state := commandOutputState{}
 	for _, event := range []commandStreamEvent{
 		{Event: "stdout", Data: "line1"},
@@ -2793,7 +2793,7 @@ func TestCommandEventReconstructsRawSSEOutputLines(t *testing.T) {
 
 func TestCommandEventDoesNotDuplicateRawSSELineTerminators(t *testing.T) {
 	var stdout bytes.Buffer
-	client := &sdkOpenSandboxClient{rt: Runtime{Stdout: &stdout, Stderr: io.Discard}}
+	client := &sdkOpenSandboxClient{rt: core.Runtime{Stdout: &stdout, Stderr: io.Discard}}
 	state := commandOutputState{}
 	for _, event := range []commandStreamEvent{
 		{Event: "stdout", Data: "line1\n"},
@@ -2810,7 +2810,7 @@ func TestCommandEventDoesNotDuplicateRawSSELineTerminators(t *testing.T) {
 
 func TestCommandEventPreservesOutputWhitespace(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	client := &sdkOpenSandboxClient{rt: Runtime{Stdout: &stdout, Stderr: &stderr}}
+	client := &sdkOpenSandboxClient{rt: core.Runtime{Stdout: &stdout, Stderr: &stderr}}
 	if _, err := client.handleCommandEvent(streamEvent("{\"type\":\"stdout\",\"text\":\"  ok\\n\"}")); err != nil {
 		t.Fatal(err)
 	}
@@ -2824,7 +2824,7 @@ func TestCommandEventPreservesOutputWhitespace(t *testing.T) {
 
 func TestCommandEventPreservesRawSSEWhitespaceChunks(t *testing.T) {
 	var stdout bytes.Buffer
-	client := &sdkOpenSandboxClient{rt: Runtime{Stdout: &stdout, Stderr: io.Discard}}
+	client := &sdkOpenSandboxClient{rt: core.Runtime{Stdout: &stdout, Stderr: io.Discard}}
 	state := commandOutputState{}
 	for _, event := range []commandStreamEvent{
 		{Event: "stdout", Data: ""},
@@ -2842,7 +2842,7 @@ func TestCommandEventPreservesRawSSEWhitespaceChunks(t *testing.T) {
 
 func TestCommandEventPreservesTrailingBlankOutputRecord(t *testing.T) {
 	var stdout bytes.Buffer
-	client := &sdkOpenSandboxClient{rt: Runtime{Stdout: &stdout, Stderr: io.Discard}}
+	client := &sdkOpenSandboxClient{rt: core.Runtime{Stdout: &stdout, Stderr: io.Discard}}
 	state := commandOutputState{}
 	for _, event := range []commandStreamEvent{
 		streamEvent("{\"type\":\"stdout\",\"text\":\"line1\\n\"}"),
@@ -2859,7 +2859,7 @@ func TestCommandEventPreservesTrailingBlankOutputRecord(t *testing.T) {
 
 func TestCommandEventPreservesLineStateAcrossResultOutput(t *testing.T) {
 	var stdout bytes.Buffer
-	client := &sdkOpenSandboxClient{rt: Runtime{Stdout: &stdout, Stderr: io.Discard}}
+	client := &sdkOpenSandboxClient{rt: core.Runtime{Stdout: &stdout, Stderr: io.Discard}}
 	state := commandOutputState{}
 	for _, event := range []commandStreamEvent{
 		streamEvent("{\"type\":\"stdout\",\"text\":\"a\\n\"}"),
@@ -2899,19 +2899,19 @@ func newTestBackend(fake *fakeOpenSandboxClient) *openSandboxBackend {
 	return &openSandboxBackend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt: Runtime{
+		rt: core.Runtime{
 			Stdout: &bytes.Buffer{},
 			Stderr: &bytes.Buffer{},
 		},
-		newClient: func(Config, Runtime) (openSandboxClient, error) {
+		newClient: func(core.Config, core.Runtime) (openSandboxClient, error) {
 			return fake, nil
 		},
 		cleanupTimeoutOverride: 10 * time.Millisecond,
 	}
 }
 
-func testConfig() Config {
-	cfg := Config{}
+func testConfig() core.Config {
+	cfg := core.Config{}
 	cfg.Provider = providerName
 	cfg.OpenSandbox.Image = "ubuntu:24.04"
 	cfg.OpenSandbox.Workdir = "/workspace/crabbox"
@@ -3139,24 +3139,24 @@ func TestRunCancellationAfterResumeDoesNotReclaim(t *testing.T) {
 	backend.rt.Stderr = &stderr
 	leaseID := leasePrefix + fake.sandbox.ID
 	scope := testOpenSandboxScope(t, fake.baseURL)
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, scope, "", "/original", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, scope, "", "/original", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
-	before, err := readLeaseClaim(leaseID)
+	before, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	fake.afterResume = cancel
-	result, err := backend.Run(ctx, RunRequest{
-		ID: leaseID, Repo: Repo{Name: "my-app", Root: "/other"}, Reclaim: true, NoSync: true, KeepOnFailure: true, Command: []string{"true"},
+	result, err := backend.Run(ctx, core.RunRequest{
+		ID: leaseID, Repo: core.Repo{Name: "my-app", Root: "/other"}, Reclaim: true, NoSync: true, KeepOnFailure: true, Command: []string{"true"},
 	})
 	if !errors.Is(err, context.Canceled) || result.Session == nil || !result.Session.Kept || !result.Session.Reused {
 		t.Fatalf("result=%#v session=%#v err=%v", result, result.Session, err)
 	}
-	after, err := readLeaseClaim(leaseID)
+	after, err := core.ReadLeaseClaim(leaseID)
 	if err != nil || !reflect.DeepEqual(after, before) {
 		t.Fatalf("claim changed: before=%#v after=%#v err=%v", before, after, err)
 	}

--- a/internal/providers/opensandbox/client.go
+++ b/internal/providers/opensandbox/client.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	core "github.com/openclaw/crabbox/internal/cli"
 	"io"
 	"net"
 	"net/http"
@@ -16,6 +15,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 
 	sdk "github.com/alibaba/OpenSandbox/sdks/sandbox/go"
 	"github.com/openclaw/crabbox/internal/providers/shared"
@@ -117,7 +118,7 @@ func (t openSandboxRedirectTransport) RoundTrip(req *http.Request) (*http.Respon
 		response.Body.Close()
 		return nil, errors.New("opensandbox received an invalid redirect location")
 	}
-	if sameOpenSandboxOrigin(req.URL, destination) {
+	if core.SameHTTPOrigin(req.URL, destination) {
 		return response, nil
 	}
 	response.Body.Close()
@@ -139,8 +140,8 @@ func (t openSandboxQueryTransport) RoundTrip(req *http.Request) (*http.Response,
 var errOpenSandboxNotFound = errors.New("opensandbox not found")
 
 type sdkOpenSandboxClient struct {
-	cfg                    Config
-	rt                     Runtime
+	cfg                    core.Config
+	rt                     core.Runtime
 	base                   string
 	key                    string
 	client                 *http.Client
@@ -148,10 +149,10 @@ type sdkOpenSandboxClient struct {
 	execTimeoutOverride    time.Duration
 }
 
-func newOpenSandboxClient(cfg Config, rt Runtime) (openSandboxClient, error) {
+func newOpenSandboxClient(cfg core.Config, rt core.Runtime) (openSandboxClient, error) {
 	rawURL := strings.TrimSpace(cfg.OpenSandbox.APIURL)
 	if rawURL == "" {
-		return nil, exit(2, "provider=opensandbox needs a trusted API URL; set --opensandbox-api-url, CRABBOX_OPENSANDBOX_API_URL, or OPEN_SANDBOX_API_URL")
+		return nil, core.Exit(2, "provider=opensandbox needs a trusted API URL; set --opensandbox-api-url, CRABBOX_OPENSANDBOX_API_URL, or OPEN_SANDBOX_API_URL")
 	}
 	baseURL, err := validateOpenSandboxAPIURL(rawURL)
 	if err != nil {
@@ -162,7 +163,7 @@ func newOpenSandboxClient(cfg Config, rt Runtime) (openSandboxClient, error) {
 		os.Getenv("OPEN_SANDBOX_API_KEY"),
 	)
 	if apiKey == "" {
-		return nil, exit(2, "provider=opensandbox needs an API key; load CRABBOX_OPENSANDBOX_API_KEY or OPEN_SANDBOX_API_KEY from a secret manager")
+		return nil, core.Exit(2, "provider=opensandbox needs an API key; load CRABBOX_OPENSANDBOX_API_KEY or OPEN_SANDBOX_API_KEY from a secret manager")
 	}
 	httpClient := rt.HTTP
 	if httpClient == nil {
@@ -180,14 +181,14 @@ func newOpenSandboxClient(cfg Config, rt Runtime) (openSandboxClient, error) {
 func validateOpenSandboxAPIURL(raw string) (string, error) {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {
-		return "", exit(2, "provider=opensandbox API URL must be an absolute HTTP(S) URL")
+		return "", core.Exit(2, "provider=opensandbox API URL must be an absolute HTTP(S) URL")
 	}
 	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", exit(2, "provider=opensandbox API URL must not contain userinfo, query parameters, or a fragment")
+		return "", core.Exit(2, "provider=opensandbox API URL must not contain userinfo, query parameters, or a fragment")
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
 	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
-		return "", exit(2, "provider=opensandbox API URL must use HTTPS except for loopback development endpoints")
+		return "", core.Exit(2, "provider=opensandbox API URL must use HTTPS except for loopback development endpoints")
 	}
 	host := shared.LowercaseHostname(parsed.Hostname())
 	port := parsed.Port()
@@ -230,10 +231,6 @@ func secureOpenSandboxHTTPClient(source *http.Client) *http.Client {
 		return nil
 	}
 	return &client
-}
-
-func sameOpenSandboxOrigin(a, b *url.URL) bool {
-	return core.SameHTTPOrigin(a, b)
 }
 
 func (c *sdkOpenSandboxClient) BaseURL() string { return c.base }
@@ -963,10 +960,10 @@ func normalizeOpenSandboxEndpointHeaders(values map[string]string) (map[string]s
 	for key, value := range values {
 		canonical := http.CanonicalHeaderKey(strings.TrimSpace(key))
 		if canonical == "" {
-			return nil, exit(5, "opensandbox execd endpoint returned an invalid empty header name")
+			return nil, core.Exit(5, "opensandbox execd endpoint returned an invalid empty header name")
 		}
 		if existing, ok := headers[canonical]; ok && existing != value {
-			return nil, exit(5, "opensandbox execd endpoint returned conflicting values for header %s", canonical)
+			return nil, core.Exit(5, "opensandbox execd endpoint returned conflicting values for header %s", canonical)
 		}
 		headers[canonical] = value
 	}
@@ -980,17 +977,17 @@ func validateOpenSandboxExecdURL(raw, defaultProtocol string) (string, string, e
 	}
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {
-		return "", "", exit(5, "opensandbox execd endpoint must be an absolute HTTP(S) URL")
+		return "", "", core.Exit(5, "opensandbox execd endpoint must be an absolute HTTP(S) URL")
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return "", "", exit(5, "opensandbox execd endpoint must use HTTP(S)")
+		return "", "", core.Exit(5, "opensandbox execd endpoint must use HTTP(S)")
 	}
 	if parsed.User != nil || parsed.Fragment != "" {
-		return "", "", exit(5, "opensandbox execd endpoint must not contain userinfo or a fragment")
+		return "", "", core.Exit(5, "opensandbox execd endpoint must not contain userinfo or a fragment")
 	}
 	if parsed.Scheme == "http" && !isLoopbackHost(parsed.Hostname()) {
-		return "", "", exit(5, "opensandbox execd endpoint host %q must use HTTPS unless it is loopback", parsed.Host)
+		return "", "", core.Exit(5, "opensandbox execd endpoint host %q must use HTTPS unless it is loopback", parsed.Host)
 	}
 	rawQuery := parsed.RawQuery
 	parsed.RawQuery = ""

--- a/internal/providers/opensandbox/core.go
+++ b/internal/providers/opensandbox/core.go
@@ -1,32 +1,10 @@
 package opensandbox
 
 import (
-	"io"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type CleanupRequest = core.CleanupRequest
-type Server = core.Server
-type Repo = core.Repo
-type LeaseClaim = core.LeaseClaim
-type ExitError = core.ExitError
-type timingPhase = core.TimingPhase
 
 const (
 	providerName    = "opensandbox"
@@ -52,30 +30,6 @@ const (
 	openSandboxNameKey          = "crabbox.name"
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
-}
-
-func readLeaseClaim(leaseID string) (core.LeaseClaim, error) {
-	return core.ReadLeaseClaim(leaseID)
-}
-
 func listOpenSandboxLeaseClaims() ([]core.LeaseClaim, error) {
 	return core.ListLeaseClaimsWithPrefix(leasePrefix)
 }
@@ -92,26 +46,6 @@ func listOpenSandboxCleanupClaims() ([]core.LeaseClaim, error) {
 	return append(claims, recoveries...), nil
 }
 
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
-func removeLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
-	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
-func shellQuote(s string) string {
-	return core.ShellQuote(s)
-}
-
 func openSandboxCleanupCommand(leaseID string) string {
-	return "crabbox stop --provider " + providerName + " " + shellQuote(leaseID)
-}
-
-func inventoryDoctorResult(provider string, leases int) DoctorResult {
-	return core.InventoryDoctorResult(provider, leases)
+	return "crabbox stop --provider " + providerName + " " + core.ShellQuote(leaseID)
 }

--- a/internal/providers/opensandbox/flags.go
+++ b/internal/providers/opensandbox/flags.go
@@ -8,11 +8,11 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func RegisterOpenSandboxProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterOpenSandboxProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterOpenSandboxConfigFlags(fs, defaults.OpenSandbox)
 }
 
-func ApplyOpenSandboxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyOpenSandboxProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	switch strings.ToLower(strings.TrimSpace(cfg.Provider)) {
 	case providerName:
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --opensandbox-cpu and --opensandbox-memory", "use --opensandbox-cpu and --opensandbox-memory"); err != nil {

--- a/internal/providers/opensandbox/operation_lock.go
+++ b/internal/providers/opensandbox/operation_lock.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -12,7 +13,7 @@ func lockOpenSandboxLeaseOperation(ctx context.Context, leaseID string) (func(),
 	validLeaseID := strings.HasPrefix(leaseID, leasePrefix) && strings.TrimPrefix(leaseID, leasePrefix) != ""
 	validRecoveryID := strings.HasPrefix(leaseID, recoveryPrefix) && strings.TrimPrefix(leaseID, recoveryPrefix) != ""
 	if (!validLeaseID && !validRecoveryID) || filepath.Base(leaseID) != leaseID || leaseID == "." {
-		return nil, exit(2, "invalid opensandbox lease id %q", leaseID)
+		return nil, core.Exit(2, "invalid opensandbox lease id %q", leaseID)
 	}
 	return shared.LockLeaseOperation(ctx, "opensandbox", leaseID)
 }

--- a/internal/providers/opensandbox/provider.go
+++ b/internal/providers/opensandbox/provider.go
@@ -54,29 +54,29 @@ func (Provider) ValidateConfig(cfg core.Config) error {
 	return validateOpenSandboxConfig(cfg)
 }
 
-func validateOpenSandboxConfig(cfg Config) error {
+func validateOpenSandboxConfig(cfg core.Config) error {
 	if cfg.OpenSandbox.TimeoutSecs < 0 {
-		return exit(2, "opensandbox timeoutSecs must be non-negative")
+		return core.Exit(2, "opensandbox timeoutSecs must be non-negative")
 	}
 	if cfg.OpenSandbox.ExecTimeoutSecs < 0 {
-		return exit(2, "opensandbox execTimeoutSecs must be non-negative")
+		return core.Exit(2, "opensandbox execTimeoutSecs must be non-negative")
 	}
 	return nil
 }
 
-func validateOpenSandboxRunConfig(cfg Config) error {
-	return validateOpenSandboxRequestConfig(cfg, RunRequest{})
+func validateOpenSandboxRunConfig(cfg core.Config) error {
+	return validateOpenSandboxRequestConfig(cfg, core.RunRequest{})
 }
 
-func validateOpenSandboxRequestConfig(cfg Config, req RunRequest) error {
+func validateOpenSandboxRequestConfig(cfg core.Config, req core.RunRequest) error {
 	required := openSandboxRunBudgetForConfig(cfg, req.NoSync, req.SyncOnly)
 	if lifetime := openSandboxLifetimeForConfig(cfg); lifetime < required {
-		return exit(2, "opensandbox effective lifetime %s must cover sync/command budget %s", lifetime, required)
+		return core.Exit(2, "opensandbox effective lifetime %s must cover sync/command budget %s", lifetime, required)
 	}
 	return nil
 }
 
-func openSandboxCommandBudgetForConfig(cfg Config) time.Duration {
+func openSandboxCommandBudgetForConfig(cfg core.Config) time.Duration {
 	execTimeout := cfg.OpenSandbox.ExecTimeoutSecs
 	if execTimeout == 0 {
 		execTimeout = openSandboxExecTimeoutSecs
@@ -84,7 +84,7 @@ func openSandboxCommandBudgetForConfig(cfg Config) time.Duration {
 	return time.Duration(execTimeout)*time.Second + openSandboxExecGrace
 }
 
-func openSandboxRunBudgetForConfig(cfg Config, noSync, syncOnly bool) time.Duration {
+func openSandboxRunBudgetForConfig(cfg core.Config, noSync, syncOnly bool) time.Duration {
 	commandBudget := openSandboxCommandBudgetForConfig(cfg)
 	// Even --no-sync runs one remote command to create the configured workdir.
 	syncBudget := commandBudget
@@ -97,7 +97,7 @@ func openSandboxRunBudgetForConfig(cfg Config, noSync, syncOnly bool) time.Durat
 	return syncBudget + commandBudget
 }
 
-func openSandboxLifetimeForConfig(cfg Config) time.Duration {
+func openSandboxLifetimeForConfig(cfg core.Config) time.Duration {
 	lifetime := time.Duration(0)
 	for _, candidate := range []time.Duration{
 		time.Duration(cfg.OpenSandbox.TimeoutSecs) * time.Second,

--- a/internal/providers/opensandbox/sync.go
+++ b/internal/providers/opensandbox/sync.go
@@ -8,7 +8,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *openSandboxBackend) syncWorkspace(ctx context.Context, api openSandboxClient, sandboxID string, req RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+func (b *openSandboxBackend) syncWorkspace(ctx context.Context, api openSandboxClient, sandboxID string, req core.RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
@@ -32,18 +32,18 @@ func (b *openSandboxBackend) syncWorkspace(ctx context.Context, api openSandboxC
 
 func (b *openSandboxBackend) execShell(ctx context.Context, api openSandboxClient, sandboxID, command string) error {
 	exitCode, err := api.RunCommand(ctx, sandboxID, runCommandRequest{
-		Command:     "sh -lc " + shellQuote(command),
+		Command:     "sh -lc " + core.ShellQuote(command),
 		TimeoutSecs: b.execTimeoutSecs(),
 	})
 	if err != nil {
 		return err
 	}
 	if exitCode != 0 {
-		return exit(exitCode, "opensandbox exec %q exited %d", command, exitCode)
+		return core.Exit(exitCode, "opensandbox exec %q exited %d", command, exitCode)
 	}
 	return nil
 }
 
 func (b *openSandboxBackend) ensureWorkspace(ctx context.Context, api openSandboxClient, sandboxID, workdir string) error {
-	return b.execShell(ctx, api, sandboxID, "mkdir -p "+shellQuote(workdir))
+	return b.execShell(ctx, api, sandboxID, "mkdir -p "+core.ShellQuote(workdir))
 }


### PR DESCRIPTION
E2B, Modal, Blaxel, CodeSandbox, Cloudflare Sandbox, and OpenSandbox each carried provider-local copies of core API names and exact forwarding functions. Use core types and functions directly, deleting 437 net production lines and making their actual ownership visible at the call site.

The replacements were checked against Go type identity and resolved symbol uses. Provider-bound claim scopes, recovery behavior, constants, and mutable injection hooks retain their adapter ownership. No command behavior or public CLI/configuration surface changes.

Validation: complete tests passed for all six provider packages, including their acquisition, reuse, execution, ownership, cleanup, and transport fixtures. Scoped Autoreview passed. Full CI passed on the PR head. No new dependencies or configuration.
