### PR TITLE
refactor(providers): use core directly in delegated adapters

### DIFF
--- a/internal/providers/azuredynamicsessions/backend.go
+++ b/internal/providers/azuredynamicsessions/backend.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func NewAzureDynamicSessionsBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewAzureDynamicSessionsBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	return &azureDynamicSessionsBackend{spec: spec, cfg: cfg, rt: rt}
 }
@@ -20,16 +20,16 @@ func NewAzureDynamicSessionsBackend(spec ProviderSpec, cfg Config, rt Runtime) B
 var azureDynamicSessionsDeleteTimeout = 30 * time.Second
 
 type azureDynamicSessionsBackend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
-func (b *azureDynamicSessionsBackend) Spec() ProviderSpec { return b.spec }
+func (b *azureDynamicSessionsBackend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *azureDynamicSessionsBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *azureDynamicSessionsBackend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if req.ActionsRunner {
-		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+		return core.Exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
 	started := core.ClockNow(b.rt.Clock)
 	client, err := newAzureDynamicSessionsClient(ctx, b.cfg, b.rt)
@@ -46,7 +46,7 @@ func (b *azureDynamicSessionsBackend) Warmup(ctx context.Context, req WarmupRequ
 		if err != nil {
 			return err
 		}
-		if err := removeLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
+		if err := core.RemoveLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
 			return client.DeleteSession(ctx, leaseID)
 		}); err != nil {
 			return providerError("delete session", err)
@@ -62,11 +62,11 @@ func (b *azureDynamicSessionsBackend) Warmup(ctx context.Context, req WarmupRequ
 	})
 }
 
-func (b *azureDynamicSessionsBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *azureDynamicSessionsBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	workspace, workspaceErr := azureDynamicSessionsWorkspace(b.cfg)
 	var client azureDynamicSessionsAPI
 	var leaseID, slug string
-	var cleanupClaim LeaseClaim
+	var cleanupClaim core.LeaseClaim
 	handle := func() shared.DelegatedSandbox {
 		return shared.DelegatedSandbox{LeaseID: leaseID, Slug: slug, CleanupCommand: azureDynamicSessionsCleanupCommand(leaseID)}
 	}
@@ -74,11 +74,11 @@ func (b *azureDynamicSessionsBackend) Run(ctx context.Context, req RunRequest) (
 		Provider: providerName, Runtime: b.rt, Workdir: workspace,
 		IdleTimeout: b.cfg.IdleTimeout, TTL: b.cfg.TTL, CleanupTimeout: azureDynamicSessionsDeleteTimeout,
 		Preflight: func(ctx context.Context) error {
-			if err := delegatedSyncOptionsError(b.spec, req); err != nil {
+			if err := core.RejectDelegatedSyncOptionsForSpec(b.spec, req); err != nil {
 				return err
 			}
 			if !req.SyncOnly && len(req.Command) == 0 {
-				return exit(2, "missing command")
+				return core.Exit(2, "missing command")
 			}
 			var err error
 			client, err = newAzureDynamicSessionsClient(ctx, b.cfg, b.rt)
@@ -122,7 +122,7 @@ func (b *azureDynamicSessionsBackend) Run(ctx context.Context, req RunRequest) (
 				return shared.DelegatedSandboxCommand{}, err
 			}
 			if req.EnvSummary {
-				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+				core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 			}
 			return shared.DelegatedSandboxCommand{Text: command, Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
 				fmt.Fprintf(b.rt.Stderr, "running on %s %s\n", providerName, strings.Join(req.Command, " "))
@@ -140,7 +140,7 @@ func (b *azureDynamicSessionsBackend) Run(ctx context.Context, req RunRequest) (
 	})
 }
 
-func (b *azureDynamicSessionsBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *azureDynamicSessionsBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	client, err := newAzureDynamicSessionsClient(ctx, b.cfg, b.rt)
 	if err != nil {
 		return nil, err
@@ -149,7 +149,7 @@ func (b *azureDynamicSessionsBackend) List(ctx context.Context, req ListRequest)
 	if err != nil {
 		return nil, providerError("list sessions", err)
 	}
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (b *azureDynamicSessionsBackend) List(ctx context.Context, req ListRequest)
 			claimByID[claim.LeaseID] = coreLeaseClaim{LeaseID: claim.LeaseID, Slug: claim.Slug, RepoRoot: claim.RepoRoot}
 		}
 	}
-	servers := make([]Server, 0, len(sessions))
+	servers := make([]core.Server, 0, len(sessions))
 	for _, session := range sessions {
 		identifier := session.Identifier
 		if identifier == "" {
@@ -178,18 +178,18 @@ func (b *azureDynamicSessionsBackend) List(ctx context.Context, req ListRequest)
 	return servers, nil
 }
 
-func (b *azureDynamicSessionsBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
-	servers, err := b.List(ctx, ListRequest{})
+func (b *azureDynamicSessionsBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
+	servers, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return inventoryDoctorResult(providerName, len(servers)), nil
+	return core.InventoryDoctorResult(providerName, len(servers)), nil
 }
 
-func (b *azureDynamicSessionsBackend) Status(ctx context.Context, req StatusRequest) (statusView, error) {
+func (b *azureDynamicSessionsBackend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	client, err := newAzureDynamicSessionsClient(ctx, b.cfg, b.rt)
 	if err != nil {
-		return statusView{}, err
+		return core.StatusView{}, err
 	}
 	waitTimeout := req.WaitTimeout
 	if waitTimeout <= 0 {
@@ -204,7 +204,7 @@ func (b *azureDynamicSessionsBackend) Status(ctx context.Context, req StatusRequ
 	defer cancel()
 	leaseID, slug, err := b.resolveSessionID(pollCtx, client, req.ID, "", false)
 	if err != nil {
-		return statusView{}, err
+		return core.StatusView{}, err
 	}
 	for {
 		session, err := client.GetSession(pollCtx, leaseID)
@@ -214,42 +214,42 @@ func (b *azureDynamicSessionsBackend) Status(ctx context.Context, req StatusRequ
 				return view, nil
 			}
 			if core.ClockNow(b.rt.Clock).After(deadline) {
-				return statusView{}, exit(5, "timed out waiting for session %s to become ready", leaseID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for session %s to become ready", leaseID)
 			}
 			select {
 			case <-pollCtx.Done():
 				if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-					return statusView{}, exit(5, "timed out waiting for session %s to become ready", leaseID)
+					return core.StatusView{}, core.Exit(5, "timed out waiting for session %s to become ready", leaseID)
 				}
-				return statusView{}, pollCtx.Err()
+				return core.StatusView{}, pollCtx.Err()
 			case <-time.After(2 * time.Second):
 			}
 			continue
 		}
 		if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-			return statusView{}, exit(5, "timed out waiting for session %s to become ready", leaseID)
+			return core.StatusView{}, core.Exit(5, "timed out waiting for session %s to become ready", leaseID)
 		}
 		if ctx.Err() != nil {
-			return statusView{}, ctx.Err()
+			return core.StatusView{}, ctx.Err()
 		}
 		if !isNotFoundError(err) || !req.Wait {
-			return statusView{}, providerError("get session", err)
+			return core.StatusView{}, providerError("get session", err)
 		}
 		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return statusView{}, exit(5, "timed out waiting for session %s to become ready", leaseID)
+			return core.StatusView{}, core.Exit(5, "timed out waiting for session %s to become ready", leaseID)
 		}
 		select {
 		case <-pollCtx.Done():
 			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return statusView{}, exit(5, "timed out waiting for session %s to become ready", leaseID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for session %s to become ready", leaseID)
 			}
-			return statusView{}, pollCtx.Err()
+			return core.StatusView{}, pollCtx.Err()
 		case <-time.After(2 * time.Second):
 		}
 	}
 }
 
-func (b *azureDynamicSessionsBackend) Stop(ctx context.Context, req StopRequest) error {
+func (b *azureDynamicSessionsBackend) Stop(ctx context.Context, req core.StopRequest) error {
 	client, err := newAzureDynamicSessionsClient(ctx, b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -263,7 +263,7 @@ func (b *azureDynamicSessionsBackend) Stop(ctx context.Context, req StopRequest)
 		return err
 	}
 	missing := false
-	if err := removeLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
+	if err := core.RemoveLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
 		if err := client.DeleteSession(ctx, leaseID); err != nil {
 			if isNotFoundError(err) {
 				missing = true
@@ -283,9 +283,9 @@ func (b *azureDynamicSessionsBackend) Stop(ctx context.Context, req StopRequest)
 	return nil
 }
 
-func (b *azureDynamicSessionsBackend) createSession(ctx context.Context, client azureDynamicSessionsAPI, repo Repo, reclaim bool, requestedSlug string) (string, string, error) {
+func (b *azureDynamicSessionsBackend) createSession(ctx context.Context, client azureDynamicSessionsAPI, repo core.Repo, reclaim bool, requestedSlug string) (string, string, error) {
 	leaseID := newSessionID()
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return "", "", err
 	}
@@ -297,7 +297,7 @@ func (b *azureDynamicSessionsBackend) createSession(ctx context.Context, client 
 	if err != nil {
 		return "", "", b.rollbackCreatedSession(client, leaseID, err)
 	}
-	if err := claimLeaseForRepoProviderScope(leaseID, slug, providerName, scope, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScope(leaseID, slug, providerName, scope, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
 		return "", "", b.rollbackCreatedSession(client, leaseID, err)
 	}
 	return leaseID, slug, nil
@@ -316,24 +316,24 @@ func (b *azureDynamicSessionsBackend) deleteSessionBounded(client azureDynamicSe
 	return client.DeleteSession(ctx, leaseID)
 }
 
-func (b *azureDynamicSessionsBackend) sessionClaimForDeletion(leaseID string) (LeaseClaim, error) {
+func (b *azureDynamicSessionsBackend) sessionClaimForDeletion(leaseID string) (core.LeaseClaim, error) {
 	scope, err := b.claimScope()
 	if err != nil {
-		return LeaseClaim{}, err
+		return core.LeaseClaim{}, err
 	}
 	claim, ok, err := resolveAzureDynamicSessionsClaim(leaseID, scope)
 	if err != nil {
-		return LeaseClaim{}, err
+		return core.LeaseClaim{}, err
 	}
 	if !ok || claim.LeaseID != leaseID {
-		return LeaseClaim{}, exit(4, "%s session %q is not claimed by Crabbox", providerName, leaseID)
+		return core.LeaseClaim{}, core.Exit(4, "%s session %q is not claimed by Crabbox", providerName, leaseID)
 	}
 	return claim, nil
 }
 
 func (b *azureDynamicSessionsBackend) resolveSessionID(_ context.Context, _ azureDynamicSessionsAPI, id, repoRoot string, reclaim bool) (string, string, error) {
 	if id == "" {
-		return "", "", exit(2, "provider=%s requires a kept Crabbox lease id or slug", providerName)
+		return "", "", core.Exit(2, "provider=%s requires a kept Crabbox lease id or slug", providerName)
 	}
 	scope, err := b.claimScope()
 	if err != nil {
@@ -343,13 +343,13 @@ func (b *azureDynamicSessionsBackend) resolveSessionID(_ context.Context, _ azur
 		return "", "", err
 	} else if ok {
 		if repoRoot != "" {
-			if err := claimLeaseForRepoProviderScope(claim.LeaseID, claim.Slug, providerName, scope, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim); err != nil {
+			if err := core.ClaimLeaseForRepoProviderScope(claim.LeaseID, claim.Slug, providerName, scope, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim); err != nil {
 				return "", "", err
 			}
 		}
 		return claim.LeaseID, claim.Slug, nil
 	}
-	return "", "", exit(4, "%s session %q is not claimed by Crabbox; use a kept Crabbox lease id or slug", providerName, id)
+	return "", "", core.Exit(4, "%s session %q is not claimed by Crabbox; use a kept Crabbox lease id or slug", providerName, id)
 }
 
 func (b *azureDynamicSessionsBackend) claimScope() (string, error) {
@@ -360,21 +360,21 @@ func (b *azureDynamicSessionsBackend) claimScope() (string, error) {
 	return "endpoint:" + endpoint, nil
 }
 
-func resolveAzureDynamicSessionsClaim(identifier, scope string) (LeaseClaim, bool, error) {
-	claims, err := listLeaseClaims()
+func resolveAzureDynamicSessionsClaim(identifier, scope string) (core.LeaseClaim, bool, error) {
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
-		return LeaseClaim{}, false, err
+		return core.LeaseClaim{}, false, err
 	}
-	slug := normalizeLeaseSlug(identifier)
+	slug := core.NormalizeLeaseSlug(identifier)
 	for _, claim := range claims {
 		if claim.Provider != providerName || strings.TrimSpace(claim.ProviderScope) != scope {
 			continue
 		}
-		if claim.LeaseID == identifier || (slug != "" && normalizeLeaseSlug(claim.Slug) == slug) {
+		if claim.LeaseID == identifier || (slug != "" && core.NormalizeLeaseSlug(claim.Slug) == slug) {
 			return claim, true, nil
 		}
 	}
-	return LeaseClaim{}, false, nil
+	return core.LeaseClaim{}, false, nil
 }
 
 type coreLeaseClaim struct {
@@ -383,18 +383,18 @@ type coreLeaseClaim struct {
 	RepoRoot string
 }
 
-func (b *azureDynamicSessionsBackend) sessionToServer(session azureDynamicSessionsSession, claim coreLeaseClaim) Server {
+func (b *azureDynamicSessionsBackend) sessionToServer(session azureDynamicSessionsSession, claim coreLeaseClaim) core.Server {
 	identifier := session.Identifier
 	slug := claim.Slug
 	if slug == "" {
-		slug = newLeaseSlug(identifier)
+		slug = core.NewLeaseSlug(identifier)
 	}
 	status := azureDynamicSessionsSessionStatus(session)
 	labels := map[string]string{
 		"crabbox":  "true",
 		"provider": providerName,
 		"lease":    identifier,
-		"slug":     normalizeLeaseSlug(slug),
+		"slug":     core.NormalizeLeaseSlug(slug),
 		"target":   targetLinux,
 		"state":    core.Blank(status, "ready"),
 	}
@@ -404,7 +404,7 @@ func (b *azureDynamicSessionsBackend) sessionToServer(session azureDynamicSessio
 	if expires := azureDynamicSessionsSessionExpires(session); expires != "" {
 		labels["expires_at"] = expires
 	}
-	server := Server{
+	server := core.Server{
 		Provider: providerName,
 		CloudID:  identifier,
 		Name:     identifier,
@@ -415,9 +415,9 @@ func (b *azureDynamicSessionsBackend) sessionToServer(session azureDynamicSessio
 	return server
 }
 
-func (b *azureDynamicSessionsBackend) statusView(leaseID, slug string, session azureDynamicSessionsSession) statusView {
+func (b *azureDynamicSessionsBackend) statusView(leaseID, slug string, session azureDynamicSessionsSession) core.StatusView {
 	status := azureDynamicSessionsSessionStatus(session)
-	return statusView{
+	return core.StatusView{
 		ID:         leaseID,
 		Slug:       slug,
 		Provider:   providerName,
@@ -431,7 +431,7 @@ func (b *azureDynamicSessionsBackend) statusView(leaseID, slug string, session a
 		Labels: map[string]string{
 			"provider": providerName,
 			"lease":    leaseID,
-			"slug":     normalizeLeaseSlug(slug),
+			"slug":     core.NormalizeLeaseSlug(slug),
 			"target":   targetLinux,
 		},
 	}

--- a/internal/providers/azuredynamicsessions/backend_test.go
+++ b/internal/providers/azuredynamicsessions/backend_test.go
@@ -38,8 +38,8 @@ func TestRunStopsNewSessionByDefault(t *testing.T) {
 	restoreAzureDynamicSessionsClient(t, fake)
 	backend := testAzureDynamicSessionsBackend()
 
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: repo, Name: "repo"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: repo, Name: "repo"},
 		NoSync:  true,
 		Command: []string{"printf", "ok"},
 	})
@@ -67,7 +67,7 @@ func TestRunStopsNewSessionByDefault(t *testing.T) {
 	if len(fake.deleted) != 1 || fake.deleted[0] != result.LeaseID {
 		t.Fatalf("deleted sessions = %#v, want %s", fake.deleted, result.LeaseID)
 	}
-	if _, ok, err := resolveLeaseClaimForProvider(result.LeaseID, providerName); err != nil || ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider(result.LeaseID, providerName); err != nil || ok {
 		t.Fatalf("claim after cleanup ok=%t err=%v", ok, err)
 	}
 }
@@ -82,8 +82,8 @@ func TestRunCleanupUsesBoundedContext(t *testing.T) {
 	backend := testAzureDynamicSessionsBackend()
 
 	started := time.Now()
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:       Repo{Root: t.TempDir(), Name: "repo"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Root: t.TempDir(), Name: "repo"},
 		NoSync:     true,
 		Command:    []string{"printf", "ok"},
 		TimingJSON: true,
@@ -115,19 +115,19 @@ func TestRunCleanupPreservesReplacedSessionClaim(t *testing.T) {
 		if strings.HasPrefix(req.Command, "mkdir -p ") {
 			return
 		}
-		claims, err := listLeaseClaims()
+		claims, err := core.ListLeaseClaims()
 		if err != nil || len(claims) != 1 {
 			t.Fatalf("claims=%#v err=%v", claims, err)
 		}
 		claim := claims[0]
-		if err := claimLeaseForRepoProviderScope(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, replacementRepo, time.Minute, true); err != nil {
+		if err := core.ClaimLeaseForRepoProviderScope(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, replacementRepo, time.Minute, true); err != nil {
 			t.Fatal(err)
 		}
 	}
 	restoreAzureDynamicSessionsClient(t, fake)
 	backend := testAzureDynamicSessionsBackend()
-	result, err := backend.Run(t.Context(), RunRequest{
-		Repo:    Repo{Root: t.TempDir(), Name: "repo"},
+	result, err := backend.Run(t.Context(), core.RunRequest{
+		Repo:    core.Repo{Root: t.TempDir(), Name: "repo"},
 		NoSync:  true,
 		Command: []string{"printf", "ok"},
 	})
@@ -137,7 +137,7 @@ func TestRunCleanupPreservesReplacedSessionClaim(t *testing.T) {
 	if len(fake.deleted) != 0 {
 		t.Fatalf("deleted=%#v, want replaced session claim protected", fake.deleted)
 	}
-	claim, ok, err := resolveLeaseClaimForProvider(result.LeaseID, providerName)
+	claim, ok, err := core.ResolveLeaseClaimForProvider(result.LeaseID, providerName)
 	if err != nil || !ok || claim.RepoRoot != replacementRepo {
 		t.Fatalf("replacement claim=%#v ok=%t err=%v", claim, ok, err)
 	}
@@ -152,7 +152,7 @@ func TestCreateSessionRollbackReportsDeleteFailure(t *testing.T) {
 	backend := testAzureDynamicSessionsBackend()
 	backend.cfg.AzureDynamicSessions.Endpoint = ""
 
-	_, _, err := backend.createSession(context.Background(), fake, Repo{Root: t.TempDir(), Name: "repo"}, false, "")
+	_, _, err := backend.createSession(context.Background(), fake, core.Repo{Root: t.TempDir(), Name: "repo"}, false, "")
 	if err == nil || !strings.Contains(err.Error(), "requires azureDynamicSessions.endpoint") || !strings.Contains(err.Error(), "cleanup azure-dynamic-sessions session") || !strings.Contains(err.Error(), "delete failed") {
 		t.Fatalf("err = %v, want claim-scope and cleanup errors", err)
 	}
@@ -168,14 +168,14 @@ func TestRunKeepOnFailureRetainsNewSession(t *testing.T) {
 	restoreAzureDynamicSessionsClient(t, fake)
 	backend := testAzureDynamicSessionsBackend()
 
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:          Repo{Root: repo, Name: "repo"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:          core.Repo{Root: repo, Name: "repo"},
 		NoSync:        true,
 		KeepOnFailure: true,
 		Command:       []string{"false"},
 		TimingJSON:    true,
 	})
-	var exitErr ExitError
+	var exitErr core.ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 7 {
 		t.Fatalf("err = %v, want exit 7", err)
 	}
@@ -188,7 +188,7 @@ func TestRunKeepOnFailureRetainsNewSession(t *testing.T) {
 	if len(fake.deleted) != 0 {
 		t.Fatalf("deleted sessions = %#v, want retained session", fake.deleted)
 	}
-	if claim, ok, err := resolveLeaseClaimForProvider(result.LeaseID, providerName); err != nil || !ok || claim.RepoRoot != repo {
+	if claim, ok, err := core.ResolveLeaseClaimForProvider(result.LeaseID, providerName); err != nil || !ok || claim.RepoRoot != repo {
 		t.Fatalf("retained claim ok=%t claim=%#v err=%v", ok, claim, err)
 	}
 	var report core.TimingReport
@@ -231,8 +231,8 @@ func TestRunKeepOnFailureRetainsNewSessionAfterSetupFailure(t *testing.T) {
 			backend := testAzureDynamicSessionsBackend()
 			repo := newAzureDynamicSessionsSyncTestRepo(t)
 
-			result, err := backend.Run(t.Context(), RunRequest{
-				Repo:          Repo{Root: repo, Name: "repo"},
+			result, err := backend.Run(t.Context(), core.RunRequest{
+				Repo:          core.Repo{Root: repo, Name: "repo"},
 				NoSync:        tc.noSync,
 				KeepOnFailure: true,
 				Command:       []string{"true"},
@@ -246,7 +246,7 @@ func TestRunKeepOnFailureRetainsNewSessionAfterSetupFailure(t *testing.T) {
 			if len(fake.deleted) != 0 {
 				t.Fatalf("deleted sessions=%v, want retained session", fake.deleted)
 			}
-			if claim, ok, claimErr := resolveLeaseClaimForProvider(result.LeaseID, providerName); claimErr != nil || !ok || claim.RepoRoot != repo {
+			if claim, ok, claimErr := core.ResolveLeaseClaimForProvider(result.LeaseID, providerName); claimErr != nil || !ok || claim.RepoRoot != repo {
 				t.Fatalf("retained claim ok=%t claim=%#v err=%v", ok, claim, claimErr)
 			}
 			if !strings.Contains(backend.rt.Stderr.(*bytes.Buffer).String(), "keep-on-failure") {
@@ -282,8 +282,8 @@ func TestSyncDeletePreservesWorkspaceWhenReplacementFails(t *testing.T) {
 			backend := testAzureDynamicSessionsBackend()
 			backend.cfg.Sync.Delete = true
 
-			_, _, err := backend.syncWorkspace(t.Context(), fake, "azds-session", RunRequest{
-				Repo: Repo{Root: newAzureDynamicSessionsSyncTestRepo(t), Name: "repo"},
+			_, _, err := backend.syncWorkspace(t.Context(), fake, "azds-session", core.RunRequest{
+				Repo: core.Repo{Root: newAzureDynamicSessionsSyncTestRepo(t), Name: "repo"},
 			}, workspace)
 			if err == nil {
 				t.Fatal("sync unexpectedly succeeded")
@@ -307,10 +307,10 @@ func TestStatusWaitBoundsInFlightSessionLookup(t *testing.T) {
 	backend := testAzureDynamicSessionsBackend()
 	started := time.Now()
 
-	_, err := backend.Status(t.Context(), StatusRequest{
+	_, err := backend.Status(t.Context(), core.StatusRequest{
 		ID: "waiting-session", Wait: true, WaitTimeout: 30 * time.Millisecond,
 	})
-	var exitErr ExitError
+	var exitErr core.ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 5 || !strings.Contains(err.Error(), "timed out waiting for session azds-wait") {
 		t.Fatalf("status err=%v, want session wait timeout with exit code 5", err)
 	}
@@ -327,8 +327,8 @@ func TestRunReusesClaimWithoutStoppingSession(t *testing.T) {
 	restoreAzureDynamicSessionsClient(t, fake)
 	backend := testAzureDynamicSessionsBackend()
 
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: repo, Name: "repo"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: repo, Name: "repo"},
 		ID:      "kept-session",
 		NoSync:  true,
 		Command: []string{"printf", "ok"},
@@ -356,8 +356,8 @@ func TestWarmupRejectsActionsRunner(t *testing.T) {
 	restoreAzureDynamicSessionsClient(t, fake)
 	backend := testAzureDynamicSessionsBackend()
 
-	err := backend.Warmup(context.Background(), WarmupRequest{
-		Repo:          Repo{Root: t.TempDir(), Name: "repo"},
+	err := backend.Warmup(context.Background(), core.WarmupRequest{
+		Repo:          core.Repo{Root: t.TempDir(), Name: "repo"},
 		ActionsRunner: true,
 	})
 	if err == nil || !strings.Contains(err.Error(), "--actions-runner is not supported") {
@@ -377,10 +377,10 @@ func TestStopRemovesStaleClaimWhenSessionIsGone(t *testing.T) {
 	restoreAzureDynamicSessionsClient(t, fake)
 	backend := testAzureDynamicSessionsBackend()
 
-	if err := backend.Stop(context.Background(), StopRequest{ID: "stale-session"}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: "stale-session"}); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok, err := resolveLeaseClaimForProvider("stale-session", providerName); err != nil || ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider("stale-session", providerName); err != nil || ok {
 		t.Fatalf("claim after stale stop ok=%t err=%v", ok, err)
 	}
 }
@@ -398,10 +398,10 @@ func TestStopRemovesStaleClaimOnAzureMissingSessionCode(t *testing.T) {
 	restoreAzureDynamicSessionsClient(t, fake)
 	backend := testAzureDynamicSessionsBackend()
 
-	if err := backend.Stop(context.Background(), StopRequest{ID: "stale-session-400"}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: "stale-session-400"}); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok, err := resolveLeaseClaimForProvider("stale-session-400", providerName); err != nil || ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider("stale-session-400", providerName); err != nil || ok {
 		t.Fatalf("claim after stale stop ok=%t err=%v", ok, err)
 	}
 }
@@ -445,7 +445,7 @@ func TestResolveSessionIDUsesClaimedSlug(t *testing.T) {
 
 func TestResolveSessionIDRejectsClaimFromDifferentEndpoint(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	if err := claimLeaseForRepoProviderScope("azds-other-pool", "other-pool", providerName, "endpoint:http://127.0.0.1:8788", t.TempDir(), time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScope("azds-other-pool", "other-pool", providerName, "endpoint:http://127.0.0.1:8788", t.TempDir(), time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	backend := testAzureDynamicSessionsBackend()
@@ -462,7 +462,7 @@ func TestResolveSessionIDRejectsClaimFromDifferentEndpoint(t *testing.T) {
 func claimAzureDynamicSessionsLease(t *testing.T, leaseID, slug, repoRoot string, idleTimeout time.Duration) {
 	t.Helper()
 	scope := "endpoint:" + testAzureDynamicSessionsEndpoint
-	if err := claimLeaseForRepoProviderScope(leaseID, slug, providerName, scope, repoRoot, idleTimeout, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScope(leaseID, slug, providerName, scope, repoRoot, idleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -549,8 +549,8 @@ func TestRunPreservesPrimaryFailureThroughCleanupAndTimingWrite(t *testing.T) {
 			restoreAzureDynamicSessionsClient(t, fake)
 			b := testAzureDynamicSessionsBackend()
 			b.rt.Stderr = azureLifecycleFailingWriter{writerErr}
-			result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, Command: []string{"workload"}, TimingJSON: true})
-			var exitErr ExitError
+			result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, Command: []string{"workload"}, TimingJSON: true})
+			var exitErr core.ExitError
 			if !errors.As(err, &exitErr) || exitErr.Code != wantCode || result.ExitCode != wantCode {
 				t.Fatalf("primary exit lost: result=%#v err=%v", result, err)
 			}
@@ -563,7 +563,7 @@ func TestRunPreservesPrimaryFailureThroughCleanupAndTimingWrite(t *testing.T) {
 			if len(fake.deleted) != 1 || result.Session == nil || !result.Session.Kept {
 				t.Fatalf("cleanup/session=%v/%#v", fake.deleted, result.Session)
 			}
-			if _, ok, err := resolveLeaseClaimForProvider(result.LeaseID, providerName); err != nil || !ok {
+			if _, ok, err := core.ResolveLeaseClaimForProvider(result.LeaseID, providerName); err != nil || !ok {
 				t.Fatalf("failed cleanup removed claim: %v", err)
 			}
 		})
@@ -593,7 +593,7 @@ func (r *recordingAzureDynamicSessionsAPI) DeleteSession(ctx context.Context, id
 func restoreAzureDynamicSessionsClient(t *testing.T, api azureDynamicSessionsAPI) {
 	t.Helper()
 	previous := newAzureDynamicSessionsClient
-	newAzureDynamicSessionsClient = func(context.Context, Config, Runtime) (azureDynamicSessionsAPI, error) {
+	newAzureDynamicSessionsClient = func(context.Context, core.Config, core.Runtime) (azureDynamicSessionsAPI, error) {
 		return api, nil
 	}
 	t.Cleanup(func() {
@@ -604,8 +604,8 @@ func restoreAzureDynamicSessionsClient(t *testing.T, api azureDynamicSessionsAPI
 func testAzureDynamicSessionsBackend() *azureDynamicSessionsBackend {
 	return &azureDynamicSessionsBackend{
 		spec: Provider{}.Spec(),
-		cfg:  Config{AzureDynamicSessions: AzureDynamicSessionsConfig{Endpoint: testAzureDynamicSessionsEndpoint}},
-		rt: Runtime{
+		cfg:  core.Config{AzureDynamicSessions: core.AzureDynamicSessionsConfig{Endpoint: testAzureDynamicSessionsEndpoint}},
+		rt: core.Runtime{
 			Stdout: &bytes.Buffer{},
 			Stderr: &bytes.Buffer{},
 		},
@@ -648,7 +648,7 @@ func TestRunCleanupBoundsClaimFenceWait(t *testing.T) {
 		if strings.HasPrefix(req.Command, "mkdir -p ") {
 			return
 		}
-		claims, err := listLeaseClaims()
+		claims, err := core.ListLeaseClaims()
 		if err != nil || len(claims) != 1 {
 			t.Fatalf("claims=%v err=%v", claims, err)
 		}
@@ -671,7 +671,7 @@ func TestRunCleanupBoundsClaimFenceWait(t *testing.T) {
 			t.Fatal("claim fence was not acquired")
 		}
 	}
-	result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, Command: []string{"true"}, TimingJSON: true})
+	result, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, Command: []string{"true"}, TimingJSON: true})
 	if !errors.Is(err, context.DeadlineExceeded) || result.ExitCode != 1 || result.ErrorKind != core.RunErrorProvider || len(fake.deleted) != 0 {
 		t.Fatalf("cleanup escaped bounded claim fence: result=%#v err=%v deletes=%v", result, err, fake.deleted)
 	}

--- a/internal/providers/azuredynamicsessions/client.go
+++ b/internal/providers/azuredynamicsessions/client.go
@@ -85,7 +85,7 @@ func (e *azureDynamicSessionsAPIError) Error() string {
 	return e.Status + ": " + e.Body
 }
 
-var newAzureDynamicSessionsClient = func(ctx context.Context, cfg Config, rt Runtime) (azureDynamicSessionsAPI, error) {
+var newAzureDynamicSessionsClient = func(ctx context.Context, cfg core.Config, rt core.Runtime) (azureDynamicSessionsAPI, error) {
 	if err := validateNativeCredentialDestination(cfg); err != nil {
 		return nil, err
 	}
@@ -107,29 +107,29 @@ var newAzureDynamicSessionsClient = func(ctx context.Context, cfg Config, rt Run
 	}, nil
 }
 
-func azureDynamicSessionsEndpoint(cfg Config) (string, error) {
+func azureDynamicSessionsEndpoint(cfg core.Config) (string, error) {
 	if strings.TrimSpace(cfg.AzureDynamicSessions.Pool) != "" {
-		return "", exit(2, "azureDynamicSessions.pool is not supported; set azureDynamicSessions.endpoint to the custom container poolManagementEndpoint")
+		return "", core.Exit(2, "azureDynamicSessions.pool is not supported; set azureDynamicSessions.endpoint to the custom container poolManagementEndpoint")
 	}
 	endpoint := strings.TrimSpace(cfg.AzureDynamicSessions.Endpoint)
 	if endpoint == "" {
-		return "", exit(2, "provider=%s requires azureDynamicSessions.endpoint set to the custom container poolManagementEndpoint", providerName)
+		return "", core.Exit(2, "provider=%s requires azureDynamicSessions.endpoint set to the custom container poolManagementEndpoint", providerName)
 	}
 	parsed, err := url.Parse(endpoint)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return "", exit(2, "%s endpoint %q is invalid", providerName, endpoint)
+		return "", core.Exit(2, "%s endpoint %q is invalid", providerName, endpoint)
 	}
 	if parsed.User != nil {
-		return "", exit(2, "%s endpoint must not include userinfo", providerName)
+		return "", core.Exit(2, "%s endpoint must not include userinfo", providerName)
 	}
 	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
-		return "", exit(2, "%s endpoint %q must use https unless it targets localhost", providerName, endpoint)
+		return "", core.Exit(2, "%s endpoint %q must use https unless it targets localhost", providerName, endpoint)
 	}
 	if !isAzureDynamicSessionsTrustedEndpointURL(parsed) {
-		return "", exit(2, "%s endpoint %q must target an Azure Container Apps Dynamic Sessions host", providerName, endpoint)
+		return "", core.Exit(2, "%s endpoint %q must target an Azure Container Apps Dynamic Sessions host", providerName, endpoint)
 	}
 	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", exit(2, "%s endpoint %q must not include query or fragment components", providerName, endpoint)
+		return "", core.Exit(2, "%s endpoint %q must not include query or fragment components", providerName, endpoint)
 	}
 	return strings.TrimRight(parsed.String(), "/"), nil
 }
@@ -149,12 +149,12 @@ func isLoopbackHTTPURL(parsed *url.URL) bool {
 	return shared.IsLoopbackHTTPURL(parsed)
 }
 
-func azureDynamicSessionsAccessToken(ctx context.Context, cfg Config, rt Runtime) (string, error) {
+func azureDynamicSessionsAccessToken(ctx context.Context, cfg core.Config, rt core.Runtime) (string, error) {
 	if token := strings.TrimSpace(os.Getenv(tokenEnvName)); token != "" {
 		return token, nil
 	}
 	if rt.Exec == nil {
-		return "", exit(2, "provider=%s requires %s or Azure CLI authentication", providerName, tokenEnvName)
+		return "", core.Exit(2, "provider=%s requires %s or Azure CLI authentication", providerName, tokenEnvName)
 	}
 	args := []string{
 		"account", "get-access-token",
@@ -168,20 +168,20 @@ func azureDynamicSessionsAccessToken(ctx context.Context, cfg Config, rt Runtime
 	if subscription := strings.TrimSpace(cfg.AzureSubscription); subscription != "" {
 		args = append(args, "--subscription", subscription)
 	}
-	result, err := rt.Exec.Run(ctx, LocalCommandRequest{Name: "az", Args: args})
+	result, err := rt.Exec.Run(ctx, core.LocalCommandRequest{Name: "az", Args: args})
 	if err != nil || result.ExitCode != 0 {
 		stderr := strings.TrimSpace(result.Stderr)
 		if stderr != "" {
-			return "", exit(2, "Azure CLI token request failed: %s", stderr)
+			return "", core.Exit(2, "Azure CLI token request failed: %s", stderr)
 		}
 		if err != nil {
-			return "", exit(2, "Azure CLI token request failed: %v", err)
+			return "", core.Exit(2, "Azure CLI token request failed: %v", err)
 		}
-		return "", exit(2, "Azure CLI token request failed with exit %d", result.ExitCode)
+		return "", core.Exit(2, "Azure CLI token request failed with exit %d", result.ExitCode)
 	}
 	token := strings.TrimSpace(result.Stdout)
 	if token == "" {
-		return "", exit(2, "Azure CLI token request returned an empty token")
+		return "", core.Exit(2, "Azure CLI token request returned an empty token")
 	}
 	return token, nil
 }
@@ -383,13 +383,13 @@ func (c *azureDynamicSessionsClient) doJSONURL(ctx context.Context, method, endp
 	}
 	defer resp.Body.Close()
 	return shared.DecodeUnboundedJSONResponse(resp, out, func(statusCode int, status string, data []byte) error {
-		return &azureDynamicSessionsAPIError{StatusCode: statusCode, Status: status, Body: shared.RedactErrorSecrets(summarizeJSON(data), c.token)}
+		return &azureDynamicSessionsAPIError{StatusCode: statusCode, Status: status, Body: shared.RedactErrorSecrets(core.SummarizeJSON(data), c.token)}
 	})
 }
 
 func (c *azureDynamicSessionsClient) responseError(resp *http.Response) error {
 	data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-	return &azureDynamicSessionsAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(summarizeJSON(data), c.token)}
+	return &azureDynamicSessionsAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(core.SummarizeJSON(data), c.token)}
 }
 
 func (c *azureDynamicSessionsClient) controlPlaneHTTPClient() *http.Client {
@@ -417,7 +417,7 @@ func (c *azureDynamicSessionsClient) secureHTTPClient(source *http.Client) *http
 	trusted, _ := url.Parse(c.endpoint)
 	originalCheckRedirect := source.CheckRedirect
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameOriginURL(trusted, req.URL) {
+		if !core.SameHTTPOrigin(trusted, req.URL) {
 			return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, req.URL.Redacted())
 		}
 		if originalCheckRedirect != nil {
@@ -450,7 +450,7 @@ func (c *azureDynamicSessionsClient) nextURL(next string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if !sameOriginURL(base, parsed) {
+	if !core.SameHTTPOrigin(base, parsed) {
 		return "", fmt.Errorf("%s nextLink points outside configured endpoint origin", providerName)
 	}
 	query := parsed.Query()
@@ -459,10 +459,6 @@ func (c *azureDynamicSessionsClient) nextURL(next string) (string, error) {
 		parsed.RawQuery = query.Encode()
 	}
 	return parsed.String(), nil
-}
-
-func sameOriginURL(a, b *url.URL) bool {
-	return core.SameHTTPOrigin(a, b)
 }
 
 func (c *azureDynamicSessionsClient) url(path string, query url.Values) string {
@@ -507,11 +503,11 @@ func (s azureDynamicSessionsSession) normalized(fallback string) azureDynamicSes
 	return s
 }
 
-func azureDynamicSessionsTimeout(cfg Config) time.Duration {
+func azureDynamicSessionsTimeout(cfg core.Config) time.Duration {
 	return time.Duration(azureDynamicSessionsTimeoutSeconds(cfg)) * time.Second
 }
 
-func azureDynamicSessionsTimeoutSeconds(cfg Config) int {
+func azureDynamicSessionsTimeoutSeconds(cfg core.Config) int {
 	timeout := cfg.AzureDynamicSessions.TimeoutSecs
 	if timeout <= 0 {
 		if cfg.TTL > 0 {

--- a/internal/providers/azuredynamicsessions/client_test.go
+++ b/internal/providers/azuredynamicsessions/client_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestAzureDynamicSessionsFlagRouteAndDeferredPoolContract(t *testing.T) {
 	p := Provider{}
-	cfg := Config{}
+	cfg := core.Config{}
 	if err := p.RouteConfig(&cfg, nil, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -35,8 +35,8 @@ func TestAzureDynamicSessionsFlagRouteAndDeferredPoolContract(t *testing.T) {
 		t.Fatal("Azure backend route changed")
 	}
 	for _, target := range []string{"", core.TargetLinux, "darwin"} {
-		cfg := Config{TargetOS: target}
-		b, err := p.Configure(cfg, Runtime{})
+		cfg := core.Config{TargetOS: target}
+		b, err := p.Configure(cfg, core.Runtime{})
 		if target == "darwin" {
 			if err == nil || err.Error() != "azure-dynamic-sessions supports target=linux only" {
 				t.Fatalf("target check=%v", err)
@@ -58,7 +58,7 @@ func TestAzureDynamicSessionsFlagRouteAndDeferredPoolContract(t *testing.T) {
 	if fs.Lookup("azure-dynamic-sessions-pool") != nil {
 		t.Fatal("legacy Pool acquired a flag")
 	}
-	cfg.AzureDynamicSessions = AzureDynamicSessionsConfig{Endpoint: "https://example.invalid/pool", Pool: "legacy", APIVersion: "version", Workdir: "/workspace/app", TimeoutSecs: 12}
+	cfg.AzureDynamicSessions = core.AzureDynamicSessionsConfig{Endpoint: "https://example.invalid/pool", Pool: "legacy", APIVersion: "version", Workdir: "/workspace/app", TimeoutSecs: 12}
 	before := cfg
 	if err := ApplyAzureDynamicSessionsProviderFlags(&cfg, fs, values); err != nil {
 		t.Fatal(err)
@@ -69,7 +69,7 @@ func TestAzureDynamicSessionsFlagRouteAndDeferredPoolContract(t *testing.T) {
 	if err := fs.Parse([]string{"--azure-dynamic-sessions-endpoint=https://example.invalid/pool", "--azure-dynamic-sessions-api-version=version", "--azure-dynamic-sessions-workdir=/workspace/app", "--azure-dynamic-sessions-timeout-secs=12"}); err != nil {
 		t.Fatal(err)
 	}
-	cfg.AzureDynamicSessions = AzureDynamicSessionsConfig{Pool: "legacy"}
+	cfg.AzureDynamicSessions = core.AzureDynamicSessionsConfig{Pool: "legacy"}
 	if err := ApplyAzureDynamicSessionsProviderFlags(&cfg, fs, values); err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +83,7 @@ func TestAzureDynamicSessionsFlagRouteAndDeferredPoolContract(t *testing.T) {
 	if err := ApplyAzureDynamicSessionsProviderFlags(&cfg, fs, values); err != nil {
 		t.Fatal("flag application performed deferred validation")
 	}
-	before.AzureDynamicSessions = AzureDynamicSessionsConfig{Pool: "legacy", TimeoutSecs: -1}
+	before.AzureDynamicSessions = core.AzureDynamicSessionsConfig{Pool: "legacy", TimeoutSecs: -1}
 	if !reflect.DeepEqual(cfg, before) {
 		t.Fatal("explicit fields or central marker phase changed")
 	}
@@ -100,7 +100,7 @@ func TestAzureDynamicSessionsFlagRouteAndDeferredPoolContract(t *testing.T) {
 		t.Fatalf("legacy Pool later rejection=%v", err)
 	}
 	for _, name := range []string{providerName, "Azure-Dynamic-Sessions", " azure-dynamic-sessions "} {
-		cfg := Config{Provider: name}
+		cfg := core.Config{Provider: name}
 		fs := flag.NewFlagSet("guard", flag.ContinueOnError)
 		fs.String("class", "", "")
 		fs.String("type", "", "")
@@ -132,9 +132,9 @@ func TestAzureDynamicSessionsFlagRouteAndDeferredPoolContract(t *testing.T) {
 func TestAzureDynamicSessionsDefaultConsumersWithMockedAuth(t *testing.T) {
 	t.Setenv(tokenEnvName, "")
 	for _, raw := range []string{"", "  ", " custom-version "} {
-		cfg := Config{AzureDynamicSessions: AzureDynamicSessionsConfig{Endpoint: "http://127.0.0.1:8787", APIVersion: raw, Workdir: "  "}}
-		runner := &recordingRunner{result: LocalCommandResult{Stdout: "inert-mocked-auth\n"}}
-		api, err := newAzureDynamicSessionsClient(context.Background(), cfg, Runtime{Exec: runner, HTTP: &http.Client{}})
+		cfg := core.Config{AzureDynamicSessions: core.AzureDynamicSessionsConfig{Endpoint: "http://127.0.0.1:8787", APIVersion: raw, Workdir: "  "}}
+		runner := &recordingRunner{result: core.LocalCommandResult{Stdout: "inert-mocked-auth\n"}}
+		api, err := newAzureDynamicSessionsClient(context.Background(), cfg, core.Runtime{Exec: runner, HTTP: &http.Client{}})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -157,12 +157,12 @@ func TestAzureDynamicSessionsDefaultConsumersWithMockedAuth(t *testing.T) {
 		ttl        time.Duration
 		want       int
 	}{{0, 0, 1800}, {-1, 0, 1800}, {0, -time.Second, 1800}, {0, 1500 * time.Millisecond, 2}, {-1, 42 * time.Second, 42}, {7, 42 * time.Second, 7}} {
-		cfg := Config{TTL: tc.ttl, AzureDynamicSessions: AzureDynamicSessionsConfig{TimeoutSecs: tc.configured}}
+		cfg := core.Config{TTL: tc.ttl, AzureDynamicSessions: core.AzureDynamicSessionsConfig{TimeoutSecs: tc.configured}}
 		if got := azureDynamicSessionsTimeoutSeconds(cfg); got != tc.want {
 			t.Fatalf("timeout configured=%d ttl=%s got=%d want=%d", tc.configured, tc.ttl, got, tc.want)
 		}
 	}
-	cfg := Config{AzureDynamicSessions: AzureDynamicSessionsConfig{Workdir: " /workspace/custom/ "}}
+	cfg := core.Config{AzureDynamicSessions: core.AzureDynamicSessionsConfig{Workdir: " /workspace/custom/ "}}
 	if got, err := azureDynamicSessionsWorkspace(cfg); err != nil || got != "/workspace/custom" {
 		t.Fatalf("custom workspace=%q error=%v", got, err)
 	}
@@ -170,8 +170,8 @@ func TestAzureDynamicSessionsDefaultConsumersWithMockedAuth(t *testing.T) {
 	if defaults.APIVersion != "2025-02-02-preview" || defaults.Workdir != "/workspace/crabbox" || defaults.TimeoutSecs != 1800 {
 		t.Fatal("compiled defaults changed")
 	}
-	runner := &recordingRunner{result: LocalCommandResult{Stdout: "inert"}}
-	_, err := newAzureDynamicSessionsClient(context.Background(), Config{AzureDynamicSessions: AzureDynamicSessionsConfig{Pool: "legacy"}}, Runtime{Exec: runner, HTTP: &http.Client{}})
+	runner := &recordingRunner{result: core.LocalCommandResult{Stdout: "inert"}}
+	_, err := newAzureDynamicSessionsClient(context.Background(), core.Config{AzureDynamicSessions: core.AzureDynamicSessionsConfig{Pool: "legacy"}}, core.Runtime{Exec: runner, HTTP: &http.Client{}})
 	if err == nil || len(runner.calls) != 0 {
 		t.Fatal("legacy Pool validation must precede mocked authentication")
 	}
@@ -233,9 +233,9 @@ func TestAzureDynamicSessionsFallbackBoundsControlAndPreservesExecStream(t *test
 func TestAzureDynamicSessionsInjectedHTTPClientIsPreservedForBothPlanes(t *testing.T) {
 	t.Setenv(tokenEnvName, "test-token")
 	injected := &http.Client{Timeout: 17 * time.Second}
-	api, err := newAzureDynamicSessionsClient(context.Background(), Config{AzureDynamicSessions: AzureDynamicSessionsConfig{
+	api, err := newAzureDynamicSessionsClient(context.Background(), core.Config{AzureDynamicSessions: core.AzureDynamicSessionsConfig{
 		Endpoint: "http://127.0.0.1:8787",
-	}}, Runtime{HTTP: injected})
+	}}, core.Runtime{HTTP: injected})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -246,7 +246,7 @@ func TestAzureDynamicSessionsInjectedHTTPClientIsPreservedForBothPlanes(t *testi
 }
 
 func TestAzureDynamicSessionsEndpointRequiresPoolManagementEndpoint(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	if _, err := azureDynamicSessionsEndpoint(cfg); err == nil {
 		t.Fatal("endpoint should be required")
 	}
@@ -263,12 +263,12 @@ func TestAzureDynamicSessionsEndpointRequiresPoolManagementEndpoint(t *testing.T
 
 func TestAzureDynamicSessionsPoolSelectorIsUnsupported(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	RegisterAzureDynamicSessionsProviderFlags(fs, Config{})
+	RegisterAzureDynamicSessionsProviderFlags(fs, core.Config{})
 	if fs.Lookup("azure-dynamic-sessions-pool") != nil {
 		t.Fatal("azure-dynamic-sessions-pool should not be registered")
 	}
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.AzureDynamicSessions.Endpoint = "https://pool.env.eastus.azurecontainerapps.io"
 	cfg.AzureDynamicSessions.Pool = "pool"
 	_, err := azureDynamicSessionsEndpoint(cfg)
@@ -288,7 +288,7 @@ func TestAzureDynamicSessionsEndpointRejectsUnsafeTokenDestinations(t *testing.T
 		"pool.env.eastus.azurecontainerapps.io",
 	} {
 		t.Run(endpoint, func(t *testing.T) {
-			cfg := Config{}
+			cfg := core.Config{}
 			cfg.AzureDynamicSessions.Endpoint = endpoint
 			_, err := azureDynamicSessionsEndpoint(cfg)
 			if err == nil {
@@ -299,7 +299,7 @@ func TestAzureDynamicSessionsEndpointRejectsUnsafeTokenDestinations(t *testing.T
 }
 
 func TestAzureDynamicSessionsEndpointAllowsLoopbackHTTPForLocalRunner(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.AzureDynamicSessions.Endpoint = "http://127.0.0.1:8787/"
 	got, err := azureDynamicSessionsEndpoint(cfg)
 	if err != nil {
@@ -312,9 +312,9 @@ func TestAzureDynamicSessionsEndpointAllowsLoopbackHTTPForLocalRunner(t *testing
 
 func TestAzureDynamicSessionsAccessTokenUsesDynamicsessionsAudience(t *testing.T) {
 	t.Setenv(tokenEnvName, "")
-	runner := &recordingRunner{result: LocalCommandResult{Stdout: "token\n"}}
-	cfg := Config{AzureTenant: "tenant-1", AzureSubscription: "sub-1"}
-	token, err := azureDynamicSessionsAccessToken(context.Background(), cfg, Runtime{Exec: runner})
+	runner := &recordingRunner{result: core.LocalCommandResult{Stdout: "token\n"}}
+	cfg := core.Config{AzureTenant: "tenant-1", AzureSubscription: "sub-1"}
+	token, err := azureDynamicSessionsAccessToken(context.Background(), cfg, core.Runtime{Exec: runner})
 	if err != nil {
 		t.Fatalf("access token: %v", err)
 	}
@@ -335,9 +335,9 @@ func TestAzureDynamicSessionsAccessTokenUsesDynamicsessionsAudience(t *testing.T
 
 func TestAzureDynamicSessionsAccessTokenPrefersEnvironmentToken(t *testing.T) {
 	t.Setenv(tokenEnvName, " env-token ")
-	runner := &recordingRunner{result: LocalCommandResult{Stdout: "az-token\n"}}
+	runner := &recordingRunner{result: core.LocalCommandResult{Stdout: "az-token\n"}}
 
-	token, err := azureDynamicSessionsAccessToken(context.Background(), Config{}, Runtime{Exec: runner})
+	token, err := azureDynamicSessionsAccessToken(context.Background(), core.Config{}, core.Runtime{Exec: runner})
 	if err != nil {
 		t.Fatalf("access token: %v", err)
 	}
@@ -708,11 +708,11 @@ func (w errWriter) Write([]byte) (int, error) {
 }
 
 type recordingRunner struct {
-	calls  []LocalCommandRequest
-	result LocalCommandResult
+	calls  []core.LocalCommandRequest
+	result core.LocalCommandResult
 }
 
-func (r *recordingRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.calls = append(r.calls, req)
 	return r.result, nil
 }

--- a/internal/providers/azuredynamicsessions/core.go
+++ b/internal/providers/azuredynamicsessions/core.go
@@ -1,41 +1,14 @@
 package azuredynamicsessions
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"io"
-	"os"
 	"strings"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type AzureDynamicSessionsConfig = core.AzureDynamicSessionsConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type Server = core.Server
-type Repo = core.Repo
-type SyncManifest = core.SyncManifest
-type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
-type ExitError = core.ExitError
-type LeaseClaim = core.LeaseClaim
-type timingPhase = core.TimingPhase
 
 const (
 	providerName = "azure-dynamic-sessions"
@@ -48,13 +21,7 @@ const (
 	exitSentinel            = "__crabbox_azds_exit_code__="
 )
 
-type statusView = core.StatusView
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func validateNativeCredentialDestination(cfg Config) error {
+func validateNativeCredentialDestination(cfg core.Config) error {
 	return core.ValidateNativeCredentialDestination(cfg, providerName)
 }
 
@@ -66,76 +33,8 @@ func newSessionID() string {
 	return "azds-" + hex.EncodeToString(b[:])
 }
 
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func claimLeaseForRepoProviderScope(leaseID, slug, provider, providerScope, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProviderScope(leaseID, slug, provider, providerScope, repoRoot, idleTimeout, reclaim)
-}
-
-func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaimForProvider(identifier, provider)
-}
-
-func removeLeaseClaimIfUnchangedAfter(leaseID string, claim LeaseClaim, action func() error) error {
-	return core.RemoveLeaseClaimIfUnchangedAfter(leaseID, claim, action)
-}
-
-func listLeaseClaims() ([]core.LeaseClaim, error) {
-	return core.ListLeaseClaims()
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
-func shellQuote(value string) string {
-	return core.ShellQuote(value)
-}
-
 func azureDynamicSessionsCleanupCommand(leaseID string) string {
-	return "crabbox stop --provider " + providerName + " " + shellQuote(leaseID)
-}
-
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
-func shellWords(words []string) []string {
-	return core.ShellWords(words)
-}
-
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func leadingEnvAssignment(command []string) bool {
-	return core.LeadingEnvAssignment(command)
-}
-
-func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
-	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
-}
-
-func summarizeJSON(data []byte) string {
-	return core.SummarizeJSON(data)
-}
-
-func inventoryDoctorResult(provider string, leases int) DoctorResult {
-	return core.InventoryDoctorResult(provider, leases)
-}
-
-func delegatedSyncOptionsError(spec ProviderSpec, req RunRequest) error {
-	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
+	return "crabbox stop --provider " + providerName + " " + core.ShellQuote(leaseID)
 }
 
 func durationSecondsCeil(duration time.Duration) int {

--- a/internal/providers/azuredynamicsessions/flags.go
+++ b/internal/providers/azuredynamicsessions/flags.go
@@ -7,11 +7,11 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func RegisterAzureDynamicSessionsProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterAzureDynamicSessionsProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterAzureDynamicSessionsConfigFlags(fs, defaults.AzureDynamicSessions)
 }
 
-func ApplyAzureDynamicSessionsProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyAzureDynamicSessionsProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if cfg.Provider == providerName {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "choose pool sizing in Azure", "choose pool sizing in Azure"); err != nil {
 			return err

--- a/internal/providers/azuredynamicsessions/sync.go
+++ b/internal/providers/azuredynamicsessions/sync.go
@@ -13,7 +13,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *azureDynamicSessionsBackend) syncWorkspace(ctx context.Context, client azureDynamicSessionsAPI, sessionID string, req RunRequest, workspace string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+func (b *azureDynamicSessionsBackend) syncWorkspace(ctx context.Context, client azureDynamicSessionsAPI, sessionID string, req core.RunRequest, workspace string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	workspace, err := cleanAzureDynamicSessionsWorkspacePath(workspace)
 	if err != nil {
 		return nil, 0, err
@@ -47,7 +47,7 @@ func (b *azureDynamicSessionsBackend) prepareWorkspace(ctx context.Context, clie
 	if err != nil {
 		return err
 	}
-	return b.execShell(ctx, client, sessionID, "mkdir -p "+shellQuote(workspace), io.Discard)
+	return b.execShell(ctx, client, sessionID, "mkdir -p "+core.ShellQuote(workspace), io.Discard)
 }
 
 func (b *azureDynamicSessionsBackend) execShell(ctx context.Context, client azureDynamicSessionsAPI, sessionID, command string, stdout io.Writer) error {
@@ -60,31 +60,31 @@ func (b *azureDynamicSessionsBackend) execShell(ctx context.Context, client azur
 		return fmt.Errorf("%s exec %q: %w", providerName, command, err)
 	}
 	if code != 0 {
-		return exit(code, "%s exec %q exited %d", providerName, command, code)
+		return core.Exit(code, "%s exec %q exited %d", providerName, command, code)
 	}
 	return nil
 }
 
-func createAzureDynamicSessionsSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest) (*os.File, error) {
-	return createPortableSyncArchive(ctx, repo, manifest, "crabbox-azds-sync-*.tgz")
+func createAzureDynamicSessionsSyncArchive(ctx context.Context, repo core.Repo, manifest core.SyncManifest) (*os.File, error) {
+	return core.CreateSyncArchive(ctx, repo, manifest, "crabbox-azds-sync-*.tgz")
 }
 
-func azureDynamicSessionsWorkspace(cfg Config) (string, error) {
+func azureDynamicSessionsWorkspace(cfg core.Config) (string, error) {
 	return cleanAzureDynamicSessionsWorkspacePath(core.Blank(strings.TrimSpace(cfg.AzureDynamicSessions.Workdir), core.AzureDynamicSessionsConfigDefaultWorkdir))
 }
 
 func cleanAzureDynamicSessionsWorkspacePath(workspace string) (string, error) {
 	trimmed := strings.TrimSpace(workspace)
 	if trimmed == "" {
-		return "", exit(2, "%s workspace path is empty", providerName)
+		return "", core.Exit(2, "%s workspace path is empty", providerName)
 	}
 	clean := path.Clean(trimmed)
 	if !strings.HasPrefix(clean, "/") {
-		return "", exit(2, "%s workspace path %q must resolve to an absolute path", providerName, workspace)
+		return "", core.Exit(2, "%s workspace path %q must resolve to an absolute path", providerName, workspace)
 	}
 	switch clean {
 	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/mnt", "/mnt/data", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspace":
-		return "", exit(2, "%s workspace path %q is too broad; choose a dedicated subdirectory", providerName, clean)
+		return "", core.Exit(2, "%s workspace path %q is too broad; choose a dedicated subdirectory", providerName, clean)
 	}
 	return clean, nil
 }
@@ -96,11 +96,11 @@ func buildAzureDynamicSessionsCommand(command []string, shellMode bool) (string,
 	if shellMode {
 		return strings.Join(command, " "), nil
 	}
-	if len(command) == 1 && shouldUseShell(command) {
+	if len(command) == 1 && core.ShouldUseShell(command) {
 		return command[0], nil
 	}
-	if shouldUseShell(command) || leadingEnvAssignment(command) {
-		return shellScriptFromArgv(command), nil
+	if core.ShouldUseShell(command) || core.LeadingEnvAssignment(command) {
+		return core.ShellScriptFromArgv(command), nil
 	}
-	return strings.Join(shellWords(command), " "), nil
+	return strings.Join(core.ShellWords(command), " "), nil
 }

--- a/internal/providers/azuredynamicsessions/sync_test.go
+++ b/internal/providers/azuredynamicsessions/sync_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestCleanAzureDynamicSessionsWorkspacePathRejectsUnsafeRoots(t *testing.T) {
@@ -32,7 +34,7 @@ func TestCleanAzureDynamicSessionsWorkspacePathCleansDedicatedAbsolutePath(t *te
 }
 
 func TestCreateAzureDynamicSessionsSyncArchiveRejectsUnsafeManifestPath(t *testing.T) {
-	_, err := createAzureDynamicSessionsSyncArchive(t.Context(), Repo{Root: t.TempDir()}, SyncManifest{Files: []string{"../secret.txt"}})
+	_, err := createAzureDynamicSessionsSyncArchive(t.Context(), core.Repo{Root: t.TempDir()}, core.SyncManifest{Files: []string{"../secret.txt"}})
 	if err == nil || !strings.Contains(err.Error(), "unsafe sync path") {
 		t.Fatalf("err = %v, want unsafe path", err)
 	}
@@ -46,7 +48,7 @@ func TestCreateAzureDynamicSessionsSyncArchiveIncludesFilesAndSymlinks(t *testin
 	if err := os.Symlink("file.txt", filepath.Join(repo, "link.txt")); err != nil {
 		t.Fatal(err)
 	}
-	archive, err := createAzureDynamicSessionsSyncArchive(t.Context(), Repo{Root: repo}, SyncManifest{Files: []string{"file.txt", "link.txt"}})
+	archive, err := createAzureDynamicSessionsSyncArchive(t.Context(), core.Repo{Root: repo}, core.SyncManifest{Files: []string{"file.txt", "link.txt"}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/cloudrunsandbox/backend.go
+++ b/internal/providers/cloudrunsandbox/backend.go
@@ -18,28 +18,28 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	return &backend{spec: spec, cfg: cfg, rt: rt}
 }
 
 type backend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *backend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if req.ActionsRunner {
-		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+		return core.Exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
 	if req.Options.Desktop || req.Options.Browser || req.Options.Code {
-		return exit(2, "provider=%s does not support desktop, browser, or code-server options", providerName)
+		return core.Exit(2, "provider=%s does not support desktop, browser, or code-server options", providerName)
 	}
 	if req.Options.Tailscale.Enabled {
-		return exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
+		return core.Exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
 	}
 	started := core.ClockNow(b.rt.Clock)
 	transport, err := newTransport(b.cfg, b.rt)
@@ -63,32 +63,32 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	})
 }
 
-func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResult, finalErr error) {
-	if err := delegatedSyncOptionsError(b.spec, req); err != nil {
-		return RunResult{}, err
+func (b *backend) Run(ctx context.Context, req core.RunRequest) (finalResult core.RunResult, finalErr error) {
+	if err := core.RejectDelegatedSyncOptionsForSpec(b.spec, req); err != nil {
+		return core.RunResult{}, err
 	}
 	if req.Options.Desktop || req.Options.Browser || req.Options.Code {
-		return RunResult{}, exit(2, "provider=%s does not support desktop, browser, or code-server options", providerName)
+		return core.RunResult{}, core.Exit(2, "provider=%s does not support desktop, browser, or code-server options", providerName)
 	}
 	if req.Options.Tailscale.Enabled {
-		return RunResult{}, exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
+		return core.RunResult{}, core.Exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
 	}
 	var command []string
 	if !req.SyncOnly {
 		var err error
 		command, err = buildCommand(req.Command, req.ShellMode)
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 	}
 	workdir, err := cloudRunSandboxWorkdir(b.cfg)
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	started := core.ClockNow(b.rt.Clock)
 	transport, err := newTransport(b.cfg, b.rt)
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	var prepared *core.PreparedArchive
 	if req.ID == "" && !req.NoSync {
@@ -97,31 +97,31 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 			TempPattern: "crabbox-cloud-run-sandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 		})
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 		defer prepared.Close()
 	}
 	leaseID, sandboxID, slug := "", "", ""
-	var claim LeaseClaim
+	var claim core.LeaseClaim
 	acquired := false
 	if req.ID == "" {
 		leaseID, sandboxID, slug, claim, err = b.createSandbox(ctx, transport, req.Repo, req.Reclaim, req.RequestedSlug)
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s mode=%s\n", leaseID, slug, providerName, sandboxID, transport.Mode())
 		acquired = true
 	} else {
 		leaseID, sandboxID, slug, claim, err = b.resolveLeaseID(req.ID, req.Repo.Root, req.Reclaim)
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 		if state, ready := b.claimStatus(claim); !ready {
-			return RunResult{}, exit(4, "cloud-run-sandbox lease %q is not ready for execution (state=%s)", leaseID, state)
+			return core.RunResult{}, core.Exit(4, "cloud-run-sandbox lease %q is not ready for execution (state=%s)", leaseID, state)
 		}
 	}
 	shouldStop := acquired && !req.Keep
-	session := &RunSessionHandle{
+	session := &core.RunSessionHandle{
 		Provider:       providerName,
 		LeaseID:        leaseID,
 		Slug:           slug,
@@ -129,7 +129,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 		Kept:           !shouldStop,
 		CleanupCommand: cleanupCommand(b.cfg, leaseID),
 	}
-	pendingTiming := timingReport{
+	pendingTiming := core.TimingReport{
 		Provider:      providerName,
 		LeaseID:       leaseID,
 		Slug:          slug,
@@ -167,27 +167,27 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 		if req.TimingJSON {
 			pendingTiming.ExitCode = finalResult.ExitCode
 			pendingTiming.TotalMs = finalResult.Total.Milliseconds()
-			report := timingReportWithRunResult(pendingTiming, finalResult, finalErr)
-			finalResult, finalErr = appendRunFailure(finalResult, finalErr, writeTimingJSON(b.rt.Stderr, report))
+			report := core.TimingReportWithRunResult(pendingTiming, finalResult, finalErr)
+			finalResult, finalErr = appendRunFailure(finalResult, finalErr, core.WriteTimingJSON(b.rt.Stderr, report))
 		}
 	}()
 	activityTimeout, err := claimOperationTimeout(claim, leaseActivityTimeout, core.ClockNow(b.rt.Clock).UTC())
 	if err != nil {
-		return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Session: session}, err
+		return core.RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Session: session}, err
 	}
 	claim, err = b.markClaimActivity(claim, "running", activityTimeout)
 	if err != nil {
-		return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Session: session}, err
+		return core.RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Session: session}, err
 	}
 	ctx, cancel := context.WithTimeout(ctx, activityTimeout)
 	defer cancel()
-	var guardedResult RunResult
+	var guardedResult core.RunResult
 	var guardedErr error
-	guardErr := withLeaseClaimUnchanged(leaseID, claim, func() error {
-		guardedResult, guardedErr = func() (RunResult, error) {
+	guardErr := core.WithLeaseClaimUnchanged(leaseID, claim, func() error {
+		guardedResult, guardedErr = func() (core.RunResult, error) {
 			fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s mode=%s\n", providerName, leaseID, sandboxID, workdir, transport.Mode())
 
-			syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
+			syncPhases := []core.TimingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
 			if req.TimingJSON {
 				pendingTiming.SyncPhases = syncPhases
 			}
@@ -198,20 +198,20 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 					pendingTiming.SyncPhases = syncPhases
 				}
 				if err != nil {
-					handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-					return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: core.ClockNow(b.rt.Clock).Sub(started), SyncDelegated: true, Session: session}, err
+					core.HandleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+					return core.RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: core.ClockNow(b.rt.Clock).Sub(started), SyncDelegated: true, Session: session}, err
 				}
 				fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
 			} else if err := b.ensureWorkspace(ctx, transport, sandboxID, workdir); err != nil {
-				handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-				return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: core.ClockNow(b.rt.Clock).Sub(started), SyncDelegated: true, Session: session}, err
+				core.HandleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+				return core.RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: core.ClockNow(b.rt.Clock).Sub(started), SyncDelegated: true, Session: session}, err
 			}
 
 			if req.SyncOnly {
-				result := RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: core.ClockNow(b.rt.Clock).Sub(started), SyncDelegated: true, Session: session}
+				result := core.RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: core.ClockNow(b.rt.Clock).Sub(started), SyncDelegated: true, Session: session}
 				fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
 				if req.TimingJSON {
-					pendingTiming = timingReport{
+					pendingTiming = core.TimingReport{
 						Provider:      providerName,
 						LeaseID:       leaseID,
 						Slug:          slug,
@@ -228,7 +228,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 			}
 
 			if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
-				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+				core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 			}
 			commandStart := core.ClockNow(b.rt.Clock)
 			req.Observation.Phase(core.RunPhaseCommand)
@@ -244,7 +244,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 					outcome.ExitCode = 124
 				}
 			}
-			result := RunResult{
+			result := core.RunResult{
 				ExitCode:      outcome.ExitCode,
 				Status:        outcome.Status,
 				ErrorKind:     outcome.ErrorKind,
@@ -258,7 +258,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 				Session:       session,
 			}
 			if req.TimingJSON {
-				pendingTiming = timingReport{
+				pendingTiming = core.TimingReport{
 					Provider:      providerName,
 					LeaseID:       leaseID,
 					Slug:          slug,
@@ -273,12 +273,12 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 				}
 			}
 			if runErr != nil {
-				handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+				core.HandleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 				return result, shared.ExitErrorWithCause(result.ExitCode, fmt.Sprintf("cloud-run-sandbox run failed: %v", runErr), runErr)
 			}
 			if exitCode != 0 {
-				handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-				return result, ExitError{Code: exitCode, Message: fmt.Sprintf("cloud-run-sandbox run exited %d", exitCode)}
+				core.HandleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+				return result, core.ExitError{Code: exitCode, Message: fmt.Sprintf("cloud-run-sandbox run exited %d", exitCode)}
 			}
 			return result, nil
 		}()
@@ -289,7 +289,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 		claim = clearedClaim
 	}
 	if guardErr != nil {
-		guardedResult, guardedErr = shared.PinDelegatedRunFailure(RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Session: session}, guardErr)
+		guardedResult, guardedErr = shared.PinDelegatedRunFailure(core.RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Session: session}, guardErr)
 	}
 	if clearErr != nil {
 		guardedResult, guardedErr = shared.PinDelegatedRunFailure(guardedResult, guardedErr)
@@ -298,28 +298,28 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 	return guardedResult, guardedErr
 }
 
-func appendRunFailure(result RunResult, primary, secondary error) (RunResult, error) {
+func appendRunFailure(result core.RunResult, primary, secondary error) (core.RunResult, error) {
 	if secondary == nil || primary != nil {
 		return shared.AppendDelegatedRunFailure(result, primary, secondary, 1)
 	}
 	// Cloud Run already exposed typed claim/cleanup errors as public exit codes.
 	// Select that first failure without discarding measured command/session data.
-	outcome, err := shared.PinDelegatedRunFailure(RunResult{}, secondary)
+	outcome, err := shared.PinDelegatedRunFailure(core.RunResult{}, secondary)
 	result.ExitCode, result.Status, result.ErrorKind = outcome.ExitCode, outcome.Status, outcome.ErrorKind
 	return result, err
 }
 
-func cleanupCommand(cfg Config, leaseID string) string {
+func cleanupCommand(cfg core.Config, leaseID string) string {
 	command := "crabbox stop --provider " + providerName
 	if gatewayURL := strings.TrimSpace(cfg.CloudRunSandbox.GatewayURL); gatewayURL != "" {
-		command += " --cloud-run-sandbox-gateway-url " + shellQuote(gatewayURL)
+		command += " --cloud-run-sandbox-gateway-url " + core.ShellQuote(gatewayURL)
 	} else if cliPath := strings.TrimSpace(cfg.CloudRunSandbox.CLIPath); cliPath != "" && cliPath != core.CloudRunSandboxConfigDefaultCLIPath {
-		command += " --cloud-run-sandbox-cli " + shellQuote(cliPath)
+		command += " --cloud-run-sandbox-cli " + core.ShellQuote(cliPath)
 	}
-	return command + " --id " + shellQuote(leaseID)
+	return command + " --id " + core.ShellQuote(leaseID)
 }
 
-func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
 	scope, err := b.claimScope()
 	if err != nil {
 		return nil, err
@@ -328,7 +328,7 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 	if err != nil {
 		return nil, err
 	}
-	servers := make([]Server, 0, len(claims))
+	servers := make([]core.Server, 0, len(claims))
 	var transport sandboxTransport
 	for _, claim := range claims {
 		if claim.Provider != providerName || !strings.HasPrefix(claim.LeaseID, leasePrefix) {
@@ -357,7 +357,7 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 				state = "unknown"
 			}
 		}
-		servers = append(servers, Server{
+		servers = append(servers, core.Server{
 			Provider: providerName,
 			CloudID:  sandboxID,
 			Name:     sandboxID,
@@ -375,12 +375,12 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 	return servers, nil
 }
 
-func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	transport, err := newTransport(b.cfg, b.rt)
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	result := DoctorResult{Provider: providerName}
+	result := core.DoctorResult{Provider: providerName}
 	healthErr := transport.Health(ctx)
 	details := map[string]string{
 		"mode":    transport.Mode(),
@@ -391,11 +391,11 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 		details["gateway"] = strings.TrimSpace(b.cfg.CloudRunSandbox.GatewayURL)
 	}
 	result.Checks = append(result.Checks, doctorCheck("control_plane", healthErr, details))
-	servers, listErr := b.List(ctx, ListRequest{})
+	servers, listErr := b.List(ctx, core.ListRequest{})
 	if listErr != nil {
 		result.Checks = append(result.Checks, doctorCheck("local_claims", listErr, nil))
 	} else {
-		result.Checks = append(result.Checks, DoctorCheck{
+		result.Checks = append(result.Checks, core.DoctorCheck{
 			Status:  "ok",
 			Check:   "local_claims",
 			Message: fmt.Sprintf("%d claimed sandboxes", len(servers)),
@@ -417,16 +417,16 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	return result, nil
 }
 
-func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	leaseID, sandboxID, slug, claim, err := b.resolveLeaseID(req.ID, "", false)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	state, ready := b.claimStatus(claim)
 	if ready {
 		transport, transportErr := newTransport(b.cfg, b.rt)
 		if transportErr != nil {
-			return StatusView{}, transportErr
+			return core.StatusView{}, transportErr
 		}
 		ownershipToken := strings.TrimSpace(claim.Labels[claimOwnershipLabel])
 		if probeErr := transport.Probe(ctx, sandboxID, ownershipToken); probeErr != nil {
@@ -434,11 +434,11 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 				state = "missing"
 				ready = false
 			} else {
-				return StatusView{}, fmt.Errorf("probe cloud-run-sandbox %q: %w", sandboxID, probeErr)
+				return core.StatusView{}, fmt.Errorf("probe cloud-run-sandbox %q: %w", sandboxID, probeErr)
 			}
 		}
 	}
-	return StatusView{
+	return core.StatusView{
 		ID:       leaseID,
 		Slug:     slug,
 		Provider: providerName,
@@ -457,7 +457,7 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 	}, nil
 }
 
-func (b *backend) claimStatus(claim LeaseClaim) (string, bool) {
+func (b *backend) claimStatus(claim core.LeaseClaim) (string, bool) {
 	state := statusViewReady
 	ready := true
 	claimState := strings.TrimSpace(claim.Labels[claimStateLabel])
@@ -474,7 +474,7 @@ func (b *backend) claimStatus(claim LeaseClaim) (string, bool) {
 	return state, ready
 }
 
-func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+func (b *backend) Stop(ctx context.Context, req core.StopRequest) error {
 	transport, err := newTransport(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -484,7 +484,7 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 		return err
 	}
 	if state := strings.TrimSpace(claim.Labels[claimStateLabel]); state == "conflict" {
-		return exit(4, "cloud-run-sandbox lease %q has no destructive ownership (state=%s)", leaseID, state)
+		return core.Exit(4, "cloud-run-sandbox lease %q has no destructive ownership (state=%s)", leaseID, state)
 	}
 	if err := b.releaseClaimedSandboxIfUnchanged(ctx, transport, sandboxID, claim); err != nil {
 		return err
@@ -493,7 +493,7 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 	return nil
 }
 
-func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
+func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	scope, err := b.claimScope()
 	if err != nil {
 		return err
@@ -527,7 +527,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			continue
 		}
 		if req.DryRun {
-			if err := verifyLeaseClaimUnchanged(claim.LeaseID, claim); err != nil {
+			if err := core.VerifyLeaseClaimUnchanged(claim.LeaseID, claim); err != nil {
 				changed, inspectErr := claimChangedSinceSnapshot(claim)
 				if inspectErr != nil {
 					return fmt.Errorf("inspect cloud-run-sandbox claim after cleanup guard failed: %v: %w", err, inspectErr)
@@ -565,10 +565,10 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	return errors.Join(cleanupErrs...)
 }
 
-func (b *backend) destroyClaimedSandboxIfUnchanged(ctx context.Context, transport sandboxTransport, sandboxID string, claim LeaseClaim) (bool, error) {
+func (b *backend) destroyClaimedSandboxIfUnchanged(ctx context.Context, transport sandboxTransport, sandboxID string, claim core.LeaseClaim) (bool, error) {
 	ownershipToken := strings.TrimSpace(claim.Labels[claimOwnershipLabel])
 	if ownershipToken == "" {
-		return false, exit(4, "cloud-run-sandbox lease %q has no ownership token", claim.LeaseID)
+		return false, core.Exit(4, "cloud-run-sandbox lease %q has no ownership token", claim.LeaseID)
 	}
 	cleanupStarted := false
 	var destroyErr error
@@ -583,7 +583,7 @@ func (b *backend) destroyClaimedSandboxIfUnchanged(ctx context.Context, transpor
 	// Hold the claim lock across the final comparison and remote destroy. This
 	// closes the compare/destroy race while removing the claim only after a
 	// confirmed destroy (or confirmed absence), so failed cleanup stays tracked.
-	if err := removeLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, cleanupSandbox); err != nil {
+	if err := core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, cleanupSandbox); err != nil {
 		if destroyErr != nil {
 			fmt.Fprintf(b.rt.Stderr, "warning: destroy sandbox=%s failed; claim retained: %v\n", sandboxID, err)
 			return false, destroyErr
@@ -606,12 +606,12 @@ func (b *backend) destroyClaimedSandboxIfUnchanged(ctx context.Context, transpor
 	return true, nil
 }
 
-func (b *backend) releaseClaimedSandboxIfUnchanged(ctx context.Context, transport sandboxTransport, sandboxID string, claim LeaseClaim) error {
+func (b *backend) releaseClaimedSandboxIfUnchanged(ctx context.Context, transport sandboxTransport, sandboxID string, claim core.LeaseClaim) error {
 	ownershipToken := strings.TrimSpace(claim.Labels[claimOwnershipLabel])
 	if ownershipToken == "" {
-		return exit(4, "cloud-run-sandbox lease %q has no ownership token", claim.LeaseID)
+		return core.Exit(4, "cloud-run-sandbox lease %q has no ownership token", claim.LeaseID)
 	}
-	return removeLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+	return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
 		err := transport.Destroy(ctx, sandboxID, ownershipToken)
 		if errors.Is(err, errSandboxNotFound) {
 			return nil
@@ -620,7 +620,7 @@ func (b *backend) releaseClaimedSandboxIfUnchanged(ctx context.Context, transpor
 	})
 }
 
-func (b *backend) markClaimActivity(claim LeaseClaim, state string, timeout time.Duration) (LeaseClaim, error) {
+func (b *backend) markClaimActivity(claim core.LeaseClaim, state string, timeout time.Duration) (core.LeaseClaim, error) {
 	labels := cloneLabels(claim.Labels)
 	labels[claimStateLabel] = state
 	activeUntil := core.ClockNow(b.rt.Clock).UTC().Add(timeout)
@@ -628,14 +628,14 @@ func (b *backend) markClaimActivity(claim LeaseClaim, state string, timeout time
 		activeUntil = expires
 	}
 	labels[claimActiveUntilLabel] = activeUntil.Format(time.RFC3339Nano)
-	return updateLeaseClaimLabelsIfUnchanged(claim.LeaseID, claim, labels)
+	return core.UpdateLeaseClaimLabelsIfUnchanged(claim.LeaseID, claim, labels)
 }
 
-func (b *backend) clearClaimActivity(claim LeaseClaim) (LeaseClaim, error) {
+func (b *backend) clearClaimActivity(claim core.LeaseClaim) (core.LeaseClaim, error) {
 	labels := cloneLabels(claim.Labels)
 	delete(labels, claimStateLabel)
 	delete(labels, claimActiveUntilLabel)
-	return updateLeaseClaimLabelsAndLastUsedIfUnchanged(claim.LeaseID, claim, labels, core.ClockNow(b.rt.Clock).UTC())
+	return core.UpdateLeaseClaimLabelsAndLastUsedIfUnchanged(claim.LeaseID, claim, labels, core.ClockNow(b.rt.Clock).UTC())
 }
 
 func cloneLabels(labels map[string]string) map[string]string {
@@ -646,7 +646,7 @@ func cloneLabels(labels map[string]string) map[string]string {
 	return cloned
 }
 
-func claimOperationTimeout(claim LeaseClaim, maximum time.Duration, now time.Time) (time.Duration, error) {
+func claimOperationTimeout(claim core.LeaseClaim, maximum time.Duration, now time.Time) (time.Duration, error) {
 	expiresAt := strings.TrimSpace(claim.Labels[claimExpiresAtLabel])
 	if expiresAt == "" {
 		return maximum, nil
@@ -657,7 +657,7 @@ func claimOperationTimeout(claim LeaseClaim, maximum time.Duration, now time.Tim
 	}
 	remaining := expires.Sub(now)
 	if remaining <= 0 {
-		return 0, exit(4, "cloud-run-sandbox lease %q has expired", claim.LeaseID)
+		return 0, core.Exit(4, "cloud-run-sandbox lease %q has expired", claim.LeaseID)
 	}
 	if remaining < maximum {
 		return remaining, nil
@@ -665,15 +665,15 @@ func claimOperationTimeout(claim LeaseClaim, maximum time.Duration, now time.Tim
 	return maximum, nil
 }
 
-func claimChangedSinceSnapshot(expected LeaseClaim) (bool, error) {
-	current, exists, err := readLeaseClaimWithPresence(expected.LeaseID)
+func claimChangedSinceSnapshot(expected core.LeaseClaim) (bool, error) {
+	current, exists, err := core.ReadLeaseClaimWithPresence(expected.LeaseID)
 	if err != nil {
 		return false, err
 	}
 	return !exists || !reflect.DeepEqual(current, expected), nil
 }
 
-func claimCleanupDue(claim LeaseClaim, now time.Time) (bool, string) {
+func claimCleanupDue(claim core.LeaseClaim, now time.Time) (bool, string) {
 	state := strings.TrimSpace(claim.Labels[claimStateLabel])
 	if state == "conflict" {
 		return false, "ownership-" + state
@@ -725,19 +725,19 @@ func claimCleanupDue(claim LeaseClaim, now time.Time) (bool, string) {
 	return true, "idle-timeout-expired"
 }
 
-func (b *backend) createSandbox(ctx context.Context, transport sandboxTransport, repo Repo, reclaim bool, requestedSlug string) (string, string, string, LeaseClaim, error) {
+func (b *backend) createSandbox(ctx context.Context, transport sandboxTransport, repo core.Repo, reclaim bool, requestedSlug string) (string, string, string, core.LeaseClaim, error) {
 	sandboxID, err := newSandboxName(repo)
 	if err != nil {
-		return "", "", "", LeaseClaim{}, err
+		return "", "", "", core.LeaseClaim{}, err
 	}
 	leaseID := leasePrefix + sandboxID
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
-		return "", "", "", LeaseClaim{}, err
+		return "", "", "", core.LeaseClaim{}, err
 	}
 	scope, err := b.claimScope()
 	if err != nil {
-		return "", "", "", LeaseClaim{}, err
+		return "", "", "", core.LeaseClaim{}, err
 	}
 	labels := map[string]string{}
 	labels[claimStateLabel] = "creating"
@@ -752,23 +752,23 @@ func (b *backend) createSandbox(ctx context.Context, transport sandboxTransport,
 		}
 	}
 	labels[claimActiveUntilLabel] = activeUntil.Format(time.RFC3339Nano)
-	claim, err := claimLeaseForRepoProviderScopePondWithLabels(leaseID, slug, providerName, scope, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, labels)
+	claim, err := core.ClaimLeaseForRepoProviderScopePondWithLabels(leaseID, slug, providerName, scope, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, labels)
 	if err != nil {
-		return "", "", "", LeaseClaim{}, err
+		return "", "", "", core.LeaseClaim{}, err
 	}
 	claimed := true
 	defer func() {
 		if claimed {
-			_ = removeLeaseClaimIfUnchangedAfter(leaseID, claim, nil)
+			_ = core.RemoveLeaseClaimIfUnchangedAfter(leaseID, claim, nil)
 		}
 	}()
 	workdir, err := cloudRunSandboxWorkdir(b.cfg)
 	if err != nil {
-		return "", "", "", LeaseClaim{}, err
+		return "", "", "", core.LeaseClaim{}, err
 	}
 	createTimeout, err := claimOperationTimeout(claim, defaultExecTimeout, core.ClockNow(b.rt.Clock).UTC())
 	if err != nil {
-		return "", "", "", LeaseClaim{}, err
+		return "", "", "", core.LeaseClaim{}, err
 	}
 	createCtx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
@@ -781,7 +781,7 @@ func (b *backend) createSandbox(ctx context.Context, transport sandboxTransport,
 	readyLabels := cloneLabels(claim.Labels)
 	delete(readyLabels, claimStateLabel)
 	delete(readyLabels, claimActiveUntilLabel)
-	resolvedClaim, conflictClaimRemoved, actionSucceeded, createErr := resolveLeaseClaimAfterActionIfUnchanged(leaseID, claim, func() error {
+	resolvedClaim, conflictClaimRemoved, actionSucceeded, createErr := core.ResolveLeaseClaimAfterActionIfUnchanged(leaseID, claim, func() error {
 		return transport.Create(createCtx, sandboxID, runOptions{
 			AllowEgress:    b.cfg.CloudRunSandbox.AllowEgress,
 			Write:          b.cfg.CloudRunSandbox.Write,
@@ -808,13 +808,13 @@ func (b *backend) createSandbox(ctx context.Context, transport sandboxTransport,
 		rollbackErr := b.releaseClaimedSandboxIfUnchanged(rollbackCtx, transport, sandboxID, rollbackClaim)
 		claimed = false
 		if rollbackErr == nil {
-			return "", "", "", LeaseClaim{}, fmt.Errorf("cloud-run-sandbox create succeeded but publishing ready ownership failed; sandbox rolled back lease=%s: %w", leaseID, createErr)
+			return "", "", "", core.LeaseClaim{}, fmt.Errorf("cloud-run-sandbox create succeeded but publishing ready ownership failed; sandbox rolled back lease=%s: %w", leaseID, createErr)
 		}
 		fallbackLabels := cloneLabels(rollbackClaim.Labels)
 		fallbackLabels[claimStateLabel] = "recovery"
 		delete(fallbackLabels, claimActiveUntilLabel)
-		_, recoveryErr := updateLeaseClaimLabelsIfUnchanged(leaseID, rollbackClaim, fallbackLabels)
-		return "", "", "", LeaseClaim{}, errors.Join(
+		_, recoveryErr := core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, rollbackClaim, fallbackLabels)
+		return "", "", "", core.LeaseClaim{}, errors.Join(
 			fmt.Errorf("cloud-run-sandbox create succeeded but publishing ready ownership failed; recovery claim retained lease=%s: %w", leaseID, createErr),
 			rollbackErr,
 			recoveryErr,
@@ -823,42 +823,42 @@ func (b *backend) createSandbox(ctx context.Context, transport sandboxTransport,
 	if createErr != nil {
 		if errors.Is(createErr, errSandboxAlreadyExists) {
 			if !conflictClaimRemoved {
-				return "", "", "", LeaseClaim{}, fmt.Errorf("cloud-run-sandbox create conflict quarantined but provisional claim removal failed lease=%s: %w", leaseID, createErr)
+				return "", "", "", core.LeaseClaim{}, fmt.Errorf("cloud-run-sandbox create conflict quarantined but provisional claim removal failed lease=%s: %w", leaseID, createErr)
 			}
 			claimed = false
-			return "", "", "", LeaseClaim{}, fmt.Errorf("cloud-run-sandbox create rejected without taking ownership lease=%s: %w", leaseID, createErr)
+			return "", "", "", core.LeaseClaim{}, fmt.Errorf("cloud-run-sandbox create rejected without taking ownership lease=%s: %w", leaseID, createErr)
 		}
 		claimed = false
 		// Creation is not transactional: a timeout or lost response can arrive
 		// after the deterministically named sandbox was created. Keep the exact,
 		// scoped claim so stop/cleanup can recover it instead of leaving untracked
 		// billable infrastructure.
-		return "", "", "", LeaseClaim{}, fmt.Errorf("cloud-run-sandbox create remains indeterminate; recovery claim retained lease=%s: %w", leaseID, createErr)
+		return "", "", "", core.LeaseClaim{}, fmt.Errorf("cloud-run-sandbox create remains indeterminate; recovery claim retained lease=%s: %w", leaseID, createErr)
 	}
 	claim = resolvedClaim
 	claimed = false
 	return leaseID, sandboxID, slug, claim, nil
 }
 
-func (b *backend) resolveLeaseID(id, repoRoot string, reclaim bool) (string, string, string, LeaseClaim, error) {
+func (b *backend) resolveLeaseID(id, repoRoot string, reclaim bool) (string, string, string, core.LeaseClaim, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return "", "", "", LeaseClaim{}, exit(2, "missing lease id")
+		return "", "", "", core.LeaseClaim{}, core.Exit(2, "missing lease id")
 	}
 	scope, err := b.claimScope()
 	if err != nil {
-		return "", "", "", LeaseClaim{}, err
+		return "", "", "", core.LeaseClaim{}, err
 	}
-	if claim, ok, err := resolveLeaseClaim(id); err != nil {
-		return "", "", "", LeaseClaim{}, err
+	if claim, ok, err := core.ResolveLeaseClaim(id); err != nil {
+		return "", "", "", core.LeaseClaim{}, err
 	} else if ok && claim.Provider == providerName {
 		if claim.ProviderScope != scope {
-			return "", "", "", LeaseClaim{}, exit(4, "cloud-run-sandbox lease %q belongs to a different gateway/cli scope", id)
+			return "", "", "", core.LeaseClaim{}, core.Exit(4, "cloud-run-sandbox lease %q belongs to a different gateway/cli scope", id)
 		}
 		if repoRoot != "" {
 			claim, err = claimLeaseForRepoProviderScopePondIfUnchanged(claim.LeaseID, claim.Slug, providerName, scope, claim.Pond, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim, claim)
 			if err != nil {
-				return "", "", "", LeaseClaim{}, err
+				return "", "", "", core.LeaseClaim{}, err
 			}
 		}
 		return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, leasePrefix), claim.Slug, claim, nil
@@ -868,20 +868,20 @@ func (b *backend) resolveLeaseID(id, repoRoot string, reclaim bool) (string, str
 	if !strings.HasPrefix(leaseID, leasePrefix) {
 		leaseID = leasePrefix + id
 	}
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
-		return "", "", "", LeaseClaim{}, exit(4, "cloud-run-sandbox sandbox %q is not claimed by Crabbox", id)
+		return "", "", "", core.LeaseClaim{}, core.Exit(4, "cloud-run-sandbox sandbox %q is not claimed by Crabbox", id)
 	}
 	if claim.Provider != providerName {
-		return "", "", "", LeaseClaim{}, exit(4, "cloud-run-sandbox sandbox %q is not claimed by Crabbox", id)
+		return "", "", "", core.LeaseClaim{}, core.Exit(4, "cloud-run-sandbox sandbox %q is not claimed by Crabbox", id)
 	}
 	if claim.ProviderScope != scope {
-		return "", "", "", LeaseClaim{}, exit(4, "cloud-run-sandbox lease %q belongs to a different gateway/cli scope", id)
+		return "", "", "", core.LeaseClaim{}, core.Exit(4, "cloud-run-sandbox lease %q belongs to a different gateway/cli scope", id)
 	}
 	if repoRoot != "" {
 		claim, err = claimLeaseForRepoProviderScopePondIfUnchanged(claim.LeaseID, claim.Slug, providerName, scope, claim.Pond, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim, claim)
 		if err != nil {
-			return "", "", "", LeaseClaim{}, err
+			return "", "", "", core.LeaseClaim{}, err
 		}
 	}
 	return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, leasePrefix), claim.Slug, claim, nil
@@ -905,15 +905,15 @@ func (b *backend) cleanupContext(parent context.Context) (context.Context, conte
 	return context.WithTimeout(context.WithoutCancel(parent), cleanupTimeout)
 }
 
-func cloudRunSandboxWorkdir(cfg Config) (string, error) {
+func cloudRunSandboxWorkdir(cfg core.Config) (string, error) {
 	workdir := core.Blank(strings.TrimSpace(cfg.CloudRunSandbox.Workdir), core.CloudRunSandboxConfigDefaultWorkdir)
 	if !path.IsAbs(workdir) {
-		return "", exit(2, "cloudRunSandbox.workdir must be an absolute path")
+		return "", core.Exit(2, "cloudRunSandbox.workdir must be an absolute path")
 	}
 	return workdir, nil
 }
 
-func newSandboxName(repo Repo) (string, error) {
+func newSandboxName(repo core.Repo) (string, error) {
 	base := namePrefix
 	if name := sanitizeName(path.Base(repo.Root)); name != "" {
 		base = namePrefix + name + "-"
@@ -951,9 +951,9 @@ func randomSuffix() (string, error) {
 	return hex.EncodeToString(buf[:]), nil
 }
 
-func doctorCheck(name string, err error, details map[string]string) DoctorCheck {
+func doctorCheck(name string, err error, details map[string]string) core.DoctorCheck {
 	if err != nil {
-		return DoctorCheck{Status: "error", Check: name, Message: err.Error(), Details: details}
+		return core.DoctorCheck{Status: "error", Check: name, Message: err.Error(), Details: details}
 	}
-	return DoctorCheck{Status: "ok", Check: name, Message: "ready", Details: details}
+	return core.DoctorCheck{Status: "ok", Check: name, Message: "ready", Details: details}
 }

--- a/internal/providers/cloudrunsandbox/backend_test.go
+++ b/internal/providers/cloudrunsandbox/backend_test.go
@@ -51,15 +51,15 @@ func TestCloudRunEffectiveDefaultConsumersRecorded(t *testing.T) {
 		{"custom", " /opt/example-sandbox ", " /tmp/example ", "/opt/example-sandbox", "/tmp/example"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := Config{CloudRunSandbox: CloudRunSandboxConfig{CLIPath: tc.cli, Workdir: tc.workdir}}
+			cfg := core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: tc.cli, Workdir: tc.workdir}}
 			before := cfg.CloudRunSandbox
-			var calls []LocalCommandRequest
-			rt := Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: recordingLocalExec{handler: func(req LocalCommandRequest) (LocalCommandResult, error) {
+			var calls []core.LocalCommandRequest
+			rt := core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: recordingLocalExec{handler: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				calls = append(calls, req)
-				return LocalCommandResult{}, nil
+				return core.LocalCommandResult{}, nil
 			}}}
 			b := NewBackend(Provider{}.Spec(), cfg, rt).(*backend)
-			doctor, err := b.Doctor(context.Background(), DoctorRequest{})
+			doctor, err := b.Doctor(context.Background(), core.DoctorRequest{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -97,7 +97,7 @@ func TestCloudRunEffectiveDefaultConsumersRecorded(t *testing.T) {
 			}
 		})
 	}
-	cfg := Config{CloudRunSandbox: CloudRunSandboxConfig{GatewayURL: " https://example.invalid/gateway ", CLIPath: "/opt/custom"}}
+	cfg := core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{GatewayURL: " https://example.invalid/gateway ", CLIPath: "/opt/custom"}}
 	if got := cleanupCommand(cfg, "example"); got != "crabbox stop --provider cloud-run-sandbox --cloud-run-sandbox-gateway-url 'https://example.invalid/gateway' --id 'example'" {
 		t.Fatalf("gateway cleanup precedence=%q", got)
 	}
@@ -153,8 +153,8 @@ func TestCloudRunSandboxTerminalOutcome(t *testing.T) {
 				}
 				clock.now = clock.now.Add(time.Second)
 				if tc.native {
-					native := &directTransport{rt: Runtime{Exec: recordingLocalExec{handler: func(LocalCommandRequest) (LocalCommandResult, error) {
-						return LocalCommandResult{ExitCode: 23}, plain
+					native := &directTransport{rt: core.Runtime{Exec: recordingLocalExec{handler: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+						return core.LocalCommandResult{ExitCode: 23}, plain
 					}}}}
 					code, err := native.Exec(t.Context(), "fixture", command, execOptions{}, io.Discard, io.Discard)
 					return code, "", "", err
@@ -172,11 +172,11 @@ func TestCloudRunSandboxTerminalOutcome(t *testing.T) {
 				return nil
 			}}
 			previous := newTransport
-			newTransport = func(Config, Runtime) (sandboxTransport, error) { return transport, nil }
+			newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) { return transport, nil }
 			t.Cleanup(func() { newTransport = previous })
-			b := NewBackend(Provider{}.Spec(), Config{CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"}, IdleTimeout: time.Minute}, Runtime{Stdout: io.Discard, Stderr: writer, Clock: clock}).(*backend)
-			repo := Repo{Root: t.TempDir()}
-			req := RunRequest{Repo: repo, Command: []string{"fixture-command"}, NoSync: true, TimingJSON: true, KeepOnFailure: tc.keepFailure}
+			b := NewBackend(Provider{}.Spec(), core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"}, IdleTimeout: time.Minute}, core.Runtime{Stdout: io.Discard, Stderr: writer, Clock: clock}).(*backend)
+			repo := core.Repo{Root: t.TempDir()}
+			req := core.RunRequest{Repo: repo, Command: []string{"fixture-command"}, NoSync: true, TimingJSON: true, KeepOnFailure: tc.keepFailure}
 			if tc.reuse {
 				id, _, _, _, err := b.createSandbox(t.Context(), transport, repo, false, "fixture")
 				if err != nil {
@@ -192,7 +192,7 @@ func TestCloudRunSandboxTerminalOutcome(t *testing.T) {
 					wantStatus = core.RunStatusFailed
 				}
 			}
-			var public ExitError
+			var public core.ExitError
 			hasPublic := errors.As(err, &public)
 			if result.ExitCode != tc.want || result.Status != wantStatus || result.ErrorKind != tc.kind || tc.want != 0 && (!hasPublic || public.Code != tc.want) || tc.want == 0 && err != nil {
 				t.Errorf("outcome result=%+v publicCode=%d err=%v", result, public.Code, err)
@@ -217,7 +217,7 @@ func TestCloudRunSandboxTerminalOutcome(t *testing.T) {
 			if deletes != boolInt(wantDelete) || result.Session == nil || result.Session.Kept != wantKept || result.Session.Reused != tc.reuse {
 				t.Errorf("deletes=%d session=%+v", deletes, result.Session)
 			}
-			_, exists, claimErr := readLeaseClaimWithPresence(result.LeaseID)
+			_, exists, claimErr := core.ReadLeaseClaimWithPresence(result.LeaseID)
 			if claimErr != nil || exists != wantKept {
 				t.Errorf("claim exists=%v err=%v", exists, claimErr)
 			}
@@ -233,7 +233,7 @@ func TestCloudRunSandboxTerminalOutcome(t *testing.T) {
 			}
 			if !tc.writer {
 				lines := strings.Split(strings.TrimSpace(writer.String()), "\n")
-				var report timingReport
+				var report core.TimingReport
 				if err := json.Unmarshal([]byte(lines[len(lines)-1]), &report); err != nil {
 					t.Fatal(err)
 				}
@@ -279,12 +279,12 @@ func TestCloudRunSandboxClaimReadFailurePreservesPublicCode(t *testing.T) {
 					return code, "", "", nil
 				}, onDestroy: func(string) error { deletes++; return nil }}
 				previous := newTransport
-				newTransport = func(Config, Runtime) (sandboxTransport, error) { return transport, nil }
+				newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) { return transport, nil }
 				t.Cleanup(func() { newTransport = previous })
-				b := NewBackend(Provider{}.Spec(), Config{CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"}, IdleTimeout: time.Minute}, Runtime{Stdout: io.Discard, Stderr: io.Discard, Clock: clock}).(*backend)
-				result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir()}, Command: []string{"fixture-command"}, NoSync: true, Keep: keep})
-				_, _, readErr := readLeaseClaimWithPresence(result.LeaseID)
-				var readPublic, public ExitError
+				b := NewBackend(Provider{}.Spec(), core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"}, IdleTimeout: time.Minute}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Clock: clock}).(*backend)
+				result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, Command: []string{"fixture-command"}, NoSync: true, Keep: keep})
+				_, _, readErr := core.ReadLeaseClaimWithPresence(result.LeaseID)
+				var readPublic, public core.ExitError
 				if !errors.As(readErr, &readPublic) || readPublic.Code != 2 {
 					t.Fatalf("real claim read code=%d err=%v", readPublic.Code, readErr)
 				}
@@ -345,11 +345,11 @@ func TestCloudRunSandboxClaimRemovalFailurePreservesPublicCode(t *testing.T) {
 				return nil
 			}}
 			previous := newTransport
-			newTransport = func(Config, Runtime) (sandboxTransport, error) { return transport, nil }
+			newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) { return transport, nil }
 			t.Cleanup(func() { newTransport = previous })
-			b := NewBackend(Provider{}.Spec(), Config{CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"}, IdleTimeout: time.Minute}, Runtime{Stdout: io.Discard, Stderr: io.Discard, Clock: clock}).(*backend)
-			result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir()}, Command: []string{"fixture-command"}, NoSync: true})
-			var public ExitError
+			b := NewBackend(Provider{}.Spec(), core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"}, IdleTimeout: time.Minute}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Clock: clock}).(*backend)
+			result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, Command: []string{"fixture-command"}, NoSync: true})
+			var public core.ExitError
 			hasPublic := errors.As(err, &public)
 			want := code
 			if want == 0 {
@@ -383,19 +383,19 @@ func TestCloudRunSandboxCreateTimeoutRetainsRecoveryClaim(t *testing.T) {
 			return createErr
 		},
 	}
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
 		IdleTimeout:     time.Minute,
-	}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
-	_, _, _, _, err := b.createSandbox(context.Background(), transport, Repo{Root: t.TempDir()}, false, "timeout-recovery")
+	_, _, _, _, err := b.createSandbox(context.Background(), transport, core.Repo{Root: t.TempDir()}, false, "timeout-recovery")
 	if !errors.Is(err, createErr) || !strings.Contains(err.Error(), "recovery claim retained") {
 		t.Fatalf("create error=%v, want indeterminate recovery", err)
 	}
 	if sandboxID == "" {
 		t.Fatal("create did not receive a sandbox id")
 	}
-	claim, readErr := readLeaseClaim(leasePrefix + sandboxID)
+	claim, readErr := core.ReadLeaseClaim(leasePrefix + sandboxID)
 	if readErr != nil {
 		t.Fatalf("read recovery claim: %v", readErr)
 	}
@@ -405,18 +405,18 @@ func TestCloudRunSandboxCreateTimeoutRetainsRecoveryClaim(t *testing.T) {
 	if claim.Labels[claimStateLabel] != "recovery" {
 		t.Fatalf("recovery state=%q", claim.Labels[claimStateLabel])
 	}
-	status, statusErr := b.Status(context.Background(), StatusRequest{ID: claim.LeaseID})
+	status, statusErr := b.Status(context.Background(), core.StatusRequest{ID: claim.LeaseID})
 	if statusErr != nil || status.Ready || status.State != "recovery" {
 		t.Fatalf("recovery status=%#v err=%v", status, statusErr)
 	}
-	leases, listErr := b.List(context.Background(), ListRequest{})
+	leases, listErr := b.List(context.Background(), core.ListRequest{})
 	if listErr != nil || len(leases) != 1 || leases[0].Status != "recovery" {
 		t.Fatalf("recovery list=%#v err=%v", leases, listErr)
 	}
 	previousTransport := newTransport
-	newTransport = func(Config, Runtime) (sandboxTransport, error) { return transport, nil }
+	newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) { return transport, nil }
 	t.Cleanup(func() { newTransport = previousTransport })
-	if _, runErr := b.Run(context.Background(), RunRequest{ID: claim.LeaseID, Repo: Repo{Root: claim.RepoRoot}, Command: []string{"true"}, NoSync: true}); runErr == nil || !strings.Contains(runErr.Error(), "not ready") {
+	if _, runErr := b.Run(context.Background(), core.RunRequest{ID: claim.LeaseID, Repo: core.Repo{Root: claim.RepoRoot}, Command: []string{"true"}, NoSync: true}); runErr == nil || !strings.Contains(runErr.Error(), "not ready") {
 		t.Fatalf("recovery run error=%v", runErr)
 	}
 }
@@ -427,12 +427,12 @@ func TestCloudRunSandboxStatusProbesProviderLiveness(t *testing.T) {
 		return errSandboxNotFound
 	}}
 	previousTransport := newTransport
-	newTransport = func(Config, Runtime) (sandboxTransport, error) { return transport, nil }
+	newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) { return transport, nil }
 	t.Cleanup(func() { newTransport = previousTransport })
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
 		IdleTimeout:     time.Minute,
-	}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 	scope, err := b.claimScope()
 	if err != nil {
 		t.Fatal(err)
@@ -441,11 +441,11 @@ func TestCloudRunSandboxStatusProbesProviderLiveness(t *testing.T) {
 	if err := claimTestCloudRunSandboxLease(leaseID, "missing", scope, t.TempDir(), time.Minute); err != nil {
 		t.Fatal(err)
 	}
-	status, err := b.Status(context.Background(), StatusRequest{ID: leaseID})
+	status, err := b.Status(context.Background(), core.StatusRequest{ID: leaseID})
 	if err != nil || status.Ready || status.State != "missing" {
 		t.Fatalf("status=%#v err=%v", status, err)
 	}
-	leases, err := b.List(context.Background(), ListRequest{})
+	leases, err := b.List(context.Background(), core.ListRequest{})
 	if err != nil || len(leases) != 1 || leases[0].Status != "missing" {
 		t.Fatalf("leases=%#v err=%v", leases, err)
 	}
@@ -463,21 +463,21 @@ func TestCloudRunSandboxRunPreservesCancellation(t *testing.T) {
 		},
 	}
 	previousTransport := newTransport
-	newTransport = func(Config, Runtime) (sandboxTransport, error) { return transport, nil }
+	newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) { return transport, nil }
 	t.Cleanup(func() { newTransport = previousTransport })
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
 		IdleTimeout:     time.Minute,
-	}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
-	_, err := b.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: t.TempDir()},
+	}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	_, err := b.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: t.TempDir()},
 		Command: []string{"cancel-me"},
 		NoSync:  true,
 	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("run err=%v", err)
 	}
-	var exitErr ExitError
+	var exitErr core.ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 130 {
 		t.Fatalf("exit err=%#v err=%v", exitErr, err)
 	}
@@ -490,16 +490,16 @@ func TestCloudRunSandboxCreateConflictDropsProvisionalClaim(t *testing.T) {
 		sandboxID = id
 		return errSandboxAlreadyExists
 	}}
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
 		IdleTimeout:     time.Minute,
-	}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
-	_, _, _, _, err := b.createSandbox(context.Background(), transport, Repo{Root: t.TempDir()}, false, "conflict")
+	_, _, _, _, err := b.createSandbox(context.Background(), transport, core.Repo{Root: t.TempDir()}, false, "conflict")
 	if !errors.Is(err, errSandboxAlreadyExists) || !strings.Contains(err.Error(), "without taking ownership") {
 		t.Fatalf("create error=%v", err)
 	}
-	if _, exists, readErr := readLeaseClaimWithPresence(leasePrefix + sandboxID); readErr != nil || exists {
+	if _, exists, readErr := core.ReadLeaseClaimWithPresence(leasePrefix + sandboxID); readErr != nil || exists {
 		t.Fatal("definitive conflict retained a destructive ownership claim")
 	}
 }
@@ -522,20 +522,20 @@ func TestCloudRunSandboxCreateConflictRemovalPrecedesWaitingStop(t *testing.T) {
 		},
 	}
 	previousTransport := newTransport
-	newTransport = func(Config, Runtime) (sandboxTransport, error) { return transport, nil }
+	newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) { return transport, nil }
 	t.Cleanup(func() { newTransport = previousTransport })
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
 		IdleTimeout:     time.Minute,
-	}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 	createDone := make(chan error, 1)
 	go func() {
-		_, _, _, _, err := b.createSandbox(context.Background(), transport, Repo{Root: t.TempDir()}, false, "conflict-race")
+		_, _, _, _, err := b.createSandbox(context.Background(), transport, core.Repo{Root: t.TempDir()}, false, "conflict-race")
 		createDone <- err
 	}()
 	sandboxID := <-createStarted
 	stopDone := make(chan error, 1)
-	go func() { stopDone <- b.Stop(context.Background(), StopRequest{ID: leasePrefix + sandboxID}) }()
+	go func() { stopDone <- b.Stop(context.Background(), core.StopRequest{ID: leasePrefix + sandboxID}) }()
 	select {
 	case err := <-stopDone:
 		t.Fatalf("stop bypassed create claim lock: %v", err)
@@ -593,13 +593,13 @@ func TestCloudRunSandboxCleanupSkipsInFlightThenDeletesIdle(t *testing.T) {
 				},
 			}
 			previousTransport := newTransport
-			newTransport = func(Config, Runtime) (sandboxTransport, error) { return transport, nil }
+			newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) { return transport, nil }
 			t.Cleanup(func() { newTransport = previousTransport })
-			b := NewBackend(Provider{}.Spec(), Config{
-				CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+			b := NewBackend(Provider{}.Spec(), core.Config{
+				CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
 				IdleTimeout:     time.Second,
-			}, Runtime{Clock: cloudRunSandboxFixedClock{now: now}, Stdout: io.Discard, Stderr: io.Discard}).(*backend)
-			repo := Repo{Root: t.TempDir()}
+			}, core.Runtime{Clock: cloudRunSandboxFixedClock{now: now}, Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+			repo := core.Repo{Root: t.TempDir()}
 			action := func() error {
 				_, _, _, _, err := b.createSandbox(context.Background(), transport, repo, false, state)
 				return err
@@ -610,7 +610,7 @@ func TestCloudRunSandboxCleanupSkipsInFlightThenDeletesIdle(t *testing.T) {
 					t.Fatal(err)
 				}
 				action = func() error {
-					result, err := b.Run(context.Background(), RunRequest{
+					result, err := b.Run(context.Background(), core.RunRequest{
 						ID: leaseID, Repo: repo, Command: []string{"echo", "active"}, NoSync: true,
 					})
 					if err == nil && (result.Session == nil || !result.Session.Reused || !result.Session.Kept) {
@@ -659,7 +659,7 @@ func TestCloudRunSandboxCleanupSkipsInFlightThenDeletesIdle(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			var snapshot LeaseClaim
+			var snapshot core.LeaseClaim
 			if err := json.Unmarshal(before, &snapshot); err != nil {
 				t.Fatal(err)
 			}
@@ -683,7 +683,7 @@ func TestCloudRunSandboxCleanupSkipsInFlightThenDeletesIdle(t *testing.T) {
 			var cleanupErr error
 			go func() {
 				defer close(cleanupDone)
-				cleanupErr = cleanup.Cleanup(context.Background(), CleanupRequest{})
+				cleanupErr = cleanup.Cleanup(context.Background(), core.CleanupRequest{})
 			}()
 			if !wait(cleanupDone, "in-flight cleanup without releasing provider action") {
 				t.FailNow()
@@ -702,7 +702,7 @@ func TestCloudRunSandboxCleanupSkipsInFlightThenDeletesIdle(t *testing.T) {
 			if actionErr != nil {
 				t.Fatal(actionErr)
 			}
-			completed, err := readLeaseClaim(leaseID)
+			completed, err := core.ReadLeaseClaim(leaseID)
 			if err != nil || completed.Revision == snapshot.Revision || completed.Labels[claimStateLabel] != "" || completed.Labels[claimActiveUntilLabel] != "" {
 				t.Fatalf("completed claim=%#v err=%v", completed, err)
 			}
@@ -722,7 +722,7 @@ func TestCloudRunSandboxCleanupSkipsInFlightThenDeletesIdle(t *testing.T) {
 				cleanup.rt.Clock = cloudRunSandboxFixedClock{now: cleanupNow}
 				stdout.Reset()
 				stderr.Reset()
-				if err := cleanup.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+				if err := cleanup.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 					t.Fatal(err)
 				}
 				if !idleExpired {
@@ -735,7 +735,7 @@ func TestCloudRunSandboxCleanupSkipsInFlightThenDeletesIdle(t *testing.T) {
 			if !strings.Contains(stdout.String(), "delete sandbox="+sandboxID+" lease="+leaseID+" reason=idle-timeout-expired\n") {
 				t.Fatalf("expired cleanup stdout=%q", stdout.String())
 			}
-			if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
+			if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
 				t.Fatalf("deleted claim exists=%v err=%v", exists, err)
 			}
 			if owner != "" || len(destroys) != 1 || destroys[0] != [2]string{sandboxID, snapshot.Labels[claimOwnershipLabel]} {
@@ -749,16 +749,16 @@ func TestCloudRunSandboxCleanupReconcilesOnlyOwnedStaleCreate(t *testing.T) {
 	t.Run("owned", func(t *testing.T) {
 		isolateLeaseHome(t)
 		now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
-		b := NewBackend(Provider{}.Spec(), Config{
-			CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+		b := NewBackend(Provider{}.Spec(), core.Config{
+			CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
 			IdleTimeout:     time.Hour,
-		}, Runtime{Clock: cloudRunSandboxFixedClock{now: now}, Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+		}, core.Runtime{Clock: cloudRunSandboxFixedClock{now: now}, Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 		scope, err := b.claimScope()
 		if err != nil {
 			t.Fatal(err)
 		}
 		const sandboxID = "crabbox-stale-owned"
-		claim, err := claimLeaseForRepoProviderScopePondWithLabels(leasePrefix+sandboxID, "stale-owned", providerName, scope, "", t.TempDir(), time.Hour, map[string]string{
+		claim, err := core.ClaimLeaseForRepoProviderScopePondWithLabels(leasePrefix+sandboxID, "stale-owned", providerName, scope, "", t.TempDir(), time.Hour, map[string]string{
 			claimStateLabel:       "creating",
 			claimActiveUntilLabel: now.Add(-time.Minute).Format(time.RFC3339Nano),
 			claimOwnershipLabel:   sandboxID,
@@ -775,15 +775,15 @@ func TestCloudRunSandboxCleanupReconcilesOnlyOwnedStaleCreate(t *testing.T) {
 			return nil
 		}}
 		previousTransport := newTransport
-		newTransport = func(Config, Runtime) (sandboxTransport, error) { return transport, nil }
+		newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) { return transport, nil }
 		t.Cleanup(func() { newTransport = previousTransport })
-		if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 			t.Fatal(err)
 		}
 		if !destroyed {
 			t.Fatal("stale owned create was not destroyed")
 		}
-		if _, exists, err := readLeaseClaimWithPresence(claim.LeaseID); err != nil || exists {
+		if _, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID); err != nil || exists {
 			t.Fatalf("claim exists=%v err=%v", exists, err)
 		}
 	})
@@ -791,15 +791,15 @@ func TestCloudRunSandboxCleanupReconcilesOnlyOwnedStaleCreate(t *testing.T) {
 	t.Run("missing-token-fails-closed", func(t *testing.T) {
 		isolateLeaseHome(t)
 		now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
-		b := NewBackend(Provider{}.Spec(), Config{
-			CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+		b := NewBackend(Provider{}.Spec(), core.Config{
+			CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
 			IdleTimeout:     time.Hour,
-		}, Runtime{Clock: cloudRunSandboxFixedClock{now: now}, Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+		}, core.Runtime{Clock: cloudRunSandboxFixedClock{now: now}, Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 		scope, err := b.claimScope()
 		if err != nil {
 			t.Fatal(err)
 		}
-		claim, err := claimLeaseForRepoProviderScopePondWithLabels(leasePrefix+"crabbox-stale-unknown", "stale-unknown", providerName, scope, "", t.TempDir(), time.Hour, map[string]string{
+		claim, err := core.ClaimLeaseForRepoProviderScopePondWithLabels(leasePrefix+"crabbox-stale-unknown", "stale-unknown", providerName, scope, "", t.TempDir(), time.Hour, map[string]string{
 			claimStateLabel:       "creating",
 			claimActiveUntilLabel: now.Add(-time.Minute).Format(time.RFC3339Nano),
 		})
@@ -812,15 +812,15 @@ func TestCloudRunSandboxCleanupReconcilesOnlyOwnedStaleCreate(t *testing.T) {
 			return nil
 		}}
 		previousTransport := newTransport
-		newTransport = func(Config, Runtime) (sandboxTransport, error) { return transport, nil }
+		newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) { return transport, nil }
 		t.Cleanup(func() { newTransport = previousTransport })
-		if err := b.Cleanup(context.Background(), CleanupRequest{}); err == nil || !strings.Contains(err.Error(), "no ownership token") {
+		if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err == nil || !strings.Contains(err.Error(), "no ownership token") {
 			t.Fatalf("cleanup err=%v", err)
 		}
 		if destroyed {
 			t.Fatal("cleanup destroyed a sandbox without ownership proof")
 		}
-		if _, exists, err := readLeaseClaimWithPresence(claim.LeaseID); err != nil || !exists {
+		if _, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID); err != nil || !exists {
 			t.Fatalf("claim exists=%v err=%v", exists, err)
 		}
 	})
@@ -830,22 +830,22 @@ func TestCloudRunSandboxCleanupDryRunNeedsNoTransportCredentials(t *testing.T) {
 	isolateLeaseHome(t)
 	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
 	var stdout bytes.Buffer
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
 		IdleTimeout:     time.Hour,
-	}, Runtime{Clock: cloudRunSandboxFixedClock{now: now}, Stdout: &stdout, Stderr: io.Discard}).(*backend)
+	}, core.Runtime{Clock: cloudRunSandboxFixedClock{now: now}, Stdout: &stdout, Stderr: io.Discard}).(*backend)
 	scope, err := b.claimScope()
 	if err != nil {
 		t.Fatal(err)
 	}
 	const sandboxID = "crabbox-dry-run"
-	if _, err := claimLeaseForRepoProviderScopePondWithLabels(leasePrefix+sandboxID, "dry-run", providerName, scope, "", t.TempDir(), time.Hour, map[string]string{
+	if _, err := core.ClaimLeaseForRepoProviderScopePondWithLabels(leasePrefix+sandboxID, "dry-run", providerName, scope, "", t.TempDir(), time.Hour, map[string]string{
 		claimOwnershipLabel: sandboxID,
 		claimExpiresAtLabel: now.Add(-time.Minute).Format(time.RFC3339Nano),
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(stdout.String(), "would delete sandbox="+sandboxID) {
@@ -855,12 +855,12 @@ func TestCloudRunSandboxCleanupDryRunNeedsNoTransportCredentials(t *testing.T) {
 
 func TestCloudRunSandboxCreatePersistsTTL(t *testing.T) {
 	isolateLeaseHome(t)
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
 		IdleTimeout:     time.Hour,
 		TTL:             10 * time.Minute,
-	}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
-	_, _, _, claim, err := b.createSandbox(context.Background(), &fakeTransport{mode: "direct"}, Repo{Root: t.TempDir()}, false, "ttl")
+	}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	_, _, _, claim, err := b.createSandbox(context.Background(), &fakeTransport{mode: "direct"}, core.Repo{Root: t.TempDir()}, false, "ttl")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -879,15 +879,15 @@ func TestCloudRunSandboxCreatePersistsTTL(t *testing.T) {
 func TestRunMissingCommandHasNoSideEffects(t *testing.T) {
 	transportCalls := 0
 	previousTransport := newTransport
-	newTransport = func(Config, Runtime) (sandboxTransport, error) {
+	newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) {
 		transportCalls++
 		return &fakeTransport{mode: "direct"}, nil
 	}
 	t.Cleanup(func() { newTransport = previousTransport })
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
-	}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
-	_, err := b.Run(context.Background(), RunRequest{Repo: Repo{Root: t.TempDir()}})
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+	}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	_, err := b.Run(context.Background(), core.RunRequest{Repo: core.Repo{Root: t.TempDir()}})
 	if err == nil || !strings.Contains(err.Error(), "missing command") {
 		t.Fatalf("run error=%v", err)
 	}
@@ -900,10 +900,10 @@ func TestCloudRunSandboxCleanupSkipsClaimReclaimedAfterSnapshot(t *testing.T) {
 	isolateLeaseHome(t)
 	const sandboxID = "crabbox-reclaimed-123456"
 	leaseID := leasePrefix + sandboxID
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
 		IdleTimeout:     time.Minute,
-	}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 	scope, err := b.claimScope()
 	if err != nil {
 		t.Fatal(err)
@@ -911,12 +911,12 @@ func TestCloudRunSandboxCleanupSkipsClaimReclaimedAfterSnapshot(t *testing.T) {
 	if err := claimTestCloudRunSandboxLease(leaseID, "reclaimed", scope, t.TempDir(), time.Minute); err != nil {
 		t.Fatal(err)
 	}
-	snapshot, err := readLeaseClaim(leaseID)
+	snapshot, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	newRepo := t.TempDir()
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "reclaimed", providerName, scope, "", newRepo, time.Minute, true); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "reclaimed", providerName, scope, "", newRepo, time.Minute, true); err != nil {
 		t.Fatalf("reclaim: %v", err)
 	}
 	destroyed := false
@@ -935,7 +935,7 @@ func TestCloudRunSandboxCleanupSkipsClaimReclaimedAfterSnapshot(t *testing.T) {
 	if destroyed {
 		t.Fatal("cleanup destroyed a sandbox reclaimed after its snapshot")
 	}
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil || claim.RepoRoot != newRepo {
 		t.Fatalf("reclaimed claim not preserved: claim=%#v err=%v", claim, err)
 	}
@@ -945,10 +945,10 @@ func TestCloudRunSandboxCleanupDestroyFailureRetainsClaim(t *testing.T) {
 	isolateLeaseHome(t)
 	const sandboxID = "crabbox-destroy-failure-123456"
 	leaseID := leasePrefix + sandboxID
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
 		IdleTimeout:     time.Minute,
-	}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 	scope, err := b.claimScope()
 	if err != nil {
 		t.Fatal(err)
@@ -956,7 +956,7 @@ func TestCloudRunSandboxCleanupDestroyFailureRetainsClaim(t *testing.T) {
 	if err := claimTestCloudRunSandboxLease(leaseID, "destroy-failure", scope, t.TempDir(), time.Minute); err != nil {
 		t.Fatal(err)
 	}
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -970,7 +970,7 @@ func TestCloudRunSandboxCleanupDestroyFailureRetainsClaim(t *testing.T) {
 	if removed {
 		t.Fatal("cleanup reported a failed destroy removed")
 	}
-	retained, err := readLeaseClaim(leaseID)
+	retained, err := core.ReadLeaseClaim(leaseID)
 	if err != nil || retained.LeaseID != leaseID {
 		t.Fatalf("failed destroy lost claim: claim=%#v err=%v", retained, err)
 	}
@@ -989,12 +989,12 @@ func TestCloudRunSandboxCleanupContinuesAfterDestroyFailure(t *testing.T) {
 		return nil
 	}}
 	previousTransport := newTransport
-	newTransport = func(Config, Runtime) (sandboxTransport, error) { return transport, nil }
+	newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) { return transport, nil }
 	t.Cleanup(func() { newTransport = previousTransport })
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
 		IdleTimeout:     time.Second,
-	}, Runtime{Stdout: io.Discard, Stderr: io.Discard, Clock: cloudRunSandboxFixedClock{now: now}}).(*backend)
+	}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Clock: cloudRunSandboxFixedClock{now: now}}).(*backend)
 	scope, err := b.claimScope()
 	if err != nil {
 		t.Fatal(err)
@@ -1004,16 +1004,16 @@ func TestCloudRunSandboxCleanupContinuesAfterDestroyFailure(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); !errors.Is(err, destroyErr) {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); !errors.Is(err, destroyErr) {
 		t.Fatalf("cleanup err=%v, want %v", err, destroyErr)
 	}
 	if len(destroyed) != 2 {
 		t.Fatalf("destroyed=%v", destroyed)
 	}
-	if _, exists, err := readLeaseClaimWithPresence(leasePrefix + "crabbox-a-fail"); err != nil || !exists {
+	if _, exists, err := core.ReadLeaseClaimWithPresence(leasePrefix + "crabbox-a-fail"); err != nil || !exists {
 		t.Fatalf("failed claim exists=%v err=%v", exists, err)
 	}
-	if _, exists, err := readLeaseClaimWithPresence(leasePrefix + "crabbox-z-success"); err != nil || exists {
+	if _, exists, err := core.ReadLeaseClaimWithPresence(leasePrefix + "crabbox-z-success"); err != nil || exists {
 		t.Fatalf("successful claim exists=%v err=%v", exists, err)
 	}
 }
@@ -1027,15 +1027,15 @@ func TestCloudRunSandboxRunPropagatesAutomaticTeardownFailure(t *testing.T) {
 		onDestroy: func(string) error { return destroyErr },
 	}
 	previousTransport := newTransport
-	newTransport = func(Config, Runtime) (sandboxTransport, error) { return transport, nil }
+	newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) { return transport, nil }
 	t.Cleanup(func() { newTransport = previousTransport })
 	var stderr bytes.Buffer
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
 		IdleTimeout:     time.Minute,
-	}, Runtime{Stdout: io.Discard, Stderr: &stderr}).(*backend)
-	result, err := b.Run(context.Background(), RunRequest{
-		Repo:       Repo{Root: t.TempDir()},
+	}, core.Runtime{Stdout: io.Discard, Stderr: &stderr}).(*backend)
+	result, err := b.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Root: t.TempDir()},
 		Command:    []string{"true"},
 		NoSync:     true,
 		TimingJSON: true,
@@ -1043,7 +1043,7 @@ func TestCloudRunSandboxRunPropagatesAutomaticTeardownFailure(t *testing.T) {
 	if !errors.Is(err, destroyErr) || result.Session == nil || !result.Session.Kept {
 		t.Fatalf("result=%#v err=%v", result, err)
 	}
-	if _, exists, readErr := readLeaseClaimWithPresence(result.LeaseID); readErr != nil || !exists {
+	if _, exists, readErr := core.ReadLeaseClaimWithPresence(result.LeaseID); readErr != nil || !exists {
 		t.Fatalf("recovery claim exists=%v err=%v", exists, readErr)
 	}
 	lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
@@ -1069,15 +1069,15 @@ func TestCloudRunSandboxRunEmitsTimingJSONOnWorkspaceSetupFailure(t *testing.T) 
 		},
 	}
 	previousTransport := newTransport
-	newTransport = func(Config, Runtime) (sandboxTransport, error) { return transport, nil }
+	newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) { return transport, nil }
 	t.Cleanup(func() { newTransport = previousTransport })
 	var stderr bytes.Buffer
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
 		IdleTimeout:     time.Minute,
-	}, Runtime{Stdout: io.Discard, Stderr: &stderr}).(*backend)
-	_, err := b.Run(context.Background(), RunRequest{
-		Repo:       Repo{Root: t.TempDir()},
+	}, core.Runtime{Stdout: io.Discard, Stderr: &stderr}).(*backend)
+	_, err := b.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Root: t.TempDir()},
 		Command:    []string{"true"},
 		NoSync:     true,
 		TimingJSON: true,
@@ -1098,9 +1098,9 @@ func TestCloudRunSandboxRunEmitsTimingJSONOnWorkspaceSetupFailure(t *testing.T) 
 func TestCloudRunSandboxStatusReportsExpiredClaim(t *testing.T) {
 	isolateLeaseHome(t)
 	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
-	}, Runtime{Stdout: io.Discard, Stderr: io.Discard, Clock: cloudRunSandboxFixedClock{now: now}}).(*backend)
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+	}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Clock: cloudRunSandboxFixedClock{now: now}}).(*backend)
 	scope, err := b.claimScope()
 	if err != nil {
 		t.Fatal(err)
@@ -1109,20 +1109,20 @@ func TestCloudRunSandboxStatusReportsExpiredClaim(t *testing.T) {
 	if err := claimTestCloudRunSandboxLease(leaseID, "expired", scope, t.TempDir(), time.Minute); err != nil {
 		t.Fatal(err)
 	}
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	labels := cloneLabels(claim.Labels)
 	labels[claimExpiresAtLabel] = now.Add(-time.Second).Format(time.RFC3339Nano)
-	if _, err := updateLeaseClaimLabelsIfUnchanged(leaseID, claim, labels); err != nil {
+	if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, claim, labels); err != nil {
 		t.Fatal(err)
 	}
-	status, err := b.Status(context.Background(), StatusRequest{ID: leaseID})
+	status, err := b.Status(context.Background(), core.StatusRequest{ID: leaseID})
 	if err != nil || status.Ready || status.State != "expired" {
 		t.Fatalf("status=%#v err=%v", status, err)
 	}
-	leases, err := b.List(context.Background(), ListRequest{})
+	leases, err := b.List(context.Background(), core.ListRequest{})
 	if err != nil || len(leases) != 1 || leases[0].Status != "expired" {
 		t.Fatalf("expired list=%#v err=%v", leases, err)
 	}
@@ -1131,10 +1131,10 @@ func TestCloudRunSandboxStatusReportsExpiredClaim(t *testing.T) {
 func TestCloudRunSandboxClearActivityTouchesLastUsed(t *testing.T) {
 	isolateLeaseHome(t)
 	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
 		IdleTimeout:     time.Minute,
-	}, Runtime{Stdout: io.Discard, Stderr: io.Discard, Clock: cloudRunSandboxFixedClock{now: now}}).(*backend)
+	}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Clock: cloudRunSandboxFixedClock{now: now}}).(*backend)
 	scope, err := b.claimScope()
 	if err != nil {
 		t.Fatal(err)
@@ -1143,7 +1143,7 @@ func TestCloudRunSandboxClearActivityTouchesLastUsed(t *testing.T) {
 	if err := claimTestCloudRunSandboxLease(leaseID, "touch", scope, t.TempDir(), time.Minute); err != nil {
 		t.Fatal(err)
 	}
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1175,13 +1175,13 @@ func TestCloudRunSandboxReclaimCannotRepublishAfterCleanupWins(t *testing.T) {
 		return nil
 	}}
 	previousTransport := newTransport
-	newTransport = func(Config, Runtime) (sandboxTransport, error) { return transport, nil }
+	newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) { return transport, nil }
 	t.Cleanup(func() { newTransport = previousTransport })
 
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
 		IdleTimeout:     time.Second,
-	}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 	scope, err := b.claimScope()
 	if err != nil {
 		t.Fatal(err)
@@ -1189,7 +1189,7 @@ func TestCloudRunSandboxReclaimCannotRepublishAfterCleanupWins(t *testing.T) {
 	if err := claimTestCloudRunSandboxLease(leaseID, "cleanup-wins", scope, t.TempDir(), time.Second); err != nil {
 		t.Fatal(err)
 	}
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1200,7 +1200,7 @@ func TestCloudRunSandboxReclaimCannotRepublishAfterCleanupWins(t *testing.T) {
 	}
 
 	cleanupDone := make(chan error, 1)
-	go func() { cleanupDone <- b.Cleanup(context.Background(), CleanupRequest{}) }()
+	go func() { cleanupDone <- b.Cleanup(context.Background(), core.CleanupRequest{}) }()
 	<-destroyStarted
 
 	reclaimDone := make(chan error, 1)
@@ -1221,7 +1221,7 @@ func TestCloudRunSandboxReclaimCannotRepublishAfterCleanupWins(t *testing.T) {
 	if err := <-reclaimDone; err == nil || (!strings.Contains(err.Error(), "claim changed") && !strings.Contains(err.Error(), "not claimed by Crabbox")) {
 		t.Fatalf("reclaim error=%v, want guarded missing-claim failure", err)
 	}
-	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
+	if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
 		t.Fatalf("reclaim republished deleted sandbox claim: exists=%v err=%v", exists, err)
 	}
 }
@@ -1273,7 +1273,7 @@ func TestRunWithFakeTransport(t *testing.T) {
 		},
 	}
 	prev := newTransport
-	newTransport = func(Config, Runtime) (sandboxTransport, error) { return fake, nil }
+	newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) { return fake, nil }
 	t.Cleanup(func() { newTransport = prev })
 
 	// Isolate lease claims to a temp dir.
@@ -1287,20 +1287,20 @@ func TestRunWithFakeTransport(t *testing.T) {
 		t.Fatal(err)
 	}
 	var stdout, stderr bytes.Buffer
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{
 			CLIPath: "/usr/local/gcp/bin/sandbox",
 			Workdir: "/tmp/crabbox",
 			Write:   true,
 		},
 		IdleTimeout: 30 * time.Minute,
-	}, Runtime{
+	}, core.Runtime{
 		Stdout: &stdout,
 		Stderr: &stderr,
 	}).(*backend)
 
-	result, err := b.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: root},
+	result, err := b.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: root},
 		Command: []string{"echo", "hello"},
 		NoSync:  true,
 		Keep:    false,
@@ -1324,7 +1324,7 @@ func TestRunWithFakeTransport(t *testing.T) {
 
 func TestValidateConfig(t *testing.T) {
 	t.Parallel()
-	cfg := Config{CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"}}
+	cfg := core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"}}
 	if err := validateConfig(cfg); err != nil {
 		t.Fatalf("valid config rejected: %v", err)
 	}
@@ -1350,7 +1350,7 @@ type fakeTransport struct {
 }
 
 func claimTestCloudRunSandboxLease(leaseID, slug, scope, repoRoot string, idleTimeout time.Duration) error {
-	_, err := claimLeaseForRepoProviderScopePondWithLabels(leaseID, slug, providerName, scope, "", repoRoot, idleTimeout, map[string]string{
+	_, err := core.ClaimLeaseForRepoProviderScopePondWithLabels(leaseID, slug, providerName, scope, "", repoRoot, idleTimeout, map[string]string{
 		claimOwnershipLabel: strings.TrimPrefix(leaseID, leasePrefix),
 	})
 	return err

--- a/internal/providers/cloudrunsandbox/client.go
+++ b/internal/providers/cloudrunsandbox/client.go
@@ -51,7 +51,7 @@ type execOptions struct {
 var errSandboxNotFound = errors.New("cloud-run-sandbox sandbox not found")
 var errSandboxAlreadyExists = errors.New("cloud-run-sandbox sandbox already exists")
 
-var newTransport = func(cfg Config, rt Runtime) (sandboxTransport, error) {
+var newTransport = func(cfg core.Config, rt core.Runtime) (sandboxTransport, error) {
 	// GatewayURL is deliberately absent from fileCloudRunSandboxConfig. Only an
 	// operator-supplied flag or environment value can select the origin that
 	// receives the environment-only gateway credentials below.
@@ -62,7 +62,7 @@ var newTransport = func(cfg Config, rt Runtime) (sandboxTransport, error) {
 	)
 	if gatewayURL != "" {
 		if secret == "" {
-			return nil, exit(2, "provider=cloud-run-sandbox remote mode requires CLOUD_RUN_SANDBOX_SECRET or CRABBOX_CLOUD_RUN_SANDBOX_SECRET")
+			return nil, core.Exit(2, "provider=cloud-run-sandbox remote mode requires CLOUD_RUN_SANDBOX_SECRET or CRABBOX_CLOUD_RUN_SANDBOX_SECRET")
 		}
 		validated, err := validateGatewayURL(gatewayURL)
 		if err != nil {
@@ -82,7 +82,7 @@ var newTransport = func(cfg Config, rt Runtime) (sandboxTransport, error) {
 		}, nil
 	}
 	if rt.Exec == nil {
-		return nil, exit(2, "provider=cloud-run-sandbox direct mode requires Runtime.Exec")
+		return nil, core.Exit(2, "provider=cloud-run-sandbox direct mode requires Runtime.Exec")
 	}
 	return &directTransport{
 		cfg: cfg,
@@ -101,9 +101,9 @@ func firstNonEmpty(values ...string) string {
 
 func validateGatewayURL(raw string) (string, error) {
 	return shared.NormalizeHTTPSURL(raw, shared.EndpointURLErrors{
-		Invalid:    exit(2, "provider=cloud-run-sandbox gateway URL must be an absolute HTTPS URL"),
-		Components: exit(2, "provider=cloud-run-sandbox gateway URL must not contain userinfo, query parameters, or a fragment"),
-		Insecure:   exit(2, "provider=cloud-run-sandbox gateway URL must use HTTPS except for loopback development endpoints"),
+		Invalid:    core.Exit(2, "provider=cloud-run-sandbox gateway URL must be an absolute HTTPS URL"),
+		Components: core.Exit(2, "provider=cloud-run-sandbox gateway URL must not contain userinfo, query parameters, or a fragment"),
+		Insecure:   core.Exit(2, "provider=cloud-run-sandbox gateway URL must use HTTPS except for loopback development endpoints"),
 	})
 }
 
@@ -117,7 +117,7 @@ func cloudRunSandboxRedirectError(destination *url.URL) error {
 
 func validateSandboxID(id string) error {
 	if !regexp.MustCompile(`^[A-Za-z0-9_-]+$`).MatchString(id) {
-		return exit(2, "invalid cloud-run-sandbox id %q", id)
+		return core.Exit(2, "invalid cloud-run-sandbox id %q", id)
 	}
 	return nil
 }
@@ -125,7 +125,7 @@ func validateSandboxID(id string) error {
 func validateEnv(env map[string]string) error {
 	for key := range env {
 		if !core.ValidShellEnvName(key) {
-			return exit(2, "invalid environment variable name %q", key)
+			return core.Exit(2, "invalid environment variable name %q", key)
 		}
 	}
 	return nil
@@ -137,7 +137,7 @@ type remoteTransport struct {
 	baseURL   string
 	secret    string
 	authToken string
-	cfg       Config
+	cfg       core.Config
 	http      *http.Client
 }
 
@@ -227,7 +227,7 @@ func (t *remoteTransport) request(ctx context.Context, path string, body map[str
 		return nil, err
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, exit(2, "cloud-run-sandbox gateway unauthorized; check CLOUD_RUN_SANDBOX_SECRET")
+		return nil, core.Exit(2, "cloud-run-sandbox gateway unauthorized; check CLOUD_RUN_SANDBOX_SECRET")
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		var errBody struct {
@@ -301,7 +301,7 @@ func (t *remoteTransport) Health(ctx context.Context) error {
 		return err
 	}
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return exit(2, "cloud-run-sandbox gateway unauthorized; check gateway secret and Cloud Run IAM token")
+		return core.Exit(2, "cloud-run-sandbox gateway unauthorized; check gateway secret and Cloud Run IAM token")
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("cloud-run-sandbox gateway health returned %s", resp.Status)
@@ -389,7 +389,7 @@ func (t *remoteTransport) Exec(ctx context.Context, sandboxID, command string, o
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return 1, exit(2, "cloud-run-sandbox gateway unauthorized; check gateway credentials")
+		return 1, core.Exit(2, "cloud-run-sandbox gateway unauthorized; check gateway credentials")
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		data, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
@@ -503,8 +503,8 @@ func (t *remoteTransport) WriteFile(ctx context.Context, sandboxID, path, conten
 // --- direct in-container sandbox CLI transport ---
 
 type directTransport struct {
-	cfg Config
-	rt  Runtime
+	cfg core.Config
+	rt  core.Runtime
 }
 
 func (t *directTransport) Mode() string { return "direct" }
@@ -540,14 +540,14 @@ func (t *directTransport) pushExecArgs(args []string, opts execOptions) []string
 	return args
 }
 
-func (t *directTransport) runCLI(ctx context.Context, args []string, stdout, stderr io.Writer) (LocalCommandResult, error) {
+func (t *directTransport) runCLI(ctx context.Context, args []string, stdout, stderr io.Writer) (core.LocalCommandResult, error) {
 	return t.runCLIWithStdin(ctx, args, nil, stdout, stderr)
 }
 
-func (t *directTransport) runCLIWithStdin(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) (LocalCommandResult, error) {
+func (t *directTransport) runCLIWithStdin(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) (core.LocalCommandResult, error) {
 	ctx, cancel := contextWithDefaultTimeout(ctx, defaultExecTimeout)
 	defer cancel()
-	result, err := t.rt.Exec.Run(ctx, LocalCommandRequest{
+	result, err := t.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name:                 t.binary(),
 		Args:                 args,
 		Stdin:                stdin,
@@ -566,10 +566,10 @@ func (t *directTransport) Health(ctx context.Context) error {
 	var stdout, stderr bytes.Buffer
 	result, err := t.runCLI(ctx, append(t.baseArgs(), "--help"), &stdout, &stderr)
 	if err != nil {
-		return exit(2, "cloud-run-sandbox CLI %q not usable: %v (%s)", t.binary(), err, strings.TrimSpace(stderr.String()))
+		return core.Exit(2, "cloud-run-sandbox CLI %q not usable: %v (%s)", t.binary(), err, strings.TrimSpace(stderr.String()))
 	}
 	if result.ExitCode != 0 {
-		return exit(2, "cloud-run-sandbox CLI %q --help exited %d: %s", t.binary(), result.ExitCode, strings.TrimSpace(stderr.String()+stdout.String()))
+		return core.Exit(2, "cloud-run-sandbox CLI %q --help exited %d: %s", t.binary(), result.ExitCode, strings.TrimSpace(stderr.String()+stdout.String()))
 	}
 	return nil
 }
@@ -608,7 +608,7 @@ func (t *directTransport) Create(ctx context.Context, sandboxID string, opts run
 		return errors.New("cloud-run-sandbox direct create requires the sandbox ID as its ownership token")
 	}
 	if len(opts.Env) > 0 {
-		return exit(2, "cloud-run-sandbox direct create does not accept environment values; pass them to exec so they stay off argv")
+		return core.Exit(2, "cloud-run-sandbox direct create does not accept environment values; pass them to exec so they stay off argv")
 	}
 	args := append(t.baseArgs(), "run", sandboxID, "--detach")
 	createOpts := opts
@@ -617,7 +617,7 @@ func (t *directTransport) Create(ctx context.Context, sandboxID string, opts run
 	createOpts.Workdir = ""
 	createOpts.OmitWorkdir = true
 	args = t.pushRunArgs(args, createOpts)
-	keeper := "PATH=" + shellQuote(defaultSandboxPath) + "; export PATH; while :; do /bin/sleep 3600; done"
+	keeper := "PATH=" + core.ShellQuote(defaultSandboxPath) + "; export PATH; while :; do /bin/sleep 3600; done"
 	args = append(args, "--", "/bin/sh", "-c", keeper)
 	var stdout, stderr bytes.Buffer
 	result, err := t.runCLI(ctx, args, &stdout, &stderr)
@@ -651,12 +651,12 @@ func (t *directTransport) Exec(ctx context.Context, sandboxID, command string, o
 	sort.Strings(keys)
 	var script strings.Builder
 	if _, hasPath := opts.Env["PATH"]; !hasPath {
-		fmt.Fprintf(&script, "export PATH=%s\n", shellQuote(defaultSandboxPath))
+		fmt.Fprintf(&script, "export PATH=%s\n", core.ShellQuote(defaultSandboxPath))
 	}
 	for _, key := range keys {
-		fmt.Fprintf(&script, "export %s=%s\n", key, shellQuote(opts.Env[key]))
+		fmt.Fprintf(&script, "export %s=%s\n", key, core.ShellQuote(opts.Env[key]))
 	}
-	fmt.Fprintf(&script, "exec /bin/sh -c %s\n", shellQuote(command))
+	fmt.Fprintf(&script, "exec /bin/sh -c %s\n", core.ShellQuote(command))
 	if opts.Timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
@@ -706,12 +706,12 @@ func (t *directTransport) WriteFile(ctx context.Context, sandboxID, path, conten
 	// Stream content over stdin so workspace data never appears in host process
 	// arguments. The first chunk is atomically published; later chunks append to
 	// that unique per-sync temporary archive.
-	command := fmt.Sprintf("mkdir -p \"$(dirname %s)\" && cat >> %s", shellQuote(path), shellQuote(path))
+	command := fmt.Sprintf("mkdir -p \"$(dirname %s)\" && cat >> %s", core.ShellQuote(path), core.ShellQuote(path))
 	if !appendContent {
 		tempPath := path + ".crabbox-upload"
-		command = fmt.Sprintf("mkdir -p \"$(dirname %s)\" && cat > %s && mv -f %s %s", shellQuote(path), shellQuote(tempPath), shellQuote(tempPath), shellQuote(path))
+		command = fmt.Sprintf("mkdir -p \"$(dirname %s)\" && cat > %s && mv -f %s %s", core.ShellQuote(path), core.ShellQuote(tempPath), core.ShellQuote(tempPath), core.ShellQuote(path))
 	}
-	command = "PATH=" + shellQuote(defaultSandboxPath) + "; export PATH; " + command
+	command = "PATH=" + core.ShellQuote(defaultSandboxPath) + "; export PATH; " + command
 	args := append(t.baseArgs(), "exec", sandboxID, "--workdir", "/", "--", "/bin/sh", "-c", command)
 	var stdout, stderr bytes.Buffer
 	result, err := t.runCLIWithStdin(ctx, args, strings.NewReader(content), &stdout, &stderr)

--- a/internal/providers/cloudrunsandbox/client_test.go
+++ b/internal/providers/cloudrunsandbox/client_test.go
@@ -65,8 +65,8 @@ func TestDirectTransportExecPreservesNativeBoundary(t *testing.T) {
 		{name: "canceled exit", code: 23, err: errors.Join(plain, context.Canceled)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			transport := &directTransport{rt: Runtime{Exec: recordingLocalExec{handler: func(LocalCommandRequest) (LocalCommandResult, error) {
-				return LocalCommandResult{ExitCode: tc.code}, tc.err
+			transport := &directTransport{rt: core.Runtime{Exec: recordingLocalExec{handler: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+				return core.LocalCommandResult{ExitCode: tc.code}, tc.err
 			}}}}
 			code, err := transport.Exec(t.Context(), "fixture", "true", execOptions{}, io.Discard, io.Discard)
 			if code != tc.code || tc.plain && err != nil || !tc.plain && !errors.Is(err, tc.err) {
@@ -117,7 +117,7 @@ func TestClientHelpers(t *testing.T) {
 
 func TestRemoteRequestBody(t *testing.T) {
 	t.Parallel()
-	transport := &remoteTransport{cfg: Config{CloudRunSandbox: CloudRunSandboxConfig{
+	transport := &remoteTransport{cfg: core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{
 		AllowEgress: true,
 		Write:       true,
 		Rootfs:      "base",
@@ -140,7 +140,7 @@ func TestRemoteRequestBody(t *testing.T) {
 func TestCloudRunOperationOptionsKeepRawConfigSemantics(t *testing.T) {
 	for _, tc := range []struct {
 		name            string
-		cfg             Config
+		cfg             core.Config
 		opts            runOptions
 		args            []string
 		write, egress   bool
@@ -148,8 +148,8 @@ func TestCloudRunOperationOptionsKeepRawConfigSemantics(t *testing.T) {
 	}{
 		{name: "raw zero"},
 		{name: "base", cfg: core.BaseConfig(), args: []string{"--rootfs", "/", "--workdir", "/tmp/crabbox", "--write"}, write: true, rootfs: "/", workdir: "/tmp/crabbox"},
-		{name: "option priority", cfg: Config{CloudRunSandbox: CloudRunSandboxConfig{Rootfs: "/base", Workdir: "/base", Write: true}}, opts: runOptions{Rootfs: "/option", Workdir: "/option", AllowEgress: true}, args: []string{"--allow-egress", "--rootfs", "/option", "--workdir", "/option", "--write"}, write: true, egress: true, rootfs: "/option", workdir: "/option"},
-		{name: "config OR", cfg: Config{CloudRunSandbox: CloudRunSandboxConfig{AllowEgress: true}}, opts: runOptions{Write: true}, args: []string{"--allow-egress", "--write"}, write: true, egress: true},
+		{name: "option priority", cfg: core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{Rootfs: "/base", Workdir: "/base", Write: true}}, opts: runOptions{Rootfs: "/option", Workdir: "/option", AllowEgress: true}, args: []string{"--allow-egress", "--rootfs", "/option", "--workdir", "/option", "--write"}, write: true, egress: true, rootfs: "/option", workdir: "/option"},
+		{name: "config OR", cfg: core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{AllowEgress: true}}, opts: runOptions{Write: true}, args: []string{"--allow-egress", "--write"}, write: true, egress: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			direct := &directTransport{cfg: tc.cfg}
@@ -170,10 +170,10 @@ func TestCloudRunOperationOptionsKeepRawConfigSemantics(t *testing.T) {
 	}
 	cfg := core.BaseConfig()
 	cfg.CloudRunSandbox.Workdir = "/tmp/custom"
-	var calls []LocalCommandRequest
-	transport := &directTransport{cfg: cfg, rt: Runtime{Exec: recordingLocalExec{handler: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	var calls []core.LocalCommandRequest
+	transport := &directTransport{cfg: cfg, rt: core.Runtime{Exec: recordingLocalExec{handler: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		calls = append(calls, req)
-		return LocalCommandResult{}, nil
+		return core.LocalCommandResult{}, nil
 	}}}}
 	if err := transport.Create(context.Background(), "example", runOptions{OwnershipToken: "example", Workdir: "/tmp/option"}); err != nil {
 		t.Fatal(err)
@@ -248,8 +248,8 @@ func TestRemoteTransportLifecycle(t *testing.T) {
 	transport := &remoteTransport{
 		baseURL: server.URL,
 		secret:  "test-secret",
-		cfg: Config{
-			CloudRunSandbox: CloudRunSandboxConfig{
+		cfg: core.Config{
+			CloudRunSandbox: core.CloudRunSandboxConfig{
 				GatewayURL: server.URL,
 				CLIPath:    "/usr/local/gcp/bin/sandbox",
 				Workdir:    "/tmp/crabbox",
@@ -342,20 +342,20 @@ func TestNewTransportRemoteAndDirect(t *testing.T) {
 	t.Setenv("CRABBOX_CLOUD_RUN_SANDBOX_SECRET", "")
 	t.Setenv("CLOUD_RUN_AUTH_TOKEN", "")
 	t.Setenv("CRABBOX_CLOUD_RUN_SANDBOX_AUTH_TOKEN", "")
-	_, err := newTransport(Config{CloudRunSandbox: CloudRunSandboxConfig{
+	_, err := newTransport(core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{
 		GatewayURL: "https://gw.example.run.app",
 		CLIPath:    "/usr/local/gcp/bin/sandbox",
-	}}, Runtime{})
+	}}, core.Runtime{})
 	if err == nil || !strings.Contains(err.Error(), "requires CLOUD_RUN_SANDBOX_SECRET") {
 		t.Fatalf("expected secret requirement, got %v", err)
 	}
 
 	t.Setenv("CLOUD_RUN_SANDBOX_SECRET", "sec")
 	t.Setenv("CRABBOX_CLOUD_RUN_SANDBOX_AUTH_TOKEN", "tok")
-	transport, err := newTransport(Config{CloudRunSandbox: CloudRunSandboxConfig{
+	transport, err := newTransport(core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{
 		GatewayURL: "https://gw.example.run.app/",
 		CLIPath:    "/usr/local/gcp/bin/sandbox",
-	}}, Runtime{})
+	}}, core.Runtime{})
 	if err != nil {
 		t.Fatalf("remote newTransport: %v", err)
 	}
@@ -368,14 +368,14 @@ func TestNewTransportRemoteAndDirect(t *testing.T) {
 	}
 
 	// Direct mode requires Runtime.Exec.
-	_, err = newTransport(Config{CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox"}}, Runtime{})
+	_, err = newTransport(core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox"}}, core.Runtime{})
 	if err == nil || !strings.Contains(err.Error(), "requires Runtime.Exec") {
 		t.Fatalf("expected Exec requirement, got %v", err)
 	}
 
-	transport, err = newTransport(Config{CloudRunSandbox: CloudRunSandboxConfig{
+	transport, err = newTransport(core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{
 		CLIPath: "/bin/sandbox",
-	}}, Runtime{Exec: stubLocalExec{}})
+	}}, core.Runtime{Exec: stubLocalExec{}})
 	if err != nil {
 		t.Fatalf("direct newTransport: %v", err)
 	}
@@ -409,7 +409,7 @@ func TestRemoteTransportErrorPaths(t *testing.T) {
 		secret:    "sec",
 		authToken: "tok",
 		http:      server.Client(),
-		cfg:       Config{CloudRunSandbox: CloudRunSandboxConfig{Write: true}},
+		cfg:       core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{Write: true}},
 	}
 	ctx := context.Background()
 	if err := transport.Health(ctx); err == nil {
@@ -559,36 +559,36 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { re
 
 func TestDirectTransportLifecycle(t *testing.T) {
 	var calls []string
-	exec := recordingLocalExec{handler: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	exec := recordingLocalExec{handler: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		joined := strings.Join(append([]string{req.Name}, req.Args...), " ")
 		calls = append(calls, joined)
 		if strings.Contains(joined, "--help") {
-			return LocalCommandResult{ExitCode: 0}, nil
+			return core.LocalCommandResult{ExitCode: 0}, nil
 		}
 		if strings.Contains(joined, " delete ") {
 			if strings.Contains(joined, "missing-box") {
 				_, _ = io.WriteString(req.Stderr, "sandbox missing-box not found")
-				return LocalCommandResult{ExitCode: 1}, nil
+				return core.LocalCommandResult{ExitCode: 1}, nil
 			}
-			return LocalCommandResult{ExitCode: 0}, nil
+			return core.LocalCommandResult{ExitCode: 0}, nil
 		}
 		if strings.Contains(joined, " run ") || strings.Contains(joined, " exec ") {
 			if req.Stdout != nil {
 				_, _ = io.WriteString(req.Stdout, "ok\n")
 			}
-			return LocalCommandResult{ExitCode: 0}, nil
+			return core.LocalCommandResult{ExitCode: 0}, nil
 		}
-		return LocalCommandResult{ExitCode: 0}, nil
+		return core.LocalCommandResult{ExitCode: 0}, nil
 	}}
 	transport := &directTransport{
-		cfg: Config{CloudRunSandbox: CloudRunSandboxConfig{
+		cfg: core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{
 			CLIPath:     "/bin/sandbox",
 			AllowEgress: true,
 			Write:       true,
 			Rootfs:      "/",
 			Workdir:     "/tmp/crabbox",
 		}},
-		rt: Runtime{Exec: exec},
+		rt: core.Runtime{Exec: exec},
 	}
 	ctx := context.Background()
 	if err := transport.Health(ctx); err != nil {
@@ -636,10 +636,10 @@ func TestDirectTransportLifecycle(t *testing.T) {
 func TestDirectTransportExecHonorsTimeout(t *testing.T) {
 	t.Parallel()
 	transport := &directTransport{
-		cfg: Config{CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/bin/sandbox"}},
-		rt: Runtime{Exec: contextLocalExec{run: func(ctx context.Context, _ LocalCommandRequest) (LocalCommandResult, error) {
+		cfg: core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/bin/sandbox"}},
+		rt: core.Runtime{Exec: contextLocalExec{run: func(ctx context.Context, _ core.LocalCommandRequest) (core.LocalCommandResult, error) {
 			<-ctx.Done()
-			return LocalCommandResult{ExitCode: 124}, ctx.Err()
+			return core.LocalCommandResult{ExitCode: 124}, ctx.Err()
 		}}},
 	}
 	started := time.Now()
@@ -656,13 +656,13 @@ func TestDirectTransportBoundsControlCommands(t *testing.T) {
 	t.Parallel()
 	calls := 0
 	transport := &directTransport{
-		cfg: Config{CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/bin/sandbox"}},
-		rt: Runtime{Exec: contextLocalExec{run: func(ctx context.Context, _ LocalCommandRequest) (LocalCommandResult, error) {
+		cfg: core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/bin/sandbox"}},
+		rt: core.Runtime{Exec: contextLocalExec{run: func(ctx context.Context, _ core.LocalCommandRequest) (core.LocalCommandResult, error) {
 			calls++
 			if _, ok := ctx.Deadline(); !ok {
 				t.Fatal("direct CLI call has no deadline")
 			}
-			return LocalCommandResult{}, nil
+			return core.LocalCommandResult{}, nil
 		}}},
 	}
 	ctx := context.Background()
@@ -683,12 +683,12 @@ func TestDirectTransportBoundsControlCommands(t *testing.T) {
 func TestDirectTransportWriteFileStreamsLargePayloadOnStdin(t *testing.T) {
 	t.Parallel()
 	payload := strings.Repeat("sensitive-workspace-data", 8<<10)
-	var request LocalCommandRequest
+	var request core.LocalCommandRequest
 	transport := &directTransport{
-		cfg: Config{CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/bin/sandbox"}},
-		rt: Runtime{Exec: recordingLocalExec{handler: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		cfg: core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/bin/sandbox"}},
+		rt: core.Runtime{Exec: recordingLocalExec{handler: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 			request = req
-			return LocalCommandResult{}, nil
+			return core.LocalCommandResult{}, nil
 		}}},
 	}
 	if err := transport.WriteFile(context.Background(), "box", "/tmp/archive.b64", payload, false); err != nil {
@@ -711,12 +711,12 @@ func TestDirectTransportWriteFileStreamsLargePayloadOnStdin(t *testing.T) {
 
 func TestDirectTransportExecStreamsEnvironmentOnStdin(t *testing.T) {
 	t.Parallel()
-	var request LocalCommandRequest
+	var request core.LocalCommandRequest
 	transport := &directTransport{
-		cfg: Config{CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/bin/sandbox"}},
-		rt: Runtime{Exec: recordingLocalExec{handler: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		cfg: core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/bin/sandbox"}},
+		rt: core.Runtime{Exec: recordingLocalExec{handler: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 			request = req
-			return LocalCommandResult{}, nil
+			return core.LocalCommandResult{}, nil
 		}}},
 	}
 	const value = "sensitive-env-value"
@@ -733,7 +733,7 @@ func TestDirectTransportExecStreamsEnvironmentOnStdin(t *testing.T) {
 	if err != nil || !strings.Contains(string(script), value) {
 		t.Fatalf("stdin script=%q err=%v", script, err)
 	}
-	if !strings.Contains(string(script), "export PATH="+shellQuote(defaultSandboxPath)) {
+	if !strings.Contains(string(script), "export PATH="+core.ShellQuote(defaultSandboxPath)) {
 		t.Fatalf("stdin script has no baseline PATH: %q", script)
 	}
 	if _, err := transport.Exec(context.Background(), "box", "true", execOptions{Env: map[string]string{"PATH": "/custom/bin"}}, nil, nil); err != nil {
@@ -769,27 +769,27 @@ func TestSecureHTTPClientSameOrigin(t *testing.T) {
 
 type stubLocalExec struct{}
 
-func (stubLocalExec) Run(context.Context, LocalCommandRequest) (LocalCommandResult, error) {
-	return LocalCommandResult{}, nil
+func (stubLocalExec) Run(context.Context, core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	return core.LocalCommandResult{}, nil
 }
 
 type recordingLocalExec struct {
-	handler func(LocalCommandRequest) (LocalCommandResult, error)
+	handler func(core.LocalCommandRequest) (core.LocalCommandResult, error)
 }
 
 type contextLocalExec struct {
-	run func(context.Context, LocalCommandRequest) (LocalCommandResult, error)
+	run func(context.Context, core.LocalCommandRequest) (core.LocalCommandResult, error)
 }
 
-func (r contextLocalExec) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (r contextLocalExec) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	return r.run(ctx, req)
 }
 
-func (r recordingLocalExec) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (r recordingLocalExec) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	if r.handler != nil {
 		return r.handler(req)
 	}
-	return LocalCommandResult{}, nil
+	return core.LocalCommandResult{}, nil
 }
 
 func TestCompactJSONRemoteRequestAndExecEnvelopes(t *testing.T) {

--- a/internal/providers/cloudrunsandbox/core.go
+++ b/internal/providers/cloudrunsandbox/core.go
@@ -1,38 +1,10 @@
 package cloudrunsandbox
 
 import (
-	"io"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type CloudRunSandboxConfig = core.CloudRunSandboxConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type DoctorCheck = core.DoctorCheck
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type RunSessionHandle = core.RunSessionHandle
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type CleanupRequest = core.CleanupRequest
-type Server = core.Server
-type Repo = core.Repo
-type LeaseClaim = core.LeaseClaim
-type ExitError = core.ExitError
-type timingReport = core.TimingReport
-type timingPhase = core.TimingPhase
-type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
 
 const (
 	providerName          = "cloud-run-sandbox"
@@ -54,99 +26,10 @@ const (
 	claimOwnershipLabel   = "cloud_run_sandbox_ownership_token"
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
-}
-
-func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
-	return core.TimingReportWithRunResult(report, result, err)
-}
-
-func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
-	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
-}
-
-func claimLeaseForRepoProviderScopePondWithLabels(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, labels map[string]string) (LeaseClaim, error) {
-	return core.ClaimLeaseForRepoProviderScopePondWithLabels(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, labels)
-}
-
-func claimLeaseForRepoProviderScopePondIfUnchanged(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool, expected LeaseClaim) (LeaseClaim, error) {
+func claimLeaseForRepoProviderScopePondIfUnchanged(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool, expected core.LeaseClaim) (core.LeaseClaim, error) {
 	return core.ClaimLeaseForRepoProviderScopePondIfUnchanged(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim, expected, true)
-}
-
-func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaim(identifier)
-}
-
-func readLeaseClaim(leaseID string) (core.LeaseClaim, error) {
-	return core.ReadLeaseClaim(leaseID)
-}
-
-func readLeaseClaimWithPresence(leaseID string) (core.LeaseClaim, bool, error) {
-	return core.ReadLeaseClaimWithPresence(leaseID)
-}
-
-func withLeaseClaimUnchanged(leaseID string, expected LeaseClaim, action func() error) error {
-	return core.WithLeaseClaimUnchanged(leaseID, expected, action)
-}
-
-func resolveLeaseClaimAfterActionIfUnchanged(
-	leaseID string,
-	expected LeaseClaim,
-	action func() error,
-	resolve func(error) (map[string]string, bool),
-) (LeaseClaim, bool, bool, error) {
-	return core.ResolveLeaseClaimAfterActionIfUnchanged(leaseID, expected, action, resolve)
-}
-
-func updateLeaseClaimLabelsIfUnchanged(leaseID string, expected LeaseClaim, labels map[string]string) (LeaseClaim, error) {
-	return core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, expected, labels)
-}
-
-func updateLeaseClaimLabelsAndLastUsedIfUnchanged(leaseID string, expected LeaseClaim, labels map[string]string, lastUsed time.Time) (LeaseClaim, error) {
-	return core.UpdateLeaseClaimLabelsAndLastUsedIfUnchanged(leaseID, expected, labels, lastUsed)
 }
 
 func listCloudRunSandboxLeaseClaims() ([]core.LeaseClaim, error) {
 	return core.ListLeaseClaimsWithPrefix(leasePrefix)
-}
-
-func verifyLeaseClaimUnchanged(leaseID string, expected LeaseClaim) error {
-	return core.VerifyLeaseClaimUnchanged(leaseID, expected)
-}
-
-func removeLeaseClaimIfUnchangedAfter(leaseID string, expected LeaseClaim, action func() error) error {
-	return core.RemoveLeaseClaimIfUnchangedAfter(leaseID, expected, action)
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
-func shellQuote(s string) string {
-	return core.ShellQuote(s)
-}
-
-func delegatedSyncOptionsError(spec ProviderSpec, req RunRequest) error {
-	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
 }

--- a/internal/providers/cloudrunsandbox/flags.go
+++ b/internal/providers/cloudrunsandbox/flags.go
@@ -7,11 +7,11 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func RegisterCloudRunSandboxProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterCloudRunSandboxProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterCloudRunSandboxConfigFlags(fs, defaults.CloudRunSandbox)
 }
 
-func ApplyCloudRunSandboxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyCloudRunSandboxProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "sandboxes share Cloud Run service CPU/memory", "sandboxes share Cloud Run service CPU/memory"); err != nil {
 			return err

--- a/internal/providers/cloudrunsandbox/provider.go
+++ b/internal/providers/cloudrunsandbox/provider.go
@@ -75,12 +75,12 @@ func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.Doctor
 	return shared.ConfigureDoctor("cloud-run-sandbox", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
-func validateConfig(cfg Config) error {
+func validateConfig(cfg core.Config) error {
 	if workdir := strings.TrimSpace(cfg.CloudRunSandbox.Workdir); workdir != "" && !strings.HasPrefix(workdir, "/") {
-		return exit(2, "cloudRunSandbox.workdir must be an absolute path")
+		return core.Exit(2, "cloudRunSandbox.workdir must be an absolute path")
 	}
 	if cli := strings.TrimSpace(cfg.CloudRunSandbox.CLIPath); cli == "" {
-		return exit(2, "cloudRunSandbox.cliPath must not be empty")
+		return core.Exit(2, "cloudRunSandbox.cliPath must not be empty")
 	}
 	return nil
 }

--- a/internal/providers/cloudrunsandbox/provider_test.go
+++ b/internal/providers/cloudrunsandbox/provider_test.go
@@ -34,14 +34,14 @@ func TestProviderAliasesAndDiagnosticSecrets(t *testing.T) {
 			t.Fatalf("missing alias %q in %v", want, aliases)
 		}
 	}
-	if p.ServerTypeForConfig(Config{}) != "" || p.ServerTypeForClass("any") != "" {
+	if p.ServerTypeForConfig(core.Config{}) != "" || p.ServerTypeForClass("any") != "" {
 		t.Fatal("expected empty server type surface")
 	}
 	t.Setenv("CLOUD_RUN_SANDBOX_SECRET", "s1")
 	t.Setenv("CRABBOX_CLOUD_RUN_SANDBOX_SECRET", "s2")
 	t.Setenv("CLOUD_RUN_AUTH_TOKEN", "t1")
 	t.Setenv("CRABBOX_CLOUD_RUN_SANDBOX_AUTH_TOKEN", "t2")
-	secrets := p.DiagnosticSecrets(Config{})
+	secrets := p.DiagnosticSecrets(core.Config{})
 	joined := strings.Join(secrets, ",")
 	for _, want := range []string{"s1", "s2", "t1", "t2"} {
 		if !strings.Contains(joined, want) {
@@ -52,7 +52,7 @@ func TestProviderAliasesAndDiagnosticSecrets(t *testing.T) {
 
 func TestProviderConfigureAndFlags(t *testing.T) {
 	p := Provider{}
-	cfg := Config{CloudRunSandbox: CloudRunSandboxConfig{
+	cfg := core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{
 		CLIPath: "/usr/local/gcp/bin/sandbox",
 		Workdir: "/tmp/crabbox",
 		Write:   true,
@@ -83,7 +83,7 @@ func TestProviderConfigureAndFlags(t *testing.T) {
 		t.Fatalf("flags not applied: %#v", cfg.CloudRunSandbox)
 	}
 
-	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard}
+	rt := core.Runtime{Stdout: io.Discard, Stderr: io.Discard}
 	backend, err := p.Configure(cfg, rt)
 	if err != nil {
 		t.Fatalf("Configure: %v", err)
@@ -130,7 +130,7 @@ func TestCloudRunConfigFlagPresenceAndGuardOrder(t *testing.T) {
 		fs.String("class", "", "")
 		fs.String("type", "", "")
 		values := RegisterCloudRunSandboxProviderFlags(fs, cfg)
-		cfg.CloudRunSandbox = CloudRunSandboxConfig{GatewayURL: "https://example.invalid/env", CLIPath: "/opt/env", Workdir: "/tmp/env", Rootfs: "/env", Write: true, AllowEgress: true}
+		cfg.CloudRunSandbox = core.CloudRunSandboxConfig{GatewayURL: "https://example.invalid/env", CLIPath: "/opt/env", Workdir: "/tmp/env", Rootfs: "/env", Write: true, AllowEgress: true}
 		before := cfg.CloudRunSandbox
 		if err := ApplyCloudRunSandboxProviderFlags(&cfg, fs, values); err != nil {
 			t.Fatal(err)
@@ -144,7 +144,7 @@ func TestCloudRunConfigFlagPresenceAndGuardOrder(t *testing.T) {
 		if err := ApplyCloudRunSandboxProviderFlags(&cfg, fs, values); err == nil || err.Error() != "cloudRunSandbox.cliPath must not be empty" {
 			t.Fatalf("empty flags=%v", err)
 		}
-		if cfg.CloudRunSandbox != (CloudRunSandboxConfig{}) {
+		if cfg.CloudRunSandbox != (core.CloudRunSandboxConfig{}) {
 			t.Fatalf("all flags not copied before validation: %#v", cfg.CloudRunSandbox)
 		}
 		cfg.CloudRunSandbox.Workdir = "relative"
@@ -177,18 +177,18 @@ func TestCloudRunConfigFlagPresenceAndGuardOrder(t *testing.T) {
 }
 
 func TestWarmupRejectsUnsupportedOptions(t *testing.T) {
-	b := NewBackend(Provider{}.Spec(), Config{CloudRunSandbox: CloudRunSandboxConfig{
+	b := NewBackend(Provider{}.Spec(), core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{
 		CLIPath: "/usr/local/gcp/bin/sandbox",
 		Workdir: "/tmp/crabbox",
-	}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
-	if err := b.Warmup(context.Background(), WarmupRequest{ActionsRunner: true}); err == nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{ActionsRunner: true}); err == nil {
 		t.Fatal("expected actions-runner rejection")
 	}
-	if err := b.Warmup(context.Background(), WarmupRequest{Options: core.LeaseOptions{Desktop: true}}); err == nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Options: core.LeaseOptions{Desktop: true}}); err == nil {
 		t.Fatal("expected desktop rejection")
 	}
-	if err := b.Warmup(context.Background(), WarmupRequest{Options: core.LeaseOptions{Tailscale: core.TailscaleConfig{Enabled: true}}}); err == nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Options: core.LeaseOptions{Tailscale: core.TailscaleConfig{Enabled: true}}}); err == nil {
 		t.Fatal("expected tailscale rejection")
 	}
 }
@@ -196,24 +196,24 @@ func TestWarmupRejectsUnsupportedOptions(t *testing.T) {
 func TestRunRejectsUnsupportedOptionsAndMissingCommand(t *testing.T) {
 	isolateLeaseHome(t)
 	prev := newTransport
-	newTransport = func(Config, Runtime) (sandboxTransport, error) {
+	newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) {
 		return &fakeTransport{mode: "remote"}, nil
 	}
 	t.Cleanup(func() { newTransport = prev })
 
-	b := NewBackend(Provider{}.Spec(), Config{CloudRunSandbox: CloudRunSandboxConfig{
+	b := NewBackend(Provider{}.Spec(), core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{
 		CLIPath: "/usr/local/gcp/bin/sandbox",
 		Workdir: "/tmp/crabbox",
-	}, IdleTimeout: time.Minute}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	}, IdleTimeout: time.Minute}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
-	if _, err := b.Run(context.Background(), RunRequest{Options: core.LeaseOptions{Browser: true}}); err == nil {
+	if _, err := b.Run(context.Background(), core.RunRequest{Options: core.LeaseOptions{Browser: true}}); err == nil {
 		t.Fatal("expected browser rejection")
 	}
-	if _, err := b.Run(context.Background(), RunRequest{Options: core.LeaseOptions{Tailscale: core.TailscaleConfig{Enabled: true}}}); err == nil {
+	if _, err := b.Run(context.Background(), core.RunRequest{Options: core.LeaseOptions{Tailscale: core.TailscaleConfig{Enabled: true}}}); err == nil {
 		t.Fatal("expected tailscale rejection")
 	}
-	if _, err := b.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: t.TempDir()},
+	if _, err := b.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: t.TempDir()},
 		NoSync:  true,
 		Command: nil,
 	}); err == nil {
@@ -232,19 +232,19 @@ func TestDoctorListStopStatusCleanup(t *testing.T) {
 		},
 	}
 	prev := newTransport
-	newTransport = func(Config, Runtime) (sandboxTransport, error) { return fake, nil }
+	newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) { return fake, nil }
 	t.Cleanup(func() { newTransport = prev })
 
 	var stdout, stderr bytes.Buffer
-	cfg := Config{
-		CloudRunSandbox: CloudRunSandboxConfig{
+	cfg := core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{
 			GatewayURL: "https://gw.example.run.app",
 			CLIPath:    "/usr/local/gcp/bin/sandbox",
 			Workdir:    "/tmp/crabbox",
 		},
 		IdleTimeout: time.Minute,
 	}
-	b := NewBackend(Provider{}.Spec(), cfg, Runtime{Stdout: &stdout, Stderr: &stderr}).(*backend)
+	b := NewBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &stdout, Stderr: &stderr}).(*backend)
 
 	scope, err := b.claimScope()
 	if err != nil {
@@ -255,7 +255,7 @@ func TestDoctorListStopStatusCleanup(t *testing.T) {
 		t.Fatalf("claim: %v", err)
 	}
 
-	doctor, err := b.Doctor(context.Background(), DoctorRequest{})
+	doctor, err := b.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatalf("Doctor: %v", err)
 	}
@@ -263,7 +263,7 @@ func TestDoctorListStopStatusCleanup(t *testing.T) {
 		t.Fatalf("doctor=%#v", doctor)
 	}
 
-	leases, err := b.List(context.Background(), ListRequest{})
+	leases, err := b.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -271,7 +271,7 @@ func TestDoctorListStopStatusCleanup(t *testing.T) {
 		t.Fatalf("leases=%#v", leases)
 	}
 
-	status, err := b.Status(context.Background(), StatusRequest{ID: leaseID})
+	status, err := b.Status(context.Background(), core.StatusRequest{ID: leaseID})
 	if err != nil {
 		t.Fatalf("Status: %v", err)
 	}
@@ -280,20 +280,20 @@ func TestDoctorListStopStatusCleanup(t *testing.T) {
 	}
 
 	// Dry-run cleanup should not destroy while idle timeout remains.
-	if err := b.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
 		t.Fatalf("Cleanup dry-run: %v", err)
 	}
 	if len(destroyed) != 0 {
 		t.Fatalf("dry-run destroyed=%v", destroyed)
 	}
 
-	if err := b.Stop(context.Background(), StopRequest{ID: leaseID}); err != nil {
+	if err := b.Stop(context.Background(), core.StopRequest{ID: leaseID}); err != nil {
 		t.Fatalf("Stop: %v", err)
 	}
 	if len(destroyed) != 1 || destroyed[0] != "demo-box-1" {
 		t.Fatalf("destroyed=%v", destroyed)
 	}
-	if _, err := b.Status(context.Background(), StatusRequest{ID: leaseID}); err == nil {
+	if _, err := b.Status(context.Background(), core.StatusRequest{ID: leaseID}); err == nil {
 		t.Fatal("expected status failure after stop")
 	}
 }
@@ -302,7 +302,7 @@ func TestDoctorFailsWhenLocalClaimsAreUnreadable(t *testing.T) {
 	isolateLeaseHome(t)
 	fake := &fakeTransport{mode: "remote"}
 	previousTransport := newTransport
-	newTransport = func(Config, Runtime) (sandboxTransport, error) { return fake, nil }
+	newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) { return fake, nil }
 	t.Cleanup(func() { newTransport = previousTransport })
 	stateDir := filepath.Join(os.Getenv("XDG_STATE_HOME"), "crabbox")
 	if err := os.MkdirAll(stateDir, 0o700); err != nil {
@@ -311,10 +311,10 @@ func TestDoctorFailsWhenLocalClaimsAreUnreadable(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(stateDir, "claims"), []byte("not a directory"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{GatewayURL: "https://gw.example.run.app", CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
-	}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
-	result, err := b.Doctor(context.Background(), DoctorRequest{})
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{GatewayURL: "https://gw.example.run.app", CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox"},
+	}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	result, err := b.Doctor(context.Background(), core.DoctorRequest{})
 	if err == nil || result.Status != "error" || !strings.Contains(result.Message, "local_claims=blocked") {
 		t.Fatalf("doctor result=%#v err=%v", result, err)
 	}
@@ -323,31 +323,31 @@ func TestDoctorFailsWhenLocalClaimsAreUnreadable(t *testing.T) {
 func TestClaimCleanupDue(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
-	if due, reason := claimCleanupDue(LeaseClaim{}, now); due || reason != "no-idle-timeout" {
+	if due, reason := claimCleanupDue(core.LeaseClaim{}, now); due || reason != "no-idle-timeout" {
 		t.Fatalf("empty claim due=%v reason=%s", due, reason)
 	}
-	if due, reason := claimCleanupDue(LeaseClaim{IdleTimeoutSeconds: 60}, now); !due || reason != "missing-timestamps" {
+	if due, reason := claimCleanupDue(core.LeaseClaim{IdleTimeoutSeconds: 60}, now); !due || reason != "missing-timestamps" {
 		t.Fatalf("missing ts due=%v reason=%s", due, reason)
 	}
-	if due, reason := claimCleanupDue(LeaseClaim{
+	if due, reason := claimCleanupDue(core.LeaseClaim{
 		IdleTimeoutSeconds: 60,
 		LastUsedAt:         "not-a-time",
 	}, now); !due || reason != "unparseable-timestamp" {
 		t.Fatalf("bad ts due=%v reason=%s", due, reason)
 	}
-	if due, reason := claimCleanupDue(LeaseClaim{
+	if due, reason := claimCleanupDue(core.LeaseClaim{
 		IdleTimeoutSeconds: 3600,
 		LastUsedAt:         now.Add(-30 * time.Minute).Format(time.RFC3339),
 	}, now); due || reason != "idle-timeout-remaining" {
 		t.Fatalf("remaining due=%v reason=%s", due, reason)
 	}
-	if due, reason := claimCleanupDue(LeaseClaim{
+	if due, reason := claimCleanupDue(core.LeaseClaim{
 		IdleTimeoutSeconds: 60,
 		ClaimedAt:          now.Add(-2 * time.Hour).Format(time.RFC3339Nano),
 	}, now); !due || reason != "idle-timeout-expired" {
 		t.Fatalf("expired due=%v reason=%s", due, reason)
 	}
-	creating := LeaseClaim{Labels: map[string]string{
+	creating := core.LeaseClaim{Labels: map[string]string{
 		claimStateLabel:       "creating",
 		claimActiveUntilLabel: now.Add(time.Minute).Format(time.RFC3339Nano),
 		claimOwnershipLabel:   "sandbox-token",
@@ -373,19 +373,19 @@ func TestBuildCommandAndHelpers(t *testing.T) {
 	if err != nil || len(got) != 1 || got[0] != "echo hi" {
 		t.Fatalf("shell mode: %v %v", got, err)
 	}
-	directCleanup := cleanupCommand(Config{CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox"}}, "gcrs_x")
+	directCleanup := cleanupCommand(core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox"}}, "gcrs_x")
 	if directCleanup != `crabbox stop --provider cloud-run-sandbox --id 'gcrs_x'` {
 		t.Fatalf("cleanupCommand=%q", directCleanup)
 	}
-	remoteCleanup := cleanupCommand(Config{CloudRunSandbox: CloudRunSandboxConfig{GatewayURL: "https://gateway.example.run.app"}}, "gcrs_x")
+	remoteCleanup := cleanupCommand(core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{GatewayURL: "https://gateway.example.run.app"}}, "gcrs_x")
 	if !strings.Contains(remoteCleanup, "--cloud-run-sandbox-gateway-url 'https://gateway.example.run.app'") {
 		t.Fatalf("remote cleanupCommand=%q", remoteCleanup)
 	}
-	customDirectCleanup := cleanupCommand(Config{CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/opt/sandbox"}}, "gcrs_x")
+	customDirectCleanup := cleanupCommand(core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/opt/sandbox"}}, "gcrs_x")
 	if !strings.Contains(customDirectCleanup, "--cloud-run-sandbox-cli '/opt/sandbox'") {
 		t.Fatalf("custom direct cleanupCommand=%q", customDirectCleanup)
 	}
-	name, err := newSandboxName(Repo{Root: "/tmp/My Repo!"})
+	name, err := newSandboxName(core.Repo{Root: "/tmp/My Repo!"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -395,7 +395,7 @@ func TestBuildCommandAndHelpers(t *testing.T) {
 	if suffix := strings.TrimPrefix(name, "crabbox-my-repo-"); len(suffix) != sandboxNameSuffix*2 {
 		t.Fatalf("ownership suffix=%q len=%d", suffix, len(suffix))
 	}
-	longName, err := newSandboxName(Repo{Root: "/tmp/" + strings.Repeat("a", 100)})
+	longName, err := newSandboxName(core.Repo{Root: "/tmp/" + strings.Repeat("a", 100)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,10 +432,10 @@ func TestExecCommandAndUploadArchive(t *testing.T) {
 	}
 	transport := &writeCaptureTransport{fakeTransport: fake}
 
-	b := NewBackend(Provider{}.Spec(), Config{CloudRunSandbox: CloudRunSandboxConfig{
+	b := NewBackend(Provider{}.Spec(), core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{
 		CLIPath: "/usr/local/gcp/bin/sandbox",
 		Workdir: "/tmp/crabbox",
-	}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
 	if err := b.uploadArchive(context.Background(), transport, "box", "/tmp/a.tgz", strings.NewReader("payload")); err != nil {
 		t.Fatalf("uploadArchive: %v", err)
@@ -474,10 +474,10 @@ func TestUploadArchiveStreamsBoundedChunks(t *testing.T) {
 	transport := &writeCaptureTransport{fakeTransport: &fakeTransport{
 		onExec: func(string, string) (int, string, string, error) { return 0, "", "", nil },
 	}}
-	b := NewBackend(Provider{}.Spec(), Config{CloudRunSandbox: CloudRunSandboxConfig{
+	b := NewBackend(Provider{}.Spec(), core.Config{CloudRunSandbox: core.CloudRunSandboxConfig{
 		CLIPath: "/usr/local/gcp/bin/sandbox",
 		Workdir: "/tmp/crabbox",
-	}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 	if err := b.uploadArchive(context.Background(), transport, "box", "/tmp/large.tgz", strings.NewReader(input)); err != nil {
 		t.Fatal(err)
 	}
@@ -525,7 +525,7 @@ func TestRunSyncOnlyAndFailurePaths(t *testing.T) {
 		},
 	}
 	prev := newTransport
-	newTransport = func(Config, Runtime) (sandboxTransport, error) { return fake, nil }
+	newTransport = func(core.Config, core.Runtime) (sandboxTransport, error) { return fake, nil }
 	t.Cleanup(func() { newTransport = prev })
 
 	root := t.TempDir()
@@ -533,13 +533,13 @@ func TestRunSyncOnlyAndFailurePaths(t *testing.T) {
 		t.Fatal(err)
 	}
 	var stdout, stderr bytes.Buffer
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox", Write: true},
+	b := NewBackend(Provider{}.Spec(), core.Config{
+		CloudRunSandbox: core.CloudRunSandboxConfig{CLIPath: "/usr/local/gcp/bin/sandbox", Workdir: "/tmp/crabbox", Write: true},
 		IdleTimeout:     time.Minute,
-	}, Runtime{Stdout: &stdout, Stderr: &stderr}).(*backend)
+	}, core.Runtime{Stdout: &stdout, Stderr: &stderr}).(*backend)
 
-	result, err := b.Run(context.Background(), RunRequest{
-		Repo:     Repo{Root: root},
+	result, err := b.Run(context.Background(), core.RunRequest{
+		Repo:     core.Repo{Root: root},
 		NoSync:   true,
 		SyncOnly: true,
 		Keep:     true,
@@ -553,8 +553,8 @@ func TestRunSyncOnlyAndFailurePaths(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	result, err = b.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: root},
+	result, err = b.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: root},
 		Command: []string{"false"},
 		NoSync:  true,
 		Keep:    true,

--- a/internal/providers/cloudrunsandbox/sync.go
+++ b/internal/providers/cloudrunsandbox/sync.go
@@ -14,7 +14,7 @@ import (
 
 const archiveUploadChunkSize = 3 << 20
 
-func (b *backend) syncWorkspace(ctx context.Context, transport sandboxTransport, sandboxID string, req RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+func (b *backend) syncWorkspace(ctx context.Context, transport sandboxTransport, sandboxID string, req core.RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
@@ -57,7 +57,7 @@ func (b *backend) uploadArchive(ctx context.Context, transport sandboxTransport,
 	if err := errors.Join(copyErr, encodeErr, flushErr); err != nil {
 		return fmt.Errorf("cloud-run-sandbox upload archive: %w", err)
 	}
-	decode := fmt.Sprintf("base64 -d %s > %s && rm -f %s", shellQuote(b64Path), shellQuote(remoteArchive), shellQuote(b64Path))
+	decode := fmt.Sprintf("base64 -d %s > %s && rm -f %s", core.ShellQuote(b64Path), core.ShellQuote(remoteArchive), core.ShellQuote(b64Path))
 	return b.execShell(ctx, transport, sandboxID, decode)
 }
 
@@ -114,21 +114,21 @@ func (b *backend) execShell(ctx context.Context, transport sandboxTransport, san
 		return err
 	}
 	if code != 0 {
-		return exit(code, "cloud-run-sandbox exec %q exited %d", command, code)
+		return core.Exit(code, "cloud-run-sandbox exec %q exited %d", command, code)
 	}
 	return nil
 }
 
 func (b *backend) ensureWorkspace(ctx context.Context, transport sandboxTransport, sandboxID, workdir string) error {
-	return b.execShell(ctx, transport, sandboxID, "mkdir -p "+shellQuote(workdir))
+	return b.execShell(ctx, transport, sandboxID, "mkdir -p "+core.ShellQuote(workdir))
 }
 
 func (b *backend) execCommand(ctx context.Context, transport sandboxTransport, sandboxID, workdir string, command []string, env map[string]string, stdout, stderr io.Writer) (int, error) {
 	if len(command) == 0 {
-		return 2, exit(2, "missing command")
+		return 2, core.Exit(2, "missing command")
 	}
-	commandText := shellScriptFromArgv(command)
-	if len(command) == 1 && shouldUseShell(command) {
+	commandText := core.ShellScriptFromArgv(command)
+	if len(command) == 1 && core.ShouldUseShell(command) {
 		commandText = command[0]
 	}
 	return transport.Exec(ctx, sandboxID, commandText, execOptions{
@@ -140,7 +140,7 @@ func (b *backend) execCommand(ctx context.Context, transport sandboxTransport, s
 
 func buildCommand(command []string, shellMode bool) ([]string, error) {
 	if len(command) == 0 {
-		return nil, exit(2, "missing command")
+		return nil, core.Exit(2, "missing command")
 	}
 	if shellMode {
 		return []string{strings.Join(command, " ")}, nil

--- a/internal/providers/crownest/backend.go
+++ b/internal/providers/crownest/backend.go
@@ -19,19 +19,19 @@ import (
 const cleanupTimeout = 15 * time.Second
 const statusPollInterval = 250 * time.Millisecond
 
-func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	return &backend{spec: spec, cfg: cfg, rt: rt, newClient: newClient}
 }
 
 type backend struct {
-	spec      ProviderSpec
-	cfg       Config
-	rt        Runtime
-	newClient func(Config, Runtime) (client, error)
+	spec      core.ProviderSpec
+	cfg       core.Config
+	rt        core.Runtime
+	newClient func(core.Config, core.Runtime) (client, error)
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
 func (b *backend) client() (client, error) {
 	if b.newClient != nil {
@@ -40,26 +40,26 @@ func (b *backend) client() (client, error) {
 	return newClient(b.cfg, b.rt)
 }
 
-func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	api, err := b.client()
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
 	if err := api.Probe(ctx); err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return DoctorResult{
+	return core.DoctorResult{
 		Provider: providerName,
 		Message:  "auth=ready api=ready mutation=false runtime=ready",
 	}, nil
 }
 
-func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *backend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if req.ActionsRunner {
-		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+		return core.Exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
 	if req.Options.Tailscale.Enabled {
-		return exit(2, "provider=crownest is delegated-run only and does not support Tailscale options")
+		return core.Exit(2, "provider=crownest is delegated-run only and does not support Tailscale options")
 	}
 	started := core.ClockNow(b.rt.Clock)
 	api, err := b.client()
@@ -83,23 +83,23 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	})
 }
 
-func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {
-	if err := rejectDelegatedSyncOptionsForSpec(b.spec, req); err != nil {
-		return RunResult{}, err
+func (b *backend) Run(ctx context.Context, req core.RunRequest) (result core.RunResult, retErr error) {
+	if err := core.RejectDelegatedSyncOptionsForSpec(b.spec, req); err != nil {
+		return core.RunResult{}, err
 	}
 	if req.NoSync {
-		return RunResult{}, exit(2, "provider=crownest requires archive sync; --no-sync is not supported")
+		return core.RunResult{}, core.Exit(2, "provider=crownest requires archive sync; --no-sync is not supported")
 	}
 	if req.SyncOnly {
-		return RunResult{}, exit(2, "provider=crownest uses archive sync; --sync-only is not supported")
+		return core.RunResult{}, core.Exit(2, "provider=crownest uses archive sync; --sync-only is not supported")
 	}
 	if req.Options.Tailscale.Enabled {
-		return RunResult{}, exit(2, "provider=crownest is delegated-run only and does not support Tailscale options")
+		return core.RunResult{}, core.Exit(2, "provider=crownest is delegated-run only and does not support Tailscale options")
 	}
 	started := core.ClockNow(b.rt.Clock)
 	api, err := b.client()
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	scope := claimScope(api.BaseURL(), b.cfg)
 	leaseID, sandboxID, slug := "", "", ""
@@ -121,23 +121,23 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	if !acquired {
 		leaseID, _, _, err = resolveLeaseID(req.ID, "", false, 0, scope)
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 		unlockOperation, err = lockCrownestLeaseOperation(ctx, leaseID)
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 		leaseID, sandboxID, slug, err = resolveLeaseID(leaseID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout, scope)
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 		if _, err := api.GetSandbox(ctx, sandboxID); err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 	}
 	keepSandbox := false
 	shouldStop := acquired && !req.Keep
-	var syncPhases []timingPhase
+	var syncPhases []core.TimingPhase
 	var syncDuration time.Duration
 	var streamErr error
 	var cancelRunID string
@@ -176,7 +176,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		fmt.Fprintf(b.rt.Stderr, "crownest run summary sync=%s command=%s total=%s exit=%d\n",
 			syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
 		if req.TimingJSON {
-			appendFailure(writeTimingJSON(b.rt.Stderr, core.TimingReportWithRunResult(timingReport{
+			appendFailure(core.WriteTimingJSON(b.rt.Stderr, core.TimingReportWithRunResult(core.TimingReport{
 				Provider: providerName, LeaseID: leaseID, Slug: slug,
 				SyncDelegated: true, SyncMs: syncDuration.Milliseconds(), SyncPhases: syncPhases,
 				CommandMs: result.Command.Milliseconds(), TotalMs: result.Total.Milliseconds(),
@@ -186,7 +186,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	}()
 	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	commandText := intent.ShellCommand("bash", "-lc")
 	commandEnv, stripped := commandEnv(req.Env)
@@ -194,15 +194,15 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		fmt.Fprintf(b.rt.Stderr, "warning: provider=crownest did not forward provider authentication variables: %s\n", strings.Join(stripped, ","))
 	}
 	if len(commandEnv) > 0 {
-		return RunResult{}, exit(2, "provider=crownest does not support command environment forwarding yet; run without Crabbox env forwarding")
+		return core.RunResult{}, core.Exit(2, "provider=crownest does not support command environment forwarding yet; run without Crabbox env forwarding")
 	}
 	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
-		printEnvForwardingSummary(b.rt.Stderr, providerName, "not-forwarded", req.Options.EnvAllow, commandEnv)
+		core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "not-forwarded", req.Options.EnvAllow, commandEnv)
 	}
 	archive, archiveSHA, archiveBytes, phases, duration, err := b.prepareArchive(ctx, req)
 	syncPhases, syncDuration = phases, duration
 	if err != nil {
-		return RunResult{Total: core.ClockNow(b.rt.Clock).Sub(started), SyncDelegated: true}, err
+		return core.RunResult{Total: core.ClockNow(b.rt.Clock).Sub(started), SyncDelegated: true}, err
 	}
 	defer func() {
 		_ = archive.Close()
@@ -233,16 +233,16 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	}, idempotencyKey("create", shared.RandomSuffix()))
 	if err != nil {
 		if acquired && workspaceRun.SandboxID != "" {
-			return RunResult{}, b.cleanupCreateFailure(ctx, api, workspaceRun.SandboxID, err)
+			return core.RunResult{}, b.cleanupCreateFailure(ctx, api, workspaceRun.SandboxID, err)
 		}
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	if workspaceRun.SandboxID != "" {
 		sandboxID = workspaceRun.SandboxID
 	}
 	if acquired && sandboxID != "" {
 		if err := b.claimAcquiredSandbox(ctx, api, req, leaseID, sandboxID, slug, &leaseID, &slug); err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 		if err := lockAcquiredLease(); err != nil {
 			return b.setupFailure(ctx, req, api, err, started, acquired, leaseID, sandboxID, slug, &shouldStop)
@@ -253,10 +253,10 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		return b.setupFailure(ctx, req, api, err, started, acquired, leaseID, sandboxID, slug, &shouldStop)
 	}
 	if transfer.MaxSizeBytes > 0 && archiveBytes > transfer.MaxSizeBytes {
-		return b.setupFailure(ctx, req, api, exit(6, "crownest archive too large: %d > %d bytes", archiveBytes, transfer.MaxSizeBytes), started, acquired, leaseID, sandboxID, slug, &shouldStop)
+		return b.setupFailure(ctx, req, api, core.Exit(6, "crownest archive too large: %d > %d bytes", archiveBytes, transfer.MaxSizeBytes), started, acquired, leaseID, sandboxID, slug, &shouldStop)
 	}
 	if _, err := archive.Seek(0, io.SeekStart); err != nil {
-		return b.setupFailure(ctx, req, api, exit(6, "rewind sync archive: %v", err), started, acquired, leaseID, sandboxID, slug, &shouldStop)
+		return b.setupFailure(ctx, req, api, core.Exit(6, "rewind sync archive: %v", err), started, acquired, leaseID, sandboxID, slug, &shouldStop)
 	}
 	if err := api.UploadArchive(ctx, transfer, archive, archiveBytes); err != nil {
 		return b.setupFailure(ctx, req, api, err, started, acquired, leaseID, sandboxID, slug, &shouldStop)
@@ -273,7 +273,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	}
 	if acquired {
 		if err := b.claimAcquiredSandbox(ctx, api, req, leaseID, sandboxID, slug, &leaseID, &slug); err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 		if err := lockAcquiredLease(); err != nil {
 			return b.setupFailure(ctx, req, api, err, started, acquired, leaseID, sandboxID, slug, &shouldStop)
@@ -303,7 +303,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	} else if missingExitStatusFailure {
 		exitCode = 1
 	}
-	result = RunResult{
+	result = core.RunResult{
 		Provider:      providerName,
 		LeaseID:       leaseID,
 		Slug:          slug,
@@ -320,17 +320,17 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	case streamErr != nil:
 		retErr = shared.ExitErrorWithCause(1, fmt.Sprintf("crownest stream failed: %v", streamErr), streamErr)
 	case missingExitStatusFailure:
-		retErr = exit(5, "crownest workspace run ended status=%s reason=%s class=%s without command exit code", core.Blank(terminalStatus, "unknown"), core.Blank(terminal.FailureReason, "unknown"), core.Blank(terminal.FailureClass, "unknown"))
+		retErr = core.Exit(5, "crownest workspace run ended status=%s reason=%s class=%s without command exit code", core.Blank(terminalStatus, "unknown"), core.Blank(terminal.FailureReason, "unknown"), core.Blank(terminal.FailureClass, "unknown"))
 	case terminalStatus == "failed" && terminal.FailureReason != "command_exit":
-		retErr = exit(5, "crownest workspace run failed reason=%s class=%s", core.Blank(terminal.FailureReason, "unknown"), core.Blank(terminal.FailureClass, "unknown"))
+		retErr = core.Exit(5, "crownest workspace run failed reason=%s class=%s", core.Blank(terminal.FailureReason, "unknown"), core.Blank(terminal.FailureClass, "unknown"))
 	default:
 		result = core.FinalizeRunResult(result, nil)
 		if result.ExitCode != 0 {
-			retErr = ExitError{Code: result.ExitCode, Message: fmt.Sprintf("crownest run exited %d", result.ExitCode)}
+			retErr = core.ExitError{Code: result.ExitCode, Message: fmt.Sprintf("crownest run exited %d", result.ExitCode)}
 		}
 	}
 	if retErr != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		core.HandleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 		if result.Session != nil {
 			result.Session.Kept = !shouldStop
 		}
@@ -338,9 +338,9 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	return result, retErr
 }
 
-func (b *backend) claimAcquiredSandbox(ctx context.Context, api client, req RunRequest, currentLeaseID, sandboxID, currentSlug string, leaseID, slug *string) error {
+func (b *backend) claimAcquiredSandbox(ctx context.Context, api client, req core.RunRequest, currentLeaseID, sandboxID, currentSlug string, leaseID, slug *string) error {
 	if sandboxID == "" {
-		return exit(5, "crownest workspace run did not report a sandbox id")
+		return core.Exit(5, "crownest workspace run did not report a sandbox id")
 	}
 	nextLeaseID := leasePrefix + sandboxID
 	if currentLeaseID == nextLeaseID && currentSlug != "" {
@@ -349,13 +349,13 @@ func (b *backend) claimAcquiredSandbox(ctx context.Context, api client, req RunR
 		return nil
 	}
 	if currentLeaseID != "" && currentLeaseID != nextLeaseID {
-		return exit(5, "crownest workspace run changed sandbox id from %s to %s", strings.TrimPrefix(currentLeaseID, leasePrefix), sandboxID)
+		return core.Exit(5, "crownest workspace run changed sandbox id from %s to %s", strings.TrimPrefix(currentLeaseID, leasePrefix), sandboxID)
 	}
-	allocatedSlug, err := allocateClaimLeaseSlug(nextLeaseID, req.RequestedSlug)
+	allocatedSlug, err := core.AllocateClaimLeaseSlug(nextLeaseID, req.RequestedSlug)
 	if err != nil {
 		return b.cleanupCreateFailure(ctx, api, sandboxID, err)
 	}
-	if err := claimLeaseForRepoProviderScopePond(nextLeaseID, allocatedSlug, providerName, claimScope(api.BaseURL(), b.cfg), b.cfg.Pond, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(nextLeaseID, allocatedSlug, providerName, claimScope(api.BaseURL(), b.cfg), b.cfg.Pond, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim); err != nil {
 		return b.cleanupCreateFailure(ctx, api, sandboxID, err)
 	}
 	*leaseID = nextLeaseID
@@ -364,16 +364,16 @@ func (b *backend) claimAcquiredSandbox(ctx context.Context, api client, req RunR
 	return nil
 }
 
-func (b *backend) setupFailure(ctx context.Context, req RunRequest, api client, cause error, started time.Time, acquired bool, leaseID, sandboxID, slug string, shouldStop *bool) (RunResult, error) {
+func (b *backend) setupFailure(ctx context.Context, req core.RunRequest, api client, cause error, started time.Time, acquired bool, leaseID, sandboxID, slug string, shouldStop *bool) (core.RunResult, error) {
 	if acquired && sandboxID != "" && leaseID == "" {
 		if err := b.claimAcquiredSandbox(ctx, api, req, leaseID, sandboxID, slug, &leaseID, &slug); err != nil {
-			return RunResult{Provider: providerName, ExitCode: 1, Total: core.ClockNow(b.rt.Clock).Sub(started), SyncDelegated: true}, errors.Join(cause, err)
+			return core.RunResult{Provider: providerName, ExitCode: 1, Total: core.ClockNow(b.rt.Clock).Sub(started), SyncDelegated: true}, errors.Join(cause, err)
 		}
 	}
 	if leaseID != "" {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, shouldStop)
+		core.HandleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, shouldStop)
 	}
-	return RunResult{
+	return core.RunResult{
 		Provider:      providerName,
 		LeaseID:       leaseID,
 		Slug:          slug,
@@ -384,11 +384,11 @@ func (b *backend) setupFailure(ctx context.Context, req RunRequest, api client, 
 	}, cause
 }
 
-func (b *backend) crownestRunSession(leaseID, slug string, reused, kept bool) *RunSessionHandle {
+func (b *backend) crownestRunSession(leaseID, slug string, reused, kept bool) *core.RunSessionHandle {
 	if leaseID == "" {
 		return nil
 	}
-	return &RunSessionHandle{
+	return &core.RunSessionHandle{
 		Provider:       providerName,
 		LeaseID:        leaseID,
 		Slug:           slug,
@@ -398,15 +398,15 @@ func (b *backend) crownestRunSession(leaseID, slug string, reused, kept bool) *R
 	}
 }
 
-func crownestCleanupCommand(cfg Config, id string) string {
+func crownestCleanupCommand(cfg core.Config, id string) string {
 	return "crabbox stop --provider " + providerName +
-		" --crownest-url " + shellQuote(cfg.Crownest.APIURL) +
-		" --crownest-project-id " + shellQuote(cfg.Crownest.ProjectID) +
-		" --crownest-template " + shellQuote(cfg.Crownest.Template) +
-		" --id " + shellQuote(id)
+		" --crownest-url " + core.ShellQuote(cfg.Crownest.APIURL) +
+		" --crownest-project-id " + core.ShellQuote(cfg.Crownest.ProjectID) +
+		" --crownest-template " + core.ShellQuote(cfg.Crownest.Template) +
+		" --id " + core.ShellQuote(id)
 }
 
-func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	api, err := b.client()
 	if err != nil {
 		return nil, err
@@ -415,7 +415,7 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 	if err != nil {
 		return nil, err
 	}
-	views := make([]LeaseView, 0, len(claims))
+	views := make([]core.LeaseView, 0, len(claims))
 	scope := claimScope(api.BaseURL(), b.cfg)
 	for _, claim := range claims {
 		if claim.Provider != providerName || claim.ProviderScope != scope {
@@ -439,14 +439,14 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 	return views, nil
 }
 
-func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	api, err := b.client()
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	leaseID, sandboxID, slug, err := resolveLeaseID(req.ID, "", false, 0, claimScope(api.BaseURL(), b.cfg))
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	waitTimeout := req.WaitTimeout
 	if waitTimeout <= 0 {
@@ -462,15 +462,15 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 		sb, getErr := api.GetSandbox(pollCtx, sandboxID)
 		if getErr != nil {
 			if req.Wait && ctx.Err() == nil && pollCtx.Err() != nil {
-				return StatusView{}, exit(5, "timed out waiting for crownest sandbox %s to become ready", sandboxID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for crownest sandbox %s to become ready", sandboxID)
 			}
 			if ctx.Err() != nil {
-				return StatusView{}, ctx.Err()
+				return core.StatusView{}, ctx.Err()
 			}
-			return StatusView{}, getErr
+			return core.StatusView{}, getErr
 		}
 		state := normalizedSandboxState(sb)
-		view := StatusView{
+		view := core.StatusView{
 			ID:       leaseID,
 			Slug:     slug,
 			Provider: providerName,
@@ -489,20 +489,20 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 			return view, nil
 		}
 		if isTerminalState(state) {
-			return StatusView{}, exit(5, "crownest sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
+			return core.StatusView{}, core.Exit(5, "crownest sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
 		select {
 		case <-pollCtx.Done():
 			if ctx.Err() == nil {
-				return StatusView{}, exit(5, "timed out waiting for crownest sandbox %s to become ready", sandboxID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for crownest sandbox %s to become ready", sandboxID)
 			}
-			return StatusView{}, pollCtx.Err()
+			return core.StatusView{}, pollCtx.Err()
 		case <-time.After(statusPollInterval):
 		}
 	}
 }
 
-func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+func (b *backend) Stop(ctx context.Context, req core.StopRequest) error {
 	api, err := b.client()
 	if err != nil {
 		return err
@@ -526,12 +526,12 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 		}
 		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing crownest sandbox=%s after explicit request\n", sandboxID)
 	}
-	removeLeaseClaim(leaseID)
+	core.RemoveLeaseClaim(leaseID)
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, sandboxID)
 	return nil
 }
 
-func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
+func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	api, err := b.client()
 	if err != nil {
 		return err
@@ -556,7 +556,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 				return err
 			}
 			defer unlockOperation()
-			claim, err := readLeaseClaim(listed.LeaseID)
+			claim, err := core.ReadLeaseClaim(listed.LeaseID)
 			if err != nil {
 				return err
 			}
@@ -578,7 +578,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 					return nil
 				}
-				if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+				if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 					return err
 				}
 				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
@@ -597,7 +597,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			if err := api.DeleteSandbox(ctx, sandboxID); err != nil && !isNotFound(err) {
 				return err
 			}
-			if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+			if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 				return err
 			}
 			fmt.Fprintf(b.rt.Stdout, "delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
@@ -623,7 +623,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	return nil
 }
 
-func (b *backend) createSandbox(ctx context.Context, api client, repo Repo, reclaim bool, requestedSlug string) (string, string, string, error) {
+func (b *backend) createSandbox(ctx context.Context, api client, repo core.Repo, reclaim bool, requestedSlug string) (string, string, string, error) {
 	sb, err := api.CreateSandbox(ctx, createSandboxRequest{
 		ProjectID: strings.TrimSpace(b.cfg.Crownest.ProjectID),
 		Template:  strings.TrimSpace(b.cfg.Crownest.Template),
@@ -637,11 +637,11 @@ func (b *backend) createSandbox(ctx context.Context, api client, repo Repo, recl
 		return "", "", "", err
 	}
 	leaseID := leasePrefix + sb.ID
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return leaseID, sb.ID, "", b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
-	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, claimScope(api.BaseURL(), b.cfg), b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, providerName, claimScope(api.BaseURL(), b.cfg), b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
 		return leaseID, sb.ID, slug, b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
 	return leaseID, sb.ID, slug, nil
@@ -659,7 +659,7 @@ func (b *backend) cleanupCreateFailure(ctx context.Context, api client, sandboxI
 	return cause
 }
 
-func (b *backend) prepareArchive(ctx context.Context, req RunRequest) (*os.File, string, int64, []timingPhase, time.Duration, error) {
+func (b *backend) prepareArchive(ctx context.Context, req core.RunRequest) (*os.File, string, int64, []core.TimingPhase, time.Duration, error) {
 	start := core.ClockNow(b.rt.Clock)
 	syncCtx := ctx
 	cancel := func() {}
@@ -667,23 +667,23 @@ func (b *backend) prepareArchive(ctx context.Context, req RunRequest) (*os.File,
 		syncCtx, cancel = context.WithTimeout(ctx, b.cfg.Sync.Timeout)
 	}
 	defer cancel()
-	excludes, err := syncExcludes(req.Repo.Root, b.cfg)
+	excludes, err := core.SyncExcludes(req.Repo.Root, b.cfg)
 	if err != nil {
 		return nil, "", 0, nil, 0, err
 	}
 	manifestStart := core.ClockNow(b.rt.Clock)
-	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
+	manifest, err := core.BuildSyncManifestFiltered(req.Repo.Root, excludes, b.cfg.Sync.Includes)
 	if err != nil {
-		return nil, "", 0, nil, 0, exit(6, "build sync file list: %v", err)
+		return nil, "", 0, nil, 0, core.Exit(6, "build sync file list: %v", err)
 	}
 	manifestDuration := core.ClockNow(b.rt.Clock).Sub(manifestStart)
 	preflightStart := core.ClockNow(b.rt.Clock)
-	if err := checkSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
+	if err := core.CheckSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
 		return nil, "", 0, nil, 0, err
 	}
 	preflightDuration := core.ClockNow(b.rt.Clock).Sub(preflightStart)
 	archiveStart := core.ClockNow(b.rt.Clock)
-	archive, err := createPortableSyncArchive(syncCtx, req.Repo, manifest, "crabbox-crownest-sync-*.tgz")
+	archive, err := core.CreateSyncArchive(syncCtx, req.Repo, manifest, "crabbox-crownest-sync-*.tgz")
 	if err != nil {
 		return nil, "", 0, nil, 0, err
 	}
@@ -695,7 +695,7 @@ func (b *backend) prepareArchive(ctx context.Context, req RunRequest) (*os.File,
 		return nil, "", 0, nil, 0, err
 	}
 	total := core.ClockNow(b.rt.Clock).Sub(start)
-	return archive, sum, size, []timingPhase{
+	return archive, sum, size, []core.TimingPhase{
 		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
 		{Name: "preflight", Ms: preflightDuration.Milliseconds()},
 		{Name: "archive", Ms: archiveDuration.Milliseconds()},
@@ -705,15 +705,15 @@ func (b *backend) prepareArchive(ctx context.Context, req RunRequest) (*os.File,
 
 func hashArchive(file *os.File) (string, int64, error) {
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
-		return "", 0, exit(6, "rewind sync archive: %v", err)
+		return "", 0, core.Exit(6, "rewind sync archive: %v", err)
 	}
 	h := sha256.New()
 	size, err := io.Copy(h, file)
 	if err != nil {
-		return "", 0, exit(6, "hash sync archive: %v", err)
+		return "", 0, core.Exit(6, "hash sync archive: %v", err)
 	}
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
-		return "", 0, exit(6, "rewind sync archive: %v", err)
+		return "", 0, core.Exit(6, "rewind sync archive: %v", err)
 	}
 	return hex.EncodeToString(h.Sum(nil)), size, nil
 }
@@ -738,7 +738,7 @@ func (b *backend) streamRun(ctx context.Context, api client, workspaceRunID stri
 			case "terminal":
 				terminal = event.WorkspaceRun
 			case "error":
-				return exit(5, "crownest event error %s: %s", core.Blank(event.Code, "error"), event.Message)
+				return core.Exit(5, "crownest event error %s: %s", core.Blank(event.Code, "error"), event.Message)
 			}
 			return nil
 		})
@@ -750,7 +750,7 @@ func (b *backend) streamRun(ctx context.Context, api client, workspaceRunID stri
 			return workspaceRun{}, err
 		}
 	}
-	return workspaceRun{}, exit(5, "crownest event stream ended before terminal event")
+	return workspaceRun{}, core.Exit(5, "crownest event stream ended before terminal event")
 }
 
 func (b *backend) cleanupCreatedRun(ctx context.Context, api client, leaseID, sandboxID string, deleteSandbox bool, shouldStop *bool) error {
@@ -766,7 +766,7 @@ func (b *backend) cleanupCreatedRun(ctx context.Context, api client, leaseID, sa
 		}
 	}
 	if leaseID != "" {
-		removeLeaseClaim(leaseID)
+		core.RemoveLeaseClaim(leaseID)
 	}
 	return nil
 }
@@ -774,49 +774,49 @@ func (b *backend) cleanupCreatedRun(ctx context.Context, api client, leaseID, sa
 func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration, scope string) (string, string, string, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return "", "", "", exit(2, "provider=crownest requires a Crabbox-created sandbox slug or lease id")
+		return "", "", "", core.Exit(2, "provider=crownest requires a Crabbox-created sandbox slug or lease id")
 	}
 	exactLeaseID := id
 	if !strings.HasPrefix(exactLeaseID, leasePrefix) {
 		exactLeaseID = leasePrefix + exactLeaseID
 	}
-	if claim, err := readLeaseClaim(exactLeaseID); err == nil && claim.LeaseID == exactLeaseID && claim.Provider == providerName {
+	if claim, err := core.ReadLeaseClaim(exactLeaseID); err == nil && claim.LeaseID == exactLeaseID && claim.Provider == providerName {
 		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, scope)
 	}
 	claims, err := listCrownestLeaseClaims()
 	if err != nil {
 		return "", "", "", err
 	}
-	slug := normalizeLeaseSlug(id)
+	slug := core.NormalizeLeaseSlug(id)
 	for _, claim := range claims {
 		if claim.Provider != providerName {
 			continue
 		}
-		if claim.LeaseID == id || normalizeLeaseSlug(claim.Slug) == slug {
+		if claim.LeaseID == id || core.NormalizeLeaseSlug(claim.Slug) == slug {
 			return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, scope)
 		}
 	}
-	return "", "", "", exit(4, "crownest sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
+	return "", "", "", core.Exit(4, "crownest sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
 }
 
-func finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration, scope string) (string, string, string, error) {
+func finishResolvedLease(claim core.LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration, scope string) (string, string, string, error) {
 	if claim.ProviderScope != scope {
-		return "", "", "", exit(4, "crownest lease %q belongs to a different API endpoint, project, or template", claim.LeaseID)
+		return "", "", "", core.Exit(4, "crownest lease %q belongs to a different API endpoint, project, or template", claim.LeaseID)
 	}
 	if repoRoot != "" {
-		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, repoRoot, timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
+		if err := core.ClaimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, repoRoot, timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
 			return "", "", "", err
 		}
 	}
 	slug := claim.Slug
 	if strings.TrimSpace(slug) == "" {
-		slug = newLeaseSlug(claim.LeaseID)
+		slug = core.NewLeaseSlug(claim.LeaseID)
 	}
 	return claim.LeaseID, sandboxIDFromLease(claim.LeaseID), slug, nil
 }
 
-func serverFromClaim(claim LeaseClaim, state string) Server {
-	return Server{
+func serverFromClaim(claim core.LeaseClaim, state string) core.Server {
+	return core.Server{
 		Provider: providerName,
 		CloudID:  sandboxIDFromLease(claim.LeaseID),
 		Name:     sandboxIDFromLease(claim.LeaseID),
@@ -836,7 +836,7 @@ func sandboxIDFromLease(leaseID string) string {
 	return strings.TrimPrefix(leaseID, leasePrefix)
 }
 
-func claimScope(baseURL string, cfg Config) string {
+func claimScope(baseURL string, cfg core.Config) string {
 	return strings.Join([]string{
 		"endpoint:" + strings.TrimSpace(baseURL),
 		"project:" + strings.TrimSpace(cfg.Crownest.ProjectID),
@@ -874,7 +874,7 @@ func isProviderAuthEnv(name string) bool {
 		strings.HasPrefix(name, "CROWNEST_")
 }
 
-func crownestClaimCleanupDue(claim LeaseClaim, now time.Time) (bool, string) {
+func crownestClaimCleanupDue(claim core.LeaseClaim, now time.Time) (bool, string) {
 	if claim.IdleTimeoutSeconds <= 0 {
 		return false, "idle-timeout-disabled"
 	}
@@ -900,7 +900,7 @@ func timeoutMS(timeoutSecs int) int64 {
 	return int64(timeoutSecs) * int64(time.Second/time.Millisecond)
 }
 
-func ttlMS(cfg Config) int64 {
+func ttlMS(cfg core.Config) int64 {
 	if cfg.TTL <= 0 {
 		return 0
 	}
@@ -949,7 +949,7 @@ func normalizedWorkspaceRunStatus(status string) string {
 	return strings.TrimSpace(strings.ToLower(status))
 }
 
-func repoName(repo Repo) string {
+func repoName(repo core.Repo) string {
 	if strings.TrimSpace(repo.Name) != "" {
 		return repo.Name
 	}

--- a/internal/providers/crownest/backend_test.go
+++ b/internal/providers/crownest/backend_test.go
@@ -26,15 +26,15 @@ func TestRunUploadsArchiveStreamsLogsAndCleansUp(t *testing.T) {
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt: Runtime{
+		rt: core.Runtime{
 			Stdout: &stdout,
 			Stderr: &stderr,
 		},
-		newClient: func(Config, Runtime) (client, error) { return api, nil },
+		newClient: func(core.Config, core.Runtime) (client, error) { return api, nil },
 	}
 
-	result, err := b.Run(context.Background(), RunRequest{
-		Repo:               Repo{Root: repoRoot, Name: "demo"},
+	result, err := b.Run(context.Background(), core.RunRequest{
+		Repo:               core.Repo{Root: repoRoot, Name: "demo"},
 		Command:            []string{"pnpm", "test", "&&"},
 		CommandLiteralArgs: map[int]bool{2: true},
 	})
@@ -67,7 +67,7 @@ func TestRunUploadsArchiveStreamsLogsAndCleansUp(t *testing.T) {
 	if strings.Contains(stderr.String(), "cn_test") {
 		t.Fatalf("stderr leaked secret: %q", stderr.String())
 	}
-	if claim, err := readLeaseClaim(result.LeaseID); err != nil || claim.LeaseID != "" {
+	if claim, err := core.ReadLeaseClaim(result.LeaseID); err != nil || claim.LeaseID != "" {
 		t.Fatalf("claim=%#v err=%v, want one-shot local claim removed without sandbox delete", claim, err)
 	}
 	if result.CommandText != "'pnpm' 'test' '&&'" {
@@ -82,12 +82,12 @@ func (c *crownestOutcomeClock) Sleep(d time.Duration) { c.current = c.current.Ad
 
 type crownestOutcomeWriter struct {
 	bytes.Buffer
-	report *timingReport
+	report *core.TimingReport
 	err    error
 	onTime func()
 }
 
-func (w *crownestOutcomeWriter) WriteTimingReport(report timingReport) error {
+func (w *crownestOutcomeWriter) WriteTimingReport(report core.TimingReport) error {
 	if w.onTime != nil {
 		w.onTime()
 	}
@@ -100,7 +100,7 @@ func TestRunFinalizesCrownestOutcomesAfterTerminalActions(t *testing.T) {
 	deleteFailure := errors.New("delete failed")
 	cancelFailure := errors.New("cancel failed")
 	writerFailure := errors.New("timing writer failed")
-	typedCleanupFailure := &apiError{StatusCode: 503, err: exit(5, "typed cleanup provider failure")}
+	typedCleanupFailure := &apiError{StatusCode: 503, err: core.Exit(5, "typed cleanup provider failure")}
 	for _, tc := range []struct {
 		name        string
 		terminal    string
@@ -157,7 +157,7 @@ func TestRunFinalizesCrownestOutcomesAfterTerminalActions(t *testing.T) {
 				if _, ok := cleanupCtx.Deadline(); !ok {
 					t.Error("cancellation request has no deadline")
 				}
-				claim, err := readLeaseClaim(leasePrefix + "sbx_123")
+				claim, err := core.ReadLeaseClaim(leasePrefix + "sbx_123")
 				if err != nil || claim.LeaseID == "" {
 					t.Errorf("claim retired before cancellation attempt: claim=%+v err=%v", claim, err)
 				}
@@ -195,8 +195,8 @@ func TestRunFinalizesCrownestOutcomesAfterTerminalActions(t *testing.T) {
 					t.Errorf("timing emitted before cancellation: calls=%d", cancelCalls)
 				}
 			}
-			b := &backend{spec: Provider{}.Spec(), cfg: testConfig(), rt: Runtime{Stdout: io.Discard, Stderr: writer, Clock: clock}, newClient: func(Config, Runtime) (client, error) { return api, nil }}
-			result, err := b.Run(ctx, RunRequest{Repo: Repo{Root: tempGitRepo(t), Name: "demo"}, Command: []string{"true"}, Keep: tc.keep, KeepOnFailure: tc.keepFailure, TimingJSON: true})
+			b := &backend{spec: Provider{}.Spec(), cfg: testConfig(), rt: core.Runtime{Stdout: io.Discard, Stderr: writer, Clock: clock}, newClient: func(core.Config, core.Runtime) (client, error) { return api, nil }}
+			result, err := b.Run(ctx, core.RunRequest{Repo: core.Repo{Root: tempGitRepo(t), Name: "demo"}, Command: []string{"true"}, Keep: tc.keep, KeepOnFailure: tc.keepFailure, TimingJSON: true})
 			final := core.FinalizeRunResult(result, err)
 			if final.ExitCode != tc.wantCode || final.Status != tc.wantStatus || final.ErrorKind != tc.wantKind {
 				t.Errorf("outcome=(%d,%s,%s), want (%d,%s,%s); error=%v", final.ExitCode, final.Status, final.ErrorKind, tc.wantCode, tc.wantStatus, tc.wantKind, err)
@@ -205,7 +205,7 @@ func TestRunFinalizesCrownestOutcomesAfterTerminalActions(t *testing.T) {
 				t.Errorf("success error=%v", err)
 			}
 			if tc.wantCode != 0 {
-				var public ExitError
+				var public core.ExitError
 				if !errors.As(err, &public) || public.Code != tc.wantCode {
 					t.Errorf("public error=%v, want code %d", err, tc.wantCode)
 				}
@@ -218,7 +218,7 @@ func TestRunFinalizesCrownestOutcomesAfterTerminalActions(t *testing.T) {
 			if result.Session == nil || result.Session.Kept != tc.wantKept {
 				t.Errorf("session=%+v, want kept=%v", result.Session, tc.wantKept)
 			}
-			claim, claimErr := readLeaseClaim(result.LeaseID)
+			claim, claimErr := core.ReadLeaseClaim(result.LeaseID)
 			if claimErr != nil || (claim.LeaseID != "") != tc.wantKept {
 				t.Errorf("claim=%+v err=%v, want retained=%v", claim, claimErr, tc.wantKept)
 			}
@@ -243,11 +243,11 @@ func TestRunFinalizesCrownestOutcomesAfterTerminalActions(t *testing.T) {
 func TestRunPreservesFirstTypedTimingWriterFailure(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	api := &fakeCrownestClient{baseURL: "https://api.crownest.dev"}
-	writerFailure := exit(69, "typed timing writer failure")
+	writerFailure := core.Exit(69, "typed timing writer failure")
 	writer := &crownestOutcomeWriter{err: writerFailure}
-	b := &backend{spec: Provider{}.Spec(), cfg: testConfig(), rt: Runtime{Stdout: io.Discard, Stderr: writer}, newClient: func(Config, Runtime) (client, error) { return api, nil }}
-	result, err := b.Run(context.Background(), RunRequest{Repo: Repo{Root: tempGitRepo(t), Name: "demo"}, Command: []string{"true"}, TimingJSON: true})
-	var public ExitError
+	b := &backend{spec: Provider{}.Spec(), cfg: testConfig(), rt: core.Runtime{Stdout: io.Discard, Stderr: writer}, newClient: func(core.Config, core.Runtime) (client, error) { return api, nil }}
+	result, err := b.Run(context.Background(), core.RunRequest{Repo: core.Repo{Root: tempGitRepo(t), Name: "demo"}, Command: []string{"true"}, TimingJSON: true})
+	var public core.ExitError
 	if !errors.As(err, &public) || public.Code != 69 || !errors.Is(err, writerFailure) {
 		t.Errorf("typed writer failure changed: result=%+v error=%v", result, err)
 	}
@@ -271,14 +271,14 @@ func TestRunCleanupCommandIncludesCrownestScopeFlags(t *testing.T) {
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt:   Runtime{Stdout: io.Discard, Stderr: io.Discard},
-		newClient: func(Config, Runtime) (client, error) {
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		newClient: func(core.Config, core.Runtime) (client, error) {
 			return api, nil
 		},
 	}
 
-	result, err := b.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: repoRoot, Name: "demo"},
+	result, err := b.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: repoRoot, Name: "demo"},
 		Command: []string{"pnpm", "test"},
 		Keep:    true,
 	})
@@ -308,14 +308,14 @@ func TestRunMarksSessionKeptWhenRetainedCleanupFails(t *testing.T) {
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  testConfig(),
-		rt:   Runtime{Stdout: io.Discard, Stderr: io.Discard},
-		newClient: func(Config, Runtime) (client, error) {
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		newClient: func(core.Config, core.Runtime) (client, error) {
 			return api, nil
 		},
 	}
 
-	result, err := b.Run(context.Background(), RunRequest{
-		Repo:          Repo{Root: repoRoot, Name: "demo"},
+	result, err := b.Run(context.Background(), core.RunRequest{
+		Repo:          core.Repo{Root: repoRoot, Name: "demo"},
 		Command:       []string{"pnpm", "test"},
 		KeepOnFailure: true,
 	})
@@ -335,13 +335,13 @@ func TestRunRejectsWorkspaceEnvUntilCrownestSupportsIt(t *testing.T) {
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  testConfig(),
-		rt:   Runtime{Stdout: io.Discard, Stderr: io.Discard},
-		newClient: func(Config, Runtime) (client, error) {
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		newClient: func(core.Config, core.Runtime) (client, error) {
 			return &fakeCrownestClient{baseURL: "https://api.crownest.dev"}, nil
 		},
 	}
-	_, err := b.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: tempGitRepo(t), Name: "demo"},
+	_, err := b.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: tempGitRepo(t), Name: "demo"},
 		Command: []string{"printenv", "FOO"},
 		Env:     map[string]string{"FOO": "bar"},
 	})
@@ -356,14 +356,14 @@ func TestRunDistinguishesFrameworkMetadataFromUnsupportedUserEnv(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			api := &fakeCrownestClient{baseURL: "https://api.crownest.dev"}
 			var stderr bytes.Buffer
-			b := &backend{spec: Provider{}.Spec(), cfg: testConfig(), rt: Runtime{Stdout: io.Discard, Stderr: &stderr}, newClient: func(Config, Runtime) (client, error) { return api, nil }}
+			b := &backend{spec: Provider{}.Spec(), cfg: testConfig(), rt: core.Runtime{Stdout: io.Discard, Stderr: &stderr}, newClient: func(core.Config, core.Runtime) (client, error) { return api, nil }}
 			env := map[string]string{"CRABBOX_LEASE_ID": "framework-lease", "crabbox_run_id": "framework-run", "CrAbBoX_SlUg": "framework-slug", "CROWNEST_API_KEY": "fixture-auth"}
 			if userName != "" {
 				env[userName] = "user-value"
 			}
-			_, err := b.Run(context.Background(), RunRequest{Repo: Repo{Root: tempGitRepo(t), Name: "demo"}, Command: []string{"true"}, Env: env})
+			_, err := b.Run(context.Background(), core.RunRequest{Repo: core.Repo{Root: tempGitRepo(t), Name: "demo"}, Command: []string{"true"}, Env: env})
 			if userName != "" {
-				var public ExitError
+				var public core.ExitError
 				if !errors.As(err, &public) || public.Code != 2 || !strings.Contains(err.Error(), "does not support command environment forwarding") || api.created.Command != "" {
 					t.Fatalf("unsupported user env admitted: error=%v request=%+v", err, api.created)
 				}
@@ -391,15 +391,15 @@ func TestRunRejectsSyncOnlyBeforeCreatingWorkspaceRun(t *testing.T) {
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  testConfig(),
-		rt:   Runtime{Stdout: io.Discard, Stderr: io.Discard},
-		newClient: func(Config, Runtime) (client, error) {
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		newClient: func(core.Config, core.Runtime) (client, error) {
 			calledClient = true
 			return &fakeCrownestClient{baseURL: "https://api.crownest.dev"}, nil
 		},
 	}
 
-	_, err := b.Run(context.Background(), RunRequest{
-		Repo:     Repo{Root: tempGitRepo(t), Name: "demo"},
+	_, err := b.Run(context.Background(), core.RunRequest{
+		Repo:     core.Repo{Root: tempGitRepo(t), Name: "demo"},
 		Command:  []string{"echo", "should-not-run"},
 		SyncOnly: true,
 	})
@@ -426,14 +426,14 @@ func TestRunCancelsWorkspaceRunWhenLocalContextIsCanceled(t *testing.T) {
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  testConfig(),
-		rt:   Runtime{Stdout: io.Discard, Stderr: io.Discard},
-		newClient: func(Config, Runtime) (client, error) {
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		newClient: func(core.Config, core.Runtime) (client, error) {
 			return api, nil
 		},
 	}
 
-	_, err := b.Run(ctx, RunRequest{
-		Repo:    Repo{Root: repoRoot, Name: "demo"},
+	_, err := b.Run(ctx, core.RunRequest{
+		Repo:    core.Repo{Root: repoRoot, Name: "demo"},
 		Command: []string{"pnpm", "test"},
 		Keep:    true,
 	})
@@ -459,14 +459,14 @@ func TestRunCancelsWorkspaceRunWhenStreamFailsBeforeTerminal(t *testing.T) {
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  testConfig(),
-		rt:   Runtime{Stdout: io.Discard, Stderr: io.Discard},
-		newClient: func(Config, Runtime) (client, error) {
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		newClient: func(core.Config, core.Runtime) (client, error) {
 			return api, nil
 		},
 	}
 
-	result, err := b.Run(context.Background(), RunRequest{
-		Repo:          Repo{Root: repoRoot, Name: "demo"},
+	result, err := b.Run(context.Background(), core.RunRequest{
+		Repo:          core.Repo{Root: repoRoot, Name: "demo"},
 		Command:       []string{"pnpm", "test"},
 		KeepOnFailure: true,
 	})
@@ -490,20 +490,20 @@ func TestRunReusesClaimWithoutDeletingSandbox(t *testing.T) {
 	cfg := testConfig()
 	api := &fakeCrownestClient{baseURL: "https://api.crownest.dev", startSandboxID: "sbx_reused"}
 	leaseID := leasePrefix + "sbx_reused"
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "kept", providerName, claimScope(api.BaseURL(), cfg), cfg.Pond, repoRoot, cfg.IdleTimeout, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "kept", providerName, claimScope(api.BaseURL(), cfg), cfg.Pond, repoRoot, cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt:   Runtime{Stdout: io.Discard, Stderr: io.Discard},
-		newClient: func(Config, Runtime) (client, error) {
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		newClient: func(core.Config, core.Runtime) (client, error) {
 			return api, nil
 		},
 	}
 
-	result, err := b.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: repoRoot, Name: "demo"},
+	result, err := b.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: repoRoot, Name: "demo"},
 		ID:      "kept",
 		Command: []string{"pnpm", "test"},
 	})
@@ -527,7 +527,7 @@ func TestRunReuseHonorsOperationLock(t *testing.T) {
 	cfg := testConfig()
 	api := &fakeCrownestClient{baseURL: "https://api.crownest.dev", startSandboxID: "sbx_reused"}
 	leaseID := leasePrefix + "sbx_reused"
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "kept", providerName, claimScope(api.BaseURL(), cfg), cfg.Pond, repoRoot, cfg.IdleTimeout, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "kept", providerName, claimScope(api.BaseURL(), cfg), cfg.Pond, repoRoot, cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
 	unlock, err := lockCrownestLeaseOperation(context.Background(), leaseID)
@@ -538,16 +538,16 @@ func TestRunReuseHonorsOperationLock(t *testing.T) {
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt:   Runtime{Stdout: io.Discard, Stderr: io.Discard},
-		newClient: func(Config, Runtime) (client, error) {
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		newClient: func(core.Config, core.Runtime) (client, error) {
 			return api, nil
 		},
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
-	_, err = b.Run(ctx, RunRequest{
-		Repo:    Repo{Root: repoRoot, Name: "demo"},
+	_, err = b.Run(ctx, core.RunRequest{
+		Repo:    core.Repo{Root: repoRoot, Name: "demo"},
 		ID:      "kept",
 		Command: []string{"pnpm", "test"},
 	})
@@ -568,20 +568,20 @@ func TestStatusWaitPollsUntilSandboxReady(t *testing.T) {
 		getSandboxStates: []string{"starting", "running"},
 	}
 	leaseID := leasePrefix + "sbx_123"
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "status-wait", providerName, claimScope(api.BaseURL(), cfg), cfg.Pond, repoRoot, cfg.IdleTimeout, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "status-wait", providerName, claimScope(api.BaseURL(), cfg), cfg.Pond, repoRoot, cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { removeLeaseClaim(leaseID) })
+	t.Cleanup(func() { core.RemoveLeaseClaim(leaseID) })
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt:   Runtime{Stdout: io.Discard, Stderr: io.Discard},
-		newClient: func(Config, Runtime) (client, error) {
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		newClient: func(core.Config, core.Runtime) (client, error) {
 			return api, nil
 		},
 	}
 
-	view, err := b.Status(context.Background(), StatusRequest{ID: "status-wait", Wait: true, WaitTimeout: time.Second})
+	view, err := b.Status(context.Background(), core.StatusRequest{ID: "status-wait", Wait: true, WaitTimeout: time.Second})
 	if err != nil {
 		t.Fatalf("Status err=%v", err)
 	}
@@ -599,7 +599,7 @@ func TestStopHonorsOperationLock(t *testing.T) {
 	cfg := testConfig()
 	api := &fakeCrownestClient{baseURL: "https://api.crownest.dev"}
 	leaseID := leasePrefix + "sbx_stop_locked"
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "stop-locked", providerName, claimScope(api.BaseURL(), cfg), cfg.Pond, repoRoot, cfg.IdleTimeout, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "stop-locked", providerName, claimScope(api.BaseURL(), cfg), cfg.Pond, repoRoot, cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
 	unlock, err := lockCrownestLeaseOperation(context.Background(), leaseID)
@@ -610,15 +610,15 @@ func TestStopHonorsOperationLock(t *testing.T) {
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt:   Runtime{Stdout: io.Discard, Stderr: io.Discard},
-		newClient: func(Config, Runtime) (client, error) {
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		newClient: func(core.Config, core.Runtime) (client, error) {
 			return api, nil
 		},
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
-	err = b.Stop(ctx, StopRequest{ID: "stop-locked"})
+	err = b.Stop(ctx, core.StopRequest{ID: "stop-locked"})
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("err=%v, want context deadline while waiting for operation lock", err)
 	}
@@ -634,10 +634,10 @@ func TestCleanupSerializesAndRechecksLeaseActivity(t *testing.T) {
 	cfg.IdleTimeout = time.Minute
 	api := &fakeCrownestClient{baseURL: "https://api.crownest.dev"}
 	leaseID := leasePrefix + "sbx_cleanup_locked"
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "cleanup-locked", providerName, claimScope(api.BaseURL(), cfg), cfg.Pond, repoRoot, cfg.IdleTimeout, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "cleanup-locked", providerName, claimScope(api.BaseURL(), cfg), cfg.Pond, repoRoot, cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -651,15 +651,15 @@ func TestCleanupSerializesAndRechecksLeaseActivity(t *testing.T) {
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt:   Runtime{Stdout: io.Discard, Stderr: io.Discard},
-		newClient: func(Config, Runtime) (client, error) {
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		newClient: func(core.Config, core.Runtime) (client, error) {
 			return api, nil
 		},
 	}
 
 	cleanupDone := make(chan error, 1)
 	go func() {
-		cleanupDone <- b.Cleanup(context.Background(), CleanupRequest{})
+		cleanupDone <- b.Cleanup(context.Background(), core.CleanupRequest{})
 	}()
 	select {
 	case err := <-cleanupDone:
@@ -703,14 +703,14 @@ func TestRunRemovesOneShotClaimAfterArchiveSetupFailure(t *testing.T) {
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  testConfig(),
-		rt:   Runtime{Stdout: io.Discard, Stderr: io.Discard},
-		newClient: func(Config, Runtime) (client, error) {
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		newClient: func(core.Config, core.Runtime) (client, error) {
 			return api, nil
 		},
 	}
 
-	_, err := b.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: repoRoot, Name: "demo"},
+	_, err := b.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: repoRoot, Name: "demo"},
 		Command: []string{"pnpm", "test"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "transfer failed") {
@@ -720,7 +720,7 @@ func TestRunRemovesOneShotClaimAfterArchiveSetupFailure(t *testing.T) {
 		t.Fatalf("deletedSandboxID=%q, want Crownest-owned one-shot cleanup", api.deletedSandboxID)
 	}
 	leaseID := leasePrefix + "sbx_created"
-	if claim, err := readLeaseClaim(leaseID); err != nil || claim.LeaseID != "" {
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil || claim.LeaseID != "" {
 		t.Fatalf("claim=%#v err=%v, want one-shot setup-failure claim removed", claim, err)
 	}
 }
@@ -736,14 +736,14 @@ func TestRunDeletesPartialCreateSandboxWhenWorkspaceRunIDIsMissing(t *testing.T)
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  testConfig(),
-		rt:   Runtime{Stdout: io.Discard, Stderr: io.Discard},
-		newClient: func(Config, Runtime) (client, error) {
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		newClient: func(core.Config, core.Runtime) (client, error) {
 			return api, nil
 		},
 	}
 
-	_, err := b.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: repoRoot, Name: "demo"},
+	_, err := b.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: repoRoot, Name: "demo"},
 		Command: []string{"pnpm", "test"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "returned no id") {
@@ -753,7 +753,7 @@ func TestRunDeletesPartialCreateSandboxWhenWorkspaceRunIDIsMissing(t *testing.T)
 		t.Fatalf("deletedSandboxID=%q, want partial sandbox cleanup", api.deletedSandboxID)
 	}
 	leaseID := leasePrefix + "sbx_partial"
-	if claim, err := readLeaseClaim(leaseID); err != nil || claim.LeaseID != "" {
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil || claim.LeaseID != "" {
 		t.Fatalf("claim=%#v err=%v, want no partial-create claim", claim, err)
 	}
 }
@@ -770,14 +770,14 @@ func TestRunKeepOnFailureRetainsCreatedSandboxAfterArchiveSetupFailure(t *testin
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  testConfig(),
-		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr},
-		newClient: func(Config, Runtime) (client, error) {
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: &stderr},
+		newClient: func(core.Config, core.Runtime) (client, error) {
 			return api, nil
 		},
 	}
 
-	result, err := b.Run(context.Background(), RunRequest{
-		Repo:          Repo{Root: repoRoot, Name: "demo"},
+	result, err := b.Run(context.Background(), core.RunRequest{
+		Repo:          core.Repo{Root: repoRoot, Name: "demo"},
 		Command:       []string{"pnpm", "test"},
 		KeepOnFailure: true,
 	})
@@ -788,8 +788,8 @@ func TestRunKeepOnFailureRetainsCreatedSandboxAfterArchiveSetupFailure(t *testin
 		t.Fatalf("deletedSandboxID=%q, want retained sandbox", api.deletedSandboxID)
 	}
 	leaseID := leasePrefix + "sbx_kept_setup"
-	t.Cleanup(func() { removeLeaseClaim(leaseID) })
-	if claim, err := readLeaseClaim(leaseID); err != nil || claim.LeaseID != leaseID {
+	t.Cleanup(func() { core.RemoveLeaseClaim(leaseID) })
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil || claim.LeaseID != leaseID {
 		t.Fatalf("claim=%#v err=%v, want retained claim", claim, err)
 	}
 	if result.Session == nil || !result.Session.Kept || result.Session.LeaseID != leaseID {
@@ -809,21 +809,21 @@ func TestRunKeepDeletesCreatedSandboxWhenLocalClaimFails(t *testing.T) {
 		createSandboxID: "sbx_unclaimable",
 	}
 	leaseID := leasePrefix + "sbx_unclaimable"
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "existing", providerName, claimScope(api.BaseURL(), cfg), cfg.Pond, filepath.Join(repoRoot, "other"), cfg.IdleTimeout, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "existing", providerName, claimScope(api.BaseURL(), cfg), cfg.Pond, filepath.Join(repoRoot, "other"), cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { removeLeaseClaim(leaseID) })
+	t.Cleanup(func() { core.RemoveLeaseClaim(leaseID) })
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt:   Runtime{Stdout: io.Discard, Stderr: io.Discard},
-		newClient: func(Config, Runtime) (client, error) {
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		newClient: func(core.Config, core.Runtime) (client, error) {
 			return api, nil
 		},
 	}
 
-	_, err := b.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: repoRoot, Name: "demo"},
+	_, err := b.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: repoRoot, Name: "demo"},
 		Command: []string{"pnpm", "test"},
 		Keep:    true,
 	})
@@ -852,18 +852,18 @@ func TestRunKeepOnFailureRetainsCreatedSandbox(t *testing.T) {
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  testConfig(),
-		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr},
-		newClient: func(Config, Runtime) (client, error) {
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: &stderr},
+		newClient: func(core.Config, core.Runtime) (client, error) {
 			return api, nil
 		},
 	}
 
-	result, err := b.Run(context.Background(), RunRequest{
-		Repo:          Repo{Root: repoRoot, Name: "demo"},
+	result, err := b.Run(context.Background(), core.RunRequest{
+		Repo:          core.Repo{Root: repoRoot, Name: "demo"},
 		Command:       []string{"false"},
 		KeepOnFailure: true,
 	})
-	var exitErr ExitError
+	var exitErr core.ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 7 {
 		t.Fatalf("err=%v, want exit 7", err)
 	}
@@ -876,7 +876,7 @@ func TestRunKeepOnFailureRetainsCreatedSandbox(t *testing.T) {
 	if result.Session == nil || !result.Session.Kept {
 		t.Fatalf("session=%#v, want kept session after failure", result.Session)
 	}
-	if claim, err := readLeaseClaim(result.LeaseID); err != nil || claim.LeaseID != result.LeaseID {
+	if claim, err := core.ReadLeaseClaim(result.LeaseID); err != nil || claim.LeaseID != result.LeaseID {
 		t.Fatalf("claim=%#v err=%v, want retained claim", claim, err)
 	}
 	if !strings.Contains(stderr.String(), "keep-on-failure") {
@@ -900,14 +900,14 @@ func TestRunReturnsErrorForCanceledTerminalWithoutExitCode(t *testing.T) {
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  testConfig(),
-		rt:   Runtime{Stdout: io.Discard, Stderr: io.Discard},
-		newClient: func(Config, Runtime) (client, error) {
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		newClient: func(core.Config, core.Runtime) (client, error) {
 			return api, nil
 		},
 	}
 
-	result, err := b.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: repoRoot, Name: "demo"},
+	result, err := b.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: repoRoot, Name: "demo"},
 		Command: []string{"pnpm", "test"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "status=canceled") {
@@ -919,7 +919,7 @@ func TestRunReturnsErrorForCanceledTerminalWithoutExitCode(t *testing.T) {
 	if api.deletedSandboxID != "" {
 		t.Fatalf("deletedSandboxID=%q, want Crownest-owned canceled sandbox cleanup", api.deletedSandboxID)
 	}
-	if claim, err := readLeaseClaim(result.LeaseID); err != nil || claim.LeaseID != "" {
+	if claim, err := core.ReadLeaseClaim(result.LeaseID); err != nil || claim.LeaseID != "" {
 		t.Fatalf("claim=%#v err=%v, want one-shot terminal-failure claim removed", claim, err)
 	}
 }
@@ -933,16 +933,16 @@ func TestCreateSandboxCleansUpRemoteWhenLocalClaimFails(t *testing.T) {
 		createSandboxID: "sbx_new",
 	}
 	leaseID := leasePrefix + "sbx_new"
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "existing", providerName, claimScope(api.BaseURL(), cfg), cfg.Pond, filepath.Join(repoRoot, "other"), cfg.IdleTimeout, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "existing", providerName, claimScope(api.BaseURL(), cfg), cfg.Pond, filepath.Join(repoRoot, "other"), cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
 	b := &backend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt:   Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 	}
 
-	_, _, _, err := b.createSandbox(context.Background(), api, Repo{Root: repoRoot, Name: "demo"}, false, "")
+	_, _, _, err := b.createSandbox(context.Background(), api, core.Repo{Root: repoRoot, Name: "demo"}, false, "")
 	if err == nil || !strings.Contains(err.Error(), "claimed by repo") {
 		t.Fatalf("err=%v, want claim repo conflict", err)
 	}
@@ -1066,7 +1066,7 @@ func (f *fakeCrownestClient) StreamWorkspaceRunEvents(context.Context, string, i
 
 func (f *fakeCrownestClient) Probe(context.Context) error { return nil }
 
-func writeCrownestClaimFixture(t *testing.T, claim LeaseClaim) {
+func writeCrownestClaimFixture(t *testing.T, claim core.LeaseClaim) {
 	t.Helper()
 	data, err := json.MarshalIndent(claim, "", "  ")
 	if err != nil {

--- a/internal/providers/crownest/client.go
+++ b/internal/providers/crownest/client.go
@@ -7,13 +7,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	core "github.com/openclaw/crabbox/internal/cli"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
@@ -101,14 +102,14 @@ type apiError struct {
 func (e *apiError) Error() string { return e.err.Error() }
 func (e *apiError) Unwrap() error { return e.err }
 
-func newClient(cfg Config, rt Runtime) (client, error) {
+func newClient(cfg core.Config, rt core.Runtime) (client, error) {
 	baseURL, err := validateBaseURL(cfg.Crownest.APIURL)
 	if err != nil {
 		return nil, err
 	}
 	apiKey := firstNonEmpty(os.Getenv("CRABBOX_CROWNEST_API_KEY"), os.Getenv("CROWNEST_API_KEY"))
 	if apiKey == "" {
-		return nil, exit(2, "provider=crownest needs an API key; load CRABBOX_CROWNEST_API_KEY or CROWNEST_API_KEY from a secret manager")
+		return nil, core.Exit(2, "provider=crownest needs an API key; load CRABBOX_CROWNEST_API_KEY or CROWNEST_API_KEY from a secret manager")
 	}
 	rawHTTPClient := rt.HTTP
 	if rawHTTPClient == nil {
@@ -120,10 +121,6 @@ func newClient(cfg Config, rt Runtime) (client, error) {
 
 func crownestRedirectError(destination *url.URL) error {
 	return fmt.Errorf("crownest refused cross-origin redirect to %s", destination.Redacted())
-}
-
-func sameOrigin(a, b *url.URL) bool {
-	return core.SameHTTPOrigin(a, b)
 }
 
 func (c *httpClient) BaseURL() string { return c.baseURL }
@@ -140,7 +137,7 @@ func (c *httpClient) CreateSandbox(ctx context.Context, req createSandboxRequest
 		return sandbox{}, err
 	}
 	if out.Sandbox.ID == "" {
-		return sandbox{}, exit(5, "crownest create sandbox returned no sandbox id")
+		return sandbox{}, core.Exit(5, "crownest create sandbox returned no sandbox id")
 	}
 	return out.Sandbox, nil
 }
@@ -167,7 +164,7 @@ func (c *httpClient) CreateWorkspaceRun(ctx context.Context, req createWorkspace
 		return workspaceRun{}, err
 	}
 	if out.WorkspaceRun.ID == "" {
-		return out.WorkspaceRun, exit(5, "crownest create workspace run returned no id")
+		return out.WorkspaceRun, core.Exit(5, "crownest create workspace run returned no id")
 	}
 	return out.WorkspaceRun, nil
 }
@@ -180,7 +177,7 @@ func (c *httpClient) CreateArchiveTransfer(ctx context.Context, workspaceRunID s
 		return archiveTransfer{}, err
 	}
 	if out.Transfer.ID == "" || out.Transfer.UploadURL == "" {
-		return archiveTransfer{}, exit(5, "crownest archive transfer returned incomplete upload target")
+		return archiveTransfer{}, core.Exit(5, "crownest archive transfer returned incomplete upload target")
 	}
 	return out.Transfer, nil
 }
@@ -245,7 +242,7 @@ func sanitizeUploadTransportError(err error, target *url.URL) string {
 
 func (c *httpClient) sameOrigin(target *url.URL) bool {
 	base, err := url.Parse(c.baseURL)
-	return err == nil && sameOrigin(base, target)
+	return err == nil && core.SameHTTPOrigin(base, target)
 }
 
 func (c *httpClient) FinalizeArchive(ctx context.Context, workspaceRunID string, req finalizeArchiveRequest, key string) (workspaceRun, error) {
@@ -382,7 +379,7 @@ func (c *httpClient) apiError(method, apiPath string, resp *http.Response) error
 	msg = redactSecrets(msg, c.apiKey)
 	return &apiError{
 		StatusCode: resp.StatusCode,
-		err:        exit(5, "crownest %s %s failed: %s: %s", method, apiPath, resp.Status, msg),
+		err:        core.Exit(5, "crownest %s %s failed: %s: %s", method, apiPath, resp.Status, msg),
 	}
 }
 

--- a/internal/providers/crownest/client_test.go
+++ b/internal/providers/crownest/client_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestClientSandboxWorkspaceRunAndArchiveFlow(t *testing.T) {
@@ -59,7 +61,7 @@ func TestClientSandboxWorkspaceRunAndArchiveFlow(t *testing.T) {
 	defer server.Close()
 
 	t.Setenv("CRABBOX_CROWNEST_API_KEY", "cn_test_key")
-	client, err := newClient(testConfigWithURL(server.URL), Runtime{HTTP: server.Client()})
+	client, err := newClient(testConfigWithURL(server.URL), core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +111,7 @@ func TestClientCreateWorkspaceRunPreservesSandboxIDOnMissingRunID(t *testing.T) 
 	defer server.Close()
 
 	t.Setenv("CRABBOX_CROWNEST_API_KEY", "cn_test_key")
-	client, err := newClient(testConfigWithURL(server.URL), Runtime{HTTP: server.Client()})
+	client, err := newClient(testConfigWithURL(server.URL), core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +151,7 @@ func TestClientRedactsSecretsFromErrors(t *testing.T) {
 	}))
 	defer server.Close()
 	t.Setenv("CRABBOX_CROWNEST_API_KEY", "cn_test_key")
-	client, err := newClient(testConfigWithURL(server.URL), Runtime{HTTP: server.Client()})
+	client, err := newClient(testConfigWithURL(server.URL), core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -206,7 +208,7 @@ func TestClientKeepsRequestContextAliveUntilJSONBodyRead(t *testing.T) {
 	}
 }
 
-func testConfigWithURL(url string) Config {
+func testConfigWithURL(url string) core.Config {
 	cfg := testConfig()
 	cfg.Crownest.APIURL = url
 	return cfg

--- a/internal/providers/crownest/core.go
+++ b/internal/providers/crownest/core.go
@@ -1,38 +1,8 @@
 package crownest
 
 import (
-	"context"
-
-	"io"
-	"os"
-	"time"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type RunSessionHandle = core.RunSessionHandle
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type CleanupRequest = core.CleanupRequest
-type Server = core.Server
-type LeaseClaim = core.LeaseClaim
-type Repo = core.Repo
-type SyncManifest = core.SyncManifest
-type ExitError = core.ExitError
-type timingReport = core.TimingReport
-type timingPhase = core.TimingPhase
 
 const (
 	providerName = "crownest"
@@ -40,74 +10,6 @@ const (
 	targetLinux  = core.TargetLinux
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
-}
-
-func readLeaseClaim(leaseID string) (LeaseClaim, error) {
-	return core.ReadLeaseClaim(leaseID)
-}
-
-func listCrownestLeaseClaims() ([]LeaseClaim, error) {
+func listCrownestLeaseClaims() ([]core.LeaseClaim, error) {
 	return core.ListLeaseClaimsWithPrefix(leasePrefix)
-}
-
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
-func removeLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
-	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
-}
-
-func shellQuote(value string) string {
-	return core.ShellQuote(value)
-}
-
-func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
-	return core.SyncExcludes(root, cfg)
-}
-
-func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (SyncManifest, error) {
-	return core.BuildSyncManifestFiltered(root, excludes, includes)
-}
-
-func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
-	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
-}
-
-func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
-	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
-}
-
-func writeTimingJSON(w io.Writer, report core.TimingReport) error {
-	return core.WriteTimingJSON(w, report)
-}
-
-func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
-	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
-func rejectDelegatedSyncOptionsForSpec(spec ProviderSpec, req RunRequest) error {
-	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
 }

--- a/internal/providers/crownest/flags.go
+++ b/internal/providers/crownest/flags.go
@@ -1,20 +1,19 @@
 package crownest
 
-import core "github.com/openclaw/crabbox/internal/cli"
-
 import (
 	"flag"
 	"net/url"
 	"strings"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func registerFlags(fs *flag.FlagSet, defaults Config) any {
+func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterCrownestConfigFlags(fs, defaults.Crownest)
 }
 
-func applyFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if strings.EqualFold(strings.TrimSpace(cfg.Provider), providerName) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --crownest-template", "use --crownest-template"); err != nil {
 			return err
@@ -32,15 +31,15 @@ func applyFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	return validateConfig(*cfg)
 }
 
-func validateConfig(cfg Config) error {
+func validateConfig(cfg core.Config) error {
 	if _, err := validateBaseURL(cfg.Crownest.APIURL); err != nil {
 		return err
 	}
 	if cfg.Crownest.TimeoutSecs < 0 {
-		return exit(2, "crownest timeoutSecs must be non-negative")
+		return core.Exit(2, "crownest timeoutSecs must be non-negative")
 	}
 	if strings.TrimSpace(cfg.Crownest.Template) == "" {
-		return exit(2, "crownest template must not be empty")
+		return core.Exit(2, "crownest template must not be empty")
 	}
 	return nil
 }
@@ -52,14 +51,14 @@ func validateBaseURL(raw string) (string, error) {
 	}
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return "", exit(2, "provider=crownest base URL must be an absolute URL")
+		return "", core.Exit(2, "provider=crownest base URL must be an absolute URL")
 	}
 	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
-		return "", exit(2, "provider=crownest base URL must not contain userinfo, query parameters, or a fragment")
+		return "", core.Exit(2, "provider=crownest base URL must not contain userinfo, query parameters, or a fragment")
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
 	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && shared.IsLoopbackHost(parsed.Hostname())) {
-		return "", exit(2, "provider=crownest base URL must use HTTPS except for loopback development endpoints")
+		return "", core.Exit(2, "provider=crownest base URL must use HTTPS except for loopback development endpoints")
 	}
 	parsed.Host = canonicalHostPort(parsed)
 	parsed.Path = strings.TrimRight(parsed.Path, "/")

--- a/internal/providers/crownest/operation_lock.go
+++ b/internal/providers/crownest/operation_lock.go
@@ -5,13 +5,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func lockCrownestLeaseOperation(ctx context.Context, leaseID string) (func(), error) {
 	if !strings.HasPrefix(leaseID, leasePrefix) || strings.TrimPrefix(leaseID, leasePrefix) == "" ||
 		filepath.Base(leaseID) != leaseID || leaseID == "." {
-		return nil, exit(2, "invalid crownest lease id %q", leaseID)
+		return nil, core.Exit(2, "invalid crownest lease id %q", leaseID)
 	}
 	return shared.LockLeaseOperation(ctx, "crownest", leaseID)
 }

--- a/internal/providers/crownest/provider_test.go
+++ b/internal/providers/crownest/provider_test.go
@@ -15,7 +15,7 @@ import (
 func TestCrownestConfigShowSection(t *testing.T) {
 	for _, selected := range []string{"", "crownest"} {
 		for _, forget := range []bool{false, true} {
-			cfg := Config{Provider: selected, Crownest: core.CrownestConfig{APIURL: "https://api.example.test/path?debug=1#hint", ProjectID: "", Template: " raw-template ", TimeoutSecs: 0, ForgetMissing: forget}}
+			cfg := core.Config{Provider: selected, Crownest: core.CrownestConfig{APIURL: "https://api.example.test/path?debug=1#hint", ProjectID: "", Template: " raw-template ", TimeoutSecs: 0, ForgetMissing: forget}}
 			before := cfg.Crownest
 			section := (Provider{}).ConfigShowSection(cfg)
 			values := map[string]any{}
@@ -41,7 +41,7 @@ func TestCrownestConfigShowSection(t *testing.T) {
 func TestCrownestOrdinaryFlagOrdering(t *testing.T) {
 	for _, provider := range []string{" CROWNEST ", "other"} {
 		for _, sizing := range []string{"", "class", "type"} {
-			cfg := Config{Provider: provider}
+			cfg := core.Config{Provider: provider}
 			before := cfg
 			fs := flag.NewFlagSet("test", flag.ContinueOnError)
 			fs.String("class", "", "")
@@ -65,7 +65,7 @@ func TestCrownestOrdinaryFlagOrdering(t *testing.T) {
 			timeout       int
 			diagnostic    string
 		}{{" https://example.invalid ", "same", 0, ""}, {"", "same", 7, ""}, {"ordinary", "", -1, "provider=crownest base URL must be an absolute URL"}, {"https://example.invalid", "", -1, "crownest timeoutSecs must be non-negative"}, {"https://example.invalid", "", 0, "crownest template must not be empty"}} {
-			cfg := Config{Provider: provider, Crownest: core.CrownestConfig{APIURL: "https://example.invalid", ProjectID: "same", Template: "same", TimeoutSecs: 7}}
+			cfg := core.Config{Provider: provider, Crownest: core.CrownestConfig{APIURL: "https://example.invalid", ProjectID: "same", Template: "same", TimeoutSecs: 7}}
 			fs := flag.NewFlagSet("test", flag.ContinueOnError)
 			values := (Provider{}).RegisterFlags(fs, cfg)
 			before := cfg
@@ -213,7 +213,7 @@ func TestConfigureReturnsDelegatedCleanupAndDoctor(t *testing.T) {
 	t.Setenv("CRABBOX_CROWNEST_API_KEY", "")
 	t.Setenv("CROWNEST_API_KEY", "")
 	provider := Provider{}
-	configured, err := provider.Configure(testConfig(), Runtime{Stdout: io.Discard, Stderr: io.Discard})
+	configured, err := provider.Configure(testConfig(), core.Runtime{Stdout: io.Discard, Stderr: io.Discard})
 	if err != nil {
 		t.Fatalf("Configure err=%v", err)
 	}
@@ -221,22 +221,22 @@ func TestConfigureReturnsDelegatedCleanupAndDoctor(t *testing.T) {
 	if !ok {
 		t.Fatalf("configured backend does not implement DelegatedRunBackend: %T", configured)
 	}
-	if _, err := delegated.Run(context.Background(), RunRequest{}); err == nil || !strings.Contains(err.Error(), "API key") {
+	if _, err := delegated.Run(context.Background(), core.RunRequest{}); err == nil || !strings.Contains(err.Error(), "API key") {
 		t.Fatalf("Run err=%v, want API key requirement", err)
 	}
 	if _, ok := configured.(core.CleanupBackend); !ok {
 		t.Fatalf("configured backend does not implement CleanupBackend: %T", configured)
 	}
-	doctor, err := provider.ConfigureDoctor(testConfig(), Runtime{Stdout: io.Discard, Stderr: io.Discard})
+	doctor, err := provider.ConfigureDoctor(testConfig(), core.Runtime{Stdout: io.Discard, Stderr: io.Discard})
 	if err != nil {
 		t.Fatalf("ConfigureDoctor err=%v", err)
 	}
-	if _, err := doctor.Doctor(context.Background(), DoctorRequest{}); err == nil || !strings.Contains(err.Error(), "API key") {
+	if _, err := doctor.Doctor(context.Background(), core.DoctorRequest{}); err == nil || !strings.Contains(err.Error(), "API key") {
 		t.Fatalf("Doctor err=%v, want API key requirement", err)
 	}
 }
 
-func testConfig() Config {
+func testConfig() core.Config {
 	cfg := core.BaseConfig()
 	cfg.Crownest.APIURL = "https://api.crownest.dev"
 	cfg.Crownest.Template = "python-node"

--- a/internal/providers/opencomputer/apiclient.go
+++ b/internal/providers/opencomputer/apiclient.go
@@ -95,7 +95,7 @@ func (e *ocAPIError) Unwrap() error { return e.err }
 // newOCAPIClient resolves the API URL and key. Key precedence:
 // CRABBOX_OPENCOMPUTER_API_KEY, OPENCOMPUTER_API_KEY, then the `oc` CLI config
 // (~/.oc/config.json). Returns an error when no key can be found.
-func newOCAPIClient(cfg Config, rt Runtime) (*ocAPIClient, error) {
+func newOCAPIClient(cfg core.Config, rt core.Runtime) (*ocAPIClient, error) {
 	fileCfg := readOCFileConfig()
 	// API URL precedence: an explicit trusted Crabbox setting, then the `oc` CLI
 	// config file's api_url, then the built-in default. Repository YAML cannot
@@ -110,7 +110,7 @@ func newOCAPIClient(cfg Config, rt Runtime) (*ocAPIClient, error) {
 		fileCfg.APIKey,
 	)
 	if apiKey == "" {
-		return nil, exit(2, "provider=opencomputer needs an API key; load CRABBOX_OPENCOMPUTER_API_KEY from a secret manager or configure an existing oc CLI credential")
+		return nil, core.Exit(2, "provider=opencomputer needs an API key; load CRABBOX_OPENCOMPUTER_API_KEY from a secret manager or configure an existing oc CLI credential")
 	}
 	httpClient := rt.HTTP
 	if httpClient == nil {
@@ -123,14 +123,14 @@ func newOCAPIClient(cfg Config, rt Runtime) (*ocAPIClient, error) {
 func validateOCAPIURL(raw string) (string, error) {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {
-		return "", exit(2, "provider=opencomputer API URL must be an absolute HTTPS URL")
+		return "", core.Exit(2, "provider=opencomputer API URL must be an absolute HTTPS URL")
 	}
 	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", exit(2, "provider=opencomputer API URL must not contain userinfo, query parameters, or a fragment")
+		return "", core.Exit(2, "provider=opencomputer API URL must not contain userinfo, query parameters, or a fragment")
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
 	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
-		return "", exit(2, "provider=opencomputer API URL must use HTTPS except for loopback development endpoints")
+		return "", core.Exit(2, "provider=opencomputer API URL must use HTTPS except for loopback development endpoints")
 	}
 	host := shared.LowercaseHostname(parsed.Hostname())
 	port := parsed.Port()
@@ -218,7 +218,7 @@ func (c *ocAPIClient) createSandbox(ctx context.Context, req createSandboxReques
 		return sandbox{}, err
 	}
 	if sb.ID == "" {
-		return sandbox{}, exit(5, "opencomputer create returned no sandbox id")
+		return sandbox{}, core.Exit(5, "opencomputer create returned no sandbox id")
 	}
 	return sb, nil
 }
@@ -310,7 +310,7 @@ func (c *ocAPIClient) apiError(method, path string, resp *http.Response) error {
 	path = redactOCSecrets(path, c.apiKey)
 	return &ocAPIError{
 		StatusCode: resp.StatusCode,
-		err:        exit(5, "opencomputer %s %s failed: %s: %s", method, path, resp.Status, msg),
+		err:        core.Exit(5, "opencomputer %s %s failed: %s: %s", method, path, resp.Status, msg),
 	}
 }
 

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -22,23 +22,23 @@ const (
 	openComputerClaimTagKey    = "crabbox.claim"
 )
 
-func NewOpenComputerBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewOpenComputerBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	return &openComputerBackend{spec: spec, cfg: cfg, rt: rt}
 }
 
 type openComputerBackend struct {
-	spec                   ProviderSpec
-	cfg                    Config
-	rt                     Runtime
+	spec                   core.ProviderSpec
+	cfg                    core.Config
+	rt                     core.Runtime
 	cleanupTimeoutOverride time.Duration
 }
 
-func (b *openComputerBackend) Spec() ProviderSpec { return b.spec }
+func (b *openComputerBackend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *openComputerBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *openComputerBackend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if req.ActionsRunner {
-		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+		return core.Exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
 	started := core.ClockNow(b.rt.Clock)
 	api, err := newOCAPIClient(b.cfg, b.rt)
@@ -62,10 +62,10 @@ func (b *openComputerBackend) Warmup(ctx context.Context, req WarmupRequest) err
 	})
 }
 
-func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *openComputerBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	workdir, err := openComputerWorkdir(b.cfg)
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	var api *ocAPIClient
 	var leaseID, sandboxID, slug string
@@ -105,7 +105,7 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 			if _, err := verifyOpenComputerClaim(ctx, api, leaseID, sandboxID); err != nil {
 				return shared.DelegatedSandbox{}, err
 			}
-			claim, err := readLeaseClaim(leaseID)
+			claim, err := core.ReadLeaseClaim(leaseID)
 			if err != nil {
 				return shared.DelegatedSandbox{}, err
 			}
@@ -128,7 +128,7 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 			}
 			command := intent.Argv("bash", "-lc")
 			if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
-				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+				core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 			}
 			return shared.DelegatedSandboxCommand{
 				Text: strings.Join(req.Command, " "),
@@ -141,17 +141,17 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 			if err := api.killSandbox(ctx, sandboxID); err != nil && !isOCNotFound(err) {
 				return err
 			}
-			removeLeaseClaim(leaseID)
+			core.RemoveLeaseClaim(leaseID)
 			return nil
 		},
 	})
 }
 
 func openComputerCleanupCommand(leaseID string) string {
-	return "crabbox stop --provider " + providerName + " --id " + shellQuote(leaseID)
+	return "crabbox stop --provider " + providerName + " --id " + core.ShellQuote(leaseID)
 }
 
-func (b *openComputerBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *openComputerBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	api, err := newOCAPIClient(b.cfg, b.rt)
 	if err != nil {
@@ -161,7 +161,7 @@ func (b *openComputerBackend) List(ctx context.Context, req ListRequest) ([]Leas
 	if err != nil {
 		return nil, err
 	}
-	servers := make([]Server, 0, len(claims))
+	servers := make([]core.Server, 0, len(claims))
 	for _, claim := range claims {
 		if claim.Provider != providerName || !strings.HasPrefix(claim.LeaseID, leasePrefix) {
 			continue
@@ -187,7 +187,7 @@ func (b *openComputerBackend) List(ctx context.Context, req ListRequest) ([]Leas
 			}
 			state = core.Blank(sb.Status, statusViewReady)
 		}
-		servers = append(servers, Server{
+		servers = append(servers, core.Server{
 			Provider: providerName,
 			CloudID:  sandboxID,
 			Name:     sandboxID,
@@ -205,36 +205,36 @@ func (b *openComputerBackend) List(ctx context.Context, req ListRequest) ([]Leas
 	return servers, nil
 }
 
-func (b *openComputerBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *openComputerBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	api, err := newOCAPIClient(b.cfg, b.rt)
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
 	if err := api.probeSandboxes(ctx); err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	servers, err := b.List(ctx, ListRequest{})
+	servers, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return inventoryDoctorResult(providerName, len(servers)), nil
+	return core.InventoryDoctorResult(providerName, len(servers)), nil
 }
 
-func (b *openComputerBackend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *openComputerBackend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	api, err := newOCAPIClient(b.cfg, b.rt)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	leaseID, sandboxID, slug, err := resolveLeaseID(req.ID, "", false, 0, api.baseURL)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	claim, ok, err := resolveOpenComputerLeaseClaim(leaseID, api.baseURL)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	if !ok {
-		return StatusView{}, exit(4, "opencomputer sandbox %q is not claimed by Crabbox", req.ID)
+		return core.StatusView{}, core.Exit(4, "opencomputer sandbox %q is not claimed by Crabbox", req.ID)
 	}
 	waitTimeout := req.WaitTimeout
 	if waitTimeout <= 0 {
@@ -251,20 +251,20 @@ func (b *openComputerBackend) Status(ctx context.Context, req StatusRequest) (St
 		sb, getErr := api.getSandboxWithTags(pollCtx, sandboxID)
 		if getErr != nil {
 			if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return StatusView{}, exit(5, "timed out waiting for opencomputer sandbox %s to become ready", sandboxID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for opencomputer sandbox %s to become ready", sandboxID)
 			}
 			if ctx.Err() != nil {
-				return StatusView{}, ctx.Err()
+				return core.StatusView{}, ctx.Err()
 			}
 			// Surface real API failures (auth, 5xx, sandbox gone) instead of
 			// masking them as a not-ready status.
-			return StatusView{}, getErr
+			return core.StatusView{}, getErr
 		}
 		if err := validateOpenComputerSandboxOwnership(claim, sb); err != nil {
-			return StatusView{}, err
+			return core.StatusView{}, err
 		}
 		state := strings.ToLower(strings.TrimSpace(sb.Status))
-		view := StatusView{
+		view := core.StatusView{
 			ID:       leaseID,
 			Slug:     slug,
 			Provider: providerName,
@@ -285,23 +285,23 @@ func (b *openComputerBackend) Status(ctx context.Context, req StatusRequest) (St
 			return view, nil
 		}
 		if isTerminalState(state) {
-			return StatusView{}, exit(5, "opencomputer sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
+			return core.StatusView{}, core.Exit(5, "opencomputer sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
 		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return StatusView{}, exit(5, "timed out waiting for opencomputer sandbox %s to become ready", sandboxID)
+			return core.StatusView{}, core.Exit(5, "timed out waiting for opencomputer sandbox %s to become ready", sandboxID)
 		}
 		select {
 		case <-pollCtx.Done():
 			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return StatusView{}, exit(5, "timed out waiting for opencomputer sandbox %s to become ready", sandboxID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for opencomputer sandbox %s to become ready", sandboxID)
 			}
-			return StatusView{}, pollCtx.Err()
+			return core.StatusView{}, pollCtx.Err()
 		case <-time.After(2 * time.Second):
 		}
 	}
 }
 
-func (b *openComputerBackend) Stop(ctx context.Context, req StopRequest) error {
+func (b *openComputerBackend) Stop(ctx context.Context, req core.StopRequest) error {
 	api, err := newOCAPIClient(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -315,7 +315,7 @@ func (b *openComputerBackend) Stop(ctx context.Context, req StopRequest) error {
 			return err
 		}
 		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing opencomputer sandbox=%s after explicit request\n", sandboxID)
-		removeLeaseClaim(leaseID)
+		core.RemoveLeaseClaim(leaseID)
 		return nil
 	}
 	if err := api.killSandbox(ctx, sandboxID); err != nil {
@@ -324,7 +324,7 @@ func (b *openComputerBackend) Stop(ctx context.Context, req StopRequest) error {
 		}
 		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing opencomputer sandbox=%s after explicit request\n", sandboxID)
 	}
-	removeLeaseClaim(leaseID)
+	core.RemoveLeaseClaim(leaseID)
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, sandboxID)
 	return nil
 }
@@ -356,7 +356,7 @@ func (b *openComputerBackend) execCommand(ctx context.Context, api *ocAPIClient,
 
 // createSandbox creates a Crabbox-owned sandbox and records the local lease.
 // Returns (leaseID, sandboxID, slug, err).
-func (b *openComputerBackend) createSandbox(ctx context.Context, api *ocAPIClient, repo Repo, reclaim bool, requestedSlug string) (string, string, string, error) {
+func (b *openComputerBackend) createSandbox(ctx context.Context, api *ocAPIClient, repo core.Repo, reclaim bool, requestedSlug string) (string, string, string, error) {
 	providerScope, err := newOpenComputerClaimScope(api.baseURL)
 	if err != nil {
 		return "", "", "", err
@@ -383,11 +383,11 @@ func (b *openComputerBackend) createSandbox(ctx context.Context, api *ocAPIClien
 		return leasePrefix + sb.ID, sb.ID, "", b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
 	leaseID := leasePrefix + sb.ID
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return leaseID, sb.ID, "", b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
-	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, providerScope, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, providerName, providerScope, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
 		return leaseID, sb.ID, slug, b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
 	return leaseID, sb.ID, slug, nil
@@ -402,41 +402,41 @@ func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration
 	return shared.ResolveScopedLeaseID(id, shared.ScopedLeaseResolver{
 		Provider:      providerName,
 		LeasePrefix:   leasePrefix,
-		ReadClaim:     readLeaseClaim,
+		ReadClaim:     core.ReadLeaseClaim,
 		ListClaims:    listOpenComputerLeaseClaims,
-		ValidateClaim: func(claim LeaseClaim) error { return validateOpenComputerClaimScope(claim, baseURL) },
-		FinishClaim: func(claim LeaseClaim) (string, string, string, error) {
+		ValidateClaim: func(claim core.LeaseClaim) error { return validateOpenComputerClaimScope(claim, baseURL) },
+		FinishClaim: func(claim core.LeaseClaim) (string, string, string, error) {
 			return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, baseURL)
 		},
 		EmptyIdentifierError: func() error {
-			return exit(2, "provider=opencomputer requires a Crabbox-created sandbox slug or lease id")
+			return core.Exit(2, "provider=opencomputer requires a Crabbox-created sandbox slug or lease id")
 		},
 		UnclaimedIdentifierError: func(identifier string) error {
-			return exit(4, "opencomputer sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", identifier, leasePrefix)
+			return core.Exit(4, "opencomputer sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", identifier, leasePrefix)
 		},
 	})
 }
 
-func resolveOpenComputerLeaseClaim(identifier, baseURL string) (LeaseClaim, bool, error) {
-	return shared.ResolveScopedLeaseClaim(identifier, providerName, listOpenComputerLeaseClaims, func(claim LeaseClaim) error {
+func resolveOpenComputerLeaseClaim(identifier, baseURL string) (core.LeaseClaim, bool, error) {
+	return shared.ResolveScopedLeaseClaim(identifier, providerName, listOpenComputerLeaseClaims, func(claim core.LeaseClaim) error {
 		return validateOpenComputerClaimScope(claim, baseURL)
 	})
 }
 
-func finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL string) (string, string, string, error) {
+func finishResolvedLease(claim core.LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL string) (string, string, string, error) {
 	return shared.FinishScopedLease(claim, shared.ScopedLeaseFinishOptions{
 		Provider:      providerName,
 		LeasePrefix:   leasePrefix,
 		RepoRoot:      repoRoot,
 		Reclaim:       reclaim,
 		IdleTimeout:   idleTimeout,
-		ValidateClaim: func(claim LeaseClaim) error { return validateOpenComputerClaimScope(claim, baseURL) },
+		ValidateClaim: func(claim core.LeaseClaim) error { return validateOpenComputerClaimScope(claim, baseURL) },
 	})
 }
 
-func validateOpenComputerClaimScope(claim LeaseClaim, baseURL string) error {
+func validateOpenComputerClaimScope(claim core.LeaseClaim, baseURL string) error {
 	if !strings.HasPrefix(strings.TrimSpace(claim.ProviderScope), openComputerEndpointScope(baseURL)+"/ownership:") {
-		return exit(4, "opencomputer lease %q belongs to a different API endpoint; restore the endpoint used to create it", claim.LeaseID)
+		return core.Exit(4, "opencomputer lease %q belongs to a different API endpoint; restore the endpoint used to create it", claim.LeaseID)
 	}
 	return nil
 }
@@ -444,7 +444,7 @@ func validateOpenComputerClaimScope(claim LeaseClaim, baseURL string) error {
 func newOpenComputerClaimScope(baseURL string) (string, error) {
 	var token [16]byte
 	if _, err := rand.Read(token[:]); err != nil {
-		return "", exit(5, "generate opencomputer ownership token: %v", err)
+		return "", core.Exit(5, "generate opencomputer ownership token: %v", err)
 	}
 	return openComputerEndpointScope(baseURL) + "/ownership:" + hex.EncodeToString(token[:]), nil
 }
@@ -455,7 +455,7 @@ func openComputerEndpointScope(baseURL string) string {
 }
 
 func verifyOpenComputerClaim(ctx context.Context, api *ocAPIClient, leaseID, sandboxID string) (sandbox, error) {
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		return sandbox{}, err
 	}
@@ -472,15 +472,15 @@ func verifyOpenComputerClaim(ctx context.Context, api *ocAPIClient, leaseID, san
 	return sb, nil
 }
 
-func validateOpenComputerSandboxOwnership(claim LeaseClaim, sb sandbox) error {
+func validateOpenComputerSandboxOwnership(claim core.LeaseClaim, sb sandbox) error {
 	if sb.Tags[openComputerClaimTagKey] != claim.ProviderScope {
-		return exit(4, "opencomputer sandbox %q ownership tag does not match its local claim", sb.ID)
+		return core.Exit(4, "opencomputer sandbox %q ownership tag does not match its local claim", sb.ID)
 	}
 	return nil
 }
 
-func newSandboxName(repo Repo) string {
-	base := normalizeLeaseSlug(repo.Name)
+func newSandboxName(repo core.Repo) string {
+	base := core.NormalizeLeaseSlug(repo.Name)
 	if base == "" {
 		base = "crabbox"
 	}
@@ -520,18 +520,18 @@ func isTerminalState(state string) bool {
 
 // openComputerWorkdir returns the configured absolute workspace path inside the
 // sandbox, validating that it isn't relative, empty, or a broad system path.
-func openComputerWorkdir(cfg Config) (string, error) {
+func openComputerWorkdir(cfg core.Config) (string, error) {
 	workdir := strings.TrimSpace(cfg.OpenComputer.Workdir)
 	if workdir == "" {
 		workdir = core.OpenComputerConfigDefaultWorkdir
 	}
 	clean := path.Clean(workdir)
 	if !strings.HasPrefix(clean, "/") {
-		return "", exit(2, "opencomputer workdir %q must be an absolute path", workdir)
+		return "", core.Exit(2, "opencomputer workdir %q must be an absolute path", workdir)
 	}
 	switch clean {
 	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspace":
-		return "", exit(2, "opencomputer workdir %q is too broad; choose a dedicated subdirectory", clean)
+		return "", core.Exit(2, "opencomputer workdir %q is too broad; choose a dedicated subdirectory", clean)
 	}
 	return clean, nil
 }

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -195,14 +195,14 @@ func TestResolveLeaseIDRequiresIdentifier(t *testing.T) {
 func TestResolveLeaseIDFallsBackForSluglessClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "ocbx_sb-known123"
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "", providerName, testOCClaimScope("https://api.example.test"), "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "", providerName, testOCClaimScope("https://api.example.test"), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	gotLease, sandboxID, slug, err := resolveLeaseID(leaseID, "", false, 0, "https://api.example.test")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if gotLease != leaseID || sandboxID != "sb-known123" || slug != newLeaseSlug(leaseID) {
+	if gotLease != leaseID || sandboxID != "sb-known123" || slug != core.NewLeaseSlug(leaseID) {
 		t.Fatalf("lease=%q sandbox=%q slug=%q", gotLease, sandboxID, slug)
 	}
 }
@@ -210,10 +210,10 @@ func TestResolveLeaseIDFallsBackForSluglessClaim(t *testing.T) {
 func TestResolveLeaseIDPrefersExactLeaseOverCollidingSlug(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	exactLeaseID := "ocbx_sb-z-exact"
-	if err := claimLeaseForRepoProviderScopePond(exactLeaseID, "exact", providerName, testOCClaimScope("https://api.example.test"), "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(exactLeaseID, "exact", providerName, testOCClaimScope("https://api.example.test"), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := claimLeaseForRepoProviderScopePond("ocbx_sb-a-other", exactLeaseID, providerName, testOCClaimScope("https://api.example.test"), "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond("ocbx_sb-a-other", exactLeaseID, providerName, testOCClaimScope("https://api.example.test"), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	leaseID, sandboxID, _, err := resolveLeaseID(exactLeaseID, "", false, 0, "https://api.example.test")
@@ -229,10 +229,10 @@ func TestStopSurfacesMalformedExactClaimBeforeSlugFallback(t *testing.T) {
 	f := newFakeAPI(t)
 	backend := newAPIBackend(t, f)
 	exactLeaseID := leasePrefix + "sb-z-exact"
-	if err := claimLeaseForRepoProviderScopePond(exactLeaseID, "exact", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(exactLeaseID, "exact", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := claimLeaseForRepoProviderScopePond(leasePrefix+"sb-a-other", exactLeaseID, providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leasePrefix+"sb-a-other", exactLeaseID, providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	claimPath := path.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims", exactLeaseID+".json")
@@ -240,7 +240,7 @@ func TestStopSurfacesMalformedExactClaimBeforeSlugFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := backend.Stop(context.Background(), StopRequest{ID: exactLeaseID})
+	err := backend.Stop(context.Background(), core.StopRequest{ID: exactLeaseID})
 	if err == nil || !strings.Contains(err.Error(), "parse claim") {
 		t.Fatalf("Stop err=%v, want malformed exact claim error", err)
 	}
@@ -254,10 +254,10 @@ func TestStopRejectsClaimFromDifferentAPIAccount(t *testing.T) {
 	backend := newAPIBackend(t, f)
 	leaseID := leasePrefix + f.sandboxID
 	otherScope := openComputerEndpointScope(f.server.URL) + "/ownership:11111111111111111111111111111111"
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "other-account", providerName, otherScope, "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "other-account", providerName, otherScope, "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	err := backend.Stop(context.Background(), StopRequest{ID: leaseID})
+	err := backend.Stop(context.Background(), core.StopRequest{ID: leaseID})
 	if err == nil || !strings.Contains(err.Error(), "ownership tag") {
 		t.Fatalf("Stop err=%v, want ownership mismatch", err)
 	}
@@ -271,16 +271,16 @@ func TestRunVerifiesOwnershipBeforeReclaim(t *testing.T) {
 	backend := newAPIBackend(t, f)
 	leaseID := leasePrefix + f.sandboxID
 	otherScope := openComputerEndpointScope(f.server.URL) + "/ownership:11111111111111111111111111111111"
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "other-account", providerName, otherScope, "", "/original", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "other-account", providerName, otherScope, "", "/original", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	_, err := backend.Run(context.Background(), RunRequest{
-		ID: leaseID, Repo: Repo{Name: "carbbox", Root: "/replacement"}, Reclaim: true, NoSync: true, Command: []string{"true"},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		ID: leaseID, Repo: core.Repo{Name: "carbbox", Root: "/replacement"}, Reclaim: true, NoSync: true, Command: []string{"true"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "ownership tag") {
 		t.Fatalf("Run err=%v, want ownership mismatch", err)
 	}
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -290,26 +290,26 @@ func TestRunVerifiesOwnershipBeforeReclaim(t *testing.T) {
 }
 
 func TestNewSandboxName(t *testing.T) {
-	if name := newSandboxName(Repo{Name: "carbbox"}); !strings.HasPrefix(name, "crabbox-carbbox-") {
+	if name := newSandboxName(core.Repo{Name: "carbbox"}); !strings.HasPrefix(name, "crabbox-carbbox-") {
 		t.Fatalf("name=%q", name)
 	}
-	if name := newSandboxName(Repo{Name: "crabbox-app"}); strings.HasPrefix(name, "crabbox-crabbox-") || !strings.HasPrefix(name, "crabbox-app-") {
+	if name := newSandboxName(core.Repo{Name: "crabbox-app"}); strings.HasPrefix(name, "crabbox-crabbox-") || !strings.HasPrefix(name, "crabbox-app-") {
 		t.Fatalf("name=%q double/!prefixed", name)
 	}
-	if name := newSandboxName(Repo{Name: strings.Repeat("very-long-repo-name-", 8)}); len(name) > 63 || strings.HasSuffix(name, "-") {
+	if name := newSandboxName(core.Repo{Name: strings.Repeat("very-long-repo-name-", 8)}); len(name) > 63 || strings.HasSuffix(name, "-") {
 		t.Fatalf("name len=%d %q", len(name), name)
 	}
 }
 
 func TestSpecAllowsForceSyncLargeAndSyncOnly(t *testing.T) {
 	spec := Provider{}.Spec()
-	if err := core.RejectDelegatedSyncOptionsForSpec(spec, RunRequest{ForceSyncLarge: true}); err != nil {
+	if err := core.RejectDelegatedSyncOptionsForSpec(spec, core.RunRequest{ForceSyncLarge: true}); err != nil {
 		t.Fatalf("--force-sync-large should be allowed, got %v", err)
 	}
-	if err := core.RejectDelegatedSyncOptionsForSpec(spec, RunRequest{SyncOnly: true}); err != nil {
+	if err := core.RejectDelegatedSyncOptionsForSpec(spec, core.RunRequest{SyncOnly: true}); err != nil {
 		t.Fatalf("--sync-only should be allowed, got %v", err)
 	}
-	if err := core.RejectDelegatedSyncOptionsForSpec(spec, RunRequest{ChecksumSync: true}); err == nil {
+	if err := core.RejectDelegatedSyncOptionsForSpec(spec, core.RunRequest{ChecksumSync: true}); err == nil {
 		t.Fatalf("--checksum should be rejected")
 	}
 }
@@ -497,8 +497,8 @@ func (f *fakeAPI) firstRequest(method, path string) (recordedRequest, bool) {
 	return recordedRequest{}, false
 }
 
-func newTestConfig(apiURL string) Config {
-	cfg := Config{}
+func newTestConfig(apiURL string) core.Config {
+	cfg := core.Config{}
 	cfg.OpenComputer.APIURL = apiURL
 	cfg.OpenComputer.Workdir = "/workspace/crabbox"
 	return cfg
@@ -516,7 +516,7 @@ func newAPIBackend(t *testing.T, f *fakeAPI) *openComputerBackend {
 	t.Setenv("HOME", t.TempDir()) // no real ~/.oc/config.json
 	t.Setenv("CRABBOX_OPENCOMPUTER_API_KEY", "osb_testkey")
 	f.tags = map[string]string{openComputerClaimTagKey: testOCClaimScope(f.server.URL)}
-	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard, HTTP: f.server.Client()}
+	rt := core.Runtime{Stdout: io.Discard, Stderr: io.Discard, HTTP: f.server.Client()}
 	return NewOpenComputerBackend(Provider{}.Spec(), newTestConfig(f.server.URL), rt).(*openComputerBackend)
 }
 
@@ -526,8 +526,8 @@ func TestRunCreatesExecsAndKillsEphemeral(t *testing.T) {
 	f := newFakeAPI(t)
 	f.execReply = []execRunResult{{ExitCode: 0}, {ExitCode: 0, Stdout: "hello\n"}} // mkdir, user cmd
 	backend := newAPIBackend(t, f)
-	res, err := backend.Run(context.Background(), RunRequest{
-		Repo: Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"echo", "hello"}, NoSync: true,
+	res, err := backend.Run(context.Background(), core.RunRequest{
+		Repo: core.Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"echo", "hello"}, NoSync: true,
 	})
 	if err != nil {
 		t.Fatalf("Run err=%v", err)
@@ -544,7 +544,7 @@ func TestRunCreatesExecsAndKillsEphemeral(t *testing.T) {
 	if res.Session.Provider != providerName || res.Session.LeaseID != res.LeaseID || res.Session.Slug != res.Slug || res.Session.Reused || res.Session.Kept {
 		t.Fatalf("session=%#v result=%#v", res.Session, res)
 	}
-	if res.Session.CleanupCommand != "crabbox stop --provider opencomputer --id "+shellQuote(res.LeaseID) {
+	if res.Session.CleanupCommand != "crabbox stop --provider opencomputer --id "+core.ShellQuote(res.LeaseID) {
 		t.Fatalf("cleanup command=%q", res.Session.CleanupCommand)
 	}
 	if f.callsExact(http.MethodPost, "/api/sandboxes") != 1 {
@@ -591,13 +591,13 @@ func TestRunPreservesCommandErrorCause(t *testing.T) {
 				}
 				return transport.RoundTrip(req)
 			})
-			result, err := backend.Run(context.Background(), RunRequest{
-				Repo: Repo{Name: "fixture", Root: t.TempDir()}, Command: []string{"fixture-user"}, NoSync: true,
+			result, err := backend.Run(context.Background(), core.RunRequest{
+				Repo: core.Repo{Name: "fixture", Root: t.TempDir()}, Command: []string{"fixture-user"}, NoSync: true,
 			})
 			if !errors.Is(err, cause) {
 				t.Errorf("Run error %v lost cause %v", err, cause)
 			}
-			var exitErr ExitError
+			var exitErr core.ExitError
 			if !errors.As(err, &exitErr) || exitErr.Code != 1 || !strings.HasPrefix(err.Error(), "opencomputer run failed: ") {
 				t.Errorf("Run error=%v, want provider failure with exit code 1", err)
 			}
@@ -653,13 +653,13 @@ func TestRunCancellationThroughNativeHTTPTransport(t *testing.T) {
 				}
 				f.handle(w, r)
 			})
-			result, err := backend.Run(ctx, RunRequest{
-				Repo: Repo{Name: "fixture", Root: t.TempDir()}, Command: []string{"fixture-user"}, NoSync: true, KeepOnFailure: keep,
+			result, err := backend.Run(ctx, core.RunRequest{
+				Repo: core.Repo{Name: "fixture", Root: t.TempDir()}, Command: []string{"fixture-user"}, NoSync: true, KeepOnFailure: keep,
 			})
 			if !errors.Is(err, context.Canceled) {
 				t.Errorf("Run error %v lost native request cancellation", err)
 			}
-			var exitErr ExitError
+			var exitErr core.ExitError
 			if !errors.As(err, &exitErr) || exitErr.Code != 1 {
 				t.Errorf("Run error=%v, want exit code 1", err)
 			}
@@ -675,11 +675,11 @@ func TestRunCancellationThroughNativeHTTPTransport(t *testing.T) {
 				t.Fatalf("deletes=%d, keep-on-failure=%t", got, keep)
 			}
 			if keep {
-				if err := backend.Stop(context.Background(), StopRequest{ID: result.LeaseID}); err != nil {
+				if err := backend.Stop(context.Background(), core.StopRequest{ID: result.LeaseID}); err != nil {
 					t.Fatal(err)
 				}
 			}
-			if claim, err := readLeaseClaim(result.LeaseID); err != nil || claim.LeaseID != "" {
+			if claim, err := core.ReadLeaseClaim(result.LeaseID); err != nil || claim.LeaseID != "" {
 				t.Fatalf("claim remains after cleanup: %#v, %v", claim, err)
 			}
 		})
@@ -696,10 +696,10 @@ func TestRunCleanupCannotBlockForever(t *testing.T) {
 	backend.cleanupTimeoutOverride = 20 * time.Millisecond
 	started := time.Now()
 
-	res, err := backend.Run(context.Background(), RunRequest{
-		Repo: Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true,
+	res, err := backend.Run(context.Background(), core.RunRequest{
+		Repo: core.Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true,
 	})
-	var exitErr ExitError
+	var exitErr core.ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 1 || res.ExitCode != 1 || res.ErrorKind != core.RunErrorProvider {
 		t.Fatalf("result=%#v err=%v, want cleanup failure", res, err)
 	}
@@ -747,8 +747,8 @@ func TestRunLifecycleFinalization(t *testing.T) {
 			if tc.missingCommand {
 				command = nil
 			}
-			result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "fixture", Root: t.TempDir()}, Command: command, NoSync: true, TimingJSON: true, KeepOnFailure: tc.keepOnFailure})
-			var exitErr ExitError
+			result, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Name: "fixture", Root: t.TempDir()}, Command: command, NoSync: true, TimingJSON: true, KeepOnFailure: tc.keepOnFailure})
+			var exitErr core.ExitError
 			if !errors.As(err, &exitErr) || exitErr.Code != tc.wantCode || result.ExitCode != tc.wantCode || result.ErrorKind != tc.wantKind {
 				t.Errorf("result=%#v err=%v, want code=%d kind=%s", result, err, tc.wantCode, tc.wantKind)
 			}
@@ -771,7 +771,7 @@ func TestRunLifecycleFinalization(t *testing.T) {
 				}
 			}
 			fake.deleteStatus = 0
-			if err := backend.Stop(context.Background(), StopRequest{ID: result.LeaseID}); err != nil {
+			if err := backend.Stop(context.Background(), core.StopRequest{ID: result.LeaseID}); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -792,12 +792,12 @@ func TestRunClearsClaimWhenAcquiredSandboxAlreadyMissingAtCleanup(t *testing.T) 
 	f.deleteStatus = http.StatusNotFound
 	f.execReply = []execRunResult{{ExitCode: 0}, {ExitCode: 0}}
 	backend := newAPIBackend(t, f)
-	if _, err := backend.Run(context.Background(), RunRequest{
-		Repo: Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true,
+	if _, err := backend.Run(context.Background(), core.RunRequest{
+		Repo: core.Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true,
 	}); err != nil {
 		t.Fatalf("Run err=%v", err)
 	}
-	if _, ok, err := resolveLeaseClaim(leasePrefix + f.sandboxID); err != nil || ok {
+	if _, ok, err := core.ResolveLeaseClaim(leasePrefix + f.sandboxID); err != nil || ok {
 		t.Fatalf("acquired missing sandbox claim remains: ok=%t err=%v", ok, err)
 	}
 }
@@ -808,8 +808,8 @@ func TestRunForwardsEnvInExecBodyOffArgv(t *testing.T) {
 	backend := newAPIBackend(t, f)
 	var stderr bytes.Buffer
 	backend.rt.Stderr = &stderr
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:       Repo{Name: "carbbox", Root: t.TempDir()},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Name: "carbbox", Root: t.TempDir()},
 		Command:    []string{"printenv", "SECRET_TOKEN"},
 		NoSync:     true,
 		Env:        map[string]string{"SECRET_TOKEN": "super-secret"},
@@ -842,8 +842,8 @@ func TestRunUsesConfiguredExecTimeout(t *testing.T) {
 	f.execReply = []execRunResult{{ExitCode: 0}, {ExitCode: 0}}
 	backend := newAPIBackend(t, f)
 	backend.cfg.OpenComputer.ExecTimeoutSecs = 123
-	if _, err := backend.Run(context.Background(), RunRequest{
-		Repo: Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true,
+	if _, err := backend.Run(context.Background(), core.RunRequest{
+		Repo: core.Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true,
 	}); err != nil {
 		t.Fatalf("Run err=%v", err)
 	}
@@ -860,9 +860,9 @@ func TestRunRequiresAPIKey(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("CRABBOX_OPENCOMPUTER_API_KEY", "")
 	t.Setenv("OPENCOMPUTER_API_KEY", "")
-	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard, HTTP: f.server.Client()}
+	rt := core.Runtime{Stdout: io.Discard, Stderr: io.Discard, HTTP: f.server.Client()}
 	backend := NewOpenComputerBackend(Provider{}.Spec(), newTestConfig(f.server.URL), rt).(*openComputerBackend)
-	_, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "x", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true})
+	_, err := backend.Run(context.Background(), core.RunRequest{Repo: core.Repo{Name: "x", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true})
 	if err == nil || !strings.Contains(err.Error(), "API key") {
 		t.Fatalf("err=%v, want API-key error", err)
 	}
@@ -875,7 +875,7 @@ func TestRunPerformsArchiveSyncViaFileAPI(t *testing.T) {
 	f := newFakeAPI(t)
 	f.execReply = []execRunResult{{ExitCode: 0}, {ExitCode: 0}, {ExitCode: 0, Stdout: "done\n"}} // mkdir, extract, user
 	backend := newAPIBackend(t, f)
-	_, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"true"}})
+	_, err := backend.Run(context.Background(), core.RunRequest{Repo: core.Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"true"}})
 	if err != nil {
 		t.Fatalf("Run err=%v", err)
 	}
@@ -905,8 +905,8 @@ func TestSyncHonorsConfiguredTimeout(t *testing.T) {
 	repoRoot := newGitRepo(t)
 	result := make(chan error, 1)
 	go func() {
-		_, err := backend.Run(ctx, RunRequest{
-			Repo: Repo{Name: "carbbox", Root: repoRoot}, Command: []string{"true"}, Keep: true,
+		_, err := backend.Run(ctx, core.RunRequest{
+			Repo: core.Repo{Name: "carbbox", Root: repoRoot}, Command: []string{"true"}, Keep: true,
 		})
 		result <- err
 	}()
@@ -948,8 +948,8 @@ func TestSyncDeleteDoesNotTouchLiveWorkspaceBeforeUploadSucceeds(t *testing.T) {
 	f.uploadStatus = http.StatusServiceUnavailable
 	backend := newAPIBackend(t, f)
 	backend.cfg.Sync.Delete = true
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo: Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"true"}, Keep: true,
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo: core.Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"true"}, Keep: true,
 	})
 	if err == nil || !strings.Contains(err.Error(), "upload denied") {
 		t.Fatalf("Run err=%v, want upload failure", err)
@@ -972,8 +972,8 @@ func TestSyncFailureHonorsKeepOnFailure(t *testing.T) {
 	var stderr bytes.Buffer
 	backend.rt.Stderr = &stderr
 
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo: Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"true"}, KeepOnFailure: true,
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo: core.Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"true"}, KeepOnFailure: true,
 	})
 	if err == nil || !strings.Contains(err.Error(), "upload denied") {
 		t.Fatalf("Run err=%v, want upload failure", err)
@@ -982,8 +982,8 @@ func TestSyncFailureHonorsKeepOnFailure(t *testing.T) {
 		t.Fatal("sync failure deleted sandbox despite --keep-on-failure")
 	}
 	leaseID := leasePrefix + f.sandboxID
-	t.Cleanup(func() { removeLeaseClaim(leaseID) })
-	if claim, err := readLeaseClaim(leaseID); err != nil || claim.LeaseID != leaseID {
+	t.Cleanup(func() { core.RemoveLeaseClaim(leaseID) })
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil || claim.LeaseID != leaseID {
 		t.Fatalf("retained claim=%#v err=%v", claim, err)
 	}
 	if !strings.Contains(stderr.String(), "keep-on-failure: kept lease="+leaseID) {
@@ -995,8 +995,8 @@ func TestSyncDeleteStagesBeforeReplacingWorkspace(t *testing.T) {
 	f := newFakeAPI(t)
 	backend := newAPIBackend(t, f)
 	backend.cfg.Sync.Delete = true
-	if _, err := backend.Run(context.Background(), RunRequest{
-		Repo: Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"true"},
+	if _, err := backend.Run(context.Background(), core.RunRequest{
+		Repo: core.Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"true"},
 	}); err != nil {
 		t.Fatalf("Run err=%v", err)
 	}
@@ -1037,8 +1037,8 @@ func TestSyncDeleteWarnsWhenPreviousWorkspaceCleanupFails(t *testing.T) {
 	backend.cfg.Sync.Delete = true
 	var stderr bytes.Buffer
 	backend.rt.Stderr = &stderr
-	if _, err := backend.Run(context.Background(), RunRequest{
-		Repo: Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"true"},
+	if _, err := backend.Run(context.Background(), core.RunRequest{
+		Repo: core.Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"true"},
 	}); err != nil {
 		t.Fatalf("Run err=%v", err)
 	}
@@ -1053,11 +1053,11 @@ func TestNoSyncDoesNotDeleteRetainedWorkspace(t *testing.T) {
 	backend := newAPIBackend(t, f)
 	backend.cfg.Sync.Delete = true
 	leaseID := leasePrefix + f.sandboxID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "retained", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "retained", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := backend.Run(context.Background(), RunRequest{
-		ID: leaseID, Repo: Repo{Name: "carbbox", Root: "/repo"}, Command: []string{"true"}, NoSync: true,
+	if _, err := backend.Run(context.Background(), core.RunRequest{
+		ID: leaseID, Repo: core.Repo{Name: "carbbox", Root: "/repo"}, Command: []string{"true"}, NoSync: true,
 	}); err != nil {
 		t.Fatalf("Run err=%v", err)
 	}
@@ -1086,11 +1086,11 @@ func TestCreateSandboxForwardsPartialSizing(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			leaseID, _, _, err := backend.createSandbox(context.Background(), api, Repo{Name: "carbbox", Root: t.TempDir()}, false, "")
+			leaseID, _, _, err := backend.createSandbox(context.Background(), api, core.Repo{Name: "carbbox", Root: t.TempDir()}, false, "")
 			if err != nil {
 				t.Fatal(err)
 			}
-			t.Cleanup(func() { removeLeaseClaim(leaseID) })
+			t.Cleanup(func() { core.RemoveLeaseClaim(leaseID) })
 			recorded, ok := f.firstRequest(http.MethodPost, "/api/sandboxes")
 			if !ok {
 				t.Fatal("missing create request")
@@ -1114,11 +1114,11 @@ func TestCreateSandboxForwardsBurst(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	leaseID, _, _, err := backend.createSandbox(context.Background(), api, Repo{Name: "carbbox", Root: t.TempDir()}, false, "")
+	leaseID, _, _, err := backend.createSandbox(context.Background(), api, core.Repo{Name: "carbbox", Root: t.TempDir()}, false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { removeLeaseClaim(leaseID) })
+	t.Cleanup(func() { core.RemoveLeaseClaim(leaseID) })
 	recorded, ok := f.firstRequest(http.MethodPost, "/api/sandboxes")
 	if !ok {
 		t.Fatal("missing create request")
@@ -1147,7 +1147,7 @@ func TestCreateSandboxReportsCleanupFailureAndSandboxID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	leaseID, sandboxID, _, err := backend.createSandbox(context.Background(), api, Repo{Name: "carbbox", Root: t.TempDir()}, false, "taken")
+	leaseID, sandboxID, _, err := backend.createSandbox(context.Background(), api, core.Repo{Name: "carbbox", Root: t.TempDir()}, false, "taken")
 	if err == nil {
 		t.Fatal("expected claim setup and cleanup failure")
 	}
@@ -1165,7 +1165,7 @@ func TestSyncOnlySkipsUserCommand(t *testing.T) {
 	f := newFakeAPI(t)
 	f.execReply = []execRunResult{{ExitCode: 0}, {ExitCode: 0}} // mkdir, extract
 	backend := newAPIBackend(t, f)
-	res, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"echo", "should-not-run"}, SyncOnly: true})
+	res, err := backend.Run(context.Background(), core.RunRequest{Repo: core.Repo{Name: "carbbox", Root: newGitRepo(t)}, Command: []string{"echo", "should-not-run"}, SyncOnly: true})
 	if err != nil {
 		t.Fatalf("Run err=%v", err)
 	}
@@ -1188,11 +1188,11 @@ func TestRunSurfacesNonZeroExit(t *testing.T) {
 	backend := newAPIBackend(t, f)
 	var stderr bytes.Buffer
 	backend.rt.Stderr = &stderr
-	res, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"false"}, NoSync: true, TimingJSON: true})
+	res, err := backend.Run(context.Background(), core.RunRequest{Repo: core.Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"false"}, NoSync: true, TimingJSON: true})
 	if res.ExitCode != 7 {
 		t.Fatalf("exit=%d want 7", res.ExitCode)
 	}
-	ee, ok := err.(ExitError)
+	ee, ok := err.(core.ExitError)
 	if !ok || ee.Code != 7 {
 		t.Fatalf("err=%v want ExitError code 7", err)
 	}
@@ -1210,7 +1210,7 @@ func TestKeepRetainsSandbox(t *testing.T) {
 	f := newFakeAPI(t)
 	f.execReply = []execRunResult{{ExitCode: 0}, {ExitCode: 0}}
 	backend := newAPIBackend(t, f)
-	res, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, Keep: true})
+	res, err := backend.Run(context.Background(), core.RunRequest{Repo: core.Repo{Name: "carbbox", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, Keep: true})
 	if err != nil {
 		t.Fatalf("Run err=%v", err)
 	}
@@ -1228,12 +1228,12 @@ func TestRunReturnsReusedSandboxSession(t *testing.T) {
 	backend := newAPIBackend(t, f)
 	repoRoot := t.TempDir()
 	leaseID := leasePrefix + f.sandboxID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "blue", providerName, testOCClaimScope(f.server.URL), "", repoRoot, time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "blue", providerName, testOCClaimScope(f.server.URL), "", repoRoot, time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	res, err := backend.Run(context.Background(), RunRequest{
+	res, err := backend.Run(context.Background(), core.RunRequest{
 		ID:      leaseID,
-		Repo:    Repo{Name: "carbbox", Root: repoRoot},
+		Repo:    core.Repo{Name: "carbbox", Root: repoRoot},
 		Command: []string{"true"},
 		NoSync:  true,
 	})
@@ -1251,7 +1251,7 @@ func TestRunReturnsReusedSandboxSession(t *testing.T) {
 func TestWarmupRejectsActionsRunnerBeforeCreate(t *testing.T) {
 	f := newFakeAPI(t)
 	backend := newAPIBackend(t, f)
-	err := backend.Warmup(context.Background(), WarmupRequest{ActionsRunner: true})
+	err := backend.Warmup(context.Background(), core.WarmupRequest{ActionsRunner: true})
 	if err == nil || !strings.Contains(err.Error(), "--actions-runner is not supported") {
 		t.Fatalf("Warmup err=%v", err)
 	}
@@ -1263,7 +1263,7 @@ func TestWarmupRejectsActionsRunnerBeforeCreate(t *testing.T) {
 func TestStopRejectsUnclaimedID(t *testing.T) {
 	f := newFakeAPI(t)
 	backend := newAPIBackend(t, f)
-	err := backend.Stop(context.Background(), StopRequest{ID: "sb-not-claimed"})
+	err := backend.Stop(context.Background(), core.StopRequest{ID: "sb-not-claimed"})
 	if err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
 		t.Fatalf("err=%v want unclaimed rejection", err)
 	}
@@ -1274,14 +1274,14 @@ func TestStopClearsClaimWhenSandboxAlreadyDeleted(t *testing.T) {
 	f.deleteStatus = http.StatusNotFound
 	backend := newAPIBackend(t, f)
 	leaseID := leasePrefix + f.sandboxID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "gone", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "gone", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	backend.cfg.OpenComputer.ForgetMissing = true
-	if err := backend.Stop(context.Background(), StopRequest{ID: leaseID}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: leaseID}); err != nil {
 		t.Fatalf("Stop err=%v", err)
 	}
-	if _, ok, err := resolveLeaseClaim(leaseID); err != nil || ok {
+	if _, ok, err := core.ResolveLeaseClaim(leaseID); err != nil || ok {
 		t.Fatalf("claim remains after idempotent stop: ok=%t err=%v", ok, err)
 	}
 }
@@ -1291,17 +1291,17 @@ func TestStopPreservesClaimForAmbiguousMissingSandbox(t *testing.T) {
 	f.deleteStatus = http.StatusNotFound
 	backend := newAPIBackend(t, f)
 	leaseID := leasePrefix + f.sandboxID
-	if err := claimLeaseForRepoProviderScopePond(leaseID, "possibly-other-account", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, "possibly-other-account", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	err := backend.Stop(context.Background(), StopRequest{ID: leaseID})
+	err := backend.Stop(context.Background(), core.StopRequest{ID: leaseID})
 	if err == nil || !strings.Contains(err.Error(), "404") {
 		t.Fatalf("Stop err=%v, want ambiguous missing error", err)
 	}
 	if f.calls(http.MethodDelete, "/api/sandboxes/") != 1 {
 		t.Fatal("stop did not attempt remote deletion")
 	}
-	if _, ok, err := resolveLeaseClaim(leaseID); err != nil || !ok {
+	if _, ok, err := core.ResolveLeaseClaim(leaseID); err != nil || !ok {
 		t.Fatalf("claim removed without explicit forget: ok=%t err=%v", ok, err)
 	}
 }
@@ -1320,7 +1320,7 @@ func TestAPIURLPrecedenceHonorsOCConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	// No explicit Crabbox API URL → oc config api_url wins over the default.
-	api, err := newOCAPIClient(newTestConfig(""), Runtime{})
+	api, err := newOCAPIClient(newTestConfig(""), core.Runtime{})
 	if err != nil {
 		t.Fatalf("newOCAPIClient err=%v", err)
 	}
@@ -1331,7 +1331,7 @@ func TestAPIURLPrecedenceHonorsOCConfig(t *testing.T) {
 		t.Fatalf("apiKey not read from oc config: %q", api.apiKey)
 	}
 	// Explicit Crabbox API URL takes precedence over the oc config file.
-	api, err = newOCAPIClient(newTestConfig("https://explicit.example"), Runtime{})
+	api, err = newOCAPIClient(newTestConfig("https://explicit.example"), core.Runtime{})
 	if err != nil {
 		t.Fatalf("newOCAPIClient err=%v", err)
 	}
@@ -1352,7 +1352,7 @@ func TestAPIURLRejectsUnsafeCredentialDestinations(t *testing.T) {
 		"api.example.test",
 	} {
 		t.Run(apiURL, func(t *testing.T) {
-			if _, err := newOCAPIClient(newTestConfig(apiURL), Runtime{}); err == nil {
+			if _, err := newOCAPIClient(newTestConfig(apiURL), core.Runtime{}); err == nil {
 				t.Fatalf("newOCAPIClient(%q) succeeded", apiURL)
 			}
 		})
@@ -1369,7 +1369,7 @@ func TestAPIURLAllowsLoopbackHTTP(t *testing.T) {
 		"http://[::1]:8080/",
 	} {
 		t.Run(apiURL, func(t *testing.T) {
-			api, err := newOCAPIClient(newTestConfig(apiURL), Runtime{})
+			api, err := newOCAPIClient(newTestConfig(apiURL), core.Runtime{})
 			if err != nil {
 				t.Fatalf("newOCAPIClient(%q) err=%v", apiURL, err)
 			}
@@ -1384,7 +1384,7 @@ func TestAPIURLNormalizesTrailingAPISuffix(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("CRABBOX_OPENCOMPUTER_API_KEY", "osb_test")
 	t.Setenv("OPENCOMPUTER_API_KEY", "")
-	api, err := newOCAPIClient(newTestConfig("https://api.example.test/gateway/api/"), Runtime{})
+	api, err := newOCAPIClient(newTestConfig("https://api.example.test/gateway/api/"), core.Runtime{})
 	if err != nil {
 		t.Fatalf("newOCAPIClient err=%v", err)
 	}
@@ -1432,7 +1432,7 @@ func TestAPIClientBlocksCrossOriginRedirects(t *testing.T) {
 	}))
 	defer source.Close()
 
-	api, err := newOCAPIClient(newTestConfig(source.URL), Runtime{HTTP: source.Client()})
+	api, err := newOCAPIClient(newTestConfig(source.URL), core.Runtime{HTTP: source.Client()})
 	if err != nil {
 		t.Fatalf("newOCAPIClient err=%v", err)
 	}
@@ -1545,7 +1545,7 @@ func TestControlAndExecRequestsUseOperationDeadlines(t *testing.T) {
 			Request:    req,
 		}, nil
 	})}
-	api, err := newOCAPIClient(newTestConfig(""), Runtime{HTTP: httpClient})
+	api, err := newOCAPIClient(newTestConfig(""), core.Runtime{HTTP: httpClient})
 	if err != nil {
 		t.Fatalf("newOCAPIClient err=%v", err)
 	}
@@ -1579,7 +1579,7 @@ func TestListFetchesClaimedHibernatedSandbox(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Unclaimed sandboxes are not inventory and do not trigger remote calls.
-	views, err := backend.List(context.Background(), ListRequest{})
+	views, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatalf("List err=%v", err)
 	}
@@ -1591,10 +1591,10 @@ func TestListFetchesClaimedHibernatedSandbox(t *testing.T) {
 	}
 	// The collection endpoint omits hibernated sandboxes, so List must fetch
 	// each locally claimed sandbox by ID.
-	if err := claimLeaseForRepoProviderScopePond("ocbx_"+f.sandboxID, "slug", providerName, testOCClaimScope(f.server.URL), "alpha", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond("ocbx_"+f.sandboxID, "slug", providerName, testOCClaimScope(f.server.URL), "alpha", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	views, err = backend.List(context.Background(), ListRequest{})
+	views, err = backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatalf("List err=%v", err)
 	}
@@ -1607,7 +1607,7 @@ func TestListFetchesClaimedHibernatedSandbox(t *testing.T) {
 	if f.callsExact(http.MethodGet, "/api/sandboxes/"+f.sandboxID+"/tags") != 1 {
 		t.Fatalf("want one ownership-tag fetch, requests=%#v", f.requests)
 	}
-	status, err := backend.Status(context.Background(), StatusRequest{ID: "slug"})
+	status, err := backend.Status(context.Background(), core.StatusRequest{ID: "slug"})
 	if err != nil {
 		t.Fatalf("Status err=%v", err)
 	}
@@ -1620,10 +1620,10 @@ func TestListKeepsAmbiguousMissingClaimVisible(t *testing.T) {
 	f := newFakeAPI(t)
 	f.getStatusCode = http.StatusNotFound
 	backend := newAPIBackend(t, f)
-	if err := claimLeaseForRepoProviderScopePond(leasePrefix+f.sandboxID, "ambiguous", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leasePrefix+f.sandboxID, "ambiguous", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	views, err := backend.List(context.Background(), ListRequest{})
+	views, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatalf("List err=%v", err)
 	}
@@ -1635,14 +1635,14 @@ func TestListKeepsAmbiguousMissingClaimVisible(t *testing.T) {
 func TestListSurfacesMalformedMatchingClaim(t *testing.T) {
 	f := newFakeAPI(t)
 	backend := newAPIBackend(t, f)
-	if err := claimLeaseForRepoProviderScopePond(leasePrefix+f.sandboxID, "valid", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leasePrefix+f.sandboxID, "valid", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	claimsDir := path.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims")
 	if err := os.WriteFile(path.Join(claimsDir, leasePrefix+"broken.json"), []byte("{"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	_, err := backend.List(context.Background(), ListRequest{})
+	_, err := backend.List(context.Background(), core.ListRequest{})
 	if err == nil || !strings.Contains(err.Error(), "parse claim") {
 		t.Fatalf("List err=%v, want malformed matching claim error", err)
 	}
@@ -1652,7 +1652,7 @@ func TestDoctorProbesControlPlaneWithoutClaims(t *testing.T) {
 	f := newFakeAPI(t)
 	f.listStatus = http.StatusUnauthorized
 	backend := newAPIBackend(t, f)
-	_, err := backend.Doctor(context.Background(), DoctorRequest{})
+	_, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err == nil || !strings.Contains(err.Error(), "list denied") {
 		t.Fatalf("Doctor err=%v, want control-plane failure", err)
 	}
@@ -1667,10 +1667,10 @@ func TestStatusSurfacesAPIError(t *testing.T) {
 	f := newFakeAPI(t)
 	f.getStatusCode = http.StatusInternalServerError
 	backend := newAPIBackend(t, f)
-	if err := claimLeaseForRepoProviderScopePond("ocbx_"+f.sandboxID, "slug", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond("ocbx_"+f.sandboxID, "slug", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	_, err := backend.Status(context.Background(), StatusRequest{ID: "ocbx_" + f.sandboxID})
+	_, err := backend.Status(context.Background(), core.StatusRequest{ID: "ocbx_" + f.sandboxID})
 	if err == nil || !strings.Contains(err.Error(), "500") {
 		t.Fatalf("err=%v, want surfaced API error", err)
 	}
@@ -1680,11 +1680,11 @@ func TestStatusWaitTimeoutCancelsBlockedAPIRequest(t *testing.T) {
 	f := newFakeAPI(t)
 	f.blockGet = true
 	backend := newAPIBackend(t, f)
-	if err := claimLeaseForRepoProviderScopePond(leasePrefix+f.sandboxID, "slug", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leasePrefix+f.sandboxID, "slug", providerName, testOCClaimScope(f.server.URL), "", "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	started := time.Now()
-	_, err := backend.Status(context.Background(), StatusRequest{
+	_, err := backend.Status(context.Background(), core.StatusRequest{
 		ID: leasePrefix + f.sandboxID, Wait: true, WaitTimeout: 50 * time.Millisecond,
 	})
 	if err == nil || !strings.Contains(err.Error(), "timed out waiting") {
@@ -1715,8 +1715,8 @@ func TestRunCommandIntentReachesNativeRequest(t *testing.T) {
 	testutil.VerifyNativeCommandIntent(t, "bash", true, func(t *testing.T, intent testutil.CommandIntent) []string {
 		fake := newFakeAPI(t)
 		backend := newAPIBackend(t, fake)
-		_, err := backend.Run(t.Context(), RunRequest{
-			Repo:               Repo{Name: "my-app", Root: t.TempDir()},
+		_, err := backend.Run(t.Context(), core.RunRequest{
+			Repo:               core.Repo{Name: "my-app", Root: t.TempDir()},
 			NoSync:             true,
 			Command:            intent.Command,
 			ShellMode:          intent.ShellMode,
@@ -1736,7 +1736,7 @@ func TestRunCommandIntentReachesNativeRequest(t *testing.T) {
 func TestRunMissingCommandRetainsCleanup(t *testing.T) {
 	fake := newFakeAPI(t)
 	backend := newAPIBackend(t, fake)
-	_, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "my-app", Root: t.TempDir()}, NoSync: true})
+	_, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Name: "my-app", Root: t.TempDir()}, NoSync: true})
 	if err == nil || err.Error() != "missing command" {
 		t.Fatalf("err=%v", err)
 	}
@@ -1750,7 +1750,7 @@ func TestRunMissingCommandRetainsCleanup(t *testing.T) {
 
 func TestOpenComputerConfigFlagContract(t *testing.T) {
 	for _, provider := range []string{"opencomputer", " OC ", "open-computer", "aws"} {
-		cfg := Config{Provider: provider, OpenComputer: core.OpenComputerConfig{APIURL: "prior-url", Workdir: "/workspace/prior", CPU: 8, MemoryMB: 1024, TimeoutSecs: 45, ExecTimeoutSecs: 90, Burst: true, ForgetMissing: true}}
+		cfg := core.Config{Provider: provider, OpenComputer: core.OpenComputerConfig{APIURL: "prior-url", Workdir: "/workspace/prior", CPU: 8, MemoryMB: 1024, TimeoutSecs: 45, ExecTimeoutSecs: 90, Burst: true, ForgetMissing: true}}
 		fs := flag.NewFlagSet("contract", flag.ContinueOnError)
 		values := RegisterOpenComputerProviderFlags(fs, cfg)
 		count := 0
@@ -1801,7 +1801,7 @@ func TestOpenComputerConfigFlagContract(t *testing.T) {
 func TestOpenComputerConfigMachineFlagOrder(t *testing.T) {
 	for _, provider := range []string{"opencomputer", " OC ", "open-computer", "aws"} {
 		for _, args := range [][]string{{"--class=large", "--type=machine"}, {"--type=machine"}} {
-			cfg := Config{Provider: provider}
+			cfg := core.Config{Provider: provider}
 			fs := flag.NewFlagSet("contract", flag.ContinueOnError)
 			fs.String("class", "", "")
 			fs.String("type", "", "")
@@ -1829,15 +1829,15 @@ func TestOpenComputerConfigMachineFlagOrder(t *testing.T) {
 
 func TestOpenComputerConfigEffectiveDefaults(t *testing.T) {
 	for _, tc := range []struct{ workdir, want string }{{"", "/workspace/crabbox"}, {"  ", "/workspace/crabbox"}, {" /workspace/example/ ", "/workspace/example"}} {
-		cfg := Config{OpenComputer: core.OpenComputerConfig{Workdir: tc.workdir}}
+		cfg := core.Config{OpenComputer: core.OpenComputerConfig{Workdir: tc.workdir}}
 		got, err := openComputerWorkdir(cfg)
 		if err != nil || got != tc.want {
 			t.Fatalf("workdir=%q err=%v want=%q", got, err, tc.want)
 		}
 	}
 	for _, n := range []int{-2, 0, 45} {
-		cfg := Config{OpenComputer: core.OpenComputerConfig{ExecTimeoutSecs: n}}
-		backend := NewOpenComputerBackend(Provider{}.Spec(), cfg, Runtime{}).(*openComputerBackend)
+		cfg := core.Config{OpenComputer: core.OpenComputerConfig{ExecTimeoutSecs: n}}
+		backend := NewOpenComputerBackend(Provider{}.Spec(), cfg, core.Runtime{}).(*openComputerBackend)
 		want := 3600
 		if n > 0 {
 			want = n
@@ -1872,7 +1872,7 @@ func TestOpenComputerConfigClientFallbackContract(t *testing.T) {
 			if err := os.WriteFile(home+"/.oc/config.json", data, 0600); err != nil {
 				t.Fatal(err)
 			}
-			api, err := newOCAPIClient(Config{}, Runtime{})
+			api, err := newOCAPIClient(core.Config{}, core.Runtime{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/providers/opencomputer/core.go
+++ b/internal/providers/opencomputer/core.go
@@ -1,31 +1,8 @@
 package opencomputer
 
 import (
-	"io"
-	"time"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type Server = core.Server
-type Repo = core.Repo
-type LeaseClaim = core.LeaseClaim
-type ExitError = core.ExitError
-type timingPhase = core.TimingPhase
 
 const (
 	providerName    = "opencomputer"
@@ -40,50 +17,6 @@ const (
 	sandboxNameSuffixLen = 6
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
-}
-
-func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaim(identifier)
-}
-
-func readLeaseClaim(leaseID string) (core.LeaseClaim, error) {
-	return core.ReadLeaseClaim(leaseID)
-}
-
 func listOpenComputerLeaseClaims() ([]core.LeaseClaim, error) {
 	return core.ListLeaseClaimsWithPrefix(leasePrefix)
-}
-
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
-func shellQuote(s string) string {
-	return core.ShellQuote(s)
-}
-
-func inventoryDoctorResult(provider string, leases int) DoctorResult {
-	return core.InventoryDoctorResult(provider, leases)
 }

--- a/internal/providers/opencomputer/flags.go
+++ b/internal/providers/opencomputer/flags.go
@@ -7,11 +7,11 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func RegisterOpenComputerProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterOpenComputerProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterOpenComputerConfigFlags(fs, defaults.OpenComputer)
 }
 
-func ApplyOpenComputerProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyOpenComputerProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --opencomputer-cpu and --opencomputer-memory-mb", "use --opencomputer-cpu and --opencomputer-memory-mb"); err != nil {
 			return err

--- a/internal/providers/opencomputer/sync.go
+++ b/internal/providers/opencomputer/sync.go
@@ -9,7 +9,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClient, sandboxID string, req RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClient, sandboxID string, req core.RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
@@ -42,11 +42,11 @@ func (b *openComputerBackend) execShell(ctx context.Context, api *ocAPIClient, s
 		return err
 	}
 	if res.ExitCode != 0 {
-		return exit(res.ExitCode, "opencomputer exec %q exited %d: %s", command, res.ExitCode, strings.TrimSpace(res.Stderr))
+		return core.Exit(res.ExitCode, "opencomputer exec %q exited %d: %s", command, res.ExitCode, strings.TrimSpace(res.Stderr))
 	}
 	return nil
 }
 
 func (b *openComputerBackend) ensureWorkspace(ctx context.Context, api *ocAPIClient, sandboxID, workdir string) error {
-	return b.execShell(ctx, api, sandboxID, "mkdir -p "+shellQuote(workdir))
+	return b.execShell(ctx, api, sandboxID, "mkdir -p "+core.ShellQuote(workdir))
 }

--- a/internal/providers/orgo/backend.go
+++ b/internal/providers/orgo/backend.go
@@ -25,16 +25,16 @@ const (
 
 var orgoEnvNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
-func NewOrgoBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewOrgoBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	applyOrgoDefaults(&cfg)
 	return &orgoBackend{spec: spec, cfg: cfg, rt: rt}
 }
 
 type orgoBackend struct {
-	spec   ProviderSpec
-	cfg    Config
-	rt     Runtime
+	spec   core.ProviderSpec
+	cfg    core.Config
+	rt     core.Runtime
 	client orgoAPI
 }
 
@@ -45,14 +45,14 @@ type orgoLease struct {
 	CreatedWorkspace string
 }
 
-func (b *orgoBackend) Spec() ProviderSpec { return b.spec }
+func (b *orgoBackend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *orgoBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *orgoBackend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if req.ActionsRunner {
-		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+		return core.Exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
 	if req.Options.Tailscale.Enabled {
-		return exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
+		return core.Exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
 	}
 	started := core.ClockNow(b.rt.Clock)
 	client, err := b.api()
@@ -76,40 +76,40 @@ func (b *orgoBackend) Warmup(ctx context.Context, req WarmupRequest) error {
 	})
 }
 
-func (b *orgoBackend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {
+func (b *orgoBackend) Run(ctx context.Context, req core.RunRequest) (result core.RunResult, retErr error) {
 	if err := b.rejectRunOptions(req); err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	if len(req.Command) == 0 {
-		return RunResult{}, exit(2, "missing command")
+		return core.RunResult{}, core.Exit(2, "missing command")
 	}
 	started := core.ClockNow(b.rt.Clock)
 	client, err := b.api()
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	lease := orgoLease{}
 	acquired := false
 	if strings.TrimSpace(req.ID) == "" {
 		lease, err = b.createComputer(ctx, client, req.Repo, req.RequestedSlug, req.Reclaim)
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 		acquired = true
 		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s computer=%s workspace=%s\n", lease.LeaseID, lease.Slug, providerName, lease.Computer.ID, lease.Computer.WorkspaceID)
 	} else {
 		lease, err = b.resolveComputer(ctx, client, req.ID)
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 		lease.Computer, err = b.ensureComputerRunning(ctx, client, lease.Computer)
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 	}
 
 	shouldStop := acquired && !req.Keep
-	result = RunResult{Provider: providerName, LeaseID: lease.LeaseID, Slug: lease.Slug, SyncDelegated: true}
+	result = core.RunResult{Provider: providerName, LeaseID: lease.LeaseID, Slug: lease.Slug, SyncDelegated: true}
 	commandRan := false
 	defer func() {
 		// HTTP failures expose provider-specific public codes. Pin the primary
@@ -126,7 +126,7 @@ func (b *orgoBackend) Run(ctx context.Context, req RunRequest) (result RunResult
 			fmt.Fprintf(b.rt.Stderr, "orgo run summary sync_delegated=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
 		}
 		if req.TimingJSON {
-			timingErr := writeTimingJSON(b.rt.Stderr, core.TimingReportWithRunResult(timingReport{
+			timingErr := core.WriteTimingJSON(b.rt.Stderr, core.TimingReportWithRunResult(core.TimingReport{
 				Provider: providerName, LeaseID: lease.LeaseID, Slug: lease.Slug,
 				SyncDelegated: true, SyncSkipped: true,
 				CommandMs: result.Command.Milliseconds(), TotalMs: result.Total.Milliseconds(),
@@ -142,7 +142,7 @@ func (b *orgoBackend) Run(ctx context.Context, req RunRequest) (result RunResult
 	}
 	result.CommandText = orgoCommandText(req)
 	if req.EnvSummary {
-		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+		core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
 	commandStarted := core.ClockNow(b.rt.Clock)
 	req.Observation.Phase(core.RunPhaseCommand)
@@ -151,19 +151,19 @@ func (b *orgoBackend) Run(ctx context.Context, req RunRequest) (result RunResult
 	result.Command = core.ClockNow(b.rt.Clock).Sub(commandStarted)
 	commandRan = true
 	if runErr != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, lease.LeaseID, lease.Slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		core.HandleDelegatedRunFailure(b.rt.Stderr, req, providerName, lease.LeaseID, lease.Slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 		return result, runErr
 	}
 	outcome := shared.FinalizeDelegatedCommandOutcome(exitCode, nil)
 	result.ExitCode, result.Status, result.ErrorKind = outcome.ExitCode, outcome.Status, outcome.ErrorKind
 	if result.ExitCode != 0 {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, lease.LeaseID, lease.Slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s computer exit=%d", providerName, result.ExitCode)}
+		core.HandleDelegatedRunFailure(b.rt.Stderr, req, providerName, lease.LeaseID, lease.Slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		return result, core.ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s computer exit=%d", providerName, result.ExitCode)}
 	}
 	return result, nil
 }
 
-func (b *orgoBackend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+func (b *orgoBackend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
 	client, err := b.api()
 	if err != nil {
 		return nil, err
@@ -172,15 +172,15 @@ func (b *orgoBackend) List(ctx context.Context, _ ListRequest) ([]LeaseView, err
 	if err != nil {
 		return nil, err
 	}
-	claimsByComputer := map[string]LeaseClaim{}
-	if claims, err := listLeaseClaims(); err == nil {
+	claimsByComputer := map[string]core.LeaseClaim{}
+	if claims, err := core.ListLeaseClaims(); err == nil {
 		for _, claim := range claims {
 			if claim.Provider == providerName && strings.TrimSpace(claim.CloudID) != "" && b.validateOrgoClaim(claim) == nil {
 				claimsByComputer[claim.CloudID] = claim
 			}
 		}
 	}
-	servers := make([]Server, 0, len(computers))
+	servers := make([]core.Server, 0, len(computers))
 	for _, computer := range computers {
 		claim := claimsByComputer[computer.ID]
 		servers = append(servers, orgoComputerServer(computer, claim))
@@ -188,17 +188,17 @@ func (b *orgoBackend) List(ctx context.Context, _ ListRequest) ([]LeaseView, err
 	return servers, nil
 }
 
-func (b *orgoBackend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *orgoBackend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	if strings.TrimSpace(req.ID) == "" {
-		return StatusView{}, exit(2, "provider=%s status requires --id <computer-id-or-slug>", providerName)
+		return core.StatusView{}, core.Exit(2, "provider=%s status requires --id <computer-id-or-slug>", providerName)
 	}
 	client, err := b.api()
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	lease, err := b.resolveComputer(ctx, client, req.ID)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	timeout := req.WaitTimeout
 	if timeout <= 0 {
@@ -212,27 +212,27 @@ func (b *orgoBackend) Status(ctx context.Context, req StatusRequest) (StatusView
 		}
 		switch view.State {
 		case "error", "failed", "deleted":
-			return view, exit(5, "orgo computer %s entered %s state", lease.Computer.ID, view.State)
+			return view, core.Exit(5, "orgo computer %s entered %s state", lease.Computer.ID, view.State)
 		}
 		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return StatusView{}, exit(5, "timed out waiting for orgo computer %s to become ready", lease.Computer.ID)
+			return core.StatusView{}, core.Exit(5, "timed out waiting for orgo computer %s to become ready", lease.Computer.ID)
 		}
 		select {
 		case <-ctx.Done():
-			return StatusView{}, ctx.Err()
+			return core.StatusView{}, ctx.Err()
 		case <-time.After(1 * time.Second):
 		}
 		computer, err := client.GetComputer(ctx, lease.Computer.ID)
 		if err != nil {
-			return StatusView{}, err
+			return core.StatusView{}, err
 		}
 		lease.Computer = computer
 	}
 }
 
-func (b *orgoBackend) Stop(ctx context.Context, req StopRequest) error {
+func (b *orgoBackend) Stop(ctx context.Context, req core.StopRequest) error {
 	if strings.TrimSpace(req.ID) == "" {
-		return exit(2, "provider=%s stop requires --id <computer-id-or-slug>", providerName)
+		return core.Exit(2, "provider=%s stop requires --id <computer-id-or-slug>", providerName)
 	}
 	client, err := b.api()
 	if err != nil {
@@ -258,11 +258,11 @@ func (b *orgoBackend) resolveClaimedComputer(ctx context.Context, client orgoAPI
 		}
 	}
 	if !ok {
-		return orgoLease{}, exit(4, "provider=%s refuses to stop unclaimed computer %s", providerName, id)
+		return orgoLease{}, core.Exit(4, "provider=%s refuses to stop unclaimed computer %s", providerName, id)
 	}
 	computerID := strings.TrimSpace(claim.CloudID)
 	if computerID == "" {
-		return orgoLease{}, exit(4, "provider=%s claim %s has no computer identity", providerName, claim.LeaseID)
+		return orgoLease{}, core.Exit(4, "provider=%s claim %s has no computer identity", providerName, claim.LeaseID)
 	}
 	if err := b.validateOrgoClaim(claim); err != nil {
 		return orgoLease{}, err
@@ -308,25 +308,25 @@ func (b *orgoBackend) resolveClaimedComputer(ctx context.Context, client orgoAPI
 	if computer.WorkspaceID == "" {
 		computer.WorkspaceID = lease.Computer.WorkspaceID
 	} else if computer.WorkspaceID != lease.Computer.WorkspaceID {
-		return orgoLease{}, exit(2, "provider=%s computer %s belongs to a different workspace namespace", providerName, computer.ID)
+		return orgoLease{}, core.Exit(2, "provider=%s computer %s belongs to a different workspace namespace", providerName, computer.ID)
 	}
 	if expected := strings.TrimSpace(claim.Labels["orgo_instance_id"]); expected != "" && computer.InstanceID != "" && computer.InstanceID != expected {
-		return orgoLease{}, exit(2, "provider=%s computer %s no longer matches its claimed instance identity", providerName, computer.ID)
+		return orgoLease{}, core.Exit(2, "provider=%s computer %s no longer matches its claimed instance identity", providerName, computer.ID)
 	}
 	lease.Computer = computer
 	return lease, nil
 }
 
-func (b *orgoBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *orgoBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	client, err := b.api()
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
 	computers, err := b.listComputers(ctx, client)
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return inventoryDoctorResult(providerName, len(computers)), nil
+	return core.InventoryDoctorResult(providerName, len(computers)), nil
 }
 
 func (b *orgoBackend) api() (orgoAPI, error) {
@@ -341,9 +341,9 @@ func (b *orgoBackend) api() (orgoAPI, error) {
 	return client, nil
 }
 
-func (b *orgoBackend) createComputer(ctx context.Context, client orgoAPI, repo Repo, requestedSlug string, reclaim bool) (orgoLease, error) {
+func (b *orgoBackend) createComputer(ctx context.Context, client orgoAPI, repo core.Repo, requestedSlug string, reclaim bool) (orgoLease, error) {
 	leaseID := core.NewLeaseID()
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return orgoLease{}, err
 	}
@@ -435,7 +435,7 @@ func (b *orgoBackend) waitForComputerRunning(ctx context.Context, client orgoAPI
 			case "running":
 				return true, nil
 			case "error", "failed", "deleted":
-				return false, exit(5, "orgo computer %s entered %s state while starting", computer.ID, state)
+				return false, core.Exit(5, "orgo computer %s entered %s state while starting", computer.ID, state)
 			case "stopped", "suspended":
 				if startStopped && !startRequested {
 					if err := client.StartComputer(ctx, computer.ID); err != nil {
@@ -447,7 +447,7 @@ func (b *orgoBackend) waitForComputerRunning(ctx context.Context, client orgoAPI
 				}
 			}
 			if !core.ClockNow(b.rt.Clock).Before(deadline) {
-				return false, exit(5, "timed out waiting for orgo computer %s to become running (last state=%s)", computer.ID, state)
+				return false, core.Exit(5, "timed out waiting for orgo computer %s to become running (last state=%s)", computer.ID, state)
 			}
 			return false, nil
 		}, nil)
@@ -470,7 +470,7 @@ func (b *orgoBackend) createComputerRequest(workspaceID, leaseID string) orgoCre
 	}
 }
 
-func (b *orgoBackend) claimLease(repo Repo, lease orgoLease, reclaim bool) error {
+func (b *orgoBackend) claimLease(repo core.Repo, lease orgoLease, reclaim bool) error {
 	labels := map[string]string{
 		"provider":           providerName,
 		orgoWorkspaceLabel:   lease.Computer.WorkspaceID,
@@ -481,7 +481,7 @@ func (b *orgoBackend) claimLease(repo Repo, lease orgoLease, reclaim bool) error
 	if lease.CreatedWorkspace != "" {
 		labels[orgoCreatedWorkspaceLabel] = lease.CreatedWorkspace
 	}
-	server := orgoComputerServer(lease.Computer, LeaseClaim{
+	server := orgoComputerServer(lease.Computer, core.LeaseClaim{
 		LeaseID: lease.LeaseID,
 		Slug:    lease.Slug,
 		Labels:  labels,
@@ -489,7 +489,7 @@ func (b *orgoBackend) claimLease(repo Repo, lease orgoLease, reclaim bool) error
 	return claimLeaseForRepoProviderEndpoint(lease.LeaseID, lease.Slug, orgoClaimScope(b.cfg, lease.Computer.WorkspaceID), repo.Root, b.cfg.IdleTimeout, reclaim, server)
 }
 
-func orgoClaimScope(cfg Config, workspaceID string) string {
+func orgoClaimScope(cfg core.Config, workspaceID string) string {
 	endpoint := strings.TrimRight(strings.TrimSpace(core.Blank(cfg.Orgo.APIBase, core.OrgoConfigDefaultAPIBase)), "/")
 	if parsed, err := url.Parse(endpoint); err == nil && parsed.Host != "" {
 		parsed.Scheme = strings.ToLower(parsed.Scheme)
@@ -510,13 +510,13 @@ func (b *orgoBackend) orgoClaimBinding(leaseID, slug, computerID, workspaceID st
 	}
 }
 
-func (b *orgoBackend) validateOrgoClaim(claim LeaseClaim) error {
+func (b *orgoBackend) validateOrgoClaim(claim core.LeaseClaim) error {
 	workspaceID := strings.TrimSpace(claim.Labels[orgoWorkspaceLabel])
 	if workspaceID == "" {
-		return exit(2, "provider=%s lease=%s has no claimed workspace namespace", providerName, claim.LeaseID)
+		return core.Exit(2, "provider=%s lease=%s has no claimed workspace namespace", providerName, claim.LeaseID)
 	}
 	if configured := strings.TrimSpace(b.cfg.Orgo.WorkspaceID); configured != "" && configured != workspaceID {
-		return exit(2, "provider=%s lease=%s belongs to a different workspace namespace", providerName, claim.LeaseID)
+		return core.Exit(2, "provider=%s lease=%s belongs to a different workspace namespace", providerName, claim.LeaseID)
 	}
 	_, err := shared.RequireExactClaim(b.orgoClaimBinding(claim.LeaseID, claim.Slug, claim.CloudID, workspaceID))
 	return err
@@ -574,7 +574,7 @@ func (b *orgoBackend) deleteLease(ctx context.Context, client orgoAPI, lease org
 		return err
 	}
 	if !exists {
-		return exit(2, "provider=%s lease=%s has no exact local ownership claim", providerName, lease.LeaseID)
+		return core.Exit(2, "provider=%s lease=%s has no exact local ownership claim", providerName, lease.LeaseID)
 	}
 	computerID := core.Blank(strings.TrimSpace(lease.Computer.ID), claim.CloudID)
 	workspaceID := core.Blank(strings.TrimSpace(lease.Computer.WorkspaceID), claim.Labels[orgoWorkspaceLabel])
@@ -609,7 +609,7 @@ func (b *orgoBackend) deleteLease(ctx context.Context, client orgoAPI, lease org
 			} else if computer.ID != claim.CloudID ||
 				(computer.WorkspaceID != "" && computer.WorkspaceID != workspaceID) ||
 				(claim.Labels["orgo_instance_id"] != "" && computer.InstanceID != claim.Labels["orgo_instance_id"]) {
-				return exit(2, "provider=%s computer %s no longer matches its exact ownership claim", providerName, lease.Computer.ID)
+				return core.Exit(2, "provider=%s computer %s no longer matches its exact ownership claim", providerName, lease.Computer.ID)
 			}
 		}
 		return b.deleteLeaseResources(ctx, client, lease)
@@ -637,7 +637,7 @@ func (b *orgoBackend) deleteLeaseResources(ctx context.Context, client orgoAPI, 
 }
 
 func isOrgoNotFound(err error) bool {
-	var exitErr ExitError
+	var exitErr core.ExitError
 	return errors.As(err, &exitErr) && exitErr.Code == 4
 }
 
@@ -689,7 +689,7 @@ func orgoComputersForWorkspace(workspace orgoWorkspace) []orgoComputer {
 	return computers
 }
 
-func (b *orgoBackend) buildCommand(req RunRequest) (string, error) {
+func (b *orgoBackend) buildCommand(req core.RunRequest) (string, error) {
 	command := orgoCommandText(req)
 	if len(req.Env) == 0 {
 		return command, nil
@@ -697,40 +697,40 @@ func (b *orgoBackend) buildCommand(req RunRequest) (string, error) {
 	names := make([]string, 0, len(req.Env))
 	for name := range req.Env {
 		if !orgoEnvNamePattern.MatchString(name) {
-			return "", exit(2, "provider=%s cannot forward invalid env var name %q", providerName, name)
+			return "", core.Exit(2, "provider=%s cannot forward invalid env var name %q", providerName, name)
 		}
 		names = append(names, name)
 	}
 	sort.Strings(names)
 	var bld strings.Builder
 	for _, name := range names {
-		fmt.Fprintf(&bld, "export %s=%s\n", name, shellQuote(req.Env[name]))
+		fmt.Fprintf(&bld, "export %s=%s\n", name, core.ShellQuote(req.Env[name]))
 	}
 	bld.WriteString(command)
 	return bld.String(), nil
 }
 
-func orgoCommandText(req RunRequest) string {
+func orgoCommandText(req core.RunRequest) string {
 	if req.ShellMode {
 		return strings.Join(req.Command, " ")
 	}
-	return shellScriptFromArgv(req.Command)
+	return core.ShellScriptFromArgv(req.Command)
 }
 
-func (b *orgoBackend) rejectRunOptions(req RunRequest) error {
-	if err := rejectDelegatedSyncOptionsForSpec(b.spec, req); err != nil {
+func (b *orgoBackend) rejectRunOptions(req core.RunRequest) error {
+	if err := core.RejectDelegatedSyncOptionsForSpec(b.spec, req); err != nil {
 		return err
 	}
 	if req.Options.Tailscale.Enabled {
-		return exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
+		return core.Exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
 	}
 	if req.Options.Desktop || req.Options.Browser || req.Options.Code {
-		return exit(2, "provider=%s does not support desktop, browser, or code-server options", providerName)
+		return core.Exit(2, "provider=%s does not support desktop, browser, or code-server options", providerName)
 	}
 	return nil
 }
 
-func orgoComputerServer(computer orgoComputer, claim LeaseClaim) Server {
+func orgoComputerServer(computer orgoComputer, claim core.LeaseClaim) core.Server {
 	labels := map[string]string{
 		"provider":         providerName,
 		orgoWorkspaceLabel: computer.WorkspaceID,
@@ -747,7 +747,7 @@ func orgoComputerServer(computer orgoComputer, claim LeaseClaim) Server {
 			labels[key] = value
 		}
 	}
-	server := Server{
+	server := core.Server{
 		CloudID:  computer.ID,
 		Provider: providerName,
 		Name:     core.Blank(computer.Name, computer.ID),
@@ -763,9 +763,9 @@ func orgoComputerServer(computer orgoComputer, claim LeaseClaim) Server {
 	return server
 }
 
-func orgoStatusView(lease orgoLease) StatusView {
+func orgoStatusView(lease orgoLease) core.StatusView {
 	state := normalizeOrgoStatus(lease.Computer.Status)
-	return StatusView{
+	return core.StatusView{
 		ID:         core.Blank(lease.LeaseID, lease.Computer.ID),
 		Slug:       lease.Slug,
 		Provider:   providerName,
@@ -791,7 +791,7 @@ func normalizeOrgoStatus(status string) string {
 	return status
 }
 
-func applyOrgoDefaults(cfg *Config) {
+func applyOrgoDefaults(cfg *core.Config) {
 	cfg.Provider = providerName
 	if cfg.TargetOS == "" {
 		cfg.TargetOS = targetLinux

--- a/internal/providers/orgo/backend_e2e_test.go
+++ b/internal/providers/orgo/backend_e2e_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 // TestOrgoBackendEndToEndCreateRunDelete drives the real *orgoHTTPClient through
@@ -89,12 +91,12 @@ func TestOrgoBackendEndToEndCreateRunDelete(t *testing.T) {
 	t.Setenv("CRABBOX_ORGO_API_KEY", dummyKey)
 
 	var out, errBuf bytes.Buffer
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIBase: server.URL}}, Runtime{
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIBase: server.URL}}, core.Runtime{
 		Stdout: &out, Stderr: &errBuf, HTTP: server.Client(),
 	}).(*orgoBackend)
 
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: t.TempDir()},
 		NoSync:  true,
 		Command: []string{"echo", "crabbox-orgo-ok"},
 	})

--- a/internal/providers/orgo/backend_test.go
+++ b/internal/providers/orgo/backend_test.go
@@ -123,7 +123,7 @@ func (f *fakeOrgoAPI) GetComputer(_ context.Context, id string) (orgoComputer, e
 	}
 	computer, ok := f.computers[id]
 	if !ok {
-		return orgoComputer{}, exit(4, "missing computer %s", id)
+		return orgoComputer{}, core.Exit(4, "missing computer %s", id)
 	}
 	if f.replaceInstanceOnGet == f.getComputerCalls {
 		computer.InstanceID = "instance_replaced"
@@ -152,7 +152,7 @@ func (f *fakeOrgoAPI) DeleteComputer(ctx context.Context, id string) error {
 		f.onDelete()
 	}
 	if _, ok := f.computers[id]; !ok && f.missingDeleteNotFound {
-		return exit(4, "missing computer %s", id)
+		return core.Exit(4, "missing computer %s", id)
 	}
 	delete(f.computers, id)
 	return f.deleteComputerErr
@@ -175,7 +175,7 @@ func (f *fakeOrgoAPI) RunBash(_ context.Context, id string, command string, stdo
 
 func TestProviderRegistersSecretSafeFlags(t *testing.T) {
 	fs := flag.NewFlagSet("orgo", flag.ContinueOnError)
-	cfg := Config{}
+	cfg := core.Config{}
 	values := RegisterOrgoProviderFlags(fs, cfg)
 	if fs.Lookup("orgo-api-key") != nil {
 		t.Fatalf("Orgo API key must not be registered as a CLI flag")
@@ -203,7 +203,7 @@ func TestProviderAliasesRejectUnsupportedMachineFlags(t *testing.T) {
 	for _, provider := range []string{providerName, "orgo-ai", " ORGO-AI "} {
 		t.Run(provider, func(t *testing.T) {
 			fs := flag.NewFlagSet(provider, flag.ContinueOnError)
-			cfg := Config{Provider: provider}
+			cfg := core.Config{Provider: provider}
 			values := RegisterOrgoProviderFlags(fs, cfg)
 			fs.String("class", "", "")
 			if err := fs.Parse([]string{"--class", "large"}); err != nil {
@@ -220,11 +220,11 @@ func TestRunCreatesExecutesAndDeletesTemporaryWorkspace(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeOrgoAPI()
 	var stdout, stderr bytes.Buffer
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: &stdout, Stderr: &stderr}).(*orgoBackend)
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key"}}, core.Runtime{Stdout: &stdout, Stderr: &stderr}).(*orgoBackend)
 	backend.client = fake
 
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:       Repo{Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Root: t.TempDir()},
 		NoSync:     true,
 		Command:    []string{"printf", "crabbox-orgo-ok"},
 		Env:        map[string]string{"EXAMPLE_TOKEN": "test value"},
@@ -266,11 +266,11 @@ func TestRunWaitsForNewComputerBeforeBash(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeOrgoAPI()
 	fake.computerStatuses = []string{"creating", "running"}
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 	backend.client = fake
 
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: t.TempDir()},
 		NoSync:  true,
 		Command: []string{"true"},
 	})
@@ -303,10 +303,10 @@ func TestRunStartsReusedComputerBeforeBash(t *testing.T) {
 				ID: "computer_test", Name: "orgo-reused", WorkspaceID: "ws_existing", Status: tt.statuses[0],
 			}
 			fake.computerStatuses = append([]string(nil), tt.statuses...)
-			backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+			backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 			backend.client = fake
 
-			result, err := backend.Run(context.Background(), RunRequest{ID: "computer_test", NoSync: true, Command: []string{"true"}})
+			result, err := backend.Run(context.Background(), core.RunRequest{ID: "computer_test", NoSync: true, Command: []string{"true"}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -327,11 +327,11 @@ func TestCreateComputerCleansUpTerminalStartupFailure(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeOrgoAPI()
 	fake.computerStatuses = []string{"creating", "error"}
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 	backend.client = fake
 
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: t.TempDir()},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: t.TempDir()},
 		NoSync:  true,
 		Command: []string{"true"},
 	})
@@ -355,9 +355,9 @@ func TestCreateComputerReportsRollbackFailureWithResourceIdentity(t *testing.T) 
 	fake.computerStatuses = []string{"creating", "failed"}
 	fake.deleteComputerErr = errors.New("computer cleanup failed")
 	fake.deleteWorkspaceErr = errors.New("workspace cleanup failed")
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 
-	_, err := backend.createComputer(context.Background(), fake, Repo{Root: t.TempDir()}, "rollback-proof", false)
+	_, err := backend.createComputer(context.Background(), fake, core.Repo{Root: t.TempDir()}, "rollback-proof", false)
 	if err == nil {
 		t.Fatal("create unexpectedly succeeded")
 	}
@@ -373,9 +373,9 @@ func TestCreateComputerReportsWorkspaceRollbackFailureAfterCreateError(t *testin
 	fake := newFakeOrgoAPI()
 	fake.createComputerErr = &orgoHTTPError{StatusCode: 400, Body: "computer create failed"}
 	fake.deleteWorkspaceErr = errors.New("workspace cleanup failed")
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 
-	_, err := backend.createComputer(context.Background(), fake, Repo{Root: t.TempDir()}, "rollback-proof", false)
+	_, err := backend.createComputer(context.Background(), fake, core.Repo{Root: t.TempDir()}, "rollback-proof", false)
 	if err == nil {
 		t.Fatal("create unexpectedly succeeded")
 	}
@@ -390,8 +390,8 @@ func TestCreateComputerPreservesRequestedWorkspaceWhenResponseOmitsIt(t *testing
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeOrgoAPI()
 	fake.omitWorkspaceID = true
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
-	lease, err := backend.createComputer(context.Background(), fake, Repo{Root: t.TempDir()}, "workspace-proof", false)
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	lease, err := backend.createComputer(context.Background(), fake, core.Repo{Root: t.TempDir()}, "workspace-proof", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -409,22 +409,22 @@ func TestCreateComputerPreservesRequestedWorkspaceWhenResponseOmitsIt(t *testing
 func TestStopByComputerIDDeletesTemporaryWorkspaceAndClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeOrgoAPI()
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 	backend.client = fake
-	lease, err := backend.createComputer(context.Background(), fake, Repo{Root: t.TempDir()}, "cloud-id-stop", false)
+	lease, err := backend.createComputer(context.Background(), fake, core.Repo{Root: t.TempDir()}, "cloud-id-stop", false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	otherLeaseID := "cbx_slug_collision_1234567890"
-	if err := claimLeaseForRepoProviderEndpoint(otherLeaseID, lease.Computer.ID, orgoClaimScope(backend.cfg, lease.Computer.WorkspaceID), t.TempDir(), time.Minute, false, Server{
+	if err := claimLeaseForRepoProviderEndpoint(otherLeaseID, lease.Computer.ID, orgoClaimScope(backend.cfg, lease.Computer.WorkspaceID), t.TempDir(), time.Minute, false, core.Server{
 		CloudID:  "other-computer",
 		Provider: providerName,
 		Name:     "other-computer",
 	}); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { removeLeaseClaim(otherLeaseID) })
-	if err := backend.Stop(context.Background(), StopRequest{ID: lease.Computer.ID}); err != nil {
+	t.Cleanup(func() { core.RemoveLeaseClaim(otherLeaseID) })
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: lease.Computer.ID}); err != nil {
 		t.Fatal(err)
 	}
 	if got := strings.Join(fake.deletedComputers, ","); got != lease.Computer.ID {
@@ -442,10 +442,10 @@ func TestStopRefusesUnclaimedComputerID(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeOrgoAPI()
 	fake.computers["computer_unclaimed"] = orgoComputer{ID: "computer_unclaimed", Status: "running"}
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 	backend.client = fake
 
-	err := backend.Stop(context.Background(), StopRequest{ID: "computer_unclaimed"})
+	err := backend.Stop(context.Background(), core.StopRequest{ID: "computer_unclaimed"})
 	if err == nil || !strings.Contains(err.Error(), "refuses to stop unclaimed") {
 		t.Fatalf("err=%v", err)
 	}
@@ -470,9 +470,9 @@ func TestStopRequiresExactOrgoEndpointWorkspaceAndComputerIdentity(t *testing.T)
 		t.Run(test.name, func(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			originalAPI := newFakeOrgoAPI()
-			original := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key", APIBase: "https://one.example.test/api"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+			original := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key", APIBase: "https://one.example.test/api"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 			original.client = originalAPI
-			lease, err := original.createComputer(context.Background(), originalAPI, Repo{Root: t.TempDir()}, "owned", false)
+			lease, err := original.createComputer(context.Background(), originalAPI, core.Repo{Root: t.TempDir()}, "owned", false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -482,13 +482,13 @@ func TestStopRequiresExactOrgoEndpointWorkspaceAndComputerIdentity(t *testing.T)
 				computer.InstanceID = test.instanceID
 			}
 			currentAPI.computers[computer.ID] = computer
-			current := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{
+			current := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{
 				APIKey:      "test-key",
 				APIBase:     core.Blank(test.endpoint, "https://one.example.test/api"),
 				WorkspaceID: test.workspace,
-			}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+			}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 			current.client = currentAPI
-			err = current.Stop(context.Background(), StopRequest{ID: lease.Computer.ID})
+			err = current.Stop(context.Background(), core.StopRequest{ID: lease.Computer.ID})
 			if test.name == "exact ownership" {
 				if err != nil || len(currentAPI.deletedComputers) != 1 || len(currentAPI.deletedWorkspaces) != 1 {
 					t.Fatalf("owned stop err=%v computers=%v workspaces=%v", err, currentAPI.deletedComputers, currentAPI.deletedWorkspaces)
@@ -512,18 +512,18 @@ func TestStopRetriesWorkspaceCleanupAfterComputerWasDeleted(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeOrgoAPI()
 	fake.missingDeleteNotFound = true
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 	backend.client = fake
-	lease, err := backend.createComputer(context.Background(), fake, Repo{Root: t.TempDir()}, "partial-cleanup", false)
+	lease, err := backend.createComputer(context.Background(), fake, core.Repo{Root: t.TempDir()}, "partial-cleanup", false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	fake.deleteWorkspaceErr = errors.New("transient workspace delete failure")
-	if err := backend.Stop(context.Background(), StopRequest{ID: lease.LeaseID}); err == nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: lease.LeaseID}); err == nil {
 		t.Fatal("first stop unexpectedly succeeded")
 	}
 	fake.deleteWorkspaceErr = nil
-	if err := backend.Stop(context.Background(), StopRequest{ID: lease.LeaseID}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: lease.LeaseID}); err != nil {
 		t.Fatal(err)
 	}
 	if got := strings.Join(fake.deletedComputers, ","); got != "computer_test" {
@@ -540,14 +540,14 @@ func TestStopRetriesWorkspaceCleanupAfterComputerWasDeleted(t *testing.T) {
 func TestStopFinishesWorkspaceCleanupWhenComputerDisappearsDuringLockedPreflight(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeOrgoAPI()
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 	backend.client = fake
-	lease, err := backend.createComputer(context.Background(), fake, Repo{Root: t.TempDir()}, "preflight-disappearance", false)
+	lease, err := backend.createComputer(context.Background(), fake, core.Repo{Root: t.TempDir()}, "preflight-disappearance", false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	fake.disappearOnGet = 2
-	if err := backend.Stop(context.Background(), StopRequest{ID: lease.LeaseID}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: lease.LeaseID}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deletedComputers) != 0 || strings.Join(fake.deletedWorkspaces, ",") != "ws_created" {
@@ -561,14 +561,14 @@ func TestStopFinishesWorkspaceCleanupWhenComputerDisappearsDuringLockedPreflight
 func TestStopRefusesInstanceReplacementDuringLockedPreflight(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeOrgoAPI()
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 	backend.client = fake
-	lease, err := backend.createComputer(context.Background(), fake, Repo{Root: t.TempDir()}, "preflight-replacement", false)
+	lease, err := backend.createComputer(context.Background(), fake, core.Repo{Root: t.TempDir()}, "preflight-replacement", false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	fake.replaceInstanceOnGet = 2
-	if err := backend.Stop(context.Background(), StopRequest{ID: lease.LeaseID}); err == nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: lease.LeaseID}); err == nil {
 		t.Fatal("stop unexpectedly accepted an instance replacement")
 	}
 	if len(fake.deletedComputers) != 0 || len(fake.deletedWorkspaces) != 0 {
@@ -582,15 +582,15 @@ func TestStopRefusesInstanceReplacementDuringLockedPreflight(t *testing.T) {
 func TestStopRetainsClaimWhenNotFoundCouldBeAuthorizationFailure(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeOrgoAPI()
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 	backend.client = fake
-	lease, err := backend.createComputer(context.Background(), fake, Repo{Root: t.TempDir()}, "ambiguous-not-found", false)
+	lease, err := backend.createComputer(context.Background(), fake, core.Repo{Root: t.TempDir()}, "ambiguous-not-found", false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	delete(fake.computers, lease.Computer.ID)
-	fake.getWorkspaceErr = exit(4, "workspace unavailable")
-	if err := backend.Stop(context.Background(), StopRequest{ID: lease.LeaseID}); err == nil {
+	fake.getWorkspaceErr = core.Exit(4, "workspace unavailable")
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: lease.LeaseID}); err == nil {
 		t.Fatal("stop unexpectedly accepted ambiguous absence")
 	}
 	if len(fake.deletedComputers) != 0 || len(fake.deletedWorkspaces) != 0 {
@@ -604,15 +604,15 @@ func TestStopRetainsClaimWhenNotFoundCouldBeAuthorizationFailure(t *testing.T) {
 func TestStopFinalizesClaimWhenComputerAndWorkspaceAreConfirmedAbsent(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeOrgoAPI()
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 	backend.client = fake
-	lease, err := backend.createComputer(context.Background(), fake, Repo{Root: t.TempDir()}, "confirmed-absence", false)
+	lease, err := backend.createComputer(context.Background(), fake, core.Repo{Root: t.TempDir()}, "confirmed-absence", false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	delete(fake.computers, lease.Computer.ID)
 	fake.getWorkspaceErr = &orgoHTTPError{StatusCode: http.StatusNotFound, Body: "workspace not found"}
-	if err := backend.Stop(context.Background(), StopRequest{ID: lease.LeaseID}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: lease.LeaseID}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deletedComputers) != 0 || len(fake.deletedWorkspaces) != 0 {
@@ -627,12 +627,12 @@ func TestWarmupClaimsSlugForStatusAndStop(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeOrgoAPI()
 	var stdout, stderr bytes.Buffer
-	cfg := Config{Orgo: OrgoConfig{APIKey: "test-key", WorkspaceID: "ws_existing"}}
-	backend := NewOrgoBackend(Provider{}.Spec(), cfg, Runtime{Stdout: &stdout, Stderr: &stderr}).(*orgoBackend)
+	cfg := core.Config{Orgo: core.OrgoConfig{APIKey: "test-key", WorkspaceID: "ws_existing"}}
+	backend := NewOrgoBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &stdout, Stderr: &stderr}).(*orgoBackend)
 	backend.client = fake
 
-	if err := backend.Warmup(context.Background(), WarmupRequest{
-		Repo:          Repo{Root: t.TempDir()},
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{
+		Repo:          core.Repo{Root: t.TempDir()},
 		RequestedSlug: "orgo-smoke",
 	}); err != nil {
 		t.Fatal(err)
@@ -640,14 +640,14 @@ func TestWarmupClaimsSlugForStatusAndStop(t *testing.T) {
 	if !strings.Contains(stdout.String(), "slug=orgo-smoke") {
 		t.Fatalf("stdout=%q", stdout.String())
 	}
-	view, err := backend.Status(context.Background(), StatusRequest{ID: "orgo-smoke", Wait: true})
+	view, err := backend.Status(context.Background(), core.StatusRequest{ID: "orgo-smoke", Wait: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if view.ServerID != "computer_test" || view.Slug != "orgo-smoke" || !view.Ready {
 		t.Fatalf("status=%#v", view)
 	}
-	if err := backend.Stop(context.Background(), StopRequest{ID: "orgo-smoke"}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: "orgo-smoke"}); err != nil {
 		t.Fatal(err)
 	}
 	if got := strings.Join(fake.deletedComputers, ","); got != "computer_test" {
@@ -664,9 +664,9 @@ func TestStatusWaitStopsOnTerminalStates(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			fake := newFakeOrgoAPI()
 			fake.computers["computer_test"] = orgoComputer{ID: "computer_test", Status: state}
-			backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+			backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 			backend.client = fake
-			_, err := backend.Status(context.Background(), StatusRequest{ID: "computer_test", Wait: true})
+			_, err := backend.Status(context.Background(), core.StatusRequest{ID: "computer_test", Wait: true})
 			if err == nil || !strings.Contains(err.Error(), "entered "+state+" state") {
 				t.Fatalf("err=%v", err)
 			}
@@ -678,18 +678,18 @@ func TestListMergesLocalClaimLabels(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeOrgoAPI()
 	var stdout, stderr bytes.Buffer
-	cfg := Config{Orgo: OrgoConfig{APIKey: "test-key", WorkspaceID: "ws_existing"}}
-	backend := NewOrgoBackend(Provider{}.Spec(), cfg, Runtime{Stdout: &stdout, Stderr: &stderr}).(*orgoBackend)
+	cfg := core.Config{Orgo: core.OrgoConfig{APIKey: "test-key", WorkspaceID: "ws_existing"}}
+	backend := NewOrgoBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &stdout, Stderr: &stderr}).(*orgoBackend)
 	backend.client = fake
 
-	if err := backend.Warmup(context.Background(), WarmupRequest{
-		Repo:          Repo{Root: t.TempDir()},
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{
+		Repo:          core.Repo{Root: t.TempDir()},
 		RequestedSlug: "orgo-list",
 	}); err != nil {
 		t.Fatal(err)
 	}
 
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -703,7 +703,7 @@ func TestListMergesLocalClaimLabels(t *testing.T) {
 		t.Fatalf("claim slug label=%q", got)
 	}
 
-	views, err := backend.List(context.Background(), ListRequest{})
+	views, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -729,10 +729,10 @@ func TestDoctorCountsInventoryComputers(t *testing.T) {
 	fake := newFakeOrgoAPI()
 	fake.computers["computer_one"] = orgoComputer{ID: "computer_one", WorkspaceID: "ws_existing", Status: "running"}
 	fake.computers["computer_two"] = orgoComputer{ID: "computer_two", WorkspaceID: "ws_existing", Status: "stopped"}
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key", WorkspaceID: "ws_existing"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key", WorkspaceID: "ws_existing"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 	backend.client = fake
 
-	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -745,9 +745,9 @@ func TestDoctorCountsInventoryComputers(t *testing.T) {
 }
 
 func TestBuildCommandQuotesForwardedEnvValues(t *testing.T) {
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 
-	command, err := backend.buildCommand(RunRequest{
+	command, err := backend.buildCommand(core.RunRequest{
 		Command: []string{"printf", "ok"},
 		Env: map[string]string{
 			"PIPE": "|",
@@ -772,11 +772,11 @@ func TestRunKeepOnFailurePreservesComputer(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeOrgoAPI()
 	fake.bashExitCode = 7
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key", WorkspaceID: "ws_existing"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key", WorkspaceID: "ws_existing"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 	backend.client = fake
 
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:          Repo{Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:          core.Repo{Root: t.TempDir()},
 		NoSync:        true,
 		KeepOnFailure: true,
 		Command:       []string{"false"},
@@ -797,7 +797,7 @@ func TestDeleteLeaseTreatsOwnedWorkspaceDeletionAsAuthoritative(t *testing.T) {
 	computerErr := errors.New("computer delete failed")
 	fake := newFakeOrgoAPI()
 	fake.deleteComputerErr = computerErr
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "test-key"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
 
 	err := backend.deleteLease(context.Background(), fake, orgoLease{
 		LeaseID:          "lease_test",
@@ -857,9 +857,9 @@ func TestRunFinalizesAfterAuthoritativeCleanup(t *testing.T) {
 			fake.onBash = func() { clock.at = clock.at.Add(time.Second) }
 			fake.onDelete = func() { clock.at = clock.at.Add(2 * time.Second) }
 			var stderr bytes.Buffer
-			b := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "synthetic", WorkspaceID: tc.workspace}}, Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: clock}).(*orgoBackend)
+			b := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "synthetic", WorkspaceID: tc.workspace}}, core.Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: clock}).(*orgoBackend)
 			b.client = fake
-			result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir()}, Command: []string{"true"}, TimingJSON: true})
+			result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, Command: []string{"true"}, TimingJSON: true})
 			wantStatus := core.RunStatusSucceeded
 			if tc.wantCode != 0 {
 				wantStatus = core.RunStatusFailed
@@ -874,7 +874,7 @@ func TestRunFinalizesAfterAuthoritativeCleanup(t *testing.T) {
 				t.Errorf("command=%s total=%s", result.Command, result.Total)
 			}
 			if tc.wantCode != 0 {
-				var public ExitError
+				var public core.ExitError
 				if !core.AsExitError(err, &public) || public.Code != tc.wantCode {
 					t.Errorf("public code=%d err=%v", public.Code, err)
 				}
@@ -915,10 +915,10 @@ func TestRunPreservesPrimaryHTTPCodeAndClassification(t *testing.T) {
 			fake.bashExitCode = 1
 			fake.bashErr = &orgoHTTPError{StatusCode: status, Body: "synthetic request refusal"}
 			var stderr bytes.Buffer
-			b := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "synthetic", WorkspaceID: "ws_existing"}}, Runtime{Stdout: io.Discard, Stderr: &stderr}).(*orgoBackend)
+			b := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "synthetic", WorkspaceID: "ws_existing"}}, core.Runtime{Stdout: io.Discard, Stderr: &stderr}).(*orgoBackend)
 			b.client = fake
-			result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir()}, Command: []string{"true"}, KeepOnFailure: true, TimingJSON: true})
-			var expected, actual ExitError
+			result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, Command: []string{"true"}, KeepOnFailure: true, TimingJSON: true})
+			var expected, actual core.ExitError
 			if !core.AsExitError(fake.bashErr, &expected) || !core.AsExitError(err, &actual) {
 				t.Fatal("missing typed HTTP error")
 			}
@@ -952,18 +952,18 @@ func TestRunTimingFailureKeepsPrimaryAndRetention(t *testing.T) {
 			fake.bashErr = cause
 			writerErr := errors.New("synthetic timing writer failure")
 			writer := &orgoFailingTimingWriter{err: writerErr}
-			b := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "synthetic", WorkspaceID: "ws_existing"}}, Runtime{Stdout: io.Discard, Stderr: writer}).(*orgoBackend)
+			b := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "synthetic", WorkspaceID: "ws_existing"}}, core.Runtime{Stdout: io.Discard, Stderr: writer}).(*orgoBackend)
 			b.client = fake
-			result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir()}, Command: []string{"false"}, KeepOnFailure: true, TimingJSON: true})
+			result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, Command: []string{"false"}, KeepOnFailure: true, TimingJSON: true})
 			wantCode := 7
 			if cause != nil {
 				wantCode = 1
-				var typed ExitError
+				var typed core.ExitError
 				if core.AsExitError(cause, &typed) {
 					wantCode = typed.Code
 				}
 			}
-			var public ExitError
+			var public core.ExitError
 			if !core.AsExitError(err, &public) || public.Code != wantCode || result.ExitCode != wantCode || !errors.Is(err, writerErr) {
 				t.Errorf("code=%d want=%d result=%+v err=%v", public.Code, wantCode, result, err)
 			}
@@ -1010,9 +1010,9 @@ func TestRunTypedTimingReportFailurePreservesFirstPublicCode(t *testing.T) {
 			fake.deleteComputerErr = tc.cleanupErr
 			writerErr := core.ExitError{Code: 69, Message: "synthetic typed timing failure"}
 			writer := &orgoTypedTimingReportWriter{err: writerErr}
-			b := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "synthetic", WorkspaceID: "ws_existing"}}, Runtime{Stdout: io.Discard, Stderr: writer}).(*orgoBackend)
+			b := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: "synthetic", WorkspaceID: "ws_existing"}}, core.Runtime{Stdout: io.Discard, Stderr: writer}).(*orgoBackend)
 			b.client = fake
-			result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir()}, Command: []string{"true"}, TimingJSON: true})
+			result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, Command: []string{"true"}, TimingJSON: true})
 			var public core.ExitError
 			if !core.AsExitError(err, &public) || public.Code != tc.wantCode || result.ExitCode != tc.wantCode || result.ErrorKind != tc.wantKind || !errors.Is(err, writerErr) {
 				t.Errorf("result=%+v public code=%d want=%d err=%v", result, public.Code, tc.wantCode, err)
@@ -1046,7 +1046,7 @@ func TestRunTypedTimingReportFailurePreservesFirstPublicCode(t *testing.T) {
 
 func TestOrgoConfigFlagAndFactoryContract(t *testing.T) {
 	for _, provider := range []string{"orgo", " ORGO-AI ", "aws"} {
-		cfg := Config{Provider: provider, Orgo: OrgoConfig{APIKey: "inert", APIBase: "https://configured.example.test", WorkspaceID: "prior", RAMGB: 4, CPUs: 1, DiskGB: 8, Resolution: "1280x720x24"}}
+		cfg := core.Config{Provider: provider, Orgo: core.OrgoConfig{APIKey: "inert", APIBase: "https://configured.example.test", WorkspaceID: "prior", RAMGB: 4, CPUs: 1, DiskGB: 8, Resolution: "1280x720x24"}}
 		fs := flag.NewFlagSet("contract", flag.ContinueOnError)
 		values := RegisterOrgoProviderFlags(fs, cfg)
 		count := 0
@@ -1073,7 +1073,7 @@ func TestOrgoConfigFlagAndFactoryContract(t *testing.T) {
 		if err := ApplyOrgoProviderFlags(&cfg, fs, values); err != nil {
 			t.Fatal(err)
 		}
-		want := OrgoConfig{APIKey: "inert", WorkspaceID: "workspace", RAMGB: 0, CPUs: -2, DiskGB: -3, Resolution: "  "}
+		want := core.OrgoConfig{APIKey: "inert", WorkspaceID: "workspace", RAMGB: 0, CPUs: -2, DiskGB: -3, Resolution: "  "}
 		if cfg.Orgo != want {
 			t.Fatalf("flags=%#v want=%#v", cfg.Orgo, want)
 		}
@@ -1081,7 +1081,7 @@ func TestOrgoConfigFlagAndFactoryContract(t *testing.T) {
 		t.Setenv("ORGO_API_KEY", "")
 		t.Setenv("CRABBOX_ORGO_API_BASE", "https://ambient.example.test")
 		t.Setenv("ORGO_API_BASE_URL", "https://vendor.example.test")
-		b := NewOrgoBackend(Provider{}.Spec(), cfg, Runtime{}).(*orgoBackend)
+		b := NewOrgoBackend(Provider{}.Spec(), cfg, core.Runtime{}).(*orgoBackend)
 		want.APIBase = "https://www.orgo.ai/api"
 		want.RAMGB = 4
 		want.CPUs = 1
@@ -1102,14 +1102,14 @@ func TestOrgoConfigFlagAndFactoryContract(t *testing.T) {
 
 func TestOrgoConfigEffectiveDefaultsAndScope(t *testing.T) {
 	for _, raw := range []string{"", "  "} {
-		cfg := Config{Orgo: OrgoConfig{APIBase: raw, Resolution: raw, RAMGB: -2, CPUs: 0, DiskGB: -3}}
+		cfg := core.Config{Orgo: core.OrgoConfig{APIBase: raw, Resolution: raw, RAMGB: -2, CPUs: 0, DiskGB: -3}}
 		applyOrgoDefaults(&cfg)
-		want := OrgoConfig{APIBase: "https://www.orgo.ai/api", RAMGB: 4, CPUs: 1, DiskGB: 8, Resolution: "1280x720x24"}
+		want := core.OrgoConfig{APIBase: "https://www.orgo.ai/api", RAMGB: 4, CPUs: 1, DiskGB: 8, Resolution: "1280x720x24"}
 		if cfg.Orgo != want || cfg.Provider != "orgo" || cfg.TargetOS != "linux" {
 			t.Fatalf("defaults=%#v", cfg.Orgo)
 		}
 	}
-	cfg := Config{Provider: "other", TargetOS: "windows", Orgo: OrgoConfig{APIBase: " https://EXAMPLE.test/api/ ", Resolution: " 1920x1080 ", RAMGB: 2, CPUs: 3, DiskGB: 4, WorkspaceID: "workspace"}}
+	cfg := core.Config{Provider: "other", TargetOS: "windows", Orgo: core.OrgoConfig{APIBase: " https://EXAMPLE.test/api/ ", Resolution: " 1920x1080 ", RAMGB: 2, CPUs: 3, DiskGB: 4, WorkspaceID: "workspace"}}
 	want := cfg.Orgo
 	applyOrgoDefaults(&cfg)
 	if cfg.Orgo != want || cfg.Provider != "orgo" || cfg.TargetOS != "windows" {
@@ -1118,7 +1118,7 @@ func TestOrgoConfigEffectiveDefaultsAndScope(t *testing.T) {
 	if got := orgoClaimScope(cfg, " workspace "); got != "endpoint:https://example.test/api|workspace:workspace" {
 		t.Fatalf("scope=%q", got)
 	}
-	if got := orgoClaimScope(Config{}, " workspace "); got != "endpoint:https://www.orgo.ai/api|workspace:workspace" {
+	if got := orgoClaimScope(core.Config{}, " workspace "); got != "endpoint:https://www.orgo.ai/api|workspace:workspace" {
 		t.Fatalf("default scope=%q", got)
 	}
 }
@@ -1134,7 +1134,7 @@ func TestOrgoConfigFactoryKeyNormalization(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("CRABBOX_ORGO_API_KEY", tc.primary)
 			t.Setenv("ORGO_API_KEY", tc.vendor)
-			b := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: tc.resolved}}, Runtime{}).(*orgoBackend)
+			b := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIKey: tc.resolved}}, core.Runtime{}).(*orgoBackend)
 			api, err := b.api()
 			if err != nil {
 				t.Fatal(err)
@@ -1149,7 +1149,7 @@ func TestOrgoConfigFactoryKeyNormalization(t *testing.T) {
 func TestOrgoConfigMachineFlagOrder(t *testing.T) {
 	for _, provider := range []string{"orgo", " ORGO-AI ", "aws"} {
 		for _, args := range [][]string{{"--class=large", "--type=machine"}, {"--type=machine"}} {
-			cfg := Config{Provider: provider}
+			cfg := core.Config{Provider: provider}
 			fs := flag.NewFlagSet("contract", flag.ContinueOnError)
 			fs.String("class", "", "")
 			fs.String("type", "", "")
@@ -1199,7 +1199,7 @@ func TestOrgoConfigLoaderContract(t *testing.T) {
 			if cfg.Orgo.APIKey != wantKey || cfg.Orgo.WorkspaceID != "workspace-env" || cfg.Orgo.RAMGB != 6 || cfg.Orgo.APIBase != "https://www.orgo.ai/api" {
 				t.Fatal("public loader precedence/default contract changed")
 			}
-			backend := NewOrgoBackend(Provider{}.Spec(), cfg, Runtime{}).(*orgoBackend)
+			backend := NewOrgoBackend(Provider{}.Spec(), cfg, core.Runtime{}).(*orgoBackend)
 			api, err := backend.api()
 			if err != nil {
 				t.Fatal(err)

--- a/internal/providers/orgo/client.go
+++ b/internal/providers/orgo/client.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -105,7 +106,7 @@ func (e *orgoHTTPError) Error() string {
 }
 
 func (e *orgoHTTPError) As(target any) bool {
-	t, ok := target.(*ExitError)
+	t, ok := target.(*core.ExitError)
 	if !ok {
 		return false
 	}
@@ -118,11 +119,11 @@ func (e *orgoHTTPError) As(target any) bool {
 	case e.StatusCode == http.StatusTooManyRequests || e.StatusCode >= 500:
 		code = 69
 	}
-	*t = ExitError{Code: code, Message: e.Error()}
+	*t = core.ExitError{Code: code, Message: e.Error()}
 	return true
 }
 
-func newOrgoClient(cfg Config, rt Runtime) (orgoAPI, error) {
+func newOrgoClient(cfg core.Config, rt core.Runtime) (orgoAPI, error) {
 	apiKey := strings.TrimSpace(os.Getenv("CRABBOX_ORGO_API_KEY"))
 	if apiKey == "" {
 		apiKey = strings.TrimSpace(cfg.Orgo.APIKey)
@@ -131,19 +132,19 @@ func newOrgoClient(cfg Config, rt Runtime) (orgoAPI, error) {
 		apiKey = strings.TrimSpace(os.Getenv("ORGO_API_KEY"))
 	}
 	if apiKey == "" {
-		return nil, exit(2, "provider=%s requires CRABBOX_ORGO_API_KEY, orgo.apiKey, or ORGO_API_KEY", providerName)
+		return nil, core.Exit(2, "provider=%s requires CRABBOX_ORGO_API_KEY, orgo.apiKey, or ORGO_API_KEY", providerName)
 	}
 	// The backend resolves APIBase before constructing its lazy client.
 	baseURL := strings.TrimSpace(cfg.Orgo.APIBase)
 	parsed, err := url.Parse(baseURL)
 	if err != nil {
-		return nil, exit(2, "provider=%s invalid Orgo API base URL %q: %v", providerName, baseURL, err)
+		return nil, core.Exit(2, "provider=%s invalid Orgo API base URL %q: %v", providerName, baseURL, err)
 	}
 	if parsed.Scheme == "" || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
-		return nil, exit(2, "provider=%s invalid Orgo API base URL %q", providerName, baseURL)
+		return nil, core.Exit(2, "provider=%s invalid Orgo API base URL %q", providerName, baseURL)
 	}
 	if parsed.Scheme != "https" && !isOrgoLoopbackHTTP(parsed) {
-		return nil, exit(2, "provider=%s API base URL %q must use https unless it targets localhost", providerName, baseURL)
+		return nil, core.Exit(2, "provider=%s API base URL %q must use https unless it targets localhost", providerName, baseURL)
 	}
 	client, dataClient := shared.ControlAndDataHTTPClients(rt.HTTP, orgoControlTimeout)
 	return &orgoHTTPClient{

--- a/internal/providers/orgo/client_test.go
+++ b/internal/providers/orgo/client_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -405,7 +406,7 @@ func (fn orgoRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error)
 func TestNewOrgoClientRejectsInsecureNonLoopbackAPIBase(t *testing.T) {
 	t.Setenv("CRABBOX_ORGO_API_KEY", "test-key")
 	t.Setenv("CRABBOX_ORGO_API_BASE", "http://api.example.test")
-	if _, err := newOrgoClient(Config{Orgo: OrgoConfig{APIBase: "http://api.example.test"}}, Runtime{}); err == nil || !strings.Contains(err.Error(), "must use https") {
+	if _, err := newOrgoClient(core.Config{Orgo: core.OrgoConfig{APIBase: "http://api.example.test"}}, core.Runtime{}); err == nil || !strings.Contains(err.Error(), "must use https") {
 		t.Fatalf("err=%v, want HTTPS requirement", err)
 	}
 }
@@ -413,7 +414,7 @@ func TestNewOrgoClientRejectsInsecureNonLoopbackAPIBase(t *testing.T) {
 func TestNewOrgoClientUsesResolvedConfigBeforeAmbientAPIBase(t *testing.T) {
 	t.Setenv("CRABBOX_ORGO_API_KEY", "test-key")
 	t.Setenv("CRABBOX_ORGO_API_BASE", "https://ambient.example.test")
-	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIBase: "https://flag-selected.example.test"}}, Runtime{}).(*orgoBackend)
+	backend := NewOrgoBackend(Provider{}.Spec(), core.Config{Orgo: core.OrgoConfig{APIBase: "https://flag-selected.example.test"}}, core.Runtime{}).(*orgoBackend)
 	client, err := backend.api()
 	if err != nil {
 		t.Fatal(err)
@@ -475,7 +476,7 @@ func TestOrgoFallbackBoundsControlAndPreservesCommand(t *testing.T) {
 func TestOrgoInjectedHTTPClientIsPreservedForBothPlanes(t *testing.T) {
 	t.Setenv("CRABBOX_ORGO_API_KEY", "test-key")
 	injected := &http.Client{Timeout: 17 * time.Second}
-	api, err := newOrgoClient(Config{Orgo: OrgoConfig{APIBase: "http://127.0.0.1:8787"}}, Runtime{HTTP: injected})
+	api, err := newOrgoClient(core.Config{Orgo: core.OrgoConfig{APIBase: "http://127.0.0.1:8787"}}, core.Runtime{HTTP: injected})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/orgo/core.go
+++ b/internal/providers/orgo/core.go
@@ -1,32 +1,10 @@
 package orgo
 
 import (
-	"io"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type OrgoConfig = core.OrgoConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type Server = core.Server
-type Repo = core.Repo
-type LeaseClaim = core.LeaseClaim
-type ExitError = core.ExitError
-type timingReport = core.TimingReport
 
 const (
 	providerName  = "orgo"
@@ -34,15 +12,7 @@ const (
 	networkPublic = core.NetworkPublic
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func claimLeaseForRepoProviderEndpoint(leaseID, slug, providerScope, repoRoot string, idleTimeout time.Duration, reclaim bool, server Server) error {
+func claimLeaseForRepoProviderEndpoint(leaseID, slug, providerScope, repoRoot string, idleTimeout time.Duration, reclaim bool, server core.Server) error {
 	return core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, providerScope, "", repoRoot, idleTimeout, reclaim, server, core.SSHTarget{TargetOS: targetLinux})
 }
 
@@ -52,40 +22,4 @@ func resolveLeaseClaimForProvider(identifier string) (core.LeaseClaim, bool, err
 
 func resolveLeaseClaimForProviderCloudID(cloudID string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaimForProviderCloudID(cloudID, providerName)
-}
-
-func listLeaseClaims() ([]core.LeaseClaim, error) {
-	return core.ListLeaseClaims()
-}
-
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
-}
-
-func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
-	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
-func shellQuote(value string) string {
-	return core.ShellQuote(value)
-}
-
-func rejectDelegatedSyncOptionsForSpec(spec ProviderSpec, req RunRequest) error {
-	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
-}
-
-func inventoryDoctorResult(provider string, leases int) DoctorResult {
-	return core.InventoryDoctorResult(provider, leases)
 }

--- a/internal/providers/orgo/flags.go
+++ b/internal/providers/orgo/flags.go
@@ -9,11 +9,11 @@ import (
 
 // RegisterOrgoProviderFlags exposes non-secret Orgo settings. The API key is
 // intentionally not a flag; secrets are read from env/config only.
-func RegisterOrgoProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterOrgoProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterOrgoConfigFlags(fs, defaults.Orgo)
 }
 
-func ApplyOrgoProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyOrgoProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
 			return err

--- a/internal/providers/smolvm/backend.go
+++ b/internal/providers/smolvm/backend.go
@@ -16,21 +16,21 @@ import (
 )
 
 type backend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
-func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	return &backend{spec: spec, cfg: cfg, rt: rt}
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *backend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if req.ActionsRunner {
-		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+		return core.Exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
 	started := b.now()
 	client, err := newAPI(b.cfg, b.rt)
@@ -49,7 +49,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	total := b.now().Sub(started)
 	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
 	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
+		return core.WriteTimingJSON(b.rt.Stderr, core.TimingReport{
 			Provider: providerName,
 			LeaseID:  leaseID,
 			Slug:     slug,
@@ -60,14 +60,14 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	return nil
 }
 
-func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *backend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	workdir, err := cleanWorkdir(workdir(b.cfg))
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	folder, err := workspaceFolder(workdir)
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	effectiveKeep := req.Keep || b.cfg.Smolvm.Keep
 	lifecycleReq := req
@@ -118,7 +118,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			}
 			command := intent.ShellSource()
 			if req.EnvSummary {
-				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+				core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 			}
 			var closeCommand func(context.Context) error
 			if len(req.Env) > 0 {
@@ -151,10 +151,10 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 }
 
 func smolvmCleanupCommand(leaseID string) string {
-	return "crabbox stop --provider " + providerName + " --id " + shellQuote(leaseID)
+	return "crabbox stop --provider " + providerName + " --id " + core.ShellQuote(leaseID)
 }
 
-func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	client, err := newAPI(b.cfg, b.rt)
 	if err != nil {
@@ -164,7 +164,7 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 	if err != nil {
 		return nil, err
 	}
-	servers := make([]Server, 0, len(machines))
+	servers := make([]core.Server, 0, len(machines))
 	for _, m := range machines {
 		if isCrabboxMachine(m) {
 			servers = append(servers, machineToServer(b.cfg, m))
@@ -173,18 +173,18 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 	return servers, nil
 }
 
-func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
-	servers, err := b.List(ctx, ListRequest{})
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
+	servers, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return inventoryDoctorResult(providerName, len(servers)), nil
+	return core.InventoryDoctorResult(providerName, len(servers)), nil
 }
 
-func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	client, err := newAPI(b.cfg, b.rt)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	return shared.PollDelegatedStatus(ctx, shared.DelegatedStatusRequest{
 		ID:          req.ID,
@@ -212,12 +212,12 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 			}, nil
 		},
 		TimeoutError: func(machineID string) error {
-			return exit(5, "timed out waiting for smolvm %s to become ready", machineID)
+			return core.Exit(5, "timed out waiting for smolvm %s to become ready", machineID)
 		},
 	})
 }
 
-func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+func (b *backend) Stop(ctx context.Context, req core.StopRequest) error {
 	client, err := newAPI(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -235,9 +235,9 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 	return nil
 }
 
-func (b *backend) createMachine(ctx context.Context, client api, repo Repo, keep bool, requestedSlug string) (claim core.LeaseClaim, machine machineData, resultErr error) {
+func (b *backend) createMachine(ctx context.Context, client api, repo core.Repo, keep bool, requestedSlug string) (claim core.LeaseClaim, machine machineData, resultErr error) {
 	leaseID := core.NewLeaseID()
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return core.LeaseClaim{}, machineData{}, err
 	}
@@ -271,7 +271,7 @@ func (b *backend) createMachine(ctx context.Context, client api, repo Repo, keep
 	}
 	original := machine
 	if machine.Name != name || validateMachineIdentity(machine, machine) != nil {
-		return core.LeaseClaim{}, machineData{}, exit(2, "smolvm create returned an incomplete or unexpected identity; retaining machine id=%q name=%q", machine.ID, machine.Name)
+		return core.LeaseClaim{}, machineData{}, core.Exit(2, "smolvm create returned an incomplete or unexpected identity; retaining machine id=%q name=%q", machine.ID, machine.Name)
 	}
 	// Publish before start so failures retain an exact cleanup receipt. A failed
 	// publication permits rollback only while the lease still has no claim.
@@ -310,10 +310,10 @@ func (b *backend) createMachine(ctx context.Context, client api, repo Repo, keep
 			break
 		}
 		if st == "error" || st == "failed" || st == "erroring" {
-			return claim, machine, exit(5, "smolvm machine failed for %s status=%s", original.ID, machine.State)
+			return claim, machine, core.Exit(5, "smolvm machine failed for %s status=%s", original.ID, machine.State)
 		}
 		if time.Now().After(deadline) {
-			return claim, machine, exit(5, "smolvm start timed out for %s status=%s", original.ID, machine.State)
+			return claim, machine, core.Exit(5, "smolvm start timed out for %s status=%s", original.ID, machine.State)
 		}
 		select {
 		case <-ctx.Done():
@@ -335,9 +335,9 @@ func (b *backend) createMachine(ctx context.Context, client api, repo Repo, keep
 func (b *backend) resolveMachineID(ctx context.Context, client api, id string) (string, string, string, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return "", "", "", exit(2, "provider=%s requires a Crabbox lease id, slug, or smolvm machine id/name", providerName)
+		return "", "", "", core.Exit(2, "provider=%s requires a Crabbox lease id, slug, or smolvm machine id/name", providerName)
 	}
-	if claim, ok, err := resolveLeaseClaim(id); err != nil {
+	if claim, ok, err := core.ResolveLeaseClaim(id); err != nil {
 		return "", "", "", err
 	} else if ok && claim.Provider == providerName {
 		machine, err := resolveMachineByLease(ctx, client, claim.LeaseID)
@@ -386,7 +386,7 @@ func resolveMachineByLease(ctx context.Context, client api, leaseID string) (mac
 			return m, nil
 		}
 	}
-	return machineData{}, exit(4, "smolvm lease %q was not found", leaseID)
+	return machineData{}, core.Exit(4, "smolvm lease %q was not found", leaseID)
 }
 
 func resolveMachineBySlug(ctx context.Context, client api, slug string) (machineData, error) {
@@ -399,16 +399,16 @@ func resolveMachineBySlug(ctx context.Context, client api, slug string) (machine
 			return m, nil
 		}
 	}
-	return machineData{}, exit(4, "smolvm %q was not found", slug)
+	return machineData{}, core.Exit(4, "smolvm %q was not found", slug)
 }
 
 func (b *backend) now() time.Time {
 	return now(b.rt)
 }
 
-func machineToServer(cfg Config, m machineData) Server {
+func machineToServer(cfg core.Config, m machineData) core.Server {
 	leaseID := machineLeaseID(m)
-	labels := directLeaseLabels(cfg, leaseID, machineSlug(leaseID, m), providerName, "", cfg.Smolvm.Keep, time.Now().UTC())
+	labels := core.DirectLeaseLabels(cfg, leaseID, machineSlug(leaseID, m), providerName, "", cfg.Smolvm.Keep, time.Now().UTC())
 	labels["machine_id"] = m.ID
 	labels["machine_name"] = m.Name
 	labels["image"] = core.Blank(m.Source.Reference, imageName(cfg))
@@ -419,7 +419,7 @@ func machineToServer(cfg Config, m machineData) Server {
 		labels["memory_mb"] = fmt.Sprintf("%d", m.Resources.MemoryMB)
 	}
 	labels["state"] = m.State
-	server := Server{
+	server := core.Server{
 		Provider: providerName,
 		CloudID:  m.ID,
 		Name:     core.Blank(m.Name, m.ID),
@@ -431,7 +431,7 @@ func machineToServer(cfg Config, m machineData) Server {
 	return server
 }
 
-func machineBaseHost(cfg Config) string {
+func machineBaseHost(cfg core.Config) string {
 	raw := core.Blank(strings.TrimSpace(cfg.Smolvm.BaseURL), core.SmolvmConfigDefaultBaseURL)
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Host == "" {
@@ -457,7 +457,7 @@ func machineSlug(leaseID string, m machineData) string {
 	if match := machineNamePattern.FindStringSubmatch(strings.TrimSpace(m.Name)); len(match) == 3 {
 		return match[1]
 	}
-	return newLeaseSlug(leaseID)
+	return core.NewLeaseSlug(leaseID)
 }
 
 func statusReady(status string) bool {
@@ -469,33 +469,33 @@ func statusReady(status string) bool {
 	}
 }
 
-func imageName(cfg Config) string {
+func imageName(cfg core.Config) string {
 	return core.Blank(strings.TrimSpace(cfg.Smolvm.Image), core.SmolvmConfigDefaultImage)
 }
 
 func machineName(leaseID, slug string) string {
 	slug = strings.Trim(strings.ToLower(strings.TrimSpace(slug)), "-")
 	if slug == "" {
-		slug = newLeaseSlug(leaseID)
+		slug = core.NewLeaseSlug(leaseID)
 	}
 	return "crabbox-" + slug + "-" + strings.TrimPrefix(leaseID, "cbx_")
 }
 
-func cpusValue(cfg Config) int {
+func cpusValue(cfg core.Config) int {
 	if cfg.Smolvm.CPUs > 0 {
 		return cfg.Smolvm.CPUs
 	}
 	return core.SmolvmConfigDefaultCPUs
 }
 
-func memoryValue(cfg Config) int {
+func memoryValue(cfg core.Config) int {
 	if cfg.Smolvm.MemoryMB > 0 {
 		return cfg.Smolvm.MemoryMB
 	}
 	return core.SmolvmConfigDefaultMemoryMB
 }
 
-func networkMode(cfg Config) string {
+func networkMode(cfg core.Config) string {
 	n := strings.ToLower(strings.TrimSpace(cfg.Smolvm.Network))
 	if n == "" {
 		return "blocked"
@@ -506,22 +506,22 @@ func networkMode(cfg Config) string {
 	return "blocked"
 }
 
-func workdir(cfg Config) string {
+func workdir(cfg core.Config) string {
 	return core.Blank(strings.TrimSpace(cfg.Smolvm.Workdir), core.SmolvmConfigDefaultWorkdir)
 }
 
 func cleanWorkdir(workdir string) (string, error) {
 	trimmed := strings.TrimSpace(workdir)
 	if trimmed == "" {
-		return "", exit(2, "smolvm workdir is empty")
+		return "", core.Exit(2, "smolvm workdir is empty")
 	}
 	clean := path.Clean(trimmed)
 	if !strings.HasPrefix(clean, "/") {
-		return "", exit(2, "smolvm workdir %q must resolve to an absolute path", workdir)
+		return "", core.Exit(2, "smolvm workdir %q must resolve to an absolute path", workdir)
 	}
 	switch clean {
 	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var":
-		return "", exit(2, "smolvm workdir %q is too broad; choose a dedicated subdirectory", clean)
+		return "", core.Exit(2, "smolvm workdir %q is too broad; choose a dedicated subdirectory", clean)
 	}
 	return clean, nil
 }
@@ -539,7 +539,7 @@ func workspaceFolder(workdir string) (string, error) {
 		if clean == workspaceRoot {
 			return "/workspace", nil
 		}
-		return "", exit(2, "smolvm workdir %q must be under %s or exactly %s", clean, workspaceRoot, workspaceRoot)
+		return "", core.Exit(2, "smolvm workdir %q must be under %s or exactly %s", clean, workspaceRoot, workspaceRoot)
 	}
 	return clean, nil
 }

--- a/internal/providers/smolvm/backend_test.go
+++ b/internal/providers/smolvm/backend_test.go
@@ -67,7 +67,7 @@ func TestSmolvmFlagPresenceAndValidationOrder(t *testing.T) {
 		t.Fatal("explicit false/empty/zero flags changed")
 	}
 	for _, name := range []string{"smolvm", "smol", "smolmachines", "smolfleet", "SMOL", " smolvm "} {
-		cfg := Config{Provider: name}
+		cfg := core.Config{Provider: name}
 		fs := flag.NewFlagSet("guard", flag.ContinueOnError)
 		fs.String("class", "", "")
 		fs.String("type", "", "")
@@ -94,7 +94,7 @@ func TestSmolvmFlagPresenceAndValidationOrder(t *testing.T) {
 			}
 		}
 	}
-	cfg = Config{Smolvm: core.SmolvmConfig{Network: "other", CPUs: -1, MemoryMB: -1, Workdir: "relative"}}
+	cfg = core.Config{Smolvm: core.SmolvmConfig{Network: "other", CPUs: -1, MemoryMB: -1, Workdir: "relative"}}
 	if err := ApplySmolvmProviderFlags(&cfg, flag.NewFlagSet("foreign", flag.ContinueOnError), struct{}{}); err != nil {
 		t.Fatal("foreign values reached validation")
 	}
@@ -117,13 +117,13 @@ func TestSmolvmFlagPresenceAndValidationOrder(t *testing.T) {
 
 func TestSmolvmSixDefaultConsumersAndSeparateNetworkRoot(t *testing.T) {
 	for _, tc := range []struct{ base, image, dir, wantBase, wantImage, wantDir, wantHost string }{{"", "", "", "https://api.smolmachines.com", "alpine", "/workspace", "api.smolmachines.com"}, {"  ", "  ", "  ", "https://api.smolmachines.com", "alpine", "/workspace", "api.smolmachines.com"}, {" http://127.0.0.1:8787/api/ ", " ubuntu ", " /workspace/app ", "http://127.0.0.1:8787/api", "ubuntu", "/workspace/app", "127.0.0.1:8787"}} {
-		cfg := Config{Smolvm: core.SmolvmConfig{APIKey: "inert", BaseURL: tc.base, Image: tc.image, Workdir: tc.dir}}
+		cfg := core.Config{Smolvm: core.SmolvmConfig{APIKey: "inert", BaseURL: tc.base, Image: tc.image, Workdir: tc.dir}}
 		before := cfg.Smolvm
 		endpoint, err := smolvmEndpoint(cfg)
 		if err != nil || endpoint != tc.wantBase {
 			t.Fatalf("endpoint=%q err=%v", endpoint, err)
 		}
-		api, err := newAPI(cfg, Runtime{HTTP: &http.Client{}})
+		api, err := newAPI(cfg, core.Runtime{HTTP: &http.Client{}})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -135,7 +135,7 @@ func TestSmolvmSixDefaultConsumersAndSeparateNetworkRoot(t *testing.T) {
 		}
 	}
 	for _, raw := range []int{-1, 0, 7} {
-		cfg := Config{Smolvm: core.SmolvmConfig{CPUs: raw, MemoryMB: raw}}
+		cfg := core.Config{Smolvm: core.SmolvmConfig{CPUs: raw, MemoryMB: raw}}
 		cpu, memory := 2, 2048
 		if raw > 0 {
 			cpu, memory = raw, raw
@@ -144,11 +144,11 @@ func TestSmolvmSixDefaultConsumersAndSeparateNetworkRoot(t *testing.T) {
 			t.Fatal("numeric default changed")
 		}
 	}
-	if networkMode(Config{}) != "blocked" || networkMode(core.BaseConfig()) != "open" {
+	if networkMode(core.Config{}) != "blocked" || networkMode(core.BaseConfig()) != "open" {
 		t.Fatal("raw empty network and compiled open default conflated")
 	}
 	for raw, want := range map[string]string{"  ": "blocked", " PUBLIC ": "open", "private": "blocked"} {
-		if got := networkMode(Config{Smolvm: core.SmolvmConfig{Network: raw}}); got != want {
+		if got := networkMode(core.Config{Smolvm: core.SmolvmConfig{Network: raw}}); got != want {
 			t.Fatalf("network raw=%q got=%q", raw, got)
 		}
 	}
@@ -307,10 +307,10 @@ func TestClientUsesSmolvmRESTShape(t *testing.T) {
 }
 
 func TestNewAPIRejectsBareHTTPBaseURL(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Smolvm.APIKey = "smk_key"
 	cfg.Smolvm.BaseURL = "http://api.smolmachines.com"
-	if _, err := newAPI(cfg, Runtime{}); err == nil {
+	if _, err := newAPI(cfg, core.Runtime{}); err == nil {
 		t.Fatal("newAPI accepted plaintext http URL")
 	}
 }
@@ -321,48 +321,48 @@ func TestNewAPIRejectsUserinfoQueryAndFragment(t *testing.T) {
 		"https://api.smolmachines.com?key=value",
 		"https://api.smolmachines.com#fragment",
 	} {
-		cfg := Config{}
+		cfg := core.Config{}
 		cfg.Smolvm.APIKey = "smk_key"
 		cfg.Smolvm.BaseURL = base
-		if _, err := newAPI(cfg, Runtime{}); err == nil {
+		if _, err := newAPI(cfg, core.Runtime{}); err == nil {
 			t.Fatalf("newAPI accepted %q", base)
 		}
 	}
 }
 
 func TestNewAPIAllowsLoopbackHTTPBaseURL(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Smolvm.APIKey = "smk_key"
 	cfg.Smolvm.BaseURL = "http://127.0.0.1:8080"
-	if _, err := newAPI(cfg, Runtime{}); err != nil {
+	if _, err := newAPI(cfg, core.Runtime{}); err != nil {
 		t.Fatalf("loopback http rejected: %v", err)
 	}
 }
 
 func TestNewAPIRejectsUntrustedHTTPSBaseURLByDefault(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Smolvm.APIKey = "smk_key"
 	cfg.Smolvm.BaseURL = "https://smolvm.attacker.example"
-	if _, err := newAPI(cfg, Runtime{}); err == nil || !strings.Contains(err.Error(), "ALLOW_CUSTOM_BASE_URL") {
+	if _, err := newAPI(cfg, core.Runtime{}); err == nil || !strings.Contains(err.Error(), "ALLOW_CUSTOM_BASE_URL") {
 		t.Fatalf("newAPI error=%v, want custom endpoint opt-in requirement", err)
 	}
 }
 
 func TestNewAPIAllowsExplicitCustomHTTPSBaseURL(t *testing.T) {
 	t.Setenv("CRABBOX_SMOLVM_ALLOW_CUSTOM_BASE_URL", "1")
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Smolvm.APIKey = "smk_key"
 	cfg.Smolvm.BaseURL = "https://smolvm.example.test"
-	if _, err := newAPI(cfg, Runtime{}); err != nil {
+	if _, err := newAPI(cfg, core.Runtime{}); err != nil {
 		t.Fatalf("explicit custom endpoint rejected: %v", err)
 	}
 }
 
 func TestNewAPINormalizesBaseURL(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Smolvm.APIKey = "smk_key"
 	cfg.Smolvm.BaseURL = " https://eu.smolmachines.com/base/ "
-	apiClient, err := newAPI(cfg, Runtime{})
+	apiClient, err := newAPI(cfg, core.Runtime{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,10 +432,10 @@ func TestSmolVMFallbackBoundsControlAndPreservesCommand(t *testing.T) {
 func TestSmolVMInjectedHTTPSettingsArePreservedForBothPlanes(t *testing.T) {
 	transport := &http.Transport{DisableKeepAlives: true}
 	injected := &http.Client{Transport: transport, Timeout: 17 * time.Second}
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Smolvm.APIKey = "smk_key"
 	cfg.Smolvm.BaseURL = "http://127.0.0.1:8787"
-	api, err := newAPI(cfg, Runtime{HTTP: injected})
+	api, err := newAPI(cfg, core.Runtime{HTTP: injected})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -462,8 +462,8 @@ func TestSmolvmClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
 	}))
 	defer trusted.Close()
 
-	cfg := Config{Smolvm: SmolvmConfig{APIKey: "smk_key", BaseURL: trusted.URL}}
-	apiClient, err := newAPI(cfg, Runtime{HTTP: trusted.Client()})
+	cfg := core.Config{Smolvm: core.SmolvmConfig{APIKey: "smk_key", BaseURL: trusted.URL}}
+	apiClient, err := newAPI(cfg, core.Runtime{HTTP: trusted.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -491,8 +491,8 @@ func TestSmolvmClientFollowsSameOriginRedirect(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{Smolvm: SmolvmConfig{APIKey: "smk_key", BaseURL: server.URL}}
-	apiClient, err := newAPI(cfg, Runtime{HTTP: server.Client()})
+	cfg := core.Config{Smolvm: core.SmolvmConfig{APIKey: "smk_key", BaseURL: server.URL}}
+	apiClient, err := newAPI(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -517,10 +517,7 @@ func TestSmolvmClientPreservesCallerRedirectPolicy(t *testing.T) {
 		callerChecks++
 		return callerErr
 	}
-	apiClient, err := newAPI(
-		Config{Smolvm: SmolvmConfig{APIKey: "smk_key", BaseURL: server.URL}},
-		Runtime{HTTP: httpClient},
-	)
+	apiClient, err := newAPI(core.Config{Smolvm: core.SmolvmConfig{APIKey: "smk_key", BaseURL: server.URL}}, core.Runtime{HTTP: httpClient})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -612,7 +609,7 @@ func TestCleanWorkdirAndCommand(t *testing.T) {
 
 func TestWarmupRejectsActionsRunner(t *testing.T) {
 	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-	err := backend.Warmup(context.Background(), WarmupRequest{ActionsRunner: true})
+	err := backend.Warmup(context.Background(), core.WarmupRequest{ActionsRunner: true})
 	if err == nil || !strings.Contains(err.Error(), "--actions-runner is not supported") {
 		t.Fatalf("err=%v, want actions-runner rejection", err)
 	}
@@ -623,8 +620,8 @@ func TestRunCreatesExecsAndDeletesOneShotMachine(t *testing.T) {
 	fake := &fakeAPI{}
 	withFakeAPI(t, fake)
 	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "repo", Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "repo", Root: t.TempDir()},
 		Command: []string{"echo", "hello"},
 		NoSync:  true,
 	})
@@ -640,7 +637,7 @@ func TestRunCreatesExecsAndDeletesOneShotMachine(t *testing.T) {
 	if result.Session.Provider != providerName || result.Session.LeaseID != result.LeaseID || result.Session.Slug != result.Slug || result.Session.Reused || result.Session.Kept {
 		t.Fatalf("session=%#v result=%#v", result.Session, result)
 	}
-	if result.Session.CleanupCommand != "crabbox stop --provider smolvm --id "+shellQuote(result.LeaseID) {
+	if result.Session.CleanupCommand != "crabbox stop --provider smolvm --id "+core.ShellQuote(result.LeaseID) {
 		t.Fatalf("cleanup command=%q", result.Session.CleanupCommand)
 	}
 	if fake.createReq.Name == "" || !strings.HasPrefix(fake.createReq.Name, "crabbox-") {
@@ -667,8 +664,8 @@ func TestRunHonorsProviderKeepConfig(t *testing.T) {
 	cfg := testConfig()
 	cfg.Smolvm.Keep = true
 	backend := NewBackend(Provider{}.Spec(), cfg, testRuntime()).(*backend)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "repo", Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "repo", Root: t.TempDir()},
 		Command: []string{"echo", "hello"},
 		NoSync:  true,
 	})
@@ -694,9 +691,9 @@ func TestRunReturnsReusedMachineSession(t *testing.T) {
 	fake := &fakeAPI{machine: machineData{ID: "mach_1", Name: "crabbox-blue-123456789abc", State: "running", CreatedAt: "2026-08-30T00:00:00Z"}}
 	withFakeAPI(t, fake)
 	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-	result, err := backend.Run(context.Background(), RunRequest{
+	result, err := backend.Run(context.Background(), core.RunRequest{
 		ID:      leaseID,
-		Repo:    Repo{Name: "repo", Root: repo},
+		Repo:    core.Repo{Name: "repo", Root: repo},
 		Command: []string{"echo", "hello"},
 		NoSync:  true,
 	})
@@ -719,13 +716,13 @@ func TestRunPreservesSessionAfterDeleteFailure(t *testing.T) {
 	rt := testRuntime()
 	rt.Stderr = &stderr
 	backend := NewBackend(Provider{}.Spec(), testConfig(), rt).(*backend)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:       Repo{Name: "repo", Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Name: "repo", Root: t.TempDir()},
 		Command:    []string{"echo", "hello"},
 		NoSync:     true,
 		TimingJSON: true,
 	})
-	var public ExitError
+	var public core.ExitError
 	if !errors.Is(err, fake.deleteErr) || !errors.As(err, &public) || public.Code != 1 || result.ExitCode != 1 || result.Status != core.RunStatusFailed || result.ErrorKind != core.RunErrorProvider {
 		t.Errorf("cleanup failure result=%+v err=%v", result, err)
 	}
@@ -741,7 +738,7 @@ func TestRunPreservesSessionAfterDeleteFailure(t *testing.T) {
 	assertLifecycleTiming(t, stderr.String(), result, err)
 }
 
-func assertLifecycleTiming(t *testing.T, stderr string, result RunResult, err error) {
+func assertLifecycleTiming(t *testing.T, stderr string, result core.RunResult, err error) {
 	t.Helper()
 	result = core.FinalizeRunResult(result, err)
 	var reports []core.TimingReport
@@ -812,8 +809,8 @@ func TestRunFinalizationPreservesPrimaryOutcome(t *testing.T) {
 				rt.Stderr = &lifecycleTimingWriter{cause: writerErr}
 			}
 			b := NewBackend(Provider{}.Spec(), testConfig(), rt).(*backend)
-			result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: tc.keepFailure, TimingJSON: true, Command: []string{"true"}})
-			var public ExitError
+			result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: tc.keepFailure, TimingJSON: true, Command: []string{"true"}})
+			var public core.ExitError
 			if !errors.As(err, &public) || public.Code != tc.wantCode || result.ExitCode != tc.wantCode || result.Status != tc.wantStatus || result.ErrorKind != tc.wantKind {
 				t.Errorf("primary outcome: result=%+v err=%v public=%+v", result, err, public)
 			}
@@ -877,7 +874,7 @@ func TestRunEffectiveKeepAndReuseControls(t *testing.T) {
 			var stderr bytes.Buffer
 			rt.Stderr = &stderr
 			b := NewBackend(Provider{}.Spec(), cfg, rt).(*backend)
-			req := RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, Keep: tc.keep, KeepOnFailure: tc.keepFailure, SyncOnly: tc.syncOnly, NoSync: true, TimingJSON: true, Command: []string{"true"}}
+			req := core.RunRequest{Repo: core.Repo{Root: t.TempDir(), Name: "fixture"}, Keep: tc.keep, KeepOnFailure: tc.keepFailure, SyncOnly: tc.syncOnly, NoSync: true, TimingJSON: true, Command: []string{"true"}}
 			if tc.reuse {
 				req.ID = "cbx_123456789abc"
 				seedSmolvmClaim(t, req.ID, "blue", "mach_1", req.Repo.Root, nil)
@@ -942,7 +939,7 @@ func TestRunCleanupBudgetsRemainIndependent(t *testing.T) {
 			}
 			withFakeAPI(t, fake)
 			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-			result, err := b.Run(ctx, RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
+			result, err := b.Run(ctx, core.RunRequest{Repo: core.Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
 			if partial && !errors.Is(err, context.Canceled) || !partial && err != nil {
 				t.Errorf("result=%+v err=%v", result, err)
 			}
@@ -958,7 +955,7 @@ func TestWarmupCreatesRetainedMachine(t *testing.T) {
 	fake := &fakeAPI{}
 	withFakeAPI(t, fake)
 	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}}); err != nil {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "repo", Root: t.TempDir()}}); err != nil {
 		t.Fatal(err)
 	}
 	if fake.createReq.Ephemeral || fake.createReq.TTLSeconds != 0 {
@@ -973,8 +970,8 @@ func TestRunKeepsWorkspaceSubdirectoryConsistent(t *testing.T) {
 	cfg := testConfig()
 	cfg.Smolvm.Workdir = "/workspace/repo"
 	backend := NewBackend(Provider{}.Spec(), cfg, testRuntime()).(*backend)
-	if _, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "repo", Root: newGitRepo(t)},
+	if _, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "repo", Root: newGitRepo(t)},
 		Command: []string{"pwd"},
 		Env:     map[string]string{"A": "1"},
 	}); err != nil {
@@ -997,8 +994,8 @@ func TestRunKeepsWorkspaceSubdirectoryConsistent(t *testing.T) {
 func TestSyncWorkspaceUsesInject(t *testing.T) {
 	fake := &fakeAPI{}
 	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-	_, _, err := backend.syncWorkspace(context.Background(), fake, "mach_1", RunRequest{
-		Repo: Repo{Name: "repo", Root: newGitRepo(t)},
+	_, _, err := backend.syncWorkspace(context.Background(), fake, "mach_1", core.RunRequest{
+		Repo: core.Repo{Name: "repo", Root: newGitRepo(t)},
 	}, "/workspace", nil)
 	if err != nil {
 		t.Fatalf("sync err=%v", err)
@@ -1074,7 +1071,7 @@ func TestRunArchivePreparationPrecedesMutation(t *testing.T) {
 						return time.Unix(0, int64(calls)*int64(time.Millisecond))
 					})
 				}
-				req := RunRequest{Repo: Repo{Root: repo, Name: "fixture"}, SyncOnly: true}
+				req := core.RunRequest{Repo: core.Repo{Root: repo, Name: "fixture"}, SyncOnly: true}
 				if reused {
 					req.ID = "cbx_123456789abc"
 					seedSmolvmClaim(t, req.ID, "blue", "mach_1", repo, nil)
@@ -1148,7 +1145,7 @@ func TestRunUploadsPreparedSnapshotAndClosesIt(t *testing.T) {
 	rt := testRuntime()
 	rt.Stderr = &stderr
 	b := NewBackend(Provider{}.Spec(), testConfig(), rt).(*backend)
-	if _, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: repo}, SyncOnly: true}); err != nil {
+	if _, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: repo}, SyncOnly: true}); err != nil {
 		t.Fatal(err)
 	}
 	if strings.Count(stderr.String(), "sync candidate:") != 1 || archivePath == "" {
@@ -1170,7 +1167,7 @@ func TestSyncArchivePreparationTiming(t *testing.T) {
 				return time.Unix(0, int64(calls)*int64(7*time.Millisecond))
 			})
 			b := NewBackend(Provider{}.Spec(), testConfig(), rt).(*backend)
-			req := RunRequest{Repo: Repo{Root: repo}}
+			req := core.RunRequest{Repo: core.Repo{Root: repo}}
 			var prepared *core.PreparedArchive
 			if external {
 				var err error
@@ -1211,7 +1208,7 @@ func TestSyncPreparedArchiveSharesRemainingBudget(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-			prepared, err := b.prepareArchive(t.Context(), RunRequest{Repo: Repo{Root: repo}})
+			prepared, err := b.prepareArchive(t.Context(), core.RunRequest{Repo: core.Repo{Root: repo}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1245,7 +1242,7 @@ func TestSyncPreparedArchiveSharesRemainingBudget(t *testing.T) {
 					}
 					return ctx.Err()
 				}
-				_, _, err := b.syncWorkspace(ctx, fake, "mach_1", RunRequest{}, "/workspace", prepared)
+				_, _, err := b.syncWorkspace(ctx, fake, "mach_1", core.RunRequest{}, "/workspace", prepared)
 				bounded := test.timeout > 0 || test.parent > 0
 				if (bounded && !errors.Is(err, context.DeadlineExceeded)) || (!bounded && err != nil) {
 					t.Fatalf("sync err=%v", err)
@@ -1265,7 +1262,7 @@ func TestStatusMapsMachineName(t *testing.T) {
 	cfg := testConfig()
 	cfg.Smolvm.BaseURL = "https://eu.smolmachines.com"
 	backend := NewBackend(Provider{}.Spec(), cfg, testRuntime()).(*backend)
-	view, err := backend.Status(context.Background(), StatusRequest{ID: "mach_1"})
+	view, err := backend.Status(context.Background(), core.StatusRequest{ID: "mach_1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1285,7 +1282,7 @@ func TestStatusRejectsNonCrabboxRawMachine(t *testing.T) {
 	fake := &fakeAPI{machine: machineData{ID: "mach_1", Name: "external-machine", State: "running"}}
 	withFakeAPI(t, fake)
 	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-	if _, err := backend.Status(context.Background(), StatusRequest{ID: "mach_1"}); err == nil {
+	if _, err := backend.Status(context.Background(), core.StatusRequest{ID: "mach_1"}); err == nil {
 		t.Fatal("expected non-Crabbox raw machine id to be rejected")
 	}
 }
@@ -1299,9 +1296,9 @@ func TestRunRawMachineIDEnforcesRepositoryClaim(t *testing.T) {
 	fake := &fakeAPI{machine: machineData{ID: "mach_1", Name: "crabbox-blue-123456789abc", State: "running", CreatedAt: "2026-08-30T00:00:00Z"}}
 	withFakeAPI(t, fake)
 	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-	_, err := backend.Run(context.Background(), RunRequest{
+	_, err := backend.Run(context.Background(), core.RunRequest{
 		ID:      "mach_1",
-		Repo:    Repo{Name: "repo-b", Root: repoB},
+		Repo:    core.Repo{Name: "repo-b", Root: repoB},
 		Command: []string{"echo", "hello"},
 		NoSync:  true,
 	})
@@ -1322,10 +1319,10 @@ func hasFeature(features core.FeatureSet, want core.Feature) bool {
 	return false
 }
 
-func testConfig() Config {
-	return Config{
+func testConfig() core.Config {
+	return core.Config{
 		Provider: providerName,
-		Smolvm: SmolvmConfig{
+		Smolvm: core.SmolvmConfig{
 			APIKey:   "smk_key",
 			BaseURL:  "https://api.smolmachines.com",
 			Image:    "ubuntu:24.04",
@@ -1337,14 +1334,14 @@ func testConfig() Config {
 	}
 }
 
-func testRuntime() Runtime {
-	return Runtime{Stdout: io.Discard, Stderr: io.Discard}
+func testRuntime() core.Runtime {
+	return core.Runtime{Stdout: io.Discard, Stderr: io.Discard}
 }
 
 func withFakeAPI(t *testing.T, fake *fakeAPI) {
 	t.Helper()
 	original := newAPI
-	newAPI = func(Config, Runtime) (api, error) { return fake, nil }
+	newAPI = func(core.Config, core.Runtime) (api, error) { return fake, nil }
 	t.Cleanup(func() { newAPI = original })
 }
 
@@ -1559,11 +1556,11 @@ func TestClientNativeUploadFailureAndPublication(t *testing.T) {
 				t.Fatal(err)
 			}
 			const content = "literal quote'\n$(must-not-execute)\x00bytes"
-			scriptPrefix := "base64() { " + shellQuote(decoder) + " \"$@\"; };\n"
+			scriptPrefix := "base64() { " + core.ShellQuote(decoder) + " \"$@\"; };\n"
 			if tc.failure == "decode" || tc.failure == "decode-cleanup" {
 				scriptPrefix = "base64() { printf partial; return 23; };\n"
 			} else if tc.failure == "decode-after-output" {
-				scriptPrefix = "base64() { " + shellQuote(decoder) + " \"$@\"; return 23; };\n"
+				scriptPrefix = "base64() { " + core.ShellQuote(decoder) + " \"$@\"; return 23; };\n"
 			}
 			if strings.Contains(tc.failure, "cleanup") {
 				scriptPrefix += "rm() { return 17; };\n"
@@ -1581,7 +1578,7 @@ func TestClientNativeUploadFailureAndPublication(t *testing.T) {
 					return
 				}
 				// Isolate the old fixed staging name when demonstrating the regression.
-				script := strings.ReplaceAll(request.Command, "/tmp/crabbox-sync.tgz", shellQuote(filepath.Join(root, "baseline-sync.tgz")))
+				script := strings.ReplaceAll(request.Command, "/tmp/crabbox-sync.tgz", core.ShellQuote(filepath.Join(root, "baseline-sync.tgz")))
 				script = strings.ReplaceAll(script, "/tmp/crabbox-write-", filepath.Join(root, "baseline-write-"))
 				cmd := exec.Command("sh", "-c", "umask 022\n"+scriptPrefix+script)
 				cmd.Env = []string{"PATH=" + os.Getenv("PATH"), "HOME=" + root, "TMPDIR=" + root}
@@ -1607,7 +1604,7 @@ func TestClientNativeUploadFailureAndPublication(t *testing.T) {
 				if err := os.WriteFile(filepath.Join(repo, "uploaded"), []byte(content), 0o755); err != nil {
 					t.Fatal(err)
 				}
-				archive, err := core.CreateSyncArchive(t.Context(), Repo{Root: repo}, core.SyncManifest{Files: []string{"uploaded"}}, "crabbox-smolvm-native-*.tgz")
+				archive, err := core.CreateSyncArchive(t.Context(), core.Repo{Root: repo}, core.SyncManifest{Files: []string{"uploaded"}}, "crabbox-smolvm-native-*.tgz")
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -1626,7 +1623,7 @@ func TestClientNativeUploadFailureAndPublication(t *testing.T) {
 				t.Fatalf("upload error=%v, wantError=%v", uploadErr, tc.wantError)
 			}
 			if strings.HasPrefix(tc.failure, "decode") {
-				var exitErr ExitError
+				var exitErr core.ExitError
 				if !errors.As(uploadErr, &exitErr) || exitErr.Code != 23 {
 					t.Fatalf("decoder status lost: %v", uploadErr)
 				}
@@ -1684,8 +1681,8 @@ func TestRunPreservesStreamErrorCause(t *testing.T) {
 			fake := &fakeAPI{streamErr: fmt.Errorf("stream: %w", cause)}
 			withFakeAPI(t, fake)
 			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-			result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir()}, NoSync: true, Keep: true, Command: []string{"true"}})
-			var exitErr ExitError
+			result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, NoSync: true, Keep: true, Command: []string{"true"}})
+			var exitErr core.ExitError
 			if !errors.Is(err, cause) || !errors.As(err, &exitErr) || exitErr.Code != 1 || len(fake.streamCommands) != 1 || t.Context().Err() != nil {
 				t.Fatalf("stream cause lost: err=%v stream calls=%d parent=%v", err, len(fake.streamCommands), t.Context().Err())
 			}
@@ -1713,7 +1710,7 @@ func TestRunSkipsStreamAfterCanceledSuccessfulEnvUpload(t *testing.T) {
 	}
 	withFakeAPI(t, fake)
 	b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-	_, err := b.Run(ctx, RunRequest{Repo: Repo{Root: t.TempDir()}, NoSync: true, Keep: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
+	_, err := b.Run(ctx, core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, NoSync: true, Keep: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
 	if !errors.Is(err, context.Canceled) || len(fake.streamCommands) != 0 || cleanups != 1 || fake.deleted {
 		t.Fatalf("canceled successful upload: err=%v streams=%v cleanups=%d deleted=%t", err, fake.streamCommands, cleanups, fake.deleted)
 	}
@@ -1759,16 +1756,16 @@ func TestRunCleansPartialEnvironmentProfile(t *testing.T) {
 				if _, ok := cleanupCtx.Deadline(); !ok {
 					t.Fatal("cleanup is unbounded")
 				}
-				if !strings.Contains(command, shellQuote(remote)) {
+				if !strings.Contains(command, core.ShellQuote(remote)) {
 					t.Fatal("wrong cleanup target")
 				}
-				cmd := exec.CommandContext(cleanupCtx, "sh", "-c", strings.ReplaceAll(command, shellQuote(remote), shellQuote(mapped)))
+				cmd := exec.CommandContext(cleanupCtx, "sh", "-c", strings.ReplaceAll(command, core.ShellQuote(remote), core.ShellQuote(mapped)))
 				out, err := cmd.CombinedOutput()
 				return execResult{Output: string(out)}, err
 			}
 			withFakeAPI(t, fake)
 			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-			_, err := b.Run(ctx, RunRequest{Repo: Repo{Root: root, Name: "fixture"}, NoSync: true, Keep: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
+			_, err := b.Run(ctx, core.RunRequest{Repo: core.Repo{Root: root, Name: "fixture"}, NoSync: true, Keep: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
 			want := primary
 			if canceled {
 				want = context.Canceled
@@ -1811,7 +1808,7 @@ func TestEnvironmentProfileCleanupRejectsChangedOwnership(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			_, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, Keep: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
+			_, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, Keep: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1858,7 +1855,7 @@ func TestRunSourceIntentSurvivesNativeShell(t *testing.T) {
 			fake := &fakeAPI{}
 			withFakeAPI(t, fake)
 			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-			_, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: root, Name: "fixture"}, NoSync: true, Keep: true, Command: tc.command, CommandLiteralArgs: tc.literal})
+			_, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: root, Name: "fixture"}, NoSync: true, Keep: true, Command: tc.command, CommandLiteralArgs: tc.literal})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/providers/smolvm/client.go
+++ b/internal/providers/smolvm/client.go
@@ -135,10 +135,10 @@ type smolvmExecCommandRequest struct {
 	TimeoutSeconds *int              `json:"timeoutSeconds,omitempty"`
 }
 
-var newAPI = func(cfg Config, rt Runtime) (api, error) {
+var newAPI = func(cfg core.Config, rt core.Runtime) (api, error) {
 	apiKey := strings.TrimSpace(cfg.Smolvm.APIKey)
 	if apiKey == "" {
-		return nil, exit(2, "provider=%s requires CRABBOX_SMOLVM_API_KEY, SMOLMACHINES_API_KEY, or SMK_API_KEY", providerName)
+		return nil, core.Exit(2, "provider=%s requires CRABBOX_SMOLVM_API_KEY, SMOLMACHINES_API_KEY, or SMK_API_KEY", providerName)
 	}
 
 	// There is no official Go SDK for the hosted smolfleet control plane
@@ -159,26 +159,26 @@ var newAPI = func(cfg Config, rt Runtime) (api, error) {
 	}, nil
 }
 
-func smolvmEndpoint(cfg Config) (string, error) {
+func smolvmEndpoint(cfg core.Config) (string, error) {
 	base := core.Blank(strings.TrimSpace(cfg.Smolvm.BaseURL), core.SmolvmConfigDefaultBaseURL)
 	parsed, err := url.Parse(base)
 	if err != nil {
-		return "", exit(2, "%s url %q is invalid", providerName, base)
+		return "", core.Exit(2, "%s url %q is invalid", providerName, base)
 	}
 	if parsed.User != nil {
-		return "", exit(2, "%s url must not include userinfo", providerName)
+		return "", core.Exit(2, "%s url must not include userinfo", providerName)
 	}
 	if parsed.Scheme == "" || parsed.Host == "" {
-		return "", exit(2, "%s url %q is invalid", providerName, base)
+		return "", core.Exit(2, "%s url %q is invalid", providerName, base)
 	}
 	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
-		return "", exit(2, "%s url %q must use https unless it targets localhost", providerName, base)
+		return "", core.Exit(2, "%s url %q must use https unless it targets localhost", providerName, base)
 	}
 	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", exit(2, "%s url %q must not include query or fragment components", providerName, base)
+		return "", core.Exit(2, "%s url %q must not include query or fragment components", providerName, base)
 	}
 	if !trustedSmolvmAPIHost(parsed) && !customSmolvmBaseURLAllowed() {
-		return "", exit(2, "%s url host %q is not an official Smol Machines endpoint; set CRABBOX_SMOLVM_ALLOW_CUSTOM_BASE_URL=1 to send credentials to a custom control plane", providerName, parsed.Hostname())
+		return "", core.Exit(2, "%s url host %q is not an official Smol Machines endpoint; set CRABBOX_SMOLVM_ALLOW_CUSTOM_BASE_URL=1 to send credentials to a custom control plane", providerName, parsed.Hostname())
 	}
 	base = strings.TrimRight(parsed.String(), "/")
 	return base, nil
@@ -325,7 +325,7 @@ func (c *client) InjectArchive(ctx context.Context, machineID, localPath, target
 		absTarget = "/workspace"
 	}
 	return c.withDecodedFile(ctx, machineID, data, "", `"${TMPDIR:-/tmp}"`,
-		"tar -xzf \"$upload_dir/payload\" -C "+shellQuote(absTarget), "archive extract")
+		"tar -xzf \"$upload_dir/payload\" -C "+core.ShellQuote(absTarget), "archive extract")
 }
 
 func (c *client) WriteFile(ctx context.Context, machineID, remotePath, content string) error {
@@ -333,11 +333,11 @@ func (c *client) WriteFile(ctx context.Context, machineID, remotePath, content s
 	if !strings.HasPrefix(absPath, "/") {
 		absPath = "/workspace/" + strings.TrimLeft(absPath, "/")
 	}
-	parent := shellQuote(path.Dir(absPath))
+	parent := core.ShellQuote(path.Dir(absPath))
 	// Stage beside the destination so publication stays on one filesystem.
-	prepare := "mkdir -p " + parent + "\n[ ! -d " + shellQuote(absPath) + " ] || { echo 'file destination is a directory' >&2; exit 1; }\n"
+	prepare := "mkdir -p " + parent + "\n[ ! -d " + core.ShellQuote(absPath) + " ] || { echo 'file destination is a directory' >&2; exit 1; }\n"
 	return c.withDecodedFile(ctx, machineID, []byte(content), prepare, parent,
-		"mv -f \"$upload_dir/payload\" "+shellQuote(absPath), "write")
+		"mv -f \"$upload_dir/payload\" "+core.ShellQuote(absPath), "write")
 }
 
 // withDecodedFile owns only this exec's private staging directory. Its trap
@@ -447,7 +447,7 @@ func commandExitError(prefix string, result execResult) error {
 	if msg == "" {
 		msg = "exit " + strconv.Itoa(result.ExitCode)
 	}
-	return exit(result.ExitCode, "%s: %s", prefix, msg)
+	return core.Exit(result.ExitCode, "%s: %s", prefix, msg)
 }
 
 func isNotFound(err error) bool {

--- a/internal/providers/smolvm/core.go
+++ b/internal/providers/smolvm/core.go
@@ -1,32 +1,10 @@
 package smolvm
 
 import (
-	"io"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type SmolvmConfig = core.SmolvmConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type Server = core.Server
-type Repo = core.Repo
-type ExitError = core.ExitError
-type timingReport = core.TimingReport
-type timingPhase = core.TimingPhase
 
 const (
 	providerName = "smolvm"
@@ -35,43 +13,7 @@ const (
 	networkPublic = core.NetworkPublic
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
-	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
-}
-
-func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaim(identifier)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
-func shellQuote(s string) string {
-	return core.ShellQuote(s)
-}
-
-func inventoryDoctorResult(provider string, leases int) DoctorResult {
-	return core.InventoryDoctorResult(provider, leases)
-}
-
-func now(rt Runtime) time.Time {
+func now(rt core.Runtime) time.Time {
 	if rt.Clock != nil {
 		return rt.Clock.Now()
 	}

--- a/internal/providers/smolvm/env.go
+++ b/internal/providers/smolvm/env.go
@@ -36,7 +36,7 @@ func (b *backend) uploadEnvProfile(ctx context.Context, client api, claim core.L
 	cleanup := func(cleanupCtx context.Context) {
 		err := profile.Close(cleanupCtx, func(removeCtx context.Context, remotePath string) error {
 			return authorized(removeCtx, func() error {
-				return b.execShell(removeCtx, client, claim.CloudID, "rm -f "+shellQuote(remotePath), io.Discard)
+				return b.execShell(removeCtx, client, claim.CloudID, "rm -f "+core.ShellQuote(remotePath), io.Discard)
 			})
 		})
 		if err != nil {

--- a/internal/providers/smolvm/flags.go
+++ b/internal/providers/smolvm/flags.go
@@ -8,11 +8,11 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func RegisterSmolvmProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterSmolvmProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterSmolvmConfigFlags(fs, defaults.Smolvm)
 }
 
-func ApplySmolvmProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplySmolvmProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if core.ProviderNameMatchesExact(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --smolvm-cpus/--smolvm-memory-mb", "use --smolvm-image"); err != nil {
 			return err
@@ -30,19 +30,19 @@ func ApplySmolvmProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	return validateConfig(*cfg)
 }
 
-func validateConfig(cfg Config) error {
+func validateConfig(cfg core.Config) error {
 	if network := strings.TrimSpace(cfg.Smolvm.Network); network != "" {
 		switch strings.ToLower(network) {
 		case "open", "blocked", "public", "private":
 		default:
-			return exit(2, "invalid smolvm network %q (use open or blocked)", network)
+			return core.Exit(2, "invalid smolvm network %q (use open or blocked)", network)
 		}
 	}
 	if cpus := cfg.Smolvm.CPUs; cpus < 0 {
-		return exit(2, "smolvm cpus must be >= 0")
+		return core.Exit(2, "smolvm cpus must be >= 0")
 	}
 	if mem := cfg.Smolvm.MemoryMB; mem < 0 {
-		return exit(2, "smolvm memory-mb must be >= 0")
+		return core.Exit(2, "smolvm memory-mb must be >= 0")
 	}
 	_, err := cleanWorkdir(workdir(cfg))
 	return err

--- a/internal/providers/smolvm/ownership.go
+++ b/internal/providers/smolvm/ownership.go
@@ -15,7 +15,7 @@ const machineCreatedLabel = "smolvm_created_at"
 func validateMachineIdentity(actual, expected machineData) error {
 	if strings.TrimSpace(expected.ID) == "" || expected.Name == "" || strings.TrimSpace(expected.CreatedAt) == "" ||
 		actual.ID != expected.ID || actual.Name != expected.Name || actual.CreatedAt != expected.CreatedAt {
-		return exit(2, "smolvm machine %q identity is missing or changed; retaining machine and claim", expected.ID)
+		return core.Exit(2, "smolvm machine %q identity is missing or changed; retaining machine and claim", expected.ID)
 	}
 	return nil
 }
@@ -26,7 +26,7 @@ func (b *backend) claimBinding(claim core.LeaseClaim) (shared.ClaimBinding, erro
 		return shared.ClaimBinding{}, err
 	}
 	if !core.IsCanonicalLeaseID(claim.LeaseID) || claim.Slug == "" || strings.TrimSpace(claim.CloudID) == "" || claim.Revision == "" || strings.TrimSpace(claim.Labels[machineCreatedLabel]) == "" {
-		return shared.ClaimBinding{}, exit(2, "smolvm lease %q requires an exact local ownership claim; legacy or unclaimed machines are retained", claim.LeaseID)
+		return shared.ClaimBinding{}, core.Exit(2, "smolvm lease %q requires an exact local ownership claim; legacy or unclaimed machines are retained", claim.LeaseID)
 	}
 	want := shared.ClaimBinding{
 		Provider: providerName, ProviderScope: scope, ExactProviderScope: true,
@@ -37,7 +37,7 @@ func (b *backend) claimBinding(claim core.LeaseClaim) (shared.ClaimBinding, erro
 		},
 	}
 	if err := shared.ValidateClaimBinding(claim, want); err != nil {
-		return shared.ClaimBinding{}, exit(2, "smolvm exact local ownership claim mismatch: %v", err)
+		return shared.ClaimBinding{}, core.Exit(2, "smolvm exact local ownership claim mismatch: %v", err)
 	}
 	return want, nil
 }
@@ -50,7 +50,7 @@ func machineFromClaim(claim core.LeaseClaim) machineData {
 func (b *backend) resolveOwnedMachine(id string) (core.LeaseClaim, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return core.LeaseClaim{}, exit(2, "smolvm requires a lease id, slug, or machine id/name")
+		return core.LeaseClaim{}, core.Exit(2, "smolvm requires a lease id, slug, or machine id/name")
 	}
 	if core.IsCanonicalLeaseID(id) {
 		claim, exists, err := core.ReadLeaseClaimWithPresence(id)
@@ -58,7 +58,7 @@ func (b *backend) resolveOwnedMachine(id string) (core.LeaseClaim, error) {
 			return core.LeaseClaim{}, err
 		}
 		if !exists {
-			return core.LeaseClaim{}, exit(2, "smolvm %q has no exact local ownership claim", id)
+			return core.LeaseClaim{}, core.Exit(2, "smolvm %q has no exact local ownership claim", id)
 		}
 		_, err = b.claimBinding(claim)
 		return claim, err
@@ -74,13 +74,13 @@ func (b *backend) resolveOwnedMachine(id string) (core.LeaseClaim, error) {
 		}
 	}
 	if len(matches) != 1 {
-		return core.LeaseClaim{}, exit(2, "smolvm %q requires one unambiguous exact local ownership claim (found %d)", id, len(matches))
+		return core.LeaseClaim{}, core.Exit(2, "smolvm %q requires one unambiguous exact local ownership claim (found %d)", id, len(matches))
 	}
 	_, err = b.claimBinding(matches[0])
 	return matches[0], err
 }
 
-func (b *backend) publishMachineClaim(ctx context.Context, leaseID, slug string, machine machineData, repo Repo) (core.LeaseClaim, error) {
+func (b *backend) publishMachineClaim(ctx context.Context, leaseID, slug string, machine machineData, repo core.Repo) (core.LeaseClaim, error) {
 	scope, err := smolvmEndpoint(b.cfg)
 	if err != nil {
 		return core.LeaseClaim{}, err
@@ -88,7 +88,7 @@ func (b *backend) publishMachineClaim(ctx context.Context, leaseID, slug string,
 	var published core.LeaseClaim
 	err = core.WithDurableLeaseClaimLockContext(ctx, leaseID, func(claim *core.LeaseClaim, exists bool, persist func() error) error {
 		if exists {
-			return exit(2, "smolvm lease %s acquired a claim during creation; retaining machine", leaseID)
+			return core.Exit(2, "smolvm lease %s acquired a claim during creation; retaining machine", leaseID)
 		}
 		now := time.Now().UTC().Format(time.RFC3339)
 		*claim = core.LeaseClaim{
@@ -112,9 +112,9 @@ func (b *backend) reuseMachine(ctx context.Context, client api, id, repoRoot str
 		return core.LeaseClaim{}, err
 	}
 	if repoRoot == "" {
-		return core.LeaseClaim{}, exit(2, "smolvm reuse requires repository context")
+		return core.LeaseClaim{}, core.Exit(2, "smolvm reuse requires repository context")
 	}
-	server := Server{Provider: providerName, CloudID: claim.CloudID, Labels: claim.Labels}
+	server := core.Server{Provider: providerName, CloudID: claim.CloudID, Labels: claim.Labels}
 	return core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfterContext(ctx, claim.LeaseID, claim.Slug, b.cfg, claim.ProviderScope, server, core.SSHTarget{}, repoRoot, b.cfg.IdleTimeout, reclaim, claim, true, func() error {
 		machine, err := client.GetMachine(ctx, claim.CloudID)
 		if err != nil {

--- a/internal/providers/smolvm/ownership_test.go
+++ b/internal/providers/smolvm/ownership_test.go
@@ -74,7 +74,7 @@ func TestSmolvmClaimWaitHonorsCallerDeadline(t *testing.T) {
 				done := make(chan error, 1)
 				go func() {
 					if operation == "stop" {
-						done <- b.Stop(ctx, StopRequest{ID: claim.LeaseID})
+						done <- b.Stop(ctx, core.StopRequest{ID: claim.LeaseID})
 					} else {
 						_, err := b.reuseMachine(ctx, fake, claim.LeaseID, repo, true)
 						done <- err
@@ -113,7 +113,7 @@ func TestSmolvmCanceledPublicationPreservesSuccessorAndCause(t *testing.T) {
 	b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	repo, successorRepo := Repo{Root: t.TempDir()}, t.TempDir()
+	repo, successorRepo := core.Repo{Root: t.TempDir()}, t.TempDir()
 	entered, release := make(chan struct{}), make(chan struct{})
 	holderDone := make(chan error, 1)
 	var successor core.LeaseClaim
@@ -216,7 +216,7 @@ func TestStopRequiresExactSmolvmClaim(t *testing.T) {
 					t.Fatal(err)
 				}
 				b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-				if err := b.Stop(context.Background(), StopRequest{ID: identifier}); err == nil {
+				if err := b.Stop(context.Background(), core.StopRequest{ID: identifier}); err == nil {
 					t.Fatal("unsafe stop succeeded")
 				}
 				if fake.deletedID != "" {
@@ -276,7 +276,7 @@ func TestStopSmolvmConfirmsDeletionBeforeRemovingClaim(t *testing.T) {
 				fake.deleteErr = errors.New("denied")
 			}
 			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-			err := b.Stop(ctx, StopRequest{ID: "blue"})
+			err := b.Stop(ctx, core.StopRequest{ID: "blue"})
 			_, exists, readErr := core.ReadLeaseClaimWithPresence(claim.LeaseID)
 			if readErr != nil {
 				t.Fatal(readErr)
@@ -302,7 +302,7 @@ func TestSmolvmRunRetainsChangedClaim(t *testing.T) {
 		successor = seedSmolvmClaim(t, id, machineSlug(id, fake.machine), "mach_successor", t.TempDir(), nil)
 	}
 	b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-	result, err := b.Run(context.Background(), RunRequest{Repo: Repo{Root: t.TempDir()}, NoSync: true, Command: []string{"true"}})
+	result, err := b.Run(context.Background(), core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, NoSync: true, Command: []string{"true"}})
 	if err == nil || result.ExitCode != 1 || result.ErrorKind != core.RunErrorProvider {
 		t.Fatalf("changed claim cleanup result=%+v err=%v", result, err)
 	}
@@ -323,7 +323,7 @@ func TestSmolvmSetupRollbackUsesCreatedIdentity(t *testing.T) {
 			withFakeAPI(t, fake)
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			primaryFailure, cleanupFailure := exit(7, "typed start failed"), exit(2, "typed cleanup failed")
+			primaryFailure, cleanupFailure := core.Exit(7, "typed start failed"), core.Exit(2, "typed cleanup failed")
 			fake.createHook = func(f *fakeAPI) {
 				if mode == "incomplete-create" {
 					f.machine.CreatedAt = ""
@@ -363,12 +363,12 @@ func TestSmolvmSetupRollbackUsesCreatedIdentity(t *testing.T) {
 				fake.deleted = true
 				return nil
 			}
-			repo := Repo{Root: t.TempDir()}
+			repo := core.Repo{Root: t.TempDir()}
 			if mode == "no-repo" {
 				repo.Root = ""
 			}
 			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-			err := b.Warmup(ctx, WarmupRequest{Repo: repo})
+			err := b.Warmup(ctx, core.WarmupRequest{Repo: repo})
 			if err == nil {
 				t.Fatal("expected setup error")
 			}
@@ -405,7 +405,7 @@ func TestSmolvmReuseNeverAdoptsLegacyClaim(t *testing.T) {
 			fake := &fakeAPI{machine: ownedTestMachine()}
 			withFakeAPI(t, fake)
 			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-			_, err := b.Run(context.Background(), RunRequest{ID: "blue", Repo: Repo{Root: repo}, Reclaim: reclaim, NoSync: true, Command: []string{"true"}})
+			_, err := b.Run(context.Background(), core.RunRequest{ID: "blue", Repo: core.Repo{Root: repo}, Reclaim: reclaim, NoSync: true, Command: []string{"true"}})
 			if err == nil || len(fake.verbs) != 0 {
 				t.Fatalf("err=%v verbs=%v", err, fake.verbs)
 			}

--- a/internal/providers/smolvm/sync.go
+++ b/internal/providers/smolvm/sync.go
@@ -10,14 +10,14 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *backend) prepareArchive(ctx context.Context, req RunRequest) (*core.PreparedArchive, error) {
+func (b *backend) prepareArchive(ctx context.Context, req core.RunRequest) (*core.PreparedArchive, error) {
 	return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
 		TempPattern: "crabbox-smolvm-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
 	})
 }
 
-func (b *backend) syncWorkspace(ctx context.Context, client api, machineID string, req RunRequest, folder string, prepared *core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+func (b *backend) syncWorkspace(ctx context.Context, client api, machineID string, req core.RunRequest, folder string, prepared *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	start := b.now()
 	preparedExternally := prepared != nil
 	if prepared == nil {
@@ -49,7 +49,7 @@ func (b *backend) syncWorkspace(ctx context.Context, client api, machineID strin
 	if preparedExternally {
 		total += prepared.ManifestDuration + prepared.PreflightDuration + prepared.ArchiveDuration
 	}
-	return []timingPhase{
+	return []core.TimingPhase{
 		{Name: "manifest", Ms: prepared.ManifestDuration.Milliseconds()},
 		{Name: "preflight", Ms: prepared.PreflightDuration.Milliseconds()},
 		{Name: "archive", Ms: prepared.ArchiveDuration.Milliseconds()},
@@ -69,13 +69,13 @@ func (b *backend) prepareWorkspace(ctx context.Context, client api, machineID, f
 	if absFolder == "/" {
 		absFolder = "/workspace"
 	}
-	command := "mkdir -p " + shellQuote(absFolder)
+	command := "mkdir -p " + core.ShellQuote(absFolder)
 	if delete {
 		if absFolder == "/workspace" {
 			// safe clean for workdir root
 			command = "find /workspace -mindepth 1 -exec rm -rf {} + 2>/dev/null || rm -rf -- /workspace/* 2>/dev/null || true; mkdir -p /workspace"
 		} else {
-			command = "rm -rf " + shellQuote(absFolder) + " && " + command
+			command = "rm -rf " + core.ShellQuote(absFolder) + " && " + command
 		}
 	}
 	return b.execShell(ctx, client, machineID, command, io.Discard)


### PR DESCRIPTION
Remove provider-local aliases and exact core forwarding functions from Cloud Run Sandbox, Azure Dynamic Sessions, Crownest, SmolVM, Orgo, and OpenComputer. Call the core implementations directly so claim operations, command utilities, and run reporting have one visible owner. This removes 513 net production lines.

Go type identity and resolved references were checked before replacement. Provider-specific scope binding, native credential admission, recovery policy, and mutable injection hooks retain their adapter ownership.

Validation: complete tests passed for all six provider packages; scoped Autoreview passed. Full CI passed on the PR head. No command, configuration, dependency, or credential changes.
