### PR TITLE
refactor(providers): use core directly in infrastructure adapters

### DIFF
--- a/internal/providers/firecracker/backend.go
+++ b/internal/providers/firecracker/backend.go
@@ -17,25 +17,6 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-type Config = core.Config
-type Runtime = core.Runtime
-type ProviderSpec = core.ProviderSpec
-type Backend = core.Backend
-type DoctorRequest = core.DoctorRequest
-type DoctorResult = core.DoctorResult
-type DoctorCheck = core.DoctorCheck
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type CleanupRequest = core.CleanupRequest
-type LeaseTarget = core.LeaseTarget
-type LeaseClaim = core.LeaseClaim
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-
 const (
 	providerName           = "firecracker"
 	firecrackerNetworkCNI  = "cni"
@@ -54,9 +35,9 @@ var (
 )
 
 type backend struct {
-	spec           ProviderSpec
-	cfg            Config
-	rt             Runtime
+	spec           core.ProviderSpec
+	cfg            core.Config
+	rt             core.Runtime
 	stateRoot      func() (string, error)
 	machines       machineFactory
 	processes      processManager
@@ -64,7 +45,7 @@ type backend struct {
 	cleanupNetwork func(context.Context, leaseStateRecord) error
 }
 
-func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	applyDefaults(&cfg)
 	b := &backend{
 		spec:           spec,
@@ -79,7 +60,7 @@ func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	return b
 }
 
-func applyDefaults(cfg *Config) {
+func applyDefaults(cfg *core.Config) {
 	if cfg == nil {
 		return
 	}
@@ -111,7 +92,7 @@ func applyDefaults(cfg *Config) {
 	}
 }
 
-func firecrackerServerTypeForConfig(_ Config) string {
+func firecrackerServerTypeForConfig(_ core.Config) string {
 	return firecrackerServerClass
 }
 
@@ -123,7 +104,7 @@ func normalizeFirecrackerNetwork(value string) string {
 	return mode
 }
 
-func validateConfig(cfg Config) error {
+func validateConfig(cfg core.Config) error {
 	applyDefaults(&cfg)
 	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
 		return core.Exit(2, "provider=firecracker supports target=linux only")
@@ -153,46 +134,46 @@ func validateConfig(cfg Config) error {
 	return nil
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *backend) RebindResolvedLeaseTarget(target *LeaseTarget, leaseID string) error {
+func (b *backend) RebindResolvedLeaseTarget(target *core.LeaseTarget, leaseID string) error {
 	return core.UseStoredTestboxKey(&target.SSH, leaseID)
 }
 
-func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
-	return shared.AcquireAttemptsRetry(b.rt, req.Keep, func() (LeaseTarget, error) {
+func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
+	return shared.AcquireAttemptsRetry(b.rt, req.Keep, func() (core.LeaseTarget, error) {
 		return b.acquireOnce(ctx, req)
 	})
 }
 
-func (b *backend) acquireOnce(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	cfg := b.configForRun()
 	if err := requireLifecycleHost(); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if jailer := strings.TrimSpace(cfg.Firecracker.Jailer); jailer != "" {
-		return LeaseTarget{}, exit(2, "provider=firecracker does not support firecracker.jailer yet")
+		return core.LeaseTarget{}, core.Exit(2, "provider=firecracker does not support firecracker.jailer yet")
 	}
 
 	servers, err := b.listServers(cfg)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	leaseID := core.NewLeaseID()
 	slug, err := core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	name := core.LeaseProviderName(leaseID, slug)
 	now := b.currentTime().UTC()
 	paths, err := b.ensureLeaseDir(leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 
 	keyPath, publicKey, err := ensureTestboxKey(cfg, leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cleanupKey := true
 	defer func() {
@@ -204,16 +185,16 @@ func (b *backend) acquireOnce(ctx context.Context, req AcquireRequest) (LeaseTar
 	payload, err := buildCloudInitPayload(cfg, leaseID, slug, publicKey)
 	if err != nil {
 		_ = b.removeStateDir(leaseStateRecord{LeaseID: leaseID})
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 
 	if err := prepareWritableRootFS(cfg.Firecracker.RootFS, paths.RootFS, cfg.Firecracker.DiskMiB); err != nil {
 		_ = b.removeStateDir(leaseStateRecord{LeaseID: leaseID})
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if err := writeCloudInitDrive(paths.CloudInit, payload); err != nil {
 		_ = b.removeStateDir(leaseStateRecord{LeaseID: leaseID})
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 
 	labels := core.TouchDirectLeaseLabels(core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", req.Keep, now), cfg, "provisioning", now)
@@ -252,7 +233,7 @@ func (b *backend) acquireOnce(ctx context.Context, req AcquireRequest) (LeaseTar
 	}
 	if err := b.writeStateRecord(record); err != nil {
 		_ = b.removeStateDir(record)
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 
 	vm, err := b.machines.New(ctx, machineLaunchConfig{
@@ -274,19 +255,19 @@ func (b *backend) acquireOnce(ctx context.Context, req AcquireRequest) (LeaseTar
 	})
 	if err != nil {
 		_ = b.removeStateDir(record)
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	rollback := func(cause error) error {
 		return b.rollbackAcquire(record, vm, cause)
 	}
 
 	if err := startFirecrackerMachine(ctx, vm, cfg.Firecracker.LaunchTimeout); err != nil {
-		return LeaseTarget{}, rollback(err)
+		return core.LeaseTarget{}, rollback(err)
 	}
 
 	identity, err := b.processes.Capture(vm.PID())
 	if err != nil {
-		return LeaseTarget{}, rollback(err)
+		return core.LeaseTarget{}, rollback(err)
 	}
 	record.PID = identity.PID
 	record.ProcessStarted = identity.Started
@@ -294,98 +275,98 @@ func (b *backend) acquireOnce(ctx context.Context, req AcquireRequest) (LeaseTar
 	record.Labels = core.TouchDirectLeaseLabels(record.Labels, cfg, "running", b.currentTime().UTC())
 	record.UpdatedAt = b.currentTime().UTC().Format(time.RFC3339Nano)
 	if err := b.writeStateRecord(record); err != nil {
-		return LeaseTarget{}, rollback(err)
+		return core.LeaseTarget{}, rollback(err)
 	}
 
 	guestIP := vm.GuestIP()
 	if strings.TrimSpace(guestIP) == "" {
-		return LeaseTarget{}, rollback(exit(5, "firecracker lease %s did not report a guest IP from CNI", leaseID))
+		return core.LeaseTarget{}, rollback(core.Exit(5, "firecracker lease %s did not report a guest IP from CNI", leaseID))
 	}
 	record.GuestIP = guestIP
 	target, err := b.targetFromRecord(cfg, record)
 	if err != nil {
-		return LeaseTarget{}, rollback(err)
+		return core.LeaseTarget{}, rollback(err)
 	}
 	if err := b.waitForSSH(ctx, &target, b.rt.Stderr, "bootstrap", cfg.Firecracker.LaunchTimeout); err != nil {
-		return LeaseTarget{}, rollback(err)
+		return core.LeaseTarget{}, rollback(err)
 	}
 
 	record.Labels = core.TouchDirectLeaseLabels(record.Labels, cfg, "ready", b.currentTime().UTC())
 	record.UpdatedAt = b.currentTime().UTC().Format(time.RFC3339Nano)
 	if err := b.writeStateRecord(record); err != nil {
-		return LeaseTarget{}, rollback(err)
+		return core.LeaseTarget{}, rollback(err)
 	}
 	server := b.serverFromRecord(cfg, record, true)
 	if err := b.claimLeaseTarget(cfg, leaseID, slug, req.Repo.Root, req.Reclaim, server, target); err != nil {
-		return LeaseTarget{}, rollback(err)
+		return core.LeaseTarget{}, rollback(err)
 	}
 
 	cleanupKey = false
 	fmt.Fprintf(b.rt.Stderr, "provisioned provider=%s lease=%s vmid=%s ip=%s\n", providerName, leaseID, name, guestIP)
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
-func (b *backend) Resolve(_ context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *backend) Resolve(_ context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	cfg := b.configForRun()
 	record, found, err := b.recordByIdentifier(cfg, req.ID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if !found {
 		claim, ok, err := core.ResolveLeaseClaimForProvider(req.ID, providerName)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		if !ok {
-			return LeaseTarget{}, exit(4, "lease/server not found: %s", req.ID)
+			return core.LeaseTarget{}, core.Exit(4, "lease/server not found: %s", req.ID)
 		}
 		if req.ReleaseOnly {
-			return LeaseTarget{Server: serverFromClaim(cfg, claim), LeaseID: claim.LeaseID}, nil
+			return core.LeaseTarget{Server: serverFromClaim(cfg, claim), LeaseID: claim.LeaseID}, nil
 		}
-		return LeaseTarget{}, exit(4, "firecracker lease %q has a stale local claim but no local state; run `crabbox cleanup --provider firecracker`", req.ID)
+		return core.LeaseTarget{}, core.Exit(4, "firecracker lease %q has a stale local claim but no local state; run `crabbox cleanup --provider firecracker`", req.ID)
 	}
 
 	running := b.processes.Matches(record.processIdentity())
 	server := b.serverFromRecord(cfg, record, running)
 	if req.ReleaseOnly {
-		return LeaseTarget{Server: server, LeaseID: record.LeaseID}, nil
+		return core.LeaseTarget{Server: server, LeaseID: record.LeaseID}, nil
 	}
 	if !running {
 		if req.StatusOnly {
-			return LeaseTarget{Server: server, LeaseID: record.LeaseID}, nil
+			return core.LeaseTarget{Server: server, LeaseID: record.LeaseID}, nil
 		}
-		return LeaseTarget{}, exit(5, "firecracker lease %s is not running; use `crabbox stop --provider firecracker %s` or `crabbox cleanup --provider firecracker`", blankIfEmpty(record.Name), req.ID)
+		return core.LeaseTarget{}, core.Exit(5, "firecracker lease %s is not running; use `crabbox stop --provider firecracker %s` or `crabbox cleanup --provider firecracker`", blankIfEmpty(record.Name), req.ID)
 	}
 	if strings.TrimSpace(record.GuestIP) == "" && req.StatusOnly {
-		return LeaseTarget{Server: server, LeaseID: record.LeaseID}, nil
+		return core.LeaseTarget{Server: server, LeaseID: record.LeaseID}, nil
 	}
 	target, err := b.targetFromRecord(cfg, record)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	lease := LeaseTarget{Server: server, SSH: target, LeaseID: record.LeaseID}
+	lease := core.LeaseTarget{Server: server, SSH: target, LeaseID: record.LeaseID}
 	if req.Repo.Root != "" {
 		if err := b.claimLeaseTarget(cfg, record.LeaseID, record.Slug, req.Repo.Root, req.Reclaim, server, target); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	return lease, nil
 }
 
-func (b *backend) List(_ context.Context, _ ListRequest) ([]LeaseView, error) {
+func (b *backend) List(_ context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
 	cfg := b.configForRun()
 	records, err := b.listStateRecords()
 	if err != nil {
 		return nil, err
 	}
-	views := make([]LeaseView, 0, len(records))
+	views := make([]core.LeaseView, 0, len(records))
 	for _, record := range records {
 		views = append(views, b.serverFromRecord(cfg, record, b.processes.Matches(record.processIdentity())))
 	}
 	return views, nil
 }
 
-func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	cfg := b.configForRun()
 	record, found, err := b.releaseRecordForLease(cfg, req.Lease)
 	if err != nil {
@@ -398,7 +379,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 			removeTestboxKey(leaseID)
 			return nil
 		}
-		return exit(2, "provider=%s release requires a lease id or firecracker instance name", providerName)
+		return core.Exit(2, "provider=%s release requires a lease id or firecracker instance name", providerName)
 	}
 	if err := b.releaseStateRecord(ctx, cfg, record, record.DeleteOnRelease); err != nil {
 		return err
@@ -408,7 +389,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 	return nil
 }
 
-func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
+func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	cfg := b.configForRun()
 	records, err := b.listStateRecords()
 	if err != nil {
@@ -453,7 +434,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	return nil
 }
 
-func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
+func (b *backend) Touch(_ context.Context, req core.TouchRequest) (core.Server, error) {
 	cfg := b.configForRun()
 	server := req.Lease.Server
 	if server.Provider == "" {
@@ -490,10 +471,10 @@ func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
 	return server, nil
 }
 
-func (b *backend) Doctor(_ context.Context, _ DoctorRequest) (DoctorResult, error) {
+func (b *backend) Doctor(_ context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
 	cfg := b.cfg
 	applyDefaults(&cfg)
-	checks := []DoctorCheck{
+	checks := []core.DoctorCheck{
 		doctorHostCheck(),
 		doctorKVMCheck(),
 		doctorExecutableCheck("binary", "firecracker.binary", cfg.Firecracker.Binary),
@@ -502,7 +483,7 @@ func (b *backend) Doctor(_ context.Context, _ DoctorRequest) (DoctorResult, erro
 		doctorFileCheck("rootfs", "firecracker.rootfs", cfg.Firecracker.RootFS),
 		doctorNetworkCheck(cfg),
 	}
-	return DoctorResult{
+	return core.DoctorResult{
 		Provider: providerName,
 		Status:   core.DoctorChecksStatus(checks),
 		Message:  summarizeDoctorChecks(checks),
@@ -510,7 +491,7 @@ func (b *backend) Doctor(_ context.Context, _ DoctorRequest) (DoctorResult, erro
 	}, nil
 }
 
-func (b *backend) configForRun() Config {
+func (b *backend) configForRun() core.Config {
 	cfg := b.cfg
 	applyDefaults(&cfg)
 	return cfg
@@ -523,31 +504,31 @@ func (b *backend) currentTime() time.Time {
 	return time.Now()
 }
 
-func (b *backend) claimLeaseTarget(cfg Config, leaseID, slug, repoRoot string, reclaim bool, server Server, target SSHTarget) error {
+func (b *backend) claimLeaseTarget(cfg core.Config, leaseID, slug, repoRoot string, reclaim bool, server core.Server, target core.SSHTarget) error {
 	if strings.TrimSpace(repoRoot) == "" {
 		return core.ClaimLeaseTargetForConfig(leaseID, slug, cfg, server, target, cfg.IdleTimeout)
 	}
 	return core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, target, repoRoot, cfg.IdleTimeout, reclaim)
 }
 
-func (b *backend) listServers(cfg Config) ([]Server, error) {
+func (b *backend) listServers(cfg core.Config) ([]core.Server, error) {
 	records, err := b.listStateRecords()
 	if err != nil {
 		return nil, err
 	}
-	servers := make([]Server, 0, len(records))
+	servers := make([]core.Server, 0, len(records))
 	for _, record := range records {
 		servers = append(servers, b.serverFromRecord(cfg, record, b.processes.Matches(record.processIdentity())))
 	}
 	return servers, nil
 }
 
-func (b *backend) recordByIdentifier(cfg Config, identifier string) (leaseStateRecord, bool, error) {
+func (b *backend) recordByIdentifier(cfg core.Config, identifier string) (leaseStateRecord, bool, error) {
 	records, err := b.listStateRecords()
 	if err != nil {
 		return leaseStateRecord{}, false, err
 	}
-	servers := make([]Server, 0, len(records))
+	servers := make([]core.Server, 0, len(records))
 	byLeaseID := make(map[string]leaseStateRecord, len(records))
 	byName := make(map[string]leaseStateRecord, len(records))
 	for _, record := range records {
@@ -570,20 +551,20 @@ func (b *backend) recordByIdentifier(cfg Config, identifier string) (leaseStateR
 	return leaseStateRecord{}, false, nil
 }
 
-func (b *backend) targetFromRecord(cfg Config, record leaseStateRecord) (SSHTarget, error) {
+func (b *backend) targetFromRecord(cfg core.Config, record leaseStateRecord) (core.SSHTarget, error) {
 	if strings.TrimSpace(record.GuestIP) == "" {
-		return SSHTarget{}, exit(5, "firecracker lease %s has no guest IP", record.LeaseID)
+		return core.SSHTarget{}, core.Exit(5, "firecracker lease %s has no guest IP", record.LeaseID)
 	}
 	cfg.SSHUser = firstNonBlank(record.SSHUser, cfg.SSHUser)
 	cfg.SSHPort = firstNonBlank(record.SSHPort, cfg.SSHPort)
 	target := core.SSHTargetFromConfig(cfg, record.GuestIP)
 	if err := core.UseStoredTestboxKey(&target, record.LeaseID); err != nil {
-		return SSHTarget{}, err
+		return core.SSHTarget{}, err
 	}
 	return target, nil
 }
 
-func (b *backend) serverFromRecord(cfg Config, record leaseStateRecord, running bool) Server {
+func (b *backend) serverFromRecord(cfg core.Config, record leaseStateRecord, running bool) core.Server {
 	labels := shared.CloneLabels(record.Labels)
 	status := strings.TrimSpace(labels["state"])
 	if status == "" {
@@ -593,7 +574,7 @@ func (b *backend) serverFromRecord(cfg Config, record leaseStateRecord, running 
 		status = "stopped"
 		labels["state"] = status
 	}
-	server := Server{
+	server := core.Server{
 		CloudID:  firstNonBlank(record.VMID, record.Name, record.LeaseID),
 		Provider: providerName,
 		Name:     firstNonBlank(record.Name, record.VMID, record.LeaseID),
@@ -605,10 +586,10 @@ func (b *backend) serverFromRecord(cfg Config, record leaseStateRecord, running 
 	return server
 }
 
-func serverFromClaim(cfg Config, claim LeaseClaim) Server {
+func serverFromClaim(cfg core.Config, claim core.LeaseClaim) core.Server {
 	labels := shared.CloneLabels(claim.Labels)
 	name := firstNonBlank(labels["instance"], core.LeaseProviderName(claim.LeaseID, claim.Slug))
-	server := Server{
+	server := core.Server{
 		CloudID:  name,
 		Provider: providerName,
 		Name:     name,
@@ -688,7 +669,7 @@ func (b *backend) stopRecordedProcess(record leaseStateRecord) error {
 	return nil
 }
 
-func (b *backend) releaseStateRecord(ctx context.Context, cfg Config, record leaseStateRecord, deleteArtifacts bool) error {
+func (b *backend) releaseStateRecord(ctx context.Context, cfg core.Config, record leaseStateRecord, deleteArtifacts bool) error {
 	if err := b.stopRecordedProcess(record); err != nil {
 		return err
 	}
@@ -714,7 +695,7 @@ func (b *backend) releaseStateRecord(ctx context.Context, cfg Config, record lea
 	return nil
 }
 
-func (b *backend) releaseRecordForLease(cfg Config, lease LeaseTarget) (leaseStateRecord, bool, error) {
+func (b *backend) releaseRecordForLease(cfg core.Config, lease core.LeaseTarget) (leaseStateRecord, bool, error) {
 	identifier := firstNonBlank(lease.LeaseID, lease.Server.Labels["lease"], lease.Server.Name, lease.Server.CloudID)
 	if strings.TrimSpace(identifier) == "" {
 		return leaseStateRecord{}, false, nil
@@ -722,7 +703,7 @@ func (b *backend) releaseRecordForLease(cfg Config, lease LeaseTarget) (leaseSta
 	return b.recordByIdentifier(cfg, identifier)
 }
 
-func (b *backend) shouldCleanupRecord(server Server, record leaseStateRecord) (bool, string) {
+func (b *backend) shouldCleanupRecord(server core.Server, record leaseStateRecord) (bool, string) {
 	if strings.EqualFold(server.Labels["keep"], "true") {
 		return false, "keep=true"
 	}
@@ -732,12 +713,12 @@ func (b *backend) shouldCleanupRecord(server Server, record leaseStateRecord) (b
 	return core.ShouldCleanupServer(server, b.currentTime().UTC())
 }
 
-func firecrackerClaims() (map[string]LeaseClaim, error) {
+func firecrackerClaims() (map[string]core.LeaseClaim, error) {
 	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		return nil, err
 	}
-	out := make(map[string]LeaseClaim)
+	out := make(map[string]core.LeaseClaim)
 	for _, claim := range claims {
 		if claim.Provider != providerName {
 			continue
@@ -753,13 +734,9 @@ func (record leaseStateRecord) processIdentity() processIdentity {
 
 func requireLifecycleHost() error {
 	if firecrackerHostGOOS != "linux" {
-		return exit(2, "provider=firecracker requires a Linux KVM host, got host=%s", firecrackerHostGOOS)
+		return core.Exit(2, "provider=firecracker requires a Linux KVM host, got host=%s", firecrackerHostGOOS)
 	}
 	return nil
-}
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
 }
 
 func firstNonBlank(values ...string) string {
@@ -771,26 +748,26 @@ func removeIfExists(path string) error {
 		return nil
 	}
 	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return exit(2, "remove firecracker artifact %s: %v", path, err)
+		return core.Exit(2, "remove firecracker artifact %s: %v", path, err)
 	}
 	return nil
 }
 
-func doctorHostCheck() DoctorCheck {
+func doctorHostCheck() core.DoctorCheck {
 	details := map[string]string{
 		"os":       firecrackerHostGOOS,
 		"mutation": "false",
 	}
 	if firecrackerHostGOOS != "linux" {
 		details["class"] = "environment_blocked"
-		return DoctorCheck{
+		return core.DoctorCheck{
 			Status:  "failed",
 			Check:   "host",
 			Message: fmt.Sprintf("host=%s requires a Linux KVM host", firecrackerHostGOOS),
 			Details: details,
 		}
 	}
-	return DoctorCheck{
+	return core.DoctorCheck{
 		Status:  "ok",
 		Check:   "host",
 		Message: "host=linux mutation=false",
@@ -798,14 +775,14 @@ func doctorHostCheck() DoctorCheck {
 	}
 }
 
-func doctorKVMCheck() DoctorCheck {
+func doctorKVMCheck() core.DoctorCheck {
 	details := map[string]string{
 		"path":     "/dev/kvm",
 		"mutation": "false",
 	}
 	if firecrackerHostGOOS != "linux" {
 		details["reason"] = "unsupported_host"
-		return DoctorCheck{
+		return core.DoctorCheck{
 			Status:  "skip",
 			Check:   "kvm",
 			Message: "/dev/kvm check skipped on non-Linux host",
@@ -815,7 +792,7 @@ func doctorKVMCheck() DoctorCheck {
 	info, err := firecrackerStat("/dev/kvm")
 	if err != nil {
 		details["class"] = "environment_blocked"
-		return DoctorCheck{
+		return core.DoctorCheck{
 			Status:  "failed",
 			Check:   "kvm",
 			Message: fmt.Sprintf("/dev/kvm unavailable: %v", err),
@@ -824,7 +801,7 @@ func doctorKVMCheck() DoctorCheck {
 	}
 	if info.IsDir() {
 		details["class"] = "environment_blocked"
-		return DoctorCheck{
+		return core.DoctorCheck{
 			Status:  "failed",
 			Check:   "kvm",
 			Message: "/dev/kvm must be a device file, not a directory",
@@ -833,14 +810,14 @@ func doctorKVMCheck() DoctorCheck {
 	}
 	if err := firecrackerOpenKVM(); err != nil {
 		details["class"] = "environment_blocked"
-		return DoctorCheck{
+		return core.DoctorCheck{
 			Status:  "failed",
 			Check:   "kvm",
 			Message: fmt.Sprintf("/dev/kvm not accessible: %v", err),
 			Details: details,
 		}
 	}
-	return DoctorCheck{
+	return core.DoctorCheck{
 		Status:  "ok",
 		Check:   "kvm",
 		Message: "kvm=/dev/kvm mutation=false",
@@ -848,7 +825,7 @@ func doctorKVMCheck() DoctorCheck {
 	}
 }
 
-func doctorExecutableCheck(check, field, configured string) DoctorCheck {
+func doctorExecutableCheck(check, field, configured string) core.DoctorCheck {
 	value := strings.TrimSpace(configured)
 	details := map[string]string{
 		"configured": value,
@@ -857,7 +834,7 @@ func doctorExecutableCheck(check, field, configured string) DoctorCheck {
 	}
 	if value == "" {
 		details["class"] = "configuration_incomplete"
-		return DoctorCheck{
+		return core.DoctorCheck{
 			Status:  "failed",
 			Check:   check,
 			Message: fmt.Sprintf("%s is required", field),
@@ -867,7 +844,7 @@ func doctorExecutableCheck(check, field, configured string) DoctorCheck {
 	resolved, err := firecrackerLookPath(value)
 	if err != nil {
 		details["class"] = "environment_blocked"
-		return DoctorCheck{
+		return core.DoctorCheck{
 			Status:  "failed",
 			Check:   check,
 			Message: fmt.Sprintf("%s unavailable: %v", field, err),
@@ -875,7 +852,7 @@ func doctorExecutableCheck(check, field, configured string) DoctorCheck {
 		}
 	}
 	details["path"] = resolved
-	return DoctorCheck{
+	return core.DoctorCheck{
 		Status:  "ok",
 		Check:   check,
 		Message: fmt.Sprintf("%s=%s mutation=false", check, resolved),
@@ -883,14 +860,14 @@ func doctorExecutableCheck(check, field, configured string) DoctorCheck {
 	}
 }
 
-func doctorJailerCheck(configured string) DoctorCheck {
+func doctorJailerCheck(configured string) core.DoctorCheck {
 	value := strings.TrimSpace(configured)
 	details := map[string]string{
 		"configured": value,
 		"mutation":   "false",
 	}
 	if value == "" {
-		return DoctorCheck{
+		return core.DoctorCheck{
 			Status:  "skip",
 			Check:   "jailer",
 			Message: "jailer=disabled",
@@ -898,7 +875,7 @@ func doctorJailerCheck(configured string) DoctorCheck {
 		}
 	}
 	details["class"] = "configuration_incomplete"
-	return DoctorCheck{
+	return core.DoctorCheck{
 		Status:  "failed",
 		Check:   "jailer",
 		Message: "firecracker.jailer is configured, but jailer launch is not supported yet",
@@ -906,7 +883,7 @@ func doctorJailerCheck(configured string) DoctorCheck {
 	}
 }
 
-func doctorFileCheck(check, field, configured string) DoctorCheck {
+func doctorFileCheck(check, field, configured string) core.DoctorCheck {
 	value := strings.TrimSpace(configured)
 	details := map[string]string{
 		"path":     value,
@@ -915,7 +892,7 @@ func doctorFileCheck(check, field, configured string) DoctorCheck {
 	}
 	if value == "" {
 		details["class"] = "configuration_incomplete"
-		return DoctorCheck{
+		return core.DoctorCheck{
 			Status:  "failed",
 			Check:   check,
 			Message: fmt.Sprintf("%s is required", field),
@@ -925,7 +902,7 @@ func doctorFileCheck(check, field, configured string) DoctorCheck {
 	info, err := firecrackerStat(value)
 	if err != nil {
 		details["class"] = "environment_blocked"
-		return DoctorCheck{
+		return core.DoctorCheck{
 			Status:  "failed",
 			Check:   check,
 			Message: fmt.Sprintf("%s unavailable: %v", field, err),
@@ -934,14 +911,14 @@ func doctorFileCheck(check, field, configured string) DoctorCheck {
 	}
 	if info.IsDir() {
 		details["class"] = "configuration_incomplete"
-		return DoctorCheck{
+		return core.DoctorCheck{
 			Status:  "failed",
 			Check:   check,
 			Message: fmt.Sprintf("%s must point to a file, got directory %s", field, value),
 			Details: details,
 		}
 	}
-	return DoctorCheck{
+	return core.DoctorCheck{
 		Status:  "ok",
 		Check:   check,
 		Message: fmt.Sprintf("%s=%s mutation=false", check, value),
@@ -949,7 +926,7 @@ func doctorFileCheck(check, field, configured string) DoctorCheck {
 	}
 }
 
-func doctorNetworkCheck(cfg Config) DoctorCheck {
+func doctorNetworkCheck(cfg core.Config) core.DoctorCheck {
 	mode := normalizeFirecrackerNetwork(cfg.Firecracker.Network)
 	details := map[string]string{
 		"mode":       mode,
@@ -960,7 +937,7 @@ func doctorNetworkCheck(cfg Config) DoctorCheck {
 	}
 	if mode != firecrackerNetworkCNI {
 		details["class"] = "configuration_incomplete"
-		return DoctorCheck{
+		return core.DoctorCheck{
 			Status:  "failed",
 			Check:   "network",
 			Message: fmt.Sprintf("firecracker.network=%s is unsupported; only %s is supported", blankIfEmpty(mode), firecrackerNetworkCNI),
@@ -988,14 +965,14 @@ func doctorNetworkCheck(cfg Config) DoctorCheck {
 	}
 	if len(problems) > 0 {
 		details["class"] = class
-		return DoctorCheck{
+		return core.DoctorCheck{
 			Status:  "failed",
 			Check:   "network",
 			Message: fmt.Sprintf("network=%s %s", mode, strings.Join(problems, "; ")),
 			Details: details,
 		}
 	}
-	return DoctorCheck{
+	return core.DoctorCheck{
 		Status:  "ok",
 		Check:   "network",
 		Message: fmt.Sprintf("network=%s cni_network=%s mutation=false", mode, details["cniNetwork"]),
@@ -1026,7 +1003,7 @@ func openKVMDevice() error {
 	return file.Close()
 }
 
-func summarizeDoctorChecks(checks []DoctorCheck) string {
+func summarizeDoctorChecks(checks []core.DoctorCheck) string {
 	fields := make([]string, 0, len(checks)+1)
 	for _, check := range checks {
 		fields = append(fields, fmt.Sprintf("%s=%s", check.Check, strings.TrimSpace(check.Status)))

--- a/internal/providers/firecracker/cloudinit.go
+++ b/internal/providers/firecracker/cloudinit.go
@@ -16,10 +16,10 @@ type cloudInitPayload struct {
 
 type fatFile = shared.FATFile
 
-func buildCloudInitPayload(cfg Config, leaseID, slug, publicKey string) (cloudInitPayload, error) {
+func buildCloudInitPayload(cfg core.Config, leaseID, slug, publicKey string) (cloudInitPayload, error) {
 	publicKey = strings.TrimSpace(publicKey)
 	if publicKey == "" {
-		return cloudInitPayload{}, exit(2, "firecracker cloud-init public key is required")
+		return cloudInitPayload{}, core.Exit(2, "firecracker cloud-init public key is required")
 	}
 	userData := core.CloudInitUserData(cfg, publicKey)
 	metaData := fmt.Sprintf("instance-id: %s\nlocal-hostname: crabbox-%s\n", leaseID, slug)
@@ -35,7 +35,7 @@ func writeCloudInitDrive(path string, payload cloudInitPayload) error {
 		return err
 	}
 	if err := os.WriteFile(path, image, 0o600); err != nil {
-		return exit(2, "write firecracker cloud-init drive %s: %v", path, err)
+		return core.Exit(2, "write firecracker cloud-init drive %s: %v", path, err)
 	}
 	return nil
 }

--- a/internal/providers/firecracker/lifecycle_test.go
+++ b/internal/providers/firecracker/lifecycle_test.go
@@ -134,7 +134,7 @@ func newLifecycleTestBackend(t *testing.T, cfg core.Config) lifecycleTestBackend
 	oldEnsureKey := ensureTestboxKey
 	oldRemoveKey := removeTestboxKey
 	firecrackerHostGOOS = "linux"
-	ensureTestboxKey = func(_ Config, leaseID string) (string, string, error) {
+	ensureTestboxKey = func(_ core.Config, leaseID string) (string, string, error) {
 		path, err := core.TestboxKeyPath(leaseID)
 		if err != nil {
 			return "", "", err
@@ -468,7 +468,7 @@ func TestCleanupDryRunReportsStateAndClaimWithoutMutating(t *testing.T) {
 	}
 	test.processes.alive[4242] = false
 
-	orphanServer := Server{
+	orphanServer := core.Server{
 		CloudID:  "orphan-vmid",
 		Provider: providerName,
 		Name:     "orphan-vmid",
@@ -478,7 +478,7 @@ func TestCleanupDryRunReportsStateAndClaimWithoutMutating(t *testing.T) {
 			"state": "ready",
 		},
 	}
-	if err := core.ClaimLeaseTargetForConfig(lease.LeaseID+"-orphan", "orphan-slug", lifecycleConfig(t), orphanServer, SSHTarget{}, time.Minute); err != nil {
+	if err := core.ClaimLeaseTargetForConfig(lease.LeaseID+"-orphan", "orphan-slug", lifecycleConfig(t), orphanServer, core.SSHTarget{}, time.Minute); err != nil {
 		t.Fatalf("ClaimLeaseTargetForConfig: %v", err)
 	}
 

--- a/internal/providers/firecracker/state.go
+++ b/internal/providers/firecracker/state.go
@@ -81,11 +81,11 @@ func (b *backend) firecrackerStateRoot() (string, error) {
 	}
 	root := filepath.Join(stateDir, providerName)
 	if err := ensurePrivateDir(root); err != nil {
-		return "", exit(2, "create firecracker state directory: %v", err)
+		return "", core.Exit(2, "create firecracker state directory: %v", err)
 	}
 	leasesDir := filepath.Join(root, firecrackerLeasesDirName)
 	if err := ensurePrivateDir(leasesDir); err != nil {
-		return "", exit(2, "create firecracker leases directory: %v", err)
+		return "", core.Exit(2, "create firecracker leases directory: %v", err)
 	}
 	return root, nil
 }
@@ -97,7 +97,7 @@ func (b *backend) leasePaths(leaseID string) (leaseStatePaths, error) {
 	}
 	leasesDir := filepath.Join(root, firecrackerLeasesDirName)
 	if err := ensurePrivateDir(leasesDir); err != nil {
-		return leaseStatePaths{}, exit(2, "create firecracker leases directory: %v", err)
+		return leaseStatePaths{}, core.Exit(2, "create firecracker leases directory: %v", err)
 	}
 	dir := filepath.Join(leasesDir, leaseID)
 	return leaseStatePaths{
@@ -118,14 +118,14 @@ func (b *backend) ensureLeaseDir(leaseID string) (leaseStatePaths, error) {
 		return leaseStatePaths{}, err
 	}
 	if err := ensurePrivateDir(paths.Dir); err != nil {
-		return leaseStatePaths{}, exit(2, "create firecracker lease directory %s: %v", paths.Dir, err)
+		return leaseStatePaths{}, core.Exit(2, "create firecracker lease directory %s: %v", paths.Dir, err)
 	}
 	return paths, nil
 }
 
 func (b *backend) writeStateRecord(record leaseStateRecord) error {
 	if strings.TrimSpace(record.LeaseID) == "" {
-		return exit(2, "write firecracker state requires a lease id")
+		return core.Exit(2, "write firecracker state requires a lease id")
 	}
 	paths, err := b.ensureLeaseDir(record.LeaseID)
 	if err != nil {
@@ -145,27 +145,27 @@ func (b *backend) writeStateRecord(record leaseStateRecord) error {
 	}
 	data, err := json.MarshalIndent(record, "", "  ")
 	if err != nil {
-		return exit(2, "encode firecracker state for %s: %v", record.LeaseID, err)
+		return core.Exit(2, "encode firecracker state for %s: %v", record.LeaseID, err)
 	}
 	tmp, err := os.CreateTemp(paths.Dir, ".metadata-*.tmp")
 	if err != nil {
-		return exit(2, "create firecracker state temp file for %s: %v", record.LeaseID, err)
+		return core.Exit(2, "create firecracker state temp file for %s: %v", record.LeaseID, err)
 	}
 	tmpPath := tmp.Name()
 	defer os.Remove(tmpPath)
 	if _, err := tmp.Write(append(data, '\n')); err != nil {
 		tmp.Close()
-		return exit(2, "write firecracker state for %s: %v", record.LeaseID, err)
+		return core.Exit(2, "write firecracker state for %s: %v", record.LeaseID, err)
 	}
 	if err := tmp.Sync(); err != nil {
 		tmp.Close()
-		return exit(2, "sync firecracker state for %s: %v", record.LeaseID, err)
+		return core.Exit(2, "sync firecracker state for %s: %v", record.LeaseID, err)
 	}
 	if err := tmp.Close(); err != nil {
-		return exit(2, "close firecracker state temp file for %s: %v", record.LeaseID, err)
+		return core.Exit(2, "close firecracker state temp file for %s: %v", record.LeaseID, err)
 	}
 	if err := os.Rename(tmpPath, paths.Metadata); err != nil {
-		return exit(2, "install firecracker state for %s: %v", record.LeaseID, err)
+		return core.Exit(2, "install firecracker state for %s: %v", record.LeaseID, err)
 	}
 	return nil
 }
@@ -218,7 +218,7 @@ func (b *backend) listStateRecords() ([]leaseStateRecord, error) {
 		return nil, nil
 	}
 	if err != nil {
-		return nil, exit(2, "read firecracker leases directory: %v", err)
+		return nil, core.Exit(2, "read firecracker leases directory: %v", err)
 	}
 	records := make([]leaseStateRecord, 0, len(entries))
 	for _, entry := range entries {
@@ -229,11 +229,11 @@ func (b *backend) listStateRecords() ([]leaseStateRecord, error) {
 		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
 			continue
 		} else if err != nil {
-			return nil, exit(2, "stat firecracker state for %s: %v", entry.Name(), err)
+			return nil, core.Exit(2, "stat firecracker state for %s: %v", entry.Name(), err)
 		}
 		record, err := readStateRecordFile(path)
 		if err != nil {
-			return nil, exit(2, "read firecracker state for %s: %v", entry.Name(), err)
+			return nil, core.Exit(2, "read firecracker state for %s: %v", entry.Name(), err)
 		}
 		records = append(records, record)
 	}
@@ -245,14 +245,14 @@ func (b *backend) listStateRecords() ([]leaseStateRecord, error) {
 
 func (b *backend) removeStateDir(record leaseStateRecord) error {
 	if strings.TrimSpace(record.LeaseID) == "" {
-		return exit(2, "remove firecracker state requires a lease id")
+		return core.Exit(2, "remove firecracker state requires a lease id")
 	}
 	paths, err := b.leasePaths(record.LeaseID)
 	if err != nil {
 		return err
 	}
 	if err := os.RemoveAll(paths.Dir); err != nil {
-		return exit(2, "remove firecracker state for %s: %v", record.LeaseID, err)
+		return core.Exit(2, "remove firecracker state for %s: %v", record.LeaseID, err)
 	}
 	return nil
 }

--- a/internal/providers/incus/backend.go
+++ b/internal/providers/incus/backend.go
@@ -14,22 +14,10 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-type ProviderSpec = core.ProviderSpec
-type Backend = core.Backend
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type CleanupRequest = core.CleanupRequest
-type LeaseTarget = core.LeaseTarget
-type SSHTarget = core.SSHTarget
-
 type backend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec core.ProviderSpec
+	cfg  core.Config
+	rt   core.Runtime
 }
 
 var waitForSSHReady = core.WaitForSSHReady
@@ -49,12 +37,12 @@ func (e *retainedAcquireError) Error() string { return e.err.Error() }
 
 func (e *retainedAcquireError) Unwrap() error { return e.err }
 
-func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	applyDefaults(&cfg)
 	return &backend{spec: spec, cfg: cfg, rt: rt}
 }
 
-func applyDefaults(cfg *Config) {
+func applyDefaults(cfg *core.Config) {
 	cfg.Provider = providerName
 	base := core.BaseConfig()
 	if cfg.TargetOS == "" {
@@ -83,19 +71,19 @@ func applyDefaults(cfg *Config) {
 	}
 }
 
-func (b *backend) Spec() ProviderSpec { return b.spec }
+func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
-func (b *backend) RebindResolvedLeaseTarget(target *LeaseTarget, leaseID string) error {
+func (b *backend) RebindResolvedLeaseTarget(target *core.LeaseTarget, leaseID string) error {
 	return core.UseStoredTestboxKey(&target.SSH, leaseID)
 }
 
-func (b *backend) configForRun() Config {
+func (b *backend) configForRun() core.Config {
 	cfg := b.cfg
 	applyDefaults(&cfg)
 	return cfg
 }
 
-func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	var lastErr error
 	attempts := core.AcquireAttempts(req.Keep)
 	if req.RequestedLeaseID != "" {
@@ -108,7 +96,7 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		}
 		lastErr = err
 		if attempt == attempts || !core.IsBootstrapWaitError(err) {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		var retained *retainedAcquireError
 		if errors.As(err, &retained) && retained.cleanup != nil {
@@ -116,57 +104,57 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		}
 		fmt.Fprintf(b.rt.Stderr, "warning: bootstrap failed; retrying with fresh lease: %v\n", err)
 	}
-	return LeaseTarget{}, lastErr
+	return core.LeaseTarget{}, lastErr
 }
 
-func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (lease LeaseTarget, err error) {
+func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (lease core.LeaseTarget, err error) {
 	cfg := b.configForRun()
 	client, err := newClient(cfg)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.ReleaseOnly {
 		claim, exists, err := core.ResolveLeaseClaimForProvider(req.ID, providerName)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		if exists && claim.FixedCreateIntent != nil && (claim.FixedCreateIntent.State == "acquired" || claim.FixedCreateIntent.State == "deleting") {
 			if err := verifyConnection(client, claim.ProviderScope); err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 			_, _, lookupErr := client.GetInstance(claim.CloudID)
 			if api.StatusErrorCheck(lookupErr, 404) {
-				return LeaseTarget{LeaseID: claim.LeaseID, Server: core.Server{Provider: providerName, Name: claim.CloudID, CloudID: claim.CloudID, ImmutableID: claim.CloudImmutableID, Labels: claim.Labels}}, nil
+				return core.LeaseTarget{LeaseID: claim.LeaseID, Server: core.Server{Provider: providerName, Name: claim.CloudID, CloudID: claim.CloudID, ImmutableID: claim.CloudImmutableID, Labels: claim.Labels}}, nil
 			}
 			if lookupErr != nil {
-				return LeaseTarget{}, lookupErr
+				return core.LeaseTarget{}, lookupErr
 			}
 		}
 	}
 	inst, server, leaseID, err := b.resolveInstance(ctx, client, req.ID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.ReleaseOnly {
 		claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		if !exists || !incusLeaseKind.IsFixedClaim(claim) {
-			return LeaseTarget{}, core.Exit(4, "Incus lease %s requires its durable ownership claim for release; inspect legacy instances with Incus directly", leaseID)
+			return core.LeaseTarget{}, core.Exit(4, "Incus lease %s requires its durable ownership claim for release; inspect legacy instances with Incus directly", leaseID)
 		}
-		return LeaseTarget{Server: server, LeaseID: leaseID}, nil
+		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
 	}
 	if !req.StatusOnly {
 		claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		if !exists {
-			return LeaseTarget{}, core.Exit(4, "Incus instance %s requires an existing ownership claim for reuse; automatic adoption is not supported", inst.Name)
+			return core.LeaseTarget{}, core.Exit(4, "Incus instance %s requires an existing ownership claim for reuse; automatic adoption is not supported", inst.Name)
 		}
 		if err := requireAcquiredIntent(claim); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	var previousClaim, preflightClaim core.LeaseClaim
@@ -185,38 +173,38 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (lease LeaseT
 		// ownership first or waits for cleanup to finish.
 		previousClaim, previousClaimExists, err = core.ReadLeaseClaimWithPresence(leaseID)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		if !previousClaimExists {
-			return LeaseTarget{}, core.Exit(4, "Incus lease %s ownership claim disappeared before reservation", leaseID)
+			return core.LeaseTarget{}, core.Exit(4, "Incus lease %s ownership claim disappeared before reservation", leaseID)
 		}
 		if err := requireAcquiredIntent(previousClaim); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		reservationWindow := 2*cfg.Incus.StartTimeout + core.BootstrapWaitTimeout(cfg) + incusResolveCompletionMargin
 		preflightClaim, err = core.ClaimLeaseForRepoProviderScopePondEndpointReservationIfUnchanged(leaseID, server.Labels["slug"], providerName, claimScopeForInstance(inst), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, server, core.SSHTarget{}, incusClaimReservationUntilLabel, reservationWindow, previousClaim, previousClaimExists)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		rollbackClaim = true
 		// Re-read the provider after reservation publication; failure rolls the
 		// reservation back through the deferred comparison above.
 		current, _, currentErr := client.GetInstance(inst.Name)
 		if currentErr != nil {
-			return LeaseTarget{}, fmt.Errorf("revalidate Incus instance %s after reserving claim: %w", inst.Name, currentErr)
+			return core.LeaseTarget{}, fmt.Errorf("revalidate Incus instance %s after reserving claim: %w", inst.Name, currentErr)
 		}
 		if err := validateClaimInstance(client, previousClaim, *current); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		if !isCrabboxInstance(*current) {
-			return LeaseTarget{}, core.Exit(4, "Incus instance %s changed ownership while reserving claim", inst.Name)
+			return core.LeaseTarget{}, core.Exit(4, "Incus instance %s changed ownership while reserving claim", inst.Name)
 		}
 		currentServer := serverFromInstance(*current, nil, cfg)
 		if strings.TrimSpace(currentServer.Labels["lease"]) != leaseID ||
 			strings.TrimSpace(currentServer.Labels["provider"]) != providerName ||
 			strings.TrimSpace(currentServer.Labels["created_at"]) == "" ||
 			currentServer.Labels["created_at"] != server.Labels["created_at"] {
-			return LeaseTarget{}, core.Exit(4, "Incus instance %s changed lease identity while reserving claim", inst.Name)
+			return core.LeaseTarget{}, core.Exit(4, "Incus instance %s changed lease identity while reserving claim", inst.Name)
 		}
 		inst = *current
 		server = currentServer
@@ -224,7 +212,7 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (lease LeaseT
 	if req.StatusOnly {
 		state, _, err := client.GetInstanceState(inst.Name)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		server = serverFromInstance(inst, state, cfg)
 		if liveState := strings.ToLower(strings.TrimSpace(state.Status)); liveState != "" {
@@ -237,12 +225,12 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (lease LeaseT
 	} else {
 		if !inst.IsActive() {
 			if err := client.SetInstanceState(inst.Name, api.InstanceStatePut{Action: "start", Timeout: durationSecondsCeil(cfg.Incus.StartTimeout)}, ""); err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 		}
 		instWithAddress, _, err := b.waitForAddress(ctx, client, inst.Name)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		inst = *instWithAddress
 		server = serverFromInstance(inst, nil, cfg)
@@ -256,12 +244,12 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (lease LeaseT
 	}
 	if leaseID != "" {
 		if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	if !req.StatusOnly {
 		if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "reuse", core.BootstrapWaitTimeout(cfg)); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		server.Status = "ready"
 		server.Labels = core.TouchDirectLeaseLabels(server.Labels, cfg, "ready", time.Now().UTC())
@@ -271,18 +259,18 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (lease LeaseT
 	}
 	if !req.StatusOnly && req.Repo.Root != "" && leaseID != "" {
 		if _, err = core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, preflightClaim, server, target); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		rollbackClaim = false
 	} else if !req.StatusOnly && leaseID != "" {
 		if err := core.UpdateLeaseClaimEndpoint(leaseID, server, target); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
-func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
+func (b *backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseView, error) {
 	cfg := b.configForRun()
 	client, err := newClient(cfg)
 	if err != nil {
@@ -292,7 +280,7 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 	if err != nil {
 		return nil, err
 	}
-	views := make([]LeaseView, 0, len(instances))
+	views := make([]core.LeaseView, 0, len(instances))
 	for _, inst := range instances {
 		if !isCrabboxInstance(inst) {
 			continue
@@ -308,7 +296,7 @@ func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.Doctor
 	if err != nil {
 		return core.DoctorResult{}, err
 	}
-	views, err := b.List(ctx, ListRequest{})
+	views, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
 		return core.DoctorResult{}, err
 	}
@@ -336,18 +324,18 @@ func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.Doctor
 	return core.DoctorResult{Provider: providerName, Message: strings.Join(fields, " ")}, nil
 }
 
-func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
 	return err
 }
 
-func (b *backend) ReleaseLeaseWithOutcome(ctx context.Context, req ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+func (b *backend) ReleaseLeaseWithOutcome(ctx context.Context, req core.ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
 	var outcome core.ReleaseLeaseOutcome
 	err := b.releaseLease(ctx, req, &outcome)
 	return outcome, err
 }
 
-func (b *backend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
+func (b *backend) releaseLease(ctx context.Context, req core.ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	cfg := b.configForRun()
 	client, err := newClient(cfg)
 	if err != nil {
@@ -380,7 +368,7 @@ func (b *backend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, out
 	return core.Exit(4, "Incus lease %s requires its durable ownership claim for release; inspect legacy instances with Incus directly", leaseID)
 }
 
-func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
+func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 	instance := core.Blank(core.Blank(lease.Server.CloudID, lease.Server.Name), "-")
 	if incusDeleteOnRelease(lease, b.configForRun()) {
 		return fmt.Sprintf("deleted lease=%s instance=%s", lease.LeaseID, instance)
@@ -388,18 +376,18 @@ func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
 	return fmt.Sprintf("stopped lease=%s instance=%s retained=true", lease.LeaseID, instance)
 }
 
-func (b *backend) RetainLeaseClaimAfterRelease(lease LeaseTarget) bool {
+func (b *backend) RetainLeaseClaimAfterRelease(lease core.LeaseTarget) bool {
 	return !incusDeleteOnRelease(lease, b.configForRun()) || lease.Server.Labels["fixed_intent_sha256"] != ""
 }
 
-func incusReleaseAction(cfg Config) string {
+func incusReleaseAction(cfg core.Config) string {
 	if cfg.Incus.DeleteOnRelease {
 		return "delete"
 	}
 	return "stop"
 }
 
-func incusDeleteOnRelease(lease LeaseTarget, cfg Config) bool {
+func incusDeleteOnRelease(lease core.LeaseTarget, cfg core.Config) bool {
 	if core.DeleteOnReleaseExplicit(cfg, providerName) {
 		return cfg.Incus.DeleteOnRelease
 	}
@@ -414,7 +402,7 @@ func incusDeleteOnRelease(lease LeaseTarget, cfg Config) bool {
 	return cfg.Incus.DeleteOnRelease
 }
 
-func (b *backend) Touch(ctx context.Context, req TouchRequest) (core.Server, error) {
+func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
 	cfg := b.configForRun()
 	client, err := newClient(cfg)
 	if err != nil {
@@ -442,7 +430,7 @@ func (b *backend) Touch(ctx context.Context, req TouchRequest) (core.Server, err
 	return server, nil
 }
 
-func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
+func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	cfg := b.configForRun()
 	client, err := newClient(cfg)
 	if err != nil {
@@ -681,7 +669,7 @@ func (b *backend) resolveInstance(ctx context.Context, client instanceClient, id
 	return *inst, server, leaseID, nil
 }
 
-func instanceConfigForCreate(cfg Config, labels map[string]string, publicKey string) map[string]string {
+func instanceConfigForCreate(cfg core.Config, labels map[string]string, publicKey string) map[string]string {
 	bootstrapCfg := cfg
 	if strings.TrimSpace(cfg.Incus.ProxyListenPort) != "" {
 		bootstrapCfg.SSHPort = core.Blank(strings.TrimSpace(cfg.Incus.LaunchPort), "22")
@@ -696,7 +684,7 @@ func instanceConfigForCreate(cfg Config, labels map[string]string, publicKey str
 	return config
 }
 
-func profilesForConfig(cfg Config) []string {
+func profilesForConfig(cfg core.Config) []string {
 	profile := strings.TrimSpace(cfg.Incus.Profile)
 	if profile == "" {
 		return nil
@@ -704,7 +692,7 @@ func profilesForConfig(cfg Config) []string {
 	return []string{profile}
 }
 
-func devicesForCreate(cfg Config) api.DevicesMap {
+func devicesForCreate(cfg core.Config) api.DevicesMap {
 	port := strings.TrimSpace(cfg.Incus.ProxyListenPort)
 	if port == "" {
 		return nil
@@ -757,7 +745,7 @@ func setInstanceLabels(ctx context.Context, client instanceClient, name string, 
 	return client.UpdateInstance(name, put, etag)
 }
 
-func serverFromInstance(inst api.Instance, state *api.InstanceState, cfg Config) core.Server {
+func serverFromInstance(inst api.Instance, state *api.InstanceState, cfg core.Config) core.Server {
 	server := core.Server{
 		CloudID:     inst.Name,
 		ImmutableID: inst.Config["volatile.uuid"],
@@ -771,7 +759,7 @@ func serverFromInstance(inst api.Instance, state *api.InstanceState, cfg Config)
 	return server
 }
 
-func instanceHost(inst api.Instance, state *api.InstanceState, cfg Config) string {
+func instanceHost(inst api.Instance, state *api.InstanceState, cfg core.Config) string {
 	if strings.TrimSpace(cfg.Incus.ProxyListenPort) != "" {
 		if host := sshHostForConfig(cfg); host != "" {
 			return host
@@ -783,7 +771,7 @@ func instanceHost(inst api.Instance, state *api.InstanceState, cfg Config) strin
 	return bestAddress(inst, state)
 }
 
-func sshTargetHost(server core.Server, cfg Config) string {
+func sshTargetHost(server core.Server, cfg core.Config) string {
 	if strings.TrimSpace(cfg.Incus.ProxyListenPort) != "" {
 		if host := sshHostForConfig(cfg); host != "" {
 			return host

--- a/internal/providers/incus/backend_test.go
+++ b/internal/providers/incus/backend_test.go
@@ -648,7 +648,7 @@ func TestDoctorReportsSocketModeWithoutMutation(t *testing.T) {
 		},
 		states: map[string]*api.InstanceState{},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
@@ -711,7 +711,7 @@ func TestDoctorReportsSocketModeForDefaultLocalRemote(t *testing.T) {
 		instances: map[string]*api.Instance{},
 		states:    map[string]*api.InstanceState{},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
@@ -762,11 +762,11 @@ func TestAcquireResolveListTouchReleaseAndCleanup(t *testing.T) {
 			},
 		},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
-	waitForSSHReady = func(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+	waitForSSHReady = func(ctx context.Context, target *core.SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
 		_ = ctx
 		_ = stderr
 		_ = phase
@@ -808,7 +808,7 @@ func TestAcquireResolveListTouchReleaseAndCleanup(t *testing.T) {
 		t.Fatalf("proxy device listen=%q", got)
 	}
 
-	views, err := b.List(context.Background(), ListRequest{})
+	views, err := b.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -816,7 +816,7 @@ func TestAcquireResolveListTouchReleaseAndCleanup(t *testing.T) {
 		t.Fatalf("views=%#v", views)
 	}
 
-	resolved, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+	resolved, err := b.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -886,11 +886,11 @@ func TestAcquireCleansUpPartialInstanceEvenWhenDeleteOnReleaseFalse(t *testing.T
 		instances:          map[string]*api.Instance{},
 		states:             map[string]*api.InstanceState{},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
-	waitForSSHReady = func(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+	waitForSSHReady = func(ctx context.Context, target *core.SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
 		_ = ctx
 		_ = target
 		_ = stderr
@@ -932,11 +932,11 @@ func TestAcquireKeepFailurePreservesStoredKey(t *testing.T) {
 		instances: map[string]*api.Instance{},
 		states:    map[string]*api.InstanceState{},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
-	waitForSSHReady = func(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+	waitForSSHReady = func(ctx context.Context, target *core.SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
 		_ = ctx
 		_ = target
 		_ = stderr
@@ -997,11 +997,11 @@ func TestAcquireKeepBootstrapRetryCleansRetainedAttempt(t *testing.T) {
 		states:    map[string]*api.InstanceState{},
 	}
 	waitCalls := 0
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
-	waitForSSHReady = func(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+	waitForSSHReady = func(ctx context.Context, target *core.SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
 		_ = ctx
 		_ = target
 		_ = stderr
@@ -1077,11 +1077,11 @@ func TestAcquireUsesProxyHostWhenGuestAddressUnavailable(t *testing.T) {
 		states:               map[string]*api.InstanceState{},
 		preserveEmptyNetwork: true,
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
-	waitForSSHReady = func(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+	waitForSSHReady = func(ctx context.Context, target *core.SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
 		_ = ctx
 		_ = stderr
 		_ = phase
@@ -1151,11 +1151,11 @@ func TestResolveUsesPersistedProxyEndpointWhenFlagsAreOmitted(t *testing.T) {
 			"crabbox-retained": {Status: "Stopped", StatusCode: api.Stopped},
 		},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
-	waitForSSHReady = func(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+	waitForSSHReady = func(ctx context.Context, target *core.SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
 		_ = ctx
 		_ = stderr
 		_ = phase
@@ -1178,7 +1178,7 @@ func TestResolveUsesPersistedProxyEndpointWhenFlagsAreOmitted(t *testing.T) {
 	claimLegacyFixture(t, fake, "crabbox-retained", t.TempDir())
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "cbx_abcd12345678"})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "cbx_abcd12345678"})
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -1217,11 +1217,11 @@ func TestResolveStartsStoppedInstanceAndPersistsReadyLabels(t *testing.T) {
 			"crabbox-retained": {Status: "Stopped", StatusCode: api.Stopped},
 		},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
-	waitForSSHReady = func(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+	waitForSSHReady = func(ctx context.Context, target *core.SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
 		_ = ctx
 		_ = stderr
 		_ = phase
@@ -1244,7 +1244,7 @@ func TestResolveStartsStoppedInstanceAndPersistsReadyLabels(t *testing.T) {
 	claimLegacyFixture(t, fake, "crabbox-retained", t.TempDir())
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "cbx_deadbeefcafe"})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "cbx_deadbeefcafe"})
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -1286,7 +1286,7 @@ func TestResolveChecksRepoClaimBeforeStartingInstance(t *testing.T) {
 			"crabbox-retained": {Status: "Stopped", StatusCode: api.Stopped},
 		},
 	}
-	newClient = func(Config) (instanceClient, error) { return fake, nil }
+	newClient = func(core.Config) (instanceClient, error) { return fake, nil }
 	t.Cleanup(func() { newClient = oldNewClient })
 
 	cfg := core.BaseConfig()
@@ -1296,7 +1296,7 @@ func TestResolveChecksRepoClaimBeforeStartingInstance(t *testing.T) {
 	}
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
-	_, err := b.Resolve(context.Background(), ResolveRequest{
+	_, err := b.Resolve(context.Background(), core.ResolveRequest{
 		ID:   "crabbox-retained",
 		Repo: core.Repo{Root: t.TempDir()},
 	})
@@ -1335,7 +1335,7 @@ func TestResolveRestoresRepoClaimWhenStartFails(t *testing.T) {
 		},
 		stateErr: io.ErrUnexpectedEOF,
 	}
-	newClient = func(Config) (instanceClient, error) { return fake, nil }
+	newClient = func(core.Config) (instanceClient, error) { return fake, nil }
 	t.Cleanup(func() { newClient = oldNewClient })
 
 	cfg := core.BaseConfig()
@@ -1343,7 +1343,7 @@ func TestResolveRestoresRepoClaimWhenStartFails(t *testing.T) {
 	repoRoot := t.TempDir()
 	previous := claimLegacyFixture(t, fake, "crabbox-failing", repoRoot)
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
-	_, err := b.Resolve(context.Background(), ResolveRequest{
+	_, err := b.Resolve(context.Background(), core.ResolveRequest{
 		ID:   "crabbox-failing",
 		Repo: core.Repo{Root: repoRoot},
 	})
@@ -1384,11 +1384,11 @@ func TestResolveFallsBackToConfiguredKeyWhenStoredKeyIsMissing(t *testing.T) {
 			}},
 		},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
-	waitForSSHReady = func(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+	waitForSSHReady = func(ctx context.Context, target *core.SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
 		_ = ctx
 		_ = stderr
 		_ = phase
@@ -1409,7 +1409,7 @@ func TestResolveFallsBackToConfiguredKeyWhenStoredKeyIsMissing(t *testing.T) {
 	claimLegacyFixture(t, fake, "crabbox-nokey", t.TempDir())
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "cbx_a1b2c3d4e5f6"})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "cbx_a1b2c3d4e5f6"})
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -1449,11 +1449,11 @@ func TestResolveUsesLeaseLabelsForSSHUserAndPort(t *testing.T) {
 			}},
 		},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
-	waitForSSHReady = func(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+	waitForSSHReady = func(ctx context.Context, target *core.SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
 		_ = ctx
 		_ = stderr
 		_ = phase
@@ -1470,7 +1470,7 @@ func TestResolveUsesLeaseLabelsForSSHUserAndPort(t *testing.T) {
 	claimLegacyFixture(t, fake, "crabbox-label", t.TempDir())
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "cbx_1abe1e55f00d"})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "cbx_1abe1e55f00d"})
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -1522,11 +1522,11 @@ func TestResolveIgnoresStaleHostLabelWhileWaitingForLiveAddress(t *testing.T) {
 			}
 		}
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return counting, nil
 	}
-	waitForSSHReady = func(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+	waitForSSHReady = func(ctx context.Context, target *core.SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
 		_ = ctx
 		_ = stderr
 		_ = phase
@@ -1550,7 +1550,7 @@ func TestResolveIgnoresStaleHostLabelWhileWaitingForLiveAddress(t *testing.T) {
 	claimLegacyFixture(t, fake, "crabbox-stale-host", t.TempDir())
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "cbx_deadbeefcafe"})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "cbx_deadbeefcafe"})
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -1596,11 +1596,11 @@ func TestResolvePrefersLiveAddressOverStoredHost(t *testing.T) {
 			},
 		},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
-	waitForSSHReady = func(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+	waitForSSHReady = func(ctx context.Context, target *core.SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
 		_ = ctx
 		_ = stderr
 		_ = phase
@@ -1623,7 +1623,7 @@ func TestResolvePrefersLiveAddressOverStoredHost(t *testing.T) {
 	claimLegacyFixture(t, fake, "crabbox-running", t.TempDir())
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "cbx_feedfaceb00c"})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "cbx_feedfaceb00c"})
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -1664,7 +1664,7 @@ func TestResolveStatusOnlyUsesLiveStoppedState(t *testing.T) {
 			"crabbox-status": {Status: "Stopped", StatusCode: api.Stopped},
 		},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
@@ -1674,7 +1674,7 @@ func TestResolveStatusOnlyUsesLiveStoppedState(t *testing.T) {
 	cfg.Provider = providerName
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "cbx_0badf00dbeef", StatusOnly: true})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "cbx_0badf00dbeef", StatusOnly: true})
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -1712,7 +1712,7 @@ func TestResolveStatusOnlyPromotesRunningStateWhenStoredLabelIsStale(t *testing.
 			"crabbox-status": {Status: "Running", StatusCode: api.Running},
 		},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
@@ -1722,7 +1722,7 @@ func TestResolveStatusOnlyPromotesRunningStateWhenStoredLabelIsStale(t *testing.
 	cfg.Provider = providerName
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "cbx_feedfacebead", StatusOnly: true})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "cbx_feedfacebead", StatusOnly: true})
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -1759,7 +1759,7 @@ func TestReleaseLeaseRetainsStoppedInstanceWhenDeleteOnReleaseFalse(t *testing.T
 			"crabbox-retained": {Status: "Running", StatusCode: api.Running},
 		},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
@@ -1846,7 +1846,7 @@ func TestReleaseLeaseRetainIsIdempotentWhenInstanceAlreadyStopped(t *testing.T) 
 			"crabbox-retained": {Status: "Stopped", StatusCode: api.Stopped},
 		},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
@@ -1895,7 +1895,7 @@ func TestReleaseLeaseDeleteOnReleaseFinalizesClaimAndRemovesKey(t *testing.T) {
 			"crabbox-delete": {Status: "Running", StatusCode: api.Running},
 		},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
@@ -1967,7 +1967,7 @@ func TestListSkipsForeignInstancesBeforeManagedOnes(t *testing.T) {
 		},
 		listOrder: []string{"foreign", "crabbox-managed"},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
@@ -1977,7 +1977,7 @@ func TestListSkipsForeignInstancesBeforeManagedOnes(t *testing.T) {
 	cfg.Provider = providerName
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
-	views, err := b.List(context.Background(), ListRequest{})
+	views, err := b.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -2014,7 +2014,7 @@ func TestResolveSkipsForeignInstancesBeforeManagedOnes(t *testing.T) {
 		},
 		listOrder: []string{"foreign", "crabbox-managed"},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
@@ -2024,7 +2024,7 @@ func TestResolveSkipsForeignInstancesBeforeManagedOnes(t *testing.T) {
 	cfg.Provider = providerName
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
-	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "cbx_abcd1234ef56", StatusOnly: true})
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "cbx_abcd1234ef56", StatusOnly: true})
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -2087,7 +2087,7 @@ func TestCleanupContinuesPastForeignAndFreshInstances(t *testing.T) {
 		},
 		listOrder: []string{"foreign", "crabbox-fresh", "crabbox-stale"},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
@@ -2098,7 +2098,7 @@ func TestCleanupContinuesPastForeignAndFreshInstances(t *testing.T) {
 	claimDurableFixture(t, fake, "crabbox-stale")
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	if len(fake.deleted) != 1 || fake.deleted[0] != "crabbox-stale" {
@@ -2135,7 +2135,7 @@ func TestCleanupStopsRunningStaleInstancesBeforeDelete(t *testing.T) {
 			"crabbox-stale": {Status: "Running", StatusCode: api.Running},
 		},
 	}
-	newClient = func(cfg Config) (instanceClient, error) {
+	newClient = func(cfg core.Config) (instanceClient, error) {
 		_ = cfg
 		return fake, nil
 	}
@@ -2146,7 +2146,7 @@ func TestCleanupStopsRunningStaleInstancesBeforeDelete(t *testing.T) {
 	claimDurableFixture(t, fake, "crabbox-stale")
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
-	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatalf("Cleanup: %v", err)
 	}
 	if len(fake.deleted) != 1 || fake.deleted[0] != "crabbox-stale" {

--- a/internal/providers/incus/checkpoint.go
+++ b/internal/providers/incus/checkpoint.go
@@ -23,7 +23,7 @@ func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (co
 	}
 	return capability, true
 }
-func (Provider) NativeCheckpointSourceStatusOnly(Config) bool { return true }
+func (Provider) NativeCheckpointSourceStatusOnly(core.Config) bool { return true }
 func (Provider) NativeCheckpointWorkdir(req core.NativeCheckpointWorkdirRequest) string {
 	if req.Override != "" {
 		return req.Override
@@ -322,7 +322,7 @@ func (Provider) ApplyNativeCheckpointForkConfig(req core.NativeCheckpointForkReq
 	return nil
 }
 
-func validateForkImage(client instanceClient, cfg Config) error {
+func validateForkImage(client instanceClient, cfg core.Config) error {
 	if err := verifyConnection(client, cfg.Incus.CheckpointMetadata[identityLabel]); err != nil {
 		return err
 	}

--- a/internal/providers/incus/cleanup_toctou_test.go
+++ b/internal/providers/incus/cleanup_toctou_test.go
@@ -149,7 +149,7 @@ func testCleanupPreservesInstanceReclaimedDuringList(t *testing.T, dryRun, reser
 	}
 
 	oldNewClient := newClient
-	newClient = func(Config) (instanceClient, error) { return client, nil }
+	newClient = func(core.Config) (instanceClient, error) { return client, nil }
 	t.Cleanup(func() { newClient = oldNewClient })
 
 	cfg := core.BaseConfig()
@@ -253,7 +253,7 @@ func TestCleanupRemovesUnchangedClaimedExpiredInstance(t *testing.T) {
 	}
 
 	oldNewClient := newClient
-	newClient = func(Config) (instanceClient, error) { return fake, nil }
+	newClient = func(core.Config) (instanceClient, error) { return fake, nil }
 	t.Cleanup(func() { newClient = oldNewClient })
 
 	cfg := core.BaseConfig()
@@ -364,7 +364,7 @@ func TestResolveRollsBackReservationWhenInstanceDisappearsOrChanges(t *testing.T
 				}
 			}
 			oldNewClient := newClient
-			newClient = func(Config) (instanceClient, error) { return client, nil }
+			newClient = func(core.Config) (instanceClient, error) { return client, nil }
 			t.Cleanup(func() { newClient = oldNewClient })
 
 			cfg := core.BaseConfig()

--- a/internal/providers/incus/client.go
+++ b/internal/providers/incus/client.go
@@ -20,10 +20,6 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-type Config = core.Config
-type Runtime = core.Runtime
-type Server = core.Server
-
 type instanceClient interface {
 	Identity() (connectionIdentity, error)
 	Profile(name string) (*api.Profile, error)
@@ -211,7 +207,7 @@ type instanceConnection struct {
 	oidcLock         *flock.Flock
 }
 
-var newClient = func(cfg Config) (instanceClient, error) {
+var newClient = func(cfg core.Config) (instanceClient, error) {
 	connection, err := connectInstanceConnection(cfg)
 	if err != nil {
 		return nil, err
@@ -233,7 +229,7 @@ type doctorConnectionInfo struct {
 	Auth     string
 }
 
-func connectInstanceServer(cfg Config) (incusclient.InstanceServer, error) {
+func connectInstanceServer(cfg core.Config) (incusclient.InstanceServer, error) {
 	connection, err := connectInstanceConnection(cfg)
 	if err != nil {
 		return nil, err
@@ -241,7 +237,7 @@ func connectInstanceServer(cfg Config) (incusclient.InstanceServer, error) {
 	return connection.server, nil
 }
 
-func connectInstanceConnection(cfg Config) (instanceConnection, error) {
+func connectInstanceConnection(cfg core.Config) (instanceConnection, error) {
 	if socket := strings.TrimSpace(cfg.Incus.Socket); socket != "" {
 		server, err := incusclient.ConnectIncusUnix(socket, nil)
 		if err != nil {
@@ -347,7 +343,7 @@ func connectInstanceConnection(cfg Config) (instanceConnection, error) {
 	return connection, nil
 }
 
-func doctorConnectionInfoForConfig(cfg Config) (doctorConnectionInfo, error) {
+func doctorConnectionInfoForConfig(cfg core.Config) (doctorConnectionInfo, error) {
 	info := doctorConnectionInfo{
 		Project: selectedProject(cfg, nil),
 	}
@@ -397,12 +393,12 @@ func doctorConnectionInfoForConfig(cfg Config) (doctorConnectionInfo, error) {
 	return info, nil
 }
 
-func connectionArgsForAddress(cfg Config) (*incusclient.ConnectionArgs, error) {
+func connectionArgsForAddress(cfg core.Config) (*incusclient.ConnectionArgs, error) {
 	args, _, err := connectionArgsForAddressWithTokenPath(cfg)
 	return args, err
 }
 
-func connectionArgsForAddressWithTokenPath(cfg Config) (*incusclient.ConnectionArgs, string, error) {
+func connectionArgsForAddressWithTokenPath(cfg core.Config) (*incusclient.ConnectionArgs, string, error) {
 	args := &incusclient.ConnectionArgs{
 		InsecureSkipVerify: cfg.Incus.InsecureTLS,
 	}
@@ -566,7 +562,7 @@ func disableOIDCKeepAlive(clientConfig *cliconfig.Config, remoteName string) {
 	clientConfig.Remotes[remoteName] = remote
 }
 
-func doctorAddressAuth(cfg Config) (string, error) {
+func doctorAddressAuth(cfg core.Config) (string, error) {
 	args, err := connectionArgsForAddress(cfg)
 	if err != nil {
 		return "", err
@@ -657,7 +653,7 @@ func loadOIDCTokens(path string) (*oidc.Tokens[*oidc.IDTokenClaims], error) {
 	return &tokens, nil
 }
 
-func configuredRemoteName(cfg Config, clientConfig *cliconfig.Config) string {
+func configuredRemoteName(cfg core.Config, clientConfig *cliconfig.Config) string {
 	remote := strings.TrimSpace(cfg.Incus.Remote)
 	if remote == "" && clientConfig != nil {
 		remote = strings.TrimSpace(clientConfig.DefaultRemote)
@@ -673,7 +669,7 @@ func configuredRemoteAddr(remote cliconfig.Remote) string {
 	return addr
 }
 
-func selectedProject(cfg Config, remote *cliconfig.Remote) string {
+func selectedProject(cfg core.Config, remote *cliconfig.Remote) string {
 	if project := strings.TrimSpace(cfg.Incus.Project); project != "" {
 		return project
 	}
@@ -704,7 +700,7 @@ func useProject(server incusclient.InstanceServer, project string) incusclient.I
 	return server.UseProject(project)
 }
 
-func imageSourceForConfig(cfg Config) api.InstanceSource {
+func imageSourceForConfig(cfg core.Config) api.InstanceSource {
 	image := strings.TrimSpace(cfg.Incus.Image)
 	server := strings.TrimSpace(cfg.Incus.RemoteImageServer)
 	source := api.InstanceSource{Type: "image"}
@@ -791,7 +787,7 @@ func imageRemoteFromConfig(clientConfig *cliconfig.Config, name string) (string,
 	return addr, protocol, true
 }
 
-func sshHostForConfig(cfg Config) string {
+func sshHostForConfig(cfg core.Config) string {
 	if host := strings.TrimSpace(cfg.Incus.ProxyListenHost); host != "" && !isWildcardHost(host) {
 		return host
 	}

--- a/internal/providers/incus/fixed.go
+++ b/internal/providers/incus/fixed.go
@@ -19,11 +19,11 @@ var incusLeaseKind = core.FixedLeaseKind{ClaimProvider: providerName, IntentVers
 func (*backend) SupportsRequestedLeaseID() bool      { return true }
 func (*backend) SupportsRequestedCheckpointID() bool { return true }
 
-func (b *backend) acquireDurable(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+func (b *backend) acquireDurable(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	cfg := b.configForRun()
 	client, err := newClient(cfg)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	leaseID := req.RequestedLeaseID
 	if leaseID == "" {
@@ -78,15 +78,15 @@ func (b *backend) acquireDurable(ctx context.Context, req AcquireRequest) (Lease
 		}
 		binding.Slug, err = core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
 		return binding, err
-	}, func(ctx context.Context, claim *core.LeaseClaim, intent *core.FixedCreateIntent, persist func() error) (LeaseTarget, error) {
+	}, func(ctx context.Context, claim *core.LeaseClaim, intent *core.FixedCreateIntent, persist func() error) (core.LeaseTarget, error) {
 		name := core.LeaseProviderName(leaseID, intent.Slug)
 		if intent.Attempt == nil {
 			if intent.State != "prepared" || claim.CloudID != "" {
-				return LeaseTarget{}, core.Exit(4, "lease_id_conflict: Incus create intent has no attempt")
+				return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: Incus create intent has no attempt")
 			}
 			identity, err := client.Identity()
 			if err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 			intent.Attempt = map[string]string{"name": name, "uuid": uuid.NewString()}
 			cfg.ProviderKey = core.ProviderKeyForLease(leaseID)
@@ -102,11 +102,11 @@ func (b *backend) acquireDurable(ctx context.Context, req AcquireRequest) (Lease
 			claim.Labels = labels
 			// Persist before submitting. Even a transport error can have created the instance.
 			if err := persist(); err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 		}
 		if intent.Attempt["name"] != name || intent.Attempt["uuid"] == "" {
-			return LeaseTarget{}, core.Exit(4, "lease_id_conflict: Incus attempt identity changed")
+			return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: Incus attempt identity changed")
 		}
 		inst, _, err := client.GetInstance(name)
 		if api.StatusErrorCheck(err, 404) && intent.State == "prepared" && claim.CloudID == "" {
@@ -120,62 +120,62 @@ func (b *backend) acquireDurable(ctx context.Context, req AcquireRequest) (Lease
 				// Only checkpoint clones must remain stopped until inherited credentials are replaced.
 				create.Config["boot.autostart"] = "false"
 				if err := validateForkImage(client, cfg); err != nil {
-					return LeaseTarget{}, err
+					return core.LeaseTarget{}, err
 				}
 				create.Source = api.InstanceSource{Type: "image", Fingerprint: cfg.Incus.Image}
 			}
 			fmt.Fprintf(b.rt.Stderr, "provisioning provider=incus lease=%s slug=%s instance=%s\n", leaseID, intent.Slug, name)
 			if err := client.CreateInstance(create); err != nil {
-				return LeaseTarget{}, fmt.Errorf("Incus create outcome uncertain for lease=%s instance=%s; claim and key retained, retry the same lease ID or stop it: %w", leaseID, name, err)
+				return core.LeaseTarget{}, fmt.Errorf("Incus create outcome uncertain for lease=%s instance=%s; claim and key retained, retry the same lease ID or stop it: %w", leaseID, name, err)
 			}
 			inst, _, err = client.GetInstance(name)
 		}
 		if err != nil {
-			return LeaseTarget{}, fmt.Errorf("reconcile Incus lease=%s instance=%s (claim and key retained): %w", leaseID, name, err)
+			return core.LeaseTarget{}, fmt.Errorf("reconcile Incus lease=%s instance=%s (claim and key retained): %w", leaseID, name, err)
 		}
 
 		if err := validateClaimInstance(client, *claim, *inst); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		claim.CloudID, claim.CloudImmutableID = name, inst.Config["volatile.uuid"]
 		if err := persist(); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		if len(cfg.Incus.CheckpointMetadata) != 0 && inst.Config[labelKey("fork_identity")] != "ready" {
 			if inst.IsActive() {
-				return LeaseTarget{}, core.Exit(4, "Incus fork became active before identity replacement; refusing reuse")
+				return core.LeaseTarget{}, core.Exit(4, "Incus fork became active before identity replacement; refusing reuse")
 			}
 			if err := prepareForkIdentity(client, cfg, *inst, publicKey); err != nil {
-				return LeaseTarget{}, fmt.Errorf("prepare stopped Incus fork %s (claim retained): %w", name, err)
+				return core.LeaseTarget{}, fmt.Errorf("prepare stopped Incus fork %s (claim retained): %w", name, err)
 			}
 			labels := labelsFromInstance(*inst)
 			labels["fork_identity"] = "ready"
 			if err := setInstanceLabels(ctx, client, name, labels); err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 		}
 		if !inst.IsActive() {
 			if err := client.SetInstanceState(name, api.InstanceStatePut{Action: "start", Timeout: durationSecondsCeil(cfg.Incus.StartTimeout)}, ""); err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 		}
 		inst, _, err = b.waitForAddress(ctx, client, name)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		if err := validateClaimInstance(client, *claim, *inst); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		server := serverFromInstance(*inst, nil, cfg)
 		target := core.SSHTargetFromConfig(cfg, sshTargetHost(server, cfg))
 		if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "bootstrap", core.BootstrapWaitTimeout(cfg)); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		server.Labels = core.TouchDirectLeaseLabels(server.Labels, cfg, "ready", time.Now().UTC())
 		if err := setInstanceLabels(ctx, client, name, server.Labels); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
-		return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+		return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 	}, ctx)
 	if err != nil {
 		// Fixed IDs keep their durable attempt on every failure. Generated IDs retain
@@ -192,11 +192,11 @@ func (b *backend) acquireDurable(ctx context.Context, req AcquireRequest) (Lease
 				}}
 			}
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if req.OnAcquired != nil {
 		if err := req.OnAcquired(lease); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	return lease, nil
@@ -267,7 +267,7 @@ func (b *backend) releaseDurableWithOutcome(ctx context.Context, client instance
 	return err
 }
 
-func (b *backend) RetainLeaseClaimAfterReleaseWithClaim(lease LeaseTarget, previous core.LeaseClaim) (bool, error) {
+func (b *backend) RetainLeaseClaimAfterReleaseWithClaim(lease core.LeaseTarget, previous core.LeaseClaim) (bool, error) {
 	if !incusDeleteOnRelease(lease, b.configForRun()) {
 		return true, nil
 	}

--- a/internal/providers/incus/fork_identity.go
+++ b/internal/providers/incus/fork_identity.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lxc/incus/v7/shared/api"
+	core "github.com/openclaw/crabbox/internal/cli"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -20,7 +21,7 @@ var forkUserPattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]*[$]?$`)
 
 // Only the stopped clone is changed. Incus regenerates its own UUID and network
 // identity; cloud-init's per-instance user module would append inherited keys.
-func prepareForkIdentity(client instanceClient, cfg Config, inst api.Instance, publicKey string) error {
+func prepareForkIdentity(client instanceClient, cfg core.Config, inst api.Instance, publicKey string) error {
 	if inst.IsActive() || inst.Type != "container" {
 		return fmt.Errorf("fork identity replacement requires a stopped container")
 	}

--- a/internal/providers/incus/identity.go
+++ b/internal/providers/incus/identity.go
@@ -23,7 +23,7 @@ func (s connectionIdentity) scope() string {
 const connectionLabel = "incus_connection"
 const identityLabel = "incus_identity"
 
-func connectionMetadata(cfg Config, identity connectionIdentity) map[string]string {
+func connectionMetadata(cfg core.Config, identity connectionIdentity) map[string]string {
 	// Config stores paths to existing trust material, never certificate keys or tokens.
 	config := cfg.Incus
 	config.CheckpointMetadata = nil
@@ -31,7 +31,7 @@ func connectionMetadata(cfg Config, identity connectionIdentity) map[string]stri
 	return map[string]string{connectionLabel: string(data), identityLabel: identity.scope()}
 }
 
-func configFromMetadata(metadata map[string]string) (Config, error) {
+func configFromMetadata(metadata map[string]string) (core.Config, error) {
 	cfg := core.BaseConfig()
 	if metadata[connectionLabel] == "" || metadata[identityLabel] == "" {
 		return cfg, fmt.Errorf("Incus resource has no recorded connection identity")

--- a/internal/providers/incus/interruption_test.go
+++ b/internal/providers/incus/interruption_test.go
@@ -77,7 +77,7 @@ func TestIncusCheckpointProcessDeathRetainsRecovery(t *testing.T) {
 			t.Fatal(err)
 		}
 		client := captureCrashClient{fake, root, os.Getenv("CRABBOX_TEST_CAPTURE_PHASE")}
-		newClient = func(Config) (instanceClient, error) { return client, nil }
+		newClient = func(core.Config) (instanceClient, error) { return client, nil }
 		err = (core.App{Stdout: io.Discard, Stderr: io.Discard}).Run(context.Background(), []string{"checkpoint", "create", "--provider", "incus", "--id", lease.LeaseID, "--mode", "native", "--json"})
 		t.Fatalf("capture did not reach crash boundary: %v", err)
 	}
@@ -161,23 +161,23 @@ func TestIncusIncompleteAllocationLostDeleteReply(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			lease := LeaseTarget{LeaseID: req.RequestedLeaseID, Server: core.Server{Provider: providerName, CloudID: claim.FixedCreateIntent.Attempt["name"], Labels: claim.Labels}}
+			lease := core.LeaseTarget{LeaseID: req.RequestedLeaseID, Server: core.Server{Provider: providerName, CloudID: claim.FixedCreateIntent.Attempt["name"], Labels: claim.Labels}}
 			fake.lostDeleteReply = sentinel
-			if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true}); err == nil {
+			if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease, Force: true}); err == nil {
 				t.Fatal("expected uncertain delete")
 			}
 			fake.lostDeleteReply = nil
 			if scenario == "cleanup-replay" {
-				err = b.Cleanup(context.Background(), CleanupRequest{})
+				err = b.Cleanup(context.Background(), core.CleanupRequest{})
 			} else {
 				resolved := lease
 				if reachedServer {
-					resolved, err = b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true})
+					resolved, err = b.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true})
 					if err != nil {
 						t.Fatalf("resolve deleted incomplete allocation: %v", err)
 					}
 				}
-				err = b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: resolved, Force: true})
+				err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: resolved, Force: true})
 			}
 			if !reachedServer {
 				if err == nil {

--- a/internal/providers/incus/legacy_ownership_test.go
+++ b/internal/providers/incus/legacy_ownership_test.go
@@ -67,7 +67,7 @@ func claimDurableFixture(t *testing.T, fake *fakeClient, name string) core.Lease
 	return claim
 }
 
-func legacyOwnershipFixture(t *testing.T, claimed bool) (*backend, *fakeClient, LeaseTarget) {
+func legacyOwnershipFixture(t *testing.T, claimed bool) (*backend, *fakeClient, core.LeaseTarget) {
 	t.Helper()
 	b, fake, req := lifecycleFixture(t)
 	const name = "crabbox-legacy"
@@ -91,7 +91,7 @@ func legacyOwnershipFixture(t *testing.T, claimed bool) (*backend, *fakeClient, 
 	if _, _, err := core.EnsureTestboxKeyForConfig(b.cfg, req.RequestedLeaseID); err != nil {
 		t.Fatal(err)
 	}
-	return b, fake, LeaseTarget{LeaseID: req.RequestedLeaseID, Server: server}
+	return b, fake, core.LeaseTarget{LeaseID: req.RequestedLeaseID, Server: server}
 }
 
 func TestLegacyOwnershipReleaseRefusesStopAndDelete(t *testing.T) {
@@ -105,7 +105,7 @@ func TestLegacyOwnershipReleaseRefusesStopAndDelete(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true}); err == nil {
+				if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease, Force: true}); err == nil {
 					t.Fatal("legacy release accepted without durable ownership")
 				}
 				assertLegacyOwnershipUnchanged(t, fake, lease.LeaseID, before, exists)
@@ -122,7 +122,7 @@ func TestLegacyOwnershipCleanupPreservesInstanceClaimAndKey(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+			if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 				t.Fatal(err)
 			}
 			assertLegacyOwnershipUnchanged(t, fake, lease.LeaseID, before, exists)
@@ -132,7 +132,7 @@ func TestLegacyOwnershipCleanupPreservesInstanceClaimAndKey(t *testing.T) {
 
 func TestLegacyOwnershipCannotBeAdoptedByReuse(t *testing.T) {
 	b, fake, lease := legacyOwnershipFixture(t, false)
-	if _, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.Server.Name, Repo: core.Repo{Root: t.TempDir()}, Reclaim: true}); err == nil {
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: lease.Server.Name, Repo: core.Repo{Root: t.TempDir()}, Reclaim: true}); err == nil {
 		t.Fatal("claimless reuse implicitly adopted a legacy instance")
 	}
 	assertLegacyOwnershipUnchanged(t, fake, lease.LeaseID, core.LeaseClaim{}, false)
@@ -141,7 +141,7 @@ func TestLegacyOwnershipCannotBeAdoptedByReuse(t *testing.T) {
 func TestLegacyOwnershipStatusIsReadOnlyWithRepoRoot(t *testing.T) {
 	b, fake, lease := legacyOwnershipFixture(t, false)
 	before := maps.Clone(fake.instances[lease.Server.Name].Config)
-	if _, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.Server.Name, StatusOnly: true, Repo: core.Repo{Root: t.TempDir()}}); err != nil {
+	if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: lease.Server.Name, StatusOnly: true, Repo: core.Repo{Root: t.TempDir()}}); err != nil {
 		t.Fatal(err)
 	}
 	assertLegacyOwnershipUnchanged(t, fake, lease.LeaseID, core.LeaseClaim{}, false)
@@ -179,9 +179,9 @@ func TestDurableOwnershipRecheckedAfterStop(t *testing.T) {
 			b.cfg.Incus.DeleteOnRelease = remove
 			core.MarkDeleteOnReleaseExplicit(&b.cfg, providerName)
 			client := &replaceAfterStopClient{fakeClient: fake}
-			newClient = func(Config) (instanceClient, error) { return client, nil }
+			newClient = func(core.Config) (instanceClient, error) { return client, nil }
 			updatesBefore := len(fake.updated)
-			if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true}); err == nil {
+			if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease, Force: true}); err == nil {
 				t.Fatal("replacement after stop was accepted")
 			}
 			if len(fake.deleted) != 0 || len(fake.updated) != updatesBefore {
@@ -223,10 +223,10 @@ func TestDurableOwnershipRejectsConflictingProviderLabel(t *testing.T) {
 				}
 				fake.updated, fake.stateUpdates = nil, nil
 				if operation == "release" {
-					if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true}); err == nil {
+					if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease, Force: true}); err == nil {
 						t.Fatal("release accepted conflicting provider label")
 					}
-				} else if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+				} else if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 					t.Fatal(err)
 				}
 				assertLegacyOwnershipUnchanged(t, fake, lease.LeaseID, before, true)

--- a/internal/providers/incus/lifecycle_test.go
+++ b/internal/providers/incus/lifecycle_test.go
@@ -120,19 +120,19 @@ func cloneFiles(files map[string][]byte) map[string][]byte {
 	return result
 }
 
-func lifecycleFixture(t *testing.T) (*backend, *fakeClient, AcquireRequest) {
+func lifecycleFixture(t *testing.T) (*backend, *fakeClient, core.AcquireRequest) {
 	t.Helper()
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
 	fake := &fakeClient{instances: map[string]*api.Instance{}, states: map[string]*api.InstanceState{}}
 	oldClient, oldWait := newClient, waitForSSHReady
-	newClient = func(Config) (instanceClient, error) { return fake, nil }
+	newClient = func(core.Config) (instanceClient, error) { return fake, nil }
 	waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
 	t.Cleanup(func() { newClient, waitForSSHReady = oldClient, oldWait })
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
-	return b, fake, AcquireRequest{RequestedLeaseID: "cbx_123456789abc", RequestedSlug: "quiet-lobster", Repo: core.Repo{Root: t.TempDir()}, Keep: true}
+	return b, fake, core.AcquireRequest{RequestedLeaseID: "cbx_123456789abc", RequestedSlug: "quiet-lobster", Repo: core.Repo{Root: t.TempDir()}, Keep: true}
 }
 
 func TestFixedIncusLostResponseConcurrentReplayAndConflicts(t *testing.T) {
@@ -207,7 +207,7 @@ func TestIncusCheckpointSurvivesSourceAndForkReplacesIdentity(t *testing.T) {
 	if len(fake.snapshots) != 0 {
 		t.Fatal("temporary capture snapshot leaked")
 	}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: source, Force: true}); err != nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: source, Force: true}); err != nil {
 		t.Fatal(err)
 	}
 	resource := core.NativeCheckpointResourceRequest{Persist: (&checkpointRecorder{}).persist, Image: checkpoint.Image, Metadata: checkpoint.Metadata}
@@ -256,7 +256,7 @@ func TestIncusCheckpointSurvivesSourceAndForkReplacesIdentity(t *testing.T) {
 	if len(fake.images) != 0 || fake.instances[fork.Server.Name] == nil {
 		t.Fatal("checkpoint deletion did not preserve fork")
 	}
-	if err := forkBackend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: fork, Force: true}); err != nil {
+	if err := forkBackend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: fork, Force: true}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := forkBackend.Acquire(context.Background(), forkReq); err == nil {
@@ -342,16 +342,16 @@ func TestIncusCheckpointFailuresKeepOwnershipAndCleanupIdentity(t *testing.T) {
 						t.Chdir(req.Repo.Root)
 						err = (core.App{Stdout: io.Discard, Stderr: io.Discard}).Run(context.Background(), []string{"run", "--provider", "incus", "--id", forkReq.RequestedLeaseID, "--no-sync", "--", "true"})
 					} else {
-						_, err = fb.Resolve(context.Background(), ResolveRequest{ID: forkReq.RequestedLeaseID})
+						_, err = fb.Resolve(context.Background(), core.ResolveRequest{ID: forkReq.RequestedLeaseID})
 					}
 					if err == nil || !strings.Contains(err.Error(), "incomplete") || len(fake.stateUpdates) != starts {
 						t.Fatalf("incomplete fork operational reuse cli=%v: %v; state updates %v", cliRun, err, fake.stateUpdates)
 					}
 				}
-				if _, err := fb.Resolve(context.Background(), ResolveRequest{ID: forkReq.RequestedLeaseID, StatusOnly: true}); err != nil {
+				if _, err := fb.Resolve(context.Background(), core.ResolveRequest{ID: forkReq.RequestedLeaseID, StatusOnly: true}); err != nil {
 					t.Fatalf("inspect incomplete fork: %v", err)
 				}
-				if _, err := fb.Resolve(context.Background(), ResolveRequest{ID: forkReq.RequestedLeaseID, ReleaseOnly: true}); err != nil {
+				if _, err := fb.Resolve(context.Background(), core.ResolveRequest{ID: forkReq.RequestedLeaseID, ReleaseOnly: true}); err != nil {
 					t.Fatalf("stop incomplete fork: %v", err)
 				}
 				fake.writeFileErr = nil
@@ -398,13 +398,13 @@ func TestIncusCopiedIdentityCannotReleaseOrCleanup(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true}); err == nil {
+			if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease, Force: true}); err == nil {
 				t.Fatal("stale claim released another resource")
 			}
 			labels := fake.instances[lease.Server.Name].Config
 			labels[labelKey("keep")] = "false"
 			labels[labelKey("expires_at")] = "1"
-			_ = b.Cleanup(context.Background(), CleanupRequest{})
+			_ = b.Cleanup(context.Background(), core.CleanupRequest{})
 			if len(fake.deleted) != 0 {
 				t.Fatal("cleanup deleted a conflicting resource")
 			}
@@ -506,11 +506,11 @@ func TestIncusInterruptedIntentAndLostDeletionReconcile(t *testing.T) {
 	if err := fake.DeleteInstance(lease.Server.Name); err != nil {
 		t.Fatal(err)
 	}
-	target, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true})
+	target, err := b.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true})
 	if err != nil {
 		t.Fatalf("reconcile lost delete: %v", err)
 	}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: target, Force: true}); err != nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: target, Force: true}); err != nil {
 		t.Fatal(err)
 	}
 	after, err := core.ReadLeaseClaim(lease.LeaseID)
@@ -531,7 +531,7 @@ func TestIncusLostPublishResponseFindsIndependentImage(t *testing.T) {
 	if err == nil || !strings.HasPrefix(checkpoint.Image.ID, "pending:") {
 		t.Fatalf("lost publish not recorded: %+v %v", checkpoint, err)
 	}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil {
 		t.Fatal(err)
 	}
 	resource := core.NativeCheckpointResourceRequest{Persist: (&checkpointRecorder{}).persist, Image: checkpoint.Image, Metadata: checkpoint.Metadata}

--- a/internal/providers/parallels/backend.go
+++ b/internal/providers/parallels/backend.go
@@ -13,26 +13,11 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-type Config = core.Config
-type Runtime = core.Runtime
-type ProviderSpec = core.ProviderSpec
-type Backend = core.Backend
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type CleanupRequest = core.CleanupRequest
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-
 type leaseBackend struct {
 	shared.DirectSSHBackend
 }
 
-func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = "parallels"
 	if cfg.Parallels.User != "" {
 		cfg.SSHUser = cfg.Parallels.User
@@ -49,36 +34,36 @@ func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	return &leaseBackend{DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt, StoredLeaseKeys: true}}
 }
 
-func (b *leaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
-	return shared.AcquireAttemptsRetry(b.RT, req.Keep, func() (LeaseTarget, error) {
+func (b *leaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
+	return shared.AcquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
 		return b.acquireOnce(ctx, req.Keep, req.RequestedSlug)
 	})
 }
 
-func (b *leaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (LeaseTarget, error) {
+func (b *leaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (core.LeaseTarget, error) {
 	cfg := b.Cfg
 	source := strings.TrimSpace(firstNonEmpty(cfg.Parallels.SourceID, cfg.Parallels.Source))
 	if source == "" {
-		return LeaseTarget{}, core.Exit(2, "provider=parallels requires --parallels-source, --parallels-template, or parallels.source")
+		return core.LeaseTarget{}, core.Exit(2, "provider=parallels requires --parallels-source, --parallels-template, or parallels.source")
 	}
 	selected, err := core.SelectParallelsFleetConfig(ctx, cfg, b.RT.Exec, source)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cfg = selected
 	client := core.NewParallelsClient(cfg, b.RT.Exec)
 	servers, err := client.ListCrabboxServers(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	leaseID := core.NewLeaseID()
 	slug, err := core.AllocateDirectLeaseSlug(leaseID, requestedSlug, servers)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	keepKey := false
 	defer func() {
@@ -97,7 +82,7 @@ func (b *leaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug
 	if snapshotID != "" && cfg.Parallels.SourceSnapshotID == "" {
 		resolved, err := client.SnapshotID(ctx, source, snapshotID)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		snapshotID = resolved
 	}
@@ -105,28 +90,28 @@ func (b *leaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug
 		leaseID, slug, parallelsHostName(cfg), source, blank(snapshotID, "-"), blank(cfg.Parallels.CloneMode, "linked"), keep)
 	server, err := client.Clone(ctx, source, snapshotID, leaseID, slug, keep)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if err := client.Start(ctx, server.CloudID); err != nil {
 		cleanupVM(server.CloudID)
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	vm, err := client.WaitForIP(ctx, server.CloudID, cfg.Parallels.StartupTimeout)
 	if err != nil {
 		cleanupVM(server.CloudID)
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if err := client.WaitForGuestExec(ctx, server.CloudID, cfg, cfg.Parallels.StartupTimeout); err != nil {
 		cleanupVM(server.CloudID)
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if err := client.InstallSSHKey(ctx, server.CloudID, cfg, publicKey); err != nil {
 		cleanupVM(server.CloudID)
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if err := client.EnsureGuestReady(ctx, server.CloudID, cfg); err != nil {
 		cleanupVM(server.CloudID)
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	server.PublicNet.IPv4.IP = vm.IP
 	target := core.SSHTargetFromConfig(cfg, vm.IP)
@@ -139,26 +124,26 @@ func (b *leaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug
 	}
 	if err := core.WaitForSSHReady(ctx, &target, b.RT.Stderr, "bootstrap", core.BootstrapWaitTimeout(cfg)); err != nil {
 		cleanupVM(server.CloudID)
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	server.Status = "ready"
 	server.Labels = core.TouchDirectLeaseLabels(server.Labels, cfg, "ready", time.Now().UTC())
 	if err := core.ClaimLeaseTargetForConfig(leaseID, slug, cfg, server, target, cfg.IdleTimeout); err != nil {
 		cleanupVM(server.CloudID)
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s vm=%s ip=%s\n", leaseID, server.DisplayID(), vm.IP)
 	keepKey = true
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
-func (b *leaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *leaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	id := strings.TrimSpace(req.ID)
 	if id == "" {
-		return LeaseTarget{}, core.Exit(2, "parallels resolve requires lease id or slug")
+		return core.LeaseTarget{}, core.Exit(2, "parallels resolve requires lease id or slug")
 	}
 	if claim, ok, err := core.ResolveLeaseClaimForProvider(id, "parallels"); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	} else if ok {
 		id = claim.LeaseID
 	}
@@ -185,7 +170,7 @@ func (b *leaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTa
 				leaseID = firstNonEmpty(leaseID, vm.ID)
 				adopt, err := authorizeParallelsResolve(req, leaseID, vm.ID, parallelsHostName(candidate))
 				if err != nil {
-					return LeaseTarget{}, err
+					return core.LeaseTarget{}, err
 				}
 				if vm.IP == "" && strings.EqualFold(vm.State, "running") {
 					vm, _ = client.WaitForIP(ctx, vm.ID, 30*time.Second)
@@ -204,8 +189,8 @@ func (b *leaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTa
 				}
 				target := core.SSHTargetFromConfig(candidate, vm.IP)
 				if !req.ReleaseOnly {
-					if err := useStoredTestboxKey(&target, leaseID); err != nil {
-						return LeaseTarget{}, err
+					if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
+						return core.LeaseTarget{}, err
 					}
 				}
 				if candidate.Parallels.Host != "" {
@@ -214,20 +199,20 @@ func (b *leaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTa
 				}
 				if adopt {
 					if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, candidate, server, target, req.Repo.Root, candidate.IdleTimeout, true); err != nil {
-						return LeaseTarget{}, err
+						return core.LeaseTarget{}, err
 					}
 				}
-				return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+				return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 			}
 		}
 	}
 	if len(hostErrs) > 0 {
-		return LeaseTarget{}, fmt.Errorf("parallels fleet inventory incomplete while resolving %s: %w", req.ID, errors.Join(hostErrs...))
+		return core.LeaseTarget{}, fmt.Errorf("parallels fleet inventory incomplete while resolving %s: %w", req.ID, errors.Join(hostErrs...))
 	}
-	return LeaseTarget{}, core.Exit(4, "parallels lease not found: %s", req.ID)
+	return core.LeaseTarget{}, core.Exit(4, "parallels lease not found: %s", req.ID)
 }
 
-func authorizeParallelsResolve(req ResolveRequest, leaseID, vmID, host string) (bool, error) {
+func authorizeParallelsResolve(req core.ResolveRequest, leaseID, vmID, host string) (bool, error) {
 	owned, err := exactParallelsClaimOwned(leaseID, vmID, host)
 	if err != nil {
 		return false, err
@@ -245,9 +230,9 @@ func authorizeParallelsResolve(req ResolveRequest, leaseID, vmID, host string) (
 	return true, nil
 }
 
-func (b *leaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *leaseBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
-	var out []LeaseView
+	var out []core.LeaseView
 	var hostErrs []error
 	for _, cfg := range core.ParallelsCandidateConfigs(b.Cfg) {
 		leases, err := core.NewParallelsClient(cfg, b.RT.Exec).ListCrabboxServers(ctx)
@@ -269,12 +254,12 @@ func (b *leaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, 
 	return out, nil
 }
 
-func parallelsHostError(cfg Config, action string, err error) error {
+func parallelsHostError(cfg core.Config, action string, err error) error {
 	return fmt.Errorf("host %s %s: %w", parallelsHostName(cfg), action, err)
 }
 
 func (b *leaseBackend) Doctor(ctx context.Context, req core.DoctorRequest) (core.DoctorResult, error) {
-	servers, err := b.List(ctx, ListRequest{})
+	servers, err := b.List(ctx, core.ListRequest{})
 	if err != nil {
 		return core.DoctorResult{}, err
 	}
@@ -308,7 +293,7 @@ func (b *leaseBackend) Doctor(ctx context.Context, req core.DoctorRequest) (core
 	}, nil
 }
 
-func (b *leaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *leaseBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	if req.Lease.Server.Name != "" && !strings.HasPrefix(req.Lease.Server.Name, "crabbox-") {
 		return core.Exit(2, "refusing to release non-Crabbox Parallels VM %q", req.Lease.Server.Name)
 	}
@@ -325,15 +310,15 @@ func (b *leaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest
 	return nil
 }
 
-func (b *leaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
+func (b *leaseBackend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
 	server := req.Lease.Server
 	server.Labels = core.TouchDirectLeaseLabels(server.Labels, b.Cfg, req.State, time.Now().UTC())
 	core.NewParallelsClient(b.configForLease(ctx, req.Lease), b.RT.Exec).SetLeaseLabels(firstNonEmpty(req.Lease.LeaseID, server.Labels["lease"]), server.Labels)
 	return server, nil
 }
 
-func (b *leaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
-	servers, err := b.List(ctx, ListRequest{Options: req.Options})
+func (b *leaseBackend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
+	servers, err := b.List(ctx, core.ListRequest{Options: req.Options})
 	if err != nil {
 		return err
 	}
@@ -344,7 +329,7 @@ func (b *leaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			continue
 		}
 		leaseID := server.Labels["lease"]
-		cfg := b.configForLease(ctx, LeaseTarget{
+		cfg := b.configForLease(ctx, core.LeaseTarget{
 			Server:  server,
 			LeaseID: leaseID,
 		})
@@ -396,7 +381,7 @@ func exactParallelsClaimOwned(leaseID, vmID, host string) (bool, error) {
 	return ok && exact && claim.LeaseID == leaseID && claim.CloudID == vmID && strings.TrimSpace(claim.Labels["host"]) == host, nil
 }
 
-func parallelsProxyCommand(cfg Config, guestIP string) string {
+func parallelsProxyCommand(cfg core.Config, guestIP string) string {
 	host := cfg.Parallels.Host
 	if cfg.Parallels.HostUser != "" {
 		host = cfg.Parallels.HostUser + "@" + host
@@ -410,7 +395,7 @@ func parallelsProxyCommand(cfg Config, guestIP string) string {
 	return strings.Join(core.ShellWords(args), " ")
 }
 
-func (b *leaseBackend) configForLease(ctx context.Context, lease LeaseTarget) Config {
+func (b *leaseBackend) configForLease(ctx context.Context, lease core.LeaseTarget) core.Config {
 	host := strings.TrimSpace(lease.Server.Labels["host"])
 	if host != "" {
 		for _, candidate := range core.ParallelsCandidateConfigs(b.Cfg) {
@@ -440,7 +425,7 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func parallelsHostName(cfg Config) string {
+func parallelsHostName(cfg core.Config) string {
 	return firstNonEmpty(cfg.Parallels.SelectedHost, cfg.Parallels.Host, "local")
 }
 
@@ -449,10 +434,6 @@ func blank(value, fallback string) string {
 		return fallback
 	}
 	return value
-}
-
-func useStoredTestboxKey(target *SSHTarget, leaseID string) error {
-	return core.UseStoredTestboxKey(target, leaseID)
 }
 
 func parallelsLeaseFromVMName(name string) (string, string) {

--- a/internal/providers/parallels/provider_test.go
+++ b/internal/providers/parallels/provider_test.go
@@ -121,7 +121,7 @@ func TestResolveReportsPartialFleetInventory(t *testing.T) {
 	backend := &leaseBackend{
 		DirectSSHBackend: sharedBackend(testParallelsFleetConfig(), &parallelsFleetRunner{}),
 	}
-	_, err := backend.Resolve(context.Background(), ResolveRequest{ID: "missing-lease"})
+	_, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "missing-lease"})
 	if err == nil {
 		t.Fatal("Resolve err=nil, want partial fleet inventory error")
 	}
@@ -139,7 +139,7 @@ func TestListReportsPartialFleetInventory(t *testing.T) {
 	backend := &leaseBackend{
 		DirectSSHBackend: sharedBackend(testParallelsFleetConfig(), &parallelsFleetRunner{}),
 	}
-	leases, err := backend.List(context.Background(), ListRequest{})
+	leases, err := backend.List(context.Background(), core.ListRequest{})
 	if err == nil {
 		t.Fatalf("List err=nil leases=%#v, want partial fleet inventory error", leases)
 	}
@@ -180,7 +180,7 @@ func TestCleanupStopsOnPartialFleetInventory(t *testing.T) {
 	backend := &leaseBackend{
 		DirectSSHBackend: sharedBackend(testParallelsFleetConfig(), runner),
 	}
-	err := backend.Cleanup(context.Background(), CleanupRequest{})
+	err := backend.Cleanup(context.Background(), core.CleanupRequest{})
 	if err == nil {
 		t.Fatal("Cleanup err=nil, want partial fleet inventory error")
 	}
@@ -196,7 +196,7 @@ func TestCleanupRemovesClaimAndStoredKeyAfterDelete(t *testing.T) {
 		DirectSSHBackend: sharedBackend(testParallelsCleanupConfig(), runner),
 	}
 
-	if err := backend.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
 	if runner.deleteCalls != 1 {
@@ -219,7 +219,7 @@ func TestCleanupKeepsClaimAndStoredKeyWhenDeleteFails(t *testing.T) {
 		DirectSSHBackend: sharedBackend(testParallelsCleanupConfig(), runner),
 	}
 
-	err := backend.Cleanup(context.Background(), CleanupRequest{})
+	err := backend.Cleanup(context.Background(), core.CleanupRequest{})
 	if err == nil || !strings.Contains(err.Error(), "delete failed") {
 		t.Fatalf("Cleanup err=%v, want delete failure", err)
 	}
@@ -242,7 +242,7 @@ func TestReleaseRequiresExactClaim(t *testing.T) {
 	backend := &leaseBackend{
 		DirectSSHBackend: sharedBackend(testParallelsCleanupConfig(), runner),
 	}
-	lease := LeaseTarget{
+	lease := core.LeaseTarget{
 		LeaseID: "cbx_unclaimed",
 		Server: core.Server{
 			CloudID: "vm-good",
@@ -250,7 +250,7 @@ func TestReleaseRequiresExactClaim(t *testing.T) {
 			Labels:  map[string]string{"lease": "cbx_unclaimed", "host": "local"},
 		},
 	}
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
 		t.Fatalf("ReleaseLease unclaimed err=%v", err)
 	}
 	if runner.deleteCalls != 0 {
@@ -261,13 +261,13 @@ func TestReleaseRequiresExactClaim(t *testing.T) {
 func TestResolveUnclaimedVMRequiresExplicitAdoption(t *testing.T) {
 	tests := []struct {
 		name    string
-		request ResolveRequest
+		request core.ResolveRequest
 		wantErr string
 	}{
-		{name: "reuse", request: ResolveRequest{ID: "vm-good", Repo: core.Repo{Root: "/repo"}}, wantErr: "explicit --reclaim"},
-		{name: "status", request: ResolveRequest{ID: "vm-good", StatusOnly: true}},
-		{name: "reclaim", request: ResolveRequest{ID: "vm-good", Repo: core.Repo{Root: "/repo"}, Reclaim: true}},
-		{name: "release", request: ResolveRequest{ID: "vm-good", ReleaseOnly: true}, wantErr: "no exact local claim"},
+		{name: "reuse", request: core.ResolveRequest{ID: "vm-good", Repo: core.Repo{Root: "/repo"}}, wantErr: "explicit --reclaim"},
+		{name: "status", request: core.ResolveRequest{ID: "vm-good", StatusOnly: true}},
+		{name: "reclaim", request: core.ResolveRequest{ID: "vm-good", Repo: core.Repo{Root: "/repo"}, Reclaim: true}},
+		{name: "release", request: core.ResolveRequest{ID: "vm-good", ReleaseOnly: true}, wantErr: "no exact local claim"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -383,7 +383,7 @@ func storedTestboxKeyMatches(t *testing.T) []string {
 }
 
 func sharedBackend(cfg core.Config, runner core.CommandRunner) shared.DirectSSHBackend {
-	return shared.DirectSSHBackend{Cfg: cfg, RT: Runtime{Exec: runner, Stderr: io.Discard}}
+	return shared.DirectSSHBackend{Cfg: cfg, RT: core.Runtime{Exec: runner, Stderr: io.Discard}}
 }
 
 func testParallelsFleetConfig() core.Config {

--- a/internal/providers/ssh/architecture.go
+++ b/internal/providers/ssh/architecture.go
@@ -99,7 +99,7 @@ type architectureObservation struct {
 	architecture, host, process, translated string
 }
 
-func architectureProbe(target SSHTarget) (command, source, scope string) {
+func architectureProbe(target core.SSHTarget) (command, source, scope string) {
 	if target.TargetOS == core.TargetWindows && target.WindowsMode == "normal" {
 		return windowsArchitectureProbe, "ssh-iswow64process2", "powershell-process"
 	}
@@ -142,7 +142,7 @@ func parseArchitectureObservation(output string, detailed bool) (architectureObs
 	return architectureObservation{fields[1], fields[2], fields[3], fields[4]}, nil
 }
 
-func (b *staticLeaseBackend) observeArchitecture(ctx context.Context, lease *LeaseTarget) error {
+func (b *staticLeaseBackend) observeArchitecture(ctx context.Context, lease *core.LeaseTarget) error {
 	probeCtx, cancel := context.WithTimeout(ctx, architectureProbeTimeout)
 	defer cancel()
 	// Readiness selected this exact port. nil would silently re-enable port 22.
@@ -205,7 +205,7 @@ func (b *staticLeaseBackend) observeArchitecture(ctx context.Context, lease *Lea
 	return nil
 }
 
-func architectureEndpoint(target SSHTarget) string {
+func architectureEndpoint(target core.SSHTarget) string {
 	// No credential material is persisted. Bind observations to the resolved route,
 	// including user/port/target and transport selectors, not just a lease name.
 	data, _ := json.Marshal([]string{target.Host, target.User, target.Port, target.TargetOS, target.WindowsMode, target.Key, target.CertificateFile, target.ProxyCommand, fmt.Sprint(target.SSHConfigProxy), target.HostKeyAlias, target.KnownHostsFile})
@@ -214,7 +214,7 @@ func architectureEndpoint(target SSHTarget) string {
 	return fmt.Sprintf("%x", digest[:24])
 }
 
-func clearArchitecture(server *Server) {
+func clearArchitecture(server *core.Server) {
 	server.Labels = shared.CloneLabels(server.Labels)
 	delete(server.Labels, "architecture")
 	for key := range server.Labels {
@@ -225,7 +225,7 @@ func clearArchitecture(server *Server) {
 	server.ServerType.Architecture = ""
 }
 
-func historicalArchitecture(server *Server, target SSHTarget) {
+func historicalArchitecture(server *core.Server, target core.SSHTarget) {
 	labels := server.Labels
 	_, source, scope := architectureProbe(target)
 	observedAt, timeErr := strconv.ParseInt(labels["architecture_observed_at"], 10, 64)
@@ -238,7 +238,7 @@ func historicalArchitecture(server *Server, target SSHTarget) {
 	}
 }
 
-func (b *staticLeaseBackend) reportHistoricalArchitecture(server Server) {
+func (b *staticLeaseBackend) reportHistoricalArchitecture(server core.Server) {
 	labels := server.Labels
 	if labels["architecture_observed_at"] == "" {
 		fmt.Fprintln(b.RT.Stderr, "static SSH architecture unknown (offline; no evidence for this endpoint)")

--- a/internal/providers/ssh/architecture_ownership_test.go
+++ b/internal/providers/ssh/architecture_ownership_test.go
@@ -14,7 +14,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func staticOwnershipCacheSnapshot(b *staticLeaseBackend) LeaseTarget {
+func staticOwnershipCacheSnapshot(b *staticLeaseBackend) core.LeaseTarget {
 	lease := b.acquired
 	lease.Server.Labels = maps.Clone(lease.Server.Labels)
 	return lease
@@ -35,12 +35,12 @@ func trackStaticOwnershipPreparation(t *testing.T, b *staticLeaseBackend, expect
 	}
 	readiness, probes := 0, 0
 	ready := waitForSSH
-	waitForSSH = func(ctx context.Context, target *SSHTarget, log io.Writer) error {
+	waitForSSH = func(ctx context.Context, target *core.SSHTarget, log io.Writer) error {
 		readiness++
 		checkUnpublished()
 		return ready(ctx, target, log)
 	}
-	runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) {
+	runArchitectureProbe = func(context.Context, core.SSHTarget, string, int) (string, error) {
 		probes++
 		checkUnpublished()
 		return output, nil
@@ -63,7 +63,7 @@ func TestStaticSSHArchitecturePrepareDefersOwnershipPublication(t *testing.T) {
 		} {
 			t.Run(map[bool]string{false: "claimed", true: "cached"}[cached]+"/"+tc.name, func(t *testing.T) {
 				b, _, repoA := staticArchitectureFixture(t, "linux", "normal", "")
-				lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repoA}})
+				lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repoA}})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -81,7 +81,7 @@ func TestStaticSSHArchitecturePrepareDefersOwnershipPublication(t *testing.T) {
 					core.MarkArchitectureExplicit(&b.Cfg)
 				}
 				readiness, probes := trackStaticOwnershipPreparation(t, b, initial, true, "v1|amd64|-|-|-")
-				prepared, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Repo: core.Repo{Root: repoB}, Reclaim: tc.reclaim, Prepare: true})
+				prepared, err := b.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID, Repo: core.Repo{Root: repoB}, Reclaim: tc.reclaim, Prepare: true})
 				after, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
 				if !reflect.DeepEqual(after, initial) {
 					t.Error("Prepare mutated the claim before repository authorization")
@@ -114,7 +114,7 @@ func TestStaticSSHArchitecturePrepareDefersOwnershipPublication(t *testing.T) {
 				if prepared.Server.ServerType.Architecture != "amd64" {
 					t.Fatal("Prepare did not return fresh evidence")
 				}
-				published, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(lease.LeaseID, serverSlug(prepared.Server), b.Cfg, prepared.Server, prepared.SSH, repoB, b.Cfg.IdleTimeout, tc.reclaim, expected, exists)
+				published, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(lease.LeaseID, core.ServerSlug(prepared.Server), b.Cfg, prepared.Server, prepared.SSH, repoB, b.Cfg.IdleTimeout, tc.reclaim, expected, exists)
 				if err != nil {
 					t.Fatalf("authorized publication failed: %v", err)
 				}
@@ -151,7 +151,7 @@ func TestStaticSSHArchitectureRunOwnershipPublication(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repoA}})
+			lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repoA}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -191,14 +191,14 @@ func TestStaticSSHArchitectureRunOwnershipPublication(t *testing.T) {
 				host = "other.example.test"
 			}
 			ready := waitForSSH
-			waitForSSH = func(ctx context.Context, target *SSHTarget, log io.Writer) error {
+			waitForSSH = func(ctx context.Context, target *core.SSHTarget, log io.Writer) error {
 				if target.Host != host {
 					t.Fatalf("readiness used %q instead of selected host %q", target.Host, host)
 				}
 				return ready(ctx, target, log)
 			}
 			probe := runArchitectureProbe
-			runArchitectureProbe = func(ctx context.Context, target SSHTarget, command string, limit int) (string, error) {
+			runArchitectureProbe = func(ctx context.Context, target core.SSHTarget, command string, limit int) (string, error) {
 				if target.Host != host {
 					t.Fatalf("probe used %q instead of selected host %q", target.Host, host)
 				}
@@ -273,7 +273,7 @@ func TestStaticSSHArchitectureConfiguredHostOwnershipPreflight(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			b, _, repoA := staticArchitectureFixture(t, "linux", "normal", "")
 			if !tc.missing {
-				if _, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repoA}}); err != nil {
+				if _, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repoA}}); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -294,7 +294,7 @@ func TestStaticSSHArchitectureConfiguredHostOwnershipPreflight(t *testing.T) {
 			if tc.byHost {
 				id = b.Cfg.Static.Host
 			}
-			offline, err := b.Resolve(context.Background(), ResolveRequest{ID: id})
+			offline, err := b.Resolve(context.Background(), core.ResolveRequest{ID: id})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -305,7 +305,7 @@ func TestStaticSSHArchitectureConfiguredHostOwnershipPreflight(t *testing.T) {
 			readiness, probes := trackStaticOwnershipPreparation(t, b, initial, exists, "v1|amd64|-|-|-")
 			wantClaim, wantPresent := initial, exists
 			probe := runArchitectureProbe
-			runArchitectureProbe = func(ctx context.Context, target SSHTarget, command string, limit int) (string, error) {
+			runArchitectureProbe = func(ctx context.Context, target core.SSHTarget, command string, limit int) (string, error) {
 				if target.Host != b.Cfg.Static.Host {
 					t.Fatalf("probe ignored configured host: %q", target.Host)
 				}
@@ -329,7 +329,7 @@ func TestStaticSSHArchitectureConfiguredHostOwnershipPreflight(t *testing.T) {
 				}
 				return output, err
 			}
-			prepared, err := b.Resolve(context.Background(), ResolveRequest{ID: id, Repo: core.Repo{Root: repo}, Reclaim: tc.reclaim, Prepare: true})
+			prepared, err := b.Resolve(context.Background(), core.ResolveRequest{ID: id, Repo: core.Repo{Root: repo}, Reclaim: tc.reclaim, Prepare: true})
 			after, present, readErr := core.ReadLeaseClaimWithPresence(b.Cfg.Static.ID)
 			if readErr != nil || !reflect.DeepEqual(b.acquired, cacheBefore) {
 				t.Fatalf("preparation changed cache or claim became unreadable: %v", readErr)
@@ -367,7 +367,7 @@ func TestStaticSSHArchitecturePrepareWithoutRepository(t *testing.T) {
 	for _, legacy := range []bool{false, true} {
 		t.Run(map[bool]string{false: "owned", true: "legacy-unowned"}[legacy], func(t *testing.T) {
 			b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
-			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+			lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -383,7 +383,7 @@ func TestStaticSSHArchitecturePrepareWithoutRepository(t *testing.T) {
 			}
 			cacheBefore := staticOwnershipCacheSnapshot(b)
 			readiness, probes := trackStaticOwnershipPreparation(t, b, initial, true, "v1|amd64|-|-|-")
-			prepared, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Prepare: true, NoLocalStateMutations: true})
+			prepared, err := b.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID, Prepare: true, NoLocalStateMutations: true})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -412,7 +412,7 @@ func TestStaticSSHArchitecturePrepareRejectsStaleCachedClaim(t *testing.T) {
 		for _, caller := range []string{"same-owner", "reclaim", "admin"} {
 			t.Run(change+"/"+caller, func(t *testing.T) {
 				b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
-				lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+				lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -439,7 +439,7 @@ func TestStaticSSHArchitecturePrepareRejectsStaleCachedClaim(t *testing.T) {
 				}
 				cacheBefore := staticOwnershipCacheSnapshot(b)
 				readiness, probes := trackStaticOwnershipPreparation(t, b, current, exists, "v1|amd64|-|-|-")
-				req := ResolveRequest{ID: lease.LeaseID, Repo: core.Repo{Root: repo}, Prepare: true}
+				req := core.ResolveRequest{ID: lease.LeaseID, Repo: core.Repo{Root: repo}, Prepare: true}
 				if caller == "reclaim" {
 					req.Reclaim = true
 				} else if caller == "admin" {
@@ -479,7 +479,7 @@ func TestStaticSSHArchitectureAcquireOwnershipPreflight(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			b, _, repoA := staticArchitectureFixture(t, "linux", "normal", "")
 			if !tc.unclaimed {
-				if _, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repoA}}); err != nil {
+				if _, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repoA}}); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -499,7 +499,7 @@ func TestStaticSSHArchitectureAcquireOwnershipPreflight(t *testing.T) {
 			}
 			cacheBefore := staticOwnershipCacheSnapshot(b)
 			readiness, probes := trackStaticOwnershipPreparation(t, b, initial, exists, "v1|amd64|-|-|-")
-			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}, Reclaim: tc.reclaim})
+			lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}, Reclaim: tc.reclaim})
 			after, present, readErr := core.ReadLeaseClaimWithPresence(b.Cfg.Static.ID)
 			if readErr != nil {
 				t.Fatal(readErr)
@@ -544,20 +544,20 @@ func TestStaticSSHArchitectureTouchRetainsPublishedEvidence(t *testing.T) {
 	for _, publishedArchitecture := range []string{"arm64", "unknown"} {
 		t.Run(publishedArchitecture, func(t *testing.T) {
 			b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
-			runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) {
+			runArchitectureProbe = func(context.Context, core.SSHTarget, string, int) (string, error) {
 				return "v1|" + publishedArchitecture + "|-|-|-", nil
 			}
-			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+			lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 			if err != nil {
 				t.Fatal(err)
 			}
 			initial, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
-			runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) { return "v1|amd64|-|-|-", nil }
-			prepared, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Prepare: true})
+			runArchitectureProbe = func(context.Context, core.SSHTarget, string, int) (string, error) { return "v1|amd64|-|-|-", nil }
+			prepared, err := b.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID, Prepare: true})
 			if err != nil {
 				t.Fatal(err)
 			}
-			touched, err := b.Touch(context.Background(), TouchRequest{Lease: prepared, State: "busy"})
+			touched, err := b.Touch(context.Background(), core.TouchRequest{Lease: prepared, State: "busy"})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/providers/ssh/architecture_test.go
+++ b/internal/providers/ssh/architecture_test.go
@@ -19,7 +19,7 @@ import (
 func stubStaticArchitecture(t *testing.T) {
 	t.Helper()
 	old := runArchitectureProbe
-	runArchitectureProbe = func(_ context.Context, target SSHTarget, _ string, _ int) (string, error) {
+	runArchitectureProbe = func(_ context.Context, target core.SSHTarget, _ string, _ int) (string, error) {
 		_, source, _ := architectureProbe(target)
 		if source == "ssh-uname" {
 			return "v1|arm64|-|-|-", nil
@@ -34,7 +34,7 @@ func staticArchitectureFixture(t *testing.T, target, mode, assertion string) (*s
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	old := waitForSSH
-	waitForSSH = func(ctx context.Context, target *SSHTarget, _ io.Writer) error {
+	waitForSSH = func(ctx context.Context, target *core.SSHTarget, _ io.Writer) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -52,17 +52,17 @@ func staticArchitectureFixture(t *testing.T, target, mode, assertion string) (*s
 		core.MarkArchitectureExplicit(&cfg)
 	}
 	var log bytes.Buffer
-	b := NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: &log, Clock: staticLifecycleClock{now: time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)}}).(*staticLeaseBackend)
+	b := NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stderr: &log, Clock: staticLifecycleClock{now: time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)}}).(*staticLeaseBackend)
 	return b, &log, t.TempDir()
 }
 
 func TestStaticSSHArchitectureAliasesAndTargets(t *testing.T) {
-	for _, cfg := range []Config{{TargetOS: "worker-runtime"}, {TargetOS: "windows", WindowsMode: "unsupported"}, {TargetOS: "macos", WindowsMode: "wsl2"}} {
+	for _, cfg := range []core.Config{{TargetOS: "worker-runtime"}, {TargetOS: "windows", WindowsMode: "unsupported"}, {TargetOS: "macos", WindowsMode: "wsl2"}} {
 		if (Provider{}).SupportsArchitecture(cfg, "arm64") {
 			t.Fatalf("unsupported tuple admitted: target=%s mode=%s", cfg.TargetOS, cfg.WindowsMode)
 		}
 	}
-	if (Provider{}).SupportsArchitecture(Config{TargetOS: "linux"}, "s390x") {
+	if (Provider{}).SupportsArchitecture(core.Config{TargetOS: "linux"}, "s390x") {
 		t.Fatal("unsupported architecture admitted")
 	}
 	for _, alias := range []string{"ssh", "static", "static-ssh"} {
@@ -80,7 +80,7 @@ func TestStaticSSHArchitectureAliasesAndTargets(t *testing.T) {
 					}
 					// The real CLI admission path must reach the adapter's readiness boundary.
 					sentinel := errors.New("admitted to static adapter")
-					waitForSSH = func(context.Context, *SSHTarget, io.Writer) error { return sentinel }
+					waitForSSH = func(context.Context, *core.SSHTarget, io.Writer) error { return sentinel }
 					t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "absent.yaml"))
 					t.Setenv("CRABBOX_PROVIDER", "ssh")
 					var log bytes.Buffer
@@ -146,7 +146,7 @@ func TestStaticSSHArchitectureAssertions(t *testing.T) {
 			}
 			b, log, repo := staticArchitectureFixture(t, target, mode, tc.assertion)
 			beforeCfg := b.Cfg
-			runArchitectureProbe = func(ctx context.Context, target SSHTarget, command string, limit int) (string, error) {
+			runArchitectureProbe = func(ctx context.Context, target core.SSHTarget, command string, limit int) (string, error) {
 				if target.Port != "2207" || target.FallbackPorts == nil || len(target.FallbackPorts) != 0 {
 					t.Fatalf("probe did not pin resolved port: %#v", target)
 				}
@@ -166,7 +166,7 @@ func TestStaticSSHArchitectureAssertions(t *testing.T) {
 				}
 				return tc.output, tc.probeErr
 			}
-			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+			lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 			if (err != nil) != tc.fail {
 				t.Fatalf("err=%v want failure=%t", err, tc.fail)
 			}
@@ -210,7 +210,7 @@ func TestStaticSSHArchitecturePreparedReuseAndHistoricalLookup(t *testing.T) {
 	for _, cached := range []bool{false, true} {
 		t.Run(map[bool]string{false: "claimed", true: "cached"}[cached], func(t *testing.T) {
 			b, log, repo := staticArchitectureFixture(t, "linux", "normal", "")
-			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+			lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -219,12 +219,15 @@ func TestStaticSSHArchitecturePreparedReuseAndHistoricalLookup(t *testing.T) {
 				b = NewStaticSSHLeaseBackend(Provider{}.Spec(), b.Cfg, b.RT).(*staticLeaseBackend)
 			}
 			calls := 0
-			runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) { calls++; return "v1|amd64|-|-|-", nil }
-			offline, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+			runArchitectureProbe = func(context.Context, core.SSHTarget, string, int) (string, error) {
+				calls++
+				return "v1|amd64|-|-|-", nil
+			}
+			offline, err := b.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID})
 			if err != nil {
 				t.Fatal(err)
 			}
-			views, err := b.List(context.Background(), ListRequest{})
+			views, err := b.List(context.Background(), core.ListRequest{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -233,7 +236,7 @@ func TestStaticSSHArchitecturePreparedReuseAndHistoricalLookup(t *testing.T) {
 			}
 			b.Cfg.Architecture = "amd64"
 			core.MarkArchitectureExplicit(&b.Cfg)
-			fresh, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Prepare: true})
+			fresh, err := b.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID, Prepare: true})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -248,7 +251,7 @@ func TestStaticSSHArchitecturePreparedReuseAndHistoricalLookup(t *testing.T) {
 			if !reflect.DeepEqual(afterPrepare, initial) {
 				t.Fatal("Prepare published evidence before its caller")
 			}
-			updated, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(lease.LeaseID, serverSlug(fresh.Server), b.Cfg, fresh.Server, fresh.SSH, repo, b.Cfg.IdleTimeout, false, expected, exists)
+			updated, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(lease.LeaseID, core.ServerSlug(fresh.Server), b.Cfg, fresh.Server, fresh.SSH, repo, b.Cfg.IdleTimeout, false, expected, exists)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -258,7 +261,7 @@ func TestStaticSSHArchitecturePreparedReuseAndHistoricalLookup(t *testing.T) {
 				}
 			}
 			core.SetServerLeaseClaimSnapshot(&fresh.Server, updated, true)
-			touched, err := b.Touch(context.Background(), TouchRequest{Lease: fresh, State: "busy"})
+			touched, err := b.Touch(context.Background(), core.TouchRequest{Lease: fresh, State: "busy"})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -277,7 +280,7 @@ func TestStaticSSHArchitectureFailedRefreshPreservesClaimsAndCache(t *testing.T)
 	for _, path := range []string{"acquire", "claimed", "cached"} {
 		t.Run(path, func(t *testing.T) {
 			b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
-			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+			lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -288,9 +291,9 @@ func TestStaticSSHArchitectureFailedRefreshPreservesClaimsAndCache(t *testing.T)
 				b = NewStaticSSHLeaseBackend(Provider{}.Spec(), b.Cfg, b.RT).(*staticLeaseBackend)
 			}
 			if path == "acquire" {
-				_, err = b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+				_, err = b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 			} else {
-				_, err = b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Prepare: true})
+				_, err = b.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID, Prepare: true})
 			}
 			if err == nil {
 				t.Fatal("accepted mismatch")
@@ -311,7 +314,7 @@ func TestStaticSSHArchitectureClaimReplacementRaces(t *testing.T) {
 		for _, remove := range []bool{false, true} {
 			t.Run(path+map[bool]string{false: "/replace", true: "/remove"}[remove], func(t *testing.T) {
 				b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
-				lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+				lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -320,7 +323,7 @@ func TestStaticSSHArchitectureClaimReplacementRaces(t *testing.T) {
 					b = NewStaticSSHLeaseBackend(Provider{}.Spec(), b.Cfg, b.RT).(*staticLeaseBackend)
 				}
 				var replacement core.LeaseClaim
-				runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) {
+				runArchitectureProbe = func(context.Context, core.SSHTarget, string, int) (string, error) {
 					if remove {
 						core.RemoveLeaseClaim(lease.LeaseID)
 					} else {
@@ -337,9 +340,9 @@ func TestStaticSSHArchitectureClaimReplacementRaces(t *testing.T) {
 					return "v1|amd64|-|-|-", nil
 				}
 				if path == "acquire" {
-					_, err = b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+					_, err = b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 				} else {
-					_, err = b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Prepare: true})
+					_, err = b.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID, Prepare: true})
 				}
 				if err == nil || !strings.Contains(err.Error(), "claim changed") {
 					t.Fatalf("race err=%v", err)
@@ -357,7 +360,7 @@ func TestStaticSSHArchitectureLegacyAndEndpointOverrides(t *testing.T) {
 	for _, change := range []string{"legacy", "host", "user", "port", "target", "mode", "key"} {
 		t.Run(change, func(t *testing.T) {
 			b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
-			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+			lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -392,8 +395,11 @@ func TestStaticSSHArchitectureLegacyAndEndpointOverrides(t *testing.T) {
 			}
 			fresh := NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, b.RT).(*staticLeaseBackend)
 			calls := 0
-			runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) { calls++; return "v1|amd64|-|-|-", nil }
-			offline, err := fresh.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+			runArchitectureProbe = func(context.Context, core.SSHTarget, string, int) (string, error) {
+				calls++
+				return "v1|amd64|-|-|-", nil
+			}
+			offline, err := fresh.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -401,7 +407,7 @@ func TestStaticSSHArchitectureLegacyAndEndpointOverrides(t *testing.T) {
 				t.Fatal("attached old evidence to changed/legacy route")
 			}
 			if change == "legacy" {
-				prepared, err := fresh.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Prepare: true})
+				prepared, err := fresh.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID, Prepare: true})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -416,8 +422,11 @@ func TestStaticSSHArchitectureLegacyAndEndpointOverrides(t *testing.T) {
 func TestStaticSSHArchitectureCancellationBeforePublication(t *testing.T) {
 	b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
 	ctx, cancel := context.WithCancel(context.Background())
-	runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) { cancel(); return "v1|arm64|-|-|-", nil }
-	if _, err := b.Acquire(ctx, AcquireRequest{Repo: core.Repo{Root: repo}}); !errors.Is(err, context.Canceled) {
+	runArchitectureProbe = func(context.Context, core.SSHTarget, string, int) (string, error) {
+		cancel()
+		return "v1|arm64|-|-|-", nil
+	}
+	if _, err := b.Acquire(ctx, core.AcquireRequest{Repo: core.Repo{Root: repo}}); !errors.Is(err, context.Canceled) {
 		t.Fatalf("err=%v", err)
 	}
 	if _, exists, _ := core.ReadLeaseClaimWithPresence(b.Cfg.Static.ID); exists {
@@ -428,7 +437,7 @@ func TestStaticSSHArchitectureCancellationBeforePublication(t *testing.T) {
 // WSL must select POSIX execution-environment queries, not Windows host queries.
 func TestStaticSSHArchitectureProbeSelection(t *testing.T) {
 	for _, tc := range []struct{ target, mode, source, scope string }{{"linux", "normal", "ssh-uname", "posix-environment"}, {"macos", "normal", "ssh-uname-sysctl", "posix-process"}, {"windows", "normal", "ssh-iswow64process2", "powershell-process"}, {"windows", "wsl2", "ssh-uname", "wsl-environment"}} {
-		command, source, scope := architectureProbe(SSHTarget{TargetOS: tc.target, WindowsMode: tc.mode})
+		command, source, scope := architectureProbe(core.SSHTarget{TargetOS: tc.target, WindowsMode: tc.mode})
 		if source != tc.source || scope != tc.scope || command == "" {
 			t.Fatalf("selection %s/%s", tc.target, tc.mode)
 		}
@@ -437,8 +446,8 @@ func TestStaticSSHArchitectureProbeSelection(t *testing.T) {
 
 func TestStaticSSHArchitectureResolvedTransportPreserved(t *testing.T) {
 	b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
-	var resolved SSHTarget
-	waitForSSH = func(_ context.Context, target *SSHTarget, _ io.Writer) error {
+	var resolved core.SSHTarget
+	waitForSSH = func(_ context.Context, target *core.SSHTarget, _ io.Writer) error {
 		target.Port = "2207"
 		target.Key = "/fixture/resolved-key"
 		target.CertificateFile = "/fixture/certificate"
@@ -452,13 +461,13 @@ func TestStaticSSHArchitectureResolvedTransportPreserved(t *testing.T) {
 		resolved.FallbackPorts = []string{}
 		return nil
 	}
-	runArchitectureProbe = func(_ context.Context, target SSHTarget, _ string, _ int) (string, error) {
+	runArchitectureProbe = func(_ context.Context, target core.SSHTarget, _ string, _ int) (string, error) {
 		if !reflect.DeepEqual(target, resolved) {
 			t.Fatalf("probe changed resolved transport: %#v", target)
 		}
 		return "v1|arm64|-|-|-", nil
 	}
-	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -470,14 +479,14 @@ func TestStaticSSHArchitectureResolvedTransportPreserved(t *testing.T) {
 func TestStaticSSHArchitectureFreshAcquireClaimRace(t *testing.T) {
 	b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
 	var replacement core.LeaseClaim
-	runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) {
+	runArchitectureProbe = func(context.Context, core.SSHTarget, string, int) (string, error) {
 		if err := core.ClaimLeaseForRepoProvider(b.Cfg.Static.ID, "concurrent-claim", "ssh", repo, 0, false); err != nil {
 			t.Fatal(err)
 		}
 		replacement, _, _ = core.ReadLeaseClaimWithPresence(b.Cfg.Static.ID)
 		return "v1|arm64|-|-|-", nil
 	}
-	if _, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}}); err == nil || !strings.Contains(err.Error(), "claim changed") {
+	if _, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}}); err == nil || !strings.Contains(err.Error(), "claim changed") {
 		t.Fatalf("err=%v", err)
 	}
 	after, _, _ := core.ReadLeaseClaimWithPresence(b.Cfg.Static.ID)
@@ -488,16 +497,16 @@ func TestStaticSSHArchitectureFreshAcquireClaimRace(t *testing.T) {
 
 func TestStaticSSHArchitectureSuccessfulReacquirePreservesLifecycle(t *testing.T) {
 	b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
-	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	touched, err := b.Touch(context.Background(), TouchRequest{Lease: lease, State: "busy"})
+	touched, err := b.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "busy"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) { return "v1|amd64|-|-|-", nil }
-	fresh, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	runArchitectureProbe = func(context.Context, core.SSHTarget, string, int) (string, error) { return "v1|amd64|-|-|-", nil }
+	fresh, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: repo}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -566,7 +575,7 @@ func TestStaticSSHArchitectureLegacyConfigMigration(t *testing.T) {
 		}
 	}
 	probes := 0
-	runArchitectureProbe = func(_ context.Context, target SSHTarget, _ string, _ int) (string, error) {
+	runArchitectureProbe = func(_ context.Context, target core.SSHTarget, _ string, _ int) (string, error) {
 		probes++
 		if target.Host != "build.example.test" || target.User != "builder" || target.Port != "2207" || target.TargetOS != "linux" {
 			t.Fatalf("migration changed the resolved SSH identity: %#v", target)
@@ -653,8 +662,11 @@ func TestStaticSSHArchitectureDestinationApprovalPrecedesProbe(t *testing.T) {
 	t.Setenv("CRABBOX_CONFIG", path)
 	t.Setenv("CRABBOX_PROVIDER", "ssh")
 	calls := 0
-	waitForSSH = func(context.Context, *SSHTarget, io.Writer) error { calls++; return errors.New("unexpected readiness") }
-	runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) {
+	waitForSSH = func(context.Context, *core.SSHTarget, io.Writer) error {
+		calls++
+		return errors.New("unexpected readiness")
+	}
+	runArchitectureProbe = func(context.Context, core.SSHTarget, string, int) (string, error) {
 		calls++
 		return "", errors.New("unexpected probe")
 	}
@@ -672,7 +684,7 @@ func TestStaticSSHArchitecturePreparedWindowsModeOverride(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: root}})
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: root}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -684,7 +696,7 @@ func TestStaticSSHArchitecturePreparedWindowsModeOverride(t *testing.T) {
 	t.Setenv("CRABBOX_PROVIDER", "ssh")
 	sentinel := errors.New("native Windows probe selected")
 	calls := 0
-	runArchitectureProbe = func(_ context.Context, target SSHTarget, command string, _ int) (string, error) {
+	runArchitectureProbe = func(_ context.Context, target core.SSHTarget, command string, _ int) (string, error) {
 		calls++
 		if target.TargetOS != "windows" || target.WindowsMode != "normal" || !strings.Contains(command, "IsWow64Process2") {
 			t.Fatalf("mode override ignored: target=%#v", target)

--- a/internal/providers/ssh/backend.go
+++ b/internal/providers/ssh/backend.go
@@ -12,63 +12,48 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-type Config = core.Config
-type Runtime = core.Runtime
-type ProviderSpec = core.ProviderSpec
-type Backend = core.Backend
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type CleanupRequest = core.CleanupRequest
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-
 type staticLeaseBackend struct {
 	shared.DirectSSHBackend
 	mu            sync.Mutex
-	acquired      LeaseTarget
+	acquired      core.LeaseTarget
 	acquiredRoute string
 }
 
 const staticProvider = "ssh"
 
-func NewStaticSSHLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+func NewStaticSSHLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	cfg.Provider = "ssh"
 	return &staticLeaseBackend{DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt}}
 }
 
-func (b *staticLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+func (b *staticLeaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
 	cfg := b.Cfg
 	if req.RequestedSlug != "" {
-		_, _, leaseID, err := staticLease(cfg)
+		_, _, leaseID, err := core.StaticLease(cfg)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
-		slug, err := allocateClaimLeaseSlug(leaseID, req.RequestedSlug)
+		slug, err := core.AllocateClaimLeaseSlug(leaseID, req.RequestedSlug)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		cfg.Static.Name = slug
 	}
-	server, target, leaseID, err := staticLease(cfg)
+	server, target, leaseID, err := core.StaticLease(cfg)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	expected, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if exists {
 		if err := core.VerifyLeaseClaimUnchanged(leaseID, expected); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		if req.Repo.Root != "" {
 			if err := core.CheckLeaseClaimRepositoryOwner(leaseID, expected, req.Repo.Root, req.Reclaim); err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 		}
 	}
@@ -86,36 +71,36 @@ func (b *staticLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 			server.Status = state
 		}
 	}
-	fmt.Fprintf(b.RT.Stderr, "using static target lease=%s slug=%s target=%s windows_mode=%s host=%s keep=%v\n", leaseID, serverSlug(server), b.Cfg.TargetOS, b.Cfg.WindowsMode, target.Host, req.Keep)
+	fmt.Fprintf(b.RT.Stderr, "using static target lease=%s slug=%s target=%s windows_mode=%s host=%s keep=%v\n", leaseID, core.ServerSlug(server), b.Cfg.TargetOS, b.Cfg.WindowsMode, target.Host, req.Keep)
 	route := architectureEndpoint(target)
 	if err := waitForSSH(ctx, &target, b.RT.Stderr); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	lease := LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
+	lease := core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
 	if err := b.observeArchitecture(ctx, &lease); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	lease.Server.Labels["architecture_route"] = route
 	if !exists {
 		lease.Server.Labels["state"] = "ready"
 	}
-	claim, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, serverSlug(lease.Server), cfg, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, expected, exists)
+	claim, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, core.ServerSlug(lease.Server), cfg, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, expected, exists)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if claim.LeaseID != "" {
 		core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
 	} else if req.Repo.Root != "" {
-		return LeaseTarget{}, exit(4, "static lease %s claim changed after acquisition", leaseID)
+		return core.LeaseTarget{}, core.Exit(4, "static lease %s claim changed after acquisition", leaseID)
 	}
 	b.rememberAcquiredLease(lease)
 	return lease, nil
 }
 
-func (b *staticLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *staticLeaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	lease, err := b.resolveOffline(req)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if !req.Prepare {
 		b.reportHistoricalArchitecture(lease.Server)
@@ -124,24 +109,24 @@ func (b *staticLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (L
 	expected, exists, set := core.ServerLeaseClaimSnapshot(lease.Server)
 	if set && exists {
 		if err := validateStaticTouchIdentity(b.Cfg, lease, expected); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	} else if !set && req.Repo.Root != "" {
 		// Endpoint overrides can hide a known claim from target selection, but
 		// cannot bypass its ID's owner. Do not attach it as endpoint identity.
 		expected, exists, err = core.ReadLeaseClaimWithPresence(lease.LeaseID)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	if exists {
 		// Cached ownership must still match disk before any credentialed SSH.
 		if err := core.VerifyLeaseClaimUnchanged(lease.LeaseID, expected); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		if req.Repo.Root != "" {
 			if err := core.CheckLeaseClaimRepositoryOwner(lease.LeaseID, expected, req.Repo.Root, req.Reclaim); err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 		}
 	}
@@ -151,15 +136,15 @@ func (b *staticLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (L
 		route = lease.Server.Labels["architecture_route"]
 	}
 	if err := waitForSSH(ctx, &lease.SSH, b.RT.Stderr); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if err := b.observeArchitecture(ctx, &lease); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	lease.Server.Labels["architecture_route"] = route
 	if exists {
 		if err := core.VerifyLeaseClaimUnchanged(lease.LeaseID, expected); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	// Run/pond own claim publication after resolution. Keep fresh evidence in
@@ -168,45 +153,45 @@ func (b *staticLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (L
 	return lease, nil
 }
 
-func (b *staticLeaseBackend) resolveOffline(req ResolveRequest) (LeaseTarget, error) {
+func (b *staticLeaseBackend) resolveOffline(req core.ResolveRequest) (core.LeaseTarget, error) {
 	if lease, ok := b.acquiredLeaseForID(req.ID); ok {
 		return lease, nil
 	}
 	if claim, ok, err := staticLeaseClaimForID(b.Cfg, req.ID); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	} else if ok {
 		server, target, leaseID, err := staticLeaseFromClaim(b.Cfg, claim)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
-		return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+		return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 	}
-	server, target, leaseID, err := staticLease(b.Cfg)
+	server, target, leaseID, err := core.StaticLease(b.Cfg)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
-	if req.ID == "" || req.ID == leaseID || req.ID == server.Name || req.ID == serverSlug(server) || req.ID == b.Cfg.Static.Host {
+	if req.ID == "" || req.ID == leaseID || req.ID == server.Name || req.ID == core.ServerSlug(server) || req.ID == b.Cfg.Static.Host {
 		if claim, ok, err := staticLeaseClaimForConfig(b.Cfg); err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		} else if ok {
 			server, target, leaseID, err := staticLeaseFromClaim(b.Cfg, claim)
 			if err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
-			return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+			return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 		}
 	}
-	if req.ID == "" || req.ID == leaseID || req.ID == server.Name || req.ID == serverSlug(server) || req.ID == b.Cfg.Static.Host {
-		return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+	if req.ID == "" || req.ID == leaseID || req.ID == server.Name || req.ID == core.ServerSlug(server) || req.ID == b.Cfg.Static.Host {
+		return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 	}
-	return LeaseTarget{}, exit(4, "static lease not found: %s", req.ID)
+	return core.LeaseTarget{}, core.Exit(4, "static lease not found: %s", req.ID)
 }
 
-func (b *staticLeaseBackend) List(_ context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *staticLeaseBackend) List(_ context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	if lease, ok := b.acquiredLeaseView(); ok {
 		b.reportHistoricalArchitecture(lease.Server)
-		return []LeaseView{lease.Server}, nil
+		return []core.LeaseView{lease.Server}, nil
 	}
 	if claim, ok, err := staticLeaseClaimForConfig(b.Cfg); err != nil {
 		return nil, err
@@ -216,19 +201,19 @@ func (b *staticLeaseBackend) List(_ context.Context, req ListRequest) ([]LeaseVi
 			return nil, err
 		}
 		b.reportHistoricalArchitecture(server)
-		return []LeaseView{server}, nil
+		return []core.LeaseView{server}, nil
 	}
-	server, _, _, err := staticLease(b.Cfg)
+	server, _, _, err := core.StaticLease(b.Cfg)
 	if err != nil {
 		return nil, err
 	}
 	b.reportHistoricalArchitecture(server)
-	return []LeaseView{server}, nil
+	return []core.LeaseView{server}, nil
 }
 
 func (b *staticLeaseBackend) Doctor(ctx context.Context, req core.DoctorRequest) (core.DoctorResult, error) {
 	if b.Cfg.Static.Host == "" {
-		return core.DoctorResult{}, exit(3, "missing static.host")
+		return core.DoctorResult{}, core.Exit(3, "missing static.host")
 	}
 	wsl2 := b.Cfg.TargetOS == core.TargetWindows && b.Cfg.WindowsMode == "wsl2"
 	if wsl2 && !req.ProbeSSH {
@@ -237,7 +222,7 @@ func (b *staticLeaseBackend) Doctor(ctx context.Context, req core.DoctorRequest)
 	runtime := "unchecked"
 	api := "static_config"
 	if req.ProbeSSH {
-		_, target, _, err := staticLease(b.Cfg)
+		_, target, _, err := core.StaticLease(b.Cfg)
 		if err != nil {
 			return core.DoctorResult{}, err
 		}
@@ -259,22 +244,22 @@ func (b *staticLeaseBackend) Doctor(ctx context.Context, req core.DoctorRequest)
 	}, nil
 }
 
-func (b *staticLeaseBackend) ReleaseLease(_ context.Context, req ReleaseLeaseRequest) error {
-	removeLeaseClaim(req.Lease.LeaseID)
+func (b *staticLeaseBackend) ReleaseLease(_ context.Context, req core.ReleaseLeaseRequest) error {
+	core.RemoveLeaseClaim(req.Lease.LeaseID)
 	b.clearAcquiredLease(req.Lease.LeaseID)
 	return nil
 }
 
 func (b *staticLeaseBackend) PreservesSSHWorkspaceAfterRelease() bool { return true }
 
-func (b *staticLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
+func (b *staticLeaseBackend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 	return fmt.Sprintf("released static lease=%s host=%s", lease.LeaseID, lease.SSH.Host)
 }
 
-func (b *staticLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
+func (b *staticLeaseBackend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
 	updated, err := shared.CommitClaimTouch(ctx, req, shared.ClaimTouchPolicy{
 		Provider: "static",
-		Authorize: func(_ context.Context, lease LeaseTarget, claim core.LeaseClaim) error {
+		Authorize: func(_ context.Context, lease core.LeaseTarget, claim core.LeaseClaim) error {
 			return validateStaticTouchIdentity(b.Cfg, lease, claim)
 		},
 		Prepare: func(expected core.LeaseClaim) (map[string]string, time.Time) {
@@ -291,7 +276,7 @@ func (b *staticLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Serve
 		},
 	})
 	if err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	server := req.Lease.Server
 	server.Labels = updated.Labels
@@ -305,26 +290,23 @@ func (b *staticLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Serve
 	return server, nil
 }
 
-func (b *staticLeaseBackend) Cleanup(context.Context, CleanupRequest) error {
-	return exit(2, "machine cleanup is not supported for provider=%s", b.Cfg.Provider)
+func (b *staticLeaseBackend) Cleanup(context.Context, core.CleanupRequest) error {
+	return core.Exit(2, "machine cleanup is not supported for provider=%s", b.Cfg.Provider)
 }
-
-func staticLease(cfg Config) (Server, SSHTarget, string, error) { return core.StaticLease(cfg) }
-func serverSlug(server Server) string                           { return core.ServerSlug(server) }
 
 var waitForSSH = core.WaitForSSH
 var waitForSSHReady = core.WaitForSSHReady
 var isWSLSFTPUnavailable = core.IsWSLSFTPUnavailable
 
-func (b *staticLeaseBackend) rememberAcquiredLease(lease LeaseTarget) {
+func (b *staticLeaseBackend) rememberAcquiredLease(lease core.LeaseTarget) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.acquired = lease
-	_, configured, _, _ := staticLease(b.Cfg)
+	_, configured, _, _ := core.StaticLease(b.Cfg)
 	b.acquiredRoute = architectureEndpoint(configured)
 }
 
-func (b *staticLeaseBackend) refreshAcquiredLeaseServer(leaseID string, server Server) {
+func (b *staticLeaseBackend) refreshAcquiredLeaseServer(leaseID string, server core.Server) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.acquired.LeaseID == leaseID {
@@ -332,24 +314,24 @@ func (b *staticLeaseBackend) refreshAcquiredLeaseServer(leaseID string, server S
 	}
 }
 
-func (b *staticLeaseBackend) acquiredLeaseForID(id string) (LeaseTarget, bool) {
+func (b *staticLeaseBackend) acquiredLeaseForID(id string) (core.LeaseTarget, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	_, configured, _, _ := staticLease(b.Cfg)
+	_, configured, _, _ := core.StaticLease(b.Cfg)
 	if b.acquiredRoute != architectureEndpoint(configured) || !staticLeaseTargetMatchesID(b.acquired, id) {
-		return LeaseTarget{}, false
+		return core.LeaseTarget{}, false
 	}
 	lease := b.acquired
 	historicalArchitecture(&lease.Server, lease.SSH)
 	return lease, true
 }
 
-func (b *staticLeaseBackend) acquiredLeaseView() (LeaseTarget, bool) {
+func (b *staticLeaseBackend) acquiredLeaseView() (core.LeaseTarget, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	_, configured, _, _ := staticLease(b.Cfg)
+	_, configured, _, _ := core.StaticLease(b.Cfg)
 	if b.acquired.LeaseID == "" || b.acquiredRoute != architectureEndpoint(configured) {
-		return LeaseTarget{}, false
+		return core.LeaseTarget{}, false
 	}
 	lease := b.acquired
 	historicalArchitecture(&lease.Server, lease.SSH)
@@ -360,16 +342,16 @@ func (b *staticLeaseBackend) clearAcquiredLease(leaseID string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.acquired.LeaseID == leaseID {
-		b.acquired = LeaseTarget{}
+		b.acquired = core.LeaseTarget{}
 	}
 }
 
-func staticLeaseTargetMatchesID(lease LeaseTarget, id string) bool {
-	return id != "" && lease.LeaseID != "" && (id == lease.LeaseID || id == lease.Server.Name || id == serverSlug(lease.Server) || id == lease.SSH.Host)
+func staticLeaseTargetMatchesID(lease core.LeaseTarget, id string) bool {
+	return id != "" && lease.LeaseID != "" && (id == lease.LeaseID || id == lease.Server.Name || id == core.ServerSlug(lease.Server) || id == lease.SSH.Host)
 }
 
-func staticLeaseClaimForID(cfg Config, id string) (core.LeaseClaim, bool, error) {
-	claim, ok, err := resolveLeaseClaimForProvider(id, staticProvider)
+func staticLeaseClaimForID(cfg core.Config, id string) (core.LeaseClaim, bool, error) {
+	claim, ok, err := core.ResolveLeaseClaimForProvider(id, staticProvider)
 	if err != nil || !ok {
 		return claim, ok, err
 	}
@@ -379,8 +361,8 @@ func staticLeaseClaimForID(cfg Config, id string) (core.LeaseClaim, bool, error)
 	return claim, true, nil
 }
 
-func staticLeaseClaimForConfig(cfg Config) (core.LeaseClaim, bool, error) {
-	_, _, leaseID, err := staticLease(cfg)
+func staticLeaseClaimForConfig(cfg core.Config) (core.LeaseClaim, bool, error) {
+	_, _, leaseID, err := core.StaticLease(cfg)
 	if err != nil {
 		return core.LeaseClaim{}, false, err
 	}
@@ -391,7 +373,7 @@ func staticLeaseClaimForConfig(cfg Config) (core.LeaseClaim, bool, error) {
 	return claim, true, nil
 }
 
-func staticLeaseFromClaim(cfg Config, claim core.LeaseClaim) (Server, SSHTarget, string, error) {
+func staticLeaseFromClaim(cfg core.Config, claim core.LeaseClaim) (core.Server, core.SSHTarget, string, error) {
 	if claim.LeaseID != "" {
 		cfg.Static.ID = claim.LeaseID
 	}
@@ -419,9 +401,9 @@ func staticLeaseFromClaim(cfg Config, claim core.LeaseClaim) (Server, SSHTarget,
 	if claim.IdleTimeoutSeconds > 0 {
 		cfg.IdleTimeout = time.Duration(claim.IdleTimeoutSeconds) * time.Second
 	}
-	server, target, leaseID, err := staticLease(cfg)
+	server, target, leaseID, err := core.StaticLease(cfg)
 	if err != nil {
-		return Server{}, SSHTarget{}, "", err
+		return core.Server{}, core.SSHTarget{}, "", err
 	}
 	server.Labels = staticLeaseLabelsFromClaim(claim)
 	server.Labels["target"] = target.TargetOS
@@ -474,44 +456,34 @@ func persistedClaimTimeLabel(value string) string {
 	return ""
 }
 
-func validateStaticTouchIdentity(cfg Config, lease LeaseTarget, claim core.LeaseClaim) error {
+func validateStaticTouchIdentity(cfg core.Config, lease core.LeaseTarget, claim core.LeaseClaim) error {
 	leaseID := strings.TrimSpace(lease.LeaseID)
 	if leaseID == "" || claim.LeaseID != leaseID {
-		return exit(4, "static lease claim ID mismatch: expected %s, found %s", leaseID, claim.LeaseID)
+		return core.Exit(4, "static lease claim ID mismatch: expected %s, found %s", leaseID, claim.LeaseID)
 	}
 	if claim.Provider != staticProvider || lease.Server.Provider != staticProvider || claim.Labels["provider"] != staticProvider {
-		return exit(4, "static lease %s provider identity mismatch", leaseID)
+		return core.Exit(4, "static lease %s provider identity mismatch", leaseID)
 	}
 	if claim.ProviderScope != core.ProviderClaimScope(staticProvider, cfg) {
-		return exit(4, "static lease %s provider scope mismatch", leaseID)
+		return core.Exit(4, "static lease %s provider scope mismatch", leaseID)
 	}
 	if claim.CloudID == "" || claim.CloudID != leaseID || lease.Server.CloudID != claim.CloudID || claim.Labels["lease"] != leaseID {
-		return exit(4, "static lease %s resource identity mismatch", leaseID)
+		return core.Exit(4, "static lease %s resource identity mismatch", leaseID)
 	}
 	host := strings.TrimSpace(claim.StaticHost)
 	if host == "" || strings.TrimSpace(cfg.Static.Host) != host || strings.TrimSpace(lease.SSH.Host) != host || strings.TrimSpace(lease.Server.PublicNet.IPv4.IP) != host {
-		return exit(4, "static lease %s host identity mismatch", leaseID)
+		return core.Exit(4, "static lease %s host identity mismatch", leaseID)
 	}
 	return nil
 }
 
-func staticLeaseClaimMatchesConfig(cfg Config, claim core.LeaseClaim) bool {
+func staticLeaseClaimMatchesConfig(cfg core.Config, claim core.LeaseClaim) bool {
 	if claim.StaticHost != "" && cfg.Static.Host != "" {
 		return claim.StaticHost == cfg.Static.Host
 	}
-	_, _, leaseID, err := staticLease(cfg)
+	_, _, leaseID, err := core.StaticLease(cfg)
 	if err == nil && claim.LeaseID == leaseID {
 		return true
 	}
 	return false
-}
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
-}
-func removeLeaseClaim(leaseID string) { core.RemoveLeaseClaim(leaseID) }
-func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
-	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-func resolveLeaseClaimForProvider(id, provider string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaimForProvider(id, provider)
 }

--- a/internal/providers/ssh/backend_doctor_test.go
+++ b/internal/providers/ssh/backend_doctor_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 func TestStaticSSHDoctorDoesNotReportProbeWhenUnchecked(t *testing.T) {
-	cfg := Config{}
+	cfg := core.Config{}
 	cfg.Static.Host = "example.test"
-	backend := NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard}).(*staticLeaseBackend)
+	backend := NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stderr: io.Discard}).(*staticLeaseBackend)
 
 	result, err := backend.Doctor(context.Background(), core.DoctorRequest{})
 	if err != nil {
@@ -30,7 +30,7 @@ func TestStaticSSHDoctorDoesNotReportProbeWhenUnchecked(t *testing.T) {
 }
 
 func TestStaticSSHDoctorReportsWSL2SFTPPrerequisite(t *testing.T) {
-	cfg := Config{Provider: "ssh"}
+	cfg := core.Config{Provider: "ssh"}
 	cfg.TargetOS = core.TargetWindows
 	cfg.WindowsMode = "wsl2"
 	cfg.Static.Host = "example.test"
@@ -41,7 +41,7 @@ func TestStaticSSHDoctorReportsWSL2SFTPPrerequisite(t *testing.T) {
 		isWSLSFTPUnavailable = oldIsUnavailable
 	})
 
-	backend := NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard}).(*staticLeaseBackend)
+	backend := NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stderr: io.Discard}).(*staticLeaseBackend)
 	result, err := backend.Doctor(t.Context(), core.DoctorRequest{})
 	if err != nil || len(result.Checks) != 1 || result.Checks[0].Check != "wsl2-sftp" || result.Checks[0].Status != "skip" ||
 		!strings.Contains(result.Checks[0].Message, "runtime=unchecked transport=sftp_required mutation=false") ||
@@ -50,7 +50,7 @@ func TestStaticSSHDoctorReportsWSL2SFTPPrerequisite(t *testing.T) {
 	}
 
 	var readyCheck string
-	waitForSSHReady = func(_ context.Context, target *SSHTarget, _ io.Writer, _ string, _ time.Duration) error {
+	waitForSSHReady = func(_ context.Context, target *core.SSHTarget, _ io.Writer, _ string, _ time.Duration) error {
 		readyCheck = target.ReadyCheck
 		return nil
 	}
@@ -65,7 +65,7 @@ func TestStaticSSHDoctorReportsWSL2SFTPPrerequisite(t *testing.T) {
 
 	missingSFTP := errors.New("missing SFTP")
 	isWSLSFTPUnavailable = func(err error) bool { return errors.Is(err, missingSFTP) }
-	waitForSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+	waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
 		return fmt.Errorf("wrapped: %w", missingSFTP)
 	}
 	result, err = backend.Doctor(t.Context(), core.DoctorRequest{ProbeSSH: true})
@@ -74,7 +74,7 @@ func TestStaticSSHDoctorReportsWSL2SFTPPrerequisite(t *testing.T) {
 	}
 
 	toolErr := errors.New("remote git missing")
-	waitForSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error { return toolErr }
+	waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return toolErr }
 	if _, err = backend.Doctor(t.Context(), core.DoctorRequest{ProbeSSH: true}); !errors.Is(err, toolErr) {
 		t.Fatalf("tool failure=%v, want unchanged %v", err, toolErr)
 	}
@@ -86,10 +86,10 @@ func TestStaticSSHRequestedSlugPersistsThroughClaimedResolveAndList(t *testing.T
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	oldWait := waitForSSH
-	waitForSSH = func(context.Context, *SSHTarget, io.Writer) error { return nil }
+	waitForSSH = func(context.Context, *core.SSHTarget, io.Writer) error { return nil }
 	t.Cleanup(func() { waitForSSH = oldWait })
 
-	cfg := Config{Provider: "ssh"}
+	cfg := core.Config{Provider: "ssh"}
 	cfg.TargetOS = "macos"
 	cfg.SSHUser = "fallback-user"
 	cfg.SSHPort = "2222"
@@ -97,16 +97,16 @@ func TestStaticSSHRequestedSlugPersistsThroughClaimedResolveAndList(t *testing.T
 	cfg.Static.ID = "static_stable"
 	cfg.Static.Name = "configured-name"
 	cfg.Static.WorkRoot = "/workspace/static"
-	backend := NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard}).(*staticLeaseBackend)
-	lease, err := backend.Acquire(context.Background(), AcquireRequest{
+	backend := NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stderr: io.Discard}).(*staticLeaseBackend)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{
 		Repo:          core.Repo{Root: t.TempDir()},
 		RequestedSlug: "requested-name",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if lease.Server.Name != "requested-name" || serverSlug(lease.Server) != "requested-name" {
-		t.Fatalf("acquired name=%q slug=%q, want requested-name", lease.Server.Name, serverSlug(lease.Server))
+	if lease.Server.Name != "requested-name" || core.ServerSlug(lease.Server) != "requested-name" {
+		t.Fatalf("acquired name=%q slug=%q, want requested-name", lease.Server.Name, core.ServerSlug(lease.Server))
 	}
 	claim, ok, err := core.ResolveLeaseClaim(lease.LeaseID)
 	if err != nil || !ok {
@@ -116,32 +116,32 @@ func TestStaticSSHRequestedSlugPersistsThroughClaimedResolveAndList(t *testing.T
 		t.Fatalf("claim did not persist static target details: %#v", claim)
 	}
 
-	backend = NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard}).(*staticLeaseBackend)
-	views, err := backend.List(context.Background(), ListRequest{})
+	backend = NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stderr: io.Discard}).(*staticLeaseBackend)
+	views, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(views) != 1 || views[0].Name != "requested-name" || serverSlug(views[0]) != "requested-name" {
+	if len(views) != 1 || views[0].Name != "requested-name" || core.ServerSlug(views[0]) != "requested-name" {
 		t.Fatalf("views=%#v, want requested-name from persisted claim", views)
 	}
-	defaultLease, err := backend.Resolve(context.Background(), ResolveRequest{})
+	defaultLease, err := backend.Resolve(context.Background(), core.ResolveRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if defaultLease.Server.Name != "requested-name" || serverSlug(defaultLease.Server) != "requested-name" {
+	if defaultLease.Server.Name != "requested-name" || core.ServerSlug(defaultLease.Server) != "requested-name" {
 		t.Fatalf("default resolve server=%#v, want requested-name", defaultLease.Server)
 	}
-	byID, err := backend.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+	byID, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if byID.Server.Name != "requested-name" || serverSlug(byID.Server) != "requested-name" {
+	if byID.Server.Name != "requested-name" || core.ServerSlug(byID.Server) != "requested-name" {
 		t.Fatalf("resolve by id server=%#v, want requested-name", byID.Server)
 	}
 	if byID.SSH.Host != "static.example.test" || byID.SSH.User != "fallback-user" || byID.SSH.Port != "2222" {
 		t.Fatalf("resolve by id ssh=%#v, want original claimed static target", byID.SSH)
 	}
-	bySlug, err := backend.Resolve(context.Background(), ResolveRequest{ID: "requested-name"})
+	bySlug, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "requested-name"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,8 +152,8 @@ func TestStaticSSHRequestedSlugPersistsThroughClaimedResolveAndList(t *testing.T
 	overrideCfg := cfg
 	overrideCfg.SSHUser = "override-user"
 	overrideCfg.SSHPort = "2200"
-	backend = NewStaticSSHLeaseBackend(Provider{}.Spec(), overrideCfg, Runtime{Stderr: io.Discard}).(*staticLeaseBackend)
-	override, err := backend.Resolve(context.Background(), ResolveRequest{ID: "requested-name"})
+	backend = NewStaticSSHLeaseBackend(Provider{}.Spec(), overrideCfg, core.Runtime{Stderr: io.Discard}).(*staticLeaseBackend)
+	override, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "requested-name"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,23 +168,23 @@ func TestStaticSSHRequestedSlugAvoidsClaimCollision(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	oldWait := waitForSSH
-	waitForSSH = func(context.Context, *SSHTarget, io.Writer) error { return nil }
+	waitForSSH = func(context.Context, *core.SSHTarget, io.Writer) error { return nil }
 	t.Cleanup(func() { waitForSSH = oldWait })
 	if err := core.ClaimLeaseForRepoProvider("cbx_other123456", "requested-name", "aws", t.TempDir(), 0, false); err != nil {
 		t.Fatal(err)
 	}
 
-	cfg := Config{Provider: "ssh"}
+	cfg := core.Config{Provider: "ssh"}
 	cfg.Static.Host = "static.example.test"
-	backend := NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard}).(*staticLeaseBackend)
-	lease, err := backend.Acquire(context.Background(), AcquireRequest{
+	backend := NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stderr: io.Discard}).(*staticLeaseBackend)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{
 		Repo:          core.Repo{Root: t.TempDir()},
 		RequestedSlug: "requested-name",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	slug := serverSlug(lease.Server)
+	slug := core.ServerSlug(lease.Server)
 	if slug == "requested-name" || !strings.HasPrefix(slug, "requested-name-") {
 		t.Fatalf("slug=%q, want collision-suffixed requested-name", slug)
 	}

--- a/internal/providers/ssh/backend_lifecycle_test.go
+++ b/internal/providers/ssh/backend_lifecycle_test.go
@@ -24,7 +24,7 @@ func TestStaticSSHTouchPersistsExplicitIdleTimeoutForFreshResolve(t *testing.T) 
 	touchedAt := unixLabelTime(t, initialTouchedAt).Add(2 * time.Minute)
 
 	backend := newStaticLifecycleBackend(cfg, touchedAt)
-	resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: initial.Slug})
+	resolved, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: initial.Slug})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func TestStaticSSHTouchPersistsExplicitIdleTimeoutForFreshResolve(t *testing.T) 
 	}
 
 	override := 45 * time.Minute
-	touched, err := backend.Touch(context.Background(), TouchRequest{
+	touched, err := backend.Touch(context.Background(), core.TouchRequest{
 		Lease:               resolved,
 		State:               "busy",
 		IdleTimeout:         override,
@@ -74,7 +74,7 @@ func TestStaticSSHTouchPersistsExplicitIdleTimeoutForFreshResolve(t *testing.T) 
 
 	freshCfg := cfg
 	freshCfg.IdleTimeout = 7 * time.Minute
-	fresh, err := newStaticLifecycleBackend(freshCfg, touchedAt.Add(time.Minute)).Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+	fresh, err := newStaticLifecycleBackend(freshCfg, touchedAt.Add(time.Minute)).Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestStaticSSHTouchRefreshesAcquiredLeaseCache(t *testing.T) {
 	backend.rememberAcquiredLease(lease)
 
 	override := 45 * time.Minute
-	touched, err := backend.Touch(context.Background(), TouchRequest{
+	touched, err := backend.Touch(context.Background(), core.TouchRequest{
 		Lease:               lease,
 		State:               "busy",
 		IdleTimeoutOverride: &override,
@@ -102,14 +102,14 @@ func TestStaticSSHTouchRefreshesAcquiredLeaseCache(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+	resolved, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if resolved.Server.Labels["idle_timeout_secs"] != "2700" || !reflect.DeepEqual(resolved.Server.Labels, touched.Labels) {
 		t.Fatalf("cached resolve did not observe touch: resolved=%#v touched=%#v", resolved.Server.Labels, touched.Labels)
 	}
-	listed, err := backend.List(context.Background(), ListRequest{})
+	listed, err := backend.List(context.Background(), core.ListRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +118,7 @@ func TestStaticSSHTouchRefreshesAcquiredLeaseCache(t *testing.T) {
 	}
 
 	backend.RT.Clock = staticLifecycleClock{now: touchedAt.Add(time.Minute)}
-	if _, err := backend.Touch(context.Background(), TouchRequest{Lease: resolved, State: "ready"}); err != nil {
+	if _, err := backend.Touch(context.Background(), core.TouchRequest{Lease: resolved, State: "ready"}); err != nil {
 		t.Fatalf("touch using cached refreshed snapshot: %v", err)
 	}
 }
@@ -129,11 +129,11 @@ func TestStaticSSHTouchWithoutOverridePreservesPersistedIdleTimeout(t *testing.T
 	backendCfg := cfg
 	backendCfg.IdleTimeout = 5 * time.Minute
 	backend := newStaticLifecycleBackend(backendCfg, touchedAt)
-	resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+	resolved, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID})
 	if err != nil {
 		t.Fatal(err)
 	}
-	touched, err := backend.Touch(context.Background(), TouchRequest{
+	touched, err := backend.Touch(context.Background(), core.TouchRequest{
 		Lease:       resolved,
 		State:       "ready",
 		IdleTimeout: 5 * time.Minute,
@@ -148,7 +148,7 @@ func TestStaticSSHTouchWithoutOverridePreservesPersistedIdleTimeout(t *testing.T
 	if committed.IdleTimeoutSeconds != 2220 || touched.Labels["idle_timeout_secs"] != "2220" {
 		t.Fatalf("omitted override replaced timeout: response=%q claim=%d", touched.Labels["idle_timeout_secs"], committed.IdleTimeoutSeconds)
 	}
-	fresh, err := newStaticLifecycleBackend(backendCfg, touchedAt.Add(time.Minute)).Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+	fresh, err := newStaticLifecycleBackend(backendCfg, touchedAt.Add(time.Minute)).Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,11 +160,11 @@ func TestStaticSSHTouchWithoutOverridePreservesPersistedIdleTimeout(t *testing.T
 func TestStaticSSHTouchRejectsMismatchedIdentity(t *testing.T) {
 	for _, test := range []struct {
 		name   string
-		mutate func(*testing.T, *LeaseTarget)
+		mutate func(*testing.T, *core.LeaseTarget)
 	}{
-		{name: "canonical lease ID", mutate: func(_ *testing.T, lease *LeaseTarget) { lease.LeaseID = lease.Server.Labels["slug"] }},
-		{name: "provider", mutate: func(_ *testing.T, lease *LeaseTarget) { lease.Server.Provider = "aws" }},
-		{name: "scope", mutate: func(t *testing.T, lease *LeaseTarget) {
+		{name: "canonical lease ID", mutate: func(_ *testing.T, lease *core.LeaseTarget) { lease.LeaseID = lease.Server.Labels["slug"] }},
+		{name: "provider", mutate: func(_ *testing.T, lease *core.LeaseTarget) { lease.Server.Provider = "aws" }},
+		{name: "scope", mutate: func(t *testing.T, lease *core.LeaseTarget) {
 			claim, exists, set := core.ServerLeaseClaimSnapshot(lease.Server)
 			if !exists || !set {
 				t.Fatal("resolved lease has no claim snapshot")
@@ -172,18 +172,18 @@ func TestStaticSSHTouchRejectsMismatchedIdentity(t *testing.T) {
 			claim.ProviderScope = "other-scope"
 			core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
 		}},
-		{name: "resource", mutate: func(_ *testing.T, lease *LeaseTarget) { lease.Server.CloudID = "static_replacement" }},
-		{name: "host", mutate: func(_ *testing.T, lease *LeaseTarget) { lease.SSH.Host = "replacement.example.test" }},
+		{name: "resource", mutate: func(_ *testing.T, lease *core.LeaseTarget) { lease.Server.CloudID = "static_replacement" }},
+		{name: "host", mutate: func(_ *testing.T, lease *core.LeaseTarget) { lease.SSH.Host = "replacement.example.test" }},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			cfg, lease, initial := acquireStaticLifecycleLease(t, 30*time.Minute)
 			backend := newStaticLifecycleBackend(cfg, unixLabelTime(t, initial.Labels["last_touched_at"]).Add(time.Minute))
-			resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+			resolved, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID})
 			if err != nil {
 				t.Fatal(err)
 			}
 			test.mutate(t, &resolved)
-			if _, err := backend.Touch(context.Background(), TouchRequest{Lease: resolved, State: "ready"}); err == nil || !strings.Contains(err.Error(), "mismatch") {
+			if _, err := backend.Touch(context.Background(), core.TouchRequest{Lease: resolved, State: "ready"}); err == nil || !strings.Contains(err.Error(), "mismatch") {
 				t.Fatalf("touch error=%v want identity mismatch", err)
 			}
 			after, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
@@ -197,7 +197,7 @@ func TestStaticSSHTouchRejectsMismatchedIdentity(t *testing.T) {
 func TestStaticSSHTouchRejectsConcurrentClaimReplacement(t *testing.T) {
 	cfg, lease, initial := acquireStaticLifecycleLease(t, 30*time.Minute)
 	backend := newStaticLifecycleBackend(cfg, unixLabelTime(t, initial.Labels["last_touched_at"]).Add(time.Minute))
-	resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+	resolved, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,7 +211,7 @@ func TestStaticSSHTouchRejectsConcurrentClaimReplacement(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := backend.Touch(context.Background(), TouchRequest{Lease: resolved, State: "ready"}); err == nil || !strings.Contains(err.Error(), "claim changed") {
+	if _, err := backend.Touch(context.Background(), core.TouchRequest{Lease: resolved, State: "ready"}); err == nil || !strings.Contains(err.Error(), "claim changed") {
 		t.Fatalf("touch error=%v want claim changed", err)
 	}
 	after, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
@@ -223,7 +223,7 @@ func TestStaticSSHTouchRejectsConcurrentClaimReplacement(t *testing.T) {
 func TestStaticSSHProviderReplacementFailsClosed(t *testing.T) {
 	cfg, lease, initial := acquireStaticLifecycleLease(t, 30*time.Minute)
 	backend := newStaticLifecycleBackend(cfg, unixLabelTime(t, initial.Labels["last_touched_at"]).Add(time.Minute))
-	resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+	resolved, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +245,7 @@ func TestStaticSSHProviderReplacementFailsClosed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := backend.Touch(context.Background(), TouchRequest{Lease: resolved, State: "ready"}); err == nil || !strings.Contains(err.Error(), "claim changed") {
+	if _, err := backend.Touch(context.Background(), core.TouchRequest{Lease: resolved, State: "ready"}); err == nil || !strings.Contains(err.Error(), "claim changed") {
 		t.Fatalf("touch error=%v want claim changed", err)
 	}
 	after, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
@@ -254,7 +254,7 @@ func TestStaticSSHProviderReplacementFailsClosed(t *testing.T) {
 	}
 
 	fresh := newStaticLifecycleBackend(cfg, time.Now().UTC())
-	unclaimed, err := fresh.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+	unclaimed, err := fresh.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,13 +266,13 @@ func TestStaticSSHProviderReplacementFailsClosed(t *testing.T) {
 func TestStaticSSHTouchDoesNotRecreateRacedAwayClaim(t *testing.T) {
 	cfg, lease, initial := acquireStaticLifecycleLease(t, 30*time.Minute)
 	backend := newStaticLifecycleBackend(cfg, unixLabelTime(t, initial.Labels["last_touched_at"]).Add(time.Minute))
-	resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+	resolved, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID})
 	if err != nil {
 		t.Fatal(err)
 	}
 	core.RemoveLeaseClaim(lease.LeaseID)
 
-	if _, err := backend.Touch(context.Background(), TouchRequest{Lease: resolved, State: "ready"}); err == nil || !strings.Contains(err.Error(), "claim changed") {
+	if _, err := backend.Touch(context.Background(), core.TouchRequest{Lease: resolved, State: "ready"}); err == nil || !strings.Contains(err.Error(), "claim changed") {
 		t.Fatalf("touch error=%v want claim changed", err)
 	}
 	if claim, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID); err != nil || exists {
@@ -280,13 +280,13 @@ func TestStaticSSHTouchDoesNotRecreateRacedAwayClaim(t *testing.T) {
 	}
 }
 
-func acquireStaticLifecycleLease(t *testing.T, idleTimeout time.Duration) (Config, LeaseTarget, core.LeaseClaim) {
+func acquireStaticLifecycleLease(t *testing.T, idleTimeout time.Duration) (core.Config, core.LeaseTarget, core.LeaseClaim) {
 	t.Helper()
 	stubStaticArchitecture(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	oldWait := waitForSSH
-	waitForSSH = func(context.Context, *SSHTarget, io.Writer) error { return nil }
+	waitForSSH = func(context.Context, *core.SSHTarget, io.Writer) error { return nil }
 	t.Cleanup(func() { waitForSSH = oldWait })
 
 	cfg := core.BaseConfig()
@@ -296,8 +296,8 @@ func acquireStaticLifecycleLease(t *testing.T, idleTimeout time.Duration) (Confi
 	cfg.Static.ID = "static_heartbeat"
 	cfg.Static.Name = "heartbeat-static"
 	cfg.IdleTimeout = idleTimeout
-	backend := NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard}).(*staticLeaseBackend)
-	lease, err := backend.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true})
+	backend := NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stderr: io.Discard}).(*staticLeaseBackend)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -308,8 +308,8 @@ func acquireStaticLifecycleLease(t *testing.T, idleTimeout time.Duration) (Confi
 	return cfg, lease, claim
 }
 
-func newStaticLifecycleBackend(cfg Config, now time.Time) *staticLeaseBackend {
-	return NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard, Clock: staticLifecycleClock{now: now}}).(*staticLeaseBackend)
+func newStaticLifecycleBackend(cfg core.Config, now time.Time) *staticLeaseBackend {
+	return NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stderr: io.Discard, Clock: staticLifecycleClock{now: now}}).(*staticLeaseBackend)
 }
 
 func unixLabelTime(t *testing.T, value string) time.Time {

--- a/internal/providers/ssh/command_lifecycle_test.go
+++ b/internal/providers/ssh/command_lifecycle_test.go
@@ -104,7 +104,7 @@ func TestStaticSSHRunCommandReleasePolicy(t *testing.T) {
 }
 
 type staticCommandFixture struct {
-	cfg                    Config
+	cfg                    core.Config
 	repo, logPath, keyPath string
 	other                  core.LeaseClaim
 }
@@ -184,7 +184,7 @@ CRABBOX_STATIC_TEST_HELPER=1 exec "$CRABBOX_STATIC_TEST_BINARY" -test.run='^Test
 `, 0o700)
 	writeStaticCommandFile(t, filepath.Join(bin, "git"), "#!/bin/sh\nexit 1\n", 0o700)
 	oldWait := waitForSSH
-	waitForSSH = func(_ context.Context, target *SSHTarget, _ io.Writer) error {
+	waitForSSH = func(_ context.Context, target *core.SSHTarget, _ io.Writer) error {
 		// Core waits again after acquisition. Fake ssh alone does not prevent
 		// its direct TCP probe; this flag routes readiness through fake ssh too.
 		target.SSHConfigProxy = true
@@ -196,8 +196,8 @@ CRABBOX_STATIC_TEST_HELPER=1 exec "$CRABBOX_STATIC_TEST_BINARY" -test.run='^Test
 	otherCfg.Static.ID = "static_unrelated_fixture"
 	otherCfg.Static.Name = "unrelated-fixture"
 	otherCfg.Static.Host = "unrelated.invalid"
-	backend := NewStaticSSHLeaseBackend(Provider{}.Spec(), otherCfg, Runtime{Stderr: io.Discard})
-	if _, err := backend.(core.SSHLeaseBackend).Acquire(t.Context(), AcquireRequest{Repo: core.Repo{Root: f.repo}, Keep: true}); err != nil {
+	backend := NewStaticSSHLeaseBackend(Provider{}.Spec(), otherCfg, core.Runtime{Stderr: io.Discard})
+	if _, err := backend.(core.SSHLeaseBackend).Acquire(t.Context(), core.AcquireRequest{Repo: core.Repo{Root: f.repo}, Keep: true}); err != nil {
 		t.Fatal(err)
 	}
 	f.other = readStaticCommandClaim(t, otherCfg.Static.ID)
@@ -206,8 +206,8 @@ CRABBOX_STATIC_TEST_HELPER=1 exec "$CRABBOX_STATIC_TEST_BINARY" -test.run='^Test
 
 func (f staticCommandFixture) acquire(t *testing.T) core.LeaseClaim {
 	t.Helper()
-	backend := NewStaticSSHLeaseBackend(Provider{}.Spec(), f.cfg, Runtime{Stderr: io.Discard})
-	if _, err := backend.(core.SSHLeaseBackend).Acquire(t.Context(), AcquireRequest{Repo: core.Repo{Root: f.repo}, Keep: true}); err != nil {
+	backend := NewStaticSSHLeaseBackend(Provider{}.Spec(), f.cfg, core.Runtime{Stderr: io.Discard})
+	if _, err := backend.(core.SSHLeaseBackend).Acquire(t.Context(), core.AcquireRequest{Repo: core.Repo{Root: f.repo}, Keep: true}); err != nil {
 		t.Fatal(err)
 	}
 	return readStaticCommandClaim(t, f.cfg.Static.ID)

--- a/internal/providers/ssh/provider.go
+++ b/internal/providers/ssh/provider.go
@@ -13,7 +13,7 @@ func init() {
 
 type Provider struct{}
 
-func (Provider) SupportsArchitecture(cfg Config, architecture string) bool {
+func (Provider) SupportsArchitecture(cfg core.Config, architecture string) bool {
 	if architecture != core.ArchitectureAMD64 && architecture != core.ArchitectureARM64 {
 		return false
 	}

--- a/internal/providers/xcpng/backend.go
+++ b/internal/providers/xcpng/backend.go
@@ -12,27 +12,12 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-type Config = core.Config
-type Runtime = core.Runtime
-type ProviderSpec = core.ProviderSpec
-type Backend = core.Backend
-type AcquireRequest = core.AcquireRequest
-type ResolveRequest = core.ResolveRequest
-type ListRequest = core.ListRequest
-type LeaseView = core.LeaseView
-type ReleaseLeaseRequest = core.ReleaseLeaseRequest
-type TouchRequest = core.TouchRequest
-type CleanupRequest = core.CleanupRequest
-type LeaseTarget = core.LeaseTarget
-type Server = core.Server
-type SSHTarget = core.SSHTarget
-
 type leaseBackend struct{ shared.DirectSSHBackend }
 
 type lifecycleClient interface {
 	Close(context.Context) error
-	DoctorInventory(context.Context, xcpNgConfig) ([]Server, error)
-	ListCrabboxServers(context.Context) ([]Server, error)
+	DoctorInventory(context.Context, xcpNgConfig) ([]core.Server, error)
+	ListCrabboxServers(context.Context) ([]core.Server, error)
 	ResolveTemplate(context.Context, xcpNgConfig) (xapiRef, error)
 	ResolveSR(context.Context, xcpNgConfig) (xapiRef, error)
 	ResolveNetwork(context.Context, xcpNgConfig) (xapiRef, error)
@@ -48,7 +33,7 @@ type lifecycleClient interface {
 	StartVM(context.Context, xapiRef) error
 	GuestIPv4(context.Context, xapiRef) (string, error)
 	GuestIPv4ForID(context.Context, string) (string, error)
-	GetServer(context.Context, string) (Server, error)
+	GetServer(context.Context, string) (core.Server, error)
 	SetLabels(context.Context, string, map[string]string) error
 	DeleteServer(context.Context, string) error
 	DeleteFreshServer(context.Context, string, string) error
@@ -76,7 +61,7 @@ type xcpNgConfig struct {
 }
 
 type xcpNgCloneRequest struct {
-	Config      Config
+	Config      core.Config
 	TemplateRef xapiRef
 	SRRef       xapiRef
 	NetworkRef  xapiRef
@@ -119,36 +104,36 @@ func NewLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) c
 	return &leaseBackend{DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt, StoredLeaseKeys: true}}
 }
 
-func (b *leaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
-	return shared.AcquireAttemptsRetry(b.RT, req.Keep, func() (LeaseTarget, error) {
+func (b *leaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
+	return shared.AcquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
 		return b.acquireOnce(ctx, req)
 	})
 }
 
-func (b *leaseBackend) acquireOnce(ctx context.Context, req AcquireRequest) (lease LeaseTarget, err error) {
+func (b *leaseBackend) acquireOnce(ctx context.Context, req core.AcquireRequest) (lease core.LeaseTarget, err error) {
 	keep := req.Keep
 	if err := validateXCPNgProvisioningConfig(xcpNgProviderConfig(b.Cfg)); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	client, err := newLifecycleClient(ctx, b.Cfg)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	defer closeClient(ctx, client, b.RT.Stderr)
 
 	leaseID := newLeaseID()
 	servers, err := client.ListCrabboxServers(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	cfg := b.Cfg
 	keyPath, publicKey, err := ensureTestboxKeyForConfig(cfg, leaseID)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	retainKey := false
 	defer func() {
@@ -165,7 +150,7 @@ func (b *leaseBackend) acquireOnce(ctx context.Context, req AcquireRequest) (lea
 
 	resolved, err := b.resolvePlacement(ctx, client)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	fmt.Fprintf(b.RT.Stderr, "provisioning provider=xcp-ng lease=%s slug=%s template=%s keep=%v\n",
 		leaseID, slug, resolved.templateRef.value(), keep)
@@ -173,18 +158,18 @@ func (b *leaseBackend) acquireOnce(ctx context.Context, req AcquireRequest) (lea
 	if err != nil {
 		retainKey = server.CloudID != ""
 		if retainKey {
-			return LeaseTarget{}, fmt.Errorf("%w; retained xcp-ng VM requires manual cleanup: %s", err, server.CloudID)
+			return core.LeaseTarget{}, fmt.Errorf("%w; retained xcp-ng VM requires manual cleanup: %s", err, server.CloudID)
 		}
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	ip, err := b.waitForGuestIPv4(ctx, client, vmRef, bootstrapWaitTimeout(cfg))
 	if err != nil {
 		vmRetained, cleanupErr := b.cleanupFailedLease(ctx, client, server.CloudID, configDrive)
 		retainKey = vmRetained
 		if vmRetained {
-			return LeaseTarget{}, fmt.Errorf("xcp-ng VM retained after guest IP failure; manual cleanup required for %s: %v; cleanup: %v", server.CloudID, err, cleanupErr)
+			return core.LeaseTarget{}, fmt.Errorf("xcp-ng VM retained after guest IP failure; manual cleanup required for %s: %v; cleanup: %v", server.CloudID, err, cleanupErr)
 		}
-		return LeaseTarget{}, errors.Join(err, cleanupErr)
+		return core.LeaseTarget{}, errors.Join(err, cleanupErr)
 	}
 	server.PublicNet.IPv4.IP = ip
 	target := sshTargetFromConfig(cfg, ip)
@@ -192,9 +177,9 @@ func (b *leaseBackend) acquireOnce(ctx context.Context, req AcquireRequest) (lea
 		vmRetained, cleanupErr := b.cleanupFailedLease(ctx, client, server.CloudID, configDrive)
 		retainKey = vmRetained
 		if vmRetained {
-			return LeaseTarget{}, fmt.Errorf("xcp-ng VM retained after SSH bootstrap failure; manual cleanup required for %s: %v; cleanup: %v", server.CloudID, err, cleanupErr)
+			return core.LeaseTarget{}, fmt.Errorf("xcp-ng VM retained after SSH bootstrap failure; manual cleanup required for %s: %v; cleanup: %v", server.CloudID, err, cleanupErr)
 		}
-		return LeaseTarget{}, errors.Join(err, cleanupErr)
+		return core.LeaseTarget{}, errors.Join(err, cleanupErr)
 	}
 	server.Labels = core.TouchDirectLeaseLabels(server.Labels, cfg, "ready", currentTime(b.RT).UTC())
 	if err := client.SetLabels(ctx, server.CloudID, server.Labels); err != nil {
@@ -208,13 +193,13 @@ func (b *leaseBackend) acquireOnce(ctx context.Context, req AcquireRequest) (lea
 		vmRetained, cleanupErr := b.cleanupFailedLease(ctx, client, server.CloudID, configDrive)
 		retainKey = vmRetained
 		if vmRetained {
-			return LeaseTarget{}, fmt.Errorf("xcp-ng VM retained after ownership claim failure; manual cleanup required for %s: %v; cleanup: %v", server.CloudID, err, cleanupErr)
+			return core.LeaseTarget{}, fmt.Errorf("xcp-ng VM retained after ownership claim failure; manual cleanup required for %s: %v; cleanup: %v", server.CloudID, err, cleanupErr)
 		}
-		return LeaseTarget{}, errors.Join(fmt.Errorf("persist exact xcp-ng VM ownership claim: %w", err), cleanupErr)
+		return core.LeaseTarget{}, errors.Join(fmt.Errorf("persist exact xcp-ng VM ownership claim: %w", err), cleanupErr)
 	}
 	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s server=%s ip=%s\n", leaseID, server.DisplayID(), ip)
 	retainKey = true
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
 type xcpNgPlacement struct {
@@ -248,7 +233,7 @@ func (b *leaseBackend) resolvePlacement(ctx context.Context, client lifecycleCli
 	return xcpNgPlacement{templateRef: templateRef, srRef: srRef, networkRef: networkRef, hostRef: hostRef}, nil
 }
 
-func (b *leaseBackend) createAndBoot(ctx context.Context, client lifecycleClient, cfg Config, placement xcpNgPlacement, leaseID, slug, publicKey string, keep bool, labels map[string]string) (Server, xcpNgConfigDrive, xapiRef, error) {
+func (b *leaseBackend) createAndBoot(ctx context.Context, client lifecycleClient, cfg core.Config, placement xcpNgPlacement, leaseID, slug, publicKey string, keep bool, labels map[string]string) (core.Server, xcpNgConfigDrive, xapiRef, error) {
 	vm, err := client.CloneVM(ctx, xcpNgCloneRequest{
 		Config:      cfg,
 		TemplateRef: placement.templateRef,
@@ -265,7 +250,7 @@ func (b *leaseBackend) createAndBoot(ctx context.Context, client lifecycleClient
 		if vm.Ref != "" {
 			return xcpNgVMToServer(vm, labels, ""), xcpNgConfigDrive{}, xapiRef(vm.Ref), err
 		}
-		return Server{}, xcpNgConfigDrive{}, "", err
+		return core.Server{}, xcpNgConfigDrive{}, "", err
 	}
 	server := xcpNgVMToServer(vm, labels, "")
 	payload, err := newCloudInitPayload(cfg, leaseID, slug, publicKey)
@@ -274,7 +259,7 @@ func (b *leaseBackend) createAndBoot(ctx context.Context, client lifecycleClient
 		if vmRetained {
 			return server, xcpNgConfigDrive{}, xapiRef(vm.Ref), errors.Join(err, cleanupErr)
 		}
-		return Server{}, xcpNgConfigDrive{}, "", errors.Join(err, cleanupErr)
+		return core.Server{}, xcpNgConfigDrive{}, "", errors.Join(err, cleanupErr)
 	}
 	configDrive, err := client.AttachConfigDrive(ctx, xcpNgConfigDriveRequest{VMRef: xapiRef(vm.Ref), SRRef: placement.srRef, LeaseID: leaseID, Slug: slug, Payload: payload, Labels: labels})
 	if err != nil {
@@ -282,14 +267,14 @@ func (b *leaseBackend) createAndBoot(ctx context.Context, client lifecycleClient
 		if vmRetained {
 			return server, xcpNgConfigDrive{}, xapiRef(vm.Ref), errors.Join(err, cleanupErr)
 		}
-		return Server{}, xcpNgConfigDrive{}, "", errors.Join(err, cleanupErr)
+		return core.Server{}, xcpNgConfigDrive{}, "", errors.Join(err, cleanupErr)
 	}
 	if err := client.StartVM(ctx, xapiRef(vm.Ref)); err != nil {
 		vmRetained, cleanupErr := b.cleanupFailedLease(ctx, client, server.CloudID, configDrive)
 		if vmRetained {
 			return server, configDrive, xapiRef(vm.Ref), errors.Join(err, cleanupErr)
 		}
-		return Server{}, xcpNgConfigDrive{}, "", errors.Join(err, cleanupErr)
+		return core.Server{}, xcpNgConfigDrive{}, "", errors.Join(err, cleanupErr)
 	}
 	return server, configDrive, xapiRef(vm.Ref), nil
 }
@@ -357,66 +342,66 @@ func (b *leaseBackend) cleanupFailedLease(ctx context.Context, client lifecycleC
 	return false, cleanupErr
 }
 
-func (b *leaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *leaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
 	client, err := newLifecycleClient(ctx, b.Cfg)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	defer closeClient(ctx, client, b.RT.Stderr)
 	if req.ID != "" {
 		server, err := client.GetServer(ctx, req.ID)
 		if err == nil {
 			if !isCrabboxLease(server) {
-				return LeaseTarget{}, exit(4, "lease/server not found: %s (VM exists but is not Crabbox-managed)", req.ID)
+				return core.LeaseTarget{}, exit(4, "lease/server not found: %s (VM exists but is not Crabbox-managed)", req.ID)
 			}
 			if req.StatusOnly && !req.ReadyProbe {
 				return b.targetForServer(b.resolveStatusServer(ctx, client, server), req.ReleaseOnly)
 			}
 			server, err = b.ensureServerIP(ctx, client, server, req.ReleaseOnly)
 			if err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 			return b.targetForServer(server, req.ReleaseOnly)
 		}
 		if !isNotFound(err) {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 	}
 	servers, err := client.ListCrabboxServers(ctx)
 	if err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	}
 	if server, leaseID, err := findServerByAlias(servers, req.ID); err != nil {
-		return LeaseTarget{}, err
+		return core.LeaseTarget{}, err
 	} else if leaseID != "" {
 		if refreshed, err := client.GetServer(ctx, server.CloudID); err == nil {
 			server = refreshed
 		} else if !req.ReleaseOnly {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		if req.StatusOnly && !req.ReadyProbe {
 			target, err := b.targetForServer(b.resolveStatusServer(ctx, client, server), req.ReleaseOnly)
 			if err != nil {
-				return LeaseTarget{}, err
+				return core.LeaseTarget{}, err
 			}
 			target.LeaseID = leaseID
 			return target, nil
 		}
 		server, err = b.ensureServerIP(ctx, client, server, req.ReleaseOnly)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		target, err := b.targetForServer(server, req.ReleaseOnly)
 		if err != nil {
-			return LeaseTarget{}, err
+			return core.LeaseTarget{}, err
 		}
 		target.LeaseID = leaseID
 		return target, nil
 	}
-	return LeaseTarget{}, exit(4, "lease/server not found: %s", req.ID)
+	return core.LeaseTarget{}, exit(4, "lease/server not found: %s", req.ID)
 }
 
-func (b *leaseBackend) resolveStatusServer(ctx context.Context, client lifecycleClient, server Server) Server {
+func (b *leaseBackend) resolveStatusServer(ctx context.Context, client lifecycleClient, server core.Server) core.Server {
 	server = reconcileXCPNgServerState(server)
 	if !strings.EqualFold(strings.TrimSpace(server.Status), "running") || firstNonBlank(server.PublicNet.IPv4.IP, server.PrivateNet.IPv4.IP) != "" {
 		return server
@@ -436,7 +421,7 @@ func (b *leaseBackend) resolveStatusServer(ctx context.Context, client lifecycle
 	return server
 }
 
-func reconcileXCPNgServerState(server Server) Server {
+func reconcileXCPNgServerState(server core.Server) core.Server {
 	liveState := strings.ToLower(strings.TrimSpace(server.Status))
 	if liveState == "" {
 		return server
@@ -452,7 +437,7 @@ func reconcileXCPNgServerState(server Server) Server {
 	return server
 }
 
-func (b *leaseBackend) ensureServerIP(ctx context.Context, client lifecycleClient, server Server, releaseOnly bool) (Server, error) {
+func (b *leaseBackend) ensureServerIP(ctx context.Context, client lifecycleClient, server core.Server, releaseOnly bool) (core.Server, error) {
 	if firstNonBlank(server.PublicNet.IPv4.IP, server.PrivateNet.IPv4.IP) != "" || releaseOnly {
 		return server, nil
 	}
@@ -466,22 +451,22 @@ func (b *leaseBackend) ensureServerIP(ctx context.Context, client lifecycleClien
 				if guestErr == nil {
 					guestErr = errors.New("no guest ipv4 address reported by XCP-ng guest metrics")
 				}
-				return Server{}, errors.Join(guestErr, discoverErr)
+				return core.Server{}, errors.Join(guestErr, discoverErr)
 			}
 		}
 	}
 	if ip == "" {
 		if guestErr != nil {
-			return Server{}, guestErr
+			return core.Server{}, guestErr
 		}
-		return Server{}, errors.New("no guest ipv4 address reported by XCP-ng guest metrics")
+		return core.Server{}, errors.New("no guest ipv4 address reported by XCP-ng guest metrics")
 	}
 	server.PublicNet.IPv4.IP = ip
 	server.PrivateNet.IPv4.IP = ip
 	return server, nil
 }
 
-func (b *leaseBackend) targetForServer(server Server, releaseOnly bool) (LeaseTarget, error) {
+func (b *leaseBackend) targetForServer(server core.Server, releaseOnly bool) (core.LeaseTarget, error) {
 	cfg := b.Cfg
 	if storedTarget := strings.TrimSpace(server.Labels["target"]); storedTarget != "" {
 		cfg.TargetOS = storedTarget
@@ -498,14 +483,14 @@ func (b *leaseBackend) targetForServer(server Server, releaseOnly bool) (LeaseTa
 	target := sshTargetFromConfig(cfg, firstNonBlank(server.PublicNet.IPv4.IP, server.PrivateNet.IPv4.IP))
 	leaseID := core.Blank(server.Labels["lease"], server.CloudID)
 	if !releaseOnly {
-		if err := useStoredTestboxKey(&target, leaseID); err != nil {
-			return LeaseTarget{}, err
+		if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
+			return core.LeaseTarget{}, err
 		}
 	}
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
-func (b *leaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+func (b *leaseBackend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseView, error) {
 	_ = req
 	client, err := newLifecycleClient(ctx, b.Cfg)
 	if err != nil {
@@ -515,7 +500,7 @@ func (b *leaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, 
 	return client.ListCrabboxServers(ctx)
 }
 
-func (b *leaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *leaseBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
 	client, err := newLifecycleClient(ctx, b.Cfg)
 	if err != nil {
 		return err
@@ -531,7 +516,7 @@ func (b *leaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest
 	return nil
 }
 
-func (b *leaseBackend) claimBinding(server Server, leaseID string) shared.ClaimBinding {
+func (b *leaseBackend) claimBinding(server core.Server, leaseID string) shared.ClaimBinding {
 	return shared.ClaimBinding{
 		Provider:           "xcp-ng",
 		ProviderScope:      core.ProviderClaimScope("xcp-ng", b.Cfg),
@@ -546,7 +531,7 @@ func (b *leaseBackend) claimBinding(server Server, leaseID string) shared.ClaimB
 	}
 }
 
-func (b *leaseBackend) deleteClaimedServer(ctx context.Context, client lifecycleClient, server Server, leaseID string) error {
+func (b *leaseBackend) deleteClaimedServer(ctx context.Context, client lifecycleClient, server core.Server, leaseID string) error {
 	binding := b.claimBinding(server, leaseID)
 	claim, err := shared.RequireExactClaim(binding)
 	if err != nil {
@@ -568,25 +553,25 @@ func (b *leaseBackend) deleteClaimedServer(ctx context.Context, client lifecycle
 	return nil
 }
 
-func (b *leaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
+func (b *leaseBackend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
 	client, err := newLifecycleClient(ctx, b.Cfg)
 	if err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	defer closeClient(ctx, client, b.RT.Stderr)
 	server := req.Lease.Server
 	if !isCrabboxLease(server) {
-		return Server{}, exit(4, "refusing to touch non-Crabbox xcp-ng VM: %s", server.DisplayID())
+		return core.Server{}, exit(4, "refusing to touch non-Crabbox xcp-ng VM: %s", server.DisplayID())
 	}
 	server.Labels = core.TouchDirectLeaseLabels(server.Labels, b.Cfg, req.State, currentTime(b.RT).UTC())
 	if err := client.SetLabels(ctx, server.CloudID, server.Labels); err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	return server, nil
 }
 
-func (b *leaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
-	servers, err := b.List(ctx, ListRequest{Options: req.Options})
+func (b *leaseBackend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
+	servers, err := b.List(ctx, core.ListRequest{Options: req.Options})
 	if err != nil {
 		return err
 	}
@@ -715,7 +700,7 @@ func xcpNgServerTypeForConfig(cfg core.Config) string {
 	return "template"
 }
 
-func xcpNgProviderConfig(cfg Config) xcpNgConfig {
+func xcpNgProviderConfig(cfg core.Config) xcpNgConfig {
 	return xcpNgConfig{
 		APIURL:       cfg.XCPNg.APIURL,
 		Username:     cfg.XCPNg.Username,
@@ -764,14 +749,14 @@ func validateXCPNgProvisioningConfig(cfg xcpNgConfig) error {
 	return nil
 }
 
-func xcpNgVMToServer(vm xapiVM, labels map[string]string, ip string) Server {
+func xcpNgVMToServer(vm xapiVM, labels map[string]string, ip string) core.Server {
 	if labels == nil {
 		labels = vm.Labels
 	}
 	if labels == nil {
 		labels = map[string]string{}
 	}
-	server := Server{
+	server := core.Server{
 		Provider: "xcp-ng",
 		CloudID:  firstNonBlank(vm.UUID, vm.Ref),
 		Name:     vm.Name,
@@ -784,7 +769,7 @@ func xcpNgVMToServer(vm xapiVM, labels map[string]string, ip string) Server {
 	return server
 }
 
-func isCrabboxLease(server Server) bool {
+func isCrabboxLease(server core.Server) bool {
 	if server.Labels == nil {
 		return false
 	}
@@ -820,40 +805,36 @@ func firstNonBlank(values ...string) string {
 	return shared.FirstNonBlank(values...)
 }
 
-func currentTime(rt Runtime) time.Time {
+func currentTime(rt core.Runtime) time.Time {
 	if rt.Clock != nil {
 		return rt.Clock.Now()
 	}
 	return time.Now()
 }
 
-var newLifecycleClient = func(ctx context.Context, cfg Config) (lifecycleClient, error) {
+var newLifecycleClient = func(ctx context.Context, cfg core.Config) (lifecycleClient, error) {
 	return newXAPIClient(ctx, cfg)
 }
 
 var newLeaseID = func() string { return core.NewLeaseID() }
-var allocateDirectLeaseSlug = func(id, requested string, servers []Server) (string, error) {
+var allocateDirectLeaseSlug = func(id, requested string, servers []core.Server) (string, error) {
 	return core.AllocateDirectLeaseSlug(id, requested, servers)
 }
-var ensureTestboxKeyForConfig = func(cfg Config, leaseID string) (string, string, error) {
+var ensureTestboxKeyForConfig = func(cfg core.Config, leaseID string) (string, string, error) {
 	return core.EnsureTestboxKeyForConfig(cfg, leaseID)
 }
 var providerKeyForLease = func(leaseID string) string { return core.ProviderKeyForLease(leaseID) }
-var sshTargetFromConfig = func(cfg Config, host string) SSHTarget { return core.SSHTargetFromConfig(cfg, host) }
-var waitForSSHReady = func(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+var sshTargetFromConfig = func(cfg core.Config, host string) core.SSHTarget { return core.SSHTargetFromConfig(cfg, host) }
+var waitForSSHReady = func(ctx context.Context, target *core.SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
 	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
 }
-var bootstrapWaitTimeout = func(cfg Config) time.Duration { return core.BootstrapWaitTimeout(cfg) }
+var bootstrapWaitTimeout = func(cfg core.Config) time.Duration { return core.BootstrapWaitTimeout(cfg) }
 var guestIPPollInterval = 5 * time.Second
 var guestIPDiscoverInterval = 15 * time.Second
 var xcpNgRollbackCleanupTimeout = 11 * time.Minute
 var xcpNgPartialRollbackTimeout = 30 * time.Second
-var findServerByAlias = func(servers []Server, id string) (Server, string, error) {
+var findServerByAlias = func(servers []core.Server, id string) (core.Server, string, error) {
 	return core.FindServerByAlias(servers, id)
 }
 var removeStoredTestboxKey = func(leaseID string) { core.RemoveStoredTestboxKey(leaseID) }
 var exit = func(code int, format string, args ...any) core.ExitError { return core.Exit(code, format, args...) }
-
-func useStoredTestboxKey(target *SSHTarget, leaseID string) error {
-	return core.UseStoredTestboxKey(target, leaseID)
-}

--- a/internal/providers/xcpng/backend_test.go
+++ b/internal/providers/xcpng/backend_test.go
@@ -19,7 +19,7 @@ const xcpNgTestVMUUID = "11111111-1111-1111-1111-111111111111"
 
 type fakeLifecycleClient struct {
 	calls           []string
-	servers         []Server
+	servers         []core.Server
 	templateRef     string
 	srRef           string
 	networkRef      string
@@ -33,7 +33,7 @@ type fakeLifecycleClient struct {
 	attachedDisk    xcpNgConfigDrive
 	guestIP         string
 	discoveredIP    string
-	getServer       map[string]Server
+	getServer       map[string]core.Server
 	errOn           map[string]error
 	mutated         bool
 	deleted         []string
@@ -66,14 +66,14 @@ func (f *fakeLifecycleClient) Close(ctx context.Context) error {
 	return f.fail("close")
 }
 
-func (f *fakeLifecycleClient) DoctorInventory(context.Context, xcpNgConfig) ([]Server, error) {
+func (f *fakeLifecycleClient) DoctorInventory(context.Context, xcpNgConfig) ([]core.Server, error) {
 	f.record("doctor-inventory")
 	return f.servers, f.fail("doctor-inventory")
 }
 
-func (f *fakeLifecycleClient) ListCrabboxServers(context.Context) ([]Server, error) {
+func (f *fakeLifecycleClient) ListCrabboxServers(context.Context) ([]core.Server, error) {
 	f.record("list")
-	out := make([]Server, 0, len(f.servers))
+	out := make([]core.Server, 0, len(f.servers))
 	for _, server := range f.servers {
 		if isCrabboxLease(server) {
 			out = append(out, server)
@@ -280,14 +280,14 @@ func (f *fakeLifecycleClient) DiscoverGuestIPv4(context.Context, xapiRef) (strin
 	return f.discoveredIP, nil
 }
 
-func (f *fakeLifecycleClient) GetServer(_ context.Context, id string) (Server, error) {
+func (f *fakeLifecycleClient) GetServer(_ context.Context, id string) (core.Server, error) {
 	f.record("get")
 	if f.getServer != nil {
 		if server, ok := f.getServer[id]; ok {
 			return server, nil
 		}
 	}
-	return Server{}, xapiHTTPError{StatusCode: 404, Body: "not found"}
+	return core.Server{}, xapiHTTPError{StatusCode: 404, Body: "not found"}
 }
 
 func (f *fakeLifecycleClient) SetLabels(_ context.Context, id string, labels map[string]string) error {
@@ -329,7 +329,7 @@ func (f *fakeLifecycleClient) DeleteConfigDrive(ctx context.Context, drive xcpNg
 
 func TestDoctorUsesReadOnlyPlacementAndInventory(t *testing.T) {
 	fake := &fakeLifecycleClient{
-		servers:     []Server{crabboxServer("OpaqueRef:vm-1", "cbx_lease", "ready", time.Now().Add(time.Hour))},
+		servers:     []core.Server{crabboxServer("OpaqueRef:vm-1", "cbx_lease", "ready", time.Now().Add(time.Hour))},
 		templateRef: "OpaqueRef:tpl",
 		srRef:       "OpaqueRef:sr",
 	}
@@ -692,7 +692,7 @@ func TestWaitForGuestIPv4ReturnsDiscoveryConfigurationErrorImmediately(t *testin
 }
 
 func TestResolveRejectsExistingNonCrabboxVM(t *testing.T) {
-	fake := &fakeLifecycleClient{getServer: map[string]Server{"OpaqueRef:user": {CloudID: "OpaqueRef:user", Name: "user-vm", Labels: map[string]string{"crabbox": "false"}}}}
+	fake := &fakeLifecycleClient{getServer: map[string]core.Server{"OpaqueRef:user": {CloudID: "OpaqueRef:user", Name: "user-vm", Labels: map[string]string{"crabbox": "false"}}}}
 	backend := newTestBackend(t, fake)
 	if _, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "OpaqueRef:user"}); err == nil || !strings.Contains(err.Error(), "not Crabbox-managed") {
 		t.Fatalf("err=%v", err)
@@ -705,7 +705,7 @@ func TestResolveStatusOnlySkipsGuestIPAndUsesLivePowerState(t *testing.T) {
 	managed.PublicNet.IPv4.IP = ""
 	managed.PrivateNet.IPv4.IP = ""
 	fake := &fakeLifecycleClient{
-		getServer: map[string]Server{"cbx_status": managed},
+		getServer: map[string]core.Server{"cbx_status": managed},
 		errOn: map[string]error{
 			"guest-ip-by-id":    errors.New("guest tools unavailable"),
 			"discover-guest-ip": errors.New("guest network unavailable"),
@@ -732,7 +732,7 @@ func TestResolveStatusOnlyPreservesHealthyRunningEndpoint(t *testing.T) {
 	managed.PublicNet.IPv4.IP = ""
 	managed.PrivateNet.IPv4.IP = ""
 	fake := &fakeLifecycleClient{
-		getServer: map[string]Server{"cbx_status": managed},
+		getServer: map[string]core.Server{"cbx_status": managed},
 		guestIP:   "192.0.2.55",
 	}
 	backend := newTestBackend(t, fake)
@@ -755,7 +755,7 @@ func TestResolveStatusOnlyToleratesUnavailableRunningEndpoint(t *testing.T) {
 	managed.PublicNet.IPv4.IP = ""
 	managed.PrivateNet.IPv4.IP = ""
 	fake := &fakeLifecycleClient{
-		getServer: map[string]Server{"cbx_status": managed},
+		getServer: map[string]core.Server{"cbx_status": managed},
 		errOn: map[string]error{
 			"guest-ip-by-id":    errors.New("guest tools unavailable"),
 			"discover-guest-ip": errors.New("guest network unavailable"),
@@ -787,8 +787,8 @@ func TestResolveByAliasFallsBackToMACDiscoveryWhenGuestMetricsFail(t *testing.T)
 	managed.PublicNet.IPv4.IP = ""
 	managed.PrivateNet.IPv4.IP = ""
 	fake := &fakeLifecycleClient{
-		servers:      []Server{managed},
-		getServer:    map[string]Server{xcpNgTestVMUUID: managed},
+		servers:      []core.Server{managed},
+		getServer:    map[string]core.Server{xcpNgTestVMUUID: managed},
 		discoveredIP: "192.0.2.77",
 		errOn:        map[string]error{"guest-ip": errors.New("guest metrics unavailable")},
 	}
@@ -837,10 +837,10 @@ func TestTargetForServerRestoresStoredTargetLabels(t *testing.T) {
 
 func TestListResolveTouchReleaseUseOnlyCrabboxMetadata(t *testing.T) {
 	managed := crabboxServer(xcpNgTestVMUUID, "cbx_lease", "ready", time.Now().Add(time.Hour))
-	unmanaged := Server{CloudID: "OpaqueRef:vm-2", Name: "crabbox-prefix-only", Labels: map[string]string{"provider": "xcp-ng"}}
+	unmanaged := core.Server{CloudID: "OpaqueRef:vm-2", Name: "crabbox-prefix-only", Labels: map[string]string{"provider": "xcp-ng"}}
 	fake := &fakeLifecycleClient{
-		servers: []Server{managed, unmanaged},
-		getServer: map[string]Server{
+		servers: []core.Server{managed, unmanaged},
+		getServer: map[string]core.Server{
 			"cbx_lease":     managed,
 			xcpNgTestVMUUID: managed,
 		},
@@ -885,7 +885,7 @@ func TestReleaseRemovesStoredKey(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", home)
 	managed := crabboxServer(xcpNgTestVMUUID, "cbx_release", "ready", time.Now().Add(time.Hour))
-	fake := &fakeLifecycleClient{getServer: map[string]Server{"cbx_release": managed, xcpNgTestVMUUID: managed}}
+	fake := &fakeLifecycleClient{getServer: map[string]core.Server{"cbx_release": managed, xcpNgTestVMUUID: managed}}
 	backend := newTestBackend(t, fake)
 	claimXCPNgServer(t, backend, managed)
 	removeStoredTestboxKey = func(leaseID string) { core.RemoveStoredTestboxKey(leaseID) }
@@ -929,7 +929,7 @@ func TestReleaseRequiresExactScopedClaimAndLiveOwnership(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			server := crabboxServer(xcpNgTestVMUUID, "cbx_owned", "ready", time.Now().Add(time.Hour))
 			live := crabboxServer(tc.liveVM, tc.liveLease, "ready", time.Now().Add(time.Hour))
-			fake := &fakeLifecycleClient{getServer: map[string]Server{xcpNgTestVMUUID: live}}
+			fake := &fakeLifecycleClient{getServer: map[string]core.Server{xcpNgTestVMUUID: live}}
 			if tc.deleteErr != nil {
 				fake.errOn = map[string]error{"delete": tc.deleteErr}
 			}
@@ -941,7 +941,7 @@ func TestReleaseRequiresExactScopedClaimAndLiveOwnership(t *testing.T) {
 				}
 				claimed := server
 				claimed.CloudID = tc.claimVM
-				if err := core.ClaimLeaseTargetForRepoConfig("cbx_owned", "owned", claimCfg, claimed, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+				if err := core.ClaimLeaseTargetForRepoConfig("cbx_owned", "owned", claimCfg, claimed, core.SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -970,12 +970,12 @@ func TestCleanupSkipsUnclaimedAndWrongScopedVMs(t *testing.T) {
 	unclaimed := crabboxServer("vm-unclaimed", "cbx_unclaimed", "ready", now.Add(-time.Minute))
 	wrongScope := crabboxServer("vm-wrong-scope", "cbx_wrong", "ready", now.Add(-time.Minute))
 	owned := crabboxServer("vm-owned", "cbx_owned", "ready", now.Add(-time.Minute))
-	fake := &fakeLifecycleClient{servers: []Server{unclaimed, wrongScope, owned}, getServer: map[string]Server{"vm-owned": owned}}
+	fake := &fakeLifecycleClient{servers: []core.Server{unclaimed, wrongScope, owned}, getServer: map[string]core.Server{"vm-owned": owned}}
 	backend := newTestBackend(t, fake)
 	backend.RT.Clock = fixedClock{t: now}
 	wrongCfg := backend.Cfg
 	wrongCfg.XCPNg.APIURL = "https://another-pool.example.test"
-	if err := core.ClaimLeaseTargetForRepoConfig("cbx_wrong", "wrong", wrongCfg, wrongScope, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_wrong", "wrong", wrongCfg, wrongScope, core.SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	claimXCPNgServer(t, backend, owned)
@@ -993,11 +993,11 @@ func TestCleanupSkipsUnclaimedAndWrongScopedVMs(t *testing.T) {
 func TestCleanupIsMetadataAndExpiryGated(t *testing.T) {
 	now := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
 	expired := crabboxServer("OpaqueRef:expired", "cbx_expired", "ready", now.Add(-time.Minute))
-	fake := &fakeLifecycleClient{servers: []Server{
+	fake := &fakeLifecycleClient{servers: []core.Server{
 		expired,
 		crabboxServer("OpaqueRef:fresh", "cbx_fresh", "ready", now.Add(time.Hour)),
 		{CloudID: "OpaqueRef:prefix", Name: "crabbox-prefix-only", Labels: map[string]string{"provider": "xcp-ng"}},
-	}, getServer: map[string]Server{"OpaqueRef:expired": expired}}
+	}, getServer: map[string]core.Server{"OpaqueRef:expired": expired}}
 	backend := newTestBackend(t, fake)
 	claimXCPNgServer(t, backend, expired)
 	backend.Cfg.XCPNg.Template = ""
@@ -1029,7 +1029,7 @@ func TestRunISOE2ELinuxReadOnlyAcceptsLocalInstallerPath(t *testing.T) {
 	}
 	fake := &fakeLifecycleClient{srRef: "OpaqueRef:sr", networkRef: "OpaqueRef:net", hostRef: "OpaqueRef:host", iso: xcpNgISOMediaRef{Source: "local-file", NameLabel: isoPath}}
 	oldClient := newLifecycleClient
-	newLifecycleClient = func(context.Context, Config) (lifecycleClient, error) { return fake, nil }
+	newLifecycleClient = func(context.Context, core.Config) (lifecycleClient, error) { return fake, nil }
 	t.Cleanup(func() { newLifecycleClient = oldClient })
 	summary, err := RunISOE2E(context.Background(), ISOE2EOptions{Config: testConfig(), Mode: "read-only", OS: "linux", ISO: isoPath, EvidenceDir: filepath.Join(dir, "evidence")})
 	if err != nil {
@@ -1054,7 +1054,7 @@ func TestRunISOE2EMutateRequiresNetworkBeforeCreatingVM(t *testing.T) {
 		hostRef: "OpaqueRef:host",
 	}
 	oldClient := newLifecycleClient
-	newLifecycleClient = func(context.Context, Config) (lifecycleClient, error) { return fake, nil }
+	newLifecycleClient = func(context.Context, core.Config) (lifecycleClient, error) { return fake, nil }
 	t.Cleanup(func() { newLifecycleClient = oldClient })
 
 	cfg := testConfig()
@@ -1088,7 +1088,7 @@ func TestRunISOE2EReportsLogoutFailureInSummary(t *testing.T) {
 		errOn:      map[string]error{"close": errors.New("logout failed")},
 	}
 	oldClient := newLifecycleClient
-	newLifecycleClient = func(context.Context, Config) (lifecycleClient, error) { return fake, nil }
+	newLifecycleClient = func(context.Context, core.Config) (lifecycleClient, error) { return fake, nil }
 	t.Cleanup(func() { newLifecycleClient = oldClient })
 
 	summary, err := RunISOE2E(context.Background(), ISOE2EOptions{Config: testConfig(), Mode: "read-only", OS: "linux", ISO: isoPath, EvidenceDir: filepath.Join(dir, "evidence")})
@@ -1116,7 +1116,7 @@ func TestRunISOE2EJoinsLogoutFailureWithPrimaryFailure(t *testing.T) {
 		},
 	}
 	oldClient := newLifecycleClient
-	newLifecycleClient = func(context.Context, Config) (lifecycleClient, error) { return fake, nil }
+	newLifecycleClient = func(context.Context, core.Config) (lifecycleClient, error) { return fake, nil }
 	t.Cleanup(func() { newLifecycleClient = oldClient })
 
 	summary, err := RunISOE2E(context.Background(), ISOE2EOptions{Config: testConfig(), Mode: "read-only", OS: "linux", ISO: isoPath, EvidenceDir: filepath.Join(dir, "evidence")})
@@ -1141,7 +1141,7 @@ func TestRunISOE2EWindowsReadOnlyBlocksARMInstaller(t *testing.T) {
 	}
 	fake := &fakeLifecycleClient{srRef: "OpaqueRef:sr", networkRef: "OpaqueRef:net", hostRef: "OpaqueRef:host", iso: xcpNgISOMediaRef{Source: "local-file", NameLabel: isoPath}}
 	oldClient := newLifecycleClient
-	newLifecycleClient = func(context.Context, Config) (lifecycleClient, error) { return fake, nil }
+	newLifecycleClient = func(context.Context, core.Config) (lifecycleClient, error) { return fake, nil }
 	t.Cleanup(func() { newLifecycleClient = oldClient })
 	summary, err := RunISOE2E(context.Background(), ISOE2EOptions{Config: testConfig(), Mode: "read-only", OS: "windows", ISO: isoPath, EvidenceDir: filepath.Join(dir, "evidence")})
 	if err == nil {
@@ -1183,7 +1183,7 @@ func TestRunISOE2EWindowsUsesResolvedInstallerNameForVTPM(t *testing.T) {
 		errOn: map[string]error{"create-fresh-vm": errors.New("stop after request capture")},
 	}
 	oldClient := newLifecycleClient
-	newLifecycleClient = func(context.Context, Config) (lifecycleClient, error) { return fake, nil }
+	newLifecycleClient = func(context.Context, core.Config) (lifecycleClient, error) { return fake, nil }
 	t.Cleanup(func() { newLifecycleClient = oldClient })
 
 	_, err := RunISOE2E(context.Background(), ISOE2EOptions{
@@ -1227,14 +1227,14 @@ func TestRunISOE2EWindowsMutateGeneratesAndAttachesBootstrapBeforeStart(t *testi
 	oldPassword := isoE2EGenerateWindowsPassword
 	var sshTimeout time.Duration
 	var sshContextDeadline time.Time
-	newLifecycleClient = func(context.Context, Config) (lifecycleClient, error) { return fake, nil }
+	newLifecycleClient = func(context.Context, core.Config) (lifecycleClient, error) { return fake, nil }
 	isoE2EWaitForSSHReady = func(ctx context.Context, _ *core.SSHTarget, _ string, timeout time.Duration) error {
 		sshTimeout = timeout
 		sshContextDeadline, _ = ctx.Deadline()
 		return nil
 	}
 	isoE2ERunSSHQuiet = func(context.Context, core.SSHTarget, string) error { return nil }
-	isoE2EEnsureTestboxKey = func(Config, string) (string, string, error) {
+	isoE2EEnsureTestboxKey = func(core.Config, string) (string, string, error) {
 		return filepath.Join(dir, "id_ed25519"), "ssh-ed25519 AAAATEST crabbox", nil
 	}
 	isoE2EWriteWindowsAnswerISO = func(_ context.Context, _ string, payload xcpNgWindowsAutounattendPayload) (string, error) {
@@ -1290,7 +1290,7 @@ func TestPrepareWindowsAnswerMediaRetainsGeneratedISOOnlyWhenRequested(t *testin
 	oldEnsure := isoE2EEnsureTestboxKey
 	oldWrite := isoE2EWriteWindowsAnswerISO
 	oldPassword := isoE2EGenerateWindowsPassword
-	isoE2EEnsureTestboxKey = func(Config, string) (string, string, error) {
+	isoE2EEnsureTestboxKey = func(core.Config, string) (string, string, error) {
 		return filepath.Join(dir, "id_ed25519"), "ssh-ed25519 AAAATEST crabbox", nil
 	}
 	isoE2EWriteWindowsAnswerISO = func(context.Context, string, xcpNgWindowsAutounattendPayload) (string, error) {
@@ -1447,7 +1447,7 @@ func TestRunISOE2EWindowsMutateFallsBackToSourceUncoveredWithProvidedAnswerISO(t
 		attachedDisk: xcpNgConfigDrive{VDIRef: "OpaqueRef:disk-vdi", VBDRef: "OpaqueRef:disk-vbd", Name: "install-disk", DestroyVDI: true},
 	}
 	oldClient := newLifecycleClient
-	newLifecycleClient = func(context.Context, Config) (lifecycleClient, error) { return fake, nil }
+	newLifecycleClient = func(context.Context, core.Config) (lifecycleClient, error) { return fake, nil }
 	t.Cleanup(func() { newLifecycleClient = oldClient })
 	summary, err := RunISOE2E(context.Background(), ISOE2EOptions{Config: testConfig(), Mode: "mutate", OS: "windows", ISO: isoPath, AnswerISO: answerPath, EvidenceDir: filepath.Join(dir, "evidence"), MutateGate: true})
 	if err == nil {
@@ -1483,7 +1483,7 @@ func TestRunISOE2EWindowsMutateClassifiesGuestMetricsBlocker(t *testing.T) {
 		errOn:        map[string]error{"guest-ip": errors.New("no guest ipv4 address reported by XCP-ng guest metrics")},
 	}
 	oldClient := newLifecycleClient
-	newLifecycleClient = func(context.Context, Config) (lifecycleClient, error) { return fake, nil }
+	newLifecycleClient = func(context.Context, core.Config) (lifecycleClient, error) { return fake, nil }
 	t.Cleanup(func() { newLifecycleClient = oldClient })
 	summary, err := RunISOE2E(context.Background(), ISOE2EOptions{Config: testConfig(), Mode: "mutate", OS: "windows", ISO: isoPath, AnswerISO: answerPath, EvidenceDir: filepath.Join(dir, "evidence"), Timeout: 25 * time.Second, MutateGate: true})
 	if err == nil {
@@ -1517,10 +1517,10 @@ func TestRunISOE2ELinuxMutatePassesWithImportedMediaAndSSHProof(t *testing.T) {
 	oldNow := isoE2ECurrentTime
 	oldRemaster := isoE2ERemasterUbuntuISO
 	oldSeed := isoE2EWriteLinuxSeedISO
-	newLifecycleClient = func(context.Context, Config) (lifecycleClient, error) { return fake, nil }
+	newLifecycleClient = func(context.Context, core.Config) (lifecycleClient, error) { return fake, nil }
 	isoE2EWaitForSSHReady = func(context.Context, *core.SSHTarget, string, time.Duration) error { return nil }
 	isoE2ERunSSHQuiet = func(context.Context, core.SSHTarget, string) error { return nil }
-	isoE2EEnsureTestboxKey = func(Config, string) (string, string, error) {
+	isoE2EEnsureTestboxKey = func(core.Config, string) (string, string, error) {
 		return filepath.Join(dir, "id_ed25519"), "ssh-ed25519 AAAATEST crabbox", nil
 	}
 	isoE2ECurrentTime = func() time.Time { return time.Unix(1700000000, 0).UTC() }
@@ -1584,8 +1584,8 @@ func TestRunISOE2ELinuxMutateClassifiesGuestMetricsBlocker(t *testing.T) {
 	oldEnsure := isoE2EEnsureTestboxKey
 	oldRemaster := isoE2ERemasterUbuntuISO
 	oldSeed := isoE2EWriteLinuxSeedISO
-	newLifecycleClient = func(context.Context, Config) (lifecycleClient, error) { return fake, nil }
-	isoE2EEnsureTestboxKey = func(Config, string) (string, string, error) {
+	newLifecycleClient = func(context.Context, core.Config) (lifecycleClient, error) { return fake, nil }
+	isoE2EEnsureTestboxKey = func(core.Config, string) (string, string, error) {
 		return filepath.Join(dir, "id_ed25519"), "ssh-ed25519 AAAATEST crabbox", nil
 	}
 	isoE2ERemasterUbuntuISO = func(context.Context, string, string) (string, error) { return isoPath, nil }
@@ -1637,10 +1637,10 @@ func TestRunISOE2ELinuxMutateUsesGuestMetricsForInstallCompletion(t *testing.T) 
 	oldEnsure := isoE2EEnsureTestboxKey
 	oldRemaster := isoE2ERemasterUbuntuISO
 	oldSeed := isoE2EWriteLinuxSeedISO
-	newLifecycleClient = func(context.Context, Config) (lifecycleClient, error) { return fake, nil }
+	newLifecycleClient = func(context.Context, core.Config) (lifecycleClient, error) { return fake, nil }
 	isoE2EWaitForSSHReady = func(context.Context, *core.SSHTarget, string, time.Duration) error { return nil }
 	isoE2ERunSSHQuiet = func(context.Context, core.SSHTarget, string) error { return nil }
-	isoE2EEnsureTestboxKey = func(Config, string) (string, string, error) {
+	isoE2EEnsureTestboxKey = func(core.Config, string) (string, string, error) {
 		return filepath.Join(dir, "id_ed25519"), "ssh-ed25519 AAAATEST crabbox", nil
 	}
 	isoE2ERemasterUbuntuISO = func(context.Context, string, string) (string, error) { return isoPath, nil }
@@ -1720,8 +1720,8 @@ func TestRunISOE2ELinuxMutateCleansImportedInstallerWhenAttachFails(t *testing.T
 	oldEnsure := isoE2EEnsureTestboxKey
 	oldRemaster := isoE2ERemasterUbuntuISO
 	oldSeed := isoE2EWriteLinuxSeedISO
-	newLifecycleClient = func(context.Context, Config) (lifecycleClient, error) { return fake, nil }
-	isoE2EEnsureTestboxKey = func(Config, string) (string, string, error) {
+	newLifecycleClient = func(context.Context, core.Config) (lifecycleClient, error) { return fake, nil }
+	isoE2EEnsureTestboxKey = func(core.Config, string) (string, string, error) {
 		return filepath.Join(dir, "id_ed25519"), "ssh-ed25519 AAAATEST crabbox", nil
 	}
 	isoE2ERemasterUbuntuISO = func(context.Context, string, string) (string, error) { return isoPath, nil }
@@ -1852,7 +1852,7 @@ func TestWindowsAnswerPreparationRegistersOwnedKeyBeforeLaterFailure(t *testing.
 	oldExists := isoE2EStoredTestboxKeyExists
 	oldPassword := isoE2EGenerateWindowsPassword
 	isoE2EStoredTestboxKeyExists = func(string) bool { return false }
-	isoE2EEnsureTestboxKey = func(Config, string) (string, string, error) {
+	isoE2EEnsureTestboxKey = func(core.Config, string) (string, string, error) {
 		return "/tmp/owned-key", "ssh-ed25519 AAAATEST", nil
 	}
 	isoE2EGenerateWindowsPassword = func() (string, error) {
@@ -1908,7 +1908,7 @@ func TestISOE2ERuntimeKeepsRecoveryHandlesFromFailedAllocations(t *testing.T) {
 
 func TestCleanupDryRunDoesNotDelete(t *testing.T) {
 	now := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
-	fake := &fakeLifecycleClient{servers: []Server{crabboxServer("OpaqueRef:expired", "cbx_expired", "ready", now.Add(-time.Minute))}}
+	fake := &fakeLifecycleClient{servers: []core.Server{crabboxServer("OpaqueRef:expired", "cbx_expired", "ready", now.Add(-time.Minute))}}
 	backend := newTestBackend(t, fake)
 	backend.RT.Clock = fixedClock{t: now}
 	if err := backend.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
@@ -1943,13 +1943,13 @@ func newTestBackend(t *testing.T, fake *fakeLifecycleClient) *leaseBackend {
 	oldBootstrapTimeout := bootstrapWaitTimeout
 	oldPollInterval := guestIPPollInterval
 	oldRemoveStoredKey := removeStoredTestboxKey
-	newLifecycleClient = func(context.Context, Config) (lifecycleClient, error) { return fake, nil }
+	newLifecycleClient = func(context.Context, core.Config) (lifecycleClient, error) { return fake, nil }
 	newLeaseID = func() string { return "cbx_testlease" }
-	ensureTestboxKeyForConfig = func(Config, string) (string, string, error) {
+	ensureTestboxKeyForConfig = func(core.Config, string) (string, string, error) {
 		return "/tmp/crabbox-test-key", "ssh-ed25519 AAAATEST crabbox", nil
 	}
-	waitForSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error { return nil }
-	bootstrapWaitTimeout = func(Config) time.Duration { return 10 * time.Millisecond }
+	waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	bootstrapWaitTimeout = func(core.Config) time.Duration { return 10 * time.Millisecond }
 	guestIPPollInterval = time.Millisecond
 	removeStoredTestboxKey = func(string) {}
 	t.Cleanup(func() {
@@ -1962,19 +1962,19 @@ func newTestBackend(t *testing.T, fake *fakeLifecycleClient) *leaseBackend {
 		removeStoredTestboxKey = oldRemoveStoredKey
 	})
 	cfg := testConfig()
-	backend := NewLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: &bytes.Buffer{}}).(*leaseBackend)
+	backend := NewLeaseBackend(Provider{}.Spec(), cfg, core.Runtime{Stderr: &bytes.Buffer{}}).(*leaseBackend)
 	return backend
 }
 
-func claimXCPNgServer(t *testing.T, backend *leaseBackend, server Server) {
+func claimXCPNgServer(t *testing.T, backend *leaseBackend, server core.Server) {
 	t.Helper()
-	if err := core.ClaimLeaseTargetForRepoConfig(server.Labels["lease"], server.Labels["slug"], backend.Cfg, server, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+	if err := core.ClaimLeaseTargetForRepoConfig(server.Labels["lease"], server.Labels["slug"], backend.Cfg, server, core.SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func testConfig() Config {
-	cfg := Config{}
+func testConfig() core.Config {
+	cfg := core.Config{}
 	cfg.Provider = "xcp-ng"
 	cfg.TargetOS = "linux"
 	cfg.SSHUser = "crabbox"
@@ -1992,7 +1992,7 @@ func testConfig() Config {
 	return cfg
 }
 
-func crabboxServer(id, lease, state string, expires time.Time) Server {
+func crabboxServer(id, lease, state string, expires time.Time) core.Server {
 	labels := map[string]string{
 		"crabbox":     "true",
 		"created_by":  "crabbox",
@@ -2004,7 +2004,7 @@ func crabboxServer(id, lease, state string, expires time.Time) Server {
 		"expires_at":  core.LeaseLabelTime(expires),
 		"server_type": "template-ubuntu",
 	}
-	server := Server{CloudID: id, Name: "crabbox-" + strings.TrimPrefix(lease, "cbx_"), Status: state, Labels: labels, Provider: "xcp-ng"}
+	server := core.Server{CloudID: id, Name: "crabbox-" + strings.TrimPrefix(lease, "cbx_"), Status: state, Labels: labels, Provider: "xcp-ng"}
 	server.PublicNet.IPv4.IP = "192.0.2.44"
 	return server
 }

--- a/internal/providers/xcpng/client.go
+++ b/internal/providers/xcpng/client.go
@@ -62,7 +62,7 @@ var (
 	}
 )
 
-func newXAPIClient(ctx context.Context, cfg Config) (*xapiClient, error) {
+func newXAPIClient(ctx context.Context, cfg core.Config) (*xapiClient, error) {
 	xcfg := xcpNgProviderConfig(cfg)
 	if err := validateXCPNgConfig(xcfg); err != nil {
 		return nil, err
@@ -130,17 +130,17 @@ func (c *xapiClient) Close(ctx context.Context) error {
 	return nil
 }
 
-func (c *xapiClient) DoctorInventory(ctx context.Context, cfg xcpNgConfig) ([]Server, error) {
+func (c *xapiClient) DoctorInventory(ctx context.Context, cfg xcpNgConfig) ([]core.Server, error) {
 	_ = cfg
 	return c.ListCrabboxServers(ctx)
 }
 
-func (c *xapiClient) ListCrabboxServers(ctx context.Context) ([]Server, error) {
+func (c *xapiClient) ListCrabboxServers(ctx context.Context) ([]core.Server, error) {
 	vms, err := c.vmRecords(ctx)
 	if err != nil {
 		return nil, err
 	}
-	servers := make([]Server, 0, len(vms))
+	servers := make([]core.Server, 0, len(vms))
 	for _, vm := range vms {
 		server := xcpNgVMToServer(vm, vm.Labels, "")
 		if isCrabboxLease(server) {
@@ -812,14 +812,14 @@ func (c *xapiClient) GuestIPv4ForID(ctx context.Context, id string) (string, err
 	return c.GuestIPv4(ctx, xapiRef(ref))
 }
 
-func (c *xapiClient) GetServer(ctx context.Context, id string) (Server, error) {
+func (c *xapiClient) GetServer(ctx context.Context, id string) (core.Server, error) {
 	ref, err := c.vmRefForID(ctx, id)
 	if err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	record, err := c.vmRecord(ctx, ref)
 	if err != nil {
-		return Server{}, err
+		return core.Server{}, err
 	}
 	return xcpNgVMToServer(record, record.Labels, ""), nil
 }

--- a/internal/providers/xcpng/cloudinit.go
+++ b/internal/providers/xcpng/cloudinit.go
@@ -28,7 +28,7 @@ type xcpNgWindowsAutounattendPayload struct {
 	Username            string
 }
 
-func newCloudInitPayload(cfg Config, leaseID, slug, publicKey string) (xcpNgCloudInitPayload, error) {
+func newCloudInitPayload(cfg core.Config, leaseID, slug, publicKey string) (xcpNgCloudInitPayload, error) {
 	user := strings.TrimSpace(core.Blank(cfg.XCPNg.User, cfg.SSHUser))
 	if user == "" {
 		return xcpNgCloudInitPayload{}, exit(2, "xcp-ng cloud-init user is required")
@@ -93,7 +93,7 @@ func newCloudInitPayload(cfg Config, leaseID, slug, publicKey string) (xcpNgClou
 	return xcpNgCloudInitPayload{UserData: userData.String(), MetaData: metaData}, nil
 }
 
-func newLinuxAutoinstallPayload(cfg Config, leaseID, slug, publicKey string) (xcpNgLinuxAutoinstallPayload, error) {
+func newLinuxAutoinstallPayload(cfg core.Config, leaseID, slug, publicKey string) (xcpNgLinuxAutoinstallPayload, error) {
 	user := strings.TrimSpace(core.Blank(cfg.XCPNg.User, cfg.SSHUser))
 	if user == "" {
 		return xcpNgLinuxAutoinstallPayload{}, exit(2, "xcp-ng linux autoinstall user is required")
@@ -160,7 +160,7 @@ func newLinuxAutoinstallPayload(cfg Config, leaseID, slug, publicKey string) (xc
 	return xcpNgLinuxAutoinstallPayload{UserData: userData.String(), MetaData: metaData}, nil
 }
 
-func newWindowsAutounattendPayload(cfg Config, leaseID, slug, publicKey, initialPassword string) (xcpNgWindowsAutounattendPayload, error) {
+func newWindowsAutounattendPayload(cfg core.Config, leaseID, slug, publicKey, initialPassword string) (xcpNgWindowsAutounattendPayload, error) {
 	rawUser := strings.TrimSpace(core.Blank(cfg.XCPNg.User, cfg.SSHUser))
 	if rawUser == "" {
 		return xcpNgWindowsAutounattendPayload{}, exit(2, "xcp-ng windows autounattend user is required")
@@ -300,7 +300,7 @@ if (-not (Test-Path -LiteralPath $scriptPath)) { throw "Crabbox bootstrap script
 	}, nil
 }
 
-func cloudInitSSHPortConfig(cfg Config) string {
+func cloudInitSSHPortConfig(cfg core.Config) string {
 	portLines := ""
 	for _, port := range xcpNgSSHPortCandidates(cfg.SSHPort, cfg.SSHFallbackPorts) {
 		portLines += fmt.Sprintf("      Port %s\n", port)

--- a/internal/providers/xcpng/iso_e2e.go
+++ b/internal/providers/xcpng/iso_e2e.go
@@ -16,7 +16,7 @@ import (
 )
 
 type ISOE2EOptions struct {
-	Config      Config
+	Config      core.Config
 	Mode        string
 	OS          string
 	ISO         string
@@ -84,7 +84,7 @@ var (
 	isoE2ERunSSHQuiet = func(ctx context.Context, target core.SSHTarget, remote string) error {
 		return core.RunSSHQuiet(ctx, target, remote)
 	}
-	isoE2EEnsureTestboxKey = func(cfg Config, leaseID string) (string, string, error) {
+	isoE2EEnsureTestboxKey = func(cfg core.Config, leaseID string) (string, string, error) {
 		return core.EnsureTestboxKeyForConfig(cfg, leaseID)
 	}
 	isoE2EStoredTestboxKeyExists  = storedISOE2ETestboxKeyExists
@@ -1068,7 +1068,7 @@ func (r *isoE2ERuntime) cleanupLocalArtifacts() error {
 	return cleanupErr
 }
 
-func resolveISOE2EPlacement(ctx context.Context, client lifecycleClient, cfg Config) (xcpNgPlacement, error) {
+func resolveISOE2EPlacement(ctx context.Context, client lifecycleClient, cfg core.Config) (xcpNgPlacement, error) {
 	xcfg := xcpNgProviderConfig(cfg)
 	if err := validateXCPNgConfig(xcfg); err != nil {
 		return xcpNgPlacement{}, err


### PR DESCRIPTION
Reference shared core types and primitives directly in Firecracker, static SSH, Parallels, XCP-ng, and Incus. Removing identity aliases and exact forwarding functions deletes 104 net production lines.

Provider transactions, host/platform checks, resource identity, and mutable test hooks retain their current implementation. Replacements were checked with resolved Go symbols and exact type identity.

Validation: full tests passed for all five providers; scoped Autoreview passed. CI is required before merge. No dependency or configuration changes.
