### PR TITLE
refactor(providers): use shared core in compute adapters

### DIFF
--- a/internal/providers/freestyle/backend.go
+++ b/internal/providers/freestyle/backend.go
@@ -16,26 +16,6 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-type Config = core.Config
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type FreestyleConfig = core.FreestyleConfig
-type SyncConfig = core.SyncConfig
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type Server = core.Server
-type Repo = core.Repo
-type ExitError = core.ExitError
-type timingReport = core.TimingReport
-type timingPhase = core.TimingPhase
-
 const (
 	targetLinux   = core.TargetLinux
 	NetworkPublic = core.NetworkPublic
@@ -49,11 +29,11 @@ const (
 
 var freestyleCleanupTimeout = 30 * time.Second
 
-func RegisterFreestyleProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterFreestyleProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterFreestyleConfigFlags(fs, defaults.Freestyle)
 }
 
-func ApplyFreestyleProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyFreestyleProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	v, ok := values.(core.FreestyleConfigFlagValues)
 	if !ok {
 		return nil
@@ -63,22 +43,22 @@ func ApplyFreestyleProviderFlags(cfg *Config, fs *flag.FlagSet, values any) erro
 	return err
 }
 
-func NewFreestyleBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewFreestyleBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = freestyleProvider
 	return &freestyleBackend{spec: spec, cfg: cfg, rt: rt}
 }
 
 type freestyleBackend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
-func (b *freestyleBackend) Spec() ProviderSpec { return b.spec }
+func (b *freestyleBackend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *freestyleBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *freestyleBackend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if req.ActionsRunner {
-		return exit(2, "--actions-runner is not supported for provider=%s", freestyleProvider)
+		return core.Exit(2, "--actions-runner is not supported for provider=%s", freestyleProvider)
 	}
 	started := b.now()
 	client, err := newFreestyleClient(b.cfg, b.rt)
@@ -96,7 +76,7 @@ func (b *freestyleBackend) Warmup(ctx context.Context, req WarmupRequest) error 
 	total := b.now().Sub(started)
 	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
 	if req.TimingJSON {
-		return writeTimingJSON(b.rt.Stderr, timingReport{
+		return core.WriteTimingJSON(b.rt.Stderr, core.TimingReport{
 			Provider: freestyleProvider,
 			LeaseID:  leaseID,
 			Slug:     slug,
@@ -107,7 +87,7 @@ func (b *freestyleBackend) Warmup(ctx context.Context, req WarmupRequest) error 
 	return nil
 }
 
-func (b *freestyleBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *freestyleBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	workspace, workspaceErr := freestyleWorkspacePath(b.cfg)
 	var client freestyleAPI
 	var leaseID, name, slug string
@@ -118,14 +98,14 @@ func (b *freestyleBackend) Run(ctx context.Context, req RunRequest) (RunResult, 
 		Provider: freestyleProvider, Runtime: b.rt, Workdir: workspace,
 		IdleTimeout: b.cfg.IdleTimeout, TTL: b.cfg.TTL, CleanupTimeout: freestyleCleanupTimeout,
 		Preflight: func(context.Context) error {
-			if err := delegatedSyncOptionsError(b.spec, req); err != nil {
+			if err := core.RejectDelegatedSyncOptionsForSpec(b.spec, req); err != nil {
 				return err
 			}
 			if workspaceErr != nil {
 				return workspaceErr
 			}
 			if !req.SyncOnly && (len(req.Command) == 0 || (len(req.Command) == 1 && strings.TrimSpace(req.Command[0]) == "")) {
-				return exit(2, "missing command")
+				return core.Exit(2, "missing command")
 			}
 			var err error
 			client, err = newFreestyleClient(b.cfg, b.rt)
@@ -160,7 +140,7 @@ func (b *freestyleBackend) Run(ctx context.Context, req RunRequest) (RunResult, 
 		NoSync: func(ctx context.Context) error { return b.prepareWorkspace(ctx, client, name, workspace) },
 		Command: func(context.Context) (shared.DelegatedSandboxCommand, error) {
 			if req.EnvSummary {
-				printEnvForwardingSummary(b.rt.Stderr, freestyleProvider, "forwarded", req.Options.EnvAllow, req.Env)
+				core.PrintEnvForwardingSummary(b.rt.Stderr, freestyleProvider, "forwarded", req.Options.EnvAllow, req.Env)
 			}
 			return shared.DelegatedSandboxCommand{Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
 				return b.exec(ctx, client, name, workspace, req.Command, req.ShellMode, req.Env, stdout, stderr)
@@ -170,13 +150,13 @@ func (b *freestyleBackend) Run(ctx context.Context, req RunRequest) (RunResult, 
 			if err := client.DeleteVM(ctx, name); err != nil {
 				return err
 			}
-			removeLeaseClaim(leaseID)
+			core.RemoveLeaseClaim(leaseID)
 			return nil
 		},
 	})
 }
 
-func (b *freestyleBackend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+func (b *freestyleBackend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
 	client, err := newFreestyleClient(b.cfg, b.rt)
 	if err != nil {
 		return nil, err
@@ -185,7 +165,7 @@ func (b *freestyleBackend) List(ctx context.Context, _ ListRequest) ([]LeaseView
 	if err != nil {
 		return nil, freestyleError("list vms", err)
 	}
-	servers := make([]Server, 0, len(vms))
+	servers := make([]core.Server, 0, len(vms))
 	for _, vm := range vms {
 		if !isCrabboxFreestyleSandboxName(vm.Name) {
 			continue
@@ -196,21 +176,21 @@ func (b *freestyleBackend) List(ctx context.Context, _ ListRequest) ([]LeaseView
 }
 
 func (b *freestyleBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
-	servers, err := b.List(ctx, ListRequest{})
+	servers, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
 		return core.DoctorResult{}, err
 	}
 	return core.InventoryDoctorResult(freestyleProvider, len(servers)), nil
 }
 
-func (b *freestyleBackend) Status(ctx context.Context, req StatusRequest) (statusView, error) {
+func (b *freestyleBackend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	client, err := newFreestyleClient(b.cfg, b.rt)
 	if err != nil {
-		return statusView{}, err
+		return core.StatusView{}, err
 	}
 	leaseID, id, err := b.resolveLeaseID(ctx, client, req.ID, "", false)
 	if err != nil {
-		return statusView{}, err
+		return core.StatusView{}, err
 	}
 	deadline := b.now().Add(req.WaitTimeout)
 	if req.WaitTimeout <= 0 {
@@ -219,27 +199,27 @@ func (b *freestyleBackend) Status(ctx context.Context, req StatusRequest) (statu
 	for {
 		vm, err := client.GetVM(ctx, id)
 		if err != nil {
-			return statusView{}, freestyleError("get vm", err)
+			return core.StatusView{}, freestyleError("get vm", err)
 		}
 		view := freestyleStatusView(leaseID, vm)
 		if !req.Wait || view.Ready {
 			return view, nil
 		}
 		if freestyleStatusTerminal(view.State) {
-			return statusView{}, exit(5, "freestyle vm %s entered terminal state %q before becoming ready", id, view.State)
+			return core.StatusView{}, core.Exit(5, "freestyle vm %s entered terminal state %q before becoming ready", id, view.State)
 		}
 		if b.now().After(deadline) {
-			return statusView{}, exit(5, "timed out waiting for vm %s to become ready", id)
+			return core.StatusView{}, core.Exit(5, "timed out waiting for vm %s to become ready", id)
 		}
 		select {
 		case <-ctx.Done():
-			return statusView{}, ctx.Err()
+			return core.StatusView{}, ctx.Err()
 		case <-time.After(2 * time.Second):
 		}
 	}
 }
 
-func (b *freestyleBackend) Stop(ctx context.Context, req StopRequest) error {
+func (b *freestyleBackend) Stop(ctx context.Context, req core.StopRequest) error {
 	client, err := newFreestyleClient(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -254,12 +234,12 @@ func (b *freestyleBackend) Stop(ctx context.Context, req StopRequest) error {
 	if err := client.DeleteVM(ctx, id); err != nil {
 		return freestyleError("delete vm", err)
 	}
-	removeLeaseClaim(leaseID)
+	core.RemoveLeaseClaim(leaseID)
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, id)
 	return nil
 }
 
-func (b *freestyleBackend) createSandbox(ctx context.Context, client freestyleAPI, repo Repo, reclaim bool, requestedSlug string) (string, string, string, error) {
+func (b *freestyleBackend) createSandbox(ctx context.Context, client freestyleAPI, repo core.Repo, reclaim bool, requestedSlug string) (string, string, string, error) {
 	if _, err := freestyleRelativeWorkdir(b.cfg); err != nil {
 		return "", "", "", err
 	}
@@ -282,10 +262,10 @@ func (b *freestyleBackend) createSandbox(ctx context.Context, client freestyleAP
 		return "", "", "", freestyleError("create vm", err)
 	}
 	if vm.ID == "" {
-		return "", "", "", exit(5, "freestyle create vm returned no id")
+		return "", "", "", core.Exit(5, "freestyle create vm returned no id")
 	}
 	leaseID := freestyleLeasePrefix + vm.ID
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return "", "", "", b.rollbackCreatedVM(client, vm.ID, err)
 	}
@@ -308,7 +288,7 @@ func (b *freestyleBackend) rollbackCreatedVM(client freestyleAPI, vmID string, c
 }
 
 func freestyleAdoptCommand(leaseID string) string {
-	return fmt.Sprintf("crabbox run --provider %s --id %s --reclaim --no-sync -- true", freestyleProvider, shellQuote(leaseID))
+	return fmt.Sprintf("crabbox run --provider %s --id %s --reclaim --no-sync -- true", freestyleProvider, core.ShellQuote(leaseID))
 }
 
 func deleteFreestyleVMForCleanup(client freestyleAPI, vmID string) error {
@@ -318,21 +298,21 @@ func deleteFreestyleVMForCleanup(client freestyleAPI, vmID string) error {
 }
 
 func freestyleCleanupCommand(leaseID string) string {
-	return fmt.Sprintf("crabbox stop --provider %s --id %s", freestyleProvider, shellQuote(leaseID))
+	return fmt.Sprintf("crabbox stop --provider %s --id %s", freestyleProvider, core.ShellQuote(leaseID))
 }
 
 func (b *freestyleBackend) exec(ctx context.Context, client freestyleAPI, id, workdir string, command []string, shellMode bool, env map[string]string, stdout, stderr io.Writer) (int, error) {
 	execCommand := freestyleExecCommand(command, shellMode)
 	parts := make([]string, 0, 3)
 	if workdir != "" {
-		parts = append(parts, "cd "+shellQuote(workdir))
+		parts = append(parts, "cd "+core.ShellQuote(workdir))
 	}
 	if envCommand := freestyleEnvExportCommand(env); envCommand != "" {
 		parts = append(parts, envCommand)
 	}
 	parts = append(parts, execCommand)
 	fullCommand := strings.Join(parts, " && ")
-	return client.Exec(ctx, id, "bash -lc "+shellQuote(fullCommand), stdout, stderr)
+	return client.Exec(ctx, id, "bash -lc "+core.ShellQuote(fullCommand), stdout, stderr)
 }
 
 func freestyleEnvExportCommand(env map[string]string) string {
@@ -355,7 +335,7 @@ func freestyleEnvExportCommand(env map[string]string) string {
 		b.WriteByte(' ')
 		b.WriteString(name)
 		b.WriteByte('=')
-		b.WriteString(shellQuote(env[name]))
+		b.WriteString(core.ShellQuote(env[name]))
 	}
 	return b.String()
 }
@@ -367,20 +347,20 @@ func freestyleExecCommand(command []string, shellMode bool) string {
 	if shellMode {
 		return strings.Join(command, " ")
 	}
-	if len(command) == 1 && shouldUseShell(command) {
+	if len(command) == 1 && core.ShouldUseShell(command) {
 		return command[0]
 	}
-	if shouldUseShell(command) || leadingEnvAssignment(command) {
-		return shellScriptFromArgv(command)
+	if core.ShouldUseShell(command) || core.LeadingEnvAssignment(command) {
+		return core.ShellScriptFromArgv(command)
 	}
-	return strings.Join(shellWords(command), " ")
+	return strings.Join(core.ShellWords(command), " ")
 }
 
 func (b *freestyleBackend) resolveLeaseID(ctx context.Context, client freestyleAPI, id, repoRoot string, reclaim bool) (string, string, error) {
 	if id == "" {
-		return "", "", exit(2, "provider=freestyle requires a Crabbox-created vm name, lease id, or slug")
+		return "", "", core.Exit(2, "provider=freestyle requires a Crabbox-created vm name, lease id, or slug")
 	}
-	if claim, ok, err := resolveLeaseClaim(id); err != nil {
+	if claim, ok, err := core.ResolveLeaseClaim(id); err != nil {
 		return "", "", err
 	} else if ok && claim.Provider == freestyleProvider {
 		if repoRoot != "" {
@@ -396,7 +376,7 @@ func (b *freestyleBackend) resolveLeaseID(ctx context.Context, client freestyleA
 	if strings.HasPrefix(leaseID, freestyleLeasePrefix) {
 		vmID = strings.TrimPrefix(leaseID, freestyleLeasePrefix)
 		if vmID == "" {
-			return "", "", exit(4, "freestyle vm %q is not claimed by Crabbox", id)
+			return "", "", core.Exit(4, "freestyle vm %q is not claimed by Crabbox", id)
 		}
 		var err error
 		vm, err = client.GetVM(ctx, vmID)
@@ -408,28 +388,28 @@ func (b *freestyleBackend) resolveLeaseID(ctx context.Context, client freestyleA
 		if err != nil {
 			return "", "", freestyleError("list vms", err)
 		}
-		normalizedID := normalizeLeaseSlug(id)
+		normalizedID := core.NormalizeLeaseSlug(id)
 		for _, candidate := range vms {
 			if !isCrabboxFreestyleSandboxName(candidate.Name) {
 				continue
 			}
 			candidateLeaseID := freestyleLeasePrefix + candidate.ID
-			if candidate.ID != id && candidate.Name != id && newLeaseSlug(candidateLeaseID) != normalizedID {
+			if candidate.ID != id && candidate.Name != id && core.NewLeaseSlug(candidateLeaseID) != normalizedID {
 				continue
 			}
 			if vmID != "" {
-				return "", "", exit(4, "freestyle identifier %q is ambiguous", id)
+				return "", "", core.Exit(4, "freestyle identifier %q is ambiguous", id)
 			}
 			vm = candidate
 			vmID = candidate.ID
 			leaseID = candidateLeaseID
 		}
 		if vmID == "" {
-			return "", "", exit(4, "freestyle vm %q is not claimed by Crabbox; use an id, name, slug, or claimed lease from `crabbox list --provider freestyle`", id)
+			return "", "", core.Exit(4, "freestyle vm %q is not claimed by Crabbox; use an id, name, slug, or claimed lease from `crabbox list --provider freestyle`", id)
 		}
 	}
 	if !isCrabboxFreestyleSandboxName(vm.Name) {
-		return "", "", exit(4, "freestyle vm %q is not claimed by Crabbox", id)
+		return "", "", core.Exit(4, "freestyle vm %q is not claimed by Crabbox", id)
 	}
 	if repoRoot != "" {
 		claim, ok, err := resolveExactFreestyleLeaseClaim(leaseID)
@@ -441,8 +421,8 @@ func (b *freestyleBackend) resolveLeaseID(ctx context.Context, client freestyleA
 				return "", "", err
 			}
 		} else if !reclaim {
-			return "", "", exit(4, "freestyle vm %q has no exact local claim; use --reclaim to adopt it before reuse", id)
-		} else if err := claimLeaseForRepoProviderPond(leaseID, newLeaseSlug(leaseID), freestyleProvider, b.cfg.Pond, repoRoot, b.cfg.IdleTimeout, true); err != nil {
+			return "", "", core.Exit(4, "freestyle vm %q has no exact local claim; use --reclaim to adopt it before reuse", id)
+		} else if err := claimLeaseForRepoProviderPond(leaseID, core.NewLeaseSlug(leaseID), freestyleProvider, b.cfg.Pond, repoRoot, b.cfg.IdleTimeout, true); err != nil {
 			return "", "", err
 		}
 	}
@@ -450,7 +430,7 @@ func (b *freestyleBackend) resolveLeaseID(ctx context.Context, client freestyleA
 }
 
 func resolveExactFreestyleLeaseClaim(leaseID string) (core.LeaseClaim, bool, error) {
-	claim, ok, err := resolveLeaseClaim(leaseID)
+	claim, ok, err := core.ResolveLeaseClaim(leaseID)
 	if err != nil {
 		return claim, ok, err
 	}
@@ -464,15 +444,15 @@ func requireFreestyleLeaseClaim(leaseID string) error {
 	if _, ok, err := resolveExactFreestyleLeaseClaim(leaseID); err != nil {
 		return err
 	} else if !ok {
-		return exit(4, "freestyle lease %q has no exact local claim; adopt it with an explicit --reclaim reuse before stop", leaseID)
+		return core.Exit(4, "freestyle lease %q has no exact local claim; adopt it with an explicit --reclaim reuse before stop", leaseID)
 	}
 	return nil
 }
 
-func freestyleVMToServer(vm freestyleVM) Server {
+func freestyleVMToServer(vm freestyleVM) core.Server {
 	leaseID := freestyleLeasePrefix + vm.ID
 	labels := applyFreestyleClaimLabels(leaseID, vm)
-	return Server{
+	return core.Server{
 		Provider: freestyleProvider,
 		CloudID:  vm.ID,
 		Name:     vm.Name,
@@ -481,15 +461,15 @@ func freestyleVMToServer(vm freestyleVM) Server {
 	}
 }
 
-func freestyleStatusView(leaseID string, vm freestyleVM) statusView {
+func freestyleStatusView(leaseID string, vm freestyleVM) core.StatusView {
 	labels := map[string]string{
 		"provider": freestyleProvider,
 		"lease":    leaseID,
-		"slug":     newLeaseSlug(leaseID),
+		"slug":     core.NewLeaseSlug(leaseID),
 		"state":    vm.State,
 	}
 	applyFreestyleClaimMetadata(labels, leaseID)
-	return statusView{
+	return core.StatusView{
 		ID:         leaseID,
 		Slug:       labels["slug"],
 		Provider:   freestyleProvider,
@@ -507,7 +487,7 @@ func applyFreestyleClaimLabels(leaseID string, vm freestyleVM) map[string]string
 	labels := map[string]string{
 		"provider": freestyleProvider,
 		"lease":    leaseID,
-		"slug":     newLeaseSlug(leaseID),
+		"slug":     core.NewLeaseSlug(leaseID),
 		"target":   targetLinux,
 		"state":    vm.State,
 	}
@@ -516,12 +496,12 @@ func applyFreestyleClaimLabels(leaseID string, vm freestyleVM) map[string]string
 }
 
 func applyFreestyleClaimMetadata(labels map[string]string, leaseID string) {
-	claim, ok, err := resolveLeaseClaim(leaseID)
+	claim, ok, err := core.ResolveLeaseClaim(leaseID)
 	if err != nil || !ok || claim.Provider != freestyleProvider {
 		return
 	}
 	if strings.TrimSpace(claim.Slug) != "" {
-		labels["slug"] = normalizeLeaseSlug(claim.Slug)
+		labels["slug"] = core.NormalizeLeaseSlug(claim.Slug)
 	}
 	if strings.TrimSpace(claim.Pond) != "" {
 		labels["pond"] = claim.Pond
@@ -529,10 +509,10 @@ func applyFreestyleClaimMetadata(labels map[string]string, leaseID string) {
 }
 
 func freestyleClaimSlug(leaseID string) string {
-	if claim, ok, err := resolveLeaseClaim(leaseID); err == nil && ok && claim.Provider == freestyleProvider && strings.TrimSpace(claim.Slug) != "" {
+	if claim, ok, err := core.ResolveLeaseClaim(leaseID); err == nil && ok && claim.Provider == freestyleProvider && strings.TrimSpace(claim.Slug) != "" {
 		return claim.Slug
 	}
-	return newLeaseSlug(leaseID)
+	return core.NewLeaseSlug(leaseID)
 }
 
 func freestyleStatusReady(status string) bool {
@@ -548,8 +528,8 @@ func freestyleStatusTerminal(status string) bool {
 	}
 }
 
-func newFreestyleSandboxName(repo Repo) string {
-	base := normalizeLeaseSlug(repo.Name)
+func newFreestyleSandboxName(repo core.Repo) string {
+	base := core.NormalizeLeaseSlug(repo.Name)
 	if base == "" {
 		base = "crabbox"
 	}
@@ -558,7 +538,7 @@ func newFreestyleSandboxName(repo Repo) string {
 }
 
 func isCrabboxFreestyleSandboxName(name string) bool {
-	return name == normalizeLeaseSlug(name) && strings.HasPrefix(name, freestyleNamePrefix)
+	return name == core.NormalizeLeaseSlug(name) && strings.HasPrefix(name, freestyleNamePrefix)
 }
 
 func freestyleRandomSuffix() string {

--- a/internal/providers/freestyle/backend_test.go
+++ b/internal/providers/freestyle/backend_test.go
@@ -89,7 +89,7 @@ func TestFreestyleEnvExportCommandQuotesValuesOnly(t *testing.T) {
 
 func TestFreestyleExecForwardsEnvAfterWorkdir(t *testing.T) {
 	client := &fakeFreestyleClient{}
-	backend := &freestyleBackend{rt: Runtime{Stderr: io.Discard}}
+	backend := &freestyleBackend{rt: core.Runtime{Stderr: io.Discard}}
 	code, err := backend.exec(context.Background(), client, "vm123", "/workspace/repo", []string{`echo "$GREETING"`}, false, map[string]string{
 		"GREETING": "hello world",
 	}, backend.rt.Stdout, backend.rt.Stderr)
@@ -115,7 +115,7 @@ func TestFreestyleExecForwardsEnvAfterWorkdir(t *testing.T) {
 func TestFreestyleConfigShowSection(t *testing.T) {
 	for _, selected := range []string{"", "freestyle"} {
 		for _, key := range []string{"", "synthetic-test-key"} {
-			cfg := Config{Provider: selected, Freestyle: FreestyleConfig{APIURL: "https://api.example.test/path?debug=1#hint", APIKey: key, Workdir: " raw-workdir ", VCPUs: 0, MemoryGB: -2}}
+			cfg := core.Config{Provider: selected, Freestyle: core.FreestyleConfig{APIURL: "https://api.example.test/path?debug=1#hint", APIKey: key, Workdir: " raw-workdir ", VCPUs: 0, MemoryGB: -2}}
 			before := cfg.Freestyle
 			section := (Provider{}).ConfigShowSection(cfg)
 			values := map[string]any{}
@@ -146,7 +146,7 @@ func TestFreestyleOrdinaryFlagBindings(t *testing.T) {
 	for _, provider := range []string{"other", "freestyle"} {
 		for _, value := range []string{"", "same", " padded "} {
 			for _, number := range []int{0, -2, 7} {
-				cfg := Config{Provider: provider, Freestyle: core.FreestyleConfig{APIURL: "same", Workdir: "same", VCPUs: 7, MemoryGB: 7}}
+				cfg := core.Config{Provider: provider, Freestyle: core.FreestyleConfig{APIURL: "same", Workdir: "same", VCPUs: 7, MemoryGB: 7}}
 				before := cfg
 				fs := flag.NewFlagSet("test", flag.ContinueOnError)
 				values := (Provider{}).RegisterFlags(fs, cfg)
@@ -184,7 +184,7 @@ func TestFreestyleOrdinaryFlagBindings(t *testing.T) {
 }
 
 func TestFreestyleAPIKeyFlagIsNotRegistered(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Freestyle.APIKey = "secret-key"
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	RegisterFreestyleProviderFlags(fs, cfg)
@@ -201,8 +201,8 @@ func TestFreestyleAPIKeyFlagIsNotRegistered(t *testing.T) {
 }
 
 func TestFreestyleWarmupRejectsActionsRunner(t *testing.T) {
-	backend := &freestyleBackend{rt: Runtime{Stderr: io.Discard}}
-	err := backend.Warmup(context.Background(), WarmupRequest{ActionsRunner: true})
+	backend := &freestyleBackend{rt: core.Runtime{Stderr: io.Discard}}
+	err := backend.Warmup(context.Background(), core.WarmupRequest{ActionsRunner: true})
 	if err == nil || !strings.Contains(err.Error(), "--actions-runner") {
 		t.Fatalf("Warmup err=%v, want actions-runner rejection", err)
 	}
@@ -236,13 +236,13 @@ func TestFreestyleStatusWaitFailsOnTerminalState(t *testing.T) {
 		State: "stopped",
 	}}
 	oldClient := newFreestyleClient
-	newFreestyleClient = func(Config, Runtime) (freestyleAPI, error) {
+	newFreestyleClient = func(core.Config, core.Runtime) (freestyleAPI, error) {
 		return client, nil
 	}
 	t.Cleanup(func() { newFreestyleClient = oldClient })
 
-	backend := &freestyleBackend{cfg: Config{}, rt: Runtime{Stderr: io.Discard}}
-	_, err := backend.Status(context.Background(), StatusRequest{
+	backend := &freestyleBackend{cfg: core.Config{}, rt: core.Runtime{Stderr: io.Discard}}
+	_, err := backend.Status(context.Background(), core.StatusRequest{
 		ID:          "fsb_vm123",
 		Wait:        true,
 		WaitTimeout: time.Minute,
@@ -308,11 +308,11 @@ func TestFreestyleStopRejectsMalformedCrabboxNameWithoutDelete(t *testing.T) {
 		State: "running",
 	}}
 	oldClient := newFreestyleClient
-	newFreestyleClient = func(Config, Runtime) (freestyleAPI, error) { return client, nil }
+	newFreestyleClient = func(core.Config, core.Runtime) (freestyleAPI, error) { return client, nil }
 	t.Cleanup(func() { newFreestyleClient = oldClient })
-	backend := &freestyleBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	backend := &freestyleBackend{rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
 
-	err := backend.Stop(context.Background(), StopRequest{ID: "fsb_vm123"})
+	err := backend.Stop(context.Background(), core.StopRequest{ID: "fsb_vm123"})
 	if err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
 		t.Fatalf("Stop error = %v, want ownership refusal", err)
 	}
@@ -329,11 +329,11 @@ func TestFreestyleStopRejectsCanonicalSandboxWithoutExactClaim(t *testing.T) {
 		State: "running",
 	}}
 	oldClient := newFreestyleClient
-	newFreestyleClient = func(Config, Runtime) (freestyleAPI, error) { return client, nil }
+	newFreestyleClient = func(core.Config, core.Runtime) (freestyleAPI, error) { return client, nil }
 	t.Cleanup(func() { newFreestyleClient = oldClient })
-	backend := &freestyleBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	backend := &freestyleBackend{rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
 
-	err := backend.Stop(context.Background(), StopRequest{ID: "fsb_vm123"})
+	err := backend.Stop(context.Background(), core.StopRequest{ID: "fsb_vm123"})
 	if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
 		t.Fatalf("Stop error = %v, want exact-claim refusal", err)
 	}
@@ -350,11 +350,11 @@ func TestFreestyleStopDeletesExactlyClaimedSandbox(t *testing.T) {
 	}
 	client := &fakeFreestyleClient{}
 	oldClient := newFreestyleClient
-	newFreestyleClient = func(Config, Runtime) (freestyleAPI, error) { return client, nil }
+	newFreestyleClient = func(core.Config, core.Runtime) (freestyleAPI, error) { return client, nil }
 	t.Cleanup(func() { newFreestyleClient = oldClient })
-	backend := &freestyleBackend{rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	backend := &freestyleBackend{rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
 
-	if err := backend.Stop(context.Background(), StopRequest{ID: "web"}); err != nil {
+	if err := backend.Stop(context.Background(), core.StopRequest{ID: "web"}); err != nil {
 		t.Fatal(err)
 	}
 	if len(client.deleteIDs) != 1 || client.deleteIDs[0] != "vm123" {
@@ -380,7 +380,7 @@ func TestResolveFreestyleLeaseIDClaimsRawSandboxForRepo(t *testing.T) {
 	t.Cleanup(func() { claimLeaseForRepoProviderPond = oldClaim })
 
 	repoRoot := t.TempDir()
-	backend := &freestyleBackend{cfg: Config{Pond: "demo", IdleTimeout: 7 * time.Minute}}
+	backend := &freestyleBackend{cfg: core.Config{Pond: "demo", IdleTimeout: 7 * time.Minute}}
 	if _, _, err := backend.resolveLeaseID(context.Background(), client, "fsb_vm123", repoRoot, true); err != nil {
 		t.Fatal(err)
 	}
@@ -401,7 +401,7 @@ func TestResolveFreestyleLeaseIDRequiresExplicitReclaimForUnclaimedReuse(t *test
 	if _, _, err := backend.resolveLeaseID(context.Background(), client, "fsb_vm123", t.TempDir(), false); err == nil || !strings.Contains(err.Error(), "--reclaim") {
 		t.Fatalf("resolve error = %v, want explicit reclaim refusal", err)
 	}
-	if _, ok, err := resolveLeaseClaim("fsb_vm123"); err != nil || ok {
+	if _, ok, err := core.ResolveLeaseClaim("fsb_vm123"); err != nil || ok {
 		t.Fatalf("claim created without reclaim: ok=%t err=%v", ok, err)
 	}
 }
@@ -437,7 +437,7 @@ func TestResolveFreestyleLeaseIDAcceptsListedIdentifiers(t *testing.T) {
 	client := &fakeFreestyleClient{listVMs: []freestyleVM{vm}}
 	backend := &freestyleBackend{}
 	leaseID := freestyleLeasePrefix + vm.ID
-	for _, id := range []string{vm.ID, vm.Name, newLeaseSlug(leaseID)} {
+	for _, id := range []string{vm.ID, vm.Name, core.NewLeaseSlug(leaseID)} {
 		t.Run(id, func(t *testing.T) {
 			gotLeaseID, gotVMID, err := backend.resolveLeaseID(context.Background(), client, id, "", false)
 			if err != nil {
@@ -451,15 +451,15 @@ func TestResolveFreestyleLeaseIDAcceptsListedIdentifiers(t *testing.T) {
 }
 
 func TestFreestyleWorkspacePathDefaultsUnderWorkspace(t *testing.T) {
-	cfg := Config{Freestyle: FreestyleConfig{}}
+	cfg := core.Config{Freestyle: core.FreestyleConfig{}}
 	if got, err := freestyleWorkspacePath(cfg); err != nil || got != "/workspace/crabbox" {
 		t.Fatalf("workspace=%q err=%v", got, err)
 	}
-	cfg = Config{Freestyle: FreestyleConfig{Workdir: "repo"}}
+	cfg = core.Config{Freestyle: core.FreestyleConfig{Workdir: "repo"}}
 	if got, err := freestyleWorkspacePath(cfg); err != nil || got != "/workspace/repo" {
 		t.Fatalf("workspace=%q err=%v", got, err)
 	}
-	cfg = Config{Freestyle: FreestyleConfig{Workdir: "team/repo"}}
+	cfg = core.Config{Freestyle: core.FreestyleConfig{Workdir: "team/repo"}}
 	if got, err := freestyleWorkspacePath(cfg); err != nil || got != "/workspace/team/repo" {
 		t.Fatalf("workspace=%q err=%v", got, err)
 	}
@@ -468,7 +468,7 @@ func TestFreestyleWorkspacePathDefaultsUnderWorkspace(t *testing.T) {
 func TestFreestyleWorkspacePathRejectsEscapes(t *testing.T) {
 	for _, workdir := range []string{"/work/repo", "/etc", "../etc", "repo/../../../etc", ".", "./.."} {
 		t.Run(workdir, func(t *testing.T) {
-			if got, err := freestyleWorkspacePath(Config{Freestyle: FreestyleConfig{Workdir: workdir}}); err == nil {
+			if got, err := freestyleWorkspacePath(core.Config{Freestyle: core.FreestyleConfig{Workdir: workdir}}); err == nil {
 				t.Fatalf("workspace=%q, want error for workdir %q", got, workdir)
 			}
 		})
@@ -478,10 +478,10 @@ func TestFreestyleWorkspacePathRejectsEscapes(t *testing.T) {
 func TestFreestyleRunRejectsUnsafeWorkdirBeforeProviderClient(t *testing.T) {
 	backend := &freestyleBackend{
 		spec: Provider{}.Spec(),
-		cfg:  Config{Freestyle: FreestyleConfig{Workdir: "../etc"}},
-		rt:   Runtime{Stderr: io.Discard},
+		cfg:  core.Config{Freestyle: core.FreestyleConfig{Workdir: "../etc"}},
+		rt:   core.Runtime{Stderr: io.Discard},
 	}
-	_, err := backend.Run(context.Background(), RunRequest{NoSync: true})
+	_, err := backend.Run(context.Background(), core.RunRequest{NoSync: true})
 	if err == nil || !strings.Contains(err.Error(), "escapes /workspace") {
 		t.Fatalf("Run err=%v, want workdir containment error", err)
 	}
@@ -491,17 +491,17 @@ func TestFreestyleRunRejectsMissingCommand(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	client := &fakeFreestyleClient{createID: "vm123"}
 	oldClient := newFreestyleClient
-	newFreestyleClient = func(cfg Config, rt Runtime) (freestyleAPI, error) {
+	newFreestyleClient = func(cfg core.Config, rt core.Runtime) (freestyleAPI, error) {
 		return client, nil
 	}
 	defer func() { newFreestyleClient = oldClient }()
 	backend := &freestyleBackend{
 		spec: Provider{}.Spec(),
-		cfg:  Config{Freestyle: FreestyleConfig{}},
-		rt:   Runtime{Stderr: io.Discard},
+		cfg:  core.Config{Freestyle: core.FreestyleConfig{}},
+		rt:   core.Runtime{Stderr: io.Discard},
 	}
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: t.TempDir(), Name: "repo"},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: t.TempDir(), Name: "repo"},
 		NoSync:  true,
 		Command: nil,
 	})
@@ -517,18 +517,18 @@ func TestFreestyleRunCleansNewSandboxAfterPrepareFailure(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	client := &fakeFreestyleClient{createID: "vm123", execErrAt: 1}
 	oldClient := newFreestyleClient
-	newFreestyleClient = func(Config, Runtime) (freestyleAPI, error) {
+	newFreestyleClient = func(core.Config, core.Runtime) (freestyleAPI, error) {
 		return client, nil
 	}
 	t.Cleanup(func() { newFreestyleClient = oldClient })
 
 	backend := &freestyleBackend{
 		spec: Provider{}.Spec(),
-		cfg:  Config{Freestyle: FreestyleConfig{}},
-		rt:   Runtime{Stderr: io.Discard},
+		cfg:  core.Config{Freestyle: core.FreestyleConfig{}},
+		rt:   core.Runtime{Stderr: io.Discard},
 	}
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: t.TempDir(), Name: "repo"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: t.TempDir(), Name: "repo"},
 		NoSync:  true,
 		Command: []string{"true"},
 	})
@@ -553,7 +553,7 @@ func TestFreestyleRunKeepsNewSandboxAfterPrepareFailureWhenRequested(t *testing.
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	client := &fakeFreestyleClient{createID: "vm123", execErrAt: 1}
 	oldClient := newFreestyleClient
-	newFreestyleClient = func(Config, Runtime) (freestyleAPI, error) {
+	newFreestyleClient = func(core.Config, core.Runtime) (freestyleAPI, error) {
 		return client, nil
 	}
 	t.Cleanup(func() { newFreestyleClient = oldClient })
@@ -561,15 +561,15 @@ func TestFreestyleRunKeepsNewSandboxAfterPrepareFailureWhenRequested(t *testing.
 	var stderr bytes.Buffer
 	backend := &freestyleBackend{
 		spec: Provider{}.Spec(),
-		cfg: Config{
+		cfg: core.Config{
 			IdleTimeout: 5 * time.Minute,
 			TTL:         time.Hour,
-			Freestyle:   FreestyleConfig{},
+			Freestyle:   core.FreestyleConfig{},
 		},
-		rt: Runtime{Stderr: &stderr},
+		rt: core.Runtime{Stderr: &stderr},
 	}
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:          Repo{Root: t.TempDir(), Name: "repo"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:          core.Repo{Root: t.TempDir(), Name: "repo"},
 		NoSync:        true,
 		KeepOnFailure: true,
 		TimingJSON:    true,
@@ -618,7 +618,7 @@ func TestFreestyleRunSyncOnlySkipsUserExec(t *testing.T) {
 	}
 	client := &fakeFreestyleClient{createID: "vm-sync"}
 	oldClient := newFreestyleClient
-	newFreestyleClient = func(cfg Config, rt Runtime) (freestyleAPI, error) {
+	newFreestyleClient = func(cfg core.Config, rt core.Runtime) (freestyleAPI, error) {
 		return client, nil
 	}
 	defer func() { newFreestyleClient = oldClient }()
@@ -626,11 +626,11 @@ func TestFreestyleRunSyncOnlySkipsUserExec(t *testing.T) {
 	var stderr bytes.Buffer
 	backend := &freestyleBackend{
 		spec: Provider{}.Spec(),
-		cfg:  Config{Freestyle: FreestyleConfig{}},
-		rt:   Runtime{Stdout: &stdout, Stderr: &stderr},
+		cfg:  core.Config{Freestyle: core.FreestyleConfig{}},
+		rt:   core.Runtime{Stdout: &stdout, Stderr: &stderr},
 	}
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:       Repo{Root: root, Name: "repo"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Root: root, Name: "repo"},
 		SyncOnly:   true,
 		TimingJSON: true,
 		Command:    []string{"printf", "unexpected-user-command"},
@@ -663,21 +663,21 @@ func TestFreestyleRunNoSyncDoesNotDeleteExistingWorkspace(t *testing.T) {
 		State: "running",
 	}}
 	oldClient := newFreestyleClient
-	newFreestyleClient = func(cfg Config, rt Runtime) (freestyleAPI, error) {
+	newFreestyleClient = func(cfg core.Config, rt core.Runtime) (freestyleAPI, error) {
 		return client, nil
 	}
 	defer func() { newFreestyleClient = oldClient }()
 	backend := &freestyleBackend{
 		spec: Provider{}.Spec(),
-		cfg: Config{
-			Freestyle: FreestyleConfig{},
-			Sync:      SyncConfig{Delete: true},
+		cfg: core.Config{
+			Freestyle: core.FreestyleConfig{},
+			Sync:      core.SyncConfig{Delete: true},
 		},
-		rt: Runtime{Stderr: io.Discard},
+		rt: core.Runtime{Stderr: io.Discard},
 	}
-	result, err := backend.Run(context.Background(), RunRequest{
+	result, err := backend.Run(context.Background(), core.RunRequest{
 		ID:      "fsb_vm123",
-		Repo:    Repo{Root: t.TempDir(), Name: "repo"},
+		Repo:    core.Repo{Root: t.TempDir(), Name: "repo"},
 		Reclaim: true,
 		NoSync:  true,
 		Command: []string{"test", "-f", "kept.txt"},
@@ -713,7 +713,7 @@ func TestFreestyleRunCleanupFailureReportsRetainedSession(t *testing.T) {
 		deleteErr: errors.New("delete failed"),
 	}
 	oldClient := newFreestyleClient
-	newFreestyleClient = func(Config, Runtime) (freestyleAPI, error) {
+	newFreestyleClient = func(core.Config, core.Runtime) (freestyleAPI, error) {
 		return client, nil
 	}
 	t.Cleanup(func() { newFreestyleClient = oldClient })
@@ -721,16 +721,16 @@ func TestFreestyleRunCleanupFailureReportsRetainedSession(t *testing.T) {
 	var stderr bytes.Buffer
 	backend := &freestyleBackend{
 		spec: Provider{}.Spec(),
-		cfg:  Config{Freestyle: FreestyleConfig{}},
-		rt:   Runtime{Stderr: &stderr},
+		cfg:  core.Config{Freestyle: core.FreestyleConfig{}},
+		rt:   core.Runtime{Stderr: &stderr},
 	}
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:       Repo{Root: t.TempDir(), Name: "repo"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Root: t.TempDir(), Name: "repo"},
 		NoSync:     true,
 		TimingJSON: true,
 		Command:    []string{"true"},
 	})
-	var public ExitError
+	var public core.ExitError
 	if !errors.Is(err, client.deleteErr) || !errors.As(err, &public) || public.Code != 1 || result.ExitCode != 1 || result.Status != core.RunStatusFailed || result.ErrorKind != core.RunErrorProvider {
 		t.Errorf("cleanup failure result=%#v err=%v", result, err)
 	}
@@ -759,12 +759,12 @@ func freestyleLifecycleBackend(t *testing.T, client *fakeFreestyleClient, stderr
 	t.Helper()
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	original := newFreestyleClient
-	newFreestyleClient = func(Config, Runtime) (freestyleAPI, error) { return client, nil }
+	newFreestyleClient = func(core.Config, core.Runtime) (freestyleAPI, error) { return client, nil }
 	t.Cleanup(func() { newFreestyleClient = original })
-	return &freestyleBackend{spec: Provider{}.Spec(), cfg: Config{Freestyle: FreestyleConfig{}}, rt: Runtime{Stdout: io.Discard, Stderr: stderr}}
+	return &freestyleBackend{spec: Provider{}.Spec(), cfg: core.Config{Freestyle: core.FreestyleConfig{}}, rt: core.Runtime{Stdout: io.Discard, Stderr: stderr}}
 }
 
-func assertFreestyleLifecycleTiming(t *testing.T, diagnostics string, result RunResult, runErr error) {
+func assertFreestyleLifecycleTiming(t *testing.T, diagnostics string, result core.RunResult, runErr error) {
 	t.Helper()
 	result = core.FinalizeRunResult(result, runErr)
 	lines := strings.Split(strings.TrimSpace(diagnostics), "\n")
@@ -828,12 +828,12 @@ func TestFreestyleRunFinalizationPreservesPrimaryOutcome(t *testing.T) {
 				diagnostics = &freestyleTimingFailureWriter{cause: writerErr}
 			}
 			backend := freestyleLifecycleBackend(t, client, diagnostics)
-			result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: tc.keep, TimingJSON: true, Command: []string{"__lifecycle_workload__"}})
+			result, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: tc.keep, TimingJSON: true, Command: []string{"__lifecycle_workload__"}})
 			wantCode, wantKind := tc.commandCode, core.RunErrorCommandExit
 			if wantCode == 0 {
 				wantCode, wantKind = 1, core.RunErrorProvider
 			}
-			var public ExitError
+			var public core.ExitError
 			if !errors.As(err, &public) || public.Code != wantCode || result.ExitCode != wantCode || result.Status != core.RunStatusFailed || result.ErrorKind != wantKind || workloads != 1 {
 				t.Errorf("primary outcome lost: result=%#v err=%v public=%#v workloads=%d", result, err, public, workloads)
 			}
@@ -881,8 +881,8 @@ func TestFreestyleRunPreservesTransportCauses(t *testing.T) {
 			}
 			var stderr bytes.Buffer
 			backend := freestyleLifecycleBackend(t, client, &stderr)
-			result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: true, TimingJSON: true, Command: []string{"__lifecycle_workload__"}})
-			var public ExitError
+			result, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir(), Name: "fixture"}, NoSync: true, KeepOnFailure: true, TimingJSON: true, Command: []string{"__lifecycle_workload__"}})
+			var public core.ExitError
 			if !errors.Is(err, tc.cause) || !errors.As(err, &public) || public.Code != 1 || result.ExitCode != 1 || result.Status != tc.status || result.ErrorKind != tc.kind || workloads != 1 || t.Context().Err() != nil {
 				t.Errorf("transport cause/outcome lost: result=%#v err=%v workloads=%d", result, err, workloads)
 			}
@@ -919,7 +919,7 @@ func TestFreestyleRunReusedLifecycleControls(t *testing.T) {
 			}
 			var stderr bytes.Buffer
 			backend := freestyleLifecycleBackend(t, client, &stderr)
-			repo := Repo{Root: t.TempDir(), Name: "fixture"}
+			repo := core.Repo{Root: t.TempDir(), Name: "fixture"}
 			if tc.syncOnly {
 				repo = freestyleArchiveRepo(t)
 			}
@@ -927,7 +927,7 @@ func TestFreestyleRunReusedLifecycleControls(t *testing.T) {
 			if err := claimLeaseForRepoProviderPond(leaseID, "reused", freestyleProvider, "", repo.Root, time.Minute, false); err != nil {
 				t.Fatal(err)
 			}
-			result, err := backend.Run(t.Context(), RunRequest{ID: leaseID, Repo: repo, NoSync: !tc.syncOnly, SyncOnly: tc.syncOnly, TimingJSON: true, Command: []string{"__lifecycle_workload__"}})
+			result, err := backend.Run(t.Context(), core.RunRequest{ID: leaseID, Repo: repo, NoSync: !tc.syncOnly, SyncOnly: tc.syncOnly, TimingJSON: true, Command: []string{"__lifecycle_workload__"}})
 			if result.ExitCode != tc.commandCode || (err != nil) != (tc.commandCode != 0) || result.Session == nil || !result.Session.Kept || !result.Session.Reused || client.createReq != nil || len(client.deleteIDs) != 0 {
 				t.Fatalf("reused disposition: result=%#v err=%v creates=%#v deletes=%v", result, err, client.createReq, client.deleteIDs)
 			}
@@ -954,19 +954,19 @@ func TestFreestyleRunPrintsRedactedEnvSummary(t *testing.T) {
 		State: "running",
 	}}
 	oldClient := newFreestyleClient
-	newFreestyleClient = func(cfg Config, rt Runtime) (freestyleAPI, error) {
+	newFreestyleClient = func(cfg core.Config, rt core.Runtime) (freestyleAPI, error) {
 		return client, nil
 	}
 	defer func() { newFreestyleClient = oldClient }()
 	var stderr bytes.Buffer
 	backend := &freestyleBackend{
 		spec: Provider{}.Spec(),
-		cfg:  Config{Freestyle: FreestyleConfig{}},
-		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr},
+		cfg:  core.Config{Freestyle: core.FreestyleConfig{}},
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: &stderr},
 	}
-	_, err := backend.Run(context.Background(), RunRequest{
+	_, err := backend.Run(context.Background(), core.RunRequest{
 		ID:         "fsb_vm123",
-		Repo:       Repo{Root: t.TempDir(), Name: "repo"},
+		Repo:       core.Repo{Root: t.TempDir(), Name: "repo"},
 		Reclaim:    true,
 		NoSync:     true,
 		Command:    []string{"printenv", "SECRET_TOKEN"},
@@ -988,10 +988,10 @@ func TestFreestyleCreateSandboxWorksWithoutWorkdir(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	client := &fakeFreestyleClient{createID: "vm123"}
 	backend := &freestyleBackend{
-		cfg: Config{Freestyle: FreestyleConfig{}},
-		rt:  Runtime{Stderr: io.Discard},
+		cfg: core.Config{Freestyle: core.FreestyleConfig{}},
+		rt:  core.Runtime{Stderr: io.Discard},
 	}
-	leaseID, id, slug, err := backend.createSandbox(context.Background(), client, Repo{Root: t.TempDir(), Name: "repo"}, false, "")
+	leaseID, id, slug, err := backend.createSandbox(context.Background(), client, core.Repo{Root: t.TempDir(), Name: "repo"}, false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1019,10 +1019,10 @@ func TestFreestyleCreateSandboxPassesNameWithoutWorkdir(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	client := &fakeFreestyleClient{createID: "vm456"}
 	backend := &freestyleBackend{
-		cfg: Config{Freestyle: FreestyleConfig{VCPUs: 4, MemoryGB: 8}},
-		rt:  Runtime{Stderr: io.Discard},
+		cfg: core.Config{Freestyle: core.FreestyleConfig{VCPUs: 4, MemoryGB: 8}},
+		rt:  core.Runtime{Stderr: io.Discard},
 	}
-	_, _, _, err := backend.createSandbox(context.Background(), client, Repo{Root: t.TempDir(), Name: "repo"}, false, "")
+	_, _, _, err := backend.createSandbox(context.Background(), client, core.Repo{Root: t.TempDir(), Name: "repo"}, false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1044,14 +1044,14 @@ func TestFreestyleCreateSandboxStoresClaimForList(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	client := &fakeFreestyleClient{createID: "vm789"}
 	backend := &freestyleBackend{
-		cfg: Config{Pond: "Alpha Pond", Freestyle: FreestyleConfig{}},
-		rt:  Runtime{Stderr: io.Discard},
+		cfg: core.Config{Pond: "Alpha Pond", Freestyle: core.FreestyleConfig{}},
+		rt:  core.Runtime{Stderr: io.Discard},
 	}
-	_, _, _, err := backend.createSandbox(context.Background(), client, Repo{Root: t.TempDir(), Name: "repo"}, false, "")
+	_, _, _, err := backend.createSandbox(context.Background(), client, core.Repo{Root: t.TempDir(), Name: "repo"}, false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	claim, ok, err := resolveLeaseClaim("fsb_vm789")
+	claim, ok, err := core.ResolveLeaseClaim("fsb_vm789")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1070,10 +1070,10 @@ func TestFreestyleListAndStatusUseStoredClaimSlug(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	client := &fakeFreestyleClient{createID: "vm789"}
 	backend := &freestyleBackend{
-		cfg: Config{Pond: "demo", Freestyle: FreestyleConfig{}},
-		rt:  Runtime{Stderr: io.Discard},
+		cfg: core.Config{Pond: "demo", Freestyle: core.FreestyleConfig{}},
+		rt:  core.Runtime{Stderr: io.Discard},
 	}
-	leaseID, id, slug, err := backend.createSandbox(context.Background(), client, Repo{Root: t.TempDir(), Name: "repo"}, false, "blue-lobster")
+	leaseID, id, slug, err := backend.createSandbox(context.Background(), client, core.Repo{Root: t.TempDir(), Name: "repo"}, false, "blue-lobster")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1104,10 +1104,10 @@ func TestFreestyleCreateSandboxReportsBoundedCleanupFailure(t *testing.T) {
 	}
 	var stderr bytes.Buffer
 	backend := &freestyleBackend{
-		cfg: Config{Freestyle: FreestyleConfig{}},
-		rt:  Runtime{Stderr: &stderr},
+		cfg: core.Config{Freestyle: core.FreestyleConfig{}},
+		rt:  core.Runtime{Stderr: &stderr},
 	}
-	_, _, _, err := backend.createSandbox(context.Background(), client, Repo{Root: t.TempDir(), Name: "repo"}, false, "")
+	_, _, _, err := backend.createSandbox(context.Background(), client, core.Repo{Root: t.TempDir(), Name: "repo"}, false, "")
 	if err == nil {
 		t.Fatal("expected claim failure")
 	}
@@ -1151,11 +1151,11 @@ func TestFreestyleSyncWorkspaceUploadsRepoArchive(t *testing.T) {
 	}
 	client := &fakeFreestyleClient{}
 	backend := &freestyleBackend{
-		cfg: Config{Freestyle: FreestyleConfig{Workdir: "repo"}},
-		rt:  Runtime{Stderr: io.Discard},
+		cfg: core.Config{Freestyle: core.FreestyleConfig{Workdir: "repo"}},
+		rt:  core.Runtime{Stderr: io.Discard},
 	}
-	_, _, err := backend.syncWorkspace(context.Background(), client, "crabbox-test", RunRequest{
-		Repo: Repo{Root: root, Name: "repo"},
+	_, _, err := backend.syncWorkspace(context.Background(), client, "crabbox-test", core.RunRequest{
+		Repo: core.Repo{Root: root, Name: "repo"},
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1195,11 +1195,11 @@ func TestFreestyleSyncWorkspaceValidatesArchiveBeforeDeletingWorkspace(t *testin
 	calls := 0
 	client := &fakeFreestyleClient{}
 	backend := &freestyleBackend{
-		cfg: Config{
-			Freestyle: FreestyleConfig{Workdir: "repo"},
-			Sync:      SyncConfig{Delete: true},
+		cfg: core.Config{
+			Freestyle: core.FreestyleConfig{Workdir: "repo"},
+			Sync:      core.SyncConfig{Delete: true},
 		},
-		rt: Runtime{Stderr: io.Discard, Clock: freestyleArchiveClock(func() time.Time {
+		rt: core.Runtime{Stderr: io.Discard, Clock: freestyleArchiveClock(func() time.Time {
 			calls++
 			if calls == 5 {
 				if err := os.Remove(trackedPath); err != nil {
@@ -1210,8 +1210,8 @@ func TestFreestyleSyncWorkspaceValidatesArchiveBeforeDeletingWorkspace(t *testin
 		})},
 	}
 
-	if _, _, err := backend.syncWorkspace(context.Background(), client, "crabbox-test", RunRequest{
-		Repo: Repo{Root: root, Name: "repo"},
+	if _, _, err := backend.syncWorkspace(context.Background(), client, "crabbox-test", core.RunRequest{
+		Repo: core.Repo{Root: root, Name: "repo"},
 	}, nil); err == nil {
 		t.Fatal("syncWorkspace err=nil, want local archive failure")
 	}
@@ -1252,14 +1252,14 @@ func TestFreestyleSyncWorkspaceHonorsIncludes(t *testing.T) {
 	}
 	client := &fakeFreestyleClient{}
 	backend := &freestyleBackend{
-		cfg: Config{
-			Freestyle: FreestyleConfig{Workdir: "repo"},
-			Sync:      SyncConfig{Includes: []string{"keep/**"}},
+		cfg: core.Config{
+			Freestyle: core.FreestyleConfig{Workdir: "repo"},
+			Sync:      core.SyncConfig{Includes: []string{"keep/**"}},
 		},
-		rt: Runtime{Stderr: io.Discard},
+		rt: core.Runtime{Stderr: io.Discard},
 	}
-	_, _, err := backend.syncWorkspace(context.Background(), client, "crabbox-test", RunRequest{
-		Repo: Repo{Root: root, Name: "repo"},
+	_, _, err := backend.syncWorkspace(context.Background(), client, "crabbox-test", core.RunRequest{
+		Repo: core.Repo{Root: root, Name: "repo"},
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1294,11 +1294,11 @@ func TestFreestyleSyncWorkspaceFallsBackToExecUpload(t *testing.T) {
 	}
 	client := &fakeFreestyleClient{writeFileErr: errors.New("file api upload failed")}
 	backend := &freestyleBackend{
-		cfg: Config{Freestyle: FreestyleConfig{Workdir: "repo"}},
-		rt:  Runtime{Stderr: io.Discard},
+		cfg: core.Config{Freestyle: core.FreestyleConfig{Workdir: "repo"}},
+		rt:  core.Runtime{Stderr: io.Discard},
 	}
-	_, _, err := backend.syncWorkspace(context.Background(), client, "crabbox-test", RunRequest{
-		Repo: Repo{Root: root, Name: "repo"},
+	_, _, err := backend.syncWorkspace(context.Background(), client, "crabbox-test", core.RunRequest{
+		Repo: core.Repo{Root: root, Name: "repo"},
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1323,14 +1323,14 @@ func TestFreestyleSyncDeleteStagesBeforeReplacingWorkspace(t *testing.T) {
 	}
 	client := &fakeFreestyleClient{}
 	backend := &freestyleBackend{
-		cfg: Config{
-			Freestyle: FreestyleConfig{Workdir: "repo"},
-			Sync:      SyncConfig{Delete: true},
+		cfg: core.Config{
+			Freestyle: core.FreestyleConfig{Workdir: "repo"},
+			Sync:      core.SyncConfig{Delete: true},
 		},
-		rt: Runtime{Stderr: io.Discard},
+		rt: core.Runtime{Stderr: io.Discard},
 	}
-	if _, _, err := backend.syncWorkspace(context.Background(), client, "vm123", RunRequest{
-		Repo: Repo{Root: root, Name: "repo"},
+	if _, _, err := backend.syncWorkspace(context.Background(), client, "vm123", core.RunRequest{
+		Repo: core.Repo{Root: root, Name: "repo"},
 	}, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -1374,14 +1374,14 @@ func TestFreestyleSyncDeletePreservesWorkspaceWhenFallbackUploadFails(t *testing
 		},
 	}
 	backend := &freestyleBackend{
-		cfg: Config{
-			Freestyle: FreestyleConfig{Workdir: "repo"},
-			Sync:      SyncConfig{Delete: true},
+		cfg: core.Config{
+			Freestyle: core.FreestyleConfig{Workdir: "repo"},
+			Sync:      core.SyncConfig{Delete: true},
 		},
-		rt: Runtime{Stderr: io.Discard},
+		rt: core.Runtime{Stderr: io.Discard},
 	}
-	if _, _, err := backend.syncWorkspace(context.Background(), client, "vm123", RunRequest{
-		Repo: Repo{Root: root, Name: "repo"},
+	if _, _, err := backend.syncWorkspace(context.Background(), client, "vm123", core.RunRequest{
+		Repo: core.Repo{Root: root, Name: "repo"},
 	}, nil); err == nil || !strings.Contains(err.Error(), "exec failed") {
 		t.Fatalf("syncWorkspace err=%v, want fallback upload failure", err)
 	}
@@ -1406,11 +1406,11 @@ func TestFreestyleSyncHonorsConfiguredTimeout(t *testing.T) {
 		t.Fatalf("git init: %v\n%s", err, out)
 	}
 	backend := &freestyleBackend{
-		cfg: Config{
-			Freestyle: FreestyleConfig{Workdir: "repo"},
-			Sync:      SyncConfig{Timeout: 100 * time.Millisecond},
+		cfg: core.Config{
+			Freestyle: core.FreestyleConfig{Workdir: "repo"},
+			Sync:      core.SyncConfig{Timeout: 100 * time.Millisecond},
 		},
-		rt: Runtime{Stderr: io.Discard},
+		rt: core.Runtime{Stderr: io.Discard},
 	}
 	// Local Git manifest queries and archive I/O finish before the fake transfer
 	// blocks. Measure cancellation in virtual time, independent of their wall time.
@@ -1445,8 +1445,8 @@ func TestFreestyleSyncHonorsConfiguredTimeout(t *testing.T) {
 			}
 			return ctx.Err()
 		}}
-		if _, _, err := backend.syncWorkspace(context.Background(), client, "vm123", RunRequest{
-			Repo: Repo{Root: root, Name: "repo"},
+		if _, _, err := backend.syncWorkspace(context.Background(), client, "vm123", core.RunRequest{
+			Repo: core.Repo{Root: root, Name: "repo"},
 		}, nil); !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("syncWorkspace err=%v, want timeout", err)
 		}
@@ -1467,7 +1467,7 @@ func TestFreestyleUploadCleansAttemptFilesAfterFailure(t *testing.T) {
 				client.writeFileErr = errors.New("file api upload failed")
 				client.execErrAt = 2
 			}
-			backend := &freestyleBackend{rt: Runtime{Stderr: io.Discard}}
+			backend := &freestyleBackend{rt: core.Runtime{Stderr: io.Discard}}
 			payload := []byte("synthetic payload")
 			err := backend.uploadArchive(t.Context(), client, "vm123", "/tmp/archive.tgz", bytes.NewReader(payload))
 			if err == nil || !strings.Contains(err.Error(), "exec failed") {
@@ -1498,19 +1498,19 @@ func TestReadFreestyleArchiveForUploadRejectsOversize(t *testing.T) {
 
 func TestRejectFreestyleSyncOptionsAllowsForceSyncLarge(t *testing.T) {
 	spec := Provider{}.Spec()
-	if err := delegatedSyncOptionsError(spec, RunRequest{ForceSyncLarge: true}); err != nil {
+	if err := core.RejectDelegatedSyncOptionsForSpec(spec, core.RunRequest{ForceSyncLarge: true}); err != nil {
 		t.Fatalf("force sync large should be honored by Freestyle archive sync: %v", err)
 	}
-	if err := delegatedSyncOptionsError(spec, RunRequest{SyncOnly: true}); err != nil {
+	if err := core.RejectDelegatedSyncOptionsForSpec(spec, core.RunRequest{SyncOnly: true}); err != nil {
 		t.Fatalf("sync-only should be supported: %v", err)
 	}
-	if err := delegatedSyncOptionsError(spec, RunRequest{ChecksumSync: true}); err == nil || !strings.Contains(err.Error(), "--checksum") {
+	if err := core.RejectDelegatedSyncOptionsForSpec(spec, core.RunRequest{ChecksumSync: true}); err == nil || !strings.Contains(err.Error(), "--checksum") {
 		t.Fatalf("checksum err=%v", err)
 	}
 }
 
 func TestNewFreestyleSandboxNameUsesCrabboxPrefix(t *testing.T) {
-	name := newFreestyleSandboxName(Repo{Name: "repo"})
+	name := newFreestyleSandboxName(core.Repo{Name: "repo"})
 	if !strings.HasPrefix(name, "crabbox-repo-") {
 		t.Fatalf("name=%q", name)
 	}
@@ -1626,7 +1626,7 @@ func (f *fakeFreestyleClient) commandContains(value string) bool {
 	return false
 }
 
-func freestyleArchiveRepo(t *testing.T) Repo {
+func freestyleArchiveRepo(t *testing.T) core.Repo {
 	t.Helper()
 	root := t.TempDir()
 	for _, name := range []string{"tracked.txt", "other.txt"} {
@@ -1641,7 +1641,7 @@ func freestyleArchiveRepo(t *testing.T) Repo {
 			t.Fatalf("git %v: %v: %s", args, err, out)
 		}
 	}
-	return Repo{Root: root, Name: "repo"}
+	return core.Repo{Root: root, Name: "repo"}
 }
 
 func TestFreestyleRunBoundsFullArchiveBeforeMutation(t *testing.T) {
@@ -1659,10 +1659,10 @@ func TestFreestyleRunBoundsFullArchiveBeforeMutation(t *testing.T) {
 				}
 				client := &fakeFreestyleClient{getVM: freestyleVM{ID: "vm123", Name: "crabbox-repo-abc123", State: "running"}}
 				old := newFreestyleClient
-				newFreestyleClient = func(Config, Runtime) (freestyleAPI, error) { return client, nil }
+				newFreestyleClient = func(core.Config, core.Runtime) (freestyleAPI, error) { return client, nil }
 				t.Cleanup(func() { newFreestyleClient = old })
-				b := &freestyleBackend{spec: Provider{}.Spec(), cfg: Config{Sync: SyncConfig{FailFiles: 2, Delete: true}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-				req := RunRequest{Repo: repo, SyncOnly: true, ForceSyncLarge: force}
+				b := &freestyleBackend{spec: Provider{}.Spec(), cfg: core.Config{Sync: core.SyncConfig{FailFiles: 2, Delete: true}}, rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+				req := core.RunRequest{Repo: repo, SyncOnly: true, ForceSyncLarge: force}
 				if reused {
 					req.ID = "fsb_vm123"
 					req.Reclaim = true
@@ -1707,10 +1707,10 @@ func TestFreestyleRunCompressedCapPrecedesCreateEvenWhenForced(t *testing.T) {
 	}
 	client := &fakeFreestyleClient{}
 	old := newFreestyleClient
-	newFreestyleClient = func(Config, Runtime) (freestyleAPI, error) { return client, nil }
+	newFreestyleClient = func(core.Config, core.Runtime) (freestyleAPI, error) { return client, nil }
 	t.Cleanup(func() { newFreestyleClient = old })
-	b := &freestyleBackend{spec: Provider{}.Spec(), rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-	_, err = b.Run(t.Context(), RunRequest{Repo: repo, SyncOnly: true, ForceSyncLarge: true})
+	b := &freestyleBackend{spec: Provider{}.Spec(), rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	_, err = b.Run(t.Context(), core.RunRequest{Repo: repo, SyncOnly: true, ForceSyncLarge: true})
 	if err == nil || !strings.Contains(err.Error(), "after compression") {
 		t.Fatalf("compressed cap failure=%v", err)
 	}
@@ -1749,10 +1749,10 @@ func TestFreestyleRunPreparesSnapshotBeforeCreate(t *testing.T) {
 				return os.WriteFile(filepath.Join(repo.Root, "tracked.txt"), []byte("changed during create"), 0600)
 			}}
 			old := newFreestyleClient
-			newFreestyleClient = func(Config, Runtime) (freestyleAPI, error) { return client, nil }
+			newFreestyleClient = func(core.Config, core.Runtime) (freestyleAPI, error) { return client, nil }
 			t.Cleanup(func() { newFreestyleClient = old })
-			b := &freestyleBackend{spec: Provider{}.Spec(), rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
-			_, err := b.Run(t.Context(), RunRequest{Repo: repo, SyncOnly: true})
+			b := &freestyleBackend{spec: Provider{}.Spec(), rt: core.Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+			_, err := b.Run(t.Context(), core.RunRequest{Repo: repo, SyncOnly: true})
 			if createFails {
 				if err == nil || !strings.Contains(err.Error(), "synthetic create failure") || client.writeFileContent != "" {
 					t.Fatalf("create failure err=%v uploaded=%t", err, client.writeFileContent != "")
@@ -1839,7 +1839,7 @@ func TestFreestyleUploadNativeAttemptIsolation(t *testing.T) {
 				}
 				return 0, nil
 			}
-			b := &freestyleBackend{rt: Runtime{Stderr: io.Discard}}
+			b := &freestyleBackend{rt: core.Runtime{Stderr: io.Discard}}
 			err := b.uploadArchive(t.Context(), client, "fixture", archive, bytes.NewReader(payload))
 			if decodeFails {
 				var exitErr core.ExitError

--- a/internal/providers/freestyle/client.go
+++ b/internal/providers/freestyle/client.go
@@ -87,10 +87,10 @@ type freestyleHTTPClient struct {
 const freestyleListPageSize = 100
 const freestyleControlTimeout = 60 * time.Second
 
-var newFreestyleClient = func(cfg Config, rt Runtime) (freestyleAPI, error) {
+var newFreestyleClient = func(cfg core.Config, rt core.Runtime) (freestyleAPI, error) {
 	apiKey := strings.TrimSpace(cfg.Freestyle.APIKey)
 	if apiKey == "" {
-		return nil, exit(2, "provider=freestyle requires FREESTYLE_API_KEY")
+		return nil, core.Exit(2, "provider=freestyle requires FREESTYLE_API_KEY")
 	}
 	apiURL, err := validateFreestyleAPIURL(core.Blank(cfg.Freestyle.APIURL, core.FreestyleConfigDefaultAPIURL))
 	if err != nil {
@@ -108,9 +108,9 @@ var newFreestyleClient = func(cfg Config, rt Runtime) (freestyleAPI, error) {
 
 func validateFreestyleAPIURL(raw string) (string, error) {
 	return shared.NormalizeHTTPSURL(raw, shared.EndpointURLErrors{
-		Invalid:    exit(2, "provider=freestyle API URL must be an absolute HTTPS URL"),
-		Components: exit(2, "provider=freestyle API URL must not contain userinfo, query parameters, or a fragment"),
-		Insecure:   exit(2, "provider=freestyle API URL must use HTTPS except for loopback development endpoints"),
+		Invalid:    core.Exit(2, "provider=freestyle API URL must be an absolute HTTPS URL"),
+		Components: core.Exit(2, "provider=freestyle API URL must not contain userinfo, query parameters, or a fragment"),
+		Insecure:   core.Exit(2, "provider=freestyle API URL must use HTTPS except for loopback development endpoints"),
 	})
 }
 

--- a/internal/providers/freestyle/client_test.go
+++ b/internal/providers/freestyle/client_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -76,10 +77,10 @@ func TestFreestyleInjectedHTTPSettingsArePreservedForBothPlanes(t *testing.T) {
 		redirectCalls++
 		return redirectErr
 	}}
-	api, err := newFreestyleClient(Config{Freestyle: FreestyleConfig{
+	api, err := newFreestyleClient(core.Config{Freestyle: core.FreestyleConfig{
 		APIKey: "test-key",
 		APIURL: "http://127.0.0.1:8787",
-	}}, Runtime{HTTP: injected})
+	}}, core.Runtime{HTTP: injected})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,12 +217,12 @@ func TestFreestyleClientRefusesCrossOriginRedirect(t *testing.T) {
 	}))
 	defer trusted.Close()
 
-	api, err := newFreestyleClient(Config{
-		Freestyle: FreestyleConfig{
+	api, err := newFreestyleClient(core.Config{
+		Freestyle: core.FreestyleConfig{
 			APIKey: "test-key",
 			APIURL: trusted.URL,
 		},
-	}, Runtime{HTTP: trusted.Client()})
+	}, core.Runtime{HTTP: trusted.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/freestyle/core.go
+++ b/internal/providers/freestyle/core.go
@@ -1,67 +1,7 @@
 package freestyle
 
 import (
-	"io"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-type statusView = core.StatusView
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
-}
-
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}
-
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
-func shellWords(words []string) []string {
-	return core.ShellWords(words)
-}
-
-func leadingEnvAssignment(command []string) bool {
-	return core.LeadingEnvAssignment(command)
-}
-
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
 var claimLeaseForRepoProviderPond = core.ClaimLeaseForRepoProviderPond
-
-func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaim(identifier)
-}
-
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
-func shellQuote(s string) string {
-	return core.ShellQuote(s)
-}
-
-func delegatedSyncOptionsError(spec ProviderSpec, req RunRequest) error {
-	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
-}

--- a/internal/providers/freestyle/sync.go
+++ b/internal/providers/freestyle/sync.go
@@ -14,7 +14,7 @@ import (
 
 const maxFreestyleArchiveUploadBytes = 64 << 20
 
-func (b *freestyleBackend) prepareArchive(ctx context.Context, req RunRequest) (*core.PreparedArchive, error) {
+func (b *freestyleBackend) prepareArchive(ctx context.Context, req core.RunRequest) (*core.PreparedArchive, error) {
 	archive, err := core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
 		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
 		TempPattern: "crabbox-freestyle-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
@@ -29,7 +29,7 @@ func (b *freestyleBackend) prepareArchive(ctx context.Context, req RunRequest) (
 	return archive, nil
 }
 
-func (b *freestyleBackend) syncWorkspace(ctx context.Context, client freestyleAPI, name string, req RunRequest, prepared *core.PreparedArchive) ([]timingPhase, time.Duration, error) {
+func (b *freestyleBackend) syncWorkspace(ctx context.Context, client freestyleAPI, name string, req core.RunRequest, prepared *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	workspace, err := freestyleWorkspacePath(b.cfg)
 	if err != nil {
 		return nil, 0, err
@@ -56,7 +56,7 @@ func (b *freestyleBackend) syncWorkspace(ctx context.Context, client freestyleAP
 }
 
 func (b *freestyleBackend) prepareWorkspace(ctx context.Context, client freestyleAPI, name, workspace string) error {
-	return b.execShell(ctx, client, name, "mkdir -p "+shellQuote(workspace))
+	return b.execShell(ctx, client, name, "mkdir -p "+core.ShellQuote(workspace))
 }
 
 func (b *freestyleBackend) uploadArchive(ctx context.Context, client freestyleAPI, name, remoteArchive string, body io.Reader) error {
@@ -68,11 +68,11 @@ func (b *freestyleBackend) uploadArchive(ctx context.Context, client freestyleAP
 	apiPath, remoteB64, decoded := remoteArchive+".api", remoteArchive+".exec.b64", remoteArchive+".exec"
 	defer b.cleanupFreestyleUpload(ctx, client, name, apiPath, remoteB64, decoded)
 	if err := client.WriteFile(ctx, name, apiPath, base64.StdEncoding.EncodeToString(data), "base64"); err == nil {
-		return b.execShell(ctx, client, name, "mv -f "+shellQuote(apiPath)+" "+shellQuote(remoteArchive))
+		return b.execShell(ctx, client, name, "mv -f "+core.ShellQuote(apiPath)+" "+core.ShellQuote(remoteArchive))
 	} else {
 		fmt.Fprintf(b.rt.Stderr, "warning: freestyle file API upload failed; falling back to exec upload: %v\n", err)
 	}
-	if err := b.execShell(ctx, client, name, "rm -f "+shellQuote(remoteB64)+" "+shellQuote(decoded)); err != nil {
+	if err := b.execShell(ctx, client, name, "rm -f "+core.ShellQuote(remoteB64)+" "+core.ShellQuote(decoded)); err != nil {
 		return err
 	}
 	const chunkSize = 48 * 1024
@@ -80,14 +80,14 @@ func (b *freestyleBackend) uploadArchive(ctx context.Context, client freestyleAP
 	for i := 0; i < len(data); i += chunkSize {
 		end := min(i+chunkSize, len(data))
 		chunk := base64.StdEncoding.EncodeToString(data[i:end])
-		command := "printf %s " + shellQuote(chunk) + " >> " + shellQuote(remoteB64)
+		command := "printf %s " + core.ShellQuote(chunk) + " >> " + core.ShellQuote(remoteB64)
 		action := fmt.Sprintf("upload archive chunk %d/%d", i/chunkSize+1, chunkCount)
 		if err := b.execShellRedacted(ctx, client, name, command, action); err != nil {
 			return err
 		}
 	}
-	decode := "if base64 -d < " + shellQuote(remoteB64) + " > " + shellQuote(decoded) + " 2>/dev/null; then :; else base64 --decode < " + shellQuote(remoteB64) + " > " + shellQuote(decoded) + "; fi"
-	return b.execShell(ctx, client, name, decode+" && mv -f "+shellQuote(decoded)+" "+shellQuote(remoteArchive))
+	decode := "if base64 -d < " + core.ShellQuote(remoteB64) + " > " + core.ShellQuote(decoded) + " 2>/dev/null; then :; else base64 --decode < " + core.ShellQuote(remoteB64) + " > " + core.ShellQuote(decoded) + "; fi"
+	return b.execShell(ctx, client, name, decode+" && mv -f "+core.ShellQuote(decoded)+" "+core.ShellQuote(remoteArchive))
 }
 
 func freestyleSyncCleanupContext(parent context.Context) (context.Context, context.CancelFunc) {
@@ -97,7 +97,7 @@ func freestyleSyncCleanupContext(parent context.Context) (context.Context, conte
 func (b *freestyleBackend) cleanupFreestyleUpload(parent context.Context, client freestyleAPI, name string, paths ...string) {
 	quoted := make([]string, 0, len(paths))
 	for _, remotePath := range paths {
-		quoted = append(quoted, shellQuote(remotePath))
+		quoted = append(quoted, core.ShellQuote(remotePath))
 	}
 	cleanupCtx, cancel := freestyleSyncCleanupContext(parent)
 	defer cancel()
@@ -108,7 +108,7 @@ func (b *freestyleBackend) cleanupFreestyleUpload(parent context.Context, client
 
 func checkFreestyleArchiveSize(size int64) error {
 	if size > maxFreestyleArchiveUploadBytes {
-		return exit(6, "freestyle sync archive exceeds %d bytes after compression; narrow sync.include/excludes or split the run", maxFreestyleArchiveUploadBytes)
+		return core.Exit(6, "freestyle sync archive exceeds %d bytes after compression; narrow sync.include/excludes or split the run", maxFreestyleArchiveUploadBytes)
 	}
 	return nil
 }
@@ -126,28 +126,28 @@ func readFreestyleArchiveForUpload(r io.Reader) ([]byte, error) {
 }
 
 func (b *freestyleBackend) execShell(ctx context.Context, client freestyleAPI, name, command string) error {
-	code, err := client.Exec(ctx, name, "bash -lc "+shellQuote(command), io.Discard, b.rt.Stderr)
+	code, err := client.Exec(ctx, name, "bash -lc "+core.ShellQuote(command), io.Discard, b.rt.Stderr)
 	if err != nil {
 		return fmt.Errorf("freestyle exec %q: %w", command, err)
 	}
 	if code != 0 {
-		return exit(code, "freestyle exec %q exited %d", command, code)
+		return core.Exit(code, "freestyle exec %q exited %d", command, code)
 	}
 	return nil
 }
 
 func (b *freestyleBackend) execShellRedacted(ctx context.Context, client freestyleAPI, name, command, action string) error {
-	code, err := client.Exec(ctx, name, "bash -lc "+shellQuote(command), io.Discard, b.rt.Stderr)
+	code, err := client.Exec(ctx, name, "bash -lc "+core.ShellQuote(command), io.Discard, b.rt.Stderr)
 	if err != nil {
 		return fmt.Errorf("freestyle %s: %w", action, err)
 	}
 	if code != 0 {
-		return exit(code, "freestyle %s exited %d", action, code)
+		return core.Exit(code, "freestyle %s exited %d", action, code)
 	}
 	return nil
 }
 
-func freestyleWorkspacePath(cfg Config) (string, error) {
+func freestyleWorkspacePath(cfg core.Config) (string, error) {
 	workdir, err := freestyleRelativeWorkdir(cfg)
 	if err != nil {
 		return "", err
@@ -155,17 +155,17 @@ func freestyleWorkspacePath(cfg Config) (string, error) {
 	return path.Join("/workspace", workdir), nil
 }
 
-func freestyleRelativeWorkdir(cfg Config) (string, error) {
+func freestyleRelativeWorkdir(cfg core.Config) (string, error) {
 	workdir := strings.TrimSpace(cfg.Freestyle.Workdir)
 	if workdir == "" {
 		workdir = core.FreestyleConfigDefaultWorkdir
 	}
 	if strings.HasPrefix(workdir, "/") {
-		return "", exit(2, "freestyle workdir %q must be relative under /workspace", workdir)
+		return "", core.Exit(2, "freestyle workdir %q must be relative under /workspace", workdir)
 	}
 	workdir = path.Clean(workdir)
 	if workdir == "." || workdir == ".." || strings.HasPrefix(workdir, "../") {
-		return "", exit(2, "freestyle workdir %q escapes /workspace", workdir)
+		return "", core.Exit(2, "freestyle workdir %q escapes /workspace", workdir)
 	}
 	return workdir, nil
 }

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -20,15 +20,15 @@ import (
 )
 
 type backend struct {
-	spec                     ProviderSpec
-	cfg                      Config
-	rt                       Runtime
+	spec                     core.ProviderSpec
+	cfg                      core.Config
+	rt                       core.Runtime
 	api                      machine0API
 	sleep                    func(context.Context, time.Duration) error
 	stat                     func(string) (os.FileInfo, error)
 	knownHostsFile           func(string, string) (string, error)
-	waitSSH                  func(context.Context, *SSHTarget, time.Duration) error
-	prepareNativeImageSource func(context.Context, SSHTarget) error
+	waitSSH                  func(context.Context, *core.SSHTarget, time.Duration) error
+	prepareNativeImageSource func(context.Context, core.SSHTarget) error
 }
 
 type machine0PrepareOptions struct {
@@ -36,21 +36,21 @@ type machine0PrepareOptions struct {
 	ResetHostTrust bool
 }
 
-func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	applyDefaults(&cfg)
 	b := &backend{spec: spec, cfg: cfg, rt: rt}
 	b.api = &client{cfg: cfg.Machine0, rt: rt, sleep: sleepContext}
 	b.sleep = sleepContext
 	b.stat = os.Stat
 	b.knownHostsFile = machine0KnownHostsFile
-	b.waitSSH = func(ctx context.Context, target *SSHTarget, timeout time.Duration) error {
-		return waitForSSHReady(ctx, target, rt.Stderr, "machine0", timeout)
+	b.waitSSH = func(ctx context.Context, target *core.SSHTarget, timeout time.Duration) error {
+		return core.WaitForSSHReady(ctx, target, rt.Stderr, "machine0", timeout)
 	}
 	b.prepareNativeImageSource = core.PrepareNativeImageSource
 	return b
 }
 
-func applyDefaults(cfg *Config) {
+func applyDefaults(cfg *core.Config) {
 	base := core.BaseConfig().Machine0
 	cfg.Provider = providerName
 	if cfg.TargetOS == "" {
@@ -88,19 +88,19 @@ func applyDefaults(cfg *Config) {
 	cfg.ServerType = cfg.Machine0.Size
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
 func (b *backend) SupportsRequestedLeaseID() bool { return true }
 
 func (b *backend) SupportsRequestedCheckpointID() bool { return true }
 
-func (b *backend) configForRun() Config {
+func (b *backend) configForRun() core.Config {
 	cfg := b.cfg
 	applyDefaults(&cfg)
 	return cfg
 }
 
-func effectiveMachine0Config(cfg Config, item machine) Config {
+func effectiveMachine0Config(cfg core.Config, item machine) core.Config {
 	user := machine0SSHUser(item)
 	workRoot := cfg.Machine0.WorkRoot
 	if strings.TrimSpace(workRoot) == "" {
@@ -122,33 +122,33 @@ func machine0SSHUser(item machine) string {
 	return "ubuntu"
 }
 
-func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	if strings.TrimSpace(req.RequestedLeaseID) != "" {
 		return b.acquireFixed(ctx, req)
 	}
 	cfg := b.configForRun()
 	if err := b.preflightSSHKey(ctx, cfg.Machine0.Key); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if err := b.validateCatalogSelection(ctx, cfg.Machine0.Size, cfg.Machine0.Region); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	machines, err := b.api.List(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	claims, err := machine0Claims()
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	servers := make([]Server, 0, len(machines))
+	servers := make([]core.Server, 0, len(machines))
 	for _, item := range machines {
 		servers = append(servers, b.serverFromMachine(item, claims[item.ID], cfg))
 	}
 	leaseID := core.NewLeaseID()
-	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	name := machine0MachineName(leaseID, slug)
 	image := cfg.Machine0.Image
@@ -157,13 +157,13 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	}
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s size=%s region=%s image=%s keep=%v\n", providerName, leaseID, slug, name, cfg.Machine0.Size, cfg.Machine0.Region, image, req.Keep)
 	if err := b.api.Create(ctx, createMachineRequest{Name: name, Size: cfg.Machine0.Size, Region: cfg.Machine0.Region, Image: image, ImageVersion: cfg.Machine0.ImageVersion, Key: cfg.Machine0.Key}); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	pendingMachine := machine{Name: name, Status: "CREATING", Size: cfg.Machine0.Size, Region: cfg.Machine0.Region, Image: image, ImageVersion: cfg.Machine0.ImageVersion}
-	pendingServer := Server{Provider: providerName, Name: name, Status: "provisioning", Labels: machineLabels(cfg, pendingMachine, leaseID, slug, req.Keep, core.ClockNow(b.rt.Clock).UTC())}
+	pendingServer := core.Server{Provider: providerName, Name: name, Status: "provisioning", Labels: machineLabels(cfg, pendingMachine, leaseID, slug, req.Keep, core.ClockNow(b.rt.Clock).UTC())}
 	pendingServer.Labels["recovery"] = "create-pending"
 	recoveryClaim, claimErr := core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurable(
-		leaseID, slug, cfg, machine0NameScope(name), pendingServer, SSHTarget{}, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, LeaseClaim{}, false,
+		leaseID, slug, cfg, machine0NameScope(name), pendingServer, core.SSHTarget{}, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, core.LeaseClaim{}, false,
 	)
 	if claimErr != nil || recoveryClaim.LeaseID == "" {
 		if claimErr == nil {
@@ -172,9 +172,9 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
 		if cleanupErr := b.api.Remove(cleanupCtx, name); cleanupErr != nil {
-			return LeaseTarget{}, errors.Join(fmt.Errorf("persist machine0 recovery claim for %s: %w", name, claimErr), fmt.Errorf("machine0 rollback failed for %s; remove the machine manually: %w", name, cleanupErr))
+			return core.LeaseTarget{}, errors.Join(fmt.Errorf("persist machine0 recovery claim for %s: %w", name, claimErr), fmt.Errorf("machine0 rollback failed for %s; remove the machine manually: %w", name, cleanupErr))
 		}
-		return LeaseTarget{}, fmt.Errorf("persist machine0 recovery claim for %s: %w", name, claimErr)
+		return core.LeaseTarget{}, fmt.Errorf("persist machine0 recovery claim for %s: %w", name, claimErr)
 	}
 	rollback := func(cause error) error {
 		if req.Keep {
@@ -191,31 +191,31 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	}
 	item, err := b.waitForRunning(ctx, name, cfg.Machine0.CreateTimeout)
 	if err != nil {
-		return LeaseTarget{}, rollback(err)
+		return core.LeaseTarget{}, rollback(err)
 	}
 	if err := validateCreatedMachine(item, name, cfg.Machine0.Size); err != nil {
-		return LeaseTarget{}, rollback(err)
+		return core.LeaseTarget{}, rollback(err)
 	}
 	cfg = effectiveMachine0Config(cfg, item)
 	boundClaim, err := b.bindRecoveryClaim(recoveryClaim, item, cfg)
 	if err != nil {
-		return LeaseTarget{}, rollback(err)
+		return core.LeaseTarget{}, rollback(err)
 	}
 	recoveryClaim = boundClaim
-	claim := LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: machineScope(item.ID)}
+	claim := core.LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: machineScope(item.ID)}
 	server := b.serverFromMachine(item, claim, cfg)
 	server.Labels = machineLabels(cfg, item, leaseID, slug, req.Keep, core.ClockNow(b.rt.Clock).UTC())
 	lease, err := b.prepareLease(ctx, item, server, leaseID, true)
 	if err != nil {
-		return LeaseTarget{}, rollback(err)
+		return core.LeaseTarget{}, rollback(err)
 	}
 	if req.OnAcquired != nil {
 		if err := req.OnAcquired(lease); err != nil {
-			return LeaseTarget{}, rollback(err)
+			return core.LeaseTarget{}, rollback(err)
 		}
 	}
 	if err := claimLease(leaseID, slug, cfg, req.Repo.Root, req.Reclaim, lease.Server, lease.SSH); err != nil {
-		return LeaseTarget{}, rollback(err)
+		return core.LeaseTarget{}, rollback(err)
 	}
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s machine=%s resource=%s state=ready\n", leaseID, item.Name, item.ID)
 	return lease, nil
@@ -229,7 +229,7 @@ func (b *backend) preflightSSHKey(ctx context.Context, name string) error {
 	if key == nil {
 		keyRoot, err := machine0SSHKeyDirectory()
 		if err != nil {
-			return exit(2, "Machine0 has no default SSH key: set SSH_KEY_PATH or select an existing key with --machine0-key")
+			return core.Exit(2, "Machine0 has no default SSH key: set SSH_KEY_PATH or select an existing key with --machine0-key")
 		}
 		for _, name := range []string{"id_rsa", "id_rsa.pub"} {
 			keyPath := filepath.Join(keyRoot, name)
@@ -240,7 +240,7 @@ func (b *backend) preflightSSHKey(ctx context.Context, name string) error {
 			if err == nil {
 				err = errors.New("not a regular file")
 			}
-			return exit(2, "Machine0 has no default SSH key and cannot use legacy key file %q: %v; provide both id_rsa and id_rsa.pub in SSH_KEY_PATH, or select an existing key with --machine0-key", keyPath, err)
+			return core.Exit(2, "Machine0 has no default SSH key and cannot use legacy key file %q: %v; provide both id_rsa and id_rsa.pub in SSH_KEY_PATH, or select an existing key with --machine0-key", keyPath, err)
 		}
 		return nil
 	}
@@ -249,11 +249,11 @@ func (b *backend) preflightSSHKey(ctx context.Context, name string) error {
 	}
 	fileName := strings.TrimSpace(key.FileName)
 	if fileName == "" || filepath.IsAbs(fileName) || fileName == "." || fileName == ".." || strings.ContainsAny(fileName, `/\`) || filepath.Base(fileName) != fileName {
-		return exit(2, "Machine0 PUBLIC SSH key %q has no usable local private-key filename; select a managed key with --machine0-key <managed-key-name>", core.Blank(key.Name, "<default>"))
+		return core.Exit(2, "Machine0 PUBLIC SSH key %q has no usable local private-key filename; select a managed key with --machine0-key <managed-key-name>", core.Blank(key.Name, "<default>"))
 	}
 	keyRoot, err := machine0SSHKeyDirectory()
 	if err != nil {
-		return exit(2, "resolve private key for Machine0 PUBLIC SSH key %q: set SSH_KEY_PATH or select --machine0-key <managed-key-name>", core.Blank(key.Name, "<default>"))
+		return core.Exit(2, "resolve private key for Machine0 PUBLIC SSH key %q: set SSH_KEY_PATH or select --machine0-key <managed-key-name>", core.Blank(key.Name, "<default>"))
 	}
 	keyPath := filepath.Join(keyRoot, fileName)
 	info, err := b.stat(keyPath)
@@ -268,7 +268,7 @@ func (b *backend) preflightSSHKey(ctx context.Context, name string) error {
 		}
 		// Like native Machine0 SSH, compare the private file, not its .pub sidecar.
 		// Failed noninteractive extraction (including encrypted keys) is unknown.
-		result, extractErr := b.rt.Exec.Run(ctx, LocalCommandRequest{
+		result, extractErr := b.rt.Exec.Run(ctx, core.LocalCommandRequest{
 			Name: "ssh-keygen", Args: []string{"-y", "-P", "", "-f", keyPath},
 			MaxCapturedOutputBytes: 64 << 10,
 		})
@@ -277,15 +277,15 @@ func (b *backend) preflightSSHKey(ctx context.Context, name string) error {
 		}
 		if extractErr == nil && result.ExitCode == 0 {
 			if local := machine0BarePublicKey(result.Stdout); local != nil && !bytes.Equal(local.Marshal(), registered.Marshal()) {
-				return exit(2, "Machine0 PUBLIC SSH key does not match the local private key; provide the matching local key or select the intended key with --machine0-key")
+				return core.Exit(2, "Machine0 PUBLIC SSH key does not match the local private key; provide the matching local key or select the intended key with --machine0-key")
 			}
 		}
 		return nil
 	}
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return exit(2, "inspect private key for Machine0 PUBLIC SSH key %q at %q: %v", core.Blank(key.Name, "<default>"), keyPath, err)
+		return core.Exit(2, "inspect private key for Machine0 PUBLIC SSH key %q at %q: %v", core.Blank(key.Name, "<default>"), keyPath, err)
 	}
-	return exit(2, "Machine0 PUBLIC SSH key %q has no local private key at %q; select a managed key with --machine0-key <managed-key-name>", core.Blank(key.Name, "<default>"), keyPath)
+	return core.Exit(2, "Machine0 PUBLIC SSH key %q has no local private key at %q; select a managed key with --machine0-key <managed-key-name>", core.Blank(key.Name, "<default>"), keyPath)
 }
 
 func machine0SSHKeyDirectory() (string, error) {
@@ -320,23 +320,23 @@ func machine0BarePublicKey(value string) ssh.PublicKey {
 	return key
 }
 
-func resolveClaim(identifier string) (LeaseClaim, bool, error) {
+func resolveClaim(identifier string) (core.LeaseClaim, bool, error) {
 	identifier = strings.TrimSpace(identifier)
 	claim, exists, err := core.ResolveLeaseClaimForProvider(identifier, providerName)
 	if err != nil || !exists {
 		return claim, exists, err
 	}
 	if err := validateResolvedMachine0Claim(identifier, claim); err != nil {
-		return LeaseClaim{}, false, err
+		return core.LeaseClaim{}, false, err
 	}
 	return claim, true, nil
 }
 
-func validateResolvedMachine0Claim(identifier string, claim LeaseClaim) error {
+func validateResolvedMachine0Claim(identifier string, claim core.LeaseClaim) error {
 	if claim.Provider == core.FixedMachine0ClaimProvider || claim.FixedCreateIntent != nil {
 		var err error
 		if claim.FixedCreateIntent != nil && claim.FixedCreateIntent.State == fixedMachine0IntentReleased {
-			err = fixedMachine0LeaseKind.ValidateTerminalClaim(claim, LeaseClaim{}, claim.LeaseID, validateFixedMachine0TerminalClaimExtra)
+			err = fixedMachine0LeaseKind.ValidateTerminalClaim(claim, core.LeaseClaim{}, claim.LeaseID, validateFixedMachine0TerminalClaimExtra)
 		} else {
 			_, err = fixedMachine0ClaimAttempt(claim)
 		}
@@ -344,25 +344,25 @@ func validateResolvedMachine0Claim(identifier string, claim LeaseClaim) error {
 			return err
 		}
 	} else if firstNonBlank(claim.Labels["machine0_name"], claim.CloudID) == "" {
-		return exit(4, "machine0 lease %q has no bound native resource", identifier)
+		return core.Exit(4, "machine0 lease %q has no bound native resource", identifier)
 	}
 	return nil
 }
 
-func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	return b.resolve(ctx, req, nil)
 }
 
-func (b *backend) ResolveRunLeaseUnderClaim(ctx context.Context, req ResolveRequest, original core.LeaseClaim) (LeaseTarget, error) {
+func (b *backend) ResolveRunLeaseUnderClaim(ctx context.Context, req core.ResolveRequest, original core.LeaseClaim) (core.LeaseTarget, error) {
 	return b.resolve(ctx, req, &original)
 }
 
-func (b *backend) resolve(ctx context.Context, req ResolveRequest, original *LeaseClaim) (LeaseTarget, error) {
+func (b *backend) resolve(ctx context.Context, req core.ResolveRequest, original *core.LeaseClaim) (core.LeaseTarget, error) {
 	if req.Reclaim && req.Repo.Root == "" {
-		return LeaseTarget{}, exit(2, "machine0 --reclaim requires repository context")
+		return core.LeaseTarget{}, core.Exit(2, "machine0 --reclaim requires repository context")
 	}
 	baseCfg := b.configForRun()
-	var claim LeaseClaim
+	var claim core.LeaseClaim
 	var claimed bool
 	var err error
 	if original == nil {
@@ -372,7 +372,7 @@ func (b *backend) resolve(ctx context.Context, req ResolveRequest, original *Lea
 		err = validateResolvedMachine0Claim(req.ID, claim)
 	}
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	lookup := strings.TrimSpace(req.ID)
 	if claimed {
@@ -381,30 +381,30 @@ func (b *backend) resolve(ctx context.Context, req ResolveRequest, original *Lea
 	var item machine
 	if claimed && (claim.Provider == core.FixedMachine0ClaimProvider || claim.FixedCreateIntent != nil) {
 		if req.Repo.Root != "" && claim.RepoRoot != "" && req.Repo.Root != claim.RepoRoot && !req.Reclaim {
-			return LeaseTarget{}, exit(4, "lease_id_conflict: fixed Machine0 lease %s is bound to another repository", claim.LeaseID)
+			return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: fixed Machine0 lease %s is bound to another repository", claim.LeaseID)
 		}
 		item, err = b.resolveFixedMachine0(ctx, claim)
 		if err == nil && item.ID != "" && original == nil && !req.NoLocalStateMutations {
 			claim, err = b.bindFixedMachine0Claim(claim, item)
 		}
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		if item.ID == "" {
 			if claim.CloudID == "" && claim.FixedCreateIntent.State != fixedMachine0IntentReleased {
-				return LeaseTarget{}, exit(4, "fixed Machine0 lease %s has no observed resource; retain its claim and inspect the create attempt", claim.LeaseID)
+				return core.LeaseTarget{}, core.Exit(4, "fixed Machine0 lease %s has no observed resource; retain its claim and inspect the create attempt", claim.LeaseID)
 			}
-			server := Server{Provider: providerName, CloudID: claim.CloudID, ImmutableID: claim.CloudImmutableID, Status: "deleted", Labels: map[string]string{"lease": claim.LeaseID, "slug": claim.Slug, "state": "deleted"}}
+			server := core.Server{Provider: providerName, CloudID: claim.CloudID, ImmutableID: claim.CloudImmutableID, Status: "deleted", Labels: map[string]string{"lease": claim.LeaseID, "slug": claim.Slug, "state": "deleted"}}
 			if claim.FixedCreateIntent.State == fixedMachine0IntentReleased {
 				server.Status, server.Labels["state"] = "released", "released"
 			}
 			core.SetServerLeaseClaimSnapshot(&server, claim, true)
-			return LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
+			return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
 		}
 	} else if !claimed && core.IsCanonicalLeaseID(lookup) {
 		machines, err := b.api.List(ctx)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		suffix := machine0LeaseSuffix(lookup)
 		for _, candidate := range machines {
@@ -412,49 +412,49 @@ func (b *backend) resolve(ctx context.Context, req ResolveRequest, original *Lea
 				continue
 			}
 			if item.Name != "" {
-				return LeaseTarget{}, exit(4, "multiple Machine0 machines match lease %s", lookup)
+				return core.LeaseTarget{}, core.Exit(4, "multiple Machine0 machines match lease %s", lookup)
 			}
 			item = candidate
 		}
 		if item.Name == "" {
-			return LeaseTarget{}, exit(4, "lease/server not found: %s", lookup)
+			return core.LeaseTarget{}, core.Exit(4, "lease/server not found: %s", lookup)
 		}
-		return LeaseTarget{}, exit(4, "machine0 lease %s has no local claim; candidate %q matches only a short name hash: inspect the machine and use its explicit name with --reclaim to adopt it", lookup, item.Name)
+		return core.LeaseTarget{}, core.Exit(4, "machine0 lease %s has no local claim; candidate %q matches only a short name hash: inspect the machine and use its explicit name with --reclaim to adopt it", lookup, item.Name)
 	} else {
 		item, err = b.api.Get(ctx, lookup)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	cfg := effectiveMachine0Config(baseCfg, item)
 	if claimed && claim.CloudID != "" && claim.CloudID != item.ID {
-		return LeaseTarget{}, exit(4, "machine0 lease=%s resource identity changed: expected %s, found %s", claim.LeaseID, claim.CloudID, item.ID)
+		return core.LeaseTarget{}, core.Exit(4, "machine0 lease=%s resource identity changed: expected %s, found %s", claim.LeaseID, claim.CloudID, item.ID)
 	}
 	// Explicit-name status probes may discover SSH access without adopting a claim.
 	if !claimed && !req.Reclaim && !req.ReleaseOnly && !req.StatusOnly {
-		return LeaseTarget{}, exit(4, "machine0 machine %q has no Crabbox lease claim; reuse it with explicit --reclaim", item.Name)
+		return core.LeaseTarget{}, core.Exit(4, "machine0 machine %q has no Crabbox lease claim; reuse it with explicit --reclaim", item.Name)
 	}
 	leaseID := claim.LeaseID
 	slug := claim.Slug
 	if !claimed && req.Reclaim {
 		if req.Repo.Root == "" {
-			return LeaseTarget{}, exit(2, "machine0 --reclaim requires repository context")
+			return core.LeaseTarget{}, core.Exit(2, "machine0 --reclaim requires repository context")
 		}
 		leaseID = core.NewLeaseID()
 		slug = core.NormalizeLeaseSlug(item.Name)
 		if slug == "" {
 			slug = core.NewLeaseSlug(leaseID)
 		}
-		claim = LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: machineScope(item.ID)}
+		claim = core.LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: machineScope(item.ID)}
 	}
 	server := b.serverFromMachine(item, claim, cfg)
 	if fixedMachine0LeaseKind.IsFixedClaim(claim) {
 		core.SetServerLeaseClaimSnapshot(&server, claim, true)
 	}
 	if req.ReleaseOnly || (req.StatusOnly && !req.ReadyProbe) {
-		return LeaseTarget{Server: server, LeaseID: leaseID}, nil
+		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
 	}
-	prepare := func() (LeaseTarget, error) {
+	prepare := func() (core.LeaseTarget, error) {
 		resetHostTrust := !machineRunning(item.Status)
 		if resetHostTrust {
 			item, err = b.waitForResolveRunning(ctx, item, cfg.Machine0.CreateTimeout, true, func(previous, observed machine) (machine, error) {
@@ -464,7 +464,7 @@ func (b *backend) resolve(ctx context.Context, req ResolveRequest, original *Lea
 				return observed, nil
 			})
 			if err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 			cfg = effectiveMachine0Config(baseCfg, item)
 			server = b.serverFromMachine(item, claim, cfg)
@@ -475,17 +475,17 @@ func (b *backend) resolve(ctx context.Context, req ResolveRequest, original *Lea
 		// Core already owns the claim transaction; preparation keeps its
 		// checkpoint fence without reentering endpoint publication.
 		if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		return prepare()
 	}
 	if claimed {
-		var lease LeaseTarget
-		updated, _, _, err := core.UpdateLeaseClaimEndpointIfUnchangedAction(leaseID, claim, func() (Server, SSHTarget, bool, error) {
+		var lease core.LeaseTarget
+		updated, _, _, err := core.UpdateLeaseClaimEndpointIfUnchangedAction(leaseID, claim, func() (core.Server, core.SSHTarget, bool, error) {
 			// Admission reserves under this claim fence, even before it binds a
 			// new revision. Check the journal here and hold through Start/SSH/write.
 			if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
-				return Server{}, SSHTarget{}, false, err
+				return core.Server{}, core.SSHTarget{}, false, err
 			}
 			var err error
 			lease, err = prepare()
@@ -504,18 +504,18 @@ func (b *backend) resolve(ctx context.Context, req ResolveRequest, original *Lea
 	}
 	lease, err := prepare()
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if !claimed && req.Reclaim {
 		lease.Server.Labels = machineLabels(cfg, item, leaseID, slug, true, core.ClockNow(b.rt.Clock).UTC())
 		if err := claimLease(leaseID, slug, cfg, req.Repo.Root, true, lease.Server, lease.SSH); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	return lease, nil
 }
 
-func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	cfg := b.configForRun()
 	machines, err := b.api.List(ctx)
 	if err != nil {
@@ -525,7 +525,7 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 	if err != nil {
 		return nil, err
 	}
-	views := make([]LeaseView, 0, len(machines))
+	views := make([]core.LeaseView, 0, len(machines))
 	for _, item := range machines {
 		claim := claims[item.ID]
 		if claim.LeaseID == "" {
@@ -539,7 +539,7 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 	return views, nil
 }
 
-func (b *backend) AuthorizeStatusTouchClaim(_ context.Context, lease LeaseTarget, claim LeaseClaim) error {
+func (b *backend) AuthorizeStatusTouchClaim(_ context.Context, lease core.LeaseTarget, claim core.LeaseClaim) error {
 	if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
 		return err
 	}
@@ -547,18 +547,18 @@ func (b *backend) AuthorizeStatusTouchClaim(_ context.Context, lease LeaseTarget
 	if !core.IsCanonicalLeaseID(lease.LeaseID) || claim.LeaseID != lease.LeaseID ||
 		lease.Server.Provider != providerName || !isMachine0ClaimProvider(claim.Provider) ||
 		resourceID == "" || lease.Server.ImmutableID != resourceID || claim.CloudImmutableID != resourceID {
-		return exit(4, "refusing machine0 lifecycle touch for lease=%s resource=%s: claim does not match the canonical lease, provider, or immutable Machine0 identity", lease.LeaseID, core.Blank(resourceID, "<empty>"))
+		return core.Exit(4, "refusing machine0 lifecycle touch for lease=%s resource=%s: claim does not match the canonical lease, provider, or immutable Machine0 identity", lease.LeaseID, core.Blank(resourceID, "<empty>"))
 	}
 	if err := validateMachineClaimOwnership(claim, machine{ID: resourceID}); err != nil {
-		return exit(4, "refusing machine0 lifecycle touch for lease=%s resource=%s: %v", lease.LeaseID, resourceID, err)
+		return core.Exit(4, "refusing machine0 lifecycle touch for lease=%s resource=%s: %v", lease.LeaseID, resourceID, err)
 	}
 	return nil
 }
 
-func (b *backend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
+func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
 	updated, err := shared.CommitClaimTouch(ctx, req, shared.ClaimTouchPolicy{
 		Provider: "machine0", Authorize: b.AuthorizeStatusTouchClaim,
-		Prepare: func(expected LeaseClaim) (map[string]string, time.Time) {
+		Prepare: func(expected core.LeaseClaim) (map[string]string, time.Time) {
 			cfg := b.configForRun()
 			if expected.IdleTimeoutSeconds > 0 {
 				cfg.IdleTimeout = time.Duration(expected.IdleTimeoutSeconds) * time.Second
@@ -574,7 +574,7 @@ func (b *backend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
 		},
 	})
 	if err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	server := req.Lease.Server
 	server.Labels = updated.Labels
@@ -582,18 +582,18 @@ func (b *backend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
 	return server, nil
 }
 
-func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
 	return err
 }
 
-func (b *backend) ReleaseLeaseWithOutcome(ctx context.Context, req ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+func (b *backend) ReleaseLeaseWithOutcome(ctx context.Context, req core.ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
 	var outcome core.ReleaseLeaseOutcome
 	err := b.releaseLease(ctx, req, &outcome)
 	return outcome, err
 }
 
-func (b *backend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
+func (b *backend) releaseLease(ctx context.Context, req core.ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	if err := core.ValidateLeaseTargetProviderIdentity(req.Lease, req.ExpectedProviderIdentity); err != nil {
 		return err
 	}
@@ -611,10 +611,10 @@ func (b *backend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, out
 	if claimed && claim.Provider == providerName && claim.CloudID == "" && claim.Labels["recovery"] == "create-pending" {
 		name := machine0MachineName(claim.LeaseID, claim.Slug)
 		if claim.ProviderScope != machine0NameScope(name) || claim.Labels["machine0_name"] != name {
-			return exit(2, "refusing machine0 recovery release for lease=%s: pending machine name does not match its durable claim", claim.LeaseID)
+			return core.Exit(2, "refusing machine0 recovery release for lease=%s: pending machine name does not match its durable claim", claim.LeaseID)
 		}
 		if normalizeReleasePolicy(b.configForRun().Machine0.ReleasePolicy) != "destroy" {
-			return exit(2, "pending machine0 lease=%s cannot be suspended before its resource identity is known; use --machine0-release-policy destroy", claim.LeaseID)
+			return core.Exit(2, "pending machine0 lease=%s cannot be suspended before its resource identity is known; use --machine0-release-policy destroy", claim.LeaseID)
 		}
 		// Pending claims retain only the exact-name deletion already authorized by create rollback.
 		return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
@@ -633,10 +633,10 @@ func (b *backend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, out
 	if normalizeReleasePolicy(b.configForRun().Machine0.ReleasePolicy) == "suspend" {
 		return b.suspendClaimedMachine(ctx, claim, item)
 	}
-	return b.destroyClaimedMachineWithOutcome(ctx, claim, LeaseTarget{LeaseID: claim.LeaseID, Server: b.serverFromMachine(item, claim, b.configForRun())}, outcome)
+	return b.destroyClaimedMachineWithOutcome(ctx, claim, core.LeaseTarget{LeaseID: claim.LeaseID, Server: b.serverFromMachine(item, claim, b.configForRun())}, outcome)
 }
 
-func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
+func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	cfg := b.configForRun()
 	machines, err := b.api.List(ctx)
 	if err != nil {
@@ -681,7 +681,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			if err := b.suspendClaimedMachine(ctx, claim, item); err != nil {
 				return err
 			}
-		} else if err := b.destroyClaimedMachine(ctx, claim, LeaseTarget{LeaseID: claim.LeaseID, Server: server}); err != nil {
+		} else if err := b.destroyClaimedMachine(ctx, claim, core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}); err != nil {
 			return err
 		}
 		removed++
@@ -713,7 +713,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s reason=missing machine\n", claim.LeaseID)
 			continue
 		}
-		if err := b.destroyClaimedMachine(ctx, claim, LeaseTarget{LeaseID: claim.LeaseID}); err != nil {
+		if err := b.destroyClaimedMachine(ctx, claim, core.LeaseTarget{LeaseID: claim.LeaseID}); err != nil {
 			return err
 		}
 		claimsRemoved++
@@ -724,22 +724,22 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	return nil
 }
 
-func (b *backend) RetainLeaseClaimAfterRelease(lease LeaseTarget) bool {
-	retained, err := b.retainLeaseClaimAfterRelease(lease, LeaseClaim{})
+func (b *backend) RetainLeaseClaimAfterRelease(lease core.LeaseTarget) bool {
+	retained, err := b.retainLeaseClaimAfterRelease(lease, core.LeaseClaim{})
 	return retained || err != nil
 }
 
-func (b *backend) RetainLeaseClaimAfterReleaseWithClaim(lease LeaseTarget, previous LeaseClaim) (bool, error) {
+func (b *backend) RetainLeaseClaimAfterReleaseWithClaim(lease core.LeaseTarget, previous core.LeaseClaim) (bool, error) {
 	return b.retainLeaseClaimAfterRelease(lease, previous)
 }
 
-func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
+func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 	action := normalizeReleasePolicy(b.configForRun().Machine0.ReleasePolicy)
 	return fmt.Sprintf("released lease=%s machine=%s action=%s", lease.LeaseID, core.Blank(lease.Server.Name, "-"), action)
 }
 
-func (b *backend) Pause(ctx context.Context, req PauseRequest) error {
-	claim, item, err := b.releaseTarget(ctx, LeaseTarget{LeaseID: req.ID})
+func (b *backend) Pause(ctx context.Context, req core.PauseRequest) error {
+	claim, item, err := b.releaseTarget(ctx, core.LeaseTarget{LeaseID: req.ID})
 	if err != nil {
 		return err
 	}
@@ -749,19 +749,19 @@ func (b *backend) Pause(ctx context.Context, req PauseRequest) error {
 	return b.suspendClaimedMachine(ctx, claim, item)
 }
 
-func (b *backend) Resume(ctx context.Context, req ResumeRequest) error {
+func (b *backend) Resume(ctx context.Context, req core.ResumeRequest) error {
 	claim, _, err := resolveClaim(req.ID)
 	if err != nil {
 		return err
 	}
 	if fixedMachine0LeaseKind.IsFixedClaim(claim) {
-		lease, err := b.Resolve(ctx, ResolveRequest{ID: req.ID, Prepare: true})
+		lease, err := b.Resolve(ctx, core.ResolveRequest{ID: req.ID, Prepare: true})
 		if err == nil && lease.Server.Status != "ready" {
-			return exit(4, "fixed Machine0 lease %s has no live resource to resume", claim.LeaseID)
+			return core.Exit(4, "fixed Machine0 lease %s has no live resource to resume", claim.LeaseID)
 		}
 		return err
 	}
-	claim, item, err := b.releaseTarget(ctx, LeaseTarget{LeaseID: req.ID})
+	claim, item, err := b.releaseTarget(ctx, core.LeaseTarget{LeaseID: req.ID})
 	if err != nil {
 		return err
 	}
@@ -770,7 +770,7 @@ func (b *backend) Resume(ctx context.Context, req ResumeRequest) error {
 	}
 	resetHostTrust := !machineRunning(item.Status)
 	if resetHostTrust {
-		if err := withClaimUnchanged(claim.LeaseID, claim, func() error {
+		if err := core.WithLeaseClaimUnchanged(claim.LeaseID, claim, func() error {
 			if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
 				return err
 			}
@@ -788,11 +788,11 @@ func (b *backend) Resume(ctx context.Context, req ResumeRequest) error {
 	if err != nil {
 		return err
 	}
-	_, err = updateClaim(claim.LeaseID, claim, lease.Server, lease.SSH)
+	_, err = core.UpdateLeaseClaimEndpointIfUnchanged(claim.LeaseID, claim, lease.Server, lease.SSH)
 	return err
 }
 
-func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, error) {
+func (b *backend) Doctor(ctx context.Context, req core.DoctorRequest) (core.DoctorResult, error) {
 	type probeResult struct {
 		version  string
 		sizes    []machineSize
@@ -841,13 +841,13 @@ func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, 
 		}
 	}
 	if probeErr != nil {
-		return DoctorResult{}, probeErr
+		return core.DoctorResult{}, probeErr
 	}
 	probe := "unchecked"
 	if req.ProbeSSH {
 		probe = "requires_running_lease"
 	}
-	return DoctorResult{Provider: providerName, Message: fmt.Sprintf("cli=ready auth=ready control_plane=ready inventory=ready ssh_key_prerequisites=checked mutation=false leases=%d sizes=%d runtime=%s version=%s", len(machines), len(sizes), probe, firstLine(version))}, nil
+	return core.DoctorResult{Provider: providerName, Message: fmt.Sprintf("cli=ready auth=ready control_plane=ready inventory=ready ssh_key_prerequisites=checked mutation=false leases=%d sizes=%d runtime=%s version=%s", len(machines), len(sizes), probe, firstLine(version))}, nil
 }
 
 func (b *backend) SizeSelection() core.ProviderSizeSelection {
@@ -890,21 +890,21 @@ func (b *backend) validateCatalogSelection(ctx context.Context, sizeName, region
 				return nil
 			}
 		}
-		return exit(2, "machine0 size %q is not currently available in region %q; available regions: %s", sizeName, region, core.Blank(strings.Join(size.Regions, ","), "none"))
+		return core.Exit(2, "machine0 size %q is not currently available in region %q; available regions: %s", sizeName, region, core.Blank(strings.Join(size.Regions, ","), "none"))
 	}
 	available := make([]string, 0, len(sizes))
 	for _, size := range sizes {
 		available = append(available, size.Size)
 	}
-	return exit(2, "machine0 size %q is not in the live catalog; available: %s", sizeName, strings.Join(available, ","))
+	return core.Exit(2, "machine0 size %q is not in the live catalog; available: %s", sizeName, strings.Join(available, ","))
 }
 
 func validateCreatedMachine(item machine, name, size string) error {
 	if item.Name != name {
-		return exit(5, "machine0 create returned mismatched machine name: expected %s, found %s", name, item.Name)
+		return core.Exit(5, "machine0 create returned mismatched machine name: expected %s, found %s", name, item.Name)
 	}
 	if item.Size != size {
-		return exit(5, "machine0 create returned mismatched machine size: expected %s, found %s", size, item.Size)
+		return core.Exit(5, "machine0 create returned mismatched machine size: expected %s, found %s", size, item.Size)
 	}
 	return nil
 }
@@ -925,12 +925,12 @@ func (b *backend) waitForRunningState(ctx context.Context, name string, timeout 
 		if target == "" {
 			switch {
 			case machineStopped(item.Status):
-				return false, exit(5, "machine0 machine %s reached stable state %s while waiting for creation", item.Name, item.Status)
+				return false, core.Exit(5, "machine0 machine %s reached stable state %s while waiting for creation", item.Name, item.Status)
 			case !machineAcquirePending(item.Status):
-				return false, exit(5, "machine0 machine %s entered unexpected state %s", item.Name, item.Status)
+				return false, core.Exit(5, "machine0 machine %s entered unexpected state %s", item.Name, item.Status)
 			}
 		} else if !machinePending(item.Status) && !machineStopped(item.Status) {
-			return false, exit(5, "machine0 machine %s entered unexpected state %s after start", item.Name, item.Status)
+			return false, core.Exit(5, "machine0 machine %s entered unexpected state %s after start", item.Name, item.Status)
 		}
 		return false, nil
 	}, observe...)
@@ -953,7 +953,7 @@ func (b *backend) waitForResolveRunning(ctx context.Context, initial machine, ti
 			}
 			started = true
 		case !machineAcquirePending(item.Status) && !(allowStart && (machinePending(item.Status) || machineStopped(item.Status))):
-			return false, exit(5, "machine0 machine %s entered unexpected state %s while resolving", item.Name, item.Status)
+			return false, core.Exit(5, "machine0 machine %s entered unexpected state %s while resolving", item.Name, item.Status)
 		}
 		return false, nil
 	}, observe)
@@ -989,7 +989,7 @@ func (b *backend) waitForExactMachine(ctx context.Context, name string, timeout 
 			return false, terminalMachineError(item)
 		}
 		if !pending(item) {
-			return false, exit(5, "machine0 machine %s entered unexpected state %s while %s", item.Name, item.Status, phase)
+			return false, core.Exit(5, "machine0 machine %s entered unexpected state %s while %s", item.Name, item.Status, phase)
 		}
 		return false, nil
 	})
@@ -1038,9 +1038,9 @@ func (b *backend) pollMachine(
 	}, nil)
 	if err != nil && context.Cause(ctx) == nil && errors.Is(context.Cause(waitCtx), context.DeadlineExceeded) && errors.Is(err, context.DeadlineExceeded) {
 		if target == "" {
-			err = exit(5, "timed out waiting for machine0 machine %s; last state=%s", name, core.Blank(result.Value.Status, "unknown"))
+			err = core.Exit(5, "timed out waiting for machine0 machine %s; last state=%s", name, core.Blank(result.Value.Status, "unknown"))
 		} else {
-			err = exit(5, "timed out waiting for machine0 machine %s to reach %s; last state=%s", name, target, core.Blank(result.Value.Status, "unknown"))
+			err = core.Exit(5, "timed out waiting for machine0 machine %s to reach %s; last state=%s", name, target, core.Blank(result.Value.Status, "unknown"))
 		}
 	}
 	return result.Value, err
@@ -1054,30 +1054,30 @@ func runningMachineResult(item machine) (bool, error) {
 		return false, nil
 	}
 	if strings.TrimSpace(item.IP) == "" {
-		return false, exit(5, "machine0 machine %s is RUNNING without an IP", item.Name)
+		return false, core.Exit(5, "machine0 machine %s is RUNNING without an IP", item.Name)
 	}
 	return true, nil
 }
 
-func (b *backend) suspendClaimedMachine(ctx context.Context, claim LeaseClaim, item machine) error {
-	_, _, _, err := updateClaimAction(claim.LeaseID, claim, func() (Server, SSHTarget, bool, error) {
+func (b *backend) suspendClaimedMachine(ctx context.Context, claim core.LeaseClaim, item machine) error {
+	_, _, _, err := core.ReplaceLeaseClaimEndpointIfUnchangedAction(claim.LeaseID, claim, func() (core.Server, core.SSHTarget, bool, error) {
 		if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
-			return Server{}, SSHTarget{}, false, err
+			return core.Server{}, core.SSHTarget{}, false, err
 		}
 		var err error
 		if fixedMachine0LeaseKind.IsFixedClaim(claim) {
 			item, err = b.resolveFixedMachine0(ctx, claim)
 			if err != nil {
-				return Server{}, SSHTarget{}, false, err
+				return core.Server{}, core.SSHTarget{}, false, err
 			}
 			if item.ID == "" {
-				return Server{}, SSHTarget{}, false, exit(4, "fixed Machine0 lease %s has no live resource", claim.LeaseID)
+				return core.Server{}, core.SSHTarget{}, false, core.Exit(4, "fixed Machine0 lease %s has no live resource", claim.LeaseID)
 			}
 		}
 		suspended := item
 		if !strings.EqualFold(strings.TrimSpace(item.Status), "SUSPENDED") {
 			if err := b.api.Suspend(ctx, item.Name); err != nil {
-				return Server{}, SSHTarget{}, false, err
+				return core.Server{}, core.SSHTarget{}, false, err
 			}
 			suspended, err = b.waitForSuspended(ctx, item.Name, b.configForRun().Machine0.CreateTimeout, func(observed machine) error {
 				if fixedMachine0LeaseKind.IsFixedClaim(claim) {
@@ -1087,23 +1087,23 @@ func (b *backend) suspendClaimedMachine(ctx context.Context, claim LeaseClaim, i
 				return nil
 			})
 			if err != nil {
-				return Server{}, SSHTarget{}, false, err
+				return core.Server{}, core.SSHTarget{}, false, err
 			}
 		}
 		suspended.IP = ""
 		server := b.serverFromMachine(suspended, claim, b.configForRun())
-		return server, SSHTarget{}, true, nil
+		return server, core.SSHTarget{}, true, nil
 	})
 	return err
 }
 
-func (b *backend) prepareLease(ctx context.Context, item machine, server Server, leaseID string, check bool) (LeaseTarget, error) {
+func (b *backend) prepareLease(ctx context.Context, item machine, server core.Server, leaseID string, check bool) (core.LeaseTarget, error) {
 	return b.prepareLeaseWithOptions(ctx, item, server, leaseID, machine0PrepareOptions{Check: check})
 }
 
-func (b *backend) prepareLeaseWithOptions(ctx context.Context, item machine, server Server, leaseID string, opts machine0PrepareOptions) (LeaseTarget, error) {
+func (b *backend) prepareLeaseWithOptions(ctx context.Context, item machine, server core.Server, leaseID string, opts machine0PrepareOptions) (core.LeaseTarget, error) {
 	if !machineRunning(item.Status) || strings.TrimSpace(item.IP) == "" {
-		return LeaseTarget{}, exit(4, "machine0 machine %s is not ready for SSH; state=%s", item.Name, item.Status)
+		return core.LeaseTarget{}, core.Exit(4, "machine0 machine %s is not ready for SSH; state=%s", item.Name, item.Status)
 	}
 	cfg := b.configForRun()
 	user := machine0SSHUser(item)
@@ -1118,12 +1118,12 @@ func (b *backend) prepareLeaseWithOptions(ctx context.Context, item machine, ser
 	}
 	if keyFileName != "" {
 		if filepath.IsAbs(keyFileName) || keyFileName == "." || keyFileName == ".." || strings.ContainsAny(keyFileName, `/\`) || filepath.Base(keyFileName) != keyFileName {
-			return LeaseTarget{}, exit(2, "Machine0 returned invalid SSH key filename %q; key filename must be a single basename", keyFileName)
+			return core.LeaseTarget{}, core.Exit(2, "Machine0 returned invalid SSH key filename %q; key filename must be a single basename", keyFileName)
 		}
 		if keyRoot == "" {
 			home, err := os.UserHomeDir()
 			if err != nil || strings.TrimSpace(home) == "" {
-				return LeaseTarget{}, exit(2, "resolve Machine0 SSH key directory for %s: set SSH_KEY_PATH or configure a user home", item.Name)
+				return core.LeaseTarget{}, core.Exit(2, "resolve Machine0 SSH key directory for %s: set SSH_KEY_PATH or configure a user home", item.Name)
 			}
 			keyRoot = filepath.Join(home, ".ssh")
 		}
@@ -1132,22 +1132,22 @@ func (b *backend) prepareLeaseWithOptions(ctx context.Context, item machine, ser
 			info, err := b.stat(keyPath)
 			switch {
 			case err == nil && info.IsDir():
-				return LeaseTarget{}, exit(2, "Machine0 SSH key path %q is a directory; set SSH_KEY_PATH to the directory containing private key %s", keyPath, keyFileName)
+				return core.LeaseTarget{}, core.Exit(2, "Machine0 SSH key path %q is a directory; set SSH_KEY_PATH to the directory containing private key %s", keyPath, keyFileName)
 			case err == nil:
 			case !errors.Is(err, os.ErrNotExist):
-				return LeaseTarget{}, exit(2, "inspect Machine0 SSH key %q: %v", keyPath, err)
+				return core.LeaseTarget{}, core.Exit(2, "inspect Machine0 SSH key %q: %v", keyPath, err)
 			default:
 				primeErr := b.api.PrimeSSH(ctx, item.Name)
 				info, statErr := b.stat(keyPath)
 				if statErr != nil || info.IsDir() {
-					missingErr := exit(2, "Machine0 SSH key %q is missing after `machine0 ssh %s true`; set SSH_KEY_PATH to the directory containing private key %s (resolved directory: %q), or ensure Machine0 can materialize it", keyPath, item.Name, keyFileName, keyRoot)
+					missingErr := core.Exit(2, "Machine0 SSH key %q is missing after `machine0 ssh %s true`; set SSH_KEY_PATH to the directory containing private key %s (resolved directory: %q), or ensure Machine0 can materialize it", keyPath, item.Name, keyFileName, keyRoot)
 					if primeErr != nil {
-						return LeaseTarget{}, errors.Join(primeErr, missingErr)
+						return core.LeaseTarget{}, errors.Join(primeErr, missingErr)
 					}
-					return LeaseTarget{}, missingErr
+					return core.LeaseTarget{}, missingErr
 				}
 				if primeErr != nil {
-					return LeaseTarget{}, primeErr
+					return core.LeaseTarget{}, primeErr
 				}
 			}
 		}
@@ -1158,40 +1158,40 @@ func (b *backend) prepareLeaseWithOptions(ctx context.Context, item machine, ser
 		} else {
 			home, err := os.UserHomeDir()
 			if err != nil || strings.TrimSpace(home) == "" {
-				return LeaseTarget{}, exit(2, "resolve Machine0 SSH trust directory for %s: set SSH_KEY_PATH or configure a user home", item.Name)
+				return core.LeaseTarget{}, core.Exit(2, "resolve Machine0 SSH trust directory for %s: set SSH_KEY_PATH or configure a user home", item.Name)
 			}
 			keyRoot = filepath.Join(home, ".ssh")
 		}
 	}
 	knownHostsFile, err := b.knownHostsFile(keyRoot, item.ID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if opts.ResetHostTrust {
 		if err := resetMachine0HostTrust(knownHostsFile); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
-	target := SSHTarget{User: user, Host: item.IP, Key: keyPath, KnownHostsFile: knownHostsFile, Port: sshPort, TargetOS: targetLinux, NetworkKind: core.NetworkPublic, ReadyCheck: "command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null"}
+	target := core.SSHTarget{User: user, Host: item.IP, Key: keyPath, KnownHostsFile: knownHostsFile, Port: sshPort, TargetOS: targetLinux, NetworkKind: core.NetworkPublic, ReadyCheck: "command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null"}
 	if opts.Check {
-		if err := b.waitSSH(ctx, &target, bootstrapWaitTimeout(cfg)); err != nil {
-			return LeaseTarget{}, err
+		if err := b.waitSSH(ctx, &target, core.BootstrapWaitTimeout(cfg)); err != nil {
+			return core.LeaseTarget{}, err
 		}
 	}
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
 func machine0KnownHostsFile(keyRoot, machineID string) (string, error) {
 	machineID = strings.TrimSpace(machineID)
 	if machineID == "" {
-		return "", exit(2, "resolve Machine0 SSH host trust: missing immutable machine id")
+		return "", core.Exit(2, "resolve Machine0 SSH host trust: missing immutable machine id")
 	}
 	dir := filepath.Join(keyRoot, "crabbox", providerName, "known_hosts.d")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return "", exit(2, "create Machine0 SSH host trust directory %q: %v", dir, err)
+		return "", core.Exit(2, "create Machine0 SSH host trust directory %q: %v", dir, err)
 	}
 	if err := os.Chmod(dir, 0o700); err != nil {
-		return "", exit(2, "secure Machine0 SSH host trust directory %q: %v", dir, err)
+		return "", core.Exit(2, "secure Machine0 SSH host trust directory %q: %v", dir, err)
 	}
 	sum := sha256.Sum256([]byte(machineID))
 	return filepath.Join(dir, hex.EncodeToString(sum[:8])), nil
@@ -1203,70 +1203,70 @@ func resetMachine0HostTrust(path string) error {
 		return nil
 	}
 	if err != nil {
-		return exit(2, "inspect Machine0 SSH host trust %q before reset: %v", path, err)
+		return core.Exit(2, "inspect Machine0 SSH host trust %q before reset: %v", path, err)
 	}
 	if info.IsDir() {
-		return exit(2, "refusing to reset Machine0 SSH host trust %q because it is a directory", path)
+		return core.Exit(2, "refusing to reset Machine0 SSH host trust %q because it is a directory", path)
 	}
 	if err := os.Remove(path); err != nil {
-		return exit(2, "reset Machine0 SSH host trust %q: %v", path, err)
+		return core.Exit(2, "reset Machine0 SSH host trust %q: %v", path, err)
 	}
 	return nil
 }
 
-func (b *backend) releaseTarget(ctx context.Context, lease LeaseTarget) (LeaseClaim, machine, error) {
+func (b *backend) releaseTarget(ctx context.Context, lease core.LeaseTarget) (core.LeaseClaim, machine, error) {
 	identifier := firstNonBlank(lease.LeaseID, lease.Server.Labels["lease"], lease.Server.CloudID, lease.Server.Name)
 	claim, claimed, err := resolveClaim(identifier)
 	if err != nil {
-		return LeaseClaim{}, machine{}, err
+		return core.LeaseClaim{}, machine{}, err
 	}
 	if !claimed {
-		return LeaseClaim{}, machine{}, exit(2, "refusing to release machine0 machine without an exact local Crabbox claim")
+		return core.LeaseClaim{}, machine{}, core.Exit(2, "refusing to release machine0 machine without an exact local Crabbox claim")
 	}
 	lookup := firstNonBlank(claim.Labels["machine0_name"], claim.CloudID)
 	if fixedMachine0LeaseKind.IsFixedClaim(claim) {
 		item, err := b.resolveFixedMachine0(ctx, claim)
 		if err != nil {
-			return LeaseClaim{}, machine{}, err
+			return core.LeaseClaim{}, machine{}, err
 		}
 		if item.ID == "" {
-			return LeaseClaim{}, machine{}, exit(4, "fixed Machine0 lease %s has no live resource", claim.LeaseID)
+			return core.LeaseClaim{}, machine{}, core.Exit(4, "fixed Machine0 lease %s has no live resource", claim.LeaseID)
 		}
 		claim, err = b.bindFixedMachine0Claim(claim, item)
 		return claim, item, err
 	}
 	item, err := b.api.Get(ctx, lookup)
 	if err != nil {
-		return LeaseClaim{}, machine{}, err
+		return core.LeaseClaim{}, machine{}, err
 	}
 	if err := validateMachineClaimOwnership(claim, item); err != nil {
-		return LeaseClaim{}, machine{}, exit(2, "refusing machine0 release for lease=%s: %v", claim.LeaseID, err)
+		return core.LeaseClaim{}, machine{}, core.Exit(2, "refusing machine0 release for lease=%s: %v", claim.LeaseID, err)
 	}
 	return claim, item, nil
 }
 
-func (b *backend) bindRecoveryClaim(claim LeaseClaim, item machine, cfg Config) (LeaseClaim, error) {
+func (b *backend) bindRecoveryClaim(claim core.LeaseClaim, item machine, cfg core.Config) (core.LeaseClaim, error) {
 	expectedName := machine0MachineName(claim.LeaseID, claim.Slug)
 	if claim.Labels["recovery"] != "create-pending" || claim.CloudID != "" ||
 		claim.ProviderScope != machine0NameScope(expectedName) || claim.Labels["machine0_name"] != expectedName ||
 		item.Name != expectedName || strings.TrimSpace(item.ID) == "" {
-		return LeaseClaim{}, exit(2, "Machine0 recovery claim does not match its durable machine name and resource identity")
+		return core.LeaseClaim{}, core.Exit(2, "Machine0 recovery claim does not match its durable machine name and resource identity")
 	}
 	server := b.serverFromMachine(item, claim, cfg)
 	server.Labels["recovery"] = "create-pending"
 	bound, err := core.ClaimLeaseTargetForRepoConfigScopeReplacingEndpointIfUnchanged(
-		claim.LeaseID, claim.Slug, cfg, machineScope(item.ID), server, SSHTarget{}, claim.RepoRoot, cfg.IdleTimeout, false, claim, true,
+		claim.LeaseID, claim.Slug, cfg, machineScope(item.ID), server, core.SSHTarget{}, claim.RepoRoot, cfg.IdleTimeout, false, claim, true,
 	)
 	if err != nil {
-		return LeaseClaim{}, err
+		return core.LeaseClaim{}, err
 	}
 	if bound.LeaseID != claim.LeaseID || bound.CloudID != item.ID || bound.ProviderScope != machineScope(item.ID) {
-		return LeaseClaim{}, exit(2, "Machine0 recovery claim did not publish its immutable resource identity")
+		return core.LeaseClaim{}, core.Exit(2, "Machine0 recovery claim did not publish its immutable resource identity")
 	}
 	return bound, nil
 }
 
-func validateMachineClaimOwnership(claim LeaseClaim, item machine) error {
+func validateMachineClaimOwnership(claim core.LeaseClaim, item machine) error {
 	if strings.TrimSpace(claim.LeaseID) == "" {
 		return errors.New("missing lease identity")
 	}
@@ -1282,12 +1282,12 @@ func validateMachineClaimOwnership(claim LeaseClaim, item machine) error {
 	return nil
 }
 
-func machine0Claims() (map[string]LeaseClaim, error) {
-	claims, err := listClaims()
+func machine0Claims() (map[string]core.LeaseClaim, error) {
+	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return nil, err
 	}
-	out := map[string]LeaseClaim{}
+	out := map[string]core.LeaseClaim{}
 	for _, claim := range claims {
 		if !isMachine0ClaimProvider(claim.Provider) {
 			continue
@@ -1302,7 +1302,7 @@ func machine0Claims() (map[string]LeaseClaim, error) {
 	return out, nil
 }
 
-func (b *backend) serverFromMachine(item machine, claim LeaseClaim, cfg Config) Server {
+func (b *backend) serverFromMachine(item machine, claim core.LeaseClaim, cfg core.Config) core.Server {
 	cfg = effectiveMachine0Config(cfg, item)
 	labels := shared.CloneLabels(claim.Labels)
 	leaseID, slug := claim.LeaseID, claim.Slug
@@ -1313,7 +1313,7 @@ func (b *backend) serverFromMachine(item machine, claim LeaseClaim, cfg Config) 
 		labels[key] = value
 	}
 	labels["work_root"] = cfg.WorkRoot
-	server := Server{CloudID: item.ID, ImmutableID: item.ID, Provider: providerName, Name: item.Name, Status: normalizeMachineState(item.Status), Labels: labels, ProviderMetadata: machineProviderMetadata(item)}
+	server := core.Server{CloudID: item.ID, ImmutableID: item.ID, Provider: providerName, Name: item.Name, Status: normalizeMachineState(item.Status), Labels: labels, ProviderMetadata: machineProviderMetadata(item)}
 	server.PublicNet.IPv4.IP = item.IP
 	server.ServerType.Name = item.Size
 	return server
@@ -1321,7 +1321,7 @@ func (b *backend) serverFromMachine(item machine, claim LeaseClaim, cfg Config) 
 
 var machineLabelKeys = []string{"machine0_id", "machine0_name", "machine0_status", "machine0_url", "image", "image_version", "size", "region", "ssh_user", "ssh_key", "release_policy", "price_per_hour_micro", "work_root"}
 
-func machineLabels(cfg Config, item machine, leaseID, slug string, keep bool, now time.Time) map[string]string {
+func machineLabels(cfg core.Config, item machine, leaseID, slug string, keep bool, now time.Time) map[string]string {
 	cfg = effectiveMachine0Config(cfg, item)
 	labels := directLeaseLabels(cfg, leaseID, slug, keep, now)
 	for key, value := range machineDynamicLabels(item) {
@@ -1370,7 +1370,7 @@ func machine0LeaseSuffix(leaseID string) string {
 	return fmt.Sprintf("-%08x", hash.Sum32())
 }
 
-func shouldCleanupMachine0(server Server, claim LeaseClaim, hasClaim bool, now time.Time) (bool, string) {
+func shouldCleanupMachine0(server core.Server, claim core.LeaseClaim, hasClaim bool, now time.Time) (bool, string) {
 	if fixedMachine0LeaseKind.IsFixedClaim(claim) && claim.FixedCreateIntent.State == fixedMachine0IntentPrepared {
 		return false, "fixed creation incomplete; use stop with its lease ID"
 	}
@@ -1442,7 +1442,7 @@ func machineTerminal(value string) bool {
 	return value == "ERRORED" || value == "UNAVAILABLE"
 }
 func terminalMachineError(item machine) error {
-	return exit(5, "machine0 machine %s entered terminal state %s: %s", item.Name, item.Status, core.Blank(item.LastErrorMessage, "run `machine0 get "+item.Name+" --json` for diagnostics"))
+	return core.Exit(5, "machine0 machine %s entered terminal state %s: %s", item.Name, item.Status, core.Blank(item.LastErrorMessage, "run `machine0 get "+item.Name+" --json` for diagnostics"))
 }
 func sleepContext(ctx context.Context, delay time.Duration) error {
 	timer := time.NewTimer(delay)

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -266,11 +266,11 @@ func testBackendWithAPI(api *fakeAPI) *backend {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.SSHKey = "/tmp/test-key"
-	b := newBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 	b.api = api
 	b.sleep = func(context.Context, time.Duration) error { return nil }
-	b.waitSSH = func(context.Context, *SSHTarget, time.Duration) error { return nil }
-	b.prepareNativeImageSource = func(context.Context, SSHTarget) error { return nil }
+	b.waitSSH = func(context.Context, *core.SSHTarget, time.Duration) error { return nil }
+	b.prepareNativeImageSource = func(context.Context, core.SSHTarget) error { return nil }
 	return b
 }
 
@@ -290,7 +290,7 @@ func TestNewBackendConfiguresClientReadRetryCadenceAndContextSleep(t *testing.T)
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := core.BaseConfig()
 			cfg.Machine0.PollInterval = tc.configured
-			b := newBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+			b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 			c, ok := b.api.(*client)
 			if !ok || b.cfg.Machine0.PollInterval != tc.want || c.cfg.PollInterval != tc.want || c.sleep == nil {
 				t.Fatalf("backend interval=%s client=%#v ok=%v want=%s", b.cfg.Machine0.PollInterval, c, ok, tc.want)
@@ -328,14 +328,14 @@ func TestEffectiveMachine0WorkRootUsesResolvedSSHUser(t *testing.T) {
 
 	for _, tc := range []struct {
 		name     string
-		cfg      Config
+		cfg      core.Config
 		item     machine
 		wantUser string
 		wantRoot string
 	}{
 		{name: "ubuntu default", cfg: base, item: ubuntu, wantUser: "ubuntu", wantRoot: "/home/ubuntu/crabbox"},
 		{name: "nixos default", cfg: base, item: nixos, wantUser: "nix", wantRoot: "/home/nix/crabbox"},
-		{name: "explicit override", cfg: func() Config { cfg := base; cfg.Machine0.WorkRoot = "/srv/machine0-work"; return cfg }(), item: nixos, wantUser: "nix", wantRoot: "/srv/machine0-work"},
+		{name: "explicit override", cfg: func() core.Config { cfg := base; cfg.Machine0.WorkRoot = "/srv/machine0-work"; return cfg }(), item: nixos, wantUser: "nix", wantRoot: "/srv/machine0-work"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got := effectiveMachine0Config(tc.cfg, tc.item)
@@ -352,17 +352,17 @@ func TestPrepareLeaseUsesDeterministicPrivateMachineKnownHosts(t *testing.T) {
 	item := readyMachine("203.0.113.10")
 	b := testBackendWithAPI(&fakeAPI{machine: item})
 
-	first, err := b.prepareLease(context.Background(), item, Server{CloudID: item.ID}, "cbx_trust", false)
+	first, err := b.prepareLease(context.Background(), item, core.Server{CloudID: item.ID}, "cbx_trust", false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	again, err := b.prepareLease(context.Background(), item, Server{CloudID: item.ID}, "cbx_trust", false)
+	again, err := b.prepareLease(context.Background(), item, core.Server{CloudID: item.ID}, "cbx_trust", false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	other := item
 	other.ID = "vm-456"
-	second, err := b.prepareLease(context.Background(), other, Server{CloudID: other.ID}, "cbx_other", false)
+	second, err := b.prepareLease(context.Background(), other, core.Server{CloudID: other.ID}, "cbx_other", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -424,12 +424,12 @@ func TestPrepareLeaseMachine0FilenameOverridesGenericSSHKey(t *testing.T) {
 	api := &fakeAPI{machine: item}
 	b := testBackendWithAPI(api)
 	b.cfg.SSHKey = "/tmp/unrelated-crabbox-key"
-	var waited SSHTarget
-	b.waitSSH = func(_ context.Context, target *SSHTarget, _ time.Duration) error {
+	var waited core.SSHTarget
+	b.waitSSH = func(_ context.Context, target *core.SSHTarget, _ time.Duration) error {
 		waited = *target
 		return nil
 	}
-	lease, err := b.prepareLease(context.Background(), item, Server{CloudID: item.ID}, "cbx_keytest", true)
+	lease, err := b.prepareLease(context.Background(), item, core.Server{CloudID: item.ID}, "cbx_keytest", true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -485,12 +485,12 @@ func TestPrepareLeaseValidatesMachine0KeyFilenameBeforeSideEffects(t *testing.T)
 				return machine0KnownHostsFile(root, machineID)
 			}
 			sshCalls := 0
-			b.waitSSH = func(context.Context, *SSHTarget, time.Duration) error {
+			b.waitSSH = func(context.Context, *core.SSHTarget, time.Duration) error {
 				sshCalls++
 				return nil
 			}
 
-			lease, err := b.prepareLease(context.Background(), item, Server{CloudID: item.ID}, "cbx_key_validation", true)
+			lease, err := b.prepareLease(context.Background(), item, core.Server{CloudID: item.ID}, "cbx_key_validation", true)
 			if tc.wantOK {
 				if err != nil {
 					t.Fatal(err)
@@ -528,7 +528,7 @@ func TestPrepareLeasePrimesMissingMachine0KeyAndVerifiesMaterialization(t *testi
 	}
 	b := testBackendWithAPI(api)
 
-	lease, err := b.prepareLease(context.Background(), item, Server{CloudID: item.ID}, "cbx_keymaterialize", true)
+	lease, err := b.prepareLease(context.Background(), item, core.Server{CloudID: item.ID}, "cbx_keymaterialize", true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -545,7 +545,7 @@ func TestPrepareLeaseRejectsPrimeWithoutExpectedMachine0Key(t *testing.T) {
 	api := &fakeAPI{machine: item}
 	b := testBackendWithAPI(api)
 
-	_, err := b.prepareLease(context.Background(), item, Server{CloudID: item.ID}, "cbx_keymissing", true)
+	_, err := b.prepareLease(context.Background(), item, core.Server{CloudID: item.ID}, "cbx_keymissing", true)
 	wantPath := filepath.Join(keyRoot, "id_ed25519")
 	if err == nil || !strings.Contains(err.Error(), wantPath) || !strings.Contains(err.Error(), "SSH_KEY_PATH") || !strings.Contains(err.Error(), "materialize") {
 		t.Fatalf("err=%v", err)
@@ -581,7 +581,7 @@ func TestPrepareLeaseSelectsMachine0KeyOwnershipWithoutFilename(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			lease, err := b.prepareLease(context.Background(), item, Server{CloudID: item.ID}, "cbx_keyfallback", true)
+			lease, err := b.prepareLease(context.Background(), item, core.Server{CloudID: item.ID}, "cbx_keyfallback", true)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -599,7 +599,7 @@ func TestAcquirePollsToRunningAndDefaultReleaseDestroys(t *testing.T) {
 	repo := setupState(t)
 	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{{ID: "vm-123", Name: "crabbox-blue", Status: "CREATING"}, readyMachine("203.0.113.10")}}
 	b := testBackendWithAPI(api)
-	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}, RequestedSlug: "blue"})
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}, RequestedSlug: "blue"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -616,7 +616,7 @@ func TestAcquirePollsToRunningAndDefaultReleaseDestroys(t *testing.T) {
 	if err != nil || !ok || claim.Labels["work_root"] != "/home/ubuntu/crabbox" {
 		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
 	}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
 	}
 	if len(api.removed) != 1 || len(api.suspended) != 0 {
@@ -652,11 +652,11 @@ func TestAcquirePreservesConfiguredNativeSizeAcrossClassChanges(t *testing.T) {
 					{result: core.LocalCommandResult{Stdout: `[]`}},
 					{err: errors.New("create intercepted")},
 				}}
-				b, err := (Provider{}).Configure(cfg, Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard})
+				b, err := (Provider{}).Configure(cfg, core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard})
 				if err != nil {
 					t.Fatal(err)
 				}
-				_, err = b.(*backend).Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+				_, err = b.(*backend).Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 				if err == nil || !strings.Contains(err.Error(), "create intercepted") {
 					t.Fatalf("Acquire error=%v, want intercepted create", err)
 				}
@@ -680,7 +680,7 @@ func TestAcquireTerminalStateRollsBackWithDiagnostic(t *testing.T) {
 	repo := setupState(t)
 	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{{ID: "vm-123", Name: "crabbox-blue", Status: "ERRORED", LastErrorMessage: "regional capacity unavailable"}}}
 	b := testBackendWithAPI(api)
-	_, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 	if err == nil || !strings.Contains(err.Error(), "regional capacity unavailable") {
 		t.Fatalf("err=%v", err)
 	}
@@ -719,7 +719,7 @@ func TestAcquireRecoveryClaimTracksCreatedMachines(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := setupState(t)
 			api := &fakeAPI{sizes: []machineSize{testSize()}, removeErr: tc.removeErr}
-			var observed LeaseClaim
+			var observed core.LeaseClaim
 			api.getFn = func(_ context.Context, name string) (machine, error) {
 				claims, err := core.ListLeaseClaims()
 				if err != nil || len(claims) != 1 {
@@ -756,7 +756,7 @@ func TestAcquireRecoveryClaimTracksCreatedMachines(t *testing.T) {
 			}
 			b := testBackendWithAPI(api)
 			if tc.ready && !tc.bindingFails && !tc.wrongSize {
-				b.waitSSH = func(context.Context, *SSHTarget, time.Duration) error {
+				b.waitSSH = func(context.Context, *core.SSHTarget, time.Duration) error {
 					bound, ok, err := resolveClaim(observed.LeaseID)
 					if err != nil || !ok || bound.CloudID != "vm-123" || bound.ProviderScope != machineScope("vm-123") {
 						t.Fatalf("claim was not ID-scoped before SSH readiness: claim=%#v ok=%v err=%v", bound, ok, err)
@@ -764,7 +764,7 @@ func TestAcquireRecoveryClaimTracksCreatedMachines(t *testing.T) {
 					return tc.sshErr
 				}
 			}
-			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}, RequestedSlug: "recovery", Keep: tc.keep})
+			lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}, RequestedSlug: "recovery", Keep: tc.keep})
 			if tc.ready && !tc.bindingFails && !tc.wrongSize && tc.sshErr == nil {
 				if err != nil {
 					t.Fatal(err)
@@ -786,7 +786,7 @@ func TestAcquireRecoveryClaimTracksCreatedMachines(t *testing.T) {
 				t.Fatalf("final claim=%#v lease=%#v", claim, lease)
 			}
 			if tc.stopRecovery {
-				views, listErr := b.List(context.Background(), ListRequest{})
+				views, listErr := b.List(context.Background(), core.ListRequest{})
 				if listErr != nil || len(views) != 1 {
 					t.Fatalf("recovery list=%#v err=%v", views, listErr)
 				}
@@ -794,7 +794,7 @@ func TestAcquireRecoveryClaimTracksCreatedMachines(t *testing.T) {
 					t.Fatal("pending recovery stop must remove the exact name without adopting an inventory machine")
 					return machine{}, nil
 				}
-				if releaseErr := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: claim.LeaseID}}); releaseErr != nil {
+				if releaseErr := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: claim.LeaseID}}); releaseErr != nil {
 					t.Fatalf("recovery stop: %v", releaseErr)
 				}
 				if _, remains, resolveErr := core.ReadLeaseClaimWithPresence(claim.LeaseID); resolveErr != nil || remains {
@@ -913,8 +913,8 @@ func TestAcquirePreflightsPublicSSHKeyBeforeCreate(t *testing.T) {
 				var diagnostics bytes.Buffer
 				b.rt.Stdout, b.rt.Stderr = &diagnostics, &diagnostics
 				waited := 0
-				b.waitSSH = func(context.Context, *SSHTarget, time.Duration) error { waited++; return nil }
-				_, err := b.Acquire(ctx, AcquireRequest{RequestedLeaseID: leaseID, Repo: core.Repo{Root: repo}})
+				b.waitSSH = func(context.Context, *core.SSHTarget, time.Duration) error { waited++; return nil }
+				_, err := b.Acquire(ctx, core.AcquireRequest{RequestedLeaseID: leaseID, Repo: core.Repo{Root: repo}})
 				for _, material := range []string{public, otherPublic, string(private), "sensitive diagnostic"} {
 					if strings.Contains(diagnostics.String(), material) {
 						t.Fatal("preflight logged key material or raw extraction diagnostics")
@@ -1024,7 +1024,7 @@ func TestAcquirePublicSSHKeyFileKinds(t *testing.T) {
 					return core.LocalCommandResult{Stdout: string(output)}, err
 				}}
 				b.rt.Exec = runner
-				_, err := b.Acquire(t.Context(), AcquireRequest{RequestedLeaseID: leaseID, Repo: core.Repo{Root: repo}})
+				_, err := b.Acquire(t.Context(), core.AcquireRequest{RequestedLeaseID: leaseID, Repo: core.Repo{Root: repo}})
 				wantExtractions := 0
 				if kind == "symlink regular" {
 					wantExtractions = 1
@@ -1040,11 +1040,11 @@ func TestAcquirePublicSSHKeyFileKinds(t *testing.T) {
 func TestPendingRecoveryReleaseRejectsInvalidOwnershipAndSuspend(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
-		mutate func(*backend, *LeaseClaim)
+		mutate func(*backend, *core.LeaseClaim)
 	}{
-		{name: "mismatched name scope", mutate: func(_ *backend, claim *LeaseClaim) { claim.ProviderScope = machine0NameScope("another-machine") }},
-		{name: "mismatched machine name", mutate: func(_ *backend, claim *LeaseClaim) { claim.Labels["machine0_name"] = "another-machine" }},
-		{name: "pending claim cannot suspend", mutate: func(b *backend, _ *LeaseClaim) { b.cfg.Machine0.ReleasePolicy = "suspend" }},
+		{name: "mismatched name scope", mutate: func(_ *backend, claim *core.LeaseClaim) { claim.ProviderScope = machine0NameScope("another-machine") }},
+		{name: "mismatched machine name", mutate: func(_ *backend, claim *core.LeaseClaim) { claim.Labels["machine0_name"] = "another-machine" }},
+		{name: "pending claim cannot suspend", mutate: func(b *backend, _ *core.LeaseClaim) { b.cfg.Machine0.ReleasePolicy = "suspend" }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := setupState(t)
@@ -1056,7 +1056,7 @@ func TestPendingRecoveryReleaseRejectsInvalidOwnershipAndSuspend(t *testing.T) {
 				return machine{}, context.Canceled
 			}
 			b := testBackendWithAPI(api)
-			if _, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}, RequestedSlug: "pending", Keep: true}); err == nil {
+			if _, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}, RequestedSlug: "pending", Keep: true}); err == nil {
 				t.Fatal("expected interrupted acquisition")
 			}
 			claims, err := core.ListLeaseClaims()
@@ -1072,7 +1072,7 @@ func TestPendingRecoveryReleaseRejectsInvalidOwnershipAndSuspend(t *testing.T) {
 			if err := core.ReplaceLeaseClaimIfUnchanged(claim.LeaseID, claim, replacement); err != nil {
 				t.Fatal(err)
 			}
-			err = b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: claim.LeaseID}})
+			err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: claim.LeaseID}})
 			if err == nil || len(api.removed) != 0 {
 				t.Fatalf("pending release err=%v removals=%v", err, api.removed)
 			}
@@ -1089,7 +1089,7 @@ func TestAcquireDoesNotStartUnexpectedStoppedMachine(t *testing.T) {
 	stopped.Status = "STOPPED"
 	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{stopped}}
 	b := testBackendWithAPI(api)
-	_, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 	if err == nil || !strings.Contains(err.Error(), "stable state STOPPED") {
 		t.Fatalf("err=%v", err)
 	}
@@ -1144,7 +1144,7 @@ func TestResolveUnclaimedIdentifier(t *testing.T) {
 			if tc.listErr != nil {
 				api.listFn = func(context.Context, int) ([]machine, error) { return nil, tc.listErr }
 			}
-			lease, err := testBackendWithAPI(api).Resolve(context.Background(), ResolveRequest{ID: tc.id, StatusOnly: true})
+			lease, err := testBackendWithAPI(api).Resolve(context.Background(), core.ResolveRequest{ID: tc.id, StatusOnly: true})
 			switch {
 			case tc.listErr != nil:
 				if !errors.Is(err, tc.listErr) {
@@ -1206,7 +1206,7 @@ func TestResolveUnclaimedMachineNameUsesDetail(t *testing.T) {
 			if mode == "generic key" {
 				keyPath = b.cfg.SSHKey
 			}
-			b.waitSSH = func(_ context.Context, target *SSHTarget, _ time.Duration) error {
+			b.waitSSH = func(_ context.Context, target *core.SSHTarget, _ time.Duration) error {
 				waits++
 				if target.Key != keyPath || target.Host != detail.IP || target.User != "nix" {
 					t.Fatalf("readiness target=%#v", target)
@@ -1214,7 +1214,7 @@ func TestResolveUnclaimedMachineNameUsesDetail(t *testing.T) {
 				return nil
 			}
 			ready := mode != "status"
-			lease, err := b.Resolve(context.Background(), ResolveRequest{ID: inventory.Name, StatusOnly: true, ReadyProbe: ready})
+			lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: inventory.Name, StatusOnly: true, ReadyProbe: ready})
 			if err != nil || gets != 1 || api.listCalls != 0 || lease.Server.PublicNet.IPv4.IP != detail.IP || lease.Server.Labels["work_root"] != "/home/nix/crabbox" {
 				t.Fatalf("lease=%#v gets=%d lists=%d err=%v", lease, gets, api.listCalls, err)
 			}
@@ -1252,11 +1252,11 @@ func TestResolveUnclaimedLeaseHashCollisionFailsClosed(t *testing.T) {
 				return inventory, nil
 			}}
 			b := testBackendWithAPI(api)
-			b.waitSSH = func(context.Context, *SSHTarget, time.Duration) error {
+			b.waitSSH = func(context.Context, *core.SSHTarget, time.Duration) error {
 				t.Fatal("readiness ran on a hash-only candidate")
 				return nil
 			}
-			_, err := b.Resolve(context.Background(), ResolveRequest{ID: id, Reclaim: true, ReadyProbe: true, Repo: core.Repo{Root: repo}})
+			_, err := b.Resolve(context.Background(), core.ResolveRequest{ID: id, Reclaim: true, ReadyProbe: true, Repo: core.Repo{Root: repo}})
 			var exitErr core.ExitError
 			if !errors.As(err, &exitErr) || exitErr.Code != 4 || !strings.Contains(err.Error(), "matches only a short name hash") {
 				t.Fatalf("unexpected error=%v", err)
@@ -1276,7 +1276,7 @@ func TestResolveRefreshesChangedIPAndPrefersReturnedUsername(t *testing.T) {
 	repo := setupState(t)
 	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
 	b := testBackendWithAPI(api)
-	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1294,7 +1294,7 @@ func TestResolveRefreshesChangedIPAndPrefersReturnedUsername(t *testing.T) {
 		}
 		return api.machine, nil
 	}
-	resolved, err := b.Resolve(context.Background(), ResolveRequest{Repo: core.Repo{Root: repo}, ID: lease.LeaseID})
+	resolved, err := b.Resolve(context.Background(), core.ResolveRequest{Repo: core.Repo{Root: repo}, ID: lease.LeaseID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1323,7 +1323,7 @@ func TestResolveRunningMachinePreservesIsolatedHostTrust(t *testing.T) {
 	repo := setupState(t)
 	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
 	b := testBackendWithAPI(api)
-	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1333,7 +1333,7 @@ func TestResolveRunningMachinePreservesIsolatedHostTrust(t *testing.T) {
 	}
 	api.machine = readyMachine("203.0.113.10")
 
-	resolved, err := b.Resolve(context.Background(), ResolveRequest{Repo: core.Repo{Root: repo}, ID: lease.LeaseID})
+	resolved, err := b.Resolve(context.Background(), core.ResolveRequest{Repo: core.Repo{Root: repo}, ID: lease.LeaseID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1360,7 +1360,7 @@ func TestMachine0RunResolutionPreparesWithoutPublishingClaim(t *testing.T) {
 					t.Fatal(err)
 				}
 				if scenario == "checkpoint hold" {
-					if err := core.WithDurableLeaseClaimLock(lease.LeaseID, func(claim *LeaseClaim, _ bool, persist func() error) error {
+					if err := core.WithDurableLeaseClaimLock(lease.LeaseID, func(claim *core.LeaseClaim, _ bool, persist func() error) error {
 						claim.CheckpointCapture = &core.CheckpointCaptureBinding{ID: "chk_runhold", Revision: claim.Revision, BoundRevision: claim.Revision}
 						return persist()
 					}); err != nil {
@@ -1391,7 +1391,7 @@ func TestMachine0RunResolutionPreparesWithoutPublishingClaim(t *testing.T) {
 				ctx, cancel := context.WithCancel(t.Context())
 				defer cancel()
 				prepared := false
-				b.waitSSH = func(prepareCtx context.Context, target *SSHTarget, _ time.Duration) error {
+				b.waitSSH = func(prepareCtx context.Context, target *core.SSHTarget, _ time.Duration) error {
 					prepared = true
 					if target.Host != ready.IP || target.KnownHostsFile != lease.SSH.KnownHostsFile {
 						t.Fatal("readiness lost the exact endpoint or isolated trust path")
@@ -1402,7 +1402,7 @@ func TestMachine0RunResolutionPreparesWithoutPublishingClaim(t *testing.T) {
 					}
 					return nil
 				}
-				resolved, resolveErr := b.ResolveRunLeaseUnderClaim(ctx, ResolveRequest{ID: lease.LeaseID, Repo: req.Repo, Prepare: true}, before)
+				resolved, resolveErr := b.ResolveRunLeaseUnderClaim(ctx, core.ResolveRequest{ID: lease.LeaseID, Repo: req.Repo, Prepare: true}, before)
 				if scenario == "ready" || scenario == "stopped" {
 					if resolveErr != nil || !prepared || resolved.Server.CloudID != before.CloudID || resolved.SSH.Host != ready.IP {
 						t.Fatalf("run resolution did not prepare the bound machine: %v", resolveErr)
@@ -1445,7 +1445,7 @@ func TestAcquirePreservesExplicitMachine0WorkRoot(t *testing.T) {
 	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
 	b := testBackendWithAPI(api)
 	b.cfg.Machine0.WorkRoot = "/srv/explicit-machine0"
-	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1463,7 +1463,7 @@ func TestSuspendResumePreservesMachineIDAndRefreshesChangedIP(t *testing.T) {
 	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
 	b := testBackendWithAPI(api)
 	b.cfg.Machine0.ReleasePolicy = "suspend"
-	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1475,7 +1475,7 @@ func TestSuspendResumePreservesMachineIDAndRefreshesChangedIP(t *testing.T) {
 	suspended := readyMachine("")
 	suspended.Status = "SUSPENDED"
 	api.getSequence = []machine{readyMachine("203.0.113.10"), suspending, suspended}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
 	}
 	if len(api.suspended) != 1 || len(api.removed) != 0 || !b.RetainLeaseClaimAfterRelease(lease) {
@@ -1485,7 +1485,7 @@ func TestSuspendResumePreservesMachineIDAndRefreshesChangedIP(t *testing.T) {
 		t.Fatal(err)
 	}
 	api.getSequence = []machine{func() machine { m := readyMachine("203.0.113.77"); m.Status = "STARTING"; return m }(), readyMachine("203.0.113.77")}
-	if err := b.Resume(context.Background(), ResumeRequest{ID: lease.LeaseID}); err != nil {
+	if err := b.Resume(context.Background(), core.ResumeRequest{ID: lease.LeaseID}); err != nil {
 		t.Fatal(err)
 	}
 	if len(api.started) != 1 {
@@ -1494,7 +1494,7 @@ func TestSuspendResumePreservesMachineIDAndRefreshesChangedIP(t *testing.T) {
 	if _, err := os.Stat(lease.SSH.KnownHostsFile); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("resume did not reset isolated host trust: %v", err)
 	}
-	resolved, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, StatusOnly: true, ReadyProbe: true})
+	resolved, err := b.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID, StatusOnly: true, ReadyProbe: true})
 	if err != nil || resolved.Server.CloudID != "vm-123" || resolved.SSH.Host != "203.0.113.77" || resolved.SSH.Host == lease.SSH.Host {
 		t.Fatalf("resolved=%#v err=%v", resolved, err)
 	}
@@ -1505,7 +1505,7 @@ func TestPauseAndCleanupWaitForExactSuspendedState(t *testing.T) {
 		repo := setupState(t)
 		api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
 		b := testBackendWithAPI(api)
-		lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+		lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1514,7 +1514,7 @@ func TestPauseAndCleanupWaitForExactSuspendedState(t *testing.T) {
 		suspended := readyMachine("")
 		suspended.Status = "SUSPENDED"
 		api.getSequence = []machine{readyMachine("203.0.113.10"), suspending, suspended}
-		if err := b.Pause(context.Background(), PauseRequest{ID: lease.LeaseID}); err != nil {
+		if err := b.Pause(context.Background(), core.PauseRequest{ID: lease.LeaseID}); err != nil {
 			t.Fatal(err)
 		}
 		claim, ok, err := resolveClaim(lease.LeaseID)
@@ -1531,7 +1531,7 @@ func TestPauseAndCleanupWaitForExactSuspendedState(t *testing.T) {
 		api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
 		b := testBackendWithAPI(api)
 		b.cfg.Machine0.ReleasePolicy = "suspend"
-		lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+		lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1541,7 +1541,7 @@ func TestPauseAndCleanupWaitForExactSuspendedState(t *testing.T) {
 		suspended := readyMachine("")
 		suspended.Status = "SUSPENDED"
 		api.getSequence = []machine{suspending, suspended}
-		if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 			t.Fatal(err)
 		}
 		claim, ok, err := resolveClaim(lease.LeaseID)
@@ -1555,7 +1555,7 @@ func TestSuspendFailureDoesNotClearLiveClaimEndpoint(t *testing.T) {
 	repo := setupState(t)
 	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
 	b := testBackendWithAPI(api)
-	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1563,7 +1563,7 @@ func TestSuspendFailureDoesNotClearLiveClaimEndpoint(t *testing.T) {
 	failed.Status = "ERRORED"
 	failed.LastErrorMessage = "snapshot failed"
 	api.getSequence = []machine{readyMachine("203.0.113.10"), failed}
-	if err := b.Pause(context.Background(), PauseRequest{ID: lease.LeaseID}); err == nil || !strings.Contains(err.Error(), "snapshot failed") {
+	if err := b.Pause(context.Background(), core.PauseRequest{ID: lease.LeaseID}); err == nil || !strings.Contains(err.Error(), "snapshot failed") {
 		t.Fatalf("err=%v", err)
 	}
 	claim, ok, err := resolveClaim(lease.LeaseID)
@@ -1633,7 +1633,7 @@ func TestResolveStartsOnceAfterStoppingTransition(t *testing.T) {
 			repo := setupState(t)
 			api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
 			b := testBackendWithAPI(api)
-			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+			lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1646,7 +1646,7 @@ func TestResolveStartsOnceAfterStoppingTransition(t *testing.T) {
 				}
 				api.getSequence = append(api.getSequence, item)
 			}
-			resolved, err := b.Resolve(context.Background(), ResolveRequest{Repo: core.Repo{Root: repo}, ID: lease.LeaseID})
+			resolved, err := b.Resolve(context.Background(), core.ResolveRequest{Repo: core.Repo{Root: repo}, ID: lease.LeaseID})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1691,7 +1691,7 @@ func TestCatalogValidationUsesLiveRegions(t *testing.T) {
 func TestDoctorChecksCLIAuthInventoryAndCatalogWithoutMutation(t *testing.T) {
 	api := &fakeAPI{machine: readyMachine("203.0.113.10"), sizes: []machineSize{testSize()}}
 	b := testBackendWithAPI(api)
-	result, err := b.Doctor(context.Background(), DoctorRequest{})
+	result, err := b.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1714,7 +1714,7 @@ func TestDoctorRunsSlowProviderProbesWithinSharedBudget(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	started := time.Now()
-	result, err := testBackendWithAPI(api).Doctor(ctx, DoctorRequest{})
+	result, err := testBackendWithAPI(api).Doctor(ctx, core.DoctorRequest{})
 	if err != nil {
 		t.Fatalf("doctor failed within shared budget: %v", err)
 	}
@@ -1735,7 +1735,7 @@ func TestDoctorProbeFailureCancelsSiblingProbes(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	_, err := testBackendWithAPI(api).Doctor(ctx, DoctorRequest{})
+	_, err := testBackendWithAPI(api).Doctor(ctx, core.DoctorRequest{})
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("doctor error=%v, want original probe error %v", err, wantErr)
 	}
@@ -1748,11 +1748,11 @@ func TestCleanupDestroysStoppedClaimByDefault(t *testing.T) {
 	repo := setupState(t)
 	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
 	b := testBackendWithAPI(api)
-	if _, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}}); err != nil {
+	if _, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}}); err != nil {
 		t.Fatal(err)
 	}
 	api.machine.Status = "STOPPED"
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(api.removed) != 1 || len(api.suspended) != 0 {
@@ -1763,10 +1763,10 @@ func TestCleanupDestroysStoppedClaimByDefault(t *testing.T) {
 func TestCleanupRejectsPartialOrMismatchedOwnership(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
-		mutate func(*LeaseClaim)
+		mutate func(*core.LeaseClaim)
 	}{
-		{name: "missing cloud id with mutable label fallback", mutate: func(claim *LeaseClaim) { claim.CloudID = "" }},
-		{name: "mismatched provider scope", mutate: func(claim *LeaseClaim) { claim.ProviderScope = machineScope("vm-other") }},
+		{name: "missing cloud id with mutable label fallback", mutate: func(claim *core.LeaseClaim) { claim.CloudID = "" }},
+		{name: "mismatched provider scope", mutate: func(claim *core.LeaseClaim) { claim.ProviderScope = machineScope("vm-other") }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := setupState(t)
@@ -1774,7 +1774,7 @@ func TestCleanupRejectsPartialOrMismatchedOwnership(t *testing.T) {
 			var stderr bytes.Buffer
 			b := testBackendWithAPI(api)
 			b.rt.Stderr = &stderr
-			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+			lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1788,7 +1788,7 @@ func TestCleanupRejectsPartialOrMismatchedOwnership(t *testing.T) {
 				t.Fatal(err)
 			}
 			api.machine.Status = "STOPPED"
-			if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+			if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 				t.Fatal(err)
 			}
 			if len(api.removed) != 0 || len(api.suspended) != 0 {
@@ -2045,12 +2045,12 @@ func TestNativeCheckpointWorkdirUsesResolvedMachine0Root(t *testing.T) {
 	}
 }
 
-func checkpointCreateFixture(t *testing.T) (*backend, *fakeAPI, LeaseTarget, LeaseClaim, core.NativeCheckpointCreateRequest) {
+func checkpointCreateFixture(t *testing.T) (*backend, *fakeAPI, core.LeaseTarget, core.LeaseClaim, core.NativeCheckpointCreateRequest) {
 	t.Helper()
 	repo := setupState(t)
 	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
 	b := testBackendWithAPI(api)
-	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2082,7 +2082,7 @@ func checkpointSource(req core.NativeCheckpointCreateRequest, ip string) machine
 	return item
 }
 
-func readyCheckpointImage(req core.NativeCheckpointCreateRequest, claim LeaseClaim, version int) machineImageDetail {
+func readyCheckpointImage(req core.NativeCheckpointCreateRequest, claim core.LeaseClaim, version int) machineImageDetail {
 	return machineImageDetail{
 		Image: machineImage{ID: "img-1", Name: req.Name, Status: "READY"},
 		Versions: []machineImageVersion{{
@@ -2092,7 +2092,7 @@ func readyCheckpointImage(req core.NativeCheckpointCreateRequest, claim LeaseCla
 	}
 }
 
-func checkpointImageSnapshotState(req core.NativeCheckpointCreateRequest, claim LeaseClaim, version int, snapshotStatus string) machineImageDetail {
+func checkpointImageSnapshotState(req core.NativeCheckpointCreateRequest, claim core.LeaseClaim, version int, snapshotStatus string) machineImageDetail {
 	detail := readyCheckpointImage(req, claim, version)
 	detail.Versions[0].SnapshotStatus = snapshotStatus
 	return detail
@@ -2114,7 +2114,7 @@ func TestCreateNativeCheckpointStopsSavesRestartsAndRefreshesClaimEndpoint(t *te
 		func() machine { item := checkpointSource(req, "203.0.113.77"); item.Status = "STARTING"; return item }(),
 		checkpointSource(req, "203.0.113.77"),
 	}
-	b.prepareNativeImageSource = func(context.Context, SSHTarget) error {
+	b.prepareNativeImageSource = func(context.Context, core.SSHTarget) error {
 		api.actions = append(api.actions, "prepare")
 		return nil
 	}
@@ -2133,7 +2133,7 @@ func TestCreateNativeCheckpointStopsSavesRestartsAndRefreshesClaimEndpoint(t *te
 	if err := os.WriteFile(globalKnownHosts, []byte(globalTrust), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	b.waitSSH = func(_ context.Context, target *SSHTarget, _ time.Duration) error {
+	b.waitSSH = func(_ context.Context, target *core.SSHTarget, _ time.Duration) error {
 		if target.KnownHostsFile != lease.SSH.KnownHostsFile {
 			t.Fatalf("restart known hosts=%q want=%q", target.KnownHostsFile, lease.SSH.KnownHostsFile)
 		}
@@ -2352,7 +2352,7 @@ func TestCreateNativeCheckpointPreservesAlreadyStoppedSource(t *testing.T) {
 	stopped := checkpointSource(req, "203.0.113.10")
 	stopped.Status = "STOPPED"
 	api.getSequence = []machine{stopped}
-	b.prepareNativeImageSource = func(context.Context, SSHTarget) error {
+	b.prepareNativeImageSource = func(context.Context, core.SSHTarget) error {
 		t.Fatal("pre-stopped source must not require SSH preparation")
 		return nil
 	}

--- a/internal/providers/machine0/capture.go
+++ b/internal/providers/machine0/capture.go
@@ -8,15 +8,15 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *backend) advanceCheckpointCapture(ctx context.Context, req core.NativeCheckpointCreateRequest, claim LeaseClaim) (result core.NativeCheckpointCreateResult, err error) {
+func (b *backend) advanceCheckpointCapture(ctx context.Context, req core.NativeCheckpointCreateRequest, claim core.LeaseClaim) (result core.NativeCheckpointCreateResult, err error) {
 	if reason := checkpointRetirementPolicy(b.configForRun(), claim.Labels); reason != "" {
-		return result, exit(2, "%s", reason)
+		return result, core.Exit(2, "%s", reason)
 	}
 	if err := core.ValidateCheckpointCaptureClaim(claim, req.CheckpointID, req.Capture); err != nil {
 		return result, err
 	}
 	if req.Persist == nil {
-		return result, exit(2, "replayable checkpoint requires durable observation")
+		return result, core.Exit(2, "replayable checkpoint requires durable observation")
 	}
 	name := "crabbox-" + strings.TrimPrefix(req.CheckpointID, "chk_")
 	metadata := req.Metadata
@@ -24,22 +24,22 @@ func (b *backend) advanceCheckpointCapture(ctx context.Context, req core.NativeC
 		metadata = map[string]string{metadataImageName: name, metadataCreatedImage: "true", metadataSourceMachine: claim.CloudID, "crabbox_checkpoint": req.CheckpointID, "crabbox_lease": claim.LeaseID}
 	}
 	if metadata[metadataImageName] != name || metadata[metadataSourceMachine] != claim.CloudID {
-		return result, exit(2, "checkpoint capture metadata conflicts with its source binding")
+		return result, core.Exit(2, "checkpoint capture metadata conflicts with its source binding")
 	}
 	result.Metadata = metadata
 	req.Metadata = metadata
 	remoteMetadata := map[string]string{"crabbox_checkpoint": req.CheckpointID, "crabbox_lease": claim.LeaseID, "crabbox_source": claim.CloudID}
 	persist := func(phase string) error { req.Capture.Phase = phase; return req.Persist(result) }
-	err = withClaimUnchanged(claim.LeaseID, claim, func() error {
+	err = core.WithLeaseClaimUnchanged(claim.LeaseID, claim, func() error {
 		if metadata[metadataAccountID] == "" && req.Capture.Phase != "prepared" {
-			return exit(2, "checkpoint has no captured Machine0 account identity; retain source for recovery")
+			return core.Exit(2, "checkpoint has no captured Machine0 account identity; retain source for recovery")
 		}
 		accountID, err := b.api.AccountID(ctx)
 		if err != nil {
 			return err
 		}
 		if accountID == "" || (metadata[metadataAccountID] != "" && metadata[metadataAccountID] != accountID) {
-			return exit(2, "Machine0 checkpoint account identity changed; retain source")
+			return core.Exit(2, "Machine0 checkpoint account identity changed; retain source")
 		}
 		readSource := func() (machine, error) {
 			if err := b.attestCheckpointAccount(ctx, metadata[metadataAccountID]); err != nil {
@@ -67,7 +67,7 @@ func (b *backend) advanceCheckpointCapture(ctx context.Context, req core.NativeC
 			}
 			for _, image := range images {
 				if image.Name == name {
-					return exit(2, "checkpoint image name already exists before submission; retain operation for inspection")
+					return core.Exit(2, "checkpoint image name already exists before submission; retain operation for inspection")
 				}
 			}
 			if err := persist("stopping"); err != nil {
@@ -102,7 +102,7 @@ func (b *backend) advanceCheckpointCapture(ctx context.Context, req core.NativeC
 				return nil
 			case "STOPPED":
 			default:
-				return exit(5, "checkpoint source state=%s cannot be captured; retain operation", item.Status)
+				return core.Exit(5, "checkpoint source state=%s cannot be captured; retain operation", item.Status)
 			}
 			if !strings.EqualFold(item.Status, "STOPPED") {
 				return nil
@@ -115,7 +115,7 @@ func (b *backend) advanceCheckpointCapture(ctx context.Context, req core.NativeC
 				return err
 			}
 			if !strings.EqualFold(item.Status, "STOPPED") {
-				return exit(5, "checkpoint source left STOPPED before submission; retain operation")
+				return core.Exit(5, "checkpoint source left STOPPED before submission; retain operation")
 			}
 			// A lost response (including death before invocation) stays submitting.
 			// Absence from a later inventory never authorizes another save.
@@ -134,11 +134,11 @@ func (b *backend) advanceCheckpointCapture(ctx context.Context, req core.NativeC
 		for _, image := range images {
 			if image.Name == name {
 				if imageID != "" || image.ID == "" {
-					return exit(2, "checkpoint image inventory is ambiguous")
+					return core.Exit(2, "checkpoint image inventory is ambiguous")
 				}
 				imageID = image.ID
 				if metadata[metadataImageID] != "" && metadata[metadataImageID] != image.ID {
-					return exit(2, "checkpoint image identity changed")
+					return core.Exit(2, "checkpoint image identity changed")
 				}
 			}
 		}
@@ -151,22 +151,22 @@ func (b *backend) advanceCheckpointCapture(ctx context.Context, req core.NativeC
 			return err
 		}
 		if detail.Image.Name != name || detail.Image.ID != imageID {
-			return exit(2, "checkpoint image identity changed")
+			return core.Exit(2, "checkpoint image identity changed")
 		}
 		var version machineImageVersion
 		for _, candidate := range detail.Versions {
 			if machine0ImageVersionMetadataMatches(candidate, remoteMetadata) {
 				if version.Version != 0 {
-					return exit(2, "multiple versions match checkpoint operation; retain all references")
+					return core.Exit(2, "multiple versions match checkpoint operation; retain all references")
 				}
 				version = candidate
 			}
 		}
 		if version.Version == 0 {
-			return exit(2, "checkpoint image has no exact operation version; retain source")
+			return core.Exit(2, "checkpoint image has no exact operation version; retain source")
 		}
 		if metadata[metadataImageVersion] != "" && metadata[metadataImageVersion] != fmt.Sprint(version.Version) {
-			return exit(2, "checkpoint image version changed")
+			return core.Exit(2, "checkpoint image version changed")
 		}
 		result = machine0NativeCheckpointResult(req, claim, name, true, detail, version)
 		req.Capture.Error = ""
@@ -183,19 +183,19 @@ func (b *backend) advanceCheckpointCapture(ctx context.Context, req core.NativeC
 	return result, err
 }
 
-func (b *backend) releaseCheckpointSource(ctx context.Context, req ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
+func (b *backend) releaseCheckpointSource(ctx context.Context, req core.ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	claim, exists, err := core.ReadLeaseClaimWithPresence(req.Lease.LeaseID)
 	if err != nil {
 		return err
 	}
 	if !exists {
-		return exit(2, "checkpoint source claim is missing; retain the operation")
+		return core.Exit(2, "checkpoint source claim is missing; retain the operation")
 	}
 	if err := core.AuthorizeCheckpointRelease(claim, req.CheckpointID); err != nil {
 		return err
 	}
 	if reason := checkpointRetirementPolicy(b.configForRun(), claim.Labels); reason != "" {
-		return exit(2, "%s", reason)
+		return core.Exit(2, "%s", reason)
 	}
 	return fixedMachine0LeaseKind.FinalizeAfterCleanup(claim, func() error {
 		resource, err := core.AuthorizedCheckpointReleaseResource(claim, req.CheckpointID)
@@ -204,7 +204,7 @@ func (b *backend) releaseCheckpointSource(ctx context.Context, req ReleaseLeaseR
 		}
 		name := claim.Labels["machine0_name"]
 		if name == "" || req.Lease.Server.CloudID != claim.CloudID {
-			return exit(2, "checkpoint source release identity changed")
+			return core.Exit(2, "checkpoint source release identity changed")
 		}
 		findSource := func() (bool, error) {
 			if err := b.attestCheckpointSourceAccount(ctx, resource.Metadata, resource.Capture); err != nil {
@@ -217,11 +217,11 @@ func (b *backend) releaseCheckpointSource(ctx context.Context, req ReleaseLeaseR
 			found := false
 			for _, item := range items {
 				if item.Name == name && item.ID != claim.CloudID {
-					return false, exit(2, "checkpoint source name now belongs to a replacement")
+					return false, core.Exit(2, "checkpoint source name now belongs to a replacement")
 				}
 				if item.ID == claim.CloudID {
 					if item.Name != name {
-						return false, exit(2, "checkpoint source name changed")
+						return false, core.Exit(2, "checkpoint source name changed")
 					}
 					found = true
 				}
@@ -242,7 +242,7 @@ func (b *backend) releaseCheckpointSource(ctx context.Context, req ReleaseLeaseR
 			return core.ErrCheckpointPending
 		case "RUNNING", "STOPPED", "ERRORED":
 		default:
-			return exit(5, "checkpoint source state=%s is not safe to retire; retain operation", item.Status)
+			return core.Exit(5, "checkpoint source state=%s is not safe to retire; retain operation", item.Status)
 		}
 		if err := b.attestCheckpointSourceAccount(ctx, resource.Metadata, resource.Capture); err != nil {
 			return err
@@ -274,11 +274,11 @@ func (b *backend) CheckpointSourceAbsent(ctx context.Context, req core.Checkpoin
 	found := false
 	for _, item := range items {
 		if item.Name == req.Capture.SourceName && item.ID != req.Capture.SourceID {
-			return false, exit(2, "checkpoint source name now belongs to a replacement")
+			return false, core.Exit(2, "checkpoint source name now belongs to a replacement")
 		}
 		if item.ID == req.Capture.SourceID {
 			if item.Name != req.Capture.SourceName {
-				return false, exit(2, "checkpoint source name changed")
+				return false, core.Exit(2, "checkpoint source name changed")
 			}
 			found = true
 		}
@@ -291,14 +291,14 @@ func (b *backend) CheckpointSourceAbsent(ctx context.Context, req core.Checkpoin
 
 func (b *backend) attestCheckpointAccount(ctx context.Context, expected string) error {
 	if expected == "" {
-		return exit(2, "checkpoint has no captured Machine0 account identity; retain source for recovery")
+		return core.Exit(2, "checkpoint has no captured Machine0 account identity; retain source for recovery")
 	}
 	actual, err := b.api.AccountID(ctx)
 	if err != nil {
 		return err
 	}
 	if actual != expected {
-		return exit(2, "Machine0 checkpoint account identity changed; retain checkpoint and source")
+		return core.Exit(2, "Machine0 checkpoint account identity changed; retain checkpoint and source")
 	}
 	return nil
 }

--- a/internal/providers/machine0/checkpoint_abandon.go
+++ b/internal/providers/machine0/checkpoint_abandon.go
@@ -24,20 +24,20 @@ func (b *backend) PrepareNativeCheckpointAbandon(ctx context.Context, req core.N
 		capture.SourceScope != claim.ProviderScope || capture.SourceRevision != claim.Revision ||
 		capture.SourceClaimedAt != claim.ClaimedAt || capture.SourceName == "" ||
 		req.Server.CloudID != claim.CloudID || req.Server.Name != capture.SourceName {
-		return nil, exit(2, "checkpoint abandonment requires the exact current unbound Machine0 source claim")
+		return nil, core.Exit(2, "checkpoint abandonment requires the exact current unbound Machine0 source claim")
 	}
 	intent := ""
 	if claim.FixedCreateIntent != nil {
 		intent = claim.FixedCreateIntent.Fingerprint
 	}
 	if capture.SourceIntent != intent {
-		return nil, exit(2, "checkpoint abandonment source intent changed")
+		return nil, core.Exit(2, "checkpoint abandonment source intent changed")
 	}
 	if reason := checkpointRetirementPolicy(b.configForRun(), claim.Labels); reason != "" {
-		return nil, exit(2, "%s", reason)
+		return nil, core.Exit(2, "%s", reason)
 	}
 	if req.Metadata[metadataImageID] != "" || req.Metadata[metadataImageVersion] != "" {
-		return nil, exit(2, "checkpoint abandonment cannot discard a recorded Machine0 image identity")
+		return nil, core.Exit(2, "checkpoint abandonment cannot discard a recorded Machine0 image identity")
 	}
 	name := strings.TrimSpace(req.Name)
 	if name == "" {
@@ -56,7 +56,7 @@ func (b *backend) PrepareNativeCheckpointAbandon(ctx context.Context, req core.N
 		"machine0_original_submission": "unknown",
 	} {
 		if expected == "" || metadata[key] != "" && metadata[key] != expected {
-			return nil, exit(2, "checkpoint abandonment metadata conflicts with its source binding: %s", key)
+			return nil, core.Exit(2, "checkpoint abandonment metadata conflicts with its source binding: %s", key)
 		}
 		metadata[key] = expected
 	}
@@ -65,7 +65,7 @@ func (b *backend) PrepareNativeCheckpointAbandon(ctx context.Context, req core.N
 		return nil, err
 	}
 	if strings.TrimSpace(accountID) == "" || metadata[metadataSourceCleanupAccountID] != "" && metadata[metadataSourceCleanupAccountID] != accountID {
-		return nil, exit(2, "Machine0 checkpoint source cleanup account identity changed; retain source")
+		return nil, core.Exit(2, "Machine0 checkpoint source cleanup account identity changed; retain source")
 	}
 	metadata[metadataSourceCleanupAccountID] = accountID
 	if _, err := b.readCheckpointSource(ctx, claim, capture.SourceName); err != nil {
@@ -79,7 +79,7 @@ func (b *backend) PrepareNativeCheckpointAbandon(ctx context.Context, req core.N
 
 func (b *backend) attestCheckpointSourceAccount(ctx context.Context, metadata map[string]string, capture *core.NativeCheckpointCapture) error {
 	if capture == nil {
-		return exit(2, "checkpoint source cleanup has no operation identity; retain source")
+		return core.Exit(2, "checkpoint source cleanup has no operation identity; retain source")
 	}
 	key := metadataAccountID
 	switch capture.SourceDisposition {
@@ -89,7 +89,7 @@ func (b *backend) attestCheckpointSourceAccount(ctx context.Context, metadata ma
 		// original image account, or promote cleanup provenance to image authority.
 		key = metadataSourceCleanupAccountID
 	default:
-		return exit(2, "checkpoint source cleanup has an unknown disposition; retain source")
+		return core.Exit(2, "checkpoint source cleanup has an unknown disposition; retain source")
 	}
 	return b.attestCheckpointAccount(ctx, metadata[key])
 }

--- a/internal/providers/machine0/client.go
+++ b/internal/providers/machine0/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	core "github.com/openclaw/crabbox/internal/cli"
 	"io"
 	"os/exec"
 	"regexp"
@@ -14,6 +13,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 const (
@@ -47,8 +48,8 @@ type machine0API interface {
 }
 
 type client struct {
-	cfg   Machine0Config
-	rt    Runtime
+	cfg   core.Machine0Config
+	rt    core.Runtime
 	sleep func(context.Context, time.Duration) error
 }
 
@@ -134,9 +135,9 @@ func (s *machineSize) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (c *client) run(ctx context.Context, args ...string) (LocalCommandResult, error) {
+func (c *client) run(ctx context.Context, args ...string) (core.LocalCommandResult, error) {
 	started := time.Now()
-	result, err := c.rt.Exec.Run(ctx, LocalCommandRequest{
+	result, err := c.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name:                   c.cfg.CLIPath,
 		Args:                   args,
 		MaxCapturedOutputBytes: maxCLIOutput,
@@ -148,7 +149,7 @@ func (c *client) run(ctx context.Context, args ...string) (LocalCommandResult, e
 		return result, nil
 	}
 	if errors.Is(err, exec.ErrNotFound) || strings.Contains(strings.ToLower(fmt.Sprint(err)), "executable file not found") || strings.Contains(strings.ToLower(fmt.Sprint(err)), "no such file or directory") {
-		return result, exit(3, "Machine0 CLI %q was not found; install @machine0/cli and ensure machine0 is on PATH (for example: npm install -g @machine0/cli)", c.cfg.CLIPath)
+		return result, core.Exit(3, "Machine0 CLI %q was not found; install @machine0/cli and ensure machine0 is on PATH (for example: npm install -g @machine0/cli)", c.cfg.CLIPath)
 	}
 	detail := strings.TrimSpace(result.Stderr)
 	if detail == "" {
@@ -172,12 +173,12 @@ func (c *client) run(ctx context.Context, args ...string) (LocalCommandResult, e
 	}
 	lower := strings.ToLower(detail)
 	if strings.Contains(lower, "not logged in") || strings.Contains(lower, "not authenticated") || strings.Contains(lower, "unauthorized") {
-		return result, exit(3, "Machine0 authentication is required; run `machine0 login` or set MACHINE0_API_TOKEN: %s", detail)
+		return result, core.Exit(3, "Machine0 authentication is required; run `machine0 login` or set MACHINE0_API_TOKEN: %s", detail)
 	}
-	return result, exit(5, "machine0 %s failed: %s", strings.Join(args, " "), core.Blank(detail, "unknown error"))
+	return result, core.Exit(5, "machine0 %s failed: %s", strings.Join(args, " "), core.Blank(detail, "unknown error"))
 }
 
-func (c *client) runRead(ctx context.Context, args ...string) (LocalCommandResult, error) {
+func (c *client) runRead(ctx context.Context, args ...string) (core.LocalCommandResult, error) {
 	delay := machine0ReadRetryDelay(c.cfg.PollInterval)
 	sleep := c.sleep
 	if sleep == nil {
@@ -186,7 +187,7 @@ func (c *client) runRead(ctx context.Context, args ...string) (LocalCommandResul
 	warned := false
 	for {
 		if err := context.Cause(ctx); err != nil {
-			return LocalCommandResult{}, err
+			return core.LocalCommandResult{}, err
 		}
 		result, err := c.run(ctx, args...)
 		if err == nil {
@@ -223,7 +224,7 @@ func machine0ReadRetryDelay(configured time.Duration) time.Duration {
 	return configured
 }
 
-func machine0ReadUnavailable(result LocalCommandResult, err error) bool {
+func machine0ReadUnavailable(result core.LocalCommandResult, err error) bool {
 	detail := strings.ToLower(strings.Join([]string{result.Stdout, result.Stderr, fmt.Sprint(err)}, "\n"))
 	return strings.Contains(detail, machine0RateLimitMessage) || strings.Contains(detail, machine0UnavailableMessage)
 }
@@ -259,7 +260,7 @@ func (c *client) AccountID(ctx context.Context) (string, error) {
 			return "", cause
 		}
 		// Native output includes personal and billing details; never echo it.
-		return "", exit(5, "machine0 account identity lookup failed; retain checkpoint and source")
+		return "", core.Exit(5, "machine0 account identity lookup failed; retain checkpoint and source")
 	}
 	var account struct {
 		User struct {
@@ -267,7 +268,7 @@ func (c *client) AccountID(ctx context.Context) (string, error) {
 		} `json:"user"`
 	}
 	if err := decodeJSON(result.Stdout, &account); err != nil || strings.TrimSpace(account.User.ID) == "" || account.User.ID != strings.TrimSpace(account.User.ID) {
-		return "", exit(5, "machine0 whoami --json omitted a valid user.id; retain checkpoint and source")
+		return "", core.Exit(5, "machine0 whoami --json omitted a valid user.id; retain checkpoint and source")
 	}
 	return account.User.ID, nil
 }
@@ -279,11 +280,11 @@ func (c *client) List(ctx context.Context) ([]machine, error) {
 	}
 	var machines []machine
 	if err := decodeJSON(result.Stdout, &machines); err != nil {
-		return nil, exit(5, "parse machine0 ls --json: %v", err)
+		return nil, core.Exit(5, "parse machine0 ls --json: %v", err)
 	}
 	for i := range machines {
 		if err := validateMachine(machines[i], false); err != nil {
-			return nil, exit(5, "parse machine0 ls --json item %d: %v", i, err)
+			return nil, core.Exit(5, "parse machine0 ls --json item %d: %v", i, err)
 		}
 	}
 	return machines, nil
@@ -300,24 +301,24 @@ func (c *client) Get(ctx context.Context, name string) (machine, error) {
 			return machine{}, err
 		}
 		if machines == nil {
-			return machine{}, exit(5, "invalid machine0 ls --json for UUID lookup: expected an array")
+			return machine{}, core.Exit(5, "invalid machine0 ls --json for UUID lookup: expected an array")
 		}
 		for i, candidate := range machines {
 			if !machine0UUIDPattern.MatchString(candidate.ID) {
-				return machine{}, exit(5, "invalid machine0 ls --json item %d: missing or malformed UUID", i)
+				return machine{}, core.Exit(5, "invalid machine0 ls --json item %d: missing or malformed UUID", i)
 			}
 			if strings.EqualFold(candidate.ID, id) {
 				if name != "" {
-					return machine{}, exit(5, "multiple Machine0 inventory entries match UUID %s", id)
+					return machine{}, core.Exit(5, "multiple Machine0 inventory entries match UUID %s", id)
 				}
 				name = candidate.Name
 			}
 		}
 		if name == "" {
-			return machine{}, exit(4, "Machine0 UUID %s is absent from current authorized inventory", id)
+			return machine{}, core.Exit(4, "Machine0 UUID %s is absent from current authorized inventory", id)
 		}
 		if machine0UUIDPattern.MatchString(name) {
-			return machine{}, exit(5, "invalid machine name in Machine0 inventory for UUID %s: %q", id, name)
+			return machine{}, core.Exit(5, "invalid machine name in Machine0 inventory for UUID %s: %q", id, name)
 		}
 	}
 	result, err := c.runRead(ctx, "get", name, "--json")
@@ -326,13 +327,13 @@ func (c *client) Get(ctx context.Context, name string) (machine, error) {
 	}
 	var item machine
 	if err := decodeJSON(result.Stdout, &item); err != nil {
-		return machine{}, exit(5, "parse machine0 get %s --json: %v", name, err)
+		return machine{}, core.Exit(5, "parse machine0 get %s --json: %v", name, err)
 	}
 	if err := validateMachine(item, true); err != nil {
-		return machine{}, exit(5, "invalid machine0 get %s --json: %v", name, err)
+		return machine{}, core.Exit(5, "invalid machine0 get %s --json: %v", name, err)
 	}
 	if id != "" && (!strings.EqualFold(item.ID, id) || item.Name != name) {
-		return machine{}, exit(5, "Machine0 lookup identity changed: expected id=%s name=%q, found id=%s name=%q", id, name, item.ID, item.Name)
+		return machine{}, core.Exit(5, "Machine0 lookup identity changed: expected id=%s name=%q, found id=%s name=%q", id, name, item.ID, item.Name)
 	}
 	return item, nil
 }
@@ -345,13 +346,13 @@ func (c *client) SelectedKey(ctx context.Context, name string) (*machineKey, err
 		}
 		var keys []machineKey
 		if err := decodeJSON(result.Stdout, &keys); err != nil {
-			return nil, exit(5, "parse machine0 keys ls --json: %v", err)
+			return nil, core.Exit(5, "parse machine0 keys ls --json: %v", err)
 		}
 		for _, key := range keys {
 			if key.IsDefault {
 				name = strings.TrimSpace(key.Name)
 				if name == "" {
-					return nil, exit(5, "machine0 default SSH key has no name")
+					return nil, core.Exit(5, "machine0 default SSH key has no name")
 				}
 				break
 			}
@@ -367,10 +368,10 @@ func (c *client) SelectedKey(ctx context.Context, name string) (*machineKey, err
 	}
 	var key machineKey
 	if err := decodeJSON(result.Stdout, &key); err != nil {
-		return nil, exit(5, "parse machine0 keys get %s --json: %v", name, err)
+		return nil, core.Exit(5, "parse machine0 keys get %s --json: %v", name, err)
 	}
 	if strings.TrimSpace(key.Name) != name {
-		return nil, exit(5, "machine0 key lookup returned mismatched key name: expected %s, found %s", name, core.Blank(key.Name, "<empty>"))
+		return nil, core.Exit(5, "machine0 key lookup returned mismatched key name: expected %s, found %s", name, core.Blank(key.Name, "<empty>"))
 	}
 	return &key, nil
 }
@@ -432,14 +433,14 @@ func (c *client) Sizes(ctx context.Context) ([]machineSize, error) {
 	}
 	var sizes []machineSize
 	if err := decodeJSON(result.Stdout, &sizes); err != nil {
-		return nil, exit(5, "parse machine0 sizes --json: %v", err)
+		return nil, core.Exit(5, "parse machine0 sizes --json: %v", err)
 	}
 	for i, size := range sizes {
 		if strings.TrimSpace(size.Size) == "" || size.VCPU <= 0 || size.RAMGB <= 0 || size.DiskGB <= 0 || size.PricePerHourMicro < 0 {
-			return nil, exit(5, "invalid machine0 size catalog item %d", i)
+			return nil, core.Exit(5, "invalid machine0 size catalog item %d", i)
 		}
 		if size.GPU != nil && (strings.TrimSpace(size.GPU.Label) == "" || size.GPU.VRAMGB <= 0 || size.GPU.ScratchDiskGB < 0) {
-			return nil, exit(5, "invalid machine0 GPU metadata for size %s", size.Size)
+			return nil, core.Exit(5, "invalid machine0 GPU metadata for size %s", size.Size)
 		}
 	}
 	return sizes, nil

--- a/internal/providers/machine0/client_output_unix_test.go
+++ b/internal/providers/machine0/client_output_unix_test.go
@@ -37,7 +37,7 @@ process.exit(0);
 	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	c := &client{cfg: Machine0Config{CLIPath: path}, rt: core.RuntimeForProviderOperation(io.Discard)}
+	c := &client{cfg: core.Machine0Config{CLIPath: path}, rt: core.RuntimeForProviderOperation(io.Discard)}
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 	t.Run("account identity", func(t *testing.T) {

--- a/internal/providers/machine0/client_test.go
+++ b/internal/providers/machine0/client_test.go
@@ -42,7 +42,7 @@ func (r *recordingRunner) Run(ctx context.Context, req core.LocalCommandRequest)
 }
 
 func testClient(runner *recordingRunner) *client {
-	return &client{cfg: Machine0Config{CLIPath: "/opt/bin/machine0"}, rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
+	return &client{cfg: core.Machine0Config{CLIPath: "/opt/bin/machine0"}, rt: core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
 }
 
 func TestClientCreateCommandConstruction(t *testing.T) {
@@ -297,7 +297,7 @@ func TestClientReadRetriesUnavailableThenSucceeds(t *testing.T) {
 			sequence = append(sequence, runnerResponse{result: core.LocalCommandResult{Stdout: detail}})
 			runner := &recordingRunner{sequence: sequence}
 			var stderr bytes.Buffer
-			c := &client{cfg: Machine0Config{CLIPath: "/opt/bin/machine0", PollInterval: tc.pollInterval}, rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: &stderr}}
+			c := &client{cfg: core.Machine0Config{CLIPath: "/opt/bin/machine0", PollInterval: tc.pollInterval}, rt: core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: &stderr}}
 			var sleeps []time.Duration
 			c.sleep = func(_ context.Context, delay time.Duration) error {
 				sleeps = append(sleeps, delay)

--- a/internal/providers/machine0/core.go
+++ b/internal/providers/machine0/core.go
@@ -1,36 +1,10 @@
 package machine0
 
 import (
-	"context"
-
-	"io"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type Machine0Config = core.Machine0Config
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type PauseRequest = core.PauseRequest
-type ResumeRequest = core.ResumeRequest
-type CleanupRequest = core.CleanupRequest
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-type LeaseClaim = core.LeaseClaim
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
 
 const (
 	providerName = "machine0"
@@ -38,38 +12,10 @@ const (
 	sshPort      = "22"
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (string, error) {
-	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
-}
-
-func directLeaseLabels(cfg Config, leaseID, slug string, keep bool, now time.Time) map[string]string {
+func directLeaseLabels(cfg core.Config, leaseID, slug string, keep bool, now time.Time) map[string]string {
 	return core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
 }
 
-func claimLease(leaseID, slug string, cfg Config, repoRoot string, reclaim bool, server Server, target SSHTarget) error {
+func claimLease(leaseID, slug string, cfg core.Config, repoRoot string, reclaim bool, server core.Server, target core.SSHTarget) error {
 	return core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, machineScope(server.CloudID), cfg.Pond, repoRoot, cfg.IdleTimeout, reclaim, server, target)
 }
-
-func listClaims() ([]LeaseClaim, error) { return core.ListLeaseClaims() }
-
-func updateClaim(leaseID string, expected LeaseClaim, server Server, target SSHTarget) (LeaseClaim, error) {
-	return core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, expected, server, target)
-}
-
-func updateClaimAction(leaseID string, expected LeaseClaim, action func() (Server, SSHTarget, bool, error)) (LeaseClaim, Server, SSHTarget, error) {
-	return core.ReplaceLeaseClaimEndpointIfUnchangedAction(leaseID, expected, action)
-}
-
-func withClaimUnchanged(leaseID string, expected LeaseClaim, action func() error) error {
-	return core.WithLeaseClaimUnchanged(leaseID, expected, action)
-}
-
-func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
-	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
-}
-
-func bootstrapWaitTimeout(cfg Config) time.Duration { return core.BootstrapWaitTimeout(cfg) }

--- a/internal/providers/machine0/fixed.go
+++ b/internal/providers/machine0/fixed.go
@@ -35,7 +35,7 @@ type machine0CreateAttempt struct {
 	CreatedAt    string `json:"createdAt"`
 }
 
-func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+func (b *backend) acquireFixed(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	leaseID := strings.TrimSpace(req.RequestedLeaseID)
 	cfg := b.configForRun()
 	var fingerprint string
@@ -75,11 +75,11 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 			if err != nil {
 				return core.FixedLeaseBinding{}, err
 			}
-			servers := make([]Server, 0, len(machines))
+			servers := make([]core.Server, 0, len(machines))
 			for _, item := range machines {
 				servers = append(servers, b.serverFromMachine(item, claims[item.ID], cfg))
 			}
-			slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+			slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
 			if err != nil {
 				return core.FixedLeaseBinding{}, err
 			}
@@ -88,9 +88,9 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 			binding.Slug = slug
 		}
 		return binding, nil
-	}, func(ctx context.Context, claim *core.LeaseClaim, intent *core.FixedCreateIntent, persist func() error) (_ LeaseTarget, acquireErr error) {
+	}, func(ctx context.Context, claim *core.LeaseClaim, intent *core.FixedCreateIntent, persist func() error) (_ core.LeaseTarget, acquireErr error) {
 		if err := core.AuthorizeCheckpointRelease(*claim, ""); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		name := machine0MachineName(leaseID, intent.Slug)
 		defer func() {
@@ -100,24 +100,24 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 		}()
 		item, err := b.resolveFixedMachine0(ctx, *claim)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		replay := item.ID != ""
 		if !replay {
 			if claim.CloudID != "" {
-				return LeaseTarget{}, exit(4, "lease_id_conflict: acquired fixed lease %s is missing its bound Machine0 machine", leaseID)
+				return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: acquired fixed lease %s is missing its bound Machine0 machine", leaseID)
 			}
 			// Older clients could erase an ambiguous attempt. Only this invocation
 			// can prove it created the empty claim while holding the create lock.
 			if !freshClaim {
-				return LeaseTarget{}, exit(4, "lease_id_conflict: fixed Machine0 lease %s has no observed resource or provably unsubmitted attempt; retain its claim", leaseID)
+				return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: fixed Machine0 lease %s has no observed resource or provably unsubmitted attempt; retain its claim", leaseID)
 			}
 			// Capacity gates new creation, never replay of an attested VM.
 			if err := b.validateCatalogSelection(ctx, cfg.Machine0.Size, cfg.Machine0.Region); err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 			if err := b.preflightSSHKey(ctx, cfg.Machine0.Key); err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 			image := cfg.Machine0.Image
 			if req.Options.Desktop && strings.TrimSpace(cfg.Machine0.DesktopImage) != "" {
@@ -130,18 +130,18 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 			}
 			data, err := json.Marshal(attempt)
 			if err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 			intent.Attempt = map[string]string{"machine0": string(data)}
 			if err := persist(); err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 			fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s size=%s region=%s image=%s keep=%v fixed=true\n", providerName, leaseID, intent.Slug, name, cfg.Machine0.Size, cfg.Machine0.Region, image, req.Keep)
 			if createErr := b.api.Create(ctx, createMachineRequest{Name: name, Size: attempt.Size, Region: attempt.Region, Image: image, ImageVersion: attempt.ImageVersion, Key: attempt.Key}); createErr != nil {
 				// An empty inventory cannot prove a failed request will never create a VM.
 				item, err = b.resolveFixedMachine0(ctx, *claim)
 				if err != nil {
-					return LeaseTarget{}, errors.Join(createErr, err)
+					return core.LeaseTarget{}, errors.Join(createErr, err)
 				}
 			} else {
 				// Native new prints no UUID; the bounded poll attests the first get.
@@ -150,7 +150,7 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 		}
 		if item.ID != "" {
 			if err := b.bindFixedMachine0(claim, item, req.Keep, persist); err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 		}
 		item, err = b.waitForResolveRunning(ctx, item, cfg.Machine0.CreateTimeout, replay, func(previous, observed machine) (machine, error) {
@@ -161,19 +161,19 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 			return item, b.bindFixedMachine0(claim, item, req.Keep, persist)
 		})
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		server := b.serverFromMachine(item, *claim, cfg)
 		server.Labels = machineLabels(cfg, item, leaseID, intent.Slug, req.Keep, core.ClockNow(b.rt.Clock).UTC())
 		return b.prepareLease(ctx, item, server, leaseID, true)
 	}, ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s machine=%s resource=%s state=ready\n", leaseID, acquired.Server.Name, acquired.Server.CloudID)
 	if req.OnAcquired != nil {
 		if err := req.OnAcquired(acquired); err != nil {
-			return LeaseTarget{}, fmt.Errorf("acknowledge fixed Machine0 acquisition: %w", err)
+			return core.LeaseTarget{}, fmt.Errorf("acknowledge fixed Machine0 acquisition: %w", err)
 		}
 	}
 	return acquired, nil
@@ -185,9 +185,9 @@ func machine0NameScope(name string) string {
 
 // Fixed ownership comes from the durable attempt and, once observed, the UUID.
 // Resolution never starts a machine or needs a usable SSH endpoint.
-func (b *backend) resolveFixedMachine0(ctx context.Context, claim LeaseClaim) (machine, error) {
+func (b *backend) resolveFixedMachine0(ctx context.Context, claim core.LeaseClaim) (machine, error) {
 	if claim.FixedCreateIntent != nil && claim.FixedCreateIntent.State == fixedMachine0IntentReleased {
-		return machine{}, fixedMachine0LeaseKind.ValidateTerminalClaim(claim, LeaseClaim{}, claim.LeaseID, validateFixedMachine0TerminalClaimExtra)
+		return machine{}, fixedMachine0LeaseKind.ValidateTerminalClaim(claim, core.LeaseClaim{}, claim.LeaseID, validateFixedMachine0TerminalClaimExtra)
 	}
 	attempt, err := fixedMachine0ClaimAttempt(claim)
 	if err != nil {
@@ -202,24 +202,24 @@ func (b *backend) resolveFixedMachine0(ctx context.Context, claim LeaseClaim) (m
 	var found *machine
 	for _, item := range machines {
 		if item.ID != "" && seen[item.ID] {
-			return machine{}, exit(4, "lease_id_conflict: Machine0 inventory contains duplicate resource ID %s", item.ID)
+			return machine{}, core.Exit(4, "lease_id_conflict: Machine0 inventory contains duplicate resource ID %s", item.ID)
 		}
 		seen[item.ID] = true
 		if item.Name == name {
 			if found != nil {
-				return machine{}, exit(4, "lease_id_conflict: multiple Machine0 machines match fixed lease %s", claim.LeaseID)
+				return machine{}, core.Exit(4, "lease_id_conflict: multiple Machine0 machines match fixed lease %s", claim.LeaseID)
 			}
 			found = &item
 		} else if item.ID == claim.CloudID && claim.CloudID != "" {
-			return machine{}, exit(4, "lease_id_conflict: fixed Machine0 lease %s resource name changed", claim.LeaseID)
+			return machine{}, core.Exit(4, "lease_id_conflict: fixed Machine0 lease %s resource name changed", claim.LeaseID)
 		}
 	}
 	if found != nil {
 		if attempt == nil {
-			return machine{}, exit(4, "lease_id_conflict: Machine0 machine %s has no durable create attempt", name)
+			return machine{}, core.Exit(4, "lease_id_conflict: Machine0 machine %s has no durable create attempt", name)
 		}
 		if strings.TrimSpace(found.ID) == "" {
-			return machine{}, exit(4, "lease_id_conflict: Machine0 machine %s has no resource ID", name)
+			return machine{}, core.Exit(4, "lease_id_conflict: Machine0 machine %s has no resource ID", name)
 		}
 		// Inventory discovers identity; only full detail can attest pinned fields.
 		detail, err := b.api.Get(ctx, name)
@@ -229,63 +229,63 @@ func (b *backend) resolveFixedMachine0(ctx context.Context, claim LeaseClaim) (m
 		return attestFixedMachine0Detail(claim, *found, detail)
 	}
 	if claim.FixedCreateIntent.State == fixedMachine0IntentPrepared && len(claim.FixedCreateIntent.Attempt) != 0 {
-		return machine{}, exit(4, "lease_id_conflict: fixed Machine0 lease %s has an unresolved create attempt; retain the claim and retry inspection or stop after provider inventory converges", claim.LeaseID)
+		return machine{}, core.Exit(4, "lease_id_conflict: fixed Machine0 lease %s has an unresolved create attempt; retain the claim and retry inspection or stop after provider inventory converges", claim.LeaseID)
 	}
 	return machine{}, nil
 }
 
-func fixedMachine0ClaimAttempt(claim LeaseClaim) (*machine0CreateAttempt, error) {
+func fixedMachine0ClaimAttempt(claim core.LeaseClaim) (*machine0CreateAttempt, error) {
 	intent := claim.FixedCreateIntent
 	name := machine0MachineName(claim.LeaseID, claim.Slug)
 	if !core.IsCanonicalLeaseID(claim.LeaseID) || !fixedMachine0LeaseKind.IsFixedClaim(claim) ||
 		intent.Version != fixedMachine0CreateIntentVersion || intent.Fingerprint == "" || intent.Slug != claim.Slug ||
 		intent.ProviderScope != machine0NameScope(name) ||
 		(intent.State != fixedMachine0IntentPrepared && intent.State != fixedMachine0IntentAcquired) {
-		return nil, exit(4, "lease_id_conflict: invalid fixed Machine0 create intent for lease %s", claim.LeaseID)
+		return nil, core.Exit(4, "lease_id_conflict: invalid fixed Machine0 create intent for lease %s", claim.LeaseID)
 	}
 	if claim.CloudNumericID != 0 || claim.CloudImmutableID != claim.CloudID ||
 		(claim.CloudID == "" && (claim.ProviderScope != intent.ProviderScope || intent.State == fixedMachine0IntentAcquired)) ||
 		(claim.CloudID != "" && claim.ProviderScope != machineScope(claim.CloudID)) {
-		return nil, exit(4, "lease_id_conflict: fixed Machine0 lease %s has inconsistent immutable identity or provider scope", claim.LeaseID)
+		return nil, core.Exit(4, "lease_id_conflict: fixed Machine0 lease %s has inconsistent immutable identity or provider scope", claim.LeaseID)
 	}
 	if _, err := time.Parse(time.RFC3339Nano, intent.CreatedAt); err != nil || len(intent.FailedAttempts) != 0 {
-		return nil, exit(4, "lease_id_conflict: invalid fixed Machine0 attempt history for lease %s", claim.LeaseID)
+		return nil, core.Exit(4, "lease_id_conflict: invalid fixed Machine0 attempt history for lease %s", claim.LeaseID)
 	}
 	if len(intent.Attempt) == 0 {
 		if claim.CloudID != "" || len(claim.Labels) != 0 || claim.SSHHost != "" || claim.SSHPort != 0 {
-			return nil, exit(4, "lease_id_conflict: fixed Machine0 lease %s has no durable create attempt", claim.LeaseID)
+			return nil, core.Exit(4, "lease_id_conflict: fixed Machine0 lease %s has no durable create attempt", claim.LeaseID)
 		}
 		return nil, nil
 	}
 	var attempt machine0CreateAttempt
 	if err := json.Unmarshal([]byte(intent.Attempt["machine0"]), &attempt); err != nil ||
 		attempt.Name != name || attempt.Size == "" || attempt.Region == "" || attempt.Image == "" {
-		return nil, exit(4, "lease_id_conflict: invalid fixed Machine0 attempt for lease %s", claim.LeaseID)
+		return nil, core.Exit(4, "lease_id_conflict: invalid fixed Machine0 attempt for lease %s", claim.LeaseID)
 	}
 	return &attempt, nil
 }
 
-func validateFixedMachine0Ownership(claim LeaseClaim, item machine) error {
+func validateFixedMachine0Ownership(claim core.LeaseClaim, item machine) error {
 	attempt, err := fixedMachine0ClaimAttempt(claim)
 	if err != nil {
 		return err
 	}
 	if attempt == nil {
-		return exit(4, "lease_id_conflict: Machine0 machine %s has no durable create attempt", item.Name)
+		return core.Exit(4, "lease_id_conflict: Machine0 machine %s has no durable create attempt", item.Name)
 	}
 	if strings.TrimSpace(item.ID) == "" || (claim.CloudID != "" && item.ID != claim.CloudID) {
-		return exit(4, "lease_id_conflict: fixed lease %s machine %s does not match acquired CloudID %s", claim.LeaseID, core.Blank(item.ID, "<empty>"), core.Blank(claim.CloudID, "<empty>"))
+		return core.Exit(4, "lease_id_conflict: fixed lease %s machine %s does not match acquired CloudID %s", claim.LeaseID, core.Blank(item.ID, "<empty>"), core.Blank(claim.CloudID, "<empty>"))
 	}
 	if strings.TrimSpace(attempt.Key) != "" && (item.Key == nil || strings.TrimSpace(item.Key.Name) != strings.TrimSpace(attempt.Key)) {
-		return exit(4, "lease_id_conflict: Machine0 machine detail for fixed lease %s does not match its durable selected SSH key %q", claim.LeaseID, attempt.Key)
+		return core.Exit(4, "lease_id_conflict: Machine0 machine detail for fixed lease %s does not match its durable selected SSH key %q", claim.LeaseID, attempt.Key)
 	}
 	if mismatch := validateFixedMachine0Attempt(item, *attempt); mismatch != "" {
-		return exit(4, "lease_id_conflict: Machine0 machine for lease %s does not match its durable create attempt: %s", claim.LeaseID, mismatch)
+		return core.Exit(4, "lease_id_conflict: Machine0 machine for lease %s does not match its durable create attempt: %s", claim.LeaseID, mismatch)
 	}
 	return nil
 }
 
-func (b *backend) bindFixedMachine0(claim *LeaseClaim, item machine, keep bool, persist func() error) error {
+func (b *backend) bindFixedMachine0(claim *core.LeaseClaim, item machine, keep bool, persist func() error) error {
 	if err := validateFixedMachine0Ownership(*claim, item); err != nil {
 		return err
 	}
@@ -298,7 +298,7 @@ func (b *backend) bindFixedMachine0(claim *LeaseClaim, item machine, keep bool, 
 	return persist()
 }
 
-func (b *backend) bindFixedMachine0Claim(claim LeaseClaim, item machine) (LeaseClaim, error) {
+func (b *backend) bindFixedMachine0Claim(claim core.LeaseClaim, item machine) (core.LeaseClaim, error) {
 	expected := claim
 	err := b.bindFixedMachine0(&claim, item, false, func() error {
 		var err error
@@ -308,11 +308,11 @@ func (b *backend) bindFixedMachine0Claim(claim LeaseClaim, item machine) (LeaseC
 	return claim, err
 }
 
-func (b *backend) destroyClaimedMachine(ctx context.Context, expected LeaseClaim, lease LeaseTarget) error {
+func (b *backend) destroyClaimedMachine(ctx context.Context, expected core.LeaseClaim, lease core.LeaseTarget) error {
 	return b.destroyClaimedMachineWithOutcome(ctx, expected, lease, &core.ReleaseLeaseOutcome{})
 }
 
-func (b *backend) destroyClaimedMachineWithOutcome(ctx context.Context, expected LeaseClaim, lease LeaseTarget, outcome *core.ReleaseLeaseOutcome) error {
+func (b *backend) destroyClaimedMachineWithOutcome(ctx context.Context, expected core.LeaseClaim, lease core.LeaseTarget, outcome *core.ReleaseLeaseOutcome) error {
 	if expected.Provider != core.FixedMachine0ClaimProvider && expected.FixedCreateIntent == nil {
 		return fixedMachine0LeaseKind.FinalizeAfterCleanup(expected, func() error {
 			// Reservation holds the source before it changes the claim revision.
@@ -329,11 +329,11 @@ func (b *backend) destroyClaimedMachineWithOutcome(ctx context.Context, expected
 		})
 	}
 	if snapshot, exists, set := core.ServerLeaseClaimSnapshot(lease.Server); set && (!exists || !reflect.DeepEqual(snapshot, expected)) {
-		return exit(4, "fixed Machine0 lease %s claim changed after resolution; retry", expected.LeaseID)
+		return core.Exit(4, "fixed Machine0 lease %s claim changed after resolution; retry", expected.LeaseID)
 	}
-	return core.WithDurableLeaseClaimLock(expected.LeaseID, func(claim *LeaseClaim, exists bool, persist func() error) error {
+	return core.WithDurableLeaseClaimLock(expected.LeaseID, func(claim *core.LeaseClaim, exists bool, persist func() error) error {
 		if !exists || !reflect.DeepEqual(*claim, expected) {
-			return exit(4, "fixed Machine0 lease %s claim changed before release; retry", expected.LeaseID)
+			return core.Exit(4, "fixed Machine0 lease %s claim changed before release; retry", expected.LeaseID)
 		}
 		if err := core.AuthorizeCheckpointRelease(*claim, ""); err != nil {
 			return err
@@ -345,7 +345,7 @@ func (b *backend) destroyClaimedMachineWithOutcome(ctx context.Context, expected
 		}
 		resourceID := firstNonBlank(item.ID, claim.CloudID)
 		if (lease.Server.CloudID != "" && lease.Server.CloudID != resourceID) || (lease.Server.ImmutableID != "" && lease.Server.ImmutableID != resourceID) {
-			return exit(4, "lease_id_conflict: fixed Machine0 resource changed before release")
+			return core.Exit(4, "lease_id_conflict: fixed Machine0 resource changed before release")
 		}
 		if item.ID != "" {
 			if err := b.bindFixedMachine0(claim, item, false, persist); err != nil {
@@ -365,7 +365,7 @@ func (b *backend) destroyClaimedMachineWithOutcome(ctx context.Context, expected
 			}
 			outcome.Terminal = true
 		} else {
-			return exit(4, "fixed Machine0 lease %s is not visible in the current account; absence is unverified, retain its claim and inspect the original account", claim.LeaseID)
+			return core.Exit(4, "fixed Machine0 lease %s is not visible in the current account; absence is unverified, retain its claim and inspect the original account", claim.LeaseID)
 		}
 		*claim = fixedMachine0LeaseKind.TerminalClaim(*claim, core.ClockNow(b.rt.Clock).UTC())
 		return persist()
@@ -397,12 +397,12 @@ func validateFixedMachine0TerminalClaimExtra(claim core.LeaseClaim) error {
 	intent := claim.FixedCreateIntent
 	if intent.ProviderScope != machine0NameScope(machine0MachineName(claim.LeaseID, intent.Slug)) ||
 		claim.CloudNumericID != 0 || claim.CloudImmutableID != "" {
-		return exit(4, "lease_id_conflict: fixed Machine0 lease %s has an invalid terminal tombstone", claim.LeaseID)
+		return core.Exit(4, "lease_id_conflict: fixed Machine0 lease %s has an invalid terminal tombstone", claim.LeaseID)
 	}
 	return nil
 }
 
-func (b *backend) retainLeaseClaimAfterRelease(lease LeaseTarget, previous core.LeaseClaim) (bool, error) {
+func (b *backend) retainLeaseClaimAfterRelease(lease core.LeaseTarget, previous core.LeaseClaim) (bool, error) {
 	claim, exists, err := resolveClaim(lease.LeaseID)
 	if err != nil {
 		return false, err
@@ -414,19 +414,19 @@ func (b *backend) retainLeaseClaimAfterRelease(lease LeaseTarget, previous core.
 	return fixedMachine0LeaseKind.RetainClaimAfterRelease(lease.LeaseID, previous, fixedMachine0LeaseKind.IsFixedClaim(claim), validateFixedMachine0TerminalClaimExtra, nil)
 }
 
-func attestFixedMachine0Detail(claim LeaseClaim, previous, detail machine) (machine, error) {
+func attestFixedMachine0Detail(claim core.LeaseClaim, previous, detail machine) (machine, error) {
 	if previous.ID != "" && (detail.ID != previous.ID || detail.Name != previous.Name) {
-		return machine{}, exit(4, "lease_id_conflict: Machine0 machine detail for fixed lease %s does not match its inventory resource identity", claim.LeaseID)
+		return machine{}, core.Exit(4, "lease_id_conflict: Machine0 machine detail for fixed lease %s does not match its inventory resource identity", claim.LeaseID)
 	}
 	if err := validateFixedMachine0Ownership(claim, detail); err != nil {
 		return machine{}, err
 	}
 	if previous.Key != nil && detail.Key != nil {
 		if strings.TrimSpace(previous.Key.Name) != "" && strings.TrimSpace(previous.Key.Name) != strings.TrimSpace(detail.Key.Name) {
-			return machine{}, exit(4, "lease_id_conflict: Machine0 machine detail for fixed lease %s does not match its inventory SSH key name", claim.LeaseID)
+			return machine{}, core.Exit(4, "lease_id_conflict: Machine0 machine detail for fixed lease %s does not match its inventory SSH key name", claim.LeaseID)
 		}
 		if strings.TrimSpace(previous.Key.Type) != "" && strings.TrimSpace(detail.Key.Type) != "" && !strings.EqualFold(strings.TrimSpace(previous.Key.Type), strings.TrimSpace(detail.Key.Type)) {
-			return machine{}, exit(4, "lease_id_conflict: Machine0 machine detail for fixed lease %s does not match its inventory SSH key type", claim.LeaseID)
+			return machine{}, core.Exit(4, "lease_id_conflict: Machine0 machine detail for fixed lease %s does not match its inventory SSH key type", claim.LeaseID)
 		}
 		if strings.TrimSpace(detail.Key.Type) == "" {
 			key := *detail.Key

--- a/internal/providers/machine0/fixed_cleanup_test.go
+++ b/internal/providers/machine0/fixed_cleanup_test.go
@@ -43,7 +43,7 @@ func TestMachine0FixedReadinessFailureBindsIdentity(t *testing.T) {
 				}
 				return item, nil
 			}
-			b.waitSSH = func(context.Context, *SSHTarget, time.Duration) error { return failure }
+			b.waitSSH = func(context.Context, *core.SSHTarget, time.Duration) error { return failure }
 			if _, err := b.Acquire(context.Background(), req); err == nil || !strings.Contains(err.Error(), failure.Error()) {
 				t.Fatalf("expected readiness failure, got %v", err)
 			}
@@ -70,14 +70,14 @@ func TestMachine0ResumeRejectsTerminalFixedLease(t *testing.T) {
 				t.Fatal(err)
 			}
 			if released {
-				if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+				if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 					t.Fatal(err)
 				}
 			}
 			api.machines = []machine{}
 			before := readFixedMachine0Claim(t, req.RequestedLeaseID)
 			starts := len(api.started)
-			if err := b.Resume(context.Background(), ResumeRequest{ID: req.RequestedLeaseID}); err == nil {
+			if err := b.Resume(context.Background(), core.ResumeRequest{ID: req.RequestedLeaseID}); err == nil {
 				t.Fatal("resume reported success without a live resource")
 			}
 			if len(api.started) != starts || !reflect.DeepEqual(before, readFixedMachine0Claim(t, req.RequestedLeaseID)) {
@@ -162,11 +162,11 @@ func TestMachine0FixedNativeCreateResponseRemainsStoppable(t *testing.T) {
 			}
 			runner.responses["ls\x00--json"] = core.LocalCommandResult{Stdout: "[" + string(data) + "]"}
 			runner.responses[get] = core.LocalCommandResult{Stdout: string(data)}
-			lease, err := b.Resolve(context.Background(), ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true})
+			lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true})
 			if err != nil {
 				t.Fatal(err)
 			}
-			if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+			if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 				t.Fatal(err)
 			}
 			assertFixedMachine0Tombstone(t, readFixedMachine0Claim(t, req.RequestedLeaseID))
@@ -196,7 +196,7 @@ func TestMachine0FixedResolvedClaimReplacementFencesDeletion(t *testing.T) {
 	if _, err := b.Acquire(context.Background(), req); err != nil {
 		t.Fatal(err)
 	}
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -206,24 +206,24 @@ func TestMachine0FixedResolvedClaimReplacementFencesDeletion(t *testing.T) {
 	if err := core.ReplaceLeaseClaimIfUnchanged(claim.LeaseID, claim, replacement); err != nil {
 		t.Fatal(err)
 	}
-	err = b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease})
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
 	if err == nil || !strings.Contains(err.Error(), "claim changed") || len(api.removed) != 0 {
 		t.Fatalf("stale resolve deleted replacement: err=%v removed=%v", err, api.removed)
 	}
-	if _, err := b.Resolve(context.Background(), ResolveRequest{ID: req.RequestedLeaseID, Repo: req.Repo}); err == nil {
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: req.RequestedLeaseID, Repo: req.Repo}); err == nil {
 		t.Fatal("resolve ignored repository binding")
 	}
 }
 
 func TestMachine0FixedCleanupRetainsInvisiblePreparation(t *testing.T) {
 	b, api, req := fixedMachine0TestFixture(t)
-	b.waitSSH = func(context.Context, *SSHTarget, time.Duration) error { return errors.New("SSH failed") }
+	b.waitSSH = func(context.Context, *core.SSHTarget, time.Duration) error { return errors.New("SSH failed") }
 	if _, err := b.Acquire(context.Background(), req); err == nil {
 		t.Fatal("expected interrupted acquisition")
 	}
 	before := readFixedMachine0Claim(t, req.RequestedLeaseID)
 	api.machines = []machine{}
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if after := readFixedMachine0Claim(t, req.RequestedLeaseID); !reflect.DeepEqual(before, after) {
@@ -414,7 +414,7 @@ func TestMachine0ResolveReclaimsExistingLease(t *testing.T) {
 				t.Fatal(err)
 			}
 			other := core.Repo{Root: t.TempDir()}
-			resolved, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Repo: other, Reclaim: true, Prepare: true})
+			resolved, err := b.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID, Repo: other, Reclaim: true, Prepare: true})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -422,7 +422,7 @@ func TestMachine0ResolveReclaimsExistingLease(t *testing.T) {
 			if err != nil || after.RepoRoot != other.Root || after.CloudID != before.CloudID || !reflect.DeepEqual(after.FixedCreateIntent, before.FixedCreateIntent) || len(api.created) != 1 || resolved.Server.CloudID != before.CloudID {
 				t.Fatalf("reclaim did not transfer exact lease: err=%v before=%+v after=%+v", err, before, after)
 			}
-			if _, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Repo: other, Prepare: true}); err != nil {
+			if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID, Repo: other, Prepare: true}); err != nil {
 				t.Fatalf("new owner resolve: %v", err)
 			}
 		})
@@ -476,7 +476,7 @@ func TestMachine0CheckpointAccountFencesAbsenceAndRelease(t *testing.T) {
 			if (err != nil) != tc.fail || absent == tc.fail {
 				t.Fatalf("absence=%t err=%v", absent, err)
 			}
-			outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: lease, CheckpointID: checkpointID})
+			outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: lease, CheckpointID: checkpointID})
 			if (err != nil) != tc.fail || outcome.Terminal == tc.fail {
 				t.Fatalf("release outcome=%+v err=%v", outcome, err)
 			}

--- a/internal/providers/machine0/fixed_reconcile_test.go
+++ b/internal/providers/machine0/fixed_reconcile_test.go
@@ -51,7 +51,7 @@ func TestMachine0FixedEmptyLegacyRecordRemainsHeld(t *testing.T) {
 			if _, err := b.Acquire(context.Background(), req); err == nil {
 				t.Error("empty legacy record authorized another create")
 			}
-			if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: req.RequestedLeaseID}}); err == nil {
+			if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: req.RequestedLeaseID}}); err == nil {
 				t.Error("empty legacy record was canceled as never started")
 			}
 			if after := readFixedMachine0Claim(t, req.RequestedLeaseID); !reflect.DeepEqual(before, after) {
@@ -84,9 +84,9 @@ func TestMachine0FixedReadinessRejectsFreshReplacementBeforeStart(t *testing.T) 
 			if operation == "acquire" {
 				_, err = b.Acquire(context.Background(), req)
 			} else if operation == "resume" {
-				err = b.Resume(context.Background(), ResumeRequest{ID: req.RequestedLeaseID})
+				err = b.Resume(context.Background(), core.ResumeRequest{ID: req.RequestedLeaseID})
 			} else {
-				_, err = b.Resolve(context.Background(), ResolveRequest{ID: req.RequestedLeaseID, Prepare: true})
+				_, err = b.Resolve(context.Background(), core.ResolveRequest{ID: req.RequestedLeaseID, Prepare: true})
 			}
 			if err == nil || len(api.started)+len(api.removed) != 0 {
 				t.Fatalf("observed replacement reached mutation: err=%v starts=%v removes=%v", err, api.started, api.removed)
@@ -132,13 +132,13 @@ func TestMachine0FixedPreparedDetailMustAttestBeforeBinding(t *testing.T) {
 			} else {
 				api.getFn = func(context.Context, string) (machine, error) { return machine{}, errors.New("detail failed") }
 			}
-			if _, err := b.Resolve(context.Background(), ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true}); err == nil {
+			if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true}); err == nil {
 				t.Error("unattested preparation resolved")
 			}
 			if _, err := b.Acquire(context.Background(), req); err == nil {
 				t.Error("unattested preparation acquired")
 			}
-			if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: req.RequestedLeaseID}}); err == nil {
+			if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: req.RequestedLeaseID}}); err == nil {
 				t.Error("unattested preparation released")
 			}
 			if !reflect.DeepEqual(before, readFixedMachine0Claim(t, req.RequestedLeaseID)) || len(api.created)+len(api.started)+len(api.removed)+len(api.primed) != 0 {
@@ -155,7 +155,7 @@ func TestMachine0OrdinaryReleaseByLeaseIDUsesResolvedName(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: lease.LeaseID}}); err != nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: lease.LeaseID}}); err != nil {
 		t.Fatal(err)
 	}
 	if len(api.removed) != 1 || api.removed[0] != lease.Server.Name {
@@ -168,7 +168,7 @@ func TestMachine0FixedReadyResolutionPublishesCurrentSnapshot(t *testing.T) {
 	if _, err := b.Acquire(context.Background(), req); err != nil {
 		t.Fatal(err)
 	}
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: req.RequestedLeaseID, Prepare: true})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: req.RequestedLeaseID, Prepare: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,25 +177,25 @@ func TestMachine0FixedReadyResolutionPublishesCurrentSnapshot(t *testing.T) {
 	if !set || !exists || !reflect.DeepEqual(current, snapshot) {
 		t.Fatal("ready resolution returned a stale claim generation")
 	}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil || len(api.removed) != 1 {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil || len(api.removed) != 1 {
 		t.Fatalf("current readiness snapshot could not release: %v", err)
 	}
 }
 
 func TestMachine0FixedReleaseRacingCreateRejectsStaleSnapshot(t *testing.T) {
 	b, api, req := fixedMachine0TestFixture(t)
-	creating, finishCreate := make(chan LeaseTarget, 1), make(chan struct{})
+	creating, finishCreate := make(chan core.LeaseTarget, 1), make(chan struct{})
 	create := api.createFn
 	api.createFn = func(ctx context.Context, request createMachineRequest) error {
 		data, err := os.ReadFile(filepath.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims", req.RequestedLeaseID+".json"))
 		if err != nil {
 			return err
 		}
-		var claim LeaseClaim
+		var claim core.LeaseClaim
 		if err := json.Unmarshal(data, &claim); err != nil {
 			return err
 		}
-		lease := LeaseTarget{LeaseID: claim.LeaseID}
+		lease := core.LeaseTarget{LeaseID: claim.LeaseID}
 		core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
 		creating <- lease
 		<-finishCreate
@@ -203,13 +203,13 @@ func TestMachine0FixedReleaseRacingCreateRejectsStaleSnapshot(t *testing.T) {
 	}
 	acquired, released := make(chan error, 1), make(chan error, 1)
 	go func() { _, err := b.Acquire(context.Background(), req); acquired <- err }()
-	var lease LeaseTarget
+	var lease core.LeaseTarget
 	select {
 	case lease = <-creating: // Current producer persisted the attempt under lock.
 	case err := <-acquired:
 		t.Fatalf("create callback did not observe the durable attempt: %v", err)
 	}
-	go func() { released <- b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}) }()
+	go func() { released <- b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}) }()
 	close(finishCreate)
 	if err := <-acquired; err != nil {
 		t.Fatal(err)
@@ -247,11 +247,11 @@ func TestMachine0FixedEarlyBindingAllowsCleanupAfterLostReadiness(t *testing.T) 
 	summary := api.machine
 	summary.ImageVersion = 0 // Real native inventory omits the pinned version.
 	api.machines = []machine{summary}
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
 	}
 	assertFixedMachine0Tombstone(t, readFixedMachine0Claim(t, req.RequestedLeaseID))
@@ -291,7 +291,7 @@ func TestMachine0FixedFinalReleaseObservationRejectsReplacement(t *testing.T) {
 					}
 					return item, nil
 				}
-				if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err == nil {
+				if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil {
 					t.Fatal("release accepted changed final detail")
 				}
 				if reads != 2 || len(api.removed)+len(api.suspended) != 0 || !reflect.DeepEqual(before, readFixedMachine0Claim(t, req.RequestedLeaseID)) {
@@ -308,7 +308,7 @@ func TestMachine0FixedCaptureHoldBlocksCanonicalDestroy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = core.WithDurableLeaseClaimLock(lease.LeaseID, func(claim *LeaseClaim, _ bool, persist func() error) error {
+	err = core.WithDurableLeaseClaimLock(lease.LeaseID, func(claim *core.LeaseClaim, _ bool, persist func() error) error {
 		claim.CheckpointCapture = &core.CheckpointCaptureBinding{ID: "chk_capture", Revision: claim.Revision, BoundRevision: claim.Revision}
 		return persist()
 	})
@@ -316,10 +316,10 @@ func TestMachine0FixedCaptureHoldBlocksCanonicalDestroy(t *testing.T) {
 		t.Fatal(err)
 	}
 	before := readFixedMachine0Claim(t, lease.LeaseID)
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err == nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil {
 		t.Fatal("ordinary stop cut through capture hold")
 	}
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(api.removed)+len(api.started) != 0 || !reflect.DeepEqual(before, readFixedMachine0Claim(t, lease.LeaseID)) {

--- a/internal/providers/machine0/fixed_test.go
+++ b/internal/providers/machine0/fixed_test.go
@@ -63,7 +63,7 @@ func TestMachine0FixedCreateRejectsSubstitutedSizeAndPinsReplay(t *testing.T) {
 	}
 	_, err = b.Acquire(context.Background(), req)
 	assertMachine0Exit(t, err, 4, "durable create attempt")
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: req.RequestedLeaseID}}); err == nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: req.RequestedLeaseID}}); err == nil {
 		t.Fatal("release authorized a mismatched VM without an attested resource ID")
 	}
 	if len(api.created) != 1 || len(api.removed) != 0 {
@@ -199,7 +199,7 @@ func TestMachine0FixedAcquireReplayAdoptsExactMachine(t *testing.T) {
 				return detail, nil
 			}
 			var readinessKey string
-			b.waitSSH = func(_ context.Context, target *SSHTarget, _ time.Duration) error {
+			b.waitSSH = func(_ context.Context, target *core.SSHTarget, _ time.Duration) error {
 				readinessKey = target.Key
 				return nil
 			}
@@ -293,15 +293,15 @@ func TestMachine0FixedAcquireRejectsMachineAppearingAfterSlugBinding(t *testing.
 func TestMachine0FixedAcquireRejectsIntentDrift(t *testing.T) {
 	tests := []struct {
 		name   string
-		mutate func(*backend, *AcquireRequest)
+		mutate func(*backend, *core.AcquireRequest)
 	}{
-		{name: "size", mutate: func(b *backend, _ *AcquireRequest) { b.cfg.Machine0.Size = "xlarge" }},
-		{name: "region", mutate: func(b *backend, _ *AcquireRequest) { b.cfg.Machine0.Region = "us-east" }},
-		{name: "image", mutate: func(b *backend, _ *AcquireRequest) { b.cfg.Machine0.Image = "nixos-loaded" }},
-		{name: "keep", mutate: func(_ *backend, req *AcquireRequest) { req.Keep = true }},
-		{name: "requested slug", mutate: func(_ *backend, req *AcquireRequest) { req.RequestedSlug = "other" }},
-		{name: "idle timeout", mutate: func(b *backend, _ *AcquireRequest) { b.cfg.IdleTimeout = 2 * time.Hour }},
-		{name: "cache volume", mutate: func(b *backend, _ *AcquireRequest) {
+		{name: "size", mutate: func(b *backend, _ *core.AcquireRequest) { b.cfg.Machine0.Size = "xlarge" }},
+		{name: "region", mutate: func(b *backend, _ *core.AcquireRequest) { b.cfg.Machine0.Region = "us-east" }},
+		{name: "image", mutate: func(b *backend, _ *core.AcquireRequest) { b.cfg.Machine0.Image = "nixos-loaded" }},
+		{name: "keep", mutate: func(_ *backend, req *core.AcquireRequest) { req.Keep = true }},
+		{name: "requested slug", mutate: func(_ *backend, req *core.AcquireRequest) { req.RequestedSlug = "other" }},
+		{name: "idle timeout", mutate: func(b *backend, _ *core.AcquireRequest) { b.cfg.IdleTimeout = 2 * time.Hour }},
+		{name: "cache volume", mutate: func(b *backend, _ *core.AcquireRequest) {
 			b.cfg.Cache.Volumes = []core.CacheVolumeConfig{{Name: "npm", Key: "npm-fixed", Path: "/var/cache/npm"}}
 		}},
 	}
@@ -328,7 +328,7 @@ func TestMachine0FixedReleasedTombstoneRefusesReplay(t *testing.T) {
 		t.Fatal(err)
 	}
 	previous := readFixedMachine0Claim(t, lease.LeaseID)
-	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil || !outcome.Terminal {
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil || !outcome.Terminal {
 		t.Fatalf("fixed deletion outcome=%+v err=%v", outcome, err)
 	}
 	if len(api.removed) != 1 {
@@ -341,7 +341,7 @@ func TestMachine0FixedReleasedTombstoneRefusesReplay(t *testing.T) {
 		t.Fatalf("retained=%v err=%v", retained, err)
 	}
 	b.cfg.Machine0.ReleasePolicy = "suspend"
-	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: lease.LeaseID}}); err != nil || !outcome.Terminal || len(api.removed) != 1 {
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: lease.LeaseID}}); err != nil || !outcome.Terminal || len(api.removed) != 1 {
 		t.Fatalf("terminal receipt under suspend policy: outcome=%+v err=%v removed=%v", outcome, err, api.removed)
 	}
 	_, err = b.Acquire(context.Background(), req)
@@ -351,11 +351,11 @@ func TestMachine0FixedReleasedTombstoneRefusesReplay(t *testing.T) {
 func TestMachine0FixedClaimBindingMismatchesRefuse(t *testing.T) {
 	tests := []struct {
 		name   string
-		mutate func(*LeaseClaim)
+		mutate func(*core.LeaseClaim)
 		want   string
 	}{
-		{name: "claim provider", mutate: func(claim *LeaseClaim) { claim.Provider = providerName }, want: "bound to provider=machine0"},
-		{name: "name scope", mutate: func(claim *LeaseClaim) {
+		{name: "claim provider", mutate: func(claim *core.LeaseClaim) { claim.Provider = providerName }, want: "bound to provider=machine0"},
+		{name: "name scope", mutate: func(claim *core.LeaseClaim) {
 			intent := *claim.FixedCreateIntent
 			intent.ProviderScope = machine0NameScope("crabbox-impostor")
 			claim.FixedCreateIntent = &intent
@@ -386,7 +386,7 @@ func TestMachine0FixedAdoptionRequiresDurableAttempt(t *testing.T) {
 	repo := setupState(t)
 	api := &fakeAPI{sizes: []machineSize{testSize()}, machines: []machine{}}
 	b := testBackendWithAPI(api)
-	req := AcquireRequest{RequestedLeaseID: fixedMachine0TestLeaseID, RequestedSlug: "fixed", Repo: core.Repo{Root: repo}}
+	req := core.AcquireRequest{RequestedLeaseID: fixedMachine0TestLeaseID, RequestedSlug: "fixed", Repo: core.Repo{Root: repo}}
 	seedFixedMachine0PreparedClaim(t, b, req, nil)
 	name := machine0MachineName(req.RequestedLeaseID, req.RequestedSlug)
 	item := fixedMachine0TestMachine(createMachineRequest{Name: name, Size: b.configForRun().Machine0.Size, Region: b.configForRun().Machine0.Region, Image: b.configForRun().Machine0.Image})
@@ -447,7 +447,7 @@ func TestMachine0FixedAdoptionValidatesPinnedMachineShape(t *testing.T) {
 			} else {
 				api.getFn = func(context.Context, string) (machine, error) { return machine{}, readErr }
 			}
-			b.waitSSH = func(context.Context, *SSHTarget, time.Duration) error {
+			b.waitSSH = func(context.Context, *core.SSHTarget, time.Duration) error {
 				t.Fatal("unattested detail reached SSH readiness")
 				return nil
 			}
@@ -570,7 +570,7 @@ func TestMachine0FixedCreateErrorReconcilesVisibleMachine(t *testing.T) {
 		api.machines = []machine{item}
 		return responseErr
 	}
-	req := AcquireRequest{RequestedLeaseID: fixedMachine0TestLeaseID, RequestedSlug: "fixed", Repo: core.Repo{Root: repo}}
+	req := core.AcquireRequest{RequestedLeaseID: fixedMachine0TestLeaseID, RequestedSlug: "fixed", Repo: core.Repo{Root: repo}}
 
 	lease, err := b.Acquire(context.Background(), req)
 	if err != nil {
@@ -609,7 +609,7 @@ func TestMachine0FixedSuspendReleaseKeepsLiveClaimAndReplayStartsMachine(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil || outcome.Terminal {
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil || outcome.Terminal {
 		t.Fatalf("suspend outcome=%+v err=%v", outcome, err)
 	}
 	claim := readFixedMachine0Claim(t, lease.LeaseID)
@@ -662,22 +662,22 @@ func TestMachine0FixedAcquireClaimDoesNotPersistSecrets(t *testing.T) {
 func TestMachine0FixedUnboundClaimsFailClosed(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
-		mutate func(*LeaseClaim)
+		mutate func(*core.LeaseClaim)
 	}{
-		{"durable attempt", func(c *LeaseClaim) { c.FixedCreateIntent.Attempt = map[string]string{"machine0": "unresolved"} }},
-		{"failed attempts", func(c *LeaseClaim) { c.FixedCreateIntent.FailedAttempts = []string{"unresolved"} }},
-		{"missing intent", func(c *LeaseClaim) { c.FixedCreateIntent = nil }},
-		{"prepared invalid timestamp", func(c *LeaseClaim) { c.FixedCreateIntent.CreatedAt = "invalid" }},
-		{"prepared wrong scope", func(c *LeaseClaim) { c.ProviderScope = "machine0:name:other" }},
-		{"released wrong version", func(c *LeaseClaim) { c.FixedCreateIntent.Version++ }},
-		{"released wrong scope", func(c *LeaseClaim) {
+		{"durable attempt", func(c *core.LeaseClaim) { c.FixedCreateIntent.Attempt = map[string]string{"machine0": "unresolved"} }},
+		{"failed attempts", func(c *core.LeaseClaim) { c.FixedCreateIntent.FailedAttempts = []string{"unresolved"} }},
+		{"missing intent", func(c *core.LeaseClaim) { c.FixedCreateIntent = nil }},
+		{"prepared invalid timestamp", func(c *core.LeaseClaim) { c.FixedCreateIntent.CreatedAt = "invalid" }},
+		{"prepared wrong scope", func(c *core.LeaseClaim) { c.ProviderScope = "machine0:name:other" }},
+		{"released wrong version", func(c *core.LeaseClaim) { c.FixedCreateIntent.Version++ }},
+		{"released wrong scope", func(c *core.LeaseClaim) {
 			c.FixedCreateIntent.ProviderScope = "machine0:name:other"
 			c.ProviderScope = c.FixedCreateIntent.ProviderScope
 		}},
-		{"released wrong provider", func(c *LeaseClaim) { c.Provider = providerName; c.CloudID = "vm-other" }},
-		{"released resource", func(c *LeaseClaim) { c.CloudID = "vm-other" }},
-		{"released immutable identity", func(c *LeaseClaim) { c.CloudImmutableID = "vm-other" }},
-		{"released attempt", func(c *LeaseClaim) { c.FixedCreateIntent.Attempt = map[string]string{"machine0": "unresolved"} }},
+		{"released wrong provider", func(c *core.LeaseClaim) { c.Provider = providerName; c.CloudID = "vm-other" }},
+		{"released resource", func(c *core.LeaseClaim) { c.CloudID = "vm-other" }},
+		{"released immutable identity", func(c *core.LeaseClaim) { c.CloudImmutableID = "vm-other" }},
+		{"released attempt", func(c *core.LeaseClaim) { c.FixedCreateIntent.Attempt = map[string]string{"machine0": "unresolved"} }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			b, api, req := fixedMachine0TestFixture(t)
@@ -702,21 +702,21 @@ func TestMachine0FixedUnboundClaimsFailClosed(t *testing.T) {
 				t.Fatal("unbound claim reached native lookup")
 				return machine{}, nil
 			}
-			for _, request := range []ResolveRequest{{StatusOnly: true}, {ReleaseOnly: true}, {StatusOnly: true, ReadyProbe: true}, {Reclaim: true}} {
+			for _, request := range []core.ResolveRequest{{StatusOnly: true}, {ReleaseOnly: true}, {StatusOnly: true, ReadyProbe: true}, {Reclaim: true}} {
 				request.ID = req.RequestedLeaseID
 				_, err := b.Resolve(context.Background(), request)
 				if err == nil || strings.Contains(err.Error(), "not found") {
 					t.Fatalf("invalid or unresolved claim became absence/success: %v", err)
 				}
 			}
-			err = b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: req.RequestedLeaseID}})
+			err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: req.RequestedLeaseID}})
 			if err == nil || strings.Contains(err.Error(), "not found") {
 				t.Fatalf("invalid or unresolved release became absence/success: %v", err)
 			}
 			if strings.HasPrefix(tc.name, "released") {
 				for _, policy := range []string{"destroy", "suspend"} {
 					b.cfg.Machine0.ReleasePolicy = policy
-					if _, err := b.RetainLeaseClaimAfterReleaseWithClaim(LeaseTarget{LeaseID: req.RequestedLeaseID}, before); err == nil {
+					if _, err := b.RetainLeaseClaimAfterReleaseWithClaim(core.LeaseTarget{LeaseID: req.RequestedLeaseID}, before); err == nil {
 						t.Fatal("invalid terminal passed shared retention")
 					}
 				}
@@ -737,17 +737,17 @@ func TestMachine0FixedCleanupSkipsReleasedTombstone(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
 	}
 	b.api.(*fakeAPI).machines = []machine{}
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	assertFixedMachine0Tombstone(t, readFixedMachine0Claim(t, req.RequestedLeaseID))
 }
 
-func fixedMachine0TestFixture(t *testing.T) (*backend, *fakeAPI, AcquireRequest) {
+func fixedMachine0TestFixture(t *testing.T) (*backend, *fakeAPI, core.AcquireRequest) {
 	t.Helper()
 	repo := setupState(t)
 	xlarge := testSize()
@@ -760,7 +760,7 @@ func fixedMachine0TestFixture(t *testing.T) (*backend, *fakeAPI, AcquireRequest)
 		api.machines = []machine{item}
 		return nil
 	}
-	req := AcquireRequest{RequestedLeaseID: fixedMachine0TestLeaseID, RequestedSlug: "fixed", Repo: core.Repo{Root: repo}}
+	req := core.AcquireRequest{RequestedLeaseID: fixedMachine0TestLeaseID, RequestedSlug: "fixed", Repo: core.Repo{Root: repo}}
 	return b, api, req
 }
 
@@ -775,7 +775,7 @@ func fixedMachine0TestMachine(req createMachineRequest) machine {
 	return item
 }
 
-func seedFixedMachine0PreparedClaim(t *testing.T, b *backend, req AcquireRequest, attempt *machine0CreateAttempt) {
+func seedFixedMachine0PreparedClaim(t *testing.T, b *backend, req core.AcquireRequest, attempt *machine0CreateAttempt) {
 	t.Helper()
 	cfg := b.configForRun()
 	fingerprint, err := core.FixedMachine0CreateIntentFingerprint(cfg, core.FixedMachine0CreateIntentRequest{RequestedSlug: core.NormalizeLeaseSlug(req.RequestedSlug), Keep: req.Keep})
@@ -809,7 +809,7 @@ func seedFixedMachine0PreparedClaim(t *testing.T, b *backend, req AcquireRequest
 	}
 }
 
-func readFixedMachine0Claim(t *testing.T, leaseID string) LeaseClaim {
+func readFixedMachine0Claim(t *testing.T, leaseID string) core.LeaseClaim {
 	t.Helper()
 	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
 	if err != nil || !exists {
@@ -826,7 +826,7 @@ func assertMachine0Exit(t *testing.T, err error, code int, contains string) {
 	}
 }
 
-func assertFixedMachine0Tombstone(t *testing.T, claim LeaseClaim) {
+func assertFixedMachine0Tombstone(t *testing.T, claim core.LeaseClaim) {
 	t.Helper()
 	if claim.Provider != core.FixedMachine0ClaimProvider || claim.FixedCreateIntent == nil ||
 		claim.FixedCreateIntent.State != fixedMachine0IntentReleased || claim.ProviderScope != claim.FixedCreateIntent.ProviderScope || claim.Slug != claim.FixedCreateIntent.Slug ||

--- a/internal/providers/machine0/heartbeat_test.go
+++ b/internal/providers/machine0/heartbeat_test.go
@@ -86,7 +86,7 @@ func TestMachine0TouchDurablyPersistsLifecycleAndIdleTimeout(t *testing.T) {
 			}
 			api.machine.PricePerHour = 123_000
 			api.machines = []machine{api.machine}
-			lease, err = b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, StatusOnly: true})
+			lease, err = b.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID, StatusOnly: true})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -98,7 +98,7 @@ func TestMachine0TouchDurablyPersistsLifecycleAndIdleTimeout(t *testing.T) {
 			now := previousTouch.Add(2 * time.Minute)
 			b.rt.Clock = machine0HeartbeatClock(now)
 			b.cfg.IdleTimeout = 15 * time.Minute
-			touch := TouchRequest{Lease: lease, State: "running", IdleTimeout: b.cfg.IdleTimeout}
+			touch := core.TouchRequest{Lease: lease, State: "running", IdleTimeout: b.cfg.IdleTimeout}
 			wantTimeout := 45 * time.Minute
 			if tc.override > 0 {
 				touch.IdleTimeoutOverride = &tc.override
@@ -124,7 +124,7 @@ func TestMachine0TouchDurablyPersistsLifecycleAndIdleTimeout(t *testing.T) {
 
 			fresh := testBackendWithAPI(api)
 			fresh.cfg.IdleTimeout = 5 * time.Minute
-			resolved, err := fresh.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, StatusOnly: true})
+			resolved, err := fresh.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID, StatusOnly: true})
 			if err != nil || resolved.Server.Labels["idle_timeout_secs"] != wantSeconds ||
 				resolved.Server.Labels["last_touched_at"] != core.LeaseLabelTime(now) {
 				t.Fatalf("fresh backend lost committed lifecycle: lease=%#v err=%v", resolved, err)
@@ -139,56 +139,56 @@ func TestMachine0TouchRejectsOwnershipChangesWithoutMutation(t *testing.T) {
 	tooShort := 100 * time.Millisecond
 	tests := []struct {
 		name   string
-		mutate func(*testing.T, *LeaseTarget, *LeaseClaim, *TouchRequest)
+		mutate func(*testing.T, *core.LeaseTarget, *core.LeaseClaim, *core.TouchRequest)
 		want   string
 	}{
-		{name: "missing snapshot", mutate: func(_ *testing.T, lease *LeaseTarget, _ *LeaseClaim, _ *TouchRequest) {
-			core.SetServerLeaseClaimSnapshot(&lease.Server, LeaseClaim{}, false)
+		{name: "missing snapshot", mutate: func(_ *testing.T, lease *core.LeaseTarget, _ *core.LeaseClaim, _ *core.TouchRequest) {
+			core.SetServerLeaseClaimSnapshot(&lease.Server, core.LeaseClaim{}, false)
 		}, want: "no exact claim snapshot"},
-		{name: "noncanonical lease", mutate: func(_ *testing.T, lease *LeaseTarget, _ *LeaseClaim, _ *TouchRequest) {
+		{name: "noncanonical lease", mutate: func(_ *testing.T, lease *core.LeaseTarget, _ *core.LeaseClaim, _ *core.TouchRequest) {
 			lease.LeaseID = "not-canonical"
 		}, want: "canonical lease"},
-		{name: "wrong lease", mutate: func(_ *testing.T, lease *LeaseTarget, _ *LeaseClaim, _ *TouchRequest) {
+		{name: "wrong lease", mutate: func(_ *testing.T, lease *core.LeaseTarget, _ *core.LeaseClaim, _ *core.TouchRequest) {
 			lease.LeaseID = "cbx_abcdef123457"
 		}, want: "canonical lease"},
-		{name: "wrong server provider", mutate: func(_ *testing.T, lease *LeaseTarget, _ *LeaseClaim, _ *TouchRequest) {
+		{name: "wrong server provider", mutate: func(_ *testing.T, lease *core.LeaseTarget, _ *core.LeaseClaim, _ *core.TouchRequest) {
 			lease.Server.Provider = "external"
 		}, want: "provider"},
-		{name: "wrong claim provider", mutate: func(_ *testing.T, _ *LeaseTarget, claim *LeaseClaim, _ *TouchRequest) {
+		{name: "wrong claim provider", mutate: func(_ *testing.T, _ *core.LeaseTarget, claim *core.LeaseClaim, _ *core.TouchRequest) {
 			claim.Provider = "external"
 		}, want: "provider"},
-		{name: "missing server resource", mutate: func(_ *testing.T, lease *LeaseTarget, _ *LeaseClaim, _ *TouchRequest) {
+		{name: "missing server resource", mutate: func(_ *testing.T, lease *core.LeaseTarget, _ *core.LeaseClaim, _ *core.TouchRequest) {
 			lease.Server.CloudID = ""
 		}, want: "immutable Machine0 identity"},
-		{name: "wrong server resource", mutate: func(_ *testing.T, lease *LeaseTarget, _ *LeaseClaim, _ *TouchRequest) {
+		{name: "wrong server resource", mutate: func(_ *testing.T, lease *core.LeaseTarget, _ *core.LeaseClaim, _ *core.TouchRequest) {
 			lease.Server.CloudID = "vm-replacement"
 			lease.Server.ImmutableID = "vm-replacement"
 		}, want: "immutable Machine0 identity"},
-		{name: "missing server immutable identity", mutate: func(_ *testing.T, lease *LeaseTarget, _ *LeaseClaim, _ *TouchRequest) {
+		{name: "missing server immutable identity", mutate: func(_ *testing.T, lease *core.LeaseTarget, _ *core.LeaseClaim, _ *core.TouchRequest) {
 			lease.Server.ImmutableID = ""
 		}, want: "immutable Machine0 identity"},
-		{name: "wrong claim resource", mutate: func(_ *testing.T, _ *LeaseTarget, claim *LeaseClaim, _ *TouchRequest) {
+		{name: "wrong claim resource", mutate: func(_ *testing.T, _ *core.LeaseTarget, claim *core.LeaseClaim, _ *core.TouchRequest) {
 			claim.CloudID = "vm-replacement"
 		}, want: "Machine0 id mismatch"},
-		{name: "missing claim immutable identity", mutate: func(_ *testing.T, _ *LeaseTarget, claim *LeaseClaim, _ *TouchRequest) {
+		{name: "missing claim immutable identity", mutate: func(_ *testing.T, _ *core.LeaseTarget, claim *core.LeaseClaim, _ *core.TouchRequest) {
 			claim.CloudImmutableID = ""
 		}, want: "immutable Machine0 identity"},
-		{name: "wrong claim scope", mutate: func(_ *testing.T, _ *LeaseTarget, claim *LeaseClaim, _ *TouchRequest) {
+		{name: "wrong claim scope", mutate: func(_ *testing.T, _ *core.LeaseTarget, claim *core.LeaseClaim, _ *core.TouchRequest) {
 			claim.ProviderScope = machineScope("vm-replacement")
 		}, want: "provider scope mismatch"},
-		{name: "missing claim scope", mutate: func(_ *testing.T, _ *LeaseTarget, claim *LeaseClaim, _ *TouchRequest) {
+		{name: "missing claim scope", mutate: func(_ *testing.T, _ *core.LeaseTarget, claim *core.LeaseClaim, _ *core.TouchRequest) {
 			claim.ProviderScope = ""
 		}, want: "provider scope mismatch"},
-		{name: "zero timeout override", mutate: func(_ *testing.T, _ *LeaseTarget, _ *LeaseClaim, touch *TouchRequest) {
+		{name: "zero timeout override", mutate: func(_ *testing.T, _ *core.LeaseTarget, _ *core.LeaseClaim, touch *core.TouchRequest) {
 			touch.IdleTimeoutOverride = &zero
 		}, want: "must be positive"},
-		{name: "negative timeout override", mutate: func(_ *testing.T, _ *LeaseTarget, _ *LeaseClaim, touch *TouchRequest) {
+		{name: "negative timeout override", mutate: func(_ *testing.T, _ *core.LeaseTarget, _ *core.LeaseClaim, touch *core.TouchRequest) {
 			touch.IdleTimeoutOverride = &negative
 		}, want: "must be positive"},
-		{name: "subsecond timeout override", mutate: func(_ *testing.T, _ *LeaseTarget, _ *LeaseClaim, touch *TouchRequest) {
+		{name: "subsecond timeout override", mutate: func(_ *testing.T, _ *core.LeaseTarget, _ *core.LeaseClaim, touch *core.TouchRequest) {
 			touch.IdleTimeoutOverride = &tooShort
 		}, want: "at least one second"},
-		{name: "concurrent claim replacement", mutate: func(t *testing.T, lease *LeaseTarget, claim *LeaseClaim, _ *TouchRequest) {
+		{name: "concurrent claim replacement", mutate: func(t *testing.T, lease *core.LeaseTarget, claim *core.LeaseClaim, _ *core.TouchRequest) {
 			labels := make(map[string]string, len(claim.Labels)+1)
 			for key, value := range claim.Labels {
 				labels[key] = value
@@ -198,7 +198,7 @@ func TestMachine0TouchRejectsOwnershipChangesWithoutMutation(t *testing.T) {
 				t.Fatal(err)
 			}
 		}, want: "claim changed"},
-		{name: "removed claim", mutate: func(t *testing.T, lease *LeaseTarget, claim *LeaseClaim, _ *TouchRequest) {
+		{name: "removed claim", mutate: func(t *testing.T, lease *core.LeaseTarget, claim *core.LeaseClaim, _ *core.TouchRequest) {
 			if err := core.RemoveLeaseClaimIfUnchanged(lease.LeaseID, *claim); err != nil {
 				t.Fatal(err)
 			}
@@ -214,7 +214,7 @@ func TestMachine0TouchRejectsOwnershipChangesWithoutMutation(t *testing.T) {
 			leaseID := lease.LeaseID
 			claim := readFixedMachine0Claim(t, leaseID)
 			core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
-			touch := TouchRequest{State: "running"}
+			touch := core.TouchRequest{State: "running"}
 			tc.mutate(t, &lease, &claim, &touch)
 			if tc.name != "missing snapshot" {
 				core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)

--- a/internal/providers/machine0/images.go
+++ b/internal/providers/machine0/images.go
@@ -70,11 +70,11 @@ func (c *client) ListImages(ctx context.Context) ([]machineImage, error) {
 	}
 	var images []machineImage
 	if err := decodeJSON(result.Stdout, &images); err != nil {
-		return nil, exit(5, "parse machine0 images ls --json: %v", err)
+		return nil, core.Exit(5, "parse machine0 images ls --json: %v", err)
 	}
 	for i, image := range images {
 		if strings.TrimSpace(image.ID) == "" || strings.TrimSpace(image.Name) == "" || strings.TrimSpace(image.Status) == "" {
-			return nil, exit(5, "invalid machine0 image list item %d", i)
+			return nil, core.Exit(5, "invalid machine0 image list item %d", i)
 		}
 	}
 	return images, nil
@@ -87,14 +87,14 @@ func (c *client) GetImage(ctx context.Context, name string) (machineImageDetail,
 	}
 	var detail machineImageDetail
 	if err := decodeJSON(result.Stdout, &detail); err != nil {
-		return machineImageDetail{}, exit(5, "parse machine0 images get %s --json: %v", name, err)
+		return machineImageDetail{}, core.Exit(5, "parse machine0 images get %s --json: %v", name, err)
 	}
 	if detail.Image.ID == "" || detail.Image.Name == "" {
-		return machineImageDetail{}, exit(5, "invalid machine0 image details for %s", name)
+		return machineImageDetail{}, core.Exit(5, "invalid machine0 image details for %s", name)
 	}
 	for i, version := range detail.Versions {
 		if version.Version <= 0 {
-			return machineImageDetail{}, exit(5, "invalid machine0 image %s version at index %d", name, i)
+			return machineImageDetail{}, core.Exit(5, "invalid machine0 image %s version at index %d", name, i)
 		}
 	}
 	return detail, nil
@@ -103,7 +103,7 @@ func (c *client) GetImage(ctx context.Context, name string) (machineImageDetail,
 func (c *client) SaveImage(ctx context.Context, machine, image string, metadata map[string]string) error {
 	encoded, err := json.Marshal(metadata)
 	if err != nil {
-		return exit(2, "encode Machine0 image metadata: %v", err)
+		return core.Exit(2, "encode Machine0 image metadata: %v", err)
 	}
 	_, err = c.run(ctx, "images", "save", machine, image, "--metadata", string(encoded))
 	return err
@@ -131,7 +131,7 @@ func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (co
 	return capability, true
 }
 
-func checkpointRetirementPolicy(cfg Config, labels map[string]string) string {
+func checkpointRetirementPolicy(cfg core.Config, labels map[string]string) string {
 	if normalizeReleasePolicy(cfg.Machine0.ReleasePolicy) != "destroy" || labels["release_policy"] == "suspend" {
 		return "checkpoint --retire-source requires the configured and claimed Machine0 release policy to allow destruction; suspend is not retirement"
 	}
@@ -151,14 +151,14 @@ func (Provider) NativeCheckpointWorkdir(req core.NativeCheckpointWorkdirRequest)
 
 func (p Provider) CreateNativeCheckpoint(ctx context.Context, req core.NativeCheckpointCreateRequest) (core.NativeCheckpointCreateResult, error) {
 	if core.NormalizeCheckpointStrategy(req.Strategy) == core.CheckpointStrategyDiskSnapshot {
-		return core.NativeCheckpointCreateResult{}, core.NativeCheckpointNotSubmittedError{Cause: exit(2, "Machine0 reusable images require --strategy image; use `crabbox pause` for suspend snapshots")}
+		return core.NativeCheckpointCreateResult{}, core.NativeCheckpointNotSubmittedError{Cause: core.Exit(2, "Machine0 reusable images require --strategy image; use `crabbox pause` for suspend snapshots")}
 	}
 	claim, claimed, err := resolveClaim(req.LeaseID)
 	if err != nil {
 		return core.NativeCheckpointCreateResult{}, core.NativeCheckpointNotSubmittedError{Cause: err}
 	}
 	if !claimed || claim.CloudID != req.Server.CloudID {
-		return core.NativeCheckpointCreateResult{}, core.NativeCheckpointNotSubmittedError{Cause: exit(2, "refusing Machine0 image save without an exact source lease claim")}
+		return core.NativeCheckpointCreateResult{}, core.NativeCheckpointNotSubmittedError{Cause: core.Exit(2, "refusing Machine0 image save without an exact source lease claim")}
 	}
 	configured, err := p.Configure(req.Config, providerOperationRuntime(req.Stderr))
 	if err != nil {
@@ -167,7 +167,7 @@ func (p Provider) CreateNativeCheckpoint(ctx context.Context, req core.NativeChe
 	return configured.(*backend).createNativeCheckpoint(ctx, req, claim)
 }
 
-func (b *backend) createNativeCheckpoint(ctx context.Context, req core.NativeCheckpointCreateRequest, claim LeaseClaim) (result core.NativeCheckpointCreateResult, err error) {
+func (b *backend) createNativeCheckpoint(ctx context.Context, req core.NativeCheckpointCreateRequest, claim core.LeaseClaim) (result core.NativeCheckpointCreateResult, err error) {
 	if req.Capture != nil {
 		return b.advanceCheckpointCapture(ctx, req, claim)
 	}
@@ -213,40 +213,40 @@ func (b *backend) createNativeCheckpoint(ctx context.Context, req core.NativeChe
 	var version machineImageVersion
 	var lifecycleErr error
 	snapshotTimeout := machine0CheckpointSnapshotTimeout(req.WaitTimeout, b.configForRun().Machine0.CreateTimeout)
-	_, _, _, actionErr := updateClaimAction(claim.LeaseID, claim, func() (Server, SSHTarget, bool, error) {
+	_, _, _, actionErr := core.ReplaceLeaseClaimEndpointIfUnchangedAction(claim.LeaseID, claim, func() (core.Server, core.SSHTarget, bool, error) {
 		lookup := firstNonBlank(claim.Labels["machine0_name"], req.Server.Name, claim.CloudID)
 		item, err := b.readCheckpointSource(ctx, claim, lookup)
 		if err != nil {
-			return Server{}, SSHTarget{}, false, err
+			return core.Server{}, core.SSHTarget{}, false, err
 		}
 
 		stoppedByCheckpoint := false
 		switch {
 		case machineRunning(item.Status):
 			if err := b.prepareNativeImageSource(ctx, req.Target); err != nil {
-				return Server{}, SSHTarget{}, false, err
+				return core.Server{}, core.SSHTarget{}, false, err
 			}
 			item, err = b.readCheckpointSource(ctx, claim, item.Name)
 			if err != nil {
-				return Server{}, SSHTarget{}, false, err
+				return core.Server{}, core.SSHTarget{}, false, err
 			}
 			if !machineRunning(item.Status) {
-				return Server{}, SSHTarget{}, false, exit(5, "Machine0 checkpoint source changed state before stop")
+				return core.Server{}, core.SSHTarget{}, false, core.Exit(5, "Machine0 checkpoint source changed state before stop")
 			}
 			if err := b.api.Stop(ctx, item.Name); err != nil {
-				return Server{}, SSHTarget{}, false, err
+				return core.Server{}, core.SSHTarget{}, false, err
 			}
 			stoppedByCheckpoint = true
 			if stopped, err := b.waitForStopped(ctx, item.Name, b.configForRun().Machine0.CreateTimeout); err != nil {
 				lifecycleErr = err
 			} else if err := validateMachineClaimOwnership(claim, stopped); err != nil {
 				// The observed source was replaced; never save or restart its successor.
-				return Server{}, SSHTarget{}, false, err
+				return core.Server{}, core.SSHTarget{}, false, err
 			}
 		case strings.EqualFold(strings.TrimSpace(item.Status), "STOPPED"):
 			// A pre-stopped source is already filesystem-consistent. Preserve its state.
 		default:
-			return Server{}, SSHTarget{}, false, exit(5, "machine0 machine %s must be RUNNING or STOPPED to create an image; state=%s", item.Name, item.Status)
+			return core.Server{}, core.SSHTarget{}, false, core.Exit(5, "machine0 machine %s must be RUNNING or STOPPED to create an image; state=%s", item.Name, item.Status)
 		}
 
 		if lifecycleErr == nil {
@@ -265,13 +265,13 @@ func (b *backend) createNativeCheckpoint(ctx context.Context, req core.NativeChe
 			}
 		}
 
-		var server Server
-		var target SSHTarget
+		var server core.Server
+		var target core.SSHTarget
 		if stoppedByCheckpoint {
 			var restartErr error
 			server, target, restartErr = b.restartCheckpointSource(ctx, claim, item)
 			if restartErr != nil {
-				return Server{}, SSHTarget{}, false, restartErr
+				return core.Server{}, core.SSHTarget{}, false, restartErr
 			}
 		}
 		return server, target, stoppedByCheckpoint, nil
@@ -292,7 +292,7 @@ func machine0CheckpointSnapshotTimeout(requested, fallback time.Duration) time.D
 
 // Native mutations accept names. This rejects replacements visible at each
 // adapter boundary, not a privileged remote rename inside the opaque CLI call.
-func (b *backend) readCheckpointSource(ctx context.Context, claim LeaseClaim, name string) (machine, error) {
+func (b *backend) readCheckpointSource(ctx context.Context, claim core.LeaseClaim, name string) (machine, error) {
 	item, err := b.api.Get(ctx, name)
 	if err != nil {
 		return machine{}, err
@@ -301,7 +301,7 @@ func (b *backend) readCheckpointSource(ctx context.Context, claim LeaseClaim, na
 		return machine{}, err
 	}
 	if item.Name != name {
-		return machine{}, exit(2, "checkpoint source name changed")
+		return machine{}, core.Exit(2, "checkpoint source name changed")
 	}
 	if fixedMachine0LeaseKind.IsFixedClaim(claim) {
 		if err := validateFixedMachine0Ownership(claim, item); err != nil {
@@ -311,7 +311,7 @@ func (b *backend) readCheckpointSource(ctx context.Context, claim LeaseClaim, na
 	return item, nil
 }
 
-func (b *backend) restartCheckpointSource(ctx context.Context, claim LeaseClaim, stopped machine) (Server, SSHTarget, error) {
+func (b *backend) restartCheckpointSource(ctx context.Context, claim core.LeaseClaim, stopped machine) (core.Server, core.SSHTarget, error) {
 	timeout := b.configForRun().Machine0.CreateTimeout
 	// Once this operation stops a running source, restoring it is a rollback
 	// obligation even if the caller cancels the checkpoint wait.
@@ -319,10 +319,10 @@ func (b *backend) restartCheckpointSource(ctx context.Context, claim LeaseClaim,
 	defer cancel()
 	_, err := b.readCheckpointSource(restartCtx, claim, stopped.Name)
 	if err != nil {
-		return Server{}, SSHTarget{}, err
+		return core.Server{}, core.SSHTarget{}, err
 	}
 	if err := b.api.Start(restartCtx, stopped.Name); err != nil {
-		return Server{}, SSHTarget{}, fmt.Errorf("restart Machine0 checkpoint source %s: %w", stopped.Name, err)
+		return core.Server{}, core.SSHTarget{}, fmt.Errorf("restart Machine0 checkpoint source %s: %w", stopped.Name, err)
 	}
 	running, err := b.waitForRunningAfterStart(restartCtx, stopped.Name, timeout, func(previous, observed machine) (machine, error) {
 		if fixedMachine0LeaseKind.IsFixedClaim(claim) {
@@ -334,21 +334,21 @@ func (b *backend) restartCheckpointSource(ctx context.Context, claim LeaseClaim,
 		return observed, nil
 	})
 	if err != nil {
-		return Server{}, SSHTarget{}, fmt.Errorf("restart Machine0 checkpoint source %s: %w", stopped.Name, err)
+		return core.Server{}, core.SSHTarget{}, fmt.Errorf("restart Machine0 checkpoint source %s: %w", stopped.Name, err)
 	}
 	if err := validateMachineClaimOwnership(claim, running); err != nil {
-		return Server{}, SSHTarget{}, err
+		return core.Server{}, core.SSHTarget{}, err
 	}
 	cfg := effectiveMachine0Config(b.configForRun(), running)
 	server := b.serverFromMachine(running, claim, cfg)
 	lease, err := b.prepareLeaseWithOptions(restartCtx, running, server, claim.LeaseID, machine0PrepareOptions{Check: true, ResetHostTrust: true})
 	if err != nil {
-		return Server{}, SSHTarget{}, fmt.Errorf("prepare restarted Machine0 checkpoint source %s: %w", stopped.Name, err)
+		return core.Server{}, core.SSHTarget{}, fmt.Errorf("prepare restarted Machine0 checkpoint source %s: %w", stopped.Name, err)
 	}
 	return lease.Server, lease.SSH, nil
 }
 
-func machine0NativeCheckpointResult(req core.NativeCheckpointCreateRequest, claim LeaseClaim, name string, createdImage bool, detail machineImageDetail, version machineImageVersion) core.NativeCheckpointCreateResult {
+func machine0NativeCheckpointResult(req core.NativeCheckpointCreateRequest, claim core.LeaseClaim, name string, createdImage bool, detail machineImageDetail, version machineImageVersion) core.NativeCheckpointCreateResult {
 	if strings.TrimSpace(detail.Image.ID) == "" || version.Version <= 0 {
 		return core.NativeCheckpointCreateResult{}
 	}
@@ -422,7 +422,7 @@ func (b *backend) deleteNativeCheckpoint(ctx context.Context, req core.NativeChe
 	createdImage := req.Metadata[metadataCreatedImage] == "true"
 	if createdImage {
 		if len(detail.Versions) != 1 || detail.Versions[0].Version != version.Version {
-			return exit(2, "refusing to remove Machine0 image %q: owned checkpoint version v%d is no longer the only version (%d versions found); remove the exact draft version with `machine0 images versions rm %s %d --yes` when applicable, or resolve the image versions manually", detail.Image.Name, version.Version, len(detail.Versions), detail.Image.Name, version.Version)
+			return core.Exit(2, "refusing to remove Machine0 image %q: owned checkpoint version v%d is no longer the only version (%d versions found); remove the exact draft version with `machine0 images versions rm %s %d --yes` when applicable, or resolve the image versions manually", detail.Image.Name, version.Version, len(detail.Versions), detail.Image.Name, version.Version)
 		}
 		err = b.api.RemoveImage(ctx, detail.Image.Name)
 	} else {
@@ -444,12 +444,12 @@ func (b *backend) deleteNativeCheckpoint(ctx context.Context, req core.NativeChe
 
 func (Provider) ApplyNativeCheckpointForkConfig(req core.NativeCheckpointForkRequest) error {
 	if req.Record.Kind != core.CheckpointKindMachine0 || !req.Record.Direct {
-		return exit(2, "provider=machine0 does not support checkpoint kind=%s", req.Record.Kind)
+		return core.Exit(2, "provider=machine0 does not support checkpoint kind=%s", req.Record.Kind)
 	}
 	name := strings.TrimSpace(req.Record.Metadata[metadataImageName])
 	version, err := strconv.Atoi(req.Record.Metadata[metadataImageVersion])
 	if name == "" || err != nil || version <= 0 {
-		return exit(2, "Machine0 checkpoint image metadata is missing or invalid")
+		return core.Exit(2, "Machine0 checkpoint image metadata is missing or invalid")
 	}
 	req.Config.Provider = providerName
 	req.Config.Machine0.Image = name
@@ -498,7 +498,7 @@ func (b *backend) waitForImageVersion(ctx context.Context, name string, previous
 		}
 		if version.Version == 0 {
 			if !wait {
-				return false, exit(5, "Machine0 did not report a new image version for %s", name)
+				return false, core.Exit(5, "Machine0 did not report a new image version for %s", name)
 			}
 			return false, nil
 		}
@@ -512,7 +512,7 @@ func (b *backend) waitForImageVersion(ctx context.Context, name string, previous
 			return true, nil
 		}
 		if imageVersionTerminal(version) {
-			return false, exit(5, "Machine0 image %s v%d entered terminal state %s", name, version.Version, imageVersionState(version))
+			return false, core.Exit(5, "Machine0 image %s v%d entered terminal state %s", name, version.Version, imageVersionState(version))
 		}
 		if stderr != nil {
 			_, _ = fmt.Fprintf(stderr, "waiting image=%s version=%d state=%s\n", name, version.Version, imageVersionState(version))
@@ -520,7 +520,7 @@ func (b *backend) waitForImageVersion(ctx context.Context, name string, previous
 		return false, nil
 	}, nil)
 	if err != nil && wait && context.Cause(ctx) == nil && errors.Is(context.Cause(pollCtx), context.DeadlineExceeded) && errors.Is(err, context.DeadlineExceeded) {
-		err = exit(5, "timed out waiting for Machine0 image %s", name)
+		err = core.Exit(5, "timed out waiting for Machine0 image %s", name)
 	}
 	if lastVersion.Version > 0 {
 		return lastDetail, lastVersion, err
@@ -542,7 +542,7 @@ func machine0ImageVersionMetadataMatches(version machineImageVersion, expected m
 
 func (b *backend) loadCheckpointImage(ctx context.Context, req core.NativeCheckpointResourceRequest) (machineImageDetail, machineImageVersion, error) {
 	if req.Capture != nil && req.Capture.SourceDisposition == "abandon" {
-		return machineImageDetail{}, machineImageVersion{}, exit(2, "checkpoint abandonment does not authorize image operations; retain the unresolved image obligation")
+		return machineImageDetail{}, machineImageVersion{}, core.Exit(2, "checkpoint abandonment does not authorize image operations; retain the unresolved image obligation")
 	}
 	// Ordinary checkpoints predating account-bound retirement keep their existing
 	// image contract. A bound capture must never treat another account as absence.
@@ -552,15 +552,15 @@ func (b *backend) loadCheckpointImage(ctx context.Context, req core.NativeCheckp
 		}
 	}
 	if req.Image.Provider != providerName || req.Image.Kind != core.CheckpointKindMachine0 || !req.Image.Direct {
-		return machineImageDetail{}, machineImageVersion{}, exit(2, "refusing to operate on a non-direct Machine0 checkpoint")
+		return machineImageDetail{}, machineImageVersion{}, core.Exit(2, "refusing to operate on a non-direct Machine0 checkpoint")
 	}
 	name := req.Metadata[metadataImageName]
 	versionNumber, err := strconv.Atoi(req.Metadata[metadataImageVersion])
 	if name == "" || err != nil || versionNumber <= 0 {
-		return machineImageDetail{}, machineImageVersion{}, exit(2, "Machine0 checkpoint metadata is missing image version identity")
+		return machineImageDetail{}, machineImageVersion{}, core.Exit(2, "Machine0 checkpoint metadata is missing image version identity")
 	}
 	if req.Metadata[metadataImageID] == "" || req.Metadata[metadataImageID] != req.Image.ResourceID || req.Metadata[metadataSourceMachine] == "" || req.Metadata["crabbox_checkpoint"] == "" || req.Metadata["crabbox_lease"] == "" {
-		return machineImageDetail{}, machineImageVersion{}, exit(2, "Machine0 checkpoint is missing its exact resource binding")
+		return machineImageDetail{}, machineImageVersion{}, core.Exit(2, "Machine0 checkpoint is missing its exact resource binding")
 	}
 	images, err := b.api.ListImages(ctx)
 	if err != nil {
@@ -570,14 +570,14 @@ func (b *backend) loadCheckpointImage(ctx context.Context, req core.NativeCheckp
 	for _, image := range images {
 		if image.Name == name || image.ID == req.Image.ResourceID {
 			if image.Name != name || image.ID != req.Image.ResourceID || found {
-				return machineImageDetail{}, machineImageVersion{}, exit(2, "Machine0 checkpoint image identity changed or is ambiguous")
+				return machineImageDetail{}, machineImageVersion{}, core.Exit(2, "Machine0 checkpoint image identity changed or is ambiguous")
 			}
 			found = true
 		}
 	}
 	if !found {
 		if req.Metadata[metadataAccountID] == "" {
-			return machineImageDetail{}, machineImageVersion{}, exit(4, "Machine0 checkpoint image is not visible and its original account is unbound; retain checkpoint metadata and inspect the original account")
+			return machineImageDetail{}, machineImageVersion{}, core.Exit(4, "Machine0 checkpoint image is not visible and its original account is unbound; retain checkpoint metadata and inspect the original account")
 		}
 		if req.Metadata[metadataAccountID] != "" {
 			if err := b.attestCheckpointAccount(ctx, req.Metadata[metadataAccountID]); err != nil {
@@ -591,7 +591,7 @@ func (b *backend) loadCheckpointImage(ctx context.Context, req core.NativeCheckp
 		return machineImageDetail{}, machineImageVersion{}, err
 	}
 	if detail.Image.ID != req.Metadata[metadataImageID] || detail.Image.ID != req.Image.ResourceID || detail.Image.Name != name {
-		return machineImageDetail{}, machineImageVersion{}, exit(2, "refusing Machine0 checkpoint operation with mismatched image identity")
+		return machineImageDetail{}, machineImageVersion{}, core.Exit(2, "refusing Machine0 checkpoint operation with mismatched image identity")
 	}
 	for _, version := range detail.Versions {
 		if version.Version == versionNumber {
@@ -601,13 +601,13 @@ func (b *backend) loadCheckpointImage(ctx context.Context, req core.NativeCheckp
 					expected = req.Metadata[metadataSourceMachine]
 				}
 				if expected == "" || fmt.Sprint(version.Metadata[key]) != expected {
-					return machineImageDetail{}, machineImageVersion{}, exit(2, "refusing Machine0 checkpoint operation with mismatched %s metadata", key)
+					return machineImageDetail{}, machineImageVersion{}, core.Exit(2, "refusing Machine0 checkpoint operation with mismatched %s metadata", key)
 				}
 			}
 			return detail, version, nil
 		}
 	}
-	return detail, machineImageVersion{}, checkpointImageVersionAbsentError{exit(4, "Machine0 image %s version %d was not found", name, versionNumber)}
+	return detail, machineImageVersion{}, checkpointImageVersionAbsentError{core.Exit(4, "Machine0 image %s version %d was not found", name, versionNumber)}
 }
 
 func imageVersionState(version machineImageVersion) string {

--- a/internal/providers/machine0/provider.go
+++ b/internal/providers/machine0/provider.go
@@ -68,10 +68,10 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 		return nil, err
 	}
 	if cfg.TargetOS != targetLinux {
-		return nil, exit(2, "provider=%s supports target=linux only", providerName)
+		return nil, core.Exit(2, "provider=%s supports target=linux only", providerName)
 	}
 	if cfg.Tailscale.Enabled || string(cfg.Network) == "tailscale" {
-		return nil, exit(2, "--tailscale is not supported for provider=%s; use the Machine0 public IP or authenticated HTTPS URL", providerName)
+		return nil, core.Exit(2, "--tailscale is not supported for provider=%s; use the Machine0 public IP or authenticated HTTPS URL", providerName)
 	}
 	return newBackend(p.Spec(), cfg, rt), nil
 }
@@ -89,22 +89,22 @@ func (Provider) ValidateConfig(cfg core.Config) error {
 		"machine0.region":  m.Region,
 	} {
 		if strings.TrimSpace(value) == "" {
-			return exit(2, "%s is required", name)
+			return core.Exit(2, "%s is required", name)
 		}
 	}
 	switch strings.ToLower(strings.TrimSpace(m.ReleasePolicy)) {
 	case "", "destroy", "suspend":
 	default:
-		return exit(2, "machine0.releasePolicy must be destroy or suspend")
+		return core.Exit(2, "machine0.releasePolicy must be destroy or suspend")
 	}
 	if m.CreateTimeout <= 0 {
-		return exit(2, "machine0.createTimeout must be positive")
+		return core.Exit(2, "machine0.createTimeout must be positive")
 	}
 	if m.ImageVersion < 0 {
-		return exit(2, "machine0.imageVersion must not be negative")
+		return core.Exit(2, "machine0.imageVersion must not be negative")
 	}
 	if m.PollInterval <= 0 {
-		return exit(2, "machine0.pollInterval must be positive")
+		return core.Exit(2, "machine0.pollInterval must be positive")
 	}
 	return nil
 }

--- a/internal/providers/machine0/readiness_capture_test.go
+++ b/internal/providers/machine0/readiness_capture_test.go
@@ -19,7 +19,7 @@ func TestResolveReadinessOwnsClaimUntilPublicationBeforeCaptureAdmission(t *test
 	repo := setupState(t)
 	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
 	b := testBackendWithAPI(api)
-	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func TestResolveReadinessOwnsClaimUntilPublicationBeforeCaptureAdmission(t *test
 	preparingSSH, releaseSSH := make(chan struct{}), make(chan struct{})
 	var releaseOnce sync.Once
 	release := func() { releaseOnce.Do(func() { close(releaseSSH) }) }
-	b.waitSSH = func(context.Context, *SSHTarget, time.Duration) error {
+	b.waitSSH = func(context.Context, *core.SSHTarget, time.Duration) error {
 		close(preparingSSH)
 		<-releaseSSH
 		return nil
@@ -45,7 +45,7 @@ func TestResolveReadinessOwnsClaimUntilPublicationBeforeCaptureAdmission(t *test
 	resolveDone := make(chan struct{})
 	go func() {
 		defer close(resolveDone)
-		_, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, StatusOnly: true, ReadyProbe: true})
+		_, err := b.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID, StatusOnly: true, ReadyProbe: true})
 		resolved <- err
 	}()
 	t.Cleanup(func() {

--- a/internal/providers/machine0/ssh_key_preflight_test.go
+++ b/internal/providers/machine0/ssh_key_preflight_test.go
@@ -23,7 +23,7 @@ func TestDoctorRejectsMissingSSHKeyPrerequisites(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			setupState(t)
 			api := &fakeAPI{selectedKey: tc.key, noDefaultKey: tc.key == nil, sizes: []machineSize{testSize()}}
-			_, err := testBackendWithAPI(api).Doctor(context.Background(), DoctorRequest{})
+			_, err := testBackendWithAPI(api).Doctor(context.Background(), core.DoctorRequest{})
 			if err == nil || !strings.Contains(err.Error(), "key") {
 				t.Fatalf("doctor accepted missing SSH prerequisites: %v", err)
 			}
@@ -69,9 +69,9 @@ func TestLegacySSHKeyPrerequisitesBeforeDoctorAndCreate(t *testing.T) {
 				}
 				var err error
 				if mode == "doctor" {
-					_, err = b.Doctor(context.Background(), DoctorRequest{})
+					_, err = b.Doctor(context.Background(), core.DoctorRequest{})
 				} else {
-					req := AcquireRequest{Repo: core.Repo{Root: repo}}
+					req := core.AcquireRequest{Repo: core.Repo{Root: repo}}
 					if mode == "fixed" {
 						req.RequestedLeaseID = fixedMachine0TestLeaseID
 					}
@@ -110,7 +110,7 @@ func TestDoctorLegacyPairIsOnlyAPrerequisite(t *testing.T) {
 				}
 			}
 			api := &fakeAPI{noDefaultKey: true, sizes: []machineSize{testSize()}}
-			result, err := testBackendWithAPI(api).Doctor(context.Background(), DoctorRequest{})
+			result, err := testBackendWithAPI(api).Doctor(context.Background(), core.DoctorRequest{})
 			if err != nil || !strings.Contains(result.Message, "ssh_key_prerequisites=checked") || !strings.Contains(result.Message, "runtime=unchecked") {
 				t.Fatalf("doctor result=%#v err=%v", result, err)
 			}
@@ -131,7 +131,7 @@ func TestDoctorKeyFailureCancelsSiblingProbes(t *testing.T) {
 	api := &fakeAPI{selectedKeyErr: want, doctorDelay: time.Hour}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	_, err := testBackendWithAPI(api).Doctor(ctx, DoctorRequest{})
+	_, err := testBackendWithAPI(api).Doctor(ctx, core.DoctorRequest{})
 	if !errors.Is(err, want) || ctx.Err() != nil {
 		t.Fatalf("doctor did not cancel siblings after key failure: err=%v ctx=%v", err, ctx.Err())
 	}

--- a/internal/providers/mxc/backend.go
+++ b/internal/providers/mxc/backend.go
@@ -17,39 +17,39 @@ import (
 var windowsBuildPattern = regexp.MustCompile(`(?m)CurrentBuildNumber\s+REG_SZ\s+(\d+)`)
 
 type backend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
-func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	return &backend{spec: spec, cfg: cfg, rt: rt}
 }
-func (b *backend) Spec() ProviderSpec { return b.spec }
-func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	if err := requireSupportedWindows(); err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
 	path, err := exec.LookPath(defaultString(b.cfg.MXC.CLIPath, "wxc-exec.exe"))
 	if err != nil {
-		return DoctorResult{}, exit(3, "MXC executor not found: %v", err)
+		return core.DoctorResult{}, core.Exit(3, "MXC executor not found: %v", err)
 	}
 	if err := b.smokeTest(ctx, path); err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return DoctorResult{Provider: providerName, Message: fmt.Sprintf("cli=ready control_plane=local executor=%s containment=%s version=%s network=%s", path, b.cfg.MXC.Containment, b.cfg.MXC.Version, b.cfg.MXC.Network)}, nil
+	return core.DoctorResult{Provider: providerName, Message: fmt.Sprintf("cli=ready control_plane=local executor=%s containment=%s version=%s network=%s", path, b.cfg.MXC.Containment, b.cfg.MXC.Version, b.cfg.MXC.Network)}, nil
 }
 
 func (b *backend) smokeTest(ctx context.Context, path string) error {
-	config, configDir, cleanupConfig, err := buildIsolatedConfig(b.cfg, RunRequest{Command: []string{"cmd.exe", "/d", "/c", "exit", "0"}, Options: LeaseOptions{TTL: 30 * time.Second}})
+	config, configDir, cleanupConfig, err := buildIsolatedConfig(b.cfg, core.RunRequest{Command: []string{"cmd.exe", "/d", "/c", "exit", "0"}, Options: core.LeaseOptions{TTL: 30 * time.Second}})
 	if err != nil {
 		return err
 	}
 	defer cleanupConfig()
 	configPath, cleanup, err := writeConfigFile(configDir, config)
 	if err != nil {
-		return exit(3, "write MXC doctor config: %v", err)
+		return core.Exit(3, "write MXC doctor config: %v", err)
 	}
 	defer cleanup()
 	args := []string{}
@@ -57,37 +57,37 @@ func (b *backend) smokeTest(ctx context.Context, path string) error {
 		args = append(args, "--experimental")
 	}
 	args = append(args, configPath)
-	result, runErr := b.rt.Exec.Run(ctx, LocalCommandRequest{Name: path, Args: args})
+	result, runErr := b.rt.Exec.Run(ctx, core.LocalCommandRequest{Name: path, Args: args})
 	if runErr != nil {
-		return exit(3, "MXC runtime unavailable: %s", failureDetail(result, runErr))
+		return core.Exit(3, "MXC runtime unavailable: %s", failureDetail(result, runErr))
 	}
 	return nil
 }
-func (b *backend) Warmup(context.Context, WarmupRequest) error {
-	return exit(2, "provider=mxc is one-shot; use crabbox run")
+func (b *backend) Warmup(context.Context, core.WarmupRequest) error {
+	return core.Exit(2, "provider=mxc is one-shot; use crabbox run")
 }
-func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *backend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	if err := requireSupportedWindows(); err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	if req.ID != "" || req.Keep || req.KeepOnFailure {
-		return RunResult{}, exit(2, "provider=mxc is one-shot and does not support persistent lease ids")
+		return core.RunResult{}, core.Exit(2, "provider=mxc is one-shot and does not support persistent lease ids")
 	}
 	if req.SyncOnly || req.ApplyLocalPatch || req.FreshPR.Number > 0 {
-		return RunResult{}, exit(2, "provider=mxc executes the local checkout directly; explicit sync and patch preparation are not supported")
+		return core.RunResult{}, core.Exit(2, "provider=mxc executes the local checkout directly; explicit sync and patch preparation are not supported")
 	}
 	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
-		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+		core.PrintEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
 	started := time.Now()
 	config, configDir, cleanupConfig, err := buildIsolatedConfig(b.cfg, req)
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	defer cleanupConfig()
 	path, cleanup, err := writeConfigFile(configDir, config)
 	if err != nil {
-		return RunResult{}, exit(2, "write MXC config: %v", err)
+		return core.RunResult{}, core.Exit(2, "write MXC config: %v", err)
 	}
 	defer cleanup()
 	args := []string{}
@@ -98,41 +98,41 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	commandStarted := time.Now()
 	req.Observation.Phase(core.RunPhaseCommand)
 	stdout, stderr := req.Observation.CommandWriters(b.rt.Stdout, b.rt.Stderr, core.RunOutputProvider)
-	result, runErr := b.rt.Exec.Run(ctx, LocalCommandRequest{Name: defaultString(b.cfg.MXC.CLIPath, "wxc-exec.exe"), Args: args, Dir: req.Repo.Root, Stdout: stdout, Stderr: stderr})
-	out := RunResult{ExitCode: result.ExitCode, Command: time.Since(commandStarted), Total: time.Since(started), SyncDelegated: true, Provider: providerName, CommandText: strings.Join(req.Command, " ")}
+	result, runErr := b.rt.Exec.Run(ctx, core.LocalCommandRequest{Name: defaultString(b.cfg.MXC.CLIPath, "wxc-exec.exe"), Args: args, Dir: req.Repo.Root, Stdout: stdout, Stderr: stderr})
+	out := core.RunResult{ExitCode: result.ExitCode, Command: time.Since(commandStarted), Total: time.Since(started), SyncDelegated: true, Provider: providerName, CommandText: strings.Join(req.Command, " ")}
 	if req.TimingJSON {
-		_ = writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{Provider: providerName, CommandMs: out.Command.Milliseconds(), TotalMs: out.Total.Milliseconds(), ExitCode: out.ExitCode, SyncDelegated: true, SyncSkipped: true}, out, runErr))
+		_ = core.WriteTimingJSON(b.rt.Stderr, core.TimingReportWithRunResult(core.TimingReport{Provider: providerName, CommandMs: out.Command.Milliseconds(), TotalMs: out.Total.Milliseconds(), ExitCode: out.ExitCode, SyncDelegated: true, SyncSkipped: true}, out, runErr))
 	}
 	if runErr != nil {
 		detail := strings.TrimSpace(result.Stderr)
 		if detail == "" {
 			detail = runErr.Error()
 		}
-		return out, exit(result.ExitCode, "MXC command failed: %s", detail)
+		return out, core.Exit(result.ExitCode, "MXC command failed: %s", detail)
 	}
 	return out, nil
 }
-func (b *backend) List(context.Context, ListRequest) ([]LeaseView, error) { return nil, nil }
-func (b *backend) Status(context.Context, StatusRequest) (StatusView, error) {
-	return StatusView{}, exit(2, "provider=mxc is one-shot and does not support status")
+func (b *backend) List(context.Context, core.ListRequest) ([]core.LeaseView, error) { return nil, nil }
+func (b *backend) Status(context.Context, core.StatusRequest) (core.StatusView, error) {
+	return core.StatusView{}, core.Exit(2, "provider=mxc is one-shot and does not support status")
 }
-func (b *backend) Stop(context.Context, StopRequest) error {
-	return exit(2, "provider=mxc is one-shot and does not support stop")
+func (b *backend) Stop(context.Context, core.StopRequest) error {
+	return core.Exit(2, "provider=mxc is one-shot and does not support stop")
 }
 func requireSupportedWindows() error {
 	if runtime.GOOS != "windows" {
-		return exit(2, "provider=mxc requires a Windows host")
+		return core.Exit(2, "provider=mxc requires a Windows host")
 	}
 	output, err := exec.Command("reg.exe", "query", `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion`, "/v", "CurrentBuildNumber").CombinedOutput()
 	if err != nil {
-		return exit(3, "detect Windows build: %v", err)
+		return core.Exit(3, "detect Windows build: %v", err)
 	}
 	build, err := parseWindowsBuild(string(output))
 	if err != nil {
-		return exit(3, "%v", err)
+		return core.Exit(3, "%v", err)
 	}
 	if build < 26100 {
-		return exit(2, "provider=mxc requires Windows build 26100 or newer; detected build %d", build)
+		return core.Exit(2, "provider=mxc requires Windows build 26100 or newer; detected build %d", build)
 	}
 	return nil
 }
@@ -149,7 +149,7 @@ func parseWindowsBuild(output string) (int, error) {
 	return build, nil
 }
 
-func failureDetail(result LocalCommandResult, err error) string {
+func failureDetail(result core.LocalCommandResult, err error) string {
 	if detail := strings.TrimSpace(result.Stderr); detail != "" {
 		return detail
 	}

--- a/internal/providers/mxc/config.go
+++ b/internal/providers/mxc/config.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type mxcConfig struct {
@@ -43,9 +45,9 @@ type mxcUI struct {
 	Disable bool `json:"disable"`
 }
 
-func buildConfig(cfg Config, req RunRequest) (mxcConfig, error) {
+func buildConfig(cfg core.Config, req core.RunRequest) (mxcConfig, error) {
 	if req.ShellMode && !cfg.MXC.AllowWindowsUI {
-		return mxcConfig{}, exit(2, "provider=mxc --shell uses Windows PowerShell; rerun with --mxc-allow-windows-ui")
+		return mxcConfig{}, core.Exit(2, "provider=mxc --shell uses Windows PowerShell; rerun with --mxc-allow-windows-ui")
 	}
 	commandLine, err := windowsCommandLine(req.Command, req.ShellMode)
 	if err != nil {
@@ -54,7 +56,7 @@ func buildConfig(cfg Config, req RunRequest) (mxcConfig, error) {
 	readwrite := append([]string(nil), cfg.MXC.ReadWritePaths...)
 	if root := strings.TrimSpace(req.Repo.Root); root != "" {
 		if isWindowsVolumeRoot(root) {
-			return mxcConfig{}, exit(2, "refusing to grant MXC read-write access to volume root %q", root)
+			return mxcConfig{}, core.Exit(2, "refusing to grant MXC read-write access to volume root %q", root)
 		}
 		readwrite = append(readwrite, root)
 	}
@@ -141,15 +143,15 @@ func windowsProcessEnvironment(forwarded map[string]string) []string {
 	return env
 }
 
-func buildIsolatedConfig(cfg Config, req RunRequest) (mxcConfig, string, func(), error) {
+func buildIsolatedConfig(cfg core.Config, req core.RunRequest) (mxcConfig, string, func(), error) {
 	tempDir, err := os.MkdirTemp("", "crabbox-mxc-run-*")
 	if err != nil {
-		return mxcConfig{}, "", nil, exit(2, "create MXC temporary directory: %v", err)
+		return mxcConfig{}, "", nil, core.Exit(2, "create MXC temporary directory: %v", err)
 	}
 	cleanup := func() { _ = os.RemoveAll(tempDir) }
 	if err := secureDirectory(tempDir); err != nil {
 		cleanup()
-		return mxcConfig{}, "", nil, exit(2, "secure MXC temporary directory: %v", err)
+		return mxcConfig{}, "", nil, core.Exit(2, "secure MXC temporary directory: %v", err)
 	}
 	cfg.MXC.ReadWritePaths = append(append([]string(nil), cfg.MXC.ReadWritePaths...), tempDir)
 	req.Env = cloneEnv(req.Env)
@@ -178,7 +180,7 @@ func secureDirectory(path string) error {
 	}
 	result, err := exec.Command("icacls.exe", path, "/inheritance:r", "/grant:r", current.Username+`:(OI)(CI)F`).CombinedOutput()
 	if err != nil {
-		return exit(2, "icacls: %s", strings.TrimSpace(string(result)))
+		return core.Exit(2, "icacls: %s", strings.TrimSpace(string(result)))
 	}
 	return nil
 }
@@ -246,7 +248,7 @@ func windowsCommandLine(command []string, shellMode bool) (string, error) {
 
 func windowsCommandLineWithLookPath(command []string, shellMode bool, lookPath func(string) (string, error)) (string, error) {
 	if len(command) == 0 {
-		return "", exit(2, "provider=mxc requires a command")
+		return "", core.Exit(2, "provider=mxc requires a command")
 	}
 	if shellMode {
 		return "powershell.exe -NoProfile -NonInteractive -Command " + quoteWindowsArg(strings.Join(command, " ")), nil
@@ -255,7 +257,7 @@ func windowsCommandLineWithLookPath(command []string, shellMode bool, lookPath f
 	if resolved, err := lookPath(command[0]); err == nil {
 		switch strings.ToLower(filepath.Ext(resolved)) {
 		case ".bat", ".cmd":
-			return "", exit(2, "command %q resolves to a Windows script shim; rerun with --shell or invoke an executable directly", command[0])
+			return "", core.Exit(2, "command %q resolves to a Windows script shim; rerun with --shell or invoke an executable directly", command[0])
 		}
 		resolvedCommand[0] = resolved
 	}

--- a/internal/providers/mxc/config_test.go
+++ b/internal/providers/mxc/config_test.go
@@ -24,7 +24,7 @@ func TestBuildConfigDefaultsToBlockedProcessContainer(t *testing.T) {
 	t.Setenv("OS", `Windows_NT`)
 	cfg := core.BaseConfig()
 	cfg.MXC.ReadOnlyPaths = []string{`C:\Windows`}
-	config, err := buildConfig(cfg, RunRequest{
+	config, err := buildConfig(cfg, core.RunRequest{
 		Repo:    core.Repo{Root: `C:\src\example`},
 		Command: []string{"powershell.exe", "-Command", `Write-Output "hello world"`},
 		Env:     map[string]string{"CI": "1"},
@@ -83,7 +83,7 @@ func TestBuildConfigAllowsExplicitDACLMutationFallback(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.MXC.AllowDACLMutation = true
 	cfg.MXC.AllowWindowsUI = true
-	config, err := buildConfig(cfg, RunRequest{Command: []string{"cmd.exe", "/c", "exit", "0"}})
+	config, err := buildConfig(cfg, core.RunRequest{Command: []string{"cmd.exe", "/c", "exit", "0"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestBuildConfigAllowsExplicitDACLMutationFallback(t *testing.T) {
 }
 
 func TestBuildConfigShellRequiresWindowsUI(t *testing.T) {
-	_, err := buildConfig(core.BaseConfig(), RunRequest{Command: []string{"npm", "test"}, ShellMode: true})
+	_, err := buildConfig(core.BaseConfig(), core.RunRequest{Command: []string{"npm", "test"}, ShellMode: true})
 	if err == nil || !strings.Contains(err.Error(), "--mxc-allow-windows-ui") {
 		t.Fatalf("err=%v", err)
 	}
@@ -105,7 +105,7 @@ func TestBuildConfigShellRequiresWindowsUI(t *testing.T) {
 func TestBuildConfigRejectsVolumeRoot(t *testing.T) {
 	for _, root := range []string{`C:\`, `\\server\share\`, `\\?\C:\`, `\\?\UNC\server\share\`} {
 		t.Run(root, func(t *testing.T) {
-			_, err := buildConfig(core.BaseConfig(), RunRequest{Repo: core.Repo{Root: root}, Command: []string{"cmd.exe", "/c", "exit", "0"}})
+			_, err := buildConfig(core.BaseConfig(), core.RunRequest{Repo: core.Repo{Root: root}, Command: []string{"cmd.exe", "/c", "exit", "0"}})
 			if err == nil || !strings.Contains(err.Error(), "volume root") {
 				t.Fatalf("root=%q err=%v", root, err)
 			}
@@ -120,7 +120,7 @@ func TestBuildConfigRejectsVolumeRoot(t *testing.T) {
 
 func TestBuildIsolatedConfigUsesPrivateTemporaryDirectory(t *testing.T) {
 	cfg := core.BaseConfig()
-	config, _, cleanup, err := buildIsolatedConfig(cfg, RunRequest{Command: []string{"cmd.exe", "/c", "exit", "0"}, Env: map[string]string{"Temp": `C:\attacker`, "tmp": `C:\other`}})
+	config, _, cleanup, err := buildIsolatedConfig(cfg, core.RunRequest{Command: []string{"cmd.exe", "/c", "exit", "0"}, Env: map[string]string{"Temp": `C:\attacker`, "tmp": `C:\other`}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/mxc/core.go
+++ b/internal/providers/mxc/core.go
@@ -1,42 +1,10 @@
 package mxc
 
 import (
-	"io"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
-
-type Config = core.Config
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type LeaseOptions = core.LeaseOptions
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
-type timingReport = core.TimingReport
 
 const (
 	providerName  = "mxc"
 	targetWindows = core.TargetWindows
 )
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-func writeTimingJSON(w io.Writer, report timingReport) error { return core.WriteTimingJSON(w, report) }
-func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
-	return core.TimingReportWithRunResult(report, result, err)
-}
-func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
-	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
-}

--- a/internal/providers/nebius/backend.go
+++ b/internal/providers/nebius/backend.go
@@ -187,7 +187,7 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 	ssh := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
 	if !req.ReleaseOnly {
 		if err := core.UseStoredTestboxKey(&ssh, leaseID); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	if req.Repo.Root != "" && !req.NoLocalStateMutations {

--- a/internal/providers/nebius/backend.go
+++ b/internal/providers/nebius/backend.go
@@ -14,18 +14,18 @@ import (
 
 type backend struct {
 	shared.DirectSSHBackend
-	clientFactory func(Runtime) nebiusAPI
+	clientFactory func(core.Runtime) nebiusAPI
 	waitSSH       func(context.Context, *core.SSHTarget, string, time.Duration) error
 	now           func() time.Time
 }
 
-func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	b := &backend{
 		DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt, StoredLeaseKeys: true},
 		now:              time.Now,
 	}
-	b.clientFactory = func(rt Runtime) nebiusAPI { return newNebiusClient(cfg.Nebius, rt) }
+	b.clientFactory = func(rt core.Runtime) nebiusAPI { return newNebiusClient(cfg.Nebius, rt) }
 	b.waitSSH = func(ctx context.Context, target *core.SSHTarget, phase string, timeout time.Duration) error {
 		return core.WaitForSSHReady(ctx, target, b.RT.Stderr, phase, timeout)
 	}
@@ -34,31 +34,31 @@ func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	return b
 }
 
-func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	return shared.AcquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
 		return b.acquireOnce(ctx, req)
 	})
 }
 
-func (b *backend) acquireOnce(ctx context.Context, req AcquireRequest) (target LeaseTarget, err error) {
+func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (target core.LeaseTarget, err error) {
 	cfg := b.Cfg
 	if err := validateNebiusAcquireConfig(cfg); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	client := b.clientFactory(b.RT)
 	leaseID := core.NewLeaseID()
 	existing, err := client.ListInstances(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	servers := ownedServers(existing, cfg)
 	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	committed := false
 	retainKey := false
@@ -77,7 +77,7 @@ func (b *backend) acquireOnce(ctx context.Context, req AcquireRequest) (target L
 	created := nebiusInstance{}
 	userData, err := renderNebiusCloudInit(cfg, publicKey)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	fmt.Fprintf(b.RT.Stderr, "provisioning provider=nebius lease=%s slug=%s platform=%s preset=%s keep=%v\n", leaseID, slug, cfg.Nebius.Platform, cfg.Nebius.Preset, req.Keep)
 	created, err = client.CreateInstance(ctx, nebiusCreateRequest{
@@ -90,7 +90,7 @@ func (b *backend) acquireOnce(ctx context.Context, req AcquireRequest) (target L
 		if isIndeterminateNebiusError(err) {
 			_ = b.persistRecoveryClaim(leaseID, slug, "", cfg, req.Repo.Root, labels, req.Reclaim)
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	defer func() {
 		if err == nil || committed || strings.TrimSpace(created.ID) == "" {
@@ -119,39 +119,39 @@ func (b *backend) acquireOnce(ctx context.Context, req AcquireRequest) (target L
 	}()
 	if req.OnAcquired != nil {
 		if err := req.OnAcquired(core.LeaseTarget{LeaseID: leaseID, Server: serverFromInstance(created, cfg)}); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	ready, err := client.WaitInstance(ctx, created.ID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	server := serverFromInstance(ready, cfg)
 	if server.PublicNet.IPv4.IP == "" {
-		return LeaseTarget{}, core.Exit(5, "nebius instance %s has no public IP", server.DisplayID())
+		return core.LeaseTarget{}, core.Exit(5, "nebius instance %s has no public IP", server.DisplayID())
 	}
 	ssh := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
 	if err := b.waitSSH(ctx, &ssh, "nebius bootstrap", core.BootstrapWaitTimeout(cfg)); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	readyLabels := nebiusLeaseLabels(cfg, leaseID, slug, "ready", req.Keep, now)
 	if err := client.UpdateLabels(ctx, server.CloudID, readyLabels); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	server.Labels = readyLabels
 	server.Status = "ready"
 	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, ssh, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	committed = true
-	return LeaseTarget{LeaseID: leaseID, Server: server, SSH: ssh}, nil
+	return core.LeaseTarget{LeaseID: leaseID, Server: server, SSH: ssh}, nil
 }
 
-func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	client := b.clientFactory(b.RT)
 	items, err := client.ListInstances(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	servers := ownedServers(items, b.Cfg)
 	byCloudID := make(map[string]nebiusInstance, len(items))
@@ -160,7 +160,7 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 	}
 	server, leaseID, err := core.FindServerByAlias(servers, req.ID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if leaseID == "" {
 		for _, s := range servers {
@@ -175,14 +175,14 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 		return b.releaseTargetFromClaim(req.ID)
 	}
 	if leaseID == "" {
-		return LeaseTarget{}, core.Exit(4, "lease/nebius instance not found: %s", req.ID)
+		return core.LeaseTarget{}, core.Exit(4, "lease/nebius instance not found: %s", req.ID)
 	}
 	item := byCloudID[server.CloudID]
 	if item.ID != "" {
 		server = serverFromInstance(item, b.Cfg)
 	}
 	if err := validateNebiusOwnership(server.Labels, b.Cfg); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	ssh := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
 	if !req.ReleaseOnly {
@@ -193,88 +193,88 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 	if req.Repo.Root != "" && !req.NoLocalStateMutations {
 		claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		if _, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.Cfg, server, ssh, req.Repo.Root, b.Cfg.IdleTimeout, req.Reclaim, claim, exists); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
-	return LeaseTarget{LeaseID: leaseID, Server: server, SSH: ssh}, nil
+	return core.LeaseTarget{LeaseID: leaseID, Server: server, SSH: ssh}, nil
 }
 
-func (b *backend) releaseTargetFromClaim(id string) (LeaseTarget, error) {
+func (b *backend) releaseTargetFromClaim(id string) (core.LeaseTarget, error) {
 	claim, ok, err := core.ResolveLeaseClaimForProvider(id, providerName)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if !ok {
 		claim, ok, err = core.ResolveLeaseClaimForProviderCloudID(id, providerName)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	if !ok {
-		return LeaseTarget{}, core.Exit(4, "lease/nebius instance not found: %s", id)
+		return core.LeaseTarget{}, core.Exit(4, "lease/nebius instance not found: %s", id)
 	}
 	if err := validateNebiusOwnership(claim.Labels, b.Cfg); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	server := Server{Provider: providerName, CloudID: claim.CloudID, Name: claim.Slug, Labels: claim.Labels}
-	return LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
+	server := core.Server{Provider: providerName, CloudID: claim.CloudID, Name: claim.Slug, Labels: claim.Labels}
+	return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
 }
 
-func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
 	items, err := b.clientFactory(b.RT).ListInstances(ctx)
 	if err != nil {
 		return nil, err
 	}
 	servers := ownedServers(items, b.Cfg)
-	out := make([]LeaseView, 0, len(servers))
+	out := make([]core.LeaseView, 0, len(servers))
 	for _, server := range servers {
 		out = append(out, server)
 	}
 	return out, nil
 }
 
-func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	if err := core.ValidateLeaseTargetProviderIdentity(req.Lease, req.ExpectedProviderIdentity); err != nil {
 		return err
 	}
 	return b.deleteServer(ctx, b.Cfg, req.Lease.Server)
 }
 
-func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
+func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 	return fmt.Sprintf("deleted lease=%s nebius_instance=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
 }
 
-func (b *backend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
+func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
 	server := req.Lease.Server
 	if err := validateNebiusOwnership(server.Labels, b.Cfg); err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	client := b.clientFactory(b.RT)
 	live, err := client.GetInstance(ctx, server.CloudID)
 	if err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	liveServer := serverFromInstance(live, b.Cfg)
 	if err := validateNebiusOwnership(liveServer.Labels, b.Cfg); err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	if liveServer.Labels["lease"] != server.Labels["lease"] || liveServer.Labels["slug"] != server.Labels["slug"] {
-		return Server{}, core.Exit(3, "nebius live ownership changed for instance %s; refusing touch", server.DisplayID())
+		return core.Server{}, core.Exit(3, "nebius live ownership changed for instance %s; refusing touch", server.DisplayID())
 	}
 	leaseID := liveServer.Labels["lease"]
 	claim, claimExists, err := core.ReadLeaseClaimWithPresence(leaseID)
 	if err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	if claimExists {
 		if claim.Provider != providerName || (claim.CloudID != "" && claim.CloudID != liveServer.CloudID) || claim.Slug != liveServer.Labels["slug"] {
-			return Server{}, core.Exit(3, "nebius local claim changed for instance %s; refusing touch", server.DisplayID())
+			return core.Server{}, core.Exit(3, "nebius local claim changed for instance %s; refusing touch", server.DisplayID())
 		}
 		if claim.Labels["state"] == "cleanup" {
-			return Server{}, core.Exit(4, "nebius lease=%s cleanup is already in progress", leaseID)
+			return core.Server{}, core.Exit(4, "nebius lease=%s cleanup is already in progress", leaseID)
 		}
 	}
 	cfg := b.Cfg
@@ -288,7 +288,7 @@ func (b *backend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
 	labels = core.TouchDirectLeaseLabels(labels, cfg, req.State, b.now().UTC())
 	labels = addNebiusScopeLabels(labels, cfg)
 	if err := client.UpdateLabels(ctx, server.CloudID, labels); err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	if claimExists {
 		liveServer.Labels = labels
@@ -299,19 +299,19 @@ func (b *backend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
 			_, err = core.ClaimLeaseTargetForConfigIfUnchanged(leaseID, labels["slug"], cfg, liveServer, req.Lease.SSH, cfg.IdleTimeout, claim, true)
 		}
 		if err != nil {
-			return Server{}, err
+			return core.Server{}, err
 		}
 	}
 	liveServer.Labels = labels
 	return liveServer, nil
 }
 
-func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
+func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	items, err := b.clientFactory(b.RT).ListInstances(ctx)
 	if err != nil {
 		return err
 	}
-	servers := make([]Server, 0, len(items))
+	servers := make([]core.Server, 0, len(items))
 	for _, item := range items {
 		server := serverFromInstance(item, b.Cfg)
 		if err := validateNebiusOwnership(server.Labels, b.Cfg); err != nil {
@@ -325,7 +325,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	return b.CleanupServers(ctx, req, servers)
 }
 
-func (b *backend) cleanupClaimBinding(server Server) shared.ClaimBinding {
+func (b *backend) cleanupClaimBinding(server core.Server) shared.ClaimBinding {
 	return shared.ClaimBinding{
 		Provider:      providerName,
 		ProviderScope: core.ProviderClaimScope(providerName, b.Cfg),
@@ -338,7 +338,7 @@ func (b *backend) cleanupClaimBinding(server Server) shared.ClaimBinding {
 	}
 }
 
-func (b *backend) prepareCleanupServer(_ context.Context, server Server) (Server, bool, shared.CleanupSkipReason, error) {
+func (b *backend) prepareCleanupServer(_ context.Context, server core.Server) (core.Server, bool, shared.CleanupSkipReason, error) {
 	claim, err := shared.RequireExactClaim(b.cleanupClaimBinding(server))
 	if err != nil {
 		eligible, cleanupErr := shared.CleanupClaimEligible(err)
@@ -348,7 +348,7 @@ func (b *backend) prepareCleanupServer(_ context.Context, server Server) (Server
 	return server, true, "", nil
 }
 
-func (b *backend) deleteServer(ctx context.Context, _ Config, server Server) error {
+func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.Server) error {
 	if err := validateNebiusOwnership(server.Labels, b.Cfg); err != nil {
 		return err
 	}
@@ -400,13 +400,13 @@ func (b *backend) deleteServer(ctx context.Context, _ Config, server Server) err
 	return nil
 }
 
-func (b *backend) persistRecoveryClaim(leaseID, slug, cloudID string, cfg Config, repoRoot string, labels map[string]string, reclaim bool) error {
-	server := Server{Provider: providerName, CloudID: cloudID, Name: core.LeaseProviderName(leaseID, slug), Labels: labels}
-	return core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, SSHTarget{}, repoRoot, cfg.IdleTimeout, reclaim)
+func (b *backend) persistRecoveryClaim(leaseID, slug, cloudID string, cfg core.Config, repoRoot string, labels map[string]string, reclaim bool) error {
+	server := core.Server{Provider: providerName, CloudID: cloudID, Name: core.LeaseProviderName(leaseID, slug), Labels: labels}
+	return core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, core.SSHTarget{}, repoRoot, cfg.IdleTimeout, reclaim)
 }
 
-func ownedServers(items []nebiusInstance, cfg Config) []Server {
-	servers := make([]Server, 0, len(items))
+func ownedServers(items []nebiusInstance, cfg core.Config) []core.Server {
+	servers := make([]core.Server, 0, len(items))
 	for _, item := range items {
 		server := serverFromInstance(item, cfg)
 		if validateNebiusOwnership(server.Labels, cfg) == nil {
@@ -416,7 +416,7 @@ func ownedServers(items []nebiusInstance, cfg Config) []Server {
 	return servers
 }
 
-func validateNebiusAcquireConfig(cfg Config) error {
+func validateNebiusAcquireConfig(cfg core.Config) error {
 	if cfg.TargetOS != "" && cfg.TargetOS != targetLinux {
 		return core.Exit(2, "provider=nebius supports target=linux only")
 	}
@@ -470,7 +470,7 @@ func isNebiusInstanceNotFound(err error, id string) bool {
 	return strings.Contains(text, "instance not found")
 }
 
-func nebiusServerType(cfg Config) string {
+func nebiusServerType(cfg core.Config) string {
 	if strings.TrimSpace(cfg.ServerType) != "" {
 		return strings.TrimSpace(cfg.ServerType)
 	}
@@ -489,12 +489,12 @@ var _ core.SSHLeaseBackend = (*backend)(nil)
 var _ core.CleanupBackend = (*backend)(nil)
 var _ core.ReleaseLeaseReporter = (*backend)(nil)
 
-func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	if b.RT.Exec == nil {
-		return DoctorResult{}, exit(2, "provider=nebius doctor requires command runner")
+		return core.DoctorResult{}, core.Exit(2, "provider=nebius doctor requires command runner")
 	}
 	client := newCLIRunner(b.Cfg.Nebius, b.RT)
-	checks := []DoctorCheck{
+	checks := []core.DoctorCheck{
 		b.checkVersion(ctx, client),
 		b.checkProfile(ctx, client),
 		b.checkParentID(ctx, client),
@@ -510,7 +510,7 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 			break
 		}
 	}
-	return DoctorResult{
+	return core.DoctorResult{
 		Provider: providerName,
 		Status:   status,
 		Message:  fmt.Sprintf("cli=%s control_plane=read_only mutation=false", status),
@@ -518,7 +518,7 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 	}, nil
 }
 
-func (b *backend) checkVersion(ctx context.Context, client cliRunner) DoctorCheck {
+func (b *backend) checkVersion(ctx context.Context, client cliRunner) core.DoctorCheck {
 	result, err := client.run(ctx, "version")
 	if err != nil {
 		return doctorCheck("cli", "error", err.Error(), nil)
@@ -526,7 +526,7 @@ func (b *backend) checkVersion(ctx context.Context, client cliRunner) DoctorChec
 	return doctorCheck("cli", "ok", "nebius cli available", map[string]string{"version": redactNebiusText(firstNonBlank(result.Stdout, result.Stderr))})
 }
 
-func (b *backend) checkProfile(ctx context.Context, client cliRunner) DoctorCheck {
+func (b *backend) checkProfile(ctx context.Context, client cliRunner) core.DoctorCheck {
 	result, err := client.run(ctx, "profile", "list")
 	if err != nil {
 		return doctorCheck("profile", "error", err.Error(), nil)
@@ -537,7 +537,7 @@ func (b *backend) checkProfile(ctx context.Context, client cliRunner) DoctorChec
 	return doctorCheck("profile", "ok", "profile store readable", nil)
 }
 
-func (b *backend) checkParentID(ctx context.Context, client cliRunner) DoctorCheck {
+func (b *backend) checkParentID(ctx context.Context, client cliRunner) core.DoctorCheck {
 	parentID := strings.TrimSpace(b.Cfg.Nebius.ParentID)
 	if parentID == "" {
 		return doctorCheck("parent-id", "error", "nebius.parentId is required", nil)
@@ -552,7 +552,7 @@ func (b *backend) checkParentID(ctx context.Context, client cliRunner) DoctorChe
 	return doctorCheck("parent-id", "ok", "project readable", map[string]string{"parentId": parentID})
 }
 
-func (b *backend) checkSubnet(ctx context.Context, client cliRunner) DoctorCheck {
+func (b *backend) checkSubnet(ctx context.Context, client cliRunner) core.DoctorCheck {
 	subnetID := strings.TrimSpace(b.Cfg.Nebius.SubnetID)
 	if subnetID == "" {
 		return doctorCheck("subnet", "error", "nebius.subnetId is required", nil)
@@ -571,7 +571,7 @@ func (b *backend) checkSubnet(ctx context.Context, client cliRunner) DoctorCheck
 	return doctorCheck("subnet", "ok", "subnet readable", map[string]string{"subnetId": subnetID})
 }
 
-func (b *backend) checkPlatform(ctx context.Context, client cliRunner) DoctorCheck {
+func (b *backend) checkPlatform(ctx context.Context, client cliRunner) core.DoctorCheck {
 	platform := strings.TrimSpace(b.Cfg.Nebius.Platform)
 	result, err := client.run(ctx, "compute", "platform", "list", "--parent-id", b.Cfg.Nebius.ParentID, "--format", "json")
 	if err != nil {
@@ -587,7 +587,7 @@ func (b *backend) checkPlatform(ctx context.Context, client cliRunner) DoctorChe
 	return doctorCheck("platform", "ok", "platform readable", map[string]string{"platform": platform})
 }
 
-func (b *backend) checkImage(ctx context.Context, client cliRunner) DoctorCheck {
+func (b *backend) checkImage(ctx context.Context, client cliRunner) core.DoctorCheck {
 	imageFamily := strings.TrimSpace(b.Cfg.Nebius.ImageFamily)
 	result, err := client.run(ctx, "compute", "image", "get-latest-by-family", "--image-family", imageFamily, "--format", "json")
 	if err != nil {
@@ -603,7 +603,7 @@ func (b *backend) checkImage(ctx context.Context, client cliRunner) DoctorCheck 
 	return doctorCheck("image", "ok", "image family readable", map[string]string{"imageFamily": imageFamily})
 }
 
-func (b *backend) checkJSON(ctx context.Context, client cliRunner) DoctorCheck {
+func (b *backend) checkJSON(ctx context.Context, client cliRunner) core.DoctorCheck {
 	// A single page is enough to verify CLI JSON compatibility; lifecycle inventory uses --all.
 	result, err := client.run(ctx, "compute", "instance", "list", "--parent-id", b.Cfg.Nebius.ParentID, "--format", "json")
 	if err != nil {
@@ -615,6 +615,6 @@ func (b *backend) checkJSON(ctx context.Context, client cliRunner) DoctorCheck {
 	return doctorCheck("json", "ok", "json output available", nil)
 }
 
-func doctorCheck(name, status, message string, details map[string]string) DoctorCheck {
-	return DoctorCheck{Check: name, Status: status, Message: redactNebiusText(message), Details: details}
+func doctorCheck(name, status, message string, details map[string]string) core.DoctorCheck {
+	return core.DoctorCheck{Check: name, Status: status, Message: redactNebiusText(message), Details: details}
 }

--- a/internal/providers/nebius/cli.go
+++ b/internal/providers/nebius/cli.go
@@ -12,12 +12,13 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type cliRunner struct {
-	cfg NebiusConfig
-	rt  Runtime
+	cfg core.NebiusConfig
+	rt  core.Runtime
 }
 
 type cliResult struct {
@@ -37,7 +38,7 @@ type nebiusAPI interface {
 }
 
 type nebiusClient struct {
-	cfg NebiusConfig
+	cfg core.NebiusConfig
 	cli cliRunner
 }
 
@@ -57,17 +58,17 @@ type nebiusInstance struct {
 	Raw      map[string]any
 }
 
-func newCLIRunner(cfg NebiusConfig, rt Runtime) cliRunner {
+func newCLIRunner(cfg core.NebiusConfig, rt core.Runtime) cliRunner {
 	return cliRunner{cfg: cfg, rt: rt}
 }
 
-func newNebiusClient(cfg NebiusConfig, rt Runtime) *nebiusClient {
+func newNebiusClient(cfg core.NebiusConfig, rt core.Runtime) *nebiusClient {
 	return &nebiusClient{cfg: cfg, cli: newCLIRunner(cfg, rt)}
 }
 
 func (c cliRunner) run(ctx context.Context, args ...string) (cliResult, error) {
 	commandArgs := c.withProfile(args)
-	result, err := c.rt.Exec.Run(ctx, LocalCommandRequest{
+	result, err := c.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name: c.cfg.CLI,
 		Args: commandArgs,
 	})
@@ -281,9 +282,9 @@ func instanceFromObject(object map[string]any) nebiusInstance {
 	}
 }
 
-func serverFromInstance(item nebiusInstance, cfg Config) Server {
+func serverFromInstance(item nebiusInstance, cfg core.Config) core.Server {
 	labels := shared.CloneLabels(item.Labels)
-	server := Server{
+	server := core.Server{
 		CloudID:  item.ID,
 		Provider: providerName,
 		Name:     firstNonBlank(item.Name, labels["slug"]),
@@ -327,7 +328,7 @@ func cleanIP(value string) string {
 	return strings.TrimSpace(value)
 }
 
-func renderNetworkInterfaces(cfg NebiusConfig) string {
+func renderNetworkInterfaces(cfg core.NebiusConfig) string {
 	item := map[string]any{
 		"name":       "eth0",
 		"subnet_id":  strings.TrimSpace(cfg.SubnetID),
@@ -482,5 +483,5 @@ func isJSON(output string) bool {
 }
 
 func validationError(format string, args ...any) error {
-	return exit(2, format, args...)
+	return core.Exit(2, format, args...)
 }

--- a/internal/providers/nebius/cloudinit.go
+++ b/internal/providers/nebius/cloudinit.go
@@ -9,7 +9,7 @@ import (
 
 var linuxUsernamePattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]{0,31}$`)
 
-func renderNebiusCloudInit(cfg Config, publicKey string) (string, error) {
+func renderNebiusCloudInit(cfg core.Config, publicKey string) (string, error) {
 	user := strings.TrimSpace(cfg.SSHUser)
 	if user == "" {
 		user = strings.TrimSpace(cfg.Nebius.User)

--- a/internal/providers/nebius/core.go
+++ b/internal/providers/nebius/core.go
@@ -4,32 +4,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-type Config = core.Config
-type NebiusConfig = core.NebiusConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type DoctorCheck = core.DoctorCheck
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type CleanupRequest = core.CleanupRequest
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
-type SSHTarget = core.SSHTarget
-
 const (
 	providerName = "nebius"
 	targetLinux  = core.TargetLinux
 )
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}

--- a/internal/providers/nebius/flags.go
+++ b/internal/providers/nebius/flags.go
@@ -1,16 +1,18 @@
 package nebius
 
-import core "github.com/openclaw/crabbox/internal/cli"
+import (
+	"flag"
 
-import "flag"
+	core "github.com/openclaw/crabbox/internal/cli"
+)
 
 // RegisterNebiusProviderFlags exposes only non-secret Nebius settings.
 // Authentication is owned by Nebius CLI profiles, not Crabbox argv.
-func RegisterNebiusProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterNebiusProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterNebiusConfigFlags(fs, defaults.Nebius)
 }
 
-func ApplyNebiusProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyNebiusProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	v, ok := values.(core.NebiusConfigFlagValues)
 	if !ok {
 		return nil

--- a/internal/providers/nebius/labels.go
+++ b/internal/providers/nebius/labels.go
@@ -19,13 +19,13 @@ const (
 	nebiusProfileLabel  = "crabbox_profile"
 )
 
-func nebiusLeaseLabels(cfg Config, leaseID, slug, state string, keep bool, now time.Time) map[string]string {
+func nebiusLeaseLabels(cfg core.Config, leaseID, slug, state string, keep bool, now time.Time) map[string]string {
 	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
 	labels["state"] = state
 	return addNebiusScopeLabels(labels, cfg)
 }
 
-func addNebiusScopeLabels(labels map[string]string, cfg Config) map[string]string {
+func addNebiusScopeLabels(labels map[string]string, cfg core.Config) map[string]string {
 	out := make(map[string]string, len(labels)+8)
 	for key, value := range labels {
 		out[normalizeNebiusLabelKey(key)] = normalizeNebiusLabelValue(value)
@@ -45,7 +45,7 @@ func addNebiusScopeLabels(labels map[string]string, cfg Config) map[string]strin
 	return out
 }
 
-func validateNebiusOwnership(labels map[string]string, cfg Config) error {
+func validateNebiusOwnership(labels map[string]string, cfg core.Config) error {
 	if labels == nil {
 		return core.Exit(3, "nebius resource has no labels; refusing lifecycle action")
 	}
@@ -80,7 +80,7 @@ func validateNebiusOwnership(labels map[string]string, cfg Config) error {
 	return nil
 }
 
-func nebiusScopeHash(cfg Config) string {
+func nebiusScopeHash(cfg core.Config) string {
 	parts := []string{
 		"provider=" + providerName,
 		"profile=" + strings.TrimSpace(cfg.Nebius.Profile),

--- a/internal/providers/nebius/lifecycle_test.go
+++ b/internal/providers/nebius/lifecycle_test.go
@@ -83,8 +83,8 @@ func newTestBackend(t *testing.T, api *fakeNebiusAPI) *backend {
 	cfg.TTL = 2 * time.Hour
 	cfg.Nebius.SecurityGroupIDs = []string{"sg-a", "sg-b"}
 	cfg.Nebius.ServiceAccountID = "sa-a"
-	b := NewBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard}).(*backend)
-	b.clientFactory = func(Runtime) nebiusAPI { return api }
+	b := NewBackend(Provider{}.Spec(), cfg, core.Runtime{Stderr: io.Discard}).(*backend)
+	b.clientFactory = func(core.Runtime) nebiusAPI { return api }
 	b.waitSSH = func(context.Context, *core.SSHTarget, string, time.Duration) error { return nil }
 	b.now = func() time.Time { return time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC) }
 	return b
@@ -137,38 +137,38 @@ func TestLabelOwnershipRequiresCompleteMatchingScope(t *testing.T) {
 }
 
 func TestCommandConstructionUsesManagedDiskPublicIPLabelsAndNoSecrets(t *testing.T) {
-	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &recordingRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		joined := strings.Join(req.Args, " ")
 		if !strings.Contains(joined, "compute instance create") {
-			return LocalCommandResult{}, errors.New("unexpected command: " + joined)
+			return core.LocalCommandResult{}, errors.New("unexpected command: " + joined)
 		}
 		if strings.Contains(joined, "osb_") || strings.Contains(joined, "private_key") {
-			return LocalCommandResult{}, errors.New("secret-like value passed on argv")
+			return core.LocalCommandResult{}, errors.New("secret-like value passed on argv")
 		}
 		if !strings.Contains(joined, "--network-interfaces") || !strings.Contains(joined, `"name":"eth0"`) || !strings.Contains(joined, `"subnet_id":"subnet-123"`) || !strings.Contains(joined, `"ip_address":{}`) || !strings.Contains(joined, `"public_ip_address":{}`) {
-			return LocalCommandResult{}, errors.New("missing dynamic public IP network interface: " + joined)
+			return core.LocalCommandResult{}, errors.New("missing dynamic public IP network interface: " + joined)
 		}
 		if !strings.Contains(joined, "--boot-disk-managed-disk-name cbx-demo") ||
 			!strings.Contains(joined, "--boot-disk-managed-disk-source-image-family-image-family ubuntu24.04-driverless") ||
 			!strings.Contains(joined, "--boot-disk-managed-disk-type network_ssd") ||
 			!strings.Contains(joined, "--boot-disk-managed-disk-size-gibibytes 50") ||
 			!strings.Contains(joined, "--boot-disk-attach-mode read_write") {
-			return LocalCommandResult{}, errors.New("missing managed boot disk args: " + joined)
+			return core.LocalCommandResult{}, errors.New("missing managed boot disk args: " + joined)
 		}
 		if strings.Contains(joined, "--boot-disk-managed-disk-source-image-family-parent-id") {
-			return LocalCommandResult{}, errors.New("public image family incorrectly scoped to the lease project: " + joined)
+			return core.LocalCommandResult{}, errors.New("public image family incorrectly scoped to the lease project: " + joined)
 		}
 		for i, arg := range req.Args {
 			if arg == "--cloud-init-user-data" && i+1 < len(req.Args) && req.Args[i+1] != "#cloud-config\n" {
-				return LocalCommandResult{}, errors.New("cloud-init content was not passed as a raw string")
+				return core.LocalCommandResult{}, errors.New("cloud-init content was not passed as a raw string")
 			}
 		}
 		if !strings.Contains(joined, "--labels ") || !strings.Contains(joined, "crabbox_provider=nebius") || !strings.Contains(joined, "crabbox_scope=") {
-			return LocalCommandResult{}, errors.New("missing ownership labels: " + joined)
+			return core.LocalCommandResult{}, errors.New("missing ownership labels: " + joined)
 		}
-		return LocalCommandResult{Stdout: `{"metadata":{"id":"vm-1","name":"cbx-demo","labels":{"crabbox":"true"}},"status":{"state":"RUNNING","network_interfaces":[{"public_ip_address":{"address":"203.0.113.10/32"}}]}}`}, nil
+		return core.LocalCommandResult{Stdout: `{"metadata":{"id":"vm-1","name":"cbx-demo","labels":{"crabbox":"true"}},"status":{"state":"RUNNING","network_interfaces":[{"public_ip_address":{"address":"203.0.113.10/32"}}]}}`}, nil
 	}}
-	client := newNebiusClient(testConfig().Nebius, Runtime{Exec: runner})
+	client := newNebiusClient(testConfig().Nebius, core.Runtime{Exec: runner})
 	labels := nebiusLeaseLabels(testConfig(), "cbx_123456789abc", "demo", "ready", false, time.Unix(1000, 0))
 	item, err := client.CreateInstance(context.Background(), nebiusCreateRequest{Name: "cbx-demo", Labels: labels, UserData: "#cloud-config\n"})
 	if err != nil {
@@ -180,10 +180,10 @@ func TestCommandConstructionUsesManagedDiskPublicIPLabelsAndNoSecrets(t *testing
 }
 
 func TestCLIErrorRedactsCloudInitAndDeleteUsesSupportedFlags(t *testing.T) {
-	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
-		return LocalCommandResult{Stderr: "request failed"}, errors.New("request failed")
+	runner := &recordingRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		return core.LocalCommandResult{Stderr: "request failed"}, errors.New("request failed")
 	}}
-	client := newNebiusClient(testConfig().Nebius, Runtime{Exec: runner})
+	client := newNebiusClient(testConfig().Nebius, core.Runtime{Exec: runner})
 	secretMarker := "ssh-ed25519 AAAA-marker"
 	_, err := client.CreateInstance(context.Background(), nebiusCreateRequest{Name: "cbx-demo", UserData: "#cloud-config\n" + secretMarker})
 	if err == nil || strings.Contains(err.Error(), secretMarker) || !strings.Contains(err.Error(), "[REDACTED]") {
@@ -201,7 +201,7 @@ func TestCLIErrorRedactsCloudInitAndDeleteUsesSupportedFlags(t *testing.T) {
 
 func TestUpdateLabelsIncludesParentScope(t *testing.T) {
 	runner := &recordingRunner{}
-	client := newNebiusClient(testConfig().Nebius, Runtime{Exec: runner})
+	client := newNebiusClient(testConfig().Nebius, core.Runtime{Exec: runner})
 	if err := client.UpdateLabels(context.Background(), "vm-1", map[string]string{"state": "ready"}); err != nil {
 		t.Fatal(err)
 	}
@@ -212,10 +212,10 @@ func TestUpdateLabelsIncludesParentScope(t *testing.T) {
 }
 
 func TestListInstancesRequestsAllPages(t *testing.T) {
-	runner := &recordingRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
-		return LocalCommandResult{Stdout: `{"items":[]}`}, nil
+	runner := &recordingRunner{fn: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		return core.LocalCommandResult{Stdout: `{"items":[]}`}, nil
 	}}
-	client := newNebiusClient(testConfig().Nebius, Runtime{Exec: runner})
+	client := newNebiusClient(testConfig().Nebius, core.Runtime{Exec: runner})
 	if _, err := client.ListInstances(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -244,7 +244,7 @@ func TestAcquirePersistsClaimAndSSHReadyTarget(t *testing.T) {
 		waited:  nebiusInstance{ID: "vm-new", Name: "ready", Status: "RUNNING", Labels: labels, PublicIP: "203.0.113.20"},
 	}
 	b := newTestBackend(t, api)
-	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "demo"})
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "demo"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -271,7 +271,7 @@ func TestResolveListStatusByAliases(t *testing.T) {
 		{ID: "foreign", Name: "foreign", Status: "RUNNING", Labels: map[string]string{"crabbox": "true"}, PublicIP: "203.0.113.11"},
 	}}
 	b := newTestBackend(t, api)
-	list, err := b.List(context.Background(), ListRequest{})
+	list, err := b.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -279,7 +279,7 @@ func TestResolveListStatusByAliases(t *testing.T) {
 		t.Fatalf("list=%#v", list)
 	}
 	for _, id := range []string{"cbx_123456789abc", "demo", "vm-1", core.LeaseProviderName("cbx_123456789abc", "demo")} {
-		got, err := b.Resolve(context.Background(), ResolveRequest{ID: id})
+		got, err := b.Resolve(context.Background(), core.ResolveRequest{ID: id})
 		if err != nil {
 			t.Fatalf("Resolve(%q): %v", id, err)
 		}
@@ -296,7 +296,7 @@ func TestResolveAssociatesLiveInstanceWithRepoUnlessMutationsDisabled(t *testing
 	api := &fakeNebiusAPI{items: []nebiusInstance{{ID: "vm-1", Name: "demo", Status: "RUNNING", Labels: labels, PublicIP: "203.0.113.10"}}}
 	b := newTestBackend(t, api)
 	repo := t.TempDir()
-	if _, err := b.Resolve(context.Background(), ResolveRequest{ID: leaseID, Repo: core.Repo{Root: repo}}); err != nil {
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, Repo: core.Repo{Root: repo}}); err != nil {
 		t.Fatal(err)
 	}
 	claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName)
@@ -310,7 +310,7 @@ func TestResolveAssociatesLiveInstanceWithRepoUnlessMutationsDisabled(t *testing
 	otherLeaseID := "cbx_b123456789ab"
 	otherLabels := nebiusLeaseLabels(cfg, otherLeaseID, "no-mutate", "ready", false, time.Unix(1000, 0))
 	api.items = append(api.items, nebiusInstance{ID: "vm-2", Name: "no-mutate", Status: "RUNNING", Labels: otherLabels, PublicIP: "203.0.113.11"})
-	if _, err := b.Resolve(context.Background(), ResolveRequest{ID: otherLeaseID, Repo: core.Repo{Root: repo}, NoLocalStateMutations: true}); err != nil {
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: otherLeaseID, Repo: core.Repo{Root: repo}, NoLocalStateMutations: true}); err != nil {
 		t.Fatal(err)
 	}
 	if _, exists, err := core.ReadLeaseClaimWithPresence(otherLeaseID); err != nil || exists {
@@ -333,19 +333,19 @@ func TestReleaseAndCleanupRefuseForeignOrAmbiguousResources(t *testing.T) {
 	if err := core.ClaimLeaseTargetForRepoConfig(ownedServer.Labels["lease"], ownedServer.Labels["slug"], b.Cfg, ownedServer, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
 		t.Fatal(err)
 	}
 	if len(api.deletedIDs) != 0 {
 		t.Fatalf("dry-run deleted: %v", api.deletedIDs)
 	}
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if strings.Join(api.deletedIDs, ",") != "vm-owned" {
 		t.Fatalf("deletedIDs=%v", api.deletedIDs)
 	}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: "cbx_deadbeef1234", Server: Server{CloudID: "vm-foreign", Labels: foreign}}}); err == nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_deadbeef1234", Server: core.Server{CloudID: "vm-foreign", Labels: foreign}}}); err == nil {
 		t.Fatal("ReleaseLease accepted foreign ownership")
 	}
 }
@@ -377,7 +377,7 @@ func TestNebiusReleaseRejectsMissingOrStaleExactOwnership(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}})
+			err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
 			if test.seedClaim && !test.staleID {
 				if err != nil || strings.Join(api.deletedIDs, ",") != item.ID {
 					t.Fatalf("owned release err=%v deleted=%v", err, api.deletedIDs)
@@ -400,11 +400,11 @@ func TestTouchUpdatesLabelsWithoutLosingOwnership(t *testing.T) {
 	api := &fakeNebiusAPI{items: []nebiusInstance{{ID: "vm-1", Name: "demo", Status: "RUNNING", Labels: labels, PublicIP: "203.0.113.10"}}}
 	b := newTestBackend(t, api)
 	leaseID := "cbx_123456789abc"
-	claimedServer := Server{Provider: providerName, CloudID: "vm-1", Name: "demo", Labels: labels}
+	claimedServer := core.Server{Provider: providerName, CloudID: "vm-1", Name: "demo", Labels: labels}
 	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "demo", b.Cfg, claimedServer, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
-	server, err := b.Touch(context.Background(), TouchRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: claimedServer}, State: "ready", IdleTimeout: 30 * time.Minute})
+	server, err := b.Touch(context.Background(), core.TouchRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: claimedServer}, State: "ready", IdleTimeout: 30 * time.Minute})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -437,7 +437,7 @@ func TestTouchRefusesLiveOwnershipMismatch(t *testing.T) {
 	liveLabels[nebiusLeaseLabel] = "cbx_other123456"
 	api := &fakeNebiusAPI{items: []nebiusInstance{{ID: "vm-1", Name: "demo", Status: "RUNNING", Labels: liveLabels, PublicIP: "203.0.113.10"}}}
 	b := newTestBackend(t, api)
-	_, err := b.Touch(context.Background(), TouchRequest{Lease: LeaseTarget{LeaseID: "cbx_123456789abc", Server: Server{CloudID: "vm-1", Labels: labels}}, State: "ready"})
+	_, err := b.Touch(context.Background(), core.TouchRequest{Lease: core.LeaseTarget{LeaseID: "cbx_123456789abc", Server: core.Server{CloudID: "vm-1", Labels: labels}}, State: "ready"})
 	if err == nil {
 		t.Fatal("Touch accepted changed live ownership")
 	}
@@ -457,7 +457,7 @@ func TestManagedDiskAcquireRejectsPublicIPNone(t *testing.T) {
 func TestAcquireRecoveryRetainsClaimOnIndeterminateCreate(t *testing.T) {
 	api := &fakeNebiusAPI{createErr: errors.New("connection reset after create")}
 	b := newTestBackend(t, api)
-	_, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "recover"})
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "recover"})
 	if err == nil {
 		t.Fatal("Acquire succeeded unexpectedly")
 	}
@@ -473,7 +473,7 @@ func TestAcquireRecoveryRetainsClaimOnIndeterminateCreate(t *testing.T) {
 func TestAcquireQuotaFailureWithTimeoutLabelDoesNotRetainRecoveryClaim(t *testing.T) {
 	api := &fakeNebiusAPI{createErr: errors.New("create --labels idle_timeout=300 failed: quota limit exceeded")}
 	b := newTestBackend(t, api)
-	_, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "quota-failure"})
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "quota-failure"})
 	if err == nil {
 		t.Fatal("Acquire succeeded unexpectedly")
 	}
@@ -488,10 +488,10 @@ func TestAcquireRollsBackCreatedInstanceWhenOnAcquiredFails(t *testing.T) {
 		waited:  nebiusInstance{ID: "vm-new", Name: "ready", Status: "RUNNING", Labels: map[string]string{}, PublicIP: "203.0.113.20"},
 	}
 	b := newTestBackend(t, api)
-	_, err := b.Acquire(context.Background(), AcquireRequest{
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
 		Repo:          core.Repo{Root: t.TempDir()},
 		RequestedSlug: "rollback",
-		OnAcquired: func(LeaseTarget) error {
+		OnAcquired: func(core.LeaseTarget) error {
 			return errors.New("controller rejected identity")
 		},
 	})
@@ -509,11 +509,11 @@ func TestAcquireRollsBackCreatedInstanceWhenOnAcquiredFails(t *testing.T) {
 func TestAcquireKeepRetainsCreatedInstanceClaimAndKeyAfterFailure(t *testing.T) {
 	api := &fakeNebiusAPI{created: nebiusInstance{ID: "vm-kept", Name: "pending", Status: "CREATING"}}
 	b := newTestBackend(t, api)
-	_, err := b.Acquire(context.Background(), AcquireRequest{
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
 		Repo:          core.Repo{Root: t.TempDir()},
 		RequestedSlug: "kept-failure",
 		Keep:          true,
-		OnAcquired: func(LeaseTarget) error {
+		OnAcquired: func(core.LeaseTarget) error {
 			return errors.New("controller rejected identity")
 		},
 	})
@@ -544,10 +544,10 @@ func TestAcquireRollbackUsesBoundedContextIndependentOfCaller(t *testing.T) {
 	b := newTestBackend(t, api)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err := b.Acquire(ctx, AcquireRequest{
+	_, err := b.Acquire(ctx, core.AcquireRequest{
 		Repo:          core.Repo{Root: t.TempDir()},
 		RequestedSlug: "rollback-context",
-		OnAcquired: func(LeaseTarget) error {
+		OnAcquired: func(core.LeaseTarget) error {
 			return errors.New("controller rejected identity")
 		},
 	})
@@ -567,12 +567,12 @@ func TestReleaseCleansLocalClaimWhenInstanceAlreadyAbsent(t *testing.T) {
 	labels := nebiusLeaseLabels(cfg, leaseID, slug, "ready", false, time.Unix(1000, 0))
 	api := &fakeNebiusAPI{getErr: errors.New("instance " + cloudID + " not found")}
 	b := newTestBackend(t, api)
-	server := Server{Provider: providerName, CloudID: cloudID, Name: slug, Labels: labels}
+	server := core.Server{Provider: providerName, CloudID: cloudID, Name: slug, Labels: labels}
 	server.PublicNet.IPv4.IP = "203.0.113.10"
 	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
 		t.Fatal(err)
 	}
 	if len(api.deletedIDs) != 0 {
@@ -591,7 +591,7 @@ func TestReleaseFencesClaimMutationDuringDelete(t *testing.T) {
 	labels := nebiusLeaseLabels(cfg, leaseID, slug, "ready", false, time.Unix(1000, 0))
 	api := &fakeNebiusAPI{items: []nebiusInstance{{ID: cloudID, Name: slug, Status: "RUNNING", Labels: labels, PublicIP: "203.0.113.10"}}}
 	b := newTestBackend(t, api)
-	server := Server{Provider: providerName, CloudID: cloudID, Name: slug, Labels: labels}
+	server := core.Server{Provider: providerName, CloudID: cloudID, Name: slug, Labels: labels}
 	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
@@ -616,7 +616,7 @@ func TestReleaseFencesClaimMutationDuringDelete(t *testing.T) {
 		default:
 		}
 	}
-	err = b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}})
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
 	if err != nil {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
@@ -638,11 +638,11 @@ func TestReleaseRetainsIdentitylessRecoveryClaim(t *testing.T) {
 	if err := b.persistRecoveryClaim(leaseID, slug, "", b.Cfg, t.TempDir(), labels, false); err != nil {
 		t.Fatal(err)
 	}
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease})
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
 	if err == nil || !strings.Contains(err.Error(), "no instance identity") {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
@@ -662,11 +662,11 @@ func TestReleaseDoesNotCleanClaimOnUnrelatedNotFound(t *testing.T) {
 	labels := nebiusLeaseLabels(cfg, leaseID, slug, "ready", false, time.Unix(1000, 0))
 	api := &fakeNebiusAPI{getErr: errors.New("profile production not found")}
 	b := newTestBackend(t, api)
-	server := Server{Provider: providerName, CloudID: cloudID, Name: slug, Labels: labels}
+	server := core.Server{Provider: providerName, CloudID: cloudID, Name: slug, Labels: labels}
 	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err == nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err == nil {
 		t.Fatal("ReleaseLease cleaned state after unrelated not-found error")
 	}
 	if _, ok, err := core.ResolveLeaseClaimForProvider(slug, providerName); err != nil || !ok {
@@ -682,11 +682,11 @@ func TestResolveReleaseOnlyFindsClaimByCloudID(t *testing.T) {
 	labels := nebiusLeaseLabels(cfg, leaseID, slug, "ready", false, time.Unix(1000, 0))
 	api := &fakeNebiusAPI{}
 	b := newTestBackend(t, api)
-	server := Server{Provider: providerName, CloudID: cloudID, Name: slug, Labels: labels}
+	server := core.Server{Provider: providerName, CloudID: cloudID, Name: slug, Labels: labels}
 	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: cloudID, ReleaseOnly: true})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: cloudID, ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -703,7 +703,7 @@ func TestReleaseRefusesLiveOwnershipMismatch(t *testing.T) {
 	liveLabels[nebiusLeaseLabel] = "cbx_other123456"
 	api := &fakeNebiusAPI{items: []nebiusInstance{{ID: "vm-1", Name: "other", Status: "RUNNING", Labels: liveLabels, PublicIP: "203.0.113.10"}}}
 	b := newTestBackend(t, api)
-	err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: "cbx_deadbeef1234", Server: Server{CloudID: "vm-1", Labels: labels}}})
+	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_deadbeef1234", Server: core.Server{CloudID: "vm-1", Labels: labels}}})
 	if err == nil {
 		t.Fatal("ReleaseLease accepted changed live ownership")
 	}
@@ -718,10 +718,10 @@ func TestAcquireRollbackFailureRetainsCreatedInstanceIDClaim(t *testing.T) {
 		deleteErr: errors.New("lost delete response"),
 	}
 	b := newTestBackend(t, api)
-	_, err := b.Acquire(context.Background(), AcquireRequest{
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
 		Repo:          core.Repo{Root: t.TempDir()},
 		RequestedSlug: "rollback-failed",
-		OnAcquired: func(LeaseTarget) error {
+		OnAcquired: func(core.LeaseTarget) error {
 			return errors.New("controller rejected identity")
 		},
 	})

--- a/internal/providers/nebius/provider.go
+++ b/internal/providers/nebius/provider.go
@@ -40,10 +40,10 @@ func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error
 
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
-		return nil, exit(2, "provider=%s supports target=linux only", providerName)
+		return nil, core.Exit(2, "provider=%s supports target=linux only", providerName)
 	}
 	if cfg.Tailscale.Enabled || string(cfg.Network) == "tailscale" {
-		return nil, exit(2, "--tailscale is not supported for provider=%s in the Nebius provider foundation", providerName)
+		return nil, core.Exit(2, "--tailscale is not supported for provider=%s in the Nebius provider foundation", providerName)
 	}
 	if err := p.ValidateConfig(cfg); err != nil {
 		return nil, err
@@ -58,23 +58,23 @@ func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.Doctor
 func (Provider) ValidateConfig(cfg core.Config) error {
 	neb := cfg.Nebius
 	if strings.TrimSpace(neb.CLI) == "" {
-		return exit(2, "nebius.cli is required")
+		return core.Exit(2, "nebius.cli is required")
 	}
 	if err := validateNebiusUser(neb.User); err != nil {
 		return err
 	}
 	if neb.DiskSizeGiB <= 0 {
-		return exit(2, "nebius.diskSizeGiB must be positive")
+		return core.Exit(2, "nebius.diskSizeGiB must be positive")
 	}
 	switch strings.ToLower(strings.TrimSpace(neb.PublicIP)) {
 	case "", "dynamic", "none":
 	default:
-		return exit(2, "nebius.publicIP must be dynamic or none")
+		return core.Exit(2, "nebius.publicIP must be dynamic or none")
 	}
 	switch strings.ToLower(strings.TrimSpace(neb.RecoveryPolicy)) {
 	case "", "fail":
 	default:
-		return exit(2, "nebius.recoveryPolicy must be fail")
+		return core.Exit(2, "nebius.recoveryPolicy must be fail")
 	}
 	return nil
 }

--- a/internal/providers/nebius/provider_test.go
+++ b/internal/providers/nebius/provider_test.go
@@ -15,26 +15,26 @@ import (
 
 type recordingRunner struct {
 	calls [][]string
-	fn    func(LocalCommandRequest) (LocalCommandResult, error)
+	fn    func(core.LocalCommandRequest) (core.LocalCommandResult, error)
 }
 
-func (r *recordingRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	call := append([]string{req.Name}, req.Args...)
 	r.calls = append(r.calls, call)
 	if r.fn != nil {
 		return r.fn(req)
 	}
-	return LocalCommandResult{}, nil
+	return core.LocalCommandResult{}, nil
 }
 
-func testConfig() Config {
-	return Config{
+func testConfig() core.Config {
+	return core.Config{
 		Provider: providerName,
 		TargetOS: targetLinux,
 		SSHUser:  "crabbox",
 		SSHPort:  "22",
 		WorkRoot: "/tmp/crabbox",
-		Nebius: NebiusConfig{
+		Nebius: core.NebiusConfig{
 			CLI:            "nebius",
 			Profile:        "sandbox",
 			ParentID:       "project-123",
@@ -203,7 +203,7 @@ func TestValidateConfigRejectsReservedUsers(t *testing.T) {
 func TestCLIRunnerAddsProfileBeforeCommand(t *testing.T) {
 	runner := &recordingRunner{}
 	cfg := testConfig()
-	client := newCLIRunner(cfg.Nebius, Runtime{Exec: runner})
+	client := newCLIRunner(cfg.Nebius, core.Runtime{Exec: runner})
 	if _, err := client.run(context.Background(), "compute", "platform", "list", "--format", "json"); err != nil {
 		t.Fatal(err)
 	}
@@ -248,34 +248,34 @@ func TestRedactNebiusText(t *testing.T) {
 }
 
 func TestDoctorUsesReadOnlyCLICommands(t *testing.T) {
-	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &recordingRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		joined := strings.Join(req.Args, " ")
 		for _, forbidden := range []string{" create", " delete", " update", " disk create", " disk delete", " allocation create", " allocation delete"} {
 			if strings.Contains(" "+joined, forbidden) {
-				return LocalCommandResult{}, errors.New("mutating command invoked: " + joined)
+				return core.LocalCommandResult{}, errors.New("mutating command invoked: " + joined)
 			}
 		}
 		switch joined {
 		case "--profile sandbox version":
-			return LocalCommandResult{Stdout: "nebius version 1.0.0\n"}, nil
+			return core.LocalCommandResult{Stdout: "nebius version 1.0.0\n"}, nil
 		case "--profile sandbox profile list":
-			return LocalCommandResult{Stdout: "sandbox [default]\n"}, nil
+			return core.LocalCommandResult{Stdout: "sandbox [default]\n"}, nil
 		case "--profile sandbox iam project get project-123 --format json":
-			return LocalCommandResult{Stdout: `{"id":"project-123"}`}, nil
+			return core.LocalCommandResult{Stdout: `{"id":"project-123"}`}, nil
 		case "--profile sandbox vpc subnet list --parent-id project-123 --format json":
-			return LocalCommandResult{Stdout: `[{"id":"subnet-123"}]`}, nil
+			return core.LocalCommandResult{Stdout: `[{"id":"subnet-123"}]`}, nil
 		case "--profile sandbox compute platform list --parent-id project-123 --format json":
-			return LocalCommandResult{Stdout: `[{"id":"cpu-d3"}]`}, nil
+			return core.LocalCommandResult{Stdout: `[{"id":"cpu-d3"}]`}, nil
 		case "--profile sandbox compute image get-latest-by-family --image-family ubuntu24.04-driverless --format json":
-			return LocalCommandResult{Stdout: `{"metadata":{"id":"image-123"}}`}, nil
+			return core.LocalCommandResult{Stdout: `{"metadata":{"id":"image-123"}}`}, nil
 		case "--profile sandbox compute instance list --parent-id project-123 --format json":
-			return LocalCommandResult{Stdout: `{"items":[]}`}, nil
+			return core.LocalCommandResult{Stdout: `{"items":[]}`}, nil
 		default:
-			return LocalCommandResult{}, errors.New("unexpected command: " + joined)
+			return core.LocalCommandResult{}, errors.New("unexpected command: " + joined)
 		}
 	}}
-	backend := NewBackend(Provider{}.Spec(), testConfig(), Runtime{Exec: runner}).(*backend)
-	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	backend := NewBackend(Provider{}.Spec(), testConfig(), core.Runtime{Exec: runner}).(*backend)
+	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,29 +291,29 @@ func TestDoctorUsesReadOnlyCLICommands(t *testing.T) {
 }
 
 func TestDoctorRejectsMissingImageFamily(t *testing.T) {
-	runner := &recordingRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &recordingRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		joined := strings.Join(req.Args, " ")
 		switch joined {
 		case "--profile sandbox version":
-			return LocalCommandResult{Stdout: "nebius version 1.0.0\n"}, nil
+			return core.LocalCommandResult{Stdout: "nebius version 1.0.0\n"}, nil
 		case "--profile sandbox profile list":
-			return LocalCommandResult{Stdout: "sandbox [default]\n"}, nil
+			return core.LocalCommandResult{Stdout: "sandbox [default]\n"}, nil
 		case "--profile sandbox iam project get project-123 --format json":
-			return LocalCommandResult{Stdout: `{"id":"project-123"}`}, nil
+			return core.LocalCommandResult{Stdout: `{"id":"project-123"}`}, nil
 		case "--profile sandbox vpc subnet list --parent-id project-123 --format json":
-			return LocalCommandResult{Stdout: `[{"metadata":{"id":"subnet-123"}}]`}, nil
+			return core.LocalCommandResult{Stdout: `[{"metadata":{"id":"subnet-123"}}]`}, nil
 		case "--profile sandbox compute platform list --parent-id project-123 --format json":
-			return LocalCommandResult{Stdout: `[{"metadata":{"id":"cpu-d3"}}]`}, nil
+			return core.LocalCommandResult{Stdout: `[{"metadata":{"id":"cpu-d3"}}]`}, nil
 		case "--profile sandbox compute image get-latest-by-family --image-family ubuntu24.04-driverless --format json":
-			return LocalCommandResult{Stdout: `{}`}, nil
+			return core.LocalCommandResult{Stdout: `{}`}, nil
 		case "--profile sandbox compute instance list --parent-id project-123 --format json":
-			return LocalCommandResult{Stdout: `{"items":[]}`}, nil
+			return core.LocalCommandResult{Stdout: `{"items":[]}`}, nil
 		default:
-			return LocalCommandResult{}, errors.New("unexpected command: " + joined)
+			return core.LocalCommandResult{}, errors.New("unexpected command: " + joined)
 		}
 	}}
-	backend := NewBackend(Provider{}.Spec(), testConfig(), Runtime{Exec: runner}).(*backend)
-	result, err := backend.Doctor(context.Background(), DoctorRequest{})
+	backend := NewBackend(Provider{}.Spec(), testConfig(), core.Runtime{Exec: runner}).(*backend)
+	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/unikraftcloud/backend.go
+++ b/internal/providers/unikraftcloud/backend.go
@@ -16,22 +16,22 @@ const (
 	defaultWaitTimeout = 5 * time.Minute
 )
 
-func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	return &backend{spec: spec, cfg: cfg, rt: rt, newClient: newUnikraftCloudClient, pollInterval: statusPollInterval, deleteConfirmationTimeout: 30 * time.Second}
 }
 
 type backend struct {
-	spec      ProviderSpec
-	cfg       Config
-	rt        Runtime
-	newClient func(Config, Runtime) (unikraftCloudAPI, error)
+	spec      core.ProviderSpec
+	cfg       core.Config
+	rt        core.Runtime
+	newClient func(core.Config, core.Runtime) (unikraftCloudAPI, error)
 
 	pollInterval              time.Duration
 	deleteConfirmationTimeout time.Duration
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
 func (b *backend) client() (unikraftCloudAPI, error) {
 	if b.newClient != nil {
@@ -40,47 +40,47 @@ func (b *backend) client() (unikraftCloudAPI, error) {
 	return newUnikraftCloudClient(b.cfg, b.rt)
 }
 
-func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	api, err := b.client()
 	if err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
 	if _, err := api.UserUUID(ctx); err != nil {
 		if isUnauthorized(err) {
-			return DoctorResult{}, exit(3, "provider=%s API key was rejected; check UKC_TOKEN / UNIKRAFT_CLOUD_API_KEY and the configured metro: %v", providerName, err)
+			return core.DoctorResult{}, core.Exit(3, "provider=%s API key was rejected; check UKC_TOKEN / UNIKRAFT_CLOUD_API_KEY and the configured metro: %v", providerName, err)
 		}
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
 	instances, err := api.ListInstances(ctx)
 	if err != nil {
 		if isUnauthorized(err) {
-			return DoctorResult{}, exit(3, "provider=%s API key was rejected; check UKC_TOKEN / UNIKRAFT_CLOUD_API_KEY and the configured metro: %v", providerName, err)
+			return core.DoctorResult{}, core.Exit(3, "provider=%s API key was rejected; check UKC_TOKEN / UNIKRAFT_CLOUD_API_KEY and the configured metro: %v", providerName, err)
 		}
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
 	if _, err := indexUnikraftCloudInventory(instances); err != nil {
-		return DoctorResult{}, err
+		return core.DoctorResult{}, err
 	}
-	return inventoryDoctorResult(providerName, len(instances)), nil
+	return core.InventoryDoctorResult(providerName, len(instances)), nil
 }
 
 // Warmup creates an instance from the configured OCI image and starts it.
 // Unikraft Cloud instances run their image entrypoint as a microVM service;
 // there is no exec or SSH surface, so warmup is the create-and-claim step and
 // stop deletes the instance.
-func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *backend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if req.ActionsRunner {
-		return exit(2, "--actions-runner is not supported for provider=%s", providerName)
+		return core.Exit(2, "--actions-runner is not supported for provider=%s", providerName)
 	}
 	if req.Options.Tailscale.Enabled {
-		return exit(2, "provider=%s is service-control only and does not support Tailscale options", providerName)
+		return core.Exit(2, "provider=%s is service-control only and does not support Tailscale options", providerName)
 	}
 	image := strings.TrimSpace(b.cfg.UnikraftCloud.Image)
 	if image == "" {
-		return exit(2, "provider=%s warmup requires an OCI image; set --unikraft-cloud-image, UNIKRAFT_CLOUD_IMAGE, or unikraftCloud.image", providerName)
+		return core.Exit(2, "provider=%s warmup requires an OCI image; set --unikraft-cloud-image, UNIKRAFT_CLOUD_IMAGE, or unikraftCloud.image", providerName)
 	}
 	if b.cfg.UnikraftCloud.MemoryMB < 0 {
-		return exit(2, "provider=%s memory must be zero or greater", providerName)
+		return core.Exit(2, "provider=%s memory must be zero or greater", providerName)
 	}
 	started := core.ClockNow(b.rt.Clock)
 	api, err := b.client()
@@ -105,13 +105,13 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if err != nil {
 		return err
 	}
-	slug, err := allocateClaimLeaseSlug(leaseID, req.RequestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, req.RequestedSlug)
 	if err != nil {
 		unlockSlug()
 		return err
 	}
 	createReq := createInstanceRequest{
-		Name:      leaseProviderName(leaseID, ""),
+		Name:      core.LeaseProviderName(leaseID, ""),
 		Image:     image,
 		MemoryMB:  b.cfg.UnikraftCloud.MemoryMB,
 		Autostart: true,
@@ -138,7 +138,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 			if proofErr := b.proveInstanceAbsent(proofCtx, api, resourceName, resourceName); proofErr != nil {
 				return errors.Join(createErr, fmt.Errorf("%s create rejection could not prove zero residue; non-adoptable recovery claim %s retained: %w", providerName, leaseID, proofErr))
 			}
-			if removeErr := removeLeaseClaimIfUnchanged(conflict.LeaseID, conflict); removeErr != nil {
+			if removeErr := core.RemoveLeaseClaimIfUnchanged(conflict.LeaseID, conflict); removeErr != nil {
 				return errors.Join(createErr, fmt.Errorf("remove rejected %s create claim %s: %w", providerName, leaseID, removeErr))
 			}
 			return createErr
@@ -159,7 +159,7 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	return b.finishWarmup(started, ready, instance, req)
 }
 
-func (b *backend) preflightCreateIntent(ctx context.Context, api unikraftCloudAPI, preflight LeaseClaim) (LeaseClaim, error) {
+func (b *backend) preflightCreateIntent(ctx context.Context, api unikraftCloudAPI, preflight core.LeaseClaim) (core.LeaseClaim, error) {
 	resourceName := strings.TrimSpace(preflight.Labels[ukcLabelResourceName])
 	instances, listErr := api.ListInstances(ctx)
 	if listErr == nil {
@@ -168,30 +168,30 @@ func (b *backend) preflightCreateIntent(ctx context.Context, api unikraftCloudAP
 	if listErr == nil {
 		for _, instance := range instances {
 			if instance.Name == resourceName {
-				cleanupErr := removeLeaseClaimIfUnchanged(preflight.LeaseID, preflight)
-				conflictErr := exit(4, "%s instance name %q already exists before create; refusing to claim or mutate it", providerName, resourceName)
+				cleanupErr := core.RemoveLeaseClaimIfUnchanged(preflight.LeaseID, preflight)
+				conflictErr := core.Exit(4, "%s instance name %q already exists before create; refusing to claim or mutate it", providerName, resourceName)
 				if cleanupErr != nil {
-					return LeaseClaim{}, errors.Join(conflictErr, fmt.Errorf("remove unused preflight claim %s: %w", preflight.LeaseID, cleanupErr))
+					return core.LeaseClaim{}, errors.Join(conflictErr, fmt.Errorf("remove unused preflight claim %s: %w", preflight.LeaseID, cleanupErr))
 				}
-				return LeaseClaim{}, conflictErr
+				return core.LeaseClaim{}, conflictErr
 			}
 		}
 	}
 	if listErr != nil {
-		if cleanupErr := removeLeaseClaimIfUnchanged(preflight.LeaseID, preflight); cleanupErr != nil {
-			return LeaseClaim{}, errors.Join(listErr, fmt.Errorf("remove unused preflight claim %s: %w", preflight.LeaseID, cleanupErr))
+		if cleanupErr := core.RemoveLeaseClaimIfUnchanged(preflight.LeaseID, preflight); cleanupErr != nil {
+			return core.LeaseClaim{}, errors.Join(listErr, fmt.Errorf("remove unused preflight claim %s: %w", preflight.LeaseID, cleanupErr))
 		}
-		return LeaseClaim{}, fmt.Errorf("preflight %s instance inventory: %w", providerName, listErr)
+		return core.LeaseClaim{}, fmt.Errorf("preflight %s instance inventory: %w", providerName, listErr)
 	}
 	intent, err := transitionUnikraftCloudCreateState(preflight, ukcStateCreateIntent)
 	if err != nil {
 		cause := fmt.Errorf("arm %s create intent %s: %w", providerName, preflight.LeaseID, err)
-		return LeaseClaim{}, discardUnmutatedUnikraftCloudCreateClaim(preflight, cause)
+		return core.LeaseClaim{}, discardUnmutatedUnikraftCloudCreateClaim(preflight, cause)
 	}
 	return intent, nil
 }
 
-func (b *backend) finishWarmup(started time.Time, claim LeaseClaim, instance ukcInstance, req WarmupRequest) error {
+func (b *backend) finishWarmup(started time.Time, claim core.LeaseClaim, instance ukcInstance, req core.WarmupRequest) error {
 	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s instance=%s state=%s fqdn=%s\n",
 		claim.LeaseID, claim.Slug, providerName, instance.UUID, normalizedInstanceState(instance.State), core.Blank(instanceFQDN(instance), "-"))
 	if !req.Keep {
@@ -206,18 +206,18 @@ func (b *backend) finishWarmup(started time.Time, claim LeaseClaim, instance ukc
 	})
 }
 
-func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *backend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	_ = ctx
 	if err := shared.RejectServiceRunOptions(req, providerName, "cannot run commands", "cannot open an interactive shell"); err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	if len(req.Command) == 0 {
-		return RunResult{}, exit(2, "missing command")
+		return core.RunResult{}, core.Exit(2, "missing command")
 	}
-	return RunResult{}, exit(2, "provider=%s cannot execute arbitrary run commands; Unikraft Cloud instances run their OCI image entrypoint", providerName)
+	return core.RunResult{}, core.Exit(2, "provider=%s cannot execute arbitrary run commands; Unikraft Cloud instances run their OCI image entrypoint", providerName)
 }
 
-func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	api, err := b.client()
 	if err != nil {
 		return nil, err
@@ -246,7 +246,7 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 		return nil, err
 	}
 	claimedUUIDs := make(map[string]string)
-	servers := make([]Server, 0, len(instances)+len(claims))
+	servers := make([]core.Server, 0, len(instances)+len(claims))
 	for _, snapshot := range claims {
 		if snapshot.Provider != providerName || snapshot.ProviderScope != scope {
 			continue
@@ -260,7 +260,7 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 			if err != nil {
 				return nil, err
 			}
-			current, exists, readErr := readLeaseClaimWithPresence(claim.LeaseID)
+			current, exists, readErr := core.ReadLeaseClaimWithPresence(claim.LeaseID)
 			if readErr != nil {
 				unlock()
 				return nil, readErr
@@ -285,7 +285,7 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 		}
 		instanceKey := strings.ToLower(claim.CloudID)
 		if previous, exists := claimedUUIDs[instanceKey]; exists {
-			return nil, exit(5, "%s instance %s is claimed by both %s and %s", providerName, claim.CloudID, previous, claim.LeaseID)
+			return nil, core.Exit(5, "%s instance %s is claimed by both %s and %s", providerName, claim.CloudID, previous, claim.LeaseID)
 		}
 		claimedUUIDs[instanceKey] = claim.LeaseID
 		instance, exists := instanceByUUID[instanceKey]
@@ -305,30 +305,30 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 			if _, claimed := claimedUUIDs[strings.ToLower(instance.UUID)]; claimed {
 				continue
 			}
-			servers = append(servers, unikraftCloudServer(instance, LeaseClaim{}))
+			servers = append(servers, unikraftCloudServer(instance, core.LeaseClaim{}))
 		}
 	}
 	return servers, nil
 }
 
-func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
+func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	api, err := b.client()
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	accountUUID, err := api.UserUUID(ctx)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	scope, err := unikraftCloudClaimScope(api.BaseURL(), accountUUID)
 	if err != nil {
-		return StatusView{}, err
+		return core.StatusView{}, err
 	}
 	claim, claimed, claimErr := b.resolveClaim(req.ID, scope)
 	if claimErr != nil {
 		var notClaimed *unikraftCloudClaimNotFoundError
 		if !errors.As(claimErr, &notClaimed) || !unikraftCloudUUIDPattern.MatchString(strings.TrimSpace(req.ID)) {
-			return StatusView{}, claimErr
+			return core.StatusView{}, claimErr
 		}
 	}
 	leaseID := ""
@@ -353,27 +353,27 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 		for {
 			unlock, err := lockUnikraftCloudLeaseOperation(pollCtx, claim.LeaseID)
 			if err != nil {
-				return StatusView{}, err
+				return core.StatusView{}, err
 			}
-			current, exists, readErr := readLeaseClaimWithPresence(claim.LeaseID)
+			current, exists, readErr := core.ReadLeaseClaimWithPresence(claim.LeaseID)
 			if readErr != nil {
 				unlock()
-				return StatusView{}, readErr
+				return core.StatusView{}, readErr
 			}
 			if !exists {
 				unlock()
-				return StatusView{}, exit(4, "%s lease %s no longer exists", providerName, claim.LeaseID)
+				return core.StatusView{}, core.Exit(4, "%s lease %s no longer exists", providerName, claim.LeaseID)
 			}
 			if err := validateUnikraftCloudClaim(current, scope); err != nil {
 				unlock()
-				return StatusView{}, err
+				return core.StatusView{}, err
 			}
 			claim = current
 			if claim.CloudID == "" {
 				claim, _, _, err = b.reconcileCreateIntent(pollCtx, api, current, false)
 				if err != nil {
 					unlock()
-					return StatusView{}, err
+					return core.StatusView{}, err
 				}
 			}
 			unlock()
@@ -381,7 +381,7 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 				break
 			}
 			if !req.Wait {
-				return StatusView{
+				return core.StatusView{
 					ID:         claim.LeaseID,
 					Slug:       claim.Slug,
 					Provider:   providerName,
@@ -393,11 +393,11 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 				}, nil
 			}
 			if state := claim.Labels["state"]; state == ukcStateCreatePreflight || state == ukcStateCreateConflict {
-				return StatusView{}, exit(5, "%s lease %s reached non-adoptable state=%s before an instance was created", providerName, claim.LeaseID, state)
+				return core.StatusView{}, core.Exit(5, "%s lease %s reached non-adoptable state=%s before an instance was created", providerName, claim.LeaseID, state)
 			}
 			select {
 			case <-pollCtx.Done():
-				return StatusView{}, exit(5, "timed out waiting for %s lease %s create outcome", providerName, claim.LeaseID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for %s lease %s create outcome", providerName, claim.LeaseID)
 			case <-time.After(pollInterval):
 			}
 		}
@@ -407,18 +407,18 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 		instanceID = claim.CloudID
 	}
 	if instanceID == "" {
-		return StatusView{}, exit(2, "provider=%s requires --id <lease-id, slug, or instance uuid>", providerName)
+		return core.StatusView{}, core.Exit(2, "provider=%s requires --id <lease-id, slug, or instance uuid>", providerName)
 	}
 	for {
 		instance, getErr := api.GetInstance(pollCtx, instanceID)
 		if getErr != nil {
 			if req.Wait && ctx.Err() == nil && pollCtx.Err() != nil {
-				return StatusView{}, exit(5, "timed out waiting for %s instance %s to become ready", providerName, instanceID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for %s instance %s to become ready", providerName, instanceID)
 			}
 			if ctx.Err() != nil {
-				return StatusView{}, ctx.Err()
+				return core.StatusView{}, ctx.Err()
 			}
-			return StatusView{}, getErr
+			return core.StatusView{}, getErr
 		}
 		expectedName := ""
 		expectedUUID := instanceID
@@ -427,7 +427,7 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 			expectedName = resourceName
 		}
 		if err := validateUnikraftCloudInstanceIdentity(instance, expectedUUID, expectedName); err != nil {
-			return StatusView{}, err
+			return core.StatusView{}, err
 		}
 		state := normalizedInstanceState(instance.State)
 		labels := unikraftCloudLabels(instance)
@@ -437,7 +437,7 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 			}
 			labels[ukcLabelProviderState] = state
 		}
-		view := StatusView{
+		view := core.StatusView{
 			ID:         core.Blank(leaseID, instance.UUID),
 			Slug:       slug,
 			Provider:   providerName,
@@ -454,20 +454,20 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 			return view, nil
 		}
 		if unikraftCloudTerminalState(state) {
-			return StatusView{}, exit(5, "%s instance %s reached terminal state=%s before becoming ready", providerName, instanceID, state)
+			return core.StatusView{}, core.Exit(5, "%s instance %s reached terminal state=%s before becoming ready", providerName, instanceID, state)
 		}
 		select {
 		case <-pollCtx.Done():
 			if ctx.Err() == nil {
-				return StatusView{}, exit(5, "timed out waiting for %s instance %s to become ready", providerName, instanceID)
+				return core.StatusView{}, core.Exit(5, "timed out waiting for %s instance %s to become ready", providerName, instanceID)
 			}
-			return StatusView{}, pollCtx.Err()
+			return core.StatusView{}, pollCtx.Err()
 		case <-time.After(pollInterval):
 		}
 	}
 }
 
-func (b *backend) Stop(ctx context.Context, req StopRequest) error {
+func (b *backend) Stop(ctx context.Context, req core.StopRequest) error {
 	api, err := b.client()
 	if err != nil {
 		return err
@@ -489,12 +489,12 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 		return err
 	}
 	defer unlock()
-	claim, exists, err := readLeaseClaimWithPresence(snapshot.LeaseID)
+	claim, exists, err := core.ReadLeaseClaimWithPresence(snapshot.LeaseID)
 	if err != nil {
 		return err
 	}
 	if !exists {
-		return exit(4, "%s lease %s no longer exists", providerName, snapshot.LeaseID)
+		return core.Exit(4, "%s lease %s no longer exists", providerName, snapshot.LeaseID)
 	}
 	if err := validateUnikraftCloudClaim(claim, scope); err != nil {
 		return err
@@ -521,7 +521,7 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 	return nil
 }
 
-func unikraftCloudServer(instance ukcInstance, claim LeaseClaim) Server {
+func unikraftCloudServer(instance ukcInstance, claim core.LeaseClaim) core.Server {
 	labels := unikraftCloudLabels(instance)
 	if claim.LeaseID != "" {
 		providerState := labels["state"]
@@ -530,7 +530,7 @@ func unikraftCloudServer(instance ukcInstance, claim LeaseClaim) Server {
 		}
 		labels[ukcLabelProviderState] = providerState
 	}
-	return Server{
+	return core.Server{
 		CloudID:  instance.UUID,
 		Provider: providerName,
 		Name:     core.Blank(instance.Name, instance.UUID),

--- a/internal/providers/unikraftcloud/backend_test.go
+++ b/internal/providers/unikraftcloud/backend_test.go
@@ -143,7 +143,7 @@ func (f *fakeUnikraftCloudAPI) DeleteInstance(_ context.Context, id string) (ukc
 }
 
 func testBackend(api unikraftCloudAPI, stdout, stderr *bytes.Buffer) *backend {
-	cfg := Config{Provider: providerName}
+	cfg := core.Config{Provider: providerName}
 	cfg.UnikraftCloud.Image = "unikraft.org/nginx:latest"
 	cfg.UnikraftCloud.MemoryMB = 256
 	if stdout == nil {
@@ -155,8 +155,8 @@ func testBackend(api unikraftCloudAPI, stdout, stderr *bytes.Buffer) *backend {
 	return &backend{
 		spec:                      Provider{}.Spec(),
 		cfg:                       cfg,
-		rt:                        Runtime{Stdout: stdout, Stderr: stderr},
-		newClient:                 func(Config, Runtime) (unikraftCloudAPI, error) { return api, nil },
+		rt:                        core.Runtime{Stdout: stdout, Stderr: stderr},
+		newClient:                 func(core.Config, core.Runtime) (unikraftCloudAPI, error) { return api, nil },
 		pollInterval:              time.Millisecond,
 		deleteConfirmationTimeout: 20 * time.Millisecond,
 	}
@@ -175,7 +175,7 @@ func testClaimScope(t *testing.T, baseURL string) string {
 	return scope
 }
 
-func onlyTestClaim(t *testing.T) LeaseClaim {
+func onlyTestClaim(t *testing.T) core.LeaseClaim {
 	t.Helper()
 	claims, err := listUnikraftCloudLeaseClaims()
 	if err != nil {
@@ -203,7 +203,7 @@ func TestWarmupCreatesInstanceAndClaimsLease(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	b := testBackend(api, &stdout, &stderr)
 
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	if len(api.created) != 1 {
@@ -237,7 +237,7 @@ func TestWarmupErrors(t *testing.T) {
 	for _, test := range []struct {
 		name            string
 		mutate          func(b *backend, api *fakeUnikraftCloudAPI)
-		req             WarmupRequest
+		req             core.WarmupRequest
 		wantErrContains string
 		wantExitCode    int
 	}{
@@ -249,13 +249,13 @@ func TestWarmupErrors(t *testing.T) {
 		},
 		{
 			name:            "actions runner rejected",
-			req:             WarmupRequest{ActionsRunner: true},
+			req:             core.WarmupRequest{ActionsRunner: true},
 			wantErrContains: "--actions-runner is not supported",
 			wantExitCode:    2,
 		},
 		{
 			name: "tailscale rejected",
-			req: WarmupRequest{Options: core.LeaseOptions{
+			req: core.WarmupRequest{Options: core.LeaseOptions{
 				Tailscale: core.TailscaleConfig{Enabled: true},
 			}},
 			wantErrContains: "does not support Tailscale",
@@ -278,7 +278,7 @@ func TestWarmupErrors(t *testing.T) {
 			}
 			req := test.req
 			if req.Repo.Root == "" {
-				req.Repo = Repo{Root: t.TempDir(), Name: "demo"}
+				req.Repo = core.Repo{Root: t.TempDir(), Name: "demo"}
 			}
 			err := b.Warmup(context.Background(), req)
 			if err == nil {
@@ -288,7 +288,7 @@ func TestWarmupErrors(t *testing.T) {
 				t.Fatalf("err = %v, want containing %q", err, test.wantErrContains)
 			}
 			if test.wantExitCode != 0 {
-				var exitErr ExitError
+				var exitErr core.ExitError
 				if !errors.As(err, &exitErr) || exitErr.Code != test.wantExitCode {
 					t.Fatalf("err = %#v, want exit code %d", err, test.wantExitCode)
 				}
@@ -308,8 +308,8 @@ func TestWarmupDoesNotCreateWhenIntentCannotBePersisted(t *testing.T) {
 		createResult: ukcInstance{UUID: testInstanceUUID, State: "running"},
 	}
 	b := testBackend(api, nil, nil)
-	err := b.Warmup(context.Background(), WarmupRequest{
-		Repo: Repo{Root: t.TempDir(), Name: "demo"},
+	err := b.Warmup(context.Background(), core.WarmupRequest{
+		Repo: core.Repo{Root: t.TempDir(), Name: "demo"},
 	})
 	if err == nil {
 		t.Fatal("Warmup succeeded, want claim write failure")
@@ -322,28 +322,28 @@ func TestWarmupDoesNotCreateWhenIntentCannotBePersisted(t *testing.T) {
 func TestRunIsRejected(t *testing.T) {
 	for _, tc := range []struct {
 		name string
-		req  RunRequest
+		req  core.RunRequest
 		want string
 	}{
-		{name: "keep first", req: RunRequest{Keep: true, Reclaim: true}, want: "provider=unikraft-cloud cannot run commands; --keep is not supported"},
-		{name: "reclaim", req: RunRequest{Reclaim: true}, want: "provider=unikraft-cloud cannot run commands; --reclaim is not supported"},
-		{name: "no sync", req: RunRequest{}, want: "provider=unikraft-cloud does not support workspace sync; pass --no-sync"},
-		{name: "shell", req: RunRequest{NoSync: true, ShellMode: true}, want: "provider=unikraft-cloud cannot open an interactive shell; --shell is not supported"},
-		{name: "env summary without env", req: RunRequest{NoSync: true, EnvSummary: true}, want: "provider=unikraft-cloud cannot forward per-run environment variables"},
-		{name: "missing command", req: RunRequest{NoSync: true}, want: "missing command"},
-		{name: "command", req: RunRequest{NoSync: true, Command: []string{"true"}}, want: "provider=unikraft-cloud cannot execute arbitrary run commands; Unikraft Cloud instances run their OCI image entrypoint"},
-		{name: "implicit env", req: RunRequest{NoSync: true, Env: map[string]string{"CI": "true"}, Command: []string{"true"}}, want: "provider=unikraft-cloud cannot execute arbitrary run commands; Unikraft Cloud instances run their OCI image entrypoint"},
+		{name: "keep first", req: core.RunRequest{Keep: true, Reclaim: true}, want: "provider=unikraft-cloud cannot run commands; --keep is not supported"},
+		{name: "reclaim", req: core.RunRequest{Reclaim: true}, want: "provider=unikraft-cloud cannot run commands; --reclaim is not supported"},
+		{name: "no sync", req: core.RunRequest{}, want: "provider=unikraft-cloud does not support workspace sync; pass --no-sync"},
+		{name: "shell", req: core.RunRequest{NoSync: true, ShellMode: true}, want: "provider=unikraft-cloud cannot open an interactive shell; --shell is not supported"},
+		{name: "env summary without env", req: core.RunRequest{NoSync: true, EnvSummary: true}, want: "provider=unikraft-cloud cannot forward per-run environment variables"},
+		{name: "missing command", req: core.RunRequest{NoSync: true}, want: "missing command"},
+		{name: "command", req: core.RunRequest{NoSync: true, Command: []string{"true"}}, want: "provider=unikraft-cloud cannot execute arbitrary run commands; Unikraft Cloud instances run their OCI image entrypoint"},
+		{name: "implicit env", req: core.RunRequest{NoSync: true, Env: map[string]string{"CI": "true"}, Command: []string{"true"}}, want: "provider=unikraft-cloud cannot execute arbitrary run commands; Unikraft Cloud instances run their OCI image entrypoint"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			b := &backend{newClient: func(Config, Runtime) (unikraftCloudAPI, error) {
+			b := &backend{newClient: func(core.Config, core.Runtime) (unikraftCloudAPI, error) {
 				panic("Run must not request a provider API client")
 			}}
 			result, err := b.Run(context.Background(), tc.req)
-			var public ExitError
+			var public core.ExitError
 			if !errors.As(err, &public) || public.Code != 2 || public.Message != tc.want {
 				t.Fatalf("err=%v, want exit2 %q", err, tc.want)
 			}
-			if !reflect.DeepEqual(result, RunResult{}) {
+			if !reflect.DeepEqual(result, core.RunResult{}) {
 				t.Fatalf("result=%#v, want zero result", result)
 			}
 		})
@@ -367,7 +367,7 @@ func TestStatusReportsInstanceState(t *testing.T) {
 		}},
 	}
 	b := testBackend(api, nil, nil)
-	view, err := b.Status(context.Background(), StatusRequest{ID: testInstanceUUID})
+	view, err := b.Status(context.Background(), core.StatusRequest{ID: testInstanceUUID})
 	if err != nil {
 		t.Fatalf("Status: %v", err)
 	}
@@ -390,10 +390,10 @@ func TestStatusResolvesClaimedSlug(t *testing.T) {
 	}
 	var stdout bytes.Buffer
 	b := testBackend(api, &stdout, nil)
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}, RequestedSlug: "my-ukc"}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}, RequestedSlug: "my-ukc"}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
-	view, err := b.Status(context.Background(), StatusRequest{ID: "my-ukc"})
+	view, err := b.Status(context.Background(), core.StatusRequest{ID: "my-ukc"})
 	if err != nil {
 		t.Fatalf("Status: %v", err)
 	}
@@ -417,7 +417,7 @@ func TestStatusErrors(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			api := &fakeUnikraftCloudAPI{baseURL: "https://api.fra.unikraft.cloud", getErr: test.getErr}
 			b := testBackend(api, nil, nil)
-			_, err := b.Status(context.Background(), StatusRequest{ID: test.id})
+			_, err := b.Status(context.Background(), core.StatusRequest{ID: test.id})
 			if err == nil {
 				t.Fatal("Status succeeded, want error")
 			}
@@ -439,7 +439,7 @@ func TestStatusWaitPollsUntilRunning(t *testing.T) {
 		},
 	}
 	b := testBackend(api, nil, nil)
-	view, err := b.Status(context.Background(), StatusRequest{ID: testInstanceUUID, Wait: true, WaitTimeout: 10 * time.Second})
+	view, err := b.Status(context.Background(), core.StatusRequest{ID: testInstanceUUID, Wait: true, WaitTimeout: 10 * time.Second})
 	if err != nil {
 		t.Fatalf("Status: %v", err)
 	}
@@ -458,7 +458,7 @@ func TestStatusWaitTimesOut(t *testing.T) {
 		getResults: []ukcInstance{{UUID: testInstanceUUID, State: "starting"}},
 	}
 	b := testBackend(api, nil, nil)
-	_, err := b.Status(context.Background(), StatusRequest{ID: testInstanceUUID, Wait: true, WaitTimeout: 300 * time.Millisecond})
+	_, err := b.Status(context.Background(), core.StatusRequest{ID: testInstanceUUID, Wait: true, WaitTimeout: 300 * time.Millisecond})
 	if err == nil || !strings.Contains(err.Error(), "timed out waiting") {
 		t.Fatalf("err = %v, want wait timeout", err)
 	}
@@ -475,11 +475,11 @@ func TestListMergesRemoteInstancesWithLocalClaims(t *testing.T) {
 		},
 	}
 	b := testBackend(api, nil, nil)
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}, RequestedSlug: "my-ukc"}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}, RequestedSlug: "my-ukc"}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	api.listResult[0].Name = api.createResult.Name
-	servers, err := b.List(context.Background(), ListRequest{})
+	servers, err := b.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -493,7 +493,7 @@ func TestListMergesRemoteInstancesWithLocalClaims(t *testing.T) {
 	if servers[0].Labels["lease"] != claim.LeaseID || servers[0].Labels["slug"] != "my-ukc" {
 		t.Fatalf("servers[0].Labels = %#v", servers[0].Labels)
 	}
-	all, err := b.List(context.Background(), ListRequest{All: true})
+	all, err := b.List(context.Background(), core.ListRequest{All: true})
 	if err != nil || len(all) != 2 || all[1].Labels["lease"] != "" {
 		t.Fatalf("all = %#v err=%v, want claimed plus unclaimed", all, err)
 	}
@@ -506,7 +506,7 @@ func TestListPropagatesAPIError(t *testing.T) {
 		listErr: &unikraftCloudAPIError{StatusCode: http.StatusUnauthorized, Message: "invalid token"},
 	}
 	b := testBackend(api, nil, nil)
-	if _, err := b.List(context.Background(), ListRequest{}); err == nil || !strings.Contains(err.Error(), "invalid token") {
+	if _, err := b.List(context.Background(), core.ListRequest{}); err == nil || !strings.Contains(err.Error(), "invalid token") {
 		t.Fatalf("err = %v, want invalid token", err)
 	}
 }
@@ -520,7 +520,7 @@ func TestListDoesNotPresentUnboundClaimAsOwned(t *testing.T) {
 	}
 	b := testBackend(api, nil, nil)
 	repoRoot := t.TempDir()
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: repoRoot, Name: "demo"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: repoRoot, Name: "demo"}}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	leaseID := onlyTestClaim(t).LeaseID
@@ -529,7 +529,7 @@ func TestListDoesNotPresentUnboundClaimAsOwned(t *testing.T) {
 		t.Fatalf("write unbound claim: %v", err)
 	}
 
-	if _, err := b.List(context.Background(), ListRequest{}); err == nil || !strings.Contains(err.Error(), "ownership labels") {
+	if _, err := b.List(context.Background(), core.ListRequest{}); err == nil || !strings.Contains(err.Error(), "ownership labels") {
 		t.Fatalf("List err = %v, want invalid legacy claim rejection", err)
 	}
 }
@@ -542,11 +542,11 @@ func TestStopDeletesClaimedInstance(t *testing.T) {
 	}
 	var stderr bytes.Buffer
 	b := testBackend(api, nil, &stderr)
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}, RequestedSlug: "my-ukc"}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}, RequestedSlug: "my-ukc"}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	claim := onlyTestClaim(t)
-	if err := b.Stop(context.Background(), StopRequest{ID: "my-ukc"}); err != nil {
+	if err := b.Stop(context.Background(), core.StopRequest{ID: "my-ukc"}); err != nil {
 		t.Fatalf("Stop: %v", err)
 	}
 	if len(api.deletedIDs) != 1 || api.deletedIDs[0] != testInstanceUUID {
@@ -555,7 +555,7 @@ func TestStopDeletesClaimedInstance(t *testing.T) {
 	if !strings.Contains(stderr.String(), "released lease="+claim.LeaseID) {
 		t.Fatalf("stderr = %q", stderr.String())
 	}
-	if stored, err := readLeaseClaim(claim.LeaseID); err == nil && stored.LeaseID != "" {
+	if stored, err := core.ReadLeaseClaim(claim.LeaseID); err == nil && stored.LeaseID != "" {
 		t.Fatalf("claim = %#v, want removed", stored)
 	}
 }
@@ -564,11 +564,11 @@ func TestStopRequiresLocalClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	api := &fakeUnikraftCloudAPI{baseURL: "https://api.fra.unikraft.cloud"}
 	b := testBackend(api, nil, nil)
-	err := b.Stop(context.Background(), StopRequest{ID: testInstanceUUID})
+	err := b.Stop(context.Background(), core.StopRequest{ID: testInstanceUUID})
 	if err == nil {
 		t.Fatal("Stop succeeded, want unclaimed error")
 	}
-	var exitErr ExitError
+	var exitErr core.ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 4 {
 		t.Fatalf("err = %#v, want exit code 4", err)
 	}
@@ -585,7 +585,7 @@ func TestStopRejectsClaimWithoutExactInstanceBinding(t *testing.T) {
 	}
 	b := testBackend(api, nil, nil)
 	repoRoot := t.TempDir()
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: repoRoot, Name: "demo"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: repoRoot, Name: "demo"}}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	leaseID := onlyTestClaim(t).LeaseID
@@ -594,7 +594,7 @@ func TestStopRejectsClaimWithoutExactInstanceBinding(t *testing.T) {
 		t.Fatalf("write unbound claim: %v", err)
 	}
 
-	err := b.Stop(context.Background(), StopRequest{ID: leaseID})
+	err := b.Stop(context.Background(), core.StopRequest{ID: leaseID})
 	if err == nil || !strings.Contains(err.Error(), "ownership labels") {
 		t.Fatalf("Stop err = %v, want incomplete legacy claim rejection", err)
 	}
@@ -611,12 +611,12 @@ func TestStopRemovesClaimWhenInstanceAlreadyGone(t *testing.T) {
 	}
 	var stderr bytes.Buffer
 	b := testBackend(api, nil, &stderr)
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	claim := onlyTestClaim(t)
 	api.deleted = map[string]bool{testInstanceUUID: true}
-	if err := b.Stop(context.Background(), StopRequest{ID: claim.LeaseID}); err != nil {
+	if err := b.Stop(context.Background(), core.StopRequest{ID: claim.LeaseID}); err != nil {
 		t.Fatalf("Stop: %v", err)
 	}
 	if len(api.deletedIDs) != 0 {
@@ -625,7 +625,7 @@ func TestStopRemovesClaimWhenInstanceAlreadyGone(t *testing.T) {
 	if !strings.Contains(stderr.String(), "already gone") {
 		t.Fatalf("stderr = %q", stderr.String())
 	}
-	if stored, err := readLeaseClaim(claim.LeaseID); err == nil && stored.LeaseID != "" {
+	if stored, err := core.ReadLeaseClaim(claim.LeaseID); err == nil && stored.LeaseID != "" {
 		t.Fatalf("claim = %#v, want removed", stored)
 	}
 }
@@ -638,16 +638,16 @@ func TestStopPropagatesDeleteError(t *testing.T) {
 		deleteErr:    &unikraftCloudAPIError{StatusCode: http.StatusInternalServerError, Message: "backend unavailable"},
 	}
 	b := testBackend(api, nil, nil)
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	claim := onlyTestClaim(t)
-	err := b.Stop(context.Background(), StopRequest{ID: claim.LeaseID})
+	err := b.Stop(context.Background(), core.StopRequest{ID: claim.LeaseID})
 	if err == nil || !strings.Contains(err.Error(), "backend unavailable") {
 		t.Fatalf("err = %v, want delete failure", err)
 	}
 	// The claim must survive so the user can retry stop.
-	if stored, readErr := readLeaseClaim(claim.LeaseID); readErr != nil || stored.LeaseID == "" {
+	if stored, readErr := core.ReadLeaseClaim(claim.LeaseID); readErr != nil || stored.LeaseID == "" {
 		t.Fatalf("claim = %#v err = %v, want retained claim", stored, readErr)
 	}
 }
@@ -659,12 +659,12 @@ func TestStopRejectsClaimFromDifferentEndpoint(t *testing.T) {
 		createResult: ukcInstance{UUID: testInstanceUUID, State: "running"},
 	}
 	b := testBackend(api, nil, nil)
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	claim := onlyTestClaim(t)
 	api.baseURL = "https://api.dal.unikraft.cloud"
-	err := b.Stop(context.Background(), StopRequest{ID: claim.LeaseID})
+	err := b.Stop(context.Background(), core.StopRequest{ID: claim.LeaseID})
 	if err == nil || !strings.Contains(err.Error(), "different API endpoint or account") {
 		t.Fatalf("err = %v, want scope mismatch", err)
 	}
@@ -693,7 +693,7 @@ func TestWarmupPublishesCreateIntentBeforeProviderMutation(t *testing.T) {
 		}
 	}
 	b := testBackend(api, nil, nil)
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	if len(api.created) != 1 || !strings.HasPrefix(api.created[0].Name, "crabbox-ukc-") {
@@ -710,7 +710,7 @@ func TestWarmupReconcilesAmbiguousCreateWithoutSecondPost(t *testing.T) {
 		createBeforeError: true,
 	}
 	b := testBackend(api, nil, nil)
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	if len(api.created) != 1 {
@@ -729,7 +729,7 @@ func TestWarmupRetainsIntentWhenCreateOutcomeIsAmbiguous(t *testing.T) {
 		createErr: errors.New("connection reset after request"),
 	}
 	b := testBackend(api, nil, nil)
-	err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}})
+	err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}})
 	if err == nil || !strings.Contains(err.Error(), "recovery claim") {
 		t.Fatalf("Warmup err = %v", err)
 	}
@@ -747,7 +747,7 @@ func TestWarmupRejectsNegativeMemoryBeforeProviderAccess(t *testing.T) {
 	api := &fakeUnikraftCloudAPI{baseURL: "https://api.fra.unikraft.cloud"}
 	b := testBackend(api, nil, nil)
 	b.cfg.UnikraftCloud.MemoryMB = -1
-	err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}})
+	err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}})
 	if err == nil || !strings.Contains(err.Error(), "memory must be zero or greater") {
 		t.Fatalf("Warmup err = %v", err)
 	}
@@ -764,19 +764,19 @@ func TestStopRejectsClaimFromDifferentAccount(t *testing.T) {
 		createResult: ukcInstance{UUID: testInstanceUUID, State: "running"},
 	}
 	b := testBackend(api, nil, nil)
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	claim := onlyTestClaim(t)
 	api.userUUID = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
-	err := b.Stop(context.Background(), StopRequest{ID: claim.LeaseID})
+	err := b.Stop(context.Background(), core.StopRequest{ID: claim.LeaseID})
 	if err == nil || !strings.Contains(err.Error(), "different API endpoint or account") {
 		t.Fatalf("Stop err = %v", err)
 	}
 	if len(api.deletedIDs) != 0 {
 		t.Fatalf("deletedIDs = %#v, want none", api.deletedIDs)
 	}
-	if stored, exists, readErr := readLeaseClaimWithPresence(claim.LeaseID); readErr != nil || !exists || stored.CloudID != testInstanceUUID {
+	if stored, exists, readErr := core.ReadLeaseClaimWithPresence(claim.LeaseID); readErr != nil || !exists || stored.CloudID != testInstanceUUID {
 		t.Fatalf("stored claim = %#v exists=%v err=%v", stored, exists, readErr)
 	}
 }
@@ -789,28 +789,28 @@ func TestStopRetainsAcceptedClaimUntilStrongAbsenceProof(t *testing.T) {
 		retainAfterDelete: true,
 	}
 	b := testBackend(api, nil, nil)
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	claim := onlyTestClaim(t)
-	if err := b.Stop(context.Background(), StopRequest{ID: claim.LeaseID}); err == nil || !strings.Contains(err.Error(), "absence is unconfirmed") {
+	if err := b.Stop(context.Background(), core.StopRequest{ID: claim.LeaseID}); err == nil || !strings.Contains(err.Error(), "absence is unconfirmed") {
 		t.Fatalf("first Stop err = %v", err)
 	}
 	accepted := onlyTestClaim(t)
 	if accepted.Labels["state"] != ukcStateDeleteAccepted || len(api.deletedIDs) != 1 {
 		t.Fatalf("accepted = %#v deleted=%#v", accepted, api.deletedIDs)
 	}
-	if err := b.Stop(context.Background(), StopRequest{ID: claim.LeaseID}); err == nil {
+	if err := b.Stop(context.Background(), core.StopRequest{ID: claim.LeaseID}); err == nil {
 		t.Fatal("second Stop succeeded while instance remains visible")
 	}
 	if len(api.deletedIDs) != 1 {
 		t.Fatalf("accepted delete replayed: %#v", api.deletedIDs)
 	}
 	api.deleted = map[string]bool{testInstanceUUID: true}
-	if err := b.Stop(context.Background(), StopRequest{ID: claim.LeaseID}); err != nil {
+	if err := b.Stop(context.Background(), core.StopRequest{ID: claim.LeaseID}); err != nil {
 		t.Fatalf("final Stop: %v", err)
 	}
-	if _, exists, err := readLeaseClaimWithPresence(claim.LeaseID); err != nil || exists {
+	if _, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID); err != nil || exists {
 		t.Fatalf("claim exists=%v err=%v, want removed", exists, err)
 	}
 }
@@ -822,20 +822,20 @@ func TestStopDoesNotTrustNotFoundWhenInventoryStillContainsInstance(t *testing.T
 		createResult: ukcInstance{UUID: testInstanceUUID, State: "running"},
 	}
 	b := testBackend(api, nil, nil)
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	claim := onlyTestClaim(t)
 	api.listResult = []ukcInstance{api.createResult}
 	api.getErr = notFoundErr()
-	err := b.Stop(context.Background(), StopRequest{ID: claim.LeaseID})
+	err := b.Stop(context.Background(), core.StopRequest{ID: claim.LeaseID})
 	if err == nil {
 		t.Fatal("Stop succeeded on contradictory absence evidence")
 	}
 	if len(api.deletedIDs) != 0 {
 		t.Fatalf("deletedIDs = %#v, want none", api.deletedIDs)
 	}
-	if _, exists, readErr := readLeaseClaimWithPresence(claim.LeaseID); readErr != nil || !exists {
+	if _, exists, readErr := core.ReadLeaseClaimWithPresence(claim.LeaseID); readErr != nil || !exists {
 		t.Fatalf("claim exists=%v err=%v, want retained", exists, readErr)
 	}
 }
@@ -849,17 +849,17 @@ func TestStopReconcilesAmbiguousDeleteAfterStrongAbsenceProof(t *testing.T) {
 		removeBeforeDeleteErr: true,
 	}
 	b := testBackend(api, nil, nil)
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	claim := onlyTestClaim(t)
-	if err := b.Stop(context.Background(), StopRequest{ID: claim.LeaseID}); err != nil {
+	if err := b.Stop(context.Background(), core.StopRequest{ID: claim.LeaseID}); err != nil {
 		t.Fatalf("Stop: %v", err)
 	}
 	if len(api.deletedIDs) != 1 {
 		t.Fatalf("deletedIDs = %#v", api.deletedIDs)
 	}
-	if _, exists, err := readLeaseClaimWithPresence(claim.LeaseID); err != nil || exists {
+	if _, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID); err != nil || exists {
 		t.Fatalf("claim exists=%v err=%v, want removed", exists, err)
 	}
 }
@@ -875,7 +875,7 @@ func TestConcurrentWarmupsReserveDistinctRequestedSlugs(t *testing.T) {
 		api := api
 		go func() {
 			b := testBackend(api, nil, nil)
-			errCh <- b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}, RequestedSlug: "same-slug"})
+			errCh <- b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}, RequestedSlug: "same-slug"})
 		}()
 	}
 	for range apis {
@@ -900,7 +900,7 @@ func TestStatusWaitFailsImmediatelyOnTerminalState(t *testing.T) {
 	}
 	b := testBackend(api, nil, nil)
 	started := time.Now()
-	_, err := b.Status(context.Background(), StatusRequest{ID: testInstanceUUID, Wait: true, WaitTimeout: time.Second})
+	_, err := b.Status(context.Background(), core.StatusRequest{ID: testInstanceUUID, Wait: true, WaitTimeout: time.Second})
 	if err == nil || !strings.Contains(err.Error(), "terminal state=stopped") {
 		t.Fatalf("Status err = %v", err)
 	}
@@ -917,21 +917,21 @@ func TestCleanupResumesAcceptedDeletionWithoutReissuingDelete(t *testing.T) {
 		retainAfterDelete: true,
 	}
 	b := testBackend(api, nil, nil)
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	claim := onlyTestClaim(t)
-	if err := b.Stop(context.Background(), StopRequest{ID: claim.LeaseID}); err == nil {
+	if err := b.Stop(context.Background(), core.StopRequest{ID: claim.LeaseID}); err == nil {
 		t.Fatal("Stop succeeded without absence proof")
 	}
 	api.deleted = map[string]bool{testInstanceUUID: true}
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	if len(api.deletedIDs) != 1 {
 		t.Fatalf("accepted delete replayed: %#v", api.deletedIDs)
 	}
-	if _, exists, err := readLeaseClaimWithPresence(claim.LeaseID); err != nil || exists {
+	if _, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID); err != nil || exists {
 		t.Fatalf("claim exists=%v err=%v, want removed", exists, err)
 	}
 }
@@ -964,7 +964,7 @@ func TestDoctorReportsInventory(t *testing.T) {
 				listResult: []ukcInstance{{UUID: testInstanceUUID, State: "running"}},
 			}
 			b := testBackend(api, nil, nil)
-			result, err := b.Doctor(context.Background(), DoctorRequest{})
+			result, err := b.Doctor(context.Background(), core.DoctorRequest{})
 			if test.wantErr {
 				if err == nil || !strings.Contains(err.Error(), test.wantErrContains) {
 					t.Fatalf("err = %v, want containing %q", err, test.wantErrContains)

--- a/internal/providers/unikraftcloud/client.go
+++ b/internal/providers/unikraftcloud/client.go
@@ -141,10 +141,10 @@ var (
 	unikraftCloudUUIDPattern  = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 )
 
-func newUnikraftCloudClient(cfg Config, rt Runtime) (unikraftCloudAPI, error) {
+func newUnikraftCloudClient(cfg core.Config, rt core.Runtime) (unikraftCloudAPI, error) {
 	apiKey := strings.TrimSpace(cfg.UnikraftCloud.APIKey)
 	if apiKey == "" {
-		return nil, exit(2, "provider=%s requires an API key; set UKC_TOKEN, UNIKRAFT_CLOUD_API_KEY, or unikraftCloud.apiKey", providerName)
+		return nil, core.Exit(2, "provider=%s requires an API key; set UKC_TOKEN, UNIKRAFT_CLOUD_API_KEY, or unikraftCloud.apiKey", providerName)
 	}
 	baseURL, err := unikraftCloudBaseURL(cfg)
 	if err != nil {
@@ -163,16 +163,16 @@ func newUnikraftCloudClient(cfg Config, rt Runtime) (unikraftCloudAPI, error) {
 
 // unikraftCloudBaseURL derives the metro endpoint unless an explicit API URL
 // override is configured (tests, self-hosted gateways).
-func unikraftCloudBaseURL(cfg Config) (string, error) {
+func unikraftCloudBaseURL(cfg core.Config) (string, error) {
 	if raw := strings.TrimSpace(cfg.UnikraftCloud.APIURL); raw != "" {
 		return validateUnikraftCloudAPIURL(raw)
 	}
 	metro := strings.ToLower(strings.TrimSpace(cfg.UnikraftCloud.Metro))
 	if metro == "" {
-		return "", exit(2, "provider=%s requires a metro (for example fra, dal, sin, was, sfo) or an explicit API URL", providerName)
+		return "", core.Exit(2, "provider=%s requires a metro (for example fra, dal, sin, was, sfo) or an explicit API URL", providerName)
 	}
 	if !unikraftCloudMetroPattern.MatchString(metro) {
-		return "", exit(2, "provider=%s metro %q is invalid; use a short lowercase identifier such as fra", providerName, metro)
+		return "", core.Exit(2, "provider=%s metro %q is invalid; use a short lowercase identifier such as fra", providerName, metro)
 	}
 	return "https://api." + metro + ".unikraft.cloud", nil
 }
@@ -180,17 +180,17 @@ func unikraftCloudBaseURL(cfg Config) (string, error) {
 func validateUnikraftCloudAPIURL(raw string) (string, error) {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {
-		return "", exit(2, "provider=%s API URL must be an absolute HTTPS URL", providerName)
+		return "", core.Exit(2, "provider=%s API URL must be an absolute HTTPS URL", providerName)
 	}
 	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", exit(2, "provider=%s API URL must not contain userinfo, query parameters, or a fragment", providerName)
+		return "", core.Exit(2, "provider=%s API URL must not contain userinfo, query parameters, or a fragment", providerName)
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
 	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
-		return "", exit(2, "provider=%s API URL must use HTTPS except for loopback development endpoints", providerName)
+		return "", core.Exit(2, "provider=%s API URL must use HTTPS except for loopback development endpoints", providerName)
 	}
 	if escapedPath := parsed.EscapedPath(); escapedPath != "" && escapedPath != "/" {
-		return "", exit(2, "provider=%s API URL must identify the endpoint root without a path", providerName)
+		return "", core.Exit(2, "provider=%s API URL must identify the endpoint root without a path", providerName)
 	}
 	parsed.Path = ""
 	parsed.RawPath = ""
@@ -206,7 +206,7 @@ func secureUnikraftCloudHTTPClient(source *http.Client, baseURL string) *http.Cl
 	trusted, _ := url.Parse(baseURL)
 	originalCheckRedirect := source.CheckRedirect
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameUnikraftCloudOrigin(trusted, req.URL) {
+		if !core.SameHTTPOrigin(trusted, req.URL) {
 			return &unikraftCloudRedirectError{origin: unikraftCloudRedirectOrigin(req.URL)}
 		}
 		if !withinUnikraftCloudAPIPath(trusted, req.URL) {
@@ -251,10 +251,6 @@ func isUnikraftCloudMutation(method string) bool {
 	default:
 		return false
 	}
-}
-
-func sameUnikraftCloudOrigin(a, b *url.URL) bool {
-	return core.SameHTTPOrigin(a, b)
 }
 
 type unikraftCloudRedirectError struct {
@@ -343,7 +339,7 @@ func (c *unikraftCloudClient) CreateInstance(ctx context.Context, req createInst
 		return ukcInstance{}, err
 	}
 	if req.Name != "" && instance.Name != req.Name {
-		return ukcInstance{}, exit(5, "%s create instance returned an unexpected instance name", providerName)
+		return ukcInstance{}, core.Exit(5, "%s create instance returned an unexpected instance name", providerName)
 	}
 	return instance, nil
 }
@@ -391,7 +387,7 @@ func (c *unikraftCloudClient) DeleteInstance(ctx context.Context, id string) (uk
 		return ukcInstance{}, err
 	}
 	if !strings.EqualFold(strings.TrimSpace(instance.ItemStatus), "success") {
-		return ukcInstance{}, exit(5, "%s delete instance returned an item without explicit success", providerName)
+		return ukcInstance{}, core.Exit(5, "%s delete instance returned an item without explicit success", providerName)
 	}
 	return instance, nil
 }
@@ -497,11 +493,11 @@ func (c *unikraftCloudClient) doJSON(ctx context.Context, method, apiPath string
 
 func requireExactUnikraftCloudInstance(operation, requestedID string, instances []ukcInstance) (ukcInstance, error) {
 	if len(instances) != 1 {
-		return ukcInstance{}, exit(5, "%s %s returned %d instances; expected exactly one", providerName, operation, len(instances))
+		return ukcInstance{}, core.Exit(5, "%s %s returned %d instances; expected exactly one", providerName, operation, len(instances))
 	}
 	instance := instances[0]
 	if !unikraftCloudUUIDPattern.MatchString(instance.UUID) {
-		return ukcInstance{}, exit(5, "%s %s returned an invalid instance uuid", providerName, operation)
+		return ukcInstance{}, core.Exit(5, "%s %s returned an invalid instance uuid", providerName, operation)
 	}
 	if requestedID != "" {
 		matches := instance.Name == requestedID
@@ -509,7 +505,7 @@ func requireExactUnikraftCloudInstance(operation, requestedID string, instances 
 			matches = strings.EqualFold(instance.UUID, requestedID)
 		}
 		if !matches {
-			return ukcInstance{}, exit(5, "%s %s returned an unexpected instance identity", providerName, operation)
+			return ukcInstance{}, core.Exit(5, "%s %s returned an unexpected instance identity", providerName, operation)
 		}
 	}
 	return instance, nil

--- a/internal/providers/unikraftcloud/client_test.go
+++ b/internal/providers/unikraftcloud/client_test.go
@@ -7,19 +7,21 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func testClientConfig(apiURL string) Config {
-	cfg := Config{}
+func testClientConfig(apiURL string) core.Config {
+	cfg := core.Config{}
 	cfg.UnikraftCloud.APIKey = "ukc-test-key"
 	cfg.UnikraftCloud.APIURL = apiURL
 	return cfg
 }
 
 func TestUnikraftCloudClientRequiresAPIKey(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.UnikraftCloud.Metro = "fra"
-	if _, err := newUnikraftCloudClient(cfg, Runtime{}); err == nil {
+	if _, err := newUnikraftCloudClient(cfg, core.Runtime{}); err == nil {
 		t.Fatal("newUnikraftCloudClient accepted empty API key")
 	}
 }
@@ -41,7 +43,7 @@ func TestUnikraftCloudBaseURLFromMetro(t *testing.T) {
 		{name: "explicit URL trailing slash", metro: "fra", apiURL: "https://ukc.example.com/", want: "https://ukc.example.com"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			cfg := Config{}
+			cfg := core.Config{}
 			cfg.UnikraftCloud.Metro = test.metro
 			cfg.UnikraftCloud.APIURL = test.apiURL
 			got, err := unikraftCloudBaseURL(cfg)
@@ -76,7 +78,7 @@ func TestUnikraftCloudClientRejectsUnsafeAPIURLs(t *testing.T) {
 		{name: "encoded non-root path", apiURL: "https://api.fra.unikraft.cloud/%2e"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := newUnikraftCloudClient(testClientConfig(test.apiURL), Runtime{})
+			_, err := newUnikraftCloudClient(testClientConfig(test.apiURL), core.Runtime{})
 			if err == nil {
 				t.Fatalf("newUnikraftCloudClient accepted unsafe URL %q", test.apiURL)
 			}
@@ -158,7 +160,7 @@ func TestUnikraftCloudClientLifecycleEndpoints(t *testing.T) {
 	}))
 	defer server.Close()
 
-	api, err := newUnikraftCloudClient(testClientConfig(server.URL), Runtime{HTTP: server.Client()})
+	api, err := newUnikraftCloudClient(testClientConfig(server.URL), core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatalf("newUnikraftCloudClient: %v", err)
 	}
@@ -224,7 +226,7 @@ func TestUnikraftCloudDeleteRejectsNameBeforeRequest(t *testing.T) {
 	}))
 	defer server.Close()
 
-	api, err := newUnikraftCloudClient(testClientConfig(server.URL), Runtime{HTTP: server.Client()})
+	api, err := newUnikraftCloudClient(testClientConfig(server.URL), core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatalf("newUnikraftCloudClient: %v", err)
 	}
@@ -262,7 +264,7 @@ func TestUnikraftCloudDeleteNormalizesUUIDAndMatchesResponseCase(t *testing.T) {
 	}))
 	defer server.Close()
 
-	api, err := newUnikraftCloudClient(testClientConfig(server.URL), Runtime{HTTP: server.Client()})
+	api, err := newUnikraftCloudClient(testClientConfig(server.URL), core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatalf("newUnikraftCloudClient: %v", err)
 	}
@@ -361,7 +363,7 @@ func TestUnikraftCloudClientErrorClassification(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			server := httptest.NewServer(test.handler)
 			defer server.Close()
-			api, err := newUnikraftCloudClient(testClientConfig(server.URL), Runtime{HTTP: server.Client()})
+			api, err := newUnikraftCloudClient(testClientConfig(server.URL), core.Runtime{HTTP: server.Client()})
 			if err != nil {
 				t.Fatalf("newUnikraftCloudClient: %v", err)
 			}
@@ -389,7 +391,7 @@ func TestUnikraftCloudClientDoesNotLeakAPIKeyInErrors(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"status": "error", "message": "bad key ukc-test-key rejected"})
 	}))
 	defer server.Close()
-	api, err := newUnikraftCloudClient(testClientConfig(server.URL), Runtime{HTTP: server.Client()})
+	api, err := newUnikraftCloudClient(testClientConfig(server.URL), core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatalf("newUnikraftCloudClient: %v", err)
 	}
@@ -421,7 +423,7 @@ func TestUnikraftCloudDeleteRejectsMalformedSuccessEnvelope(t *testing.T) {
 				_, _ = w.Write([]byte(test.body))
 			}))
 			defer server.Close()
-			api, err := newUnikraftCloudClient(testClientConfig(server.URL), Runtime{HTTP: server.Client()})
+			api, err := newUnikraftCloudClient(testClientConfig(server.URL), core.Runtime{HTTP: server.Client()})
 			if err != nil {
 				t.Fatalf("newUnikraftCloudClient: %v", err)
 			}
@@ -449,7 +451,7 @@ func TestUnikraftCloudClientRefusesCrossOriginRedirect(t *testing.T) {
 		http.Redirect(w, r, other.URL+"/v1/instances", http.StatusFound)
 	}))
 	defer server.Close()
-	api, err := newUnikraftCloudClient(testClientConfig(server.URL), Runtime{HTTP: server.Client()})
+	api, err := newUnikraftCloudClient(testClientConfig(server.URL), core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatalf("newUnikraftCloudClient: %v", err)
 	}
@@ -519,7 +521,7 @@ func TestUnikraftCloudUserUUID(t *testing.T) {
 				_, _ = w.Write([]byte(test.body))
 			}))
 			defer server.Close()
-			api, err := newUnikraftCloudClient(testClientConfig(server.URL), Runtime{HTTP: server.Client()})
+			api, err := newUnikraftCloudClient(testClientConfig(server.URL), core.Runtime{HTTP: server.Client()})
 			if err != nil {
 				t.Fatalf("newUnikraftCloudClient: %v", err)
 			}
@@ -573,7 +575,7 @@ func TestUnikraftCloudClientRejectsPartialInstanceResults(t *testing.T) {
 				_, _ = w.Write([]byte(test.body))
 			}))
 			defer server.Close()
-			api, err := newUnikraftCloudClient(testClientConfig(server.URL), Runtime{HTTP: server.Client()})
+			api, err := newUnikraftCloudClient(testClientConfig(server.URL), core.Runtime{HTTP: server.Client()})
 			if err != nil {
 				t.Fatalf("newUnikraftCloudClient: %v", err)
 			}
@@ -684,7 +686,7 @@ func TestUnikraftCloudSingleInstanceOperationsRequireExactResult(t *testing.T) {
 				_, _ = w.Write([]byte(test.body))
 			}))
 			defer server.Close()
-			api, err := newUnikraftCloudClient(testClientConfig(server.URL), Runtime{HTTP: server.Client()})
+			api, err := newUnikraftCloudClient(testClientConfig(server.URL), core.Runtime{HTTP: server.Client()})
 			if err != nil {
 				t.Fatalf("newUnikraftCloudClient: %v", err)
 			}
@@ -708,7 +710,7 @@ func TestUnikraftCloudClientRefusesSameOriginRedirectOutsideAPIPath(t *testing.T
 		http.Redirect(w, r, "/login", http.StatusTemporaryRedirect)
 	}))
 	defer server.Close()
-	api, err := newUnikraftCloudClient(testClientConfig(server.URL), Runtime{HTTP: server.Client()})
+	api, err := newUnikraftCloudClient(testClientConfig(server.URL), core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatalf("newUnikraftCloudClient: %v", err)
 	}
@@ -734,7 +736,7 @@ func TestUnikraftCloudClientRefusesEncodedRedirectTraversal(t *testing.T) {
 		w.WriteHeader(http.StatusTemporaryRedirect)
 	}))
 	defer server.Close()
-	api, err := newUnikraftCloudClient(testClientConfig(server.URL), Runtime{HTTP: server.Client()})
+	api, err := newUnikraftCloudClient(testClientConfig(server.URL), core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatalf("newUnikraftCloudClient: %v", err)
 	}
@@ -759,7 +761,7 @@ func TestUnikraftCloudClientRefusesRedirectMutationMethodChange(t *testing.T) {
 		http.Redirect(w, r, "/v1/instances/delete-result", http.StatusFound)
 	}))
 	defer server.Close()
-	api, err := newUnikraftCloudClient(testClientConfig(server.URL), Runtime{HTTP: server.Client()})
+	api, err := newUnikraftCloudClient(testClientConfig(server.URL), core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatalf("newUnikraftCloudClient: %v", err)
 	}
@@ -802,7 +804,7 @@ func TestUnikraftCloudClientAllowsMethodPreservingMutationRedirect(t *testing.T)
 		})
 	}))
 	defer server.Close()
-	api, err := newUnikraftCloudClient(testClientConfig(server.URL), Runtime{HTTP: server.Client()})
+	api, err := newUnikraftCloudClient(testClientConfig(server.URL), core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatalf("newUnikraftCloudClient: %v", err)
 	}

--- a/internal/providers/unikraftcloud/core.go
+++ b/internal/providers/unikraftcloud/core.go
@@ -7,27 +7,6 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-type Config = core.Config
-type UnikraftCloudConfig = core.UnikraftCloudConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type CleanupRequest = core.CleanupRequest
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type Server = core.Server
-type LeaseClaim = core.LeaseClaim
-type Repo = core.Repo
-type ExitError = core.ExitError
-
 const (
 	providerName = "unikraft-cloud"
 	leasePrefix  = "ukc_"
@@ -36,56 +15,20 @@ const (
 	networkPublic = core.NetworkPublic
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func inventoryDoctorResult(provider string, leases int) DoctorResult {
-	return core.InventoryDoctorResult(provider, leases)
-}
-
-func normalizeLeaseSlug(value string) string {
-	return core.NormalizeLeaseSlug(value)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
 func newLeaseID() string {
 	return leasePrefix + strings.TrimPrefix(core.NewLeaseID(), "cbx_")
 }
 
-func leaseProviderName(leaseID, slug string) string {
-	return core.LeaseProviderName(leaseID, slug)
-}
-
-func directLeaseLabels(cfg Config, leaseID, slug string, keep bool, now time.Time) map[string]string {
+func directLeaseLabels(cfg core.Config, leaseID, slug string, keep bool, now time.Time) map[string]string {
 	return core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
 }
 
-var claimLeaseTargetForRepoConfigScopeIfUnchangedDurable = func(leaseID, slug string, cfg Config, providerScope string, server Server, repoRoot string, idleTimeout time.Duration, reclaim bool, expected LeaseClaim, expectedExists bool) (LeaseClaim, error) {
+var claimLeaseTargetForRepoConfigScopeIfUnchangedDurable = func(leaseID, slug string, cfg core.Config, providerScope string, server core.Server, repoRoot string, idleTimeout time.Duration, reclaim bool, expected core.LeaseClaim, expectedExists bool) (core.LeaseClaim, error) {
 	return core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurable(leaseID, slug, cfg, providerScope, server, core.SSHTarget{}, repoRoot, idleTimeout, reclaim, expected, expectedExists)
 }
 
-func readLeaseClaim(leaseID string) (LeaseClaim, error) {
-	return core.ReadLeaseClaim(leaseID)
-}
-
-func readLeaseClaimWithPresence(leaseID string) (LeaseClaim, bool, error) {
-	return core.ReadLeaseClaimWithPresence(leaseID)
-}
-
-func listUnikraftCloudLeaseClaims() ([]LeaseClaim, error) {
+func listUnikraftCloudLeaseClaims() ([]core.LeaseClaim, error) {
 	return core.ListLeaseClaimsWithPrefix(leasePrefix)
 }
 
-func removeLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
-	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
-}
-
 var replaceLeaseClaimIfUnchangedDurable = core.ReplaceLeaseClaimIfUnchangedDurableReturning
-
-func shouldCleanupServer(server Server, now time.Time) (bool, string) {
-	return core.ShouldCleanupServer(server, now)
-}

--- a/internal/providers/unikraftcloud/deletion_response.go
+++ b/internal/providers/unikraftcloud/deletion_response.go
@@ -1,13 +1,17 @@
 package unikraftcloud
 
-import "strings"
+import (
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
 
 func validateUnikraftCloudDeleteIdentity(instance ukcInstance, expectedUUID, expectedName string) error {
 	if err := validateUnikraftCloudInstanceIdentity(instance, expectedUUID, ""); err != nil {
 		return err
 	}
 	if name := strings.TrimSpace(instance.Name); name != "" && expectedName != "" && name != expectedName {
-		return exit(5, "%s delete response for instance %s changed name: got %q, want %q", providerName, instance.UUID, instance.Name, expectedName)
+		return core.Exit(5, "%s delete response for instance %s changed name: got %q, want %q", providerName, instance.UUID, instance.Name, expectedName)
 	}
 	return nil
 }

--- a/internal/providers/unikraftcloud/deletion_response_test.go
+++ b/internal/providers/unikraftcloud/deletion_response_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type unikraftCloudNamelessDeleteAPI struct {
@@ -37,17 +39,17 @@ func TestStopAcceptsExactDeleteResponseWithOmittedName(t *testing.T) {
 	api := &unikraftCloudNamelessDeleteAPI{fakeUnikraftCloudAPI: base}
 	b := testBackend(api, nil, nil)
 
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	claim := onlyTestClaim(t)
-	if err := b.Stop(context.Background(), StopRequest{ID: claim.LeaseID}); err != nil {
+	if err := b.Stop(context.Background(), core.StopRequest{ID: claim.LeaseID}); err != nil {
 		t.Fatalf("Stop: %v", err)
 	}
 	if len(base.deletedIDs) != 1 || base.deletedIDs[0] != testInstanceUUID {
 		t.Fatalf("deleted IDs = %#v", base.deletedIDs)
 	}
-	if _, exists, err := readLeaseClaimWithPresence(claim.LeaseID); err != nil || exists {
+	if _, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID); err != nil || exists {
 		t.Fatalf("claim exists=%v err=%v, want removed", exists, err)
 	}
 }
@@ -61,18 +63,18 @@ func TestStopRetainsDeleteAttemptForConflictingResponseName(t *testing.T) {
 	api := &unikraftCloudConflictingDeleteNameAPI{fakeUnikraftCloudAPI: base}
 	b := testBackend(api, nil, nil)
 
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	claim := onlyTestClaim(t)
-	err := b.Stop(context.Background(), StopRequest{ID: claim.LeaseID})
+	err := b.Stop(context.Background(), core.StopRequest{ID: claim.LeaseID})
 	if err == nil || !strings.Contains(err.Error(), "changed name") {
 		t.Fatalf("Stop err = %v, want changed-name refusal", err)
 	}
 	if len(base.deletedIDs) != 1 || base.deletedIDs[0] != testInstanceUUID {
 		t.Fatalf("deleted IDs = %#v", base.deletedIDs)
 	}
-	stored, exists, readErr := readLeaseClaimWithPresence(claim.LeaseID)
+	stored, exists, readErr := core.ReadLeaseClaimWithPresence(claim.LeaseID)
 	if readErr != nil || !exists {
 		t.Fatalf("claim exists=%v err=%v, want retained", exists, readErr)
 	}

--- a/internal/providers/unikraftcloud/durability_test.go
+++ b/internal/providers/unikraftcloud/durability_test.go
@@ -18,12 +18,12 @@ func TestReconcileReadyClaimWriteReallocatesMissingClaimSlug(t *testing.T) {
 	leaseID := leasePrefix + "aaaaaaaaaaaa"
 	repoRoot := t.TempDir()
 	createReq := createInstanceRequest{
-		Name:      leaseProviderName(leaseID, ""),
+		Name:      core.LeaseProviderName(leaseID, ""),
 		Image:     b.cfg.UnikraftCloud.Image,
 		MemoryMB:  b.cfg.UnikraftCloud.MemoryMB,
 		Autostart: true,
 	}
-	preflight, err := b.createIntentClaim(leaseID, "reused-slug", testClaimScope(t, "https://api.fra.unikraft.cloud"), testUserUUID, WarmupRequest{Repo: Repo{Root: repoRoot}}, createReq)
+	preflight, err := b.createIntentClaim(leaseID, "reused-slug", testClaimScope(t, "https://api.fra.unikraft.cloud"), testUserUUID, core.WarmupRequest{Repo: core.Repo{Root: repoRoot}}, createReq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func TestReconcileReadyClaimWriteReallocatesMissingClaimSlug(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := removeLeaseClaimIfUnchanged(intent.LeaseID, intent); err != nil {
+	if err := core.RemoveLeaseClaimIfUnchanged(intent.LeaseID, intent); err != nil {
 		t.Fatal(err)
 	}
 	if err := core.ClaimLeaseForRepoProviderScopePond("cbx_new_slug_owner", intent.Slug, "external", "", "", t.TempDir(), time.Minute, false); err != nil {
@@ -55,12 +55,12 @@ func TestReconcileReadyClaimWriteRejectsChangedRecoveryIdentity(t *testing.T) {
 	b := testBackend(&fakeUnikraftCloudAPI{baseURL: "https://api.fra.unikraft.cloud"}, nil, nil)
 	leaseID := leasePrefix + "bbbbbbbbbbbb"
 	createReq := createInstanceRequest{
-		Name:      leaseProviderName(leaseID, ""),
+		Name:      core.LeaseProviderName(leaseID, ""),
 		Image:     b.cfg.UnikraftCloud.Image,
 		MemoryMB:  b.cfg.UnikraftCloud.MemoryMB,
 		Autostart: true,
 	}
-	preflight, err := b.createIntentClaim(leaseID, "identity-check", testClaimScope(t, "https://api.fra.unikraft.cloud"), testUserUUID, WarmupRequest{Repo: Repo{Root: t.TempDir()}}, createReq)
+	preflight, err := b.createIntentClaim(leaseID, "identity-check", testClaimScope(t, "https://api.fra.unikraft.cloud"), testUserUUID, core.WarmupRequest{Repo: core.Repo{Root: t.TempDir()}}, createReq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestReconcileReadyClaimWriteRejectsChangedRecoveryIdentity(t *testing.T) {
 	if _, err := b.reconcileReadyClaimWrite(intent, instance, errors.New("simulated ready write error")); err == nil || !strings.Contains(err.Error(), "changed recovery identity") {
 		t.Fatalf("reconcile error=%v, want recovery identity refusal", err)
 	}
-	stored, exists, err := readLeaseClaimWithPresence(ready.LeaseID)
+	stored, exists, err := core.ReadLeaseClaimWithPresence(ready.LeaseID)
 	if err != nil || !exists || stored.Labels[ukcLabelRequestHash] != changed.Labels[ukcLabelRequestHash] {
 		t.Fatalf("stored=%#v exists=%v err=%v, want changed claim retained", stored, exists, err)
 	}
@@ -93,12 +93,12 @@ func TestDiscardUnmutatedCreateClaimRemovesVisibleIntent(t *testing.T) {
 	b := testBackend(&fakeUnikraftCloudAPI{baseURL: "https://api.fra.unikraft.cloud"}, nil, nil)
 	leaseID := leasePrefix + "cccccccccccc"
 	createReq := createInstanceRequest{
-		Name:      leaseProviderName(leaseID, ""),
+		Name:      core.LeaseProviderName(leaseID, ""),
 		Image:     b.cfg.UnikraftCloud.Image,
 		MemoryMB:  b.cfg.UnikraftCloud.MemoryMB,
 		Autostart: true,
 	}
-	preflight, err := b.createIntentClaim(leaseID, "discard-intent", testClaimScope(t, "https://api.fra.unikraft.cloud"), testUserUUID, WarmupRequest{Repo: Repo{Root: t.TempDir()}}, createReq)
+	preflight, err := b.createIntentClaim(leaseID, "discard-intent", testClaimScope(t, "https://api.fra.unikraft.cloud"), testUserUUID, core.WarmupRequest{Repo: core.Repo{Root: t.TempDir()}}, createReq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +109,7 @@ func TestDiscardUnmutatedCreateClaimRemovesVisibleIntent(t *testing.T) {
 	if err := discardUnmutatedUnikraftCloudCreateClaim(preflight, cause); !errors.Is(err, cause) {
 		t.Fatalf("discard error=%v want %v", err, cause)
 	}
-	if stored, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
+	if stored, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
 		t.Fatalf("stored=%#v exists=%v err=%v, want no adoptable claim", stored, exists, err)
 	}
 }
@@ -119,12 +119,12 @@ func TestQuarantineRejectedCreateClaimNeverRemovesVisibleIntent(t *testing.T) {
 	b := testBackend(&fakeUnikraftCloudAPI{baseURL: "https://api.fra.unikraft.cloud"}, nil, nil)
 	leaseID := leasePrefix + "dddddddddddd"
 	createReq := createInstanceRequest{
-		Name:      leaseProviderName(leaseID, ""),
+		Name:      core.LeaseProviderName(leaseID, ""),
 		Image:     b.cfg.UnikraftCloud.Image,
 		MemoryMB:  b.cfg.UnikraftCloud.MemoryMB,
 		Autostart: true,
 	}
-	preflight, err := b.createIntentClaim(leaseID, "quarantine-intent", testClaimScope(t, "https://api.fra.unikraft.cloud"), testUserUUID, WarmupRequest{Repo: Repo{Root: t.TempDir()}}, createReq)
+	preflight, err := b.createIntentClaim(leaseID, "quarantine-intent", testClaimScope(t, "https://api.fra.unikraft.cloud"), testUserUUID, core.WarmupRequest{Repo: core.Repo{Root: t.TempDir()}}, createReq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +136,7 @@ func TestQuarantineRejectedCreateClaimNeverRemovesVisibleIntent(t *testing.T) {
 	if err := quarantineRejectedUnikraftCloudCreateClaim(intent, cause); !errors.Is(err, cause) {
 		t.Fatalf("quarantine error=%v want %v", err, cause)
 	}
-	stored, exists, err := readLeaseClaimWithPresence(leaseID)
+	stored, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
 	if err != nil || !exists || stored.Labels["state"] != ukcStateCreateConflict || stored.CloudID != "" {
 		t.Fatalf("stored=%#v exists=%v err=%v, want non-adoptable conflict", stored, exists, err)
 	}
@@ -146,8 +146,8 @@ func TestCreateStateTransitionReconcilesErrorAfterRename(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	b := testBackend(&fakeUnikraftCloudAPI{baseURL: "https://api.fra.unikraft.cloud"}, nil, nil)
 	leaseID := leasePrefix + "eeeeeeeeeeee"
-	createReq := createInstanceRequest{Name: leaseProviderName(leaseID, ""), Image: b.cfg.UnikraftCloud.Image, MemoryMB: b.cfg.UnikraftCloud.MemoryMB, Autostart: true}
-	preflight, err := b.createIntentClaim(leaseID, "rename-reconcile", testClaimScope(t, "https://api.fra.unikraft.cloud"), testUserUUID, WarmupRequest{Repo: Repo{Root: t.TempDir()}}, createReq)
+	createReq := createInstanceRequest{Name: core.LeaseProviderName(leaseID, ""), Image: b.cfg.UnikraftCloud.Image, MemoryMB: b.cfg.UnikraftCloud.MemoryMB, Autostart: true}
+	preflight, err := b.createIntentClaim(leaseID, "rename-reconcile", testClaimScope(t, "https://api.fra.unikraft.cloud"), testUserUUID, core.WarmupRequest{Repo: core.Repo{Root: t.TempDir()}}, createReq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,10 +155,10 @@ func TestCreateStateTransitionReconcilesErrorAfterRename(t *testing.T) {
 	t.Cleanup(func() { replaceLeaseClaimIfUnchangedDurable = originalReplace })
 	injected := errors.New("sync failed after rename")
 	calls := 0
-	replaceLeaseClaimIfUnchangedDurable = func(leaseID string, current, replacement LeaseClaim) (LeaseClaim, error) {
+	replaceLeaseClaimIfUnchangedDurable = func(leaseID string, current, replacement core.LeaseClaim) (core.LeaseClaim, error) {
 		written, err := originalReplace(leaseID, current, replacement)
 		if err != nil {
-			return LeaseClaim{}, err
+			return core.LeaseClaim{}, err
 		}
 		calls++
 		if calls == 1 {
@@ -179,8 +179,8 @@ func TestCreateStateTransitionDoesNotReconcileGuardConflict(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	b := testBackend(&fakeUnikraftCloudAPI{baseURL: "https://api.fra.unikraft.cloud"}, nil, nil)
 	leaseID := leasePrefix + "edededededed"
-	createReq := createInstanceRequest{Name: leaseProviderName(leaseID, ""), Image: b.cfg.UnikraftCloud.Image, MemoryMB: b.cfg.UnikraftCloud.MemoryMB, Autostart: true}
-	preflight, err := b.createIntentClaim(leaseID, "guard-conflict", testClaimScope(t, "https://api.fra.unikraft.cloud"), testUserUUID, WarmupRequest{Repo: Repo{Root: t.TempDir()}}, createReq)
+	createReq := createInstanceRequest{Name: core.LeaseProviderName(leaseID, ""), Image: b.cfg.UnikraftCloud.Image, MemoryMB: b.cfg.UnikraftCloud.MemoryMB, Autostart: true}
+	preflight, err := b.createIntentClaim(leaseID, "guard-conflict", testClaimScope(t, "https://api.fra.unikraft.cloud"), testUserUUID, core.WarmupRequest{Repo: core.Repo{Root: t.TempDir()}}, createReq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +195,7 @@ func TestCreateStateTransitionDoesNotReconcileGuardConflict(t *testing.T) {
 	if _, err := transitionUnikraftCloudCreateState(preflight, ukcStateCreateIntent); err == nil || !strings.Contains(err.Error(), "claim changed") {
 		t.Fatalf("stale transition error=%v, want claim changed", err)
 	}
-	stored, exists, err := readLeaseClaimWithPresence(leaseID)
+	stored, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
 	if err != nil || !exists || !reflect.DeepEqual(stored, concurrent) {
 		t.Fatalf("stored=%#v exists=%v err=%v, want concurrent=%#v", stored, exists, err, concurrent)
 	}
@@ -205,21 +205,21 @@ func TestInitialPreflightWriteErrorAfterRenameRemovesUnusedClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	b := testBackend(&fakeUnikraftCloudAPI{baseURL: "https://api.fra.unikraft.cloud"}, nil, nil)
 	leaseID := leasePrefix + "abababababab"
-	createReq := createInstanceRequest{Name: leaseProviderName(leaseID, ""), Image: b.cfg.UnikraftCloud.Image, MemoryMB: b.cfg.UnikraftCloud.MemoryMB, Autostart: true}
+	createReq := createInstanceRequest{Name: core.LeaseProviderName(leaseID, ""), Image: b.cfg.UnikraftCloud.Image, MemoryMB: b.cfg.UnikraftCloud.MemoryMB, Autostart: true}
 	originalClaim := claimLeaseTargetForRepoConfigScopeIfUnchangedDurable
 	t.Cleanup(func() { claimLeaseTargetForRepoConfigScopeIfUnchangedDurable = originalClaim })
 	injected := errors.New("preflight sync failed after rename")
-	claimLeaseTargetForRepoConfigScopeIfUnchangedDurable = func(leaseID, slug string, cfg Config, providerScope string, server Server, repoRoot string, idleTimeout time.Duration, reclaim bool, expected LeaseClaim, expectedExists bool) (LeaseClaim, error) {
+	claimLeaseTargetForRepoConfigScopeIfUnchangedDurable = func(leaseID, slug string, cfg core.Config, providerScope string, server core.Server, repoRoot string, idleTimeout time.Duration, reclaim bool, expected core.LeaseClaim, expectedExists bool) (core.LeaseClaim, error) {
 		claim, err := originalClaim(leaseID, slug, cfg, providerScope, server, repoRoot, idleTimeout, reclaim, expected, expectedExists)
 		if err != nil {
 			return claim, err
 		}
 		return claim, injected
 	}
-	if _, err := b.createIntentClaim(leaseID, "initial-preflight", testClaimScope(t, "https://api.fra.unikraft.cloud"), testUserUUID, WarmupRequest{Repo: Repo{Root: t.TempDir()}}, createReq); err == nil || !strings.Contains(err.Error(), injected.Error()) {
+	if _, err := b.createIntentClaim(leaseID, "initial-preflight", testClaimScope(t, "https://api.fra.unikraft.cloud"), testUserUUID, core.WarmupRequest{Repo: core.Repo{Root: t.TempDir()}}, createReq); err == nil || !strings.Contains(err.Error(), injected.Error()) {
 		t.Fatalf("createIntentClaim error=%v want %v", err, injected)
 	}
-	if stored, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
+	if stored, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
 		t.Fatalf("stored=%#v exists=%v err=%v, want unused preflight removed", stored, exists, err)
 	}
 }
@@ -229,18 +229,18 @@ func TestPreflightTransitionFailureDoesNotLeaveAdoptableIntent(t *testing.T) {
 	api := &fakeUnikraftCloudAPI{baseURL: "https://api.fra.unikraft.cloud"}
 	b := testBackend(api, nil, nil)
 	leaseID := leasePrefix + "ffffffffffff"
-	createReq := createInstanceRequest{Name: leaseProviderName(leaseID, ""), Image: b.cfg.UnikraftCloud.Image, MemoryMB: b.cfg.UnikraftCloud.MemoryMB, Autostart: true}
-	preflight, err := b.createIntentClaim(leaseID, "failed-arm", testClaimScope(t, api.BaseURL()), testUserUUID, WarmupRequest{Repo: Repo{Root: t.TempDir()}}, createReq)
+	createReq := createInstanceRequest{Name: core.LeaseProviderName(leaseID, ""), Image: b.cfg.UnikraftCloud.Image, MemoryMB: b.cfg.UnikraftCloud.MemoryMB, Autostart: true}
+	preflight, err := b.createIntentClaim(leaseID, "failed-arm", testClaimScope(t, api.BaseURL()), testUserUUID, core.WarmupRequest{Repo: core.Repo{Root: t.TempDir()}}, createReq)
 	if err != nil {
 		t.Fatal(err)
 	}
 	originalReplace := replaceLeaseClaimIfUnchangedDurable
 	t.Cleanup(func() { replaceLeaseClaimIfUnchangedDurable = originalReplace })
 	injected := errors.New("persistent sync failure after rename")
-	replaceLeaseClaimIfUnchangedDurable = func(leaseID string, current, replacement LeaseClaim) (LeaseClaim, error) {
+	replaceLeaseClaimIfUnchangedDurable = func(leaseID string, current, replacement core.LeaseClaim) (core.LeaseClaim, error) {
 		written, err := originalReplace(leaseID, current, replacement)
 		if err != nil {
-			return LeaseClaim{}, err
+			return core.LeaseClaim{}, err
 		}
 		if replacement.Labels["state"] == ukcStateCreateIntent {
 			return written, injected
@@ -250,7 +250,7 @@ func TestPreflightTransitionFailureDoesNotLeaveAdoptableIntent(t *testing.T) {
 	if _, err := b.preflightCreateIntent(context.Background(), api, preflight); err == nil || !strings.Contains(err.Error(), injected.Error()) {
 		t.Fatalf("preflight error=%v want %v", err, injected)
 	}
-	if stored, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
+	if stored, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
 		t.Fatalf("stored=%#v exists=%v err=%v, want no adoptable intent", stored, exists, err)
 	}
 	if len(api.created) != 0 {
@@ -268,17 +268,17 @@ func TestRejectedCreateTransitionFailureRetainsNonAdoptableClaim(t *testing.T) {
 	originalReplace := replaceLeaseClaimIfUnchangedDurable
 	t.Cleanup(func() { replaceLeaseClaimIfUnchangedDurable = originalReplace })
 	injected := errors.New("persistent conflict sync failure after rename")
-	replaceLeaseClaimIfUnchangedDurable = func(leaseID string, current, replacement LeaseClaim) (LeaseClaim, error) {
+	replaceLeaseClaimIfUnchangedDurable = func(leaseID string, current, replacement core.LeaseClaim) (core.LeaseClaim, error) {
 		written, err := originalReplace(leaseID, current, replacement)
 		if err != nil {
-			return LeaseClaim{}, err
+			return core.LeaseClaim{}, err
 		}
 		if replacement.Labels["state"] == ukcStateCreateConflict {
 			return written, injected
 		}
 		return written, nil
 	}
-	err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}})
+	err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}})
 	if err == nil || !strings.Contains(err.Error(), injected.Error()) {
 		t.Fatalf("Warmup error=%v want %v", err, injected)
 	}

--- a/internal/providers/unikraftcloud/flags.go
+++ b/internal/providers/unikraftcloud/flags.go
@@ -18,7 +18,7 @@ type unikraftCloudFlagValues struct {
 // The API key is sourced from CRABBOX_UNIKRAFT_CLOUD_API_KEY /
 // UNIKRAFT_CLOUD_API_KEY / UKC_API_KEY / UKC_TOKEN or the unikraftCloud.apiKey
 // config key so it is never passed as a command-line argument.
-func registerUnikraftCloudProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func registerUnikraftCloudProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return unikraftCloudFlagValues{
 		APIURL:   fs.String("unikraft-cloud-url", defaults.UnikraftCloud.APIURL, "Unikraft Cloud API URL override (default derived from the metro)"),
 		Metro:    fs.String("unikraft-cloud-metro", defaults.UnikraftCloud.Metro, "Unikraft Cloud metro (fra, dal, sin, was, sfo)"),
@@ -27,7 +27,7 @@ func registerUnikraftCloudProviderFlags(fs *flag.FlagSet, defaults Config) any {
 	}
 }
 
-func applyUnikraftCloudProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func applyUnikraftCloudProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "", ""); err != nil {
 			return err

--- a/internal/providers/unikraftcloud/inventory.go
+++ b/internal/providers/unikraftcloud/inventory.go
@@ -1,16 +1,20 @@
 package unikraftcloud
 
-import "strings"
+import (
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
 
 func indexUnikraftCloudInventory(instances []ukcInstance) (map[string]ukcInstance, error) {
 	indexed := make(map[string]ukcInstance, len(instances))
 	for _, instance := range instances {
 		if !unikraftCloudUUIDPattern.MatchString(instance.UUID) {
-			return nil, exit(5, "%s inventory returned an invalid instance UUID", providerName)
+			return nil, core.Exit(5, "%s inventory returned an invalid instance UUID", providerName)
 		}
 		key := strings.ToLower(instance.UUID)
 		if _, exists := indexed[key]; exists {
-			return nil, exit(5, "%s inventory returned duplicate instance UUID %s", providerName, instance.UUID)
+			return nil, core.Exit(5, "%s inventory returned duplicate instance UUID %s", providerName, instance.UUID)
 		}
 		indexed[key] = instance
 	}

--- a/internal/providers/unikraftcloud/lifecycle.go
+++ b/internal/providers/unikraftcloud/lifecycle.go
@@ -32,10 +32,10 @@ func unikraftCloudClaimScope(baseURL, accountUUID string) (string, error) {
 	baseURL = strings.TrimSpace(baseURL)
 	accountUUID = strings.TrimSpace(accountUUID)
 	if baseURL == "" {
-		return "", exit(2, "provider=%s API endpoint is unavailable", providerName)
+		return "", core.Exit(2, "provider=%s API endpoint is unavailable", providerName)
 	}
 	if !unikraftCloudUUIDPattern.MatchString(accountUUID) {
-		return "", exit(3, "provider=%s account identity is unavailable", providerName)
+		return "", core.Exit(3, "provider=%s account identity is unavailable", providerName)
 	}
 	return "endpoint:" + baseURL + "|account:" + accountUUID, nil
 }
@@ -54,7 +54,7 @@ func cloneLabels(labels map[string]string) map[string]string {
 	return out
 }
 
-func (b *backend) createIntentClaim(leaseID, slug, scope, accountUUID string, req WarmupRequest, createReq createInstanceRequest) (LeaseClaim, error) {
+func (b *backend) createIntentClaim(leaseID, slug, scope, accountUUID string, req core.WarmupRequest, createReq createInstanceRequest) (core.LeaseClaim, error) {
 	labels := directLeaseLabels(b.cfg, leaseID, slug, req.Keep, core.ClockNow(b.rt.Clock))
 	labels["state"] = ukcStateCreatePreflight
 	labels[ukcLabelResourceName] = createReq.Name
@@ -64,27 +64,23 @@ func (b *backend) createIntentClaim(leaseID, slug, scope, accountUUID string, re
 		leaseID,
 		slug,
 		b.cfg,
-		scope,
-		Server{Provider: providerName, Name: createReq.Name, Status: ukcStateCreatePreflight, Labels: labels},
-		req.Repo.Root,
+		scope, core.Server{Provider: providerName, Name: createReq.Name, Status: ukcStateCreatePreflight, Labels: labels}, req.Repo.Root,
 		b.cfg.IdleTimeout,
-		req.Reclaim,
-		LeaseClaim{},
-		false,
+		req.Reclaim, core.LeaseClaim{}, false,
 	)
 	if err != nil {
 		cause := fmt.Errorf("persist %s create preflight %s: %w", providerName, leaseID, err)
 		if intent.LeaseID != "" {
-			return LeaseClaim{}, discardUnmutatedUnikraftCloudCreateClaim(intent, cause)
+			return core.LeaseClaim{}, discardUnmutatedUnikraftCloudCreateClaim(intent, cause)
 		}
-		return LeaseClaim{}, cause
+		return core.LeaseClaim{}, cause
 	}
 	return intent, nil
 }
 
-func transitionUnikraftCloudCreateState(claim LeaseClaim, state string) (LeaseClaim, error) {
+func transitionUnikraftCloudCreateState(claim core.LeaseClaim, state string) (core.LeaseClaim, error) {
 	if claim.CloudID != "" {
-		return LeaseClaim{}, exit(5, "%s lease %s is already bound to instance %s", providerName, claim.LeaseID, claim.CloudID)
+		return core.LeaseClaim{}, core.Exit(5, "%s lease %s is already bound to instance %s", providerName, claim.LeaseID, claim.CloudID)
 	}
 	updated := claim
 	updated.Labels = cloneLabels(claim.Labels)
@@ -92,36 +88,35 @@ func transitionUnikraftCloudCreateState(claim LeaseClaim, state string) (LeaseCl
 	written, err := replaceLeaseClaimIfUnchangedDurable(claim.LeaseID, claim, updated)
 	if err != nil {
 		if written.Revision == "" {
-			return LeaseClaim{}, err
+			return core.LeaseClaim{}, err
 		}
-		current, exists, readErr := readLeaseClaimWithPresence(claim.LeaseID)
+		current, exists, readErr := core.ReadLeaseClaimWithPresence(claim.LeaseID)
 		if readErr != nil {
-			return LeaseClaim{}, errors.Join(err, readErr)
+			return core.LeaseClaim{}, errors.Join(err, readErr)
 		}
 		if !exists || !reflect.DeepEqual(current, written) {
-			return LeaseClaim{}, err
+			return core.LeaseClaim{}, err
 		}
 		retryWritten, retryErr := replaceLeaseClaimIfUnchangedDurable(claim.LeaseID, current, current)
 		if retryErr != nil {
-			return LeaseClaim{}, errors.Join(err, retryErr)
+			return core.LeaseClaim{}, errors.Join(err, retryErr)
 		}
 		return retryWritten, nil
 	}
 	return written, nil
 }
 
-func sameUnikraftCloudCreateIdentity(left, right LeaseClaim) bool {
+func sameUnikraftCloudCreateIdentity(left, right core.LeaseClaim) bool {
 	return left.LeaseID == right.LeaseID &&
 		left.Provider == right.Provider &&
-		left.ProviderScope == right.ProviderScope &&
-		normalizeLeaseSlug(left.Slug) == normalizeLeaseSlug(right.Slug) &&
+		left.ProviderScope == right.ProviderScope && core.NormalizeLeaseSlug(left.Slug) == core.NormalizeLeaseSlug(right.Slug) &&
 		left.Labels[ukcLabelResourceName] == right.Labels[ukcLabelResourceName] &&
 		left.Labels[ukcLabelRequestHash] == right.Labels[ukcLabelRequestHash] &&
 		left.Labels[ukcLabelAccountUUID] == right.Labels[ukcLabelAccountUUID]
 }
 
-func discardUnmutatedUnikraftCloudCreateClaim(expected LeaseClaim, cause error) error {
-	current, exists, readErr := readLeaseClaimWithPresence(expected.LeaseID)
+func discardUnmutatedUnikraftCloudCreateClaim(expected core.LeaseClaim, cause error) error {
+	current, exists, readErr := core.ReadLeaseClaimWithPresence(expected.LeaseID)
 	if readErr != nil {
 		return errors.Join(cause, readErr)
 	}
@@ -135,11 +130,11 @@ func discardUnmutatedUnikraftCloudCreateClaim(expected LeaseClaim, cause error) 
 	if state != ukcStateCreatePreflight && state != ukcStateCreateIntent {
 		return cause
 	}
-	removeErr := removeLeaseClaimIfUnchanged(current.LeaseID, current)
+	removeErr := core.RemoveLeaseClaimIfUnchanged(current.LeaseID, current)
 	if removeErr == nil {
 		return cause
 	}
-	after, afterExists, afterErr := readLeaseClaimWithPresence(current.LeaseID)
+	after, afterExists, afterErr := core.ReadLeaseClaimWithPresence(current.LeaseID)
 	if afterErr != nil {
 		return errors.Join(cause, removeErr, afterErr)
 	}
@@ -150,8 +145,8 @@ func discardUnmutatedUnikraftCloudCreateClaim(expected LeaseClaim, cause error) 
 	return errors.Join(cause, removeErr, quarantineErr)
 }
 
-func quarantineRejectedUnikraftCloudCreateClaim(expected LeaseClaim, cause error) error {
-	current, exists, readErr := readLeaseClaimWithPresence(expected.LeaseID)
+func quarantineRejectedUnikraftCloudCreateClaim(expected core.LeaseClaim, cause error) error {
+	current, exists, readErr := core.ReadLeaseClaimWithPresence(expected.LeaseID)
 	if readErr != nil {
 		return errors.Join(cause, readErr)
 	}
@@ -174,7 +169,7 @@ func quarantineRejectedUnikraftCloudCreateClaim(expected LeaseClaim, cause error
 	if quarantineErr == nil {
 		return cause
 	}
-	after, afterExists, afterErr := readLeaseClaimWithPresence(current.LeaseID)
+	after, afterExists, afterErr := core.ReadLeaseClaimWithPresence(current.LeaseID)
 	if afterErr != nil {
 		return errors.Join(cause, quarantineErr, afterErr)
 	}
@@ -184,23 +179,23 @@ func quarantineRejectedUnikraftCloudCreateClaim(expected LeaseClaim, cause error
 	return errors.Join(cause, quarantineErr, fmt.Errorf("%s rejected create recovery claim %s remains adoptable", providerName, expected.LeaseID))
 }
 
-func validateUnikraftCloudReadyClaimReadback(intent, current LeaseClaim, instance ukcInstance) error {
+func validateUnikraftCloudReadyClaimReadback(intent, current core.LeaseClaim, instance ukcInstance) error {
 	if err := validateUnikraftCloudClaim(current, intent.ProviderScope); err != nil {
 		return err
 	}
 	if !sameUnikraftCloudCreateIdentity(current, intent) {
-		return exit(4, "%s lease %q ready claim changed recovery identity", providerName, intent.LeaseID)
+		return core.Exit(4, "%s lease %q ready claim changed recovery identity", providerName, intent.LeaseID)
 	}
 	if current.Labels["state"] != ukcStateReady || current.CloudID != instance.UUID || current.Labels[ukcLabelResourceName] != instance.Name {
-		return exit(4, "%s lease %q does not contain the expected ready binding", providerName, intent.LeaseID)
+		return core.Exit(4, "%s lease %q does not contain the expected ready binding", providerName, intent.LeaseID)
 	}
 	return nil
 }
 
-func (b *backend) publishReadyClaim(intent LeaseClaim, instance ukcInstance) (LeaseClaim, error) {
+func (b *backend) publishReadyClaim(intent core.LeaseClaim, instance ukcInstance) (core.LeaseClaim, error) {
 	resourceName := strings.TrimSpace(intent.Labels[ukcLabelResourceName])
 	if err := validateUnikraftCloudInstanceIdentity(instance, strings.TrimSpace(instance.UUID), resourceName); err != nil {
-		return LeaseClaim{}, err
+		return core.LeaseClaim{}, err
 	}
 	labels := cloneLabels(intent.Labels)
 	labels["state"] = ukcStateReady
@@ -210,15 +205,13 @@ func (b *backend) publishReadyClaim(intent LeaseClaim, instance ukcInstance) (Le
 		intent.LeaseID,
 		intent.Slug,
 		b.cfg,
-		intent.ProviderScope,
-		Server{
+		intent.ProviderScope, core.Server{
 			CloudID:  instance.UUID,
 			Provider: providerName,
 			Name:     instance.Name,
 			Status:   normalizedInstanceState(instance.State),
 			Labels:   labels,
-		},
-		intent.RepoRoot,
+		}, intent.RepoRoot,
 		time.Duration(intent.IdleTimeoutSeconds)*time.Second,
 		false,
 		intent,
@@ -230,29 +223,29 @@ func (b *backend) publishReadyClaim(intent LeaseClaim, instance ukcInstance) (Le
 	return ready, nil
 }
 
-func (b *backend) reconcileReadyClaimWrite(intent LeaseClaim, instance ukcInstance, writeErr error) (LeaseClaim, error) {
-	current, exists, readErr := readLeaseClaimWithPresence(intent.LeaseID)
+func (b *backend) reconcileReadyClaimWrite(intent core.LeaseClaim, instance ukcInstance, writeErr error) (core.LeaseClaim, error) {
+	current, exists, readErr := core.ReadLeaseClaimWithPresence(intent.LeaseID)
 	if readErr != nil {
-		return LeaseClaim{}, errors.Join(writeErr, readErr)
+		return core.LeaseClaim{}, errors.Join(writeErr, readErr)
 	}
 	if exists {
 		if err := validateUnikraftCloudReadyClaimReadback(intent, current, instance); err != nil {
-			return LeaseClaim{}, errors.Join(writeErr, err)
+			return core.LeaseClaim{}, errors.Join(writeErr, err)
 		}
 		written, err := replaceLeaseClaimIfUnchangedDurable(intent.LeaseID, current, current)
 		if err != nil {
-			return LeaseClaim{}, errors.Join(writeErr, err)
+			return core.LeaseClaim{}, errors.Join(writeErr, err)
 		}
 		return written, nil
 	}
 	unlockSlug, lockErr := lockUnikraftCloudSlugAllocation(context.Background())
 	if lockErr != nil {
-		return LeaseClaim{}, errors.Join(writeErr, fmt.Errorf("reserve restored %s lease slug: %w", providerName, lockErr))
+		return core.LeaseClaim{}, errors.Join(writeErr, fmt.Errorf("reserve restored %s lease slug: %w", providerName, lockErr))
 	}
-	recoveredSlug, slugErr := allocateClaimLeaseSlug(intent.LeaseID, intent.Slug)
+	recoveredSlug, slugErr := core.AllocateClaimLeaseSlug(intent.LeaseID, intent.Slug)
 	if slugErr != nil {
 		unlockSlug()
-		return LeaseClaim{}, errors.Join(writeErr, fmt.Errorf("reserve restored %s lease slug: %w", providerName, slugErr))
+		return core.LeaseClaim{}, errors.Join(writeErr, fmt.Errorf("reserve restored %s lease slug: %w", providerName, slugErr))
 	}
 	labels := cloneLabels(intent.Labels)
 	labels["slug"] = recoveredSlug
@@ -263,77 +256,73 @@ func (b *backend) reconcileReadyClaimWrite(intent LeaseClaim, instance ukcInstan
 		intent.LeaseID,
 		recoveredSlug,
 		b.cfg,
-		intent.ProviderScope,
-		Server{CloudID: instance.UUID, Provider: providerName, Name: instance.Name, Status: normalizedInstanceState(instance.State), Labels: labels},
-		intent.RepoRoot,
+		intent.ProviderScope, core.Server{CloudID: instance.UUID, Provider: providerName, Name: instance.Name, Status: normalizedInstanceState(instance.State), Labels: labels}, intent.RepoRoot,
 		time.Duration(intent.IdleTimeoutSeconds)*time.Second,
-		false,
-		LeaseClaim{},
-		false,
+		false, core.LeaseClaim{}, false,
 	)
 	unlockSlug()
 	if recoverErr != nil {
-		return LeaseClaim{}, errors.Join(writeErr, fmt.Errorf("restore known %s ownership: %w", providerName, recoverErr))
+		return core.LeaseClaim{}, errors.Join(writeErr, fmt.Errorf("restore known %s ownership: %w", providerName, recoverErr))
 	}
 	return recovered, nil
 }
 
-func validateUnikraftCloudClaim(claim LeaseClaim, scope string) error {
+func validateUnikraftCloudClaim(claim core.LeaseClaim, scope string) error {
 	if claim.LeaseID == "" || !strings.HasPrefix(claim.LeaseID, leasePrefix) {
-		return exit(4, "%s claim has an invalid lease identity", providerName)
+		return core.Exit(4, "%s claim has an invalid lease identity", providerName)
 	}
 	if claim.Provider != providerName {
-		return exit(4, "%s lease %q belongs to provider=%s", providerName, claim.LeaseID, claim.Provider)
+		return core.Exit(4, "%s lease %q belongs to provider=%s", providerName, claim.LeaseID, claim.Provider)
 	}
 	if claim.ProviderScope != scope {
-		return exit(4, "%s lease %q belongs to a different API endpoint or account", providerName, claim.LeaseID)
+		return core.Exit(4, "%s lease %q belongs to a different API endpoint or account", providerName, claim.LeaseID)
 	}
-	if claim.Labels["provider"] != providerName || claim.Labels["lease"] != claim.LeaseID || normalizeLeaseSlug(claim.Labels["slug"]) != normalizeLeaseSlug(claim.Slug) {
-		return exit(4, "%s lease %q ownership labels do not match its local claim", providerName, claim.LeaseID)
+	if claim.Labels["provider"] != providerName || claim.Labels["lease"] != claim.LeaseID || core.NormalizeLeaseSlug(claim.Labels["slug"]) != core.NormalizeLeaseSlug(claim.Slug) {
+		return core.Exit(4, "%s lease %q ownership labels do not match its local claim", providerName, claim.LeaseID)
 	}
 	resourceName := claim.Labels[ukcLabelResourceName]
 	accountUUID := claim.Labels[ukcLabelAccountUUID]
 	if strings.TrimSpace(resourceName) == "" || strings.TrimSpace(accountUUID) == "" || strings.TrimSpace(claim.Labels[ukcLabelRequestHash]) == "" {
-		return exit(4, "%s lease %q has incomplete recovery identity", providerName, claim.LeaseID)
+		return core.Exit(4, "%s lease %q has incomplete recovery identity", providerName, claim.LeaseID)
 	}
-	if resourceName != leaseProviderName(claim.LeaseID, "") {
-		return exit(4, "%s lease %q has an unexpected recovery resource name", providerName, claim.LeaseID)
+	if resourceName != core.LeaseProviderName(claim.LeaseID, "") {
+		return core.Exit(4, "%s lease %q has an unexpected recovery resource name", providerName, claim.LeaseID)
 	}
 	if accountUUID != unikraftCloudScopeAccountUUID(scope) {
-		return exit(4, "%s lease %q account identity does not match its local claim scope", providerName, claim.LeaseID)
+		return core.Exit(4, "%s lease %q account identity does not match its local claim scope", providerName, claim.LeaseID)
 	}
 	if claim.CloudID != "" {
 		if !unikraftCloudUUIDPattern.MatchString(claim.CloudID) {
-			return exit(4, "%s lease %q has an invalid instance UUID", providerName, claim.LeaseID)
+			return core.Exit(4, "%s lease %q has an invalid instance UUID", providerName, claim.LeaseID)
 		}
 		if claim.Labels[ukcLabelInstanceUUID] != claim.CloudID {
-			return exit(4, "%s lease %q has a mismatched instance binding", providerName, claim.LeaseID)
+			return core.Exit(4, "%s lease %q has a mismatched instance binding", providerName, claim.LeaseID)
 		}
 	}
 	return nil
 }
 
-func verifyUnikraftCloudClaimSnapshot(snapshot, current LeaseClaim) error {
+func verifyUnikraftCloudClaimSnapshot(snapshot, current core.LeaseClaim) error {
 	if !reflect.DeepEqual(snapshot, current) {
-		return exit(4, "%s lease %q changed while waiting for its operation lock; retry with the current lease identity", providerName, snapshot.LeaseID)
+		return core.Exit(4, "%s lease %q changed while waiting for its operation lock; retry with the current lease identity", providerName, snapshot.LeaseID)
 	}
 	return nil
 }
 
 func validateUnikraftCloudInstanceIdentity(instance ukcInstance, expectedUUID, expectedName string) error {
 	if !unikraftCloudUUIDPattern.MatchString(instance.UUID) {
-		return exit(5, "%s instance response has an invalid UUID", providerName)
+		return core.Exit(5, "%s instance response has an invalid UUID", providerName)
 	}
 	if expectedUUID != "" && !strings.EqualFold(instance.UUID, expectedUUID) {
-		return exit(5, "%s instance identity changed: got %s, want %s", providerName, instance.UUID, expectedUUID)
+		return core.Exit(5, "%s instance identity changed: got %s, want %s", providerName, instance.UUID, expectedUUID)
 	}
 	if expectedName != "" && instance.Name != expectedName {
-		return exit(5, "%s instance %s name changed: got %q, want %q", providerName, instance.UUID, instance.Name, expectedName)
+		return core.Exit(5, "%s instance %s name changed: got %q, want %q", providerName, instance.UUID, instance.Name, expectedName)
 	}
 	return nil
 }
 
-func (b *backend) reconcileCreateIntent(ctx context.Context, api unikraftCloudAPI, claim LeaseClaim, removeWhenAbsent bool) (LeaseClaim, *ukcInstance, bool, error) {
+func (b *backend) reconcileCreateIntent(ctx context.Context, api unikraftCloudAPI, claim core.LeaseClaim, removeWhenAbsent bool) (core.LeaseClaim, *ukcInstance, bool, error) {
 	if claim.CloudID != "" {
 		return claim, nil, false, nil
 	}
@@ -354,13 +343,13 @@ func (b *backend) reconcileCreateIntent(ctx context.Context, api unikraftCloudAP
 	if err := b.proveCreateIntentAbsent(ctx, api, claim); err != nil {
 		return claim, nil, false, err
 	}
-	if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+	if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 		return claim, nil, false, err
 	}
-	return LeaseClaim{}, nil, true, nil
+	return core.LeaseClaim{}, nil, true, nil
 }
 
-func (b *backend) reconcileCreateIntentFromInventory(claim LeaseClaim, instances []ukcInstance) (LeaseClaim, *ukcInstance, error) {
+func (b *backend) reconcileCreateIntentFromInventory(claim core.LeaseClaim, instances []ukcInstance) (core.LeaseClaim, *ukcInstance, error) {
 	if claim.CloudID != "" || claim.Labels["state"] != ukcStateCreateIntent {
 		return claim, nil, nil
 	}
@@ -375,7 +364,7 @@ func (b *backend) reconcileCreateIntentFromInventory(claim LeaseClaim, instances
 		}
 	}
 	if len(matches) > 1 {
-		return claim, nil, exit(5, "%s create recovery found %d instances named %q; claim retained", providerName, len(matches), resourceName)
+		return claim, nil, core.Exit(5, "%s create recovery found %d instances named %q; claim retained", providerName, len(matches), resourceName)
 	}
 	if len(matches) == 1 {
 		if err := validateUnikraftCloudInstanceIdentity(matches[0], "", resourceName); err != nil {
@@ -405,82 +394,82 @@ func definiteUnikraftCloudCreateRejection(err error) bool {
 }
 
 type unikraftCloudClaimNotFoundError struct {
-	cause ExitError
+	cause core.ExitError
 }
 
 func (e *unikraftCloudClaimNotFoundError) Error() string { return e.cause.Error() }
 func (e *unikraftCloudClaimNotFoundError) Unwrap() error { return e.cause }
 
 func newUnikraftCloudClaimNotFoundError(identifier string) error {
-	return &unikraftCloudClaimNotFoundError{cause: exit(4, "%s instance %q is not claimed by Crabbox; warmup creates claimed instances, or use the Unikraft Cloud console or kraft CLI for unmanaged instances", providerName, identifier)}
+	return &unikraftCloudClaimNotFoundError{cause: core.Exit(4, "%s instance %q is not claimed by Crabbox; warmup creates claimed instances, or use the Unikraft Cloud console or kraft CLI for unmanaged instances", providerName, identifier)}
 }
 
-func (b *backend) resolveClaim(identifier, scope string) (LeaseClaim, bool, error) {
+func (b *backend) resolveClaim(identifier, scope string) (core.LeaseClaim, bool, error) {
 	identifier = strings.TrimSpace(identifier)
 	if identifier == "" {
-		return LeaseClaim{}, false, exit(2, "provider=%s requires --id <lease-id or slug>", providerName)
+		return core.LeaseClaim{}, false, core.Exit(2, "provider=%s requires --id <lease-id or slug>", providerName)
 	}
 	if strings.HasPrefix(identifier, leasePrefix) {
-		claim, exists, err := readLeaseClaimWithPresence(identifier)
+		claim, exists, err := core.ReadLeaseClaimWithPresence(identifier)
 		if err != nil {
-			return LeaseClaim{}, false, err
+			return core.LeaseClaim{}, false, err
 		}
 		if exists {
 			if err := validateUnikraftCloudClaim(claim, scope); err != nil {
-				return LeaseClaim{}, false, err
+				return core.LeaseClaim{}, false, err
 			}
 			return claim, true, nil
 		}
-		return LeaseClaim{}, false, newUnikraftCloudClaimNotFoundError(identifier)
+		return core.LeaseClaim{}, false, newUnikraftCloudClaimNotFoundError(identifier)
 	}
 	claims, err := listUnikraftCloudLeaseClaims()
 	if err != nil {
-		return LeaseClaim{}, false, err
+		return core.LeaseClaim{}, false, err
 	}
 	if unikraftCloudUUIDPattern.MatchString(identifier) {
-		var matched LeaseClaim
+		var matched core.LeaseClaim
 		for _, claim := range claims {
 			if claim.Provider != providerName || claim.ProviderScope != scope || !strings.EqualFold(claim.CloudID, identifier) {
 				continue
 			}
 			if matched.LeaseID != "" {
-				return LeaseClaim{}, false, exit(4, "%s instance %q is claimed by multiple local leases; use an exact lease ID", providerName, identifier)
+				return core.LeaseClaim{}, false, core.Exit(4, "%s instance %q is claimed by multiple local leases; use an exact lease ID", providerName, identifier)
 			}
 			matched = claim
 		}
 		if matched.LeaseID == "" {
-			return LeaseClaim{}, false, newUnikraftCloudClaimNotFoundError(identifier)
+			return core.LeaseClaim{}, false, newUnikraftCloudClaimNotFoundError(identifier)
 		}
 		if err := validateUnikraftCloudClaim(matched, scope); err != nil {
-			return LeaseClaim{}, false, err
+			return core.LeaseClaim{}, false, err
 		}
 		return matched, true, nil
 	}
 
-	slug := normalizeLeaseSlug(identifier)
-	var matched LeaseClaim
+	slug := core.NormalizeLeaseSlug(identifier)
+	var matched core.LeaseClaim
 	for _, claim := range claims {
 		if claim.Provider != providerName || claim.ProviderScope != scope {
 			continue
 		}
-		if claim.LeaseID != identifier && normalizeLeaseSlug(claim.Slug) != slug {
+		if claim.LeaseID != identifier && core.NormalizeLeaseSlug(claim.Slug) != slug {
 			continue
 		}
 		if matched.LeaseID != "" {
-			return LeaseClaim{}, false, exit(4, "%s identifier %q matches multiple local claims; use an exact lease ID", providerName, identifier)
+			return core.LeaseClaim{}, false, core.Exit(4, "%s identifier %q matches multiple local claims; use an exact lease ID", providerName, identifier)
 		}
 		matched = claim
 	}
 	if matched.LeaseID == "" {
-		return LeaseClaim{}, false, newUnikraftCloudClaimNotFoundError(identifier)
+		return core.LeaseClaim{}, false, newUnikraftCloudClaimNotFoundError(identifier)
 	}
 	if err := validateUnikraftCloudClaim(matched, scope); err != nil {
-		return LeaseClaim{}, false, err
+		return core.LeaseClaim{}, false, err
 	}
 	return matched, true, nil
 }
 
-func (b *backend) deleteClaimedInstance(ctx context.Context, api unikraftCloudAPI, claim LeaseClaim) (bool, error) {
+func (b *backend) deleteClaimedInstance(ctx context.Context, api unikraftCloudAPI, claim core.LeaseClaim) (bool, error) {
 	if claim.CloudID == "" {
 		state := claim.Labels["state"]
 		if state == ukcStateCreatePreflight || state == ukcStateCreateConflict {
@@ -488,7 +477,7 @@ func (b *backend) deleteClaimedInstance(ctx context.Context, api unikraftCloudAP
 			if err := b.proveInstanceAbsent(ctx, api, resourceName, resourceName); err != nil {
 				return false, fmt.Errorf("%s lease %s is non-adoptable and exact-name absence is unconfirmed; claim retained: %w", providerName, claim.LeaseID, err)
 			}
-			if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+			if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 				return false, err
 			}
 			return true, nil
@@ -500,7 +489,7 @@ func (b *backend) deleteClaimedInstance(ctx context.Context, api unikraftCloudAP
 		claim = resolved
 	}
 	if claim.CloudID == "" {
-		return false, exit(5, "%s lease %s has no resolved instance; recovery claim retained", providerName, claim.LeaseID)
+		return false, core.Exit(5, "%s lease %s has no resolved instance; recovery claim retained", providerName, claim.LeaseID)
 	}
 	instanceID := claim.CloudID
 	resourceName := claim.Labels[ukcLabelResourceName]
@@ -512,7 +501,7 @@ func (b *backend) deleteClaimedInstance(ctx context.Context, api unikraftCloudAP
 				if proofErr := b.proveInstanceAbsent(ctx, api, instanceID, resourceName); proofErr != nil {
 					return false, errors.Join(err, proofErr)
 				}
-				return true, removeLeaseClaimIfUnchanged(claim.LeaseID, claim)
+				return true, core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim)
 			}
 			return false, err
 		}
@@ -533,7 +522,7 @@ func (b *backend) deleteClaimedInstance(ctx context.Context, api unikraftCloudAP
 		deleted, deleteErr := api.DeleteInstance(ctx, instanceID)
 		if deleteErr != nil {
 			if proofErr := b.proveInstanceAbsent(ctx, api, instanceID, resourceName); proofErr == nil {
-				return true, removeLeaseClaimIfUnchanged(claim.LeaseID, claim)
+				return true, core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim)
 			}
 			return false, fmt.Errorf("delete %s instance %s was not confirmed; claim retained: %w", providerName, instanceID, deleteErr)
 		}
@@ -554,7 +543,7 @@ func (b *backend) deleteClaimedInstance(ctx context.Context, api unikraftCloudAP
 	if err := b.proveInstanceAbsent(ctx, api, instanceID, resourceName); err != nil {
 		return false, fmt.Errorf("%s deletion accepted for instance %s but absence is unconfirmed; claim retained: %w", providerName, instanceID, err)
 	}
-	if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+	if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 		return false, err
 	}
 	return false, nil
@@ -595,7 +584,7 @@ func (b *backend) proveInstanceAbsent(ctx context.Context, api unikraftCloudAPI,
 	}
 }
 
-func (b *backend) proveCreateIntentAbsent(ctx context.Context, api unikraftCloudAPI, claim LeaseClaim) error {
+func (b *backend) proveCreateIntentAbsent(ctx context.Context, api unikraftCloudAPI, claim core.LeaseClaim) error {
 	resourceName := strings.TrimSpace(claim.Labels[ukcLabelResourceName])
 	grace := b.deleteConfirmationTimeout
 	if grace <= 0 {
@@ -609,7 +598,7 @@ func (b *backend) proveCreateIntentAbsent(ctx context.Context, api unikraftCloud
 	defer cancel()
 	for {
 		if instance, err := api.GetInstance(graceCtx, resourceName); err == nil {
-			return exit(5, "%s ambiguous create for lease %s became visible as instance %s; claim retained, retry stop to reconcile exact ownership", providerName, claim.LeaseID, instance.UUID)
+			return core.Exit(5, "%s ambiguous create for lease %s became visible as instance %s; claim retained, retry stop to reconcile exact ownership", providerName, claim.LeaseID, instance.UUID)
 		} else if !isNotFound(err) {
 			return fmt.Errorf("observe %s ambiguous create %s during absence grace: %w", providerName, claim.LeaseID, err)
 		}
@@ -621,7 +610,7 @@ func (b *backend) proveCreateIntentAbsent(ctx context.Context, api unikraftCloud
 			return err
 		}
 		if unikraftCloudInventoryContains(instances, resourceName, resourceName) {
-			return exit(5, "%s ambiguous create for lease %s became visible during absence grace; claim retained, retry stop to reconcile exact ownership", providerName, claim.LeaseID)
+			return core.Exit(5, "%s ambiguous create for lease %s became visible during absence grace; claim retained, retry stop to reconcile exact ownership", providerName, claim.LeaseID)
 		}
 		timer := time.NewTimer(poll)
 		select {
@@ -667,9 +656,9 @@ func unikraftCloudTerminalState(state string) bool {
 	}
 }
 
-func serverFromClaim(claim LeaseClaim) Server {
+func serverFromClaim(claim core.LeaseClaim) core.Server {
 	labels := cloneLabels(claim.Labels)
-	return Server{
+	return core.Server{
 		CloudID:  claim.CloudID,
 		Provider: providerName,
 		Name:     core.Blank(labels[ukcLabelResourceName], claim.CloudID),
@@ -678,7 +667,7 @@ func serverFromClaim(claim LeaseClaim) Server {
 	}
 }
 
-func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
+func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	api, err := b.client()
 	if err != nil {
 		return err
@@ -706,7 +695,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 		if err != nil {
 			return err
 		}
-		current, exists, readErr := readLeaseClaimWithPresence(snapshot.LeaseID)
+		current, exists, readErr := core.ReadLeaseClaimWithPresence(snapshot.LeaseID)
 		if readErr != nil {
 			unlock()
 			return readErr
@@ -720,7 +709,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			return err
 		}
 		state := current.Labels["state"]
-		remove, reason := shouldCleanupServer(serverFromClaim(current), core.ClockNow(b.rt.Clock))
+		remove, reason := core.ShouldCleanupServer(serverFromClaim(current), core.ClockNow(b.rt.Clock))
 		if state == ukcStateDeleteAttempt || state == ukcStateDeleteAccepted || state == ukcStateCreatePreflight || state == ukcStateCreateConflict {
 			remove, reason = true, "resume "+state
 		}

--- a/internal/providers/unikraftcloud/nonadoptable_recovery_test.go
+++ b/internal/providers/unikraftcloud/nonadoptable_recovery_test.go
@@ -3,6 +3,8 @@ package unikraftcloud
 import (
 	"context"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestNonAdoptableCreateClaimsClearOnlyAfterAbsenceProof(t *testing.T) {
@@ -14,7 +16,7 @@ func TestNonAdoptableCreateClaimsClearOnlyAfterAbsenceProof(t *testing.T) {
 				b := testBackend(api, nil, nil)
 				leaseID := newLeaseID()
 				createReq := createInstanceRequest{
-					Name:      leaseProviderName(leaseID, ""),
+					Name:      core.LeaseProviderName(leaseID, ""),
 					Image:     b.cfg.UnikraftCloud.Image,
 					MemoryMB:  b.cfg.UnikraftCloud.MemoryMB,
 					Autostart: true,
@@ -23,9 +25,7 @@ func TestNonAdoptableCreateClaimsClearOnlyAfterAbsenceProof(t *testing.T) {
 					leaseID,
 					"non-adoptable",
 					testClaimScope(t, api.BaseURL()),
-					testUserUUID,
-					WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}, Keep: true},
-					createReq,
+					testUserUUID, core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}, Keep: true}, createReq,
 				)
 				if err != nil {
 					t.Fatalf("create preflight claim: %v", err)
@@ -39,9 +39,9 @@ func TestNonAdoptableCreateClaimsClearOnlyAfterAbsenceProof(t *testing.T) {
 
 				switch operation {
 				case "stop":
-					err = b.Stop(context.Background(), StopRequest{ID: claim.LeaseID})
+					err = b.Stop(context.Background(), core.StopRequest{ID: claim.LeaseID})
 				case "cleanup":
-					err = b.Cleanup(context.Background(), CleanupRequest{})
+					err = b.Cleanup(context.Background(), core.CleanupRequest{})
 				}
 				if err != nil {
 					t.Fatalf("%s: %v", operation, err)
@@ -49,7 +49,7 @@ func TestNonAdoptableCreateClaimsClearOnlyAfterAbsenceProof(t *testing.T) {
 				if len(api.created) != 0 || len(api.deletedIDs) != 0 {
 					t.Fatalf("provider mutations = created %#v deleted %#v, want none", api.created, api.deletedIDs)
 				}
-				if _, exists, readErr := readLeaseClaimWithPresence(claim.LeaseID); readErr != nil || exists {
+				if _, exists, readErr := core.ReadLeaseClaimWithPresence(claim.LeaseID); readErr != nil || exists {
 					t.Fatalf("claim exists=%v err=%v, want removed", exists, readErr)
 				}
 			})

--- a/internal/providers/unikraftcloud/operation_lock.go
+++ b/internal/providers/unikraftcloud/operation_lock.go
@@ -5,13 +5,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func lockUnikraftCloudLeaseOperation(ctx context.Context, leaseID string) (func(), error) {
 	if !strings.HasPrefix(leaseID, leasePrefix) || strings.TrimPrefix(leaseID, leasePrefix) == "" ||
 		strings.ContainsAny(leaseID, `/\`) || filepath.Base(leaseID) != leaseID || leaseID == "." {
-		return nil, exit(2, "invalid unikraft-cloud lease id %q", leaseID)
+		return nil, core.Exit(2, "invalid unikraft-cloud lease id %q", leaseID)
 	}
 	return shared.LockLeaseOperation(ctx, "unikraft-cloud", leaseID)
 }

--- a/internal/providers/unikraftcloud/ownership.go
+++ b/internal/providers/unikraftcloud/ownership.go
@@ -1,10 +1,14 @@
 package unikraftcloud
 
-import "strings"
+import (
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
 
 // preflightUnikraftCloudClaimOwnership rejects ambiguous or corrupted local
 // ownership before any provider mutation or create-intent reconciliation.
-func preflightUnikraftCloudClaimOwnership(claims []LeaseClaim, scope string) error {
+func preflightUnikraftCloudClaimOwnership(claims []core.LeaseClaim, scope string) error {
 	accountUUID := unikraftCloudScopeAccountUUID(scope)
 	resourceOwners := make(map[string]string)
 	instanceOwners := make(map[string]string)
@@ -16,14 +20,14 @@ func preflightUnikraftCloudClaimOwnership(claims []LeaseClaim, scope string) err
 			return err
 		}
 		if claim.Labels[ukcLabelAccountUUID] != accountUUID {
-			return exit(4, "%s lease %q account identity does not match its local claim scope", providerName, claim.LeaseID)
+			return core.Exit(4, "%s lease %q account identity does not match its local claim scope", providerName, claim.LeaseID)
 		}
 		resourceName := strings.TrimSpace(claim.Labels[ukcLabelResourceName])
-		if expected := leaseProviderName(claim.LeaseID, ""); resourceName != expected {
-			return exit(4, "%s lease %q has an unexpected recovery resource name", providerName, claim.LeaseID)
+		if expected := core.LeaseProviderName(claim.LeaseID, ""); resourceName != expected {
+			return core.Exit(4, "%s lease %q has an unexpected recovery resource name", providerName, claim.LeaseID)
 		}
 		if previous, exists := resourceOwners[resourceName]; exists {
-			return exit(5, "%s resource name %q is claimed by both %s and %s", providerName, resourceName, previous, claim.LeaseID)
+			return core.Exit(5, "%s resource name %q is claimed by both %s and %s", providerName, resourceName, previous, claim.LeaseID)
 		}
 		resourceOwners[resourceName] = claim.LeaseID
 
@@ -32,7 +36,7 @@ func preflightUnikraftCloudClaimOwnership(claims []LeaseClaim, scope string) err
 			continue
 		}
 		if previous, exists := instanceOwners[instanceID]; exists {
-			return exit(5, "%s instance %s is claimed by both %s and %s", providerName, instanceID, previous, claim.LeaseID)
+			return core.Exit(5, "%s instance %s is claimed by both %s and %s", providerName, instanceID, previous, claim.LeaseID)
 		}
 		instanceOwners[instanceID] = claim.LeaseID
 	}

--- a/internal/providers/unikraftcloud/ownership_test.go
+++ b/internal/providers/unikraftcloud/ownership_test.go
@@ -8,7 +8,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func duplicateBoundUnikraftCloudClaims(t *testing.T) (*backend, *fakeUnikraftCloudAPI, LeaseClaim, LeaseClaim) {
+func duplicateBoundUnikraftCloudClaims(t *testing.T) (*backend, *fakeUnikraftCloudAPI, core.LeaseClaim, core.LeaseClaim) {
 	t.Helper()
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	api := &fakeUnikraftCloudAPI{
@@ -16,13 +16,13 @@ func duplicateBoundUnikraftCloudClaims(t *testing.T) (*backend, *fakeUnikraftClo
 		createResult: ukcInstance{UUID: testInstanceUUID, State: "running"},
 	}
 	b := testBackend(api, nil, nil)
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	first := onlyTestClaim(t)
 
 	secondLeaseID := newLeaseID()
-	secondName := leaseProviderName(secondLeaseID, "")
+	secondName := core.LeaseProviderName(secondLeaseID, "")
 	createReq := createInstanceRequest{
 		Name:      secondName,
 		Image:     b.cfg.UnikraftCloud.Image,
@@ -33,9 +33,7 @@ func duplicateBoundUnikraftCloudClaims(t *testing.T) (*backend, *fakeUnikraftClo
 		secondLeaseID,
 		"duplicate-owner",
 		testClaimScope(t, api.BaseURL()),
-		testUserUUID,
-		WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}, Keep: true},
-		createReq,
+		testUserUUID, core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}, Keep: true}, createReq,
 	)
 	if err != nil {
 		t.Fatalf("create second intent: %v", err)
@@ -50,7 +48,7 @@ func duplicateBoundUnikraftCloudClaims(t *testing.T) (*backend, *fakeUnikraftClo
 func TestStopRejectsDuplicateInstanceClaimsBeforeMutation(t *testing.T) {
 	b, api, first, _ := duplicateBoundUnikraftCloudClaims(t)
 
-	err := b.Stop(context.Background(), StopRequest{ID: first.LeaseID})
+	err := b.Stop(context.Background(), core.StopRequest{ID: first.LeaseID})
 	if err == nil || !strings.Contains(err.Error(), "claimed by both") {
 		t.Fatalf("Stop err = %v, want duplicate ownership error", err)
 	}
@@ -68,7 +66,7 @@ func TestCleanupRejectsDuplicateInstanceClaimsBeforeMutation(t *testing.T) {
 		t.Fatalf("expire first claim: %v", err)
 	}
 
-	err := b.Cleanup(context.Background(), CleanupRequest{})
+	err := b.Cleanup(context.Background(), core.CleanupRequest{})
 	if err == nil || !strings.Contains(err.Error(), "claimed by both") {
 		t.Fatalf("Cleanup err = %v, want duplicate ownership error", err)
 	}
@@ -80,7 +78,7 @@ func TestCleanupRejectsDuplicateInstanceClaimsBeforeMutation(t *testing.T) {
 func TestStatusRejectsDuplicateInstanceClaimAmbiguity(t *testing.T) {
 	b, api, _, _ := duplicateBoundUnikraftCloudClaims(t)
 
-	_, err := b.Status(context.Background(), StatusRequest{ID: testInstanceUUID})
+	_, err := b.Status(context.Background(), core.StatusRequest{ID: testInstanceUUID})
 	if err == nil || !strings.Contains(err.Error(), "claimed by multiple") {
 		t.Fatalf("Status err = %v, want duplicate CloudID ambiguity", err)
 	}
@@ -94,7 +92,7 @@ func TestOwnershipPreflightCanonicalizesInstanceUUIDCase(t *testing.T) {
 	second.CloudID = strings.ToUpper(second.CloudID)
 	second.Labels[ukcLabelInstanceUUID] = second.CloudID
 
-	err := preflightUnikraftCloudClaimOwnership([]LeaseClaim{first, second}, first.ProviderScope)
+	err := preflightUnikraftCloudClaimOwnership([]core.LeaseClaim{first, second}, first.ProviderScope)
 	if err == nil || !strings.Contains(err.Error(), "claimed by both") {
 		t.Fatalf("preflight err = %v, want case-insensitive duplicate UUID rejection", err)
 	}
@@ -106,7 +104,7 @@ func TestOwnershipPreflightRejectsPendingResourceNameCollision(t *testing.T) {
 	second.Labels[ukcLabelInstanceUUID] = ""
 	second.Labels[ukcLabelResourceName] = first.Labels[ukcLabelResourceName]
 
-	err := preflightUnikraftCloudClaimOwnership([]LeaseClaim{first, second}, first.ProviderScope)
+	err := preflightUnikraftCloudClaimOwnership([]core.LeaseClaim{first, second}, first.ProviderScope)
 	if err == nil || !strings.Contains(err.Error(), "recovery resource name") {
 		t.Fatalf("preflight err = %v, want corrupt resource-name rejection", err)
 	}

--- a/internal/providers/unikraftcloud/provenance_test.go
+++ b/internal/providers/unikraftcloud/provenance_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type unikraftCloudProvenanceAPI struct {
@@ -58,7 +60,7 @@ func TestWarmupRefusesPreexistingGeneratedNameBeforeCreate(t *testing.T) {
 	}
 	b := testBackend(api, nil, nil)
 
-	err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}})
+	err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}})
 	if err == nil || !strings.Contains(err.Error(), "already exists before create") {
 		t.Fatalf("Warmup err = %v, want ownership conflict", err)
 	}
@@ -79,7 +81,7 @@ func TestWarmupRefusesMalformedPreflightInventoryBeforeCreate(t *testing.T) {
 	}
 	b := testBackend(api, nil, nil)
 
-	err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}})
+	err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}})
 	if err == nil || !strings.Contains(err.Error(), "invalid instance UUID") {
 		t.Fatalf("Warmup err = %v, want malformed inventory rejection", err)
 	}
@@ -110,7 +112,7 @@ func TestWarmupNeverAdoptsExactNameAfterDefiniteCreateRejection(t *testing.T) {
 	}
 	b := testBackend(api, nil, nil)
 
-	err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}})
+	err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}})
 	if err == nil || !strings.Contains(err.Error(), "non-adoptable recovery claim") {
 		t.Fatalf("Warmup err = %v, want retained non-adoptable conflict", err)
 	}
@@ -122,14 +124,14 @@ func TestWarmupNeverAdoptsExactNameAfterDefiniteCreateRejection(t *testing.T) {
 		t.Fatalf("conflict claim = %#v", conflict)
 	}
 
-	if _, listErr := b.List(context.Background(), ListRequest{}); listErr != nil {
+	if _, listErr := b.List(context.Background(), core.ListRequest{}); listErr != nil {
 		t.Fatalf("List conflict claim: %v", listErr)
 	}
 	stillConflict := onlyTestClaim(t)
 	if stillConflict.CloudID != "" || stillConflict.Labels["state"] != ukcStateCreateConflict {
 		t.Fatalf("List adopted rejected create: %#v", stillConflict)
 	}
-	if stopErr := b.Stop(context.Background(), StopRequest{ID: conflict.LeaseID}); stopErr == nil {
+	if stopErr := b.Stop(context.Background(), core.StopRequest{ID: conflict.LeaseID}); stopErr == nil {
 		t.Fatal("Stop adopted or deleted a rejected create conflict")
 	}
 	if len(base.deletedIDs) != 0 {
@@ -146,14 +148,14 @@ func TestStopRetainsAmbiguousCreateThatAppearsDuringAbsenceGrace(t *testing.T) {
 	api := &unikraftCloudEventuallyVisibleCreateAPI{fakeUnikraftCloudAPI: base}
 	b := testBackend(api, nil, nil)
 
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}}); err == nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}); err == nil {
 		t.Fatal("Warmup succeeded, want ambiguous create error")
 	}
 	intent := onlyTestClaim(t)
 	if intent.CloudID != "" || intent.Labels["state"] != ukcStateCreateIntent {
 		t.Fatalf("intent = %#v", intent)
 	}
-	err := b.Stop(context.Background(), StopRequest{ID: intent.LeaseID})
+	err := b.Stop(context.Background(), core.StopRequest{ID: intent.LeaseID})
 	if err == nil || !strings.Contains(err.Error(), "became visible") {
 		t.Fatalf("Stop err = %v, want eventual-visibility retention", err)
 	}

--- a/internal/providers/unikraftcloud/provider_test.go
+++ b/internal/providers/unikraftcloud/provider_test.go
@@ -35,7 +35,7 @@ func TestUnikraftCloudProviderSpec(t *testing.T) {
 
 func TestUnikraftCloudAPIKeyFlagIsNotRegistered(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	registerUnikraftCloudProviderFlags(fs, Config{})
+	registerUnikraftCloudProviderFlags(fs, core.Config{})
 	for _, name := range []string{"unikraft-cloud-token", "unikraft-cloud-api-key", "unikraft-cloud-key", "ukc-token"} {
 		if fs.Lookup(name) != nil {
 			t.Fatalf("Unikraft Cloud API key surfaced as a flag --%s", name)
@@ -53,12 +53,12 @@ func TestApplyUnikraftCloudProviderFlags(t *testing.T) {
 		name    string
 		args    []string
 		wantErr bool
-		check   func(t *testing.T, cfg Config)
+		check   func(t *testing.T, cfg core.Config)
 	}{
 		{
 			name: "overrides",
 			args: []string{"-unikraft-cloud-metro", "dal", "-unikraft-cloud-image", "unikraft.org/nginx:latest", "-unikraft-cloud-memory", "256"},
-			check: func(t *testing.T, cfg Config) {
+			check: func(t *testing.T, cfg core.Config) {
 				if cfg.UnikraftCloud.Metro != "dal" {
 					t.Fatalf("metro = %q", cfg.UnikraftCloud.Metro)
 				}
@@ -85,11 +85,11 @@ func TestApplyUnikraftCloudProviderFlags(t *testing.T) {
 			fs := flag.NewFlagSet("test", flag.ContinueOnError)
 			fs.String("class", "", "")
 			fs.String("type", "", "")
-			values := registerUnikraftCloudProviderFlags(fs, Config{})
+			values := registerUnikraftCloudProviderFlags(fs, core.Config{})
 			if err := fs.Parse(test.args); err != nil {
 				t.Fatalf("parse: %v", err)
 			}
-			cfg := Config{Provider: providerName}
+			cfg := core.Config{Provider: providerName}
 			err := applyUnikraftCloudProviderFlags(&cfg, fs, values)
 			if test.wantErr {
 				if err == nil {

--- a/internal/providers/unikraftcloud/resolution_inventory_test.go
+++ b/internal/providers/unikraftcloud/resolution_inventory_test.go
@@ -27,17 +27,15 @@ func (api *sequencedUnikraftCloudAPI) ListInstances(context.Context) ([]ukcInsta
 	return append([]ukcInstance(nil), api.listResults[index]...), nil
 }
 
-func createPendingUnikraftCloudIntent(t *testing.T, b *backend, api unikraftCloudAPI) LeaseClaim {
+func createPendingUnikraftCloudIntent(t *testing.T, b *backend, api unikraftCloudAPI) core.LeaseClaim {
 	t.Helper()
 	leaseID := newLeaseID()
-	name := leaseProviderName(leaseID, "")
+	name := core.LeaseProviderName(leaseID, "")
 	intent, err := b.createIntentClaim(
 		leaseID,
 		"pending-intent",
 		testClaimScope(t, api.BaseURL()),
-		testUserUUID,
-		WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}},
-		createInstanceRequest{Name: name, Image: b.cfg.UnikraftCloud.Image, MemoryMB: b.cfg.UnikraftCloud.MemoryMB, Autostart: true},
+		testUserUUID, core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}, createInstanceRequest{Name: name, Image: b.cfg.UnikraftCloud.Image, MemoryMB: b.cfg.UnikraftCloud.MemoryMB, Autostart: true},
 	)
 	if err != nil {
 		t.Fatalf("create intent: %v", err)
@@ -60,7 +58,7 @@ func TestListReconcilesPendingIntentAgainstOneInventorySnapshot(t *testing.T) {
 		{{UUID: testInstanceUUID, Name: intent.Labels[ukcLabelResourceName], State: "running"}},
 	}
 
-	servers, err := b.List(context.Background(), ListRequest{All: true})
+	servers, err := b.List(context.Background(), core.ListRequest{All: true})
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -80,14 +78,14 @@ func TestStatusExactCloudIDPrecedesUUIDShapedSlug(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	apiA := &fakeUnikraftCloudAPI{baseURL: "https://api.fra.unikraft.cloud", createResult: ukcInstance{UUID: testInstanceUUID, State: "running"}}
 	bA := testBackend(apiA, nil, nil)
-	if err := bA.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "a"}, RequestedSlug: "owner-a"}); err != nil {
+	if err := bA.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "a"}, RequestedSlug: "owner-a"}); err != nil {
 		t.Fatalf("Warmup A: %v", err)
 	}
 
 	const otherUUID = "66666666-7777-8888-9999-000000000000"
 	apiB := &fakeUnikraftCloudAPI{baseURL: apiA.BaseURL(), createResult: ukcInstance{UUID: otherUUID, State: "running"}}
 	bB := testBackend(apiB, nil, nil)
-	if err := bB.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "b"}, RequestedSlug: testInstanceUUID}); err != nil {
+	if err := bB.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "b"}, RequestedSlug: testInstanceUUID}); err != nil {
 		t.Fatalf("Warmup B: %v", err)
 	}
 
@@ -101,7 +99,7 @@ func TestStatusExactCloudIDPrecedesUUIDShapedSlug(t *testing.T) {
 			wantLeaseID = claim.LeaseID
 		}
 	}
-	view, err := bA.Status(context.Background(), StatusRequest{ID: testInstanceUUID})
+	view, err := bA.Status(context.Background(), core.StatusRequest{ID: testInstanceUUID})
 	if err != nil {
 		t.Fatalf("Status: %v", err)
 	}
@@ -118,7 +116,7 @@ func TestStatusRawUnclaimedUUIDStillWorks(t *testing.T) {
 	}
 	b := testBackend(api, nil, nil)
 
-	view, err := b.Status(context.Background(), StatusRequest{ID: testInstanceUUID})
+	view, err := b.Status(context.Background(), core.StatusRequest{ID: testInstanceUUID})
 	if err != nil {
 		t.Fatalf("Status: %v", err)
 	}
@@ -131,7 +129,7 @@ func TestStatusDoesNotRawFallbackForCorruptExactClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	api := &fakeUnikraftCloudAPI{baseURL: "https://api.fra.unikraft.cloud", createResult: ukcInstance{UUID: testInstanceUUID, State: "running"}}
 	b := testBackend(api, nil, nil)
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	claim := onlyTestClaim(t)
@@ -141,7 +139,7 @@ func TestStatusDoesNotRawFallbackForCorruptExactClaim(t *testing.T) {
 		t.Fatalf("corrupt claim: %v", err)
 	}
 
-	_, err := b.Status(context.Background(), StatusRequest{ID: claim.LeaseID})
+	_, err := b.Status(context.Background(), core.StatusRequest{ID: claim.LeaseID})
 	if err == nil || !strings.Contains(err.Error(), "account identity") {
 		t.Fatalf("Status err = %v, want exact claim corruption", err)
 	}
@@ -155,15 +153,15 @@ func TestStopTreatsLeaseShapedIdentifierAsExactOnly(t *testing.T) {
 	api := &fakeUnikraftCloudAPI{baseURL: "https://api.fra.unikraft.cloud", createResult: ukcInstance{UUID: testInstanceUUID, State: "running"}}
 	b := testBackend(api, nil, nil)
 	const staleLeaseID = "ukc_stale-missing"
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}, RequestedSlug: staleLeaseID}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}, RequestedSlug: staleLeaseID}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 
-	err := b.Stop(context.Background(), StopRequest{ID: staleLeaseID})
+	err := b.Stop(context.Background(), core.StopRequest{ID: staleLeaseID})
 	if err == nil || !strings.Contains(err.Error(), "not claimed") {
 		t.Fatalf("Stop err = %v, want exact missing lease", err)
 	}
-	var exitErr ExitError
+	var exitErr core.ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 4 {
 		t.Fatalf("Stop err = %#v, want exit 4", err)
 	}
@@ -180,7 +178,7 @@ func TestWarmupRejectsMalformedPreflightInventoryBeforeCreate(t *testing.T) {
 	}
 	b := testBackend(api, nil, nil)
 
-	err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}})
+	err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}})
 	if err == nil || !strings.Contains(err.Error(), "invalid instance UUID") {
 		t.Fatalf("Warmup err = %v, want malformed inventory", err)
 	}
@@ -196,21 +194,21 @@ func TestStopRetainsClaimWhenAbsenceInventoryIsMalformed(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	api := &fakeUnikraftCloudAPI{baseURL: "https://api.fra.unikraft.cloud", createResult: ukcInstance{UUID: testInstanceUUID, State: "running"}}
 	b := testBackend(api, nil, nil)
-	if err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
+	if err := b.Warmup(context.Background(), core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}); err != nil {
 		t.Fatalf("Warmup: %v", err)
 	}
 	claim := onlyTestClaim(t)
 	api.getErr = notFoundErr()
 	api.listResult = []ukcInstance{{UUID: "not-a-uuid", Name: "unrelated", State: "running"}}
 
-	err := b.Stop(context.Background(), StopRequest{ID: claim.LeaseID})
+	err := b.Stop(context.Background(), core.StopRequest{ID: claim.LeaseID})
 	if err == nil || !strings.Contains(err.Error(), "invalid instance UUID") {
 		t.Fatalf("Stop err = %v, want malformed absence inventory", err)
 	}
 	if len(api.deletedIDs) != 0 {
 		t.Fatalf("deletedIDs = %#v, want no delete after ambiguous GET", api.deletedIDs)
 	}
-	if _, exists, readErr := readLeaseClaimWithPresence(claim.LeaseID); readErr != nil || !exists {
+	if _, exists, readErr := core.ReadLeaseClaimWithPresence(claim.LeaseID); readErr != nil || !exists {
 		t.Fatalf("claim exists=%v err=%v, want retained", exists, readErr)
 	}
 }

--- a/internal/providers/unikraftcloud/snapshot_test.go
+++ b/internal/providers/unikraftcloud/snapshot_test.go
@@ -3,10 +3,12 @@ package unikraftcloud
 import (
 	"strings"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestVerifyUnikraftCloudClaimSnapshotRejectsRebind(t *testing.T) {
-	snapshot := LeaseClaim{
+	snapshot := core.LeaseClaim{
 		LeaseID:       "ukc_aaaaaaaaaaaa",
 		Slug:          "snapshot",
 		Provider:      providerName,

--- a/internal/providers/unikraftcloud/status_lock_test.go
+++ b/internal/providers/unikraftcloud/status_lock_test.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type unikraftCloudStatusWaitAPI struct {
@@ -33,7 +35,7 @@ func TestStatusWaitSleepsOutsideLeaseOperationLock(t *testing.T) {
 	b.pollInterval = 50 * time.Millisecond
 	leaseID := newLeaseID()
 	createReq := createInstanceRequest{
-		Name:      leaseProviderName(leaseID, ""),
+		Name:      core.LeaseProviderName(leaseID, ""),
 		Image:     b.cfg.UnikraftCloud.Image,
 		MemoryMB:  b.cfg.UnikraftCloud.MemoryMB,
 		Autostart: true,
@@ -42,9 +44,7 @@ func TestStatusWaitSleepsOutsideLeaseOperationLock(t *testing.T) {
 		leaseID,
 		"status-wait-lock",
 		testClaimScope(t, api.BaseURL()),
-		testUserUUID,
-		WarmupRequest{Repo: Repo{Root: t.TempDir(), Name: "demo"}},
-		createReq,
+		testUserUUID, core.WarmupRequest{Repo: core.Repo{Root: t.TempDir(), Name: "demo"}}, createReq,
 	)
 	if err != nil {
 		t.Fatalf("create preflight claim: %v", err)
@@ -56,7 +56,7 @@ func TestStatusWaitSleepsOutsideLeaseOperationLock(t *testing.T) {
 
 	statusErr := make(chan error, 1)
 	go func() {
-		_, waitErr := b.Status(context.Background(), StatusRequest{ID: intent.LeaseID, Wait: true, WaitTimeout: 500 * time.Millisecond})
+		_, waitErr := b.Status(context.Background(), core.StatusRequest{ID: intent.LeaseID, Wait: true, WaitTimeout: 500 * time.Millisecond})
 		statusErr <- waitErr
 	}()
 	select {
@@ -67,7 +67,7 @@ func TestStatusWaitSleepsOutsideLeaseOperationLock(t *testing.T) {
 
 	stopCtx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
 	defer cancel()
-	if err := b.Stop(stopCtx, StopRequest{ID: intent.LeaseID}); err != nil {
+	if err := b.Stop(stopCtx, core.StopRequest{ID: intent.LeaseID}); err != nil {
 		t.Fatalf("Stop while Status waits: %v", err)
 	}
 	select {

--- a/internal/providers/vast/backend.go
+++ b/internal/providers/vast/backend.go
@@ -150,7 +150,7 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 
 func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (target core.LeaseTarget, err error) {
 	if b.cfg.TargetOS != "" && b.cfg.TargetOS != core.TargetLinux {
-		return core.LeaseTarget{}, exit(2, "provider=%s supports target=linux only", providerName)
+		return core.LeaseTarget{}, core.Exit(2, "provider=%s supports target=linux only", providerName)
 	}
 	client, err := b.api()
 	if err != nil {
@@ -161,7 +161,7 @@ func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 		return core.LeaseTarget{}, err
 	}
 	if user.ID == 0 {
-		return core.LeaseTarget{}, exit(5, "vast auth returned no account id")
+		return core.LeaseTarget{}, core.Exit(5, "vast auth returned no account id")
 	}
 	accountID := strconv.Itoa(user.ID)
 	apiURL := vastAPIEndpointIdentity(b.cfg.Vast.APIURL)
@@ -245,7 +245,7 @@ func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 	instanceID = firstNonZero(created.Instance.ID, created.NewContract)
 	if instanceID == 0 {
 		ambiguousCreate = true
-		err = exit(5, "vast create returned no instance id")
+		err = core.Exit(5, "vast create returned no instance id")
 		return core.LeaseTarget{}, err
 	}
 	if attach, attachErr := client.AttachInstanceSSHKey(ctx, instanceID, publicKey); attachErr != nil {
@@ -262,7 +262,7 @@ func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 		}
 		keyID = vastMatchingSSHKeyID(keys, publicKey)
 		if keyID == "" {
-			err = exit(5, "vast attach SSH key returned no removable key id")
+			err = core.Exit(5, "vast attach SSH key returned no removable key id")
 			return core.LeaseTarget{}, err
 		}
 	}
@@ -317,7 +317,7 @@ func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 func (b *backend) bootstrapVastTools(ctx context.Context, target core.SSHTarget) error {
 	fmt.Fprintln(b.stderr(), "bootstrapping vast instance tools")
 	if err := b.runSSH(ctx, target, vastBootstrapToolsCommand()); err != nil {
-		return exit(1, "vast instance tool bootstrap failed: %v", err)
+		return core.Exit(1, "vast instance tool bootstrap failed: %v", err)
 	}
 	return nil
 }
@@ -352,7 +352,7 @@ func selectVastOffer(offers []vastOffer) (vastOffer, error) {
 	if len(offers) > 0 && vastOfferAskID(offers[0]) != 0 {
 		return offers[0], nil
 	}
-	return vastOffer{}, exit(4, "vast found no eligible offers")
+	return vastOffer{}, core.Exit(4, "vast found no eligible offers")
 }
 
 func vastOfferAskID(offer vastOffer) int {
@@ -396,10 +396,10 @@ func (b *backend) waitForInstanceReady(ctx context.Context, client vastAPI, id i
 				return true, nil
 			}
 			if isTerminalVastStatus(instance.Status) {
-				return false, exit(5, "vast instance %d reached terminal status %s", id, instance.Status)
+				return false, core.Exit(5, "vast instance %d reached terminal status %s", id, instance.Status)
 			}
 			if b.now().After(deadline) {
-				return false, exit(5, "timed out waiting for Vast instance %d to expose SSH", id)
+				return false, core.Exit(5, "timed out waiting for Vast instance %d to expose SSH", id)
 			}
 			return false, nil
 		}, nil)
@@ -468,7 +468,7 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 		}
 		return b.targetFromInstance(ctx, client, item, req)
 	}
-	return core.LeaseTarget{}, exit(4, "lease/instance not found: %s", req.ID)
+	return core.LeaseTarget{}, core.Exit(4, "lease/instance not found: %s", req.ID)
 }
 
 func (b *backend) resolveAmbiguousVastCreate(ctx context.Context, client vastAPI, instances []vastInstance, claim core.LeaseClaim, req core.ResolveRequest) (core.LeaseTarget, error) {
@@ -489,13 +489,13 @@ func (b *backend) resolveAmbiguousVastCreate(ctx context.Context, client vastAPI
 		matches++
 	}
 	if matches > 1 {
-		return core.LeaseTarget{}, exit(2, "refusing to recover ambiguous Vast create for lease=%s slug=%s: matched %d instances", claim.LeaseID, claim.Slug, matches)
+		return core.LeaseTarget{}, core.Exit(2, "refusing to recover ambiguous Vast create for lease=%s slug=%s: matched %d instances", claim.LeaseID, claim.Slug, matches)
 	}
 	if matches == 0 {
-		return core.LeaseTarget{}, exit(4, "vast ambiguous instance create remains indeterminate for lease=%s; credentials and recovery claim retained", claim.LeaseID)
+		return core.LeaseTarget{}, core.Exit(4, "vast ambiguous instance create remains indeterminate for lease=%s; credentials and recovery claim retained", claim.LeaseID)
 	}
 	if req.NoLocalStateMutations {
-		return core.LeaseTarget{}, exit(2, "vast ambiguous-create recovery for lease=%s requires a durable instance claim", claim.LeaseID)
+		return core.LeaseTarget{}, core.Exit(2, "vast ambiguous-create recovery for lease=%s requires a durable instance claim", claim.LeaseID)
 	}
 	replacement := claim
 	replacement.CloudID = strconv.Itoa(recovered.ID)
@@ -521,10 +521,10 @@ func (b *backend) releaseTargetFromClaim(id string, cause error, releaseOnly boo
 
 func (b *backend) targetFromInstance(ctx context.Context, client vastAPI, item vastInstance, req core.ResolveRequest) (core.LeaseTarget, error) {
 	if !isOwnedVastInstance(item) {
-		return core.LeaseTarget{}, exit(2, "refusing to operate on non-Crabbox Vast instance %d", item.ID)
+		return core.LeaseTarget{}, core.Exit(2, "refusing to operate on non-Crabbox Vast instance %d", item.ID)
 	}
 	if isTerminalVastStatus(item.Status) && !req.ReleaseOnly && !req.StatusOnly {
-		return core.LeaseTarget{}, exit(5, "vast instance %d reached terminal status %s", item.ID, item.Status)
+		return core.LeaseTarget{}, core.Exit(5, "vast instance %d reached terminal status %s", item.ID, item.Status)
 	}
 	server := serverFromInstance(item, b.cfg)
 	server = mergeVastClaimMetadata(server)
@@ -541,13 +541,13 @@ func (b *backend) targetFromInstance(ctx context.Context, client vastAPI, item v
 			return core.LeaseTarget{}, err
 		}
 	} else if req.ReleaseOnly {
-		return core.LeaseTarget{}, exit(2, "vast lease=%s has no exact local claim; refusing release", leaseID)
+		return core.LeaseTarget{}, core.Exit(2, "vast lease=%s has no exact local claim; refusing release", leaseID)
 	} else if !req.NoLocalStateMutations && !req.StatusOnly {
 		if !req.Reclaim {
-			return core.LeaseTarget{}, exit(2, "vast lease=%s is unclaimed; use --reclaim to adopt it explicitly", leaseID)
+			return core.LeaseTarget{}, core.Exit(2, "vast lease=%s is unclaimed; use --reclaim to adopt it explicitly", leaseID)
 		}
 		if req.Repo.Root == "" {
-			return core.LeaseTarget{}, exit(2, "vast lease=%s cannot be reclaimed without a repository root", leaseID)
+			return core.LeaseTarget{}, core.Exit(2, "vast lease=%s cannot be reclaimed without a repository root", leaseID)
 		}
 		if err := b.populateVastClaimProviderIdentity(ctx, client, server.Labels); err != nil {
 			return core.LeaseTarget{}, err
@@ -689,7 +689,7 @@ func (b *backend) deleteServerWithOutcome(ctx context.Context, server core.Serve
 	leaseID := binding.LeaseID
 	instanceID, ok := parseVastInstanceID(firstNonBlank(server.CloudID, claim.CloudID))
 	if !ok {
-		return exit(2, "provider=%s release requires a Vast instance id", providerName)
+		return core.Exit(2, "provider=%s release requires a Vast instance id", providerName)
 	}
 	action := effectiveVastReleaseAction(b.cfg, claim.Labels)
 	switch action {
@@ -876,24 +876,24 @@ func isOwnedVastInstance(item vastInstance) bool {
 
 func validateVastServer(server core.Server) error {
 	if server.Provider != "" && server.Provider != providerName {
-		return exit(2, "refusing to operate on provider=%s server as Vast", server.Provider)
+		return core.Exit(2, "refusing to operate on provider=%s server as Vast", server.Provider)
 	}
 	leaseID := strings.TrimSpace(server.Labels["lease"])
 	if leaseID == "" || strings.TrimSpace(server.Labels["slug"]) == "" {
-		return exit(2, "refusing to operate on non-Crabbox Vast instance %s", server.DisplayID())
+		return core.Exit(2, "refusing to operate on non-Crabbox Vast instance %s", server.DisplayID())
 	}
 	return nil
 }
 
 func validateLiveVastInstance(item vastInstance, expected core.Server) error {
 	if !isOwnedVastInstance(item) {
-		return exit(2, "refusing to operate on non-Crabbox Vast instance %d", item.ID)
+		return core.Exit(2, "refusing to operate on non-Crabbox Vast instance %d", item.ID)
 	}
 	owner, _ := decodeVastOwnershipLabel(item.Label)
 	if strconv.Itoa(item.ID) != expected.CloudID ||
 		owner.LeaseID != expected.Labels["lease"] ||
 		owner.Slug != expected.Labels["slug"] {
-		return exit(2, "refusing to operate on changed Vast instance %s", expected.CloudID)
+		return core.Exit(2, "refusing to operate on changed Vast instance %s", expected.CloudID)
 	}
 	return nil
 }
@@ -901,14 +901,14 @@ func validateLiveVastInstance(item vastInstance, expected core.Server) error {
 func validateVastClaimIdentity(claim core.LeaseClaim, leaseID, slug, cloudID string) error {
 	binding := shared.ClaimBinding{Provider: providerName, LeaseID: leaseID, Slug: slug}
 	if claim.Slug == "" || shared.ValidateClaimBinding(claim, binding) != nil {
-		return exit(2, "vast lease claim identity does not match lease=%s slug=%s", leaseID, slug)
+		return core.Exit(2, "vast lease claim identity does not match lease=%s slug=%s", leaseID, slug)
 	}
 	if cloudID != "" {
 		if claim.CloudID == "" {
-			return exit(2, "vast lease=%s claim has no instance identity", leaseID)
+			return core.Exit(2, "vast lease=%s claim has no instance identity", leaseID)
 		}
 		if claim.CloudID != cloudID {
-			return exit(2, "refusing to resolve Vast instance %s from stale local claim", cloudID)
+			return core.Exit(2, "refusing to resolve Vast instance %s from stale local claim", cloudID)
 		}
 	}
 	return nil
@@ -917,7 +917,7 @@ func validateVastClaimIdentity(claim core.LeaseClaim, leaseID, slug, cloudID str
 func sshTargetFromInstance(cfg core.Config, item vastInstance) (core.SSHTarget, error) {
 	host := strings.TrimSpace(item.SSHHost)
 	if host == "" || item.SSHPort <= 0 {
-		return core.SSHTarget{}, exit(5, "vast instance %d is missing SSH endpoint", item.ID)
+		return core.SSHTarget{}, core.Exit(5, "vast instance %d is missing SSH endpoint", item.ID)
 	}
 	ssh := core.SSHTargetFromConfig(cfg, host)
 	ssh.Port = strconv.Itoa(item.SSHPort)
@@ -1022,21 +1022,21 @@ func (b *backend) validateVastCleanupIdentity(ctx context.Context, client vastAP
 func (b *backend) validateVastClaimProviderIdentity(ctx context.Context, client vastAPI, claim core.LeaseClaim, action string) error {
 	expectedAPIURL := strings.TrimSpace(claim.Labels[vastAPIURLLabel])
 	if expectedAPIURL == "" {
-		return exit(2, "lease=%s has no stored Vast API endpoint identity; refusing %s", claim.LeaseID, action)
+		return core.Exit(2, "lease=%s has no stored Vast API endpoint identity; refusing %s", claim.LeaseID, action)
 	}
 	if vastAPIEndpointIdentity(b.cfg.Vast.APIURL) != expectedAPIURL {
-		return exit(2, "lease=%s Vast API endpoint identity does not match current configuration; refusing %s", claim.LeaseID, action)
+		return core.Exit(2, "lease=%s Vast API endpoint identity does not match current configuration; refusing %s", claim.LeaseID, action)
 	}
 	expectedAccountID := strings.TrimSpace(claim.Labels[vastAccountIDLabel])
 	if expectedAccountID == "" {
-		return exit(2, "lease=%s has no stored Vast account identity; refusing %s", claim.LeaseID, action)
+		return core.Exit(2, "lease=%s has no stored Vast account identity; refusing %s", claim.LeaseID, action)
 	}
 	user, err := client.CheckAuth(ctx)
 	if err != nil {
 		return err
 	}
 	if strconv.Itoa(user.ID) != expectedAccountID {
-		return exit(2, "lease=%s Vast account identity does not match current credentials; refusing %s", claim.LeaseID, action)
+		return core.Exit(2, "lease=%s Vast account identity does not match current credentials; refusing %s", claim.LeaseID, action)
 	}
 	return nil
 }

--- a/internal/providers/vast/client.go
+++ b/internal/providers/vast/client.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -112,11 +113,11 @@ type vastAttachSSHKeyResponse struct {
 }
 
 type vastOfferSearchInput struct {
-	Config VastConfig
+	Config core.VastConfig
 }
 
 type vastCreateInstanceInput struct {
-	Config      VastConfig
+	Config      core.VastConfig
 	Label       string
 	SSHKey      string
 	Environment map[string]string
@@ -128,18 +129,18 @@ type vastManageInstanceInput struct {
 	Label string `json:"label,omitempty"`
 }
 
-func newVastClient(cfg VastConfig, rt Runtime) (vastAPI, error) {
+func newVastClient(cfg core.VastConfig, rt core.Runtime) (vastAPI, error) {
 	apiKey := strings.TrimSpace(cfg.APIKey)
 	if apiKey == "" {
-		return nil, exit(2, "provider=%s requires CRABBOX_VAST_API_KEY or VAST_API_KEY", providerName)
+		return nil, core.Exit(2, "provider=%s requires CRABBOX_VAST_API_KEY or VAST_API_KEY", providerName)
 	}
 	apiURL := strings.TrimRight(strings.TrimSpace(cfg.APIURL), "/")
 	parsed, err := url.Parse(apiURL)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.User != nil {
-		return nil, exit(2, "vast.apiUrl must be an absolute URL without credentials")
+		return nil, core.Exit(2, "vast.apiUrl must be an absolute URL without credentials")
 	}
 	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
-		return nil, exit(2, "vast.apiUrl must use https unless it targets localhost")
+		return nil, core.Exit(2, "vast.apiUrl must use https unless it targets localhost")
 	}
 	httpClient := rt.HTTP
 	if httpClient == nil {
@@ -305,7 +306,7 @@ func (c *vastClient) DetachInstanceSSHKey(ctx context.Context, id int, keyID str
 	return c.do(ctx, http.MethodDelete, "/instances/"+strconv.Itoa(id)+"/ssh/"+url.PathEscape(keyID)+"/", nil, nil)
 }
 
-func buildVastOfferSearchPayload(cfg VastConfig) map[string]any {
+func buildVastOfferSearchPayload(cfg core.VastConfig) map[string]any {
 	payload := map[string]any{
 		"verified":          vastFilter("eq", true),
 		"rentable":          vastFilter("eq", true),
@@ -337,11 +338,11 @@ func vastFilter(operator string, value any) map[string]any {
 }
 
 func vastAPIInstanceType(value string) string {
-	switch normalizeInstanceType(value) {
+	switch core.NormalizeVastInstanceType(value) {
 	case "interruptible":
 		return "bid"
 	default:
-		return normalizeInstanceType(value)
+		return core.NormalizeVastInstanceType(value)
 	}
 }
 

--- a/internal/providers/vast/client_test.go
+++ b/internal/providers/vast/client_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/openclaw/crabbox/internal/testutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestClientSendsBearerAuthAndRefusesCrossOriginRedirect(t *testing.T) {
@@ -22,7 +24,7 @@ func TestClientSendsBearerAuthAndRefusesCrossOriginRedirect(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := newVastClient(VastConfig{APIKey: "vast-secret", APIURL: server.URL}, Runtime{HTTP: server.Client()})
+	client, err := newVastClient(core.VastConfig{APIKey: "vast-secret", APIURL: server.URL}, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +113,7 @@ func TestOfferSearchPayloadAndDecode(t *testing.T) {
 	defer server.Close()
 
 	client := newTestVastClient(t, server)
-	offers, err := client.SearchOffers(context.Background(), vastOfferSearchInput{Config: VastConfig{
+	offers, err := client.SearchOffers(context.Background(), vastOfferSearchInput{Config: core.VastConfig{
 		InstanceType:   "on-demand",
 		GPUName:        "H100",
 		GPUCount:       4,
@@ -128,7 +130,7 @@ func TestOfferSearchPayloadAndDecode(t *testing.T) {
 }
 
 func TestOfferSearchPayloadMapsInterruptibleToBid(t *testing.T) {
-	body := buildVastOfferSearchPayload(VastConfig{InstanceType: "interruptible"})
+	body := buildVastOfferSearchPayload(core.VastConfig{InstanceType: "interruptible"})
 	if body["type"] != "bid" {
 		t.Fatalf("type=%#v want bid", body["type"])
 	}
@@ -163,7 +165,7 @@ func TestCreateInstancePayloadAndDecodeNewContract(t *testing.T) {
 
 	client := newTestVastClient(t, server)
 	resp, err := client.CreateInstance(context.Background(), 42, vastCreateInstanceInput{
-		Config:      VastConfig{Image: "nvidia/cuda:12", TemplateID: "tpl-123", Runtype: "ssh_direct", DiskGB: 80},
+		Config:      core.VastConfig{Image: "nvidia/cuda:12", TemplateID: "tpl-123", Runtype: "ssh_direct", DiskGB: 80},
 		Label:       "cbx1|lease|slug|active",
 		SSHKey:      "ssh-ed25519 AAAA...",
 		Environment: map[string]string{"CRABBOX": "1", "MESSAGE": "space ' value"},
@@ -320,17 +322,17 @@ func TestManageInstanceAllowsSuccessOnlyMutationResponse(t *testing.T) {
 }
 
 func TestClientRejectsNonHTTPSExceptLoopback(t *testing.T) {
-	if _, err := newVastClient(VastConfig{APIKey: "secret", APIURL: "http://vast.example.test"}, Runtime{}); err == nil {
+	if _, err := newVastClient(core.VastConfig{APIKey: "secret", APIURL: "http://vast.example.test"}, core.Runtime{}); err == nil {
 		t.Fatal("expected non-https non-loopback rejection")
 	}
-	if _, err := newVastClient(VastConfig{APIKey: "secret", APIURL: "http://127.0.0.1:8080/api/v0"}, Runtime{}); err != nil {
+	if _, err := newVastClient(core.VastConfig{APIKey: "secret", APIURL: "http://127.0.0.1:8080/api/v0"}, core.Runtime{}); err != nil {
 		t.Fatalf("loopback rejected: %v", err)
 	}
 }
 
 func newTestVastClient(t *testing.T, server *httptest.Server) *vastClient {
 	t.Helper()
-	api, err := newVastClient(VastConfig{APIKey: "vast-secret", APIURL: server.URL + "/api/v0"}, Runtime{HTTP: server.Client()})
+	api, err := newVastClient(core.VastConfig{APIKey: "vast-secret", APIURL: server.URL + "/api/v0"}, core.Runtime{HTTP: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providers/vast/core.go
+++ b/internal/providers/vast/core.go
@@ -4,39 +4,10 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-type Config = core.Config
-type VastConfig = core.VastConfig
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-
 const (
 	providerName = "vast"
 )
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func markVastWorkRootExplicit(cfg *Config) {
-	core.MarkVastWorkRootExplicit(cfg)
-}
-
-func markReleaseActionExplicit(cfg *Config) {
+func markReleaseActionExplicit(cfg *core.Config) {
 	core.MarkDeleteOnReleaseExplicit(cfg, providerName)
-}
-
-func normalizeInstanceType(value string) string {
-	return core.NormalizeVastInstanceType(value)
 }

--- a/internal/providers/vast/flags.go
+++ b/internal/providers/vast/flags.go
@@ -9,11 +9,11 @@ import (
 
 // RegisterVastProviderFlags exposes only non-secret Vast settings. API keys
 // are sourced from CRABBOX_VAST_API_KEY / VAST_API_KEY and never argv.
-func RegisterVastProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterVastProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterVastConfigFlags(fs, defaults.Vast)
 }
 
-func ApplyVastProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyVastProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if core.ProviderNameMatches(cfg.Provider, Provider{}) {
 		if err := shared.RejectExplicitMachineSizingFlags(fs, providerName, "use --vast-gpu-name or --vast-gpu-count", "use --vast-image"); err != nil {
 			return err
@@ -26,10 +26,10 @@ func ApplyVastProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	applied, err := v.Apply(&cfg.Vast, fs)
 	core.RecordProviderFlagInputs(cfg, applied.InputAccepted, providerName)
 	if applied.InstanceType {
-		cfg.Vast.InstanceType = normalizeInstanceType(cfg.Vast.InstanceType)
+		cfg.Vast.InstanceType = core.NormalizeVastInstanceType(cfg.Vast.InstanceType)
 	}
 	if applied.WorkRoot {
-		markVastWorkRootExplicit(cfg)
+		core.MarkVastWorkRootExplicit(cfg)
 	}
 	if applied.ReleaseAction {
 		markReleaseActionExplicit(cfg)

--- a/internal/providers/vast/provider.go
+++ b/internal/providers/vast/provider.go
@@ -67,10 +67,10 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 		return nil, err
 	}
 	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
-		return nil, exit(2, "provider=%s supports target=linux only", providerName)
+		return nil, core.Exit(2, "provider=%s supports target=linux only", providerName)
 	}
 	if cfg.Tailscale.Enabled || cfg.Network == core.NetworkTailscale {
-		return nil, exit(2, "provider=%s does not support Tailscale options", providerName)
+		return nil, core.Exit(2, "provider=%s does not support Tailscale options", providerName)
 	}
 	return newBackend(p.Spec(), cfg, rt), nil
 }
@@ -82,46 +82,46 @@ func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.Doctor
 func (Provider) ValidateConfig(cfg core.Config) error {
 	apiURL := strings.TrimSpace(cfg.Vast.APIURL)
 	if apiURL == "" {
-		return exit(2, "vast.apiUrl is required")
+		return core.Exit(2, "vast.apiUrl is required")
 	}
 	u, err := url.Parse(apiURL)
 	if err != nil || u.Scheme == "" || u.Host == "" || u.User != nil {
-		return exit(2, "vast.apiUrl must be an absolute URL without credentials")
+		return core.Exit(2, "vast.apiUrl must be an absolute URL without credentials")
 	}
 	if u.RawQuery != "" || u.Fragment != "" {
-		return exit(2, "vast.apiUrl must not include query strings or fragments")
+		return core.Exit(2, "vast.apiUrl must not include query strings or fragments")
 	}
 	switch strings.ToLower(u.Scheme) {
 	case "https", "http":
 	default:
-		return exit(2, "vast.apiUrl must use http or https")
+		return core.Exit(2, "vast.apiUrl must use http or https")
 	}
-	switch normalizeInstanceType(cfg.Vast.InstanceType) {
+	switch core.NormalizeVastInstanceType(cfg.Vast.InstanceType) {
 	case "ondemand", "interruptible":
 	default:
-		return exit(2, "vast.instanceType must be ondemand or interruptible")
+		return core.Exit(2, "vast.instanceType must be ondemand or interruptible")
 	}
 	switch strings.ToLower(strings.TrimSpace(cfg.Vast.Runtype)) {
 	case "ssh_direct":
 	default:
-		return exit(2, "vast.runtype must be ssh_direct")
+		return core.Exit(2, "vast.runtype must be ssh_direct")
 	}
 	if cfg.Vast.GPUCount < 0 {
-		return exit(2, "vast.gpuCount must be non-negative")
+		return core.Exit(2, "vast.gpuCount must be non-negative")
 	}
 	if cfg.Vast.DiskGB < 0 {
-		return exit(2, "vast.diskGB must be non-negative")
+		return core.Exit(2, "vast.diskGB must be non-negative")
 	}
 	if cfg.Vast.MaxDphTotal < 0 {
-		return exit(2, "vast.maxDphTotal must be non-negative")
+		return core.Exit(2, "vast.maxDphTotal must be non-negative")
 	}
 	if cfg.Vast.MinReliability < 0 || cfg.Vast.MinReliability > 1 {
-		return exit(2, "vast.minReliability must be between 0 and 1")
+		return core.Exit(2, "vast.minReliability must be between 0 and 1")
 	}
 	switch strings.ToLower(strings.TrimSpace(cfg.Vast.ReleaseAction)) {
 	case "", "destroy", "delete", "stop", "keep":
 	default:
-		return exit(2, "vast.releaseAction must be destroy, delete, stop, or keep")
+		return core.Exit(2, "vast.releaseAction must be destroy, delete, stop, or keep")
 	}
 	return nil
 }


### PR DESCRIPTION
Use core contracts directly in Freestyle, Machine0, MXC, Nebius, Unikraft Cloud, and Vast. Removing identity aliases and exact forwarding functions deletes 272 net production lines while retaining provider-specific ownership and recovery policy.

Validation: complete tests passed for all six changed packages; scoped Autoreview passed in two complete chunks. CI is required before merge. No dependencies or configuration changes.
