### PR TITLE
refactor(providers): use core contracts in local runtimes

### DIFF
--- a/internal/providers/anthropicsandboxruntime/backend.go
+++ b/internal/providers/anthropicsandboxruntime/backend.go
@@ -11,37 +11,37 @@ import (
 )
 
 type backend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
-func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	return &backend{spec: spec, cfg: cfg, rt: rt}
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *backend) Warmup(context.Context, WarmupRequest) error {
-	return exit(2, "provider=anthropic-sandbox-runtime is one-shot; use crabbox run")
+func (b *backend) Warmup(context.Context, core.WarmupRequest) error {
+	return core.Exit(2, "provider=anthropic-sandbox-runtime is one-shot; use crabbox run")
 }
 
-func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *backend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	if err := rejectRunOptions(b.spec, req); err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	started := time.Now()
 	cli, err := newSRTCLI(b.cfg, b.rt)
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	commandText, err := buildCommandText(req.Command, req.ShellMode)
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
-		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+		core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
 	fmt.Fprintf(b.rt.Stderr, "provider=%s cli=%s sync_delegated=true lifecycle=one-shot\n", providerName, cli.binary())
 	commandStart := time.Now()
@@ -49,7 +49,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	stdout, stderr := req.Observation.CommandWriters(b.rt.Stdout, b.rt.Stderr, core.RunOutputProvider)
 	exitCode, runErr := cli.runCommand(ctx, req.Repo.Root, commandText, req.Env, stdout, stderr)
 	commandDuration := time.Since(commandStart)
-	result := RunResult{
+	result := core.RunResult{
 		ExitCode:      exitCode,
 		Command:       commandDuration,
 		Total:         time.Since(started),
@@ -60,7 +60,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	result = core.FinalizeRunResult(result, runErr)
 	fmt.Fprintf(b.rt.Stderr, "anthropic-sandbox-runtime run summary sync_delegated=true command=%s total=%s exit=%d\n", commandDuration.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
 	if req.TimingJSON {
-		report := timingReportWithRunResult(timingReport{
+		report := core.TimingReportWithRunResult(core.TimingReport{
 			Provider:      providerName,
 			SyncDelegated: true,
 			SyncSkipped:   true,
@@ -69,37 +69,37 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			ExitCode:      exitCode,
 			Label:         strings.TrimSpace(req.Label),
 		}, result, runErr)
-		if err := writeTimingJSON(b.rt.Stderr, report); err != nil {
+		if err := core.WriteTimingJSON(b.rt.Stderr, report); err != nil {
 			return result, err
 		}
 	}
 	if runErr != nil {
 		if exitCode != 0 {
-			return result, exit(exitCode, "anthropic-sandbox-runtime run failed: %v", runErr)
+			return result, core.Exit(exitCode, "anthropic-sandbox-runtime run failed: %v", runErr)
 		}
-		return result, exit(1, "anthropic-sandbox-runtime run failed: %v", runErr)
+		return result, core.Exit(1, "anthropic-sandbox-runtime run failed: %v", runErr)
 	}
 	return result, nil
 }
 
-func (b *backend) List(context.Context, ListRequest) ([]LeaseView, error) {
+func (b *backend) List(context.Context, core.ListRequest) ([]core.LeaseView, error) {
 	return nil, nil
 }
 
-func (b *backend) Status(context.Context, StatusRequest) (StatusView, error) {
-	return StatusView{}, exit(2, "provider=anthropic-sandbox-runtime is one-shot and does not support status")
+func (b *backend) Status(context.Context, core.StatusRequest) (core.StatusView, error) {
+	return core.StatusView{}, core.Exit(2, "provider=anthropic-sandbox-runtime is one-shot and does not support status")
 }
 
-func (b *backend) Stop(context.Context, StopRequest) error {
-	return exit(2, "provider=anthropic-sandbox-runtime is one-shot and does not support stop")
+func (b *backend) Stop(context.Context, core.StopRequest) error {
+	return core.Exit(2, "provider=anthropic-sandbox-runtime is one-shot and does not support stop")
 }
 
-func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	cli, err := newSRTCLI(b.cfg, b.rt)
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	result := DoctorResult{Provider: providerName}
+	result := core.DoctorResult{Provider: providerName}
 	help, helpErr := cli.help(ctx)
 	helpDetails := map[string]string{
 		"cli":      cli.binary(),
@@ -110,14 +110,14 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	result.Checks = append(result.Checks, doctorCheck("srt_help", helpErr, helpDetails))
 	version, versionErr := cli.version(ctx)
 	if versionErr == nil {
-		result.Checks = append(result.Checks, DoctorCheck{
+		result.Checks = append(result.Checks, core.DoctorCheck{
 			Status:  "ok",
 			Check:   "srt_version",
 			Message: "version reported; compatibility is based on command-surface checks",
 			Details: map[string]string{"version": version, "authoritative": "false"},
 		})
 	} else {
-		result.Checks = append(result.Checks, DoctorCheck{
+		result.Checks = append(result.Checks, core.DoctorCheck{
 			Status:  "warn",
 			Check:   "srt_version",
 			Message: versionErr.Error(),
@@ -134,44 +134,44 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	return result, nil
 }
 
-func rejectRunOptions(spec ProviderSpec, req RunRequest) error {
+func rejectRunOptions(spec core.ProviderSpec, req core.RunRequest) error {
 	if err := core.RejectDelegatedSyncOptionsForSpec(spec, req); err != nil {
 		return err
 	}
 	if req.ID != "" || req.Keep || req.KeepOnFailure || strings.TrimSpace(req.RequestedSlug) != "" {
-		return exit(2, "provider=anthropic-sandbox-runtime is one-shot and does not support persistent lease ids")
+		return core.Exit(2, "provider=anthropic-sandbox-runtime is one-shot and does not support persistent lease ids")
 	}
 	if req.Options.Desktop || req.Options.Browser || req.Options.Code {
-		return exit(2, "provider=anthropic-sandbox-runtime does not support desktop, browser, or code-server options")
+		return core.Exit(2, "provider=anthropic-sandbox-runtime does not support desktop, browser, or code-server options")
 	}
 	if req.Options.Tailscale.Enabled {
-		return exit(2, "provider=anthropic-sandbox-runtime is delegated-run only and does not support Tailscale options")
+		return core.Exit(2, "provider=anthropic-sandbox-runtime is delegated-run only and does not support Tailscale options")
 	}
 	if !req.ApplyLocalPatch && strings.TrimSpace(req.Repo.Root) == "" {
-		return exit(2, "provider=anthropic-sandbox-runtime requires a local workspace")
+		return core.Exit(2, "provider=anthropic-sandbox-runtime requires a local workspace")
 	}
 	return nil
 }
 
 func buildCommandText(command []string, shellMode bool) (string, error) {
 	if len(command) == 0 {
-		return "", exit(2, "missing command")
+		return "", core.Exit(2, "missing command")
 	}
 	if shellMode {
 		return strings.Join(command, " "), nil
 	}
-	if len(command) == 1 && shouldUseShell(command) {
+	if len(command) == 1 && core.ShouldUseShell(command) {
 		return command[0], nil
 	}
-	if shouldUseShell(command) || leadingEnvAssignment(command) {
-		return shellScriptFromArgv(command), nil
+	if core.ShouldUseShell(command) || core.LeadingEnvAssignment(command) {
+		return core.ShellScriptFromArgv(command), nil
 	}
-	return shellScriptFromArgv(command), nil
+	return core.ShellScriptFromArgv(command), nil
 }
 
-func doctorCheck(name string, err error, details map[string]string) DoctorCheck {
+func doctorCheck(name string, err error, details map[string]string) core.DoctorCheck {
 	if err != nil {
-		return DoctorCheck{Status: "error", Check: name, Message: err.Error(), Details: details}
+		return core.DoctorCheck{Status: "error", Check: name, Message: err.Error(), Details: details}
 	}
-	return DoctorCheck{Status: "ok", Check: name, Message: "ready", Details: details}
+	return core.DoctorCheck{Status: "ok", Check: name, Message: "ready", Details: details}
 }

--- a/internal/providers/anthropicsandboxruntime/backend_test.go
+++ b/internal/providers/anthropicsandboxruntime/backend_test.go
@@ -119,7 +119,7 @@ func TestSRTLauncherDefaultsAndArgumentsRecorded(t *testing.T) {
 			cfg.AnthropicSRT = core.AnthropicSRTConfig{CLIPath: tc.cli, Settings: tc.settings, Debug: tc.debug}
 			before := cfg.AnthropicSRT
 			runner := &recordingRunner{}
-			client, err := newSRTCLI(cfg, Runtime{Exec: runner})
+			client, err := newSRTCLI(cfg, core.Runtime{Exec: runner})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -142,11 +142,11 @@ func TestSRTLauncherDefaultsAndArgumentsRecorded(t *testing.T) {
 
 func TestConfigureRequiresRuntimeExec(t *testing.T) {
 	cfg := newTestConfig()
-	if _, err := (Provider{}).Configure(cfg, Runtime{}); err != nil {
+	if _, err := (Provider{}).Configure(cfg, core.Runtime{}); err != nil {
 		t.Fatalf("Configure should allow Runtime.Exec check to happen at operation time: %v", err)
 	}
 	backend := newTestBackend(cfg, nil, io.Discard, io.Discard)
-	_, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "my-app", Root: t.TempDir()}, Command: []string{"true"}})
+	_, err := backend.Run(context.Background(), core.RunRequest{Repo: core.Repo{Name: "my-app", Root: t.TempDir()}, Command: []string{"true"}})
 	if err == nil || !strings.Contains(err.Error(), "requires Runtime.Exec") {
 		t.Fatalf("Run err=%v", err)
 	}
@@ -157,19 +157,19 @@ func TestRunBuildsSRTCommandAndStreamsOutput(t *testing.T) {
 	cfg.AnthropicSRT.CLIPath = "/opt/srt"
 	cfg.AnthropicSRT.Settings = ".crabbox/srt-settings.json"
 	cfg.AnthropicSRT.Debug = true
-	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &recordingRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if req.Stdout != nil {
 			_, _ = io.WriteString(req.Stdout, "ok\n")
 		}
 		if req.Stderr != nil {
 			_, _ = io.WriteString(req.Stderr, "srt debug\n")
 		}
-		return LocalCommandResult{ExitCode: 0, Stdout: "ok\n", Stderr: "srt debug\n"}, nil
+		return core.LocalCommandResult{ExitCode: 0, Stdout: "ok\n", Stderr: "srt debug\n"}, nil
 	}}
 	var stdout, stderr bytes.Buffer
 	backend := newTestBackend(cfg, runner, &stdout, &stderr)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: "/tmp/my-app"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: "/tmp/my-app"},
 		Command: []string{"echo", "hello world"},
 	})
 	if err != nil {
@@ -198,13 +198,13 @@ func TestRunForwardsEnvOutsideArgv(t *testing.T) {
 	cfg := newTestConfig()
 	secret := "secret-token-value"
 	t.Setenv("CRABBOX_SECRET_SHOULD_NOT_LEAK", "host-secret")
-	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
-		return LocalCommandResult{ExitCode: 0}, nil
+	runner := &recordingRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		return core.LocalCommandResult{ExitCode: 0}, nil
 	}}
 	var stderr bytes.Buffer
 	backend := newTestBackend(cfg, runner, io.Discard, &stderr)
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:       Repo{Name: "my-app", Root: t.TempDir()},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Name: "my-app", Root: t.TempDir()},
 		Command:    []string{"printenv", "SECRET_TOKEN"},
 		Env:        map[string]string{"SECRET_TOKEN": secret},
 		EnvSummary: true,
@@ -229,16 +229,16 @@ func TestRunForwardsEnvOutsideArgv(t *testing.T) {
 }
 
 func TestRunReturnsNonZeroExitWithoutPersistentSession(t *testing.T) {
-	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &recordingRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if req.Stderr != nil {
 			_, _ = io.WriteString(req.Stderr, "boom\n")
 		}
-		return LocalCommandResult{ExitCode: 7, Stderr: "boom\n"}, errors.New("exit status 7")
+		return core.LocalCommandResult{ExitCode: 7, Stderr: "boom\n"}, errors.New("exit status 7")
 	}}
 	var stderr bytes.Buffer
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, &stderr)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:       Repo{Name: "my-app", Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Name: "my-app", Root: t.TempDir()},
 		Command:    []string{"false"},
 		TimingJSON: true,
 	})
@@ -261,21 +261,21 @@ func TestRunRejectsUnsupportedOneShotOptions(t *testing.T) {
 	backend := newTestBackend(newTestConfig(), &recordingRunner{}, io.Discard, io.Discard)
 	tests := []struct {
 		name string
-		req  RunRequest
+		req  core.RunRequest
 		want string
 	}{
-		{name: "lease id", req: RunRequest{ID: "cbx_123"}, want: "persistent lease ids"},
-		{name: "keep", req: RunRequest{Keep: true}, want: "persistent lease ids"},
-		{name: "desktop", req: RunRequest{Options: core.LeaseOptions{Desktop: true}}, want: "desktop"},
-		{name: "tailscale", req: RunRequest{Options: core.LeaseOptions{Tailscale: core.TailscaleConfig{Enabled: true}}}, want: "Tailscale"},
-		{name: "sync only", req: RunRequest{SyncOnly: true}, want: "--sync-only is not supported"},
-		{name: "capture", req: RunRequest{CaptureStdout: "stdout.txt"}, want: "--capture-stdout is not supported"},
-		{name: "fresh pr", req: RunRequest{FreshPR: core.FreshPRSpec{Owner: "example-org", Repo: "my-app", Number: 1}}, want: "--fresh-pr is not supported"},
+		{name: "lease id", req: core.RunRequest{ID: "cbx_123"}, want: "persistent lease ids"},
+		{name: "keep", req: core.RunRequest{Keep: true}, want: "persistent lease ids"},
+		{name: "desktop", req: core.RunRequest{Options: core.LeaseOptions{Desktop: true}}, want: "desktop"},
+		{name: "tailscale", req: core.RunRequest{Options: core.LeaseOptions{Tailscale: core.TailscaleConfig{Enabled: true}}}, want: "Tailscale"},
+		{name: "sync only", req: core.RunRequest{SyncOnly: true}, want: "--sync-only is not supported"},
+		{name: "capture", req: core.RunRequest{CaptureStdout: "stdout.txt"}, want: "--capture-stdout is not supported"},
+		{name: "fresh pr", req: core.RunRequest{FreshPR: core.FreshPRSpec{Owner: "example-org", Repo: "my-app", Number: 1}}, want: "--fresh-pr is not supported"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := tt.req
-			req.Repo = Repo{Name: "my-app", Root: t.TempDir()}
+			req.Repo = core.Repo{Name: "my-app", Root: t.TempDir()}
 			req.Command = []string{"true"}
 			_, err := backend.Run(context.Background(), req)
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
@@ -289,19 +289,19 @@ func TestRunRejectsUnsupportedOneShotOptions(t *testing.T) {
 }
 
 func TestDoctorChecksHelpAndTreatsVersionAsInformational(t *testing.T) {
-	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &recordingRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		switch strings.Join(req.Args, " ") {
 		case "--help":
-			return LocalCommandResult{ExitCode: 0, Stdout: "Usage: srt -c <command>\n"}, nil
+			return core.LocalCommandResult{ExitCode: 0, Stdout: "Usage: srt -c <command>\n"}, nil
 		case "--version":
-			return LocalCommandResult{ExitCode: 1, Stderr: "not available\n"}, errors.New("version failed")
+			return core.LocalCommandResult{ExitCode: 1, Stderr: "not available\n"}, errors.New("version failed")
 		default:
 			t.Fatalf("unexpected args=%v", req.Args)
-			return LocalCommandResult{}, nil
+			return core.LocalCommandResult{}, nil
 		}
 	}}
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatalf("Doctor err=%v", err)
 	}
@@ -314,11 +314,11 @@ func TestDoctorChecksHelpAndTreatsVersionAsInformational(t *testing.T) {
 }
 
 func TestDoctorFailsWhenHelpUnavailable(t *testing.T) {
-	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
-		return LocalCommandResult{ExitCode: 127, Stderr: "srt not found"}, errors.New("not found")
+	runner := &recordingRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		return core.LocalCommandResult{ExitCode: 127, Stderr: "srt not found"}, errors.New("not found")
 	}}
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err == nil || result.Status != "error" || !strings.Contains(result.Message, "command_surface=blocked") {
 		t.Fatalf("result=%#v err=%v", result, err)
 	}
@@ -326,16 +326,16 @@ func TestDoctorFailsWhenHelpUnavailable(t *testing.T) {
 
 func TestLifecycleIsOneShot(t *testing.T) {
 	backend := newTestBackend(newTestConfig(), &recordingRunner{}, io.Discard, io.Discard)
-	if err := backend.Warmup(context.Background(), WarmupRequest{}); err == nil || !strings.Contains(err.Error(), "one-shot") {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{}); err == nil || !strings.Contains(err.Error(), "one-shot") {
 		t.Fatalf("Warmup err=%v", err)
 	}
-	if leases, err := backend.List(context.Background(), ListRequest{}); err != nil || len(leases) != 0 {
+	if leases, err := backend.List(context.Background(), core.ListRequest{}); err != nil || len(leases) != 0 {
 		t.Fatalf("List leases=%#v err=%v", leases, err)
 	}
-	if _, err := backend.Status(context.Background(), StatusRequest{}); err == nil || !strings.Contains(err.Error(), "does not support status") {
+	if _, err := backend.Status(context.Background(), core.StatusRequest{}); err == nil || !strings.Contains(err.Error(), "does not support status") {
 		t.Fatalf("Status err=%v", err)
 	}
-	if err := backend.Stop(context.Background(), StopRequest{}); err == nil || !strings.Contains(err.Error(), "does not support stop") {
+	if err := backend.Stop(context.Background(), core.StopRequest{}); err == nil || !strings.Contains(err.Error(), "does not support stop") {
 		t.Fatalf("Stop err=%v", err)
 	}
 }
@@ -367,19 +367,19 @@ func TestBuildCommandText(t *testing.T) {
 }
 
 type recordingRunner struct {
-	calls []LocalCommandRequest
-	fn    func(LocalCommandRequest) (LocalCommandResult, error)
+	calls []core.LocalCommandRequest
+	fn    func(core.LocalCommandRequest) (core.LocalCommandResult, error)
 }
 
-func (r *recordingRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.calls = append(r.calls, req)
 	if r.fn != nil {
 		return r.fn(req)
 	}
-	return LocalCommandResult{ExitCode: 0}, nil
+	return core.LocalCommandResult{ExitCode: 0}, nil
 }
 
-func (r *recordingRunner) onlyCall(t *testing.T) LocalCommandRequest {
+func (r *recordingRunner) onlyCall(t *testing.T) core.LocalCommandRequest {
 	t.Helper()
 	if len(r.calls) != 1 {
 		t.Fatalf("calls=%#v want one", r.calls)
@@ -387,15 +387,15 @@ func (r *recordingRunner) onlyCall(t *testing.T) LocalCommandRequest {
 	return r.calls[0]
 }
 
-func newTestConfig() Config {
+func newTestConfig() core.Config {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.AnthropicSRT.CLIPath = "srt"
 	return cfg
 }
 
-func newTestBackend(cfg Config, runner *recordingRunner, stdout, stderr io.Writer) *backend {
-	rt := Runtime{Stdout: stdout, Stderr: stderr}
+func newTestBackend(cfg core.Config, runner *recordingRunner, stdout, stderr io.Writer) *backend {
+	rt := core.Runtime{Stdout: stdout, Stderr: stderr}
 	if runner != nil {
 		rt.Exec = runner
 	}

--- a/internal/providers/anthropicsandboxruntime/client.go
+++ b/internal/providers/anthropicsandboxruntime/client.go
@@ -12,13 +12,13 @@ import (
 )
 
 type srtCLI struct {
-	cfg Config
-	rt  Runtime
+	cfg core.Config
+	rt  core.Runtime
 }
 
-func newSRTCLI(cfg Config, rt Runtime) (*srtCLI, error) {
+func newSRTCLI(cfg core.Config, rt core.Runtime) (*srtCLI, error) {
 	if rt.Exec == nil {
-		return nil, exit(2, "provider=anthropic-sandbox-runtime requires Runtime.Exec")
+		return nil, core.Exit(2, "provider=anthropic-sandbox-runtime requires Runtime.Exec")
 	}
 	return &srtCLI{cfg: cfg, rt: rt}, nil
 }
@@ -93,7 +93,7 @@ func (c *srtCLI) version(ctx context.Context) (string, error) {
 
 func (c *srtCLI) runQuiet(ctx context.Context, args []string) (string, string, error) {
 	var stdout, stderr bytes.Buffer
-	result, err := c.rt.Exec.Run(ctx, LocalCommandRequest{
+	result, err := c.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name:   c.binary(),
 		Args:   args,
 		Env:    c.env(nil),
@@ -108,7 +108,7 @@ func (c *srtCLI) runQuiet(ctx context.Context, args []string) (string, string, e
 
 func (c *srtCLI) runCommand(ctx context.Context, dir, commandText string, env map[string]string, stdout, stderr io.Writer) (int, error) {
 	args := append(c.baseArgs(), "-c", commandText)
-	result, err := c.rt.Exec.Run(ctx, LocalCommandRequest{
+	result, err := c.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name:   c.binary(),
 		Args:   args,
 		Env:    c.env(env),
@@ -125,7 +125,7 @@ func (c *srtCLI) runCommand(ctx context.Context, dir, commandText string, env ma
 	return result.ExitCode, nil
 }
 
-func srtError(args []string, result LocalCommandResult, stdout, stderr string, err error) error {
+func srtError(args []string, result core.LocalCommandResult, stdout, stderr string, err error) error {
 	detail := strings.TrimSpace(stderr)
 	if detail == "" {
 		detail = strings.TrimSpace(stdout)

--- a/internal/providers/anthropicsandboxruntime/core.go
+++ b/internal/providers/anthropicsandboxruntime/core.go
@@ -1,61 +1,6 @@
 package anthropicsandboxruntime
 
-import (
-	"io"
-
-	core "github.com/openclaw/crabbox/internal/cli"
-)
-
-type Config = core.Config
-type AnthropicSRTConfig = core.AnthropicSRTConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type DoctorCheck = core.DoctorCheck
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type Repo = core.Repo
-type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
-type timingReport = core.TimingReport
-
 const (
 	providerName   = "anthropic-sandbox-runtime"
 	providerFamily = "anthropic-sandbox-runtime"
 )
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
-}
-
-func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
-	return core.TimingReportWithRunResult(report, result, err)
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func leadingEnvAssignment(command []string) bool {
-	return core.LeadingEnvAssignment(command)
-}
-
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}

--- a/internal/providers/anthropicsandboxruntime/flags.go
+++ b/internal/providers/anthropicsandboxruntime/flags.go
@@ -24,9 +24,9 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	return validateConfig(*cfg)
 }
 
-func validateConfig(cfg Config) error {
+func validateConfig(cfg core.Config) error {
 	if strings.TrimSpace(cfg.AnthropicSRT.CLIPath) == "" {
-		return exit(2, "anthropicSandboxRuntime cliPath must not be empty")
+		return core.Exit(2, "anthropicSandboxRuntime cliPath must not be empty")
 	}
 	return nil
 }

--- a/internal/providers/applecontainer/backend.go
+++ b/internal/providers/applecontainer/backend.go
@@ -228,7 +228,7 @@ func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.Doctor
 	// running. We use it as the readiness probe before listing.
 	statusResult, statusErr := b.container(ctx, []string{"system", "status"}, nil, nil)
 	if statusErr != nil {
-		return core.DoctorResult{}, exit(2, "%s system status failed (is the container CLI installed and started with `container system start`?): %s", providerName, commandDetail(statusResult, statusErr))
+		return core.DoctorResult{}, core.Exit(2, "%s system status failed (is the container CLI installed and started with `container system start`?): %s", providerName, commandDetail(statusResult, statusErr))
 	}
 	// The lease path shells out to `container run` with detached mode, `--user`,
 	// `--label`, and `--dns`. Probe that surface here so doctor fails fast on a
@@ -263,7 +263,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 		}
 	}
 	if id == "" {
-		return exit(2, "provider=%s release requires a container id", providerName)
+		return core.Exit(2, "provider=%s release requires a container id", providerName)
 	}
 	if err := requireExactAppleContainerClaim(lease.LeaseID, id); err != nil {
 		return err
@@ -296,7 +296,7 @@ func appleContainerClaimStatus(leaseID, containerID string) (owned, conflict boo
 }
 
 func appleContainerOwnershipError(leaseID, containerID string) error {
-	return exit(4, "apple-container lease %q has no exact local claim bound to container %q; adopt it with an explicit --reclaim reuse before stop", strings.TrimSpace(leaseID), strings.TrimSpace(containerID))
+	return core.Exit(4, "apple-container lease %q has no exact local claim bound to container %q; adopt it with an explicit --reclaim reuse before stop", strings.TrimSpace(leaseID), strings.TrimSpace(containerID))
 }
 
 func requireExactAppleContainerClaim(leaseID, containerID string) error {
@@ -415,7 +415,7 @@ func (b *backend) Touch(_ context.Context, req core.TouchRequest) (core.Server, 
 func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, leaseID, slug, publicKey string, keep bool) (string, error) {
 	digest, reviewedDefault := core.DefaultContainerImageDigest(cfg.AppleContainer.Image)
 	if reviewedDefault && digest == "" {
-		return "", exit(2, "compiled container image is missing its reviewed digest")
+		return "", core.Exit(2, "compiled container image is missing its reviewed digest")
 	}
 	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
 	labels["image"] = cfg.AppleContainer.Image
@@ -502,23 +502,23 @@ func appleContainerCacheVolumeMounts(volumes []core.CacheVolumeConfig) ([]string
 		key := strings.TrimSpace(volume.Key)
 		path := strings.TrimSpace(volume.Path)
 		if key == "" {
-			return nil, exit(2, "cache volume key is required")
+			return nil, core.Exit(2, "cache volume key is required")
 		}
 		if strings.Contains(key, ":") {
-			return nil, exit(2, "cache volume key %q must not contain ':'", key)
+			return nil, core.Exit(2, "cache volume key %q must not contain ':'", key)
 		}
 		if path == "" {
-			return nil, exit(2, "cache volume path is required")
+			return nil, core.Exit(2, "cache volume path is required")
 		}
 		if !strings.HasPrefix(path, "/") {
-			return nil, exit(2, "cache volume path %q must be absolute", path)
+			return nil, core.Exit(2, "cache volume path %q must be absolute", path)
 		}
 		hostPath := filepath.Join(root, appleContainerCacheVolumeName(key))
 		if err := os.MkdirAll(hostPath, 0o777); err != nil {
-			return nil, exit(2, "create apple-container cache volume %s: %v", hostPath, err)
+			return nil, core.Exit(2, "create apple-container cache volume %s: %v", hostPath, err)
 		}
 		if err := os.Chmod(hostPath, 0o777); err != nil {
-			return nil, exit(2, "make apple-container cache volume writable %s: %v", hostPath, err)
+			return nil, core.Exit(2, "make apple-container cache volume writable %s: %v", hostPath, err)
 		}
 		mounts = append(mounts, hostPath+":"+path)
 	}
@@ -528,7 +528,7 @@ func appleContainerCacheVolumeMounts(volumes []core.CacheVolumeConfig) ([]string
 func appleContainerCacheRoot() (string, error) {
 	dir, err := os.UserCacheDir()
 	if err != nil {
-		return "", exit(2, "user cache directory is unavailable")
+		return "", core.Exit(2, "user cache directory is unavailable")
 	}
 	return filepath.Join(dir, "crabbox", "apple-container-cache"), nil
 }
@@ -544,7 +544,7 @@ func (b *backend) listContainers(ctx context.Context) ([]inspectContainer, error
 	}
 	all, err := decodeInspect([]byte(result.Stdout))
 	if err != nil {
-		return nil, exit(2, "parse container ls: %v", err)
+		return nil, core.Exit(2, "parse container ls: %v", err)
 	}
 	out := make([]inspectContainer, 0, len(all))
 	for _, c := range all {
@@ -563,10 +563,10 @@ func (b *backend) inspectContainer(ctx context.Context, id string) (inspectConta
 	}
 	containers, err := decodeInspect([]byte(result.Stdout))
 	if err != nil {
-		return inspectContainer{}, exit(2, "parse container inspect for %s: %v", id, err)
+		return inspectContainer{}, core.Exit(2, "parse container inspect for %s: %v", id, err)
 	}
 	if len(containers) == 0 {
-		return inspectContainer{}, exit(4, "container not found: %s", id)
+		return inspectContainer{}, core.Exit(4, "container not found: %s", id)
 	}
 	return containers[0], nil
 }
@@ -576,7 +576,7 @@ func (b *backend) waitForNetworkAddress(ctx context.Context, id string, c inspec
 		return c, nil
 	}
 	if appleContainerTerminalStatus(c.status()) {
-		return inspectContainer{}, exit(5, "apple-container %s stopped before a network address was assigned", id)
+		return inspectContainer{}, core.Exit(5, "apple-container %s stopped before a network address was assigned", id)
 	}
 	if timeout <= 0 {
 		timeout = 30 * time.Second
@@ -592,7 +592,7 @@ func (b *backend) waitForNetworkAddress(ctx context.Context, id string, c inspec
 			case <-ctx.Done():
 				return ctx.Err()
 			case <-deadline.C:
-				return exit(5, "apple-container %s has no network address yet", id)
+				return core.Exit(5, "apple-container %s has no network address yet", id)
 			case <-tick.C:
 				return nil
 			}
@@ -612,7 +612,7 @@ func (b *backend) waitForNetworkAddress(ctx context.Context, id string, c inspec
 				return true, nil
 			}
 			if appleContainerTerminalStatus(next.status()) {
-				return false, exit(5, "apple-container %s stopped before a network address was assigned", id)
+				return false, core.Exit(5, "apple-container %s stopped before a network address was assigned", id)
 			}
 			return false, nil
 		}, nil)
@@ -634,7 +634,7 @@ func appleContainerTerminalStatus(status string) bool {
 func (b *backend) resolveContainer(ctx context.Context, identifier string) (inspectContainer, string, string, error) {
 	identifier = strings.TrimSpace(identifier)
 	if identifier == "" {
-		return inspectContainer{}, "", "", exit(2, "provider=%s requires --id <lease-id-or-slug-or-container>", providerName)
+		return inspectContainer{}, "", "", core.Exit(2, "provider=%s requires --id <lease-id-or-slug-or-container>", providerName)
 	}
 	var resolvedClaim core.LeaseClaim
 	var wantLease, wantSlug string
@@ -656,7 +656,7 @@ func (b *backend) resolveContainer(ctx context.Context, identifier string) (insp
 				return c, firstNonBlank(resolvedClaim.LeaseID, labels["lease"]), firstNonBlank(resolvedClaim.Slug, labels["slug"]), nil
 			}
 		}
-		return inspectContainer{}, "", "", exit(4, "apple-container lease not found: %s", identifier)
+		return inspectContainer{}, "", "", core.Exit(4, "apple-container lease not found: %s", identifier)
 	}
 	normalized := core.NormalizeLeaseSlug(identifier)
 	var matched *inspectContainer
@@ -667,7 +667,7 @@ func (b *backend) resolveContainer(ctx context.Context, identifier string) (insp
 		slug := labels["slug"]
 		if wantLease != "" && leaseID == wantLease {
 			if matched != nil {
-				return inspectContainer{}, "", "", exit(2, "apple-container lease %s matches multiple containers; use an exact claimed container id", wantLease)
+				return inspectContainer{}, "", "", core.Exit(2, "apple-container lease %s matches multiple containers; use an exact claimed container id", wantLease)
 			}
 			candidate := c
 			matched, matchedLease, matchedSlug = &candidate, leaseID, slug
@@ -675,7 +675,7 @@ func (b *backend) resolveContainer(ctx context.Context, identifier string) (insp
 		}
 		if wantSlug != "" && core.NormalizeLeaseSlug(slug) == core.NormalizeLeaseSlug(wantSlug) {
 			if matched != nil {
-				return inspectContainer{}, "", "", exit(2, "apple-container slug %s matches multiple containers; use a lease id", wantSlug)
+				return inspectContainer{}, "", "", core.Exit(2, "apple-container slug %s matches multiple containers; use a lease id", wantSlug)
 			}
 			candidate := c
 			matched, matchedLease, matchedSlug = &candidate, leaseID, slug
@@ -691,7 +691,7 @@ func (b *backend) resolveContainer(ctx context.Context, identifier string) (insp
 	if matched != nil {
 		return *matched, matchedLease, matchedSlug, nil
 	}
-	return inspectContainer{}, "", "", exit(4, "apple-container lease not found: %s", identifier)
+	return inspectContainer{}, "", "", core.Exit(4, "apple-container lease not found: %s", identifier)
 }
 
 func (b *backend) removeContainer(ctx context.Context, id string) error {
@@ -715,7 +715,7 @@ func (b *backend) prepareLease(ctx context.Context, cfg core.Config, c inspectCo
 	}
 	host := c.ip()
 	if host == "" {
-		return core.LeaseTarget{}, exit(5, "apple-container %s has no network address yet", c.id())
+		return core.LeaseTarget{}, core.Exit(5, "apple-container %s has no network address yet", c.id())
 	}
 	keyPath, err := core.TestboxKeyPath(leaseID)
 	if err == nil {
@@ -771,9 +771,9 @@ func (b *backend) exitedDuringBootstrapError(ctx context.Context, id, status str
 		hint = "; DNS failed during package bootstrap, retry with --apple-container-extra-run-args '--dns <resolver>' or configure appleContainer.extraRunArgs"
 	}
 	if strings.TrimSpace(logs) == "" {
-		return exit(5, "apple-container %s stopped during SSH bootstrap status=%s%s", id, core.Blank(status, "unknown"), hint)
+		return core.Exit(5, "apple-container %s stopped during SSH bootstrap status=%s%s", id, core.Blank(status, "unknown"), hint)
 	}
-	return exit(5, "apple-container %s stopped during SSH bootstrap status=%s%s\ncontainer logs:\n%s", id, core.Blank(status, "unknown"), hint, logs)
+	return core.Exit(5, "apple-container %s stopped during SSH bootstrap status=%s%s\ncontainer logs:\n%s", id, core.Blank(status, "unknown"), hint, logs)
 }
 
 func (b *backend) containerLogTail(ctx context.Context, id string, limit int) string {
@@ -853,7 +853,7 @@ func (b *backend) serverFromContainer(c inspectContainer, cfg core.Config) core.
 func (b *backend) checkRunSurface(ctx context.Context) error {
 	result, err := b.container(ctx, []string{"run", "--help"}, nil, nil)
 	if err != nil {
-		return exit(2, "%s `container run` subcommand unavailable (incompatible container CLI?): %s", providerName, commandDetail(result, err))
+		return core.Exit(2, "%s `container run` subcommand unavailable (incompatible container CLI?): %s", providerName, commandDetail(result, err))
 	}
 	help := result.Stdout + result.Stderr
 	required := []string{"--user", "--label", "--dns"}
@@ -862,7 +862,7 @@ func (b *backend) checkRunSurface(ctx context.Context) error {
 	}
 	for _, opt := range required {
 		if !strings.Contains(help, opt) {
-			return exit(2, "%s `container run` is missing the required %s option; upgrade Apple's container CLI", providerName, opt)
+			return core.Exit(2, "%s `container run` is missing the required %s option; upgrade Apple's container CLI", providerName, opt)
 		}
 	}
 	return nil
@@ -870,7 +870,7 @@ func (b *backend) checkRunSurface(ctx context.Context) error {
 
 func requireMacOS() error {
 	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
-		return exit(2, "provider=%s requires macOS on Apple silicon; current host is %s/%s", providerName, runtime.GOOS, runtime.GOARCH)
+		return core.Exit(2, "provider=%s requires macOS on Apple silicon; current host is %s/%s", providerName, runtime.GOOS, runtime.GOARCH)
 	}
 	return nil
 }

--- a/internal/providers/applecontainer/core.go
+++ b/internal/providers/applecontainer/core.go
@@ -4,18 +4,6 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-// Type aliases keep the provider body terse while leaning on the shared core
-// package, mirroring the asciibox/localcontainer providers.
-type Config = core.Config
-type AppleContainerConfig = core.AppleContainerConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type CommandRunner = core.CommandRunner
-type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
-type Backend = core.Backend
-type Server = core.Server
-type SSHTarget = core.SSHTarget
 
 const (
 	providerName = "apple-container"
@@ -27,7 +15,3 @@ const (
 	sshPort            = "22"
 	workRootMarkerName = ".crabbox-apple-container-work-root"
 )
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}

--- a/internal/providers/applecontainer/core.go
+++ b/internal/providers/applecontainer/core.go
@@ -4,7 +4,6 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-
 const (
 	providerName = "apple-container"
 	targetLinux  = core.TargetLinux

--- a/internal/providers/applecontainer/image.go
+++ b/internal/providers/applecontainer/image.go
@@ -43,7 +43,7 @@ func (b *backend) imageControl(ctx context.Context, cfg core.Config, args []stri
 		return core.LocalCommandResult{}, ctx.Err()
 	}
 	if err != nil || result.ExitCode != 0 || len(result.Stdout) >= limit || len(result.Stderr) >= limit {
-		return core.LocalCommandResult{}, exit(5, "Apple Container %s image verification command failed (native response withheld)", args[0])
+		return core.LocalCommandResult{}, core.Exit(5, "Apple Container %s image verification command failed (native response withheld)", args[0])
 	}
 	return result, nil
 }
@@ -55,20 +55,20 @@ func (b *backend) inspectImageContainer(ctx context.Context, cfg core.Config, na
 	}
 	var entries []json.RawMessage
 	if json.Unmarshal([]byte(result.Stdout), &entries) != nil || len(entries) != 1 {
-		return imageContainerObservation{}, exit(5, "Apple Container inspect must return exactly one created container")
+		return imageContainerObservation{}, core.Exit(5, "Apple Container inspect must return exactly one created container")
 	}
 	var c inspectContainer
 	var raw struct {
 		Configuration json.RawMessage `json:"configuration"`
 	}
 	if json.Unmarshal(entries[0], &c) != nil || json.Unmarshal(entries[0], &raw) != nil || c.id() != name {
-		return imageContainerObservation{}, exit(5, "Apple Container inspect did not return the exact created target")
+		return imageContainerObservation{}, core.Exit(5, "Apple Container inspect did not return the exact created target")
 	}
 	var configuration any
 	decoder := json.NewDecoder(bytes.NewReader(raw.Configuration))
 	decoder.UseNumber()
 	if decoder.Decode(&configuration) != nil || configuration == nil {
-		return imageContainerObservation{}, exit(5, "Apple Container inspect omitted its created configuration")
+		return imageContainerObservation{}, core.Exit(5, "Apple Container inspect omitted its created configuration")
 	}
 	return imageContainerObservation{c, configuration}, nil
 }
@@ -118,17 +118,17 @@ func (b *backend) createPinnedContainer(ctx context.Context, cfg core.Config, ar
 		return retained(err)
 	}
 	if strings.TrimSpace(result.Stdout) != name {
-		return retained(exit(5, "Apple Container create did not confirm the requested target"))
+		return retained(core.Exit(5, "Apple Container create did not confirm the requested target"))
 	}
 	observed, err := b.inspectImageContainer(ctx, cfg, name)
 	if err != nil {
 		return retained(err)
 	}
 	if !ownedStoppedImageContainer(observed.container, cfg.AppleContainer.Image, leaseID, slug) {
-		return retained(exit(5, "Apple Container created target has incomplete or unexpected ownership/image metadata"))
+		return retained(core.Exit(5, "Apple Container created target has incomplete or unexpected ownership/image metadata"))
 	}
 	if observed.container.Configuration.Image.Descriptor.Digest != digest {
-		cause := exit(5, "Apple Container created image digest differs from the reviewed default; bootstrap refused")
+		cause := core.Exit(5, "Apple Container created image digest differs from the reviewed default; bootstrap refused")
 		if err := b.rollbackImageContainer(cfg, observed, leaseID, slug); err != nil {
 			return retained(errors.Join(cause, err))
 		}
@@ -136,14 +136,14 @@ func (b *backend) createPinnedContainer(ctx context.Context, cfg core.Config, ar
 	}
 	err = core.WithDurableLeaseClaimLock(leaseID, func(_ *core.LeaseClaim, exists bool, _ func() error) error {
 		if exists {
-			return exit(2, "Apple Container claim appeared before verified image start")
+			return core.Exit(2, "Apple Container claim appeared before verified image start")
 		}
 		fresh, err := b.inspectImageContainer(ctx, cfg, name)
 		if err != nil {
 			return err
 		}
 		if !ownedStoppedImageContainer(fresh.container, cfg.AppleContainer.Image, leaseID, slug) || !reflect.DeepEqual(fresh.configuration, observed.configuration) {
-			return exit(2, "Apple Container configuration changed before verified image start")
+			return core.Exit(2, "Apple Container configuration changed before verified image start")
 		}
 		_, err = b.imageControl(ctx, cfg, []string{"start", name}, 2*time.Minute)
 		return err
@@ -164,7 +164,7 @@ func (b *backend) rollbackImageContainer(cfg core.Config, observed imageContaine
 			return err
 		}
 		if !ownedStoppedImageContainer(fresh.container, cfg.AppleContainer.Image, leaseID, slug) || !reflect.DeepEqual(fresh.configuration, observed.configuration) {
-			return exit(2, "Apple Container created target changed; refusing image rollback")
+			return core.Exit(2, "Apple Container created target changed; refusing image rollback")
 		}
 		if _, err := b.imageControl(ctx, cfg, []string{"delete", "--force", name}, 30*time.Second); err != nil {
 			return err
@@ -175,11 +175,11 @@ func (b *backend) rollbackImageContainer(cfg core.Config, observed imageContaine
 		}
 		var containers []inspectContainer
 		if strings.TrimSpace(result.Stdout) == "null" || json.Unmarshal([]byte(result.Stdout), &containers) != nil {
-			return exit(5, "Apple Container image rollback inventory is invalid")
+			return core.Exit(5, "Apple Container image rollback inventory is invalid")
 		}
 		for _, c := range containers {
 			if c.id() == "" || c.id() == name {
-				return exit(5, "Apple Container image rollback absence is unconfirmed")
+				return core.Exit(5, "Apple Container image rollback absence is unconfirmed")
 			}
 		}
 		return nil

--- a/internal/providers/applemachine/backend.go
+++ b/internal/providers/applemachine/backend.go
@@ -16,36 +16,36 @@ import (
 )
 
 type backend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
 var hostGOOS, hostGOARCH = runtime.GOOS, runtime.GOARCH
 
-func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	return &backend{spec: spec, cfg: cfg, rt: rt}
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	if err := requireHost(); err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{Name: core.Blank(b.cfg.AppleContainer.CLIPath, "container"), Args: []string{"--version"}})
+	result, err := b.rt.Exec.Run(ctx, core.LocalCommandRequest{Name: core.Blank(b.cfg.AppleContainer.CLIPath, "container"), Args: []string{"--version"}})
 	if err != nil {
-		return DoctorResult{}, exit(3, "Apple container CLI unavailable: %s", failureDetail(result, err))
+		return core.DoctorResult{}, core.Exit(3, "Apple container CLI unavailable: %s", failureDetail(result, err))
 	}
 	machines, err := b.listMachines(ctx)
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return DoctorResult{Provider: providerName, Message: fmt.Sprintf("cli=ready control_plane=local inventory=ready leases=%d version=%s", len(machines), strings.TrimSpace(result.Stdout))}, nil
+	return core.DoctorResult{Provider: providerName, Message: fmt.Sprintf("cli=ready control_plane=local inventory=ready leases=%d version=%s", len(machines), strings.TrimSpace(result.Stdout))}, nil
 }
 
-func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *backend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	started := time.Now()
 	claim, err := b.createLease(ctx, req.Repo, req.Reclaim, req.RequestedSlug)
 	if err != nil {
@@ -62,15 +62,15 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	})
 }
 
-func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {
+func (b *backend) Run(ctx context.Context, req core.RunRequest) (result core.RunResult, retErr error) {
 	if err := requireHost(); err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	if req.SyncOnly || req.ApplyLocalPatch || req.FreshPR.Number > 0 {
-		return RunResult{}, exit(2, "provider=%s uses the host home mount; sync-only, patch upload, and fresh-PR preparation are not supported", providerName)
+		return core.RunResult{}, core.Exit(2, "provider=%s uses the host home mount; sync-only, patch upload, and fresh-PR preparation are not supported", providerName)
 	}
 	if err := validateRepoMount(req.Repo.Root); err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	started := time.Now()
 	var claim core.LeaseClaim
@@ -83,12 +83,12 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		claim, err = b.resolveLease(ctx, req.ID, req.Repo.Root, req.Reclaim)
 	}
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	leaseID, slug, name := claim.LeaseID, claim.Slug, claim.CloudID
-	result = RunResult{
+	result = core.RunResult{
 		Provider: providerName, LeaseID: leaseID, Slug: slug, SyncDelegated: true,
-		Session: &RunSessionHandle{
+		Session: &core.RunSessionHandle{
 			Provider: providerName, LeaseID: leaseID, Slug: slug, Reused: !acquired, Kept: true,
 			CleanupCommand: appleMachineCleanupCommand(leaseID),
 		},
@@ -110,7 +110,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		result.Total = time.Since(started)
 		result = core.FinalizeRunResult(result, retErr)
 		if req.TimingJSON {
-			timingErr := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
+			timingErr := core.WriteTimingJSON(b.rt.Stderr, core.TimingReportWithRunResult(core.TimingReport{
 				Provider: providerName, LeaseID: leaseID, Slug: slug, SyncDelegated: true, SyncSkipped: true,
 				CommandMs: result.Command.Milliseconds(), TotalMs: result.Total.Milliseconds(),
 				ExitCode: result.ExitCode, Label: strings.TrimSpace(req.Label),
@@ -132,10 +132,10 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	}
 	command := req.Command
 	if req.ShellMode {
-		command = []string{"/bin/sh", "-lc", shellScriptFromArgv(req.Command)}
+		command = []string{"/bin/sh", "-lc", core.ShellScriptFromArgv(req.Command)}
 	}
 	if len(command) == 0 {
-		return result, exit(2, "provider=%s requires a command", providerName)
+		return result, core.Exit(2, "provider=%s requires a command", providerName)
 	}
 	args = append(args, command...)
 	commandStarted := time.Now()
@@ -155,13 +155,13 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		return result, shared.ExitErrorWithCause(result.ExitCode, fmt.Sprintf("apple-machine command failed: %s", failureDetail(native, runErr)), runErr)
 	}
 	if result.ExitCode != 0 {
-		return result, exit(result.ExitCode, "apple-machine command exited %d", result.ExitCode)
+		return result, core.Exit(result.ExitCode, "apple-machine command exited %d", result.ExitCode)
 	}
 	return result, nil
 }
 
 func appleMachineCleanupCommand(leaseID string) string {
-	return "crabbox stop --provider " + providerName + " --id " + shellQuote(leaseID)
+	return "crabbox stop --provider " + providerName + " --id " + core.ShellQuote(leaseID)
 }
 
 func writeEnvFile(env map[string]string, explicitlyAllowed []string) (string, func(), error) {
@@ -173,7 +173,7 @@ func writeEnvFile(env map[string]string, explicitlyAllowed []string) (string, fu
 	for key := range env {
 		if machineOwnedEnv(key) {
 			if explicit[strings.ToUpper(strings.TrimSpace(key))] {
-				return "", nil, exit(2, "provider=%s cannot forward host-owned environment variable %s; set it inside the machine command instead", providerName, key)
+				return "", nil, core.Exit(2, "provider=%s cannot forward host-owned environment variable %s; set it inside the machine command instead", providerName, key)
 			}
 			continue
 		}
@@ -185,29 +185,29 @@ func writeEnvFile(env map[string]string, explicitlyAllowed []string) (string, fu
 	sort.Strings(keys)
 	file, err := os.CreateTemp("", "crabbox-apple-machine-env-*.env")
 	if err != nil {
-		return "", nil, exit(2, "create apple-machine env file: %v", err)
+		return "", nil, core.Exit(2, "create apple-machine env file: %v", err)
 	}
 	cleanup := func() { _ = os.Remove(file.Name()) }
 	if err := file.Chmod(0o600); err != nil {
 		file.Close()
 		cleanup()
-		return "", nil, exit(2, "secure apple-machine env file: %v", err)
+		return "", nil, core.Exit(2, "secure apple-machine env file: %v", err)
 	}
 	for _, key := range keys {
 		if strings.ContainsAny(key, "=\r\n") || strings.ContainsAny(env[key], "\r\n") {
 			file.Close()
 			cleanup()
-			return "", nil, exit(2, "apple-machine environment values cannot contain newlines")
+			return "", nil, core.Exit(2, "apple-machine environment values cannot contain newlines")
 		}
 		if _, err := fmt.Fprintf(file, "%s=%s\n", key, env[key]); err != nil {
 			file.Close()
 			cleanup()
-			return "", nil, exit(2, "write apple-machine env file: %v", err)
+			return "", nil, core.Exit(2, "write apple-machine env file: %v", err)
 		}
 	}
 	if err := file.Close(); err != nil {
 		cleanup()
-		return "", nil, exit(2, "close apple-machine env file: %v", err)
+		return "", nil, core.Exit(2, "close apple-machine env file: %v", err)
 	}
 	return file.Name(), cleanup, nil
 }
@@ -221,12 +221,12 @@ func machineOwnedEnv(key string) bool {
 	}
 }
 
-func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
 	machines, err := b.listMachines(ctx)
 	if err != nil {
 		return nil, err
 	}
-	claims, err := coreClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +236,7 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 			byName[machineName(claim.LeaseID)] = claim
 		}
 	}
-	views := make([]LeaseView, 0)
+	views := make([]core.LeaseView, 0)
 	for _, item := range machines {
 		claim, ok := byName[item.ID]
 		if !ok {
@@ -253,10 +253,10 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 	return views, nil
 }
 
-func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	claim, err := b.resolveLease(ctx, req.ID, "", false)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	var item machine
 	err = core.WithLeaseClaimUnchangedContext(ctx, claim.LeaseID, claim, func() error {
@@ -265,13 +265,13 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 		return err
 	})
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	server := machineServer(item, claim.LeaseID, claim.Slug, b.cfg)
-	return StatusView{ID: claim.LeaseID, Slug: claim.Slug, Provider: providerName, TargetOS: targetLinux, State: server.Status, ServerID: claim.CloudID, ServerType: server.ServerType.Name, Ready: machineReady(item.Status), Labels: server.Labels}, nil
+	return core.StatusView{ID: claim.LeaseID, Slug: claim.Slug, Provider: providerName, TargetOS: targetLinux, State: server.Status, ServerID: claim.CloudID, ServerType: server.ServerType.Name, Ready: machineReady(item.Status), Labels: server.Labels}, nil
 }
 
-func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+func (b *backend) Stop(ctx context.Context, req core.StopRequest) error {
 	claim, err := b.resolveLease(ctx, req.ID, "", false)
 	if err != nil {
 		return err
@@ -283,7 +283,7 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 	return nil
 }
 
-func (b *backend) createLease(ctx context.Context, repo Repo, reclaim bool, requestedSlug string) (core.LeaseClaim, error) {
+func (b *backend) createLease(ctx context.Context, repo core.Repo, reclaim bool, requestedSlug string) (core.LeaseClaim, error) {
 	if err := requireHost(); err != nil {
 		return core.LeaseClaim{}, err
 	}
@@ -291,10 +291,10 @@ func (b *backend) createLease(ctx context.Context, repo Repo, reclaim bool, requ
 		return core.LeaseClaim{}, err
 	}
 	if strings.TrimSpace(repo.Root) == "" {
-		return core.LeaseClaim{}, exit(2, "apple-machine acquisition requires a repository root for durable ownership")
+		return core.LeaseClaim{}, core.Exit(2, "apple-machine acquisition requires a repository root for durable ownership")
 	}
 	leaseID := core.NewLeaseID()
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return core.LeaseClaim{}, err
 	}
@@ -304,10 +304,10 @@ func (b *backend) createLease(ctx context.Context, repo Repo, reclaim bool, requ
 	}
 	name := machineName(leaseID)
 	if err := b.createMachine(ctx, name); err != nil {
-		return core.LeaseClaim{}, fmt.Errorf("%w; creation may be incomplete: inspect container machine inspect %s before manual cleanup", err, shellQuote(name))
+		return core.LeaseClaim{}, fmt.Errorf("%w; creation may be incomplete: inspect container machine inspect %s before manual cleanup", err, core.ShellQuote(name))
 	}
 	retained := func(err error) (core.LeaseClaim, error) {
-		return core.LeaseClaim{}, fmt.Errorf("%w; retained machine=%s lease=%s: inspect container machine inspect %s before manual cleanup", err, name, leaseID, shellQuote(name))
+		return core.LeaseClaim{}, fmt.Errorf("%w; retained machine=%s lease=%s: inspect container machine inspect %s before manual cleanup", err, name, leaseID, core.ShellQuote(name))
 	}
 	retainedAfterRollback := func(primary, cleanup error) (core.LeaseClaim, error) {
 		code := core.ExitCodeForError(primary, 1)
@@ -397,7 +397,7 @@ func (b *backend) resolveLease(ctx context.Context, identifier, repoRoot string,
 		return core.LeaseClaim{}, shared.ErrStrictClaimMismatch
 	}
 	if !ok {
-		return core.LeaseClaim{}, exit(4, "apple-machine lease %q was not found", identifier)
+		return core.LeaseClaim{}, core.Exit(4, "apple-machine lease %q was not found", identifier)
 	}
 	if _, err := machineClaimBinding(claim); err != nil {
 		return core.LeaseClaim{}, err
@@ -418,9 +418,9 @@ func machineName(leaseID string) string {
 	return "crabbox-" + strings.TrimPrefix(leaseID, "cbx_")
 }
 
-func machineServer(item machine, leaseID, slug string, cfg Config) Server {
+func machineServer(item machine, leaseID, slug string, cfg core.Config) core.Server {
 	labels := map[string]string{"crabbox": "true", "provider": providerName, "lease": leaseID, "slug": slug, "target": targetLinux}
-	server := Server{Provider: providerName, CloudID: item.ID, Name: item.ID, Status: item.Status, Labels: labels}
+	server := core.Server{Provider: providerName, CloudID: item.ID, Name: item.ID, Status: item.Status, Labels: labels}
 	server.ServerType.Name = core.Blank(cfg.AppleContainer.Image, "ubuntu:26.04")
 	return server
 }
@@ -436,7 +436,7 @@ func machineReady(status string) bool {
 
 func requireHost() error {
 	if hostGOOS != "darwin" || hostGOARCH != "arm64" {
-		return exit(2, "provider=%s requires Apple silicon macOS", providerName)
+		return core.Exit(2, "provider=%s requires Apple silicon macOS", providerName)
 	}
 	return nil
 }
@@ -447,13 +447,11 @@ func validateRepoMount(root string) error {
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return exit(2, "resolve home directory: %v", err)
+		return core.Exit(2, "resolve home directory: %v", err)
 	}
 	rel, err := filepath.Rel(home, root)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return exit(2, "provider=%s requires the repository under %s because container machine shares the host home directory", providerName, home)
+		return core.Exit(2, "provider=%s requires the repository under %s because container machine shares the host home directory", providerName, home)
 	}
 	return nil
 }
-
-func coreClaims() ([]core.LeaseClaim, error) { return core.ListLeaseClaims() }

--- a/internal/providers/applemachine/backend_test.go
+++ b/internal/providers/applemachine/backend_test.go
@@ -185,8 +185,8 @@ func TestRunUsesHomeMountedRepoAndEnv(t *testing.T) {
 	fixture.claim(t, leaseID, slug, repo)
 	var stderr bytes.Buffer
 	b := newBackend(Provider{}.Spec(), testBackend(runner).cfg, core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: &stderr}).(*backend)
-	result, err := b.Run(t.Context(), RunRequest{
-		Repo:       Repo{Root: repo},
+	result, err := b.Run(t.Context(), core.RunRequest{
+		Repo:       core.Repo{Root: repo},
 		ID:         leaseID,
 		Keep:       true,
 		TimingJSON: true,
@@ -202,7 +202,7 @@ func TestRunUsesHomeMountedRepoAndEnv(t *testing.T) {
 	if result.Session == nil || result.Session.Provider != providerName || result.Session.LeaseID != leaseID || result.Session.Slug != slug || !result.Session.Reused || !result.Session.Kept {
 		t.Fatalf("session=%#v", result.Session)
 	}
-	if result.Session.CleanupCommand != "crabbox stop --provider apple-machine --id "+shellQuote(leaseID) {
+	if result.Session.CleanupCommand != "crabbox stop --provider apple-machine --id "+core.ShellQuote(leaseID) {
 		t.Fatalf("cleanup command=%q", result.Session.CleanupCommand)
 	}
 	req := runner.requests[len(runner.requests)-1]
@@ -243,8 +243,8 @@ func TestRunTimingJSONClassifiesCommandFailure(t *testing.T) {
 	fixture := newMachineFixture(t, runner)
 	fixture.claim(t, leaseID, slug, repo)
 	b := newBackend(Provider{}.Spec(), testBackend(runner).cfg, core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: &stderr}).(*backend)
-	result, err := b.Run(t.Context(), RunRequest{
-		Repo:       Repo{Root: repo},
+	result, err := b.Run(t.Context(), core.RunRequest{
+		Repo:       core.Repo{Root: repo},
 		ID:         leaseID,
 		Keep:       true,
 		TimingJSON: true,
@@ -275,8 +275,8 @@ func TestRunDeletesOneShotMachineSession(t *testing.T) {
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	newMachineFixture(t, runner)
 	b := newBackend(Provider{}.Spec(), testBackend(runner).cfg, core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}).(*backend)
-	result, err := b.Run(t.Context(), RunRequest{
-		Repo:    Repo{Root: repo},
+	result, err := b.Run(t.Context(), core.RunRequest{
+		Repo:    core.Repo{Root: repo},
 		Command: []string{"true"},
 	})
 	if err != nil {
@@ -409,7 +409,7 @@ func TestRunTerminalOutcomeAndRetention(t *testing.T) {
 				}
 				return core.LocalCommandResult{}, nil, false
 			}
-			req := RunRequest{Repo: Repo{Root: repo}, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}, TimingJSON: true, Keep: tc.keep, KeepOnFailure: tc.keepFailure, Label: "terminal-fixture"}
+			req := core.RunRequest{Repo: core.Repo{Root: repo}, Command: []string{"true"}, Env: map[string]string{"FIXTURE": "synthetic"}, TimingJSON: true, Keep: tc.keep, KeepOnFailure: tc.keepFailure, Label: "terminal-fixture"}
 			if tc.badEnv {
 				req.Env = map[string]string{"FIXTURE": "invalid\nvalue"}
 			}
@@ -532,7 +532,7 @@ func TestWriteEnvFileRejectsExplicitHostOwnedVariable(t *testing.T) {
 	}
 }
 
-func decodeLastTimingReport(t *testing.T, output string) timingReport {
+func decodeLastTimingReport(t *testing.T, output string) core.TimingReport {
 	t.Helper()
 	lines := strings.Split(strings.TrimSpace(output), "\n")
 	for i := len(lines) - 1; i >= 0; i-- {
@@ -541,12 +541,12 @@ func decodeLastTimingReport(t *testing.T, output string) timingReport {
 		if start < 0 {
 			continue
 		}
-		var report timingReport
+		var report core.TimingReport
 		if err := json.Unmarshal([]byte(line[start:]), &report); err != nil {
 			t.Fatalf("timing json: %v\noutput=%s", err, output)
 		}
 		return report
 	}
 	t.Fatalf("output does not contain timing JSON: %s", output)
-	return timingReport{}
+	return core.TimingReport{}
 }

--- a/internal/providers/applemachine/client.go
+++ b/internal/providers/applemachine/client.go
@@ -19,8 +19,8 @@ type machine struct {
 	Memory    uint64 `json:"memory,omitempty"`
 }
 
-func (b *backend) command(ctx context.Context, args []string, dir string) (LocalCommandResult, error) {
-	return b.rt.Exec.Run(ctx, LocalCommandRequest{
+func (b *backend) command(ctx context.Context, args []string, dir string) (core.LocalCommandResult, error) {
+	return b.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name:   core.Blank(strings.TrimSpace(b.cfg.AppleContainer.CLIPath), "container"),
 		Args:   args,
 		Dir:    dir,
@@ -52,7 +52,7 @@ func (b *backend) inspectMachine(ctx context.Context, name string) (machine, err
 	}
 	var machines []machine
 	if err := json.Unmarshal([]byte(result.Stdout), &machines); err != nil || len(machines) != 1 || machines[0].ID != name || machines[0].Status == "" {
-		return machine{}, exit(5, "invalid Apple container machine inspection for %q", name)
+		return machine{}, core.Exit(5, "invalid Apple container machine inspection for %q", name)
 	}
 	return machines[0], nil
 }
@@ -64,15 +64,15 @@ func (b *backend) listMachines(ctx context.Context) ([]machine, error) {
 	}
 	var machines []machine
 	if err := json.Unmarshal([]byte(result.Stdout), &machines); err != nil {
-		return nil, exit(5, "decode Apple container machine list: %v", err)
+		return nil, core.Exit(5, "decode Apple container machine list: %v", err)
 	}
 	if machines == nil {
-		return nil, exit(5, "Apple container machine list must be a JSON array")
+		return nil, core.Exit(5, "Apple container machine list must be a JSON array")
 	}
 	seen := map[string]bool{}
 	for _, item := range machines {
 		if !validMachineName(item.ID) || item.Status == "" || seen[item.ID] {
-			return nil, exit(5, "invalid or duplicate Apple container machine inventory entry")
+			return nil, core.Exit(5, "invalid or duplicate Apple container machine inventory entry")
 		}
 		seen[item.ID] = true
 	}
@@ -88,11 +88,11 @@ func (b *backend) removeMachine(ctx context.Context, name string) error {
 }
 
 // Control responses are private, bounded, and never accepted after a partial failure.
-func (b *backend) control(ctx context.Context, args []string) (LocalCommandResult, error) {
+func (b *backend) control(ctx context.Context, args []string) (core.LocalCommandResult, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	const limit = 1024 * 1024
-	result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{
+	result, err := b.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name: core.Blank(strings.TrimSpace(b.cfg.AppleContainer.CLIPath), "container"), Args: args,
 		MaxCapturedOutputBytes: limit, CancelGracePeriod: time.Second,
 	})
@@ -100,7 +100,7 @@ func (b *backend) control(ctx context.Context, args []string) (LocalCommandResul
 		return result, ctx.Err()
 	}
 	if len(result.Stdout) > limit || len(result.Stderr) > limit {
-		return LocalCommandResult{}, fmt.Errorf("Apple container control output exceeded its limit")
+		return core.LocalCommandResult{}, fmt.Errorf("Apple container control output exceeded its limit")
 	}
 	if err == nil && result.ExitCode != 0 {
 		err = fmt.Errorf("Apple container exited with code %d", result.ExitCode)
@@ -108,7 +108,7 @@ func (b *backend) control(ctx context.Context, args []string) (LocalCommandResul
 	return result, err
 }
 
-func failureDetail(result LocalCommandResult, err error) string {
+func failureDetail(result core.LocalCommandResult, err error) string {
 	if detail := strings.TrimSpace(result.Stderr); detail != "" {
 		return detail
 	}

--- a/internal/providers/applemachine/core.go
+++ b/internal/providers/applemachine/core.go
@@ -1,52 +1,10 @@
 package applemachine
 
 import (
-	"io"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type RunSessionHandle = core.RunSessionHandle
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type Server = core.Server
-type Repo = core.Repo
-type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
-type timingReport = core.TimingReport
 
 const (
 	providerName = "apple-machine"
 	targetLinux  = core.TargetLinux
 )
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
-}
-
-func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
-	return core.TimingReportWithRunResult(report, result, err)
-}
-
-func shellScriptFromArgv(command []string) string { return core.ShellScriptFromArgv(command) }
-func shellQuote(s string) string                  { return core.ShellQuote(s) }

--- a/internal/providers/applemachine/identity.go
+++ b/internal/providers/applemachine/identity.go
@@ -151,7 +151,7 @@ func machineClaimBinding(claim core.LeaseClaim) (shared.ClaimBinding, error) {
 		RequiredLabels: map[string]string{"apple_machine_storage": root},
 	}
 	if !core.IsCanonicalLeaseID(claim.LeaseID) || claim.Slug == "" || !filepath.IsAbs(root) || filepath.Clean(root) != root || !validMachineIdentity(claim.CloudImmutableID) {
-		return want, exit(2, "apple-machine lease %q has no exact storage/ownership binding; retain the machine and inspect it with container machine inspect before manual cleanup or creating a new lease", claim.LeaseID)
+		return want, core.Exit(2, "apple-machine lease %q has no exact storage/ownership binding; retain the machine and inspect it with container machine inspect before manual cleanup or creating a new lease", claim.LeaseID)
 	}
 	return want, shared.ValidateClaimBinding(claim, want)
 }

--- a/internal/providers/applemachine/identity_test.go
+++ b/internal/providers/applemachine/identity_test.go
@@ -56,13 +56,13 @@ func TestClaimOperationWaitHonorsCallerContext(t *testing.T) {
 						var err error
 						switch operation {
 						case "stop":
-							err = b.Stop(ctx, StopRequest{ID: claim.LeaseID})
+							err = b.Stop(ctx, core.StopRequest{ID: claim.LeaseID})
 						case "reuse":
 							_, err = b.resolveLease(ctx, claim.LeaseID, claim.RepoRoot, false)
 						case "status":
-							_, err = b.Status(ctx, StatusRequest{ID: claim.LeaseID})
+							_, err = b.Status(ctx, core.StatusRequest{ID: claim.LeaseID})
 						case "list":
-							_, err = b.List(ctx, ListRequest{})
+							_, err = b.List(ctx, core.ListRequest{})
 						}
 						done <- err
 					}()
@@ -190,7 +190,7 @@ func TestAcquisitionPublicationRollbackIncludesClaimFence(t *testing.T) {
 					t.Fatal(err)
 				}
 				done := make(chan error, 1)
-				go func() { _, err := b.createLease(ctx, Repo{Root: home}, false, ""); done <- err }()
+				go func() { _, err := b.createLease(ctx, core.Repo{Root: home}, false, ""); done <- err }()
 				<-entered
 				synctest.Wait()
 				if _, err := readMachineIdentity(f.root, name); err != nil {
@@ -257,10 +257,10 @@ func TestAcquisitionPublicationRollbackIncludesClaimFence(t *testing.T) {
 func TestClaimContextLookupsRemainReadOnly(t *testing.T) {
 	b, f, claim := identityFixture(t)
 	b.rt.Exec = claimContextRunner{inner: f.runner}
-	if _, err := b.List(t.Context(), ListRequest{}); err != nil {
+	if _, err := b.List(t.Context(), core.ListRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := b.Status(t.Context(), StatusRequest{ID: claim.LeaseID}); err != nil {
+	if _, err := b.Status(t.Context(), core.StatusRequest{ID: claim.LeaseID}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := b.resolveLease(t.Context(), claim.LeaseID, "", false); err != nil {
@@ -520,7 +520,7 @@ func TestStopRejectsUnboundAndReplacedMachines(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			if err := b.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err == nil {
+			if err := b.Stop(t.Context(), core.StopRequest{ID: claim.LeaseID}); err == nil {
 				t.Fatal("unsafe stop succeeded")
 			}
 			requireNoMachineMutation(t, f)
@@ -532,7 +532,7 @@ func TestStopRejectsUnboundAndReplacedMachines(t *testing.T) {
 func TestStopBoundStoppedMachineAndConfirmAbsence(t *testing.T) {
 	b, f, claim := identityFixture(t)
 	t.Setenv("CONTAINER_APP_ROOT", t.TempDir())
-	if err := b.Stop(t.Context(), StopRequest{ID: claim.Slug}); err != nil {
+	if err := b.Stop(t.Context(), core.StopRequest{ID: claim.Slug}); err != nil {
 		t.Fatal(err)
 	}
 	if _, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID); err != nil || exists {
@@ -579,7 +579,7 @@ func TestDeleteRetainsClaimWhenRemovalOrInventoryIsUncertain(t *testing.T) {
 				}
 				return core.LocalCommandResult{}, nil, false
 			}
-			if err := b.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err == nil {
+			if err := b.Stop(t.Context(), core.StopRequest{ID: claim.LeaseID}); err == nil {
 				t.Fatal("uncertain deletion succeeded")
 			}
 			requireClaimUnchanged(t, claim)
@@ -600,7 +600,7 @@ func TestStopRetriesConfirmedAbsenceWithoutAnotherDelete(t *testing.T) {
 		}
 		return core.LocalCommandResult{}, nil, false
 	}
-	if err := b.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err == nil {
+	if err := b.Stop(t.Context(), core.StopRequest{ID: claim.LeaseID}); err == nil {
 		t.Fatal("uncertain deletion succeeded")
 	}
 	requireClaimUnchanged(t, claim)
@@ -609,7 +609,7 @@ func TestStopRetriesConfirmedAbsenceWithoutAnotherDelete(t *testing.T) {
 	}
 	f.before = nil
 	f.runner.requests = nil
-	if err := b.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err != nil {
+	if err := b.Stop(t.Context(), core.StopRequest{ID: claim.LeaseID}); err != nil {
 		t.Fatal(err)
 	}
 	requireNoMachineMutation(t, f)
@@ -621,7 +621,7 @@ func TestStopRetriesConfirmedAbsenceWithoutAnotherDelete(t *testing.T) {
 func TestAbsentInventoryDoesNotRetireExistingStorage(t *testing.T) {
 	b, f, claim := identityFixture(t)
 	delete(f.machines, claim.CloudID)
-	if err := b.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err == nil {
+	if err := b.Stop(t.Context(), core.StopRequest{ID: claim.LeaseID}); err == nil {
 		t.Fatal("retired claim while bundle still exists")
 	}
 	requireNoMachineMutation(t, f)
@@ -761,7 +761,7 @@ func TestAcquisitionRollbackRequiresOriginalBindingAndClaim(t *testing.T) {
 				}
 				return core.LocalCommandResult{}, nil, false
 			}
-			if _, err := b.createLease(ctx, Repo{Root: filepath.Join(home, "src", "fixture")}, false, ""); err == nil {
+			if _, err := b.createLease(ctx, core.Repo{Root: filepath.Join(home, "src", "fixture")}, false, ""); err == nil {
 				t.Fatal("failed acquisition succeeded")
 			}
 			removed := false
@@ -798,7 +798,7 @@ func TestAcquisitionRejectsEmptyRepositoryBeforeMutation(t *testing.T) {
 	originalGOOS, originalGOARCH := hostGOOS, hostGOARCH
 	hostGOOS, hostGOARCH = "darwin", "arm64"
 	defer func() { hostGOOS, hostGOARCH = originalGOOS, originalGOARCH }()
-	if _, err := b.createLease(t.Context(), Repo{}, false, ""); err == nil {
+	if _, err := b.createLease(t.Context(), core.Repo{}, false, ""); err == nil {
 		t.Fatal("empty repo accepted")
 	}
 	requireNoMachineMutation(t, f)

--- a/internal/providers/dockersandbox/backend.go
+++ b/internal/providers/dockersandbox/backend.go
@@ -24,21 +24,21 @@ var statusPollInterval = 2 * time.Second
 const dockerSandboxCleanupTimeout = 30 * time.Second
 
 type backend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
-func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	return &backend{spec: spec, cfg: cfg, rt: rt}
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *backend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if req.ActionsRunner {
-		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+		return core.Exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
 	started := core.ClockNow(b.rt.Clock)
 	cli, err := newSBXCLI(b.cfg, b.rt)
@@ -62,34 +62,34 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	})
 }
 
-func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {
+func (b *backend) Run(ctx context.Context, req core.RunRequest) (result core.RunResult, retErr error) {
 	if err := rejectRunOptions(b.spec, req); err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	workdir, err := dockerSandboxWorkdir(b.cfg, req.Repo.Root)
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	started := core.ClockNow(b.rt.Clock)
 	cli, err := newSBXCLI(b.cfg, b.rt)
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	leaseID, sandboxName, slug := "", "", ""
 	acquired := req.ID == ""
 	if acquired {
 		leaseID, sandboxName, slug, err = b.createSandbox(ctx, cli, req.Repo, req.Reclaim, req.RequestedSlug)
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s name=%s\n", leaseID, slug, providerName, sandboxName, sandboxName)
 	} else {
 		leaseID, sandboxName, slug, err = resolveLeaseID(req.ID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout)
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 	}
-	result = RunResult{
+	result = core.RunResult{
 		Provider: providerName, LeaseID: leaseID, Slug: slug, SyncDelegated: true,
 		Session: &core.RunSessionHandle{
 			Provider: providerName, LeaseID: leaseID, Slug: slug, Reused: !acquired, Kept: true,
@@ -102,7 +102,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	defer func() {
 		result, retErr = shared.PinDelegatedRunFailure(result, retErr)
 		if retErr != nil {
-			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+			core.HandleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 		}
 		// Preserve clone commits based on command success, before reporting can fail.
 		if commandRan && retErr == nil && acquired && b.cfg.DockerSandbox.Clone && !req.Keep {
@@ -127,9 +127,9 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 			fmt.Fprintf(b.rt.Stderr, "docker-sandbox run summary sync_delegated=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
 		}
 		if req.TimingJSON {
-			timingErr := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
+			timingErr := core.WriteTimingJSON(b.rt.Stderr, core.TimingReportWithRunResult(core.TimingReport{
 				Provider: providerName, LeaseID: leaseID, Slug: slug, SyncDelegated: true,
-				SyncPhases:  []timingPhase{{Name: "sync", Skipped: true, Reason: "provider-delegated workspace"}},
+				SyncPhases:  []core.TimingPhase{{Name: "sync", Skipped: true, Reason: "provider-delegated workspace"}},
 				SyncSkipped: true, CommandMs: result.Command.Milliseconds(), TotalMs: result.Total.Milliseconds(),
 				ExitCode: result.ExitCode, Label: strings.TrimSpace(req.Label),
 			}, result, retErr))
@@ -149,7 +149,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	}
 	command := intent.Argv("sh", "-lc")
 	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
-		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+		core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
 	envFile := ""
 	if len(req.Env) > 0 {
@@ -174,12 +174,12 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		return result, shared.ExitErrorWithCause(result.ExitCode, fmt.Sprintf("docker-sandbox run failed: %v", shared.RedactErrorSecrets(runErr.Error())), runErr)
 	}
 	if result.ExitCode != 0 {
-		return result, exit(result.ExitCode, "docker-sandbox run exited %d", result.ExitCode)
+		return result, core.Exit(result.ExitCode, "docker-sandbox run exited %d", result.ExitCode)
 	}
 	return result, nil
 }
 
-func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
 	cli, err := newSBXCLI(b.cfg, b.rt)
 	if err != nil {
 		return nil, err
@@ -194,11 +194,11 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 			byName[record.Name] = record
 		}
 	}
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return nil, err
 	}
-	var servers []Server
+	var servers []core.Server
 	for _, claim := range claims {
 		if claim.Provider != providerName {
 			continue
@@ -213,12 +213,12 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 	return servers, nil
 }
 
-func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	cli, err := newSBXCLI(b.cfg, b.rt)
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	result := DoctorResult{Provider: providerName}
+	result := core.DoctorResult{Provider: providerName}
 	version, versionErr := cli.version(ctx)
 	result.Checks = append(result.Checks, doctorCheck("sbx_version", versionErr, map[string]string{"version": version}))
 	if versionErr == nil {
@@ -227,9 +227,9 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	records, listErr := cli.list(ctx)
 	result.Checks = append(result.Checks, doctorCheck("sbx_inventory", listErr, map[string]string{"leases": fmt.Sprint(len(records))}))
 	if _, diagnoseErr := cli.diagnose(ctx); diagnoseErr == nil {
-		result.Checks = append(result.Checks, DoctorCheck{Status: "ok", Check: "sbx_diagnose", Message: "diagnose completed", Details: map[string]string{"mutation": "false"}})
+		result.Checks = append(result.Checks, core.DoctorCheck{Status: "ok", Check: "sbx_diagnose", Message: "diagnose completed", Details: map[string]string{"mutation": "false"}})
 	} else {
-		result.Checks = append(result.Checks, DoctorCheck{Status: "warn", Check: "sbx_diagnose", Message: diagnoseErr.Error(), Details: map[string]string{"mutation": "false", "optional": "true"}})
+		result.Checks = append(result.Checks, core.DoctorCheck{Status: "warn", Check: "sbx_diagnose", Message: diagnoseErr.Error(), Details: map[string]string{"mutation": "false", "optional": "true"}})
 	}
 	if versionErr != nil || listErr != nil {
 		result.Status = "error"
@@ -244,14 +244,14 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	return result, nil
 }
 
-func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	cli, err := newSBXCLI(b.cfg, b.rt)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	leaseID, sandboxName, slug, err := resolveLeaseID(req.ID, "", false, 0)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	deadline := core.ClockNow(b.rt.Clock).Add(req.WaitTimeout)
 	if req.WaitTimeout <= 0 {
@@ -260,11 +260,11 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 	for {
 		records, err := cli.list(ctx)
 		if err != nil {
-			return StatusView{}, err
+			return core.StatusView{}, err
 		}
 		record, ok := findRecord(records, sandboxName)
 		if !ok {
-			return StatusView{}, exit(4, "docker-sandbox sandbox %q is not present in sbx inventory", sandboxName)
+			return core.StatusView{}, core.Exit(4, "docker-sandbox sandbox %q is not present in sbx inventory", sandboxName)
 		}
 		view := statusFromRecord(leaseID, slug, record)
 		if !req.Wait || view.Ready || dockerSandboxTerminalState(view.State) {
@@ -272,7 +272,7 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 		}
 		remaining := deadline.Sub(core.ClockNow(b.rt.Clock))
 		if remaining <= 0 {
-			return StatusView{}, exit(5, "timed out waiting for docker-sandbox sandbox %s to become ready", sandboxName)
+			return core.StatusView{}, core.Exit(5, "timed out waiting for docker-sandbox sandbox %s to become ready", sandboxName)
 		}
 		sleepFor := statusPollInterval
 		if remaining < sleepFor {
@@ -287,13 +287,13 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 				default:
 				}
 			}
-			return StatusView{}, ctx.Err()
+			return core.StatusView{}, ctx.Err()
 		case <-timer.C:
 		}
 	}
 }
 
-func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+func (b *backend) Stop(ctx context.Context, req core.StopRequest) error {
 	cli, err := newSBXCLI(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -319,17 +319,17 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 }
 
 func dockerSandboxClaimForDeletion(leaseID string) (core.LeaseClaim, error) {
-	claim, ok, err := resolveLeaseClaimForProvider(leaseID, providerName)
+	claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
 	if err != nil {
 		return core.LeaseClaim{}, err
 	}
 	if !ok || claim.LeaseID != leaseID {
-		return core.LeaseClaim{}, exit(4, "docker-sandbox sandbox %q is not claimed by Crabbox", leaseID)
+		return core.LeaseClaim{}, core.Exit(4, "docker-sandbox sandbox %q is not claimed by Crabbox", leaseID)
 	}
 	return claim, nil
 }
 
-func (b *backend) Ports(ctx context.Context, req PortsRequest) (string, error) {
+func (b *backend) Ports(ctx context.Context, req core.PortsRequest) (string, error) {
 	cli, err := newSBXCLI(b.cfg, b.rt)
 	if err != nil {
 		return "", err
@@ -341,7 +341,7 @@ func (b *backend) Ports(ctx context.Context, req PortsRequest) (string, error) {
 	return cli.ports(ctx, sandboxName, req.Publish, req.Unpublish, req.JSON)
 }
 
-func (b *backend) Copy(ctx context.Context, req CopyRequest) error {
+func (b *backend) Copy(ctx context.Context, req core.CopyRequest) error {
 	cli, err := newSBXCLI(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -373,20 +373,20 @@ func rewriteSandboxCopyPaths(sandboxName, src, dst string) (string, string, erro
 	srcSandbox, srcPath := parseSandboxPathSpec(src)
 	dstSandbox, dstPath := parseSandboxPathSpec(dst)
 	if srcSandbox == "" && dstSandbox == "" {
-		return "", "", exit(2, "copy requires one side to use SANDBOX:PATH")
+		return "", "", core.Exit(2, "copy requires one side to use SANDBOX:PATH")
 	}
 	if srcSandbox != "" && dstSandbox != "" {
-		return "", "", exit(2, "copy does not support sandbox-to-sandbox transfers")
+		return "", "", core.Exit(2, "copy does not support sandbox-to-sandbox transfers")
 	}
 	if srcSandbox != "" {
 		if !strings.EqualFold(srcSandbox, "SANDBOX") {
-			return "", "", exit(2, "copy source must use SANDBOX:PATH")
+			return "", "", core.Exit(2, "copy source must use SANDBOX:PATH")
 		}
 		src = sandboxName + ":" + srcPath
 	}
 	if dstSandbox != "" {
 		if !strings.EqualFold(dstSandbox, "SANDBOX") {
-			return "", "", exit(2, "copy destination must use SANDBOX:PATH")
+			return "", "", core.Exit(2, "copy destination must use SANDBOX:PATH")
 		}
 		dst = sandboxName + ":" + dstPath
 	}
@@ -408,7 +408,7 @@ func parseSandboxPathSpec(value string) (string, string) {
 	return prefix, value[idx+1:]
 }
 
-func (b *backend) createSandbox(ctx context.Context, cli *sbxCLI, repo Repo, reclaim bool, requestedSlug string) (string, string, string, error) {
+func (b *backend) createSandbox(ctx context.Context, cli *sbxCLI, repo core.Repo, reclaim bool, requestedSlug string) (string, string, string, error) {
 	if err := validateCreateRepo(b.cfg, repo); err != nil {
 		return "", "", "", err
 	}
@@ -417,11 +417,11 @@ func (b *backend) createSandbox(ctx context.Context, cli *sbxCLI, repo Repo, rec
 		return "", "", "", err
 	}
 	leaseID := leasePrefix + sandboxName
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return "", "", "", b.removeCreatedSandboxAfterClaimFailure(cli, sandboxName, err)
 	}
-	if err := claimLeaseForRepoProviderPond(leaseID, slug, providerName, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+	if err := core.ClaimLeaseForRepoProviderPond(leaseID, slug, providerName, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
 		return "", "", "", b.removeCreatedSandboxAfterClaimFailure(cli, sandboxName, err)
 	}
 	return leaseID, sandboxName, slug, nil
@@ -441,14 +441,14 @@ func (b *backend) removeCreatedSandboxAfterClaimFailure(cli *sbxCLI, sandboxName
 func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration) (string, string, string, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return "", "", "", exit(2, "provider=docker-sandbox requires a Crabbox-created sandbox slug or lease id")
+		return "", "", "", core.Exit(2, "provider=docker-sandbox requires a Crabbox-created sandbox slug or lease id")
 	}
 	probes := []string{id}
 	if !strings.HasPrefix(id, leasePrefix) {
 		probes = append(probes, leasePrefix+id)
 	}
 	for _, probe := range probes {
-		claim, ok, err := resolveLeaseClaimForProvider(probe, providerName)
+		claim, ok, err := core.ResolveLeaseClaimForProvider(probe, providerName)
 		if err != nil {
 			return "", "", "", err
 		}
@@ -456,49 +456,49 @@ func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration
 			continue
 		}
 		if repoRoot != "" {
-			if err := claimLeaseForRepoProviderPond(claim.LeaseID, claim.Slug, providerName, claim.Pond, repoRoot, timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
+			if err := core.ClaimLeaseForRepoProviderPond(claim.LeaseID, claim.Slug, providerName, claim.Pond, repoRoot, timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
 				return "", "", "", err
 			}
 		}
 		slug := claim.Slug
 		if strings.TrimSpace(slug) == "" {
-			slug = newLeaseSlug(claim.LeaseID)
+			slug = core.NewLeaseSlug(claim.LeaseID)
 		}
 		return claim.LeaseID, sandboxNameFromLeaseID(claim.LeaseID), slug, nil
 	}
-	return "", "", "", exit(4, "docker-sandbox sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-name>", id, leasePrefix)
+	return "", "", "", core.Exit(4, "docker-sandbox sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-name>", id, leasePrefix)
 }
 
-func rejectRunOptions(spec ProviderSpec, req RunRequest) error {
+func rejectRunOptions(spec core.ProviderSpec, req core.RunRequest) error {
 	if err := core.RejectDelegatedSyncOptionsForSpec(spec, req); err != nil {
 		return err
 	}
 	if req.Options.Desktop || req.Options.Browser || req.Options.Code {
-		return exit(2, "provider=%s does not support desktop, browser, or code-server options in v1", providerName)
+		return core.Exit(2, "provider=%s does not support desktop, browser, or code-server options in v1", providerName)
 	}
 	if req.Options.Tailscale.Enabled {
-		return exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
+		return core.Exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
 	}
 	if !req.ApplyLocalPatch && strings.TrimSpace(req.Repo.Root) == "" {
-		return exit(2, "provider=%s requires a local workspace", providerName)
+		return core.Exit(2, "provider=%s requires a local workspace", providerName)
 	}
 	return nil
 }
 
-func validateCreateRepo(cfg Config, repo Repo) error {
+func validateCreateRepo(cfg core.Config, repo core.Repo) error {
 	if strings.TrimSpace(repo.Root) == "" {
-		return exit(2, "provider=%s requires a local workspace", providerName)
+		return core.Exit(2, "provider=%s requires a local workspace", providerName)
 	}
 	if cfg.DockerSandbox.Clone {
 		cmd := exec.Command("git", "rev-parse", "--git-dir", "--git-common-dir", "--is-inside-work-tree")
 		cmd.Dir = repo.Root
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return exit(2, "docker-sandbox --clone requires a normal Git repository workspace: %v: %s", err, strings.TrimSpace(string(output)))
+			return core.Exit(2, "docker-sandbox --clone requires a normal Git repository workspace: %v: %s", err, strings.TrimSpace(string(output)))
 		}
 		lines := strings.Split(strings.TrimSpace(string(output)), "\n")
 		if len(lines) != 3 || strings.TrimSpace(lines[2]) != "true" {
-			return exit(2, "docker-sandbox --clone requires a normal Git repository workspace: git rev-parse output was %q", strings.TrimSpace(string(output)))
+			return core.Exit(2, "docker-sandbox --clone requires a normal Git repository workspace: git rev-parse output was %q", strings.TrimSpace(string(output)))
 		}
 		resolveGitPath := func(value string) string {
 			value = strings.TrimSpace(value)
@@ -508,13 +508,13 @@ func validateCreateRepo(cfg Config, repo Repo) error {
 			return filepath.Clean(filepath.Join(repo.Root, value))
 		}
 		if resolveGitPath(lines[0]) != resolveGitPath(lines[1]) {
-			return exit(2, "docker-sandbox --clone requires a normal Git repository workspace: linked Git worktrees are not supported")
+			return core.Exit(2, "docker-sandbox --clone requires a normal Git repository workspace: linked Git worktrees are not supported")
 		}
 	}
 	return nil
 }
 
-func dockerSandboxAgent(cfg Config) string {
+func dockerSandboxAgent(cfg core.Config) string {
 	agent := strings.TrimSpace(cfg.DockerSandbox.Agent)
 	if agent == "" {
 		return defaultAgent
@@ -522,7 +522,7 @@ func dockerSandboxAgent(cfg Config) string {
 	return agent
 }
 
-func dockerSandboxWorkdir(cfg Config, repoRoot string) (string, error) {
+func dockerSandboxWorkdir(cfg core.Config, repoRoot string) (string, error) {
 	workdir := strings.TrimSpace(cfg.DockerSandbox.Workdir)
 	if workdir == "" {
 		workdir = repoRoot
@@ -532,7 +532,7 @@ func dockerSandboxWorkdir(cfg Config, repoRoot string) (string, error) {
 	}
 	clean := path.Clean(workdir)
 	if !strings.HasPrefix(clean, "/") {
-		return "", exit(2, "docker-sandbox workdir %q must be an absolute path", workdir)
+		return "", core.Exit(2, "docker-sandbox workdir %q must be an absolute path", workdir)
 	}
 	return clean, nil
 }
@@ -541,8 +541,8 @@ func sandboxNameFromLeaseID(leaseID string) string {
 	return strings.TrimPrefix(leaseID, leasePrefix)
 }
 
-func newSandboxName(repo Repo) string {
-	base := normalizeLeaseSlug(repo.Name)
+func newSandboxName(repo core.Repo) string {
+	base := core.NormalizeLeaseSlug(repo.Name)
 	if base == "" {
 		base = "crabbox"
 	}
@@ -572,7 +572,7 @@ func randomSuffix() string {
 	return hex.EncodeToString(b[:])
 }
 
-func serverFromClaimRecord(claim core.LeaseClaim, record sandboxRecord) Server {
+func serverFromClaimRecord(claim core.LeaseClaim, record sandboxRecord) core.Server {
 	state := core.Blank(record.State, "unknown")
 	labels := map[string]string{
 		"provider":  providerName,
@@ -584,7 +584,7 @@ func serverFromClaimRecord(claim core.LeaseClaim, record sandboxRecord) Server {
 		"agent":     core.Blank(record.Agent, defaultAgent),
 		"workspace": record.Workspace,
 	}
-	server := Server{
+	server := core.Server{
 		Provider: providerName,
 		CloudID:  record.Name,
 		Name:     record.Name,
@@ -595,9 +595,9 @@ func serverFromClaimRecord(claim core.LeaseClaim, record sandboxRecord) Server {
 	return server
 }
 
-func statusFromRecord(leaseID, slug string, record sandboxRecord) StatusView {
+func statusFromRecord(leaseID, slug string, record sandboxRecord) core.StatusView {
 	state := core.Blank(record.State, "unknown")
-	return StatusView{
+	return core.StatusView{
 		ID:         leaseID,
 		Slug:       slug,
 		Provider:   providerName,
@@ -653,32 +653,32 @@ func timeoutOrDefault(primary, fallback time.Duration) time.Duration {
 	return fallback
 }
 
-func doctorCheck(name string, err error, details map[string]string) DoctorCheck {
+func doctorCheck(name string, err error, details map[string]string) core.DoctorCheck {
 	if details == nil {
 		details = map[string]string{}
 	}
 	details["mutation"] = "false"
 	if err != nil {
-		return DoctorCheck{Status: "error", Check: name, Message: err.Error(), Details: details}
+		return core.DoctorCheck{Status: "error", Check: name, Message: err.Error(), Details: details}
 	}
-	return DoctorCheck{Status: "ok", Check: name, Message: "ready", Details: details}
+	return core.DoctorCheck{Status: "ok", Check: name, Message: "ready", Details: details}
 }
 
-func dockerSandboxCompatibilityCheck(version string) DoctorCheck {
+func dockerSandboxCompatibilityCheck(version string) core.DoctorCheck {
 	details := map[string]string{
 		"mutation": "false",
 		"baseline": baselineSBX,
 		"version":  version,
 	}
 	if sbxVersionMatchesBaseline(version) {
-		return DoctorCheck{
+		return core.DoctorCheck{
 			Status:  "ok",
 			Check:   "sbx_compatibility",
 			Message: fmt.Sprintf("matches documented compatibility baseline %s", baselineSBX),
 			Details: details,
 		}
 	}
-	return DoctorCheck{
+	return core.DoctorCheck{
 		Status:  "warn",
 		Check:   "sbx_compatibility",
 		Message: fmt.Sprintf("best-effort compatibility; validated baseline is %s", baselineSBX),
@@ -733,7 +733,7 @@ func formatDockerSandboxEnvFile(env map[string]string) (string, error) {
 	keys := make([]string, 0, len(env))
 	for key := range env {
 		if !core.ValidShellEnvName(key) {
-			return "", exit(2, "docker-sandbox env name %q is not a valid shell environment name", key)
+			return "", core.Exit(2, "docker-sandbox env name %q is not a valid shell environment name", key)
 		}
 		keys = append(keys, key)
 	}
@@ -742,7 +742,7 @@ func formatDockerSandboxEnvFile(env map[string]string) (string, error) {
 	for _, key := range keys {
 		value := env[key]
 		if strings.ContainsAny(value, "\x00\r\n") {
-			return "", exit(2, "docker-sandbox env value for %s cannot contain NUL or newlines when forwarded through sbx --env-file", key)
+			return "", core.Exit(2, "docker-sandbox env value for %s cannot contain NUL or newlines when forwarded through sbx --env-file", key)
 		}
 		fmt.Fprintf(&b, "%s=%s\n", key, value)
 	}

--- a/internal/providers/dockersandbox/backend_test.go
+++ b/internal/providers/dockersandbox/backend_test.go
@@ -94,7 +94,7 @@ func TestProviderWrappersConfigureBackendAndDoctor(t *testing.T) {
 		t.Fatalf("cfg=%#v", cfg.DockerSandbox)
 	}
 
-	rt := Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: newRunner(nil, nil)}
+	rt := core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: newRunner(nil, nil)}
 	configured, err := provider.Configure(cfg, rt)
 	if err != nil {
 		t.Fatalf("Configure err=%v", err)
@@ -224,8 +224,8 @@ func TestRunCreatesExecsAndRemovesEphemeralSandbox(t *testing.T) {
 	repoRoot := t.TempDir()
 	var stdout, stderr bytes.Buffer
 	backend := newTestBackend(newTestConfig(), runner, &stdout, &stderr)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: repoRoot},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: repoRoot},
 		Command: []string{"echo", "ok"},
 	})
 	if err != nil {
@@ -270,7 +270,7 @@ func TestRunCreatesExecsAndRemovesEphemeralSandbox(t *testing.T) {
 	if rm == nil || !containsArg(rm.Args, "--force") {
 		t.Fatalf("rm call=%#v missing --force", rm)
 	}
-	if claim, ok, err := resolveLeaseClaimForProvider(result.LeaseID, providerName); err != nil || ok || claim.LeaseID != "" {
+	if claim, ok, err := core.ResolveLeaseClaimForProvider(result.LeaseID, providerName); err != nil || ok || claim.LeaseID != "" {
 		t.Fatalf("ephemeral claim still resolved claim=%#v ok=%t err=%v", claim, ok, err)
 	}
 	if !cleanupDeadlineSet {
@@ -291,18 +291,18 @@ func TestRunCleanupPreservesReplacedClaim(t *testing.T) {
 		if scriptKey(req.Args) != "exec" {
 			return
 		}
-		claims, err := listLeaseClaims()
+		claims, err := core.ListLeaseClaims()
 		if err != nil || len(claims) != 1 {
 			t.Fatalf("claims=%#v err=%v", claims, err)
 		}
 		claim := claims[0]
-		if err := claimLeaseForRepoProviderPond(claim.LeaseID, claim.Slug, providerName, claim.Pond, replacementRepo, time.Hour, true); err != nil {
+		if err := core.ClaimLeaseForRepoProviderPond(claim.LeaseID, claim.Slug, providerName, claim.Pond, replacementRepo, time.Hour, true); err != nil {
 			t.Fatal(err)
 		}
 	}
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, &stderr)
-	result, err := backend.Run(t.Context(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: t.TempDir()},
+	result, err := backend.Run(t.Context(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: t.TempDir()},
 		Command: []string{"echo", "ok"},
 	})
 	if err == nil || result.ExitCode != 1 || result.Status != core.RunStatusFailed || result.ErrorKind != core.RunErrorProvider || result.Session == nil || !result.Session.Kept {
@@ -311,7 +311,7 @@ func TestRunCleanupPreservesReplacedClaim(t *testing.T) {
 	if findCall(runner, "rm") != nil {
 		t.Fatal("cleanup removed a sandbox after its local claim was replaced")
 	}
-	claim, ok, claimErr := resolveLeaseClaimForProvider(result.LeaseID, providerName)
+	claim, ok, claimErr := core.ResolveLeaseClaimForProvider(result.LeaseID, providerName)
 	if claimErr != nil || !ok || claim.RepoRoot != replacementRepo {
 		t.Fatalf("replacement claim=%#v ok=%t err=%v", claim, ok, claimErr)
 	}
@@ -333,8 +333,8 @@ func TestRunCloneModeKeepsSandboxAfterSuccess(t *testing.T) {
 		"rm":     {stdout: ""},
 	}, nil)
 	backend := newTestBackend(cfg, runner, io.Discard, &stderr)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: repoRoot},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: repoRoot},
 		Command: []string{"echo", "ok"},
 	})
 	if err != nil {
@@ -349,7 +349,7 @@ func TestRunCloneModeKeepsSandboxAfterSuccess(t *testing.T) {
 	if !strings.Contains(stderr.String(), "clone run kept sandbox") || !strings.Contains(stderr.String(), result.Session.CleanupCommand) {
 		t.Fatalf("stderr missing clone cleanup guidance: %s", stderr.String())
 	}
-	if claim, ok, err := resolveLeaseClaimForProvider(result.LeaseID, providerName); err != nil || !ok || claim.LeaseID == "" {
+	if claim, ok, err := core.ResolveLeaseClaimForProvider(result.LeaseID, providerName); err != nil || !ok || claim.LeaseID == "" {
 		t.Fatalf("kept clone claim claim=%#v ok=%t err=%v", claim, ok, err)
 	}
 }
@@ -406,7 +406,7 @@ func TestRunTerminalFailuresPreserveOutcomeAndDisposition(t *testing.T) {
 			if tc.clone {
 				runGit(t, repoRoot, "init", "-q")
 			}
-			req := RunRequest{Repo: Repo{Name: "fixture", Root: repoRoot}, Command: []string{"true"}, TimingJSON: true, KeepOnFailure: tc.keepFailure, Keep: tc.keep}
+			req := core.RunRequest{Repo: core.Repo{Name: "fixture", Root: repoRoot}, Command: []string{"true"}, TimingJSON: true, KeepOnFailure: tc.keepFailure, Keep: tc.keep}
 			if tc.badEnv {
 				req.Env = map[string]string{"INVALID-NAME": "synthetic"}
 			}
@@ -433,7 +433,7 @@ func TestRunTerminalFailuresPreserveOutcomeAndDisposition(t *testing.T) {
 				wantCode = 1
 				wantKind = core.RunErrorProvider
 			}
-			var public ExitError
+			var public core.ExitError
 			if !errors.As(err, &public) || public.Code != wantCode || result.ExitCode != wantCode || result.Status != wantStatus || result.ErrorKind != wantKind {
 				t.Errorf("primary outcome result=%+v err=%v public=%+v", result, err, public)
 			}
@@ -457,7 +457,7 @@ func TestRunTerminalFailuresPreserveOutcomeAndDisposition(t *testing.T) {
 			if (findCall(runner, "rm") != nil) != wantStop {
 				t.Errorf("remove calls=%v want stop=%t", callVerbs(runner), wantStop)
 			}
-			if claim, ok, claimErr := resolveLeaseClaimForProvider(result.LeaseID, providerName); claimErr != nil || ok != wantKept || ok && claim.RepoRoot != repoRoot {
+			if claim, ok, claimErr := core.ResolveLeaseClaimForProvider(result.LeaseID, providerName); claimErr != nil || ok != wantKept || ok && claim.RepoRoot != repoRoot {
 				t.Errorf("claim=%+v exists=%t want=%t err=%v", claim, ok, wantKept, claimErr)
 			}
 			if tc.badEnv && findCall(runner, "exec") != nil {
@@ -473,7 +473,7 @@ func TestRunTerminalFailuresPreserveOutcomeAndDisposition(t *testing.T) {
 	}
 }
 
-func assertTerminalTiming(t *testing.T, diagnostics string, result RunResult, err error) {
+func assertTerminalTiming(t *testing.T, diagnostics string, result core.RunResult, err error) {
 	t.Helper()
 	var reports []core.TimingReport
 	for _, line := range strings.Split(strings.TrimSpace(diagnostics), "\n") {
@@ -522,10 +522,10 @@ func TestRunCloneFailureAndNativeWorkspaceControls(t *testing.T) {
 			runner := newRunner(map[string]scriptedReply{"create": {}, "exec": {exitCode: tc.code}, "rm": {}}, nil)
 			var stderr bytes.Buffer
 			backend := newTestBackend(cfg, runner, io.Discard, &stderr)
-			req := RunRequest{Repo: Repo{Name: "fixture", Root: repoRoot}, Command: []string{"true"}, TimingJSON: true, Keep: tc.keep, KeepOnFailure: tc.keepFailure, NoSync: tc.noSync}
+			req := core.RunRequest{Repo: core.Repo{Name: "fixture", Root: repoRoot}, Command: []string{"true"}, TimingJSON: true, Keep: tc.keep, KeepOnFailure: tc.keepFailure, NoSync: tc.noSync}
 			if tc.reuse {
 				req.ID = "dsbx_crabbox-fixture-123456"
-				if err := claimLeaseForRepoProviderPond(req.ID, "fixture", providerName, "", repoRoot, time.Hour, false); err != nil {
+				if err := core.ClaimLeaseForRepoProviderPond(req.ID, "fixture", providerName, "", repoRoot, time.Hour, false); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -567,8 +567,8 @@ func TestRunBuildsConfiguredCreateCommandAndExec(t *testing.T) {
 		"rm":     {stdout: ""},
 	}, nil)
 	backend := newTestBackend(cfg, runner, io.Discard, io.Discard)
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:      Repo{Name: "my-app", Root: repoRoot},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:      core.Repo{Name: "my-app", Root: repoRoot},
 		Command:   []string{"echo", "hello"},
 		ShellMode: true,
 	})
@@ -607,8 +607,8 @@ func TestRunForwardsEnvViaSBXEnvFile(t *testing.T) {
 		"rm":     {stdout: ""},
 	}, nil)
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, &stderr)
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:       Repo{Name: "my-app", Root: t.TempDir()},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Name: "my-app", Root: t.TempDir()},
 		Command:    []string{"printenv", "SECRET_TOKEN"},
 		Env:        map[string]string{"SECRET_TOKEN": "secret-token-value"},
 		EnvSummary: true,
@@ -649,8 +649,8 @@ func TestRunCleansUpEnvFileAfterExecFailure(t *testing.T) {
 		"rm":     {stdout: ""},
 	}, nil)
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: t.TempDir()},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: t.TempDir()},
 		Command: []string{"printenv", "SECRET_TOKEN"},
 		Env:     map[string]string{"SECRET_TOKEN": "secret-token-value"},
 	})
@@ -726,8 +726,8 @@ func TestRunEnvSummaryTimingAndNoEnvBranches(t *testing.T) {
 		"rm":     {stdout: ""},
 	}, nil)
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, &stderr)
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:       Repo{Name: "my-app", Root: t.TempDir()},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Name: "my-app", Root: t.TempDir()},
 		Command:    []string{"true"},
 		EnvSummary: true,
 		TimingJSON: true,
@@ -768,8 +768,8 @@ func TestRunEnvSummaryTimingAndNoEnvBranches(t *testing.T) {
 		"rm":     {stdout: ""},
 	}, nil)
 	backend = newTestBackend(newTestConfig(), runner, io.Discard, &stderr)
-	_, err = backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: t.TempDir()},
+	_, err = backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: t.TempDir()},
 		Command: []string{"true"},
 	})
 	if err != nil {
@@ -785,8 +785,8 @@ func TestRunEnvSummaryTimingAndNoEnvBranches(t *testing.T) {
 		"rm":     {stdout: ""},
 	}, nil)
 	backend = newTestBackend(newTestConfig(), runner, io.Discard, errWriter{})
-	_, err = backend.Run(context.Background(), RunRequest{
-		Repo:       Repo{Name: "my-app", Root: t.TempDir()},
+	_, err = backend.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Name: "my-app", Root: t.TempDir()},
 		Command:    []string{"true"},
 		TimingJSON: true,
 	})
@@ -799,13 +799,13 @@ func TestRunWithExistingIDReusesClaimedSandbox(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repoRoot := t.TempDir()
 	leaseID := leasePrefix + "crabbox-my-app-abc123"
-	if err := claimLeaseForRepoProviderPond(leaseID, "blue-box", providerName, "", repoRoot, time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderPond(leaseID, "blue-box", providerName, "", repoRoot, time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	runner := newRunner(map[string]scriptedReply{"exec": {stdout: "pwd\n"}}, nil)
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: repoRoot},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: repoRoot},
 		ID:      "blue-box",
 		Command: []string{"pwd"},
 	})
@@ -824,15 +824,15 @@ func TestRunWithExistingIDClassifiesMissingSBXCLI(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repoRoot := t.TempDir()
 	leaseID := leasePrefix + "crabbox-my-app-missing-cli"
-	if err := claimLeaseForRepoProviderPond(leaseID, "missing-cli", providerName, "", repoRoot, time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderPond(leaseID, "missing-cli", providerName, "", repoRoot, time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	runner := newRunner(map[string]scriptedReply{
 		"exec": {stderr: "not found", exitCode: 1, err: os.ErrNotExist},
 	}, nil)
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: repoRoot},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: repoRoot},
 		ID:      "missing-cli",
 		Command: []string{"pwd"},
 	})
@@ -849,21 +849,21 @@ func TestRunKeepsClaimOnKeepAndCleansUpAfterCommandBuildFailure(t *testing.T) {
 		"rm":     {stdout: ""},
 	}, nil)
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Name: "my-app", Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Name: "my-app", Root: t.TempDir()},
 		Command: []string{"true"},
 		Keep:    true,
 	})
 	if err != nil {
 		t.Fatalf("Run keep err=%v", err)
 	}
-	if _, ok, err := resolveLeaseClaimForProvider(result.LeaseID, providerName); err != nil || !ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider(result.LeaseID, providerName); err != nil || !ok {
 		t.Fatalf("kept claim missing ok=%t err=%v", ok, err)
 	}
 
 	runner = newRunner(map[string]scriptedReply{"create": {stdout: ""}, "rm": {stdout: ""}}, nil)
 	backend = newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-	_, err = backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "my-app", Root: t.TempDir()}})
+	_, err = backend.Run(context.Background(), core.RunRequest{Repo: core.Repo{Name: "my-app", Root: t.TempDir()}})
 	if err == nil || !strings.Contains(err.Error(), "missing command") {
 		t.Fatalf("Run empty command err=%v", err)
 	}
@@ -955,7 +955,7 @@ func TestCreateSandboxRemovesSandboxWhenClaimSetupFails(t *testing.T) {
 			var stderr bytes.Buffer
 			backend := newTestBackend(newTestConfig(), runner, io.Discard, &stderr)
 			cli := &sbxCLI{cfg: backend.cfg, rt: backend.rt}
-			_, _, _, err := backend.createSandbox(context.Background(), cli, Repo{Name: "my-app", Root: repoRoot}, false, tt.requestedSlug)
+			_, _, _, err := backend.createSandbox(context.Background(), cli, core.Repo{Name: "my-app", Root: repoRoot}, false, tt.requestedSlug)
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("createSandbox err=%v want %q", err, tt.want)
 			}
@@ -982,10 +982,10 @@ func TestListFiltersToCrabboxOwnedDockerSandboxes(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repoRoot := t.TempDir()
 	owned := "crabbox-my-app-owned"
-	if err := claimLeaseForRepoProviderPond(leasePrefix+owned, "owned", providerName, "", repoRoot, time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderPond(leasePrefix+owned, "owned", providerName, "", repoRoot, time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := claimLeaseForRepoProviderPond(leasePrefix+"crabbox-other-provider", "other", "tensorlake", "", repoRoot, time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderPond(leasePrefix+"crabbox-other-provider", "other", "tensorlake", "", repoRoot, time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	runner := newRunner(map[string]scriptedReply{
@@ -997,7 +997,7 @@ func TestListFiltersToCrabboxOwnedDockerSandboxes(t *testing.T) {
 		]`},
 	}, nil)
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-	leases, err := backend.List(context.Background(), ListRequest{})
+	leases, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1012,13 +1012,13 @@ func TestListFiltersToCrabboxOwnedDockerSandboxes(t *testing.T) {
 func TestStatusReadyMissingWaitAndTimeout(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := leasePrefix + "crabbox-my-app-status"
-	if err := claimLeaseForRepoProviderPond(leaseID, "status", providerName, "", t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderPond(leaseID, "status", providerName, "", t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	readyRunner := newRunner(map[string]scriptedReply{
 		"ls": {stdout: `[{"name":"crabbox-my-app-status","status":"running","agent":"shell","workspace":"/repo"}]`},
 	}, nil)
-	view, err := newTestBackend(newTestConfig(), readyRunner, io.Discard, io.Discard).Status(context.Background(), StatusRequest{ID: "status"})
+	view, err := newTestBackend(newTestConfig(), readyRunner, io.Discard, io.Discard).Status(context.Background(), core.StatusRequest{ID: "status"})
 	if err != nil {
 		t.Fatalf("Status ready err=%v", err)
 	}
@@ -1027,7 +1027,7 @@ func TestStatusReadyMissingWaitAndTimeout(t *testing.T) {
 	}
 
 	missingRunner := newRunner(map[string]scriptedReply{"ls": {stdout: `[]`}}, nil)
-	_, err = newTestBackend(newTestConfig(), missingRunner, io.Discard, io.Discard).Status(context.Background(), StatusRequest{ID: "status"})
+	_, err = newTestBackend(newTestConfig(), missingRunner, io.Discard, io.Discard).Status(context.Background(), core.StatusRequest{ID: "status"})
 	if err == nil || !strings.Contains(err.Error(), "not present") {
 		t.Fatalf("missing status err=%v", err)
 	}
@@ -1035,7 +1035,7 @@ func TestStatusReadyMissingWaitAndTimeout(t *testing.T) {
 	terminalRunner := newRunner(map[string]scriptedReply{
 		"ls": {stdout: `[{"name":"crabbox-my-app-status","status":"stopped"}]`},
 	}, nil)
-	view, err = newTestBackend(newTestConfig(), terminalRunner, io.Discard, io.Discard).Status(context.Background(), StatusRequest{
+	view, err = newTestBackend(newTestConfig(), terminalRunner, io.Discard, io.Discard).Status(context.Background(), core.StatusRequest{
 		ID:          "status",
 		Wait:        true,
 		WaitTimeout: time.Nanosecond,
@@ -1053,7 +1053,7 @@ func TestStatusReadyMissingWaitAndTimeout(t *testing.T) {
 			{stdout: `[{"name":"crabbox-my-app-status","status":"running"}]`},
 		},
 	})
-	view, err = newTestBackend(newTestConfig(), waitRunner, io.Discard, io.Discard).Status(context.Background(), StatusRequest{
+	view, err = newTestBackend(newTestConfig(), waitRunner, io.Discard, io.Discard).Status(context.Background(), core.StatusRequest{
 		ID:          "status",
 		Wait:        true,
 		WaitTimeout: time.Second,
@@ -1067,7 +1067,7 @@ func TestStatusReadyMissingWaitAndTimeout(t *testing.T) {
 	}, nil)
 	timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer timeoutCancel()
-	_, err = newTestBackend(newTestConfig(), timeoutRunner, io.Discard, io.Discard).Status(timeoutCtx, StatusRequest{
+	_, err = newTestBackend(newTestConfig(), timeoutRunner, io.Discard, io.Discard).Status(timeoutCtx, core.StatusRequest{
 		ID:          "status",
 		Wait:        true,
 		WaitTimeout: time.Nanosecond,
@@ -1078,7 +1078,7 @@ func TestStatusReadyMissingWaitAndTimeout(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
-	_, err = newTestBackend(newTestConfig(), timeoutRunner, io.Discard, io.Discard).Status(ctx, StatusRequest{
+	_, err = newTestBackend(newTestConfig(), timeoutRunner, io.Discard, io.Discard).Status(ctx, core.StatusRequest{
 		ID:   "status",
 		Wait: true,
 	})
@@ -1090,7 +1090,7 @@ func TestStatusReadyMissingWaitAndTimeout(t *testing.T) {
 func TestStatusWaitTimeoutDoesNotSleepPastDeadline(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := leasePrefix + "crabbox-my-app-short-timeout"
-	if err := claimLeaseForRepoProviderPond(leaseID, "short-timeout", providerName, "", t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderPond(leaseID, "short-timeout", providerName, "", t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1104,7 +1104,7 @@ func TestStatusWaitTimeoutDoesNotSleepPastDeadline(t *testing.T) {
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
 
 	start := time.Now()
-	_, err := backend.Status(context.Background(), StatusRequest{
+	_, err := backend.Status(context.Background(), core.StatusRequest{
 		ID:          "short-timeout",
 		Wait:        true,
 		WaitTimeout: 20 * time.Millisecond,
@@ -1122,7 +1122,7 @@ func TestStopRejectsUnclaimedIDBeforeCallingRM(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	runner := newRunner(map[string]scriptedReply{"rm": {stdout: ""}}, nil)
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-	err := backend.Stop(context.Background(), StopRequest{ID: "user-owned-sandbox"})
+	err := backend.Stop(context.Background(), core.StopRequest{ID: "user-owned-sandbox"})
 	if err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
 		t.Fatalf("err=%v want unclaimed rejection", err)
 	}
@@ -1134,26 +1134,26 @@ func TestStopRejectsUnclaimedIDBeforeCallingRM(t *testing.T) {
 func TestStopRemovesClaimedSandboxWithForce(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := leasePrefix + "crabbox-my-app-stopme"
-	if err := claimLeaseForRepoProviderPond(leaseID, "stopme", providerName, "", t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderPond(leaseID, "stopme", providerName, "", t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	runner := newRunner(map[string]scriptedReply{"rm": {stdout: ""}}, nil)
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-	if err := backend.Stop(context.Background(), StopRequest{ID: "stopme"}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: "stopme"}); err != nil {
 		t.Fatalf("Stop err=%v", err)
 	}
 	rm := findCall(runner, "rm")
 	if rm == nil || !reflect.DeepEqual(rm.Args, []string{"rm", "--force", "crabbox-my-app-stopme"}) {
 		t.Fatalf("rm args=%v", rm.Args)
 	}
-	if _, ok, err := resolveLeaseClaimForProvider(leaseID, providerName); err != nil || ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil || ok {
 		t.Fatalf("claim resolved after stop ok=%t err=%v", ok, err)
 	}
 }
 
 func TestWarmupRejectsActionsRunnerAndEmitsTiming(t *testing.T) {
 	backend := newTestBackend(newTestConfig(), newRunner(nil, nil), io.Discard, io.Discard)
-	if err := backend.Warmup(context.Background(), WarmupRequest{ActionsRunner: true}); err == nil || !strings.Contains(err.Error(), "--actions-runner") {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{ActionsRunner: true}); err == nil || !strings.Contains(err.Error(), "--actions-runner") {
 		t.Fatalf("actions runner err=%v", err)
 	}
 
@@ -1161,7 +1161,7 @@ func TestWarmupRejectsActionsRunnerAndEmitsTiming(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	runner := newRunner(map[string]scriptedReply{"create": {stdout: ""}}, nil)
 	backend = newTestBackend(newTestConfig(), runner, &stdout, &stderr)
-	if err := backend.Warmup(context.Background(), WarmupRequest{Repo: Repo{Name: "my-app", Root: t.TempDir()}, TimingJSON: true}); err != nil {
+	if err := backend.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Name: "my-app", Root: t.TempDir()}, TimingJSON: true}); err != nil {
 		t.Fatalf("Warmup timing err=%v", err)
 	}
 	if !strings.Contains(stdout.String(), "warmup complete") || !strings.Contains(stderr.String(), `"provider":"docker-sandbox"`) {
@@ -1175,7 +1175,7 @@ func TestDoctorSuccessAndErrorGuidance(t *testing.T) {
 		"ls":       {stdout: `[]`},
 		"diagnose": {stdout: `{}`},
 	}, nil)
-	okResult, err := newTestBackend(newTestConfig(), success, io.Discard, io.Discard).Doctor(context.Background(), DoctorRequest{})
+	okResult, err := newTestBackend(newTestConfig(), success, io.Discard, io.Discard).Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatalf("Doctor success err=%v", err)
 	}
@@ -1189,7 +1189,7 @@ func TestDoctorSuccessAndErrorGuidance(t *testing.T) {
 	missing := newRunner(map[string]scriptedReply{
 		"version": {stderr: "not found", err: os.ErrNotExist},
 	}, nil)
-	_, err = newTestBackend(newTestConfig(), missing, io.Discard, io.Discard).Doctor(context.Background(), DoctorRequest{})
+	_, err = newTestBackend(newTestConfig(), missing, io.Discard, io.Discard).Doctor(context.Background(), core.DoctorRequest{})
 	if err == nil || !strings.Contains(err.Error(), "install the Docker Sandbox sbx CLI") {
 		t.Fatalf("missing cli err=%v", err)
 	}
@@ -1197,7 +1197,7 @@ func TestDoctorSuccessAndErrorGuidance(t *testing.T) {
 		"version": {stdout: "sbx version 0.1.0\n"},
 		"ls":      {stderr: "not logged in", exitCode: 1},
 	}, nil)
-	_, err = newTestBackend(newTestConfig(), auth, io.Discard, io.Discard).Doctor(context.Background(), DoctorRequest{})
+	_, err = newTestBackend(newTestConfig(), auth, io.Discard, io.Discard).Doctor(context.Background(), core.DoctorRequest{})
 	if err == nil || !strings.Contains(err.Error(), "run sbx login") {
 		t.Fatalf("auth err=%v", err)
 	}
@@ -1209,7 +1209,7 @@ func TestDoctorWarnsWhenOptionalDiagnoseFailsAndReportsListParse(t *testing.T) {
 		"ls":       {stdout: `[]`},
 		"diagnose": {stderr: "diagnose unavailable", exitCode: 1},
 	}, nil)
-	result, err := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard).Doctor(context.Background(), DoctorRequest{})
+	result, err := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard).Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatalf("Doctor optional diagnose err=%v", err)
 	}
@@ -1221,7 +1221,7 @@ func TestDoctorWarnsWhenOptionalDiagnoseFailsAndReportsListParse(t *testing.T) {
 		"version": {stdout: "sbx version 0.1.0\n"},
 		"ls":      {stdout: `42`},
 	}, nil)
-	_, err = newTestBackend(newTestConfig(), badList, io.Discard, io.Discard).Doctor(context.Background(), DoctorRequest{})
+	_, err = newTestBackend(newTestConfig(), badList, io.Discard, io.Discard).Doctor(context.Background(), core.DoctorRequest{})
 	if err == nil || !strings.Contains(err.Error(), "expected array or object") {
 		t.Fatalf("bad list err=%v", err)
 	}
@@ -1230,14 +1230,14 @@ func TestDoctorWarnsWhenOptionalDiagnoseFailsAndReportsListParse(t *testing.T) {
 func TestUnsupportedAgentAndTailscaleOptionsRejectClearly(t *testing.T) {
 	cfg := newTestConfig()
 	cfg.DockerSandbox.Agent = "codex"
-	if _, err := (Provider{}).Configure(cfg, Runtime{Exec: newRunner(nil, nil)}); err == nil || !strings.Contains(err.Error(), "v1 supports shell only") {
+	if _, err := (Provider{}).Configure(cfg, core.Runtime{Exec: newRunner(nil, nil)}); err == nil || !strings.Contains(err.Error(), "v1 supports shell only") {
 		t.Fatalf("Configure err=%v, want unsupported agent rejection", err)
 	}
-	err := rejectRunOptions(Provider{}.Spec(), RunRequest{Repo: Repo{Root: t.TempDir()}, Options: core.LeaseOptions{Tailscale: core.TailscaleConfig{Enabled: true}}})
+	err := rejectRunOptions(Provider{}.Spec(), core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, Options: core.LeaseOptions{Tailscale: core.TailscaleConfig{Enabled: true}}})
 	if err == nil || !strings.Contains(err.Error(), "Tailscale") {
 		t.Fatalf("rejectRunOptions err=%v, want Tailscale rejection", err)
 	}
-	err = rejectRunOptions(Provider{}.Spec(), RunRequest{Repo: Repo{Root: t.TempDir()}, Options: core.LeaseOptions{SSHUser: "root", SSHPort: "2222", SSHKey: "/tmp/key"}})
+	err = rejectRunOptions(Provider{}.Spec(), core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, Options: core.LeaseOptions{SSHUser: "root", SSHPort: "2222", SSHKey: "/tmp/key"}})
 	if err != nil {
 		t.Fatalf("inherited SSH config should be ignored for delegated sbx provider, got %v", err)
 	}
@@ -1245,28 +1245,28 @@ func TestUnsupportedAgentAndTailscaleOptionsRejectClearly(t *testing.T) {
 
 func TestRejectRunOptionsAndCreateRepoValidation(t *testing.T) {
 	spec := Provider{}.Spec()
-	for name, req := range map[string]RunRequest{
-		"desktop":   {Repo: Repo{Root: t.TempDir()}, Options: core.LeaseOptions{Desktop: true}},
-		"tailscale": {Repo: Repo{Root: t.TempDir()}, Options: core.LeaseOptions{Tailscale: core.TailscaleConfig{Enabled: true}}},
+	for name, req := range map[string]core.RunRequest{
+		"desktop":   {Repo: core.Repo{Root: t.TempDir()}, Options: core.LeaseOptions{Desktop: true}},
+		"tailscale": {Repo: core.Repo{Root: t.TempDir()}, Options: core.LeaseOptions{Tailscale: core.TailscaleConfig{Enabled: true}}},
 		"no-root":   {},
 	} {
 		if err := rejectRunOptions(spec, req); err == nil {
 			t.Fatalf("%s: expected rejection", name)
 		}
 	}
-	if err := validateCreateRepo(newTestConfig(), Repo{}); err == nil || !strings.Contains(err.Error(), "requires a local workspace") {
+	if err := validateCreateRepo(newTestConfig(), core.Repo{}); err == nil || !strings.Contains(err.Error(), "requires a local workspace") {
 		t.Fatalf("empty repo err=%v", err)
 	}
 	cfg := newTestConfig()
 	cfg.DockerSandbox.Clone = true
-	if err := validateCreateRepo(cfg, Repo{Root: t.TempDir()}); err == nil || !strings.Contains(err.Error(), "--clone requires") {
+	if err := validateCreateRepo(cfg, core.Repo{Root: t.TempDir()}); err == nil || !strings.Contains(err.Error(), "--clone requires") {
 		t.Fatalf("clone validation err=%v", err)
 	}
 	worktreeRoot := t.TempDir()
 	if err := os.WriteFile(filepathJoin(worktreeRoot, ".git"), []byte("gitdir: ../.git/worktrees/example\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := validateCreateRepo(cfg, Repo{Root: worktreeRoot}); err == nil || !strings.Contains(err.Error(), "--clone requires") {
+	if err := validateCreateRepo(cfg, core.Repo{Root: worktreeRoot}); err == nil || !strings.Contains(err.Error(), "--clone requires") {
 		t.Fatalf("fake worktree validation err=%v", err)
 	}
 }
@@ -1291,10 +1291,10 @@ func TestValidateCreateRepoCloneRejectsGitWorktree(t *testing.T) {
 	runGit(t, repoRoot, "commit", "-q", "-m", "init")
 	runGit(t, repoRoot, "worktree", "add", "-q", worktreeRoot)
 
-	if err := validateCreateRepo(cfg, Repo{Root: repoRoot}); err != nil {
+	if err := validateCreateRepo(cfg, core.Repo{Root: repoRoot}); err != nil {
 		t.Fatalf("validateCreateRepo rejected main Git checkout: %v", err)
 	}
-	if err := validateCreateRepo(cfg, Repo{Root: worktreeRoot}); err == nil || !strings.Contains(err.Error(), "linked Git worktrees are not supported") {
+	if err := validateCreateRepo(cfg, core.Repo{Root: worktreeRoot}); err == nil || !strings.Contains(err.Error(), "linked Git worktrees are not supported") {
 		t.Fatalf("validateCreateRepo err=%v, want linked worktree rejection", err)
 	}
 }
@@ -1324,16 +1324,16 @@ func TestDockerSandboxWorkdirAndNameHelpers(t *testing.T) {
 		}
 		return len(b), nil
 	}
-	name := newSandboxName(Repo{Name: namePrefix + strings.Repeat("a", 100)})
+	name := newSandboxName(core.Repo{Name: namePrefix + strings.Repeat("a", 100)})
 	if len(name) > maxSandboxNameLen || !strings.HasPrefix(name, namePrefix) || !strings.HasSuffix(name, "-010203") || strings.Contains(name, namePrefix+namePrefix) {
 		t.Fatalf("sandbox name=%q len=%d", name, len(name))
 	}
 	exactBase := strings.Repeat("b", maxSandboxNameLen-len(namePrefix)-1-sandboxNameSuffixLen)
-	exactName := newSandboxName(Repo{Name: exactBase})
+	exactName := newSandboxName(core.Repo{Name: exactBase})
 	if !strings.Contains(exactName, namePrefix+exactBase+"-") || len(exactName) != maxSandboxNameLen {
 		t.Fatalf("exact sandbox name=%q len=%d", exactName, len(exactName))
 	}
-	oversizedName := newSandboxName(Repo{Name: exactBase + "c"})
+	oversizedName := newSandboxName(core.Repo{Name: exactBase + "c"})
 	if strings.Contains(oversizedName, exactBase+"c") || len(oversizedName) != maxSandboxNameLen {
 		t.Fatalf("oversized sandbox name=%q len=%d", oversizedName, len(oversizedName))
 	}
@@ -1499,15 +1499,15 @@ func TestFlagApplicationAndValidation(t *testing.T) {
 func TestStopRemovesStaleClaimWhenSandboxIsAlreadyGone(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := leasePrefix + "crabbox-my-app-gone"
-	if err := claimLeaseForRepoProviderPond(leaseID, "gone", providerName, "", t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderPond(leaseID, "gone", providerName, "", t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	runner := newRunner(map[string]scriptedReply{"rm": {stderr: "sandbox not found", exitCode: 1}}, nil)
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-	if err := backend.Stop(context.Background(), StopRequest{ID: "gone"}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: "gone"}); err != nil {
 		t.Fatalf("Stop stale claim err=%v", err)
 	}
-	if _, ok, err := resolveLeaseClaimForProvider(leaseID, providerName); err != nil || ok {
+	if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil || ok {
 		t.Fatalf("stale claim resolved after stop ok=%t err=%v", ok, err)
 	}
 }
@@ -1515,14 +1515,14 @@ func TestStopRemovesStaleClaimWhenSandboxIsAlreadyGone(t *testing.T) {
 func TestDockerSandboxPorts(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := leasePrefix + "crabbox-my-app-ports"
-	if err := claimLeaseForRepoProviderPond(leaseID, "ports", providerName, "", t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderPond(leaseID, "ports", providerName, "", t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	runner := newRunner(map[string]scriptedReply{
 		"ports": {stdout: "127.0.0.1:41000->3000/tcp\n"},
 	}, nil)
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-	out, err := backend.Ports(context.Background(), PortsRequest{ID: "ports", Publish: []string{"3000"}})
+	out, err := backend.Ports(context.Background(), core.PortsRequest{ID: "ports", Publish: []string{"3000"}})
 	if err != nil {
 		t.Fatalf("Ports err=%v", err)
 	}
@@ -1538,7 +1538,7 @@ func TestDockerSandboxPorts(t *testing.T) {
 		"ports": {stdout: "[]\n"},
 	}, nil)
 	backend = newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-	_, err = backend.Ports(context.Background(), PortsRequest{ID: leaseID, JSON: true, Unpublish: []string{"41000:3000"}})
+	_, err = backend.Ports(context.Background(), core.PortsRequest{ID: leaseID, JSON: true, Unpublish: []string{"41000:3000"}})
 	if err != nil {
 		t.Fatalf("Ports json err=%v", err)
 	}
@@ -1547,7 +1547,7 @@ func TestDockerSandboxPorts(t *testing.T) {
 		t.Fatalf("ports json call=%#v", call)
 	}
 
-	_, err = backend.Ports(context.Background(), PortsRequest{ID: "user-owned"})
+	_, err = backend.Ports(context.Background(), core.PortsRequest{ID: "user-owned"})
 	if err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
 		t.Fatalf("unclaimed ports err=%v", err)
 	}
@@ -1556,14 +1556,14 @@ func TestDockerSandboxPorts(t *testing.T) {
 func TestDockerSandboxCopy(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := leasePrefix + "crabbox-my-app-copy"
-	if err := claimLeaseForRepoProviderPond(leaseID, "copy", providerName, "", t.TempDir(), time.Hour, false); err != nil {
+	if err := core.ClaimLeaseForRepoProviderPond(leaseID, "copy", providerName, "", t.TempDir(), time.Hour, false); err != nil {
 		t.Fatal(err)
 	}
 	runner := newRunner(map[string]scriptedReply{
 		"cp": {stdout: ""},
 	}, nil)
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-	err := backend.Copy(context.Background(), CopyRequest{ID: "copy", Source: "./coverage.xml", Destination: "SANDBOX:/tmp/coverage.xml", FollowLink: true})
+	err := backend.Copy(context.Background(), core.CopyRequest{ID: "copy", Source: "./coverage.xml", Destination: "SANDBOX:/tmp/coverage.xml", FollowLink: true})
 	if err != nil {
 		t.Fatalf("Copy err=%v", err)
 	}
@@ -1576,7 +1576,7 @@ func TestDockerSandboxCopy(t *testing.T) {
 		"cp": {stdout: ""},
 	}, nil)
 	backend = newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-	err = backend.Copy(context.Background(), CopyRequest{ID: leaseID, Source: "SANDBOX:/tmp/output.log", Destination: "./output.log"})
+	err = backend.Copy(context.Background(), core.CopyRequest{ID: leaseID, Source: "SANDBOX:/tmp/output.log", Destination: "./output.log"})
 	if err != nil {
 		t.Fatalf("Copy download err=%v", err)
 	}
@@ -1589,7 +1589,7 @@ func TestDockerSandboxCopy(t *testing.T) {
 		"cp": {stdout: ""},
 	}, nil)
 	backend = newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-	err = backend.Copy(context.Background(), CopyRequest{ID: leaseID, Source: "C:\\tmp\\output.log", Destination: "SANDBOX:/tmp/output.log"})
+	err = backend.Copy(context.Background(), core.CopyRequest{ID: leaseID, Source: "C:\\tmp\\output.log", Destination: "SANDBOX:/tmp/output.log"})
 	if err != nil {
 		t.Fatalf("Copy windows path err=%v", err)
 	}
@@ -1598,15 +1598,15 @@ func TestDockerSandboxCopy(t *testing.T) {
 		t.Fatalf("copy windows path call=%#v", call)
 	}
 
-	err = backend.Copy(context.Background(), CopyRequest{ID: leaseID, Source: "./a", Destination: "./b"})
+	err = backend.Copy(context.Background(), core.CopyRequest{ID: leaseID, Source: "./a", Destination: "./b"})
 	if err == nil || !strings.Contains(err.Error(), "requires one side to use SANDBOX:PATH") {
 		t.Fatalf("missing sandbox path err=%v", err)
 	}
-	err = backend.Copy(context.Background(), CopyRequest{ID: leaseID, Source: "SANDBOX:/a", Destination: "SANDBOX:/b"})
+	err = backend.Copy(context.Background(), core.CopyRequest{ID: leaseID, Source: "SANDBOX:/a", Destination: "SANDBOX:/b"})
 	if err == nil || !strings.Contains(err.Error(), "sandbox-to-sandbox") {
 		t.Fatalf("double sandbox err=%v", err)
 	}
-	err = backend.Copy(context.Background(), CopyRequest{ID: leaseID, Source: "OTHER:/a", Destination: "./b"})
+	err = backend.Copy(context.Background(), core.CopyRequest{ID: leaseID, Source: "OTHER:/a", Destination: "./b"})
 	if err == nil || !strings.Contains(err.Error(), "requires one side to use SANDBOX:PATH") {
 		t.Fatalf("bad source err=%v", err)
 	}
@@ -1615,7 +1615,7 @@ func TestDockerSandboxCopy(t *testing.T) {
 func TestConfigureDoctorRejectsInvalidConfig(t *testing.T) {
 	cfg := newTestConfig()
 	cfg.DockerSandbox.Agent = "codex"
-	if _, err := (Provider{}).ConfigureDoctor(cfg, Runtime{Exec: newRunner(nil, nil)}); err == nil || !strings.Contains(err.Error(), "v1 supports shell only") {
+	if _, err := (Provider{}).ConfigureDoctor(cfg, core.Runtime{Exec: newRunner(nil, nil)}); err == nil || !strings.Contains(err.Error(), "v1 supports shell only") {
 		t.Fatalf("ConfigureDoctor err=%v, want invalid config rejection", err)
 	}
 }
@@ -1676,7 +1676,7 @@ func newRunner(defaults map[string]scriptedReply, sequenced map[string][]scripte
 	return &recordingCommandRunner{defaults: defaults, scripts: sequenced}
 }
 
-func newTestConfig() Config {
+func newTestConfig() core.Config {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.DockerSandbox.CLIPath = "sbx"
@@ -1684,8 +1684,8 @@ func newTestConfig() Config {
 	return cfg
 }
 
-func newTestBackend(cfg Config, runner *recordingCommandRunner, stdout, stderr io.Writer) *backend {
-	rt := Runtime{Stdout: stdout, Stderr: stderr, Exec: runner}
+func newTestBackend(cfg core.Config, runner *recordingCommandRunner, stdout, stderr io.Writer) *backend {
+	rt := core.Runtime{Stdout: stdout, Stderr: stderr, Exec: runner}
 	return NewBackend(Provider{}.Spec(), cfg, rt).(*backend)
 }
 
@@ -1753,7 +1753,7 @@ func TestSBXErrorClassifiesTimeoutAndStreamedErrors(t *testing.T) {
 	runner := newRunner(map[string]scriptedReply{
 		"exec": {err: errors.New("broken pipe")},
 	}, nil)
-	cli, err := newSBXCLI(newTestConfig(), Runtime{Exec: runner})
+	cli, err := newSBXCLI(newTestConfig(), core.Runtime{Exec: runner})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1764,7 +1764,7 @@ func TestSBXErrorClassifiesTimeoutAndStreamedErrors(t *testing.T) {
 	runner = newRunner(map[string]scriptedReply{
 		"exec": {exitCode: 4},
 	}, nil)
-	cli, err = newSBXCLI(newTestConfig(), Runtime{Exec: runner})
+	cli, err = newSBXCLI(newTestConfig(), core.Runtime{Exec: runner})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1775,7 +1775,7 @@ func TestSBXErrorClassifiesTimeoutAndStreamedErrors(t *testing.T) {
 	runner = newRunner(map[string]scriptedReply{
 		"exec": {exitCode: 4, err: errors.New("process failed")},
 	}, nil)
-	cli, err = newSBXCLI(newTestConfig(), Runtime{Exec: runner})
+	cli, err = newSBXCLI(newTestConfig(), core.Runtime{Exec: runner})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1795,7 +1795,7 @@ func TestRunPropagatesCommandExit(t *testing.T) {
 		"exec":   {exitCode: 7, stderr: "failed\n"},
 	}, nil)
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-	_, err := backend.Run(context.Background(), RunRequest{Repo: Repo{Name: "my-app", Root: t.TempDir()}, Command: []string{"deploy", "--token", "secret-token"}, Keep: true})
+	_, err := backend.Run(context.Background(), core.RunRequest{Repo: core.Repo{Name: "my-app", Root: t.TempDir()}, Command: []string{"deploy", "--token", "secret-token"}, Keep: true})
 	var exitErr core.ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 7 {
 		t.Fatalf("err=%v want exit 7", err)
@@ -1823,7 +1823,7 @@ func TestRunPropagatesStreamRuntimeErrorWithCommandExit(t *testing.T) {
 			}, nil)
 			var stderr bytes.Buffer
 			backend := newTestBackend(newTestConfig(), runner, io.Discard, &stderr)
-			result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "my-app", Root: t.TempDir()}, Command: []string{"deploy", "--token", "secret-token"}, Keep: true, TimingJSON: true})
+			result, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Name: "my-app", Root: t.TempDir()}, Command: []string{"deploy", "--token", "secret-token"}, Keep: true, TimingJSON: true})
 			var exitErr core.ExitError
 			if !errors.As(err, &exitErr) || exitErr.Code != 1 || !errors.Is(err, tc.cause) {
 				t.Fatalf("err=%v want transport exit 1 and original cause", err)
@@ -1852,8 +1852,8 @@ func TestRunKeepOnFailureMarksSessionKept(t *testing.T) {
 		"rm":     {stdout: ""},
 	}, nil)
 	backend := newTestBackend(newTestConfig(), runner, io.Discard, &stderr)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:          Repo{Name: "my-app", Root: t.TempDir()},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:          core.Repo{Name: "my-app", Root: t.TempDir()},
 		Command:       []string{"false"},
 		KeepOnFailure: true,
 	})
@@ -1878,7 +1878,7 @@ func TestRunTimingFailureDoesNotReportSuccess(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			runner := newRunner(map[string]scriptedReply{"create": {}, "exec": {exitCode: commandExit}}, nil)
 			backend := newTestBackend(newTestConfig(), runner, io.Discard, errWriter{})
-			result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "my-app", Root: t.TempDir()}, Command: []string{"true"}, Keep: true, TimingJSON: true})
+			result, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Name: "my-app", Root: t.TempDir()}, Command: []string{"true"}, Keep: true, TimingJSON: true})
 			if err == nil || !strings.Contains(err.Error(), "write failed") {
 				t.Fatalf("timing error=%v", err)
 			}
@@ -1899,8 +1899,8 @@ func TestRunCommandIntentReachesNativeRequest(t *testing.T) {
 		t.Setenv("XDG_STATE_HOME", t.TempDir())
 		runner := newRunner(nil, nil)
 		backend := newTestBackend(newTestConfig(), runner, io.Discard, io.Discard)
-		_, err := backend.Run(t.Context(), RunRequest{
-			Repo:               Repo{Name: "my-app", Root: t.TempDir()},
+		_, err := backend.Run(t.Context(), core.RunRequest{
+			Repo:               core.Repo{Name: "my-app", Root: t.TempDir()},
 			Command:            intent.Command,
 			ShellMode:          intent.ShellMode,
 			CommandLiteralArgs: intent.LiteralArgs,

--- a/internal/providers/dockersandbox/client.go
+++ b/internal/providers/dockersandbox/client.go
@@ -15,13 +15,13 @@ import (
 )
 
 type sbxCLI struct {
-	cfg Config
-	rt  Runtime
+	cfg core.Config
+	rt  core.Runtime
 }
 
-func newSBXCLI(cfg Config, rt Runtime) (*sbxCLI, error) {
+func newSBXCLI(cfg core.Config, rt core.Runtime) (*sbxCLI, error) {
 	if rt.Exec == nil {
-		return nil, exit(2, "provider=docker-sandbox requires Runtime.Exec")
+		return nil, core.Exit(2, "provider=docker-sandbox requires Runtime.Exec")
 	}
 	return &sbxCLI{cfg: cfg, rt: rt}, nil
 }
@@ -36,7 +36,7 @@ func (c *sbxCLI) env() []string {
 
 func (c *sbxCLI) runQuiet(ctx context.Context, args []string) (string, string, error) {
 	var stdout, stderr bytes.Buffer
-	res, err := c.rt.Exec.Run(ctx, LocalCommandRequest{
+	res, err := c.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name:   c.binary(),
 		Args:   args,
 		Env:    c.env(),
@@ -53,7 +53,7 @@ func (c *sbxCLI) runQuiet(ctx context.Context, args []string) (string, string, e
 }
 
 func (c *sbxCLI) runStreamed(ctx context.Context, args []string, stdout, stderr io.Writer) (int, error) {
-	res, err := c.rt.Exec.Run(ctx, LocalCommandRequest{
+	res, err := c.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name:   c.binary(),
 		Args:   args,
 		Env:    c.env(),
@@ -87,7 +87,7 @@ func (c *sbxCLI) diagnose(ctx context.Context) (string, error) {
 	return out, err
 }
 
-func (c *sbxCLI) create(ctx context.Context, name string, repo Repo) error {
+func (c *sbxCLI) create(ctx context.Context, name string, repo core.Repo) error {
 	args := []string{"create", "--name", name}
 	if v := strings.TrimSpace(c.cfg.DockerSandbox.Template); v != "" {
 		args = append(args, "--template", v)
@@ -182,7 +182,7 @@ func parseSandboxList(data string) ([]sandboxRecord, error) {
 	}
 	var root any
 	if err := json.Unmarshal([]byte(data), &root); err != nil {
-		return nil, exit(2, "parse sbx ls --json output: %v", err)
+		return nil, core.Exit(2, "parse sbx ls --json output: %v", err)
 	}
 	var items []any
 	switch value := root.(type) {
@@ -199,7 +199,7 @@ func parseSandboxList(data string) ([]sandboxRecord, error) {
 			items = []any{value}
 		}
 	default:
-		return nil, exit(2, "parse sbx ls --json output: expected array or object, got %T", root)
+		return nil, core.Exit(2, "parse sbx ls --json output: expected array or object, got %T", root)
 	}
 	records := make([]sandboxRecord, 0, len(items))
 	for _, item := range items {

--- a/internal/providers/dockersandbox/core.go
+++ b/internal/providers/dockersandbox/core.go
@@ -1,37 +1,8 @@
 package dockersandbox
 
 import (
-	"io"
-	"time"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type DockerSandboxConfig = core.DockerSandboxConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type DoctorCheck = core.DoctorCheck
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type PortsRequest = core.PortsRequest
-type CopyRequest = core.CopyRequest
-type Server = core.Server
-type Repo = core.Repo
-type ExitError = core.ExitError
-type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
-type timingReport = core.TimingReport
-type timingPhase = core.TimingPhase
 
 const (
 	providerName   = "docker-sandbox"
@@ -47,47 +18,3 @@ const (
 	maxSandboxNameLen    = 63
 	sandboxNameSuffixLen = 6
 )
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
-}
-
-func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
-	return core.TimingReportWithRunResult(report, result, err)
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
-func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
-	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func claimLeaseForRepoProviderPond(leaseID, slug, provider, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProviderPond(leaseID, slug, provider, pond, repoRoot, idleTimeout, reclaim)
-}
-
-func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaimForProvider(identifier, provider)
-}
-
-func listLeaseClaims() ([]core.LeaseClaim, error) {
-	return core.ListLeaseClaims()
-}

--- a/internal/providers/dockersandbox/flags.go
+++ b/internal/providers/dockersandbox/flags.go
@@ -1,7 +1,5 @@
 package dockersandbox
 
-import core "github.com/openclaw/crabbox/internal/cli"
-
 import (
 	"flag"
 	"fmt"
@@ -9,6 +7,7 @@ import (
 	"path"
 	"strings"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -44,7 +43,7 @@ type flagValues struct {
 	Kit             *stringListFlag
 }
 
-func RegisterDockerSandboxProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterDockerSandboxProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	extraWorkspaces := stringListFlag(append([]string(nil), defaults.DockerSandbox.ExtraWorkspaces...))
 	mcp := stringListFlag(append([]string(nil), defaults.DockerSandbox.MCP...))
 	kit := stringListFlag(append([]string(nil), defaults.DockerSandbox.Kit...))
@@ -65,7 +64,7 @@ func RegisterDockerSandboxProviderFlags(fs *flag.FlagSet, defaults Config) any {
 	}
 }
 
-func ApplyDockerSandboxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyDockerSandboxProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if cfg.Provider == providerName {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --docker-sandbox-cpus or --docker-sandbox-memory", "use --docker-sandbox-template"); err != nil {
 			return err
@@ -118,30 +117,30 @@ func ApplyDockerSandboxProviderFlags(cfg *Config, fs *flag.FlagSet, values any) 
 	return validateConfig(*cfg)
 }
 
-func validateConfig(cfg Config) error {
+func validateConfig(cfg core.Config) error {
 	agent := strings.TrimSpace(cfg.DockerSandbox.Agent)
 	if agent == "" {
 		agent = defaultAgent
 	}
 	if agent != defaultAgent {
-		return exit(2, "docker-sandbox agent %q is not supported yet; v1 supports shell only", agent)
+		return core.Exit(2, "docker-sandbox agent %q is not supported yet; v1 supports shell only", agent)
 	}
 	if math.IsNaN(cfg.DockerSandbox.CPUs) || math.IsInf(cfg.DockerSandbox.CPUs, 0) {
-		return exit(2, "docker-sandbox cpus must be finite")
+		return core.Exit(2, "docker-sandbox cpus must be finite")
 	}
 	if cfg.DockerSandbox.CPUs < 0 {
-		return exit(2, "docker-sandbox cpus must be greater than zero")
+		return core.Exit(2, "docker-sandbox cpus must be greater than zero")
 	}
 	if cfg.DockerSandbox.CPUs != math.Trunc(cfg.DockerSandbox.CPUs) {
-		return exit(2, "docker-sandbox cpus must be a whole number")
+		return core.Exit(2, "docker-sandbox cpus must be a whole number")
 	}
 	if workdir := strings.TrimSpace(cfg.DockerSandbox.Workdir); workdir != "" {
 		clean := path.Clean(workdir)
 		if !strings.HasPrefix(clean, "/") {
-			return exit(2, "docker-sandbox workdir %q must be an absolute path", workdir)
+			return core.Exit(2, "docker-sandbox workdir %q must be an absolute path", workdir)
 		}
 		if clean == "/" {
-			return exit(2, "docker-sandbox workdir %q is too broad; choose a dedicated workspace path", workdir)
+			return core.Exit(2, "docker-sandbox workdir %q is too broad; choose a dedicated workspace path", workdir)
 		}
 	}
 	for _, field := range []struct {

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -18,9 +18,9 @@ import (
 )
 
 type backend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 
 	// PowerShell Direct can block instead of failing while a guest boots, so
 	// readiness probes and later guest calls need per-attempt timeouts.
@@ -43,7 +43,7 @@ type hypervVM struct {
 	State int    `json:"State"`
 }
 
-func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	applyDefaults(&cfg)
 	return &backend{
 		spec:                   spec,
@@ -56,7 +56,7 @@ func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	}
 }
 
-func applyDefaults(cfg *Config) {
+func applyDefaults(cfg *core.Config) {
 	cfg.Provider = providerName
 	if cfg.TargetOS == "" {
 		cfg.TargetOS = targetWindows
@@ -87,32 +87,32 @@ func applyDefaults(cfg *Config) {
 	cfg.WorkRoot = cfg.HyperV.WorkRoot
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *backend) RebindResolvedLeaseTarget(target *LeaseTarget, leaseID string) error {
+func (b *backend) RebindResolvedLeaseTarget(target *core.LeaseTarget, leaseID string) error {
 	core.UseStoredTestboxKey(&target.SSH, leaseID)
 	return nil
 }
 
-func (b *backend) configForRun() Config {
+func (b *backend) configForRun() core.Config {
 	cfg := b.cfg
 	applyDefaults(&cfg)
 	return cfg
 }
 
-func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	if hypervHostOS != "windows" {
-		return LeaseTarget{}, exit(2, "provider=%s requires a Windows host with Hyper-V enabled", providerName)
+		return core.LeaseTarget{}, core.Exit(2, "provider=%s requires a Windows host with Hyper-V enabled", providerName)
 	}
 	cfg := b.configForRun()
 	if cfg.HyperV.Image == "" {
-		return LeaseTarget{}, exit(2, "provider=%s requires --hyperv-image (path to a Windows VHDX template with a known administrator password; the provider installs OpenSSH if missing)", providerName)
+		return core.LeaseTarget{}, core.Exit(2, "provider=%s requires --hyperv-image (path to a Windows VHDX template with a known administrator password; the provider installs OpenSSH if missing)", providerName)
 	}
 	if strings.HasSuffix(strings.ToLower(cfg.HyperV.Image), ".iso") {
-		return LeaseTarget{}, exit(2, "provider=%s does not support ISO images; provide a Windows VHDX template with a reachable administrator account", providerName)
+		return core.LeaseTarget{}, core.Exit(2, "provider=%s does not support ISO images; provide a Windows VHDX template with a reachable administrator account", providerName)
 	}
 	if strings.TrimSpace(cfg.HyperV.GuestPassword) == "" {
-		return LeaseTarget{}, exit(2, "provider=%s requires an explicit CRABBOX_HYPERV_GUEST_PASSWORD or hyperv.guestPassword in trusted user config", providerName)
+		return core.LeaseTarget{}, core.Exit(2, "provider=%s requires an explicit CRABBOX_HYPERV_GUEST_PASSWORD or hyperv.guestPassword in trusted user config", providerName)
 	}
 	if cfg.HyperV.InitPassword {
 		// Both values land inside a double-quoted cmd.exe RunOnce command at
@@ -121,48 +121,48 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		// either value rather than emitting a command that does something
 		// other than what was configured.
 		if strings.ContainsAny(cfg.HyperV.GuestPassword, `"%`) {
-			return LeaseTarget{}, exit(2, "provider=%s --hyperv-init-password sets the password through cmd.exe, which cannot carry double quotes or percent signs; choose a different CRABBOX_HYPERV_GUEST_PASSWORD", providerName)
+			return core.LeaseTarget{}, core.Exit(2, "provider=%s --hyperv-init-password sets the password through cmd.exe, which cannot carry double quotes or percent signs; choose a different CRABBOX_HYPERV_GUEST_PASSWORD", providerName)
 		}
 		if strings.ContainsAny(cfg.HyperV.User, `"%`) {
-			return LeaseTarget{}, exit(2, "provider=%s --hyperv-init-password sets the password through cmd.exe, which cannot carry double quotes or percent signs in the user name; choose a different --hyperv-user", providerName)
+			return core.LeaseTarget{}, core.Exit(2, "provider=%s --hyperv-init-password sets the password through cmd.exe, which cannot carry double quotes or percent signs in the user name; choose a different --hyperv-user", providerName)
 		}
 	}
 	if !validHyperVSSHUser(cfg.HyperV.User) {
-		return LeaseTarget{}, exit(2, "provider=%s --hyperv-user must be a local account name containing only letters, digits, dot, underscore, or hyphen", providerName)
+		return core.LeaseTarget{}, core.Exit(2, "provider=%s --hyperv-user must be a local account name containing only letters, digits, dot, underscore, or hyphen", providerName)
 	}
 	if strings.TrimSpace(req.Repo.Root) == "" {
-		return LeaseTarget{}, exit(2, "provider=%s requires a repository root so the VM claim can be persisted before bootstrap", providerName)
+		return core.LeaseTarget{}, core.Exit(2, "provider=%s requires a repository root so the VM claim can be persisted before bootstrap", providerName)
 	}
 	leaseID := core.NewLeaseID()
 	instances, err := b.listInstances(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	claims, err := providerClaims()
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	servers := make([]Server, 0, len(instances))
+	servers := make([]core.Server, 0, len(instances))
 	for _, inst := range instances {
 		servers = append(servers, b.serverFromInstance(inst, claims[inst.Name], cfg))
 	}
-	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	keyPath, publicKey, err := ensureTestboxKeyForConfig(cfg, leaseID)
+	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cleanupKey := true
 	defer func() {
 		if cleanupKey {
-			removeStoredTestboxKey(leaseID)
+			core.RemoveStoredTestboxKey(leaseID)
 		}
 	}()
 	cfg.SSHKey = keyPath
-	name := leaseProviderName(leaseID, slug)
-	labels := directLeaseLabels(cfg, leaseID, slug, providerName, "", req.Keep, time.Now().UTC())
+	name := core.LeaseProviderName(leaseID, slug)
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", req.Keep, time.Now().UTC())
 	labels["instance"] = name
 	labels["image"] = cfg.HyperV.Image
 	labels["ssh_user"] = cfg.HyperV.User
@@ -173,12 +173,12 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%dMB switch=%s keep=%v\n",
 		providerName, leaseID, slug, cfg.HyperV.Image, cfg.HyperV.CPUs, cfg.HyperV.Memory, cfg.HyperV.Switch, req.Keep)
 
-	provisional := LeaseTarget{
+	provisional := core.LeaseTarget{
 		Server:  b.serverFromInstance(hypervVM{Name: name, State: 2}, claim, cfg),
 		LeaseID: leaseID,
 	}
 	if err := persistLease(leaseID, slug, name, cfg, req, provisional); err != nil {
-		return LeaseTarget{}, fmt.Errorf("persist hyperv lease before bootstrap: %w", err)
+		return core.LeaseTarget{}, fmt.Errorf("persist hyperv lease before bootstrap: %w", err)
 	}
 	cleanupKey = false
 	if err := b.createVM(ctx, cfg, name); err != nil {
@@ -186,7 +186,7 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		if cleanupErr == nil {
 			pruneLeaseState(leaseID)
 		}
-		return LeaseTarget{}, errors.Join(err, cleanupErr)
+		return core.LeaseTarget{}, errors.Join(err, cleanupErr)
 	}
 	cleanupFailedLease := func() error {
 		if req.Keep {
@@ -195,44 +195,44 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		if err := b.removeVM(context.Background(), name); err != nil {
 			return fmt.Errorf("remove failed hyperv lease %s: %w", leaseID, err)
 		}
-		removeLeaseClaim(leaseID)
-		removeStoredTestboxKey(leaseID)
+		core.RemoveLeaseClaim(leaseID)
+		core.RemoveStoredTestboxKey(leaseID)
 		return nil
 	}
 
 	if err := b.waitGuestReady(ctx, name, cfg.HyperV.User); err != nil {
-		return LeaseTarget{}, errors.Join(fmt.Errorf("guest did not become reachable over PowerShell Direct: %w", err), cleanupFailedLease())
+		return core.LeaseTarget{}, errors.Join(fmt.Errorf("guest did not become reachable over PowerShell Direct: %w", err), cleanupFailedLease())
 	}
 	if err := b.stageSSHKey(ctx, name, cfg.HyperV.User, publicKey); err != nil {
-		return LeaseTarget{}, errors.Join(fmt.Errorf("pre-network SSH lockdown failed: %w", err), cleanupFailedLease())
+		return core.LeaseTarget{}, errors.Join(fmt.Errorf("pre-network SSH lockdown failed: %w", err), cleanupFailedLease())
 	}
 	if err := b.connectVMNetwork(ctx, name, cfg.HyperV.Switch); err != nil {
-		return LeaseTarget{}, errors.Join(err, cleanupFailedLease())
+		return core.LeaseTarget{}, errors.Join(err, cleanupFailedLease())
 	}
 
 	ip, err := b.waitForIP(ctx, name, 5*time.Minute)
 	if err != nil {
-		return LeaseTarget{}, errors.Join(err, cleanupFailedLease())
+		return core.LeaseTarget{}, errors.Join(err, cleanupFailedLease())
 	}
 
 	if err := b.ensureOpenSSH(ctx, name, cfg.HyperV.User); err != nil {
-		return LeaseTarget{}, errors.Join(fmt.Errorf("guest OpenSSH setup failed: %w", err), cleanupFailedLease())
+		return core.LeaseTarget{}, errors.Join(fmt.Errorf("guest OpenSSH setup failed: %w", err), cleanupFailedLease())
 	}
 
 	if publicKey != "" {
 		if retryErr := b.injectSSHKey(ctx, name, cfg.HyperV.User, publicKey); retryErr != nil {
-			return LeaseTarget{}, errors.Join(fmt.Errorf("post-boot SSH key injection failed: %w", retryErr), cleanupFailedLease())
+			return core.LeaseTarget{}, errors.Join(fmt.Errorf("post-boot SSH key injection failed: %w", retryErr), cleanupFailedLease())
 		}
 	}
 	if err := b.ensureGit(ctx, name, cfg.HyperV.User); err != nil {
-		return LeaseTarget{}, errors.Join(fmt.Errorf("guest git setup failed: %w", err), cleanupFailedLease())
+		return core.LeaseTarget{}, errors.Join(fmt.Errorf("guest git setup failed: %w", err), cleanupFailedLease())
 	}
 	lease, err := b.prepareLease(ctx, cfg, hypervVM{Name: name, State: 2}, ip, claim, true)
 	if err != nil {
-		return LeaseTarget{}, errors.Join(err, cleanupFailedLease())
+		return core.LeaseTarget{}, errors.Join(err, cleanupFailedLease())
 	}
 	if err := persistLease(leaseID, slug, name, cfg, req, lease); err != nil {
-		return LeaseTarget{}, errors.Join(err, cleanupFailedLease())
+		return core.LeaseTarget{}, errors.Join(err, cleanupFailedLease())
 	}
 	cleanupKey = false
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s instance=%s state=ready\n", leaseID, name)
@@ -241,37 +241,37 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 
 // persistLease records ownership before VM creation, then atomically updates
 // the same claim with its SSH endpoint after bootstrap.
-func persistLease(leaseID, slug, name string, cfg Config, req AcquireRequest, lease LeaseTarget) error {
-	return claimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, instanceScope(name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, lease.Server, lease.SSH)
+func persistLease(leaseID, slug, name string, cfg core.Config, req core.AcquireRequest, lease core.LeaseTarget) error {
+	return core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, instanceScope(name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, lease.Server, lease.SSH)
 }
 
-func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	cfg := b.configForRun()
 	inst, claim, err := b.resolveInstance(ctx, req.ID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.ReleaseOnly {
-		return LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: claim.LeaseID}, nil
+		return core.LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: claim.LeaseID}, nil
 	}
 	if inst.State == hypervMissingState {
-		return LeaseTarget{}, exit(4, "hyperv VM %s from claim %s no longer exists; run `crabbox stop --provider hyperv %s` to prune local lease state", inst.Name, claim.LeaseID, claim.LeaseID)
+		return core.LeaseTarget{}, core.Exit(4, "hyperv VM %s from claim %s no longer exists; run `crabbox stop --provider hyperv %s` to prune local lease state", inst.Name, claim.LeaseID, claim.LeaseID)
 	}
 	if claim.LeaseID == "" {
-		return LeaseTarget{}, exit(4, "hyperv instance %q has no Crabbox lease claim; use `crabbox stop --provider hyperv %s` to delete it or warm a new lease", inst.Name, inst.Name)
+		return core.LeaseTarget{}, core.Exit(4, "hyperv instance %q has no Crabbox lease claim; use `crabbox stop --provider hyperv %s` to delete it or warm a new lease", inst.Name, inst.Name)
 	}
 	if req.StatusOnly && !req.ReadyProbe {
-		return LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: claim.LeaseID}, nil
+		return core.LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: claim.LeaseID}, nil
 	}
 	owned, err := exactHyperVClaimOwned(claim.LeaseID, inst.Name)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if !owned && !req.Reclaim {
-		return LeaseTarget{}, exit(4, "hyperv lease %q has a legacy claim not bound to VM %q; adopt it with an explicit --reclaim reuse", claim.LeaseID, inst.Name)
+		return core.LeaseTarget{}, core.Exit(4, "hyperv lease %q has a legacy claim not bound to VM %q; adopt it with an explicit --reclaim reuse", claim.LeaseID, inst.Name)
 	}
 	if !owned && req.Repo.Root == "" {
-		return LeaseTarget{}, exit(2, "hyperv --reclaim requires repository context before binding VM %q", inst.Name)
+		return core.LeaseTarget{}, core.Exit(2, "hyperv --reclaim requires repository context before binding VM %q", inst.Name)
 	}
 	ip := b.queryLiveIP(ctx, inst.Name)
 	if ip == "" {
@@ -279,17 +279,17 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 	}
 	lease, err := b.prepareLease(ctx, cfg, inst, ip, claim, false)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.Repo.Root != "" {
-		if err := claimLeaseForRepoProviderScopePondEndpoint(claim.LeaseID, claim.Slug, providerName, instanceScope(inst.Name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, lease.Server, lease.SSH); err != nil {
-			return LeaseTarget{}, err
+		if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(claim.LeaseID, claim.Slug, providerName, instanceScope(inst.Name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, lease.Server, lease.SSH); err != nil {
+			return core.LeaseTarget{}, err
 		}
 	}
 	return lease, nil
 }
 
-func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
 	cfg := b.configForRun()
 	instances, err := b.listInstances(ctx)
 	if err != nil {
@@ -299,7 +299,7 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 	if err != nil {
 		return nil, err
 	}
-	views := make([]LeaseView, 0, len(instances))
+	views := make([]core.LeaseView, 0, len(instances))
 	for _, inst := range instances {
 		claim := claims[inst.Name]
 		if claim.LeaseID == "" && !strings.HasPrefix(inst.Name, "crabbox-") {
@@ -310,19 +310,19 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 	return views, nil
 }
 
-func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, error) {
+func (b *backend) Doctor(ctx context.Context, req core.DoctorRequest) (core.DoctorResult, error) {
 	if hypervHostOS != "windows" {
-		return DoctorResult{}, exit(2, "provider=%s requires a Windows host", providerName)
+		return core.DoctorResult{}, core.Exit(2, "provider=%s requires a Windows host", providerName)
 	}
 	script := `(Get-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V).State`
 	result, err := b.powershell(ctx, script)
 	if err != nil {
-		return DoctorResult{}, shared.LocalCommandError("hyperv feature check", result, err)
+		return core.DoctorResult{}, shared.LocalCommandError("hyperv feature check", result, err)
 	}
 	state := strings.TrimSpace(result.Stdout)
 	instances, err := b.listInstances(ctx)
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
 	cfg := b.configForRun()
 	probe := "unchecked"
@@ -331,10 +331,10 @@ func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, 
 	}
 	msg := fmt.Sprintf("hyperv=%s control_plane=local inventory=ready api=powershell mutation=false leases=%d image=%s ssh_probe=%s",
 		firstLine(state), len(instances), cfg.HyperV.Image, probe)
-	return DoctorResult{Provider: providerName, Message: msg}, nil
+	return core.DoctorResult{Provider: providerName, Message: msg}, nil
 }
 
-func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	lease := req.Lease
 	if lease.LeaseID == "" {
 		lease.LeaseID = strings.TrimSpace(lease.Server.Labels["lease"])
@@ -348,7 +348,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 		name = inst.Name
 	}
 	if name == "" {
-		return exit(2, "provider=%s release requires a Hyper-V VM name", providerName)
+		return core.Exit(2, "provider=%s release requires a Hyper-V VM name", providerName)
 	}
 	if err := requireExactHyperVClaim(lease.LeaseID, name); err != nil {
 		return err
@@ -363,11 +363,11 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 }
 
 func pruneLeaseState(leaseID string) {
-	removeLeaseClaim(leaseID)
-	removeStoredTestboxKey(leaseID)
+	core.RemoveLeaseClaim(leaseID)
+	core.RemoveStoredTestboxKey(leaseID)
 }
 
-func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
+func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, core.Blank(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
 }
 
@@ -416,8 +416,8 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 			return err
 		}
 		if claim.LeaseID != "" {
-			removeLeaseClaim(claim.LeaseID)
-			removeStoredTestboxKey(claim.LeaseID)
+			core.RemoveLeaseClaim(claim.LeaseID)
+			core.RemoveStoredTestboxKey(claim.LeaseID)
 		}
 		removed++
 	}
@@ -452,13 +452,13 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	return nil
 }
 
-func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
+func (b *backend) Touch(_ context.Context, req core.TouchRequest) (core.Server, error) {
 	server := req.Lease.Server
 	if server.Labels == nil {
 		server.Labels = map[string]string{}
 	}
 	original := server.Labels
-	server.Labels = touchDirectLeaseLabels(original, b.configForRun(), req.State, time.Now().UTC())
+	server.Labels = core.TouchDirectLeaseLabels(original, b.configForRun(), req.State, time.Now().UTC())
 	for _, key := range []string{"image", "instance", "ssh_user", "ssh_port", "work_root"} {
 		if value := strings.TrimSpace(original[key]); value != "" {
 			server.Labels[key] = value
@@ -469,14 +469,14 @@ func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
 
 // createVM creates and starts a disconnected Hyper-V VM. Acquire configures
 // guest SSH over PowerShell Direct before connecting the network adapter.
-func (b *backend) createVM(ctx context.Context, cfg Config, name string) error {
+func (b *backend) createVM(ctx context.Context, cfg core.Config, name string) error {
 	vhdDir := hypervVHDDir()
 	if err := os.MkdirAll(vhdDir, 0o755); err != nil {
-		return exit(2, "create VHD directory %s: %v", vhdDir, err)
+		return core.Exit(2, "create VHD directory %s: %v", vhdDir, err)
 	}
 	vmDir := hypervVMDir()
 	if err := os.MkdirAll(vmDir, 0o755); err != nil {
-		return exit(2, "create VM directory %s: %v", vmDir, err)
+		return core.Exit(2, "create VM directory %s: %v", vmDir, err)
 	}
 	vhdPath := filepath.Join(vhdDir, name+".vhdx")
 
@@ -606,7 +606,7 @@ func hypervInitHiveName(vhdPath string) string {
 }
 
 // invokeGuestScript bounds a PowerShell Direct attempt so callers can retry it.
-func (b *backend) invokeGuestScript(ctx context.Context, script string, env []string, perAttempt time.Duration) (LocalCommandResult, error) {
+func (b *backend) invokeGuestScript(ctx context.Context, script string, env []string, perAttempt time.Duration) (core.LocalCommandResult, error) {
 	attemptCtx, cancel := context.WithTimeout(ctx, perAttempt)
 	defer cancel()
 	return b.powershellWithEnv(attemptCtx, script, env)
@@ -895,7 +895,7 @@ func (b *backend) waitForIP(ctx context.Context, name string, timeout time.Durat
 		func(_ context.Context, delay time.Duration) error { return shared.SleepContext(ctx, delay) },
 		func(context.Context) (string, error) {
 			if time.Now().After(deadline) {
-				return "", exit(5, "hyperv VM %s did not acquire an IP within %s", name, timeout)
+				return "", core.Exit(5, "hyperv VM %s did not acquire an IP within %s", name, timeout)
 			}
 			result, err := b.powershell(ctx, script)
 			if err != nil || strings.TrimSpace(result.Stdout) == "" || strings.TrimSpace(result.Stdout) == "null" {
@@ -933,18 +933,18 @@ func (b *backend) listInstances(ctx context.Context) ([]hypervVM, error) {
 func (b *backend) resolveInstance(ctx context.Context, identifier string) (hypervVM, core.LeaseClaim, error) {
 	identifier = strings.TrimSpace(identifier)
 	if identifier == "" {
-		return hypervVM{}, core.LeaseClaim{}, exit(2, "provider=%s requires --id <lease-id-or-slug-or-instance>", providerName)
+		return hypervVM{}, core.LeaseClaim{}, core.Exit(2, "provider=%s requires --id <lease-id-or-slug-or-instance>", providerName)
 	}
-	if claim, ok, err := resolveLeaseClaimForProvider(identifier, providerName); err != nil {
+	if claim, ok, err := core.ResolveLeaseClaimForProvider(identifier, providerName); err != nil {
 		return hypervVM{}, core.LeaseClaim{}, err
 	} else if ok {
 		name := instanceNameFromClaim(claim)
 		if name == "" {
-			return hypervVM{}, core.LeaseClaim{}, exit(4, "hyperv lease %s has no instance name in its claim", claim.LeaseID)
+			return hypervVM{}, core.LeaseClaim{}, core.Exit(4, "hyperv lease %s has no instance name in its claim", claim.LeaseID)
 		}
 		vm, queryErr := b.queryVM(ctx, name)
 		if queryErr != nil {
-			return hypervVM{}, claim, exit(4, "hyperv VM %s from claim %s not reachable: %v", name, claim.LeaseID, queryErr)
+			return hypervVM{}, claim, core.Exit(4, "hyperv VM %s from claim %s not reachable: %v", name, claim.LeaseID, queryErr)
 		}
 		return vm, claim, nil
 	}
@@ -956,17 +956,17 @@ func (b *backend) resolveInstance(ctx context.Context, identifier string) (hyper
 	if err != nil {
 		return hypervVM{}, core.LeaseClaim{}, err
 	}
-	normalized := normalizeLeaseSlug(identifier)
+	normalized := core.NormalizeLeaseSlug(identifier)
 	for _, inst := range instances {
 		claim := claims[inst.Name]
-		if inst.Name == identifier || claim.LeaseID == identifier || (normalized != "" && normalizeLeaseSlug(claim.Slug) == normalized) {
+		if inst.Name == identifier || claim.LeaseID == identifier || (normalized != "" && core.NormalizeLeaseSlug(claim.Slug) == normalized) {
 			return inst, claim, nil
 		}
 	}
-	return hypervVM{}, core.LeaseClaim{}, exit(4, "hyperv lease not found: %s", identifier)
+	return hypervVM{}, core.LeaseClaim{}, core.Exit(4, "hyperv lease not found: %s", identifier)
 }
 
-func (b *backend) prepareLease(ctx context.Context, cfg Config, inst hypervVM, ip string, claim core.LeaseClaim, wait bool) (LeaseTarget, error) {
+func (b *backend) prepareLease(ctx context.Context, cfg core.Config, inst hypervVM, ip string, claim core.LeaseClaim, wait bool) (core.LeaseTarget, error) {
 	server := b.serverFromInstance(inst, claim, cfg)
 	if user := strings.TrimSpace(server.Labels["ssh_user"]); user != "" {
 		cfg.HyperV.User = user
@@ -977,33 +977,33 @@ func (b *backend) prepareLease(ctx context.Context, cfg Config, inst hypervVM, i
 		cfg.WorkRoot = root
 	}
 	if ip == "" {
-		return LeaseTarget{}, exit(5, "hyperv instance %s has no IPv4 address", inst.Name)
+		return core.LeaseTarget{}, core.Exit(5, "hyperv instance %s has no IPv4 address", inst.Name)
 	}
 	server.PublicNet.IPv4.IP = ip
 	if claim.LeaseID != "" {
-		keyPath, err := testboxKeyPath(claim.LeaseID)
+		keyPath, err := core.TestboxKeyPath(claim.LeaseID)
 		if err == nil {
 			if _, statErr := os.Stat(keyPath); statErr == nil {
 				cfg.SSHKey = keyPath
 			}
 		}
 	}
-	target := sshTargetFromConfig(cfg, ip)
+	target := core.SSHTargetFromConfig(cfg, ip)
 	target.Port = sshPort
 	target.FallbackPorts = []string{}
 	if wait {
-		if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "hyperv ssh", bootstrapWaitTimeout(cfg)); err != nil {
-			return LeaseTarget{}, err
+		if err := core.WaitForSSHReady(ctx, &target, b.rt.Stderr, "hyperv ssh", core.BootstrapWaitTimeout(cfg)); err != nil {
+			return core.LeaseTarget{}, err
 		}
 		server.Status = "ready"
 		server.Labels["state"] = "ready"
 	}
-	return LeaseTarget{Server: server, SSH: target, LeaseID: claim.LeaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: claim.LeaseID}, nil
 }
 
 func (b *backend) removeVM(ctx context.Context, name string) error {
 	if !validHyperVVMName(name) {
-		return exit(2, "refusing to remove non-Crabbox Hyper-V VM %q", name)
+		return core.Exit(2, "refusing to remove non-Crabbox Hyper-V VM %q", name)
 	}
 
 	vm, err := b.queryVM(ctx, name)
@@ -1027,7 +1027,7 @@ func (b *backend) removeVM(ctx context.Context, name string) error {
 
 func (b *backend) removeVMStorage(name string, attachedPaths []string) error {
 	if !validHyperVVMName(name) {
-		return exit(2, "refusing to remove storage for invalid Crabbox Hyper-V VM %q", name)
+		return core.Exit(2, "refusing to remove storage for invalid Crabbox Hyper-V VM %q", name)
 	}
 	var errs []error
 	vhdDir := hypervVHDDir()
@@ -1176,7 +1176,7 @@ func (b *backend) queryVM(ctx context.Context, name string) (hypervVM, error) {
 	}
 	var vm hypervVM
 	if err := json.Unmarshal([]byte(stdout), &vm); err != nil {
-		return hypervVM{}, exit(2, "parse hyperv VM %s: %v", name, err)
+		return hypervVM{}, core.Exit(2, "parse hyperv VM %s: %v", name, err)
 	}
 	return vm, nil
 }
@@ -1212,7 +1212,7 @@ func (b *backend) queryVHDPaths(ctx context.Context, name string) []string {
 	return paths
 }
 
-func (b *backend) serverFromInstance(inst hypervVM, claim core.LeaseClaim, cfg Config) Server {
+func (b *backend) serverFromInstance(inst hypervVM, claim core.LeaseClaim, cfg core.Config) core.Server {
 	labels := map[string]string{}
 	for key, value := range claim.Labels {
 		labels[key] = value
@@ -1252,7 +1252,7 @@ func (b *backend) serverFromInstance(inst hypervVM, claim core.LeaseClaim, cfg C
 	if inst.State == 2 && labels["state"] == "ready" {
 		status = "ready"
 	}
-	server := Server{
+	server := core.Server{
 		CloudID:  inst.Name,
 		Provider: providerName,
 		Name:     inst.Name,
@@ -1273,15 +1273,15 @@ func (b *backend) getIPFromClaim(claim core.LeaseClaim) string {
 	return ""
 }
 
-func (b *backend) powershell(ctx context.Context, script string) (LocalCommandResult, error) {
-	return b.rt.Exec.Run(ctx, LocalCommandRequest{
+func (b *backend) powershell(ctx context.Context, script string) (core.LocalCommandResult, error) {
+	return b.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name: "powershell",
 		Args: []string{"-NoProfile", "-NonInteractive", "-Command", script},
 	})
 }
 
-func (b *backend) powershellWithEnv(ctx context.Context, script string, env []string) (LocalCommandResult, error) {
-	return b.rt.Exec.Run(ctx, LocalCommandRequest{
+func (b *backend) powershellWithEnv(ctx context.Context, script string, env []string) (core.LocalCommandResult, error) {
+	return b.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name: "powershell",
 		Args: []string{"-NoProfile", "-NonInteractive", "-Command", script},
 		Env:  env,
@@ -1289,7 +1289,7 @@ func (b *backend) powershellWithEnv(ctx context.Context, script string, env []st
 }
 
 func providerClaims() (map[string]core.LeaseClaim, error) {
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return nil, err
 	}
@@ -1346,7 +1346,7 @@ func missingClaimCleanupReady(claim core.LeaseClaim, now time.Time) (bool, strin
 	return true, ""
 }
 
-func shouldCleanup(server Server, claim core.LeaseClaim, hasClaim bool, now time.Time) (bool, string) {
+func shouldCleanup(server core.Server, claim core.LeaseClaim, hasClaim bool, now time.Time) (bool, string) {
 	if strings.EqualFold(server.Labels["keep"], "true") {
 		return false, "keep=true"
 	}
@@ -1385,7 +1385,7 @@ func requireExactHyperVClaim(leaseID, instanceName string) error {
 		return err
 	}
 	if !owned {
-		return exit(4, "hyperv lease %q has no exact local claim bound to VM %q; adopt it with an explicit --reclaim reuse before stop", strings.TrimSpace(leaseID), strings.TrimSpace(instanceName))
+		return core.Exit(4, "hyperv lease %q has no exact local claim bound to VM %q; adopt it with an explicit --reclaim reuse before stop", strings.TrimSpace(leaseID), strings.TrimSpace(instanceName))
 	}
 	return nil
 }
@@ -1443,13 +1443,13 @@ func parseVMList(raw string) ([]hypervVM, error) {
 	if strings.HasPrefix(raw, "[") {
 		var vms []hypervVM
 		if err := json.Unmarshal([]byte(raw), &vms); err != nil {
-			return nil, exit(2, "parse hyperv VM list: %v", err)
+			return nil, core.Exit(2, "parse hyperv VM list: %v", err)
 		}
 		return vms, nil
 	}
 	var vm hypervVM
 	if err := json.Unmarshal([]byte(raw), &vm); err != nil {
-		return nil, exit(2, "parse hyperv VM: %v", err)
+		return nil, core.Exit(2, "parse hyperv VM: %v", err)
 	}
 	return []hypervVM{vm}, nil
 }

--- a/internal/providers/hyperv/core.go
+++ b/internal/providers/hyperv/core.go
@@ -1,99 +1,11 @@
 package hyperv
 
 import (
-	"context"
-
-	"io"
-	"time"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type HyperVConfig = core.HyperVConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
 
 const (
 	providerName  = "hyperv"
 	targetWindows = core.TargetWindows
 	sshPort       = "22"
 )
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func leaseProviderName(leaseID, slug string) string {
-	return core.LeaseProviderName(leaseID, slug)
-}
-
-func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (string, error) {
-	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
-	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
-}
-
-func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, now time.Time) map[string]string {
-	return core.TouchDirectLeaseLabels(labels, cfg, state, now)
-}
-
-func claimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool, server Server, target SSHTarget) error {
-	return core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim, server, target)
-}
-
-func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaimForProvider(identifier, provider)
-}
-
-func listLeaseClaims() ([]core.LeaseClaim, error) {
-	return core.ListLeaseClaims()
-}
-
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
-func ensureTestboxKeyForConfig(cfg Config, leaseID string) (string, string, error) {
-	return core.EnsureTestboxKeyForConfig(cfg, leaseID)
-}
-
-func testboxKeyPath(leaseID string) (string, error) {
-	return core.TestboxKeyPath(leaseID)
-}
-
-func removeStoredTestboxKey(leaseID string) {
-	core.RemoveStoredTestboxKey(leaseID)
-}
-
-func sshTargetFromConfig(cfg Config, host string) SSHTarget {
-	return core.SSHTargetFromConfig(cfg, host)
-}
-
-func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
-	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
-}
-
-func bootstrapWaitTimeout(cfg Config) time.Duration {
-	return core.BootstrapWaitTimeout(cfg)
-}

--- a/internal/providers/hyperv/provider_test.go
+++ b/internal/providers/hyperv/provider_test.go
@@ -223,7 +223,7 @@ func TestDoctorReportsConfiguredImage(t *testing.T) {
 	t.Cleanup(func() { hypervHostOS = oldOS })
 
 	b := testBackend(&recordingRunner{})
-	result, err := b.Doctor(context.Background(), DoctorRequest{})
+	result, err := b.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatalf("Doctor: %v", err)
 	}
@@ -246,7 +246,7 @@ func TestCleanupScopedToCrabboxPrefix(t *testing.T) {
 	}
 	cfg := b.configForRun()
 	claims := map[string]core.LeaseClaim{}
-	var views []LeaseView
+	var views []core.LeaseView
 	for _, vm := range vms {
 		claim := claims[vm.Name]
 		if claim.LeaseID == "" && !strings.HasPrefix(vm.Name, "crabbox-") {
@@ -377,7 +377,7 @@ func TestInstanceScopeRoundTrip(t *testing.T) {
 
 func TestShouldCleanupProtectsRetainedLease(t *testing.T) {
 	now := time.Now().UTC()
-	server := Server{Status: "stopped", Labels: map[string]string{
+	server := core.Server{Status: "stopped", Labels: map[string]string{
 		"keep":       "true",
 		"expires_at": core.LeaseLabelTime(now.Add(-time.Hour)),
 	}}
@@ -388,7 +388,7 @@ func TestShouldCleanupProtectsRetainedLease(t *testing.T) {
 }
 
 func TestShouldCleanupExpiredClaim(t *testing.T) {
-	server := Server{Status: "running", Labels: map[string]string{}}
+	server := core.Server{Status: "running", Labels: map[string]string{}}
 	claim := core.LeaseClaim{
 		LeaseID:            "cbx_123",
 		LastUsedAt:         time.Now().Add(-48 * time.Hour).Format(time.RFC3339),
@@ -400,14 +400,14 @@ func TestShouldCleanupExpiredClaim(t *testing.T) {
 }
 
 func TestShouldCleanupSkipsMissingClaim(t *testing.T) {
-	server := Server{Status: "running", Labels: map[string]string{}}
+	server := core.Server{Status: "running", Labels: map[string]string{}}
 	if ok, reason := shouldCleanup(server, core.LeaseClaim{}, false, time.Now()); ok || reason != "missing claim" {
 		t.Fatalf("cleanup=%v reason=%s", ok, reason)
 	}
 }
 
 func TestShouldCleanupStoppedVM(t *testing.T) {
-	server := Server{Status: "off", Labels: map[string]string{}}
+	server := core.Server{Status: "off", Labels: map[string]string{}}
 	if ok, reason := shouldCleanup(server, core.LeaseClaim{}, false, time.Now()); ok || reason != "missing claim" {
 		t.Fatalf("cleanup=%v reason=%s, want false missing claim", ok, reason)
 	}
@@ -422,11 +422,11 @@ func TestReleaseRequiresExactClaim(t *testing.T) {
 	const name = "crabbox-unclaimed-1234"
 	runner := &recordingRunner{}
 	b := testBackend(runner)
-	lease := LeaseTarget{
+	lease := core.LeaseTarget{
 		LeaseID: leaseID,
-		Server:  Server{CloudID: name, Labels: map[string]string{"lease": leaseID, "instance": name}},
+		Server:  core.Server{CloudID: name, Labels: map[string]string{"lease": leaseID, "instance": name}},
 	}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
 		t.Fatalf("ReleaseLease unclaimed err=%v", err)
 	}
 	for _, call := range runner.calls {
@@ -775,7 +775,7 @@ func TestAcquireQuarantinesSSHBeforeConnectingNetwork(t *testing.T) {
 		}
 		script := req.Args[len(req.Args)-1]
 		if strings.Contains(script, "Start-VM") {
-			claims, err := listLeaseClaims()
+			claims, err := core.ListLeaseClaims()
 			claimSeenBeforeStart = err == nil && len(claims) == 1
 		}
 		if strings.Contains(script, "Connect-VMNetworkAdapter") {
@@ -848,7 +848,7 @@ func TestAcquireKeepPersistsClaimAndKeyBeforeBootstrap(t *testing.T) {
 		t.Fatal("Acquire unexpectedly succeeded")
 	}
 
-	claims, claimErr := listLeaseClaims()
+	claims, claimErr := core.ListLeaseClaims()
 	if claimErr != nil {
 		t.Fatalf("listLeaseClaims: %v", claimErr)
 	}
@@ -857,13 +857,13 @@ func TestAcquireKeepPersistsClaimAndKeyBeforeBootstrap(t *testing.T) {
 	}
 	claim := claims[0]
 	t.Cleanup(func() {
-		removeLeaseClaim(claim.LeaseID)
-		removeStoredTestboxKey(claim.LeaseID)
+		core.RemoveLeaseClaim(claim.LeaseID)
+		core.RemoveStoredTestboxKey(claim.LeaseID)
 	})
 	if claim.Provider != providerName || instanceNameFromClaim(claim) == "" {
 		t.Fatalf("retained claim missing provider identity: %#v", claim)
 	}
-	keyPath, keyErr := testboxKeyPath(claim.LeaseID)
+	keyPath, keyErr := core.TestboxKeyPath(claim.LeaseID)
 	if keyErr != nil {
 		t.Fatalf("testboxKeyPath: %v", keyErr)
 	}
@@ -885,7 +885,7 @@ func TestAcquirePersistsProvisionalClaimThenRollsBackFailedLease(t *testing.T) {
 		if len(req.Args) == 0 || !strings.Contains(req.Args[len(req.Args)-1], "Get-VMNetworkAdapter") {
 			return
 		}
-		claims, err := listLeaseClaims()
+		claims, err := core.ListLeaseClaims()
 		if err == nil && len(claims) == 1 {
 			observed = claims[0]
 		}
@@ -903,14 +903,14 @@ func TestAcquirePersistsProvisionalClaimThenRollsBackFailedLease(t *testing.T) {
 	if observed.LeaseID == "" || observed.Provider != providerName || instanceNameFromClaim(observed) == "" {
 		t.Fatalf("bootstrap started without a provisional claim: %#v", observed)
 	}
-	claims, claimErr := listLeaseClaims()
+	claims, claimErr := core.ListLeaseClaims()
 	if claimErr != nil {
 		t.Fatalf("listLeaseClaims: %v", claimErr)
 	}
 	if len(claims) != 0 {
 		t.Fatalf("failed non-retained lease left claims: %#v", claims)
 	}
-	keyPath, keyErr := testboxKeyPath(observed.LeaseID)
+	keyPath, keyErr := core.TestboxKeyPath(observed.LeaseID)
 	if keyErr != nil {
 		t.Fatalf("testboxKeyPath: %v", keyErr)
 	}
@@ -962,19 +962,19 @@ func TestPersistLeaseWritesClaimAndEndpointAtomically(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	b := testBackend(&recordingRunner{})
 	cfg := b.configForRun()
-	lease := LeaseTarget{LeaseID: "cbx_atomic123456"}
+	lease := core.LeaseTarget{LeaseID: "cbx_atomic123456"}
 	lease.Server = b.serverFromInstance(hypervVM{Name: "crabbox-atom-1234", State: 2}, core.LeaseClaim{}, cfg)
 	lease.Server.PublicNet.IPv4.IP = "172.20.0.9"
-	lease.SSH = sshTargetFromConfig(cfg, "172.20.0.9")
+	lease.SSH = core.SSHTargetFromConfig(cfg, "172.20.0.9")
 
-	req := AcquireRequest{}
+	req := core.AcquireRequest{}
 	req.Repo.Root = t.TempDir()
 	if err := persistLease("cbx_atomic123456", "atomslug", "crabbox-atom-1234", cfg, req, lease); err != nil {
 		t.Fatalf("persistLease: %v", err)
 	}
-	t.Cleanup(func() { removeLeaseClaim("cbx_atomic123456") })
+	t.Cleanup(func() { core.RemoveLeaseClaim("cbx_atomic123456") })
 
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		t.Fatalf("listLeaseClaims: %v", err)
 	}
@@ -1009,11 +1009,11 @@ func TestPersistLeaseFailureLeavesNoStaleClaim(t *testing.T) {
 
 	b := testBackend(&recordingRunner{})
 	cfg := b.configForRun()
-	lease := LeaseTarget{LeaseID: "cbx_atomfail12345"}
+	lease := core.LeaseTarget{LeaseID: "cbx_atomfail12345"}
 	lease.Server = b.serverFromInstance(hypervVM{Name: "crabbox-atom-fail", State: 2}, core.LeaseClaim{}, cfg)
-	lease.SSH = sshTargetFromConfig(cfg, "172.20.0.10")
+	lease.SSH = core.SSHTargetFromConfig(cfg, "172.20.0.10")
 
-	req := AcquireRequest{}
+	req := core.AcquireRequest{}
 	req.Repo.Root = t.TempDir()
 	if err := persistLease("cbx_atomfail12345", "atomfail", "crabbox-atom-fail", cfg, req, lease); err == nil {
 		t.Fatal("persistLease should fail when the state directory is unwritable")
@@ -1033,7 +1033,7 @@ func TestResolveStatusOnlyAllowsRetainedLeaseWithoutIP(t *testing.T) {
 	}}
 	b := testBackend(runner)
 	cfg := b.configForRun()
-	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true}
+	req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true}
 	claim := core.LeaseClaim{
 		LeaseID:       "cbx_retained12345",
 		Slug:          "retained-no-ip",
@@ -1041,16 +1041,16 @@ func TestResolveStatusOnlyAllowsRetainedLeaseWithoutIP(t *testing.T) {
 		ProviderScope: instanceScope(name),
 		Labels:        map[string]string{"instance": name, "state": "leased"},
 	}
-	lease := LeaseTarget{
+	lease := core.LeaseTarget{
 		Server:  b.serverFromInstance(hypervVM{Name: name, State: 2}, claim, cfg),
 		LeaseID: claim.LeaseID,
 	}
 	if err := persistLease(claim.LeaseID, claim.Slug, name, cfg, req, lease); err != nil {
 		t.Fatalf("persistLease: %v", err)
 	}
-	t.Cleanup(func() { removeLeaseClaim(claim.LeaseID) })
+	t.Cleanup(func() { core.RemoveLeaseClaim(claim.LeaseID) })
 
-	resolved, err := b.Resolve(context.Background(), ResolveRequest{ID: claim.LeaseID, StatusOnly: true})
+	resolved, err := b.Resolve(context.Background(), core.ResolveRequest{ID: claim.LeaseID, StatusOnly: true})
 	if err != nil {
 		t.Fatalf("Resolve status-only: %v", err)
 	}
@@ -1106,7 +1106,7 @@ func TestReleasePrunesClaimAndKeyWhenVMIsMissing(t *testing.T) {
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	b := testBackend(runner)
 	cfg := b.configForRun()
-	if _, _, err := ensureTestboxKeyForConfig(cfg, leaseID); err != nil {
+	if _, _, err := core.EnsureTestboxKeyForConfig(cfg, leaseID); err != nil {
 		t.Fatalf("ensureTestboxKeyForConfig: %v", err)
 	}
 	claim := core.LeaseClaim{
@@ -1116,11 +1116,11 @@ func TestReleasePrunesClaimAndKeyWhenVMIsMissing(t *testing.T) {
 		ProviderScope: instanceScope(name),
 		Labels:        map[string]string{"instance": name, "lease": leaseID},
 	}
-	lease := LeaseTarget{
+	lease := core.LeaseTarget{
 		Server:  b.serverFromInstance(hypervVM{Name: name, State: 2}, claim, cfg),
 		LeaseID: leaseID,
 	}
-	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}}
+	req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}}
 	if err := persistLease(leaseID, claim.Slug, name, cfg, req, lease); err != nil {
 		t.Fatalf("persistLease: %v", err)
 	}
@@ -1139,20 +1139,20 @@ func TestReleasePrunesClaimAndKeyWhenVMIsMissing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resolved, err := b.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	resolved, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReleaseOnly: true})
 	if err != nil {
 		t.Fatalf("Resolve release-only: %v", err)
 	}
 	if resolved.Server.Status != "missing" {
 		t.Fatalf("resolved status=%q want missing", resolved.Server.Status)
 	}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: resolved}); err != nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: resolved}); err != nil {
 		t.Fatalf("ReleaseLease: %v", err)
 	}
-	if claims, err := listLeaseClaims(); err != nil || len(claims) != 0 {
+	if claims, err := core.ListLeaseClaims(); err != nil || len(claims) != 0 {
 		t.Fatalf("claims after release=%#v err=%v", claims, err)
 	}
-	keyPath, err := testboxKeyPath(leaseID)
+	keyPath, err := core.TestboxKeyPath(leaseID)
 	if err != nil {
 		t.Fatalf("testboxKeyPath: %v", err)
 	}
@@ -1196,11 +1196,11 @@ func TestCleanupMissingClaimRemovesDeterministicStorage(t *testing.T) {
 			"created_at": core.LeaseLabelTime(time.Now().Add(-2 * hypervProvisioningClaimGrace)),
 		},
 	}
-	lease := LeaseTarget{
+	lease := core.LeaseTarget{
 		Server:  b.serverFromInstance(hypervVM{Name: name, State: 2}, claim, cfg),
 		LeaseID: leaseID,
 	}
-	if err := persistLease(leaseID, claim.Slug, name, cfg, AcquireRequest{Repo: core.Repo{Root: t.TempDir()}}, lease); err != nil {
+	if err := persistLease(leaseID, claim.Slug, name, cfg, core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}}, lease); err != nil {
 		t.Fatalf("persistLease: %v", err)
 	}
 	baseVHD := filepath.Join(hypervVHDDir(), name+".vhdx")
@@ -1217,7 +1217,7 @@ func TestCleanupMissingClaimRemovesDeterministicStorage(t *testing.T) {
 	if _, err := os.Stat(baseVHD); !os.IsNotExist(err) {
 		t.Fatalf("cleanup left deterministic disk %s: %v", baseVHD, err)
 	}
-	if claims, err := listLeaseClaims(); err != nil || len(claims) != 0 {
+	if claims, err := core.ListLeaseClaims(); err != nil || len(claims) != 0 {
 		t.Fatalf("claims after cleanup=%#v err=%v", claims, err)
 	}
 }
@@ -1248,11 +1248,11 @@ func TestCleanupMissingKeepClaimPreservesStorage(t *testing.T) {
 			"created_at": core.LeaseLabelTime(time.Now().Add(-2 * hypervProvisioningClaimGrace)),
 		},
 	}
-	lease := LeaseTarget{
+	lease := core.LeaseTarget{
 		Server:  b.serverFromInstance(hypervVM{Name: name, State: 2}, claim, cfg),
 		LeaseID: leaseID,
 	}
-	if err := persistLease(leaseID, claim.Slug, name, cfg, AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true}, lease); err != nil {
+	if err := persistLease(leaseID, claim.Slug, name, cfg, core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true}, lease); err != nil {
 		t.Fatalf("persistLease: %v", err)
 	}
 	baseVHD := filepath.Join(hypervVHDDir(), name+".vhdx")
@@ -1269,7 +1269,7 @@ func TestCleanupMissingKeepClaimPreservesStorage(t *testing.T) {
 	if _, err := os.Stat(baseVHD); err != nil {
 		t.Fatalf("cleanup removed retained disk %s: %v", baseVHD, err)
 	}
-	if claims, err := listLeaseClaims(); err != nil || len(claims) != 1 || claims[0].LeaseID != leaseID {
+	if claims, err := core.ListLeaseClaims(); err != nil || len(claims) != 1 || claims[0].LeaseID != leaseID {
 		t.Fatalf("claims after cleanup=%#v err=%v", claims, err)
 	}
 }
@@ -2100,7 +2100,7 @@ func TestInheritedWorkRootCallerContract(t *testing.T) {
 		{"/provider/root", "/srv/custom", "/provider/root"},
 	} {
 		for _, explicit := range []bool{false, true} {
-			cfg := Config{Provider: "prior", WorkRoot: "/recorded/root", SSHUser: "fixture-user", SSHPort: "1234", SSHFallbackPorts: []string{"4567"}, ServerType: "prior-type", Network: "prior-network"}
+			cfg := core.Config{Provider: "prior", WorkRoot: "/recorded/root", SSHUser: "fixture-user", SSHPort: "1234", SSHFallbackPorts: []string{"4567"}, ServerType: "prior-type", Network: "prior-network"}
 			if explicit {
 				core.MarkWorkRootExplicit(&cfg)
 				cfg.TargetOS = "existing-target"

--- a/internal/providers/multipass/backend.go
+++ b/internal/providers/multipass/backend.go
@@ -18,9 +18,9 @@ import (
 )
 
 type backend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
 var multipassHostOS = runtime.GOOS
@@ -49,12 +49,12 @@ type multipassInfoEntry struct {
 	ImageRelease string   `json:"image_release"`
 }
 
-func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	applyDefaults(&cfg)
 	return &backend{spec: spec, cfg: cfg, rt: rt}
 }
 
-func applyDefaults(cfg *Config) {
+func applyDefaults(cfg *core.Config) {
 	cfg.Provider = providerName
 	if cfg.TargetOS == "" {
 		cfg.TargetOS = targetLinux
@@ -82,54 +82,54 @@ func applyDefaults(cfg *Config) {
 	cfg.ServerType = cfg.Multipass.Image
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *backend) RebindResolvedLeaseTarget(target *LeaseTarget, leaseID string) error {
+func (b *backend) RebindResolvedLeaseTarget(target *core.LeaseTarget, leaseID string) error {
 	core.UseStoredTestboxKey(&target.SSH, leaseID)
 	return nil
 }
 
-func (b *backend) configForRun() Config {
+func (b *backend) configForRun() core.Config {
 	cfg := b.cfg
 	applyDefaults(&cfg)
 	return cfg
 }
 
-func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	cfg := b.configForRun()
 	leaseID := core.NewLeaseID()
 	instances, err := b.listInstances(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	claims, err := providerClaims()
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	servers := make([]Server, 0, len(instances))
+	servers := make([]core.Server, 0, len(instances))
 	for _, inst := range instances {
 		servers = append(servers, b.serverFromInstance(inst, claims[inst.Name], cfg))
 	}
-	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	keyPath, publicKey, err := ensureTestboxKeyForConfig(cfg, leaseID)
+	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cleanupKey := true
 	defer func() {
 		if cleanupKey {
-			removeStoredTestboxKey(leaseID)
+			core.RemoveStoredTestboxKey(leaseID)
 		}
 	}()
 	cfg.SSHKey = keyPath
-	name := leaseProviderName(leaseID, slug)
+	name := core.LeaseProviderName(leaseID, slug)
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%s disk=%s keep=%v\n", providerName, leaseID, slug, cfg.Multipass.Image, cfg.Multipass.CPUs, core.Blank(cfg.Multipass.Memory, "-"), core.Blank(cfg.Multipass.Disk, "-"), req.Keep)
 	if err := b.createInstance(ctx, cfg, name, leaseID, slug, publicKey); err != nil {
 		_ = b.removeInstance(context.Background(), name)
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.Keep {
 		cleanupKey = false
@@ -149,9 +149,9 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	}
 	info, err := b.inspectInstance(ctx, name)
 	if err != nil {
-		return LeaseTarget{}, rollbackProvisioned(err)
+		return core.LeaseTarget{}, rollbackProvisioned(err)
 	}
-	labels := directLeaseLabels(cfg, leaseID, slug, providerName, "", req.Keep, time.Now().UTC())
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", req.Keep, time.Now().UTC())
 	labels["instance"] = name
 	labels["image"] = cfg.Multipass.Image
 	labels["ssh_user"] = cfg.Multipass.User
@@ -160,61 +160,61 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	claim := core.LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: instanceScope(name), Labels: labels}
 	lease, err := b.prepareLease(ctx, cfg, info.toInstance(name), claim, true)
 	if err != nil {
-		return LeaseTarget{}, rollbackProvisioned(err)
+		return core.LeaseTarget{}, rollbackProvisioned(err)
 	}
 	if err := claimLeaseForRepoProviderScopePond(leaseID, slug, providerName, instanceScope(name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
-		return LeaseTarget{}, rollbackProvisioned(err)
+		return core.LeaseTarget{}, rollbackProvisioned(err)
 	}
 	claimCreated = true
 	if err := updateLeaseClaimEndpoint(leaseID, lease.Server, lease.SSH); err != nil {
-		return LeaseTarget{}, rollbackProvisioned(err)
+		return core.LeaseTarget{}, rollbackProvisioned(err)
 	}
-	if err := updateLeaseClaimCacheVolumes(leaseID, cacheVolumeStickyDiskSpecs(cfg.Cache.Volumes)); err != nil {
-		return LeaseTarget{}, rollbackProvisioned(err)
+	if err := updateLeaseClaimCacheVolumes(leaseID, core.CacheVolumeStickyDiskSpecs(cfg.Cache.Volumes)); err != nil {
+		return core.LeaseTarget{}, rollbackProvisioned(err)
 	}
 	cleanupKey = false
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s instance=%s state=ready\n", leaseID, name)
 	return lease, nil
 }
 
-func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	cfg := b.configForRun()
 	inst, claim, err := b.resolveInstance(ctx, req.ID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.ReleaseOnly {
-		return LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: claim.LeaseID}, nil
+		return core.LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: claim.LeaseID}, nil
 	}
 	if claim.LeaseID == "" {
-		return LeaseTarget{}, exit(4, "multipass instance %q has no Crabbox lease claim; use `crabbox stop --provider multipass %s` to delete it or warm a new lease", inst.Name, inst.Name)
+		return core.LeaseTarget{}, core.Exit(4, "multipass instance %q has no Crabbox lease claim; use `crabbox stop --provider multipass %s` to delete it or warm a new lease", inst.Name, inst.Name)
 	}
 	if req.StatusOnly && !req.ReadyProbe {
-		return LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: claim.LeaseID}, nil
+		return core.LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: claim.LeaseID}, nil
 	}
 	owned, err := exactMultipassClaimOwned(claim.LeaseID, inst.Name)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if !owned && !req.Reclaim {
-		return LeaseTarget{}, exit(4, "multipass lease %q has a legacy claim not bound to instance %q; adopt it with an explicit --reclaim reuse", claim.LeaseID, inst.Name)
+		return core.LeaseTarget{}, core.Exit(4, "multipass lease %q has a legacy claim not bound to instance %q; adopt it with an explicit --reclaim reuse", claim.LeaseID, inst.Name)
 	}
 	if !owned && req.Repo.Root == "" {
-		return LeaseTarget{}, exit(2, "multipass --reclaim requires repository context before binding instance %q", inst.Name)
+		return core.LeaseTarget{}, core.Exit(2, "multipass --reclaim requires repository context before binding instance %q", inst.Name)
 	}
 	lease, err := b.prepareLease(ctx, cfg, inst, claim, false)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.Repo.Root != "" {
 		if err := claimLeaseForRepoProviderScopePondEndpoint(claim.LeaseID, claim.Slug, providerName, instanceScope(inst.Name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, lease.Server, lease.SSH); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	return lease, nil
 }
 
-func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
 	cfg := b.configForRun()
 	instances, err := b.listInstances(ctx)
 	if err != nil {
@@ -224,7 +224,7 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 	if err != nil {
 		return nil, err
 	}
-	views := make([]LeaseView, 0, len(instances))
+	views := make([]core.LeaseView, 0, len(instances))
 	for _, inst := range instances {
 		claim := claims[inst.Name]
 		if claim.LeaseID == "" && !strings.HasPrefix(inst.Name, "crabbox-") {
@@ -235,25 +235,25 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 	return views, nil
 }
 
-func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, error) {
+func (b *backend) Doctor(ctx context.Context, req core.DoctorRequest) (core.DoctorResult, error) {
 	cfg := b.configForRun()
 	version, err := b.multipass(ctx, []string{"version"}, nil, nil)
 	if err != nil {
-		return DoctorResult{}, shared.LocalCommandError("multipass version", version, err)
+		return core.DoctorResult{}, shared.LocalCommandError("multipass version", version, err)
 	}
 	instances, err := b.listInstances(ctx)
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
 	probe := "unchecked"
 	if req.ProbeSSH {
 		probe = "requires_running_lease"
 	}
 	msg := fmt.Sprintf("cli=ready daemon=ready control_plane=local inventory=ready api=list mutation=false leases=%d runtime=%s image=%s ssh_probe=%s", len(instances), firstLine(version.Stdout+version.Stderr), cfg.Multipass.Image, probe)
-	return DoctorResult{Provider: providerName, Message: msg}, nil
+	return core.DoctorResult{Provider: providerName, Message: msg}, nil
 }
 
-func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	lease := req.Lease
 	if lease.LeaseID == "" {
 		lease.LeaseID = strings.TrimSpace(lease.Server.Labels["lease"])
@@ -270,7 +270,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 		}
 	}
 	if name == "" {
-		return exit(2, "provider=%s release requires a Multipass instance name", providerName)
+		return core.Exit(2, "provider=%s release requires a Multipass instance name", providerName)
 	}
 	if err := requireExactMultipassClaim(lease.LeaseID, name); err != nil {
 		return err
@@ -280,12 +280,12 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 	}
 	if lease.LeaseID != "" {
 		removeLeaseClaim(lease.LeaseID)
-		removeStoredTestboxKey(lease.LeaseID)
+		core.RemoveStoredTestboxKey(lease.LeaseID)
 	}
 	return nil
 }
 
-func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
+func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, core.Blank(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
 }
 
@@ -331,7 +331,7 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		}
 		if claim.LeaseID != "" {
 			removeLeaseClaim(claim.LeaseID)
-			removeStoredTestboxKey(claim.LeaseID)
+			core.RemoveStoredTestboxKey(claim.LeaseID)
 		}
 		removed++
 	}
@@ -349,7 +349,7 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		}
 		fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing instance\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 		removeLeaseClaim(claim.LeaseID)
-		removeStoredTestboxKey(claim.LeaseID)
+		core.RemoveStoredTestboxKey(claim.LeaseID)
 		claimsRemoved++
 	}
 	if !req.DryRun {
@@ -358,13 +358,13 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	return nil
 }
 
-func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
+func (b *backend) Touch(_ context.Context, req core.TouchRequest) (core.Server, error) {
 	server := req.Lease.Server
 	if server.Labels == nil {
 		server.Labels = map[string]string{}
 	}
 	original := server.Labels
-	server.Labels = touchDirectLeaseLabels(original, b.configForRun(), req.State, time.Now().UTC())
+	server.Labels = core.TouchDirectLeaseLabels(original, b.configForRun(), req.State, time.Now().UTC())
 	for _, key := range []string{"image", "instance", "ssh_user", "ssh_port", "work_root"} {
 		if value := strings.TrimSpace(original[key]); value != "" {
 			server.Labels[key] = value
@@ -373,24 +373,24 @@ func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
 	return server, nil
 }
 
-func (b *backend) createInstance(ctx context.Context, cfg Config, name, leaseID, slug, publicKey string) error {
+func (b *backend) createInstance(ctx context.Context, cfg core.Config, name, leaseID, slug, publicKey string) error {
 	mounts, err := multipassCacheVolumeMounts(cfg.Cache.Volumes)
 	if err != nil {
 		return err
 	}
-	userData := cloudInitUserData(cfg, publicKey)
+	userData := core.CloudInitUserData(cfg, publicKey)
 	tmp, err := os.CreateTemp("", "crabbox-multipass-*.cloud-init.yaml")
 	if err != nil {
-		return exit(2, "create multipass cloud-init file: %v", err)
+		return core.Exit(2, "create multipass cloud-init file: %v", err)
 	}
 	tmpPath := tmp.Name()
 	defer os.Remove(tmpPath)
 	if _, err := tmp.WriteString(userData); err != nil {
 		_ = tmp.Close()
-		return exit(2, "write multipass cloud-init file: %v", err)
+		return core.Exit(2, "write multipass cloud-init file: %v", err)
 	}
 	if err := tmp.Close(); err != nil {
-		return exit(2, "close multipass cloud-init file: %v", err)
+		return core.Exit(2, "close multipass cloud-init file: %v", err)
 	}
 	args := []string{"launch", "--name", name, "--cloud-init", tmpPath}
 	if cfg.Multipass.CPUs > 0 {
@@ -478,23 +478,23 @@ func multipassCacheVolumeMounts(volumes []core.CacheVolumeConfig) ([]multipassCa
 		key := strings.TrimSpace(volume.Key)
 		path := strings.TrimSpace(volume.Path)
 		if key == "" {
-			return nil, exit(2, "cache volume key is required")
+			return nil, core.Exit(2, "cache volume key is required")
 		}
 		if strings.Contains(key, ":") {
-			return nil, exit(2, "cache volume key %q must not contain ':'", key)
+			return nil, core.Exit(2, "cache volume key %q must not contain ':'", key)
 		}
 		if path == "" {
-			return nil, exit(2, "cache volume path is required")
+			return nil, core.Exit(2, "cache volume path is required")
 		}
 		if !strings.HasPrefix(path, "/") {
-			return nil, exit(2, "cache volume path %q must be absolute", path)
+			return nil, core.Exit(2, "cache volume path %q must be absolute", path)
 		}
 		hostPath := filepath.Join(root, multipassCacheVolumeName(key))
 		if err := os.MkdirAll(hostPath, 0o777); err != nil {
-			return nil, exit(2, "create multipass cache volume %s: %v", hostPath, err)
+			return nil, core.Exit(2, "create multipass cache volume %s: %v", hostPath, err)
 		}
 		if err := os.Chmod(hostPath, 0o777); err != nil {
-			return nil, exit(2, "make multipass cache volume writable %s: %v", hostPath, err)
+			return nil, core.Exit(2, "make multipass cache volume writable %s: %v", hostPath, err)
 		}
 		mounts = append(mounts, multipassCacheMount{hostPath: hostPath, guestPath: path})
 	}
@@ -504,7 +504,7 @@ func multipassCacheVolumeMounts(volumes []core.CacheVolumeConfig) ([]multipassCa
 func multipassCacheRoot() (string, error) {
 	dir, err := os.UserCacheDir()
 	if err != nil {
-		return "", exit(2, "user cache directory is unavailable")
+		return "", core.Exit(2, "user cache directory is unavailable")
 	}
 	return filepath.Join(dir, "crabbox", "multipass-cache"), nil
 }
@@ -520,7 +520,7 @@ func (b *backend) listInstances(ctx context.Context) ([]multipassInstance, error
 	}
 	var out listResponse
 	if err := json.Unmarshal([]byte(result.Stdout), &out); err != nil {
-		return nil, exit(2, "parse multipass list: %v", err)
+		return nil, core.Exit(2, "parse multipass list: %v", err)
 	}
 	return out.List, nil
 }
@@ -532,14 +532,14 @@ func (b *backend) inspectInstance(ctx context.Context, name string) (multipassIn
 	}
 	var out infoResponse
 	if err := json.Unmarshal([]byte(result.Stdout), &out); err != nil {
-		return multipassInfoEntry{}, exit(2, "parse multipass info for %s: %v", name, err)
+		return multipassInfoEntry{}, core.Exit(2, "parse multipass info for %s: %v", name, err)
 	}
 	if len(out.Errors) > 0 {
-		return multipassInfoEntry{}, exit(4, "multipass info for %s returned %d error(s)", name, len(out.Errors))
+		return multipassInfoEntry{}, core.Exit(4, "multipass info for %s returned %d error(s)", name, len(out.Errors))
 	}
 	info, ok := out.Info[name]
 	if !ok {
-		return multipassInfoEntry{}, exit(4, "multipass instance not found: %s", name)
+		return multipassInfoEntry{}, core.Exit(4, "multipass instance not found: %s", name)
 	}
 	return info, nil
 }
@@ -547,14 +547,14 @@ func (b *backend) inspectInstance(ctx context.Context, name string) (multipassIn
 func (b *backend) resolveInstance(ctx context.Context, identifier string) (multipassInstance, core.LeaseClaim, error) {
 	identifier = strings.TrimSpace(identifier)
 	if identifier == "" {
-		return multipassInstance{}, core.LeaseClaim{}, exit(2, "provider=%s requires --id <lease-id-or-slug-or-instance>", providerName)
+		return multipassInstance{}, core.LeaseClaim{}, core.Exit(2, "provider=%s requires --id <lease-id-or-slug-or-instance>", providerName)
 	}
-	if claim, ok, err := resolveLeaseClaimForProvider(identifier, providerName); err != nil {
+	if claim, ok, err := core.ResolveLeaseClaimForProvider(identifier, providerName); err != nil {
 		return multipassInstance{}, core.LeaseClaim{}, err
 	} else if ok {
 		name := instanceNameFromClaim(claim)
 		if name == "" {
-			return multipassInstance{}, core.LeaseClaim{}, exit(4, "multipass lease %s has no instance name in its claim", claim.LeaseID)
+			return multipassInstance{}, core.LeaseClaim{}, core.Exit(4, "multipass lease %s has no instance name in its claim", claim.LeaseID)
 		}
 		info, err := b.inspectInstance(ctx, name)
 		if err != nil {
@@ -570,20 +570,20 @@ func (b *backend) resolveInstance(ctx context.Context, identifier string) (multi
 	if err != nil {
 		return multipassInstance{}, core.LeaseClaim{}, err
 	}
-	normalized := normalizeLeaseSlug(identifier)
+	normalized := core.NormalizeLeaseSlug(identifier)
 	for _, inst := range instances {
 		claim := claims[inst.Name]
-		if inst.Name == identifier || claim.LeaseID == identifier || (normalized != "" && normalizeLeaseSlug(claim.Slug) == normalized) {
+		if inst.Name == identifier || claim.LeaseID == identifier || (normalized != "" && core.NormalizeLeaseSlug(claim.Slug) == normalized) {
 			if info, err := b.inspectInstance(ctx, inst.Name); err == nil {
 				inst = info.toInstance(inst.Name)
 			}
 			return inst, claim, nil
 		}
 	}
-	return multipassInstance{}, core.LeaseClaim{}, exit(4, "multipass lease not found: %s", identifier)
+	return multipassInstance{}, core.LeaseClaim{}, core.Exit(4, "multipass lease not found: %s", identifier)
 }
 
-func (b *backend) prepareLease(ctx context.Context, cfg Config, inst multipassInstance, claim core.LeaseClaim, wait bool) (LeaseTarget, error) {
+func (b *backend) prepareLease(ctx context.Context, cfg core.Config, inst multipassInstance, claim core.LeaseClaim, wait bool) (core.LeaseTarget, error) {
 	server := b.serverFromInstance(inst, claim, cfg)
 	if user := strings.TrimSpace(server.Labels["ssh_user"]); user != "" {
 		cfg.Multipass.User = user
@@ -595,28 +595,28 @@ func (b *backend) prepareLease(ctx context.Context, cfg Config, inst multipassIn
 	}
 	host := inst.ip()
 	if host == "" {
-		return LeaseTarget{}, exit(5, "multipass instance %s has no IPv4 address", inst.Name)
+		return core.LeaseTarget{}, core.Exit(5, "multipass instance %s has no IPv4 address", inst.Name)
 	}
 	if claim.LeaseID != "" {
-		keyPath, err := testboxKeyPath(claim.LeaseID)
+		keyPath, err := core.TestboxKeyPath(claim.LeaseID)
 		if err == nil {
 			if _, statErr := os.Stat(keyPath); statErr == nil {
 				cfg.SSHKey = keyPath
 			}
 		}
 	}
-	target := sshTargetFromConfig(cfg, host)
+	target := core.SSHTargetFromConfig(cfg, host)
 	target.Port = sshPort
 	target.FallbackPorts = []string{}
 	target.ReadyCheck = "/usr/local/bin/crabbox-ready"
 	if wait {
-		if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "multipass ssh", bootstrapWaitTimeout(cfg)); err != nil {
-			return LeaseTarget{}, err
+		if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "multipass ssh", core.BootstrapWaitTimeout(cfg)); err != nil {
+			return core.LeaseTarget{}, err
 		}
 		server.Status = "ready"
 		server.Labels["state"] = "ready"
 	}
-	return LeaseTarget{Server: server, SSH: target, LeaseID: claim.LeaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: claim.LeaseID}, nil
 }
 
 func (b *backend) removeInstance(ctx context.Context, name string) error {
@@ -627,7 +627,7 @@ func (b *backend) removeInstance(ctx context.Context, name string) error {
 	return nil
 }
 
-func (b *backend) serverFromInstance(inst multipassInstance, claim core.LeaseClaim, cfg Config) Server {
+func (b *backend) serverFromInstance(inst multipassInstance, claim core.LeaseClaim, cfg core.Config) core.Server {
 	labels := map[string]string{}
 	for key, value := range claim.Labels {
 		labels[key] = value
@@ -669,7 +669,7 @@ func (b *backend) serverFromInstance(inst multipassInstance, claim core.LeaseCla
 	if instanceRunning(inst.State) && labels["state"] == "ready" {
 		status = "ready"
 	}
-	server := Server{
+	server := core.Server{
 		CloudID:  inst.Name,
 		Provider: providerName,
 		Name:     inst.Name,
@@ -682,7 +682,7 @@ func (b *backend) serverFromInstance(inst multipassInstance, claim core.LeaseCla
 }
 
 func providerClaims() (map[string]core.LeaseClaim, error) {
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return nil, err
 	}
@@ -719,7 +719,7 @@ func instanceNameFromScope(scope string) string {
 	return strings.TrimPrefix(strings.TrimSpace(scope), "instance:")
 }
 
-func shouldCleanup(server Server, claim core.LeaseClaim, hasClaim bool, now time.Time) (bool, string) {
+func shouldCleanup(server core.Server, claim core.LeaseClaim, hasClaim bool, now time.Time) (bool, string) {
 	if strings.EqualFold(server.Labels["keep"], "true") {
 		return false, "keep=true"
 	}
@@ -749,7 +749,7 @@ func requireExactMultipassClaim(leaseID, instanceName string) error {
 		return err
 	}
 	if !owned {
-		return exit(4, "multipass lease %q has no exact local claim bound to instance %q; adopt it with an explicit --reclaim reuse before stop", strings.TrimSpace(leaseID), strings.TrimSpace(instanceName))
+		return core.Exit(4, "multipass lease %q has no exact local claim bound to instance %q; adopt it with an explicit --reclaim reuse before stop", strings.TrimSpace(leaseID), strings.TrimSpace(instanceName))
 	}
 	return nil
 }
@@ -764,9 +764,9 @@ func exactMultipassClaimOwned(leaseID, instanceName string) (bool, error) {
 	return ok && exact && claim.LeaseID == leaseID && claim.CloudID == instanceName && claim.ProviderScope == instanceScope(instanceName) && instanceNameFromClaim(claim) == instanceName, nil
 }
 
-func (b *backend) multipass(ctx context.Context, args []string, stdout, stderr io.Writer) (LocalCommandResult, error) {
+func (b *backend) multipass(ctx context.Context, args []string, stdout, stderr io.Writer) (core.LocalCommandResult, error) {
 	cfg := b.configForRun()
-	return b.rt.Exec.Run(ctx, LocalCommandRequest{
+	return b.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name:   cfg.Multipass.CLIPath,
 		Args:   args,
 		Stdout: stdout,

--- a/internal/providers/multipass/backend_test.go
+++ b/internal/providers/multipass/backend_test.go
@@ -536,7 +536,7 @@ func findStoredTestboxKeys(root string) ([]string, error) {
 func TestAcquireRemovesClaimAfterEndpointUpdateFailure(t *testing.T) {
 	runner, b := setupAcquireMetadataFailureTest(t)
 	oldUpdate := updateLeaseClaimEndpoint
-	updateLeaseClaimEndpoint = func(string, Server, SSHTarget) error {
+	updateLeaseClaimEndpoint = func(string, core.Server, core.SSHTarget) error {
 		return errors.New("endpoint boom")
 	}
 	t.Cleanup(func() { updateLeaseClaimEndpoint = oldUpdate })
@@ -564,7 +564,7 @@ func TestAcquireRemovesClaimAfterCacheVolumeUpdateFailure(t *testing.T) {
 func TestAcquireKeepsClaimWhenMetadataRollbackDeleteFails(t *testing.T) {
 	runner, b := setupAcquireMetadataFailureTest(t)
 	oldUpdate := updateLeaseClaimEndpoint
-	updateLeaseClaimEndpoint = func(string, Server, SSHTarget) error {
+	updateLeaseClaimEndpoint = func(string, core.Server, core.SSHTarget) error {
 		return errors.New("endpoint boom")
 	}
 	t.Cleanup(func() { updateLeaseClaimEndpoint = oldUpdate })
@@ -574,7 +574,7 @@ func TestAcquireKeepsClaimWhenMetadataRollbackDeleteFails(t *testing.T) {
 		t.Fatalf("Acquire error=%v, want metadata and cleanup errors", err)
 	}
 	_ = recordedArgsForCommand(t, runner, "delete")
-	claims, claimErr := listLeaseClaims()
+	claims, claimErr := core.ListLeaseClaims()
 	if claimErr != nil {
 		t.Fatal(claimErr)
 	}
@@ -591,7 +591,7 @@ func setupAcquireMetadataFailureTest(t *testing.T) (*recordingRunner, *backend) 
 	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
 	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
 	oldWait := waitForSSHReady
-	waitForSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+	waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
 		return nil
 	}
 	t.Cleanup(func() { waitForSSHReady = oldWait })
@@ -609,7 +609,7 @@ func assertAcquireRollbackRemovedInstanceAndClaim(t *testing.T, runner *recordin
 	if !strings.Contains(deleteArgs, "delete\n--purge\ncrabbox-") {
 		t.Fatalf("delete not recorded after metadata failure:\n%s", deleteArgs)
 	}
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -761,14 +761,14 @@ func TestServerFromUnclaimedCrabboxNamedInstance(t *testing.T) {
 }
 
 func TestShouldCleanupRespectsKeepLabel(t *testing.T) {
-	server := Server{Status: "stopped", Labels: map[string]string{"keep": "true"}}
+	server := core.Server{Status: "stopped", Labels: map[string]string{"keep": "true"}}
 	if ok, reason := shouldCleanup(server, core.LeaseClaim{}, true, time.Now()); ok || reason != "keep=true" {
 		t.Fatalf("cleanup=%v reason=%s", ok, reason)
 	}
 }
 
 func TestShouldCleanupExpiredClaim(t *testing.T) {
-	server := Server{Status: "running", Labels: map[string]string{}}
+	server := core.Server{Status: "running", Labels: map[string]string{}}
 	claim := core.LeaseClaim{LeaseID: "cbx_123", LastUsedAt: time.Now().Add(-48 * time.Hour).Format(time.RFC3339), IdleTimeoutSeconds: int((30 * time.Minute).Seconds())}
 	if ok, reason := shouldCleanup(server, claim, true, time.Now()); !ok || reason != "claim expired" {
 		t.Fatalf("cleanup=%v reason=%s", ok, reason)
@@ -776,14 +776,14 @@ func TestShouldCleanupExpiredClaim(t *testing.T) {
 }
 
 func TestShouldCleanupSkipsMissingClaim(t *testing.T) {
-	server := Server{Status: "running", Labels: map[string]string{}}
+	server := core.Server{Status: "running", Labels: map[string]string{}}
 	if ok, reason := shouldCleanup(server, core.LeaseClaim{}, false, time.Now()); ok || reason != "missing claim" {
 		t.Fatalf("cleanup=%v reason=%s", ok, reason)
 	}
 }
 
 func TestShouldCleanupSkipsStoppedMissingClaim(t *testing.T) {
-	server := Server{Status: "stopped", Labels: map[string]string{}}
+	server := core.Server{Status: "stopped", Labels: map[string]string{}}
 	if ok, reason := shouldCleanup(server, core.LeaseClaim{}, false, time.Now()); ok || reason != "missing claim" {
 		t.Fatalf("cleanup=%v reason=%s", ok, reason)
 	}
@@ -795,20 +795,20 @@ func TestReleaseRequiresExactClaim(t *testing.T) {
 	const name = "crabbox-release-1234"
 	runner := &recordingRunner{}
 	b := testBackend(runner)
-	lease := LeaseTarget{
+	lease := core.LeaseTarget{
 		LeaseID: leaseID,
-		Server:  Server{CloudID: name, Labels: map[string]string{"lease": leaseID, "instance": name}},
+		Server:  core.Server{CloudID: name, Labels: map[string]string{"lease": leaseID, "instance": name}},
 	}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
 		t.Fatalf("ReleaseLease unclaimed err=%v", err)
 	}
 	if len(runner.calls) != 0 {
 		t.Fatalf("unclaimed release mutated provider: %#v", runner.calls)
 	}
-	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, "release", providerName, instanceScope(name), "", t.TempDir(), time.Minute, false, lease.Server, SSHTarget{}); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, "release", providerName, instanceScope(name), "", t.TempDir(), time.Minute, false, lease.Server, core.SSHTarget{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatalf("ReleaseLease exact claim: %v", err)
 	}
 	if got := recordedArgsForCommand(t, runner, "delete"); !strings.Contains(got, "--purge\n"+name) {
@@ -843,7 +843,7 @@ func TestInheritedWorkRootCallerContract(t *testing.T) {
 		{"/provider/root", "/srv/custom", "/provider/root"},
 	} {
 		for _, explicit := range []bool{false, true} {
-			cfg := Config{Provider: "prior", WorkRoot: "/recorded/root", SSHUser: "fixture-user", SSHPort: "1234", SSHFallbackPorts: []string{"4567"}, ServerType: "prior-type", Network: "prior-network"}
+			cfg := core.Config{Provider: "prior", WorkRoot: "/recorded/root", SSHUser: "fixture-user", SSHPort: "1234", SSHFallbackPorts: []string{"4567"}, ServerType: "prior-type", Network: "prior-network"}
 			if explicit {
 				core.MarkWorkRootExplicit(&cfg)
 				cfg.TargetOS = "existing-target"

--- a/internal/providers/multipass/core.go
+++ b/internal/providers/multipass/core.go
@@ -9,76 +9,25 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-type Config = core.Config
-type MultipassConfig = core.MultipassConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
-
 const (
 	providerName = "multipass"
 	targetLinux  = core.TargetLinux
 	sshPort      = "22"
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func leaseProviderName(leaseID, slug string) string {
-	return core.LeaseProviderName(leaseID, slug)
-}
-
-func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (string, error) {
-	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
-	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
-}
-
-func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, now time.Time) map[string]string {
-	return core.TouchDirectLeaseLabels(labels, cfg, state, now)
-}
-
 var claimLeaseForRepoProviderScopePond = func(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
 	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
 }
 
-var claimLeaseForRepoProviderScopePondEndpoint = func(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool, server Server, target SSHTarget) error {
+var claimLeaseForRepoProviderScopePondEndpoint = func(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool, server core.Server, target core.SSHTarget) error {
 	return core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim, server, target)
-}
-
-func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaimForProvider(identifier, provider)
-}
-
-func listLeaseClaims() ([]core.LeaseClaim, error) {
-	return core.ListLeaseClaims()
 }
 
 var removeLeaseClaim = func(leaseID string) {
 	core.RemoveLeaseClaim(leaseID)
 }
 
-var updateLeaseClaimEndpoint = func(leaseID string, server Server, target SSHTarget) error {
+var updateLeaseClaimEndpoint = func(leaseID string, server core.Server, target core.SSHTarget) error {
 	return core.UpdateLeaseClaimEndpoint(leaseID, server, target)
 }
 
@@ -86,34 +35,6 @@ var updateLeaseClaimCacheVolumes = func(leaseID string, specs []string) error {
 	return core.UpdateLeaseClaimCacheVolumes(leaseID, specs)
 }
 
-func cacheVolumeStickyDiskSpecs(volumes []core.CacheVolumeConfig) []string {
-	return core.CacheVolumeStickyDiskSpecs(volumes)
-}
-
-func ensureTestboxKeyForConfig(cfg Config, leaseID string) (string, string, error) {
-	return core.EnsureTestboxKeyForConfig(cfg, leaseID)
-}
-
-func testboxKeyPath(leaseID string) (string, error) {
-	return core.TestboxKeyPath(leaseID)
-}
-
-func removeStoredTestboxKey(leaseID string) {
-	core.RemoveStoredTestboxKey(leaseID)
-}
-
-func sshTargetFromConfig(cfg Config, host string) SSHTarget {
-	return core.SSHTargetFromConfig(cfg, host)
-}
-
-var waitForSSHReady = func(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+var waitForSSHReady = func(ctx context.Context, target *core.SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
 	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
-}
-
-func bootstrapWaitTimeout(cfg Config) time.Duration {
-	return core.BootstrapWaitTimeout(cfg)
-}
-
-func cloudInitUserData(cfg Config, publicKey string) string {
-	return core.CloudInitUserData(cfg, publicKey)
 }

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -17,9 +17,9 @@ import (
 )
 
 type backend struct {
-	spec                  ProviderSpec
-	cfg                   Config
-	rt                    Runtime
+	spec                  core.ProviderSpec
+	cfg                   core.Config
+	rt                    core.Runtime
 	startupObserveTimeout time.Duration
 }
 
@@ -32,7 +32,7 @@ type tartInstance struct {
 	Source  string      `json:"Source"`
 }
 
-func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	applyDefaults(&cfg)
 	return &backend{
 		spec:                  spec,
@@ -42,7 +42,7 @@ func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	}
 }
 
-func applyDefaults(cfg *Config) {
+func applyDefaults(cfg *core.Config) {
 	cfg.Provider = providerName
 	if cfg.TargetOS == "" {
 		cfg.TargetOS = targetMacOS
@@ -75,53 +75,53 @@ func applyDefaults(cfg *Config) {
 	cfg.ServerType = cfg.Tart.Image
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *backend) RebindResolvedLeaseTarget(target *LeaseTarget, leaseID string) error {
+func (b *backend) RebindResolvedLeaseTarget(target *core.LeaseTarget, leaseID string) error {
 	core.UseStoredTestboxKey(&target.SSH, leaseID)
 	return nil
 }
 
-func (b *backend) configForRun() Config {
+func (b *backend) configForRun() core.Config {
 	cfg := b.cfg
 	applyDefaults(&cfg)
 	return cfg
 }
 
-func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (target LeaseTarget, acquireErr error) {
+func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (target core.LeaseTarget, acquireErr error) {
 	cfg := b.configForRun()
 	leaseID := core.NewLeaseID()
 	instances, err := b.listInstances(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	claims, err := providerClaims()
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	servers := make([]Server, 0, len(instances))
+	servers := make([]core.Server, 0, len(instances))
 	for _, inst := range instances {
 		if !strings.HasPrefix(inst.Name, "crabbox-") {
 			continue
 		}
 		servers = append(servers, b.serverFromInstance(inst, claims[inst.Name], cfg))
 	}
-	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	keyPath, publicKey, err := ensureTestboxKeyForConfig(cfg, leaseID)
+	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cleanupKey := true
 	defer func() {
 		if cleanupKey {
-			removeStoredTestboxKey(leaseID)
+			core.RemoveStoredTestboxKey(leaseID)
 		}
 	}()
 	cfg.SSHKey = keyPath
-	name := leaseProviderName(leaseID, slug)
+	name := core.LeaseProviderName(leaseID, slug)
 	diskLabel := "clone-default"
 	if core.IsTartDiskExplicit(&cfg) {
 		diskLabel = fmt.Sprintf("%dGB", cfg.Tart.Disk)
@@ -129,11 +129,11 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (target Lease
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%dMB disk=%s keep=%v\n", providerName, leaseID, slug, cfg.Tart.Image, cfg.Tart.CPUs, cfg.Tart.Memory, diskLabel, req.Keep)
 
 	if err := b.cloneVM(ctx, cfg, name); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	storage, identity, err := createTartVMIdentity(name)
 	if err != nil {
-		return LeaseTarget{}, fmt.Errorf("bind new Tart instance %s ownership (VM retained): %w", name, err)
+		return core.LeaseTarget{}, fmt.Errorf("bind new Tart instance %s ownership (VM retained): %w", name, err)
 	}
 	cleanupUnclaimedVM := func() error {
 		if err := verifyTartVMIdentity(name, storage, identity); err != nil {
@@ -150,17 +150,17 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (target Lease
 	}
 	imageDigest, err := verifyDefaultTartImage(ctx, cfg.Tart.Image, storage, name)
 	if err != nil {
-		return LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
+		return core.LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
 	}
 	if err := verifyTartVMIdentity(name, storage, identity); err != nil {
-		return LeaseTarget{}, fmt.Errorf("Tart clone ownership changed before configuration (VM retained): %w", err)
+		return core.LeaseTarget{}, fmt.Errorf("Tart clone ownership changed before configuration (VM retained): %w", err)
 	}
 	if err := b.configureVM(ctx, cfg, name); err != nil {
-		return LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
+		return core.LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
 	}
 	startup, err := b.startVM(ctx, name, req.Keep)
 	if err != nil {
-		return LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
+		return core.LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
 	}
 	var publishedClaim core.LeaseClaim
 	defer func() {
@@ -186,18 +186,18 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (target Lease
 	ctx = startup.ctx
 	ip, err := b.waitForIP(ctx, name)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if err := b.injectSSHKey(ctx, name, cfg.Tart.User, publicKey); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if cfg.Desktop {
 		if err := b.enableScreenSharing(ctx, name); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 
-	labels := directLeaseLabels(cfg, leaseID, slug, providerName, "", req.Keep, time.Now().UTC())
+	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", req.Keep, time.Now().UTC())
 	labels["instance"] = name
 	labels["image"] = cfg.Tart.Image
 	if imageDigest != "" {
@@ -212,50 +212,50 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (target Lease
 	inst := tartInstance{Name: name, State: "running", Running: true, Source: cfg.Tart.Image}
 	lease, err := b.prepareLease(ctx, cfg, inst, ip, claim, true)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	// Cancel lock acquisition on startup exit, and retain the exact published
 	// revision for rollback if startup fails at the final handoff.
 	publishedClaim, err = core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfterContext(ctx, leaseID, slug, cfg, instanceScope(name), lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, core.LeaseClaim{}, false, nil)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if err := startup.handoff(); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cleanupKey = false
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s instance=%s state=ready\n", leaseID, name)
 	return lease, nil
 }
 
-func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	cfg := b.configForRun()
 	inst, ip, claim, err := b.resolveInstance(ctx, req.ID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if claim.LeaseID == "" {
-		return LeaseTarget{}, exit(4, "tart instance %q has no Crabbox lease claim; remove it with `tart stop %s && tart delete %s` or warm a new lease with `crabbox run`", inst.Name, inst.Name, inst.Name)
+		return core.LeaseTarget{}, core.Exit(4, "tart instance %q has no Crabbox lease claim; remove it with `tart stop %s && tart delete %s` or warm a new lease with `crabbox run`", inst.Name, inst.Name, inst.Name)
 	}
 	if req.ReleaseOnly {
-		return LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: claim.LeaseID}, nil
+		return core.LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: claim.LeaseID}, nil
 	}
 	if !inst.Running && !instanceRunning(inst.State) && !req.StatusOnly {
-		return LeaseTarget{}, exit(5, "tart instance %s is stopped; start a new lease with `crabbox run` or clean up with `crabbox cleanup --provider tart`", inst.Name)
+		return core.LeaseTarget{}, core.Exit(5, "tart instance %s is stopped; start a new lease with `crabbox run` or clean up with `crabbox cleanup --provider tart`", inst.Name)
 	}
 	lease, err := b.prepareLease(ctx, cfg, inst, ip, claim, false)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.Repo.Root != "" {
-		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, instanceScope(inst.Name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
-			return LeaseTarget{}, err
+		if err := core.ClaimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, instanceScope(inst.Name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+			return core.LeaseTarget{}, err
 		}
 	}
 	return lease, nil
 }
 
-func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
 	cfg := b.configForRun()
 	instances, err := b.listInstances(ctx)
 	if err != nil {
@@ -265,7 +265,7 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 	if err != nil {
 		return nil, err
 	}
-	views := make([]LeaseView, 0, len(instances))
+	views := make([]core.LeaseView, 0, len(instances))
 	for _, inst := range instances {
 		claim := claims[inst.Name]
 		if claim.LeaseID == "" && !strings.HasPrefix(inst.Name, "crabbox-") {
@@ -276,15 +276,15 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 	return views, nil
 }
 
-func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, error) {
+func (b *backend) Doctor(ctx context.Context, req core.DoctorRequest) (core.DoctorResult, error) {
 	cfg := b.configForRun()
 	version, err := b.tart(ctx, []string{"--version"}, nil, nil)
 	if err != nil {
-		return DoctorResult{}, shared.LocalCommandError("tart --version", version, err)
+		return core.DoctorResult{}, shared.LocalCommandError("tart --version", version, err)
 	}
 	instances, err := b.listInstances(ctx)
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
 	leases := 0
 	for _, inst := range instances {
@@ -297,10 +297,10 @@ func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, 
 		probe = "requires_running_lease"
 	}
 	msg := fmt.Sprintf("cli=ready control_plane=local inventory=ready api=list mutation=false leases=%d runtime=%s image=%s ssh_probe=%s", leases, firstLine(version.Stdout+version.Stderr), cfg.Tart.Image, probe)
-	return DoctorResult{Provider: providerName, Message: msg}, nil
+	return core.DoctorResult{Provider: providerName, Message: msg}, nil
 }
 
-func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	lease := req.Lease
 	if lease.LeaseID == "" {
 		lease.LeaseID = strings.TrimSpace(lease.Server.Labels["lease"])
@@ -325,7 +325,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 		}
 	}
 	if name == "" {
-		return exit(2, "provider=%s release requires a tart instance name", providerName)
+		return core.Exit(2, "provider=%s release requires a tart instance name", providerName)
 	}
 	_ = b.stopVM(ctx, name)
 	if err := b.deleteVM(ctx, name); err != nil {
@@ -338,11 +338,11 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 }
 
 func pruneLeaseState(leaseID string) {
-	removeLeaseClaim(leaseID)
-	removeStoredTestboxKey(leaseID)
+	core.RemoveLeaseClaim(leaseID)
+	core.RemoveStoredTestboxKey(leaseID)
 }
 
-func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
+func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, core.Blank(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
 }
 
@@ -350,7 +350,7 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	cfg := b.configForRun()
 	// Snapshot candidates before instances so newer claims cannot be compared
 	// against an older instance view and misclassified as orphans.
-	orphanCandidates, err := listLeaseClaims()
+	orphanCandidates, err := core.ListLeaseClaims()
 	if err != nil {
 		return err
 	}
@@ -358,7 +358,7 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	if err != nil {
 		return err
 	}
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return err
 	}
@@ -446,7 +446,7 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	return nil
 }
 
-func (b *backend) cleanupInstance(ctx context.Context, cfg Config, inst tartInstance, claim core.LeaseClaim, storage string) error {
+func (b *backend) cleanupInstance(ctx context.Context, cfg core.Config, inst tartInstance, claim core.LeaseClaim, storage string) error {
 	binding, err := tartCleanupBinding(claim, inst.Name, storage)
 	if err != nil {
 		return err
@@ -486,14 +486,14 @@ func (b *backend) cleanupInstance(ctx context.Context, cfg Config, inst tartInst
 	})
 }
 
-func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
+func (b *backend) Touch(_ context.Context, req core.TouchRequest) (core.Server, error) {
 	server := req.Lease.Server
-	server.Labels = touchDirectLeaseLabels(server.Labels, b.configForRun(), req.State, time.Now().UTC())
+	server.Labels = core.TouchDirectLeaseLabels(server.Labels, b.configForRun(), req.State, time.Now().UTC())
 	return server, nil
 }
 
 // cloneVM clones the base image to create a new VM.
-func (b *backend) cloneVM(ctx context.Context, cfg Config, name string) error {
+func (b *backend) cloneVM(ctx context.Context, cfg core.Config, name string) error {
 	args := []string{"clone", cfg.Tart.Image, name}
 	result, err := b.tart(ctx, args, nil, b.rt.Stderr)
 	if err != nil {
@@ -503,7 +503,7 @@ func (b *backend) cloneVM(ctx context.Context, cfg Config, name string) error {
 }
 
 // configureVM applies CPU, memory, and disk settings to the cloned VM before boot.
-func (b *backend) configureVM(ctx context.Context, cfg Config, name string) error {
+func (b *backend) configureVM(ctx context.Context, cfg core.Config, name string) error {
 	if cfg.Tart.CPUs > 0 {
 		if _, err := b.tart(ctx, []string{"set", name, "--cpu", strconv.Itoa(cfg.Tart.CPUs)}, nil, b.rt.Stderr); err != nil {
 			return fmt.Errorf("tart set --cpu: %w", err)
@@ -528,7 +528,7 @@ func (b *backend) waitForIP(ctx context.Context, name string) (string, error) {
 	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
 	type observation struct {
-		result LocalCommandResult
+		result core.LocalCommandResult
 		err    error
 	}
 	initial := true
@@ -536,9 +536,9 @@ func (b *backend) waitForIP(ctx context.Context, name string) (string, error) {
 		func(context.Context, time.Duration) error {
 			select {
 			case <-ctx.Done():
-				return exit(2, "tart ip %s: context cancelled", name)
+				return core.Exit(2, "tart ip %s: context cancelled", name)
 			case <-deadline:
-				return exit(5, "tart ip %s: timed out waiting for IP address", name)
+				return core.Exit(5, "tart ip %s: timed out waiting for IP address", name)
 			case <-ticker.C:
 				return nil
 			}
@@ -558,7 +558,7 @@ func (b *backend) waitForIP(ctx context.Context, name string) (string, error) {
 			if current.err != nil {
 				stderr := strings.ToLower(strings.TrimSpace(current.result.Stderr))
 				if strings.Contains(stderr, "is your vm running") || strings.Contains(stderr, "not running") {
-					return false, exit(2, "tart ip %s: %s", name, strings.TrimSpace(current.result.Stderr))
+					return false, core.Exit(2, "tart ip %s: %s", name, strings.TrimSpace(current.result.Stderr))
 				}
 				return false, nil
 			}
@@ -575,7 +575,7 @@ var validPOSIXUser = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9._-]*$`)
 
 func (b *backend) injectSSHKey(ctx context.Context, name string, user string, publicKey string) error {
 	if !validPOSIXUser.MatchString(user) {
-		return exit(2, "tart.user %q is not a valid POSIX account name", user)
+		return core.Exit(2, "tart.user %q is not a valid POSIX account name", user)
 	}
 	if err := b.waitForGuestAgent(ctx, name); err != nil {
 		return fmt.Errorf("ssh key injection: %w", err)
@@ -599,7 +599,7 @@ func (b *backend) waitForGuestAgent(ctx context.Context, name string) error {
 	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 	type observation struct {
-		result LocalCommandResult
+		result core.LocalCommandResult
 		err    error
 	}
 	_, err := shared.Poll(waitCtx, 0, 500*time.Millisecond, shared.SleepContext,
@@ -681,7 +681,7 @@ func (b *backend) listInstances(ctx context.Context) ([]tartInstance, error) {
 	}
 	var instances []tartInstance
 	if err := json.Unmarshal([]byte(result.Stdout), &instances); err != nil {
-		return nil, exit(2, "parse tart list: %v", err)
+		return nil, core.Exit(2, "parse tart list: %v", err)
 	}
 	return instances, nil
 }
@@ -689,14 +689,14 @@ func (b *backend) listInstances(ctx context.Context) ([]tartInstance, error) {
 func (b *backend) resolveInstance(ctx context.Context, identifier string) (tartInstance, string, core.LeaseClaim, error) {
 	identifier = strings.TrimSpace(identifier)
 	if identifier == "" {
-		return tartInstance{}, "", core.LeaseClaim{}, exit(2, "provider=%s requires --id <lease-id-or-slug-or-instance>", providerName)
+		return tartInstance{}, "", core.LeaseClaim{}, core.Exit(2, "provider=%s requires --id <lease-id-or-slug-or-instance>", providerName)
 	}
-	if claim, ok, err := resolveLeaseClaimForProvider(identifier, providerName); err != nil {
+	if claim, ok, err := core.ResolveLeaseClaimForProvider(identifier, providerName); err != nil {
 		return tartInstance{}, "", core.LeaseClaim{}, err
 	} else if ok {
 		name := instanceNameFromClaim(claim)
 		if name == "" {
-			return tartInstance{}, "", core.LeaseClaim{}, exit(4, "tart lease %s has no instance name in its claim", claim.LeaseID)
+			return tartInstance{}, "", core.LeaseClaim{}, core.Exit(4, "tart lease %s has no instance name in its claim", claim.LeaseID)
 		}
 		instances, listErr := b.listInstances(ctx)
 		if listErr != nil {
@@ -718,15 +718,15 @@ func (b *backend) resolveInstance(ctx context.Context, identifier string) (tartI
 	if err != nil {
 		return tartInstance{}, "", core.LeaseClaim{}, err
 	}
-	normalized := normalizeLeaseSlug(identifier)
+	normalized := core.NormalizeLeaseSlug(identifier)
 	for _, inst := range instances {
 		claim := claims[inst.Name]
-		if inst.Name == identifier || claim.LeaseID == identifier || (normalized != "" && normalizeLeaseSlug(claim.Slug) == normalized) {
+		if inst.Name == identifier || claim.LeaseID == identifier || (normalized != "" && core.NormalizeLeaseSlug(claim.Slug) == normalized) {
 			ip := b.getIP(ctx, inst.Name)
 			return inst, ip, claim, nil
 		}
 	}
-	return tartInstance{}, "", core.LeaseClaim{}, exit(4, "tart lease not found: %s", identifier)
+	return tartInstance{}, "", core.LeaseClaim{}, core.Exit(4, "tart lease not found: %s", identifier)
 }
 
 func (b *backend) getIP(ctx context.Context, name string) string {
@@ -741,7 +741,7 @@ func (b *backend) getIP(ctx context.Context, name string) string {
 	return ip
 }
 
-func (b *backend) prepareLease(ctx context.Context, cfg Config, inst tartInstance, ip string, claim core.LeaseClaim, wait bool) (LeaseTarget, error) {
+func (b *backend) prepareLease(ctx context.Context, cfg core.Config, inst tartInstance, ip string, claim core.LeaseClaim, wait bool) (core.LeaseTarget, error) {
 	server := b.serverFromInstance(inst, claim, cfg)
 	if user := strings.TrimSpace(server.Labels["ssh_user"]); user != "" && validPOSIXUser.MatchString(user) {
 		cfg.Tart.User = user
@@ -755,35 +755,35 @@ func (b *backend) prepareLease(ctx context.Context, cfg Config, inst tartInstanc
 		if !instanceRunning(inst.State) {
 			server.Status = inst.State
 			server.Labels["state"] = tartState(inst.State)
-			return LeaseTarget{Server: server, LeaseID: claim.LeaseID}, nil
+			return core.LeaseTarget{Server: server, LeaseID: claim.LeaseID}, nil
 		}
-		return LeaseTarget{}, exit(5, "tart instance %s has no IP address", inst.Name)
+		return core.LeaseTarget{}, core.Exit(5, "tart instance %s has no IP address", inst.Name)
 	}
 	server.PublicNet.IPv4.IP = ip
 	if claim.LeaseID != "" {
-		keyPath, err := testboxKeyPath(claim.LeaseID)
+		keyPath, err := core.TestboxKeyPath(claim.LeaseID)
 		if err == nil {
 			if _, statErr := os.Stat(keyPath); statErr == nil {
 				cfg.SSHKey = keyPath
 			}
 		}
 	}
-	target := sshTargetFromConfig(cfg, ip)
+	target := core.SSHTargetFromConfig(cfg, ip)
 	target.Port = sshPort
 	target.FallbackPorts = []string{}
 	target.ReadyCheck = "uname -s && test -d ~"
 	target.SSHConfigProxy = true
 	if wait {
-		if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "tart ssh", bootstrapWaitTimeout(cfg)); err != nil {
-			return LeaseTarget{}, err
+		if err := core.WaitForSSHReady(ctx, &target, b.rt.Stderr, "tart ssh", core.BootstrapWaitTimeout(cfg)); err != nil {
+			return core.LeaseTarget{}, err
 		}
 		server.Status = "ready"
 		server.Labels["state"] = "ready"
 	}
-	return LeaseTarget{Server: server, SSH: target, LeaseID: claim.LeaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: claim.LeaseID}, nil
 }
 
-func (b *backend) serverFromInstance(inst tartInstance, claim core.LeaseClaim, cfg Config) Server {
+func (b *backend) serverFromInstance(inst tartInstance, claim core.LeaseClaim, cfg core.Config) core.Server {
 	labels := map[string]string{}
 	for key, value := range claim.Labels {
 		labels[key] = value
@@ -824,7 +824,7 @@ func (b *backend) serverFromInstance(inst tartInstance, claim core.LeaseClaim, c
 	if instanceRunning(inst.State) && labels["state"] == "ready" {
 		status = "ready"
 	}
-	server := Server{
+	server := core.Server{
 		CloudID:     inst.Name,
 		ImmutableID: claim.CloudImmutableID,
 		Provider:    providerName,
@@ -837,7 +837,7 @@ func (b *backend) serverFromInstance(inst tartInstance, claim core.LeaseClaim, c
 }
 
 func providerClaims() (map[string]core.LeaseClaim, error) {
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return nil, err
 	}
@@ -878,7 +878,7 @@ func instanceNameFromScope(scope string) string {
 	return strings.TrimPrefix(scope, "instance:")
 }
 
-func shouldCleanup(server Server, claim core.LeaseClaim, hasClaim bool, now time.Time) (bool, string) {
+func shouldCleanup(server core.Server, claim core.LeaseClaim, hasClaim bool, now time.Time) (bool, string) {
 	if strings.EqualFold(server.Labels["keep"], "true") {
 		return false, "keep=true"
 	}
@@ -905,12 +905,12 @@ func shouldCleanup(server Server, claim core.LeaseClaim, hasClaim bool, now time
 	return false, "missing claim"
 }
 
-func (b *backend) tart(ctx context.Context, args []string, stdout, stderr io.Writer) (LocalCommandResult, error) {
+func (b *backend) tart(ctx context.Context, args []string, stdout, stderr io.Writer) (core.LocalCommandResult, error) {
 	env, err := tartEnvironment()
 	if err != nil {
-		return LocalCommandResult{}, err
+		return core.LocalCommandResult{}, err
 	}
-	return b.rt.Exec.Run(ctx, LocalCommandRequest{
+	return b.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name:   "tart",
 		Args:   args,
 		Env:    env,

--- a/internal/providers/tart/cleanup_ownership_test.go
+++ b/internal/providers/tart/cleanup_ownership_test.go
@@ -288,7 +288,7 @@ func TestTartOwnershipMarkerCannotAdoptOrFollowSymlinks(t *testing.T) {
 
 func TestCleanupFencesClaimThroughDeleteAndRetainsKey(t *testing.T) {
 	b, runner, claim := cleanupFixture(t)
-	key, err := testboxKeyPath(cleanupLease)
+	key, err := core.TestboxKeyPath(cleanupLease)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/tart/core.go
+++ b/internal/providers/tart/core.go
@@ -1,32 +1,10 @@
 package tart
 
 import (
-	"context"
-
-	"io"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type TartConfig = core.TartConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
 
 const (
 	providerName                 = "tart"
@@ -34,67 +12,3 @@ const (
 	sshPort                      = "22"
 	defaultStartupObserveTimeout = 2 * time.Second
 )
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func leaseProviderName(leaseID, slug string) string {
-	return core.LeaseProviderName(leaseID, slug)
-}
-
-func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (string, error) {
-	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep bool, now time.Time) map[string]string {
-	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
-}
-
-func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, now time.Time) map[string]string {
-	return core.TouchDirectLeaseLabels(labels, cfg, state, now)
-}
-
-func claimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
-}
-
-func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaimForProvider(identifier, provider)
-}
-
-func listLeaseClaims() ([]core.LeaseClaim, error) {
-	return core.ListLeaseClaims()
-}
-
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
-func ensureTestboxKeyForConfig(cfg Config, leaseID string) (string, string, error) {
-	return core.EnsureTestboxKeyForConfig(cfg, leaseID)
-}
-
-func testboxKeyPath(leaseID string) (string, error) {
-	return core.TestboxKeyPath(leaseID)
-}
-
-func removeStoredTestboxKey(leaseID string) {
-	core.RemoveStoredTestboxKey(leaseID)
-}
-
-func sshTargetFromConfig(cfg Config, host string) SSHTarget {
-	return core.SSHTargetFromConfig(cfg, host)
-}
-
-func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
-	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
-}
-
-func bootstrapWaitTimeout(cfg Config) time.Duration {
-	return core.BootstrapWaitTimeout(cfg)
-}

--- a/internal/providers/tart/flags.go
+++ b/internal/providers/tart/flags.go
@@ -42,21 +42,21 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	}
 	if core.FlagWasSet(fs, "tart-cpu") {
 		if *v.CPUs < 4 {
-			return exit(2, "--tart-cpu must be at least 4 (got %d)", *v.CPUs)
+			return core.Exit(2, "--tart-cpu must be at least 4 (got %d)", *v.CPUs)
 		}
 		cfg.Tart.CPUs = *v.CPUs
 		core.RecordProviderFlagInputs(cfg, true, providerName)
 	}
 	if core.FlagWasSet(fs, "tart-memory") {
 		if *v.Memory < 4096 {
-			return exit(2, "--tart-memory must be at least 4096 MB (got %d)", *v.Memory)
+			return core.Exit(2, "--tart-memory must be at least 4096 MB (got %d)", *v.Memory)
 		}
 		cfg.Tart.Memory = *v.Memory
 		core.RecordProviderFlagInputs(cfg, true, providerName)
 	}
 	if core.FlagWasSet(fs, "tart-disk") {
 		if *v.Disk < 0 {
-			return exit(2, "--tart-disk must be non-negative (got %d)", *v.Disk)
+			return core.Exit(2, "--tart-disk must be non-negative (got %d)", *v.Disk)
 		}
 		cfg.Tart.Disk = *v.Disk
 		core.RecordProviderFlagInputs(cfg, true, providerName)
@@ -66,19 +66,19 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	}
 	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if core.IsTargetExplicit(cfg) && cfg.TargetOS != targetMacOS {
-			return exit(2, "provider=%s supports target=%s only (got %s)", providerName, targetMacOS, cfg.TargetOS)
+			return core.Exit(2, "provider=%s supports target=%s only (got %s)", providerName, targetMacOS, cfg.TargetOS)
 		}
 		if !core.IsTargetExplicit(cfg) && cfg.TargetOS == "linux" {
 			cfg.TargetOS = targetMacOS
 		}
 		if cfg.Tart.CPUs < 0 || (cfg.Tart.CPUs > 0 && cfg.Tart.CPUs < 4) || (cfg.Tart.CPUs == 0 && core.IsTartCPUsExplicit(cfg)) {
-			return exit(2, "tart cpu count must be at least 4 (got %d)", cfg.Tart.CPUs)
+			return core.Exit(2, "tart cpu count must be at least 4 (got %d)", cfg.Tart.CPUs)
 		}
 		if cfg.Tart.Memory < 0 || (cfg.Tart.Memory > 0 && cfg.Tart.Memory < 4096) || (cfg.Tart.Memory == 0 && core.IsTartMemoryExplicit(cfg)) {
-			return exit(2, "tart memory must be at least 4096 MB (got %d)", cfg.Tart.Memory)
+			return core.Exit(2, "tart memory must be at least 4096 MB (got %d)", cfg.Tart.Memory)
 		}
 		if cfg.Tart.Disk < 0 {
-			return exit(2, "tart disk size must be non-negative (got %d)", cfg.Tart.Disk)
+			return core.Exit(2, "tart disk size must be non-negative (got %d)", cfg.Tart.Disk)
 		}
 		if err := validateTartEnvInt("CRABBOX_TART_CPUS", 4, "tart cpu count must be at least 4"); err != nil {
 			return err
@@ -101,10 +101,10 @@ func validateTartEnvInt(name string, floor int, floorMsg string) error {
 	}
 	n, err := strconv.Atoi(v)
 	if err != nil {
-		return exit(2, "%s must be a valid integer (got %q)", name, v)
+		return core.Exit(2, "%s must be a valid integer (got %q)", name, v)
 	}
 	if n < floor {
-		return exit(2, "%s (got %d)", floorMsg, n)
+		return core.Exit(2, "%s (got %d)", floorMsg, n)
 	}
 	return nil
 }

--- a/internal/providers/tart/process_unix_test.go
+++ b/internal/providers/tart/process_unix_test.go
@@ -612,7 +612,7 @@ func processFileDescriptors(t *testing.T) map[int]uint64 {
 }
 
 type acquisitionResult struct {
-	lease LeaseTarget
+	lease core.LeaseTarget
 	err   error
 	done  chan struct{}
 }
@@ -654,7 +654,7 @@ func (f *processFixture) assertFailedAcquisitionCleaned(t *testing.T, child proc
 	if err != nil || len(keys) != 0 {
 		t.Fatalf("failed-acquisition keys=%v err=%v", keys, err)
 	}
-	claims, err := listLeaseClaims()
+	claims, err := core.ListLeaseClaims()
 	if err != nil || len(claims) != 0 {
 		t.Fatalf("failed-acquisition claims=%v err=%v", claims, err)
 	}
@@ -769,7 +769,7 @@ func TestAcquireStartupSuccessLifetime(t *testing.T) {
 			if result.err != nil {
 				t.Fatal(result.err)
 			}
-			claims, err := listLeaseClaims()
+			claims, err := core.ListLeaseClaims()
 			if err != nil || len(claims) != 1 || claims[0].LeaseID != result.lease.LeaseID || claims[0].CloudImmutableID == "" {
 				t.Fatalf("claim=%+v err=%v", claims, err)
 			}

--- a/internal/providers/tart/provider_test.go
+++ b/internal/providers/tart/provider_test.go
@@ -298,14 +298,14 @@ func TestInstanceScopeRoundTrip(t *testing.T) {
 }
 
 func TestShouldCleanupRespectsKeepLabel(t *testing.T) {
-	server := Server{Status: "stopped", Labels: map[string]string{"keep": "true"}}
+	server := core.Server{Status: "stopped", Labels: map[string]string{"keep": "true"}}
 	if ok, reason := shouldCleanup(server, core.LeaseClaim{}, true, time.Now()); ok || reason != "keep=true" {
 		t.Fatalf("cleanup=%v reason=%s", ok, reason)
 	}
 }
 
 func TestShouldCleanupExpiredClaim(t *testing.T) {
-	server := Server{Status: "running", Labels: map[string]string{}}
+	server := core.Server{Status: "running", Labels: map[string]string{}}
 	claim := core.LeaseClaim{LeaseID: "cbx_123", LastUsedAt: time.Now().Add(-48 * time.Hour).Format(time.RFC3339), IdleTimeoutSeconds: int((30 * time.Minute).Seconds())}
 	if ok, reason := shouldCleanup(server, claim, true, time.Now()); !ok || reason != "claim expired" {
 		t.Fatalf("cleanup=%v reason=%s", ok, reason)
@@ -313,7 +313,7 @@ func TestShouldCleanupExpiredClaim(t *testing.T) {
 }
 
 func TestShouldCleanupSkipsMissingClaim(t *testing.T) {
-	server := Server{Status: "running", Labels: map[string]string{}}
+	server := core.Server{Status: "running", Labels: map[string]string{}}
 	if ok, reason := shouldCleanup(server, core.LeaseClaim{}, false, time.Now()); ok || reason != "missing claim" {
 		t.Fatalf("cleanup=%v reason=%s", ok, reason)
 	}
@@ -980,7 +980,7 @@ func TestConfigureVMSkipsZeroCPUAndMemory(t *testing.T) {
 }
 
 func TestShouldCleanupStoppedInstance(t *testing.T) {
-	server := Server{Status: "stopped", Labels: map[string]string{}}
+	server := core.Server{Status: "stopped", Labels: map[string]string{}}
 	ok, reason := shouldCleanup(server, core.LeaseClaim{}, true, time.Now())
 	if !ok || reason != "instance state=stopped" {
 		t.Fatalf("cleanup=%v reason=%q, want true/instance state=stopped", ok, reason)
@@ -988,7 +988,7 @@ func TestShouldCleanupStoppedInstance(t *testing.T) {
 }
 
 func TestShouldCleanupZeroIdleTimeout(t *testing.T) {
-	server := Server{Status: "running", Labels: map[string]string{}}
+	server := core.Server{Status: "running", Labels: map[string]string{}}
 	claim := core.LeaseClaim{
 		LeaseID:            "cbx_123",
 		LastUsedAt:         time.Now().Add(-48 * time.Hour).Format(time.RFC3339),
@@ -1031,7 +1031,7 @@ func TestConfigureVMSkipsExplicitZeroDisk(t *testing.T) {
 }
 
 func TestShouldCleanupGracePeriodNotExpired(t *testing.T) {
-	server := Server{Status: "running", Labels: map[string]string{}}
+	server := core.Server{Status: "running", Labels: map[string]string{}}
 	now := time.Now()
 	claim := core.LeaseClaim{
 		LeaseID:            "cbx_123",
@@ -1576,7 +1576,7 @@ func TestCleanupRemovesOrphanedClaimsWithoutDeletingStoredKey(t *testing.T) {
 	if err := os.RemoveAll(filepath.Join(os.Getenv("TART_HOME"), "vms", "crabbox-gone-9999")); err != nil {
 		t.Fatal(err)
 	}
-	keyPath, err := testboxKeyPath(leaseID)
+	keyPath, err := core.TestboxKeyPath(leaseID)
 	if err != nil {
 		t.Fatalf("testbox key path: %v", err)
 	}
@@ -2425,7 +2425,7 @@ func TestReleaseLeasePrunesMissingResolvedInstance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setup claim: %v", err)
 	}
-	keyPath, err := testboxKeyPath("cbx_missingrel")
+	keyPath, err := core.TestboxKeyPath("cbx_missingrel")
 	if err != nil {
 		t.Fatalf("testbox key path: %v", err)
 	}
@@ -2461,7 +2461,7 @@ func TestReleaseLeasePrunesMissingResolvedInstance(t *testing.T) {
 			t.Fatal("ReleaseLease should not delete an already-missing resolved VM")
 		}
 	}
-	if _, ok, err := resolveLeaseClaimForProvider("cbx_missingrel", providerName); err != nil {
+	if _, ok, err := core.ResolveLeaseClaimForProvider("cbx_missingrel", providerName); err != nil {
 		t.Fatalf("resolve claim: %v", err)
 	} else if ok {
 		t.Fatal("ReleaseLease should prune the stale claim")
@@ -2479,7 +2479,7 @@ func TestReleaseLeasePrunesAlreadyResolvedMissingInstance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setup claim: %v", err)
 	}
-	keyPath, err := testboxKeyPath("cbx_resolvedmissing")
+	keyPath, err := core.TestboxKeyPath("cbx_resolvedmissing")
 	if err != nil {
 		t.Fatalf("testbox key path: %v", err)
 	}
@@ -2514,7 +2514,7 @@ func TestReleaseLeasePrunesAlreadyResolvedMissingInstance(t *testing.T) {
 	if len(runner.calls) != 0 {
 		t.Fatalf("ReleaseLease should not call tart for already-resolved missing instance, calls=%v", runner.calls)
 	}
-	if _, ok, err := resolveLeaseClaimForProvider("cbx_resolvedmissing", providerName); err != nil {
+	if _, ok, err := core.ResolveLeaseClaimForProvider("cbx_resolvedmissing", providerName); err != nil {
 		t.Fatalf("resolve claim: %v", err)
 	} else if ok {
 		t.Fatal("ReleaseLease should prune the stale claim")
@@ -3738,7 +3738,7 @@ func TestApplyFlagsConfigMemoryZeroWithExplicit(t *testing.T) {
 }
 
 func TestShouldCleanupUnparseableLastUsedAt(t *testing.T) {
-	server := Server{
+	server := core.Server{
 		Status: "running",
 		Labels: map[string]string{"state": "ready"},
 	}
@@ -3757,7 +3757,7 @@ func TestShouldCleanupUnparseableLastUsedAt(t *testing.T) {
 }
 
 func TestShouldCleanupZeroLastUsedAt(t *testing.T) {
-	server := Server{
+	server := core.Server{
 		Status: "running",
 		Labels: map[string]string{"state": "ready"},
 	}
@@ -3786,9 +3786,9 @@ func TestReleaseLeaseMessageFormat(t *testing.T) {
 	runner := &recordingRunner{}
 	cfg := core.BaseConfig()
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
-	lease := LeaseTarget{
+	lease := core.LeaseTarget{
 		LeaseID: "test-lease-id",
-		Server: Server{
+		Server: core.Server{
 			CloudID: "crabbox-test-vm",
 			Labels:  map[string]string{},
 		},
@@ -3806,9 +3806,9 @@ func TestReleaseLeaseMessageNoCloudID(t *testing.T) {
 	runner := &recordingRunner{}
 	cfg := core.BaseConfig()
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
-	lease := LeaseTarget{
+	lease := core.LeaseTarget{
 		LeaseID: "test-lease-id",
-		Server: Server{
+		Server: core.Server{
 			Labels: map[string]string{"instance": "from-labels"},
 		},
 	}
@@ -3822,9 +3822,9 @@ func TestReleaseLeaseMessageEmptyBoth(t *testing.T) {
 	runner := &recordingRunner{}
 	cfg := core.BaseConfig()
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
-	lease := LeaseTarget{
+	lease := core.LeaseTarget{
 		LeaseID: "test-lease-id",
-		Server: Server{
+		Server: core.Server{
 			Labels: map[string]string{},
 		},
 	}
@@ -4074,7 +4074,7 @@ func TestServerFromInstanceSourcePreferred(t *testing.T) {
 }
 
 func TestShouldCleanupNegativeIdleTimeout(t *testing.T) {
-	server := Server{
+	server := core.Server{
 		Status: "running",
 		Labels: map[string]string{"state": "ready"},
 	}
@@ -4090,7 +4090,7 @@ func TestShouldCleanupNegativeIdleTimeout(t *testing.T) {
 }
 
 func TestShouldCleanupNotRunningNotReady(t *testing.T) {
-	server := Server{
+	server := core.Server{
 		Status: "suspended",
 		Labels: map[string]string{"state": "suspended"},
 	}
@@ -4105,7 +4105,7 @@ func TestShouldCleanupNotRunningNotReady(t *testing.T) {
 }
 
 func TestShouldCleanupEmptyStatus(t *testing.T) {
-	server := Server{
+	server := core.Server{
 		Status: "",
 		Labels: map[string]string{},
 	}
@@ -4189,13 +4189,13 @@ func TestInstanceNameFromClaimReturnsEmptyForMissing(t *testing.T) {
 }
 
 func TestNormalizeLeaseSlugEmpty(t *testing.T) {
-	if got := normalizeLeaseSlug(""); got != "" {
+	if got := core.NormalizeLeaseSlug(""); got != "" {
 		t.Fatalf("normalizeLeaseSlug(\"\") = %q", got)
 	}
 }
 
 func TestNormalizeLeaseSlugWithPrefix(t *testing.T) {
-	result := normalizeLeaseSlug("my-slug")
+	result := core.NormalizeLeaseSlug("my-slug")
 	if result == "" {
 		t.Fatal("normalizeLeaseSlug should return non-empty for valid slug")
 	}
@@ -4222,7 +4222,7 @@ func TestInheritedWorkRootCallerContract(t *testing.T) {
 		{"/provider/root", "/srv/custom", "/provider/root"},
 	} {
 		for _, explicit := range []bool{false, true} {
-			cfg := Config{Provider: "prior", WorkRoot: "/recorded/root", SSHUser: "fixture-user", SSHPort: "1234", SSHFallbackPorts: []string{"4567"}, ServerType: "prior-type", Network: "prior-network"}
+			cfg := core.Config{Provider: "prior", WorkRoot: "/recorded/root", SSHUser: "fixture-user", SSHPort: "1234", SSHFallbackPorts: []string{"4567"}, ServerType: "prior-type", Network: "prior-network"}
 			if explicit {
 				core.MarkWorkRootExplicit(&cfg)
 				cfg.TargetOS = "existing-target"

--- a/internal/providers/tart/startup.go
+++ b/internal/providers/tart/startup.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 const startupDiagnosticLimit = 64 << 10
@@ -39,7 +41,7 @@ type startupProcess struct {
 
 func (b *backend) startVM(ctx context.Context, name string, keep bool) (*startupProcess, error) {
 	if err := context.Cause(ctx); err != nil {
-		return nil, errors.Join(exit(2, "tart run %s: context already cancelled: %v", name, err), err)
+		return nil, errors.Join(core.Exit(2, "tart run %s: context already cancelled: %v", name, err), err)
 	}
 	env, err := tartEnvironment()
 	if err != nil {
@@ -47,7 +49,7 @@ func (b *backend) startVM(ctx context.Context, name string, keep bool) (*startup
 	}
 	log, err := os.CreateTemp("", "crabbox-tart-run-*.log")
 	if err != nil {
-		return nil, exit(2, "tart run %s: create startup log: %v", name, err)
+		return nil, core.Exit(2, "tart run %s: create startup log: %v", name, err)
 	}
 	// Files (including nil's /dev/null) avoid exec's copy pipes. A kept VM must
 	// not depend on a reader in Crabbox after a successful acquisition.
@@ -60,7 +62,7 @@ func (b *backend) startVM(ctx context.Context, name string, keep bool) (*startup
 	p := &startupProcess{cmd: cmd, name: name, keep: keep, caller: ctx, ctx: startupCtx, cancel: cancel, log: log, done: make(chan struct{})}
 	if err := cmd.Start(); err != nil {
 		cancel(nil)
-		return nil, errors.Join(exit(2, "tart run %s: %v", name, err), p.closeLog())
+		return nil, errors.Join(core.Exit(2, "tart run %s: %v", name, err), p.closeLog())
 	}
 	go p.reap()
 	if err := p.observe(b.startupObserveTimeout); err != nil {
@@ -81,11 +83,11 @@ func (p *startupProcess) reap() {
 		p.capture()
 		switch {
 		case p.detail != "":
-			p.failure = exit(2, "tart run %s failed during startup: %s", p.name, p.detail)
+			p.failure = core.Exit(2, "tart run %s failed during startup: %s", p.name, p.detail)
 		case err != nil:
-			p.failure = exit(2, "tart run %s failed during startup: %v", p.name, err)
+			p.failure = core.Exit(2, "tart run %s failed during startup: %v", p.name, err)
 		default:
-			p.failure = exit(2, "tart run %s exited unexpectedly during startup", p.name)
+			p.failure = core.Exit(2, "tart run %s exited unexpectedly during startup", p.name)
 		}
 		if !p.stopping {
 			p.cancel(p.failure)
@@ -167,15 +169,15 @@ func (p *startupProcess) abort(readinessErr error) error {
 		killErr = nil
 	}
 	if callerErr := context.Cause(p.caller); callerErr != nil && errors.Is(cause, callerErr) {
-		readinessErr = errors.Join(exit(2, "tart run %s: context cancelled during startup: %v", p.name, callerErr), callerErr)
+		readinessErr = errors.Join(core.Exit(2, "tart run %s: context cancelled during startup: %v", p.name, callerErr), callerErr)
 	}
 	if stoppedByCleanup && p.detail != "" {
 		// The CLI displays ExitError.Message, so a joined diagnostic alone
 		// would disappear there. Preserve both its exit code and original cause.
-		display := exit(1, "%v", readinessErr)
+		display := core.Exit(1, "%v", readinessErr)
 		_ = errors.As(readinessErr, &display)
 		readinessErr = startupStderrError{
-			error: exit(display.Code, "%s\ntart run %s startup stderr: %s", display.Message, p.name, p.detail),
+			error: core.Exit(display.Code, "%s\ntart run %s startup stderr: %s", display.Message, p.name, p.detail),
 			cause: readinessErr,
 		}
 	}

--- a/internal/providers/windowssandbox/backend.go
+++ b/internal/providers/windowssandbox/backend.go
@@ -17,21 +17,21 @@ import (
 )
 
 type backend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
 var windowsSandboxHostOS = runtime.GOOS
 
 const windowsSandboxProcessNames = "WindowsSandbox,WindowsSandboxClient,WindowsSandboxServer,WindowsSandboxRemoteSession"
 
-func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	applyDefaults(&cfg)
 	return &backend{spec: spec, cfg: cfg, rt: rt}
 }
 
-func applyDefaults(cfg *Config) {
+func applyDefaults(cfg *core.Config) {
 	cfg.Provider = providerName
 	if cfg.TargetOS == "" {
 		cfg.TargetOS = targetWindows
@@ -74,36 +74,36 @@ func applyDefaults(cfg *Config) {
 	cfg.WorkRoot = cfg.WindowsSandbox.Workdir
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *backend) configForRun() Config {
+func (b *backend) configForRun() core.Config {
 	cfg := b.cfg
 	applyDefaults(&cfg)
 	return cfg
 }
 
-func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *backend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	_ = ctx
 	_ = req
-	return exit(2, "provider=%s does not support warmup; Windows Sandbox is launched per run", providerName)
+	return core.Exit(2, "provider=%s does not support warmup; Windows Sandbox is launched per run", providerName)
 }
 
-func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *backend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	if err := rejectWindowsSandboxRunOptions(b.spec, req); err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	if len(req.Command) == 0 {
-		return RunResult{}, exit(2, "missing command")
+		return core.RunResult{}, core.Exit(2, "missing command")
 	}
 	if err := requireWindowsHost(); err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 
 	started := core.ClockNow(b.rt.Clock)
 	cfg := b.configForRun()
 	run, syncPhases, syncDuration, err := b.prepareRun(ctx, cfg, req)
 	if err != nil {
-		return RunResult{Total: core.ClockNow(b.rt.Clock).Sub(started), SyncDelegated: true, Provider: providerName}, err
+		return core.RunResult{Total: core.ClockNow(b.rt.Clock).Sub(started), SyncDelegated: true, Provider: providerName}, err
 	}
 	keepWorkspace := req.Keep
 	defer func() {
@@ -116,14 +116,14 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}()
 
 	if req.EnvSummary {
-		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+		core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
 	fmt.Fprintf(b.rt.Stderr, "provider=%s workdir=%s host_workspace=%s networking=%s vgpu=%s\n", providerName, cfg.WindowsSandbox.Workdir, run.hostWorkspace, cfg.WindowsSandbox.Networking, cfg.WindowsSandbox.VGPU)
 
 	commandStarted := core.ClockNow(b.rt.Clock)
 	req.Observation.Phase(core.RunPhaseCommand)
 	stdout, stderr := req.Observation.CommandWriters(b.rt.Stdout, b.rt.Stderr, core.RunOutputProvider)
-	execResult, execErr := b.runHostRunner(ctx, LocalCommandRequest{
+	execResult, execErr := b.runHostRunner(ctx, core.LocalCommandRequest{
 		Name:                 "powershell.exe",
 		Args:                 hostRunnerArgs(run, cfg, req),
 		Stdout:               stdout,
@@ -140,7 +140,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		fmt.Fprintf(b.rt.Stderr, "windows-sandbox temp preserved path=%s policy=%s\n", run.root, keepPolicy(req, exitCode))
 	}
 
-	result := RunResult{
+	result := core.RunResult{
 		ExitCode:      exitCode,
 		Command:       commandDuration,
 		Total:         core.ClockNow(b.rt.Clock).Sub(started),
@@ -149,14 +149,14 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		Slug:          filepath.Base(run.root),
 		CommandText:   windowsSandboxCommandText(req),
 	}
-	result = finalizeRunResult(result, execErr)
+	result = core.FinalizeRunResult(result, execErr)
 	if req.NoSync {
 		fmt.Fprintf(b.rt.Stderr, "windows-sandbox run summary sync_skipped=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
 	} else {
 		fmt.Fprintf(b.rt.Stderr, "windows-sandbox run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
 	}
 	if req.TimingJSON {
-		report := timingReportWithRunResult(timingReport{
+		report := core.TimingReportWithRunResult(core.TimingReport{
 			Provider:      providerName,
 			Slug:          result.Slug,
 			SyncDelegated: true,
@@ -168,39 +168,39 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			ExitCode:      result.ExitCode,
 			Label:         strings.TrimSpace(req.Label),
 		}, result, execErr)
-		if err := writeTimingJSON(b.rt.Stderr, report); err != nil {
+		if err := core.WriteTimingJSON(b.rt.Stderr, report); err != nil {
 			return result, err
 		}
 	}
 	if execErr != nil || result.ExitCode != 0 {
-		return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s run exited %d", providerName, result.ExitCode)}
+		return result, core.ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s run exited %d", providerName, result.ExitCode)}
 	}
 	return result, nil
 }
 
-func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = ctx
 	_ = req
-	return nil, exit(2, "provider=%s does not expose persistent inventory; Windows Sandbox supports one disposable session at a time", providerName)
+	return nil, core.Exit(2, "provider=%s does not expose persistent inventory; Windows Sandbox supports one disposable session at a time", providerName)
 }
 
-func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	_ = ctx
 	_ = req
-	return StatusView{}, exit(2, "provider=%s does not expose persistent status; close the Windows Sandbox window or rerun the command", providerName)
+	return core.StatusView{}, core.Exit(2, "provider=%s does not expose persistent status; close the Windows Sandbox window or rerun the command", providerName)
 }
 
-func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+func (b *backend) Stop(ctx context.Context, req core.StopRequest) error {
 	_ = ctx
 	_ = req
-	return exit(2, "provider=%s stop is not supported; close the Windows Sandbox window", providerName)
+	return core.Exit(2, "provider=%s stop is not supported; close the Windows Sandbox window", providerName)
 }
 
-func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	if err := requireWindowsHost(); err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{
+	result, err := b.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name: "powershell.exe",
 		Args: []string{
 			"-NoProfile",
@@ -215,11 +215,11 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 		if code == 0 {
 			code = 2
 		}
-		return DoctorResult{}, exit(code, "provider=%s doctor failed: %s", providerName, commandDetail(result, err))
+		return core.DoctorResult{}, core.Exit(code, "provider=%s doctor failed: %s", providerName, commandDetail(result, err))
 	}
 	cfg := b.configForRun()
 	msg := fmt.Sprintf("cli=ready control_plane=local sandbox=ready mutation=false runtime=%s networking=%s vgpu=%s workdir=%s", strings.TrimSpace(result.Stdout), cfg.WindowsSandbox.Networking, cfg.WindowsSandbox.VGPU, cfg.WindowsSandbox.Workdir)
-	return DoctorResult{Provider: providerName, Message: msg}, nil
+	return core.DoctorResult{Provider: providerName, Message: msg}, nil
 }
 
 type preparedRun struct {
@@ -230,7 +230,7 @@ type preparedRun struct {
 	hostRunner    string
 }
 
-func (b *backend) prepareRun(ctx context.Context, cfg Config, req RunRequest) (preparedRun, []timingPhase, time.Duration, error) {
+func (b *backend) prepareRun(ctx context.Context, cfg core.Config, req core.RunRequest) (preparedRun, []core.TimingPhase, time.Duration, error) {
 	root, err := os.MkdirTemp(strings.TrimSpace(cfg.WindowsSandbox.TempRoot), "crabbox-wsb-*")
 	if err != nil {
 		return preparedRun{}, nil, 0, fmt.Errorf("create windows-sandbox temp dir: %w", err)
@@ -281,13 +281,13 @@ func (b *backend) prepareRun(ctx context.Context, cfg Config, req RunRequest) (p
 	return run, syncPhases, syncDuration, nil
 }
 
-func (b *backend) syncWorkspace(ctx context.Context, cfg Config, req RunRequest, hostWorkspace string) ([]timingPhase, time.Duration, error) {
+func (b *backend) syncWorkspace(ctx context.Context, cfg core.Config, req core.RunRequest, hostWorkspace string) ([]core.TimingPhase, time.Duration, error) {
 	started := core.ClockNow(b.rt.Clock)
 	if req.NoSync {
 		if err := os.MkdirAll(hostWorkspace, 0o700); err != nil {
 			return nil, 0, fmt.Errorf("create windows-sandbox workspace: %w", err)
 		}
-		return []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}, 0, nil
+		return []core.TimingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}, 0, nil
 	}
 	syncCtx := ctx
 	cancel := func() {}
@@ -296,18 +296,18 @@ func (b *backend) syncWorkspace(ctx context.Context, cfg Config, req RunRequest,
 	}
 	defer cancel()
 
-	excludes, err := syncExcludes(req.Repo.Root, cfg)
+	excludes, err := core.SyncExcludes(req.Repo.Root, cfg)
 	if err != nil {
 		return nil, 0, err
 	}
 	manifestStarted := core.ClockNow(b.rt.Clock)
-	manifest, err := syncManifest(req.Repo.Root, excludes, cfg.Sync.Includes)
+	manifest, err := core.BuildSyncManifestFiltered(req.Repo.Root, excludes, cfg.Sync.Includes)
 	if err != nil {
-		return nil, 0, exit(6, "build sync file list: %v", err)
+		return nil, 0, core.Exit(6, "build sync file list: %v", err)
 	}
 	manifestDuration := core.ClockNow(b.rt.Clock).Sub(manifestStarted)
 	preflightStarted := core.ClockNow(b.rt.Clock)
-	if err := checkSyncPreflight(manifest, cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
+	if err := core.CheckSyncPreflight(manifest, cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
 		return nil, 0, err
 	}
 	preflightDuration := core.ClockNow(b.rt.Clock).Sub(preflightStarted)
@@ -325,7 +325,7 @@ func (b *backend) syncWorkspace(ctx context.Context, cfg Config, req RunRequest,
 	}
 	copyDuration := core.ClockNow(b.rt.Clock).Sub(copyStarted)
 	total := core.ClockNow(b.rt.Clock).Sub(started)
-	return []timingPhase{
+	return []core.TimingPhase{
 		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
 		{Name: "preflight", Ms: preflightDuration.Milliseconds()},
 		{Name: "copy", Ms: copyDuration.Milliseconds()},
@@ -333,7 +333,7 @@ func (b *backend) syncWorkspace(ctx context.Context, cfg Config, req RunRequest,
 	}, total, nil
 }
 
-func copyManifest(ctx context.Context, root, dstRoot string, manifest SyncManifest) error {
+func copyManifest(ctx context.Context, root, dstRoot string, manifest core.SyncManifest) error {
 	for _, rel := range manifest.Files {
 		select {
 		case <-ctx.Done():
@@ -342,7 +342,7 @@ func copyManifest(ctx context.Context, root, dstRoot string, manifest SyncManife
 		}
 		clean := path.Clean(filepath.ToSlash(rel))
 		if clean == "." || path.IsAbs(clean) || strings.HasPrefix(clean, "../") || clean != filepath.ToSlash(rel) {
-			return exit(6, "unsafe sync path %q", rel)
+			return core.Exit(6, "unsafe sync path %q", rel)
 		}
 		src := filepath.Join(root, filepath.FromSlash(clean))
 		dst := filepath.Join(dstRoot, filepath.FromSlash(clean))
@@ -363,7 +363,7 @@ func copyWorkspaceEntry(src, dst, rel string) error {
 	}
 	mode := info.Mode()
 	if mode&os.ModeSymlink != 0 {
-		return exit(6, "provider=%s does not support syncing symlink %q; exclude it or replace it with a regular file before using Windows Sandbox", providerName, filepath.ToSlash(rel))
+		return core.Exit(6, "provider=%s does not support syncing symlink %q; exclude it or replace it with a regular file before using Windows Sandbox", providerName, filepath.ToSlash(rel))
 	}
 	if !mode.IsRegular() {
 		return nil
@@ -387,7 +387,7 @@ func copyWorkspaceEntry(src, dst, rel string) error {
 	return nil
 }
 
-func hostRunnerArgs(run preparedRun, cfg Config, req RunRequest) []string {
+func hostRunnerArgs(run preparedRun, cfg core.Config, req core.RunRequest) []string {
 	timeout := durationSecondsCeil(cfg.TTL)
 	if timeout <= 0 {
 		timeout = 5400
@@ -415,11 +415,11 @@ func hostRunnerArgs(run preparedRun, cfg Config, req RunRequest) []string {
 }
 
 type localCommandOutcome struct {
-	result LocalCommandResult
+	result core.LocalCommandResult
 	err    error
 }
 
-func (b *backend) runHostRunner(ctx context.Context, command LocalCommandRequest, cancelPath string, keepOnCancel bool) (LocalCommandResult, error) {
+func (b *backend) runHostRunner(ctx context.Context, command core.LocalCommandRequest, cancelPath string, keepOnCancel bool) (core.LocalCommandResult, error) {
 	runCtx, cancelRun := context.WithCancel(context.WithoutCancel(ctx))
 	defer cancelRun()
 	done := make(chan localCommandOutcome, 1)
@@ -469,7 +469,7 @@ func (b *backend) runHostRunner(ctx context.Context, command LocalCommandRequest
 func (b *backend) stopCanceledSandbox(ctx context.Context) {
 	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
 	defer cancel()
-	result, err := b.rt.Exec.Run(cleanupCtx, LocalCommandRequest{
+	result, err := b.rt.Exec.Run(cleanupCtx, core.LocalCommandRequest{
 		Name: "powershell.exe",
 		Args: []string{
 			"-NoProfile",
@@ -485,7 +485,7 @@ func (b *backend) stopCanceledSandbox(ctx context.Context) {
 	}
 }
 
-func windowsSandboxConfigXML(cfg Config, run preparedRun) ([]byte, error) {
+func windowsSandboxConfigXML(cfg core.Config, run preparedRun) ([]byte, error) {
 	workdir, err := cleanWindowsSandboxPath(cfg.WindowsSandbox.Workdir)
 	if err != nil {
 		return nil, err
@@ -540,7 +540,7 @@ type wsbLogonCommand struct {
 	Command string `xml:"Command"`
 }
 
-func sandboxRunScript(cfg Config, req RunRequest) (string, error) {
+func sandboxRunScript(cfg core.Config, req core.RunRequest) (string, error) {
 	workdir, err := cleanWindowsSandboxPath(cfg.WindowsSandbox.Workdir)
 	if err != nil {
 		return "", err
@@ -584,9 +584,9 @@ func sandboxRunScript(cfg Config, req RunRequest) (string, error) {
 	}, "\r\n"), nil
 }
 
-func sandboxCommand(req RunRequest) (string, error) {
+func sandboxCommand(req core.RunRequest) (string, error) {
 	if len(req.Command) == 0 {
-		return "", exit(2, "missing command")
+		return "", core.Exit(2, "missing command")
 	}
 	if req.ShellMode {
 		return "& powershell.exe -NoProfile -ExecutionPolicy Bypass -Command " + psSingleQuote(strings.Join(req.Command, " ")), nil
@@ -605,7 +605,7 @@ func powershellEnvLines(env map[string]string) (string, error) {
 	keys := make([]string, 0, len(env))
 	for key := range env {
 		if !core.ValidShellEnvName(key) {
-			return "", exit(2, "invalid environment variable name %q for provider=%s", key, providerName)
+			return "", core.Exit(2, "invalid environment variable name %q for provider=%s", key, providerName)
 		}
 		keys = append(keys, key)
 	}
@@ -767,25 +767,25 @@ while ($true) {
 `, "__SANDBOX_PROCESS_NAMES__", windowsSandboxProcessNames), "\n", "\r\n")
 }
 
-func rejectWindowsSandboxRunOptions(spec ProviderSpec, req RunRequest) error {
-	if err := rejectDelegatedSyncOptionsForSpec(spec, req); err != nil {
+func rejectWindowsSandboxRunOptions(spec core.ProviderSpec, req core.RunRequest) error {
+	if err := core.RejectDelegatedSyncOptionsForSpec(spec, req); err != nil {
 		return err
 	}
 	if req.ID != "" {
-		return exit(2, "provider=%s does not support --id; Windows Sandbox sessions are disposable", providerName)
+		return core.Exit(2, "provider=%s does not support --id; Windows Sandbox sessions are disposable", providerName)
 	}
 	if req.SyncOnly {
-		return exit(2, "provider=%s does not support --sync-only; Windows Sandbox workspaces are created per run", providerName)
+		return core.Exit(2, "provider=%s does not support --sync-only; Windows Sandbox workspaces are created per run", providerName)
 	}
 	if req.Reclaim {
-		return exit(2, "provider=%s does not support --reclaim; Windows Sandbox sessions are disposable", providerName)
+		return core.Exit(2, "provider=%s does not support --reclaim; Windows Sandbox sessions are disposable", providerName)
 	}
 	return nil
 }
 
 func requireWindowsHost() error {
 	if windowsSandboxHostOS != "windows" {
-		return exit(2, "provider=%s requires a Windows host with the Windows Sandbox optional feature enabled", providerName)
+		return core.Exit(2, "provider=%s requires a Windows host with the Windows Sandbox optional feature enabled", providerName)
 	}
 	return nil
 }
@@ -799,7 +799,7 @@ func normalizeWSBState(value, flagName string) (string, error) {
 	case "disable", "disabled", "false", "no", "off":
 		return "Disable", nil
 	default:
-		return "", exit(2, "%s must be enable, disable, or default", flagName)
+		return "", core.Exit(2, "%s must be enable, disable, or default", flagName)
 	}
 }
 
@@ -811,7 +811,7 @@ func normalizeWSBStateBestEffort(value string) string {
 	return normalized
 }
 
-func validateWindowsSandboxConfig(cfg Config) error {
+func validateWindowsSandboxConfig(cfg core.Config) error {
 	checks := map[string]string{
 		"windows-sandbox.networking":         cfg.WindowsSandbox.Networking,
 		"windows-sandbox.vgpu":               cfg.WindowsSandbox.VGPU,
@@ -827,7 +827,7 @@ func validateWindowsSandboxConfig(cfg Config) error {
 		}
 	}
 	if cfg.WindowsSandbox.MemoryMB < 0 {
-		return exit(2, "windows-sandbox.memoryMB must be non-negative")
+		return core.Exit(2, "windows-sandbox.memoryMB must be non-negative")
 	}
 	_, err := cleanWindowsSandboxPath(cfg.WindowsSandbox.Workdir)
 	return err
@@ -836,22 +836,22 @@ func validateWindowsSandboxConfig(cfg Config) error {
 func cleanWindowsSandboxPath(value string) (string, error) {
 	value = strings.TrimSpace(value)
 	if value == "" {
-		return "", exit(2, "windows-sandbox workdir must not be empty")
+		return "", core.Exit(2, "windows-sandbox workdir must not be empty")
 	}
 	if strings.Contains(value, "/") {
 		value = strings.ReplaceAll(value, "/", `\`)
 	}
 	if len(value) < 3 || value[1] != ':' || value[2] != '\\' {
-		return "", exit(2, "windows-sandbox workdir %q must be an absolute Windows path like C:\\crabbox-work", value)
+		return "", core.Exit(2, "windows-sandbox workdir %q must be an absolute Windows path like C:\\crabbox-work", value)
 	}
 	drive := value[0]
 	if !((drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z')) {
-		return "", exit(2, "windows-sandbox workdir %q must start with a Windows drive letter like C:\\crabbox-work", value)
+		return "", core.Exit(2, "windows-sandbox workdir %q must start with a Windows drive letter like C:\\crabbox-work", value)
 	}
 	clean := cleanWindowsPath(value)
 	switch strings.ToUpper(clean) {
 	case `C:\`, `C:\WINDOWS`, `C:\USERS`, `C:\PROGRAM FILES`, `C:\PROGRAM FILES (X86)`:
-		return "", exit(2, "windows-sandbox workdir %q is too broad; choose a dedicated directory", clean)
+		return "", core.Exit(2, "windows-sandbox workdir %q is too broad; choose a dedicated directory", clean)
 	}
 	return clean, nil
 }
@@ -888,11 +888,11 @@ func psBool(value bool) string {
 	return "$false"
 }
 
-func windowsSandboxCommandText(req RunRequest) string {
+func windowsSandboxCommandText(req core.RunRequest) string {
 	return strings.Join(req.Command, " ")
 }
 
-func keepPolicy(req RunRequest, exitCode int) string {
+func keepPolicy(req core.RunRequest, exitCode int) string {
 	if req.Keep {
 		return "keep"
 	}
@@ -902,7 +902,7 @@ func keepPolicy(req RunRequest, exitCode int) string {
 	return "none"
 }
 
-func commandDetail(result LocalCommandResult, err error) string {
+func commandDetail(result core.LocalCommandResult, err error) string {
 	text := strings.TrimSpace(result.Stderr)
 	if text == "" {
 		text = strings.TrimSpace(result.Stdout)

--- a/internal/providers/windowssandbox/backend_test.go
+++ b/internal/providers/windowssandbox/backend_test.go
@@ -34,7 +34,7 @@ func TestProviderSpec(t *testing.T) {
 }
 
 func TestApplyDefaultsSelectsNativeWindowsAndSecureWSBDefaults(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	applyDefaults(&cfg)
 	if cfg.Provider != providerName {
 		t.Fatalf("Provider=%q", cfg.Provider)
@@ -99,7 +99,7 @@ func TestWindowsSandboxConfigXML(t *testing.T) {
 func TestSandboxRunScriptQuotesCommandEnvAndKeepOnFailure(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.WindowsSandbox.Workdir = `C:\work\repo`
-	script, err := sandboxRunScript(cfg, RunRequest{
+	script, err := sandboxRunScript(cfg, core.RunRequest{
 		Command:       []string{"pwsh", "-NoProfile", "-Command", "Write-Output 'hi'"},
 		KeepOnFailure: true,
 		Env: map[string]string{
@@ -214,7 +214,7 @@ func TestGeneratedPowerShellScriptsParse(t *testing.T) {
 		t.Skip("powershell.exe not available")
 	}
 	cfg := core.BaseConfig()
-	sandboxScript, err := sandboxRunScript(cfg, RunRequest{Command: []string{"cmd.exe", "/c", "echo ok"}})
+	sandboxScript, err := sandboxRunScript(cfg, core.RunRequest{Command: []string{"cmd.exe", "/c", "echo ok"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -250,7 +250,7 @@ func TestCleanWindowsSandboxPathUsesWindowsSemantics(t *testing.T) {
 }
 
 func TestRejectWindowsSandboxSyncOnly(t *testing.T) {
-	err := rejectWindowsSandboxRunOptions(Provider{}.Spec(), RunRequest{SyncOnly: true})
+	err := rejectWindowsSandboxRunOptions(Provider{}.Spec(), core.RunRequest{SyncOnly: true})
 	if err == nil || !strings.Contains(err.Error(), "--sync-only") {
 		t.Fatalf("err=%v, want --sync-only rejection", err)
 	}
@@ -265,7 +265,7 @@ func TestCopyManifestRejectsSymlinks(t *testing.T) {
 	if err := os.Symlink("target.txt", filepath.Join(repo, "link.txt")); err != nil {
 		t.Skipf("symlink creation unavailable on this host: %v", err)
 	}
-	err := copyManifest(context.Background(), repo, dst, SyncManifest{Files: []string{"link.txt"}})
+	err := copyManifest(context.Background(), repo, dst, core.SyncManifest{Files: []string{"link.txt"}})
 	if err == nil || !strings.Contains(err.Error(), "does not support syncing symlink") {
 		t.Fatalf("err=%v, want symlink rejection", err)
 	}
@@ -289,7 +289,7 @@ func TestSyncManifestHonorsIncludes(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	manifest, err := syncManifest(repo, core.SyncExcludeRules{}, []string{"keep.txt", "nested/"})
+	manifest, err := core.BuildSyncManifestFiltered(repo, core.SyncExcludeRules{}, []string{"keep.txt", "nested/"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -308,7 +308,7 @@ func TestRunInvokesHostRunnerWithNoSync(t *testing.T) {
 	cfg.WindowsSandbox.TempRoot = t.TempDir()
 	cfg.TTL = 2 * time.Minute
 	be := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner})
-	result, err := be.(*backend).Run(context.Background(), RunRequest{
+	result, err := be.(*backend).Run(context.Background(), core.RunRequest{
 		NoSync:  true,
 		Command: []string{"cmd.exe", "/c", "echo ok"},
 	})
@@ -350,7 +350,7 @@ func TestRunSignalsCancellationAndWaitsForHostCleanup(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		_, err := be.(*backend).Run(ctx, RunRequest{
+		_, err := be.(*backend).Run(ctx, core.RunRequest{
 			NoSync:  true,
 			Command: []string{"cmd.exe", "/c", "timeout /t 30"},
 		})
@@ -392,7 +392,7 @@ func TestRunHostRunnerNormalizesCancellationFallbackExitCode(t *testing.T) {
 	cancelPath := filepath.Join(t.TempDir(), "missing", "cancel.txt")
 	done := make(chan localCommandOutcome, 1)
 	go func() {
-		result, err := be.runHostRunner(ctx, LocalCommandRequest{Name: "powershell.exe"}, cancelPath, true)
+		result, err := be.runHostRunner(ctx, core.LocalCommandRequest{Name: "powershell.exe"}, cancelPath, true)
 		done <- localCommandOutcome{result: result, err: err}
 	}()
 	<-runner.started
@@ -411,12 +411,12 @@ func TestRunKeepsWorkspaceOnFailureWithKeepOnFailure(t *testing.T) {
 	windowsSandboxHostOS = "windows"
 	defer func() { windowsSandboxHostOS = oldOS }()
 
-	runner := &recordingRunner{result: LocalCommandResult{ExitCode: 7}, err: errors.New("exit status 7")}
+	runner := &recordingRunner{result: core.LocalCommandResult{ExitCode: 7}, err: errors.New("exit status 7")}
 	cfg := core.BaseConfig()
 	cfg.WindowsSandbox.TempRoot = t.TempDir()
 	var stderr strings.Builder
 	be := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: &stderr, Exec: runner})
-	result, err := be.(*backend).Run(context.Background(), RunRequest{
+	result, err := be.(*backend).Run(context.Background(), core.RunRequest{
 		NoSync:        true,
 		KeepOnFailure: true,
 		Command:       []string{"cmd.exe", "/c", "exit 7"},
@@ -450,11 +450,11 @@ type recordingRunner struct {
 	name                 string
 	args                 []string
 	disableOutputCapture bool
-	result               LocalCommandResult
+	result               core.LocalCommandResult
 	err                  error
 }
 
-func (r *recordingRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (r *recordingRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	_ = ctx
 	r.name = req.Name
 	r.args = append([]string(nil), req.Args...)
@@ -471,16 +471,16 @@ type cancelOnContextRunner struct {
 	started chan struct{}
 }
 
-func (r *cancelOnContextRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (r *cancelOnContextRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	_ = req
 	close(r.started)
 	<-ctx.Done()
-	return LocalCommandResult{ExitCode: 1}, ctx.Err()
+	return core.LocalCommandResult{ExitCode: 1}, ctx.Err()
 }
 
-func (r *cancelAwareRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (r *cancelAwareRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	if req.Name != "powershell.exe" {
-		return LocalCommandResult{}, nil
+		return core.LocalCommandResult{}, nil
 	}
 	close(r.started)
 	var controlDir string
@@ -494,11 +494,11 @@ func (r *cancelAwareRunner) Run(ctx context.Context, req LocalCommandRequest) (L
 	for {
 		if _, err := os.Stat(cancelPath); err == nil {
 			close(r.observedCancel)
-			return LocalCommandResult{ExitCode: 130}, errors.New("exit status 130")
+			return core.LocalCommandResult{ExitCode: 130}, errors.New("exit status 130")
 		}
 		select {
 		case <-ctx.Done():
-			return LocalCommandResult{ExitCode: 1}, ctx.Err()
+			return core.LocalCommandResult{ExitCode: 1}, ctx.Err()
 		case <-time.After(10 * time.Millisecond):
 		}
 	}

--- a/internal/providers/windowssandbox/core.go
+++ b/internal/providers/windowssandbox/core.go
@@ -1,75 +1,16 @@
 package windowssandbox
 
 import (
-	"io"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type WindowsSandboxConfig = core.WindowsSandboxConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
-type ExitError = core.ExitError
-type SyncManifest = core.SyncManifest
-type timingReport = core.TimingReport
-type timingPhase = core.TimingPhase
 
 const (
 	providerName      = "windows-sandbox"
 	targetWindows     = core.TargetWindows
 	windowsModeNormal = core.WindowsModeNormal
 )
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
-}
-
-func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
-	return core.TimingReportWithRunResult(report, result, err)
-}
-
-func finalizeRunResult(result RunResult, err error) RunResult {
-	return core.FinalizeRunResult(result, err)
-}
-
-func rejectDelegatedSyncOptionsForSpec(spec ProviderSpec, req RunRequest) error {
-	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
-}
-
-func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
-	return core.SyncExcludes(root, cfg)
-}
-
-func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (SyncManifest, error) {
-	return core.BuildSyncManifestFiltered(root, excludes, includes)
-}
-
-func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
-	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
 
 func durationSecondsCeil(duration time.Duration) int {
 	if duration <= 0 {

--- a/internal/providers/windowssandbox/flags.go
+++ b/internal/providers/windowssandbox/flags.go
@@ -118,7 +118,7 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	}
 	if core.FlagWasSet(fs, "windows-sandbox-memory-mb") {
 		if *v.MemoryMB < 0 {
-			return exit(2, "--windows-sandbox-memory-mb must be non-negative")
+			return core.Exit(2, "--windows-sandbox-memory-mb must be non-negative")
 		}
 		cfg.WindowsSandbox.MemoryMB = *v.MemoryMB
 		core.RecordProviderFlagInputs(cfg, true, "windows-sandbox")


### PR DESCRIPTION
Use the shared core API directly in Apple Container, Apple Machine, Multipass, Tart, Hyper-V, Windows Sandbox, Docker Sandbox, and Anthropic Sandbox Runtime. Deleting identity aliases and exact forwarding functions removes 499 net production lines.

Platform operations, provider-bound policies, snapshots, cleanup, and mutable injection hooks keep their existing implementations. The refactoring checks resolved Go symbols and refuses to remove names still referenced by excluded platform files.

Validation: complete tests passed for all eight providers; Windows x64 and ARM64 CLI builds passed with Go 1.26.5 in Crabbox; scoped Autoreview passed. CI is required before merge. No new dependencies or configuration.
