### PR TITLE
refactor(providers): remove cloud adapter core mirrors

### DIFF
--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -17,42 +17,27 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-type Config = core.Config
-type Runtime = core.Runtime
-type ProviderSpec = core.ProviderSpec
-type Backend = core.Backend
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type CleanupRequest = core.CleanupRequest
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-
 type awsLeaseBackend struct{ shared.DirectSSHBackend }
 
 const awsAcquireRollbackTimeout = 2 * time.Minute
 
 type awsClient interface {
-	ListCrabboxServers(context.Context) ([]Server, error)
-	CreateServerWithFallback(context.Context, Config, string, string, string, bool, func(string, ...any)) (Server, Config, error)
-	CreateServerWithFallbackControl(context.Context, Config, string, string, string, bool, func(string, ...any), *core.AWSFixedCreateControl) (Server, Config, error)
-	WaitForServerIP(context.Context, string) (Server, error)
-	GetServer(context.Context, string) (Server, error)
+	ListCrabboxServers(context.Context) ([]core.Server, error)
+	CreateServerWithFallback(context.Context, core.Config, string, string, string, bool, func(string, ...any)) (core.Server, core.Config, error)
+	CreateServerWithFallbackControl(context.Context, core.Config, string, string, string, bool, func(string, ...any), *core.AWSFixedCreateControl) (core.Server, core.Config, error)
+	WaitForServerIP(context.Context, string) (core.Server, error)
+	GetServer(context.Context, string) (core.Server, error)
 	DeleteServer(context.Context, string) error
 	DeleteSSHKey(context.Context, string) error
 	ResolveCleanupSSHKeyID(context.Context, string) (string, error)
 	DeleteCleanupSSHKeyID(context.Context, string) error
 	CallerAccountID(context.Context) (string, error)
 	SetTags(context.Context, string, map[string]string) error
-	CapacityDoctorChecks(context.Context, Config) []core.DoctorCheck
-	SpotPlacementScores(context.Context, Config) ([]ec2types.SpotPlacementScore, error)
+	CapacityDoctorChecks(context.Context, core.Config) []core.DoctorCheck
+	SpotPlacementScores(context.Context, core.Config) ([]ec2types.SpotPlacementScore, error)
 }
 
-func NewAWSLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewAWSLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = "aws"
 	return &awsLeaseBackend{DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt, Delete: deleteServer, StoredLeaseKeys: true}}
 }
@@ -61,46 +46,46 @@ func (b *awsLeaseBackend) SupportsRequestedLeaseID() bool { return true }
 
 func (b *awsLeaseBackend) SupportsRequestedCheckpointID() bool { return true }
 
-func (b *awsLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+func (b *awsLeaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	if strings.TrimSpace(req.RequestedLeaseID) != "" {
 		return b.acquireFixed(ctx, req)
 	}
-	return acquireAttemptsRetry(b.RT, req.Keep, func() (LeaseTarget, error) {
+	return acquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
 		return b.acquireOnce(ctx, req.Keep, req.RequestedSlug)
 	})
 }
 
-func (b *awsLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (result LeaseTarget, retErr error) {
+func (b *awsLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (result core.LeaseTarget, retErr error) {
 	if b.Cfg.Tailscale.Enabled && b.Cfg.Tailscale.AuthKey == "" {
-		return LeaseTarget{}, exit(2, "direct --tailscale requires %s to contain a Tailscale auth key; brokered mode uses coordinator OAuth secrets", b.Cfg.Tailscale.AuthKeyEnv)
+		return core.LeaseTarget{}, core.Exit(2, "direct --tailscale requires %s to contain a Tailscale auth key; brokered mode uses coordinator OAuth secrets", b.Cfg.Tailscale.AuthKeyEnv)
 	}
 	cfg := chooseAWSRegion(ctx, b.Cfg, b.RT.Stderr)
 	client, err := newAWSClient(ctx, cfg)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	leaseID := core.NewLeaseID()
 	servers, err := b.listAcrossRegions(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	slug, err := allocateDirectLeaseSlug(leaseID, requestedSlug, servers)
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, requestedSlug, servers)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	keyPath, publicKey, err := ensureTestboxKeyForConfig(cfg, leaseID)
+	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cfg.SSHKey = keyPath
-	cfg.ProviderKey = providerKeyForLease(leaseID)
+	cfg.ProviderKey = core.ProviderKeyForLease(leaseID)
 	ensureAWSSSHCIDRs(ctx, &cfg)
 	fmt.Fprintf(b.RT.Stderr, "provisioning provider=aws lease=%s slug=%s class=%s preferred_type=%s region=%s keep=%v market=%s strategy=%s\n", leaseID, slug, cfg.Class, cfg.ServerType, cfg.AWSRegion, keep, cfg.Capacity.Market, cfg.Capacity.Strategy)
 	server, resolvedCfg, err := client.CreateServerWithFallback(ctx, cfg, publicKey, leaseID, slug, keep, func(format string, args ...any) {
 		fmt.Fprintf(b.RT.Stderr, format, args...)
 	})
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cfg = resolvedCfg
 	rollback := true
@@ -116,12 +101,12 @@ func (b *awsLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedS
 	}()
 	client, err = newAWSClient(ctx, cfg)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s server=%s type=%s\n", leaseID, server.DisplayID(), cfg.ServerType)
 	server, err = client.WaitForServerIP(ctx, server.CloudID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	server = annotateAWSServerRegion(server, cfg.AWSRegion)
 	if rollbackKeyID != "" {
@@ -129,7 +114,7 @@ func (b *awsLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedS
 	}
 	accountID, err := client.CallerAccountID(ctx)
 	if err != nil {
-		return LeaseTarget{}, fmt.Errorf("bind AWS caller account: %w", err)
+		return core.LeaseTarget{}, fmt.Errorf("bind AWS caller account: %w", err)
 	}
 	server.Labels["aws_account_id"] = accountID
 	if cfg.Network == core.NetworkTailscale && cfg.Tailscale.Enabled && strings.TrimSpace(cfg.Tailscale.Hostname) == "" {
@@ -137,14 +122,14 @@ func (b *awsLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedS
 	}
 	target := sshTargetForBootstrap(cfg, server.PublicNet.IPv4.IP, leaseID, slug)
 	if err := bootstrapAWSWindowsDesktop(ctx, cfg, &target, publicKey, b.RT.Stderr); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	server.Labels["state"] = "ready"
 	if err := client.SetTags(ctx, server.CloudID, server.Labels); err != nil {
-		return LeaseTarget{}, fmt.Errorf("persist AWS lease identity tags: %w", err)
+		return core.LeaseTarget{}, fmt.Errorf("persist AWS lease identity tags: %w", err)
 	}
 	rollback = false
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
 const (
@@ -164,10 +149,10 @@ var fixedAWSLeaseKind = core.FixedLeaseKind{
 	},
 }
 
-func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	leaseID := strings.TrimSpace(req.RequestedLeaseID)
 	if b.Cfg.Tailscale.Enabled && b.Cfg.Tailscale.AuthKey == "" {
-		return LeaseTarget{}, exit(2, "direct --tailscale requires %s to contain a Tailscale auth key; brokered mode uses coordinator OAuth secrets", b.Cfg.Tailscale.AuthKeyEnv)
+		return core.LeaseTarget{}, core.Exit(2, "direct --tailscale requires %s to contain a Tailscale auth key; brokered mode uses coordinator OAuth secrets", b.Cfg.Tailscale.AuthKeyEnv)
 	}
 	cfg := b.Cfg
 	var client awsClient
@@ -193,13 +178,13 @@ func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) 
 			return core.FixedLeaseBinding{}, fmt.Errorf("bind fixed AWS lease account: %w", err)
 		}
 		providerScope = "account:" + accountID
-		keyPath, key, err := ensureTestboxKeyForConfig(cfg, leaseID)
+		keyPath, key, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
 		if err != nil {
 			return core.FixedLeaseBinding{}, err
 		}
 		publicKey = key
 		cfg.SSHKey = keyPath
-		cfg.ProviderKey = providerKeyForLease(leaseID)
+		cfg.ProviderKey = core.ProviderKeyForLease(leaseID)
 		cfg.AWSSSHCIDRsPinned = len(cfg.AWSSSHCIDRs) > 0
 		ensureAWSSSHCIDRs(ctx, &cfg)
 		requestedSlug := core.NormalizeLeaseSlug(req.RequestedSlug)
@@ -215,16 +200,16 @@ func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) 
 			if err != nil {
 				return core.FixedLeaseBinding{}, err
 			}
-			slug, err := allocateDirectLeaseSlug(leaseID, requestedSlug, servers)
+			slug, err := core.AllocateDirectLeaseSlug(leaseID, requestedSlug, servers)
 			if err != nil {
 				return core.FixedLeaseBinding{}, err
 			}
 			binding.Slug = slug
 		}
 		return binding, nil
-	}, func(ctx context.Context, claim *core.LeaseClaim, intent *core.FixedCreateIntent, persist func() error) (LeaseTarget, error) {
+	}, func(ctx context.Context, claim *core.LeaseClaim, intent *core.FixedCreateIntent, persist func() error) (core.LeaseTarget, error) {
 		createdAt, _ := time.Parse(time.RFC3339Nano, intent.CreatedAt)
-		var lease LeaseTarget
+		var lease core.LeaseTarget
 		err := func() error {
 			servers, err := b.listAcrossRegions(ctx)
 			if err != nil {
@@ -232,28 +217,28 @@ func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) 
 			}
 			matching := fixedAWSLeaseMatches(servers, leaseID)
 			if len(matching) > 1 {
-				return exit(4, "lease_id_conflict: multiple AWS resources match fixed lease %s", leaseID)
+				return core.Exit(4, "lease_id_conflict: multiple AWS resources match fixed lease %s", leaseID)
 			}
 			pinned, err := fixedAWSAttemptFromIntent(intent)
 			if err != nil {
-				return exit(4, "lease_id_conflict: invalid fixed AWS attempt for lease %s: %v", leaseID, err)
+				return core.Exit(4, "lease_id_conflict: invalid fixed AWS attempt for lease %s: %v", leaseID, err)
 			}
-			var server Server
+			var server core.Server
 			resolvedCfg := cfg
 			if len(matching) == 1 {
 				server = matching[0]
 				if intent.State == fixedAWSIntentAcquired || claim.CloudID != "" {
 					if claim.CloudID == "" || server.CloudID != claim.CloudID {
-						return exit(4, "lease_id_conflict: fixed lease %s resource %s does not match acquired CloudID %s", leaseID, core.Blank(server.CloudID, "<empty>"), core.Blank(claim.CloudID, "<empty>"))
+						return core.Exit(4, "lease_id_conflict: fixed lease %s resource %s does not match acquired CloudID %s", leaseID, core.Blank(server.CloudID, "<empty>"), core.Blank(claim.CloudID, "<empty>"))
 					}
 				}
 				resolvedCfg = awsConfigForServer(cfg, server)
 			} else {
 				if intent.State == fixedAWSIntentAcquired || claim.CloudID != "" {
-					return exit(4, "lease_id_conflict: acquired fixed lease %s is missing its bound AWS instance", leaseID)
+					return core.Exit(4, "lease_id_conflict: acquired fixed lease %s is missing its bound AWS instance", leaseID)
 				}
 				if pinned != nil {
-					return exit(4, "lease_id_conflict: fixed AWS lease %s has an unresolved launch attempt; retry after provider inventory converges", leaseID)
+					return core.Exit(4, "lease_id_conflict: fixed AWS lease %s has an unresolved launch attempt; retry after provider inventory converges", leaseID)
 				}
 				failed := make(map[string]bool, len(intent.FailedAttempts))
 				for _, token := range intent.FailedAttempts {
@@ -295,7 +280,7 @@ func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) 
 				}, control)
 				if err != nil {
 					if control.TerminalRejection && control.PinnedAttempt == nil {
-						return exit(4, "lease_id_conflict: fixed AWS lease %s terminated after %v", leaseID, err)
+						return core.Exit(4, "lease_id_conflict: fixed AWS lease %s terminated after %v", leaseID, err)
 					}
 					return err
 				}
@@ -308,7 +293,7 @@ func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) 
 			}
 			pinned, err = fixedAWSAttemptFromIntent(intent)
 			if err != nil || pinned == nil {
-				return exit(4, "lease_id_conflict: fixed AWS lease %s has no valid durable launch attempt after provisioning", leaseID)
+				return core.Exit(4, "lease_id_conflict: fixed AWS lease %s has no valid durable launch attempt after provisioning", leaseID)
 			}
 			if err := validateFixedAWSAttemptServer(server, leaseID, *pinned); err != nil {
 				return err
@@ -352,24 +337,24 @@ func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) 
 				return fmt.Errorf("persist AWS fixed lease identity tags: %w", err)
 			}
 			claim.ProviderScope = providerScope
-			lease = LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
+			lease = core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
 			return nil
 		}()
 		return lease, err
 	}, ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.OnAcquired != nil {
 		if err := req.OnAcquired(acquired); err != nil {
-			return LeaseTarget{}, fmt.Errorf("acknowledge fixed AWS acquisition: %w", err)
+			return core.LeaseTarget{}, fmt.Errorf("acknowledge fixed AWS acquisition: %w", err)
 		}
 	}
 	return acquired, nil
 }
 
-func fixedAWSLeaseMatches(servers []LeaseView, leaseID string) []Server {
-	var matching []Server
+func fixedAWSLeaseMatches(servers []core.LeaseView, leaseID string) []core.Server {
+	var matching []core.Server
 	for _, server := range servers {
 		if server.Labels["lease"] == leaseID {
 			matching = append(matching, server)
@@ -378,34 +363,34 @@ func fixedAWSLeaseMatches(servers []LeaseView, leaseID string) []Server {
 	return matching
 }
 
-func validateFixedAWSServer(server Server, leaseID, slug, fingerprint, accountID string) error {
+func validateFixedAWSServer(server core.Server, leaseID, slug, fingerprint, accountID string) error {
 	if server.CloudID == "" || !isCrabboxAWSLease(server) || server.Labels["lease"] != leaseID ||
 		core.NormalizeLeaseSlug(server.Labels["slug"]) != slug ||
 		server.Labels["fixed_intent_sha256"] != fingerprint ||
 		server.Labels["aws_account_id"] != accountID {
-		return exit(4, "lease_id_conflict: AWS resource for lease %s does not match its fixed create intent", leaseID)
+		return core.Exit(4, "lease_id_conflict: AWS resource for lease %s does not match its fixed create intent", leaseID)
 	}
 	return nil
 }
 
-func validateFixedAWSAttemptServer(server Server, leaseID string, attempt core.AWSLaunchAttempt) error {
+func validateFixedAWSAttemptServer(server core.Server, leaseID string, attempt core.AWSLaunchAttempt) error {
 	if err := core.ValidateAWSFixedAttemptAttestation(server.Labels, attempt); err != nil {
-		return exit(4, "lease_id_conflict: AWS resource for lease %s does not match its durable launch attempt: %v", leaseID, err)
+		return core.Exit(4, "lease_id_conflict: AWS resource for lease %s does not match its durable launch attempt: %v", leaseID, err)
 	}
 	if strings.TrimSpace(server.ServerType.Name) != strings.TrimSpace(attempt.ServerType) ||
 		awsServerRegion(server) != strings.TrimSpace(attempt.Region) ||
 		strings.TrimSpace(server.Labels["provider_key"]) != core.ProviderKeyForLease(leaseID) ||
 		strings.TrimSpace(server.Labels["aws_key_pair_id"]) != strings.TrimSpace(attempt.KeyPairID) ||
 		strings.TrimSpace(server.HostID) != strings.TrimSpace(attempt.HostID) {
-		return exit(4, "lease_id_conflict: AWS resource for lease %s provider identity does not match its durable launch attempt", leaseID)
+		return core.Exit(4, "lease_id_conflict: AWS resource for lease %s provider identity does not match its durable launch attempt", leaseID)
 	}
 	if err := validateFixedAWSAttemptProviderMetadata(server, attempt); err != nil {
-		return exit(4, "lease_id_conflict: AWS resource for lease %s provider metadata does not match its durable launch attempt: %v", leaseID, err)
+		return core.Exit(4, "lease_id_conflict: AWS resource for lease %s provider metadata does not match its durable launch attempt: %v", leaseID, err)
 	}
 	return nil
 }
 
-func validateFixedAWSAttemptProviderMetadata(server Server, attempt core.AWSLaunchAttempt) error {
+func validateFixedAWSAttemptProviderMetadata(server core.Server, attempt core.AWSLaunchAttempt) error {
 	metadata := server.ProviderMetadata
 	require := func(key, expected string) error {
 		if strings.TrimSpace(expected) == "" {
@@ -458,13 +443,13 @@ func fixedAWSAttemptFromIntent(intent *core.FixedCreateIntent) (*core.AWSLaunchA
 	return &attempt, nil
 }
 
-func (b *awsLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *awsLeaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	if strings.HasPrefix(req.ID, "i-") {
 		var lastErr error
 		for _, cfg := range awsRegionConfigs(b.Cfg) {
 			client, err := newAWSClient(ctx, cfg)
 			if err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 			server, err := client.GetServer(ctx, req.ID)
 			if err != nil {
@@ -472,75 +457,75 @@ func (b *awsLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (Leas
 				if isAWSResolveNotFound(err) {
 					continue
 				}
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 			server = annotateAWSServerRegion(server, cfg.AWSRegion)
 			if !isCrabboxAWSLease(server) {
-				return LeaseTarget{}, exit(4, "lease/server not found: %s (instance exists but is not Crabbox-managed)", req.ID)
+				return core.LeaseTarget{}, core.Exit(4, "lease/server not found: %s (instance exists but is not Crabbox-managed)", req.ID)
 			}
 			leaseID := core.Blank(server.Labels["lease"], req.ID)
-			target := sshTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+			target := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
 			if !req.ReleaseOnly {
-				if err := useStoredTestboxKey(&target, leaseID); err != nil {
-					return LeaseTarget{}, err
+				if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
+					return core.LeaseTarget{}, err
 				}
 			}
-			return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+			return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 		}
 		if lastErr != nil {
-			return LeaseTarget{}, lastErr
+			return core.LeaseTarget{}, lastErr
 		}
 	}
 	servers, err := b.listAcrossRegions(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.ReleaseOnly && core.IsCanonicalLeaseID(req.ID) {
 		claim, exists, err := core.ReadLeaseClaimWithPresence(req.ID)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		if exists && claim.FixedCreateIntent != nil && claim.FixedCreateIntent.State == fixedAWSIntentReleased {
 			return b.resolveTerminalRelease(ctx, req, claim, servers)
 		}
 	}
-	if server, leaseID, err := findServerByAlias(servers, req.ID); err != nil {
-		return LeaseTarget{}, err
+	if server, leaseID, err := core.FindServerByAlias(servers, req.ID); err != nil {
+		return core.LeaseTarget{}, err
 	} else if leaseID != "" {
 		cfg := awsConfigForServer(b.Cfg, server)
-		target := sshTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+		target := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
 		if !req.ReleaseOnly {
-			if err := useStoredTestboxKey(&target, leaseID); err != nil {
-				return LeaseTarget{}, err
+			if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
+				return core.LeaseTarget{}, err
 			}
 		}
-		return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+		return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 	}
-	return LeaseTarget{}, exit(4, "lease/server not found: %s", req.ID)
+	return core.LeaseTarget{}, core.Exit(4, "lease/server not found: %s", req.ID)
 }
 
-func (b *awsLeaseBackend) ResolveRunLeaseUnderClaim(ctx context.Context, req ResolveRequest, original core.LeaseClaim) (LeaseTarget, error) {
+func (b *awsLeaseBackend) ResolveRunLeaseUnderClaim(ctx context.Context, req core.ResolveRequest, original core.LeaseClaim) (core.LeaseTarget, error) {
 	// The held claim already identifies the instance and region. Reuse the
 	// direct resolver without inventory discovery or cross-region fallback.
 	bound := *b
-	bound.Cfg = awsConfigForServer(b.Cfg, Server{Labels: original.Labels})
+	bound.Cfg = awsConfigForServer(b.Cfg, core.Server{Labels: original.Labels})
 	bound.Cfg.Capacity.Regions = nil
 	req.ID = original.CloudID
 	lease, err := bound.Resolve(ctx, req)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	// Fixed leases retain their acquired/account fence. Ordinary run admission
 	// uses the endpoint policy, which preserves absent historical cleanup identity.
 	if original.Provider == core.FixedAWSClaimProvider || original.FixedCreateIntent != nil {
 		if err := bound.AuthorizeStatusTouchClaim(ctx, lease, original); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	return lease, nil
 }
 
-func isCrabboxAWSLease(server Server) bool {
+func isCrabboxAWSLease(server core.Server) bool {
 	labels := server.Labels
 	return labels != nil &&
 		labels["crabbox"] == "true" &&
@@ -550,7 +535,7 @@ func isCrabboxAWSLease(server Server) bool {
 		strings.TrimSpace(labels["slug"]) != ""
 }
 
-func (b *awsLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *awsLeaseBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	return b.listAcrossRegions(ctx)
 }
@@ -559,7 +544,7 @@ func (b *awsLeaseBackend) CheckpointSourceAbsent(ctx context.Context, req core.C
 	cfg := b.Cfg
 	cfg.AWSRegion = req.Resource.Image.Region
 	if cfg.AWSRegion == "" || req.AccountID == "" {
-		return false, exit(2, "checkpoint source account or region is missing; retain operation")
+		return false, core.Exit(2, "checkpoint source account or region is missing; retain operation")
 	}
 	client, err := newAWSClient(ctx, cfg)
 	if err != nil {
@@ -570,7 +555,7 @@ func (b *awsLeaseBackend) CheckpointSourceAbsent(ctx context.Context, req core.C
 		return false, err
 	}
 	if account != req.AccountID {
-		return false, exit(2, "checkpoint source account changed")
+		return false, core.Exit(2, "checkpoint source account changed")
 	}
 	source, err := client.GetServer(ctx, req.Capture.SourceID)
 	if err != nil {
@@ -582,7 +567,7 @@ func (b *awsLeaseBackend) CheckpointSourceAbsent(ctx context.Context, req core.C
 		return false, err
 	}
 	if source.CloudID != req.Capture.SourceID {
-		return false, exit(2, "checkpoint source identity changed")
+		return false, core.Exit(2, "checkpoint source identity changed")
 	}
 	return source.Status == "terminated", nil
 }
@@ -612,20 +597,20 @@ func (b *awsLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (cor
 	return result, nil
 }
 
-func (b *awsLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *awsLeaseBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
 	return err
 }
 
-func (b *awsLeaseBackend) ReleaseLeaseWithOutcome(ctx context.Context, req ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+func (b *awsLeaseBackend) ReleaseLeaseWithOutcome(ctx context.Context, req core.ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
 	var outcome core.ReleaseLeaseOutcome
 	err := b.releaseLease(ctx, req, &outcome)
 	return outcome, err
 }
 
-func (b *awsLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
+func (b *awsLeaseBackend) releaseLease(ctx context.Context, req core.ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	if !isCrabboxAWSLease(req.Lease.Server) || req.Lease.LeaseID != req.Lease.Server.Labels["lease"] {
-		return exit(4, "refusing to release AWS instance %s without matching canonical Crabbox ownership tags", req.Lease.Server.DisplayID())
+		return core.Exit(4, "refusing to release AWS instance %s without matching canonical Crabbox ownership tags", req.Lease.Server.DisplayID())
 	}
 	claim, exists, err := core.ReadLeaseClaimWithPresence(req.Lease.LeaseID)
 	if err != nil {
@@ -638,7 +623,7 @@ func (b *awsLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRequ
 		return b.releaseTerminalReceipt(ctx, req, outcome)
 	}
 	if strings.TrimSpace(req.Lease.Server.Labels["fixed_intent_sha256"]) != "" && (!exists || !fixedAWSLeaseKind.IsFixedClaim(claim)) {
-		return exit(4, "refusing to release fixed AWS lease %s without its durable create intent", req.Lease.LeaseID)
+		return core.Exit(4, "refusing to release fixed AWS lease %s without its durable create intent", req.Lease.LeaseID)
 	}
 	exact, err := requireExactAWSClaim(req.Lease.Server, req.Lease.LeaseID)
 	if err != nil {
@@ -680,33 +665,33 @@ func (b *awsLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRequ
 	return providerKeyErr
 }
 
-func (b *awsLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
+func (b *awsLeaseBackend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 	return fmt.Sprintf("deleted lease=%s server=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
 }
 
-func (b *awsLeaseBackend) RetainLeaseClaimAfterRelease(lease LeaseTarget) bool {
+func (b *awsLeaseBackend) RetainLeaseClaimAfterRelease(lease core.LeaseTarget) bool {
 	retained, err := b.retainLeaseClaimAfterRelease(lease, core.LeaseClaim{})
 	return retained || err != nil
 }
 
-func (b *awsLeaseBackend) RetainLeaseClaimAfterReleaseWithClaim(lease LeaseTarget, previous core.LeaseClaim) (bool, error) {
+func (b *awsLeaseBackend) RetainLeaseClaimAfterReleaseWithClaim(lease core.LeaseTarget, previous core.LeaseClaim) (bool, error) {
 	return b.retainLeaseClaimAfterRelease(lease, previous)
 }
 
-func (b *awsLeaseBackend) retainLeaseClaimAfterRelease(lease LeaseTarget, previous core.LeaseClaim) (bool, error) {
+func (b *awsLeaseBackend) retainLeaseClaimAfterRelease(lease core.LeaseTarget, previous core.LeaseClaim) (bool, error) {
 	serverFingerprint := strings.TrimSpace(lease.Server.Labels["fixed_intent_sha256"])
 	return fixedAWSLeaseKind.RetainClaimAfterRelease(lease.LeaseID, previous, serverFingerprint != "", func(claim core.LeaseClaim) error {
 		return validateAWSTerminalReceipt(claim, lease.LeaseID)
 	}, func(claim core.LeaseClaim) error {
 		if serverFingerprint != "" && serverFingerprint != claim.FixedCreateIntent.Fingerprint {
-			return exit(4, "lease_id_conflict: fixed AWS lease %s server tag differs from its terminal tombstone", lease.LeaseID)
+			return core.Exit(4, "lease_id_conflict: fixed AWS lease %s server tag differs from its terminal tombstone", lease.LeaseID)
 		}
 		return nil
 	})
 }
 
-func (b *awsLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
-	servers, err := b.List(ctx, ListRequest{Options: req.Options})
+func (b *awsLeaseBackend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
+	servers, err := b.List(ctx, core.ListRequest{Options: req.Options})
 	if err != nil {
 		return err
 	}
@@ -784,8 +769,8 @@ func (b *awsLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error
 	return b.cleanupOrphanedAWSClaims(ctx, req.DryRun)
 }
 
-func (b *awsLeaseBackend) listAcrossRegions(ctx context.Context) ([]LeaseView, error) {
-	var all []LeaseView
+func (b *awsLeaseBackend) listAcrossRegions(ctx context.Context) ([]core.LeaseView, error) {
+	var all []core.LeaseView
 	for _, cfg := range awsRegionConfigs(b.Cfg) {
 		client, err := newAWSClient(ctx, cfg)
 		if err != nil {
@@ -802,15 +787,11 @@ func (b *awsLeaseBackend) listAcrossRegions(ctx context.Context) ([]LeaseView, e
 	return all, nil
 }
 
-func acquireAttemptsRetry(rt Runtime, keep bool, acquire func() (LeaseTarget, error)) (LeaseTarget, error) {
+func acquireAttemptsRetry(rt core.Runtime, keep bool, acquire func() (core.LeaseTarget, error)) (core.LeaseTarget, error) {
 	return shared.AcquireAttemptsRetry(rt, keep, acquire)
 }
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func chooseAWSRegion(ctx context.Context, cfg Config, stderr io.Writer) Config {
+func chooseAWSRegion(ctx context.Context, cfg core.Config, stderr io.Writer) core.Config {
 	if cfg.Provider != "aws" || cfg.Capacity.Market != "spot" || len(cfg.Capacity.Regions) < 2 {
 		return cfg
 	}
@@ -842,28 +823,16 @@ func chooseAWSRegion(ctx context.Context, cfg Config, stderr io.Writer) Config {
 	return cfg
 }
 
-var newAWSClient = func(ctx context.Context, cfg Config) (awsClient, error) {
+var newAWSClient = func(ctx context.Context, cfg core.Config) (awsClient, error) {
 	return core.NewAWSClient(ctx, cfg)
 }
 
-func allocateDirectLeaseSlug(id, requested string, servers []Server) (string, error) {
-	return core.AllocateDirectLeaseSlug(id, requested, servers)
-}
-func ensureTestboxKeyForConfig(cfg Config, leaseID string) (string, string, error) {
-	return core.EnsureTestboxKeyForConfig(cfg, leaseID)
-}
-func providerKeyForLease(leaseID string) string { return core.ProviderKeyForLease(leaseID) }
-
-var ensureAWSSSHCIDRs = func(ctx context.Context, cfg *Config) { core.EnsureAWSSSHCIDRs(ctx, cfg) }
-
-func sshTargetFromConfig(cfg Config, host string) SSHTarget {
-	return core.SSHTargetFromConfig(cfg, host)
-}
+var ensureAWSSSHCIDRs = func(ctx context.Context, cfg *core.Config) { core.EnsureAWSSSHCIDRs(ctx, cfg) }
 
 // bootstrapSSHHost returns the address used for the acquisition readiness probe.
 // Strict Tailscale mode cannot fall back to the public address, which can be
 // unreachable from same-account EC2 operators even after cloud-init succeeds.
-func bootstrapSSHHost(cfg Config, publicIP, leaseID, slug string) string {
+func bootstrapSSHHost(cfg core.Config, publicIP, leaseID, slug string) string {
 	if cfg.Network != core.NetworkTailscale || !cfg.Tailscale.Enabled {
 		return publicIP
 	}
@@ -877,21 +846,15 @@ func bootstrapSSHHost(cfg Config, publicIP, leaseID, slug string) string {
 	return hostname
 }
 
-func sshTargetForBootstrap(cfg Config, publicIP, leaseID, slug string) SSHTarget {
-	return sshTargetFromConfig(cfg, bootstrapSSHHost(cfg, publicIP, leaseID, slug))
+func sshTargetForBootstrap(cfg core.Config, publicIP, leaseID, slug string) core.SSHTarget {
+	return core.SSHTargetFromConfig(cfg, bootstrapSSHHost(cfg, publicIP, leaseID, slug))
 }
 
 var bootstrapAWSWindowsDesktop = core.BootstrapAWSWindowsDesktop
 
-func useStoredTestboxKey(target *SSHTarget, leaseID string) error {
-	return core.UseStoredTestboxKey(target, leaseID)
-}
-func findServerByAlias(servers []Server, id string) (Server, string, error) {
-	return core.FindServerByAlias(servers, id)
-}
-func deleteServer(ctx context.Context, cfg Config, server Server) error {
+func deleteServer(ctx context.Context, cfg core.Config, server core.Server) error {
 	if !isCrabboxAWSLease(server) {
-		return exit(4, "refusing to delete AWS instance %s without canonical Crabbox ownership tags", server.DisplayID())
+		return core.Exit(4, "refusing to delete AWS instance %s without canonical Crabbox ownership tags", server.DisplayID())
 	}
 	client, err := newAWSClient(ctx, cfg)
 	if err != nil {
@@ -900,7 +863,7 @@ func deleteServer(ctx context.Context, cfg Config, server Server) error {
 	return deleteAWSServerWithClient(ctx, client, server)
 }
 
-func deleteAWSServerWithClient(ctx context.Context, client awsClient, server Server) error {
+func deleteAWSServerWithClient(ctx context.Context, client awsClient, server core.Server) error {
 	if err := client.DeleteServer(ctx, server.CloudID); err != nil {
 		return err
 	}
@@ -912,20 +875,20 @@ func deleteAWSServerWithClient(ctx context.Context, client awsClient, server Ser
 	return nil
 }
 
-func requireExactAWSClaim(server Server, expectedLeaseID string) (core.LeaseClaim, error) {
+func requireExactAWSClaim(server core.Server, expectedLeaseID string) (core.LeaseClaim, error) {
 	claim, exists, err := core.ReadLeaseClaimWithPresence(expectedLeaseID)
 	if err != nil {
 		return core.LeaseClaim{}, err
 	}
 	if !exists {
-		return core.LeaseClaim{}, exit(2, "aws lease=%s has no exact local claim; refusing destructive operation", expectedLeaseID)
+		return core.LeaseClaim{}, core.Exit(2, "aws lease=%s has no exact local claim; refusing destructive operation", expectedLeaseID)
 	}
 	return claim, validateExactAWSClaim(server, expectedLeaseID, claim)
 }
 
-func validateExactAWSClaim(server Server, expectedLeaseID string, claim core.LeaseClaim) error {
+func validateExactAWSClaim(server core.Server, expectedLeaseID string, claim core.LeaseClaim) error {
 	if claim.FixedCreateIntent != nil && claim.FixedCreateIntent.State == fixedAWSIntentReleased {
-		return exit(4, "lease_id_conflict: AWS lease %s is terminal; refusing another operation", expectedLeaseID)
+		return core.Exit(4, "lease_id_conflict: AWS lease %s is terminal; refusing another operation", expectedLeaseID)
 	}
 	if server.Provider != "aws" || !isCrabboxAWSLease(server) ||
 		claim.LeaseID != expectedLeaseID ||
@@ -937,19 +900,19 @@ func validateExactAWSClaim(server Server, expectedLeaseID string, claim core.Lea
 		server.Labels["lease"] != expectedLeaseID ||
 		awsServerRegion(server) == "" ||
 		strings.TrimSpace(claim.Labels["aws_region"]) != awsServerRegion(server) {
-		return exit(2, "refusing to operate on AWS instance %s from a missing or stale exact local claim", server.DisplayID())
+		return core.Exit(2, "refusing to operate on AWS instance %s from a missing or stale exact local claim", server.DisplayID())
 	}
 	expectedProviderKey := strings.TrimSpace(claim.Labels["provider_key"])
 	if expectedProviderKey == "" {
 		expectedProviderKey = core.ProviderKeyForLease(expectedLeaseID)
 	}
 	if strings.TrimSpace(core.ServerProviderKey(server)) != expectedProviderKey {
-		return exit(2, "refusing to operate on AWS instance %s whose provider key differs from its exact local claim", server.DisplayID())
+		return core.Exit(2, "refusing to operate on AWS instance %s whose provider key differs from its exact local claim", server.DisplayID())
 	}
 	return nil
 }
 
-func deleteClaimedAWSServerWithClient(ctx context.Context, client awsClient, server Server, claim core.LeaseClaim, cleanupKeyID string) error {
+func deleteClaimedAWSServerWithClient(ctx context.Context, client awsClient, server core.Server, claim core.LeaseClaim, cleanupKeyID string) error {
 	if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
 		return err
 	}
@@ -961,7 +924,7 @@ func deleteClaimedAWSServerWithClient(ctx context.Context, client awsClient, ser
 	})
 }
 
-func resolveAWSCleanupKeyID(ctx context.Context, client awsClient, server Server, claim core.LeaseClaim) (string, error) {
+func resolveAWSCleanupKeyID(ctx context.Context, client awsClient, server core.Server, claim core.LeaseClaim) (string, error) {
 	keyName := core.ServerProviderKey(server)
 	expectedKeyID := strings.TrimSpace(claim.Labels["aws_key_pair_id"])
 	if !core.ValidCrabboxProviderKey(keyName) || expectedKeyID == "" {
@@ -989,7 +952,7 @@ func awsClaimMatchesCurrentAccount(ctx context.Context, client awsClient, claim 
 	return accountID == expectedAccountID, nil
 }
 
-func isAWSTerminalServer(server Server) bool {
+func isAWSTerminalServer(server core.Server) bool {
 	switch strings.ToLower(strings.TrimSpace(server.Status)) {
 	case "shutting-down", "terminated":
 		return true
@@ -1014,11 +977,11 @@ func (b *awsLeaseBackend) cleanupOrphanedAWSClaims(ctx context.Context, dryRun b
 		}
 		labels := claim.Labels
 		if labels == nil || labels["lease"] != claim.LeaseID || labels["provider"] != "aws" || strings.TrimSpace(labels["aws_region"]) == "" ||
-			!strings.HasPrefix(claim.CloudID, "i-") || !core.ValidCrabboxProviderKey(core.ServerProviderKey(Server{Labels: labels})) ||
+			!strings.HasPrefix(claim.CloudID, "i-") || !core.ValidCrabboxProviderKey(core.ServerProviderKey(core.Server{Labels: labels})) ||
 			strings.TrimSpace(labels["aws_key_pair_id"]) == "" || strings.TrimSpace(labels["aws_account_id"]) == "" {
 			continue
 		}
-		server := Server{CloudID: claim.CloudID, Provider: "aws", Name: claim.Slug, Labels: labels}
+		server := core.Server{CloudID: claim.CloudID, Provider: "aws", Name: claim.Slug, Labels: labels}
 		client, err := newAWSClient(ctx, awsConfigForServer(b.Cfg, server))
 		if err != nil {
 			return err
@@ -1031,7 +994,7 @@ func (b *awsLeaseBackend) cleanupOrphanedAWSClaims(ctx context.Context, dryRun b
 			fmt.Fprintf(b.RT.Stderr, "skip orphaned AWS claim lease=%s reason=current AWS account differs from exact local claim\n", claim.LeaseID)
 			continue
 		}
-		var terminal *Server
+		var terminal *core.Server
 		if live, err := client.GetServer(ctx, claim.CloudID); err == nil {
 			if !isAWSTerminalServer(live) {
 				continue
@@ -1060,10 +1023,10 @@ func (b *awsLeaseBackend) cleanupOrphanedAWSClaims(ctx context.Context, dryRun b
 	return nil
 }
 
-func finalizeAWSKeyRecovery(ctx context.Context, client awsClient, claim core.LeaseClaim, cleanupKeyID string, terminal *Server) error {
+func finalizeAWSKeyRecovery(ctx context.Context, client awsClient, claim core.LeaseClaim, cleanupKeyID string, terminal *core.Server) error {
 	if terminal != nil {
 		if !isAWSTerminalServer(*terminal) {
-			return exit(4, "AWS lease %s has no observed terminal instance", claim.LeaseID)
+			return core.Exit(4, "AWS lease %s has no observed terminal instance", claim.LeaseID)
 		}
 		if err := validateExactAWSClaim(*terminal, claim.LeaseID, claim); err != nil {
 			return err
@@ -1071,7 +1034,7 @@ func finalizeAWSKeyRecovery(ctx context.Context, client awsClient, claim core.Le
 	} else if fixedAWSLeaseKind.IsFixedClaim(claim) && claim.FixedCreateIntent.State == fixedAWSIntentPrepared {
 		// A new allocation can be temporarily invisible. Keep its cleanup authority
 		// until full release succeeds or the exact instance is observed terminal.
-		return exit(4, "AWS lease %s instance visibility is unresolved; retaining its claim and key; retry when the exact instance is visible, or arrange operator recovery if it remains absent", claim.LeaseID)
+		return core.Exit(4, "AWS lease %s instance visibility is unresolved; retaining its claim and key; retry when the exact instance is visible, or arrange operator recovery if it remains absent", claim.LeaseID)
 	}
 	if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
 		return err
@@ -1088,7 +1051,7 @@ func isAWSClaimProvider(provider string) bool {
 	return provider == "aws" || provider == core.FixedAWSClaimProvider
 }
 
-func deleteAWSCleanupServerWithClient(ctx context.Context, client awsClient, server Server, cleanupKeyID string) error {
+func deleteAWSCleanupServerWithClient(ctx context.Context, client awsClient, server core.Server, cleanupKeyID string) error {
 	if err := client.DeleteServer(ctx, server.CloudID); err != nil {
 		return err
 	}
@@ -1100,7 +1063,7 @@ func deleteAWSCleanupServerWithClient(ctx context.Context, client awsClient, ser
 	return nil
 }
 
-func validateAWSCleanupLiveServer(expected, live Server) error {
+func validateAWSCleanupLiveServer(expected, live core.Server) error {
 	cloudID := strings.TrimSpace(expected.CloudID)
 	if cloudID == "" || strings.TrimSpace(live.CloudID) != cloudID {
 		return fmt.Errorf("live cloud id %q does not match cleanup candidate %q", live.CloudID, expected.CloudID)
@@ -1130,7 +1093,7 @@ func (e *awsProviderKeyCleanupError) Error() string {
 
 func (e *awsProviderKeyCleanupError) Unwrap() error { return e.err }
 
-func cleanupAWSCreatedResources(ctx context.Context, stderr io.Writer, cfg Config, cloudID, keyPairID string) error {
+func cleanupAWSCreatedResources(ctx context.Context, stderr io.Writer, cfg core.Config, cloudID, keyPairID string) error {
 	client, err := newAWSClient(ctx, cfg)
 	if err != nil {
 		fmt.Fprintf(stderr, "warning: create aws cleanup client for %s region=%s: %v\n", cloudID, cfg.AWSRegion, err)
@@ -1152,12 +1115,12 @@ func cleanupAWSCreatedResources(ctx context.Context, stderr io.Writer, cfg Confi
 	return nil
 }
 
-func awsRegionConfigs(cfg Config) []Config {
+func awsRegionConfigs(cfg core.Config) []core.Config {
 	regions := uniqueAWSRegions(append([]string{cfg.AWSRegion}, cfg.Capacity.Regions...))
 	if len(regions) == 0 {
 		regions = []string{cfg.AWSRegion}
 	}
-	configs := make([]Config, 0, len(regions))
+	configs := make([]core.Config, 0, len(regions))
 	for _, region := range regions {
 		next := cfg
 		next.AWSRegion = region
@@ -1183,14 +1146,14 @@ func uniqueAWSRegions(regions []string) []string {
 	return out
 }
 
-func awsServerRegion(server Server) string {
+func awsServerRegion(server core.Server) string {
 	if server.Labels == nil {
 		return ""
 	}
 	return strings.TrimSpace(server.Labels["aws_region"])
 }
 
-func annotateAWSServerRegion(server Server, region string) Server {
+func annotateAWSServerRegion(server core.Server, region string) core.Server {
 	region = strings.TrimSpace(region)
 	if region == "" {
 		return server
@@ -1208,7 +1171,7 @@ func annotateAWSServerRegion(server Server, region string) Server {
 	return server
 }
 
-func awsConfigForServer(cfg Config, server Server) Config {
+func awsConfigForServer(cfg core.Config, server core.Server) core.Config {
 	if region := awsServerRegion(server); region != "" {
 		cfg.AWSRegion = region
 	}

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -25,14 +25,14 @@ import (
 
 type fakeAWSClient struct {
 	mu               sync.Mutex
-	servers          []Server
-	created          Server
+	servers          []core.Server
+	created          core.Server
 	createCalls      int
 	createSlugs      []string
-	createCfg        Config
+	createCfg        core.Config
 	createErr        error
 	waitErr          error
-	get              map[string]Server
+	get              map[string]core.Server
 	getErrs          map[string]error
 	getErr           error
 	getIDs           []string
@@ -48,20 +48,20 @@ type fakeAWSClient struct {
 	tagged           []string
 	tagLabels        []map[string]string
 	setTagsErr       error
-	controlCreate    func(*core.AWSFixedCreateControl, Config, string, string) (Server, Config, error)
+	controlCreate    func(*core.AWSFixedCreateControl, core.Config, string, string) (core.Server, core.Config, error)
 }
 
-func (c *fakeAWSClient) ListCrabboxServers(context.Context) ([]Server, error) {
+func (c *fakeAWSClient) ListCrabboxServers(context.Context) ([]core.Server, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return append([]Server(nil), c.servers...), nil
+	return append([]core.Server(nil), c.servers...), nil
 }
 
-func (c *fakeAWSClient) CreateServerWithFallback(_ context.Context, cfg Config, _, leaseID, slug string, _ bool, _ func(string, ...any)) (Server, Config, error) {
+func (c *fakeAWSClient) CreateServerWithFallback(_ context.Context, cfg core.Config, _, leaseID, slug string, _ bool, _ func(string, ...any)) (core.Server, core.Config, error) {
 	c.createCalls++
 	c.createSlugs = append(c.createSlugs, slug)
 	if c.createErr != nil {
-		return Server{}, Config{}, c.createErr
+		return core.Server{}, core.Config{}, c.createErr
 	}
 	if c.created.CloudID == "" {
 		c.created = awsTestServer("i-created", leaseID, slug, "us-east-1")
@@ -79,7 +79,7 @@ func (c *fakeAWSClient) CreateServerWithFallback(_ context.Context, cfg Config, 
 	return c.created, c.createCfg, nil
 }
 
-func (c *fakeAWSClient) CreateServerWithFallbackControl(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any), control *core.AWSFixedCreateControl) (Server, Config, error) {
+func (c *fakeAWSClient) CreateServerWithFallbackControl(ctx context.Context, cfg core.Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any), control *core.AWSFixedCreateControl) (core.Server, core.Config, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.controlCreate != nil {
@@ -94,32 +94,32 @@ func (c *fakeAWSClient) CreateServerWithFallbackControl(ctx context.Context, cfg
 	}
 	if control.BeforeAttempt != nil {
 		if err := control.BeforeAttempt(attempt); err != nil {
-			return Server{}, cfg, err
+			return core.Server{}, cfg, err
 		}
 	}
 	server := fixedAWSTestServer(control, cfg, leaseID, slug, attempt)
 	c.created = server
-	c.servers = []Server{server}
+	c.servers = []core.Server{server}
 	c.createCfg = cfg
 	return server, cfg, nil
 }
 
-func (c *fakeAWSClient) WaitForServerIP(context.Context, string) (Server, error) {
+func (c *fakeAWSClient) WaitForServerIP(context.Context, string) (core.Server, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.waitErr != nil {
-		return Server{}, c.waitErr
+		return core.Server{}, c.waitErr
 	}
 	return c.created, nil
 }
 
-func (c *fakeAWSClient) GetServer(_ context.Context, id string) (Server, error) {
+func (c *fakeAWSClient) GetServer(_ context.Context, id string) (core.Server, error) {
 	c.getIDs = append(c.getIDs, id)
 	if err := c.getErrs[id]; err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	if c.getErr != nil {
-		return Server{}, c.getErr
+		return core.Server{}, c.getErr
 	}
 	if c.get != nil {
 		if server, ok := c.get[id]; ok {
@@ -131,7 +131,7 @@ func (c *fakeAWSClient) GetServer(_ context.Context, id string) (Server, error) 
 			return server, nil
 		}
 	}
-	return Server{}, core.Exit(4, "aws instance not found: %s", id)
+	return core.Server{}, core.Exit(4, "aws instance not found: %s", id)
 }
 
 func (c *fakeAWSClient) DeleteServer(_ context.Context, id string) error {
@@ -187,11 +187,11 @@ func (c *fakeAWSClient) SetTags(_ context.Context, id string, labels map[string]
 	return nil
 }
 
-func (c *fakeAWSClient) CapacityDoctorChecks(context.Context, Config) []core.DoctorCheck {
+func (c *fakeAWSClient) CapacityDoctorChecks(context.Context, core.Config) []core.DoctorCheck {
 	return nil
 }
 
-func (c *fakeAWSClient) SpotPlacementScores(context.Context, Config) ([]ec2types.SpotPlacementScore, error) {
+func (c *fakeAWSClient) SpotPlacementScores(context.Context, core.Config) ([]ec2types.SpotPlacementScore, error) {
 	return nil, nil
 }
 
@@ -221,10 +221,10 @@ func TestLeaseSSHAWSInvalidStateRootPreventsAcquireAndFallback(t *testing.T) {
 				before := snapshotAWSStateFixture(t, dirs.Root)
 				fake := &fakeAWSClient{}
 				oldClient := newAWSClient
-				newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+				newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 				t.Cleanup(func() { newAWSClient = oldClient })
-				backend := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-				req := AcquireRequest{Repo: core.Repo{Root: dirs.Root}}
+				backend := NewAWSLeaseBackend(core.ProviderSpec{}, fixedAWSTestConfig(), core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+				req := core.AcquireRequest{Repo: core.Repo{Root: dirs.Root}}
 				if fixed {
 					req.RequestedLeaseID = "cbx_abcdef151607"
 				}
@@ -232,7 +232,7 @@ func TestLeaseSSHAWSInvalidStateRootPreventsAcquireAndFallback(t *testing.T) {
 				if err == nil || !strings.Contains(err.Error(), wantError) {
 					t.Fatalf("acquisition error=%v, want selected-root rejection containing %q", err, wantError)
 				}
-				if !reflect.DeepEqual(lease, LeaseTarget{}) {
+				if !reflect.DeepEqual(lease, core.LeaseTarget{}) {
 					t.Fatal("invalid state root returned an acquired lease")
 				}
 				// Both fake create entrypoints encompass instance/key provisioning;
@@ -274,16 +274,16 @@ func TestAWSAcquireCleansUpCreatedServerAndKeyOnIPFailure(t *testing.T) {
 	ipErr := errors.New("ip unavailable")
 	fake := &fakeAWSClient{
 		created:   awsTestServer("i-created", "cbx_created", "created", "us-west-2"),
-		createCfg: Config{Provider: "aws", AWSRegion: "us-west-2"},
+		createCfg: core.Config{Provider: "aws", AWSRegion: "us-west-2"},
 		waitErr:   ipErr,
 	}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) {
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	backend := NewAWSLeaseBackend(ProviderSpec{}, Config{Provider: "aws", AWSRegion: "us-west-2"}, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, core.Config{Provider: "aws", AWSRegion: "us-west-2"}, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	_, err := backend.acquireOnce(context.Background(), false, "")
 	if !errors.Is(err, ipErr) {
 		t.Fatalf("err=%v, want IP failure", err)
@@ -304,7 +304,7 @@ func TestAWSFixedAcquireAllowsReleaseAfterReadinessFailure(t *testing.T) {
 			t.Cleanup(installFixedAWSTestClient(t, fake))
 			readinessErr := errors.New("readiness interrupted")
 			bootstrapCalls, acquiredCalls := 0, 0
-			bootstrapAWSWindowsDesktop = func(context.Context, Config, *SSHTarget, string, io.Writer) error {
+			bootstrapAWSWindowsDesktop = func(context.Context, core.Config, *core.SSHTarget, string, io.Writer) error {
 				bootstrapCalls++
 				return readinessErr
 			}
@@ -312,12 +312,12 @@ func TestAWSFixedAcquireAllowsReleaseAfterReadinessFailure(t *testing.T) {
 				fake.waitErr = readinessErr
 			}
 			cfg := fixedAWSTestConfig()
-			req := AcquireRequest{
+			req := core.AcquireRequest{
 				Repo: core.Repo{Root: t.TempDir()}, Keep: true,
 				RequestedLeaseID: "cbx_abcdef123485", RequestedSlug: "interrupted-readiness",
-				OnAcquired: func(LeaseTarget) error { acquiredCalls++; return nil },
+				OnAcquired: func(core.LeaseTarget) error { acquiredCalls++; return nil },
 			}
-			backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+			backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 			if _, err := backend.Acquire(t.Context(), req); !errors.Is(err, readinessErr) {
 				t.Fatalf("acquire error=%v, want interrupted readiness", err)
 			}
@@ -325,15 +325,15 @@ func TestAWSFixedAcquireAllowsReleaseAfterReadinessFailure(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			restarted := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-			lease, err := restarted.Resolve(t.Context(), ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true})
+			restarted := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+			lease, err := restarted.Resolve(t.Context(), core.ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true})
 			if err != nil {
 				t.Fatal(err)
 			}
 			if err := restarted.AuthorizeStatusTouchClaim(t.Context(), lease, pending); err == nil || !strings.Contains(err.Error(), "no acquired fixed intent") {
 				t.Fatalf("pending claim authorized normal use: %v", err)
 			}
-			if err := restarted.ReleaseLease(t.Context(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+			if err := restarted.ReleaseLease(t.Context(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 				t.Fatalf("release after %s failure: %v", phase, err)
 			}
 			if pending.CloudID != fake.created.CloudID || pending.FixedCreateIntent.State != fixedAWSIntentPrepared ||
@@ -365,21 +365,21 @@ func TestAWSFixedAcquireAllowsReleaseAfterReadinessFailure(t *testing.T) {
 func TestAWSFixedAcquireRejectsChangedCloudIDAfterIPWait(t *testing.T) {
 	testutil.IsolateUserDirs(t)
 	fake := &fakeAWSClient{}
-	fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg Config, leaseID, slug string) (Server, Config, error) {
+	fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg core.Config, leaseID, slug string) (core.Server, core.Config, error) {
 		fake.createCalls++
 		attempt := fixedAWSTestAttempt(cfg)
 		if err := control.BeforeAttempt(attempt); err != nil {
-			return Server{}, cfg, err
+			return core.Server{}, cfg, err
 		}
 		created := fixedAWSTestServer(control, cfg, leaseID, slug, attempt)
-		fake.servers = []Server{created}
+		fake.servers = []core.Server{created}
 		fake.created = created
 		fake.created.CloudID = "i-copied-tags-after-wait"
 		return created, cfg, nil
 	}
 	t.Cleanup(installFixedAWSTestClient(t, fake))
-	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123486", RequestedSlug: "bound-before-wait"}
-	_, err := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(t.Context(), req)
+	req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123486", RequestedSlug: "bound-before-wait"}
+	_, err := NewAWSLeaseBackend(core.ProviderSpec{}, fixedAWSTestConfig(), core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(t.Context(), req)
 	if err == nil {
 		t.Fatal("accepted a different instance with copied tags after IP wait")
 	}
@@ -399,20 +399,20 @@ func TestAWSFixedAcquireReplaysSameLeaseAndRejectsIntentDrift(t *testing.T) {
 	defer restore()
 	cfg := fixedAWSTestConfig()
 	repo := t.TempDir()
-	req := AcquireRequest{
+	req := core.AcquireRequest{
 		Repo: core.Repo{Root: repo}, Keep: true, RequestedLeaseID: "cbx_abcdef123456",
 		RequestedCheckpointID: "chk_fixed_aws", RequestedSlug: "fixed-aws",
 	}
 
-	first := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	first := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	lease, err := first.Acquire(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := first.Touch(context.Background(), TouchRequest{Lease: lease, State: "running"}); err != nil {
+	if _, err := first.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "running"}); err != nil {
 		t.Fatal(err)
 	}
-	second := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	second := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	replayed, err := second.Acquire(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
@@ -435,7 +435,7 @@ func TestAWSFixedAcquireReplaysSameLeaseAndRejectsIntentDrift(t *testing.T) {
 			t.Fatalf("creates=%d after checkpoint drift, want 1", fake.createCalls)
 		}
 	}
-	for _, acquired := range []LeaseTarget{lease, replayed} {
+	for _, acquired := range []core.LeaseTarget{lease, replayed} {
 		for _, want := range []string{"timeout 20m cloud-init status --wait", "/usr/local/bin/crabbox-ready"} {
 			if !strings.Contains(acquired.SSH.ReadyCheck, want) {
 				t.Fatalf("fixed AWS acquisition/replay ready check=%q, missing %q", acquired.SSH.ReadyCheck, want)
@@ -471,11 +471,11 @@ func TestAWSFixedAcquireRejectsBoundIdentityDrift(t *testing.T) {
 				fake := &fakeAWSClient{}
 				t.Cleanup(installFixedAWSTestClient(t, fake))
 				cfg := fixedAWSTestConfig()
-				req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123481", RequestedSlug: "identity-bound"}
+				req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123481", RequestedSlug: "identity-bound"}
 				if state == fixedAWSIntentPrepared {
 					fake.waitErr = errors.New("readiness interrupted")
 				}
-				_, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(t.Context(), req)
+				_, err := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(t.Context(), req)
 				if !errors.Is(err, fake.waitErr) {
 					t.Fatalf("initial acquisition: %v", err)
 				}
@@ -490,8 +490,8 @@ func TestAWSFixedAcquireRejectsBoundIdentityDrift(t *testing.T) {
 				} else {
 					impostor.Labels["provider_key"] = core.ProviderKeyForLease("cbx_abcdef987654")
 				}
-				fake.servers, fake.created, fake.waitErr = []Server{impostor}, impostor, nil
-				if _, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(t.Context(), req); err == nil {
+				fake.servers, fake.created, fake.waitErr = []core.Server{impostor}, impostor, nil
+				if _, err := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(t.Context(), req); err == nil {
 					t.Fatal("accepted changed bound identity")
 				}
 				after, err := core.ReadLeaseClaim(req.RequestedLeaseID)
@@ -512,16 +512,16 @@ func TestAWSFixedAcquireConflictsOnExplicitSSHCIDRDrift(t *testing.T) {
 	restore := installFixedAWSTestClient(t, fake)
 	defer restore()
 	repo := t.TempDir()
-	req := AcquireRequest{Repo: core.Repo{Root: repo}, Keep: true, RequestedLeaseID: "cbx_abcdef123468", RequestedSlug: "cidr-drift"}
+	req := core.AcquireRequest{Repo: core.Repo{Root: repo}, Keep: true, RequestedLeaseID: "cbx_abcdef123468", RequestedSlug: "cidr-drift"}
 	firstCfg := fixedAWSTestConfig()
 	firstCfg.AWSSSHCIDRs = []string{"198.51.100.10/32"}
-	if _, err := NewAWSLeaseBackend(ProviderSpec{}, firstCfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err != nil {
+	if _, err := NewAWSLeaseBackend(core.ProviderSpec{}, firstCfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err != nil {
 		t.Fatal(err)
 	}
 	creates := fake.createCalls
 	secondCfg := fixedAWSTestConfig()
 	secondCfg.AWSSSHCIDRs = []string{"203.0.113.20/32"}
-	if _, err := NewAWSLeaseBackend(ProviderSpec{}, secondCfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err == nil || !strings.Contains(err.Error(), "lease_id_conflict") {
+	if _, err := NewAWSLeaseBackend(core.ProviderSpec{}, secondCfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err == nil || !strings.Contains(err.Error(), "lease_id_conflict") {
 		t.Fatalf("explicit CIDR drift err=%v", err)
 	}
 	if fake.createCalls != creates {
@@ -537,19 +537,19 @@ func TestAWSFixedAcquireIgnoresDiscoveredUnpinnedSSHCIDRDrift(t *testing.T) {
 	oldEnsure := ensureAWSSSHCIDRs
 	detected := "198.51.100.10/32"
 	var pinnedValues []bool
-	ensureAWSSSHCIDRs = func(_ context.Context, cfg *Config) {
+	ensureAWSSSHCIDRs = func(_ context.Context, cfg *core.Config) {
 		pinnedValues = append(pinnedValues, cfg.AWSSSHCIDRsPinned)
 		if len(cfg.AWSSSHCIDRs) == 0 {
 			cfg.AWSSSHCIDRs = []string{detected}
 		}
 	}
 	defer func() { ensureAWSSSHCIDRs = oldEnsure }()
-	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123469", RequestedSlug: "cidr-discovered"}
-	if _, err := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err != nil {
+	req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123469", RequestedSlug: "cidr-discovered"}
+	if _, err := NewAWSLeaseBackend(core.ProviderSpec{}, fixedAWSTestConfig(), core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err != nil {
 		t.Fatal(err)
 	}
 	detected = "203.0.113.20/32"
-	if _, err := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err != nil {
+	if _, err := NewAWSLeaseBackend(core.ProviderSpec{}, fixedAWSTestConfig(), core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err != nil {
 		t.Fatal(err)
 	}
 	if len(pinnedValues) != 2 || pinnedValues[0] || pinnedValues[1] {
@@ -575,19 +575,19 @@ func TestAWSFixedAcquireConflictsOnCacheVolumeDrift(t *testing.T) {
 			fake := &fakeAWSClient{}
 			restore := installFixedAWSTestClient(t, fake)
 			defer restore()
-			req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: test.leaseID, RequestedSlug: "cache-drift"}
+			req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: test.leaseID, RequestedSlug: "cache-drift"}
 			firstCfg := fixedAWSTestConfig()
 			firstCfg.Cache.Volumes = []core.CacheVolumeConfig{{
 				Name: "pnpm", Key: "repo-pnpm", Path: "/var/cache/pnpm", SizeGB: 40, Required: true,
 			}}
-			if _, err := NewAWSLeaseBackend(ProviderSpec{}, firstCfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err != nil {
+			if _, err := NewAWSLeaseBackend(core.ProviderSpec{}, firstCfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err != nil {
 				t.Fatal(err)
 			}
 			creates := fake.createCalls
 			secondCfg := firstCfg
 			secondCfg.Cache.Volumes = append([]core.CacheVolumeConfig(nil), firstCfg.Cache.Volumes...)
 			test.mutate(&secondCfg.Cache.Volumes[0])
-			if _, err := NewAWSLeaseBackend(ProviderSpec{}, secondCfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err == nil || !strings.Contains(err.Error(), "lease_id_conflict") {
+			if _, err := NewAWSLeaseBackend(core.ProviderSpec{}, secondCfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err == nil || !strings.Contains(err.Error(), "lease_id_conflict") {
 				t.Fatalf("cache %s drift err=%v", test.name, err)
 			}
 			if fake.createCalls != creates {
@@ -612,8 +612,8 @@ func TestAWSFixedAcquireClaimDoesNotPersistSecrets(t *testing.T) {
 	cfg.Tailscale.Enabled = true
 	cfg.Tailscale.AuthKey = secret
 	cfg.Tailscale.AuthKeyEnv = "SECRET_ENV"
-	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef12347d", RequestedSlug: "secret-free"}
-	if _, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err != nil {
+	req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef12347d", RequestedSlug: "secret-free"}
+	if _, err := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err != nil {
 		t.Fatal(err)
 	}
 	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
@@ -638,8 +638,8 @@ func TestAWSFixedAcquireRejectsPriorFingerprintVersion(t *testing.T) {
 	restore := installFixedAWSTestClient(t, fake)
 	defer restore()
 	cfg := fixedAWSTestConfig()
-	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef12347e", RequestedSlug: "old-version"}
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef12347e", RequestedSlug: "old-version"}
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	if _, err := backend.Acquire(context.Background(), req); err != nil {
 		t.Fatal(err)
 	}
@@ -667,15 +667,15 @@ func TestAWSFixedAcquireRejectsAcquiredLeaseWhenBoundInstanceIsMissing(t *testin
 	restore := installFixedAWSTestClient(t, fake)
 	defer restore()
 	cfg := fixedAWSTestConfig()
-	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123460", RequestedSlug: "acquired-missing"}
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123460", RequestedSlug: "acquired-missing"}
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	if _, err := backend.Acquire(context.Background(), req); err != nil {
 		t.Fatal(err)
 	}
 	creates := fake.createCalls
 	fake.servers = nil
 
-	restarted := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	restarted := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	if _, err := restarted.Acquire(context.Background(), req); err == nil || !strings.Contains(err.Error(), "lease_id_conflict") || !strings.Contains(err.Error(), "missing its bound AWS instance") {
 		t.Fatalf("missing acquired replay err=%v", err)
 	}
@@ -700,8 +700,8 @@ func TestAWSFixedReleasePersistsTerminalTombstoneAndRejectsReplay(t *testing.T) 
 	restore := installFixedAWSTestClient(t, fake)
 	defer restore()
 	cfg := fixedAWSTestConfig()
-	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123461", RequestedSlug: "released-fixed"}
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123461", RequestedSlug: "released-fixed"}
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	lease, err := backend.Acquire(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
@@ -732,7 +732,7 @@ func TestAWSFixedReleasePersistsTerminalTombstoneAndRejectsReplay(t *testing.T) 
 	strippedLease.Server.Labels = maps.Clone(lease.Server.Labels)
 	delete(strippedLease.Server.Labels, "fixed_intent_sha256")
 	creates := fake.createCalls
-	if outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: strippedLease}); err != nil || !outcome.Terminal {
+	if outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: strippedLease}); err != nil || !outcome.Terminal {
 		t.Fatalf("fixed deletion outcome=%+v err=%v", outcome, err)
 	}
 	retained, err := backend.RetainLeaseClaimAfterReleaseWithClaim(strippedLease, liveClaim)
@@ -768,7 +768,7 @@ func TestAWSFixedReleasePersistsTerminalTombstoneAndRejectsReplay(t *testing.T) 
 	if _, stillExists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); err != nil || !stillExists {
 		t.Fatalf("automatic orphan cleanup removed fixed tombstone: exists=%t err=%v", stillExists, err)
 	}
-	restarted := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	restarted := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	if _, err := restarted.Acquire(context.Background(), req); err == nil || !strings.Contains(err.Error(), "lease_id_conflict") || !strings.Contains(err.Error(), "terminal") {
 		t.Fatalf("released fixed replay err=%v", err)
 	}
@@ -784,20 +784,20 @@ func TestAWSOrdinaryReleaseKeepsLegacyClaimDeletionBehavior(t *testing.T) {
 	testutil.IsolateUserDirs(t)
 	server := awsTestServer("i-ordinary-release", "cbx_abcdef12347f", "ordinary-release", "us-east-1")
 	server.Labels["provider_key"] = core.ProviderKeyForLease(server.Labels["lease"])
-	fake := &fakeAWSClient{servers: []Server{server}}
+	fake := &fakeAWSClient{servers: []core.Server{server}}
 	restore := installFixedAWSTestClient(t, fake)
 	defer restore()
 	cfg := fixedAWSTestConfig()
-	if err := core.ClaimLeaseTargetForConfig(server.Labels["lease"], server.Labels["slug"], cfg, server, SSHTarget{}, time.Hour); err != nil {
+	if err := core.ClaimLeaseTargetForConfig(server.Labels["lease"], server.Labels["slug"], cfg, server, core.SSHTarget{}, time.Hour); err != nil {
 		t.Fatal(err)
 	}
 	previous, exists, err := core.ReadLeaseClaimWithPresence(server.Labels["lease"])
 	if err != nil || !exists {
 		t.Fatalf("read ordinary claim: exists=%t err=%v", exists, err)
 	}
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-	lease := LeaseTarget{LeaseID: server.Labels["lease"], Server: server}
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	lease := core.LeaseTarget{LeaseID: server.Labels["lease"], Server: server}
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
 	}
 	retained, err := backend.RetainLeaseClaimAfterReleaseWithClaim(lease, previous)
@@ -822,11 +822,11 @@ func TestAWSReleaseRejectsFixedTagWithoutDurableClaim(t *testing.T) {
 	testutil.IsolateUserDirs(t)
 	server := awsTestServer("i-fixed-no-claim", "cbx_abcdef123480", "fixed-no-claim", "us-east-1")
 	server.Labels["fixed_intent_sha256"] = strings.Repeat("a", 64)
-	fake := &fakeAWSClient{servers: []Server{server}}
+	fake := &fakeAWSClient{servers: []core.Server{server}}
 	restore := installFixedAWSTestClient(t, fake)
 	defer restore()
-	backend := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: server.Labels["lease"], Server: server}})
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, fixedAWSTestConfig(), core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: server.Labels["lease"], Server: server}})
 	if err == nil || !strings.Contains(err.Error(), "without its durable create intent") {
 		t.Fatalf("release err=%v", err)
 	}
@@ -838,30 +838,30 @@ func TestAWSReleaseRejectsFixedTagWithoutDurableClaim(t *testing.T) {
 func TestAWSOrdinaryReleaseRejectsMissingOrStaleExactClaim(t *testing.T) {
 	for _, test := range []struct {
 		name   string
-		mutate func(*Server)
+		mutate func(*core.Server)
 		seed   bool
 	}{
 		{name: "missing claim"},
-		{name: "different instance", seed: true, mutate: func(server *Server) { server.CloudID = "i-replacement" }},
-		{name: "different region", seed: true, mutate: func(server *Server) { server.Labels["aws_region"] = "us-west-2" }},
-		{name: "different provider key", seed: true, mutate: func(server *Server) { server.Labels["provider_key"] = "crabbox-cbx-000000000000" }},
+		{name: "different instance", seed: true, mutate: func(server *core.Server) { server.CloudID = "i-replacement" }},
+		{name: "different region", seed: true, mutate: func(server *core.Server) { server.Labels["aws_region"] = "us-west-2" }},
+		{name: "different provider key", seed: true, mutate: func(server *core.Server) { server.Labels["provider_key"] = "crabbox-cbx-000000000000" }},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			testutil.IsolateUserDirs(t)
 			server := awsTestServer("i-ordinary-owned", "cbx_abcdef1234aa", "ordinary-owned", "us-east-1")
 			server.Labels["provider_key"] = core.ProviderKeyForLease(server.Labels["lease"])
-			fake := &fakeAWSClient{servers: []Server{server}}
+			fake := &fakeAWSClient{servers: []core.Server{server}}
 			restore := installFixedAWSTestClient(t, fake)
 			defer restore()
 			cfg := fixedAWSTestConfig()
 			if test.seed {
-				if err := core.ClaimLeaseTargetForConfig(server.Labels["lease"], server.Labels["slug"], cfg, server, SSHTarget{}, time.Hour); err != nil {
+				if err := core.ClaimLeaseTargetForConfig(server.Labels["lease"], server.Labels["slug"], cfg, server, core.SSHTarget{}, time.Hour); err != nil {
 					t.Fatal(err)
 				}
 				test.mutate(&server)
 			}
-			backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-			err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: server.Labels["lease"], Server: server}})
+			backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+			err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: server.Labels["lease"], Server: server}})
 			if err == nil || !strings.Contains(err.Error(), "exact local claim") {
 				t.Fatalf("release err=%v, want exact-claim rejection", err)
 			}
@@ -885,25 +885,25 @@ func TestAWSFixedAcquireRecoversCommitThenTimeoutAfterFreshBackend(t *testing.T)
 	testutil.IsolateUserDirs(t)
 	fake := &fakeAWSClient{}
 	resourceCount := 0
-	fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg Config, leaseID, slug string) (Server, Config, error) {
+	fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg core.Config, leaseID, slug string) (core.Server, core.Config, error) {
 		fake.createCalls++
 		attempt := fixedAWSTestAttempt(cfg)
 		if err := control.BeforeAttempt(attempt); err != nil {
-			return Server{}, cfg, err
+			return core.Server{}, cfg, err
 		}
 		server := fixedAWSTestServer(control, cfg, leaseID, slug, attempt)
 		fake.created = server
-		fake.servers = []Server{server}
+		fake.servers = []core.Server{server}
 		resourceCount = 1
-		return Server{}, cfg, errors.New("transport closed after RunInstances committed")
+		return core.Server{}, cfg, errors.New("transport closed after RunInstances committed")
 	}
 	restore := installFixedAWSTestClient(t, fake)
 	defer restore()
-	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123457", RequestedSlug: "commit-timeout"}
+	req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123457", RequestedSlug: "commit-timeout"}
 	cfg := fixedAWSTestConfig()
 	cfg.Tailscale.AuthKey = "fixed-intent-secret-must-not-persist"
 
-	first := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	first := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	if _, err := first.Acquire(context.Background(), req); err == nil {
 		t.Fatal("expected uncertain create error")
 	}
@@ -932,7 +932,7 @@ func TestAWSFixedAcquireRecoversCommitThenTimeoutAfterFreshBackend(t *testing.T)
 		t.Fatalf("created resource lacks exact attempt attestation: %v", err)
 	}
 	fake.controlCreate = nil
-	second := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	second := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	fake.waitErr = errors.New("public IP readiness interrupted after adoption")
 	if _, err := second.Acquire(t.Context(), req); !errors.Is(err, fake.waitErr) {
 		t.Fatalf("adopted instance readiness: %v", err)
@@ -954,24 +954,24 @@ func TestAWSFixedAcquireRecoversCommitThenTimeoutAfterFreshBackend(t *testing.T)
 func TestAWSFixedAcquireTerminalizesDefinitiveProviderRejection(t *testing.T) {
 	testutil.IsolateUserDirs(t)
 	fake := &fakeAWSClient{}
-	fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg Config, leaseID, _ string) (Server, Config, error) {
+	fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg core.Config, leaseID, _ string) (core.Server, core.Config, error) {
 		fake.createCalls++
 		attempt := fixedAWSTestAttempt(cfg)
 		if err := control.BeforeAttempt(attempt); err != nil {
-			return Server{}, cfg, err
+			return core.Server{}, cfg, err
 		}
 		control.PinnedAttempt = &attempt
 		control.TerminalRejection = true
 		if err := control.DefiniteFailure(attempt); err != nil {
-			return Server{}, cfg, err
+			return core.Server{}, cfg, err
 		}
 		control.PinnedAttempt = nil
-		return Server{}, cfg, errors.New("AWS RunInstances rejected request (Blocked)")
+		return core.Server{}, cfg, errors.New("AWS RunInstances rejected request (Blocked)")
 	}
 	restore := installFixedAWSTestClient(t, fake)
 	defer restore()
-	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123488", RequestedSlug: "terminal-rejection"}
-	backend := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123488", RequestedSlug: "terminal-rejection"}
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, fixedAWSTestConfig(), core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 
 	_, err := backend.Acquire(context.Background(), req)
 	var exitErr core.ExitError
@@ -985,7 +985,7 @@ func TestAWSFixedAcquireTerminalizesDefinitiveProviderRejection(t *testing.T) {
 	if err := fixedAWSLeaseKind.ValidateTerminalClaim(claim, core.LeaseClaim{}, req.RequestedLeaseID, nil); err != nil {
 		t.Fatalf("terminal claim: %v", err)
 	}
-	if _, err := backend.Resolve(t.Context(), ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true}); err == nil {
+	if _, err := backend.Resolve(t.Context(), core.ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true}); err == nil {
 		t.Fatal("no-allocation rejection became a successful stop receipt")
 	}
 	keyPath, err := core.TestboxKeyPath(req.RequestedLeaseID)
@@ -1022,23 +1022,23 @@ func TestAWSFixedAcquireRejectsMismatchedOrMissingAttemptAttestation(t *testing.
 			t.Run(strings.TrimPrefix(tag, "fixed_attempt_")+"/"+mutation, func(t *testing.T) {
 				testutil.IsolateUserDirs(t)
 				fake := &fakeAWSClient{}
-				fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg Config, leaseID, slug string) (Server, Config, error) {
+				fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg core.Config, leaseID, slug string) (core.Server, core.Config, error) {
 					fake.createCalls++
 					attempt := fixedAWSTestAttempt(cfg)
 					attempt.AvailabilityZone = "us-east-1a"
 					attempt.SubnetID = "subnet-fixed"
 					attempt.HostID = "h-fixed"
 					if err := control.BeforeAttempt(attempt); err != nil {
-						return Server{}, cfg, err
+						return core.Server{}, cfg, err
 					}
 					fake.created = fixedAWSTestServer(control, cfg, leaseID, slug, attempt)
-					return Server{}, cfg, errors.New("transport closed after ambiguous fixed create")
+					return core.Server{}, cfg, errors.New("transport closed after ambiguous fixed create")
 				}
 				restore := installFixedAWSTestClient(t, fake)
 				defer restore()
 				cfg := fixedAWSTestConfig()
-				req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123482", RequestedSlug: "attempt-attested"}
-				if _, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err == nil {
+				req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123482", RequestedSlug: "attempt-attested"}
+				if _, err := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err == nil {
 					t.Fatal("expected ambiguous create error")
 				}
 				candidate := fake.created
@@ -1048,11 +1048,11 @@ func TestAWSFixedAcquireRejectsMismatchedOrMissingAttemptAttestation(t *testing.
 				} else {
 					candidate.Labels[tag] += "-other"
 				}
-				fake.servers = []Server{candidate}
+				fake.servers = []core.Server{candidate}
 				fake.controlCreate = nil
 				creates := fake.createCalls
 
-				_, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req)
+				_, err := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req)
 				if err == nil || !strings.Contains(err.Error(), "lease_id_conflict") || !strings.Contains(err.Error(), "durable launch attempt") {
 					t.Fatalf("%s %s attestation replay err=%v", tag, mutation, err)
 				}
@@ -1073,20 +1073,20 @@ func TestAWSFixedAcquireRejectsCopiedAttemptTagsWhenProviderIdentityDiffers(t *t
 		t.Run(field, func(t *testing.T) {
 			testutil.IsolateUserDirs(t)
 			fake := &fakeAWSClient{}
-			fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg Config, leaseID, slug string) (Server, Config, error) {
+			fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg core.Config, leaseID, slug string) (core.Server, core.Config, error) {
 				fake.createCalls++
 				attempt := fixedAWSTestAttempt(cfg)
 				if err := control.BeforeAttempt(attempt); err != nil {
-					return Server{}, cfg, err
+					return core.Server{}, cfg, err
 				}
 				fake.created = fixedAWSTestServer(control, cfg, leaseID, slug, attempt)
-				return Server{}, cfg, errors.New("transport closed after ambiguous fixed create")
+				return core.Server{}, cfg, errors.New("transport closed after ambiguous fixed create")
 			}
 			t.Cleanup(installFixedAWSTestClient(t, fake))
 			cfg := fixedAWSTestConfig()
 			cfg.Capacity.Regions = []string{"eu-west-1"}
-			req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123484", RequestedSlug: "provider-attested"}
-			if _, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(t.Context(), req); err == nil {
+			req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123484", RequestedSlug: "provider-attested"}
+			if _, err := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(t.Context(), req); err == nil {
 				t.Fatal("expected ambiguous create error")
 			}
 			candidate := fake.created
@@ -1101,19 +1101,19 @@ func TestAWSFixedAcquireRejectsCopiedAttemptTagsWhenProviderIdentityDiffers(t *t
 				candidate.Labels["aws_key_pair_id"] = "key-id-other"
 			}
 			if field == "observed region" {
-				otherRegion.servers = []Server{candidate}
+				otherRegion.servers = []core.Server{candidate}
 			} else {
-				fake.servers = []Server{candidate}
+				fake.servers = []core.Server{candidate}
 			}
 			fake.created = candidate
-			newAWSClient = func(_ context.Context, regionCfg Config) (awsClient, error) {
+			newAWSClient = func(_ context.Context, regionCfg core.Config) (awsClient, error) {
 				if regionCfg.AWSRegion == "eu-west-1" {
 					return otherRegion, nil
 				}
 				return fake, nil
 			}
 			fake.controlCreate = nil
-			_, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(t.Context(), req)
+			_, err := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(t.Context(), req)
 			if err == nil || !strings.Contains(err.Error(), "lease_id_conflict") || !strings.Contains(err.Error(), "provider") {
 				t.Fatalf("copied attempt tags with wrong %s: %v", field, err)
 			}
@@ -1130,34 +1130,34 @@ func TestAWSFixedAcquireWaitsForDelayedVisibilityWithoutResubmitting(t *testing.
 	fake := &fakeAWSClient{}
 	providerCalls := 0
 	resourceCount := 0
-	fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg Config, leaseID, slug string) (Server, Config, error) {
+	fake.controlCreate = func(control *core.AWSFixedCreateControl, cfg core.Config, leaseID, slug string) (core.Server, core.Config, error) {
 		providerCalls++
 		attempt := fixedAWSTestAttempt(cfg)
 		if providerCalls != 1 {
-			return Server{}, cfg, errors.New("persisted fixed attempt was resubmitted")
+			return core.Server{}, cfg, errors.New("persisted fixed attempt was resubmitted")
 		}
 		if err := control.BeforeAttempt(attempt); err != nil {
-			return Server{}, cfg, err
+			return core.Server{}, cfg, err
 		}
 		fake.created = fixedAWSTestServer(control, cfg, leaseID, slug, attempt)
 		resourceCount = 1
-		return Server{}, cfg, errors.New("transport closed before instance became visible")
+		return core.Server{}, cfg, errors.New("transport closed before instance became visible")
 	}
 	restore := installFixedAWSTestClient(t, fake)
 	defer restore()
-	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123458", RequestedSlug: "delayed-visible"}
+	req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123458", RequestedSlug: "delayed-visible"}
 
-	if _, err := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err == nil {
+	if _, err := NewAWSLeaseBackend(core.ProviderSpec{}, fixedAWSTestConfig(), core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err == nil {
 		t.Fatal("expected first transport error")
 	}
-	if _, err := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err == nil || !strings.Contains(err.Error(), "lease_id_conflict") || !strings.Contains(err.Error(), "inventory converges") {
+	if _, err := NewAWSLeaseBackend(core.ProviderSpec{}, fixedAWSTestConfig(), core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req); err == nil || !strings.Contains(err.Error(), "lease_id_conflict") || !strings.Contains(err.Error(), "inventory converges") {
 		t.Fatalf("first replay err=%v", err)
 	}
 	if providerCalls != 1 || resourceCount != 1 {
 		t.Fatalf("first replay providerCalls=%d resources=%d", providerCalls, resourceCount)
 	}
-	fake.servers = []Server{fake.created}
-	lease, err := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req)
+	fake.servers = []core.Server{fake.created}
+	lease, err := NewAWSLeaseBackend(core.ProviderSpec{}, fixedAWSTestConfig(), core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1171,13 +1171,13 @@ func TestAWSFixedAcquireSerializesConcurrentReplay(t *testing.T) {
 	fake := &fakeAWSClient{}
 	restore := installFixedAWSTestClient(t, fake)
 	defer restore()
-	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123459", RequestedSlug: "concurrent"}
+	req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef123459", RequestedSlug: "concurrent"}
 	start := make(chan struct{})
 	results := make(chan error, 2)
 	for range 2 {
 		go func() {
 			<-start
-			_, err := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req)
+			_, err := NewAWSLeaseBackend(core.ProviderSpec{}, fixedAWSTestConfig(), core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req)
 			results <- err
 		}()
 	}
@@ -1200,9 +1200,9 @@ func TestAWSFixedAcquireOnAcquiredCanReenterClaimLock(t *testing.T) {
 	cfg := fixedAWSTestConfig()
 	repo := t.TempDir()
 	callbackCalled := make(chan struct{}, 1)
-	req := AcquireRequest{
+	req := core.AcquireRequest{
 		Repo: core.Repo{Root: repo}, Keep: true, RequestedLeaseID: "cbx_abcdef123466", RequestedSlug: "callback-reentry",
-		OnAcquired: func(acquired LeaseTarget) error {
+		OnAcquired: func(acquired core.LeaseTarget) error {
 			if err := core.ClaimLeaseTargetForRepoConfig(
 				acquired.LeaseID, "callback-reentry", cfg, acquired.Server, acquired.SSH,
 				repo, cfg.IdleTimeout, false,
@@ -1214,12 +1214,12 @@ func TestAWSFixedAcquireOnAcquiredCanReenterClaimLock(t *testing.T) {
 		},
 	}
 	type acquireResult struct {
-		lease LeaseTarget
+		lease core.LeaseTarget
 		err   error
 	}
 	result := make(chan acquireResult, 1)
 	go func() {
-		lease, err := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req)
+		lease, err := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend).Acquire(context.Background(), req)
 		result <- acquireResult{lease: lease, err: err}
 	}()
 
@@ -1255,7 +1255,7 @@ func TestAWSFixedAcquireOnAcquiredCanReenterClaimLock(t *testing.T) {
 	}
 }
 
-func fixedAWSTestConfig() Config {
+func fixedAWSTestConfig() core.Config {
 	cfg := core.BaseConfig()
 	cfg.Provider = "aws"
 	cfg.TargetOS = "linux"
@@ -1265,7 +1265,7 @@ func fixedAWSTestConfig() Config {
 	return cfg
 }
 
-func fixedAWSTestAttempt(cfg Config) core.AWSLaunchAttempt {
+func fixedAWSTestAttempt(cfg core.Config) core.AWSLaunchAttempt {
 	return core.AWSLaunchAttempt{
 		Region: cfg.AWSRegion, ServerType: cfg.ServerType, Market: cfg.Capacity.Market,
 		ImageID: "ami-fixed", SecurityGroupID: "sg-fixed", KeyPairID: "key-id-for-" + cfg.ProviderKey,
@@ -1273,7 +1273,7 @@ func fixedAWSTestAttempt(cfg Config) core.AWSLaunchAttempt {
 	}
 }
 
-func fixedAWSTestServer(control *core.AWSFixedCreateControl, cfg Config, leaseID, slug string, attempt core.AWSLaunchAttempt) Server {
+func fixedAWSTestServer(control *core.AWSFixedCreateControl, cfg core.Config, leaseID, slug string, attempt core.AWSLaunchAttempt) core.Server {
 	server := awsTestServer("i-fixed", leaseID, slug, cfg.AWSRegion)
 	server.ServerType.Name = attempt.ServerType
 	server.HostID = attempt.HostID
@@ -1299,8 +1299,8 @@ func installFixedAWSTestClient(t *testing.T, fake *fakeAWSClient) func() {
 	t.Helper()
 	oldClient := newAWSClient
 	oldBootstrap := bootstrapAWSWindowsDesktop
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
-	bootstrapAWSWindowsDesktop = func(context.Context, Config, *SSHTarget, string, io.Writer) error { return nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
+	bootstrapAWSWindowsDesktop = func(context.Context, core.Config, *core.SSHTarget, string, io.Writer) error { return nil }
 	return func() {
 		newAWSClient = oldClient
 		bootstrapAWSWindowsDesktop = oldBootstrap
@@ -1313,8 +1313,8 @@ func TestAWSFixedCleanupRetainsPreparedClaimWhileInstanceVisibilityIsUncertain(t
 			testutil.IsolateUserDirs(t)
 			fake := &fakeAWSClient{waitErr: context.Canceled}
 			t.Cleanup(installFixedAWSTestClient(t, fake))
-			req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef12348a", RequestedSlug: "pending-visibility"}
-			backend := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+			req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef12348a", RequestedSlug: "pending-visibility"}
+			backend := NewAWSLeaseBackend(core.ProviderSpec{}, fixedAWSTestConfig(), core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 			if _, err := backend.Acquire(t.Context(), req); !errors.Is(err, context.Canceled) {
 				t.Fatalf("initial readiness cancellation: %v", err)
 			}
@@ -1336,7 +1336,7 @@ func TestAWSFixedCleanupRetainsPreparedClaimWhileInstanceVisibilityIsUncertain(t
 				if boundary == "wrong terminal identity" {
 					terminal.CloudID = "i-other"
 				}
-				fake.get = map[string]Server{before.CloudID: terminal}
+				fake.get = map[string]core.Server{before.CloudID: terminal}
 				err = backend.cleanupOrphanedAWSClaims(t.Context(), false)
 			}
 			after, readErr := core.ReadLeaseClaim(req.RequestedLeaseID)
@@ -1361,8 +1361,8 @@ func TestAWSPreparedLeaseRetainsCustodyAfterPartialReleaseAndLostVisibility(t *t
 	testutil.IsolateUserDirs(t)
 	fake := &fakeAWSClient{waitErr: context.Canceled}
 	t.Cleanup(installFixedAWSTestClient(t, fake))
-	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef12348b", RequestedSlug: "partial-release"}
-	backend := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true, RequestedLeaseID: "cbx_abcdef12348b", RequestedSlug: "partial-release"}
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, fixedAWSTestConfig(), core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	if _, err := backend.Acquire(t.Context(), req); !errors.Is(err, context.Canceled) {
 		t.Fatalf("initial readiness cancellation: %v", err)
 	}
@@ -1370,13 +1370,13 @@ func TestAWSPreparedLeaseRetainsCustodyAfterPartialReleaseAndLostVisibility(t *t
 	if err != nil || before.FixedCreateIntent == nil || before.FixedCreateIntent.State != fixedAWSIntentPrepared {
 		t.Fatalf("missing prepared allocation: %+v err=%v", before, err)
 	}
-	lease, err := backend.Resolve(t.Context(), ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true})
+	lease, err := backend.Resolve(t.Context(), core.ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 	keyErr := errors.New("key cleanup denied")
 	fake.deleteKeyErr = keyErr
-	outcome, err := backend.ReleaseLeaseWithOutcome(t.Context(), ReleaseLeaseRequest{Lease: lease})
+	outcome, err := backend.ReleaseLeaseWithOutcome(t.Context(), core.ReleaseLeaseRequest{Lease: lease})
 	if !outcome.Terminal || !errors.Is(err, keyErr) {
 		t.Fatalf("partial release outcome=%+v err=%v", outcome, err)
 	}
@@ -1407,7 +1407,7 @@ func TestAWSAcquireRollbackRetainsKeyWhenTerminationIsUncertain(t *testing.T) {
 	}
 	t.Cleanup(installFixedAWSTestClient(t, fake))
 	var stderr strings.Builder
-	backend := NewAWSLeaseBackend(ProviderSpec{}, fixedAWSTestConfig(), Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, fixedAWSTestConfig(), core.Runtime{Stderr: &stderr}).(*awsLeaseBackend)
 	if _, err := backend.acquireOnce(t.Context(), false, "uncertain-rollback"); !errors.Is(err, context.Canceled) {
 		t.Fatalf("acquisition error=%v, want cancellation", err)
 	}
@@ -1420,24 +1420,24 @@ func TestAWSAcquireBindsImmutableProviderKeyID(t *testing.T) {
 	testutil.IsolateUserDirs(t)
 	fake := &fakeAWSClient{}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 	oldEnsure := ensureAWSSSHCIDRs
 	detections := 0
-	ensureAWSSSHCIDRs = func(_ context.Context, cfg *Config) {
+	ensureAWSSSHCIDRs = func(_ context.Context, cfg *core.Config) {
 		detections++
 		if len(cfg.AWSSSHCIDRs) == 0 {
 			cfg.AWSSSHCIDRs = []string{"198.51.100.7/32"}
 		}
 	}
 	oldBootstrap := bootstrapAWSWindowsDesktop
-	bootstrapAWSWindowsDesktop = func(context.Context, Config, *SSHTarget, string, io.Writer) error { return nil }
+	bootstrapAWSWindowsDesktop = func(context.Context, core.Config, *core.SSHTarget, string, io.Writer) error { return nil }
 	t.Cleanup(func() {
 		newAWSClient = oldClient
 		ensureAWSSSHCIDRs = oldEnsure
 		bootstrapAWSWindowsDesktop = oldBootstrap
 	})
 
-	backend := NewAWSLeaseBackend(ProviderSpec{}, Config{Provider: "aws", TargetOS: "linux", AWSRegion: "us-east-1"}, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, core.Config{Provider: "aws", TargetOS: "linux", AWSRegion: "us-east-1"}, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	lease, err := backend.acquireOnce(context.Background(), false, "bound-key")
 	if err != nil {
 		t.Fatal(err)
@@ -1467,15 +1467,15 @@ func TestAWSAcquireRollsBackWhenCleanupIdentityTagsFail(t *testing.T) {
 	tagErr := errors.New("tag write failed")
 	fake := &fakeAWSClient{setTagsErr: tagErr}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 	oldBootstrap := bootstrapAWSWindowsDesktop
-	bootstrapAWSWindowsDesktop = func(context.Context, Config, *SSHTarget, string, io.Writer) error { return nil }
+	bootstrapAWSWindowsDesktop = func(context.Context, core.Config, *core.SSHTarget, string, io.Writer) error { return nil }
 	t.Cleanup(func() {
 		newAWSClient = oldClient
 		bootstrapAWSWindowsDesktop = oldBootstrap
 	})
 
-	backend := NewAWSLeaseBackend(ProviderSpec{}, Config{Provider: "aws", TargetOS: "linux", AWSRegion: "us-east-1"}, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, core.Config{Provider: "aws", TargetOS: "linux", AWSRegion: "us-east-1"}, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	_, err := backend.acquireOnce(context.Background(), false, "tag-failure")
 	if !errors.Is(err, tagErr) {
 		t.Fatalf("err=%v, want tag failure", err)
@@ -1491,7 +1491,7 @@ func TestAWSAcquireDoesNotDeleteProviderKeyByNameOnCreateFailure(t *testing.T) {
 	east := &fakeAWSClient{createErr: createErr}
 	west := &fakeAWSClient{}
 	oldClient := newAWSClient
-	newAWSClient = func(_ context.Context, cfg Config) (awsClient, error) {
+	newAWSClient = func(_ context.Context, cfg core.Config) (awsClient, error) {
 		switch cfg.AWSRegion {
 		case "us-east-1":
 			return east, nil
@@ -1504,9 +1504,9 @@ func TestAWSAcquireDoesNotDeleteProviderKeyByNameOnCreateFailure(t *testing.T) {
 	}
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
 	cfg.Capacity.Regions = []string{"us-east-1", "us-west-2"}
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	_, err := backend.acquireOnce(context.Background(), false, "")
 	if !errors.Is(err, createErr) {
 		t.Fatalf("err=%v, want create failure", err)
@@ -1525,18 +1525,18 @@ func TestLeaseSSHAWSReleaseOnlyResolveBypassesGuestKey(t *testing.T) {
 	}
 	t.Setenv("XDG_STATE_HOME", namespace)
 	server := awsTestServer("i-release", leaseID, "release-only", "us-west-2")
-	fake := &fakeAWSClient{servers: []Server{server}}
+	fake := &fakeAWSClient{servers: []core.Server{server}}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 	t.Cleanup(func() { newAWSClient = oldClient })
-	backend := NewAWSLeaseBackend(ProviderSpec{}, Config{Provider: "aws", AWSRegion: "us-west-2"}, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, core.Config{Provider: "aws", AWSRegion: "us-west-2"}, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	for _, id := range []string{server.CloudID, server.Labels["slug"]} {
 		t.Run(id, func(t *testing.T) {
-			lease, err := backend.Resolve(t.Context(), ResolveRequest{ID: id, ReleaseOnly: true})
+			lease, err := backend.Resolve(t.Context(), core.ResolveRequest{ID: id, ReleaseOnly: true})
 			if err != nil || lease.LeaseID != leaseID || lease.Server.CloudID != server.CloudID || lease.Server.Labels["aws_region"] != "us-west-2" {
 				t.Fatalf("release identity=%#v err=%v", lease, err)
 			}
-			if _, err := backend.Resolve(t.Context(), ResolveRequest{ID: id}); err == nil {
+			if _, err := backend.Resolve(t.Context(), core.ResolveRequest{ID: id}); err == nil {
 				t.Fatal("guest resolution accepted the invalid generated namespace")
 			}
 		})
@@ -1549,10 +1549,10 @@ func TestLeaseSSHAWSReleaseOnlyResolveBypassesGuestKey(t *testing.T) {
 func TestAWSResolveAndReleaseUseFallbackRegion(t *testing.T) {
 	testutil.IsolateUserDirs(t)
 	east := &fakeAWSClient{}
-	west := &fakeAWSClient{servers: []Server{awsTestServer("i-west", "cbx_fedcba654321", "west", "us-west-2")}}
+	west := &fakeAWSClient{servers: []core.Server{awsTestServer("i-west", "cbx_fedcba654321", "west", "us-west-2")}}
 	west.servers[0].Labels["provider_key"] = "crabbox-cbx-fedcba654321"
 	oldClient := newAWSClient
-	newAWSClient = func(_ context.Context, cfg Config) (awsClient, error) {
+	newAWSClient = func(_ context.Context, cfg core.Config) (awsClient, error) {
 		switch cfg.AWSRegion {
 		case "us-east-1":
 			return east, nil
@@ -1565,20 +1565,20 @@ func TestAWSResolveAndReleaseUseFallbackRegion(t *testing.T) {
 	}
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
 	cfg.Capacity.Regions = []string{"us-east-1", "us-west-2"}
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: "west"})
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "west"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if lease.Server.CloudID != "i-west" || lease.Server.Labels["aws_region"] != "us-west-2" {
 		t.Fatalf("lease=%#v, want west-region server", lease.Server)
 	}
-	if err := core.ClaimLeaseTargetForConfig(lease.LeaseID, lease.Server.Labels["slug"], cfg, lease.Server, SSHTarget{}, time.Hour); err != nil {
+	if err := core.ClaimLeaseTargetForConfig(lease.LeaseID, lease.Server.Labels["slug"], cfg, lease.Server, core.SSHTarget{}, time.Hour); err != nil {
 		t.Fatal(err)
 	}
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
 	}
 	if len(east.deletedInstances) != 0 || len(east.deletedKeys) != 0 {
@@ -1593,28 +1593,28 @@ func TestAWSResolveAndReleaseUseFallbackRegion(t *testing.T) {
 }
 
 func TestAWSResolveRawInstanceRejectsExternalServer(t *testing.T) {
-	external := Server{
+	external := core.Server{
 		CloudID:  "i-external",
 		Provider: "aws",
 		Name:     "prod-db",
 		Labels:   map[string]string{},
 	}
 	external.PublicNet.IPv4.IP = "203.0.113.44"
-	fake := &fakeAWSClient{servers: []Server{external}}
+	fake := &fakeAWSClient{servers: []core.Server{external}}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) {
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	backend := NewAWSLeaseBackend(ProviderSpec{}, Config{Provider: "aws", AWSRegion: "us-east-1"}, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: "i-external", ReleaseOnly: true})
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, core.Config{Provider: "aws", AWSRegion: "us-east-1"}, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "i-external", ReleaseOnly: true})
 	if err == nil || !strings.Contains(err.Error(), "not Crabbox-managed") {
 		t.Fatalf("lease=%#v err=%v, want not Crabbox-managed rejection", lease, err)
 	}
 
 	if err == nil {
-		_ = backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease})
+		_ = backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
 	}
 	if len(fake.deletedInstances) != 0 {
 		t.Fatalf("deleted instances=%v, want no release for external raw instance", fake.deletedInstances)
@@ -1646,15 +1646,15 @@ func TestIsCrabboxAWSLeaseRequiresCanonicalTags(t *testing.T) {
 func TestAWSResolveRawInstanceRejectsWrongProviderLabel(t *testing.T) {
 	server := awsTestServer("i-wrong-provider", "cbx_123456abcdef", "wrong-provider", "us-east-1")
 	server.Labels["provider"] = "gcp"
-	fake := &fakeAWSClient{servers: []Server{server}}
+	fake := &fakeAWSClient{servers: []core.Server{server}}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) {
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	backend := NewAWSLeaseBackend(ProviderSpec{}, Config{Provider: "aws", AWSRegion: "us-east-1"}, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: "i-wrong-provider", ReleaseOnly: true})
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, core.Config{Provider: "aws", AWSRegion: "us-east-1"}, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "i-wrong-provider", ReleaseOnly: true})
 	if err == nil || !strings.Contains(err.Error(), "not Crabbox-managed") {
 		t.Fatalf("err=%v, want wrong-provider rejection", err)
 	}
@@ -1663,15 +1663,15 @@ func TestAWSResolveRawInstanceRejectsWrongProviderLabel(t *testing.T) {
 func TestAWSResolveRawInstanceRejectsMissingProviderLabelForRelease(t *testing.T) {
 	server := awsTestServer("i-managed", "cbx_123456abcdef", "managed", "us-east-1")
 	delete(server.Labels, "provider")
-	fake := &fakeAWSClient{servers: []Server{server}}
+	fake := &fakeAWSClient{servers: []core.Server{server}}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) {
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	backend := NewAWSLeaseBackend(ProviderSpec{}, Config{Provider: "aws", AWSRegion: "us-east-1"}, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: "i-managed", ReleaseOnly: true})
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, core.Config{Provider: "aws", AWSRegion: "us-east-1"}, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "i-managed", ReleaseOnly: true})
 	if err == nil || !strings.Contains(err.Error(), "not Crabbox-managed") {
 		t.Fatalf("err=%v, want missing-provider rejection", err)
 	}
@@ -1680,19 +1680,19 @@ func TestAWSResolveRawInstanceRejectsMissingProviderLabelForRelease(t *testing.T
 func TestAWSReleaseRejectsForgedOrMismatchedOwnership(t *testing.T) {
 	for _, test := range []struct {
 		name    string
-		mutate  func(*LeaseTarget)
+		mutate  func(*core.LeaseTarget)
 		message string
 	}{
 		{
 			name: "missing created-by tag",
-			mutate: func(lease *LeaseTarget) {
+			mutate: func(lease *core.LeaseTarget) {
 				delete(lease.Server.Labels, "created_by")
 			},
 			message: "canonical Crabbox ownership tags",
 		},
 		{
 			name: "mismatched lease tag",
-			mutate: func(lease *LeaseTarget) {
+			mutate: func(lease *core.LeaseTarget) {
 				lease.LeaseID = "cbx_fedcba654321"
 			},
 			message: "matching canonical Crabbox ownership tags",
@@ -1701,18 +1701,18 @@ func TestAWSReleaseRejectsForgedOrMismatchedOwnership(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fake := &fakeAWSClient{}
 			oldClient := newAWSClient
-			newAWSClient = func(context.Context, Config) (awsClient, error) {
+			newAWSClient = func(context.Context, core.Config) (awsClient, error) {
 				return fake, nil
 			}
 			t.Cleanup(func() { newAWSClient = oldClient })
 
-			lease := LeaseTarget{
+			lease := core.LeaseTarget{
 				Server:  awsTestServer("i-managed", "cbx_123456abcdef", "managed", "us-east-1"),
 				LeaseID: "cbx_123456abcdef",
 			}
 			test.mutate(&lease)
-			backend := NewAWSLeaseBackend(ProviderSpec{}, Config{Provider: "aws", AWSRegion: "us-east-1"}, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-			err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease})
+			backend := NewAWSLeaseBackend(core.ProviderSpec{}, core.Config{Provider: "aws", AWSRegion: "us-east-1"}, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+			err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
 			if err == nil || !strings.Contains(err.Error(), test.message) {
 				t.Fatalf("err=%v, want %q", err, test.message)
 			}
@@ -1729,20 +1729,20 @@ func TestAWSReleaseRemovesClaimWhenProviderKeyDeletionFails(t *testing.T) {
 	keyName := "crabbox-cbx-abcdef123456"
 	server := awsTestServer("i-partial", leaseID, "partial-release", "us-west-2")
 	server.Labels["provider_key"] = keyName
-	cfg := Config{Provider: "aws", AWSRegion: "us-west-2"}
-	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "partial-release", cfg, server, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-west-2"}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "partial-release", cfg, server, core.SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
 		t.Fatalf("seed claim: %v", err)
 	}
 	keyErr := errors.New("iam denied key deletion")
 	fake := &fakeAWSClient{deleteKeyErr: keyErr}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) {
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-	outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{Server: server, LeaseID: leaseID}})
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{Server: server, LeaseID: leaseID}})
 	if !outcome.Terminal {
 		t.Errorf("key cleanup error hid confirmed instance deletion: %+v", outcome)
 	}
@@ -1768,7 +1768,7 @@ func TestAWSTouchUsesFallbackRegion(t *testing.T) {
 	east := &fakeAWSClient{}
 	west := &fakeAWSClient{}
 	oldClient := newAWSClient
-	newAWSClient = func(_ context.Context, cfg Config) (awsClient, error) {
+	newAWSClient = func(_ context.Context, cfg core.Config) (awsClient, error) {
 		switch cfg.AWSRegion {
 		case "us-east-1":
 			return east, nil
@@ -1786,7 +1786,7 @@ func TestAWSTouchUsesFallbackRegion(t *testing.T) {
 	server := awsTestServer("i-west", leaseID, "west", "us-west-2")
 	server.Labels["provider_key"] = core.ProviderKeyForLease(leaseID)
 	server.Labels["aws_account_id"] = "123456789012"
-	if err := core.ClaimLeaseTargetForConfig(leaseID, "west", cfg, server, SSHTarget{}, 45*time.Minute); err != nil {
+	if err := core.ClaimLeaseTargetForConfig(leaseID, "west", cfg, server, core.SSHTarget{}, 45*time.Minute); err != nil {
 		t.Fatal(err)
 	}
 	claim, err := core.ReadLeaseClaim(leaseID)
@@ -1794,9 +1794,9 @@ func TestAWSTouchUsesFallbackRegion(t *testing.T) {
 		t.Fatal(err)
 	}
 	core.SetServerLeaseClaimSnapshot(&server, claim, true)
-	west.servers = []Server{server}
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-	if _, err := backend.Touch(context.Background(), TouchRequest{Lease: LeaseTarget{Server: server, LeaseID: leaseID}, State: "ready"}); err != nil {
+	west.servers = []core.Server{server}
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	if _, err := backend.Touch(context.Background(), core.TouchRequest{Lease: core.LeaseTarget{Server: server, LeaseID: leaseID}, State: "ready"}); err != nil {
 		t.Fatal(err)
 	}
 	if len(east.tagged) != 0 {
@@ -1821,9 +1821,9 @@ func TestAWSCleanupRequiresExactClaimForFallbackRegionServer(t *testing.T) {
 	delete(unowned.Labels, "created_by")
 	unowned.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
 	east := &fakeAWSClient{}
-	west := &fakeAWSClient{servers: []Server{unowned, tagOnly, staleClaim, owned}}
+	west := &fakeAWSClient{servers: []core.Server{unowned, tagOnly, staleClaim, owned}}
 	oldClient := newAWSClient
-	newAWSClient = func(_ context.Context, cfg Config) (awsClient, error) {
+	newAWSClient = func(_ context.Context, cfg core.Config) (awsClient, error) {
 		switch cfg.AWSRegion {
 		case "us-east-1":
 			return east, nil
@@ -1836,19 +1836,19 @@ func TestAWSCleanupRequiresExactClaimForFallbackRegionServer(t *testing.T) {
 	}
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
 	cfg.Capacity.Regions = []string{"us-east-1", "us-west-2"}
-	claimCfg := Config{Provider: "aws", AWSRegion: "us-west-2"}
+	claimCfg := core.Config{Provider: "aws", AWSRegion: "us-west-2"}
 	staleOriginal := awsTestServer("i-stale-original", staleClaim.Labels["lease"], staleClaim.Labels["slug"], "us-west-2")
-	if err := core.ClaimLeaseTargetForConfig(staleClaim.Labels["lease"], staleClaim.Labels["slug"], claimCfg, staleOriginal, SSHTarget{}, time.Hour); err != nil {
+	if err := core.ClaimLeaseTargetForConfig(staleClaim.Labels["lease"], staleClaim.Labels["slug"], claimCfg, staleOriginal, core.SSHTarget{}, time.Hour); err != nil {
 		t.Fatal(err)
 	}
-	if err := core.ClaimLeaseTargetForConfig(owned.Labels["lease"], owned.Labels["slug"], claimCfg, owned, SSHTarget{}, time.Hour); err != nil {
+	if err := core.ClaimLeaseTargetForConfig(owned.Labels["lease"], owned.Labels["slug"], claimCfg, owned, core.SSHTarget{}, time.Hour); err != nil {
 		t.Fatal(err)
 	}
 	var stderr strings.Builder
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(stderr.String(), "skip server id=i-unowned") || !strings.Contains(stderr.String(), "canonical Crabbox ownership tags missing") {
@@ -1879,20 +1879,20 @@ func TestAWSCleanupDryRunRetainsExactClaim(t *testing.T) {
 	testutil.IsolateUserDirs(t)
 	server := awsTestServer("i-dry-run", "cbx_555555555555", "dry-run", "us-west-2")
 	server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
-	fake := &fakeAWSClient{servers: []Server{server}}
+	fake := &fakeAWSClient{servers: []core.Server{server}}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) {
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-west-2"}
-	if err := core.ClaimLeaseTargetForConfig(server.Labels["lease"], server.Labels["slug"], cfg, server, SSHTarget{}, time.Hour); err != nil {
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-west-2"}
+	if err := core.ClaimLeaseTargetForConfig(server.Labels["lease"], server.Labels["slug"], cfg, server, core.SSHTarget{}, time.Hour); err != nil {
 		t.Fatal(err)
 	}
 	var stderr strings.Builder
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deletedInstances) != 0 || len(fake.deletedKeys) != 0 {
@@ -1915,16 +1915,16 @@ func TestAWSCleanupRejectsProviderKeyChangedFromExactClaim(t *testing.T) {
 	candidate := original
 	candidate.Labels = maps.Clone(original.Labels)
 	candidate.Labels["provider_key"] = "crabbox-cbx-777777777777"
-	fake := &fakeAWSClient{servers: []Server{candidate}}
+	fake := &fakeAWSClient{servers: []core.Server{candidate}}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
 	claimAWSCleanupServer(t, cfg, original)
 	var stderr strings.Builder
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.getIDs) != 1 || fake.getIDs[0] != original.CloudID || len(fake.deletedInstances) != 0 || len(fake.deletedKeys) != 0 {
@@ -1945,18 +1945,18 @@ func TestAWSCleanupRevalidatesLiveOwnershipBeforeDelete(t *testing.T) {
 	live.Labels = maps.Clone(snapshot.Labels)
 	delete(live.Labels, "created_by")
 	fake := &fakeAWSClient{
-		servers: []Server{snapshot},
-		get:     map[string]Server{snapshot.CloudID: live},
+		servers: []core.Server{snapshot},
+		get:     map[string]core.Server{snapshot.CloudID: live},
 	}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
 	claimAWSCleanupServer(t, cfg, snapshot)
 	var stderr strings.Builder
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.getIDs) != 2 || fake.getIDs[0] != snapshot.CloudID || fake.getIDs[1] != snapshot.CloudID {
@@ -1980,18 +1980,18 @@ func TestAWSCleanupRejectsChangedLiveProviderKey(t *testing.T) {
 	live.Labels = maps.Clone(snapshot.Labels)
 	live.Labels["provider_key"] = "crabbox-cbx-222222222222"
 	fake := &fakeAWSClient{
-		servers: []Server{snapshot},
-		get:     map[string]Server{snapshot.CloudID: live},
+		servers: []core.Server{snapshot},
+		get:     map[string]core.Server{snapshot.CloudID: live},
 	}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
 	claimAWSCleanupServer(t, cfg, snapshot)
 	var stderr strings.Builder
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deletedInstances) != 0 || len(fake.deletedKeys) != 0 {
@@ -2009,19 +2009,19 @@ func TestAWSCleanupSkipsUnownedLiveProviderKey(t *testing.T) {
 	server.Labels["provider_key"] = "crabbox-cbx-111111111111"
 	server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
 	fake := &fakeAWSClient{
-		servers:        []Server{server},
-		get:            map[string]Server{server.CloudID: server},
+		servers:        []core.Server{server},
+		get:            map[string]core.Server{server.CloudID: server},
 		validateKeyErr: core.NewAWSCleanupKeyOwnershipError("provider key ownership changed"),
 	}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
 	claimAWSCleanupServer(t, cfg, server)
 	var stderr strings.Builder
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deletedInstances) != 0 || len(fake.deletedKeys) != 0 {
@@ -2038,19 +2038,19 @@ func TestAWSCleanupSkipsSameNameReplacementProviderKey(t *testing.T) {
 	server := awsTestServer("i-stale", "cbx_111111111111", "stale", "us-east-1")
 	server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
 	fake := &fakeAWSClient{
-		servers:       []Server{server},
-		get:           map[string]Server{server.CloudID: server},
+		servers:       []core.Server{server},
+		get:           map[string]core.Server{server.CloudID: server},
 		resolvedKeyID: "key-replacement-id",
 	}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
 	claimAWSCleanupServer(t, cfg, server)
 	var stderr strings.Builder
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deletedInstances) != 0 || len(fake.deletedKeys) != 0 {
@@ -2066,17 +2066,17 @@ func TestAWSCleanupLegacyClaimSkipsUnboundProviderKey(t *testing.T) {
 	isolateAWSClaimState(t)
 	server := awsTestServer("i-legacy", "cbx_111111111111", "legacy", "us-east-1")
 	server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
-	fake := &fakeAWSClient{servers: []Server{server}, get: map[string]Server{server.CloudID: server}}
+	fake := &fakeAWSClient{servers: []core.Server{server}, get: map[string]core.Server{server.CloudID: server}}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
-	if err := core.ClaimLeaseTargetForConfig(server.Labels["lease"], server.Labels["slug"], cfg, server, SSHTarget{}, time.Hour); err != nil {
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
+	if err := core.ClaimLeaseTargetForConfig(server.Labels["lease"], server.Labels["slug"], cfg, server, core.SSHTarget{}, time.Hour); err != nil {
 		t.Fatal(err)
 	}
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deletedInstances) != 1 || len(fake.validatedKeys) != 0 || len(fake.deletedKeys) != 0 {
@@ -2092,16 +2092,16 @@ func TestAWSCleanupRevalidatesLiveEligibilityBeforeDelete(t *testing.T) {
 	live := snapshot
 	live.Labels = maps.Clone(snapshot.Labels)
 	live.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(time.Hour))
-	fake := &fakeAWSClient{servers: []Server{snapshot}, get: map[string]Server{snapshot.CloudID: live}}
+	fake := &fakeAWSClient{servers: []core.Server{snapshot}, get: map[string]core.Server{snapshot.CloudID: live}}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
 	claimAWSCleanupServer(t, cfg, snapshot)
 	var stderr strings.Builder
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deletedInstances) != 0 {
@@ -2117,24 +2117,24 @@ func TestAWSCleanupContinuesWhenLiveCandidateAlreadyGone(t *testing.T) {
 	isolateAWSClaimState(t)
 	missing := awsTestServer("i-missing", "cbx_111111111111", "missing", "us-east-1")
 	remaining := awsTestServer("i-remaining", "cbx_222222222222", "remaining", "us-east-1")
-	for _, server := range []*Server{&missing, &remaining} {
+	for _, server := range []*core.Server{&missing, &remaining} {
 		server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
 	}
 	fake := &fakeAWSClient{
-		servers: []Server{missing, remaining},
-		get:     map[string]Server{remaining.CloudID: remaining},
+		servers: []core.Server{missing, remaining},
+		get:     map[string]core.Server{remaining.CloudID: remaining},
 		getErrs: map[string]error{missing.CloudID: core.Exit(4, "aws instance not found: %s", missing.CloudID)},
 	}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
 	claimAWSCleanupServer(t, cfg, missing)
 	claimAWSCleanupServer(t, cfg, remaining)
 	var stderr strings.Builder
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deletedInstances) != 1 || fake.deletedInstances[0] != remaining.CloudID {
@@ -2159,19 +2159,19 @@ func TestAWSCleanupRetainsMissingInstanceClaimWhenKeyOwnershipDrifts(t *testing.
 	server := awsTestServer("i-missing", "cbx_111111111111", "missing", "us-east-1")
 	server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
 	fake := &fakeAWSClient{
-		servers:        []Server{server},
+		servers:        []core.Server{server},
 		getErrs:        map[string]error{server.CloudID: core.Exit(4, "aws instance not found: %s", server.CloudID)},
 		validateKeyErr: core.NewAWSCleanupKeyOwnershipError("replacement key"),
 	}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
 	claimAWSCleanupServer(t, cfg, server)
 	var stderr strings.Builder
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deletedKeys) != 0 {
@@ -2189,25 +2189,25 @@ func TestAWSCleanupRetainsMissingInstanceClaimWhenKeyDeleteFails(t *testing.T) {
 	server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
 	deleteErr := errors.New("delete key failed")
 	fake := &fakeAWSClient{
-		servers:      []Server{server},
+		servers:      []core.Server{server},
 		getErrs:      map[string]error{server.CloudID: core.Exit(4, "aws instance not found: %s", server.CloudID)},
 		deleteKeyErr: deleteErr,
 	}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
 	claimAWSCleanupServer(t, cfg, server)
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); !errors.Is(err, deleteErr) {
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); !errors.Is(err, deleteErr) {
 		t.Fatalf("error=%v, want %v", err, deleteErr)
 	}
 	assertAWSClaimCloudID(t, server.Labels["lease"], server.CloudID)
 
 	fake.servers = nil
 	fake.deleteKeyErr = nil
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	assertAWSClaimMissing(t, server.Labels["lease"])
@@ -2218,15 +2218,15 @@ func TestAWSCleanupRecoversKeyForTerminalInstance(t *testing.T) {
 	server := awsTestServer("i-terminal", "cbx_111111111111", "terminal", "us-east-1")
 	server.Status = "terminated"
 	server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
-	fake := &fakeAWSClient{get: map[string]Server{server.CloudID: server}}
+	fake := &fakeAWSClient{get: map[string]core.Server{server.CloudID: server}}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
 	claimAWSCleanupServer(t, cfg, server)
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deletedKeys) != 1 {
@@ -2241,14 +2241,14 @@ func TestAWSCleanupOrphanRecoverySkipsDifferentAWSAccount(t *testing.T) {
 	server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
 	fake := &fakeAWSClient{accountID: "999999999999"}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
 	claimAWSCleanupServer(t, cfg, server)
 	var stderr strings.Builder
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.getIDs) != 0 || len(fake.deletedKeys) != 0 {
@@ -2267,17 +2267,17 @@ func TestAWSCleanupCopiedLeaseTagDoesNotSuppressOrphanRecovery(t *testing.T) {
 	copy := awsTestServer("i-copy", claimed.Labels["lease"], "copy", "us-east-1")
 	copy.Labels["expires_at"] = claimed.Labels["expires_at"]
 	fake := &fakeAWSClient{
-		servers: []Server{copy},
+		servers: []core.Server{copy},
 		getErrs: map[string]error{claimed.CloudID: core.Exit(4, "aws instance not found: %s", claimed.CloudID)},
 	}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
 	claimAWSCleanupServer(t, cfg, claimed)
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deletedInstances) != 0 || len(fake.deletedKeys) != 1 {
@@ -2292,18 +2292,18 @@ func TestAWSCleanupRetainsKeyAfterUncertainTerminationThenRecoversMissingInstanc
 	server.Labels["provider_key"] = "crabbox-cbx-333333333333"
 	server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
 	fake := &fakeAWSClient{
-		servers:         []Server{server},
-		get:             map[string]Server{server.CloudID: server},
+		servers:         []core.Server{server},
+		get:             map[string]core.Server{server.CloudID: server},
 		deleteServerErr: core.Exit(4, "aws instance not found: %s", server.CloudID),
 	}
 	oldClient := newAWSClient
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
 	claimAWSCleanupServer(t, cfg, server)
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); !errors.Is(err, fake.deleteServerErr) {
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); !errors.Is(err, fake.deleteServerErr) {
 		t.Fatalf("uncertain termination error=%v, want %v", err, fake.deleteServerErr)
 	}
 	if len(fake.deletedKeys) != 0 {
@@ -2313,7 +2313,7 @@ func TestAWSCleanupRetainsKeyAfterUncertainTerminationThenRecoversMissingInstanc
 	fake.servers = nil
 	fake.get = nil
 	fake.getErr = core.Exit(4, "aws instance not found: %s", server.CloudID)
-	if err := backend.Cleanup(t.Context(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(t.Context(), core.CleanupRequest{}); err != nil {
 		t.Fatalf("later missing-instance recovery: %v", err)
 	}
 	if len(fake.deletedKeys) != 1 || fake.deletedKeys[0] != "key-id-for-"+server.Labels["provider_key"] {
@@ -2327,7 +2327,7 @@ func isolateAWSClaimState(t *testing.T) {
 	testutil.IsolateUserDirs(t)
 }
 
-func claimAWSCleanupServer(t *testing.T, cfg Config, server Server) {
+func claimAWSCleanupServer(t *testing.T, cfg core.Config, server core.Server) {
 	t.Helper()
 	server.Labels = maps.Clone(server.Labels)
 	if server.Labels["aws_key_pair_id"] == "" {
@@ -2336,7 +2336,7 @@ func claimAWSCleanupServer(t *testing.T, cfg Config, server Server) {
 	if server.Labels["aws_account_id"] == "" {
 		server.Labels["aws_account_id"] = "123456789012"
 	}
-	if err := core.ClaimLeaseTargetForConfig(server.Labels["lease"], server.Labels["slug"], cfg, server, SSHTarget{}, time.Hour); err != nil {
+	if err := core.ClaimLeaseTargetForConfig(server.Labels["lease"], server.Labels["slug"], cfg, server, core.SSHTarget{}, time.Hour); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -2360,9 +2360,9 @@ func TestAWSAcquireSuffixesSlugCollisionsAcrossRegions(t *testing.T) {
 	testutil.IsolateUserDirs(t)
 	stopErr := errors.New("stop after create")
 	east := &fakeAWSClient{waitErr: stopErr}
-	west := &fakeAWSClient{servers: []Server{awsTestServer("i-west", "cbx_west", "taken", "us-west-2")}}
+	west := &fakeAWSClient{servers: []core.Server{awsTestServer("i-west", "cbx_west", "taken", "us-west-2")}}
 	oldClient := newAWSClient
-	newAWSClient = func(_ context.Context, cfg Config) (awsClient, error) {
+	newAWSClient = func(_ context.Context, cfg core.Config) (awsClient, error) {
 		switch cfg.AWSRegion {
 		case "us-east-1":
 			return east, nil
@@ -2375,9 +2375,9 @@ func TestAWSAcquireSuffixesSlugCollisionsAcrossRegions(t *testing.T) {
 	}
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := Config{Provider: "aws", AWSRegion: "us-east-1"}
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
 	cfg.Capacity.Regions = []string{"us-east-1", "us-west-2"}
-	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	_, err := backend.acquireOnce(context.Background(), false, "taken")
 	if !errors.Is(err, stopErr) {
 		t.Fatalf("err=%v, want controlled stop after create", err)
@@ -2390,8 +2390,8 @@ func TestAWSAcquireSuffixesSlugCollisionsAcrossRegions(t *testing.T) {
 	}
 }
 
-func awsTestServer(id, leaseID, slug, region string) Server {
-	server := Server{
+func awsTestServer(id, leaseID, slug, region string) core.Server {
+	server := core.Server{
 		CloudID:  id,
 		Provider: "aws",
 		Name:     slug,
@@ -2410,7 +2410,7 @@ func awsTestServer(id, leaseID, slug, region string) Server {
 
 func TestBootstrapSSHHostRespectsNetworkMode(t *testing.T) {
 	t.Parallel()
-	base := Config{Provider: "aws"}
+	base := core.Config{Provider: "aws"}
 	base.Tailscale.Enabled = true
 	base.Tailscale.HostnameTemplate = "crabbox-{slug}"
 	for _, test := range []struct {
@@ -2449,10 +2449,10 @@ func TestAWSAcquireUsesTailscaleHostnameOnlyForStrictMode(t *testing.T) {
 			testutil.IsolateUserDirs(t)
 			fake := &fakeAWSClient{}
 			oldClient := newAWSClient
-			newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+			newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fake, nil }
 			oldBootstrap := bootstrapAWSWindowsDesktop
 			var bootstrapHost string
-			bootstrapAWSWindowsDesktop = func(_ context.Context, _ Config, target *SSHTarget, _ string, _ io.Writer) error {
+			bootstrapAWSWindowsDesktop = func(_ context.Context, _ core.Config, target *core.SSHTarget, _ string, _ io.Writer) error {
 				bootstrapHost = target.Host
 				return nil
 			}
@@ -2461,11 +2461,11 @@ func TestAWSAcquireUsesTailscaleHostnameOnlyForStrictMode(t *testing.T) {
 				bootstrapAWSWindowsDesktop = oldBootstrap
 			})
 
-			cfg := Config{Provider: "aws", TargetOS: "linux", AWSRegion: "us-east-1", Network: test.network}
+			cfg := core.Config{Provider: "aws", TargetOS: "linux", AWSRegion: "us-east-1", Network: test.network}
 			cfg.Tailscale.Enabled = true
 			cfg.Tailscale.AuthKey = "test-auth-key"
 			cfg.Tailscale.HostnameTemplate = "crabbox-{slug}"
-			backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+			backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 			if _, err := backend.acquireOnce(context.Background(), false, "bootstrap"); err != nil {
 				t.Fatal(err)
 			}
@@ -2491,7 +2491,7 @@ func TestAWSAcquireStopsFreshRetryAfterRollbackFailure(t *testing.T) {
 			}
 			oldClient, oldBootstrap := newAWSClient, bootstrapAWSWindowsDesktop
 			bootstrapReached := false
-			newAWSClient = func(ctx context.Context, _ Config) (awsClient, error) {
+			newAWSClient = func(ctx context.Context, _ core.Config) (awsClient, error) {
 				if failure == "client" && bootstrapReached {
 					if _, bounded := ctx.Deadline(); bounded {
 						return nil, debt
@@ -2499,15 +2499,15 @@ func TestAWSAcquireStopsFreshRetryAfterRollbackFailure(t *testing.T) {
 				}
 				return fake, nil
 			}
-			bootstrapAWSWindowsDesktop = func(context.Context, Config, *SSHTarget, string, io.Writer) error {
+			bootstrapAWSWindowsDesktop = func(context.Context, core.Config, *core.SSHTarget, string, io.Writer) error {
 				bootstrapReached = true
 				return primary
 			}
 			t.Cleanup(func() { newAWSClient = oldClient; bootstrapAWSWindowsDesktop = oldBootstrap })
 			var stderr bytes.Buffer
-			cfg := Config{Provider: "aws", AWSRegion: "us-east-1", AWSSSHCIDRs: []string{"198.51.100.7/32"}}
-			b := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*awsLeaseBackend)
-			_, err := b.Acquire(context.Background(), AcquireRequest{})
+			cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1", AWSSSHCIDRs: []string{"198.51.100.7/32"}}
+			b := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: &stderr}).(*awsLeaseBackend)
+			_, err := b.Acquire(context.Background(), core.AcquireRequest{})
 			want := 1
 			if failure == "none" {
 				want = 2

--- a/internal/providers/aws/checkpoint_capture_test.go
+++ b/internal/providers/aws/checkpoint_capture_test.go
@@ -22,9 +22,9 @@ func TestCheckpointSourceAbsenceUsesExactAccountRegionAndID(t *testing.T) {
 		{name: "wrong account", account: "999999999999", failure: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			fake := &fakeAWSClient{accountID: tc.account, getErr: tc.err, get: map[string]Server{"i-fixture": {CloudID: "i-fixture", Status: tc.state}}}
+			fake := &fakeAWSClient{accountID: tc.account, getErr: tc.err, get: map[string]core.Server{"i-fixture": {CloudID: "i-fixture", Status: tc.state}}}
 			old := newAWSClient
-			newAWSClient = func(_ context.Context, cfg Config) (awsClient, error) {
+			newAWSClient = func(_ context.Context, cfg core.Config) (awsClient, error) {
 				if cfg.AWSRegion != "us-east-1" {
 					t.Fatalf("wrong source region: %q", cfg.AWSRegion)
 				}

--- a/internal/providers/aws/checkpoint_retained_receipt_test.go
+++ b/internal/providers/aws/checkpoint_retained_receipt_test.go
@@ -59,8 +59,8 @@ func runCheckpointRetirementReceipt(t *testing.T, tc checkpointReceiptCase) {
 	t.Cleanup(installFixedAWSTestClient(t, fake))
 	cfg := fixedAWSTestConfig()
 	cfg.AWSSSHCIDRs = []string{"127.0.0.1/32"}
-	b := NewAWSLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-	lease, err := b.Acquire(t.Context(), AcquireRequest{Repo: core.Repo{Root: repo}, Keep: true, RequestedLeaseID: "cbx_abcdef123493", RequestedSlug: "retirement-receipt"})
+	b := NewAWSLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	lease, err := b.Acquire(t.Context(), core.AcquireRequest{Repo: core.Repo{Root: repo}, Keep: true, RequestedLeaseID: "cbx_abcdef123493", RequestedSlug: "retirement-receipt"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +102,7 @@ func runCheckpointRetirementReceipt(t *testing.T, tc checkpointReceiptCase) {
 		t.Fatal(err)
 	}
 	core.SetServerLeaseClaimSnapshot(&lease.Server, bound, true)
-	if err := b.ReleaseLease(t.Context(), ReleaseLeaseRequest{Lease: lease, CheckpointID: checkpointID}); err != nil {
+	if err := b.ReleaseLease(t.Context(), core.ReleaseLeaseRequest{Lease: lease, CheckpointID: checkpointID}); err != nil {
 		t.Fatal(err)
 	}
 	terminal, err := core.ReadLeaseClaim(lease.LeaseID)
@@ -127,7 +127,7 @@ func runCheckpointRetirementReceipt(t *testing.T, tc checkpointReceiptCase) {
 	// Reopen the backend with empty inventory, as after process interruption and
 	// EC2's disappearance of terminated instances. No create/delete is allowed.
 	reloaded := &fakeAWSClient{accountID: tc.account, getErr: tc.getErr}
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return reloaded, nil }
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return reloaded, nil }
 	if tc.region != "" {
 		t.Setenv("CRABBOX_AWS_REGION", tc.region)
 	}

--- a/internal/providers/aws/heartbeat.go
+++ b/internal/providers/aws/heartbeat.go
@@ -8,7 +8,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *awsLeaseBackend) AuthorizeStatusTouchClaim(ctx context.Context, lease LeaseTarget, claim core.LeaseClaim) error {
+func (b *awsLeaseBackend) AuthorizeStatusTouchClaim(ctx context.Context, lease core.LeaseTarget, claim core.LeaseClaim) error {
 	client, err := newAWSClient(ctx, awsConfigForServer(b.Cfg, lease.Server))
 	if err != nil {
 		return err
@@ -16,7 +16,7 @@ func (b *awsLeaseBackend) AuthorizeStatusTouchClaim(ctx context.Context, lease L
 	return authorizeAWSTouch(ctx, client, lease, claim)
 }
 
-func authorizeAWSTouch(ctx context.Context, client awsClient, lease LeaseTarget, claim core.LeaseClaim) error {
+func authorizeAWSTouch(ctx context.Context, client awsClient, lease core.LeaseTarget, claim core.LeaseClaim) error {
 	if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
 		return err
 	}
@@ -29,32 +29,32 @@ func authorizeAWSTouch(ctx context.Context, client awsClient, lease LeaseTarget,
 		expectedScope = "account:" + accountID
 		intent := claim.FixedCreateIntent
 		if intent == nil || intent.State != fixedAWSIntentAcquired || intent.Fingerprint == "" {
-			return exit(4, "AWS lease %s has no acquired fixed intent; refusing touch", lease.LeaseID)
+			return core.Exit(4, "AWS lease %s has no acquired fixed intent; refusing touch", lease.LeaseID)
 		}
 		if err := validateFixedAWSServer(lease.Server, lease.LeaseID, claim.Slug, intent.Fingerprint, accountID); err != nil {
 			return err
 		}
 	}
 	if accountID == "" || claim.ProviderScope != expectedScope || lease.Server.Labels["aws_account_id"] != accountID || isAWSTerminalServer(lease.Server) {
-		return exit(4, "AWS lease %s account, scope, or live instance state differs from its exact claim; refusing touch", lease.LeaseID)
+		return core.Exit(4, "AWS lease %s account, scope, or live instance state differs from its exact claim; refusing touch", lease.LeaseID)
 	}
 	matched, err := awsClaimMatchesCurrentAccount(ctx, client, claim)
 	if err != nil {
 		return err
 	}
 	if !matched {
-		return exit(4, "AWS lease %s caller account differs from its exact claim; refusing touch", lease.LeaseID)
+		return core.Exit(4, "AWS lease %s caller account differs from its exact claim; refusing touch", lease.LeaseID)
 	}
 	return nil
 }
 
-func (b *awsLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
+func (b *awsLeaseBackend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
 	expected, exists, set := core.ServerLeaseClaimSnapshot(req.Lease.Server)
 	if !set || !exists {
-		return Server{}, exit(4, "AWS lease %s has no exact claim snapshot; refusing touch", req.Lease.LeaseID)
+		return core.Server{}, core.Exit(4, "AWS lease %s has no exact claim snapshot; refusing touch", req.Lease.LeaseID)
 	}
 	if err := validateExactAWSClaim(req.Lease.Server, req.Lease.LeaseID, expected); err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	cfg := awsConfigForServer(b.Cfg, req.Lease.Server)
 	if expected.IdleTimeoutSeconds > 0 {
@@ -63,29 +63,29 @@ func (b *awsLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, 
 	now := time.Now().UTC()
 	// Fence the current claim across account/resource checks and the tag write;
 	// a coordinator round trip must not let an old owner renew a replacement.
-	updated, server, _, err := core.UpdateLeaseClaimTouchIfUnchangedAction(ctx, req.Lease.LeaseID, expected, now, req.IdleTimeoutOverride, func() (Server, SSHTarget, bool, error) {
+	updated, server, _, err := core.UpdateLeaseClaimTouchIfUnchangedAction(ctx, req.Lease.LeaseID, expected, now, req.IdleTimeoutOverride, func() (core.Server, core.SSHTarget, bool, error) {
 		client, err := newAWSClient(ctx, cfg)
 		if err != nil {
-			return Server{}, SSHTarget{}, false, err
+			return core.Server{}, core.SSHTarget{}, false, err
 		}
 		server, err := client.GetServer(ctx, expected.CloudID)
 		if err != nil {
-			return Server{}, SSHTarget{}, false, err
+			return core.Server{}, core.SSHTarget{}, false, err
 		}
 		server = annotateAWSServerRegion(server, cfg.AWSRegion)
 		lease := req.Lease
 		lease.Server = server
 		if err := authorizeAWSTouch(ctx, client, lease, expected); err != nil {
-			return Server{}, SSHTarget{}, false, err
+			return core.Server{}, core.SSHTarget{}, false, err
 		}
 		server.Labels = core.TouchDirectLeaseLabelsWithIdleTimeoutOverride(server.Labels, cfg, req.State, now, req.IdleTimeoutOverride)
 		if err := client.SetTags(ctx, server.CloudID, server.Labels); err != nil {
-			return Server{}, SSHTarget{}, false, err
+			return core.Server{}, core.SSHTarget{}, false, err
 		}
 		return server, req.Lease.SSH, true, nil
 	})
 	if err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	core.SetServerLeaseClaimSnapshot(&server, updated, true)
 	return server, nil

--- a/internal/providers/aws/heartbeat_test.go
+++ b/internal/providers/aws/heartbeat_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/openclaw/crabbox/internal/testutil"
 )
 
-func awsHeartbeatFixture(t *testing.T, fixed bool) (*awsLeaseBackend, *fakeAWSClient, LeaseTarget) {
+func awsHeartbeatFixture(t *testing.T, fixed bool) (*awsLeaseBackend, *fakeAWSClient, core.LeaseTarget) {
 	t.Helper()
 	testutil.IsolateUserDirs(t)
 	fake := &fakeAWSClient{}
@@ -31,8 +31,8 @@ func awsHeartbeatFixture(t *testing.T, fixed bool) (*awsLeaseBackend, *fakeAWSCl
 	cfg := fixedAWSTestConfig()
 	cfg.AWSSSHCIDRs = []string{"198.51.100.10/32"}
 	cfg.IdleTimeout = 45 * time.Minute
-	backend := NewAWSLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-	request := AcquireRequest{RequestedSlug: "heartbeat"}
+	backend := NewAWSLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	request := core.AcquireRequest{RequestedSlug: "heartbeat"}
 	if fixed {
 		request.RequestedLeaseID = "cbx_abcdef123499"
 	}
@@ -41,7 +41,7 @@ func awsHeartbeatFixture(t *testing.T, fixed bool) (*awsLeaseBackend, *fakeAWSCl
 		t.Fatal(err)
 	}
 	if !fixed {
-		fake.servers = []Server{lease.Server}
+		fake.servers = []core.Server{lease.Server}
 		if err := core.ClaimLeaseTargetForConfig(lease.LeaseID, "heartbeat", cfg, lease.Server, lease.SSH, cfg.IdleTimeout); err != nil {
 			t.Fatal(err)
 		}
@@ -126,7 +126,7 @@ func TestAWSTouchCancelsWhileRunOwnsClaim(t *testing.T) {
 	}()
 	fake.getIDs = nil
 	go func() {
-		_, err := b.Touch(ctx, TouchRequest{Lease: lease, State: "running"})
+		_, err := b.Touch(ctx, core.TouchRequest{Lease: lease, State: "running"})
 		touchDone <- err
 	}()
 	cancel()
@@ -149,7 +149,7 @@ type runResolutionAWSClient struct {
 	listCalls int
 }
 
-func (c *runResolutionAWSClient) ListCrabboxServers(ctx context.Context) ([]Server, error) {
+func (c *runResolutionAWSClient) ListCrabboxServers(ctx context.Context) ([]core.Server, error) {
 	c.listCalls++
 	return c.fakeAWSClient.ListCrabboxServers(ctx)
 }
@@ -193,7 +193,7 @@ func TestAWSRunResolutionPreservesClaimAndExactAuthority(t *testing.T) {
 				}
 				lookup := &runResolutionAWSClient{fakeAWSClient: fake}
 				oldClient := newAWSClient
-				newAWSClient = func(_ context.Context, cfg Config) (awsClient, error) {
+				newAWSClient = func(_ context.Context, cfg core.Config) (awsClient, error) {
 					if cfg.AWSRegion != before.Labels["aws_region"] || len(cfg.Capacity.Regions) != 0 {
 						t.Errorf("run lookup escaped claim region: region=%s alternatives=%v", cfg.AWSRegion, cfg.Capacity.Regions)
 					}
@@ -204,7 +204,7 @@ func TestAWSRunResolutionPreservesClaimAndExactAuthority(t *testing.T) {
 				b.Cfg.Capacity.Regions = []string{"eu-west-1", before.Labels["aws_region"]}
 				fake.getIDs = nil
 				creates := fake.createCalls
-				resolved, resolveErr := b.ResolveRunLeaseUnderClaim(t.Context(), ResolveRequest{ID: lease.LeaseID, Prepare: true}, before)
+				resolved, resolveErr := b.ResolveRunLeaseUnderClaim(t.Context(), core.ResolveRequest{ID: lease.LeaseID, Prepare: true}, before)
 				if lookup.listCalls != 0 || len(fake.getIDs) != 1 || fake.getIDs[0] != before.CloudID {
 					t.Fatalf("run lookup must read only the bound instance: lists=%d gets=%v", lookup.listCalls, fake.getIDs)
 				}
@@ -281,7 +281,7 @@ func TestAWSTouchRejectsChangedAuthorityBeforeMutation(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			touch := TouchRequest{Lease: lease, State: "running"}
+			touch := core.TouchRequest{Lease: lease, State: "running"}
 			live := fake.servers[0]
 			live.Labels = maps.Clone(live.Labels)
 			live.ProviderMetadata = maps.Clone(live.ProviderMetadata)
@@ -325,7 +325,7 @@ func TestAWSTouchRejectsChangedAuthorityBeforeMutation(t *testing.T) {
 			case "failed tag write":
 				fake.setTagsErr = errors.New("CreateTags rejected")
 			}
-			fake.get = map[string]Server{lease.Server.CloudID: live}
+			fake.get = map[string]core.Server{lease.Server.CloudID: live}
 			before, existed, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
 			if err != nil {
 				t.Fatal(err)
@@ -358,7 +358,7 @@ func TestAWSStatusWaitAndConnectRenewOrdinaryAndFixedClaims(t *testing.T) {
 	}
 }
 
-func runAWSLifecycleCommandFixture(t *testing.T, fake *fakeAWSClient, lease LeaseTarget) {
+func runAWSLifecycleCommandFixture(t *testing.T, fake *fakeAWSClient, lease core.LeaseTarget) {
 	t.Helper()
 	listener, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {

--- a/internal/providers/aws/stop_replay.go
+++ b/internal/providers/aws/stop_replay.go
@@ -19,7 +19,7 @@ func finalizeAWSLeaseAfterCleanup(expected core.LeaseClaim, action func() error)
 	tombstone := fixedAWSLeaseKind.TerminalClaim(expected, time.Now().UTC())
 	return core.WithDurableLeaseClaimLock(expected.LeaseID, func(claim *core.LeaseClaim, exists bool, persist func() error) error {
 		if !exists || !reflect.DeepEqual(*claim, expected) {
-			return exit(2, "lease %s claim changed; retry", expected.LeaseID)
+			return core.Exit(2, "lease %s claim changed; retry", expected.LeaseID)
 		}
 		if err := action(); err != nil {
 			return err
@@ -55,13 +55,13 @@ func validateAWSTerminalReceipt(claim core.LeaseClaim, leaseID string) error {
 	if !core.IsCanonicalLeaseID(leaseID) ||
 		!strings.HasPrefix(claim.CloudID, "i-") || len(claim.CloudID) <= 2 || strings.TrimSpace(claim.CloudID) != claim.CloudID ||
 		claim.Slug == "" || core.NormalizeLeaseSlug(claim.Slug) != claim.Slug ||
-		!isCrabboxAWSLease(Server{Labels: labels}) || labels["lease"] != leaseID || labels["slug"] != claim.Slug ||
+		!isCrabboxAWSLease(core.Server{Labels: labels}) || labels["lease"] != leaseID || labels["slug"] != claim.Slug ||
 		len(account) != 12 || strings.Trim(account, "0123456789") != "" || claim.ProviderScope != "account:"+account ||
 		labels["aws_region"] == "" || strings.TrimSpace(labels["aws_region"]) != labels["aws_region"] ||
 		digestErr != nil || len(digest) != 32 || strings.ToLower(intent.Fingerprint) != intent.Fingerprint ||
 		labels["fixed_intent_sha256"] != intent.Fingerprint || timeErr != nil ||
 		labels["provider_key"] != core.ProviderKeyForLease(leaseID) || strings.TrimSpace(labels["aws_key_pair_id"]) == "" {
-		return exit(4, "lease_id_conflict: fixed AWS lease %s lacks a valid scoped terminal receipt; compact historical tombstones cannot prove cleanup scope", leaseID)
+		return core.Exit(4, "lease_id_conflict: fixed AWS lease %s lacks a valid scoped terminal receipt; compact historical tombstones cannot prove cleanup scope", leaseID)
 	}
 	return nil
 }
@@ -85,58 +85,58 @@ func (b *awsLeaseBackend) validateTerminalReleaseScope(ctx context.Context, clai
 			return fmt.Errorf("verify AWS terminal receipt account: %w", err)
 		}
 		if !matches {
-			return exit(4, "lease_id_conflict: fixed AWS lease %s terminal receipt belongs to another AWS account", leaseID)
+			return core.Exit(4, "lease_id_conflict: fixed AWS lease %s terminal receipt belongs to another AWS account", leaseID)
 		}
 		return nil
 	}
-	return exit(4, "lease_id_conflict: fixed AWS lease %s terminal receipt is outside configured AWS regions", leaseID)
+	return core.Exit(4, "lease_id_conflict: fixed AWS lease %s terminal receipt is outside configured AWS regions", leaseID)
 }
 
-func validateAWSTerminalInventory(claim core.LeaseClaim, servers []Server) error {
+func validateAWSTerminalInventory(claim core.LeaseClaim, servers []core.Server) error {
 	for _, server := range servers {
 		// Even incomplete or conflicting ownership tags must not conceal a
 		// visible resource behind the receipt. Do not filter by provider status.
 		if server.CloudID == claim.CloudID || server.Labels["lease"] == claim.LeaseID {
-			return exit(4, "lease_id_conflict: fixed AWS lease %s terminal receipt conflicts with visible instance %s", claim.LeaseID, server.DisplayID())
+			return core.Exit(4, "lease_id_conflict: fixed AWS lease %s terminal receipt conflicts with visible instance %s", claim.LeaseID, server.DisplayID())
 		}
 	}
 	return nil
 }
 
-func awsTerminalReleaseTarget(claim core.LeaseClaim) LeaseTarget {
-	server := Server{
+func awsTerminalReleaseTarget(claim core.LeaseClaim) core.LeaseTarget {
+	server := core.Server{
 		Provider: "aws", CloudID: claim.CloudID, ImmutableID: claim.CloudImmutableID,
 		Name: claim.Slug, Status: fixedAWSIntentReleased, Labels: maps.Clone(claim.Labels),
 	}
 	core.SetServerLeaseClaimSnapshot(&server, claim, true)
-	return LeaseTarget{LeaseID: claim.LeaseID, Server: server}
+	return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}
 }
 
-func (b *awsLeaseBackend) resolveTerminalRelease(ctx context.Context, req ResolveRequest, claim core.LeaseClaim, servers []Server) (LeaseTarget, error) {
+func (b *awsLeaseBackend) resolveTerminalRelease(ctx context.Context, req core.ResolveRequest, claim core.LeaseClaim, servers []core.Server) (core.LeaseTarget, error) {
 	if err := b.validateTerminalReleaseScope(ctx, claim, req.ID); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if err := validateAWSTerminalInventory(claim, servers); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	lease := awsTerminalReleaseTarget(claim)
 	if err := core.ValidateLeaseTargetProviderIdentity(lease, req.ExpectedProviderIdentity); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	return lease, nil
 }
 
-func (b *awsLeaseBackend) releaseTerminalReceipt(ctx context.Context, req ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
+func (b *awsLeaseBackend) releaseTerminalReceipt(ctx context.Context, req core.ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	snapshot, snapshotExists, snapshotSet := core.ServerLeaseClaimSnapshot(req.Lease.Server)
 	return core.WithDurableLeaseClaimLock(req.Lease.LeaseID, func(claim *core.LeaseClaim, exists bool, _ func() error) error {
 		if !exists || !snapshotSet || !snapshotExists || !reflect.DeepEqual(snapshot, *claim) {
-			return exit(4, "lease_id_conflict: fixed AWS lease %s terminal receipt changed or has no resolved durable snapshot", req.Lease.LeaseID)
+			return core.Exit(4, "lease_id_conflict: fixed AWS lease %s terminal receipt changed or has no resolved durable snapshot", req.Lease.LeaseID)
 		}
 		if err := b.validateTerminalReleaseScope(ctx, *claim, req.Lease.LeaseID); err != nil {
 			return err
 		}
 		if !reflect.DeepEqual(req.Lease, awsTerminalReleaseTarget(*claim)) {
-			return exit(4, "lease_id_conflict: fixed AWS lease %s terminal target differs from its durable receipt", req.Lease.LeaseID)
+			return core.Exit(4, "lease_id_conflict: fixed AWS lease %s terminal target differs from its durable receipt", req.Lease.LeaseID)
 		}
 		if err := core.ValidateLeaseTargetProviderIdentity(req.Lease, req.ExpectedProviderIdentity); err != nil {
 			return err

--- a/internal/providers/aws/stop_replay_test.go
+++ b/internal/providers/aws/stop_replay_test.go
@@ -26,7 +26,7 @@ type stopReplayAWSClient struct {
 	listErr error
 }
 
-func (c *stopReplayAWSClient) ListCrabboxServers(ctx context.Context) ([]Server, error) {
+func (c *stopReplayAWSClient) ListCrabboxServers(ctx context.Context) ([]core.Server, error) {
 	c.lists++
 	if c.listErr != nil {
 		return nil, c.listErr
@@ -51,7 +51,7 @@ func TestAWSFixedStopReplayAfterInventoryDisappears(t *testing.T) {
 		expectedExact    bool
 		lookup           string
 		inspect          bool
-		conflict         func(Server) Server
+		conflict         func(core.Server) core.Server
 		inventoryError   bool
 		malformedVersion bool
 		mutate           func(*core.LeaseClaim)
@@ -74,17 +74,17 @@ func TestAWSFixedStopReplayAfterInventoryDisappears(t *testing.T) {
 		{name: "slug", lookup: "stop-replay"},
 		{name: "raw_instance", lookup: "i-fixed"},
 		{name: "inventory_error", inventoryError: true},
-		{name: "visible_original", conflict: func(s Server) Server { return s }},
-		{name: "visible_same_lease_wrong_owner", conflict: func(s Server) Server {
+		{name: "visible_original", conflict: func(s core.Server) core.Server { return s }},
+		{name: "visible_same_lease_wrong_owner", conflict: func(s core.Server) core.Server {
 			s.CloudID = "i-conflict"
 			s.Labels["provider"] = "other"
 			return s
 		}},
-		{name: "visible_original_wrong_lease", conflict: func(s Server) Server {
+		{name: "visible_original_wrong_lease", conflict: func(s core.Server) core.Server {
 			s.Labels["lease"] = "cbx_000000000001"
 			return s
 		}},
-		{name: "visible_terminal_word", conflict: func(s Server) Server { s.Status = "terminated"; return s }},
+		{name: "visible_terminal_word", conflict: func(s core.Server) core.Server { s.Status = "terminated"; return s }},
 		{name: "wrong_provider_discriminator", mutate: func(c *core.LeaseClaim) { c.Provider = "aws" }},
 		{name: "non_fixed", mutate: func(c *core.LeaseClaim) { c.Provider = "aws"; c.FixedCreateIntent = nil }},
 		{name: "wrong_stored_lease", mutate: func(c *core.LeaseClaim) { c.LeaseID = "cbx_000000000002" }},
@@ -138,12 +138,12 @@ func TestAWSFixedStopReplayAfterInventoryDisappears(t *testing.T) {
 			fake := &fakeAWSClient{}
 			t.Cleanup(installFixedAWSTestClient(t, fake))
 			client := &stopReplayAWSClient{fakeAWSClient: fake}
-			newAWSClient = func(context.Context, Config) (awsClient, error) { return client, nil }
+			newAWSClient = func(context.Context, core.Config) (awsClient, error) { return client, nil }
 			cfg := fixedAWSTestConfig()
 			// Prevent public-IP discovery during the real fixed acquisition setup.
 			cfg.AWSSSHCIDRs = []string{"127.0.0.1/32"}
-			req := AcquireRequest{Repo: core.Repo{Root: repo}, Keep: true, RequestedLeaseID: "cbx_abcdef123490", RequestedSlug: "stop-replay"}
-			backend := NewAWSLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+			req := core.AcquireRequest{Repo: core.Repo{Root: repo}, Keep: true, RequestedLeaseID: "cbx_abcdef123490", RequestedSlug: "stop-replay"}
+			backend := NewAWSLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 			lease, err := backend.Acquire(t.Context(), req)
 			if err != nil {
 				t.Fatal(err)
@@ -233,7 +233,7 @@ func TestAWSFixedStopReplayAfterInventoryDisappears(t *testing.T) {
 			if tc.conflict != nil {
 				server := lease.Server
 				server.Labels = maps.Clone(server.Labels)
-				reloaded.servers = []Server{tc.conflict(server)}
+				reloaded.servers = []core.Server{tc.conflict(server)}
 			}
 			if tc.active {
 				// A future owner reconciliation may try the remaining key, but it
@@ -243,7 +243,7 @@ func TestAWSFixedStopReplayAfterInventoryDisappears(t *testing.T) {
 			if tc.inventoryError {
 				reloaded.listErr = errors.New("synthetic inventory unavailable")
 			}
-			newAWSClient = func(context.Context, Config) (awsClient, error) { return reloaded, nil }
+			newAWSClient = func(context.Context, core.Config) (awsClient, error) { return reloaded, nil }
 			if tc.region != "" {
 				t.Setenv("CRABBOX_AWS_REGION", tc.region)
 			}
@@ -301,7 +301,7 @@ func TestAWSFixedStopReplayAfterInventoryDisappears(t *testing.T) {
 				}
 				// A second fresh client/App must still use only the durable receipt.
 				again := &stopReplayAWSClient{fakeAWSClient: &fakeAWSClient{}}
-				newAWSClient = func(context.Context, Config) (awsClient, error) { return again, nil }
+				newAWSClient = func(context.Context, core.Config) (awsClient, error) { return again, nil }
 				output.Reset()
 				if err := (core.App{Stdout: &output, Stderr: &output}).Run(t.Context(), args); err != nil {
 					t.Fatal(err)
@@ -345,20 +345,20 @@ func assertAWSReceiptIdentity(t *testing.T, receipt, acquired core.LeaseClaim) {
 	}
 }
 
-func setupAWSReplayClaim(t *testing.T) (*awsLeaseBackend, *fakeAWSClient, AcquireRequest, LeaseTarget, string) {
+func setupAWSReplayClaim(t *testing.T) (*awsLeaseBackend, *fakeAWSClient, core.AcquireRequest, core.LeaseTarget, string) {
 	t.Helper()
 	dirs := testutil.IsolateUserDirs(t)
 	fake := &fakeAWSClient{}
 	t.Cleanup(installFixedAWSTestClient(t, fake))
 	cfg := fixedAWSTestConfig()
 	cfg.AWSSSHCIDRs = []string{"127.0.0.1/32"}
-	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedLeaseID: "cbx_abcdef123491", RequestedSlug: "receipt-fence"}
-	backend := NewAWSLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	req := core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedLeaseID: "cbx_abcdef123491", RequestedSlug: "receipt-fence"}
+	backend := NewAWSLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	lease, err := backend.Acquire(t.Context(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	lease.SSH = SSHTarget{}
+	lease.SSH = core.SSHTarget{}
 	lease.Server.PublicNet.IPv4.IP = ""
 	fake.servers[0].PublicNet.IPv4.IP = ""
 	return backend, fake, req, lease, filepath.Join(dirs.StateHome, "crabbox", "claims", lease.LeaseID+".json")
@@ -382,7 +382,7 @@ func TestAWSFixedStopRetriesLocalSSHCleanup(t *testing.T) {
 	if err := os.WriteFile(dir, []byte("synthetic cleanup obstacle"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	outcome, err := backend.ReleaseLeaseWithOutcome(t.Context(), ReleaseLeaseRequest{Lease: lease})
+	outcome, err := backend.ReleaseLeaseWithOutcome(t.Context(), core.ReleaseLeaseRequest{Lease: lease})
 	if err == nil || !outcome.Terminal || !strings.Contains(err.Error(), "local SSH cleanup") {
 		t.Fatalf("confirmed remote deletion must report pending local cleanup: outcome=%+v err=%v", outcome, err)
 	}
@@ -400,13 +400,13 @@ func TestAWSFixedStopRetriesLocalSSHCleanup(t *testing.T) {
 		t.Fatal("local cleanup failure did not follow exact provider cleanup")
 	}
 	fresh := &fakeAWSClient{}
-	newAWSClient = func(context.Context, Config) (awsClient, error) { return fresh, nil }
-	backend = NewAWSLeaseBackend(Provider{}.Spec(), backend.Cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-	target, err := backend.Resolve(t.Context(), ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true})
+	newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fresh, nil }
+	backend = NewAWSLeaseBackend(Provider{}.Spec(), backend.Cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	target, err := backend.Resolve(t.Context(), core.ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	outcome, err = backend.ReleaseLeaseWithOutcome(t.Context(), ReleaseLeaseRequest{Lease: target})
+	outcome, err = backend.ReleaseLeaseWithOutcome(t.Context(), core.ReleaseLeaseRequest{Lease: target})
 	if err == nil || !outcome.Terminal || !strings.Contains(err.Error(), "local SSH cleanup") {
 		t.Fatalf("terminal replay must report pending local cleanup: outcome=%+v err=%v", outcome, err)
 	}
@@ -441,7 +441,7 @@ func TestAWSFixedStopRetriesLocalSSHCleanup(t *testing.T) {
 
 func TestAWSFixedStopReleaseOwnerFence(t *testing.T) {
 	backend, _, _, lease, path := setupAWSReplayClaim(t)
-	if err := backend.ReleaseLease(t.Context(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+	if err := backend.ReleaseLease(t.Context(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
 	}
 	original, err := os.ReadFile(path)
@@ -451,7 +451,7 @@ func TestAWSFixedStopReleaseOwnerFence(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
 		claim       func(*core.LeaseClaim)
-		target      func(*LeaseTarget)
+		target      func(*core.LeaseTarget)
 		client      func(*stopReplayAWSClient)
 		expected    core.ProviderIdentityExpectation
 		remove      bool
@@ -491,15 +491,15 @@ func TestAWSFixedStopReleaseOwnerFence(t *testing.T) {
 			s.CloudID = "i-conflict"
 			s.Labels = maps.Clone(s.Labels)
 			s.Labels["provider"] = "other"
-			c.servers = []Server{s}
+			c.servers = []core.Server{s}
 		}},
-		{name: "forged_terminal_word_without_snapshot", target: func(l *LeaseTarget) {
-			l.Server = Server{Provider: "aws", CloudID: l.Server.CloudID, Name: l.Server.Name, Status: "released", Labels: l.Server.Labels}
+		{name: "forged_terminal_word_without_snapshot", target: func(l *core.LeaseTarget) {
+			l.Server = core.Server{Provider: "aws", CloudID: l.Server.CloudID, Name: l.Server.Name, Status: "released", Labels: l.Server.Labels}
 		}},
-		{name: "forged_target_resource", target: func(l *LeaseTarget) { l.Server.CloudID = "i-forged" }},
-		{name: "forged_target_slug", target: func(l *LeaseTarget) { l.Server.Labels["slug"] = "forged-slug" }},
-		{name: "forged_target_ssh", target: func(l *LeaseTarget) { l.SSH.Host = "127.0.0.1" }},
-		{name: "forged_matching_snapshot_invalid_receipt", claim: func(c *core.LeaseClaim) { c.FixedCreateIntent.Fingerprint = strings.Repeat("c", 64) }, target: func(l *LeaseTarget) {
+		{name: "forged_target_resource", target: func(l *core.LeaseTarget) { l.Server.CloudID = "i-forged" }},
+		{name: "forged_target_slug", target: func(l *core.LeaseTarget) { l.Server.Labels["slug"] = "forged-slug" }},
+		{name: "forged_target_ssh", target: func(l *core.LeaseTarget) { l.SSH.Host = "127.0.0.1" }},
+		{name: "forged_matching_snapshot_invalid_receipt", claim: func(c *core.LeaseClaim) { c.FixedCreateIntent.Fingerprint = strings.Repeat("c", 64) }, target: func(l *core.LeaseTarget) {
 			claim, err := core.ReadLeaseClaim(l.LeaseID)
 			if err != nil {
 				t.Fatal(err)
@@ -516,11 +516,11 @@ func TestAWSFixedStopReleaseOwnerFence(t *testing.T) {
 				t.Fatal(err)
 			}
 			client := &stopReplayAWSClient{fakeAWSClient: &fakeAWSClient{}}
-			newAWSClient = func(context.Context, Config) (awsClient, error) { return client, nil }
+			newAWSClient = func(context.Context, core.Config) (awsClient, error) { return client, nil }
 			cfg := backend.Cfg
 			cfg.Capacity.Regions = []string{"us-west-2"}
-			fresh := NewAWSLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-			target, err := fresh.Resolve(t.Context(), ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true})
+			fresh := NewAWSLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+			target, err := fresh.Resolve(t.Context(), core.ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -545,7 +545,7 @@ func TestAWSFixedStopReleaseOwnerFence(t *testing.T) {
 				fresh.Cfg.Capacity.Regions = nil
 			}
 			before, _ := os.ReadFile(path)
-			outcome, err := fresh.ReleaseLeaseWithOutcome(t.Context(), ReleaseLeaseRequest{Lease: target, ExpectedProviderIdentity: tc.expected})
+			outcome, err := fresh.ReleaseLeaseWithOutcome(t.Context(), core.ReleaseLeaseRequest{Lease: target, ExpectedProviderIdentity: tc.expected})
 			if outcome.Terminal != (tc.name == "unchanged") {
 				t.Errorf("terminal receipt outcome=%+v case=%s", outcome, tc.name)
 			}
@@ -579,7 +579,7 @@ func TestAWSFixedCleanupFailureThenStopReplay(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			visible := append([]Server(nil), fake.servers...)
+			visible := append([]core.Server(nil), fake.servers...)
 			if mode == "orphan" {
 				fake.servers = nil
 			}
@@ -592,7 +592,7 @@ func TestAWSFixedCleanupFailureThenStopReplay(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if err := backend.Cleanup(t.Context(), CleanupRequest{}); !errors.Is(err, keyErr) {
+			if err := backend.Cleanup(t.Context(), core.CleanupRequest{}); !errors.Is(err, keyErr) {
 				t.Fatalf("cleanup error=%v, want key failure", err)
 			}
 			after, err := os.ReadFile(path)
@@ -603,14 +603,14 @@ func TestAWSFixedCleanupFailureThenStopReplay(t *testing.T) {
 				t.Fatalf("wrong exact key cleanup: %v", fake.deletedKeys)
 			}
 			fake.servers = nil
-			if _, err := backend.Resolve(t.Context(), ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true}); err == nil {
+			if _, err := backend.Resolve(t.Context(), core.ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true}); err == nil {
 				t.Fatal("missing acquired inventory acknowledged outstanding cleanup")
 			}
 			if mode != "orphan" {
 				fake.servers = visible
 			}
 			fake.deleteKeyErr = nil
-			if err := backend.Cleanup(t.Context(), CleanupRequest{}); err != nil {
+			if err := backend.Cleanup(t.Context(), core.CleanupRequest{}); err != nil {
 				t.Fatal(err)
 			}
 			key, err := core.TestboxKeyPath(lease.LeaseID)
@@ -633,7 +633,7 @@ func TestAWSFixedCleanupFailureThenStopReplay(t *testing.T) {
 				t.Fatal(err)
 			}
 			fresh := &fakeAWSClient{}
-			newAWSClient = func(context.Context, Config) (awsClient, error) { return fresh, nil }
+			newAWSClient = func(context.Context, core.Config) (awsClient, error) { return fresh, nil }
 			t.Chdir(req.Repo.Root)
 			configPath := filepath.Join(req.Repo.Root, "config.yaml")
 			if err := os.WriteFile(configPath, []byte("provider: aws\naws:\n  region: us-east-1\n"), 0o600); err != nil {
@@ -654,7 +654,7 @@ func TestAWSFixedCleanupFailureThenStopReplay(t *testing.T) {
 
 func TestAWSFixedOldCompactReceiptRemainsSingleUse(t *testing.T) {
 	backend, fake, req, lease, path := setupAWSReplayClaim(t)
-	if err := backend.ReleaseLease(t.Context(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+	if err := backend.ReleaseLease(t.Context(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
 	}
 	claim, err := core.ReadLeaseClaim(lease.LeaseID)
@@ -673,13 +673,13 @@ func TestAWSFixedOldCompactReceiptRemainsSingleUse(t *testing.T) {
 	}
 	fake.servers = nil
 	creates, deletes, keys := fake.createCalls, len(fake.deletedInstances), len(fake.deletedKeys)
-	if _, err := backend.Resolve(t.Context(), ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true}); err == nil {
+	if _, err := backend.Resolve(t.Context(), core.ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true}); err == nil {
 		t.Fatal("old compact receipt acknowledged scope it cannot prove")
 	}
 	if _, err := backend.Acquire(t.Context(), req); err == nil {
 		t.Fatal("old compact receipt allowed fixed-ID reallocation")
 	}
-	if err := backend.Cleanup(t.Context(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(t.Context(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	after, err := os.ReadFile(path)

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -13,89 +13,74 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-type Config = core.Config
-type Runtime = core.Runtime
-type ProviderSpec = core.ProviderSpec
-type Backend = core.Backend
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type CleanupRequest = core.CleanupRequest
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-
 type azureLeaseBackend struct{ shared.DirectSSHBackend }
 
 const azureAcquireRollbackTimeout = 20 * time.Minute
 
 type azureClient interface {
 	LeaseClaimScope() string
-	ListCrabboxServers(context.Context) ([]Server, error)
-	CreateServerWithFallback(context.Context, Config, string, string, string, bool, func(string, ...any)) (Server, Config, error)
-	WaitForServerIP(context.Context, string) (Server, error)
-	GetServer(context.Context, string) (Server, error)
+	ListCrabboxServers(context.Context) ([]core.Server, error)
+	CreateServerWithFallback(context.Context, core.Config, string, string, string, bool, func(string, ...any)) (core.Server, core.Config, error)
+	WaitForServerIP(context.Context, string) (core.Server, error)
+	GetServer(context.Context, string) (core.Server, error)
 	DeleteServer(context.Context, string) error
-	PrepareOwnedServer(context.Context, Server) (Server, error)
-	PrepareCleanupServer(context.Context, Server, time.Time) (Server, error)
-	DeleteOwnedServer(context.Context, Server) error
-	DeleteCleanupServer(context.Context, Server, time.Time) error
+	PrepareOwnedServer(context.Context, core.Server) (core.Server, error)
+	PrepareCleanupServer(context.Context, core.Server, time.Time) (core.Server, error)
+	DeleteOwnedServer(context.Context, core.Server) error
+	DeleteCleanupServer(context.Context, core.Server, time.Time) error
 	SetTags(context.Context, string, map[string]string) error
 }
 
-func NewAzureLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewAzureLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = "azure"
 	return &azureLeaseBackend{DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt, Delete: deleteServer, StoredLeaseKeys: true}}
 }
 
-func (b *azureLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
-	return acquireAttemptsRetry(b.RT, req.Keep, func() (LeaseTarget, error) {
+func (b *azureLeaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
+	return acquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
 		return b.acquireOnce(ctx, req.Keep, req.RequestedSlug)
 	})
 }
 
-func (b *azureLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (result LeaseTarget, retErr error) {
+func (b *azureLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (result core.LeaseTarget, retErr error) {
 	cfg := b.Cfg
 	if cfg.Tailscale.Enabled && cfg.Tailscale.AuthKey == "" {
-		return LeaseTarget{}, exit(2, "direct --tailscale requires %s to contain a Tailscale auth key; brokered mode uses coordinator OAuth secrets", cfg.Tailscale.AuthKeyEnv)
+		return core.LeaseTarget{}, core.Exit(2, "direct --tailscale requires %s to contain a Tailscale auth key; brokered mode uses coordinator OAuth secrets", cfg.Tailscale.AuthKeyEnv)
 	}
 	if err := validateAzureSSHCIDRsForAcquire(ctx, cfg); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	client, err := newAzureClient(ctx, cfg)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	leaseID := core.NewLeaseID()
 	servers, err := client.ListCrabboxServers(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	slug, err := allocateDirectLeaseSlug(leaseID, requestedSlug, servers)
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, requestedSlug, servers)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	keyPath, publicKey, err := ensureTestboxKeyForConfig(cfg, leaseID)
+	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cfg.SSHKey = keyPath
-	cfg.ProviderKey = providerKeyForLease(leaseID)
-	expected := Server{CloudID: core.LeaseProviderName(leaseID, slug), Labels: core.DirectLeaseLabels(cfg, leaseID, slug, "azure", "on-demand", keep, time.Now())}
+	cfg.ProviderKey = core.ProviderKeyForLease(leaseID)
+	expected := core.Server{CloudID: core.LeaseProviderName(leaseID, slug), Labels: core.DirectLeaseLabels(cfg, leaseID, slug, "azure", "on-demand", keep, time.Now())}
 	fmt.Fprintf(b.RT.Stderr, "provisioning provider=azure lease=%s slug=%s class=%s preferred_type=%s location=%s rg=%s keep=%v\n",
 		leaseID, slug, cfg.Class, cfg.ServerType, cfg.AzureLocation, cfg.AzureResourceGroup, keep)
 	server, cfg, err := client.CreateServerWithFallback(ctx, cfg, publicKey, leaseID, slug, keep, func(format string, args ...any) {
 		fmt.Fprintf(b.RT.Stderr, format, args...)
 	})
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	expected.ImmutableID = server.ImmutableID
 	if err := validateAzureAcquiredVM(expected, server); err != nil {
-		return LeaseTarget{}, shared.JoinAcquireCleanupError(fmt.Errorf("azure creation rejected: %w", err), errors.New("Azure cleanup withheld: created VM binding is incomplete or inconsistent"))
+		return core.LeaseTarget{}, shared.JoinAcquireCleanupError(fmt.Errorf("azure creation rejected: %w", err), errors.New("Azure cleanup withheld: created VM binding is incomplete or inconsistent"))
 	}
 	created := server
 	created.Labels = maps.Clone(server.Labels)
@@ -121,34 +106,34 @@ func (b *azureLeaseBackend) acquireOnce(ctx context.Context, keep bool, requeste
 	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s server=%s type=%s\n", leaseID, server.DisplayID(), cfg.ServerType)
 	server, err = client.WaitForServerIP(ctx, server.CloudID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if err := validateAzureAcquiredVM(created, server); err != nil {
 		// A later matching read must not erase an observed replacement.
 		rollback = false
-		return LeaseTarget{}, shared.JoinAcquireCleanupError(fmt.Errorf("azure readiness rejected: %w", err), errors.New("Azure cleanup withheld after readiness identity loss"))
+		return core.LeaseTarget{}, shared.JoinAcquireCleanupError(fmt.Errorf("azure readiness rejected: %w", err), errors.New("Azure cleanup withheld after readiness identity loss"))
 	}
-	target := sshTargetFromConfig(cfg, azureServerHost(server, cfg.AzureNetwork))
+	target := core.SSHTargetFromConfig(cfg, core.AzureServerHost(server, cfg.AzureNetwork))
 	if err := bootstrapManagedWindowsDesktop(ctx, cfg, &target, publicKey, b.RT.Stderr); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	server.Labels["state"] = "ready"
 	if err := client.SetTags(ctx, server.CloudID, server.Labels); err != nil {
 		fmt.Fprintf(b.RT.Stderr, "warning: set tags: %v\n", err)
 	}
 	if err := core.ClaimLeaseTargetForConfig(leaseID, slug, cfg, server, target, cfg.IdleTimeout); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	b.Cfg.AzureSubscription = cfg.AzureSubscription
 	b.Cfg.AzureResourceGroup = cfg.AzureResourceGroup
 	rollback = false
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
-func (b *azureLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *azureLeaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	client, err := newAzureClient(ctx, b.Cfg)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if strings.HasPrefix(req.ID, "crabbox-") {
 		server, err := client.GetServer(ctx, req.ID)
@@ -156,63 +141,63 @@ func (b *azureLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (Le
 			if req.ReleaseOnly && isAzureCleanupNotFound(err) {
 				return resolveMissingAzureReleaseClaim(req.ID, client.LeaseClaimScope())
 			}
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		if !isCrabboxAzureLease(server) {
-			return LeaseTarget{}, exit(4, "lease/server not found: %s (vm exists but is not Crabbox-managed)", req.ID)
+			return core.LeaseTarget{}, core.Exit(4, "lease/server not found: %s (vm exists but is not Crabbox-managed)", req.ID)
 		}
 		leaseID := server.Labels["lease"]
-		target := sshTargetFromConfig(b.Cfg, azureServerHost(server, b.Cfg.AzureNetwork))
+		target := core.SSHTargetFromConfig(b.Cfg, core.AzureServerHost(server, b.Cfg.AzureNetwork))
 		if !req.ReleaseOnly {
-			if err := useStoredTestboxKey(&target, leaseID); err != nil {
-				return LeaseTarget{}, err
+			if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
+				return core.LeaseTarget{}, err
 			}
 		}
-		return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+		return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 	}
 	servers, err := listOwnedAzureServers(ctx, client)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	if server, leaseID, err := findServerByAlias(servers, req.ID); err != nil {
-		return LeaseTarget{}, err
+	if server, leaseID, err := core.FindServerByAlias(servers, req.ID); err != nil {
+		return core.LeaseTarget{}, err
 	} else if leaseID != "" {
-		target := sshTargetFromConfig(b.Cfg, azureServerHost(server, b.Cfg.AzureNetwork))
+		target := core.SSHTargetFromConfig(b.Cfg, core.AzureServerHost(server, b.Cfg.AzureNetwork))
 		if !req.ReleaseOnly {
-			if err := useStoredTestboxKey(&target, leaseID); err != nil {
-				return LeaseTarget{}, err
+			if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
+				return core.LeaseTarget{}, err
 			}
 		}
-		return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+		return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 	}
 	if req.ReleaseOnly {
 		return resolveMissingAzureReleaseClaim(req.ID, client.LeaseClaimScope())
 	}
-	return LeaseTarget{}, exit(4, "lease/server not found: %s", req.ID)
+	return core.LeaseTarget{}, core.Exit(4, "lease/server not found: %s", req.ID)
 }
 
-func resolveMissingAzureReleaseClaim(identifier, providerScope string) (LeaseTarget, error) {
+func resolveMissingAzureReleaseClaim(identifier, providerScope string) (core.LeaseTarget, error) {
 	claim, exists, err := core.ResolveLeaseClaimForProvider(identifier, "azure")
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if !exists {
 		claim, exists, err = core.ResolveLeaseClaimForProviderCloudID(identifier, "azure")
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	if !exists || !core.LeaseClaimMatchesIdentifier(claim, identifier) {
-		return LeaseTarget{}, exit(4, "lease/server not found: %s", identifier)
+		return core.LeaseTarget{}, core.Exit(4, "lease/server not found: %s", identifier)
 	}
 	server := azureServerFromClaim(claim)
 	if err := validateExactAzureClaim(claim, server, claim.LeaseID, providerScope); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	return LeaseTarget{Server: server, LeaseID: claim.LeaseID}, nil
+	return core.LeaseTarget{Server: server, LeaseID: claim.LeaseID}, nil
 }
 
-func isCrabboxAzureLease(server Server) bool {
+func isCrabboxAzureLease(server core.Server) bool {
 	labels := server.Labels
 	return labels != nil &&
 		labels["crabbox"] == "true" &&
@@ -222,7 +207,7 @@ func isCrabboxAzureLease(server Server) bool {
 		strings.TrimSpace(labels["slug"]) != ""
 }
 
-func (b *azureLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *azureLeaseBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	client, err := newAzureClient(ctx, b.Cfg)
 	if err != nil {
@@ -232,7 +217,7 @@ func (b *azureLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseV
 }
 
 func (b *azureLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
-	servers, err := b.List(ctx, ListRequest{})
+	servers, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
 		return core.DoctorResult{}, err
 	}
@@ -241,7 +226,7 @@ func (b *azureLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (c
 	return result, nil
 }
 
-func (b *azureLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *azureLeaseBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	client, err := newAzureClient(ctx, b.Cfg)
 	if err != nil {
 		return err
@@ -270,15 +255,15 @@ func (b *azureLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRe
 	return nil
 }
 
-func (b *azureLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
+func (b *azureLeaseBackend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 	return fmt.Sprintf("deleted lease=%s server=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
 }
 
-func (b *azureLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
+func (b *azureLeaseBackend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
 	return b.DirectSSHBackend.Touch(ctx, req.Lease.Server, req.State), nil
 }
 
-func (b *azureLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
+func (b *azureLeaseBackend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	client, err := newAzureClient(ctx, b.Cfg)
 	if err != nil {
 		return err
@@ -407,8 +392,8 @@ func (b *azureLeaseBackend) resumeAzureCleanupClaims(ctx context.Context, client
 	return nil
 }
 
-func azureServerFromClaim(claim core.LeaseClaim) Server {
-	return Server{
+func azureServerFromClaim(claim core.LeaseClaim) core.Server {
+	return core.Server{
 		CloudID:     claim.CloudID,
 		Name:        claim.CloudID,
 		Provider:    "azure",
@@ -417,12 +402,12 @@ func azureServerFromClaim(claim core.LeaseClaim) Server {
 	}
 }
 
-func listOwnedAzureServers(ctx context.Context, client azureClient) ([]Server, error) {
+func listOwnedAzureServers(ctx context.Context, client azureClient) ([]core.Server, error) {
 	servers, err := client.ListCrabboxServers(ctx)
 	if err != nil {
 		return nil, err
 	}
-	owned := make([]Server, 0, len(servers))
+	owned := make([]core.Server, 0, len(servers))
 	for _, server := range servers {
 		if isCrabboxAzureLease(server) {
 			owned = append(owned, server)
@@ -431,36 +416,21 @@ func listOwnedAzureServers(ctx context.Context, client azureClient) ([]Server, e
 	return owned, nil
 }
 
-func acquireAttemptsRetry(rt Runtime, keep bool, acquire func() (LeaseTarget, error)) (LeaseTarget, error) {
+func acquireAttemptsRetry(rt core.Runtime, keep bool, acquire func() (core.LeaseTarget, error)) (core.LeaseTarget, error) {
 	return shared.AcquireAttemptsRetry(rt, keep, acquire)
 }
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-var newAzureClient = func(ctx context.Context, cfg Config) (azureClient, error) {
+var newAzureClient = func(ctx context.Context, cfg core.Config) (azureClient, error) {
 	return core.NewAzureClient(ctx, cfg)
 }
 
 var validateAzureSSHCIDRsForAcquire = core.ValidateAzureSSHCIDRsForAcquire
 
-func allocateDirectLeaseSlug(id, requested string, servers []Server) (string, error) {
-	return core.AllocateDirectLeaseSlug(id, requested, servers)
-}
-func ensureTestboxKeyForConfig(cfg Config, leaseID string) (string, string, error) {
-	return core.EnsureTestboxKeyForConfig(cfg, leaseID)
-}
-func providerKeyForLease(leaseID string) string { return core.ProviderKeyForLease(leaseID) }
-func sshTargetFromConfig(cfg Config, host string) SSHTarget {
-	return core.SSHTargetFromConfig(cfg, host)
-}
-
 var bootstrapManagedWindowsDesktop = core.BootstrapManagedWindowsDesktop
 
-func deleteServer(ctx context.Context, cfg Config, server Server) error {
+func deleteServer(ctx context.Context, cfg core.Config, server core.Server) error {
 	if !isCrabboxAzureLease(server) {
-		return exit(4, "refusing to delete Azure VM %s without canonical Crabbox ownership tags", server.DisplayID())
+		return core.Exit(4, "refusing to delete Azure VM %s without canonical Crabbox ownership tags", server.DisplayID())
 	}
 	client, err := newAzureClient(ctx, cfg)
 	if err != nil {
@@ -469,7 +439,7 @@ func deleteServer(ctx context.Context, cfg Config, server Server) error {
 	return deleteAzureServerWithClient(ctx, client, server)
 }
 
-func deleteAzureServerWithClient(ctx context.Context, client azureClient, server Server) error {
+func deleteAzureServerWithClient(ctx context.Context, client azureClient, server core.Server) error {
 	name := server.CloudID
 	if name == "" {
 		name = server.Name
@@ -477,13 +447,13 @@ func deleteAzureServerWithClient(ctx context.Context, client azureClient, server
 	return client.DeleteServer(ctx, name)
 }
 
-func requireExactAzureClaim(server Server, expectedLeaseID, providerScope string) (core.LeaseClaim, error) {
+func requireExactAzureClaim(server core.Server, expectedLeaseID, providerScope string) (core.LeaseClaim, error) {
 	claim, exists, err := core.ReadLeaseClaimWithPresence(expectedLeaseID)
 	if err != nil {
 		return core.LeaseClaim{}, err
 	}
 	if !exists {
-		return core.LeaseClaim{}, exit(2, "azure lease=%s has no exact local claim; refusing destructive operation", expectedLeaseID)
+		return core.LeaseClaim{}, core.Exit(2, "azure lease=%s has no exact local claim; refusing destructive operation", expectedLeaseID)
 	}
 	if err := validateExactAzureClaim(claim, server, expectedLeaseID, providerScope); err != nil {
 		return core.LeaseClaim{}, err
@@ -491,7 +461,7 @@ func requireExactAzureClaim(server Server, expectedLeaseID, providerScope string
 	return claim, nil
 }
 
-func validateExactAzureClaim(claim core.LeaseClaim, server Server, expectedLeaseID, providerScope string) error {
+func validateExactAzureClaim(claim core.LeaseClaim, server core.Server, expectedLeaseID, providerScope string) error {
 	serverSlug := strings.TrimSpace(server.Labels["slug"])
 	serverProviderKey := strings.TrimSpace(server.Labels["provider_key"])
 	if strings.TrimSpace(providerScope) == "" ||
@@ -511,12 +481,12 @@ func validateExactAzureClaim(claim core.LeaseClaim, server Server, expectedLease
 		strings.TrimSpace(claim.Labels["provider"]) != "azure" ||
 		serverProviderKey == "" ||
 		strings.TrimSpace(claim.Labels["provider_key"]) != serverProviderKey {
-		return exit(2, "refusing to operate on Azure VM %s from a missing or stale exact local claim", server.DisplayID())
+		return core.Exit(2, "refusing to operate on Azure VM %s from a missing or stale exact local claim", server.DisplayID())
 	}
 	return nil
 }
 
-func validateAzureAcquiredVM(expected, live Server) error {
+func validateAzureAcquiredVM(expected, live core.Server) error {
 	if live.Name != expected.CloudID {
 		return fmt.Errorf("Azure VM name %q does not match allocation %q", live.Name, expected.CloudID)
 	}
@@ -534,14 +504,4 @@ func isAzureCleanupNotFound(err error) bool {
 	}
 	message := err.Error()
 	return strings.Contains(message, "ResourceNotFound") || strings.Contains(message, "NotFound")
-}
-
-func useStoredTestboxKey(target *SSHTarget, leaseID string) error {
-	return core.UseStoredTestboxKey(target, leaseID)
-}
-func findServerByAlias(servers []Server, id string) (Server, string, error) {
-	return core.FindServerByAlias(servers, id)
-}
-func azureServerHost(server Server, network string) string {
-	return core.AzureServerHost(server, network)
 }

--- a/internal/providers/azure/backend_test.go
+++ b/internal/providers/azure/backend_test.go
@@ -22,28 +22,28 @@ type fakeAzureClient struct {
 	claimScope        string
 	deleted           []string
 	plainDeletes      []string
-	cleanupExpected   []Server
-	ownedExpected     []Server
-	prepareCleanup    []Server
-	prepareOwned      []Server
-	prepareFunc       func(Server) Server
+	cleanupExpected   []core.Server
+	ownedExpected     []core.Server
+	prepareCleanup    []core.Server
+	prepareOwned      []core.Server
+	prepareFunc       func(core.Server) core.Server
 	prepareErr        error
 	deleteErr         error
 	createLeaseIDs    []string
-	deleteOwnedFunc   func(Server) error
-	deleteCleanupFunc func(Server) error
+	deleteOwnedFunc   func(core.Server) error
+	deleteCleanupFunc func(core.Server) error
 	tagged            []string
-	servers           []Server
+	servers           []core.Server
 	listErr           error
-	created           Server
-	createCfg         Config
+	created           core.Server
+	createCfg         core.Config
 	createErr         error
-	createFunc        func(Server) Server
-	waitFunc          func(Server) (Server, error)
+	createFunc        func(core.Server) core.Server
+	waitFunc          func(core.Server) (core.Server, error)
 	waitCalls         int
 	waitErr           error
 	getErr            error
-	get               map[string]Server
+	get               map[string]core.Server
 	getErrs           map[string]error
 	getIDs            []string
 	setTagsFunc       func()
@@ -58,17 +58,17 @@ func (c *fakeAzureClient) LeaseClaimScope() string {
 	return azureTestClaimScope
 }
 
-func (c *fakeAzureClient) ListCrabboxServers(context.Context) ([]Server, error) {
+func (c *fakeAzureClient) ListCrabboxServers(context.Context) ([]core.Server, error) {
 	if c.listErr != nil {
 		return nil, c.listErr
 	}
 	return c.servers, nil
 }
 
-func (c *fakeAzureClient) CreateServerWithFallback(_ context.Context, cfg Config, _ string, leaseID, slug string, keep bool, _ func(string, ...any)) (Server, Config, error) {
+func (c *fakeAzureClient) CreateServerWithFallback(_ context.Context, cfg core.Config, _ string, leaseID, slug string, keep bool, _ func(string, ...any)) (core.Server, core.Config, error) {
 	c.createLeaseIDs = append(c.createLeaseIDs, leaseID)
 	if c.createErr != nil {
-		return Server{}, Config{}, c.createErr
+		return core.Server{}, core.Config{}, c.createErr
 	}
 	c.created.CloudID = core.LeaseProviderName(leaseID, slug)
 	c.created.Name = c.created.CloudID
@@ -82,24 +82,24 @@ func (c *fakeAzureClient) CreateServerWithFallback(_ context.Context, cfg Config
 	return c.created, cfg, nil
 }
 
-func (c *fakeAzureClient) WaitForServerIP(context.Context, string) (Server, error) {
+func (c *fakeAzureClient) WaitForServerIP(context.Context, string) (core.Server, error) {
 	c.waitCalls++
 	if c.waitFunc != nil {
 		return c.waitFunc(c.created)
 	}
 	if c.waitErr != nil {
-		return Server{}, c.waitErr
+		return core.Server{}, c.waitErr
 	}
 	return c.created, nil
 }
 
-func (c *fakeAzureClient) GetServer(_ context.Context, id string) (Server, error) {
+func (c *fakeAzureClient) GetServer(_ context.Context, id string) (core.Server, error) {
 	c.getIDs = append(c.getIDs, id)
 	if err := c.getErrs[id]; err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	if c.getErr != nil {
-		return Server{}, c.getErr
+		return core.Server{}, c.getErr
 	}
 	if c.get != nil {
 		if server, ok := c.get[id]; ok {
@@ -111,7 +111,7 @@ func (c *fakeAzureClient) GetServer(_ context.Context, id string) (Server, error
 			return server, nil
 		}
 	}
-	return Server{}, core.Exit(4, "azure vm not found: %s", id)
+	return core.Server{}, core.Exit(4, "azure vm not found: %s", id)
 }
 
 func (c *fakeAzureClient) DeleteServer(_ context.Context, name string) error {
@@ -120,10 +120,10 @@ func (c *fakeAzureClient) DeleteServer(_ context.Context, name string) error {
 	return c.deleteErr
 }
 
-func (c *fakeAzureClient) PrepareOwnedServer(_ context.Context, server Server) (Server, error) {
+func (c *fakeAzureClient) PrepareOwnedServer(_ context.Context, server core.Server) (core.Server, error) {
 	c.prepareOwned = append(c.prepareOwned, server)
 	if c.prepareErr != nil {
-		return Server{}, c.prepareErr
+		return core.Server{}, c.prepareErr
 	}
 	if c.prepareFunc != nil {
 		server = c.prepareFunc(server)
@@ -131,10 +131,10 @@ func (c *fakeAzureClient) PrepareOwnedServer(_ context.Context, server Server) (
 	return server, nil
 }
 
-func (c *fakeAzureClient) PrepareCleanupServer(_ context.Context, server Server, _ time.Time) (Server, error) {
+func (c *fakeAzureClient) PrepareCleanupServer(_ context.Context, server core.Server, _ time.Time) (core.Server, error) {
 	c.prepareCleanup = append(c.prepareCleanup, server)
 	if c.prepareErr != nil {
-		return Server{}, c.prepareErr
+		return core.Server{}, c.prepareErr
 	}
 	if c.prepareFunc != nil {
 		server = c.prepareFunc(server)
@@ -142,7 +142,7 @@ func (c *fakeAzureClient) PrepareCleanupServer(_ context.Context, server Server,
 	return server, nil
 }
 
-func (c *fakeAzureClient) DeleteOwnedServer(_ context.Context, server Server) error {
+func (c *fakeAzureClient) DeleteOwnedServer(_ context.Context, server core.Server) error {
 	c.ownedExpected = append(c.ownedExpected, server)
 	if c.deleteOwnedFunc != nil {
 		if err := c.deleteOwnedFunc(server); err != nil {
@@ -153,7 +153,7 @@ func (c *fakeAzureClient) DeleteOwnedServer(_ context.Context, server Server) er
 	return nil
 }
 
-func (c *fakeAzureClient) DeleteCleanupServer(_ context.Context, server Server, _ time.Time) error {
+func (c *fakeAzureClient) DeleteCleanupServer(_ context.Context, server core.Server, _ time.Time) error {
 	c.cleanupExpected = append(c.cleanupExpected, server)
 	if c.deleteCleanupFunc != nil {
 		if err := c.deleteCleanupFunc(server); err != nil {
@@ -177,17 +177,17 @@ func TestAzureAcquireCleansUpCreatedServerOnIPFailure(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	ipErr := errors.New("ip unavailable")
 	fake := &fakeAzureClient{
-		created:   Server{CloudID: "crabbox-created", Name: "crabbox-created", Labels: map[string]string{"lease": "cbx_created"}},
+		created:   core.Server{CloudID: "crabbox-created", Name: "crabbox-created", Labels: map[string]string{"lease": "cbx_created"}},
 		createCfg: azureAcquireTestConfig(),
 		waitErr:   ipErr,
 	}
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) {
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newAzureClient = oldClient })
 
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
 	_, err := backend.acquireOnce(context.Background(), false, "")
 	if !errors.Is(err, ipErr) {
 		t.Fatalf("err=%v, want IP failure", err)
@@ -204,7 +204,7 @@ func TestAzureAcquireValidatesSSHCIDRsBeforeClient(t *testing.T) {
 	fake := &fakeAzureClient{listErr: listErr}
 	oldValidate := validateAzureSSHCIDRsForAcquire
 	validated := false
-	validateAzureSSHCIDRsForAcquire = func(_ context.Context, cfg Config) error {
+	validateAzureSSHCIDRsForAcquire = func(_ context.Context, cfg core.Config) error {
 		validated = true
 		if len(cfg.AzureSSHCIDRs) != 0 {
 			t.Fatalf("AzureSSHCIDRs=%v before validation, want non-explicit empty config", cfg.AzureSSHCIDRs)
@@ -212,9 +212,9 @@ func TestAzureAcquireValidatesSSHCIDRsBeforeClient(t *testing.T) {
 		return nil
 	}
 	t.Cleanup(func() { validateAzureSSHCIDRsForAcquire = oldValidate })
-	var clientCfg Config
+	var clientCfg core.Config
 	oldClient := newAzureClient
-	newAzureClient = func(_ context.Context, cfg Config) (azureClient, error) {
+	newAzureClient = func(_ context.Context, cfg core.Config) (azureClient, error) {
 		if !validated {
 			t.Fatal("newAzureClient ran before SSH CIDR validation")
 		}
@@ -223,7 +223,7 @@ func TestAzureAcquireValidatesSSHCIDRsBeforeClient(t *testing.T) {
 	}
 	t.Cleanup(func() { newAzureClient = oldClient })
 
-	backend := NewAzureLeaseBackend(ProviderSpec{}, Config{Provider: "azure", AzureLocation: "eastus", AzureResourceGroup: "rg"}, Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, core.Config{Provider: "azure", AzureLocation: "eastus", AzureResourceGroup: "rg"}, core.Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
 	_, err := backend.acquireOnce(context.Background(), false, "")
 	if !errors.Is(err, listErr) {
 		t.Fatalf("err=%v, want list failure", err)
@@ -235,18 +235,18 @@ func TestAzureAcquireValidatesSSHCIDRsBeforeClient(t *testing.T) {
 
 func TestAzureAcquireFailsClosedWhenSSHCIDRDetectionFails(t *testing.T) {
 	oldValidate := validateAzureSSHCIDRsForAcquire
-	validateAzureSSHCIDRsForAcquire = func(context.Context, Config) error {
+	validateAzureSSHCIDRsForAcquire = func(context.Context, core.Config) error {
 		return errors.New("offline")
 	}
 	t.Cleanup(func() { validateAzureSSHCIDRsForAcquire = oldValidate })
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) {
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) {
 		t.Fatal("newAzureClient should not run when SSH CIDR detection fails")
 		return nil, nil
 	}
 	t.Cleanup(func() { newAzureClient = oldClient })
 
-	backend := NewAzureLeaseBackend(ProviderSpec{}, Config{Provider: "azure", AzureLocation: "eastus", AzureResourceGroup: "rg"}, Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, core.Config{Provider: "azure", AzureLocation: "eastus", AzureResourceGroup: "rg"}, core.Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
 	_, err := backend.acquireOnce(context.Background(), false, "")
 	if err == nil || err.Error() != "offline" {
 		t.Fatalf("err=%v, want detection failure", err)
@@ -264,17 +264,17 @@ func TestAzureAcquireDoesNotRollbackReadyServer(t *testing.T) {
 		createCfg: azureAcquireTestConfig(),
 	}
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) {
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newAzureClient = oldClient })
 	oldBootstrap := bootstrapManagedWindowsDesktop
-	bootstrapManagedWindowsDesktop = func(context.Context, Config, *SSHTarget, string, io.Writer) error {
+	bootstrapManagedWindowsDesktop = func(context.Context, core.Config, *core.SSHTarget, string, io.Writer) error {
 		return nil
 	}
 	t.Cleanup(func() { bootstrapManagedWindowsDesktop = oldBootstrap })
 
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
 	lease, err := backend.acquireOnce(context.Background(), false, "")
 	if err != nil {
 		t.Fatal(err)
@@ -317,13 +317,13 @@ func TestAzureAcquireRollsBackWhenExactClaimCannotPersist(t *testing.T) {
 		},
 	}
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 	t.Cleanup(func() { newAzureClient = oldClient })
 	oldBootstrap := bootstrapManagedWindowsDesktop
-	bootstrapManagedWindowsDesktop = func(context.Context, Config, *SSHTarget, string, io.Writer) error { return nil }
+	bootstrapManagedWindowsDesktop = func(context.Context, core.Config, *core.SSHTarget, string, io.Writer) error { return nil }
 	t.Cleanup(func() { bootstrapManagedWindowsDesktop = oldBootstrap })
 
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
 	if _, err := backend.acquireOnce(context.Background(), false, ""); err == nil {
 		t.Fatal("expected exact-claim persistence failure")
 	}
@@ -332,8 +332,8 @@ func TestAzureAcquireRollsBackWhenExactClaimCannotPersist(t *testing.T) {
 	}
 }
 
-func azureAcquireTestConfig() Config {
-	return Config{
+func azureAcquireTestConfig() core.Config {
+	return core.Config{
 		Provider:           "azure",
 		AzureSubscription:  "test-sub",
 		AzureLocation:      "eastus",
@@ -345,13 +345,13 @@ func azureAcquireTestConfig() Config {
 func TestAzureResolveRawVMRejectsWeakTags(t *testing.T) {
 	weak := azureTestServer("crabbox-weak", "cbx_123456abcdef", "weak")
 	delete(weak.Labels, "created_by")
-	fake := &fakeAzureClient{servers: []Server{weak}}
+	fake := &fakeAzureClient{servers: []core.Server{weak}}
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 	t.Cleanup(func() { newAzureClient = oldClient })
 
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
-	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: weak.Name, ReleaseOnly: true})
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: weak.Name, ReleaseOnly: true})
 	if err == nil || !strings.Contains(err.Error(), "not Crabbox-managed") {
 		t.Fatalf("lease=%#v err=%v, want ownership rejection", lease, err)
 	}
@@ -364,13 +364,13 @@ func TestAzureListExcludesWeakTags(t *testing.T) {
 	owned := azureTestServer("crabbox-owned", "cbx_123456abcdef", "owned")
 	weak := azureTestServer("crabbox-weak", "cbx_fedcba654321", "weak")
 	delete(weak.Labels, "provider")
-	fake := &fakeAzureClient{servers: []Server{weak, owned}}
+	fake := &fakeAzureClient{servers: []core.Server{weak, owned}}
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 	t.Cleanup(func() { newAzureClient = oldClient })
 
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
-	servers, err := backend.List(context.Background(), ListRequest{})
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	servers, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -382,17 +382,17 @@ func TestAzureListExcludesWeakTags(t *testing.T) {
 func TestAzureReleaseRejectsForgedOrMismatchedOwnership(t *testing.T) {
 	for _, test := range []struct {
 		name   string
-		mutate func(*LeaseTarget)
+		mutate func(*core.LeaseTarget)
 	}{
 		{
 			name: "missing created-by tag",
-			mutate: func(lease *LeaseTarget) {
+			mutate: func(lease *core.LeaseTarget) {
 				delete(lease.Server.Labels, "created_by")
 			},
 		},
 		{
 			name: "mismatched lease tag",
-			mutate: func(lease *LeaseTarget) {
+			mutate: func(lease *core.LeaseTarget) {
 				lease.LeaseID = "cbx_fedcba654321"
 			},
 		},
@@ -401,15 +401,15 @@ func TestAzureReleaseRejectsForgedOrMismatchedOwnership(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			server := azureTestServer("crabbox-owned", "cbx_123456abcdef", "owned")
 			storeAzureTestClaim(t, server)
-			fake := &fakeAzureClient{servers: []Server{server}}
+			fake := &fakeAzureClient{servers: []core.Server{server}}
 			oldClient := newAzureClient
-			newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+			newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 			t.Cleanup(func() { newAzureClient = oldClient })
 
-			lease := LeaseTarget{Server: server, LeaseID: "cbx_123456abcdef"}
+			lease := core.LeaseTarget{Server: server, LeaseID: "cbx_123456abcdef"}
 			test.mutate(&lease)
-			backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
-			err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease})
+			backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+			err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
 			if err == nil || !strings.Contains(err.Error(), "exact local claim") {
 				t.Fatalf("err=%v, want ownership rejection", err)
 			}
@@ -425,20 +425,20 @@ func TestAzureReleaseRemovesStoredLeaseKey(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_123456abcdef"
-	keyPath, _, err := core.EnsureTestboxKeyForConfig(Config{}, leaseID)
+	keyPath, _, err := core.EnsureTestboxKeyForConfig(core.Config{}, leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	server := azureTestServer("crabbox-owned", leaseID, "owned")
 	storeAzureTestClaim(t, server)
-	fake := &fakeAzureClient{servers: []Server{server}}
+	fake := &fakeAzureClient{servers: []core.Server{server}}
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 	t.Cleanup(func() { newAzureClient = oldClient })
 
-	lease := LeaseTarget{Server: server, LeaseID: leaseID}
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+	lease := core.LeaseTarget{Server: server, LeaseID: leaseID}
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(filepath.Dir(keyPath)); !errors.Is(err, os.ErrNotExist) {
@@ -458,20 +458,20 @@ func TestAzureReleasePersistsCleanupBindingBeforeDelete(t *testing.T) {
 	storeAzureTestClaim(t, server)
 	deleteErr := errors.New("simulated interruption after durable binding")
 	fake := &fakeAzureClient{
-		servers: []Server{server},
-		prepareFunc: func(prepared Server) Server {
+		servers: []core.Server{server},
+		prepareFunc: func(prepared core.Server) core.Server {
 			prepared.Labels = maps.Clone(prepared.Labels)
 			prepared.Labels[core.AzureCleanupBindingLabel] = "v1"
 			return prepared
 		},
-		deleteOwnedFunc: func(Server) error { return deleteErr },
+		deleteOwnedFunc: func(core.Server) error { return deleteErr },
 	}
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 	t.Cleanup(func() { newAzureClient = oldClient })
 
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{Server: server, LeaseID: server.Labels["lease"]}}); !errors.Is(err, deleteErr) {
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{Server: server, LeaseID: server.Labels["lease"]}}); !errors.Is(err, deleteErr) {
 		t.Fatalf("err=%v, want simulated interruption", err)
 	}
 	claim, exists, err := core.ReadLeaseClaimWithPresence(server.Labels["lease"])
@@ -492,18 +492,18 @@ func TestAzureResolveAndReleaseResumeAfterVMDeletion(t *testing.T) {
 		getErrs: map[string]error{server.CloudID: core.Exit(4, "azure vm not found: %s", server.CloudID)},
 	}
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 	t.Cleanup(func() { newAzureClient = oldClient })
 
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
-	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: server.CloudID, ReleaseOnly: true})
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: server.CloudID, ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if lease.LeaseID != server.Labels["lease"] || lease.Server.ImmutableID != server.ImmutableID {
 		t.Fatalf("lease=%+v, want claim-backed exact identity", lease)
 	}
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deleted) != 1 || fake.deleted[0] != server.CloudID {
@@ -514,13 +514,13 @@ func TestAzureResolveAndReleaseResumeAfterVMDeletion(t *testing.T) {
 func TestAzureReleaseRequiresExactClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	server := azureTestServer("crabbox-owned", "cbx_123456abcdef", "owned")
-	fake := &fakeAzureClient{servers: []Server{server}}
+	fake := &fakeAzureClient{servers: []core.Server{server}}
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 	t.Cleanup(func() { newAzureClient = oldClient })
 
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
-	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{Server: server, LeaseID: server.Labels["lease"]}})
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{Server: server, LeaseID: server.Labels["lease"]}})
 	if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
 		t.Fatalf("err=%v, want exact-claim rejection", err)
 	}
@@ -536,21 +536,21 @@ func TestAzureCleanupSkipsWeakTagsAndDeletesCanonicalExpiredVM(t *testing.T) {
 	owned := azureTestServer("crabbox-owned", "cbx_123456abcdef", "owned")
 	owned.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
 	storeAzureTestClaim(t, owned)
-	keyPath, _, err := core.EnsureTestboxKeyForConfig(Config{}, owned.Labels["lease"])
+	keyPath, _, err := core.EnsureTestboxKeyForConfig(core.Config{}, owned.Labels["lease"])
 	if err != nil {
 		t.Fatal(err)
 	}
 	weak := azureTestServer("crabbox-weak", "cbx_fedcba654321", "weak")
 	delete(weak.Labels, "created_by")
 	weak.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
-	fake := &fakeAzureClient{servers: []Server{weak, owned}}
+	fake := &fakeAzureClient{servers: []core.Server{weak, owned}}
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 	t.Cleanup(func() { newAzureClient = oldClient })
 
 	var stderr strings.Builder
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: &stderr}).(*azureLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: &stderr}).(*azureLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(stderr.String(), "skip server id=crabbox-weak") || !strings.Contains(stderr.String(), "canonical Crabbox ownership tags missing") {
@@ -571,14 +571,14 @@ func TestAzureCleanupRequiresExactClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	server := azureTestServer("crabbox-unclaimed", "cbx_123456abcdef", "unclaimed")
 	server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
-	fake := &fakeAzureClient{servers: []Server{server}}
+	fake := &fakeAzureClient{servers: []core.Server{server}}
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 	t.Cleanup(func() { newAzureClient = oldClient })
 
 	var stderr strings.Builder
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: &stderr}).(*azureLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: &stderr}).(*azureLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.getIDs) != 0 || len(fake.deleted) != 0 {
@@ -594,14 +594,14 @@ func TestAzureCleanupDryRunRevalidatesExactClaim(t *testing.T) {
 	server := azureTestServer("crabbox-dry-run", "cbx_123456abcdef", "dry-run")
 	server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
 	storeAzureTestClaim(t, server)
-	fake := &fakeAzureClient{servers: []Server{server}}
+	fake := &fakeAzureClient{servers: []core.Server{server}}
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 	t.Cleanup(func() { newAzureClient = oldClient })
 
 	var stderr strings.Builder
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: &stderr}).(*azureLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: &stderr}).(*azureLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.getIDs) != 1 || len(fake.deleted) != 0 {
@@ -621,16 +621,16 @@ func TestAzureCleanupRevalidatesLiveOwnershipBeforeDelete(t *testing.T) {
 	live.Labels = maps.Clone(snapshot.Labels)
 	live.Labels["lease"] = "cbx_fedcba654321"
 	fake := &fakeAzureClient{
-		servers: []Server{snapshot},
-		get:     map[string]Server{snapshot.CloudID: live},
+		servers: []core.Server{snapshot},
+		get:     map[string]core.Server{snapshot.CloudID: live},
 	}
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 	t.Cleanup(func() { newAzureClient = oldClient })
 
 	var stderr strings.Builder
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: &stderr}).(*azureLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: &stderr}).(*azureLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.getIDs) != 1 || fake.getIDs[0] != snapshot.CloudID {
@@ -652,14 +652,14 @@ func TestAzureCleanupRevalidatesLiveEligibilityBeforeDelete(t *testing.T) {
 	live := snapshot
 	live.Labels = maps.Clone(snapshot.Labels)
 	live.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(time.Hour))
-	fake := &fakeAzureClient{servers: []Server{snapshot}, get: map[string]Server{snapshot.CloudID: live}}
+	fake := &fakeAzureClient{servers: []core.Server{snapshot}, get: map[string]core.Server{snapshot.CloudID: live}}
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 	t.Cleanup(func() { newAzureClient = oldClient })
 
 	var stderr strings.Builder
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: &stderr}).(*azureLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: &stderr}).(*azureLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deleted) != 0 {
@@ -677,14 +677,14 @@ func TestAzureCleanupRejectsSameNameReplacementVM(t *testing.T) {
 	storeAzureTestClaim(t, snapshot)
 	live := snapshot
 	live.ImmutableID = "vmid-replacement"
-	fake := &fakeAzureClient{servers: []Server{snapshot}, get: map[string]Server{snapshot.CloudID: live}}
+	fake := &fakeAzureClient{servers: []core.Server{snapshot}, get: map[string]core.Server{snapshot.CloudID: live}}
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 	t.Cleanup(func() { newAzureClient = oldClient })
 
 	var stderr strings.Builder
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: &stderr}).(*azureLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: &stderr}).(*azureLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deleted) != 0 {
@@ -703,14 +703,14 @@ func TestAzureCleanupRejectsChangedLiveSlug(t *testing.T) {
 	live := snapshot
 	live.Labels = maps.Clone(snapshot.Labels)
 	live.Labels["slug"] = "changed"
-	fake := &fakeAzureClient{servers: []Server{snapshot}, get: map[string]Server{snapshot.CloudID: live}}
+	fake := &fakeAzureClient{servers: []core.Server{snapshot}, get: map[string]core.Server{snapshot.CloudID: live}}
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 	t.Cleanup(func() { newAzureClient = oldClient })
 
 	var stderr strings.Builder
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: &stderr}).(*azureLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: &stderr}).(*azureLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.cleanupExpected) != 0 || len(fake.deleted) != 0 {
@@ -727,26 +727,26 @@ func TestAzureCleanupContinuesWhenLiveCandidateAlreadyGone(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	missing := azureTestServer("missing", "cbx_111111111111", "missing")
 	remaining := azureTestServer("remaining", "cbx_222222222222", "remaining")
-	for _, server := range []*Server{&missing, &remaining} {
+	for _, server := range []*core.Server{&missing, &remaining} {
 		server.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
 		storeAzureTestClaim(t, *server)
 	}
-	keyPath, _, err := core.EnsureTestboxKeyForConfig(Config{}, missing.Labels["lease"])
+	keyPath, _, err := core.EnsureTestboxKeyForConfig(core.Config{}, missing.Labels["lease"])
 	if err != nil {
 		t.Fatal(err)
 	}
 	fake := &fakeAzureClient{
-		servers: []Server{missing, remaining},
-		get:     map[string]Server{remaining.CloudID: remaining},
+		servers: []core.Server{missing, remaining},
+		get:     map[string]core.Server{remaining.CloudID: remaining},
 		getErrs: map[string]error{missing.CloudID: core.Exit(4, "azure vm not found: %s", missing.CloudID)},
 	}
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 	t.Cleanup(func() { newAzureClient = oldClient })
 
 	var stderr strings.Builder
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: &stderr}).(*azureLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: &stderr}).(*azureLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deleted) != 1 || fake.deleted[0] != remaining.CloudID {
@@ -770,12 +770,12 @@ func TestAzureCleanupResumesDurablyBoundCompanionsAfterVMDeletion(t *testing.T) 
 	storeAzureTestClaim(t, server)
 	fake := &fakeAzureClient{}
 	oldClient := newAzureClient
-	newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 	t.Cleanup(func() { newAzureClient = oldClient })
 
 	var stderr strings.Builder
-	backend := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: &stderr}).(*azureLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: &stderr}).(*azureLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.cleanupExpected) != 1 || fake.cleanupExpected[0].CloudID != server.CloudID {
@@ -789,8 +789,8 @@ func TestAzureCleanupResumesDurablyBoundCompanionsAfterVMDeletion(t *testing.T) 
 	}
 }
 
-func azureTestServer(id, leaseID, slug string) Server {
-	return Server{
+func azureTestServer(id, leaseID, slug string) core.Server {
+	return core.Server{
 		CloudID:     id,
 		Name:        id,
 		Provider:    "azure",
@@ -812,14 +812,18 @@ func TestValidateExactAzureClaimRejectsScopeAndResourceMismatch(t *testing.T) {
 	claim := storeAzureTestClaim(t, server)
 	for _, test := range []struct {
 		name   string
-		mutate func(*core.LeaseClaim, *Server, *string)
+		mutate func(*core.LeaseClaim, *core.Server, *string)
 	}{
-		{name: "scope", mutate: func(_ *core.LeaseClaim, _ *Server, scope *string) { *scope = "subscription:other|resource-group:rg" }},
-		{name: "name", mutate: func(_ *core.LeaseClaim, server *Server, _ *string) { server.CloudID = "replacement" }},
-		{name: "immutable id", mutate: func(_ *core.LeaseClaim, server *Server, _ *string) { server.ImmutableID = "vmid-replacement" }},
-		{name: "slug", mutate: func(_ *core.LeaseClaim, server *Server, _ *string) { server.Labels["slug"] = "replacement" }},
-		{name: "provider key", mutate: func(_ *core.LeaseClaim, server *Server, _ *string) { server.Labels["provider_key"] = "replacement" }},
-		{name: "legacy claim", mutate: func(claim *core.LeaseClaim, _ *Server, _ *string) { claim.CloudImmutableID = "" }},
+		{name: "scope", mutate: func(_ *core.LeaseClaim, _ *core.Server, scope *string) {
+			*scope = "subscription:other|resource-group:rg"
+		}},
+		{name: "name", mutate: func(_ *core.LeaseClaim, server *core.Server, _ *string) { server.CloudID = "replacement" }},
+		{name: "immutable id", mutate: func(_ *core.LeaseClaim, server *core.Server, _ *string) { server.ImmutableID = "vmid-replacement" }},
+		{name: "slug", mutate: func(_ *core.LeaseClaim, server *core.Server, _ *string) { server.Labels["slug"] = "replacement" }},
+		{name: "provider key", mutate: func(_ *core.LeaseClaim, server *core.Server, _ *string) {
+			server.Labels["provider_key"] = "replacement"
+		}},
+		{name: "legacy claim", mutate: func(claim *core.LeaseClaim, _ *core.Server, _ *string) { claim.CloudImmutableID = "" }},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			testClaim := claim
@@ -835,10 +839,10 @@ func TestValidateExactAzureClaimRejectsScopeAndResourceMismatch(t *testing.T) {
 	}
 }
 
-func storeAzureTestClaim(t *testing.T, server Server) core.LeaseClaim {
+func storeAzureTestClaim(t *testing.T, server core.Server) core.LeaseClaim {
 	t.Helper()
 	cfg := azureAcquireTestConfig()
-	if err := core.ClaimLeaseTargetForConfig(server.Labels["lease"], server.Labels["slug"], cfg, server, SSHTarget{}, time.Hour); err != nil {
+	if err := core.ClaimLeaseTargetForConfig(server.Labels["lease"], server.Labels["slug"], cfg, server, core.SSHTarget{}, time.Hour); err != nil {
 		t.Fatal(err)
 	}
 	claim, exists, err := core.ReadLeaseClaimWithPresence(server.Labels["lease"])
@@ -858,15 +862,15 @@ func TestAzureAcquireStopsFreshRetryAfterRollbackFailure(t *testing.T) {
 			fake := &fakeAzureClient{createCfg: azureAcquireTestConfig()}
 			cleanupErr := errors.New("delete unavailable")
 			if failed {
-				fake.deleteOwnedFunc = func(Server) error { return cleanupErr }
+				fake.deleteOwnedFunc = func(core.Server) error { return cleanupErr }
 			}
 			oldClient, oldBootstrap := newAzureClient, bootstrapManagedWindowsDesktop
-			newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
-			bootstrapManagedWindowsDesktop = func(context.Context, Config, *SSHTarget, string, io.Writer) error { return primary }
+			newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
+			bootstrapManagedWindowsDesktop = func(context.Context, core.Config, *core.SSHTarget, string, io.Writer) error { return primary }
 			t.Cleanup(func() { newAzureClient = oldClient; bootstrapManagedWindowsDesktop = oldBootstrap })
 			var stderr bytes.Buffer
-			b := NewAzureLeaseBackend(ProviderSpec{}, fake.createCfg, Runtime{Stderr: &stderr}).(*azureLeaseBackend)
-			_, err := b.Acquire(context.Background(), AcquireRequest{})
+			b := NewAzureLeaseBackend(core.ProviderSpec{}, fake.createCfg, core.Runtime{Stderr: &stderr}).(*azureLeaseBackend)
+			_, err := b.Acquire(context.Background(), core.AcquireRequest{})
 			want := 2
 			if failed {
 				want = 1
@@ -887,17 +891,17 @@ func TestAzureAcquireStopsFreshRetryAfterRollbackFailure(t *testing.T) {
 func TestAzureAcquireRejectsChangedReadinessGenerationWithoutMutation(t *testing.T) {
 	mutations := []struct {
 		name   string
-		change func(*Server)
+		change func(*core.Server)
 	}{
-		{"generation", func(s *Server) { s.ImmutableID = "replacement-vm" }},
-		{"missing-generation", func(s *Server) { s.ImmutableID = "" }},
-		{"cloud-name", func(s *Server) { s.CloudID = "replacement-name" }},
-		{"name", func(s *Server) { s.Name = "replacement-name" }},
-		{"owner", func(s *Server) { s.Labels["created_by"] = "other" }},
-		{"provider", func(s *Server) { s.Labels["provider"] = "gcp" }},
-		{"lease", func(s *Server) { s.Labels["lease"] = "cbx_111111111111" }},
-		{"slug", func(s *Server) { s.Labels["slug"] = "replacement" }},
-		{"key", func(s *Server) { s.Labels["provider_key"] = "replacement" }},
+		{"generation", func(s *core.Server) { s.ImmutableID = "replacement-vm" }},
+		{"missing-generation", func(s *core.Server) { s.ImmutableID = "" }},
+		{"cloud-name", func(s *core.Server) { s.CloudID = "replacement-name" }},
+		{"name", func(s *core.Server) { s.Name = "replacement-name" }},
+		{"owner", func(s *core.Server) { s.Labels["created_by"] = "other" }},
+		{"provider", func(s *core.Server) { s.Labels["provider"] = "gcp" }},
+		{"lease", func(s *core.Server) { s.Labels["lease"] = "cbx_111111111111" }},
+		{"slug", func(s *core.Server) { s.Labels["slug"] = "replacement" }},
+		{"key", func(s *core.Server) { s.Labels["provider_key"] = "replacement" }},
 	}
 	for _, creation := range []bool{false, true} {
 		for _, tc := range mutations {
@@ -911,18 +915,21 @@ func TestAzureAcquireRejectsChangedReadinessGenerationWithoutMutation(t *testing
 				t.Setenv("XDG_STATE_HOME", t.TempDir())
 				fake := &fakeAzureClient{}
 				if creation {
-					fake.createFunc = func(s Server) Server { tc.change(&s); return s }
+					fake.createFunc = func(s core.Server) core.Server { tc.change(&s); return s }
 				} else {
 					// Deliberately mutate the aliased labels returned by creation.
-					fake.waitFunc = func(s Server) (Server, error) { tc.change(&s); return s, nil }
+					fake.waitFunc = func(s core.Server) (core.Server, error) { tc.change(&s); return s, nil }
 				}
 				oldClient, oldBootstrap := newAzureClient, bootstrapManagedWindowsDesktop
-				newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+				newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 				bootstrapCalls := 0
-				bootstrapManagedWindowsDesktop = func(context.Context, Config, *SSHTarget, string, io.Writer) error { bootstrapCalls++; return nil }
+				bootstrapManagedWindowsDesktop = func(context.Context, core.Config, *core.SSHTarget, string, io.Writer) error {
+					bootstrapCalls++
+					return nil
+				}
 				t.Cleanup(func() { newAzureClient = oldClient; bootstrapManagedWindowsDesktop = oldBootstrap })
-				b := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
-				_, err := b.Acquire(t.Context(), AcquireRequest{})
+				b := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+				_, err := b.Acquire(t.Context(), core.AcquireRequest{})
 				if err == nil || bootstrapCalls != 0 || len(fake.tagged) != 0 || len(fake.deleted) != 0 || len(fake.prepareOwned) != 0 || len(fake.createLeaseIDs) != 1 {
 					t.Fatalf("err=%v bootstrap=%d tags=%v deletes=%v prepared=%d creates=%v", err, bootstrapCalls, fake.tagged, fake.deleted, len(fake.prepareOwned), fake.createLeaseIDs)
 				}
@@ -945,7 +952,7 @@ func TestAzureAcquireRollbackKeepsOriginalBindingAndRefusesUnpreparedDelete(t *t
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			primary := errors.New("readiness unavailable")
 			fake := &fakeAzureClient{waitErr: primary}
-			fake.prepareFunc = func(s Server) Server {
+			fake.prepareFunc = func(s core.Server) core.Server {
 				s.Labels = maps.Clone(s.Labels)
 				s.Labels["fixture_cleanup_binding"] = "captured"
 				return s
@@ -954,13 +961,13 @@ func TestAzureAcquireRollbackKeepsOriginalBindingAndRefusesUnpreparedDelete(t *t
 				fake.prepareErr = errors.New("cannot verify resources")
 			}
 			if failure == "changed-preparation" {
-				fake.prepareFunc = func(s Server) Server { s.ImmutableID = "replacement"; return s }
+				fake.prepareFunc = func(s core.Server) core.Server { s.ImmutableID = "replacement"; return s }
 			}
 			oldClient := newAzureClient
-			newAzureClient = func(context.Context, Config) (azureClient, error) { return fake, nil }
+			newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
 			t.Cleanup(func() { newAzureClient = oldClient })
-			b := NewAzureLeaseBackend(ProviderSpec{}, azureAcquireTestConfig(), Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
-			_, err := b.Acquire(t.Context(), AcquireRequest{})
+			b := NewAzureLeaseBackend(core.ProviderSpec{}, azureAcquireTestConfig(), core.Runtime{Stderr: io.Discard}).(*azureLeaseBackend)
+			_, err := b.Acquire(t.Context(), core.AcquireRequest{})
 			if !errors.Is(err, primary) || len(fake.prepareOwned) != 1 || len(fake.plainDeletes) != 0 {
 				t.Fatalf("err=%v prepare=%v plain=%v", err, fake.prepareOwned, fake.plainDeletes)
 			}

--- a/internal/providers/blacksmith/admission_test.go
+++ b/internal/providers/blacksmith/admission_test.go
@@ -172,10 +172,10 @@ func TestBlacksmithBackendRejectsNoSyncBeforeActivity(t *testing.T) {
 			root, processLog, gitLog := blacksmithAdmissionFixture(t, blacksmithTestboxProvider)
 			runner := &blacksmithFuncRunner{}
 			clock := &admissionClock{}
-			backend := newTestBlacksmithBackend(baseConfig(), runner)
+			backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
 			backend.rt.Clock = clock
 			before := blacksmithAdmissionState(t, root)
-			_, err := backend.Run(t.Context(), RunRequest{ID: id, Repo: Repo{Root: filepath.Join(root, "repo")}, NoSync: true, Command: []string{"true"}})
+			_, err := backend.Run(t.Context(), core.RunRequest{ID: id, Repo: core.Repo{Root: filepath.Join(root, "repo")}, NoSync: true, Command: []string{"true"}})
 			assertBlacksmithAdmissionError(t, err)
 			if clock.calls != 0 || len(runner.calls) != 0 {
 				t.Errorf("clock=%d runner=%d calls before rejection", clock.calls, len(runner.calls))

--- a/internal/providers/blacksmith/artifact_download.go
+++ b/internal/providers/blacksmith/artifact_download.go
@@ -82,7 +82,7 @@ func (b *blacksmithBackend) downloadArtifact(ctx context.Context, repoRoot, leas
 	if err != nil {
 		return nil, err
 	}
-	_, writeErr := dispatcher.WriteString("#!/bin/sh\nexec " + shellQuote(scp) + " \"$@\"\n")
+	_, writeErr := dispatcher.WriteString("#!/bin/sh\nexec " + core.ShellQuote(scp) + " \"$@\"\n")
 	if err := errors.Join(writeErr, dispatcher.Close()); err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (b *blacksmithBackend) downloadArtifact(ctx context.Context, repoRoot, leas
 	if err != nil {
 		return nil, fmt.Errorf("inspect installed artifact scp helper: %w", err)
 	}
-	result, runErr := b.rt.Exec.Run(ctx, LocalCommandRequest{
+	result, runErr := b.rt.Exec.Run(ctx, core.LocalCommandRequest{
 		Name: "/bin/sh", Args: command, Dir: repoRoot, Env: env,
 		MaxCapturedOutputBytes: int(blacksmithArtifactDiagnosticCaptureBytes), CancelGracePeriod: time.Second,
 		RequireProcessGroupJoin: true,
@@ -189,7 +189,7 @@ func (b *blacksmithBackend) downloadArtifact(ctx context.Context, repoRoot, leas
 	return data, nil
 }
 
-func retainBlacksmithDownloadDiagnostics(stage string, owned os.FileInfo, result LocalCommandResult) (metadata string, err error) {
+func retainBlacksmithDownloadDiagnostics(stage string, owned os.FileInfo, result core.LocalCommandResult) (metadata string, err error) {
 	root, err := os.OpenRoot(stage)
 	if err != nil {
 		return "", fmt.Errorf("open native diagnostic staging: %w", err)

--- a/internal/providers/blacksmith/artifact_download_diagnostics_test.go
+++ b/internal/providers/blacksmith/artifact_download_diagnostics_test.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestBlacksmithDownloadFailureDiagnostics(t *testing.T) {
@@ -41,7 +43,7 @@ func TestBlacksmithDownloadFailureDiagnostics(t *testing.T) {
 			var console bytes.Buffer
 			preserved := map[string]string{}
 			calls := 0
-			backend := newTestBlacksmithBackend(baseConfig(), ownershipRunner(func(runCtx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+			backend := newTestBlacksmithBackend(core.BaseConfig(), ownershipRunner(func(runCtx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				calls++
 				if runCtx != ctx || req.Dir != repo || !req.RequireProcessGroupJoin || req.MaxCapturedOutputBytes != int(blacksmithArtifactDiagnosticCaptureBytes) || req.Stdout != nil || req.Stderr != nil {
 					t.Fatal("download changed its context, closure, capture bounds or stream privacy")
@@ -84,7 +86,7 @@ func TestBlacksmithDownloadFailureDiagnostics(t *testing.T) {
 				if kind == "cancellation" {
 					cancel(cause)
 				}
-				return LocalCommandResult{ExitCode: 23, Stdout: streams["stdout"], Stderr: streams["stderr"]}, nativeFailure
+				return core.LocalCommandResult{ExitCode: 23, Stdout: streams["stdout"], Stderr: streams["stderr"]}, nativeFailure
 			}))
 			backend.rt.Stdout, backend.rt.Stderr = &console, &console
 			remote := ".crabbox/blacksmith-artifact-" + strings.Repeat("a", 64) + "/archive.tgz"

--- a/internal/providers/blacksmith/artifact_download_installed_test.go
+++ b/internal/providers/blacksmith/artifact_download_installed_test.go
@@ -54,7 +54,7 @@ func TestBlacksmithDownloadInstalledHelperExecution(t *testing.T) {
 	// Both executables are test-owned scripts. Only the final Go fixture reads
 	// kernel limits and writes the tiny expected destination.
 	native := "#!/bin/sh\nfor arg do destination=$arg; done\nexec scp 'one argument with spaces' '*' '' \"$destination\"\n"
-	scp := "#!/bin/sh\nexec " + shellQuote(os.Args[0]) + " -test.run=^TestBlacksmithInstalledHelperChild$ -- \"$0\" \"$@\"\n"
+	scp := "#!/bin/sh\nexec " + core.ShellQuote(os.Args[0]) + " -test.run=^TestBlacksmithInstalledHelperChild$ -- \"$0\" \"$@\"\n"
 	for name, script := range map[string]string{filepath.Join(f.tools, "blacksmith"): native, f.scp: scp} {
 		if err := os.WriteFile(name, []byte(script), 0o700); err != nil {
 			t.Fatal(err)
@@ -68,9 +68,9 @@ func TestBlacksmithDownloadInstalledHelperExecution(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 	realRunner := core.RuntimeForProviderOperation(io.Discard).Exec
-	var nativeResult LocalCommandResult
+	var nativeResult core.LocalCommandResult
 	var stage string
-	backend := newTestBlacksmithBackend(baseConfig(), ownershipRunner(func(runCtx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	backend := newTestBlacksmithBackend(core.BaseConfig(), ownershipRunner(func(runCtx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if runCtx != ctx || !req.RequireProcessGroupJoin || req.MaxCapturedOutputBytes != int(blacksmithArtifactDiagnosticCaptureBytes) {
 			t.Fatal("fixture lost its bounded original command owner")
 		}
@@ -177,7 +177,7 @@ func TestBlacksmithDownloadInstalledHelperDrift(t *testing.T) {
 			var stage string
 			calls := 0
 			const stdout, stderr = "SYNTHETIC_NATIVE_STDOUT", "SYNTHETIC_NATIVE_STDERR"
-			backend := newTestBlacksmithBackend(baseConfig(), ownershipRunner(func(runCtx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+			backend := newTestBlacksmithBackend(core.BaseConfig(), ownershipRunner(func(runCtx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				calls++
 				destination := req.Args[len(req.Args)-1]
 				stage = filepath.Dir(destination)
@@ -221,7 +221,7 @@ func TestBlacksmithDownloadInstalledHelperDrift(t *testing.T) {
 						t.Fatal(err)
 					}
 				}
-				result := LocalCommandResult{Stdout: stdout, Stderr: stderr}
+				result := core.LocalCommandResult{Stdout: stdout, Stderr: stderr}
 				if kind == "inode-native-failure" {
 					result.ExitCode = 23
 					return result, nativeFailure

--- a/internal/providers/blacksmith/artifact_download_test.go
+++ b/internal/providers/blacksmith/artifact_download_test.go
@@ -69,7 +69,7 @@ func TestBlacksmithDownloadArtifactValidation(t *testing.T) {
 				expectedHash = "invalid"
 			}
 			calls := 0
-			backend := newTestBlacksmithBackend(baseConfig(), ownershipRunner(func(runCtx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+			backend := newTestBlacksmithBackend(core.BaseConfig(), ownershipRunner(func(runCtx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				calls++
 				destination := req.Args[len(req.Args)-1]
 				stage = filepath.Dir(destination)
@@ -135,16 +135,16 @@ func TestBlacksmithDownloadArtifactValidation(t *testing.T) {
 				}
 				if kind == "cancel" {
 					cancel(nil)
-					return LocalCommandResult{ExitCode: -1}, runCtx.Err()
+					return core.LocalCommandResult{ExitCode: -1}, runCtx.Err()
 				}
 				if kind == "cancel-cause" {
 					cancel(cause)
-					return LocalCommandResult{ExitCode: -1}, runCtx.Err()
+					return core.LocalCommandResult{ExitCode: -1}, runCtx.Err()
 				}
 				if kind == "native-exit" {
-					return LocalCommandResult{ExitCode: 23}, errors.New("synthetic native failure")
+					return core.LocalCommandResult{ExitCode: 23}, errors.New("synthetic native failure")
 				}
-				return LocalCommandResult{}, nil
+				return core.LocalCommandResult{}, nil
 			}))
 			backend.route = &blacksmithRoute{API: "https://api.example.invalid", Org: "example-org"}
 			data, err := backend.downloadArtifact(ctx, repoRoot, "tbx_download", "/synthetic/key", remote, expectedBytes, expectedHash)
@@ -220,7 +220,7 @@ func TestBlacksmithDownloadFileLimit(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			result, _ := core.RuntimeForProviderOperation(io.Discard).Exec.Run(t.Context(), LocalCommandRequest{
+			result, _ := core.RuntimeForProviderOperation(io.Discard).Exec.Run(t.Context(), core.LocalCommandRequest{
 				Name: shell, Args: args, MaxCapturedOutputBytes: 1024,
 				Env: []string{"PATH=/usr/bin:/bin", "POSIXLY_CORRECT=1", "CRABBOX_TEST_DOWNLOAD_LIMIT=1"},
 			})

--- a/internal/providers/blacksmith/artifact_metadata_test.go
+++ b/internal/providers/blacksmith/artifact_metadata_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 const (
@@ -159,7 +161,7 @@ func TestBlacksmithArtifactMetadataCollectorFailure(t *testing.T) {
 				t.Fatal("collector failure corrupted the workload receipt")
 			}
 			err := r.validateArchiveReceipt()
-			var ee ExitError
+			var ee core.ExitError
 			if !errors.As(err, &ee) || ee.Code != 7 || !strings.Contains(err.Error(), fmt.Sprintf("collection exited %d", tt.collectorCode)) {
 				t.Fatal("collector failure was replaced by missing-metadata validation")
 			}

--- a/internal/providers/blacksmith/artifact_owner_test.go
+++ b/internal/providers/blacksmith/artifact_owner_test.go
@@ -24,11 +24,11 @@ func TestBlacksmithArtifactRefusesControllerOwnedGroup(t *testing.T) {
 			isolateBlacksmithOwnership(t)
 			t.Setenv("CRABBOX_CONTROLLER_PROCESS_TREE_OWNED", "1")
 			calls := 0
-			backend := newTestBlacksmithBackend(baseConfig(), ownershipRunner(func(context.Context, LocalCommandRequest) (LocalCommandResult, error) {
+			backend := newTestBlacksmithBackend(core.BaseConfig(), ownershipRunner(func(context.Context, core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				calls++
-				return LocalCommandResult{}, errors.New("unexpected native call")
+				return core.LocalCommandResult{}, errors.New("unexpected native call")
 			}))
-			req := RunRequest{Repo: Repo{Root: t.TempDir()}, Command: []string{"true"}, ArtifactGlobs: []string{"report"}}
+			req := core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, Command: []string{"true"}, ArtifactGlobs: []string{"report"}}
 			var err error
 			if boundary == "run-options" {
 				_, err = backend.Run(t.Context(), req)
@@ -58,8 +58,8 @@ func TestBlacksmithDownloadCancellationRetainsClaimUntilClosure(t *testing.T) {
 	fakeNative := "#!/bin/sh\nfor arg do destination=$arg; done\nscp \"$destination\"\n"
 	fakeSCP := "#!/bin/sh\nprintf x > \"$1\"\n(\n" +
 		"  i=0\n  while [ \"$i\" -lt 16 ]; do\n" +
-		"    printf x >> " + shellQuote(writes) + "\n" +
-		"    if [ \"$i\" -eq 0 ]; then printf ready > " + shellQuote(ready) + "; fi\n" +
+		"    printf x >> " + core.ShellQuote(writes) + "\n" +
+		"    if [ \"$i\" -eq 0 ]; then printf ready > " + core.ShellQuote(ready) + "; fi\n" +
 		"    sleep 0.02\n    i=$((i + 1))\n  done\n) &\nwait\n"
 	for name, source := range map[string]string{"blacksmith": fakeNative, "scp": fakeSCP} {
 		if err := os.WriteFile(filepath.Join(toolsDir, name), []byte(source), 0o700); err != nil {
@@ -71,12 +71,12 @@ func TestBlacksmithDownloadCancellationRetainsClaimUntilClosure(t *testing.T) {
 	route, _, _ := blacksmithClaimBinding(claim)
 	realRunner := core.RuntimeForProviderOperation(io.Discard).Exec
 	var downloads atomic.Int32
-	backend := newTestBlacksmithBackend(baseConfig(), ownershipRunner(func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	backend := newTestBlacksmithBackend(core.BaseConfig(), ownershipRunner(func(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if req.Name == "blacksmith" && len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "status" {
-			return LocalCommandResult{Stdout: testBlacksmithStatus(id, "ready")}, nil
+			return core.LocalCommandResult{Stdout: testBlacksmithStatus(id, "ready")}, nil
 		}
 		if req.Name != "/bin/sh" || req.Dir != root || !req.RequireProcessGroupJoin {
-			return LocalCommandResult{ExitCode: 2}, errors.New("download did not require inline process-group closure")
+			return core.LocalCommandResult{ExitCode: 2}, errors.New("download did not require inline process-group closure")
 		}
 		downloads.Add(1)
 		return realRunner.Run(ctx, req)

--- a/internal/providers/blacksmith/artifact_protocol_test.go
+++ b/internal/providers/blacksmith/artifact_protocol_test.go
@@ -40,8 +40,8 @@ func TestBlacksmithArtifactProtocolCancellation(t *testing.T) {
 						runs := 0
 						const privatePayload = "synthetic-private-collection-payload"
 						runner := &blacksmithFuncRunner{
-							onRequest: func(runCtx context.Context, req LocalCommandRequest) { nativeCtx = runCtx },
-							fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+							onRequest: func(runCtx context.Context, req core.LocalCommandRequest) { nativeCtx = runCtx },
+							fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 								runs++
 								start, workloadExit, _ := testBlacksmithReceiptFrames(t, syntheticBlacksmithCommand(t, req), workloadCode)
 								_, _ = io.WriteString(req.Stdout, start+"ordinary workload output\n"+workloadExit+privatePayload)
@@ -52,12 +52,12 @@ func TestBlacksmithArtifactProtocolCancellation(t *testing.T) {
 								// process or wall-clock timeout is needed for this protocol edge.
 								<-nativeCtx.Done()
 								observedCause = context.Cause(nativeCtx)
-								return LocalCommandResult{ExitCode: 1}, nativeCtx.Err()
+								return core.LocalCommandResult{ExitCode: 1}, nativeCtx.Err()
 							},
 						}
-						backend := newTestBlacksmithBackend(baseConfig(), runner)
+						backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
 						backend.rt.Stdout, backend.rt.Stderr = &stdout, &stderr
-						req := RunRequest{ID: id, Repo: Repo{Root: repo}, Command: []string{"synthetic workload"}, ArtifactGlobs: []string{"report"}}
+						req := core.RunRequest{ID: id, Repo: core.Repo{Root: repo}, Command: []string{"synthetic workload"}, ArtifactGlobs: []string{"report"}}
 						wantCode := workloadCode
 						if wantCode == 0 {
 							wantCode = 1 // Preserve the native cancellation result after exit 0.

--- a/internal/providers/blacksmith/artifact_publication_test.go
+++ b/internal/providers/blacksmith/artifact_publication_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestBlacksmithArtifactCapabilityProbeCancellation(t *testing.T) {
@@ -29,17 +31,17 @@ func TestBlacksmithArtifactCapabilityProbeCancellation(t *testing.T) {
 				cause = errors.New("synthetic caller cancellation cause")
 			}
 			calls := 0
-			backend := newTestBlacksmithBackend(baseConfig(), ownershipRunner(func(runCtx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+			backend := newTestBlacksmithBackend(core.BaseConfig(), ownershipRunner(func(runCtx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				calls++
 				if req.Name != "blacksmith" || !slices.Equal(req.Args, []string{"testbox", "download", "--help"}) {
 					t.Errorf("unexpected request after capability cancellation: %s", req.Name)
-					return LocalCommandResult{ExitCode: 2}, errors.New("unexpected request")
+					return core.LocalCommandResult{ExitCode: 2}, errors.New("unexpected request")
 				}
 				cancel(cause)
-				return LocalCommandResult{ExitCode: -1}, runCtx.Err()
+				return core.LocalCommandResult{ExitCode: -1}, runCtx.Err()
 			}))
-			_, ended, artifacts, err := backend.runArtifactTestbox(ctx, RunRequest{
-				Repo: Repo{Root: t.TempDir()}, Command: []string{"true"}, ArtifactGlobs: []string{"report"},
+			_, ended, artifacts, err := backend.runArtifactTestbox(ctx, core.RunRequest{
+				Repo: core.Repo{Root: t.TempDir()}, Command: []string{"true"}, ArtifactGlobs: []string{"report"},
 			}, "tbx_capability_cancel", nil, nil, nil, time.Second)
 			if !errors.Is(err, context.Canceled) || !errors.Is(err, cause) {
 				t.Errorf("capability cancellation lost its classification or cause: %v", err)

--- a/internal/providers/blacksmith/artifact_run.go
+++ b/internal/providers/blacksmith/artifact_run.go
@@ -46,7 +46,7 @@ func newBlacksmithArtifactReceipt(now func() time.Time) (*blacksmithArtifactRece
 	return &blacksmithArtifactReceipt{nonce: hex.EncodeToString(nonce[:]), now: now}, nil
 }
 
-func (r *blacksmithArtifactReceipt) command(req RunRequest, budget time.Duration) string {
+func (r *blacksmithArtifactReceipt) command(req core.RunRequest, budget time.Duration) string {
 	// Keep control bytes escaped in source: native --debug may echo this string.
 	format := `\036CRABBOX_BS_` + r.nonce + ":"
 	child := "printf '" + format + "start\\037' || exit 7\n" + blacksmithCommandString(req.Command, req.ShellMode)
@@ -71,7 +71,7 @@ if [ -e "$binding" ] || [ -L "$binding" ]; then
 fi
 ` + "timeout --kill-after=1s 1s /bin/sh -c ':' >/dev/null 2>&1 || exit 7\n" +
 		"command -v sha256sum >/dev/null 2>&1 || { printf '%s\\n' 'artifact collection requires sha256sum' >&2; exit 7; }\n" +
-		"(cd -P \"$native_cwd\" || exit 7\nexec bash -c " + shellQuote(child) + ")\n" +
+		"(cd -P \"$native_cwd\" || exit 7\nexec bash -c " + core.ShellQuote(child) + ")\n" +
 		"workload_code=$?\n" +
 		"printf '" + format + "exit:%d\\037' \"$workload_code\" || exit 7\n" +
 		"collection_code=0\n" +
@@ -80,10 +80,10 @@ fi
 		"if [ -L \"$transfer_parent\" ] || ! mkdir -p -- \"$transfer_parent\"; then exit 7; fi\n" +
 		"transfer_dir=\"$native_cwd/" + filepath.ToSlash(filepath.Dir(r.remotePath())) + "\"\n" +
 		"umask 077\nmkdir -- \"$transfer_dir\" || exit 7\n" +
-		"timeout --kill-after=1s " + shellQuote(fmt.Sprintf("%gs", budget.Seconds())) + " bash -c " + shellQuote(collector) + " -- \"$transfer_dir/archive.tgz\" 2>&1\n" +
+		"timeout --kill-after=1s " + core.ShellQuote(fmt.Sprintf("%gs", budget.Seconds())) + " bash -c " + core.ShellQuote(collector) + " -- \"$transfer_dir/archive.tgz\" 2>&1\n" +
 		"collection_code=$?\nfi\n" +
 		"printf '" + format + "end:%d\\037' \"$collection_code\" || exit 7\nexit 0"
-	return "/bin/sh -c " + shellQuote(body)
+	return "/bin/sh -c " + core.ShellQuote(body)
 }
 
 func (r *blacksmithArtifactReceipt) record(record string) error {
@@ -247,12 +247,12 @@ func (r *blacksmithArtifactReceipt) validateArchiveReceipt() error {
 	// after writing only an archive prefix or base64 fragment.
 	if r.collectCode != 0 {
 		if r.collectCode == 8 {
-			return exit(7, "collection exited 8: missing required artifact")
+			return core.Exit(7, "collection exited 8: missing required artifact")
 		}
-		return exit(7, "collection exited %d", r.collectCode)
+		return core.Exit(7, "collection exited %d", r.collectCode)
 	}
 	if r.archiveSize == 0 || len(r.digest) != 64 {
-		return exit(7, "collection returned incomplete archive metadata")
+		return core.Exit(7, "collection returned incomplete archive metadata")
 	}
 	return nil
 }
@@ -290,22 +290,22 @@ func (g *blacksmithArchiveGuard) flush() {
 
 // Called only inside the original shared claim fence. There is no follow-up
 // native run, route resolution, sync, or stopped-lease recovery.
-func (b *blacksmithBackend) runArtifactTestbox(ctx context.Context, req RunRequest, leaseID string, phases *core.CommandPhaseTracker, stdoutExtra, stderrExtra io.Writer, budget time.Duration) (code int, ended time.Time, collected []core.RunArtifact, artifactErr error) {
+func (b *blacksmithBackend) runArtifactTestbox(ctx context.Context, req core.RunRequest, leaseID string, phases *core.CommandPhaseTracker, stdoutExtra, stderrExtra io.Writer, budget time.Duration) (code int, ended time.Time, collected []core.RunArtifact, artifactErr error) {
 	if err := validateBlacksmithNativeSyncScope(req.Repo.Root); err != nil {
 		return 2, time.Time{}, nil, err
 	}
 	if err := core.ValidateLocalCommandProcessGroupJoin(ctx); err != nil {
-		return 2, time.Time{}, collected, exit(2, "Blacksmith artifact command ownership: %v", err)
+		return 2, time.Time{}, collected, core.Exit(2, "Blacksmith artifact command ownership: %v", err)
 	}
 	capability, err := b.runCommandCaptureInDir(ctx, []string{"testbox", "download", "--help"}, nil, nil, false, req.Repo.Root)
 	if err = blacksmithContextError(ctx, err); err != nil {
 		return core.ExitCodeForError(err, 1), time.Time{}, collected, err
 	}
 	if capability.ExitCode != 0 {
-		return capability.ExitCode, time.Time{}, collected, exit(capability.ExitCode, "Blacksmith artifact capability probe failed")
+		return capability.ExitCode, time.Time{}, collected, core.Exit(capability.ExitCode, "Blacksmith artifact capability probe failed")
 	}
 	if !strings.Contains(capability.Stdout, "testbox download --id") || !strings.Contains(capability.Stdout, "--ssh-private-key") {
-		return 2, time.Time{}, collected, exit(2, "Blacksmith artifact collection requires native testbox download support; update the Blacksmith CLI")
+		return 2, time.Time{}, collected, core.Exit(2, "Blacksmith artifact collection requires native testbox download support; update the Blacksmith CLI")
 	}
 	scp, err := blacksmithDownloadExecutable("scp")
 	if err == nil {
@@ -375,7 +375,7 @@ func (b *blacksmithBackend) runArtifactTestbox(ctx context.Context, req RunReque
 		if r.stage >= 2 && r.code != 0 {
 			code = r.code
 		}
-		protocolErr := exit(7, "native run did not complete a clean artifact protocol; artifacts withheld")
+		protocolErr := core.Exit(7, "native run did not complete a clean artifact protocol; artifacts withheld")
 		return code, ended, collected, blacksmithContextError(runCtx, protocolErr)
 	}
 	code = r.code
@@ -395,7 +395,7 @@ func (b *blacksmithBackend) runArtifactTestbox(ctx context.Context, req RunReque
 	}
 	path := core.LocalRunArtifactPath(req.Repo.Root, "", leaseID, filepath.Join(r.nonce, "blacksmith-artifacts.tgz"))
 	if err := writeBlacksmithRunArchive(runCtx, path, archive, collectionDeadline); err != nil {
-		return code, ended, collected, errors.Join(exit(2, "blacksmith artifact write: %v", err), err)
+		return code, ended, collected, errors.Join(core.Exit(2, "blacksmith artifact write: %v", err), err)
 	}
 	return code, ended, []core.RunArtifact{{Kind: "artifact-glob", Path: path, Bytes: len(archive)}}, nil
 }

--- a/internal/providers/blacksmith/artifact_run_test.go
+++ b/internal/providers/blacksmith/artifact_run_test.go
@@ -41,7 +41,7 @@ func testWriteBlacksmithFile(t *testing.T, root, name, text string) {
 	}
 }
 
-func syntheticBlacksmithCommand(t *testing.T, req LocalCommandRequest) string {
+func syntheticBlacksmithCommand(t *testing.T, req core.LocalCommandRequest) string {
 	t.Helper()
 	for _, arg := range req.Args {
 		if strings.HasPrefix(arg, "/bin/sh -c ") {
@@ -54,7 +54,7 @@ func syntheticBlacksmithCommand(t *testing.T, req LocalCommandRequest) string {
 
 // Synthetic native transport only: executes the actual wrapper and generic
 // artifact script locally. No native CLI, credentials, sync, or lease exists.
-func runSyntheticBlacksmithCommand(t *testing.T, ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func runSyntheticBlacksmithCommand(t *testing.T, ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	t.Helper()
 	if req.Dir == "" || req.Stdin != nil || !req.DisableOutputCapture || req.CancelGracePeriod <= 0 {
 		t.Errorf("unbounded or changed native request: dir=%q stdin=%v capture=%t grace=%s", req.Dir, req.Stdin != nil, req.DisableOutputCapture, req.CancelGracePeriod)
@@ -73,7 +73,7 @@ func runSyntheticBlacksmithCommand(t *testing.T, ctx context.Context, req LocalC
 			code = ee.ExitCode()
 		}
 	}
-	return LocalCommandResult{ExitCode: code}, err
+	return core.LocalCommandResult{ExitCode: code}, err
 }
 
 func readBlacksmithArchive(t *testing.T, path string) map[string]string {
@@ -168,14 +168,14 @@ func TestBlacksmithArtifactRunShellAndTerminalExit(t *testing.T) {
 				prepareBlacksmithGuestKey(t, id)
 				testOwnedBlacksmithClaim(t, id, "jade-krill", repo)
 				runs := 0
-				runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+				runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 					runs++
 					if req.Dir != repo {
 						t.Error("native sync cwd changed")
 					}
 					return runSyntheticBlacksmithCommand(t, t.Context(), req)
 				}}
-				backend := newTestBlacksmithBackend(baseConfig(), runner)
+				backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
 				var stdout, stderr bytes.Buffer
 				backend.rt.Stdout, backend.rt.Stderr = &stdout, &stderr
 				command, shell := tt.argv, false
@@ -186,7 +186,7 @@ func TestBlacksmithArtifactRunShellAndTerminalExit(t *testing.T) {
 					command = []string{"test -f transport-input || exit 90\ncd -P ./.git/crabbox-artifact-root || exit 91\n" + blacksmithCommandString(command, shell)}
 					shell = true
 				}
-				result, err := backend.Run(t.Context(), RunRequest{ID: id, Repo: Repo{Root: repo}, Command: command, ShellMode: shell, ArtifactGlobs: []string{"report"}, RequiredArtifactGlobs: []string{"report"}, TimingJSON: true})
+				result, err := backend.Run(t.Context(), core.RunRequest{ID: id, Repo: core.Repo{Root: repo}, Command: command, ShellMode: shell, ArtifactGlobs: []string{"report"}, RequiredArtifactGlobs: []string{"report"}, TimingJSON: true})
 				if result.ExitCode != tt.code || (err == nil) != (tt.code == 0) || runs != 1 || result.CommandText != blacksmithCommandString(command, shell) {
 					t.Fatalf("code=%d err=%v runs=%d text=%q", result.ExitCode, err, runs, result.CommandText)
 				}
@@ -276,15 +276,15 @@ func TestBlacksmithArtifactPreflightsSCPBeforeWorkload(t *testing.T) {
 			t.Setenv("PATH", parentBin)
 			repo := t.TempDir()
 			runs := 0
-			runner := artifactTestRunner(t, func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+			runner := artifactTestRunner(t, func(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				runs++
 				// Keep shell tools available without masking the missing local helper.
 				req.Env = append(req.Env, "PATH="+childPATH)
 				return runSyntheticBlacksmithCommand(t, ctx, req)
 			})
-			backend := newTestBlacksmithBackend(baseConfig(), runner)
-			code, ended, artifacts, err := backend.runArtifactTestbox(t.Context(), RunRequest{
-				Repo: Repo{Root: repo}, Command: []string{"printf started > workload-started; printf payload > report"}, ShellMode: true,
+			backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
+			code, ended, artifacts, err := backend.runArtifactTestbox(t.Context(), core.RunRequest{
+				Repo: core.Repo{Root: repo}, Command: []string{"printf started > workload-started; printf payload > report"}, ShellMode: true,
 				ArtifactGlobs: []string{"report"}, RequiredArtifactGlobs: []string{"report"},
 			}, "tbx_preflight", nil, nil, nil, time.Second)
 			_, markerErr := os.Stat(filepath.Join(repo, "workload-started"))
@@ -346,7 +346,7 @@ func TestBlacksmithArtifactWorkspaceBinding(t *testing.T) {
 			case "retarget", "created-by-workload":
 				other := t.TempDir()
 				testWriteBlacksmithFile(t, other, "report", "wrong binding")
-				retarget := "rm -f " + shellQuote(binding) + "\nln -s " + shellQuote(other) + " " + shellQuote(binding) + "\n"
+				retarget := "rm -f " + core.ShellQuote(binding) + "\nln -s " + core.ShellQuote(other) + " " + core.ShellQuote(binding) + "\n"
 				if mode == "created-by-workload" {
 					if err := os.Remove(binding); err != nil {
 						t.Fatal(err)
@@ -356,7 +356,7 @@ func TestBlacksmithArtifactWorkspaceBinding(t *testing.T) {
 					command += retarget
 				}
 			case "replace-directory":
-				command += "mv " + shellQuote(root) + " " + shellQuote(root+"-moved") + "\nmkdir " + shellQuote(root) + "\nprintf replacement > " + shellQuote(filepath.Join(root, "report")) + "\n"
+				command += "mv " + core.ShellQuote(root) + " " + core.ShellQuote(root+"-moved") + "\nmkdir " + core.ShellQuote(root) + "\nprintf replacement > " + core.ShellQuote(filepath.Join(root, "report")) + "\n"
 			default:
 				invalid = true
 				if err := os.Remove(binding); err != nil {
@@ -381,12 +381,12 @@ func TestBlacksmithArtifactWorkspaceBinding(t *testing.T) {
 					}
 				}
 			}
-			runner := artifactTestRunner(t, func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+			runner := artifactTestRunner(t, func(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				return runSyntheticBlacksmithCommand(t, ctx, req)
 			})
-			backend := newTestBlacksmithBackend(baseConfig(), runner)
+			backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
 			prepareBlacksmithGuestKey(t, "tbx_workspace")
-			code, ended, result, err := backend.runArtifactTestbox(t.Context(), RunRequest{Repo: Repo{Root: repo}, Command: []string{command}, ShellMode: true, ArtifactGlobs: []string{"report"}, RequiredArtifactGlobs: []string{"report"}}, "tbx_workspace", nil, nil, nil, time.Second)
+			code, ended, result, err := backend.runArtifactTestbox(t.Context(), core.RunRequest{Repo: core.Repo{Root: repo}, Command: []string{command}, ShellMode: true, ArtifactGlobs: []string{"report"}, RequiredArtifactGlobs: []string{"report"}}, "tbx_workspace", nil, nil, nil, time.Second)
 			if invalid {
 				if code != 7 || err == nil || !ended.IsZero() || len(result) != 0 {
 					t.Fatalf("invalid binding reached workload: code=%d ended=%v result=%+v err=%v", code, ended, result, err)
@@ -417,7 +417,7 @@ func TestBlacksmithArtifactRunCollectionFailurePreservesWorkload(t *testing.T) {
 				const id = "tbx_collectfailure"
 				prepareBlacksmithGuestKey(t, id)
 				testOwnedBlacksmithClaim(t, id, "jade-krill", repo)
-				req := RunRequest{ID: id, Repo: Repo{Root: repo}, Command: []string{fmt.Sprintf("exit %d", code)}, ArtifactGlobs: []string{"reports/**"}}
+				req := core.RunRequest{ID: id, Repo: core.Repo{Root: repo}, Command: []string{fmt.Sprintf("exit %d", code)}, ArtifactGlobs: []string{"reports/**"}}
 				switch kind {
 				case "required":
 					req.RequiredArtifactGlobs = []string{"reports/missing"}
@@ -431,7 +431,7 @@ func TestBlacksmithArtifactRunCollectionFailurePreservesWorkload(t *testing.T) {
 					testWriteBlacksmithFile(t, repo, ".crabbox/runs", "not a directory")
 				}
 				runs := 0
-				runner := &blacksmithFuncRunner{fn: func(native LocalCommandRequest) (LocalCommandResult, error) {
+				runner := &blacksmithFuncRunner{fn: func(native core.LocalCommandRequest) (core.LocalCommandResult, error) {
 					runs++
 					if kind == "compressed-bytes" {
 						// The collector's small-limit tests own archive construction;
@@ -440,16 +440,16 @@ func TestBlacksmithArtifactRunCollectionFailurePreservesWorkload(t *testing.T) {
 						metadata, _ := testBlacksmithArtifactMetadata(t, native, makeTarGz(t, map[string]string{"reports/report": "small fixture"}))
 						metadata = regexp.MustCompile(`:bytes:[0-9]+`).ReplaceAllString(metadata, fmt.Sprintf(":bytes:%d", core.DelegatedRunArtifactDefaultMaxBytes+1))
 						fmt.Fprint(native.Stdout, start+exit+metadata+end)
-						return LocalCommandResult{}, nil
+						return core.LocalCommandResult{}, nil
 					}
 					if kind == "remote-timeout" {
 						start, exit, end := testBlacksmithReceiptFrames(t, syntheticBlacksmithCommand(t, native), code)
 						fmt.Fprint(native.Stdout, start+exit+strings.Replace(end, ":end:0", ":end:124", 1))
-						return LocalCommandResult{}, nil
+						return core.LocalCommandResult{}, nil
 					}
 					return runSyntheticBlacksmithCommand(t, t.Context(), native)
 				}}
-				backend := newTestBlacksmithBackend(baseConfig(), runner)
+				backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
 				var stderr bytes.Buffer
 				backend.rt.Stderr = &stderr
 				result, err := backend.Run(t.Context(), req)
@@ -460,7 +460,7 @@ func TestBlacksmithArtifactRunCollectionFailurePreservesWorkload(t *testing.T) {
 						want = 2
 					}
 				}
-				var ee ExitError
+				var ee core.ExitError
 				if !errors.As(err, &ee) || ee.Code != want || result.ExitCode != want || len(result.Artifacts) != 0 {
 					t.Fatalf("result=%+v err=%v", result, err)
 				}
@@ -497,7 +497,7 @@ func TestBlacksmithArtifactReceiptAdversarial(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 			var stdout, stderr bytes.Buffer
-			runner := artifactTestRunner(t, func(runCtx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+			runner := artifactTestRunner(t, func(runCtx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				start, exit, end := testBlacksmithReceiptFrames(t, syntheticBlacksmithCommand(t, req), 0)
 				contents := archive
 				if kind == "duplicate-archive" {
@@ -538,7 +538,7 @@ func TestBlacksmithArtifactReceiptAdversarial(t *testing.T) {
 						t.Fatal(err)
 					}
 				case "native-before":
-					return LocalCommandResult{ExitCode: 1}, errors.New("transport lost")
+					return core.LocalCommandResult{ExitCode: 1}, errors.New("transport lost")
 				case "overflow":
 					output = start + exit + regexp.MustCompile(`:bytes:[0-9]+`).ReplaceAllString(payload, fmt.Sprintf(":bytes:%d", core.DelegatedRunArtifactDefaultMaxBytes+1)) + end
 				case "diagnostics-overflow":
@@ -566,20 +566,20 @@ func TestBlacksmithArtifactReceiptAdversarial(t *testing.T) {
 					cancel()
 				}
 				if kind == "native-after" {
-					return LocalCommandResult{ExitCode: 1}, errors.New("late transport loss")
+					return core.LocalCommandResult{ExitCode: 1}, errors.New("late transport loss")
 				}
 				if kind == "nil-error-nonzero" {
-					return LocalCommandResult{ExitCode: 23}, nil
+					return core.LocalCommandResult{ExitCode: 23}, nil
 				}
 				if kind == "zero-code-error" {
-					return LocalCommandResult{}, errors.New("late transport loss")
+					return core.LocalCommandResult{}, errors.New("late transport loss")
 				}
-				return LocalCommandResult{}, nil
+				return core.LocalCommandResult{}, nil
 			})
-			backend := newTestBlacksmithBackend(baseConfig(), runner)
+			backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
 			backend.rt.Stdout, backend.rt.Stderr = &stdout, &stderr
 			prepareBlacksmithGuestKey(t, "tbx_receipt")
-			code, _, collected, err := backend.runArtifactTestbox(ctx, RunRequest{Repo: Repo{Root: repo}, Command: []string{"true"}, ArtifactGlobs: []string{"report"}}, "tbx_receipt", nil, nil, nil, time.Second)
+			code, _, collected, err := backend.runArtifactTestbox(ctx, core.RunRequest{Repo: core.Repo{Root: repo}, Command: []string{"true"}, ArtifactGlobs: []string{"report"}}, "tbx_receipt", nil, nil, nil, time.Second)
 			if kind == "valid" {
 				if err != nil || code != 0 || len(collected) != 1 {
 					t.Fatalf("code=%d collected=%+v err=%v", code, collected, err)
@@ -614,7 +614,7 @@ func TestBlacksmithArtifactRunBudgets(t *testing.T) {
 				if kind == "workload-outlives-budget" {
 					budget, workloadWait = 3*time.Second, "3.2"
 				}
-				runner := artifactTestRunner(t, func(runCtx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+				runner := artifactTestRunner(t, func(runCtx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 					if kind == "startup-failure" {
 						req.Env = []string{"BASH_ENV=" + filepath.Join(repo, "bash-env")}
 					}
@@ -623,11 +623,11 @@ func TestBlacksmithArtifactRunBudgets(t *testing.T) {
 						start, exit, _ := testBlacksmithReceiptFrames(t, syntheticBlacksmithCommand(t, req), code)
 						fmt.Fprint(req.Stdout, start+exit)
 						<-runCtx.Done()
-						return LocalCommandResult{ExitCode: 1}, runCtx.Err()
+						return core.LocalCommandResult{ExitCode: 1}, runCtx.Err()
 					case "sync-stall":
 						fmt.Fprintln(req.Stdout, "Syncing from repo root: /synthetic")
 						<-runCtx.Done()
-						return LocalCommandResult{ExitCode: 1}, runCtx.Err()
+						return core.LocalCommandResult{ExitCode: 1}, runCtx.Err()
 					case "remote-collection-timeout":
 						// Buffer receipts until the real remote timeout finishes so
 						// the equal local budget starts only after native completion.
@@ -660,9 +660,9 @@ func TestBlacksmithArtifactRunBudgets(t *testing.T) {
 					}
 					return runSyntheticBlacksmithCommand(t, runCtx, req)
 				})
-				backend := newTestBlacksmithBackend(baseConfig(), runner)
+				backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
 				begin := time.Now()
-				runReq := RunRequest{Repo: Repo{Root: repo}, Command: []string{fmt.Sprintf("sleep %s; exit %d", workloadWait, code)}, ArtifactGlobs: []string{"report"}}
+				runReq := core.RunRequest{Repo: core.Repo{Root: repo}, Command: []string{fmt.Sprintf("sleep %s; exit %d", workloadWait, code)}, ArtifactGlobs: []string{"report"}}
 				if kind == "unsupported-timeout" {
 					runReq.Command = []string{fmt.Sprintf("printf started > workload-started; exit %d", code)}
 					runReq.ShellMode = true
@@ -682,13 +682,13 @@ func TestBlacksmithArtifactRunBudgets(t *testing.T) {
 						t.Fatalf("workload was bounded: code=%d err=%v", got, err)
 					}
 				} else if kind == "remote-collection-timeout" {
-					var ee ExitError
+					var ee core.ExitError
 					if got != code || ended.IsZero() || !errors.As(err, &ee) || ee.Code != 7 || ee.Message != "collection exited 124" || len(artifacts) != 0 {
 						t.Fatalf("remote collection timeout lost workload result: code=%d ended=%v artifacts=%+v err=%v", got, ended, artifacts, err)
 					}
 					assertNoBlacksmithArtifactPublication(t, repo, "tbx_budget")
 				} else {
-					var ee ExitError
+					var ee core.ExitError
 					if !errors.As(err, &ee) || ee.Code != 7 || len(artifacts) != 0 {
 						t.Fatalf("unconfirmed success code=%d err=%v", got, err)
 					}
@@ -746,16 +746,16 @@ func TestBlacksmithArtifactCollectionTimeoutReceipt(t *testing.T) {
 				// the failed collector finalized an otherwise valid archive.
 				synctest.Test(t, func(t *testing.T) {
 					runs := 0
-					runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+					runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 						runs++
 						start, workloadExit, end := testBlacksmithReceiptFrames(t, syntheticBlacksmithCommand(t, req), code)
 						payload, _ := testBlacksmithArtifactMetadata(t, req, archive)
 						fmt.Fprint(req.Stdout, start+workloadExit+payload+strings.Replace(end, "end:0", "end:124", 1))
-						return LocalCommandResult{}, nil
+						return core.LocalCommandResult{}, nil
 					}}
-					backend := newTestBlacksmithBackend(baseConfig(), runner)
-					req := RunRequest{ID: id, Repo: Repo{Root: repo}, Command: []string{fmt.Sprintf("exit %d", code)}, ArtifactGlobs: []string{"report"}}
-					var ee ExitError
+					backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
+					req := core.RunRequest{ID: id, Repo: core.Repo{Root: repo}, Command: []string{fmt.Sprintf("exit %d", code)}, ArtifactGlobs: []string{"report"}}
+					var ee core.ExitError
 					if boundary == "helper" {
 						got, ended, collected, err := backend.runArtifactTestbox(t.Context(), req, id, nil, nil, nil, 100*time.Millisecond)
 						if got != code || ended.IsZero() || !errors.As(err, &ee) || ee.Code != 7 || ee.Message != "collection exited 124" || len(collected) != 0 {
@@ -796,7 +796,7 @@ func TestBlacksmithArtifactRunInitialSourceAndTiming(t *testing.T) {
 	prepareBlacksmithGuestKey(t, id)
 	testOwnedBlacksmithClaim(t, id, "jade-krill", repo)
 	runs := 0
-	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		runs++
 		// A second synthetic native sync would overwrite this workload file.
 		testWriteBlacksmithFile(t, req.Dir, "report", "local-sync-bytes")
@@ -807,8 +807,8 @@ func TestBlacksmithArtifactRunInitialSourceAndTiming(t *testing.T) {
 		}
 		return runSyntheticBlacksmithCommand(t, t.Context(), req)
 	}}
-	backend := newTestBlacksmithBackend(baseConfig(), runner)
-	result, err := backend.Run(t.Context(), RunRequest{ID: id, Repo: Repo{Root: repo}, Command: []string{"printf workload-bytes > report"}, ArtifactGlobs: []string{"report"}})
+	backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
+	result, err := backend.Run(t.Context(), core.RunRequest{ID: id, Repo: core.Repo{Root: repo}, Command: []string{"printf workload-bytes > report"}, ArtifactGlobs: []string{"report"}})
 	if err != nil || runs != 1 || len(result.Artifacts) != 1 {
 		t.Fatalf("result=%+v runs=%d err=%v", result, runs, err)
 	}
@@ -837,12 +837,12 @@ func TestBlacksmithArtifactRunProtectedAndRequiredPaths(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			runner := artifactTestRunner(t, func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+			runner := artifactTestRunner(t, func(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				return runSyntheticBlacksmithCommand(t, ctx, req)
 			})
-			backend := newTestBlacksmithBackend(baseConfig(), runner)
+			backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
 			prepareBlacksmithGuestKey(t, "tbx_protected")
-			_, _, result, err := backend.runArtifactTestbox(t.Context(), RunRequest{Repo: Repo{Root: repo}, Command: []string{"true"}, ArtifactGlobs: []string{"**"}, RequiredArtifactGlobs: []string{required}}, "tbx_protected", nil, nil, nil, time.Second)
+			_, _, result, err := backend.runArtifactTestbox(t.Context(), core.RunRequest{Repo: core.Repo{Root: repo}, Command: []string{"true"}, ArtifactGlobs: []string{"**"}, RequiredArtifactGlobs: []string{required}}, "tbx_protected", nil, nil, nil, time.Second)
 			if required != "report" {
 				if err == nil || len(result) != 0 {
 					t.Fatal("required path bypassed")
@@ -878,8 +878,8 @@ func TestBlacksmithArtifactRunClaimFence(t *testing.T) {
 			entered, release, stopped := make(chan struct{}), make(chan struct{}), make(chan struct{})
 			archive := makeTarGz(t, map[string]string{"report": "synthetic"})
 			var publishedPath string
-			cfg := baseConfig()
-			backend := newTestBlacksmithBackend(cfg, artifactTestRunner(t, func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+			cfg := core.BaseConfig()
+			backend := newTestBlacksmithBackend(cfg, artifactTestRunner(t, func(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				switch req.Args[1] {
 				case "status":
 					state := "ready"
@@ -888,10 +888,10 @@ func TestBlacksmithArtifactRunClaimFence(t *testing.T) {
 						state = "completed"
 					default:
 					}
-					return LocalCommandResult{Stdout: testBlacksmithStatus(id, state)}, nil
+					return core.LocalCommandResult{Stdout: testBlacksmithStatus(id, state)}, nil
 				case "stop":
 					close(stopped)
-					return LocalCommandResult{}, nil
+					return core.LocalCommandResult{}, nil
 				case "run":
 					start, exit, end := testBlacksmithReceiptFrames(t, syntheticBlacksmithCommand(t, req), 23)
 					metadata, archivePath := testBlacksmithArtifactMetadata(t, req, archive)
@@ -902,15 +902,15 @@ func TestBlacksmithArtifactRunClaimFence(t *testing.T) {
 					select {
 					case <-release:
 					case <-stopped:
-						return LocalCommandResult{ExitCode: 1}, errors.New("stopped transport")
+						return core.LocalCommandResult{ExitCode: 1}, errors.New("stopped transport")
 					case <-ctx.Done():
-						return LocalCommandResult{ExitCode: 1}, ctx.Err()
+						return core.LocalCommandResult{ExitCode: 1}, ctx.Err()
 					}
 					fmt.Fprint(req.Stdout, metadata+end)
-					return LocalCommandResult{}, nil
+					return core.LocalCommandResult{}, nil
 				}
 				t.Errorf("unexpected native action %s", req.Args[1])
-				return LocalCommandResult{}, errors.New("unexpected")
+				return core.LocalCommandResult{}, errors.New("unexpected")
 			}))
 			backend.route, backend.claim = &route, &claim
 			ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
@@ -929,7 +929,7 @@ func TestBlacksmithArtifactRunClaimFence(t *testing.T) {
 			done := make(chan error, 1)
 			go func() {
 				done <- backend.withOwnedTestbox(ctx, claim, func() error {
-					code, _, result, err := backend.runArtifactTestbox(ctx, RunRequest{Repo: Repo{Root: repo}, Command: []string{"exit 23"}, ArtifactGlobs: []string{"report"}}, id, nil, nil, nil, time.Second)
+					code, _, result, err := backend.runArtifactTestbox(ctx, core.RunRequest{Repo: core.Repo{Root: repo}, Command: []string{"exit 23"}, ArtifactGlobs: []string{"report"}}, id, nil, nil, nil, time.Second)
 					if code != 23 || (mode == "writer" && (err != nil || len(result) != 1)) || (mode == "stop" && (err == nil || len(result) != 0)) {
 						return fmt.Errorf("code=%d artifact count=%d err=%v", code, len(result), err)
 					}
@@ -986,15 +986,15 @@ func TestBlacksmithArtifactFailureCleanupAndClassification(t *testing.T) {
 				t.Chdir(repo)
 				testWriteBlacksmithFile(t, repo, "report", "synthetic")
 				const id = "tbx_failureprecedence"
-				runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+				runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 					switch req.Args[1] {
 					case "warmup":
-						return LocalCommandResult{Stdout: id + "\n"}, nil
+						return core.LocalCommandResult{Stdout: id + "\n"}, nil
 					case "stop":
 						if mode == "lease-cleanup" {
-							return LocalCommandResult{ExitCode: 49}, errors.New("synthetic cleanup failure")
+							return core.LocalCommandResult{ExitCode: 49}, errors.New("synthetic cleanup failure")
 						}
-						return LocalCommandResult{}, nil
+						return core.LocalCommandResult{}, nil
 					case "run":
 						for i, arg := range req.Args {
 							if strings.HasPrefix(arg, "/bin/sh -c ") {
@@ -1010,14 +1010,14 @@ func TestBlacksmithArtifactFailureCleanupAndClassification(t *testing.T) {
 						}
 						return runSyntheticBlacksmithCommand(t, t.Context(), req)
 					}
-					return LocalCommandResult{}, nil
+					return core.LocalCommandResult{}, nil
 				}}
-				cfg := baseConfig()
+				cfg := core.BaseConfig()
 				cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 				backend := newTestBlacksmithBackend(cfg, runner)
 				var stderr bytes.Buffer
 				backend.rt.Stderr = &stderr
-				result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Root: repo}, Command: []string{fmt.Sprintf("printf 'CRABBOX_PHASE:test\\n'; exit %d", code)}, ArtifactGlobs: []string{"report"}, TimingJSON: true})
+				result, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: repo}, Command: []string{fmt.Sprintf("printf 'CRABBOX_PHASE:test\\n'; exit %d", code)}, ArtifactGlobs: []string{"report"}, TimingJSON: true})
 				want := code
 				if code == 0 {
 					want = 7
@@ -1025,7 +1025,7 @@ func TestBlacksmithArtifactFailureCleanupAndClassification(t *testing.T) {
 						want = 1
 					}
 				}
-				var ee ExitError
+				var ee core.ExitError
 				if !errors.As(err, &ee) || ee.Code != want || result.ExitCode != want {
 					t.Fatalf("result=%+v err=%v", result, err)
 				}
@@ -1075,7 +1075,7 @@ func TestBlacksmithArtifactReceiptEverySplit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	start, exit, end := testBlacksmithReceiptFrames(t, r.command(RunRequest{Command: []string{"true"}}, time.Second), 23)
+	start, exit, end := testBlacksmithReceiptFrames(t, r.command(core.RunRequest{Command: []string{"true"}}, time.Second), 23)
 	prefix := strings.TrimSuffix(start, "start\x1f")
 	metadata := prefix + "bytes:1\x1f" + prefix + "digest0:" + strings.Repeat("a", 32) + "\x1f" + prefix + "digest1:" + strings.Repeat("b", 32) + "\x1f"
 	wire := "before" + start + "during" + exit + "private" + metadata + end

--- a/internal/providers/blacksmith/artifact_run_test_support_test.go
+++ b/internal/providers/blacksmith/artifact_run_test_support_test.go
@@ -56,74 +56,74 @@ func prepareBlacksmithGuestKey(t *testing.T, id string) {
 
 // Intercept only capability discovery and the bounded download argv. Never run
 // either native binary, and preserve the exclusively precreated destination.
-func testBlacksmithArtifactTransfer(req LocalCommandRequest) (bool, LocalCommandResult, error) {
+func testBlacksmithArtifactTransfer(req core.LocalCommandRequest) (bool, core.LocalCommandResult, error) {
 	if req.Name == "blacksmith" && len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "download" && req.Args[2] == "--help" {
 		for i := 3; i < len(req.Args); i += 2 {
 			if i+1 >= len(req.Args) || (req.Args[i] != "--api-url" && req.Args[i] != "--org") {
-				return true, LocalCommandResult{}, errors.New("unexpected download capability arguments")
+				return true, core.LocalCommandResult{}, errors.New("unexpected download capability arguments")
 			}
 		}
-		return true, LocalCommandResult{Stdout: "testbox download --id <id> [--ssh-private-key <path>] <remote> <local>\n"}, nil
+		return true, core.LocalCommandResult{Stdout: "testbox download --id <id> [--ssh-private-key <path>] <remote> <local>\n"}, nil
 	}
 	if req.Name != "/bin/sh" || len(req.Args) < 3 || req.Args[2] != "blacksmith-artifact-download" {
-		return false, LocalCommandResult{}, nil
+		return false, core.LocalCommandResult{}, nil
 	}
 	if len(req.Args) < 11 || req.Args[0] != "-c" {
-		return true, LocalCommandResult{}, errors.New("invalid bounded download invocation")
+		return true, core.LocalCommandResult{}, errors.New("invalid bounded download invocation")
 	}
 	args := req.Args[5:]
 	if len(args) >= 2 && args[0] == "--org" {
 		args = args[2:]
 	}
 	if len(args) < 6 || args[0] != "testbox" || args[1] != "download" || args[2] != "--id" || args[3] == "" {
-		return true, LocalCommandResult{}, errors.New("unexpected native download arguments")
+		return true, core.LocalCommandResult{}, errors.New("unexpected native download arguments")
 	}
 	for i := 4; i < len(args)-2; i += 2 {
 		if i+1 >= len(args)-2 || (args[i] != "--ssh-private-key" && args[i] != "--api-url" && args[i] != "--org") {
-			return true, LocalCommandResult{}, errors.New("unexpected native download option")
+			return true, core.LocalCommandResult{}, errors.New("unexpected native download option")
 		}
 	}
 	remote, destination := args[len(args)-2], args[len(args)-1]
 	stage := filepath.Dir(destination)
 	if !regexp.MustCompile(`^\.crabbox/blacksmith-artifact-[0-9a-f]{64}/archive\.tgz$`).MatchString(remote) || !filepath.IsAbs(destination) || destination != filepath.Join(stage, "archive.tgz") || stage == req.Dir || !strings.HasPrefix(filepath.Base(stage), "crabbox-artifact-download-") {
-		return true, LocalCommandResult{}, errors.New("unexpected native artifact source or destination")
+		return true, core.LocalCommandResult{}, errors.New("unexpected native artifact source or destination")
 	}
 	stageInfo, err := os.Lstat(stage)
 	if err != nil || !stageInfo.IsDir() || stageInfo.Mode().Perm() != 0o700 {
-		return true, LocalCommandResult{}, errors.New("native artifact stage is not a private real directory")
+		return true, core.LocalCommandResult{}, errors.New("native artifact stage is not a private real directory")
 	}
 	if !filepath.IsAbs(req.Dir) || !containsString(req.Env, "PATH="+filepath.Join(stage, "bin")+":/usr/bin:/bin") {
-		return true, LocalCommandResult{}, errors.New("native artifact command lost original cwd or private helper resolution")
+		return true, core.LocalCommandResult{}, errors.New("native artifact command lost original cwd or private helper resolution")
 	}
 	cwd, err := filepath.EvalSymlinks(req.Dir)
 	if err != nil {
-		return true, LocalCommandResult{}, err
+		return true, core.LocalCommandResult{}, err
 	}
 	source := filepath.Join(cwd, filepath.FromSlash(remote))
 	resolved, err := filepath.EvalSymlinks(source)
 	if err != nil || resolved != source {
-		return true, LocalCommandResult{}, errors.New("synthetic artifact source is missing or redirected")
+		return true, core.LocalCommandResult{}, errors.New("synthetic artifact source is missing or redirected")
 	}
 	info, err := os.Lstat(destination)
 	if err != nil || !info.Mode().IsRegular() || info.Size() != 0 || info.Mode().Perm() != 0o600 {
-		return true, LocalCommandResult{}, errors.New("native download destination was not privately precreated")
+		return true, core.LocalCommandResult{}, errors.New("native download destination was not privately precreated")
 	}
 	in, err := os.Open(source)
 	if err != nil {
-		return true, LocalCommandResult{}, err
+		return true, core.LocalCommandResult{}, err
 	}
 	defer in.Close()
 	out, err := os.OpenFile(destination, os.O_WRONLY|os.O_TRUNC, 0)
 	if err != nil {
-		return true, LocalCommandResult{}, err
+		return true, core.LocalCommandResult{}, err
 	}
 	_, copyErr := io.Copy(out, io.LimitReader(in, core.DelegatedRunArtifactDefaultMaxBytes+1))
-	return true, LocalCommandResult{}, errors.Join(copyErr, out.Close())
+	return true, core.LocalCommandResult{}, errors.Join(copyErr, out.Close())
 }
 
 func artifactTestRunner(t *testing.T, fn ownershipRunner) ownershipRunner {
 	t.Helper()
-	return func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	return func(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if handled, result, err := testBlacksmithArtifactTransfer(req); handled {
 			return result, err
 		}
@@ -131,7 +131,7 @@ func artifactTestRunner(t *testing.T, fn ownershipRunner) ownershipRunner {
 	}
 }
 
-func testBlacksmithArtifactMetadata(t *testing.T, req LocalCommandRequest, archive []byte) (metadata, archivePath string) {
+func testBlacksmithArtifactMetadata(t *testing.T, req core.LocalCommandRequest, archive []byte) (metadata, archivePath string) {
 	t.Helper()
 	start, _, _ := testBlacksmithReceiptFrames(t, syntheticBlacksmithCommand(t, req), 0)
 	prefix := strings.TrimSuffix(start, "start\x1f")

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -21,35 +21,13 @@ import (
 	"github.com/openclaw/crabbox/internal/tailbuffer"
 )
 
-type Config = core.Config
-type ProviderSpec = core.ProviderSpec
-type Runtime = core.Runtime
-type Backend = core.Backend
-type BlacksmithConfig = core.BlacksmithConfig
-type WarmupRequest = core.WarmupRequest
-type RunRequest = core.RunRequest
-type RunResult = core.RunResult
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type StatusRequest = core.StatusRequest
-type StatusView = core.StatusView
-type StopRequest = core.StopRequest
-type Server = core.Server
-type Repo = core.Repo
-type ExitError = core.ExitError
-type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
-type CommandRunner = core.CommandRunner
-type timingReport = core.TimingReport
-type timingPhase = core.TimingPhase
-
 const targetLinux = core.TargetLinux
 
-func RegisterBlacksmithProviderFlags(fs *flag.FlagSet, defaults Config) any {
+func RegisterBlacksmithProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterBlacksmithConfigFlags(fs, defaults.Blacksmith)
 }
 
-func ApplyBlacksmithProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+func ApplyBlacksmithProviderFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if v, ok := values.(core.BlacksmithConfigFlagValues); ok {
 		applied, err := v.Apply(&cfg.Blacksmith, fs)
 		core.RecordProviderFlagInputs(cfg, applied.InputAccepted, "blacksmith-testbox")
@@ -58,26 +36,26 @@ func ApplyBlacksmithProviderFlags(cfg *Config, fs *flag.FlagSet, values any) err
 	return nil
 }
 
-func NewBlacksmithBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewBlacksmithBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = blacksmithTestboxProvider
 	return &blacksmithBackend{spec: spec, cfg: cfg, rt: rt}
 }
 
 type blacksmithBackend struct {
-	spec  ProviderSpec
-	cfg   Config
-	rt    Runtime
+	spec  core.ProviderSpec
+	cfg   core.Config
+	rt    core.Runtime
 	route *blacksmithRoute
 	claim *core.LeaseClaim
 }
 
 var _ core.RunOptionsValidator = (*blacksmithBackend)(nil)
 
-func (b *blacksmithBackend) Spec() ProviderSpec { return b.spec }
+func (b *blacksmithBackend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *blacksmithBackend) Warmup(ctx context.Context, req WarmupRequest) error {
+func (b *blacksmithBackend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 	if req.ActionsRunner {
-		return exit(2, "--actions-runner is not supported for provider=%s; Blacksmith owns runner hydration", b.cfg.Provider)
+		return core.Exit(2, "--actions-runner is not supported for provider=%s; Blacksmith owns runner hydration", b.cfg.Provider)
 	}
 	started := b.rt.Clock.Now()
 	claim, err := b.warmupLease(ctx, req.Repo, req.Reclaim, req.RequestedSlug)
@@ -101,11 +79,11 @@ func (b *blacksmithBackend) Warmup(ctx context.Context, req WarmupRequest) error
 	})
 }
 
-func (b *blacksmithBackend) ValidateRunOptions(req RunRequest) error {
+func (b *blacksmithBackend) ValidateRunOptions(req core.RunRequest) error {
 	return validateBlacksmithRunOptions(b.spec, req)
 }
 
-func validateBlacksmithRunOptions(spec ProviderSpec, req RunRequest) error {
+func validateBlacksmithRunOptions(spec core.ProviderSpec, req core.RunRequest) error {
 	if req.NoSync {
 		return core.Exit(2, "%s delegates sync; --no-sync is not supported", blacksmithTestboxProvider)
 	}
@@ -117,32 +95,32 @@ func validateBlacksmithRunOptions(spec ProviderSpec, req RunRequest) error {
 	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
 }
 
-func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult RunResult, runErr error) {
+func (b *blacksmithBackend) Run(ctx context.Context, req core.RunRequest) (runResult core.RunResult, runErr error) {
 	if err := b.ValidateRunOptions(req); err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	if err := validateBlacksmithNativeSyncScope(req.Repo.Root); err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	if len(req.ArtifactGlobs) == 0 && len(req.RequiredArtifactGlobs) == 0 {
 		if err := validateBlacksmithNativeSyncScope(""); err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 	}
 	if err := core.ValidateRunArtifactGlobs(req.ArtifactGlobs); err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	if err := core.ValidateRequiredRunArtifactGlobs(req.RequiredArtifactGlobs); err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	if blacksmithEnvForwardingRequested(req) {
 		core.PrintEnvForwardingSummary(b.rt.Stderr, blacksmithTestboxProvider, "unsupported", req.Options.EnvAllow, req.Env)
 		fmt.Fprintf(b.rt.Stderr, "env forwarding note=blacksmith-testbox delegates execution to the Blacksmith CLI; configure secrets in the Testbox workflow instead\n")
-		return RunResult{}, core.Exit(2, "env forwarding is unsupported for provider=%s; configure secrets in the provider workflow or use an SSH-backed provider", blacksmithTestboxProvider)
+		return core.RunResult{}, core.Exit(2, "env forwarding is unsupported for provider=%s; configure secrets in the provider workflow or use an SSH-backed provider", blacksmithTestboxProvider)
 	}
 	hiddenOmissions, sparseErr := core.GitCheckoutHasHiddenOmissions(req.Repo.Root)
 	if sparseErr != nil {
-		return RunResult{}, core.Exit(
+		return core.RunResult{}, core.Exit(
 			2,
 			"provider=%s cannot verify sparse-checkout safety: %v; run from a materialized full checkout",
 			blacksmithTestboxProvider,
@@ -150,7 +128,7 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 		)
 	}
 	if hiddenOmissions {
-		return RunResult{}, core.Exit(
+		return core.RunResult{}, core.Exit(
 			2,
 			"provider=%s cannot safely delegate sync while Git omits tracked paths from the working tree; run from a materialized full checkout",
 			blacksmithTestboxProvider,
@@ -163,7 +141,7 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 	if req.ID == "" {
 		claim, err = b.warmupLease(ctx, req.Repo, req.Reclaim, req.RequestedSlug)
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 		route, _, _ := blacksmithClaimBinding(claim)
 		bound := *b
@@ -173,7 +151,7 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 	} else {
 		b, claim, err = b.ownedTestbox(ctx, req.ID, req.Repo.Root, req.Reclaim)
 		if err != nil {
-			return RunResult{}, err
+			return core.RunResult{}, err
 		}
 	}
 	leaseID, slug := claim.LeaseID, claim.Slug
@@ -203,7 +181,7 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 			if runErr == nil {
 				runResult.ExitCode = 1
 				runResult.ErrorKind = core.RunErrorProvider
-				runErr = exit(1, "Blacksmith cleanup unconfirmed; retained lease %s: %v", leaseID, err)
+				runErr = core.Exit(1, "Blacksmith cleanup unconfirmed; retained lease %s: %v", leaseID, err)
 			}
 		}
 	}()
@@ -214,12 +192,12 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 	}
 	stdoutCapture, stdoutCapturePath, stdoutCleanup, err := b.openFailureStreamCapture("stdout")
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	defer stdoutCleanup()
 	stderrCapture, stderrCapturePath, stderrCleanup, err := b.openFailureStreamCapture("stderr")
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	defer stderrCleanup()
 	stdoutProof := newBlacksmithProofTailBuffer()
@@ -250,7 +228,7 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 		)
 		return nil
 	}); err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	// Artifact diagnostics must not reclassify an earlier workload failure.
 	artifactFailedSuccess := artifactErr != nil && code == 0
@@ -261,10 +239,10 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 		}
 	}
 	if closeErr := stdoutCapture.Close(); closeErr != nil && code == 0 {
-		return RunResult{}, core.Exit(2, "blacksmith failure bundle stdout close: %v", closeErr)
+		return core.RunResult{}, core.Exit(2, "blacksmith failure bundle stdout close: %v", closeErr)
 	}
 	if closeErr := stderrCapture.Close(); closeErr != nil && code == 0 {
-		return RunResult{}, core.Exit(2, "blacksmith failure bundle stderr close: %v", closeErr)
+		return core.RunResult{}, core.Exit(2, "blacksmith failure bundle stderr close: %v", closeErr)
 	}
 	finished := b.rt.Clock.Now()
 	if commandEnd.IsZero() {
@@ -274,7 +252,7 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 	commandPhases := core.FinishCommandPhaseTracker(phaseTracker, commandEnd)
 	total := finished.Sub(started)
 	actionsURL := firstNonBlank(stdoutProof.ActionsURL(), stderrProof.ActionsURL())
-	result := RunResult{
+	result := core.RunResult{
 		Provider:      blacksmithTestboxProvider,
 		LeaseID:       leaseID,
 		Slug:          slug,
@@ -322,13 +300,13 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 	fmt.Fprintf(b.rt.Stderr, "blacksmith run summary sync=delegated command=%s total=%s exit=%d%s\n", commandDuration.Round(time.Millisecond), total.Round(time.Millisecond), code, core.FormatFailureClassificationFields(core.FailureClassification{BlockedStage: report.BlockedStage, RetryLikely: report.RetryLikely}))
 	report.Label = strings.TrimSpace(req.Label)
 	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, report); err != nil {
-			return RunResult{}, err
+		if err := core.WriteTimingJSON(b.rt.Stderr, report); err != nil {
+			return core.RunResult{}, err
 		}
 	}
 	proof, proofErr := b.blacksmithProofResult(req, leaseID, slug, code, commandDuration, total, report, stdoutProof.Bytes(), stderrProof.Bytes(), actionsURL)
 	if proofErr != nil && code == 0 {
-		return RunResult{}, proofErr
+		return core.RunResult{}, proofErr
 	}
 	if proofErr == nil {
 		result.Provider = proof.Provider
@@ -370,7 +348,7 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 		}
 		core.HandleDelegatedRunFailure(b.rt.Stderr, req, blacksmithTestboxProvider, leaseID, slug, blacksmithIdleTimeout(b.cfg), b.cfg.TTL, acquired, &shouldStop)
 		result.Session.Kept = !shouldStop
-		return result, ExitError{Code: code, Message: fmt.Sprintf("blacksmith testbox run exited %d", code)}
+		return result, core.ExitError{Code: code, Message: fmt.Sprintf("blacksmith testbox run exited %d", code)}
 	}
 	return result, nil
 }
@@ -388,7 +366,7 @@ func printBlacksmithOneShotActionsWarning(w io.Writer, actionsURL string) {
 
 var githubActionsRunURLPattern = regexp.MustCompile(`https://github\.com/[^\s"'<>]+/actions/runs/[0-9]+[^\s"'<>]*`)
 
-func blacksmithEnvForwardingRequested(req RunRequest) bool {
+func blacksmithEnvForwardingRequested(req core.RunRequest) bool {
 	return req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != ""
 }
 
@@ -451,9 +429,9 @@ func (b *blacksmithProofTailBuffer) ActionsURL() string {
 	return b.actionsURL
 }
 
-func (b *blacksmithBackend) blacksmithProofResult(req RunRequest, leaseID, slug string, exitCode int, commandDuration, total time.Duration, report timingReport, stdoutData, stderrData []byte, actionsURL string) (RunResult, error) {
+func (b *blacksmithBackend) blacksmithProofResult(req core.RunRequest, leaseID, slug string, exitCode int, commandDuration, total time.Duration, report core.TimingReport, stdoutData, stderrData []byte, actionsURL string) (core.RunResult, error) {
 	combined := strings.TrimSpace(string(stdoutData) + "\n" + string(stderrData))
-	result := RunResult{
+	result := core.RunResult{
 		Provider:    blacksmithTestboxProvider,
 		LeaseID:     leaseID,
 		Slug:        slug,
@@ -466,7 +444,7 @@ func (b *blacksmithBackend) blacksmithProofResult(req RunRequest, leaseID, slug 
 	}
 	artifacts, err := persistBlacksmithRunArtifacts(req.Repo.Root, leaseID, exitCode, commandDuration, total, report, stdoutData, stderrData, result)
 	if err != nil {
-		return RunResult{}, err
+		return core.RunResult{}, err
 	}
 	result.Artifacts = artifacts
 	return result, nil
@@ -521,7 +499,7 @@ func blacksmithActionsRunID(actionsURL string) string {
 	return ""
 }
 
-func persistBlacksmithRunArtifacts(repoRoot, leaseID string, exitCode int, commandDuration, total time.Duration, report timingReport, stdoutData, stderrData []byte, result RunResult) ([]core.RunArtifact, error) {
+func persistBlacksmithRunArtifacts(repoRoot, leaseID string, exitCode int, commandDuration, total time.Duration, report core.TimingReport, stdoutData, stderrData []byte, result core.RunResult) ([]core.RunArtifact, error) {
 	metadata := map[string]any{
 		"provider":      blacksmithTestboxProvider,
 		"leaseId":       leaseID,
@@ -564,20 +542,20 @@ func persistBlacksmithRunArtifacts(repoRoot, leaseID string, exitCode int, comma
 	return artifacts, nil
 }
 
-func (b *blacksmithBackend) List(ctx context.Context, req ListRequest) ([]Server, error) {
+func (b *blacksmithBackend) List(ctx context.Context, req core.ListRequest) ([]core.Server, error) {
 	out, err := b.commandOutput(ctx, b.listArgs(req))
 	if err != nil {
 		return nil, err
 	}
 	items := parseBlacksmithList(out)
-	servers := make([]Server, 0, len(items))
+	servers := make([]core.Server, 0, len(items))
 	for _, item := range items {
 		servers = append(servers, blacksmithItemToServer(item))
 	}
 	return servers, nil
 }
 
-func (b *blacksmithBackend) ListJSON(ctx context.Context, req ListRequest) (any, error) {
+func (b *blacksmithBackend) ListJSON(ctx context.Context, req core.ListRequest) (any, error) {
 	out, err := b.commandOutput(ctx, b.listArgs(req))
 	if err != nil {
 		return nil, err
@@ -586,7 +564,7 @@ func (b *blacksmithBackend) ListJSON(ctx context.Context, req ListRequest) (any,
 }
 
 func (b *blacksmithBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
-	servers, err := b.List(ctx, ListRequest{All: true})
+	servers, err := b.List(ctx, core.ListRequest{All: true})
 	if err != nil {
 		return core.DoctorResult{}, err
 	}
@@ -611,12 +589,12 @@ func (b *blacksmithBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (c
 	}, nil
 }
 
-func delegatedTimingReport(provider, leaseID, slug, syncReason string, commandDuration time.Duration, commandPhases []timingPhase, total time.Duration, exitCode int) timingReport {
-	return timingReport{
+func delegatedTimingReport(provider, leaseID, slug, syncReason string, commandDuration time.Duration, commandPhases []core.TimingPhase, total time.Duration, exitCode int) core.TimingReport {
+	return core.TimingReport{
 		Provider:      provider,
 		LeaseID:       leaseID,
 		Slug:          slug,
-		SyncPhases:    []timingPhase{{Name: "delegated", Skipped: true, Reason: syncReason}},
+		SyncPhases:    []core.TimingPhase{{Name: "delegated", Skipped: true, Reason: syncReason}},
 		SyncDelegated: true,
 		CommandMs:     commandDuration.Milliseconds(),
 		CommandPhases: commandPhases,
@@ -625,38 +603,38 @@ func delegatedTimingReport(provider, leaseID, slug, syncReason string, commandDu
 	}
 }
 
-func (b *blacksmithBackend) listArgs(req ListRequest) []string {
+func (b *blacksmithBackend) listArgs(req core.ListRequest) []string {
 	if req.All {
 		return blacksmithListAllArgs(b.cfg)
 	}
 	return blacksmithListArgs(b.cfg)
 }
 
-func (b *blacksmithBackend) Status(ctx context.Context, req StatusRequest) (statusView, error) {
+func (b *blacksmithBackend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
 	leaseID, err := resolveBlacksmithDiscoveryID(req.ID)
 	if err != nil {
-		return statusView{}, err
+		return core.StatusView{}, err
 	}
 	deadline := b.rt.Clock.Now().Add(req.WaitTimeout)
-	var lastState statusView
+	var lastState core.StatusView
 	for {
 		state, err := b.blacksmithStatusView(ctx, leaseID)
 		if err != nil {
-			return statusView{}, err
+			return core.StatusView{}, err
 		}
 		lastState = state
 		if !req.Wait || state.Ready {
 			return state, nil
 		}
 		if b.rt.Clock.Now().After(deadline) {
-			return statusView{}, exit(5, "%s", blacksmithWaitTimeoutMessage(req.ID, lastState.State))
+			return core.StatusView{}, core.Exit(5, "%s", blacksmithWaitTimeoutMessage(req.ID, lastState.State))
 		}
 		delay := blacksmithStatusPollDelay
 		if remaining := deadline.Sub(b.rt.Clock.Now()); remaining < delay {
 			delay = remaining
 		}
 		if delay <= 0 {
-			return statusView{}, exit(5, "%s", blacksmithWaitTimeoutMessage(req.ID, lastState.State))
+			return core.StatusView{}, core.Exit(5, "%s", blacksmithWaitTimeoutMessage(req.ID, lastState.State))
 		}
 		timer := time.NewTimer(delay)
 		select {
@@ -667,13 +645,13 @@ func (b *blacksmithBackend) Status(ctx context.Context, req StatusRequest) (stat
 				default:
 				}
 			}
-			return statusView{}, context.Cause(ctx)
+			return core.StatusView{}, context.Cause(ctx)
 		case <-timer.C:
 		}
 	}
 }
 
-func (b *blacksmithBackend) Stop(ctx context.Context, req StopRequest) error {
+func (b *blacksmithBackend) Stop(ctx context.Context, req core.StopRequest) error {
 	claim, err := resolveOwnedBlacksmithClaim(req.ID)
 	if err != nil {
 		return err
@@ -688,7 +666,7 @@ func (b *blacksmithBackend) stopClaimedTestbox(ctx context.Context, leaseID stri
 		return err
 	}
 	if claim.LeaseID != leaseID {
-		return exit(2, "Blacksmith exact claim identifier mismatch")
+		return core.Exit(2, "Blacksmith exact claim identifier mismatch")
 	}
 	ctx, cancel := context.WithTimeout(ctx, blacksmithCleanupTimeout)
 	defer cancel()
@@ -714,7 +692,7 @@ func (b *blacksmithBackend) stopClaimedTestbox(ctx context.Context, leaseID stri
 			return err
 		}
 		if !identity.terminal() {
-			return exit(2, "Blacksmith termination is not confirmed; retaining claim and key")
+			return core.Exit(2, "Blacksmith termination is not confirmed; retaining claim and key")
 		}
 		if err := core.RemoveStoredTestboxConnectionArtifacts(leaseID); err != nil {
 			return fmt.Errorf("Blacksmith local connection artifacts cleanup failed; retaining claim: %w", err)
@@ -731,9 +709,9 @@ func (b *blacksmithBackend) stopClaimedTestbox(ctx context.Context, leaseID stri
 	return err
 }
 
-func (b *blacksmithBackend) warmupLease(ctx context.Context, repo Repo, reclaim bool, requestedSlug string) (core.LeaseClaim, error) {
+func (b *blacksmithBackend) warmupLease(ctx context.Context, repo core.Repo, reclaim bool, requestedSlug string) (core.LeaseClaim, error) {
 	if repo.Root == "" {
-		return core.LeaseClaim{}, exit(2, "Blacksmith acquisition requires a repository owner")
+		return core.LeaseClaim{}, core.Exit(2, "Blacksmith acquisition requires a repository owner")
 	}
 	bound, err := b.withRoute(ctx)
 	if err != nil {
@@ -741,13 +719,13 @@ func (b *blacksmithBackend) warmupLease(ctx context.Context, repo Repo, reclaim 
 	}
 	b = bound
 	pendingID := "tbx_pending_" + strings.TrimPrefix(core.NewLeaseID(), "cbx_")
-	_, publicKey, err := ensureTestboxKey(pendingID)
+	_, publicKey, err := core.EnsureTestboxKey(pendingID)
 	if err != nil {
 		return core.LeaseClaim{}, err
 	}
 	args, err := blacksmithWarmupArgs(b.cfg, publicKey)
 	if err != nil {
-		removeStoredTestboxKey(pendingID)
+		core.RemoveStoredTestboxKey(pendingID)
 		return core.LeaseClaim{}, err
 	}
 	result, warmupErr := b.runCommand(ctx, args, b.rt.Stdout, b.rt.Stderr)
@@ -759,13 +737,13 @@ func (b *blacksmithBackend) warmupLease(ctx context.Context, repo Repo, reclaim 
 	if leaseID == "" {
 		// Allocation may have succeeded even when its receipt cannot be trusted.
 		// Keep the invocation's recovery key without granting resource authority.
-		return core.LeaseClaim{}, exit(failureCode, "Blacksmith warmup returned no unambiguous creation receipt; retained pending_key=%s for native recovery; inspect Blacksmith inventory; no resource was selected for rollback: %v", pendingID, warmupErr)
+		return core.LeaseClaim{}, core.Exit(failureCode, "Blacksmith warmup returned no unambiguous creation receipt; retained pending_key=%s for native recovery; inspect Blacksmith inventory; no resource was selected for rollback: %v", pendingID, warmupErr)
 	}
 	if warmupErr != nil {
 		b.rollbackTestbox(leaseID, pendingID, repo.Root)
-		return core.LeaseClaim{}, exit(failureCode, "blacksmith testbox warmup failed: %v; inspect the exact receipt %s or use another provider", warmupErr, leaseID)
+		return core.LeaseClaim{}, core.Exit(failureCode, "blacksmith testbox warmup failed: %v; inspect the exact receipt %s or use another provider", warmupErr, leaseID)
 	}
-	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
+	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		b.rollbackTestbox(leaseID, pendingID, repo.Root)
 		return core.LeaseClaim{}, err
@@ -778,7 +756,7 @@ func (b *blacksmithBackend) warmupLease(ctx context.Context, repo Repo, reclaim 
 	var published core.LeaseClaim
 	err = core.WithDurableLeaseClaimLockContext(ctx, leaseID, func(current *core.LeaseClaim, exists bool, checkpoint func() error) error {
 		if exists {
-			return exit(2, "Blacksmith acquisition conflicts with existing claim; retaining resource")
+			return core.Exit(2, "Blacksmith acquisition conflicts with existing claim; retaining resource")
 		}
 		identity, err = b.inspectTestbox(ctx, leaseID)
 		if err != nil {
@@ -879,24 +857,24 @@ func mergeWriters(writers ...io.Writer) io.Writer {
 func (b *blacksmithBackend) commandOutput(ctx context.Context, args []string) (string, error) {
 	result, err := b.runCommand(ctx, args, nil, nil)
 	if err != nil {
-		return "", ExitError{Code: result.ExitCode, Message: fmt.Sprintf("blacksmith failed: %v: %s", err, strings.TrimSpace(result.Stdout+result.Stderr))}
+		return "", core.ExitError{Code: result.ExitCode, Message: fmt.Sprintf("blacksmith failed: %v: %s", err, strings.TrimSpace(result.Stdout+result.Stderr))}
 	}
 	return result.Stdout + result.Stderr, nil
 }
 
-func (b *blacksmithBackend) runCommand(ctx context.Context, args []string, stdout, stderr io.Writer) (LocalCommandResult, error) {
+func (b *blacksmithBackend) runCommand(ctx context.Context, args []string, stdout, stderr io.Writer) (core.LocalCommandResult, error) {
 	return b.runCommandCapture(ctx, args, stdout, stderr, false)
 }
 
-func (b *blacksmithBackend) runCommandCapture(ctx context.Context, args []string, stdout, stderr io.Writer, disableOutputCapture bool) (LocalCommandResult, error) {
+func (b *blacksmithBackend) runCommandCapture(ctx context.Context, args []string, stdout, stderr io.Writer, disableOutputCapture bool) (core.LocalCommandResult, error) {
 	return b.runCommandCaptureInDir(ctx, args, stdout, stderr, disableOutputCapture, "")
 }
 
-func (b *blacksmithBackend) runCommandCaptureInDir(ctx context.Context, args []string, stdout, stderr io.Writer, disableOutputCapture bool, dir string) (LocalCommandResult, error) {
+func (b *blacksmithBackend) runCommandCaptureInDir(ctx context.Context, args []string, stdout, stderr io.Writer, disableOutputCapture bool, dir string) (core.LocalCommandResult, error) {
 	if b.route != nil {
 		args = append(append([]string(nil), args...), "--api-url", b.route.API, "--org", b.route.Org)
 	}
-	request := LocalCommandRequest{Name: "blacksmith", Args: args, Dir: dir, Stdout: stdout, Stderr: stderr, DisableOutputCapture: disableOutputCapture}
+	request := core.LocalCommandRequest{Name: "blacksmith", Args: args, Dir: dir, Stdout: stdout, Stderr: stderr, DisableOutputCapture: disableOutputCapture}
 	if dir != "" {
 		// Artifact supervision must also bound local pipe draining on cancel.
 		request.CancelGracePeriod = time.Second
@@ -920,7 +898,7 @@ func (b *blacksmithBackend) runCommandCaptureInDir(ctx context.Context, args []s
 	}
 	result, err := b.rt.Exec.Run(ctx, request)
 	if err != nil {
-		return result, blacksmithCommandError{ExitError: ExitError{Code: result.ExitCode, Message: fmt.Sprintf("blacksmith failed: %v", err)}, cause: err}
+		return result, blacksmithCommandError{ExitError: core.ExitError{Code: result.ExitCode, Message: fmt.Sprintf("blacksmith failed: %v", err)}, cause: err}
 	}
 	return result, nil
 }
@@ -937,18 +915,18 @@ func (w *blacksmithArtifactProgressWriter) Write(p []byte) (int, error) {
 	return w.output.Write(p)
 }
 
-func (b *blacksmithBackend) runCommandWithSyncGuard(ctx context.Context, args []string, stdout, stderr io.Writer) (LocalCommandResult, bool, error) {
+func (b *blacksmithBackend) runCommandWithSyncGuard(ctx context.Context, args []string, stdout, stderr io.Writer) (core.LocalCommandResult, bool, error) {
 	return b.runCommandWithSyncGuardCapture(ctx, args, stdout, stderr, true)
 }
 
-func (b *blacksmithBackend) runCommandWithSyncGuardCapture(ctx context.Context, args []string, stdout, stderr io.Writer, disableOutputCapture bool) (LocalCommandResult, bool, error) {
+func (b *blacksmithBackend) runCommandWithSyncGuardCapture(ctx context.Context, args []string, stdout, stderr io.Writer, disableOutputCapture bool) (core.LocalCommandResult, bool, error) {
 	return b.runCommandWithSyncGuardFiltered(ctx, args, stdout, stderr, disableOutputCapture, "", nil)
 }
 
 // Filter before sync observation as well as console, proof, and failure capture.
-func (b *blacksmithBackend) runCommandWithSyncGuardFiltered(ctx context.Context, args []string, stdout, stderr io.Writer, disableOutputCapture bool, dir string, filter func(io.Writer, io.Writer) (io.Writer, io.Writer)) (LocalCommandResult, bool, error) {
+func (b *blacksmithBackend) runCommandWithSyncGuardFiltered(ctx context.Context, args []string, stdout, stderr io.Writer, disableOutputCapture bool, dir string, filter func(io.Writer, io.Writer) (io.Writer, io.Writer)) (core.LocalCommandResult, bool, error) {
 	if err := validateBlacksmithNativeSyncScope(dir); err != nil {
-		return LocalCommandResult{ExitCode: 2}, false, err
+		return core.LocalCommandResult{ExitCode: 2}, false, err
 	}
 	timeout := blacksmithSyncTimeout(os.Getenv)
 	if timeout <= 0 {
@@ -967,7 +945,7 @@ func (b *blacksmithBackend) runCommandWithSyncGuardFiltered(ctx context.Context,
 		stdout, stderr = filter(stdout, stderr)
 	}
 	resultCh := make(chan struct {
-		result LocalCommandResult
+		result core.LocalCommandResult
 		err    error
 	}, 1)
 	go func() {
@@ -980,7 +958,7 @@ func (b *blacksmithBackend) runCommandWithSyncGuardFiltered(ctx context.Context,
 			dir,
 		)
 		resultCh <- struct {
-			result LocalCommandResult
+			result core.LocalCommandResult
 			err    error
 		}{result: result, err: err}
 	}()
@@ -1085,17 +1063,17 @@ func minBlacksmithDuration(left, right time.Duration) time.Duration {
 	return right
 }
 
-func (b *blacksmithBackend) blacksmithStatusView(ctx context.Context, leaseID string) (statusView, error) {
+func (b *blacksmithBackend) blacksmithStatusView(ctx context.Context, leaseID string) (core.StatusView, error) {
 	out, err := b.commandOutput(ctx, blacksmithListAllArgs(b.cfg))
 	if err != nil {
-		return statusView{}, err
+		return core.StatusView{}, err
 	}
 	for _, item := range parseBlacksmithList(out) {
 		if item.ID != leaseID {
 			continue
 		}
 		server := blacksmithItemToServer(item)
-		return statusView{
+		return core.StatusView{
 			ID:          item.ID,
 			Provider:    blacksmithTestboxProvider,
 			TargetOS:    targetLinux,
@@ -1108,10 +1086,10 @@ func (b *blacksmithBackend) blacksmithStatusView(ctx context.Context, leaseID st
 			IdleTimeout: blacksmithIdleTimeout(b.cfg).String(),
 		}, nil
 	}
-	return statusView{}, exit(4, "blacksmith testbox not found: %s", leaseID)
+	return core.StatusView{}, core.Exit(4, "blacksmith testbox not found: %s", leaseID)
 }
 
-func blacksmithItemToServer(item blacksmithListItem) Server {
+func blacksmithItemToServer(item blacksmithListItem) core.Server {
 	labels := map[string]string{
 		"lease":    item.ID,
 		"provider": blacksmithTestboxProvider,
@@ -1122,7 +1100,7 @@ func blacksmithItemToServer(item blacksmithListItem) Server {
 		"ref":      item.Ref,
 		"created":  item.Created,
 	}
-	server := Server{
+	server := core.Server{
 		CloudID:  item.ID,
 		Provider: blacksmithTestboxProvider,
 		Name:     item.ID,
@@ -1142,34 +1120,4 @@ func blacksmithWaitTimeoutMessage(identifier, state string) string {
 		return fmt.Sprintf("timed out waiting for %s to become ready (last state %s)", identifier, state)
 	}
 	return fmt.Sprintf("timed out waiting for %s to become ready", identifier)
-}
-
-type statusView = core.StatusView
-
-func writeTimingJSON(w io.Writer, report timingReport) error {
-	return core.WriteTimingJSON(w, report)
-}
-
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-
-func ensureTestboxKey(leaseID string) (string, string, error) {
-	return core.EnsureTestboxKey(leaseID)
-}
-
-func removeStoredTestboxKey(leaseID string) {
-	core.RemoveStoredTestboxKey(leaseID)
-}
-
-func testboxKeyPath(leaseID string) (string, error) {
-	return core.TestboxKeyPath(leaseID)
-}
-
-func baseConfig() Config {
-	return core.BaseConfig()
-}
-
-func readLeaseClaim(leaseID string) (core.LeaseClaim, error) {
-	return core.ReadLeaseClaim(leaseID)
 }

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -29,12 +29,12 @@ func (testClock) Now() time.Time { return time.Now() }
 
 type blacksmithFuncRunner struct {
 	calls     [][]string
-	fn        func(LocalCommandRequest) (LocalCommandResult, error)
-	onRequest func(context.Context, LocalCommandRequest)
+	fn        func(core.LocalCommandRequest) (core.LocalCommandResult, error)
+	onRequest func(context.Context, core.LocalCommandRequest)
 	states    map[string]string
 }
 
-func (r *blacksmithFuncRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (r *blacksmithFuncRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.calls = append(r.calls, append([]string(nil), req.Args...))
 	if r.onRequest != nil {
 		r.onRequest(ctx, req)
@@ -43,7 +43,7 @@ func (r *blacksmithFuncRunner) Run(ctx context.Context, req LocalCommandRequest)
 		return result, err
 	}
 	if len(req.Args) >= 2 && req.Args[0] == "auth" && req.Args[1] == "status" {
-		return LocalCommandResult{Stdout: "Authenticated organizations:\n  * example-org (current)\n"}, nil
+		return core.LocalCommandResult{Stdout: "Authenticated organizations:\n  * example-org (current)\n"}, nil
 	}
 	if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "status" {
 		id := testBlacksmithFlag(req.Args, "--id")
@@ -51,7 +51,7 @@ func (r *blacksmithFuncRunner) Run(ctx context.Context, req LocalCommandRequest)
 		if state == "" {
 			state = "ready"
 		}
-		return LocalCommandResult{Stdout: testBlacksmithStatus(id, state)}, nil
+		return core.LocalCommandResult{Stdout: testBlacksmithStatus(id, state)}, nil
 	}
 	if r.fn != nil {
 		result, err := r.fn(req)
@@ -63,7 +63,7 @@ func (r *blacksmithFuncRunner) Run(ctx context.Context, req LocalCommandRequest)
 		}
 		return result, err
 	}
-	return LocalCommandResult{}, nil
+	return core.LocalCommandResult{}, nil
 }
 
 func testBlacksmithFlag(args []string, flag string) string {
@@ -105,25 +105,25 @@ func testOwnedBlacksmithClaim(t *testing.T, id, slug, repo string) core.LeaseCla
 
 type blockingSyncRunner struct{}
 
-func (blockingSyncRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (blockingSyncRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	if len(req.Args) >= 2 && req.Args[0] == "auth" {
-		return LocalCommandResult{Stdout: "Authenticated organizations:\n  * example-org (current)\n"}, nil
+		return core.LocalCommandResult{Stdout: "Authenticated organizations:\n  * example-org (current)\n"}, nil
 	}
 	if len(req.Args) >= 2 && req.Args[1] == "status" {
-		return LocalCommandResult{Stdout: testBlacksmithStatus(testBlacksmithFlag(req.Args, "--id"), "ready")}, nil
+		return core.LocalCommandResult{Stdout: testBlacksmithStatus(testBlacksmithFlag(req.Args, "--id"), "ready")}, nil
 	}
 	if req.Stdout != nil {
 		_, _ = req.Stdout.Write([]byte("Syncing from repo root: /repo\n"))
 	}
 	<-ctx.Done()
-	return LocalCommandResult{ExitCode: 1}, ctx.Err()
+	return core.LocalCommandResult{ExitCode: 1}, ctx.Err()
 }
 
-func newTestBlacksmithBackend(cfg Config, runner CommandRunner) *blacksmithBackend {
+func newTestBlacksmithBackend(cfg core.Config, runner core.CommandRunner) *blacksmithBackend {
 	return &blacksmithBackend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt:   Runtime{Stdout: io.Discard, Stderr: io.Discard, Clock: testClock{}, Exec: runner},
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Clock: testClock{}, Exec: runner},
 	}
 }
 
@@ -133,18 +133,18 @@ func TestManagedStateNativeBlacksmithBoundaries(t *testing.T) {
 			repo := t.TempDir()
 			t.Setenv("XDG_STATE_HOME", filepath.Join(repo, "state-base"))
 			runner := &blacksmithFuncRunner{}
-			b := newTestBlacksmithBackend(baseConfig(), runner)
+			b := newTestBlacksmithBackend(core.BaseConfig(), runner)
 			var err error
 			switch route {
 			case "run":
-				_, err = b.Run(t.Context(), RunRequest{Repo: Repo{Root: repo}, Command: []string{"true"}})
+				_, err = b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: repo}, Command: []string{"true"}})
 			case "artifact":
-				_, _, _, err = b.runArtifactTestbox(t.Context(), RunRequest{Repo: Repo{Root: repo}}, "tbx_fixture", nil, nil, nil, time.Second)
+				_, _, _, err = b.runArtifactTestbox(t.Context(), core.RunRequest{Repo: core.Repo{Root: repo}}, "tbx_fixture", nil, nil, nil, time.Second)
 			case "native handoff":
 				_, _, err = b.runCommandWithSyncGuardFiltered(t.Context(), []string{"testbox", "run"}, io.Discard, io.Discard, true, repo, nil)
 			case "native current directory":
 				t.Chdir(repo)
-				_, err = b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir()}, Command: []string{"true"}})
+				_, err = b.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: t.TempDir()}, Command: []string{"true"}})
 			}
 			if err == nil || !strings.Contains(err.Error(), "blacksmith native sync") || len(runner.calls) != 0 {
 				t.Fatalf("err=%v native calls=%v", err, runner.calls)
@@ -160,7 +160,7 @@ func TestManagedStateNativeBlacksmithBoundaries(t *testing.T) {
 func TestBlacksmithOrdinaryFlagMetadata(t *testing.T) {
 	for _, provider := range []string{"other", "blacksmith-testbox", " BLACKSMITH "} {
 		for _, value := range []string{"", "same", " padded "} {
-			cfg := Config{Provider: provider, Blacksmith: BlacksmithConfig{Org: "same", Workflow: "same", Job: "same", Ref: "same", IdleTimeout: time.Minute, Debug: true}}
+			cfg := core.Config{Provider: provider, Blacksmith: core.BlacksmithConfig{Org: "same", Workflow: "same", Job: "same", Ref: "same", IdleTimeout: time.Minute, Debug: true}}
 			before := cfg
 			fs := flag.NewFlagSet("test", flag.ContinueOnError)
 			values := RegisterBlacksmithProviderFlags(fs, cfg)
@@ -236,8 +236,8 @@ func TestManualConfigInputFlags(t *testing.T) {
 }
 
 func TestBlacksmithWarmupArgs(t *testing.T) {
-	cfg := baseConfig()
-	cfg.Blacksmith = BlacksmithConfig{
+	cfg := core.BaseConfig()
+	cfg.Blacksmith = core.BlacksmithConfig{
 		Org:         "openclaw",
 		Workflow:    ".github/workflows/testbox.yml",
 		Job:         "check",
@@ -266,7 +266,7 @@ func TestBlacksmithWarmupArgs(t *testing.T) {
 }
 
 func TestBlacksmithWarmupArgsFallsBackToTestboxActionsConfig(t *testing.T) {
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Actions.Workflow = ".github/workflows/ci-check-testbox.yml"
 	cfg.Actions.Job = "check"
 	cfg.Actions.Ref = "trunk"
@@ -282,7 +282,7 @@ func TestBlacksmithWarmupArgsFallsBackToTestboxActionsConfig(t *testing.T) {
 }
 
 func TestBlacksmithWarmupArgsFallsBackToArbitraryActionsWorkflowName(t *testing.T) {
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Actions.Workflow = ".github/workflows/ci.yml"
 	cfg.Actions.Job = "integration"
 	cfg.Actions.Ref = "trunk"
@@ -304,7 +304,7 @@ func TestBlacksmithWarmupArgsDoesNotUseGenericActionsHydrateWorkflow(t *testing.
 		".github/workflows/crabbox-hydrate.yml",
 		".github/workflows/hydrate.yml",
 	} {
-		cfg := baseConfig()
+		cfg := core.BaseConfig()
 		cfg.Actions.Workflow = workflow
 		cfg.Actions.Job = "hydrate"
 		cfg.Actions.Ref = "main"
@@ -316,7 +316,7 @@ func TestBlacksmithWarmupArgsDoesNotUseGenericActionsHydrateWorkflow(t *testing.
 }
 
 func TestBlacksmithWarmupArgsPrefersExplicitConfigOverGenericActionsConfig(t *testing.T) {
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Actions.Workflow = ".github/workflows/crabbox-hydrate.yml"
 	cfg.Actions.Job = "hydrate"
 	cfg.Actions.Ref = "actions-ref"
@@ -339,7 +339,7 @@ func TestBlacksmithWarmupArgsPrefersExplicitConfigOverGenericActionsConfig(t *te
 }
 
 func TestBlacksmithWarmupArgsExplicitWorkflowCanInheritActionsJobAndRef(t *testing.T) {
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Actions.Workflow = ".github/workflows/crabbox.yml"
 	cfg.Actions.Job = "check"
 	cfg.Actions.Ref = "trunk"
@@ -356,7 +356,7 @@ func TestBlacksmithWarmupArgsExplicitWorkflowCanInheritActionsJobAndRef(t *testi
 }
 
 func TestBlacksmithWarmupArgsRequiresWorkflow(t *testing.T) {
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	_, err := blacksmithWarmupArgs(cfg, "")
 	if err == nil || !strings.Contains(err.Error(), "requires blacksmith.workflow") {
 		t.Fatalf("expected workflow error, got %v", err)
@@ -366,14 +366,14 @@ func TestBlacksmithWarmupArgsRequiresWorkflow(t *testing.T) {
 func TestBlacksmithRunRejectsEnvForwardingBeforeWarmup(t *testing.T) {
 	var stderr bytes.Buffer
 	runner := &blacksmithFuncRunner{}
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	backend := &blacksmithBackend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
 	}
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:       Repo{Root: "/repo"},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Root: "/repo"},
 		Command:    []string{"true"},
 		EnvSummary: true,
 		Options: core.LeaseOptions{
@@ -381,7 +381,7 @@ func TestBlacksmithRunRejectsEnvForwardingBeforeWarmup(t *testing.T) {
 		},
 		Env: map[string]string{"API_TOKEN": "secret-token-value"},
 	})
-	var exitErr ExitError
+	var exitErr core.ExitError
 	if !core.AsExitError(err, &exitErr) || exitErr.Code != 2 {
 		t.Fatalf("Run error=%v, want exit 2", err)
 	}
@@ -428,12 +428,12 @@ func TestBlacksmithRunRejectsSparseCheckoutBeforeWarmup(t *testing.T) {
 	git("sparse-checkout", "set", "included")
 
 	runner := &blacksmithFuncRunner{}
-	backend := newTestBlacksmithBackend(baseConfig(), runner)
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: dir},
+	backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: dir},
 		Command: []string{"true"},
 	})
-	var exitErr ExitError
+	var exitErr core.ExitError
 	if !core.AsExitError(err, &exitErr) || exitErr.Code != 2 {
 		t.Fatalf("Run error=%v, want exit 2", err)
 	}
@@ -450,18 +450,18 @@ func TestBlacksmithRunDoesNotRejectDefaultEnvMetadata(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	var stderr bytes.Buffer
-	runner := &blacksmithFuncRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
-		return LocalCommandResult{ExitCode: 1}, errors.New("warmup failed")
+	runner := &blacksmithFuncRunner{fn: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		return core.LocalCommandResult{ExitCode: 1}, errors.New("warmup failed")
 	}}
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 	backend := &blacksmithBackend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
 	}
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: "/repo"},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: "/repo"},
 		Command: []string{"true"},
 		Options: core.LeaseOptions{
 			EnvAllow: []string{"CI", "NODE_OPTIONS"},
@@ -482,14 +482,14 @@ func TestBlacksmithRunDoesNotRejectDefaultEnvMetadata(t *testing.T) {
 func TestBlacksmithRunRejectsExplicitDefaultEnvBeforeWarmup(t *testing.T) {
 	var stderr bytes.Buffer
 	runner := &blacksmithFuncRunner{}
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	backend := &blacksmithBackend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
 	}
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:       Repo{Root: "/repo"},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Root: "/repo"},
 		Command:    []string{"true"},
 		EnvSummary: true,
 		Options: core.LeaseOptions{
@@ -497,7 +497,7 @@ func TestBlacksmithRunRejectsExplicitDefaultEnvBeforeWarmup(t *testing.T) {
 		},
 		Env: map[string]string{"NODE_OPTIONS": "--max-old-space-size=4096"},
 	})
-	var exitErr ExitError
+	var exitErr core.ExitError
 	if !core.AsExitError(err, &exitErr) || exitErr.Code != 2 {
 		t.Fatalf("Run error=%v, want exit 2", err)
 	}
@@ -511,18 +511,18 @@ func TestBlacksmithRunIgnoresConfiguredEnvAllowBeforeWarmup(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	var stderr bytes.Buffer
-	runner := &blacksmithFuncRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
-		return LocalCommandResult{ExitCode: 1}, errors.New("warmup failed")
+	runner := &blacksmithFuncRunner{fn: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		return core.LocalCommandResult{ExitCode: 1}, errors.New("warmup failed")
 	}}
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 	backend := &blacksmithBackend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
 	}
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: "/repo"},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: "/repo"},
 		Command: []string{"true"},
 		Options: core.LeaseOptions{
 			EnvAllow: []string{"API_TOKEN"},
@@ -545,18 +545,18 @@ func TestBlacksmithRunIgnoresConfiguredEnvAllowBeforeWarmup(t *testing.T) {
 
 func TestBlacksmithWarmupFailureRetainsPendingKey(t *testing.T) {
 	isolateBlacksmithOwnership(t)
-	runner := &blacksmithFuncRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
-		return LocalCommandResult{ExitCode: 1}, errors.New("exit status 1")
+	runner := &blacksmithFuncRunner{fn: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		return core.LocalCommandResult{ExitCode: 1}, errors.New("exit status 1")
 	}}
 
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 	backend := newTestBlacksmithBackend(cfg, runner)
-	_, err := backend.warmupLease(context.Background(), Repo{Root: "/repo"}, false, "")
+	_, err := backend.warmupLease(context.Background(), core.Repo{Root: "/repo"}, false, "")
 	if err == nil || !strings.Contains(err.Error(), "exit status 1") || !strings.Contains(err.Error(), "retained pending_key=tbx_pending_") {
 		t.Fatalf("expected warmup failure with recovery diagnostic: %v", err)
 	}
-	keyPath, keyErr := testboxKeyPath("tbx_probe")
+	keyPath, keyErr := core.TestboxKeyPath("tbx_probe")
 	if keyErr != nil {
 		t.Fatal(keyErr)
 	}
@@ -582,22 +582,22 @@ func TestBlacksmithWarmupFailureStopsPrintedTestbox(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	var stopped string
-	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "stop" {
 			for i, arg := range req.Args {
 				if arg == "--id" && i+1 < len(req.Args) {
 					stopped = req.Args[i+1]
 				}
 			}
-			return LocalCommandResult{}, nil
+			return core.LocalCommandResult{}, nil
 		}
-		return LocalCommandResult{ExitCode: 1, Stdout: "tbx_leaked123\n"}, errors.New("exit status 1")
+		return core.LocalCommandResult{ExitCode: 1, Stdout: "tbx_leaked123\n"}, errors.New("exit status 1")
 	}}
 
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 	backend := newTestBlacksmithBackend(cfg, runner)
-	_, err := backend.warmupLease(context.Background(), Repo{Root: "/repo"}, false, "")
+	_, err := backend.warmupLease(context.Background(), core.Repo{Root: "/repo"}, false, "")
 	if err == nil {
 		t.Fatal("expected warmup failure")
 	}
@@ -613,12 +613,12 @@ func TestBlacksmithOneShotRunRemovesClaimAfterStop(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
 	var stderr bytes.Buffer
 	cleanupDeadlineSet := false
-	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
 			if req.MaxCapturedOutputBytes != blacksmithCommandCaptureBytes || req.DisableOutputCapture {
 				t.Fatalf("warmup capture settings: limit=%d disabled=%t", req.MaxCapturedOutputBytes, req.DisableOutputCapture)
 			}
-			return LocalCommandResult{Stdout: "tbx_abc123\n"}, nil
+			return core.LocalCommandResult{Stdout: "tbx_abc123\n"}, nil
 		}
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "run" {
 			if !req.DisableOutputCapture || req.MaxCapturedOutputBytes != 0 {
@@ -627,25 +627,25 @@ func TestBlacksmithOneShotRunRemovesClaimAfterStop(t *testing.T) {
 			if req.Stdout != nil {
 				_, _ = req.Stdout.Write([]byte("https://github.com/example-org/my-app/actions/runs/123456789\n"))
 			}
-			return LocalCommandResult{}, nil
+			return core.LocalCommandResult{}, nil
 		}
-		return LocalCommandResult{}, nil
+		return core.LocalCommandResult{}, nil
 	}}
-	runner.onRequest = func(ctx context.Context, req LocalCommandRequest) {
+	runner.onRequest = func(ctx context.Context, req core.LocalCommandRequest) {
 		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "stop" {
 			_, cleanupDeadlineSet = ctx.Deadline()
 		}
 	}
 
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 	backend := &blacksmithBackend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
 	}
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: "/repo"},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: "/repo"},
 		Command: []string{"true"},
 	})
 	if err != nil {
@@ -657,12 +657,12 @@ func TestBlacksmithOneShotRunRemovesClaimAfterStop(t *testing.T) {
 	if !cleanupDeadlineSet {
 		t.Fatal("one-shot Testbox cleanup did not receive a deadline")
 	}
-	if claim, err := readLeaseClaim("tbx_abc123"); err != nil {
+	if claim, err := core.ReadLeaseClaim("tbx_abc123"); err != nil {
 		t.Fatal(err)
 	} else if claim.LeaseID != "" {
 		t.Fatalf("claim leaked after one-shot stop: %#v", claim)
 	}
-	if keyPath, err := testboxKeyPath("tbx_abc123"); err != nil {
+	if keyPath, err := core.TestboxKeyPath("tbx_abc123"); err != nil {
 		t.Fatal(err)
 	} else if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
 		t.Fatalf("key leaked after one-shot stop: %v", err)
@@ -690,14 +690,14 @@ func TestBlacksmithCleanupPreservesReplacedClaim(t *testing.T) {
 		t.Fatal(err)
 	}
 	runner := &blacksmithFuncRunner{}
-	backend := newTestBlacksmithBackend(baseConfig(), runner)
+	backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
 	if err := backend.stopClaimedTestbox(t.Context(), claim.LeaseID, claim); err == nil || !strings.Contains(err.Error(), "claim changed") {
 		t.Fatalf("cleanup=%v", err)
 	}
 	if len(runner.calls) != 0 {
 		t.Fatalf("stale snapshot reached provider: %v", runner.calls)
 	}
-	got, err := readLeaseClaim(claim.LeaseID)
+	got, err := core.ReadLeaseClaim(claim.LeaseID)
 	if err != nil || got.RepoRoot != replacement.RepoRoot {
 		t.Fatalf("replacement=%+v err=%v", got, err)
 	}
@@ -708,24 +708,24 @@ func TestBlacksmithKeptRunWritesLeaseOutput(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
-	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
-			return LocalCommandResult{Stdout: "tbx_kept123\n"}, nil
+			return core.LocalCommandResult{Stdout: "tbx_kept123\n"}, nil
 		}
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "run" {
 			if req.Stdout != nil {
 				_, _ = req.Stdout.Write([]byte("https://github.com/example-org/my-app/actions/runs/987654321\n"))
 			}
-			return LocalCommandResult{}, nil
+			return core.LocalCommandResult{}, nil
 		}
-		return LocalCommandResult{}, nil
+		return core.LocalCommandResult{}, nil
 	}}
 
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 	backend := newTestBlacksmithBackend(cfg, runner)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: "/repo"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: "/repo"},
 		Command: []string{"npm", "test"},
 		Keep:    true,
 	})
@@ -805,19 +805,19 @@ func TestBlacksmithReusedRunWritesLeaseOutput(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
-	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "run" {
-			return LocalCommandResult{}, nil
+			return core.LocalCommandResult{}, nil
 		}
-		return LocalCommandResult{}, nil
+		return core.LocalCommandResult{}, nil
 	}}
 
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	testOwnedBlacksmithClaim(t, "tbx_reuse123", "jade-krill", "/repo")
 	prepareBlacksmithGuestKey(t, "tbx_reuse123")
 	backend := newTestBlacksmithBackend(cfg, runner)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:    Repo{Root: "/repo"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:    core.Repo{Root: "/repo"},
 		ID:      "tbx_reuse123",
 		Command: []string{"npm", "run", "smoke"},
 	})
@@ -841,29 +841,29 @@ func TestBlacksmithRunTimingJSONIncludesCommandPhases(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
-	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
-			return LocalCommandResult{Stdout: "tbx_phase123\n"}, nil
+			return core.LocalCommandResult{Stdout: "tbx_phase123\n"}, nil
 		}
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "run" {
 			if req.Stdout != nil {
 				_, _ = req.Stdout.Write([]byte("CRABBOX_PHASE:delegated\nok\n"))
 			}
-			return LocalCommandResult{}, nil
+			return core.LocalCommandResult{}, nil
 		}
-		return LocalCommandResult{}, nil
+		return core.LocalCommandResult{}, nil
 	}}
 	var stderr bytes.Buffer
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 	backend := &blacksmithBackend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
 	}
 
-	_, err := backend.Run(context.Background(), RunRequest{
-		Repo:       Repo{Root: "/repo"},
+	_, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:       core.Repo{Root: "/repo"},
 		Command:    []string{"true"},
 		Label:      "update flow smoke",
 		TimingJSON: true,
@@ -871,7 +871,7 @@ func TestBlacksmithRunTimingJSONIncludesCommandPhases(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var report timingReport
+	var report core.TimingReport
 	for _, line := range strings.Split(stderr.String(), "\n") {
 		if strings.HasPrefix(line, "{") {
 			if err := json.Unmarshal([]byte(line), &report); err != nil {
@@ -922,7 +922,7 @@ func TestBlacksmithRunFailureStagesLocalCommand(t *testing.T) {
 			} {
 				if tt.marked {
 					marker := "CRABBOX_PHASE:" + phase.name + "\n"
-					fmt.Fprintf(&script, "printf '%%s' %s >&2\n", shellQuote(marker))
+					fmt.Fprintf(&script, "printf '%%s' %s >&2\n", core.ShellQuote(marker))
 					if reached {
 						wantStderr.WriteString(marker)
 						wantPhases = append(wantPhases, phase.name)
@@ -933,22 +933,22 @@ func TestBlacksmithRunFailureStagesLocalCommand(t *testing.T) {
 					code = tt.code
 				}
 				receipt := fmt.Sprintf("STAGE %s START\n{\"name\":%q,\"command\":%s,\"exit\":%d,\"seconds\":0.001}\n", phase.name, phase.name, phase.command, code)
-				fmt.Fprintf(&script, "printf '%%s' %s\n", shellQuote(receipt))
+				fmt.Fprintf(&script, "printf '%%s' %s\n", core.ShellQuote(receipt))
 				if reached {
 					wantStdout.WriteString(receipt)
 				}
 				if code != 0 {
 					diagnostic := fmt.Sprintf("[%s] FAILED (exit %d)\nassertion one failed\nassertion two failed\n", phase.name, code)
-					fmt.Fprintf(&script, "printf '%%s' %s >&2\nexit %d\n", shellQuote(diagnostic), code)
+					fmt.Fprintf(&script, "printf '%%s' %s >&2\nexit %d\n", core.ShellQuote(diagnostic), code)
 					wantStderr.WriteString(diagnostic)
 					reached = false
 				}
 			}
 			command := strings.TrimSpace(script.String())
 			var nativeCode, runs int
-			runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+			runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				if len(req.Args) < 2 || req.Args[0] != "testbox" || req.Args[1] != "run" {
-					return LocalCommandResult{ExitCode: 2}, fmt.Errorf("unexpected native operation: %v", req.Args)
+					return core.LocalCommandResult{ExitCode: 2}, fmt.Errorf("unexpected native operation: %v", req.Args)
 				}
 				var gotCommand string
 				for _, arg := range req.Args {
@@ -958,7 +958,7 @@ func TestBlacksmithRunFailureStagesLocalCommand(t *testing.T) {
 					}
 				}
 				if gotCommand != command {
-					return LocalCommandResult{ExitCode: 2}, fmt.Errorf("delegated command changed: got %q want %q", gotCommand, command)
+					return core.LocalCommandResult{ExitCode: 2}, fmt.Errorf("delegated command changed: got %q want %q", gotCommand, command)
 				}
 				runs++
 				cmd := exec.CommandContext(t.Context(), "/bin/sh", "-c", gotCommand)
@@ -967,24 +967,24 @@ func TestBlacksmithRunFailureStagesLocalCommand(t *testing.T) {
 				cmd.WaitDelay = time.Second
 				err := cmd.Run()
 				if cmd.ProcessState == nil {
-					return LocalCommandResult{ExitCode: 2}, err
+					return core.LocalCommandResult{ExitCode: 2}, err
 				}
 				nativeCode = cmd.ProcessState.ExitCode()
-				return LocalCommandResult{ExitCode: nativeCode}, err
+				return core.LocalCommandResult{ExitCode: nativeCode}, err
 			}}
-			backend := newTestBlacksmithBackend(baseConfig(), runner)
+			backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
 			var stdout, stderr bytes.Buffer
 			backend.rt.Stdout, backend.rt.Stderr = &stdout, &stderr
-			result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Root: repo}, ID: id, Command: []string{command}, ShellMode: true, TimingJSON: true})
+			result, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: repo}, ID: id, Command: []string{command}, ShellMode: true, TimingJSON: true})
 			t.Logf("command:\n%s\nstdout:\n%sstderr:\n%snative exit=%d delegated exit=%d error=%v", command, stdout.String(), stderr.String(), nativeCode, result.ExitCode, err)
-			var ee ExitError
+			var ee core.ExitError
 			if runs != 1 || nativeCode != tt.code || result.ExitCode != tt.code || (tt.code == 0 && err != nil) || (tt.code != 0 && (!errors.As(err, &ee) || ee.Code != tt.code)) {
 				t.Fatalf("runs=%d native=%d result=%+v err=%v", runs, nativeCode, result, err)
 			}
 			if stdout.String() != wantStdout.String() || !strings.Contains(stderr.String(), wantStderr.String()) || result.CommandText != command {
 				t.Fatal("command or workload output changed")
 			}
-			var report timingReport
+			var report core.TimingReport
 			for _, line := range strings.Split(stderr.String(), "\n") {
 				if strings.HasPrefix(line, "{") {
 					if err := json.Unmarshal([]byte(line), &report); err != nil {
@@ -1066,9 +1066,9 @@ func TestBlacksmithRunProofArtifactsPersistSuccessStreams(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
-	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
-			return LocalCommandResult{Stdout: "tbx_proof123\n"}, nil
+			return core.LocalCommandResult{Stdout: "tbx_proof123\n"}, nil
 		}
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "run" {
 			if req.Stdout != nil {
@@ -1079,15 +1079,15 @@ func TestBlacksmithRunProofArtifactsPersistSuccessStreams(t *testing.T) {
 			if req.Stderr != nil {
 				_, _ = req.Stderr.Write([]byte("stderr detail\n"))
 			}
-			return LocalCommandResult{}, nil
+			return core.LocalCommandResult{}, nil
 		}
-		return LocalCommandResult{}, nil
+		return core.LocalCommandResult{}, nil
 	}}
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 	backend := newTestBlacksmithBackend(cfg, runner)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:      Repo{Root: repo},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:      core.Repo{Root: repo},
 		Command:   []string{"pnpm", "test"},
 		EmitProof: filepath.Join(repo, "proof.md"),
 	})
@@ -1139,24 +1139,24 @@ func TestBlacksmithRunCollectsArtifactsBeforeOneShotCleanup(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
 	testWriteBlacksmithFile(t, repo, "reports/manifest.json", `{"ok":true}`)
 	runCalls := 0
-	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
-			return LocalCommandResult{Stdout: "tbx_artifacts\n"}, nil
+			return core.LocalCommandResult{Stdout: "tbx_artifacts\n"}, nil
 		}
 		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "run" {
 			runCalls++
 			return runSyntheticBlacksmithCommand(t, t.Context(), req)
 		}
 		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "stop" {
-			return LocalCommandResult{}, nil
+			return core.LocalCommandResult{}, nil
 		}
-		return LocalCommandResult{}, nil
+		return core.LocalCommandResult{}, nil
 	}}
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 	backend := newTestBlacksmithBackend(cfg, runner)
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:                  Repo{Root: repo},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:                  core.Repo{Root: repo},
 		Command:               []string{"true"},
 		ArtifactGlobs:         []string{"reports/**"},
 		RequiredArtifactGlobs: []string{"reports/manifest.json"},
@@ -1186,9 +1186,9 @@ func TestBlacksmithRunArtifactFailureKeepsOneShotOnKeepOnFailure(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
 	t.Chdir(repo)
 	runCalls := 0
-	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
-			return LocalCommandResult{Stdout: "tbx_artifactfail\n"}, nil
+			return core.LocalCommandResult{Stdout: "tbx_artifactfail\n"}, nil
 		}
 		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "run" {
 			runCalls++
@@ -1197,24 +1197,24 @@ func TestBlacksmithRunArtifactFailureKeepsOneShotOnKeepOnFailure(t *testing.T) {
 		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "stop" {
 			t.Fatalf("stop should not run after artifact failure with keep-on-failure: %#v", req.Args)
 		}
-		return LocalCommandResult{}, nil
+		return core.LocalCommandResult{}, nil
 	}}
 	var stderr bytes.Buffer
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 	backend := &blacksmithBackend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
 	}
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:                  Repo{Root: repo},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:                  core.Repo{Root: repo},
 		Command:               []string{"true"},
 		RequiredArtifactGlobs: []string{"reports/manifest.json"},
 		KeepOnFailure:         true,
 		TimingJSON:            true,
 	})
-	var exitErr ExitError
+	var exitErr core.ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 7 {
 		t.Fatalf("err=%v want artifact exit 7", err)
 	}
@@ -1262,9 +1262,9 @@ func TestBlacksmithKeepOnFailureKeepsTestboxAndWritesBundle(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
 	t.Chdir(t.TempDir())
-	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
-			return LocalCommandResult{Stdout: "tbx_keepfail\n"}, nil
+			return core.LocalCommandResult{Stdout: "tbx_keepfail\n"}, nil
 		}
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "run" {
 			if req.Stdout != nil {
@@ -1273,24 +1273,24 @@ func TestBlacksmithKeepOnFailureKeepsTestboxAndWritesBundle(t *testing.T) {
 			if req.Stderr != nil {
 				_, _ = req.Stderr.Write([]byte("delegated stderr\n"))
 			}
-			return LocalCommandResult{ExitCode: 7}, errors.New("exit status 7")
+			return core.LocalCommandResult{ExitCode: 7}, errors.New("exit status 7")
 		}
-		return LocalCommandResult{}, nil
+		return core.LocalCommandResult{}, nil
 	}}
 	var stderr bytes.Buffer
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 	backend := &blacksmithBackend{
 		spec: Provider{}.Spec(),
 		cfg:  cfg,
-		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
+		rt:   core.Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
 	}
-	result, err := backend.Run(context.Background(), RunRequest{
-		Repo:          Repo{Root: "/repo"},
+	result, err := backend.Run(context.Background(), core.RunRequest{
+		Repo:          core.Repo{Root: "/repo"},
 		Command:       []string{"false"},
 		KeepOnFailure: true,
 	})
-	var exitErr ExitError
+	var exitErr core.ExitError
 	if !errors.As(err, &exitErr) || exitErr.Code != 7 {
 		t.Fatalf("err=%v want exit 7", err)
 	}
@@ -1354,14 +1354,14 @@ func TestBlacksmithRunTerminatesSyncStall(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("CRABBOX_BLACKSMITH_SYNC_TIMEOUT_MS", "1")
-	if _, _, err := ensureTestboxKey("tbx_syncstall"); err != nil {
+	if _, _, err := core.EnsureTestboxKey("tbx_syncstall"); err != nil {
 		t.Fatal(err)
 	}
 	var stderr bytes.Buffer
 	backend := &blacksmithBackend{
 		spec: Provider{}.Spec(),
-		cfg:  baseConfig(),
-		rt: Runtime{
+		cfg:  core.BaseConfig(),
+		rt: core.Runtime{
 			Stdout: io.Discard,
 			Stderr: &stderr,
 			Clock:  testClock{},
@@ -1410,24 +1410,24 @@ func TestBlacksmithSyncTrackerHandlesSplitMarkers(t *testing.T) {
 }
 
 func TestBlacksmithBackendUsesInjectedCommandRunnerForListAndStatus(t *testing.T) {
-	runner := &blacksmithFuncRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
-		return LocalCommandResult{
+	runner := &blacksmithFuncRunner{fn: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		return core.LocalCommandResult{
 			Stdout: "tbx_123 ready my-app .github/workflows/testbox.yml test main 2026-05-06T00:00:00Z\n",
 		}, nil
 	}}
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 	cfg.Blacksmith.Job = "test"
 	cfg.Blacksmith.Ref = "main"
 	backend := newTestBlacksmithBackend(cfg, runner)
-	servers, err := backend.List(context.Background(), ListRequest{})
+	servers, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
 	if len(servers) != 1 || servers[0].CloudID != "tbx_123" {
 		t.Fatalf("servers=%#v", servers)
 	}
-	state, err := backend.Status(context.Background(), StatusRequest{ID: "tbx_123"})
+	state, err := backend.Status(context.Background(), core.StatusRequest{ID: "tbx_123"})
 	if err != nil {
 		t.Fatalf("status: %v", err)
 	}
@@ -1440,13 +1440,13 @@ func TestBlacksmithBackendUsesInjectedCommandRunnerForListAndStatus(t *testing.T
 }
 
 func TestBlacksmithStatusWaitTimeoutMentionsQueuedState(t *testing.T) {
-	runner := &blacksmithFuncRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
-		return LocalCommandResult{
+	runner := &blacksmithFuncRunner{fn: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		return core.LocalCommandResult{
 			Stdout: "tbx_123 queued openclaw .github/workflows/testbox.yml test main 2026-05-06T00:00:00Z\n",
 		}, nil
 	}}
-	backend := newTestBlacksmithBackend(baseConfig(), runner)
-	_, err := backend.Status(context.Background(), StatusRequest{ID: "tbx_123", Wait: true, WaitTimeout: -time.Second})
+	backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
+	_, err := backend.Status(context.Background(), core.StatusRequest{ID: "tbx_123", Wait: true, WaitTimeout: -time.Second})
 	if err == nil {
 		t.Fatal("expected queued timeout")
 	}
@@ -1463,15 +1463,15 @@ func TestBlacksmithStatusWaitReturnsOnContextCancellation(t *testing.T) {
 	t.Cleanup(func() { blacksmithStatusPollDelay = originalDelay })
 
 	ctx, cancel := context.WithCancel(context.Background())
-	runner := &blacksmithFuncRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &blacksmithFuncRunner{fn: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		cancel()
-		return LocalCommandResult{
+		return core.LocalCommandResult{
 			Stdout: "tbx_123 queued openclaw .github/workflows/testbox.yml test main 2026-05-06T00:00:00Z\n",
 		}, nil
 	}}
-	backend := newTestBlacksmithBackend(baseConfig(), runner)
+	backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
 	started := time.Now()
-	_, err := backend.Status(ctx, StatusRequest{ID: "tbx_123", Wait: true, WaitTimeout: time.Minute})
+	_, err := backend.Status(ctx, core.StatusRequest{ID: "tbx_123", Wait: true, WaitTimeout: time.Minute})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Status err=%v, want context.Canceled", err)
 	}
@@ -1484,13 +1484,13 @@ func TestBlacksmithStatusWaitReturnsOnContextCancellation(t *testing.T) {
 }
 
 func TestBlacksmithBackendListJSONKeepsParsedTableShape(t *testing.T) {
-	runner := &blacksmithFuncRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
-		return LocalCommandResult{
+	runner := &blacksmithFuncRunner{fn: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		return core.LocalCommandResult{
 			Stdout: "tbx_123 ready my-app .github/workflows/testbox.yml test main 2026-05-06T00:00:00Z\n",
 		}, nil
 	}}
-	backend := newTestBlacksmithBackend(baseConfig(), runner)
-	view, err := backend.ListJSON(context.Background(), ListRequest{})
+	backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
+	view, err := backend.ListJSON(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatalf("list json: %v", err)
 	}
@@ -1504,13 +1504,13 @@ func TestBlacksmithBackendListJSONKeepsParsedTableShape(t *testing.T) {
 }
 
 func TestBlacksmithBackendListJSONCanIncludeAllStates(t *testing.T) {
-	runner := &blacksmithFuncRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
-		return LocalCommandResult{
+	runner := &blacksmithFuncRunner{fn: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		return core.LocalCommandResult{
 			Stdout: "tbx_123 hydrating openclaw .github/workflows/testbox.yml test main 2026-05-06T00:00:00Z\n",
 		}, nil
 	}}
-	backend := newTestBlacksmithBackend(baseConfig(), runner)
-	view, err := backend.ListJSON(context.Background(), ListRequest{All: true})
+	backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
+	view, err := backend.ListJSON(context.Background(), core.ListRequest{All: true})
 	if err != nil {
 		t.Fatalf("list json: %v", err)
 	}
@@ -1527,8 +1527,8 @@ func TestBlacksmithBackendListJSONCanIncludeAllStates(t *testing.T) {
 }
 
 func TestBlacksmithDoctorListsInventoryOnly(t *testing.T) {
-	runner := &blacksmithFuncRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
-		return LocalCommandResult{
+	runner := &blacksmithFuncRunner{fn: func(core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		return core.LocalCommandResult{
 			Stdout: strings.Join([]string{
 				"tbx_123 ready my-app .github/workflows/testbox.yml test main 2026-05-06T00:00:00Z",
 				"tbx_456 hydrating my-app .github/workflows/testbox.yml test main 2026-05-06T00:01:00Z",
@@ -1537,7 +1537,7 @@ func TestBlacksmithDoctorListsInventoryOnly(t *testing.T) {
 			}, "\n"),
 		}, nil
 	}}
-	backend := newTestBlacksmithBackend(baseConfig(), runner)
+	backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
 	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
 		t.Fatal(err)
@@ -1555,14 +1555,14 @@ func TestBlacksmithDoctorListsInventoryOnly(t *testing.T) {
 }
 
 func TestApplyBlacksmithFlagOverrides(t *testing.T) {
-	defaults := baseConfig()
-	defaults.Blacksmith = BlacksmithConfig{
+	defaults := core.BaseConfig()
+	defaults.Blacksmith = core.BlacksmithConfig{
 		Org:      "default-org",
 		Workflow: "default.yml",
 		Job:      "default-job",
 		Ref:      "main",
 	}
-	cfg := Config{}
+	cfg := core.Config{}
 	fs := newFlagSet("test", io.Discard)
 	values := RegisterBlacksmithProviderFlags(fs, defaults)
 	if err := parseFlags(fs, []string{
@@ -1604,7 +1604,7 @@ func TestParseBlacksmithListIgnoresEmptyMessage(t *testing.T) {
 }
 
 func TestBlacksmithRunArgs(t *testing.T) {
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Blacksmith.Org = "openclaw"
 	got := blacksmithRunArgs(cfg, "tbx_abc123", "/tmp/key", []string{"OPENCLAW_TESTBOX=1", "pnpm", "check:changed"}, true, false)
 	want := []string{

--- a/internal/providers/blacksmith/cleanup_toctou_test.go
+++ b/internal/providers/blacksmith/cleanup_toctou_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"path/filepath"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestFailedWarmupDoesNotStopConcurrentUnclaimedTestbox(t *testing.T) {
@@ -16,22 +18,22 @@ func TestFailedWarmupDoesNotStopConcurrentUnclaimedTestbox(t *testing.T) {
 	boxExists := false
 	listCalls := 0
 	stopped := ""
-	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if len(req.Args) < 2 || req.Args[0] != "testbox" {
-			return LocalCommandResult{}, nil
+			return core.LocalCommandResult{}, nil
 		}
 		switch req.Args[1] {
 		case "list":
 			listCalls++
 			if boxExists {
-				return LocalCommandResult{Stdout: "tbx_bee123 running example-org .github/workflows/testbox.yml check main 2026-07-14T10:00:00.000000Z\n"}, nil
+				return core.LocalCommandResult{Stdout: "tbx_bee123 running example-org .github/workflows/testbox.yml check main 2026-07-14T10:00:00.000000Z\n"}, nil
 			}
-			return LocalCommandResult{Stdout: "ID STATUS REPO WORKFLOW JOB REF CREATED\n"}, nil
+			return core.LocalCommandResult{Stdout: "ID STATUS REPO WORKFLOW JOB REF CREATED\n"}, nil
 		case "warmup":
 			// Another invocation can create its testbox before warmup returns
 			// and before that invocation publishes a local lease claim.
 			boxExists = true
-			return LocalCommandResult{ExitCode: 1, Stdout: "error: delegated queue unavailable\n"}, errors.New("exit status 1")
+			return core.LocalCommandResult{ExitCode: 1, Stdout: "error: delegated queue unavailable\n"}, errors.New("exit status 1")
 		case "stop":
 			for i, arg := range req.Args {
 				if arg == "--id" && i+1 < len(req.Args) {
@@ -40,16 +42,16 @@ func TestFailedWarmupDoesNotStopConcurrentUnclaimedTestbox(t *testing.T) {
 			}
 			boxExists = false
 		}
-		return LocalCommandResult{}, nil
+		return core.LocalCommandResult{}, nil
 	}}
 
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 	cfg.Blacksmith.Job = "check"
 	cfg.Blacksmith.Ref = "main"
 	backend := newTestBlacksmithBackend(cfg, runner)
 
-	if _, err := backend.warmupLease(context.Background(), Repo{Root: "/repo-a"}, false, ""); err == nil {
+	if _, err := backend.warmupLease(context.Background(), core.Repo{Root: "/repo-a"}, false, ""); err == nil {
 		t.Fatal("expected warmup failure")
 	}
 	if stopped != "" || !boxExists {

--- a/internal/providers/blacksmith/helpers.go
+++ b/internal/providers/blacksmith/helpers.go
@@ -30,10 +30,10 @@ type blacksmithListItem struct {
 	Created  string `json:"created"`
 }
 
-func blacksmithWarmupArgs(cfg Config, publicKey string) ([]string, error) {
+func blacksmithWarmupArgs(cfg core.Config, publicKey string) ([]string, error) {
 	workflow := blacksmithWorkflow(cfg)
 	if workflow == "" {
-		return nil, exit(2, "blacksmith-testbox requires blacksmith.workflow or actions.workflow")
+		return nil, core.Exit(2, "blacksmith-testbox requires blacksmith.workflow or actions.workflow")
 	}
 	args := blacksmithBaseArgs(cfg)
 	args = append(args, "testbox", "warmup", workflow)
@@ -49,11 +49,11 @@ func blacksmithWarmupArgs(cfg Config, publicKey string) ([]string, error) {
 	for _, spec := range core.CacheVolumeStickyDiskSpecs(cfg.Cache.Volumes) {
 		args = append(args, "--sticky-disk", spec)
 	}
-	args = append(args, "--idle-timeout", fmt.Sprint(durationMinutesCeil(blacksmithIdleTimeout(cfg))))
+	args = append(args, "--idle-timeout", fmt.Sprint(core.DurationMinutesCeil(blacksmithIdleTimeout(cfg))))
 	return args, nil
 }
 
-func blacksmithRunArgs(cfg Config, leaseID, keyPath string, command []string, debug, shellMode bool) []string {
+func blacksmithRunArgs(cfg core.Config, leaseID, keyPath string, command []string, debug, shellMode bool) []string {
 	args := blacksmithBaseArgs(cfg)
 	args = append(args, "testbox", "run", "--id", leaseID)
 	if keyPath != "" {
@@ -66,17 +66,17 @@ func blacksmithRunArgs(cfg Config, leaseID, keyPath string, command []string, de
 	return args
 }
 
-func blacksmithStopArgs(cfg Config, leaseID string) []string {
+func blacksmithStopArgs(cfg core.Config, leaseID string) []string {
 	args := blacksmithBaseArgs(cfg)
 	return append(args, "testbox", "stop", "--id", leaseID)
 }
 
-func blacksmithListArgs(cfg Config) []string {
+func blacksmithListArgs(cfg core.Config) []string {
 	args := blacksmithBaseArgs(cfg)
 	return append(args, "testbox", "list")
 }
 
-func blacksmithListAllArgs(cfg Config) []string {
+func blacksmithListAllArgs(cfg core.Config) []string {
 	return append(blacksmithListArgs(cfg), "--all")
 }
 
@@ -103,7 +103,7 @@ func parseBlacksmithList(output string) []blacksmithListItem {
 	return items
 }
 
-func blacksmithBaseArgs(cfg Config) []string {
+func blacksmithBaseArgs(cfg core.Config) []string {
 	args := []string{}
 	if cfg.Blacksmith.Org != "" {
 		args = append(args, "--org", cfg.Blacksmith.Org)
@@ -111,7 +111,7 @@ func blacksmithBaseArgs(cfg Config) []string {
 	return args
 }
 
-func blacksmithWorkflow(cfg Config) string {
+func blacksmithWorkflow(cfg core.Config) string {
 	if cfg.Blacksmith.Workflow != "" {
 		return cfg.Blacksmith.Workflow
 	}
@@ -121,7 +121,7 @@ func blacksmithWorkflow(cfg Config) string {
 	return ""
 }
 
-func blacksmithJob(cfg Config) string {
+func blacksmithJob(cfg core.Config) string {
 	if cfg.Blacksmith.Job != "" {
 		return cfg.Blacksmith.Job
 	}
@@ -131,7 +131,7 @@ func blacksmithJob(cfg Config) string {
 	return ""
 }
 
-func blacksmithRef(cfg Config) string {
+func blacksmithRef(cfg core.Config) string {
 	if cfg.Blacksmith.Ref != "" {
 		return cfg.Blacksmith.Ref
 	}
@@ -141,11 +141,11 @@ func blacksmithRef(cfg Config) string {
 	return ""
 }
 
-func blacksmithCanFallbackToActionsField(cfg Config) bool {
+func blacksmithCanFallbackToActionsField(cfg core.Config) bool {
 	return strings.TrimSpace(cfg.Blacksmith.Workflow) != "" || blacksmithCanFallbackToActionsWorkflow(cfg)
 }
 
-func blacksmithCanFallbackToActionsWorkflow(cfg Config) bool {
+func blacksmithCanFallbackToActionsWorkflow(cfg core.Config) bool {
 	workflow := strings.TrimSpace(cfg.Actions.Workflow)
 	if workflow == "" {
 		return false
@@ -164,15 +164,11 @@ func blacksmithLooksLikeGenericHydrateWorkflow(workflow string) bool {
 	return false
 }
 
-func blacksmithIdleTimeout(cfg Config) time.Duration {
+func blacksmithIdleTimeout(cfg core.Config) time.Duration {
 	if cfg.Blacksmith.IdleTimeout > 0 {
 		return cfg.Blacksmith.IdleTimeout
 	}
 	return cfg.IdleTimeout
-}
-
-func durationMinutesCeil(duration time.Duration) int {
-	return core.DurationMinutesCeil(duration)
 }
 
 func parseBlacksmithID(output string) string {
@@ -195,20 +191,20 @@ func blacksmithSyncTimeout(env func(string) string) time.Duration {
 
 func resolveBlacksmithDiscoveryID(identifier string) (string, error) {
 	if identifier == "" {
-		return "", exit(2, "blacksmith-testbox requires --id <tbx-id-or-slug>")
+		return "", core.Exit(2, "blacksmith-testbox requires --id <tbx-id-or-slug>")
 	}
 	if parseBlacksmithID(identifier) == identifier {
 		return identifier, nil
 	}
-	claim, ok, err := resolveLeaseClaim(identifier)
+	claim, ok, err := core.ResolveLeaseClaim(identifier)
 	if err != nil {
 		return "", err
 	}
 	if !ok {
-		return "", exit(4, "unknown blacksmith testbox %q", identifier)
+		return "", core.Exit(4, "unknown blacksmith testbox %q", identifier)
 	}
 	if claim.Provider != "" && claim.Provider != blacksmithTestboxProvider {
-		return "", exit(4, "%q is claimed by provider %s", identifier, claim.Provider)
+		return "", core.Exit(4, "%q is claimed by provider %s", identifier, claim.Provider)
 	}
 	return claim.LeaseID, nil
 }
@@ -220,43 +216,23 @@ func blacksmithCommandString(command []string, shellMode bool) string {
 	if shellMode || len(command) == 1 {
 		return trimBlacksmithShellCommand(strings.Join(command, " "))
 	}
-	if shouldUseShell(command) {
-		return shellScriptFromArgv(command)
+	if core.ShouldUseShell(command) {
+		return core.ShellScriptFromArgv(command)
 	}
 	parts := make([]string, 0, len(command))
 	seenCommand := false
 	for _, word := range command {
 		if !seenCommand && core.IsShellEnvAssignment(word) {
 			key, value, _ := strings.Cut(word, "=")
-			parts = append(parts, key+"="+shellQuote(value))
+			parts = append(parts, key+"="+core.ShellQuote(value))
 			continue
 		}
 		seenCommand = true
-		parts = append(parts, shellQuote(word))
+		parts = append(parts, core.ShellQuote(word))
 	}
 	return strings.Join(parts, " ")
 }
 
 func trimBlacksmithShellCommand(command string) string {
 	return strings.TrimRight(command, " \t\r\n")
-}
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaim(identifier)
-}
-
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func shellScriptFromArgv(command []string) string {
-	return core.ShellScriptFromArgv(command)
-}
-
-func shellQuote(s string) string {
-	return core.ShellQuote(s)
 }

--- a/internal/providers/blacksmith/job_test.go
+++ b/internal/providers/blacksmith/job_test.go
@@ -55,7 +55,7 @@ func TestBlacksmithJobNoSyncAdmission(t *testing.T) {
 			if err := core.ClaimLeaseForRepoProvider(existingID, "existing-box", claimProvider, repo, time.Minute, false); err != nil {
 				t.Fatal(err)
 			}
-			before, err := readLeaseClaim(existingID)
+			before, err := core.ReadLeaseClaim(existingID)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -73,19 +73,19 @@ func TestBlacksmithJobNoSyncAdmission(t *testing.T) {
 			if err != nil && !os.IsNotExist(err) {
 				t.Fatal(err)
 			}
-			after, err := readLeaseClaim(existingID)
+			after, err := core.ReadLeaseClaim(existingID)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if !reflect.DeepEqual(before, after) {
 				t.Error("job changed an existing claim")
 			}
-			fresh, err := readLeaseClaim(freshID)
+			fresh, err := core.ReadLeaseClaim(freshID)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if !tc.sync && !tc.supported {
-				var exitErr ExitError
+				var exitErr core.ExitError
 				if !core.AsExitError(runErr, &exitErr) || exitErr.Code != 2 {
 					t.Errorf("job error=%v, want exit 2", runErr)
 				}
@@ -112,7 +112,7 @@ func TestBlacksmithJobNoSyncAdmission(t *testing.T) {
 			if len(calls) != 0 || fresh.LeaseID != "" {
 				t.Errorf("calls=%s retained claim=%q, want ZERO warmup/run/stop/keygen calls and no new claim", calls, fresh.LeaseID)
 			}
-			keyPath, err := testboxKeyPath(freshID)
+			keyPath, err := core.TestboxKeyPath(freshID)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/providers/blacksmith/no_sync_test.go
+++ b/internal/providers/blacksmith/no_sync_test.go
@@ -70,7 +70,7 @@ esac
 			}
 			args = append(args, "--", command)
 			err := (core.App{Stdout: &stdout, Stderr: &stderr}).Run(t.Context(), args)
-			var exitErr ExitError
+			var exitErr core.ExitError
 			if !core.AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "blacksmith-testbox") || !strings.Contains(err.Error(), "--no-sync is not supported") {
 				t.Errorf("error=%v, want provider-specific unsupported --no-sync exit 2", err)
 			}

--- a/internal/providers/blacksmith/nosync_test.go
+++ b/internal/providers/blacksmith/nosync_test.go
@@ -41,7 +41,7 @@ func TestBlacksmithRunNoSyncContract(t *testing.T) {
 					t.Setenv("CRABBOX_BLACKSMITH_SYNC_TIMEOUT_MS", "0")
 					t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
 					t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
-					repo := Repo{Name: "my-app", Root: t.TempDir()}
+					repo := core.Repo{Name: "my-app", Root: t.TempDir()}
 					t.Chdir(repo.Root)
 					if output, err := exec.Command("git", "init", "--quiet").CombinedOutput(); err != nil {
 						t.Fatalf("git init: %v\n%s", err, output)
@@ -56,7 +56,7 @@ func TestBlacksmithRunNoSyncContract(t *testing.T) {
 						prepareBlacksmithGuestKey(t, leaseID)
 						testOwnedBlacksmithClaim(t, leaseID, firstNonBlank(tc.slug, "jade-krill"), repo.Root)
 					}
-					before, err := readLeaseClaim(leaseID)
+					before, err := core.ReadLeaseClaim(leaseID)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -64,35 +64,35 @@ func TestBlacksmithRunNoSyncContract(t *testing.T) {
 					var stderr bytes.Buffer
 					var operations []string
 					var claimDuringRun core.LeaseClaim
-					runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+					runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 						if req.Name != "blacksmith" || len(req.Args) < 2 || req.Args[0] != "testbox" {
 							t.Fatalf("unexpected fake command: %s %v", req.Name, req.Args)
 						}
 						operations = append(operations, req.Args[1])
 						switch req.Args[1] {
 						case "warmup":
-							return LocalCommandResult{Stdout: leaseID + "\n"}, nil
+							return core.LocalCommandResult{Stdout: leaseID + "\n"}, nil
 						case "run":
 							var err error
-							claimDuringRun, err = readLeaseClaim(leaseID)
+							claimDuringRun, err = core.ReadLeaseClaim(leaseID)
 							if err != nil {
 								t.Fatal(err)
 							}
 						}
-						return LocalCommandResult{}, nil
+						return core.LocalCommandResult{}, nil
 					}}
-					cfg := baseConfig()
+					cfg := core.BaseConfig()
 					cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
-					backend, err := (Provider{}).Configure(cfg, Runtime{
+					backend, err := (Provider{}).Configure(cfg, core.Runtime{
 						Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner,
 					})
 					if err != nil {
 						t.Fatal(err)
 					}
-					result, runErr := backend.(core.DelegatedRunBackend).Run(context.Background(), RunRequest{
+					result, runErr := backend.(core.DelegatedRunBackend).Run(context.Background(), core.RunRequest{
 						Repo: repo, ID: tc.id, Command: []string{"true"}, NoSync: mode.noSync,
 					})
-					after, err := readLeaseClaim(leaseID)
+					after, err := core.ReadLeaseClaim(leaseID)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -120,7 +120,7 @@ func TestBlacksmithRunNoSyncContract(t *testing.T) {
 						return
 					}
 
-					var exitErr ExitError
+					var exitErr core.ExitError
 					if !core.AsExitError(runErr, &exitErr) || exitErr.Code != 2 {
 						t.Errorf("Run error=%v result.ExitCode=%d, want exit 2", runErr, result.ExitCode)
 					}

--- a/internal/providers/blacksmith/ownership.go
+++ b/internal/providers/blacksmith/ownership.go
@@ -26,10 +26,10 @@ type blacksmithRoute struct {
 func (r blacksmithRoute) canonical() (string, error) {
 	u, err := url.Parse(r.API)
 	if err != nil || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Opaque != "" || (u.Scheme != "https" && u.Scheme != "http") {
-		return "", exit(2, "Blacksmith ownership requires an API URL without credentials, query, or fragment")
+		return "", core.Exit(2, "Blacksmith ownership requires an API URL without credentials, query, or fragment")
 	}
 	if r.Org == "" || strings.TrimSpace(r.Org) != r.Org || strings.ContainsAny(r.Org, "\r\n\x00") {
-		return "", exit(2, "Blacksmith ownership requires an explicit authenticated organization")
+		return "", core.Exit(2, "Blacksmith ownership requires an explicit authenticated organization")
 	}
 	data, err := json.Marshal(r)
 	return string(data), err
@@ -52,7 +52,7 @@ func (b *blacksmithBackend) withRoute(ctx context.Context) (*blacksmithBackend, 
 			fields := strings.Fields(line)
 			if len(fields) == 3 && fields[0] == "*" && fields[2] == "(current)" {
 				if route.Org != "" {
-					return nil, exit(2, "ambiguous Blacksmith organization; pass --blacksmith-org")
+					return nil, core.Exit(2, "ambiguous Blacksmith organization; pass --blacksmith-org")
 				}
 				route.Org = fields[1]
 			}
@@ -70,15 +70,15 @@ func blacksmithClaimBinding(claim core.LeaseClaim) (blacksmithRoute, shared.Clai
 	var route blacksmithRoute
 	want := shared.ClaimBinding{Provider: blacksmithTestboxProvider, LeaseID: claim.LeaseID, CloudID: claim.LeaseID, Slug: claim.Slug, ProviderScope: claim.ProviderScope, ExactProviderScope: true}
 	if parseBlacksmithID(claim.LeaseID) != claim.LeaseID || claim.LeaseID == "" || claim.Revision == "" || claim.Slug == "" || claim.RepoRoot == "" || json.Unmarshal([]byte(claim.ProviderScope), &route) != nil {
-		return route, want, exit(2, "Blacksmith lease has no exact ownership binding; inspect and clean up through Blacksmith directly; --reclaim cannot adopt legacy or lost state")
+		return route, want, core.Exit(2, "Blacksmith lease has no exact ownership binding; inspect and clean up through Blacksmith directly; --reclaim cannot adopt legacy or lost state")
 	}
 	scope, err := route.canonical()
 	if err != nil || scope != claim.ProviderScope {
-		return route, want, exit(2, "Blacksmith lease has an invalid organization/API binding")
+		return route, want, core.Exit(2, "Blacksmith lease has an invalid organization/API binding")
 	}
 	for _, key := range []string{"workflow", "job", "ref"} {
 		if value := claim.Labels[key]; value == "" || strings.ContainsAny(value, "\r\n\x00") {
-			return route, want, exit(2, "Blacksmith lease has no exact %s binding", key)
+			return route, want, core.Exit(2, "Blacksmith lease has no exact %s binding", key)
 		}
 	}
 	return route, want, shared.ValidateClaimBinding(claim, want)
@@ -87,14 +87,14 @@ func blacksmithClaimBinding(claim core.LeaseClaim) (blacksmithRoute, shared.Clai
 func resolveOwnedBlacksmithClaim(id string) (core.LeaseClaim, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return core.LeaseClaim{}, exit(2, "Blacksmith requires a claimed Testbox ID or slug")
+		return core.LeaseClaim{}, core.Exit(2, "Blacksmith requires a claimed Testbox ID or slug")
 	}
 	claim, ok, exact, err := core.ResolveLeaseClaimForProviderWithExact(id, blacksmithTestboxProvider)
 	if err != nil {
 		return claim, err
 	}
 	if !ok || ((strings.HasPrefix(id, "tbx_") || core.IsCanonicalLeaseID(id)) && (!exact || claim.LeaseID != id)) {
-		return claim, exit(4, "Blacksmith resource %q has no exact local ownership claim; use read-only status/list and native Blacksmith cleanup", id)
+		return claim, core.Exit(4, "Blacksmith resource %q has no exact local ownership claim; use read-only status/list and native Blacksmith cleanup", id)
 	}
 	claims, err := core.ListLeaseClaims()
 	if err != nil {
@@ -102,7 +102,7 @@ func resolveOwnedBlacksmithClaim(id string) (core.LeaseClaim, error) {
 	}
 	for _, other := range claims {
 		if other.LeaseID != claim.LeaseID && other.CloudID == claim.CloudID && claim.CloudID != "" {
-			return claim, exit(2, "Blacksmith Testbox has conflicting local claims")
+			return claim, core.Exit(2, "Blacksmith Testbox has conflicting local claims")
 		}
 	}
 	_, _, err = blacksmithClaimBinding(claim)
@@ -122,11 +122,11 @@ func parseBlacksmithIdentity(output, id string) (blacksmithIdentity, error) {
 	var identity blacksmithIdentity
 	lines := strings.Split(strings.TrimSuffix(output, "\n"), "\n")
 	if len(lines) != 2 {
-		return identity, exit(2, "Blacksmith exact status requires one unambiguous row")
+		return identity, core.Exit(2, "Blacksmith exact status requires one unambiguous row")
 	}
 	columns := blacksmithStatusHeader.FindStringSubmatchIndex(lines[0])
 	if columns == nil || strings.ContainsAny(lines[1], "\t\r") {
-		return identity, exit(2, "Blacksmith exact status has an unsupported table")
+		return identity, core.Exit(2, "Blacksmith exact status has an unsupported table")
 	}
 	row := []rune(lines[1])
 	var values [8]string
@@ -139,20 +139,20 @@ func parseBlacksmithIdentity(output, id string) (blacksmithIdentity, error) {
 			continue // Queued records may not yet have a timestamp or Actions URL.
 		}
 		if start >= len(row) || end > len(row) {
-			return identity, exit(2, "Blacksmith exact status has an incomplete row")
+			return identity, core.Exit(2, "Blacksmith exact status has an incomplete row")
 		}
 		cell := string(row[start:end])
 		if i+1 < len(values) && !strings.HasSuffix(cell, "  ") {
-			return identity, exit(2, "Blacksmith exact status has misaligned columns")
+			return identity, core.Exit(2, "Blacksmith exact status has misaligned columns")
 		}
 		values[i] = strings.TrimRight(cell, " ")
 		if strings.HasPrefix(values[i], " ") {
-			return identity, exit(2, "Blacksmith exact status has misaligned cells")
+			return identity, core.Exit(2, "Blacksmith exact status has misaligned cells")
 		}
 	}
 	identity = blacksmithIdentity{ID: values[0], State: values[1], Workflow: values[3], Job: values[4], Ref: values[5]}
 	if identity.ID != id || identity.Workflow == "" || identity.Job == "" || identity.Ref == "" || !identity.knownState() {
-		return identity, exit(2, "Blacksmith exact status has missing or mismatched identity/state")
+		return identity, core.Exit(2, "Blacksmith exact status has missing or mismatched identity/state")
 	}
 	if identity.terminal() {
 		// Never-assigned Testboxes have no Actions URL. Native output still
@@ -160,7 +160,7 @@ func parseBlacksmithIdentity(output, id string) (blacksmithIdentity, error) {
 		// that framing an empty (or numeric-prefix) URL could be truncation.
 		runURLComplete := blacksmithStatusRunURL.MatchString(values[7]) || (values[7] == "" && len(row) == columns[2+7*2])
 		if values[6] == "" || !strings.HasSuffix(output, "\n") || !runURLComplete {
-			return identity, exit(2, "Blacksmith completion requires complete native metadata")
+			return identity, core.Exit(2, "Blacksmith completion requires complete native metadata")
 		}
 	}
 	return identity, nil
@@ -176,10 +176,10 @@ func (i blacksmithIdentity) knownState() bool {
 
 func (i blacksmithIdentity) usable() error {
 	if i.State == "hydration_failed" {
-		return exit(2, "Blacksmith Testbox hydration failed; stop the lease and create a new one")
+		return core.Exit(2, "Blacksmith Testbox hydration failed; stop the lease and create a new one")
 	}
 	if i.terminal() {
-		return exit(2, "Blacksmith Testbox has finished; create a new lease")
+		return core.Exit(2, "Blacksmith Testbox has finished; create a new lease")
 	}
 	return nil
 }
@@ -188,7 +188,7 @@ func (b *blacksmithBackend) inspectTestbox(ctx context.Context, id string) (blac
 	result, err := b.runCommand(ctx, []string{"testbox", "status", "--id", id}, nil, nil)
 	err = blacksmithContextError(ctx, err)
 	if err == nil && result.ExitCode != 0 {
-		err = exit(result.ExitCode, "Blacksmith exact status failed")
+		err = core.Exit(result.ExitCode, "Blacksmith exact status failed")
 	}
 	if err != nil {
 		if diagnostic := strings.TrimSpace(result.Stderr); diagnostic != "" {
@@ -237,14 +237,14 @@ func (b *blacksmithBackend) verifyTestbox(ctx context.Context, claim core.LeaseC
 		return blacksmithIdentity{}, err
 	}
 	if b.route == nil || *b.route != route {
-		return blacksmithIdentity{}, exit(2, "Blacksmith organization/API changed; retaining exact claim")
+		return blacksmithIdentity{}, core.Exit(2, "Blacksmith organization/API changed; retaining exact claim")
 	}
 	identity, err := b.inspectTestbox(ctx, claim.CloudID)
 	if err != nil {
 		return identity, err
 	}
 	if identity.Workflow != claim.Labels["workflow"] || identity.Job != claim.Labels["job"] || identity.Ref != claim.Labels["ref"] {
-		return identity, exit(2, "Blacksmith Testbox workflow identity changed; retaining exact claim")
+		return identity, core.Exit(2, "Blacksmith Testbox workflow identity changed; retaining exact claim")
 	}
 	return identity, nil
 }
@@ -270,7 +270,7 @@ func (b *blacksmithBackend) ownedTestbox(ctx context.Context, id, repoRoot strin
 	if repoRoot == "" {
 		err = core.WithLeaseClaimUnchangedShared(ctx, claim.LeaseID, claim, verify)
 	} else {
-		server := Server{Provider: blacksmithTestboxProvider, CloudID: claim.CloudID, Labels: shared.CloneLabels(claim.Labels)}
+		server := core.Server{Provider: blacksmithTestboxProvider, CloudID: claim.CloudID, Labels: shared.CloneLabels(claim.Labels)}
 		cfg := b.cfg
 		cfg.Provider = blacksmithTestboxProvider
 		claim, err = core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfterContext(ctx, claim.LeaseID, claim.Slug, cfg, claim.ProviderScope, server, core.SSHTarget{}, repoRoot, blacksmithIdleTimeout(b.cfg), reclaim, claim, true, verify)
@@ -297,11 +297,11 @@ func (b *blacksmithBackend) withOwnedTestbox(ctx context.Context, claim core.Lea
 }
 
 type blacksmithReconciledStop struct {
-	result LocalCommandResult
+	result core.LocalCommandResult
 	err    error
 }
 
-func (b *blacksmithBackend) printStopOutput(result LocalCommandResult) {
+func (b *blacksmithBackend) printStopOutput(result core.LocalCommandResult) {
 	if b.rt.Stdout != nil {
 		fmt.Fprint(b.rt.Stdout, result.Stdout)
 	}
@@ -376,12 +376,12 @@ func (b *blacksmithBackend) rollbackTestbox(id, pendingID, repoRoot string) {
 	defer cancel()
 	err := core.CleanupLeaseClaimIfUnchangedAfterContext(ctx, id, core.LeaseClaim{}, false, func() error {
 		if pendingID != id {
-			path, err := testboxKeyPath(id)
+			path, err := core.TestboxKeyPath(id)
 			if err != nil {
 				return err
 			}
 			if _, err := os.Lstat(filepath.Dir(path)); !os.IsNotExist(err) {
-				return exit(2, "Blacksmith rollback conflicts with existing key state")
+				return core.Exit(2, "Blacksmith rollback conflicts with existing key state")
 			}
 		}
 		identity, err := b.inspectTestbox(ctx, id)
@@ -403,21 +403,21 @@ func (b *blacksmithBackend) rollbackTestbox(id, pendingID, repoRoot string) {
 }
 
 func moveFreshBlacksmithKey(pendingID, id string) error {
-	path, err := testboxKeyPath(id)
+	path, err := core.TestboxKeyPath(id)
 	if err != nil {
 		return err
 	}
 	if _, err := os.Lstat(filepath.Dir(path)); !os.IsNotExist(err) {
-		return exit(2, "Blacksmith resource %s already has local key state; refusing to replace it", id)
+		return core.Exit(2, "Blacksmith resource %s already has local key state; refusing to replace it", id)
 	}
-	pending, err := testboxKeyPath(pendingID)
+	pending, err := core.TestboxKeyPath(pendingID)
 	if err != nil {
 		return err
 	}
 	for _, name := range []string{pending, pending + ".pub"} {
 		info, err := os.Lstat(name)
 		if err != nil || !info.Mode().IsRegular() {
-			return exit(2, "Blacksmith pending key pair is missing or not regular")
+			return core.Exit(2, "Blacksmith pending key pair is missing or not regular")
 		}
 	}
 	if err := os.MkdirAll(filepath.Dir(filepath.Dir(path)), 0o700); err != nil {

--- a/internal/providers/blacksmith/ownership_test.go
+++ b/internal/providers/blacksmith/ownership_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/openclaw/crabbox/internal/testutil"
 )
 
-type ownershipRunner func(context.Context, LocalCommandRequest) (LocalCommandResult, error)
+type ownershipRunner func(context.Context, core.LocalCommandRequest) (core.LocalCommandResult, error)
 
-func (f ownershipRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (f ownershipRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	return f(ctx, req)
 }
 
@@ -111,13 +111,13 @@ func TestBlacksmithStopRejectsUnownedIdentity(t *testing.T) {
 				}
 			}
 			calls := 0
-			cfg := baseConfig()
+			cfg := core.BaseConfig()
 			cfg.Blacksmith.Org = "example-org"
-			backend := newTestBlacksmithBackend(cfg, ownershipRunner(func(context.Context, LocalCommandRequest) (LocalCommandResult, error) {
+			backend := newTestBlacksmithBackend(cfg, ownershipRunner(func(context.Context, core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				calls++
-				return LocalCommandResult{}, nil
+				return core.LocalCommandResult{}, nil
 			}))
-			if err := backend.Stop(t.Context(), StopRequest{ID: id}); err == nil {
+			if err := backend.Stop(t.Context(), core.StopRequest{ID: id}); err == nil {
 				t.Fatal("unowned stop succeeded")
 			}
 			if calls != 0 {
@@ -133,14 +133,14 @@ func TestBlacksmithStopRequiresTerminalConfirmation(t *testing.T) {
 			isolateBlacksmithOwnership(t)
 			const id = "tbx_terminal123"
 			claim := testOwnedBlacksmithClaim(t, id, "jade-krill", "/repo")
-			key, _, err := ensureTestboxKey(id)
+			key, _, err := core.EnsureTestboxKey(id)
 			if err != nil {
 				t.Fatal(err)
 			}
 			statusCalls, stopCalls := 0, 0
-			cfg := baseConfig()
+			cfg := core.BaseConfig()
 			cfg.Blacksmith.Org = "example-org"
-			backend := newTestBlacksmithBackend(cfg, ownershipRunner(func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+			backend := newTestBlacksmithBackend(cfg, ownershipRunner(func(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				if testBlacksmithFlag(req.Args, "--org") != "example-org" || testBlacksmithFlag(req.Args, "--api-url") != "https://backend.blacksmith.sh" {
 					t.Fatalf("unbound route: %v", req.Args)
 				}
@@ -151,9 +151,9 @@ func TestBlacksmithStopRequiresTerminalConfirmation(t *testing.T) {
 				if args[1] == "stop" {
 					stopCalls++
 					if mode == "stop-error" {
-						return LocalCommandResult{ExitCode: 1}, errors.New("uncertain stop")
+						return core.LocalCommandResult{ExitCode: 1}, errors.New("uncertain stop")
 					}
-					return LocalCommandResult{}, nil
+					return core.LocalCommandResult{}, nil
 				}
 				if args[1] != "status" {
 					t.Fatalf("unexpected action: %v", req.Args)
@@ -176,15 +176,15 @@ func TestBlacksmithStopRequiresTerminalConfirmation(t *testing.T) {
 					output = strings.ReplaceAll(output, "testbox.yml", "foreign.yml")
 				case "post-status-error":
 					if stopCalls > 0 {
-						return LocalCommandResult{ExitCode: 1}, errors.New("status unavailable")
+						return core.LocalCommandResult{ExitCode: 1}, errors.New("status unavailable")
 					}
 				}
-				return LocalCommandResult{Stdout: output}, nil
+				return core.LocalCommandResult{Stdout: output}, nil
 			}))
 			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 			defer cancel()
-			err = backend.Stop(ctx, StopRequest{ID: id})
-			got, readErr := readLeaseClaim(id)
+			err = backend.Stop(ctx, core.StopRequest{ID: id})
+			got, readErr := core.ReadLeaseClaim(id)
 			if readErr != nil {
 				t.Fatal(readErr)
 			}
@@ -212,7 +212,7 @@ func TestBlacksmithRollbackPreservesAppearingClaimAndExistingKey(t *testing.T) {
 		t.Run(mode, func(t *testing.T) {
 			isolateBlacksmithOwnership(t)
 			const id = "tbx_rollback123"
-			pending, _, err := ensureTestboxKey("tbx_pending_owned")
+			pending, _, err := core.EnsureTestboxKey("tbx_pending_owned")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -233,15 +233,15 @@ func TestBlacksmithRollbackPreservesAppearingClaimAndExistingKey(t *testing.T) {
 			}
 			var existing string
 			if mode == "key" {
-				existing, _, err = ensureTestboxKey(id)
+				existing, _, err = core.EnsureTestboxKey(id)
 				if err != nil {
 					t.Fatal(err)
 				}
 			}
 			calls := 0
-			backend := newTestBlacksmithBackend(baseConfig(), ownershipRunner(func(context.Context, LocalCommandRequest) (LocalCommandResult, error) {
+			backend := newTestBlacksmithBackend(core.BaseConfig(), ownershipRunner(func(context.Context, core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				calls++
-				return LocalCommandResult{}, nil
+				return core.LocalCommandResult{}, nil
 			}))
 			backend.route = &blacksmithRoute{API: blacksmithDefaultAPI, Org: "example-org"}
 			backend.rollbackTestbox(id, "tbx_pending_owned", "/repo")
@@ -273,22 +273,22 @@ func TestBlacksmithUncertainReceiptRetainsRecoveryKey(t *testing.T) {
 		for _, failed := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%q/failed=%t", output, failed), func(t *testing.T) {
 				isolateBlacksmithOwnership(t)
-				runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+				runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 					if req.Args[1] != "warmup" {
 						t.Error("uncertain receipt selected a provider resource")
 					}
 					if failed {
-						return LocalCommandResult{ExitCode: 1, Stdout: output}, errors.New("allocation acknowledgement lost")
+						return core.LocalCommandResult{ExitCode: 1, Stdout: output}, errors.New("allocation acknowledgement lost")
 					}
-					return LocalCommandResult{Stdout: output}, nil
+					return core.LocalCommandResult{Stdout: output}, nil
 				}}
-				cfg := baseConfig()
+				cfg := core.BaseConfig()
 				cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
-				_, err := newTestBlacksmithBackend(cfg, runner).warmupLease(t.Context(), Repo{Root: t.TempDir()}, false, "")
+				_, err := newTestBlacksmithBackend(cfg, runner).warmupLease(t.Context(), core.Repo{Root: t.TempDir()}, false, "")
 				if err == nil || !strings.Contains(err.Error(), "retained pending_key=tbx_pending_") {
 					t.Fatalf("missing recovery diagnostic: %v", err)
 				}
-				path, pathErr := testboxKeyPath("tbx_placeholder")
+				path, pathErr := core.TestboxKeyPath("tbx_placeholder")
 				if pathErr != nil {
 					t.Fatal(pathErr)
 				}
@@ -316,27 +316,27 @@ func TestBlacksmithOneShotUncertainCleanupReportsRetention(t *testing.T) {
 	for _, commandExit := range []int{0, 7} {
 		t.Run(fmt.Sprint(commandExit), func(t *testing.T) {
 			isolateBlacksmithOwnership(t)
-			runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+			runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				switch req.Args[1] {
 				case "warmup":
-					return LocalCommandResult{Stdout: "tbx_retained123\n"}, nil
+					return core.LocalCommandResult{Stdout: "tbx_retained123\n"}, nil
 				case "run":
 					if commandExit != 0 {
-						return LocalCommandResult{ExitCode: commandExit}, errors.New("command failed")
+						return core.LocalCommandResult{ExitCode: commandExit}, errors.New("command failed")
 					}
-					return LocalCommandResult{}, nil
+					return core.LocalCommandResult{}, nil
 				case "stop":
-					return LocalCommandResult{ExitCode: 1}, errors.New("stop uncertain")
+					return core.LocalCommandResult{ExitCode: 1}, errors.New("stop uncertain")
 				}
-				return LocalCommandResult{}, nil
+				return core.LocalCommandResult{}, nil
 			}}
-			cfg := baseConfig()
+			cfg := core.BaseConfig()
 			cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 			var stderr bytes.Buffer
 			backend := newTestBlacksmithBackend(cfg, runner)
 			backend.rt.Stderr = &stderr
 			repo := t.TempDir()
-			result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Root: repo}, Command: []string{"true"}, TimingJSON: true, EmitProof: filepath.Join(repo, "proof.md")})
+			result, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: repo}, Command: []string{"true"}, TimingJSON: true, EmitProof: filepath.Join(repo, "proof.md")})
 			if err == nil || result.Session == nil || !result.Session.Kept {
 				t.Fatalf("false cleanup success result=%+v err=%v", result, err)
 			}
@@ -381,11 +381,11 @@ func TestBlacksmithOneShotUncertainCleanupReportsRetention(t *testing.T) {
 					t.Fatalf("%s falsely reports success: %s", name, data)
 				}
 			}
-			claim, err := readLeaseClaim("tbx_retained123")
+			claim, err := core.ReadLeaseClaim("tbx_retained123")
 			if err != nil || claim.LeaseID == "" {
 				t.Fatal("claim lost", err)
 			}
-			key, err := testboxKeyPath(claim.LeaseID)
+			key, err := core.TestboxKeyPath(claim.LeaseID)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -404,7 +404,7 @@ func testBlacksmithClaimPath(id string) (string, error) {
 func TestBlacksmithWarmupPreservesExistingKey(t *testing.T) {
 	isolateBlacksmithOwnership(t)
 	const id = "tbx_existingkey123"
-	path, _, err := ensureTestboxKey(id)
+	path, _, err := core.EnsureTestboxKey(id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -413,25 +413,25 @@ func TestBlacksmithWarmupPreservesExistingKey(t *testing.T) {
 		t.Fatal(err)
 	}
 	stopped := false
-	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if req.Args[1] == "warmup" {
-			return LocalCommandResult{Stdout: id + "\n"}, nil
+			return core.LocalCommandResult{Stdout: id + "\n"}, nil
 		}
 		if req.Args[1] == "stop" {
 			stopped = true
 		}
-		return LocalCommandResult{}, nil
+		return core.LocalCommandResult{}, nil
 	}}
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
-	if _, err := newTestBlacksmithBackend(cfg, runner).warmupLease(t.Context(), Repo{Root: "/repo"}, false, ""); err == nil {
+	if _, err := newTestBlacksmithBackend(cfg, runner).warmupLease(t.Context(), core.Repo{Root: "/repo"}, false, ""); err == nil {
 		t.Fatal("acquisition replaced existing key")
 	}
 	after, err := os.ReadFile(path)
 	if err != nil || string(after) != string(before) || stopped {
 		t.Fatalf("existing key/resource changed: err=%v stopped=%t", err, stopped)
 	}
-	claim, err := readLeaseClaim(id)
+	claim, err := core.ReadLeaseClaim(id)
 	if err != nil || claim.LeaseID != "" {
 		t.Fatalf("conflict claimed: %+v err=%v", claim, err)
 	}
@@ -443,9 +443,9 @@ func TestBlacksmithStopFencesConcurrentWriter(t *testing.T) {
 	claim := testOwnedBlacksmithClaim(t, id, "jade-krill", "/repo")
 	entered, release := make(chan struct{}), make(chan struct{})
 	stopped := false
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Blacksmith.Org = "example-org"
-	backend := newTestBlacksmithBackend(cfg, ownershipRunner(func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	backend := newTestBlacksmithBackend(cfg, ownershipRunner(func(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		args := req.Args
 		if args[0] == "--org" {
 			args = args[2:]
@@ -455,21 +455,21 @@ func TestBlacksmithStopFencesConcurrentWriter(t *testing.T) {
 			select {
 			case <-release:
 			case <-ctx.Done():
-				return LocalCommandResult{ExitCode: 1}, ctx.Err()
+				return core.LocalCommandResult{ExitCode: 1}, ctx.Err()
 			}
 			stopped = true
-			return LocalCommandResult{}, nil
+			return core.LocalCommandResult{}, nil
 		}
 		state := "ready"
 		if stopped {
 			state = "completed"
 		}
-		return LocalCommandResult{Stdout: testBlacksmithStatus(id, state)}, nil
+		return core.LocalCommandResult{Stdout: testBlacksmithStatus(id, state)}, nil
 	}))
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	done := make(chan error, 1)
-	go func() { done <- backend.Stop(ctx, StopRequest{ID: id}) }()
+	go func() { done <- backend.Stop(ctx, core.StopRequest{ID: id}) }()
 	select {
 	case <-entered:
 	case <-ctx.Done():
@@ -487,7 +487,7 @@ func TestBlacksmithStopFencesConcurrentWriter(t *testing.T) {
 	}
 	close(release)
 	stopErr, writerErr := <-done, <-writer
-	current, err := readLeaseClaim(id)
+	current, err := core.ReadLeaseClaim(id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -507,7 +507,7 @@ func TestBlacksmithStopCancelsActiveRun(t *testing.T) {
 			const id = "tbx_cancel123"
 			repo := t.TempDir()
 			testOwnedBlacksmithClaim(t, id, "jade-krill", repo)
-			key, _, err := ensureTestboxKey(id)
+			key, _, err := core.EnsureTestboxKey(id)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -515,9 +515,9 @@ func TestBlacksmithStopCancelsActiveRun(t *testing.T) {
 			var stopped atomic.Bool
 			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 			defer cancel()
-			cfg := baseConfig()
+			cfg := core.BaseConfig()
 			cfg.Blacksmith.Org = "example-org"
-			backend := newTestBlacksmithBackend(cfg, ownershipRunner(func(runCtx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+			backend := newTestBlacksmithBackend(cfg, ownershipRunner(func(runCtx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				args := req.Args
 				if args[0] == "--org" {
 					args = args[2:]
@@ -528,7 +528,7 @@ func TestBlacksmithStopCancelsActiveRun(t *testing.T) {
 					if stopped.Load() {
 						state = "completed"
 					}
-					return LocalCommandResult{Stdout: testBlacksmithStatus(id, state)}, nil
+					return core.LocalCommandResult{Stdout: testBlacksmithStatus(id, state)}, nil
 				case "run":
 					close(entered)
 					if hung {
@@ -539,19 +539,19 @@ func TestBlacksmithStopCancelsActiveRun(t *testing.T) {
 						case <-runCtx.Done():
 						}
 					}
-					return LocalCommandResult{ExitCode: 7}, errors.New("remote workload cancelled")
+					return core.LocalCommandResult{ExitCode: 7}, errors.New("remote workload cancelled")
 				case "stop":
 					stopped.Store(true)
 					close(remoteStopped)
-					return LocalCommandResult{}, nil
+					return core.LocalCommandResult{}, nil
 				default:
-					return LocalCommandResult{}, fmt.Errorf("unexpected native operation: %v", args)
+					return core.LocalCommandResult{}, fmt.Errorf("unexpected native operation: %v", args)
 				}
 			}))
 			backend.rt.Stdout, backend.rt.Stderr = io.Discard, io.Discard
 			runDone := make(chan error, 1)
 			go func() {
-				_, err := backend.Run(ctx, RunRequest{ID: id, Repo: Repo{Root: repo}, Command: []string{"long-running"}})
+				_, err := backend.Run(ctx, core.RunRequest{ID: id, Repo: core.Repo{Root: repo}, Command: []string{"long-running"}})
 				runDone <- err
 			}()
 			select {
@@ -568,13 +568,13 @@ func TestBlacksmithStopCancelsActiveRun(t *testing.T) {
 			case <-time.After(30 * time.Millisecond):
 			}
 			stopCtx, cancelStop := context.WithTimeout(ctx, 250*time.Millisecond)
-			stopErr := backend.Stop(stopCtx, StopRequest{ID: id})
+			stopErr := backend.Stop(stopCtx, core.StopRequest{ID: id})
 			cancelStop()
 			if !stopped.Load() {
 				t.Fatal("stop could not reach active workload")
 			}
 			if hung {
-				claim, err := readLeaseClaim(id)
+				claim, err := core.ReadLeaseClaim(id)
 				_, keyErr := os.Stat(key)
 				if !errors.Is(stopErr, context.DeadlineExceeded) || err != nil || claim.LeaseID != id || keyErr != nil {
 					t.Fatalf("hung command cleanup lost state: stop=%v claim=%+v err=%v key=%v", stopErr, claim, err, keyErr)
@@ -597,16 +597,16 @@ func TestBlacksmithRejectsHydrationFailedReuse(t *testing.T) {
 	isolateBlacksmithOwnership(t)
 	const id = "tbx_hydration123"
 	claim := testOwnedBlacksmithClaim(t, id, "jade-krill", "/repo")
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Blacksmith.Org = "example-org"
-	backend := newTestBlacksmithBackend(cfg, ownershipRunner(func(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	backend := newTestBlacksmithBackend(cfg, ownershipRunner(func(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if req.Args[1] != "status" {
 			t.Error("hydration failure reached mutation")
 		}
-		return LocalCommandResult{Stdout: testBlacksmithStatus(id, "hydration_failed")}, nil
+		return core.LocalCommandResult{Stdout: testBlacksmithStatus(id, "hydration_failed")}, nil
 	}))
 	_, _, err := backend.ownedTestbox(t.Context(), id, "/repo", false)
-	after, readErr := readLeaseClaim(id)
+	after, readErr := core.ReadLeaseClaim(id)
 	if err == nil || !strings.Contains(err.Error(), "hydration failed") || readErr != nil || after.Revision != claim.Revision {
 		t.Fatalf("hydration failure admitted or changed claim: err=%v read=%v claim=%+v", err, readErr, after)
 	}

--- a/internal/providers/blacksmith/prewarm_test.go
+++ b/internal/providers/blacksmith/prewarm_test.go
@@ -41,7 +41,7 @@ func TestBlacksmithPrewarmProbeAdmission(t *testing.T) {
 						if err := core.ClaimLeaseForRepoProvider(existingID, "existing-box", blacksmithTestboxProvider, repo, time.Minute, false); err != nil {
 							t.Fatal(err)
 						}
-						before, err := readLeaseClaim(existingID)
+						before, err := core.ReadLeaseClaim(existingID)
 						if err != nil {
 							t.Fatal(err)
 						}
@@ -55,11 +55,11 @@ func TestBlacksmithPrewarmProbeAdmission(t *testing.T) {
 						if err != nil && !os.IsNotExist(err) {
 							t.Fatal(err)
 						}
-						claim, err := readLeaseClaim(leaseID)
+						claim, err := core.ReadLeaseClaim(leaseID)
 						if err != nil {
 							t.Fatal(err)
 						}
-						after, err := readLeaseClaim(existingID)
+						after, err := core.ReadLeaseClaim(existingID)
 						if err != nil {
 							t.Fatal(err)
 						}
@@ -67,7 +67,7 @@ func TestBlacksmithPrewarmProbeAdmission(t *testing.T) {
 							t.Error("prewarm changed an existing claim")
 						}
 						if probe.name == "probe" {
-							var exitErr ExitError
+							var exitErr core.ExitError
 							if !core.AsExitError(runErr, &exitErr) || exitErr.Code != 2 {
 								t.Errorf("prewarm error=%v, want exit 2", runErr)
 							}
@@ -106,7 +106,7 @@ func TestBlacksmithPrewarmProbeAdmission(t *testing.T) {
 						if claim.LeaseID != "" {
 							t.Errorf("retained claim=%q, want no acquired lease", claim.LeaseID)
 						}
-						keyPath, err := testboxKeyPath(leaseID)
+						keyPath, err := core.TestboxKeyPath(leaseID)
 						if err != nil {
 							t.Fatal(err)
 						}

--- a/internal/providers/blacksmith/stop_reconciliation_test.go
+++ b/internal/providers/blacksmith/stop_reconciliation_test.go
@@ -45,7 +45,7 @@ func nativeStopStatusTable(cells ...string) string {
 func seedStopClaim(t *testing.T, id string) core.LeaseClaim {
 	t.Helper()
 	testOwnedBlacksmithClaim(t, id, "stop-"+strings.TrimPrefix(id, "tbx_"), t.TempDir())
-	key, err := testboxKeyPath(id)
+	key, err := core.TestboxKeyPath(id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func seedStopClaim(t *testing.T, id string) core.LeaseClaim {
 	if err := os.WriteFile(key, []byte("synthetic-key-"+id), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	claim, err := readLeaseClaim(id)
+	claim, err := core.ReadLeaseClaim(id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +64,7 @@ func seedStopClaim(t *testing.T, id string) core.LeaseClaim {
 
 func assertStopState(t *testing.T, claim core.LeaseClaim, retained bool) {
 	t.Helper()
-	got, err := readLeaseClaim(claim.LeaseID)
+	got, err := core.ReadLeaseClaim(claim.LeaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +75,7 @@ func assertStopState(t *testing.T, claim core.LeaseClaim, retained bool) {
 	} else if got.LeaseID != "" {
 		t.Fatalf("claim retained: %#v", got)
 	}
-	key, err := testboxKeyPath(claim.LeaseID)
+	key, err := core.TestboxKeyPath(claim.LeaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,16 +103,16 @@ func TestBlacksmithStopReconcilesCompletedClaim(t *testing.T) {
 				if err := core.ReplaceLeaseClaimIfUnchanged(id, claim, changed); err != nil {
 					t.Fatal(err)
 				}
-				claim, _ = readLeaseClaim(id)
+				claim, _ = core.ReadLeaseClaim(id)
 			}
 			var stdout, stderr bytes.Buffer
 			stopped := false
 			alreadyCompleted := mode == "never-assigned-already-completed"
 			successfulStop := mode == "successful-stop" || mode == "never-assigned-successful-stop"
 			var operations []string
-			cfg := baseConfig()
+			cfg := core.BaseConfig()
 			cfg.Blacksmith.Org = "example-org"
-			backend := newTestBlacksmithBackend(cfg, reconciliationRunner(t, func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+			backend := newTestBlacksmithBackend(cfg, reconciliationRunner(t, func(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				operations = append(operations, req.Args[1])
 				deadline, ok := ctx.Deadline()
 				if !ok || time.Until(deadline) > blacksmithCleanupTimeout {
@@ -125,7 +125,7 @@ func TestBlacksmithStopReconcilesCompletedClaim(t *testing.T) {
 						if stopped || alreadyCompleted {
 							state = "completed"
 						}
-						return LocalCommandResult{Stdout: nativeNeverAssignedStatus(id, state)}, nil
+						return core.LocalCommandResult{Stdout: nativeNeverAssignedStatus(id, state)}, nil
 					}
 					state, ip := "ready", "192.0.2.10"
 					if stopped {
@@ -134,19 +134,19 @@ func TestBlacksmithStopReconcilesCompletedClaim(t *testing.T) {
 					if mode != "with-ip" {
 						ip = ""
 					}
-					return LocalCommandResult{Stdout: nativeStopStatusTable(id, state, ip, claim.Labels["workflow"], "test", "main", "2026-08-30T12:00:00.123456Z", "https://github.com/example-org/my-app/actions/runs/123456789")}, nil
+					return core.LocalCommandResult{Stdout: nativeStopStatusTable(id, state, ip, claim.Labels["workflow"], "test", "main", "2026-08-30T12:00:00.123456Z", "https://github.com/example-org/my-app/actions/runs/123456789")}, nil
 				case "stop":
 					stopped = true
 					if successfulStop {
-						return LocalCommandResult{Stdout: "stopped\n", Stderr: "stop note\n"}, nil
+						return core.LocalCommandResult{Stdout: "stopped\n", Stderr: "stop note\n"}, nil
 					}
-					return LocalCommandResult{ExitCode: 1, Stderr: stopDiagnostic}, errors.New("exit status 1")
+					return core.LocalCommandResult{ExitCode: 1, Stderr: stopDiagnostic}, errors.New("exit status 1")
 				default:
-					return LocalCommandResult{}, errors.New("unexpected operation")
+					return core.LocalCommandResult{}, errors.New("unexpected operation")
 				}
 			}))
 			backend.rt.Stdout, backend.rt.Stderr = &stdout, &stderr
-			if err := backend.Stop(t.Context(), StopRequest{ID: claim.Slug}); err != nil {
+			if err := backend.Stop(t.Context(), core.StopRequest{ID: claim.Slug}); err != nil {
 				t.Fatal(err)
 			}
 			wantOperations := []string{"status", "stop", "status", "status"}
@@ -285,12 +285,12 @@ func TestBlacksmithStopReconciliationFailsClosed(t *testing.T) {
 			}
 			stopped := false
 			var operations []string
-			cfg := baseConfig()
+			cfg := core.BaseConfig()
 			cfg.Blacksmith.Org = "example-org"
-			backend := newTestBlacksmithBackend(cfg, reconciliationRunner(t, func(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+			backend := newTestBlacksmithBackend(cfg, reconciliationRunner(t, func(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				operations = append(operations, req.Args[1])
 				if req.Args[1] == "status" && !stopped {
-					return LocalCommandResult{Stdout: nativeStopStatus(id, "ready", "")}, nil
+					return core.LocalCommandResult{Stdout: nativeStopStatus(id, "ready", "")}, nil
 				}
 				if req.Args[1] == tt.cancelAt {
 					cancel()
@@ -298,19 +298,19 @@ func TestBlacksmithStopReconciliationFailsClosed(t *testing.T) {
 				switch req.Args[1] {
 				case "stop":
 					stopped = true
-					return LocalCommandResult{ExitCode: 1, Stdout: "stop stdout\n", Stderr: stopDiagnostic}, errors.New("exit status 1")
+					return core.LocalCommandResult{ExitCode: 1, Stdout: "stop stdout\n", Stderr: stopDiagnostic}, errors.New("exit status 1")
 				case "status":
 					if tt.deadline {
 						<-ctx.Done()
 					}
-					return LocalCommandResult{ExitCode: tt.code, Stdout: tt.stdout, Stderr: tt.stderr}, tt.err
+					return core.LocalCommandResult{ExitCode: tt.code, Stdout: tt.stdout, Stderr: tt.stderr}, tt.err
 				default:
-					return LocalCommandResult{}, errors.New("unexpected operation")
+					return core.LocalCommandResult{}, errors.New("unexpected operation")
 				}
 			}))
 			backend.rt.Stdout, backend.rt.Stderr = &stdout, &stderr
-			err := backend.Stop(ctx, StopRequest{ID: id})
-			var exitErr ExitError
+			err := backend.Stop(ctx, core.StopRequest{ID: id})
+			var exitErr core.ExitError
 			if !core.AsExitError(err, &exitErr) || exitErr.Code != 1 || !strings.Contains(exitErr.Message, "blacksmith failed: exit status 1") || !strings.Contains(exitErr.Message, "verification") {
 				t.Fatalf("original stop error lost: %v", err)
 			}
@@ -338,12 +338,12 @@ func TestBlacksmithStopRejectsForeignProviderClaim(t *testing.T) {
 	if err := core.ReplaceLeaseClaimIfUnchanged(claim.LeaseID, claim, foreign); err != nil {
 		t.Fatal(err)
 	}
-	foreign, _ = readLeaseClaim(claim.LeaseID)
-	backend := newTestBlacksmithBackend(baseConfig(), ownershipRunner(func(context.Context, LocalCommandRequest) (LocalCommandResult, error) {
+	foreign, _ = core.ReadLeaseClaim(claim.LeaseID)
+	backend := newTestBlacksmithBackend(core.BaseConfig(), ownershipRunner(func(context.Context, core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		t.Error("foreign claim reached provider")
-		return LocalCommandResult{}, nil
+		return core.LocalCommandResult{}, nil
 	}))
-	if err := backend.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err == nil {
+	if err := backend.Stop(t.Context(), core.StopRequest{ID: claim.LeaseID}); err == nil {
 		t.Fatal("foreign claim stopped")
 	}
 	assertStopState(t, foreign, true)
@@ -359,11 +359,11 @@ func TestBlacksmithReconciliationRetainsOriginalErrorUntilFinalized(t *testing.T
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 			inspections := 0
-			cfg := baseConfig()
+			cfg := core.BaseConfig()
 			cfg.Blacksmith.Org = "example-org"
-			backend := newTestBlacksmithBackend(cfg, reconciliationRunner(t, func(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+			backend := newTestBlacksmithBackend(cfg, reconciliationRunner(t, func(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				if req.Args[1] == "stop" {
-					return LocalCommandResult{ExitCode: 1, Stdout: "stop stdout\n", Stderr: stopDiagnostic}, errors.New("exit status 1")
+					return core.LocalCommandResult{ExitCode: 1, Stdout: "stop stdout\n", Stderr: stopDiagnostic}, errors.New("exit status 1")
 				}
 				inspections++
 				state := "completed"
@@ -380,7 +380,7 @@ func TestBlacksmithReconciliationRetainsOriginalErrorUntilFinalized(t *testing.T
 				if inspections == 3 {
 					switch mode {
 					case "status-error":
-						return LocalCommandResult{ExitCode: 7}, errors.New("final verification unavailable")
+						return core.LocalCommandResult{ExitCode: 7}, errors.New("final verification unavailable")
 					case "cancelled":
 						cancel()
 					case "changed-identity":
@@ -389,11 +389,11 @@ func TestBlacksmithReconciliationRetainsOriginalErrorUntilFinalized(t *testing.T
 						output = strings.Replace(output, "completed", "ready    ", 1)
 					}
 				}
-				return LocalCommandResult{Stdout: output}, nil
+				return core.LocalCommandResult{Stdout: output}, nil
 			}))
 			backend.rt.Stdout, backend.rt.Stderr = &stdout, &stderr
-			err := backend.Stop(ctx, StopRequest{ID: claim.LeaseID})
-			var nativeErr ExitError
+			err := backend.Stop(ctx, core.StopRequest{ID: claim.LeaseID})
+			var nativeErr core.ExitError
 			if !core.AsExitError(err, &nativeErr) || nativeErr.Code != 1 || !strings.Contains(nativeErr.Message, "blacksmith failed: exit status 1") || nativeErr.Message != err.Error() || inspections != 3 {
 				t.Fatalf("original failure lost after finalization: err=%v inspections=%d", err, inspections)
 			}
@@ -417,7 +417,7 @@ func TestBlacksmithStopRejectsChangedClaimBeforeProviderCalls(t *testing.T) {
 			if err := core.ReplaceLeaseClaimIfUnchanged(claim.LeaseID, claim, replacement); err != nil {
 				t.Fatal(err)
 			}
-			rewritten, err := readLeaseClaim(claim.LeaseID)
+			rewritten, err := core.ReadLeaseClaim(claim.LeaseID)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -429,7 +429,7 @@ func TestBlacksmithStopRejectsChangedClaimBeforeProviderCalls(t *testing.T) {
 				t.Fatalf("unexpected rewrite: got %#v want %#v", rewritten, replacement)
 			}
 			runner := &blacksmithFuncRunner{}
-			backend := newTestBlacksmithBackend(baseConfig(), runner)
+			backend := newTestBlacksmithBackend(core.BaseConfig(), runner)
 			err = backend.stopClaimedTestbox(t.Context(), claim.LeaseID, claim)
 			if err == nil || !strings.Contains(err.Error(), "claim changed; retry") || len(runner.calls) != 0 {
 				t.Fatalf("replacement was not fenced: err=%v calls=%v", err, runner.calls)
@@ -457,35 +457,35 @@ func testBlacksmithStopHoldsClaimFenceDuringStatus(t *testing.T, neverAssigned b
 	defer release()
 	stopped := false
 	inspections := 0
-	cfg := baseConfig()
+	cfg := core.BaseConfig()
 	cfg.Blacksmith.Org = "example-org"
-	backend := newTestBlacksmithBackend(cfg, reconciliationRunner(t, func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	backend := newTestBlacksmithBackend(cfg, reconciliationRunner(t, func(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		switch req.Args[1] {
 		case "stop":
 			stopped = true
-			return LocalCommandResult{ExitCode: 1, Stderr: stopDiagnostic}, errors.New("exit status 1")
+			return core.LocalCommandResult{ExitCode: 1, Stderr: stopDiagnostic}, errors.New("exit status 1")
 		case "status":
 			inspections++
 			if !stopped {
 				if neverAssigned {
-					return LocalCommandResult{Stdout: nativeNeverAssignedStatus(claim.LeaseID, "queued")}, nil
+					return core.LocalCommandResult{Stdout: nativeNeverAssignedStatus(claim.LeaseID, "queued")}, nil
 				}
-				return LocalCommandResult{Stdout: nativeStopStatus(claim.LeaseID, "ready", "")}, nil
+				return core.LocalCommandResult{Stdout: nativeStopStatus(claim.LeaseID, "ready", "")}, nil
 			}
 			if inspections == 2 {
 				close(entered)
 				select {
 				case <-proceed:
 				case <-ctx.Done():
-					return LocalCommandResult{}, ctx.Err()
+					return core.LocalCommandResult{}, ctx.Err()
 				}
 			}
 			if neverAssigned {
-				return LocalCommandResult{Stdout: nativeNeverAssignedStatus(claim.LeaseID, "completed")}, nil
+				return core.LocalCommandResult{Stdout: nativeNeverAssignedStatus(claim.LeaseID, "completed")}, nil
 			}
-			return LocalCommandResult{Stdout: nativeStopStatus(claim.LeaseID, "completed", "")}, nil
+			return core.LocalCommandResult{Stdout: nativeStopStatus(claim.LeaseID, "completed", "")}, nil
 		default:
-			return LocalCommandResult{}, errors.New("unexpected command")
+			return core.LocalCommandResult{}, errors.New("unexpected command")
 		}
 	}))
 	done := make(chan error, 1)
@@ -513,7 +513,7 @@ func testBlacksmithStopHoldsClaimFenceDuringStatus(t *testing.T, neverAssigned b
 		if stopErr == nil {
 			t.Fatal("replacement was deleted")
 		}
-		after, _ := readLeaseClaim(claim.LeaseID)
+		after, _ := core.ReadLeaseClaim(claim.LeaseID)
 		assertStopState(t, after, true)
 	} else {
 		if stopErr != nil {
@@ -525,11 +525,11 @@ func testBlacksmithStopHoldsClaimFenceDuringStatus(t *testing.T, neverAssigned b
 
 func TestBlacksmithClaimlessStopRefusesProviderAccess(t *testing.T) {
 	isolateBlacksmithOwnership(t)
-	backend := newTestBlacksmithBackend(baseConfig(), ownershipRunner(func(context.Context, LocalCommandRequest) (LocalCommandResult, error) {
+	backend := newTestBlacksmithBackend(core.BaseConfig(), ownershipRunner(func(context.Context, core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		t.Error("unclaimed ID reached provider")
-		return LocalCommandResult{}, nil
+		return core.LocalCommandResult{}, nil
 	}))
-	if err := backend.Stop(t.Context(), StopRequest{ID: "tbx_raw123"}); err == nil {
+	if err := backend.Stop(t.Context(), core.StopRequest{ID: "tbx_raw123"}); err == nil {
 		t.Fatal("unclaimed stop succeeded")
 	}
 }
@@ -556,22 +556,22 @@ func TestBlacksmithOneShotReconciliationPreservesCommandResult(t *testing.T) {
 				var stderr bytes.Buffer
 				stopped := false
 				keyMoved := false
-				runner := reconciliationRunner(t, func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+				runner := reconciliationRunner(t, func(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 					switch req.Args[1] {
 					case "warmup":
-						return LocalCommandResult{Stdout: id + "\n"}, nil
+						return core.LocalCommandResult{Stdout: id + "\n"}, nil
 					case "run":
 						fmt.Fprint(req.Stderr, command.output)
 						if command.code != 0 {
-							return LocalCommandResult{ExitCode: command.code}, fmt.Errorf("exit status %d", command.code)
+							return core.LocalCommandResult{ExitCode: command.code}, fmt.Errorf("exit status %d", command.code)
 						}
-						return LocalCommandResult{}, nil
+						return core.LocalCommandResult{}, nil
 					case "stop":
 						stopped = true
-						return LocalCommandResult{ExitCode: 1, Stderr: stopDiagnostic}, errors.New("exit status 1")
+						return core.LocalCommandResult{ExitCode: 1, Stderr: stopDiagnostic}, errors.New("exit status 1")
 					case "status":
 						if !stopped {
-							return LocalCommandResult{Stdout: nativeStopStatus(id, "ready", "")}, nil
+							return core.LocalCommandResult{Stdout: nativeStopStatus(id, "ready", "")}, nil
 						}
 						deadline, ok := ctx.Deadline()
 						if !ok || time.Until(deadline) > blacksmithCleanupTimeout {
@@ -581,7 +581,7 @@ func TestBlacksmithOneShotReconciliationPreservesCommandResult(t *testing.T) {
 						if state == "artifact-failure" {
 							observed = "completed"
 							if !keyMoved {
-								key, err := testboxKeyPath(id)
+								key, err := core.TestboxKeyPath(id)
 								if err != nil {
 									t.Fatal(err)
 								}
@@ -595,23 +595,23 @@ func TestBlacksmithOneShotReconciliationPreservesCommandResult(t *testing.T) {
 								keyMoved = true
 							}
 						}
-						return LocalCommandResult{Stdout: nativeStopStatus(id, observed, "")}, nil
+						return core.LocalCommandResult{Stdout: nativeStopStatus(id, observed, "")}, nil
 					default:
 						t.Fatalf("unexpected command: %v", req.Args)
-						return LocalCommandResult{}, nil
+						return core.LocalCommandResult{}, nil
 					}
 				})
-				cfg := baseConfig()
+				cfg := core.BaseConfig()
 				cfg.Blacksmith.Org = "example-org"
 				cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 				backend := newTestBlacksmithBackend(cfg, runner)
 				backend.rt.Stderr = &stderr
-				result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Root: repo}, Command: []string{"test-runner"}, TimingJSON: true})
+				result, err := backend.Run(t.Context(), core.RunRequest{Repo: core.Repo{Root: repo}, Command: []string{"test-runner"}, TimingJSON: true})
 				wantCode := command.code
 				if state != "completed" && wantCode == 0 {
 					wantCode = 1
 				}
-				var exitErr ExitError
+				var exitErr core.ExitError
 				if wantCode == 0 {
 					if err != nil {
 						t.Fatal(err)
@@ -638,11 +638,11 @@ func TestBlacksmithOneShotReconciliationPreservesCommandResult(t *testing.T) {
 				if len(reports) != 1 || reports[0].ExitCode != wantCode || reports[0].LeaseID != id || reports[0].CommandMs != result.Command.Milliseconds() || reports[0].TotalMs != result.Total.Milliseconds() {
 					t.Fatalf("timing changed: %#v; result=%#v", reports, result)
 				}
-				claim, err := readLeaseClaim(id)
+				claim, err := core.ReadLeaseClaim(id)
 				if err != nil {
 					t.Fatal(err)
 				}
-				key, err := testboxKeyPath(id)
+				key, err := core.TestboxKeyPath(id)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -673,20 +673,20 @@ func TestBlacksmithReconciliationRespectsKeepAndReuse(t *testing.T) {
 			repo := t.TempDir()
 			t.Chdir(repo)
 			const id = "tbx_kept123"
-			runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+			runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				switch req.Args[1] {
 				case "warmup":
-					return LocalCommandResult{Stdout: id + "\n"}, nil
+					return core.LocalCommandResult{Stdout: id + "\n"}, nil
 				case "run":
-					return LocalCommandResult{ExitCode: 255}, errors.New("exit status 255")
+					return core.LocalCommandResult{ExitCode: 255}, errors.New("exit status 255")
 				default:
 					t.Fatalf("kept/reused testbox reached cleanup: %v", req.Args)
-					return LocalCommandResult{}, nil
+					return core.LocalCommandResult{}, nil
 				}
 			}}
-			cfg := baseConfig()
+			cfg := core.BaseConfig()
 			cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
-			req := RunRequest{Repo: Repo{Root: repo}, Command: []string{"false"}, Keep: mode == "keep", KeepOnFailure: mode == "keep-on-failure"}
+			req := core.RunRequest{Repo: core.Repo{Root: repo}, Command: []string{"false"}, Keep: mode == "keep", KeepOnFailure: mode == "keep-on-failure"}
 			if mode == "reuse" {
 				req.ID = id
 				prepareBlacksmithGuestKey(t, id)
@@ -695,11 +695,11 @@ func TestBlacksmithReconciliationRespectsKeepAndReuse(t *testing.T) {
 			backend := newTestBlacksmithBackend(cfg, runner)
 			backend.rt.Stderr = io.Discard
 			result, err := backend.Run(t.Context(), req)
-			var exitErr ExitError
+			var exitErr core.ExitError
 			if !errors.As(err, &exitErr) || exitErr.Code != 255 || result.ExitCode != 255 || result.Session == nil || !result.Session.Kept {
 				t.Fatalf("kept result=%#v err=%v", result, err)
 			}
-			claim, err := readLeaseClaim(id)
+			claim, err := core.ReadLeaseClaim(id)
 			if err != nil || claim.LeaseID != id {
 				t.Fatalf("kept claim=%#v err=%v", claim, err)
 			}
@@ -707,9 +707,9 @@ func TestBlacksmithReconciliationRespectsKeepAndReuse(t *testing.T) {
 	}
 }
 
-func reconciliationRunner(t *testing.T, fn func(context.Context, LocalCommandRequest) (LocalCommandResult, error)) ownershipRunner {
+func reconciliationRunner(t *testing.T, fn func(context.Context, core.LocalCommandRequest) (core.LocalCommandResult, error)) ownershipRunner {
 	t.Helper()
-	return func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	return func(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if testBlacksmithFlag(req.Args, "--org") != "example-org" || testBlacksmithFlag(req.Args, "--api-url") != "https://backend.blacksmith.sh" {
 			t.Error("native operation lost exact route")
 		}
@@ -727,11 +727,11 @@ func TestBlacksmithStopArtifactFinalization(t *testing.T) {
 			isolateBlacksmithOwnership(t)
 			const id = "tbx_artifact123"
 			claim := testOwnedBlacksmithClaim(t, id, "artifact-krill", t.TempDir())
-			key, err := testboxKeyPath(id)
+			key, err := core.TestboxKeyPath(id)
 			if err != nil {
 				t.Fatal(err)
 			}
-			sibling, err := testboxKeyPath("tbx_sibling123")
+			sibling, err := core.TestboxKeyPath("tbx_sibling123")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -768,12 +768,12 @@ func TestBlacksmithStopArtifactFinalization(t *testing.T) {
 			var stderr bytes.Buffer
 			inspections, stops := 0, 0
 			nativeCause := errors.New("synthetic stop failure")
-			cfg := baseConfig()
+			cfg := core.BaseConfig()
 			cfg.Blacksmith.Org = "example-org"
-			backend := newTestBlacksmithBackend(cfg, reconciliationRunner(t, func(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+			backend := newTestBlacksmithBackend(cfg, reconciliationRunner(t, func(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				if req.Args[1] == "stop" {
 					stops++
-					return LocalCommandResult{ExitCode: 9, Stderr: stopDiagnostic}, nativeCause
+					return core.LocalCommandResult{ExitCode: 9, Stderr: stopDiagnostic}, nativeCause
 				}
 				inspections++
 				state := "completed"
@@ -784,13 +784,13 @@ func TestBlacksmithStopArtifactFinalization(t *testing.T) {
 					}
 				}
 				if neverAssigned {
-					return LocalCommandResult{Stdout: nativeNeverAssignedStatus(id, state)}, nil
+					return core.LocalCommandResult{Stdout: nativeNeverAssignedStatus(id, state)}, nil
 				}
-				return LocalCommandResult{Stdout: nativeStopStatus(id, state, "")}, nil
+				return core.LocalCommandResult{Stdout: nativeStopStatus(id, state, "")}, nil
 			}))
 			backend.rt.Stderr = &stderr
-			err = backend.Stop(t.Context(), StopRequest{ID: id})
-			got, readErr := readLeaseClaim(id)
+			err = backend.Stop(t.Context(), core.StopRequest{ID: id})
+			got, readErr := core.ReadLeaseClaim(id)
 			if readErr != nil {
 				t.Fatal(readErr)
 			}
@@ -810,7 +810,7 @@ func TestBlacksmithStopArtifactFinalization(t *testing.T) {
 				}
 			}
 			if mode == "reconciled-unsafe" {
-				var exitErr ExitError
+				var exitErr core.ExitError
 				if !core.AsExitError(err, &exitErr) || exitErr.Code != 9 || exitErr.Message != err.Error() || !errors.Is(err, nativeCause) || stops != 1 || inspections != 3 {
 					t.Errorf("late failure lost native error: %v stops=%d inspections=%d", err, stops, inspections)
 				}
@@ -837,30 +837,30 @@ func TestBlacksmithStopVerificationDiagnostics(t *testing.T) {
 			ctx, cancel := context.WithCancelCause(t.Context())
 			defer cancel(nil)
 			inspections := 0
-			cfg := baseConfig()
+			cfg := core.BaseConfig()
 			cfg.Blacksmith.Org = "example-org"
-			backend := newTestBlacksmithBackend(cfg, reconciliationRunner(t, func(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+			backend := newTestBlacksmithBackend(cfg, reconciliationRunner(t, func(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				if req.Args[1] == "stop" {
 					if mode == "cancel-stop" {
 						cancel(cancelCause)
 					}
-					return LocalCommandResult{ExitCode: 9}, nativeCause
+					return core.LocalCommandResult{ExitCode: 9}, nativeCause
 				}
 				inspections++
 				if inspections == 1 || mode == "nonterminal" {
-					return LocalCommandResult{Stdout: nativeStopStatus(claim.LeaseID, "ready", "")}, nil
+					return core.LocalCommandResult{Stdout: nativeStopStatus(claim.LeaseID, "ready", "")}, nil
 				}
 				if mode == "cancel-query" {
 					cancel(cancelCause)
-					return LocalCommandResult{Stdout: nativeStopStatus(claim.LeaseID, "completed", "")}, nil
+					return core.LocalCommandResult{Stdout: nativeStopStatus(claim.LeaseID, "completed", "")}, nil
 				}
 				if mode == "late-query-error" && inspections == 2 {
-					return LocalCommandResult{Stdout: nativeStopStatus(claim.LeaseID, "completed", "")}, nil
+					return core.LocalCommandResult{Stdout: nativeStopStatus(claim.LeaseID, "completed", "")}, nil
 				}
-				return LocalCommandResult{ExitCode: 7, Stdout: nativeStopStatus(claim.LeaseID, "completed", ""), Stderr: "authentication unavailable\n"}, queryCause
+				return core.LocalCommandResult{ExitCode: 7, Stdout: nativeStopStatus(claim.LeaseID, "completed", ""), Stderr: "authentication unavailable\n"}, queryCause
 			}))
-			err := backend.Stop(ctx, StopRequest{ID: claim.LeaseID})
-			var exitErr ExitError
+			err := backend.Stop(ctx, core.StopRequest{ID: claim.LeaseID})
+			var exitErr core.ExitError
 			if !core.AsExitError(err, &exitErr) || exitErr.Code != 9 || exitErr.Message != err.Error() || strings.Count(exitErr.Message, nativeCause.Error()) != 1 || !errors.Is(err, nativeCause) {
 				t.Errorf("native diagnostic/cause lost: %v", err)
 			}
@@ -886,7 +886,7 @@ func TestBlacksmithStopVerificationDiagnostics(t *testing.T) {
 func TestBlacksmithRollbackWarnsOnArtifactFailure(t *testing.T) {
 	isolateBlacksmithOwnership(t)
 	const pending = "tbx_pending_artifact123"
-	key, err := testboxKeyPath(pending)
+	key, err := core.TestboxKeyPath(pending)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -902,11 +902,11 @@ func TestBlacksmithRollbackWarnsOnArtifactFailure(t *testing.T) {
 		t.Skipf("directory symlink unavailable: %v", err)
 	}
 	var stderr bytes.Buffer
-	backend := newTestBlacksmithBackend(baseConfig(), reconciliationRunner(t, func(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	backend := newTestBlacksmithBackend(core.BaseConfig(), reconciliationRunner(t, func(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 		if req.Args[1] != "status" {
 			t.Fatalf("already-terminal rollback reached %v", req.Args)
 		}
-		return LocalCommandResult{Stdout: nativeStopStatus("tbx_rollback123", "completed", "")}, nil
+		return core.LocalCommandResult{Stdout: nativeStopStatus("tbx_rollback123", "completed", "")}, nil
 	}))
 	backend.route = &blacksmithRoute{API: blacksmithDefaultAPI, Org: "example-org"}
 	backend.rt.Stderr = &stderr

--- a/internal/providers/blacksmith/warmup_bookkeeping_test.go
+++ b/internal/providers/blacksmith/warmup_bookkeeping_test.go
@@ -161,7 +161,7 @@ esac
 		t.Fatalf("allocation repeated or ready lease stopped: %s", data)
 	}
 	if mode == "allocation failure" {
-		var exitErr ExitError
+		var exitErr core.ExitError
 		if !errors.As(err, &exitErr) || exitErr.Code != 7 {
 			t.Fatalf("allocation error=%v", err)
 		}
@@ -203,11 +203,11 @@ esac
 	if report.LeaseID != "tbx_ready123" || report.Slug != "ready-crab" || report.ExitCode != 0 {
 		t.Fatalf("timing=%+v", report)
 	}
-	claim, err := readLeaseClaim("tbx_ready123")
+	claim, err := core.ReadLeaseClaim("tbx_ready123")
 	if err != nil || claim.Slug != "ready-crab" {
 		t.Fatalf("retained claim=%+v err=%v", claim, err)
 	}
-	key, err := testboxKeyPath("tbx_ready123")
+	key, err := core.TestboxKeyPath("tbx_ready123")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,17 +233,17 @@ func TestBlacksmithWarmupBookkeepingFinalization(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", home)
 			clock := &bookkeepingClock{now: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)}
 			var stdout, stderr bytes.Buffer
-			runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+			runner := &blacksmithFuncRunner{fn: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 				if !strings.Contains(strings.Join(req.Args, " "), "testbox warmup") {
 					t.Fatalf("unexpected provider operation: %v", req.Args)
 				}
 				clock.now = clock.now.Add(time.Second)
 				if mode == "allocation failure" {
-					return LocalCommandResult{ExitCode: 7}, errors.New("allocation rejected")
+					return core.LocalCommandResult{ExitCode: 7}, errors.New("allocation rejected")
 				}
-				return LocalCommandResult{Stdout: "tbx_ready123\n"}, nil
+				return core.LocalCommandResult{Stdout: "tbx_ready123\n"}, nil
 			}}
-			cfg := baseConfig()
+			cfg := core.BaseConfig()
 			cfg.Blacksmith.Workflow = "ci.yml"
 			backend := newTestBlacksmithBackend(cfg, runner)
 			backend.rt.Clock, backend.rt.Stdout, backend.rt.Stderr = clock, &stdout, &stderr
@@ -253,14 +253,14 @@ func TestBlacksmithWarmupBookkeepingFinalization(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			finalizations := 0
-			err := backend.Warmup(ctx, WarmupRequest{
-				Repo: Repo{Root: home}, RequestedSlug: "ready-crab", Keep: true, TimingJSON: true,
+			err := backend.Warmup(ctx, core.WarmupRequest{
+				Repo: core.Repo{Root: home}, RequestedSlug: "ready-crab", Keep: true, TimingJSON: true,
 				BeforeComplete: func() {
 					finalizations++
 					if !strings.Contains(stdout.String(), "leased tbx_ready123 slug=ready-crab") || strings.Contains(stdout.String(), "warmup complete") || stderr.Len() != 0 {
 						t.Fatalf("premature final output: stdout=%q stderr=%q", stdout.String(), stderr.String())
 					}
-					if _, err := readLeaseClaim("tbx_ready123"); err != nil {
+					if _, err := core.ReadLeaseClaim("tbx_ready123"); err != nil {
 						t.Fatalf("lease not retained before finalization: %v", err)
 					}
 					clock.now = clock.now.Add(4 * time.Second)
@@ -294,7 +294,7 @@ func TestBlacksmithWarmupBookkeepingFinalization(t *testing.T) {
 			if finalizations != 1 || len(runner.calls) != 3 || strings.Count(stdout.String(), "warmup complete total=5s") != 1 {
 				t.Fatalf("finalizations=%d calls=%v stdout=%q", finalizations, runner.calls, stdout.String())
 			}
-			if _, err := readLeaseClaim("tbx_ready123"); err != nil {
+			if _, err := core.ReadLeaseClaim("tbx_ready123"); err != nil {
 				t.Fatalf("claim lost: %v", err)
 			}
 		})

--- a/internal/providers/gcp/backend.go
+++ b/internal/providers/gcp/backend.go
@@ -10,75 +10,60 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-type Config = core.Config
-type Runtime = core.Runtime
-type ProviderSpec = core.ProviderSpec
-type Backend = core.Backend
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type CleanupRequest = core.CleanupRequest
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-
 type gcpLeaseBackend struct{ shared.DirectSSHBackend }
 
 type gcpClient interface {
-	ListCrabboxServers(context.Context) ([]Server, error)
-	ListCrabboxServersComplete(context.Context) ([]Server, error)
-	CreateServerWithFallback(context.Context, Config, string, string, string, bool, func(string, ...any)) (Server, Config, error)
-	WaitForServerIP(context.Context, string) (Server, error)
-	GetServer(context.Context, string) (Server, error)
+	ListCrabboxServers(context.Context) ([]core.Server, error)
+	ListCrabboxServersComplete(context.Context) ([]core.Server, error)
+	CreateServerWithFallback(context.Context, core.Config, string, string, string, bool, func(string, ...any)) (core.Server, core.Config, error)
+	WaitForServerIP(context.Context, string) (core.Server, error)
+	GetServer(context.Context, string) (core.Server, error)
 	DeleteServer(context.Context, string) error
 	SetLabels(context.Context, string, map[string]string) error
 }
 
-func NewGCPLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewGCPLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = "gcp"
 	return &gcpLeaseBackend{DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt, StoredLeaseKeys: true}}
 }
 
-func (b *gcpLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
-	return acquireAttemptsRetry(b.RT, req.Keep, func() (LeaseTarget, error) {
+func (b *gcpLeaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
+	return acquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
 		return b.acquireOnce(ctx, req.Keep, req.RequestedSlug)
 	})
 }
 
-func (b *gcpLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (result LeaseTarget, retErr error) {
+func (b *gcpLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (result core.LeaseTarget, retErr error) {
 	if b.Cfg.Tailscale.Enabled && b.Cfg.Tailscale.AuthKey == "" {
-		return LeaseTarget{}, exit(2, "direct --tailscale requires %s to contain a Tailscale auth key; brokered mode uses coordinator OAuth secrets", b.Cfg.Tailscale.AuthKeyEnv)
+		return core.LeaseTarget{}, core.Exit(2, "direct --tailscale requires %s to contain a Tailscale auth key; brokered mode uses coordinator OAuth secrets", b.Cfg.Tailscale.AuthKeyEnv)
 	}
 	client, err := newGCPClient(ctx, b.Cfg)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	leaseID := core.NewLeaseID()
 	servers, err := client.ListCrabboxServers(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	slug, err := allocateDirectLeaseSlug(leaseID, requestedSlug, servers)
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, requestedSlug, servers)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cfg := b.Cfg
-	keyPath, publicKey, err := ensureTestboxKeyForConfig(cfg, leaseID)
+	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cfg.SSHKey = keyPath
-	cfg.ProviderKey = providerKeyForLease(leaseID)
+	cfg.ProviderKey = core.ProviderKeyForLease(leaseID)
 	fmt.Fprintf(b.RT.Stderr, "provisioning provider=gcp lease=%s slug=%s class=%s preferred_type=%s project=%s zone=%s keep=%v market=%s\n",
 		leaseID, slug, cfg.Class, cfg.ServerType, cfg.GCPProject, cfg.GCPZone, keep, cfg.Capacity.Market)
 	server, cfg, err := client.CreateServerWithFallback(ctx, cfg, publicKey, leaseID, slug, keep, func(format string, args ...any) {
 		fmt.Fprintf(b.RT.Stderr, format, args...)
 	})
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	rollback := true
 	rollbackCloudID := server.CloudID
@@ -102,74 +87,70 @@ func (b *gcpLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedS
 	}()
 	client, err = newGCPClient(ctx, cfg)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	rollbackClient = client
 	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s server=%s type=%s zone=%s\n", leaseID, server.DisplayID(), cfg.ServerType, cfg.GCPZone)
 	server, err = client.WaitForServerIP(ctx, server.CloudID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	target := sshTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
-	if err := waitForSSHReady(ctx, &target, b.RT.Stderr, "bootstrap", bootstrapWaitTimeout(cfg)); err != nil {
-		return LeaseTarget{}, err
+	target := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+	if err := waitForSSHReady(ctx, &target, b.RT.Stderr, "bootstrap", core.BootstrapWaitTimeout(cfg)); err != nil {
+		return core.LeaseTarget{}, err
 	}
 	server.Labels["state"] = "ready"
 	rollback = false
 	if err := client.SetLabels(ctx, server.CloudID, server.Labels); err != nil {
 		fmt.Fprintf(b.RT.Stderr, "warning: set labels: %v\n", err)
 	}
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
-func (b *gcpLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *gcpLeaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	client, err := newGCPClient(ctx, b.Cfg)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if strings.HasPrefix(req.ID, "crabbox-") {
 		server, err := client.GetServer(ctx, req.ID)
 		if err != nil {
 			if !core.IsGCPNotFound(err) {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 		} else {
-			if !isCrabboxGCPLease(server) {
-				return LeaseTarget{}, exit(4, "lease/server not found: %s (instance exists but is not Crabbox-managed)", req.ID)
+			if !core.IsCanonicalGCPServer(server) {
+				return core.LeaseTarget{}, core.Exit(4, "lease/server not found: %s (instance exists but is not Crabbox-managed)", req.ID)
 			}
 			leaseID := core.Blank(server.Labels["lease"], req.ID)
-			target := sshTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
+			target := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
 			if !req.ReleaseOnly {
-				if err := useStoredTestboxKey(&target, leaseID); err != nil {
-					return LeaseTarget{}, err
+				if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
+					return core.LeaseTarget{}, err
 				}
 			}
-			return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+			return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 		}
 	}
 	servers, err := client.ListCrabboxServers(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	if server, leaseID, err := findServerByAlias(servers, req.ID); err != nil {
-		return LeaseTarget{}, err
+	if server, leaseID, err := core.FindServerByAlias(servers, req.ID); err != nil {
+		return core.LeaseTarget{}, err
 	} else if leaseID != "" {
-		target := sshTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
+		target := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
 		if !req.ReleaseOnly {
-			if err := useStoredTestboxKey(&target, leaseID); err != nil {
-				return LeaseTarget{}, err
+			if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
+				return core.LeaseTarget{}, err
 			}
 		}
-		return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+		return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 	}
-	return LeaseTarget{}, exit(4, "lease/server not found: %s", req.ID)
+	return core.LeaseTarget{}, core.Exit(4, "lease/server not found: %s", req.ID)
 }
 
-func isCrabboxGCPLease(server Server) bool {
-	return core.IsCanonicalGCPServer(server)
-}
-
-func (b *gcpLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *gcpLeaseBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	client, err := newGCPClient(ctx, b.Cfg)
 	if err != nil {
@@ -179,9 +160,9 @@ func (b *gcpLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseVie
 	if err != nil {
 		return nil, err
 	}
-	canonical := make([]Server, 0, len(servers))
+	canonical := make([]core.Server, 0, len(servers))
 	for _, server := range servers {
-		if isCrabboxGCPLease(server) {
+		if core.IsCanonicalGCPServer(server) {
 			canonical = append(canonical, server)
 		}
 	}
@@ -189,7 +170,7 @@ func (b *gcpLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseVie
 }
 
 func (b *gcpLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
-	servers, err := b.List(ctx, ListRequest{})
+	servers, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
 		return core.DoctorResult{}, err
 	}
@@ -198,7 +179,7 @@ func (b *gcpLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (cor
 	return result, nil
 }
 
-func (b *gcpLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *gcpLeaseBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	claim, err := requireExactGCPClaim(req.Lease.Server, req.Lease.LeaseID, b.Cfg)
 	if err != nil {
 		return err
@@ -224,13 +205,13 @@ func (b *gcpLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequ
 		return err
 	}
 	if strings.TrimSpace(live.CloudID) != cloudID {
-		return exit(4, "refusing to delete gcp lease=%s: live instance cloud id %q does not match stored cloud id %q", req.Lease.LeaseID, live.CloudID, cloudID)
+		return core.Exit(4, "refusing to delete gcp lease=%s: live instance cloud id %q does not match stored cloud id %q", req.Lease.LeaseID, live.CloudID, cloudID)
 	}
-	if !isCrabboxGCPLease(live) {
-		return exit(4, "refusing to delete gcp instance %q for lease=%s: live instance is not canonical Crabbox-owned", cloudID, req.Lease.LeaseID)
+	if !core.IsCanonicalGCPServer(live) {
+		return core.Exit(4, "refusing to delete gcp instance %q for lease=%s: live instance is not canonical Crabbox-owned", cloudID, req.Lease.LeaseID)
 	}
 	if liveLeaseID := strings.TrimSpace(live.Labels["lease"]); liveLeaseID != req.Lease.LeaseID {
-		return exit(4, "refusing to delete gcp instance %q for lease=%s: live instance belongs to lease=%s", cloudID, req.Lease.LeaseID, core.Blank(liveLeaseID, "-"))
+		return core.Exit(4, "refusing to delete gcp instance %q for lease=%s: live instance belongs to lease=%s", cloudID, req.Lease.LeaseID, core.Blank(liveLeaseID, "-"))
 	}
 	if err := validateExactGCPClaim(claim, live, req.Lease.LeaseID, b.Cfg); err != nil {
 		return err
@@ -238,33 +219,33 @@ func (b *gcpLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequ
 	return deleteClaimedGCPServer(ctx, client, live, claim)
 }
 
-func (b *gcpLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
+func (b *gcpLeaseBackend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 	return fmt.Sprintf("deleted lease=%s server=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
 }
 
-func (b *gcpLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
+func (b *gcpLeaseBackend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
 	client, err := newGCPClient(ctx, b.Cfg)
 	if err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	if zone := req.Lease.Server.Labels["zone"]; zone != "" {
 		cfg := b.Cfg
 		cfg.GCPZone = zone
 		client, err = newGCPClient(ctx, cfg)
 		if err != nil {
-			return Server{}, err
+			return core.Server{}, err
 		}
 	}
 	server := req.Lease.Server
 	server.Labels = core.TouchDirectLeaseLabels(server.Labels, b.Cfg, req.State, time.Now().UTC())
 	if err := client.SetLabels(ctx, server.CloudID, server.Labels); err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	return server, nil
 }
 
-func (b *gcpLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
-	servers, err := b.List(ctx, ListRequest{Options: req.Options})
+func (b *gcpLeaseBackend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
+	servers, err := b.List(ctx, core.ListRequest{Options: req.Options})
 	if err != nil {
 		return err
 	}
@@ -278,7 +259,7 @@ func (b *gcpLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error
 	}
 	liveLeaseIDs := make(map[string]struct{}, len(completeServers))
 	for _, server := range completeServers {
-		if !isCrabboxGCPLease(server) {
+		if !core.IsCanonicalGCPServer(server) {
 			continue
 		}
 		if leaseID := strings.TrimSpace(server.Labels["lease"]); leaseID != "" {
@@ -342,13 +323,13 @@ func (b *gcpLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error
 	return nil
 }
 
-func requireExactGCPClaim(server Server, expectedLeaseID string, cfg Config) (core.LeaseClaim, error) {
+func requireExactGCPClaim(server core.Server, expectedLeaseID string, cfg core.Config) (core.LeaseClaim, error) {
 	claim, exists, err := core.ReadLeaseClaimWithPresence(expectedLeaseID)
 	if err != nil {
 		return core.LeaseClaim{}, err
 	}
 	if !exists {
-		return core.LeaseClaim{}, exit(2, "gcp lease=%s has no exact local claim; refusing destructive operation", expectedLeaseID)
+		return core.LeaseClaim{}, core.Exit(2, "gcp lease=%s has no exact local claim; refusing destructive operation", expectedLeaseID)
 	}
 	if err := validateExactGCPClaim(claim, server, expectedLeaseID, cfg); err != nil {
 		return core.LeaseClaim{}, err
@@ -356,13 +337,13 @@ func requireExactGCPClaim(server Server, expectedLeaseID string, cfg Config) (co
 	return claim, nil
 }
 
-func validateExactGCPClaim(claim core.LeaseClaim, server Server, expectedLeaseID string, cfg Config) error {
+func validateExactGCPClaim(claim core.LeaseClaim, server core.Server, expectedLeaseID string, cfg core.Config) error {
 	providerScope := gcpClaimScope(cfg)
 	serverSlug := strings.TrimSpace(server.Labels["slug"])
 	serverZone := strings.TrimSpace(server.Labels["zone"])
 	serverProviderKey := strings.TrimSpace(server.Labels["provider_key"])
 	if providerScope == "" ||
-		!isCrabboxGCPLease(server) ||
+		!core.IsCanonicalGCPServer(server) ||
 		claim.LeaseID != expectedLeaseID ||
 		claim.Provider != "gcp" ||
 		claim.ProviderScope != providerScope ||
@@ -380,18 +361,18 @@ func validateExactGCPClaim(claim core.LeaseClaim, server Server, expectedLeaseID
 		strings.TrimSpace(claim.Labels["provider"]) != "gcp" ||
 		serverProviderKey == "" ||
 		strings.TrimSpace(claim.Labels["provider_key"]) != serverProviderKey {
-		return exit(2, "refusing to operate on GCP instance %s from a missing or stale exact local claim", server.DisplayID())
+		return core.Exit(2, "refusing to operate on GCP instance %s from a missing or stale exact local claim", server.DisplayID())
 	}
 	return nil
 }
 
-func deleteClaimedGCPServer(ctx context.Context, client gcpClient, server Server, claim core.LeaseClaim) error {
+func deleteClaimedGCPServer(ctx context.Context, client gcpClient, server core.Server, claim core.LeaseClaim) error {
 	return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
 		return client.DeleteServer(ctx, server.CloudID)
 	})
 }
 
-func validateGCPCleanupLiveServer(expected, live Server) error {
+func validateGCPCleanupLiveServer(expected, live core.Server) error {
 	cloudID := strings.TrimSpace(expected.CloudID)
 	if cloudID == "" || strings.TrimSpace(live.CloudID) != cloudID {
 		return fmt.Errorf("live cloud id %q does not match cleanup candidate %q", live.CloudID, expected.CloudID)
@@ -399,7 +380,7 @@ func validateGCPCleanupLiveServer(expected, live Server) error {
 	if expected.ID == 0 || live.ID != expected.ID {
 		return fmt.Errorf("live instance id %d does not match cleanup candidate id %d", live.ID, expected.ID)
 	}
-	if !isCrabboxGCPLease(live) {
+	if !core.IsCanonicalGCPServer(live) {
 		return fmt.Errorf("live instance no longer has canonical Crabbox ownership labels")
 	}
 	expectedLeaseID := strings.TrimSpace(expected.Labels["lease"])
@@ -443,50 +424,25 @@ func (b *gcpLeaseBackend) pruneStaleClaims(ctx context.Context, liveLeaseIDs map
 		}
 		fmt.Fprintf(b.RT.Stderr, "remove stale claim lease=%s slug=%s provider=gcp\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
 		if !dryRun {
-			removeLeaseClaim(claim.LeaseID)
+			core.RemoveLeaseClaim(claim.LeaseID)
 		}
 	}
 	return nil
 }
 
-func gcpClaimScope(cfg Config) string {
+func gcpClaimScope(cfg core.Config) string {
 	if cfg.GCPProject == "" {
 		return ""
 	}
 	return "project:" + cfg.GCPProject
 }
 
-func acquireAttemptsRetry(rt Runtime, keep bool, acquire func() (LeaseTarget, error)) (LeaseTarget, error) {
+func acquireAttemptsRetry(rt core.Runtime, keep bool, acquire func() (core.LeaseTarget, error)) (core.LeaseTarget, error) {
 	return shared.AcquireAttemptsRetry(rt, keep, acquire)
 }
 
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-var newGCPClient = func(ctx context.Context, cfg Config) (gcpClient, error) {
+var newGCPClient = func(ctx context.Context, cfg core.Config) (gcpClient, error) {
 	return core.NewGCPClient(ctx, cfg)
 }
 
-func allocateDirectLeaseSlug(id, requested string, servers []Server) (string, error) {
-	return core.AllocateDirectLeaseSlug(id, requested, servers)
-}
-func ensureTestboxKeyForConfig(cfg Config, leaseID string) (string, string, error) {
-	return core.EnsureTestboxKeyForConfig(cfg, leaseID)
-}
-func providerKeyForLease(leaseID string) string { return core.ProviderKeyForLease(leaseID) }
-func sshTargetFromConfig(cfg Config, host string) SSHTarget {
-	return core.SSHTargetFromConfig(cfg, host)
-}
-
 var waitForSSHReady = core.WaitForSSHReady
-
-func bootstrapWaitTimeout(cfg Config) time.Duration { return core.BootstrapWaitTimeout(cfg) }
-
-func useStoredTestboxKey(target *SSHTarget, leaseID string) error {
-	return core.UseStoredTestboxKey(target, leaseID)
-}
-func findServerByAlias(servers []Server, id string) (Server, string, error) {
-	return core.FindServerByAlias(servers, id)
-}
-func removeLeaseClaim(leaseID string) { core.RemoveLeaseClaim(leaseID) }

--- a/internal/providers/gcp/backend_doctor_test.go
+++ b/internal/providers/gcp/backend_doctor_test.go
@@ -20,24 +20,24 @@ type fakeGCPDoctorClient struct {
 	listCalls   int
 	deleted     []string
 	mutated     bool
-	servers     []Server
-	complete    []Server
-	get         map[string]Server
+	servers     []core.Server
+	complete    []core.Server
+	get         map[string]core.Server
 	getErr      error
-	created     Server
-	createCfg   Config
+	created     core.Server
+	createCfg   core.Config
 	createErr   error
 	waitErr     error
 	deleteErr   error
 	createCalls int
 }
 
-func (c *fakeGCPDoctorClient) ListCrabboxServers(context.Context) ([]Server, error) {
+func (c *fakeGCPDoctorClient) ListCrabboxServers(context.Context) ([]core.Server, error) {
 	c.listCalls++
 	return c.servers, nil
 }
 
-func (c *fakeGCPDoctorClient) ListCrabboxServersComplete(context.Context) ([]Server, error) {
+func (c *fakeGCPDoctorClient) ListCrabboxServersComplete(context.Context) ([]core.Server, error) {
 	c.listCalls++
 	if c.complete != nil {
 		return c.complete, nil
@@ -45,35 +45,35 @@ func (c *fakeGCPDoctorClient) ListCrabboxServersComplete(context.Context) ([]Ser
 	return c.servers, nil
 }
 
-func (c *fakeGCPDoctorClient) CreateServerWithFallback(context.Context, Config, string, string, string, bool, func(string, ...any)) (Server, Config, error) {
+func (c *fakeGCPDoctorClient) CreateServerWithFallback(context.Context, core.Config, string, string, string, bool, func(string, ...any)) (core.Server, core.Config, error) {
 	c.createCalls++
 	c.mutated = true
 	if c.createErr != nil {
-		return Server{}, Config{}, c.createErr
+		return core.Server{}, core.Config{}, c.createErr
 	}
 	if c.created.CloudID == "" {
-		c.created = Server{CloudID: "crabbox-created", Name: "crabbox-created", Labels: map[string]string{}}
+		c.created = core.Server{CloudID: "crabbox-created", Name: "crabbox-created", Labels: map[string]string{}}
 	}
 	return c.created, c.createCfg, nil
 }
 
-func (c *fakeGCPDoctorClient) WaitForServerIP(context.Context, string) (Server, error) {
+func (c *fakeGCPDoctorClient) WaitForServerIP(context.Context, string) (core.Server, error) {
 	if c.waitErr != nil {
-		return Server{}, c.waitErr
+		return core.Server{}, c.waitErr
 	}
 	return c.created, nil
 }
 
-func (c *fakeGCPDoctorClient) GetServer(_ context.Context, name string) (Server, error) {
+func (c *fakeGCPDoctorClient) GetServer(_ context.Context, name string) (core.Server, error) {
 	if c.getErr != nil {
-		return Server{}, c.getErr
+		return core.Server{}, c.getErr
 	}
 	if c.get != nil {
 		if server, ok := c.get[name]; ok {
 			return server, nil
 		}
 	}
-	return Server{}, errors.New("gcp server not found: " + name)
+	return core.Server{}, errors.New("gcp server not found: " + name)
 }
 
 func (c *fakeGCPDoctorClient) DeleteServer(_ context.Context, name string) error {
@@ -87,9 +87,9 @@ func (c *fakeGCPDoctorClient) SetLabels(context.Context, string, map[string]stri
 	return nil
 }
 
-func canonicalGCPTestServer(leaseID, slug string) Server {
+func canonicalGCPTestServer(leaseID, slug string) core.Server {
 	name := core.LeaseProviderName(leaseID, slug)
-	return Server{
+	return core.Server{
 		Provider: "gcp",
 		CloudID:  name,
 		ID:       42,
@@ -106,7 +106,7 @@ func canonicalGCPTestServer(leaseID, slug string) Server {
 	}
 }
 
-func claimGCPTestServer(t *testing.T, cfg Config, server Server) {
+func claimGCPTestServer(t *testing.T, cfg core.Config, server core.Server) {
 	t.Helper()
 	if err := core.ClaimLeaseTargetForConfig(server.Labels["lease"], server.Labels["slug"], cfg, server, core.SSHTarget{}, time.Minute); err != nil {
 		t.Fatal(err)
@@ -115,7 +115,7 @@ func claimGCPTestServer(t *testing.T, cfg Config, server Server) {
 
 func TestValidateExactGCPClaimBindsProviderResourceAndLease(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	cfg := Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}
+	cfg := core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}
 	server := canonicalGCPTestServer("cbx_111111111111", "owned")
 	claimGCPTestServer(t, cfg, server)
 	claim, err := core.ReadLeaseClaim(server.Labels["lease"])
@@ -126,17 +126,21 @@ func TestValidateExactGCPClaimBindsProviderResourceAndLease(t *testing.T) {
 		t.Fatalf("valid exact claim rejected: %v", err)
 	}
 
-	tests := map[string]func(*core.LeaseClaim, *Server, *Config){
-		"project scope": func(_ *core.LeaseClaim, _ *Server, cfg *Config) { cfg.GCPProject = "project-b" },
-		"cloud name":    func(_ *core.LeaseClaim, server *Server, _ *Config) { server.CloudID += "-other" },
-		"numeric id":    func(_ *core.LeaseClaim, server *Server, _ *Config) { server.ID++ },
-		"slug": func(_ *core.LeaseClaim, server *Server, _ *Config) {
+	tests := map[string]func(*core.LeaseClaim, *core.Server, *core.Config){
+		"project scope": func(_ *core.LeaseClaim, _ *core.Server, cfg *core.Config) { cfg.GCPProject = "project-b" },
+		"cloud name":    func(_ *core.LeaseClaim, server *core.Server, _ *core.Config) { server.CloudID += "-other" },
+		"numeric id":    func(_ *core.LeaseClaim, server *core.Server, _ *core.Config) { server.ID++ },
+		"slug": func(_ *core.LeaseClaim, server *core.Server, _ *core.Config) {
 			server.Labels["slug"] = "other"
 			server.Name = core.LeaseProviderName(server.Labels["lease"], "other")
 		},
-		"zone":         func(_ *core.LeaseClaim, server *Server, _ *Config) { server.Labels["zone"] = "us-central1-c" },
-		"provider key": func(_ *core.LeaseClaim, server *Server, _ *Config) { server.Labels["provider_key"] = "crabbox-other" },
-		"claim labels": func(claim *core.LeaseClaim, _ *Server, _ *Config) { delete(claim.Labels, "zone") },
+		"zone": func(_ *core.LeaseClaim, server *core.Server, _ *core.Config) {
+			server.Labels["zone"] = "us-central1-c"
+		},
+		"provider key": func(_ *core.LeaseClaim, server *core.Server, _ *core.Config) {
+			server.Labels["provider_key"] = "crabbox-other"
+		},
+		"claim labels": func(claim *core.LeaseClaim, _ *core.Server, _ *core.Config) { delete(claim.Labels, "zone") },
 	}
 	for name, mutate := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -156,13 +160,13 @@ func TestValidateExactGCPClaimBindsProviderResourceAndLease(t *testing.T) {
 func TestGCPReleaseLeaseRejectsMissingExactClaimBeforeDelete(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	server := canonicalGCPTestServer("cbx_222222222222", "claimless")
-	fake := &fakeGCPDoctorClient{get: map[string]Server{server.CloudID: server}}
+	fake := &fakeGCPDoctorClient{get: map[string]core.Server{server.CloudID: server}}
 	old := newGCPClient
-	newGCPClient = func(context.Context, Config) (gcpClient, error) { return fake, nil }
+	newGCPClient = func(context.Context, core.Config) (gcpClient, error) { return fake, nil }
 	t.Cleanup(func() { newGCPClient = old })
 
-	backend := NewGCPLeaseBackend(core.ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
-	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: server.Labels["lease"], Server: server}})
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, core.Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: server.Labels["lease"], Server: server}})
 	if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
 		t.Fatalf("ReleaseLease() error=%v, want missing-claim refusal", err)
 	}
@@ -185,17 +189,17 @@ func TestGCPAcquireCleansUpCreatedServerOnIPFailure(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	ipErr := errors.New("ip unavailable")
 	fake := &fakeGCPDoctorClient{
-		created:   Server{CloudID: "crabbox-created", Name: "crabbox-created", Labels: map[string]string{"lease": "cbx_created"}},
-		createCfg: Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"},
+		created:   core.Server{CloudID: "crabbox-created", Name: "crabbox-created", Labels: map[string]string{"lease": "cbx_created"}},
+		createCfg: core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"},
 		waitErr:   ipErr,
 	}
 	old := newGCPClient
-	newGCPClient = func(context.Context, Config) (gcpClient, error) {
+	newGCPClient = func(context.Context, core.Config) (gcpClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newGCPClient = old })
 
-	backend := NewGCPLeaseBackend(core.ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a"}, Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, core.Config{Provider: "gcp", GCPProject: "project-a"}, core.Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
 	_, err := backend.acquireOnce(context.Background(), false, "")
 	if !errors.Is(err, ipErr) {
 		t.Fatalf("err=%v, want IP failure", err)
@@ -210,12 +214,12 @@ func TestGCPAcquireCleansUpCreatedServerOnFallbackClientFailure(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	rebuildErr := errors.New("fallback auth failed")
 	fake := &fakeGCPDoctorClient{
-		created:   Server{CloudID: "crabbox-fallback", Name: "crabbox-fallback", Labels: map[string]string{"lease": "cbx_created"}},
-		createCfg: Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-c"},
+		created:   core.Server{CloudID: "crabbox-fallback", Name: "crabbox-fallback", Labels: map[string]string{"lease": "cbx_created"}},
+		createCfg: core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-c"},
 	}
 	calls := 0
 	old := newGCPClient
-	newGCPClient = func(context.Context, Config) (gcpClient, error) {
+	newGCPClient = func(context.Context, core.Config) (gcpClient, error) {
 		calls++
 		if calls >= 2 {
 			return nil, rebuildErr
@@ -224,7 +228,7 @@ func TestGCPAcquireCleansUpCreatedServerOnFallbackClientFailure(t *testing.T) {
 	}
 	t.Cleanup(func() { newGCPClient = old })
 
-	backend := NewGCPLeaseBackend(core.ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a"}, Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, core.Config{Provider: "gcp", GCPProject: "project-a"}, core.Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
 	_, err := backend.acquireOnce(context.Background(), false, "")
 	if !errors.Is(err, rebuildErr) {
 		t.Fatalf("err=%v, want fallback client failure", err)
@@ -249,7 +253,7 @@ func TestGCPCleanupRemovesDeletedAndStaleClaims(t *testing.T) {
 	if err := core.ClaimLeaseForRepoProviderScope(otherProjectLeaseID, "other-box", "gcp", "project:project-b", repo, time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	expired := Server{
+	expired := core.Server{
 		CloudID: core.LeaseProviderName(expiredLeaseID, "expired-box"),
 		Name:    core.LeaseProviderName(expiredLeaseID, "expired-box"),
 		ID:      42,
@@ -259,9 +263,9 @@ func TestGCPCleanupRemovesDeletedAndStaleClaims(t *testing.T) {
 			"state": "ready", "expires_at": core.LeaseLabelTime(time.Now().Add(-time.Hour)),
 		},
 	}
-	claimGCPTestServer(t, Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, expired)
+	claimGCPTestServer(t, core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, expired)
 	fake := &fakeGCPDoctorClient{
-		servers: []Server{expired,
+		servers: []core.Server{expired,
 			{
 				CloudID: "crabbox-forged",
 				Name:    "crabbox-forged",
@@ -272,16 +276,16 @@ func TestGCPCleanupRemovesDeletedAndStaleClaims(t *testing.T) {
 					"state": "ready", "expires_at": core.LeaseLabelTime(time.Now().Add(-time.Hour)),
 				},
 			}},
-		get: map[string]Server{expired.CloudID: expired},
+		get: map[string]core.Server{expired.CloudID: expired},
 	}
 	old := newGCPClient
-	newGCPClient = func(context.Context, Config) (gcpClient, error) {
+	newGCPClient = func(context.Context, core.Config) (gcpClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newGCPClient = old })
 
 	var stderr bytes.Buffer
-	backend := NewGCPLeaseBackend(core.ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a"}, Runtime{Stderr: &stderr})
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, core.Config{Provider: "gcp", GCPProject: "project-a"}, core.Runtime{Stderr: &stderr})
 	cleaner, ok := backend.(core.CleanupBackend)
 	if !ok {
 		t.Fatal("gcp backend missing cleanup")
@@ -329,23 +333,23 @@ func TestGCPCleanupRevalidatesLiveOwnershipBeforeDelete(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	snapshot := canonicalGCPTestServer("cbx_111111111111", "stale")
 	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
-	cfg := Config{Provider: "gcp", GCPProject: "project-a", GCPZone: snapshot.Labels["zone"]}
+	cfg := core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: snapshot.Labels["zone"]}
 	claimGCPTestServer(t, cfg, snapshot)
 	live := snapshot
 	live.Labels = maps.Clone(snapshot.Labels)
 	delete(live.Labels, "created_by")
 	fake := &fakeGCPDoctorClient{
-		servers:  []Server{snapshot},
-		complete: []Server{live},
-		get:      map[string]Server{snapshot.CloudID: live},
+		servers:  []core.Server{snapshot},
+		complete: []core.Server{live},
+		get:      map[string]core.Server{snapshot.CloudID: live},
 	}
 	old := newGCPClient
-	newGCPClient = func(context.Context, Config) (gcpClient, error) { return fake, nil }
+	newGCPClient = func(context.Context, core.Config) (gcpClient, error) { return fake, nil }
 	t.Cleanup(func() { newGCPClient = old })
 
 	var stderr bytes.Buffer
-	backend := NewGCPLeaseBackend(core.ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deleted) != 0 {
@@ -358,7 +362,7 @@ func TestGCPCleanupRevalidatesLiveOwnershipBeforeDelete(t *testing.T) {
 
 func TestGCPCleanupSkipsClaimlessAndStaleExactClaims(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	cfg := Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}
+	cfg := core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}
 	claimless := canonicalGCPTestServer("cbx_333333333333", "claimless")
 	claimless.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
 	stale := canonicalGCPTestServer("cbx_444444444444", "stale")
@@ -366,16 +370,16 @@ func TestGCPCleanupSkipsClaimlessAndStaleExactClaims(t *testing.T) {
 	claimGCPTestServer(t, cfg, stale)
 	stale.ID++
 	fake := &fakeGCPDoctorClient{
-		servers: []Server{claimless, stale},
-		get:     map[string]Server{claimless.CloudID: claimless, stale.CloudID: stale},
+		servers: []core.Server{claimless, stale},
+		get:     map[string]core.Server{claimless.CloudID: claimless, stale.CloudID: stale},
 	}
 	old := newGCPClient
-	newGCPClient = func(context.Context, Config) (gcpClient, error) { return fake, nil }
+	newGCPClient = func(context.Context, core.Config) (gcpClient, error) { return fake, nil }
 	t.Cleanup(func() { newGCPClient = old })
 
 	var stderr bytes.Buffer
-	backend := NewGCPLeaseBackend(core.ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deleted) != 0 {
@@ -393,22 +397,22 @@ func TestGCPCleanupRetainsClaimWhenOwnershipLabelsDrift(t *testing.T) {
 	live := snapshot
 	live.Labels = maps.Clone(snapshot.Labels)
 	live.Labels["created_by"] = "external"
-	cfg := Config{Provider: "gcp", GCPProject: "project-a", GCPZone: snapshot.Labels["zone"]}
+	cfg := core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: snapshot.Labels["zone"]}
 	if err := core.ClaimLeaseTargetForConfig(snapshot.Labels["lease"], snapshot.Labels["slug"], cfg, snapshot, core.SSHTarget{}, time.Hour); err != nil {
 		t.Fatal(err)
 	}
 	fake := &fakeGCPDoctorClient{
-		servers:  []Server{snapshot},
-		complete: []Server{live},
-		get:      map[string]Server{snapshot.CloudID: live},
+		servers:  []core.Server{snapshot},
+		complete: []core.Server{live},
+		get:      map[string]core.Server{snapshot.CloudID: live},
 	}
 	old := newGCPClient
-	newGCPClient = func(context.Context, Config) (gcpClient, error) { return fake, nil }
+	newGCPClient = func(context.Context, core.Config) (gcpClient, error) { return fake, nil }
 	t.Cleanup(func() { newGCPClient = old })
 
 	var stderr bytes.Buffer
-	backend := NewGCPLeaseBackend(core.ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	claim, ok, err := core.ResolveLeaseClaim(snapshot.Labels["lease"])
@@ -424,19 +428,19 @@ func TestGCPCleanupRevalidatesLiveEligibilityBeforeDelete(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	snapshot := canonicalGCPTestServer("cbx_111111111111", "renewed")
 	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
-	cfg := Config{Provider: "gcp", GCPProject: "project-a", GCPZone: snapshot.Labels["zone"]}
+	cfg := core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: snapshot.Labels["zone"]}
 	claimGCPTestServer(t, cfg, snapshot)
 	live := snapshot
 	live.Labels = maps.Clone(snapshot.Labels)
 	live.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(time.Hour))
-	fake := &fakeGCPDoctorClient{servers: []Server{snapshot}, get: map[string]Server{snapshot.CloudID: live}}
+	fake := &fakeGCPDoctorClient{servers: []core.Server{snapshot}, get: map[string]core.Server{snapshot.CloudID: live}}
 	old := newGCPClient
-	newGCPClient = func(context.Context, Config) (gcpClient, error) { return fake, nil }
+	newGCPClient = func(context.Context, core.Config) (gcpClient, error) { return fake, nil }
 	t.Cleanup(func() { newGCPClient = old })
 
 	var stderr bytes.Buffer
-	backend := NewGCPLeaseBackend(core.ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deleted) != 0 {
@@ -453,19 +457,19 @@ func TestGCPCleanupTreatsMissingLiveInstanceAsAlreadyDeleted(t *testing.T) {
 	slug := "gone"
 	snapshot := canonicalGCPTestServer(leaseID, slug)
 	snapshot.Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
-	cfg := Config{Provider: "gcp", GCPProject: "project-a", GCPZone: snapshot.Labels["zone"]}
+	cfg := core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: snapshot.Labels["zone"]}
 	claimGCPTestServer(t, cfg, snapshot)
 	fake := &fakeGCPDoctorClient{
-		servers: []Server{snapshot},
+		servers: []core.Server{snapshot},
 		getErr:  &googleapi.Error{Code: http.StatusNotFound, Message: "instance gone"},
 	}
 	old := newGCPClient
-	newGCPClient = func(context.Context, Config) (gcpClient, error) { return fake, nil }
+	newGCPClient = func(context.Context, core.Config) (gcpClient, error) { return fake, nil }
 	t.Cleanup(func() { newGCPClient = old })
 
 	var stderr bytes.Buffer
-	backend := NewGCPLeaseBackend(core.ProviderSpec{}, cfg, Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deleted) != 0 {
@@ -488,17 +492,17 @@ func TestGCPReleaseLeaseRequiresCanonicalLiveOwnership(t *testing.T) {
 	leaseID := "cbx_777777777777"
 	slug := "release-box"
 	live := canonicalGCPTestServer(leaseID, slug)
-	claimGCPTestServer(t, Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, live)
-	fake := &fakeGCPDoctorClient{get: map[string]Server{live.CloudID: live}}
+	claimGCPTestServer(t, core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, live)
+	fake := &fakeGCPDoctorClient{get: map[string]core.Server{live.CloudID: live}}
 	old := newGCPClient
-	newGCPClient = func(context.Context, Config) (gcpClient, error) {
+	newGCPClient = func(context.Context, core.Config) (gcpClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newGCPClient = old })
 
-	backend := NewGCPLeaseBackend(core.ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
-	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{
-		Lease: LeaseTarget{
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, core.Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{
+		Lease: core.LeaseTarget{
 			LeaseID: leaseID,
 			Server:  live,
 		},
@@ -522,22 +526,22 @@ func TestGCPReleaseLeaseRefusesWrongLiveLease(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_888888888888"
 	claimed := canonicalGCPTestServer(leaseID, "release-box")
-	claimGCPTestServer(t, Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, claimed)
+	claimGCPTestServer(t, core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, claimed)
 	live := claimed
 	live.Labels = maps.Clone(claimed.Labels)
 	live.Labels["lease"] = "cbx_999999999999"
 	live.Labels["slug"] = "other-box"
 	live.Name = core.LeaseProviderName(live.Labels["lease"], live.Labels["slug"])
-	fake := &fakeGCPDoctorClient{get: map[string]Server{claimed.CloudID: live}}
+	fake := &fakeGCPDoctorClient{get: map[string]core.Server{claimed.CloudID: live}}
 	old := newGCPClient
-	newGCPClient = func(context.Context, Config) (gcpClient, error) {
+	newGCPClient = func(context.Context, core.Config) (gcpClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newGCPClient = old })
 
-	backend := NewGCPLeaseBackend(core.ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
-	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{
-		Lease: LeaseTarget{
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, core.Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{
+		Lease: core.LeaseTarget{
 			LeaseID: leaseID,
 			Server:  claimed,
 		},
@@ -562,20 +566,20 @@ func TestGCPReleaseLeaseRefusesNonCanonicalLiveInstance(t *testing.T) {
 	leaseID := "cbx_aaaaaaaaaaaa"
 	claimed := canonicalGCPTestServer(leaseID, "release-box")
 	cloudID := claimed.CloudID
-	claimGCPTestServer(t, Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, claimed)
+	claimGCPTestServer(t, core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, claimed)
 	live := claimed
 	live.Labels = maps.Clone(claimed.Labels)
 	delete(live.Labels, "created_by")
-	fake := &fakeGCPDoctorClient{get: map[string]Server{cloudID: live}}
+	fake := &fakeGCPDoctorClient{get: map[string]core.Server{cloudID: live}}
 	old := newGCPClient
-	newGCPClient = func(context.Context, Config) (gcpClient, error) {
+	newGCPClient = func(context.Context, core.Config) (gcpClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newGCPClient = old })
 
-	backend := NewGCPLeaseBackend(core.ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
-	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{
-		Lease: LeaseTarget{
+	backend := NewGCPLeaseBackend(core.ProviderSpec{}, core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, core.Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{
+		Lease: core.LeaseTarget{
 			LeaseID: leaseID,
 			Server:  claimed,
 		},
@@ -596,9 +600,9 @@ func TestGCPReleaseLeaseRefusesNonCanonicalLiveInstance(t *testing.T) {
 }
 
 func TestGCPDoctorListsInventoryOnly(t *testing.T) {
-	server := func(leaseID, slug string) Server {
+	server := func(leaseID, slug string) core.Server {
 		name := core.LeaseProviderName(leaseID, slug)
-		return Server{
+		return core.Server{
 			CloudID: name,
 			Name:    name,
 			Labels: map[string]string{
@@ -607,18 +611,18 @@ func TestGCPDoctorListsInventoryOnly(t *testing.T) {
 			},
 		}
 	}
-	fake := &fakeGCPDoctorClient{servers: []Server{
+	fake := &fakeGCPDoctorClient{servers: []core.Server{
 		server("cbx_555555555555", "one"),
 		server("cbx_666666666666", "two"),
 		{CloudID: "crabbox-forged", Name: "crabbox-forged", Labels: map[string]string{"crabbox": "true"}},
 	}}
 	old := newGCPClient
-	newGCPClient = func(context.Context, Config) (gcpClient, error) {
+	newGCPClient = func(context.Context, core.Config) (gcpClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newGCPClient = old })
 
-	doctor, err := Provider{}.ConfigureDoctor(Config{}, Runtime{})
+	doctor, err := Provider{}.ConfigureDoctor(core.Config{}, core.Runtime{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -645,18 +649,18 @@ func TestGCPAcquireStopsFreshRetryAfterRollbackFailure(t *testing.T) {
 			t.Setenv("XDG_STATE_HOME", t.TempDir())
 			bootstrapErr := core.Exit(5, "timed out waiting for SSH: fixture readiness failure")
 			oldWait := waitForSSHReady
-			waitForSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error { return bootstrapErr }
+			waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return bootstrapErr }
 			t.Cleanup(func() { waitForSSHReady = oldWait })
-			fake := &fakeGCPDoctorClient{created: Server{CloudID: "crabbox-created", Labels: map[string]string{}}, createCfg: Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}}
+			fake := &fakeGCPDoctorClient{created: core.Server{CloudID: "crabbox-created", Labels: map[string]string{}}, createCfg: core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}}
 			if failed {
 				fake.deleteErr = errors.New("delete unavailable")
 			}
 			old := newGCPClient
-			newGCPClient = func(context.Context, Config) (gcpClient, error) { return fake, nil }
+			newGCPClient = func(context.Context, core.Config) (gcpClient, error) { return fake, nil }
 			t.Cleanup(func() { newGCPClient = old })
 			var stderr bytes.Buffer
-			backend := NewGCPLeaseBackend(core.ProviderSpec{}, fake.createCfg, Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
-			_, err := backend.Acquire(context.Background(), AcquireRequest{})
+			backend := NewGCPLeaseBackend(core.ProviderSpec{}, fake.createCfg, core.Runtime{Stderr: &stderr}).(*gcpLeaseBackend)
+			_, err := backend.Acquire(context.Background(), core.AcquireRequest{})
 			want := 2
 			if failed {
 				want = 1
@@ -680,10 +684,10 @@ func TestGCPAcquireRetainsCleanupClientFailureDespiteFallbackSuccess(t *testing.
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	primary := core.Exit(5, "timed out waiting for SSH: fixture")
 	debt := errors.New("selected-zone cleanup client unavailable")
-	fake := &fakeGCPDoctorClient{createCfg: Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-c"}}
+	fake := &fakeGCPDoctorClient{createCfg: core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-c"}}
 	oldClient, oldWait := newGCPClient, waitForSSHReady
 	bootstrapReached := false
-	newGCPClient = func(ctx context.Context, cfg Config) (gcpClient, error) {
+	newGCPClient = func(ctx context.Context, cfg core.Config) (gcpClient, error) {
 		if bootstrapReached {
 			if _, bounded := ctx.Deadline(); bounded {
 				return nil, debt
@@ -691,13 +695,13 @@ func TestGCPAcquireRetainsCleanupClientFailureDespiteFallbackSuccess(t *testing.
 		}
 		return fake, nil
 	}
-	waitForSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+	waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
 		bootstrapReached = true
 		return primary
 	}
 	t.Cleanup(func() { newGCPClient = oldClient; waitForSSHReady = oldWait })
-	b := NewGCPLeaseBackend(ProviderSpec{}, Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
-	_, err := b.Acquire(context.Background(), AcquireRequest{})
+	b := NewGCPLeaseBackend(core.ProviderSpec{}, core.Config{Provider: "gcp", GCPProject: "project-a", GCPZone: "us-central1-b"}, core.Runtime{Stderr: io.Discard}).(*gcpLeaseBackend)
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{})
 	if fake.createCalls != 1 || len(fake.deleted) != 1 || !errors.Is(err, primary) || !errors.Is(err, debt) {
 		t.Fatalf("creates=%d deletes=%v error=%v", fake.createCalls, fake.deleted, err)
 	}

--- a/internal/providers/hetzner/backend.go
+++ b/internal/providers/hetzner/backend.go
@@ -13,28 +13,13 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-type Config = core.Config
-type Runtime = core.Runtime
-type ProviderSpec = core.ProviderSpec
-type Backend = core.Backend
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type CleanupRequest = core.CleanupRequest
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-
 const providerName = "hetzner"
 
 type hetznerClient interface {
-	ListCrabboxServers(context.Context) ([]Server, error)
+	ListCrabboxServers(context.Context) ([]core.Server, error)
 	EnsureSSHKey(context.Context, string, string) (core.SSHKey, bool, error)
-	CreateServerWithFallback(context.Context, Config, string, string, string, bool, func(string, ...any)) (Server, Config, error)
-	GetServer(context.Context, int64) (Server, error)
+	CreateServerWithFallback(context.Context, core.Config, string, string, string, bool, func(string, ...any)) (core.Server, core.Config, error)
+	GetServer(context.Context, int64) (core.Server, error)
 	DeleteServer(context.Context, int64) error
 	DeleteSSHKey(context.Context, string) error
 	SetLabels(context.Context, int64, map[string]string) error
@@ -51,44 +36,44 @@ type acquiredHetznerLease struct {
 	ID      int64
 }
 
-func NewHetznerLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewHetznerLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = providerName
 	return &hetznerLeaseBackend{DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt, Delete: deleteServer, StoredLeaseKeys: true}}
 }
 
-func (b *hetznerLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
-	return acquireAttemptsRetry(b.RT, req.Keep, func() (LeaseTarget, error) {
+func (b *hetznerLeaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
+	return acquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
 		return b.acquireOnce(ctx, req.Keep, req.RequestedSlug)
 	})
 }
 
-func (b *hetznerLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (target LeaseTarget, err error) {
+func (b *hetznerLeaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (target core.LeaseTarget, err error) {
 	if b.Cfg.Tailscale.Enabled && b.Cfg.Tailscale.AuthKey == "" {
-		return LeaseTarget{}, exit(2, "direct --tailscale requires %s to contain a Tailscale auth key; brokered mode uses coordinator OAuth secrets", b.Cfg.Tailscale.AuthKeyEnv)
+		return core.LeaseTarget{}, core.Exit(2, "direct --tailscale requires %s to contain a Tailscale auth key; brokered mode uses coordinator OAuth secrets", b.Cfg.Tailscale.AuthKeyEnv)
 	}
 	client, err := newHetznerClient()
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	leaseID := newLeaseID()
 	servers, err := client.ListCrabboxServers(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	slug, err := allocateDirectLeaseSlug(leaseID, requestedSlug, servers)
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, requestedSlug, servers)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cfg := b.Cfg
 	keyPath, publicKey, err := ensureTestboxKeyForConfig(cfg, leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cfg.SSHKey = keyPath
 	cfg.ProviderKey = providerKeyForLease(leaseID)
 	rollbackKey := ""
 	rollbackKeyCreated := false
-	var rollbackServer Server
+	var rollbackServer core.Server
 	rollbackServerCreated := false
 	committed := false
 	defer func() {
@@ -102,7 +87,7 @@ func (b *hetznerLeaseBackend) acquireOnce(ctx context.Context, keep bool, reques
 	if cfg.ProviderKey != "" {
 		providerKey, created, err := client.EnsureSSHKey(ctx, cfg.ProviderKey, publicKey)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		cfg.ProviderKey = providerKey.Name
 		rollbackKey = providerKey.Name
@@ -113,12 +98,12 @@ func (b *hetznerLeaseBackend) acquireOnce(ctx context.Context, keep bool, reques
 		fmt.Fprintf(b.RT.Stderr, format, args...)
 	})
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	identity := shared.NamedResourceIdentity{ID: strconv.FormatInt(server.ID, 10), Name: core.LeaseProviderName(leaseID, slug)}
 	ownership := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now())
 	if err := validateHetznerAcquireObservation(server, identity, ownership); err != nil {
-		return LeaseTarget{}, exit(1, "hetzner create response cannot bind lease=%s server=%d; server cleanup withheld: %v", leaseID, server.ID, err)
+		return core.LeaseTarget{}, core.Exit(1, "hetzner create response cannot bind lease=%s server=%d; server cleanup withheld: %v", leaseID, server.ID, err)
 	}
 	server = normalizeHetznerServer(server)
 	rollbackServer = server
@@ -129,27 +114,27 @@ func (b *hetznerLeaseBackend) acquireOnce(ctx context.Context, keep bool, reques
 	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s server=%d type=%s\n", leaseID, server.ID, cfg.ServerType)
 	server, err = waitForServerIP(ctx, client, server.ID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if err := validateHetznerAcquireObservation(server, identity, ownership); err != nil {
-		return LeaseTarget{}, exit(1, "hetzner readiness rejected for lease=%s server=%s: %v", leaseID, identity.ID, err)
+		return core.LeaseTarget{}, core.Exit(1, "hetzner readiness rejected for lease=%s server=%s: %v", leaseID, identity.ID, err)
 	}
 	server = normalizeHetznerServer(server)
-	ssh := sshTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+	ssh := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
 	if err := waitForSSHReady(ctx, &ssh, b.RT.Stderr, "bootstrap", bootstrapWaitTimeout(cfg)); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	server.Labels["state"] = "ready"
 	if err := client.SetLabels(ctx, server.ID, server.Labels); err != nil {
 		fmt.Fprintf(b.RT.Stderr, "warning: set labels: %v\n", err)
 	}
 	committed = true
-	target = LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}
+	target = core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}
 	b.acquired.Store(leaseID, acquiredHetznerLease{LeaseID: leaseID, CloudID: server.CloudID, ID: server.ID})
 	return target, nil
 }
 
-func validateHetznerAcquireObservation(server Server, identity shared.NamedResourceIdentity, ownership map[string]string) error {
+func validateHetznerAcquireObservation(server core.Server, identity shared.NamedResourceIdentity, ownership map[string]string) error {
 	id := strconv.FormatInt(server.ID, 10)
 	if server.ID <= 0 || server.CloudID != "" && server.CloudID != id {
 		return fmt.Errorf("invalid native server identity: ID=%d cloud ID=%q", server.ID, server.CloudID)
@@ -168,52 +153,52 @@ func validateHetznerAcquireObservation(server Server, identity shared.NamedResou
 	return nil
 }
 
-func (b *hetznerLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *hetznerLeaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	client, err := newHetznerClient()
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	if serverID, ok := parseServerID(req.ID); ok {
+	if serverID, ok := core.ParseServerID(req.ID); ok {
 		server, err := client.GetServer(ctx, serverID)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		server = normalizeHetznerServer(server)
 		if err := validateHetznerResolveOwnership(server, req); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		leaseID := core.Blank(server.Labels["lease"], req.ID)
-		target := sshTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
+		target := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
 		if !req.ReleaseOnly {
-			if err := useStoredTestboxKey(&target, leaseID); err != nil {
-				return LeaseTarget{}, err
+			if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
+				return core.LeaseTarget{}, err
 			}
 		}
-		return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+		return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 	}
 	servers, err := client.ListCrabboxServers(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	servers = ownedHetznerServers(servers)
-	if server, leaseID, err := findServerByAlias(servers, req.ID); err != nil {
-		return LeaseTarget{}, err
+	if server, leaseID, err := core.FindServerByAlias(servers, req.ID); err != nil {
+		return core.LeaseTarget{}, err
 	} else if leaseID != "" {
 		if err := validateHetznerResolveOwnership(server, req); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
-		target := sshTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
+		target := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
 		if !req.ReleaseOnly {
-			if err := useStoredTestboxKey(&target, leaseID); err != nil {
-				return LeaseTarget{}, err
+			if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
+				return core.LeaseTarget{}, err
 			}
 		}
-		return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+		return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 	}
-	return LeaseTarget{}, exit(4, "lease/server not found: %s", req.ID)
+	return core.LeaseTarget{}, core.Exit(4, "lease/server not found: %s", req.ID)
 }
 
-func (b *hetznerLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *hetznerLeaseBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	client, err := newHetznerClient()
 	if err != nil {
@@ -228,11 +213,11 @@ func (b *hetznerLeaseBackend) List(ctx context.Context, req ListRequest) ([]Leas
 
 func (b *hetznerLeaseBackend) CheckpointSourceAbsent(context.Context, core.CheckpointSourceRequest) (bool, error) {
 	// A project-scoped token cannot distinguish deletion from another project.
-	return false, exit(2, "%s", hetznerRetirementUnsupported)
+	return false, core.Exit(2, "%s", hetznerRetirementUnsupported)
 }
 
 func (b *hetznerLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
-	servers, err := b.List(ctx, ListRequest{})
+	servers, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
 		return core.DoctorResult{}, err
 	}
@@ -241,9 +226,9 @@ func (b *hetznerLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) 
 	return result, nil
 }
 
-func (b *hetznerLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *hetznerLeaseBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	if req.CheckpointID != "" {
-		return exit(2, "%s", hetznerRetirementUnsupported)
+		return core.Exit(2, "%s", hetznerRetirementUnsupported)
 	}
 	server := normalizeHetznerServer(req.Lease.Server)
 	claim, err := requireExactHetznerClaim(server, req.Lease.LeaseID)
@@ -277,7 +262,7 @@ func (b *hetznerLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLease
 	return err
 }
 
-func (b *hetznerLeaseBackend) matchesAcquiredLease(server Server, leaseID string) bool {
+func (b *hetznerLeaseBackend) matchesAcquiredLease(server core.Server, leaseID string) bool {
 	if validateHetznerServerOwnership(server, false) != nil || server.Labels["lease"] != leaseID {
 		return false
 	}
@@ -289,15 +274,15 @@ func (b *hetznerLeaseBackend) matchesAcquiredLease(server Server, leaseID string
 	return ok && acquired.LeaseID == leaseID && acquired.CloudID == server.CloudID && acquired.ID == server.ID
 }
 
-func (b *hetznerLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
+func (b *hetznerLeaseBackend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 	return fmt.Sprintf("deleted lease=%s server=%s name=%s", lease.LeaseID, lease.Server.DisplayID(), lease.Server.Name)
 }
 
-func (b *hetznerLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
+func (b *hetznerLeaseBackend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
 	return b.DirectSSHBackend.Touch(ctx, req.Lease.Server, req.State), nil
 }
 
-func (b *hetznerLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
+func (b *hetznerLeaseBackend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	client, err := newHetznerClient()
 	if err != nil {
 		return err
@@ -341,23 +326,15 @@ func (b *hetznerLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) e
 	return nil
 }
 
-func acquireAttemptsRetry(rt Runtime, keep bool, acquire func() (LeaseTarget, error)) (LeaseTarget, error) {
+func acquireAttemptsRetry(rt core.Runtime, keep bool, acquire func() (core.LeaseTarget, error)) (core.LeaseTarget, error) {
 	return shared.AcquireAttemptsRetry(rt, keep, acquire)
 }
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-func allocateDirectLeaseSlug(id, requested string, servers []Server) (string, error) {
-	return core.AllocateDirectLeaseSlug(id, requested, servers)
-}
-func sshTargetFromConfig(cfg Config, host string) SSHTarget {
-	return core.SSHTargetFromConfig(cfg, host)
-}
-func deleteServer(ctx context.Context, cfg Config, server Server) error {
+
+func deleteServer(ctx context.Context, cfg core.Config, server core.Server) error {
 	_, err := deleteServerForRelease(ctx, cfg, server)
 	return err
 }
-func deleteServerForRelease(ctx context.Context, cfg Config, server Server) (bool, error) {
+func deleteServerForRelease(ctx context.Context, cfg core.Config, server core.Server) (bool, error) {
 	_ = cfg
 	server = normalizeHetznerServer(server)
 	if err := validateHetznerServerOwnership(server, true); err != nil {
@@ -374,7 +351,7 @@ func deleteServerForRelease(ctx context.Context, cfg Config, server Server) (boo
 	return deleteClaimedHetznerServer(ctx, client, server, claim)
 }
 
-func deleteClaimedHetznerServer(ctx context.Context, client hetznerClient, server Server, claim core.LeaseClaim) (bool, error) {
+func deleteClaimedHetznerServer(ctx context.Context, client hetznerClient, server core.Server, claim core.LeaseClaim) (bool, error) {
 	serverGone := false
 	updated, err := core.UpdateLeaseClaimLabelsIfUnchangedAfter(claim.LeaseID, claim, claim.Labels, func() error {
 		if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
@@ -395,16 +372,16 @@ func deleteClaimedHetznerServer(ctx context.Context, client hetznerClient, serve
 	return serverGone, nil
 }
 
-func deleteServerWithClient(ctx context.Context, client hetznerClient, server Server, deleteKey bool, expectedLeaseID string) (bool, error) {
+func deleteServerWithClient(ctx context.Context, client hetznerClient, server core.Server, deleteKey bool, expectedLeaseID string) (bool, error) {
 	server = normalizeHetznerServer(server)
 	if err := validateHetznerServerOwnership(server, true); err != nil {
 		return false, err
 	}
 	if server.Labels["lease"] != expectedLeaseID {
-		return false, exit(2, "refusing to delete Hetzner server %s for mismatched lease %s", server.DisplayID(), expectedLeaseID)
+		return false, core.Exit(2, "refusing to delete Hetzner server %s for mismatched lease %s", server.DisplayID(), expectedLeaseID)
 	}
 	if !core.IsCanonicalLeaseID(expectedLeaseID) {
-		return false, exit(2, "refusing to delete Hetzner server %s for non-canonical lease %s", server.DisplayID(), expectedLeaseID)
+		return false, core.Exit(2, "refusing to delete Hetzner server %s for non-canonical lease %s", server.DisplayID(), expectedLeaseID)
 	}
 	// Delete the auxiliary key first. If that fails, retaining the server keeps
 	// the exact claim reachable through normal resolve-and-release retries.
@@ -424,7 +401,7 @@ func hetznerServerAlreadyAbsent(err error, serverID int64) bool {
 	var httpErr core.HetznerHTTPError
 	return errors.As(err, &httpErr) && httpErr.StatusCode == 404 && httpErr.Method == "DELETE" && httpErr.Path == fmt.Sprintf("/servers/%d", serverID)
 }
-func validateHetznerServerOwnership(server Server, allowLegacyProvider bool) error {
+func validateHetznerServerOwnership(server core.Server, allowLegacyProvider bool) error {
 	provider := strings.TrimSpace(server.Labels["provider"])
 	if server.Labels == nil ||
 		server.Labels["crabbox"] != "true" ||
@@ -432,12 +409,12 @@ func validateHetznerServerOwnership(server Server, allowLegacyProvider bool) err
 		(provider != providerName && !(allowLegacyProvider && provider == "")) ||
 		!core.IsCanonicalLeaseID(server.Labels["lease"]) ||
 		strings.TrimSpace(server.Labels["slug"]) == "" {
-		return exit(2, "refusing to operate on non-Crabbox Hetzner server: %s", server.DisplayID())
+		return core.Exit(2, "refusing to operate on non-Crabbox Hetzner server: %s", server.DisplayID())
 	}
 	return nil
 }
 
-func validateHetznerResolveOwnership(server Server, req ResolveRequest) error {
+func validateHetznerResolveOwnership(server core.Server, req core.ResolveRequest) error {
 	claim, claimExists, err := core.ReadLeaseClaimWithPresence(server.Labels["lease"])
 	if err != nil {
 		return err
@@ -455,34 +432,34 @@ func validateHetznerResolveOwnership(server Server, req ResolveRequest) error {
 		return nil
 	}
 	if req.ReleaseOnly {
-		return exit(2, "hetzner lease=%s has no exact local claim; refusing release", server.Labels["lease"])
+		return core.Exit(2, "hetzner lease=%s has no exact local claim; refusing release", server.Labels["lease"])
 	}
 	if req.NoLocalStateMutations {
 		return nil
 	}
 	if !req.Reclaim {
-		return exit(2, "hetzner lease=%s is unclaimed; use --reclaim to adopt it explicitly", server.Labels["lease"])
+		return core.Exit(2, "hetzner lease=%s is unclaimed; use --reclaim to adopt it explicitly", server.Labels["lease"])
 	}
 	if req.Repo.Root == "" {
-		return exit(2, "hetzner lease=%s cannot be reclaimed without a repository root", server.Labels["lease"])
+		return core.Exit(2, "hetzner lease=%s cannot be reclaimed without a repository root", server.Labels["lease"])
 	}
 	return nil
 }
 
-func upgradeableHetznerClaim(claim core.LeaseClaim, server Server) bool {
+func upgradeableHetznerClaim(claim core.LeaseClaim, server core.Server) bool {
 	return claim.LeaseID == server.Labels["lease"] &&
 		(claim.Provider == "" || claim.Provider == providerName) &&
 		claim.CloudID == "" &&
 		(claim.Slug == "" || claim.Slug == server.Labels["slug"])
 }
 
-func requireExactHetznerClaim(server Server, expectedLeaseID string) (core.LeaseClaim, error) {
+func requireExactHetznerClaim(server core.Server, expectedLeaseID string) (core.LeaseClaim, error) {
 	claim, exists, err := core.ReadLeaseClaimWithPresence(expectedLeaseID)
 	if err != nil {
 		return core.LeaseClaim{}, err
 	}
 	if !exists {
-		return core.LeaseClaim{}, exit(2, "hetzner lease=%s has no exact local claim; refusing destructive operation", expectedLeaseID)
+		return core.LeaseClaim{}, core.Exit(2, "hetzner lease=%s has no exact local claim; refusing destructive operation", expectedLeaseID)
 	}
 	if err := validateHetznerServerOwnership(server, true); err != nil {
 		return core.LeaseClaim{}, err
@@ -493,19 +470,19 @@ func requireExactHetznerClaim(server Server, expectedLeaseID string) (core.Lease
 	return claim, nil
 }
 
-func validateHetznerClaim(claim core.LeaseClaim, server Server, expectedLeaseID string) error {
+func validateHetznerClaim(claim core.LeaseClaim, server core.Server, expectedLeaseID string) error {
 	if claim.LeaseID != expectedLeaseID ||
 		claim.Provider != providerName ||
 		claim.CloudID == "" ||
 		claim.CloudID != server.CloudID ||
 		server.Labels["lease"] != expectedLeaseID ||
 		(claim.Slug != "" && claim.Slug != server.Labels["slug"]) {
-		return exit(2, "refusing to operate on Hetzner server %s from a missing or stale exact local claim", server.DisplayID())
+		return core.Exit(2, "refusing to operate on Hetzner server %s from a missing or stale exact local claim", server.DisplayID())
 	}
 	return nil
 }
 
-func normalizeHetznerServer(server Server) Server {
+func normalizeHetznerServer(server core.Server) core.Server {
 	if server.CloudID == "" && server.ID > 0 {
 		server.CloudID = strconv.FormatInt(server.ID, 10)
 	}
@@ -513,8 +490,8 @@ func normalizeHetznerServer(server Server) Server {
 	return server
 }
 
-func ownedHetznerServers(servers []Server) []Server {
-	owned := make([]Server, 0, len(servers))
+func ownedHetznerServers(servers []core.Server) []core.Server {
+	owned := make([]core.Server, 0, len(servers))
 	for _, raw := range servers {
 		server := normalizeHetznerServer(raw)
 		claim, claimExists, err := core.ReadLeaseClaimWithPresence(server.Labels["lease"])
@@ -526,7 +503,7 @@ func ownedHetznerServers(servers []Server) []Server {
 	}
 	return owned
 }
-func rollbackHetznerAcquire(client hetznerClient, server Server, serverCreated bool, keyName string, keyCreated bool) error {
+func rollbackHetznerAcquire(client hetznerClient, server core.Server, serverCreated bool, keyName string, keyCreated bool) error {
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 	if serverCreated {
@@ -538,14 +515,6 @@ func rollbackHetznerAcquire(client hetznerClient, server Server, serverCreated b
 	}
 	return nil
 }
-func parseServerID(s string) (int64, bool) { return core.ParseServerID(s) }
-
-func useStoredTestboxKey(target *SSHTarget, leaseID string) error {
-	return core.UseStoredTestboxKey(target, leaseID)
-}
-func findServerByAlias(servers []Server, id string) (Server, string, error) {
-	return core.FindServerByAlias(servers, id)
-}
 
 var (
 	newHetznerClient          = func() (hetznerClient, error) { return core.NewHetznerClient() }
@@ -554,10 +523,10 @@ var (
 	providerKeyForLease       = core.ProviderKeyForLease
 	waitForSSHReady           = core.WaitForSSHReady
 	bootstrapWaitTimeout      = core.BootstrapWaitTimeout
-	waitForServerIP           = func(ctx context.Context, client hetznerClient, id int64) (Server, error) {
+	waitForServerIP           = func(ctx context.Context, client hetznerClient, id int64) (core.Server, error) {
 		concrete, ok := client.(*core.HetznerClient)
 		if !ok {
-			return Server{}, exit(2, "hetzner IP wait requires a Hetzner client")
+			return core.Server{}, core.Exit(2, "hetzner IP wait requires a Hetzner client")
 		}
 		return core.WaitForServerIP(ctx, concrete, id)
 	}

--- a/internal/providers/hetzner/backend_test.go
+++ b/internal/providers/hetzner/backend_test.go
@@ -21,10 +21,10 @@ import (
 )
 
 type fakeHetznerClient struct {
-	servers map[int64]Server
-	list    []Server
+	servers map[int64]core.Server
+	list    []core.Server
 
-	createServer Server
+	createServer core.Server
 	createCalls  int
 	createErr    error
 	deleteErr    error
@@ -37,7 +37,7 @@ type fakeHetznerClient struct {
 	labeledServers []int64
 }
 
-func (f *fakeHetznerClient) ListCrabboxServers(context.Context) ([]Server, error) {
+func (f *fakeHetznerClient) ListCrabboxServers(context.Context) ([]core.Server, error) {
 	return f.list, nil
 }
 
@@ -48,15 +48,15 @@ func (f *fakeHetznerClient) EnsureSSHKey(_ context.Context, name, _ string) (cor
 	return core.SSHKey{Name: name}, f.keyCreated, nil
 }
 
-func (f *fakeHetznerClient) CreateServerWithFallback(_ context.Context, cfg Config, _, _, _ string, _ bool, _ func(string, ...any)) (Server, Config, error) {
+func (f *fakeHetznerClient) CreateServerWithFallback(_ context.Context, cfg core.Config, _, _, _ string, _ bool, _ func(string, ...any)) (core.Server, core.Config, error) {
 	f.createCalls++
 	return f.createServer, cfg, f.createErr
 }
 
-func (f *fakeHetznerClient) GetServer(_ context.Context, id int64) (Server, error) {
+func (f *fakeHetznerClient) GetServer(_ context.Context, id int64) (core.Server, error) {
 	server, ok := f.servers[id]
 	if !ok {
-		return Server{}, errors.New("server not found")
+		return core.Server{}, errors.New("server not found")
 	}
 	return server, nil
 }
@@ -88,17 +88,17 @@ func installHetznerTestHooks(t *testing.T, client *fakeHetznerClient) {
 
 	newHetznerClient = func() (hetznerClient, error) { return client, nil }
 	newLeaseID = func() string { return "cbx_abcdef123456" }
-	ensureTestboxKeyForConfig = func(Config, string) (string, string, error) {
+	ensureTestboxKeyForConfig = func(core.Config, string) (string, string, error) {
 		return "/tmp/crabbox-test-key", "ssh-ed25519 test", nil
 	}
 	providerKeyForLease = core.ProviderKeyForLease
-	waitForServerIP = func(ctx context.Context, client hetznerClient, id int64) (Server, error) {
+	waitForServerIP = func(ctx context.Context, client hetznerClient, id int64) (core.Server, error) {
 		return client.GetServer(ctx, id)
 	}
-	waitForSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+	waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
 		return nil
 	}
-	bootstrapWaitTimeout = func(Config) time.Duration { return 0 }
+	bootstrapWaitTimeout = func(core.Config) time.Duration { return 0 }
 
 	t.Cleanup(func() {
 		newHetznerClient = oldNewClient
@@ -112,13 +112,13 @@ func installHetznerTestHooks(t *testing.T, client *fakeHetznerClient) {
 }
 
 func TestHetznerResolveNumericRejectsUnownedServer(t *testing.T) {
-	client := &fakeHetznerClient{servers: map[int64]Server{
+	client := &fakeHetznerClient{servers: map[int64]core.Server{
 		42: {ID: 42, Labels: map[string]string{"crabbox": "true"}},
 	}}
 	installHetznerTestHooks(t, client)
 
-	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: "42"})
+	backend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "42"})
 	if err == nil || !strings.Contains(err.Error(), "refusing to operate on non-Crabbox Hetzner server") {
 		t.Fatalf("err=%v, want ownership refusal", err)
 	}
@@ -128,13 +128,13 @@ func TestHetznerResolveNumericRejectsUnownedServer(t *testing.T) {
 }
 
 func TestHetznerResolveAliasRejectsUnownedServer(t *testing.T) {
-	client := &fakeHetznerClient{servers: map[int64]Server{}}
-	client.servers[42] = Server{ID: 42, Name: "crabbox-test", Labels: map[string]string{"crabbox": "true", "lease": "cbx_abcdef123456", "slug": "test"}}
-	client.list = []Server{client.servers[42]}
+	client := &fakeHetznerClient{servers: map[int64]core.Server{}}
+	client.servers[42] = core.Server{ID: 42, Name: "crabbox-test", Labels: map[string]string{"crabbox": "true", "lease": "cbx_abcdef123456", "slug": "test"}}
+	client.list = []core.Server{client.servers[42]}
 	installHetznerTestHooks(t, client)
 
-	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: "test"})
+	backend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "test"})
 	if err == nil || !strings.Contains(err.Error(), "lease/server not found") {
 		t.Fatalf("err=%v, want filtered inventory miss", err)
 	}
@@ -149,7 +149,7 @@ func TestHetznerDeleteRejectsUnownedBeforeClient(t *testing.T) {
 	}
 	t.Cleanup(func() { newHetznerClient = oldNewClient })
 
-	err := deleteServer(context.Background(), Config{}, Server{ID: 42, Labels: map[string]string{"crabbox": "true"}})
+	err := deleteServer(context.Background(), core.Config{}, core.Server{ID: 42, Labels: map[string]string{"crabbox": "true"}})
 	if err == nil || !strings.Contains(err.Error(), "refusing to operate on non-Crabbox Hetzner server") {
 		t.Fatalf("err=%v, want ownership refusal", err)
 	}
@@ -167,7 +167,7 @@ func TestHetznerDeleteAllowsLegacyServerWithoutProviderLabel(t *testing.T) {
 	server := crabboxHetznerServer(42, leaseID)
 	delete(server.Labels, "provider")
 	seedHetznerClaim(t, server)
-	if err := deleteServer(context.Background(), Config{}, server); err != nil {
+	if err := deleteServer(context.Background(), core.Config{}, server); err != nil {
 		t.Fatal(err)
 	}
 	if len(client.deletedServers) != 1 || client.deletedServers[0] != 42 {
@@ -184,8 +184,8 @@ func TestHetznerReleaseKeepsServerReachableUntilKeyDeleteSucceeds(t *testing.T) 
 
 	seedHetznerClaim(t, crabboxHetznerServer(42, leaseID))
 
-	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
-	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: crabboxHetznerServer(42, leaseID)}})
+	backend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: crabboxHetznerServer(42, leaseID)}})
 	if !errors.Is(err, keyErr) {
 		t.Fatalf("err=%v, want key delete failure", err)
 	}
@@ -200,7 +200,7 @@ func TestHetznerReleaseKeepsServerReachableUntilKeyDeleteSucceeds(t *testing.T) 
 	}
 
 	client.keyDeleteErr = nil
-	err = backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: crabboxHetznerServer(42, leaseID)}})
+	err = backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: crabboxHetznerServer(42, leaseID)}})
 	if err != nil {
 		t.Fatalf("retry ReleaseLease: %v", err)
 	}
@@ -223,8 +223,8 @@ func TestHetznerReleaseTreatsMissingServerAsGone(t *testing.T) {
 
 	seedHetznerClaim(t, crabboxHetznerServer(42, leaseID))
 
-	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
-	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: crabboxHetznerServer(42, leaseID)}})
+	backend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: crabboxHetznerServer(42, leaseID)}})
 	if err != nil {
 		t.Fatalf("ReleaseLease: %v", err)
 	}
@@ -248,8 +248,8 @@ func TestHetznerReleaseDoesNotTreatBodyMentioned404AsMissingServer(t *testing.T)
 
 	seedHetznerClaim(t, crabboxHetznerServer(42, leaseID))
 
-	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
-	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: crabboxHetznerServer(42, leaseID)}})
+	backend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: crabboxHetznerServer(42, leaseID)}})
 	if !errors.Is(err, deleteErr) {
 		t.Fatalf("err=%v, want server delete failure", err)
 	}
@@ -268,8 +268,8 @@ func TestHetznerReleaseRejectsMismatchedLeaseBeforeDelete(t *testing.T) {
 	installHetznerClaimState(t)
 	seedHetznerClaim(t, server)
 
-	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
-	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
+	backend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
 		LeaseID: "cbx_fedcba654321",
 		Server:  server,
 	}})
@@ -290,8 +290,8 @@ func TestHetznerReleaseRejectsClaimForDifferentServer(t *testing.T) {
 	seedHetznerClaim(t, claimed)
 
 	replacement := crabboxHetznerServer(43, leaseID)
-	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
-	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: replacement}})
+	backend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: replacement}})
 	if err == nil || !strings.Contains(err.Error(), "stale exact local claim") {
 		t.Fatalf("err=%v, want stale-claim refusal", err)
 	}
@@ -304,19 +304,19 @@ func TestHetznerReleaseRollsBackExactLeaseAcquiredByBackendBeforeClaim(t *testin
 	leaseID := "cbx_abcdef123456"
 	server := acquiredHetznerTestServer(42, leaseID)
 	client := &fakeHetznerClient{
-		servers:      map[int64]Server{42: server},
+		servers:      map[int64]core.Server{42: server},
 		createServer: server,
 		keyCreated:   true,
 	}
 	installHetznerTestHooks(t, client)
 	installHetznerClaimState(t)
 
-	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
-	lease, err := backend.Acquire(context.Background(), AcquireRequest{RequestedSlug: "test"})
+	backend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{RequestedSlug: "test"})
 	if err != nil {
 		t.Fatalf("Acquire: %v", err)
 	}
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatalf("ReleaseLease before claim: %v", err)
 	}
 	if len(client.deletedServers) != 1 || client.deletedServers[0] != 42 {
@@ -331,20 +331,20 @@ func TestHetznerReleaseRejectsUnclaimedLeaseAcquiredByDifferentBackend(t *testin
 	leaseID := "cbx_abcdef123456"
 	server := acquiredHetznerTestServer(42, leaseID)
 	client := &fakeHetznerClient{
-		servers:      map[int64]Server{42: server},
+		servers:      map[int64]core.Server{42: server},
 		createServer: server,
 		keyCreated:   true,
 	}
 	installHetznerTestHooks(t, client)
 	installHetznerClaimState(t)
 
-	acquiringBackend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
-	lease, err := acquiringBackend.Acquire(context.Background(), AcquireRequest{RequestedSlug: "test"})
+	acquiringBackend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	lease, err := acquiringBackend.Acquire(context.Background(), core.AcquireRequest{RequestedSlug: "test"})
 	if err != nil {
 		t.Fatalf("Acquire: %v", err)
 	}
-	otherBackend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
-	err = otherBackend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease})
+	otherBackend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	err = otherBackend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
 	if err == nil || !strings.Contains(err.Error(), "no exact local claim") {
 		t.Fatalf("err=%v, want exact-claim refusal", err)
 	}
@@ -362,14 +362,14 @@ func TestHetznerCleanupSkipsWeakAndUnclaimedServers(t *testing.T) {
 	unclaimed.Labels["expires_at"] = core.LeaseLabelTime(now.Add(-time.Hour))
 	claimed := crabboxHetznerServer(43, "cbx_333333333333")
 	claimed.Labels["expires_at"] = core.LeaseLabelTime(now.Add(-time.Hour))
-	client := &fakeHetznerClient{list: []Server{weak, unclaimed, claimed}}
+	client := &fakeHetznerClient{list: []core.Server{weak, unclaimed, claimed}}
 	installHetznerTestHooks(t, client)
 	installHetznerClaimState(t)
 	seedHetznerClaim(t, claimed)
 
 	var stderr strings.Builder
-	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: &stderr}).(*hetznerLeaseBackend)
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	backend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: &stderr}).(*hetznerLeaseBackend)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if len(client.deletedServers) != 1 || client.deletedServers[0] != claimed.ID {
@@ -385,19 +385,19 @@ func TestHetznerCleanupSkipsWeakAndUnclaimedServers(t *testing.T) {
 
 func TestHetznerResolveRequiresExplicitReclaimForUnclaimedServer(t *testing.T) {
 	server := crabboxHetznerServer(42, "cbx_abcdef123456")
-	client := &fakeHetznerClient{servers: map[int64]Server{42: server}}
+	client := &fakeHetznerClient{servers: map[int64]core.Server{42: server}}
 	installHetznerTestHooks(t, client)
 	installHetznerClaimState(t)
-	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	backend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
 
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: "42", Repo: core.Repo{Root: "/repo"}})
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "42", Repo: core.Repo{Root: "/repo"}})
 	if err == nil || !strings.Contains(err.Error(), "use --reclaim") {
 		t.Fatalf("err=%v, want explicit reclaim refusal", err)
 	}
-	if _, err := backend.Resolve(context.Background(), ResolveRequest{ID: "42", Repo: core.Repo{Root: "/repo"}, Reclaim: true}); err != nil {
+	if _, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "42", Repo: core.Repo{Root: "/repo"}, Reclaim: true}); err != nil {
 		t.Fatalf("explicit reclaim resolve: %v", err)
 	}
-	if _, err := backend.Resolve(context.Background(), ResolveRequest{ID: "42", NoLocalStateMutations: true}); err != nil {
+	if _, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "42", NoLocalStateMutations: true}); err != nil {
 		t.Fatalf("read-only resolve: %v", err)
 	}
 }
@@ -406,7 +406,7 @@ func TestHetznerResolveAliasAllowsExplicitUpgradeOfLegacyClaim(t *testing.T) {
 	leaseID := "cbx_abcdef123456"
 	server := crabboxHetznerServer(42, leaseID)
 	delete(server.Labels, "provider")
-	client := &fakeHetznerClient{list: []Server{server}}
+	client := &fakeHetznerClient{list: []core.Server{server}}
 	installHetznerTestHooks(t, client)
 	installHetznerClaimState(t)
 	seedHetznerClaim(t, server)
@@ -421,11 +421,11 @@ func TestHetznerResolveAliasAllowsExplicitUpgradeOfLegacyClaim(t *testing.T) {
 		t.Fatalf("replace with legacy claim: %v", err)
 	}
 
-	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
-	if _, err := backend.Resolve(context.Background(), ResolveRequest{ID: "test", Repo: core.Repo{Root: "/repo"}}); err == nil {
+	backend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	if _, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "test", Repo: core.Repo{Root: "/repo"}}); err == nil {
 		t.Fatal("legacy alias resolved without explicit reclaim")
 	}
-	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: "test", Repo: core.Repo{Root: "/repo"}, Reclaim: true})
+	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "test", Repo: core.Repo{Root: "/repo"}, Reclaim: true})
 	if err != nil {
 		t.Fatalf("explicit legacy alias reclaim: %v", err)
 	}
@@ -438,17 +438,17 @@ func TestHetznerAcquireRollsBackAfterIPWaitFailure(t *testing.T) {
 	leaseID := "cbx_abcdef123456"
 	server := acquiredHetznerTestServer(42, leaseID)
 	client := &fakeHetznerClient{
-		servers:      map[int64]Server{42: server},
+		servers:      map[int64]core.Server{42: server},
 		createServer: server,
 		keyCreated:   true,
 	}
 	installHetznerTestHooks(t, client)
 	waitErr := errors.New("ip wait failed")
-	waitForServerIP = func(context.Context, hetznerClient, int64) (Server, error) {
-		return Server{}, waitErr
+	waitForServerIP = func(context.Context, hetznerClient, int64) (core.Server, error) {
+		return core.Server{}, waitErr
 	}
 
-	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	backend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
 	_, err := backend.acquireOnce(context.Background(), false, "test")
 	if !errors.Is(err, waitErr) {
 		t.Fatalf("err=%v, want ip wait failure", err)
@@ -465,24 +465,24 @@ func TestHetznerAcquireBindsReadinessToCreatedServer(t *testing.T) {
 	const leaseID = "cbx_abcdef123456"
 	for _, tt := range []struct {
 		name   string
-		mutate func(*Server)
+		mutate func(*core.Server)
 	}{
-		{"different ID", func(s *Server) { s.ID = 43; s.CloudID = "43" }},
-		{"missing ID", func(s *Server) { s.ID = 0; s.CloudID = "" }},
-		{"inconsistent cloud ID", func(s *Server) { s.CloudID = "43" }},
-		{"different name", func(s *Server) { s.Name = "another-resource" }},
-		{"missing name", func(s *Server) { s.Name = "" }},
-		{"different lease", func(s *Server) { s.Labels["lease"] = "cbx_111111111111" }},
-		{"different provider", func(s *Server) { s.Labels["provider"] = "other" }},
-		{"missing owner", func(s *Server) { delete(s.Labels, "created_by") }},
-		{"different slug", func(s *Server) { s.Labels["slug"] = "other" }},
-		{"different key", func(s *Server) { s.Labels["provider_key"] = core.ProviderKeyForLease("cbx_111111111111") }},
+		{"different ID", func(s *core.Server) { s.ID = 43; s.CloudID = "43" }},
+		{"missing ID", func(s *core.Server) { s.ID = 0; s.CloudID = "" }},
+		{"inconsistent cloud ID", func(s *core.Server) { s.CloudID = "43" }},
+		{"different name", func(s *core.Server) { s.Name = "another-resource" }},
+		{"missing name", func(s *core.Server) { s.Name = "" }},
+		{"different lease", func(s *core.Server) { s.Labels["lease"] = "cbx_111111111111" }},
+		{"different provider", func(s *core.Server) { s.Labels["provider"] = "other" }},
+		{"missing owner", func(s *core.Server) { delete(s.Labels, "created_by") }},
+		{"different slug", func(s *core.Server) { s.Labels["slug"] = "other" }},
+		{"different key", func(s *core.Server) { s.Labels["provider_key"] = core.ProviderKeyForLease("cbx_111111111111") }},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			created := acquiredHetznerTestServer(42, leaseID)
 			client := &fakeHetznerClient{createServer: created, keyCreated: true}
 			installHetznerTestHooks(t, client)
-			waitForServerIP = func(_ context.Context, _ hetznerClient, id int64) (Server, error) {
+			waitForServerIP = func(_ context.Context, _ hetznerClient, id int64) (core.Server, error) {
 				if id != 42 {
 					t.Fatalf("readiness lookup=%d", id)
 				}
@@ -493,12 +493,12 @@ func TestHetznerAcquireBindsReadinessToCreatedServer(t *testing.T) {
 				return ready, nil
 			}
 			sshCalls := 0
-			waitForSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+			waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
 				sshCalls++
 				return errors.New("unexpected SSH")
 			}
-			backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
-			_, err := backend.Acquire(context.Background(), AcquireRequest{RequestedSlug: "test"})
+			backend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+			_, err := backend.Acquire(context.Background(), core.AcquireRequest{RequestedSlug: "test"})
 			if err == nil || !strings.Contains(err.Error(), "readiness") {
 				t.Fatalf("err=%v, want readiness binding rejection", err)
 			}
@@ -518,7 +518,7 @@ func TestHetznerAcquireBindsReadinessToCreatedServer(t *testing.T) {
 	}
 }
 
-func acquiredHetznerTestServer(id int64, leaseID string) Server {
+func acquiredHetznerTestServer(id int64, leaseID string) core.Server {
 	server := crabboxHetznerServer(id, leaseID)
 	server.Name = core.LeaseProviderName(leaseID, "test")
 	server.Labels = maps.Clone(server.Labels)
@@ -530,30 +530,30 @@ func TestHetznerAcquireRejectsUnboundCreateWithoutDeletingReturnedServer(t *test
 	const leaseID = "cbx_abcdef123456"
 	for _, tt := range []struct {
 		name   string
-		mutate func(*Server)
+		mutate func(*core.Server)
 	}{
-		{"missing ID", func(s *Server) { s.ID = 0; s.CloudID = "" }},
-		{"contradictory ID", func(s *Server) { s.CloudID = "43" }},
-		{"foreign name", func(s *Server) { s.Name = "foreign" }},
-		{"foreign lease", func(s *Server) { s.Labels["lease"] = "cbx_111111111111" }},
-		{"missing provider", func(s *Server) { delete(s.Labels, "provider") }},
-		{"foreign key", func(s *Server) { s.Labels["provider_key"] = core.ProviderKeyForLease("cbx_111111111111") }},
+		{"missing ID", func(s *core.Server) { s.ID = 0; s.CloudID = "" }},
+		{"contradictory ID", func(s *core.Server) { s.CloudID = "43" }},
+		{"foreign name", func(s *core.Server) { s.Name = "foreign" }},
+		{"foreign lease", func(s *core.Server) { s.Labels["lease"] = "cbx_111111111111" }},
+		{"missing provider", func(s *core.Server) { delete(s.Labels, "provider") }},
+		{"foreign key", func(s *core.Server) { s.Labels["provider_key"] = core.ProviderKeyForLease("cbx_111111111111") }},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			created := acquiredHetznerTestServer(42, leaseID)
 			tt.mutate(&created)
 			client := &fakeHetznerClient{createServer: created, keyCreated: true}
 			installHetznerTestHooks(t, client)
-			waitForServerIP = func(context.Context, hetznerClient, int64) (Server, error) {
+			waitForServerIP = func(context.Context, hetznerClient, int64) (core.Server, error) {
 				t.Fatal("unbound creation polled")
-				return Server{}, nil
+				return core.Server{}, nil
 			}
-			waitForSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+			waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
 				t.Fatal("unbound creation reached SSH")
 				return nil
 			}
-			backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
-			_, err := backend.Acquire(context.Background(), AcquireRequest{RequestedSlug: "test"})
+			backend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+			_, err := backend.Acquire(context.Background(), core.AcquireRequest{RequestedSlug: "test"})
 			if err == nil || !strings.Contains(err.Error(), "server cleanup withheld") {
 				t.Fatalf("err=%v", err)
 			}
@@ -573,10 +573,10 @@ func TestHetznerAcquireAcceptsNewEndpointAndPreservesReusedKey(t *testing.T) {
 		t.Run(strconv.FormatBool(failSSH), func(t *testing.T) {
 			created := acquiredHetznerTestServer(42, leaseID)
 			const reusedKey = "shared key / with punctuation"
-			created.Labels["provider_key"] = core.DirectLeaseLabels(Config{ProviderKey: reusedKey}, leaseID, "test", providerName, "", false, time.Now())["provider_key"]
+			created.Labels["provider_key"] = core.DirectLeaseLabels(core.Config{ProviderKey: reusedKey}, leaseID, "test", providerName, "", false, time.Now())["provider_key"]
 			client := &fakeHetznerClient{createServer: created, keyName: reusedKey}
 			installHetznerTestHooks(t, client)
-			waitForServerIP = func(context.Context, hetznerClient, int64) (Server, error) {
+			waitForServerIP = func(context.Context, hetznerClient, int64) (core.Server, error) {
 				ready := created
 				ready.Labels = maps.Clone(created.Labels)
 				ready.PublicNet.IPv4.IP = "203.0.113.11"
@@ -584,7 +584,7 @@ func TestHetznerAcquireAcceptsNewEndpointAndPreservesReusedKey(t *testing.T) {
 				return ready, nil
 			}
 			sshErr := errors.New("synthetic SSH failure")
-			waitForSSHReady = func(_ context.Context, target *SSHTarget, _ io.Writer, _ string, _ time.Duration) error {
+			waitForSSHReady = func(_ context.Context, target *core.SSHTarget, _ io.Writer, _ string, _ time.Duration) error {
 				if target.Host != "203.0.113.11" {
 					t.Fatalf("SSH host=%s", target.Host)
 				}
@@ -593,8 +593,8 @@ func TestHetznerAcquireAcceptsNewEndpointAndPreservesReusedKey(t *testing.T) {
 				}
 				return nil
 			}
-			backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
-			lease, err := backend.Acquire(context.Background(), AcquireRequest{RequestedSlug: "test"})
+			backend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+			lease, err := backend.Acquire(context.Background(), core.AcquireRequest{RequestedSlug: "test"})
 			if failSSH {
 				if !errors.Is(err, sshErr) || len(client.deletedServers) != 1 || client.deletedServers[0] != 42 {
 					t.Fatalf("err=%v deleted=%v", err, client.deletedServers)
@@ -614,7 +614,7 @@ func TestHetznerAcquireNativeHTTPReadinessBinding(t *testing.T) {
 		t.Run(strconv.FormatInt(observedID, 10), func(t *testing.T) {
 			var mu sync.Mutex
 			var requests []string
-			var created Server
+			var created core.Server
 			var createdKey core.SSHKey
 			api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				mu.Lock()
@@ -648,7 +648,7 @@ func TestHetznerAcquireNativeHTTPReadinessBinding(t *testing.T) {
 						http.Error(w, "invalid server", 400)
 						return
 					}
-					created = Server{ID: 42, Name: input.Name, Labels: input.Labels}
+					created = core.Server{ID: 42, Name: input.Name, Labels: input.Labels}
 					_ = json.NewEncoder(w).Encode(map[string]any{"server": created})
 				case "GET /servers/42":
 					ready := created
@@ -666,20 +666,20 @@ func TestHetznerAcquireNativeHTTPReadinessBinding(t *testing.T) {
 			installHetznerTestHooks(t, &fakeHetznerClient{})
 			client := &core.HetznerClient{Token: "synthetic", Client: api.Client(), BaseURL: api.URL}
 			newHetznerClient = func() (hetznerClient, error) { return client, nil }
-			waitForServerIP = func(ctx context.Context, _ hetznerClient, id int64) (Server, error) {
+			waitForServerIP = func(ctx context.Context, _ hetznerClient, id int64) (core.Server, error) {
 				return core.WaitForServerIP(ctx, client, id)
 			}
 			sshCalls := 0
-			waitForSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+			waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
 				sshCalls++
 				if observedID != 42 {
 					return errors.New("unexpected readiness SSH")
 				}
 				return nil
 			}
-			cfg := Config{ServerType: "cpx11", ServerTypeExplicit: true, Location: "test", Image: "ubuntu-24.04"}
-			backend := NewHetznerLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
-			lease, err := backend.Acquire(context.Background(), AcquireRequest{RequestedSlug: "test"})
+			cfg := core.Config{ServerType: "cpx11", ServerTypeExplicit: true, Location: "test", Image: "ubuntu-24.04"}
+			backend := NewHetznerLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+			lease, err := backend.Acquire(context.Background(), core.AcquireRequest{RequestedSlug: "test"})
 			mu.Lock()
 			trace := strings.Join(requests, "\n")
 			mu.Unlock()
@@ -701,17 +701,17 @@ func TestHetznerAcquireReportsRollbackFailure(t *testing.T) {
 	deleteErr := errors.New("delete failed")
 	waitErr := errors.New("ip wait failed")
 	client := &fakeHetznerClient{
-		servers:      map[int64]Server{42: server},
+		servers:      map[int64]core.Server{42: server},
 		createServer: server,
 		deleteErr:    deleteErr,
 		keyCreated:   true,
 	}
 	installHetznerTestHooks(t, client)
-	waitForServerIP = func(context.Context, hetznerClient, int64) (Server, error) {
-		return Server{}, waitErr
+	waitForServerIP = func(context.Context, hetznerClient, int64) (core.Server, error) {
+		return core.Server{}, waitErr
 	}
 
-	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	backend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
 	_, err := backend.acquireOnce(context.Background(), false, "test")
 	if !errors.Is(err, waitErr) || !errors.Is(err, deleteErr) {
 		t.Fatalf("err=%v, want both acquisition and cleanup errors", err)
@@ -723,7 +723,7 @@ func TestHetznerAcquireDeletesProviderKeyWhenCreateFails(t *testing.T) {
 	client := &fakeHetznerClient{createErr: createErr, keyCreated: true}
 	installHetznerTestHooks(t, client)
 
-	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	backend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
 	_, err := backend.acquireOnce(context.Background(), false, "")
 	if !errors.Is(err, createErr) {
 		t.Fatalf("err=%v, want create failure", err)
@@ -738,7 +738,7 @@ func TestHetznerAcquireKeepsExistingProviderKeyWhenCreateFails(t *testing.T) {
 	client := &fakeHetznerClient{createErr: createErr}
 	installHetznerTestHooks(t, client)
 
-	backend := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
+	backend := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: io.Discard}).(*hetznerLeaseBackend)
 	_, err := backend.acquireOnce(context.Background(), false, "")
 	if !errors.Is(err, createErr) {
 		t.Fatalf("err=%v, want create failure", err)
@@ -748,8 +748,8 @@ func TestHetznerAcquireKeepsExistingProviderKeyWhenCreateFails(t *testing.T) {
 	}
 }
 
-func crabboxHetznerServer(id int64, leaseID string) Server {
-	server := Server{
+func crabboxHetznerServer(id int64, leaseID string) core.Server {
+	server := core.Server{
 		CloudID: strconv.FormatInt(id, 10),
 		ID:      id,
 		Name:    "crabbox-test",
@@ -759,10 +759,10 @@ func crabboxHetznerServer(id int64, leaseID string) Server {
 	return server
 }
 
-func seedHetznerClaim(t *testing.T, server Server) {
+func seedHetznerClaim(t *testing.T, server core.Server) {
 	t.Helper()
-	cfg := Config{Provider: providerName}
-	if err := core.ClaimLeaseTargetForRepoConfig(server.Labels["lease"], server.Labels["slug"], cfg, normalizeHetznerServer(server), SSHTarget{}, "/repo", 30*time.Minute, false); err != nil {
+	cfg := core.Config{Provider: providerName}
+	if err := core.ClaimLeaseTargetForRepoConfig(server.Labels["lease"], server.Labels["slug"], cfg, normalizeHetznerServer(server), core.SSHTarget{}, "/repo", 30*time.Minute, false); err != nil {
 		t.Fatalf("seed claim: %v", err)
 	}
 }
@@ -783,7 +783,7 @@ func TestHetznerAcquireStopsFreshRetryAfterRollbackFailure(t *testing.T) {
 	for _, failure := range []string{"none", "server", "key"} {
 		t.Run(failure, func(t *testing.T) {
 			debt := errors.New("cleanup unavailable")
-			fake := &fakeHetznerClient{servers: map[int64]Server{}, keyCreated: true}
+			fake := &fakeHetznerClient{servers: map[int64]core.Server{}, keyCreated: true}
 			if failure == "server" {
 				fake.deleteErr = debt
 			}
@@ -801,10 +801,10 @@ func TestHetznerAcquireStopsFreshRetryAfterRollbackFailure(t *testing.T) {
 				return id
 			}
 			primary := core.Exit(5, "timed out waiting for SSH: fixture")
-			waitForSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error { return primary }
+			waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return primary }
 			var stderr bytes.Buffer
-			b := NewHetznerLeaseBackend(ProviderSpec{}, Config{}, Runtime{Stderr: &stderr}).(*hetznerLeaseBackend)
-			_, err := b.Acquire(context.Background(), AcquireRequest{RequestedSlug: "test"})
+			b := NewHetznerLeaseBackend(core.ProviderSpec{}, core.Config{}, core.Runtime{Stderr: &stderr}).(*hetznerLeaseBackend)
+			_, err := b.Acquire(context.Background(), core.AcquireRequest{RequestedSlug: "test"})
 			want := 1
 			if failure == "none" {
 				want = 2

--- a/internal/providers/hetzner/checkpoint.go
+++ b/internal/providers/hetzner/checkpoint.go
@@ -23,7 +23,7 @@ const (
 )
 
 type hetznerSnapshotClient interface {
-	GetServer(context.Context, int64) (Server, error)
+	GetServer(context.Context, int64) (core.Server, error)
 	CreateServerSnapshot(context.Context, int64, string, map[string]string) (core.HetznerImage, error)
 	GetImage(context.Context, int64) (core.HetznerImage, error)
 	DeleteImage(context.Context, int64) error
@@ -392,7 +392,7 @@ func failedHetznerSnapshotState(state string) bool {
 	}
 }
 
-func hetznerServerArchitecture(server Server) (string, error) {
+func hetznerServerArchitecture(server core.Server) (string, error) {
 	imageArchitecture := ""
 	if server.Image != nil {
 		imageArchitecture = server.Image.Architecture

--- a/internal/providers/hetzner/checkpoint_test.go
+++ b/internal/providers/hetzner/checkpoint_test.go
@@ -111,7 +111,7 @@ func TestHetznerCheckpointCLIWithMalformedUnrelatedConfig(t *testing.T) {
 }
 
 type fakeHetznerSnapshotClient struct {
-	server            Server
+	server            core.Server
 	serverErr         error
 	created           core.HetznerImage
 	createErr         error
@@ -127,7 +127,7 @@ type fakeHetznerSnapshotClient struct {
 	events            []string
 }
 
-func (f *fakeHetznerSnapshotClient) GetServer(context.Context, int64) (Server, error) {
+func (f *fakeHetznerSnapshotClient) GetServer(context.Context, int64) (core.Server, error) {
 	f.events = append(f.events, "get-server")
 	return f.server, f.serverErr
 }
@@ -195,7 +195,7 @@ func TestHetznerNativeCheckpointCapabilityMatrix(t *testing.T) {
 	provider := Provider{}
 	base := core.NativeCheckpointRequest{
 		Config:   core.Config{TargetOS: core.TargetLinux},
-		Server:   Server{CloudID: "42"},
+		Server:   core.Server{CloudID: "42"},
 		Target:   core.SSHTarget{TargetOS: core.TargetLinux},
 		Strategy: core.CheckpointStrategyDiskSnapshot,
 	}
@@ -301,12 +301,12 @@ func TestCreateHetznerCheckpointWaitFalseRecordsBinding(t *testing.T) {
 
 func TestCreateHetznerCheckpointRejectsOwnershipBeforeGuestReset(t *testing.T) {
 	for name, tc := range map[string]struct {
-		mutate func(*Server)
+		mutate func(*core.Server)
 		seed   bool
 	}{
-		"missing canonical label": {mutate: func(server *Server) { delete(server.Labels, "created_by") }, seed: true},
-		"source lease mismatch":   {mutate: func(server *Server) { server.Labels["lease"] = "cbx_other123456" }, seed: true},
-		"missing exact claim":     {mutate: func(*Server) {}, seed: false},
+		"missing canonical label": {mutate: func(server *core.Server) { delete(server.Labels, "created_by") }, seed: true},
+		"source lease mismatch":   {mutate: func(server *core.Server) { server.Labels["lease"] = "cbx_other123456" }, seed: true},
+		"missing exact claim":     {mutate: func(*core.Server) {}, seed: false},
 	} {
 		t.Run(name, func(t *testing.T) {
 			installHetznerClaimState(t)
@@ -608,7 +608,7 @@ func TestCreateHetznerCheckpointRejectsImageStrategyClearly(t *testing.T) {
 	}
 }
 
-func checkpointHetznerServer() Server {
+func checkpointHetznerServer() core.Server {
 	server := crabboxHetznerServer(42, "cbx_abcdef123456")
 	server.Location = &core.ServerLocationInfo{Name: "fsn1"}
 	server.Image = &core.ServerImageInfo{Architecture: "x86"}

--- a/internal/providers/proxmox/backend.go
+++ b/internal/providers/proxmox/backend.go
@@ -13,41 +13,26 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-type Config = core.Config
-type Runtime = core.Runtime
-type ProviderSpec = core.ProviderSpec
-type Backend = core.Backend
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type CleanupRequest = core.CleanupRequest
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-
 type leaseBackend struct{ shared.DirectSSHBackend }
 
 const proxmoxReleaseAbsentMarker = "proxmox-release-absent"
 
 type proxmoxClient interface {
-	DoctorReadiness(context.Context, Config) ([]core.ProxmoxReadinessCheck, error)
-	ListCrabboxServers(context.Context) ([]Server, error)
-	ListCrabboxServersCluster(context.Context) ([]Server, error)
-	CreateServer(context.Context, Config, string, string, string, bool) (Server, error)
-	GetServer(context.Context, string) (Server, error)
-	GetServerOnNode(context.Context, string, string) (Server, error)
+	DoctorReadiness(context.Context, core.Config) ([]core.ProxmoxReadinessCheck, error)
+	ListCrabboxServers(context.Context) ([]core.Server, error)
+	ListCrabboxServersCluster(context.Context) ([]core.Server, error)
+	CreateServer(context.Context, core.Config, string, string, string, bool) (core.Server, error)
+	GetServer(context.Context, string) (core.Server, error)
+	GetServerOnNode(context.Context, string, string) (core.Server, error)
 	VMExistsInCluster(context.Context, string) (bool, error)
 	DeleteServer(context.Context, string) error
 	DeleteServerOnNode(context.Context, string, string) error
-	DeleteServerOnNodeChecked(context.Context, string, string, func(Server) error) error
+	DeleteServerOnNodeChecked(context.Context, string, string, func(core.Server) error) error
 	SetLabels(context.Context, string, map[string]string) error
 	SetLabelsOnNode(context.Context, string, string, map[string]string) error
 }
 
-func NewLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = "proxmox"
 	if cfg.Proxmox.User != "" {
 		cfg.SSHUser = cfg.Proxmox.User
@@ -58,56 +43,56 @@ func NewLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	return &leaseBackend{DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt, StoredLeaseKeys: true}}
 }
 
-func (b *leaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
-	return shared.AcquireAttemptsRetry(b.RT, req.Keep, func() (LeaseTarget, error) {
+func (b *leaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
+	return shared.AcquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
 		return b.acquireOnce(ctx, req.Keep, req.RequestedSlug)
 	})
 }
 
-func (b *leaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (LeaseTarget, error) {
+func (b *leaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (core.LeaseTarget, error) {
 	if b.Cfg.Proxmox.TemplateID <= 0 {
-		return LeaseTarget{}, exit(3, "proxmox templateId is required (set proxmox.templateId or CRABBOX_PROXMOX_TEMPLATE_ID)")
+		return core.LeaseTarget{}, core.Exit(3, "proxmox templateId is required (set proxmox.templateId or CRABBOX_PROXMOX_TEMPLATE_ID)")
 	}
 	client, err := newClient(b.Cfg)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	leaseID := newLeaseID()
+	leaseID := core.NewLeaseID()
 	servers, err := client.ListCrabboxServersCluster(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	slug, err := allocateDirectLeaseSlug(leaseID, requestedSlug, servers)
+	slug, err := core.AllocateDirectLeaseSlug(leaseID, requestedSlug, servers)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cfg := b.Cfg
-	keyPath, publicKey, err := ensureTestboxKeyForConfig(cfg, leaseID)
+	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cfg.SSHKey = keyPath
-	cfg.ProviderKey = providerKeyForLease(leaseID)
-	cfg.ServerType = proxmoxServerTypeForConfig(cfg)
+	cfg.ProviderKey = core.ProviderKeyForLease(leaseID)
+	cfg.ServerType = core.ProxmoxServerTypeForConfig(cfg)
 	fmt.Fprintf(b.RT.Stderr, "provisioning provider=proxmox lease=%s slug=%s node=%s template=%d keep=%v\n",
 		leaseID, slug, cfg.Proxmox.Node, cfg.Proxmox.TemplateID, keep)
 	server, err := client.CreateServer(ctx, cfg, publicKey, leaseID, slug, keep)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if server.PublicNet.IPv4.IP == "" {
 		cloudID := server.CloudID
 		hostID := server.HostID
-		server, err = b.waitForServerIP(ctx, client, cloudID, bootstrapWaitTimeout(cfg))
+		server, err = b.waitForServerIP(ctx, client, cloudID, core.BootstrapWaitTimeout(cfg))
 		if err != nil {
-			b.cleanupFailedAcquire(client, Server{CloudID: cloudID, HostID: hostID}, leaseID)
-			return LeaseTarget{}, err
+			b.cleanupFailedAcquire(client, core.Server{CloudID: cloudID, HostID: hostID}, leaseID)
+			return core.LeaseTarget{}, err
 		}
 	}
-	target := sshTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
-	if err := waitForSSHReadyFunc(ctx, &target, b.RT.Stderr, "bootstrap", bootstrapWaitTimeout(cfg)); err != nil {
+	target := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+	if err := waitForSSHReadyFunc(ctx, &target, b.RT.Stderr, "bootstrap", core.BootstrapWaitTimeout(cfg)); err != nil {
 		b.cleanupFailedAcquire(client, server, leaseID)
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if server.Labels == nil {
 		server.Labels = map[string]string{}
@@ -117,10 +102,10 @@ func (b *leaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug
 		fmt.Fprintf(b.RT.Stderr, "warning: set proxmox labels: %v\n", err)
 	}
 	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s server=%s node=%s ip=%s\n", leaseID, server.DisplayID(), cfg.Proxmox.Node, server.PublicNet.IPv4.IP)
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
-func (b *leaseBackend) cleanupFailedAcquire(client proxmoxClient, server Server, leaseID string) {
+func (b *leaseBackend) cleanupFailedAcquire(client proxmoxClient, server core.Server, leaseID string) {
 	node := core.Blank(server.HostID, b.Cfg.Proxmox.Node)
 	if err := client.DeleteServerOnNode(context.Background(), node, server.CloudID); err != nil && !core.IsProxmoxNotFound(err) {
 		fmt.Fprintf(b.RT.Stderr, "warning: preserve failed Proxmox acquire residue lease=%s reason=delete_failed error=%v\n", leaseID, err)
@@ -138,7 +123,7 @@ func (b *leaseBackend) cleanupFailedAcquire(client proxmoxClient, server Server,
 	removeLocalLeaseResidue(leaseID)
 }
 
-func (b *leaseBackend) waitForServerIP(ctx context.Context, client proxmoxClient, cloudID string, timeout time.Duration) (Server, error) {
+func (b *leaseBackend) waitForServerIP(ctx context.Context, client proxmoxClient, cloudID string, timeout time.Duration) (core.Server, error) {
 	deadlineCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	ticker := time.NewTicker(proxmoxIPPollInterval)
@@ -152,34 +137,34 @@ func (b *leaseBackend) waitForServerIP(ctx context.Context, client proxmoxClient
 				return nil
 			}
 		},
-		func(ctx context.Context) (Server, error) { return client.GetServer(ctx, cloudID) },
-		func(_ context.Context, server Server, fetchErr error) (bool, error) {
+		func(ctx context.Context) (core.Server, error) { return client.GetServer(ctx, cloudID) },
+		func(_ context.Context, server core.Server, fetchErr error) (bool, error) {
 			return server.PublicNet.IPv4.IP != "", fetchErr
 		}, nil)
 	if err != nil {
 		if result.Err == nil && context.Cause(deadlineCtx) != nil && errors.Is(err, context.Cause(deadlineCtx)) {
-			return Server{}, deadlineCtx.Err()
+			return core.Server{}, deadlineCtx.Err()
 		}
-		return Server{}, err
+		return core.Server{}, err
 	}
 	return result.Value, nil
 }
 
-func (b *leaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *leaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	client, err := newClient(b.Cfg)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.ID != "" {
 		if _, err := strconv.Atoi(req.ID); err == nil || strings.HasPrefix(req.ID, "crabbox-") {
 			server, err := client.GetServer(ctx, req.ID)
 			if err != nil {
 				if !core.IsProxmoxNotFound(err) && !req.ReleaseOnly {
-					return LeaseTarget{}, err
+					return core.LeaseTarget{}, err
 				}
 			} else {
-				if !isCrabboxLease(server) {
-					return LeaseTarget{}, exit(4, "lease/server not found: %s (VM exists but is not Crabbox-managed)", req.ID)
+				if !core.IsCrabboxProxmoxLease(server) {
+					return core.LeaseTarget{}, core.Exit(4, "lease/server not found: %s (VM exists but is not Crabbox-managed)", req.ID)
 				}
 				return b.targetForServer(server, req.ReleaseOnly)
 			}
@@ -187,14 +172,14 @@ func (b *leaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTa
 	}
 	servers, err := client.ListCrabboxServersCluster(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	if server, leaseID, err := findServerByAlias(servers, req.ID); err != nil {
-		return LeaseTarget{}, err
+	if server, leaseID, err := core.FindServerByAlias(servers, req.ID); err != nil {
+		return core.LeaseTarget{}, err
 	} else if leaseID != "" {
 		target, err := b.targetForServer(server, req.ReleaseOnly)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		target.LeaseID = leaseID
 		return target, nil
@@ -202,10 +187,10 @@ func (b *leaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTa
 	if req.ReleaseOnly {
 		return b.releaseTargetFromClaim(ctx, client, req.ID)
 	}
-	return LeaseTarget{}, exit(4, "lease/server not found: %s", req.ID)
+	return core.LeaseTarget{}, core.Exit(4, "lease/server not found: %s", req.ID)
 }
 
-func (b *leaseBackend) releaseTargetFromClaim(ctx context.Context, client proxmoxClient, id string) (LeaseTarget, error) {
+func (b *leaseBackend) releaseTargetFromClaim(ctx context.Context, client proxmoxClient, id string) (core.LeaseTarget, error) {
 	var (
 		claim core.LeaseClaim
 		ok    bool
@@ -217,63 +202,63 @@ func (b *leaseBackend) releaseTargetFromClaim(ctx context.Context, client proxmo
 		var exact bool
 		claim, ok, exact, err = core.ResolveLeaseClaimForProviderWithExact(id, "proxmox")
 		if err == nil && exact && (!ok || claim.LeaseID != id) {
-			return LeaseTarget{}, exit(2, "proxmox exact lease identifier %q does not match a valid Proxmox claim", id)
+			return core.LeaseTarget{}, core.Exit(2, "proxmox exact lease identifier %q does not match a valid Proxmox claim", id)
 		}
 	}
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if !ok || claim.LeaseID == "" || !core.LeaseClaimMatchesIdentifier(claim, id) {
-		return LeaseTarget{}, exit(4, "lease/server not found: %s", id)
+		return core.LeaseTarget{}, core.Exit(4, "lease/server not found: %s", id)
 	}
 	cloudID := strings.TrimSpace(claim.CloudID)
 	vmid, err := strconv.ParseInt(cloudID, 10, 64)
 	if err != nil || vmid <= 0 {
-		return LeaseTarget{}, exit(2, "proxmox lease claim has invalid VM identity for lease=%s", claim.LeaseID)
+		return core.LeaseTarget{}, core.Exit(2, "proxmox lease claim has invalid VM identity for lease=%s", claim.LeaseID)
 	}
 	if server, err := client.GetServer(ctx, cloudID); err == nil {
-		if !isCrabboxLease(server) || strings.TrimSpace(server.Labels["lease"]) != claim.LeaseID {
-			return LeaseTarget{}, exit(2, "refusing to release Proxmox VM %s from stale local claim lease=%s", cloudID, claim.LeaseID)
+		if !core.IsCrabboxProxmoxLease(server) || strings.TrimSpace(server.Labels["lease"]) != claim.LeaseID {
+			return core.LeaseTarget{}, core.Exit(2, "refusing to release Proxmox VM %s from stale local claim lease=%s", cloudID, claim.LeaseID)
 		}
-		return LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
+		return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
 	}
 	claimScope := strings.TrimSpace(claim.ProviderScope)
 	currentScope := strings.TrimSpace(core.ProviderClaimScope("proxmox", b.Cfg))
 	if claimScope == "" || currentScope == "" || claimScope != currentScope {
-		return LeaseTarget{}, exit(2, "refusing to accept missing Proxmox VM %s from lease=%s with unverified cluster scope", cloudID, claim.LeaseID)
+		return core.LeaseTarget{}, core.Exit(2, "refusing to accept missing Proxmox VM %s from lease=%s with unverified cluster scope", cloudID, claim.LeaseID)
 	}
 	clusterServers, err := client.ListCrabboxServersCluster(ctx)
 	if err != nil {
-		return LeaseTarget{}, fmt.Errorf("locate Proxmox VM %s across cluster: %w", cloudID, err)
+		return core.LeaseTarget{}, fmt.Errorf("locate Proxmox VM %s across cluster: %w", cloudID, err)
 	}
 	for _, server := range clusterServers {
 		if server.CloudID != cloudID {
 			continue
 		}
-		if !isCrabboxLease(server) || strings.TrimSpace(server.Labels["lease"]) != claim.LeaseID {
-			return LeaseTarget{}, exit(2, "refusing to release Proxmox VM %s from stale local claim lease=%s", cloudID, claim.LeaseID)
+		if !core.IsCrabboxProxmoxLease(server) || strings.TrimSpace(server.Labels["lease"]) != claim.LeaseID {
+			return core.LeaseTarget{}, core.Exit(2, "refusing to release Proxmox VM %s from stale local claim lease=%s", cloudID, claim.LeaseID)
 		}
-		return LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
+		return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
 	}
 	exists, err := client.VMExistsInCluster(ctx, cloudID)
 	if err != nil {
-		return LeaseTarget{}, fmt.Errorf("verify Proxmox VM %s cluster absence: %w", cloudID, err)
+		return core.LeaseTarget{}, fmt.Errorf("verify Proxmox VM %s cluster absence: %w", cloudID, err)
 	}
 	if exists {
-		return LeaseTarget{}, exit(2, "refusing to accept missing Proxmox VM %s from lease=%s because it still exists in the cluster", cloudID, claim.LeaseID)
+		return core.LeaseTarget{}, core.Exit(2, "refusing to accept missing Proxmox VM %s from lease=%s because it still exists in the cluster", cloudID, claim.LeaseID)
 	}
 	labels := shared.CloneLabels(claim.Labels)
 	if leaseLabel := strings.TrimSpace(labels["lease"]); leaseLabel != "" && leaseLabel != claim.LeaseID {
-		return LeaseTarget{}, exit(2, "proxmox lease claim label mismatch for lease=%s", claim.LeaseID)
+		return core.LeaseTarget{}, core.Exit(2, "proxmox lease claim label mismatch for lease=%s", claim.LeaseID)
 	}
 	if providerLabel := strings.TrimSpace(labels["provider"]); providerLabel != "" && providerLabel != "proxmox" {
-		return LeaseTarget{}, exit(2, "proxmox lease claim provider label mismatch for lease=%s", claim.LeaseID)
+		return core.LeaseTarget{}, core.Exit(2, "proxmox lease claim provider label mismatch for lease=%s", claim.LeaseID)
 	}
 	labels["lease"] = claim.LeaseID
 	labels["provider"] = "proxmox"
-	return LeaseTarget{
+	return core.LeaseTarget{
 		LeaseID: claim.LeaseID,
-		Server: Server{
+		Server: core.Server{
 			CloudID:  cloudID,
 			Provider: "proxmox",
 			HostID:   proxmoxReleaseAbsentMarker,
@@ -304,13 +289,13 @@ func (b *leaseBackend) resolveNumericClaim(cloudID string) (core.LeaseClaim, boo
 		}
 	}
 	if len(scoped) > 1 {
-		return core.LeaseClaim{}, false, exit(2, "multiple provider=proxmox claims in the current scope match cloud id %s", cloudID)
+		return core.LeaseClaim{}, false, core.Exit(2, "multiple provider=proxmox claims in the current scope match cloud id %s", cloudID)
 	}
 	if len(scoped) == 1 {
 		return scoped[0], true, nil
 	}
 	if len(legacy) > 1 {
-		return core.LeaseClaim{}, false, exit(2, "multiple unscoped provider=proxmox claims match cloud id %s", cloudID)
+		return core.LeaseClaim{}, false, core.Exit(2, "multiple unscoped provider=proxmox claims match cloud id %s", cloudID)
 	}
 	if len(legacy) == 1 {
 		return legacy[0], true, nil
@@ -318,19 +303,19 @@ func (b *leaseBackend) resolveNumericClaim(cloudID string) (core.LeaseClaim, boo
 	return core.LeaseClaim{}, false, nil
 }
 
-func (b *leaseBackend) targetForServer(server Server, releaseOnly bool) (LeaseTarget, error) {
+func (b *leaseBackend) targetForServer(server core.Server, releaseOnly bool) (core.LeaseTarget, error) {
 	cfg := b.Cfg
-	target := sshTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
+	target := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
 	leaseID := core.Blank(server.Labels["lease"], server.CloudID)
 	if !releaseOnly {
-		if err := useStoredTestboxKey(&target, leaseID); err != nil {
-			return LeaseTarget{}, err
+		if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
+			return core.LeaseTarget{}, err
 		}
 	}
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
-func (b *leaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *leaseBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	client, err := newClient(b.Cfg)
 	if err != nil {
@@ -360,7 +345,7 @@ func (b *leaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.D
 	return result, nil
 }
 
-func (b *leaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *leaseBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	client, err := newClient(b.Cfg)
 	if err != nil {
 		return err
@@ -395,7 +380,7 @@ func (b *leaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest
 	return removeCleanupLeaseResidue(ctx, client, deleted, remaining, b.Cfg, b.RT.Stderr)
 }
 
-func (b *leaseBackend) backfillReleaseClaimScope(leaseID, cloudID string, server Server) error {
+func (b *leaseBackend) backfillReleaseClaimScope(leaseID, cloudID string, server core.Server) error {
 	if leaseID == "" || proxmoxClaimLabelLeaseID(server) != leaseID {
 		return nil
 	}
@@ -411,7 +396,7 @@ func (b *leaseBackend) backfillReleaseClaimScope(leaseID, cloudID string, server
 	}
 	scope := strings.TrimSpace(core.ProviderClaimScope("proxmox", b.Cfg))
 	if scope == "" {
-		return exit(2, "cannot safely release legacy Proxmox claim lease=%s without configured cluster scope", leaseID)
+		return core.Exit(2, "cannot safely release legacy Proxmox claim lease=%s without configured cluster scope", leaseID)
 	}
 	replacement := claim
 	replacement.ProviderScope = scope
@@ -421,21 +406,21 @@ func (b *leaseBackend) backfillReleaseClaimScope(leaseID, cloudID string, server
 	return core.ReplaceLeaseClaimIfUnchanged(leaseID, claim, replacement)
 }
 
-func (b *leaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
+func (b *leaseBackend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
 	client, err := newClient(b.Cfg)
 	if err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	server := req.Lease.Server
 	server.Labels = core.TouchDirectLeaseLabels(server.Labels, b.Cfg, req.State, time.Now().UTC())
 	node := core.Blank(server.HostID, b.Cfg.Proxmox.Node)
 	if err := client.SetLabelsOnNode(ctx, node, server.CloudID, server.Labels); err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	return server, nil
 }
 
-func (b *leaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
+func (b *leaseBackend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return err
@@ -472,7 +457,7 @@ func (b *leaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	return nil
 }
 
-func (b *leaseBackend) cleanupClaimedServer(ctx context.Context, client proxmoxClient, server Server, claim core.LeaseClaim, binding shared.ClaimBinding) error {
+func (b *leaseBackend) cleanupClaimedServer(ctx context.Context, client proxmoxClient, server core.Server, claim core.LeaseClaim, binding shared.ClaimBinding) error {
 	var deleteErr error
 	err := shared.RemoveExactClaimAfter(claim, binding, func() error {
 		// Inventory is discovery only. Revalidate its node, lifecycle and native
@@ -485,7 +470,7 @@ func (b *leaseBackend) cleanupClaimedServer(ctx context.Context, client proxmoxC
 		if err != nil {
 			return err
 		}
-		var fresh Server
+		var fresh core.Server
 		for _, candidate := range current {
 			if candidate.CloudID == server.CloudID {
 				fresh = candidate
@@ -498,7 +483,7 @@ func (b *leaseBackend) cleanupClaimedServer(ctx context.Context, client proxmoxC
 		if _, _, err := b.cleanupClaim(fresh, current, currentClaims); err != nil {
 			return err
 		}
-		check := func(live Server) error {
+		check := func(live core.Server) error {
 			if live.HostID != fresh.HostID {
 				return fmt.Errorf("Proxmox VM %s changed node during cleanup", server.CloudID)
 			}
@@ -555,13 +540,13 @@ func waitForProxmoxCleanupAbsence(ctx context.Context, client proxmoxClient, clo
 	return err
 }
 
-func removeCleanupLeaseResidue(ctx context.Context, client proxmoxClient, deleted Server, inventory []Server, cfg Config, stderr io.Writer) error {
+func removeCleanupLeaseResidue(ctx context.Context, client proxmoxClient, deleted core.Server, inventory []core.Server, cfg core.Config, stderr io.Writer) error {
 	leaseID := proxmoxClaimLabelLeaseID(deleted)
 	if leaseID == "" {
 		return nil
 	}
 	missingCloudIDs := map[string]bool{deleted.CloudID: true}
-	var survivors []Server
+	var survivors []core.Server
 	for _, server := range inventory {
 		if proxmoxClaimLabelLeaseID(server) == leaseID {
 			survivors = append(survivors, server)
@@ -609,7 +594,7 @@ func removeCleanupLeaseResidue(ctx context.Context, client proxmoxClient, delete
 				}
 			}
 			if canRetarget {
-				target := sshTargetFromConfig(cfg, survivors[0].PublicNet.IPv4.IP)
+				target := core.SSHTargetFromConfig(cfg, survivors[0].PublicNet.IPv4.IP)
 				if target.Port == "" && claim.SSHPort > 0 {
 					target.Port = strconv.Itoa(claim.SSHPort)
 				}
@@ -623,7 +608,7 @@ func removeCleanupLeaseResidue(ctx context.Context, client proxmoxClient, delete
 		return fmt.Errorf("Proxmox lease %s still has %d surviving VM(s)", leaseID, len(survivors))
 	}
 	if !found {
-		removeStoredTestboxKey(leaseID)
+		core.RemoveStoredTestboxKey(leaseID)
 		return nil
 	}
 	if claim.Provider != "proxmox" {
@@ -645,18 +630,18 @@ func removeCleanupLeaseResidue(ctx context.Context, client proxmoxClient, delete
 		fmt.Fprintf(stderr, "warning: preserve local lease residue lease=%s reason=claim_changed error=%v\n", leaseID, err)
 		return nil
 	}
-	removeStoredTestboxKey(leaseID)
+	core.RemoveStoredTestboxKey(leaseID)
 	return nil
 }
 
-func proxmoxClaimLeaseID(server Server, fallback string) string {
+func proxmoxClaimLeaseID(server core.Server, fallback string) string {
 	if leaseID := proxmoxClaimLabelLeaseID(server); leaseID != "" {
 		return leaseID
 	}
 	return strings.TrimSpace(fallback)
 }
 
-func proxmoxClaimLabelLeaseID(server Server) string {
+func proxmoxClaimLabelLeaseID(server core.Server) string {
 	if server.Labels != nil {
 		if leaseID := strings.TrimSpace(server.Labels["lease"]); leaseID != "" {
 			return leaseID
@@ -665,50 +650,15 @@ func proxmoxClaimLabelLeaseID(server Server) string {
 	return ""
 }
 
-var newClient = func(cfg Config) (proxmoxClient, error) { return core.NewProxmoxClient(cfg) }
+var newClient = func(cfg core.Config) (proxmoxClient, error) { return core.NewProxmoxClient(cfg) }
 
-func newLeaseID() string { return core.NewLeaseID() }
-func allocateDirectLeaseSlug(id, requested string, servers []Server) (string, error) {
-	return core.AllocateDirectLeaseSlug(id, requested, servers)
-}
-func ensureTestboxKeyForConfig(cfg Config, leaseID string) (string, string, error) {
-	return core.EnsureTestboxKeyForConfig(cfg, leaseID)
-}
-func providerKeyForLease(leaseID string) string { return core.ProviderKeyForLease(leaseID) }
-func proxmoxServerTypeForConfig(cfg Config) string {
-	return core.ProxmoxServerTypeForConfig(cfg)
-}
-func sshTargetFromConfig(cfg Config, host string) SSHTarget {
-	return core.SSHTargetFromConfig(cfg, host)
-}
-func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
-	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
-}
-
-var waitForSSHReadyFunc = waitForSSHReady
+var waitForSSHReadyFunc = core.WaitForSSHReady
 
 var proxmoxIPPollInterval = 2 * time.Second
 var proxmoxDeleteVerifyPollInterval = time.Second
 var proxmoxDeleteVerifyTimeout = 30 * time.Second
 
-func bootstrapWaitTimeout(cfg Config) time.Duration { return core.BootstrapWaitTimeout(cfg) }
-func findServerByAlias(servers []Server, id string) (Server, string, error) {
-	return core.FindServerByAlias(servers, id)
-}
-func isCrabboxLease(server Server) bool { return core.IsCrabboxProxmoxLease(server) }
-func removeLeaseClaim(leaseID string)   { core.RemoveLeaseClaim(leaseID) }
-func removeStoredTestboxKey(leaseID string) {
-	core.RemoveStoredTestboxKey(leaseID)
-}
-
 func removeLocalLeaseResidue(leaseID string) {
-	removeLeaseClaim(leaseID)
-	removeStoredTestboxKey(leaseID)
-}
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-
-func useStoredTestboxKey(target *SSHTarget, leaseID string) error {
-	return core.UseStoredTestboxKey(target, leaseID)
+	core.RemoveLeaseClaim(leaseID)
+	core.RemoveStoredTestboxKey(leaseID)
 }

--- a/internal/providers/proxmox/backend_doctor_test.go
+++ b/internal/providers/proxmox/backend_doctor_test.go
@@ -22,9 +22,9 @@ type fakeProxmoxDoctorClient struct {
 	deletedIDs            []string
 	deletedNodes          []string
 	mutated               bool
-	servers               []Server
-	clusterServers        []Server
-	created               Server
+	servers               []core.Server
+	clusterServers        []core.Server
+	created               core.Server
 	createErr             error
 	deleteErr             error
 	deleteErrByID         map[string]error
@@ -33,7 +33,7 @@ type fakeProxmoxDoctorClient struct {
 	getErrByID            map[string]error
 	getErrSequenceByID    map[string][]error
 	getCallsByID          map[string]int
-	getServerByID         map[string]Server
+	getServerByID         map[string]core.Server
 	clusterExistsByID     map[string]bool
 	clusterExistsErr      error
 	setLabels             []map[string]string
@@ -42,16 +42,16 @@ type fakeProxmoxDoctorClient struct {
 	leaseIDs              []string
 }
 
-func (c *fakeProxmoxDoctorClient) DoctorReadiness(context.Context, Config) ([]core.ProxmoxReadinessCheck, error) {
+func (c *fakeProxmoxDoctorClient) DoctorReadiness(context.Context, core.Config) ([]core.ProxmoxReadinessCheck, error) {
 	return c.readiness, nil
 }
 
-func (c *fakeProxmoxDoctorClient) ListCrabboxServers(context.Context) ([]Server, error) {
+func (c *fakeProxmoxDoctorClient) ListCrabboxServers(context.Context) ([]core.Server, error) {
 	c.listCalls++
 	return c.servers, c.listErr
 }
 
-func (c *fakeProxmoxDoctorClient) ListCrabboxServersCluster(context.Context) ([]Server, error) {
+func (c *fakeProxmoxDoctorClient) ListCrabboxServersCluster(context.Context) ([]core.Server, error) {
 	c.listCalls++
 	if c.clusterListErr != nil && (c.listCalls > 1 || len(c.servers) == 0) {
 		return nil, c.clusterListErr
@@ -62,19 +62,19 @@ func (c *fakeProxmoxDoctorClient) ListCrabboxServersCluster(context.Context) ([]
 	return c.servers, c.listErr
 }
 
-func (c *fakeProxmoxDoctorClient) CreateServer(_ context.Context, _ Config, _ string, leaseID string, _ string, _ bool) (Server, error) {
+func (c *fakeProxmoxDoctorClient) CreateServer(_ context.Context, _ core.Config, _ string, leaseID string, _ string, _ bool) (core.Server, error) {
 	c.mutated = true
 	c.leaseIDs = append(c.leaseIDs, leaseID)
 	if c.createErr != nil {
-		return Server{}, c.createErr
+		return core.Server{}, c.createErr
 	}
 	if c.created.CloudID != "" {
 		return c.created, nil
 	}
-	return Server{}, nil
+	return core.Server{}, nil
 }
 
-func (c *fakeProxmoxDoctorClient) GetServer(_ context.Context, id string) (Server, error) {
+func (c *fakeProxmoxDoctorClient) GetServer(_ context.Context, id string) (core.Server, error) {
 	c.getCalls++
 	if c.getCallsByID == nil {
 		c.getCallsByID = map[string]int{}
@@ -83,11 +83,11 @@ func (c *fakeProxmoxDoctorClient) GetServer(_ context.Context, id string) (Serve
 	c.getCallsByID[id]++
 	if sequence := c.getErrSequenceByID[id]; callIndex < len(sequence) {
 		if err := sequence[callIndex]; err != nil {
-			return Server{}, err
+			return core.Server{}, err
 		}
 	}
 	if err := c.getErrByID[id]; err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	if server, ok := c.getServerByID[id]; ok {
 		return server, nil
@@ -98,14 +98,14 @@ func (c *fakeProxmoxDoctorClient) GetServer(_ context.Context, id string) (Serve
 		}
 	}
 	if c.getCalls < 3 {
-		return Server{CloudID: "101", Labels: map[string]string{"lease": "cbx_test", "slug": "test"}}, nil
+		return core.Server{CloudID: "101", Labels: map[string]string{"lease": "cbx_test", "slug": "test"}}, nil
 	}
-	server := Server{CloudID: "101", Labels: map[string]string{"lease": "cbx_test", "slug": "test"}}
+	server := core.Server{CloudID: "101", Labels: map[string]string{"lease": "cbx_test", "slug": "test"}}
 	server.PublicNet.IPv4.IP = "192.0.2.10"
 	return server, nil
 }
 
-func (c *fakeProxmoxDoctorClient) GetServerOnNode(ctx context.Context, node, id string) (Server, error) {
+func (c *fakeProxmoxDoctorClient) GetServerOnNode(ctx context.Context, node, id string) (core.Server, error) {
 	for _, server := range c.clusterServers {
 		if server.CloudID == id && (server.HostID == "" || server.HostID == node) {
 			return server, nil
@@ -130,7 +130,7 @@ func (c *fakeProxmoxDoctorClient) VMExistsInCluster(_ context.Context, id string
 	if _, ok := c.getServerByID[id]; ok {
 		return true, nil
 	}
-	for _, server := range append(append([]Server(nil), c.servers...), c.clusterServers...) {
+	for _, server := range append(append([]core.Server(nil), c.servers...), c.clusterServers...) {
 		if server.CloudID == id {
 			return true, nil
 		}
@@ -175,7 +175,7 @@ func (c *fakeProxmoxDoctorClient) DeleteServerOnNode(ctx context.Context, node, 
 	return nil
 }
 
-func (c *fakeProxmoxDoctorClient) DeleteServerOnNodeChecked(ctx context.Context, node, id string, check func(Server) error) error {
+func (c *fakeProxmoxDoctorClient) DeleteServerOnNodeChecked(ctx context.Context, node, id string, check func(core.Server) error) error {
 	server, err := c.GetServerOnNode(ctx, node, id)
 	if err != nil {
 		return err
@@ -212,12 +212,12 @@ func TestProxmoxDoctorReportsReadinessChecksWithoutMutation(t *testing.T) {
 		{Status: "ok", Check: "mutation", Message: "mutation=false", Details: map[string]string{"mutation": "false"}},
 	}}
 	old := newClient
-	newClient = func(Config) (proxmoxClient, error) {
+	newClient = func(core.Config) (proxmoxClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newClient = old })
 
-	doctor, err := Provider{}.ConfigureDoctor(Config{}, Runtime{})
+	doctor, err := Provider{}.ConfigureDoctor(core.Config{}, core.Runtime{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -253,13 +253,13 @@ func TestProxmoxDoctorReportsReadinessChecksWithoutMutation(t *testing.T) {
 func TestProxmoxTouchUsesMigratedVMNode(t *testing.T) {
 	fake := &fakeProxmoxDoctorClient{}
 	oldClient := newClient
-	newClient = func(Config) (proxmoxClient, error) { return fake, nil }
+	newClient = func(core.Config) (proxmoxClient, error) { return fake, nil }
 	t.Cleanup(func() { newClient = oldClient })
 
 	server := expiredProxmoxServer("101", "cbx_migrated_touch")
 	server.HostID = "pve2"
-	backend := NewLeaseBackend(Provider{}.Spec(), Config{Proxmox: core.ProxmoxConfig{Node: "pve1"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
-	if _, err := backend.Touch(context.Background(), TouchRequest{Lease: LeaseTarget{LeaseID: "cbx_migrated_touch", Server: server}, State: "running"}); err != nil {
+	backend := NewLeaseBackend(Provider{}.Spec(), core.Config{Proxmox: core.ProxmoxConfig{Node: "pve1"}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
+	if _, err := backend.Touch(context.Background(), core.TouchRequest{Lease: core.LeaseTarget{LeaseID: "cbx_migrated_touch", Server: server}, State: "running"}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.labelNodes) != 1 || fake.labelNodes[0] != "pve2" {
@@ -272,14 +272,14 @@ func TestProxmoxAcquireRejectsMissingTemplateBeforeClientWork(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	clientCalls := 0
 	oldClient := newClient
-	newClient = func(Config) (proxmoxClient, error) {
+	newClient = func(core.Config) (proxmoxClient, error) {
 		clientCalls++
 		return &fakeProxmoxDoctorClient{}, nil
 	}
 	t.Cleanup(func() { newClient = oldClient })
 
-	backend := NewLeaseBackend(Provider{}.Spec(), Config{SSHUser: "root"}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
-	if _, err := backend.Acquire(context.Background(), AcquireRequest{}); err == nil || !strings.Contains(err.Error(), "proxmox templateId is required") {
+	backend := NewLeaseBackend(Provider{}.Spec(), core.Config{SSHUser: "root"}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
+	if _, err := backend.Acquire(context.Background(), core.AcquireRequest{}); err == nil || !strings.Contains(err.Error(), "proxmox templateId is required") {
 		t.Fatalf("Acquire error=%v, want missing templateId", err)
 	}
 	if clientCalls != 0 {
@@ -291,12 +291,12 @@ func TestProxmoxAcquirePollsUntilServerIPIsAvailable(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := &fakeProxmoxDoctorClient{}
 	oldClient := newClient
-	newClient = func(Config) (proxmoxClient, error) {
+	newClient = func(core.Config) (proxmoxClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newClient = oldClient })
 	oldWait := waitForSSHReadyFunc
-	waitForSSHReadyFunc = func(_ context.Context, target *SSHTarget, _ io.Writer, _ string, _ time.Duration) error {
+	waitForSSHReadyFunc = func(_ context.Context, target *core.SSHTarget, _ io.Writer, _ string, _ time.Duration) error {
 		if target.Host != "192.0.2.10" {
 			t.Fatalf("ssh host=%q, want discovered IP", target.Host)
 		}
@@ -307,8 +307,8 @@ func TestProxmoxAcquirePollsUntilServerIPIsAvailable(t *testing.T) {
 	proxmoxIPPollInterval = time.Millisecond
 	t.Cleanup(func() { proxmoxIPPollInterval = oldPoll })
 
-	backend := NewLeaseBackend(Provider{}.Spec(), Config{SSHUser: "root", Proxmox: core.ProxmoxConfig{TemplateID: 9400}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
-	target, err := backend.Acquire(context.Background(), AcquireRequest{})
+	backend := NewLeaseBackend(Provider{}.Spec(), core.Config{SSHUser: "root", Proxmox: core.ProxmoxConfig{TemplateID: 9400}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
+	target, err := backend.Acquire(context.Background(), core.AcquireRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -325,24 +325,24 @@ func TestProxmoxAcquirePollsUntilServerIPIsAvailable(t *testing.T) {
 
 func TestProxmoxAcquireInitializesNilLabels(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	created := Server{CloudID: "101"}
+	created := core.Server{CloudID: "101"}
 	created.PublicNet.IPv4.IP = "192.0.2.10"
 	fake := &fakeProxmoxDoctorClient{
 		created: created,
 	}
 	oldClient := newClient
-	newClient = func(Config) (proxmoxClient, error) {
+	newClient = func(core.Config) (proxmoxClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newClient = oldClient })
 	oldWait := waitForSSHReadyFunc
-	waitForSSHReadyFunc = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+	waitForSSHReadyFunc = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
 		return nil
 	}
 	t.Cleanup(func() { waitForSSHReadyFunc = oldWait })
 
-	backend := NewLeaseBackend(Provider{}.Spec(), Config{SSHUser: "root", Proxmox: core.ProxmoxConfig{TemplateID: 9400}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
-	target, err := backend.Acquire(context.Background(), AcquireRequest{})
+	backend := NewLeaseBackend(Provider{}.Spec(), core.Config{SSHUser: "root", Proxmox: core.ProxmoxConfig{TemplateID: 9400}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
+	target, err := backend.Acquire(context.Background(), core.AcquireRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,22 +357,22 @@ func TestProxmoxAcquireInitializesNilLabels(t *testing.T) {
 func TestProxmoxAcquireSSHFailureRemovesStoredKeyAfterDelete(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	created := Server{CloudID: "101"}
+	created := core.Server{CloudID: "101"}
 	created.PublicNet.IPv4.IP = "192.0.2.10"
 	fake := &fakeProxmoxDoctorClient{created: created}
 	oldClient := newClient
-	newClient = func(Config) (proxmoxClient, error) {
+	newClient = func(core.Config) (proxmoxClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newClient = oldClient })
 	oldWait := waitForSSHReadyFunc
-	waitForSSHReadyFunc = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+	waitForSSHReadyFunc = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
 		return errors.New("ssh unavailable")
 	}
 	t.Cleanup(func() { waitForSSHReadyFunc = oldWait })
 
-	backend := NewLeaseBackend(Provider{}.Spec(), Config{SSHUser: "root", Proxmox: core.ProxmoxConfig{TemplateID: 9400}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
-	if _, err := backend.Acquire(context.Background(), AcquireRequest{}); err == nil {
+	backend := NewLeaseBackend(Provider{}.Spec(), core.Config{SSHUser: "root", Proxmox: core.ProxmoxConfig{TemplateID: 9400}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
+	if _, err := backend.Acquire(context.Background(), core.AcquireRequest{}); err == nil {
 		t.Fatal("expected ssh readiness failure")
 	}
 	if len(fake.deletedIDs) != 1 || fake.deletedIDs[0] != "101" {
@@ -387,22 +387,22 @@ func TestProxmoxAcquireSSHFailureRemovesStoredKeyAfterDelete(t *testing.T) {
 func TestProxmoxAcquirePreservesStoredKeyWhenDeleteFails(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	created := Server{CloudID: "101"}
+	created := core.Server{CloudID: "101"}
 	created.PublicNet.IPv4.IP = "192.0.2.10"
 	fake := &fakeProxmoxDoctorClient{created: created, deleteErr: errors.New("delete failed")}
 	oldClient := newClient
-	newClient = func(Config) (proxmoxClient, error) {
+	newClient = func(core.Config) (proxmoxClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newClient = oldClient })
 	oldWait := waitForSSHReadyFunc
-	waitForSSHReadyFunc = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+	waitForSSHReadyFunc = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
 		return errors.New("ssh unavailable")
 	}
 	t.Cleanup(func() { waitForSSHReadyFunc = oldWait })
 
-	backend := NewLeaseBackend(Provider{}.Spec(), Config{SSHUser: "root", Proxmox: core.ProxmoxConfig{TemplateID: 9400}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
-	if _, err := backend.Acquire(context.Background(), AcquireRequest{}); err == nil {
+	backend := NewLeaseBackend(Provider{}.Spec(), core.Config{SSHUser: "root", Proxmox: core.ProxmoxConfig{TemplateID: 9400}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
+	if _, err := backend.Acquire(context.Background(), core.AcquireRequest{}); err == nil {
 		t.Fatal("expected ssh readiness failure")
 	}
 	if len(fake.deletedIDs) != 1 || fake.deletedIDs[0] != "101" {
@@ -422,18 +422,18 @@ func TestProxmoxAcquirePreservesStoredKeyWhenVMClaimsToMigrateDuringCleanup(t *t
 	created.PublicNet.IPv4.IP = "192.0.2.10"
 	migrated := created
 	migrated.HostID = "pve2"
-	fake := &fakeProxmoxDoctorClient{created: created, clusterServers: []Server{migrated}}
+	fake := &fakeProxmoxDoctorClient{created: created, clusterServers: []core.Server{migrated}}
 	oldClient := newClient
-	newClient = func(Config) (proxmoxClient, error) { return fake, nil }
+	newClient = func(core.Config) (proxmoxClient, error) { return fake, nil }
 	t.Cleanup(func() { newClient = oldClient })
 	oldWait := waitForSSHReadyFunc
-	waitForSSHReadyFunc = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+	waitForSSHReadyFunc = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
 		return errors.New("ssh unavailable")
 	}
 	t.Cleanup(func() { waitForSSHReadyFunc = oldWait })
 
-	backend := NewLeaseBackend(Provider{}.Spec(), Config{SSHUser: "root", Proxmox: core.ProxmoxConfig{Node: "pve1", TemplateID: 9400}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
-	if _, err := backend.Acquire(context.Background(), AcquireRequest{}); err == nil {
+	backend := NewLeaseBackend(Provider{}.Spec(), core.Config{SSHUser: "root", Proxmox: core.ProxmoxConfig{Node: "pve1", TemplateID: 9400}}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
+	if _, err := backend.Acquire(context.Background(), core.AcquireRequest{}); err == nil {
 		t.Fatal("expected ssh readiness failure")
 	}
 	if len(fake.deletedNodes) != 1 || fake.deletedNodes[0] != "pve1" {
@@ -448,23 +448,23 @@ func TestProxmoxAcquirePreservesStoredKeyWhenVMClaimsToMigrateDuringCleanup(t *t
 func TestProxmoxReleaseRemovesClaimAndStoredKeyAfterDelete(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	cfg := Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve.example.test:8006", Node: "pve1"}}
+	cfg := core.Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve.example.test:8006", Node: "pve1"}}
 	leaseID := "cbx_proxmox_release"
 	if err := core.ClaimLeaseForRepoProvider(leaseID, "old", "proxmox", t.TempDir(), time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := core.EnsureTestboxKeyForConfig(Config{}, leaseID); err != nil {
+	if _, _, err := core.EnsureTestboxKeyForConfig(core.Config{}, leaseID); err != nil {
 		t.Fatal(err)
 	}
 	fake := &fakeProxmoxDoctorClient{}
 	oldClient := newClient
-	newClient = func(Config) (proxmoxClient, error) {
+	newClient = func(core.Config) (proxmoxClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newClient = oldClient })
 
-	backend := NewLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
-	req := ReleaseLeaseRequest{Lease: LeaseTarget{
+	backend := NewLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
+	req := core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
 		LeaseID: leaseID,
 		Server:  expiredProxmoxServer("101", leaseID),
 	}}
@@ -483,23 +483,23 @@ func TestProxmoxReleaseRemovesClaimAndStoredKeyAfterDelete(t *testing.T) {
 func TestProxmoxReleasePreservesLocalResidueWhenDeleteFails(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	cfg := Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve.example.test:8006", Node: "pve1"}}
+	cfg := core.Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve.example.test:8006", Node: "pve1"}}
 	leaseID := "cbx_proxmox_release_fail"
 	if err := core.ClaimLeaseForRepoProvider(leaseID, "old", "proxmox", t.TempDir(), time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := core.EnsureTestboxKeyForConfig(Config{}, leaseID); err != nil {
+	if _, _, err := core.EnsureTestboxKeyForConfig(core.Config{}, leaseID); err != nil {
 		t.Fatal(err)
 	}
 	fake := &fakeProxmoxDoctorClient{deleteErr: errors.New("delete failed")}
 	oldClient := newClient
-	newClient = func(Config) (proxmoxClient, error) {
+	newClient = func(core.Config) (proxmoxClient, error) {
 		return fake, nil
 	}
 	t.Cleanup(func() { newClient = oldClient })
 
-	backend := NewLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
-	req := ReleaseLeaseRequest{Lease: LeaseTarget{
+	backend := NewLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
+	req := core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
 		LeaseID: leaseID,
 		Server:  expiredProxmoxServer("101", leaseID),
 	}}
@@ -515,7 +515,7 @@ func TestProxmoxReleasePreservesLocalResidueWhenDeleteFails(t *testing.T) {
 func TestProxmoxReleaseCannotRetargetClaimToDuplicateLabel(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	cfg := Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve.example.test:8006", Node: "pve1"}}
+	cfg := core.Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve.example.test:8006", Node: "pve1"}}
 	leaseID := "cbx_proxmox_release_duplicate"
 	first := expiredProxmoxServer("101", leaseID)
 	first.Provider = "proxmox"
@@ -525,19 +525,19 @@ func TestProxmoxReleaseCannotRetargetClaimToDuplicateLabel(t *testing.T) {
 	survivor.HostID = "pve2"
 	survivor.PublicNet.IPv4.IP = "192.0.2.202"
 	first.HostID = "pve1"
-	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "old", Config{Provider: "proxmox"}, first, SSHTarget{Host: first.PublicNet.IPv4.IP, Port: "22"}, t.TempDir(), time.Minute, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "old", core.Config{Provider: "proxmox"}, first, core.SSHTarget{Host: first.PublicNet.IPv4.IP, Port: "22"}, t.TempDir(), time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := core.EnsureTestboxKeyForConfig(Config{}, leaseID); err != nil {
+	if _, _, err := core.EnsureTestboxKeyForConfig(core.Config{}, leaseID); err != nil {
 		t.Fatal(err)
 	}
-	fake := &fakeProxmoxDoctorClient{servers: []Server{first}, clusterServers: []Server{survivor}}
+	fake := &fakeProxmoxDoctorClient{servers: []core.Server{first}, clusterServers: []core.Server{survivor}}
 	oldClient := newClient
-	newClient = func(Config) (proxmoxClient, error) { return fake, nil }
+	newClient = func(core.Config) (proxmoxClient, error) { return fake, nil }
 	t.Cleanup(func() { newClient = oldClient })
 
-	backend := NewLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
-	req := ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: first}}
+	backend := NewLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
+	req := core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: first}}
 	if err := backend.ReleaseLease(context.Background(), req); err == nil || !strings.Contains(err.Error(), "surviving VM") {
 		t.Fatalf("release error=%v, want surviving VM failure", err)
 	}
@@ -551,7 +551,7 @@ func TestProxmoxReleaseCannotRetargetClaimToDuplicateLabel(t *testing.T) {
 func TestProxmoxReleasePreservesMigratedTargetWithSameVMID(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	cfg := Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve.example.test:8006", Node: "pve1"}}
+	cfg := core.Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve.example.test:8006", Node: "pve1"}}
 	leaseID := "cbx_proxmox_release_migrated"
 	first := expiredProxmoxServer("101", leaseID)
 	first.Provider = "proxmox"
@@ -560,19 +560,19 @@ func TestProxmoxReleasePreservesMigratedTargetWithSameVMID(t *testing.T) {
 	migrated := first
 	migrated.HostID = "pve2"
 	migrated.PublicNet.IPv4.IP = "192.0.2.202"
-	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "old", cfg, first, SSHTarget{Host: first.PublicNet.IPv4.IP, Port: "22"}, t.TempDir(), time.Minute, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "old", cfg, first, core.SSHTarget{Host: first.PublicNet.IPv4.IP, Port: "22"}, t.TempDir(), time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := core.EnsureTestboxKeyForConfig(Config{}, leaseID); err != nil {
+	if _, _, err := core.EnsureTestboxKeyForConfig(core.Config{}, leaseID); err != nil {
 		t.Fatal(err)
 	}
-	fake := &fakeProxmoxDoctorClient{servers: []Server{first}, clusterServers: []Server{migrated}}
+	fake := &fakeProxmoxDoctorClient{servers: []core.Server{first}, clusterServers: []core.Server{migrated}}
 	oldClient := newClient
-	newClient = func(Config) (proxmoxClient, error) { return fake, nil }
+	newClient = func(core.Config) (proxmoxClient, error) { return fake, nil }
 	t.Cleanup(func() { newClient = oldClient })
 
-	backend := NewLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: first}}); err == nil || !strings.Contains(err.Error(), "surviving VM") {
+	backend := NewLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: first}}); err == nil || !strings.Contains(err.Error(), "surviving VM") {
 		t.Fatalf("release error=%v, want migrated survivor failure", err)
 	}
 	claim, ok, err := core.ResolveLeaseClaim(leaseID)
@@ -592,19 +592,19 @@ func TestLeaseSSHProxmoxReleaseOnlyResolveBypassesGuestKey(t *testing.T) {
 	server := expiredProxmoxServer("101", leaseID)
 	server.Provider, server.HostID = "proxmox", "pve2"
 	server.Labels["crabbox"], server.Labels["provider"] = "true", "proxmox"
-	fake := &fakeProxmoxDoctorClient{servers: []Server{server}}
+	fake := &fakeProxmoxDoctorClient{servers: []core.Server{server}}
 	oldClient := newClient
-	newClient = func(Config) (proxmoxClient, error) { return fake, nil }
+	newClient = func(core.Config) (proxmoxClient, error) { return fake, nil }
 	t.Cleanup(func() { newClient = oldClient })
-	cfg := Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve.example.test:8006", Node: "pve1"}}
-	backend := NewLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard}).(*leaseBackend)
+	cfg := core.Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve.example.test:8006", Node: "pve1"}}
+	backend := NewLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stderr: io.Discard}).(*leaseBackend)
 	for _, id := range []string{server.CloudID, server.Labels["slug"]} {
 		t.Run(id, func(t *testing.T) {
-			lease, err := backend.Resolve(t.Context(), ResolveRequest{ID: id, ReleaseOnly: true})
+			lease, err := backend.Resolve(t.Context(), core.ResolveRequest{ID: id, ReleaseOnly: true})
 			if err != nil || lease.LeaseID != leaseID || lease.Server.CloudID != server.CloudID || lease.Server.HostID != "pve2" {
 				t.Fatalf("release identity=%#v err=%v", lease, err)
 			}
-			if _, err := backend.Resolve(t.Context(), ResolveRequest{ID: id}); err == nil {
+			if _, err := backend.Resolve(t.Context(), core.ResolveRequest{ID: id}); err == nil {
 				t.Fatal("guest resolution accepted the invalid generated namespace")
 			}
 		})
@@ -617,7 +617,7 @@ func TestLeaseSSHProxmoxReleaseOnlyResolveBypassesGuestKey(t *testing.T) {
 func TestProxmoxReleaseResolvesAndDeletesMigratedTarget(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	cfg := Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve.example.test:8006", Node: "pve1"}}
+	cfg := core.Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve.example.test:8006", Node: "pve1"}}
 	leaseID := "cbx_proxmox_resolve_migrated"
 	claimed := expiredProxmoxServer("101", leaseID)
 	claimed.Provider = "proxmox"
@@ -628,29 +628,29 @@ func TestProxmoxReleaseResolvesAndDeletesMigratedTarget(t *testing.T) {
 	migrated.PublicNet.IPv4.IP = "192.0.2.202"
 	migrated.Labels["crabbox"] = "true"
 	migrated.Labels["provider"] = "proxmox"
-	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "old", cfg, claimed, SSHTarget{Host: claimed.PublicNet.IPv4.IP, Port: "22"}, t.TempDir(), time.Minute, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "old", cfg, claimed, core.SSHTarget{Host: claimed.PublicNet.IPv4.IP, Port: "22"}, t.TempDir(), time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := core.EnsureTestboxKeyForConfig(Config{}, leaseID); err != nil {
+	if _, _, err := core.EnsureTestboxKeyForConfig(core.Config{}, leaseID); err != nil {
 		t.Fatal(err)
 	}
 	fake := &fakeProxmoxDoctorClient{
-		clusterServers: []Server{migrated},
+		clusterServers: []core.Server{migrated},
 		getErrByID:     map[string]error{"101": errors.New("source node unavailable")},
 	}
 	oldClient := newClient
-	newClient = func(Config) (proxmoxClient, error) { return fake, nil }
+	newClient = func(core.Config) (proxmoxClient, error) { return fake, nil }
 	t.Cleanup(func() { newClient = oldClient })
 
-	backend := NewLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
-	target, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	backend := NewLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
+	target, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if target.Server.CloudID != "101" || target.Server.HostID != "pve2" {
 		t.Fatalf("target=%#v, want migrated VM on pve2", target)
 	}
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: target}); err != nil {
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: target}); err != nil {
 		t.Fatal(err)
 	}
 	if len(fake.deletedNodes) != 1 || fake.deletedNodes[0] != "pve2" {
@@ -665,24 +665,24 @@ func TestProxmoxReleaseResolvesAndDeletesMigratedTarget(t *testing.T) {
 func TestProxmoxReleaseRetriesReconciliationAfterInventoryRefreshFails(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	cfg := Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve.example.test:8006", Node: "pve1"}}
+	cfg := core.Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve.example.test:8006", Node: "pve1"}}
 	leaseID := "cbx_proxmox_release_inventory_failure"
 	server := expiredProxmoxServer("101", leaseID)
 	server.Provider = "proxmox"
 	if err := core.ClaimLeaseForRepoProvider(leaseID, "old", "proxmox", t.TempDir(), time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := core.EnsureTestboxKeyForConfig(Config{}, leaseID); err != nil {
+	if _, _, err := core.EnsureTestboxKeyForConfig(core.Config{}, leaseID); err != nil {
 		t.Fatal(err)
 	}
-	fake := &fakeProxmoxDoctorClient{servers: []Server{server}, listErr: errors.New("inventory unavailable")}
+	fake := &fakeProxmoxDoctorClient{servers: []core.Server{server}, listErr: errors.New("inventory unavailable")}
 	oldClient := newClient
-	newClient = func(Config) (proxmoxClient, error) { return fake, nil }
+	newClient = func(core.Config) (proxmoxClient, error) { return fake, nil }
 	t.Cleanup(func() { newClient = oldClient })
 
 	var stderr strings.Builder
-	backend := NewLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: &stderr}).(*leaseBackend)
-	req := ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}
+	backend := NewLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: &stderr}).(*leaseBackend)
+	req := core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}
 	if err := backend.ReleaseLease(context.Background(), req); err == nil {
 		t.Fatal("expected inventory reconciliation failure")
 	}
@@ -705,7 +705,7 @@ func TestProxmoxReleaseRetriesReconciliationAfterInventoryRefreshFails(t *testin
 	fake.getErrByID = map[string]error{
 		"101": &core.ProxmoxError{Method: "GET", Path: "/nodes/pve1/qemu/101/status/current", StatusCode: 404, Body: "not found"},
 	}
-	resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	resolved, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReleaseOnly: true})
 	if err != nil {
 		t.Fatalf("retry resolve: %v", err)
 	}
@@ -713,7 +713,7 @@ func TestProxmoxReleaseRetriesReconciliationAfterInventoryRefreshFails(t *testin
 		t.Fatalf("retry target=%#v", resolved)
 	}
 	deleteCalls := fake.deleteCalls
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: resolved}); err != nil {
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: resolved}); err != nil {
 		t.Fatalf("retry release: %v", err)
 	}
 	if fake.deleteCalls != deleteCalls {
@@ -731,37 +731,37 @@ func TestProxmoxReleaseOnlyClaimRecoveryRequiresOriginalScopeAndClusterAbsence(t
 	leaseID := "cbx_proxmox_scoped_absence"
 	claimed := expiredProxmoxServer("101", leaseID)
 	claimed.Provider = "proxmox"
-	original := Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve-a.example.test:8006", Node: "pve1"}}
-	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "old", original, claimed, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+	original := core.Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve-a.example.test:8006", Node: "pve1"}}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "old", original, claimed, core.SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	notFound := &core.ProxmoxError{Method: "GET", Path: "/nodes/pve1/qemu/101/status/current", StatusCode: 404, Body: "not found"}
 	fake := &fakeProxmoxDoctorClient{getErrByID: map[string]error{"101": notFound}}
 	oldClient := newClient
-	newClient = func(Config) (proxmoxClient, error) { return fake, nil }
+	newClient = func(core.Config) (proxmoxClient, error) { return fake, nil }
 	t.Cleanup(func() { newClient = oldClient })
 
-	for name, changed := range map[string]Config{
-		"cluster": func() Config {
+	for name, changed := range map[string]core.Config{
+		"cluster": func() core.Config {
 			cfg := original
 			cfg.Proxmox.APIURL = "https://pve-b.example.test:8006"
 			return cfg
 		}(),
-		"node": func() Config {
+		"node": func() core.Config {
 			cfg := original
 			cfg.Proxmox.Node = "pve2"
 			return cfg
 		}(),
 	} {
-		backend := NewLeaseBackend(Provider{}.Spec(), changed, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
-		if _, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true}); err == nil || !strings.Contains(err.Error(), "unverified cluster scope") {
+		backend := NewLeaseBackend(Provider{}.Spec(), changed, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
+		if _, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReleaseOnly: true}); err == nil || !strings.Contains(err.Error(), "unverified cluster scope") {
 			t.Fatalf("%s-changed resolve error=%v", name, err)
 		}
 	}
 
 	fake.clusterExistsByID = map[string]bool{"101": true}
-	backend := NewLeaseBackend(Provider{}.Spec(), original, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
-	if _, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true}); err == nil || !strings.Contains(err.Error(), "still exists in the cluster") {
+	backend := NewLeaseBackend(Provider{}.Spec(), original, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
+	if _, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReleaseOnly: true}); err == nil || !strings.Contains(err.Error(), "still exists in the cluster") {
 		t.Fatalf("migrated-vm resolve error=%v", err)
 	}
 }
@@ -772,17 +772,17 @@ func TestProxmoxReleaseOnlyClaimRecoveryRejectsReusedVMID(t *testing.T) {
 	leaseID := "cbx_proxmox_reused_vmid"
 	claimed := expiredProxmoxServer("101", leaseID)
 	claimed.Provider = "proxmox"
-	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "old", Config{Provider: "proxmox"}, claimed, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "old", core.Config{Provider: "proxmox"}, claimed, core.SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	reused := Server{CloudID: "101", Provider: "proxmox", ID: 101, Name: "unrelated-vm", Labels: map[string]string{"crabbox": "false"}}
-	fake := &fakeProxmoxDoctorClient{getServerByID: map[string]Server{"101": reused}}
+	reused := core.Server{CloudID: "101", Provider: "proxmox", ID: 101, Name: "unrelated-vm", Labels: map[string]string{"crabbox": "false"}}
+	fake := &fakeProxmoxDoctorClient{getServerByID: map[string]core.Server{"101": reused}}
 	oldClient := newClient
-	newClient = func(Config) (proxmoxClient, error) { return fake, nil }
+	newClient = func(core.Config) (proxmoxClient, error) { return fake, nil }
 	t.Cleanup(func() { newClient = oldClient })
 
-	backend := NewLeaseBackend(Provider{}.Spec(), Config{}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
-	if _, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true}); err == nil || !strings.Contains(err.Error(), "stale local claim") {
+	backend := NewLeaseBackend(Provider{}.Spec(), core.Config{}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
+	if _, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReleaseOnly: true}); err == nil || !strings.Contains(err.Error(), "stale local claim") {
 		t.Fatalf("resolve error=%v, want stale claim rejection", err)
 	}
 	if fake.deleteCalls != 0 {
@@ -798,19 +798,19 @@ func TestProxmoxReleasePreservesDifferentClaimWhenInventoryRefreshFails(t *testi
 	deleted.Provider = "proxmox"
 	claimed := expiredProxmoxServer("202", leaseID)
 	claimed.Provider = "proxmox"
-	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "old", Config{Provider: "proxmox"}, claimed, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "old", core.Config{Provider: "proxmox"}, claimed, core.SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := core.EnsureTestboxKeyForConfig(Config{}, leaseID); err != nil {
+	if _, _, err := core.EnsureTestboxKeyForConfig(core.Config{}, leaseID); err != nil {
 		t.Fatal(err)
 	}
-	fake := &fakeProxmoxDoctorClient{servers: []Server{deleted, claimed}, listErr: errors.New("inventory unavailable")}
+	fake := &fakeProxmoxDoctorClient{servers: []core.Server{deleted, claimed}, listErr: errors.New("inventory unavailable")}
 	oldClient := newClient
-	newClient = func(Config) (proxmoxClient, error) { return fake, nil }
+	newClient = func(core.Config) (proxmoxClient, error) { return fake, nil }
 	t.Cleanup(func() { newClient = oldClient })
 
-	backend := NewLeaseBackend(Provider{}.Spec(), Config{}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: deleted}}); err == nil {
+	backend := NewLeaseBackend(Provider{}.Spec(), core.Config{}, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: deleted}}); err == nil {
 		t.Fatal("expected inventory reconciliation failure")
 	}
 	claim, ok, err := core.ResolveLeaseClaim(leaseID)
@@ -822,29 +822,29 @@ func TestProxmoxReleasePreservesDifferentClaimWhenInventoryRefreshFails(t *testi
 
 func TestProxmoxReleaseOnlyNumericClaimUsesCurrentClusterScope(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	cfgA := Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve-a.example.test:8006", Node: "pve1"}}
-	cfgB := Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve-b.example.test:8006", Node: "pve1"}}
+	cfgA := core.Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve-a.example.test:8006", Node: "pve1"}}
+	cfgB := core.Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve-b.example.test:8006", Node: "pve1"}}
 	for _, item := range []struct {
 		leaseID string
-		cfg     Config
+		cfg     core.Config
 	}{
 		{leaseID: "cbx_cluster_a", cfg: cfgA},
 		{leaseID: "cbx_cluster_b", cfg: cfgB},
 	} {
 		server := expiredProxmoxServer("101", item.leaseID)
 		server.Provider = "proxmox"
-		if err := core.ClaimLeaseTargetForRepoConfig(item.leaseID, "old", item.cfg, server, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+		if err := core.ClaimLeaseTargetForRepoConfig(item.leaseID, "old", item.cfg, server, core.SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
 			t.Fatal(err)
 		}
 	}
 	notFound := &core.ProxmoxError{Method: "GET", Path: "/nodes/pve1/qemu/101/status/current", StatusCode: 404, Body: "not found"}
 	fake := &fakeProxmoxDoctorClient{getErrByID: map[string]error{"101": notFound}}
 	oldClient := newClient
-	newClient = func(Config) (proxmoxClient, error) { return fake, nil }
+	newClient = func(core.Config) (proxmoxClient, error) { return fake, nil }
 	t.Cleanup(func() { newClient = oldClient })
 
-	backend := NewLeaseBackend(Provider{}.Spec(), cfgA, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
-	target, err := backend.Resolve(context.Background(), ResolveRequest{ID: "101", ReleaseOnly: true})
+	backend := NewLeaseBackend(Provider{}.Spec(), cfgA, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*leaseBackend)
+	target, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "101", ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -853,8 +853,8 @@ func TestProxmoxReleaseOnlyNumericClaimUsesCurrentClusterScope(t *testing.T) {
 	}
 }
 
-func expiredProxmoxServer(id, leaseID string) Server {
-	return Server{
+func expiredProxmoxServer(id, leaseID string) core.Server {
+	return core.Server{
 		CloudID: id,
 		Name:    "crabbox-old",
 		Labels: map[string]string{

--- a/internal/providers/proxmox/cleanup.go
+++ b/internal/providers/proxmox/cleanup.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func (b *leaseBackend) cleanupClaim(server Server, inventory []Server, claims []core.LeaseClaim) (core.LeaseClaim, shared.ClaimBinding, error) {
+func (b *leaseBackend) cleanupClaim(server core.Server, inventory []core.Server, claims []core.LeaseClaim) (core.LeaseClaim, shared.ClaimBinding, error) {
 	leaseID := proxmoxClaimLabelLeaseID(server)
 	scope := (Provider{}).ClaimScope(b.Cfg)
 	binding := shared.ClaimBinding{
@@ -48,7 +48,7 @@ func (b *leaseBackend) cleanupClaim(server Server, inventory []Server, claims []
 	return claim, binding, validateCleanupServer(server, claim, binding)
 }
 
-func validateCleanupServer(server Server, claim core.LeaseClaim, binding shared.ClaimBinding) error {
+func validateCleanupServer(server core.Server, claim core.LeaseClaim, binding shared.ClaimBinding) error {
 	vmid, err := strconv.Atoi(server.CloudID)
 	if err != nil || vmid <= 0 || strconv.Itoa(vmid) != server.CloudID || server.CloudID != binding.CloudID || server.Provider != "proxmox" || server.HostID == "" || !strings.HasPrefix(server.Name, "crabbox-") {
 		return fmt.Errorf("Proxmox VM identity or node mismatch")

--- a/internal/providers/proxmox/cleanup_test.go
+++ b/internal/providers/proxmox/cleanup_test.go
@@ -27,7 +27,7 @@ type cleanupClient struct {
 	stopCalls  int
 }
 
-func (c *cleanupClient) ListCrabboxServersCluster(context.Context) ([]Server, error) {
+func (c *cleanupClient) ListCrabboxServersCluster(context.Context) ([]core.Server, error) {
 	c.listCalls++
 	if c.listHook != nil {
 		if err := c.listHook(c.listCalls); err != nil {
@@ -37,19 +37,19 @@ func (c *cleanupClient) ListCrabboxServersCluster(context.Context) ([]Server, er
 	if c.listErr != nil {
 		return nil, c.listErr
 	}
-	result := append([]Server(nil), c.servers...)
+	result := append([]core.Server(nil), c.servers...)
 	for i := range result {
 		result[i].Labels = maps.Clone(result[i].Labels)
 	}
 	return result, nil
 }
 
-func (c *cleanupClient) DeleteServerOnNodeChecked(ctx context.Context, node, id string, check func(Server) error) error {
+func (c *cleanupClient) DeleteServerOnNodeChecked(ctx context.Context, node, id string, check func(core.Server) error) error {
 	for step := range 2 {
 		if c.checkHook != nil {
 			c.checkHook(step)
 		}
-		var live Server
+		var live core.Server
 		for _, server := range c.servers {
 			if server.CloudID == id && server.HostID == node {
 				live = server
@@ -82,25 +82,25 @@ func cleanupFixture(t *testing.T) (*leaseBackend, *cleanupClient, core.LeaseClai
 	t.Helper()
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_proxmox_cleanup"
-	cfg := Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve.example.test:8006", Node: "pve1"}}
+	cfg := core.Config{Provider: "proxmox", Proxmox: core.ProxmoxConfig{APIURL: "https://pve.example.test:8006", Node: "pve1"}}
 	server := expiredProxmoxServer("101", leaseID)
 	server.Provider, server.HostID, server.ImmutableID = "proxmox", "pve1", cleanupGeneration
 	server.Labels["provider"], server.Labels["crabbox"] = "proxmox", "true"
 	server.Labels["provider_key"] = core.ProviderKeyForLease(leaseID)
 	server.Labels["node"] = "pve1"
-	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "old", cfg, server, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "old", cfg, server, core.SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := core.EnsureTestboxKeyForConfig(cfg, leaseID); err != nil {
 		t.Fatal(err)
 	}
 	claim := readCleanupClaim(t, leaseID)
-	client := &cleanupClient{fakeProxmoxDoctorClient: &fakeProxmoxDoctorClient{servers: []Server{server}}}
+	client := &cleanupClient{fakeProxmoxDoctorClient: &fakeProxmoxDoctorClient{servers: []core.Server{server}}}
 	previous := newClient
-	newClient = func(Config) (proxmoxClient, error) { return client, nil }
+	newClient = func(core.Config) (proxmoxClient, error) { return client, nil }
 	t.Cleanup(func() { newClient = previous })
 	output := &strings.Builder{}
-	backend := NewLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: output}).(*leaseBackend)
+	backend := NewLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: output}).(*leaseBackend)
 	return backend, client, claim, output
 }
 
@@ -126,7 +126,7 @@ func TestProxmoxCleanupPreservesVMAndStoredKeyWhenClaimIsMissing(t *testing.T) {
 	if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 		t.Fatal(err)
 	}
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if c.stopCalls != 0 || c.deleteCalls != 0 || !strings.Contains(output.String(), "skip server") {
@@ -142,7 +142,7 @@ func TestProxmoxCleanupRejectsUnboundOrAmbiguousOwnership(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
 		claim func(*core.LeaseClaim)
-		vm    func(*Server)
+		vm    func(*core.Server)
 	}{
 		{name: "legacy scope", claim: func(c *core.LeaseClaim) { c.ProviderScope = "" }},
 		{name: "legacy VMID", claim: func(c *core.LeaseClaim) { c.CloudID = "" }},
@@ -155,17 +155,17 @@ func TestProxmoxCleanupRejectsUnboundOrAmbiguousOwnership(t *testing.T) {
 		{name: "claim lease label", claim: func(c *core.LeaseClaim) { c.Labels["lease"] = "cbx_other" }},
 		{name: "claim provider label", claim: func(c *core.LeaseClaim) { c.Labels["provider"] = "tart" }},
 		{name: "claim key namespace", claim: func(c *core.LeaseClaim) { c.Labels["provider_key"] = "other" }},
-		{name: "missing live generation", vm: func(s *Server) { s.ImmutableID = "" }},
-		{name: "recreated VMID", vm: func(s *Server) { s.ImmutableID = replacementGeneration }},
-		{name: "live provider", vm: func(s *Server) { s.Provider = "other" }},
-		{name: "live provider label", vm: func(s *Server) { delete(s.Labels, "provider") }},
-		{name: "live key namespace", vm: func(s *Server) { s.Labels["provider_key"] = "other" }},
-		{name: "live ownership label", vm: func(s *Server) { delete(s.Labels, "crabbox") }},
-		{name: "live slug", vm: func(s *Server) { s.Labels["slug"] = "other" }},
-		{name: "invalid lease label", vm: func(s *Server) { s.Labels["lease"] = "../target" }},
-		{name: "no lease label", vm: func(s *Server) { delete(s.Labels, "lease") }},
-		{name: "no node", vm: func(s *Server) { s.HostID = "" }},
-		{name: "neutral name", vm: func(s *Server) { s.Name = "my-vm" }},
+		{name: "missing live generation", vm: func(s *core.Server) { s.ImmutableID = "" }},
+		{name: "recreated VMID", vm: func(s *core.Server) { s.ImmutableID = replacementGeneration }},
+		{name: "live provider", vm: func(s *core.Server) { s.Provider = "other" }},
+		{name: "live provider label", vm: func(s *core.Server) { delete(s.Labels, "provider") }},
+		{name: "live key namespace", vm: func(s *core.Server) { s.Labels["provider_key"] = "other" }},
+		{name: "live ownership label", vm: func(s *core.Server) { delete(s.Labels, "crabbox") }},
+		{name: "live slug", vm: func(s *core.Server) { s.Labels["slug"] = "other" }},
+		{name: "invalid lease label", vm: func(s *core.Server) { s.Labels["lease"] = "../target" }},
+		{name: "no lease label", vm: func(s *core.Server) { delete(s.Labels, "lease") }},
+		{name: "no node", vm: func(s *core.Server) { s.HostID = "" }},
+		{name: "neutral name", vm: func(s *core.Server) { s.Name = "my-vm" }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			b, c, claim, _ := cleanupFixture(t)
@@ -181,7 +181,7 @@ func TestProxmoxCleanupRejectsUnboundOrAmbiguousOwnership(t *testing.T) {
 			if tc.vm != nil {
 				tc.vm(&c.servers[0])
 			}
-			if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+			if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 				t.Fatal(err)
 			}
 			if c.stopCalls != 0 || c.deleteCalls != 0 {
@@ -201,14 +201,14 @@ func TestProxmoxCleanupRejectsDuplicateBindings(t *testing.T) {
 			if local {
 				duplicate.Labels["lease"] = "cbx_duplicate"
 				duplicate.Labels["provider_key"] = core.ProviderKeyForLease("cbx_duplicate")
-				if err := core.ClaimLeaseTargetForRepoConfig("cbx_duplicate", "old", b.Cfg, duplicate, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+				if err := core.ClaimLeaseTargetForRepoConfig("cbx_duplicate", "old", b.Cfg, duplicate, core.SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
 					t.Fatal(err)
 				}
 			} else {
 				duplicate.CloudID, duplicate.ImmutableID = "202", replacementGeneration
 				c.servers = append(c.servers, duplicate)
 			}
-			if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+			if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 				t.Fatal(err)
 			}
 			if c.stopCalls != 0 || c.deleteCalls != 0 {
@@ -224,7 +224,7 @@ func TestProxmoxCleanupExactClaimAndMigration(t *testing.T) {
 		t.Run(node, func(t *testing.T) {
 			b, c, claim, output := cleanupFixture(t)
 			c.servers[0].HostID = node
-			if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+			if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 				t.Fatal(err)
 			}
 			if c.stopCalls != 1 || c.deleteCalls != 1 || c.deletedNodes[0] != node || len(c.servers) != 0 {
@@ -248,7 +248,7 @@ func TestProxmoxCleanupDryRunAndKeptLease(t *testing.T) {
 			if !dry {
 				c.servers[0].Labels["keep"] = "true"
 			}
-			if err := b.Cleanup(context.Background(), CleanupRequest{DryRun: dry}); err != nil {
+			if err := b.Cleanup(context.Background(), core.CleanupRequest{DryRun: dry}); err != nil {
 				t.Fatal(err)
 			}
 			if c.stopCalls != 0 || c.deleteCalls != 0 {
@@ -266,14 +266,14 @@ func TestProxmoxCleanupRevalidatesLiveState(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		step int
-		edit func(*Server)
+		edit func(*core.Server)
 	}{
-		{"generation before stop", 0, func(s *Server) { s.ImmutableID = replacementGeneration }},
-		{"generation after stop", 1, func(s *Server) { s.ImmutableID = replacementGeneration }},
-		{"keep before stop", 0, func(s *Server) { s.Labels["keep"] = "true" }},
-		{"keep after stop", 1, func(s *Server) { s.Labels["keep"] = "true" }},
-		{"ownership after stop", 1, func(s *Server) { s.Labels["lease"] = "cbx_other" }},
-		{"node changed", 0, func(s *Server) { s.HostID = "pve2" }},
+		{"generation before stop", 0, func(s *core.Server) { s.ImmutableID = replacementGeneration }},
+		{"generation after stop", 1, func(s *core.Server) { s.ImmutableID = replacementGeneration }},
+		{"keep before stop", 0, func(s *core.Server) { s.Labels["keep"] = "true" }},
+		{"keep after stop", 1, func(s *core.Server) { s.Labels["keep"] = "true" }},
+		{"ownership after stop", 1, func(s *core.Server) { s.Labels["lease"] = "cbx_other" }},
+		{"node changed", 0, func(s *core.Server) { s.HostID = "pve2" }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			b, c, claim, _ := cleanupFixture(t)
@@ -282,7 +282,7 @@ func TestProxmoxCleanupRevalidatesLiveState(t *testing.T) {
 					tc.edit(&c.servers[0])
 				}
 			}
-			if err := b.Cleanup(context.Background(), CleanupRequest{}); err == nil {
+			if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err == nil {
 				t.Fatal("expected changed live state rejection")
 			}
 			if c.deleteCalls != 0 || c.stopCalls != tc.step {
@@ -306,7 +306,7 @@ func TestProxmoxCleanupPreservesChangedClaim(t *testing.T) {
 		}
 		return nil
 	}
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err == nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err == nil {
 		t.Fatal("changed claim must reject cleanup")
 	}
 	if c.stopCalls != 0 || c.deleteCalls != 0 {
@@ -333,7 +333,7 @@ func TestProxmoxCleanupFencesClaimWriterThroughAbsence(t *testing.T) {
 			return false, nil
 		}
 	}
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	select {
@@ -370,7 +370,7 @@ func TestProxmoxCleanupFailurePreservesClaim(t *testing.T) {
 			case "VM exists elsewhere":
 				c.existsHook = func() (bool, error) { return true, nil }
 			}
-			if err := b.Cleanup(context.Background(), CleanupRequest{}); err == nil {
+			if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err == nil {
 				t.Fatal("expected cleanup failure")
 			}
 			if (stage == "initial inventory" || stage == "fresh inventory" || stage == "stop") && c.deleteCalls != 0 {
@@ -389,7 +389,7 @@ func TestProxmoxCleanupReconcilesAmbiguousPurgeAcrossCluster(t *testing.T) {
 	previous := proxmoxDeleteVerifyPollInterval
 	proxmoxDeleteVerifyPollInterval = time.Millisecond
 	t.Cleanup(func() { proxmoxDeleteVerifyPollInterval = previous })
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err == nil || !strings.Contains(err.Error(), "task polling unavailable") {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err == nil || !strings.Contains(err.Error(), "task polling unavailable") {
 		t.Fatalf("cleanup err=%v", err)
 	}
 	if reads != 3 {
@@ -415,10 +415,10 @@ func TestProxmoxEndpointUpdatesCannotRebindOwnership(t *testing.T) {
 			default:
 				server.Labels[field] = "other"
 			}
-			if err := core.UpdateLeaseClaimEndpoint(claim.LeaseID, server, SSHTarget{}); err == nil {
+			if err := core.UpdateLeaseClaimEndpoint(claim.LeaseID, server, core.SSHTarget{}); err == nil {
 				t.Fatal("endpoint update rebound exact claim")
 			}
-			if err := core.ClaimLeaseTargetForRepoConfig(claim.LeaseID, claim.Slug, b.Cfg, server, SSHTarget{}, claim.RepoRoot, time.Minute, false); err == nil {
+			if err := core.ClaimLeaseTargetForRepoConfig(claim.LeaseID, claim.Slug, b.Cfg, server, core.SSHTarget{}, claim.RepoRoot, time.Minute, false); err == nil {
 				t.Fatal("claim publication rebound exact claim")
 			}
 			assertCleanupClaimPreserved(t, claim)
@@ -433,16 +433,16 @@ func TestProxmoxEndpointRefreshDoesNotPromoteLegacyGeneration(t *testing.T) {
 	if err := core.ReplaceLeaseClaimIfUnchanged(claim.LeaseID, claim, legacy); err != nil {
 		t.Fatal(err)
 	}
-	if err := core.UpdateLeaseClaimEndpoint(claim.LeaseID, c.servers[0], SSHTarget{Host: "192.0.2.4"}); err != nil {
+	if err := core.UpdateLeaseClaimEndpoint(claim.LeaseID, c.servers[0], core.SSHTarget{Host: "192.0.2.4"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := core.ClaimLeaseTargetForRepoConfig(claim.LeaseID, claim.Slug, b.Cfg, c.servers[0], SSHTarget{}, claim.RepoRoot, time.Minute, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(claim.LeaseID, claim.Slug, b.Cfg, c.servers[0], core.SSHTarget{}, claim.RepoRoot, time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	if current := readCleanupClaim(t, claim.LeaseID); current.CloudImmutableID != "" {
 		t.Fatal("legacy generation silently promoted")
 	}
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if c.deleteCalls != 0 || c.stopCalls != 0 {
@@ -452,11 +452,11 @@ func TestProxmoxEndpointRefreshDoesNotPromoteLegacyGeneration(t *testing.T) {
 
 func TestProxmoxTouchPreservesGenerationBinding(t *testing.T) {
 	b, c, claim, _ := cleanupFixture(t)
-	server, err := b.Touch(context.Background(), TouchRequest{Lease: LeaseTarget{LeaseID: claim.LeaseID, Server: c.servers[0]}, State: "ready"})
+	server, err := b.Touch(context.Background(), core.TouchRequest{Lease: core.LeaseTarget{LeaseID: claim.LeaseID, Server: c.servers[0]}, State: "ready"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := core.UpdateLeaseClaimEndpoint(claim.LeaseID, server, SSHTarget{Host: "192.0.2.4"}); err != nil {
+	if err := core.UpdateLeaseClaimEndpoint(claim.LeaseID, server, core.SSHTarget{Host: "192.0.2.4"}); err != nil {
 		t.Fatal(err)
 	}
 	current := readCleanupClaim(t, claim.LeaseID)


### PR DESCRIPTION
Remove redundant core type aliases and exact forwarding functions from AWS, Azure, GCP, Hetzner, Proxmox, and Blacksmith. Common SSH, lease naming, stored-key selection, and diagnostics now call their core owners directly, deleting 278 net production lines.

Provider API interfaces, acquisition/cleanup transactions, platform policies, and mutable test injection hooks retain their existing implementations. Replacements were checked against Go type identity and resolved uses.

Validation: full tests passed for all six providers; scoped Autoreview passed in two complete chunks. CI is required before merge. No new dependencies or configuration.
