### PR TITLE
refactor(providers): use shared core APIs in runtime adapters

### DIFF
--- a/internal/providers/awslambdamicrovm/backend.go
+++ b/internal/providers/awslambdamicrovm/backend.go
@@ -24,30 +24,30 @@ type runnerAPI interface {
 }
 
 type backend struct {
-	spec       ProviderSpec
-	cfg        Config
-	rt         Runtime
-	newControl func(context.Context, Config) (controlPlane, error)
-	newRunner  func(controlPlane, Config, Runtime) (runnerAPI, error)
+	spec       core.ProviderSpec
+	cfg        core.Config
+	rt         core.Runtime
+	newControl func(context.Context, core.Config) (controlPlane, error)
+	newRunner  func(controlPlane, core.Config, core.Runtime) (runnerAPI, error)
 }
 
-func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	return &backend{
 		spec:       spec,
 		cfg:        cfg,
 		rt:         rt,
 		newControl: newControlPlane,
-		newRunner: func(control controlPlane, cfg Config, rt Runtime) (runnerAPI, error) {
+		newRunner: func(control controlPlane, cfg core.Config, rt core.Runtime) (runnerAPI, error) {
 			return newRunnerClient(control, rt.HTTP, cfg.AWSRegion)
 		},
 	}
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *backend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if req.ActionsRunner {
-		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+		return core.Exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
 	started := core.ClockNow(b.rt.Clock)
 	control, runner, err := b.clients(ctx)
@@ -71,14 +71,14 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	})
 }
 
-func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {
-	if err := delegatedSyncOptionsError(b.spec, req); err != nil {
-		return RunResult{}, err
+func (b *backend) Run(ctx context.Context, req core.RunRequest) (result core.RunResult, retErr error) {
+	if err := core.RejectDelegatedSyncOptionsForSpec(b.spec, req); err != nil {
+		return core.RunResult{}, err
 	}
 	started := core.ClockNow(b.rt.Clock)
 	control, runner, err := b.clients(ctx)
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	var prepared *core.PreparedArchive
 	if req.ID == "" && !req.NoSync {
@@ -88,59 +88,59 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 			Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 		})
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 		defer prepared.Close()
 	}
 	leaseID, slug := "", ""
 	var vm microVM
-	var server Server
+	var server core.Server
 	acquired := false
 	if req.ID == "" {
 		leaseID, slug, vm, err = b.create(ctx, control, runner, req.Repo, req.RequestedSlug, req.Keep || req.KeepOnFailure, req.Reclaim)
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 		server = b.server(vm, leaseID, slug, req.Keep || req.KeepOnFailure, nil)
 		acquired = true
 		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s microvm=%s region=%s image_version=%s\n", leaseID, slug, providerName, vm.ID, b.cfg.AWSRegion, vm.ImageVersion)
 	} else {
-		var claim LeaseClaim
+		var claim core.LeaseClaim
 		claim, vm, server, err = b.resolve(ctx, control, req.ID)
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 		unlockOperation, err := lockAWSLambdaMicroVMLeaseOperation(ctx, claim.LeaseID)
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 		defer unlockOperation()
 		claim, vm, server, err = b.resolve(ctx, control, claim.LeaseID)
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 		if vm.ImageARN != b.cfg.AWSLambdaMicroVM.Image || (b.cfg.AWSLambdaMicroVM.ImageVersion != "" && vm.ImageVersion != b.cfg.AWSLambdaMicroVM.ImageVersion) {
-			return RunResult{}, exit(4, "%s image identity mismatch for lease %s", providerName, claim.LeaseID)
+			return core.RunResult{}, core.Exit(4, "%s image identity mismatch for lease %s", providerName, claim.LeaseID)
 		}
 		leaseID, slug = claim.LeaseID, claim.Slug
-		server.Labels = touchLeaseLabels(server.Labels, b.cfg, strings.ToLower(vm.State), core.ClockNow(b.rt.Clock))
+		server.Labels = core.TouchDirectLeaseLabels(server.Labels, b.cfg, strings.ToLower(vm.State), core.ClockNow(b.rt.Clock))
 		if err := claimLease(leaseID, slug, b.scope(), req.Options.Pond, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim, server); err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 	}
 
 	shouldStop := acquired && !req.Keep
-	session := &RunSessionHandle{
+	session := &core.RunSessionHandle{
 		Provider:       providerName,
 		LeaseID:        leaseID,
 		Slug:           slug,
 		Reused:         !acquired,
 		Kept:           !shouldStop,
-		CleanupCommand: "crabbox stop --provider " + providerName + " " + shellQuote(leaseID),
+		CleanupCommand: "crabbox stop --provider " + providerName + " " + core.ShellQuote(leaseID),
 	}
-	result = RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, SyncDelegated: true, Session: session}
+	result = core.RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, SyncDelegated: true, Session: session}
 	syncDuration := time.Duration(0)
-	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
+	syncPhases := []core.TimingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
 	commandRan := false
 	defer func() {
 		// Preserve the native primary outcome before termination or reporting
@@ -154,7 +154,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 				session.Kept = true
 				result, retErr = shared.AppendDelegatedRunFailure(result, retErr, fmt.Errorf("terminate AWS Lambda MicroVM %s: %w", vm.ID, cleanupErr), 1)
 			} else {
-				removeLeaseClaim(leaseID)
+				core.RemoveLeaseClaim(leaseID)
 				session.Kept = false
 			}
 		} else {
@@ -166,7 +166,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 			fmt.Fprintf(b.rt.Stderr, "%s run summary sync=%s command=%s total=%s exit=%d\n", providerName, syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
 		}
 		if req.TimingJSON {
-			timingErr := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{Provider: providerName, LeaseID: leaseID, Slug: slug, SyncDelegated: true, SyncMs: syncDuration.Milliseconds(), SyncPhases: syncPhases, SyncSkipped: req.NoSync, CommandMs: result.Command.Milliseconds(), TotalMs: result.Total.Milliseconds(), ExitCode: result.ExitCode, Label: strings.TrimSpace(req.Label)}, result, retErr))
+			timingErr := core.WriteTimingJSON(b.rt.Stderr, core.TimingReportWithRunResult(core.TimingReport{Provider: providerName, LeaseID: leaseID, Slug: slug, SyncDelegated: true, SyncMs: syncDuration.Milliseconds(), SyncPhases: syncPhases, SyncSkipped: req.NoSync, CommandMs: result.Command.Milliseconds(), TotalMs: result.Total.Milliseconds(), ExitCode: result.ExitCode, Label: strings.TrimSpace(req.Label)}, result, retErr))
 			result, retErr = shared.AppendDelegatedRunFailure(result, retErr, timingErr, 1)
 		}
 	}()
@@ -176,9 +176,9 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		syncPhases, syncDuration, err = b.syncWorkspace(ctx, runner, vm, req, prepared)
 	} else {
 		var exitCode int
-		exitCode, err = runner.Exec(ctx, vm, "mkdir -p "+shellQuote(b.cfg.AWSLambdaMicroVM.Workdir), "/", nil, io.Discard, b.rt.Stderr)
+		exitCode, err = runner.Exec(ctx, vm, "mkdir -p "+core.ShellQuote(b.cfg.AWSLambdaMicroVM.Workdir), "/", nil, io.Discard, b.rt.Stderr)
 		if err == nil && exitCode != 0 {
-			err = exit(exitCode, "%s workspace preparation exited %d", providerName, exitCode)
+			err = core.Exit(exitCode, "%s workspace preparation exited %d", providerName, exitCode)
 		}
 	}
 	if err != nil {
@@ -193,12 +193,12 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		return result, nil
 	}
 
-	command := shellScriptFromArgv(req.Command)
+	command := core.ShellScriptFromArgv(req.Command)
 	if req.ShellMode {
 		command = strings.Join(req.Command, " ")
 	}
 	if strings.TrimSpace(command) == "" {
-		return result, exit(2, "provider=%s requires a command", providerName)
+		return result, core.Exit(2, "provider=%s requires a command", providerName)
 	}
 	if req.EnvSummary {
 		printEnvForwardingSummary(b.rt.Stderr, req.Options.EnvAllow, req.Env)
@@ -218,27 +218,27 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	}
 	if exitCode != 0 {
 		handleDelegatedRunFailure(b.rt.Stderr, req, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return result, ExitError{Code: exitCode, Message: fmt.Sprintf("%s run exited %d", providerName, exitCode)}
+		return result, core.ExitError{Code: exitCode, Message: fmt.Sprintf("%s run exited %d", providerName, exitCode)}
 	}
-	server.Labels = touchLeaseLabels(server.Labels, b.cfg, strings.ToLower(vm.State), core.ClockNow(b.rt.Clock))
+	server.Labels = core.TouchDirectLeaseLabels(server.Labels, b.cfg, strings.ToLower(vm.State), core.ClockNow(b.rt.Clock))
 	if err := claimLease(leaseID, slug, b.scope(), req.Options.Pond, req.Repo.Root, b.cfg.IdleTimeout, true, server); err != nil {
-		failure, failureErr := shared.PinDelegatedRunFailure(RunResult{}, err)
+		failure, failureErr := shared.PinDelegatedRunFailure(core.RunResult{}, err)
 		result.ExitCode, result.Status, result.ErrorKind = failure.ExitCode, failure.Status, failure.ErrorKind
 		return result, failureErr
 	}
 	return result, nil
 }
 
-func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
 	control, _, err := b.clients(ctx)
 	if err != nil {
 		return nil, err
 	}
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return nil, err
 	}
-	servers := make([]LeaseView, 0, len(claims))
+	servers := make([]core.LeaseView, 0, len(claims))
 	for _, claim := range claims {
 		if claim.Provider != providerName || claim.ProviderScope != b.scope() {
 			continue
@@ -259,14 +259,14 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 	return servers, nil
 }
 
-func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	control, _, err := b.clients(ctx)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	claim, vm, server, err := b.resolve(ctx, control, req.ID)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	deadline := core.ClockNow(b.rt.Clock).Add(req.WaitTimeout)
 	if req.WaitTimeout <= 0 {
@@ -277,21 +277,21 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 			break
 		}
 		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return StatusView{}, exit(5, "timed out waiting for AWS Lambda MicroVM %s", vm.ID)
+			return core.StatusView{}, core.Exit(5, "timed out waiting for AWS Lambda MicroVM %s", vm.ID)
 		}
 		if err := sleepContext(ctx, 2*time.Second); err != nil {
-			return StatusView{}, err
+			return core.StatusView{}, err
 		}
 		vm, err = control.Get(ctx, vm.ID)
 		if err != nil {
-			return StatusView{}, err
+			return core.StatusView{}, err
 		}
 		server = b.server(vm, claim.LeaseID, claim.Slug, claim.Labels["keep"] == "true", claim.Labels)
 	}
-	return StatusView{ID: claim.LeaseID, Slug: claim.Slug, Provider: providerName, TargetOS: targetLinux, State: strings.ToLower(vm.State), ServerID: vm.ID, ServerType: server.ServerType.Name, Host: vm.Endpoint, Network: "public", Ready: microVMReady(vm.State), Labels: server.Labels}, nil
+	return core.StatusView{ID: claim.LeaseID, Slug: claim.Slug, Provider: providerName, TargetOS: targetLinux, State: strings.ToLower(vm.State), ServerID: vm.ID, ServerType: server.ServerType.Name, Host: vm.Endpoint, Network: "public", Ready: microVMReady(vm.State), Labels: server.Labels}, nil
 }
 
-func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+func (b *backend) Stop(ctx context.Context, req core.StopRequest) error {
 	control, _, err := b.clients(ctx)
 	if err != nil {
 		return err
@@ -301,7 +301,7 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 		return err
 	}
 	if !ok || claim.ProviderScope != b.scope() {
-		return exit(4, "%s lease not found: %s", providerName, req.ID)
+		return core.Exit(4, "%s lease not found: %s", providerName, req.ID)
 	}
 	unlockOperation, err := lockAWSLambdaMicroVMLeaseOperation(ctx, claim.LeaseID)
 	if err != nil {
@@ -313,33 +313,33 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 		return err
 	}
 	if !ok || claim.ProviderScope != b.scope() {
-		return exit(4, "%s lease not found: %s", providerName, req.ID)
+		return core.Exit(4, "%s lease not found: %s", providerName, req.ID)
 	}
 	if err := control.Terminate(ctx, claim.CloudID); err != nil {
 		if !isNotFound(err) || !b.cfg.AWSLambdaMicroVM.ForgetMissing {
 			return err
 		}
 	}
-	removeLeaseClaim(claim.LeaseID)
+	core.RemoveLeaseClaim(claim.LeaseID)
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s microvm=%s\n", claim.LeaseID, claim.CloudID)
 	return nil
 }
 
-func (b *backend) Pause(ctx context.Context, req PauseRequest) error {
+func (b *backend) Pause(ctx context.Context, req core.PauseRequest) error {
 	return b.changeState(ctx, req.ID, "SUSPENDED")
 }
 
-func (b *backend) Resume(ctx context.Context, req ResumeRequest) error {
+func (b *backend) Resume(ctx context.Context, req core.ResumeRequest) error {
 	return b.changeState(ctx, req.ID, "RUNNING")
 }
 
-func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
-	servers, err := b.List(ctx, ListRequest{Options: req.Options})
+func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
+	servers, err := b.List(ctx, core.ListRequest{Options: req.Options})
 	if err != nil {
 		return err
 	}
 	for _, server := range servers {
-		shouldDelete, reason := shouldCleanupServer(server, core.ClockNow(b.rt.Clock))
+		shouldDelete, reason := core.ShouldCleanupServer(server, core.ClockNow(b.rt.Clock))
 		if !shouldDelete {
 			fmt.Fprintf(b.rt.Stderr, "skip microvm id=%s reason=%s\n", server.CloudID, reason)
 			continue
@@ -348,24 +348,24 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 		if req.DryRun {
 			continue
 		}
-		if err := b.Stop(ctx, StopRequest{ID: server.Labels["lease"]}); err != nil {
+		if err := b.Stop(ctx, core.StopRequest{ID: server.Labels["lease"]}); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	control, _, err := b.clients(ctx)
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
 	if err := control.Probe(ctx, b.cfg.AWSLambdaMicroVM.Image, b.cfg.AWSLambdaMicroVM.ImageVersion); err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
 	count := 0
 	for _, claim := range claims {
@@ -378,8 +378,8 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	return result, nil
 }
 
-func coreInventoryDoctorResult(provider string, leases int) DoctorResult {
-	return DoctorResult{Provider: provider, Message: fmt.Sprintf("auth=ready control_plane=ready inventory=ready api=list mutation=false leases=%d runtime=unchecked", leases)}
+func coreInventoryDoctorResult(provider string, leases int) core.DoctorResult {
+	return core.DoctorResult{Provider: provider, Message: fmt.Sprintf("auth=ready control_plane=ready inventory=ready api=list mutation=false leases=%d runtime=unchecked", leases)}
 }
 
 func (b *backend) clients(ctx context.Context) (controlPlane, runnerAPI, error) {
@@ -394,9 +394,9 @@ func (b *backend) clients(ctx context.Context) (controlPlane, runnerAPI, error) 
 	return control, runner, nil
 }
 
-func (b *backend) create(ctx context.Context, control controlPlane, runner runnerAPI, repo Repo, requestedSlug string, keep, reclaim bool) (leaseID, slug string, vm microVM, retErr error) {
+func (b *backend) create(ctx context.Context, control controlPlane, runner runnerAPI, repo core.Repo, requestedSlug string, keep, reclaim bool) (leaseID, slug string, vm microVM, retErr error) {
 	leaseID = core.NewLeaseID()
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return "", "", microVM{}, err
 	}
@@ -439,17 +439,17 @@ func (b *backend) create(ctx context.Context, control controlPlane, runner runne
 	return leaseID, slug, vm, nil
 }
 
-func (b *backend) resolve(ctx context.Context, control controlPlane, identifier string) (LeaseClaim, microVM, Server, error) {
+func (b *backend) resolve(ctx context.Context, control controlPlane, identifier string) (core.LeaseClaim, microVM, core.Server, error) {
 	claim, ok, err := resolveLeaseClaim(identifier)
 	if err != nil {
-		return LeaseClaim{}, microVM{}, Server{}, err
+		return core.LeaseClaim{}, microVM{}, core.Server{}, err
 	}
 	if !ok || claim.ProviderScope != b.scope() || claim.CloudID == "" {
-		return LeaseClaim{}, microVM{}, Server{}, exit(4, "%s lease not found: %s", providerName, identifier)
+		return core.LeaseClaim{}, microVM{}, core.Server{}, core.Exit(4, "%s lease not found: %s", providerName, identifier)
 	}
 	vm, err := control.Get(ctx, claim.CloudID)
 	if err != nil {
-		return LeaseClaim{}, microVM{}, Server{}, err
+		return core.LeaseClaim{}, microVM{}, core.Server{}, err
 	}
 	return claim, vm, b.server(vm, claim.LeaseID, claim.Slug, claim.Labels["keep"] == "true", claim.Labels), nil
 }
@@ -465,7 +465,7 @@ func (b *backend) waitReady(ctx context.Context, control controlPlane, runner ru
 			}
 			vm = current
 			if microVMTerminal(vm.State) {
-				return false, exit(5, "AWS Lambda MicroVM %s entered %s: %s", vm.ID, vm.State, vm.StateReason)
+				return false, core.Exit(5, "AWS Lambda MicroVM %s entered %s: %s", vm.ID, vm.State, vm.StateReason)
 			}
 			if strings.EqualFold(vm.State, "RUNNING") {
 				healthCtx, cancel := context.WithTimeout(ctx, runnerHealthProbeTimeout)
@@ -476,7 +476,7 @@ func (b *backend) waitReady(ctx context.Context, control controlPlane, runner ru
 				}
 			}
 			if core.ClockNow(b.rt.Clock).After(deadline) {
-				return false, exit(5, "timed out waiting for AWS Lambda MicroVM %s runner readiness", vm.ID)
+				return false, core.Exit(5, "timed out waiting for AWS Lambda MicroVM %s runner readiness", vm.ID)
 			}
 			return false, nil
 		}, nil)
@@ -526,7 +526,7 @@ func (b *backend) changeState(ctx context.Context, identifier, target string) er
 			return nil
 		}
 		if microVMTerminal(vm.State) || core.ClockNow(b.rt.Clock).After(deadline) {
-			return exit(5, "AWS Lambda MicroVM %s did not reach %s (state=%s)", vm.ID, target, vm.State)
+			return core.Exit(5, "AWS Lambda MicroVM %s did not reach %s (state=%s)", vm.ID, target, vm.State)
 		}
 		if err := sleepContext(ctx, 2*time.Second); err != nil {
 			return err
@@ -559,7 +559,7 @@ func (b *backend) scope() string {
 	return b.cfg.AWSRegion
 }
 
-func (b *backend) server(vm microVM, leaseID, slug string, keep bool, existing map[string]string) Server {
+func (b *backend) server(vm microVM, leaseID, slug string, keep bool, existing map[string]string) core.Server {
 	labels := directLeaseLabels(b.cfg, leaseID, slug, keep, core.ClockNow(b.rt.Clock))
 	for key, value := range existing {
 		labels[key] = value
@@ -569,18 +569,18 @@ func (b *backend) server(vm microVM, leaseID, slug string, keep bool, existing m
 	labels["image_arn"] = vm.ImageARN
 	labels["image_version"] = vm.ImageVersion
 	labels["endpoint"] = vm.Endpoint
-	server := Server{CloudID: vm.ID, Provider: providerName, Name: slug, Status: strings.ToLower(vm.State), Labels: labels}
+	server := core.Server{CloudID: vm.ID, Provider: providerName, Name: slug, Status: strings.ToLower(vm.State), Labels: labels}
 	server.PublicNet.IPv4.IP = vm.Endpoint
 	server.ServerType.Name = vm.ImageVersion
 	return server
 }
 
-func serverFromClaim(claim LeaseClaim) Server {
+func serverFromClaim(claim core.LeaseClaim) core.Server {
 	labels := make(map[string]string, len(claim.Labels))
 	for key, value := range claim.Labels {
 		labels[key] = value
 	}
-	server := Server{CloudID: claim.CloudID, Provider: providerName, Name: claim.Slug, Status: labels["state"], Labels: labels}
+	server := core.Server{CloudID: claim.CloudID, Provider: providerName, Name: claim.Slug, Status: labels["state"], Labels: labels}
 	server.PublicNet.IPv4.IP = labels["endpoint"]
 	server.ServerType.Name = labels["image_version"]
 	return server

--- a/internal/providers/awslambdamicrovm/backend_test.go
+++ b/internal/providers/awslambdamicrovm/backend_test.go
@@ -155,7 +155,7 @@ func TestRunSyncsExecutesAndTerminatesOneShot(t *testing.T) {
 	runner := &fakeRunner{}
 	var stdout bytes.Buffer
 	b := testBackend(control, runner, &stdout)
-	result, err := b.Run(context.Background(), RunRequest{Repo: Repo{Root: repo, Name: "my-app"}, Command: []string{"printf", "runner-ok"}})
+	result, err := b.Run(context.Background(), core.RunRequest{Repo: core.Repo{Root: repo, Name: "my-app"}, Command: []string{"printf", "runner-ok"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -180,8 +180,8 @@ func TestRunRejectsOversizedWorkspaceBeforeProviderCalls(t *testing.T) {
 	b := testBackend(control, runner, io.Discard)
 	b.cfg.Sync.FailBytes = 1
 
-	_, err := b.Run(context.Background(), RunRequest{
-		Repo: Repo{Root: testRepo(t), Name: "my-app"}, Command: []string{"true"},
+	_, err := b.Run(context.Background(), core.RunRequest{
+		Repo: core.Repo{Root: testRepo(t), Name: "my-app"}, Command: []string{"true"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "sync candidate too large:") || !strings.Contains(err.Error(), "limit 1 B") {
 		t.Fatalf("err=%v", err)
@@ -199,8 +199,8 @@ func TestRunCleansPreparedArchiveWhenResourceCreationFails(t *testing.T) {
 	control := &fakeControlPlane{runErr: errors.New("creation denied")}
 	b := testBackend(control, &fakeRunner{}, io.Discard)
 
-	_, err := b.Run(context.Background(), RunRequest{
-		Repo: Repo{Root: repo, Name: "my-app"}, Command: []string{"true"},
+	_, err := b.Run(context.Background(), core.RunRequest{
+		Repo: core.Repo{Root: repo, Name: "my-app"}, Command: []string{"true"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "creation denied") {
 		t.Fatalf("err=%v", err)
@@ -219,20 +219,20 @@ func TestRetainedLifecyclePauseResumeStop(t *testing.T) {
 	control := &fakeControlPlane{}
 	runner := &fakeRunner{}
 	b := testBackend(control, runner, io.Discard)
-	result, err := b.Run(context.Background(), RunRequest{Repo: Repo{Root: testRepo(t), Name: "my-app"}, Command: []string{"true"}, Keep: true})
+	result, err := b.Run(context.Background(), core.RunRequest{Repo: core.Repo{Root: testRepo(t), Name: "my-app"}, Command: []string{"true"}, Keep: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if result.Session == nil || !result.Session.Kept {
 		t.Fatalf("session=%#v", result.Session)
 	}
-	if err := b.Pause(context.Background(), PauseRequest{ID: result.LeaseID}); err != nil {
+	if err := b.Pause(context.Background(), core.PauseRequest{ID: result.LeaseID}); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Resume(context.Background(), ResumeRequest{ID: result.LeaseID}); err != nil {
+	if err := b.Resume(context.Background(), core.ResumeRequest{ID: result.LeaseID}); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Stop(context.Background(), StopRequest{ID: result.LeaseID}); err != nil {
+	if err := b.Stop(context.Background(), core.StopRequest{ID: result.LeaseID}); err != nil {
 		t.Fatal(err)
 	}
 	want := []string{"suspend:mvm-test", "resume:mvm-test", "terminate:mvm-test"}
@@ -251,22 +251,22 @@ func TestImageRotationKeepsOldLeaseManageableButBlocksReuse(t *testing.T) {
 	control := &fakeControlPlane{}
 	runner := &fakeRunner{}
 	b := testBackend(control, runner, io.Discard)
-	result, err := b.Run(context.Background(), RunRequest{Repo: Repo{Root: testRepo(t), Name: "my-app"}, Command: []string{"true"}, Keep: true})
+	result, err := b.Run(context.Background(), core.RunRequest{Repo: core.Repo{Root: testRepo(t), Name: "my-app"}, Command: []string{"true"}, Keep: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 	b.cfg.AWSLambdaMicroVM.Image = "arn:aws:lambda:eu-west-1:123456789012:microvm-image:new-runner"
-	if _, err := b.Status(context.Background(), StatusRequest{ID: result.LeaseID}); err != nil {
+	if _, err := b.Status(context.Background(), core.StatusRequest{ID: result.LeaseID}); err != nil {
 		t.Fatalf("status after image rotation: %v", err)
 	}
-	servers, err := b.List(context.Background(), ListRequest{})
+	servers, err := b.List(context.Background(), core.ListRequest{})
 	if err != nil || len(servers) != 1 {
 		t.Fatalf("list after image rotation: servers=%#v err=%v", servers, err)
 	}
-	if _, err := b.Run(context.Background(), RunRequest{Repo: Repo{Root: "/repo", Name: "my-app"}, ID: result.LeaseID, Command: []string{"true"}, NoSync: true}); err == nil || !strings.Contains(err.Error(), "image identity mismatch") {
+	if _, err := b.Run(context.Background(), core.RunRequest{Repo: core.Repo{Root: "/repo", Name: "my-app"}, ID: result.LeaseID, Command: []string{"true"}, NoSync: true}); err == nil || !strings.Contains(err.Error(), "image identity mismatch") {
 		t.Fatalf("reuse after image rotation err=%v", err)
 	}
-	if err := b.Stop(context.Background(), StopRequest{ID: result.LeaseID}); err != nil {
+	if err := b.Stop(context.Background(), core.StopRequest{ID: result.LeaseID}); err != nil {
 		t.Fatalf("stop after image rotation: %v", err)
 	}
 }
@@ -276,7 +276,7 @@ func TestNoSyncWorkspaceFailureStopsBeforeCommand(t *testing.T) {
 	control := &fakeControlPlane{}
 	runner := &fakeRunner{exitCode: 9}
 	b := testBackend(control, runner, io.Discard)
-	result, err := b.Run(context.Background(), RunRequest{Repo: Repo{Root: testRepo(t), Name: "my-app"}, Command: []string{"must-not-run"}, NoSync: true})
+	result, err := b.Run(context.Background(), core.RunRequest{Repo: core.Repo{Root: testRepo(t), Name: "my-app"}, Command: []string{"must-not-run"}, NoSync: true})
 	if err == nil || result.ExitCode != 9 || result.ErrorKind != core.RunErrorProvider {
 		t.Fatalf("result=%#v err=%v", result, err)
 	}
@@ -295,7 +295,7 @@ func TestCreateRollsBackWhenRunnerIsUnhealthy(t *testing.T) {
 	b := testBackend(control, runner, io.Discard)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	if err := b.Warmup(ctx, WarmupRequest{Repo: Repo{Root: "/repo", Name: "my-app"}, Keep: true}); err == nil {
+	if err := b.Warmup(ctx, core.WarmupRequest{Repo: core.Repo{Root: "/repo", Name: "my-app"}, Keep: true}); err == nil {
 		t.Fatal("unhealthy runner unexpectedly became ready")
 	}
 	if !slices.Contains(control.calls, "terminate:mvm-test") {
@@ -314,7 +314,7 @@ func TestCreateRollbackFailurePersistsExactRecoveryClaim(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := b.Warmup(ctx, WarmupRequest{Repo: Repo{Root: "/repo", Name: "my-app"}, Keep: true})
+	err := b.Warmup(ctx, core.WarmupRequest{Repo: core.Repo{Root: "/repo", Name: "my-app"}, Keep: true})
 	if !errors.Is(err, context.Canceled) || !errors.Is(err, terminateErr) {
 		t.Fatalf("Warmup err=%v, want joined cancellation and termination failure", err)
 	}
@@ -327,7 +327,7 @@ func TestCreateRollbackFailurePersistsExactRecoveryClaim(t *testing.T) {
 	if !control.terminateDeadline || control.terminateContextErr != nil {
 		t.Fatalf("rollback context deadline=%t err=%v", control.terminateDeadline, control.terminateContextErr)
 	}
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil || len(claims) != 1 {
 		t.Fatalf("claims=%#v err=%v, want one recovery claim", claims, err)
 	}
@@ -336,7 +336,7 @@ func TestCreateRollbackFailurePersistsExactRecoveryClaim(t *testing.T) {
 		t.Fatalf("recovery claim=%#v", claim)
 	}
 	control.terminateErr = nil
-	if err := b.Stop(context.Background(), StopRequest{ID: claim.LeaseID}); err != nil {
+	if err := b.Stop(context.Background(), core.StopRequest{ID: claim.LeaseID}); err != nil {
 		t.Fatalf("recovery stop: %v", err)
 	}
 	if _, ok, err := resolveLeaseClaim(claim.LeaseID); err != nil || ok {
@@ -356,7 +356,7 @@ func TestCreateRollbackFailureReportsRecoveryClaimPersistenceFailure(t *testing.
 	var stderr bytes.Buffer
 	b.rt.Stderr = &stderr
 
-	err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: "/repo", Name: "my-app"}, Keep: true})
+	err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: "/repo", Name: "my-app"}, Keep: true})
 	if !errors.Is(err, terminateErr) || !strings.Contains(err.Error(), "mvm-test") || !strings.Contains(err.Error(), "could not be persisted") {
 		t.Fatalf("Warmup err=%v, want termination and recovery persistence failures", err)
 	}
@@ -375,7 +375,7 @@ func TestWarmupWarnsWhenKeepIsFalse(t *testing.T) {
 	b := testBackend(control, runner, io.Discard)
 	var stderr bytes.Buffer
 	b.rt.Stderr = &stderr
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: "/repo", Name: "my-app"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: "/repo", Name: "my-app"}}); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(stderr.String(), "warmup keeps the MicroVM until explicit stop") {
@@ -782,7 +782,7 @@ func TestProviderFlagsAndEndpointValidation(t *testing.T) {
 func TestProviderConfigFlagBindings(t *testing.T) {
 	const connector = "arn:aws:lambda:eu-west-1:aws:network-connector:synthetic"
 	const role = "arn:aws:iam::123456789012:role/Synthetic"
-	newConfig := func() Config {
+	newConfig := func() core.Config {
 		cfg := core.BaseConfig()
 		cfg.AWSRegion = "eu-west-1"
 		cfg.AWSLambdaMicroVM = core.AWSLambdaMicroVMConfig{
@@ -922,11 +922,11 @@ func testBackend(control *fakeControlPlane, runner *fakeRunner, stdout io.Writer
 	return &backend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt:   Runtime{Stdout: stdout, Stderr: io.Discard},
-		newControl: func(context.Context, Config) (controlPlane, error) {
+		rt:   core.Runtime{Stdout: stdout, Stderr: io.Discard},
+		newControl: func(context.Context, core.Config) (controlPlane, error) {
 			return control, nil
 		},
-		newRunner: func(controlPlane, Config, Runtime) (runnerAPI, error) { return runner, nil },
+		newRunner: func(controlPlane, core.Config, core.Runtime) (runnerAPI, error) { return runner, nil },
 	}
 }
 
@@ -1016,7 +1016,7 @@ func TestRunFinalOutcomeIncludesCleanupAndTiming(t *testing.T) {
 			var stderr bytes.Buffer
 			b.rt.Stderr = &stderr
 			b.rt.Clock = clock
-			result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: testRepo(t), Name: "my-app"}, NoSync: true, KeepOnFailure: tc.keep, SyncOnly: tc.syncOnly, TimingJSON: true, Command: []string{"fixture-user"}})
+			result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: testRepo(t), Name: "my-app"}, NoSync: true, KeepOnFailure: tc.keep, SyncOnly: tc.syncOnly, TimingJSON: true, Command: []string{"fixture-user"}})
 			if err == nil || result.ExitCode != tc.wantCode || result.Status != core.RunStatusFailed || result.ErrorKind != tc.wantKind {
 				t.Errorf("result=%+v err=%v", result, err)
 			}
@@ -1076,7 +1076,7 @@ func TestRunTimingWriterCannotReplaceCommandFailure(t *testing.T) {
 			b := testBackend(control, runner, io.Discard)
 			writerErr := errors.New("synthetic timing writer failure")
 			b.rt.Stderr = &failingTimingWriter{err: writerErr}
-			result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: testRepo(t), Name: "my-app"}, NoSync: true, KeepOnFailure: true, TimingJSON: true, Command: []string{"fixture-user"}})
+			result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: testRepo(t), Name: "my-app"}, NoSync: true, KeepOnFailure: true, TimingJSON: true, Command: []string{"fixture-user"}})
 			wantCode := 7
 			if cause != nil {
 				wantCode = 1
@@ -1106,10 +1106,10 @@ func TestRunPreservesSuccessOnlyClaimRefresh(t *testing.T) {
 				control := &fakeControlPlane{}
 				runner := &fakeRunner{}
 				b := testBackend(control, runner, io.Discard)
-				repo := Repo{Root: testRepo(t), Name: "my-app"}
+				repo := core.Repo{Root: testRepo(t), Name: "my-app"}
 				id := ""
 				if reuse {
-					first, err := b.Run(t.Context(), RunRequest{Repo: repo, NoSync: true, Keep: true, Command: []string{"true"}})
+					first, err := b.Run(t.Context(), core.RunRequest{Repo: repo, NoSync: true, Keep: true, Command: []string{"true"}})
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -1119,7 +1119,7 @@ func TestRunPreservesSuccessOnlyClaimRefresh(t *testing.T) {
 				control.terminateErr = errors.New("synthetic termination refusal")
 				var before core.LeaseClaim
 				runner.onExec = func(_ context.Context, _ string, workdir string) (int, error) {
-					claims, err := listLeaseClaims()
+					claims, err := core.ListLeaseClaims()
 					if err != nil || len(claims) != 1 {
 						t.Fatalf("claims=%v err=%v", claims, err)
 					}
@@ -1135,7 +1135,7 @@ func TestRunPreservesSuccessOnlyClaimRefresh(t *testing.T) {
 					}
 					return 0, nil
 				}
-				result, _ := b.Run(t.Context(), RunRequest{Repo: repo, ID: id, NoSync: true, Keep: mode == "kept-success", KeepOnFailure: true, SyncOnly: mode == "sync-only", Command: []string{"fixture-user"}})
+				result, _ := b.Run(t.Context(), core.RunRequest{Repo: repo, ID: id, NoSync: true, Keep: mode == "kept-success", KeepOnFailure: true, SyncOnly: mode == "sync-only", Command: []string{"fixture-user"}})
 				after, ok, err := resolveLeaseClaim(result.LeaseID)
 				if err != nil || !ok {
 					t.Fatalf("claim ok=%t err=%v", ok, err)
@@ -1156,8 +1156,8 @@ func (f runWriteFunc) Write(p []byte) (int, error) { return f(p) }
 func TestReusedRunHoldsOperationLockThroughFinalReporting(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	b := testBackend(&fakeControlPlane{}, &fakeRunner{}, io.Discard)
-	repo := Repo{Root: testRepo(t), Name: "my-app"}
-	first, err := b.Run(t.Context(), RunRequest{Repo: repo, NoSync: true, Keep: true, Command: []string{"true"}})
+	repo := core.Repo{Root: testRepo(t), Name: "my-app"}
+	first, err := b.Run(t.Context(), core.RunRequest{Repo: repo, NoSync: true, Keep: true, Command: []string{"true"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1177,7 +1177,7 @@ func TestReusedRunHoldsOperationLockThroughFinalReporting(t *testing.T) {
 		}
 		return len(p), nil
 	})
-	if _, err := b.Run(t.Context(), RunRequest{Repo: repo, ID: first.LeaseID, NoSync: true, TimingJSON: true, Command: []string{"true"}}); err != nil {
+	if _, err := b.Run(t.Context(), core.RunRequest{Repo: repo, ID: first.LeaseID, NoSync: true, TimingJSON: true, Command: []string{"true"}}); err != nil {
 		t.Fatal(err)
 	}
 	if !observed {
@@ -1202,7 +1202,7 @@ func TestRunSuccessRefreshPreservesPublicClaimError(t *testing.T) {
 				if workdir == "/" {
 					return 0, nil
 				}
-				claims, err := listLeaseClaims()
+				claims, err := core.ListLeaseClaims()
 				if err != nil || len(claims) != 1 {
 					t.Fatalf("claims=%v err=%v", claims, err)
 				}
@@ -1215,7 +1215,7 @@ func TestRunSuccessRefreshPreservesPublicClaimError(t *testing.T) {
 				return 0, nil
 			}}
 			b := testBackend(control, runner, io.Discard)
-			result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: testRepo(t), Name: "my-app"}, NoSync: true, Keep: keep, KeepOnFailure: true, Command: []string{"fixture-user"}})
+			result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: testRepo(t), Name: "my-app"}, NoSync: true, Keep: keep, KeepOnFailure: true, Command: []string{"fixture-user"}})
 			var public core.ExitError
 			if !core.AsExitError(err, &public) || public.Code != 2 || !strings.Contains(public.Message, "parse claim") {
 				t.Errorf("public code=%d want=2 error=%v", public.Code, err)

--- a/internal/providers/awslambdamicrovm/client.go
+++ b/internal/providers/awslambdamicrovm/client.go
@@ -56,7 +56,7 @@ type controlPlane interface {
 
 type sdkControlPlane struct{ client *lambdamicrovms.Client }
 
-func newControlPlane(ctx context.Context, cfg Config) (controlPlane, error) {
+func newControlPlane(ctx context.Context, cfg core.Config) (controlPlane, error) {
 	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(cfg.AWSRegion))
 	if err != nil {
 		return nil, err

--- a/internal/providers/awslambdamicrovm/core.go
+++ b/internal/providers/awslambdamicrovm/core.go
@@ -7,75 +7,26 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-type Config = core.Config
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type RunSessionHandle = core.RunSessionHandle
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type PauseRequest = core.PauseRequest
-type ResumeRequest = core.ResumeRequest
-type CleanupRequest = core.CleanupRequest
-type Server = core.Server
-type Repo = core.Repo
-type LeaseClaim = core.LeaseClaim
-type ExitError = core.ExitError
-type timingReport = core.TimingReport
-type timingPhase = core.TimingPhase
-
 const (
 	providerName = "aws-lambda-microvm"
 	targetLinux  = core.TargetLinux
 	runnerPort   = 8080
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-func resolveLeaseClaim(identifier string) (LeaseClaim, bool, error) {
+func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaimForProvider(identifier, providerName)
 }
-func listLeaseClaims() ([]LeaseClaim, error) { return core.ListLeaseClaims() }
-func removeLeaseClaim(leaseID string)        { core.RemoveLeaseClaim(leaseID) }
-func claimLease(leaseID, slug, scope, pond, repoRoot string, idle time.Duration, reclaim bool, server Server) error {
+
+func claimLease(leaseID, slug, scope, pond, repoRoot string, idle time.Duration, reclaim bool, server core.Server) error {
 	return core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, scope, pond, repoRoot, idle, reclaim, server, core.SSHTarget{})
 }
-func directLeaseLabels(cfg Config, leaseID, slug string, keep bool, at time.Time) map[string]string {
+func directLeaseLabels(cfg core.Config, leaseID, slug string, keep bool, at time.Time) map[string]string {
 	return core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "serverless", keep, at)
 }
-func touchLeaseLabels(labels map[string]string, cfg Config, state string, at time.Time) map[string]string {
-	return core.TouchDirectLeaseLabels(labels, cfg, state, at)
-}
-func shouldCleanupServer(server Server, at time.Time) (bool, string) {
-	return core.ShouldCleanupServer(server, at)
-}
-func delegatedSyncOptionsError(spec ProviderSpec, req RunRequest) error {
-	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
-}
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
-}
-func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
-	return core.TimingReportWithRunResult(report, result, err)
-}
-func handleDelegatedRunFailure(w io.Writer, req RunRequest, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
+
+func handleDelegatedRunFailure(w io.Writer, req core.RunRequest, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
 	core.HandleDelegatedRunFailure(w, req, providerName, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }
 func printEnvForwardingSummary(w io.Writer, allow []string, env map[string]string) {
 	core.PrintEnvForwardingSummary(w, providerName, "forwarded", allow, env)
 }
-func shellScriptFromArgv(command []string) string { return core.ShellScriptFromArgv(command) }
-func shellQuote(value string) string              { return core.ShellQuote(value) }

--- a/internal/providers/awslambdamicrovm/flags.go
+++ b/internal/providers/awslambdamicrovm/flags.go
@@ -1,7 +1,5 @@
 package awslambdamicrovm
 
-import core "github.com/openclaw/crabbox/internal/cli"
-
 import (
 	"flag"
 	"fmt"
@@ -11,6 +9,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type flagValues struct {
@@ -18,14 +17,14 @@ type flagValues struct {
 	Config core.AWSLambdaMicroVMConfigFlagValues
 }
 
-func registerFlags(fs *flag.FlagSet, defaults Config) any {
+func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return flagValues{
 		Region: fs.String("aws-lambda-microvm-region", defaults.AWSRegion, "AWS Region for Lambda MicroVMs"),
 		Config: core.RegisterAWSLambdaMicroVMConfigFlags(fs, defaults.AWSLambdaMicroVM),
 	}
 }
 
-func applyFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	v, ok := values.(flagValues)
 	if !ok {
 		return nil
@@ -45,34 +44,34 @@ func applyFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 
 var awsRegionPattern = regexp.MustCompile(`^[a-z]{2}(?:-gov)?-[a-z]+-\d+$`)
 
-func validateConfig(cfg Config) error {
+func validateConfig(cfg core.Config) error {
 	region := strings.TrimSpace(cfg.AWSRegion)
 	if !awsRegionPattern.MatchString(region) {
-		return exit(2, "invalid AWS Lambda MicroVM region %q", cfg.AWSRegion)
+		return core.Exit(2, "invalid AWS Lambda MicroVM region %q", cfg.AWSRegion)
 	}
 	image := strings.TrimSpace(cfg.AWSLambdaMicroVM.Image)
 	if image == "" {
-		return exit(3, "AWS Lambda MicroVM image is required; set CRABBOX_AWS_LAMBDA_MICROVM_IMAGE or --aws-lambda-microvm-image")
+		return core.Exit(3, "AWS Lambda MicroVM image is required; set CRABBOX_AWS_LAMBDA_MICROVM_IMAGE or --aws-lambda-microvm-image")
 	}
 	parsed, err := arn.Parse(image)
 	if err != nil || parsed.Service != "lambda" || parsed.Region != region || !strings.HasPrefix(parsed.Resource, "microvm-image:") {
-		return exit(2, "invalid AWS Lambda MicroVM image ARN for region %s", region)
+		return core.Exit(2, "invalid AWS Lambda MicroVM image ARN for region %s", region)
 	}
 	if role := strings.TrimSpace(cfg.AWSLambdaMicroVM.ExecutionRoleARN); role != "" {
 		parsedRole, err := arn.Parse(role)
 		if err != nil || parsedRole.Service != "iam" || !strings.HasPrefix(parsedRole.Resource, "role/") {
-			return exit(2, "invalid AWS Lambda MicroVM execution role ARN")
+			return core.Exit(2, "invalid AWS Lambda MicroVM execution role ARN")
 		}
 	}
 	workdir := strings.TrimSpace(cfg.AWSLambdaMicroVM.Workdir)
 	if workdir == "" || !strings.HasPrefix(workdir, "/") || path.Clean(workdir) != workdir || strings.Contains(workdir, "\x00") {
-		return exit(2, "aws-lambda-microvm workdir must be a clean absolute path below /")
+		return core.Exit(2, "aws-lambda-microvm workdir must be a clean absolute path below /")
 	}
 	if awsLambdaMicroVMBroadWorkdir(workdir) {
-		return exit(2, "aws-lambda-microvm workdir %q is too broad; choose a dedicated subdirectory", workdir)
+		return core.Exit(2, "aws-lambda-microvm workdir %q is too broad; choose a dedicated subdirectory", workdir)
 	}
 	if cfg.IdleTimeout > 0 && cfg.IdleTimeout < time.Minute {
-		return exit(2, "aws-lambda-microvm idle timeout must be at least 60s")
+		return core.Exit(2, "aws-lambda-microvm idle timeout must be at least 60s")
 	}
 	for kind, connectors := range map[string][]string{
 		"ingress": cfg.AWSLambdaMicroVM.IngressConnectors,
@@ -80,7 +79,7 @@ func validateConfig(cfg Config) error {
 	} {
 		for _, connector := range connectors {
 			if err := validateConnectorARN(connector, region); err != nil {
-				return exit(2, "invalid AWS Lambda MicroVM %s connector: %v", kind, err)
+				return core.Exit(2, "invalid AWS Lambda MicroVM %s connector: %v", kind, err)
 			}
 		}
 	}

--- a/internal/providers/awslambdamicrovm/operation_lock.go
+++ b/internal/providers/awslambdamicrovm/operation_lock.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -13,7 +14,7 @@ const leasePrefix = "cbx_"
 func lockAWSLambdaMicroVMLeaseOperation(ctx context.Context, leaseID string) (func(), error) {
 	if !strings.HasPrefix(leaseID, leasePrefix) || strings.TrimPrefix(leaseID, leasePrefix) == "" ||
 		filepath.Base(leaseID) != leaseID || leaseID == "." {
-		return nil, exit(2, "invalid aws-lambda-microvm lease id %q", leaseID)
+		return nil, core.Exit(2, "invalid aws-lambda-microvm lease id %q", leaseID)
 	}
 	return shared.LockLeaseOperation(ctx, "aws-lambda-microvm", leaseID)
 }

--- a/internal/providers/awslambdamicrovm/sync.go
+++ b/internal/providers/awslambdamicrovm/sync.go
@@ -8,7 +8,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *backend) syncWorkspace(ctx context.Context, runner runnerAPI, vm microVM, req RunRequest, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+func (b *backend) syncWorkspace(ctx context.Context, runner runnerAPI, vm microVM, req core.RunRequest, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
@@ -30,7 +30,7 @@ func (b *backend) syncWorkspace(ctx context.Context, runner runnerAPI, vm microV
 				return err
 			}
 			if exitCode != 0 {
-				return exit(exitCode, "%s sync command exited %d", providerName, exitCode)
+				return core.Exit(exitCode, "%s sync command exited %d", providerName, exitCode)
 			}
 			return nil
 		},

--- a/internal/providers/cloudflare/backend.go
+++ b/internal/providers/cloudflare/backend.go
@@ -14,31 +14,31 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func NewCloudflareBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewCloudflareBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	if cfg.ServerType == "" {
 		cfg.ServerType = cloudflareContainerInstanceTypeForClass(cfg.Class)
 	}
-	if normalized, ok := normalizeCloudflareContainerInstanceType(cfg.ServerType); ok {
+	if normalized, ok := core.NormalizeCloudflareContainerInstanceType(cfg.ServerType); ok {
 		cfg.ServerType = normalized
 	}
 	return &cloudflareBackend{spec: spec, cfg: cfg, rt: rt}
 }
 
 type cloudflareBackend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
 var cloudflareDoctorTimeout = 10 * time.Second
 
-func (b *cloudflareBackend) Spec() ProviderSpec { return b.spec }
+func (b *cloudflareBackend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *cloudflareBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *cloudflareBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	client, err := newCloudflareClient(b.cfg, b.rt)
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
 	if cloudflareDoctorTimeout > 0 {
 		var cancel context.CancelFunc
@@ -46,17 +46,17 @@ func (b *cloudflareBackend) Doctor(ctx context.Context, _ DoctorRequest) (Doctor
 		defer cancel()
 	}
 	if err := client.checkAuth(ctx); err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return DoctorResult{
+	return core.DoctorResult{
 		Provider: providerName,
 		Message:  fmt.Sprintf("auth=ready control_plane=ready api=readiness mutation=false runner=%s type=%s runtime=ready", client.baseURL, client.instanceType),
 	}, nil
 }
 
-func (b *cloudflareBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *cloudflareBackend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if req.ActionsRunner {
-		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+		return core.Exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
 	started := core.ClockNow(b.rt.Clock)
 	client, err := newCloudflareClient(b.cfg, b.rt)
@@ -80,16 +80,16 @@ func (b *cloudflareBackend) Warmup(ctx context.Context, req WarmupRequest) error
 	})
 }
 
-func (b *cloudflareBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *cloudflareBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	workdir, err := cloudflareWorkdir(b.cfg)
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	var client *cloudflareClient
-	var claim LeaseClaim
+	var claim core.LeaseClaim
 	var command string
 	bound := func() shared.DelegatedSandbox {
-		return shared.DelegatedSandbox{LeaseID: claim.LeaseID, Slug: core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID)), CleanupCommand: cloudflareCleanupCommand(claim.LeaseID)}
+		return shared.DelegatedSandbox{LeaseID: claim.LeaseID, Slug: core.Blank(claim.Slug, core.NewLeaseSlug(claim.LeaseID)), CleanupCommand: cloudflareCleanupCommand(claim.LeaseID)}
 	}
 	return shared.RunDelegatedSandbox(ctx, req, shared.DelegatedSandboxLifecycle{
 		Provider: providerName, Runtime: b.rt, Workdir: workdir,
@@ -134,7 +134,7 @@ func (b *cloudflareBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		NoSync: func(ctx context.Context) error { return b.prepareWorkspace(ctx, client, claim.LeaseID, workdir) },
 		Command: func(context.Context) (shared.DelegatedSandboxCommand, error) {
 			if req.EnvSummary {
-				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+				core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 			}
 			return shared.DelegatedSandboxCommand{Text: command, Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
 				return client.execStream(ctx, claim.LeaseID, execStreamRequest{Command: command, Cwd: workdir, Env: req.Env, TimeoutMS: durationMillisecondsCeil(b.cfg.TTL)}, stdout, stderr)
@@ -144,30 +144,30 @@ func (b *cloudflareBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 	})
 }
 
-func (b *cloudflareBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *cloudflareBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	claims, err := localCloudflareClaims()
 	if err != nil {
 		return nil, err
 	}
 	if req.Refresh {
 		if len(claims) == 0 {
-			return []LeaseView{}, nil
+			return []core.LeaseView{}, nil
 		}
 		return b.listRefreshed(ctx, claims)
 	}
-	servers := make([]Server, 0, len(claims))
+	servers := make([]core.Server, 0, len(claims))
 	for _, claim := range claims {
 		servers = append(servers, claimToServer(claim, "unknown"))
 	}
 	return servers, nil
 }
 
-func (b *cloudflareBackend) listRefreshed(ctx context.Context, claims []LeaseClaim) ([]LeaseView, error) {
+func (b *cloudflareBackend) listRefreshed(ctx context.Context, claims []core.LeaseClaim) ([]core.LeaseView, error) {
 	client, err := newCloudflareClient(b.cfg, b.rt)
 	if err != nil {
 		return nil, err
 	}
-	servers := make([]Server, 0, len(claims))
+	servers := make([]core.Server, 0, len(claims))
 	defaultInstanceType := client.instanceType
 	for _, claim := range claims {
 		client.instanceType = defaultInstanceType
@@ -187,14 +187,14 @@ func (b *cloudflareBackend) listRefreshed(ctx context.Context, claims []LeaseCla
 	return servers, nil
 }
 
-func (b *cloudflareBackend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *cloudflareBackend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	client, err := newCloudflareClient(b.cfg, b.rt)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	claim, err := resolveCloudflareClaim(req.ID)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	client.useInstanceType(cloudflareClaimInstanceType(claim))
 	deadline := core.ClockNow(b.rt.Clock).Add(req.WaitTimeout)
@@ -204,7 +204,7 @@ func (b *cloudflareBackend) Status(ctx context.Context, req StatusRequest) (Stat
 	for {
 		sandbox, err := client.getSandbox(ctx, claim.LeaseID)
 		if err != nil {
-			return StatusView{}, err
+			return core.StatusView{}, err
 		}
 		view := sandboxStatusView(claim.LeaseID, claim.Slug, sandbox)
 		if cloudflareTerminalState(view.State) {
@@ -214,17 +214,17 @@ func (b *cloudflareBackend) Status(ctx context.Context, req StatusRequest) (Stat
 			return view, nil
 		}
 		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return StatusView{}, exit(5, "timed out waiting for %s container %s to become ready", providerName, claim.LeaseID)
+			return core.StatusView{}, core.Exit(5, "timed out waiting for %s container %s to become ready", providerName, claim.LeaseID)
 		}
 		select {
 		case <-ctx.Done():
-			return StatusView{}, ctx.Err()
+			return core.StatusView{}, ctx.Err()
 		case <-time.After(2 * time.Second):
 		}
 	}
 }
 
-func (b *cloudflareBackend) Stop(ctx context.Context, req StopRequest) error {
+func (b *cloudflareBackend) Stop(ctx context.Context, req core.StopRequest) error {
 	client, err := newCloudflareClient(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -247,7 +247,7 @@ func (b *cloudflareBackend) Stop(ctx context.Context, req StopRequest) error {
 
 // Keep the captured local authority fenced through the native effect. The
 // runner's instance type is a routing preference, not a remote generation CAS.
-func destroyClaimedSandbox(ctx context.Context, client *cloudflareClient, claim LeaseClaim) (bool, error) {
+func destroyClaimedSandbox(ctx context.Context, client *cloudflareClient, claim core.LeaseClaim) (bool, error) {
 	client.useInstanceType(cloudflareClaimInstanceType(claim))
 	missing := false
 	err := core.CleanupLeaseClaimIfUnchangedAfterContext(ctx, claim.LeaseID, claim, true, func() error {
@@ -261,7 +261,7 @@ func destroyClaimedSandbox(ctx context.Context, client *cloudflareClient, claim 
 	return missing, err
 }
 
-func (b *cloudflareBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
+func (b *cloudflareBackend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	client, err := newCloudflareClient(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -317,21 +317,21 @@ func cloudflareNotFoundError(err error) bool {
 }
 
 func cloudflareCleanupCommand(leaseID string) string {
-	return fmt.Sprintf("crabbox stop --provider %s --id %s", providerName, shellQuote(leaseID))
+	return fmt.Sprintf("crabbox stop --provider %s --id %s", providerName, core.ShellQuote(leaseID))
 }
 
-func (b *cloudflareBackend) createSandbox(ctx context.Context, client *cloudflareClient, repo Repo, requestedSlug string) (LeaseClaim, cloudflareContainer, error) {
+func (b *cloudflareBackend) createSandbox(ctx context.Context, client *cloudflareClient, repo core.Repo, requestedSlug string) (core.LeaseClaim, cloudflareContainer, error) {
 	if strings.TrimSpace(repo.Root) == "" {
-		return LeaseClaim{}, cloudflareContainer{}, exit(2, "cloudflare creation requires a repository root for the recovery claim")
+		return core.LeaseClaim{}, cloudflareContainer{}, core.Exit(2, "cloudflare creation requires a repository root for the recovery claim")
 	}
 	leaseID := core.NewLeaseID()
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
-		return LeaseClaim{}, cloudflareContainer{}, err
+		return core.LeaseClaim{}, cloudflareContainer{}, err
 	}
 	workdir, err := cloudflareWorkdir(b.cfg)
 	if err != nil {
-		return LeaseClaim{}, cloudflareContainer{}, err
+		return core.LeaseClaim{}, cloudflareContainer{}, err
 	}
 	labels := map[string]string{"crabbox": "true", "provider": providerName, "lease": leaseID, "slug": slug, "repo": repo.Name, "instance_type": client.instanceType}
 	sandbox, err := client.createSandbox(ctx, createSandboxRequest{
@@ -339,42 +339,42 @@ func (b *cloudflareBackend) createSandbox(ctx context.Context, client *cloudflar
 		InstanceType: client.instanceType, TTLSeconds: durationSecondsCeil(b.cfg.TTL), IdleTimeoutSeconds: durationSecondsCeil(b.cfg.IdleTimeout), Labels: labels,
 	})
 	if err != nil {
-		return LeaseClaim{}, cloudflareContainer{}, err
+		return core.LeaseClaim{}, cloudflareContainer{}, err
 	}
 	if sandbox.ID != leaseID {
-		return LeaseClaim{}, cloudflareContainer{}, fmt.Errorf("cloudflare creation returned unexpected sandbox %q for requested %q; inspect the runner before recovery", sandbox.ID, leaseID)
+		return core.LeaseClaim{}, cloudflareContainer{}, fmt.Errorf("cloudflare creation returned unexpected sandbox %q for requested %q; inspect the runner before recovery", sandbox.ID, leaseID)
 	}
 	claim, err := core.ClaimLeaseForRepoProviderScopePondWithLabels(leaseID, slug, providerName, "", b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, labels)
 	if err != nil {
 		cleanupCtx, cancel := cloudflareCleanupContext()
 		defer cancel()
-		cleanupErr := core.CleanupLeaseClaimIfUnchangedAfterContext(cleanupCtx, leaseID, LeaseClaim{}, false, func() error { return client.destroySandbox(cleanupCtx, leaseID) })
+		cleanupErr := core.CleanupLeaseClaimIfUnchangedAfterContext(cleanupCtx, leaseID, core.LeaseClaim{}, false, func() error { return client.destroySandbox(cleanupCtx, leaseID) })
 		if cleanupErr != nil {
 			err = errors.Join(err, fmt.Errorf("cleanup failed for cloudflare sandbox %s; inspect its claim and runner before recovery: %w", leaseID, cleanupErr))
 		}
-		return LeaseClaim{}, cloudflareContainer{}, err
+		return core.LeaseClaim{}, cloudflareContainer{}, err
 	}
 	return claim, sandbox, nil
 }
 
-func resolveCloudflareClaim(identifier string) (LeaseClaim, error) {
-	claim, ok, err := resolveLeaseClaimForProvider(identifier, providerName)
+func resolveCloudflareClaim(identifier string) (core.LeaseClaim, error) {
+	claim, ok, err := core.ResolveLeaseClaimForProvider(identifier, providerName)
 	if err != nil {
-		return LeaseClaim{}, err
+		return core.LeaseClaim{}, err
 	}
 	if ok {
 		return claim, nil
 	}
 	value := strings.TrimSpace(identifier)
 	if value == "" {
-		return LeaseClaim{}, exit(2, "%s id is required", providerName)
+		return core.LeaseClaim{}, core.Exit(2, "%s id is required", providerName)
 	}
-	return LeaseClaim{}, exit(2, "refusing to use %s sandbox %q without a local Crabbox claim", providerName, value)
+	return core.LeaseClaim{}, core.Exit(2, "refusing to use %s sandbox %q without a local Crabbox claim", providerName, value)
 }
 
-func admitRunClaim(ctx context.Context, captured LeaseClaim, repoRoot string, reclaim bool) (LeaseClaim, error) {
+func admitRunClaim(ctx context.Context, captured core.LeaseClaim, repoRoot string, reclaim bool) (core.LeaseClaim, error) {
 	if err := ctx.Err(); err != nil {
-		return LeaseClaim{}, err
+		return core.LeaseClaim{}, err
 	}
 	if repoRoot == "" {
 		err := core.WithLeaseClaimUnchangedShared(ctx, captured.LeaseID, captured, func() error { return nil })
@@ -391,37 +391,37 @@ func buildCloudflareCommand(command []string, shellMode bool) (string, error) {
 	if shellMode {
 		return strings.Join(command, " "), nil
 	}
-	if shouldUseShell(command) || leadingEnvAssignment(command) {
-		return shellScriptFromArgv(command), nil
+	if core.ShouldUseShell(command) || core.LeadingEnvAssignment(command) {
+		return core.ShellScriptFromArgv(command), nil
 	}
-	return strings.Join(shellWords(command), " "), nil
+	return strings.Join(core.ShellWords(command), " "), nil
 }
 
-func rejectCloudflareSyncOptions(req RunRequest) error {
+func rejectCloudflareSyncOptions(req core.RunRequest) error {
 	if req.ChecksumSync {
-		return exit(2, "%s uses archive sync; --checksum is not supported", providerName)
+		return core.Exit(2, "%s uses archive sync; --checksum is not supported", providerName)
 	}
 	return nil
 }
 
-func cloudflareWorkdir(cfg Config) (string, error) {
+func cloudflareWorkdir(cfg core.Config) (string, error) {
 	workdir := core.Blank(strings.TrimSpace(cfg.Cloudflare.Workdir), core.CloudflareConfigDefaultWorkdir)
 	clean := path.Clean(workdir)
 	if !strings.HasPrefix(clean, "/") {
-		return "", exit(2, "%s workdir %q must resolve to an absolute path", providerName, workdir)
+		return "", core.Exit(2, "%s workdir %q must resolve to an absolute path", providerName, workdir)
 	}
 	switch clean {
 	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspace":
-		return "", exit(2, "%s workdir %q is too broad; choose a dedicated subdirectory", providerName, clean)
+		return "", core.Exit(2, "%s workdir %q is too broad; choose a dedicated subdirectory", providerName, clean)
 	}
 	return clean, nil
 }
 
-func sandboxStatusView(leaseID, slug string, sandbox cloudflareContainer) StatusView {
+func sandboxStatusView(leaseID, slug string, sandbox cloudflareContainer) core.StatusView {
 	server := sandboxToServer(leaseID, slug, sandbox)
-	return StatusView{
+	return core.StatusView{
 		ID:         leaseID,
-		Slug:       core.Blank(slug, newLeaseSlug(leaseID)),
+		Slug:       core.Blank(slug, core.NewLeaseSlug(leaseID)),
 		Provider:   providerName,
 		TargetOS:   targetLinux,
 		State:      server.Status,
@@ -433,20 +433,20 @@ func sandboxStatusView(leaseID, slug string, sandbox cloudflareContainer) Status
 	}
 }
 
-func sandboxToServer(leaseID, slug string, sandbox cloudflareContainer) Server {
+func sandboxToServer(leaseID, slug string, sandbox cloudflareContainer) core.Server {
 	labels := map[string]string{}
 	for k, v := range sandbox.Labels {
 		labels[k] = v
 	}
 	labels["provider"] = providerName
 	labels["lease"] = leaseID
-	labels["slug"] = core.Blank(slug, newLeaseSlug(leaseID))
+	labels["slug"] = core.Blank(slug, core.NewLeaseSlug(leaseID))
 	labels["target"] = targetLinux
 	state := core.Blank(sandbox.State, "running")
 	instanceType := core.Blank(sandbox.InstanceType, providerName)
 	labels["state"] = state
 	labels["instance_type"] = instanceType
-	server := Server{
+	server := core.Server{
 		Provider: providerName,
 		CloudID:  sandbox.ID,
 		Name:     sandbox.ID,
@@ -457,15 +457,15 @@ func sandboxToServer(leaseID, slug string, sandbox cloudflareContainer) Server {
 	return server
 }
 
-func claimToServer(claim LeaseClaim, state string) Server {
+func claimToServer(claim core.LeaseClaim, state string) core.Server {
 	labels := map[string]string{
 		"provider": providerName,
 		"lease":    claim.LeaseID,
-		"slug":     core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID)),
+		"slug":     core.Blank(claim.Slug, core.NewLeaseSlug(claim.LeaseID)),
 		"target":   targetLinux,
 		"state":    state,
 	}
-	server := Server{
+	server := core.Server{
 		Provider: providerName,
 		CloudID:  claim.LeaseID,
 		Name:     claim.LeaseID,
@@ -504,16 +504,16 @@ func durationMillisecondsCeil(duration time.Duration) int64 {
 	return int64((duration + time.Millisecond - 1) / time.Millisecond)
 }
 
-func cloudflareClaimInstanceType(claim LeaseClaim) string {
+func cloudflareClaimInstanceType(claim core.LeaseClaim) string {
 	return claim.Labels["instance_type"]
 }
 
-func localCloudflareClaims() ([]LeaseClaim, error) {
+func localCloudflareClaims() ([]core.LeaseClaim, error) {
 	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return nil, err
 	}
-	var filtered []LeaseClaim
+	var filtered []core.LeaseClaim
 	for _, claim := range claims {
 		if claim.Provider == providerName {
 			filtered = append(filtered, claim)

--- a/internal/providers/cloudflare/backend_test.go
+++ b/internal/providers/cloudflare/backend_test.go
@@ -46,8 +46,8 @@ func TestCloudflareProviderSpec(t *testing.T) {
 }
 
 func TestCloudflareWarmupRejectsActionsRunner(t *testing.T) {
-	backend := &cloudflareBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-	err := backend.Warmup(context.Background(), WarmupRequest{ActionsRunner: true})
+	backend := &cloudflareBackend{rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	err := backend.Warmup(context.Background(), core.WarmupRequest{ActionsRunner: true})
 	if err == nil {
 		t.Fatal("Warmup accepted --actions-runner")
 	}
@@ -56,7 +56,7 @@ func TestCloudflareWarmupRejectsActionsRunner(t *testing.T) {
 	}
 }
 
-func hasCloudflareFeature(features FeatureSet, want Feature) bool {
+func hasCloudflareFeature(features core.FeatureSet, want core.Feature) bool {
 	for _, feature := range features {
 		if feature == want {
 			return true
@@ -66,7 +66,7 @@ func hasCloudflareFeature(features FeatureSet, want Feature) bool {
 }
 
 func TestCloudflareWorkdirRejectsBroadPaths(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Cloudflare.Workdir = "/workspace"
 	if _, err := cloudflareWorkdir(cfg); err == nil {
 		t.Fatal("cloudflareWorkdir accepted broad /workspace path")
@@ -100,7 +100,7 @@ func TestCloudflareStoppedWithCodeIsTerminal(t *testing.T) {
 }
 
 func TestCloudflareTokenFlagIsNotRegistered(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Cloudflare.Token = "secret-token"
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	RegisterCloudflareProviderFlags(fs, cfg)
@@ -115,7 +115,7 @@ func TestCloudflareFlagNormalizationPrecedesValues(t *testing.T) {
 			stored, want            string
 			explicit, visited, fail bool
 		}{{"", "standard-4", false, false, false}, {" STANDARD-2 ", "standard-2", false, true, false}, {"other", "standard-4", false, false, false}, {"other", "other", true, false, true}, {"other", "other", false, true, true}} {
-			cfg := Config{Provider: name, Class: "standard", ServerType: tc.stored, ServerTypeExplicit: tc.explicit}
+			cfg := core.Config{Provider: name, Class: "standard", ServerType: tc.stored, ServerTypeExplicit: tc.explicit}
 			fs := flag.NewFlagSet("test", flag.ContinueOnError)
 			fs.String("type", "", "")
 			if tc.visited {
@@ -135,7 +135,7 @@ func TestCloudflareFlagNormalizationPrecedesValues(t *testing.T) {
 			}
 		}
 	}
-	cfg := Config{Provider: "cloudflare", Class: "standard", ServerType: "standard-4"}
+	cfg := core.Config{Provider: "cloudflare", Class: "standard", ServerType: "standard-4"}
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	values := RegisterCloudflareProviderFlags(fs, cfg)
 	fs.VisitAll(func(f *flag.Flag) {
@@ -143,7 +143,7 @@ func TestCloudflareFlagNormalizationPrecedesValues(t *testing.T) {
 			t.Fatal("token flag registered")
 		}
 	})
-	cfg.Cloudflare = CloudflareConfig{APIURL: "https://example.invalid/prior", Token: "inert", Workdir: "/workspace/prior"}
+	cfg.Cloudflare = core.CloudflareConfig{APIURL: "https://example.invalid/prior", Token: "inert", Workdir: "/workspace/prior"}
 	before := cfg
 	if err := ApplyCloudflareProviderFlags(&cfg, fs, values); err != nil {
 		t.Fatal(err)
@@ -162,30 +162,30 @@ func TestCloudflareFlagNormalizationPrecedesValues(t *testing.T) {
 	if !reflect.DeepEqual(cfg, before) {
 		t.Fatal("wrapper copied token or introduced central provenance marking")
 	}
-	if _, err := (Provider{}).Configure(cfg, Runtime{}); err != nil {
+	if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err != nil {
 		t.Fatalf("Configure URL validation=%v", err)
 	}
 }
 
 func TestCloudflareClientDeferredValidationAndWorkdirDefault(t *testing.T) {
-	cfg := Config{ServerType: "other", ServerTypeExplicit: true}
-	if _, err := newCloudflareClient(cfg, Runtime{HTTP: &http.Client{}}); err == nil || err.Error() != "cloudflare requires --cloudflare-url or CRABBOX_CLOUDFLARE_RUNNER_URL" {
+	cfg := core.Config{ServerType: "other", ServerTypeExplicit: true}
+	if _, err := newCloudflareClient(cfg, core.Runtime{HTTP: &http.Client{}}); err == nil || err.Error() != "cloudflare requires --cloudflare-url or CRABBOX_CLOUDFLARE_RUNNER_URL" {
 		t.Fatalf("URL-first=%v", err)
 	}
 	cfg.Cloudflare.APIURL = "relative"
-	if _, err := newCloudflareClient(cfg, Runtime{HTTP: &http.Client{}}); err == nil || err.Error() != "cloudflare requires CRABBOX_CLOUDFLARE_RUNNER_TOKEN or user-level config" {
+	if _, err := newCloudflareClient(cfg, core.Runtime{HTTP: &http.Client{}}); err == nil || err.Error() != "cloudflare requires CRABBOX_CLOUDFLARE_RUNNER_TOKEN or user-level config" {
 		t.Fatalf("token second=%v", err)
 	}
 	cfg.Cloudflare.Token = "inert"
-	if _, err := newCloudflareClient(cfg, Runtime{HTTP: &http.Client{}}); err == nil || !strings.Contains(err.Error(), "--type must be one of") {
+	if _, err := newCloudflareClient(cfg, core.Runtime{HTTP: &http.Client{}}); err == nil || !strings.Contains(err.Error(), "--type must be one of") {
 		t.Fatalf("type before URL syntax=%v", err)
 	}
 	cfg.ServerType = "standard-2"
-	if _, err := newCloudflareClient(cfg, Runtime{HTTP: &http.Client{}}); err == nil || err.Error() != `cloudflare url "relative" is invalid` {
+	if _, err := newCloudflareClient(cfg, core.Runtime{HTTP: &http.Client{}}); err == nil || err.Error() != `cloudflare url "relative" is invalid` {
 		t.Fatalf("URL syntax=%v", err)
 	}
 	cfg.Cloudflare.APIURL = " https://example.invalid/base/ "
-	client, err := newCloudflareClient(cfg, Runtime{HTTP: &http.Client{}})
+	client, err := newCloudflareClient(cfg, core.Runtime{HTTP: &http.Client{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func TestCloudflareClientDeferredValidationAndWorkdirDefault(t *testing.T) {
 }
 
 func TestCloudflareFlagsApply(t *testing.T) {
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.Cloudflare.Token = "configured-token"
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	values := RegisterCloudflareProviderFlags(fs, cfg)
@@ -229,10 +229,10 @@ func TestCloudflareFlagsApply(t *testing.T) {
 }
 
 func TestCloudflareClientNormalizesBaseURL(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Cloudflare.APIURL = " https://runner.example.com/base/ "
 	cfg.Cloudflare.Token = "token"
-	client, err := newCloudflareClient(cfg, Runtime{})
+	client, err := newCloudflareClient(cfg, core.Runtime{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -242,10 +242,10 @@ func TestCloudflareClientNormalizesBaseURL(t *testing.T) {
 }
 
 func TestCloudflareClientUsesBoundedDefaultTransport(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Cloudflare.APIURL = "http://127.0.0.1:8787"
 	cfg.Cloudflare.Token = "token"
-	client, err := newCloudflareClient(cfg, Runtime{})
+	client, err := newCloudflareClient(cfg, core.Runtime{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -279,10 +279,10 @@ func TestNewCloudflareClientRejectsUnsupportedDefaultTransport(t *testing.T) {
 	recorder := &unusedDefaultRoundTripper{}
 	http.DefaultTransport = recorder
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Cloudflare.APIURL = "http://127.0.0.1:8787"
 	cfg.Cloudflare.Token = "token"
-	client, err := newCloudflareClient(cfg, Runtime{})
+	client, err := newCloudflareClient(cfg, core.Runtime{})
 	if client != nil || err == nil || !strings.Contains(err.Error(), "non-nil *http.Transport") {
 		t.Fatalf("client=%#v err=%v, want transport setup error", client, err)
 	}
@@ -296,11 +296,11 @@ func TestNewCloudflareClientAcceptsExplicitClientWithUnsupportedDefault(t *testi
 	t.Cleanup(func() { http.DefaultTransport = original })
 	http.DefaultTransport = &unusedDefaultRoundTripper{}
 	injected := &http.Client{Transport: &unusedDefaultRoundTripper{}}
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Cloudflare.APIURL = "http://127.0.0.1:8787"
 	cfg.Cloudflare.Token = "token"
 
-	client, err := newCloudflareClient(cfg, Runtime{HTTP: injected})
+	client, err := newCloudflareClient(cfg, core.Runtime{HTTP: injected})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -323,10 +323,10 @@ func TestCloudflareClientRejectsCrossOriginExecRedirectBeforeReplay(t *testing.T
 			}))
 			defer runner.Close()
 
-			cfg := Config{}
+			cfg := core.Config{}
 			cfg.Cloudflare.APIURL = runner.URL
 			cfg.Cloudflare.Token = "token"
-			client, err := newCloudflareClient(cfg, Runtime{HTTP: runner.Client()})
+			client, err := newCloudflareClient(cfg, core.Runtime{HTTP: runner.Client()})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -356,10 +356,10 @@ func TestCloudflareClientRejectsCrossOriginUploadRedirect(t *testing.T) {
 	}))
 	defer runner.Close()
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Cloudflare.APIURL = runner.URL
 	cfg.Cloudflare.Token = "token"
-	client, err := newCloudflareClient(cfg, Runtime{HTTP: runner.Client()})
+	client, err := newCloudflareClient(cfg, core.Runtime{HTTP: runner.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -399,10 +399,10 @@ func TestCloudflareClientAllowsSameOriginRedirectAndPreservesCallerPolicy(t *tes
 		return nil
 	}
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Cloudflare.APIURL = runner.URL
 	cfg.Cloudflare.Token = "token"
-	client, err := newCloudflareClient(cfg, Runtime{HTTP: source})
+	client, err := newCloudflareClient(cfg, core.Runtime{HTTP: source})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -425,10 +425,10 @@ func TestCloudflareClientRejectsURLQueryAndFragment(t *testing.T) {
 		"https://runner.example.com/#sandbox",
 	} {
 		t.Run(rawURL, func(t *testing.T) {
-			cfg := Config{}
+			cfg := core.Config{}
 			cfg.Cloudflare.APIURL = rawURL
 			cfg.Cloudflare.Token = "token"
-			_, err := newCloudflareClient(cfg, Runtime{})
+			_, err := newCloudflareClient(cfg, core.Runtime{})
 			if err == nil {
 				t.Fatal("newCloudflareClient accepted URL query or fragment")
 			}
@@ -445,10 +445,10 @@ func TestCloudflareClientRejectsURLUserinfoWithoutLeakingIt(t *testing.T) {
 		"http://secret-token@runner.example.com",
 	} {
 		t.Run(rawURL, func(t *testing.T) {
-			cfg := Config{}
+			cfg := core.Config{}
 			cfg.Cloudflare.APIURL = rawURL
 			cfg.Cloudflare.Token = "token"
-			_, err := newCloudflareClient(cfg, Runtime{})
+			_, err := newCloudflareClient(cfg, core.Runtime{})
 			if err == nil {
 				t.Fatal("newCloudflareClient accepted URL userinfo")
 			}
@@ -479,12 +479,12 @@ func TestCloudflareDoctorChecksRunnerAuth(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{Provider: providerName, Class: "beast"}
+	cfg := core.Config{Provider: providerName, Class: "beast"}
 	cfg.Cloudflare.APIURL = server.URL
 	cfg.Cloudflare.Token = "token"
 	cfg.ServerType = cloudflareContainerInstanceTypeForClass(cfg.Class)
-	backend := NewCloudflareBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*cloudflareBackend)
-	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	backend := NewCloudflareBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*cloudflareBackend)
+	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -534,10 +534,10 @@ func TestCloudflareClientRedactsStreamError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Cloudflare.APIURL = server.URL
 	cfg.Cloudflare.Token = token
-	client, err := newCloudflareClient(cfg, Runtime{HTTP: server.Client()})
+	client, err := newCloudflareClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -566,15 +566,15 @@ func TestCloudflareDoctorTimesOutStalledRunnerReadiness(t *testing.T) {
 		cloudflareDoctorTimeout = oldTimeout
 	})
 
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.Cloudflare.APIURL = server.URL
 	cfg.Cloudflare.Token = "token"
-	backend := NewCloudflareBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*cloudflareBackend)
+	backend := NewCloudflareBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*cloudflareBackend)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	started := time.Now()
-	_, err := backend.Doctor(ctx, DoctorRequest{})
+	_, err := backend.Doctor(ctx, core.DoctorRequest{})
 	elapsed := time.Since(started)
 	if err == nil {
 		t.Fatal("doctor succeeded against stalled runner")
@@ -594,12 +594,12 @@ func TestCloudflareDoctorRejectsInvalidReadinessPayload(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.Cloudflare.APIURL = server.URL
 	cfg.Cloudflare.Token = "token"
-	backend := NewCloudflareBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*cloudflareBackend)
+	backend := NewCloudflareBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*cloudflareBackend)
 	err := func() error {
-		_, err := backend.Doctor(context.Background(), DoctorRequest{})
+		_, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 		return err
 	}()
 	if err == nil || !strings.Contains(err.Error(), "readiness response is invalid") {
@@ -613,12 +613,12 @@ func TestCloudflareDoctorRejectsWrongRunnerPath(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.Cloudflare.APIURL = server.URL + "/wrong"
 	cfg.Cloudflare.Token = "token"
-	backend := NewCloudflareBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*cloudflareBackend)
+	backend := NewCloudflareBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*cloudflareBackend)
 	err := func() error {
-		_, err := backend.Doctor(context.Background(), DoctorRequest{})
+		_, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 		return err
 	}()
 	if err == nil || !cloudflareNotFoundError(err) {
@@ -632,12 +632,12 @@ func TestCloudflareDoctorRejectsUnauthorizedRunner(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.Cloudflare.APIURL = server.URL
 	cfg.Cloudflare.Token = "wrong"
-	backend := NewCloudflareBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*cloudflareBackend)
+	backend := NewCloudflareBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*cloudflareBackend)
 	err := func() error {
-		_, err := backend.Doctor(context.Background(), DoctorRequest{})
+		_, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 		return err
 	}()
 	if err == nil || !strings.Contains(err.Error(), "unauthorized") {
@@ -646,9 +646,9 @@ func TestCloudflareDoctorRejectsUnauthorizedRunner(t *testing.T) {
 }
 
 func TestCloudflareDoctorRejectsMissingRunnerConfig(t *testing.T) {
-	backend := NewCloudflareBackend(Provider{}.Spec(), Config{Provider: providerName}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*cloudflareBackend)
+	backend := NewCloudflareBackend(Provider{}.Spec(), core.Config{Provider: providerName}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*cloudflareBackend)
 	err := func() error {
-		_, err := backend.Doctor(context.Background(), DoctorRequest{})
+		_, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 		return err
 	}()
 	if err == nil || !strings.Contains(err.Error(), "requires --cloudflare-url") {
@@ -671,17 +671,17 @@ func TestCloudflareCreateSandboxSendsInstanceType(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{Provider: providerName, Class: "fast"}
+	cfg := core.Config{Provider: providerName, Class: "fast"}
 	cfg.ServerType = cloudflareContainerInstanceTypeForClass(cfg.Class)
 	cfg.Cloudflare.APIURL = server.URL
 	cfg.Cloudflare.Token = "token"
-	rt := Runtime{HTTP: server.Client()}
+	rt := core.Runtime{HTTP: server.Client()}
 	backend := NewCloudflareBackend(Provider{}.Spec(), cfg, rt).(*cloudflareBackend)
 	client, err := newCloudflareClient(cfg, rt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	created, _, err := backend.createSandbox(context.Background(), client, Repo{Name: "my-app", Root: t.TempDir()}, "")
+	created, _, err := backend.createSandbox(context.Background(), client, core.Repo{Name: "my-app", Root: t.TempDir()}, "")
 	leaseID, slug := created.LeaseID, created.Slug
 	if err != nil {
 		t.Fatal(err)
@@ -689,7 +689,7 @@ func TestCloudflareCreateSandboxSendsInstanceType(t *testing.T) {
 	if got.InstanceType != "standard-4" {
 		t.Fatalf("instance type = %q, want standard-4", got.InstanceType)
 	}
-	claim, ok, err := resolveLeaseClaimForProvider(slug, providerName)
+	claim, ok, err := core.ResolveLeaseClaimForProvider(slug, providerName)
 	if err != nil || !ok {
 		t.Fatalf("claim for %s ok=%t err=%v", slug, ok, err)
 	}
@@ -700,10 +700,10 @@ func TestCloudflareCreateSandboxSendsInstanceType(t *testing.T) {
 
 func TestCloudflareListRefreshChecksClaimState(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	if err := claimLeaseForRepoProvider("cbx_live", "blue-lobster", providerName, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProvider("cbx_live", "blue-lobster", providerName, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := claimLeaseForRepoProvider("cbx_missing", "red-lobster", providerName, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProvider("cbx_missing", "red-lobster", providerName, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -718,12 +718,12 @@ func TestCloudflareListRefreshChecksClaimState(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Cloudflare.APIURL = server.URL
 	cfg.Cloudflare.Token = "token"
 	cfg.ServerType = "lite"
-	backend := cloudflareBackend{cfg: cfg, rt: Runtime{HTTP: server.Client(), Stderr: io.Discard}}
-	servers, err := backend.List(context.Background(), ListRequest{Refresh: true})
+	backend := cloudflareBackend{cfg: cfg, rt: core.Runtime{HTTP: server.Client(), Stderr: io.Discard}}
+	servers, err := backend.List(context.Background(), core.ListRequest{Refresh: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -752,11 +752,11 @@ func TestCloudflareStatusUsesClaimedInstanceType(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{Provider: providerName, ServerType: "standard-4"}
+	cfg := core.Config{Provider: providerName, ServerType: "standard-4"}
 	cfg.Cloudflare.APIURL = server.URL
 	cfg.Cloudflare.Token = "token"
-	backend := cloudflareBackend{cfg: cfg, rt: Runtime{HTTP: server.Client(), Stderr: io.Discard}}
-	view, err := backend.Status(context.Background(), StatusRequest{ID: "blue-lobster"})
+	backend := cloudflareBackend{cfg: cfg, rt: core.Runtime{HTTP: server.Client(), Stderr: io.Discard}}
+	view, err := backend.Status(context.Background(), core.StatusRequest{ID: "blue-lobster"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -792,18 +792,18 @@ func TestCloudflareArchiveGuardrailUsesFullSnapshotBeforeRemoteWork(t *testing.T
 			calls := 0
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { calls++; http.Error(w, "unexpected remote work", 503) }))
 			defer server.Close()
-			cfg := Config{Provider: providerName, TTL: time.Hour}
+			cfg := core.Config{Provider: providerName, TTL: time.Hour}
 			cfg.Cloudflare.APIURL = server.URL
 			cfg.Cloudflare.Token = "synthetic-token"
 			cfg.Sync.FailBytes = 256
-			req := RunRequest{Repo: Repo{Root: root, Name: "fixture"}, SyncOnly: true}
+			req := core.RunRequest{Repo: core.Repo{Root: root, Name: "fixture"}, SyncOnly: true}
 			if reuse {
 				req.ID = "cbx_sync"
-				if err := claimLeaseForRepoProvider(req.ID, "sync", providerName, root, time.Hour, false); err != nil {
+				if err := core.ClaimLeaseForRepoProvider(req.ID, "sync", providerName, root, time.Hour, false); err != nil {
 					t.Fatal(err)
 				}
 			}
-			backend := cloudflareBackend{cfg: cfg, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+			backend := cloudflareBackend{cfg: cfg, rt: core.Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
 			_, err := backend.Run(context.Background(), req)
 			if err == nil || !strings.Contains(err.Error(), "sync candidate too large") || calls != 0 {
 				t.Fatalf("error=%v remote calls=%d", err, calls)
@@ -838,7 +838,7 @@ func TestCloudflareSyncPreservesWorkspaceUntilReplacement(t *testing.T) {
 			if err := os.WriteFile(old, []byte("original"), 0o600); err != nil {
 				t.Fatal(err)
 			}
-			if err := claimLeaseForRepoProvider("cbx_sync", "sync", providerName, repoRoot, time.Hour, false); err != nil {
+			if err := core.ClaimLeaseForRepoProvider("cbx_sync", "sync", providerName, repoRoot, time.Hour, false); err != nil {
 				t.Fatal(err)
 			}
 			var remoteArchive string
@@ -914,13 +914,13 @@ func TestCloudflareSyncPreservesWorkspaceUntilReplacement(t *testing.T) {
 					_ = os.Remove(remoteArchive)
 				}
 			}()
-			cfg := Config{Provider: providerName, TTL: time.Hour}
+			cfg := core.Config{Provider: providerName, TTL: time.Hour}
 			cfg.Cloudflare.APIURL = server.URL
 			cfg.Cloudflare.Token = "synthetic-token"
 			cfg.Cloudflare.Workdir = workdir
 			cfg.Sync.Delete = mode != "merge"
-			backend := cloudflareBackend{cfg: cfg, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
-			result, err := backend.Run(context.Background(), RunRequest{ID: "cbx_sync", Repo: Repo{Root: repoRoot, Name: "fixture"}, SyncOnly: true})
+			backend := cloudflareBackend{cfg: cfg, rt: core.Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+			result, err := backend.Run(context.Background(), core.RunRequest{ID: "cbx_sync", Repo: core.Repo{Root: repoRoot, Name: "fixture"}, SyncOnly: true})
 			failed := mode == "upload rejected" || mode == "corrupt archive"
 			if (err != nil) != failed {
 				t.Fatalf("Run error=%v, failed=%t", err, failed)
@@ -972,10 +972,10 @@ func TestCloudflareRemoteDiskCheckRejectsSmallContainer(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Cloudflare.APIURL = server.URL
 	cfg.Cloudflare.Token = "token"
-	backend := cloudflareBackend{cfg: cfg, rt: Runtime{HTTP: server.Client(), Stderr: io.Discard}}
+	backend := cloudflareBackend{cfg: cfg, rt: core.Runtime{HTTP: server.Client(), Stderr: io.Discard}}
 	client, err := newCloudflareClient(cfg, backend.rt)
 	if err != nil {
 		t.Fatal(err)
@@ -993,7 +993,7 @@ func TestCloudflareRemoteDiskCheckRejectsSmallContainer(t *testing.T) {
 }
 
 func TestCloudflareAliasAcceptsResourceFlags(t *testing.T) {
-	cfg := Config{Provider: providerAlias, ServerType: cloudflareContainerInstanceTypeForClass("standard")}
+	cfg := core.Config{Provider: providerAlias, ServerType: cloudflareContainerInstanceTypeForClass("standard")}
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	_ = fs.String("class", "", "")
 	values := RegisterCloudflareProviderFlags(fs, cfg)
@@ -1009,7 +1009,7 @@ func TestCloudflareAliasAcceptsResourceFlags(t *testing.T) {
 }
 
 func TestCloudflareRejectsUnsupportedInstanceType(t *testing.T) {
-	cfg := Config{Provider: providerName, ServerType: "ccx63", ServerTypeExplicit: true}
+	cfg := core.Config{Provider: providerName, ServerType: "ccx63", ServerTypeExplicit: true}
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	values := RegisterCloudflareProviderFlags(fs, cfg)
 	if err := ApplyCloudflareProviderFlags(&cfg, fs, values); err == nil {
@@ -1033,10 +1033,10 @@ func TestCloudflareClientExecStream(t *testing.T) {
 	defer server.Close()
 
 	token = "test-token"
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Cloudflare.APIURL = server.URL
 	cfg.Cloudflare.Token = token
-	client, err := newCloudflareClient(cfg, Runtime{HTTP: server.Client()})
+	client, err := newCloudflareClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1091,10 +1091,10 @@ func TestCloudflareClientExecStreamPropagatesWriterErrors(t *testing.T) {
 			}))
 			defer server.Close()
 
-			cfg := Config{}
+			cfg := core.Config{}
 			cfg.Cloudflare.APIURL = server.URL
 			cfg.Cloudflare.Token = "test-token"
-			client, err := newCloudflareClient(cfg, Runtime{HTTP: server.Client()})
+			client, err := newCloudflareClient(cfg, core.Runtime{HTTP: server.Client()})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1114,7 +1114,7 @@ func (w cloudflareErrWriter) Write([]byte) (int, error) {
 
 func TestCloudflareRunReportsCommandErrorAsFailure(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	if err := claimLeaseForRepoProvider("cbx_test", "test-run", providerName, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProvider("cbx_test", "test-run", providerName, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	execCalls := 0
@@ -1134,11 +1134,11 @@ func TestCloudflareRunReportsCommandErrorAsFailure(t *testing.T) {
 	defer server.Close()
 
 	var stderr bytes.Buffer
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Cloudflare.APIURL = server.URL
 	cfg.Cloudflare.Token = "token"
-	backend := cloudflareBackend{cfg: cfg, rt: Runtime{HTTP: server.Client(), Stderr: &stderr, Stdout: io.Discard}}
-	_, err := backend.Run(context.Background(), RunRequest{
+	backend := cloudflareBackend{cfg: cfg, rt: core.Runtime{HTTP: server.Client(), Stderr: &stderr, Stdout: io.Discard}}
+	_, err := backend.Run(context.Background(), core.RunRequest{
 		ID:         "cbx_test",
 		NoSync:     true,
 		Command:    []string{"true"},
@@ -1186,14 +1186,14 @@ func TestCloudflareRunCleanupDestroyUsesBoundedContext(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.Cloudflare.APIURL = server.URL
 	cfg.Cloudflare.Token = "token"
 	var stderr bytes.Buffer
-	backend := cloudflareBackend{cfg: cfg, rt: Runtime{HTTP: server.Client(), Stderr: &stderr, Stdout: io.Discard}}
+	backend := cloudflareBackend{cfg: cfg, rt: core.Runtime{HTTP: server.Client(), Stderr: &stderr, Stdout: io.Discard}}
 	start := time.Now()
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "repo", Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "repo", Root: t.TempDir()},
 		Command: []string{"true"},
 		NoSync:  true,
 	})
@@ -1217,7 +1217,7 @@ func TestCloudflareRunCleanupDestroyUsesBoundedContext(t *testing.T) {
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Fatalf("Run took %s, want bounded cleanup", elapsed)
 	}
-	if _, ok, err := resolveLeaseClaimForProvider(createdID, providerName); err != nil || !ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider(createdID, providerName); err != nil || !ok {
 		t.Fatalf("missing recovery claim: %v", err)
 	}
 }
@@ -1247,12 +1247,12 @@ func TestCloudflareRunKeepReturnsSessionHandle(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.Cloudflare.APIURL = server.URL
 	cfg.Cloudflare.Token = "token"
-	backend := cloudflareBackend{cfg: cfg, rt: Runtime{HTTP: server.Client(), Stderr: io.Discard, Stdout: io.Discard}}
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "repo", Root: t.TempDir()},
+	backend := cloudflareBackend{cfg: cfg, rt: core.Runtime{HTTP: server.Client(), Stderr: io.Discard, Stdout: io.Discard}}
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "repo", Root: t.TempDir()},
 		Command: []string{"true"},
 		NoSync:  true,
 		Keep:    true,
@@ -1326,12 +1326,12 @@ func TestCloudflareRunKeepOnFailureRetainsSession(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.Cloudflare.APIURL = server.URL
 	cfg.Cloudflare.Token = "token"
-	backend := cloudflareBackend{cfg: cfg, rt: Runtime{HTTP: server.Client(), Stderr: io.Discard, Stdout: io.Discard}}
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:          Repo{Name: "repo", Root: t.TempDir()},
+	backend := cloudflareBackend{cfg: cfg, rt: core.Runtime{HTTP: server.Client(), Stderr: io.Discard, Stdout: io.Discard}}
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:          core.Repo{Name: "repo", Root: t.TempDir()},
 		Command:       []string{"false"},
 		NoSync:        true,
 		KeepOnFailure: true,
@@ -1374,10 +1374,10 @@ func TestCloudflareClientUploadSendsContentLength(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Cloudflare.APIURL = server.URL
 	cfg.Cloudflare.Token = "token"
-	client, err := newCloudflareClient(cfg, Runtime{HTTP: server.Client()})
+	client, err := newCloudflareClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1408,10 +1408,10 @@ func TestCloudflareClientRejectsPlainHTTPExceptLoopback(t *testing.T) {
 		{name: "remote http", apiURL: "http://runner.example.test", wantErr: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := Config{}
+			cfg := core.Config{}
 			cfg.Cloudflare.APIURL = tc.apiURL
 			cfg.Cloudflare.Token = "token"
-			_, err := newCloudflareClient(cfg, Runtime{})
+			_, err := newCloudflareClient(cfg, core.Runtime{})
 			if tc.wantErr && err == nil {
 				t.Fatal("expected URL validation error")
 			}
@@ -1467,7 +1467,7 @@ func TestCloudflareUnclaimedIDNeverReachesRunner(t *testing.T) {
 		invoke func(*cloudflareBackend) error
 	}{
 		{name: "run reuse", invoke: func(backend *cloudflareBackend) error {
-			_, err := backend.Run(context.Background(), RunRequest{
+			_, err := backend.Run(context.Background(), core.RunRequest{
 				ID:      "raw-sandbox-id",
 				NoSync:  true,
 				Command: []string{"true"},
@@ -1475,11 +1475,11 @@ func TestCloudflareUnclaimedIDNeverReachesRunner(t *testing.T) {
 			return err
 		}},
 		{name: "status", invoke: func(backend *cloudflareBackend) error {
-			_, err := backend.Status(context.Background(), StatusRequest{ID: "raw-sandbox-id"})
+			_, err := backend.Status(context.Background(), core.StatusRequest{ID: "raw-sandbox-id"})
 			return err
 		}},
 		{name: "stop", invoke: func(backend *cloudflareBackend) error {
-			return backend.Stop(context.Background(), StopRequest{ID: "raw-sandbox-id"})
+			return backend.Stop(context.Background(), core.StopRequest{ID: "raw-sandbox-id"})
 		}},
 	}
 
@@ -1493,12 +1493,12 @@ func TestCloudflareUnclaimedIDNeverReachesRunner(t *testing.T) {
 				http.Error(w, "unexpected request", http.StatusInternalServerError)
 			}))
 			defer server.Close()
-			cfg := Config{Provider: providerName}
+			cfg := core.Config{Provider: providerName}
 			cfg.Cloudflare.APIURL = server.URL
 			cfg.Cloudflare.Token = "token"
 			backend := &cloudflareBackend{
 				cfg: cfg,
-				rt:  Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard},
+				rt:  core.Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard},
 			}
 
 			err := tt.invoke(backend)
@@ -1523,27 +1523,27 @@ func TestCloudflareStatusRetainsExpiredClaim(t *testing.T) {
 	}))
 	defer server.Close()
 
-	if err := claimLeaseForRepoProvider("cbx_expired", "blue-lobster", providerName, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProvider("cbx_expired", "blue-lobster", providerName, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	backend := cloudflareBackend{
-		cfg: Config{
+		cfg: core.Config{
 			Provider: providerName,
-			Cloudflare: CloudflareConfig{
+			Cloudflare: core.CloudflareConfig{
 				APIURL: server.URL,
 				Token:  "token",
 			},
 		},
-		rt: Runtime{HTTP: server.Client()},
+		rt: core.Runtime{HTTP: server.Client()},
 	}
-	view, err := backend.Status(context.Background(), StatusRequest{ID: "blue-lobster", Wait: true, WaitTimeout: time.Nanosecond})
+	view, err := backend.Status(context.Background(), core.StatusRequest{ID: "blue-lobster", Wait: true, WaitTimeout: time.Nanosecond})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if view.State != "expired" {
 		t.Fatalf("state = %q, want expired", view.State)
 	}
-	if _, ok, err := resolveLeaseClaimForProvider("blue-lobster", providerName); err != nil || !ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider("blue-lobster", providerName); err != nil || !ok {
 		t.Fatalf("claim resolved after expired status ok=%t err=%v", ok, err)
 	}
 }
@@ -1559,24 +1559,24 @@ func TestCloudflareStopPrunesMissingClaim(t *testing.T) {
 	}))
 	defer server.Close()
 
-	if err := claimLeaseForRepoProvider("cbx_missing", "stale-claim", providerName, t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProvider("cbx_missing", "stale-claim", providerName, t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	var stdout bytes.Buffer
 	backend := cloudflareBackend{
-		cfg: Config{
+		cfg: core.Config{
 			Provider: providerName,
-			Cloudflare: CloudflareConfig{
+			Cloudflare: core.CloudflareConfig{
 				APIURL: server.URL,
 				Token:  "token",
 			},
 		},
-		rt: Runtime{HTTP: server.Client(), Stdout: &stdout},
+		rt: core.Runtime{HTTP: server.Client(), Stdout: &stdout},
 	}
-	if err := backend.Stop(context.Background(), StopRequest{ID: "stale-claim"}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: "stale-claim"}); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok, err := resolveLeaseClaimForProvider("stale-claim", providerName); err != nil || ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider("stale-claim", providerName); err != nil || ok {
 		t.Fatalf("claim resolved after stale stop ok=%t err=%v", ok, err)
 	}
 	if !strings.Contains(stdout.String(), "removed stale cloudflare claim cbx_missing reason=not-found") {
@@ -1605,10 +1605,10 @@ func TestCloudflareRemoteDiskCheckRejectsZeroOrUnknownAvailable(t *testing.T) {
 			}))
 			defer server.Close()
 
-			cfg := Config{}
+			cfg := core.Config{}
 			cfg.Cloudflare.APIURL = server.URL
 			cfg.Cloudflare.Token = "token"
-			backend := cloudflareBackend{cfg: cfg, rt: Runtime{HTTP: server.Client(), Stderr: io.Discard}}
+			backend := cloudflareBackend{cfg: cfg, rt: core.Runtime{HTTP: server.Client(), Stderr: io.Discard}}
 			client, err := newCloudflareClient(cfg, backend.rt)
 			if err != nil {
 				t.Fatal(err)
@@ -1636,30 +1636,30 @@ func TestCloudflareCleanupPrunesTerminalClaims(t *testing.T) {
 	defer server.Close()
 
 	repo := t.TempDir()
-	if err := claimLeaseForRepoProvider("cbx_expired", "blue-lobster", providerName, repo, time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProvider("cbx_expired", "blue-lobster", providerName, repo, time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := claimLeaseForRepoProvider("cbx_running", "green-lobster", providerName, repo, time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProvider("cbx_running", "green-lobster", providerName, repo, time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	var stdout bytes.Buffer
 	backend := cloudflareBackend{
-		cfg: Config{
+		cfg: core.Config{
 			Provider: providerName,
-			Cloudflare: CloudflareConfig{
+			Cloudflare: core.CloudflareConfig{
 				APIURL: server.URL,
 				Token:  "token",
 			},
 		},
-		rt: Runtime{HTTP: server.Client(), Stdout: &stdout},
+		rt: core.Runtime{HTTP: server.Client(), Stdout: &stdout},
 	}
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok, err := resolveLeaseClaimForProvider("blue-lobster", providerName); err != nil || ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider("blue-lobster", providerName); err != nil || ok {
 		t.Fatalf("expired claim resolved after cleanup ok=%t err=%v", ok, err)
 	}
-	if _, ok, err := resolveLeaseClaimForProvider("green-lobster", providerName); err != nil || !ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider("green-lobster", providerName); err != nil || !ok {
 		t.Fatalf("running claim missing after cleanup ok=%t err=%v", ok, err)
 	}
 	if !bytes.Contains(stdout.Bytes(), []byte("removed=1 checked=2")) {
@@ -1695,20 +1695,20 @@ func TestCloudflareRunFinalizesAfterFailedCleanup(t *testing.T) {
 			}))
 			defer server.Close()
 			var stderr bytes.Buffer
-			backend := cloudflareBackend{cfg: Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: &stderr}}
-			result, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, NoSync: true, Command: []string{"true"}, TimingJSON: true})
+			backend := cloudflareBackend{cfg: core.Config{Cloudflare: core.CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: core.Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: &stderr}}
+			result, err := backend.Run(context.Background(), core.RunRequest{Repo: core.Repo{Name: "repo", Root: t.TempDir()}, NoSync: true, Command: []string{"true"}, TimingJSON: true})
 			wantExit, wantKind := commandExit, "command-exit"
 			if wantExit == 0 {
 				wantExit, wantKind = 1, string(core.RunErrorProvider)
 			}
-			var ee ExitError
+			var ee core.ExitError
 			if !errors.As(err, &ee) || ee.Code != wantExit || result.ExitCode != wantExit || result.Status != "failed" || string(result.ErrorKind) != wantKind {
 				t.Fatalf("result=%+v error=%v, want failed/%s/%d", result, err, wantKind, wantExit)
 			}
 			if deletes != 1 || result.Session == nil || !result.Session.Kept {
 				t.Fatalf("deletes=%d session=%+v", deletes, result.Session)
 			}
-			if _, ok, err := resolveLeaseClaimForProvider(leaseID, providerName); err != nil || !ok {
+			if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil || !ok {
 				t.Fatalf("recovery claim missing: %v", err)
 			}
 			if strings.Count(stderr.String(), `"runStatus"`) != 1 || !strings.Contains(stderr.String(), fmt.Sprintf(`"exitCode":%d`, wantExit)) {
@@ -1721,7 +1721,7 @@ func TestCloudflareRunFinalizesAfterFailedCleanup(t *testing.T) {
 func TestCloudflareFreshPublicationDoesNotReclaimCompetingClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repo := t.TempDir()
-	var competing LeaseClaim
+	var competing core.LeaseClaim
 	deletes := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodDelete {
@@ -1738,8 +1738,8 @@ func TestCloudflareFreshPublicationDoesNotReclaimCompetingClaim(t *testing.T) {
 		_, _ = fmt.Fprintf(w, `{"id":%q,"state":"running"}`, req.ID)
 	}))
 	defer server.Close()
-	backend := cloudflareBackend{cfg: Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
-	err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "repo", Root: repo}, Reclaim: true, Keep: true})
+	backend := cloudflareBackend{cfg: core.Config{Cloudflare: core.CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: core.Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+	err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "repo", Root: repo}, Reclaim: true, Keep: true})
 	if err == nil || deletes != 0 {
 		t.Fatalf("warmup error=%v deletes=%d, want rejected without destructive rollback", err, deletes)
 	}
@@ -1770,8 +1770,8 @@ func TestCloudflareCleanupRequiresConfirmedAbsence(t *testing.T) {
 				_, _ = io.WriteString(w, `{"id":"cbx_recovery","state":"stopped"}`)
 			}))
 			defer server.Close()
-			backend := cloudflareBackend{cfg: Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
-			_ = backend.Cleanup(context.Background(), CleanupRequest{DryRun: probe == "dry-run"})
+			backend := cloudflareBackend{cfg: core.Config{Cloudflare: core.CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: core.Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+			_ = backend.Cleanup(context.Background(), core.CleanupRequest{DryRun: probe == "dry-run"})
 			if err := core.VerifyLeaseClaimUnchanged(claim.LeaseID, claim); err != nil {
 				t.Fatalf("lost recovery claim: %v", err)
 			}
@@ -1814,7 +1814,7 @@ func TestCloudflareAdmissionRejectsStaleClaim(t *testing.T) {
 					}
 				}
 				if change == "remove" {
-					if _, ok, err := resolveLeaseClaimForProvider(captured.LeaseID, providerName); err != nil || ok {
+					if _, ok, err := core.ResolveLeaseClaimForProvider(captured.LeaseID, providerName); err != nil || ok {
 						t.Fatalf("retired claim resurrected: %v", err)
 					}
 				} else if err := core.VerifyLeaseClaimUnchanged(successor.LeaseID, successor); err != nil {
@@ -1830,7 +1830,7 @@ func TestCloudflareRunDoesNotDeleteSuccessorClaim(t *testing.T) {
 		t.Run(fmt.Sprint(commandExit), func(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			var leaseID string
-			var successor LeaseClaim
+			var successor core.LeaseClaim
 			execCalls, deletes := 0, 0
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch {
@@ -1864,8 +1864,8 @@ func TestCloudflareRunDoesNotDeleteSuccessorClaim(t *testing.T) {
 				}
 			}))
 			defer server.Close()
-			backend := cloudflareBackend{cfg: Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
-			result, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, NoSync: true, Command: []string{"true"}})
+			backend := cloudflareBackend{cfg: core.Config{Cloudflare: core.CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: core.Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+			result, err := backend.Run(context.Background(), core.RunRequest{Repo: core.Repo{Name: "repo", Root: t.TempDir()}, NoSync: true, Command: []string{"true"}})
 			wantExit := commandExit
 			if wantExit == 0 {
 				wantExit = 1
@@ -1888,7 +1888,7 @@ func TestCloudflareCleanupDoesNotPruneSuccessor(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			var successor LeaseClaim
+			var successor core.LeaseClaim
 			deletes := 0
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.Method == http.MethodDelete {
@@ -1909,8 +1909,8 @@ func TestCloudflareCleanupDoesNotPruneSuccessor(t *testing.T) {
 				_, _ = io.WriteString(w, `{"id":"cbx_successor","state":"stopped"}`)
 			}))
 			defer server.Close()
-			backend := cloudflareBackend{cfg: Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
-			if err := backend.Cleanup(context.Background(), CleanupRequest{}); err == nil {
+			backend := cloudflareBackend{cfg: core.Config{Cloudflare: core.CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: core.Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+			if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err == nil {
 				t.Fatal("stale cleanup succeeded")
 			}
 			if deletes != 0 {
@@ -1924,13 +1924,13 @@ func TestCloudflareCleanupDoesNotPruneSuccessor(t *testing.T) {
 }
 
 func TestCloudflareFreshRunRequiresRecoveryOwnerAndCommand(t *testing.T) {
-	for _, req := range []RunRequest{{NoSync: true, Command: []string{"true"}}, {NoSync: true, Repo: Repo{Root: t.TempDir()}}, {ID: " ", NoSync: true, Repo: Repo{Root: t.TempDir()}, Command: []string{"true"}}} {
+	for _, req := range []core.RunRequest{{NoSync: true, Command: []string{"true"}}, {NoSync: true, Repo: core.Repo{Root: t.TempDir()}}, {ID: " ", NoSync: true, Repo: core.Repo{Root: t.TempDir()}, Command: []string{"true"}}} {
 		t.Run(fmt.Sprintf("root=%t", req.Repo.Root != ""), func(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			requests := 0
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { requests++; http.Error(w, "unexpected", 500) }))
 			defer server.Close()
-			backend := cloudflareBackend{cfg: Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+			backend := cloudflareBackend{cfg: core.Config{Cloudflare: core.CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: core.Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
 			if _, err := backend.Run(context.Background(), req); err == nil {
 				t.Fatal("invalid run succeeded")
 			}
@@ -1957,7 +1957,7 @@ func TestCloudflareDestroyClaimFenceSpansNativeDelete(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer server.Close()
-	client, err := newCloudflareClient(Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, Runtime{HTTP: server.Client()})
+	client, err := newCloudflareClient(core.Config{Cloudflare: core.CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1967,7 +1967,7 @@ func TestCloudflareDestroyClaimFenceSpansNativeDelete(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
 	called := false
-	err = core.WithDurableLeaseClaimLockContext(ctx, claim.LeaseID, func(*LeaseClaim, bool, func() error) error { called = true; return nil })
+	err = core.WithDurableLeaseClaimLockContext(ctx, claim.LeaseID, func(*core.LeaseClaim, bool, func() error) error { called = true; return nil })
 	close(release)
 	if !errors.Is(err, context.DeadlineExceeded) || called {
 		t.Fatalf("claim writer entered DELETE fence: called=%t err=%v", called, err)
@@ -1975,7 +1975,7 @@ func TestCloudflareDestroyClaimFenceSpansNativeDelete(t *testing.T) {
 	if err := <-done; err != nil {
 		t.Fatal(err)
 	}
-	if _, ok, err := resolveLeaseClaimForProvider(claim.LeaseID, providerName); err != nil || ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider(claim.LeaseID, providerName); err != nil || ok {
 		t.Fatalf("cleanup did not remove exact claim: %v", err)
 	}
 }
@@ -1989,14 +1989,14 @@ func TestCloudflareCanceledDestroyFenceMakesNoRequest(t *testing.T) {
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { requests++ }))
 	defer server.Close()
-	client, err := newCloudflareClient(Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, Runtime{HTTP: server.Client()})
+	client, err := newCloudflareClient(core.Config{Cloudflare: core.CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
 	entered, release := make(chan struct{}), make(chan struct{})
 	done := make(chan error, 1)
 	go func() {
-		done <- core.WithDurableLeaseClaimLockContext(context.Background(), claim.LeaseID, func(*LeaseClaim, bool, func() error) error { close(entered); <-release; return nil })
+		done <- core.WithDurableLeaseClaimLockContext(context.Background(), claim.LeaseID, func(*core.LeaseClaim, bool, func() error) error { close(entered); <-release; return nil })
 	}()
 	<-entered
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
@@ -2043,12 +2043,12 @@ func TestCloudflareRunKeepOnPreparationFailure(t *testing.T) {
 				http.Error(w, "preparation unavailable", http.StatusServiceUnavailable)
 			}))
 			defer server.Close()
-			backend := cloudflareBackend{cfg: Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
-			result, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "repo", Root: repo}, NoSync: noSync, KeepOnFailure: true, Command: []string{"true"}})
+			backend := cloudflareBackend{cfg: core.Config{Cloudflare: core.CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: core.Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+			result, err := backend.Run(context.Background(), core.RunRequest{Repo: core.Repo{Name: "repo", Root: repo}, NoSync: noSync, KeepOnFailure: true, Command: []string{"true"}})
 			if err == nil || result.Session == nil || !result.Session.Kept || deletes != 0 {
 				t.Fatalf("result=%+v error=%v deletes=%d", result, err, deletes)
 			}
-			if _, ok, err := resolveLeaseClaimForProvider(leaseID, providerName); err != nil || !ok {
+			if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil || !ok {
 				t.Fatalf("recovery claim missing: %v", err)
 			}
 		})
@@ -2083,15 +2083,15 @@ func TestCloudflareRunCancellationSurvivesFailedCleanup(t *testing.T) {
 	}))
 	defer server.Close()
 	var stderr bytes.Buffer
-	backend := cloudflareBackend{cfg: Config{Cloudflare: CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: &stderr}}
-	result, err := backend.Run(ctx, RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, NoSync: true, Command: []string{"true"}, TimingJSON: true})
+	backend := cloudflareBackend{cfg: core.Config{Cloudflare: core.CloudflareConfig{APIURL: server.URL, Token: "synthetic-token"}}, rt: core.Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: &stderr}}
+	result, err := backend.Run(ctx, core.RunRequest{Repo: core.Repo{Name: "repo", Root: t.TempDir()}, NoSync: true, Command: []string{"true"}, TimingJSON: true})
 	if !errors.Is(err, context.Canceled) || result.Status != core.RunStatusCanceled || result.Session == nil || !result.Session.Kept || deletes != 1 {
 		t.Fatalf("result=%+v error=%v deletes=%d", result, err, deletes)
 	}
 	if !strings.Contains(stderr.String(), `"runStatus":"canceled"`) || strings.Count(stderr.String(), `"runStatus"`) != 1 {
 		t.Fatalf("timing=%s", stderr.String())
 	}
-	if _, ok, err := resolveLeaseClaimForProvider(leaseID, providerName); err != nil || !ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil || !ok {
 		t.Fatalf("recovery claim missing: %v", err)
 	}
 }

--- a/internal/providers/cloudflare/client.go
+++ b/internal/providers/cloudflare/client.go
@@ -68,37 +68,37 @@ var cloudflareCleanupTimeout = 15 * time.Second
 
 var cloudflareBearerPattern = regexp.MustCompile(`(?i)\bbearer[ \t]+[A-Za-z0-9._~+/=-]+`)
 
-func newCloudflareClient(cfg Config, rt Runtime) (*cloudflareClient, error) {
+func newCloudflareClient(cfg core.Config, rt core.Runtime) (*cloudflareClient, error) {
 	apiURL := strings.TrimSpace(cfg.Cloudflare.APIURL)
 	if apiURL == "" {
-		return nil, exit(2, "%s requires --cloudflare-url or CRABBOX_CLOUDFLARE_RUNNER_URL", providerName)
+		return nil, core.Exit(2, "%s requires --cloudflare-url or CRABBOX_CLOUDFLARE_RUNNER_URL", providerName)
 	}
 	token := strings.TrimSpace(cfg.Cloudflare.Token)
 	if token == "" {
-		return nil, exit(2, "%s requires CRABBOX_CLOUDFLARE_RUNNER_TOKEN or user-level config", providerName)
+		return nil, core.Exit(2, "%s requires CRABBOX_CLOUDFLARE_RUNNER_TOKEN or user-level config", providerName)
 	}
-	instanceType, ok := normalizeCloudflareContainerInstanceType(core.Blank(cfg.ServerType, cloudflareContainerInstanceTypeForClass(cfg.Class)))
+	instanceType, ok := core.NormalizeCloudflareContainerInstanceType(core.Blank(cfg.ServerType, cloudflareContainerInstanceTypeForClass(cfg.Class)))
 	if !ok {
 		if cfg.ServerTypeExplicit {
-			return nil, exit(2, "%s --type must be one of %s", providerName, strings.Join(cloudflareContainerInstanceTypes(), ", "))
+			return nil, core.Exit(2, "%s --type must be one of %s", providerName, strings.Join(core.CloudflareContainerInstanceTypes(), ", "))
 		}
 		instanceType = cloudflareContainerInstanceTypeForClass(cfg.Class)
 	}
 	parsed, err := url.Parse(apiURL)
 	if err != nil {
-		return nil, exit(2, "%s url %q is invalid", providerName, apiURL)
+		return nil, core.Exit(2, "%s url %q is invalid", providerName, apiURL)
 	}
 	if parsed.User != nil {
-		return nil, exit(2, "%s url must not include userinfo", providerName)
+		return nil, core.Exit(2, "%s url must not include userinfo", providerName)
 	}
 	if parsed.Scheme == "" || parsed.Host == "" {
-		return nil, exit(2, "%s url %q is invalid", providerName, apiURL)
+		return nil, core.Exit(2, "%s url %q is invalid", providerName, apiURL)
 	}
 	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
-		return nil, exit(2, "%s url %q must use https unless it targets localhost", providerName, apiURL)
+		return nil, core.Exit(2, "%s url %q must use https unless it targets localhost", providerName, apiURL)
 	}
 	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return nil, exit(2, "%s url %q must not include query or fragment components", providerName, apiURL)
+		return nil, core.Exit(2, "%s url %q must not include query or fragment components", providerName, apiURL)
 	}
 	baseURL := strings.TrimRight(parsed.String(), "/")
 	httpClient := rt.HTTP
@@ -117,7 +117,7 @@ func newCloudflareClient(cfg Config, rt Runtime) (*cloudflareClient, error) {
 }
 
 func (c *cloudflareClient) useInstanceType(instanceType string) {
-	if normalized, ok := normalizeCloudflareContainerInstanceType(instanceType); ok {
+	if normalized, ok := core.NormalizeCloudflareContainerInstanceType(instanceType); ok {
 		c.instanceType = normalized
 	}
 }

--- a/internal/providers/cloudflare/core.go
+++ b/internal/providers/cloudflare/core.go
@@ -1,36 +1,8 @@
 package cloudflare
 
 import (
-	"io"
-	"time"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type CloudflareConfig = core.CloudflareConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type RunSessionHandle = core.RunSessionHandle
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type CleanupRequest = core.CleanupRequest
-type Server = core.Server
-type LeaseClaim = core.LeaseClaim
-type Repo = core.Repo
-type ExitError = core.ExitError
-type FeatureSet = core.FeatureSet
-type Feature = core.Feature
-type timingPhase = core.TimingPhase
 
 const (
 	providerName  = "cloudflare"
@@ -39,58 +11,6 @@ const (
 	networkPublic = core.NetworkPublic
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
-}
-
-func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaimForProvider(identifier, provider)
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
-func cloudflareContainerInstanceTypes() []string {
-	return core.CloudflareContainerInstanceTypes()
-}
-
 func cloudflareContainerInstanceTypeForClass(class string) string {
 	return (Provider{}).ServerTypeForClass(class)
-}
-
-func normalizeCloudflareContainerInstanceType(value string) (string, bool) {
-	return core.NormalizeCloudflareContainerInstanceType(value)
-}
-
-func shellQuote(s string) string {
-	return core.ShellQuote(s)
-}
-
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
-func shellWords(words []string) []string {
-	return core.ShellWords(words)
-}
-
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func leadingEnvAssignment(command []string) bool {
-	return core.LeadingEnvAssignment(command)
 }

--- a/internal/providers/cloudflare/flags.go
+++ b/internal/providers/cloudflare/flags.go
@@ -7,20 +7,20 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func RegisterCloudflareProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterCloudflareProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterCloudflareConfigFlags(fs, defaults.Cloudflare)
 }
 
-func ApplyCloudflareProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyCloudflareProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		instanceType := strings.TrimSpace(cfg.ServerType)
 		if instanceType == "" {
 			instanceType = cloudflareContainerInstanceTypeForClass(cfg.Class)
 		}
-		normalized, ok := normalizeCloudflareContainerInstanceType(instanceType)
+		normalized, ok := core.NormalizeCloudflareContainerInstanceType(instanceType)
 		if !ok {
 			if core.FlagWasSet(fs, "type") || cfg.ServerTypeExplicit {
-				return exit(2, "%s --type must be one of %s", providerName, strings.Join(cloudflareContainerInstanceTypes(), ", "))
+				return core.Exit(2, "%s --type must be one of %s", providerName, strings.Join(core.CloudflareContainerInstanceTypes(), ", "))
 			}
 			normalized = cloudflareContainerInstanceTypeForClass(cfg.Class)
 		}

--- a/internal/providers/cloudflare/sync.go
+++ b/internal/providers/cloudflare/sync.go
@@ -13,14 +13,14 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *cloudflareBackend) prepareArchive(ctx context.Context, req RunRequest) (*core.PreparedArchive, error) {
+func (b *cloudflareBackend) prepareArchive(ctx context.Context, req core.RunRequest) (*core.PreparedArchive, error) {
 	return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
 		TempPattern: "crabbox-cloudflare-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 	})
 }
 
-func (b *cloudflareBackend) syncWorkspace(ctx context.Context, client *cloudflareClient, sandboxID string, req RunRequest, workdir string, prepared *core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+func (b *cloudflareBackend) syncWorkspace(ctx context.Context, client *cloudflareClient, sandboxID string, req core.RunRequest, workdir string, prepared *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	if prepared == nil {
 		var err error
 		prepared, err = b.prepareArchive(ctx, req)
@@ -56,7 +56,7 @@ func (b *cloudflareBackend) syncWorkspace(ctx context.Context, client *cloudflar
 	for i := range phases {
 		if phases[i].Name == "upload" {
 			phases[i].Ms -= diskDuration.Milliseconds()
-			phases = slices.Insert(phases, i, timingPhase{Name: "disk", Ms: diskDuration.Milliseconds()})
+			phases = slices.Insert(phases, i, core.TimingPhase{Name: "disk", Ms: diskDuration.Milliseconds()})
 			break
 		}
 	}
@@ -73,13 +73,13 @@ func (b *cloudflareBackend) checkRemoteDiskForSync(ctx context.Context, client *
 		return err
 	}
 	if !ok {
-		return exit(6, "%s could not determine remote disk headroom for sync", providerName)
+		return core.Exit(6, "%s could not determine remote disk headroom for sync", providerName)
 	}
 	if available <= 0 {
-		return exit(6, "%s remote disk too small for sync: need %s for archive+extract, available %s; use a larger Cloudflare instance_type or reduce sync.exclude", providerName, byteCount(required), byteCount(available))
+		return core.Exit(6, "%s remote disk too small for sync: need %s for archive+extract, available %s; use a larger Cloudflare instance_type or reduce sync.exclude", providerName, byteCount(required), byteCount(available))
 	}
 	if available < required {
-		return exit(6, "%s remote disk too small for sync: need %s for archive+extract, available %s; use a larger Cloudflare instance_type or reduce sync.exclude", providerName, byteCount(required), byteCount(available))
+		return core.Exit(6, "%s remote disk too small for sync: need %s for archive+extract, available %s; use a larger Cloudflare instance_type or reduce sync.exclude", providerName, byteCount(required), byteCount(available))
 	}
 	const lowHeadroom = 1 << 30
 	if remaining := available - required; remaining < lowHeadroom {
@@ -89,7 +89,7 @@ func (b *cloudflareBackend) checkRemoteDiskForSync(ctx context.Context, client *
 }
 
 func (b *cloudflareBackend) remoteDiskAvailable(ctx context.Context, client *cloudflareClient, sandboxID, workdir string) (int64, bool, error) {
-	command := "set -o pipefail; df -B1 --output=avail,target /tmp " + shellQuote(workdir) + " | tail -n +2"
+	command := "set -o pipefail; df -B1 --output=avail,target /tmp " + core.ShellQuote(workdir) + " | tail -n +2"
 	var stdout bytes.Buffer
 	if err := b.execShell(ctx, client, sandboxID, command, &stdout); err != nil {
 		return 0, false, err
@@ -129,7 +129,7 @@ func byteCount(bytes int64) string {
 }
 
 func (b *cloudflareBackend) prepareWorkspace(ctx context.Context, client *cloudflareClient, sandboxID, workdir string) error {
-	return b.execShell(ctx, client, sandboxID, "mkdir -p "+shellQuote(workdir), io.Discard)
+	return b.execShell(ctx, client, sandboxID, "mkdir -p "+core.ShellQuote(workdir), io.Discard)
 }
 
 func (b *cloudflareBackend) execShell(ctx context.Context, client *cloudflareClient, sandboxID, command string, stdout io.Writer) error {
@@ -142,7 +142,7 @@ func (b *cloudflareBackend) execShell(ctx context.Context, client *cloudflareCli
 		return fmt.Errorf("%s exec %q: %w", providerName, command, err)
 	}
 	if code != 0 {
-		return exit(code, "%s exec %q exited %d", providerName, command, code)
+		return core.Exit(code, "%s exec %q exited %d", providerName, command, code)
 	}
 	return nil
 }

--- a/internal/providers/cloudflaredynamicworkers/backend.go
+++ b/internal/providers/cloudflaredynamicworkers/backend.go
@@ -17,51 +17,51 @@ import (
 )
 
 type backend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
-func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	cfg.TargetOS = targetWorker
 	return &backend{spec: spec, cfg: cfg, rt: rt}
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	client, err := newLoaderAPI(b.cfg, b.rt)
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
 	readiness, err := client.Readiness(ctx)
 	if err != nil {
-		return DoctorResult{}, providerError("readiness", err)
+		return core.DoctorResult{}, providerError("readiness", err)
 	}
-	checks := []DoctorCheck{
+	checks := []core.DoctorCheck{
 		{Status: "pass", Check: "loader-api", Message: "readiness endpoint reachable"},
 	}
 	status := "pass"
 	if !readiness.OK || readiness.Runner != providerName || !readiness.LoaderBinding || !readiness.CoordinatorBinding || !readiness.DurableRunMetadata {
 		status = "fail"
 		if !readiness.OK {
-			checks = append(checks, DoctorCheck{Status: "fail", Check: "ok", Message: "readiness did not report ok=true"})
+			checks = append(checks, core.DoctorCheck{Status: "fail", Check: "ok", Message: "readiness did not report ok=true"})
 		}
 		if readiness.Runner != providerName {
-			checks = append(checks, DoctorCheck{Status: "fail", Check: "runner", Message: fmt.Sprintf("readiness runner=%s", core.Blank(readiness.Runner, "-"))})
+			checks = append(checks, core.DoctorCheck{Status: "fail", Check: "runner", Message: fmt.Sprintf("readiness runner=%s", core.Blank(readiness.Runner, "-"))})
 		}
 		if !readiness.LoaderBinding {
-			checks = append(checks, DoctorCheck{Status: "fail", Check: "loader-binding", Message: "Dynamic Workers binding unavailable"})
+			checks = append(checks, core.DoctorCheck{Status: "fail", Check: "loader-binding", Message: "Dynamic Workers binding unavailable"})
 		}
 		if !readiness.CoordinatorBinding {
-			checks = append(checks, DoctorCheck{Status: "fail", Check: "coordinator-binding", Message: "RUN_COORDINATOR Durable Object binding unavailable"})
+			checks = append(checks, core.DoctorCheck{Status: "fail", Check: "coordinator-binding", Message: "RUN_COORDINATOR Durable Object binding unavailable"})
 		}
 		if !readiness.DurableRunMetadata {
-			checks = append(checks, DoctorCheck{Status: "fail", Check: "run-metadata", Message: "RUNS KV binding unavailable"})
+			checks = append(checks, core.DoctorCheck{Status: "fail", Check: "run-metadata", Message: "RUNS KV binding unavailable"})
 		}
 	}
-	return DoctorResult{
+	return core.DoctorResult{
 		Provider: providerName,
 		Status:   status,
 		Message:  fmt.Sprintf("auth=ready control_plane=ready api=readiness mutation=false runner=%s loader_binding=%t coordinator_binding=%t durable_run_metadata=%t compatibility_date=%s egress=%s", core.Blank(readiness.Runner, "-"), readiness.LoaderBinding, readiness.CoordinatorBinding, readiness.DurableRunMetadata, core.Blank(readiness.CompatibilityDate, "-"), core.Blank(readiness.Egress, "-")),
@@ -69,36 +69,36 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	}, nil
 }
 
-func (b *backend) Warmup(context.Context, WarmupRequest) error {
-	return exit(2, "provider=%s requires module source; use crabbox run --script <file>", providerName)
+func (b *backend) Warmup(context.Context, core.WarmupRequest) error {
+	return core.Exit(2, "provider=%s requires module source; use crabbox run --script <file>", providerName)
 }
 
-func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
-	if err := rejectDelegatedSyncOptions(b.spec, req); err != nil {
-		return RunResult{}, err
+func (b *backend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
+	if err := core.RejectDelegatedSyncOptionsForSpec(b.spec, req); err != nil {
+		return core.RunResult{}, err
 	}
 	if req.Script == nil || len(req.Script.Data) == 0 {
-		return RunResult{}, exit(2, "%s requires --script or --script-stdin module source", providerName)
+		return core.RunResult{}, core.Exit(2, "%s requires --script or --script-stdin module source", providerName)
 	}
 	started := core.ClockNow(b.rt.Clock)
 	client, err := newLoaderAPI(b.cfg, b.rt)
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	cacheMode := normalizeCacheMode(b.cfg.CloudflareDynamicWorkers.CacheMode)
 	if cacheMode == "" {
 		cacheMode = "stable"
 	}
 	if normalizeEgress(b.cfg.CloudflareDynamicWorkers.Egress) == "intercept" && cacheMode != "one-shot" {
-		return RunResult{}, exit(2, "%s egress=intercept requires cache=one-shot because gateway context is run-scoped", providerName)
+		return core.RunResult{}, core.Exit(2, "%s egress=intercept requires cache=one-shot because gateway context is run-scoped", providerName)
 	}
 	leaseID, workerID, slug, reused, err := b.runIdentity(req, cacheMode)
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	loaderReq := b.buildRunRequest(req, leaseID, workerID, cacheMode)
 	if req.EnvSummary {
-		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+		core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
 	commandStarted := core.ClockNow(b.rt.Clock)
 	req.Observation.Phase(core.RunPhaseCommand)
@@ -107,7 +107,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if err != nil {
 		total := core.ClockNow(b.rt.Clock).Sub(started)
 		timingWritten := false
-		result := RunResult{
+		result := core.RunResult{
 			ExitCode:    1,
 			Command:     commandDuration,
 			Total:       total,
@@ -134,7 +134,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 				status.WorkerID = workerID
 			}
 			if strings.TrimSpace(slug) == "" {
-				slug = newLeaseSlug(leaseID)
+				slug = core.NewLeaseSlug(leaseID)
 				result.Slug = slug
 			}
 			server := runServer(leaseID, slug, status, mergeRunLabels(status.Metadata, map[string]string{
@@ -160,7 +160,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			total = core.ClockNow(b.rt.Clock).Sub(started)
 			result.Total = total
 			if req.TimingJSON {
-				report := timingReportWithProviderError(timingReportWithRunResult(timingReport{
+				report := timingReportWithProviderError(core.TimingReportWithRunResult(core.TimingReport{
 					Provider:  providerName,
 					LeaseID:   leaseID,
 					Slug:      slug,
@@ -169,7 +169,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 					ExitCode:  1,
 					Label:     strings.TrimSpace(req.Label),
 				}, result, err))
-				if timingErr := writeTimingJSON(b.rt.Stderr, report); timingErr != nil {
+				if timingErr := core.WriteTimingJSON(b.rt.Stderr, report); timingErr != nil {
 					return result, timingErr
 				}
 				timingWritten = true
@@ -188,7 +188,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			}
 		}
 		if req.TimingJSON && !timingWritten {
-			report := timingReportWithProviderError(timingReportWithRunResult(timingReport{
+			report := timingReportWithProviderError(core.TimingReportWithRunResult(core.TimingReport{
 				Provider:  providerName,
 				LeaseID:   leaseID,
 				Slug:      slug,
@@ -197,16 +197,16 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 				ExitCode:  result.ExitCode,
 				Label:     strings.TrimSpace(req.Label),
 			}, result, err))
-			if timingErr := writeTimingJSON(b.rt.Stderr, report); timingErr != nil {
+			if timingErr := core.WriteTimingJSON(b.rt.Stderr, report); timingErr != nil {
 				return result, timingErr
 			}
 		}
-		return result, ExitError{Code: 1, Message: fmt.Sprintf("%s run failed: %v", providerName, err)}
+		return result, core.ExitError{Code: 1, Message: fmt.Sprintf("%s run failed: %v", providerName, err)}
 	}
 	if strings.TrimSpace(run.ID) != "" {
 		leaseID = run.ID
 		if strings.TrimSpace(slug) == "" {
-			slug = newLeaseSlug(leaseID)
+			slug = core.NewLeaseSlug(leaseID)
 		}
 	}
 	if strings.TrimSpace(run.WorkerID) == "" {
@@ -251,11 +251,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	var runErr error
 	if exitCode != 0 {
-		runErr = ExitError{Code: exitCode, Message: fmt.Sprintf("%s run exited %d", providerName, exitCode)}
+		runErr = core.ExitError{Code: exitCode, Message: fmt.Sprintf("%s run exited %d", providerName, exitCode)}
 	}
 	total := core.ClockNow(b.rt.Clock).Sub(started)
 	keepRun := req.Keep || cacheMode == "explicit" || (req.KeepOnFailure && exitCode != 0) || run.LifecycleUncertain
-	result := RunResult{
+	result := core.RunResult{
 		ExitCode:    exitCode,
 		Command:     commandDuration,
 		Total:       total,
@@ -298,7 +298,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		}
 	}
 	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
+		if err := core.WriteTimingJSON(b.rt.Stderr, core.TimingReportWithRunResult(core.TimingReport{
 			Provider:  providerName,
 			LeaseID:   leaseID,
 			Slug:      slug,
@@ -321,13 +321,13 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	return result, nil
 }
 
-func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	claims, err := providerClaims(b.cfg)
 	if err != nil {
 		return nil, err
 	}
 	if !req.Refresh {
-		views := make([]LeaseView, 0, len(claims))
+		views := make([]core.LeaseView, 0, len(claims))
 		for _, claim := range claims {
 			views = append(views, claimServer(claim, "unknown"))
 		}
@@ -337,7 +337,7 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 	if err != nil {
 		return nil, err
 	}
-	views := make([]LeaseView, 0, len(claims))
+	views := make([]core.LeaseView, 0, len(claims))
 	for _, claim := range claims {
 		status, err := client.Status(ctx, claim.LeaseID)
 		if err != nil {
@@ -349,19 +349,19 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 			views = append(views, claimServer(claim, "unknown"))
 			continue
 		}
-		views = append(views, runServer(claim.LeaseID, core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID)), status, mergeRunLabels(claim.Labels, status.Metadata)))
+		views = append(views, runServer(claim.LeaseID, core.Blank(claim.Slug, core.NewLeaseSlug(claim.LeaseID)), status, mergeRunLabels(claim.Labels, status.Metadata)))
 	}
 	return views, nil
 }
 
-func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	client, err := newLoaderAPI(b.cfg, b.rt)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	leaseID, slug, _, _, err := b.resolveRunID(req.ID, "", false)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	deadline := core.ClockNow(b.rt.Clock).Add(req.WaitTimeout)
 	if req.WaitTimeout <= 0 {
@@ -373,24 +373,24 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 			if notFoundError(err) {
 				return statusView(leaseID, slug, runStatus{ID: leaseID, Status: "missing"}), nil
 			}
-			return StatusView{}, providerError("status", err)
+			return core.StatusView{}, providerError("status", err)
 		}
 		view := statusView(leaseID, slug, status)
 		if !req.Wait || view.Ready || terminalState(view.State) {
 			return view, nil
 		}
 		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return StatusView{}, exit(5, "timed out waiting for %s run %s to become ready", providerName, leaseID)
+			return core.StatusView{}, core.Exit(5, "timed out waiting for %s run %s to become ready", providerName, leaseID)
 		}
 		select {
 		case <-ctx.Done():
-			return StatusView{}, ctx.Err()
+			return core.StatusView{}, ctx.Err()
 		case <-time.After(2 * time.Second):
 		}
 	}
 }
 
-func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+func (b *backend) Stop(ctx context.Context, req core.StopRequest) error {
 	client, err := newLoaderAPI(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -400,11 +400,11 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 		return err
 	}
 	if !claimed {
-		return exit(2, "%s refusing to delete run %s without an exact local claim for the configured loader endpoint", providerName, leaseID)
+		return core.Exit(2, "%s refusing to delete run %s without an exact local claim for the configured loader endpoint", providerName, leaseID)
 	}
 	if err := client.Delete(ctx, leaseID); err != nil {
 		if notFoundError(err) {
-			if err := removeLeaseClaimIfUnchanged(leaseID, claim); err != nil {
+			if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
 				return err
 			}
 			fmt.Fprintf(b.rt.Stdout, "removed stale %s claim %s reason=not-found\n", providerName, leaseID)
@@ -412,14 +412,14 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 		}
 		return providerError("delete metadata", err)
 	}
-	if err := removeLeaseClaimIfUnchanged(leaseID, claim); err != nil {
+	if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
 		return err
 	}
 	fmt.Fprintf(b.rt.Stdout, "stopped %s provider=%s loader_metadata=%s\n", leaseID, providerName, leaseID)
 	return nil
 }
 
-func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
+func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	client, err := newLoaderAPI(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -440,7 +440,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 				fmt.Fprintf(b.rt.Stdout, "would remove stale %s claim %s slug=%s reason=not-found\n", providerName, claim.LeaseID, core.Blank(claim.Slug, "-"))
 				continue
 			}
-			if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+			if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 				fmt.Fprintf(b.rt.Stderr, "warning: %s claim removal failed for %s: %v\n", providerName, claim.LeaseID, err)
 				continue
 			}
@@ -459,7 +459,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			fmt.Fprintf(b.rt.Stderr, "warning: %s metadata delete failed for %s: %v\n", providerName, claim.LeaseID, err)
 			continue
 		}
-		if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+		if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 			fmt.Fprintf(b.rt.Stderr, "warning: %s claim removal failed for %s: %v\n", providerName, claim.LeaseID, err)
 			continue
 		}
@@ -472,28 +472,28 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	return nil
 }
 
-func (b *backend) runIdentity(req RunRequest, cacheMode string) (string, string, string, bool, error) {
+func (b *backend) runIdentity(req core.RunRequest, cacheMode string) (string, string, string, bool, error) {
 	if cacheMode == "explicit" {
 		if strings.TrimSpace(req.ID) == "" {
-			return "", "", "", false, exit(2, "%s cache=explicit requires --id", providerName)
+			return "", "", "", false, core.Exit(2, "%s cache=explicit requires --id", providerName)
 		}
 		leaseID := core.NewLeaseID()
-		slug, err := allocateClaimLeaseSlug(leaseID, req.RequestedSlug)
+		slug, err := core.AllocateClaimLeaseSlug(leaseID, req.RequestedSlug)
 		if err != nil {
 			return "", "", "", false, err
 		}
 		return leaseID, strings.TrimSpace(req.ID), slug, true, nil
 	}
 	if strings.TrimSpace(req.ID) != "" {
-		return "", "", "", false, exit(2, "%s --id requires cache=explicit", providerName)
+		return "", "", "", false, core.Exit(2, "%s --id requires cache=explicit", providerName)
 	}
 	if cacheMode == "stable" {
 		leaseID := core.NewLeaseID()
 		workerID := stableRunID(workerModuleName(req.Script), req.Script.Data, b.cfg.CloudflareDynamicWorkers, req.Env)
-		slug := newLeaseSlug(leaseID)
+		slug := core.NewLeaseSlug(leaseID)
 		if req.Keep || req.KeepOnFailure {
 			var err error
-			slug, err = allocateClaimLeaseSlug(leaseID, req.RequestedSlug)
+			slug, err = core.AllocateClaimLeaseSlug(leaseID, req.RequestedSlug)
 			if err != nil {
 				return "", "", "", false, err
 			}
@@ -505,7 +505,7 @@ func (b *backend) runIdentity(req RunRequest, cacheMode string) (string, string,
 	if req.Keep || req.KeepOnFailure {
 		leaseID = core.NewLeaseID()
 		var err error
-		slug, err = allocateClaimLeaseSlug(leaseID, req.RequestedSlug)
+		slug, err = core.AllocateClaimLeaseSlug(leaseID, req.RequestedSlug)
 		if err != nil {
 			return "", "", "", false, err
 		}
@@ -513,28 +513,28 @@ func (b *backend) runIdentity(req RunRequest, cacheMode string) (string, string,
 	return leaseID, "", slug, false, nil
 }
 
-func (b *backend) resolveRunID(identifier, repoRoot string, reclaim bool) (string, string, LeaseClaim, bool, error) {
+func (b *backend) resolveRunID(identifier, repoRoot string, reclaim bool) (string, string, core.LeaseClaim, bool, error) {
 	claim, ok, err := resolveLeaseClaim(identifier, b.cfg)
 	if err != nil {
-		return "", "", LeaseClaim{}, false, err
+		return "", "", core.LeaseClaim{}, false, err
 	}
 	if ok {
 		if repoRoot != "" {
 			server := claimServer(claim, core.Blank(claim.Labels["state"], "unknown"))
 			if err := claimLease(claim.LeaseID, claim.Slug, b.cfg, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim, server); err != nil {
-				return "", "", LeaseClaim{}, false, err
+				return "", "", core.LeaseClaim{}, false, err
 			}
 		}
-		return claim.LeaseID, core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID)), claim, true, nil
+		return claim.LeaseID, core.Blank(claim.Slug, core.NewLeaseSlug(claim.LeaseID)), claim, true, nil
 	}
 	value := strings.TrimSpace(identifier)
 	if value == "" {
-		return "", "", LeaseClaim{}, false, exit(2, "%s id is required", providerName)
+		return "", "", core.LeaseClaim{}, false, core.Exit(2, "%s id is required", providerName)
 	}
-	return value, newLeaseSlug(value), LeaseClaim{}, false, nil
+	return value, core.NewLeaseSlug(value), core.LeaseClaim{}, false, nil
 }
 
-func (b *backend) buildRunRequest(req RunRequest, leaseID, workerID, cacheMode string) runRequest {
+func (b *backend) buildRunRequest(req core.RunRequest, leaseID, workerID, cacheMode string) runRequest {
 	cfg := b.cfg.CloudflareDynamicWorkers
 	return runRequest{
 		ID:                 leaseID,
@@ -553,7 +553,7 @@ func (b *backend) buildRunRequest(req RunRequest, leaseID, workerID, cacheMode s
 	}
 }
 
-func runMetadata(configured map[string]string, req RunRequest) map[string]string {
+func runMetadata(configured map[string]string, req core.RunRequest) map[string]string {
 	out := map[string]string{
 		"provider": providerName,
 		"source":   workerModuleName(req.Script),
@@ -604,7 +604,7 @@ func writeStderrPart(stderr io.Writer, value string) {
 	}
 }
 
-func workerModuleName(script *RunScriptSpec) string {
+func workerModuleName(script *core.RunScriptSpec) string {
 	if script == nil {
 		return "index.js"
 	}
@@ -653,7 +653,7 @@ func workerModuleName(script *RunScriptSpec) string {
 	return result
 }
 
-func stableRunID(moduleName string, source []byte, cfg CloudflareDynamicWorkersConfig, env map[string]string) string {
+func stableRunID(moduleName string, source []byte, cfg core.CloudflareDynamicWorkersConfig, env map[string]string) string {
 	h := sha256.New()
 	_, _ = h.Write([]byte(strings.TrimSpace(moduleName)))
 	_, _ = h.Write([]byte{0})
@@ -703,16 +703,16 @@ func durationMillisecondsCeil(duration time.Duration) int64 {
 	return int64((duration + time.Millisecond - 1) / time.Millisecond)
 }
 
-func providerClaims(cfg Config) ([]LeaseClaim, error) {
+func providerClaims(cfg core.Config) ([]core.LeaseClaim, error) {
 	scope, err := loaderClaimScope(cfg)
 	if err != nil {
 		return nil, err
 	}
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return nil, err
 	}
-	out := make([]LeaseClaim, 0, len(claims))
+	out := make([]core.LeaseClaim, 0, len(claims))
 	for _, claim := range claims {
 		if claim.Provider == providerName && claim.ProviderScope == scope {
 			out = append(out, claim)
@@ -721,15 +721,15 @@ func providerClaims(cfg Config) ([]LeaseClaim, error) {
 	return out, nil
 }
 
-func claimServer(claim LeaseClaim, state string) Server {
-	return runServer(claim.LeaseID, core.Blank(claim.Slug, newLeaseSlug(claim.LeaseID)), runStatus{ID: claim.LeaseID, Status: state}, claim.Labels)
+func claimServer(claim core.LeaseClaim, state string) core.Server {
+	return runServer(claim.LeaseID, core.Blank(claim.Slug, core.NewLeaseSlug(claim.LeaseID)), runStatus{ID: claim.LeaseID, Status: state}, claim.Labels)
 }
 
-func runServer(leaseID, slug string, status runStatus, extra map[string]string) Server {
+func runServer(leaseID, slug string, status runStatus, extra map[string]string) core.Server {
 	labels := map[string]string{
 		"provider": providerName,
 		"lease":    leaseID,
-		"slug":     core.Blank(slug, newLeaseSlug(leaseID)),
+		"slug":     core.Blank(slug, core.NewLeaseSlug(leaseID)),
 		"target":   targetWorker,
 		"state":    core.Blank(status.Status, "unknown"),
 	}
@@ -743,7 +743,7 @@ func runServer(leaseID, slug string, status runStatus, extra map[string]string) 
 	}
 	labels["provider"] = providerName
 	labels["lease"] = leaseID
-	labels["slug"] = core.Blank(slug, newLeaseSlug(leaseID))
+	labels["slug"] = core.Blank(slug, core.NewLeaseSlug(leaseID))
 	labels["target"] = targetWorker
 	labels["state"] = core.Blank(status.Status, "unknown")
 	if strings.TrimSpace(status.WorkerID) != "" {
@@ -751,7 +751,7 @@ func runServer(leaseID, slug string, status runStatus, extra map[string]string) 
 	} else {
 		delete(labels, "worker_id")
 	}
-	server := Server{
+	server := core.Server{
 		Provider: providerName,
 		CloudID:  leaseID,
 		Name:     leaseID,
@@ -762,11 +762,11 @@ func runServer(leaseID, slug string, status runStatus, extra map[string]string) 
 	return server
 }
 
-func statusView(leaseID, slug string, status runStatus) StatusView {
+func statusView(leaseID, slug string, status runStatus) core.StatusView {
 	server := runServer(leaseID, slug, status, status.Metadata)
-	return StatusView{
+	return core.StatusView{
 		ID:         leaseID,
-		Slug:       core.Blank(slug, newLeaseSlug(leaseID)),
+		Slug:       core.Blank(slug, core.NewLeaseSlug(leaseID)),
 		Provider:   providerName,
 		TargetOS:   targetWorker,
 		State:      server.Status,
@@ -826,8 +826,8 @@ type coreRunSessionHandle struct {
 	CleanupCommand string
 }
 
-func (h *coreRunSessionHandle) toCore() *RunSessionHandle {
-	return &RunSessionHandle{
+func (h *coreRunSessionHandle) toCore() *core.RunSessionHandle {
+	return &core.RunSessionHandle{
 		Provider:       h.Provider,
 		LeaseID:        h.LeaseID,
 		Slug:           h.Slug,

--- a/internal/providers/cloudflaredynamicworkers/backend_test.go
+++ b/internal/providers/cloudflaredynamicworkers/backend_test.go
@@ -67,7 +67,7 @@ func TestProviderSpecAndFlags(t *testing.T) {
 		}
 	}
 	fs := newTestFlagSet()
-	Provider{}.RegisterFlags(fs, Config{})
+	Provider{}.RegisterFlags(fs, core.Config{})
 	if fs.Lookup("cloudflare-dynamic-workers-token") != nil {
 		t.Fatal("provider must not expose a token CLI flag")
 	}
@@ -91,7 +91,7 @@ func TestProviderFlagsRejectExpose(t *testing.T) {
 func TestConfigureNormalizesDefaultLinuxTarget(t *testing.T) {
 	cfg := testConfig("http://127.0.0.1:1")
 	cfg.TargetOS = "linux"
-	configured, err := Provider{}.Configure(cfg, Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}})
+	configured, err := Provider{}.Configure(cfg, core.Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestConfigureRejectsExplicitLinuxTarget(t *testing.T) {
 	cfg := testConfig("http://127.0.0.1:1")
 	cfg.TargetOS = core.TargetLinux
 	core.MarkTargetExplicit(&cfg)
-	_, err := Provider{}.Configure(cfg, Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}})
+	_, err := Provider{}.Configure(cfg, core.Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}})
 	if err == nil || !strings.Contains(err.Error(), "supports target=worker-runtime only") {
 		t.Fatalf("error=%v", err)
 	}
@@ -115,7 +115,7 @@ func TestConfigureRejectsUnsupportedImplicitTargets(t *testing.T) {
 		t.Run(target, func(t *testing.T) {
 			cfg := testConfig("http://127.0.0.1:1")
 			cfg.TargetOS = target
-			_, err := Provider{}.Configure(cfg, Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}})
+			_, err := Provider{}.Configure(cfg, core.Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}})
 			if err == nil || !strings.Contains(err.Error(), "supports target=worker-runtime only") {
 				t.Fatalf("target=%q error=%v", target, err)
 			}
@@ -126,8 +126,8 @@ func TestConfigureRejectsUnsupportedImplicitTargets(t *testing.T) {
 func TestListWithoutRefreshValidatesLoaderURL(t *testing.T) {
 	cfg := testConfig("")
 	cfg.CloudflareDynamicWorkers.LoaderURL = ""
-	configured := NewBackend(Provider{}.Spec(), cfg, Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}})
-	_, err := configured.(*backend).List(context.Background(), ListRequest{})
+	configured := NewBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}})
+	_, err := configured.(*backend).List(context.Background(), core.ListRequest{})
 	if err == nil || !strings.Contains(err.Error(), "requires cloudflareDynamicWorkers.loaderUrl") {
 		t.Fatalf("err=%v", err)
 	}
@@ -135,7 +135,7 @@ func TestListWithoutRefreshValidatesLoaderURL(t *testing.T) {
 
 func TestWarmupRejectsMissingModuleSource(t *testing.T) {
 	backend := newTestBackend("http://127.0.0.1:1", &bytes.Buffer{}, &bytes.Buffer{})
-	err := backend.Warmup(context.Background(), WarmupRequest{})
+	err := backend.Warmup(context.Background(), core.WarmupRequest{})
 	if err == nil || !strings.Contains(err.Error(), "requires module source") {
 		t.Fatalf("err=%v", err)
 	}
@@ -262,7 +262,7 @@ func TestNewLoaderAPIRejectsUnsupportedDefaultTransport(t *testing.T) {
 	recorder := &recordingDefaultRoundTripper{}
 	http.DefaultTransport = recorder
 
-	client, err := newLoaderAPI(testConfig("http://127.0.0.1:8787"), Runtime{})
+	client, err := newLoaderAPI(testConfig("http://127.0.0.1:8787"), core.Runtime{})
 	if client != nil || err == nil || !strings.Contains(err.Error(), "non-nil *http.Transport") {
 		t.Fatalf("client=%#v err=%v, want transport setup error", client, err)
 	}
@@ -278,7 +278,7 @@ func TestNewLoaderAPIAcceptsExplicitClientWithUnsupportedDefault(t *testing.T) {
 	injectedTransport := &recordingDefaultRoundTripper{}
 	injected := &http.Client{Transport: injectedTransport}
 
-	api, err := newLoaderAPI(testConfig("http://127.0.0.1:8787"), Runtime{HTTP: injected})
+	api, err := newLoaderAPI(testConfig("http://127.0.0.1:8787"), core.Runtime{HTTP: injected})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -682,7 +682,7 @@ func TestClientRejectsRedirectWithoutForwardingCredentialsOrPayload(t *testing.T
 	}))
 	defer loader.Close()
 
-	loaderClient, err := newLoaderAPI(testConfig(loader.URL), Runtime{HTTP: loader.Client()})
+	loaderClient, err := newLoaderAPI(testConfig(loader.URL), core.Runtime{HTTP: loader.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -721,7 +721,7 @@ func TestDoctorReadinessUsesBearerAuthAndDoesNotMutate(t *testing.T) {
 	}))
 	defer server.Close()
 	backend := newTestBackend(server.URL, &bytes.Buffer{}, &bytes.Buffer{})
-	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -744,7 +744,7 @@ func TestDoctorRequiresDurableRunMetadata(t *testing.T) {
 	}))
 	defer server.Close()
 	backend := newTestBackend(server.URL, &bytes.Buffer{}, &bytes.Buffer{})
-	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -786,9 +786,9 @@ func TestRunPostsModuleSourceWithStableCacheAndLimits(t *testing.T) {
 	defer server.Close()
 	var stdout, stderr bytes.Buffer
 	backend := newTestBackend(server.URL, &stdout, &stderr)
-	req := RunRequest{
-		Repo: Repo{Root: t.TempDir(), Name: "my-app"},
-		Script: &RunScriptSpec{
+	req := core.RunRequest{
+		Repo: core.Repo{Root: t.TempDir(), Name: "my-app"},
+		Script: &core.RunScriptSpec{
 			Source:     "../worker module.mjs",
 			RemotePath: ".crabbox/scripts/abc123-worker-module.mjs",
 			Data:       []byte("export default { fetch() { return new Response('ok') } }\n"),
@@ -852,9 +852,9 @@ func TestRunRejectsSuccessfulLoaderResponseWithoutStatus(t *testing.T) {
 	defer server.Close()
 
 	backend := newTestBackend(server.URL, &bytes.Buffer{}, &bytes.Buffer{})
-	result, err := backend.Run(context.Background(), RunRequest{
+	result, err := backend.Run(context.Background(), core.RunRequest{
 		ScriptRequested: true,
-		Script:          &RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
+		Script:          &core.RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
 	})
 	if err == nil || result.ExitCode != 1 {
 		t.Fatalf("result=%#v err=%v", result, err)
@@ -892,9 +892,9 @@ func TestRunCleansGeneratedIdentityAfterMalformedSuccessfulResponse(t *testing.T
 
 	backend := newTestBackend(server.URL, &bytes.Buffer{}, &bytes.Buffer{})
 	backend.cfg.CloudflareDynamicWorkers.CacheMode = "one-shot"
-	result, err := backend.Run(context.Background(), RunRequest{
+	result, err := backend.Run(context.Background(), core.RunRequest{
 		ScriptRequested: true,
-		Script:          &RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
+		Script:          &core.RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
 	})
 	if err == nil || result.ExitCode != 1 {
 		t.Fatalf("result=%#v err=%v", result, err)
@@ -929,9 +929,9 @@ func TestRunCleansSubmittedIdentityAfterInvalidJSONResponse(t *testing.T) {
 	defer server.Close()
 
 	backend := newTestBackend(server.URL, &bytes.Buffer{}, &bytes.Buffer{})
-	result, err := backend.Run(context.Background(), RunRequest{
+	result, err := backend.Run(context.Background(), core.RunRequest{
 		ScriptRequested: true,
-		Script:          &RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
+		Script:          &core.RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
 	})
 	if err == nil || result.ExitCode != 1 {
 		t.Fatalf("result=%#v err=%v", result, err)
@@ -944,7 +944,7 @@ func TestRunCleansSubmittedIdentityAfterInvalidJSONResponse(t *testing.T) {
 func TestRunMalformedResponseCleanupIgnoresCanceledCallerContext(t *testing.T) {
 	loader := &contractErrorLoader{}
 	originalNewLoaderAPI := newLoaderAPI
-	newLoaderAPI = func(Config, Runtime) (loaderAPI, error) {
+	newLoaderAPI = func(core.Config, core.Runtime) (loaderAPI, error) {
 		return loader, nil
 	}
 	defer func() {
@@ -954,9 +954,9 @@ func TestRunMalformedResponseCleanupIgnoresCanceledCallerContext(t *testing.T) {
 	backend := newTestBackend("http://127.0.0.1:1", &bytes.Buffer{}, &bytes.Buffer{})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	result, err := backend.Run(ctx, RunRequest{
+	result, err := backend.Run(ctx, core.RunRequest{
 		ScriptRequested: true,
-		Script:          &RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
+		Script:          &core.RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
 	})
 	if err == nil || result.ExitCode != 1 {
 		t.Fatalf("result=%#v err=%v", result, err)
@@ -968,8 +968,8 @@ func TestRunMalformedResponseCleanupIgnoresCanceledCallerContext(t *testing.T) {
 
 func TestRunStableCacheUsesUniqueRunIDsAndStableWorkerID(t *testing.T) {
 	backend := newTestBackend("http://127.0.0.1:1", &bytes.Buffer{}, &bytes.Buffer{})
-	req := RunRequest{
-		Script: &RunScriptSpec{
+	req := core.RunRequest{
+		Script: &core.RunScriptSpec{
 			Source: "worker.mjs",
 			Data:   []byte("export default { fetch() { return new Response('ok') } }"),
 		},
@@ -1015,10 +1015,10 @@ func TestRunTimingJSONRemainsFinalLineAfterUnterminatedLoaderOutput(t *testing.T
 
 	var stderr bytes.Buffer
 	backend := newTestBackend(server.URL, &bytes.Buffer{}, &stderr)
-	result, err := backend.Run(context.Background(), RunRequest{
+	result, err := backend.Run(context.Background(), core.RunRequest{
 		TimingJSON:      true,
 		ScriptRequested: true,
-		Script:          &RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
+		Script:          &core.RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1069,13 +1069,13 @@ func TestRunPreservesStructuredFailedRunAndKeepOnFailureClaim(t *testing.T) {
 	defer server.Close()
 	var stderr bytes.Buffer
 	backend := newTestBackend(server.URL, &bytes.Buffer{}, &stderr)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:            Repo{Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:            core.Repo{Root: t.TempDir()},
 		KeepOnFailure:   true,
 		RequestedSlug:   "debug-failure",
 		TimingJSON:      true,
 		ScriptRequested: true,
-		Script: &RunScriptSpec{
+		Script: &core.RunScriptSpec{
 			Source:     "../worker module.mjs",
 			RemotePath: ".crabbox/scripts/abc123-worker-module.mjs",
 			Data:       []byte("export default {}"),
@@ -1129,10 +1129,10 @@ func TestRunKeepOnFailureRemovesMetadataAfterAcknowledgedSuccess(t *testing.T) {
 	defer server.Close()
 
 	backend := newTestBackend(server.URL, &bytes.Buffer{}, &bytes.Buffer{})
-	result, err := backend.Run(context.Background(), RunRequest{
+	result, err := backend.Run(context.Background(), core.RunRequest{
 		KeepOnFailure:   true,
 		ScriptRequested: true,
-		Script:          &RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
+		Script:          &core.RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1179,12 +1179,12 @@ func TestRunKeepsLifecycleUncertainClaimFromLiveStatus(t *testing.T) {
 
 	var stderr bytes.Buffer
 	backend := newTestBackend(server.URL, &bytes.Buffer{}, &stderr)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:            Repo{Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:            core.Repo{Root: t.TempDir()},
 		Keep:            true,
 		RequestedSlug:   "uncertain-success",
 		ScriptRequested: true,
-		Script:          &RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
+		Script:          &core.RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1243,10 +1243,10 @@ func TestRunKeepsLifecycleUncertainWithoutRetentionRequest(t *testing.T) {
 			var stderr bytes.Buffer
 			backend := newTestBackend(server.URL, &bytes.Buffer{}, &stderr)
 			backend.cfg.CloudflareDynamicWorkers.CacheMode = cacheMode
-			result, err := backend.Run(context.Background(), RunRequest{
-				Repo:            Repo{Root: t.TempDir()},
+			result, err := backend.Run(context.Background(), core.RunRequest{
+				Repo:            core.Repo{Root: t.TempDir()},
 				ScriptRequested: true,
-				Script:          &RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
+				Script:          &core.RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -1312,10 +1312,10 @@ func TestRunLifecycleUncertainSurfacesRecoveryClaimPersistenceFailure(t *testing
 			defer server.Close()
 
 			backend := newTestBackend(server.URL, &bytes.Buffer{}, &bytes.Buffer{})
-			result, err := backend.Run(context.Background(), RunRequest{
-				Repo:            Repo{Root: t.TempDir()},
+			result, err := backend.Run(context.Background(), core.RunRequest{
+				Repo:            core.Repo{Root: t.TempDir()},
 				ScriptRequested: true,
-				Script:          &RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
+				Script:          &core.RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
 			})
 			if err == nil || !strings.Contains(err.Error(), "persist cloudflare-dynamic-workers uncertain-lifecycle recovery claim") {
 				t.Fatalf("result=%#v err=%v", result, err)
@@ -1324,7 +1324,7 @@ func TestRunLifecycleUncertainSurfacesRecoveryClaimPersistenceFailure(t *testing
 				t.Fatalf("result=%#v runID=%q", result, runID)
 			}
 			if tc.exitCode != 0 {
-				var exitErr ExitError
+				var exitErr core.ExitError
 				if !errors.As(err, &exitErr) || exitErr.Code != tc.exitCode {
 					t.Fatalf("joined run error=%v, want exit code %d", err, tc.exitCode)
 				}
@@ -1400,9 +1400,9 @@ func TestRunWarnsWhenCompatibilityCleanupFailsAfterSuccess(t *testing.T) {
 
 	var stderr bytes.Buffer
 	backend := newTestBackend(server.URL, &bytes.Buffer{}, &stderr)
-	result, err := backend.Run(context.Background(), RunRequest{
+	result, err := backend.Run(context.Background(), core.RunRequest{
 		ScriptRequested: true,
-		Script:          &RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
+		Script:          &core.RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1442,18 +1442,18 @@ func TestRunPreservesKeepOnFailureClaimWhenPostResponseIsLost(t *testing.T) {
 
 	var stderr bytes.Buffer
 	cfg := testConfig(server.URL)
-	backend := NewBackend(Provider{}.Spec(), cfg, Runtime{
+	backend := NewBackend(Provider{}.Spec(), cfg, core.Runtime{
 		HTTP:   &http.Client{Transport: losePostResponseTransport{base: http.DefaultTransport}},
 		Stdout: &bytes.Buffer{},
 		Stderr: &stderr,
 	}).(*backend)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:            Repo{Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:            core.Repo{Root: t.TempDir()},
 		KeepOnFailure:   true,
 		RequestedSlug:   "uncertain-failure",
 		TimingJSON:      true,
 		ScriptRequested: true,
-		Script: &RunScriptSpec{
+		Script: &core.RunScriptSpec{
 			Source:     "../worker module.mjs",
 			RemotePath: ".crabbox/scripts/abc123-worker-module.mjs",
 			Data:       []byte("export default {}"),
@@ -1482,7 +1482,7 @@ func TestRunPreservesKeepOnFailureClaimWhenPostResponseIsLost(t *testing.T) {
 	}
 }
 
-func decodeLastTimingReport(t *testing.T, output string) timingReport {
+func decodeLastTimingReport(t *testing.T, output string) core.TimingReport {
 	t.Helper()
 	lines := strings.Split(strings.TrimSpace(output), "\n")
 	for i := len(lines) - 1; i >= 0; i-- {
@@ -1490,14 +1490,14 @@ func decodeLastTimingReport(t *testing.T, output string) timingReport {
 		if !strings.HasPrefix(line, "{") {
 			continue
 		}
-		var report timingReport
+		var report core.TimingReport
 		if err := json.Unmarshal([]byte(line), &report); err != nil {
 			t.Fatalf("timing json: %v\noutput=%s", err, output)
 		}
 		return report
 	}
 	t.Fatalf("output does not contain timing JSON: %s", output)
-	return timingReport{}
+	return core.TimingReport{}
 }
 
 func TestRunPreservesKeepOnFailureClaimAfterUnstructuredServerError(t *testing.T) {
@@ -1526,12 +1526,12 @@ func TestRunPreservesKeepOnFailureClaimAfterUnstructuredServerError(t *testing.T
 
 	var stderr bytes.Buffer
 	backend := newTestBackend(server.URL, &bytes.Buffer{}, &stderr)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:            Repo{Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:            core.Repo{Root: t.TempDir()},
 		KeepOnFailure:   true,
 		RequestedSlug:   "gateway-failure",
 		ScriptRequested: true,
-		Script: &RunScriptSpec{
+		Script: &core.RunScriptSpec{
 			Source: "worker.mjs",
 			Data:   []byte("export default {}"),
 		},
@@ -1582,12 +1582,12 @@ func TestRunPreservesKeepOnFailureClaimAfterInvalidLifecycleRejection(t *testing
 
 	var stderr bytes.Buffer
 	backend := newTestBackend(server.URL, &bytes.Buffer{}, &stderr)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:            Repo{Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:            core.Repo{Root: t.TempDir()},
 		KeepOnFailure:   true,
 		RequestedSlug:   "invalid-response",
 		ScriptRequested: true,
-		Script: &RunScriptSpec{
+		Script: &core.RunScriptSpec{
 			Source: "worker.mjs",
 			Data:   []byte("export default {}"),
 		},
@@ -1621,7 +1621,7 @@ func (t losePostResponseTransport) RoundTrip(req *http.Request) (*http.Response,
 }
 
 func TestWorkerModuleNameBoundsLongGeneratedPaths(t *testing.T) {
-	name := workerModuleName(&RunScriptSpec{
+	name := workerModuleName(&core.RunScriptSpec{
 		RemotePath: ".crabbox/scripts/abc123-" + strings.Repeat("a", 250) + ".mjs",
 	})
 	if len(name) > 256 {
@@ -1633,7 +1633,7 @@ func TestWorkerModuleNameBoundsLongGeneratedPaths(t *testing.T) {
 }
 
 func TestWorkerModuleNameUsesJavaScriptForStdin(t *testing.T) {
-	name := workerModuleName(&RunScriptSpec{
+	name := workerModuleName(&core.RunScriptSpec{
 		Source:     "stdin",
 		RemotePath: ".crabbox/scripts/abc123-script.sh",
 	})
@@ -1681,9 +1681,7 @@ func TestStableRunIDIncludesForwardedEnv(t *testing.T) {
 func TestBuildRunRequestSendsEffectiveCompatibilityDate(t *testing.T) {
 	backend := newTestBackend("http://127.0.0.1:1", &bytes.Buffer{}, &bytes.Buffer{})
 	backend.cfg.CloudflareDynamicWorkers.CompatibilityDate = ""
-	req := backend.buildRunRequest(
-		RunRequest{Script: &RunScriptSpec{Source: "stdin", Data: []byte("export default {}")}},
-		"run_1",
+	req := backend.buildRunRequest(core.RunRequest{Script: &core.RunScriptSpec{Source: "stdin", Data: []byte("export default {}")}}, "run_1",
 		"worker_1",
 		"stable",
 	)
@@ -1703,9 +1701,9 @@ func TestTerminalStateIncludesSuccessfulRunStates(t *testing.T) {
 func TestRunExplicitCacheRequiresID(t *testing.T) {
 	backend := newTestBackend("http://127.0.0.1:1", &bytes.Buffer{}, &bytes.Buffer{})
 	backend.cfg.CloudflareDynamicWorkers.CacheMode = "explicit"
-	_, err := backend.Run(context.Background(), RunRequest{
+	_, err := backend.Run(context.Background(), core.RunRequest{
 		ScriptRequested: true,
-		Script:          &RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
+		Script:          &core.RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
 	})
 	if err == nil || !strings.Contains(err.Error(), "cache=explicit requires --id") {
 		t.Fatalf("err=%v", err)
@@ -1730,11 +1728,11 @@ func TestRunExplicitCachePrintsGeneratedLifecycleID(t *testing.T) {
 	var stderr bytes.Buffer
 	backend := newTestBackend(server.URL, &bytes.Buffer{}, &stderr)
 	backend.cfg.CloudflareDynamicWorkers.CacheMode = "explicit"
-	result, err := backend.Run(context.Background(), RunRequest{
+	result, err := backend.Run(context.Background(), core.RunRequest{
 		ID:              "named-worker",
-		Repo:            Repo{Root: t.TempDir()},
+		Repo:            core.Repo{Root: t.TempDir()},
 		ScriptRequested: true,
-		Script:          &RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
+		Script:          &core.RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1749,10 +1747,10 @@ func TestRunExplicitCachePrintsGeneratedLifecycleID(t *testing.T) {
 
 func TestRunRejectsIDOutsideExplicitCache(t *testing.T) {
 	backend := newTestBackend("http://127.0.0.1:1", &bytes.Buffer{}, &bytes.Buffer{})
-	_, err := backend.Run(context.Background(), RunRequest{
+	_, err := backend.Run(context.Background(), core.RunRequest{
 		ID:              "named-worker",
 		ScriptRequested: true,
-		Script:          &RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
+		Script:          &core.RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
 	})
 	if err == nil || !strings.Contains(err.Error(), "--id requires cache=explicit") {
 		t.Fatalf("err=%v", err)
@@ -1762,9 +1760,9 @@ func TestRunRejectsIDOutsideExplicitCache(t *testing.T) {
 func TestRunRejectsInterceptEgressWithReusableCache(t *testing.T) {
 	backend := newTestBackend("http://127.0.0.1:1", &bytes.Buffer{}, &bytes.Buffer{})
 	backend.cfg.CloudflareDynamicWorkers.Egress = "intercept"
-	_, err := backend.Run(context.Background(), RunRequest{
+	_, err := backend.Run(context.Background(), core.RunRequest{
 		ScriptRequested: true,
-		Script:          &RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
+		Script:          &core.RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
 	})
 	if err == nil || !strings.Contains(err.Error(), "egress=intercept requires cache=one-shot") {
 		t.Fatalf("err=%v", err)
@@ -1788,7 +1786,7 @@ func TestStopMissingRemoteRemovesStaleLocalClaim(t *testing.T) {
 	}
 	var stdout bytes.Buffer
 	backend.rt.Stdout = &stdout
-	if err := backend.Stop(context.Background(), StopRequest{ID: "stale-claim"}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: "stale-claim"}); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(stdout.String(), "removed stale cloudflare-dynamic-workers claim cfdw_stale reason=not-found") {
@@ -1815,8 +1813,8 @@ func TestStopRefusesUnrelatedExactClaim(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := backend.Stop(context.Background(), StopRequest{ID: "shared-id"})
-	var exitErr ExitError
+	err := backend.Stop(context.Background(), core.StopRequest{ID: "shared-id"})
+	var exitErr core.ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "refusing to delete") || !strings.Contains(err.Error(), "exact local claim") {
 		t.Fatalf("err=%v, want exit(2) ownership refusal", err)
 	}
@@ -1839,8 +1837,8 @@ func TestStopRefusesUnclaimedRun(t *testing.T) {
 	defer server.Close()
 	backend := newTestBackend(server.URL, &bytes.Buffer{}, &bytes.Buffer{})
 
-	err := backend.Stop(context.Background(), StopRequest{ID: "cfdw_unclaimed"})
-	var exitErr ExitError
+	err := backend.Stop(context.Background(), core.StopRequest{ID: "cfdw_unclaimed"})
+	var exitErr core.ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "refusing to delete") || !strings.Contains(err.Error(), "exact local claim") {
 		t.Fatalf("err=%v, want exit(2) ownership refusal", err)
 	}
@@ -1863,8 +1861,8 @@ func TestStopRefusesClaimFromDifferentLoaderEndpoint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := backend.Stop(context.Background(), StopRequest{ID: "cfdw_other_loader"})
-	var exitErr ExitError
+	err := backend.Stop(context.Background(), core.StopRequest{ID: "cfdw_other_loader"})
+	var exitErr core.ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "different loader endpoint") {
 		t.Fatalf("err=%v, want exit(2) loader-scope refusal", err)
 	}
@@ -1894,7 +1892,7 @@ func TestStopDeletesOwnedRunAndRemovesClaim(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := backend.Stop(context.Background(), StopRequest{ID: "owned-run"}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: "owned-run"}); err != nil {
 		t.Fatal(err)
 	}
 	if deleteRequests != 1 {
@@ -1919,7 +1917,7 @@ func TestStatusAllowsUnclaimedRunID(t *testing.T) {
 	defer server.Close()
 	backend := newTestBackend(server.URL, &bytes.Buffer{}, &bytes.Buffer{})
 
-	view, err := backend.Status(context.Background(), StatusRequest{ID: "cfdw_unclaimed"})
+	view, err := backend.Status(context.Background(), core.StatusRequest{ID: "cfdw_unclaimed"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1943,7 +1941,7 @@ func TestStopPreservesConcurrentlyReplacedClaim(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := backend.Stop(context.Background(), StopRequest{ID: "race-claim"})
+	err := backend.Stop(context.Background(), core.StopRequest{ID: "race-claim"})
 	if err == nil || !strings.Contains(err.Error(), "claim changed; retry") {
 		t.Fatalf("err=%v", err)
 	}
@@ -1973,7 +1971,7 @@ func TestCleanupDeletesTerminalMetadataBeforeClaim(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if got := strings.Join(requests, ","); got != "GET /v1/runs/cfdw_terminal,DELETE /v1/runs/cfdw_terminal" {
@@ -2000,7 +1998,7 @@ func TestCleanupPreservesClaimReplacedDuringMissingStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	claim, ok, err := core.ResolveLeaseClaim("cfdw_race")
@@ -2032,7 +2030,7 @@ func TestCleanupPreservesClaimReplacedDuringTerminalDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	claim, ok, err := core.ResolveLeaseClaim("cfdw_race")
@@ -2063,7 +2061,7 @@ func TestCleanupRetainsClaimWhenTerminalMetadataDeleteFails(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if _, ok, err := resolveLeaseClaim("terminal-claim", backend.cfg); err != nil || !ok {
@@ -2151,7 +2149,7 @@ func TestLoaderClaimScopeCanonicalizesUnreservedEscapes(t *testing.T) {
 	}
 }
 
-func mustLoaderClaimScope(t *testing.T, cfg Config) string {
+func mustLoaderClaimScope(t *testing.T, cfg core.Config) string {
 	t.Helper()
 	scope, err := loaderClaimScope(cfg)
 	if err != nil {
@@ -2210,7 +2208,7 @@ func TestListRefreshUsesLiveStatusOverLocalClaimState(t *testing.T) {
 	if err := claimLease("cfdw_live", "live-claim", backend.cfg, t.TempDir(), time.Minute, false, runServer("cfdw_live", "live-claim", runStatus{ID: "cfdw_live", Status: "ready"}, map[string]string{"state": "ready"})); err != nil {
 		t.Fatal(err)
 	}
-	views, err := backend.List(context.Background(), ListRequest{Refresh: true})
+	views, err := backend.List(context.Background(), core.ListRequest{Refresh: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2227,7 +2225,7 @@ func TestClientRedactsConfiguredTokenFromErrors(t *testing.T) {
 		http.Error(w, `{"error":"bad bearer test-token Authorization: Bearer test-token"}`, http.StatusUnauthorized)
 	}))
 	defer server.Close()
-	client, err := newLoaderAPI(testConfig(server.URL), Runtime{})
+	client, err := newLoaderAPI(testConfig(server.URL), core.Runtime{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2244,7 +2242,7 @@ func TestClientRedactsConfiguredTokenFromErrors(t *testing.T) {
 }
 
 func newTestBackend(url string, stdout, stderr *bytes.Buffer) *backend {
-	return NewBackend(Provider{}.Spec(), testConfig(url), Runtime{Stdout: stdout, Stderr: stderr}).(*backend)
+	return NewBackend(Provider{}.Spec(), testConfig(url), core.Runtime{Stdout: stdout, Stderr: stderr}).(*backend)
 }
 
 type contractErrorLoader struct {
@@ -2274,8 +2272,8 @@ func (l *contractErrorLoader) DeleteAcknowledgedComplete(ctx context.Context, id
 	return l.cleanupContextErr
 }
 
-func testConfig(url string) Config {
-	cfg := Config{}
+func testConfig(url string) core.Config {
+	cfg := core.Config{}
 	cfg.CloudflareDynamicWorkers.LoaderURL = url
 	cfg.CloudflareDynamicWorkers.Token = "test-token"
 	cfg.CloudflareDynamicWorkers.CacheMode = "stable"

--- a/internal/providers/cloudflaredynamicworkers/client.go
+++ b/internal/providers/cloudflaredynamicworkers/client.go
@@ -132,14 +132,14 @@ var defaultReadRetryDelays = []time.Duration{
 	2 * time.Second,
 }
 
-var newLoaderAPI = func(cfg Config, rt Runtime) (loaderAPI, error) {
+var newLoaderAPI = func(cfg core.Config, rt core.Runtime) (loaderAPI, error) {
 	baseURL, err := loaderURL(cfg)
 	if err != nil {
 		return nil, err
 	}
 	token := strings.TrimSpace(cfg.CloudflareDynamicWorkers.Token)
 	if token == "" {
-		return nil, exit(2, "%s requires cloudflareDynamicWorkers.token or CRABBOX_CLOUDFLARE_DYNAMIC_WORKERS_TOKEN", providerName)
+		return nil, core.Exit(2, "%s requires cloudflareDynamicWorkers.token or CRABBOX_CLOUDFLARE_DYNAMIC_WORKERS_TOKEN", providerName)
 	}
 	httpClient := rt.HTTP
 	if httpClient == nil {
@@ -158,35 +158,35 @@ var newLoaderAPI = func(cfg Config, rt Runtime) (loaderAPI, error) {
 	}, nil
 }
 
-func loaderURL(cfg Config) (string, error) {
+func loaderURL(cfg core.Config) (string, error) {
 	raw := strings.TrimSpace(cfg.CloudflareDynamicWorkers.LoaderURL)
 	if raw == "" {
-		return "", exit(2, "%s requires cloudflareDynamicWorkers.loaderUrl or CRABBOX_CLOUDFLARE_DYNAMIC_WORKERS_URL", providerName)
+		return "", core.Exit(2, "%s requires cloudflareDynamicWorkers.loaderUrl or CRABBOX_CLOUDFLARE_DYNAMIC_WORKERS_URL", providerName)
 	}
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return "", exit(2, "%s loader URL %q is invalid", providerName, shared.EndpointURLForError(raw))
+		return "", core.Exit(2, "%s loader URL %q is invalid", providerName, shared.EndpointURLForError(raw))
 	}
 	if parsed.User != nil {
-		return "", exit(2, "%s loader URL must not include userinfo", providerName)
+		return "", core.Exit(2, "%s loader URL must not include userinfo", providerName)
 	}
 	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
-		return "", exit(2, "%s loader URL %q must use https unless it targets localhost", providerName, shared.EndpointURLForError(raw))
+		return "", core.Exit(2, "%s loader URL %q must use https unless it targets localhost", providerName, shared.EndpointURLForError(raw))
 	}
 	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", exit(2, "%s loader URL %q must not include query or fragment components", providerName, shared.EndpointURLForError(raw))
+		return "", core.Exit(2, "%s loader URL %q must not include query or fragment components", providerName, shared.EndpointURLForError(raw))
 	}
 	return strings.TrimRight(parsed.String(), "/"), nil
 }
 
-func loaderClaimScope(cfg Config) (string, error) {
+func loaderClaimScope(cfg core.Config) (string, error) {
 	raw, err := loaderURL(cfg)
 	if err != nil {
 		return "", err
 	}
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Host == "" {
-		return "", exit(2, "%s loader URL is invalid", providerName)
+		return "", core.Exit(2, "%s loader URL is invalid", providerName)
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
 	host := strings.ToLower(parsed.Hostname())
@@ -204,7 +204,7 @@ func loaderClaimScope(cfg Config) (string, error) {
 	escapedPath := canonicalPercentEscapes(strings.TrimRight(parsed.EscapedPath(), "/"))
 	decodedPath, err := url.PathUnescape(escapedPath)
 	if err != nil {
-		return "", exit(2, "%s loader URL path is invalid", providerName)
+		return "", core.Exit(2, "%s loader URL path is invalid", providerName)
 	}
 	parsed.Path = decodedPath
 	if escapedPath == decodedPath {
@@ -277,7 +277,7 @@ func isLoopbackHTTPURL(parsed *url.URL) bool {
 	return shared.IsLoopbackHTTPURL(parsed)
 }
 
-func defaultHTTPClient(cfg Config) (*http.Client, error) {
+func defaultHTTPClient(cfg core.Config) (*http.Client, error) {
 	transport, err := core.CloneDefaultTransport()
 	if err != nil {
 		return nil, err
@@ -294,7 +294,7 @@ func noRedirectHTTPClient(httpClient *http.Client) *http.Client {
 	return &cloned
 }
 
-func responseHeaderTimeout(cfg Config) time.Duration {
+func responseHeaderTimeout(cfg core.Config) time.Duration {
 	runTimeout := time.Duration(cfg.CloudflareDynamicWorkers.TimeoutSecs) * time.Second
 	if runTimeout <= 0 {
 		return 0

--- a/internal/providers/cloudflaredynamicworkers/core.go
+++ b/internal/providers/cloudflaredynamicworkers/core.go
@@ -1,36 +1,10 @@
 package cloudflaredynamicworkers
 
 import (
-	"io"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type CloudflareDynamicWorkersConfig = core.CloudflareDynamicWorkersConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type DoctorCheck = core.DoctorCheck
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type RunSessionHandle = core.RunSessionHandle
-type RunScriptSpec = core.RunScriptSpec
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type CleanupRequest = core.CleanupRequest
-type Server = core.Server
-type LeaseClaim = core.LeaseClaim
-type Repo = core.Repo
-type ExitError = core.ExitError
-type timingReport = core.TimingReport
 
 const (
 	providerName             = "cloudflare-dynamic-workers"
@@ -38,19 +12,7 @@ const (
 	defaultCompatibilityDate = core.DefaultCloudflareDynamicWorkersCompatibilityDate
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func claimLease(leaseID, slug string, cfg Config, repoRoot string, idleTimeout time.Duration, reclaim bool, server Server) error {
+func claimLease(leaseID, slug string, cfg core.Config, repoRoot string, idleTimeout time.Duration, reclaim bool, server core.Server) error {
 	scope, err := loaderClaimScope(cfg)
 	if err != nil {
 		return err
@@ -58,7 +20,7 @@ func claimLease(leaseID, slug string, cfg Config, repoRoot string, idleTimeout t
 	return core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, scope, cfg.Pond, repoRoot, idleTimeout, reclaim, server, core.SSHTarget{TargetOS: targetWorker})
 }
 
-func resolveLeaseClaim(identifier string, cfg Config) (core.LeaseClaim, bool, error) {
+func resolveLeaseClaim(identifier string, cfg core.Config) (core.LeaseClaim, bool, error) {
 	scope, err := loaderClaimScope(cfg)
 	if err != nil {
 		return core.LeaseClaim{}, false, err
@@ -73,7 +35,7 @@ func resolveLeaseClaim(identifier string, cfg Config) (core.LeaseClaim, bool, er
 				return exact, true, nil
 			}
 			if exact.Provider == providerName {
-				return core.LeaseClaim{}, false, exit(2, "%s claim %s belongs to a different loader endpoint", providerName, identifier)
+				return core.LeaseClaim{}, false, core.Exit(2, "%s claim %s belongs to a different loader endpoint", providerName, identifier)
 			}
 		}
 	}
@@ -96,32 +58,8 @@ func resolveLeaseClaim(identifier string, cfg Config) (core.LeaseClaim, bool, er
 	return matched, matched.LeaseID != "", nil
 }
 
-func listLeaseClaims() ([]core.LeaseClaim, error) {
-	return core.ListLeaseClaims()
-}
-
-func removeLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
-	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
-}
-
-func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
-	return core.TimingReportWithRunResult(report, result, err)
-}
-
-func timingReportWithProviderError(report timingReport) timingReport {
+func timingReportWithProviderError(report core.TimingReport) core.TimingReport {
 	report.RunStatus = core.RunStatusFailed
 	report.ErrorKind = core.RunErrorProvider
 	return report
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
-func rejectDelegatedSyncOptions(spec ProviderSpec, req RunRequest) error {
-	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
 }

--- a/internal/providers/cloudflaredynamicworkers/flags.go
+++ b/internal/providers/cloudflaredynamicworkers/flags.go
@@ -19,7 +19,7 @@ type flagValues struct {
 	TimeoutSecs        *int
 }
 
-func RegisterProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	cfg := defaults.CloudflareDynamicWorkers
 	return flagValues{
 		URL:                fs.String("cloudflare-dynamic-workers-url", cfg.LoaderURL, "Cloudflare Dynamic Workers loader URL"),
@@ -33,13 +33,13 @@ func RegisterProviderFlags(fs *flag.FlagSet, defaults Config) any {
 	}
 }
 
-func ApplyProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if core.ProviderNameMatchesExact(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
 			return err
 		}
 		if core.FlagWasSet(fs, "expose") {
-			return exit(2, "--expose is not supported for provider=%s", providerName)
+			return core.Exit(2, "--expose is not supported for provider=%s", providerName)
 		}
 	}
 	v, ok := values.(flagValues)
@@ -81,25 +81,25 @@ func ApplyProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	return validateProviderConfig(*cfg)
 }
 
-func validateProviderConfig(cfg Config) error {
+func validateProviderConfig(cfg core.Config) error {
 	switch normalizeCacheMode(cfg.CloudflareDynamicWorkers.CacheMode) {
 	case "one-shot", "stable", "explicit":
 	default:
-		return exit(2, "invalid %s cache mode %q", providerName, cfg.CloudflareDynamicWorkers.CacheMode)
+		return core.Exit(2, "invalid %s cache mode %q", providerName, cfg.CloudflareDynamicWorkers.CacheMode)
 	}
 	switch normalizeEgress(cfg.CloudflareDynamicWorkers.Egress) {
 	case "blocked", "intercept":
 	default:
-		return exit(2, "invalid %s egress mode %q", providerName, cfg.CloudflareDynamicWorkers.Egress)
+		return core.Exit(2, "invalid %s egress mode %q", providerName, cfg.CloudflareDynamicWorkers.Egress)
 	}
 	if cfg.CloudflareDynamicWorkers.CPUMs < 0 {
-		return exit(2, "%s cpu-ms must be non-negative", providerName)
+		return core.Exit(2, "%s cpu-ms must be non-negative", providerName)
 	}
 	if cfg.CloudflareDynamicWorkers.Subrequests < 0 {
-		return exit(2, "%s subrequests must be non-negative", providerName)
+		return core.Exit(2, "%s subrequests must be non-negative", providerName)
 	}
 	if cfg.CloudflareDynamicWorkers.TimeoutSecs < 0 {
-		return exit(2, "%s timeout-secs must be non-negative", providerName)
+		return core.Exit(2, "%s timeout-secs must be non-negative", providerName)
 	}
 	return nil
 }

--- a/internal/providers/fastapicloud/backend.go
+++ b/internal/providers/fastapicloud/backend.go
@@ -9,38 +9,38 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func NewFastAPICloudBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewFastAPICloudBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	return &fastAPICloudBackend{spec: spec, cfg: cfg, rt: rt}
 }
 
 type fastAPICloudBackend struct {
-	spec   ProviderSpec
-	cfg    Config
-	rt     Runtime
+	spec   core.ProviderSpec
+	cfg    core.Config
+	rt     core.Runtime
 	client fastAPICloudAPI
 }
 
-func (b *fastAPICloudBackend) Spec() ProviderSpec { return b.spec }
+func (b *fastAPICloudBackend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *fastAPICloudBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *fastAPICloudBackend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	_ = ctx
 	_ = req
-	return exit(2, "provider=%s does not support warmup; create and deploy the FastAPI Cloud app out-of-band", providerName)
+	return core.Exit(2, "provider=%s does not support warmup; create and deploy the FastAPI Cloud app out-of-band", providerName)
 }
 
-func (b *fastAPICloudBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *fastAPICloudBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	_ = ctx
 	if err := shared.RejectServiceRunOptions(req, providerName, "lifecycle is owned by FastAPI Cloud", "cannot open an interactive shell"); err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	if len(req.Command) == 0 {
-		return RunResult{}, exit(2, "missing command")
+		return core.RunResult{}, core.Exit(2, "missing command")
 	}
-	return RunResult{}, exit(2, "provider=%s cannot execute arbitrary run commands; deploy with fastapi deploy or FastAPI Cloud CI", providerName)
+	return core.RunResult{}, core.Exit(2, "provider=%s cannot execute arbitrary run commands; deploy with fastapi deploy or FastAPI Cloud CI", providerName)
 }
 
-func (b *fastAPICloudBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *fastAPICloudBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	client, err := b.api()
 	if err != nil {
@@ -51,7 +51,7 @@ func (b *fastAPICloudBackend) List(ctx context.Context, req ListRequest) ([]Leas
 		if err != nil {
 			return nil, err
 		}
-		servers := make([]Server, 0, len(apps))
+		servers := make([]core.Server, 0, len(apps))
 		for _, app := range apps {
 			servers = append(servers, fastAPICloudServer(app))
 		}
@@ -62,44 +62,44 @@ func (b *fastAPICloudBackend) List(ctx context.Context, req ListRequest) ([]Leas
 		if err != nil {
 			return nil, err
 		}
-		return []LeaseView{fastAPICloudServer(app)}, nil
+		return []core.LeaseView{fastAPICloudServer(app)}, nil
 	}
-	return nil, exit(2, "provider=%s list requires --fastapi-cloud-team-id or --fastapi-cloud-app-id", providerName)
+	return nil, core.Exit(2, "provider=%s list requires --fastapi-cloud-team-id or --fastapi-cloud-app-id", providerName)
 }
 
-func (b *fastAPICloudBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *fastAPICloudBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	if strings.TrimSpace(b.cfg.FastAPICloud.AppID) != "" {
-		if _, err := b.Status(ctx, StatusRequest{}); err != nil {
-			return DoctorResult{}, err
+		if _, err := b.Status(ctx, core.StatusRequest{}); err != nil {
+			return core.DoctorResult{}, err
 		}
-		return inventoryDoctorResult(providerName, 1), nil
+		return core.InventoryDoctorResult(providerName, 1), nil
 	}
-	servers, err := b.List(ctx, ListRequest{})
+	servers, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return inventoryDoctorResult(providerName, len(servers)), nil
+	return core.InventoryDoctorResult(providerName, len(servers)), nil
 }
 
-func (b *fastAPICloudBackend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *fastAPICloudBackend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	appID := strings.TrimSpace(req.ID)
 	if appID == "" {
 		appID = strings.TrimSpace(b.cfg.FastAPICloud.AppID)
 	}
 	if appID == "" {
-		return StatusView{}, exit(2, "provider=%s status requires --id <fastapi-cloud-app-id> or --fastapi-cloud-app-id", providerName)
+		return core.StatusView{}, core.Exit(2, "provider=%s status requires --id <fastapi-cloud-app-id> or --fastapi-cloud-app-id", providerName)
 	}
 	client, err := b.api()
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	app, err := client.GetApp(ctx, appID)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	deployment, ok, err := client.LatestDeployment(ctx, appID)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	state := "no-deployment"
 	ready := false
@@ -107,7 +107,7 @@ func (b *fastAPICloudBackend) Status(ctx context.Context, req StatusRequest) (St
 		state = deployment.Status.State()
 		ready = deployment.Status.IsReady()
 	}
-	view := StatusView{
+	view := core.StatusView{
 		ID:         app.ID,
 		Slug:       app.Slug,
 		Provider:   providerName,
@@ -123,10 +123,10 @@ func (b *fastAPICloudBackend) Status(ctx context.Context, req StatusRequest) (St
 	return view, nil
 }
 
-func (b *fastAPICloudBackend) Stop(ctx context.Context, req StopRequest) error {
+func (b *fastAPICloudBackend) Stop(ctx context.Context, req core.StopRequest) error {
 	_ = ctx
 	_ = req
-	return exit(2, "provider=%s does not support stop; FastAPI Cloud does not expose app stop/delete through this provider", providerName)
+	return core.Exit(2, "provider=%s does not support stop; FastAPI Cloud does not expose app stop/delete through this provider", providerName)
 }
 
 func (b *fastAPICloudBackend) api() (fastAPICloudAPI, error) {
@@ -136,8 +136,8 @@ func (b *fastAPICloudBackend) api() (fastAPICloudAPI, error) {
 	return newFastAPICloudClient(b.cfg, b.rt)
 }
 
-func fastAPICloudServer(app fastAPICloudApp) Server {
-	return Server{
+func fastAPICloudServer(app fastAPICloudApp) core.Server {
+	return core.Server{
 		CloudID:  app.ID,
 		Provider: providerName,
 		Name:     core.Blank(app.Name, app.Slug),

--- a/internal/providers/fastapicloud/backend_test.go
+++ b/internal/providers/fastapicloud/backend_test.go
@@ -36,7 +36,7 @@ func TestFastAPICloudProviderSpec(t *testing.T) {
 
 func TestFastAPICloudBindingFlagsRemainDeferredAndLocal(t *testing.T) {
 	for _, name := range []string{"fastapi-cloud", "fastapicloud", "fastapi", " FastAPI "} {
-		cfg := Config{Provider: name, FastAPICloud: FastAPICloudConfig{APIURL: "https://example.invalid/prior", AppID: "prior-app", TeamID: "prior-team"}}
+		cfg := core.Config{Provider: name, FastAPICloud: core.FastAPICloudConfig{APIURL: "https://example.invalid/prior", AppID: "prior-app", TeamID: "prior-team"}}
 		fs := flag.NewFlagSet("test", flag.ContinueOnError)
 		fs.String("class", "", "")
 		fs.String("type", "", "")
@@ -65,7 +65,7 @@ func TestFastAPICloudBindingFlagsRemainDeferredAndLocal(t *testing.T) {
 		if !reflect.DeepEqual(cfg, before) {
 			t.Fatal("wrapper copies or global provenance side effects changed")
 		}
-		if _, err := (Provider{}).Configure(cfg, Runtime{}); err != nil {
+		if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err != nil {
 			t.Fatalf("Configure performed client validation: %v", err)
 		}
 		if err := ApplyFastAPICloudProviderFlags(&cfg, fs, struct{}{}); err != nil {
@@ -95,8 +95,8 @@ func TestFastAPICloudBindingFlagsRemainDeferredAndLocal(t *testing.T) {
 
 func TestFastAPICloudClientDefaultAndValidationOrder(t *testing.T) {
 	for _, rawToken := range []string{"", "  "} {
-		cfg := Config{FastAPICloud: FastAPICloudConfig{Token: rawToken, APIURL: "relative"}}
-		if _, err := newFastAPICloudClient(cfg, Runtime{}); err == nil || err.Error() != "provider=fastapi-cloud requires FASTAPI_CLOUD_TOKEN" {
+		cfg := core.Config{FastAPICloud: core.FastAPICloudConfig{Token: rawToken, APIURL: "relative"}}
+		if _, err := newFastAPICloudClient(cfg, core.Runtime{}); err == nil || err.Error() != "provider=fastapi-cloud requires FASTAPI_CLOUD_TOKEN" {
 			t.Fatalf("token validation order=%v", err)
 		}
 	}
@@ -108,9 +108,9 @@ func TestFastAPICloudClientDefaultAndValidationOrder(t *testing.T) {
 		{raw: "  ", invalid: true},
 		{raw: " https://example.invalid/api/ ", want: "https://example.invalid/api"},
 	} {
-		cfg := Config{FastAPICloud: FastAPICloudConfig{Token: "inert-constructor-only", APIURL: tc.raw}}
+		cfg := core.Config{FastAPICloud: core.FastAPICloudConfig{Token: "inert-constructor-only", APIURL: tc.raw}}
 		before := cfg.FastAPICloud
-		api, err := newFastAPICloudClient(cfg, Runtime{})
+		api, err := newFastAPICloudClient(cfg, core.Runtime{})
 		if tc.invalid {
 			if err == nil || err.Error() != "provider=fastapi-cloud API URL must be an absolute HTTPS URL" {
 				t.Fatalf("whitespace endpoint=%v", err)
@@ -130,19 +130,19 @@ func TestFastAPICloudClientDefaultAndValidationOrder(t *testing.T) {
 }
 
 func TestFastAPICloudClientRequiresToken(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.FastAPICloud.APIURL = "https://api.fastapicloud.com/api/v1"
-	if _, err := newFastAPICloudClient(cfg, Runtime{}); err == nil {
+	if _, err := newFastAPICloudClient(cfg, core.Runtime{}); err == nil {
 		t.Fatal("newFastAPICloudClient accepted empty token")
 	}
 }
 
 func TestFastAPICloudFallbackHTTPClientIsBounded(t *testing.T) {
-	cfg := Config{FastAPICloud: FastAPICloudConfig{
+	cfg := core.Config{FastAPICloud: core.FastAPICloudConfig{
 		Token:  "test-token",
 		APIURL: "http://127.0.0.1:8000/api/v1",
 	}}
-	api, err := newFastAPICloudClient(cfg, Runtime{})
+	api, err := newFastAPICloudClient(cfg, core.Runtime{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,10 +176,10 @@ func TestFastAPICloudFallbackHTTPClientTimesOutStalledControlResponse(t *testing
 }
 
 func TestFastAPICloudClientRejectsBareHTTPURL(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.FastAPICloud.Token = "test-token"
 	cfg.FastAPICloud.APIURL = "http://api.fastapicloud.com/api/v1"
-	if _, err := newFastAPICloudClient(cfg, Runtime{}); err == nil {
+	if _, err := newFastAPICloudClient(cfg, core.Runtime{}); err == nil {
 		t.Fatal("newFastAPICloudClient accepted plaintext http URL")
 	}
 }
@@ -196,8 +196,8 @@ func TestFastAPICloudClientRejectsUnsafeAPIURLComponents(t *testing.T) {
 		{name: "fragment", apiURL: "https://api.fastapicloud.com/api/v1#fragment-secret", secret: "fragment-secret"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			cfg := Config{FastAPICloud: FastAPICloudConfig{Token: "test-token", APIURL: test.apiURL}}
-			_, err := newFastAPICloudClient(cfg, Runtime{})
+			cfg := core.Config{FastAPICloud: core.FastAPICloudConfig{Token: "test-token", APIURL: test.apiURL}}
+			_, err := newFastAPICloudClient(cfg, core.Runtime{})
 			if err == nil || !strings.Contains(err.Error(), "must not contain userinfo, query parameters, or a fragment") {
 				t.Fatalf("newFastAPICloudClient error = %v, want unsafe URL rejection", err)
 			}
@@ -209,7 +209,7 @@ func TestFastAPICloudClientRejectsUnsafeAPIURLComponents(t *testing.T) {
 }
 
 func TestFastAPICloudTokenFlagIsNotRegistered(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.FastAPICloud.Token = "secret-token"
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	RegisterFastAPICloudProviderFlags(fs, cfg)
@@ -277,10 +277,10 @@ func TestFastAPICloudClientSendsBearerAndUsesRESTPaths(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.FastAPICloud.Token = "test-token"
 	cfg.FastAPICloud.APIURL = server.URL + "/api/v1"
-	client, err := newFastAPICloudClient(cfg, Runtime{HTTP: server.Client()})
+	client, err := newFastAPICloudClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,10 +316,7 @@ func TestFastAPICloudClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) 
 	}))
 	defer trusted.Close()
 
-	api, err := newFastAPICloudClient(
-		Config{FastAPICloud: FastAPICloudConfig{Token: "test-token", APIURL: trusted.URL}},
-		Runtime{HTTP: trusted.Client()},
-	)
+	api, err := newFastAPICloudClient(core.Config{FastAPICloud: core.FastAPICloudConfig{Token: "test-token", APIURL: trusted.URL}}, core.Runtime{HTTP: trusted.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -353,10 +350,7 @@ func TestFastAPICloudClientFollowsSameOriginRedirect(t *testing.T) {
 	}))
 	defer server.Close()
 
-	api, err := newFastAPICloudClient(
-		Config{FastAPICloud: FastAPICloudConfig{Token: "test-token", APIURL: server.URL + "/api/v1"}},
-		Runtime{HTTP: server.Client()},
-	)
+	api, err := newFastAPICloudClient(core.Config{FastAPICloud: core.FastAPICloudConfig{Token: "test-token", APIURL: server.URL + "/api/v1"}}, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -381,10 +375,7 @@ func TestFastAPICloudClientPreservesCallerRedirectPolicy(t *testing.T) {
 		callerChecks++
 		return callerErr
 	}
-	api, err := newFastAPICloudClient(
-		Config{FastAPICloud: FastAPICloudConfig{Token: "test-token", APIURL: server.URL}},
-		Runtime{HTTP: httpClient},
-	)
+	api, err := newFastAPICloudClient(core.Config{FastAPICloud: core.FastAPICloudConfig{Token: "test-token", APIURL: server.URL}}, core.Runtime{HTTP: httpClient})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,10 +392,10 @@ func TestFastAPICloudClientSurfacesNon2xxAsAPIError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.FastAPICloud.Token = "wrong-token"
 	cfg.FastAPICloud.APIURL = server.URL
-	client, err := newFastAPICloudClient(cfg, Runtime{HTTP: server.Client()})
+	client, err := newFastAPICloudClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -427,26 +418,26 @@ func TestFastAPICloudClientSurfacesNon2xxAsAPIError(t *testing.T) {
 func TestFastAPICloudRunRejectsBeforeAPI(t *testing.T) {
 	for _, tc := range []struct {
 		name string
-		req  RunRequest
+		req  core.RunRequest
 		want string
 	}{
-		{name: "keep first", req: RunRequest{Keep: true, Reclaim: true}, want: "provider=fastapi-cloud lifecycle is owned by FastAPI Cloud; --keep is not supported"},
-		{name: "reclaim", req: RunRequest{Reclaim: true}, want: "provider=fastapi-cloud lifecycle is owned by FastAPI Cloud; --reclaim is not supported"},
-		{name: "no sync", req: RunRequest{}, want: "provider=fastapi-cloud does not support workspace sync; pass --no-sync"},
-		{name: "shell", req: RunRequest{NoSync: true, ShellMode: true}, want: "provider=fastapi-cloud cannot open an interactive shell; --shell is not supported"},
-		{name: "env summary without env", req: RunRequest{NoSync: true, EnvSummary: true}, want: "provider=fastapi-cloud cannot forward per-run environment variables"},
-		{name: "missing command", req: RunRequest{NoSync: true}, want: "missing command"},
-		{name: "command", req: RunRequest{NoSync: true, Command: []string{"pytest"}}, want: "provider=fastapi-cloud cannot execute arbitrary run commands; deploy with fastapi deploy or FastAPI Cloud CI"},
-		{name: "implicit env", req: RunRequest{NoSync: true, Env: map[string]string{"CI": "true"}, Command: []string{"pytest"}}, want: "provider=fastapi-cloud cannot execute arbitrary run commands; deploy with fastapi deploy or FastAPI Cloud CI"},
+		{name: "keep first", req: core.RunRequest{Keep: true, Reclaim: true}, want: "provider=fastapi-cloud lifecycle is owned by FastAPI Cloud; --keep is not supported"},
+		{name: "reclaim", req: core.RunRequest{Reclaim: true}, want: "provider=fastapi-cloud lifecycle is owned by FastAPI Cloud; --reclaim is not supported"},
+		{name: "no sync", req: core.RunRequest{}, want: "provider=fastapi-cloud does not support workspace sync; pass --no-sync"},
+		{name: "shell", req: core.RunRequest{NoSync: true, ShellMode: true}, want: "provider=fastapi-cloud cannot open an interactive shell; --shell is not supported"},
+		{name: "env summary without env", req: core.RunRequest{NoSync: true, EnvSummary: true}, want: "provider=fastapi-cloud cannot forward per-run environment variables"},
+		{name: "missing command", req: core.RunRequest{NoSync: true}, want: "missing command"},
+		{name: "command", req: core.RunRequest{NoSync: true, Command: []string{"pytest"}}, want: "provider=fastapi-cloud cannot execute arbitrary run commands; deploy with fastapi deploy or FastAPI Cloud CI"},
+		{name: "implicit env", req: core.RunRequest{NoSync: true, Env: map[string]string{"CI": "true"}, Command: []string{"pytest"}}, want: "provider=fastapi-cloud cannot execute arbitrary run commands; deploy with fastapi deploy or FastAPI Cloud CI"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			backend := &fastAPICloudBackend{spec: Provider{}.Spec(), client: panicFastAPICloudAPI{}}
 			result, err := backend.Run(context.Background(), tc.req)
-			var public ExitError
+			var public core.ExitError
 			if !errors.As(err, &public) || public.Code != 2 || public.Message != tc.want {
 				t.Fatalf("err=%v, want exit2 %q", err, tc.want)
 			}
-			if !reflect.DeepEqual(result, RunResult{}) {
+			if !reflect.DeepEqual(result, core.RunResult{}) {
 				t.Fatalf("result=%#v, want zero result", result)
 			}
 		})
@@ -456,10 +447,10 @@ func TestFastAPICloudRunRejectsBeforeAPI(t *testing.T) {
 func TestFastAPICloudListRequiresAppOrTeam(t *testing.T) {
 	backend := &fastAPICloudBackend{
 		spec:   Provider{}.Spec(),
-		cfg:    Config{},
+		cfg:    core.Config{},
 		client: &fakeFastAPICloudAPI{},
 	}
-	_, err := backend.List(context.Background(), ListRequest{})
+	_, err := backend.List(context.Background(), core.ListRequest{})
 	if err == nil || !strings.Contains(err.Error(), "requires --fastapi-cloud-team-id or --fastapi-cloud-app-id") {
 		t.Fatalf("err = %v, want app/team requirement", err)
 	}
@@ -469,10 +460,10 @@ func TestFastAPICloudListWithAppID(t *testing.T) {
 	fake := &fakeFastAPICloudAPI{
 		app: fastAPICloudApp{ID: "app-1", TeamID: "team-1", Slug: "my-app", Name: "My App", URL: "https://my-app.fastapicloud.app"},
 	}
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.FastAPICloud.AppID = "app-1"
 	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: cfg, client: fake}
-	views, err := backend.List(context.Background(), ListRequest{})
+	views, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -490,10 +481,10 @@ func TestFastAPICloudStatusMapsDeploymentReadiness(t *testing.T) {
 		deployment:    fastAPICloudDeployment{ID: "dep-1", AppID: "app-1", Slug: "my-app-abc", Status: fastAPICloudStatusSuccess, URL: "https://deployment.example"},
 		hasDeployment: true,
 	}
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.FastAPICloud.AppID = "app-1"
 	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: cfg, client: fake}
-	view, err := backend.Status(context.Background(), StatusRequest{})
+	view, err := backend.Status(context.Background(), core.StatusRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -511,10 +502,10 @@ func TestFastAPICloudStatusMapsFailure(t *testing.T) {
 		deployment:    fastAPICloudDeployment{ID: "dep-1", AppID: "app-1", Status: fastAPICloudStatusVerifyingFailed},
 		hasDeployment: true,
 	}
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.FastAPICloud.AppID = "app-1"
 	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: cfg, client: fake}
-	view, err := backend.Status(context.Background(), StatusRequest{})
+	view, err := backend.Status(context.Background(), core.StatusRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -524,9 +515,9 @@ func TestFastAPICloudStatusMapsFailure(t *testing.T) {
 }
 
 func TestApplyFastAPICloudProviderFlags(t *testing.T) {
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	values := RegisterFastAPICloudProviderFlags(fs, Config{})
+	values := RegisterFastAPICloudProviderFlags(fs, core.Config{})
 	if err := fs.Parse([]string{
 		"--fastapi-cloud-url", "http://localhost:8000/api/v1",
 		"--fastapi-cloud-app-id", "app-1",
@@ -544,11 +535,11 @@ func TestApplyFastAPICloudProviderFlags(t *testing.T) {
 
 func TestApplyFastAPICloudProviderFlagsRejectsClassAndType(t *testing.T) {
 	for _, flagName := range []string{"class", "type"} {
-		cfg := Config{Provider: providerName}
+		cfg := core.Config{Provider: providerName}
 		fs := flag.NewFlagSet("test", flag.ContinueOnError)
 		fs.SetOutput(io.Discard)
 		fs.String(flagName, "", "")
-		values := RegisterFastAPICloudProviderFlags(fs, Config{})
+		values := RegisterFastAPICloudProviderFlags(fs, core.Config{})
 		if err := fs.Parse([]string{"--" + flagName, "small"}); err != nil {
 			t.Fatal(err)
 		}
@@ -560,16 +551,16 @@ func TestApplyFastAPICloudProviderFlagsRejectsClassAndType(t *testing.T) {
 }
 
 func TestFastAPICloudWarmupRejected(t *testing.T) {
-	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: Config{}, client: panicFastAPICloudAPI{}}
-	err := backend.Warmup(context.Background(), WarmupRequest{})
+	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: core.Config{}, client: panicFastAPICloudAPI{}}
+	err := backend.Warmup(context.Background(), core.WarmupRequest{})
 	if err == nil || !strings.Contains(err.Error(), "does not support warmup") {
 		t.Fatalf("err = %v, want warmup rejection", err)
 	}
 }
 
 func TestFastAPICloudStopRejected(t *testing.T) {
-	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: Config{}, client: panicFastAPICloudAPI{}}
-	err := backend.Stop(context.Background(), StopRequest{})
+	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: core.Config{}, client: panicFastAPICloudAPI{}}
+	err := backend.Stop(context.Background(), core.StopRequest{})
 	if err == nil || !strings.Contains(err.Error(), "does not support stop") {
 		t.Fatalf("err = %v, want stop rejection", err)
 	}
@@ -582,10 +573,10 @@ func TestFastAPICloudListWithTeamID(t *testing.T) {
 			{ID: "app-2", TeamID: "team-1", Slug: "two", Name: "Two", URL: "https://two.fastapicloud.app"},
 		},
 	}
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.FastAPICloud.TeamID = "team-1"
 	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: cfg, client: fake}
-	views, err := backend.List(context.Background(), ListRequest{})
+	views, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -624,10 +615,10 @@ func TestFastAPICloudClientListAppsPaginatesWithoutCount(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(fastAPICloudListResponse[fastAPICloudApp]{Data: data})
 	}))
 	defer server.Close()
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.FastAPICloud.Token = "test-token"
 	cfg.FastAPICloud.APIURL = server.URL + "/api/v1"
-	client, err := newFastAPICloudClient(cfg, Runtime{HTTP: server.Client()})
+	client, err := newFastAPICloudClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -659,10 +650,10 @@ func TestFastAPICloudClientLatestDeploymentPicksNewest(t *testing.T) {
 		})
 	}))
 	defer server.Close()
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.FastAPICloud.Token = "test-token"
 	cfg.FastAPICloud.APIURL = server.URL + "/api/v1"
-	client, err := newFastAPICloudClient(cfg, Runtime{HTTP: server.Client()})
+	client, err := newFastAPICloudClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -677,10 +668,10 @@ func TestFastAPICloudClientLatestDeploymentPicksNewest(t *testing.T) {
 
 func newTestFastAPICloudClient(t *testing.T, server *httptest.Server) fastAPICloudAPI {
 	t.Helper()
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.FastAPICloud.Token = "secret-tok"
 	cfg.FastAPICloud.APIURL = server.URL + "/api/v1"
-	client, err := newFastAPICloudClient(cfg, Runtime{HTTP: server.Client()})
+	client, err := newFastAPICloudClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -885,10 +876,10 @@ func TestFastAPICloudClientLoopbackHTTPAccepted(t *testing.T) {
 		"http://[::1]:8000/api/v1",
 		"http://LOCALHOST:8000/api/v1",
 	} {
-		cfg := Config{}
+		cfg := core.Config{}
 		cfg.FastAPICloud.Token = "t"
 		cfg.FastAPICloud.APIURL = u
-		if _, err := newFastAPICloudClient(cfg, Runtime{}); err != nil {
+		if _, err := newFastAPICloudClient(cfg, core.Runtime{}); err != nil {
 			t.Fatalf("loopback %q rejected: %v", u, err)
 		}
 	}
@@ -904,10 +895,10 @@ func TestFastAPICloudClientLoopbackSpoofRejected(t *testing.T) {
 		{apiURL: "http://localhost.evil.com/api/v1", want: "must use HTTPS"},
 		{apiURL: "http://0x7f000001/api/v1", want: "must use HTTPS"},
 	} {
-		cfg := Config{}
+		cfg := core.Config{}
 		cfg.FastAPICloud.Token = "t"
 		cfg.FastAPICloud.APIURL = test.apiURL
-		_, err := newFastAPICloudClient(cfg, Runtime{})
+		_, err := newFastAPICloudClient(cfg, core.Runtime{})
 		if err == nil || !strings.Contains(err.Error(), test.want) {
 			t.Fatalf("spoofed loopback %q: err = %v, want %q", test.apiURL, err, test.want)
 		}
@@ -916,10 +907,10 @@ func TestFastAPICloudClientLoopbackSpoofRejected(t *testing.T) {
 
 func TestFastAPICloudClientInvalidURL(t *testing.T) {
 	for _, u := range []string{"://nohost", "https://", "not a url"} {
-		cfg := Config{}
+		cfg := core.Config{}
 		cfg.FastAPICloud.Token = "t"
 		cfg.FastAPICloud.APIURL = u
-		_, err := newFastAPICloudClient(cfg, Runtime{})
+		_, err := newFastAPICloudClient(cfg, core.Runtime{})
 		if err == nil || !strings.Contains(err.Error(), "must be an absolute HTTPS URL") {
 			t.Fatalf("invalid url %q: err = %v, want absolute HTTPS URL rejection", u, err)
 		}
@@ -974,10 +965,10 @@ func TestFastAPICloudStatusNoDeployment(t *testing.T) {
 		},
 		hasDeployment: false,
 	}
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.FastAPICloud.AppID = "app-1"
 	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: cfg, client: fake}
-	view, err := backend.Status(context.Background(), StatusRequest{})
+	view, err := backend.Status(context.Background(), core.StatusRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1042,10 +1033,10 @@ func TestFastAPICloudClientRejectsNonJSONContentType(t *testing.T) {
 
 func TestFastAPICloudStatusAppNotFound(t *testing.T) {
 	fake := &fakeFastAPICloudAPI{getErr: errors.New("app not found")}
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.FastAPICloud.AppID = "missing"
 	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: cfg, client: fake}
-	_, err := backend.Status(context.Background(), StatusRequest{})
+	_, err := backend.Status(context.Background(), core.StatusRequest{})
 	if err == nil || !strings.Contains(err.Error(), "app not found") {
 		t.Fatalf("err = %v, want propagated app lookup error", err)
 	}
@@ -1055,8 +1046,8 @@ func TestFastAPICloudStatusAppNotFound(t *testing.T) {
 }
 
 func TestFastAPICloudStatusRequiresAppID(t *testing.T) {
-	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: Config{}, client: panicFastAPICloudAPI{}}
-	_, err := backend.Status(context.Background(), StatusRequest{})
+	backend := &fastAPICloudBackend{spec: Provider{}.Spec(), cfg: core.Config{}, client: panicFastAPICloudAPI{}}
+	_, err := backend.Status(context.Background(), core.StatusRequest{})
 	if err == nil || !strings.Contains(err.Error(), "status requires") {
 		t.Fatalf("err = %v, want app-id requirement before any API call", err)
 	}

--- a/internal/providers/fastapicloud/client.go
+++ b/internal/providers/fastapicloud/client.go
@@ -131,10 +131,10 @@ func (s fastAPICloudDeploymentStatus) State() string {
 	}
 }
 
-func newFastAPICloudClient(cfg Config, rt Runtime) (fastAPICloudAPI, error) {
+func newFastAPICloudClient(cfg core.Config, rt core.Runtime) (fastAPICloudAPI, error) {
 	token := strings.TrimSpace(cfg.FastAPICloud.Token)
 	if token == "" {
-		return nil, exit(2, "provider=%s requires FASTAPI_CLOUD_TOKEN", providerName)
+		return nil, core.Exit(2, "provider=%s requires FASTAPI_CLOUD_TOKEN", providerName)
 	}
 	apiURL, err := validateFastAPICloudAPIURL(core.Blank(cfg.FastAPICloud.APIURL, core.FastAPICloudConfigDefaultAPIURL))
 	if err != nil {
@@ -156,14 +156,14 @@ func validateFastAPICloudAPIURL(raw string) (string, error) {
 	apiURL := strings.TrimRight(strings.TrimSpace(raw), "/")
 	parsed, err := url.Parse(apiURL)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {
-		return "", exit(2, "provider=%s API URL must be an absolute HTTPS URL", providerName)
+		return "", core.Exit(2, "provider=%s API URL must be an absolute HTTPS URL", providerName)
 	}
 	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", exit(2, "provider=%s API URL must not contain userinfo, query parameters, or a fragment", providerName)
+		return "", core.Exit(2, "provider=%s API URL must not contain userinfo, query parameters, or a fragment", providerName)
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
 	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
-		return "", exit(2, "provider=%s API URL must use HTTPS except for loopback development endpoints", providerName)
+		return "", core.Exit(2, "provider=%s API URL must use HTTPS except for loopback development endpoints", providerName)
 	}
 	return apiURL, nil
 }

--- a/internal/providers/fastapicloud/core.go
+++ b/internal/providers/fastapicloud/core.go
@@ -4,35 +4,9 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-type Config = core.Config
-type FastAPICloudConfig = core.FastAPICloudConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type Server = core.Server
-type ExitError = core.ExitError
-
 const (
 	providerName = "fastapi-cloud"
 	targetLinux  = core.TargetLinux
 
 	networkPublic = core.NetworkPublic
 )
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func inventoryDoctorResult(provider string, leases int) DoctorResult {
-	return core.InventoryDoctorResult(provider, leases)
-}

--- a/internal/providers/fastapicloud/flags.go
+++ b/internal/providers/fastapicloud/flags.go
@@ -11,11 +11,11 @@ import (
 // Deploy tokens are sourced from FASTAPI_CLOUD_TOKEN /
 // CRABBOX_FASTAPI_CLOUD_TOKEN so they are not passed as command-line
 // arguments.
-func RegisterFastAPICloudProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterFastAPICloudProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterFastAPICloudConfigFlags(fs, defaults.FastAPICloud)
 }
 
-func ApplyFastAPICloudProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyFastAPICloudProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
 			return err

--- a/internal/providers/railway/backend.go
+++ b/internal/providers/railway/backend.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -18,45 +19,45 @@ const (
 	railwayClaimDeploymentLabel  = "railwayDeploymentId"
 )
 
-func NewRailwayBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewRailwayBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	return &railwayBackend{spec: spec, cfg: cfg, rt: rt}
 }
 
 type railwayBackend struct {
-	spec   ProviderSpec
-	cfg    Config
-	rt     Runtime
+	spec   core.ProviderSpec
+	cfg    core.Config
+	rt     core.Runtime
 	client railwayAPI
 }
 
-func (b *railwayBackend) Spec() ProviderSpec { return b.spec }
+func (b *railwayBackend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *railwayBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *railwayBackend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	_ = ctx
 	_ = req
 	// Warmup is rejected because Railway services and projects must be created
 	// out-of-band (the provider would otherwise leak billable resources if a
 	// warmup were triggered accidentally). Use the Railway dashboard or CLI to
 	// create the service, then point crabbox at it with --id <serviceId>.
-	return exit(2, "provider=%s does not support warmup; create the Railway service out-of-band", providerName)
+	return core.Exit(2, "provider=%s does not support warmup; create the Railway service out-of-band", providerName)
 }
 
-func (b *railwayBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *railwayBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	_ = ctx
 	if err := shared.RejectServiceRunOptions(req, providerName, "lifecycle is owned by Railway", "runs the Railway service start command"); err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	if req.ID == "" {
-		return RunResult{}, exit(2, "provider=%s requires --id <railway-service-id>", providerName)
+		return core.RunResult{}, core.Exit(2, "provider=%s requires --id <railway-service-id>", providerName)
 	}
 	if len(req.Command) == 0 {
-		return RunResult{}, exit(2, "missing command")
+		return core.RunResult{}, core.Exit(2, "missing command")
 	}
-	return RunResult{}, exit(2, "provider=%s cannot execute arbitrary run commands; Railway only runs the service's configured start command", providerName)
+	return core.RunResult{}, core.Exit(2, "provider=%s cannot execute arbitrary run commands; Railway only runs the service's configured start command", providerName)
 }
 
-func (b *railwayBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *railwayBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	client, err := b.api()
 	if err != nil {
@@ -66,9 +67,9 @@ func (b *railwayBackend) List(ctx context.Context, req ListRequest) ([]LeaseView
 	if err != nil {
 		return nil, err
 	}
-	servers := make([]Server, 0, len(services))
+	servers := make([]core.Server, 0, len(services))
 	for _, s := range services {
-		servers = append(servers, Server{
+		servers = append(servers, core.Server{
 			CloudID:  s.ID,
 			Provider: providerName,
 			Name:     s.Name,
@@ -78,30 +79,30 @@ func (b *railwayBackend) List(ctx context.Context, req ListRequest) ([]LeaseView
 	return servers, nil
 }
 
-func (b *railwayBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *railwayBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	if _, _, err := b.requireProjectEnv(); err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	servers, err := b.List(ctx, ListRequest{})
+	servers, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return inventoryDoctorResult(providerName, len(servers)), nil
+	return core.InventoryDoctorResult(providerName, len(servers)), nil
 }
 
-func (b *railwayBackend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *railwayBackend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	if req.ID == "" {
-		return StatusView{}, exit(2, "provider=%s status requires --id <railway-service-id>", providerName)
+		return core.StatusView{}, core.Exit(2, "provider=%s status requires --id <railway-service-id>", providerName)
 	}
 	projectID, environmentID, err := b.requireProjectEnv()
 	if err != nil {
 		// Status accepts the legacy combined message because callers historically
 		// piped --id-only requests through here.
-		return StatusView{}, exit(2, "provider=%s status requires --railway-project and --railway-environment", providerName)
+		return core.StatusView{}, core.Exit(2, "provider=%s status requires --railway-project and --railway-environment", providerName)
 	}
 	client, err := b.api()
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 
 	// GetService and LatestDeployment are independent reads; fan them out in
@@ -126,13 +127,13 @@ func (b *railwayBackend) Status(ctx context.Context, req StatusRequest) (StatusV
 	}()
 	wg.Wait()
 	if serviceErr != nil {
-		return StatusView{}, serviceErr
+		return core.StatusView{}, serviceErr
 	}
 	if deployErr != nil {
-		return StatusView{}, deployErr
+		return core.StatusView{}, deployErr
 	}
 
-	view := StatusView{
+	view := core.StatusView{
 		ID:         service.ID,
 		Slug:       service.Name,
 		Provider:   providerName,
@@ -147,7 +148,7 @@ func (b *railwayBackend) Status(ctx context.Context, req StatusRequest) (StatusV
 	return view, nil
 }
 
-func (b *railwayBackend) Stop(ctx context.Context, req StopRequest) error {
+func (b *railwayBackend) Stop(ctx context.Context, req core.StopRequest) error {
 	claim, err := b.resolveStopClaim(req.ID)
 	if err != nil {
 		return err
@@ -157,30 +158,28 @@ func (b *railwayBackend) Stop(ctx context.Context, req StopRequest) error {
 		return err
 	}
 	if deployment.ID != claim.Labels[railwayClaimDeploymentLabel] {
-		return exit(4, "provider=%s service=%s latest deployment changed from claimed %s to %s; inspect it and rerun stop --reclaim to adopt the new deployment", providerName, req.ID, claim.Labels[railwayClaimDeploymentLabel], deployment.ID)
+		return core.Exit(4, "provider=%s service=%s latest deployment changed from claimed %s to %s; inspect it and rerun stop --reclaim to adopt the new deployment", providerName, req.ID, claim.Labels[railwayClaimDeploymentLabel], deployment.ID)
 	}
 	return b.stopClaimedDeployment(ctx, service, deployment, claim)
 }
 
-func (b *railwayBackend) ReclaimAndStop(ctx context.Context, req StopRequest) error {
+func (b *railwayBackend) ReclaimAndStop(ctx context.Context, req core.StopRequest) error {
 	if req.ID == "" {
-		return exit(2, "provider=%s stop requires --id <railway-service-id>", providerName)
+		return core.Exit(2, "provider=%s stop requires --id <railway-service-id>", providerName)
 	}
 	service, deployment, err := b.railwayStopTarget(ctx, req.ID)
 	if err != nil {
 		return err
 	}
 	claimID := railwayClaimID(b.cfg, req.ID)
-	previous, previousExists, err := resolveLeaseClaim(claimID)
+	previous, previousExists, err := core.ResolveLeaseClaim(claimID)
 	if err != nil {
 		return err
 	}
 	labels := railwayClaimLabels(b.cfg, req.ID, deployment.ID)
 	claim, err := claimLeaseTargetForConfigIfUnchanged(
 		claimID,
-		b.cfg,
-		Server{CloudID: req.ID, Provider: providerName, Name: service.Name, Labels: labels},
-		previous,
+		b.cfg, core.Server{CloudID: req.ID, Provider: providerName, Name: service.Name, Labels: labels}, previous,
 		previousExists,
 	)
 	if err != nil {
@@ -192,33 +191,33 @@ func (b *railwayBackend) ReclaimAndStop(ctx context.Context, req StopRequest) er
 	return b.stopClaimedDeployment(ctx, service, deployment, claim)
 }
 
-func (b *railwayBackend) resolveStopClaim(serviceID string) (LeaseClaim, error) {
+func (b *railwayBackend) resolveStopClaim(serviceID string) (core.LeaseClaim, error) {
 	if serviceID == "" {
-		return LeaseClaim{}, exit(2, "provider=%s stop requires --id <railway-service-id>", providerName)
+		return core.LeaseClaim{}, core.Exit(2, "provider=%s stop requires --id <railway-service-id>", providerName)
 	}
 	if _, _, err := b.requireProjectEnv(); err != nil {
-		return LeaseClaim{}, exit(2, "provider=%s stop requires --railway-project and --railway-environment", providerName)
+		return core.LeaseClaim{}, core.Exit(2, "provider=%s stop requires --railway-project and --railway-environment", providerName)
 	}
 	claim, ok, err := resolveLeaseClaimForProviderCloudID(serviceID)
 	if err != nil {
-		return LeaseClaim{}, err
+		return core.LeaseClaim{}, err
 	}
 	if !ok {
-		return LeaseClaim{}, exit(4, "provider=%s service=%s is not claimed; inspect the configured project and environment, then use stop --reclaim for explicit one-deployment adoption", providerName, serviceID)
+		return core.LeaseClaim{}, core.Exit(4, "provider=%s service=%s is not claimed; inspect the configured project and environment, then use stop --reclaim for explicit one-deployment adoption", providerName, serviceID)
 	}
 	if err := validateRailwayStopClaim(b.cfg, serviceID, claim); err != nil {
-		return LeaseClaim{}, err
+		return core.LeaseClaim{}, err
 	}
 	return claim, nil
 }
 
 func (b *railwayBackend) railwayStopTarget(ctx context.Context, serviceID string) (railwayService, railwayDeployment, error) {
 	if serviceID == "" {
-		return railwayService{}, railwayDeployment{}, exit(2, "provider=%s stop requires --id <railway-service-id>", providerName)
+		return railwayService{}, railwayDeployment{}, core.Exit(2, "provider=%s stop requires --id <railway-service-id>", providerName)
 	}
 	projectID, environmentID, err := b.requireProjectEnv()
 	if err != nil {
-		return railwayService{}, railwayDeployment{}, exit(2, "provider=%s stop requires --railway-project and --railway-environment", providerName)
+		return railwayService{}, railwayDeployment{}, core.Exit(2, "provider=%s stop requires --railway-project and --railway-environment", providerName)
 	}
 	client, err := b.api()
 	if err != nil {
@@ -229,42 +228,42 @@ func (b *railwayBackend) railwayStopTarget(ctx context.Context, serviceID string
 		return railwayService{}, railwayDeployment{}, err
 	}
 	if service.ID != serviceID || service.ProjectID != projectID {
-		return railwayService{}, railwayDeployment{}, exit(4, "provider=%s service=%s does not belong to configured project=%s", providerName, serviceID, projectID)
+		return railwayService{}, railwayDeployment{}, core.Exit(4, "provider=%s service=%s does not belong to configured project=%s", providerName, serviceID, projectID)
 	}
 	deployment, err := client.LatestDeployment(ctx, projectID, environmentID, serviceID)
 	if err != nil {
 		return railwayService{}, railwayDeployment{}, err
 	}
 	if deployment.ID == "" {
-		return railwayService{}, railwayDeployment{}, exit(5, "provider=%s service=%s has no deployment to stop", providerName, serviceID)
+		return railwayService{}, railwayDeployment{}, core.Exit(5, "provider=%s service=%s has no deployment to stop", providerName, serviceID)
 	}
 	return service, deployment, nil
 }
 
-func (b *railwayBackend) stopClaimedDeployment(ctx context.Context, service railwayService, deployment railwayDeployment, claim LeaseClaim) error {
+func (b *railwayBackend) stopClaimedDeployment(ctx context.Context, service railwayService, deployment railwayDeployment, claim core.LeaseClaim) error {
 	client, err := b.api()
 	if err != nil {
 		return err
 	}
-	updated, err := updateLeaseClaimLabelsIfUnchangedAfter(claim.LeaseID, claim, claim.Labels, func() error {
+	updated, err := core.UpdateLeaseClaimLabelsIfUnchangedAfter(claim.LeaseID, claim, claim.Labels, func() error {
 		return client.StopDeployment(ctx, deployment.ID)
 	})
 	if err != nil {
 		return err
 	}
-	if err := removeLeaseClaimIfUnchanged(updated.LeaseID, updated); err != nil {
+	if err := core.RemoveLeaseClaimIfUnchanged(updated.LeaseID, updated); err != nil {
 		return fmt.Errorf("remove stopped Railway claim: %w", err)
 	}
 	fmt.Fprintf(b.rt.Stderr, "stopped %s service=%s deployment=%s\n", providerName, service.ID, deployment.ID)
 	return nil
 }
 
-func railwayClaimID(cfg Config, serviceID string) string {
+func railwayClaimID(cfg core.Config, serviceID string) string {
 	sum := sha256.Sum256([]byte(providerClaimScope(cfg) + "\x00" + strings.TrimSpace(serviceID)))
 	return "railway_" + hex.EncodeToString(sum[:16])
 }
 
-func railwayClaimLabels(cfg Config, serviceID, deploymentID string) map[string]string {
+func railwayClaimLabels(cfg core.Config, serviceID, deploymentID string) map[string]string {
 	return map[string]string{
 		railwayClaimServiceLabel:     strings.TrimSpace(serviceID),
 		railwayClaimProjectLabel:     strings.TrimSpace(cfg.Railway.ProjectID),
@@ -273,18 +272,18 @@ func railwayClaimLabels(cfg Config, serviceID, deploymentID string) map[string]s
 	}
 }
 
-func validateRailwayStopClaim(cfg Config, serviceID string, claim LeaseClaim) error {
+func validateRailwayStopClaim(cfg core.Config, serviceID string, claim core.LeaseClaim) error {
 	expectedID := railwayClaimID(cfg, serviceID)
 	expectedLabels := railwayClaimLabels(cfg, serviceID, claim.Labels[railwayClaimDeploymentLabel])
 	if claim.LeaseID != expectedID || claim.Provider != providerName || claim.CloudID != serviceID || claim.ProviderScope != providerClaimScope(cfg) {
-		return exit(4, "provider=%s service=%s local claim does not match the configured endpoint, project, and environment; use stop --reclaim only after inspecting the target", providerName, serviceID)
+		return core.Exit(4, "provider=%s service=%s local claim does not match the configured endpoint, project, and environment; use stop --reclaim only after inspecting the target", providerName, serviceID)
 	}
 	if expectedLabels[railwayClaimDeploymentLabel] == "" {
-		return exit(4, "provider=%s service=%s local claim has no exact deployment binding", providerName, serviceID)
+		return core.Exit(4, "provider=%s service=%s local claim has no exact deployment binding", providerName, serviceID)
 	}
 	for key, expected := range expectedLabels {
 		if claim.Labels[key] != expected {
-			return exit(4, "provider=%s service=%s local claim %s mismatch", providerName, serviceID, key)
+			return core.Exit(4, "provider=%s service=%s local claim %s mismatch", providerName, serviceID, key)
 		}
 	}
 	return nil
@@ -304,10 +303,10 @@ func (b *railwayBackend) requireProjectEnv() (string, string, error) {
 	projectID := strings.TrimSpace(b.cfg.Railway.ProjectID)
 	environmentID := strings.TrimSpace(b.cfg.Railway.EnvironmentID)
 	if projectID == "" {
-		return "", "", exit(2, "provider=%s requires --railway-project or RAILWAY_PROJECT_ID", providerName)
+		return "", "", core.Exit(2, "provider=%s requires --railway-project or RAILWAY_PROJECT_ID", providerName)
 	}
 	if environmentID == "" {
-		return "", "", exit(2, "provider=%s requires --railway-environment or RAILWAY_ENVIRONMENT_ID", providerName)
+		return "", "", core.Exit(2, "provider=%s requires --railway-environment or RAILWAY_ENVIRONMENT_ID", providerName)
 	}
 	return projectID, environmentID, nil
 }

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -35,7 +35,7 @@ func TestRailwayProviderSpec(t *testing.T) {
 
 func TestRailwayBindingFlagsRemainDeferredAndLocal(t *testing.T) {
 	for _, name := range []string{"railway", "rail", "railwayapp", " Railway "} {
-		cfg := Config{Provider: name, Railway: RailwayConfig{APIURL: "https://example.invalid/prior", ProjectID: "prior-app", EnvironmentID: "prior-team"}}
+		cfg := core.Config{Provider: name, Railway: core.RailwayConfig{APIURL: "https://example.invalid/prior", ProjectID: "prior-app", EnvironmentID: "prior-team"}}
 		fs := flag.NewFlagSet("test", flag.ContinueOnError)
 		fs.String("class", "", "")
 		fs.String("type", "", "")
@@ -64,7 +64,7 @@ func TestRailwayBindingFlagsRemainDeferredAndLocal(t *testing.T) {
 		if !reflect.DeepEqual(cfg, before) {
 			t.Fatal("wrapper copies or global provenance side effects changed")
 		}
-		if _, err := (Provider{}).Configure(cfg, Runtime{}); err != nil {
+		if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err != nil {
 			t.Fatalf("Configure performed client validation: %v", err)
 		}
 		if err := ApplyRailwayProviderFlags(&cfg, fs, struct{}{}); err != nil {
@@ -94,8 +94,8 @@ func TestRailwayBindingFlagsRemainDeferredAndLocal(t *testing.T) {
 
 func TestRailwayClientDefaultAndValidationOrder(t *testing.T) {
 	for _, rawToken := range []string{"", "  "} {
-		cfg := Config{Railway: RailwayConfig{APIToken: rawToken, APIURL: "relative"}}
-		if _, err := newRailwayClient(cfg, Runtime{}); err == nil || err.Error() != "provider=railway requires RAILWAY_API_TOKEN" {
+		cfg := core.Config{Railway: core.RailwayConfig{APIToken: rawToken, APIURL: "relative"}}
+		if _, err := newRailwayClient(cfg, core.Runtime{}); err == nil || err.Error() != "provider=railway requires RAILWAY_API_TOKEN" {
 			t.Fatalf("token validation order=%v", err)
 		}
 	}
@@ -107,9 +107,9 @@ func TestRailwayClientDefaultAndValidationOrder(t *testing.T) {
 		{raw: "  ", invalid: true},
 		{raw: " https://example.invalid/api/ ", want: "https://example.invalid/api"},
 	} {
-		cfg := Config{Railway: RailwayConfig{APIToken: "inert-constructor-only", APIURL: tc.raw}}
+		cfg := core.Config{Railway: core.RailwayConfig{APIToken: "inert-constructor-only", APIURL: tc.raw}}
 		before := cfg.Railway
-		api, err := newRailwayClient(cfg, Runtime{})
+		api, err := newRailwayClient(cfg, core.Runtime{})
 		if tc.invalid {
 			if err == nil || err.Error() != `railway url "" is invalid` {
 				t.Fatalf("whitespace endpoint=%v", err)
@@ -129,7 +129,7 @@ func TestRailwayClientDefaultAndValidationOrder(t *testing.T) {
 }
 
 func TestRailwayClaimScopeKeepsRawEndpointContract(t *testing.T) {
-	cfg := Config{Railway: RailwayConfig{ProjectID: " project ", EnvironmentID: " environment "}}
+	cfg := core.Config{Railway: core.RailwayConfig{ProjectID: " project ", EnvironmentID: " environment "}}
 	if got := (Provider{}).ClaimScope(cfg); got != "" {
 		t.Fatalf("empty endpoint must not gain client default scope: %q", got)
 	}
@@ -144,24 +144,24 @@ func TestRailwayClaimScopeKeepsRawEndpointContract(t *testing.T) {
 }
 
 func TestRailwayClientRequiresAPIToken(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
-	if _, err := newRailwayClient(cfg, Runtime{}); err == nil {
+	if _, err := newRailwayClient(cfg, core.Runtime{}); err == nil {
 		t.Fatal("newRailwayClient accepted empty API token")
 	}
 }
 
 func TestRailwayClientRejectsBareHTTPURL(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Railway.APIToken = "test-token"
 	cfg.Railway.APIURL = "http://backboard.railway.com/graphql/v2"
-	if _, err := newRailwayClient(cfg, Runtime{}); err == nil {
+	if _, err := newRailwayClient(cfg, core.Runtime{}); err == nil {
 		t.Fatal("newRailwayClient accepted plaintext http URL")
 	}
 }
 
 func TestRailwayTokenFlagIsNotRegistered(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Railway.APIToken = "secret-token"
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	RegisterRailwayProviderFlags(fs, cfg)
@@ -209,10 +209,10 @@ func TestRailwayClientSendsBearerAndGraphQLBody(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Railway.APIToken = "test-token"
 	cfg.Railway.APIURL = server.URL
-	client, err := newRailwayClient(cfg, Runtime{HTTP: server.Client()})
+	client, err := newRailwayClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,10 +259,7 @@ func TestRailwayClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
 	}))
 	defer trusted.Close()
 
-	api, err := newRailwayClient(
-		Config{Railway: RailwayConfig{APIToken: "test-token", APIURL: trusted.URL}},
-		Runtime{HTTP: trusted.Client()},
-	)
+	api, err := newRailwayClient(core.Config{Railway: core.RailwayConfig{APIToken: "test-token", APIURL: trusted.URL}}, core.Runtime{HTTP: trusted.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -293,10 +290,7 @@ func TestRailwayClientFollowsSameOriginRedirect(t *testing.T) {
 	}))
 	defer server.Close()
 
-	api, err := newRailwayClient(
-		Config{Railway: RailwayConfig{APIToken: "test-token", APIURL: server.URL + "/graphql"}},
-		Runtime{HTTP: server.Client()},
-	)
+	api, err := newRailwayClient(core.Config{Railway: core.RailwayConfig{APIToken: "test-token", APIURL: server.URL + "/graphql"}}, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -325,10 +319,7 @@ func TestRailwayClientPreservesCallerRedirectPolicy(t *testing.T) {
 		callerChecks++
 		return callerErr
 	}
-	api, err := newRailwayClient(
-		Config{Railway: RailwayConfig{APIToken: "test-token", APIURL: server.URL}},
-		Runtime{HTTP: httpClient},
-	)
+	api, err := newRailwayClient(core.Config{Railway: core.RailwayConfig{APIToken: "test-token", APIURL: server.URL}}, core.Runtime{HTTP: httpClient})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -367,10 +358,10 @@ func TestRailwayClientRequiresLatestDeploymentBeforeRedeploy(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Railway.APIToken = "test-token"
 	cfg.Railway.APIURL = server.URL
-	client, err := newRailwayClient(cfg, Runtime{HTTP: server.Client()})
+	client, err := newRailwayClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -391,10 +382,10 @@ func TestRailwayClientRejectsEmptyRedeployResponse(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Railway.APIToken = "test-token"
 	cfg.Railway.APIURL = server.URL
-	client, err := newRailwayClient(cfg, Runtime{HTTP: server.Client()})
+	client, err := newRailwayClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -410,10 +401,10 @@ func TestRailwayClientSurfacesNon2xxAsAPIError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Railway.APIToken = "wrong-token"
 	cfg.Railway.APIURL = server.URL
-	client, err := newRailwayClient(cfg, Runtime{HTTP: server.Client()})
+	client, err := newRailwayClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -439,10 +430,10 @@ func TestRailwayClientSurfacesGraphQLErrorsAsAPIError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Railway.APIToken = "test-token"
 	cfg.Railway.APIURL = server.URL
-	client, err := newRailwayClient(cfg, Runtime{HTTP: server.Client()})
+	client, err := newRailwayClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -536,10 +527,10 @@ func TestRailwayClientListServicesPaginatesProjectsAndServices(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Railway.APIToken = "test-token"
 	cfg.Railway.APIURL = server.URL
-	client, err := newRailwayClient(cfg, Runtime{HTTP: server.Client()})
+	client, err := newRailwayClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -596,10 +587,10 @@ func TestRailwayClientDecodesLargeLogResponse(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Railway.APIToken = "test-token"
 	cfg.Railway.APIURL = server.URL
-	client, err := newRailwayClient(cfg, Runtime{HTTP: server.Client()})
+	client, err := newRailwayClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -616,8 +607,8 @@ func TestRailwayClientDecodesLargeLogResponse(t *testing.T) {
 }
 
 func TestRailwayRunRequiresNoSync(t *testing.T) {
-	backend := &railwayBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-	_, err := backend.Run(context.Background(), RunRequest{ID: "svc-1", Command: []string{"pnpm", "test"}})
+	backend := &railwayBackend{rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	_, err := backend.Run(context.Background(), core.RunRequest{ID: "svc-1", Command: []string{"pnpm", "test"}})
 	if err == nil {
 		t.Fatal("Run accepted request without --no-sync")
 	}
@@ -627,8 +618,8 @@ func TestRailwayRunRequiresNoSync(t *testing.T) {
 }
 
 func TestRailwayRunRequiresServiceID(t *testing.T) {
-	backend := &railwayBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-	_, err := backend.Run(context.Background(), RunRequest{NoSync: true})
+	backend := &railwayBackend{rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	_, err := backend.Run(context.Background(), core.RunRequest{NoSync: true})
 	if err == nil || !strings.Contains(err.Error(), "--id") {
 		t.Fatalf("err = %v, want --id rejection", err)
 	}
@@ -636,17 +627,17 @@ func TestRailwayRunRequiresServiceID(t *testing.T) {
 
 func TestRailwayRunRejectsArbitraryCommandBeforeDeploy(t *testing.T) {
 	api := &fakeRailwayAPI{}
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Railway.ProjectID = "proj-1"
 	cfg.Railway.EnvironmentID = "env-1"
-	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
-	result, err := backend.Run(context.Background(), RunRequest{NoSync: true, ID: "svc-1", Command: []string{"false"}})
-	var exitErr ExitError
+	backend := &railwayBackend{cfg: cfg, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
+	result, err := backend.Run(context.Background(), core.RunRequest{NoSync: true, ID: "svc-1", Command: []string{"false"}})
+	var exitErr core.ExitError
 	wantMessage := "provider=railway cannot execute arbitrary run commands; Railway only runs the service's configured start command"
 	if !errors.As(err, &exitErr) || exitErr.Code != 2 || exitErr.Message != wantMessage {
 		t.Fatalf("err = %v, want unsupported command rejection", err)
 	}
-	if !reflect.DeepEqual(result, RunResult{}) {
+	if !reflect.DeepEqual(result, core.RunResult{}) {
 		t.Fatalf("result = %#v, want zero result", result)
 	}
 	if len(api.calls) != 0 {
@@ -657,12 +648,12 @@ func TestRailwayRunRejectsArbitraryCommandBeforeDeploy(t *testing.T) {
 func TestRailwayRunRequiresCommand(t *testing.T) {
 	api := &fakeRailwayAPI{}
 	backend := newRailwayBackendForTest(api)
-	result, err := backend.Run(context.Background(), RunRequest{NoSync: true, ID: "svc-1"})
-	var exitErr ExitError
+	result, err := backend.Run(context.Background(), core.RunRequest{NoSync: true, ID: "svc-1"})
+	var exitErr core.ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 2 || exitErr.Message != "missing command" {
 		t.Fatalf("err = %v, want missing command rejection", err)
 	}
-	if !reflect.DeepEqual(result, RunResult{}) {
+	if !reflect.DeepEqual(result, core.RunResult{}) {
 		t.Fatalf("result = %#v, want zero result", result)
 	}
 	if len(api.calls) != 0 {
@@ -673,27 +664,27 @@ func TestRailwayRunRequiresCommand(t *testing.T) {
 func TestRailwayRunRejectsLeaseFlags(t *testing.T) {
 	for _, tc := range []struct {
 		name string
-		req  RunRequest
+		req  core.RunRequest
 		want string
 	}{
-		{name: "keep first", req: RunRequest{Keep: true, Reclaim: true}, want: "provider=railway lifecycle is owned by Railway; --keep is not supported"},
-		{name: "reclaim", req: RunRequest{Reclaim: true}, want: "provider=railway lifecycle is owned by Railway; --reclaim is not supported"},
-		{name: "sync only", req: RunRequest{NoSync: true, SyncOnly: true}, want: "provider=railway does not support sync; --sync-only is rejected"},
-		{name: "checksum", req: RunRequest{NoSync: true, ChecksumSync: true}, want: "provider=railway does not support sync; --checksum is rejected"},
-		{name: "force large", req: RunRequest{NoSync: true, ForceSyncLarge: true}, want: "provider=railway does not support sync; --force-sync-large is rejected"},
-		{name: "full resync", req: RunRequest{NoSync: true, FullResync: true}, want: "provider=railway does not support sync; --full-resync is rejected"},
-		{name: "shell before ID", req: RunRequest{NoSync: true, ShellMode: true}, want: "provider=railway runs the Railway service start command; --shell is not supported"},
-		{name: "env summary without env", req: RunRequest{NoSync: true, EnvSummary: true}, want: "provider=railway cannot forward per-run environment variables"},
+		{name: "keep first", req: core.RunRequest{Keep: true, Reclaim: true}, want: "provider=railway lifecycle is owned by Railway; --keep is not supported"},
+		{name: "reclaim", req: core.RunRequest{Reclaim: true}, want: "provider=railway lifecycle is owned by Railway; --reclaim is not supported"},
+		{name: "sync only", req: core.RunRequest{NoSync: true, SyncOnly: true}, want: "provider=railway does not support sync; --sync-only is rejected"},
+		{name: "checksum", req: core.RunRequest{NoSync: true, ChecksumSync: true}, want: "provider=railway does not support sync; --checksum is rejected"},
+		{name: "force large", req: core.RunRequest{NoSync: true, ForceSyncLarge: true}, want: "provider=railway does not support sync; --force-sync-large is rejected"},
+		{name: "full resync", req: core.RunRequest{NoSync: true, FullResync: true}, want: "provider=railway does not support sync; --full-resync is rejected"},
+		{name: "shell before ID", req: core.RunRequest{NoSync: true, ShellMode: true}, want: "provider=railway runs the Railway service start command; --shell is not supported"},
+		{name: "env summary without env", req: core.RunRequest{NoSync: true, EnvSummary: true}, want: "provider=railway cannot forward per-run environment variables"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			api := &fakeRailwayAPI{}
 			backend := newRailwayBackendForTest(api)
 			result, err := backend.Run(context.Background(), tc.req)
-			var public ExitError
+			var public core.ExitError
 			if !errors.As(err, &public) || public.Code != 2 || public.Message != tc.want {
 				t.Fatalf("err=%v, want exit2 %q", err, tc.want)
 			}
-			if !reflect.DeepEqual(result, RunResult{}) || len(api.calls) != 0 {
+			if !reflect.DeepEqual(result, core.RunResult{}) || len(api.calls) != 0 {
 				t.Fatalf("result=%#v API calls=%v", result, api.calls)
 			}
 		})
@@ -703,15 +694,15 @@ func TestRailwayRunRejectsLeaseFlags(t *testing.T) {
 func TestRailwayRunAllowsImplicitDefaultEnv(t *testing.T) {
 	api := &fakeRailwayAPI{}
 	backend := newRailwayBackendForTest(api)
-	result, err := backend.Run(context.Background(), RunRequest{
+	result, err := backend.Run(context.Background(), core.RunRequest{
 		ID: "svc-1", NoSync: true, Env: map[string]string{"CI": "true"}, Command: []string{"pnpm", "test"},
 	})
-	var public ExitError
+	var public core.ExitError
 	want := "provider=railway cannot execute arbitrary run commands; Railway only runs the service's configured start command"
 	if !errors.As(err, &public) || public.Code != 2 || public.Message != want {
 		t.Fatalf("err=%v, want command rejection after option admission", err)
 	}
-	if !reflect.DeepEqual(result, RunResult{}) || len(api.calls) != 0 {
+	if !reflect.DeepEqual(result, core.RunResult{}) || len(api.calls) != 0 {
 		t.Fatalf("result=%#v API calls=%v", result, api.calls)
 	}
 }
@@ -722,10 +713,10 @@ func TestRailwayClientRejectsFalseStopDeploymentResponse(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Railway.APIToken = "test-token"
 	cfg.Railway.APIURL = server.URL
-	client, err := newRailwayClient(cfg, Runtime{HTTP: server.Client()})
+	client, err := newRailwayClient(cfg, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -814,12 +805,12 @@ func (f *fakeRailwayAPI) GetService(_ context.Context, _ string) (railwayService
 }
 
 func newRailwayBackendForTest(api *fakeRailwayAPI) *railwayBackend {
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.Railway.APIToken = "test-token"
 	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
 	cfg.Railway.ProjectID = "proj-1"
 	cfg.Railway.EnvironmentID = "env-1"
-	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard}
+	rt := core.Runtime{Stdout: io.Discard, Stderr: io.Discard}
 	return &railwayBackend{
 		spec:   Provider{}.Spec(),
 		cfg:    cfg,
@@ -884,16 +875,16 @@ func TestRailwayDeploymentStatusNormalizesOnUnmarshal(t *testing.T) {
 }
 
 func TestRailwayWarmupRejected(t *testing.T) {
-	backend := &railwayBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-	err := backend.Warmup(context.Background(), WarmupRequest{})
+	backend := &railwayBackend{rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	err := backend.Warmup(context.Background(), core.WarmupRequest{})
 	if err == nil || !strings.Contains(err.Error(), "warmup") {
 		t.Fatalf("Warmup err = %v, want warmup rejection", err)
 	}
 }
 
 func TestRailwayStopRequiresID(t *testing.T) {
-	backend := &railwayBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-	if err := backend.Stop(context.Background(), StopRequest{}); err == nil {
+	backend := &railwayBackend{rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	if err := backend.Stop(context.Background(), core.StopRequest{}); err == nil {
 		t.Fatal("Stop accepted empty service id")
 	}
 }
@@ -904,13 +895,13 @@ func TestRailwayStopRejectsUnclaimedServiceBeforeRemoteReads(t *testing.T) {
 		service:    railwayService{ID: "svc-1", Name: "api", ProjectID: "proj-1"},
 		deployment: railwayDeployment{ID: "dep-1", Status: "BUILDING"},
 	}
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.Railway.APIToken = "test-token"
 	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
 	cfg.Railway.ProjectID = "proj-1"
 	cfg.Railway.EnvironmentID = "env-1"
-	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
-	err := backend.Stop(context.Background(), StopRequest{ID: "svc-1"})
+	backend := &railwayBackend{cfg: cfg, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
+	err := backend.Stop(context.Background(), core.StopRequest{ID: "svc-1"})
 	if err == nil || !strings.Contains(err.Error(), "not claimed") {
 		t.Fatalf("Stop err=%v, want unclaimed rejection", err)
 	}
@@ -926,7 +917,7 @@ func TestRailwayReclaimAndStopBindsExactDeployment(t *testing.T) {
 		deployment: railwayDeployment{ID: "dep-1", Status: "BUILDING"},
 	}
 	backend := newRailwayBackendForTest(api)
-	if err := backend.ReclaimAndStop(context.Background(), StopRequest{ID: "svc-1"}); err != nil {
+	if err := backend.ReclaimAndStop(context.Background(), core.StopRequest{ID: "svc-1"}); err != nil {
 		t.Fatalf("ReclaimAndStop err: %v", err)
 	}
 	if api.stopID != "dep-1" {
@@ -945,7 +936,7 @@ func TestRailwayFailedStopPreservesClaimForExactRetry(t *testing.T) {
 		stopErr:    errors.New("stop unavailable"),
 	}
 	backend := newRailwayBackendForTest(api)
-	err := backend.ReclaimAndStop(context.Background(), StopRequest{ID: "svc-1"})
+	err := backend.ReclaimAndStop(context.Background(), core.StopRequest{ID: "svc-1"})
 	if err == nil || !strings.Contains(err.Error(), "stop unavailable") {
 		t.Fatalf("ReclaimAndStop err=%v, want provider failure", err)
 	}
@@ -958,7 +949,7 @@ func TestRailwayFailedStopPreservesClaimForExactRetry(t *testing.T) {
 	}
 	api.stopErr = nil
 	api.stopID = ""
-	if err := backend.Stop(context.Background(), StopRequest{ID: "svc-1"}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: "svc-1"}); err != nil {
 		t.Fatalf("claimed retry err: %v", err)
 	}
 	if api.stopID != "dep-1" {
@@ -974,13 +965,13 @@ func TestRailwayStopRejectsChangedDeployment(t *testing.T) {
 		stopErr:    errors.New("retain claim"),
 	}
 	backend := newRailwayBackendForTest(api)
-	if err := backend.ReclaimAndStop(context.Background(), StopRequest{ID: "svc-1"}); err == nil {
+	if err := backend.ReclaimAndStop(context.Background(), core.StopRequest{ID: "svc-1"}); err == nil {
 		t.Fatal("ReclaimAndStop unexpectedly succeeded")
 	}
 	api.stopErr = nil
 	api.stopID = ""
 	api.deployment = railwayDeployment{ID: "dep-2", Status: "BUILDING"}
-	err := backend.Stop(context.Background(), StopRequest{ID: "svc-1"})
+	err := backend.Stop(context.Background(), core.StopRequest{ID: "svc-1"})
 	if err == nil || !strings.Contains(err.Error(), "latest deployment changed") {
 		t.Fatalf("Stop err=%v, want changed deployment rejection", err)
 	}
@@ -997,7 +988,7 @@ func TestRailwayStopRejectsClaimFromDifferentEnvironmentBeforeRemoteReads(t *tes
 		stopErr:    errors.New("retain claim"),
 	}
 	backend := newRailwayBackendForTest(api)
-	if err := backend.ReclaimAndStop(context.Background(), StopRequest{ID: "svc-1"}); err == nil {
+	if err := backend.ReclaimAndStop(context.Background(), core.StopRequest{ID: "svc-1"}); err == nil {
 		t.Fatal("ReclaimAndStop unexpectedly succeeded")
 	}
 	api.getServiceCalls = 0
@@ -1005,7 +996,7 @@ func TestRailwayStopRejectsClaimFromDifferentEnvironmentBeforeRemoteReads(t *tes
 	api.stopErr = nil
 	api.stopID = ""
 	backend.cfg.Railway.EnvironmentID = "env-other"
-	err := backend.Stop(context.Background(), StopRequest{ID: "svc-1"})
+	err := backend.Stop(context.Background(), core.StopRequest{ID: "svc-1"})
 	if err == nil || !strings.Contains(err.Error(), "does not match the configured endpoint") {
 		t.Fatalf("Stop err=%v, want scope rejection", err)
 	}
@@ -1021,7 +1012,7 @@ func TestRailwayReclaimRejectsServiceFromDifferentProject(t *testing.T) {
 		deployment: railwayDeployment{ID: "dep-1", Status: "BUILDING"},
 	}
 	backend := newRailwayBackendForTest(api)
-	err := backend.ReclaimAndStop(context.Background(), StopRequest{ID: "svc-1"})
+	err := backend.ReclaimAndStop(context.Background(), core.StopRequest{ID: "svc-1"})
 	if err == nil || !strings.Contains(err.Error(), "does not belong") {
 		t.Fatalf("ReclaimAndStop err=%v, want project rejection", err)
 	}
@@ -1035,13 +1026,13 @@ func TestRailwayStatusReturnsView(t *testing.T) {
 		service:    railwayService{ID: "svc-1", Name: "api", ProjectID: "proj-1"},
 		deployment: railwayDeployment{ID: "dep-1", Status: "SUCCESS"},
 	}
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.Railway.APIToken = "test-token"
 	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
 	cfg.Railway.ProjectID = "proj-1"
 	cfg.Railway.EnvironmentID = "env-1"
-	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
-	view, err := backend.Status(context.Background(), StatusRequest{ID: "svc-1"})
+	backend := &railwayBackend{cfg: cfg, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
+	view, err := backend.Status(context.Background(), core.StatusRequest{ID: "svc-1"})
 	if err != nil {
 		t.Fatalf("Status err: %v", err)
 	}
@@ -1058,13 +1049,13 @@ func TestRailwayStatusMapsTerminalFailureState(t *testing.T) {
 		service:    railwayService{ID: "svc-1", Name: "api", ProjectID: "proj-1"},
 		deployment: railwayDeployment{ID: "dep-1", Status: railwayStatusCrashed},
 	}
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.Railway.APIToken = "test-token"
 	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
 	cfg.Railway.ProjectID = "proj-1"
 	cfg.Railway.EnvironmentID = "env-1"
-	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
-	view, err := backend.Status(context.Background(), StatusRequest{ID: "svc-1"})
+	backend := &railwayBackend{cfg: cfg, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
+	view, err := backend.Status(context.Background(), core.StatusRequest{ID: "svc-1"})
 	if err != nil {
 		t.Fatalf("Status err: %v", err)
 	}
@@ -1081,11 +1072,11 @@ func TestRailwayListEnumeratesServices(t *testing.T) {
 		{ID: "svc-1", Name: "api", ProjectID: "proj-1"},
 		{ID: "svc-2", Name: "worker", ProjectID: "proj-1"},
 	}}
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.Railway.APIToken = "test-token"
 	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
-	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
-	servers, err := backend.List(context.Background(), ListRequest{})
+	backend := &railwayBackend{cfg: cfg, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
+	servers, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatalf("List err: %v", err)
 	}
@@ -1098,23 +1089,23 @@ func TestRailwayListEnumeratesServices(t *testing.T) {
 }
 
 func TestRailwayDoctorRequiresProjectEnvironment(t *testing.T) {
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.Railway.APIToken = "test-token"
 	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
-	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: &fakeRailwayAPI{}}
-	_, err := backend.Doctor(context.Background(), DoctorRequest{})
+	backend := &railwayBackend{cfg: cfg, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: &fakeRailwayAPI{}}
+	_, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err == nil || !strings.Contains(err.Error(), "--railway-project") {
 		t.Fatalf("err = %v, want missing project rejection", err)
 	}
 }
 
 func TestRailwayDoctorRequiresToken(t *testing.T) {
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
 	cfg.Railway.ProjectID = "proj-1"
 	cfg.Railway.EnvironmentID = "env-1"
-	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-	_, err := backend.Doctor(context.Background(), DoctorRequest{})
+	backend := &railwayBackend{cfg: cfg, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	_, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err == nil || !strings.Contains(err.Error(), "RAILWAY_API_TOKEN") {
 		t.Fatalf("err = %v, want missing token rejection", err)
 	}
@@ -1124,13 +1115,13 @@ func TestRailwayDoctorListsServices(t *testing.T) {
 	api := &fakeRailwayAPI{services: []railwayService{
 		{ID: "svc-1", Name: "api", ProjectID: "proj-1"},
 	}}
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.Railway.APIToken = "test-token"
 	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
 	cfg.Railway.ProjectID = "proj-1"
 	cfg.Railway.EnvironmentID = "env-1"
-	backend := &railwayBackend{cfg: cfg, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
-	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	backend := &railwayBackend{cfg: cfg, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}, client: api}
+	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatalf("Doctor err: %v", err)
 	}
@@ -1140,7 +1131,7 @@ func TestRailwayDoctorListsServices(t *testing.T) {
 }
 
 func TestRailwayFlagsApply(t *testing.T) {
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.Railway.APIURL = "https://backboard.railway.com/graphql/v2"
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	values := RegisterRailwayProviderFlags(fs, cfg)
@@ -1161,7 +1152,7 @@ func TestRailwayFlagsApply(t *testing.T) {
 func TestRailwayFlagsRejectUnsupportedSizingForAliases(t *testing.T) {
 	for _, provider := range []string{providerName, "rail", "railwayapp"} {
 		t.Run(provider, func(t *testing.T) {
-			cfg := Config{Provider: provider}
+			cfg := core.Config{Provider: provider}
 			fs := flag.NewFlagSet("test", flag.ContinueOnError)
 			fs.String("class", "", "class")
 			values := RegisterRailwayProviderFlags(fs, cfg)

--- a/internal/providers/railway/bridge.go
+++ b/internal/providers/railway/bridge.go
@@ -32,7 +32,7 @@ import (
 func (b *railwayBackend) PublishPeer(ctx context.Context, leaseID string, port int, ttl time.Duration) (core.BridgePeerTarget, error) {
 	_ = ttl
 	if port <= 0 || port > 65535 {
-		return core.BridgePeerTarget{}, exit(2, "railway bridge: port %d out of range", port)
+		return core.BridgePeerTarget{}, core.Exit(2, "railway bridge: port %d out of range", port)
 	}
 	url, status, err := b.bridgeDeploymentURL(ctx, leaseID)
 	if err != nil {
@@ -43,7 +43,7 @@ func (b *railwayBackend) PublishPeer(ctx context.Context, leaseID string, port i
 		if statusText == "" {
 			statusText = "unknown"
 		}
-		return core.BridgePeerTarget{}, exit(4, "railway bridge: deployment for %q is not ready (status=%s)", leaseID, statusText)
+		return core.BridgePeerTarget{}, core.Exit(4, "railway bridge: deployment for %q is not ready (status=%s)", leaseID, statusText)
 	}
 	return core.BridgePeerTarget{Port: port, URL: url}, nil
 }
@@ -69,7 +69,7 @@ func (b *railwayBackend) ListPeerTargets(ctx context.Context, leaseID string) ([
 func (b *railwayBackend) bridgeDeploymentURL(ctx context.Context, leaseID string) (string, railwayDeploymentStatus, error) {
 	serviceID := strings.TrimSpace(leaseID)
 	if serviceID == "" {
-		return "", "", exit(2, "railway bridge: missing lease id")
+		return "", "", core.Exit(2, "railway bridge: missing lease id")
 	}
 	projectID, environmentID, err := b.requireProjectEnv()
 	if err != nil {

--- a/internal/providers/railway/client.go
+++ b/internal/providers/railway/client.go
@@ -154,18 +154,18 @@ func (s railwayDeploymentStatus) ExitCode() int {
 	return 1
 }
 
-func newRailwayClient(cfg Config, rt Runtime) (railwayAPI, error) {
+func newRailwayClient(cfg core.Config, rt core.Runtime) (railwayAPI, error) {
 	apiToken := strings.TrimSpace(cfg.Railway.APIToken)
 	if apiToken == "" {
-		return nil, exit(2, "provider=%s requires RAILWAY_API_TOKEN", providerName)
+		return nil, core.Exit(2, "provider=%s requires RAILWAY_API_TOKEN", providerName)
 	}
 	apiURL := strings.TrimRight(strings.TrimSpace(core.Blank(cfg.Railway.APIURL, core.RailwayConfigDefaultAPIURL)), "/")
 	parsed, err := url.Parse(apiURL)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return nil, exit(2, "%s url %q is invalid", providerName, apiURL)
+		return nil, core.Exit(2, "%s url %q is invalid", providerName, apiURL)
 	}
 	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
-		return nil, exit(2, "%s url %q must use https unless it targets localhost", providerName, apiURL)
+		return nil, core.Exit(2, "%s url %q must use https unless it targets localhost", providerName, apiURL)
 	}
 	httpClient := rt.HTTP
 	if httpClient == nil {

--- a/internal/providers/railway/core.go
+++ b/internal/providers/railway/core.go
@@ -4,28 +4,6 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-type Config = core.Config
-type RailwayConfig = core.RailwayConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type Server = core.Server
-type Repo = core.Repo
-type ExitError = core.ExitError
-type FeatureSet = core.FeatureSet
-type Feature = core.Feature
-type LeaseClaim = core.LeaseClaim
-
 const (
 	providerName = "railway"
 	targetLinux  = core.TargetLinux
@@ -33,34 +11,14 @@ const (
 	networkPublic = core.NetworkPublic
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func inventoryDoctorResult(provider string, leases int) DoctorResult {
-	return core.InventoryDoctorResult(provider, leases)
-}
-
-func claimLeaseTargetForConfigIfUnchanged(leaseID string, cfg Config, server Server, expected LeaseClaim, expectedExists bool) (LeaseClaim, error) {
+func claimLeaseTargetForConfigIfUnchanged(leaseID string, cfg core.Config, server core.Server, expected core.LeaseClaim, expectedExists bool) (core.LeaseClaim, error) {
 	return core.ClaimLeaseTargetForConfigIfUnchanged(leaseID, "", cfg, server, core.SSHTarget{}, 0, expected, expectedExists)
 }
 
-func resolveLeaseClaim(identifier string) (LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaim(identifier)
-}
-
-func resolveLeaseClaimForProviderCloudID(cloudID string) (LeaseClaim, bool, error) {
+func resolveLeaseClaimForProviderCloudID(cloudID string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaimForProviderCloudID(cloudID, providerName)
 }
 
-func providerClaimScope(cfg Config) string {
+func providerClaimScope(cfg core.Config) string {
 	return core.ProviderClaimScope(providerName, cfg)
-}
-
-func updateLeaseClaimLabelsIfUnchangedAfter(leaseID string, expected LeaseClaim, labels map[string]string, action func() error) (LeaseClaim, error) {
-	return core.UpdateLeaseClaimLabelsIfUnchangedAfter(leaseID, expected, labels, action)
-}
-
-func removeLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
-	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
 }

--- a/internal/providers/railway/flags.go
+++ b/internal/providers/railway/flags.go
@@ -11,11 +11,11 @@ import (
 // intentionally not surfaced as a flag because secrets must not be passed as
 // command-line arguments; it is sourced from RAILWAY_API_TOKEN /
 // CRABBOX_RAILWAY_API_TOKEN.
-func RegisterRailwayProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterRailwayProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterRailwayConfigFlags(fs, defaults.Railway)
 }
 
-func ApplyRailwayProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyRailwayProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
 			return err

--- a/internal/providers/tensorlake/backend.go
+++ b/internal/providers/tensorlake/backend.go
@@ -14,20 +14,20 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func NewTensorlakeBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewTensorlakeBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	return &tensorlakeBackend{spec: spec, cfg: cfg, rt: rt}
 }
 
 type tensorlakeBackend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
-func (b *tensorlakeBackend) Spec() ProviderSpec { return b.spec }
+func (b *tensorlakeBackend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *tensorlakeBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *tensorlakeBackend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	started := core.ClockNow(b.rt.Clock)
 	cli, err := newTensorlakeCLI(b.cfg, b.rt)
 	if err != nil {
@@ -51,7 +51,7 @@ func (b *tensorlakeBackend) Warmup(ctx context.Context, req WarmupRequest) error
 	})
 }
 
-func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *tensorlakeBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	workdir, workdirErr := tensorlakeWorkdir(b.cfg)
 	var cli *tensorlakeCLI
 	var claim core.LeaseClaim
@@ -66,7 +66,7 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		return core.WithLeaseClaimUnchangedContext(ctx, claim.LeaseID, claim, func() error {
 			item, err := cli.verifyBinding(ctx, binding)
 			if err == nil && item.State == "terminated" {
-				return exit(2, "Tensorlake sandbox has terminated; create a new lease")
+				return core.Exit(2, "Tensorlake sandbox has terminated; create a new lease")
 			}
 			return err
 		})
@@ -125,7 +125,7 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 			}
 			args := intent.Argv("bash", "-lc")
 			if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
-				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+				core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 			}
 			command := shared.DelegatedSandboxCommand{OutputScope: core.RunOutputProvider}
 			if len(req.Env) > 0 {
@@ -154,7 +154,7 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 	})
 }
 
-func (b *tensorlakeBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *tensorlakeBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	cli, err := newTensorlakeCLI(b.cfg, b.rt)
 	if err != nil {
@@ -164,7 +164,7 @@ func (b *tensorlakeBackend) List(ctx context.Context, req ListRequest) ([]LeaseV
 	if err != nil {
 		return nil, err
 	}
-	servers := make([]Server, 0, len(ids))
+	servers := make([]core.Server, 0, len(ids))
 	for _, id := range ids {
 		leaseID := leasePrefix + id
 		claim, ok, err := core.ReadLeaseClaimWithPresence(leaseID)
@@ -187,7 +187,7 @@ func (b *tensorlakeBackend) List(ctx context.Context, req ListRequest) ([]LeaseV
 			return nil, err
 		}
 
-		servers = append(servers, Server{
+		servers = append(servers, core.Server{
 			Provider: providerName,
 			CloudID:  id,
 			Name:     id,
@@ -204,27 +204,27 @@ func (b *tensorlakeBackend) List(ctx context.Context, req ListRequest) ([]LeaseV
 	return servers, nil
 }
 
-func (b *tensorlakeBackend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
-	servers, err := b.List(ctx, ListRequest{})
+func (b *tensorlakeBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
+	servers, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return cliDoctorResult(providerName, len(servers), "unchecked"), nil
+	return core.CLIDoctorResult(providerName, len(servers), "unchecked"), nil
 }
 
-func (b *tensorlakeBackend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *tensorlakeBackend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	cli, err := newTensorlakeCLI(b.cfg, b.rt)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	claim, err := b.resolveLease(ctx, cli, req.ID, "", false)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	leaseID, sandboxID, slug := claim.LeaseID, claim.CloudID, claim.Slug
 	_, binding, err := bindingForClaim(claim)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	deadline := core.ClockNow(b.rt.Clock).Add(req.WaitTimeout)
 	if req.WaitTimeout <= 0 {
@@ -241,14 +241,14 @@ func (b *tensorlakeBackend) Status(ctx context.Context, req StatusRequest) (Stat
 		state := item.State
 		if describeErr != nil {
 			if !req.Wait {
-				return StatusView{}, describeErr
+				return core.StatusView{}, describeErr
 			}
 			lastDescribeErr = describeErr
 		} else {
 			lastDescribeErr = nil
 		}
 		ready := describeErr == nil && isReadyState(state)
-		view := StatusView{
+		view := core.StatusView{
 			ID:       leaseID,
 			Slug:     slug,
 			Provider: providerName,
@@ -267,25 +267,25 @@ func (b *tensorlakeBackend) Status(ctx context.Context, req StatusRequest) (Stat
 			return view, nil
 		}
 		if core.ClockNow(b.rt.Clock).After(deadline) {
-			err := exit(5, "timed out waiting for tensorlake sandbox %s to become ready", sandboxID)
+			err := core.Exit(5, "timed out waiting for tensorlake sandbox %s to become ready", sandboxID)
 			if lastDescribeErr != nil {
-				return StatusView{}, errors.Join(err, fmt.Errorf("last tensorlake describe failed: %w", lastDescribeErr))
+				return core.StatusView{}, errors.Join(err, fmt.Errorf("last tensorlake describe failed: %w", lastDescribeErr))
 			}
-			return StatusView{}, err
+			return core.StatusView{}, err
 		}
 		select {
 		case <-ctx.Done():
 			err := ctx.Err()
 			if lastDescribeErr != nil {
-				return StatusView{}, errors.Join(err, fmt.Errorf("last tensorlake describe failed: %w", lastDescribeErr))
+				return core.StatusView{}, errors.Join(err, fmt.Errorf("last tensorlake describe failed: %w", lastDescribeErr))
 			}
-			return StatusView{}, err
+			return core.StatusView{}, err
 		case <-time.After(2 * time.Second):
 		}
 	}
 }
 
-func (b *tensorlakeBackend) Stop(ctx context.Context, req StopRequest) error {
+func (b *tensorlakeBackend) Stop(ctx context.Context, req core.StopRequest) error {
 	cli, err := newTensorlakeCLI(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -301,9 +301,9 @@ func (b *tensorlakeBackend) Stop(ctx context.Context, req StopRequest) error {
 	return nil
 }
 
-func (b *tensorlakeBackend) createSandbox(ctx context.Context, cli *tensorlakeCLI, repo Repo, reclaim bool, requestedSlug string) (core.LeaseClaim, string, error) {
+func (b *tensorlakeBackend) createSandbox(ctx context.Context, cli *tensorlakeCLI, repo core.Repo, reclaim bool, requestedSlug string) (core.LeaseClaim, string, error) {
 	if strings.TrimSpace(repo.Root) == "" {
-		return core.LeaseClaim{}, "", exit(2, "Tensorlake acquisition requires a repository root for durable ownership")
+		return core.LeaseClaim{}, "", core.Exit(2, "Tensorlake acquisition requires a repository root for durable ownership")
 	}
 	scope, err := cli.observeScope(ctx)
 	if err != nil {
@@ -323,7 +323,7 @@ func (b *tensorlakeBackend) createSandbox(ctx context.Context, cli *tensorlakeCL
 		return retained(err)
 	}
 	if item.Name != name || item.State == "terminated" {
-		return retained(exit(2, "Tensorlake creation returned an unexpected sandbox identity or state"))
+		return retained(core.Exit(2, "Tensorlake creation returned an unexpected sandbox identity or state"))
 	}
 	binding := sandboxBinding{id, item.Namespace, scope}
 	rollback := func(cause error) (core.LeaseClaim, string, error) {
@@ -337,15 +337,15 @@ func (b *tensorlakeBackend) createSandbox(ctx context.Context, cli *tensorlakeCL
 		}
 		return core.LeaseClaim{}, "", cause
 	}
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return rollback(err)
 	}
-	server := Server{Provider: providerName, CloudID: id, Name: name, Status: item.State, Labels: map[string]string{"provider": providerName, "lease": leaseID, "slug": slug, "target": targetLinux, "tensorlake_namespace": item.Namespace}}
+	server := core.Server{Provider: providerName, CloudID: id, Name: name, Status: item.State, Labels: map[string]string{"provider": providerName, "lease": leaseID, "slug": slug, "target": targetLinux, "tensorlake_namespace": item.Namespace}}
 	claim, err := core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfterContext(ctx, leaseID, slug, b.cfg, scope, server, core.SSHTarget{}, repo.Root, b.cfg.IdleTimeout, reclaim, core.LeaseClaim{}, false, func() error {
 		item, err := cli.verifyBinding(ctx, binding)
 		if err == nil && item.State == "terminated" {
-			err = exit(2, "Tensorlake sandbox terminated before ownership publication")
+			err = core.Exit(2, "Tensorlake sandbox terminated before ownership publication")
 		}
 		return err
 	})
@@ -358,7 +358,7 @@ func (b *tensorlakeBackend) createSandbox(ctx context.Context, cli *tensorlakeCL
 func (b *tensorlakeBackend) resolveLease(ctx context.Context, cli *tensorlakeCLI, id, repoRoot string, reclaim bool) (core.LeaseClaim, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return core.LeaseClaim{}, exit(2, "provider=tensorlake requires a Crabbox-created sandbox slug or lease id")
+		return core.LeaseClaim{}, core.Exit(2, "provider=tensorlake requires a Crabbox-created sandbox slug or lease id")
 	}
 	strict := strings.HasPrefix(id, leasePrefix) || isLikelySandboxID(id)
 	if isLikelySandboxID(id) {
@@ -369,18 +369,18 @@ func (b *tensorlakeBackend) resolveLease(ctx context.Context, cli *tensorlakeCLI
 		return core.LeaseClaim{}, err
 	}
 	if !ok || (strict || exact) && (!exact || claim.LeaseID != id) {
-		return core.LeaseClaim{}, exit(4, "tensorlake sandbox %q is not exactly claimed by Crabbox", id)
+		return core.LeaseClaim{}, core.Exit(4, "tensorlake sandbox %q is not exactly claimed by Crabbox", id)
 	}
 	_, binding, err := bindingForClaim(claim)
 	if err != nil {
 		return core.LeaseClaim{}, err
 	}
 	if repoRoot != "" {
-		server := Server{Provider: providerName, CloudID: claim.CloudID, Labels: shared.CloneLabels(claim.Labels)}
+		server := core.Server{Provider: providerName, CloudID: claim.CloudID, Labels: shared.CloneLabels(claim.Labels)}
 		return core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfterContext(ctx, claim.LeaseID, claim.Slug, b.cfg, claim.ProviderScope, server, core.SSHTarget{}, repoRoot, timeoutOrDefault(b.cfg.IdleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim, claim, true, func() error {
 			item, err := cli.verifyBinding(ctx, binding)
 			if err == nil && item.State == "terminated" {
-				err = exit(2, "Tensorlake sandbox has terminated; create a new lease")
+				err = core.Exit(2, "Tensorlake sandbox has terminated; create a new lease")
 			}
 			return err
 		})
@@ -395,8 +395,8 @@ func timeoutOrDefault(primary, fallback time.Duration) time.Duration {
 	return fallback
 }
 
-func newSandboxName(repo Repo) string {
-	base := normalizeLeaseSlug(repo.Name)
+func newSandboxName(repo core.Repo) string {
+	base := core.NormalizeLeaseSlug(repo.Name)
 	if base == "" {
 		base = "crabbox"
 	}
@@ -429,18 +429,18 @@ func randomSuffix() string {
 
 // tensorlakeWorkdir returns the configured absolute workspace path inside the
 // sandbox, validating that it isn't relative or empty.
-func tensorlakeWorkdir(cfg Config) (string, error) {
+func tensorlakeWorkdir(cfg core.Config) (string, error) {
 	workdir := strings.TrimSpace(cfg.Tensorlake.Workdir)
 	if workdir == "" {
 		workdir = core.TensorlakeConfigDefaultWorkdir
 	}
 	clean := path.Clean(workdir)
 	if !strings.HasPrefix(clean, "/") {
-		return "", exit(2, "tensorlake workdir %q must be an absolute path", workdir)
+		return "", core.Exit(2, "tensorlake workdir %q must be an absolute path", workdir)
 	}
 	switch clean {
 	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspace":
-		return "", exit(2, "tensorlake workdir %q is too broad; choose a dedicated subdirectory", clean)
+		return "", core.Exit(2, "tensorlake workdir %q is too broad; choose a dedicated subdirectory", clean)
 	}
 	return clean, nil
 }

--- a/internal/providers/tensorlake/backend_test.go
+++ b/internal/providers/tensorlake/backend_test.go
@@ -210,7 +210,7 @@ func TestStatusReturnsDescribeErrorWithoutWait(t *testing.T) {
 		"sbx describe": {stderr: "sandbox not found\n", exitCode: 1},
 	}, nil)
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
-	_, err := backend.Status(context.Background(), StatusRequest{ID: "status-missing"})
+	_, err := backend.Status(context.Background(), core.StatusRequest{ID: "status-missing"})
 	if err == nil || !strings.Contains(err.Error(), "ownership control command failed") {
 		t.Fatalf("Status err=%v, want describe failure", err)
 	}
@@ -229,7 +229,7 @@ func TestStatusWaitTimeoutIncludesDescribeError(t *testing.T) {
 	rt := newTestRuntime(runner)
 	rt.Clock = &stepClock{now: time.Unix(0, 0), step: time.Second}
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), rt).(*tensorlakeBackend)
-	_, err := backend.Status(context.Background(), StatusRequest{ID: "status-wait", Wait: true, WaitTimeout: time.Millisecond})
+	_, err := backend.Status(context.Background(), core.StatusRequest{ID: "status-wait", Wait: true, WaitTimeout: time.Millisecond})
 	if err == nil || !strings.Contains(err.Error(), "timed out waiting") || !strings.Contains(err.Error(), "ownership control command failed") {
 		t.Fatalf("Status err=%v, want timeout with describe failure", err)
 	}
@@ -248,7 +248,7 @@ func TestStatusWaitContextExpiryIncludesDescribeError(t *testing.T) {
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err := backend.Status(ctx, StatusRequest{ID: "status-context", Wait: true, WaitTimeout: time.Minute})
+	_, err := backend.Status(ctx, core.StatusRequest{ID: "status-context", Wait: true, WaitTimeout: time.Minute})
 	if err == nil || !errors.Is(err, context.Canceled) {
 		t.Fatalf("Status err=%v, want context cancellation with describe failure", err)
 	}
@@ -265,7 +265,7 @@ func (c *stepClock) Now() time.Time {
 }
 
 func TestNewSandboxNameUsesRepoName(t *testing.T) {
-	repo := Repo{Name: "carbbox"}
+	repo := core.Repo{Name: "carbbox"}
 	name := newSandboxName(repo)
 	if !strings.HasPrefix(name, "crabbox-carbbox-") {
 		t.Fatalf("name=%q does not start with crabbox-carbbox-", name)
@@ -273,7 +273,7 @@ func TestNewSandboxNameUsesRepoName(t *testing.T) {
 }
 
 func TestNewSandboxNameStripsRedundantPrefix(t *testing.T) {
-	repo := Repo{Name: "crabbox-app"}
+	repo := core.Repo{Name: "crabbox-app"}
 	name := newSandboxName(repo)
 	if strings.HasPrefix(name, "crabbox-crabbox-") {
 		t.Fatalf("name=%q double-prefixed", name)
@@ -284,7 +284,7 @@ func TestNewSandboxNameStripsRedundantPrefix(t *testing.T) {
 }
 
 func TestNewSandboxNameFitsTensorlakeLimit(t *testing.T) {
-	repo := Repo{Name: strings.Repeat("very-long-repo-name-", 8)}
+	repo := core.Repo{Name: strings.Repeat("very-long-repo-name-", 8)}
 	name := newSandboxName(repo)
 	if len(name) > 63 {
 		t.Fatalf("name len=%d want <=63: %q", len(name), name)
@@ -395,16 +395,16 @@ func scriptKey(args []string) string {
 	return ""
 }
 
-func newTestRuntime(runner *recordingCommandRunner) Runtime {
-	return Runtime{
+func newTestRuntime(runner *recordingCommandRunner) core.Runtime {
+	return core.Runtime{
 		Stdout: io.Discard,
 		Stderr: io.Discard,
 		Exec:   runner,
 	}
 }
 
-func newTestConfig() Config {
-	cfg := Config{}
+func newTestConfig() core.Config {
+	cfg := core.Config{}
 	cfg.Tensorlake.APIKey = "tl_apiKey_test"
 	cfg.Tensorlake.APIURL = "https://api.tensorlake.ai"
 	cfg.Tensorlake.CLIPath = "tensorlake"
@@ -425,8 +425,8 @@ func TestRunCreatesExecsAndTerminatesEphemeralSandbox(t *testing.T) {
 	rt := newTestRuntime(runner)
 	backend := NewTensorlakeBackend(Provider{}.Spec(), cfg, rt).(*tensorlakeBackend)
 	repoRoot := t.TempDir()
-	req := RunRequest{
-		Repo:    Repo{Name: "carbbox", Root: repoRoot},
+	req := core.RunRequest{
+		Repo:    core.Repo{Name: "carbbox", Root: repoRoot},
 		Command: []string{"echo", "hello"},
 		NoSync:  true,
 	}
@@ -491,8 +491,8 @@ func TestRunForwardsEnvViaUploadedProfile(t *testing.T) {
 	rt := newTestRuntime(runner)
 	rt.Stderr = &stderr
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), rt).(*tensorlakeBackend)
-	req := RunRequest{
-		Repo:       Repo{Name: "carbbox", Root: t.TempDir()},
+	req := core.RunRequest{
+		Repo:       core.Repo{Name: "carbbox", Root: t.TempDir()},
 		Command:    []string{"printenv", "SECRET_TOKEN"},
 		NoSync:     true,
 		Env:        map[string]string{"SECRET_TOKEN": "super-secret"},
@@ -544,7 +544,7 @@ func TestRunCommandIntentSurvivesNativeCLIArgv(t *testing.T) {
 					t.Fatal(err)
 				}
 				marker := filepath.Join(root, "must-not-exist")
-				request := RunRequest{ID: claim.LeaseID, Repo: Repo{Root: claim.RepoRoot}, NoSync: true, Command: []string{"printf", "%s", "|", "touch", marker}, CommandLiteralArgs: map[int]bool{2: true}}
+				request := core.RunRequest{ID: claim.LeaseID, Repo: core.Repo{Root: claim.RepoRoot}, NoSync: true, Command: []string{"printf", "%s", "|", "touch", marker}, CommandLiteralArgs: map[int]bool{2: true}}
 				if withEnv {
 					request.Env = map[string]string{"FIXTURE": "quoted ' synthetic\n$literal", "PATH": root + ":/usr/bin:/bin"}
 				}
@@ -702,7 +702,7 @@ func TestRunCleansPartialEnvUploadOnReusedSandbox(t *testing.T) {
 					}
 					return core.LocalCommandResult{ExitCode: 7}, uploadErr, true
 				}
-				if scriptKey(req.Args) == "sbx exec" && remotePath != "" && strings.Contains(req.Args[len(req.Args)-1], "rm -f "+shellQuote(remotePath)) {
+				if scriptKey(req.Args) == "sbx exec" && remotePath != "" && strings.Contains(req.Args[len(req.Args)-1], "rm -f "+core.ShellQuote(remotePath)) {
 					if _, ok := callCtx.Deadline(); !ok || callCtx.Err() != nil {
 						t.Fatal("cleanup context must remain live and bounded")
 					}
@@ -711,7 +711,7 @@ func TestRunCleansPartialEnvUploadOnReusedSandbox(t *testing.T) {
 				}
 				return core.LocalCommandResult{}, nil, false
 			}
-			_, err := b.Run(ctx, RunRequest{ID: claim.LeaseID, Repo: Repo{Root: claim.RepoRoot}, NoSync: true, Command: []string{"user-workload"}, Env: map[string]string{"FIXTURE_VALUE": "synthetic-marker"}})
+			_, err := b.Run(ctx, core.RunRequest{ID: claim.LeaseID, Repo: core.Repo{Root: claim.RepoRoot}, NoSync: true, Command: []string{"user-workload"}, Env: map[string]string{"FIXTURE_VALUE": "synthetic-marker"}})
 			if err == nil {
 				t.Fatal("expected partial upload failure")
 			}
@@ -788,12 +788,12 @@ func TestEnvProfileCleanupRejectsChangedAuthority(t *testing.T) {
 						runner.resources[claim.CloudID] = item
 					}
 				}
-				if scriptKey(req.Args) == "sbx exec" && remotePath != "" && strings.Contains(req.Args[len(req.Args)-1], "rm -f "+shellQuote(remotePath)) {
+				if scriptKey(req.Args) == "sbx exec" && remotePath != "" && strings.Contains(req.Args[len(req.Args)-1], "rm -f "+core.ShellQuote(remotePath)) {
 					t.Fatal("stale authority issued remote profile removal")
 				}
 				return core.LocalCommandResult{}, nil, false
 			}
-			_, err := b.Run(t.Context(), RunRequest{ID: claim.LeaseID, Repo: Repo{Root: claim.RepoRoot}, NoSync: true, Command: []string{"user-workload"}, Env: map[string]string{"FIXTURE": "synthetic"}})
+			_, err := b.Run(t.Context(), core.RunRequest{ID: claim.LeaseID, Repo: core.Repo{Root: claim.RepoRoot}, NoSync: true, Command: []string{"user-workload"}, Env: map[string]string{"FIXTURE": "synthetic"}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -956,7 +956,7 @@ func TestRunNativeCommandOutcomes(t *testing.T) {
 				observed = err
 				return result, err, true
 			}
-			result, err := b.Run(ctx, RunRequest{ID: claim.LeaseID, Repo: Repo{Root: claim.RepoRoot}, NoSync: true, TimingJSON: true, Command: []string{"__native_outcome__"}})
+			result, err := b.Run(ctx, core.RunRequest{ID: claim.LeaseID, Repo: core.Repo{Root: claim.RepoRoot}, NoSync: true, TimingJSON: true, Command: []string{"__native_outcome__"}})
 			if calls != 1 || result.ExitCode != wantCode || result.Status != wantStatus || result.ErrorKind != wantKind || result.Session == nil || !result.Session.Kept || !result.Session.Reused {
 				t.Fatalf("scenario=%s calls=%d result=%#v err=%v", scenario, calls, result, err)
 			}
@@ -965,7 +965,7 @@ func TestRunNativeCommandOutcomes(t *testing.T) {
 					t.Fatal(err)
 				}
 			} else {
-				var public ExitError
+				var public core.ExitError
 				if !errors.As(err, &public) || public.Code != wantCode {
 					t.Fatalf("public exit=%#v err=%v", public, err)
 				}
@@ -1017,8 +1017,8 @@ func TestRunSurfacesCommandExitCodeWithoutWrappingError(t *testing.T) {
 	rt := newTestRuntime(runner)
 	rt.Stderr = &stderr
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), rt).(*tensorlakeBackend)
-	req := RunRequest{
-		Repo:       Repo{Name: "carbbox", Root: t.TempDir()},
+	req := core.RunRequest{
+		Repo:       core.Repo{Name: "carbbox", Root: t.TempDir()},
 		Command:    []string{"false"},
 		NoSync:     true,
 		TimingJSON: true,
@@ -1033,7 +1033,7 @@ func TestRunSurfacesCommandExitCodeWithoutWrappingError(t *testing.T) {
 	if !strings.Contains(stderr.String(), `"runStatus":"failed"`) || !strings.Contains(stderr.String(), `"errorKind":"command-exit"`) {
 		t.Fatalf("stderr = %q, want failed command-exit timing", stderr.String())
 	}
-	var ee ExitError
+	var ee core.ExitError
 	if !errors.As(err, &ee) || ee.Code != 7 {
 		t.Fatalf("err=%v want ExitError code=7", err)
 	}
@@ -1056,8 +1056,8 @@ func TestTensorlakeDeleteSyncDoesNotRemoveWorkspaceBeforeUpload(t *testing.T) {
 	cfg := newTestConfig()
 	cfg.Sync.Delete = true
 	backend := NewTensorlakeBackend(Provider{}.Spec(), cfg, newTestRuntime(runner)).(*tensorlakeBackend)
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "repo", Root: repoRoot},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "repo", Root: repoRoot},
 		Command: []string{"echo", "ok"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "upload failed") {
@@ -1147,7 +1147,7 @@ func TestTensorlakeSyncNativeArchiveTransaction(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(repo, "incoming.txt"), []byte("new"), 0o600); err != nil {
 				t.Fatal(err)
 			}
-			_, _, err = backend.syncWorkspace(context.Background(), cli, "sandbox_fixture", RunRequest{Repo: Repo{Root: repo}}, workdir)
+			_, _, err = backend.syncWorkspace(context.Background(), cli, "sandbox_fixture", core.RunRequest{Repo: core.Repo{Root: repo}}, workdir)
 			if scenario.failure != "" && err == nil {
 				t.Fatal("expected transfer failure")
 			}
@@ -1197,8 +1197,8 @@ func TestRunTimingJSONIncludesSlug(t *testing.T) {
 	rt := newTestRuntime(runner)
 	rt.Stderr = &stderr
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), rt).(*tensorlakeBackend)
-	req := RunRequest{
-		Repo:       Repo{Name: "carbbox", Root: t.TempDir()},
+	req := core.RunRequest{
+		Repo:       core.Repo{Name: "carbbox", Root: t.TempDir()},
 		Command:    []string{"echo", "ok"},
 		NoSync:     true,
 		Keep:       true,
@@ -1219,8 +1219,8 @@ func TestRunTimingJSONIncludesSlug(t *testing.T) {
 	if report["leaseId"] != leaseID {
 		t.Fatalf("leaseId=%v want %s in timing JSON:\n%s", report["leaseId"], leaseID, stderr.String())
 	}
-	if report["slug"] != newLeaseSlug(leaseID) {
-		t.Fatalf("slug=%v want %s in timing JSON:\n%s", report["slug"], newLeaseSlug(leaseID), stderr.String())
+	if report["slug"] != core.NewLeaseSlug(leaseID) {
+		t.Fatalf("slug=%v want %s in timing JSON:\n%s", report["slug"], core.NewLeaseSlug(leaseID), stderr.String())
 	}
 }
 
@@ -1241,9 +1241,9 @@ func TestRunTimingJSONUsesClaimSlugForReusedSandbox(t *testing.T) {
 	rt := newTestRuntime(runner)
 	rt.Stderr = &stderr
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), rt).(*tensorlakeBackend)
-	req := RunRequest{
+	req := core.RunRequest{
 		ID:         "custom-slug",
-		Repo:       Repo{Name: "carbbox", Root: repoRoot},
+		Repo:       core.Repo{Name: "carbbox", Root: repoRoot},
 		Command:    []string{"echo", "ok"},
 		NoSync:     true,
 		TimingJSON: true,
@@ -1283,8 +1283,8 @@ func TestKeepOnFailureRetainsSandboxAndPrintsHint(t *testing.T) {
 	rt := newTestRuntime(runner)
 	rt.Stderr = &stderr
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), rt).(*tensorlakeBackend)
-	req := RunRequest{
-		Repo:          Repo{Name: "carbbox", Root: t.TempDir()},
+	req := core.RunRequest{
+		Repo:          core.Repo{Name: "carbbox", Root: t.TempDir()},
 		Command:       []string{"false"},
 		NoSync:        true,
 		KeepOnFailure: true,
@@ -1294,7 +1294,7 @@ func TestKeepOnFailureRetainsSandboxAndPrintsHint(t *testing.T) {
 	if result.ExitCode != 7 {
 		t.Fatalf("exit=%d want 7", result.ExitCode)
 	}
-	var ee ExitError
+	var ee core.ExitError
 	if !errors.As(err, &ee) || ee.Code != 7 {
 		t.Fatalf("err=%v want ExitError code=7", err)
 	}
@@ -1319,8 +1319,8 @@ func TestRunPerformsArchiveSyncByDefault(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repoRoot, "hello.txt"), []byte("hi"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	req := RunRequest{
-		Repo:    Repo{Name: "carbbox", Root: repoRoot},
+	req := core.RunRequest{
+		Repo:    core.Repo{Name: "carbbox", Root: repoRoot},
 		Command: []string{"echo", "ok"},
 	}
 	if _, err := backend.Run(context.Background(), req); err != nil {
@@ -1350,7 +1350,7 @@ func TestTensorlakeRunChecksArchiveBeforeAllocation(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repo, "incoming.txt"), []byte("data"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	_, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Root: repo}, Command: []string{"true"}})
+	_, err := backend.Run(context.Background(), core.RunRequest{Repo: core.Repo{Root: repo}, Command: []string{"true"}})
 	if err == nil || !strings.Contains(err.Error(), "sync candidate too large") {
 		t.Fatalf("err=%v", err)
 	}
@@ -1367,8 +1367,8 @@ func TestRunSkipsSyncWithNoSync(t *testing.T) {
 		"sbx terminate": {stdout: "nosyncidaaaaaaaaaaaa0\n"},
 	}, nil)
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
-	req := RunRequest{
-		Repo:    Repo{Name: "carbbox", Root: t.TempDir()},
+	req := core.RunRequest{
+		Repo:    core.Repo{Name: "carbbox", Root: t.TempDir()},
 		Command: []string{"echo", "ok"},
 		NoSync:  true,
 	}
@@ -1393,8 +1393,8 @@ func TestKeepRetainsSandbox(t *testing.T) {
 		"sbx exec":   {stdout: "hi\n"},
 	}, nil)
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
-	req := RunRequest{
-		Repo:    Repo{Name: "carbbox", Root: t.TempDir()},
+	req := core.RunRequest{
+		Repo:    core.Repo{Name: "carbbox", Root: t.TempDir()},
 		Command: []string{"echo", "hi"},
 		NoSync:  true,
 		Keep:    true,
@@ -1429,9 +1429,9 @@ func TestRunReusedSandboxReportsKeptSession(t *testing.T) {
 	}, nil)
 	runner.resources[sandboxID] = sandboxIdentity{ID: sandboxID, Name: "crabbox-fixture", Namespace: "sandbox_ns", State: "running"}
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
-	req := RunRequest{
+	req := core.RunRequest{
 		ID:      "reuse-session",
-		Repo:    Repo{Name: "carbbox", Root: repoRoot},
+		Repo:    core.Repo{Name: "carbbox", Root: repoRoot},
 		Command: []string{"echo", "hi"},
 		NoSync:  true,
 	}
@@ -1467,8 +1467,8 @@ func TestRunTerminateFailureReportsRetainedSession(t *testing.T) {
 	rt := newTestRuntime(runner)
 	rt.Stderr = &stderr
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), rt).(*tensorlakeBackend)
-	req := RunRequest{
-		Repo:       Repo{Name: "carbbox", Root: t.TempDir()},
+	req := core.RunRequest{
+		Repo:       core.Repo{Name: "carbbox", Root: t.TempDir()},
 		Command:    []string{"echo", "hi"},
 		NoSync:     true,
 		TimingJSON: true,
@@ -1498,7 +1498,7 @@ func TestRunEarlyFailureHonorsKeepOnFailure(t *testing.T) {
 			rt := newTestRuntime(runner)
 			rt.Stderr = &stderr
 			b := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), rt).(*tensorlakeBackend)
-			req := RunRequest{Repo: Repo{Root: t.TempDir()}, NoSync: true, KeepOnFailure: true, TimingJSON: true, Command: []string{"true"}}
+			req := core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, NoSync: true, KeepOnFailure: true, TimingJSON: true, Command: []string{"true"}}
 			switch failure {
 			case "workspace":
 				runner.scripts["sbx exec"] = []scriptedReply{{exitCode: 7}}
@@ -1568,12 +1568,12 @@ func TestRunFinalizationPreservesPrimaryFailure(t *testing.T) {
 			rt := newTestRuntime(runner)
 			rt.Stderr = &stderr
 			b := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), rt).(*tensorlakeBackend)
-			result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir()}, NoSync: true, Command: []string{"workload"}, TimingJSON: true, KeepOnFailure: commandCode == 0})
+			result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, NoSync: true, Command: []string{"workload"}, TimingJSON: true, KeepOnFailure: commandCode == 0})
 			code, kind := commandCode, core.RunErrorCommandExit
 			if commandCode == 0 {
 				code, kind = 1, core.RunErrorProvider
 			}
-			var public ExitError
+			var public core.ExitError
 			if !errors.As(err, &public) || public.Code != code || !errors.Is(err, io.ErrClosedPipe) || result.ExitCode != code || result.Status != core.RunStatusFailed || result.ErrorKind != kind {
 				t.Fatalf("result=%#v err=%v public=%#v", result, err, public)
 			}
@@ -1610,7 +1610,7 @@ func TestRunProfileCleanupWarningDoesNotRetainSuccessfulSandbox(t *testing.T) {
 	rt := newTestRuntime(runner)
 	rt.Stderr = &stderr
 	b := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), rt).(*tensorlakeBackend)
-	result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir()}, NoSync: true, Command: []string{"workload"}, Env: map[string]string{"FIXTURE": "value"}, KeepOnFailure: true, TimingJSON: true})
+	result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, NoSync: true, Command: []string{"workload"}, Env: map[string]string{"FIXTURE": "value"}, KeepOnFailure: true, TimingJSON: true})
 	if err != nil || result.ExitCode != 0 || result.Status != core.RunStatusSucceeded || result.Session == nil || result.Session.Kept {
 		t.Fatalf("best-effort profile cleanup changed success: result=%#v err=%v", result, err)
 	}
@@ -1629,7 +1629,7 @@ func TestRunRejectedReuseKeepsClaimWithoutWorkOrHints(t *testing.T) {
 	runner.resources[claim.CloudID] = item
 	var stderr bytes.Buffer
 	b.rt.Stderr = &stderr
-	result, err := b.Run(t.Context(), RunRequest{ID: claim.LeaseID, NoSync: true, KeepOnFailure: true, Command: []string{"workload"}, TimingJSON: true})
+	result, err := b.Run(t.Context(), core.RunRequest{ID: claim.LeaseID, NoSync: true, KeepOnFailure: true, Command: []string{"workload"}, TimingJSON: true})
 	if err == nil || result.Session == nil || !result.Session.Reused || !result.Session.Kept {
 		t.Fatalf("rejected reuse result=%#v err=%v", result, err)
 	}
@@ -1642,7 +1642,7 @@ func TestRunRejectedReuseKeepsClaimWithoutWorkOrHints(t *testing.T) {
 func TestStopRejectsUnclaimedID(t *testing.T) {
 	runner := newRunner(nil, nil)
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
-	err := backend.Stop(context.Background(), StopRequest{ID: "not-claimed-anywhere"})
+	err := backend.Stop(context.Background(), core.StopRequest{ID: "not-claimed-anywhere"})
 	if err == nil {
 		t.Fatalf("expected rejection of unclaimed sandbox")
 	}
@@ -1665,8 +1665,8 @@ func TestCreateInvocationCarriesSizingFlags(t *testing.T) {
 	cfg.Tensorlake.NoInternet = true
 	cfg.Tensorlake.OrganizationID = "org_xyz"
 	backend := NewTensorlakeBackend(Provider{}.Spec(), cfg, newTestRuntime(runner)).(*tensorlakeBackend)
-	req := RunRequest{
-		Repo:    Repo{Name: "carbbox", Root: t.TempDir()},
+	req := core.RunRequest{
+		Repo:    core.Repo{Name: "carbbox", Root: t.TempDir()},
 		Command: []string{"echo", "ok"},
 		NoSync:  true,
 		Keep:    true,
@@ -1820,11 +1820,11 @@ func TestTensorlakeConfigConstructorAndFallbacks(t *testing.T) {
 	cfg := newTestConfig()
 	cfg.Tensorlake.APIKey = "  "
 	cfg.Tensorlake.APIURL = ":invalid"
-	if _, err := newTensorlakeCLI(cfg, Runtime{}); err == nil || !strings.Contains(err.Error(), "requires TENSORLAKE_API_KEY") {
+	if _, err := newTensorlakeCLI(cfg, core.Runtime{}); err == nil || !strings.Contains(err.Error(), "requires TENSORLAKE_API_KEY") {
 		t.Fatalf("key order: %v", err)
 	}
 	cfg.Tensorlake.APIKey = "inert-key"
-	if _, err := newTensorlakeCLI(cfg, Runtime{}); err == nil || !strings.Contains(err.Error(), "requires Runtime.Exec") {
+	if _, err := newTensorlakeCLI(cfg, core.Runtime{}); err == nil || !strings.Contains(err.Error(), "requires Runtime.Exec") {
 		t.Fatalf("exec order: %v", err)
 	}
 	if _, err := newTensorlakeCLI(cfg, newTestRuntime(runner)); err == nil {

--- a/internal/providers/tensorlake/cli.go
+++ b/internal/providers/tensorlake/cli.go
@@ -13,16 +13,16 @@ import (
 )
 
 type tensorlakeCLI struct {
-	cfg Config
-	rt  Runtime
+	cfg core.Config
+	rt  core.Runtime
 }
 
-func newTensorlakeCLI(cfg Config, rt Runtime) (*tensorlakeCLI, error) {
+func newTensorlakeCLI(cfg core.Config, rt core.Runtime) (*tensorlakeCLI, error) {
 	if strings.TrimSpace(cfg.Tensorlake.APIKey) == "" {
-		return nil, exit(2, "provider=tensorlake requires TENSORLAKE_API_KEY")
+		return nil, core.Exit(2, "provider=tensorlake requires TENSORLAKE_API_KEY")
 	}
 	if rt.Exec == nil {
-		return nil, exit(2, "provider=tensorlake requires Runtime.Exec")
+		return nil, core.Exit(2, "provider=tensorlake requires Runtime.Exec")
 	}
 	apiURL, err := canonicalTensorlakeURL(core.Blank(cfg.Tensorlake.APIURL, core.TensorlakeConfigDefaultAPIURL))
 	if err != nil {
@@ -31,7 +31,7 @@ func newTensorlakeCLI(cfg Config, rt Runtime) (*tensorlakeCLI, error) {
 	cfg.Tensorlake.APIURL = apiURL
 	cfg.Tensorlake.Namespace = core.Blank(strings.TrimSpace(cfg.Tensorlake.Namespace), "default")
 	if !validScopeValue(cfg.Tensorlake.Namespace) {
-		return nil, exit(2, "invalid Tensorlake namespace")
+		return nil, core.Exit(2, "invalid Tensorlake namespace")
 	}
 	return &tensorlakeCLI{cfg: cfg, rt: rt}, nil
 }
@@ -81,7 +81,7 @@ func (c *tensorlakeCLI) runQuiet(ctx context.Context, sub []string, args []strin
 	full = append(full, sub...)
 	full = append(full, args...)
 	var stdout, stderr bytes.Buffer
-	res, err := c.rt.Exec.Run(ctx, LocalCommandRequest{
+	res, err := c.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name:   c.binary(),
 		Args:   full,
 		Env:    c.env(),
@@ -105,7 +105,7 @@ func (c *tensorlakeCLI) runStreamed(ctx context.Context, sub []string, args []st
 	full := append([]string{}, c.globalArgs()...)
 	full = append(full, sub...)
 	full = append(full, args...)
-	res, err := c.rt.Exec.Run(ctx, LocalCommandRequest{
+	res, err := c.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name:   c.binary(),
 		Args:   full,
 		Env:    c.env(),
@@ -208,7 +208,7 @@ func (c *tensorlakeCLI) execShell(ctx context.Context, name, command string) err
 		return fmt.Errorf("tensorlake exec %q: %w", command, err)
 	}
 	if code != 0 {
-		return exit(code, "tensorlake exec %q exited %d", command, code)
+		return core.Exit(code, "tensorlake exec %q exited %d", command, code)
 	}
 	return nil
 }

--- a/internal/providers/tensorlake/core.go
+++ b/internal/providers/tensorlake/core.go
@@ -1,31 +1,8 @@
 package tensorlake
 
 import (
-	"io"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type TensorlakeConfig = core.TensorlakeConfig
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type Server = core.Server
-type Repo = core.Repo
-type ExitError = core.ExitError
-type timingPhase = core.TimingPhase
-type LocalCommandRequest = core.LocalCommandRequest
 
 const (
 	providerName  = "tensorlake"
@@ -38,34 +15,6 @@ const (
 	sandboxNameSuffixLen = 6
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func shellQuote(s string) string {
-	return core.ShellQuote(s)
-}
-
 func tensorlakeCleanupCommand(leaseID string) string {
-	return "crabbox stop --provider " + providerName + " --id " + shellQuote(leaseID)
-}
-
-func cliDoctorResult(provider string, leases int, runtime string) DoctorResult {
-	return core.CLIDoctorResult(provider, leases, runtime)
+	return "crabbox stop --provider " + providerName + " --id " + core.ShellQuote(leaseID)
 }

--- a/internal/providers/tensorlake/env.go
+++ b/internal/providers/tensorlake/env.go
@@ -3,9 +3,10 @@ package tensorlake
 import (
 	"context"
 	"fmt"
+	"time"
+
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
-	"time"
 )
 
 const envProfileCleanupTimeout = 30 * time.Second
@@ -26,14 +27,14 @@ func (b *tensorlakeBackend) uploadEnvProfile(ctx context.Context, cli *tensorlak
 				return err
 			}
 			if item.State == "terminated" {
-				return exit(2, "Tensorlake sandbox has terminated")
+				return core.Exit(2, "Tensorlake sandbox has terminated")
 			}
 			return action()
 		})
 	}
 	cleanup := func(cleanupCtx context.Context) {
 		err := profile.Close(cleanupCtx, func(removeCtx context.Context, remotePath string) error {
-			return authorized(removeCtx, func() error { return cli.execShell(removeCtx, claim.CloudID, "rm -f "+shellQuote(remotePath)) })
+			return authorized(removeCtx, func() error { return cli.execShell(removeCtx, claim.CloudID, "rm -f "+core.ShellQuote(remotePath)) })
 		})
 		if err != nil {
 			fmt.Fprintf(b.rt.Stderr, "warning: tensorlake env profile cleanup failed for %s: %v\n", claim.CloudID, err)

--- a/internal/providers/tensorlake/flags.go
+++ b/internal/providers/tensorlake/flags.go
@@ -6,11 +6,11 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func RegisterTensorlakeProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterTensorlakeProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterTensorlakeConfigFlags(fs, defaults.Tensorlake)
 }
 
-func ApplyTensorlakeProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyTensorlakeProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	v, ok := values.(core.TensorlakeConfigFlagValues)
 	if !ok {
 		return nil

--- a/internal/providers/tensorlake/identity.go
+++ b/internal/providers/tensorlake/identity.go
@@ -26,11 +26,11 @@ type sandboxBinding struct{ ID, Namespace, Scope string }
 func canonicalTensorlakeURL(value string) (string, error) {
 	u, err := url.Parse(strings.TrimSpace(value))
 	if err != nil || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Opaque != "" || u.RawPath != "" {
-		return "", exit(2, "Tensorlake API URL must be an absolute URL without credentials, query, or fragment")
+		return "", core.Exit(2, "Tensorlake API URL must be an absolute URL without credentials, query, or fragment")
 	}
 	u.Scheme, u.Host = strings.ToLower(u.Scheme), strings.ToLower(u.Host)
 	if u.Scheme != "https" && u.Scheme != "http" {
-		return "", exit(2, "Tensorlake API URL requires HTTP or HTTPS")
+		return "", core.Exit(2, "Tensorlake API URL requires HTTP or HTTPS")
 	}
 	u.Path = strings.TrimRight(u.Path, "/")
 	u.RawPath = ""
@@ -58,7 +58,7 @@ func (c *tensorlakeCLI) control(ctx context.Context, args []string) (string, err
 		return "", err
 	}
 	const limit = 1024 * 1024
-	result, err := c.rt.Exec.Run(ctx, LocalCommandRequest{
+	result, err := c.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name: c.binary(), Args: append(c.globalArgs(), args...), Env: c.env(),
 		MaxCapturedOutputBytes: limit, CancelGracePeriod: time.Second,
 	})
@@ -66,7 +66,7 @@ func (c *tensorlakeCLI) control(ctx context.Context, args []string) (string, err
 		return "", ctx.Err()
 	}
 	if err != nil || result.ExitCode != 0 || len(result.Stdout) >= limit || len(result.Stderr) >= limit {
-		return "", exit(5, "Tensorlake ownership control command failed; verify authentication and native CLI support (response withheld)")
+		return "", core.Exit(5, "Tensorlake ownership control command failed; verify authentication and native CLI support (response withheld)")
 	}
 	return result.Stdout, nil
 }
@@ -87,24 +87,24 @@ func (c *tensorlakeCLI) observeScope(ctx context.Context) (string, error) {
 		} `json:"apiKey"`
 	}
 	if err := json.Unmarshal([]byte(out), &identity); err != nil {
-		return "", exit(5, "Tensorlake whoami did not return valid scope JSON; upgrade the native CLI")
+		return "", core.Exit(5, "Tensorlake whoami did not return valid scope JSON; upgrade the native CLI")
 	}
 	api, err := canonicalTensorlakeURL(identity.Endpoints.CloudAPI)
 	if err != nil {
-		return "", exit(5, "Tensorlake whoami returned an invalid cloud API scope")
+		return "", core.Exit(5, "Tensorlake whoami returned an invalid cloud API scope")
 	}
 	sandboxAPI, err := canonicalTensorlakeURL(identity.Endpoints.SandboxAPI)
 	if err != nil {
-		return "", exit(5, "Tensorlake whoami returned an invalid sandbox API scope")
+		return "", core.Exit(5, "Tensorlake whoami returned an invalid sandbox API scope")
 	}
 	if api != c.cfg.Tensorlake.APIURL || !validScopeValue(identity.APIKey.Organization) || !validScopeValue(identity.APIKey.Project) {
-		return "", exit(2, "Tensorlake ownership requires a verified API endpoint and API-key organization/project scope")
+		return "", core.Exit(2, "Tensorlake ownership requires a verified API endpoint and API-key organization/project scope")
 	}
 	if org := strings.TrimSpace(c.cfg.Tensorlake.OrganizationID); org != "" && org != identity.APIKey.Organization {
-		return "", exit(2, "Tensorlake API-key organization differs from the configured organization")
+		return "", core.Exit(2, "Tensorlake API-key organization differs from the configured organization")
 	}
 	if project := strings.TrimSpace(c.cfg.Tensorlake.ProjectID); project != "" && project != identity.APIKey.Project {
-		return "", exit(2, "Tensorlake API-key project differs from the configured project")
+		return "", core.Exit(2, "Tensorlake API-key project differs from the configured project")
 	}
 	data, err := json.Marshal(tensorlakeScope{api, sandboxAPI, identity.APIKey.Organization, identity.APIKey.Project, c.cfg.Tensorlake.Namespace})
 	return string(data), err
@@ -122,13 +122,13 @@ func parseSandboxIdentity(out string) (sandboxIdentity, error) {
 		}
 		key = strings.TrimSpace(key)
 		if seen[key] {
-			return sandboxIdentity{}, exit(5, "Tensorlake describe returned duplicate identity fields")
+			return sandboxIdentity{}, core.Exit(5, "Tensorlake describe returned duplicate identity fields")
 		}
 		seen[key] = true
 		*field = strings.TrimSpace(value)
 	}
 	if !isLikelySandboxID(item.ID) || !validScopeValue(item.Namespace) || !validScopeValue(item.State) {
-		return sandboxIdentity{}, exit(5, "Tensorlake describe did not return an exact sandbox ID, namespace, and state")
+		return sandboxIdentity{}, core.Exit(5, "Tensorlake describe did not return an exact sandbox ID, namespace, and state")
 	}
 	item.State = strings.ToLower(item.State)
 	return item, nil
@@ -136,7 +136,7 @@ func parseSandboxIdentity(out string) (sandboxIdentity, error) {
 
 func (c *tensorlakeCLI) inspectIdentity(ctx context.Context, id string) (sandboxIdentity, error) {
 	if !isLikelySandboxID(id) {
-		return sandboxIdentity{}, exit(2, "Tensorlake ownership requires a canonical sandbox ID")
+		return sandboxIdentity{}, core.Exit(2, "Tensorlake ownership requires a canonical sandbox ID")
 	}
 	out, err := c.control(ctx, []string{"sbx", "describe", id})
 	if err != nil {
@@ -147,7 +147,7 @@ func (c *tensorlakeCLI) inspectIdentity(ctx context.Context, id string) (sandbox
 		return sandboxIdentity{}, err
 	}
 	if item.ID != id {
-		return sandboxIdentity{}, exit(2, "Tensorlake describe returned a different sandbox ID")
+		return sandboxIdentity{}, core.Exit(2, "Tensorlake describe returned a different sandbox ID")
 	}
 	return item, nil
 }
@@ -157,7 +157,7 @@ func bindingForClaim(claim core.LeaseClaim) (shared.ClaimBinding, sandboxBinding
 	want := shared.ClaimBinding{Provider: providerName, LeaseID: leasePrefix + claim.CloudID, Slug: claim.Slug, CloudID: claim.CloudID, ProviderScope: claim.ProviderScope, ExactProviderScope: true, RequiredLabels: map[string]string{"tensorlake_namespace": binding.Namespace}}
 	var scope tensorlakeScope
 	if !isLikelySandboxID(binding.ID) || !validScopeValue(binding.Namespace) || claim.Slug == "" || json.Unmarshal([]byte(binding.Scope), &scope) != nil || scope.APIURL == "" || scope.SandboxAPIURL == "" || !validScopeValue(scope.Organization) || !validScopeValue(scope.Project) || !validScopeValue(scope.Namespace) {
-		return want, binding, exit(2, "Tensorlake lease %q has no exact resource/account binding; retain the sandbox, inspect it with tensorlake sbx describe, and use manual cleanup or create a new lease; --reclaim cannot adopt legacy ownership", claim.LeaseID)
+		return want, binding, core.Exit(2, "Tensorlake lease %q has no exact resource/account binding; retain the sandbox, inspect it with tensorlake sbx describe, and use manual cleanup or create a new lease; --reclaim cannot adopt legacy ownership", claim.LeaseID)
 	}
 	return want, binding, shared.ValidateClaimBinding(claim, want)
 }
@@ -168,14 +168,14 @@ func (c *tensorlakeCLI) verifyBinding(ctx context.Context, binding sandboxBindin
 		return sandboxIdentity{}, err
 	}
 	if scope != binding.Scope {
-		return sandboxIdentity{}, exit(2, "Tensorlake API/account/namespace scope changed; retaining sandbox ownership")
+		return sandboxIdentity{}, core.Exit(2, "Tensorlake API/account/namespace scope changed; retaining sandbox ownership")
 	}
 	item, err := c.inspectIdentity(ctx, binding.ID)
 	if err != nil {
 		return sandboxIdentity{}, err
 	}
 	if item.Namespace != binding.Namespace {
-		return sandboxIdentity{}, exit(2, "Tensorlake sandbox namespace changed; retaining sandbox ownership")
+		return sandboxIdentity{}, core.Exit(2, "Tensorlake sandbox namespace changed; retaining sandbox ownership")
 	}
 	return item, nil
 }

--- a/internal/providers/tensorlake/identity_test.go
+++ b/internal/providers/tensorlake/identity_test.go
@@ -111,7 +111,7 @@ func TestBoundStopRejectsLegacyAndMismatchedAuthority(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			if err := b.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err == nil {
+			if err := b.Stop(t.Context(), core.StopRequest{ID: claim.LeaseID}); err == nil {
 				t.Fatal("unsafe stop succeeded")
 			}
 			if len(callMutationVerbs(r)) != 0 {
@@ -133,13 +133,13 @@ func TestStopConfirmsExactTerminationAndCanRetry(t *testing.T) {
 		}
 		return core.LocalCommandResult{}, nil, false
 	}
-	if err := b.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err == nil {
+	if err := b.Stop(t.Context(), core.StopRequest{ID: claim.LeaseID}); err == nil {
 		t.Fatal("unconfirmed termination succeeded")
 	}
 	assertTensorlakeClaimUnchanged(t, claim)
 	confirmFails = false
 	r.calls = nil
-	if err := b.Stop(t.Context(), StopRequest{ID: claim.Slug}); err != nil {
+	if err := b.Stop(t.Context(), core.StopRequest{ID: claim.Slug}); err != nil {
 		t.Fatal(err)
 	}
 	if len(callMutationVerbs(r)) != 0 {
@@ -230,12 +230,12 @@ func assertTensorlakeClaimWaitDeadline(t *testing.T, operation string) {
 			ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
 			defer cancel()
 			done := make(chan error, 1)
-			var result RunResult
+			var result core.RunResult
 			go func() {
 				var err error
 				switch operation {
 				case "admission":
-					result, err = b.Run(ctx, RunRequest{ID: claim.LeaseID, NoSync: true, Command: []string{"user-workload"}})
+					result, err = b.Run(ctx, core.RunRequest{ID: claim.LeaseID, NoSync: true, Command: []string{"user-workload"}})
 				case "reclaim":
 					_, err = b.resolveLease(ctx, c, claim.LeaseID, repoRoot, true)
 				default:
@@ -291,7 +291,7 @@ func TestOneShotTeardownKeepsOriginalClaim(t *testing.T) {
 		return core.LocalCommandResult{}, nil, false
 	}
 	b := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(r)).(*tensorlakeBackend)
-	result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir()}, NoSync: true, Command: []string{"user-workload"}})
+	result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, NoSync: true, Command: []string{"user-workload"}})
 	if err == nil || result.ExitCode != 1 || result.ErrorKind != core.RunErrorProvider || result.Session == nil || !result.Session.Kept {
 		t.Fatal("expected retained session", err)
 	}
@@ -324,7 +324,7 @@ func TestRollbackRetainsAppearingClaim(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := b.createSandbox(t.Context(), c, Repo{Root: t.TempDir()}, true, ""); err == nil {
+	if _, _, err := b.createSandbox(t.Context(), c, core.Repo{Root: t.TempDir()}, true, ""); err == nil {
 		t.Fatal("acquisition overwrote successor")
 	}
 	if findCall(r, "sbx terminate") != nil {
@@ -339,7 +339,7 @@ func TestCreatePublicationCancellationRetainsDeadlineAndSuccessor(t *testing.T) 
 		t.Fatal(err)
 	}
 	runner.defaults = map[string]scriptedReply{"sbx create": {stdout: claim.CloudID + "\n"}}
-	repo := Repo{Root: t.TempDir()}
+	repo := core.Repo{Root: t.TempDir()}
 	entered, release := make(chan struct{}), make(chan struct{})
 	holderDone := make(chan error, 1)
 	var successor core.LeaseClaim
@@ -404,7 +404,7 @@ func TestCreateRollbackDefaultBudgetIncludesClaimWait(t *testing.T) {
 		t.Fatal(err)
 	}
 	runner.defaults = map[string]scriptedReply{"sbx create": {stdout: claim.CloudID + "\n"}}
-	repo := Repo{Root: t.TempDir()}
+	repo := core.Repo{Root: t.TempDir()}
 	entered, release := make(chan struct{}), make(chan struct{})
 	holderDone := make(chan error, 1)
 	go func() {
@@ -533,7 +533,7 @@ func claimBoundTensorlakeForTest(leaseID, slug, repo string, idle time.Duration,
 	scope, _ := json.Marshal(tensorlakeScope{"https://api.tensorlake.ai", "https://api.tensorlake.ai", "org_fixture", "project_fixture", "default"})
 	cfg := newTestConfig()
 	cfg.Provider = providerName
-	server := Server{Provider: providerName, CloudID: strings.TrimPrefix(leaseID, leasePrefix), Labels: map[string]string{"provider": providerName, "lease": leaseID, "slug": slug, "tensorlake_namespace": "sandbox_ns"}}
+	server := core.Server{Provider: providerName, CloudID: strings.TrimPrefix(leaseID, leasePrefix), Labels: map[string]string{"provider": providerName, "lease": leaseID, "slug": slug, "tensorlake_namespace": "sandbox_ns"}}
 	_, err := core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurable(leaseID, slug, cfg, string(scope), server, core.SSHTarget{}, repo, idle, reclaim, core.LeaseClaim{}, false)
 	return err
 }
@@ -579,7 +579,7 @@ func TestAcquisitionRollbackRequiresFreshScopeAndConfirmsTermination(t *testing.
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, _, err = b.createSandbox(ctx, c, Repo{Root: t.TempDir()}, false, "rollback-sandbox")
+			_, _, err = b.createSandbox(ctx, c, core.Repo{Root: t.TempDir()}, false, "rollback-sandbox")
 			if err == nil || !errors.Is(err, context.Canceled) {
 				t.Fatal("publication cancellation not preserved", err)
 			}
@@ -622,7 +622,7 @@ func TestCancelledStopDoesNotInvokeNativeCLI(t *testing.T) {
 	b, _, r, claim := ownedTensorlakeFixture(t)
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	if err := b.Stop(ctx, StopRequest{ID: claim.LeaseID}); !errors.Is(err, context.Canceled) {
+	if err := b.Stop(ctx, core.StopRequest{ID: claim.LeaseID}); !errors.Is(err, context.Canceled) {
 		t.Fatal("cancellation not preserved", err)
 	}
 	if len(r.calls) != 0 {

--- a/internal/providers/tensorlake/sync.go
+++ b/internal/providers/tensorlake/sync.go
@@ -10,24 +10,24 @@ import (
 
 // rejectIncompatibleSyncOptions keeps unsupported sync modes rejected before
 // archive preparation or provider work. ForceSyncLarge reaches the archive owner.
-func rejectIncompatibleSyncOptions(req RunRequest) error {
+func rejectIncompatibleSyncOptions(req core.RunRequest) error {
 	if req.SyncOnly {
-		return exit(2, "provider=tensorlake uses archive sync; --sync-only is not supported")
+		return core.Exit(2, "provider=tensorlake uses archive sync; --sync-only is not supported")
 	}
 	if req.ChecksumSync {
-		return exit(2, "provider=tensorlake uses archive sync; --checksum is not supported")
+		return core.Exit(2, "provider=tensorlake uses archive sync; --checksum is not supported")
 	}
 	return nil
 }
 
-func (b *tensorlakeBackend) prepareArchive(ctx context.Context, req RunRequest) (*core.PreparedArchive, error) {
+func (b *tensorlakeBackend) prepareArchive(ctx context.Context, req core.RunRequest) (*core.PreparedArchive, error) {
 	return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
 		TempPattern: "crabbox-tensorlake-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 	})
 }
 
-func (b *tensorlakeBackend) syncWorkspace(ctx context.Context, cli *tensorlakeCLI, sandboxID string, req RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+func (b *tensorlakeBackend) syncWorkspace(ctx context.Context, cli *tensorlakeCLI, sandboxID string, req core.RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	var archive *core.PreparedArchive
 	if len(prepared) > 0 {
 		archive = prepared[0]
@@ -51,5 +51,5 @@ func (b *tensorlakeBackend) syncWorkspace(ctx context.Context, cli *tensorlakeCL
 }
 
 func (b *tensorlakeBackend) prepareWorkspace(ctx context.Context, cli *tensorlakeCLI, sandboxID, workdir string) error {
-	return cli.execShell(ctx, sandboxID, "mkdir -p "+shellQuote(workdir))
+	return cli.execShell(ctx, sandboxID, "mkdir -p "+core.ShellQuote(workdir))
 }

--- a/internal/providers/upstashbox/backend.go
+++ b/internal/providers/upstashbox/backend.go
@@ -15,21 +15,21 @@ import (
 )
 
 type backend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
-func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	return &backend{spec: spec, cfg: cfg, rt: rt}
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *backend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if req.ActionsRunner {
-		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+		return core.Exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
 	started := core.ClockNow(b.rt.Clock)
 	client, err := newAPI(b.cfg, b.rt)
@@ -53,7 +53,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	})
 }
 
-func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *backend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	workdir, validationErr := cleanWorkdir(workdir(b.cfg))
 	folder := ""
 	if validationErr == nil {
@@ -110,7 +110,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			}
 			command := intent.ShellSource()
 			if req.EnvSummary {
-				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+				core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 			}
 			var closeCommand func(context.Context) error
 			if len(req.Env) > 0 {
@@ -140,7 +140,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	})
 }
 
-func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	client, err := newAPI(b.cfg, b.rt)
 	if err != nil {
@@ -150,7 +150,7 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 	if err != nil {
 		return nil, err
 	}
-	servers := make([]Server, 0, len(boxes))
+	servers := make([]core.Server, 0, len(boxes))
 	for _, box := range boxes {
 		if isCrabboxBox(box) {
 			servers = append(servers, boxToServer(b.cfg, box))
@@ -159,18 +159,18 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 	return servers, nil
 }
 
-func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
-	servers, err := b.List(ctx, ListRequest{})
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
+	servers, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return inventoryDoctorResult(providerName, len(servers)), nil
+	return core.InventoryDoctorResult(providerName, len(servers)), nil
 }
 
-func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	client, err := newAPI(b.cfg, b.rt)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	return shared.PollDelegatedStatus(ctx, shared.DelegatedStatusRequest{
 		ID:          req.ID,
@@ -198,12 +198,12 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 			}, nil
 		},
 		TimeoutError: func(boxID string) error {
-			return exit(5, "timed out waiting for upstash-box %s to become ready", boxID)
+			return core.Exit(5, "timed out waiting for upstash-box %s to become ready", boxID)
 		},
 	})
 }
 
-func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+func (b *backend) Stop(ctx context.Context, req core.StopRequest) error {
 	client, err := newAPI(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -241,15 +241,15 @@ func (b *backend) deleteClaimedBox(ctx context.Context, client api, leaseID, box
 			return err
 		}
 		if box.ID != boxID || !isCrabboxBox(box) || boxLeaseID(box) != leaseID || boxSlug(leaseID, box) != slug {
-			return exit(2, "provider=%s box %s no longer matches its exact local ownership claim", providerName, boxID)
+			return core.Exit(2, "provider=%s box %s no longer matches its exact local ownership claim", providerName, boxID)
 		}
 		return client.DeleteBoxes(ctx, []string{boxID})
 	})
 }
 
-func (b *backend) createBox(ctx context.Context, client api, repo Repo, keep, reclaim bool, requestedSlug string) (string, boxData, string, error) {
+func (b *backend) createBox(ctx context.Context, client api, repo core.Repo, keep, reclaim bool, requestedSlug string) (string, boxData, string, error) {
 	leaseID := core.NewLeaseID()
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return "", boxData{}, "", err
 	}
@@ -279,14 +279,14 @@ func (b *backend) createBox(ctx context.Context, client api, repo Repo, keep, re
 func (b *backend) resolveBoxID(ctx context.Context, client api, id, repoRoot string, reclaim bool) (string, string, string, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return "", "", "", exit(2, "provider=%s requires a Crabbox lease id, slug, or Upstash Box id", providerName)
+		return "", "", "", core.Exit(2, "provider=%s requires a Crabbox lease id, slug, or Upstash Box id", providerName)
 	}
-	if claim, ok, err := resolveLeaseClaim(id); err != nil {
+	if claim, ok, err := core.ResolveLeaseClaim(id); err != nil {
 		return "", "", "", err
 	} else if ok && claim.Provider == providerName {
 		if repoRoot == "" {
 			if strings.TrimSpace(claim.CloudID) == "" {
-				return "", "", "", exit(2, "provider=%s lease=%s has no exact local ownership claim for an immutable box ID", providerName, claim.LeaseID)
+				return "", "", "", core.Exit(2, "provider=%s lease=%s has no exact local ownership claim for an immutable box ID", providerName, claim.LeaseID)
 			}
 			return claim.LeaseID, claim.CloudID, claim.Slug, nil
 		}
@@ -332,7 +332,7 @@ func resolveBoxByLease(ctx context.Context, client api, leaseID string) (boxData
 			return box, nil
 		}
 	}
-	return boxData{}, exit(4, "upstash-box lease %q was not found", leaseID)
+	return boxData{}, core.Exit(4, "upstash-box lease %q was not found", leaseID)
 }
 
 func resolveBoxBySlug(ctx context.Context, client api, slug string) (boxData, error) {
@@ -345,18 +345,18 @@ func resolveBoxBySlug(ctx context.Context, client api, slug string) (boxData, er
 			return box, nil
 		}
 	}
-	return boxData{}, exit(4, "upstash-box %q was not found", slug)
+	return boxData{}, core.Exit(4, "upstash-box %q was not found", slug)
 }
 
-func boxToServer(cfg Config, box boxData) Server {
+func boxToServer(cfg core.Config, box boxData) core.Server {
 	leaseID := boxLeaseID(box)
-	labels := directLeaseLabels(cfg, leaseID, boxSlug(leaseID, box), providerName, "", box.KeepAlive, time.Now().UTC())
+	labels := core.DirectLeaseLabels(cfg, leaseID, boxSlug(leaseID, box), providerName, "", box.KeepAlive, time.Now().UTC())
 	labels["box_id"] = box.ID
 	labels["box_name"] = box.Name
 	labels["runtime"] = core.Blank(box.Runtime, runtimeName(cfg))
 	labels["size"] = core.Blank(box.Size, sizeName(cfg))
 	labels["state"] = box.Status
-	server := Server{
+	server := core.Server{
 		Provider: providerName,
 		CloudID:  box.ID,
 		Name:     core.Blank(box.Name, box.ID),
@@ -368,7 +368,7 @@ func boxToServer(cfg Config, box boxData) Server {
 	return server
 }
 
-func boxBaseHost(cfg Config) string {
+func boxBaseHost(cfg core.Config) string {
 	raw := core.Blank(strings.TrimSpace(cfg.UpstashBox.BaseURL), core.UpstashBoxConfigDefaultBaseURL)
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Host == "" {
@@ -377,7 +377,7 @@ func boxBaseHost(cfg Config) string {
 	return parsed.Host
 }
 
-func upstashBoxClaimScope(cfg Config) string {
+func upstashBoxClaimScope(cfg core.Config) string {
 	raw := core.Blank(strings.TrimSpace(cfg.UpstashBox.BaseURL), core.UpstashBoxConfigDefaultBaseURL)
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Host == "" {
@@ -406,7 +406,7 @@ func boxSlug(leaseID string, box boxData) string {
 	if match := boxNamePattern.FindStringSubmatch(strings.TrimSpace(box.Name)); len(match) == 3 {
 		return match[1]
 	}
-	return newLeaseSlug(leaseID)
+	return core.NewLeaseSlug(leaseID)
 }
 
 func statusReady(status string) bool {
@@ -426,38 +426,38 @@ func isNotFound(err error) bool {
 	return strings.Contains(msg, "404") || strings.Contains(msg, "not found")
 }
 
-func runtimeName(cfg Config) string {
+func runtimeName(cfg core.Config) string {
 	return core.Blank(strings.TrimSpace(cfg.UpstashBox.Runtime), core.UpstashBoxConfigDefaultRuntime)
 }
 
 func upstashBoxName(leaseID, slug string) string {
 	slug = strings.Trim(strings.ToLower(strings.TrimSpace(slug)), "-")
 	if slug == "" {
-		slug = newLeaseSlug(leaseID)
+		slug = core.NewLeaseSlug(leaseID)
 	}
 	return "crabbox-" + slug + "-" + strings.TrimPrefix(leaseID, "cbx_")
 }
 
-func sizeName(cfg Config) string {
+func sizeName(cfg core.Config) string {
 	return core.Blank(strings.TrimSpace(cfg.UpstashBox.Size), core.UpstashBoxConfigDefaultSize)
 }
 
-func workdir(cfg Config) string {
+func workdir(cfg core.Config) string {
 	return core.Blank(strings.TrimSpace(cfg.UpstashBox.Workdir), core.UpstashBoxConfigDefaultWorkdir)
 }
 
 func cleanWorkdir(workdir string) (string, error) {
 	trimmed := strings.TrimSpace(workdir)
 	if trimmed == "" {
-		return "", exit(2, "upstash-box workdir is empty")
+		return "", core.Exit(2, "upstash-box workdir is empty")
 	}
 	clean := path.Clean(trimmed)
 	if !strings.HasPrefix(clean, "/") {
-		return "", exit(2, "upstash-box workdir %q must resolve to an absolute path", workdir)
+		return "", core.Exit(2, "upstash-box workdir %q must resolve to an absolute path", workdir)
 	}
 	switch clean {
 	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspace", "/workspace/home":
-		return "", exit(2, "upstash-box workdir %q is too broad; choose a dedicated subdirectory", clean)
+		return "", core.Exit(2, "upstash-box workdir %q is too broad; choose a dedicated subdirectory", clean)
 	}
 	return clean, nil
 }
@@ -471,7 +471,7 @@ func workspaceFolder(workdir string) (string, error) {
 	}
 	prefix := workspaceRoot + "/"
 	if !strings.HasPrefix(clean, prefix) {
-		return "", exit(2, "upstash-box workdir %q must be under %s", clean, workspaceRoot)
+		return "", core.Exit(2, "upstash-box workdir %q must be under %s", clean, workspaceRoot)
 	}
 	return strings.TrimPrefix(clean, prefix), nil
 }

--- a/internal/providers/upstashbox/backend_test.go
+++ b/internal/providers/upstashbox/backend_test.go
@@ -67,7 +67,7 @@ func TestUpstashBoxFlagPresenceAndExactGuardOrder(t *testing.T) {
 			t.Fatal("API key flag registered")
 		}
 	})
-	cfg.UpstashBox = UpstashBoxConfig{BaseURL: "https://example.invalid/api", Runtime: "python", Size: "large", Workdir: "/workspace/home/app", KeepAlive: true}
+	cfg.UpstashBox = core.UpstashBoxConfig{BaseURL: "https://example.invalid/api", Runtime: "python", Size: "large", Workdir: "/workspace/home/app", KeepAlive: true}
 	before := cfg
 	if err := ApplyUpstashBoxProviderFlags(&cfg, fs, values); err != nil {
 		t.Fatal(err)
@@ -78,7 +78,7 @@ func TestUpstashBoxFlagPresenceAndExactGuardOrder(t *testing.T) {
 	if err := fs.Parse([]string{"--upstash-box-base-url=https://example.invalid/api", "--upstash-box-runtime=python", "--upstash-box-size=large", "--upstash-box-workdir=/workspace/home/app", "--upstash-box-keep-alive=true"}); err != nil {
 		t.Fatal(err)
 	}
-	cfg.UpstashBox = UpstashBoxConfig{}
+	cfg.UpstashBox = core.UpstashBoxConfig{}
 	if err := ApplyUpstashBoxProviderFlags(&cfg, fs, values); err != nil {
 		t.Fatal(err)
 	}
@@ -92,12 +92,12 @@ func TestUpstashBoxFlagPresenceAndExactGuardOrder(t *testing.T) {
 	if err := ApplyUpstashBoxProviderFlags(&cfg, fs, values); err != nil {
 		t.Fatal(err)
 	}
-	before.UpstashBox = UpstashBoxConfig{}
+	before.UpstashBox = core.UpstashBoxConfig{}
 	if !reflect.DeepEqual(cfg, before) {
 		t.Fatal("visited clears or wrapper provenance changed")
 	}
 	for _, name := range []string{"upstash-box", "upstash", "box", "upstashbox", "UPSTASH", " upstash-box "} {
-		cfg := Config{Provider: name}
+		cfg := core.Config{Provider: name}
 		fs := flag.NewFlagSet("test", flag.ContinueOnError)
 		fs.String("class", "", "")
 		fs.String("type", "", "")
@@ -124,7 +124,7 @@ func TestUpstashBoxFlagPresenceAndExactGuardOrder(t *testing.T) {
 			}
 		}
 	}
-	cfg = Config{UpstashBox: UpstashBoxConfig{Runtime: "other", Size: "other", Workdir: "relative"}}
+	cfg = core.Config{UpstashBox: core.UpstashBoxConfig{Runtime: "other", Size: "other", Workdir: "relative"}}
 	validationFS := flag.NewFlagSet("validation", flag.ContinueOnError)
 	validationValues := RegisterUpstashBoxProviderFlags(validationFS, cfg)
 	if err := ApplyUpstashBoxProviderFlags(&cfg, validationFS, struct{}{}); err != nil {
@@ -133,7 +133,7 @@ func TestUpstashBoxFlagPresenceAndExactGuardOrder(t *testing.T) {
 	if err := ApplyUpstashBoxProviderFlags(&cfg, validationFS, validationValues); err == nil || err.Error() != `invalid upstash-box runtime "other"` {
 		t.Fatalf("unselected wrapper validation=%v", err)
 	}
-	if _, err := (Provider{}).Configure(cfg, Runtime{}); err != nil {
+	if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err != nil {
 		t.Fatalf("Configure introduced validation: %v", err)
 	}
 	if err := validateConfig(cfg); err == nil || err.Error() != `invalid upstash-box runtime "other"` {
@@ -156,9 +156,9 @@ func TestUpstashBoxEffectiveDefaultsAndWorkspaceBoundary(t *testing.T) {
 		{name: "custom", base: " https://example.invalid/api/ ", runtime: " python ", size: " medium ", dir: " /workspace/home/app ", wantBase: "https://example.invalid/api", wantRuntime: "python", wantSize: "medium", wantDir: "/workspace/home/app", wantHost: "example.invalid"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := Config{UpstashBox: UpstashBoxConfig{APIKey: "inert-constructor-only", BaseURL: tc.base, Runtime: tc.runtime, Size: tc.size, Workdir: tc.dir}}
+			cfg := core.Config{UpstashBox: core.UpstashBoxConfig{APIKey: "inert-constructor-only", BaseURL: tc.base, Runtime: tc.runtime, Size: tc.size, Workdir: tc.dir}}
 			before := cfg.UpstashBox
-			api, err := newAPI(cfg, Runtime{HTTP: &http.Client{}})
+			api, err := newAPI(cfg, core.Runtime{HTTP: &http.Client{}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -177,7 +177,7 @@ func TestUpstashBoxEffectiveDefaultsAndWorkspaceBoundary(t *testing.T) {
 		})
 	}
 	for _, key := range []string{"", "  "} {
-		if _, err := newAPI(Config{UpstashBox: UpstashBoxConfig{APIKey: key, BaseURL: "https://example.invalid/api"}}, Runtime{HTTP: &http.Client{}}); err == nil || err.Error() != "provider=upstash-box requires UPSTASH_BOX_API_KEY" {
+		if _, err := newAPI(core.Config{UpstashBox: core.UpstashBoxConfig{APIKey: key, BaseURL: "https://example.invalid/api"}}, core.Runtime{HTTP: &http.Client{}}); err == nil || err.Error() != "provider=upstash-box requires UPSTASH_BOX_API_KEY" {
 			t.Fatalf("key requirement=%v", err)
 		}
 	}
@@ -212,8 +212,8 @@ func TestStopRequiresExactScopedUpstashBoxOwnership(t *testing.T) {
 			box := boxData{ID: "box_foreign", Name: "crabbox-foreign-0123456789ab", Status: "running"}
 			fake := &fakeAPI{box: box}
 			withFakeAPI(t, fake)
-			cfg := Config{UpstashBox: UpstashBoxConfig{APIKey: "test-key", BaseURL: "https://one.example.test"}}
-			backend := NewBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+			cfg := core.Config{UpstashBox: core.UpstashBoxConfig{APIKey: "test-key", BaseURL: "https://one.example.test"}}
+			backend := NewBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 			leaseID := "cbx_0123456789ab"
 			if test.seedClaim {
 				server := boxToServer(backend.cfg, box)
@@ -227,7 +227,7 @@ func TestStopRequiresExactScopedUpstashBoxOwnership(t *testing.T) {
 			if test.changedScope {
 				backend.cfg.UpstashBox.BaseURL = "https://two.example.test"
 			}
-			err := backend.Stop(context.Background(), StopRequest{ID: test.identifier})
+			err := backend.Stop(context.Background(), core.StopRequest{ID: test.identifier})
 			if test.seedClaim && !test.staleIdentity && !test.changedScope {
 				if err != nil || strings.Join(fake.deletedIDs, ",") != box.ID {
 					t.Fatalf("owned stop err=%v deleted=%v", err, fake.deletedIDs)
@@ -249,13 +249,13 @@ func TestStopFinalizesClaimWhenUpstashBoxVanishesDuringLockedPreflight(t *testin
 	box := boxData{ID: "box_vanished", Name: "crabbox-vanished-0123456789ab", Status: "running"}
 	fake := &fakeAPI{box: box, notFoundOnGet: 2}
 	withFakeAPI(t, fake)
-	cfg := Config{UpstashBox: UpstashBoxConfig{APIKey: "test-key", BaseURL: "https://one.example.test"}}
-	backend := NewBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	cfg := core.Config{UpstashBox: core.UpstashBoxConfig{APIKey: "test-key", BaseURL: "https://one.example.test"}}
+	backend := NewBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 	leaseID := "cbx_0123456789ab"
 	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, "vanished", providerName, upstashBoxClaimScope(backend.cfg), "", t.TempDir(), time.Hour, false, boxToServer(backend.cfg, box), core.SSHTarget{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := backend.Stop(context.Background(), StopRequest{ID: box.ID}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: box.ID}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deletedIDs) != 0 {
@@ -271,13 +271,13 @@ func TestStopFinalizesRetainedClaimAfterUpstashBoxWasAlreadyDeleted(t *testing.T
 	box := boxData{ID: "box_deleted", Name: "crabbox-deleted-0123456789ab", Status: "running"}
 	fake := &fakeAPI{box: box, notFoundOnGet: 1}
 	withFakeAPI(t, fake)
-	cfg := Config{UpstashBox: UpstashBoxConfig{APIKey: "test-key", BaseURL: "https://one.example.test"}}
-	backend := NewBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	cfg := core.Config{UpstashBox: core.UpstashBoxConfig{APIKey: "test-key", BaseURL: "https://one.example.test"}}
+	backend := NewBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 	leaseID := "cbx_0123456789ab"
 	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, "deleted", providerName, upstashBoxClaimScope(backend.cfg), "", t.TempDir(), time.Hour, false, boxToServer(backend.cfg, box), core.SSHTarget{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := backend.Stop(context.Background(), StopRequest{ID: leaseID}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: leaseID}); err != nil {
 		t.Fatal(err)
 	}
 	if fake.getBoxCalls != 1 || len(fake.deletedIDs) != 0 {
@@ -397,7 +397,7 @@ func TestClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
 	}))
 	defer trusted.Close()
 
-	apiClient, err := newAPI(Config{UpstashBox: UpstashBoxConfig{APIKey: "box_key", BaseURL: trusted.URL}}, Runtime{HTTP: trusted.Client()})
+	apiClient, err := newAPI(core.Config{UpstashBox: core.UpstashBoxConfig{APIKey: "box_key", BaseURL: trusted.URL}}, core.Runtime{HTTP: trusted.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -425,7 +425,7 @@ func TestClientFollowsSameOriginRedirect(t *testing.T) {
 	}))
 	defer server.Close()
 
-	apiClient, err := newAPI(Config{UpstashBox: UpstashBoxConfig{APIKey: "box_key", BaseURL: server.URL}}, Runtime{HTTP: server.Client()})
+	apiClient, err := newAPI(core.Config{UpstashBox: core.UpstashBoxConfig{APIKey: "box_key", BaseURL: server.URL}}, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -450,7 +450,7 @@ func TestClientPreservesCallerRedirectPolicy(t *testing.T) {
 		callerChecks++
 		return callerErr
 	}
-	apiClient, err := newAPI(Config{UpstashBox: UpstashBoxConfig{APIKey: "box_key", BaseURL: server.URL}}, Runtime{HTTP: httpClient})
+	apiClient, err := newAPI(core.Config{UpstashBox: core.UpstashBoxConfig{APIKey: "box_key", BaseURL: server.URL}}, core.Runtime{HTTP: httpClient})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -537,7 +537,7 @@ func TestUploadFileStopsProducerOnTransportFailure(t *testing.T) {
 }
 
 func TestNewAPIUsesBoundedDefaultHTTPClient(t *testing.T) {
-	api, err := newAPI(testConfig(), Runtime{})
+	api, err := newAPI(testConfig(), core.Runtime{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -569,7 +569,7 @@ func TestNewAPIRejectsUnsupportedDefaultTransport(t *testing.T) {
 		return nil, errors.New("deny all")
 	})
 
-	api, err := newAPI(testConfig(), Runtime{})
+	api, err := newAPI(testConfig(), core.Runtime{})
 	if api != nil || err == nil || !strings.Contains(err.Error(), "non-nil *http.Transport") {
 		t.Fatalf("api=%#v err=%v, want transport setup error", api, err)
 	}
@@ -589,7 +589,7 @@ func TestNewAPIAcceptsExplicitClientWithUnsupportedDefault(t *testing.T) {
 	})
 	injected := &http.Client{Transport: injectedTransport}
 
-	api, err := newAPI(testConfig(), Runtime{HTTP: injected})
+	api, err := newAPI(testConfig(), core.Runtime{HTTP: injected})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -693,7 +693,7 @@ func TestCleanWorkdirAndCommand(t *testing.T) {
 
 func TestWarmupRejectsActionsRunner(t *testing.T) {
 	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-	err := backend.Warmup(context.Background(), WarmupRequest{ActionsRunner: true})
+	err := backend.Warmup(context.Background(), core.WarmupRequest{ActionsRunner: true})
 	if err == nil || !strings.Contains(err.Error(), "--actions-runner is not supported") {
 		t.Fatalf("err=%v, want actions-runner rejection", err)
 	}
@@ -767,8 +767,8 @@ func TestRunCreatesExecsAndDeletesOneShotBox(t *testing.T) {
 	fake := &fakeAPI{}
 	withFakeAPI(t, fake)
 	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "repo", Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "repo", Root: t.TempDir()},
 		Command: []string{"echo", "hello"},
 		NoSync:  true,
 	})
@@ -813,10 +813,10 @@ func TestRunCleanupDeleteUsesBoundedContext(t *testing.T) {
 	fake := &fakeAPI{blockDelete: true}
 	withFakeAPI(t, fake)
 	var stderr bytes.Buffer
-	backend := NewBackend(Provider{}.Spec(), testConfig(), Runtime{Stdout: io.Discard, Stderr: &stderr}).(*backend)
+	backend := NewBackend(Provider{}.Spec(), testConfig(), core.Runtime{Stdout: io.Discard, Stderr: &stderr}).(*backend)
 	start := time.Now()
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "repo", Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "repo", Root: t.TempDir()},
 		Command: []string{"echo", "hello"},
 		NoSync:  true,
 	})
@@ -840,7 +840,7 @@ func TestRunKeepsFailuresBeforeCommand(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			fake := &fakeAPI{}
 			withFakeAPI(t, fake)
-			req := RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: true, TimingJSON: true, Command: []string{"true"}}
+			req := core.RunRequest{Repo: core.Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: true, TimingJSON: true, Command: []string{"true"}}
 			switch phase {
 			case "workspace":
 				fake.execHook = func(context.Context, string) (execResult, error) {
@@ -857,7 +857,7 @@ func TestRunKeepsFailuresBeforeCommand(t *testing.T) {
 				fake.uploadHook = func(context.Context, string, string) error { return errors.New("environment upload unavailable") }
 			}
 			var stderr bytes.Buffer
-			b := NewBackend(Provider{}.Spec(), testConfig(), Runtime{Stdout: io.Discard, Stderr: &stderr}).(*backend)
+			b := NewBackend(Provider{}.Spec(), testConfig(), core.Runtime{Stdout: io.Discard, Stderr: &stderr}).(*backend)
 			result, err := b.Run(t.Context(), req)
 			if err == nil || result.Session == nil || !result.Session.Kept || result.Session.Reused || len(fake.deletedIDs) != 0 || len(fake.streamCommands) != 0 {
 				t.Fatalf("early failure lost retention: result=%#v err=%v calls=%v", result, err, fake.verbs)
@@ -888,9 +888,9 @@ func TestRunTimingFailurePreservesCommandAndRetention(t *testing.T) {
 	fake := &fakeAPI{streamCode: 42}
 	withFakeAPI(t, fake)
 	cause := errors.New("synthetic timing write failure")
-	b := NewBackend(Provider{}.Spec(), testConfig(), Runtime{Stdout: io.Discard, Stderr: failingTimingWriter{cause}}).(*backend)
-	result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: true, TimingJSON: true, Command: []string{"false"}})
-	var exitErr ExitError
+	b := NewBackend(Provider{}.Spec(), testConfig(), core.Runtime{Stdout: io.Discard, Stderr: failingTimingWriter{cause}}).(*backend)
+	result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: true, TimingJSON: true, Command: []string{"false"}})
+	var exitErr core.ExitError
 	if !errors.Is(err, cause) || !errors.As(err, &exitErr) || exitErr.Code != 42 || result.ExitCode != 42 || result.Status != core.RunStatusFailed || result.ErrorKind != core.RunErrorCommandExit || result.Session == nil || !result.Session.Kept || len(fake.deletedIDs) != 0 {
 		t.Fatalf("timing masked command/retention: result=%#v err=%v deletes=%v", result, err, fake.deletedIDs)
 	}
@@ -902,10 +902,10 @@ func TestRunEnvCleanupUsesBoundedContext(t *testing.T) {
 	fake := &fakeAPI{blockEnvCleanup: true}
 	withFakeAPI(t, fake)
 	var stderr bytes.Buffer
-	backend := NewBackend(Provider{}.Spec(), testConfig(), Runtime{Stdout: io.Discard, Stderr: &stderr}).(*backend)
+	backend := NewBackend(Provider{}.Spec(), testConfig(), core.Runtime{Stdout: io.Discard, Stderr: &stderr}).(*backend)
 	start := time.Now()
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:       Repo{Name: "repo", Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Name: "repo", Root: t.TempDir()},
 		Command:    []string{"echo", "hello"},
 		Env:        map[string]string{"TOKEN": "secret"},
 		NoSync:     true,
@@ -940,9 +940,9 @@ func TestRunEnvCleanupFailsOnNonzeroExit(t *testing.T) {
 	fake := &fakeAPI{execResults: []execResult{{ExitCode: 0}, {ExitCode: 7, Error: "permission denied"}}}
 	withFakeAPI(t, fake)
 	var stderr bytes.Buffer
-	backend := NewBackend(Provider{}.Spec(), testConfig(), Runtime{Stdout: io.Discard, Stderr: &stderr}).(*backend)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:       Repo{Name: "repo", Root: t.TempDir()},
+	backend := NewBackend(Provider{}.Spec(), testConfig(), core.Runtime{Stdout: io.Discard, Stderr: &stderr}).(*backend)
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Name: "repo", Root: t.TempDir()},
 		Command:    []string{"echo", "hello"},
 		Env:        map[string]string{"TOKEN": "secret"},
 		NoSync:     true,
@@ -970,8 +970,8 @@ func TestRunEnvCleanupFailsOnNonzeroExit(t *testing.T) {
 func TestSyncWorkspaceCleansRemoteArchiveWhenExtractFails(t *testing.T) {
 	fake := &fakeAPI{execResults: []execResult{{ExitCode: 0}, {ExitCode: 9, Error: "extract failed"}, {ExitCode: 0}}}
 	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-	_, _, err := backend.syncWorkspace(context.Background(), fake, "box_1", RunRequest{
-		Repo: Repo{Name: "repo", Root: newGitRepo(t)},
+	_, _, err := backend.syncWorkspace(context.Background(), fake, "box_1", core.RunRequest{
+		Repo: core.Repo{Name: "repo", Root: newGitRepo(t)},
 	}, "/workspace/home/crabbox", "crabbox")
 	if err == nil {
 		t.Fatal("expected extract failure")
@@ -1000,7 +1000,7 @@ func TestSyncWorkspaceNativePreservesExistingFilesOnTransferFailure(t *testing.T
 			cfg := testConfig()
 			cfg.Sync.Delete = true
 			backend := NewBackend(Provider{}.Spec(), cfg, testRuntime()).(*backend)
-			_, _, err := backend.syncWorkspace(context.Background(), client, "box_1", RunRequest{Repo: Repo{Name: "repo", Root: newGitRepo(t)}}, "/workspace/home/crabbox", "crabbox")
+			_, _, err := backend.syncWorkspace(context.Background(), client, "box_1", core.RunRequest{Repo: core.Repo{Name: "repo", Root: newGitRepo(t)}}, "/workspace/home/crabbox", "crabbox")
 			if failure != "" {
 				if err == nil {
 					t.Fatal("expected transfer failure")
@@ -1039,7 +1039,7 @@ func TestRunChecksArchiveBeforeAllocation(t *testing.T) {
 	cfg := testConfig()
 	cfg.Sync.FailFiles = 1
 	backend := NewBackend(Provider{}.Spec(), cfg, testRuntime()).(*backend)
-	_, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Root: newGitRepo(t)}, Command: []string{"true"}})
+	_, err := backend.Run(context.Background(), core.RunRequest{Repo: core.Repo{Root: newGitRepo(t)}, Command: []string{"true"}})
 	if err == nil || !strings.Contains(err.Error(), "sync candidate too large") {
 		t.Fatalf("err=%v", err)
 	}
@@ -1088,9 +1088,9 @@ func (f *filesystemSyncAPI) Exec(ctx context.Context, _ string, command, _ strin
 func TestSyncWorkspaceWarnsWhenRemoteArchiveCleanupExitsNonzero(t *testing.T) {
 	fake := &fakeAPI{execResults: []execResult{{ExitCode: 0}, {ExitCode: 9, Error: "extract failed"}, {ExitCode: 7, Error: "cleanup denied"}}}
 	var stderr bytes.Buffer
-	backend := NewBackend(Provider{}.Spec(), testConfig(), Runtime{Stdout: io.Discard, Stderr: &stderr}).(*backend)
-	_, _, err := backend.syncWorkspace(context.Background(), fake, "box_1", RunRequest{
-		Repo: Repo{Name: "repo", Root: newGitRepo(t)},
+	backend := NewBackend(Provider{}.Spec(), testConfig(), core.Runtime{Stdout: io.Discard, Stderr: &stderr}).(*backend)
+	_, _, err := backend.syncWorkspace(context.Background(), fake, "box_1", core.RunRequest{
+		Repo: core.Repo{Name: "repo", Root: newGitRepo(t)},
 	}, "/workspace/home/crabbox", "crabbox")
 	if err == nil {
 		t.Fatal("expected extract failure")
@@ -1105,12 +1105,12 @@ func TestRunReusedBoxReturnsSession(t *testing.T) {
 	const leaseID = "cbx_123456789abc"
 	fake := &fakeAPI{box: boxData{ID: "box_1", Name: "crabbox-blue-123456789abc", Runtime: "node", Size: "small", Status: "running"}}
 	withFakeAPI(t, fake)
-	if err := claimLeaseForRepoProvider(leaseID, "blue", providerName, "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProvider(leaseID, "blue", providerName, "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-	result, err := backend.Run(context.Background(), RunRequest{
-		ID: leaseID, Repo: Repo{Name: "repo", Root: "/repo"}, Command: []string{"echo", "hello"}, NoSync: true,
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		ID: leaseID, Repo: core.Repo{Name: "repo", Root: "/repo"}, Command: []string{"echo", "hello"}, NoSync: true,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1132,7 +1132,7 @@ func TestStatusMapsBoxName(t *testing.T) {
 	cfg := testConfig()
 	cfg.UpstashBox.BaseURL = "https://eu-west-1.box.upstash.com"
 	backend := NewBackend(Provider{}.Spec(), cfg, testRuntime()).(*backend)
-	view, err := backend.Status(context.Background(), StatusRequest{ID: "box_1"})
+	view, err := backend.Status(context.Background(), core.StatusRequest{ID: "box_1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1171,12 +1171,12 @@ func TestStatusReadyStates(t *testing.T) {
 func TestStatusWaitTreatsMissingStatusAsNotReady(t *testing.T) {
 	fake := &fakeAPI{box: boxData{ID: "box_1", Name: "crabbox-blue-123456789abc"}}
 	withFakeAPI(t, fake)
-	backend := NewBackend(Provider{}.Spec(), testConfig(), Runtime{
+	backend := NewBackend(Provider{}.Spec(), testConfig(), core.Runtime{
 		Stdout: io.Discard,
 		Stderr: io.Discard,
 		Clock:  &advancingClock{current: time.Unix(100, 0), step: time.Second},
 	}).(*backend)
-	_, err := backend.Status(context.Background(), StatusRequest{ID: "box_1", Wait: true, WaitTimeout: time.Nanosecond})
+	_, err := backend.Status(context.Background(), core.StatusRequest{ID: "box_1", Wait: true, WaitTimeout: time.Nanosecond})
 	if err == nil || !strings.Contains(err.Error(), "timed out waiting for upstash-box box_1 to become ready") {
 		t.Fatalf("err=%v, want timeout for missing status", err)
 	}
@@ -1191,10 +1191,10 @@ func hasFeature(features core.FeatureSet, want core.Feature) bool {
 	return false
 }
 
-func testConfig() Config {
-	return Config{
+func testConfig() core.Config {
+	return core.Config{
 		Provider: providerName,
-		UpstashBox: UpstashBoxConfig{
+		UpstashBox: core.UpstashBoxConfig{
 			APIKey:  "box_key",
 			BaseURL: "https://us-east-1.box.upstash.com",
 			Runtime: "node",
@@ -1204,8 +1204,8 @@ func testConfig() Config {
 	}
 }
 
-func testRuntime() Runtime {
-	return Runtime{Stdout: io.Discard, Stderr: io.Discard}
+func testRuntime() core.Runtime {
+	return core.Runtime{Stdout: io.Discard, Stderr: io.Discard}
 }
 
 type advancingClock struct {
@@ -1221,7 +1221,7 @@ func (c *advancingClock) Now() time.Time {
 func withFakeAPI(t *testing.T, fake *fakeAPI) {
 	t.Helper()
 	original := newAPI
-	newAPI = func(Config, Runtime) (api, error) { return fake, nil }
+	newAPI = func(core.Config, core.Runtime) (api, error) { return fake, nil }
 	t.Cleanup(func() { newAPI = original })
 }
 
@@ -1420,14 +1420,14 @@ func TestRunPartialEnvUploadRetainsCleanup(t *testing.T) {
 				if _, ok := cleanupCtx.Deadline(); !ok {
 					t.Fatal("unbounded cleanup")
 				}
-				if command != "rm -f "+shellQuote(remotePath) {
+				if command != "rm -f "+core.ShellQuote(remotePath) {
 					t.Fatalf("wrong removal: %s", command)
 				}
 				return execResult{}, os.Remove(remote)
 			}
 			withFakeAPI(t, fake)
 			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-			_, err := b.Run(ctx, RunRequest{Repo: Repo{Root: root, Name: "fixture"}, NoSync: true, Keep: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
+			_, err := b.Run(ctx, core.RunRequest{Repo: core.Repo{Root: root, Name: "fixture"}, NoSync: true, Keep: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
 			want := primary
 			if canceled {
 				want = context.Canceled
@@ -1457,7 +1457,7 @@ func TestRunEnvDiscoveryDoesNotRequireOrCreateClaim(t *testing.T) {
 			fake := &fakeAPI{}
 			withFakeAPI(t, fake)
 			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-			result, err := b.Run(t.Context(), RunRequest{ID: id, Repo: Repo{Root: t.TempDir()}, NoSync: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
+			result, err := b.Run(t.Context(), core.RunRequest{ID: id, Repo: core.Repo{Root: t.TempDir()}, NoSync: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
 			if err != nil || result.ExitCode != 0 || len(fake.streamCommands) != 1 || len(fake.deletedIDs) != 0 {
 				t.Fatalf("result=%#v err=%v verbs=%v", result, err, fake.verbs)
 			}
@@ -1605,8 +1605,8 @@ func TestRunPreservesStreamErrorCause(t *testing.T) {
 				}
 				withFakeAPI(t, fake)
 				b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-				result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir()}, NoSync: true, Keep: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
-				var exitErr ExitError
+				result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, NoSync: true, Keep: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
+				var exitErr core.ExitError
 				if !errors.Is(err, cause) || !errors.As(err, &exitErr) || exitErr.Code != 1 || len(fake.streamCommands) != 1 || t.Context().Err() != nil {
 					t.Fatalf("stream cause lost: err=%v stream calls=%d parent=%v", err, len(fake.streamCommands), t.Context().Err())
 				}
@@ -1635,7 +1635,7 @@ func TestRunSkipsStreamAfterCanceledSuccessfulEnvUpload(t *testing.T) {
 	}
 	withFakeAPI(t, fake)
 	b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-	_, err := b.Run(ctx, RunRequest{Repo: Repo{Root: t.TempDir()}, NoSync: true, Keep: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
+	_, err := b.Run(ctx, core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, NoSync: true, Keep: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
 	if !errors.Is(err, context.Canceled) || len(fake.streamCommands) != 0 || cleanups != 1 || len(fake.deletedIDs) != 0 {
 		t.Fatalf("canceled successful upload: err=%v streams=%v cleanups=%d deleted=%v", err, fake.streamCommands, cleanups, fake.deletedIDs)
 	}
@@ -1664,7 +1664,7 @@ func TestRunEnvCleanupPreservesPrimaryOutcome(t *testing.T) {
 			}
 			withFakeAPI(t, fake)
 			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-			result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, Keep: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
+			result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, Keep: true, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}})
 			if err == nil || !strings.Contains(err.Error(), "synthetic cleanup failure") {
 				t.Fatalf("missing cleanup diagnosis: %v", err)
 			}
@@ -1673,7 +1673,7 @@ func TestRunEnvCleanupPreservesPrimaryOutcome(t *testing.T) {
 					t.Fatalf("primary cancellation lost: %v", err)
 				}
 			} else {
-				var exitErr ExitError
+				var exitErr core.ExitError
 				if !errors.As(err, &exitErr) || exitErr.Code != wantCode || result.ExitCode != wantCode {
 					t.Fatalf("primary outcome lost: result=%#v err=%v", result, err)
 				}
@@ -1754,7 +1754,7 @@ func TestEnvProfilesOnSameBoxHaveIndependentCustody(t *testing.T) {
 	}
 	fake.execHook = func(_ context.Context, command string) (execResult, error) {
 		for _, path := range paths {
-			if command == "rm -f "+shellQuote(path) {
+			if command == "rm -f "+core.ShellQuote(path) {
 				return execResult{}, os.Remove(filepath.Join(root, filepath.Base(path)))
 			}
 		}
@@ -1904,7 +1904,7 @@ func TestRunEnvProfileThroughNativeHTTPTransport(t *testing.T) {
 						workloads++
 					}
 					if strings.HasPrefix(body.Command[2], "rm -f ") {
-						if body.Command[2] != "rm -f "+shellQuote(profilePath) {
+						if body.Command[2] != "rm -f "+core.ShellQuote(profilePath) {
 							t.Error("removal targeted different file")
 							http.Error(w, "target", 400)
 							return
@@ -1949,7 +1949,7 @@ func TestRunEnvProfileThroughNativeHTTPTransport(t *testing.T) {
 			if scenario == "owned timing failure" {
 				diagnostics = failingTimingWriter{errors.New("synthetic timing write failure")}
 			}
-			b := NewBackend(Provider{}.Spec(), cfg, Runtime{HTTP: server.Client(), Stdout: &stdout, Stderr: diagnostics}).(*backend)
+			b := NewBackend(Provider{}.Spec(), cfg, core.Runtime{HTTP: server.Client(), Stdout: &stdout, Stderr: diagnostics}).(*backend)
 			command := `printf '%s\n' "$FIXTURE"`
 			if scenario == "source failure" {
 				command = "printf first; printf escaped"
@@ -1960,7 +1960,7 @@ func TestRunEnvProfileThroughNativeHTTPTransport(t *testing.T) {
 			if scenario == "owned command exit" || scenario == "owned timing failure" {
 				command = "exit 42"
 			}
-			req := RunRequest{ID: "box_fixture", Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, TimingJSON: true, Command: []string{command}, ShellMode: true, Env: map[string]string{"FIXTURE": "quote ' newline\n$literal"}}
+			req := core.RunRequest{ID: "box_fixture", Repo: core.Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, TimingJSON: true, Command: []string{command}, ShellMode: true, Env: map[string]string{"FIXTURE": "quote ' newline\n$literal"}}
 			if owned {
 				req.ID, req.KeepOnFailure = "", true
 			}
@@ -1995,7 +1995,7 @@ func TestRunEnvProfileThroughNativeHTTPTransport(t *testing.T) {
 					t.Fatalf("workspace error lost: %v", err)
 				}
 			case "owned command exit", "owned timing failure":
-				var exitErr ExitError
+				var exitErr core.ExitError
 				if !errors.As(err, &exitErr) || exitErr.Code != 42 || result.ExitCode != 42 || result.ErrorKind != core.RunErrorCommandExit {
 					t.Fatalf("native command outcome lost: result=%#v err=%v", result, err)
 				}
@@ -2094,7 +2094,7 @@ func TestRunSourceIntentSurvivesNativeShell(t *testing.T) {
 			fake := &fakeAPI{}
 			withFakeAPI(t, fake)
 			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-			_, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: root, Name: "fixture"}, NoSync: true, Keep: true, Command: tc.command, CommandLiteralArgs: tc.literal})
+			_, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: root, Name: "fixture"}, NoSync: true, Keep: true, Command: tc.command, CommandLiteralArgs: tc.literal})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/providers/upstashbox/client.go
+++ b/internal/providers/upstashbox/client.go
@@ -65,10 +65,10 @@ const upstashBoxDefaultResponseHeaderTimeout = 30 * time.Second
 
 var upstashBoxCleanupTimeout = 15 * time.Second
 
-var newAPI = func(cfg Config, rt Runtime) (api, error) {
+var newAPI = func(cfg core.Config, rt core.Runtime) (api, error) {
 	apiKey := strings.TrimSpace(cfg.UpstashBox.APIKey)
 	if apiKey == "" {
-		return nil, exit(2, "provider=%s requires UPSTASH_BOX_API_KEY", providerName)
+		return nil, core.Exit(2, "provider=%s requires UPSTASH_BOX_API_KEY", providerName)
 	}
 	httpClient := rt.HTTP
 	if httpClient == nil {
@@ -128,10 +128,10 @@ func (c *client) CreateBox(ctx context.Context, req createRequest) (boxData, err
 			return box, nil
 		}
 		if status == "error" || status == "failed" {
-			return boxData{}, c.cleanupCreatedBox(box.ID, exit(5, "upstash-box creation failed for %s", box.ID))
+			return boxData{}, c.cleanupCreatedBox(box.ID, core.Exit(5, "upstash-box creation failed for %s", box.ID))
 		}
 		if time.Now().After(deadline) {
-			return boxData{}, c.cleanupCreatedBox(box.ID, exit(5, "upstash-box creation timed out for %s status=%s", box.ID, core.Blank(box.Status, "unknown")))
+			return boxData{}, c.cleanupCreatedBox(box.ID, core.Exit(5, "upstash-box creation timed out for %s status=%s", box.ID, core.Blank(box.Status, "unknown")))
 		}
 		select {
 		case <-ctx.Done():
@@ -456,5 +456,5 @@ func commandExitError(prefix string, result execResult) error {
 	if msg == "" {
 		msg = "exit " + strconv.Itoa(result.ExitCode)
 	}
-	return exit(result.ExitCode, "%s: %s", prefix, msg)
+	return core.Exit(result.ExitCode, "%s: %s", prefix, msg)
 }

--- a/internal/providers/upstashbox/core.go
+++ b/internal/providers/upstashbox/core.go
@@ -1,31 +1,8 @@
 package upstashbox
 
 import (
-	"io"
-	"time"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type UpstashBoxConfig = core.UpstashBoxConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type Server = core.Server
-type Repo = core.Repo
-type ExitError = core.ExitError
-type timingPhase = core.TimingPhase
 
 const (
 	providerName = "upstash-box"
@@ -34,42 +11,6 @@ const (
 	networkPublic = core.NetworkPublic
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
-	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
-}
-
-func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
-}
-
-func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaim(identifier)
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
-func shellQuote(s string) string {
-	return core.ShellQuote(s)
-}
-
 func upstashBoxCleanupCommand(leaseID string) string {
-	return "crabbox stop --provider " + providerName + " " + shellQuote(leaseID)
-}
-
-func inventoryDoctorResult(provider string, leases int) DoctorResult {
-	return core.InventoryDoctorResult(provider, leases)
+	return "crabbox stop --provider " + providerName + " " + core.ShellQuote(leaseID)
 }

--- a/internal/providers/upstashbox/env.go
+++ b/internal/providers/upstashbox/env.go
@@ -68,7 +68,7 @@ func uploadEnvProfile(ctx context.Context, client api, leaseID, boxID, slug stri
 	cleanup := func(cleanupCtx context.Context) error {
 		err := profile.Close(cleanupCtx, func(removeCtx context.Context, remotePath string) error {
 			return receipt.withUnchanged(removeCtx, func() error {
-				result, err := client.Exec(removeCtx, boxID, "rm -f "+shellQuote(remotePath), "")
+				result, err := client.Exec(removeCtx, boxID, "rm -f "+core.ShellQuote(remotePath), "")
 				if err != nil {
 					return err
 				}

--- a/internal/providers/upstashbox/flags.go
+++ b/internal/providers/upstashbox/flags.go
@@ -8,11 +8,11 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func RegisterUpstashBoxProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterUpstashBoxProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterUpstashBoxConfigFlags(fs, defaults.UpstashBox)
 }
 
-func ApplyUpstashBoxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyUpstashBoxProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if core.ProviderNameMatchesExact(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --upstash-box-size", "use --upstash-box-runtime"); err != nil {
 			return err
@@ -30,19 +30,19 @@ func ApplyUpstashBoxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) err
 	return validateConfig(*cfg)
 }
 
-func validateConfig(cfg Config) error {
+func validateConfig(cfg core.Config) error {
 	if runtime := strings.TrimSpace(cfg.UpstashBox.Runtime); runtime != "" {
 		switch runtime {
 		case "node", "python", "golang", "ruby", "rust", "node-alpine", "python-alpine", "golang-alpine", "ruby-alpine", "rust-alpine":
 		default:
-			return exit(2, "invalid upstash-box runtime %q", runtime)
+			return core.Exit(2, "invalid upstash-box runtime %q", runtime)
 		}
 	}
 	if size := strings.TrimSpace(cfg.UpstashBox.Size); size != "" {
 		switch size {
 		case "small", "medium", "large":
 		default:
-			return exit(2, "invalid upstash-box size %q", size)
+			return core.Exit(2, "invalid upstash-box size %q", size)
 		}
 	}
 	_, err := cleanWorkdir(workdir(cfg))

--- a/internal/providers/upstashbox/sync.go
+++ b/internal/providers/upstashbox/sync.go
@@ -10,20 +10,20 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *backend) prepareArchive(ctx context.Context, req RunRequest) (*core.PreparedArchive, error) {
+func (b *backend) prepareArchive(ctx context.Context, req core.RunRequest) (*core.PreparedArchive, error) {
 	return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
 		TempPattern: "crabbox-upstash-box-sync-*.tgz", Stderr: b.rt.Stderr, Now: func() time.Time { return core.ClockNow(b.rt.Clock) },
 	})
 }
 
-func (b *backend) syncWorkspace(ctx context.Context, client api, boxID string, req RunRequest, workdir, folder string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+func (b *backend) syncWorkspace(ctx context.Context, client api, boxID string, req core.RunRequest, workdir, folder string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	expectedFolder, err := workspaceFolder(workdir)
 	if err != nil {
 		return nil, 0, err
 	}
 	if folder != expectedFolder || strings.Contains(folder, "..") {
-		return nil, 0, exit(2, "upstash-box sync folder does not match workdir")
+		return nil, 0, core.Exit(2, "upstash-box sync folder does not match workdir")
 	}
 	var archive *core.PreparedArchive
 	if len(prepared) > 0 {
@@ -57,9 +57,9 @@ func (b *backend) syncWorkspace(ctx context.Context, client api, boxID string, r
 func (b *backend) prepareWorkspace(ctx context.Context, client api, boxID, folder string) error {
 	folder = strings.Trim(strings.TrimSpace(folder), "/")
 	if folder == "" || strings.Contains(folder, "..") {
-		return exit(2, "upstash-box workspace folder %q is invalid", folder)
+		return core.Exit(2, "upstash-box workspace folder %q is invalid", folder)
 	}
-	return b.execShell(ctx, client, boxID, "mkdir -p "+shellQuote(folder), io.Discard)
+	return b.execShell(ctx, client, boxID, "mkdir -p "+core.ShellQuote(folder), io.Discard)
 }
 
 func (b *backend) execShell(ctx context.Context, client api, boxID, command string, stdout io.Writer) error {

--- a/internal/providers/vercelsandbox/backend.go
+++ b/internal/providers/vercelsandbox/backend.go
@@ -27,12 +27,12 @@ const (
 	metadataSlugKey     = "crabbox.slug"
 )
 
-func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *backend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if req.ActionsRunner {
-		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+		return core.Exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
 	if req.Options.Tailscale.Enabled {
-		return exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
+		return core.Exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
 	}
 	if _, err := vercelSandboxWorkdir(b.cfg); err != nil {
 		return err
@@ -63,7 +63,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	})
 }
 
-func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *backend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	workdir, workdirErr := vercelSandboxWorkdir(b.cfg)
 	var api vercelSandboxClient
 	var leaseID, sandboxID, slug string
@@ -75,7 +75,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		IdleTimeout: b.cfg.IdleTimeout, TTL: b.cfg.TTL, CleanupTimeout: vercelSandboxCleanupTimeout,
 		Preflight: func(context.Context) error {
 			if req.Options.Tailscale.Enabled {
-				return exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
+				return core.Exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
 			}
 			if workdirErr != nil {
 				return workdirErr
@@ -124,7 +124,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			if _, err := b.verifyClaim(ctx, api, leaseID, sandboxID); err != nil {
 				return unbound, err
 			}
-			claim, err := readLeaseClaim(leaseID)
+			claim, err := core.ReadLeaseClaim(leaseID)
 			if err != nil {
 				return unbound, err
 			}
@@ -153,7 +153,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 				fmt.Fprintf(b.rt.Stderr, "warning: provider=%s did not forward provider authentication variables: %s\n", providerName, strings.Join(strippedAuthEnv, ","))
 			}
 			if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
-				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, commandEnv)
+				core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, commandEnv)
 			}
 			return shared.DelegatedSandboxCommand{Text: commandText, Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
 				result, err := api.Exec(ctx, sandboxID, execRequest{Command: commandText, WorkingDir: workdir, Env: commandEnv, TimeoutSecs: b.execTimeoutSecs()}, stdout, stderr)
@@ -174,7 +174,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	})
 }
 
-func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
 	api, err := b.client()
 	if err != nil {
 		return nil, err
@@ -184,15 +184,15 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 		return nil, err
 	}
 	if len(sandboxes) == 0 {
-		return []LeaseView{}, nil
+		return []core.LeaseView{}, nil
 	}
 	if err := b.bindProviderScope(ctx, api, true); err != nil {
 		return nil, err
 	}
-	views := make([]LeaseView, 0, len(sandboxes))
+	views := make([]core.LeaseView, 0, len(sandboxes))
 	for _, sb := range sandboxes {
 		if len(sb.Metadata) == 0 && strings.HasPrefix(sb.ID, leasePrefix) {
-			claim, err := readLeaseClaim(sb.ID)
+			claim, err := core.ReadLeaseClaim(sb.ID)
 			if err != nil {
 				return nil, err
 			}
@@ -212,7 +212,7 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 		if leaseID == "" {
 			continue
 		}
-		claim, err := readLeaseClaim(leaseID)
+		claim, err := core.ReadLeaseClaim(leaseID)
 		if err != nil {
 			return nil, err
 		}
@@ -230,24 +230,24 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 	return views, nil
 }
 
-func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	api, err := b.client()
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	if err := b.bindProviderScope(ctx, api, true); err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	leaseID, sandboxID, slug, err := b.resolveLeaseID(req.ID, "", false, 0)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	claim, ok, err := b.resolveVercelSandboxLeaseClaim(leaseID)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	if !ok {
-		return StatusView{}, exit(4, "vercel-sandbox sandbox %q is not claimed by Crabbox", req.ID)
+		return core.StatusView{}, core.Exit(4, "vercel-sandbox sandbox %q is not claimed by Crabbox", req.ID)
 	}
 	waitTimeout := req.WaitTimeout
 	if waitTimeout <= 0 {
@@ -264,18 +264,18 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 		sb, getErr := api.GetSandbox(pollCtx, sandboxID)
 		if getErr != nil {
 			if req.Wait && ctx.Err() == nil && pollCtx.Err() != nil {
-				return StatusView{}, exit(5, "timed out waiting for vercel-sandbox sandbox %s to become ready", sandboxID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for vercel-sandbox sandbox %s to become ready", sandboxID)
 			}
 			if ctx.Err() != nil {
-				return StatusView{}, ctx.Err()
+				return core.StatusView{}, ctx.Err()
 			}
-			return StatusView{}, getErr
+			return core.StatusView{}, getErr
 		}
 		if err := validateSandboxOwnership(claim, sb); err != nil {
-			return StatusView{}, err
+			return core.StatusView{}, err
 		}
 		state := normalizedSandboxState(sb)
-		view := StatusView{
+		view := core.StatusView{
 			ID:       leaseID,
 			Slug:     slug,
 			Provider: providerName,
@@ -297,23 +297,23 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 			return view, nil
 		}
 		if isTerminalState(state) {
-			return StatusView{}, exit(5, "vercel-sandbox sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
+			return core.StatusView{}, core.Exit(5, "vercel-sandbox sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
 		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return StatusView{}, exit(5, "timed out waiting for vercel-sandbox sandbox %s to become ready", sandboxID)
+			return core.StatusView{}, core.Exit(5, "timed out waiting for vercel-sandbox sandbox %s to become ready", sandboxID)
 		}
 		select {
 		case <-pollCtx.Done():
 			if ctx.Err() == nil {
-				return StatusView{}, exit(5, "timed out waiting for vercel-sandbox sandbox %s to become ready", sandboxID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for vercel-sandbox sandbox %s to become ready", sandboxID)
 			}
-			return StatusView{}, pollCtx.Err()
+			return core.StatusView{}, pollCtx.Err()
 		case <-time.After(2 * time.Second):
 		}
 	}
 }
 
-func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+func (b *backend) Stop(ctx context.Context, req core.StopRequest) error {
 	api, err := b.client()
 	if err != nil {
 		return err
@@ -339,7 +339,7 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 			return err
 		}
 		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing vercel-sandbox sandbox=%s after explicit request\n", sandboxID)
-		removeLeaseClaim(leaseID)
+		core.RemoveLeaseClaim(leaseID)
 		return nil
 	}
 	if err := api.DeleteSandbox(ctx, sandboxID); err != nil {
@@ -348,12 +348,12 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 		}
 		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing vercel-sandbox sandbox=%s after explicit request\n", sandboxID)
 	}
-	removeLeaseClaim(leaseID)
+	core.RemoveLeaseClaim(leaseID)
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, sandboxID)
 	return nil
 }
 
-func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
+func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	api, err := b.client()
 	if err != nil {
 		return err
@@ -362,7 +362,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	if err != nil {
 		return err
 	}
-	hasProviderClaims := slices.ContainsFunc(claims, func(claim LeaseClaim) bool {
+	hasProviderClaims := slices.ContainsFunc(claims, func(claim core.LeaseClaim) bool {
 		return claim.Provider == providerName
 	})
 	if !hasProviderClaims {
@@ -389,7 +389,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 				return err
 			}
 			defer unlockOperation()
-			claim, err := readLeaseClaim(listed.LeaseID)
+			claim, err := core.ReadLeaseClaim(listed.LeaseID)
 			if err != nil {
 				return err
 			}
@@ -411,7 +411,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 					return nil
 				}
-				if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+				if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 					return err
 				}
 				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
@@ -433,7 +433,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			if err := api.DeleteSandbox(ctx, sandboxID); err != nil && !isVercelSandboxNotFound(err) {
 				return err
 			}
-			if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+			if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 				return err
 			}
 			fmt.Fprintf(b.rt.Stdout, "delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
@@ -459,7 +459,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	return nil
 }
 
-func (b *backend) createSandbox(ctx context.Context, api vercelSandboxClient, repo Repo, reclaim bool, requestedSlug string, retained bool) (string, string, string, func(), error) {
+func (b *backend) createSandbox(ctx context.Context, api vercelSandboxClient, repo core.Repo, reclaim bool, requestedSlug string, retained bool) (string, string, string, func(), error) {
 	if err := validateVercelSandboxConfig(b.cfg); err != nil {
 		return "", "", "", nil, err
 	}
@@ -472,7 +472,7 @@ func (b *backend) createSandbox(ctx context.Context, api vercelSandboxClient, re
 	}
 	name := newSandboxName(repo)
 	tentativeLeaseID := leasePrefix + name
-	slug, err := allocateClaimLeaseSlug(tentativeLeaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(tentativeLeaseID, requestedSlug)
 	if err != nil {
 		return "", "", "", nil, err
 	}
@@ -497,7 +497,7 @@ func (b *backend) createSandbox(ctx context.Context, api vercelSandboxClient, re
 		}
 	}()
 	if leaseID != tentativeLeaseID {
-		slug, err = allocateClaimLeaseSlug(leaseID, requestedSlug)
+		slug, err = core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 		if err != nil {
 			return leaseID, sb.ID, "", nil, b.cleanupCreateFailure(ctx, api, sb.ID, err)
 		}
@@ -511,17 +511,17 @@ func (b *backend) createSandbox(ctx context.Context, api vercelSandboxClient, re
 	} else if sb.Metadata == nil || sb.Metadata[metadataClaimKey] == "" {
 		sb.Metadata = metadata
 	}
-	if err := validateSandboxOwnership(LeaseClaim{LeaseID: leaseID, Provider: providerName, ProviderScope: providerScope}, sb); err != nil {
+	if err := validateSandboxOwnership(core.LeaseClaim{LeaseID: leaseID, Provider: providerName, ProviderScope: providerScope}, sb); err != nil {
 		return leaseID, sb.ID, slug, nil, b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
-	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, providerScope, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, providerName, providerScope, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
 		return leaseID, sb.ID, slug, nil, b.cleanupCreateFailure(ctx, api, sb.ID, err)
 	}
 	keepLock = true
 	return leaseID, sb.ID, slug, unlockOperation, nil
 }
 
-func (b *backend) ownershipMetadata(providerScope, leaseID, slug string, repo Repo) map[string]string {
+func (b *backend) ownershipMetadata(providerScope, leaseID, slug string, repo core.Repo) map[string]string {
 	out := map[string]string{
 		metadataProviderKey: providerName,
 		metadataScopeKey:    providerScope,
@@ -536,9 +536,9 @@ func (b *backend) ownershipMetadata(providerScope, leaseID, slug string, repo Re
 	return out
 }
 
-func (b *backend) serverFromSandbox(claim LeaseClaim, sb sandboxSummary) Server {
+func (b *backend) serverFromSandbox(claim core.LeaseClaim, sb sandboxSummary) core.Server {
 	state := normalizedSandboxState(sb)
-	return Server{
+	return core.Server{
 		Provider: providerName,
 		CloudID:  sb.ID,
 		Name:     sb.ID,
@@ -557,13 +557,13 @@ func (b *backend) serverFromSandbox(claim LeaseClaim, sb sandboxSummary) Server 
 func (b *backend) resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration) (string, string, string, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return "", "", "", exit(2, "provider=vercel-sandbox requires a Crabbox-created sandbox slug or lease id")
+		return "", "", "", core.Exit(2, "provider=vercel-sandbox requires a Crabbox-created sandbox slug or lease id")
 	}
 	exactLeaseID := id
 	if !strings.HasPrefix(exactLeaseID, leasePrefix) {
 		exactLeaseID = leasePrefix + exactLeaseID
 	}
-	if claim, err := readLeaseClaim(exactLeaseID); err != nil {
+	if claim, err := core.ReadLeaseClaim(exactLeaseID); err != nil {
 		return "", "", "", err
 	} else if claim.LeaseID == exactLeaseID && claim.Provider == providerName {
 		return b.finishResolvedLease(claim, repoRoot, reclaim, idleTimeout)
@@ -575,27 +575,27 @@ func (b *backend) resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout 
 	if ok {
 		return b.finishResolvedLease(claim, repoRoot, reclaim, idleTimeout)
 	}
-	return "", "", "", exit(4, "vercel-sandbox sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
+	return "", "", "", core.Exit(4, "vercel-sandbox sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
 }
 
-func (b *backend) resolveVercelSandboxLeaseClaim(identifier string) (LeaseClaim, bool, error) {
+func (b *backend) resolveVercelSandboxLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 	claims, err := listVercelSandboxLeaseClaims()
 	if err != nil {
-		return LeaseClaim{}, false, err
+		return core.LeaseClaim{}, false, err
 	}
 	for _, claim := range claims {
 		if claim.Provider == providerName && claim.LeaseID == identifier {
 			if err := b.validateClaimScope(claim); err != nil {
-				return LeaseClaim{}, false, err
+				return core.LeaseClaim{}, false, err
 			}
 			return claim, true, nil
 		}
 	}
-	slug := normalizeLeaseSlug(identifier)
+	slug := core.NormalizeLeaseSlug(identifier)
 	if slug != "" {
 		for _, legacy := range []bool{false, true} {
 			for _, claim := range claims {
-				if claim.Provider != providerName || normalizeLeaseSlug(claim.Slug) != slug {
+				if claim.Provider != providerName || core.NormalizeLeaseSlug(claim.Slug) != slug {
 					continue
 				}
 				isLegacy := !claimMatchesScope(claim, b.providerScopeBase())
@@ -606,22 +606,22 @@ func (b *backend) resolveVercelSandboxLeaseClaim(identifier string) (LeaseClaim,
 			}
 		}
 	}
-	return LeaseClaim{}, false, nil
+	return core.LeaseClaim{}, false, nil
 }
 
-func (b *backend) finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration) (string, string, string, error) {
+func (b *backend) finishResolvedLease(claim core.LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration) (string, string, string, error) {
 	if err := b.validateClaimScope(claim); err != nil {
 		return "", "", "", err
 	}
 	if repoRoot != "" {
-		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, repoRoot,
+		if err := core.ClaimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, repoRoot,
 			timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
 			return "", "", "", err
 		}
 	}
 	slug := claim.Slug
 	if strings.TrimSpace(slug) == "" {
-		slug = newLeaseSlug(claim.LeaseID)
+		slug = core.NewLeaseSlug(claim.LeaseID)
 	}
 	return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, leasePrefix), slug, nil
 }
@@ -629,7 +629,7 @@ func (b *backend) finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim
 func (b *backend) newClaimScope() (string, error) {
 	var token [16]byte
 	if _, err := rand.Read(token[:]); err != nil {
-		return "", exit(5, "generate vercel-sandbox ownership token: %v", err)
+		return "", core.Exit(5, "generate vercel-sandbox ownership token: %v", err)
 	}
 	return b.providerScopeBase() + "/ownership:" + hex.EncodeToString(token[:]), nil
 }
@@ -659,14 +659,14 @@ func (b *backend) providerScopeBase() string {
 	return strings.Join(parts, "/")
 }
 
-func (b *backend) validateClaimScope(claim LeaseClaim) error {
+func (b *backend) validateClaimScope(claim core.LeaseClaim) error {
 	if !b.claimMatchesActiveScope(claim) {
-		return exit(4, "vercel-sandbox lease %q belongs to a different project/team/scope; restore the configuration used to create it", claim.LeaseID)
+		return core.Exit(4, "vercel-sandbox lease %q belongs to a different project/team/scope; restore the configuration used to create it", claim.LeaseID)
 	}
 	return nil
 }
 
-func (b *backend) claimMatchesActiveScope(claim LeaseClaim) bool {
+func (b *backend) claimMatchesActiveScope(claim core.LeaseClaim) bool {
 	if claimMatchesScope(claim, b.providerScopeBase()) {
 		return true
 	}
@@ -675,12 +675,12 @@ func (b *backend) claimMatchesActiveScope(claim LeaseClaim) bool {
 	return b.legacyScopeBase != "" && claimMatchesScope(claim, b.legacyScopeBase)
 }
 
-func claimMatchesScope(claim LeaseClaim, scopeBase string) bool {
+func claimMatchesScope(claim core.LeaseClaim, scopeBase string) bool {
 	return strings.HasPrefix(strings.TrimSpace(claim.ProviderScope), scopeBase+"/ownership:")
 }
 
 func (b *backend) verifyClaim(ctx context.Context, api vercelSandboxClient, leaseID, sandboxID string) (sandboxSummary, error) {
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		return sandboxSummary{}, err
 	}
@@ -697,20 +697,20 @@ func (b *backend) verifyClaim(ctx context.Context, api vercelSandboxClient, leas
 	return sb, nil
 }
 
-func validateSandboxOwnership(claim LeaseClaim, sb sandboxSummary) error {
+func validateSandboxOwnership(claim core.LeaseClaim, sb sandboxSummary) error {
 	if sb.ID == "" {
-		return exit(5, "vercel-sandbox returned a sandbox without an id")
+		return core.Exit(5, "vercel-sandbox returned a sandbox without an id")
 	}
 	if sb.Metadata[metadataProviderKey] != providerName ||
 		sb.Metadata[metadataScopeKey] != claim.ProviderScope ||
 		sb.Metadata[metadataClaimKey] != claim.LeaseID {
-		return exit(4, "vercel-sandbox sandbox %q ownership metadata does not match its local claim", sb.ID)
+		return core.Exit(4, "vercel-sandbox sandbox %q ownership metadata does not match its local claim", sb.ID)
 	}
 	return nil
 }
 
 func (b *backend) refreshLeaseActivity(leaseID string) error {
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		return err
 	}
@@ -718,7 +718,7 @@ func (b *backend) refreshLeaseActivity(leaseID string) error {
 		return nil
 	}
 	idleTimeout := timeoutOrDefault(b.cfg.IdleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second)
-	return claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, claim.RepoRoot, idleTimeout, false)
+	return core.ClaimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, claim.RepoRoot, idleTimeout, false)
 }
 
 func (b *backend) cleanupCreateFailure(ctx context.Context, api vercelSandboxClient, sandboxID string, cause error) error {
@@ -737,7 +737,7 @@ func (b *backend) cleanupCreatedRun(ctx context.Context, api vercelSandboxClient
 	if err := api.DeleteSandbox(ctx, sandboxID); err != nil && !isVercelSandboxNotFound(err) {
 		return fmt.Errorf("vercel-sandbox delete failed for %s: %w", sandboxID, err)
 	}
-	removeLeaseClaim(leaseID)
+	core.RemoveLeaseClaim(leaseID)
 	return nil
 }
 
@@ -771,12 +771,12 @@ func isTerminalState(state string) bool {
 	}
 }
 
-func vercelSandboxRuntime(cfg Config) string {
+func vercelSandboxRuntime(cfg core.Config) string {
 	return core.Blank(strings.TrimSpace(cfg.VercelSandbox.Runtime), defaultRuntime)
 }
 
-func newSandboxName(repo Repo) string {
-	base := normalizeLeaseSlug(repo.Name)
+func newSandboxName(repo core.Repo) string {
+	base := core.NormalizeLeaseSlug(repo.Name)
 	if base == "" {
 		base = "crabbox"
 	}
@@ -790,7 +790,7 @@ func newSandboxName(repo Repo) string {
 	return "crabbox-" + base + "-" + shared.RandomSuffix()
 }
 
-func repoScope(repo Repo) string {
+func repoScope(repo core.Repo) string {
 	value := strings.TrimSpace(repo.Root)
 	if value == "" {
 		value = strings.TrimSpace(repo.Name)

--- a/internal/providers/vercelsandbox/backend_test.go
+++ b/internal/providers/vercelsandbox/backend_test.go
@@ -138,7 +138,7 @@ func TestWarmupCreatesOwnedClaim(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, &stdout, &stderr)
-	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.sandboxes) != 1 {
@@ -149,7 +149,7 @@ func TestWarmupCreatesOwnedClaim(t *testing.T) {
 		sb = value
 	}
 	leaseID := leasePrefix + sb.ID
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestWarmupStampsClaimMetadataAtCreateWhenNameIsRemoteID(t *testing.T) {
 	fake := newLifecycleFakeClient()
 	fake.useNameID = true
 	backend := testBackend(fake, io.Discard, io.Discard)
-	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
 		t.Fatal(err)
 	}
 	if slices.ContainsFunc(fake.calls, func(call string) bool { return strings.HasPrefix(call, "metadata:") }) {
@@ -193,8 +193,8 @@ func TestRunOneShotSyncsExecutesAndDeletes(t *testing.T) {
 	fake := newLifecycleFakeClient()
 	fake.stdout = "ok\n"
 	backend := testBackend(fake, &stdout, &stderr)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:               Repo{Name: "my-app", Root: repo},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:               core.Repo{Name: "my-app", Root: repo},
 		Command:            []string{"echo", "ok", "&&"},
 		CommandLiteralArgs: map[int]bool{2: true},
 	})
@@ -234,8 +234,8 @@ func TestRunRejectsOversizedWorkspaceBeforeProviderCalls(t *testing.T) {
 	backend.cfg.Sync.FailFiles = 2
 	backend.cfg.Sync.FailBytes = 0
 
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo: Repo{Name: "my-app", Root: tempRepo(t)}, Command: []string{"true"},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo: core.Repo{Name: "my-app", Root: tempRepo(t)}, Command: []string{"true"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "sync candidate too large: 2 files >= limit 2") {
 		t.Fatalf("err=%v", err)
@@ -250,15 +250,15 @@ func TestRetainedRunByIDVerifiesOwnershipAndKeepsClaim(t *testing.T) {
 	repo := tempRepo(t)
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
-	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: repo}, Keep: true}); err != nil {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "my-app", Root: repo}, Keep: true}); err != nil {
 		t.Fatal(err)
 	}
 	var leaseID string
 	for id := range fake.sandboxes {
 		leaseID = leasePrefix + id
 	}
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: repo},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: repo},
 		ID:      leaseID,
 		NoSync:  true,
 		Keep:    true,
@@ -273,7 +273,7 @@ func TestRetainedRunByIDVerifiesOwnershipAndKeepsClaim(t *testing.T) {
 	if result.Session == nil || result.Session.LeaseID != leaseID || !result.Session.Reused || !result.Session.Kept {
 		t.Fatalf("unexpected retained session handle: %#v", result.Session)
 	}
-	if _, err := readLeaseClaim(leaseID); err != nil {
+	if _, err := core.ReadLeaseClaim(leaseID); err != nil {
 		t.Fatalf("claim not retained: %v", err)
 	}
 	if len(fake.sandboxes) != 1 {
@@ -285,7 +285,7 @@ func TestListHydratesClaimOnlyInventoryBeforeOwnershipFilter(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
-	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
 		t.Fatal(err)
 	}
 	var leaseID string
@@ -298,10 +298,10 @@ func TestListHydratesClaimOnlyInventoryBeforeOwnershipFilter(t *testing.T) {
 	}
 	fakeList := []sandboxSummary{{ID: leaseID}}
 	listingFake := &claimOnlyListFakeClient{lifecycleFakeClient: fake, list: fakeList}
-	backend.newClient = func(Config, Runtime) (vercelSandboxClient, error) {
+	backend.newClient = func(core.Config, core.Runtime) (vercelSandboxClient, error) {
 		return listingFake, nil
 	}
-	views, err := backend.List(context.Background(), ListRequest{})
+	views, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +318,7 @@ func TestListSkipsMissingClaimAndReturnsRemainingSandbox(t *testing.T) {
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
 	for _, name := range []string{"first", "second"} {
-		if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: name, Root: "/repo"}, Keep: true}); err != nil {
+		if err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: name, Root: "/repo"}, Keep: true}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -334,10 +334,10 @@ func TestListSkipsMissingClaimAndReturnsRemainingSandbox(t *testing.T) {
 			{ID: leaseIDs[1]},
 		},
 	}
-	backend.newClient = func(Config, Runtime) (vercelSandboxClient, error) {
+	backend.newClient = func(core.Config, core.Runtime) (vercelSandboxClient, error) {
 		return listingFake, nil
 	}
-	views, err := backend.List(context.Background(), ListRequest{})
+	views, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -351,10 +351,10 @@ func TestEmptyListAndCleanupDoNotResolveProjectScope(t *testing.T) {
 	fake := newLifecycleFakeClient()
 	fake.scope = projectScope{}
 	backend := testBackend(fake, io.Discard, io.Discard)
-	if views, err := backend.List(context.Background(), ListRequest{}); err != nil || views == nil || len(views) != 0 {
+	if views, err := backend.List(context.Background(), core.ListRequest{}); err != nil || views == nil || len(views) != 0 {
 		t.Fatalf("views=%#v err=%v", views, err)
 	}
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -370,7 +370,7 @@ func TestLegacyScopeClaimRemainsManageableAfterBinding(t *testing.T) {
 	legacyScope := backend.providerScopeBase() + "/ownership:legacy"
 	leaseID := leasePrefix + "legacy"
 	slug := "legacy-box"
-	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, legacyScope, "", "/repo", time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, providerName, legacyScope, "", "/repo", time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	fake.sandboxes["legacy"] = sandboxSummary{
@@ -383,20 +383,20 @@ func TestLegacyScopeClaimRemainsManageableAfterBinding(t *testing.T) {
 			metadataSlugKey:     slug,
 		},
 	}
-	views, err := backend.List(context.Background(), ListRequest{})
+	views, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(views) != 1 || views[0].Labels["lease"] != leaseID {
 		t.Fatalf("views=%#v", views)
 	}
-	if err := backend.Stop(context.Background(), StopRequest{ID: slug}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: slug}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.sandboxes) != 0 {
 		t.Fatalf("legacy sandbox was not deleted: %#v", fake.sandboxes)
 	}
-	if claim, err := readLeaseClaim(leaseID); err != nil || claim.LeaseID != "" {
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil || claim.LeaseID != "" {
 		t.Fatalf("legacy claim was not removed: claim=%#v err=%v", claim, err)
 	}
 }
@@ -405,7 +405,7 @@ func TestStopRejectsOwnershipMismatch(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
-	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
 		t.Fatal(err)
 	}
 	var leaseID, sandboxID string
@@ -415,7 +415,7 @@ func TestStopRejectsOwnershipMismatch(t *testing.T) {
 		sb.Metadata[metadataProviderKey] = "foreign"
 		fake.sandboxes[id] = sb
 	}
-	err := backend.Stop(context.Background(), StopRequest{ID: leaseID})
+	err := backend.Stop(context.Background(), core.StopRequest{ID: leaseID})
 	if err == nil || !strings.Contains(err.Error(), "ownership metadata") {
 		t.Fatalf("err=%v", err)
 	}
@@ -438,7 +438,7 @@ func TestCleanupPreservesMissingClaimUnlessForgetMissing(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
-	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "my-app", Root: "/repo"}, Keep: true}); err != nil {
 		t.Fatal(err)
 	}
 	var leaseID string
@@ -446,17 +446,17 @@ func TestCleanupPreservesMissingClaimUnlessForgetMissing(t *testing.T) {
 		leaseID = leasePrefix + id
 		delete(fake.sandboxes, id)
 	}
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := readLeaseClaim(leaseID); err != nil {
+	if _, err := core.ReadLeaseClaim(leaseID); err != nil {
 		t.Fatalf("claim should be preserved without forget-missing: %v", err)
 	}
 	backend.cfg.VercelSandbox.ForgetMissing = true
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	claim, err := readLeaseClaim(leaseID)
+	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -470,8 +470,8 @@ func TestRunForwardsAllowedEnvOffArgvAndStripsProviderSecrets(t *testing.T) {
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
 	secretValue := "secret-token-value"
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: tempRepo(t)},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: tempRepo(t)},
 		Keep:    true,
 		NoSync:  true,
 		Command: []string{"env"},
@@ -505,8 +505,8 @@ func TestSyncDeleteUsesStagingReplace(t *testing.T) {
 	fake := newLifecycleFakeClient()
 	backend := testBackend(fake, io.Discard, io.Discard)
 	backend.cfg.Sync.Delete = true
-	if _, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: repo},
+	if _, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: repo},
 		Command: []string{"true"},
 	}); err != nil {
 		t.Fatal(err)
@@ -522,8 +522,8 @@ func TestRunKeepOnFailureRetainsClaim(t *testing.T) {
 	fake.exitCode = 7
 	var stderr bytes.Buffer
 	backend := testBackend(fake, io.Discard, &stderr)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:          Repo{Name: "my-app", Root: tempRepo(t)},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:          core.Repo{Name: "my-app", Root: tempRepo(t)},
 		NoSync:        true,
 		KeepOnFailure: true,
 		Command:       []string{"false"},
@@ -545,7 +545,7 @@ func TestRunKeepOnFailureRetainsClaim(t *testing.T) {
 	for id := range fake.sandboxes {
 		leaseID = leasePrefix + id
 	}
-	if claim, err := readLeaseClaim(leaseID); err != nil || claim.LeaseID == "" {
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil || claim.LeaseID == "" {
 		t.Fatalf("claim should be retained: claim=%#v err=%v", claim, err)
 	}
 	lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
@@ -571,7 +571,7 @@ func TestRunEarlyFailureKeepsAccurateRecoveryState(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			fake := newLifecycleFakeClient()
 			primary, cleanup := errors.New("workspace failed"), errors.New("delete unavailable")
-			req := RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: tc.keep, TimingJSON: true}
+			req := core.RunRequest{Repo: core.Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: tc.keep, TimingJSON: true}
 			if tc.workspace {
 				fake.execErr = primary
 				req.Command = []string{"true"}
@@ -597,7 +597,7 @@ func TestRunEarlyFailureKeepsAccurateRecoveryState(t *testing.T) {
 			if (deletes == 1) != tc.deleteFails || len(fake.sandboxes) != 1 {
 				t.Fatalf("cleanup calls=%v sandboxes=%v", fake.calls, fake.sandboxes)
 			}
-			if claim, err := readLeaseClaim(result.LeaseID); err != nil || claim.LeaseID != result.LeaseID {
+			if claim, err := core.ReadLeaseClaim(result.LeaseID); err != nil || claim.LeaseID != result.LeaseID {
 				t.Fatalf("recovery claim=%#v err=%v", claim, err)
 			}
 			var report core.TimingReport
@@ -629,8 +629,8 @@ func TestRunTimingFailurePreservesPrimaryExit(t *testing.T) {
 			}
 			writeFailure := errors.New("timing output unavailable")
 			b := testBackend(fake, io.Discard, failingTimingWriter{writeFailure})
-			result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: keep, TimingJSON: true, Command: []string{"false"}})
-			var exitErr ExitError
+			result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: keep, TimingJSON: true, Command: []string{"false"}})
+			var exitErr core.ExitError
 			if !errors.Is(err, writeFailure) || !errors.As(err, &exitErr) || exitErr.Code != 23 || result.ExitCode != 23 || result.ErrorKind != core.RunErrorCommandExit || result.Session == nil || !result.Session.Kept {
 				t.Fatalf("timing masked outcome: result=%#v err=%v", result, err)
 			}
@@ -645,13 +645,13 @@ func TestRunRejectedReuseReleasesOperationLock(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newLifecycleFakeClient()
 	b := testBackend(fake, io.Discard, io.Discard)
-	repo := Repo{Root: t.TempDir(), Name: "fixture"}
-	if err := b.Warmup(t.Context(), WarmupRequest{Repo: repo, Keep: true}); err != nil {
+	repo := core.Repo{Root: t.TempDir(), Name: "fixture"}
+	if err := b.Warmup(t.Context(), core.WarmupRequest{Repo: repo, Keep: true}); err != nil {
 		t.Fatal(err)
 	}
 	leaseID := leasePrefix + "sbx_a"
 	fake.sandboxes["sbx_a"].Metadata[metadataClaimKey] = "changed"
-	result, err := b.Run(t.Context(), RunRequest{ID: leaseID, Repo: repo, NoSync: true, Command: []string{"true"}})
+	result, err := b.Run(t.Context(), core.RunRequest{ID: leaseID, Repo: repo, NoSync: true, Command: []string{"true"}})
 	if err == nil || result.Session != nil {
 		t.Fatalf("rejected reuse result=%#v err=%v", result, err)
 	}
@@ -662,7 +662,7 @@ func TestRunRejectedReuseReleasesOperationLock(t *testing.T) {
 		t.Fatalf("failed reuse leaked operation lock: %v", err)
 	}
 	unlock()
-	if claim, err := readLeaseClaim(leaseID); err != nil || claim.RepoRoot != repo.Root || len(fake.sandboxes) != 1 {
+	if claim, err := core.ReadLeaseClaim(leaseID); err != nil || claim.RepoRoot != repo.Root || len(fake.sandboxes) != 1 {
 		t.Fatalf("rejected reuse changed custody: claim=%#v err=%v", claim, err)
 	}
 }
@@ -674,7 +674,7 @@ func TestRunRedactsProviderTokenAndPreservesCause(t *testing.T) {
 	fake := newLifecycleFakeClient()
 	fake.workloadErr = errors.Join(errors.New("backend rejected "+token), context.DeadlineExceeded)
 	b := testBackend(fake, io.Discard, io.Discard)
-	result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: true, Command: []string{"true"}})
+	result, err := b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: true, Command: []string{"true"}})
 	if err == nil || strings.Contains(err.Error(), token) || !strings.Contains(err.Error(), "[REDACTED]") {
 		t.Fatalf("provider display redaction lost: %v", err)
 	}
@@ -700,11 +700,11 @@ func testBackend(fake *lifecycleFakeClient, stdout, stderr io.Writer) *backend {
 	return &backend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt: Runtime{
+		rt: core.Runtime{
 			Stdout: stdout,
 			Stderr: stderr,
 		},
-		newClient: func(Config, Runtime) (vercelSandboxClient, error) {
+		newClient: func(core.Config, core.Runtime) (vercelSandboxClient, error) {
 			return fake, nil
 		},
 	}

--- a/internal/providers/vercelsandbox/client.go
+++ b/internal/providers/vercelsandbox/client.go
@@ -49,15 +49,15 @@ type commandSpec struct {
 }
 
 type bridgeClient struct {
-	cfg      Config
-	rt       Runtime
+	cfg      core.Config
+	rt       core.Runtime
 	lookup   func(string) (string, error)
 	run      func(context.Context, commandSpec) error
 	call     func(context.Context, bridgeRequest, any) error
 	execCall func(context.Context, commandSpec, bridgeRequest, io.Writer, io.Writer) (execResult, error)
 }
 
-func newBridgeClient(cfg Config, rt Runtime) (vercelSandboxClient, error) {
+func newBridgeClient(cfg core.Config, rt core.Runtime) (vercelSandboxClient, error) {
 	return &bridgeClient{
 		cfg:    cfg,
 		rt:     rt,
@@ -204,7 +204,7 @@ func (c *bridgeClient) CreateSandbox(ctx context.Context, req createSandboxReque
 		return sandboxSummary{}, err
 	}
 	if out.ID == "" {
-		return sandboxSummary{}, exit(5, "vercel-sandbox create returned no sandbox id")
+		return sandboxSummary{}, core.Exit(5, "vercel-sandbox create returned no sandbox id")
 	}
 	return out, nil
 }

--- a/internal/providers/vercelsandbox/client_test.go
+++ b/internal/providers/vercelsandbox/client_test.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestBridgeListCommandKeepsSecretsOffArgv(t *testing.T) {
@@ -281,7 +283,7 @@ func TestRedactSecretsRemovesTokenValues(t *testing.T) {
 }
 
 func TestCheckProjectUsesReadOnlyBridgeScopeValidation(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.VercelSandbox.ProjectID = "prj_123"
 	cfg.VercelSandbox.TeamID = "team_123"
 	var got bridgeRequest

--- a/internal/providers/vercelsandbox/core.go
+++ b/internal/providers/vercelsandbox/core.go
@@ -1,33 +1,8 @@
 package vercelsandbox
 
 import (
-	"io"
-	"time"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type DoctorCheck = core.DoctorCheck
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type CleanupRequest = core.CleanupRequest
-type Server = core.Server
-type Repo = core.Repo
-type LeaseClaim = core.LeaseClaim
-type ExitError = core.ExitError
-type timingPhase = core.TimingPhase
 
 const (
 	providerName   = "vercel-sandbox"
@@ -39,54 +14,10 @@ const (
 	NetworkPublic  = "public"
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func inventoryDoctorResult(provider string, leases int) DoctorResult {
-	return core.InventoryDoctorResult(provider, leases)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
-}
-
-func readLeaseClaim(leaseID string) (LeaseClaim, error) {
-	return core.ReadLeaseClaim(leaseID)
-}
-
 func listVercelSandboxLeaseClaims() ([]core.LeaseClaim, error) {
 	return core.ListLeaseClaimsWithPrefix(leasePrefix)
 }
 
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
-func removeLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
-	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
-}
-
-func shellQuote(value string) string {
-	return core.ShellQuote(value)
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
 func vercelSandboxCleanupCommand(leaseID string) string {
-	return "crabbox stop --provider " + providerName + " " + shellQuote(leaseID)
+	return "crabbox stop --provider " + providerName + " " + core.ShellQuote(leaseID)
 }

--- a/internal/providers/vercelsandbox/doctor.go
+++ b/internal/providers/vercelsandbox/doctor.go
@@ -6,38 +6,38 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	api, err := b.client()
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	checks := []DoctorCheck{
+	checks := []core.DoctorCheck{
 		{Status: "ok", Check: "sdk", Message: "bridge=contract mutation=false", Details: map[string]string{"bridge": "contract", "mutation": "false"}},
 	}
 	if err := api.CheckSDK(ctx); err != nil {
-		checks[0] = DoctorCheck{Status: "failed", Check: "sdk", Message: redactSecrets(err.Error()), Details: map[string]string{"class": "environment_blocked"}}
+		checks[0] = core.DoctorCheck{Status: "failed", Check: "sdk", Message: redactSecrets(err.Error()), Details: map[string]string{"class": "environment_blocked"}}
 	}
 	if path, err := api.CheckCLI(ctx); err != nil {
-		checks = append(checks, DoctorCheck{Status: "failed", Check: "cli", Message: redactSecrets(err.Error()), Details: map[string]string{"class": "environment_blocked", "mutation": "false"}})
+		checks = append(checks, core.DoctorCheck{Status: "failed", Check: "cli", Message: redactSecrets(err.Error()), Details: map[string]string{"class": "environment_blocked", "mutation": "false"}})
 	} else {
-		checks = append(checks, DoctorCheck{Status: "ok", Check: "cli", Message: "sandbox=" + path, Details: map[string]string{"path": path, "mutation": "false"}})
+		checks = append(checks, core.DoctorCheck{Status: "ok", Check: "cli", Message: "sandbox=" + path, Details: map[string]string{"path": path, "mutation": "false"}})
 	}
 	if err := api.CheckAuth(ctx); err != nil {
-		checks = append(checks, DoctorCheck{Status: "failed", Check: "auth", Message: redactSecrets(err.Error()), Details: map[string]string{"class": "environment_blocked", "mutation": "false"}})
+		checks = append(checks, core.DoctorCheck{Status: "failed", Check: "auth", Message: redactSecrets(err.Error()), Details: map[string]string{"class": "environment_blocked", "mutation": "false"}})
 	} else {
-		checks = append(checks, DoctorCheck{Status: "ok", Check: "auth", Message: "auth=ready mutation=false", Details: map[string]string{"auth": "ready", "mutation": "false"}})
+		checks = append(checks, core.DoctorCheck{Status: "ok", Check: "auth", Message: "auth=ready mutation=false", Details: map[string]string{"auth": "ready", "mutation": "false"}})
 	}
 	if err := api.CheckProject(ctx); err != nil {
-		checks = append(checks, DoctorCheck{Status: "warning", Check: "project", Message: redactSecrets(err.Error()), Details: map[string]string{"class": "environment_blocked", "mutation": "false"}})
+		checks = append(checks, core.DoctorCheck{Status: "warning", Check: "project", Message: redactSecrets(err.Error()), Details: map[string]string{"class": "environment_blocked", "mutation": "false"}})
 	} else {
-		checks = append(checks, DoctorCheck{Status: "ok", Check: "project", Message: "project=ready mutation=false", Details: map[string]string{"project": "ready", "mutation": "false"}})
+		checks = append(checks, core.DoctorCheck{Status: "ok", Check: "project", Message: "project=ready mutation=false", Details: map[string]string{"project": "ready", "mutation": "false"}})
 	}
 	sandboxes, err := api.ListSandboxes(ctx)
 	if err != nil {
-		checks = append(checks, DoctorCheck{Status: "warning", Check: "inventory", Message: redactSecrets(err.Error()), Details: map[string]string{"class": "environment_blocked", "mutation": "false"}})
+		checks = append(checks, core.DoctorCheck{Status: "warning", Check: "inventory", Message: redactSecrets(err.Error()), Details: map[string]string{"class": "environment_blocked", "mutation": "false"}})
 	} else {
-		result := inventoryDoctorResult(providerName, len(sandboxes))
-		checks = append(checks, DoctorCheck{Status: "ok", Check: "inventory", Message: result.Message, Details: map[string]string{"mutation": "false"}})
+		result := core.InventoryDoctorResult(providerName, len(sandboxes))
+		checks = append(checks, core.DoctorCheck{Status: "ok", Check: "inventory", Message: result.Message, Details: map[string]string{"mutation": "false"}})
 	}
-	return DoctorResult{Provider: providerName, Status: core.DoctorChecksStatus(checks), Checks: checks}, nil
+	return core.DoctorResult{Provider: providerName, Status: core.DoctorChecksStatus(checks), Checks: checks}, nil
 }

--- a/internal/providers/vercelsandbox/doctor_test.go
+++ b/internal/providers/vercelsandbox/doctor_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type fakeClient struct {
@@ -84,12 +86,12 @@ func TestDoctorReadyIsNonMutating(t *testing.T) {
 	fake := &fakeClient{cliPath: "/opt/bin/sandbox", list: []sandboxSummary{{ID: "vsbx_1"}}}
 	b := &backend{
 		spec: Provider{}.Spec(),
-		cfg:  Config{},
-		newClient: func(Config, Runtime) (vercelSandboxClient, error) {
+		cfg:  core.Config{},
+		newClient: func(core.Config, core.Runtime) (vercelSandboxClient, error) {
 			return fake, nil
 		},
 	}
-	result, err := b.Doctor(context.Background(), DoctorRequest{})
+	result, err := b.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,11 +123,11 @@ func TestDoctorReportsEnvironmentBlockersWithoutMutating(t *testing.T) {
 	}
 	b := &backend{
 		spec: Provider{}.Spec(),
-		newClient: func(Config, Runtime) (vercelSandboxClient, error) {
+		newClient: func(core.Config, core.Runtime) (vercelSandboxClient, error) {
 			return fake, nil
 		},
 	}
-	result, err := b.Doctor(context.Background(), DoctorRequest{})
+	result, err := b.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/vercelsandbox/flags.go
+++ b/internal/providers/vercelsandbox/flags.go
@@ -12,11 +12,11 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func RegisterVercelSandboxProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterVercelSandboxProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterVercelSandboxConfigFlags(fs, defaults.VercelSandbox)
 }
 
-func ApplyVercelSandboxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyVercelSandboxProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if strings.EqualFold(strings.TrimSpace(cfg.Provider), providerName) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --vercel-sandbox-vcpus", "use --vercel-sandbox-runtime or --vercel-sandbox-vcpus"); err != nil {
 			return err
@@ -34,49 +34,49 @@ func ApplyVercelSandboxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) 
 	return validateVercelSandboxConfig(*cfg)
 }
 
-func validateVercelSandboxConfig(cfg Config) error {
+func validateVercelSandboxConfig(cfg core.Config) error {
 	if _, err := vercelSandboxWorkdir(cfg); err != nil {
 		return err
 	}
 	if strings.TrimSpace(cfg.VercelSandbox.ProjectID) != "" &&
 		strings.TrimSpace(cfg.VercelSandbox.TeamID) == "" &&
 		strings.TrimSpace(cfg.VercelSandbox.Scope) == "" {
-		return exit(2, "vercel-sandbox projectId requires teamId or scope")
+		return core.Exit(2, "vercel-sandbox projectId requires teamId or scope")
 	}
 	switch strings.ToLower(strings.TrimSpace(cfg.VercelSandbox.Runtime)) {
 	case "", "node26", "node24", "node22", "python3.13":
 	default:
-		return exit(2, "vercel-sandbox runtime must be one of node26, node24, node22, python3.13")
+		return core.Exit(2, "vercel-sandbox runtime must be one of node26, node24, node22, python3.13")
 	}
 	if cfg.VercelSandbox.TimeoutSecs < 0 {
-		return exit(2, "vercel-sandbox timeoutSecs must be non-negative")
+		return core.Exit(2, "vercel-sandbox timeoutSecs must be non-negative")
 	}
 	if cfg.VercelSandbox.ExecTimeoutSecs < 0 {
-		return exit(2, "vercel-sandbox execTimeoutSecs must be non-negative")
+		return core.Exit(2, "vercel-sandbox execTimeoutSecs must be non-negative")
 	}
 	if cfg.VercelSandbox.VCPUs < 0 {
-		return exit(2, "vercel-sandbox vcpus must be positive when set")
+		return core.Exit(2, "vercel-sandbox vcpus must be positive when set")
 	}
 	if cfg.VercelSandbox.VCPUs > 0 && cfg.VercelSandbox.VCPUs < 0.25 {
-		return exit(2, "vercel-sandbox vcpus must be at least 0.25 when set")
+		return core.Exit(2, "vercel-sandbox vcpus must be at least 0.25 when set")
 	}
 	switch strings.ToLower(strings.TrimSpace(cfg.VercelSandbox.NetworkPolicy)) {
 	case "", "default", "public", "private", "restricted", "none":
 	default:
-		return exit(2, "vercel-sandbox networkPolicy must be default, public, private, restricted, or none")
+		return core.Exit(2, "vercel-sandbox networkPolicy must be default, public, private, restricted, or none")
 	}
 	if strings.EqualFold(strings.TrimSpace(cfg.VercelSandbox.NetworkPolicy), "none") &&
 		(len(cfg.VercelSandbox.NetworkAllow) > 0 || len(cfg.VercelSandbox.NetworkDeny) > 0) {
-		return exit(2, "vercel-sandbox networkPolicy none cannot be combined with networkAllow or networkDeny")
+		return core.Exit(2, "vercel-sandbox networkPolicy none cannot be combined with networkAllow or networkDeny")
 	}
 	for _, entry := range append([]string{}, cfg.VercelSandbox.NetworkAllow...) {
 		if err := validateNetworkEntry(entry); err != nil {
-			return exit(2, "vercel-sandbox networkAllow entry %q is invalid: %v", entry, err)
+			return core.Exit(2, "vercel-sandbox networkAllow entry %q is invalid: %v", entry, err)
 		}
 	}
 	for _, entry := range append([]string{}, cfg.VercelSandbox.NetworkDeny...) {
 		if err := validateNetworkEntry(entry); err != nil {
-			return exit(2, "vercel-sandbox networkDeny entry %q is invalid: %v", entry, err)
+			return core.Exit(2, "vercel-sandbox networkDeny entry %q is invalid: %v", entry, err)
 		}
 		value := strings.TrimSpace(entry)
 		if value == "" {
@@ -84,14 +84,14 @@ func validateVercelSandboxConfig(cfg Config) error {
 		}
 		if net.ParseIP(value) == nil {
 			if _, _, err := net.ParseCIDR(value); err != nil {
-				return exit(2, "vercel-sandbox networkDeny entry %q must be an IP address or CIDR; Vercel does not support domain deny rules", entry)
+				return core.Exit(2, "vercel-sandbox networkDeny entry %q must be an IP address or CIDR; Vercel does not support domain deny rules", entry)
 			}
 		}
 	}
 	exposedPorts := map[int]struct{}{}
 	for _, port := range cfg.VercelSandbox.Ports {
 		if err := validatePortSpec(port); err != nil {
-			return exit(2, "vercel-sandbox port %q is invalid: %v", port, err)
+			return core.Exit(2, "vercel-sandbox port %q is invalid: %v", port, err)
 		}
 		value := strings.TrimSpace(port)
 		if value == "" {
@@ -106,25 +106,25 @@ func validateVercelSandboxConfig(cfg Config) error {
 		for current := start; current <= end; current++ {
 			exposedPorts[current] = struct{}{}
 			if len(exposedPorts) > 15 {
-				return exit(2, "vercel-sandbox supports at most 15 unique exposed ports")
+				return core.Exit(2, "vercel-sandbox supports at most 15 unique exposed ports")
 			}
 		}
 	}
 	return nil
 }
 
-func vercelSandboxWorkdir(cfg Config) (string, error) {
+func vercelSandboxWorkdir(cfg core.Config) (string, error) {
 	workdir := strings.TrimSpace(cfg.VercelSandbox.Workdir)
 	if workdir == "" {
 		workdir = defaultWorkdir
 	}
 	if !path.IsAbs(workdir) {
-		return "", exit(2, "vercel-sandbox workdir must be absolute")
+		return "", core.Exit(2, "vercel-sandbox workdir must be absolute")
 	}
 	clean := path.Clean(workdir)
 	switch clean {
 	case "/", "/tmp", "/usr", "/var", "/home", "/vercel", "/vercel/sandbox":
-		return "", exit(2, "vercel-sandbox workdir %q is too broad; choose a dedicated subdirectory", clean)
+		return "", core.Exit(2, "vercel-sandbox workdir %q is too broad; choose a dedicated subdirectory", clean)
 	}
 	return clean, nil
 }

--- a/internal/providers/vercelsandbox/flags_test.go
+++ b/internal/providers/vercelsandbox/flags_test.go
@@ -26,7 +26,7 @@ func TestVercelSandboxProviderSpec(t *testing.T) {
 }
 
 func TestVercelSandboxFlagsApplyAndValidate(t *testing.T) {
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.VercelSandbox.Runtime = defaultRuntime
 	cfg.VercelSandbox.Workdir = defaultWorkdir
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
@@ -67,7 +67,7 @@ func TestVercelSandboxFlagsApplyAndValidate(t *testing.T) {
 
 func TestVercelSandboxRejectsClassAndType(t *testing.T) {
 	for _, flagName := range []string{"class", "type"} {
-		cfg := Config{Provider: providerName}
+		cfg := core.Config{Provider: providerName}
 		cfg.VercelSandbox.Runtime = defaultRuntime
 		cfg.VercelSandbox.Workdir = defaultWorkdir
 		fs := flag.NewFlagSet("test", flag.ContinueOnError)
@@ -85,32 +85,32 @@ func TestVercelSandboxRejectsClassAndType(t *testing.T) {
 }
 
 func TestValidateVercelSandboxConfigRejectsInvalidValues(t *testing.T) {
-	valid := Config{}
+	valid := core.Config{}
 	valid.VercelSandbox.Runtime = defaultRuntime
 	valid.VercelSandbox.Workdir = defaultWorkdir
 
 	tests := []struct {
 		name string
-		mut  func(*Config)
+		mut  func(*core.Config)
 		want string
 	}{
-		{"runtime", func(c *Config) { c.VercelSandbox.Runtime = "ruby" }, "runtime"},
-		{"removed-runtime", func(c *Config) { c.VercelSandbox.Runtime = "node20" }, "runtime"},
-		{"workdir-relative", func(c *Config) { c.VercelSandbox.Workdir = "workspace" }, "absolute"},
-		{"workdir-broad", func(c *Config) { c.VercelSandbox.Workdir = "/vercel/sandbox" }, "too broad"},
-		{"project-without-team", func(c *Config) { c.VercelSandbox.ProjectID = "prj_123" }, "requires teamId or scope"},
-		{"timeout", func(c *Config) { c.VercelSandbox.TimeoutSecs = -1 }, "non-negative"},
-		{"exec-timeout", func(c *Config) { c.VercelSandbox.ExecTimeoutSecs = -1 }, "non-negative"},
-		{"vcpus", func(c *Config) { c.VercelSandbox.VCPUs = -1 }, "vcpus"},
-		{"network-policy", func(c *Config) { c.VercelSandbox.NetworkPolicy = "mystery" }, "networkPolicy"},
-		{"network-none-with-rules", func(c *Config) {
+		{"runtime", func(c *core.Config) { c.VercelSandbox.Runtime = "ruby" }, "runtime"},
+		{"removed-runtime", func(c *core.Config) { c.VercelSandbox.Runtime = "node20" }, "runtime"},
+		{"workdir-relative", func(c *core.Config) { c.VercelSandbox.Workdir = "workspace" }, "absolute"},
+		{"workdir-broad", func(c *core.Config) { c.VercelSandbox.Workdir = "/vercel/sandbox" }, "too broad"},
+		{"project-without-team", func(c *core.Config) { c.VercelSandbox.ProjectID = "prj_123" }, "requires teamId or scope"},
+		{"timeout", func(c *core.Config) { c.VercelSandbox.TimeoutSecs = -1 }, "non-negative"},
+		{"exec-timeout", func(c *core.Config) { c.VercelSandbox.ExecTimeoutSecs = -1 }, "non-negative"},
+		{"vcpus", func(c *core.Config) { c.VercelSandbox.VCPUs = -1 }, "vcpus"},
+		{"network-policy", func(c *core.Config) { c.VercelSandbox.NetworkPolicy = "mystery" }, "networkPolicy"},
+		{"network-none-with-rules", func(c *core.Config) {
 			c.VercelSandbox.NetworkPolicy = "none"
 			c.VercelSandbox.NetworkAllow = []string{"api.example.com"}
 		}, "cannot be combined"},
-		{"network-entry", func(c *Config) { c.VercelSandbox.NetworkAllow = []string{"bad_host!"} }, "networkAllow"},
-		{"network-domain-deny", func(c *Config) { c.VercelSandbox.NetworkDeny = []string{"blocked.example.com"} }, "does not support domain deny"},
-		{"port", func(c *Config) { c.VercelSandbox.Ports = []string{"70000"} }, "port"},
-		{"too-many-ports", func(c *Config) { c.VercelSandbox.Ports = []string{"3000-3015"} }, "at most 15"},
+		{"network-entry", func(c *core.Config) { c.VercelSandbox.NetworkAllow = []string{"bad_host!"} }, "networkAllow"},
+		{"network-domain-deny", func(c *core.Config) { c.VercelSandbox.NetworkDeny = []string{"blocked.example.com"} }, "does not support domain deny"},
+		{"port", func(c *core.Config) { c.VercelSandbox.Ports = []string{"70000"} }, "port"},
+		{"too-many-ports", func(c *core.Config) { c.VercelSandbox.Ports = []string{"3000-3015"} }, "at most 15"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -125,17 +125,17 @@ func TestValidateVercelSandboxConfigRejectsInvalidValues(t *testing.T) {
 }
 
 func TestValidateVercelSandboxConfigAcceptsProjectWithTeamOrScope(t *testing.T) {
-	for _, cfg := range []Config{
-		func() Config {
-			cfg := Config{}
+	for _, cfg := range []core.Config{
+		func() core.Config {
+			cfg := core.Config{}
 			cfg.VercelSandbox.Runtime = defaultRuntime
 			cfg.VercelSandbox.Workdir = defaultWorkdir
 			cfg.VercelSandbox.ProjectID = "prj_123"
 			cfg.VercelSandbox.TeamID = "team_123"
 			return cfg
 		}(),
-		func() Config {
-			cfg := Config{}
+		func() core.Config {
+			cfg := core.Config{}
 			cfg.VercelSandbox.Runtime = defaultRuntime
 			cfg.VercelSandbox.Workdir = defaultWorkdir
 			cfg.VercelSandbox.ProjectID = "prj_123"
@@ -152,7 +152,7 @@ func TestValidateVercelSandboxConfigAcceptsProjectWithTeamOrScope(t *testing.T) 
 func TestValidateVercelSandboxConfigAcceptsCurrentRuntimes(t *testing.T) {
 	for _, runtime := range []string{"node26", "node24", "node22", "python3.13"} {
 		t.Run(runtime, func(t *testing.T) {
-			cfg := Config{}
+			cfg := core.Config{}
 			cfg.VercelSandbox.Runtime = runtime
 			cfg.VercelSandbox.Workdir = defaultWorkdir
 			if err := validateVercelSandboxConfig(cfg); err != nil {

--- a/internal/providers/vercelsandbox/operation_lock.go
+++ b/internal/providers/vercelsandbox/operation_lock.go
@@ -5,13 +5,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func lockVercelSandboxLeaseOperation(ctx context.Context, leaseID string) (func(), error) {
 	if !strings.HasPrefix(leaseID, leasePrefix) || strings.TrimPrefix(leaseID, leasePrefix) == "" ||
 		filepath.Base(leaseID) != leaseID || leaseID == "." {
-		return nil, exit(2, "invalid vercel-sandbox lease id %q", leaseID)
+		return nil, core.Exit(2, "invalid vercel-sandbox lease id %q", leaseID)
 	}
 	return shared.LockLeaseOperation(ctx, "vercel-sandbox", leaseID)
 }

--- a/internal/providers/vercelsandbox/provider.go
+++ b/internal/providers/vercelsandbox/provider.go
@@ -57,22 +57,22 @@ func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.Doctor
 	return shared.ConfigureDoctor("vercel-sandbox", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
-func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	return &backend{spec: spec, cfg: cfg, rt: rt, newClient: newBridgeClient}
 }
 
 type backend struct {
-	spec            ProviderSpec
-	cfg             Config
-	rt              Runtime
+	spec            core.ProviderSpec
+	cfg             core.Config
+	rt              core.Runtime
 	resolvedProject string
 	resolvedTeam    string
 	legacyScopeBase string
-	newClient       func(Config, Runtime) (vercelSandboxClient, error)
+	newClient       func(core.Config, core.Runtime) (vercelSandboxClient, error)
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
 func (b *backend) client() (vercelSandboxClient, error) {
 	if b.newClient != nil {

--- a/internal/providers/vercelsandbox/sync.go
+++ b/internal/providers/vercelsandbox/sync.go
@@ -9,7 +9,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *backend) syncWorkspace(ctx context.Context, api vercelSandboxClient, sandboxID string, req RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+func (b *backend) syncWorkspace(ctx context.Context, api vercelSandboxClient, sandboxID string, req core.RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
@@ -33,18 +33,18 @@ func (b *backend) syncWorkspace(ctx context.Context, api vercelSandboxClient, sa
 
 func (b *backend) execShell(ctx context.Context, api vercelSandboxClient, sandboxID, command string) error {
 	res, err := api.Exec(ctx, sandboxID, execRequest{
-		Command:     "sh -lc " + shellQuote(command),
+		Command:     "sh -lc " + core.ShellQuote(command),
 		TimeoutSecs: b.execTimeoutSecs(),
 	}, io.Discard, io.Discard)
 	if err != nil {
 		return err
 	}
 	if res.ExitCode != 0 {
-		return exit(res.ExitCode, "vercel-sandbox exec %q exited %d: %s", command, res.ExitCode, strings.TrimSpace(res.Stderr))
+		return core.Exit(res.ExitCode, "vercel-sandbox exec %q exited %d: %s", command, res.ExitCode, strings.TrimSpace(res.Stderr))
 	}
 	return nil
 }
 
 func (b *backend) ensureWorkspace(ctx context.Context, api vercelSandboxClient, sandboxID, workdir string) error {
-	return b.execShell(ctx, api, sandboxID, "mkdir -p "+shellQuote(workdir))
+	return b.execShell(ctx, api, sandboxID, "mkdir -p "+core.ShellQuote(workdir))
 }


### PR DESCRIPTION
Call core APIs directly from Cloudflare Containers, Cloudflare Dynamic Workers, AWS Lambda MicroVM, Vercel Sandbox, Upstash Box, Tensorlake, Railway, and FastAPI Cloud. Removing their exact forwarding functions and identity aliases eliminates 437 net production lines.

Provider-specific loader scopes, serverless labels, recovery commands, and service-control behavior stay in their existing implementations. Replacements were checked against Go type identity and resolved symbol uses.

Validation: complete tests passed for all eight provider packages; scoped Autoreview passed. CI is required before merge. No new dependencies or configuration.
