### PR TITLE
refactor(providers): use canonical core utility owners

### DIFF
--- a/internal/providers/applevm/backend.go
+++ b/internal/providers/applevm/backend.go
@@ -211,7 +211,7 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 	claim.LeaseID = leaseID
 	claim.Slug = slug
 	if leaseID == "" {
-		return core.LeaseTarget{}, exit(4, "apple-vm instance %q has no Crabbox lease metadata; clean it up with `crabbox cleanup --provider apple-vm`", inst.Name)
+		return core.LeaseTarget{}, core.Exit(4, "apple-vm instance %q has no Crabbox lease metadata; clean it up with `crabbox cleanup --provider apple-vm`", inst.Name)
 	}
 	owned, conflict, err := appleVMClaimStatus(leaseID, inst.Name)
 	if err != nil {
@@ -225,7 +225,7 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 		return core.LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: leaseID}, nil
 	}
 	if !appleVMRunning(inst.Status) && !req.StatusOnly {
-		return core.LeaseTarget{}, exit(5, "apple-vm instance %s is %s; start a new lease with `crabbox run` or clean it up with `crabbox cleanup --provider apple-vm`", inst.Name, core.Blank(inst.Status, "stopped"))
+		return core.LeaseTarget{}, core.Exit(5, "apple-vm instance %s is %s; start a new lease with `crabbox run` or clean it up with `crabbox cleanup --provider apple-vm`", inst.Name, core.Blank(inst.Status, "stopped"))
 	}
 	if req.StatusOnly && (inst.SSHHost == "" || inst.SSHPort <= 0) {
 		return core.LeaseTarget{Server: b.serverFromInstance(inst, claim, cfg), LeaseID: leaseID}, nil
@@ -283,7 +283,7 @@ func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.Doctor
 		return core.DoctorResult{}, err
 	}
 	if strings.TrimSpace(resp.Status) != "ok" {
-		return core.DoctorResult{}, exit(2, "apple-vm doctor failed: %s", core.Blank(resp.Message, "unknown error"))
+		return core.DoctorResult{}, core.Exit(2, "apple-vm doctor failed: %s", core.Blank(resp.Message, "unknown error"))
 	}
 	if image := strings.TrimSpace(resp.Details["image"]); image != "" {
 		resp.Details["image"] = applevmhelper.RedactImageRef(image)
@@ -334,7 +334,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 		core.RemoveStoredTestboxKey(leaseID)
 	}
 	if name == "" && leaseID == "" {
-		return exit(2, "provider=%s release requires an apple-vm instance name or lease id", providerName)
+		return core.Exit(2, "provider=%s release requires an apple-vm instance name or lease id", providerName)
 	}
 	return nil
 }
