### PR TITLE
refactor(providers): remove SSH adapter core forwarding layers

### DIFF
--- a/internal/providers/exedev/backend.go
+++ b/internal/providers/exedev/backend.go
@@ -18,9 +18,9 @@ import (
 )
 
 type exeDevLeaseBackend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
 const (
@@ -29,119 +29,119 @@ const (
 	exeDevConfirmedAbsentLabel     = "exe_dev_confirmed_absent"
 )
 
-func NewExeDevLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewExeDevLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	applyExeDevDefaults(&cfg)
 	return &exeDevLeaseBackend{spec: spec, cfg: cfg, rt: rt}
 }
 
-func (b *exeDevLeaseBackend) Spec() ProviderSpec { return b.spec }
+func (b *exeDevLeaseBackend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *exeDevLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+func (b *exeDevLeaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	leaseID := core.NewLeaseID()
 	servers, err := b.listServers(ctx, false)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cfg := b.configForRun()
-	name := leaseProviderName(leaseID, slug)
+	name := core.LeaseProviderName(leaseID, slug)
 	generation := core.NewLeaseID()
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s image=%s cpus=%d memory=%s disk=%s keep=%v\n", providerName, leaseID, slug, name, exeDevImage(cfg), cfg.ExeDev.CPUs, cfg.ExeDev.Memory, cfg.ExeDev.Disk, req.Keep)
 	vm, err := b.createVM(ctx, cfg, name, leaseID, slug, generation)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	lease, err := b.prepareLease(ctx, cfg, vm, leaseID, slug, req.Keep, true)
 	if err != nil {
 		if !req.Keep {
 			err = b.rollbackCreatedVM(name, leaseID, slug, generation, err)
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	providerScope, err := b.controlScope(ctx)
 	if err != nil {
 		if !req.Keep {
 			err = b.rollbackCreatedVM(name, leaseID, slug, generation, err)
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	lease.Server.Labels[exeDevClaimGenerationLabel] = generation
-	claim, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, providerScope, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, LeaseClaim{}, false)
+	claim, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, providerScope, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, core.LeaseClaim{}, false)
 	if err != nil {
 		if !req.Keep {
 			err = b.rollbackCreatedVM(name, leaseID, slug, generation, err)
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	setServerLeaseClaimSnapshot(&lease.Server, claim, true)
+	core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s name=%s state=ready\n", leaseID, name)
 	return lease, nil
 }
 
-func (b *exeDevLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *exeDevLeaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	cfg := b.configForRun()
 	if req.ReleaseOnly {
 		return b.resolveReleaseTarget(ctx, cfg, req.ID)
 	}
 	vm, leaseID, slug, err := b.resolveVM(ctx, req.ID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	lease, err := b.prepareLease(ctx, cfg, vm, leaseID, slug, true, false)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.Repo.Root != "" {
 		claim, err := b.claimResolvedVM(ctx, lease, vm, leaseID, slug, req)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
-		setServerLeaseClaimSnapshot(&lease.Server, claim, true)
-	} else if claim, exists, err := readLeaseClaimWithPresence(leaseID); err != nil {
-		return LeaseTarget{}, err
+		core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
+	} else if claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil {
+		return core.LeaseTarget{}, err
 	} else {
 		if exists {
 			if err := b.validateVMClaimBinding(ctx, vm, claim, leaseID, slug); err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 		} else if !req.IsReadOnlyStatus() {
-			return LeaseTarget{}, exit(2, "provider=%s lease %s has no exact local claim; use a repository-scoped reuse with --reclaim before operating on it", providerName, leaseID)
+			return core.LeaseTarget{}, core.Exit(2, "provider=%s lease %s has no exact local claim; use a repository-scoped reuse with --reclaim before operating on it", providerName, leaseID)
 		}
-		setServerLeaseClaimSnapshot(&lease.Server, claim, exists)
+		core.SetServerLeaseClaimSnapshot(&lease.Server, claim, exists)
 	}
 	return lease, nil
 }
 
-func (b *exeDevLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *exeDevLeaseBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	return b.listServers(ctx, req.All)
 }
 
-func (b *exeDevLeaseBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
-	servers, err := b.List(ctx, ListRequest{})
+func (b *exeDevLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
+	servers, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return cliDoctorResult(providerName, len(servers), "unchecked"), nil
+	return core.CLIDoctorResult(providerName, len(servers), "unchecked"), nil
 }
 
-func (b *exeDevLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
-	claim, exists, snapshotSet := serverLeaseClaimSnapshot(req.Lease.Server)
+func (b *exeDevLeaseBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
+	claim, exists, snapshotSet := core.ServerLeaseClaimSnapshot(req.Lease.Server)
 	if !snapshotSet || !exists {
-		return exit(2, "provider=%s release requires an exact local claim snapshot", providerName)
+		return core.Exit(2, "provider=%s release requires an exact local claim snapshot", providerName)
 	}
 	if err := b.validateReleaseTarget(req.Lease, claim); err != nil {
 		return err
 	}
 	if req.Lease.Server.Labels[exeDevConfirmedAbsentLabel] == "true" {
-		return removeLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+		return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
 			return b.confirmClaimedVMAbsent(ctx, claim)
 		})
 	}
-	return removeLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+	return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
 		vm, err := b.findVMByExactName(ctx, claim.CloudID)
 		if err != nil {
 			return err
@@ -169,7 +169,7 @@ func (b *exeDevLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseR
 	})
 }
 
-func exeDevCleanupServer(cfg Config, vm exeDevVM, claim LeaseClaim) Server {
+func exeDevCleanupServer(cfg core.Config, vm exeDevVM, claim core.LeaseClaim) core.Server {
 	server := exeDevServer(vm, claim.LeaseID, claim.Slug, cfg, true)
 	for key, value := range claim.Labels {
 		server.Labels[key] = value
@@ -198,46 +198,46 @@ func exeDevCleanupServer(cfg Config, vm exeDevVM, claim LeaseClaim) Server {
 	return server
 }
 
-func (b *exeDevLeaseBackend) resolveReleaseTarget(ctx context.Context, cfg Config, identifier string) (LeaseTarget, error) {
+func (b *exeDevLeaseBackend) resolveReleaseTarget(ctx context.Context, cfg core.Config, identifier string) (core.LeaseTarget, error) {
 	claim, claimed, err := resolveExeDevReleaseClaim(identifier)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if !claimed {
 		vm, leaseID, slug, err := b.resolveVM(ctx, identifier)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		claim, err := b.claimForVMRelease(ctx, vm, leaseID, slug)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		server := exeDevServer(vm, leaseID, slug, cfg, true)
-		setServerLeaseClaimSnapshot(&server, claim, true)
-		return LeaseTarget{Server: server, SSH: exeDevSSHTarget(cfg, vm), LeaseID: leaseID}, nil
+		core.SetServerLeaseClaimSnapshot(&server, claim, true)
+		return core.LeaseTarget{Server: server, SSH: exeDevSSHTarget(cfg, vm), LeaseID: leaseID}, nil
 	}
 	if err := b.validateAbsentCleanupClaim(ctx, claim); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	vms, err := b.listVMs(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	for _, vm := range vms {
 		if vm.Name() != claim.CloudID {
 			if exeDevVMReferencesLease(vm, claim.LeaseID) {
-				return LeaseTarget{}, exit(2, "exe.dev lease %s is present on unexpected VM %s; refusing absent-claim cleanup", claim.LeaseID, vm.Name())
+				return core.LeaseTarget{}, core.Exit(2, "exe.dev lease %s is present on unexpected VM %s; refusing absent-claim cleanup", claim.LeaseID, vm.Name())
 			}
 			continue
 		}
 		if err := b.validateVMClaimBinding(ctx, vm, claim, claim.LeaseID, claim.Slug); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		server := exeDevServer(vm, claim.LeaseID, claim.Slug, cfg, true)
-		setServerLeaseClaimSnapshot(&server, claim, true)
-		return LeaseTarget{Server: server, SSH: exeDevSSHTarget(cfg, vm), LeaseID: claim.LeaseID}, nil
+		core.SetServerLeaseClaimSnapshot(&server, claim, true)
+		return core.LeaseTarget{Server: server, SSH: exeDevSSHTarget(cfg, vm), LeaseID: claim.LeaseID}, nil
 	}
-	server := Server{
+	server := core.Server{
 		CloudID:  claim.CloudID,
 		Provider: providerName,
 		Name:     claim.CloudID,
@@ -249,12 +249,12 @@ func (b *exeDevLeaseBackend) resolveReleaseTarget(ctx context.Context, cfg Confi
 			exeDevConfirmedAbsentLabel: "true",
 		},
 	}
-	setServerLeaseClaimSnapshot(&server, claim, true)
-	return LeaseTarget{Server: server, LeaseID: claim.LeaseID}, nil
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	return core.LeaseTarget{Server: server, LeaseID: claim.LeaseID}, nil
 }
 
-func resolveExeDevReleaseClaim(identifier string) (LeaseClaim, bool, error) {
-	claim, claimed, err := resolveLeaseClaimForProvider(identifier, providerName)
+func resolveExeDevReleaseClaim(identifier string) (core.LeaseClaim, bool, error) {
+	claim, claimed, err := core.ResolveLeaseClaimForProvider(identifier, providerName)
 	if err != nil || claimed {
 		return claim, claimed, err
 	}
@@ -262,24 +262,24 @@ func resolveExeDevReleaseClaim(identifier string) (LeaseClaim, bool, error) {
 	if strings.HasSuffix(cloudID, ".exe.xyz") {
 		cloudID = strings.TrimSuffix(cloudID, ".exe.xyz")
 	}
-	return resolveLeaseClaimForProviderCloudID(cloudID, providerName)
+	return core.ResolveLeaseClaimForProviderCloudID(cloudID, providerName)
 }
 
-func (b *exeDevLeaseBackend) validateAbsentCleanupClaim(ctx context.Context, claim LeaseClaim) error {
-	slug := normalizeLeaseSlug(claim.Slug)
-	if !isCanonicalLeaseID(claim.LeaseID) || claim.Provider != providerName || slug == "" || claim.CloudID != leaseProviderName(claim.LeaseID, slug) {
-		return exit(2, "lease %s has no exact exe.dev resource binding for absent cleanup", claim.LeaseID)
+func (b *exeDevLeaseBackend) validateAbsentCleanupClaim(ctx context.Context, claim core.LeaseClaim) error {
+	slug := core.NormalizeLeaseSlug(claim.Slug)
+	if !core.IsCanonicalLeaseID(claim.LeaseID) || claim.Provider != providerName || slug == "" || claim.CloudID != core.LeaseProviderName(claim.LeaseID, slug) {
+		return core.Exit(2, "lease %s has no exact exe.dev resource binding for absent cleanup", claim.LeaseID)
 	}
-	if claim.Labels["provider"] != providerName || claim.Labels["lease"] != claim.LeaseID || normalizeLeaseSlug(claim.Labels["slug"]) != slug || claim.Labels["name"] != claim.CloudID {
-		return exit(2, "lease %s claim metadata does not attest absent exe.dev cleanup", claim.LeaseID)
+	if claim.Labels["provider"] != providerName || claim.Labels["lease"] != claim.LeaseID || core.NormalizeLeaseSlug(claim.Labels["slug"]) != slug || claim.Labels["name"] != claim.CloudID {
+		return core.Exit(2, "lease %s claim metadata does not attest absent exe.dev cleanup", claim.LeaseID)
 	}
-	if !isCanonicalLeaseID(strings.TrimSpace(claim.Labels[exeDevClaimGenerationLabel])) {
-		return exit(2, "lease %s has no canonical exe.dev claim generation for absent cleanup", claim.LeaseID)
+	if !core.IsCanonicalLeaseID(strings.TrimSpace(claim.Labels[exeDevClaimGenerationLabel])) {
+		return core.Exit(2, "lease %s has no canonical exe.dev claim generation for absent cleanup", claim.LeaseID)
 	}
 	return b.validateExistingClaimRoute(ctx, claim)
 }
 
-func (b *exeDevLeaseBackend) confirmClaimedVMAbsent(ctx context.Context, claim LeaseClaim) error {
+func (b *exeDevLeaseBackend) confirmClaimedVMAbsent(ctx context.Context, claim core.LeaseClaim) error {
 	if err := b.validateAbsentCleanupClaim(ctx, claim); err != nil {
 		return err
 	}
@@ -289,7 +289,7 @@ func (b *exeDevLeaseBackend) confirmClaimedVMAbsent(ctx context.Context, claim L
 	}
 	for _, vm := range vms {
 		if vm.Name() == claim.CloudID || exeDevVMReferencesLease(vm, claim.LeaseID) {
-			return exit(2, "exe.dev lease %s is present on VM %s; refusing absent-claim cleanup", claim.LeaseID, vm.Name())
+			return core.Exit(2, "exe.dev lease %s is present on VM %s; refusing absent-claim cleanup", claim.LeaseID, vm.Name())
 		}
 	}
 	return nil
@@ -305,34 +305,34 @@ func exeDevVMReferencesLease(vm exeDevVM, leaseID string) bool {
 	return false
 }
 
-func (b *exeDevLeaseBackend) RefreshReleaseLeaseTarget(ctx context.Context, lease LeaseTarget) (LeaseTarget, error) {
-	acquired, acquiredExists, snapshotSet := serverLeaseClaimSnapshot(lease.Server)
+func (b *exeDevLeaseBackend) RefreshReleaseLeaseTarget(ctx context.Context, lease core.LeaseTarget) (core.LeaseTarget, error) {
+	acquired, acquiredExists, snapshotSet := core.ServerLeaseClaimSnapshot(lease.Server)
 	if !snapshotSet || !acquiredExists {
-		return LeaseTarget{}, exit(2, "provider=%s release refresh requires the acquisition claim snapshot", providerName)
+		return core.LeaseTarget{}, core.Exit(2, "provider=%s release refresh requires the acquisition claim snapshot", providerName)
 	}
 	if changed, err := exeDevClaimOwnershipChanged(acquired); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	} else if changed {
-		return LeaseTarget{}, exeDevOwnershipChangedError(lease.LeaseID)
+		return core.LeaseTarget{}, exeDevOwnershipChangedError(lease.LeaseID)
 	}
-	refreshed, err := b.Resolve(ctx, ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true})
+	refreshed, err := b.Resolve(ctx, core.ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true})
 	if err != nil {
 		if changed, claimErr := exeDevClaimOwnershipChanged(acquired); claimErr == nil && changed {
-			return LeaseTarget{}, exeDevOwnershipChangedError(lease.LeaseID)
+			return core.LeaseTarget{}, exeDevOwnershipChangedError(lease.LeaseID)
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	current, currentExists, currentSnapshotSet := serverLeaseClaimSnapshot(refreshed.Server)
+	current, currentExists, currentSnapshotSet := core.ServerLeaseClaimSnapshot(refreshed.Server)
 	if !currentSnapshotSet || !currentExists || !sameExeDevClaimLineage(acquired, current) {
-		return LeaseTarget{}, exeDevOwnershipChangedError(lease.LeaseID)
+		return core.LeaseTarget{}, exeDevOwnershipChangedError(lease.LeaseID)
 	}
 	return refreshed, nil
 }
 
 func (b *exeDevLeaseBackend) ReleaseLeaseConnectionCleanupSafe() bool { return false }
 
-func exeDevClaimOwnershipChanged(acquired LeaseClaim) (bool, error) {
-	current, exists, err := readLeaseClaimWithPresence(acquired.LeaseID)
+func exeDevClaimOwnershipChanged(acquired core.LeaseClaim) (bool, error) {
+	current, exists, err := core.ReadLeaseClaimWithPresence(acquired.LeaseID)
 	if err != nil {
 		return false, err
 	}
@@ -340,38 +340,37 @@ func exeDevClaimOwnershipChanged(acquired LeaseClaim) (bool, error) {
 }
 
 func exeDevOwnershipChangedError(leaseID string) error {
-	return errors.Join(errReleaseLeaseOwnershipChanged, exit(2, "lease %s claim ownership changed after acquisition; refusing automatic release", leaseID))
+	return errors.Join(errReleaseLeaseOwnershipChanged, core.Exit(2, "lease %s claim ownership changed after acquisition; refusing automatic release", leaseID))
 }
 
-func sameExeDevClaimLineage(acquired, current LeaseClaim) bool {
+func sameExeDevClaimLineage(acquired, current core.LeaseClaim) bool {
 	return acquired.LeaseID == current.LeaseID &&
 		acquired.Provider == current.Provider &&
 		acquired.ProviderScope == current.ProviderScope &&
 		acquired.CloudID == current.CloudID &&
 		acquired.CloudNumericID == current.CloudNumericID &&
-		acquired.CloudImmutableID == current.CloudImmutableID &&
-		normalizeLeaseSlug(acquired.Slug) == normalizeLeaseSlug(current.Slug) &&
+		acquired.CloudImmutableID == current.CloudImmutableID && core.NormalizeLeaseSlug(acquired.Slug) == core.NormalizeLeaseSlug(current.Slug) &&
 		acquired.RepoRoot == current.RepoRoot &&
 		strings.TrimSpace(acquired.Labels[exeDevClaimGenerationLabel]) != "" &&
 		acquired.Labels[exeDevClaimGenerationLabel] == current.Labels[exeDevClaimGenerationLabel]
 }
 
-func (b *exeDevLeaseBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {
+func (b *exeDevLeaseBackend) Touch(_ context.Context, req core.TouchRequest) (core.Server, error) {
 	server := req.Lease.Server
 	if server.Labels == nil {
 		server.Labels = map[string]string{}
 	}
-	server.Labels = touchDirectLeaseLabels(server.Labels, b.configForRun(), req.State, time.Now().UTC())
+	server.Labels = core.TouchDirectLeaseLabels(server.Labels, b.configForRun(), req.State, time.Now().UTC())
 	return server, nil
 }
 
-func (b *exeDevLeaseBackend) configForRun() Config {
+func (b *exeDevLeaseBackend) configForRun() core.Config {
 	cfg := b.cfg
 	applyExeDevDefaults(&cfg)
 	return cfg
 }
 
-func applyExeDevDefaults(cfg *Config) {
+func applyExeDevDefaults(cfg *core.Config) {
 	cfg.Provider = providerName
 	if cfg.TargetOS == "" {
 		cfg.TargetOS = targetLinux
@@ -402,7 +401,7 @@ func applyExeDevDefaults(cfg *Config) {
 	cfg.ServerType = exeDevImage(*cfg)
 }
 
-func (b *exeDevLeaseBackend) createVM(ctx context.Context, cfg Config, name, leaseID, slug, generation string) (exeDevVM, error) {
+func (b *exeDevLeaseBackend) createVM(ctx context.Context, cfg core.Config, name, leaseID, slug, generation string) (exeDevVM, error) {
 	args := []string{"new", "--name", name, "--json", "--tag", "crabbox", "--tag", "crabbox-lease-" + leaseID, "--tag", "crabbox-slug-" + slug, "--tag", exeDevClaimGenerationTagPrefix + generation}
 	if cfg.ExeDev.NoEmail {
 		args = append(args, "--no-email")
@@ -437,54 +436,54 @@ func (b *exeDevLeaseBackend) createVM(ctx context.Context, cfg Config, name, lea
 func (b *exeDevLeaseBackend) deleteVM(ctx context.Context, name string) error {
 	result, err := b.control(ctx, []string{"rm", name, "--json"}, io.Discard, b.rt.Stderr)
 	if err != nil {
-		return exit(commandExitCode(result), "exe.dev rm %s failed: %v", name, err)
+		return core.Exit(commandExitCode(result), "exe.dev rm %s failed: %v", name, err)
 	}
 	return nil
 }
 
-func (b *exeDevLeaseBackend) claimResolvedVM(ctx context.Context, lease LeaseTarget, vm exeDevVM, leaseID, slug string, req ResolveRequest) (LeaseClaim, error) {
+func (b *exeDevLeaseBackend) claimResolvedVM(ctx context.Context, lease core.LeaseTarget, vm exeDevVM, leaseID, slug string, req core.ResolveRequest) (core.LeaseClaim, error) {
 	if err := b.validateResolvedLeaseTarget(lease, vm, leaseID, slug); err != nil {
-		return LeaseClaim{}, err
+		return core.LeaseClaim{}, err
 	}
-	previous, exists, err := readLeaseClaimWithPresence(leaseID)
+	previous, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
 	if err != nil {
-		return LeaseClaim{}, err
+		return core.LeaseClaim{}, err
 	}
 	if !exists && !req.Reclaim {
-		return LeaseClaim{}, exit(2, "exe.dev VM %s is not locally claimed; inspect it, then reuse with --reclaim before operating on it", vm.Name())
+		return core.LeaseClaim{}, core.Exit(2, "exe.dev VM %s is not locally claimed; inspect it, then reuse with --reclaim before operating on it", vm.Name())
 	}
 	if exists {
 		if previous.Provider != "" && previous.Provider != providerName {
-			return LeaseClaim{}, exit(2, "lease %s is already claimed by provider=%s", leaseID, previous.Provider)
+			return core.LeaseClaim{}, core.Exit(2, "lease %s is already claimed by provider=%s", leaseID, previous.Provider)
 		}
 		if previous.Provider == "" && !req.Reclaim {
-			return LeaseClaim{}, exit(2, "lease %s has a legacy providerless claim; reuse with --reclaim to bind provider=%s", leaseID, providerName)
+			return core.LeaseClaim{}, core.Exit(2, "lease %s has a legacy providerless claim; reuse with --reclaim to bind provider=%s", leaseID, providerName)
 		}
 		if previous.CloudID != "" && previous.CloudID != vm.Name() {
-			return LeaseClaim{}, exit(2, "lease %s is already bound to exe.dev VM %s, refusing retarget to %s", leaseID, previous.CloudID, vm.Name())
+			return core.LeaseClaim{}, core.Exit(2, "lease %s is already bound to exe.dev VM %s, refusing retarget to %s", leaseID, previous.CloudID, vm.Name())
 		}
 		// Released versions did not bind exe.dev claims to a control route.
 		// Explicit reclaim is the migration boundary after remote ownership and
 		// exact resource identity have both been revalidated above.
 		if previous.ProviderScope == "" && !req.Reclaim {
-			return LeaseClaim{}, exit(2, "lease %s has a legacy unscoped claim; reuse with --reclaim to bind the exe.dev control route", leaseID)
+			return core.LeaseClaim{}, core.Exit(2, "lease %s has a legacy unscoped claim; reuse with --reclaim to bind the exe.dev control route", leaseID)
 		}
 		if previous.ProviderScope != "" {
 			if err := b.validateExistingClaimRoute(ctx, previous); err != nil {
-				return LeaseClaim{}, err
+				return core.LeaseClaim{}, err
 			}
 		}
 	}
 	cfg := b.configForRun()
 	providerScope, err := b.controlScope(ctx)
 	if err != nil {
-		return LeaseClaim{}, err
+		return core.LeaseClaim{}, err
 	}
 	generation := ""
 	if exists && !req.Reclaim {
 		generation = strings.TrimSpace(previous.Labels[exeDevClaimGenerationLabel])
 		if generation == "" {
-			return LeaseClaim{}, exit(2, "lease %s has a legacy generationless claim; reuse with --reclaim before operating on it", leaseID)
+			return core.LeaseClaim{}, core.Exit(2, "lease %s has a legacy generationless claim; reuse with --reclaim before operating on it", leaseID)
 		}
 	}
 	if generation == "" {
@@ -493,104 +492,104 @@ func (b *exeDevLeaseBackend) claimResolvedVM(ctx context.Context, lease LeaseTar
 	lease.Server.Labels[exeDevClaimGenerationLabel] = generation
 	claim, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, providerScope, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, previous, exists)
 	if err != nil {
-		return LeaseClaim{}, err
+		return core.LeaseClaim{}, err
 	}
 	if req.Reclaim {
-		return updateLeaseClaimLabelsIfUnchangedAfter(leaseID, claim, claim.Labels, func() error {
+		return core.UpdateLeaseClaimLabelsIfUnchangedAfter(leaseID, claim, claim.Labels, func() error {
 			return b.replaceVMClaimGeneration(ctx, vm, generation)
 		})
 	}
 	if err := validateExeDevClaimGeneration(vm, generation); err != nil {
-		return LeaseClaim{}, err
+		return core.LeaseClaim{}, err
 	}
 	return claim, nil
 }
 
-func (b *exeDevLeaseBackend) validateResolvedLeaseTarget(lease LeaseTarget, vm exeDevVM, leaseID, slug string) error {
+func (b *exeDevLeaseBackend) validateResolvedLeaseTarget(lease core.LeaseTarget, vm exeDevVM, leaseID, slug string) error {
 	if err := validateExeDevVMOwnership(vm, leaseID, slug, "reuse"); err != nil {
 		return err
 	}
 	wantHost := vm.SSHAddress().Host
 	if lease.LeaseID != leaseID || lease.Server.Provider != providerName || lease.Server.CloudID != vm.Name() || lease.Server.Name != vm.Name() || lease.SSH.Host != wantHost {
-		return exit(2, "exe.dev VM %s resolved to inconsistent provider metadata", vm.Name())
+		return core.Exit(2, "exe.dev VM %s resolved to inconsistent provider metadata", vm.Name())
 	}
-	if lease.Server.Labels["provider"] != providerName || lease.Server.Labels["lease"] != leaseID || normalizeLeaseSlug(lease.Server.Labels["slug"]) != normalizeLeaseSlug(slug) || lease.Server.Labels["name"] != vm.Name() {
-		return exit(2, "exe.dev VM %s resolved to incomplete claim metadata", vm.Name())
+	if lease.Server.Labels["provider"] != providerName || lease.Server.Labels["lease"] != leaseID || core.NormalizeLeaseSlug(lease.Server.Labels["slug"]) != core.NormalizeLeaseSlug(slug) || lease.Server.Labels["name"] != vm.Name() {
+		return core.Exit(2, "exe.dev VM %s resolved to incomplete claim metadata", vm.Name())
 	}
 	return nil
 }
 
-func (b *exeDevLeaseBackend) claimForVMRelease(ctx context.Context, vm exeDevVM, leaseID, slug string) (LeaseClaim, error) {
-	claim, exists, err := readLeaseClaimWithPresence(leaseID)
+func (b *exeDevLeaseBackend) claimForVMRelease(ctx context.Context, vm exeDevVM, leaseID, slug string) (core.LeaseClaim, error) {
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
 	if err != nil {
-		return LeaseClaim{}, err
+		return core.LeaseClaim{}, err
 	}
 	if !exists {
-		return LeaseClaim{}, exit(2, "exe.dev VM %s has no exact local claim; refusing deletion", vm.Name())
+		return core.LeaseClaim{}, core.Exit(2, "exe.dev VM %s has no exact local claim; refusing deletion", vm.Name())
 	}
 	if err := b.validateVMClaimBinding(ctx, vm, claim, leaseID, slug); err != nil {
-		return LeaseClaim{}, err
+		return core.LeaseClaim{}, err
 	}
 	return claim, nil
 }
 
-func (b *exeDevLeaseBackend) validateExistingClaimRoute(ctx context.Context, claim LeaseClaim) error {
+func (b *exeDevLeaseBackend) validateExistingClaimRoute(ctx context.Context, claim core.LeaseClaim) error {
 	want, err := b.controlScope(ctx)
 	if err != nil {
 		return err
 	}
 	if got := strings.TrimSpace(claim.ProviderScope); got == "" || got != want {
-		return exit(2, "lease %s is bound to a different exe.dev control route", claim.LeaseID)
+		return core.Exit(2, "lease %s is bound to a different exe.dev control route", claim.LeaseID)
 	}
 	return nil
 }
 
-func (b *exeDevLeaseBackend) validateVMClaimBinding(ctx context.Context, vm exeDevVM, claim LeaseClaim, leaseID, slug string) error {
+func (b *exeDevLeaseBackend) validateVMClaimBinding(ctx context.Context, vm exeDevVM, claim core.LeaseClaim, leaseID, slug string) error {
 	if err := validateExeDevVMOwnership(vm, leaseID, slug, "deletion"); err != nil {
 		return err
 	}
-	slug = normalizeLeaseSlug(slug)
-	if claim.LeaseID != leaseID || claim.Provider != providerName || normalizeLeaseSlug(claim.Slug) != slug || claim.CloudID != vm.Name() {
-		return exit(2, "exe.dev VM %s is not bound to an exact provider/resource claim", vm.Name())
+	slug = core.NormalizeLeaseSlug(slug)
+	if claim.LeaseID != leaseID || claim.Provider != providerName || core.NormalizeLeaseSlug(claim.Slug) != slug || claim.CloudID != vm.Name() {
+		return core.Exit(2, "exe.dev VM %s is not bound to an exact provider/resource claim", vm.Name())
 	}
 	target := exeDevSSHTarget(b.configForRun(), vm)
 	port, err := strconv.Atoi(strings.TrimSpace(target.Port))
 	if err != nil || port <= 0 || strings.TrimSpace(target.Host) == "" {
-		return exit(2, "exe.dev VM %s has an invalid SSH endpoint", vm.Name())
+		return core.Exit(2, "exe.dev VM %s has an invalid SSH endpoint", vm.Name())
 	}
 	if strings.TrimSpace(claim.SSHHost) != strings.TrimSpace(target.Host) || claim.SSHPort != port {
-		return exit(2, "exe.dev VM %s SSH endpoint does not match the exact local claim", vm.Name())
+		return core.Exit(2, "exe.dev VM %s SSH endpoint does not match the exact local claim", vm.Name())
 	}
 	if err := b.validateExistingClaimRoute(ctx, claim); err != nil {
 		return err
 	}
-	if claim.Labels["provider"] != providerName || claim.Labels["lease"] != leaseID || normalizeLeaseSlug(claim.Labels["slug"]) != slug || claim.Labels["name"] != vm.Name() {
-		return exit(2, "exe.dev VM %s claim metadata does not attest the current provider binding", vm.Name())
+	if claim.Labels["provider"] != providerName || claim.Labels["lease"] != leaseID || core.NormalizeLeaseSlug(claim.Labels["slug"]) != slug || claim.Labels["name"] != vm.Name() {
+		return core.Exit(2, "exe.dev VM %s claim metadata does not attest the current provider binding", vm.Name())
 	}
 	return validateExeDevClaimGeneration(vm, claim.Labels[exeDevClaimGenerationLabel])
 }
 
 func validateExeDevClaimGeneration(vm exeDevVM, expected string) error {
 	expected = strings.TrimSpace(expected)
-	if !isCanonicalLeaseID(expected) {
-		return exit(2, "exe.dev VM %s has no canonical claim generation; reuse with --reclaim before operating on it", vm.Name())
+	if !core.IsCanonicalLeaseID(expected) {
+		return core.Exit(2, "exe.dev VM %s has no canonical claim generation; reuse with --reclaim before operating on it", vm.Name())
 	}
 	actual, exists, err := exeDevVMClaimGeneration(vm)
 	if err != nil {
 		return err
 	}
 	if !exists {
-		return exit(2, "exe.dev VM %s has no remote claim generation; reuse with --reclaim before operating on it", vm.Name())
+		return core.Exit(2, "exe.dev VM %s has no remote claim generation; reuse with --reclaim before operating on it", vm.Name())
 	}
 	if actual != expected {
-		return exit(2, "exe.dev VM %s claim generation does not match the exact local claim", vm.Name())
+		return core.Exit(2, "exe.dev VM %s claim generation does not match the exact local claim", vm.Name())
 	}
 	return nil
 }
 
 func (b *exeDevLeaseBackend) replaceVMClaimGeneration(ctx context.Context, vm exeDevVM, generation string) error {
-	if !isCanonicalLeaseID(generation) {
-		return exit(2, "invalid exe.dev claim generation")
+	if !core.IsCanonicalLeaseID(generation) {
+		return core.Exit(2, "invalid exe.dev claim generation")
 	}
 	want := exeDevClaimGenerationTagPrefix + generation
 	existing := exeDevClaimGenerationTags(vm)
@@ -632,55 +631,55 @@ func validateExeDevVMOwnership(vm exeDevVM, leaseID, slug, operation string) err
 		return err
 	}
 	if !owned {
-		return exit(2, "exe.dev VM %s has no complete Crabbox ownership tags; refusing %s", vm.Name(), operation)
+		return core.Exit(2, "exe.dev VM %s has no complete Crabbox ownership tags; refusing %s", vm.Name(), operation)
 	}
-	slug = normalizeLeaseSlug(slug)
+	slug = core.NormalizeLeaseSlug(slug)
 	if remoteLeaseID != leaseID || remoteSlug != slug {
-		return exit(2, "exe.dev VM %s ownership tags do not match lease=%s slug=%s", vm.Name(), leaseID, slug)
+		return core.Exit(2, "exe.dev VM %s ownership tags do not match lease=%s slug=%s", vm.Name(), leaseID, slug)
 	}
-	wantName := leaseProviderName(leaseID, slug)
+	wantName := core.LeaseProviderName(leaseID, slug)
 	if vm.Name() != wantName {
-		return exit(2, "exe.dev VM %s does not match the claimed provider name %s", vm.Name(), wantName)
+		return core.Exit(2, "exe.dev VM %s does not match the claimed provider name %s", vm.Name(), wantName)
 	}
 	return nil
 }
 
-func (b *exeDevLeaseBackend) validateReleaseTarget(lease LeaseTarget, claim LeaseClaim) error {
+func (b *exeDevLeaseBackend) validateReleaseTarget(lease core.LeaseTarget, claim core.LeaseClaim) error {
 	if lease.LeaseID != claim.LeaseID || lease.Server.Provider != providerName || lease.Server.CloudID != claim.CloudID || lease.Server.Name != claim.CloudID {
-		return exit(2, "provider=%s release target does not match its claim snapshot", providerName)
+		return core.Exit(2, "provider=%s release target does not match its claim snapshot", providerName)
 	}
-	if lease.Server.Labels["lease"] != claim.LeaseID || normalizeLeaseSlug(lease.Server.Labels["slug"]) != normalizeLeaseSlug(claim.Slug) {
-		return exit(2, "provider=%s release labels do not match their claim snapshot", providerName)
+	if lease.Server.Labels["lease"] != claim.LeaseID || core.NormalizeLeaseSlug(lease.Server.Labels["slug"]) != core.NormalizeLeaseSlug(claim.Slug) {
+		return core.Exit(2, "provider=%s release labels do not match their claim snapshot", providerName)
 	}
 	if strings.TrimSpace(claim.ProviderScope) == "" {
-		return exit(2, "lease %s has no exe.dev account-bound control scope", claim.LeaseID)
+		return core.Exit(2, "lease %s has no exe.dev account-bound control scope", claim.LeaseID)
 	}
 	return nil
 }
 
-func (b *exeDevLeaseBackend) prepareLease(ctx context.Context, cfg Config, vm exeDevVM, leaseID, slug string, keep, wait bool) (LeaseTarget, error) {
+func (b *exeDevLeaseBackend) prepareLease(ctx context.Context, cfg core.Config, vm exeDevVM, leaseID, slug string, keep, wait bool) (core.LeaseTarget, error) {
 	server := exeDevServer(vm, leaseID, slug, cfg, keep)
 	target := exeDevSSHTarget(cfg, vm)
 	if wait {
-		if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "exe.dev vm ssh", bootstrapWaitTimeout(cfg)); err != nil {
-			return LeaseTarget{}, err
+		if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "exe.dev vm ssh", core.BootstrapWaitTimeout(cfg)); err != nil {
+			return core.LeaseTarget{}, err
 		}
 		server.Status = "ready"
 		server.Labels["state"] = "ready"
 	}
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
 func (b *exeDevLeaseBackend) resolveVM(ctx context.Context, identifier string) (exeDevVM, string, string, error) {
 	identifier = strings.TrimSpace(identifier)
 	if identifier == "" {
-		return exeDevVM{}, "", "", exit(2, "provider=%s requires --id <vm-name-or-slug>", providerName)
+		return exeDevVM{}, "", "", core.Exit(2, "provider=%s requires --id <vm-name-or-slug>", providerName)
 	}
-	if claim, ok, err := resolveLeaseClaimForProvider(identifier, providerName); err != nil {
+	if claim, ok, err := core.ResolveLeaseClaimForProvider(identifier, providerName); err != nil {
 		return exeDevVM{}, "", "", err
 	} else if ok {
-		slug := core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID))
-		name := leaseProviderName(claim.LeaseID, slug)
+		slug := core.Blank(claim.Slug, core.NewLeaseSlug(claim.LeaseID))
+		name := core.LeaseProviderName(claim.LeaseID, slug)
 		vm, err := b.findVM(ctx, name)
 		return vm, claim.LeaseID, slug, err
 	}
@@ -696,8 +695,8 @@ func (b *exeDevLeaseBackend) resolveVM(ctx context.Context, identifier string) (
 			}
 			return vm, leaseID, slug, nil
 		}
-		slug := newLeaseSlug(identifier)
-		vm, err = b.findVM(ctx, leaseProviderName(identifier, slug))
+		slug := core.NewLeaseSlug(identifier)
+		vm, err = b.findVM(ctx, core.LeaseProviderName(identifier, slug))
 		return vm, identifier, slug, err
 	}
 	vm, err := b.findVM(ctx, identifier)
@@ -716,13 +715,13 @@ func (b *exeDevLeaseBackend) findVM(ctx context.Context, identifier string) (exe
 	if err != nil {
 		return exeDevVM{}, err
 	}
-	id := normalizeLeaseSlug(identifier)
+	id := core.NormalizeLeaseSlug(identifier)
 	for _, vm := range vms {
-		if vm.Name() == identifier || normalizeLeaseSlug(vm.Name()) == id || vm.SSHHost() == identifier {
+		if vm.Name() == identifier || core.NormalizeLeaseSlug(vm.Name()) == id || vm.SSHHost() == identifier {
 			return vm, nil
 		}
 	}
-	return exeDevVM{}, exit(4, "exe.dev VM not found: %s", identifier)
+	return exeDevVM{}, core.Exit(4, "exe.dev VM not found: %s", identifier)
 }
 
 func (b *exeDevLeaseBackend) findVMByExactName(ctx context.Context, name string) (exeDevVM, error) {
@@ -735,7 +734,7 @@ func (b *exeDevLeaseBackend) findVMByExactName(ctx context.Context, name string)
 			return vm, nil
 		}
 	}
-	return exeDevVM{}, exit(4, "exe.dev VM not found: %s", name)
+	return exeDevVM{}, core.Exit(4, "exe.dev VM not found: %s", name)
 }
 
 func (b *exeDevLeaseBackend) findVMByLeaseID(ctx context.Context, leaseID string) (exeDevVM, bool, error) {
@@ -758,7 +757,7 @@ func (b *exeDevLeaseBackend) findVMByLeaseID(ctx context.Context, leaseID string
 	return exeDevVM{}, false, nil
 }
 
-func (b *exeDevLeaseBackend) listServers(ctx context.Context, all bool) ([]LeaseView, error) {
+func (b *exeDevLeaseBackend) listServers(ctx context.Context, all bool) ([]core.LeaseView, error) {
 	// all widens only Crabbox's ownership filter. exe.dev scopes inventory to
 	// the authenticated account and its current CLI has no cross-account flag.
 	vms, err := b.listVMs(ctx)
@@ -766,7 +765,7 @@ func (b *exeDevLeaseBackend) listServers(ctx context.Context, all bool) ([]Lease
 		return nil, err
 	}
 	cfg := b.configForRun()
-	servers := make([]Server, 0, len(vms))
+	servers := make([]core.Server, 0, len(vms))
 	for _, vm := range vms {
 		if !all {
 			_, _, owned, err := exeDevOwnershipIdentity(vm)
@@ -798,7 +797,7 @@ func (b *exeDevLeaseBackend) leaseIdentityForInventoryVM(vm exeDevVM) (string, s
 }
 
 func fallbackExeDevIdentity(vm exeDevVM) (string, string) {
-	slug := normalizeLeaseSlug(vm.Name())
+	slug := core.NormalizeLeaseSlug(vm.Name())
 	leaseID := "exe_" + slug
 	if strings.HasPrefix(slug, "crabbox-") {
 		leaseID = "exe_" + strings.TrimPrefix(slug, "crabbox-")
@@ -813,7 +812,7 @@ func (b *exeDevLeaseBackend) listVMs(ctx context.Context) ([]exeDevVM, error) {
 	}
 	var res exeDevListResponse
 	if err := json.Unmarshal([]byte(out), &res); err != nil {
-		return nil, exit(5, "exe.dev ls returned invalid JSON: %v", err)
+		return nil, core.Exit(5, "exe.dev ls returned invalid JSON: %v", err)
 	}
 	return res.VMs, nil
 }
@@ -822,20 +821,20 @@ func (b *exeDevLeaseBackend) controlOutput(ctx context.Context, args []string) (
 	result, err := b.control(ctx, args, nil, b.rt.Stderr)
 	if err != nil {
 		if msg := exeDevErrorMessage(result.Stdout); msg != "" {
-			return "", exit(commandExitCode(result), "exe.dev %s failed: %s", strings.Join(args, " "), msg)
+			return "", core.Exit(commandExitCode(result), "exe.dev %s failed: %s", strings.Join(args, " "), msg)
 		}
-		return "", exit(commandExitCode(result), "exe.dev %s failed: %v", strings.Join(args, " "), err)
+		return "", core.Exit(commandExitCode(result), "exe.dev %s failed: %v", strings.Join(args, " "), err)
 	}
 	if msg := exeDevErrorMessage(result.Stdout); msg != "" {
-		return "", exit(5, "exe.dev %s failed: %s", strings.Join(args, " "), msg)
+		return "", core.Exit(5, "exe.dev %s failed: %s", strings.Join(args, " "), msg)
 	}
 	return result.Stdout, nil
 }
 
-func (b *exeDevLeaseBackend) control(ctx context.Context, args []string, stdout, stderr io.Writer) (LocalCommandResult, error) {
+func (b *exeDevLeaseBackend) control(ctx context.Context, args []string, stdout, stderr io.Writer) (core.LocalCommandResult, error) {
 	dest, port, err := exeDevControlDestination(b.configForRun().ExeDev.ControlHost)
 	if err != nil {
-		return LocalCommandResult{}, err
+		return core.LocalCommandResult{}, err
 	}
 	sshArgs := []string{"-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new", "-o", "ConnectTimeout=10"}
 	if port != "" {
@@ -843,7 +842,7 @@ func (b *exeDevLeaseBackend) control(ctx context.Context, args []string, stdout,
 	}
 	sshArgs = append(sshArgs, dest)
 	sshArgs = append(sshArgs, shellQuoteArgs(args))
-	return b.rt.Exec.Run(ctx, LocalCommandRequest{Name: "ssh", Args: sshArgs, Stdout: stdout, Stderr: stderr})
+	return b.rt.Exec.Run(ctx, core.LocalCommandRequest{Name: "ssh", Args: sshArgs, Stdout: stdout, Stderr: stderr})
 }
 
 func (b *exeDevLeaseBackend) rollbackCreatedVM(name, leaseID, slug, generation string, cause error) error {
@@ -851,16 +850,16 @@ func (b *exeDevLeaseBackend) rollbackCreatedVM(name, leaseID, slug, generation s
 	defer cancel()
 	vm, err := b.findVMByExactName(cleanupCtx, name)
 	if err != nil {
-		return exit(core.ExitCodeForError(cause, 1), "%v; exe.dev cleanup could not verify VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
+		return core.Exit(core.ExitCodeForError(cause, 1), "%v; exe.dev cleanup could not verify VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
 	}
 	if err := validateExeDevVMOwnership(vm, leaseID, slug, "provisioning rollback"); err != nil {
-		return exit(core.ExitCodeForError(cause, 1), "%v; exe.dev cleanup refused unverified VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
+		return core.Exit(core.ExitCodeForError(cause, 1), "%v; exe.dev cleanup refused unverified VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
 	}
 	if err := validateExeDevClaimGeneration(vm, generation); err != nil {
-		return exit(core.ExitCodeForError(cause, 1), "%v; exe.dev cleanup refused replacement VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
+		return core.Exit(core.ExitCodeForError(cause, 1), "%v; exe.dev cleanup refused replacement VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
 	}
 	if err := b.deleteVM(cleanupCtx, name); err != nil {
-		return exit(core.ExitCodeForError(cause, 1), "%v; exe.dev cleanup failed for VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
+		return core.Exit(core.ExitCodeForError(cause, 1), "%v; exe.dev cleanup failed for VM %s; manual cleanup: %s: %v", cause, name, b.manualDeleteCommand(name), err)
 	}
 	return cause
 }
@@ -880,19 +879,19 @@ func (b *exeDevLeaseBackend) manualDeleteCommand(name string) string {
 func exeDevControlDestination(value string) (string, string, error) {
 	raw := strings.TrimSpace(value)
 	if raw == "" {
-		return "", "", exit(2, "provider=%s requires exe.dev control host", providerName)
+		return "", "", core.Exit(2, "provider=%s requires exe.dev control host", providerName)
 	}
 	if strings.Contains(raw, "://") || strings.HasPrefix(raw, "-") || strings.ContainsAny(raw, "/?#") || containsSpaceOrControl(raw) {
-		return "", "", exit(2, "invalid exe.dev control host: %q", value)
+		return "", "", core.Exit(2, "invalid exe.dev control host: %q", value)
 	}
 	user := ""
 	hostPort := raw
 	if strings.Count(raw, "@") > 1 {
-		return "", "", exit(2, "invalid exe.dev control host: %q", value)
+		return "", "", core.Exit(2, "invalid exe.dev control host: %q", value)
 	}
 	if before, after, ok := strings.Cut(raw, "@"); ok {
 		if before == "" || strings.HasPrefix(before, "-") || strings.ContainsAny(before, ":@") {
-			return "", "", exit(2, "invalid exe.dev control host: %q", value)
+			return "", "", core.Exit(2, "invalid exe.dev control host: %q", value)
 		}
 		user = before
 		hostPort = after
@@ -902,37 +901,37 @@ func exeDevControlDestination(value string) (string, string, error) {
 	if strings.HasPrefix(hostPort, "[") {
 		end := strings.Index(hostPort, "]")
 		if end < 0 {
-			return "", "", exit(2, "invalid exe.dev control host: %q", value)
+			return "", "", core.Exit(2, "invalid exe.dev control host: %q", value)
 		}
 		host = hostPort[1:end]
 		rest := hostPort[end+1:]
 		if rest != "" {
 			if !strings.HasPrefix(rest, ":") || rest == ":" {
-				return "", "", exit(2, "invalid exe.dev control host: %q", value)
+				return "", "", core.Exit(2, "invalid exe.dev control host: %q", value)
 			}
 			port = strings.TrimPrefix(rest, ":")
 		}
 		if !validExeDevControlIPHost(host) {
-			return "", "", exit(2, "invalid exe.dev control host: %q", value)
+			return "", "", core.Exit(2, "invalid exe.dev control host: %q", value)
 		}
 	} else if strings.Count(hostPort, ":") == 1 {
 		before, after, _ := strings.Cut(hostPort, ":")
 		host, port = before, after
 	} else if strings.Contains(hostPort, ":") {
 		if !validExeDevControlIPHost(hostPort) {
-			return "", "", exit(2, "invalid exe.dev control host: %q", value)
+			return "", "", core.Exit(2, "invalid exe.dev control host: %q", value)
 		}
 	}
 	if host == "" || strings.HasPrefix(host, "-") || strings.ContainsAny(host, "/?#@") || containsSpaceOrControl(host) {
-		return "", "", exit(2, "invalid exe.dev control host: %q", value)
+		return "", "", core.Exit(2, "invalid exe.dev control host: %q", value)
 	}
 	if strings.Contains(host, "%") && !validExeDevControlIPHost(host) {
-		return "", "", exit(2, "invalid exe.dev control host: %q", value)
+		return "", "", core.Exit(2, "invalid exe.dev control host: %q", value)
 	}
 	if port != "" {
 		p, err := strconv.Atoi(port)
 		if err != nil || p <= 0 || p > 65535 {
-			return "", "", exit(2, "invalid exe.dev control host port: %q", value)
+			return "", "", core.Exit(2, "invalid exe.dev control host port: %q", value)
 		}
 	}
 	dest := host
@@ -965,7 +964,7 @@ func containsSpaceOrControl(value string) bool {
 	return false
 }
 
-func commandExitCode(result LocalCommandResult) int {
+func commandExitCode(result core.LocalCommandResult) int {
 	if result.ExitCode != 0 {
 		return result.ExitCode
 	}
@@ -981,11 +980,11 @@ func (b *exeDevLeaseBackend) controlScope(ctx context.Context) (string, error) {
 		Email string `json:"email"`
 	}
 	if err := json.Unmarshal([]byte(out), &identity); err != nil {
-		return "", exit(5, "exe.dev whoami returned invalid JSON: %v", err)
+		return "", core.Exit(5, "exe.dev whoami returned invalid JSON: %v", err)
 	}
 	email := strings.ToLower(strings.TrimSpace(identity.Email))
 	if email == "" {
-		return "", exit(5, "exe.dev whoami returned no account identity")
+		return "", core.Exit(5, "exe.dev whoami returned no account identity")
 	}
 	return exeDevControlScope(b.configForRun(), exeDevAccountFingerprint(email))
 }
@@ -995,20 +994,20 @@ func exeDevAccountFingerprint(email string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-func exeDevControlScope(cfg Config, accountFingerprint string) (string, error) {
+func exeDevControlScope(cfg core.Config, accountFingerprint string) (string, error) {
 	destination, port, err := exeDevControlDestination(cfg.ExeDev.ControlHost)
 	if err != nil {
 		return "", err
 	}
 	accountFingerprint = strings.TrimSpace(accountFingerprint)
 	if accountFingerprint == "" {
-		return "", exit(2, "exe.dev account fingerprint is empty")
+		return "", core.Exit(2, "exe.dev account fingerprint is empty")
 	}
 	return "ssh:" + destination + "|port:" + core.Blank(port, "default") + "|account:sha256:" + accountFingerprint, nil
 }
 
-func exeDevServer(vm exeDevVM, leaseID, slug string, cfg Config, keep bool) Server {
-	labels := directLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
+func exeDevServer(vm exeDevVM, leaseID, slug string, cfg core.Config, keep bool) core.Server {
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
 	labels["name"] = vm.Name()
 	labels["state"] = core.Blank(vm.Status, "unknown")
 	labels["work_root"] = cfg.WorkRoot
@@ -1021,7 +1020,7 @@ func exeDevServer(vm exeDevVM, leaseID, slug string, cfg Config, keep bool) Serv
 	if vm.HTTPSURL != "" {
 		labels["https_url"] = vm.HTTPSURL
 	}
-	server := Server{
+	server := core.Server{
 		CloudID:  vm.Name(),
 		Provider: providerName,
 		Name:     vm.Name(),
@@ -1033,9 +1032,9 @@ func exeDevServer(vm exeDevVM, leaseID, slug string, cfg Config, keep bool) Serv
 	return server
 }
 
-func exeDevSSHTarget(cfg Config, vm exeDevVM) SSHTarget {
+func exeDevSSHTarget(cfg core.Config, vm exeDevVM) core.SSHTarget {
 	address := vm.SSHAddress()
-	target := sshTargetFromConfig(cfg, address.Host)
+	target := core.SSHTargetFromConfig(cfg, address.Host)
 	target.Key = ""
 	if address.User != "" {
 		target.User = address.User
@@ -1082,11 +1081,11 @@ func (b *exeDevLeaseBackend) leaseIdentityForVM(vm exeDevVM) (string, string, er
 		return leaseID, slug, nil
 	}
 	if slug := inferExeDevSlugFromName(vm.Name()); slug != "" {
-		if claim, ok, err := resolveLeaseClaimForProvider(slug, providerName); err != nil {
+		if claim, ok, err := core.ResolveLeaseClaimForProvider(slug, providerName); err != nil {
 			return "", "", err
 		} else if ok {
-			claimSlug := core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID))
-			if leaseProviderName(claim.LeaseID, claimSlug) == vm.Name() {
+			claimSlug := core.Blank(claim.Slug, core.NewLeaseSlug(claim.LeaseID))
+			if core.LeaseProviderName(claim.LeaseID, claimSlug) == vm.Name() {
 				return claim.LeaseID, claimSlug, nil
 			}
 		}
@@ -1111,14 +1110,14 @@ func exeDevOwnershipIdentity(vm exeDevVM) (string, string, bool, error) {
 			}
 		}
 		if strings.HasPrefix(tag, "crabbox-slug-") {
-			slug := normalizeLeaseSlug(strings.TrimPrefix(tag, "crabbox-slug-"))
+			slug := core.NormalizeLeaseSlug(strings.TrimPrefix(tag, "crabbox-slug-"))
 			if slug != "" {
 				slugs[slug] = struct{}{}
 			}
 		}
 	}
 	if len(leaseIDs) > 1 || len(slugs) > 1 {
-		return "", "", false, exit(2, "exe.dev VM %s has conflicting Crabbox ownership tags", vm.Name())
+		return "", "", false, core.Exit(2, "exe.dev VM %s has conflicting Crabbox ownership tags", vm.Name())
 	}
 	if !baseTag || len(leaseIDs) != 1 || len(slugs) != 1 {
 		return "", "", false, nil
@@ -1127,8 +1126,8 @@ func exeDevOwnershipIdentity(vm exeDevVM) (string, string, bool, error) {
 	for value := range leaseIDs {
 		leaseID = value
 	}
-	if !isCanonicalLeaseID(leaseID) {
-		return "", "", false, exit(2, "exe.dev VM %s has an invalid Crabbox lease tag", vm.Name())
+	if !core.IsCanonicalLeaseID(leaseID) {
+		return "", "", false, core.Exit(2, "exe.dev VM %s has an invalid Crabbox lease tag", vm.Name())
 	}
 	slug := ""
 	for value := range slugs {
@@ -1140,14 +1139,14 @@ func exeDevOwnershipIdentity(vm exeDevVM) (string, string, bool, error) {
 func exeDevVMClaimGeneration(vm exeDevVM) (string, bool, error) {
 	tags := exeDevClaimGenerationTags(vm)
 	if len(tags) > 1 {
-		return "", false, exit(2, "exe.dev VM %s has conflicting claim-generation tags", vm.Name())
+		return "", false, core.Exit(2, "exe.dev VM %s has conflicting claim-generation tags", vm.Name())
 	}
 	if len(tags) == 0 {
 		return "", false, nil
 	}
 	generation := strings.TrimSpace(strings.TrimPrefix(tags[0], exeDevClaimGenerationTagPrefix))
-	if !isCanonicalLeaseID(generation) {
-		return "", false, exit(2, "exe.dev VM %s has an invalid claim-generation tag", vm.Name())
+	if !core.IsCanonicalLeaseID(generation) {
+		return "", false, core.Exit(2, "exe.dev VM %s has an invalid claim-generation tag", vm.Name())
 	}
 	return generation, true, nil
 }
@@ -1177,7 +1176,7 @@ func inferExeDevSlugFromName(name string) string {
 	if len(hash) != 8 || !isLowerHex(hash) {
 		return ""
 	}
-	return normalizeLeaseSlug(rest[:idx])
+	return core.NormalizeLeaseSlug(rest[:idx])
 }
 
 func isLowerHex(value string) bool {
@@ -1190,6 +1189,6 @@ func isLowerHex(value string) bool {
 	return value != ""
 }
 
-func exeDevImage(cfg Config) string {
+func exeDevImage(cfg core.Config) string {
 	return core.Blank(strings.TrimSpace(cfg.ExeDev.Image), core.ExeDevDefaultImageLabel)
 }

--- a/internal/providers/exedev/backend_test.go
+++ b/internal/providers/exedev/backend_test.go
@@ -18,36 +18,36 @@ import (
 )
 
 type exeDevRecordingRunner struct {
-	calls []LocalCommandRequest
-	fn    func(LocalCommandRequest) (LocalCommandResult, error)
+	calls []core.LocalCommandRequest
+	fn    func(core.LocalCommandRequest) (core.LocalCommandResult, error)
 }
 
-func (r *exeDevRecordingRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (r *exeDevRecordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.calls = append(r.calls, req)
 	if r.fn != nil {
 		return r.fn(req)
 	}
-	return LocalCommandResult{}, nil
+	return core.LocalCommandResult{}, nil
 }
 
 func TestExeDevListFiltersCrabboxVMsByDefault(t *testing.T) {
 	runner := &exeDevRecordingRunner{}
-	runner.fn = func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner.fn = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		base := []string{"-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new", "-o", "ConnectTimeout=10", "exe.dev", "ls --l --json"}
 		if !reflect.DeepEqual(req.Args, base) {
 			t.Fatalf("args=%v", req.Args)
 		}
-		return LocalCommandResult{Stdout: `{"vms":[{"vm_name":"crabbox-blue-12345678","ssh_dest":"crabbox-blue-12345678.exe.xyz","status":"running","tags":["crabbox","crabbox-lease-cbx_abcdef123456","crabbox-slug-blue"]},{"vm_name":"crabbox-manual-12345678","ssh_dest":"crabbox-manual-12345678.exe.xyz","status":"running"}]}`}, nil
+		return core.LocalCommandResult{Stdout: `{"vms":[{"vm_name":"crabbox-blue-12345678","ssh_dest":"crabbox-blue-12345678.exe.xyz","status":"running","tags":["crabbox","crabbox-lease-cbx_abcdef123456","crabbox-slug-blue"]},{"vm_name":"crabbox-manual-12345678","ssh_dest":"crabbox-manual-12345678.exe.xyz","status":"running"}]}`}, nil
 	}
-	backend := &exeDevLeaseBackend{cfg: Config{}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
-	views, err := backend.List(context.Background(), ListRequest{})
+	backend := &exeDevLeaseBackend{cfg: core.Config{}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	views, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(views) != 1 || views[0].Name != "crabbox-blue-12345678" || views[0].Provider != providerName {
 		t.Fatalf("views=%#v", views)
 	}
-	views, err = backend.List(context.Background(), ListRequest{All: true})
+	views, err = backend.List(context.Background(), core.ListRequest{All: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +57,7 @@ func TestExeDevListFiltersCrabboxVMsByDefault(t *testing.T) {
 }
 
 func TestExeDevDoctorListsInventory(t *testing.T) {
-	runner := &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &exeDevRecordingRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		got := strings.Join(req.Args, " ")
 		if !strings.Contains(got, "exe.dev ls --l --json") {
 			t.Fatalf("args=%v", req.Args)
@@ -65,13 +65,13 @@ func TestExeDevDoctorListsInventory(t *testing.T) {
 		if strings.Contains(got, " new ") || strings.Contains(got, " rm ") {
 			t.Fatalf("doctor used mutating command: %v", req.Args)
 		}
-		return LocalCommandResult{Stdout: `{"vms":[{"vm_name":"crabbox-blue-12345678","ssh_dest":"crabbox-blue-12345678.exe.xyz","status":"running","tags":["crabbox","crabbox-lease-cbx_abcdef123456","crabbox-slug-blue"]}]}`}, nil
+		return core.LocalCommandResult{Stdout: `{"vms":[{"vm_name":"crabbox-blue-12345678","ssh_dest":"crabbox-blue-12345678.exe.xyz","status":"running","tags":["crabbox","crabbox-lease-cbx_abcdef123456","crabbox-slug-blue"]}]}`}, nil
 	}}
-	doctor, err := Provider{}.ConfigureDoctor(Config{}, Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner})
+	doctor, err := Provider{}.ConfigureDoctor(core.Config{}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner})
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := doctor.Doctor(context.Background(), DoctorRequest{})
+	result, err := doctor.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestExeDevDoctorListsInventory(t *testing.T) {
 }
 
 func TestExeDevCreateVMUsesSSHControlAPI(t *testing.T) {
-	runner := &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &exeDevRecordingRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		got := strings.Join(req.Args, " ")
 		for _, want := range []string{
 			"exe.dev new",
@@ -102,9 +102,9 @@ func TestExeDevCreateVMUsesSSHControlAPI(t *testing.T) {
 				t.Fatalf("args=%v missing %q", req.Args, want)
 			}
 		}
-		return LocalCommandResult{Stdout: `{"vm_name":"crabbox-blue-12345678","ssh_dest":"crabbox-blue-12345678.exe.xyz","status":"running"}`}, nil
+		return core.LocalCommandResult{Stdout: `{"vm_name":"crabbox-blue-12345678","ssh_dest":"crabbox-blue-12345678.exe.xyz","status":"running"}`}, nil
 	}}
-	cfg := Config{ExeDev: ExeDevConfig{
+	cfg := core.Config{ExeDev: core.ExeDevConfig{
 		Image:   "ubuntu:24.04",
 		CPUs:    4,
 		Memory:  "8GB",
@@ -112,7 +112,7 @@ func TestExeDevCreateVMUsesSSHControlAPI(t *testing.T) {
 		Command: "sleep infinity",
 		NoEmail: true,
 	}}
-	backend := &exeDevLeaseBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	backend := &exeDevLeaseBackend{cfg: cfg, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 	vm, err := backend.createVM(context.Background(), backend.configForRun(), "crabbox-blue-12345678", "cbx_lease", "blue", "cbx_111111111111")
 	if err != nil {
 		t.Fatal(err)
@@ -125,31 +125,31 @@ func TestExeDevCreateVMUsesSSHControlAPI(t *testing.T) {
 func TestExeDevAcquireReportsRollbackFailureAfterPrepareFailure(t *testing.T) {
 	primaryErr := errors.New("ssh not ready")
 	oldWait := waitForSSHReady
-	waitForSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+	waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
 		return primaryErr
 	}
 	t.Cleanup(func() { waitForSSHReady = oldWait })
 	runner := newExeDevAcquireRollbackRunner()
-	backend := &exeDevLeaseBackend{cfg: Config{}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
-	_, err := backend.Acquire(context.Background(), AcquireRequest{Repo: Repo{Root: t.TempDir()}})
+	backend := &exeDevLeaseBackend{cfg: core.Config{}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	_, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}})
 	assertExeDevRollbackFailure(t, err, primaryErr, runner)
 }
 
 func TestExeDevAcquireReportsRollbackFailureAfterClaimFailure(t *testing.T) {
 	primaryErr := errors.New("claim failed")
 	oldWait := waitForSSHReady
-	waitForSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+	waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
 		return nil
 	}
 	t.Cleanup(func() { waitForSSHReady = oldWait })
 	oldClaim := claimLeaseTargetForRepoConfigScopeIfUnchanged
-	claimLeaseTargetForRepoConfigScopeIfUnchanged = func(string, string, Config, string, Server, SSHTarget, string, time.Duration, bool, LeaseClaim, bool) (LeaseClaim, error) {
-		return LeaseClaim{}, primaryErr
+	claimLeaseTargetForRepoConfigScopeIfUnchanged = func(string, string, core.Config, string, core.Server, core.SSHTarget, string, time.Duration, bool, core.LeaseClaim, bool) (core.LeaseClaim, error) {
+		return core.LeaseClaim{}, primaryErr
 	}
 	t.Cleanup(func() { claimLeaseTargetForRepoConfigScopeIfUnchanged = oldClaim })
 	runner := newExeDevAcquireRollbackRunner()
-	backend := &exeDevLeaseBackend{cfg: Config{}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
-	_, err := backend.Acquire(context.Background(), AcquireRequest{Repo: Repo{Root: t.TempDir()}})
+	backend := &exeDevLeaseBackend{cfg: core.Config{}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	_, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}})
 	assertExeDevRollbackFailure(t, err, primaryErr, runner)
 }
 
@@ -160,22 +160,22 @@ func TestExeDevProvisioningRollbackRejectsReplacementGeneration(t *testing.T) {
 		code    int
 	}{
 		{name: "opaque", primary: errors.New("ssh not ready"), code: 1},
-		{name: "typed", primary: ExitError{Code: 69, Message: "ssh not ready"}, code: 69},
-		{name: "signed", primary: ExitError{Code: -1, Message: "ssh not ready"}, code: -1},
-		{name: "zero", primary: ExitError{Code: 0, Message: "ssh not ready"}, code: 1},
+		{name: "typed", primary: core.ExitError{Code: 69, Message: "ssh not ready"}, code: 69},
+		{name: "signed", primary: core.ExitError{Code: -1, Message: "ssh not ready"}, code: -1},
+		{name: "zero", primary: core.ExitError{Code: 0, Message: "ssh not ready"}, code: 1},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			leaseID := "cbx_abcdef123456"
 			slug := "blue"
 			vm := ownedExeDevVM(leaseID, slug)
 			runner := exeDevInventoryRunner(t, vm)
-			backend := newExeDevTestBackend(Config{}, runner)
+			backend := newExeDevTestBackend(core.Config{}, runner)
 
 			err := backend.rollbackCreatedVM(vm.Name(), leaseID, slug, "cbx_222222222222", tc.primary)
 			if err == nil || !strings.Contains(err.Error(), tc.primary.Error()) || !strings.Contains(err.Error(), "refused replacement VM") {
 				t.Fatalf("err=%v, want guarded rollback refusal", err)
 			}
-			var public ExitError
+			var public core.ExitError
 			if !errors.As(err, &public) || public.Code != tc.code {
 				t.Fatalf("rollback exit=%d, want primary code %d", public.Code, tc.code)
 			}
@@ -186,18 +186,18 @@ func TestExeDevProvisioningRollbackRejectsReplacementGeneration(t *testing.T) {
 
 func newExeDevAcquireRollbackRunner() *exeDevRecordingRunner {
 	var created *exeDevVM
-	return &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	return &exeDevRecordingRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		cmd := strings.Join(req.Args, " ")
 		switch {
 		case strings.Contains(cmd, "whoami --json"):
-			return LocalCommandResult{Stdout: `{"email":"test@example.com"}`}, nil
+			return core.LocalCommandResult{Stdout: `{"email":"test@example.com"}`}, nil
 		case strings.Contains(cmd, "ls --l --json"):
 			vms := []exeDevVM{}
 			if created != nil {
 				vms = append(vms, *created)
 			}
 			payload, err := json.Marshal(exeDevListResponse{VMs: vms})
-			return LocalCommandResult{Stdout: string(payload)}, err
+			return core.LocalCommandResult{Stdout: string(payload)}, err
 		case strings.Contains(cmd, " new "):
 			fields := strings.Fields(req.Args[len(req.Args)-1])
 			vm := exeDevVM{Status: "running"}
@@ -212,11 +212,11 @@ func newExeDevAcquireRollbackRunner() *exeDevRecordingRunner {
 			}
 			created = &vm
 			payload, err := json.Marshal(vm)
-			return LocalCommandResult{Stdout: string(payload)}, err
+			return core.LocalCommandResult{Stdout: string(payload)}, err
 		case strings.Contains(cmd, " rm "):
-			return LocalCommandResult{ExitCode: 1}, errors.New("exit status 1")
+			return core.LocalCommandResult{ExitCode: 1}, errors.New("exit status 1")
 		default:
-			return LocalCommandResult{}, nil
+			return core.LocalCommandResult{}, nil
 		}
 	}}
 }
@@ -226,7 +226,7 @@ func assertExeDevRollbackFailure(t *testing.T, err error, primary error, runner 
 	if err == nil {
 		t.Fatal("Acquire succeeded, want rollback failure")
 	}
-	var exitErr ExitError
+	var exitErr core.ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 1 {
 		t.Fatalf("err=%#v, want rendered ExitError code 1", err)
 	}
@@ -244,13 +244,13 @@ func assertExeDevRollbackFailure(t *testing.T, err error, primary error, runner 
 }
 
 func TestExeDevDefaultsPreserveCustomTopLevelWorkRoot(t *testing.T) {
-	cfg := Config{WorkRoot: "/custom/crabbox"}
+	cfg := core.Config{WorkRoot: "/custom/crabbox"}
 	applyExeDevDefaults(&cfg)
 	if cfg.WorkRoot != "/custom/crabbox" || cfg.ExeDev.WorkRoot != "/custom/crabbox" {
 		t.Fatalf("workRoot=%q exeDev.workRoot=%q", cfg.WorkRoot, cfg.ExeDev.WorkRoot)
 	}
 
-	cfg = Config{WorkRoot: "/custom/crabbox", ExeDev: ExeDevConfig{WorkRoot: "/exe/crabbox"}}
+	cfg = core.Config{WorkRoot: "/custom/crabbox", ExeDev: core.ExeDevConfig{WorkRoot: "/exe/crabbox"}}
 	applyExeDevDefaults(&cfg)
 	if cfg.WorkRoot != "/exe/crabbox" || cfg.ExeDev.WorkRoot != "/exe/crabbox" {
 		t.Fatalf("workRoot=%q exeDev.workRoot=%q", cfg.WorkRoot, cfg.ExeDev.WorkRoot)
@@ -258,10 +258,10 @@ func TestExeDevDefaultsPreserveCustomTopLevelWorkRoot(t *testing.T) {
 }
 
 func TestExeDevControlSurfacesJSONError(t *testing.T) {
-	runner := &exeDevRecordingRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
-		return LocalCommandResult{ExitCode: 1, Stdout: `{"error":"active plan required"}`}, errors.New("exit status 1")
+	runner := &exeDevRecordingRunner{fn: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		return core.LocalCommandResult{ExitCode: 1, Stdout: `{"error":"active plan required"}`}, errors.New("exit status 1")
 	}}
-	backend := &exeDevLeaseBackend{cfg: Config{}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	backend := &exeDevLeaseBackend{cfg: core.Config{}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 	_, err := backend.controlOutput(context.Background(), []string{"new", "--json"})
 	if err == nil || !strings.Contains(err.Error(), "active plan required") {
 		t.Fatalf("err=%v", err)
@@ -270,7 +270,7 @@ func TestExeDevControlSurfacesJSONError(t *testing.T) {
 
 func TestExeDevControlRejectsSSHOptionLikeHost(t *testing.T) {
 	runner := &exeDevRecordingRunner{}
-	backend := &exeDevLeaseBackend{cfg: Config{ExeDev: ExeDevConfig{ControlHost: "-oProxyCommand=sh"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	backend := &exeDevLeaseBackend{cfg: core.Config{ExeDev: core.ExeDevConfig{ControlHost: "-oProxyCommand=sh"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 	if _, err := backend.controlOutput(context.Background(), []string{"ls", "--json"}); err == nil || !strings.Contains(err.Error(), "invalid exe.dev control host") {
 		t.Fatalf("err=%v, want invalid control host", err)
 	}
@@ -281,7 +281,7 @@ func TestExeDevControlRejectsSSHOptionLikeHost(t *testing.T) {
 
 func TestExeDevControlHostUsesSeparatePortArgument(t *testing.T) {
 	runner := &exeDevRecordingRunner{}
-	backend := &exeDevLeaseBackend{cfg: Config{ExeDev: ExeDevConfig{ControlHost: "alice@control.example:2222"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	backend := &exeDevLeaseBackend{cfg: core.Config{ExeDev: core.ExeDevConfig{ControlHost: "alice@control.example:2222"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 	if _, err := backend.controlOutput(context.Background(), []string{"ls", "--json"}); err != nil {
 		t.Fatal(err)
 	}
@@ -296,7 +296,7 @@ func TestExeDevControlHostUsesSeparatePortArgument(t *testing.T) {
 
 func TestExeDevControlHostPreservesBareIPv6Destination(t *testing.T) {
 	runner := &exeDevRecordingRunner{}
-	backend := &exeDevLeaseBackend{cfg: Config{ExeDev: ExeDevConfig{ControlHost: "alice@2001:db8::10"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	backend := &exeDevLeaseBackend{cfg: core.Config{ExeDev: core.ExeDevConfig{ControlHost: "alice@2001:db8::10"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 	if _, err := backend.controlOutput(context.Background(), []string{"ls", "--json"}); err != nil {
 		t.Fatal(err)
 	}
@@ -311,7 +311,7 @@ func TestExeDevControlHostPreservesBareIPv6Destination(t *testing.T) {
 
 func TestExeDevControlHostAcceptsBracketedIPv6Port(t *testing.T) {
 	runner := &exeDevRecordingRunner{}
-	backend := &exeDevLeaseBackend{cfg: Config{ExeDev: ExeDevConfig{ControlHost: "alice@[2001:db8::10]:2222"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	backend := &exeDevLeaseBackend{cfg: core.Config{ExeDev: core.ExeDevConfig{ControlHost: "alice@[2001:db8::10]:2222"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 	if _, err := backend.controlOutput(context.Background(), []string{"ls", "--json"}); err != nil {
 		t.Fatal(err)
 	}
@@ -326,7 +326,7 @@ func TestExeDevControlHostAcceptsBracketedIPv6Port(t *testing.T) {
 
 func TestExeDevControlHostPreservesScopedIPv6Destination(t *testing.T) {
 	runner := &exeDevRecordingRunner{}
-	backend := &exeDevLeaseBackend{cfg: Config{ExeDev: ExeDevConfig{ControlHost: "alice@fe80::1%eth0"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	backend := &exeDevLeaseBackend{cfg: core.Config{ExeDev: core.ExeDevConfig{ControlHost: "alice@fe80::1%eth0"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 	if _, err := backend.controlOutput(context.Background(), []string{"ls", "--json"}); err != nil {
 		t.Fatal(err)
 	}
@@ -340,10 +340,10 @@ func TestExeDevControlHostPreservesScopedIPv6Destination(t *testing.T) {
 }
 
 func TestExeDevResolveVMUsesTaggedLeaseIdentity(t *testing.T) {
-	runner := &exeDevRecordingRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
-		return LocalCommandResult{Stdout: `{"vms":[{"vm_name":"crabbox-blue-12345678","ssh_dest":"crabbox-blue-12345678.exe.xyz","status":"running","tags":["crabbox","crabbox-lease-cbx_abcdef123456","crabbox-slug-blue"]}]}`}, nil
+	runner := &exeDevRecordingRunner{fn: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		return core.LocalCommandResult{Stdout: `{"vms":[{"vm_name":"crabbox-blue-12345678","ssh_dest":"crabbox-blue-12345678.exe.xyz","status":"running","tags":["crabbox","crabbox-lease-cbx_abcdef123456","crabbox-slug-blue"]}]}`}, nil
 	}}
-	backend := &exeDevLeaseBackend{cfg: Config{}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	backend := &exeDevLeaseBackend{cfg: core.Config{}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 	_, leaseID, slug, err := backend.resolveVM(context.Background(), "crabbox-blue-12345678")
 	if err != nil {
 		t.Fatal(err)
@@ -355,10 +355,10 @@ func TestExeDevResolveVMUsesTaggedLeaseIdentity(t *testing.T) {
 
 func TestExeDevResolveCanonicalLeaseIDScansTags(t *testing.T) {
 	leaseID := "cbx_abcdef123456"
-	runner := &exeDevRecordingRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
-		return LocalCommandResult{Stdout: `{"vms":[{"vm_name":"crabbox-custom-12345678","ssh_dest":"crabbox-custom-12345678.exe.xyz","status":"running","tags":["crabbox","crabbox-lease-` + leaseID + `","crabbox-slug-custom"]}]}`}, nil
+	runner := &exeDevRecordingRunner{fn: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		return core.LocalCommandResult{Stdout: `{"vms":[{"vm_name":"crabbox-custom-12345678","ssh_dest":"crabbox-custom-12345678.exe.xyz","status":"running","tags":["crabbox","crabbox-lease-` + leaseID + `","crabbox-slug-custom"]}]}`}, nil
 	}}
-	backend := &exeDevLeaseBackend{cfg: Config{}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	backend := &exeDevLeaseBackend{cfg: core.Config{}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 	vm, gotLeaseID, slug, err := backend.resolveVM(context.Background(), leaseID)
 	if err != nil {
 		t.Fatal(err)
@@ -372,17 +372,17 @@ func TestExeDevResolveVMNameRecoversExistingClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_abcdef123456"
 	slug := "blue-lobster"
-	name := leaseProviderName(leaseID, slug)
-	cfg := Config{Provider: providerName}
+	name := core.LeaseProviderName(leaseID, slug)
+	cfg := core.Config{Provider: providerName}
 	applyExeDevDefaults(&cfg)
 	vm := exeDevVM{VMName: name, SSHDest: name + ".exe.xyz", Status: "running"}
-	if _, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, mustExeDevControlScope(t, cfg), exeDevServer(vm, leaseID, slug, cfg, true), exeDevSSHTarget(cfg, vm), t.TempDir(), 0, false, LeaseClaim{}, false); err != nil {
+	if _, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, mustExeDevControlScope(t, cfg), exeDevServer(vm, leaseID, slug, cfg, true), exeDevSSHTarget(cfg, vm), t.TempDir(), 0, false, core.LeaseClaim{}, false); err != nil {
 		t.Fatal(err)
 	}
-	runner := &exeDevRecordingRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
-		return LocalCommandResult{Stdout: `{"vms":[{"vm_name":"` + name + `","ssh_dest":"` + name + `.exe.xyz","status":"running"}]}`}, nil
+	runner := &exeDevRecordingRunner{fn: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		return core.LocalCommandResult{Stdout: `{"vms":[{"vm_name":"` + name + `","ssh_dest":"` + name + `.exe.xyz","status":"running"}]}`}, nil
 	}}
-	backend := &exeDevLeaseBackend{cfg: Config{}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	backend := &exeDevLeaseBackend{cfg: core.Config{}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 	_, gotLeaseID, gotSlug, err := backend.resolveVM(context.Background(), name)
 	if err != nil {
 		t.Fatal(err)
@@ -398,8 +398,8 @@ func TestExeDevReleaseRejectsUnclaimedRawIdentifiers(t *testing.T) {
 		t.Run(identifier, func(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			runner := exeDevInventoryRunner(t, vm)
-			backend := newExeDevTestBackend(Config{}, runner)
-			_, err := backend.Resolve(context.Background(), ResolveRequest{ID: identifier, ReleaseOnly: true})
+			backend := newExeDevTestBackend(core.Config{}, runner)
+			_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: identifier, ReleaseOnly: true})
 			if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
 				t.Fatalf("err=%v, want exact local claim refusal", err)
 			}
@@ -413,8 +413,8 @@ func TestExeDevReleaseRejectsTaggedVMWithoutLocalClaim(t *testing.T) {
 	leaseID := "cbx_abcdef123456"
 	vm := ownedExeDevVM(leaseID, "blue")
 	runner := exeDevInventoryRunner(t, vm)
-	backend := newExeDevTestBackend(Config{}, runner)
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
+	backend := newExeDevTestBackend(core.Config{}, runner)
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
 	if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
 		t.Fatalf("err=%v, want exact local claim refusal", err)
 	}
@@ -425,14 +425,14 @@ func TestExeDevReleaseRejectsClaimBoundToDifferentVM(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_abcdef123456"
 	vm := ownedExeDevVM(leaseID, "blue")
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	applyExeDevDefaults(&cfg)
 	other := vm
 	other.VMName = "crabbox-other-12345678"
 	persistExeDevClaim(t, cfg, other, leaseID, "blue", t.TempDir())
 	runner := exeDevInventoryRunner(t, vm)
 	backend := newExeDevTestBackend(cfg, runner)
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
 	if err == nil || !strings.Contains(err.Error(), "not bound to an exact provider/resource claim") {
 		t.Fatalf("err=%v, want exact resource binding refusal", err)
 	}
@@ -443,12 +443,12 @@ func TestExeDevReleaseRejectsChangedSSHEndpoint(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_abcdef123456"
 	vm := ownedExeDevVM(leaseID, "blue")
-	backend := newExeDevTestBackend(Config{}, exeDevInventoryRunner(t, vm))
+	backend := newExeDevTestBackend(core.Config{}, exeDevInventoryRunner(t, vm))
 	persistExeDevClaim(t, backend.configForRun(), vm, leaseID, "blue", t.TempDir())
 	vm.SSHDest = "replacement.exe.xyz:2222"
 	backend.rt.Exec = exeDevInventoryRunner(t, vm)
 
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
 	if err == nil || !strings.Contains(err.Error(), "SSH endpoint does not match") {
 		t.Fatalf("err=%v, want exact SSH endpoint refusal", err)
 	}
@@ -457,12 +457,12 @@ func TestExeDevReleaseRejectsChangedSSHEndpoint(t *testing.T) {
 func TestExeDevReleaseRequiresUnchangedClaimAndRemoteTags(t *testing.T) {
 	for _, test := range []struct {
 		name   string
-		mutate func(t *testing.T, backend *exeDevLeaseBackend, runner *exeDevRecordingRunner, lease LeaseTarget, claim LeaseClaim, vm exeDevVM)
+		mutate func(t *testing.T, backend *exeDevLeaseBackend, runner *exeDevRecordingRunner, lease core.LeaseTarget, claim core.LeaseClaim, vm exeDevVM)
 		want   string
 	}{
 		{
 			name: "claim changed",
-			mutate: func(t *testing.T, backend *exeDevLeaseBackend, _ *exeDevRecordingRunner, lease LeaseTarget, claim LeaseClaim, vm exeDevVM) {
+			mutate: func(t *testing.T, backend *exeDevLeaseBackend, _ *exeDevRecordingRunner, lease core.LeaseTarget, claim core.LeaseClaim, vm exeDevVM) {
 				cfg := backend.configForRun()
 				if _, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(lease.LeaseID, claim.Slug, cfg, claim.ProviderScope, lease.Server, exeDevSSHTarget(cfg, vm), t.TempDir(), cfg.IdleTimeout, true, claim, true); err != nil {
 					t.Fatal(err)
@@ -472,14 +472,14 @@ func TestExeDevReleaseRequiresUnchangedClaimAndRemoteTags(t *testing.T) {
 		},
 		{
 			name: "control route changed",
-			mutate: func(_ *testing.T, backend *exeDevLeaseBackend, _ *exeDevRecordingRunner, _ LeaseTarget, _ LeaseClaim, _ exeDevVM) {
+			mutate: func(_ *testing.T, backend *exeDevLeaseBackend, _ *exeDevRecordingRunner, _ core.LeaseTarget, _ core.LeaseClaim, _ exeDevVM) {
 				backend.cfg.ExeDev.ControlHost = "other.exe.dev"
 			},
 			want: "different exe.dev control route",
 		},
 		{
 			name: "remote tags removed",
-			mutate: func(t *testing.T, _ *exeDevLeaseBackend, runner *exeDevRecordingRunner, _ LeaseTarget, _ LeaseClaim, vm exeDevVM) {
+			mutate: func(t *testing.T, _ *exeDevLeaseBackend, runner *exeDevRecordingRunner, _ core.LeaseTarget, _ core.LeaseClaim, vm exeDevVM) {
 				vm.Tags = nil
 				runner.fn = exeDevInventoryResponse(t, vm)
 			},
@@ -491,19 +491,19 @@ func TestExeDevReleaseRequiresUnchangedClaimAndRemoteTags(t *testing.T) {
 			leaseID := "cbx_abcdef123456"
 			vm := ownedExeDevVM(leaseID, "blue")
 			runner := exeDevInventoryRunner(t, vm)
-			backend := newExeDevTestBackend(Config{}, runner)
+			backend := newExeDevTestBackend(core.Config{}, runner)
 			claim := persistExeDevClaim(t, backend.configForRun(), vm, leaseID, "blue", t.TempDir())
-			lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
+			lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
 			if err != nil {
 				t.Fatal(err)
 			}
 			test.mutate(t, backend, runner, lease, claim, vm)
-			err = backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease})
+			err = backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("err=%v, want %q", err, test.want)
 			}
 			assertNoExeDevRM(t, runner)
-			if _, exists, readErr := readLeaseClaimWithPresence(leaseID); readErr != nil || !exists {
+			if _, exists, readErr := core.ReadLeaseClaimWithPresence(leaseID); readErr != nil || !exists {
 				t.Fatalf("claim exists=%v err=%v, want retained", exists, readErr)
 			}
 		})
@@ -515,19 +515,19 @@ func TestExeDevReleaseDeletesExactlyClaimedVMAndRemovesClaim(t *testing.T) {
 	leaseID := "cbx_abcdef123456"
 	vm := ownedExeDevVM(leaseID, "blue")
 	runner := exeDevInventoryRunner(t, vm)
-	backend := newExeDevTestBackend(Config{}, runner)
+	backend := newExeDevTestBackend(core.Config{}, runner)
 	persistExeDevClaim(t, backend.configForRun(), vm, leaseID, "blue", t.TempDir())
-	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.SSHHost(), ReleaseOnly: true})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: vm.SSHHost(), ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
 	}
 	if !hasExeDevRM(runner) {
 		t.Fatalf("rm not called: %#v", runner.calls)
 	}
-	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
+	if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
 		t.Fatalf("claim exists=%v err=%v, want removed", exists, err)
 	}
 }
@@ -537,30 +537,30 @@ func TestExeDevReleaseRunsGuardedRemoteCleanupBeforeDelete(t *testing.T) {
 	leaseID := "cbx_abcdef123456"
 	vm := ownedExeDevVM(leaseID, "blue")
 	runner := exeDevInventoryRunner(t, vm)
-	backend := newExeDevTestBackend(Config{}, runner)
+	backend := newExeDevTestBackend(core.Config{}, runner)
 	claim := persistExeDevClaim(t, backend.configForRun(), vm, leaseID, "blue", t.TempDir())
 	labels := maps.Clone(claim.Labels)
 	labels["tailscale"] = "true"
-	claim, err := updateLeaseClaimLabelsIfUnchangedAfter(leaseID, claim, labels, nil)
+	claim, err := core.UpdateLeaseClaimLabelsIfUnchangedAfter(leaseID, claim, labels, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 	cleaned := false
 	lease.SSH.Host = "stale-endpoint.example"
 	baseRun := runner.fn
-	runner.fn = func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner.fn = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if strings.Contains(strings.Join(req.Args, " "), " rm ") && !cleaned {
-			return LocalCommandResult{}, errors.New("delete ran before guarded remote cleanup")
+			return core.LocalCommandResult{}, errors.New("delete ran before guarded remote cleanup")
 		}
 		return baseRun(req)
 	}
-	err = backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{
+	err = backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{
 		Lease: lease,
-		GuardedRemoteCleanup: func(_ context.Context, target LeaseTarget) {
+		GuardedRemoteCleanup: func(_ context.Context, target core.LeaseTarget) {
 			if target.SSH.Host != vm.SSHHost() {
 				t.Fatalf("cleanup SSH host=%q want %q", target.SSH.Host, vm.SSHHost())
 			}
@@ -584,16 +584,16 @@ func TestExeDevReleaseRejectsDifferentAuthenticatedAccount(t *testing.T) {
 	slug := "blue"
 	vm := ownedExeDevVM(leaseID, slug)
 	baseResponse := exeDevInventoryResponse(t, vm)
-	runner := &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &exeDevRecordingRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if strings.Contains(strings.Join(req.Args, " "), "whoami --json") {
-			return LocalCommandResult{Stdout: `{"email":"other@example.com"}`}, nil
+			return core.LocalCommandResult{Stdout: `{"email":"other@example.com"}`}, nil
 		}
 		return baseResponse(req)
 	}}
-	backend := newExeDevTestBackend(Config{}, runner)
+	backend := newExeDevTestBackend(core.Config{}, runner)
 	persistExeDevClaim(t, backend.configForRun(), vm, leaseID, slug, t.TempDir())
 
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
 	if err == nil || !strings.Contains(err.Error(), "different exe.dev control route") {
 		t.Fatalf("err=%v, want account-bound route refusal", err)
 	}
@@ -606,7 +606,7 @@ func TestExeDevReleaseRejectsReplacementClaimGeneration(t *testing.T) {
 	slug := "blue"
 	vm := ownedExeDevVM(leaseID, slug)
 	runner := exeDevInventoryRunner(t, vm)
-	backend := newExeDevTestBackend(Config{}, runner)
+	backend := newExeDevTestBackend(core.Config{}, runner)
 	persistExeDevClaim(t, backend.configForRun(), vm, leaseID, slug, t.TempDir())
 	vm.Tags = slices.DeleteFunc(vm.Tags, func(tag string) bool {
 		return strings.HasPrefix(tag, exeDevClaimGenerationTagPrefix)
@@ -614,12 +614,12 @@ func TestExeDevReleaseRejectsReplacementClaimGeneration(t *testing.T) {
 	vm.Tags = append(vm.Tags, exeDevClaimGenerationTagPrefix+"cbx_222222222222")
 	runner.fn = exeDevInventoryResponse(t, vm)
 
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReleaseOnly: true})
 	if err == nil || !strings.Contains(err.Error(), "generation does not match") {
 		t.Fatalf("err=%v, want replacement-generation refusal", err)
 	}
 	assertNoExeDevRM(t, runner)
-	if _, exists, readErr := readLeaseClaimWithPresence(leaseID); readErr != nil || !exists {
+	if _, exists, readErr := core.ReadLeaseClaimWithPresence(leaseID); readErr != nil || !exists {
 		t.Fatalf("claim exists=%v err=%v, want retained", exists, readErr)
 	}
 }
@@ -630,17 +630,17 @@ func TestExeDevReleaseSurvivesTouchedClaimRoundTrip(t *testing.T) {
 	slug := "blue"
 	vm := ownedExeDevVM(leaseID, slug)
 	runner := exeDevInventoryRunner(t, vm)
-	backend := newExeDevTestBackend(Config{}, runner)
+	backend := newExeDevTestBackend(core.Config{}, runner)
 	cfg := backend.configForRun()
 	repoRoot := t.TempDir()
 	claim := persistExeDevClaim(t, cfg, vm, leaseID, slug, repoRoot)
-	lease := LeaseTarget{
+	lease := core.LeaseTarget{
 		LeaseID: leaseID,
 		Server:  exeDevServer(vm, leaseID, slug, cfg, true),
 	}
 	lease.Server.Labels[exeDevClaimGenerationLabel] = claim.Labels[exeDevClaimGenerationLabel]
-	setServerLeaseClaimSnapshot(&lease.Server, claim, true)
-	touched, err := backend.Touch(context.Background(), TouchRequest{Lease: lease, State: "ready"})
+	core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
+	touched, err := backend.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "ready"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -655,7 +655,7 @@ func TestExeDevReleaseSurvivesTouchedClaimRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: resolved}); err != nil {
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: resolved}); err != nil {
 		t.Fatal(err)
 	}
 	if !hasExeDevRM(runner) {
@@ -669,18 +669,18 @@ func TestExeDevReleaseRefreshRejectsConcurrentReclaim(t *testing.T) {
 	slug := "blue"
 	vm := ownedExeDevVM(leaseID, slug)
 	runner := exeDevInventoryRunner(t, vm)
-	backend := newExeDevTestBackend(Config{}, runner)
+	backend := newExeDevTestBackend(core.Config{}, runner)
 	cfg := backend.configForRun()
 	repoRoot := t.TempDir()
 	claim := persistExeDevClaim(t, cfg, vm, leaseID, slug, repoRoot)
-	lease := LeaseTarget{LeaseID: leaseID, Server: exeDevServer(vm, leaseID, slug, cfg, true)}
-	setServerLeaseClaimSnapshot(&lease.Server, claim, true)
+	lease := core.LeaseTarget{LeaseID: leaseID, Server: exeDevServer(vm, leaseID, slug, cfg, true)}
+	core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
 
-	reclaimed, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), Repo: Repo{Root: repoRoot}, Reclaim: true})
+	reclaimed, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: vm.Name(), Repo: core.Repo{Root: repoRoot}, Reclaim: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	reclaimedClaim, reclaimedExists, reclaimedSet := serverLeaseClaimSnapshot(reclaimed.Server)
+	reclaimedClaim, reclaimedExists, reclaimedSet := core.ServerLeaseClaimSnapshot(reclaimed.Server)
 	if !reclaimedSet || !reclaimedExists || reclaimedClaim.Labels[exeDevClaimGenerationLabel] == claim.Labels[exeDevClaimGenerationLabel] {
 		t.Fatalf("reclaimed generation=%q, want rotation from %q", reclaimedClaim.Labels[exeDevClaimGenerationLabel], claim.Labels[exeDevClaimGenerationLabel])
 	}
@@ -696,11 +696,11 @@ func TestExeDevReleaseRefreshTreatsMissingClaimAsOwnershipChange(t *testing.T) {
 	slug := "blue"
 	vm := ownedExeDevVM(leaseID, slug)
 	runner := exeDevInventoryRunner(t, vm)
-	backend := newExeDevTestBackend(Config{}, runner)
+	backend := newExeDevTestBackend(core.Config{}, runner)
 	claim := persistExeDevClaim(t, backend.configForRun(), vm, leaseID, slug, t.TempDir())
-	lease := LeaseTarget{LeaseID: leaseID, Server: exeDevServer(vm, leaseID, slug, backend.configForRun(), true)}
-	setServerLeaseClaimSnapshot(&lease.Server, claim, true)
-	if err := removeLeaseClaimIfUnchangedAfter(leaseID, claim, nil); err != nil {
+	lease := core.LeaseTarget{LeaseID: leaseID, Server: exeDevServer(vm, leaseID, slug, backend.configForRun(), true)}
+	core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
+	if err := core.RemoveLeaseClaimIfUnchangedAfter(leaseID, claim, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -716,22 +716,22 @@ func TestExeDevReleaseRetainsClaimWhenDeleteFails(t *testing.T) {
 	leaseID := "cbx_abcdef123456"
 	vm := ownedExeDevVM(leaseID, "blue")
 	runner := exeDevInventoryRunner(t, vm)
-	backend := newExeDevTestBackend(Config{}, runner)
+	backend := newExeDevTestBackend(core.Config{}, runner)
 	persistExeDevClaim(t, backend.configForRun(), vm, leaseID, "blue", t.TempDir())
-	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: vm.Name(), ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	runner.fn = func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner.fn = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if strings.Contains(strings.Join(req.Args, " "), " rm ") {
-			return LocalCommandResult{ExitCode: 1}, errors.New("delete failed")
+			return core.LocalCommandResult{ExitCode: 1}, errors.New("delete failed")
 		}
 		return exeDevInventoryResponse(t, vm)(req)
 	}
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "delete failed") {
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "delete failed") {
 		t.Fatalf("err=%v, want delete failure", err)
 	}
-	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || !exists {
+	if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || !exists {
 		t.Fatalf("claim exists=%v err=%v, want retained", exists, err)
 	}
 }
@@ -743,27 +743,27 @@ func TestExeDevReleaseRemovesUnchangedClaimWhenVMIsAlreadyAbsent(t *testing.T) {
 	for _, identifier := range []string{leaseID, vm.Name(), vm.SSHHost()} {
 		t.Run(identifier, func(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
-			runner := &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+			runner := &exeDevRecordingRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				if strings.Contains(strings.Join(req.Args, " "), "whoami --json") {
-					return LocalCommandResult{Stdout: `{"email":"test@example.com"}`}, nil
+					return core.LocalCommandResult{Stdout: `{"email":"test@example.com"}`}, nil
 				}
-				return LocalCommandResult{Stdout: `{"vms":[]}`}, nil
+				return core.LocalCommandResult{Stdout: `{"vms":[]}`}, nil
 			}}
-			backend := newExeDevTestBackend(Config{}, runner)
+			backend := newExeDevTestBackend(core.Config{}, runner)
 			persistExeDevClaim(t, backend.configForRun(), vm, leaseID, slug, t.TempDir())
 
-			lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: identifier, ReleaseOnly: true})
+			lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: identifier, ReleaseOnly: true})
 			if err != nil {
 				t.Fatal(err)
 			}
 			if lease.Server.Labels[exeDevConfirmedAbsentLabel] != "true" {
 				t.Fatalf("labels=%v, want confirmed-absence marker", lease.Server.Labels)
 			}
-			if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+			if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 				t.Fatal(err)
 			}
 			assertNoExeDevRM(t, runner)
-			if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
+			if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
 				t.Fatalf("claim exists=%v err=%v, want removed", exists, err)
 			}
 		})
@@ -775,16 +775,16 @@ func TestExeDevAbsentReleaseRechecksInventoryBeforeRemovingClaim(t *testing.T) {
 	leaseID := "cbx_abcdef123456"
 	slug := "blue"
 	vm := ownedExeDevVM(leaseID, slug)
-	runner := &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &exeDevRecordingRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if strings.Contains(strings.Join(req.Args, " "), "whoami --json") {
-			return LocalCommandResult{Stdout: `{"email":"test@example.com"}`}, nil
+			return core.LocalCommandResult{Stdout: `{"email":"test@example.com"}`}, nil
 		}
-		return LocalCommandResult{Stdout: `{"vms":[]}`}, nil
+		return core.LocalCommandResult{Stdout: `{"vms":[]}`}, nil
 	}}
-	backend := newExeDevTestBackend(Config{}, runner)
+	backend := newExeDevTestBackend(core.Config{}, runner)
 	persistExeDevClaim(t, backend.configForRun(), vm, leaseID, slug, t.TempDir())
 
-	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -792,11 +792,11 @@ func TestExeDevAbsentReleaseRechecksInventoryBeforeRemovingClaim(t *testing.T) {
 	renamed.VMName = "renamed-owned-vm"
 	renamed.SSHDest = "renamed-owned-vm.exe.xyz"
 	runner.fn = exeDevInventoryResponse(t, renamed)
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "is present") {
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "is present") {
 		t.Fatalf("err=%v, want present-VM refusal", err)
 	}
 	assertNoExeDevRM(t, runner)
-	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || !exists {
+	if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || !exists {
 		t.Fatalf("claim exists=%v err=%v, want retained", exists, err)
 	}
 }
@@ -810,15 +810,15 @@ func TestExeDevAbsentReleaseRejectsRenamedOwnedVM(t *testing.T) {
 	renamed.VMName = "renamed-owned-vm"
 	renamed.SSHDest = "renamed-owned-vm.exe.xyz"
 	runner := exeDevInventoryRunner(t, renamed)
-	backend := newExeDevTestBackend(Config{}, runner)
+	backend := newExeDevTestBackend(core.Config{}, runner)
 	persistExeDevClaim(t, backend.configForRun(), vm, leaseID, slug, t.TempDir())
 
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReleaseOnly: true})
 	if err == nil || !strings.Contains(err.Error(), "unexpected VM") {
 		t.Fatalf("err=%v, want renamed owned-VM refusal", err)
 	}
 	assertNoExeDevRM(t, runner)
-	if _, exists, readErr := readLeaseClaimWithPresence(leaseID); readErr != nil || !exists {
+	if _, exists, readErr := core.ReadLeaseClaimWithPresence(leaseID); readErr != nil || !exists {
 		t.Fatalf("claim exists=%v err=%v, want retained", exists, readErr)
 	}
 }
@@ -828,21 +828,21 @@ func TestExeDevAbsentReleaseRejectsDifferentAuthenticatedAccount(t *testing.T) {
 	leaseID := "cbx_abcdef123456"
 	slug := "blue"
 	vm := ownedExeDevVM(leaseID, slug)
-	runner := &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &exeDevRecordingRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if strings.Contains(strings.Join(req.Args, " "), "whoami --json") {
-			return LocalCommandResult{Stdout: `{"email":"other@example.com"}`}, nil
+			return core.LocalCommandResult{Stdout: `{"email":"other@example.com"}`}, nil
 		}
-		return LocalCommandResult{Stdout: `{"vms":[]}`}, nil
+		return core.LocalCommandResult{Stdout: `{"vms":[]}`}, nil
 	}}
-	backend := newExeDevTestBackend(Config{}, runner)
+	backend := newExeDevTestBackend(core.Config{}, runner)
 	persistExeDevClaim(t, backend.configForRun(), vm, leaseID, slug, t.TempDir())
 
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReleaseOnly: true})
 	if err == nil || !strings.Contains(err.Error(), "different exe.dev control route") {
 		t.Fatalf("err=%v, want account-bound route refusal", err)
 	}
 	assertNoExeDevRM(t, runner)
-	if _, exists, readErr := readLeaseClaimWithPresence(leaseID); readErr != nil || !exists {
+	if _, exists, readErr := core.ReadLeaseClaimWithPresence(leaseID); readErr != nil || !exists {
 		t.Fatalf("claim exists=%v err=%v, want retained", exists, readErr)
 	}
 }
@@ -854,13 +854,13 @@ func TestExeDevReuseRequiresExplicitAdoptionAndPersistsExactBinding(t *testing.T
 		t.Run(map[bool]string{false: "implicit refused", true: "explicit adopted"}[reclaim], func(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			runner := exeDevInventoryRunner(t, vm)
-			backend := newExeDevTestBackend(Config{}, runner)
-			lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), Repo: Repo{Root: t.TempDir()}, Reclaim: reclaim})
+			backend := newExeDevTestBackend(core.Config{}, runner)
+			lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: vm.Name(), Repo: core.Repo{Root: t.TempDir()}, Reclaim: reclaim})
 			if !reclaim {
 				if err == nil || !strings.Contains(err.Error(), "reuse with --reclaim") {
 					t.Fatalf("err=%v, want explicit reclaim refusal", err)
 				}
-				if _, exists, readErr := readLeaseClaimWithPresence(leaseID); readErr != nil || exists {
+				if _, exists, readErr := core.ReadLeaseClaimWithPresence(leaseID); readErr != nil || exists {
 					t.Fatalf("claim exists=%v err=%v, want absent", exists, readErr)
 				}
 				return
@@ -868,7 +868,7 @@ func TestExeDevReuseRequiresExplicitAdoptionAndPersistsExactBinding(t *testing.T
 			if err != nil {
 				t.Fatal(err)
 			}
-			claim, exists, readErr := readLeaseClaimWithPresence(leaseID)
+			claim, exists, readErr := core.ReadLeaseClaimWithPresence(leaseID)
 			if readErr != nil || !exists {
 				t.Fatalf("claim exists=%v err=%v", exists, readErr)
 			}
@@ -879,7 +879,7 @@ func TestExeDevReuseRequiresExplicitAdoptionAndPersistsExactBinding(t *testing.T
 				t.Fatalf("explicit reclaim did not bind a remote claim generation: %#v", runner.calls)
 			}
 			assertExeDevTagOptionsPrecedeVM(t, runner)
-			if _, exists, snapshotSet := serverLeaseClaimSnapshot(lease.Server); !snapshotSet || !exists {
+			if _, exists, snapshotSet := core.ServerLeaseClaimSnapshot(lease.Server); !snapshotSet || !exists {
 				t.Fatalf("claim snapshot set=%v exists=%v", snapshotSet, exists)
 			}
 		})
@@ -898,17 +898,17 @@ func TestExeDevBulkInventoryTreatsMalformedTagsAsUnowned(t *testing.T) {
 	vm := ownedExeDevVM("cbx_abcdef123456", "blue")
 	vm.Tags = append(vm.Tags, "crabbox-lease-cbx_other123456")
 	runner := exeDevInventoryRunner(t, vm)
-	backend := newExeDevTestBackend(Config{}, runner)
+	backend := newExeDevTestBackend(core.Config{}, runner)
 
-	views, err := backend.List(context.Background(), ListRequest{})
+	views, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil || len(views) != 0 {
 		t.Fatalf("owned inventory views=%#v err=%v, want malformed VM omitted", views, err)
 	}
-	views, err = backend.List(context.Background(), ListRequest{All: true})
+	views, err = backend.List(context.Background(), core.ListRequest{All: true})
 	if err != nil || len(views) != 1 || views[0].Name != vm.Name() {
 		t.Fatalf("all inventory views=%#v err=%v, want malformed VM visible", views, err)
 	}
-	if _, err := backend.Resolve(context.Background(), ResolveRequest{ID: vm.Name(), ReleaseOnly: true}); err == nil || !strings.Contains(err.Error(), "conflicting") {
+	if _, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: vm.Name(), ReleaseOnly: true}); err == nil || !strings.Contains(err.Error(), "conflicting") {
 		t.Fatalf("exact resolve err=%v, want hard malformed-tag refusal", err)
 	}
 }
@@ -919,7 +919,7 @@ func TestExeDevLeaseLookupSkipsOnlyUnrelatedMalformedTags(t *testing.T) {
 	malformed := ownedExeDevVM("cbx_other123456", "other")
 	malformed.Tags = append(malformed.Tags, "crabbox-lease-cbx_second123456")
 
-	backend := newExeDevTestBackend(Config{}, &exeDevRecordingRunner{fn: exeDevInventoryResponseMany(t, malformed, valid)})
+	backend := newExeDevTestBackend(core.Config{}, &exeDevRecordingRunner{fn: exeDevInventoryResponseMany(t, malformed, valid)})
 	vm, found, err := backend.findVMByLeaseID(context.Background(), leaseID)
 	if err != nil || !found || vm.Name() != valid.Name() {
 		t.Fatalf("vm=%#v found=%v err=%v", vm, found, err)
@@ -929,7 +929,7 @@ func TestExeDevLeaseLookupSkipsOnlyUnrelatedMalformedTags(t *testing.T) {
 	}
 
 	malformed.Tags = append(malformed.Tags, "crabbox-lease-"+leaseID)
-	backend = newExeDevTestBackend(Config{}, &exeDevRecordingRunner{fn: exeDevInventoryResponseMany(t, malformed, valid)})
+	backend = newExeDevTestBackend(core.Config{}, &exeDevRecordingRunner{fn: exeDevInventoryResponseMany(t, malformed, valid)})
 	if _, _, err := backend.findVMByLeaseID(context.Background(), leaseID); err == nil || !strings.Contains(err.Error(), "conflicting") {
 		t.Fatalf("err=%v, want malformed requested-lease refusal", err)
 	}
@@ -943,7 +943,7 @@ func TestExeDevOwnershipRejectsNoncanonicalLeaseTag(t *testing.T) {
 }
 
 func ownedExeDevVM(leaseID, slug string) exeDevVM {
-	name := leaseProviderName(leaseID, slug)
+	name := core.LeaseProviderName(leaseID, slug)
 	return exeDevVM{
 		VMName:  name,
 		SSHDest: name + ".exe.xyz",
@@ -955,13 +955,13 @@ func ownedExeDevVM(leaseID, slug string) exeDevVM {
 func exeDevInventoryRunner(t *testing.T, vm exeDevVM) *exeDevRecordingRunner {
 	t.Helper()
 	current := vm
-	return &exeDevRecordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	return &exeDevRecordingRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		command := strings.Join(req.Args, " ")
 		if strings.Contains(command, "whoami --json") {
-			return LocalCommandResult{Stdout: `{"email":"test@example.com"}`}, nil
+			return core.LocalCommandResult{Stdout: `{"email":"test@example.com"}`}, nil
 		}
 		if strings.Contains(command, " rm ") {
-			return LocalCommandResult{Stdout: `{}`}, nil
+			return core.LocalCommandResult{Stdout: `{}`}, nil
 		}
 		if strings.Contains(command, " tag ") {
 			fields := strings.Fields(req.Args[len(req.Args)-1])
@@ -977,55 +977,55 @@ func exeDevInventoryRunner(t *testing.T, vm exeDevVM) *exeDevRecordingRunner {
 					current.Tags = append(current.Tags, tag)
 				}
 			}
-			return LocalCommandResult{Stdout: `{}`}, nil
+			return core.LocalCommandResult{Stdout: `{}`}, nil
 		}
 		payload, err := json.Marshal(exeDevListResponse{VMs: []exeDevVM{current}})
 		if err != nil {
 			t.Fatal(err)
 		}
-		return LocalCommandResult{Stdout: string(payload)}, nil
+		return core.LocalCommandResult{Stdout: string(payload)}, nil
 	}}
 }
 
-func exeDevInventoryResponse(t *testing.T, vm exeDevVM) func(LocalCommandRequest) (LocalCommandResult, error) {
+func exeDevInventoryResponse(t *testing.T, vm exeDevVM) func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	return exeDevInventoryResponseMany(t, vm)
 }
 
-func exeDevInventoryResponseMany(t *testing.T, vms ...exeDevVM) func(LocalCommandRequest) (LocalCommandResult, error) {
+func exeDevInventoryResponseMany(t *testing.T, vms ...exeDevVM) func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	t.Helper()
 	payload, err := json.Marshal(exeDevListResponse{VMs: vms})
 	if err != nil {
 		t.Fatal(err)
 	}
-	return func(req LocalCommandRequest) (LocalCommandResult, error) {
+	return func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		command := strings.Join(req.Args, " ")
 		if strings.Contains(command, "whoami --json") {
-			return LocalCommandResult{Stdout: `{"email":"test@example.com"}`}, nil
+			return core.LocalCommandResult{Stdout: `{"email":"test@example.com"}`}, nil
 		}
 		if strings.Contains(command, " rm ") {
-			return LocalCommandResult{Stdout: `{}`}, nil
+			return core.LocalCommandResult{Stdout: `{}`}, nil
 		}
-		return LocalCommandResult{Stdout: string(payload)}, nil
+		return core.LocalCommandResult{Stdout: string(payload)}, nil
 	}
 }
 
-func newExeDevTestBackend(cfg Config, runner *exeDevRecordingRunner) *exeDevLeaseBackend {
+func newExeDevTestBackend(cfg core.Config, runner *exeDevRecordingRunner) *exeDevLeaseBackend {
 	applyExeDevDefaults(&cfg)
-	return &exeDevLeaseBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	return &exeDevLeaseBackend{cfg: cfg, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 }
 
-func persistExeDevClaim(t *testing.T, cfg Config, vm exeDevVM, leaseID, slug, repoRoot string) LeaseClaim {
+func persistExeDevClaim(t *testing.T, cfg core.Config, vm exeDevVM, leaseID, slug, repoRoot string) core.LeaseClaim {
 	t.Helper()
 	server := exeDevServer(vm, leaseID, slug, cfg, true)
 	server.Labels[exeDevClaimGenerationLabel] = "cbx_111111111111"
-	claim, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, mustExeDevControlScope(t, cfg), server, exeDevSSHTarget(cfg, vm), repoRoot, cfg.IdleTimeout, false, LeaseClaim{}, false)
+	claim, err := claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, mustExeDevControlScope(t, cfg), server, exeDevSSHTarget(cfg, vm), repoRoot, cfg.IdleTimeout, false, core.LeaseClaim{}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return claim
 }
 
-func mustExeDevControlScope(t *testing.T, cfg Config) string {
+func mustExeDevControlScope(t *testing.T, cfg core.Config) string {
 	t.Helper()
 	scope, err := exeDevControlScope(cfg, exeDevAccountFingerprint("test@example.com"))
 	if err != nil {
@@ -1078,11 +1078,11 @@ func TestExeDevFlagsRejectGenericClassAndType(t *testing.T) {
 		fs.SetOutput(io.Discard)
 		fs.String("class", "", "")
 		fs.String("type", "", "")
-		values := RegisterExeDevProviderFlags(fs, Config{})
+		values := RegisterExeDevProviderFlags(fs, core.Config{})
 		if err := fs.Parse(args); err != nil {
 			t.Fatal(err)
 		}
-		cfg := Config{Provider: providerName}
+		cfg := core.Config{Provider: providerName}
 		err := ApplyExeDevProviderFlags(&cfg, fs, values)
 		if err == nil || !strings.Contains(err.Error(), "not supported for provider=exe-dev") {
 			t.Fatalf("args=%v err=%v", args, err)
@@ -1091,13 +1091,13 @@ func TestExeDevFlagsRejectGenericClassAndType(t *testing.T) {
 }
 
 func TestExeDevConfigureRejectsUnsupportedTargetAndTailscale(t *testing.T) {
-	for name, cfg := range map[string]Config{
+	for name, cfg := range map[string]core.Config{
 		"macos target": {TargetOS: "macos"},
-		"tailscale":    {TargetOS: targetLinux, Tailscale: TailscaleConfig{Enabled: true}},
+		"tailscale":    {TargetOS: targetLinux, Tailscale: core.TailscaleConfig{Enabled: true}},
 		"network":      {TargetOS: targetLinux, Network: "tailscale"},
 	} {
 		t.Run(name, func(t *testing.T) {
-			_, err := Provider{}.Configure(cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: &exeDevRecordingRunner{}})
+			_, err := Provider{}.Configure(cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: &exeDevRecordingRunner{}})
 			if err == nil {
 				t.Fatal("expected error")
 			}
@@ -1106,7 +1106,7 @@ func TestExeDevConfigureRejectsUnsupportedTargetAndTailscale(t *testing.T) {
 }
 
 func TestExeDevSSHTargetUsesSSHDestUserPortAndWorkRootLabel(t *testing.T) {
-	cfg := Config{SSHKey: "/tmp/crabbox-default-key", ExeDev: ExeDevConfig{WorkRoot: "/tmp/crabbox", User: "runner"}}
+	cfg := core.Config{SSHKey: "/tmp/crabbox-default-key", ExeDev: core.ExeDevConfig{WorkRoot: "/tmp/crabbox", User: "runner"}}
 	applyExeDevDefaults(&cfg)
 	vm := exeDevVM{VMName: "crabbox-blue-12345678", SSHDest: "ubuntu@crabbox-blue-12345678.exe.xyz:2200", Status: "running"}
 	target := exeDevSSHTarget(cfg, vm)
@@ -1149,7 +1149,7 @@ func TestExeDevConfigFlagContract(t *testing.T) {
 			if err := ApplyExeDevProviderFlags(&cfg, fs, values); err != nil {
 				t.Fatal(err)
 			}
-			want := ExeDevConfig{Image: "  ", CPUs: cpu, Command: "command", User: "fixture-user", WorkRoot: "/workspace/flag"}
+			want := core.ExeDevConfig{Image: "  ", CPUs: cpu, Command: "command", User: "fixture-user", WorkRoot: "/workspace/flag"}
 			if provider == "exe-dev" || provider == "exe" || provider == "exedev" {
 				want.ControlHost = "exe.dev"
 				want.CPUs = 2
@@ -1168,7 +1168,7 @@ func TestExeDevConfigFlagContract(t *testing.T) {
 	cfg.Provider = "aws"
 	fs := flag.NewFlagSet("contract", flag.ContinueOnError)
 	values := RegisterExeDevProviderFlags(fs, cfg)
-	cfg.ExeDev = ExeDevConfig{ControlHost: "layered", CPUs: 6, Image: "layered", Memory: "8GB", Disk: "20GB", Command: "layered", User: "layered", WorkRoot: "/layered", NoEmail: false}
+	cfg.ExeDev = core.ExeDevConfig{ControlHost: "layered", CPUs: 6, Image: "layered", Memory: "8GB", Disk: "20GB", Command: "layered", User: "layered", WorkRoot: "/layered", NoEmail: false}
 	want := cfg.ExeDev
 	if err := ApplyExeDevProviderFlags(&cfg, fs, values); err != nil {
 		t.Fatal(err)
@@ -1215,13 +1215,13 @@ func TestExeDevConfigFlagPhaseContract(t *testing.T) {
 func TestExeDevConfigEffectiveDefaultsContract(t *testing.T) {
 	t.Setenv("USER", "fixture-user")
 	for _, tc := range []struct{ providerRoot, generic, want string }{{"", "", "/tmp/crabbox"}, {"", "/work/crabbox", "/tmp/crabbox"}, {"", "/custom/root", "/custom/root"}, {"/specific/root", "/custom/root", "/specific/root"}, {"  ", "/custom/root", "  "}} {
-		cfg := Config{WorkRoot: tc.generic, ExeDev: ExeDevConfig{WorkRoot: tc.providerRoot, CPUs: -2}}
+		cfg := core.Config{WorkRoot: tc.generic, ExeDev: core.ExeDevConfig{WorkRoot: tc.providerRoot, CPUs: -2}}
 		applyExeDevDefaults(&cfg)
 		if cfg.ExeDev.ControlHost != "exe.dev" || cfg.ExeDev.CPUs != 2 || cfg.ExeDev.Memory != "4GB" || cfg.ExeDev.Disk != "10GB" || cfg.ExeDev.WorkRoot != tc.want || cfg.WorkRoot != tc.want || cfg.ExeDev.NoEmail || cfg.ExeDev.Image != "" {
 			t.Fatalf("defaults=%#v want root=%q", cfg.ExeDev, tc.want)
 		}
 	}
-	cfg := Config{ExeDev: ExeDevConfig{ControlHost: "  ", CPUs: 6, Memory: "  ", Disk: "  ", Image: "  "}}
+	cfg := core.Config{ExeDev: core.ExeDevConfig{ControlHost: "  ", CPUs: 6, Memory: "  ", Disk: "  ", Image: "  "}}
 	applyExeDevDefaults(&cfg)
 	if cfg.ExeDev.ControlHost != "  " || cfg.ExeDev.Memory != "  " || cfg.ExeDev.Disk != "  " || cfg.ExeDev.CPUs != 6 {
 		t.Fatal("raw whitespace fallback predicate changed")
@@ -1232,7 +1232,7 @@ func TestExeDevConfigEffectiveDefaultsContract(t *testing.T) {
 			t.Fatalf("display=%q want=%q", got, tc.want)
 		}
 	}
-	backend := NewExeDevLeaseBackend(Provider{}.Spec(), Config{}, Runtime{}).(*exeDevLeaseBackend)
+	backend := NewExeDevLeaseBackend(Provider{}.Spec(), core.Config{}, core.Runtime{}).(*exeDevLeaseBackend)
 	if backend.cfg.ExeDev.NoEmail || backend.cfg.ExeDev.Image != "" {
 		t.Fatal("constructor filled raw false/image")
 	}
@@ -1253,15 +1253,15 @@ func TestExeDevConfigCreateArgumentsContract(t *testing.T) {
 		noEmail, paddedSizes bool
 	}{{"empty", "", false, false}, {"whitespace", "  ", false, true}, {"configured", " image ", true, false}} {
 		t.Run(tc.name, func(t *testing.T) {
-			runner := &exeDevRecordingRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
-				return LocalCommandResult{Stdout: `{"vm_name":"fixture-vm","ssh_dest":"fixture-vm.example","status":"running"}`}, nil
+			runner := &exeDevRecordingRunner{fn: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+				return core.LocalCommandResult{Stdout: `{"vm_name":"fixture-vm","ssh_dest":"fixture-vm.example","status":"running"}`}, nil
 			}}
-			cfg := Config{ExeDev: ExeDevConfig{Image: tc.image, NoEmail: tc.noEmail, Command: " echo ok "}}
+			cfg := core.Config{ExeDev: core.ExeDevConfig{Image: tc.image, NoEmail: tc.noEmail, Command: " echo ok "}}
 			if tc.paddedSizes {
 				cfg.ExeDev.Memory = "  "
 				cfg.ExeDev.Disk = "  "
 			}
-			backend := &exeDevLeaseBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+			backend := &exeDevLeaseBackend{cfg: cfg, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 			if _, err := backend.createVM(t.Context(), backend.configForRun(), "fixture-vm", "cbx_fixture", "fixture", "cbx_generation"); err != nil {
 				t.Fatal(err)
 			}
@@ -1306,7 +1306,7 @@ func TestInheritedWorkRootCallerContract(t *testing.T) {
 		{"/provider/root", "/srv/custom", "/provider/root"},
 	} {
 		for _, explicit := range []bool{false, true} {
-			cfg := Config{Provider: "prior", WorkRoot: "/recorded/root", SSHUser: "fixture-user", SSHPort: "1234", SSHFallbackPorts: []string{"4567"}, ServerType: "prior-type", Network: "prior-network"}
+			cfg := core.Config{Provider: "prior", WorkRoot: "/recorded/root", SSHUser: "fixture-user", SSHPort: "1234", SSHFallbackPorts: []string{"4567"}, ServerType: "prior-type", Network: "prior-network"}
 			if explicit {
 				core.MarkWorkRootExplicit(&cfg)
 				cfg.TargetOS = "existing-target"

--- a/internal/providers/exedev/core.go
+++ b/internal/providers/exedev/core.go
@@ -8,30 +8,6 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-type Config = core.Config
-type ExeDevConfig = core.ExeDevConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type CleanupRequest = core.CleanupRequest
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-type TailscaleConfig = core.TailscaleConfig
-type Repo = core.Repo
-type ExitError = core.ExitError
-type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
-type LeaseClaim = core.LeaseClaim
-
 var errReleaseLeaseOwnershipChanged = core.ErrReleaseLeaseOwnershipChanged
 
 const (
@@ -40,82 +16,10 @@ const (
 	networkPublic = core.NetworkPublic
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func isCanonicalLeaseID(value string) bool {
-	return core.IsCanonicalLeaseID(value)
-}
-
-func leaseProviderName(leaseID, slug string) string {
-	return core.LeaseProviderName(leaseID, slug)
-}
-
-func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (string, error) {
-	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
-}
-
-var claimLeaseTargetForRepoConfigScopeIfUnchanged = func(leaseID, slug string, cfg Config, providerScope string, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected core.LeaseClaim, expectedExists bool) (core.LeaseClaim, error) {
+var claimLeaseTargetForRepoConfigScopeIfUnchanged = func(leaseID, slug string, cfg core.Config, providerScope string, server core.Server, target core.SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected core.LeaseClaim, expectedExists bool) (core.LeaseClaim, error) {
 	return core.ClaimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, providerScope, server, target, repoRoot, idleTimeout, reclaim, expected, expectedExists)
 }
 
-func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaimForProvider(identifier, provider)
-}
-
-func resolveLeaseClaimForProviderCloudID(cloudID, provider string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaimForProviderCloudID(cloudID, provider)
-}
-
-func readLeaseClaimWithPresence(leaseID string) (core.LeaseClaim, bool, error) {
-	return core.ReadLeaseClaimWithPresence(leaseID)
-}
-
-func removeLeaseClaimIfUnchangedAfter(leaseID string, expected core.LeaseClaim, action func() error) error {
-	return core.RemoveLeaseClaimIfUnchangedAfter(leaseID, expected, action)
-}
-
-func updateLeaseClaimLabelsIfUnchangedAfter(leaseID string, expected core.LeaseClaim, labels map[string]string, action func() error) (core.LeaseClaim, error) {
-	return core.UpdateLeaseClaimLabelsIfUnchangedAfter(leaseID, expected, labels, action)
-}
-
-func setServerLeaseClaimSnapshot(server *Server, claim core.LeaseClaim, exists bool) {
-	core.SetServerLeaseClaimSnapshot(server, claim, exists)
-}
-
-func serverLeaseClaimSnapshot(server Server) (core.LeaseClaim, bool, bool) {
-	return core.ServerLeaseClaimSnapshot(server)
-}
-
-func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
-	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
-}
-
-func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, now time.Time) map[string]string {
-	return core.TouchDirectLeaseLabels(labels, cfg, state, now)
-}
-
-func sshTargetFromConfig(cfg Config, host string) SSHTarget {
-	return core.SSHTargetFromConfig(cfg, host)
-}
-
-var waitForSSHReady = func(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+var waitForSSHReady = func(ctx context.Context, target *core.SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
 	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
-}
-
-func bootstrapWaitTimeout(cfg Config) time.Duration {
-	return core.BootstrapWaitTimeout(cfg)
-}
-
-func cliDoctorResult(provider string, leases int, runtime string) DoctorResult {
-	return core.CLIDoctorResult(provider, leases, runtime)
 }

--- a/internal/providers/exedev/flags.go
+++ b/internal/providers/exedev/flags.go
@@ -7,11 +7,11 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func RegisterExeDevProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterExeDevProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterExeDevConfigFlags(fs, defaults.ExeDev)
 }
 
-func ApplyExeDevProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyExeDevProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if core.ProviderNameMatchesExact(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --exe-dev-cpus, --exe-dev-memory, and --exe-dev-disk", "use --exe-dev-image"); err != nil {
 			return err

--- a/internal/providers/exedev/provider.go
+++ b/internal/providers/exedev/provider.go
@@ -42,10 +42,10 @@ func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error
 
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
-		return nil, exit(2, "provider=%s managed provisioning supports target=linux only", providerName)
+		return nil, core.Exit(2, "provider=%s managed provisioning supports target=linux only", providerName)
 	}
 	if cfg.Tailscale.Enabled || string(cfg.Network) == "tailscale" {
-		return nil, exit(2, "--tailscale is not supported for provider=%s; exe.dev VMs expose public SSH only", providerName)
+		return nil, core.Exit(2, "--tailscale is not supported for provider=%s; exe.dev VMs expose public SSH only", providerName)
 	}
 	return NewExeDevLeaseBackend(p.Spec(), cfg, rt), nil
 }

--- a/internal/providers/githubcodespaces/backend.go
+++ b/internal/providers/githubcodespaces/backend.go
@@ -37,14 +37,14 @@ type githubCLI interface {
 }
 
 type backend struct {
-	spec             ProviderSpec
-	cfg              Config
-	rt               Runtime
+	spec             core.ProviderSpec
+	cfg              core.Config
+	rt               core.Runtime
 	clientFactory    func(string) codespacesAPI
 	ghFactory        func() githubCLI
-	bindClaim        func(string, LeaseClaim, Server) (LeaseClaim, error)
+	bindClaim        func(string, core.LeaseClaim, core.Server) (core.LeaseClaim, error)
 	newRecoveryNonce func() (string, error)
-	waitSSH          func(context.Context, *SSHTarget, string, time.Duration) error
+	waitSSH          func(context.Context, *core.SSHTarget, string, time.Duration) error
 	now              func() time.Time
 	pollInterval     time.Duration
 	readyTimeout     time.Duration
@@ -78,7 +78,7 @@ const (
 	defaultReadyTimeout = 10 * time.Minute
 )
 
-func newBackend(spec ProviderSpec, cfg Config, rt Runtime) *backend {
+func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) *backend {
 	b := &backend{spec: spec, cfg: cfg, rt: rt, pollInterval: defaultPollInterval, readyTimeout: defaultReadyTimeout}
 	b.clientFactory = func(token string) codespacesAPI {
 		return newClient(cfg.GitHubCodespaces, rt, token)
@@ -86,12 +86,12 @@ func newBackend(spec ProviderSpec, cfg Config, rt Runtime) *backend {
 	b.ghFactory = func() githubCLI {
 		return newGHRunner(cfg.GitHubCodespaces, rt)
 	}
-	b.bindClaim = func(leaseID string, expected LeaseClaim, server Server) (LeaseClaim, error) {
-		return updateLeaseClaimEndpointIfUnchanged(leaseID, expected, server, SSHTarget{})
+	b.bindClaim = func(leaseID string, expected core.LeaseClaim, server core.Server) (core.LeaseClaim, error) {
+		return core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, expected, server, core.SSHTarget{})
 	}
 	b.newRecoveryNonce = newGitHubCodespacesRecoveryNonce
-	b.waitSSH = func(ctx context.Context, target *SSHTarget, phase string, timeout time.Duration) error {
-		return waitForSSHReady(ctx, target, b.stderr(), phase, timeout)
+	b.waitSSH = func(ctx context.Context, target *core.SSHTarget, phase string, timeout time.Duration) error {
+		return core.WaitForSSHReady(ctx, target, b.stderr(), phase, timeout)
 	}
 	b.now = func() time.Time {
 		if rt.Clock != nil {
@@ -102,20 +102,20 @@ func newBackend(spec ProviderSpec, cfg Config, rt Runtime) *backend {
 	return b
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	gh, api, user, err := b.controlPlane(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	repo, err := b.resolveRepo(req.Repo)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cfg := b.claimConfig(repo)
 	if _, err := api.listMachines(ctx, repo, b.cfg.GitHubCodespaces.Ref); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	leaseID := strings.TrimSpace(req.RequestedLeaseID)
 	if leaseID == "" {
@@ -123,13 +123,13 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	}
 	unlockLease, err := lockGitHubCodespacesLeaseOperation(ctx, leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	defer unlockLease()
 
 	unlockSlug, err := lockGitHubCodespacesSlugAllocation(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	defer func() {
 		if unlockSlug != nil {
@@ -138,44 +138,44 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	}()
 	live, err := api.listCodespaces(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	existing, err := b.serversFromCodespaces(live)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	// The core allocator checks durable claim files as well as this live-server
 	// snapshot, so pending and temporarily absent claims reserve their slugs.
-	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, existing)
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, existing)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	release := releaseDelete
-	if !githubCodespacesDeleteOnRelease(LeaseTarget{}, cfg) {
+	if !githubCodespacesDeleteOnRelease(core.LeaseTarget{}, cfg) {
 		release = releaseStop
 	}
 	repoRoot, err := repoRootForClaim(req.Repo)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if b.newRecoveryNonce == nil {
-		return LeaseTarget{}, exit(2, "generate github-codespaces recovery nonce")
+		return core.LeaseTarget{}, core.Exit(2, "generate github-codespaces recovery nonce")
 	}
 	recoveryNonce, err := b.newRecoveryNonce()
 	recoveryNonce = strings.TrimSpace(recoveryNonce)
 	if err != nil {
-		return LeaseTarget{}, fmt.Errorf("generate github-codespaces recovery nonce: %w", err)
+		return core.LeaseTarget{}, fmt.Errorf("generate github-codespaces recovery nonce: %w", err)
 	}
 	if recoveryNonce == "" {
-		return LeaseTarget{}, exit(2, "generate github-codespaces recovery nonce")
+		return core.LeaseTarget{}, core.Exit(2, "generate github-codespaces recovery nonce")
 	}
 	displayName := githubCodespacesDisplayName(leaseID, slug, recoveryNonce)
 	if err := rejectExistingRecoveryIdentity(live, displayName, repo); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	claim, err := b.claimPendingCreate(leaseID, slug, repo, user, displayName, recoveryNonce, repoRoot, release, req.Keep, req.Reclaim)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	// The durable pending claim reserves both the lease and slug. Provider
 	// creation remains protected by the lease lock, but unrelated acquires may proceed.
@@ -190,7 +190,7 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		Geo:              strings.TrimSpace(b.cfg.GitHubCodespaces.Geo),
 		IdleTimeout:      b.githubIdleTimeout(),
 		RetentionPeriod:  b.cfg.GitHubCodespaces.RetentionPeriod,
-		RetentionSet:     retentionPeriodExplicit(b.cfg),
+		RetentionSet:     core.GitHubCodespacesRetentionExplicit(b.cfg),
 		DisplayName:      displayName,
 	})
 	if createErr == nil && strings.TrimSpace(created.Name) == "" {
@@ -198,11 +198,11 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	}
 	if createErr != nil {
 		if !githubCodespacesCreateMayHaveSucceeded(createErr) {
-			return LeaseTarget{}, errors.Join(createErr, discardPendingClaim(claim))
+			return core.LeaseTarget{}, errors.Join(createErr, discardPendingClaim(claim))
 		}
 		recovered, recoveryErr := b.recoverPendingResource(api, claim, user)
 		if recoveryErr != nil {
-			return LeaseTarget{}, errors.Join(
+			return core.LeaseTarget{}, errors.Join(
 				fmt.Errorf("github-codespaces create outcome is uncertain for lease=%s display_name=%q repo=%q; recovery claim retained: %w", leaseID, displayName, repo, createErr),
 				recoveryErr,
 			)
@@ -211,13 +211,13 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	} else {
 		created, err = validateCreatedCodespaceIdentity(claim, created)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	if req.OnAcquired != nil {
-		acquired := LeaseTarget{Server: b.serverFromCodespace(created, cloneLabels(claim.Labels)), LeaseID: leaseID}
+		acquired := core.LeaseTarget{Server: b.serverFromCodespace(created, cloneLabels(claim.Labels)), LeaseID: leaseID}
 		if err := req.OnAcquired(acquired); err != nil {
-			return LeaseTarget{}, errors.Join(err, rollbackUnboundCreatedCodespace(api, claim, created))
+			return core.LeaseTarget{}, errors.Join(err, rollbackUnboundCreatedCodespace(api, claim, created))
 		}
 	}
 	claim, err = b.bindValidatedCreatedClaim(claim, created)
@@ -225,23 +225,23 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		if !req.Keep {
 			err = errors.Join(err, rollbackUnboundCreatedCodespace(api, claim, created))
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	available, err := b.waitForAvailable(ctx, api, created.Name)
 	if err != nil {
 		if !req.Keep {
 			err = errors.Join(err, rollbackCreatedCodespace(api, claim))
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if err := validateCodespaceClaimResource(claim, available); err != nil {
 		if !req.Keep {
 			err = errors.Join(err, rollbackCreatedCodespace(api, claim))
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if err := validateStopPreservesCodespace(available); err != nil {
-		return LeaseTarget{}, errors.Join(err, rollbackCreatedCodespace(api, claim))
+		return core.LeaseTarget{}, errors.Join(err, rollbackCreatedCodespace(api, claim))
 	}
 	refreshedUser := user
 	refreshedUser.Login = claim.Labels[labelLogin]
@@ -254,16 +254,16 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		if !req.Keep {
 			err = errors.Join(err, rollbackCreatedCodespace(api, claim))
 		}
-		return LeaseTarget{}, b.sshPrerequisiteError(err)
+		return core.LeaseTarget{}, b.sshPrerequisiteError(err)
 	}
 	if err := b.waitSSH(ctx, &target, "github-codespaces ssh", b.readyTimeout); err != nil {
 		if !req.Keep {
 			err = errors.Join(err, rollbackCreatedCodespace(api, claim))
 		}
-		return LeaseTarget{}, b.sshPrerequisiteError(err)
+		return core.LeaseTarget{}, b.sshPrerequisiteError(err)
 	}
-	lease := LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
-	finalClaim, err := updateLeaseClaimEndpointIfUnchangedAfter(leaseID, claim, server, target, func() error {
+	lease := core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
+	finalClaim, err := core.UpdateLeaseClaimEndpointIfUnchangedAfter(leaseID, claim, server, target, func() error {
 		_, err := storeSSHConfig(leaseID, sshConfig)
 		return err
 	})
@@ -271,25 +271,25 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		if !req.Keep {
 			err = errors.Join(err, rollbackCreatedCodespace(api, claim))
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	setServerLeaseClaimSnapshot(&lease.Server, finalClaim, true)
+	core.SetServerLeaseClaimSnapshot(&lease.Server, finalClaim, true)
 	fmt.Fprintf(b.stderr(), "provisioned provider=github-codespaces lease=%s slug=%s codespace=%s repo=%s state=%s\n", leaseID, slug, available.Name, repo, available.State)
 	return lease, nil
 }
 
-func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	gh, api, user, err := b.controlPlane(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	live, err := api.listCodespaces(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	candidate, candidateOK, err := resolveUniqueGitHubCodespacesClaim(req.ID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	leaseID := ""
 	if candidateOK {
@@ -297,41 +297,41 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 	} else {
 		_, leaseID, err = b.resolveServer(live, req.ID)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	if strings.TrimSpace(leaseID) == "" {
-		return LeaseTarget{}, exit(4, "github-codespaces lease not found: %s", req.ID)
+		return core.LeaseTarget{}, core.Exit(4, "github-codespaces lease not found: %s", req.ID)
 	}
 	unlockOperation, err := lockGitHubCodespacesLeaseOperation(ctx, leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	defer unlockOperation()
 	currentCandidate, currentCandidateOK, err := resolveUniqueGitHubCodespacesClaim(req.ID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if !currentCandidateOK || currentCandidate.LeaseID != leaseID {
-		return LeaseTarget{}, exit(2, "github-codespaces identifier %s changed during resolve; retry", req.ID)
+		return core.LeaseTarget{}, core.Exit(2, "github-codespaces identifier %s changed during resolve; retry", req.ID)
 	}
 	claim := currentCandidate
 
 	live, err = api.listCodespaces(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if claim.Provider != providerName {
-		return LeaseTarget{}, exit(4, "github-codespaces lease %s has no current local claim", leaseID)
+		return core.LeaseTarget{}, core.Exit(4, "github-codespaces lease %s has no current local claim", leaseID)
 	}
 
-	server := Server{}
+	server := core.Server{}
 	pendingReadOnly := false
 	if strings.TrimSpace(claim.CloudID) == "" && claim.Labels[labelRecovery] == recoveryPreCreate {
 		if req.NoLocalStateMutations {
 			item, err := b.matchPendingClaimFromInventory(claim, user, live)
 			if err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 			server = b.mergeLiveServer(serverFromClaim(claim), item)
 			pendingReadOnly = true
@@ -339,7 +339,7 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 			var item codespace
 			claim, item, err = b.recoverPendingClaimFromInventory(claim, user, live)
 			if err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 			server = b.mergeLiveServer(serverFromClaim(claim), item)
 		}
@@ -347,17 +347,17 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 		var resolvedLeaseID string
 		server, resolvedLeaseID, err = b.resolveServer(live, leaseID)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		if resolvedLeaseID != "" && resolvedLeaseID != leaseID {
-			return LeaseTarget{}, exit(3, "github-codespaces lease identity changed during resolve: expected=%s got=%s", leaseID, resolvedLeaseID)
+			return core.LeaseTarget{}, core.Exit(3, "github-codespaces lease identity changed during resolve: expected=%s got=%s", leaseID, resolvedLeaseID)
 		}
 	}
 	if server.CloudID == "" {
-		return LeaseTarget{}, exit(4, "github-codespaces lease not found: %s", req.ID)
+		return core.LeaseTarget{}, core.Exit(4, "github-codespaces lease not found: %s", req.ID)
 	}
 	if err := b.validateClaimForServer(claim, server, user); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	validateResolvedItem := func(item codespace) error {
 		if !pendingReadOnly {
@@ -368,30 +368,30 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 			return err
 		}
 		if matched.Name != server.CloudID {
-			return exit(3, "github-codespaces pending recovery resource changed during resolve: expected=%s got=%s", server.CloudID, matched.Name)
+			return core.Exit(3, "github-codespaces pending recovery resource changed during resolve: expected=%s got=%s", server.CloudID, matched.Name)
 		}
 		return nil
 	}
-	resolveAction := func() (Server, SSHTarget, bool, error) {
+	resolveAction := func() (core.Server, core.SSHTarget, bool, error) {
 		item, err := api.getCodespace(ctx, server.CloudID)
 		if err != nil {
 			if req.ReleaseOnly && isGitHubNotFound(err) {
 				server.Status = "deleted"
 				server.Labels[labelState] = "deleted"
-				return server, SSHTarget{}, false, nil
+				return server, core.SSHTarget{}, false, nil
 			}
-			return Server{}, SSHTarget{}, false, err
+			return core.Server{}, core.SSHTarget{}, false, err
 		}
 		if err := validateResolvedItem(item); err != nil {
-			return Server{}, SSHTarget{}, false, err
+			return core.Server{}, core.SSHTarget{}, false, err
 		}
 		server = b.mergeLiveServer(server, item)
 		if codespaceStopped(item.State) && (req.StatusOnly || req.NoLocalStateMutations) {
 			server.Labels[labelState] = "stopped"
-			return server, SSHTarget{}, false, nil
+			return server, core.SSHTarget{}, false, nil
 		}
 		if req.ReleaseOnly || (req.StatusOnly && !req.ReadyProbe) {
-			return server, SSHTarget{}, false, nil
+			return server, core.SSHTarget{}, false, nil
 		}
 		if codespaceStopping(item.State) {
 			waitCtx := ctx
@@ -402,44 +402,44 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 			item, err = b.waitForStopped(waitCtx, api, item.Name)
 			cancel()
 			if err != nil {
-				return Server{}, SSHTarget{}, false, err
+				return core.Server{}, core.SSHTarget{}, false, err
 			}
 			if err := validateResolvedItem(item); err != nil {
-				return Server{}, SSHTarget{}, false, err
+				return core.Server{}, core.SSHTarget{}, false, err
 			}
 			server = b.mergeLiveServer(server, item)
 		}
 		if codespaceStopped(item.State) && (req.StatusOnly || req.NoLocalStateMutations) {
 			server.Labels[labelState] = "stopped"
-			return server, SSHTarget{}, false, nil
+			return server, core.SSHTarget{}, false, nil
 		}
 		if codespaceStopped(item.State) {
 			item, err = api.startCodespace(ctx, item.Name)
 			if err != nil {
-				return Server{}, SSHTarget{}, false, err
+				return core.Server{}, core.SSHTarget{}, false, err
 			}
 			if strings.TrimSpace(item.Name) != server.CloudID {
-				return Server{}, SSHTarget{}, false, exit(3, "github-codespaces start returned a different resource: expected=%s got=%s", server.CloudID, item.Name)
+				return core.Server{}, core.SSHTarget{}, false, core.Exit(3, "github-codespaces start returned a different resource: expected=%s got=%s", server.CloudID, item.Name)
 			}
 			item, err = b.waitForAvailable(ctx, api, item.Name)
 			if err != nil {
-				return Server{}, SSHTarget{}, false, err
+				return core.Server{}, core.SSHTarget{}, false, err
 			}
 			if err := validateResolvedItem(item); err != nil {
-				return Server{}, SSHTarget{}, false, err
+				return core.Server{}, core.SSHTarget{}, false, err
 			}
 			server = b.mergeLiveServer(server, item)
 		}
 		if codespaceTerminal(item.State) {
-			return Server{}, SSHTarget{}, false, exit(5, "github-codespaces codespace %s entered terminal state=%s", item.Name, item.State)
+			return core.Server{}, core.SSHTarget{}, false, core.Exit(5, "github-codespaces codespace %s entered terminal state=%s", item.Name, item.State)
 		}
 		if !codespaceAvailable(item.State) {
 			item, err = b.waitForAvailable(ctx, api, item.Name)
 			if err != nil {
-				return Server{}, SSHTarget{}, false, err
+				return core.Server{}, core.SSHTarget{}, false, err
 			}
 			if err := validateResolvedItem(item); err != nil {
-				return Server{}, SSHTarget{}, false, err
+				return core.Server{}, core.SSHTarget{}, false, err
 			}
 			server = b.mergeLiveServer(server, item)
 		}
@@ -449,77 +449,77 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 			server.Labels = map[string]string{}
 		}
 		server.Labels["work_root"] = cfg.WorkRoot
-		server.Labels = touchDirectLeaseLabels(server.Labels, cfg, "ready", b.now().UTC())
+		server.Labels = core.TouchDirectLeaseLabels(server.Labels, cfg, "ready", b.now().UTC())
 		target, sshConfig, err := b.sshTargetWithConfig(ctx, gh, item.Name, repo)
 		if err != nil {
-			return Server{}, SSHTarget{}, false, b.sshPrerequisiteError(err)
+			return core.Server{}, core.SSHTarget{}, false, b.sshPrerequisiteError(err)
 		}
 		if req.ReadyProbe {
 			if err := b.waitSSH(ctx, &target, "github-codespaces ssh", b.readyTimeout); err != nil {
-				return Server{}, SSHTarget{}, false, b.sshPrerequisiteError(err)
+				return core.Server{}, core.SSHTarget{}, false, b.sshPrerequisiteError(err)
 			}
 		}
 		if !req.NoLocalStateMutations {
 			if _, err := storeSSHConfig(leaseID, sshConfig); err != nil {
-				return Server{}, SSHTarget{}, false, err
+				return core.Server{}, core.SSHTarget{}, false, err
 			}
 		}
 		return server, target, true, nil
 	}
-	target := SSHTarget{}
+	target := core.SSHTarget{}
 	if req.NoLocalStateMutations {
-		if err := withLeaseClaimUnchanged(leaseID, claim, func() error {
+		if err := core.WithLeaseClaimUnchanged(leaseID, claim, func() error {
 			var actionErr error
 			server, target, _, actionErr = resolveAction()
 			return actionErr
 		}); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	} else {
-		_, server, target, err = updateLeaseClaimEndpointIfUnchangedAction(leaseID, claim, resolveAction)
+		_, server, target, err = core.UpdateLeaseClaimEndpointIfUnchangedAction(leaseID, claim, resolveAction)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
-func resolveUniqueGitHubCodespacesClaim(identifier string) (LeaseClaim, bool, error) {
+func resolveUniqueGitHubCodespacesClaim(identifier string) (core.LeaseClaim, bool, error) {
 	identifier = strings.TrimSpace(identifier)
 	if identifier == "" {
-		return LeaseClaim{}, false, nil
+		return core.LeaseClaim{}, false, nil
 	}
-	if isCanonicalLeaseID(identifier) {
-		claim, exists, err := readLeaseClaimWithPresence(identifier)
+	if core.IsCanonicalLeaseID(identifier) {
+		claim, exists, err := core.ReadLeaseClaimWithPresence(identifier)
 		if err != nil {
-			return LeaseClaim{}, false, err
+			return core.LeaseClaim{}, false, err
 		}
 		if exists {
 			if claim.Provider != providerName {
-				return LeaseClaim{}, false, exit(4, "%q is claimed by provider %s", identifier, claim.Provider)
+				return core.LeaseClaim{}, false, core.Exit(4, "%q is claimed by provider %s", identifier, claim.Provider)
 			}
 			return claim, true, nil
 		}
-		return LeaseClaim{}, false, nil
+		return core.LeaseClaim{}, false, nil
 	}
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
-		return LeaseClaim{}, false, err
+		return core.LeaseClaim{}, false, err
 	}
-	var match LeaseClaim
+	var match core.LeaseClaim
 	for _, claim := range claims {
-		if claim.Provider != providerName || !leaseClaimMatchesIdentifier(claim, identifier) {
+		if claim.Provider != providerName || !core.LeaseClaimMatchesIdentifier(claim, identifier) {
 			continue
 		}
 		if match.LeaseID != "" {
-			return LeaseClaim{}, false, exit(2, "multiple github-codespaces claims match identifier %s", identifier)
+			return core.LeaseClaim{}, false, core.Exit(2, "multiple github-codespaces claims match identifier %s", identifier)
 		}
 		match = claim
 	}
 	return match, match.LeaseID != "", nil
 }
 
-func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
 	_, api, _, err := b.controlPlane(ctx)
 	if err != nil {
 		return nil, err
@@ -531,63 +531,63 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 	return b.serversFromCodespaces(live)
 }
 
-func (b *backend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
+func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
 	leaseID := strings.TrimSpace(req.Lease.LeaseID)
 	if leaseID == "" {
-		return Server{}, exit(2, "github-codespaces touch requires a lease id")
+		return core.Server{}, core.Exit(2, "github-codespaces touch requires a lease id")
 	}
 	unlockOperation, err := lockGitHubCodespacesLeaseOperation(ctx, leaseID)
 	if err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	defer unlockOperation()
 
-	claim, ok, err := readLeaseClaimWithPresence(leaseID)
+	claim, ok, err := core.ReadLeaseClaimWithPresence(leaseID)
 	if err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	if !ok || claim.Provider != providerName {
-		return Server{}, exit(4, "github-codespaces touch requires a current local claim for lease %s", leaseID)
+		return core.Server{}, core.Exit(4, "github-codespaces touch requires a current local claim for lease %s", leaseID)
 	}
 	if strings.TrimSpace(claim.CloudID) == "" || claim.Labels[labelRecovery] == recoveryPreCreate {
-		return Server{}, exit(4, "github-codespaces lease %s is not active", leaseID)
+		return core.Server{}, core.Exit(4, "github-codespaces lease %s is not active", leaseID)
 	}
 	state := strings.ToLower(strings.TrimSpace(claim.Labels[labelState]))
 	if codespaceStopped(state) || codespaceTerminal(state) || state == "paused" || state == "deleting" || state == "deleted" {
-		return Server{}, exit(4, "github-codespaces lease %s is not active (state=%s)", leaseID, state)
+		return core.Server{}, core.Exit(4, "github-codespaces lease %s is not active (state=%s)", leaseID, state)
 	}
 	requestedName := firstNonEmpty(req.Lease.Server.CloudID, req.Lease.Server.Name, req.Lease.Server.Labels[labelCodespaceName])
 	if requestedName != "" && requestedName != claim.CloudID {
-		return Server{}, exit(3, "github-codespaces touch resource mismatch: claim=%s request=%s", claim.CloudID, requestedName)
+		return core.Server{}, core.Exit(3, "github-codespaces touch resource mismatch: claim=%s request=%s", claim.CloudID, requestedName)
 	}
 	repo := strings.TrimSpace(claim.Labels[labelRepository])
 	if expectedScope := providerClaimScope(b.claimConfig(repo)); expectedScope == "" || claim.ProviderScope != expectedScope {
-		return Server{}, exit(4, "github-codespaces claim %s scope mismatch: claim=%q current=%q", claim.LeaseID, claim.ProviderScope, expectedScope)
+		return core.Server{}, core.Exit(4, "github-codespaces claim %s scope mismatch: claim=%q current=%q", claim.LeaseID, claim.ProviderScope, expectedScope)
 	}
 	server := serverFromClaim(claim)
-	server.Labels = touchDirectLeaseLabels(server.Labels, b.repoConfig(repo), req.State, b.now().UTC())
-	updated, err := updateLeaseClaimEndpointIfUnchanged(leaseID, claim, server, SSHTarget{})
+	server.Labels = core.TouchDirectLeaseLabels(server.Labels, b.repoConfig(repo), req.State, b.now().UTC())
+	updated, err := core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, claim, server, core.SSHTarget{})
 	if err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	return serverFromClaim(updated), nil
 }
 
-func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
 	return err
 }
 
-func (b *backend) ReleaseLeaseWithOutcome(ctx context.Context, req ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+func (b *backend) ReleaseLeaseWithOutcome(ctx context.Context, req core.ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
 	var outcome core.ReleaseLeaseOutcome
 	err := b.releaseLease(ctx, req, &outcome)
 	return outcome, err
 }
 
-func (b *backend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
+func (b *backend) releaseLease(ctx context.Context, req core.ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	leaseID := strings.TrimSpace(req.Lease.LeaseID)
 	if leaseID == "" {
-		return exit(2, "github-codespaces release requires a lease id")
+		return core.Exit(2, "github-codespaces release requires a lease id")
 	}
 	unlockOperation, err := lockGitHubCodespacesLeaseOperation(ctx, leaseID)
 	if err != nil {
@@ -599,12 +599,12 @@ func (b *backend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, out
 		return err
 	}
 	requestedServer := req.Lease.Server
-	claim, claimOK, err := readLeaseClaimWithPresence(leaseID)
+	claim, claimOK, err := core.ReadLeaseClaimWithPresence(leaseID)
 	if err != nil {
 		return err
 	}
 	if !claimOK {
-		return exit(2, "github-codespaces release requires a local claim for lease %s", leaseID)
+		return core.Exit(2, "github-codespaces release requires a local claim for lease %s", leaseID)
 	}
 	if strings.TrimSpace(claim.CloudID) == "" && claim.Labels[labelRecovery] == recoveryPreCreate {
 		claim, _, err = b.recoverPendingClaim(api, claim, user)
@@ -613,7 +613,7 @@ func (b *backend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, out
 		}
 	}
 	if requestedName := firstNonEmpty(requestedServer.CloudID, requestedServer.Name, requestedServer.Labels[labelCodespaceName]); requestedName != "" && requestedName != claim.CloudID {
-		return exit(3, "github-codespaces release resource mismatch: claim=%s request=%s", claim.CloudID, requestedName)
+		return core.Exit(3, "github-codespaces release resource mismatch: claim=%s request=%s", claim.CloudID, requestedName)
 	}
 	server := serverFromClaim(claim)
 	if err := b.validateClaimForServer(claim, server, user); err != nil {
@@ -621,7 +621,7 @@ func (b *backend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, out
 	}
 	name := firstNonEmpty(server.CloudID, server.Name, server.Labels[labelCodespaceName])
 	if name == "" {
-		return exit(2, "github-codespaces release requires a claim-backed codespace name")
+		return core.Exit(2, "github-codespaces release requires a claim-backed codespace name")
 	}
 	authoritativeLease := req.Lease
 	authoritativeLease.Server = server
@@ -647,11 +647,11 @@ func (b *backend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, out
 	return b.stopCodespaceAndRetainWithOutcome(ctx, api, leaseID, claim, server, name, outcome)
 }
 
-func (b *backend) stopCodespaceAndRetain(ctx context.Context, api codespacesAPI, leaseID string, claim LeaseClaim, server Server, name string) error {
+func (b *backend) stopCodespaceAndRetain(ctx context.Context, api codespacesAPI, leaseID string, claim core.LeaseClaim, server core.Server, name string) error {
 	return b.stopCodespaceAndRetainWithOutcome(ctx, api, leaseID, claim, server, name, &core.ReleaseLeaseOutcome{})
 }
 
-func (b *backend) stopCodespaceAndRetainWithOutcome(ctx context.Context, api codespacesAPI, leaseID string, claim LeaseClaim, server Server, name string, outcome *core.ReleaseLeaseOutcome) error {
+func (b *backend) stopCodespaceAndRetainWithOutcome(ctx context.Context, api codespacesAPI, leaseID string, claim core.LeaseClaim, server core.Server, name string, outcome *core.ReleaseLeaseOutcome) error {
 	server.Provider = providerName
 	server.CloudID = name
 	server.Name = name
@@ -676,7 +676,7 @@ func (b *backend) stopCodespaceAndRetainWithOutcome(ctx context.Context, api cod
 		}
 	}
 	absent := false
-	updated, err := updateLeaseClaimEndpointIfUnchangedAfter(leaseID, claim, server, SSHTarget{}, func() error {
+	updated, err := core.UpdateLeaseClaimEndpointIfUnchangedAfter(leaseID, claim, server, core.SSHTarget{}, func() error {
 		item, err := api.getCodespace(ctx, name)
 		if isGitHubNotFound(err) {
 			absent = true
@@ -703,21 +703,21 @@ func (b *backend) stopCodespaceAndRetainWithOutcome(ctx context.Context, api cod
 	if err != nil || !absent {
 		return err
 	}
-	return removeLeaseClaimIfUnchangedAfter(leaseID, updated, func() error {
+	return core.RemoveLeaseClaimIfUnchangedAfter(leaseID, updated, func() error {
 		return removeStoredSSHConfig(leaseID)
 	})
 }
 
-func (b *backend) deleteClaimedCodespace(ctx context.Context, api codespacesAPI, claim LeaseClaim, name string) error {
+func (b *backend) deleteClaimedCodespace(ctx context.Context, api codespacesAPI, claim core.LeaseClaim, name string) error {
 	return b.deleteClaimedCodespaceWithOutcome(ctx, api, claim, name, &core.ReleaseLeaseOutcome{})
 }
 
-func (b *backend) deleteClaimedCodespaceWithOutcome(ctx context.Context, api codespacesAPI, claim LeaseClaim, name string, outcome *core.ReleaseLeaseOutcome) error {
+func (b *backend) deleteClaimedCodespaceWithOutcome(ctx context.Context, api codespacesAPI, claim core.LeaseClaim, name string, outcome *core.ReleaseLeaseOutcome) error {
 	name = strings.TrimSpace(name)
 	if name == "" || claim.CloudID != name || claim.Labels[labelCodespaceName] != name {
-		return exit(4, "refusing github-codespaces delete for lease=%s without its exact bound resource identity", claim.LeaseID)
+		return core.Exit(4, "refusing github-codespaces delete for lease=%s without its exact bound resource identity", claim.LeaseID)
 	}
-	return removeLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+	return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
 		deleteCtx, cancel := context.WithTimeout(ctx, githubCodespacesDeleteTimeout)
 		defer cancel()
 
@@ -774,7 +774,7 @@ func (b *backend) deleteClaimedCodespaceWithOutcome(ctx context.Context, api cod
 	})
 }
 
-func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
+func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 	if githubCodespacesClaimRelease(lease.LeaseID) == releaseStop {
 		return fmt.Sprintf("stopped github-codespaces lease=%s codespace=%s retained=true", lease.LeaseID, firstNonEmpty(lease.Server.CloudID, lease.Server.Name))
 	}
@@ -784,7 +784,7 @@ func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
 	return fmt.Sprintf("stopped github-codespaces lease=%s codespace=%s retained=true", lease.LeaseID, firstNonEmpty(lease.Server.CloudID, lease.Server.Name))
 }
 
-func (b *backend) RetainLeaseClaimAfterRelease(lease LeaseTarget) bool {
+func (b *backend) RetainLeaseClaimAfterRelease(lease core.LeaseTarget) bool {
 	switch githubCodespacesClaimRelease(lease.LeaseID) {
 	case releaseStop:
 		return true
@@ -795,14 +795,14 @@ func (b *backend) RetainLeaseClaimAfterRelease(lease LeaseTarget) bool {
 }
 
 func githubCodespacesClaimRelease(leaseID string) string {
-	claim, ok, err := readLeaseClaimWithPresence(strings.TrimSpace(leaseID))
+	claim, ok, err := core.ReadLeaseClaimWithPresence(strings.TrimSpace(leaseID))
 	if err != nil || !ok {
 		return ""
 	}
 	return strings.ToLower(strings.TrimSpace(claim.Labels[labelRelease]))
 }
 
-func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
+func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	_, api, user, err := b.controlPlane(ctx)
 	if err != nil {
 		return err
@@ -819,7 +819,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	for _, server := range servers {
 		seen[strings.ToLower(strings.TrimSpace(server.CloudID))] = server.Labels["lease"]
 	}
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return err
 	}
@@ -831,7 +831,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 		}
 		key := strings.ToLower(cloudID)
 		if otherLease, ok := boundOwners[key]; ok && otherLease != claim.LeaseID {
-			return exit(3, "multiple github-codespaces claims bind resource %s: leases=%s,%s", cloudID, otherLease, claim.LeaseID)
+			return core.Exit(3, "multiple github-codespaces claims bind resource %s: leases=%s,%s", cloudID, otherLease, claim.LeaseID)
 		}
 		boundOwners[key] = claim.LeaseID
 	}
@@ -843,18 +843,18 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 		}
 		if otherLease, ok := seen[strings.ToLower(cloudID)]; ok {
 			if otherLease != snapshotClaim.LeaseID {
-				return exit(3, "multiple github-codespaces claims bind resource %s: leases=%s,%s", cloudID, otherLease, snapshotClaim.LeaseID)
+				return core.Exit(3, "multiple github-codespaces claims bind resource %s: leases=%s,%s", cloudID, otherLease, snapshotClaim.LeaseID)
 			}
 			continue
 		}
-		claim, item, found, err := func() (LeaseClaim, codespace, bool, error) {
+		claim, item, found, err := func() (core.LeaseClaim, codespace, bool, error) {
 			unlockOperation, err := lockGitHubCodespacesLeaseOperation(ctx, snapshotClaim.LeaseID)
 			if err != nil {
-				return LeaseClaim{}, codespace{}, false, err
+				return core.LeaseClaim{}, codespace{}, false, err
 			}
 			defer unlockOperation()
 
-			claim, ok, err := readLeaseClaimWithPresence(snapshotClaim.LeaseID)
+			claim, ok, err := core.ReadLeaseClaimWithPresence(snapshotClaim.LeaseID)
 			if err != nil || !ok {
 				return claim, codespace{}, false, err
 			}
@@ -867,7 +867,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			}
 			if otherLease, ok := seen[strings.ToLower(cloudID)]; ok {
 				if otherLease != claim.LeaseID {
-					return claim, codespace{}, false, exit(3, "multiple github-codespaces claims bind resource %s: leases=%s,%s", cloudID, otherLease, claim.LeaseID)
+					return claim, codespace{}, false, core.Exit(3, "multiple github-codespaces claims bind resource %s: leases=%s,%s", cloudID, otherLease, claim.LeaseID)
 				}
 				return claim, codespace{}, false, nil
 			}
@@ -898,7 +898,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 		if found {
 			key := strings.ToLower(strings.TrimSpace(item.Name))
 			if otherLease, ok := seen[key]; ok {
-				return exit(3, "multiple github-codespaces claims bind resource %s: leases=%s,%s", item.Name, otherLease, claim.LeaseID)
+				return core.Exit(3, "multiple github-codespaces claims bind resource %s: leases=%s,%s", item.Name, otherLease, claim.LeaseID)
 			}
 			seen[key] = claim.LeaseID
 			servers = append(servers, b.mergeLiveServer(serverFromClaim(claim), item))
@@ -908,14 +908,14 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 		if snapshotClaim.Provider != providerName || strings.TrimSpace(snapshotClaim.CloudID) != "" || snapshotClaim.Labels[labelRecovery] != recoveryPreCreate {
 			continue
 		}
-		claim, item, found, err := func() (LeaseClaim, codespace, bool, error) {
+		claim, item, found, err := func() (core.LeaseClaim, codespace, bool, error) {
 			unlockOperation, err := lockGitHubCodespacesLeaseOperation(ctx, snapshotClaim.LeaseID)
 			if err != nil {
-				return LeaseClaim{}, codespace{}, false, err
+				return core.LeaseClaim{}, codespace{}, false, err
 			}
 			defer unlockOperation()
 
-			claim, ok, err := readLeaseClaimWithPresence(snapshotClaim.LeaseID)
+			claim, ok, err := core.ReadLeaseClaimWithPresence(snapshotClaim.LeaseID)
 			if err != nil || !ok {
 				return claim, codespace{}, false, err
 			}
@@ -949,7 +949,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 		}
 		key := strings.ToLower(strings.TrimSpace(item.Name))
 		if otherLease, ok := seen[key]; ok {
-			return exit(3, "multiple github-codespaces claims bind recovery resource %s: leases=%s,%s", item.Name, otherLease, claim.LeaseID)
+			return core.Exit(3, "multiple github-codespaces claims bind recovery resource %s: leases=%s,%s", item.Name, otherLease, claim.LeaseID)
 		}
 		seen[key] = claim.LeaseID
 		servers = append(servers, b.mergeLiveServer(serverFromClaim(claim), item))
@@ -958,7 +958,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 		err := func() error {
 			leaseID := strings.TrimSpace(listedServer.Labels["lease"])
 			if leaseID == "" {
-				return exit(3, "refusing to cleanup github-codespaces codespace=%s without a lease identity", listedServer.DisplayID())
+				return core.Exit(3, "refusing to cleanup github-codespaces codespace=%s without a lease identity", listedServer.DisplayID())
 			}
 			unlockOperation, err := lockGitHubCodespacesLeaseOperation(ctx, leaseID)
 			if err != nil {
@@ -966,12 +966,12 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			}
 			defer unlockOperation()
 
-			claim, ok, err := readLeaseClaimWithPresence(leaseID)
+			claim, ok, err := core.ReadLeaseClaimWithPresence(leaseID)
 			if err != nil {
 				return err
 			}
 			if !ok {
-				return exit(3, "refusing to cleanup github-codespaces codespace=%s without local claim", listedServer.DisplayID())
+				return core.Exit(3, "refusing to cleanup github-codespaces codespace=%s without local claim", listedServer.DisplayID())
 			}
 			server := serverFromClaim(claim)
 			pending := strings.TrimSpace(claim.CloudID) == "" && claim.Labels[labelRecovery] == recoveryPreCreate
@@ -987,18 +987,18 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 					return nil
 				}
 				if listedServer.CloudID != "" && listedServer.CloudID != pendingItem.Name {
-					return exit(2, "github-codespaces pending claim %s resource changed during cleanup; retry", leaseID)
+					return core.Exit(2, "github-codespaces pending claim %s resource changed during cleanup; retry", leaseID)
 				}
 				server = b.mergeLiveServer(server, pendingItem)
 			} else if listedServer.CloudID != "" && listedServer.CloudID != server.CloudID {
-				return exit(2, "github-codespaces claim %s resource changed during cleanup; retry", leaseID)
+				return core.Exit(2, "github-codespaces claim %s resource changed during cleanup; retry", leaseID)
 			}
 			if !pending {
 				if err := b.validateClaimForServer(claim, server, user); err != nil {
 					return err
 				}
 			}
-			shouldDelete, reason := shouldCleanupServer(server, now)
+			shouldDelete, reason := core.ShouldCleanupServer(server, now)
 			if !shouldDelete {
 				fmt.Fprintf(b.stderr(), "skip codespace=%s reason=%s\n", server.DisplayID(), reason)
 				return nil
@@ -1085,50 +1085,50 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	return nil
 }
 
-func shouldDiscardMissingClaim(claim LeaseClaim, now time.Time) (bool, string) {
+func shouldDiscardMissingClaim(claim core.LeaseClaim, now time.Time) (bool, string) {
 	server := serverFromClaim(claim)
 	server.Labels = cloneLabels(server.Labels)
 	server.Labels[labelState] = "provisioning"
-	return shouldCleanupServer(server, now)
+	return core.ShouldCleanupServer(server, now)
 }
 
-func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	_, api, user, err := b.controlPlane(ctx)
-	checks := []DoctorCheck{}
+	checks := []core.DoctorCheck{}
 	if err != nil {
-		return DoctorResult{
+		return core.DoctorResult{
 			Provider: providerName,
 			Status:   "failed",
 			Message:  "auth=failed control_plane=unchecked inventory=unchecked mutation=false",
-			Checks:   append(checks, DoctorCheck{Status: "failed", Check: "auth", Message: err.Error()}),
+			Checks:   append(checks, core.DoctorCheck{Status: "failed", Check: "auth", Message: err.Error()}),
 		}, err
 	}
-	repo, repoErr := b.resolveRepo(Repo{})
+	repo, repoErr := b.resolveRepo(core.Repo{})
 	if repoErr == nil {
 		if _, err := api.listMachines(ctx, repo, b.cfg.GitHubCodespaces.Ref); err != nil {
-			checks = append(checks, DoctorCheck{Status: "failed", Check: "machines", Message: err.Error(), Details: map[string]string{"repo": repo}})
-			return DoctorResult{Provider: providerName, Status: "failed", Message: "auth=ready control_plane=failed inventory=unchecked mutation=false", Checks: checks}, err
+			checks = append(checks, core.DoctorCheck{Status: "failed", Check: "machines", Message: err.Error(), Details: map[string]string{"repo": repo}})
+			return core.DoctorResult{Provider: providerName, Status: "failed", Message: "auth=ready control_plane=failed inventory=unchecked mutation=false", Checks: checks}, err
 		}
-		checks = append(checks, DoctorCheck{Status: "ok", Check: "machines", Details: map[string]string{"repo": repo}})
+		checks = append(checks, core.DoctorCheck{Status: "ok", Check: "machines", Details: map[string]string{"repo": repo}})
 	} else {
-		checks = append(checks, DoctorCheck{Status: "warning", Check: "repo", Message: repoErr.Error()})
+		checks = append(checks, core.DoctorCheck{Status: "warning", Check: "repo", Message: repoErr.Error()})
 	}
 	live, err := api.listCodespaces(ctx)
 	if err != nil {
-		checks = append(checks, DoctorCheck{Status: "failed", Check: "inventory", Message: err.Error()})
-		return DoctorResult{Provider: providerName, Status: "failed", Message: "auth=ready control_plane=ready inventory=failed mutation=false", Checks: checks}, err
+		checks = append(checks, core.DoctorCheck{Status: "failed", Check: "inventory", Message: err.Error()})
+		return core.DoctorResult{Provider: providerName, Status: "failed", Message: "auth=ready control_plane=ready inventory=failed mutation=false", Checks: checks}, err
 	}
 	leases := 0
 	servers, err := b.serversFromCodespaces(live)
 	if err != nil {
-		checks = append(checks, DoctorCheck{Status: "failed", Check: "claims", Message: err.Error()})
-		return DoctorResult{Provider: providerName, Status: "failed", Message: "auth=ready control_plane=ready inventory=unsafe mutation=false", Checks: checks}, err
+		checks = append(checks, core.DoctorCheck{Status: "failed", Check: "claims", Message: err.Error()})
+		return core.DoctorResult{Provider: providerName, Status: "failed", Message: "auth=ready control_plane=ready inventory=unsafe mutation=false", Checks: checks}, err
 	}
 	leases = len(servers)
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
-		checks = append(checks, DoctorCheck{Status: "failed", Check: "claims", Message: err.Error()})
-		return DoctorResult{Provider: providerName, Status: "failed", Message: "auth=ready control_plane=ready inventory=unsafe mutation=false", Checks: checks}, err
+		checks = append(checks, core.DoctorCheck{Status: "failed", Check: "claims", Message: err.Error()})
+		return core.DoctorResult{Provider: providerName, Status: "failed", Message: "auth=ready control_plane=ready inventory=unsafe mutation=false", Checks: checks}, err
 	}
 	liveNames := make(map[string]struct{}, len(live))
 	for _, item := range live {
@@ -1140,8 +1140,8 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 			continue
 		}
 		if err := b.validateClaimScope(claim, user); err != nil {
-			checks = append(checks, DoctorCheck{Status: "failed", Check: "claim-scope", Message: err.Error(), Details: map[string]string{"lease": claim.LeaseID}})
-			return DoctorResult{Provider: providerName, Status: "failed", Message: "auth=ready control_plane=ready inventory=unsafe mutation=false", Checks: checks}, err
+			checks = append(checks, core.DoctorCheck{Status: "failed", Check: "claim-scope", Message: err.Error(), Details: map[string]string{"lease": claim.LeaseID}})
+			return core.DoctorResult{Provider: providerName, Status: "failed", Message: "auth=ready control_plane=ready inventory=unsafe mutation=false", Checks: checks}, err
 		}
 		name := strings.ToLower(strings.TrimSpace(claim.CloudID))
 		if name != "" {
@@ -1151,10 +1151,10 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 		}
 	}
 	if stranded > 0 {
-		checks = append(checks, DoctorCheck{Status: "warning", Check: "claims", Message: "local claims are absent from current GitHub Codespaces inventory", Details: map[string]string{"stranded": strconv.Itoa(stranded)}})
+		checks = append(checks, core.DoctorCheck{Status: "warning", Check: "claims", Message: "local claims are absent from current GitHub Codespaces inventory", Details: map[string]string{"stranded": strconv.Itoa(stranded)}})
 	}
-	checks = append(checks, DoctorCheck{Status: "ok", Check: "inventory", Details: map[string]string{"leases": strconv.Itoa(leases)}})
-	return DoctorResult{Provider: providerName, Message: fmt.Sprintf("auth=ready control_plane=ready inventory=ready api=list mutation=false leases=%d stranded=%d runtime=unchecked", leases, stranded), Checks: checks}, nil
+	checks = append(checks, core.DoctorCheck{Status: "ok", Check: "inventory", Details: map[string]string{"leases": strconv.Itoa(leases)}})
+	return core.DoctorResult{Provider: providerName, Message: fmt.Sprintf("auth=ready control_plane=ready inventory=ready api=list mutation=false leases=%d stranded=%d runtime=unchecked", leases, stranded), Checks: checks}, nil
 }
 
 func (b *backend) controlPlane(ctx context.Context) (githubCLI, codespacesAPI, githubUser, error) {
@@ -1178,7 +1178,7 @@ func (b *backend) controlPlane(ctx context.Context) (githubCLI, codespacesAPI, g
 	return gh, api, user, nil
 }
 
-func githubCodespacesTokenFromEnv(cfg GitHubCodespacesConfig) string {
+func githubCodespacesTokenFromEnv(cfg core.GitHubCodespacesConfig) string {
 	names := []string{"GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"}
 	if githubCodespacesUsesDotcomTokenEnv(cfg) {
 		names = []string{"GH_TOKEN", "GITHUB_TOKEN"}
@@ -1209,7 +1209,7 @@ func (b *backend) waitForAvailable(ctx context.Context, api codespacesAPI, name 
 				return true, nil
 			}
 			if codespaceTerminal(item.State) {
-				return false, exit(5, "github-codespaces codespace %s entered terminal state=%s", name, item.State)
+				return false, core.Exit(5, "github-codespaces codespace %s entered terminal state=%s", name, item.State)
 			}
 			return false, nil
 		}, nil)
@@ -1233,7 +1233,7 @@ func (b *backend) waitForStopped(ctx context.Context, api codespacesAPI, name st
 				return true, nil
 			}
 			if codespaceTerminal(item.State) {
-				return false, exit(5, "github-codespaces codespace %s entered terminal state=%s while stopping", name, item.State)
+				return false, core.Exit(5, "github-codespaces codespace %s entered terminal state=%s while stopping", name, item.State)
 			}
 			return false, nil
 		}, nil)
@@ -1272,10 +1272,10 @@ func waitForCodespaceDeleted(ctx context.Context, api codespacesAPI, name string
 	return err
 }
 
-func (b *backend) sshTargetWithConfig(ctx context.Context, gh githubCLI, codespaceName, repo string) (SSHTarget, string, error) {
+func (b *backend) sshTargetWithConfig(ctx context.Context, gh githubCLI, codespaceName, repo string) (core.SSHTarget, string, error) {
 	data, err := gh.codespaceSSHConfig(ctx, codespaceName)
 	if err != nil {
-		return SSHTarget{}, "", err
+		return core.SSHTarget{}, "", err
 	}
 	cfg := b.cfg
 	cfg = b.repoConfig(repo)
@@ -1290,17 +1290,17 @@ func (b *backend) sshPrerequisiteError(err error) error {
 	return fmt.Errorf("%w; github-codespaces requires an SSH server in the devcontainer image (for example ghcr.io/devcontainers/features/sshd:1) and git, rsync, and tar in the codespace", err)
 }
 
-func (b *backend) resolveRepo(repo Repo) (string, error) {
+func (b *backend) resolveRepo(repo core.Repo) (string, error) {
 	if configured := strings.TrimSpace(b.cfg.GitHubCodespaces.Repo); configured != "" {
 		if !validRepo(configured) {
-			return "", exit(2, "github-codespaces repo must be owner/name")
+			return "", core.Exit(2, "github-codespaces repo must be owner/name")
 		}
 		return configured, nil
 	}
 	if parsed := repoFromRemote(repo.RemoteURL); parsed != "" {
 		return parsed, nil
 	}
-	return "", exit(2, "github-codespaces repo is required; set githubCodespaces.repo or --github-codespaces-repo")
+	return "", core.Exit(2, "github-codespaces repo is required; set githubCodespaces.repo or --github-codespaces-repo")
 }
 
 func (b *backend) githubIdleTimeout() time.Duration {
@@ -1322,7 +1322,7 @@ func (b *backend) effectiveMachine() string {
 
 func (b *backend) effectiveWorkRoot(repo string) string {
 	workRoot := strings.TrimSpace(b.cfg.GitHubCodespaces.WorkRoot)
-	if workRootExplicit(&b.cfg) && strings.TrimSpace(b.cfg.WorkRoot) != "" && (workRoot == "" || workRoot == defaultWorkRoot) {
+	if core.IsWorkRootExplicit(&b.cfg) && strings.TrimSpace(b.cfg.WorkRoot) != "" && (workRoot == "" || workRoot == defaultWorkRoot) {
 		return strings.TrimSpace(b.cfg.WorkRoot)
 	}
 	repoName := repoName(repo)
@@ -1338,7 +1338,7 @@ func (b *backend) effectiveWorkRoot(repo string) string {
 	return workRoot
 }
 
-func (b *backend) repoConfig(repo string) Config {
+func (b *backend) repoConfig(repo string) core.Config {
 	cfg := b.cfg
 	cfg.GitHubCodespaces.WorkRoot = b.effectiveWorkRoot(repo)
 	cfg.WorkRoot = cfg.GitHubCodespaces.WorkRoot
@@ -1347,7 +1347,7 @@ func (b *backend) repoConfig(repo string) Config {
 
 func githubCodespacesDisplayName(leaseID, slug, recoveryNonce string) string {
 	const maxDisplayNameLength = 48
-	name := leaseProviderName(leaseID, slug)
+	name := core.LeaseProviderName(leaseID, slug)
 	const prefix = "crabbox-"
 	nonceHash := sha256.Sum256([]byte(recoveryNonce))
 	nonceSuffix := fmt.Sprintf("-%x", nonceHash[:8])
@@ -1387,7 +1387,7 @@ func (b *backend) labelsFor(leaseID, slug, repo, login string, keep bool, releas
 	if len(users) > 0 {
 		user = users[0]
 	}
-	labels := directLeaseLabels(cfg, leaseID, slug, providerName, "", keep, b.now().UTC())
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, b.now().UTC())
 	labels[labelState] = state
 	labels[labelRelease] = release
 	labels[labelCodespaceName] = item.Name
@@ -1412,8 +1412,8 @@ func (b *backend) labelsFor(leaseID, slug, repo, login string, keep bool, releas
 	return labels
 }
 
-func (b *backend) serverFromCodespace(item codespace, labels map[string]string) Server {
-	server := Server{
+func (b *backend) serverFromCodespace(item codespace, labels map[string]string) core.Server {
+	server := core.Server{
 		CloudID:  item.Name,
 		Provider: providerName,
 		Name:     item.Name,
@@ -1424,12 +1424,12 @@ func (b *backend) serverFromCodespace(item codespace, labels map[string]string) 
 	return server
 }
 
-func (b *backend) serversFromCodespaces(items []codespace) ([]LeaseView, error) {
-	claims, err := listLeaseClaims()
+func (b *backend) serversFromCodespaces(items []codespace) ([]core.LeaseView, error) {
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return nil, err
 	}
-	byName := map[string]LeaseClaim{}
+	byName := map[string]core.LeaseClaim{}
 	for _, claim := range claims {
 		if claim.Provider != providerName {
 			continue
@@ -1440,24 +1440,24 @@ func (b *backend) serversFromCodespaces(items []codespace) ([]LeaseView, error) 
 			continue
 		}
 		if cloudID == "" || labelName == "" || cloudID != labelName {
-			return nil, exit(3, "github-codespaces claim %s has inconsistent resource identity: cloud_id=%q label=%q", claim.LeaseID, cloudID, labelName)
+			return nil, core.Exit(3, "github-codespaces claim %s has inconsistent resource identity: cloud_id=%q label=%q", claim.LeaseID, cloudID, labelName)
 		}
 		key := strings.ToLower(cloudID)
 		if other, exists := byName[key]; exists {
-			return nil, exit(3, "multiple github-codespaces claims bind resource %s: leases=%s,%s", cloudID, other.LeaseID, claim.LeaseID)
+			return nil, core.Exit(3, "multiple github-codespaces claims bind resource %s: leases=%s,%s", cloudID, other.LeaseID, claim.LeaseID)
 		}
 		byName[key] = claim
 	}
-	servers := make([]LeaseView, 0, len(items))
+	servers := make([]core.LeaseView, 0, len(items))
 	seenLive := make(map[string]struct{}, len(items))
 	for _, item := range items {
 		name := strings.TrimSpace(item.Name)
 		if name == "" {
-			return nil, exit(3, "github-codespaces inventory returned a resource without a name")
+			return nil, core.Exit(3, "github-codespaces inventory returned a resource without a name")
 		}
 		key := strings.ToLower(name)
 		if _, exists := seenLive[key]; exists {
-			return nil, exit(3, "github-codespaces inventory returned duplicate resource name %s", name)
+			return nil, core.Exit(3, "github-codespaces inventory returned duplicate resource name %s", name)
 		}
 		seenLive[key] = struct{}{}
 		claim, ok := byName[key]
@@ -1477,21 +1477,21 @@ func (b *backend) serversFromCodespaces(items []codespace) ([]LeaseView, error) 
 	return servers, nil
 }
 
-func (b *backend) resolveServer(items []codespace, id string) (Server, string, error) {
+func (b *backend) resolveServer(items []codespace, id string) (core.Server, string, error) {
 	servers, err := b.serversFromCodespaces(items)
 	if err != nil {
-		return Server{}, "", err
+		return core.Server{}, "", err
 	}
-	server, leaseID, err := findServerByAlias(servers, id)
+	server, leaseID, err := core.FindServerByAlias(servers, id)
 	if err != nil {
-		return Server{}, "", err
+		return core.Server{}, "", err
 	}
 	if leaseID != "" || server.CloudID != "" {
 		return server, leaseID, nil
 	}
 	claim, ok, err := resolveUniqueGitHubCodespacesClaim(id)
 	if err != nil {
-		return Server{}, "", err
+		return core.Server{}, "", err
 	}
 	if ok {
 		name := firstNonEmpty(claim.CloudID, claim.Labels[labelCodespaceName])
@@ -1508,18 +1508,18 @@ func (b *backend) resolveServer(items []codespace, id string) (Server, string, e
 		if item.Name == id {
 			claim, ok, err := resolveUniqueGitHubCodespacesClaim(item.Name)
 			if err != nil {
-				return Server{}, "", err
+				return core.Server{}, "", err
 			}
 			if !ok {
-				return Server{}, "", exit(3, "refusing unmanaged github-codespaces codespace=%s without local claim", item.Name)
+				return core.Server{}, "", core.Exit(3, "refusing unmanaged github-codespaces codespace=%s without local claim", item.Name)
 			}
 			return b.serverFromCodespace(item, cloneLabels(claim.Labels)), claim.LeaseID, nil
 		}
 	}
-	return Server{}, "", nil
+	return core.Server{}, "", nil
 }
 
-func (b *backend) mergeLiveServer(server Server, item codespace) Server {
+func (b *backend) mergeLiveServer(server core.Server, item codespace) core.Server {
 	server.CloudID = item.Name
 	server.Provider = providerName
 	server.Name = item.Name
@@ -1544,16 +1544,16 @@ func (b *backend) mergeLiveServer(server Server, item codespace) Server {
 	return server
 }
 
-func (b *backend) validateClaimForServer(claim LeaseClaim, server Server, user githubUser) error {
+func (b *backend) validateClaimForServer(claim core.LeaseClaim, server core.Server, user githubUser) error {
 	if err := b.validateClaimScope(claim, user); err != nil {
 		return err
 	}
 	if strings.TrimSpace(claim.CloudID) != "" && server.CloudID != "" && claim.CloudID != server.CloudID {
-		return exit(3, "github-codespaces claim cloud id mismatch: claim=%s live=%s", claim.CloudID, server.CloudID)
+		return core.Exit(3, "github-codespaces claim cloud id mismatch: claim=%s live=%s", claim.CloudID, server.CloudID)
 	}
 	expectedName := strings.TrimSpace(claim.Labels[labelCodespaceName])
 	if expectedName != "" && server.CloudID != "" && expectedName != server.CloudID {
-		return exit(3, "github-codespaces claim codespace mismatch: claim=%s live=%s", expectedName, server.CloudID)
+		return core.Exit(3, "github-codespaces claim codespace mismatch: claim=%s live=%s", expectedName, server.CloudID)
 	}
 	return nil
 }
@@ -1565,7 +1565,7 @@ func (b *backend) stderr() io.Writer {
 	return io.Discard
 }
 
-func githubCodespacesDeleteOnRelease(lease LeaseTarget, cfg Config) bool {
+func githubCodespacesDeleteOnRelease(lease core.LeaseTarget, cfg core.Config) bool {
 	if deleteOnReleaseExplicit(cfg) {
 		return cfg.GitHubCodespaces.DeleteOnRelease
 	}
@@ -1608,10 +1608,10 @@ func codespaceTerminal(state string) bool {
 
 func validateStopPreservesCodespace(item codespace) error {
 	if item.RetentionPeriodMinutes == nil {
-		return exit(3, "refusing to stop github-codespaces codespace=%s without an effective retention period", item.Name)
+		return core.Exit(3, "refusing to stop github-codespaces codespace=%s without an effective retention period", item.Name)
 	}
 	if *item.RetentionPeriodMinutes <= 0 {
-		return exit(3, "refusing to stop github-codespaces codespace=%s because effective retention is zero", item.Name)
+		return core.Exit(3, "refusing to stop github-codespaces codespace=%s because effective retention is zero", item.Name)
 	}
 	return nil
 }
@@ -1631,18 +1631,18 @@ func (e *unsafeCodespaceDeleteError) Unwrap() error {
 func validateDeleteSafe(item codespace) error {
 	status := item.GitStatus
 	if !status.deletionSafetyKnown() {
-		return &unsafeCodespaceDeleteError{err: exit(3, "refusing to delete github-codespaces codespace=%s because Git status safety fields are missing", item.Name)}
+		return &unsafeCodespaceDeleteError{err: core.Exit(3, "refusing to delete github-codespaces codespace=%s because Git status safety fields are missing", item.Name)}
 	}
 	if status.HasUncommittedChanges || status.HasUnpushedChanges || status.Ahead > 0 {
-		return &unsafeCodespaceDeleteError{err: exit(3, "refusing to delete github-codespaces codespace=%s with uncommitted or unpushed changes", item.Name)}
+		return &unsafeCodespaceDeleteError{err: core.Exit(3, "refusing to delete github-codespaces codespace=%s with uncommitted or unpushed changes", item.Name)}
 	}
 	return nil
 }
 
-func validateCodespaceClaimResource(claim LeaseClaim, item codespace) error {
+func validateCodespaceClaimResource(claim core.LeaseClaim, item codespace) error {
 	expectedName := strings.TrimSpace(claim.Labels[labelCodespaceName])
 	if expectedName == "" || strings.TrimSpace(claim.CloudID) != expectedName || strings.TrimSpace(item.Name) != expectedName {
-		return exit(4, "refusing github-codespaces delete for lease=%s after resource identity changed", claim.LeaseID)
+		return core.Exit(4, "refusing github-codespaces delete for lease=%s after resource identity changed", claim.LeaseID)
 	}
 	for _, identity := range []struct {
 		label string
@@ -1656,17 +1656,17 @@ func validateCodespaceClaimResource(claim LeaseClaim, item codespace) error {
 	} {
 		expected := strings.TrimSpace(claim.Labels[identity.label])
 		if expected == "" || strings.TrimSpace(identity.live) == "" {
-			return exit(4, "refusing github-codespaces mutation for lease=%s without complete %s identity", claim.LeaseID, identity.name)
+			return core.Exit(4, "refusing github-codespaces mutation for lease=%s without complete %s identity", claim.LeaseID, identity.name)
 		}
 		if strings.TrimSpace(identity.live) != expected {
-			return exit(4, "refusing github-codespaces delete for lease=%s after %s changed", claim.LeaseID, identity.name)
+			return core.Exit(4, "refusing github-codespaces delete for lease=%s after %s changed", claim.LeaseID, identity.name)
 		}
 	}
 	return nil
 }
 
-func serverFromClaim(claim LeaseClaim) Server {
-	server := Server{
+func serverFromClaim(claim core.LeaseClaim) core.Server {
+	server := core.Server{
 		CloudID:  firstNonEmpty(claim.CloudID, claim.Labels[labelCodespaceName]),
 		Provider: providerName,
 		Name:     firstNonEmpty(claim.CloudID, claim.Labels[labelCodespaceName]),
@@ -1709,7 +1709,7 @@ func cloneLabels(labels map[string]string) map[string]string {
 	return out
 }
 
-func repoRootForClaim(repo Repo) (string, error) {
+func repoRootForClaim(repo core.Repo) (string, error) {
 	if strings.TrimSpace(repo.Root) != "" {
 		return repo.Root, nil
 	}

--- a/internal/providers/githubcodespaces/backend_test.go
+++ b/internal/providers/githubcodespaces/backend_test.go
@@ -24,8 +24,8 @@ func TestAcquireCreatesClaimGeneratesSSHConfigAndWaitsReady(t *testing.T) {
 	fg := &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"}
 	b := newTestBackend(t, fc, fg)
 
-	lease, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:          Repo{Root: t.TempDir(), Name: "my-app"},
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:          core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedSlug: "green-box",
 	})
 	if err != nil {
@@ -56,7 +56,7 @@ func TestAcquireCreatesClaimGeneratesSSHConfigAndWaitsReady(t *testing.T) {
 	if !strings.Contains(wait.ReadyCheck, "test -d '/workspaces/my-app'") {
 		t.Fatalf("ready check=%q", wait.ReadyCheck)
 	}
-	claim, ok, err := resolveLeaseClaimForProvider(lease.LeaseID, providerName)
+	claim, ok, err := core.ResolveLeaseClaimForProvider(lease.LeaseID, providerName)
 	if err != nil || !ok {
 		t.Fatalf("claim ok=%t err=%v", ok, err)
 	}
@@ -76,7 +76,7 @@ func TestAcquireUsesExplicitGenericServerType(t *testing.T) {
 	b.cfg.ServerType = "premiumLinux"
 	b.cfg.ServerTypeExplicit = true
 
-	if _, err := b.Acquire(context.Background(), AcquireRequest{Repo: Repo{Root: t.TempDir(), Name: "my-app"}}); err != nil {
+	if _, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir(), Name: "my-app"}}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fc.creates) != 1 || fc.creates[0].Machine != "premiumLinux" {
@@ -92,7 +92,7 @@ func TestAcquirePersistsRecoveryClaimBeforeCreate(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789aa1"
 	fc.onCreate = func(req createCodespaceRequest) {
-		claim, ok, err := resolveLeaseClaimForProvider(leaseID, providerName)
+		claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
 		if err != nil || !ok {
 			t.Fatalf("pre-create claim ok=%t err=%v", ok, err)
 		}
@@ -104,8 +104,8 @@ func TestAcquirePersistsRecoveryClaimBeforeCreate(t *testing.T) {
 		}
 	}
 
-	lease, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: leaseID,
 		RequestedSlug:    "durable-box",
 	})
@@ -131,13 +131,13 @@ func TestAcquireRecoversAmbiguousCreateByExactIdentity(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	callbackCalled := false
 
-	lease, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: "cbx_123456789aa2",
 		RequestedSlug:    "recovered-box",
-		OnAcquired: func(lease LeaseTarget) error {
+		OnAcquired: func(lease core.LeaseTarget) error {
 			callbackCalled = true
-			claim, ok, claimErr := resolveLeaseClaimForProvider(lease.LeaseID, providerName)
+			claim, ok, claimErr := core.ResolveLeaseClaimForProvider(lease.LeaseID, providerName)
 			if claimErr != nil || !ok || claim.CloudID != "" || claim.Labels[labelRecovery] != recoveryPreCreate {
 				t.Fatalf("claim was bound before callback: claim=%#v ok=%t err=%v", claim, ok, claimErr)
 			}
@@ -150,7 +150,7 @@ func TestAcquireRecoversAmbiguousCreateByExactIdentity(t *testing.T) {
 	if !callbackCalled || lease.Server.CloudID != "cs-recovered" || len(fc.deletes) != 0 {
 		t.Fatalf("lease=%#v deletes=%#v", lease, fc.deletes)
 	}
-	claim, ok, err := resolveLeaseClaimForProvider(lease.LeaseID, providerName)
+	claim, ok, err := core.ResolveLeaseClaimForProvider(lease.LeaseID, providerName)
 	if err != nil || !ok || claim.CloudID != "cs-recovered" || claim.Labels[labelRecovery] != "" {
 		t.Fatalf("claim=%#v ok=%t err=%v", claim, ok, err)
 	}
@@ -169,8 +169,8 @@ func TestAcquireRecoversIdentitylessSuccessByExactIdentity(t *testing.T) {
 	fg := &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"}
 	b := newTestBackend(t, fc, fg)
 
-	lease, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: "cbx_123456789aa8",
 		RequestedSlug:    "identityless-box",
 	})
@@ -205,11 +205,11 @@ func TestAcquireRejectsIncompletePermanentIdentity(t *testing.T) {
 			leaseID := "cbx_123456789ab2"
 			callbackCalled := false
 
-			_, err := b.Acquire(context.Background(), AcquireRequest{
-				Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+			_, err := b.Acquire(context.Background(), core.AcquireRequest{
+				Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 				RequestedLeaseID: leaseID,
 				RequestedSlug:    "incomplete-box",
-				OnAcquired: func(LeaseTarget) error {
+				OnAcquired: func(core.LeaseTarget) error {
 					callbackCalled = true
 					return nil
 				},
@@ -220,7 +220,7 @@ func TestAcquireRejectsIncompletePermanentIdentity(t *testing.T) {
 			if callbackCalled || len(fc.deletes) != 0 {
 				t.Fatalf("callback=%t deletes=%#v", callbackCalled, fc.deletes)
 			}
-			claim, ok, claimErr := readLeaseClaimWithPresence(leaseID)
+			claim, ok, claimErr := core.ReadLeaseClaimWithPresence(leaseID)
 			if claimErr != nil || !ok || claim.CloudID != "" || claim.Labels[labelRecovery] != recoveryPreCreate {
 				t.Fatalf("claim=%#v ok=%t err=%v", claim, ok, claimErr)
 			}
@@ -236,8 +236,8 @@ func TestAcquireAcceptsRenamedOwnerWithSameUserID(t *testing.T) {
 	fc.createResult.Owner.Login = "alice-renamed"
 	b := newTestBackend(t, fc, &fakeGH{login: "alice", token: "test" + "-value"})
 
-	lease, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: "cbx_123456789af1",
 		RequestedSlug:    "renamed-owner-box",
 	})
@@ -262,8 +262,8 @@ func TestAcquireRejectsAndRollsBackZeroEffectiveRetention(t *testing.T) {
 	b := newTestBackend(t, fc, &fakeGH{login: "alice", token: "test" + "-value"})
 	leaseID := "cbx_123456789af7"
 
-	_, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: leaseID,
 		RequestedSlug:    "zero-effective-retention",
 	})
@@ -273,7 +273,7 @@ func TestAcquireRejectsAndRollsBackZeroEffectiveRetention(t *testing.T) {
 	if strings.Join(fc.deletes, ",") != "cs-zero-effective-retention" {
 		t.Fatalf("deletes=%#v", fc.deletes)
 	}
-	if _, ok, claimErr := readLeaseClaimWithPresence(leaseID); claimErr != nil || ok {
+	if _, ok, claimErr := core.ReadLeaseClaimWithPresence(leaseID); claimErr != nil || ok {
 		t.Fatalf("claim ok=%t err=%v", ok, claimErr)
 	}
 }
@@ -281,7 +281,7 @@ func TestAcquireRejectsAndRollsBackZeroEffectiveRetention(t *testing.T) {
 func TestValidateClaimScopeAcceptsRenamedLoginForSameUserID(t *testing.T) {
 	b := newTestBackend(t, newFakeCodespacesClient(), &fakeGH{login: "alice", token: "test" + "-value"})
 	user := fakeGitHubUser("alice")
-	claim := LeaseClaim{
+	claim := core.LeaseClaim{
 		LeaseID:       "cbx_123456789af2",
 		Provider:      providerName,
 		ProviderScope: providerClaimScope(b.claimConfig("example-org/my-app")),
@@ -305,15 +305,15 @@ func TestAcquireRetainsClaimWhenAmbiguousCreateHasNoMatch(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789aa3"
 
-	_, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: leaseID,
 		RequestedSlug:    "pending-box",
 	})
 	if err == nil || !strings.Contains(err.Error(), "claim retained") {
 		t.Fatalf("err=%v", err)
 	}
-	claim, ok, claimErr := resolveLeaseClaimForProvider(leaseID, providerName)
+	claim, ok, claimErr := core.ResolveLeaseClaimForProvider(leaseID, providerName)
 	if claimErr != nil || !ok || claim.CloudID != "" || claim.Labels[labelRecovery] != recoveryPreCreate {
 		t.Fatalf("claim=%#v ok=%t err=%v", claim, ok, claimErr)
 	}
@@ -337,8 +337,8 @@ func TestAcquireRejectsDuplicateRecoveryMatches(t *testing.T) {
 	fg := &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"}
 	b := newTestBackend(t, fc, fg)
 
-	_, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: "cbx_123456789aa4",
 		RequestedSlug:    "duplicate-box",
 	})
@@ -358,15 +358,15 @@ func TestAcquireDiscardsClaimAfterDefinitiveCreateRejection(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789aa5"
 
-	_, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: leaseID,
 		RequestedSlug:    "rejected-box",
 	})
 	if err == nil || !strings.Contains(err.Error(), "status=422") {
 		t.Fatalf("err=%v", err)
 	}
-	if _, ok, claimErr := resolveLeaseClaimForProvider(leaseID, providerName); claimErr != nil || ok {
+	if _, ok, claimErr := core.ResolveLeaseClaimForProvider(leaseID, providerName); claimErr != nil || ok {
 		t.Fatalf("claim retained ok=%t err=%v", ok, claimErr)
 	}
 	if len(fc.deletes) != 0 {
@@ -379,13 +379,13 @@ func TestAcquireRollsBackExactCreateWhenClaimBindingFails(t *testing.T) {
 	fc := newFakeCodespacesClient()
 	fg := &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"}
 	b := newTestBackend(t, fc, fg)
-	b.bindClaim = func(_ string, expected LeaseClaim, _ Server) (LeaseClaim, error) {
+	b.bindClaim = func(_ string, expected core.LeaseClaim, _ core.Server) (core.LeaseClaim, error) {
 		return expected, errors.New("claim write failed")
 	}
 	leaseID := "cbx_123456789aa9"
 
-	_, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: leaseID,
 		RequestedSlug:    "bind-failure-box",
 	})
@@ -398,7 +398,7 @@ func TestAcquireRollsBackExactCreateWhenClaimBindingFails(t *testing.T) {
 	if !fc.deleteDeadline {
 		t.Fatal("rollback delete context had no deadline")
 	}
-	if _, ok, claimErr := resolveLeaseClaimForProvider(leaseID, providerName); claimErr != nil || ok {
+	if _, ok, claimErr := core.ResolveLeaseClaimForProvider(leaseID, providerName); claimErr != nil || ok {
 		t.Fatalf("claim retained ok=%t err=%v", ok, claimErr)
 	}
 }
@@ -409,17 +409,17 @@ func TestAcquireDoesNotRollbackWhenPendingClaimRaces(t *testing.T) {
 	fg := &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"}
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789aaa"
-	b.bindClaim = func(_ string, expected LeaseClaim, _ Server) (LeaseClaim, error) {
+	b.bindClaim = func(_ string, expected core.LeaseClaim, _ core.Server) (core.LeaseClaim, error) {
 		server := serverFromClaim(expected)
 		server.Labels["raced"] = "true"
-		if err := updateLeaseClaimEndpoint(expected.LeaseID, server, SSHTarget{}); err != nil {
+		if err := core.UpdateLeaseClaimEndpoint(expected.LeaseID, server, core.SSHTarget{}); err != nil {
 			t.Fatal(err)
 		}
 		return expected, errors.New("claim raced")
 	}
 
-	_, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: leaseID,
 		RequestedSlug:    "race-box",
 	})
@@ -429,7 +429,7 @@ func TestAcquireDoesNotRollbackWhenPendingClaimRaces(t *testing.T) {
 	if len(fc.deletes) != 0 {
 		t.Fatalf("deleted after claim race=%#v", fc.deletes)
 	}
-	claim, ok, claimErr := resolveLeaseClaimForProvider(leaseID, providerName)
+	claim, ok, claimErr := core.ResolveLeaseClaimForProvider(leaseID, providerName)
 	if claimErr != nil || !ok || claim.Labels[labelRecovery] != recoveryPreCreate || claim.Labels["raced"] != "true" {
 		t.Fatalf("claim=%#v ok=%t err=%v", claim, ok, claimErr)
 	}
@@ -443,17 +443,17 @@ func TestAcquireOnAcquiredErrorRollsBackEvenWhenKept(t *testing.T) {
 	callbackErr := errors.New("controller rejected identity")
 	called := false
 
-	_, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: leaseID,
 		RequestedSlug:    "callback-box",
 		Keep:             true,
-		OnAcquired: func(lease LeaseTarget) error {
+		OnAcquired: func(lease core.LeaseTarget) error {
 			called = true
 			if lease.LeaseID != leaseID || lease.Server.CloudID != "cs-1" || lease.SSH.Host != "" {
 				t.Fatalf("callback lease=%#v", lease)
 			}
-			claim, ok, claimErr := resolveLeaseClaimForProvider(leaseID, providerName)
+			claim, ok, claimErr := core.ResolveLeaseClaimForProvider(leaseID, providerName)
 			if claimErr != nil || !ok || claim.CloudID != "" || claim.Labels[labelRecovery] != recoveryPreCreate {
 				t.Fatalf("claim was bound before callback: claim=%#v ok=%t err=%v", claim, ok, claimErr)
 			}
@@ -466,7 +466,7 @@ func TestAcquireOnAcquiredErrorRollsBackEvenWhenKept(t *testing.T) {
 	if got := strings.Join(fc.deletes, ","); got != "cs-1" {
 		t.Fatalf("deletes=%q", got)
 	}
-	if _, ok, claimErr := readLeaseClaimWithPresence(leaseID); claimErr != nil || ok {
+	if _, ok, claimErr := core.ReadLeaseClaimWithPresence(leaseID); claimErr != nil || ok {
 		t.Fatalf("claim retained ok=%t err=%v", ok, claimErr)
 	}
 }
@@ -478,11 +478,11 @@ func TestAcquireOnAcquiredErrorRetainsPendingClaimWhenRollbackCannotConfirmResou
 	leaseID := "cbx_123456789ab0"
 	callbackErr := errors.New("controller rejected identity")
 
-	_, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: leaseID,
 		RequestedSlug:    "callback-missing-box",
-		OnAcquired: func(lease LeaseTarget) error {
+		OnAcquired: func(lease core.LeaseTarget) error {
 			delete(fc.items, lease.Server.CloudID)
 			return callbackErr
 		},
@@ -493,7 +493,7 @@ func TestAcquireOnAcquiredErrorRetainsPendingClaimWhenRollbackCannotConfirmResou
 	if len(fc.deletes) != 0 {
 		t.Fatalf("deleted unconfirmed resource=%#v", fc.deletes)
 	}
-	claim, ok, claimErr := readLeaseClaimWithPresence(leaseID)
+	claim, ok, claimErr := core.ReadLeaseClaimWithPresence(leaseID)
 	if claimErr != nil || !ok || claim.CloudID != "" || claim.Labels[labelRecovery] != recoveryPreCreate {
 		t.Fatalf("claim=%#v ok=%t err=%v", claim, ok, claimErr)
 	}
@@ -513,11 +513,11 @@ func TestAcquireOnAcquiredErrorRetainsClaimWhenResourceDisappearsAfterPreflight(
 	leaseID := "cbx_123456789ab4"
 	callbackErr := errors.New("controller rejected identity")
 
-	_, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: leaseID,
 		RequestedSlug:    "callback-vanished-box",
-		OnAcquired: func(LeaseTarget) error {
+		OnAcquired: func(core.LeaseTarget) error {
 			return callbackErr
 		},
 	})
@@ -527,7 +527,7 @@ func TestAcquireOnAcquiredErrorRetainsClaimWhenResourceDisappearsAfterPreflight(
 	if getCount != 2 || len(fc.deletes) != 0 {
 		t.Fatalf("gets=%d deletes=%#v", getCount, fc.deletes)
 	}
-	claim, ok, claimErr := readLeaseClaimWithPresence(leaseID)
+	claim, ok, claimErr := core.ReadLeaseClaimWithPresence(leaseID)
 	if claimErr != nil || !ok || claim.CloudID != "" || claim.Labels[labelRecovery] != recoveryPreCreate {
 		t.Fatalf("claim=%#v ok=%t err=%v", claim, ok, claimErr)
 	}
@@ -541,10 +541,10 @@ func TestRollbackCreatedCodespaceRetainsClaimWhenResourceDisappearsAfterPrefligh
 	b := newTestBackend(t, fc, &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"})
 	leaseID := "cbx_123456789ab6"
 	server := b.serverFromCodespace(item, b.labelsFor(leaseID, "rollback-missing-box", "example-org/my-app", "alice", false, releaseDelete, item, "ready"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "rollback-missing-box", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "rollback-missing-box", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
-	claim, ok, err := readLeaseClaimWithPresence(leaseID)
+	claim, ok, err := core.ReadLeaseClaimWithPresence(leaseID)
 	if err != nil || !ok {
 		t.Fatalf("claim=%#v ok=%t err=%v", claim, ok, err)
 	}
@@ -563,7 +563,7 @@ func TestRollbackCreatedCodespaceRetainsClaimWhenResourceDisappearsAfterPrefligh
 	if getCount != 2 || len(fc.deletes) != 0 {
 		t.Fatalf("gets=%d deletes=%#v", getCount, fc.deletes)
 	}
-	retained, ok, claimErr := readLeaseClaimWithPresence(leaseID)
+	retained, ok, claimErr := core.ReadLeaseClaimWithPresence(leaseID)
 	if claimErr != nil || !ok || retained.CloudID != item.Name {
 		t.Fatalf("claim=%#v ok=%t err=%v", retained, ok, claimErr)
 	}
@@ -576,11 +576,11 @@ func TestAcquireOnAcquiredErrorRollsBackAfterDisplayNameChanges(t *testing.T) {
 	leaseID := "cbx_123456789ab5"
 	callbackErr := errors.New("controller rejected identity")
 
-	_, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: leaseID,
 		RequestedSlug:    "callback-renamed-box",
-		OnAcquired: func(lease LeaseTarget) error {
+		OnAcquired: func(lease core.LeaseTarget) error {
 			item := fc.items[lease.Server.CloudID]
 			item.DisplayName = "renamed-after-create"
 			fc.items[item.Name] = item
@@ -593,7 +593,7 @@ func TestAcquireOnAcquiredErrorRollsBackAfterDisplayNameChanges(t *testing.T) {
 	if got := strings.Join(fc.deletes, ","); got != "cs-1" {
 		t.Fatalf("deletes=%q", got)
 	}
-	if _, ok, claimErr := readLeaseClaimWithPresence(leaseID); claimErr != nil || ok {
+	if _, ok, claimErr := core.ReadLeaseClaimWithPresence(leaseID); claimErr != nil || ok {
 		t.Fatalf("claim retained ok=%t err=%v", ok, claimErr)
 	}
 }
@@ -607,8 +607,8 @@ func TestAcquireRetainsClaimAndRefusesRollbackAfterReadyIdentityChanges(t *testi
 	b := newTestBackend(t, fc, &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"})
 	leaseID := "cbx_123456789ab0"
 
-	_, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: leaseID,
 		RequestedSlug:    "replacement-box",
 	})
@@ -618,7 +618,7 @@ func TestAcquireRetainsClaimAndRefusesRollbackAfterReadyIdentityChanges(t *testi
 	if len(fc.deletes) != 0 {
 		t.Fatalf("replacement deleted: %#v", fc.deletes)
 	}
-	claim, ok, claimErr := readLeaseClaimWithPresence(leaseID)
+	claim, ok, claimErr := core.ReadLeaseClaimWithPresence(leaseID)
 	if claimErr != nil || !ok || claim.CloudID != "cs-1" {
 		t.Fatalf("claim=%#v ok=%t err=%v", claim, ok, claimErr)
 	}
@@ -632,15 +632,15 @@ func TestReleaseRecoversPendingCreateThenDeletesExactResource(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789aa6"
 
-	_, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: leaseID,
 		RequestedSlug:    "later-box",
 	})
 	if err == nil {
 		t.Fatal("acquire unexpectedly succeeded")
 	}
-	claim, ok, err := resolveLeaseClaimForProvider(leaseID, providerName)
+	claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
 	if err != nil || !ok {
 		t.Fatalf("pending claim ok=%t err=%v", ok, err)
 	}
@@ -649,13 +649,13 @@ func TestReleaseRecoversPendingCreateThenDeletesExactResource(t *testing.T) {
 	item.Repository.FullName = "Example-Org/My-App"
 	fc.items[item.Name] = item
 
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID}}); err != nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID}}); err != nil {
 		t.Fatal(err)
 	}
 	if got := strings.Join(fc.deletes, ","); got != item.Name {
 		t.Fatalf("deletes=%q", got)
 	}
-	if _, ok, err := resolveLeaseClaimForProvider(leaseID, providerName); err != nil || ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil || ok {
 		t.Fatalf("claim retained ok=%t err=%v", ok, err)
 	}
 }
@@ -670,8 +670,8 @@ func TestAcquireKeepDoesNotOverrideDeleteOnReleasePolicy(t *testing.T) {
 	fg := &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"}
 	b := newTestBackend(t, fc, fg)
 
-	lease, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:          Repo{Root: t.TempDir(), Name: "my-app"},
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:          core.Repo{Root: t.TempDir(), Name: "my-app"},
 		Keep:          true,
 		RequestedSlug: "warm-box",
 	})
@@ -681,7 +681,7 @@ func TestAcquireKeepDoesNotOverrideDeleteOnReleasePolicy(t *testing.T) {
 	if lease.Server.Labels["keep"] != "true" || lease.Server.Labels[labelRelease] != releaseDelete {
 		t.Fatalf("labels=%#v", lease.Server.Labels)
 	}
-	claim, ok, err := resolveLeaseClaimForProvider(lease.LeaseID, providerName)
+	claim, ok, err := core.ResolveLeaseClaimForProvider(lease.LeaseID, providerName)
 	if err != nil || !ok {
 		t.Fatalf("claim ok=%t err=%v", ok, err)
 	}
@@ -698,8 +698,8 @@ func TestAcquireRetainsClaimWhenRollbackDeleteFails(t *testing.T) {
 	fg := &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"}
 	b := newTestBackend(t, fc, fg)
 
-	_, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: "cbx_123456789abc",
 		RequestedSlug:    "rollback-box",
 	})
@@ -711,7 +711,7 @@ func TestAcquireRetainsClaimWhenRollbackDeleteFails(t *testing.T) {
 			t.Fatalf("err=%q missing %q", err, want)
 		}
 	}
-	if _, ok, err := resolveLeaseClaimForProvider("cbx_123456789abc", providerName); err != nil || !ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider("cbx_123456789abc", providerName); err != nil || !ok {
 		t.Fatalf("recovery claim missing ok=%t err=%v", ok, err)
 	}
 	if !fc.deleteDeadline {
@@ -732,11 +732,11 @@ func TestResolveStartsStoppedCodespaceAndRefreshesTarget(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789abc"
 	server := b.serverFromCodespace(fc.items["cs-stopped"], b.labelsFor(leaseID, "sleepy-box", "example-org/my-app", "alice", true, releaseStop, fc.items["cs-stopped"], "stopped"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "sleepy-box", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "sleepy-box", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "sleepy-box", ReadyProbe: true})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "sleepy-box", ReadyProbe: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -746,7 +746,7 @@ func TestResolveStartsStoppedCodespaceAndRefreshesTarget(t *testing.T) {
 	if lease.Server.Status != "Available" || lease.SSH.Host != "cs.cs-stopped.main" {
 		t.Fatalf("lease=%#v", lease)
 	}
-	claim, ok, err := resolveLeaseClaimForProvider(leaseID, providerName)
+	claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
 	if err != nil || !ok {
 		t.Fatalf("claim ok=%t err=%v", ok, err)
 	}
@@ -773,11 +773,11 @@ func TestResolveWaitsForShutdownThenRestartsCodespace(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789ad0"
 	server := b.serverFromCodespace(fc.items["cs-stopping"], b.labelsFor(leaseID, "stopping-box", "example-org/my-app", "alice", true, releaseStop, fc.items["cs-stopping"], "stopping"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "stopping-box", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "stopping-box", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReadyProbe: true})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReadyProbe: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -796,11 +796,11 @@ func TestResolveShuttingDownCodespaceUsesReadyTimeout(t *testing.T) {
 	b.pollInterval = time.Hour
 	leaseID := "cbx_123456789ad1"
 	server := b.serverFromCodespace(fc.items["cs-stopping"], b.labelsFor(leaseID, "stopping-box", "example-org/my-app", "alice", true, releaseStop, fc.items["cs-stopping"], "stopping"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "stopping-box", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "stopping-box", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	_, err := b.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReadyProbe: true})
+	_, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReadyProbe: true})
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("err=%v", err)
 	}
@@ -819,11 +819,11 @@ func TestResolveWaitsForTransitionalCodespaceBeforeSSH(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789ae1"
 	server := b.serverFromCodespace(fc.items["cs-starting"], b.labelsFor(leaseID, "starting-box", "example-org/my-app", "alice", true, releaseStop, fc.items["cs-starting"], "provisioning"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "starting-box", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "starting-box", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReadyProbe: true})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReadyProbe: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -840,11 +840,11 @@ func TestResolveStatusOnlyReadyProbeDoesNotStartStoppedCodespace(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789ac5"
 	server := b.serverFromCodespace(fc.items["cs-stopped-status"], b.labelsFor(leaseID, "stopped-status-box", "example-org/my-app", "alice", true, releaseStop, fc.items["cs-stopped-status"], "stopped"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "stopped-status-box", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "stopped-status-box", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "stopped-status-box", StatusOnly: true, ReadyProbe: true, NoLocalStateMutations: true})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "stopped-status-box", StatusOnly: true, ReadyProbe: true, NoLocalStateMutations: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -864,11 +864,11 @@ func TestResolveStatusOnlyNormalizesStoppedCodespace(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789ac6"
 	server := b.serverFromCodespace(fc.items["cs-stopped-status"], b.labelsFor(leaseID, "stopped-status-box", "example-org/my-app", "alice", true, releaseStop, fc.items["cs-stopped-status"], "ready"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "stopped-status-box", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "stopped-status-box", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: leaseID, StatusOnly: true})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, StatusOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -885,11 +885,11 @@ func TestResolveNoLocalStateMutationsDoesNotStartStoppedCodespace(t *testing.T) 
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789ac7"
 	server := b.serverFromCodespace(fc.items["cs-readonly-stopped"], b.labelsFor(leaseID, "readonly-stopped", "example-org/my-app", "alice", true, releaseStop, fc.items["cs-readonly-stopped"], "stopped"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "readonly-stopped", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "readonly-stopped", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: leaseID, NoLocalStateMutations: true, ReadyProbe: true})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, NoLocalStateMutations: true, ReadyProbe: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -907,11 +907,11 @@ func TestResolveNoLocalStateMutationsDoesNotStoreSSHConfig(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789ac3"
 	server := b.serverFromCodespace(fc.items["cs-readonly"], b.labelsFor(leaseID, "readonly-box", "example-org/my-app", "alice", true, releaseStop, fc.items["cs-readonly"], "ready"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "readonly-box", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "readonly-box", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "readonly-box", NoLocalStateMutations: true})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "readonly-box", NoLocalStateMutations: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -932,11 +932,11 @@ func TestResolveStatusOnlyReadyProbeBuildsSSHTarget(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789ac4"
 	server := b.serverFromCodespace(fc.items["cs-status"], b.labelsFor(leaseID, "status-box", "example-org/my-app", "alice", false, releaseDelete, fc.items["cs-status"], "ready"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "status-box", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "status-box", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "status-box", StatusOnly: true, ReadyProbe: true})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "status-box", StatusOnly: true, ReadyProbe: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -953,7 +953,7 @@ func TestReleaseDeleteRemovesOnlyClaimBackedCodespaceAndConfig(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789abd"
 	server := b.serverFromCodespace(fc.items["cs-delete"], b.labelsFor(leaseID, "delete-box", "example-org/my-app", "alice", false, releaseDelete, fc.items["cs-delete"], "ready"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "delete-box", b.cfg, server, SSHTarget{Host: "cs-delete", Port: "22"}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "delete-box", b.cfg, server, core.SSHTarget{Host: "cs-delete", Port: "22"}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	configPath, err := storeSSHConfig(leaseID, fg.config("cs-delete"))
@@ -961,13 +961,13 @@ func TestReleaseDeleteRemovesOnlyClaimBackedCodespaceAndConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil || !outcome.Terminal {
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil || !outcome.Terminal {
 		t.Fatalf("deletion outcome=%+v err=%v", outcome, err)
 	}
 	if strings.Join(fc.deletes, ",") != "cs-delete" {
 		t.Fatalf("deletes=%#v", fc.deletes)
 	}
-	if _, ok, err := resolveLeaseClaimForProvider(leaseID, providerName); err != nil || ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil || ok {
 		t.Fatalf("claim remains ok=%t err=%v", ok, err)
 	}
 	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
@@ -984,7 +984,7 @@ func TestReleaseDeleteRetainsClaimUntilAbsenceIsConfirmed(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789ab1"
 	server := b.serverFromCodespace(fc.items["cs-delete-pending"], b.labelsFor(leaseID, "delete-pending-box", "example-org/my-app", "alice", false, releaseDelete, fc.items["cs-delete-pending"], "ready"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "delete-pending-box", b.cfg, server, SSHTarget{Host: "cs-delete-pending", Port: "22"}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "delete-pending-box", b.cfg, server, core.SSHTarget{Host: "cs-delete-pending", Port: "22"}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	configPath, err := storeSSHConfig(leaseID, fg.config("cs-delete-pending"))
@@ -994,14 +994,14 @@ func TestReleaseDeleteRetainsClaimUntilAbsenceIsConfirmed(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	fc.onDelete = func(string) { cancel() }
-	err = b.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}})
+	err = b.ReleaseLease(ctx, core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("err=%v", err)
 	}
 	if strings.Join(fc.deletes, ",") != "cs-delete-pending" {
 		t.Fatalf("deletes=%#v", fc.deletes)
 	}
-	if _, ok, claimErr := resolveLeaseClaimForProvider(leaseID, providerName); claimErr != nil || !ok {
+	if _, ok, claimErr := core.ResolveLeaseClaimForProvider(leaseID, providerName); claimErr != nil || !ok {
 		t.Fatalf("claim retained ok=%t err=%v", ok, claimErr)
 	}
 	if _, statErr := os.Stat(configPath); statErr != nil {
@@ -1017,22 +1017,22 @@ func TestReleaseDeleteRejectsClaimRaceBeforeMutation(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789aab"
 	server := b.serverFromCodespace(fc.items["cs-race-delete"], b.labelsFor(leaseID, "race-delete-box", "example-org/my-app", "alice", false, releaseDelete, fc.items["cs-race-delete"], "ready"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "race-delete-box", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "race-delete-box", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	fc.onGet = func(string) {
-		claim, ok, err := resolveLeaseClaimForProvider(leaseID, providerName)
+		claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
 		if err != nil || !ok {
 			t.Fatalf("claim ok=%t err=%v", ok, err)
 		}
 		raced := serverFromClaim(claim)
 		raced.Labels["raced"] = "true"
-		if err := updateLeaseClaimEndpoint(leaseID, raced, SSHTarget{}); err != nil {
+		if err := core.UpdateLeaseClaimEndpoint(leaseID, raced, core.SSHTarget{}); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}})
+	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
 	if err == nil || !strings.Contains(err.Error(), "claim changed") {
 		t.Fatalf("err=%v", err)
 	}
@@ -1049,7 +1049,7 @@ func TestReleaseDeleteRequiresLocalClaim(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	server := b.serverFromCodespace(fc.items["cs-orphan"], b.labelsFor("cbx_123456789ad0", "orphan-box", "example-org/my-app", "alice", false, releaseDelete, fc.items["cs-orphan"], "ready"))
 
-	err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: "cbx_123456789ad0", Server: server}})
+	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_123456789ad0", Server: server}})
 	if err == nil || !strings.Contains(err.Error(), "requires a local claim") {
 		t.Fatalf("err=%v", err)
 	}
@@ -1067,12 +1067,12 @@ func TestReleaseRefusesProviderScopeMismatch(t *testing.T) {
 	leaseID := "cbx_123456789aa7"
 	server := b.serverFromCodespace(fc.items["cs-scope"], b.labelsFor(leaseID, "scope-box", "example-org/my-app", "alice", false, releaseDelete, fc.items["cs-scope"], "ready"))
 	server.Labels[labelDisplayName] = "crabbox-scope-box"
-	if err := claimLeaseTargetForRepoConfig(leaseID, "scope-box", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "scope-box", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	b.cfg.GitHubCodespaces.APIURL = "https://api.enterprise.example"
 
-	err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}})
+	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
 	if err == nil || !strings.Contains(err.Error(), "scope mismatch") {
 		t.Fatalf("err=%v", err)
 	}
@@ -1091,27 +1091,27 @@ func TestReleaseDeleteFallsBackToStopForDirtyCodespace(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789ac2"
 	server := b.serverFromCodespace(item, b.labelsFor(leaseID, "dirty-box", "example-org/my-app", "alice", false, releaseDelete, item, "ready"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "dirty-box", b.cfg, server, SSHTarget{Host: "cs-dirty", Port: "22"}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "dirty-box", b.cfg, server, core.SSHTarget{Host: "cs-dirty", Port: "22"}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil || outcome.Terminal {
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil || outcome.Terminal {
 		t.Fatalf("dirty fallback outcome=%+v err=%v", outcome, err)
 	}
 	if strings.Join(fc.stops, ",") != "cs-dirty" || len(fc.deletes) != 0 {
 		t.Fatalf("stops=%#v deletes=%#v", fc.stops, fc.deletes)
 	}
-	claim, ok, err := resolveLeaseClaimForProvider(leaseID, providerName)
+	claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
 	if err != nil || !ok {
 		t.Fatalf("claim ok=%t err=%v", ok, err)
 	}
 	if claim.SSHHost != "" || claim.SSHPort != 0 || claim.Labels[labelRelease] != releaseStop || claim.Labels[labelState] != "stopped" {
 		t.Fatalf("claim=%#v", claim)
 	}
-	if !b.RetainLeaseClaimAfterRelease(LeaseTarget{LeaseID: leaseID, Server: server}) {
+	if !b.RetainLeaseClaimAfterRelease(core.LeaseTarget{LeaseID: leaseID, Server: server}) {
 		t.Fatal("dirty release fallback should retain local claim")
 	}
-	if got := b.ReleaseLeaseMessage(LeaseTarget{LeaseID: leaseID, Server: server}); !strings.Contains(got, "retained=true") {
+	if got := b.ReleaseLeaseMessage(core.LeaseTarget{LeaseID: leaseID, Server: server}); !strings.Contains(got, "retained=true") {
 		t.Fatalf("message=%q", got)
 	}
 }
@@ -1127,11 +1127,11 @@ func TestReleaseDirtyCodespaceRefusesZeroRetentionWithoutStopping(t *testing.T) 
 	b := newTestBackend(t, fc, &fakeGH{login: "alice", token: "test" + "-value"})
 	leaseID := "cbx_123456789af3"
 	server := b.serverFromCodespace(item, b.labelsFor(leaseID, "zero-retention", "example-org/my-app", "alice", false, releaseDelete, item, "ready"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "zero-retention", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "zero-retention", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}})
+	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
 	if err == nil || !strings.Contains(err.Error(), "effective retention is zero") {
 		t.Fatalf("err=%v", err)
 	}
@@ -1150,11 +1150,11 @@ func TestReleaseCleanCodespaceRefusesZeroRetentionWithoutStopping(t *testing.T) 
 	b := newTestBackend(t, fc, &fakeGH{login: "alice", token: "test" + "-value"})
 	leaseID := "cbx_123456789af6"
 	server := b.serverFromCodespace(item, b.labelsFor(leaseID, "clean-zero-retention", "example-org/my-app", "alice", false, releaseDelete, item, "ready"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "clean-zero-retention", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "clean-zero-retention", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}})
+	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
 	if err == nil || !strings.Contains(err.Error(), "effective retention is zero") {
 		t.Fatalf("err=%v", err)
 	}
@@ -1175,11 +1175,11 @@ func TestCleanupDryRunReportsDirtyRetentionWithoutMutation(t *testing.T) {
 	leaseID := "cbx_123456789af4"
 	server := b.serverFromCodespace(item, b.labelsFor(leaseID, "dirty-dry-run", "example-org/my-app", "alice", false, releaseDelete, item, "ready"))
 	server.Labels["expires_at"] = time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
-	if err := claimLeaseTargetForRepoConfig(leaseID, "dirty-dry-run", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "dirty-dry-run", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := b.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(stderr.String(), "retain codespace=cs-dirty-dry-run") || len(fc.stops) != 0 || len(fc.deletes) != 0 {
@@ -1208,17 +1208,17 @@ func TestReleaseDeleteRechecksGitStatusAfterStop(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789ac5"
 	server := b.serverFromCodespace(fc.items["cs-dirty-race"], b.labelsFor(leaseID, "dirty-race-box", "example-org/my-app", "alice", false, releaseDelete, fc.items["cs-dirty-race"], "ready"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "dirty-race-box", b.cfg, server, SSHTarget{Host: "cs-dirty-race", Port: "22"}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "dirty-race-box", b.cfg, server, core.SSHTarget{Host: "cs-dirty-race", Port: "22"}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fc.deletes) != 0 || len(fc.stops) != 2 {
 		t.Fatalf("stops=%#v deletes=%#v", fc.stops, fc.deletes)
 	}
-	claim, ok, err := resolveLeaseClaimForProvider(leaseID, providerName)
+	claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
 	if err != nil || !ok || claim.Labels[labelRelease] != releaseStop || claim.Labels[labelState] != "stopped" {
 		t.Fatalf("claim=%#v ok=%t err=%v", claim, ok, err)
 	}
@@ -1237,11 +1237,11 @@ func TestReleaseDeleteRechecksIdentityAfterStop(t *testing.T) {
 	b := newTestBackend(t, fc, fg)
 	leaseID := "cbx_123456789ac6"
 	server := b.serverFromCodespace(fc.items["cs-identity-race"], b.labelsFor(leaseID, "identity-race-box", "example-org/my-app", "alice", false, releaseDelete, fc.items["cs-identity-race"], "ready"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "identity-race-box", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "identity-race-box", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}})
+	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
 	if err == nil || !strings.Contains(err.Error(), "environment id changed") {
 		t.Fatalf("err=%v", err)
 	}
@@ -1259,17 +1259,17 @@ func TestReleaseRetainedStopsAndClearsEndpoint(t *testing.T) {
 	b.cfg.GitHubCodespaces.DeleteOnRelease = false
 	leaseID := "cbx_123456789abe"
 	server := b.serverFromCodespace(fc.items["cs-stop"], b.labelsFor(leaseID, "stop-box", "example-org/my-app", "alice", true, releaseStop, fc.items["cs-stop"], "ready"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "stop-box", b.cfg, server, SSHTarget{Host: "cs-stop", Port: "22"}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "stop-box", b.cfg, server, core.SSHTarget{Host: "cs-stop", Port: "22"}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
 		t.Fatal(err)
 	}
 	if strings.Join(fc.stops, ",") != "cs-stop" || len(fc.deletes) != 0 {
 		t.Fatalf("stops=%#v deletes=%#v", fc.stops, fc.deletes)
 	}
-	claim, ok, err := resolveLeaseClaimForProvider(leaseID, providerName)
+	claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
 	if err != nil || !ok {
 		t.Fatalf("claim ok=%t err=%v", ok, err)
 	}
@@ -1289,17 +1289,17 @@ func TestReleaseRetainedRemovesClaimWhenCodespaceIsAlreadyAbsent(t *testing.T) {
 	leaseID := "cbx_123456789ab9"
 	item := fakeCodespace("cs-retained-absent", "Shutdown")
 	server := b.serverFromCodespace(item, b.labelsFor(leaseID, "retained-absent-box", "example-org/my-app", "alice", true, releaseStop, item, "stopped"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "retained-absent-box", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "retained-absent-box", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := storeSSHConfig(leaseID, "Host retained-absent-box\n"); err != nil {
 		t.Fatal(err)
 	}
 
-	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil || !outcome.Terminal {
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil || !outcome.Terminal {
 		t.Fatalf("absent resource under stop policy: outcome=%+v err=%v", outcome, err)
 	}
-	if _, ok, err := resolveLeaseClaimForProvider(leaseID, providerName); err != nil || ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil || ok {
 		t.Fatalf("claim ok=%t err=%v", ok, err)
 	}
 	configPath := filepath.Join(stateHome, "crabbox", "github-codespaces", leaseID+".ssh_config")
@@ -1318,17 +1318,17 @@ func TestCleanupDryRunKeepsProviderNonMutating(t *testing.T) {
 	leaseID := "cbx_123456789abf"
 	server := b.serverFromCodespace(fc.items["cs-expired"], b.labelsFor(leaseID, "expired-box", "example-org/my-app", "alice", false, releaseDelete, fc.items["cs-expired"], "ready"))
 	server.Labels["expires_at"] = time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
-	if err := claimLeaseTargetForRepoConfig(leaseID, "expired-box", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "expired-box", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := b.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fc.deletes) != 0 {
 		t.Fatalf("dry run deleted: %#v", fc.deletes)
 	}
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if strings.Join(fc.deletes, ",") != "cs-expired" {
@@ -1350,20 +1350,20 @@ func TestCleanupRecoversExpiredPendingCreateBeforeDelete(t *testing.T) {
 	item.DisplayName = displayName
 	fc.items[item.Name] = item
 
-	if err := b.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
 		t.Fatal(err)
 	}
-	claim, ok, err := readLeaseClaimWithPresence(leaseID)
+	claim, ok, err := core.ReadLeaseClaimWithPresence(leaseID)
 	if err != nil || !ok || claim.CloudID != "" || len(fc.deletes) != 0 {
 		t.Fatalf("dry-run claim=%#v ok=%t err=%v deletes=%#v", claim, ok, err, fc.deletes)
 	}
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if strings.Join(fc.deletes, ",") != item.Name {
 		t.Fatalf("deletes=%#v", fc.deletes)
 	}
-	if _, ok, err := readLeaseClaimWithPresence(leaseID); err != nil || ok {
+	if _, ok, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || ok {
 		t.Fatalf("claim remained ok=%t err=%v", ok, err)
 	}
 }
@@ -1378,16 +1378,16 @@ func TestCleanupDiscardsExpiredPendingCreateWithoutInventoryMatch(t *testing.T) 
 	persistPendingRecoveryClaimForTest(t, b, leaseID, "pending-absent", "pending-absent-nonce", true)
 	b.now = func() time.Time { return now }
 
-	if err := b.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok, err := readLeaseClaimWithPresence(leaseID); err != nil || !ok {
+	if _, ok, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || !ok {
 		t.Fatalf("dry-run claim ok=%t err=%v", ok, err)
 	}
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok, err := readLeaseClaimWithPresence(leaseID); err != nil || ok {
+	if _, ok, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || ok {
 		t.Fatalf("claim remained ok=%t err=%v", ok, err)
 	}
 	if len(fc.deletes) != 0 {
@@ -1404,21 +1404,21 @@ func TestCleanupDiscardsExpiredBoundClaimAfterConfirmedAbsence(t *testing.T) {
 	b.now = func() time.Time { return now.Add(-14 * time.Hour) }
 	item := fakeCodespace("cs-bound-absent", "Available")
 	server := b.serverFromCodespace(item, b.labelsFor(leaseID, "bound-absent", "example-org/my-app", "alice", false, releaseDelete, item, "ready"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "bound-absent", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "bound-absent", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	b.now = func() time.Time { return now }
 
-	if err := b.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok, err := readLeaseClaimWithPresence(leaseID); err != nil || !ok {
+	if _, ok, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || !ok {
 		t.Fatalf("dry-run claim ok=%t err=%v", ok, err)
 	}
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok, err := readLeaseClaimWithPresence(leaseID); err != nil || ok {
+	if _, ok, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || ok {
 		t.Fatalf("claim remained ok=%t err=%v", ok, err)
 	}
 	if len(fc.deletes) != 0 {
@@ -1435,17 +1435,17 @@ func TestCleanupRetainsExpiredAbsentClaimForDifferentGitHubIdentity(t *testing.T
 	b.now = func() time.Time { return now.Add(-14 * time.Hour) }
 	item := fakeCodespace("cs-other-account", "Available")
 	server := b.serverFromCodespace(item, b.labelsFor(leaseID, "other-account", "example-org/my-app", "alice", false, releaseDelete, item, "ready"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "other-account", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "other-account", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	b.now = func() time.Time { return now }
 	fc.user = fakeGitHubUser("bob")
 
-	err := b.Cleanup(context.Background(), CleanupRequest{})
+	err := b.Cleanup(context.Background(), core.CleanupRequest{})
 	if err == nil || !strings.Contains(err.Error(), "account mismatch") {
 		t.Fatalf("err=%v", err)
 	}
-	if _, ok, claimErr := readLeaseClaimWithPresence(leaseID); claimErr != nil || !ok {
+	if _, ok, claimErr := core.ReadLeaseClaimWithPresence(leaseID); claimErr != nil || !ok {
 		t.Fatalf("claim ok=%t err=%v", ok, claimErr)
 	}
 	if len(fc.deletes) != 0 {
@@ -1462,10 +1462,10 @@ func TestCleanupRefusesIdentityMismatch(t *testing.T) {
 	leaseID := "cbx_123456789ac1"
 	server := b.serverFromCodespace(fc.items["cs-mismatch"], b.labelsFor(leaseID, "mismatch-box", "example-org/my-app", "alice", false, releaseDelete, fc.items["cs-mismatch"], "ready"))
 	server.Labels["expires_at"] = time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
-	if err := claimLeaseTargetForRepoConfig(leaseID, "mismatch-box", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "mismatch-box", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
-	err := b.Cleanup(context.Background(), CleanupRequest{})
+	err := b.Cleanup(context.Background(), core.CleanupRequest{})
 	if err == nil || !strings.Contains(err.Error(), "account mismatch") {
 		t.Fatalf("err=%v", err)
 	}
@@ -1483,22 +1483,22 @@ func TestCleanupRejectsClaimRaceBeforeMutation(t *testing.T) {
 	leaseID := "cbx_123456789aac"
 	server := b.serverFromCodespace(fc.items["cs-cleanup-race"], b.labelsFor(leaseID, "cleanup-race-box", "example-org/my-app", "alice", false, releaseDelete, fc.items["cs-cleanup-race"], "ready"))
 	server.Labels["expires_at"] = time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
-	if err := claimLeaseTargetForRepoConfig(leaseID, "cleanup-race-box", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "cleanup-race-box", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	fc.onGet = func(string) {
-		claim, ok, err := resolveLeaseClaimForProvider(leaseID, providerName)
+		claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
 		if err != nil || !ok {
 			t.Fatalf("claim ok=%t err=%v", ok, err)
 		}
 		raced := serverFromClaim(claim)
 		raced.Labels["raced"] = "true"
-		if err := updateLeaseClaimEndpoint(leaseID, raced, SSHTarget{}); err != nil {
+		if err := core.UpdateLeaseClaimEndpoint(leaseID, raced, core.SSHTarget{}); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	err := b.Cleanup(context.Background(), CleanupRequest{})
+	err := b.Cleanup(context.Background(), core.CleanupRequest{})
 	if err == nil || !strings.Contains(err.Error(), "claim changed") {
 		t.Fatalf("err=%v", err)
 	}
@@ -1516,13 +1516,13 @@ func TestListAllowsUserRenamedDisplayName(t *testing.T) {
 	leaseID := "cbx_123456789ad1"
 	server := b.serverFromCodespace(item, b.labelsFor(leaseID, "renamed-display", "example-org/my-app", "alice", false, releaseDelete, item, "ready"))
 	server.Labels[labelDisplayName] = "original-display"
-	if err := claimLeaseTargetForRepoConfig(leaseID, "renamed-display", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "renamed-display", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	item.DisplayName = "user-renamed-display"
 	fc.items[item.Name] = item
 
-	views, err := b.List(context.Background(), ListRequest{})
+	views, err := b.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1537,7 +1537,7 @@ func TestDoctorIsNonMutating(t *testing.T) {
 	fg := &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"}
 	b := newTestBackend(t, fc, fg)
 
-	result, err := b.Doctor(context.Background(), DoctorRequest{})
+	result, err := b.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1557,11 +1557,11 @@ func TestDoctorFailsClosedAfterGitHubAccountSwitch(t *testing.T) {
 	b := newTestBackend(t, fc, &fakeGH{login: "bob", token: "ghp_this_token_value_is_redacted"})
 	leaseID := "cbx_123456789ad2"
 	server := b.serverFromCodespace(item, b.labelsFor(leaseID, "other-account", "example-org/my-app", "alice", false, releaseDelete, item, "ready"))
-	if err := claimLeaseTargetForRepoConfig(leaseID, "other-account", b.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "other-account", b.cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
-	result, err := b.Doctor(context.Background(), DoctorRequest{})
+	result, err := b.Doctor(context.Background(), core.DoctorRequest{})
 	if err == nil || result.Status != "failed" || !strings.Contains(err.Error(), "account mismatch") {
 		t.Fatalf("result=%#v err=%v", result, err)
 	}
@@ -1635,15 +1635,15 @@ func TestWaitForAvailableUsesReadyTimeout(t *testing.T) {
 }
 
 func TestEffectiveWorkRootHonorsExplicitGenericWorkRoot(t *testing.T) {
-	cfg := Config{
+	cfg := core.Config{
 		Provider: providerName,
 		WorkRoot: "/custom/workspace",
-		GitHubCodespaces: GitHubCodespacesConfig{
+		GitHubCodespaces: core.GitHubCodespacesConfig{
 			WorkRoot: defaultWorkRoot,
 		},
 	}
 	core.MarkWorkRootExplicit(&cfg)
-	b := newBackend(Provider{}.Spec(), cfg, Runtime{})
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{})
 
 	if got := b.effectiveWorkRoot("example-org/my-app"); got != "/custom/workspace" {
 		t.Fatalf("work root=%q", got)
@@ -1651,7 +1651,7 @@ func TestEffectiveWorkRootHonorsExplicitGenericWorkRoot(t *testing.T) {
 }
 
 func TestRepoConfigReadyCheckUsesEffectiveWorkRoot(t *testing.T) {
-	b := newBackend(Provider{}.Spec(), Config{GitHubCodespaces: GitHubCodespacesConfig{WorkRoot: defaultWorkRoot}}, Runtime{})
+	b := newBackend(Provider{}.Spec(), core.Config{GitHubCodespaces: core.GitHubCodespacesConfig{WorkRoot: defaultWorkRoot}}, core.Runtime{})
 	check := githubCodespacesReadyCheck(b.repoConfig("example-org/my-app"))
 	if !strings.Contains(check, "'/workspaces/my-app'") || strings.Contains(check, "'/workspaces/crabbox'") {
 		t.Fatalf("ready check=%q", check)
@@ -1684,18 +1684,18 @@ func TestDisplayNameFitsGitHubCodespacesLimit(t *testing.T) {
 
 type testBackend struct {
 	*backend
-	waits []SSHTarget
+	waits []core.SSHTarget
 }
 
 func newTestBackend(t *testing.T, fc *fakeCodespacesClient, fg *fakeGH) *testBackend {
 	t.Helper()
-	cfg := Config{
+	cfg := core.Config{
 		Provider:    providerName,
 		TargetOS:    targetLinux,
 		SSHUser:     "vscode",
 		SSHPort:     "22",
 		IdleTimeout: time.Hour,
-		GitHubCodespaces: GitHubCodespacesConfig{
+		GitHubCodespaces: core.GitHubCodespacesConfig{
 			APIURL:           defaultAPIURL,
 			GHPath:           "gh",
 			Repo:             "example-org/my-app",
@@ -1710,14 +1710,14 @@ func newTestBackend(t *testing.T, fc *fakeCodespacesClient, fg *fakeGH) *testBac
 			WorkRoot:         defaultWorkRoot,
 		},
 	}
-	rt := Runtime{}
+	rt := core.Runtime{}
 	b := newBackend(Provider{}.Spec(), cfg, rt)
 	fc.user = fakeGitHubUser(fg.login)
 	b.pollInterval = time.Nanosecond
 	tb := &testBackend{backend: b}
 	b.clientFactory = func(string) codespacesAPI { return fc }
 	b.ghFactory = func() githubCLI { return fg }
-	b.waitSSH = func(_ context.Context, target *SSHTarget, _ string, _ time.Duration) error {
+	b.waitSSH = func(_ context.Context, target *core.SSHTarget, _ string, _ time.Duration) error {
 		tb.waits = append(tb.waits, *target)
 		return nil
 	}

--- a/internal/providers/githubcodespaces/client.go
+++ b/internal/providers/githubcodespaces/client.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type githubAPIResponseError struct {
@@ -71,7 +73,7 @@ func (c client) currentUser(ctx context.Context) (githubUser, error) {
 	}
 	user.Login = strings.TrimSpace(user.Login)
 	if user.ID <= 0 || user.Login == "" {
-		return githubUser{}, exit(4, "github-codespaces API returned incomplete authenticated user identity")
+		return githubUser{}, core.Exit(4, "github-codespaces API returned incomplete authenticated user identity")
 	}
 	return user, nil
 }
@@ -166,7 +168,7 @@ func (m *machineRef) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func newClient(cfg GitHubCodespacesConfig, rt Runtime, token string) client {
+func newClient(cfg core.GitHubCodespacesConfig, rt core.Runtime, token string) client {
 	httpClient := rt.HTTP
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 60 * time.Second}
@@ -187,7 +189,7 @@ func newClient(cfg GitHubCodespacesConfig, rt Runtime, token string) client {
 func (c client) createCodespace(ctx context.Context, req createCodespaceRequest) (codespace, error) {
 	owner, repo, ok := strings.Cut(strings.TrimSpace(req.Repo), "/")
 	if !ok || owner == "" || repo == "" {
-		return codespace{}, exit(2, "github-codespaces repo must be owner/name")
+		return codespace{}, core.Exit(2, "github-codespaces repo must be owner/name")
 	}
 	body := map[string]any{}
 	if req.Ref != "" {
@@ -240,7 +242,7 @@ func (c client) listCodespaces(ctx context.Context) ([]codespace, error) {
 func (c client) getCodespace(ctx context.Context, name string) (codespace, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
-		return codespace{}, exit(2, "github-codespaces codespace name is required")
+		return codespace{}, core.Exit(2, "github-codespaces codespace name is required")
 	}
 	var out codespace
 	if err := c.do(ctx, http.MethodGet, "/user/codespaces/"+url.PathEscape(name), nil, &out, nil); err != nil {
@@ -252,7 +254,7 @@ func (c client) getCodespace(ctx context.Context, name string) (codespace, error
 func (c client) startCodespace(ctx context.Context, name string) (codespace, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
-		return codespace{}, exit(2, "github-codespaces codespace name is required")
+		return codespace{}, core.Exit(2, "github-codespaces codespace name is required")
 	}
 	var out codespace
 	if err := c.do(ctx, http.MethodPost, "/user/codespaces/"+url.PathEscape(name)+"/start", nil, &out, map[int]bool{http.StatusNotModified: true}); err != nil {
@@ -267,7 +269,7 @@ func (c client) startCodespace(ctx context.Context, name string) (codespace, err
 func (c client) stopCodespace(ctx context.Context, name string) error {
 	name = strings.TrimSpace(name)
 	if name == "" {
-		return exit(2, "github-codespaces codespace name is required")
+		return core.Exit(2, "github-codespaces codespace name is required")
 	}
 	return c.do(ctx, http.MethodPost, "/user/codespaces/"+url.PathEscape(name)+"/stop", nil, nil, map[int]bool{http.StatusNotModified: true})
 }
@@ -275,7 +277,7 @@ func (c client) stopCodespace(ctx context.Context, name string) error {
 func (c client) deleteCodespace(ctx context.Context, name string) error {
 	name = strings.TrimSpace(name)
 	if name == "" {
-		return exit(2, "github-codespaces codespace name is required")
+		return core.Exit(2, "github-codespaces codespace name is required")
 	}
 	return c.do(ctx, http.MethodDelete, "/user/codespaces/"+url.PathEscape(name), nil, nil, map[int]bool{http.StatusNotModified: true})
 }
@@ -283,7 +285,7 @@ func (c client) deleteCodespace(ctx context.Context, name string) error {
 func (c client) listMachines(ctx context.Context, repo, ref string) ([]codespaceMachine, error) {
 	owner, name, ok := strings.Cut(strings.TrimSpace(repo), "/")
 	if !ok || owner == "" || name == "" {
-		return nil, exit(2, "github-codespaces repo must be owner/name")
+		return nil, core.Exit(2, "github-codespaces repo must be owner/name")
 	}
 	path := "/repos/" + url.PathEscape(owner) + "/" + url.PathEscape(name) + "/codespaces/machines"
 	if strings.TrimSpace(ref) != "" {
@@ -360,7 +362,7 @@ func (c client) doWithHeader(ctx context.Context, method, path string, body any,
 		return nil, readErr
 	}
 	if len(data) > githubCodespacesMaxResponseSize {
-		return nil, exit(4, "github-codespaces API response exceeds %d-byte limit", githubCodespacesMaxResponseSize)
+		return nil, core.Exit(4, "github-codespaces API response exceeds %d-byte limit", githubCodespacesMaxResponseSize)
 	}
 	if accepted == nil {
 		accepted = map[int]bool{}
@@ -380,7 +382,7 @@ func validateGitHubCodespacesAPIBase(raw string) error {
 		return fmt.Errorf("invalid github-codespaces API URL: %w", err)
 	}
 	if parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
-		return exit(2, "github-codespaces API URL must be an origin with an optional path")
+		return core.Exit(2, "github-codespaces API URL must be an origin with an optional path")
 	}
 	if strings.EqualFold(parsed.Scheme, "https") {
 		return nil
@@ -390,7 +392,7 @@ func validateGitHubCodespacesAPIBase(raw string) error {
 	if strings.EqualFold(parsed.Scheme, "http") && (strings.EqualFold(host, "localhost") || (ip != nil && ip.IsLoopback())) {
 		return nil
 	}
-	return exit(2, "github-codespaces API URL must use https; http is allowed only for loopback testing")
+	return core.Exit(2, "github-codespaces API URL must use https; http is allowed only for loopback testing")
 }
 
 func githubAPIError(status int, retryAfter, body string) error {

--- a/internal/providers/githubcodespaces/client_test.go
+++ b/internal/providers/githubcodespaces/client_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestClientCreateCodespaceRequestShape(t *testing.T) {
@@ -34,7 +36,7 @@ func TestClientCreateCodespaceRequestShape(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := newClient(GitHubCodespacesConfig{APIURL: server.URL}, Runtime{HTTP: server.Client()}, "ghp_this_token_value_is_redacted")
+	c := newClient(core.GitHubCodespacesConfig{APIURL: server.URL}, core.Runtime{HTTP: server.Client()}, "ghp_this_token_value_is_redacted")
 	created, err := c.createCodespace(context.Background(), createCodespaceRequest{
 		Repo:             "example-org/my-app",
 		Ref:              "main",
@@ -91,7 +93,7 @@ func TestClientCreateCodespaceIncludesExplicitZeroRetention(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := newClient(GitHubCodespacesConfig{APIURL: server.URL}, Runtime{HTTP: server.Client()}, "redacted")
+	c := newClient(core.GitHubCodespacesConfig{APIURL: server.URL}, core.Runtime{HTTP: server.Client()}, "redacted")
 	if _, err := c.createCodespace(context.Background(), createCodespaceRequest{
 		Repo:            "example-org/my-app",
 		RetentionPeriod: 0,
@@ -119,7 +121,7 @@ func TestClientListAcceptsResponseAboveLegacyOneMiBLimit(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := newClient(GitHubCodespacesConfig{APIURL: server.URL}, Runtime{HTTP: server.Client()}, "redacted")
+	c := newClient(core.GitHubCodespacesConfig{APIURL: server.URL}, core.Runtime{HTTP: server.Client()}, "redacted")
 	items, err := c.listCodespaces(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -141,7 +143,7 @@ func TestClientCurrentUserUsesConfiguredAPIBase(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := newClient(GitHubCodespacesConfig{APIURL: server.URL + "/api/v3"}, Runtime{HTTP: server.Client()}, "ghp_this_token_value_is_redacted")
+	c := newClient(core.GitHubCodespacesConfig{APIURL: server.URL + "/api/v3"}, core.Runtime{HTTP: server.Client()}, "ghp_this_token_value_is_redacted")
 	user, err := c.currentUser(context.Background())
 	if err != nil || user.ID != 42 || user.Login != "alice" {
 		t.Fatalf("user=%#v err=%v", user, err)
@@ -228,7 +230,7 @@ func TestClientLifecycleOperationsRequestShape(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := newClient(GitHubCodespacesConfig{APIURL: server.URL + "/api/v3"}, Runtime{HTTP: server.Client()}, "token")
+	c := newClient(core.GitHubCodespacesConfig{APIURL: server.URL + "/api/v3"}, core.Runtime{HTTP: server.Client()}, "token")
 	listed, err := c.listCodespaces(context.Background())
 	if err != nil || len(listed) != 2 || listed[0].Name != "space-1" || listed[1].Name != "space-2" {
 		t.Fatalf("listed=%#v err=%v", listed, err)
@@ -291,7 +293,7 @@ func TestClientListCodespacesRejectsCrossOriginPagination(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := newClient(GitHubCodespacesConfig{APIURL: server.URL + "/api/v3"}, Runtime{HTTP: server.Client()}, "token")
+	c := newClient(core.GitHubCodespacesConfig{APIURL: server.URL + "/api/v3"}, core.Runtime{HTTP: server.Client()}, "token")
 	_, err := c.listCodespaces(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "outside configured API base") {
 		t.Fatalf("err=%v", err)
@@ -323,7 +325,7 @@ func TestClientRejectsRedirectWithoutForwardingAuthorization(t *testing.T) {
 	}))
 	defer origin.Close()
 
-	c := newClient(GitHubCodespacesConfig{APIURL: origin.URL}, Runtime{HTTP: origin.Client()}, "ghp_this_token_value_is_redacted")
+	c := newClient(core.GitHubCodespacesConfig{APIURL: origin.URL}, core.Runtime{HTTP: origin.Client()}, "ghp_this_token_value_is_redacted")
 	_, err := c.listCodespaces(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "status=302") {
 		t.Fatalf("err=%v", err)

--- a/internal/providers/githubcodespaces/core.go
+++ b/internal/providers/githubcodespaces/core.go
@@ -1,36 +1,10 @@
 package githubcodespaces
 
 import (
-	"context"
-
-	"io"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type GitHubCodespacesConfig = core.GitHubCodespacesConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type DoctorCheck = core.DoctorCheck
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type CleanupRequest = core.CleanupRequest
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
-type LeaseClaim = core.LeaseClaim
-type Repo = core.Repo
 
 const (
 	providerName               = "github-codespaces"
@@ -47,51 +21,15 @@ const (
 	defaultSSHPort             = "22"
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func markDeleteOnReleaseExplicit(cfg *Config) {
+func markDeleteOnReleaseExplicit(cfg *core.Config) {
 	core.MarkDeleteOnReleaseExplicit(cfg, providerName)
 }
 
-func markRetentionPeriodExplicit(cfg *Config) {
-	core.MarkGitHubCodespacesRetentionExplicit(cfg)
-}
-
-func retentionPeriodExplicit(cfg Config) bool {
-	return core.GitHubCodespacesRetentionExplicit(cfg)
-}
-
-func deleteOnReleaseExplicit(cfg Config) bool {
+func deleteOnReleaseExplicit(cfg core.Config) bool {
 	return core.DeleteOnReleaseExplicit(cfg, providerName)
 }
 
-func workRootExplicit(cfg *Config) bool {
-	return core.IsWorkRootExplicit(cfg)
-}
-
-func markWorkRootExplicit(cfg *Config) {
-	core.MarkWorkRootExplicit(cfg)
-}
-
-func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (string, error) {
-	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
-}
-
-func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
-	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
-}
-
-func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, now time.Time) map[string]string {
-	return core.TouchDirectLeaseLabels(labels, cfg, state, now)
-}
-
-func claimLeaseTargetForRepoConfig(leaseID, slug string, cfg Config, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, target, repoRoot, idleTimeout, reclaim)
-}
-
-func claimLeaseTargetForRepoConfigIfUnchangedDurable(leaseID, slug string, cfg Config, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected LeaseClaim, expectedExists bool) (LeaseClaim, error) {
+func claimLeaseTargetForRepoConfigIfUnchangedDurable(leaseID, slug string, cfg core.Config, server core.Server, target core.SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected core.LeaseClaim, expectedExists bool) (core.LeaseClaim, error) {
 	return core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurable(
 		leaseID,
 		slug,
@@ -107,82 +45,6 @@ func claimLeaseTargetForRepoConfigIfUnchangedDurable(leaseID, slug string, cfg C
 	)
 }
 
-func providerClaimScope(cfg Config) string {
+func providerClaimScope(cfg core.Config) string {
 	return Provider{}.ClaimScope(cfg)
-}
-
-func resolveLeaseClaimForProvider(identifier, provider string) (LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaimForProvider(identifier, provider)
-}
-
-func readLeaseClaimWithPresence(leaseID string) (LeaseClaim, bool, error) {
-	return core.ReadLeaseClaimWithPresence(leaseID)
-}
-
-func listLeaseClaims() ([]LeaseClaim, error) {
-	return core.ListLeaseClaims()
-}
-
-func leaseClaimMatchesIdentifier(claim LeaseClaim, identifier string) bool {
-	return core.LeaseClaimMatchesIdentifier(claim, identifier)
-}
-
-func isCanonicalLeaseID(value string) bool {
-	return core.IsCanonicalLeaseID(value)
-}
-
-func setServerLeaseClaimSnapshot(server *Server, claim LeaseClaim, exists bool) {
-	core.SetServerLeaseClaimSnapshot(server, claim, exists)
-}
-
-func serverLeaseClaimSnapshot(server Server) (LeaseClaim, bool, bool) {
-	return core.ServerLeaseClaimSnapshot(server)
-}
-
-func updateLeaseClaimEndpoint(leaseID string, server Server, target SSHTarget) error {
-	return core.UpdateLeaseClaimEndpoint(leaseID, server, target)
-}
-
-func updateLeaseClaimEndpointIfUnchanged(leaseID string, expected LeaseClaim, server Server, target SSHTarget) (LeaseClaim, error) {
-	return core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, expected, server, target)
-}
-
-func updateLeaseClaimEndpointIfUnchangedAfter(leaseID string, expected LeaseClaim, server Server, target SSHTarget, action func() error) (LeaseClaim, error) {
-	return core.UpdateLeaseClaimEndpointIfUnchangedAfter(leaseID, expected, server, target, action)
-}
-
-func withLeaseClaimUnchanged(leaseID string, expected LeaseClaim, action func() error) error {
-	return core.WithLeaseClaimUnchanged(leaseID, expected, action)
-}
-
-func updateLeaseClaimEndpointIfUnchangedAction(
-	leaseID string,
-	expected LeaseClaim,
-	action func() (Server, SSHTarget, bool, error),
-) (LeaseClaim, Server, SSHTarget, error) {
-	return core.UpdateLeaseClaimEndpointIfUnchangedAction(leaseID, expected, action)
-}
-
-func removeLeaseClaimIfUnchangedAfter(leaseID string, expected LeaseClaim, action func() error) error {
-	return core.RemoveLeaseClaimIfUnchangedAfter(leaseID, expected, action)
-}
-
-func shouldCleanupServer(server Server, now time.Time) (bool, string) {
-	return core.ShouldCleanupServer(server, now)
-}
-
-func findServerByAlias(servers []Server, id string) (Server, string, error) {
-	return core.FindServerByAlias(servers, id)
-}
-
-func leaseProviderName(leaseID, slug string) string {
-	return core.LeaseProviderName(leaseID, slug)
-}
-
-func crabboxStateDir() (string, error) {
-	return core.CrabboxStateDir()
-}
-
-func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
-	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
 }

--- a/internal/providers/githubcodespaces/flags.go
+++ b/internal/providers/githubcodespaces/flags.go
@@ -23,7 +23,7 @@ type flagValues struct {
 	WorkRoot        *string
 }
 
-func RegisterGitHubCodespacesProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterGitHubCodespacesProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return flagValues{
 		Repo:            fs.String("github-codespaces-repo", defaults.GitHubCodespaces.Repo, "GitHub repository owner/name for Codespaces"),
 		Ref:             fs.String("github-codespaces-ref", defaults.GitHubCodespaces.Ref, "Git ref for a new GitHub Codespace"),
@@ -39,13 +39,13 @@ func RegisterGitHubCodespacesProviderFlags(fs *flag.FlagSet, defaults Config) an
 	}
 }
 
-func ApplyGitHubCodespacesProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyGitHubCodespacesProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if core.FlagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=github-codespaces; use --type or --github-codespaces-machine for a Codespaces machine slug")
+			return core.Exit(2, "--class is not supported for provider=github-codespaces; use --type or --github-codespaces-machine for a Codespaces machine slug")
 		}
 		if cfg.TargetOS != "" && strings.ToLower(strings.TrimSpace(cfg.TargetOS)) != targetLinux {
-			return exit(2, "provider=github-codespaces supports target=linux only")
+			return core.Exit(2, "provider=github-codespaces supports target=linux only")
 		}
 		if core.FlagWasSet(fs, "type") && !core.FlagWasSet(fs, "github-codespaces-machine") {
 			if flag := fs.Lookup("type"); flag != nil {
@@ -91,7 +91,7 @@ func ApplyGitHubCodespacesProviderFlags(cfg *Config, fs *flag.FlagSet, values an
 	if core.FlagWasSet(fs, "github-codespaces-retention-period") {
 		cfg.GitHubCodespaces.RetentionPeriod = *v.RetentionPeriod
 		core.RecordProviderFlagInputs(cfg, true, providerName)
-		markRetentionPeriodExplicit(cfg)
+		core.MarkGitHubCodespacesRetentionExplicit(cfg)
 	}
 	if core.FlagWasSet(fs, "github-codespaces-delete-on-release") {
 		cfg.GitHubCodespaces.DeleteOnRelease = *v.DeleteOnRelease
@@ -106,30 +106,30 @@ func ApplyGitHubCodespacesProviderFlags(cfg *Config, fs *flag.FlagSet, values an
 		cfg.GitHubCodespaces.WorkRoot = *v.WorkRoot
 		core.RecordProviderFlagInputs(cfg, true, providerName)
 		cfg.WorkRoot = *v.WorkRoot
-		markWorkRootExplicit(cfg)
+		core.MarkWorkRootExplicit(cfg)
 	}
 	return ValidateGitHubCodespacesConfig(*cfg)
 }
 
-func ValidateGitHubCodespacesConfig(cfg Config) error {
+func ValidateGitHubCodespacesConfig(cfg core.Config) error {
 	if core.ProviderNameMatches(cfg.Provider, Provider{}) && strings.TrimSpace(cfg.TargetOS) != "" && strings.ToLower(strings.TrimSpace(cfg.TargetOS)) != targetLinux {
-		return exit(2, "provider=github-codespaces supports target=linux only")
+		return core.Exit(2, "provider=github-codespaces supports target=linux only")
 	}
 	c := cfg.GitHubCodespaces
 	if strings.TrimSpace(c.Repo) != "" && !validRepo(c.Repo) {
-		return exit(2, "github-codespaces repo must be owner/name")
+		return core.Exit(2, "github-codespaces repo must be owner/name")
 	}
 	if c.IdleTimeout < 0 {
-		return exit(2, "github-codespaces idle timeout must be non-negative")
+		return core.Exit(2, "github-codespaces idle timeout must be non-negative")
 	}
 	if c.IdleTimeout > 0 && (c.IdleTimeout < 5*time.Minute || c.IdleTimeout > 4*time.Hour) {
-		return exit(2, "github-codespaces idle timeout must be between 5m and 4h")
+		return core.Exit(2, "github-codespaces idle timeout must be between 5m and 4h")
 	}
 	if c.RetentionPeriod < 0 {
-		return exit(2, "github-codespaces retention period must be non-negative")
+		return core.Exit(2, "github-codespaces retention period must be non-negative")
 	}
 	if c.RetentionPeriod > 30*24*time.Hour {
-		return exit(2, "github-codespaces retention period must not exceed 30 days")
+		return core.Exit(2, "github-codespaces retention period must not exceed 30 days")
 	}
 	if err := validateGitHubCodespacesWorkRoot("work root", c.WorkRoot); err != nil {
 		return err
@@ -138,7 +138,7 @@ func ValidateGitHubCodespacesConfig(cfg Config) error {
 		return err
 	}
 	if strings.TrimSpace(c.GHPath) == "" {
-		return exit(2, "github-codespaces gh path is required")
+		return core.Exit(2, "github-codespaces gh path is required")
 	}
 	return nil
 }
@@ -150,14 +150,14 @@ func validateGitHubCodespacesWorkRoot(label, value string) error {
 	}
 	clean := path.Clean(trimmed)
 	if !path.IsAbs(clean) {
-		return exit(2, "github-codespaces %s must be absolute", label)
+		return core.Exit(2, "github-codespaces %s must be absolute", label)
 	}
 	if clean != trimmed {
-		return exit(2, "github-codespaces %s must be a canonical path", label)
+		return core.Exit(2, "github-codespaces %s must be a canonical path", label)
 	}
 	switch clean {
 	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspace", "/workspaces":
-		return exit(2, "github-codespaces %s %q is too broad; choose a dedicated subdirectory", label, clean)
+		return core.Exit(2, "github-codespaces %s %q is too broad; choose a dedicated subdirectory", label, clean)
 	}
 	return nil
 }

--- a/internal/providers/githubcodespaces/gh.go
+++ b/internal/providers/githubcodespaces/gh.go
@@ -7,16 +7,18 @@ import (
 	"os"
 	"regexp"
 	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 var githubTokenPattern = regexp.MustCompile(`(?i)(?:github_pat_[a-z0-9_]{12,}|gh[opur]_[a-z0-9_]{12,}|ghs_[a-z0-9._-]{36,})`)
 
 type ghRunner struct {
-	cfg GitHubCodespacesConfig
-	rt  Runtime
+	cfg core.GitHubCodespacesConfig
+	rt  core.Runtime
 }
 
-func newGHRunner(cfg GitHubCodespacesConfig, rt Runtime) ghRunner {
+func newGHRunner(cfg core.GitHubCodespacesConfig, rt core.Runtime) ghRunner {
 	return ghRunner{cfg: cfg, rt: rt}
 }
 
@@ -56,9 +58,9 @@ func (r ghRunner) codespaceSSHConfig(ctx context.Context, codespace string) (str
 	return result.Stdout, nil
 }
 
-func (r ghRunner) run(ctx context.Context, args ...string) (LocalCommandResult, error) {
+func (r ghRunner) run(ctx context.Context, args ...string) (core.LocalCommandResult, error) {
 	if r.rt.Exec == nil {
-		return LocalCommandResult{}, exit(2, "provider=github-codespaces requires local command runner")
+		return core.LocalCommandResult{}, core.Exit(2, "provider=github-codespaces requires local command runner")
 	}
 	name := strings.TrimSpace(r.cfg.GHPath)
 	if name == "" {
@@ -66,7 +68,7 @@ func (r ghRunner) run(ctx context.Context, args ...string) (LocalCommandResult, 
 	}
 	host, err := r.apiHostname()
 	if err != nil {
-		return LocalCommandResult{}, err
+		return core.LocalCommandResult{}, err
 	}
 	dotcomTokens := githubCodespacesUsesDotcomTokenEnv(r.cfg)
 	selectedToken := githubCodespacesTokenFromEnv(r.cfg)
@@ -88,7 +90,7 @@ func (r ghRunner) run(ctx context.Context, args ...string) (LocalCommandResult, 
 		}
 		env = append(env, name+"="+selectedToken)
 	}
-	result, err := r.rt.Exec.Run(ctx, LocalCommandRequest{Name: name, Args: args, Env: env})
+	result, err := r.rt.Exec.Run(ctx, core.LocalCommandRequest{Name: name, Args: args, Env: env})
 	if err != nil {
 		return result, fmt.Errorf("github-codespaces gh %s failed: %s", strings.Join(redactGHArgs(args), " "), redactSecretText(result.Stderr+" "+err.Error()))
 	}
@@ -120,12 +122,12 @@ func (r ghRunner) apiHostname() (string, error) {
 		}
 	}
 	if host == "" {
-		return "", exit(2, "github-codespaces API URL has no hostname")
+		return "", core.Exit(2, "github-codespaces API URL has no hostname")
 	}
 	return host, nil
 }
 
-func githubCodespacesUsesDotcomTokenEnv(cfg GitHubCodespacesConfig) bool {
+func githubCodespacesUsesDotcomTokenEnv(cfg core.GitHubCodespacesConfig) bool {
 	raw := strings.TrimSpace(cfg.APIURL)
 	if raw == "" {
 		raw = defaultAPIURL

--- a/internal/providers/githubcodespaces/gh_test.go
+++ b/internal/providers/githubcodespaces/gh_test.go
@@ -6,11 +6,13 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestGHRunnerCodespaceSSHConfigArgv(t *testing.T) {
-	runner := &recordingRunner{result: LocalCommandResult{Stdout: "Host sturdy-space\n"}}
-	gh := newGHRunner(GitHubCodespacesConfig{GHPath: "/opt/gh"}, Runtime{Exec: runner})
+	runner := &recordingRunner{result: core.LocalCommandResult{Stdout: "Host sturdy-space\n"}}
+	gh := newGHRunner(core.GitHubCodespacesConfig{GHPath: "/opt/gh"}, core.Runtime{Exec: runner})
 	out, err := gh.codespaceSSHConfig(context.Background(), "sturdy-space")
 	if err != nil {
 		t.Fatal(err)
@@ -32,7 +34,7 @@ func TestGHRunnerCodespaceSSHConfigArgv(t *testing.T) {
 
 func TestGHRunnerAuthStatusReadOnly(t *testing.T) {
 	runner := &recordingRunner{}
-	gh := newGHRunner(GitHubCodespacesConfig{GHPath: "gh"}, Runtime{Exec: runner})
+	gh := newGHRunner(core.GitHubCodespacesConfig{GHPath: "gh"}, core.Runtime{Exec: runner})
 	if err := gh.authStatus(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -44,10 +46,10 @@ func TestGHRunnerAuthStatusReadOnly(t *testing.T) {
 
 func TestGHRunnerAuthStatusFallsBackForOlderCLI(t *testing.T) {
 	runner := &recordingRunner{results: []recordingResult{
-		{result: LocalCommandResult{ExitCode: 1, Stderr: "unknown flag: --active"}},
+		{result: core.LocalCommandResult{ExitCode: 1, Stderr: "unknown flag: --active"}},
 		{},
 	}}
-	gh := newGHRunner(GitHubCodespacesConfig{GHPath: "gh"}, Runtime{Exec: runner})
+	gh := newGHRunner(core.GitHubCodespacesConfig{GHPath: "gh"}, core.Runtime{Exec: runner})
 	if err := gh.authStatus(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -66,8 +68,8 @@ func TestGHRunnerRoutesAuthAndCodespaceCommandsToConfiguredAPIHost(t *testing.T)
 	t.Setenv("GH_TOKEN", "dotcom-test-token")
 	t.Setenv("GITHUB_TOKEN", "dotcom-fallback-token")
 	t.Setenv("GH_ENTERPRISE_TOKEN", "enterprise-test-token")
-	runner := &recordingRunner{result: LocalCommandResult{Stdout: "token"}}
-	gh := newGHRunner(GitHubCodespacesConfig{GHPath: "gh", APIURL: "https://api.enterprise.example:8443/api/v3"}, Runtime{Exec: runner})
+	runner := &recordingRunner{result: core.LocalCommandResult{Stdout: "token"}}
+	gh := newGHRunner(core.GitHubCodespacesConfig{GHPath: "gh", APIURL: "https://api.enterprise.example:8443/api/v3"}, core.Runtime{Exec: runner})
 	if _, err := gh.authToken(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -101,8 +103,8 @@ func TestGHRunnerRoutesAuthAndCodespaceCommandsToConfiguredAPIHost(t *testing.T)
 func TestGHRunnerMapsGHECloudAPIHostToCLIHost(t *testing.T) {
 	t.Setenv("GH_TOKEN", "dotcom-test-token")
 	t.Setenv("GH_ENTERPRISE_TOKEN", "enterprise-test-token")
-	runner := &recordingRunner{result: LocalCommandResult{Stdout: "token"}}
-	gh := newGHRunner(GitHubCodespacesConfig{GHPath: "gh", APIURL: "https://api.octocorp.ghe.com"}, Runtime{Exec: runner})
+	runner := &recordingRunner{result: core.LocalCommandResult{Stdout: "token"}}
+	gh := newGHRunner(core.GitHubCodespacesConfig{GHPath: "gh", APIURL: "https://api.octocorp.ghe.com"}, core.Runtime{Exec: runner})
 	if _, err := gh.authToken(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -130,8 +132,8 @@ func TestGHRunnerMapsGHECloudAPIHostToCLIHost(t *testing.T) {
 }
 
 func TestGHRunnerMapsGHECloudDefaultHTTPSPortToPortlessCLIHost(t *testing.T) {
-	runner := &recordingRunner{result: LocalCommandResult{Stdout: "value"}}
-	gh := newGHRunner(GitHubCodespacesConfig{GHPath: "gh", APIURL: "https://api.octocorp.ghe.com:443"}, Runtime{Exec: runner})
+	runner := &recordingRunner{result: core.LocalCommandResult{Stdout: "value"}}
+	gh := newGHRunner(core.GitHubCodespacesConfig{GHPath: "gh", APIURL: "https://api.octocorp.ghe.com:443"}, core.Runtime{Exec: runner})
 	if _, err := gh.authToken(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -146,10 +148,10 @@ func TestGHRunnerMapsGHECloudDefaultHTTPSPortToPortlessCLIHost(t *testing.T) {
 
 func TestGHRunnerErrorRedactsToken(t *testing.T) {
 	runner := &recordingRunner{
-		result: LocalCommandResult{ExitCode: 1, Stderr: "denied ghp_this_token_value_is_redacted"},
+		result: core.LocalCommandResult{ExitCode: 1, Stderr: "denied ghp_this_token_value_is_redacted"},
 		err:    fmt.Errorf("ghp_this_token_value_is_redacted failed"),
 	}
-	gh := newGHRunner(GitHubCodespacesConfig{GHPath: "gh"}, Runtime{Exec: runner})
+	gh := newGHRunner(core.GitHubCodespacesConfig{GHPath: "gh"}, core.Runtime{Exec: runner})
 	_, err := gh.codespaceSSHConfig(context.Background(), "sturdy-space")
 	if err == nil {
 		t.Fatal("expected error")
@@ -182,18 +184,18 @@ func TestRedactSecretTextRedactsStatelessInstallationToken(t *testing.T) {
 }
 
 type recordingRunner struct {
-	calls   []LocalCommandRequest
-	result  LocalCommandResult
+	calls   []core.LocalCommandRequest
+	result  core.LocalCommandResult
 	err     error
 	results []recordingResult
 }
 
 type recordingResult struct {
-	result LocalCommandResult
+	result core.LocalCommandResult
 	err    error
 }
 
-func (r *recordingRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.calls = append(r.calls, req)
 	if len(r.results) > 0 {
 		result := r.results[0]
@@ -203,7 +205,7 @@ func (r *recordingRunner) Run(_ context.Context, req LocalCommandRequest) (Local
 	return r.result, r.err
 }
 
-func (r *recordingRunner) onlyCall(t *testing.T) LocalCommandRequest {
+func (r *recordingRunner) onlyCall(t *testing.T) core.LocalCommandRequest {
 	t.Helper()
 	if len(r.calls) != 1 {
 		t.Fatalf("call count=%d, want 1", len(r.calls))

--- a/internal/providers/githubcodespaces/operation_lock.go
+++ b/internal/providers/githubcodespaces/operation_lock.go
@@ -15,7 +15,7 @@ var ensureGitHubCodespacesClaimNamespace = func(string) error {
 
 func lockGitHubCodespacesLeaseOperation(ctx context.Context, leaseID string) (func(), error) {
 	if !core.IsCanonicalLeaseID(leaseID) {
-		return nil, exit(2, "invalid github-codespaces lease id %q", leaseID)
+		return nil, core.Exit(2, "invalid github-codespaces lease id %q", leaseID)
 	}
 	return lockGitHubCodespacesOperation(
 		ctx,
@@ -42,14 +42,14 @@ func lockGitHubCodespacesOperation(ctx context.Context, lockName, description st
 	}
 	stateDir = filepath.Clean(stateDir)
 	if !filepath.IsAbs(stateDir) {
-		return nil, exit(2, "github-codespaces state directory must be absolute: %s", stateDir)
+		return nil, core.Exit(2, "github-codespaces state directory must be absolute: %s", stateDir)
 	}
 	if err := ensureGitHubCodespacesClaimNamespace(stateDir); err != nil {
-		return nil, exit(2, "create github-codespaces claim namespace: %v", err)
+		return nil, core.Exit(2, "create github-codespaces claim namespace: %v", err)
 	}
 	lockDir := filepath.Join(stateDir, "claim-locks")
 	if err := os.MkdirAll(lockDir, 0o700); err != nil {
-		return nil, exit(2, "create github-codespaces lock directory: %v", err)
+		return nil, core.Exit(2, "create github-codespaces lock directory: %v", err)
 	}
 	lockPath := filepath.Join(lockDir, lockName)
 	return shared.LockOperationFile(ctx, lockPath, description)

--- a/internal/providers/githubcodespaces/provider.go
+++ b/internal/providers/githubcodespaces/provider.go
@@ -25,8 +25,8 @@ func (Provider) Aliases() []string {
 	return []string{"codespaces", "gh-codespaces"}
 }
 
-func (Provider) Spec() ProviderSpec {
-	return ProviderSpec{
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
 		Authentication:   core.DirectProviderAuthentication(core.ProviderAuthenticationCLI),
 		Name:             providerName,
 		Family:           providerFamily,
@@ -38,15 +38,15 @@ func (Provider) Spec() ProviderSpec {
 	}
 }
 
-func (Provider) RegisterFlags(fs *flag.FlagSet, defaults Config) any {
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return RegisterGitHubCodespacesProviderFlags(fs, defaults)
 }
 
-func (Provider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	return ApplyGitHubCodespacesProviderFlags(cfg, fs, values)
 }
 
-func (Provider) ApplyConfigDefaults(cfg *Config) error {
+func (Provider) ApplyConfigDefaults(cfg *core.Config) error {
 	c := &cfg.GitHubCodespaces
 	if strings.TrimSpace(c.GHPath) == "" {
 		c.GHPath = defaultGHPath
@@ -57,7 +57,7 @@ func (Provider) ApplyConfigDefaults(cfg *Config) error {
 	if c.IdleTimeout == 0 {
 		c.IdleTimeout = time.Duration(defaultIdleTimeoutMinutes) * time.Minute
 	}
-	if c.RetentionPeriod == 0 && !retentionPeriodExplicit(*cfg) {
+	if c.RetentionPeriod == 0 && !core.GitHubCodespacesRetentionExplicit(*cfg) {
 		c.RetentionPeriod = time.Duration(defaultRetentionPeriodDays) * 24 * time.Hour
 	}
 	if strings.TrimSpace(c.WorkRoot) == "" {
@@ -81,11 +81,11 @@ func (Provider) ApplyConfigDefaults(cfg *Config) error {
 	return ValidateGitHubCodespacesConfig(*cfg)
 }
 
-func (Provider) ClaimScope(cfg Config) string {
+func (Provider) ClaimScope(cfg core.Config) string {
 	return githubCodespacesClaimScope(cfg)
 }
 
-func (Provider) ServerTypeForConfig(cfg Config) string {
+func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	if cfg.ServerTypeExplicit && cfg.ServerType != "" {
 		return cfg.ServerType
 	}
@@ -99,7 +99,7 @@ func (Provider) ServerTypeForClass(string) string {
 	return defaultCodespaceMachine
 }
 
-func (p Provider) Configure(cfg Config, rt Runtime) (Backend, error) {
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	cfg.Provider = providerName
 	if err := ValidateGitHubCodespacesConfig(cfg); err != nil {
 		return nil, err
@@ -107,6 +107,6 @@ func (p Provider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return newBackend(p.Spec(), cfg, rt), nil
 }
 
-func (p Provider) ConfigureDoctor(cfg Config, rt Runtime) (core.DoctorBackend, error) {
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
 	return shared.ConfigureDoctor("github-codespaces", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/githubcodespaces/provider_test.go
+++ b/internal/providers/githubcodespaces/provider_test.go
@@ -289,7 +289,7 @@ func TestCodespacesWorkRootFlagControlsDefaultDerivation(t *testing.T) {
 			if err := (Provider{}).ApplyConfigDefaults(&cfg); err != nil {
 				t.Fatal(err)
 			}
-			backend := newBackend(Provider{}.Spec(), cfg, Runtime{})
+			backend := newBackend(Provider{}.Spec(), cfg, core.Runtime{})
 			if got := backend.effectiveWorkRoot("example-org/my-app"); got != tt.want {
 				t.Fatalf("work root=%q want %q", got, tt.want)
 			}

--- a/internal/providers/githubcodespaces/recovery.go
+++ b/internal/providers/githubcodespaces/recovery.go
@@ -8,9 +8,11 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func githubCodespacesClaimScope(cfg Config) string {
+func githubCodespacesClaimScope(cfg core.Config) string {
 	endpoint := strings.TrimSpace(cfg.GitHubCodespaces.APIURL)
 	if endpoint != "" {
 		parsed, err := url.Parse(endpoint)
@@ -37,7 +39,7 @@ func githubCodespacesClaimScope(cfg Config) string {
 	return strings.Join(parts, "|")
 }
 
-func (b *backend) claimConfig(repo string) Config {
+func (b *backend) claimConfig(repo string) core.Config {
 	cfg := b.repoConfig(repo)
 	cfg.GitHubCodespaces.Repo = strings.TrimSpace(repo)
 	if strings.TrimSpace(cfg.GitHubCodespaces.APIURL) == "" {
@@ -46,32 +48,32 @@ func (b *backend) claimConfig(repo string) Config {
 	return cfg
 }
 
-func (b *backend) validateClaimScope(claim LeaseClaim, user githubUser) error {
+func (b *backend) validateClaimScope(claim core.LeaseClaim, user githubUser) error {
 	if claim.Provider != providerName {
-		return exit(4, "%q is claimed by provider %s", claim.LeaseID, claim.Provider)
+		return core.Exit(4, "%q is claimed by provider %s", claim.LeaseID, claim.Provider)
 	}
 	repo := strings.TrimSpace(claim.Labels[labelRepository])
 	expectedScope := providerClaimScope(b.claimConfig(repo))
 	if expectedScope == "" || claim.ProviderScope != expectedScope {
-		return exit(4, "github-codespaces claim %s scope mismatch: claim=%q current=%q", claim.LeaseID, claim.ProviderScope, expectedScope)
+		return core.Exit(4, "github-codespaces claim %s scope mismatch: claim=%q current=%q", claim.LeaseID, claim.ProviderScope, expectedScope)
 	}
 	expectedUserID, err := strconv.ParseInt(strings.TrimSpace(claim.Labels[labelUserID]), 10, 64)
 	if err != nil || expectedUserID <= 0 {
-		return exit(4, "github-codespaces claim %s has no valid authenticated user identity", claim.LeaseID)
+		return core.Exit(4, "github-codespaces claim %s has no valid authenticated user identity", claim.LeaseID)
 	}
 	if expectedUserID != user.ID {
-		return exit(3, "github-codespaces account mismatch: current login=%s id=%d does not match lease login=%s id=%d", user.Login, user.ID, claim.Labels[labelLogin], expectedUserID)
+		return core.Exit(3, "github-codespaces account mismatch: current login=%s id=%d does not match lease login=%s id=%d", user.Login, user.ID, claim.Labels[labelLogin], expectedUserID)
 	}
 	if repo == "" {
-		return exit(4, "github-codespaces claim %s has no repository identity", claim.LeaseID)
+		return core.Exit(4, "github-codespaces claim %s has no repository identity", claim.LeaseID)
 	}
 	return nil
 }
 
-func (b *backend) claimPendingCreate(leaseID, slug, repo string, user githubUser, displayName, recoveryNonce, repoRoot, release string, keep, reclaim bool) (LeaseClaim, error) {
+func (b *backend) claimPendingCreate(leaseID, slug, repo string, user githubUser, displayName, recoveryNonce, repoRoot, release string, keep, reclaim bool) (core.LeaseClaim, error) {
 	recoveryNonce = strings.TrimSpace(recoveryNonce)
 	if recoveryNonce == "" {
-		return LeaseClaim{}, exit(2, "github-codespaces pending claim requires a recovery nonce")
+		return core.LeaseClaim{}, core.Exit(2, "github-codespaces pending claim requires a recovery nonce")
 	}
 	labels := b.labelsFor(leaseID, slug, repo, user.Login, keep, release, codespace{}, "provisioning", user)
 	delete(labels, labelCodespaceName)
@@ -81,7 +83,7 @@ func (b *backend) claimPendingCreate(leaseID, slug, repo string, user githubUser
 	labels[labelDisplayName] = displayName
 	labels[labelRecovery] = recoveryPreCreate
 	labels[labelRecoveryNonce] = recoveryNonce
-	server := Server{
+	server := core.Server{
 		Provider: providerName,
 		Name:     displayName,
 		Status:   "provisioning",
@@ -91,17 +93,13 @@ func (b *backend) claimPendingCreate(leaseID, slug, repo string, user githubUser
 		leaseID,
 		slug,
 		b.claimConfig(repo),
-		server,
-		SSHTarget{},
-		repoRoot,
+		server, core.SSHTarget{}, repoRoot,
 		b.cfg.IdleTimeout,
-		reclaim,
-		LeaseClaim{},
-		false,
+		reclaim, core.LeaseClaim{}, false,
 	)
 }
 
-func (b *backend) recoverPendingClaim(api codespacesAPI, claim LeaseClaim, user githubUser) (LeaseClaim, codespace, error) {
+func (b *backend) recoverPendingClaim(api codespacesAPI, claim core.LeaseClaim, user githubUser) (core.LeaseClaim, codespace, error) {
 	item, err := b.recoverPendingResource(api, claim, user)
 	if err != nil {
 		return claim, codespace{}, err
@@ -109,7 +107,7 @@ func (b *backend) recoverPendingClaim(api codespacesAPI, claim LeaseClaim, user 
 	return b.bindCreatedClaim(claim, item)
 }
 
-func (b *backend) recoverPendingResource(api codespacesAPI, claim LeaseClaim, user githubUser) (codespace, error) {
+func (b *backend) recoverPendingResource(api codespacesAPI, claim core.LeaseClaim, user githubUser) (codespace, error) {
 	if err := b.validateClaimScope(claim, user); err != nil {
 		return codespace{}, err
 	}
@@ -117,15 +115,12 @@ func (b *backend) recoverPendingResource(api codespacesAPI, claim LeaseClaim, us
 	defer cancel()
 	items, err := api.listCodespaces(ctx)
 	if err != nil {
-		return codespace{}, errors.Join(
-			exit(4, "github-codespaces create recovery is still pending for lease=%s; claim retained", claim.LeaseID),
-			err,
-		)
+		return codespace{}, errors.Join(core.Exit(4, "github-codespaces create recovery is still pending for lease=%s; claim retained", claim.LeaseID), err)
 	}
 	return b.matchPendingClaimFromInventory(claim, user, items)
 }
 
-func (b *backend) recoverPendingClaimFromInventory(claim LeaseClaim, user githubUser, items []codespace) (LeaseClaim, codespace, error) {
+func (b *backend) recoverPendingClaimFromInventory(claim core.LeaseClaim, user githubUser, items []codespace) (core.LeaseClaim, codespace, error) {
 	item, err := b.matchPendingClaimFromInventory(claim, user, items)
 	if err != nil {
 		return claim, codespace{}, err
@@ -133,33 +128,33 @@ func (b *backend) recoverPendingClaimFromInventory(claim LeaseClaim, user github
 	return b.bindCreatedClaim(claim, item)
 }
 
-func (b *backend) matchPendingClaimFromInventory(claim LeaseClaim, user githubUser, items []codespace) (codespace, error) {
+func (b *backend) matchPendingClaimFromInventory(claim core.LeaseClaim, user githubUser, items []codespace) (codespace, error) {
 	item, found, err := b.findPendingClaimInInventory(claim, user, items)
 	if err != nil {
 		return codespace{}, err
 	}
 	if !found {
-		return codespace{}, exit(4, "github-codespaces create recovery is still pending for lease=%s; claim retained", claim.LeaseID)
+		return codespace{}, core.Exit(4, "github-codespaces create recovery is still pending for lease=%s; claim retained", claim.LeaseID)
 	}
 	return item, nil
 }
 
-func (b *backend) findPendingClaimInInventory(claim LeaseClaim, user githubUser, items []codespace) (codespace, bool, error) {
+func (b *backend) findPendingClaimInInventory(claim core.LeaseClaim, user githubUser, items []codespace) (codespace, bool, error) {
 	if err := b.validateClaimScope(claim, user); err != nil {
 		return codespace{}, false, err
 	}
 	if claim.Labels[labelRecovery] != recoveryPreCreate || strings.TrimSpace(claim.CloudID) != "" {
-		return codespace{}, false, exit(4, "github-codespaces claim %s has no valid pending-create recovery state", claim.LeaseID)
+		return codespace{}, false, core.Exit(4, "github-codespaces claim %s has no valid pending-create recovery state", claim.LeaseID)
 	}
 	displayName := strings.TrimSpace(claim.Labels[labelDisplayName])
 	repo := strings.TrimSpace(claim.Labels[labelRepository])
 	recoveryNonce := strings.TrimSpace(claim.Labels[labelRecoveryNonce])
 	if recoveryNonce == "" {
-		return codespace{}, false, exit(4, "github-codespaces legacy pending claim %s has no recovery nonce; manual recovery required; claim retained", claim.LeaseID)
+		return codespace{}, false, core.Exit(4, "github-codespaces legacy pending claim %s has no recovery nonce; manual recovery required; claim retained", claim.LeaseID)
 	}
 	expectedDisplayName := githubCodespacesDisplayName(claim.LeaseID, claim.Slug, recoveryNonce)
 	if displayName == "" || repo == "" || displayName != expectedDisplayName {
-		return codespace{}, false, exit(4, "github-codespaces claim %s has incomplete or inconsistent recovery identity; claim retained", claim.LeaseID)
+		return codespace{}, false, core.Exit(4, "github-codespaces claim %s has incomplete or inconsistent recovery identity; claim retained", claim.LeaseID)
 	}
 	matches := make([]codespace, 0, 2)
 	for _, item := range items {
@@ -172,25 +167,25 @@ func (b *backend) findPendingClaimInInventory(claim LeaseClaim, user githubUser,
 		return codespace{}, false, nil
 	case 1:
 		if strings.TrimSpace(matches[0].Name) == "" {
-			return codespace{}, false, exit(4, "matched github-codespaces recovery result has no resource identity; claim retained")
+			return codespace{}, false, core.Exit(4, "matched github-codespaces recovery result has no resource identity; claim retained")
 		}
 		item, err := validateCreatedCodespaceIdentity(claim, matches[0])
 		return item, err == nil, err
 	default:
-		return codespace{}, false, exit(4, "multiple github-codespaces resources match recovery display name %q repo %q; claim retained", displayName, repo)
+		return codespace{}, false, core.Exit(4, "multiple github-codespaces resources match recovery display name %q repo %q; claim retained", displayName, repo)
 	}
 }
 
 func rejectExistingRecoveryIdentity(items []codespace, displayName, repo string) error {
 	for _, item := range items {
 		if item.DisplayName == displayName && strings.EqualFold(strings.TrimSpace(item.Repository.FullName), strings.TrimSpace(repo)) {
-			return exit(3, "refusing github-codespaces create because recovery identity display_name=%q repo=%q already exists before create", displayName, repo)
+			return core.Exit(3, "refusing github-codespaces create because recovery identity display_name=%q repo=%q already exists before create", displayName, repo)
 		}
 	}
 	return nil
 }
 
-func (b *backend) bindCreatedClaim(expected LeaseClaim, item codespace) (LeaseClaim, codespace, error) {
+func (b *backend) bindCreatedClaim(expected core.LeaseClaim, item codespace) (core.LeaseClaim, codespace, error) {
 	item, err := validateCreatedCodespaceIdentity(expected, item)
 	if err != nil {
 		return expected, codespace{}, err
@@ -199,41 +194,41 @@ func (b *backend) bindCreatedClaim(expected LeaseClaim, item codespace) (LeaseCl
 	return claim, item, err
 }
 
-func validateCreatedCodespaceIdentity(expected LeaseClaim, item codespace) (codespace, error) {
+func validateCreatedCodespaceIdentity(expected core.LeaseClaim, item codespace) (codespace, error) {
 	name := strings.TrimSpace(item.Name)
 	if name == "" {
-		return codespace{}, exit(4, "github-codespaces create returned no resource identity; recovery claim retained")
+		return codespace{}, core.Exit(4, "github-codespaces create returned no resource identity; recovery claim retained")
 	}
 	displayName := strings.TrimSpace(expected.Labels[labelDisplayName])
 	recoveryNonce := strings.TrimSpace(expected.Labels[labelRecoveryNonce])
 	repo := strings.TrimSpace(expected.Labels[labelRepository])
 	if recoveryNonce == "" || displayName != githubCodespacesDisplayName(expected.LeaseID, expected.Slug, recoveryNonce) {
-		return codespace{}, exit(4, "github-codespaces create recovery identity changed before binding; claim retained")
+		return codespace{}, core.Exit(4, "github-codespaces create recovery identity changed before binding; claim retained")
 	}
 	if item.DisplayName != "" && item.DisplayName != displayName {
-		return codespace{}, exit(4, "github-codespaces create display name mismatch: got %q want %q; recovery claim retained", item.DisplayName, displayName)
+		return codespace{}, core.Exit(4, "github-codespaces create display name mismatch: got %q want %q; recovery claim retained", item.DisplayName, displayName)
 	}
 	liveRepo := strings.TrimSpace(item.Repository.FullName)
 	if liveRepo == "" {
-		return codespace{}, exit(4, "github-codespaces create returned no repository identity; recovery claim retained")
+		return codespace{}, core.Exit(4, "github-codespaces create returned no repository identity; recovery claim retained")
 	}
 	if !strings.EqualFold(liveRepo, repo) {
-		return codespace{}, exit(4, "github-codespaces create repository mismatch: got %q want %q; recovery claim retained", item.Repository.FullName, repo)
+		return codespace{}, core.Exit(4, "github-codespaces create repository mismatch: got %q want %q; recovery claim retained", item.Repository.FullName, repo)
 	}
 	ownerLogin := strings.TrimSpace(item.Owner.Login)
 	expectedUserID, userIDErr := strconv.ParseInt(strings.TrimSpace(expected.Labels[labelUserID]), 10, 64)
 	if item.ID <= 0 || strings.TrimSpace(item.EnvironmentID) == "" || item.Owner.ID <= 0 || ownerLogin == "" || item.Repository.ID <= 0 {
-		return codespace{}, exit(4, "github-codespaces create returned incomplete permanent resource identity; recovery claim retained")
+		return codespace{}, core.Exit(4, "github-codespaces create returned incomplete permanent resource identity; recovery claim retained")
 	}
 	if userIDErr != nil || expectedUserID <= 0 || item.Owner.ID != expectedUserID {
-		return codespace{}, exit(4, "github-codespaces create owner mismatch: got login=%q id=%d want login=%q id=%d; recovery claim retained", ownerLogin, item.Owner.ID, expected.Labels[labelLogin], expectedUserID)
+		return codespace{}, core.Exit(4, "github-codespaces create owner mismatch: got login=%q id=%d want login=%q id=%d; recovery claim retained", ownerLogin, item.Owner.ID, expected.Labels[labelLogin], expectedUserID)
 	}
 	item.Repository.FullName = liveRepo
 	item.Owner.Login = ownerLogin
 	return item, nil
 }
 
-func (b *backend) bindValidatedCreatedClaim(expected LeaseClaim, item codespace) (LeaseClaim, error) {
+func (b *backend) bindValidatedCreatedClaim(expected core.LeaseClaim, item codespace) (core.LeaseClaim, error) {
 	name := strings.TrimSpace(item.Name)
 	displayName := strings.TrimSpace(expected.Labels[labelDisplayName])
 	repo := firstNonEmpty(strings.TrimSpace(item.Repository.FullName), strings.TrimSpace(expected.Labels[labelRepository]))
@@ -265,31 +260,31 @@ func githubCodespacesCreateMayHaveSucceeded(err error) bool {
 	return status == http.StatusRequestTimeout || status == http.StatusTooManyRequests || status >= http.StatusInternalServerError
 }
 
-func discardPendingClaim(claim LeaseClaim) error {
+func discardPendingClaim(claim core.LeaseClaim) error {
 	if strings.TrimSpace(claim.CloudID) != "" || claim.Labels[labelRecovery] != recoveryPreCreate {
-		return exit(4, "refusing to discard non-pending github-codespaces claim %s", claim.LeaseID)
+		return core.Exit(4, "refusing to discard non-pending github-codespaces claim %s", claim.LeaseID)
 	}
-	return removeLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+	return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
 		return removeStoredSSHConfig(claim.LeaseID)
 	})
 }
 
-func discardMissingBoundClaim(claim LeaseClaim) error {
+func discardMissingBoundClaim(claim core.LeaseClaim) error {
 	name := strings.TrimSpace(claim.CloudID)
 	resourceID, resourceIDErr := strconv.ParseInt(strings.TrimSpace(claim.Labels[labelCodespaceID]), 10, 64)
 	ownerID, ownerIDErr := strconv.ParseInt(strings.TrimSpace(claim.Labels[labelOwnerID]), 10, 64)
 	if name == "" || claim.Labels[labelCodespaceName] != name || resourceIDErr != nil || resourceID <= 0 || ownerIDErr != nil || ownerID <= 0 || strings.TrimSpace(claim.Labels[labelEnvironmentID]) == "" {
-		return exit(4, "refusing to discard github-codespaces claim %s without its exact bound resource identity", claim.LeaseID)
+		return core.Exit(4, "refusing to discard github-codespaces claim %s without its exact bound resource identity", claim.LeaseID)
 	}
-	return removeLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+	return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
 		return removeStoredSSHConfig(claim.LeaseID)
 	})
 }
 
-func rollbackCreatedCodespace(api codespacesAPI, claim LeaseClaim) error {
+func rollbackCreatedCodespace(api codespacesAPI, claim core.LeaseClaim) error {
 	name := strings.TrimSpace(claim.CloudID)
 	if name == "" || claim.Labels[labelCodespaceName] != name {
-		return exit(4, "refusing github-codespaces rollback for lease=%s without its exact bound resource identity", claim.LeaseID)
+		return core.Exit(4, "refusing github-codespaces rollback for lease=%s without its exact bound resource identity", claim.LeaseID)
 	}
 	preflightCtx, preflightCancel := context.WithTimeout(context.Background(), githubCodespacesRollbackTimeout)
 	defer preflightCancel()
@@ -302,12 +297,12 @@ func rollbackCreatedCodespace(api codespacesAPI, claim LeaseClaim) error {
 			return err
 		}
 	}
-	return removeLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+	return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
 		ctx, cancel := context.WithTimeout(context.Background(), githubCodespacesRollbackTimeout)
 		defer cancel()
 		item, err := api.getCodespace(ctx, name)
 		if isGitHubNotFound(err) {
-			return exit(4, "github-codespaces rollback could not confirm created resource %s for lease=%s; recovery claim retained", name, claim.LeaseID)
+			return core.Exit(4, "github-codespaces rollback could not confirm created resource %s for lease=%s; recovery claim retained", name, claim.LeaseID)
 		}
 		if err != nil {
 			return err
@@ -327,9 +322,9 @@ func rollbackCreatedCodespace(api codespacesAPI, claim LeaseClaim) error {
 	})
 }
 
-func rollbackUnboundCreatedCodespace(api codespacesAPI, pending LeaseClaim, item codespace) error {
+func rollbackUnboundCreatedCodespace(api codespacesAPI, pending core.LeaseClaim, item codespace) error {
 	if strings.TrimSpace(pending.CloudID) != "" || pending.Labels[labelRecovery] != recoveryPreCreate {
-		return exit(4, "refusing unbound github-codespaces rollback for non-pending claim %s", pending.LeaseID)
+		return core.Exit(4, "refusing unbound github-codespaces rollback for non-pending claim %s", pending.LeaseID)
 	}
 	if _, err := validateCreatedCodespaceIdentity(pending, item); err != nil {
 		return err
@@ -339,7 +334,7 @@ func rollbackUnboundCreatedCodespace(api codespacesAPI, pending LeaseClaim, item
 	defer preflightCancel()
 	live, err := api.getCodespace(preflightCtx, name)
 	if isGitHubNotFound(err) {
-		return exit(4, "github-codespaces rollback could not yet confirm created resource %s for lease=%s; recovery claim retained", name, pending.LeaseID)
+		return core.Exit(4, "github-codespaces rollback could not yet confirm created resource %s for lease=%s; recovery claim retained", name, pending.LeaseID)
 	}
 	if err != nil {
 		return err
@@ -347,12 +342,12 @@ func rollbackUnboundCreatedCodespace(api codespacesAPI, pending LeaseClaim, item
 	if err := validatePendingRecoveryResource(pending, item, live); err != nil {
 		return err
 	}
-	return removeLeaseClaimIfUnchangedAfter(pending.LeaseID, pending, func() error {
+	return core.RemoveLeaseClaimIfUnchangedAfter(pending.LeaseID, pending, func() error {
 		ctx, cancel := context.WithTimeout(context.Background(), githubCodespacesRollbackTimeout)
 		defer cancel()
 		live, err := api.getCodespace(ctx, name)
 		if isGitHubNotFound(err) {
-			return exit(4, "github-codespaces rollback could not confirm created resource %s for lease=%s; recovery claim retained", name, pending.LeaseID)
+			return core.Exit(4, "github-codespaces rollback could not confirm created resource %s for lease=%s; recovery claim retained", name, pending.LeaseID)
 		}
 		if err != nil {
 			return err
@@ -372,15 +367,15 @@ func rollbackUnboundCreatedCodespace(api codespacesAPI, pending LeaseClaim, item
 	})
 }
 
-func validatePendingRecoveryResource(pending LeaseClaim, expected, live codespace) error {
+func validatePendingRecoveryResource(pending core.LeaseClaim, expected, live codespace) error {
 	nonce := strings.TrimSpace(pending.Labels[labelRecoveryNonce])
 	displayName := strings.TrimSpace(pending.Labels[labelDisplayName])
 	repo := strings.TrimSpace(pending.Labels[labelRepository])
 	if nonce == "" || displayName != githubCodespacesDisplayName(pending.LeaseID, pending.Slug, nonce) {
-		return exit(4, "refusing github-codespaces rollback for lease=%s with inconsistent recovery identity", pending.LeaseID)
+		return core.Exit(4, "refusing github-codespaces rollback for lease=%s with inconsistent recovery identity", pending.LeaseID)
 	}
 	if strings.TrimSpace(live.Name) != strings.TrimSpace(expected.Name) || live.ID != expected.ID || live.EnvironmentID != expected.EnvironmentID || live.Owner.ID != expected.Owner.ID || !strings.EqualFold(strings.TrimSpace(live.Repository.FullName), repo) {
-		return exit(4, "refusing github-codespaces rollback for lease=%s after recovery resource identity changed", pending.LeaseID)
+		return core.Exit(4, "refusing github-codespaces rollback for lease=%s after recovery resource identity changed", pending.LeaseID)
 	}
 	return nil
 }

--- a/internal/providers/githubcodespaces/recovery_safety_test.go
+++ b/internal/providers/githubcodespaces/recovery_safety_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestRecoveryNonceUsesCryptoEntropy(t *testing.T) {
@@ -34,8 +36,8 @@ func TestAcquireFailsBeforeCreateWhenRecoveryEntropyFails(t *testing.T) {
 	b.newRecoveryNonce = func() (string, error) { return "", errors.New("entropy unavailable") }
 	leaseID := "cbx_123456789b05"
 
-	_, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: leaseID,
 		RequestedSlug:    "entropy-box",
 	})
@@ -45,7 +47,7 @@ func TestAcquireFailsBeforeCreateWhenRecoveryEntropyFails(t *testing.T) {
 	if len(fc.creates) != 0 {
 		t.Fatalf("create called after entropy failure: %#v", fc.creates)
 	}
-	if _, ok, claimErr := readLeaseClaimWithPresence(leaseID); claimErr != nil || ok {
+	if _, ok, claimErr := core.ReadLeaseClaimWithPresence(leaseID); claimErr != nil || ok {
 		t.Fatalf("claim persisted ok=%t err=%v", ok, claimErr)
 	}
 }
@@ -65,8 +67,8 @@ func TestAcquireRejectsPreExistingRecoveryIdentityBeforeCreate(t *testing.T) {
 	item.Repository.FullName = "example-org/my-app"
 	fc.items[item.Name] = item
 
-	_, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: leaseID,
 		RequestedSlug:    slug,
 	})
@@ -76,7 +78,7 @@ func TestAcquireRejectsPreExistingRecoveryIdentityBeforeCreate(t *testing.T) {
 	if len(fc.creates) != 0 {
 		t.Fatalf("create called for pre-existing recovery identity: %#v", fc.creates)
 	}
-	if _, ok, claimErr := readLeaseClaimWithPresence(leaseID); claimErr != nil || ok {
+	if _, ok, claimErr := core.ReadLeaseClaimWithPresence(leaseID); claimErr != nil || ok {
 		t.Fatalf("claim persisted ok=%t err=%v", ok, claimErr)
 	}
 	if len(fc.starts) != 0 || len(fc.stops) != 0 || len(fc.deletes) != 0 {
@@ -98,11 +100,11 @@ func TestResolveRetainsLegacyPendingClaimWithoutRecoveryNonce(t *testing.T) {
 	item.Repository.FullName = "example-org/my-app"
 	fc.items[item.Name] = item
 
-	_, err := b.Resolve(context.Background(), ResolveRequest{ID: leaseID})
+	_, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID})
 	if err == nil || !strings.Contains(err.Error(), "manual") || !strings.Contains(err.Error(), "claim retained") {
 		t.Fatalf("err=%v", err)
 	}
-	after, ok, claimErr := readLeaseClaimWithPresence(leaseID)
+	after, ok, claimErr := core.ReadLeaseClaimWithPresence(leaseID)
 	if claimErr != nil || !ok {
 		t.Fatalf("claim ok=%t err=%v", ok, claimErr)
 	}
@@ -126,14 +128,14 @@ func TestResolveNoLocalStateMutationsMatchesPendingRecoveryWithoutPersistence(t 
 	item.Repository.FullName = "Example-Org/My-App"
 	fc.items[item.Name] = item
 
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: leaseID, NoLocalStateMutations: true})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, NoLocalStateMutations: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if lease.LeaseID != leaseID || lease.Server.CloudID != item.Name || lease.SSH.Host != "cs."+item.Name+".main" {
 		t.Fatalf("lease=%#v", lease)
 	}
-	after, ok, claimErr := readLeaseClaimWithPresence(leaseID)
+	after, ok, claimErr := core.ReadLeaseClaimWithPresence(leaseID)
 	if claimErr != nil || !ok {
 		t.Fatalf("claim ok=%t err=%v", ok, claimErr)
 	}
@@ -165,11 +167,11 @@ func TestResolvePendingRecoveryRejectsAmbiguousNonceMatches(t *testing.T) {
 		fc.items[name] = item
 	}
 
-	_, err := b.Resolve(context.Background(), ResolveRequest{ID: leaseID, NoLocalStateMutations: true})
+	_, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, NoLocalStateMutations: true})
 	if err == nil || (!strings.Contains(err.Error(), "multiple") && !strings.Contains(err.Error(), "ambiguous")) {
 		t.Fatalf("err=%v", err)
 	}
-	after, ok, claimErr := readLeaseClaimWithPresence(leaseID)
+	after, ok, claimErr := core.ReadLeaseClaimWithPresence(leaseID)
 	if claimErr != nil || !ok {
 		t.Fatalf("claim ok=%t err=%v", ok, claimErr)
 	}
@@ -184,7 +186,7 @@ func TestPendingRecoveryClaimReservesSlugForAllocation(t *testing.T) {
 	b := newTestBackend(t, newFakeCodespacesClient(), &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"})
 	persistPendingRecoveryClaimForTest(t, b, "cbx_123456789ab6", "pending-reservation", "pending-reservation-nonce", true)
 
-	slug, err := allocateDirectLeaseSlug("cbx_123456789ab7", "pending-reservation", nil)
+	slug, err := core.AllocateDirectLeaseSlug("cbx_123456789ab7", "pending-reservation", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +195,7 @@ func TestPendingRecoveryClaimReservesSlugForAllocation(t *testing.T) {
 	}
 }
 
-func persistPendingRecoveryClaimForTest(t *testing.T, b *testBackend, leaseID, slug, nonce string, persistNonce bool) (LeaseClaim, string) {
+func persistPendingRecoveryClaimForTest(t *testing.T, b *testBackend, leaseID, slug, nonce string, persistNonce bool) (core.LeaseClaim, string) {
 	t.Helper()
 	const (
 		repo  = "example-org/my-app"
@@ -210,16 +212,16 @@ func persistPendingRecoveryClaimForTest(t *testing.T, b *testBackend, leaseID, s
 	if persistNonce {
 		labels[labelRecoveryNonce] = nonce
 	}
-	server := Server{
+	server := core.Server{
 		Provider: providerName,
 		Name:     displayName,
 		Status:   "provisioning",
 		Labels:   labels,
 	}
-	if err := claimLeaseTargetForRepoConfig(leaseID, slug, b.claimConfig(repo), server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.claimConfig(repo), server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
-	claim, ok, err := readLeaseClaimWithPresence(leaseID)
+	claim, ok, err := core.ReadLeaseClaimWithPresence(leaseID)
 	if err != nil || !ok {
 		t.Fatalf("claim ok=%t err=%v", ok, err)
 	}

--- a/internal/providers/githubcodespaces/safety_test.go
+++ b/internal/providers/githubcodespaces/safety_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestSafetyResolveRejectsDuplicateClaimSlug(t *testing.T) {
@@ -18,10 +20,10 @@ func TestSafetyResolveRejectsDuplicateClaimSlug(t *testing.T) {
 	fc.items[second.Name] = second
 	fg := &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"}
 	b := newTestBackend(t, fc, fg)
-	mustCreateSafetyClaim(t, b, first, "cbx_347000000008", "shared-slug", releaseDelete, "ready", time.Now().Add(time.Hour), SSHTarget{})
-	mustCreateSafetyClaim(t, b, second, "cbx_347000000009", "shared-slug", releaseDelete, "ready", time.Now().Add(time.Hour), SSHTarget{})
+	mustCreateSafetyClaim(t, b, first, "cbx_347000000008", "shared-slug", releaseDelete, "ready", time.Now().Add(time.Hour), core.SSHTarget{})
+	mustCreateSafetyClaim(t, b, second, "cbx_347000000009", "shared-slug", releaseDelete, "ready", time.Now().Add(time.Hour), core.SSHTarget{})
 
-	if _, err := b.Resolve(context.Background(), ResolveRequest{ID: "shared-slug"}); err == nil || !strings.Contains(err.Error(), "multiple") {
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "shared-slug"}); err == nil || !strings.Contains(err.Error(), "multiple") {
 		t.Fatalf("duplicate slug resolve err=%v", err)
 	}
 	if len(fc.starts) != 0 || fg.configFor != "" {
@@ -36,9 +38,9 @@ func TestSafetyResolveCanonicalIDNeverFallsBackToSlug(t *testing.T) {
 	fc.items[item.Name] = item
 	fg := &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"}
 	b := newTestBackend(t, fc, fg)
-	mustCreateSafetyClaim(t, b, item, "cbx_34700000000a", "cbx-aaaaaaaaaaaa", releaseDelete, "ready", time.Now().Add(time.Hour), SSHTarget{})
+	mustCreateSafetyClaim(t, b, item, "cbx_34700000000a", "cbx-aaaaaaaaaaaa", releaseDelete, "ready", time.Now().Add(time.Hour), core.SSHTarget{})
 
-	if _, err := b.Resolve(context.Background(), ResolveRequest{ID: "cbx_aaaaaaaaaaaa"}); err == nil || !strings.Contains(err.Error(), "not found") {
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "cbx_aaaaaaaaaaaa"}); err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Fatalf("canonical miss resolve err=%v", err)
 	}
 	if len(fc.starts) != 0 || fg.configFor != "" {
@@ -84,15 +86,15 @@ func TestSafetyResolveRevalidatesIdentityBeforeMutationAndSSH(t *testing.T) {
 			fg := &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"}
 			b := newTestBackend(t, fc, fg)
 			leaseID := "cbx_34700000000e"
-			mustCreateSafetyClaim(t, b, item, leaseID, "resolve-replacement", releaseDelete, "ready", time.Now().Add(time.Hour), SSHTarget{})
+			mustCreateSafetyClaim(t, b, item, leaseID, "resolve-replacement", releaseDelete, "ready", time.Now().Add(time.Hour), core.SSHTarget{})
 
-			if _, err := b.Resolve(context.Background(), ResolveRequest{ID: leaseID}); err == nil || !strings.Contains(err.Error(), "environment id changed") {
+			if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID}); err == nil || !strings.Contains(err.Error(), "environment id changed") {
 				t.Fatalf("resolve err=%v", err)
 			}
 			if len(fc.starts) != test.wantStartCount || fg.configFor != "" {
 				t.Fatalf("starts=%#v config=%q", fc.starts, fg.configFor)
 			}
-			claim, ok, err := readLeaseClaimWithPresence(leaseID)
+			claim, ok, err := core.ReadLeaseClaimWithPresence(leaseID)
 			if err != nil || !ok || claim.Labels[labelState] != "ready" || claim.Labels[labelEnvironmentID] != item.EnvironmentID {
 				t.Fatalf("claim=%#v ok=%t err=%v", claim, ok, err)
 			}
@@ -105,16 +107,16 @@ func TestSafetyAcquireCarriesFinalClaimSnapshot(t *testing.T) {
 	fc := newFakeCodespacesClient()
 	fc.getSeq["cs-1"] = []codespace{fakeCodespace("cs-1", "Available")}
 	b := newTestBackend(t, fc, &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"})
-	lease, err := b.Acquire(context.Background(), AcquireRequest{
-		Repo:             Repo{Root: t.TempDir(), Name: "my-app"},
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:             core.Repo{Root: t.TempDir(), Name: "my-app"},
 		RequestedLeaseID: "cbx_34700000000b",
 		RequestedSlug:    "snapshot-box",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	snapshot, exists, set := serverLeaseClaimSnapshot(lease.Server)
-	persisted, ok, err := readLeaseClaimWithPresence(lease.LeaseID)
+	snapshot, exists, set := core.ServerLeaseClaimSnapshot(lease.Server)
+	persisted, ok, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
 	if err != nil || !ok {
 		t.Fatalf("claim ok=%t err=%v", ok, err)
 	}
@@ -131,10 +133,10 @@ func TestSafetyCleanupRejectsDuplicateCloudIDClaimsBeforeMutation(t *testing.T) 
 	b := newTestBackend(t, fc, &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"})
 	expiresAt := time.Now().Add(-time.Hour)
 
-	mustCreateSafetyClaim(t, b, item, "cbx_347000000001", "duplicate-a", releaseDelete, "ready", expiresAt, SSHTarget{})
-	mustCreateSafetyClaim(t, b, item, "cbx_347000000002", "duplicate-b", releaseDelete, "ready", expiresAt, SSHTarget{})
+	mustCreateSafetyClaim(t, b, item, "cbx_347000000001", "duplicate-a", releaseDelete, "ready", expiresAt, core.SSHTarget{})
+	mustCreateSafetyClaim(t, b, item, "cbx_347000000002", "duplicate-b", releaseDelete, "ready", expiresAt, core.SSHTarget{})
 
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err == nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err == nil {
 		t.Fatal("cleanup accepted two claims bound to the same Codespace")
 	}
 	if len(fc.stops) != 0 || len(fc.deletes) != 0 {
@@ -148,7 +150,7 @@ func TestSafetyCleanupRejectsDuplicateLiveCodespaceNamesBeforeMutation(t *testin
 	item := fakeCodespace("cs-duplicate-live", "Available")
 	fc.items[item.Name] = item
 	b := newTestBackend(t, fc, &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"})
-	mustCreateSafetyClaim(t, b, item, "cbx_347000000003", "duplicate-live", releaseDelete, "ready", time.Now().Add(-time.Hour), SSHTarget{})
+	mustCreateSafetyClaim(t, b, item, "cbx_347000000003", "duplicate-live", releaseDelete, "ready", time.Now().Add(-time.Hour), core.SSHTarget{})
 
 	duplicateInventory := &duplicateCodespacesInventoryClient{
 		fakeCodespacesClient: fc,
@@ -156,7 +158,7 @@ func TestSafetyCleanupRejectsDuplicateLiveCodespaceNamesBeforeMutation(t *testin
 	}
 	b.clientFactory = func(string) codespacesAPI { return duplicateInventory }
 
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err == nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err == nil {
 		t.Fatal("cleanup accepted duplicate Codespace names in live inventory")
 	}
 	if len(fc.stops) != 0 || len(fc.deletes) != 0 {
@@ -167,14 +169,14 @@ func TestSafetyCleanupRejectsDuplicateLiveCodespaceNamesBeforeMutation(t *testin
 func TestSafetyClaimResourceRequiresPermanentIdentity(t *testing.T) {
 	item := fakeCodespace("cs-permanent-identity", "Available")
 	b := newTestBackend(t, newFakeCodespacesClient(), &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"})
-	baseClaim := LeaseClaim{
+	baseClaim := core.LeaseClaim{
 		LeaseID: "cbx_123456789ab3",
 		CloudID: item.Name,
 		Labels:  b.labelsFor("cbx_123456789ab3", "identity-box", "example-org/my-app", "alice", false, releaseDelete, item, "ready"),
 	}
 	for _, test := range []struct {
 		name        string
-		mutateClaim func(*LeaseClaim)
+		mutateClaim func(*core.LeaseClaim)
 		mutateLive  func(*codespace)
 		want        string
 	}{
@@ -182,7 +184,7 @@ func TestSafetyClaimResourceRequiresPermanentIdentity(t *testing.T) {
 		{name: "environment id changed", mutateLive: func(live *codespace) { live.EnvironmentID = "env-other" }, want: "environment id changed"},
 		{name: "owner id changed", mutateLive: func(live *codespace) { live.Owner.ID++ }, want: "owner id changed"},
 		{name: "repository id changed", mutateLive: func(live *codespace) { live.Repository.ID++ }, want: "repository id changed"},
-		{name: "missing claim id", mutateClaim: func(claim *LeaseClaim) { delete(claim.Labels, labelCodespaceID) }, want: "without complete codespace id identity"},
+		{name: "missing claim id", mutateClaim: func(claim *core.LeaseClaim) { delete(claim.Labels, labelCodespaceID) }, want: "without complete codespace id identity"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			claim := baseClaim
@@ -205,7 +207,7 @@ func TestSafetyClaimResourceRequiresPermanentIdentity(t *testing.T) {
 func TestSafetyClaimResourceAllowsRepositoryRenameWithStableID(t *testing.T) {
 	item := fakeCodespace("cs-repository-renamed", "Available")
 	b := newTestBackend(t, newFakeCodespacesClient(), &fakeGH{login: "alice", token: "test" + "-value"})
-	claim := LeaseClaim{
+	claim := core.LeaseClaim{
 		LeaseID: "cbx_123456789af5",
 		CloudID: item.Name,
 		Labels:  b.labelsFor("cbx_123456789af5", "repository-renamed", "example-org/my-app", "alice", false, releaseDelete, item, "ready"),
@@ -224,26 +226,26 @@ func TestSafetyTouchCannotRestoreStaleEndpointAfterRelease(t *testing.T) {
 	b := newTestBackend(t, fc, &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"})
 	b.cfg.GitHubCodespaces.DeleteOnRelease = false
 	leaseID := "cbx_347000000004"
-	staleTarget := SSHTarget{Host: "cs.cs-stale-touch.main", Port: "22"}
+	staleTarget := core.SSHTarget{Host: "cs.cs-stale-touch.main", Port: "22"}
 	server := mustCreateSafetyClaim(t, b, item, leaseID, "stale-touch", releaseStop, "ready", time.Now().Add(time.Hour), staleTarget)
 	staleServer := server
 	staleServer.Labels = cloneLabels(server.Labels)
 	releaseServer := server
 	releaseServer.Labels = cloneLabels(server.Labels)
 
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{
-		Lease: LeaseTarget{LeaseID: leaseID, Server: releaseServer, SSH: staleTarget},
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{
+		Lease: core.LeaseTarget{LeaseID: leaseID, Server: releaseServer, SSH: staleTarget},
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := b.Touch(context.Background(), TouchRequest{
-		Lease: LeaseTarget{LeaseID: leaseID, Server: staleServer, SSH: staleTarget},
+	if _, err := b.Touch(context.Background(), core.TouchRequest{
+		Lease: core.LeaseTarget{LeaseID: leaseID, Server: staleServer, SSH: staleTarget},
 		State: "ready",
 	}); err == nil {
 		t.Fatal("stale touch revived a released claim")
 	}
 
-	claim, ok, err := resolveLeaseClaimForProvider(leaseID, providerName)
+	claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
 	if err != nil || !ok {
 		t.Fatalf("claim ok=%t err=%v", ok, err)
 	}
@@ -259,23 +261,23 @@ func TestSafetyTouchUsesCurrentClaimInsteadOfStaleLeaseSnapshot(t *testing.T) {
 	fc.items[item.Name] = item
 	b := newTestBackend(t, fc, &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"})
 	leaseID := "cbx_347000000007"
-	currentTarget := SSHTarget{Host: "current.codespace.example", Port: "22"}
-	staleTarget := SSHTarget{Host: "stale.codespace.example", Port: "2200"}
+	currentTarget := core.SSHTarget{Host: "current.codespace.example", Port: "22"}
+	staleTarget := core.SSHTarget{Host: "stale.codespace.example", Port: "2200"}
 	staleServer := mustCreateSafetyClaim(t, b, item, leaseID, "authoritative-touch", releaseDelete, "ready", time.Now().Add(time.Hour), currentTarget)
 
-	claim, ok, err := readLeaseClaimWithPresence(leaseID)
+	claim, ok, err := core.ReadLeaseClaimWithPresence(leaseID)
 	if err != nil || !ok {
 		t.Fatalf("claim ok=%t err=%v", ok, err)
 	}
 	currentServer := serverFromClaim(claim)
 	currentServer.Labels["authoritative"] = "current"
-	if _, err := updateLeaseClaimEndpointIfUnchanged(leaseID, claim, currentServer, currentTarget); err != nil {
+	if _, err := core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, claim, currentServer, currentTarget); err != nil {
 		t.Fatal(err)
 	}
 	staleServer.Labels["authoritative"] = "stale"
 
-	touched, err := b.Touch(context.Background(), TouchRequest{
-		Lease: LeaseTarget{LeaseID: leaseID, Server: staleServer, SSH: staleTarget},
+	touched, err := b.Touch(context.Background(), core.TouchRequest{
+		Lease: core.LeaseTarget{LeaseID: leaseID, Server: staleServer, SSH: staleTarget},
 		State: "in-use",
 	})
 	if err != nil {
@@ -284,7 +286,7 @@ func TestSafetyTouchUsesCurrentClaimInsteadOfStaleLeaseSnapshot(t *testing.T) {
 	if touched.Labels["authoritative"] != "current" || touched.Labels[labelState] != "in-use" {
 		t.Fatalf("touch returned stale state: %#v", touched)
 	}
-	claim, ok, err = readLeaseClaimWithPresence(leaseID)
+	claim, ok, err = core.ReadLeaseClaimWithPresence(leaseID)
 	if err != nil || !ok {
 		t.Fatalf("claim ok=%t err=%v", ok, err)
 	}
@@ -314,7 +316,7 @@ func TestSafetyReleaseRefusesSameNameReplacementBeforeStop(t *testing.T) {
 			if test.deleteLease {
 				release = releaseDelete
 			}
-			server := mustCreateSafetyClaim(t, b, item, test.leaseID, "replacement-stop", release, "ready", time.Now().Add(time.Hour), SSHTarget{})
+			server := mustCreateSafetyClaim(t, b, item, test.leaseID, "replacement-stop", release, "ready", time.Now().Add(time.Hour), core.SSHTarget{})
 			replacement := item
 			replacement.EnvironmentID = "env-foreign-replacement"
 			if test.dirty {
@@ -322,14 +324,14 @@ func TestSafetyReleaseRefusesSameNameReplacementBeforeStop(t *testing.T) {
 			}
 			fc.items[item.Name] = replacement
 
-			err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: test.leaseID, Server: server}})
+			err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: test.leaseID, Server: server}})
 			if err == nil || !strings.Contains(err.Error(), "environment id changed") {
 				t.Fatalf("release err=%v", err)
 			}
 			if len(fc.stops) != 0 || len(fc.deletes) != 0 {
 				t.Fatalf("replacement mutated: stops=%#v deletes=%#v", fc.stops, fc.deletes)
 			}
-			claim, ok, readErr := readLeaseClaimWithPresence(test.leaseID)
+			claim, ok, readErr := core.ReadLeaseClaimWithPresence(test.leaseID)
 			if readErr != nil || !ok || claim.CloudID != item.Name || claim.Labels[labelState] != "ready" {
 				t.Fatalf("claim=%#v ok=%t err=%v", claim, ok, readErr)
 			}
@@ -345,14 +347,14 @@ func TestSafetyCleanupSkipsClaimRenewedAfterInventorySnapshot(t *testing.T) {
 	b := newTestBackend(t, fc, &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"})
 	leaseID := "cbx_347000000005"
 	now := time.Now().UTC()
-	mustCreateSafetyClaim(t, b, item, leaseID, "renewed", releaseDelete, "ready", now.Add(-time.Hour), SSHTarget{})
+	mustCreateSafetyClaim(t, b, item, leaseID, "renewed", releaseDelete, "ready", now.Add(-time.Hour), core.SSHTarget{})
 
 	renewed := false
 	var renewErr error
 	b.now = func() time.Time {
 		if !renewed {
 			renewed = true
-			claim, ok, err := resolveLeaseClaimForProvider(leaseID, providerName)
+			claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
 			if err != nil {
 				renewErr = err
 				return now
@@ -363,12 +365,12 @@ func TestSafetyCleanupSkipsClaimRenewedAfterInventorySnapshot(t *testing.T) {
 			}
 			server := serverFromClaim(claim)
 			server.Labels["expires_at"] = now.Add(time.Hour).Format(time.RFC3339)
-			renewErr = updateLeaseClaimEndpoint(leaseID, server, SSHTarget{})
+			renewErr = core.UpdateLeaseClaimEndpoint(leaseID, server, core.SSHTarget{})
 		}
 		return now
 	}
 
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if renewErr != nil {
@@ -380,7 +382,7 @@ func TestSafetyCleanupSkipsClaimRenewedAfterInventorySnapshot(t *testing.T) {
 	if len(fc.stops) != 0 || len(fc.deletes) != 0 {
 		t.Fatalf("renewed claim was mutated: stops=%#v deletes=%#v", fc.stops, fc.deletes)
 	}
-	claim, ok, err := resolveLeaseClaimForProvider(leaseID, providerName)
+	claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
 	if err != nil || !ok {
 		t.Fatalf("renewed claim ok=%t err=%v", ok, err)
 	}
@@ -401,16 +403,16 @@ func TestSafetyCleanupDirtyFallbackStopsRetainsAndSucceeds(t *testing.T) {
 	}
 	b := newTestBackend(t, fc, &fakeGH{login: "alice", token: "ghp_this_token_value_is_redacted"})
 	leaseID := "cbx_347000000006"
-	target := SSHTarget{Host: "cs.cs-dirty-cleanup.main", Port: "22"}
+	target := core.SSHTarget{Host: "cs.cs-dirty-cleanup.main", Port: "22"}
 	mustCreateSafetyClaim(t, b, item, leaseID, "dirty-cleanup", releaseDelete, "ready", time.Now().Add(-time.Hour), target)
 
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatalf("dirty fallback should stop and retain successfully: %v", err)
 	}
 	if len(fc.stops) == 0 || len(fc.deletes) != 0 {
 		t.Fatalf("dirty fallback actions: stops=%#v deletes=%#v", fc.stops, fc.deletes)
 	}
-	claim, ok, err := resolveLeaseClaimForProvider(leaseID, providerName)
+	claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
 	if err != nil || !ok {
 		t.Fatalf("retained claim ok=%t err=%v", ok, err)
 	}
@@ -437,13 +439,13 @@ func mustCreateSafetyClaim(
 	release string,
 	state string,
 	expiresAt time.Time,
-	target SSHTarget,
-) Server {
+	target core.SSHTarget,
+) core.Server {
 	t.Helper()
 	labels := b.labelsFor(leaseID, slug, "example-org/my-app", "alice", false, release, item, state)
 	labels["expires_at"] = expiresAt.UTC().Format(time.RFC3339)
 	server := b.serverFromCodespace(item, labels)
-	if err := claimLeaseTargetForRepoConfig(leaseID, slug, b.cfg, server, target, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.cfg, server, target, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	return server

--- a/internal/providers/githubcodespaces/ssh_config.go
+++ b/internal/providers/githubcodespaces/ssh_config.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type sshConfigEntry struct {
@@ -66,25 +68,25 @@ func parseSSHConfig(data string) ([]sshConfigEntry, error) {
 	return entries, nil
 }
 
-func selectSSHTarget(cfg Config, data, alias string) (SSHTarget, error) {
+func selectSSHTarget(cfg core.Config, data, alias string) (core.SSHTarget, error) {
 	entry, selectedAlias, err := selectSSHConfigEntry(data, alias)
 	if err != nil {
-		return SSHTarget{}, err
+		return core.SSHTarget{}, err
 	}
 	user := firstNonEmpty(entry.User, cfg.SSHUser)
 	if user == "" {
-		return SSHTarget{}, exit(2, "github-codespaces SSH config entry %q is missing User", selectedAlias)
+		return core.SSHTarget{}, core.Exit(2, "github-codespaces SSH config entry %q is missing User", selectedAlias)
 	}
 	if !validSSHUser(user) {
-		return SSHTarget{}, exit(2, "github-codespaces SSH config entry %q has invalid User %q", selectedAlias, user)
+		return core.SSHTarget{}, core.Exit(2, "github-codespaces SSH config entry %q has invalid User %q", selectedAlias, user)
 	}
 	if strings.TrimSpace(entry.IdentityFile) == "" {
-		return SSHTarget{}, exit(2, "github-codespaces SSH config entry %q is missing IdentityFile", selectedAlias)
+		return core.SSHTarget{}, core.Exit(2, "github-codespaces SSH config entry %q is missing IdentityFile", selectedAlias)
 	}
 	host := strings.TrimSpace(entry.HostName)
 	proxy := strings.TrimSpace(entry.ProxyCommand)
 	if host == "" && proxy == "" {
-		return SSHTarget{}, exit(2, "github-codespaces SSH config entry %q is missing HostName or ProxyCommand", selectedAlias)
+		return core.SSHTarget{}, core.Exit(2, "github-codespaces SSH config entry %q is missing HostName or ProxyCommand", selectedAlias)
 	}
 	if host == "" {
 		host = selectedAlias
@@ -94,9 +96,9 @@ func selectSSHTarget(cfg Config, data, alias string) (SSHTarget, error) {
 		port = defaultSSHPort
 	}
 	if _, err := strconv.Atoi(port); err != nil {
-		return SSHTarget{}, exit(2, "github-codespaces SSH config entry %q has invalid Port %q", selectedAlias, port)
+		return core.SSHTarget{}, core.Exit(2, "github-codespaces SSH config entry %q has invalid Port %q", selectedAlias, port)
 	}
-	target := SSHTarget{
+	target := core.SSHTarget{
 		User:           user,
 		Host:           host,
 		Key:            entry.IdentityFile,
@@ -114,7 +116,7 @@ func selectSSHTarget(cfg Config, data, alias string) (SSHTarget, error) {
 		)
 		host, err := (ghRunner{cfg: cfg.GitHubCodespaces}).apiHostname()
 		if err != nil {
-			return SSHTarget{}, err
+			return core.SSHTarget{}, err
 		}
 		target.ProxyCommand = command
 		target.ChildEnv = map[string]string{"GH_HOST": host}
@@ -125,7 +127,7 @@ func selectSSHTarget(cfg Config, data, alias string) (SSHTarget, error) {
 func selectSSHConfigEntry(data, alias string) (sshConfigEntry, string, error) {
 	alias = strings.TrimSpace(alias)
 	if alias == "" {
-		return sshConfigEntry{}, "", exit(2, "github-codespaces SSH config host alias is required")
+		return sshConfigEntry{}, "", core.Exit(2, "github-codespaces SSH config host alias is required")
 	}
 	entries, err := parseSSHConfig(data)
 	if err != nil {
@@ -152,10 +154,10 @@ func selectSSHConfigEntry(data, alias string) (sshConfigEntry, string, error) {
 		}
 	}
 	if len(matches) == 0 {
-		return sshConfigEntry{}, "", exit(4, "github-codespaces SSH config entry not found for host %q", alias)
+		return sshConfigEntry{}, "", core.Exit(4, "github-codespaces SSH config entry not found for host %q", alias)
 	}
 	if len(matches) > 1 {
-		return sshConfigEntry{}, "", exit(2, "github-codespaces SSH config entry for host %q is ambiguous", alias)
+		return sshConfigEntry{}, "", core.Exit(2, "github-codespaces SSH config entry for host %q is ambiguous", alias)
 	}
 	return matches[0], matchAliases[0], nil
 }
@@ -263,7 +265,7 @@ func validatePrivateSSHConfigFile(path string) error {
 		return err
 	}
 	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-		return exit(2, "github-codespaces SSH config path %q must be a regular non-symlink file", path)
+		return core.Exit(2, "github-codespaces SSH config path %q must be a regular non-symlink file", path)
 	}
 	return validatePrivateSSHConfigPermissions(path, info)
 }
@@ -271,7 +273,7 @@ func validatePrivateSSHConfigFile(path string) error {
 func storeSSHConfig(leaseID, data string) (string, error) {
 	leaseID = strings.TrimSpace(leaseID)
 	if leaseID == "" {
-		return "", exit(2, "github-codespaces lease id is required for SSH config storage")
+		return "", core.Exit(2, "github-codespaces lease id is required for SSH config storage")
 	}
 	dir, err := sshConfigDir()
 	if err != nil {
@@ -283,7 +285,7 @@ func storeSSHConfig(leaseID, data string) (string, error) {
 	path := filepath.Join(dir, leaseID+".ssh_config")
 	if info, err := os.Lstat(path); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-			return "", exit(2, "refusing to replace non-regular github-codespaces SSH config path %q", path)
+			return "", core.Exit(2, "refusing to replace non-regular github-codespaces SSH config path %q", path)
 		}
 	} else if !os.IsNotExist(err) {
 		return "", err
@@ -343,14 +345,14 @@ func removeStoredSSHConfig(leaseID string) error {
 }
 
 func sshConfigDir() (string, error) {
-	stateDir, err := crabboxStateDir()
+	stateDir, err := core.CrabboxStateDir()
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(stateDir, "github-codespaces"), nil
 }
 
-func githubCodespacesReadyCheck(cfg Config) string {
+func githubCodespacesReadyCheck(cfg core.Config) string {
 	workRoot := strings.TrimSpace(cfg.GitHubCodespaces.WorkRoot)
 	if workRoot == "" {
 		workRoot = strings.TrimSpace(cfg.WorkRoot)

--- a/internal/providers/githubcodespaces/ssh_config_permissions_unix.go
+++ b/internal/providers/githubcodespaces/ssh_config_permissions_unix.go
@@ -2,7 +2,11 @@
 
 package githubcodespaces
 
-import "os"
+import (
+	"os"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
 
 func securePrivateSSHConfigFile(path string) error {
 	return os.Chmod(path, defaultSSHConfigFileMode)
@@ -11,7 +15,7 @@ func securePrivateSSHConfigFile(path string) error {
 func validatePrivateSSHConfigPermissions(path string, info os.FileInfo) error {
 	mode := info.Mode().Perm()
 	if mode != defaultSSHConfigFileMode {
-		return exit(2, "github-codespaces SSH config path %q must have mode 0600, got %04o", path, mode)
+		return core.Exit(2, "github-codespaces SSH config path %q must have mode 0600, got %04o", path, mode)
 	}
 	return nil
 }

--- a/internal/providers/githubcodespaces/ssh_config_permissions_windows.go
+++ b/internal/providers/githubcodespaces/ssh_config_permissions_windows.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 	"unsafe"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"golang.org/x/sys/windows"
 )
 
@@ -76,11 +77,11 @@ func validatePrivateSSHConfigPermissions(path string, _ os.FileInfo) error {
 	}
 	owner, _, err := descriptor.Owner()
 	if err != nil || owner == nil || !owner.Equals(user) {
-		return exit(2, "github-codespaces SSH config path %q is not owned by the current user", path)
+		return core.Exit(2, "github-codespaces SSH config path %q is not owned by the current user", path)
 	}
 	dacl, _, err := descriptor.DACL()
 	if err != nil || dacl == nil || dacl.AceCount != 2 {
-		return exit(2, "github-codespaces SSH config path %q does not have a private DACL", path)
+		return core.Exit(2, "github-codespaces SSH config path %q does not have a private DACL", path)
 	}
 	seenUser, seenSystem := false, false
 	for i := uint16(0); i < dacl.AceCount; i++ {
@@ -89,7 +90,7 @@ func validatePrivateSSHConfigPermissions(path string, _ os.FileInfo) error {
 			return err
 		}
 		if ace == nil || ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE || ace.Mask&windows.ACCESS_MASK(windows.GENERIC_ALL) == 0 {
-			return exit(2, "github-codespaces SSH config path %q has a non-private DACL entry", path)
+			return core.Exit(2, "github-codespaces SSH config path %q has a non-private DACL entry", path)
 		}
 		sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
 		switch {
@@ -98,11 +99,11 @@ func validatePrivateSSHConfigPermissions(path string, _ os.FileInfo) error {
 		case sid.Equals(system):
 			seenSystem = true
 		default:
-			return exit(2, "github-codespaces SSH config path %q grants access to another principal", path)
+			return core.Exit(2, "github-codespaces SSH config path %q grants access to another principal", path)
 		}
 	}
 	if !seenUser || !seenSystem {
-		return exit(2, "github-codespaces SSH config path %q does not have the required private DACL", path)
+		return core.Exit(2, "github-codespaces SSH config path %q does not have the required private DACL", path)
 	}
 	return nil
 }

--- a/internal/providers/githubcodespaces/ssh_config_test.go
+++ b/internal/providers/githubcodespaces/ssh_config_test.go
@@ -5,10 +5,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestSSHConfigParsesProxyTarget(t *testing.T) {
-	target, err := selectSSHTarget(Config{GitHubCodespaces: GitHubCodespacesConfig{WorkRoot: "/workspaces/my-app"}}, `Host sturdy-space
+	target, err := selectSSHTarget(core.Config{GitHubCodespaces: core.GitHubCodespacesConfig{WorkRoot: "/workspaces/my-app"}}, `Host sturdy-space
   User vscode
   IdentityFile "/tmp/codespaces/key"
   UserKnownHostsFile=/dev/null
@@ -34,7 +36,7 @@ func TestSSHConfigParsesProxyTarget(t *testing.T) {
 }
 
 func TestSSHConfigSelectsGeneratedGitHubCLIAliasByProxyCodespace(t *testing.T) {
-	target, err := selectSSHTarget(Config{GitHubCodespaces: GitHubCodespacesConfig{GHPath: "/opt/github/bin/gh"}}, `Host cs.sturdy-space.main
+	target, err := selectSSHTarget(core.Config{GitHubCodespaces: core.GitHubCodespacesConfig{GHPath: "/opt/github/bin/gh"}}, `Host cs.sturdy-space.main
   User vscode
   IdentityFile "/tmp/codespaces/key"
   UserKnownHostsFile /dev/null
@@ -52,7 +54,7 @@ func TestSSHConfigSelectsGeneratedGitHubCLIAliasByProxyCodespace(t *testing.T) {
 }
 
 func TestSSHConfigProxyPinsConfiguredGitHubHost(t *testing.T) {
-	target, err := selectSSHTarget(Config{GitHubCodespaces: GitHubCodespacesConfig{APIURL: "https://api.octocorp.ghe.com"}}, `Host sturdy-space
+	target, err := selectSSHTarget(core.Config{GitHubCodespaces: core.GitHubCodespacesConfig{APIURL: "https://api.octocorp.ghe.com"}}, `Host sturdy-space
   User vscode
   IdentityFile /tmp/codespaces/key
   ProxyCommand gh codespace ssh -c sturdy-space --stdio
@@ -81,7 +83,7 @@ Host sturdy-space
 }
 
 func TestSSHConfigParsesDirectTarget(t *testing.T) {
-	target, err := selectSSHTarget(Config{}, `Host sturdy-space
+	target, err := selectSSHTarget(core.Config{}, `Host sturdy-space
   HostName 127.0.0.1
   User vscode
   Port 2222
@@ -131,7 +133,7 @@ Host sturdy
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := selectSSHTarget(Config{}, tt.data, "sturdy")
+			_, err := selectSSHTarget(core.Config{}, tt.data, "sturdy")
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("err=%v want %q", err, tt.want)
 			}
@@ -141,7 +143,7 @@ Host sturdy
 
 func TestSSHConfigRejectsInvalidUsers(t *testing.T) {
 	for _, user := range []string{"-oProxyCommand=sh", "alice@example.com", "alice bob", "alice\tbob"} {
-		_, err := selectSSHTarget(Config{}, `Host sturdy
+		_, err := selectSSHTarget(core.Config{}, `Host sturdy
   User `+user+`
   IdentityFile "/tmp/key"
   ProxyCommand gh codespace ssh -c sturdy --stdio

--- a/internal/providers/morph/backend.go
+++ b/internal/providers/morph/backend.go
@@ -21,12 +21,12 @@ import (
 const morphReadyCheck = "command -v bash >/dev/null && command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null && (command -v python3 >/dev/null || command -v python >/dev/null || command -v perl >/dev/null)"
 const morphAcquireRollbackTimeout = 30 * time.Second
 
-var waitForMorphSSHReady = waitForSSHReady
+var waitForMorphSSHReady = core.WaitForSSHReady
 
 type morphLeaseBackend struct {
-	spec              ProviderSpec
-	cfg               Config
-	rt                Runtime
+	spec              core.ProviderSpec
+	cfg               core.Config
+	rt                core.Runtime
 	client            morphAPI
 	now               func() time.Time
 	readyPollInterval time.Duration
@@ -34,17 +34,17 @@ type morphLeaseBackend struct {
 	rollbackTimeout   time.Duration
 }
 
-func RegisterMorphProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterMorphProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterMorphConfigFlags(fs, defaults.Morph)
 }
 
-func ApplyMorphProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyMorphProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if isMorphProviderName(cfg.Provider) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", "use --morph-snapshot"); err != nil {
 			return err
 		}
 		if cfg.TargetOS != "" && cfg.TargetOS != targetLinux {
-			return exit(2, "provider=morph supports target=linux only")
+			return core.Exit(2, "provider=morph supports target=linux only")
 		}
 	}
 	v, ok := values.(core.MorphConfigFlagValues)
@@ -66,7 +66,7 @@ func ApplyMorphProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	return nil
 }
 
-func NewMorphBackend(spec ProviderSpec, cfg Config, rt Runtime) (Backend, error) {
+func NewMorphBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	applyMorphDefaults(&cfg)
 	if err := validateMorphConfig(cfg); err != nil {
 		return nil, err
@@ -82,35 +82,35 @@ func NewMorphBackend(spec ProviderSpec, cfg Config, rt Runtime) (Backend, error)
 	}, nil
 }
 
-func (b *morphLeaseBackend) Spec() ProviderSpec { return b.spec }
+func (b *morphLeaseBackend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *morphLeaseBackend) RebindResolvedLeaseTarget(target *LeaseTarget, leaseID string) error {
+func (b *morphLeaseBackend) RebindResolvedLeaseTarget(target *core.LeaseTarget, leaseID string) error {
 	core.UseStoredTestboxKey(&target.SSH, leaseID)
 	return nil
 }
 
-func (b *morphLeaseBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *morphLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	cfg := b.configForRun()
 	if err := validateMorphCreateConfig(cfg); err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
 	client, err := b.api()
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
 	if _, err := client.GetSnapshot(ctx, cfg.Morph.Snapshot); err != nil {
 		if isMorphNotFound(err) {
-			return DoctorResult{}, exit(2, "provider=morph snapshot %q not found", cfg.Morph.Snapshot)
+			return core.DoctorResult{}, core.Exit(2, "provider=morph snapshot %q not found", cfg.Morph.Snapshot)
 		}
-		return DoctorResult{}, exit(1, "provider=morph snapshot lookup failed: %v", err)
+		return core.DoctorResult{}, core.Exit(1, "provider=morph snapshot lookup failed: %v", err)
 	}
 	instances, err := b.listInstances(ctx, client, false)
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return DoctorResult{
+	return core.DoctorResult{
 		Provider: providerName,
-		Checks: []DoctorCheck{{
+		Checks: []core.DoctorCheck{{
 			Status:  "ok",
 			Check:   "provider",
 			Message: fmt.Sprintf("provider=%s auth=ready control_plane=ready inventory=ready snapshot=ready api=list,get_snapshot mutation=false leases=%d runtime=unchecked", providerName, len(instances)),
@@ -129,29 +129,29 @@ func (b *morphLeaseBackend) Doctor(ctx context.Context, _ DoctorRequest) (Doctor
 	}, nil
 }
 
-func (b *morphLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+func (b *morphLeaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	cfg := b.configForRun()
 	if err := validateMorphCreateConfig(cfg); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	client, err := b.api()
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if _, err := client.GetSnapshot(ctx, cfg.Morph.Snapshot); err != nil {
 		if isMorphNotFound(err) {
-			return LeaseTarget{}, exit(2, "provider=morph snapshot %q not found", cfg.Morph.Snapshot)
+			return core.LeaseTarget{}, core.Exit(2, "provider=morph snapshot %q not found", cfg.Morph.Snapshot)
 		}
-		return LeaseTarget{}, exit(1, "morph snapshot lookup failed: %v", err)
+		return core.LeaseTarget{}, core.Exit(1, "morph snapshot lookup failed: %v", err)
 	}
 	instances, err := b.listInstances(ctx, client, false)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	leaseID := core.NewLeaseID()
-	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, serversFromLeaseViews(instances, cfg))
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, serversFromLeaseViews(instances, cfg))
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	now := b.now().UTC()
 	labels := morphLeaseMetadata(cfg, morphInstance{
@@ -166,11 +166,11 @@ func (b *morphLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (Le
 	}
 	instance, err := client.BootSnapshot(ctx, cfg.Morph.Snapshot, bootReq)
 	if err != nil {
-		return LeaseTarget{}, exit(1, "morph boot snapshot %q failed: %v", cfg.Morph.Snapshot, err)
+		return core.LeaseTarget{}, core.Exit(1, "morph boot snapshot %q failed: %v", cfg.Morph.Snapshot, err)
 	}
-	createdLease := LeaseTarget{LeaseID: leaseID, Server: Server{CloudID: instance.ID}}
+	createdLease := core.LeaseTarget{LeaseID: leaseID, Server: core.Server{CloudID: instance.ID}}
 	cleanupCreated := func() {
-		removeStoredTestboxKey(leaseID)
+		core.RemoveStoredTestboxKey(leaseID)
 		timeout := b.rollbackTimeout
 		if timeout <= 0 {
 			timeout = morphAcquireRollbackTimeout
@@ -186,28 +186,28 @@ func (b *morphLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (Le
 		if !req.Keep {
 			cleanupCreated()
 		}
-		return LeaseTarget{}, exit(1, "morph set metadata for %s failed: %v", instance.ID, err)
+		return core.LeaseTarget{}, core.Exit(1, "morph set metadata for %s failed: %v", instance.ID, err)
 	}
 	if ttlSeconds := morphTTLSecondsFromLabels(labels, b.now().UTC()); ttlSeconds > 0 {
 		if err := client.UpdateInstanceTTL(ctx, instance.ID, ttlSeconds, morphTTLAction(cfg)); err != nil {
 			if !req.Keep {
 				cleanupCreated()
 			}
-			return LeaseTarget{}, exit(1, "morph update ttl for %s failed: %v", instance.ID, err)
+			return core.LeaseTarget{}, core.Exit(1, "morph update ttl for %s failed: %v", instance.ID, err)
 		}
 	}
 	if err := client.UpdateInstanceWakeOn(ctx, instance.ID, boolPtr(cfg.Morph.WakeOnSSH), nil); err != nil {
 		if !req.Keep {
 			cleanupCreated()
 		}
-		return LeaseTarget{}, exit(1, "morph update wake-on for %s failed: %v", instance.ID, err)
+		return core.LeaseTarget{}, core.Exit(1, "morph update wake-on for %s failed: %v", instance.ID, err)
 	}
 	instance, err = b.waitForInstanceReady(ctx, client, instance.ID, false)
 	if err != nil {
 		if !req.Keep {
 			cleanupCreated()
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	instance.Metadata = labels
 	target, err := b.resolveSSHTarget(ctx, cfg, client, leaseID, instance, true)
@@ -215,7 +215,7 @@ func (b *morphLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (Le
 		if !req.Keep {
 			cleanupCreated()
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	server := morphServer(instance, cfg, leaseID, slug)
 	createdLease.Server = server
@@ -228,43 +228,43 @@ func (b *morphLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (Le
 	}
 	if claimErr != nil {
 		cleanupCreated()
-		return LeaseTarget{}, fmt.Errorf("persist exact morph instance ownership claim: %w", claimErr)
+		return core.LeaseTarget{}, fmt.Errorf("persist exact morph instance ownership claim: %w", claimErr)
 	}
 	return createdLease, nil
 }
 
-func (b *morphLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (lease LeaseTarget, err error) {
+func (b *morphLeaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (lease core.LeaseTarget, err error) {
 	cfg := b.configForRun()
 	client, err := b.api()
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	instance, leaseID, slug, err := b.resolveInstance(ctx, client, req.ID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	server := morphServer(instance, cfg, leaseID, slug)
 	if req.ReleaseOnly || (req.StatusOnly && !req.ReadyProbe) {
-		return LeaseTarget{LeaseID: leaseID, Server: server}, nil
+		return core.LeaseTarget{LeaseID: leaseID, Server: server}, nil
 	}
-	var previousClaim, preflightClaim LeaseClaim
+	var previousClaim, preflightClaim core.LeaseClaim
 	var previousClaimExists, rollbackClaim bool
 	defer func() {
 		if err == nil || !rollbackClaim {
 			return
 		}
-		if restoreErr := restoreLeaseClaimIfUnchanged(leaseID, preflightClaim, previousClaim, previousClaimExists); restoreErr != nil {
+		if restoreErr := core.RestoreLeaseClaimIfUnchanged(leaseID, preflightClaim, previousClaim, previousClaimExists); restoreErr != nil {
 			fmt.Fprintf(b.rt.Stderr, "warning: restore Morph lease claim %s after resolve failure: %v\n", leaseID, restoreErr)
 		}
 	}()
 	if req.Repo.Root != "" {
-		previousClaim, previousClaimExists, err = readLeaseClaimWithPresence(leaseID)
+		previousClaim, previousClaimExists, err = core.ReadLeaseClaimWithPresence(leaseID)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		preflightClaim, err = claimLeaseForRepoProviderIfUnchanged(leaseID, slug, providerName, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, previousClaim, previousClaimExists)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		rollbackClaim = true
 	}
@@ -275,28 +275,28 @@ func (b *morphLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (le
 				if cfg.Morph.WakeOnSSH {
 					if !instance.WakeOn.WakeOnSSH {
 						if err := client.UpdateInstanceWakeOn(ctx, instance.ID, boolPtr(true), nil); err != nil {
-							return LeaseTarget{}, exit(1, "morph enable wake-on-ssh for %s failed: %v", instance.ID, err)
+							return core.LeaseTarget{}, core.Exit(1, "morph enable wake-on-ssh for %s failed: %v", instance.ID, err)
 						}
 						instance.WakeOn.WakeOnSSH = true
 					}
 					break
 				}
 				if err := client.ResumeInstance(ctx, instance.ID); err != nil && !isMorphNotFound(err) {
-					return LeaseTarget{}, exit(1, "morph resume instance %s failed: %v", instance.ID, err)
+					return core.LeaseTarget{}, core.Exit(1, "morph resume instance %s failed: %v", instance.ID, err)
 				}
 				instance, err = b.waitForInstanceReady(ctx, client, instance.ID, false)
 			} else {
 				instance, err = b.waitForInstanceReady(ctx, client, instance.ID, true)
 			}
 			if err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 		}
 	}
 	server = morphServer(instance, cfg, leaseID, slug)
 	target, err := b.resolveSSHTarget(ctx, cfg, client, leaseID, instance, needsReady)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if needsReady && morphInstancePaused(instance) && cfg.Morph.WakeOnSSH {
 		if refreshed, refreshErr := client.GetInstance(ctx, instance.ID); refreshErr == nil {
@@ -305,15 +305,15 @@ func (b *morphLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (le
 		}
 	}
 	if req.Repo.Root != "" {
-		if _, err = updateLeaseClaimEndpointIfUnchanged(leaseID, preflightClaim, server, target); err != nil {
-			return LeaseTarget{}, err
+		if _, err = core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, preflightClaim, server, target); err != nil {
+			return core.LeaseTarget{}, err
 		}
 		rollbackClaim = false
 	}
-	return LeaseTarget{LeaseID: leaseID, Server: server, SSH: target}, nil
+	return core.LeaseTarget{LeaseID: leaseID, Server: server, SSH: target}, nil
 }
 
-func (b *morphLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *morphLeaseBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	cfg := b.configForRun()
 	client, err := b.api()
 	if err != nil {
@@ -323,7 +323,7 @@ func (b *morphLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseV
 	if err != nil {
 		return nil, err
 	}
-	views := make([]LeaseView, 0, len(instances))
+	views := make([]core.LeaseView, 0, len(instances))
 	for _, instance := range instances {
 		leaseID := strings.TrimSpace(instance.Metadata["lease"])
 		slug := strings.TrimSpace(instance.Metadata["slug"])
@@ -337,18 +337,18 @@ func (b *morphLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseV
 	return views, nil
 }
 
-func (b *morphLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *morphLeaseBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
 	return err
 }
 
-func (b *morphLeaseBackend) ReleaseLeaseWithOutcome(ctx context.Context, req ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+func (b *morphLeaseBackend) ReleaseLeaseWithOutcome(ctx context.Context, req core.ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
 	var outcome core.ReleaseLeaseOutcome
 	err := b.releaseLease(ctx, req, &outcome)
 	return outcome, err
 }
 
-func (b *morphLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
+func (b *morphLeaseBackend) releaseLease(ctx context.Context, req core.ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	cfg := b.configForRun()
 	client, err := b.api()
 	if err != nil {
@@ -360,12 +360,12 @@ func (b *morphLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRe
 		instanceID = strings.TrimSpace(req.Lease.Server.Labels["instance_id"])
 	}
 	removeMissingInstance := func() error {
-		claim, ok, claimErr := resolveLeaseClaimForProvider(core.Blank(leaseID, instanceID), providerName)
+		claim, ok, claimErr := core.ResolveLeaseClaimForProvider(core.Blank(leaseID, instanceID), providerName)
 		if claimErr != nil {
 			return claimErr
 		}
 		if !ok {
-			return exit(2, "morph instance %s has no exact local ownership claim", instanceID)
+			return core.Exit(2, "morph instance %s has no exact local ownership claim", instanceID)
 		}
 		binding := shared.ClaimBinding{
 			Provider: providerName, ProviderScope: Provider{}.ClaimScope(cfg), ExactProviderScope: true,
@@ -381,17 +381,17 @@ func (b *morphLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRe
 		}); claimErr != nil {
 			return claimErr
 		}
-		removeStoredTestboxKey(claim.LeaseID)
+		core.RemoveStoredTestboxKey(claim.LeaseID)
 		return nil
 	}
 	var instance morphInstance
 	if instanceID != "" {
 		instance, err = client.GetInstance(ctx, instanceID)
 		if err != nil && !isMorphNotFound(err) {
-			return exit(1, "morph get instance %s failed: %v", instanceID, err)
+			return core.Exit(1, "morph get instance %s failed: %v", instanceID, err)
 		}
 		if instance.ID != "" && !morphIsManaged(instance) {
-			return exit(4, "morph instance %s is not managed by Crabbox", instance.ID)
+			return core.Exit(4, "morph instance %s is not managed by Crabbox", instance.ID)
 		}
 	}
 	if instance.ID == "" {
@@ -399,8 +399,8 @@ func (b *morphLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRe
 		if resolveID != "" {
 			resolved, resolvedLeaseID, _, resolveErr := b.resolveInstance(ctx, client, resolveID)
 			if resolveErr != nil {
-				var exitErr ExitError
-				if asExitError(resolveErr, &exitErr) && exitErr.Code == 4 {
+				var exitErr core.ExitError
+				if core.AsExitError(resolveErr, &exitErr) && exitErr.Code == 4 {
 					return removeMissingInstance()
 				}
 				return resolveErr
@@ -430,7 +430,7 @@ func (b *morphLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRe
 			return fmt.Errorf("verify live morph instance %s ownership: %w", instance.ID, err)
 		}
 		if live.ID != instance.ID || !morphIsManaged(live) || live.Metadata["lease"] != leaseID || live.Metadata["slug"] != slug || live.Metadata["instance_id"] != instance.ID {
-			return exit(2, "morph instance %s ownership changed before release", instance.ID)
+			return core.Exit(2, "morph instance %s ownership changed before release", instance.ID)
 		}
 		return nil
 	}
@@ -476,14 +476,14 @@ func (b *morphLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRe
 				return err
 			}
 			if err := client.DeleteInstance(ctx, instance.ID); err != nil && !isMorphNotFound(err) {
-				return exit(1, "morph delete instance %s failed: %v", instance.ID, err)
+				return core.Exit(1, "morph delete instance %s failed: %v", instance.ID, err)
 			}
 			outcome.Terminal = true
 			return nil
 		}); err != nil {
 			return err
 		}
-		removeStoredTestboxKey(core.Blank(leaseID, instance.ID))
+		core.RemoveStoredTestboxKey(core.Blank(leaseID, instance.ID))
 		return nil
 	}
 	wasPaused := morphInstancePaused(instance)
@@ -496,21 +496,21 @@ func (b *morphLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRe
 		}
 		if !wasPaused {
 			if err := client.PauseInstance(ctx, instance.ID); err != nil && !isMorphNotFound(err) {
-				return exit(1, "morph pause instance %s failed: %v", instance.ID, err)
+				return core.Exit(1, "morph pause instance %s failed: %v", instance.ID, err)
 			}
 		}
 		if err := client.SetInstanceMetadata(ctx, instance.ID, labels); err != nil {
-			return exit(1, "morph persist paused metadata for %s failed: %v", instance.ID, err)
+			return core.Exit(1, "morph persist paused metadata for %s failed: %v", instance.ID, err)
 		}
 		return nil
 	}
 	instance.Metadata = labels
 	server := morphServer(instance, cfg, leaseID, labels["slug"])
-	_, err = updateLeaseClaimEndpointIfUnchangedAfter(leaseID, claim, server, SSHTarget{}, pauseAndPersist)
+	_, err = core.UpdateLeaseClaimEndpointIfUnchangedAfter(leaseID, claim, server, core.SSHTarget{}, pauseAndPersist)
 	return err
 }
 
-func (b *morphLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
+func (b *morphLeaseBackend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 	instance := core.Blank(core.Blank(lease.Server.CloudID, lease.Server.Labels["instance_id"]), "-")
 	if morphDeleteOnRelease(lease, b.configForRun()) {
 		return fmt.Sprintf("deleted lease=%s instance=%s", lease.LeaseID, instance)
@@ -518,18 +518,18 @@ func (b *morphLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
 	return fmt.Sprintf("paused lease=%s instance=%s retained=true", lease.LeaseID, instance)
 }
 
-func (b *morphLeaseBackend) RetainLeaseClaimAfterRelease(lease LeaseTarget) bool {
+func (b *morphLeaseBackend) RetainLeaseClaimAfterRelease(lease core.LeaseTarget) bool {
 	return !morphDeleteOnRelease(lease, b.configForRun())
 }
 
-func (b *morphLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
+func (b *morphLeaseBackend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
 	cfg := b.configForRun()
 	if req.IdleTimeout > 0 {
 		cfg.IdleTimeout = req.IdleTimeout
 	}
 	client, err := b.api()
 	if err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	leaseID := strings.TrimSpace(req.Lease.LeaseID)
 	slug := strings.TrimSpace(req.Lease.Server.Labels["slug"])
@@ -539,17 +539,17 @@ func (b *morphLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server
 		instance, err = client.GetInstance(ctx, instanceID)
 		if err != nil {
 			if isMorphNotFound(err) {
-				return Server{}, exit(4, "lease %s not found for provider=%s", core.Blank(leaseID, instanceID), providerName)
+				return core.Server{}, core.Exit(4, "lease %s not found for provider=%s", core.Blank(leaseID, instanceID), providerName)
 			}
-			return Server{}, exit(1, "morph get instance %s failed: %v", instanceID, err)
+			return core.Server{}, core.Exit(1, "morph get instance %s failed: %v", instanceID, err)
 		}
 		if !morphIsManaged(instance) {
-			return Server{}, exit(4, "morph instance %s is not managed by Crabbox", instance.ID)
+			return core.Server{}, core.Exit(4, "morph instance %s is not managed by Crabbox", instance.ID)
 		}
 	} else {
 		instance, leaseID, slug, err = b.resolveInstance(ctx, client, core.Blank(leaseID, slug))
 		if err != nil {
-			return Server{}, err
+			return core.Server{}, err
 		}
 	}
 	if instance.Metadata == nil {
@@ -561,15 +561,15 @@ func (b *morphLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server
 	}
 	labels := morphLeaseMetadata(cfg, instance, core.Blank(leaseID, instance.ID), slug, req.State, false, b.now().UTC(), true)
 	if err := client.SetInstanceMetadata(ctx, instance.ID, labels); err != nil {
-		return Server{}, exit(1, "morph set metadata for %s failed: %v", instance.ID, err)
+		return core.Server{}, core.Exit(1, "morph set metadata for %s failed: %v", instance.ID, err)
 	}
 	if ttlSeconds := morphTTLSecondsFromLabels(labels, b.now().UTC()); ttlSeconds > 0 {
 		if err := client.UpdateInstanceTTL(ctx, instance.ID, ttlSeconds, morphTTLAction(cfg)); err != nil {
-			return Server{}, exit(1, "morph update ttl for %s failed: %v", instance.ID, err)
+			return core.Server{}, core.Exit(1, "morph update ttl for %s failed: %v", instance.ID, err)
 		}
 	}
 	if err := client.UpdateInstanceWakeOn(ctx, instance.ID, boolPtr(cfg.Morph.WakeOnSSH), nil); err != nil {
-		return Server{}, exit(1, "morph update wake-on for %s failed: %v", instance.ID, err)
+		return core.Server{}, core.Exit(1, "morph update wake-on for %s failed: %v", instance.ID, err)
 	}
 	instance.Metadata = labels
 	return morphServer(instance, cfg, core.Blank(leaseID, instance.ID), slug), nil
@@ -582,7 +582,7 @@ func (b *morphLeaseBackend) api() (morphAPI, error) {
 	return newMorphClient(b.configForRun(), b.rt)
 }
 
-func (b *morphLeaseBackend) configForRun() Config {
+func (b *morphLeaseBackend) configForRun() core.Config {
 	cfg := b.cfg
 	applyMorphDefaults(&cfg)
 	return cfg
@@ -591,9 +591,9 @@ func (b *morphLeaseBackend) configForRun() Config {
 func (b *morphLeaseBackend) resolveInstance(ctx context.Context, client morphAPI, identifier string) (morphInstance, string, string, error) {
 	identifier = strings.TrimSpace(identifier)
 	if identifier == "" {
-		return morphInstance{}, "", "", exit(2, "missing lease identifier for provider=%s", providerName)
+		return morphInstance{}, "", "", core.Exit(2, "missing lease identifier for provider=%s", providerName)
 	}
-	claim, claimed, err := resolveLeaseClaimForProvider(identifier, providerName)
+	claim, claimed, err := core.ResolveLeaseClaimForProvider(identifier, providerName)
 	if err != nil {
 		return morphInstance{}, "", "", err
 	}
@@ -604,20 +604,20 @@ func (b *morphLeaseBackend) resolveInstance(ctx context.Context, client morphAPI
 		instance, err := client.GetInstance(ctx, candidate)
 		if err == nil {
 			if !morphIsManaged(instance) {
-				return morphInstance{}, "", "", exit(4, "morph instance %s is not managed by Crabbox", instance.ID)
+				return morphInstance{}, "", "", core.Exit(4, "morph instance %s is not managed by Crabbox", instance.ID)
 			}
 			instance, leaseID, slug := finalizeMorphResolution(instance, identifier, claim, claimed)
 			return instance, leaseID, slug, nil
 		}
 		if !isMorphNotFound(err) {
-			return morphInstance{}, "", "", exit(1, "morph get instance %s failed: %v", candidate, err)
+			return morphInstance{}, "", "", core.Exit(1, "morph get instance %s failed: %v", candidate, err)
 		}
 	}
 	instances, err := b.listInstances(ctx, client, false)
 	if err != nil {
 		return morphInstance{}, "", "", err
 	}
-	wantSlug := normalizeLeaseSlug(identifier)
+	wantSlug := core.NormalizeLeaseSlug(identifier)
 	var matched *morphInstance
 	for i := range instances {
 		labels := instances[i].Metadata
@@ -627,13 +627,13 @@ func (b *morphLeaseBackend) resolveInstance(ctx context.Context, client morphAPI
 			labels["instance_id"] == identifier ||
 			instances[i].ID == identifier {
 			if matched != nil {
-				return morphInstance{}, "", "", exit(5, "lease %s matched multiple morph instances", identifier)
+				return morphInstance{}, "", "", core.Exit(5, "lease %s matched multiple morph instances", identifier)
 			}
 			matched = &instances[i]
 		}
 	}
 	if matched == nil {
-		return morphInstance{}, "", "", exit(4, "lease %s not found for provider=%s", identifier, providerName)
+		return morphInstance{}, "", "", core.Exit(4, "lease %s not found for provider=%s", identifier, providerName)
 	}
 	instance, leaseID, slug := finalizeMorphResolution(*matched, identifier, claim, claimed)
 	return instance, leaseID, slug, nil
@@ -646,7 +646,7 @@ func (b *morphLeaseBackend) listInstances(ctx context.Context, client morphAPI, 
 	}
 	instances, err := client.ListInstances(ctx, filter)
 	if err != nil {
-		return nil, exit(1, "morph list instances failed: %v", err)
+		return nil, core.Exit(1, "morph list instances failed: %v", err)
 	}
 	if all {
 		return instances, nil
@@ -671,19 +671,19 @@ func (b *morphLeaseBackend) waitForInstanceReady(ctx context.Context, client mor
 		func(_ context.Context, instance morphInstance, fetchErr error) (bool, error) {
 			switch {
 			case isMorphNotFound(fetchErr):
-				return false, exit(4, "morph instance %s disappeared while waiting for readiness", instanceID)
+				return false, core.Exit(4, "morph instance %s disappeared while waiting for readiness", instanceID)
 			case fetchErr != nil:
-				return false, exit(1, "morph get instance %s failed: %v", instanceID, fetchErr)
+				return false, core.Exit(1, "morph get instance %s failed: %v", instanceID, fetchErr)
 			case morphInstanceReady(instance) || allowPaused && morphInstancePaused(instance):
 				return true, nil
 			case morphInstanceTerminal(instance):
-				return false, exit(1, "morph instance %s entered terminal state %q", instanceID, core.Blank(instance.Status, "unknown"))
+				return false, core.Exit(1, "morph instance %s entered terminal state %q", instanceID, core.Blank(instance.Status, "unknown"))
 			}
 			return false, nil
 		}, nil)
 	if waitErr := waitCtx.Err(); waitErr != nil && errors.Is(err, context.Cause(waitCtx)) {
 		if waitErr == context.DeadlineExceeded {
-			return morphInstance{}, exit(5, "timed out waiting for morph instance %s to become ready", instanceID)
+			return morphInstance{}, core.Exit(5, "timed out waiting for morph instance %s to become ready", instanceID)
 		}
 		return morphInstance{}, waitErr
 	}
@@ -693,29 +693,29 @@ func (b *morphLeaseBackend) waitForInstanceReady(ctx context.Context, client mor
 	return morphInstance{}, err
 }
 
-func (b *morphLeaseBackend) resolveSSHTarget(ctx context.Context, cfg Config, client morphAPI, leaseID string, instance morphInstance, waitReady bool) (SSHTarget, error) {
+func (b *morphLeaseBackend) resolveSSHTarget(ctx context.Context, cfg core.Config, client morphAPI, leaseID string, instance morphInstance, waitReady bool) (core.SSHTarget, error) {
 	sshKey, err := client.GetSSHKey(ctx, instance.ID)
 	if err != nil {
-		return SSHTarget{}, exit(1, "morph get ssh key for %s failed: %v", instance.ID, err)
+		return core.SSHTarget{}, core.Exit(1, "morph get ssh key for %s failed: %v", instance.ID, err)
 	}
 	keyPath, err := storeMorphSSHKey(leaseID, sshKey)
 	if err != nil {
-		return SSHTarget{}, err
+		return core.SSHTarget{}, err
 	}
 	knownHostsPath, err := ensureMorphKnownHostsPath()
 	if err != nil {
-		return SSHTarget{}, err
+		return core.SSHTarget{}, err
 	}
 	target := morphSSHTarget(cfg, instance, keyPath, knownHostsPath)
 	if waitReady {
-		if err := waitForMorphSSHReady(ctx, &target, b.rt.Stderr, "morph ssh", bootstrapWaitTimeout(cfg)); err != nil {
-			return SSHTarget{}, err
+		if err := waitForMorphSSHReady(ctx, &target, b.rt.Stderr, "morph ssh", core.BootstrapWaitTimeout(cfg)); err != nil {
+			return core.SSHTarget{}, err
 		}
 	}
 	return target, nil
 }
 
-func applyMorphDefaults(cfg *Config) {
+func applyMorphDefaults(cfg *core.Config) {
 	cfg.Provider = providerName
 	if strings.TrimSpace(cfg.TargetOS) == "" {
 		cfg.TargetOS = targetLinux
@@ -727,7 +727,7 @@ func applyMorphDefaults(cfg *Config) {
 		cfg.Morph.SSHGatewayHost = core.MorphConfigDefaultSSHGatewayHost
 	}
 	if strings.TrimSpace(cfg.Morph.WorkRoot) == "" {
-		if isDefaultWorkRoot(cfg.WorkRoot) || strings.TrimSpace(cfg.WorkRoot) == "" {
+		if core.IsDefaultWorkRoot(cfg.WorkRoot) || strings.TrimSpace(cfg.WorkRoot) == "" {
 			cfg.Morph.WorkRoot = core.MorphConfigDefaultWorkRoot
 		} else {
 			cfg.Morph.WorkRoot = cfg.WorkRoot
@@ -742,25 +742,25 @@ func applyMorphDefaults(cfg *Config) {
 	cfg.ServerType = core.Blank(strings.TrimSpace(cfg.Morph.Snapshot), "snapshot")
 }
 
-func validateMorphConfig(cfg Config) error {
+func validateMorphConfig(cfg core.Config) error {
 	if cfg.TargetOS != "" && cfg.TargetOS != targetLinux {
-		return exit(2, "provider=morph supports target=linux only")
+		return core.Exit(2, "provider=morph supports target=linux only")
 	}
 	if cfg.Network == networkTailscale {
-		return exit(2, "--network=tailscale is not supported for provider=morph; Morph exposes SSH through the public gateway")
+		return core.Exit(2, "--network=tailscale is not supported for provider=morph; Morph exposes SSH through the public gateway")
 	}
 	if cfg.Tailscale.Enabled {
-		return exit(2, "--tailscale is not supported for provider=morph; Morph exposes SSH through the public gateway")
+		return core.Exit(2, "--tailscale is not supported for provider=morph; Morph exposes SSH through the public gateway")
 	}
 	return nil
 }
 
-func validateMorphCreateConfig(cfg Config) error {
+func validateMorphCreateConfig(cfg core.Config) error {
 	if err := validateMorphConfig(cfg); err != nil {
 		return err
 	}
 	if strings.TrimSpace(cfg.Morph.Snapshot) == "" {
-		return exit(2, "provider=morph requires CRABBOX_MORPH_SNAPSHOT or morph.snapshot")
+		return core.Exit(2, "provider=morph requires CRABBOX_MORPH_SNAPSHOT or morph.snapshot")
 	}
 	return nil
 }
@@ -777,18 +777,18 @@ func morphIsManaged(instance morphInstance) bool {
 		strings.EqualFold(strings.TrimSpace(instance.Metadata["provider"]), providerName)
 }
 
-func morphLeaseMetadata(cfg Config, instance morphInstance, leaseID, slug, state string, keep bool, now time.Time, touch bool) map[string]string {
+func morphLeaseMetadata(cfg core.Config, instance morphInstance, leaseID, slug, state string, keep bool, now time.Time, touch bool) map[string]string {
 	existingWorkRoot := strings.TrimSpace(instance.Metadata["work_root"])
 	var labels map[string]string
 	if touch {
-		labels = touchDirectLeaseLabels(instance.Metadata.Clone(), cfg, state, now)
+		labels = core.TouchDirectLeaseLabels(instance.Metadata.Clone(), cfg, state, now)
 		if strings.EqualFold(strings.TrimSpace(state), "running") {
 			if expiresAt := morphLeaseTTLCap(labels); expiresAt != "" {
 				labels["expires_at"] = expiresAt
 			}
 		}
 	} else {
-		labels = directLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
+		labels = core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
 	}
 	labels["crabbox"] = "true"
 	labels["provider"] = providerName
@@ -796,7 +796,7 @@ func morphLeaseMetadata(cfg Config, instance morphInstance, leaseID, slug, state
 		labels["lease"] = leaseID
 	}
 	if slug != "" {
-		labels["slug"] = normalizeLeaseSlug(slug)
+		labels["slug"] = core.NormalizeLeaseSlug(slug)
 	}
 	if root := strings.TrimSpace(cfg.WorkRoot); root != "" {
 		switch {
@@ -828,7 +828,7 @@ func morphLeaseMetadata(cfg Config, instance morphInstance, leaseID, slug, state
 	} else if strings.TrimSpace(labels["server_type"]) == "" && snapshotID != "" {
 		labels["server_type"] = snapshotID
 	}
-	if name := leaseProviderName(core.Blank(leaseID, instance.ID), slug); name != "" {
+	if name := core.LeaseProviderName(core.Blank(leaseID, instance.ID), slug); name != "" {
 		labels["lease_name"] = name
 	}
 	if strings.TrimSpace(labels["release"]) == "" {
@@ -837,7 +837,7 @@ func morphLeaseMetadata(cfg Config, instance morphInstance, leaseID, slug, state
 	return labels
 }
 
-func morphServer(instance morphInstance, cfg Config, leaseID, slug string) Server {
+func morphServer(instance morphInstance, cfg core.Config, leaseID, slug string) core.Server {
 	labels := instance.Metadata.Clone()
 	if leaseID == "" {
 		leaseID = core.Blank(strings.TrimSpace(labels["lease"]), instance.ID)
@@ -849,7 +849,7 @@ func morphServer(instance morphInstance, cfg Config, leaseID, slug string) Serve
 		labels["lease"] = leaseID
 	}
 	if slug != "" {
-		labels["slug"] = normalizeLeaseSlug(slug)
+		labels["slug"] = core.NormalizeLeaseSlug(slug)
 	}
 	if labels["provider"] == "" {
 		labels["provider"] = providerName
@@ -882,7 +882,7 @@ func morphServer(instance morphInstance, cfg Config, leaseID, slug string) Serve
 	if state != "" {
 		labels["state"] = state
 	}
-	server := Server{
+	server := core.Server{
 		CloudID:  instance.ID,
 		Provider: providerName,
 		Name:     core.Blank(labels["lease_name"], instance.ID),
@@ -894,8 +894,8 @@ func morphServer(instance morphInstance, cfg Config, leaseID, slug string) Serve
 	return server
 }
 
-func morphSSHTarget(cfg Config, instance morphInstance, keyPath, knownHostsPath string) SSHTarget {
-	target := sshTargetFromConfig(cfg, core.Blank(strings.TrimSpace(cfg.Morph.SSHGatewayHost), core.MorphConfigDefaultSSHGatewayHost))
+func morphSSHTarget(cfg core.Config, instance morphInstance, keyPath, knownHostsPath string) core.SSHTarget {
+	target := core.SSHTargetFromConfig(cfg, core.Blank(strings.TrimSpace(cfg.Morph.SSHGatewayHost), core.MorphConfigDefaultSSHGatewayHost))
 	target.Host = core.Blank(strings.TrimSpace(cfg.Morph.SSHGatewayHost), core.MorphConfigDefaultSSHGatewayHost)
 	target.Port = "22"
 	target.User = instance.ID
@@ -911,7 +911,7 @@ func morphSSHTarget(cfg Config, instance morphInstance, keyPath, knownHostsPath 
 func storeMorphSSHKey(leaseID string, sshKey morphSSHKey) (string, error) {
 	privateKey := strings.TrimSpace(sshKey.PrivateKey)
 	if privateKey == "" {
-		return "", exit(1, "morph ssh key response did not include private_key")
+		return "", core.Exit(1, "morph ssh key response did not include private_key")
 	}
 	keyData := []byte(privateKey + "\n")
 	if sshKey.Password != "" {
@@ -920,16 +920,16 @@ func storeMorphSSHKey(leaseID string, sshKey morphSSHKey) (string, error) {
 			decryptedKey, decryptErr := ssh.ParseRawPrivateKeyWithPassphrase(keyData, password)
 			clear(password)
 			if decryptErr != nil {
-				return "", exit(1, "morph ssh key response could not be decrypted")
+				return "", core.Exit(1, "morph ssh key response could not be decrypted")
 			}
 			block, marshalErr := ssh.MarshalPrivateKey(decryptedKey, "")
 			if marshalErr != nil {
-				return "", exit(1, "morph ssh key response could not be stored: %v", marshalErr)
+				return "", core.Exit(1, "morph ssh key response could not be stored: %v", marshalErr)
 			}
 			keyData = pem.EncodeToMemory(block)
 		}
 	}
-	path, err := testboxKeyPath(leaseID)
+	path, err := core.TestboxKeyPath(leaseID)
 	if err != nil {
 		return "", err
 	}
@@ -945,7 +945,7 @@ func storeMorphSSHKey(leaseID string, sshKey morphSSHKey) (string, error) {
 func ensureMorphKnownHostsPath() (string, error) {
 	configDir, err := os.UserConfigDir()
 	if err != nil {
-		return "", exit(2, "user config directory is unavailable")
+		return "", core.Exit(2, "user config directory is unavailable")
 	}
 	path := filepath.Join(configDir, "crabbox", providerName, "known_hosts")
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
@@ -954,15 +954,15 @@ func ensureMorphKnownHostsPath() (string, error) {
 	return path, nil
 }
 
-func serversFromLeaseViews(instances []morphInstance, cfg Config) []Server {
-	servers := make([]Server, 0, len(instances))
+func serversFromLeaseViews(instances []morphInstance, cfg core.Config) []core.Server {
+	servers := make([]core.Server, 0, len(instances))
 	for _, instance := range instances {
 		servers = append(servers, morphServer(instance, cfg, strings.TrimSpace(instance.Metadata["lease"]), strings.TrimSpace(instance.Metadata["slug"])))
 	}
 	return servers
 }
 
-func finalizeMorphResolution(instance morphInstance, requested string, claim LeaseClaim, claimed bool) (morphInstance, string, string) {
+func finalizeMorphResolution(instance morphInstance, requested string, claim core.LeaseClaim, claimed bool) (morphInstance, string, string) {
 	leaseID := strings.TrimSpace(instance.Metadata["lease"])
 	slug := strings.TrimSpace(instance.Metadata["slug"])
 	if claimed {
@@ -974,7 +974,7 @@ func finalizeMorphResolution(instance morphInstance, requested string, claim Lea
 		}
 	}
 	if leaseID == "" {
-		if isCanonicalLeaseID(requested) {
+		if core.IsCanonicalLeaseID(requested) {
 			leaseID = requested
 		} else {
 			leaseID = instance.ID
@@ -1016,21 +1016,21 @@ func morphInstanceTerminal(instance morphInstance) bool {
 	}
 }
 
-func morphTTLAction(cfg Config) string {
+func morphTTLAction(cfg core.Config) string {
 	if cfg.Morph.DeleteOnRelease {
 		return "stop"
 	}
 	return "pause"
 }
 
-func morphReleaseAction(cfg Config) string {
+func morphReleaseAction(cfg core.Config) string {
 	if cfg.Morph.DeleteOnRelease {
 		return "delete"
 	}
 	return "pause"
 }
 
-func morphDeleteOnRelease(lease LeaseTarget, cfg Config) bool {
+func morphDeleteOnRelease(lease core.LeaseTarget, cfg core.Config) bool {
 	if deleteOnReleaseExplicit(cfg) {
 		return cfg.Morph.DeleteOnRelease
 	}
@@ -1079,5 +1079,5 @@ func boolPtr(value bool) *bool {
 
 func isDefaultMorphWorkRoot(value string) bool {
 	value = strings.TrimSpace(value)
-	return value == "" || value == core.MorphConfigDefaultWorkRoot || isDefaultWorkRoot(value)
+	return value == "" || value == core.MorphConfigDefaultWorkRoot || core.IsDefaultWorkRoot(value)
 }

--- a/internal/providers/morph/backend_test.go
+++ b/internal/providers/morph/backend_test.go
@@ -216,7 +216,7 @@ func TestMorphAcquireStoresMetadataAndKey(t *testing.T) {
 	var gotWakeOnSSH *bool
 	waitCalled := false
 	originalWait := waitForMorphSSHReady
-	waitForMorphSSHReady = func(_ context.Context, target *SSHTarget, _ io.Writer, _ string, _ time.Duration) error {
+	waitForMorphSSHReady = func(_ context.Context, target *core.SSHTarget, _ io.Writer, _ string, _ time.Duration) error {
 		waitCalled = true
 		if target.Host != "ssh.cloud.morph.so" || target.User != "inst_1" {
 			t.Fatalf("unexpected target: %#v", target)
@@ -286,7 +286,7 @@ func TestMorphAcquireStoresMetadataAndKey(t *testing.T) {
 	backend := &morphLeaseBackend{
 		spec:   Provider{}.Spec(),
 		cfg:    cfg,
-		rt:     Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}},
+		rt:     core.Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}},
 		client: fake,
 		now: func() time.Time {
 			nowCalls++
@@ -299,7 +299,7 @@ func TestMorphAcquireStoresMetadataAndKey(t *testing.T) {
 		readyTimeout:      time.Second,
 	}
 
-	lease, err := backend.Acquire(context.Background(), AcquireRequest{RequestedSlug: "blue-lobster"})
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{RequestedSlug: "blue-lobster"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -408,7 +408,7 @@ func TestNewMorphBackendAllowsMissingSnapshotForExistingLeaseOps(t *testing.T) {
 	cfg.Morph.Snapshot = ""
 	cfg.ServerType = ""
 
-	backend, err := NewMorphBackend(Provider{}.Spec(), cfg, Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}})
+	backend, err := NewMorphBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -421,7 +421,7 @@ func TestNewMorphBackendRejectsTailscaleNetwork(t *testing.T) {
 	cfg := testMorphConfig()
 	cfg.Network = networkTailscale
 
-	_, err := NewMorphBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard})
+	_, err := NewMorphBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard})
 	if err == nil || !strings.Contains(err.Error(), "--network=tailscale is not supported") {
 		t.Fatalf("NewMorphBackend error=%v", err)
 	}
@@ -445,7 +445,7 @@ func TestApplyMorphProviderFlagsUpdatesServerType(t *testing.T) {
 }
 
 func TestConfigureDoctorReturnsMorphDoctorBackend(t *testing.T) {
-	doctor, err := Provider{}.ConfigureDoctor(testMorphConfig(), Runtime{Stdout: io.Discard, Stderr: io.Discard})
+	doctor, err := Provider{}.ConfigureDoctor(testMorphConfig(), core.Runtime{Stdout: io.Discard, Stderr: io.Discard})
 	if err != nil {
 		t.Fatalf("ConfigureDoctor: %v", err)
 	}
@@ -464,12 +464,12 @@ func TestMorphAcquireRequiresSnapshot(t *testing.T) {
 	backend := &morphLeaseBackend{
 		spec:   Provider{}.Spec(),
 		cfg:    cfg,
-		rt:     Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}},
+		rt:     core.Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}},
 		client: &fakeMorphAPI{},
 		now:    time.Now,
 	}
 
-	_, err := backend.Acquire(context.Background(), AcquireRequest{})
+	_, err := backend.Acquire(context.Background(), core.AcquireRequest{})
 	if err == nil || !strings.Contains(err.Error(), "CRABBOX_MORPH_SNAPSHOT") {
 		t.Fatalf("Acquire error=%v", err)
 	}
@@ -502,14 +502,14 @@ func TestMorphAcquireRollbackIsBounded(t *testing.T) {
 	backend := &morphLeaseBackend{
 		spec:            Provider{}.Spec(),
 		cfg:             cfg,
-		rt:              Runtime{Stdout: io.Discard, Stderr: &stderr},
+		rt:              core.Runtime{Stdout: io.Discard, Stderr: &stderr},
 		client:          fake,
 		now:             time.Now,
 		rollbackTimeout: 20 * time.Millisecond,
 	}
 
 	started := time.Now()
-	_, err := backend.Acquire(context.Background(), AcquireRequest{})
+	_, err := backend.Acquire(context.Background(), core.AcquireRequest{})
 	if err == nil || !strings.Contains(err.Error(), "metadata failed") {
 		t.Fatalf("Acquire error=%v", err)
 	}
@@ -535,7 +535,7 @@ func TestMorphResolveResumesPausedInstanceWithoutWakeOnSSH(t *testing.T) {
 	getInstanceCalls := 0
 	waitCalls := 0
 	originalWait := waitForMorphSSHReady
-	waitForMorphSSHReady = func(_ context.Context, _ *SSHTarget, _ io.Writer, _ string, _ time.Duration) error {
+	waitForMorphSSHReady = func(_ context.Context, _ *core.SSHTarget, _ io.Writer, _ string, _ time.Duration) error {
 		waitCalls++
 		return nil
 	}
@@ -569,14 +569,14 @@ func TestMorphResolveResumesPausedInstanceWithoutWakeOnSSH(t *testing.T) {
 	backend := &morphLeaseBackend{
 		spec:              Provider{}.Spec(),
 		cfg:               cfg,
-		rt:                Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}},
+		rt:                core.Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}},
 		client:            fake,
 		now:               time.Now,
 		readyPollInterval: time.Millisecond,
 		readyTimeout:      time.Second,
 	}
 
-	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: "inst_2"})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "inst_2"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -593,7 +593,7 @@ func TestMorphResolveChecksRepoClaimBeforeResume(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	cfg := testMorphConfig()
 	cfg.Morph.WakeOnSSH = false
-	if err := claimLeaseForRepoProvider("cbx_claimed", "claimed", providerName, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProvider("cbx_claimed", "claimed", providerName, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -619,12 +619,12 @@ func TestMorphResolveChecksRepoClaimBeforeResume(t *testing.T) {
 	backend := &morphLeaseBackend{
 		spec:   Provider{}.Spec(),
 		cfg:    cfg,
-		rt:     Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		rt:     core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 		client: fake,
 		now:    time.Now,
 	}
 
-	req := ResolveRequest{ID: "inst_claimed"}
+	req := core.ResolveRequest{ID: "inst_claimed"}
 	req.Repo.Root = t.TempDir()
 	_, err := backend.Resolve(context.Background(), req)
 	if err == nil || !strings.Contains(err.Error(), "is claimed by repo") {
@@ -653,18 +653,18 @@ func TestMorphResolveRestoresRepoClaimWhenSSHKeyFails(t *testing.T) {
 	backend := &morphLeaseBackend{
 		spec:   Provider{}.Spec(),
 		cfg:    testMorphConfig(),
-		rt:     Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		rt:     core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 		client: fake,
 		now:    time.Now,
 	}
-	req := ResolveRequest{ID: "inst_failing"}
+	req := core.ResolveRequest{ID: "inst_failing"}
 	req.Repo.Root = t.TempDir()
 
 	_, err := backend.Resolve(context.Background(), req)
 	if err == nil || !strings.Contains(err.Error(), "key unavailable") {
 		t.Fatalf("Resolve error=%v", err)
 	}
-	if _, exists, err := readLeaseClaimWithPresence("cbx_failing"); err != nil || exists {
+	if _, exists, err := core.ReadLeaseClaimWithPresence("cbx_failing"); err != nil || exists {
 		t.Fatalf("failed resolve retained claim exists=%v err=%v", exists, err)
 	}
 }
@@ -689,23 +689,23 @@ func TestMorphResolveRejectsConcurrentRepoReclaim(t *testing.T) {
 	backend := &morphLeaseBackend{
 		spec:   Provider{}.Spec(),
 		cfg:    testMorphConfig(),
-		rt:     Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		rt:     core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 		client: fake,
 		now:    time.Now,
 	}
 	oldWait := waitForMorphSSHReady
-	waitForMorphSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
-		return claimLeaseForRepoProvider("cbx_race", "race", providerName, repoB, time.Hour, true)
+	waitForMorphSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
+		return core.ClaimLeaseForRepoProvider("cbx_race", "race", providerName, repoB, time.Hour, true)
 	}
 	t.Cleanup(func() { waitForMorphSSHReady = oldWait })
-	req := ResolveRequest{ID: "inst_race"}
+	req := core.ResolveRequest{ID: "inst_race"}
 	req.Repo.Root = repoA
 
 	_, err := backend.Resolve(context.Background(), req)
 	if err == nil || !strings.Contains(err.Error(), "claim changed; retry") {
 		t.Fatalf("Resolve error=%v", err)
 	}
-	claim, ok, claimErr := resolveLeaseClaimForProvider("cbx_race", providerName)
+	claim, ok, claimErr := core.ResolveLeaseClaimForProvider("cbx_race", providerName)
 	if claimErr != nil || !ok || claim.RepoRoot != repoB {
 		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, claimErr)
 	}
@@ -720,7 +720,7 @@ func TestMorphResolveEnablesProviderWakeOnSSHBeforeRelyingOnIt(t *testing.T) {
 	wakeOnCalls := 0
 	wakeEnabled := false
 	originalWait := waitForMorphSSHReady
-	waitForMorphSSHReady = func(_ context.Context, _ *SSHTarget, _ io.Writer, _ string, _ time.Duration) error {
+	waitForMorphSSHReady = func(_ context.Context, _ *core.SSHTarget, _ io.Writer, _ string, _ time.Duration) error {
 		if !wakeEnabled {
 			t.Fatal("SSH readiness checked before wake-on-SSH was enabled")
 		}
@@ -757,14 +757,14 @@ func TestMorphResolveEnablesProviderWakeOnSSHBeforeRelyingOnIt(t *testing.T) {
 	backend := &morphLeaseBackend{
 		spec:              Provider{}.Spec(),
 		cfg:               cfg,
-		rt:                Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		rt:                core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 		client:            fake,
 		now:               time.Now,
 		readyPollInterval: time.Millisecond,
 		readyTimeout:      time.Second,
 	}
 
-	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: "inst_wake"})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "inst_wake"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -781,7 +781,7 @@ func TestMorphResolveResumesAfterSavingTransitionsToPaused(t *testing.T) {
 	resumeCalls := 0
 	getInstanceCalls := 0
 	originalWait := waitForMorphSSHReady
-	waitForMorphSSHReady = func(_ context.Context, _ *SSHTarget, _ io.Writer, _ string, _ time.Duration) error {
+	waitForMorphSSHReady = func(_ context.Context, _ *core.SSHTarget, _ io.Writer, _ string, _ time.Duration) error {
 		return nil
 	}
 	defer func() { waitForMorphSSHReady = originalWait }()
@@ -813,14 +813,14 @@ func TestMorphResolveResumesAfterSavingTransitionsToPaused(t *testing.T) {
 	backend := &morphLeaseBackend{
 		spec:              Provider{}.Spec(),
 		cfg:               cfg,
-		rt:                Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		rt:                core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 		client:            fake,
 		now:               time.Now,
 		readyPollInterval: time.Millisecond,
 		readyTimeout:      time.Second,
 	}
 
-	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: "inst_saving"})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "inst_saving"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -893,12 +893,12 @@ func TestMorphResolveRejectsUnsafeMetadataLeaseID(t *testing.T) {
 	backend := &morphLeaseBackend{
 		spec:   Provider{}.Spec(),
 		cfg:    testMorphConfig(),
-		rt:     Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		rt:     core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 		client: fake,
 		now:    time.Now,
 	}
 
-	_, err = backend.Resolve(context.Background(), ResolveRequest{ID: "inst_unsafe"})
+	_, err = backend.Resolve(context.Background(), core.ResolveRequest{ID: "inst_unsafe"})
 	if err == nil || !strings.Contains(err.Error(), "invalid lease claim id") {
 		t.Fatalf("Resolve error=%v", err)
 	}
@@ -922,12 +922,12 @@ func TestMorphResolveRejectsUnmanagedInstance(t *testing.T) {
 	backend := &morphLeaseBackend{
 		spec:   Provider{}.Spec(),
 		cfg:    testMorphConfig(),
-		rt:     Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		rt:     core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 		client: fake,
 		now:    time.Now,
 	}
 
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: "inst_unmanaged"})
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "inst_unmanaged"})
 	if err == nil || !strings.Contains(err.Error(), "not managed by Crabbox") {
 		t.Fatalf("Resolve error=%v", err)
 	}
@@ -957,13 +957,13 @@ func TestMorphReleaseRejectsUnmanagedInstance(t *testing.T) {
 	backend := &morphLeaseBackend{
 		spec:   Provider{}.Spec(),
 		cfg:    cfg,
-		rt:     Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		rt:     core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 		client: fake,
 		now:    time.Now,
 	}
 
-	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{
-		Lease: LeaseTarget{LeaseID: "cbx_unmanaged", Server: Server{CloudID: "inst_unmanaged"}},
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{
+		Lease: core.LeaseTarget{LeaseID: "cbx_unmanaged", Server: core.Server{CloudID: "inst_unmanaged"}},
 	})
 	if err == nil || !strings.Contains(err.Error(), "not managed by Crabbox") {
 		t.Fatalf("ReleaseLease error=%v", err)
@@ -1009,7 +1009,7 @@ func TestMorphReleaseRequiresExactScopedClaimAndLiveOwnership(t *testing.T) {
 				"crabbox": "true", "provider": providerName, "lease": "cbx_owned",
 				"slug": "owned", "instance_id": "inst_owned",
 			}
-			server := Server{CloudID: "inst_owned", Provider: providerName, Labels: labels}
+			server := core.Server{CloudID: "inst_owned", Provider: providerName, Labels: labels}
 			if tc.claim {
 				claimCfg := cfg
 				claimServer := server
@@ -1034,10 +1034,10 @@ func TestMorphReleaseRequiresExactScopedClaimAndLiveOwnership(t *testing.T) {
 							legacyServer.Labels[key] = value
 						}
 					}
-					if err := core.UpdateLeaseClaimEndpoint("cbx_owned", legacyServer, SSHTarget{}); err != nil {
+					if err := core.UpdateLeaseClaimEndpoint("cbx_owned", legacyServer, core.SSHTarget{}); err != nil {
 						t.Fatal(err)
 					}
-				} else if err := core.ClaimLeaseTargetForRepoConfig("cbx_owned", "owned", claimCfg, claimServer, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+				} else if err := core.ClaimLeaseTargetForRepoConfig("cbx_owned", "owned", claimCfg, claimServer, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -1074,8 +1074,8 @@ func TestMorphReleaseRequiresExactScopedClaimAndLiveOwnership(t *testing.T) {
 				},
 				setInstanceMetadata: func(context.Context, string, map[string]string) error { return nil },
 			}
-			backend := &morphLeaseBackend{spec: Provider{}.Spec(), cfg: cfg, rt: Runtime{Stderr: io.Discard}, client: fake, now: time.Now}
-			err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: "cbx_owned", Server: server}})
+			backend := &morphLeaseBackend{spec: Provider{}.Spec(), cfg: cfg, rt: core.Runtime{Stderr: io.Discard}, client: fake, now: time.Now}
+			err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_owned", Server: server}})
 			wantSuccess := tc.claim && !tc.wrongEndpoint && !tc.wrongInstance && !tc.changedOwner && !tc.providerFails
 			if (err == nil) != wantSuccess {
 				t.Fatalf("err=%v wantSuccess=%v", err, wantSuccess)
@@ -1100,17 +1100,17 @@ func TestMorphReleaseMissingInstanceRequiresMatchingEndpointClaim(t *testing.T) 
 			if wrongEndpoint {
 				claimCfg.Morph.APIURL = "https://another.example.com"
 			}
-			server := Server{
+			server := core.Server{
 				CloudID: "inst_missing", Provider: providerName,
 				Labels: map[string]string{
 					"crabbox": "true", "provider": providerName, "lease": "cbx_missing",
 					"slug": "missing", "instance_id": "inst_missing",
 				},
 			}
-			if err := core.ClaimLeaseTargetForRepoConfig("cbx_missing", "missing", claimCfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+			if err := core.ClaimLeaseTargetForRepoConfig("cbx_missing", "missing", claimCfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
 				t.Fatal(err)
 			}
-			keyPath, err := testboxKeyPath("cbx_missing")
+			keyPath, err := core.TestboxKeyPath("cbx_missing")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1126,8 +1126,8 @@ func TestMorphReleaseMissingInstanceRequiresMatchingEndpointClaim(t *testing.T) 
 				},
 				listInstances: func(context.Context, map[string]string) ([]morphInstance, error) { return nil, nil },
 			}
-			backend := &morphLeaseBackend{spec: Provider{}.Spec(), cfg: cfg, rt: Runtime{Stderr: io.Discard}, client: fake, now: time.Now}
-			err = backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: "cbx_missing", Server: server}})
+			backend := &morphLeaseBackend{spec: Provider{}.Spec(), cfg: cfg, rt: core.Runtime{Stderr: io.Discard}, client: fake, now: time.Now}
+			err = backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_missing", Server: server}})
 			if (err != nil) != wrongEndpoint {
 				t.Fatalf("err=%v wrongEndpoint=%v", err, wrongEndpoint)
 			}
@@ -1146,10 +1146,10 @@ func TestMorphReleaseMissingInstanceRequiresMatchingEndpointClaim(t *testing.T) 
 func TestMorphResolveStatusOnlyAndReleaseOnlySkipSSHPreparation(t *testing.T) {
 	for _, tc := range []struct {
 		name string
-		req  ResolveRequest
+		req  core.ResolveRequest
 	}{
-		{name: "status-only", req: ResolveRequest{ID: "inst_2", StatusOnly: true}},
-		{name: "release-only", req: ResolveRequest{ID: "inst_2", ReleaseOnly: true}},
+		{name: "status-only", req: core.ResolveRequest{ID: "inst_2", StatusOnly: true}},
+		{name: "release-only", req: core.ResolveRequest{ID: "inst_2", ReleaseOnly: true}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			configureMorphTestHome(t)
@@ -1179,7 +1179,7 @@ func TestMorphResolveStatusOnlyAndReleaseOnlySkipSSHPreparation(t *testing.T) {
 			backend := &morphLeaseBackend{
 				spec:              Provider{}.Spec(),
 				cfg:               cfg,
-				rt:                Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}},
+				rt:                core.Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}},
 				client:            fake,
 				now:               time.Now,
 				readyPollInterval: time.Millisecond,
@@ -1221,7 +1221,7 @@ func TestMorphReleaseUsesStoredPolicyAndPreservesPausedClaim(t *testing.T) {
 				cfg.Morph.DeleteOnRelease = false
 				markDeleteOnReleaseExplicit(&cfg)
 			}
-			keyPath, err := testboxKeyPath("cbx_release")
+			keyPath, err := core.TestboxKeyPath("cbx_release")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1231,7 +1231,7 @@ func TestMorphReleaseUsesStoredPolicyAndPreservesPausedClaim(t *testing.T) {
 			if err := os.WriteFile(keyPath, []byte("PRIVATE KEY"), 0o600); err != nil {
 				t.Fatal(err)
 			}
-			server := Server{
+			server := core.Server{
 				CloudID:  "inst_release",
 				Provider: providerName,
 				Name:     "crabbox-release",
@@ -1245,7 +1245,7 @@ func TestMorphReleaseUsesStoredPolicyAndPreservesPausedClaim(t *testing.T) {
 					"state":       "ready",
 				},
 			}
-			if err := core.ClaimLeaseTargetForRepoConfig("cbx_release", "release", cfg, server, SSHTarget{Host: "ssh.cloud.morph.so", Port: "22"}, t.TempDir(), time.Hour, false); err != nil {
+			if err := core.ClaimLeaseTargetForRepoConfig("cbx_release", "release", cfg, server, core.SSHTarget{Host: "ssh.cloud.morph.so", Port: "22"}, t.TempDir(), time.Hour, false); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1277,15 +1277,15 @@ func TestMorphReleaseUsesStoredPolicyAndPreservesPausedClaim(t *testing.T) {
 			backend := &morphLeaseBackend{
 				spec:   Provider{}.Spec(),
 				cfg:    cfg,
-				rt:     Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}},
+				rt:     core.Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}},
 				client: fake,
 				now:    time.Now,
 			}
-			lease := LeaseTarget{LeaseID: "cbx_release", Server: server}
+			lease := core.LeaseTarget{LeaseID: "cbx_release", Server: server}
 			if got := backend.RetainLeaseClaimAfterRelease(lease); got != tc.explicitRetain {
 				t.Fatalf("RetainLeaseClaimAfterRelease=%t release=%s", got, tc.release)
 			}
-			outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{
+			outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{
 				Lease: lease,
 			})
 			if err != nil || outcome.Terminal != (tc.wantDeleteCalls == 1) {
@@ -1294,7 +1294,7 @@ func TestMorphReleaseUsesStoredPolicyAndPreservesPausedClaim(t *testing.T) {
 			if pauseCalls != tc.wantPauseCalls || deleteCalls != tc.wantDeleteCalls {
 				t.Fatalf("pauseCalls=%d deleteCalls=%d", pauseCalls, deleteCalls)
 			}
-			claim, ok, err := resolveLeaseClaimForProvider("cbx_release", providerName)
+			claim, ok, err := core.ResolveLeaseClaimForProvider("cbx_release", providerName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1321,9 +1321,9 @@ func TestMorphReleaseUsesStoredPolicyAndPreservesPausedClaim(t *testing.T) {
 }
 
 func TestMorphReleaseLeaseMessage(t *testing.T) {
-	lease := LeaseTarget{
+	lease := core.LeaseTarget{
 		LeaseID: "cbx_release",
-		Server:  Server{CloudID: "inst_release", Labels: map[string]string{"release": "pause"}},
+		Server:  core.Server{CloudID: "inst_release", Labels: map[string]string{"release": "pause"}},
 	}
 
 	pauseBackend := &morphLeaseBackend{cfg: testMorphConfig()}
@@ -1377,14 +1377,14 @@ func TestMorphTouchInitializesMissingMetadata(t *testing.T) {
 	backend := &morphLeaseBackend{
 		spec:   Provider{}.Spec(),
 		cfg:    cfg,
-		rt:     Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}},
+		rt:     core.Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}},
 		client: fake,
 		now:    func() time.Time { return now },
 	}
-	_, err := backend.Touch(context.Background(), TouchRequest{
-		Lease: LeaseTarget{
+	_, err := backend.Touch(context.Background(), core.TouchRequest{
+		Lease: core.LeaseTarget{
 			LeaseID: "cbx_nil",
-			Server: Server{
+			Server: core.Server{
 				CloudID: "inst_nil",
 				Labels:  map[string]string{"slug": "blue-lobster"},
 			},
@@ -1446,12 +1446,12 @@ func TestMorphTouchPreservesCustomWorkRootAndProtectsActiveRun(t *testing.T) {
 	backend := &morphLeaseBackend{
 		spec:   Provider{}.Spec(),
 		cfg:    cfg,
-		rt:     Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}},
+		rt:     core.Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}},
 		client: fake,
 		now:    func() time.Time { return now },
 	}
-	server, err := backend.Touch(context.Background(), TouchRequest{
-		Lease: LeaseTarget{
+	server, err := backend.Touch(context.Background(), core.TouchRequest{
+		Lease: core.LeaseTarget{
 			LeaseID: "cbx_touch",
 			Server:  morphServer(instance, cfg, "cbx_touch", "blue-lobster"),
 		},
@@ -1512,13 +1512,13 @@ func TestMorphTouchPreservesInstanceSnapshotIdentity(t *testing.T) {
 	backend := &morphLeaseBackend{
 		spec:   Provider{}.Spec(),
 		cfg:    cfg,
-		rt:     Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		rt:     core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 		client: fake,
 		now:    func() time.Time { return now },
 	}
 
-	server, err := backend.Touch(context.Background(), TouchRequest{
-		Lease:       LeaseTarget{LeaseID: "cbx_snapshot", Server: Server{CloudID: instance.ID}},
+	server, err := backend.Touch(context.Background(), core.TouchRequest{
+		Lease:       core.LeaseTarget{LeaseID: "cbx_snapshot", Server: core.Server{CloudID: instance.ID}},
 		State:       "ready",
 		IdleTimeout: 30 * time.Minute,
 	})
@@ -1548,15 +1548,15 @@ func TestMorphServerUsesProviderStateWhenInstanceIsNotReady(t *testing.T) {
 	}
 }
 
-func testMorphConfig() Config {
-	return Config{
+func testMorphConfig() core.Config {
+	return core.Config{
 		Provider:    providerName,
 		TargetOS:    targetLinux,
 		TTL:         2 * time.Hour,
 		IdleTimeout: 15 * time.Minute,
 		SSHPort:     "22",
 		WorkRoot:    "/tmp/crabbox",
-		Morph: MorphConfig{
+		Morph: core.MorphConfig{
 			APIKey:         "token",
 			APIURL:         "https://cloud.morph.so",
 			Snapshot:       "snapshot_123",
@@ -1599,7 +1599,7 @@ func TestMorphConfigFlagAndRoutingContract(t *testing.T) {
 		if err := ApplyMorphProviderFlags(&cfg, fs, values); err != nil {
 			t.Fatal(err)
 		}
-		want := MorphConfig{APIKey: "inert", Snapshot: "flag-snapshot", SSHGatewayHost: "  ", WorkRoot: "/workspace/flag"}
+		want := core.MorphConfig{APIKey: "inert", Snapshot: "flag-snapshot", SSHGatewayHost: "  ", WorkRoot: "/workspace/flag"}
 		if provider != "aws" {
 			want.APIURL = "https://cloud.morph.so"
 			want.SSHGatewayHost = "ssh.cloud.morph.so"
@@ -1678,7 +1678,7 @@ func TestMorphConfigFlagPhaseContract(t *testing.T) {
 
 func TestMorphConfigEffectiveDefaultsContract(t *testing.T) {
 	for _, tc := range []struct{ morph, generic, want string }{{"", "", "/tmp/crabbox"}, {"  ", "/work/crabbox", "/tmp/crabbox"}, {"", "/Users/ec2-user/crabbox", "/tmp/crabbox"}, {"", `C:\crabbox`, "/tmp/crabbox"}, {"", "/workspace/generic", "/workspace/generic"}, {" /workspace/morph ", "/workspace/generic", " /workspace/morph "}} {
-		cfg := Config{WorkRoot: tc.generic, Morph: MorphConfig{APIURL: "  ", SSHGatewayHost: "  ", WorkRoot: tc.morph}, SSHPort: "1234", SSHFallbackPorts: []string{"5678"}}
+		cfg := core.Config{WorkRoot: tc.generic, Morph: core.MorphConfig{APIURL: "  ", SSHGatewayHost: "  ", WorkRoot: tc.morph}, SSHPort: "1234", SSHFallbackPorts: []string{"5678"}}
 		applyMorphDefaults(&cfg)
 		if cfg.Morph.APIURL != "https://cloud.morph.so" || cfg.Morph.SSHGatewayHost != "ssh.cloud.morph.so" || cfg.Morph.WorkRoot != tc.want || cfg.WorkRoot != tc.want || cfg.Morph.WakeOnSSH || cfg.Provider != "morph" || cfg.TargetOS != "linux" || cfg.SSHPort != "22" || len(cfg.SSHFallbackPorts) != 0 || cfg.ServerType != "snapshot" {
 			t.Fatalf("defaults roots=%q/%q cfg=%#v", tc.morph, tc.generic, cfg.Morph)
@@ -1692,7 +1692,7 @@ func TestMorphConfigEffectiveDefaultsContract(t *testing.T) {
 			t.Fatalf("root=%q default=%t want=%t", tc.root, got, tc.want)
 		}
 	}
-	backend, err := NewMorphBackend(Provider{}.Spec(), Config{}, Runtime{})
+	backend, err := NewMorphBackend(Provider{}.Spec(), core.Config{}, core.Runtime{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1709,7 +1709,7 @@ func TestMorphConfigEndpointAndPresentationContract(t *testing.T) {
 		}
 	}
 	for _, tc := range []struct{ raw, want string }{{"", "ssh.cloud.morph.so"}, {"  ", "ssh.cloud.morph.so"}, {" gateway.example ", "gateway.example"}} {
-		cfg := Config{Morph: MorphConfig{SSHGatewayHost: tc.raw}}
+		cfg := core.Config{Morph: core.MorphConfig{SSHGatewayHost: tc.raw}}
 		instance := morphInstance{ID: "inst_fixture", Status: "ready"}
 		server := morphServer(instance, cfg, "cbx_fixture", "fixture")
 		if server.PublicNet.IPv4.IP != tc.want {

--- a/internal/providers/morph/client.go
+++ b/internal/providers/morph/client.go
@@ -30,14 +30,14 @@ type morphAPI interface {
 	DeleteInstance(ctx context.Context, instanceID string) error
 }
 
-var newMorphClient = func(cfg Config, rt Runtime) (morphAPI, error) {
+var newMorphClient = func(cfg core.Config, rt core.Runtime) (morphAPI, error) {
 	apiURL, err := normalizeMorphAPIURL(cfg.Morph.APIURL)
 	if err != nil {
-		return nil, exit(2, "provider=morph has invalid apiUrl %q: %v", cfg.Morph.APIURL, err)
+		return nil, core.Exit(2, "provider=morph has invalid apiUrl %q: %v", cfg.Morph.APIURL, err)
 	}
 	apiKey := strings.TrimSpace(cfg.Morph.APIKey)
 	if apiKey == "" {
-		return nil, exit(2, "provider=morph requires CRABBOX_MORPH_API_KEY, MORPH_API_KEY, or morph.apiKey")
+		return nil, core.Exit(2, "provider=morph requires CRABBOX_MORPH_API_KEY, MORPH_API_KEY, or morph.apiKey")
 	}
 	httpClient := rt.HTTP
 	if httpClient == nil {

--- a/internal/providers/morph/client_test.go
+++ b/internal/providers/morph/client_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	core "github.com/openclaw/crabbox/internal/cli"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 
 	"github.com/openclaw/crabbox/internal/testutil"
 )
@@ -79,10 +80,7 @@ func TestMorphClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
 	}))
 	defer trusted.Close()
 
-	client, err := newMorphClient(
-		Config{Morph: MorphConfig{APIKey: "test-key", APIURL: trusted.URL}},
-		Runtime{HTTP: trusted.Client()},
-	)
+	client, err := newMorphClient(core.Config{Morph: core.MorphConfig{APIKey: "test-key", APIURL: trusted.URL}}, core.Runtime{HTTP: trusted.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,10 +111,7 @@ func TestMorphClientFollowsSameOriginRedirect(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := newMorphClient(
-		Config{Morph: MorphConfig{APIKey: "test-key", APIURL: server.URL}},
-		Runtime{HTTP: server.Client()},
-	)
+	client, err := newMorphClient(core.Config{Morph: core.MorphConfig{APIKey: "test-key", APIURL: server.URL}}, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,10 +136,7 @@ func TestMorphClientPreservesCallerRedirectPolicy(t *testing.T) {
 		callerChecks++
 		return callerErr
 	}
-	client, err := newMorphClient(
-		Config{Morph: MorphConfig{APIKey: "test-key", APIURL: server.URL}},
-		Runtime{HTTP: httpClient},
-	)
+	client, err := newMorphClient(core.Config{Morph: core.MorphConfig{APIKey: "test-key", APIURL: server.URL}}, core.Runtime{HTTP: httpClient})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/morph/core.go
+++ b/internal/providers/morph/core.go
@@ -1,33 +1,11 @@
 package morph
 
 import (
-	"context"
-	"io"
 	"strings"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type MorphConfig = core.MorphConfig
-type LeaseClaim = core.LeaseClaim
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type DoctorCheck = core.DoctorCheck
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-type ExitError = core.ExitError
 
 const (
 	providerName     = "morph"
@@ -37,96 +15,16 @@ const (
 	networkPublic    = core.NetworkPublic
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func asExitError(err error, target *ExitError) bool {
-	return core.AsExitError(err, target)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func isCanonicalLeaseID(value string) bool {
-	return core.IsCanonicalLeaseID(value)
-}
-
-func leaseProviderName(leaseID, slug string) string {
-	return core.LeaseProviderName(leaseID, slug)
-}
-
-func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (string, error) {
-	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
-}
-
-func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaimForProvider(identifier, provider)
-}
-
-func updateLeaseClaimEndpointIfUnchangedAfter(leaseID string, expected LeaseClaim, server Server, target SSHTarget, action func() error) (LeaseClaim, error) {
-	return core.UpdateLeaseClaimEndpointIfUnchangedAfter(leaseID, expected, server, target, action)
-}
-
-func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
-}
-
-func claimLeaseForRepoProviderIfUnchanged(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool, expected LeaseClaim, expectedExists bool) (LeaseClaim, error) {
+func claimLeaseForRepoProviderIfUnchanged(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool, expected core.LeaseClaim, expectedExists bool) (core.LeaseClaim, error) {
 	return core.ClaimLeaseForRepoProviderScopePondIfUnchanged(leaseID, slug, provider, "", "", repoRoot, idleTimeout, reclaim, expected, expectedExists)
 }
 
-func readLeaseClaimWithPresence(leaseID string) (LeaseClaim, bool, error) {
-	return core.ReadLeaseClaimWithPresence(leaseID)
-}
-
-func restoreLeaseClaimIfUnchanged(leaseID string, current, previous LeaseClaim, previousExists bool) error {
-	return core.RestoreLeaseClaimIfUnchanged(leaseID, current, previous, previousExists)
-}
-
-func updateLeaseClaimEndpointIfUnchanged(leaseID string, expected LeaseClaim, server Server, target SSHTarget) (LeaseClaim, error) {
-	return core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, expected, server, target)
-}
-
-func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
-	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
-}
-
-func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, now time.Time) map[string]string {
-	return core.TouchDirectLeaseLabels(labels, cfg, state, now)
-}
-
-func sshTargetFromConfig(cfg Config, host string) SSHTarget {
-	return core.SSHTargetFromConfig(cfg, host)
-}
-
-func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
-	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
-}
-
-func bootstrapWaitTimeout(cfg Config) time.Duration {
-	return core.BootstrapWaitTimeout(cfg)
-}
-
-func isDefaultWorkRoot(value string) bool {
-	return core.IsDefaultWorkRoot(value)
-}
-
-func deleteOnReleaseExplicit(cfg Config) bool {
+func deleteOnReleaseExplicit(cfg core.Config) bool {
 	return core.DeleteOnReleaseExplicit(cfg, providerName)
 }
 
-func markDeleteOnReleaseExplicit(cfg *Config) {
+func markDeleteOnReleaseExplicit(cfg *core.Config) {
 	core.MarkDeleteOnReleaseExplicit(cfg, providerName)
-}
-
-func testboxKeyPath(leaseID string) (string, error) {
-	return core.TestboxKeyPath(leaseID)
-}
-
-func removeStoredTestboxKey(leaseID string) {
-	core.RemoveStoredTestboxKey(leaseID)
 }
 
 func isMorphProviderName(provider string) bool {

--- a/internal/providers/morph/provider.go
+++ b/internal/providers/morph/provider.go
@@ -16,7 +16,7 @@ type Provider struct{}
 func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return nil }
 
-func (Provider) ClaimScope(cfg Config) string {
+func (Provider) ClaimScope(cfg core.Config) string {
 	endpoint, err := normalizeMorphAPIURL(cfg.Morph.APIURL)
 	if err != nil {
 		return ""
@@ -24,8 +24,8 @@ func (Provider) ClaimScope(cfg Config) string {
 	return "endpoint:" + endpoint
 }
 
-func (Provider) Spec() ProviderSpec {
-	return ProviderSpec{
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
 		Authentication: core.DirectProviderAuthentication(core.ProviderAuthenticationAPIKey),
 		Name:           providerName,
 		Kind:           core.ProviderKindSSHLease,
@@ -38,31 +38,31 @@ func (Provider) Spec() ProviderSpec {
 	}
 }
 
-func (Provider) RegisterFlags(fs *flag.FlagSet, defaults Config) any {
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return RegisterMorphProviderFlags(fs, defaults)
 }
 
-func (Provider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	return ApplyMorphProviderFlags(cfg, fs, values)
 }
 
-func (p Provider) Configure(cfg Config, rt Runtime) (Backend, error) {
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	return NewMorphBackend(p.Spec(), cfg, rt)
 }
 
-func (p Provider) ConfigureDoctor(cfg Config, rt Runtime) (core.DoctorBackend, error) {
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
 	backend, err := p.Configure(cfg, rt)
 	if err != nil {
 		return nil, err
 	}
 	doctor, ok := backend.(core.DoctorBackend)
 	if !ok {
-		return nil, exit(2, "provider=%s does not implement doctor", providerName)
+		return nil, core.Exit(2, "provider=%s does not implement doctor", providerName)
 	}
 	return doctor, nil
 }
 
-func (Provider) ServerTypeForConfig(cfg Config) string {
+func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	if snapshot := strings.TrimSpace(cfg.Morph.Snapshot); snapshot != "" {
 		return snapshot
 	}

--- a/internal/providers/namespace/backend.go
+++ b/internal/providers/namespace/backend.go
@@ -18,12 +18,12 @@ import (
 )
 
 type namespaceLeaseBackend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
-func NewNamespaceLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewNamespaceLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = namespaceProvider
 	cfg.TargetOS = targetLinux
 	cfg.SSHFallbackPorts = nil
@@ -33,15 +33,15 @@ func NewNamespaceLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend
 	return &namespaceLeaseBackend{spec: spec, cfg: cfg, rt: rt}
 }
 
-func (b *namespaceLeaseBackend) Spec() ProviderSpec { return b.spec }
+func (b *namespaceLeaseBackend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *namespaceLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+func (b *namespaceLeaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	leaseID := core.NewLeaseID()
-	slug, err := allocateClaimLeaseSlug(leaseID, req.RequestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, req.RequestedSlug)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	name := leaseProviderName(leaseID, slug)
+	name := core.LeaseProviderName(leaseID, slug)
 	cfg := b.namespaceConfigForRun()
 	size := namespaceSize(cfg)
 	image := namespaceImage(cfg)
@@ -53,45 +53,45 @@ func (b *namespaceLeaseBackend) Acquire(ctx context.Context, req AcquireRequest)
 		Checkout:            strings.TrimSpace(cfg.Namespace.Repository),
 		Site:                strings.TrimSpace(cfg.Namespace.Site),
 		VolumeSizeGB:        cfg.Namespace.VolumeSizeGB,
-		AutoStopIdleTimeout: fmt.Sprintf("%dm", durationMinutesCeil(namespaceAutoStopIdleTimeout(cfg))),
+		AutoStopIdleTimeout: fmt.Sprintf("%dm", core.DurationMinutesCeil(namespaceAutoStopIdleTimeout(cfg))),
 	}); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	lease, err := b.prepareLease(ctx, name, leaseID, slug, req.Keep)
 	if err != nil {
 		if !req.Keep {
 			_ = b.deleteDevbox(context.Background(), name)
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	if err := claimLeaseForRepoProvider(leaseID, slug, namespaceProvider, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+	if err := core.ClaimLeaseForRepoProvider(leaseID, slug, namespaceProvider, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
 		if !req.Keep {
 			_ = b.deleteDevbox(context.Background(), name)
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	if err := updateLeaseClaimEndpoint(leaseID, lease.Server, lease.SSH); err != nil {
+	if err := core.UpdateLeaseClaimEndpoint(leaseID, lease.Server, lease.SSH); err != nil {
 		if !req.Keep {
-			removeLeaseClaim(leaseID)
+			core.RemoveLeaseClaim(leaseID)
 			_ = b.deleteDevbox(context.Background(), name)
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s name=%s state=ready\n", leaseID, name)
 	return lease, nil
 }
 
-func (b *namespaceLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (lease LeaseTarget, err error) {
+func (b *namespaceLeaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (lease core.LeaseTarget, err error) {
 	name, leaseID, slug, err := resolveNamespaceDevboxName(req.ID, req.Reclaim)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	claim, claimOK, err := resolveLeaseClaim(leaseID)
+	claim, claimOK, err := core.ResolveLeaseClaim(leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if claimOK && claim.Provider != "" && claim.Provider != namespaceProvider {
-		return LeaseTarget{}, exit(4, "%q is claimed by provider %s", req.ID, claim.Provider)
+		return core.LeaseTarget{}, core.Exit(4, "%q is claimed by provider %s", req.ID, claim.Provider)
 	}
 	if req.ReleaseOnly {
 		server := namespaceServer(name, leaseID, slug, b.namespaceConfigForRun(), true)
@@ -100,44 +100,44 @@ func (b *namespaceLeaseBackend) Resolve(ctx context.Context, req ResolveRequest)
 				server.Labels[key] = value
 			}
 		}
-		return LeaseTarget{Server: server, LeaseID: leaseID}, nil
+		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
 	}
-	var previousClaim, preflightClaim LeaseClaim
+	var previousClaim, preflightClaim core.LeaseClaim
 	var previousClaimExists, rollbackClaim bool
 	defer func() {
 		if err == nil || !rollbackClaim {
 			return
 		}
-		if restoreErr := restoreLeaseClaimIfUnchanged(leaseID, preflightClaim, previousClaim, previousClaimExists); restoreErr != nil {
+		if restoreErr := core.RestoreLeaseClaimIfUnchanged(leaseID, preflightClaim, previousClaim, previousClaimExists); restoreErr != nil {
 			fmt.Fprintf(b.rt.Stderr, "warning: restore Namespace lease claim %s after resolve failure: %v\n", leaseID, restoreErr)
 		}
 	}()
 	if req.Repo.Root != "" {
-		previousClaim, previousClaimExists, err = readLeaseClaimWithPresence(leaseID)
+		previousClaim, previousClaimExists, err = core.ReadLeaseClaimWithPresence(leaseID)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		preflightClaim, err = claimLeaseForRepoProviderIfUnchanged(leaseID, slug, namespaceProvider, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim, previousClaim, previousClaimExists)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		rollbackClaim = true
 	}
 	lease, err = b.prepareLease(ctx, name, leaseID, slug, true)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	restoreNamespaceClaimLabels(&lease.Server, claim, claimOK, b.namespaceConfigForRun())
 	if req.Repo.Root != "" {
-		if _, err = updateLeaseClaimEndpointIfUnchanged(leaseID, preflightClaim, lease.Server, lease.SSH); err != nil {
-			return LeaseTarget{}, err
+		if _, err = core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, preflightClaim, lease.Server, lease.SSH); err != nil {
+			return core.LeaseTarget{}, err
 		}
 		rollbackClaim = false
 	}
 	return lease, nil
 }
 
-func restoreNamespaceClaimLabels(server *Server, claim LeaseClaim, claimOK bool, cfg Config) {
+func restoreNamespaceClaimLabels(server *core.Server, claim core.LeaseClaim, claimOK bool, cfg core.Config) {
 	if !claimOK || server == nil {
 		return
 	}
@@ -145,7 +145,7 @@ func restoreNamespaceClaimLabels(server *Server, claim LeaseClaim, claimOK bool,
 	if server.Labels != nil {
 		state = core.Blank(strings.TrimSpace(server.Labels["state"]), state)
 	}
-	labels := touchDirectLeaseLabels(claim.Labels, cfg, state, time.Now().UTC())
+	labels := core.TouchDirectLeaseLabels(claim.Labels, cfg, state, time.Now().UTC())
 	for _, key := range []string{"lease", "name", "provider", "slug", "target"} {
 		if value := strings.TrimSpace(server.Labels[key]); value != "" {
 			labels[key] = value
@@ -157,17 +157,17 @@ func restoreNamespaceClaimLabels(server *Server, claim LeaseClaim, claimOK bool,
 	server.Labels = labels
 }
 
-func (b *namespaceLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *namespaceLeaseBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	items, err := b.listDevboxes(ctx)
 	if err != nil {
 		return nil, err
 	}
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return nil, err
 	}
-	servers := make([]Server, 0, len(items))
+	servers := make([]core.Server, 0, len(items))
 	for _, item := range items {
 		server := namespaceItemToServer(item, b.namespaceConfigForRun())
 		if claim, ok := namespaceClaimForServer(claims, server.Name); ok {
@@ -178,7 +178,7 @@ func (b *namespaceLeaseBackend) List(ctx context.Context, req ListRequest) ([]Le
 	return servers, nil
 }
 
-func namespaceClaimForServer(claims []LeaseClaim, name string) (LeaseClaim, bool) {
+func namespaceClaimForServer(claims []core.LeaseClaim, name string) (core.LeaseClaim, bool) {
 	name = strings.TrimSpace(name)
 	for _, claim := range claims {
 		if claim.Provider != namespaceProvider {
@@ -189,16 +189,16 @@ func namespaceClaimForServer(claims []LeaseClaim, name string) (LeaseClaim, bool
 			claimedName = strings.TrimSpace(claim.Slug)
 		}
 		if claimedName == "" {
-			claimedName = leaseProviderName(claim.LeaseID, claim.Slug)
+			claimedName = core.LeaseProviderName(claim.LeaseID, claim.Slug)
 		}
 		if strings.TrimSpace(claim.CloudID) == name || claimedName == name {
 			return claim, true
 		}
 	}
-	return LeaseClaim{}, false
+	return core.LeaseClaim{}, false
 }
 
-func mergeNamespaceListClaim(server *Server, claim LeaseClaim) {
+func mergeNamespaceListClaim(server *core.Server, claim core.LeaseClaim) {
 	if server == nil {
 		return
 	}
@@ -217,32 +217,32 @@ func mergeNamespaceListClaim(server *Server, claim LeaseClaim) {
 	server.Labels = labels
 }
 
-func (b *namespaceLeaseBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
-	servers, err := b.List(ctx, ListRequest{})
+func (b *namespaceLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
+	servers, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return cliDoctorResult(namespaceProvider, len(servers), "unchecked"), nil
+	return core.CLIDoctorResult(namespaceProvider, len(servers), "unchecked"), nil
 }
 
-func (b *namespaceLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *namespaceLeaseBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
 	return err
 }
 
-func (b *namespaceLeaseBackend) ReleaseLeaseWithOutcome(ctx context.Context, req ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+func (b *namespaceLeaseBackend) ReleaseLeaseWithOutcome(ctx context.Context, req core.ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
 	var outcome core.ReleaseLeaseOutcome
 	err := b.releaseLease(ctx, req, &outcome)
 	return outcome, err
 }
 
-func (b *namespaceLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
+func (b *namespaceLeaseBackend) releaseLease(ctx context.Context, req core.ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	name := strings.TrimSpace(req.Lease.Server.Name)
 	if name == "" {
 		name, _, _, _ = resolveNamespaceDevboxName(req.Lease.LeaseID, true)
 	}
 	if name == "" {
-		return exit(2, "namespace devbox release requires a devbox name")
+		return core.Exit(2, "namespace devbox release requires a devbox name")
 	}
 	binding := shared.ClaimBinding{
 		Provider:           namespaceProvider,
@@ -280,37 +280,37 @@ func (b *namespaceLeaseBackend) releaseLease(ctx context.Context, req ReleaseLea
 	server.Status = "stopped"
 	server.Labels["state"] = "stopped"
 	server.Labels["release"] = "stop"
-	_, err = updateLeaseClaimEndpointIfUnchangedAfter(req.Lease.LeaseID, claim, server, SSHTarget{}, func() error {
+	_, err = core.UpdateLeaseClaimEndpointIfUnchangedAfter(req.Lease.LeaseID, claim, server, core.SSHTarget{}, func() error {
 		return b.shutdownDevbox(ctx, name)
 	})
 	return err
 }
 
-func (b *namespaceLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
+func (b *namespaceLeaseBackend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 	if namespaceDeleteOnRelease(lease, b.namespaceConfigForRun()) {
 		return fmt.Sprintf("deleted namespace devbox lease=%s name=%s", lease.LeaseID, lease.Server.Name)
 	}
 	return fmt.Sprintf("stopped namespace devbox lease=%s name=%s retained=true", lease.LeaseID, lease.Server.Name)
 }
 
-func (b *namespaceLeaseBackend) RetainLeaseClaimAfterRelease(lease LeaseTarget) bool {
+func (b *namespaceLeaseBackend) RetainLeaseClaimAfterRelease(lease core.LeaseTarget) bool {
 	return !namespaceDeleteOnRelease(lease, b.namespaceConfigForRun())
 }
 
-func (b *namespaceLeaseBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {
+func (b *namespaceLeaseBackend) Touch(_ context.Context, req core.TouchRequest) (core.Server, error) {
 	server := req.Lease.Server
 	if server.Labels == nil {
 		server.Labels = map[string]string{}
 	}
-	server.Labels = touchDirectLeaseLabels(server.Labels, b.cfg, req.State, time.Now().UTC())
+	server.Labels = core.TouchDirectLeaseLabels(server.Labels, b.cfg, req.State, time.Now().UTC())
 	return server, nil
 }
 
-func (b *namespaceLeaseBackend) Cleanup(_ context.Context, req CleanupRequest) error {
+func (b *namespaceLeaseBackend) Cleanup(_ context.Context, req core.CleanupRequest) error {
 	return cleanupNamespaceSSHFiles("", req.DryRun, b.rt.Stdout)
 }
 
-func (b *namespaceLeaseBackend) namespaceConfigForRun() Config {
+func (b *namespaceLeaseBackend) namespaceConfigForRun() core.Config {
 	cfg := b.cfg
 	cfg.Provider = namespaceProvider
 	cfg.TargetOS = targetLinux
@@ -321,23 +321,23 @@ func (b *namespaceLeaseBackend) namespaceConfigForRun() Config {
 	return cfg
 }
 
-func (b *namespaceLeaseBackend) prepareLease(ctx context.Context, name, leaseID, slug string, keep bool) (LeaseTarget, error) {
+func (b *namespaceLeaseBackend) prepareLease(ctx context.Context, name, leaseID, slug string, keep bool) (core.LeaseTarget, error) {
 	cfg := b.namespaceConfigForRun()
 	target, err := b.prepareDevbox(ctx, name)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	target.TargetOS = targetLinux
 	target.NetworkKind = networkPublic
 	target.ReadyCheck = "command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null"
 	server := namespaceServer(name, leaseID, slug, cfg, keep)
 	server.PublicNet.IPv4.IP = target.Host
-	if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "namespace devbox ssh", bootstrapWaitTimeout(cfg)); err != nil {
-		return LeaseTarget{}, err
+	if err := core.WaitForSSHReady(ctx, &target, b.rt.Stderr, "namespace devbox ssh", core.BootstrapWaitTimeout(cfg)); err != nil {
+		return core.LeaseTarget{}, err
 	}
 	server.Status = "ready"
 	server.Labels["state"] = "ready"
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
 func (b *namespaceLeaseBackend) createDevbox(ctx context.Context, spec namespaceCreateSpec) error {
@@ -366,34 +366,34 @@ func (b *namespaceLeaseBackend) createDevbox(ctx context.Context, spec namespace
 	}
 	result, err := b.runCommand(ctx, []string{"create", "--from", path}, b.rt.Stdout, b.rt.Stderr)
 	if err != nil {
-		return ExitError{Code: result.ExitCode, Message: fmt.Sprintf("namespace devbox create failed: %v", err)}
+		return core.ExitError{Code: result.ExitCode, Message: fmt.Sprintf("namespace devbox create failed: %v", err)}
 	}
 	return nil
 }
 
-func (b *namespaceLeaseBackend) prepareDevbox(ctx context.Context, name string) (SSHTarget, error) {
+func (b *namespaceLeaseBackend) prepareDevbox(ctx context.Context, name string) (core.SSHTarget, error) {
 	target, configureErr := b.configureSSHDevbox(ctx, name)
 	if configureErr == nil {
 		return target, nil
 	}
 	out, err := b.commandOutput(ctx, []string{"prepare", name})
 	if err != nil {
-		return SSHTarget{}, err
+		return core.SSHTarget{}, err
 	}
 	var result namespacePrepareResult
 	if err := json.Unmarshal([]byte(extractJSONObject(out)), &result); err != nil {
-		return SSHTarget{}, exit(5, "namespace devbox prepare returned invalid JSON: %v", err)
+		return core.SSHTarget{}, core.Exit(5, "namespace devbox prepare returned invalid JSON: %v", err)
 	}
 	return namespaceSSHTarget(result)
 }
 
-func (b *namespaceLeaseBackend) configureSSHDevbox(ctx context.Context, name string) (SSHTarget, error) {
+func (b *namespaceLeaseBackend) configureSSHDevbox(ctx context.Context, name string) (core.SSHTarget, error) {
 	if target, err := namespaceSSHTargetFromConfig(name); err == nil {
 		return target, nil
 	}
 	result, err := b.runCommand(ctx, []string{"configure-ssh"}, b.rt.Stdout, b.rt.Stderr)
 	if err != nil {
-		return SSHTarget{}, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("namespace devbox configure-ssh failed: %v", err)}
+		return core.SSHTarget{}, core.ExitError{Code: result.ExitCode, Message: fmt.Sprintf("namespace devbox configure-ssh failed: %v", err)}
 	}
 	return namespaceSSHTargetFromConfig(name)
 }
@@ -414,7 +414,7 @@ func (b *namespaceLeaseBackend) shutdownDevbox(ctx context.Context, name string)
 	if err != nil {
 		result, err := b.runCommand(ctx, []string{"stop", name, "--force"}, b.rt.Stdout, b.rt.Stderr)
 		if err != nil {
-			return ExitError{Code: result.ExitCode, Message: fmt.Sprintf("namespace devbox shutdown failed: %v", err)}
+			return core.ExitError{Code: result.ExitCode, Message: fmt.Sprintf("namespace devbox shutdown failed: %v", err)}
 		}
 	}
 	return nil
@@ -425,7 +425,7 @@ func (b *namespaceLeaseBackend) deleteDevbox(ctx context.Context, name string) e
 	if err != nil {
 		result, err := b.runCommand(ctx, []string{"destroy", name, "--force"}, b.rt.Stdout, b.rt.Stderr)
 		if err != nil {
-			return ExitError{Code: result.ExitCode, Message: fmt.Sprintf("namespace devbox delete failed: %v", err)}
+			return core.ExitError{Code: result.ExitCode, Message: fmt.Sprintf("namespace devbox delete failed: %v", err)}
 		}
 	}
 	return nil
@@ -434,7 +434,7 @@ func (b *namespaceLeaseBackend) deleteDevbox(ctx context.Context, name string) e
 func (b *namespaceLeaseBackend) commandOutput(ctx context.Context, args []string) (string, error) {
 	result, err := b.runCommand(ctx, args, nil, nil)
 	if err != nil {
-		return "", ExitError{Code: result.ExitCode, Message: fmt.Sprintf("namespace devbox failed: %v: %s", err, strings.TrimSpace(result.Stdout+result.Stderr))}
+		return "", core.ExitError{Code: result.ExitCode, Message: fmt.Sprintf("namespace devbox failed: %v: %s", err, strings.TrimSpace(result.Stdout+result.Stderr))}
 	}
 	if result.Stderr != "" && b.rt.Stderr != nil {
 		_, _ = io.WriteString(b.rt.Stderr, result.Stderr)
@@ -442,8 +442,8 @@ func (b *namespaceLeaseBackend) commandOutput(ctx context.Context, args []string
 	return result.Stdout, nil
 }
 
-func (b *namespaceLeaseBackend) runCommand(ctx context.Context, args []string, stdout, stderr io.Writer) (LocalCommandResult, error) {
-	return b.rt.Exec.Run(ctx, LocalCommandRequest{Name: "devbox", Args: args, Stdout: stdout, Stderr: stderr})
+func (b *namespaceLeaseBackend) runCommand(ctx context.Context, args []string, stdout, stderr io.Writer) (core.LocalCommandResult, error) {
+	return b.rt.Exec.Run(ctx, core.LocalCommandRequest{Name: "devbox", Args: args, Stdout: stdout, Stderr: stderr})
 }
 
 type namespaceCreateSpec struct {
@@ -471,34 +471,34 @@ type namespaceListItem struct {
 	Created    string
 }
 
-func namespaceSSHTarget(result namespacePrepareResult) (SSHTarget, error) {
+func namespaceSSHTarget(result namespacePrepareResult) (core.SSHTarget, error) {
 	endpoint := strings.TrimSpace(result.SSHEndpoint)
 	keyPath := strings.TrimSpace(result.SSHKeyPath)
 	if endpoint == "" {
-		return SSHTarget{}, exit(5, "namespace devbox prepare response missing ssh_endpoint")
+		return core.SSHTarget{}, core.Exit(5, "namespace devbox prepare response missing ssh_endpoint")
 	}
 	user, hostPort, ok := strings.Cut(endpoint, "@")
 	if !ok || strings.TrimSpace(user) == "" || strings.TrimSpace(hostPort) == "" {
-		return SSHTarget{}, exit(5, "namespace devbox prepare returned invalid ssh_endpoint %q", endpoint)
+		return core.SSHTarget{}, core.Exit(5, "namespace devbox prepare returned invalid ssh_endpoint %q", endpoint)
 	}
 	host, port, err := net.SplitHostPort(hostPort)
 	if err != nil {
 		idx := strings.LastIndex(hostPort, ":")
 		if idx <= 0 || idx == len(hostPort)-1 {
-			return SSHTarget{}, exit(5, "namespace devbox prepare returned invalid ssh_endpoint %q", endpoint)
+			return core.SSHTarget{}, core.Exit(5, "namespace devbox prepare returned invalid ssh_endpoint %q", endpoint)
 		}
 		host = hostPort[:idx]
 		port = hostPort[idx+1:]
 	}
-	return SSHTarget{User: user, Host: host, Port: port, Key: keyPath, SSHConfigProxy: result.SSHConfig}, nil
+	return core.SSHTarget{User: user, Host: host, Port: port, Key: keyPath, SSHConfigProxy: result.SSHConfig}, nil
 }
 
-func namespaceSSHTargetFromConfig(name string) (SSHTarget, error) {
+func namespaceSSHTargetFromConfig(name string) (core.SSHTarget, error) {
 	host := namespaceSSHHost(name)
 	path := filepath.Join(os.Getenv("HOME"), ".namespace", "ssh", host+".ssh")
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return SSHTarget{}, exit(5, "namespace devbox ssh config missing for %s: %v", name, err)
+		return core.SSHTarget{}, core.Exit(5, "namespace devbox ssh config missing for %s: %v", name, err)
 	}
 	user := "devbox"
 	key := ""
@@ -510,7 +510,7 @@ func namespaceSSHTargetFromConfig(name string) (SSHTarget, error) {
 		switch strings.ToLower(fields[0]) {
 		case "host":
 			if fields[1] != host {
-				return SSHTarget{}, exit(5, "namespace devbox ssh config host mismatch: got %s want %s", fields[1], host)
+				return core.SSHTarget{}, core.Exit(5, "namespace devbox ssh config host mismatch: got %s want %s", fields[1], host)
 			}
 		case "user":
 			user = fields[1]
@@ -519,9 +519,9 @@ func namespaceSSHTargetFromConfig(name string) (SSHTarget, error) {
 		}
 	}
 	if key == "" {
-		return SSHTarget{}, exit(5, "namespace devbox ssh config missing IdentityFile for %s", name)
+		return core.SSHTarget{}, core.Exit(5, "namespace devbox ssh config missing IdentityFile for %s", name)
 	}
-	return SSHTarget{User: user, Host: host, Port: "22", Key: key, SSHConfigProxy: true}, nil
+	return core.SSHTarget{User: user, Host: host, Port: "22", Key: key, SSHConfigProxy: true}, nil
 }
 
 func cleanupNamespaceSSHFiles(name string, dryRun bool, stdout io.Writer) error {
@@ -600,13 +600,13 @@ func expandHomePath(path string) string {
 	return path
 }
 
-func namespaceServer(name, leaseID, slug string, cfg Config, keep bool) Server {
-	labels := directLeaseLabels(cfg, leaseID, slug, namespaceProvider, "", keep, time.Now().UTC())
+func namespaceServer(name, leaseID, slug string, cfg core.Config, keep bool) core.Server {
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, namespaceProvider, "", keep, time.Now().UTC())
 	labels["name"] = name
 	labels["target"] = targetLinux
 	labels["state"] = "starting"
 	labels["release"] = namespaceReleaseAction(cfg)
-	server := Server{
+	server := core.Server{
 		CloudID:  name,
 		Provider: namespaceProvider,
 		Name:     name,
@@ -617,11 +617,11 @@ func namespaceServer(name, leaseID, slug string, cfg Config, keep bool) Server {
 	return server
 }
 
-func namespaceItemToServer(item namespaceListItem, cfg Config) Server {
+func namespaceItemToServer(item namespaceListItem, cfg core.Config) core.Server {
 	name := core.Blank(item.Name, item.ID)
 	slug := namespaceSlugFromName(name)
 	leaseID := namespaceLeaseIDFromName(name)
-	labels := directLeaseLabels(cfg, leaseID, slug, namespaceProvider, "", true, time.Now().UTC())
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, namespaceProvider, "", true, time.Now().UTC())
 	labels["name"] = name
 	labels["state"] = core.Blank(item.Status, "unknown")
 	labels["release"] = namespaceReleaseAction(cfg)
@@ -631,7 +631,7 @@ func namespaceItemToServer(item namespaceListItem, cfg Config) Server {
 	if item.Created != "" {
 		labels["created"] = item.Created
 	}
-	server := Server{
+	server := core.Server{
 		CloudID:  name,
 		Provider: namespaceProvider,
 		Name:     name,
@@ -642,14 +642,14 @@ func namespaceItemToServer(item namespaceListItem, cfg Config) Server {
 	return server
 }
 
-func namespaceReleaseAction(cfg Config) string {
+func namespaceReleaseAction(cfg core.Config) string {
 	if cfg.Namespace.DeleteOnRelease {
 		return "delete"
 	}
 	return "stop"
 }
 
-func namespaceDeleteOnRelease(lease LeaseTarget, cfg Config) bool {
+func namespaceDeleteOnRelease(lease core.LeaseTarget, cfg core.Config) bool {
 	if deleteOnReleaseExplicit(cfg) {
 		return cfg.Namespace.DeleteOnRelease
 	}
@@ -668,13 +668,13 @@ var crabboxNamespaceNamePattern = regexp.MustCompile(`^crabbox-(.+)-[0-9a-f]{8}$
 
 func namespaceSlugFromName(name string) string {
 	if match := crabboxNamespaceNamePattern.FindStringSubmatch(strings.TrimSpace(name)); len(match) == 2 {
-		return normalizeLeaseSlug(match[1])
+		return core.NormalizeLeaseSlug(match[1])
 	}
-	return normalizeLeaseSlug(name)
+	return core.NormalizeLeaseSlug(name)
 }
 
 func namespaceLeaseIDFromName(name string) string {
-	slug := normalizeLeaseSlug(name)
+	slug := core.NormalizeLeaseSlug(name)
 	if slug == "" {
 		slug = "devbox"
 	}
@@ -687,34 +687,34 @@ func namespaceLeaseIDFromName(name string) string {
 func resolveNamespaceDevboxName(identifier string, reclaim bool) (string, string, string, error) {
 	identifier = strings.TrimSpace(identifier)
 	if identifier == "" {
-		return "", "", "", exit(2, "provider=%s requires --id <devbox-name-or-slug>", namespaceProvider)
+		return "", "", "", core.Exit(2, "provider=%s requires --id <devbox-name-or-slug>", namespaceProvider)
 	}
-	if claim, ok, err := resolveLeaseClaim(identifier); err != nil {
+	if claim, ok, err := core.ResolveLeaseClaim(identifier); err != nil {
 		return "", "", "", err
 	} else if ok {
 		if claim.Provider != "" && claim.Provider != namespaceProvider {
-			return "", "", "", exit(4, "%q is claimed by provider %s", identifier, claim.Provider)
+			return "", "", "", core.Exit(4, "%q is claimed by provider %s", identifier, claim.Provider)
 		}
 		_ = reclaim
-		slug := core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID))
+		slug := core.Blank(claim.Slug, core.NewLeaseSlug(claim.LeaseID))
 		if strings.HasPrefix(claim.LeaseID, "nsd_") {
 			return slug, claim.LeaseID, slug, nil
 		}
-		return leaseProviderName(claim.LeaseID, slug), claim.LeaseID, slug, nil
+		return core.LeaseProviderName(claim.LeaseID, slug), claim.LeaseID, slug, nil
 	}
 	if strings.HasPrefix(identifier, "cbx_") {
-		slug := newLeaseSlug(identifier)
-		return leaseProviderName(identifier, slug), identifier, slug, nil
+		slug := core.NewLeaseSlug(identifier)
+		return core.LeaseProviderName(identifier, slug), identifier, slug, nil
 	}
-	slug := normalizeLeaseSlug(identifier)
+	slug := core.NormalizeLeaseSlug(identifier)
 	return identifier, namespaceLeaseIDFromName(identifier), slug, nil
 }
 
-func namespaceImage(cfg Config) string {
+func namespaceImage(cfg core.Config) string {
 	return core.Blank(strings.TrimSpace(cfg.Namespace.Image), core.NamespaceConfigDefaultImage)
 }
 
-func namespaceSize(cfg Config) string {
+func namespaceSize(cfg core.Config) string {
 	if strings.TrimSpace(cfg.Namespace.Size) != "" {
 		if size := namespaceValidSize(strings.TrimSpace(cfg.Namespace.Size)); size != "" {
 			return size
@@ -738,11 +738,11 @@ func namespaceValidSize(value string) string {
 	}
 }
 
-func namespaceWorkRoot(cfg Config) string {
+func namespaceWorkRoot(cfg core.Config) string {
 	return core.Blank(strings.TrimSpace(cfg.Namespace.WorkRoot), core.NamespaceConfigDefaultWorkRoot)
 }
 
-func namespaceAutoStopIdleTimeout(cfg Config) time.Duration {
+func namespaceAutoStopIdleTimeout(cfg core.Config) time.Duration {
 	if cfg.Namespace.AutoStopIdleTimeout > 0 {
 		return cfg.Namespace.AutoStopIdleTimeout
 	}
@@ -781,7 +781,7 @@ func parseNamespaceList(output string) ([]namespaceListItem, error) {
 	}
 	var raw any
 	if err := json.Unmarshal([]byte(extractJSONValue(output)), &raw); err != nil {
-		return nil, exit(5, "namespace devbox list returned invalid JSON: %v", err)
+		return nil, core.Exit(5, "namespace devbox list returned invalid JSON: %v", err)
 	}
 	values := []any{}
 	switch typed := raw.(type) {

--- a/internal/providers/namespace/backend_test.go
+++ b/internal/providers/namespace/backend_test.go
@@ -34,14 +34,14 @@ func TestProviderServerTypeResolution(t *testing.T) {
 	provider := Provider{}
 	for _, test := range []struct {
 		name string
-		cfg  Config
+		cfg  core.Config
 		want string
 	}{
-		{name: "provider size", cfg: Config{Provider: namespaceProvider, Namespace: NamespaceConfig{Size: " xl "}, Class: "standard"}, want: "XL"},
-		{name: "explicit type", cfg: Config{Provider: namespaceProvider, ServerType: " l ", ServerTypeExplicit: true, Class: "standard"}, want: "L"},
-		{name: "canonical class", cfg: Config{Provider: namespaceProvider, TargetOS: targetLinux, Architecture: "amd64", Class: "large"}, want: "L"},
-		{name: "empty default", cfg: Config{Provider: namespaceProvider}, want: "M"},
-		{name: "custom class", cfg: Config{Provider: namespaceProvider, Class: "gpu"}, want: "GPU"},
+		{name: "provider size", cfg: core.Config{Provider: namespaceProvider, Namespace: core.NamespaceConfig{Size: " xl "}, Class: "standard"}, want: "XL"},
+		{name: "explicit type", cfg: core.Config{Provider: namespaceProvider, ServerType: " l ", ServerTypeExplicit: true, Class: "standard"}, want: "L"},
+		{name: "canonical class", cfg: core.Config{Provider: namespaceProvider, TargetOS: targetLinux, Architecture: "amd64", Class: "large"}, want: "L"},
+		{name: "empty default", cfg: core.Config{Provider: namespaceProvider}, want: "M"},
+		{name: "custom class", cfg: core.Config{Provider: namespaceProvider, Class: "gpu"}, want: "GPU"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if got := provider.ServerTypeForConfig(test.cfg); got != test.want {
@@ -83,13 +83,13 @@ func TestParseNamespaceListAcceptsEmptyCLIText(t *testing.T) {
 
 func TestListDevboxesIgnoresSuccessfulCommandStderr(t *testing.T) {
 	runner := &namespaceQueuedRunner{
-		results: []LocalCommandResult{{
+		results: []core.LocalCommandResult{{
 			Stdout: `[{"name":"crabbox-blue-lobster-deadbeef","status":"running","size":"L"}]`,
 			Stderr: "warning: update available\n",
 		}},
 	}
 	var stderr bytes.Buffer
-	backend := &namespaceLeaseBackend{rt: Runtime{Exec: runner, Stderr: &stderr}}
+	backend := &namespaceLeaseBackend{rt: core.Runtime{Exec: runner, Stderr: &stderr}}
 
 	items, err := backend.listDevboxes(context.Background())
 	if err != nil {
@@ -135,7 +135,7 @@ func TestNamespaceItemToServerMapsCrabboxNames(t *testing.T) {
 		Name:   "crabbox-blue-lobster-deadbeef",
 		Status: "running",
 		Size:   "XL",
-	}, Config{})
+	}, core.Config{})
 	if server.Provider != namespaceProvider || server.Name != "crabbox-blue-lobster-deadbeef" || server.Status != "running" {
 		t.Fatalf("server=%#v", server)
 	}
@@ -148,11 +148,11 @@ func TestListRestoresNamespaceClaimMetadata(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_deadbeef0000"
 	slug := "blue-lobster"
-	name := leaseProviderName(leaseID, slug)
-	if err := claimLeaseForRepoProvider(leaseID, slug, namespaceProvider, t.TempDir(), time.Hour, false); err != nil {
+	name := core.LeaseProviderName(leaseID, slug)
+	if err := core.ClaimLeaseForRepoProvider(leaseID, slug, namespaceProvider, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
-	server := Server{
+	server := core.Server{
 		CloudID:  name,
 		Provider: namespaceProvider,
 		Name:     name,
@@ -167,12 +167,12 @@ func TestListRestoresNamespaceClaimMetadata(t *testing.T) {
 			"state":              "stopped",
 		},
 	}
-	if err := updateLeaseClaimEndpoint(leaseID, server, SSHTarget{}); err != nil {
+	if err := core.UpdateLeaseClaimEndpoint(leaseID, server, core.SSHTarget{}); err != nil {
 		t.Fatal(err)
 	}
-	runner := &namespaceQueuedRunner{results: []LocalCommandResult{{Stdout: `{"devboxes":[{"name":"` + name + `","state":"stopped","machine_size":"M"}]}`}}}
-	backend := &namespaceLeaseBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
-	servers, err := backend.List(context.Background(), ListRequest{})
+	runner := &namespaceQueuedRunner{results: []core.LocalCommandResult{{Stdout: `{"devboxes":[{"name":"` + name + `","state":"stopped","machine_size":"M"}]}`}}}
+	backend := &namespaceLeaseBackend{rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	servers, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +183,7 @@ func TestListRestoresNamespaceClaimMetadata(t *testing.T) {
 
 func TestResolveNamespaceDevboxNameKeepsClaimedExternalName(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	if err := claimLeaseForRepoProvider("nsd_existing-devbox", "existing-devbox", namespaceProvider, t.TempDir(), 0, false); err != nil {
+	if err := core.ClaimLeaseForRepoProvider("nsd_existing-devbox", "existing-devbox", namespaceProvider, t.TempDir(), 0, false); err != nil {
 		t.Fatal(err)
 	}
 	name, leaseID, slug, err := resolveNamespaceDevboxName("existing-devbox", false)
@@ -198,15 +198,15 @@ func TestResolveNamespaceDevboxNameKeepsClaimedExternalName(t *testing.T) {
 func TestResolveReleaseOnlySkipsNamespacePrepare(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repoRoot := t.TempDir()
-	if err := claimLeaseForRepoProvider("nsd_crabbox-blue-lobster-deadbeef", "blue-lobster", namespaceProvider, repoRoot, 0, true); err != nil {
+	if err := core.ClaimLeaseForRepoProvider("nsd_crabbox-blue-lobster-deadbeef", "blue-lobster", namespaceProvider, repoRoot, 0, true); err != nil {
 		t.Fatal(err)
 	}
 	runner := &namespaceRecordingRunner{}
 	backend := &namespaceLeaseBackend{
-		cfg: Config{Namespace: NamespaceConfig{WorkRoot: "/workspaces/crabbox"}},
-		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner},
+		cfg: core.Config{Namespace: core.NamespaceConfig{WorkRoot: "/workspaces/crabbox"}},
+		rt:  core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner},
 	}
-	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: "blue-lobster", ReleaseOnly: true})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "blue-lobster", ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,16 +225,16 @@ func TestResolveChecksRepoClaimBeforeNamespacePrepare(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_deadbeef0000"
 	slug := "blue-lobster"
-	if err := claimLeaseForRepoProvider(leaseID, slug, namespaceProvider, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProvider(leaseID, slug, namespaceProvider, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	runner := &namespaceRecordingRunner{}
 	backend := &namespaceLeaseBackend{
-		cfg: Config{Provider: namespaceProvider},
-		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner},
+		cfg: core.Config{Provider: namespaceProvider},
+		rt:  core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner},
 	}
 
-	req := ResolveRequest{ID: leaseID}
+	req := core.ResolveRequest{ID: leaseID}
 	req.Repo.Root = t.TempDir()
 	_, err := backend.Resolve(context.Background(), req)
 	if err == nil || !strings.Contains(err.Error(), "is claimed by repo") {
@@ -250,17 +250,17 @@ func TestResolveRestoresRepoClaimWhenNamespacePrepareFails(t *testing.T) {
 	leaseID := "cbx_deadbeef0000"
 	runner := &namespaceRecordingRunner{failAll: true}
 	backend := &namespaceLeaseBackend{
-		cfg: Config{Provider: namespaceProvider},
-		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner},
+		cfg: core.Config{Provider: namespaceProvider},
+		rt:  core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner},
 	}
-	req := ResolveRequest{ID: leaseID}
+	req := core.ResolveRequest{ID: leaseID}
 	req.Repo.Root = t.TempDir()
 
 	_, err := backend.Resolve(context.Background(), req)
 	if err == nil || !strings.Contains(err.Error(), "namespace devbox failed") {
 		t.Fatalf("Resolve error=%v", err)
 	}
-	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
+	if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
 		t.Fatalf("failed resolve retained claim exists=%v err=%v", exists, err)
 	}
 }
@@ -316,25 +316,25 @@ func TestReleaseLeaseCleansNamespaceSSHFiles(t *testing.T) {
 	runner := &namespaceRecordingRunner{}
 	var out bytes.Buffer
 	backend := &namespaceLeaseBackend{
-		cfg: Config{Namespace: NamespaceConfig{DeleteOnRelease: true}},
-		rt:  Runtime{Stdout: &out, Stderr: io.Discard, Exec: runner},
+		cfg: core.Config{Namespace: core.NamespaceConfig{DeleteOnRelease: true}},
+		rt:  core.Runtime{Stdout: &out, Stderr: io.Discard, Exec: runner},
 	}
 	leaseID := "cbx_deadbeef0000"
 	name := "crabbox-blue-lobster-deadbeef"
-	server := Server{
+	server := core.Server{
 		CloudID:  name,
 		Provider: namespaceProvider,
 		Name:     name,
 		Labels:   map[string]string{"provider": namespaceProvider, "lease": leaseID, "slug": "blue-lobster", "name": name},
 	}
-	if err := claimLeaseForRepoProvider(leaseID, "blue-lobster", namespaceProvider, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProvider(leaseID, "blue-lobster", namespaceProvider, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := updateLeaseClaimEndpoint(leaseID, server, SSHTarget{}); err != nil {
+	if err := core.UpdateLeaseClaimEndpoint(leaseID, server, core.SSHTarget{}); err != nil {
 		t.Fatal(err)
 	}
-	lease := LeaseTarget{LeaseID: leaseID, Server: server}
-	if outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil || !outcome.Terminal {
+	lease := core.LeaseTarget{LeaseID: leaseID, Server: server}
+	if outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil || !outcome.Terminal {
 		t.Fatalf("deletion outcome=%+v err=%v", outcome, err)
 	}
 	if len(runner.calls) != 1 || runner.calls[0] != "devbox delete crabbox-blue-lobster-deadbeef --force" {
@@ -367,23 +367,23 @@ func TestReleaseLeaseRequiresExactNamespaceClaim(t *testing.T) {
 			const slug = "blue-lobster"
 			const name = "crabbox-blue-lobster-deadbeef"
 			if test.claimName != "" {
-				if err := claimLeaseForRepoProvider(leaseID, slug, namespaceProvider, t.TempDir(), time.Hour, false); err != nil {
+				if err := core.ClaimLeaseForRepoProvider(leaseID, slug, namespaceProvider, t.TempDir(), time.Hour, false); err != nil {
 					t.Fatal(err)
 				}
-				claimed := Server{CloudID: test.claimName, Provider: namespaceProvider, Name: test.claimName, Labels: map[string]string{
+				claimed := core.Server{CloudID: test.claimName, Provider: namespaceProvider, Name: test.claimName, Labels: map[string]string{
 					"provider": namespaceProvider, "lease": leaseID, "slug": slug, "name": test.claimName,
 				}}
-				if err := updateLeaseClaimEndpoint(leaseID, claimed, SSHTarget{}); err != nil {
+				if err := core.UpdateLeaseClaimEndpoint(leaseID, claimed, core.SSHTarget{}); err != nil {
 					t.Fatal(err)
 				}
 			}
 			runner := &namespaceRecordingRunner{failAll: test.failProvider}
 			backend := &namespaceLeaseBackend{
-				cfg: Config{Namespace: NamespaceConfig{DeleteOnRelease: test.deleteOnRelease}},
-				rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner},
+				cfg: core.Config{Namespace: core.NamespaceConfig{DeleteOnRelease: test.deleteOnRelease}},
+				rt:  core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner},
 			}
-			lease := LeaseTarget{LeaseID: leaseID, Server: Server{Name: name, Labels: map[string]string{"slug": slug}}}
-			err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true})
+			lease := core.LeaseTarget{LeaseID: leaseID, Server: core.Server{Name: name, Labels: map[string]string{"slug": slug}}}
+			err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease, Force: true})
 			if err == nil {
 				t.Fatal("expected release to fail")
 			}
@@ -391,7 +391,7 @@ func TestReleaseLeaseRequiresExactNamespaceClaim(t *testing.T) {
 				t.Fatalf("calls=%#v want %d", runner.calls, test.wantCalls)
 			}
 			if test.claimName != "" {
-				claim, exists, claimErr := resolveLeaseClaim(leaseID)
+				claim, exists, claimErr := core.ResolveLeaseClaim(leaseID)
 				if claimErr != nil || !exists || claim.CloudID != test.claimName {
 					t.Fatalf("claim=%#v exists=%v err=%v", claim, exists, claimErr)
 				}
@@ -404,7 +404,7 @@ func TestReleaseLeaseRetainsStoppedNamespaceClaimAndSSHFiles(t *testing.T) {
 	home := testutil.IsolateUserDirs(t).Home
 	leaseID := "cbx_deadbeef0000"
 	slug := "blue-lobster"
-	name := leaseProviderName(leaseID, slug)
+	name := core.LeaseProviderName(leaseID, slug)
 	dir := filepath.Join(home, ".namespace", "ssh")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatal(err)
@@ -414,10 +414,10 @@ func TestReleaseLeaseRetainsStoppedNamespaceClaimAndSSHFiles(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if err := claimLeaseForRepoProvider(leaseID, slug, namespaceProvider, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProvider(leaseID, slug, namespaceProvider, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
-	server := Server{
+	server := core.Server{
 		CloudID:  name,
 		Provider: namespaceProvider,
 		Name:     name,
@@ -430,44 +430,44 @@ func TestReleaseLeaseRetainsStoppedNamespaceClaimAndSSHFiles(t *testing.T) {
 			"state":    "ready",
 		},
 	}
-	if err := updateLeaseClaimEndpoint(leaseID, server, SSHTarget{Host: "ssh.namespace.example", Port: "22"}); err != nil {
+	if err := core.UpdateLeaseClaimEndpoint(leaseID, server, core.SSHTarget{Host: "ssh.namespace.example", Port: "22"}); err != nil {
 		t.Fatal(err)
 	}
-	claim, ok, err := resolveLeaseClaim(leaseID)
+	claim, ok, err := core.ResolveLeaseClaim(leaseID)
 	if err != nil || !ok {
 		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
 	}
 	claim.Labels["pond"] = "alpha"
 	claim.Labels["pond_exposed_ports"] = "8080"
-	currentServer := namespaceServer(name, leaseID, slug, Config{Namespace: NamespaceConfig{DeleteOnRelease: true}}, true)
-	restoreNamespaceClaimLabels(&currentServer, claim, true, Config{Namespace: NamespaceConfig{DeleteOnRelease: true}})
+	currentServer := namespaceServer(name, leaseID, slug, core.Config{Namespace: core.NamespaceConfig{DeleteOnRelease: true}}, true)
+	restoreNamespaceClaimLabels(&currentServer, claim, true, core.Config{Namespace: core.NamespaceConfig{DeleteOnRelease: true}})
 	if currentServer.Labels["release"] != "stop" || currentServer.Labels["pond"] != "alpha" || currentServer.Labels["pond_exposed_ports"] != "8080" {
 		t.Fatalf("stored release policy was overwritten: %#v", currentServer.Labels)
 	}
-	explicitCfg := Config{Namespace: NamespaceConfig{DeleteOnRelease: true}}
+	explicitCfg := core.Config{Namespace: core.NamespaceConfig{DeleteOnRelease: true}}
 	markDeleteOnReleaseExplicit(&explicitCfg)
-	if !namespaceDeleteOnRelease(LeaseTarget{Server: currentServer}, explicitCfg) {
+	if !namespaceDeleteOnRelease(core.LeaseTarget{Server: currentServer}, explicitCfg) {
 		t.Fatal("explicit delete flag did not override stored stop policy")
 	}
 	runner := &namespaceRecordingRunner{}
 	backend := &namespaceLeaseBackend{
-		cfg: Config{Namespace: NamespaceConfig{DeleteOnRelease: true}},
-		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner},
+		cfg: core.Config{Namespace: core.NamespaceConfig{DeleteOnRelease: true}},
+		rt:  core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner},
 	}
-	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if lease.Server.Labels["release"] != "stop" || !backend.RetainLeaseClaimAfterRelease(lease) {
 		t.Fatalf("resolved lease=%#v", lease)
 	}
-	if outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil || outcome.Terminal {
+	if outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil || outcome.Terminal {
 		t.Fatalf("stop outcome=%+v err=%v", outcome, err)
 	}
 	if len(runner.calls) != 1 || runner.calls[0] != "devbox shutdown "+name+" --force" {
 		t.Fatalf("calls=%#v", runner.calls)
 	}
-	claim, ok, err = resolveLeaseClaim(leaseID)
+	claim, ok, err = core.ResolveLeaseClaim(leaseID)
 	if err != nil || !ok || claim.Labels["state"] != "stopped" || claim.SSHHost != "" || claim.SSHPort != 0 {
 		t.Fatalf("stopped claim=%#v ok=%v err=%v", claim, ok, err)
 	}
@@ -481,12 +481,12 @@ func TestReleaseLeaseRetainsStoppedNamespaceClaimAndSSHFiles(t *testing.T) {
 
 func TestNamespaceRejectsUnsafeWorkRoot(t *testing.T) {
 	for _, workRoot := range []string{"/", "/workspaces", "/tmp", "relative"} {
-		cfg := Config{Namespace: NamespaceConfig{WorkRoot: workRoot}}
+		cfg := core.Config{Namespace: core.NamespaceConfig{WorkRoot: workRoot}}
 		if err := validateNamespaceConfig(cfg); err == nil {
 			t.Fatalf("expected %q to be rejected", workRoot)
 		}
 	}
-	if err := validateNamespaceConfig(Config{Namespace: NamespaceConfig{WorkRoot: "/workspaces/crabbox"}}); err != nil {
+	if err := validateNamespaceConfig(core.Config{Namespace: core.NamespaceConfig{WorkRoot: "/workspaces/crabbox"}}); err != nil {
 		t.Fatalf("valid work root rejected: %v", err)
 	}
 }
@@ -497,7 +497,7 @@ func TestNamespaceConfigGetterDefaults(t *testing.T) {
 		{" \t ", "builtin:base", "/workspaces/crabbox"},
 		{" /workspaces/custom ", "/workspaces/custom", "/workspaces/custom"},
 	} {
-		cfg := Config{Namespace: NamespaceConfig{Image: tc.raw, WorkRoot: tc.raw}}
+		cfg := core.Config{Namespace: core.NamespaceConfig{Image: tc.raw, WorkRoot: tc.raw}}
 		if image, root := namespaceImage(cfg), namespaceWorkRoot(cfg); image != tc.image || root != tc.root {
 			t.Fatalf("raw %q resolved to %q / %q", tc.raw, image, root)
 		}
@@ -508,7 +508,7 @@ func TestNamespaceConfigGetterDefaults(t *testing.T) {
 		{-time.Minute, 0, 30 * time.Minute},
 		{0, -time.Minute, 30 * time.Minute},
 	} {
-		cfg := Config{Namespace: NamespaceConfig{AutoStopIdleTimeout: tc.provider}, IdleTimeout: tc.generic}
+		cfg := core.Config{Namespace: core.NamespaceConfig{AutoStopIdleTimeout: tc.provider}, IdleTimeout: tc.generic}
 		if got := namespaceAutoStopIdleTimeout(cfg); got != tc.want {
 			t.Fatalf("timeout=%s, want %s", got, tc.want)
 		}
@@ -518,7 +518,7 @@ func TestNamespaceConfigGetterDefaults(t *testing.T) {
 func TestNamespaceAutoStopDurationFlagValidation(t *testing.T) {
 	for _, value := range []string{"bogus", "0s", "-1m", ""} {
 		t.Run(value, func(t *testing.T) {
-			cfg := Config{}
+			cfg := core.Config{}
 			fs := flag.NewFlagSet("test", flag.ContinueOnError)
 			fs.SetOutput(io.Discard)
 			values := RegisterNamespaceProviderFlags(fs, cfg)
@@ -536,7 +536,7 @@ func TestNamespaceAutoStopDurationFlagValidation(t *testing.T) {
 func TestNamespaceAutoStopDurationFlagAppliesValidValue(t *testing.T) {
 	for _, raw := range []string{"45m", " 45m "} {
 		t.Run(raw, func(t *testing.T) {
-			cfg := Config{Namespace: NamespaceConfig{DeleteOnRelease: true}}
+			cfg := core.Config{Namespace: core.NamespaceConfig{DeleteOnRelease: true}}
 			fs := flag.NewFlagSet("test", flag.ContinueOnError)
 			fs.SetOutput(io.Discard)
 			values := RegisterNamespaceProviderFlags(fs, cfg)
@@ -560,7 +560,7 @@ func TestNamespaceDurationFlagPartialEffects(t *testing.T) {
 	for _, priorMarker := range []bool{false, true} {
 		for _, raw := range []string{"", " \t ", "bogus", "0s", "-1m"} {
 			t.Run(fmt.Sprintf("marker-%t-duration-%q", priorMarker, raw), func(t *testing.T) {
-				cfg := Config{WorkRoot: "/workspaces/generic", Namespace: NamespaceConfig{AutoStopIdleTimeout: 17 * time.Minute, WorkRoot: "/workspaces/prior", DeleteOnRelease: true}}
+				cfg := core.Config{WorkRoot: "/workspaces/generic", Namespace: core.NamespaceConfig{AutoStopIdleTimeout: 17 * time.Minute, WorkRoot: "/workspaces/prior", DeleteOnRelease: true}}
 				if priorMarker {
 					markDeleteOnReleaseExplicit(&cfg)
 				}
@@ -587,7 +587,7 @@ func TestNamespaceDurationFlagPartialEffects(t *testing.T) {
 
 func TestNamespaceLifecycleCommandFallbacks(t *testing.T) {
 	runner := &namespaceRecordingRunner{failFirst: true}
-	backend := &namespaceLeaseBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	backend := &namespaceLeaseBackend{rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 
 	if err := backend.shutdownDevbox(context.Background(), "crabbox-blue-lobster-deadbeef"); err != nil {
 		t.Fatal(err)
@@ -609,7 +609,7 @@ func TestNamespaceLifecycleCommandFallbacks(t *testing.T) {
 func TestNamespacePrepareReportsPrepareFailure(t *testing.T) {
 	testutil.IsolateUserDirs(t)
 	runner := &namespaceRecordingRunner{failAll: true}
-	backend := &namespaceLeaseBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	backend := &namespaceLeaseBackend{rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 
 	_, err := backend.prepareDevbox(context.Background(), "crabbox-blue-lobster-deadbeef")
 	if err == nil || !strings.Contains(err.Error(), "namespace devbox failed") {
@@ -623,14 +623,14 @@ func TestNamespacePrepareReportsPrepareFailure(t *testing.T) {
 func TestNamespacePrepareIgnoresSuccessfulCommandStderr(t *testing.T) {
 	testutil.IsolateUserDirs(t)
 	runner := &namespaceQueuedRunner{
-		results: []LocalCommandResult{
+		results: []core.LocalCommandResult{
 			{ExitCode: 2, Stderr: "configure unsupported"},
 			{Stdout: `{"ssh_endpoint":"crabbox@ssh.namespace.example:2222","ssh_key_path":"/tmp/ns-key"}`, Stderr: "warning: update available\n"},
 		},
 		errs: []error{errors.New("unsupported"), nil},
 	}
 	var stderr bytes.Buffer
-	backend := &namespaceLeaseBackend{rt: Runtime{Stdout: io.Discard, Stderr: &stderr, Exec: runner}}
+	backend := &namespaceLeaseBackend{rt: core.Runtime{Stdout: io.Discard, Stderr: &stderr, Exec: runner}}
 
 	target, err := backend.prepareDevbox(context.Background(), "crabbox-blue-lobster-deadbeef")
 	if err != nil {
@@ -650,28 +650,28 @@ type namespaceRecordingRunner struct {
 	failFirst bool
 }
 
-func (r *namespaceRecordingRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (r *namespaceRecordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.calls = append(r.calls, req.Name+" "+strings.Join(req.Args, " "))
 	if r.failAll {
-		return LocalCommandResult{ExitCode: 2}, errors.New("unsupported")
+		return core.LocalCommandResult{ExitCode: 2}, errors.New("unsupported")
 	}
 	if r.failFirst {
 		r.failFirst = false
-		return LocalCommandResult{ExitCode: 2}, errors.New("unsupported")
+		return core.LocalCommandResult{ExitCode: 2}, errors.New("unsupported")
 	}
-	return LocalCommandResult{}, nil
+	return core.LocalCommandResult{}, nil
 }
 
 type namespaceQueuedRunner struct {
 	calls   []string
-	results []LocalCommandResult
+	results []core.LocalCommandResult
 	errs    []error
 }
 
-func (r *namespaceQueuedRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (r *namespaceQueuedRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.calls = append(r.calls, req.Name+" "+strings.Join(req.Args, " "))
 	if len(r.results) == 0 {
-		return LocalCommandResult{}, nil
+		return core.LocalCommandResult{}, nil
 	}
 	result := r.results[0]
 	r.results = r.results[1:]

--- a/internal/providers/namespace/core.go
+++ b/internal/providers/namespace/core.go
@@ -1,35 +1,10 @@
 package namespace
 
 import (
-	"context"
-
-	"io"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type NamespaceConfig = core.NamespaceConfig
-type LeaseClaim = core.LeaseClaim
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type ListRequest = core.ListRequest
-type CleanupRequest = core.CleanupRequest
-type LeaseView = core.LeaseView
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-type ExitError = core.ExitError
-type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
 
 const (
 	namespaceProvider = "namespace-devbox"
@@ -37,94 +12,14 @@ const (
 	networkPublic     = core.NetworkPublic
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func deleteOnReleaseExplicit(cfg Config) bool {
+func deleteOnReleaseExplicit(cfg core.Config) bool {
 	return core.DeleteOnReleaseExplicit(cfg, namespaceProvider)
 }
 
-func markDeleteOnReleaseExplicit(cfg *Config) {
+func markDeleteOnReleaseExplicit(cfg *core.Config) {
 	core.MarkDeleteOnReleaseExplicit(cfg, namespaceProvider)
 }
 
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func leaseProviderName(leaseID, slug string) string {
-	return core.LeaseProviderName(leaseID, slug)
-}
-
-func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
-	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
-}
-
-func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, now time.Time) map[string]string {
-	return core.TouchDirectLeaseLabels(labels, cfg, state, now)
-}
-
-func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
-}
-
-func claimLeaseForRepoProviderIfUnchanged(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool, expected LeaseClaim, expectedExists bool) (LeaseClaim, error) {
+func claimLeaseForRepoProviderIfUnchanged(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool, expected core.LeaseClaim, expectedExists bool) (core.LeaseClaim, error) {
 	return core.ClaimLeaseForRepoProviderScopePondIfUnchanged(leaseID, slug, provider, "", "", repoRoot, idleTimeout, reclaim, expected, expectedExists)
-}
-
-func readLeaseClaimWithPresence(leaseID string) (LeaseClaim, bool, error) {
-	return core.ReadLeaseClaimWithPresence(leaseID)
-}
-
-func restoreLeaseClaimIfUnchanged(leaseID string, current, previous LeaseClaim, previousExists bool) error {
-	return core.RestoreLeaseClaimIfUnchanged(leaseID, current, previous, previousExists)
-}
-
-func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaim(identifier)
-}
-
-func listLeaseClaims() ([]LeaseClaim, error) {
-	return core.ListLeaseClaims()
-}
-
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
-func updateLeaseClaimEndpoint(leaseID string, server Server, target SSHTarget) error {
-	return core.UpdateLeaseClaimEndpoint(leaseID, server, target)
-}
-
-func updateLeaseClaimEndpointIfUnchanged(leaseID string, expected LeaseClaim, server Server, target SSHTarget) (LeaseClaim, error) {
-	return core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, expected, server, target)
-}
-
-func updateLeaseClaimEndpointIfUnchangedAfter(leaseID string, expected LeaseClaim, server Server, target SSHTarget, action func() error) (LeaseClaim, error) {
-	return core.UpdateLeaseClaimEndpointIfUnchangedAfter(leaseID, expected, server, target, action)
-}
-
-func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
-	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
-}
-
-func bootstrapWaitTimeout(cfg Config) time.Duration {
-	return core.BootstrapWaitTimeout(cfg)
-}
-
-func durationMinutesCeil(duration time.Duration) int {
-	return core.DurationMinutesCeil(duration)
-}
-
-func cliDoctorResult(provider string, leases int, runtime string) DoctorResult {
-	return core.CLIDoctorResult(provider, leases, runtime)
 }

--- a/internal/providers/namespace/flags.go
+++ b/internal/providers/namespace/flags.go
@@ -1,18 +1,18 @@
 package namespace
 
-import core "github.com/openclaw/crabbox/internal/cli"
-
 import (
 	"flag"
 	"path"
 	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func RegisterNamespaceProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterNamespaceProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterNamespaceConfigFlags(fs, defaults.Namespace)
 }
 
-func ApplyNamespaceProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyNamespaceProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	v, ok := values.(core.NamespaceConfigFlagValues)
 	if !ok {
 		return nil
@@ -37,22 +37,22 @@ func ApplyNamespaceProviderFlags(cfg *Config, fs *flag.FlagSet, values any) erro
 	return validateNamespaceConfig(*cfg)
 }
 
-func validateNamespaceConfig(cfg Config) error {
+func validateNamespaceConfig(cfg core.Config) error {
 	if strings.TrimSpace(cfg.Namespace.Size) != "" {
 		switch strings.ToUpper(strings.TrimSpace(cfg.Namespace.Size)) {
 		case "S", "M", "L", "XL":
 		default:
-			return exit(2, "namespace devbox size must be S, M, L, or XL")
+			return core.Exit(2, "namespace devbox size must be S, M, L, or XL")
 		}
 	}
 	size := namespaceSize(cfg)
 	switch size {
 	case "S", "M", "L", "XL":
 	default:
-		return exit(2, "namespace devbox size must be S, M, L, or XL")
+		return core.Exit(2, "namespace devbox size must be S, M, L, or XL")
 	}
 	if cfg.Namespace.VolumeSizeGB < 0 {
-		return exit(2, "namespace volume size must be non-negative")
+		return core.Exit(2, "namespace volume size must be non-negative")
 	}
 	if err := cleanNamespaceWorkRoot(namespaceWorkRoot(cfg)); err != nil {
 		return err
@@ -63,11 +63,11 @@ func validateNamespaceConfig(cfg Config) error {
 func cleanNamespaceWorkRoot(workRoot string) error {
 	clean := path.Clean(strings.TrimSpace(workRoot))
 	if clean == "" || !strings.HasPrefix(clean, "/") {
-		return exit(2, "namespace.workRoot %q must resolve to an absolute path", workRoot)
+		return core.Exit(2, "namespace.workRoot %q must resolve to an absolute path", workRoot)
 	}
 	switch clean {
 	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspaces":
-		return exit(2, "namespace.workRoot %q is too broad; choose a dedicated subdirectory", clean)
+		return core.Exit(2, "namespace.workRoot %q is too broad; choose a dedicated subdirectory", clean)
 	}
 	return nil
 }

--- a/internal/providers/runpod/backend.go
+++ b/internal/providers/runpod/backend.go
@@ -47,9 +47,9 @@ func runpodJitter(d time.Duration) time.Duration {
 }
 
 type runpodLeaseBackend struct {
-	spec   ProviderSpec
-	cfg    Config
-	rt     Runtime
+	spec   core.ProviderSpec
+	cfg    core.Config
+	rt     core.Runtime
 	client runpodAPI
 
 	pollInitialOverride    time.Duration
@@ -65,36 +65,36 @@ type runpodSSHEndpoint struct {
 	Public bool
 }
 
-func NewRunpodLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewRunpodLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	applyRunpodDefaults(&cfg)
 	return &runpodLeaseBackend{spec: spec, cfg: cfg, rt: rt}
 }
 
-func (b *runpodLeaseBackend) Spec() ProviderSpec { return b.spec }
+func (b *runpodLeaseBackend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *runpodLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+func (b *runpodLeaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	client, err := b.api()
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	leaseID := core.NewLeaseID()
 	cfg := b.configForRun()
 	servers, err := b.listServersFromClient(ctx, client, true)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	name := leaseProviderName(leaseID, slug)
+	name := core.LeaseProviderName(leaseID, slug)
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s image=%s instance=%s disk=%dGB keep=%v\n",
 		providerName, leaseID, slug, name, cfg.Runpod.Image, cfg.Runpod.InstanceID, cfg.Runpod.DiskGB, req.Keep)
 
-	publicKey, err := publicKeyFor(cfg.SSHKey)
+	publicKey, err := core.PublicKeyFor(cfg.SSHKey)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	pod, err := client.DeployPod(ctx, runpodDeployInput{
 		Name:              name,
@@ -107,7 +107,7 @@ func (b *runpodLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 		PublicKey:         publicKey,
 	})
 	if err != nil {
-		return LeaseTarget{}, exit(1, "runpod create pod failed: %v", err)
+		return core.LeaseTarget{}, core.Exit(1, "runpod create pod failed: %v", err)
 	}
 
 	ready, err := b.waitForPodSSH(ctx, client, pod.ID)
@@ -115,13 +115,13 @@ func (b *runpodLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 		if !req.Keep {
 			err = b.cleanupFailedAcquire(client, pod.ID, err)
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if err := validateCreatedRunpodPod(ready, pod.ID, name); err != nil {
 		if !req.Keep {
 			err = b.cleanupFailedAcquire(client, pod.ID, err)
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 
 	lease, err := b.prepareLease(ctx, cfg, ready, leaseID, slug, req.Keep, true)
@@ -129,13 +129,13 @@ func (b *runpodLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 		if !req.Keep {
 			err = b.cleanupFailedAcquire(client, pod.ID, err)
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
 		if !req.Keep {
 			err = b.cleanupFailedAcquire(client, pod.ID, err)
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s pod=%s state=ready\n", leaseID, pod.ID)
 	return lease, nil
@@ -154,29 +154,29 @@ func (b *runpodLeaseBackend) cleanupFailedAcquire(client runpodAPI, podID string
 	return cause
 }
 
-func (b *runpodLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *runpodLeaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	cfg := b.configForRun()
 	client, err := b.api()
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.ReleaseOnly {
 		claim, ok, err := resolveRunpodClaim(req.ID)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		if !ok {
-			return LeaseTarget{}, unclaimedRunpodError(req.ID)
+			return core.LeaseTarget{}, unclaimedRunpodError(req.ID)
 		}
 		pod, err := b.resolveClaimedPod(ctx, client, claim, true)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
-		return LeaseTarget{Server: runpodServer(pod, claim.LeaseID, claim.Slug, cfg, true), LeaseID: claim.LeaseID}, nil
+		return core.LeaseTarget{Server: runpodServer(pod, claim.LeaseID, claim.Slug, cfg, true), LeaseID: claim.LeaseID}, nil
 	}
 	claim, claimed, err := resolveRunpodClaim(req.ID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	var (
 		pod     runpodPod
@@ -186,7 +186,7 @@ func (b *runpodLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (L
 	if claimed {
 		pod, err = b.resolveClaimedPod(ctx, client, claim, false)
 		leaseID = claim.LeaseID
-		slug = core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID))
+		slug = core.Blank(claim.Slug, core.NewLeaseSlug(claim.LeaseID))
 	} else {
 		pod, leaseID, slug, err = b.resolveUnclaimedPod(ctx, client, req.ID)
 		if err == nil {
@@ -203,24 +203,24 @@ func (b *runpodLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (L
 		}
 	}
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.Repo.Root != "" && (!claimed || !runpodClaimIsBound(claim)) && !req.Reclaim {
-		return LeaseTarget{}, exit(2, "runpod pod %s is not bound to an exact local claim; retry with --reclaim to adopt it", pod.ID)
+		return core.LeaseTarget{}, core.Exit(2, "runpod pod %s is not bound to an exact local claim; retry with --reclaim to adopt it", pod.ID)
 	}
 	lease, err := b.prepareLease(ctx, cfg, pod, leaseID, slug, true, false)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.Repo.Root != "" {
-		if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
-			return LeaseTarget{}, err
+		if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+			return core.LeaseTarget{}, err
 		}
 	}
 	return lease, nil
 }
 
-func (b *runpodLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *runpodLeaseBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	client, err := b.api()
 	if err != nil {
 		return nil, err
@@ -228,28 +228,28 @@ func (b *runpodLeaseBackend) List(ctx context.Context, req ListRequest) ([]Lease
 	return b.listServersFromClient(ctx, client, req.All)
 }
 
-func (b *runpodLeaseBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *runpodLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	// Doctor performs a read-only auth verification that never creates a pod.
 	// Surface clearer messaging than the generic newRunpodClient error so the
 	// missing-key case is obvious without staring at a stack trace.
 	if strings.TrimSpace(b.cfg.Runpod.APIKey) == "" {
-		return DoctorResult{}, exit(2, "provider=%s requires RUNPOD_API_KEY (CRABBOX_RUNPOD_API_KEY also accepted)", providerName)
+		return core.DoctorResult{}, core.Exit(2, "provider=%s requires RUNPOD_API_KEY (CRABBOX_RUNPOD_API_KEY also accepted)", providerName)
 	}
 	client, err := b.api()
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
 	if _, err := client.Whoami(ctx); err != nil {
-		return DoctorResult{}, exit(1, "runpod auth check failed: %v", err)
+		return core.DoctorResult{}, core.Exit(1, "runpod auth check failed: %v", err)
 	}
 	pods, err := client.ListPods(ctx)
 	if err != nil {
-		return DoctorResult{}, exit(1, "runpod list pods failed: %v", err)
+		return core.DoctorResult{}, core.Exit(1, "runpod list pods failed: %v", err)
 	}
-	return inventoryDoctorResult(providerName, len(pods)), nil
+	return core.InventoryDoctorResult(providerName, len(pods)), nil
 }
 
-func (b *runpodLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *runpodLeaseBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	client, err := b.api()
 	if err != nil {
 		return err
@@ -269,34 +269,34 @@ func (b *runpodLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseR
 		return unclaimedRunpodError(identifier)
 	}
 	if leaseID := strings.TrimSpace(req.Lease.LeaseID); leaseID != "" && leaseID != claim.LeaseID {
-		return exit(2, "runpod release lease %s does not match bound claim %s", leaseID, claim.LeaseID)
+		return core.Exit(2, "runpod release lease %s does not match bound claim %s", leaseID, claim.LeaseID)
 	}
 	if podID := strings.TrimSpace(req.Lease.Server.CloudID); podID != "" && podID != claim.CloudID {
-		return exit(2, "runpod release pod %s does not match bound claim pod %s", podID, claim.CloudID)
+		return core.Exit(2, "runpod release pod %s does not match bound claim pod %s", podID, claim.CloudID)
 	}
-	err = removeLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+	err = core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
 		pod, err := b.resolveClaimedPod(ctx, client, claim, true)
 		if err != nil {
 			return err
 		}
 		if err := client.TerminatePod(ctx, pod.ID); err != nil {
-			return exit(1, "runpod terminate pod %s failed: %v", pod.ID, err)
+			return core.Exit(1, "runpod terminate pod %s failed: %v", pod.ID, err)
 		}
 		return nil
 	})
 	if err != nil {
 		return err
 	}
-	removeStoredTestboxKey(claim.LeaseID)
+	core.RemoveStoredTestboxKey(claim.LeaseID)
 	return nil
 }
 
-func (b *runpodLeaseBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {
+func (b *runpodLeaseBackend) Touch(_ context.Context, req core.TouchRequest) (core.Server, error) {
 	server := req.Lease.Server
 	if server.Labels == nil {
 		server.Labels = map[string]string{}
 	}
-	server.Labels = touchDirectLeaseLabels(server.Labels, b.configForRun(), req.State, time.Now().UTC())
+	server.Labels = core.TouchDirectLeaseLabels(server.Labels, b.configForRun(), req.State, time.Now().UTC())
 	return server, nil
 }
 
@@ -307,13 +307,13 @@ func (b *runpodLeaseBackend) api() (runpodAPI, error) {
 	return newRunpodClient(b.cfg, b.rt)
 }
 
-func (b *runpodLeaseBackend) configForRun() Config {
+func (b *runpodLeaseBackend) configForRun() core.Config {
 	cfg := b.cfg
 	applyRunpodDefaults(&cfg)
 	return cfg
 }
 
-func applyRunpodDefaults(cfg *Config) {
+func applyRunpodDefaults(cfg *core.Config) {
 	cfg.Provider = providerName
 	if cfg.TargetOS == "" {
 		cfg.TargetOS = targetLinux
@@ -388,36 +388,36 @@ func (b *runpodLeaseBackend) waitForPodSSH(ctx context.Context, client runpodAPI
 	}
 }
 
-func (b *runpodLeaseBackend) prepareLease(ctx context.Context, cfg Config, pod runpodPod, leaseID, slug string, keep, wait bool) (LeaseTarget, error) {
+func (b *runpodLeaseBackend) prepareLease(ctx context.Context, cfg core.Config, pod runpodPod, leaseID, slug string, keep, wait bool) (core.LeaseTarget, error) {
 	server := runpodServer(pod, leaseID, slug, cfg, keep)
 	target := runpodSSHTarget(cfg, pod)
 	if wait {
 		bootstrapTarget := target
 		bootstrapTarget.ReadyCheck = "true"
-		if err := waitForSSHReady(ctx, &bootstrapTarget, b.rt.Stderr, "runpod pod ssh", bootstrapWaitTimeout(cfg)); err != nil {
-			return LeaseTarget{}, err
+		if err := core.WaitForSSHReady(ctx, &bootstrapTarget, b.rt.Stderr, "runpod pod ssh", core.BootstrapWaitTimeout(cfg)); err != nil {
+			return core.LeaseTarget{}, err
 		}
 		target.Port = bootstrapTarget.Port
 		if err := b.bootstrapRunpodTools(ctx, target); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
-		if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "runpod pod ssh", bootstrapWaitTimeout(cfg)); err != nil {
-			return LeaseTarget{}, err
+		if err := core.WaitForSSHReady(ctx, &target, b.rt.Stderr, "runpod pod ssh", core.BootstrapWaitTimeout(cfg)); err != nil {
+			return core.LeaseTarget{}, err
 		}
 		server.Status = "ready"
 		if server.Labels != nil {
 			server.Labels["state"] = "ready"
 		}
 	}
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
-func (b *runpodLeaseBackend) bootstrapRunpodTools(ctx context.Context, target SSHTarget) error {
+func (b *runpodLeaseBackend) bootstrapRunpodTools(ctx context.Context, target core.SSHTarget) error {
 	if b.rt.Stderr != nil {
 		fmt.Fprintln(b.rt.Stderr, "bootstrapping runpod pod tools")
 	}
-	if err := runSSHQuiet(ctx, target, runpodBootstrapToolsCommand()); err != nil {
-		return exit(1, "runpod pod tool bootstrap failed: %v", err)
+	if err := core.RunSSHQuiet(ctx, target, runpodBootstrapToolsCommand()); err != nil {
+		return core.Exit(1, "runpod pod tool bootstrap failed: %v", err)
 	}
 	return nil
 }
@@ -441,15 +441,15 @@ func runpodBootstrapToolsCommand() string {
 	}, "\n")
 }
 
-func resolveRunpodClaim(identifier string) (LeaseClaim, bool, error) {
+func resolveRunpodClaim(identifier string) (core.LeaseClaim, bool, error) {
 	identifier = strings.TrimSpace(identifier)
 	if identifier == "" {
-		return LeaseClaim{}, false, exit(2, "provider=%s requires --id <pod-id-or-lease>", providerName)
+		return core.LeaseClaim{}, false, core.Exit(2, "provider=%s requires --id <pod-id-or-lease>", providerName)
 	}
-	if claim, ok, exact, err := resolveLeaseClaimForProviderWithExact(identifier, providerName); err != nil {
-		return LeaseClaim{}, false, err
+	if claim, ok, exact, err := core.ResolveLeaseClaimForProviderWithExact(identifier, providerName); err != nil {
+		return core.LeaseClaim{}, false, err
 	} else if exact && !ok {
-		return LeaseClaim{}, false, exit(2, "local claim %s belongs to provider=%s, not provider=%s", identifier, core.Blank(claim.Provider, "<unknown>"), providerName)
+		return core.LeaseClaim{}, false, core.Exit(2, "local claim %s belongs to provider=%s, not provider=%s", identifier, core.Blank(claim.Provider, "<unknown>"), providerName)
 	} else if exact {
 		return claim, true, nil
 	} else if ok {
@@ -457,46 +457,44 @@ func resolveRunpodClaim(identifier string) (LeaseClaim, bool, error) {
 		// different claim whose provider ID or pod name happens to collide.
 		return claim, true, nil
 	}
-	if claim, ok, err := resolveLeaseClaimForProviderCloudID(identifier, providerName); err != nil {
-		return LeaseClaim{}, false, err
+	if claim, ok, err := core.ResolveLeaseClaimForProviderCloudID(identifier, providerName); err != nil {
+		return core.LeaseClaim{}, false, err
 	} else if ok {
 		return claim, true, nil
 	}
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
-		return LeaseClaim{}, false, err
+		return core.LeaseClaim{}, false, err
 	}
-	var match LeaseClaim
+	var match core.LeaseClaim
 	for _, claim := range claims {
 		if claim.Provider != providerName || strings.TrimSpace(claim.Labels["name"]) != identifier {
 			continue
 		}
 		if match.LeaseID != "" {
-			return LeaseClaim{}, false, exit(2, "multiple provider=%s claims match pod name %s", providerName, identifier)
+			return core.LeaseClaim{}, false, core.Exit(2, "multiple provider=%s claims match pod name %s", providerName, identifier)
 		}
 		match = claim
 	}
 	if match.LeaseID != "" {
 		return match, true, nil
 	}
-	return resolveLeaseClaimForProvider(identifier, providerName)
+	return core.ResolveLeaseClaimForProvider(identifier, providerName)
 }
 
-func findRunpodClaimForPodName(pod runpodPod) (LeaseClaim, bool, error) {
-	claims, err := listLeaseClaims()
+func findRunpodClaimForPodName(pod runpodPod) (core.LeaseClaim, bool, error) {
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
-		return LeaseClaim{}, false, err
+		return core.LeaseClaim{}, false, err
 	}
 	_, podSlug := runpodLeaseIdentity(pod.Name)
-	var match LeaseClaim
+	var match core.LeaseClaim
 	for _, claim := range claims {
-		if claim.Provider != providerName ||
-			normalizeLeaseSlug(claim.Slug) != normalizeLeaseSlug(podSlug) ||
-			leaseProviderName(claim.LeaseID, claim.Slug) != pod.Name {
+		if claim.Provider != providerName || core.NormalizeLeaseSlug(claim.Slug) != core.NormalizeLeaseSlug(podSlug) || core.LeaseProviderName(claim.LeaseID, claim.Slug) != pod.Name {
 			continue
 		}
 		if match.LeaseID != "" {
-			return LeaseClaim{}, false, exit(2, "multiple provider=%s claims match pod name %s", providerName, pod.Name)
+			return core.LeaseClaim{}, false, core.Exit(2, "multiple provider=%s claims match pod name %s", providerName, pod.Name)
 		}
 		match = claim
 	}
@@ -504,7 +502,7 @@ func findRunpodClaimForPodName(pod runpodPod) (LeaseClaim, bool, error) {
 }
 
 func ensureRunpodAdoptionDoesNotRetargetClaim(leaseID string, pod runpodPod) error {
-	claim, ok, exact, err := resolveLeaseClaimForProviderWithExact(leaseID, providerName)
+	claim, ok, exact, err := core.ResolveLeaseClaimForProviderWithExact(leaseID, providerName)
 	if err != nil {
 		return err
 	}
@@ -512,25 +510,25 @@ func ensureRunpodAdoptionDoesNotRetargetClaim(leaseID string, pod runpodPod) err
 		return nil
 	}
 	if !ok {
-		return exit(2, "cannot adopt RunPod pod %s as lease %s because that local claim belongs to provider=%s", pod.ID, leaseID, core.Blank(claim.Provider, "<unknown>"))
+		return core.Exit(2, "cannot adopt RunPod pod %s as lease %s because that local claim belongs to provider=%s", pod.ID, leaseID, core.Blank(claim.Provider, "<unknown>"))
 	}
 	if !runpodClaimIsBound(claim) {
 		return nil
 	}
 	if claim.CloudID != pod.ID || strings.TrimSpace(claim.Labels["name"]) != pod.Name {
-		return exit(2, "cannot retarget RunPod claim %s from pod %s (%s) to pod %s (%s)", claim.LeaseID, claim.CloudID, claim.Labels["name"], pod.ID, pod.Name)
+		return core.Exit(2, "cannot retarget RunPod claim %s from pod %s (%s) to pod %s (%s)", claim.LeaseID, claim.CloudID, claim.Labels["name"], pod.ID, pod.Name)
 	}
 	return nil
 }
 
-func runpodClaimIsBound(claim LeaseClaim) bool {
+func runpodClaimIsBound(claim core.LeaseClaim) bool {
 	return claim.Provider == providerName &&
 		strings.TrimSpace(claim.LeaseID) != "" &&
 		strings.TrimSpace(claim.CloudID) != "" &&
 		strings.TrimSpace(claim.Labels["name"]) != ""
 }
 
-func (b *runpodLeaseBackend) resolveClaimedPod(ctx context.Context, client runpodAPI, claim LeaseClaim, requireBound bool) (runpodPod, error) {
+func (b *runpodLeaseBackend) resolveClaimedPod(ctx context.Context, client runpodAPI, claim core.LeaseClaim, requireBound bool) (runpodPod, error) {
 	bound := runpodClaimIsBound(claim)
 	if requireBound && !bound {
 		return runpodPod{}, unclaimedRunpodError(claim.LeaseID)
@@ -542,8 +540,8 @@ func (b *runpodLeaseBackend) resolveClaimedPod(ctx context.Context, client runpo
 	if strings.TrimSpace(claim.CloudID) != "" {
 		pod, err = client.GetPod(ctx, claim.CloudID)
 	} else {
-		slug := core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID))
-		pod, err = b.findPodByName(ctx, client, leaseProviderName(claim.LeaseID, slug))
+		slug := core.Blank(claim.Slug, core.NewLeaseSlug(claim.LeaseID))
+		pod, err = b.findPodByName(ctx, client, core.LeaseProviderName(claim.LeaseID, slug))
 	}
 	if err != nil {
 		return runpodPod{}, err
@@ -552,10 +550,10 @@ func (b *runpodLeaseBackend) resolveClaimedPod(ctx context.Context, client runpo
 		return pod, nil
 	}
 	if pod.ID != claim.CloudID {
-		return runpodPod{}, exit(2, "runpod claim %s expects pod %s but provider returned %s", claim.LeaseID, claim.CloudID, core.Blank(pod.ID, "<empty>"))
+		return runpodPod{}, core.Exit(2, "runpod claim %s expects pod %s but provider returned %s", claim.LeaseID, claim.CloudID, core.Blank(pod.ID, "<empty>"))
 	}
 	if name := strings.TrimSpace(claim.Labels["name"]); pod.Name != name {
-		return runpodPod{}, exit(2, "runpod claim %s expects pod name %s but provider returned %s", claim.LeaseID, name, core.Blank(pod.Name, "<empty>"))
+		return runpodPod{}, core.Exit(2, "runpod claim %s expects pod name %s but provider returned %s", claim.LeaseID, name, core.Blank(pod.Name, "<empty>"))
 	}
 	return pod, nil
 }
@@ -563,7 +561,7 @@ func (b *runpodLeaseBackend) resolveClaimedPod(ctx context.Context, client runpo
 func (b *runpodLeaseBackend) resolveUnclaimedPod(ctx context.Context, client runpodAPI, identifier string) (runpodPod, string, string, error) {
 	identifier = strings.TrimSpace(identifier)
 	if identifier == "" {
-		return runpodPod{}, "", "", exit(2, "provider=%s requires --id <pod-id-or-lease>", providerName)
+		return runpodPod{}, "", "", core.Exit(2, "provider=%s requires --id <pod-id-or-lease>", providerName)
 	}
 	if strings.HasPrefix(identifier, "cbx_") {
 		pod, ok, err := b.findPodByLeaseName(ctx, client, identifier)
@@ -574,8 +572,8 @@ func (b *runpodLeaseBackend) resolveUnclaimedPod(ctx context.Context, client run
 			leaseID, slug := runpodLeaseIdentity(pod.Name)
 			return pod, leaseID, slug, nil
 		}
-		slug := newLeaseSlug(identifier)
-		pod, err = b.findPodByName(ctx, client, leaseProviderName(identifier, slug))
+		slug := core.NewLeaseSlug(identifier)
+		pod, err = b.findPodByName(ctx, client, core.LeaseProviderName(identifier, slug))
 		return pod, identifier, slug, err
 	}
 	// Identifier is treated as a raw RunPod pod ID first, then as a pod name
@@ -594,7 +592,7 @@ func (b *runpodLeaseBackend) resolveUnclaimedPod(ctx context.Context, client run
 }
 
 func unclaimedRunpodError(identifier string) error {
-	return exit(2, "runpod pod %s has no exact resource-bound local claim; adopt it from a reuse command with --reclaim before stopping it", core.Blank(strings.TrimSpace(identifier), "<unknown>"))
+	return core.Exit(2, "runpod pod %s has no exact resource-bound local claim; adopt it from a reuse command with --reclaim before stopping it", core.Blank(strings.TrimSpace(identifier), "<unknown>"))
 }
 
 func validateCreatedRunpodPod(pod runpodPod, expectedID, expectedName string) error {
@@ -604,9 +602,9 @@ func validateCreatedRunpodPod(pod runpodPod, expectedID, expectedName string) er
 		return nil
 	}
 	if mismatch.Field == "ID" {
-		return exit(1, "runpod create returned pod %s but readiness resolved %s", core.Blank(expectedID, "<empty>"), core.Blank(pod.ID, "<empty>"))
+		return core.Exit(1, "runpod create returned pod %s but readiness resolved %s", core.Blank(expectedID, "<empty>"), core.Blank(pod.ID, "<empty>"))
 	}
-	return exit(1, "runpod create expected pod name %s but readiness returned %s", core.Blank(expectedName, "<empty>"), core.Blank(pod.Name, "<empty>"))
+	return core.Exit(1, "runpod create expected pod name %s but readiness returned %s", core.Blank(expectedName, "<empty>"), core.Blank(pod.Name, "<empty>"))
 }
 
 func (b *runpodLeaseBackend) findPodByName(ctx context.Context, client runpodAPI, name string) (runpodPod, error) {
@@ -624,12 +622,12 @@ func (b *runpodLeaseBackend) findPodByName(ctx context.Context, client runpodAPI
 		return exact[0], nil
 	}
 	if len(exact) > 1 {
-		return runpodPod{}, exit(2, "multiple RunPod pods match exact identifier %s", name)
+		return runpodPod{}, core.Exit(2, "multiple RunPod pods match exact identifier %s", name)
 	}
-	normalized := normalizeLeaseSlug(name)
+	normalized := core.NormalizeLeaseSlug(name)
 	matches := make([]runpodPod, 0, 1)
 	for _, pod := range pods {
-		if normalizeLeaseSlug(pod.Name) == normalized {
+		if core.NormalizeLeaseSlug(pod.Name) == normalized {
 			matches = append(matches, pod)
 		}
 	}
@@ -637,9 +635,9 @@ func (b *runpodLeaseBackend) findPodByName(ctx context.Context, client runpodAPI
 		return matches[0], nil
 	}
 	if len(matches) > 1 {
-		return runpodPod{}, exit(2, "multiple RunPod pods match normalized name %s", name)
+		return runpodPod{}, core.Exit(2, "multiple RunPod pods match normalized name %s", name)
 	}
-	return runpodPod{}, exit(4, "runpod pod not found: %s", name)
+	return runpodPod{}, core.Exit(4, "runpod pod not found: %s", name)
 }
 
 func (b *runpodLeaseBackend) findPodByLeaseName(ctx context.Context, client runpodAPI, leaseID string) (runpodPod, bool, error) {
@@ -657,18 +655,18 @@ func (b *runpodLeaseBackend) findPodByLeaseName(ctx context.Context, client runp
 		return matches[0], true, nil
 	}
 	if len(matches) > 1 {
-		return runpodPod{}, false, exit(2, "multiple RunPod pods match lease %s", leaseID)
+		return runpodPod{}, false, core.Exit(2, "multiple RunPod pods match lease %s", leaseID)
 	}
 	return runpodPod{}, false, nil
 }
 
-func (b *runpodLeaseBackend) listServersFromClient(ctx context.Context, client runpodAPI, all bool) ([]LeaseView, error) {
+func (b *runpodLeaseBackend) listServersFromClient(ctx context.Context, client runpodAPI, all bool) ([]core.LeaseView, error) {
 	pods, err := client.ListPods(ctx)
 	if err != nil {
 		return nil, err
 	}
 	cfg := b.configForRun()
-	servers := make([]Server, 0, len(pods))
+	servers := make([]core.Server, 0, len(pods))
 	for _, pod := range pods {
 		if !all && !strings.HasPrefix(pod.Name, "crabbox-") {
 			continue
@@ -679,8 +677,8 @@ func (b *runpodLeaseBackend) listServersFromClient(ctx context.Context, client r
 	return servers, nil
 }
 
-func runpodServer(pod runpodPod, leaseID, slug string, cfg Config, keep bool) Server {
-	labels := directLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
+func runpodServer(pod runpodPod, leaseID, slug string, cfg core.Config, keep bool) core.Server {
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
 	labels["name"] = pod.Name
 	state := pod.DesiredStatus
 	if state == "" {
@@ -708,7 +706,7 @@ func runpodServer(pod runpodPod, leaseID, slug string, cfg Config, keep bool) Se
 	if endpoint.Kind != "" {
 		labels["ssh_kind"] = endpoint.Kind
 	}
-	server := Server{
+	server := core.Server{
 		CloudID:  pod.ID,
 		Provider: providerName,
 		Name:     pod.Name,
@@ -722,9 +720,9 @@ func runpodServer(pod runpodPod, leaseID, slug string, cfg Config, keep bool) Se
 	return server
 }
 
-func runpodSSHTarget(cfg Config, pod runpodPod) SSHTarget {
+func runpodSSHTarget(cfg core.Config, pod runpodPod) core.SSHTarget {
 	endpoint := pod.SSHEndpoint()
-	target := sshTargetFromConfig(cfg, endpoint.Host)
+	target := core.SSHTargetFromConfig(cfg, endpoint.Host)
 	if endpoint.Port != 0 {
 		target.Port = strconv.Itoa(endpoint.Port)
 	}
@@ -744,21 +742,21 @@ func runpodLeaseIdentity(name string) (string, string) {
 	name = strings.TrimSpace(name)
 	const prefix = "crabbox-"
 	if !strings.HasPrefix(name, prefix) {
-		slug := normalizeLeaseSlug(core.Blank(name, "manual"))
+		slug := core.NormalizeLeaseSlug(core.Blank(name, "manual"))
 		return "rpod_" + slug, slug
 	}
 	rest := strings.TrimPrefix(name, prefix)
 	idx := strings.LastIndex(rest, "-")
 	if idx <= 0 || idx == len(rest)-1 {
-		slug := normalizeLeaseSlug(rest)
+		slug := core.NormalizeLeaseSlug(rest)
 		return "rpod_" + slug, slug
 	}
 	hash := rest[idx+1:]
 	if len(hash) != 8 || !isLowerHex(hash) {
-		slug := normalizeLeaseSlug(rest)
+		slug := core.NormalizeLeaseSlug(rest)
 		return "rpod_" + slug, slug
 	}
-	slug := normalizeLeaseSlug(rest[:idx])
+	slug := core.NormalizeLeaseSlug(rest[:idx])
 	return "rpod_" + hash, slug
 }
 

--- a/internal/providers/runpod/backend_test.go
+++ b/internal/providers/runpod/backend_test.go
@@ -41,7 +41,7 @@ func TestRunpodClientRedactsReflectedCredential(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := newRunpodClient(Config{Runpod: RunpodConfig{APIKey: secret, APIURL: server.URL}}, Runtime{HTTP: server.Client()})
+	client, err := newRunpodClient(core.Config{Runpod: core.RunpodConfig{APIKey: secret, APIURL: server.URL}}, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,33 +83,33 @@ func TestRunpodIsRunpodProviderNameAcceptsAliases(t *testing.T) {
 }
 
 func TestRunpodClientRequiresAPIKey(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Runpod.APIURL = "https://rest.runpod.io/v1"
-	if _, err := newRunpodClient(cfg, Runtime{}); err == nil {
+	if _, err := newRunpodClient(cfg, core.Runtime{}); err == nil {
 		t.Fatal("newRunpodClient accepted empty API key")
 	}
 }
 
 func TestRunpodClientRejectsBareHTTPURL(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Runpod.APIKey = "test-key"
 	cfg.Runpod.APIURL = "http://rest.runpod.io/v1"
-	if _, err := newRunpodClient(cfg, Runtime{}); err == nil {
+	if _, err := newRunpodClient(cfg, core.Runtime{}); err == nil {
 		t.Fatal("newRunpodClient accepted plaintext http URL")
 	}
 }
 
 func TestRunpodClientAllowsLoopbackHTTPURL(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Runpod.APIKey = "test-key"
 	cfg.Runpod.APIURL = "http://127.0.0.1:8080/v1"
-	if _, err := newRunpodClient(cfg, Runtime{}); err != nil {
+	if _, err := newRunpodClient(cfg, core.Runtime{}); err != nil {
 		t.Fatalf("loopback http rejected: %v", err)
 	}
 }
 
 func TestRunpodTokenFlagIsNotRegistered(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Runpod.APIKey = "secret-key"
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	RegisterRunpodProviderFlags(fs, cfg)
@@ -134,11 +134,11 @@ func TestRunpodFlagsRejectGenericClassAndType(t *testing.T) {
 		fs.SetOutput(io.Discard)
 		fs.String("class", "", "")
 		fs.String("type", "", "")
-		values := RegisterRunpodProviderFlags(fs, Config{})
+		values := RegisterRunpodProviderFlags(fs, core.Config{})
 		if err := fs.Parse(args); err != nil {
 			t.Fatal(err)
 		}
-		cfg := Config{Provider: providerName}
+		cfg := core.Config{Provider: providerName}
 		err := ApplyRunpodProviderFlags(&cfg, fs, values)
 		if err == nil || !strings.Contains(err.Error(), "not supported for provider=runpod") {
 			t.Fatalf("args=%v err=%v", args, err)
@@ -147,13 +147,13 @@ func TestRunpodFlagsRejectGenericClassAndType(t *testing.T) {
 }
 
 func TestRunpodConfigureRejectsUnsupportedTargetAndTailscale(t *testing.T) {
-	for name, cfg := range map[string]Config{
+	for name, cfg := range map[string]core.Config{
 		"macos target": {TargetOS: "macos"},
-		"tailscale":    {TargetOS: targetLinux, Tailscale: TailscaleConfig{Enabled: true}},
+		"tailscale":    {TargetOS: targetLinux, Tailscale: core.TailscaleConfig{Enabled: true}},
 		"network":      {TargetOS: targetLinux, Network: "tailscale"},
 	} {
 		t.Run(name, func(t *testing.T) {
-			_, err := Provider{}.Configure(cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard})
+			_, err := Provider{}.Configure(cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard})
 			if err == nil {
 				t.Fatal("expected error")
 			}
@@ -162,7 +162,7 @@ func TestRunpodConfigureRejectsUnsupportedTargetAndTailscale(t *testing.T) {
 }
 
 func TestRunpodDefaultsPickPublicSSHGPUAndPreserveCustomWorkRoot(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	applyRunpodDefaults(&cfg)
 	if cfg.Runpod.APIURL != "https://rest.runpod.io/v1" {
 		t.Fatalf("default apiUrl = %q, want REST API", cfg.Runpod.APIURL)
@@ -177,13 +177,13 @@ func TestRunpodDefaultsPickPublicSSHGPUAndPreserveCustomWorkRoot(t *testing.T) {
 		t.Fatalf("default diskGB = %d, want 20", cfg.Runpod.DiskGB)
 	}
 
-	cfg = Config{WorkRoot: "/custom/crabbox"}
+	cfg = core.Config{WorkRoot: "/custom/crabbox"}
 	applyRunpodDefaults(&cfg)
 	if cfg.WorkRoot != "/custom/crabbox" || cfg.Runpod.WorkRoot != "/custom/crabbox" {
 		t.Fatalf("workRoot=%q runpod.workRoot=%q", cfg.WorkRoot, cfg.Runpod.WorkRoot)
 	}
 
-	cfg = Config{WorkRoot: "/custom/crabbox", Runpod: RunpodConfig{WorkRoot: "/runpod/crabbox"}}
+	cfg = core.Config{WorkRoot: "/custom/crabbox", Runpod: core.RunpodConfig{WorkRoot: "/runpod/crabbox"}}
 	applyRunpodDefaults(&cfg)
 	if cfg.WorkRoot != "/runpod/crabbox" || cfg.Runpod.WorkRoot != "/runpod/crabbox" {
 		t.Fatalf("workRoot=%q runpod.workRoot=%q", cfg.WorkRoot, cfg.Runpod.WorkRoot)
@@ -263,7 +263,7 @@ func TestRunpodDeployPayloadSerializesSSHPublicKey(t *testing.T) {
 }
 
 func TestRunpodSSHTargetUsesPublicPortAndUser(t *testing.T) {
-	cfg := Config{Runpod: RunpodConfig{User: "root", WorkRoot: "/tmp/crabbox"}}
+	cfg := core.Config{Runpod: core.RunpodConfig{User: "root", WorkRoot: "/tmp/crabbox"}}
 	applyRunpodDefaults(&cfg)
 	pod := runpodPod{Name: "crabbox-blue-12345678", ID: "pod_abc", Runtime: &runpodRuntime{Ports: []runpodRuntimePort{
 		{IP: "203.0.113.7", PrivatePort: 22, PublicPort: 41010, IsIPPublic: true, Type: "tcp"},
@@ -282,19 +282,19 @@ func TestRunpodSSHTargetUsesPublicPortAndUser(t *testing.T) {
 
 func TestRunpodDefaultsUseRootInsteadOfLocalUser(t *testing.T) {
 	t.Setenv("USER", "alice")
-	cfg := Config{}
+	cfg := core.Config{}
 	applyRunpodDefaults(&cfg)
 	if cfg.SSHUser != "root" {
 		t.Fatalf("ssh user=%q, want root", cfg.SSHUser)
 	}
 
-	cfg = Config{Runpod: RunpodConfig{User: "ubuntu"}}
+	cfg = core.Config{Runpod: core.RunpodConfig{User: "ubuntu"}}
 	applyRunpodDefaults(&cfg)
 	if cfg.SSHUser != "ubuntu" {
 		t.Fatalf("explicit runpod user=%q, want ubuntu", cfg.SSHUser)
 	}
 
-	cfg = Config{SSHUser: "custom"}
+	cfg = core.Config{SSHUser: "custom"}
 	applyRunpodDefaults(&cfg)
 	if cfg.SSHUser != "custom" {
 		t.Fatalf("explicit generic user=%q, want custom", cfg.SSHUser)
@@ -330,14 +330,14 @@ func TestRunpodDoctorChecksAuthAndListPods(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Runpod.APIKey = "test-key"
 	cfg.Runpod.APIURL = server.URL
-	doctor, err := Provider{}.ConfigureDoctor(cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard, HTTP: server.Client()})
+	doctor, err := Provider{}.ConfigureDoctor(cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := doctor.Doctor(context.Background(), DoctorRequest{})
+	result, err := doctor.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatalf("doctor returned err: %v", err)
 	}
@@ -350,11 +350,11 @@ func TestRunpodDoctorChecksAuthAndListPods(t *testing.T) {
 }
 
 func TestRunpodDoctorReportsMissingAPIKey(t *testing.T) {
-	doctor, err := Provider{}.ConfigureDoctor(Config{}, Runtime{Stdout: io.Discard, Stderr: io.Discard})
+	doctor, err := Provider{}.ConfigureDoctor(core.Config{}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard})
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = doctor.Doctor(context.Background(), DoctorRequest{})
+	_, err = doctor.Doctor(context.Background(), core.DoctorRequest{})
 	if err == nil || !strings.Contains(err.Error(), "RUNPOD_API_KEY") {
 		t.Fatalf("err=%v, want clear missing-key message", err)
 	}
@@ -375,15 +375,15 @@ type fakeRunpodAPI struct {
 
 const testRunpodPublicKey = "ssh-ed25519 AAAATEST crabbox-runpod-test"
 
-func testRunpodConfig(t *testing.T) Config {
+func testRunpodConfig(t *testing.T) core.Config {
 	t.Helper()
 	keyPath := t.TempDir() + "/id_ed25519"
 	if err := os.WriteFile(keyPath+".pub", []byte(testRunpodPublicKey+"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	return Config{
+	return core.Config{
 		SSHKey: keyPath,
-		Runpod: RunpodConfig{
+		Runpod: core.RunpodConfig{
 			APIKey:     "test-key",
 			InstanceID: "NVIDIA L4",
 		},
@@ -439,11 +439,11 @@ func TestRunpodAcquireUsesConfiguredSSHPublicKey(t *testing.T) {
 	}
 	backend := &runpodLeaseBackend{
 		cfg:    testRunpodConfig(t),
-		rt:     Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		rt:     core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 		client: fake,
 	}
 
-	if _, err := backend.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: t.TempDir()}}); err == nil {
+	if _, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}}); err == nil {
 		t.Fatal("Acquire succeeded after the fake readiness failure")
 	}
 	if len(fake.deployCalls) != 1 || fake.deployCalls[0].PublicKey != testRunpodPublicKey {
@@ -454,19 +454,19 @@ func TestRunpodAcquireUsesConfiguredSSHPublicKey(t *testing.T) {
 func TestRunpodAcquireRejectsInvalidSSHPublicKeyBeforeDeploy(t *testing.T) {
 	tests := []struct {
 		name      string
-		configure func(*testing.T, *Config)
+		configure func(*testing.T, *core.Config)
 		wantError string
 	}{
 		{
 			name: "unconfigured key path",
-			configure: func(_ *testing.T, cfg *Config) {
+			configure: func(_ *testing.T, cfg *core.Config) {
 				cfg.SSHKey = ""
 			},
 			wantError: "ssh key path is not configured",
 		},
 		{
 			name: "missing public key",
-			configure: func(t *testing.T, cfg *Config) {
+			configure: func(t *testing.T, cfg *core.Config) {
 				t.Helper()
 				if err := os.Remove(cfg.SSHKey + ".pub"); err != nil {
 					t.Fatal(err)
@@ -476,7 +476,7 @@ func TestRunpodAcquireRejectsInvalidSSHPublicKeyBeforeDeploy(t *testing.T) {
 		},
 		{
 			name: "empty public key",
-			configure: func(t *testing.T, cfg *Config) {
+			configure: func(t *testing.T, cfg *core.Config) {
 				t.Helper()
 				if err := os.WriteFile(cfg.SSHKey+".pub", nil, 0o600); err != nil {
 					t.Fatal(err)
@@ -486,7 +486,7 @@ func TestRunpodAcquireRejectsInvalidSSHPublicKeyBeforeDeploy(t *testing.T) {
 		},
 		{
 			name: "private key material",
-			configure: func(t *testing.T, cfg *Config) {
+			configure: func(t *testing.T, cfg *core.Config) {
 				t.Helper()
 				privateKey := "-----BEGIN OPENSSH PRIVATE KEY-----\nnot-a-public-key\n-----END OPENSSH PRIVATE KEY-----\n"
 				if err := os.WriteFile(cfg.SSHKey+".pub", []byte(privateKey), 0o600); err != nil {
@@ -504,11 +504,11 @@ func TestRunpodAcquireRejectsInvalidSSHPublicKeyBeforeDeploy(t *testing.T) {
 			fake := &fakeRunpodAPI{}
 			backend := &runpodLeaseBackend{
 				cfg:    cfg,
-				rt:     Runtime{Stdout: io.Discard, Stderr: io.Discard},
+				rt:     core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 				client: fake,
 			}
 
-			_, err := backend.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: t.TempDir()}})
+			_, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}})
 			var exitErr core.ExitError
 			if err == nil || !core.AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), test.wantError) {
 				t.Fatalf("Acquire error=%v, want exit 2 containing %q", err, test.wantError)
@@ -525,15 +525,15 @@ func TestRunpodListFiltersCrabboxPodsByDefault(t *testing.T) {
 		{ID: "pod_a", Name: "crabbox-blue-12345678", DesiredStatus: "RUNNING"},
 		{ID: "pod_b", Name: "manual-pod", DesiredStatus: "RUNNING"},
 	}}
-	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
-	views, err := backend.List(context.Background(), ListRequest{})
+	backend := &runpodLeaseBackend{cfg: core.Config{Runpod: core.RunpodConfig{APIKey: "k"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+	views, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(views) != 1 || views[0].Name != "crabbox-blue-12345678" || views[0].Provider != providerName {
 		t.Fatalf("views=%#v", views)
 	}
-	views, err = backend.List(context.Background(), ListRequest{All: true})
+	views, err = backend.List(context.Background(), core.ListRequest{All: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -554,8 +554,8 @@ func TestRunpodWaitForPodSSHReturnsWhenPublicPortReady(t *testing.T) {
 		}}}, nil
 	}}
 	backend := &runpodLeaseBackend{
-		cfg:                 Config{Runpod: RunpodConfig{APIKey: "k"}},
-		rt:                  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		cfg:                 core.Config{Runpod: core.RunpodConfig{APIKey: "k"}},
+		rt:                  core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 		client:              fake,
 		pollInitialOverride: 10 * time.Millisecond,
 		pollTimeoutOverride: 2 * time.Second,
@@ -575,8 +575,8 @@ func TestRunpodWaitForSSHRejectsProxyOnlyPods(t *testing.T) {
 		return runpodPod{ID: id, Name: "crabbox-blue-12345678", DesiredStatus: "RUNNING", Machine: runpodMachine{PodHostID: "pod_abc-1234"}}, nil
 	}}
 	backend := &runpodLeaseBackend{
-		cfg:                 Config{Runpod: RunpodConfig{APIKey: "k"}},
-		rt:                  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		cfg:                 core.Config{Runpod: core.RunpodConfig{APIKey: "k"}},
+		rt:                  core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 		client:              fake,
 		pollInitialOverride: 10 * time.Millisecond,
 		pollTimeoutOverride: 2 * time.Second,
@@ -606,14 +606,14 @@ func TestRunpodAcquireRollbackUsesBoundedCleanup(t *testing.T) {
 	}
 	backend := &runpodLeaseBackend{
 		cfg:                    testRunpodConfig(t),
-		rt:                     Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		rt:                     core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 		client:                 fake,
 		pollInitialOverride:    time.Millisecond,
 		pollTimeoutOverride:    5 * time.Millisecond,
 		cleanupTimeoutOverride: 20 * time.Millisecond,
 	}
 
-	_, err := backend.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: t.TempDir()}})
+	_, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}})
 	if err == nil || !strings.Contains(err.Error(), "ssh endpoint not exposed") || !strings.Contains(err.Error(), "cleanup failed") || !errors.Is(err, terminateErr) {
 		t.Fatalf("err=%v, want original wait failure plus cleanup failure", err)
 	}
@@ -635,13 +635,13 @@ func TestRunpodAcquireRollbackCannotBlockForever(t *testing.T) {
 	}
 	backend := &runpodLeaseBackend{
 		cfg:                    testRunpodConfig(t),
-		rt:                     Runtime{Stdout: io.Discard, Stderr: io.Discard},
+		rt:                     core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 		client:                 fake,
 		pollInitialOverride:    time.Millisecond,
 		pollTimeoutOverride:    5 * time.Millisecond,
 		cleanupTimeoutOverride: 20 * time.Millisecond,
 	}
-	_, err := backend.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: t.TempDir()}})
+	_, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}})
 	if err == nil || !strings.Contains(err.Error(), "cleanup failed") || !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("err=%v, want bounded cleanup deadline error", err)
 	}
@@ -677,8 +677,8 @@ func TestRunpodAcquireRejectsMismatchedReadyPodAndRollsBack(t *testing.T) {
 					tt.mutate(&pod)
 					return pod, nil
 				}
-				backend := &runpodLeaseBackend{cfg: testRunpodConfig(t), rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
-				_, err := backend.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: keep})
+				backend := &runpodLeaseBackend{cfg: testRunpodConfig(t), rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+				_, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: keep})
 				if err == nil || !strings.Contains(err.Error(), tt.diagnostic) {
 					t.Fatalf("err=%v, want %s", err, tt.diagnostic)
 				}
@@ -697,9 +697,9 @@ func TestRunpodAcquireRejectsMismatchedReadyPodAndRollsBack(t *testing.T) {
 func TestRunpodResolveReleaseOnlyRejectsUnclaimedPodWithoutProviderLookup(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := &fakeRunpodAPI{}
-	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+	backend := &runpodLeaseBackend{cfg: core.Config{Runpod: core.RunpodConfig{APIKey: "k"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
 
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: "pod_manual", ReleaseOnly: true})
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "pod_manual", ReleaseOnly: true})
 	if err == nil || !strings.Contains(err.Error(), "no exact resource-bound local claim") {
 		t.Fatalf("err=%v, want unclaimed refusal", err)
 	}
@@ -725,9 +725,9 @@ func TestRunpodResolveReleaseOnlyPrefersLocalSlugOverProviderAlias(t *testing.T)
 			}
 			claimRunpodPod(t, "rpod_456789ab", "remote", tt.pod)
 			fake := &fakeRunpodAPI{getPod: func(string) (runpodPod, error) { return tt.pod, nil }}
-			backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+			backend := &runpodLeaseBackend{cfg: core.Config{Runpod: core.RunpodConfig{APIKey: "k"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
 
-			_, err := backend.Resolve(context.Background(), ResolveRequest{ID: tt.identifier, ReleaseOnly: true})
+			_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: tt.identifier, ReleaseOnly: true})
 			if err == nil || !strings.Contains(err.Error(), "no exact resource-bound local claim") {
 				t.Fatalf("err=%v, want local slug claim refusal", err)
 			}
@@ -742,10 +742,10 @@ func TestRunpodResolveRequiresExplicitReclaimBeforeBindingPod(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	pod := runpodPod{ID: "pod_manual", Name: "manual-pod", DesiredStatus: "RUNNING"}
 	fake := &fakeRunpodAPI{getPod: func(string) (runpodPod, error) { return pod, nil }}
-	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+	backend := &runpodLeaseBackend{cfg: core.Config{Runpod: core.RunpodConfig{APIKey: "k"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
 	repo := core.Repo{Root: t.TempDir()}
 
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: pod.ID, Repo: repo})
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: pod.ID, Repo: repo})
 	if err == nil || !strings.Contains(err.Error(), "retry with --reclaim") {
 		t.Fatalf("err=%v, want explicit reclaim requirement", err)
 	}
@@ -753,7 +753,7 @@ func TestRunpodResolveRequiresExplicitReclaimBeforeBindingPod(t *testing.T) {
 		t.Fatalf("claim before reclaim: exists=%v err=%v", exists, err)
 	}
 
-	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: pod.ID, Repo: repo, Reclaim: true})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: pod.ID, Repo: repo, Reclaim: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -772,9 +772,9 @@ func TestRunpodReclaimCannotRetargetBoundClaim(t *testing.T) {
 	claimRunpodPod(t, "rpod_manual-pod", "manual-pod", claimed)
 	replacement := runpodPod{ID: "pod_replacement", Name: claimed.Name, DesiredStatus: "RUNNING"}
 	fake := &fakeRunpodAPI{getPod: func(string) (runpodPod, error) { return replacement, nil }}
-	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+	backend := &runpodLeaseBackend{cfg: core.Config{Runpod: core.RunpodConfig{APIKey: "k"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
 
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: replacement.ID, Repo: core.Repo{Root: t.TempDir()}, Reclaim: true})
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: replacement.ID, Repo: core.Repo{Root: t.TempDir()}, Reclaim: true})
 	if err == nil || !strings.Contains(err.Error(), "cannot retarget RunPod claim") {
 		t.Fatalf("err=%v, want retarget refusal", err)
 	}
@@ -834,15 +834,15 @@ func TestRunpodLegacyClaimRequiresReclaimToBindExactPod(t *testing.T) {
 	if err := core.ClaimLeaseForRepoProvider(leaseID, slug, providerName, repo.Root, 0, false); err != nil {
 		t.Fatal(err)
 	}
-	pod := runpodPod{ID: "pod_legacy", Name: leaseProviderName(leaseID, slug), DesiredStatus: "RUNNING"}
+	pod := runpodPod{ID: "pod_legacy", Name: core.LeaseProviderName(leaseID, slug), DesiredStatus: "RUNNING"}
 	fake := &fakeRunpodAPI{listPods: []runpodPod{pod}}
-	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+	backend := &runpodLeaseBackend{cfg: core.Config{Runpod: core.RunpodConfig{APIKey: "k"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
 
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, Repo: repo})
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, Repo: repo})
 	if err == nil || !strings.Contains(err.Error(), "retry with --reclaim") {
 		t.Fatalf("err=%v, want legacy claim reclaim requirement", err)
 	}
-	if _, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, Repo: repo, Reclaim: true}); err != nil {
+	if _, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, Repo: repo, Reclaim: true}); err != nil {
 		t.Fatal(err)
 	}
 	claim, err := core.ReadLeaseClaim(leaseID)
@@ -862,11 +862,11 @@ func TestRunpodReclaimByPodIDUpgradesLegacySlugClaim(t *testing.T) {
 	if err := core.ClaimLeaseForRepoProvider(leaseID, slug, providerName, repo.Root, 0, false); err != nil {
 		t.Fatal(err)
 	}
-	pod := runpodPod{ID: "pod-legacy", Name: leaseProviderName(leaseID, slug), DesiredStatus: "RUNNING"}
+	pod := runpodPod{ID: "pod-legacy", Name: core.LeaseProviderName(leaseID, slug), DesiredStatus: "RUNNING"}
 	fake := &fakeRunpodAPI{getPod: func(string) (runpodPod, error) { return pod, nil }}
-	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+	backend := &runpodLeaseBackend{cfg: core.Config{Runpod: core.RunpodConfig{APIKey: "k"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
 
-	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: pod.ID, Repo: repo, Reclaim: true})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: pod.ID, Repo: repo, Reclaim: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -880,11 +880,11 @@ func TestRunpodReclaimByPodIDUpgradesLegacySlugClaim(t *testing.T) {
 	if len(claims) != 1 || claims[0].LeaseID != leaseID || claims[0].CloudID != pod.ID || claims[0].Labels["name"] != pod.Name {
 		t.Fatalf("claims=%#v, want one upgraded legacy claim", claims)
 	}
-	releaseLease, err := backend.Resolve(context.Background(), ResolveRequest{ID: slug, ReleaseOnly: true})
+	releaseLease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: slug, ReleaseOnly: true})
 	if err != nil {
 		t.Fatalf("resolve upgraded claim by slug: %v", err)
 	}
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: releaseLease}); err != nil {
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: releaseLease}); err != nil {
 		t.Fatalf("release upgraded claim by slug: %v", err)
 	}
 	if len(fake.terminated) != 1 || fake.terminated[0] != pod.ID {
@@ -897,8 +897,8 @@ func TestRunpodReleaseLeaseRechecksBoundClaimAndTerminatesPod(t *testing.T) {
 	pod := runpodPod{ID: "pod_z", Name: "crabbox-blue-abcdef12", DesiredStatus: "RUNNING"}
 	claimRunpodPod(t, "rpod_abcdef12", "blue", pod)
 	fake := &fakeRunpodAPI{getPod: func(string) (runpodPod, error) { return pod, nil }}
-	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
-	req := ReleaseLeaseRequest{Lease: LeaseTarget{Server: Server{CloudID: pod.ID}, LeaseID: "rpod_abcdef12"}}
+	backend := &runpodLeaseBackend{cfg: core.Config{Runpod: core.RunpodConfig{APIKey: "k"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+	req := core.ReleaseLeaseRequest{Lease: core.LeaseTarget{Server: core.Server{CloudID: pod.ID}, LeaseID: "rpod_abcdef12"}}
 	if err := backend.ReleaseLease(context.Background(), req); err != nil {
 		t.Fatal(err)
 	}
@@ -915,10 +915,10 @@ func TestRunpodReleaseLeaseRejectsResourceOutsideBoundClaim(t *testing.T) {
 	pod := runpodPod{ID: "pod_owned", Name: "crabbox-blue-abcdef12", DesiredStatus: "RUNNING"}
 	claimRunpodPod(t, "rpod_abcdef12", "blue", pod)
 	fake := &fakeRunpodAPI{getPod: func(string) (runpodPod, error) { return pod, nil }}
-	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+	backend := &runpodLeaseBackend{cfg: core.Config{Runpod: core.RunpodConfig{APIKey: "k"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
 
-	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
-		Server:  Server{CloudID: "pod_other"},
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
+		Server:  core.Server{CloudID: "pod_other"},
 		LeaseID: "rpod_abcdef12",
 	}})
 	if err == nil || !strings.Contains(err.Error(), "does not match bound claim pod") {
@@ -936,10 +936,10 @@ func TestRunpodReleaseLeaseRejectsProviderNameMismatch(t *testing.T) {
 	changed := claimed
 	changed.Name = "renamed-outside-crabbox"
 	fake := &fakeRunpodAPI{getPod: func(string) (runpodPod, error) { return changed, nil }}
-	backend := &runpodLeaseBackend{cfg: Config{Runpod: RunpodConfig{APIKey: "k"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
+	backend := &runpodLeaseBackend{cfg: core.Config{Runpod: core.RunpodConfig{APIKey: "k"}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: fake}
 
-	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
-		Server:  Server{CloudID: claimed.ID},
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
+		Server:  core.Server{CloudID: claimed.ID},
 		LeaseID: "rpod_abcdef12",
 	}})
 	if err == nil || !strings.Contains(err.Error(), "expects pod name") {
@@ -955,7 +955,7 @@ func TestRunpodReleaseLeaseRejectsProviderNameMismatch(t *testing.T) {
 
 func claimRunpodPod(t *testing.T, leaseID, slug string, pod runpodPod) {
 	t.Helper()
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	applyRunpodDefaults(&cfg)
 	server := runpodServer(pod, leaseID, slug, cfg, true)
 	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, runpodSSHTarget(cfg, pod), t.TempDir(), 0, false); err != nil {
@@ -978,10 +978,10 @@ func TestRunpodClientSendsBearerAndRESTRequest(t *testing.T) {
 		_, _ = io.WriteString(w, `[]`)
 	}))
 	defer server.Close()
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Runpod.APIKey = "test-key"
 	cfg.Runpod.APIURL = server.URL
-	client, err := newRunpodClient(cfg, Runtime{HTTP: server.Client()})
+	client, err := newRunpodClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1015,8 +1015,8 @@ func TestRunpodClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
 		http.Redirect(w, r, target.URL+"/stolen", http.StatusTemporaryRedirect)
 	}))
 	defer trusted.Close()
-	cfg := Config{Runpod: RunpodConfig{APIKey: "test-key", APIURL: trusted.URL}}
-	client, err := newRunpodClient(cfg, Runtime{HTTP: trusted.Client()})
+	cfg := core.Config{Runpod: core.RunpodConfig{APIKey: "test-key", APIURL: trusted.URL}}
+	client, err := newRunpodClient(cfg, core.Runtime{HTTP: trusted.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1051,8 +1051,8 @@ func TestRunpodClientFollowsSameOriginRedirect(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	cfg := Config{Runpod: RunpodConfig{APIKey: "test-key", APIURL: server.URL}}
-	client, err := newRunpodClient(cfg, Runtime{HTTP: server.Client()})
+	cfg := core.Config{Runpod: core.RunpodConfig{APIKey: "test-key", APIURL: server.URL}}
+	client, err := newRunpodClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1080,10 +1080,7 @@ func TestRunpodClientPreservesCallerRedirectPolicy(t *testing.T) {
 		callerChecks++
 		return callerErr
 	}
-	client, err := newRunpodClient(
-		Config{Runpod: RunpodConfig{APIKey: "test-key", APIURL: server.URL}},
-		Runtime{HTTP: httpClient},
-	)
+	client, err := newRunpodClient(core.Config{Runpod: core.RunpodConfig{APIKey: "test-key", APIURL: server.URL}}, core.Runtime{HTTP: httpClient})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1120,10 +1117,10 @@ func TestRunpodClientRetriesGPUCapacityFallbacks(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Runpod.APIKey = "test-key"
 	cfg.Runpod.APIURL = server.URL
-	client, err := newRunpodClient(cfg, Runtime{HTTP: server.Client()})
+	client, err := newRunpodClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1167,7 +1164,7 @@ func TestInheritedWorkRootCallerContract(t *testing.T) {
 		{"/provider/root", "/srv/custom", "/provider/root"},
 	} {
 		for _, explicit := range []bool{false, true} {
-			cfg := Config{Provider: "prior", WorkRoot: "/recorded/root", SSHUser: "fixture-user", SSHPort: "1234", SSHFallbackPorts: []string{"4567"}, ServerType: "prior-type", Network: "prior-network"}
+			cfg := core.Config{Provider: "prior", WorkRoot: "/recorded/root", SSHUser: "fixture-user", SSHPort: "1234", SSHFallbackPorts: []string{"4567"}, ServerType: "prior-type", Network: "prior-network"}
 			if explicit {
 				core.MarkWorkRootExplicit(&cfg)
 				cfg.TargetOS = "existing-target"
@@ -1289,7 +1286,7 @@ func TestRunpodBindingSizingPhase(t *testing.T) {
 
 func TestRunpodBindingDefaultsContract(t *testing.T) {
 	for _, n := range []int{-2, 0, 4, 37} {
-		cfg := Config{Runpod: RunpodConfig{DiskGB: n}}
+		cfg := core.Config{Runpod: core.RunpodConfig{DiskGB: n}}
 		applyRunpodDefaults(&cfg)
 		wantDisk := n
 		if n <= 0 {
@@ -1299,13 +1296,13 @@ func TestRunpodBindingDefaultsContract(t *testing.T) {
 			t.Fatalf("disk=%d defaults=%#v", n, cfg.Runpod)
 		}
 	}
-	cfg := Config{Runpod: RunpodConfig{APIURL: "  ", CloudType: "  ", InstanceID: "  ", Image: "  ", DiskGB: 37}}
+	cfg := core.Config{Runpod: core.RunpodConfig{APIURL: "  ", CloudType: "  ", InstanceID: "  ", Image: "  ", DiskGB: 37}}
 	applyRunpodDefaults(&cfg)
 	if cfg.Runpod.APIURL != "  " || cfg.Runpod.CloudType != "  " || cfg.Runpod.InstanceID != "  " || cfg.Runpod.Image != "  " || cfg.Runpod.DiskGB != 37 {
 		t.Fatal("raw whitespace defaults changed")
 	}
 	for _, tc := range []struct{ user, genericUser, root, genericRoot, wantUser, wantRoot string }{{"", "", "", "", "root", "/tmp/crabbox"}, {"", "crabbox", "", "/work/crabbox", "root", "/tmp/crabbox"}, {"", "alice", "", "/Users/ec2-user/crabbox", "alice", "/tmp/crabbox"}, {"", "  ", "", `C:\crabbox`, "  ", "/tmp/crabbox"}, {"provider-user", "alice", "", "/custom/root", "provider-user", "/custom/root"}, {"", "alice", "/provider/root", "/custom/root", "alice", "/provider/root"}, {"", "alice", "", " /work/crabbox ", "alice", " /work/crabbox "}} {
-		cfg := Config{SSHUser: tc.genericUser, WorkRoot: tc.genericRoot, Runpod: RunpodConfig{User: tc.user, WorkRoot: tc.root}}
+		cfg := core.Config{SSHUser: tc.genericUser, WorkRoot: tc.genericRoot, Runpod: core.RunpodConfig{User: tc.user, WorkRoot: tc.root}}
 		applyRunpodDefaults(&cfg)
 		if cfg.Runpod.User != tc.user || cfg.SSHUser != tc.wantUser || cfg.Runpod.WorkRoot != tc.wantRoot || cfg.WorkRoot != tc.wantRoot || cfg.SSHPort != "" || cfg.SSHFallbackPorts != nil {
 			t.Fatalf("roles user=%q root=%q got=%#v SSH=%q", tc.user, tc.root, cfg.Runpod, cfg.SSHUser)
@@ -1318,8 +1315,8 @@ func TestRunpodBindingEffectivePayloadContract(t *testing.T) {
 		url, cloud, template, wantCloud string
 		disk, wantDisk                  int
 	}{{"", "", "", "SECURE", -2, 20}, {"https://rest.runpod.io/v1/", "COMMUNITY", "fixture-template", "COMMUNITY", 37, 37}} {
-		cfg := Config{Runpod: RunpodConfig{APIKey: "inert-configured-key", APIURL: tc.url, CloudType: tc.cloud, TemplateID: tc.template, DiskGB: tc.disk}}
-		backend := NewRunpodLeaseBackend(Provider{}.Spec(), cfg, Runtime{}).(*runpodLeaseBackend)
+		cfg := core.Config{Runpod: core.RunpodConfig{APIKey: "inert-configured-key", APIURL: tc.url, CloudType: tc.cloud, TemplateID: tc.template, DiskGB: tc.disk}}
+		backend := NewRunpodLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{}).(*runpodLeaseBackend)
 		effective := backend.configForRun()
 		if effective.Runpod.APIURL == "" || effective.Runpod.CloudType != tc.wantCloud || effective.Runpod.DiskGB != tc.wantDisk {
 			t.Fatal("upstream effective inputs missing")

--- a/internal/providers/runpod/client.go
+++ b/internal/providers/runpod/client.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -116,18 +117,18 @@ type runpodDeployInput struct {
 	PublicKey         string
 }
 
-func newRunpodClient(cfg Config, rt Runtime) (runpodAPI, error) {
+func newRunpodClient(cfg core.Config, rt core.Runtime) (runpodAPI, error) {
 	apiKey := strings.TrimSpace(cfg.Runpod.APIKey)
 	if apiKey == "" {
-		return nil, exit(2, "provider=%s requires RUNPOD_API_KEY", providerName)
+		return nil, core.Exit(2, "provider=%s requires RUNPOD_API_KEY", providerName)
 	}
 	apiURL := strings.TrimRight(strings.TrimSpace(cfg.Runpod.APIURL), "/")
 	parsed, err := url.Parse(apiURL)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return nil, exit(2, "%s url %q is invalid", providerName, apiURL)
+		return nil, core.Exit(2, "%s url %q is invalid", providerName, apiURL)
 	}
 	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
-		return nil, exit(2, "%s url %q must use https unless it targets localhost", providerName, apiURL)
+		return nil, core.Exit(2, "%s url %q must use https unless it targets localhost", providerName, apiURL)
 	}
 	httpClient := rt.HTTP
 	if httpClient == nil {

--- a/internal/providers/runpod/core.go
+++ b/internal/providers/runpod/core.go
@@ -1,114 +1,11 @@
 package runpod
 
 import (
-	"context"
-	"io"
-	"time"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type RunpodConfig = core.RunpodConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-type TailscaleConfig = core.TailscaleConfig
-type LeaseClaim = core.LeaseClaim
 
 const (
 	providerName  = "runpod"
 	targetLinux   = core.TargetLinux
 	networkPublic = core.NetworkPublic
 )
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func publicKeyFor(privatePath string) (string, error) {
-	return core.PublicKeyFor(privatePath)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func leaseProviderName(leaseID, slug string) string {
-	return core.LeaseProviderName(leaseID, slug)
-}
-
-func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (string, error) {
-	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
-}
-
-func claimLeaseTargetForRepoConfig(leaseID, slug string, cfg Config, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, target, repoRoot, idleTimeout, reclaim)
-}
-
-func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaimForProvider(identifier, provider)
-}
-
-func resolveLeaseClaimForProviderWithExact(identifier, provider string) (core.LeaseClaim, bool, bool, error) {
-	return core.ResolveLeaseClaimForProviderWithExact(identifier, provider)
-}
-
-func resolveLeaseClaimForProviderCloudID(cloudID, provider string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaimForProviderCloudID(cloudID, provider)
-}
-
-func listLeaseClaims() ([]core.LeaseClaim, error) {
-	return core.ListLeaseClaims()
-}
-
-func removeLeaseClaimIfUnchangedAfter(leaseID string, expected core.LeaseClaim, action func() error) error {
-	return core.RemoveLeaseClaimIfUnchangedAfter(leaseID, expected, action)
-}
-
-func removeStoredTestboxKey(leaseID string) {
-	core.RemoveStoredTestboxKey(leaseID)
-}
-
-func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
-	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
-}
-
-func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, now time.Time) map[string]string {
-	return core.TouchDirectLeaseLabels(labels, cfg, state, now)
-}
-
-func sshTargetFromConfig(cfg Config, host string) SSHTarget {
-	return core.SSHTargetFromConfig(cfg, host)
-}
-
-func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
-	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
-}
-
-func runSSHQuiet(ctx context.Context, target SSHTarget, remote string) error {
-	return core.RunSSHQuiet(ctx, target, remote)
-}
-
-func bootstrapWaitTimeout(cfg Config) time.Duration {
-	return core.BootstrapWaitTimeout(cfg)
-}
-
-func inventoryDoctorResult(provider string, leases int) DoctorResult {
-	return core.InventoryDoctorResult(provider, leases)
-}

--- a/internal/providers/runpod/flags.go
+++ b/internal/providers/runpod/flags.go
@@ -11,11 +11,11 @@ import (
 // intentionally not surfaced as a flag because secrets must not be passed as
 // command-line arguments; it is sourced from RUNPOD_API_KEY /
 // CRABBOX_RUNPOD_API_KEY.
-func RegisterRunpodProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterRunpodProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterRunpodConfigFlags(fs, defaults.Runpod)
 }
 
-func ApplyRunpodProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyRunpodProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --runpod-instance-id", "use --runpod-image"); err != nil {
 			return err

--- a/internal/providers/runpod/provider.go
+++ b/internal/providers/runpod/provider.go
@@ -42,10 +42,10 @@ func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error
 
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
-		return nil, exit(2, "provider=%s managed provisioning supports target=linux only", providerName)
+		return nil, core.Exit(2, "provider=%s managed provisioning supports target=linux only", providerName)
 	}
 	if cfg.Tailscale.Enabled || string(cfg.Network) == "tailscale" {
-		return nil, exit(2, "--tailscale is not supported for provider=%s; runpod pods expose public SSH only", providerName)
+		return nil, core.Exit(2, "--tailscale is not supported for provider=%s; runpod pods expose public SSH only", providerName)
 	}
 	return NewRunpodLeaseBackend(p.Spec(), cfg, rt), nil
 }

--- a/internal/providers/sprites/backend.go
+++ b/internal/providers/sprites/backend.go
@@ -17,23 +17,23 @@ type spritesFlagValues struct {
 	WorkRoot *string
 }
 
-func RegisterSpritesProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterSpritesProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return spritesFlagValues{
 		APIURL:   fs.String("sprites-api-url", defaults.Sprites.APIURL, "Sprites API URL"),
 		WorkRoot: fs.String("sprites-work-root", defaults.Sprites.WorkRoot, "Sprites remote work root"),
 	}
 }
 
-func ApplySpritesProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplySpritesProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if cfg.Provider == spritesProvider {
 		if core.FlagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=sprites")
+			return core.Exit(2, "--class is not supported for provider=sprites")
 		}
 		if core.FlagWasSet(fs, "type") {
-			return exit(2, "--type is not supported for provider=sprites")
+			return core.Exit(2, "--type is not supported for provider=sprites")
 		}
 		if cfg.TargetOS != "" && cfg.TargetOS != targetLinux {
-			return exit(2, "provider=sprites supports target=linux only")
+			return core.Exit(2, "provider=sprites supports target=linux only")
 		}
 		if err := validateSpritesOptions(*cfg); err != nil {
 			return err
@@ -54,7 +54,7 @@ func ApplySpritesProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error 
 	return nil
 }
 
-func NewSpritesBackend(spec ProviderSpec, cfg Config, rt Runtime) (Backend, error) {
+func NewSpritesBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	if err := validateSpritesOptions(cfg); err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func NewSpritesBackend(spec ProviderSpec, cfg Config, rt Runtime) (Backend, erro
 		cfg.WorkRoot = cfg.Sprites.WorkRoot
 	}
 	if strings.TrimSpace(cfg.Sprites.Token) == "" {
-		return nil, exit(2, "provider=sprites requires SPRITES_TOKEN, SPRITE_TOKEN, SETUP_SPRITE_TOKEN, or CRABBOX_SPRITES_TOKEN")
+		return nil, core.Exit(2, "provider=sprites requires SPRITES_TOKEN, SPRITE_TOKEN, SETUP_SPRITE_TOKEN, or CRABBOX_SPRITES_TOKEN")
 	}
 	client, err := newSpritesClient(cfg, rt)
 	if err != nil {
@@ -77,9 +77,9 @@ func NewSpritesBackend(spec ProviderSpec, cfg Config, rt Runtime) (Backend, erro
 	return &spritesBackend{spec: spec, cfg: cfg, rt: rt, client: client}, nil
 }
 
-func validateSpritesOptions(cfg Config) error {
+func validateSpritesOptions(cfg core.Config) error {
 	if cfg.Tailscale.Enabled {
-		return exit(2, "--tailscale is not supported for provider=sprites; Sprites exposes SSH through sprite proxy")
+		return core.Exit(2, "--tailscale is not supported for provider=sprites; Sprites exposes SSH through sprite proxy")
 	}
 	if err := cleanSpritesWorkRoot(cfg.Sprites.WorkRoot); err != nil {
 		return err
@@ -88,38 +88,38 @@ func validateSpritesOptions(cfg Config) error {
 }
 
 type spritesBackend struct {
-	spec   ProviderSpec
-	cfg    Config
-	rt     Runtime
+	spec   core.ProviderSpec
+	cfg    core.Config
+	rt     core.Runtime
 	client spritesAPI
 }
 
-func (b *spritesBackend) Spec() ProviderSpec { return b.spec }
+func (b *spritesBackend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *spritesBackend) RebindResolvedLeaseTarget(target *LeaseTarget, leaseID string) error {
+func (b *spritesBackend) RebindResolvedLeaseTarget(target *core.LeaseTarget, leaseID string) error {
 	core.UseStoredTestboxKey(&target.SSH, leaseID)
 	return nil
 }
 
-func (b *spritesBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+func (b *spritesBackend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	if err := b.ensureCLI(ctx); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	leaseID := core.NewLeaseID()
-	slug, err := allocateClaimLeaseSlug(leaseID, req.RequestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, req.RequestedSlug)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	name := leaseProviderName(leaseID, slug)
-	keyPath, publicKey, err := ensureTestboxKey(leaseID)
+	name := core.LeaseProviderName(leaseID, slug)
+	keyPath, publicKey, err := core.EnsureTestboxKey(leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cfg := b.configForRun()
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=sprites lease=%s slug=%s sprite=%s keep=%v\n", leaseID, slug, name, req.Keep)
 	sprite, err := b.client.CreateSprite(ctx, name, spritesAPILabels(leaseID, slug))
 	if err != nil {
-		return LeaseTarget{}, spritesError("create sprite", err)
+		return core.LeaseTarget{}, spritesError("create sprite", err)
 	}
 	if sprite.Name == "" {
 		sprite.Name = name
@@ -139,133 +139,133 @@ func (b *spritesBackend) Acquire(ctx context.Context, req AcquireRequest) (Lease
 		} else if deleteSprite() != nil {
 			return
 		}
-		removeStoredTestboxKey(leaseID)
+		core.RemoveStoredTestboxKey(leaseID)
 	}
 	server := b.spriteToServer(sprite, req.Keep)
-	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, SSHTarget{}, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, core.SSHTarget{}, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
 		cleanupFailedAcquire()
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	claimed = true
 	lease, err := b.prepareLease(ctx, sprite, leaseID, slug, req.Keep, keyPath, publicKey)
 	if err != nil {
 		cleanupFailedAcquire()
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if err := core.UpdateLeaseClaimEndpoint(leaseID, lease.Server, lease.SSH); err != nil {
 		cleanupFailedAcquire()
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s sprite=%s state=ready\n", leaseID, sprite.Name)
 	return lease, nil
 }
 
-func (b *spritesBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *spritesBackend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	name, leaseID, slug, err := b.resolveSpriteName(ctx, req.ID, req.Reclaim)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.ReleaseOnly {
 		sprite := spritesInfo{Name: name, Labels: spritesAPILabels(leaseID, slug)}
-		return LeaseTarget{Server: b.spriteToServer(sprite, true), LeaseID: leaseID}, nil
+		return core.LeaseTarget{Server: b.spriteToServer(sprite, true), LeaseID: leaseID}, nil
 	}
 	sprite, err := b.client.GetSprite(ctx, name)
 	if err != nil {
-		return LeaseTarget{}, spritesError("get sprite", err)
+		return core.LeaseTarget{}, spritesError("get sprite", err)
 	}
 	if sprite.Name != name {
-		return LeaseTarget{}, exit(4, "sprite %q returned a different resource name %q", name, sprite.Name)
+		return core.LeaseTarget{}, core.Exit(4, "sprite %q returned a different resource name %q", name, sprite.Name)
 	}
-	claim, hasClaim, err := resolveLeaseClaim(leaseID)
+	claim, hasClaim, err := core.ResolveLeaseClaim(leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if hasClaim {
 		if err := b.validateResolvedClaim(claim, sprite, req); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	adopted := hasClaim && claim.Labels["sprites_ownership"] == "adopted" &&
 		claim.Labels["sprites_resource_id"] != "" && claim.Labels["sprites_resource_id"] == sprite.ID
 	if !spriteHasExactOwnership(sprite, leaseID, slug) {
 		if !req.Reclaim && !adopted {
-			return LeaseTarget{}, exit(4, "sprite %q has incomplete Crabbox ownership labels; use --reclaim to adopt it", sprite.Name)
+			return core.LeaseTarget{}, core.Exit(4, "sprite %q has incomplete Crabbox ownership labels; use --reclaim to adopt it", sprite.Name)
 		}
 		if strings.TrimSpace(sprite.ID) == "" {
-			return LeaseTarget{}, exit(4, "refusing to adopt sprite %q without an immutable provider resource identity", sprite.Name)
+			return core.LeaseTarget{}, core.Exit(4, "refusing to adopt sprite %q without an immutable provider resource identity", sprite.Name)
 		}
 		adopted = true
 	}
 	target, err := b.sshTarget(name, "")
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	core.UseStoredTestboxKey(&target, leaseID)
-	resolved := LeaseTarget{Server: b.spriteToServer(sprite, true), SSH: target, LeaseID: leaseID}
+	resolved := core.LeaseTarget{Server: b.spriteToServer(sprite, true), SSH: target, LeaseID: leaseID}
 	resolved.Server.Labels["lease"], resolved.Server.Labels["slug"] = leaseID, slug
 	if err := core.ValidateLeaseTargetProviderIdentity(resolved, req.ExpectedProviderIdentity); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.StatusOnly || req.NoLocalStateMutations {
 		return resolved, nil
 	}
 	if !hasClaim {
 		if !req.Reclaim {
-			return LeaseTarget{}, exit(4, "sprite %q has no local ownership claim; use --reclaim to adopt it", sprite.Name)
+			return core.LeaseTarget{}, core.Exit(4, "sprite %q has no local ownership claim; use --reclaim to adopt it", sprite.Name)
 		}
 		if strings.TrimSpace(sprite.ID) == "" {
-			return LeaseTarget{}, exit(4, "refusing to adopt sprite %q without an immutable provider resource identity", sprite.Name)
+			return core.LeaseTarget{}, core.Exit(4, "refusing to adopt sprite %q without an immutable provider resource identity", sprite.Name)
 		}
 		adopted = true
 	}
 	if err := b.ensureCLI(ctx); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	keyPath, publicKey, err := ensureTestboxKey(leaseID)
+	keyPath, publicKey, err := core.EnsureTestboxKey(leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	lease, err := b.prepareLease(ctx, sprite, leaseID, slug, true, keyPath, publicKey)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.Repo.Root != "" {
 		if adopted {
 			lease.Server.Labels["sprites_ownership"] = "adopted"
 		}
 		if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.configForRun(), lease.Server, lease.SSH, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	return lease, nil
 }
 
-func (b *spritesBackend) validateResolvedClaim(claim LeaseClaim, sprite spritesInfo, req ResolveRequest) error {
+func (b *spritesBackend) validateResolvedClaim(claim core.LeaseClaim, sprite spritesInfo, req core.ResolveRequest) error {
 	if err := shared.ValidateClaimBinding(claim, b.claimBinding(claim.LeaseID, claim.Slug, sprite.Name)); err != nil {
-		return exit(4, "sprite %q does not match its ownership claim: %v", sprite.Name, err)
+		return core.Exit(4, "sprite %q does not match its ownership claim: %v", sprite.Name, err)
 	}
 	if id := claim.Labels["sprites_resource_id"]; id != "" && id != sprite.ID {
-		return exit(4, "sprite %q immutable provider resource identity does not match its ownership claim", sprite.Name)
+		return core.Exit(4, "sprite %q immutable provider resource identity does not match its ownership claim", sprite.Name)
 	}
 	if org := claim.Labels["sprites_organization"]; org != "" && org != sprite.Organization {
-		return exit(4, "sprite %q organization does not match its ownership claim", sprite.Name)
+		return core.Exit(4, "sprite %q organization does not match its ownership claim", sprite.Name)
 	}
 	if liveLease := spritesLeaseID(sprite); liveLease != "" && liveLease != claim.LeaseID {
-		return exit(4, "sprite %q belongs to a different live lease %q", sprite.Name, liveLease)
+		return core.Exit(4, "sprite %q belongs to a different live lease %q", sprite.Name, liveLease)
 	}
 	if req.Repo.Root != "" && claim.RepoRoot != "" && req.Repo.Root != claim.RepoRoot && !req.Reclaim {
-		return exit(4, "lease %s is claimed by repo %s; use --reclaim to claim it for %s", claim.LeaseID, claim.RepoRoot, req.Repo.Root)
+		return core.Exit(4, "lease %s is claimed by repo %s; use --reclaim to claim it for %s", claim.LeaseID, claim.RepoRoot, req.Repo.Root)
 	}
 	return nil
 }
 
-func (b *spritesBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *spritesBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	sprites, err := b.client.ListSprites(ctx, "crabbox-")
 	if err != nil {
 		return nil, spritesError("list sprites", err)
 	}
-	out := make([]Server, 0, len(sprites))
+	out := make([]core.Server, 0, len(sprites))
 	for _, sprite := range sprites {
 		if !isCrabboxSprite(sprite) {
 			continue
@@ -275,15 +275,15 @@ func (b *spritesBackend) List(ctx context.Context, req ListRequest) ([]LeaseView
 	return out, nil
 }
 
-func (b *spritesBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
-	servers, err := b.List(ctx, ListRequest{})
+func (b *spritesBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
+	servers, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return inventoryDoctorResult(spritesProvider, len(servers)), nil
+	return core.InventoryDoctorResult(spritesProvider, len(servers)), nil
 }
 
-func (b *spritesBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *spritesBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	name := strings.TrimSpace(req.Lease.Server.Name)
 	if name == "" {
 		var err error
@@ -306,21 +306,21 @@ func (b *spritesBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseReque
 			return spritesError("get sprite", err)
 		}
 		if sprite.Name != name {
-			return exit(4, "refusing to delete sprite %q: live sprite identity is %q", name, sprite.Name)
+			return core.Exit(4, "refusing to delete sprite %q: live sprite identity is %q", name, sprite.Name)
 		}
 		if resourceID := claim.Labels["sprites_resource_id"]; resourceID != "" && sprite.ID != resourceID {
-			return exit(4, "refusing to delete sprite %q: immutable provider resource identity does not match its ownership claim", name)
+			return core.Exit(4, "refusing to delete sprite %q: immutable provider resource identity does not match its ownership claim", name)
 		}
 		liveLeaseID := spritesLeaseID(sprite)
 		if liveLeaseID != "" && liveLeaseID != req.Lease.LeaseID {
-			return exit(4, "refusing to delete sprite %q: live lease %q does not match %q", name, liveLeaseID, req.Lease.LeaseID)
+			return core.Exit(4, "refusing to delete sprite %q: live lease %q does not match %q", name, liveLeaseID, req.Lease.LeaseID)
 		}
 		if !spriteHasExactOwnership(sprite, req.Lease.LeaseID, claim.Slug) &&
 			(claim.Labels["sprites_ownership"] != "adopted" || claim.Labels["sprites_resource_id"] == "") {
-			return exit(4, "refusing to delete sprite %q without exact Crabbox ownership labels or an explicitly adopted immutable identity", name)
+			return core.Exit(4, "refusing to delete sprite %q without exact Crabbox ownership labels or an explicitly adopted immutable identity", name)
 		}
 		if organization := claim.Labels["sprites_organization"]; organization != "" && sprite.Organization != organization {
-			return exit(4, "refusing to delete sprite %q: organization does not match its ownership claim", name)
+			return core.Exit(4, "refusing to delete sprite %q: organization does not match its ownership claim", name)
 		}
 		if err := b.client.DeleteSprite(ctx, name); err != nil && !isSpritesNotFound(err) {
 			return spritesError("delete sprite", err)
@@ -329,7 +329,7 @@ func (b *spritesBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseReque
 	}); err != nil {
 		return err
 	}
-	removeStoredTestboxKey(req.Lease.LeaseID)
+	core.RemoveStoredTestboxKey(req.Lease.LeaseID)
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s sprite=%s\n", req.Lease.LeaseID, name)
 	return nil
 }
@@ -337,24 +337,24 @@ func (b *spritesBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseReque
 // A 404 alone cannot identify the account: another valid organization's token
 // can see the same name as missing. Confirm the original account and recheck
 // absence before removing only the exact fenced local claim and key.
-func (b *spritesBackend) confirmAbsentSprite(ctx context.Context, claim LeaseClaim, name string) error {
+func (b *spritesBackend) confirmAbsentSprite(ctx context.Context, claim core.LeaseClaim, name string) error {
 	organization := claim.Labels["sprites_organization"]
 	if organization == "" || claim.Labels["sprites_resource_id"] == "" {
-		return exit(4, "cannot confirm absent sprite %q without its original organization and immutable identity; preserving the local claim", name)
+		return core.Exit(4, "cannot confirm absent sprite %q without its original organization and immutable identity; preserving the local claim", name)
 	}
 	current, err := b.client.GetOrganization(ctx)
 	if err != nil {
 		return spritesError("confirm organization for absent sprite", err)
 	}
 	if current != organization {
-		return exit(4, "refusing local cleanup for sprite %q: organization does not match its ownership claim", name)
+		return core.Exit(4, "refusing local cleanup for sprite %q: organization does not match its ownership claim", name)
 	}
 	if _, err := b.client.GetSprite(ctx, name); isSpritesNotFound(err) {
 		return nil
 	} else if err != nil {
 		return spritesError("confirm absent sprite", err)
 	}
-	return exit(4, "sprite %q appeared during cleanup; preserving its local claim for revalidation", name)
+	return core.Exit(4, "sprite %q appeared during cleanup; preserving its local claim for revalidation", name)
 }
 
 func (b *spritesBackend) claimBinding(leaseID, slug, name string) shared.ClaimBinding {
@@ -385,16 +385,16 @@ func spriteHasExactOwnership(sprite spritesInfo, leaseID, slug string) bool {
 	return true
 }
 
-func (b *spritesBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {
+func (b *spritesBackend) Touch(_ context.Context, req core.TouchRequest) (core.Server, error) {
 	server := req.Lease.Server
 	if server.Labels == nil {
 		server.Labels = map[string]string{}
 	}
-	server.Labels = touchDirectLeaseLabels(server.Labels, b.cfg, req.State, time.Now().UTC())
+	server.Labels = core.TouchDirectLeaseLabels(server.Labels, b.cfg, req.State, time.Now().UTC())
 	return server, nil
 }
 
-func (b *spritesBackend) configForRun() Config {
+func (b *spritesBackend) configForRun() core.Config {
 	cfg := b.cfg
 	cfg.Provider = spritesProvider
 	cfg.TargetOS = targetLinux
@@ -408,17 +408,17 @@ func (b *spritesBackend) configForRun() Config {
 	return cfg
 }
 
-func (b *spritesBackend) prepareLease(ctx context.Context, sprite spritesInfo, leaseID, slug string, keep bool, keyPath, publicKey string) (LeaseTarget, error) {
+func (b *spritesBackend) prepareLease(ctx context.Context, sprite spritesInfo, leaseID, slug string, keep bool, keyPath, publicKey string) (core.LeaseTarget, error) {
 	cfg := b.configForRun()
 	if err := cleanSpritesWorkRoot(cfg.WorkRoot); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if err := b.bootstrapSSH(ctx, sprite.Name, publicKey); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	target, err := b.sshTarget(sprite.Name, keyPath)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	server := b.spriteToServer(sprite, keep)
 	server.Labels["lease"] = leaseID
@@ -427,10 +427,10 @@ func (b *spritesBackend) prepareLease(ctx context.Context, sprite spritesInfo, l
 	server.Labels["work_root"] = cfg.WorkRoot
 	server.Labels["state"] = "ready"
 	server.Status = "ready"
-	if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "sprites ssh", bootstrapWaitTimeout(cfg)); err != nil {
-		return LeaseTarget{}, err
+	if err := core.WaitForSSHReady(ctx, &target, b.rt.Stderr, "sprites ssh", core.BootstrapWaitTimeout(cfg)); err != nil {
+		return core.LeaseTarget{}, err
 	}
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
 func (b *spritesBackend) bootstrapSSH(ctx context.Context, spriteName, publicKey string) error {
@@ -449,7 +449,7 @@ func (b *spritesBackend) bootstrapSSH(ctx context.Context, spriteName, publicKey
 	}, "\n")
 	result, err := b.runSprite(ctx, []string{"exec", "-s", spriteName, "--env", "CRABBOX_SSH_PUBLIC_KEY=" + publicKey, "--", "/bin/bash", "-lc", script}, nil, b.rt.Stderr)
 	if err != nil {
-		return ExitError{Code: result.ExitCode, Message: fmt.Sprintf("sprites ssh bootstrap failed: %v", err)}
+		return core.ExitError{Code: result.ExitCode, Message: fmt.Sprintf("sprites ssh bootstrap failed: %v", err)}
 	}
 	return nil
 }
@@ -457,20 +457,20 @@ func (b *spritesBackend) bootstrapSSH(ctx context.Context, spriteName, publicKey
 func (b *spritesBackend) ensureCLI(ctx context.Context) error {
 	result, err := b.runSprite(ctx, []string{"--version"}, nil, nil)
 	if err != nil {
-		return ExitError{Code: result.ExitCode, Message: fmt.Sprintf("provider=sprites requires the sprite CLI on PATH: %v", err)}
+		return core.ExitError{Code: result.ExitCode, Message: fmt.Sprintf("provider=sprites requires the sprite CLI on PATH: %v", err)}
 	}
 	return nil
 }
 
 func (b *spritesBackend) resolveSpriteName(ctx context.Context, identifier string, reclaim bool) (string, string, string, error) {
 	if strings.TrimSpace(identifier) == "" {
-		return "", "", "", exit(2, "provider=sprites requires a Crabbox lease id, slug, or Sprite name")
+		return "", "", "", core.Exit(2, "provider=sprites requires a Crabbox lease id, slug, or Sprite name")
 	}
-	if claim, ok, err := resolveLeaseClaim(identifier); err != nil {
+	if claim, ok, err := core.ResolveLeaseClaim(identifier); err != nil {
 		return "", "", "", err
 	} else if ok {
 		if claim.Provider != "" && claim.Provider != spritesProvider {
-			return "", "", "", exit(4, "lease %q is claimed for provider=%s, not sprites", identifier, claim.Provider)
+			return "", "", "", core.Exit(4, "lease %q is claimed for provider=%s, not sprites", identifier, claim.Provider)
 		}
 		if name, ok := spriteNameFromClaim(claim); ok {
 			return name, claim.LeaseID, claim.Slug, nil
@@ -497,22 +497,22 @@ func (b *spritesBackend) resolveSpriteName(ctx context.Context, identifier strin
 	if sprite, err := b.client.GetSprite(ctx, spriteIdentifier); err == nil {
 		if !isCrabboxSprite(sprite) && !reclaim {
 			if isLegacyCrabboxSpriteName(sprite) {
-				return "", "", "", exit(4, "sprite %q uses a legacy Crabbox name but has no Crabbox labels; use --reclaim to adopt it", spriteIdentifier)
+				return "", "", "", core.Exit(4, "sprite %q uses a legacy Crabbox name but has no Crabbox labels; use --reclaim to adopt it", spriteIdentifier)
 			}
-			return "", "", "", exit(4, "sprite %q is not Crabbox-managed; use --reclaim to adopt it", spriteIdentifier)
+			return "", "", "", core.Exit(4, "sprite %q is not Crabbox-managed; use --reclaim to adopt it", spriteIdentifier)
 		}
 		leaseID := spritesLeaseID(sprite)
 		if leaseID == "" {
-			leaseID = "spr_" + normalizeLeaseSlug(sprite.Name)
+			leaseID = "spr_" + core.NormalizeLeaseSlug(sprite.Name)
 		}
 		return sprite.Name, leaseID, spritesSlug(leaseID, sprite), nil
 	} else if !isSpritesNotFound(err) {
 		return "", "", "", spritesError("get sprite", err)
 	}
-	return "", "", "", exit(4, "sprites lease or sprite %q was not found", identifier)
+	return "", "", "", core.Exit(4, "sprites lease or sprite %q was not found", identifier)
 }
 
-func spriteNameFromClaim(claim LeaseClaim) (string, bool) {
+func spriteNameFromClaim(claim core.LeaseClaim) (string, bool) {
 	if name := strings.TrimSpace(claim.CloudID); name != "" {
 		return name, true
 	}
@@ -520,7 +520,7 @@ func spriteNameFromClaim(claim LeaseClaim) (string, bool) {
 		return strings.TrimPrefix(claim.LeaseID, "spr_"), true
 	}
 	if strings.HasPrefix(claim.LeaseID, "cbx_") {
-		return leaseProviderName(claim.LeaseID, claim.Slug), true
+		return core.LeaseProviderName(claim.LeaseID, claim.Slug), true
 	}
 	return "", false
 }
@@ -535,14 +535,14 @@ func (b *spritesBackend) findSpriteByLease(ctx context.Context, leaseID string) 
 			return sprite, nil
 		}
 	}
-	return spritesInfo{}, exit(4, "sprites lease %q was not found", leaseID)
+	return spritesInfo{}, core.Exit(4, "sprites lease %q was not found", leaseID)
 }
 
-func (b *spritesBackend) spriteToServer(sprite spritesInfo, keep bool) Server {
+func (b *spritesBackend) spriteToServer(sprite spritesInfo, keep bool) core.Server {
 	leaseID := spritesLeaseID(sprite)
 	slug := spritesSlug(leaseID, sprite)
 	cfg := b.configForRun()
-	labels := directLeaseLabels(cfg, leaseID, slug, spritesProvider, "", keep, time.Now().UTC())
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, spritesProvider, "", keep, time.Now().UTC())
 	labels["name"] = sprite.Name
 	labels["state"] = spritesState(sprite.Status)
 	labels["work_root"] = cfg.WorkRoot
@@ -555,7 +555,7 @@ func (b *spritesBackend) spriteToServer(sprite spritesInfo, keep bool) Server {
 	if sprite.URL != "" {
 		labels["url"] = sprite.URL
 	}
-	server := Server{
+	server := core.Server{
 		CloudID:  sprite.Name,
 		Provider: spritesProvider,
 		Name:     sprite.Name,
@@ -567,8 +567,8 @@ func (b *spritesBackend) spriteToServer(sprite spritesInfo, keep bool) Server {
 	return server
 }
 
-func spritesSSHTarget(name, keyPath string) SSHTarget {
-	return SSHTarget{
+func spritesSSHTarget(name, keyPath string) core.SSHTarget {
+	return core.SSHTarget{
 		User:           "sprite",
 		Host:           name,
 		Key:            keyPath,
@@ -592,11 +592,11 @@ func spritesState(status string) string {
 func cleanSpritesWorkRoot(workRoot string) error {
 	clean := path.Clean(strings.TrimSpace(workRoot))
 	if clean == "" || !strings.HasPrefix(clean, "/") {
-		return exit(2, "sprites.workRoot %q must resolve to an absolute path", workRoot)
+		return core.Exit(2, "sprites.workRoot %q must resolve to an absolute path", workRoot)
 	}
 	switch clean {
 	case "/", "/bin", "/dev", "/etc", "/home", "/home/sprite", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var":
-		return exit(2, "sprites.workRoot %q is too broad; choose a dedicated subdirectory", clean)
+		return core.Exit(2, "sprites.workRoot %q is too broad; choose a dedicated subdirectory", clean)
 	}
 	return nil
 }

--- a/internal/providers/sprites/backend_test.go
+++ b/internal/providers/sprites/backend_test.go
@@ -100,7 +100,7 @@ func TestResolveSpriteNameAcceptsPrefixOnlyWithReclaim(t *testing.T) {
 
 func TestResolveSpriteNameUsesAdoptedSpriteNameFromClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	if err := claimLeaseForRepoProvider("spr_handmade-sprite", "adopted", spritesProvider, t.TempDir(), 0, true); err != nil {
+	if err := core.ClaimLeaseForRepoProvider("spr_handmade-sprite", "adopted", spritesProvider, t.TempDir(), 0, true); err != nil {
 		t.Fatal(err)
 	}
 	backend := &spritesBackend{client: &fakeSpritesAPI{}}
@@ -115,7 +115,7 @@ func TestResolveSpriteNameUsesAdoptedSpriteNameFromClaim(t *testing.T) {
 
 func TestResolveSpriteNameAcceptsProviderlessCrabboxClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	if err := claimLeaseForRepoProvider("cbx_abcdef123456", "blue-lobster", "", t.TempDir(), 0, true); err != nil {
+	if err := core.ClaimLeaseForRepoProvider("cbx_abcdef123456", "blue-lobster", "", t.TempDir(), 0, true); err != nil {
 		t.Fatal(err)
 	}
 	backend := &spritesBackend{client: &fakeSpritesAPI{}}
@@ -130,7 +130,7 @@ func TestResolveSpriteNameAcceptsProviderlessCrabboxClaim(t *testing.T) {
 
 func TestResolveSpriteNameRejectsOtherProviderClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	if err := claimLeaseForRepoProvider("cbx_abcdef123456", "blue-lobster", "aws", t.TempDir(), 0, true); err != nil {
+	if err := core.ClaimLeaseForRepoProvider("cbx_abcdef123456", "blue-lobster", "aws", t.TempDir(), 0, true); err != nil {
 		t.Fatal(err)
 	}
 	backend := &spritesBackend{client: &fakeSpritesAPI{}}
@@ -144,22 +144,22 @@ func TestResolveReleaseOnlySkipsSpriteCLIAndBootstrap(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateDir)
 	repoRoot := t.TempDir()
-	cfg := Config{Provider: spritesProvider, Sprites: SpritesConfig{WorkRoot: "/home/sprite/crabbox"}}
-	server := Server{Provider: spritesProvider, CloudID: "unhealthy-sprite", Name: "unhealthy-sprite", Labels: map[string]string{
+	cfg := core.Config{Provider: spritesProvider, Sprites: core.SpritesConfig{WorkRoot: "/home/sprite/crabbox"}}
+	server := core.Server{Provider: spritesProvider, CloudID: "unhealthy-sprite", Name: "unhealthy-sprite", Labels: map[string]string{
 		"provider": spritesProvider, "lease": "spr_unhealthy-sprite", "slug": "unhealthy", "name": "unhealthy-sprite",
 		"sprites_ownership": "adopted", "sprites_resource_id": "sprite-immutable-1",
 	}}
-	if err := core.ClaimLeaseTargetForRepoConfig("spr_unhealthy-sprite", "unhealthy", cfg, server, SSHTarget{}, repoRoot, 0, true); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig("spr_unhealthy-sprite", "unhealthy", cfg, server, core.SSHTarget{}, repoRoot, 0, true); err != nil {
 		t.Fatal(err)
 	}
 	api := &fakeSpritesAPI{get: spritesInfo{ID: "sprite-immutable-1", Name: "unhealthy-sprite"}}
 	runner := &recordingRunner{}
 	backend := &spritesBackend{
 		cfg:    cfg,
-		rt:     Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner},
+		rt:     core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner},
 		client: api,
 	}
-	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: "unhealthy", ReleaseOnly: true})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "unhealthy", ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,13 +169,13 @@ func TestResolveReleaseOnlySkipsSpriteCLIAndBootstrap(t *testing.T) {
 	if lease.LeaseID != "spr_unhealthy-sprite" || lease.Server.Name != "unhealthy-sprite" {
 		t.Fatalf("lease=%#v", lease)
 	}
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil {
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil {
 		t.Fatal(err)
 	}
 	if api.deleted != "unhealthy-sprite" {
 		t.Fatalf("deleted=%q", api.deleted)
 	}
-	if _, ok, err := resolveLeaseClaim("unhealthy"); err != nil || ok {
+	if _, ok, err := core.ResolveLeaseClaim("unhealthy"); err != nil || ok {
 		t.Fatalf("claim still resolves ok=%t err=%v", ok, err)
 	}
 }
@@ -184,10 +184,10 @@ func TestReleaseLeaseRejectsUnclaimedPrefixOnlySprite(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	api := &fakeSpritesAPI{get: spritesInfo{Name: "crabbox-handmade"}}
 	backend := &spritesBackend{client: api}
-	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{
-		Lease: LeaseTarget{
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{
+		Lease: core.LeaseTarget{
 			LeaseID: "spr_crabbox-handmade",
-			Server:  Server{Name: "crabbox-handmade"},
+			Server:  core.Server{Name: "crabbox-handmade"},
 		},
 		Force: true,
 	})
@@ -219,19 +219,19 @@ func TestSpritesReleaseRequiresExactScopedClaimAndLiveOwnership(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
-			cfg := Config{Provider: spritesProvider, Sprites: SpritesConfig{WorkRoot: "/home/sprite/crabbox"}}
+			cfg := core.Config{Provider: spritesProvider, Sprites: core.SpritesConfig{WorkRoot: "/home/sprite/crabbox"}}
 			claimCfg := cfg
 			claimCfg.Sprites.APIURL = tc.claimedAPIURL
-			claimedServer := Server{Provider: spritesProvider, CloudID: tc.claimedName, Name: tc.claimedName, Labels: map[string]string{
+			claimedServer := core.Server{Provider: spritesProvider, CloudID: tc.claimedName, Name: tc.claimedName, Labels: map[string]string{
 				"provider": spritesProvider, "lease": "cbx_abcdef123456", "slug": "owned", "name": tc.claimedName,
 			}}
-			if err := core.ClaimLeaseTargetForRepoConfig("cbx_abcdef123456", "owned", claimCfg, claimedServer, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+			if err := core.ClaimLeaseTargetForRepoConfig("cbx_abcdef123456", "owned", claimCfg, claimedServer, core.SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
 				t.Fatal(err)
 			}
 			api := &fakeSpritesAPI{get: tc.live, deleteErr: tc.deleteErr}
-			backend := &spritesBackend{cfg: cfg, client: api, rt: Runtime{Stderr: io.Discard}}
-			err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
-				LeaseID: "cbx_abcdef123456", Server: Server{Name: "sprite-owned", Labels: map[string]string{"slug": "owned"}},
+			backend := &spritesBackend{cfg: cfg, client: api, rt: core.Runtime{Stderr: io.Discard}}
+			err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
+				LeaseID: "cbx_abcdef123456", Server: core.Server{Name: "sprite-owned", Labels: map[string]string{"slug": "owned"}},
 			}})
 			if tc.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
@@ -265,7 +265,7 @@ func TestSpritesLegacyReleaseRequiresExplicitImmutableAdoption(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
-			cfg := Config{Provider: spritesProvider}
+			cfg := core.Config{Provider: spritesProvider}
 			labels := map[string]string{"provider": spritesProvider, "lease": "spr_legacy", "slug": "legacy", "name": "legacy"}
 			if tc.adopted {
 				labels["sprites_ownership"] = "adopted"
@@ -273,14 +273,14 @@ func TestSpritesLegacyReleaseRequiresExplicitImmutableAdoption(t *testing.T) {
 			if tc.claimID != "" {
 				labels["sprites_resource_id"] = tc.claimID
 			}
-			server := Server{Provider: spritesProvider, CloudID: "legacy", Name: "legacy", Labels: labels}
-			if err := core.ClaimLeaseTargetForRepoConfig("spr_legacy", "legacy", cfg, server, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+			server := core.Server{Provider: spritesProvider, CloudID: "legacy", Name: "legacy", Labels: labels}
+			if err := core.ClaimLeaseTargetForRepoConfig("spr_legacy", "legacy", cfg, server, core.SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
 				t.Fatal(err)
 			}
 			api := &fakeSpritesAPI{get: spritesInfo{ID: tc.liveID, Name: "legacy"}}
-			backend := &spritesBackend{cfg: cfg, client: api, rt: Runtime{Stderr: io.Discard}}
-			err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
-				LeaseID: "spr_legacy", Server: Server{Name: "legacy", Labels: map[string]string{"slug": "legacy"}},
+			backend := &spritesBackend{cfg: cfg, client: api, rt: core.Runtime{Stderr: io.Discard}}
+			err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
+				LeaseID: "spr_legacy", Server: core.Server{Name: "legacy", Labels: map[string]string{"slug": "legacy"}},
 			}})
 			if tc.wantDelete != (err == nil) || tc.wantDelete != (api.deleted == "legacy") {
 				t.Fatalf("err=%v deleted=%q wantDelete=%t", err, api.deleted, tc.wantDelete)
@@ -295,12 +295,12 @@ func TestAcquireKeepFailurePreservesRetainedSpriteKey(t *testing.T) {
 	api := &fakeSpritesAPI{}
 	runner := &recordingRunner{failContains: "exec -s", err: errors.New("bootstrap failed")}
 	backend := &spritesBackend{
-		cfg:    Config{Sprites: SpritesConfig{WorkRoot: "/home/sprite/crabbox"}},
-		rt:     Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner},
+		cfg:    core.Config{Sprites: core.SpritesConfig{WorkRoot: "/home/sprite/crabbox"}},
+		rt:     core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner},
 		client: api,
 	}
 
-	_, err := backend.Acquire(context.Background(), AcquireRequest{Keep: true, Repo: core.Repo{Root: t.TempDir()}})
+	_, err := backend.Acquire(context.Background(), core.AcquireRequest{Keep: true, Repo: core.Repo{Root: t.TempDir()}})
 	if err == nil || !strings.Contains(err.Error(), "bootstrap failed") {
 		t.Fatalf("Acquire err=%v, want bootstrap failure", err)
 	}
@@ -324,12 +324,12 @@ func TestAcquireFailureDeletesReturnedSpriteName(t *testing.T) {
 	api := &fakeSpritesAPI{create: spritesInfo{Name: "canonical-sprite"}}
 	runner := &recordingRunner{failContains: "exec -s", err: errors.New("bootstrap failed")}
 	backend := &spritesBackend{
-		cfg:    Config{Sprites: SpritesConfig{WorkRoot: "/home/sprite/crabbox"}},
-		rt:     Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner},
+		cfg:    core.Config{Sprites: core.SpritesConfig{WorkRoot: "/home/sprite/crabbox"}},
+		rt:     core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner},
 		client: api,
 	}
 
-	_, err := backend.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: t.TempDir()}})
+	_, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}})
 	if err == nil || !strings.Contains(err.Error(), "bootstrap failed") {
 		t.Fatalf("Acquire err=%v, want bootstrap failure", err)
 	}
@@ -342,29 +342,29 @@ func TestAcquireFailureDeletesReturnedSpriteName(t *testing.T) {
 }
 
 func TestSpritesRejectsTailscale(t *testing.T) {
-	cfg := Config{Sprites: SpritesConfig{Token: "test-token"}}
+	cfg := core.Config{Sprites: core.SpritesConfig{Token: "test-token"}}
 	cfg.Tailscale.Enabled = true
-	_, err := NewSpritesBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: &recordingRunner{}})
+	_, err := NewSpritesBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: &recordingRunner{}})
 	if err == nil || !strings.Contains(err.Error(), "--tailscale is not supported for provider=sprites") {
 		t.Fatalf("err=%v", err)
 	}
 }
 
 func TestSpritesRejectsUnsafeWorkRootBeforeBackend(t *testing.T) {
-	cfg := Config{Sprites: SpritesConfig{Token: "test-token", WorkRoot: "/tmp"}}
-	_, err := NewSpritesBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: &recordingRunner{}})
+	cfg := core.Config{Sprites: core.SpritesConfig{Token: "test-token", WorkRoot: "/tmp"}}
+	_, err := NewSpritesBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: &recordingRunner{}})
 	if err == nil || !strings.Contains(err.Error(), "too broad") {
 		t.Fatalf("err=%v", err)
 	}
 }
 
 func TestSpritesRejectsUnsafeAPIURLBeforeBackend(t *testing.T) {
-	cfg := Config{Sprites: SpritesConfig{
+	cfg := core.Config{Sprites: core.SpritesConfig{
 		Token:    "test-token",
 		APIURL:   "http://api.sprites.dev",
 		WorkRoot: "/home/sprite/crabbox",
 	}}
-	_, err := NewSpritesBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: &recordingRunner{}})
+	_, err := NewSpritesBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: &recordingRunner{}})
 	if err == nil || !strings.Contains(err.Error(), "must use HTTPS") {
 		t.Fatalf("err=%v", err)
 	}
@@ -419,7 +419,7 @@ func TestSpritesAPIURLValidation(t *testing.T) {
 }
 
 func TestSpritesClientDefaultsAPIURL(t *testing.T) {
-	client, err := newSpritesClient(Config{Sprites: SpritesConfig{Token: "test-token"}}, Runtime{})
+	client, err := newSpritesClient(core.Config{Sprites: core.SpritesConfig{Token: "test-token"}}, core.Runtime{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -439,10 +439,7 @@ func TestSpritesClientRejectsCrossOriginRedirect(t *testing.T) {
 	}))
 	defer origin.Close()
 
-	client, err := newSpritesClient(
-		Config{Sprites: SpritesConfig{Token: "test-token", APIURL: origin.URL}},
-		Runtime{HTTP: origin.Client()},
-	)
+	client, err := newSpritesClient(core.Config{Sprites: core.SpritesConfig{Token: "test-token", APIURL: origin.URL}}, core.Runtime{HTTP: origin.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -471,10 +468,7 @@ func TestSpritesClientPreservesAuthOnSameOriginRedirect(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client, err := newSpritesClient(
-		Config{Sprites: SpritesConfig{Token: "test-token", APIURL: srv.URL}},
-		Runtime{HTTP: srv.Client()},
-	)
+	client, err := newSpritesClient(core.Config{Sprites: core.SpritesConfig{Token: "test-token", APIURL: srv.URL}}, core.Runtime{HTTP: srv.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -499,10 +493,7 @@ func TestSpritesClientPreservesCustomRedirectPolicy(t *testing.T) {
 		return errors.New("custom redirect stop")
 	}
 
-	client, err := newSpritesClient(
-		Config{Sprites: SpritesConfig{Token: "test-token", APIURL: srv.URL}},
-		Runtime{HTTP: source},
-	)
+	client, err := newSpritesClient(core.Config{Sprites: core.SpritesConfig{Token: "test-token", APIURL: srv.URL}}, core.Runtime{HTTP: source})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -566,7 +557,7 @@ func TestSpritesClientLifecycleRequests(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client, err := newSpritesClient(Config{Sprites: SpritesConfig{Token: "test-token", APIURL: srv.URL}}, Runtime{HTTP: srv.Client()})
+	client, err := newSpritesClient(core.Config{Sprites: core.SpritesConfig{Token: "test-token", APIURL: srv.URL}}, core.Runtime{HTTP: srv.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -603,7 +594,7 @@ func TestSpritesClientRedactsErrorResponseCredentials(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client, err := newSpritesClient(Config{Sprites: SpritesConfig{Token: token, APIURL: srv.URL}}, Runtime{HTTP: srv.Client()})
+	client, err := newSpritesClient(core.Config{Sprites: core.SpritesConfig{Token: token, APIURL: srv.URL}}, core.Runtime{HTTP: srv.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -636,7 +627,7 @@ func TestSpritesClientRedactsErrorStatusText(t *testing.T) {
 			Request:    r,
 		}, nil
 	})}
-	client, err := newSpritesClient(Config{Sprites: SpritesConfig{Token: token}}, Runtime{HTTP: httpClient})
+	client, err := newSpritesClient(core.Config{Sprites: core.SpritesConfig{Token: token}}, core.Runtime{HTTP: httpClient})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -671,7 +662,7 @@ func TestSpritesClientRejectsBadPagination(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			client, err := newSpritesClient(Config{Sprites: SpritesConfig{Token: "test-token", APIURL: srv.URL}}, Runtime{HTTP: srv.Client()})
+			client, err := newSpritesClient(core.Config{Sprites: core.SpritesConfig{Token: "test-token", APIURL: srv.URL}}, core.Runtime{HTTP: srv.Client()})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -691,7 +682,7 @@ func TestSpritesClientRejectsBadPagination(t *testing.T) {
 
 func TestSpritesEnsureCLIUsesSpriteBinary(t *testing.T) {
 	runner := &recordingRunner{}
-	backend := &spritesBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	backend := &spritesBackend{rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 	if err := backend.ensureCLI(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -702,7 +693,7 @@ func TestSpritesEnsureCLIUsesSpriteBinary(t *testing.T) {
 
 func TestSpritesBootstrapInstallsFullSyncToolchain(t *testing.T) {
 	runner := &recordingRunner{}
-	backend := &spritesBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
+	backend := &spritesBackend{rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}}
 	if err := backend.bootstrapSSH(context.Background(), "crabbox-blue-lobster-12345678", "ssh-ed25519 AAAAtest"); err != nil {
 		t.Fatal(err)
 	}
@@ -719,12 +710,12 @@ func TestSpritesBootstrapInstallsFullSyncToolchain(t *testing.T) {
 
 type recordingRunner struct {
 	calls        []string
-	requests     []LocalCommandRequest
+	requests     []core.LocalCommandRequest
 	failContains string
 	err          error
 }
 
-func (r *recordingRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	call := strings.Join(append([]string{req.Name}, req.Args...), " ")
 	r.calls = append(r.calls, call)
 	r.requests = append(r.requests, req)
@@ -733,9 +724,9 @@ func (r *recordingRunner) Run(_ context.Context, req LocalCommandRequest) (Local
 		if err == nil {
 			err = errors.New("command failed")
 		}
-		return LocalCommandResult{ExitCode: 1, Stderr: err.Error()}, err
+		return core.LocalCommandResult{ExitCode: 1, Stderr: err.Error()}, err
 	}
-	return LocalCommandResult{}, nil
+	return core.LocalCommandResult{}, nil
 }
 
 type fakeSpritesAPI struct {

--- a/internal/providers/sprites/client.go
+++ b/internal/providers/sprites/client.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -72,8 +73,8 @@ func (e *spritesAPIError) Error() string {
 	return e.Status + ": " + e.Body
 }
 
-func newSpritesClient(cfg Config, rt Runtime) (spritesAPI, error) {
-	apiURL, origin, err := validateSpritesAPIURL(blank(cfg.Sprites.APIURL, "https://api.sprites.dev"))
+func newSpritesClient(cfg core.Config, rt core.Runtime) (spritesAPI, error) {
+	apiURL, origin, err := validateSpritesAPIURL(core.Blank(cfg.Sprites.APIURL, "https://api.sprites.dev"))
 	if err != nil {
 		return nil, err
 	}
@@ -91,24 +92,24 @@ func newSpritesClient(cfg Config, rt Runtime) (spritesAPI, error) {
 func validateSpritesAPIURL(raw string) (string, *url.URL, error) {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil {
-		return "", nil, exit(2, "provider=sprites API URL must be an absolute HTTP(S) URL")
+		return "", nil, core.Exit(2, "provider=sprites API URL must be an absolute HTTP(S) URL")
 	}
 	if !parsed.IsAbs() || parsed.Host == "" || parsed.Hostname() == "" || parsed.Opaque != "" {
-		return "", nil, exit(2, "provider=sprites API URL must be an absolute HTTP(S) URL")
+		return "", nil, core.Exit(2, "provider=sprites API URL must be an absolute HTTP(S) URL")
 	}
 	if parsed.User != nil {
-		return "", nil, exit(2, "provider=sprites API URL must not contain userinfo")
+		return "", nil, core.Exit(2, "provider=sprites API URL must not contain userinfo")
 	}
 	if parsed.RawQuery != "" || parsed.ForceQuery {
-		return "", nil, exit(2, "provider=sprites API URL must not contain a query")
+		return "", nil, core.Exit(2, "provider=sprites API URL must not contain a query")
 	}
 	if parsed.Fragment != "" {
-		return "", nil, exit(2, "provider=sprites API URL must not contain a fragment")
+		return "", nil, core.Exit(2, "provider=sprites API URL must not contain a fragment")
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
 	hostname := canonicalSpritesHostname(parsed.Hostname())
 	if parsed.Scheme != "https" && (parsed.Scheme != "http" || !isSpritesLoopbackHost(hostname)) {
-		return "", nil, exit(2, "provider=sprites API URL must use HTTPS except for loopback HTTP")
+		return "", nil, core.Exit(2, "provider=sprites API URL must use HTTPS except for loopback HTTP")
 	}
 	port := parsed.Port()
 	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
@@ -282,7 +283,7 @@ func spritesAPILabels(leaseID, slug string) []string {
 		"crabbox",
 		"provider-sprites",
 		"lease-" + strings.ReplaceAll(leaseID, "_", "-"),
-		"slug-" + normalizeLeaseSlug(slug),
+		"slug-" + core.NormalizeLeaseSlug(slug),
 	}
 }
 
@@ -311,13 +312,13 @@ func spritesLeaseID(sprite spritesInfo) string {
 func spritesSlug(leaseID string, sprite spritesInfo) string {
 	for _, label := range sprite.Labels {
 		if strings.HasPrefix(label, "slug-") {
-			return normalizeLeaseSlug(strings.TrimPrefix(label, "slug-"))
+			return core.NormalizeLeaseSlug(strings.TrimPrefix(label, "slug-"))
 		}
 	}
 	if leaseID != "" {
-		return newLeaseSlug(leaseID)
+		return core.NewLeaseSlug(leaseID)
 	}
-	return normalizeLeaseSlug(sprite.Name)
+	return core.NormalizeLeaseSlug(sprite.Name)
 }
 
 func isSpritesNotFound(err error) bool {

--- a/internal/providers/sprites/core.go
+++ b/internal/providers/sprites/core.go
@@ -1,97 +1,11 @@
 package sprites
 
 import (
-	"context"
-
-	"io"
-	"time"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type SpritesConfig = core.SpritesConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type LeaseTarget = core.LeaseTarget
-type LeaseClaim = core.LeaseClaim
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-type ExitError = core.ExitError
-type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
 
 const (
 	spritesProvider = "sprites"
 	targetLinux     = core.TargetLinux
 	networkPublic   = core.NetworkPublic
 )
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func blank(value, fallback string) string {
-	return core.Blank(value, fallback)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func leaseProviderName(leaseID, slug string) string {
-	return core.LeaseProviderName(leaseID, slug)
-}
-
-func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
-	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
-}
-
-func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, now time.Time) map[string]string {
-	return core.TouchDirectLeaseLabels(labels, cfg, state, now)
-}
-
-func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
-}
-
-func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaim(identifier)
-}
-
-func ensureTestboxKey(leaseID string) (string, string, error) {
-	return core.EnsureTestboxKey(leaseID)
-}
-
-func removeStoredTestboxKey(leaseID string) {
-	core.RemoveStoredTestboxKey(leaseID)
-}
-
-func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
-	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
-}
-
-func bootstrapWaitTimeout(cfg Config) time.Duration {
-	return core.BootstrapWaitTimeout(cfg)
-}
-
-func inventoryDoctorResult(provider string, leases int) DoctorResult {
-	return core.InventoryDoctorResult(provider, leases)
-}

--- a/internal/providers/sprites/lifecycle_test.go
+++ b/internal/providers/sprites/lifecycle_test.go
@@ -15,31 +15,31 @@ import (
 	"github.com/openclaw/crabbox/internal/testutil"
 )
 
-func spritesTestClaim(t *testing.T, cfg Config, name, id, org string) (LeaseTarget, LeaseClaim, string) {
+func spritesTestClaim(t *testing.T, cfg core.Config, name, id, org string) (core.LeaseTarget, core.LeaseClaim, string) {
 	t.Helper()
 	repo := t.TempDir()
-	server := Server{Provider: spritesProvider, CloudID: name, Name: name, Labels: map[string]string{
+	server := core.Server{Provider: spritesProvider, CloudID: name, Name: name, Labels: map[string]string{
 		"provider": spritesProvider, "lease": "cbx_testidentity", "slug": "test-identity", "name": name,
 		"sprites_resource_id": id, "sprites_organization": org,
 	}}
-	if err := core.ClaimLeaseTargetForRepoConfig("cbx_testidentity", "test-identity", cfg, server, SSHTarget{}, repo, 0, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_testidentity", "test-identity", cfg, server, core.SSHTarget{}, repo, 0, false); err != nil {
 		t.Fatal(err)
 	}
 	claim, _, err := core.ReadLeaseClaimWithPresence("cbx_testidentity")
 	if err != nil {
 		t.Fatal(err)
 	}
-	return LeaseTarget{Server: server, LeaseID: "cbx_testidentity"}, claim, repo
+	return core.LeaseTarget{Server: server, LeaseID: "cbx_testidentity"}, claim, repo
 }
 
 func TestSpritesResolveValidatesClaimBeforeBootstrap(t *testing.T) {
 	for _, scenario := range []string{"identity", "reclaim replacement", "raw reclaim replacement", "prefixed reclaim replacement", "raw changed lease", "organization", "endpoint", "name", "labels", "live lease", "repo", "expected identity"} {
 		t.Run(scenario, func(t *testing.T) {
 			testutil.IsolateUserDirs(t)
-			cfg := Config{Provider: spritesProvider, Sprites: SpritesConfig{WorkRoot: "/home/sprite/crabbox"}}
+			cfg := core.Config{Provider: spritesProvider, Sprites: core.SpritesConfig{WorkRoot: "/home/sprite/crabbox"}}
 			lease, before, repo := spritesTestClaim(t, cfg, "crabbox-test", "original-id", "test-org")
 			sprite := spritesInfo{ID: "original-id", Name: "crabbox-test", Organization: "test-org", Labels: spritesAPILabels(lease.LeaseID, "test-identity")}
-			req := ResolveRequest{ID: lease.LeaseID, Repo: core.Repo{Root: repo}}
+			req := core.ResolveRequest{ID: lease.LeaseID, Repo: core.Repo{Root: repo}}
 			switch scenario {
 			case "identity":
 				sprite.ID = "replacement-id"
@@ -70,7 +70,7 @@ func TestSpritesResolveValidatesClaimBeforeBootstrap(t *testing.T) {
 				req.ExpectedProviderIdentity = core.ProviderIdentityExpectation{LeaseID: lease.LeaseID, ResourceID: "other-name"}
 			}
 			runner := &recordingRunner{failContains: "sprite", err: errors.New("unexpected native command")}
-			b := &spritesBackend{cfg: cfg, client: &fakeSpritesAPI{get: sprite}, rt: Runtime{Exec: runner, Stderr: io.Discard}}
+			b := &spritesBackend{cfg: cfg, client: &fakeSpritesAPI{get: sprite}, rt: core.Runtime{Exec: runner, Stderr: io.Discard}}
 			if _, err := b.Resolve(t.Context(), req); err == nil {
 				t.Fatal("expected identity/ownership error")
 			}
@@ -89,12 +89,12 @@ func TestSpritesReadOnlyResolutionAndStatusDoNotBootstrap(t *testing.T) {
 	for _, state := range []string{"cold", "warm", "running"} {
 		t.Run(state, func(t *testing.T) {
 			testutil.IsolateUserDirs(t)
-			cfg := Config{Provider: spritesProvider, Sprites: SpritesConfig{WorkRoot: "/home/sprite/crabbox"}}
+			cfg := core.Config{Provider: spritesProvider, Sprites: core.SpritesConfig{WorkRoot: "/home/sprite/crabbox"}}
 			lease, before, _ := spritesTestClaim(t, cfg, "crabbox-test", "original-id", "test-org")
 			sprite := spritesInfo{ID: "original-id", Name: "crabbox-test", Organization: "test-org", Status: state, Labels: spritesAPILabels(lease.LeaseID, "test-identity")}
 			b := &spritesBackend{cfg: cfg, client: &fakeSpritesAPI{get: sprite}}
 			// No runner is installed: read-only resolution must not require a CLI.
-			for _, req := range []ResolveRequest{{ID: lease.LeaseID, StatusOnly: true}, {ID: lease.LeaseID, NoLocalStateMutations: true}} {
+			for _, req := range []core.ResolveRequest{{ID: lease.LeaseID, StatusOnly: true}, {ID: lease.LeaseID, NoLocalStateMutations: true}} {
 				resolved, err := b.Resolve(t.Context(), req)
 				if err != nil {
 					t.Fatal(err)
@@ -131,7 +131,7 @@ func TestSpritesResolveAllowsVerifiedReuseAndExplicitAdoption(t *testing.T) {
 	for _, scenario := range []string{"managed", "adopted", "reclaim", "raw reclaim"} {
 		t.Run(scenario, func(t *testing.T) {
 			testutil.IsolateUserDirs(t)
-			cfg := Config{Provider: spritesProvider, Sprites: SpritesConfig{WorkRoot: "/home/sprite/crabbox"}}
+			cfg := core.Config{Provider: spritesProvider, Sprites: core.SpritesConfig{WorkRoot: "/home/sprite/crabbox"}}
 			lease, _, repo := spritesTestClaim(t, cfg, "crabbox-test", "original-id", "test-org")
 			sprite := spritesInfo{ID: "original-id", Name: "crabbox-test", Organization: "test-org", Labels: spritesAPILabels(lease.LeaseID, "test-identity")}
 			if scenario != "managed" {
@@ -139,18 +139,18 @@ func TestSpritesResolveAllowsVerifiedReuseAndExplicitAdoption(t *testing.T) {
 			}
 			if scenario == "adopted" {
 				lease.Server.Labels["sprites_ownership"] = "adopted"
-				if err := core.ClaimLeaseTargetForRepoConfig(lease.LeaseID, "test-identity", cfg, lease.Server, SSHTarget{}, repo, 0, false); err != nil {
+				if err := core.ClaimLeaseTargetForRepoConfig(lease.LeaseID, "test-identity", cfg, lease.Server, core.SSHTarget{}, repo, 0, false); err != nil {
 					t.Fatal(err)
 				}
 			}
 			// Stop at bootstrap so this test never starts SSH or remote processes.
 			runner := &recordingRunner{failContains: "sprite exec", err: errors.New("bootstrap reached")}
-			b := &spritesBackend{cfg: cfg, client: &fakeSpritesAPI{get: sprite}, rt: Runtime{Exec: runner, Stderr: io.Discard}}
+			b := &spritesBackend{cfg: cfg, client: &fakeSpritesAPI{get: sprite}, rt: core.Runtime{Exec: runner, Stderr: io.Discard}}
 			id := lease.LeaseID
 			if scenario == "raw reclaim" {
 				id = sprite.Name
 			}
-			_, err := b.Resolve(t.Context(), ResolveRequest{ID: id, Repo: core.Repo{Root: repo}, Reclaim: scenario == "reclaim" || scenario == "raw reclaim"})
+			_, err := b.Resolve(t.Context(), core.ResolveRequest{ID: id, Repo: core.Repo{Root: repo}, Reclaim: scenario == "reclaim" || scenario == "raw reclaim"})
 			if err == nil || !strings.Contains(err.Error(), "bootstrap reached") || len(runner.calls) != 2 {
 				t.Fatalf("verified reuse did not reach bootstrap: err=%v calls=%d", err, len(runner.calls))
 			}
@@ -163,9 +163,9 @@ func TestSpritesClaimlessReuseRequiresExplicitAdoption(t *testing.T) {
 		t.Run(scenario, func(t *testing.T) {
 			testutil.IsolateUserDirs(t)
 			const leaseID = "cbx_abcdef123456"
-			cfg := Config{Provider: spritesProvider, Sprites: SpritesConfig{WorkRoot: "/home/sprite/crabbox"}}
+			cfg := core.Config{Provider: spritesProvider, Sprites: core.SpritesConfig{WorkRoot: "/home/sprite/crabbox"}}
 			sprite := spritesInfo{ID: "original-id", Name: "crabbox-test", Organization: "test-org", Labels: spritesAPILabels(leaseID, "test-identity")}
-			req := ResolveRequest{ID: sprite.Name, Repo: core.Repo{Root: t.TempDir()}}
+			req := core.ResolveRequest{ID: sprite.Name, Repo: core.Repo{Root: t.TempDir()}}
 			switch scenario {
 			case "empty repo":
 				req.Repo.Root = ""
@@ -185,7 +185,7 @@ func TestSpritesClaimlessReuseRequiresExplicitAdoption(t *testing.T) {
 				req.NoLocalStateMutations = true
 			}
 			runner := &recordingRunner{failContains: "sprite exec", err: errors.New("bootstrap reached")}
-			b := &spritesBackend{cfg: cfg, client: &fakeSpritesAPI{get: sprite, list: []spritesInfo{sprite}}, rt: Runtime{Exec: runner, Stderr: io.Discard}}
+			b := &spritesBackend{cfg: cfg, client: &fakeSpritesAPI{get: sprite, list: []spritesInfo{sprite}}, rt: core.Runtime{Exec: runner, Stderr: io.Discard}}
 			_, err := b.Resolve(t.Context(), req)
 			if scenario == "reclaim" {
 				if err == nil || !strings.Contains(err.Error(), "bootstrap reached") || len(runner.calls) != 2 {
@@ -267,22 +267,22 @@ func TestSpritesReleaseAbsentResource(t *testing.T) {
 				}
 			}))
 			defer srv.Close()
-			cfg := Config{Provider: spritesProvider, Sprites: SpritesConfig{Token: "test-token", APIURL: srv.URL, WorkRoot: "/home/sprite/crabbox"}}
+			cfg := core.Config{Provider: spritesProvider, Sprites: core.SpritesConfig{Token: "test-token", APIURL: srv.URL, WorkRoot: "/home/sprite/crabbox"}}
 			id, org := "original-id", "test-org"
 			if scenario == "legacy claim" {
 				id, org = "", ""
 			}
 			lease, before, _ := spritesTestClaim(t, cfg, "crabbox-test", id, org)
-			keyPath, _, err := ensureTestboxKey(lease.LeaseID)
+			keyPath, _, err := core.EnsureTestboxKey(lease.LeaseID)
 			if err != nil {
 				t.Fatal(err)
 			}
-			client, err := newSpritesClient(cfg, Runtime{HTTP: srv.Client()})
+			client, err := newSpritesClient(cfg, core.Runtime{HTTP: srv.Client()})
 			if err != nil {
 				t.Fatal(err)
 			}
-			b := &spritesBackend{cfg: cfg, client: client, rt: Runtime{Stderr: io.Discard}}
-			err = b.ReleaseLease(t.Context(), ReleaseLeaseRequest{Lease: lease})
+			b := &spritesBackend{cfg: cfg, client: client, rt: core.Runtime{Stderr: io.Discard}}
+			err = b.ReleaseLease(t.Context(), core.ReleaseLeaseRequest{Lease: lease})
 			after, exists, readErr := core.ReadLeaseClaimWithPresence(lease.LeaseID)
 			if readErr != nil {
 				t.Fatal(readErr)

--- a/internal/providers/sprites/provider.go
+++ b/internal/providers/sprites/provider.go
@@ -17,7 +17,7 @@ func (Provider) Name() string      { return spritesProvider }
 func (Provider) Aliases() []string { return nil }
 
 func (Provider) ClaimScope(cfg core.Config) string {
-	endpoint, _, err := validateSpritesAPIURL(blank(cfg.Sprites.APIURL, "https://api.sprites.dev"))
+	endpoint, _, err := validateSpritesAPIURL(core.Blank(cfg.Sprites.APIURL, "https://api.sprites.dev"))
 	if err != nil {
 		return ""
 	}

--- a/internal/providers/sprites/saved_context_cli_darwin_test.go
+++ b/internal/providers/sprites/saved_context_cli_darwin_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/testutil"
 )
 
@@ -20,7 +21,7 @@ type spritesSandboxedCLIRunner struct {
 	profile string
 }
 
-func (r spritesSandboxedCLIRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (r spritesSandboxedCLIRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	req.Name = "/usr/bin/sandbox-exec"
 	req.Args = append([]string{"-f", r.profile, r.cli}, req.Args...)
 	return (spritesRealCLIRunner{}).Run(ctx, req)
@@ -102,13 +103,13 @@ func TestSpritesRealCLIOverridesWorkingSavedContext(t *testing.T) {
 	}
 	runner := spritesSandboxedCLIRunner{cli: cli, profile: profile}
 	b := &spritesBackend{
-		cfg: Config{Sprites: SpritesConfig{Token: "test-configured-token", APIURL: configured.URL}},
-		rt:  Runtime{Exec: runner},
+		cfg: core.Config{Sprites: core.SpritesConfig{Token: "test-configured-token", APIURL: configured.URL}},
+		rt:  core.Runtime{Exec: runner},
 	}
 	for i, args := range [][]string{{"exec", "-s", "crabbox-test", "--", "true"}, {"proxy", "-s", "crabbox-test", "-W", "22"}} {
 		// Prove the saved fixture works before testing Crabbox's overrides.
 		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-		_, err := runner.Run(ctx, LocalCommandRequest{Name: "sprite", Args: args, Env: os.Environ(), Dir: dirs.Home})
+		_, err := runner.Run(ctx, core.LocalCommandRequest{Name: "sprite", Args: args, Env: os.Environ(), Dir: dirs.Home})
 		cancel()
 		if err == nil || savedRequests[i].Load() == 0 || configuredRequests[i].Load() != 0 {
 			t.Fatalf("%s did not use the working saved context", args[0])

--- a/internal/providers/sprites/status.go
+++ b/internal/providers/sprites/status.go
@@ -10,7 +10,7 @@ import (
 // Plain status is API-only: it must not wake a sleeping Sprite just to display
 // its state. --wait explicitly opts into an SSH probe, never SSH installation.
 func (b *spritesBackend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
-	lease, err := b.Resolve(ctx, ResolveRequest{ID: req.ID, StatusOnly: true, NoLocalStateMutations: true})
+	lease, err := b.Resolve(ctx, core.ResolveRequest{ID: req.ID, StatusOnly: true, NoLocalStateMutations: true})
 	if err != nil {
 		return core.StatusView{}, err
 	}

--- a/internal/providers/sprites/status_unix_test.go
+++ b/internal/providers/sprites/status_unix_test.go
@@ -43,9 +43,9 @@ printf 'probed' > "$CRABBOX_TEST_STATUS_PROBE"
 	t.Setenv("CRABBOX_TEST_STATUS_REMOTE_PATH", remoteBin)
 	t.Setenv("SPRITE_TOKEN", "ambient-token")
 	t.Setenv("SPRITE_URL", "https://ambient.example")
-	cfg := Config{Provider: spritesProvider, Sprites: SpritesConfig{Token: "test-token", WorkRoot: "/home/sprite/crabbox"}}
+	cfg := core.Config{Provider: spritesProvider, Sprites: core.SpritesConfig{Token: "test-token", WorkRoot: "/home/sprite/crabbox"}}
 	lease, claim, _ := spritesTestClaim(t, cfg, "crabbox-test", "original-id", "test-org")
-	key, _, err := ensureTestboxKey(lease.LeaseID)
+	key, _, err := core.EnsureTestboxKey(lease.LeaseID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/sprites/transport.go
+++ b/internal/providers/sprites/transport.go
@@ -5,13 +5,15 @@ import (
 	"io"
 	"os"
 	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 // Both the bootstrap CLI and SSH's ProxyCommand must use the same endpoint and
 // credential as the API client, regardless of saved CLI context or env aliases.
 // These values stay in child-process environments, never argv or lease claims.
 func (b *spritesBackend) cliEnvironment() (map[string]string, error) {
-	endpoint, _, err := validateSpritesAPIURL(blank(b.cfg.Sprites.APIURL, "https://api.sprites.dev"))
+	endpoint, _, err := validateSpritesAPIURL(core.Blank(b.cfg.Sprites.APIURL, "https://api.sprites.dev"))
 	if err != nil {
 		return nil, err
 	}
@@ -22,11 +24,11 @@ func (b *spritesBackend) cliEnvironment() (map[string]string, error) {
 	}, nil
 }
 
-func (b *spritesBackend) sshTarget(name, keyPath string) (SSHTarget, error) {
+func (b *spritesBackend) sshTarget(name, keyPath string) (core.SSHTarget, error) {
 	target := spritesSSHTarget(name, keyPath)
 	env, err := b.cliEnvironment()
 	if err != nil {
-		return SSHTarget{}, err
+		return core.SSHTarget{}, err
 	}
 	target.ChildEnv = env
 	// An existing master may have authenticated through a different CLI context.
@@ -34,10 +36,10 @@ func (b *spritesBackend) sshTarget(name, keyPath string) (SSHTarget, error) {
 	return target, nil
 }
 
-func (b *spritesBackend) runSprite(ctx context.Context, args []string, stdout, stderr io.Writer) (LocalCommandResult, error) {
+func (b *spritesBackend) runSprite(ctx context.Context, args []string, stdout, stderr io.Writer) (core.LocalCommandResult, error) {
 	overrides, err := b.cliEnvironment()
 	if err != nil {
-		return LocalCommandResult{ExitCode: 2}, err
+		return core.LocalCommandResult{ExitCode: 2}, err
 	}
 	env := make([]string, 0, len(os.Environ())+len(overrides))
 	for _, entry := range os.Environ() {
@@ -49,5 +51,5 @@ func (b *spritesBackend) runSprite(ctx context.Context, args []string, stdout, s
 	for _, name := range []string{"SPRITE_TOKEN", "SPRITE_URL", "SPRITES_API_URL"} {
 		env = append(env, name+"="+overrides[name])
 	}
-	return b.rt.Exec.Run(ctx, LocalCommandRequest{Name: "sprite", Args: args, Env: env, Stdout: stdout, Stderr: stderr})
+	return b.rt.Exec.Run(ctx, core.LocalCommandRequest{Name: "sprite", Args: args, Env: env, Stdout: stdout, Stderr: stderr})
 }

--- a/internal/providers/sprites/transport_test.go
+++ b/internal/providers/sprites/transport_test.go
@@ -25,7 +25,7 @@ func TestSpritesTransportUsesResolvedEnvironment(t *testing.T) {
 	t.Setenv("SPRITES_API_URL", "https://other.example")
 	t.Setenv("CRABBOX_SPRITES_TOKEN", "alias-token")
 	runner := &recordingRunner{}
-	b := &spritesBackend{cfg: Config{Provider: spritesProvider, Sprites: SpritesConfig{Token: " resolved-token ", APIURL: "https://API.SPRITES.DEV:443/"}}, rt: Runtime{Exec: runner, Stderr: io.Discard}}
+	b := &spritesBackend{cfg: core.Config{Provider: spritesProvider, Sprites: core.SpritesConfig{Token: " resolved-token ", APIURL: "https://API.SPRITES.DEV:443/"}}, rt: core.Runtime{Exec: runner, Stderr: io.Discard}}
 	if err := b.bootstrapSSH(t.Context(), "crabbox-test", "ssh-ed25519 AAAAtest"); err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestSpritesTransportUsesResolvedEnvironment(t *testing.T) {
 	if strings.Contains(string(encoded), "resolved-token") || strings.Contains(string(encoded), `"ChildEnv":`) {
 		t.Fatal("transport credential serialized in lease target")
 	}
-	server := Server{Provider: spritesProvider, CloudID: "crabbox-test", Name: "crabbox-test", Labels: map[string]string{"name": "crabbox-test"}}
+	server := core.Server{Provider: spritesProvider, CloudID: "crabbox-test", Name: "crabbox-test", Labels: map[string]string{"name": "crabbox-test"}}
 	if err := core.ClaimLeaseTargetForRepoConfig("cbx_transport", "transport", b.cfg, server, target, t.TempDir(), 0, false); err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestSpritesTransportUsesResolvedEnvironment(t *testing.T) {
 
 func TestSpritesTransportRejectsInvalidEndpointBeforeExec(t *testing.T) {
 	runner := &recordingRunner{}
-	b := &spritesBackend{cfg: Config{Sprites: SpritesConfig{APIURL: "http://not-loopback.example"}}, rt: Runtime{Exec: runner}}
+	b := &spritesBackend{cfg: core.Config{Sprites: core.SpritesConfig{APIURL: "http://not-loopback.example"}}, rt: core.Runtime{Exec: runner}}
 	if _, err := b.runSprite(t.Context(), []string{"--version"}, nil, nil); err == nil {
 		t.Fatal("expected URL validation error")
 	}
@@ -95,7 +95,7 @@ func TestSpritesTransportRejectsInvalidEndpointBeforeExec(t *testing.T) {
 
 type spritesRealCLIRunner struct{}
 
-func (spritesRealCLIRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (spritesRealCLIRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	cmd := exec.CommandContext(ctx, req.Name, req.Args...)
 	cmd.Env = req.Env
 	cmd.Dir = req.Dir
@@ -104,7 +104,7 @@ func (spritesRealCLIRunner) Run(ctx context.Context, req LocalCommandRequest) (L
 	if cmd.ProcessState != nil {
 		code = cmd.ProcessState.ExitCode()
 	}
-	return LocalCommandResult{ExitCode: code, Stderr: string(output)}, err
+	return core.LocalCommandResult{ExitCode: code, Stderr: string(output)}, err
 }
 
 // Optional, credential-free contract test against an installed sprite CLI.
@@ -149,15 +149,15 @@ func TestSpritesRealCLIUsesConfiguredEndpointAndToken(t *testing.T) {
 	t.Setenv("SPRITES_API_URL", wrong.URL)
 	t.Setenv("CRABBOX_SPRITES_TOKEN", "test-configured-token")
 	t.Setenv("CRABBOX_SPRITES_API_URL", api.URL)
-	cfg := Config{Sprites: SpritesConfig{Token: "test-configured-token", APIURL: api.URL}}
-	client, err := newSpritesClient(cfg, Runtime{HTTP: api.Client()})
+	cfg := core.Config{Sprites: core.SpritesConfig{Token: "test-configured-token", APIURL: api.URL}}
+	client, err := newSpritesClient(cfg, core.Runtime{HTTP: api.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if _, err := client.GetSprite(t.Context(), "crabbox-test"); err != nil {
 		t.Fatal(err)
 	}
-	b := &spritesBackend{cfg: cfg, rt: Runtime{Exec: spritesRealCLIRunner{}}}
+	b := &spritesBackend{cfg: cfg, rt: core.Runtime{Exec: spritesRealCLIRunner{}}}
 	for _, args := range [][]string{{"exec", "-s", "crabbox-test", "--", "true"}, {"proxy", "-s", "crabbox-test", "-W", "22"}} {
 		requests := &execRequests
 		if args[0] == "proxy" {


### PR DESCRIPTION
Remove exact forwarding functions and core type aliases from Morph, exe.dev, Sprites, Namespace Devbox, GitHub Codespaces, and Runpod. Call core directly for common SSH, claim, lease-label, and diagnostic operations, removing 623 net production lines.

Go type identity and resolved symbol uses were checked before replacement. Provider-specific scope binding, release policy, endpoint handling, and mutable injection hooks retain their existing ownership.

Validation: complete tests passed for all six provider packages; scoped Autoreview passed in two complete review chunks. Windows-only SSH permission call sites were included after the release check exposed missing references. Windows x64 and ARM64 builds and the Windows test-package compilation pass; CI is rerunning on the corrected head. No command, configuration, dependency, or credential changes.