@@ -362,7 +362,7 @@ func appleVMClaimStatus(leaseID, instanceName string) (owned, conflict bool, err
 }
 
 func appleVMOwnershipError(leaseID, instanceName string) error {
-	return exit(4, "apple-vm lease %q has no exact local claim bound to instance %q; adopt it with an explicit --reclaim reuse before stop", strings.TrimSpace(leaseID), strings.TrimSpace(instanceName))
+	return core.Exit(4, "apple-vm lease %q has no exact local claim bound to instance %q; adopt it with an explicit --reclaim reuse before stop", strings.TrimSpace(leaseID), strings.TrimSpace(instanceName))
 }
 
 func requireExactAppleVMClaim(leaseID, instanceName string) error {
@@ -509,7 +509,7 @@ func (b *backend) prepareLease(ctx context.Context, cfg core.Config, inst applev
 		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
 	}
 	if inst.SSHHost == "" || inst.SSHPort <= 0 {
-		return core.LeaseTarget{}, exit(5, "apple-vm instance %s has no local SSH endpoint", inst.Name)
+		return core.LeaseTarget{}, core.Exit(5, "apple-vm instance %s has no local SSH endpoint", inst.Name)
 	}
 	if leaseID != "" {
 		if keyPath, err := core.OptionalStoredTestboxKeyPath(leaseID); err == nil {
@@ -666,7 +666,7 @@ func (b *backend) listInstances(ctx context.Context, cfg core.Config) ([]applevm
 func (b *backend) resolveInstance(ctx context.Context, cfg core.Config, identifier string) (applevmhelper.Instance, core.LeaseClaim, error) {
 	identifier = strings.TrimSpace(identifier)
 	if identifier == "" {
-		return applevmhelper.Instance{}, core.LeaseClaim{}, exit(2, "provider=%s requires a lease id, slug, or instance name", providerName)
+		return applevmhelper.Instance{}, core.LeaseClaim{}, core.Exit(2, "provider=%s requires a lease id, slug, or instance name", providerName)
 	}
 	instances, err := b.listInstances(ctx, cfg)
 	if err != nil {
@@ -692,7 +692,7 @@ func (b *backend) resolveInstance(ctx context.Context, cfg core.Config, identifi
 				}
 			}
 			return applevmhelper.Instance{}, requestedClaim, &missingInstanceError{
-				err: exit(4, "apple-vm lease %q points to a missing instance; run `crabbox cleanup --provider apple-vm`", identifier),
+				err: core.Exit(4, "apple-vm lease %q points to a missing instance; run `crabbox cleanup --provider apple-vm`", identifier),
 			}
 		}
 	}
@@ -702,7 +702,7 @@ func (b *backend) resolveInstance(ctx context.Context, cfg core.Config, identifi
 		claim := claims[inst.Name]
 		if inst.Name == identifier || inst.LeaseID == identifier || inst.Slug == identifier || claim.LeaseID == identifier || claim.Slug == identifier {
 			if matched != nil {
-				return applevmhelper.Instance{}, core.LeaseClaim{}, exit(2, "apple-vm identifier %s matches multiple instances; use an exact claimed instance name", identifier)
+				return applevmhelper.Instance{}, core.LeaseClaim{}, core.Exit(2, "apple-vm identifier %s matches multiple instances; use an exact claimed instance name", identifier)
 			}
 			candidate := inst
 			matched, matchedClaim = &candidate, claim
@@ -713,10 +713,10 @@ func (b *backend) resolveInstance(ctx context.Context, cfg core.Config, identifi
 	}
 	if hasRequestedClaim {
 		return applevmhelper.Instance{}, requestedClaim, &missingInstanceError{
-			err: exit(4, "apple-vm lease %q points to a missing instance; run `crabbox cleanup --provider apple-vm`", identifier),
+			err: core.Exit(4, "apple-vm lease %q points to a missing instance; run `crabbox cleanup --provider apple-vm`", identifier),
 		}
 	}
-	return applevmhelper.Instance{}, core.LeaseClaim{}, exit(4, "apple-vm lease not found: %s", identifier)
+	return applevmhelper.Instance{}, core.LeaseClaim{}, core.Exit(4, "apple-vm lease not found: %s", identifier)
 }
 
 type missingInstanceError struct {
@@ -797,7 +797,7 @@ func (b *backend) runHelperJSONInput(ctx context.Context, helperPath string, arg
 	if input != nil {
 		data, err := json.Marshal(input)
 		if err != nil {
-			return exit(2, "encode apple-vm helper input: %v", err)
+			return core.Exit(2, "encode apple-vm helper input: %v", err)
 		}
 		stdin = strings.NewReader(string(data))
 	}
@@ -809,13 +809,13 @@ func (b *backend) runHelperJSONInput(ctx context.Context, helperPath string, arg
 		CancelGracePeriod: helperCancelGracePeriod,
 	})
 	if err != nil {
-		return exit(2, "apple-vm helper %s failed: %s", strings.Join(args, " "), localCommandDetail(result, err))
+		return core.Exit(2, "apple-vm helper %s failed: %s", strings.Join(args, " "), localCommandDetail(result, err))
 	}
 	if out == nil {
 		return nil
 	}
 	if err := json.Unmarshal([]byte(result.Stdout), out); err != nil {
-		return exit(2, "apple-vm helper %s returned invalid JSON: %v", strings.Join(args, " "), err)
+		return core.Exit(2, "apple-vm helper %s returned invalid JSON: %v", strings.Join(args, " "), err)
 	}
 	return nil
 }
@@ -868,12 +868,12 @@ func (b *backend) appleVMStateRoot() (string, error) {
 		legacy := filepath.Join(stateDir, "apple-vz")
 		if _, legacyErr := os.Stat(legacy); legacyErr == nil {
 			if err := os.Rename(legacy, root); err != nil {
-				return "", exit(2, "migrate apple-vz state directory: %v", err)
+				return "", core.Exit(2, "migrate apple-vz state directory: %v", err)
 			}
 		}
 	}
 	if err := ensurePrivateDir(root); err != nil {
-		return "", exit(2, "create apple-vm state directory: %v", err)
+		return "", core.Exit(2, "create apple-vm state directory: %v", err)
 	}
 	return root, nil
 }
@@ -891,7 +891,7 @@ func resolveHelperSourcePath(cfg core.Config) (string, error) {
 		if _, err := os.Stat(path); err == nil {
 			return path, nil
 		}
-		return "", exit(2, "apple-vm helper not found at %s", path)
+		return "", core.Exit(2, "apple-vm helper not found at %s", path)
 	}
 	if exe, err := os.Executable(); err == nil {
 		sibling := filepath.Join(filepath.Dir(exe), applevmhelper.ManagedHelperName)
@@ -902,7 +902,7 @@ func resolveHelperSourcePath(cfg core.Config) (string, error) {
 	if path, err := exec.LookPath(applevmhelper.ManagedHelperName); err == nil {
 		return path, nil
 	}
-	return "", exit(2, "apple-vm helper binary not found. Reinstall Crabbox on Apple Silicon, put `%s` on PATH, or explicitly pass --apple-vm-helper for a source build", applevmhelper.ManagedHelperName)
+	return "", core.Exit(2, "apple-vm helper binary not found. Reinstall Crabbox on Apple Silicon, put `%s` on PATH, or explicitly pass --apple-vm-helper for a source build", applevmhelper.ManagedHelperName)
 }
 
 func providerClaims() (map[string]core.LeaseClaim, error) {
@@ -929,18 +929,18 @@ func instanceScope(name string) string { return name }
 
 func requireHost() error {
 	if hostGOOS != "darwin" || hostGOARCH != "arm64" {
-		return exit(2, "provider=%s requires macOS on Apple silicon; current host is %s/%s", providerName, hostGOOS, hostGOARCH)
+		return core.Exit(2, "provider=%s requires macOS on Apple silicon; current host is %s/%s", providerName, hostGOOS, hostGOARCH)
 	}
 	version, err := hostMacOSVersion()
 	if err != nil {
-		return exit(2, "provider=%s could not determine the macOS version: %v", providerName, err)
+		return core.Exit(2, "provider=%s could not determine the macOS version: %v", providerName, err)
 	}
 	major, err := macOSMajorVersion(version)
 	if err != nil {
-		return exit(2, "provider=%s could not parse macOS version %q: %v", providerName, version, err)
+		return core.Exit(2, "provider=%s could not parse macOS version %q: %v", providerName, version, err)
 	}
 	if major < 13 {
-		return exit(2, "provider=%s requires macOS 13 or newer for Virtualization.framework EFI support; current version is %s", providerName, version)
+		return core.Exit(2, "provider=%s requires macOS 13 or newer for Virtualization.framework EFI support; current version is %s", providerName, version)
 	}
 	return nil
 }
@@ -1059,8 +1059,4 @@ func localCommandDetail(result core.LocalCommandResult, err error) string {
 
 func firstNonBlank(values ...string) string {
 	return shared.FirstNonBlankTrimmed(values...)
-}
-
-func exit(code int, format string, args ...any) core.ExitError {
-	return core.Exit(code, format, args...)
 }

--- a/internal/providers/applevm/flags.go
+++ b/internal/providers/applevm/flags.go
@@ -94,7 +94,7 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	if image, set := stringFlag(fs, "apple-vm-image", v.Image, "apple-vz-image", v.LegacyImage); set {
 		image = strings.TrimSpace(image)
 		if applevmhelper.IsRemoteImageRef(image) {
-			return exit(2, "--apple-vm-image accepts local paths only; use CRABBOX_APPLE_VM_IMAGE or configuration for remote URLs")
+			return core.Exit(2, "--apple-vm-image accepts local paths only; use CRABBOX_APPLE_VM_IMAGE or configuration for remote URLs")
 		}
 		core.ApplyAppleVMImage(cfg, image)
 		core.RecordProviderFlagInputs(cfg, true, providerName)
@@ -115,7 +115,7 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	}
 	if cpus, set := intFlag(fs, "apple-vm-cpus", v.CPUs, "apple-vz-cpus", v.LegacyCPUs); set {
 		if cpus <= 0 {
-			return exit(2, "--apple-vm-cpus must be positive (got %d)", cpus)
+			return core.Exit(2, "--apple-vm-cpus must be positive (got %d)", cpus)
 		}
 		cfg.AppleVM.CPUs = cpus
 		core.MarkAppleVMCPUsExplicit(cfg)
@@ -123,7 +123,7 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	}
 	if memoryMiB, set := intFlag(fs, "apple-vm-memory", v.MemoryMiB, "apple-vz-memory", v.LegacyMemoryMiB); set {
 		if memoryMiB < 1024 {
-			return exit(2, "--apple-vm-memory must be at least 1024 MiB (got %d)", memoryMiB)
+			return core.Exit(2, "--apple-vm-memory must be at least 1024 MiB (got %d)", memoryMiB)
 		}
 		cfg.AppleVM.MemoryMiB = memoryMiB
 		core.MarkAppleVMMemoryExplicit(cfg)
@@ -131,7 +131,7 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	}
 	if diskGiB, set := intFlag(fs, "apple-vm-disk", v.DiskGiB, "apple-vz-disk", v.LegacyDiskGiB); set {
 		if diskGiB <= 0 {
-			return exit(2, "--apple-vm-disk must be positive (got %d)", diskGiB)
+			return core.Exit(2, "--apple-vm-disk must be positive (got %d)", diskGiB)
 		}
 		cfg.AppleVM.DiskGiB = diskGiB
 		core.MarkAppleVMDiskExplicit(cfg)

--- a/internal/providers/lambda/backend.go
+++ b/internal/providers/lambda/backend.go
@@ -227,7 +227,7 @@ func (b *backend) launchRequest(cfg core.Config, leaseID, slug, publicKey string
 		InstanceTypeName: typeForConfig(cfg),
 		Quantity:         1,
 		SSHKeyNames:      []string{key.Name},
-		UserData:         lambdaUserData(cfg, publicKey),
+		UserData:         core.CloudInitUserData(cfg, publicKey),
 	}
 	if image := imageForConfig(cfg); image != "" {
 		req.ImageID = image

--- a/internal/providers/lambda/cloudinit.go
+++ b/internal/providers/lambda/cloudinit.go
@@ -1,7 +1,0 @@
-package lambda
-
-import core "github.com/openclaw/crabbox/internal/cli"
-
-func lambdaUserData(cfg core.Config, publicKey string) string {
-	return core.CloudInitUserData(cfg, publicKey)
-}

--- a/internal/providers/ovh/backend.go
+++ b/internal/providers/ovh/backend.go
@@ -165,7 +165,7 @@ func (b *Backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 		return core.LeaseTarget{}, err
 	}
 	cfg.SSHKey = keyPath
-	cfg.ProviderKey = providerKeyForLease(leaseID)
+	cfg.ProviderKey = core.ProviderKeyForLease(leaseID)
 	if cfg.Tailscale.Enabled && cfg.Tailscale.Hostname == "" {
 		cfg.Tailscale.Hostname = core.RenderTailscaleHostname(cfg.Tailscale.HostnameTemplate, leaseID, slug, cfg.Provider)
 	}
@@ -933,7 +933,7 @@ func (b *Backend) reconcilePendingSSHKey(ctx context.Context, client API, claim 
 	if err != nil {
 		return core.LeaseTarget{}, false, fmt.Errorf("read retained OVH public key: %w", err)
 	}
-	key, found, err := b.reconcileSSHKey(ctx, client, b.Cfg.OVH.ProjectID, providerKeyForLease(claim.LeaseID), strings.TrimSpace(string(publicKey)))
+	key, found, err := b.reconcileSSHKey(ctx, client, b.Cfg.OVH.ProjectID, core.ProviderKeyForLease(claim.LeaseID), strings.TrimSpace(string(publicKey)))
 	if err != nil || !found {
 		return core.LeaseTarget{}, false, err
 	}
@@ -1447,8 +1447,4 @@ func blank(value string) string {
 
 func firstNonBlank(values ...string) string {
 	return shared.FirstNonBlank(values...)
-}
-
-func providerKeyForLease(leaseID string) string {
-	return core.ProviderKeyForLease(leaseID)
 }

--- a/internal/providers/ovh/backend_test.go
+++ b/internal/providers/ovh/backend_test.go
@@ -1179,7 +1179,7 @@ func TestAcquireRetainsAmbiguousSSHKeyClaimUntilExactKeyAppears(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fake.sshKeys = []SSHKey{{ID: "key-recovered", Name: providerKeyForLease(claims[0].LeaseID), PublicKey: strings.TrimSpace(string(publicKey))}}
+	fake.sshKeys = []SSHKey{{ID: "key-recovered", Name: core.ProviderKeyForLease(claims[0].LeaseID), PublicKey: strings.TrimSpace(string(publicKey))}}
 	resolved, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: claims[0].Slug, ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/providers/ovh/client.go
+++ b/internal/providers/ovh/client.go
@@ -251,7 +251,7 @@ func secureOVHHTTPClient(source *http.Client, trusted *url.URL) *http.Client {
 	client := *source
 	originalCheckRedirect := source.CheckRedirect
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameOVHOrigin(trusted, req.URL) {
+		if !core.SameHTTPOrigin(trusted, req.URL) {
 			return errOVHCrossOriginRedirect
 		}
 		if originalCheckRedirect != nil {
@@ -263,10 +263,6 @@ func secureOVHHTTPClient(source *http.Client, trusted *url.URL) *http.Client {
 		return nil
 	}
 	return &client
-}
-
-func sameOVHOrigin(a, b *url.URL) bool {
-	return core.SameHTTPOrigin(a, b)
 }
 
 func sanitizeOVHClientError(err error) error {

--- a/internal/providers/ovh/client_test.go
+++ b/internal/providers/ovh/client_test.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestClientRefusesCrossOriginRedirectBeforeSignedHeaderReplay(t *testing.T) {
@@ -135,13 +137,13 @@ func TestClientRedirectGuardUsesEffectiveOrigin(t *testing.T) {
 	same, _ := url.Parse("https://api.ovh.example.test:443/redirected")
 	otherPort, _ := url.Parse("https://api.ovh.example.test:444/redirected")
 	otherScheme, _ := url.Parse("http://api.ovh.example.test:443/redirected")
-	if !sameOVHOrigin(base, same) {
+	if !core.SameHTTPOrigin(base, same) {
 		t.Fatal("default HTTPS port should share origin")
 	}
-	if sameOVHOrigin(base, otherPort) {
+	if core.SameHTTPOrigin(base, otherPort) {
 		t.Fatal("different effective port should be refused")
 	}
-	if sameOVHOrigin(base, otherScheme) {
+	if core.SameHTTPOrigin(base, otherScheme) {
 		t.Fatal("different scheme should be refused")
 	}
 }

--- a/internal/providers/scaleway/client.go
+++ b/internal/providers/scaleway/client.go
@@ -185,7 +185,7 @@ func (t *scalewayRedirectTransport) RoundTrip(req *http.Request) (*http.Response
 	switch {
 	case parseErr != nil:
 		marker = scalewayRedirectInvalid
-	case !sameScalewayOrigin(t.trusted, target):
+	case !core.SameHTTPOrigin(t.trusted, target):
 		marker = scalewayRedirectCrossOrigin
 	case t.enforceDefaultLimit && scalewayRedirectHop(req.Context()) >= 9:
 		marker = scalewayRedirectLimit
@@ -249,7 +249,7 @@ func secureScalewayHTTPClient(source *http.Client, trusted *url.URL) *http.Clien
 				return errScalewayRedirectLimit
 			}
 		}
-		if !sameScalewayOrigin(trusted, req.URL) {
+		if !core.SameHTTPOrigin(trusted, req.URL) {
 			return errScalewayCrossOriginRedirect
 		}
 		if originalCheckRedirect != nil {
@@ -276,10 +276,6 @@ func isScalewayRedirect(status int) bool {
 	default:
 		return false
 	}
-}
-
-func sameScalewayOrigin(a, b *url.URL) bool {
-	return core.SameHTTPOrigin(a, b)
 }
 
 func scalewayProfileFromSDKConfig() (*scw.Profile, error) {

--- a/internal/providers/scaleway/client_test.go
+++ b/internal/providers/scaleway/client_test.go
@@ -230,13 +230,13 @@ func TestScalewayRedirectGuardUsesEffectiveOrigin(t *testing.T) {
 	same, _ := url.Parse("https://api.scaleway.example.test:443/redirected")
 	otherPort, _ := url.Parse("https://api.scaleway.example.test:444/redirected")
 	otherScheme, _ := url.Parse("http://api.scaleway.example.test:443/redirected")
-	if !sameScalewayOrigin(base, same) {
+	if !core.SameHTTPOrigin(base, same) {
 		t.Fatal("default HTTPS port should share origin")
 	}
-	if sameScalewayOrigin(base, otherPort) {
+	if core.SameHTTPOrigin(base, otherPort) {
 		t.Fatal("different effective port should be refused")
 	}
-	if sameScalewayOrigin(base, otherScheme) {
+	if core.SameHTTPOrigin(base, otherScheme) {
 		t.Fatal("different scheme should be refused")
 	}
 }

--- a/internal/providers/sealosdevbox/backend.go
+++ b/internal/providers/sealosdevbox/backend.go
@@ -227,7 +227,7 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (lease c
 			return
 		}
 	}()
-	item, err := b.waitForDevboxPrepared(ctx, name, bootstrapWaitTimeout(b.cfg))
+	item, err := b.waitForDevboxPrepared(ctx, name, core.BootstrapWaitTimeout(b.cfg))
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
@@ -263,7 +263,7 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (lease c
 		return core.LeaseTarget{}, err
 	}
 	claimPersisted = true
-	secret, err := b.waitForDevboxSecret(ctx, item, bootstrapWaitTimeout(b.cfg))
+	secret, err := b.waitForDevboxSecret(ctx, item, core.BootstrapWaitTimeout(b.cfg))
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
@@ -448,7 +448,7 @@ func (b *backend) resumeDevboxIfPaused(ctx context.Context, item devboxItem, ser
 	if err := b.patchDevboxState(ctx, name, item.Metadata.ResourceVersion, devboxStateRun, nil); err != nil {
 		return item, server, err
 	}
-	resumed, err := b.waitForDevboxPrepared(ctx, name, bootstrapWaitTimeout(b.cfg))
+	resumed, err := b.waitForDevboxPrepared(ctx, name, core.BootstrapWaitTimeout(b.cfg))
 	if err != nil {
 		return item, server, err
 	}
@@ -699,8 +699,4 @@ func sleepContext(ctx context.Context, d time.Duration) error {
 	case <-timer.C:
 		return nil
 	}
-}
-
-func bootstrapWaitTimeout(cfg core.Config) time.Duration {
-	return core.BootstrapWaitTimeout(cfg)
 }

--- a/internal/providers/sealosdevbox/devbox.go
+++ b/internal/providers/sealosdevbox/devbox.go
@@ -152,7 +152,7 @@ func (b *backend) renderDevboxManifest(name, leaseID, slug string, keep bool, no
 			Network:      devboxNetworkSpec{Type: network},
 			Config: devboxConfigSpec{
 				User:       strings.TrimSpace(cfg.SSHUser),
-				WorkingDir: sealosWorkRoot(b.cfg),
+				WorkingDir: core.EffectiveSealosDevboxWorkRoot(b.cfg),
 				Ports:      []devboxPortSpec{{Name: devboxSSHPortName, ContainerPort: 22, Protocol: "TCP"}},
 			},
 			Tolerations: []devboxToleration{{

--- a/internal/providers/sealosdevbox/flags.go
+++ b/internal/providers/sealosdevbox/flags.go
@@ -59,7 +59,7 @@ func validateBaseConfig(cfg core.Config) error {
 			return core.Exit(2, "sealos-devbox SSH gateway port must be between 1 and 65535")
 		}
 	}
-	clean := path.Clean(sealosWorkRoot(cfg))
+	clean := path.Clean(core.EffectiveSealosDevboxWorkRoot(cfg))
 	if !strings.HasPrefix(clean, "/") {
 		return core.Exit(2, "sealosDevbox.workRoot %q must resolve to an absolute path", values.WorkRoot)
 	}
@@ -102,8 +102,4 @@ func normalizeNetwork(value string) string {
 	default:
 		return strings.TrimSpace(value)
 	}
-}
-
-func sealosWorkRoot(cfg core.Config) string {
-	return core.EffectiveSealosDevboxWorkRoot(cfg)
 }

--- a/internal/providers/sealosdevbox/provider.go
+++ b/internal/providers/sealosdevbox/provider.go
@@ -60,7 +60,7 @@ func (Provider) CommandRouting(cfg core.Config, _ core.CommandRoutingRequest) co
 		"--sealos-devbox-network", normalizeNetwork(values.Network),
 		"--sealos-devbox-ssh-gateway-port", values.SSHGatewayPort,
 		"--sealos-devbox-ssh-user", values.SSHUser,
-		"--sealos-devbox-work-root", sealosWorkRoot(cfg),
+		"--sealos-devbox-work-root", core.EffectiveSealosDevboxWorkRoot(cfg),
 	}
 	for _, optional := range []struct {
 		flagName string
@@ -107,7 +107,7 @@ func prepareBackendConfig(cfg core.Config) core.Config {
 	cfg.SSHUser = cfg.SealosDevbox.SSHUser
 	cfg.SSHPort = cfg.SealosDevbox.SSHGatewayPort
 	cfg.SSHFallbackPorts = nil
-	cfg.WorkRoot = sealosWorkRoot(cfg)
+	cfg.WorkRoot = core.EffectiveSealosDevboxWorkRoot(cfg)
 	if strings.EqualFold(cfg.SealosDevbox.Network, networkNodePort) {
 		cfg.SSHPort = "22"
 	}

--- a/internal/providers/sealosdevbox/ssh.go
+++ b/internal/providers/sealosdevbox/ssh.go
@@ -167,7 +167,7 @@ func (b *backend) waitForSSH(ctx context.Context, target *core.SSHTarget, phase 
 	if waiter == nil {
 		waiter = core.WaitForSSHReady
 	}
-	return waiter(ctx, target, b.rt.Stderr, phase, bootstrapWaitTimeout(b.cfg))
+	return waiter(ctx, target, b.rt.Stderr, phase, core.BootstrapWaitTimeout(b.cfg))
 }
 
 func (b *backend) prepareSSH(ctx context.Context, target *core.SSHTarget, phase string) error {

--- a/internal/providers/semaphore/api.go
+++ b/internal/providers/semaphore/api.go
@@ -318,7 +318,7 @@ func (c *apiClient) resolvePaginationRef(ref string) (string, error) {
 	if resolved.User != nil {
 		return "", fmt.Errorf("semaphore pagination link contains userinfo")
 	}
-	if !sameOriginURL(base, resolved) {
+	if !core.SameHTTPOrigin(base, resolved) {
 		return "", fmt.Errorf("semaphore pagination link points outside configured host")
 	}
 	return resolved.RequestURI(), nil
@@ -350,14 +350,10 @@ func (c *apiClient) apiURL(path string) (string, error) {
 	if resolved.User != nil {
 		return "", fmt.Errorf("semaphore request URL contains userinfo")
 	}
-	if !sameOriginURL(base, resolved) {
+	if !core.SameHTTPOrigin(base, resolved) {
 		return "", fmt.Errorf("semaphore request URL points outside configured host")
 	}
 	return resolved.String(), nil
-}
-
-func sameOriginURL(a, b *url.URL) bool {
-	return core.SameHTTPOrigin(a, b)
 }
 
 func (c *apiClient) getWithHeaders(ctx context.Context, path string) ([]byte, http.Header, error) {


### PR DESCRIPTION
Remove the remaining exact core utility forwarders in Apple VM, Lambda, OVHcloud, Scaleway, Sealos Devbox, and Semaphore. Call the existing SSH error, bootstrap, key naming, work-root, and origin-comparison owners directly, and delete the empty Lambda wrapper file.

Validation: full tests passed for all six providers; scoped Autoreview passed. CI is required before merge. Provider-specific validation and ownership policy are unchanged; no dependencies or configuration changes.
