### PR TITLE
refactor(providers): consolidate common helper policies

### DIFF
--- a/internal/cli/sleep_context.go
+++ b/internal/cli/sleep_context.go
@@ -5,6 +5,11 @@ import (
 	"time"
 )
 
+// SleepContext waits for delay and preserves ctx.Err as the cancellation result.
+func SleepContext(ctx context.Context, delay time.Duration) error {
+	return sleepContext(ctx, delay)
+}
+
 // sleepContext waits for delay or returns early when ctx is cancelled.
 // Matches the pattern used by GCP/Azure WaitForServerIP and provider backends.
 func sleepContext(ctx context.Context, delay time.Duration) error {

--- a/internal/cli/sleep_context_test.go
+++ b/internal/cli/sleep_context_test.go
@@ -25,6 +25,15 @@ func TestSleepContextHonorsCancellation(t *testing.T) {
 	}
 }
 
+func TestSleepContextPreservesContextError(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(errors.New("provider cancellation detail"))
+	if err := SleepContext(ctx, time.Hour); err != context.Canceled {
+		t.Fatalf("SleepContext returned %v, want context.Canceled", err)
+	}
+}
+
 func TestSleepContextCompletesWhenContextStaysLive(t *testing.T) {
 	t.Parallel()
 	start := time.Now()

--- a/internal/providers/applecontainer/backend.go
+++ b/internal/providers/applecontainer/backend.go
@@ -512,7 +512,7 @@ func appleContainerCacheVolumeMounts(volumes []core.CacheVolumeConfig) ([]string
 		if !strings.HasPrefix(path, "/") {
 			return nil, core.Exit(2, "cache volume path %q must be absolute", path)
 		}
-		hostPath := filepath.Join(root, appleContainerCacheVolumeName(key))
+		hostPath := filepath.Join(root, shared.CacheVolumeName(key))
 		if err := os.MkdirAll(hostPath, 0o777); err != nil {
 			return nil, core.Exit(2, "create apple-container cache volume %s: %v", hostPath, err)
 		}
@@ -530,10 +530,6 @@ func appleContainerCacheRoot() (string, error) {
 		return "", core.Exit(2, "user cache directory is unavailable")
 	}
 	return filepath.Join(dir, "crabbox", "apple-container-cache"), nil
-}
-
-func appleContainerCacheVolumeName(key string) string {
-	return shared.CacheVolumeName(key)
 }
 
 func (b *backend) listContainers(ctx context.Context) ([]inspectContainer, error) {
@@ -652,7 +648,7 @@ func (b *backend) resolveContainer(ctx context.Context, identifier string) (insp
 		for _, c := range containers {
 			if c.id() == boundID {
 				labels := c.labels()
-				return c, firstNonBlank(resolvedClaim.LeaseID, labels["lease"]), firstNonBlank(resolvedClaim.Slug, labels["slug"]), nil
+				return c, shared.FirstNonBlank(resolvedClaim.LeaseID, labels["lease"]), shared.FirstNonBlank(resolvedClaim.Slug, labels["slug"]), nil
 			}
 		}
 		return inspectContainer{}, "", "", core.Exit(4, "apple-container lease not found: %s", identifier)
@@ -824,7 +820,7 @@ func (b *backend) serverFromContainer(c inspectContainer, cfg core.Config) core.
 		labels["provider"] = providerName
 	}
 	if labels["server_type"] == "" {
-		labels["server_type"] = firstNonBlank(c.image(), cfg.AppleContainer.Image)
+		labels["server_type"] = shared.FirstNonBlank(c.image(), cfg.AppleContainer.Image)
 	}
 	if labels["state"] == "" {
 		labels["state"] = c.status()
@@ -842,7 +838,7 @@ func (b *backend) serverFromContainer(c inspectContainer, cfg core.Config) core.
 		Labels:   labels,
 	}
 	server.PublicNet.IPv4.IP = c.ip()
-	server.ServerType.Name = firstNonBlank(labels["server_type"], cfg.AppleContainer.Image)
+	server.ServerType.Name = shared.FirstNonBlank(labels["server_type"], cfg.AppleContainer.Image)
 	return server
 }
 
@@ -991,10 +987,6 @@ func uniqueAppleContainerDNSServers(servers []string, limit int) []string {
 		}
 	}
 	return unique
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlank(values...)
 }
 
 // bootstrapScript provisions sshd, the Crabbox SSH user and work root inside a

--- a/internal/providers/applecontainer/backend_test.go
+++ b/internal/providers/applecontainer/backend_test.go
@@ -18,6 +18,7 @@ import (
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	_ "github.com/openclaw/crabbox/internal/providers/applemachine"
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func TestConcreteFlagInputAttribution(t *testing.T) {
@@ -516,7 +517,7 @@ func TestCreateContainerMountsCacheVolumes(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, volume := range cfg.Cache.Volumes {
-		want := "--volume\n" + filepath.Join(root, appleContainerCacheVolumeName(volume.Key)) + ":" + volume.Path
+		want := "--volume\n" + filepath.Join(root, shared.CacheVolumeName(volume.Key)) + ":" + volume.Path
 		if !strings.Contains(args, want) {
 			t.Fatalf("cache volume mount missing %q:\n%s", want, args)
 		}
@@ -530,8 +531,8 @@ func TestCreateContainerMountsCacheVolumes(t *testing.T) {
 }
 
 func TestAppleContainerCacheVolumeNameIsStableAndFilesystemSafe(t *testing.T) {
-	got := appleContainerCacheVolumeName("My App/linux node24 lock")
-	again := appleContainerCacheVolumeName("My App/linux node24 lock")
+	got := shared.CacheVolumeName("My App/linux node24 lock")
+	again := shared.CacheVolumeName("My App/linux node24 lock")
 	if got != again {
 		t.Fatalf("cache volume name unstable: %q then %q", got, again)
 	}

--- a/internal/providers/applecontainer/client.go
+++ b/internal/providers/applecontainer/client.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 // inspectContainer mirrors the JSON returned by `container inspect <id>` and
@@ -160,7 +162,7 @@ func (c inspectContainer) ip() string {
 
 func firstNetworkAddress(networks []inspectNetwork) string {
 	for _, n := range networks {
-		addr := firstNonBlank(n.Address, n.IPv4Address)
+		addr := shared.FirstNonBlank(n.Address, n.IPv4Address)
 		if addr == "" {
 			continue
 		}

--- a/internal/providers/applevm/backend.go
+++ b/internal/providers/applevm/backend.go
@@ -206,8 +206,8 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
-	leaseID := firstNonBlank(claim.LeaseID, inst.LeaseID)
-	slug := firstNonBlank(claim.Slug, inst.Slug)
+	leaseID := shared.FirstNonBlankTrimmed(claim.LeaseID, inst.LeaseID)
+	slug := shared.FirstNonBlankTrimmed(claim.Slug, inst.Slug)
 	claim.LeaseID = leaseID
 	claim.Slug = slug
 	if leaseID == "" {
@@ -306,8 +306,8 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 	if err := requireHost(); err != nil {
 		return err
 	}
-	leaseID := firstNonBlank(req.Lease.LeaseID, req.Lease.Server.Labels["lease"])
-	name := strings.TrimSpace(firstNonBlank(req.Lease.Server.CloudID, req.Lease.Server.Labels["instance"]))
+	leaseID := shared.FirstNonBlankTrimmed(req.Lease.LeaseID, req.Lease.Server.Labels["lease"])
+	name := strings.TrimSpace(shared.FirstNonBlankTrimmed(req.Lease.Server.CloudID, req.Lease.Server.Labels["instance"]))
 	if name == "" && leaseID != "" {
 		inst, claim, err := b.resolveInstance(ctx, cfg, leaseID)
 		if err != nil {
@@ -315,10 +315,10 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 			if !errors.As(err, &missing) {
 				return err
 			}
-			leaseID = firstNonBlank(leaseID, claim.LeaseID)
+			leaseID = shared.FirstNonBlankTrimmed(leaseID, claim.LeaseID)
 		} else {
 			name = inst.Name
-			leaseID = firstNonBlank(leaseID, claim.LeaseID, inst.LeaseID)
+			leaseID = shared.FirstNonBlankTrimmed(leaseID, claim.LeaseID, inst.LeaseID)
 		}
 	}
 	if name != "" {
@@ -377,7 +377,7 @@ func requireExactAppleVMClaim(leaseID, instanceName string) error {
 }
 
 func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
-	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, core.Blank(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
+	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, core.Blank(shared.FirstNonBlankTrimmed(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
 }
 
 func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
@@ -406,7 +406,7 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	removed := 0
 	for _, inst := range instances {
 		claim, hasClaim := claims[inst.Name]
-		leaseID := firstNonBlank(claim.LeaseID, inst.LeaseID)
+		leaseID := shared.FirstNonBlankTrimmed(claim.LeaseID, inst.LeaseID)
 		if hasClaim && claim.LeaseID != "" {
 			live[claim.LeaseID] = struct{}{}
 			claim.LeaseID = leaseID
@@ -502,7 +502,7 @@ func (b *backend) prepareLease(ctx context.Context, cfg core.Config, inst applev
 		cfg.AppleVM.WorkRoot = root
 		cfg.WorkRoot = root
 	}
-	leaseID := firstNonBlank(claim.LeaseID, inst.LeaseID)
+	leaseID := shared.FirstNonBlankTrimmed(claim.LeaseID, inst.LeaseID)
 	if !appleVMRunning(inst.Status) {
 		server.Status = appleVMState(inst.Status)
 		server.Labels["state"] = server.Status
@@ -746,22 +746,22 @@ func (b *backend) serverFromInstance(inst applevmhelper.Instance, claim core.Lea
 		labels["instance"] = inst.Name
 	}
 	if labels["lease"] == "" {
-		labels["lease"] = firstNonBlank(claim.LeaseID, inst.LeaseID)
+		labels["lease"] = shared.FirstNonBlankTrimmed(claim.LeaseID, inst.LeaseID)
 	}
 	if labels["slug"] == "" {
-		labels["slug"] = firstNonBlank(claim.Slug, inst.Slug)
+		labels["slug"] = shared.FirstNonBlankTrimmed(claim.Slug, inst.Slug)
 	}
 	imageIdentity := applevmhelper.ImageIdentity(cfg.AppleVM.Image, cfg.AppleVM.ImageSHA256)
 	if labels["server_type"] == "" {
-		labels["server_type"] = firstNonBlank(inst.Image, imageIdentity)
+		labels["server_type"] = shared.FirstNonBlankTrimmed(inst.Image, imageIdentity)
 	}
 	labels["server_type"] = applevmhelper.RedactImageRef(labels["server_type"])
 	if labels["image"] == "" {
-		labels["image"] = firstNonBlank(inst.Image, imageIdentity)
+		labels["image"] = shared.FirstNonBlankTrimmed(inst.Image, imageIdentity)
 	}
 	labels["image"] = applevmhelper.RedactImageRef(labels["image"])
 	if labels["ssh_user"] == "" {
-		labels["ssh_user"] = firstNonBlank(inst.SSHUser, cfg.AppleVM.User)
+		labels["ssh_user"] = shared.FirstNonBlankTrimmed(inst.SSHUser, cfg.AppleVM.User)
 	}
 	if inst.SSHPort > 0 {
 		labels["ssh_port"] = strconv.Itoa(inst.SSHPort)
@@ -769,7 +769,7 @@ func (b *backend) serverFromInstance(inst applevmhelper.Instance, claim core.Lea
 		labels["ssh_port"] = cfg.SSHPort
 	}
 	if labels["work_root"] == "" {
-		labels["work_root"] = firstNonBlank(inst.WorkRoot, cfg.AppleVM.WorkRoot)
+		labels["work_root"] = shared.FirstNonBlankTrimmed(inst.WorkRoot, cfg.AppleVM.WorkRoot)
 	}
 	status := appleVMState(inst.Status)
 	if appleVMRunning(inst.Status) && labels["state"] == "ready" {
@@ -784,7 +784,7 @@ func (b *backend) serverFromInstance(inst applevmhelper.Instance, claim core.Lea
 		Labels:   labels,
 	}
 	server.PublicNet.IPv4.IP = inst.SSHHost
-	server.ServerType.Name = applevmhelper.RedactImageRef(firstNonBlank(labels["server_type"], imageIdentity))
+	server.ServerType.Name = applevmhelper.RedactImageRef(shared.FirstNonBlankTrimmed(labels["server_type"], imageIdentity))
 	return server
 }
 
@@ -1055,8 +1055,4 @@ func localCommandDetail(result core.LocalCommandResult, err error) string {
 		return "no output"
 	}
 	return strings.Join(parts, " ")
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlankTrimmed(values...)
 }

--- a/internal/providers/asciibox/backend.go
+++ b/internal/providers/asciibox/backend.go
@@ -539,7 +539,7 @@ func boxSSHTarget(cfg core.Config, box boxData) (core.SSHTarget, error) {
 }
 
 func boxSSHConnection(box boxData) (string, string, error) {
-	if endpoint := strings.TrimSpace(firstNonBlank(box.SSHEndpoint, box.SSHEndpointAlt)); endpoint != "" {
+	if endpoint := strings.TrimSpace(shared.FirstNonBlankTrimmed(box.SSHEndpoint, box.SSHEndpointAlt)); endpoint != "" {
 		host, port, err := net.SplitHostPort(endpoint)
 		if err != nil || strings.TrimSpace(host) == "" || strings.TrimSpace(port) == "" {
 			return "", "", core.Exit(5, "ascii-box %s has invalid SSH endpoint %q", box.ID, endpoint)
@@ -558,15 +558,15 @@ func boxSSHKey(cfg core.Config) string {
 }
 
 func boxHost(box boxData) string {
-	return firstNonBlank(box.IP, box.MachineIP, box.MachineIPAlt, box.PublicIP)
+	return shared.FirstNonBlankTrimmed(box.IP, box.MachineIP, box.MachineIPAlt, box.PublicIP)
 }
 
 func boxSSHUser(box boxData) string {
-	return firstNonBlank(box.SSHUser, box.SSHUserAlt, "user")
+	return shared.FirstNonBlankTrimmed(box.SSHUser, box.SSHUserAlt, "user")
 }
 
 func boxState(box boxData) string {
-	return strings.ToLower(core.Blank(firstNonBlank(box.Status, box.State), "provisioning"))
+	return strings.ToLower(core.Blank(shared.FirstNonBlankTrimmed(box.Status, box.State), "provisioning"))
 }
 
 func boxExpiresAt(box boxData) string {
@@ -693,10 +693,6 @@ func cleanWorkdir(workdir string) (string, error) {
 		return "", core.Exit(2, "ascii-box workdir %q is too broad; choose a dedicated subdirectory", clean)
 	}
 	return clean, nil
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlankTrimmed(values...)
 }
 
 var waitForSSHReadyFunc = core.WaitForSSHReady

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -50,7 +50,7 @@ func (b *awsLeaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) 
 	if strings.TrimSpace(req.RequestedLeaseID) != "" {
 		return b.acquireFixed(ctx, req)
 	}
-	return acquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
+	return shared.AcquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
 		return b.acquireOnce(ctx, req.Keep, req.RequestedSlug)
 	})
 }
@@ -785,10 +785,6 @@ func (b *awsLeaseBackend) listAcrossRegions(ctx context.Context) ([]core.LeaseVi
 		}
 	}
 	return all, nil
-}
-
-func acquireAttemptsRetry(rt core.Runtime, keep bool, acquire func() (core.LeaseTarget, error)) (core.LeaseTarget, error) {
-	return shared.AcquireAttemptsRetry(rt, keep, acquire)
 }
 
 func chooseAWSRegion(ctx context.Context, cfg core.Config, stderr io.Writer) core.Config {

--- a/internal/providers/aws/provider.go
+++ b/internal/providers/aws/provider.go
@@ -313,7 +313,7 @@ func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (co
 	if req.Server.CloudID == "" {
 		return core.NativeCheckpointCapability{}, false
 	}
-	targetOS := firstNonBlank(req.Target.TargetOS, req.Config.TargetOS)
+	targetOS := shared.FirstNonEmpty(req.Target.TargetOS, req.Config.TargetOS)
 	strategy := core.NormalizeCheckpointStrategy(req.Strategy)
 	if isWindowsNativeTarget(req) {
 		if req.StrategyExplicit && strategy != core.CheckpointStrategyImage {
@@ -340,13 +340,8 @@ func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (co
 	return core.NativeCheckpointCapability{Kind: core.CheckpointKindAWSEBS, RetireSource: true}, true
 }
 
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonEmpty(values...)
-}
-
 func isWindowsNativeTarget(req core.NativeCheckpointRequest) bool {
-	return firstNonBlank(req.Target.TargetOS, req.Config.TargetOS) == core.TargetWindows &&
-		firstNonBlank(req.Target.WindowsMode, req.Config.WindowsMode) == core.WindowsModeNormal
+	return shared.FirstNonEmpty(req.Target.TargetOS, req.Config.TargetOS) == core.TargetWindows && shared.FirstNonEmpty(req.Target.WindowsMode, req.Config.WindowsMode) == core.WindowsModeNormal
 }
 
 func (Provider) ApplyNativeCheckpointForkConfig(req core.NativeCheckpointForkRequest) error {

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -37,7 +37,7 @@ func NewAzureLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runti
 }
 
 func (b *azureLeaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
-	return acquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
+	return shared.AcquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
 		return b.acquireOnce(ctx, req.Keep, req.RequestedSlug)
 	})
 }
@@ -414,10 +414,6 @@ func listOwnedAzureServers(ctx context.Context, client azureClient) ([]core.Serv
 		}
 	}
 	return owned, nil
-}
-
-func acquireAttemptsRetry(rt core.Runtime, keep bool, acquire func() (core.LeaseTarget, error)) (core.LeaseTarget, error) {
-	return shared.AcquireAttemptsRetry(rt, keep, acquire)
 }
 
 var newAzureClient = func(ctx context.Context, cfg core.Config) (azureClient, error) {

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -317,8 +317,8 @@ func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (co
 	if req.Server.CloudID == "" {
 		return core.NativeCheckpointCapability{}, false
 	}
-	targetOS := firstNonBlank(req.Target.TargetOS, req.Config.TargetOS)
-	if targetOS == core.TargetWindows && firstNonBlank(req.Target.WindowsMode, req.Config.WindowsMode) == core.WindowsModeNormal {
+	targetOS := shared.FirstNonEmpty(req.Target.TargetOS, req.Config.TargetOS)
+	if targetOS == core.TargetWindows && shared.FirstNonEmpty(req.Target.WindowsMode, req.Config.WindowsMode) == core.WindowsModeNormal {
 		if core.NormalizeCheckpointStrategy(req.Strategy) == core.CheckpointStrategyImage {
 			return core.NativeCheckpointCapability{}, false
 		}
@@ -336,27 +336,23 @@ func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (co
 	return core.NativeCheckpointCapability{Kind: core.CheckpointKindAzureOS, RetireSource: true}, true
 }
 
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonEmpty(values...)
-}
-
 func (Provider) ApplyNativeCheckpointForkConfig(req core.NativeCheckpointForkRequest) error {
 	cfg := req.Config
 	switch req.Record.Kind {
 	case core.CheckpointKindAzure:
-		cfg.AzureImage = firstNonBlank(req.Record.Resource, req.Record.ImageID)
+		cfg.AzureImage = shared.FirstNonEmpty(req.Record.Resource, req.Record.ImageID)
 	case core.CheckpointKindAzureOS:
-		cfg.AzureSnapshot = firstNonBlank(req.Record.Resource, req.Record.ImageID)
+		cfg.AzureSnapshot = shared.FirstNonEmpty(req.Record.Resource, req.Record.ImageID)
 	default:
 		return core.Exit(2, "provider=azure does not support checkpoint kind=%s", req.Record.Kind)
 	}
 	if req.Record.Region != "" {
 		cfg.AzureLocation = req.Record.Region
 	}
-	if resourceGroup := azureResourceGroup(firstNonBlank(req.Record.Resource, req.Record.ImageID)); resourceGroup != "" {
+	if resourceGroup := azureResourceGroup(shared.FirstNonEmpty(req.Record.Resource, req.Record.ImageID)); resourceGroup != "" {
 		cfg.AzureResourceGroup = resourceGroup
 	}
-	if subscription := azureSubscription(firstNonBlank(req.Record.Resource, req.Record.ImageID)); subscription != "" {
+	if subscription := azureSubscription(shared.FirstNonEmpty(req.Record.Resource, req.Record.ImageID)); subscription != "" {
 		cfg.AzureSubscription = subscription
 	}
 	if req.AzureOSDiskExplicit {

--- a/internal/providers/azuredynamicsessions/client.go
+++ b/internal/providers/azuredynamicsessions/client.go
@@ -122,7 +122,7 @@ func azureDynamicSessionsEndpoint(cfg core.Config) (string, error) {
 	if parsed.User != nil {
 		return "", core.Exit(2, "%s endpoint must not include userinfo", providerName)
 	}
-	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
+	if parsed.Scheme != "https" && !shared.IsLoopbackHTTPURL(parsed) {
 		return "", core.Exit(2, "%s endpoint %q must use https unless it targets localhost", providerName, endpoint)
 	}
 	if !isAzureDynamicSessionsTrustedEndpointURL(parsed) {
@@ -135,7 +135,7 @@ func azureDynamicSessionsEndpoint(cfg core.Config) (string, error) {
 }
 
 func isAzureDynamicSessionsTrustedEndpointURL(parsed *url.URL) bool {
-	if isLoopbackHTTPURL(parsed) {
+	if shared.IsLoopbackHTTPURL(parsed) {
 		return true
 	}
 	if parsed.Scheme != "https" {
@@ -143,10 +143,6 @@ func isAzureDynamicSessionsTrustedEndpointURL(parsed *url.URL) bool {
 	}
 	host := strings.ToLower(parsed.Hostname())
 	return host == "azurecontainerapps.io" || strings.HasSuffix(host, ".azurecontainerapps.io")
-}
-
-func isLoopbackHTTPURL(parsed *url.URL) bool {
-	return shared.IsLoopbackHTTPURL(parsed)
 }
 
 func azureDynamicSessionsAccessToken(ctx context.Context, cfg core.Config, rt core.Runtime) (string, error) {

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -251,14 +251,14 @@ func (b *blacksmithBackend) Run(ctx context.Context, req core.RunRequest) (runRe
 	commandDuration := commandEnd.Sub(commandStart)
 	commandPhases := core.FinishCommandPhaseTracker(phaseTracker, commandEnd)
 	total := finished.Sub(started)
-	actionsURL := firstNonBlank(stdoutProof.ActionsURL(), stderrProof.ActionsURL())
+	actionsURL := shared.FirstNonBlank(stdoutProof.ActionsURL(), stderrProof.ActionsURL())
 	result := core.RunResult{
 		Provider:      blacksmithTestboxProvider,
 		LeaseID:       leaseID,
 		Slug:          slug,
 		CommandText:   blacksmithCommandString(req.Command, req.ShellMode),
 		LogExcerpt:    core.SelectProofLogExcerpt(strings.TrimSpace(string(stdoutProof.Bytes()) + "\n" + string(stderrProof.Bytes()))),
-		ActionsURL:    firstNonBlank(actionsURL, firstBlacksmithActionsURL(string(stdoutProof.Bytes())+"\n"+string(stderrProof.Bytes()))),
+		ActionsURL:    shared.FirstNonBlank(actionsURL, firstBlacksmithActionsURL(string(stdoutProof.Bytes())+"\n"+string(stderrProof.Bytes()))),
 		ExitCode:      code,
 		Command:       commandDuration,
 		Total:         total,
@@ -385,10 +385,6 @@ type blacksmithProofTailBuffer struct {
 	fullChunk  bool
 }
 
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlank(values...)
-}
-
 func newBlacksmithProofTailBuffer() *blacksmithProofTailBuffer {
 	return &blacksmithProofTailBuffer{
 		data:     tailbuffer.NewLimited(blacksmithProofStreamCaptureBytes),
@@ -437,7 +433,7 @@ func (b *blacksmithBackend) blacksmithProofResult(req core.RunRequest, leaseID, 
 		Slug:        slug,
 		CommandText: blacksmithCommandString(req.Command, req.ShellMode),
 		LogExcerpt:  core.SelectProofLogExcerpt(combined),
-		ActionsURL:  firstNonBlank(actionsURL, firstBlacksmithActionsURL(combined)),
+		ActionsURL:  shared.FirstNonBlank(actionsURL, firstBlacksmithActionsURL(combined)),
 	}
 	if strings.TrimSpace(req.EmitProof) == "" {
 		return result, nil

--- a/internal/providers/blacksmith/nosync_test.go
+++ b/internal/providers/blacksmith/nosync_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 	"github.com/openclaw/crabbox/internal/testutil"
 )
 
@@ -54,7 +55,7 @@ func TestBlacksmithRunNoSyncContract(t *testing.T) {
 					}
 					if tc.id != "" {
 						prepareBlacksmithGuestKey(t, leaseID)
-						testOwnedBlacksmithClaim(t, leaseID, firstNonBlank(tc.slug, "jade-krill"), repo.Root)
+						testOwnedBlacksmithClaim(t, leaseID, shared.FirstNonBlank(tc.slug, "jade-krill"), repo.Root)
 					}
 					before, err := core.ReadLeaseClaim(leaseID)
 					if err != nil {

--- a/internal/providers/blacksmith/ownership.go
+++ b/internal/providers/blacksmith/ownership.go
@@ -39,7 +39,7 @@ func (b *blacksmithBackend) withRoute(ctx context.Context) (*blacksmithBackend, 
 	if b.route != nil {
 		return b, nil
 	}
-	route := blacksmithRoute{API: strings.TrimSpace(os.Getenv("BLACKSMITH_API_URL")), Org: strings.TrimSpace(firstNonBlank(b.cfg.Blacksmith.Org, os.Getenv("BLACKSMITH_ORG")))}
+	route := blacksmithRoute{API: strings.TrimSpace(os.Getenv("BLACKSMITH_API_URL")), Org: strings.TrimSpace(shared.FirstNonBlank(b.cfg.Blacksmith.Org, os.Getenv("BLACKSMITH_ORG")))}
 	if route.API == "" {
 		route.API = blacksmithDefaultAPI
 	}

--- a/internal/providers/blaxel/backend.go
+++ b/internal/providers/blaxel/backend.go
@@ -670,7 +670,7 @@ func (b *backend) cleanupCreateFailure(ctx context.Context, client Client, sandb
 		if strings.TrimSpace(localLeaseID) != "" {
 			return errors.Join(cause, fmt.Errorf("blaxel cleanup failed for sandbox %s; local claim %s remains for cleanup: %w", sandboxID, localLeaseID, cleanupErr))
 		}
-		recoveryID := recoveryPrefix + randomSuffix()
+		recoveryID := recoveryPrefix + shared.RandomSuffix()
 		if claimErr := core.ClaimLeaseForRepoProviderScopePond(recoveryID, "", providerName, claimScope, "", repo.Root, blaxelRecoveryLifetime(b.cfg), true); claimErr != nil {
 			return errors.Join(cause, fmt.Errorf("blaxel cleanup failed for sandbox %s and recovery claim failed: %v; delete it in the Blaxel console: %w", sandboxID, claimErr, cleanupErr))
 		}

--- a/internal/providers/blaxel/claims.go
+++ b/internal/providers/blaxel/claims.go
@@ -87,7 +87,7 @@ func newSandboxName(repo core.Repo) string {
 	if base == "" {
 		base = "crabbox"
 	}
-	return namePrefix + base + "-" + randomSuffix()
+	return namePrefix + base + "-" + shared.RandomSuffix()
 }
 
 func resolveLeaseID(identifier, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL, workspace string) (string, string, string, error) {
@@ -198,8 +198,4 @@ func timeoutOrDefault(primary, fallback time.Duration) time.Duration {
 		return primary
 	}
 	return fallback
-}
-
-func randomSuffix() string {
-	return shared.RandomSuffix()
 }

--- a/internal/providers/blaxel/client.go
+++ b/internal/providers/blaxel/client.go
@@ -160,7 +160,7 @@ func ValidateAPIURL(raw string) (string, error) {
 		return "", core.Exit(2, "provider=blaxel API URL must not contain userinfo, query parameters, or a fragment")
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
-	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && shared.IsLoopbackHost(parsed.Hostname())) {
 		return "", core.Exit(2, "provider=blaxel API URL must use HTTPS except for loopback development endpoints")
 	}
 	host := shared.LowercaseHostname(parsed.Hostname())
@@ -197,13 +197,13 @@ func validateSandboxEndpoint(raw, managementBase string) (string, error) {
 	host := shared.LowercaseHostname(parsed.Hostname())
 	if parsed.Scheme == "http" {
 		management, _ := url.Parse(managementBase)
-		if management == nil || !isLoopbackHost(management.Hostname()) || !isLoopbackHost(host) {
+		if management == nil || !shared.IsLoopbackHost(management.Hostname()) || !shared.IsLoopbackHost(host) {
 			return "", core.Exit(5, "blaxel sandbox metadata.url must use HTTPS except for loopback development endpoints")
 		}
 	} else if parsed.Scheme != "https" {
 		return "", core.Exit(5, "blaxel sandbox metadata.url must use HTTPS")
 	}
-	if !isLoopbackHost(host) && !isBlaxelDataPlaneHost(host) {
+	if !shared.IsLoopbackHost(host) && !isBlaxelDataPlaneHost(host) {
 		return "", core.Exit(5, "blaxel sandbox metadata.url host %q is not a trusted Blaxel data-plane origin", host)
 	}
 	port := parsed.Port()
@@ -244,10 +244,6 @@ func validateBlaxelConfig(cfg core.Config) error {
 		return err
 	}
 	return nil
-}
-
-func isLoopbackHost(host string) bool {
-	return shared.IsLoopbackHost(host)
 }
 
 func secureHTTPClient(source *http.Client) *http.Client {

--- a/internal/providers/cloudflare/client.go
+++ b/internal/providers/cloudflare/client.go
@@ -94,7 +94,7 @@ func newCloudflareClient(cfg core.Config, rt core.Runtime) (*cloudflareClient, e
 	if parsed.Scheme == "" || parsed.Host == "" {
 		return nil, core.Exit(2, "%s url %q is invalid", providerName, apiURL)
 	}
-	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
+	if parsed.Scheme != "https" && !shared.IsLoopbackHTTPURL(parsed) {
 		return nil, core.Exit(2, "%s url %q must use https unless it targets localhost", providerName, apiURL)
 	}
 	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
@@ -137,10 +137,6 @@ func defaultCloudflareHTTPClient() (*http.Client, error) {
 
 func cloudflareRedirectError(destination *url.URL) error {
 	return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, destination.Redacted())
-}
-
-func isLoopbackHTTPURL(parsed *url.URL) bool {
-	return shared.IsLoopbackHTTPURL(parsed)
 }
 
 func (c *cloudflareClient) createSandbox(ctx context.Context, req createSandboxRequest) (cloudflareContainer, error) {

--- a/internal/providers/cloudflaredynamicworkers/client.go
+++ b/internal/providers/cloudflaredynamicworkers/client.go
@@ -170,7 +170,7 @@ func loaderURL(cfg core.Config) (string, error) {
 	if parsed.User != nil {
 		return "", core.Exit(2, "%s loader URL must not include userinfo", providerName)
 	}
-	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
+	if parsed.Scheme != "https" && !shared.IsLoopbackHTTPURL(parsed) {
 		return "", core.Exit(2, "%s loader URL %q must use https unless it targets localhost", providerName, shared.EndpointURLForError(raw))
 	}
 	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
@@ -271,10 +271,6 @@ func asciiUpperHex(value byte) byte {
 		return value - ('a' - 'A')
 	}
 	return value
-}
-
-func isLoopbackHTTPURL(parsed *url.URL) bool {
-	return shared.IsLoopbackHTTPURL(parsed)
 }
 
 func defaultHTTPClient(cfg core.Config) (*http.Client, error) {
@@ -538,7 +534,7 @@ func (c *client) doJSON(ctx context.Context, method, endpoint string, input any,
 		}
 		if method == http.MethodGet && retryableReadStatus(resp.StatusCode) && attempt < len(c.readRetryDelays) {
 			_ = resp.Body.Close()
-			if err := waitForRetry(ctx, c.readRetryDelays[attempt]); err != nil {
+			if err := core.SleepContext(ctx, c.readRetryDelays[attempt]); err != nil {
 				return err
 			}
 			continue
@@ -560,17 +556,6 @@ func retryableReadStatus(statusCode int) bool {
 		return true
 	default:
 		return false
-	}
-}
-
-func waitForRetry(ctx context.Context, delay time.Duration) error {
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
 	}
 }
 

--- a/internal/providers/cloudrunsandbox/client.go
+++ b/internal/providers/cloudrunsandbox/client.go
@@ -107,10 +107,6 @@ func validateGatewayURL(raw string) (string, error) {
 	})
 }
 
-func isLoopbackHost(host string) bool {
-	return shared.IsLoopbackHost(host)
-}
-
 func cloudRunSandboxRedirectError(destination *url.URL) error {
 	return fmt.Errorf("cloud-run-sandbox refused cross-origin redirect to %s", destination.Redacted())
 }

--- a/internal/providers/cloudrunsandbox/client_test.go
+++ b/internal/providers/cloudrunsandbox/client_test.go
@@ -101,7 +101,7 @@ func TestClientHelpers(t *testing.T) {
 	if got := firstNonEmpty("", "  ", " value ", "later"); got != "value" {
 		t.Fatalf("firstNonEmpty=%q", got)
 	}
-	if !isLoopbackHost("localhost") || !isLoopbackHost("::1") || isLoopbackHost("example.com") {
+	if !shared.IsLoopbackHost("localhost") || !shared.IsLoopbackHost("::1") || shared.IsLoopbackHost("example.com") {
 		t.Fatal("unexpected loopback classification")
 	}
 	if err := validateEnv(map[string]string{"VALID_1": "x"}); err != nil {

--- a/internal/providers/codesandbox/claims.go
+++ b/internal/providers/codesandbox/claims.go
@@ -187,7 +187,7 @@ func newSandboxTitle(repo core.Repo) string {
 	if base == "" {
 		base = "workspace"
 	}
-	return codeSandboxNamePrefix + base + "-" + randomSuffix()
+	return codeSandboxNamePrefix + base + "-" + shared.RandomSuffix()
 }
 
 func codeSandboxWorkdir(cfg core.Config) (string, error) {
@@ -228,10 +228,6 @@ func isTerminalState(state string) bool {
 	default:
 		return false
 	}
-}
-
-func randomSuffix() string {
-	return shared.RandomSuffix()
 }
 
 func (b *codeSandboxBackend) cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/internal/providers/cua/flags.go
+++ b/internal/providers/cua/flags.go
@@ -102,7 +102,7 @@ func cuaAPIURL(cfg core.Config) (string, error) {
 		return "", core.Exit(2, "%s API URL must not contain userinfo, query parameters, or a fragment", providerName)
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
-	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && shared.IsLoopbackHost(parsed.Hostname())) {
 		return "", core.Exit(2, "%s API URL must use HTTPS except for loopback development endpoints", providerName)
 	}
 	host := canonicalHostname(parsed.Hostname())
@@ -123,10 +123,6 @@ func cuaAPIURL(cfg core.Config) (string, error) {
 	parsed.Path = strings.TrimSuffix(parsed.Path, "/v1")
 	parsed.RawPath = ""
 	return strings.TrimRight(parsed.String(), "/"), nil
-}
-
-func isLoopbackHost(host string) bool {
-	return shared.IsLoopbackHost(host)
 }
 
 func canonicalHostname(host string) string {

--- a/internal/providers/digitalocean/backend.go
+++ b/internal/providers/digitalocean/backend.go
@@ -680,7 +680,7 @@ func (b *digitalOceanLeaseBackend) targetFromDroplet(item droplet, req core.Reso
 		if expectedAccountID != accountID {
 			return core.LeaseTarget{}, core.Exit(3, "digitalocean account mismatch: current account %s does not match lease account %s", accountID, expectedAccountID)
 		}
-		liveCloudID := firstNonBlank(server.CloudID, strconv.FormatInt(server.ID, 10))
+		liveCloudID := shared.FirstNonBlank(server.CloudID, strconv.FormatInt(server.ID, 10))
 		if claim.CloudID != "" && claim.CloudID != liveCloudID {
 			return core.LeaseTarget{}, core.Exit(2, "refusing to resolve DigitalOcean Droplet %d from stale local claim", server.ID)
 		}
@@ -862,7 +862,7 @@ func (b *digitalOceanLeaseBackend) UpdateTailscaleMetadata(ctx context.Context, 
 	labels := normalizedDropletLabels(item.Tags)
 	preserveDigitalOceanKeyIdentity(labels, expected.Labels)
 	labels[digitalOceanAccountLabel] = accountID
-	applyTailscaleMetadata(labels, meta)
+	shared.ApplyTailscaleMetadata(labels, meta)
 	updatedClaim, server, _, err := core.UpdateLeaseClaimEndpointIfUnchangedAction(lease.LeaseID, expected, func() (core.Server, core.SSHTarget, bool, error) {
 		currentAccountID, err := client.AccountID(ctx)
 		if err != nil {
@@ -1021,7 +1021,7 @@ func validateDigitalOceanCleanupClaim(server core.Server, claim core.LeaseClaim,
 		if _, ok := parseDropletID(claim.CloudID); !ok {
 			return core.Exit(2, "digitalocean lease=%s has invalid immutable Droplet id %q", leaseID, claim.CloudID)
 		}
-		if liveID := firstNonBlank(server.CloudID, dropletIDString(server.ID)); liveID != "" && liveID != claim.CloudID {
+		if liveID := shared.FirstNonBlank(server.CloudID, dropletIDString(server.ID)); liveID != "" && liveID != claim.CloudID {
 			return core.Exit(2, "refusing to release DigitalOcean Droplet %d from stale local claim", server.ID)
 		}
 	} else {
@@ -1051,10 +1051,6 @@ func validateDigitalOceanCleanupClaim(server core.Server, claim core.LeaseClaim,
 		}
 	}
 	return nil
-}
-
-func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadata) {
-	shared.ApplyTailscaleMetadata(labels, meta)
 }
 
 func (b *digitalOceanLeaseBackend) deleteServer(ctx context.Context, _ core.Config, server core.Server) error {
@@ -1333,7 +1329,7 @@ func serverFromDroplet(item droplet, cfg core.Config) core.Server {
 		Labels:   labels,
 	}
 	server.PublicNet.IPv4.IP = publicIPv4(item)
-	server.ServerType.Name = firstNonBlank(item.Size.Slug, cfg.ServerType)
+	server.ServerType.Name = shared.FirstNonBlank(item.Size.Slug, cfg.ServerType)
 	return server
 }
 
@@ -1405,8 +1401,4 @@ func applyDigitalOceanDefaults(cfg *core.Config) {
 		cfg.SSHPort = "22"
 	}
 	cfg.SSHFallbackPorts = nil
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlank(values...)
 }

--- a/internal/providers/fastapicloud/client.go
+++ b/internal/providers/fastapicloud/client.go
@@ -162,7 +162,7 @@ func validateFastAPICloudAPIURL(raw string) (string, error) {
 		return "", core.Exit(2, "provider=%s API URL must not contain userinfo, query parameters, or a fragment", providerName)
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
-	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
+	if parsed.Scheme != "https" && !shared.IsLoopbackHTTPURL(parsed) {
 		return "", core.Exit(2, "provider=%s API URL must use HTTPS except for loopback development endpoints", providerName)
 	}
 	return apiURL, nil
@@ -334,8 +334,4 @@ func (c *fastAPICloudClient) endpoint(apiPath string, params url.Values) (string
 		parsed.RawQuery = params.Encode()
 	}
 	return parsed.String(), nil
-}
-
-func isLoopbackHTTPURL(parsed *url.URL) bool {
-	return shared.IsLoopbackHTTPURL(parsed)
 }

--- a/internal/providers/firecracker/backend.go
+++ b/internal/providers/firecracker/backend.go
@@ -372,7 +372,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 	if err != nil {
 		return err
 	}
-	leaseID := firstNonBlank(req.Lease.LeaseID, req.Lease.Server.Labels["lease"])
+	leaseID := shared.FirstNonBlankTrimmed(req.Lease.LeaseID, req.Lease.Server.Labels["lease"])
 	if !found {
 		if strings.TrimSpace(leaseID) != "" {
 			core.RemoveLeaseClaim(leaseID)
@@ -450,7 +450,7 @@ func (b *backend) Touch(_ context.Context, req core.TouchRequest) (core.Server, 
 	server.Status = state
 	server.Labels = core.TouchDirectLeaseLabels(server.Labels, cfg, state, b.currentTime().UTC())
 
-	leaseID := firstNonBlank(req.Lease.LeaseID, server.Labels["lease"])
+	leaseID := shared.FirstNonBlankTrimmed(req.Lease.LeaseID, server.Labels["lease"])
 	if strings.TrimSpace(leaseID) == "" {
 		return server, nil
 	}
@@ -555,8 +555,8 @@ func (b *backend) targetFromRecord(cfg core.Config, record leaseStateRecord) (co
 	if strings.TrimSpace(record.GuestIP) == "" {
 		return core.SSHTarget{}, core.Exit(5, "firecracker lease %s has no guest IP", record.LeaseID)
 	}
-	cfg.SSHUser = firstNonBlank(record.SSHUser, cfg.SSHUser)
-	cfg.SSHPort = firstNonBlank(record.SSHPort, cfg.SSHPort)
+	cfg.SSHUser = shared.FirstNonBlankTrimmed(record.SSHUser, cfg.SSHUser)
+	cfg.SSHPort = shared.FirstNonBlankTrimmed(record.SSHPort, cfg.SSHPort)
 	target := core.SSHTargetFromConfig(cfg, record.GuestIP)
 	if err := core.UseStoredTestboxKey(&target, record.LeaseID); err != nil {
 		return core.SSHTarget{}, err
@@ -575,29 +575,29 @@ func (b *backend) serverFromRecord(cfg core.Config, record leaseStateRecord, run
 		labels["state"] = status
 	}
 	server := core.Server{
-		CloudID:  firstNonBlank(record.VMID, record.Name, record.LeaseID),
+		CloudID:  shared.FirstNonBlankTrimmed(record.VMID, record.Name, record.LeaseID),
 		Provider: providerName,
-		Name:     firstNonBlank(record.Name, record.VMID, record.LeaseID),
+		Name:     shared.FirstNonBlankTrimmed(record.Name, record.VMID, record.LeaseID),
 		Status:   status,
 		Labels:   labels,
 	}
 	server.PublicNet.IPv4.IP = record.GuestIP
-	server.ServerType.Name = firstNonBlank(labels["server_type"], firecrackerServerTypeForConfig(cfg))
+	server.ServerType.Name = shared.FirstNonBlankTrimmed(labels["server_type"], firecrackerServerTypeForConfig(cfg))
 	return server
 }
 
 func serverFromClaim(cfg core.Config, claim core.LeaseClaim) core.Server {
 	labels := shared.CloneLabels(claim.Labels)
-	name := firstNonBlank(labels["instance"], core.LeaseProviderName(claim.LeaseID, claim.Slug))
+	name := shared.FirstNonBlankTrimmed(labels["instance"], core.LeaseProviderName(claim.LeaseID, claim.Slug))
 	server := core.Server{
 		CloudID:  name,
 		Provider: providerName,
 		Name:     name,
-		Status:   firstNonBlank(labels["state"], "unknown"),
+		Status:   shared.FirstNonBlankTrimmed(labels["state"], "unknown"),
 		Labels:   labels,
 	}
 	server.PublicNet.IPv4.IP = claim.SSHHost
-	server.ServerType.Name = firstNonBlank(labels["server_type"], firecrackerServerTypeForConfig(cfg))
+	server.ServerType.Name = shared.FirstNonBlankTrimmed(labels["server_type"], firecrackerServerTypeForConfig(cfg))
 	return server
 }
 
@@ -696,7 +696,7 @@ func (b *backend) releaseStateRecord(ctx context.Context, cfg core.Config, recor
 }
 
 func (b *backend) releaseRecordForLease(cfg core.Config, lease core.LeaseTarget) (leaseStateRecord, bool, error) {
-	identifier := firstNonBlank(lease.LeaseID, lease.Server.Labels["lease"], lease.Server.Name, lease.Server.CloudID)
+	identifier := shared.FirstNonBlankTrimmed(lease.LeaseID, lease.Server.Labels["lease"], lease.Server.Name, lease.Server.CloudID)
 	if strings.TrimSpace(identifier) == "" {
 		return leaseStateRecord{}, false, nil
 	}
@@ -737,10 +737,6 @@ func requireLifecycleHost() error {
 		return core.Exit(2, "provider=firecracker requires a Linux KVM host, got host=%s", firecrackerHostGOOS)
 	}
 	return nil
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlankTrimmed(values...)
 }
 
 func removeIfExists(path string) error {

--- a/internal/providers/firecracker/cloudinit.go
+++ b/internal/providers/firecracker/cloudinit.go
@@ -14,8 +14,6 @@ type cloudInitPayload struct {
 	MetaData string
 }
 
-type fatFile = shared.FATFile
-
 func buildCloudInitPayload(cfg core.Config, leaseID, slug, publicKey string) (cloudInitPayload, error) {
 	publicKey = strings.TrimSpace(publicKey)
 	if publicKey == "" {
@@ -27,7 +25,7 @@ func buildCloudInitPayload(cfg core.Config, leaseID, slug, publicKey string) (cl
 }
 
 func writeCloudInitDrive(path string, payload cloudInitPayload) error {
-	image, err := buildFAT16Image("cidata", []fatFile{
+	image, err := buildFAT16Image("cidata", []shared.FATFile{
 		{Name: "user-data", Data: []byte(payload.UserData)},
 		{Name: "meta-data", Data: []byte(payload.MetaData)},
 	})
@@ -40,6 +38,6 @@ func writeCloudInitDrive(path string, payload cloudInitPayload) error {
 	return nil
 }
 
-func buildFAT16Image(label string, files []fatFile) ([]byte, error) {
+func buildFAT16Image(label string, files []shared.FATFile) ([]byte, error) {
 	return shared.BuildFAT16Image(label, files, "FC%06dTXT", "firecracker cloud-init")
 }

--- a/internal/providers/firecracker/cloudinit_test.go
+++ b/internal/providers/firecracker/cloudinit_test.go
@@ -4,10 +4,12 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"testing"
+
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func TestBuildFAT16ImagePreservesFirecrackerEncoding(t *testing.T) {
-	image, err := buildFAT16Image("cidata", []fatFile{
+	image, err := buildFAT16Image("cidata", []shared.FATFile{
 		{Name: "user-data", Data: []byte("#cloud-config\nusers:\n- name: alice\n")},
 		{Name: "meta-data", Data: []byte("instance-id: crabbox-test\nlocal-hostname: my-app\n")},
 	})

--- a/internal/providers/firecracker/state.go
+++ b/internal/providers/firecracker/state.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -199,7 +200,7 @@ func readStateRecordFile(path string) (leaseStateRecord, error) {
 	record.NetNSPath = filepath.Join(record.StateDir, firecrackerNetNSFile)
 	record.CNICacheDir = filepath.Join(record.StateDir, firecrackerCNICacheDirName)
 	if strings.TrimSpace(record.VMID) == "" {
-		record.VMID = firstNonBlank(record.Name, record.LeaseID)
+		record.VMID = shared.FirstNonBlankTrimmed(record.Name, record.LeaseID)
 	}
 	if record.Labels == nil {
 		record.Labels = map[string]string{}

--- a/internal/providers/freestyle/backend.go
+++ b/internal/providers/freestyle/backend.go
@@ -2,8 +2,6 @@ package freestyle
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
@@ -534,19 +532,11 @@ func newFreestyleSandboxName(repo core.Repo) string {
 		base = "crabbox"
 	}
 	base = strings.TrimPrefix(base, freestyleNamePrefix)
-	return freestyleNamePrefix + base + "-" + freestyleRandomSuffix()
+	return freestyleNamePrefix + base + "-" + shared.RandomSuffix()
 }
 
 func isCrabboxFreestyleSandboxName(name string) bool {
 	return name == core.NormalizeLeaseSlug(name) && strings.HasPrefix(name, freestyleNamePrefix)
-}
-
-func freestyleRandomSuffix() string {
-	var b [3]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return fmt.Sprintf("%x", time.Now().UnixNano())[:6]
-	}
-	return hex.EncodeToString(b[:])
 }
 
 func (b *freestyleBackend) now() time.Time {

--- a/internal/providers/gcp/backend.go
+++ b/internal/providers/gcp/backend.go
@@ -28,7 +28,7 @@ func NewGCPLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime
 }
 
 func (b *gcpLeaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
-	return acquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
+	return shared.AcquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
 		return b.acquireOnce(ctx, req.Keep, req.RequestedSlug)
 	})
 }
@@ -435,10 +435,6 @@ func gcpClaimScope(cfg core.Config) string {
 		return ""
 	}
 	return "project:" + cfg.GCPProject
-}
-
-func acquireAttemptsRetry(rt core.Runtime, keep bool, acquire func() (core.LeaseTarget, error)) (core.LeaseTarget, error) {
-	return shared.AcquireAttemptsRetry(rt, keep, acquire)
 }
 
 var newGCPClient = func(ctx context.Context, cfg core.Config) (gcpClient, error) {

--- a/internal/providers/hetzner/backend.go
+++ b/internal/providers/hetzner/backend.go
@@ -42,7 +42,7 @@ func NewHetznerLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Run
 }
 
 func (b *hetznerLeaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (core.LeaseTarget, error) {
-	return acquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
+	return shared.AcquireAttemptsRetry(b.RT, req.Keep, func() (core.LeaseTarget, error) {
 		return b.acquireOnce(ctx, req.Keep, req.RequestedSlug)
 	})
 }
@@ -324,10 +324,6 @@ func (b *hetznerLeaseBackend) Cleanup(ctx context.Context, req core.CleanupReque
 		}
 	}
 	return nil
-}
-
-func acquireAttemptsRetry(rt core.Runtime, keep bool, acquire func() (core.LeaseTarget, error)) (core.LeaseTarget, error) {
-	return shared.AcquireAttemptsRetry(rt, keep, acquire)
 }
 
 func deleteServer(ctx context.Context, cfg core.Config, server core.Server) error {

--- a/internal/providers/hetzner/checkpoint.go
+++ b/internal/providers/hetzner/checkpoint.go
@@ -53,7 +53,7 @@ func (Provider) CreateNativeCheckpoint(ctx context.Context, req core.NativeCheck
 			err = core.NativeCheckpointNotSubmittedError{Cause: err}
 		}
 	}()
-	if firstNonBlank(req.Target.TargetOS, req.Config.TargetOS) != core.TargetLinux {
+	if shared.FirstNonBlank(req.Target.TargetOS, req.Config.TargetOS) != core.TargetLinux {
 		return core.NativeCheckpointCreateResult{}, core.Exit(2, "Hetzner native checkpoints require a Linux lease")
 	}
 	if core.NormalizeCheckpointStrategy(req.Strategy) == core.CheckpointStrategyImage {
@@ -268,7 +268,7 @@ func hetznerCheckpointResult(snapshot core.HetznerImage, location string, metada
 	return core.NativeCheckpointCreateResult{
 		Image: core.NativeCheckpointImage{
 			ID:           strconv.FormatInt(snapshot.ID, 10),
-			Name:         firstNonBlank(snapshot.Description, snapshot.Name),
+			Name:         shared.FirstNonBlank(snapshot.Description, snapshot.Name),
 			State:        snapshot.Status,
 			Provider:     providerName,
 			Kind:         core.CheckpointKindHetzner,
@@ -397,7 +397,7 @@ func hetznerServerArchitecture(server core.Server) (string, error) {
 	if server.Image != nil {
 		imageArchitecture = server.Image.Architecture
 	}
-	value := firstNonBlank(imageArchitecture, server.ServerType.Architecture, server.Labels["architecture"])
+	value := shared.FirstNonBlank(imageArchitecture, server.ServerType.Architecture, server.Labels["architecture"])
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "x86", "amd64", "x86_64":
 		return "x86", nil
@@ -445,10 +445,6 @@ func cloneMetadata(values map[string]string) map[string]string {
 		cloned[key] = value
 	}
 	return cloned
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlank(values...)
 }
 
 var (

--- a/internal/providers/hetzner/provider.go
+++ b/internal/providers/hetzner/provider.go
@@ -57,7 +57,7 @@ func (Provider) Spec() core.ProviderSpec {
 }
 
 func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (core.NativeCheckpointCapability, bool) {
-	if strings.TrimSpace(req.Config.Coordinator) != "" || firstNonBlank(req.Target.TargetOS, req.Config.TargetOS) != core.TargetLinux {
+	if strings.TrimSpace(req.Config.Coordinator) != "" || shared.FirstNonBlank(req.Target.TargetOS, req.Config.TargetOS) != core.TargetLinux {
 		return core.NativeCheckpointCapability{}, false
 	}
 	serverID, err := strconv.ParseInt(strings.TrimSpace(req.Server.CloudID), 10, 64)

--- a/internal/providers/hostinger/backend.go
+++ b/internal/providers/hostinger/backend.go
@@ -417,7 +417,7 @@ func (b *leaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (le
 			return core.LeaseTarget{}, rollbackStarted(vmID, err)
 		}
 	} else if !vm.Ready() {
-		return core.LeaseTarget{}, core.Exit(5, "hostinger vps %s is not runnable; state=%s", vm.IDString(), firstNonBlank(vm.State, vm.Status, "unknown"))
+		return core.LeaseTarget{}, core.Exit(5, "hostinger vps %s is not runnable; state=%s", vm.IDString(), shared.FirstNonBlankTrimmed(vm.State, vm.Status, "unknown"))
 	}
 	lease, err = b.leaseFromVM(cfg, vm, leaseID, slug, true)
 	if err != nil {
@@ -985,7 +985,7 @@ func validateHostingerConfiguredPurchaseOptions(cfg core.Config, options hosting
 			return core.Exit(2, "provider=%s configured template id %q is unavailable; available=%s", providerName, templateID, core.Blank(summarizeHostingerTemplates(options.templates), "none"))
 		}
 		if !hostingerTemplateSupported(selected) {
-			return core.Exit(2, "provider=%s template %s=%s is unsupported; choose an Ubuntu or Debian template so Crabbox can install required SSH tools before readiness", providerName, templateID, firstNonBlank(selected.Name, selected.OS))
+			return core.Exit(2, "provider=%s template %s=%s is unsupported; choose an Ubuntu or Debian template so Crabbox can install required SSH tools before readiness", providerName, templateID, shared.FirstNonBlankTrimmed(selected.Name, selected.OS))
 		}
 	}
 
@@ -1096,7 +1096,7 @@ func summarizeHostingerPaymentMethods(methods []hostingerPaymentMethod) string {
 		if method.IsDefault {
 			state += "+default"
 		}
-		values = append(values, fmt.Sprintf("%s=%s(%s)", hostingerIDString(method.ID), firstNonBlank(method.Name, method.PaymentMethod, "payment-method"), state))
+		values = append(values, fmt.Sprintf("%s=%s(%s)", hostingerIDString(method.ID), shared.FirstNonBlankTrimmed(method.Name, method.PaymentMethod, "payment-method"), state))
 	}
 	return strings.Join(values, ",")
 }
@@ -1108,7 +1108,7 @@ func summarizeHostingerTemplates(templates []hostingerTemplate) string {
 		if len(values) == limit {
 			break
 		}
-		values = append(values, fmt.Sprintf("%s=%s", hostingerIDString(template.ID), firstNonBlank(template.Name, template.OS)))
+		values = append(values, fmt.Sprintf("%s=%s", hostingerIDString(template.ID), shared.FirstNonBlankTrimmed(template.Name, template.OS)))
 	}
 	return strings.Join(values, ",")
 }
@@ -1120,7 +1120,7 @@ func summarizeHostingerDataCenters(dataCenters []hostingerDataCenter) string {
 		if len(values) == limit {
 			break
 		}
-		values = append(values, fmt.Sprintf("%s=%s", hostingerIDString(dataCenter.ID), firstNonBlank(dataCenter.Name, dataCenter.Location)))
+		values = append(values, fmt.Sprintf("%s=%s", hostingerIDString(dataCenter.ID), shared.FirstNonBlankTrimmed(dataCenter.Name, dataCenter.Location)))
 	}
 	return strings.Join(values, ",")
 }
@@ -1137,9 +1137,9 @@ func (b *leaseBackend) resolveVM(ctx context.Context, client hostingerAPI, id st
 			if getErr != nil {
 				return hostingerVM{}, "", "", core.Exit(1, "hostinger get claimed vps %s failed: %v", claim.CloudID, getErr)
 			}
-			return vm, claim.LeaseID, firstNonBlank(claim.Slug, hostingerLeaseIdentitySlug(vm, b.configForRun())), nil
+			return vm, claim.LeaseID, shared.FirstNonBlankTrimmed(claim.Slug, hostingerLeaseIdentitySlug(vm, b.configForRun())), nil
 		}
-		id = firstNonBlank(claim.LeaseID, claim.Slug, id)
+		id = shared.FirstNonBlankTrimmed(claim.LeaseID, claim.Slug, id)
 	}
 	if id != "" && !strings.HasPrefix(id, "cbx_") {
 		vm, err := client.GetVM(ctx, id)
@@ -1171,7 +1171,7 @@ func (b *leaseBackend) resolveVM(ctx context.Context, client hostingerAPI, id st
 		}
 		vm := matches[0]
 		leaseID := claim.LeaseID
-		slug := firstNonBlank(claim.Slug, hostingerLeaseIdentitySlug(vm, b.configForRun()))
+		slug := shared.FirstNonBlankTrimmed(claim.Slug, hostingerLeaseIdentitySlug(vm, b.configForRun()))
 		server, serverErr := b.serverFromVMWithClaim(vm, leaseID, slug, b.configForRun(), true)
 		if serverErr != nil {
 			return hostingerVM{}, "", "", serverErr
@@ -1247,10 +1247,10 @@ func (b *leaseBackend) waitForVM(ctx context.Context, client hostingerAPI, id st
 				return true, nil
 			}
 			if vm.Terminal() {
-				return false, core.Exit(5, "hostinger vps %s entered terminal state=%s", id, firstNonBlank(vm.State, vm.Status, "unknown"))
+				return false, core.Exit(5, "hostinger vps %s entered terminal state=%s", id, shared.FirstNonBlankTrimmed(vm.State, vm.Status, "unknown"))
 			}
 			if time.Now().After(deadline) {
-				return false, core.Exit(5, "timed out waiting for hostinger vps %s to expose a public IP; last_state=%s", id, firstNonBlank(vm.State, vm.Status))
+				return false, core.Exit(5, "timed out waiting for hostinger vps %s to expose a public IP; last_state=%s", id, shared.FirstNonBlankTrimmed(vm.State, vm.Status))
 			}
 			return false, nil
 		}, nil)
@@ -1280,7 +1280,7 @@ func (b *leaseBackend) stopVMAndWait(ctx context.Context, client hostingerAPI, i
 				}
 				return false, core.Exit(1, "hostinger confirm stopped vps %s failed: %v", id, fetchErr)
 			}
-			lastState = firstNonBlank(vm.State, vm.Status, "unknown")
+			lastState = shared.FirstNonBlankTrimmed(vm.State, vm.Status, "unknown")
 			if vm.Stopped() {
 				return true, nil
 			}
@@ -1506,14 +1506,14 @@ func hostingerServer(vm hostingerVM, leaseID, slug string, cfg core.Config, keep
 	labels["release"] = "stop"
 	labels["ssh_user"] = cfg.SSHUser
 	labels["work_root"] = cfg.WorkRoot
-	if state := strings.ToLower(firstNonBlank(vm.State, vm.Status)); state != "" {
+	if state := strings.ToLower(shared.FirstNonBlankTrimmed(vm.State, vm.Status)); state != "" {
 		labels["state"] = state
 	}
 	server := core.Server{
 		CloudID:  vm.IDString(),
 		Provider: providerName,
 		Name:     vm.NameValue(),
-		Status:   firstNonBlank(vm.State, vm.Status),
+		Status:   shared.FirstNonBlankTrimmed(vm.State, vm.Status),
 		Labels:   labels,
 	}
 	if server.Name == "" {
@@ -1548,7 +1548,7 @@ func (b *leaseBackend) serverFromVMWithClaim(vm hostingerVM, leaseID, slug strin
 	labels["release"] = "stop"
 	labels["ssh_user"] = cfg.SSHUser
 	labels["work_root"] = cfg.WorkRoot
-	if state := strings.ToLower(firstNonBlank(vm.State, vm.Status)); state != "" {
+	if state := strings.ToLower(shared.FirstNonBlankTrimmed(vm.State, vm.Status)); state != "" {
 		labels["state"] = state
 	}
 	server.Labels = labels
@@ -1572,7 +1572,7 @@ func hostingerLeaseIdentity(vm hostingerVM, cfg core.Config) (string, string) {
 	if id == "" {
 		id = "manual"
 	}
-	return "cbx_hostinger_" + id, firstNonBlank(name, "manual")
+	return "cbx_hostinger_" + id, shared.FirstNonBlankTrimmed(name, "manual")
 }
 
 func hostingerLeaseIdentitySlug(vm hostingerVM, cfg core.Config) string {
@@ -1586,20 +1586,20 @@ func hostingerLeaseIdentityWithClaim(vm hostingerVM, cfg core.Config) (string, s
 		return "", "", false, err
 	}
 	if ok && claim.LeaseID != "" {
-		return claim.LeaseID, firstNonBlank(claim.Slug, hostingerLeaseIdentitySlug(vm, cfg)), !hostingerAdoptionPending(claim), nil
+		return claim.LeaseID, shared.FirstNonBlankTrimmed(claim.Slug, hostingerLeaseIdentitySlug(vm, cfg)), !hostingerAdoptionPending(claim), nil
 	}
 	recovery, recovered, err := findHostingerRecoveryRecord(vm)
 	if err != nil {
 		return "", "", false, err
 	}
 	if recovered {
-		return recovery.LeaseID, firstNonBlank(recovery.Slug, hostingerLeaseIdentitySlug(vm, cfg)), false, nil
+		return recovery.LeaseID, shared.FirstNonBlankTrimmed(recovery.Slug, hostingerLeaseIdentitySlug(vm, cfg)), false, nil
 	}
 	id := vm.IDString()
 	if id == "" {
 		id = "manual"
 	}
-	return "cbx_hostinger_" + id, firstNonBlank(hostingerLeaseIdentitySlug(vm, cfg), vm.NameValue(), "manual"), false, nil
+	return "cbx_hostinger_" + id, shared.FirstNonBlankTrimmed(hostingerLeaseIdentitySlug(vm, cfg), vm.NameValue(), "manual"), false, nil
 }
 
 func hostingerOwnedName(name string, cfg core.Config) bool {
@@ -1636,7 +1636,7 @@ func (vm hostingerVM) IDString() string {
 }
 
 func (vm hostingerVM) NameValue() string {
-	return firstNonBlank(vm.Hostname, vm.Name)
+	return shared.FirstNonBlankTrimmed(vm.Hostname, vm.Name)
 }
 
 func (vm hostingerVM) Host() string {
@@ -1656,24 +1656,20 @@ func (vm hostingerVM) Host() string {
 }
 
 func (vm hostingerVM) Ready() bool {
-	state := strings.ToLower(firstNonBlank(vm.State, vm.Status))
+	state := strings.ToLower(shared.FirstNonBlankTrimmed(vm.State, vm.Status))
 	return state == "" || strings.Contains(state, "running") || strings.Contains(state, "active") || strings.Contains(state, "ready")
 }
 
 func (vm hostingerVM) Stopped() bool {
-	state := strings.ToLower(firstNonBlank(vm.State, vm.Status))
+	state := strings.ToLower(shared.FirstNonBlankTrimmed(vm.State, vm.Status))
 	return state == "stopped" || state == "off" || state == "powered_off"
 }
 
 func (vm hostingerVM) Terminal() bool {
-	switch strings.ToLower(firstNonBlank(vm.State, vm.Status)) {
+	switch strings.ToLower(shared.FirstNonBlankTrimmed(vm.State, vm.Status)) {
 	case "error", "suspended", "destroyed":
 		return true
 	default:
 		return false
 	}
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlankTrimmed(values...)
 }

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -338,7 +338,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 	if lease.LeaseID == "" {
 		lease.LeaseID = strings.TrimSpace(lease.Server.Labels["lease"])
 	}
-	name := strings.TrimSpace(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]))
+	name := strings.TrimSpace(shared.FirstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]))
 	if name == "" && lease.LeaseID != "" {
 		inst, _, err := b.resolveInstance(ctx, lease.LeaseID)
 		if err != nil {
@@ -367,7 +367,7 @@ func pruneLeaseState(leaseID string) {
 }
 
 func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
-	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, core.Blank(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
+	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, core.Blank(shared.FirstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
 }
 
 func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
@@ -1497,8 +1497,4 @@ func firstLine(value string) string {
 		value = value[:idx]
 	}
 	return strings.TrimSpace(value)
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlank(values...)
 }

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -3,9 +3,7 @@ package islo
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"encoding/base64"
-	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
@@ -1061,19 +1059,11 @@ func newIsloSandboxName(repo core.Repo) string {
 		base = "crabbox"
 	}
 	base = strings.TrimPrefix(base, strings.TrimSuffix(isloNamePrefix, "-")+"-")
-	return isloNamePrefix + base + "-" + isloRandomSuffix()
+	return isloNamePrefix + base + "-" + shared.RandomSuffix()
 }
 
 func isCrabboxIsloSandboxName(name string) bool {
 	return name == core.NormalizeLeaseSlug(name) && strings.HasPrefix(name, isloNamePrefix)
-}
-
-func isloRandomSuffix() string {
-	var b [3]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return fmt.Sprintf("%x", time.Now().UnixNano())[:6]
-	}
-	return hex.EncodeToString(b[:])
 }
 
 func leadingEnvAssignment(command []string) bool {

--- a/internal/providers/islo/sync.go
+++ b/internal/providers/islo/sync.go
@@ -12,6 +12,7 @@ import (
 
 	gosdk "github.com/islo-labs/go-sdk"
 	core "github.com/openclaw/crabbox/internal/cli"
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func rejectIsloSyncOptions(req core.RunRequest) error {
@@ -121,7 +122,7 @@ func (b *isloBackend) restoreWorkspaceOwnership(ctx context.Context, client islo
 }
 
 func (b *isloBackend) uploadArchiveViaExec(ctx context.Context, client isloAPI, name, workspace string, archive io.Reader, user string) error {
-	suffix := isloRandomSuffix()
+	suffix := shared.RandomSuffix()
 	remoteB64 := path.Join("/tmp", "crabbox-"+suffix+".tgz.b64")
 	remoteArchive := path.Join("/tmp", "crabbox-"+suffix+".tgz")
 	cleanup := "rm -f " + core.ShellQuote(remoteB64) + " " + core.ShellQuote(remoteArchive)

--- a/internal/providers/lambda/backend.go
+++ b/internal/providers/lambda/backend.go
@@ -283,7 +283,7 @@ func (b *backend) ensureSSHKey(ctx context.Context, client lambdaAPI, name, publ
 	if err != nil {
 		return lambdaSSHKeyIdentity{Name: name, Created: isAmbiguousLambdaMutationError(err)}, err
 	}
-	return lambdaSSHKeyIdentity{ID: key.ID, Name: firstNonBlank(key.Name, name), Created: true}, nil
+	return lambdaSSHKeyIdentity{ID: key.ID, Name: shared.FirstNonBlankTrimmed(key.Name, name), Created: true}, nil
 }
 
 func (b *backend) waitForInstanceReady(ctx context.Context, client lambdaAPI, id string) (Instance, error) {
@@ -507,7 +507,7 @@ func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.S
 	if err != nil {
 		return err
 	}
-	instanceID := firstNonBlank(server.CloudID, claim.CloudID)
+	instanceID := shared.FirstNonBlankTrimmed(server.CloudID, claim.CloudID)
 	if claim.CloudID == "" {
 		switch claim.Labels[lambdaRecoveryKeyLabel] {
 		case "rollback-cleanup", "ambiguous-key-create":
@@ -639,7 +639,7 @@ func (b *backend) persistRecoveryClaim(leaseID, slug string, cfg core.Config, re
 	labels := leaseTags(cfg, leaseID, slug, "provisioning", keep, now)
 	labels[lambdaRecoveryKeyLabel] = recovery
 	labels[lambdaKeyIDLabel] = key.ID
-	labels[lambdaKeyNameLabel] = firstNonBlank(key.Name, cfg.ProviderKey)
+	labels[lambdaKeyNameLabel] = shared.FirstNonBlankTrimmed(key.Name, cfg.ProviderKey)
 	labels[lambdaKeyOwnedLabel] = fmt.Sprint(key.Created)
 	if repoRoot == "" {
 		var err error
@@ -779,12 +779,12 @@ func serverFromInstance(item Instance, cfg core.Config) core.Server {
 	server := core.Server{
 		CloudID:  item.ID,
 		Provider: providerName,
-		Name:     firstNonBlank(item.Name, item.Hostname, item.ID),
+		Name:     shared.FirstNonBlankTrimmed(item.Name, item.Hostname, item.ID),
 		Status:   normalizeInstanceStatus(item.Status),
 		Labels:   labels,
 	}
 	server.PublicNet.IPv4.IP = strings.TrimSpace(item.IP)
-	server.ServerType.Name = firstNonBlank(item.Type, cfg.ServerType, typeForConfig(cfg))
+	server.ServerType.Name = shared.FirstNonBlankTrimmed(item.Type, cfg.ServerType, typeForConfig(cfg))
 	return server
 }
 

--- a/internal/providers/lambda/client.go
+++ b/internal/providers/lambda/client.go
@@ -193,7 +193,7 @@ func decodeInstanceTypes(raw json.RawMessage) ([]InstanceType, error) {
 		item := keyed[key]
 		instanceType := item.InstanceType
 		if instanceType.Name == "" {
-			instanceType.Name = firstNonBlank(item.Name, key)
+			instanceType.Name = shared.FirstNonBlankTrimmed(item.Name, key)
 		}
 		if instanceType.Description == "" {
 			instanceType.Description = item.Description

--- a/internal/providers/lambda/config.go
+++ b/internal/providers/lambda/config.go
@@ -31,21 +31,21 @@ func requireToken() (string, error) {
 }
 
 func regionForConfig(cfg core.Config) string {
-	return firstNonBlank(cfg.Lambda.Region, core.LambdaConfiguredRegionDefault)
+	return shared.FirstNonBlankTrimmed(cfg.Lambda.Region, core.LambdaConfiguredRegionDefault)
 }
 
 func typeForConfig(cfg core.Config) string {
 	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
 		return strings.TrimSpace(cfg.ServerType)
 	}
-	return firstNonBlank(cfg.Lambda.Type, core.LambdaConfiguredTypeDefault)
+	return shared.FirstNonBlankTrimmed(cfg.Lambda.Type, core.LambdaConfiguredTypeDefault)
 }
 
 func imageFamilyForConfig(cfg core.Config) string {
 	if strings.TrimSpace(cfg.Lambda.Image) != "" {
 		return ""
 	}
-	return firstNonBlank(cfg.Lambda.ImageFamily, core.LambdaImageFamilyFallback)
+	return shared.FirstNonBlankTrimmed(cfg.Lambda.ImageFamily, core.LambdaImageFamilyFallback)
 }
 
 func imageForConfig(cfg core.Config) string {
@@ -75,8 +75,4 @@ func validateConfig(cfg core.Config) error {
 		return core.Exit(2, "lambda image and imageFamily are mutually exclusive")
 	}
 	return nil
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlankTrimmed(values...)
 }

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -469,7 +469,7 @@ func (b *linodeLeaseBackend) targetFromLinode(item linodeInstance, req core.Reso
 		if expectedAccountID != accountID {
 			return core.LeaseTarget{}, core.Exit(3, "linode account mismatch: current account %s does not match lease account %s", accountID, expectedAccountID)
 		}
-		liveCloudID := firstNonBlank(server.CloudID, strconv.FormatInt(server.ID, 10))
+		liveCloudID := shared.FirstNonBlank(server.CloudID, strconv.FormatInt(server.ID, 10))
 		if claim.CloudID != "" && claim.CloudID != liveCloudID {
 			return core.LeaseTarget{}, core.Exit(2, "refusing to resolve Linode instance %d from stale local claim", server.ID)
 		}
@@ -647,7 +647,7 @@ func (b *linodeLeaseBackend) updateFencedLinodeMetadata(ctx context.Context, lea
 				labels[key] = value
 			}
 		} else {
-			applyTailscaleMetadata(labels, *meta)
+			shared.ApplyTailscaleMetadata(labels, *meta)
 		}
 		labels[linodeAccountLabel] = accountID
 		if err := client.UpdateLinodeTags(providerCtx, server.ID, replaceCrabboxTags(item.Tags, tagsFromLabels(labels))); err != nil {
@@ -819,7 +819,7 @@ func validateCleanupClaim(server core.Server, claim core.LeaseClaim, liveLinodeV
 	if claim.LeaseID != leaseID || claim.Provider == "" {
 		return core.Exit(2, "linode lease claim is incomplete for lease=%s", leaseID)
 	}
-	cloudID := firstNonBlank(server.CloudID, strconv.FormatInt(server.ID, 10))
+	cloudID := shared.FirstNonBlank(server.CloudID, strconv.FormatInt(server.ID, 10))
 	if claim.Provider == providerName && claim.CloudID != "" && claim.CloudID != cloudID {
 		return core.Exit(2, "refusing to release Linode instance %d from stale local claim", server.ID)
 	}
@@ -927,10 +927,6 @@ func appendLinodeIfMissing(linodes []linodeInstance, item linodeInstance) []lino
 	return append(linodes, item)
 }
 
-func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadata) {
-	shared.ApplyTailscaleMetadata(labels, meta)
-}
-
 func (b *linodeLeaseBackend) waitForLinodeIP(ctx context.Context, client linodeAPI, id int64, timeout time.Duration) (linodeInstance, error) {
 	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -987,7 +983,7 @@ func serverFromLinode(item linodeInstance, cfg core.Config) core.Server {
 		Labels:   labels,
 	}
 	server.PublicNet.IPv4.IP = publicIPv4(item)
-	server.ServerType.Name = firstNonBlank(item.Type, cfg.ServerType)
+	server.ServerType.Name = shared.FirstNonBlank(item.Type, cfg.ServerType)
 	return server
 }
 
@@ -1093,10 +1089,6 @@ func applyLinodeDefaults(cfg *core.Config) {
 		cfg.SSHPort = "22"
 	}
 	cfg.SSHFallbackPorts = nil
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlank(values...)
 }
 
 func isLinodeNotFound(err error) bool {

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -685,7 +685,7 @@ func (b *backend) rollbackPendingLease(expected core.LeaseClaim, lease core.Leas
 }
 
 func (b *backend) printPendingRecovery(leaseID, slug string, claim core.LeaseClaim, reason error) {
-	runtimeName := firstNonBlank(claim.Labels[checkpointMetadataRuntime], claim.Labels["runtime"], b.cfg.LocalContainer.Runtime, "docker")
+	runtimeName := shared.FirstNonBlank(claim.Labels[checkpointMetadataRuntime], claim.Labels["runtime"], b.cfg.LocalContainer.Runtime, "docker")
 	envPrefix := []string{"CRABBOX_LOCAL_CONTAINER_RUNTIME=" + core.ShellQuote(runtimeName)}
 	scope := checkpointScopeFromMetadata(checkpointScopeMetadataFromLabels(claim.Labels), runtimeName)
 	if isDockerRuntime(runtimeName) && scope.Context != "" {
@@ -983,7 +983,7 @@ func (b *backend) releaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 		return err
 	}
 	if !appliedScope {
-		identifier := firstNonBlank(lease.LeaseID, lease.Server.Labels["lease"])
+		identifier := shared.FirstNonBlank(lease.LeaseID, lease.Server.Labels["lease"])
 		if claim, ok, err := core.ResolveLeaseClaimForProvider(identifier, providerName); err != nil {
 			return err
 		} else if ok {
@@ -1124,7 +1124,7 @@ func (b *backend) AuthorizeStatusTouchClaim(ctx context.Context, lease core.Leas
 }
 
 func (b *backend) releaseMissingClaim(ctx context.Context, lease core.LeaseTarget, checkpointID string, outcome *core.ReleaseLeaseOutcome) (bool, error) {
-	leaseID := strings.TrimSpace(firstNonBlank(lease.LeaseID, lease.Server.Labels["lease"]))
+	leaseID := strings.TrimSpace(shared.FirstNonBlank(lease.LeaseID, lease.Server.Labels["lease"]))
 	if leaseID == "" || strings.TrimSpace(lease.Server.CloudID) != "" {
 		return false, nil
 	}
@@ -1966,13 +1966,9 @@ func localContainerCacheVolumeMounts(volumes []core.CacheVolumeConfig) ([]string
 		if !strings.HasPrefix(path, "/") {
 			return nil, core.Exit(2, "cache volume path %q must be absolute", path)
 		}
-		mounts = append(mounts, localContainerCacheVolumeName(key)+":"+path)
+		mounts = append(mounts, shared.CacheVolumeName(key)+":"+path)
 	}
 	return mounts, nil
-}
-
-func localContainerCacheVolumeName(key string) string {
-	return shared.CacheVolumeName(key)
 }
 
 func (b *backend) dockerSocketMountPath(ctx context.Context) (string, error) {
@@ -2176,7 +2172,7 @@ func (b *backend) exactContainerAbsent(ctx context.Context, id string) (bool, er
 	if err == nil {
 		return false, nil
 	}
-	detail := strings.ToLower(strings.TrimSpace(firstNonBlank(result.Stderr, result.Stdout)))
+	detail := strings.ToLower(strings.TrimSpace(shared.FirstNonBlank(result.Stderr, result.Stdout)))
 	if localContainerRouteFailure(detail) {
 		return false, shared.LocalCommandError("confirm local-container absence", result, err)
 	}
@@ -2349,10 +2345,10 @@ func (b *backend) findContainerForClaim(ctx context.Context, claim core.LeaseCla
 		for _, container := range containers {
 			if strings.TrimSpace(container.ID) == boundID {
 				labels := container.Config.Labels
-				return container, firstNonBlank(claim.LeaseID, labels["lease"]), firstNonBlank(claim.Slug, labels["slug"]), nil
+				return container, shared.FirstNonBlank(claim.LeaseID, labels["lease"]), shared.FirstNonBlank(claim.Slug, labels["slug"]), nil
 			}
 		}
-		return inspectContainer{}, "", "", core.Exit(4, "local-container lease not found: %s", firstNonBlank(claim.Slug, claim.LeaseID))
+		return inspectContainer{}, "", "", core.Exit(4, "local-container lease not found: %s", shared.FirstNonBlank(claim.Slug, claim.LeaseID))
 	}
 	var matched *inspectContainer
 	for _, container := range containers {
@@ -2369,7 +2365,7 @@ func (b *backend) findContainerForClaim(ctx context.Context, claim core.LeaseCla
 		labels := matched.Config.Labels
 		return *matched, labels["lease"], labels["slug"], nil
 	}
-	return inspectContainer{}, "", "", core.Exit(4, "local-container lease not found: %s", firstNonBlank(claim.Slug, claim.LeaseID))
+	return inspectContainer{}, "", "", core.Exit(4, "local-container lease not found: %s", shared.FirstNonBlank(claim.Slug, claim.LeaseID))
 }
 
 func (b *backend) removeContainer(ctx context.Context, id string) error {
@@ -2611,7 +2607,7 @@ func (b *backend) serverFromContainer(container inspectContainer, cfg core.Confi
 		server.Status = "ready"
 	}
 	server.PublicNet.IPv4.IP = host
-	server.ServerType.Name = firstNonBlank(labels["server_type"], cfg.LocalContainer.Image)
+	server.ServerType.Name = shared.FirstNonBlank(labels["server_type"], cfg.LocalContainer.Image)
 	return server
 }
 
@@ -2709,19 +2705,15 @@ func blank(value, fallback string) string {
 	return value
 }
 
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlank(values...)
-}
-
 func hostLeaseWorkRoot(lease core.LeaseTarget) string {
-	return hostLeaseWorkRootFromLabels(firstNonBlank(lease.LeaseID, lease.Server.Labels["lease"]), lease.Server.Labels)
+	return hostLeaseWorkRootFromLabels(shared.FirstNonBlank(lease.LeaseID, lease.Server.Labels["lease"]), lease.Server.Labels)
 }
 
 func hostLeaseWorkRootFromLabels(leaseID string, labels map[string]string) string {
 	if labels["docker_socket"] != "1" {
 		return ""
 	}
-	root := strings.TrimSpace(firstNonBlank(labels["host_work_root"], labels["work_root"]))
+	root := strings.TrimSpace(shared.FirstNonBlank(labels["host_work_root"], labels["work_root"]))
 	leaseID = strings.TrimSpace(leaseID)
 	if root == "" || leaseID == "" || !filepath.IsAbs(root) {
 		return ""

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const testRecoveredContainerID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -1797,7 +1798,7 @@ func TestResolveContainerHydratesCustomRuntimeRouteBeforeLookup(t *testing.T) {
 			t.Setenv("DOCKER_HOST", "unix:///ambient.sock")
 			leaseID := "cbx_hydrated_route"
 			labels := checkpointScopeMetadata(checkpointScope{
-				Runtime: tc.runtime, Context: tc.context, Host: tc.host, Endpoint: firstNonBlank(tc.host, "connection://captured-podman"), DaemonID: "daemon-captured",
+				Runtime: tc.runtime, Context: tc.context, Host: tc.host, Endpoint: shared.FirstNonBlank(tc.host, "connection://captured-podman"), DaemonID: "daemon-captured",
 			})
 			labels["provider"] = providerName
 			labels["lease"] = leaseID
@@ -3482,7 +3483,7 @@ func TestPendingRecoveryCommandsUseSafeExactRoute(t *testing.T) {
 			var stderr strings.Builder
 			b.rt.Stderr = &stderr
 			labels := checkpointScopeMetadata(checkpointScope{
-				Runtime: tc.runtime, Context: tc.context, Host: tc.host, Config: tc.config, Endpoint: firstNonBlank(tc.host, "local"), DaemonID: "daemon-test",
+				Runtime: tc.runtime, Context: tc.context, Host: tc.host, Config: tc.config, Endpoint: shared.FirstNonBlank(tc.host, "local"), DaemonID: "daemon-test",
 			})
 			labels["runtime"] = tc.runtime
 			claim := core.LeaseClaim{LeaseID: "cbx_recovery_route", Provider: providerName, CloudID: "container-route", Labels: labels}
@@ -4579,7 +4580,7 @@ func TestCreateContainerMountsCacheVolumes(t *testing.T) {
 	}
 	args := recordedArgsForCommand(t, runner, "run")
 	for _, volume := range cfg.Cache.Volumes {
-		want := "-v\n" + localContainerCacheVolumeName(volume.Key) + ":" + volume.Path
+		want := "-v\n" + shared.CacheVolumeName(volume.Key) + ":" + volume.Path
 		if !strings.Contains(args, want) {
 			t.Fatalf("cache volume mount missing %q:\n%s", want, args)
 		}
@@ -4593,8 +4594,8 @@ func TestCreateContainerMountsCacheVolumes(t *testing.T) {
 }
 
 func TestLocalContainerCacheVolumeNameIsStableAndDockerSafe(t *testing.T) {
-	got := localContainerCacheVolumeName("My App/linux node24 lock")
-	again := localContainerCacheVolumeName("My App/linux node24 lock")
+	got := shared.CacheVolumeName("My App/linux node24 lock")
+	again := shared.CacheVolumeName("My App/linux node24 lock")
 	if got != again {
 		t.Fatalf("cache volume name unstable: %q then %q", got, again)
 	}

--- a/internal/providers/lume/backend.go
+++ b/internal/providers/lume/backend.go
@@ -115,7 +115,7 @@ func (b *backend) RebindResolvedLeaseTarget(target *core.LeaseTarget, leaseID st
 	if err := core.UseLeaseKnownHosts(&target.SSH, leaseID); err != nil {
 		return err
 	}
-	name := strings.TrimSpace(firstNonBlank(target.Server.CloudID, target.Server.Labels["instance"]))
+	name := strings.TrimSpace(shared.FirstNonBlank(target.Server.CloudID, target.Server.Labels["instance"]))
 	if name == "" {
 		return core.Exit(5, "Lume lease %s has no VM identity for SSH host-key binding", leaseID)
 	}
@@ -563,7 +563,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 	if err := core.ValidateLeaseTargetProviderIdentity(lease, req.ExpectedProviderIdentity); err != nil {
 		return err
 	}
-	name := strings.TrimSpace(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]))
+	name := strings.TrimSpace(shared.FirstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]))
 	if name == "" && lease.LeaseID != "" {
 		inst, claim, err := b.resolveInstance(ctx, lease.LeaseID)
 		if err != nil {
@@ -630,7 +630,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 }
 
 func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
-	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, core.Blank(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
+	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, core.Blank(shared.FirstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
 }
 
 func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
@@ -1451,7 +1451,7 @@ func (b *backend) activeMacOSGuestCount(ctx context.Context, cfg core.Config) (i
 }
 
 func lumeStorageIdentity(cfg core.Config, inst lumeVM, fallback string) (string, error) {
-	cfg.Lume.Storage = strings.TrimSpace(firstNonBlank(inst.LocationName, fallback))
+	cfg.Lume.Storage = strings.TrimSpace(shared.FirstNonBlank(inst.LocationName, fallback))
 	root, err := lumeStorageRoot(cfg, inst.LocationName)
 	if err != nil {
 		return "", err
@@ -1970,8 +1970,4 @@ func firstLine(value string) string {
 		value = value[:idx]
 	}
 	return core.Blank(strings.TrimSpace(value), "unknown")
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlank(values...)
 }

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -39,8 +39,8 @@ type machine0PrepareOptions struct {
 func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	applyDefaults(&cfg)
 	b := &backend{spec: spec, cfg: cfg, rt: rt}
-	b.api = &client{cfg: cfg.Machine0, rt: rt, sleep: sleepContext}
-	b.sleep = sleepContext
+	b.api = &client{cfg: cfg.Machine0, rt: rt, sleep: core.SleepContext}
+	b.sleep = core.SleepContext
 	b.stat = os.Stat
 	b.knownHostsFile = machine0KnownHostsFile
 	b.waitSSH = func(ctx context.Context, target *core.SSHTarget, timeout time.Duration) error {
@@ -343,7 +343,7 @@ func validateResolvedMachine0Claim(identifier string, claim core.LeaseClaim) err
 		if err != nil {
 			return err
 		}
-	} else if firstNonBlank(claim.Labels["machine0_name"], claim.CloudID) == "" {
+	} else if shared.FirstNonBlankTrimmed(claim.Labels["machine0_name"], claim.CloudID) == "" {
 		return core.Exit(4, "machine0 lease %q has no bound native resource", identifier)
 	}
 	return nil
@@ -376,7 +376,7 @@ func (b *backend) resolve(ctx context.Context, req core.ResolveRequest, original
 	}
 	lookup := strings.TrimSpace(req.ID)
 	if claimed {
-		lookup = firstNonBlank(claim.Labels["machine0_name"], claim.CloudID)
+		lookup = shared.FirstNonBlankTrimmed(claim.Labels["machine0_name"], claim.CloudID)
 	}
 	var item machine
 	if claimed && (claim.Provider == core.FixedMachine0ClaimProvider || claim.FixedCreateIntent != nil) {
@@ -600,7 +600,7 @@ func (b *backend) releaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 	if req.CheckpointID != "" {
 		return b.releaseCheckpointSource(ctx, req, outcome)
 	}
-	identifier := firstNonBlank(req.Lease.LeaseID, req.Lease.Server.Labels["lease"], req.Lease.Server.CloudID, req.Lease.Server.Name)
+	identifier := shared.FirstNonBlankTrimmed(req.Lease.LeaseID, req.Lease.Server.Labels["lease"], req.Lease.Server.CloudID, req.Lease.Server.Name)
 	claim, claimed, err := resolveClaim(identifier)
 	if err != nil {
 		return err
@@ -1215,7 +1215,7 @@ func resetMachine0HostTrust(path string) error {
 }
 
 func (b *backend) releaseTarget(ctx context.Context, lease core.LeaseTarget) (core.LeaseClaim, machine, error) {
-	identifier := firstNonBlank(lease.LeaseID, lease.Server.Labels["lease"], lease.Server.CloudID, lease.Server.Name)
+	identifier := shared.FirstNonBlankTrimmed(lease.LeaseID, lease.Server.Labels["lease"], lease.Server.CloudID, lease.Server.Name)
 	claim, claimed, err := resolveClaim(identifier)
 	if err != nil {
 		return core.LeaseClaim{}, machine{}, err
@@ -1223,7 +1223,7 @@ func (b *backend) releaseTarget(ctx context.Context, lease core.LeaseTarget) (co
 	if !claimed {
 		return core.LeaseClaim{}, machine{}, core.Exit(2, "refusing to release machine0 machine without an exact local Crabbox claim")
 	}
-	lookup := firstNonBlank(claim.Labels["machine0_name"], claim.CloudID)
+	lookup := shared.FirstNonBlankTrimmed(claim.Labels["machine0_name"], claim.CloudID)
 	if fixedMachine0LeaseKind.IsFixedClaim(claim) {
 		item, err := b.resolveFixedMachine0(ctx, claim)
 		if err != nil {
@@ -1292,7 +1292,7 @@ func machine0Claims() (map[string]core.LeaseClaim, error) {
 		if !isMachine0ClaimProvider(claim.Provider) {
 			continue
 		}
-		id := firstNonBlank(claim.CloudID, claim.Labels["machine0_id"])
+		id := shared.FirstNonBlankTrimmed(claim.CloudID, claim.Labels["machine0_id"])
 		if id != "" {
 			out[id] = claim
 		} else if (fixedMachine0LeaseKind.IsFixedClaim(claim) || claim.Labels["recovery"] == "create-pending") && claim.ProviderScope != "" {
@@ -1444,19 +1444,7 @@ func machineTerminal(value string) bool {
 func terminalMachineError(item machine) error {
 	return core.Exit(5, "machine0 machine %s entered terminal state %s: %s", item.Name, item.Status, core.Blank(item.LastErrorMessage, "run `machine0 get "+item.Name+" --json` for diagnostics"))
 }
-func sleepContext(ctx context.Context, delay time.Duration) error {
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
-	}
-}
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlankTrimmed(values...)
-}
+
 func firstLine(value string) string {
 	if line, _, ok := strings.Cut(strings.TrimSpace(value), "\n"); ok {
 		return line

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -69,7 +70,7 @@ func (f *fakeAPI) AccountID(ctx context.Context) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
-	return firstNonBlank(f.accountID, "fixture-account"), f.accountErr
+	return shared.FirstNonBlankTrimmed(f.accountID, "fixture-account"), f.accountErr
 }
 
 func (f *fakeAPI) Version(ctx context.Context) (string, error) {
@@ -1586,7 +1587,7 @@ func TestWaitForSuspendedHonorsContextAndTimeout(t *testing.T) {
 			item := readyMachine("203.0.113.10")
 			item.Status = "SUSPENDING"
 			b := testBackendWithAPI(&fakeAPI{machine: item})
-			b.sleep = sleepContext
+			b.sleep = core.SleepContext
 			_, err := b.waitForSuspended(tc.ctx(), item.Name, tc.timeout)
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("err=%v", err)
@@ -2270,7 +2271,7 @@ func TestCreateNativeCheckpointRestartsAfterSnapshotTimeout(t *testing.T) {
 	b, api, _, claim, req := checkpointCreateFixture(t)
 	req.Wait = false
 	req.WaitTimeout = 10 * time.Millisecond
-	b.sleep = sleepContext
+	b.sleep = core.SleepContext
 	api.imageDetail = checkpointImageSnapshotState(req, claim, 1, "CREATING")
 	api.getSequence = []machine{
 		checkpointSource(req, "203.0.113.10"),
@@ -2293,7 +2294,7 @@ func TestCreateNativeCheckpointRestartsAfterSnapshotTimeout(t *testing.T) {
 
 func TestCreateNativeCheckpointRestartsAfterCallerCancellation(t *testing.T) {
 	b, api, _, claim, req := checkpointCreateFixture(t)
-	b.sleep = sleepContext
+	b.sleep = core.SleepContext
 	api.imageDetail = checkpointImageSnapshotState(req, claim, 1, "CREATING")
 	api.getSequence = []machine{
 		checkpointSource(req, "203.0.113.10"),
@@ -2328,7 +2329,7 @@ func TestMachine0CheckpointSnapshotTimeoutPrecedence(t *testing.T) {
 func TestCreateNativeCheckpointStopTimeoutRestartsWithoutSaving(t *testing.T) {
 	b, api, _, claim, req := checkpointCreateFixture(t)
 	b.cfg.Machine0.CreateTimeout = time.Nanosecond
-	b.sleep = sleepContext
+	b.sleep = core.SleepContext
 	stopping := checkpointSource(req, "203.0.113.10")
 	stopping.Status = "STOPPING"
 	api.getSequence = []machine{checkpointSource(req, "203.0.113.10"), checkpointSource(req, "203.0.113.10"), stopping, checkpointSource(req, "203.0.113.10")}
@@ -2433,7 +2434,7 @@ func TestWaitForStoppedRequiresExactStoppedState(t *testing.T) {
 			stopping := readyMachine("203.0.113.10")
 			stopping.Status = "STOPPING"
 			b := testBackendWithAPI(&fakeAPI{machine: stopping})
-			b.sleep = sleepContext
+			b.sleep = core.SleepContext
 			_, err := b.waitForStopped(tc.ctx(), stopping.Name, tc.timeout)
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("err=%v", err)
@@ -2548,7 +2549,7 @@ func TestImageWaitKeepsObservedVersionOnTimeoutAndError(t *testing.T) {
 
 	t.Run("timeout retains observed identity", func(t *testing.T) {
 		b := testBackendWithAPI(&fakeAPI{imageDetail: pending})
-		b.sleep = sleepContext
+		b.sleep = core.SleepContext
 		detail, version, err := b.waitForImageVersion(context.Background(), "baseline", 1, expected, true, 10*time.Millisecond, io.Discard)
 		if err == nil || !strings.Contains(err.Error(), "timed out") {
 			t.Fatalf("err=%v", err)

--- a/internal/providers/machine0/client.go
+++ b/internal/providers/machine0/client.go
@@ -182,7 +182,7 @@ func (c *client) runRead(ctx context.Context, args ...string) (core.LocalCommand
 	delay := machine0ReadRetryDelay(c.cfg.PollInterval)
 	sleep := c.sleep
 	if sleep == nil {
-		sleep = sleepContext
+		sleep = core.SleepContext
 	}
 	warned := false
 	for {

--- a/internal/providers/machine0/fixed.go
+++ b/internal/providers/machine0/fixed.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -343,7 +344,7 @@ func (b *backend) destroyClaimedMachineWithOutcome(ctx context.Context, expected
 			outcome.Terminal = err == nil
 			return err
 		}
-		resourceID := firstNonBlank(item.ID, claim.CloudID)
+		resourceID := shared.FirstNonBlankTrimmed(item.ID, claim.CloudID)
 		if (lease.Server.CloudID != "" && lease.Server.CloudID != resourceID) || (lease.Server.ImmutableID != "" && lease.Server.ImmutableID != resourceID) {
 			return core.Exit(4, "lease_id_conflict: fixed Machine0 resource changed before release")
 		}

--- a/internal/providers/machine0/images.go
+++ b/internal/providers/machine0/images.go
@@ -120,7 +120,7 @@ func (c *client) RemoveImageVersion(ctx context.Context, image string, version i
 }
 
 func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (core.NativeCheckpointCapability, bool) {
-	if firstNonBlank(req.Server.Provider, req.Config.Provider) != providerName || strings.TrimSpace(req.Server.CloudID) == "" {
+	if shared.FirstNonBlankTrimmed(req.Server.Provider, req.Config.Provider) != providerName || strings.TrimSpace(req.Server.CloudID) == "" {
 		return core.NativeCheckpointCapability{}, false
 	}
 	capability := core.NativeCheckpointCapability{Kind: core.CheckpointKindMachine0, Direct: true, ReplayCapture: true, RetireSource: true}
@@ -214,7 +214,7 @@ func (b *backend) createNativeCheckpoint(ctx context.Context, req core.NativeChe
 	var lifecycleErr error
 	snapshotTimeout := machine0CheckpointSnapshotTimeout(req.WaitTimeout, b.configForRun().Machine0.CreateTimeout)
 	_, _, _, actionErr := core.ReplaceLeaseClaimEndpointIfUnchangedAction(claim.LeaseID, claim, func() (core.Server, core.SSHTarget, bool, error) {
-		lookup := firstNonBlank(claim.Labels["machine0_name"], req.Server.Name, claim.CloudID)
+		lookup := shared.FirstNonBlankTrimmed(claim.Labels["machine0_name"], req.Server.Name, claim.CloudID)
 		item, err := b.readCheckpointSource(ctx, claim, lookup)
 		if err != nil {
 			return core.Server{}, core.SSHTarget{}, false, err
@@ -359,7 +359,7 @@ func machine0NativeCheckpointResult(req core.NativeCheckpointCreateRequest, clai
 	for key, value := range machine0ImageCostMetadata(version) {
 		metadata[key] = value
 	}
-	return core.NativeCheckpointCreateResult{Image: core.NativeCheckpointImage{ID: fmt.Sprintf("%s@v%d", detail.Image.ID, version.Version), Name: name, State: imageVersionState(version), Provider: providerName, Kind: core.CheckpointKindMachine0, Region: req.Server.Labels["region"], ResourceID: detail.Image.ID, Architecture: firstNonBlank(req.Server.ServerType.Architecture, "amd64"), Direct: true}, Metadata: metadata}
+	return core.NativeCheckpointCreateResult{Image: core.NativeCheckpointImage{ID: fmt.Sprintf("%s@v%d", detail.Image.ID, version.Version), Name: name, State: imageVersionState(version), Provider: providerName, Kind: core.CheckpointKindMachine0, Region: req.Server.Labels["region"], ResourceID: detail.Image.ID, Architecture: shared.FirstNonBlankTrimmed(req.Server.ServerType.Architecture, "amd64"), Direct: true}, Metadata: metadata}
 }
 
 func (Provider) VerifyNativeCheckpoint(ctx context.Context, req core.NativeCheckpointResourceRequest) (core.NativeCheckpointVerifyResult, error) {
@@ -611,7 +611,7 @@ func (b *backend) loadCheckpointImage(ctx context.Context, req core.NativeCheckp
 }
 
 func imageVersionState(version machineImageVersion) string {
-	return firstNonBlank(version.DisplayStatus, version.Status, "unknown")
+	return shared.FirstNonBlankTrimmed(version.DisplayStatus, version.Status, "unknown")
 }
 
 func machine0ImageCostMetadata(version machineImageVersion) map[string]string {

--- a/internal/providers/multipass/backend.go
+++ b/internal/providers/multipass/backend.go
@@ -257,7 +257,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 	if lease.LeaseID == "" {
 		lease.LeaseID = strings.TrimSpace(lease.Server.Labels["lease"])
 	}
-	name := strings.TrimSpace(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]))
+	name := strings.TrimSpace(shared.FirstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]))
 	if name == "" && lease.LeaseID != "" {
 		inst, claim, err := b.resolveInstance(ctx, lease.LeaseID)
 		if err != nil {
@@ -285,7 +285,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 }
 
 func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
-	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, core.Blank(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
+	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, core.Blank(shared.FirstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
 }
 
 func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
@@ -488,7 +488,7 @@ func multipassCacheVolumeMounts(volumes []core.CacheVolumeConfig) ([]multipassCa
 		if !strings.HasPrefix(path, "/") {
 			return nil, core.Exit(2, "cache volume path %q must be absolute", path)
 		}
-		hostPath := filepath.Join(root, multipassCacheVolumeName(key))
+		hostPath := filepath.Join(root, shared.CacheVolumeName(key))
 		if err := os.MkdirAll(hostPath, 0o777); err != nil {
 			return nil, core.Exit(2, "create multipass cache volume %s: %v", hostPath, err)
 		}
@@ -506,10 +506,6 @@ func multipassCacheRoot() (string, error) {
 		return "", core.Exit(2, "user cache directory is unavailable")
 	}
 	return filepath.Join(dir, "crabbox", "multipass-cache"), nil
-}
-
-func multipassCacheVolumeName(key string) string {
-	return shared.CacheVolumeName(key)
 }
 
 func (b *backend) listInstances(ctx context.Context) ([]multipassInstance, error) {
@@ -652,7 +648,7 @@ func (b *backend) serverFromInstance(inst multipassInstance, claim core.LeaseCla
 		labels["state"] = multipassState(inst.State)
 	}
 	if labels["server_type"] == "" {
-		labels["server_type"] = firstNonBlank(inst.Release, cfg.Multipass.Image)
+		labels["server_type"] = shared.FirstNonBlank(inst.Release, cfg.Multipass.Image)
 	}
 	if labels["image"] == "" {
 		labels["image"] = cfg.Multipass.Image
@@ -678,7 +674,7 @@ func (b *backend) serverFromInstance(inst multipassInstance, claim core.LeaseCla
 		Labels:   labels,
 	}
 	server.PublicNet.IPv4.IP = inst.ip()
-	server.ServerType.Name = firstNonBlank(labels["server_type"], cfg.Multipass.Image)
+	server.ServerType.Name = shared.FirstNonBlank(labels["server_type"], cfg.Multipass.Image)
 	return server
 }
 
@@ -790,7 +786,7 @@ func (i multipassInfoEntry) toInstance(name string) multipassInstance {
 		Name:    name,
 		State:   i.State,
 		IPv4:    append([]string(nil), i.IPv4...),
-		Release: firstNonBlank(i.Release, i.ImageRelease),
+		Release: shared.FirstNonBlank(i.Release, i.ImageRelease),
 	}
 }
 
@@ -827,8 +823,4 @@ func firstLine(value string) string {
 		value = value[:idx]
 	}
 	return strings.TrimSpace(value)
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlank(values...)
 }

--- a/internal/providers/multipass/backend_test.go
+++ b/internal/providers/multipass/backend_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type recordingRunner struct {
@@ -267,7 +268,7 @@ func TestCreateInstanceBuildsLaunchArgsAndCloudInit(t *testing.T) {
 		t.Fatalf("darwin qemu launch should not include --mount:\n%s", args)
 	}
 	mountArgs := recordedArgsForCommand(t, runner, "mount")
-	for _, want := range []string{"mount\n--type\nnative", filepath.Join(root, multipassCacheVolumeName("my-app/linux node24 lock")), "crabbox-blue-1234abcd:/var/cache/crabbox/pnpm"} {
+	for _, want := range []string{"mount\n--type\nnative", filepath.Join(root, shared.CacheVolumeName("my-app/linux node24 lock")), "crabbox-blue-1234abcd:/var/cache/crabbox/pnpm"} {
 		if !strings.Contains(mountArgs, want) {
 			t.Fatalf("native mount args missing %q:\n%s", want, mountArgs)
 		}
@@ -308,7 +309,7 @@ func TestCreateInstanceFallsBackToClassicMountsForDarwinVirtualBox(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mountArg := filepath.Join(root, multipassCacheVolumeName("gomod")) + ":/var/cache/crabbox/go"
+	mountArg := filepath.Join(root, shared.CacheVolumeName("gomod")) + ":/var/cache/crabbox/go"
 	if !strings.Contains(args, "--mount\n"+mountArg) {
 		t.Fatalf("virtualbox launch args missing classic mount %q:\n%s", mountArg, args)
 	}
@@ -642,8 +643,8 @@ func TestDurationSecondsCeil(t *testing.T) {
 }
 
 func TestCacheVolumeNameIsStableAndFilesystemSafe(t *testing.T) {
-	got := multipassCacheVolumeName("My App/linux node24 lock")
-	again := multipassCacheVolumeName("My App/linux node24 lock")
+	got := shared.CacheVolumeName("My App/linux node24 lock")
+	again := shared.CacheVolumeName("My App/linux node24 lock")
 	if got != again {
 		t.Fatalf("cache volume name unstable: %q then %q", got, again)
 	}

--- a/internal/providers/namespaceinstance/backend.go
+++ b/internal/providers/namespaceinstance/backend.go
@@ -837,11 +837,11 @@ func (b *backend) server(item instance, cfg core.Config) core.Server {
 	if labels["state"] == "" {
 		labels["state"] = "running"
 	}
-	labels["server_type"] = firstNonBlank(labels["server_type"], shapeName(item.Shape), cfg.ServerType)
+	labels["server_type"] = shared.FirstNonBlankTrimmed(labels["server_type"], shapeName(item.Shape), cfg.ServerType)
 	server := core.Server{
 		CloudID:  item.ClusterID,
 		Provider: providerName,
-		Name:     firstNonBlank(labels["slug"], item.ClusterID),
+		Name:     shared.FirstNonBlankTrimmed(labels["slug"], item.ClusterID),
 		Status:   labels["state"],
 		Labels:   labels,
 	}
@@ -1084,8 +1084,4 @@ func commandError(action string, result core.LocalCommandResult, err error) erro
 		return core.Exit(result.ExitCode, "%s failed: %v: %s", action, err, detail)
 	}
 	return core.Exit(result.ExitCode, "%s failed: %v", action, err)
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlankTrimmed(values...)
 }

--- a/internal/providers/nebius/backend.go
+++ b/internal/providers/nebius/backend.go
@@ -523,7 +523,7 @@ func (b *backend) checkVersion(ctx context.Context, client cliRunner) core.Docto
 	if err != nil {
 		return doctorCheck("cli", "error", err.Error(), nil)
 	}
-	return doctorCheck("cli", "ok", "nebius cli available", map[string]string{"version": redactNebiusText(firstNonBlank(result.Stdout, result.Stderr))})
+	return doctorCheck("cli", "ok", "nebius cli available", map[string]string{"version": redactNebiusText(shared.FirstNonBlankTrimmed(result.Stdout, result.Stderr))})
 }
 
 func (b *backend) checkProfile(ctx context.Context, client cliRunner) core.DoctorCheck {

--- a/internal/providers/nebius/cli.go
+++ b/internal/providers/nebius/cli.go
@@ -73,7 +73,7 @@ func (c cliRunner) run(ctx context.Context, args ...string) (cliResult, error) {
 		Args: commandArgs,
 	})
 	if err != nil {
-		return cliResult{Stdout: result.Stdout, Stderr: result.Stderr}, fmt.Errorf("nebius cli %s failed: %s", strings.Join(redactNebiusArgs(commandArgs), " "), redactNebiusText(firstNonBlank(result.Stderr, err.Error())))
+		return cliResult{Stdout: result.Stdout, Stderr: result.Stderr}, fmt.Errorf("nebius cli %s failed: %s", strings.Join(redactNebiusArgs(commandArgs), " "), redactNebiusText(shared.FirstNonBlankTrimmed(result.Stderr, err.Error())))
 	}
 	return cliResult{Stdout: result.Stdout, Stderr: result.Stderr}, nil
 }
@@ -147,7 +147,7 @@ func (c *nebiusClient) CreateInstance(ctx context.Context, req nebiusCreateReque
 		"--boot-disk-attach-mode", "read_write",
 		"--cloud-init-user-data", req.UserData,
 		"--network-interfaces", renderNetworkInterfaces(c.cfg),
-		"--recovery-policy", firstNonBlank(c.cfg.RecoveryPolicy, "fail"),
+		"--recovery-policy", shared.FirstNonBlankTrimmed(c.cfg.RecoveryPolicy, "fail"),
 	}
 	if strings.TrimSpace(c.cfg.ServiceAccountID) != "" {
 		args = append(args, "--service-account-id", strings.TrimSpace(c.cfg.ServiceAccountID))
@@ -287,7 +287,7 @@ func serverFromInstance(item nebiusInstance, cfg core.Config) core.Server {
 	server := core.Server{
 		CloudID:  item.ID,
 		Provider: providerName,
-		Name:     firstNonBlank(item.Name, labels["slug"]),
+		Name:     shared.FirstNonBlankTrimmed(item.Name, labels["slug"]),
 		Status:   normalizeNebiusState(item.Status),
 		Labels:   labels,
 	}
@@ -471,10 +471,6 @@ func mapFromAny(value any) map[string]string {
 func redactNebiusText(text string) string {
 	text = tokenLikePattern.ReplaceAllString(text, "[REDACTED]")
 	return strings.TrimSpace(text)
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlankTrimmed(values...)
 }
 
 func isJSON(output string) bool {

--- a/internal/providers/opencomputer/apiclient.go
+++ b/internal/providers/opencomputer/apiclient.go
@@ -129,7 +129,7 @@ func validateOCAPIURL(raw string) (string, error) {
 		return "", core.Exit(2, "provider=opencomputer API URL must not contain userinfo, query parameters, or a fragment")
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
-	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && shared.IsLoopbackHost(parsed.Hostname())) {
 		return "", core.Exit(2, "provider=opencomputer API URL must use HTTPS except for loopback development endpoints")
 	}
 	host := shared.LowercaseHostname(parsed.Hostname())
@@ -151,10 +151,6 @@ func validateOCAPIURL(raw string) (string, error) {
 	parsed.Path = cleanPath
 	parsed.RawPath = ""
 	return strings.TrimRight(parsed.String(), "/"), nil
-}
-
-func isLoopbackHost(host string) bool {
-	return shared.IsLoopbackHost(host)
 }
 
 func ocRedirectError(destination *url.URL) error {

--- a/internal/providers/opensandbox/client.go
+++ b/internal/providers/opensandbox/client.go
@@ -158,7 +158,7 @@ func newOpenSandboxClient(cfg core.Config, rt core.Runtime) (openSandboxClient, 
 	if err != nil {
 		return nil, err
 	}
-	apiKey := firstNonEmpty(
+	apiKey := shared.FirstNonBlankTrimmed(
 		os.Getenv("CRABBOX_OPENSANDBOX_API_KEY"),
 		os.Getenv("OPEN_SANDBOX_API_KEY"),
 	)
@@ -187,7 +187,7 @@ func validateOpenSandboxAPIURL(raw string) (string, error) {
 		return "", core.Exit(2, "provider=opensandbox API URL must not contain userinfo, query parameters, or a fragment")
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
-	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && shared.IsLoopbackHost(parsed.Hostname())) {
 		return "", core.Exit(2, "provider=opensandbox API URL must use HTTPS except for loopback development endpoints")
 	}
 	host := shared.LowercaseHostname(parsed.Hostname())
@@ -208,10 +208,6 @@ func validateOpenSandboxAPIURL(raw string) (string, error) {
 	}
 	parsed.RawPath = ""
 	return strings.TrimRight(parsed.String(), "/"), nil
-}
-
-func isLoopbackHost(host string) bool {
-	return shared.IsLoopbackHost(host)
 }
 
 func secureOpenSandboxHTTPClient(source *http.Client) *http.Client {
@@ -986,7 +982,7 @@ func validateOpenSandboxExecdURL(raw, defaultProtocol string) (string, string, e
 	if parsed.User != nil || parsed.Fragment != "" {
 		return "", "", core.Exit(5, "opensandbox execd endpoint must not contain userinfo or a fragment")
 	}
-	if parsed.Scheme == "http" && !isLoopbackHost(parsed.Hostname()) {
+	if parsed.Scheme == "http" && !shared.IsLoopbackHost(parsed.Hostname()) {
 		return "", "", core.Exit(5, "opensandbox execd endpoint host %q must use HTTPS unless it is loopback", parsed.Host)
 	}
 	rawQuery := parsed.RawQuery
@@ -1029,15 +1025,6 @@ func sdkSandboxInfo(info *sdk.SandboxInfo) sandboxInfo {
 func isOpenSandboxNotFound(err error) bool {
 	var apiErr *sdk.APIError
 	return errors.Is(err, errOpenSandboxNotFound) || (errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound)
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
 }
 
 func cloneStringMap(in map[string]string) map[string]string {

--- a/internal/providers/ovh/backend.go
+++ b/internal/providers/ovh/backend.go
@@ -241,7 +241,7 @@ func (b *Backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 		} else if ok {
 			recovery = "ambiguous-create"
 			created = mergeInstanceLabels(recovered, labels)
-			created.SSHKeyID = firstNonBlank(created.SSHKeyID, createdKey.ID)
+			created.SSHKeyID = shared.FirstNonBlank(created.SSHKeyID, createdKey.ID)
 		}
 		return core.LeaseTarget{}, err
 	}
@@ -251,7 +251,7 @@ func (b *Backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 		return core.LeaseTarget{}, err
 	}
 	waited = mergeInstanceLabels(waited, labels)
-	waited.SSHKeyID = firstNonBlank(waited.SSHKeyID, createdKey.ID)
+	waited.SSHKeyID = shared.FirstNonBlank(waited.SSHKeyID, createdKey.ID)
 	server := serverFromInstance(waited, cfg)
 	ssh := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
 	if err := b.waitSSH(ctx, &ssh, "ovh bootstrap", core.BootstrapWaitTimeout(cfg)); err != nil {
@@ -540,12 +540,12 @@ func (b *Backend) UpdateTailscaleMetadata(ctx context.Context, lease core.LeaseT
 			return core.Server{}, core.Exit(4, "ovh lease=%s cleanup is already in progress", claim.LeaseID)
 		}
 		labels = shared.CloneLabels(claim.Labels)
-		applyTailscaleMetadata(labels, meta)
+		shared.ApplyTailscaleMetadata(labels, meta)
 		if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(claim.LeaseID, claim, labels); err != nil {
 			return core.Server{}, err
 		}
 	} else {
-		applyTailscaleMetadata(labels, meta)
+		shared.ApplyTailscaleMetadata(labels, meta)
 	}
 	live.Labels = labels
 	return live, nil
@@ -784,13 +784,13 @@ func selectFlavor(flavors []Flavor, value string) (Flavor, error) {
 
 func validateFlavor(flavor Flavor) (Flavor, error) {
 	if flavor.Available != nil && !*flavor.Available {
-		return Flavor{}, core.Exit(2, "ovh flavor %q is unavailable", firstNonBlank(flavor.ID, flavor.Name))
+		return Flavor{}, core.Exit(2, "ovh flavor %q is unavailable", shared.FirstNonBlank(flavor.ID, flavor.Name))
 	}
 	if flavor.Quota != nil && *flavor.Quota <= 0 {
-		return Flavor{}, core.Exit(2, "ovh flavor %q has no remaining project quota", firstNonBlank(flavor.ID, flavor.Name))
+		return Flavor{}, core.Exit(2, "ovh flavor %q has no remaining project quota", shared.FirstNonBlank(flavor.ID, flavor.Name))
 	}
 	if osType := strings.ToLower(strings.TrimSpace(flavor.OSType)); osType != "" && osType != "linux" {
-		return Flavor{}, core.Exit(2, "ovh flavor %q is for osType=%s, not linux", firstNonBlank(flavor.ID, flavor.Name), flavor.OSType)
+		return Flavor{}, core.Exit(2, "ovh flavor %q is for osType=%s, not linux", shared.FirstNonBlank(flavor.ID, flavor.Name), flavor.OSType)
 	}
 	return flavor, nil
 }
@@ -820,14 +820,14 @@ func selectImage(images []Image, value string) (Image, error) {
 
 func validateImage(image Image, selectedByID bool) (Image, error) {
 	if status := strings.ToLower(strings.TrimSpace(image.Status)); status != "" && status != "active" {
-		return Image{}, core.Exit(2, "ovh image %q has status=%s", firstNonBlank(image.ID, image.Name), image.Status)
+		return Image{}, core.Exit(2, "ovh image %q has status=%s", shared.FirstNonBlank(image.ID, image.Name), image.Status)
 	}
 	if imageType := strings.ToLower(strings.TrimSpace(image.Type)); imageType != "" && imageType != "linux" {
-		return Image{}, core.Exit(2, "ovh image %q has type=%s, not linux", firstNonBlank(image.ID, image.Name), image.Type)
+		return Image{}, core.Exit(2, "ovh image %q has type=%s, not linux", shared.FirstNonBlank(image.ID, image.Name), image.Type)
 	}
 	imageName := strings.ToLower(strings.TrimSpace(image.Name))
 	if !strings.Contains(imageName, "ubuntu") && !strings.Contains(imageName, "debian") {
-		return Image{}, core.Exit(2, "ovh image %q is not a supported Debian or Ubuntu image", firstNonBlank(image.ID, image.Name))
+		return Image{}, core.Exit(2, "ovh image %q is not a supported Debian or Ubuntu image", shared.FirstNonBlank(image.ID, image.Name))
 	}
 	if !selectedByID {
 		visibility := strings.ToLower(strings.TrimSpace(image.Visibility))
@@ -892,7 +892,7 @@ func (b *Backend) reconcileCreatedInstance(ctx context.Context, client API, clai
 			lastErr = err
 		}
 		if attempt+1 < b.effectiveRecoveryPolls() {
-			if err := sleepContext(ctx, b.effectiveRecoveryInterval()); err != nil {
+			if err := core.SleepContext(ctx, b.effectiveRecoveryInterval()); err != nil {
 				return Instance{}, false, err
 			}
 		}
@@ -916,7 +916,7 @@ func (b *Backend) reconcileSSHKey(ctx context.Context, client API, projectID, na
 			lastErr = err
 		}
 		if attempt+1 < b.effectiveRecoveryPolls() {
-			if err := sleepContext(ctx, b.effectiveRecoveryInterval()); err != nil {
+			if err := core.SleepContext(ctx, b.effectiveRecoveryInterval()); err != nil {
 				return SSHKey{}, false, err
 			}
 		}
@@ -986,17 +986,6 @@ func selectSSHKey(keys []SSHKey, name, publicKey string) (SSHKey, bool, error) {
 		return SSHKey{}, false, core.Exit(3, "ovh SSH key %q exists with a different public key", name)
 	default:
 		return SSHKey{}, false, nil
-	}
-}
-
-func sleepContext(ctx context.Context, delay time.Duration) error {
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
 	}
 }
 
@@ -1189,10 +1178,6 @@ func overlayExpectedOVHLabels(live, expected core.Server) core.Server {
 	return merged
 }
 
-func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadata) {
-	shared.ApplyTailscaleMetadata(labels, meta)
-}
-
 func exactTailscaleLabels(labels map[string]string) map[string]string {
 	out := map[string]string{}
 	for _, key := range []string{
@@ -1225,7 +1210,7 @@ func serverFromInstance(instance Instance, cfg core.Config) core.Server {
 		labels[ovhProjectLabel] = cfg.OVH.ProjectID
 	}
 	if labels[ovhRegionLabel] == "" {
-		labels[ovhRegionLabel] = firstNonBlank(instance.Region, cfg.OVH.Region)
+		labels[ovhRegionLabel] = shared.FirstNonBlank(instance.Region, cfg.OVH.Region)
 	}
 	if labels[ovhSSHKeyIDLabel] == "" && instance.SSHKeyID != "" {
 		labels[ovhSSHKeyIDLabel] = instance.SSHKeyID
@@ -1238,7 +1223,7 @@ func serverFromInstance(instance Instance, cfg core.Config) core.Server {
 		Labels:   labels,
 	}
 	server.PublicNet.IPv4.IP = publicIPv4(instance)
-	server.ServerType.Name = firstNonBlank(instance.FlavorID, instance.Flavor.ID, instance.Flavor.Name, cfg.ServerType)
+	server.ServerType.Name = shared.FirstNonBlank(instance.FlavorID, instance.Flavor.ID, instance.Flavor.Name, cfg.ServerType)
 	return server
 }
 
@@ -1374,7 +1359,7 @@ func retryOVHDelete(ctx context.Context, interval time.Duration, resource string
 			return err
 		}
 		lastErr = err
-		if err := sleepContext(ctx, interval); err != nil {
+		if err := core.SleepContext(ctx, interval); err != nil {
 			return fmt.Errorf("could not confirm deletion of OVH %s: %w", resource, errors.Join(lastErr, err))
 		}
 	}
@@ -1443,8 +1428,4 @@ func blank(value string) string {
 		return "-"
 	}
 	return value
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlank(values...)
 }

--- a/internal/providers/parallels/backend.go
+++ b/internal/providers/parallels/backend.go
@@ -42,7 +42,7 @@ func (b *leaseBackend) Acquire(ctx context.Context, req core.AcquireRequest) (co
 
 func (b *leaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (core.LeaseTarget, error) {
 	cfg := b.Cfg
-	source := strings.TrimSpace(firstNonEmpty(cfg.Parallels.SourceID, cfg.Parallels.Source))
+	source := strings.TrimSpace(shared.FirstNonBlankTrimmed(cfg.Parallels.SourceID, cfg.Parallels.Source))
 	if source == "" {
 		return core.LeaseTarget{}, core.Exit(2, "provider=parallels requires --parallels-source, --parallels-template, or parallels.source")
 	}
@@ -78,7 +78,7 @@ func (b *leaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug
 	}
 	cfg.SSHKey = keyPath
 	cfg.ProviderKey = core.ProviderKeyForLease(leaseID)
-	snapshotID := strings.TrimSpace(firstNonEmpty(cfg.Parallels.SourceSnapshotID, cfg.Parallels.SourceSnapshot))
+	snapshotID := strings.TrimSpace(shared.FirstNonBlankTrimmed(cfg.Parallels.SourceSnapshotID, cfg.Parallels.SourceSnapshot))
 	if snapshotID != "" && cfg.Parallels.SourceSnapshotID == "" {
 		resolved, err := client.SnapshotID(ctx, source, snapshotID)
 		if err != nil {
@@ -159,7 +159,7 @@ func (b *leaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (co
 			leaseID, slug := parallelsLeaseFromVMName(vm.Name)
 			labels := core.ParallelsLabelsFromName(vm.Name)
 			if labels["lease"] == "" {
-				labels = core.DirectLeaseLabels(candidate, firstNonEmpty(leaseID, vm.ID), slug, "parallels", "", true, time.Now().UTC())
+				labels = core.DirectLeaseLabels(candidate, shared.FirstNonBlankTrimmed(leaseID, vm.ID), slug, "parallels", "", true, time.Now().UTC())
 			}
 			labels["host"] = parallelsHostName(candidate)
 			server := core.Server{CloudID: vm.ID, Provider: "parallels", Name: vm.Name, Status: strings.ToLower(vm.State), Labels: labels}
@@ -167,7 +167,7 @@ func (b *leaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (co
 			server.ServerType.Name = core.ServerTypeForProviderClass("parallels", candidate.Class)
 			normalizedID := strings.ReplaceAll(id, "_", "-")
 			if vm.ID == id || vm.Name == id || leaseID == id || strings.ReplaceAll(leaseID, "_", "-") == normalizedID || core.NormalizeLeaseSlug(slug) == core.NormalizeLeaseSlug(id) {
-				leaseID = firstNonEmpty(leaseID, vm.ID)
+				leaseID = shared.FirstNonBlankTrimmed(leaseID, vm.ID)
 				adopt, err := authorizeParallelsResolve(req, leaseID, vm.ID, parallelsHostName(candidate))
 				if err != nil {
 					return core.LeaseTarget{}, err
@@ -297,7 +297,7 @@ func (b *leaseBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRe
 	if req.Lease.Server.Name != "" && !strings.HasPrefix(req.Lease.Server.Name, "crabbox-") {
 		return core.Exit(2, "refusing to release non-Crabbox Parallels VM %q", req.Lease.Server.Name)
 	}
-	id := firstNonEmpty(req.Lease.Server.CloudID, req.Lease.LeaseID)
+	id := shared.FirstNonBlankTrimmed(req.Lease.Server.CloudID, req.Lease.LeaseID)
 	cfg := b.configForLease(ctx, req.Lease)
 	if err := requireExactParallelsClaim(req.Lease.LeaseID, id, parallelsHostName(cfg)); err != nil {
 		return err
@@ -313,7 +313,7 @@ func (b *leaseBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRe
 func (b *leaseBackend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
 	server := req.Lease.Server
 	server.Labels = core.TouchDirectLeaseLabels(server.Labels, b.Cfg, req.State, time.Now().UTC())
-	core.NewParallelsClient(b.configForLease(ctx, req.Lease), b.RT.Exec).SetLeaseLabels(firstNonEmpty(req.Lease.LeaseID, server.Labels["lease"]), server.Labels)
+	core.NewParallelsClient(b.configForLease(ctx, req.Lease), b.RT.Exec).SetLeaseLabels(shared.FirstNonBlankTrimmed(req.Lease.LeaseID, server.Labels["lease"]), server.Labels)
 	return server, nil
 }
 
@@ -404,7 +404,7 @@ func (b *leaseBackend) configForLease(ctx context.Context, lease core.LeaseTarge
 			}
 		}
 	}
-	id := firstNonEmpty(lease.Server.CloudID, lease.LeaseID)
+	id := shared.FirstNonBlankTrimmed(lease.Server.CloudID, lease.LeaseID)
 	if id != "" {
 		for _, candidate := range core.ParallelsCandidateConfigs(b.Cfg) {
 			client := core.NewParallelsClient(candidate, b.RT.Exec)
@@ -416,17 +416,8 @@ func (b *leaseBackend) configForLease(ctx context.Context, lease core.LeaseTarge
 	return b.Cfg
 }
 
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
-}
-
 func parallelsHostName(cfg core.Config) string {
-	return firstNonEmpty(cfg.Parallels.SelectedHost, cfg.Parallels.Host, "local")
+	return shared.FirstNonBlankTrimmed(cfg.Parallels.SelectedHost, cfg.Parallels.Host, "local")
 }
 
 func blank(value, fallback string) string {

--- a/internal/providers/phala/backend.go
+++ b/internal/providers/phala/backend.go
@@ -132,7 +132,7 @@ func (i *instance) UnmarshalJSON(data []byte) error {
 // app_id is preferred (confirmed working against live `cvms get/delete
 // --cvm-id`); vm_uuid, instance_id, and name are accepted fallbacks.
 func (i instance) cloudID() string {
-	return firstNonBlank(i.AppID, i.VMUUID, i.ID, i.InstanceID, i.Name)
+	return shared.FirstNonBlankTrimmed(i.AppID, i.VMUUID, i.ID, i.InstanceID, i.Name)
 }
 
 // matchesID reports whether identifier names this CVM under any of the handles
@@ -498,7 +498,7 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 		// stored one. b.lease()/mergeClaimLabels surfaced the authoritative claim.Slug
 		// onto lease.Server.Labels["slug"], so prefer that, and never overwrite a
 		// non-empty stored slug with a blank.
-		slug := firstNonBlank(lease.Server.Labels["slug"], item.Labels["slug"])
+		slug := shared.FirstNonBlankTrimmed(lease.Server.Labels["slug"], item.Labels["slug"])
 		if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
 			return core.LeaseTarget{}, err
 		}
@@ -623,7 +623,7 @@ func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server
 		// a blank server.Labels["slug"] (e.g. a lease target whose labels lost it)
 		// would WIPE the stored slug on every idle keepalive. Prefer the existing
 		// claim's slug so Touch never blanks it.
-		slug := firstNonBlank(server.Labels["slug"], claim.Slug)
+		slug := shared.FirstNonBlankTrimmed(server.Labels["slug"], claim.Slug)
 		if ok {
 			if claim.RepoRoot != "" {
 				_, err = core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, slug, cfg, server, req.Lease.SSH, claim.RepoRoot, idleTimeout, false, claim, true)
@@ -1179,11 +1179,11 @@ func (b *backend) server(item instance, cfg core.Config) core.Server {
 	if labels["state"] == "" {
 		labels["state"] = phalaState(item.Status)
 	}
-	labels["server_type"] = firstNonBlank(labels["server_type"], item.InstanceType, cfg.ServerType)
+	labels["server_type"] = shared.FirstNonBlankTrimmed(labels["server_type"], item.InstanceType, cfg.ServerType)
 	server := core.Server{
 		CloudID:  item.cloudID(),
 		Provider: providerName,
-		Name:     firstNonBlank(labels["slug"], item.Name, item.cloudID()),
+		Name:     shared.FirstNonBlankTrimmed(labels["slug"], item.Name, item.cloudID()),
 		Status:   labels["state"],
 		Labels:   labels,
 	}
@@ -1579,7 +1579,7 @@ func (g *gatewayGetOutput) UnmarshalJSON(data []byte) error {
 // phalaCVM.appID() EXACTLY so the cached host and the proxy-resolved fallback
 // host are identical (the gateway domain preference already matches).
 func (g *gatewayGetOutput) appID() string {
-	id := firstNonBlank(g.AppID, g.AppIDAlt, g.ID, g.InstanceID)
+	id := shared.FirstNonBlankTrimmed(g.AppID, g.AppIDAlt, g.ID, g.InstanceID)
 	if id == "" && g.CVM != nil {
 		id = g.CVM.appID()
 	}
@@ -1590,7 +1590,7 @@ func (g *gatewayGetOutput) appID() string {
 // the nested base_domain/domain, then a top-level gateway_domain, falling
 // through to the nested cvm object. This preference matches resolvePhalaProxyHost.
 func (g *gatewayGetOutput) gatewayDomain() string {
-	domain := firstNonBlank(g.GatewayDomain, g.BaseDomain, g.Domain, g.TopGateway)
+	domain := shared.FirstNonBlankTrimmed(g.GatewayDomain, g.BaseDomain, g.Domain, g.TopGateway)
 	if domain == "" && g.CVM != nil {
 		domain = g.CVM.gatewayDomain()
 	}
@@ -1639,7 +1639,7 @@ func (b *backend) validateDestroyTarget(ctx context.Context, cfg core.Config, id
 	if !ok {
 		return false, core.Exit(4, "refusing to destroy Phala CVM %s: no local claim for lease %s", id, leaseID)
 	}
-	claimedID := firstNonBlank(claim.CloudID, claim.Labels["phala_cvm"])
+	claimedID := shared.FirstNonBlankTrimmed(claim.CloudID, claim.Labels["phala_cvm"])
 	if claimedID != "" && strings.TrimSpace(claimedID) != strings.TrimSpace(id) {
 		return false, core.Exit(4, "refusing to destroy Phala CVM %s: local claim for lease %s points to %s", id, leaseID, claimedID)
 	}
@@ -1684,10 +1684,6 @@ func commandError(action string, result core.LocalCommandResult, err error) erro
 		return core.Exit(result.ExitCode, "%s failed: %v: %s", action, err, detail)
 	}
 	return core.Exit(result.ExitCode, "%s failed: %v", action, err)
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlankTrimmed(values...)
 }
 
 // jsonObjectPrefix returns the first top-level JSON object/array embedded in a

--- a/internal/providers/railway/client.go
+++ b/internal/providers/railway/client.go
@@ -164,7 +164,7 @@ func newRailwayClient(cfg core.Config, rt core.Runtime) (railwayAPI, error) {
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return nil, core.Exit(2, "%s url %q is invalid", providerName, apiURL)
 	}
-	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
+	if parsed.Scheme != "https" && !shared.IsLoopbackHTTPURL(parsed) {
 		return nil, core.Exit(2, "%s url %q must use https unless it targets localhost", providerName, apiURL)
 	}
 	httpClient := rt.HTTP
@@ -623,8 +623,4 @@ func (c *railwayClient) GetService(ctx context.Context, serviceID string) (railw
 		return railwayService{}, fmt.Errorf("service %s not found", serviceID)
 	}
 	return railwayService{ID: out.Service.ID, Name: out.Service.Name, ProjectID: out.Service.ProjectID}, nil
-}
-
-func isLoopbackHTTPURL(parsed *url.URL) bool {
-	return shared.IsLoopbackHTTPURL(parsed)
 }

--- a/internal/providers/runpod/client.go
+++ b/internal/providers/runpod/client.go
@@ -127,7 +127,7 @@ func newRunpodClient(cfg core.Config, rt core.Runtime) (runpodAPI, error) {
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return nil, core.Exit(2, "%s url %q is invalid", providerName, apiURL)
 	}
-	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
+	if parsed.Scheme != "https" && !shared.IsLoopbackHTTPURL(parsed) {
 		return nil, core.Exit(2, "%s url %q must use https unless it targets localhost", providerName, apiURL)
 	}
 	httpClient := rt.HTTP
@@ -371,8 +371,4 @@ func (p *runpodPod) UnmarshalJSON(data []byte) error {
 	}
 	p.PortMappings = decodePortMappings(aux.PortMappings)
 	return nil
-}
-
-func isLoopbackHTTPURL(parsed *url.URL) bool {
-	return shared.IsLoopbackHTTPURL(parsed)
 }

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -524,7 +524,7 @@ func (b *Backend) UpdateTailscaleMetadata(ctx context.Context, lease core.LeaseT
 		return core.Server{}, err
 	}
 	labels := live.Labels
-	applyTailscaleMetadata(labels, meta)
+	shared.ApplyTailscaleMetadata(labels, meta)
 	updateResp, err := client.Instance().UpdateServer(&instance.UpdateServerRequest{
 		Zone:     scw.Zone(client.Zone()),
 		ServerID: resp.Server.ID,
@@ -1228,8 +1228,4 @@ func isAmbiguousScalewayError(err error) bool {
 		}
 	}
 	return false
-}
-
-func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadata) {
-	shared.ApplyTailscaleMetadata(labels, meta)
 }

--- a/internal/providers/smolvm/client.go
+++ b/internal/providers/smolvm/client.go
@@ -171,7 +171,7 @@ func smolvmEndpoint(cfg core.Config) (string, error) {
 	if parsed.Scheme == "" || parsed.Host == "" {
 		return "", core.Exit(2, "%s url %q is invalid", providerName, base)
 	}
-	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
+	if parsed.Scheme != "https" && !shared.IsLoopbackHTTPURL(parsed) {
 		return "", core.Exit(2, "%s url %q must use https unless it targets localhost", providerName, base)
 	}
 	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
@@ -201,10 +201,6 @@ func customSmolvmBaseURLAllowed() bool {
 	default:
 		return false
 	}
-}
-
-func isLoopbackHTTPURL(parsed *url.URL) bool {
-	return shared.IsLoopbackHTTPURL(parsed)
 }
 
 func (c *client) CreateMachine(ctx context.Context, req createRequest) (machineData, error) {

--- a/internal/providers/superserve/client.go
+++ b/internal/providers/superserve/client.go
@@ -112,7 +112,7 @@ func newSuperserveClient(cfg core.Config, rt core.Runtime) (superserveClient, er
 	if err != nil {
 		return nil, err
 	}
-	apiKey := firstNonEmpty(
+	apiKey := shared.FirstNonBlankTrimmed(
 		os.Getenv("CRABBOX_SUPERSERVE_API_KEY"),
 		os.Getenv("SUPERSERVE_API_KEY"),
 	)
@@ -383,7 +383,7 @@ func (c *httpSuperserveClient) dataPlaneTarget(sandboxID string) (dataPlaneTarge
 	if err != nil {
 		return dataPlaneTarget{}, err
 	}
-	if isLoopbackHost(parsed.Hostname()) {
+	if shared.IsLoopbackHost(parsed.Hostname()) {
 		return dataPlaneTarget{
 			baseURL: strings.TrimRight(parsed.String(), "/"),
 			headers: map[string]string{
@@ -686,13 +686,4 @@ func redactJSONSecretField(value, key string) string {
 func superserveEndpointScope(baseURL string) string {
 	digest := sha256.Sum256([]byte(baseURL))
 	return "endpoint-sha256:" + hex.EncodeToString(digest[:])
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
 }

--- a/internal/providers/superserve/flags.go
+++ b/internal/providers/superserve/flags.go
@@ -143,7 +143,7 @@ func validateSuperserveBaseURL(raw string) (string, error) {
 		return "", core.Exit(2, "provider=superserve base URL must not contain userinfo, query parameters, or a fragment")
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
-	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && shared.IsLoopbackHost(parsed.Hostname())) {
 		return "", core.Exit(2, "provider=superserve base URL must use HTTPS except for loopback development endpoints")
 	}
 	parsed.Host = shared.CanonicalHostPort(parsed)
@@ -165,10 +165,6 @@ func superserveWorkdir(cfg core.Config) (string, error) {
 		return "", core.Exit(2, "superserve workdir %q is too broad; choose a dedicated subdirectory", clean)
 	}
 	return clean, nil
-}
-
-func isLoopbackHost(host string) bool {
-	return shared.IsLoopbackHost(host)
 }
 
 func splitSuperserveList(value string) []string {

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -308,7 +308,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 		pruneLeaseState(lease.LeaseID)
 		return nil
 	}
-	name := strings.TrimSpace(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]))
+	name := strings.TrimSpace(shared.FirstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]))
 	if name == "" && lease.LeaseID != "" {
 		inst, _, claim, err := b.resolveInstance(ctx, lease.LeaseID)
 		if err != nil {
@@ -342,7 +342,7 @@ func pruneLeaseState(leaseID string) {
 }
 
 func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
-	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, core.Blank(firstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
+	return fmt.Sprintf("released lease=%s instance=%s", lease.LeaseID, core.Blank(shared.FirstNonBlank(lease.Server.CloudID, lease.Server.Labels["instance"]), "-"))
 }
 
 func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
@@ -808,7 +808,7 @@ func (b *backend) serverFromInstance(inst tartInstance, claim core.LeaseClaim, c
 		labels["state"] = tartState(inst.State)
 	}
 	if labels["server_type"] == "" {
-		labels["server_type"] = firstNonBlank(inst.Source, cfg.Tart.Image)
+		labels["server_type"] = shared.FirstNonBlank(inst.Source, cfg.Tart.Image)
 	}
 	// Native inventory's Source is a storage kind, not an image identity.
 	// Only acquisition records image provenance in the claim.
@@ -833,7 +833,7 @@ func (b *backend) serverFromInstance(inst tartInstance, claim core.LeaseClaim, c
 		Status:      status,
 		Labels:      labels,
 	}
-	server.ServerType.Name = firstNonBlank(labels["server_type"], cfg.Tart.Image)
+	server.ServerType.Name = shared.FirstNonBlank(labels["server_type"], cfg.Tart.Image)
 	return server
 }
 
@@ -942,8 +942,4 @@ func firstLine(value string) string {
 		value = value[:idx]
 	}
 	return strings.TrimSpace(value)
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlank(values...)
 }

--- a/internal/providers/tart/provider_test.go
+++ b/internal/providers/tart/provider_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 	"github.com/openclaw/crabbox/internal/testutil"
 )
 
@@ -2135,13 +2136,13 @@ func TestInstanceNameFromClaim(t *testing.T) {
 }
 
 func TestFirstNonBlank(t *testing.T) {
-	if got := firstNonBlank("", "  ", "hello", "world"); got != "hello" {
+	if got := shared.FirstNonBlank("", "  ", "hello", "world"); got != "hello" {
 		t.Fatalf("firstNonBlank = %q, want hello", got)
 	}
-	if got := firstNonBlank("", "", ""); got != "" {
+	if got := shared.FirstNonBlank("", "", ""); got != "" {
 		t.Fatalf("firstNonBlank all blank = %q", got)
 	}
-	if got := firstNonBlank("first"); got != "first" {
+	if got := shared.FirstNonBlank("first"); got != "first" {
 		t.Fatalf("firstNonBlank single = %q", got)
 	}
 }
@@ -3324,19 +3325,19 @@ func TestFirstLineMultiLine(t *testing.T) {
 }
 
 func TestFirstNonBlankAllEmpty(t *testing.T) {
-	if got := firstNonBlank("", "  ", "\t"); got != "" {
+	if got := shared.FirstNonBlank("", "  ", "\t"); got != "" {
 		t.Fatalf("firstNonBlank all empty = %q, want \"\"", got)
 	}
 }
 
 func TestFirstNonBlankFindsFirst(t *testing.T) {
-	if got := firstNonBlank("", "hello", "world"); got != "hello" {
+	if got := shared.FirstNonBlank("", "hello", "world"); got != "hello" {
 		t.Fatalf("firstNonBlank = %q, want \"hello\"", got)
 	}
 }
 
 func TestFirstNonBlankSingleValue(t *testing.T) {
-	if got := firstNonBlank("only"); got != "only" {
+	if got := shared.FirstNonBlank("only"); got != "only" {
 		t.Fatalf("firstNonBlank(\"only\") = %q", got)
 	}
 }

--- a/internal/providers/tencentcloud/backend.go
+++ b/internal/providers/tencentcloud/backend.go
@@ -425,7 +425,7 @@ func (b *Backend) UpdateTailscaleMetadata(ctx context.Context, lease core.LeaseT
 	if accountID := strings.TrimSpace(server.Labels[accountLabel]); accountID != "" {
 		labels[accountLabel] = accountID
 	}
-	applyTailscaleMetadata(labels, meta)
+	shared.ApplyTailscaleMetadata(labels, meta)
 	if err := client.ReplaceInstanceTags(ctx, server.CloudID, item.Tags, tagsFromLabels(labels)); err != nil {
 		return core.Server{}, err
 	}
@@ -556,7 +556,7 @@ func serverFromInstance(item instance, cfg core.Config) core.Server {
 		Labels:   labels,
 	}
 	server.PublicNet.IPv4.IP = publicIPv4(item)
-	server.ServerType.Name = firstNonBlank(item.InstanceType, cfg.ServerType, serverTypeForConfig(cfg))
+	server.ServerType.Name = shared.FirstNonBlankTrimmed(item.InstanceType, cfg.ServerType, serverTypeForConfig(cfg))
 	return server
 }
 

--- a/internal/providers/tencentcloud/client.go
+++ b/internal/providers/tencentcloud/client.go
@@ -103,7 +103,7 @@ func (c *client) AccountID(ctx context.Context) (string, error) {
 	if err := c.do(ctx, stsService, c.stsEndpoint, "GetCallerIdentity", stsVersion, c.region, map[string]any{}, &out); err != nil {
 		return "", err
 	}
-	c.accountID = firstNonBlank(out.AccountID, out.UIN)
+	c.accountID = shared.FirstNonBlankTrimmed(out.AccountID, out.UIN)
 	if c.accountID == "" {
 		return "", core.Exit(3, "tencentcloud GetCallerIdentity response did not include AccountId or Uin")
 	}
@@ -338,10 +338,6 @@ func hmacSHA256(key []byte, value string) []byte {
 
 func resourceName(region, accountID, instanceID string) string {
 	return fmt.Sprintf("qcs::cvm:%s:uin/%s:instance/%s", region, accountID, instanceID)
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlankTrimmed(values...)
 }
 
 func isNotFound(err error) bool {

--- a/internal/providers/tencentcloud/tags.go
+++ b/internal/providers/tencentcloud/tags.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
-	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -180,8 +179,4 @@ func truncateTagValue(value string) string {
 
 func ownedLabels(labels map[string]string) bool {
 	return labels["crabbox"] == "true" && labels["provider"] == providerName
-}
-
-func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadata) {
-	shared.ApplyTailscaleMetadata(labels, meta)
 }

--- a/internal/providers/tensorlake/backend.go
+++ b/internal/providers/tensorlake/backend.go
@@ -411,7 +411,7 @@ func newSandboxName(repo core.Repo) string {
 	if base == "" {
 		base = "crabbox"
 	}
-	return namePrefix + base + "-" + randomSuffix()
+	return namePrefix + base + "-" + shared.RandomSuffix()
 }
 
 func isReadyState(state string) bool {
@@ -421,10 +421,6 @@ func isReadyState(state string) bool {
 	default:
 		return false
 	}
-}
-
-func randomSuffix() string {
-	return shared.RandomSuffix()
 }
 
 // tensorlakeWorkdir returns the configured absolute workspace path inside the

--- a/internal/providers/tensorlake/backend_test.go
+++ b/internal/providers/tensorlake/backend_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 	"github.com/openclaw/crabbox/internal/testutil"
 )
 
@@ -1266,7 +1267,7 @@ func TestRunTimingJSONUsesClaimSlugForReusedSandbox(t *testing.T) {
 
 func TestKeepOnFailureRetainsSandboxAndPrintsHint(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir()) // keep-on-failure writes a lease claim (and lock); keep both out of the real state dir
-	sandboxID := "failkeep0" + randomSuffix() + randomSuffix()
+	sandboxID := "failkeep0" + shared.RandomSuffix() + shared.RandomSuffix()
 	defer core.RemoveLeaseClaim(leasePrefix + sandboxID)
 	runner := newRunner(
 		map[string]scriptedReply{

--- a/internal/providers/unikraftcloud/client.go
+++ b/internal/providers/unikraftcloud/client.go
@@ -186,7 +186,7 @@ func validateUnikraftCloudAPIURL(raw string) (string, error) {
 		return "", core.Exit(2, "provider=%s API URL must not contain userinfo, query parameters, or a fragment", providerName)
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
-	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
+	if parsed.Scheme != "https" && !shared.IsLoopbackHTTPURL(parsed) {
 		return "", core.Exit(2, "provider=%s API URL must use HTTPS except for loopback development endpoints", providerName)
 	}
 	if escapedPath := parsed.EscapedPath(); escapedPath != "" && escapedPath != "/" {
@@ -195,10 +195,6 @@ func validateUnikraftCloudAPIURL(raw string) (string, error) {
 	parsed.Path = ""
 	parsed.RawPath = ""
 	return parsed.String(), nil
-}
-
-func isLoopbackHTTPURL(parsed *url.URL) bool {
-	return shared.IsLoopbackHTTPURL(parsed)
 }
 
 func secureUnikraftCloudHTTPClient(source *http.Client, baseURL string) *http.Client {

--- a/internal/providers/vast/backend.go
+++ b/internal/providers/vast/backend.go
@@ -687,7 +687,7 @@ func (b *backend) deleteServerWithOutcome(ctx context.Context, server core.Serve
 		claim = snapshot
 	}
 	leaseID := binding.LeaseID
-	instanceID, ok := parseVastInstanceID(firstNonBlank(server.CloudID, claim.CloudID))
+	instanceID, ok := parseVastInstanceID(shared.FirstNonBlankTrimmed(server.CloudID, claim.CloudID))
 	if !ok {
 		return core.Exit(2, "provider=%s release requires a Vast instance id", providerName)
 	}
@@ -825,12 +825,12 @@ func serverFromInstance(item vastInstance, cfg core.Config) core.Server {
 	server := core.Server{
 		CloudID:  strconv.Itoa(item.ID),
 		Provider: providerName,
-		Name:     firstNonBlank(labels["slug"], item.Label, strconv.Itoa(item.ID)),
+		Name:     shared.FirstNonBlankTrimmed(labels["slug"], item.Label, strconv.Itoa(item.ID)),
 		Status:   normalizeVastStatus(item.Status),
 		Labels:   labels,
 	}
 	server.PublicNet.IPv4.IP = strings.TrimSpace(item.SSHHost)
-	server.ServerType.Name = firstNonBlank(item.GPUName, cfg.ServerType)
+	server.ServerType.Name = shared.FirstNonBlankTrimmed(item.GPUName, cfg.ServerType)
 	return server
 }
 
@@ -921,7 +921,7 @@ func sshTargetFromInstance(cfg core.Config, item vastInstance) (core.SSHTarget, 
 	}
 	ssh := core.SSHTargetFromConfig(cfg, host)
 	ssh.Port = strconv.Itoa(item.SSHPort)
-	ssh.User = firstNonBlank(cfg.SSHUser, cfg.Vast.User, "root")
+	ssh.User = shared.FirstNonBlankTrimmed(cfg.SSHUser, cfg.Vast.User, "root")
 	ssh.TargetOS = core.TargetLinux
 	ssh.ReadyCheck = vastReadyCheck
 	return ssh, nil
@@ -970,16 +970,12 @@ func effectiveVastReleaseAction(cfg core.Config, labels map[string]string) strin
 	if core.DeleteOnReleaseExplicit(cfg, providerName) {
 		return normalizeVastReleaseAction(cfg.Vast.ReleaseAction)
 	}
-	return normalizeVastReleaseAction(firstNonBlank(labels[vastReleaseActionLabel], cfg.Vast.ReleaseAction))
+	return normalizeVastReleaseAction(shared.FirstNonBlankTrimmed(labels[vastReleaseActionLabel], cfg.Vast.ReleaseAction))
 }
 
 func parseVastInstanceID(value string) (int, bool) {
 	id, err := strconv.Atoi(strings.TrimSpace(value))
 	return id, err == nil && id > 0
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlankTrimmed(values...)
 }
 
 func claimTarget(claim core.LeaseClaim) (core.LeaseTarget, error) {

--- a/internal/providers/vast/client.go
+++ b/internal/providers/vast/client.go
@@ -589,7 +589,7 @@ func (k *vastInstanceSSHKey) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	k.Name = raw.Name
-	k.PublicKey = firstNonBlank(raw.SSHKey, raw.PublicKey, raw.Key)
+	k.PublicKey = shared.FirstNonBlankTrimmed(raw.SSHKey, raw.PublicKey, raw.Key)
 	switch id := raw.ID.(type) {
 	case string:
 		k.ID = strings.TrimSpace(id)

--- a/internal/providers/vultr/backend.go
+++ b/internal/providers/vultr/backend.go
@@ -791,7 +791,7 @@ func serverFromInstance(item vultrInstance, cfg core.Config) core.Server {
 		Labels:   labels,
 	}
 	server.PublicNet.IPv4.IP = item.MainIP
-	server.ServerType.Name = firstNonBlank(item.Plan, cfg.ServerType)
+	server.ServerType.Name = shared.FirstNonBlank(item.Plan, cfg.ServerType)
 	return server
 }
 
@@ -909,8 +909,4 @@ func applyVultrDefaults(cfg *core.Config) {
 func isVultrInstanceID(value string) bool {
 	value = strings.TrimSpace(value)
 	return vultrInstanceIDRe.MatchString(value)
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlank(values...)
 }

--- a/internal/providers/xcpng/backend.go
+++ b/internal/providers/xcpng/backend.go
@@ -146,7 +146,7 @@ func (b *leaseBackend) acquireOnce(ctx context.Context, req core.AcquireRequest)
 	cfg.ServerType = xcpNgServerTypeForConfig(cfg)
 	now := currentTime(b.RT).UTC()
 	labels := core.DirectLeaseLabels(cfg, leaseID, slug, "xcp-ng", "", keep, now)
-	labels["work_root"] = firstNonBlank(cfg.XCPNg.WorkRoot, cfg.WorkRoot)
+	labels["work_root"] = shared.FirstNonBlank(cfg.XCPNg.WorkRoot, cfg.WorkRoot)
 
 	resolved, err := b.resolvePlacement(ctx, client)
 	if err != nil {
@@ -403,7 +403,7 @@ func (b *leaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) (co
 
 func (b *leaseBackend) resolveStatusServer(ctx context.Context, client lifecycleClient, server core.Server) core.Server {
 	server = reconcileXCPNgServerState(server)
-	if !strings.EqualFold(strings.TrimSpace(server.Status), "running") || firstNonBlank(server.PublicNet.IPv4.IP, server.PrivateNet.IPv4.IP) != "" {
+	if !strings.EqualFold(strings.TrimSpace(server.Status), "running") || shared.FirstNonBlank(server.PublicNet.IPv4.IP, server.PrivateNet.IPv4.IP) != "" {
 		return server
 	}
 	probeCtx, cancel := context.WithTimeout(ctx, 4*time.Second)
@@ -438,7 +438,7 @@ func reconcileXCPNgServerState(server core.Server) core.Server {
 }
 
 func (b *leaseBackend) ensureServerIP(ctx context.Context, client lifecycleClient, server core.Server, releaseOnly bool) (core.Server, error) {
-	if firstNonBlank(server.PublicNet.IPv4.IP, server.PrivateNet.IPv4.IP) != "" || releaseOnly {
+	if shared.FirstNonBlank(server.PublicNet.IPv4.IP, server.PrivateNet.IPv4.IP) != "" || releaseOnly {
 		return server, nil
 	}
 	ip, guestErr := client.GuestIPv4ForID(ctx, server.CloudID)
@@ -480,7 +480,7 @@ func (b *leaseBackend) targetForServer(server core.Server, releaseOnly bool) (co
 	if storedWorkRoot := strings.TrimSpace(server.Labels["work_root"]); storedWorkRoot != "" {
 		cfg.WorkRoot = storedWorkRoot
 	}
-	target := sshTargetFromConfig(cfg, firstNonBlank(server.PublicNet.IPv4.IP, server.PrivateNet.IPv4.IP))
+	target := sshTargetFromConfig(cfg, shared.FirstNonBlank(server.PublicNet.IPv4.IP, server.PrivateNet.IPv4.IP))
 	leaseID := core.Blank(server.Labels["lease"], server.CloudID)
 	if !releaseOnly {
 		if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
@@ -758,7 +758,7 @@ func xcpNgVMToServer(vm xapiVM, labels map[string]string, ip string) core.Server
 	}
 	server := core.Server{
 		Provider: "xcp-ng",
-		CloudID:  firstNonBlank(vm.UUID, vm.Ref),
+		CloudID:  shared.FirstNonBlank(vm.UUID, vm.Ref),
 		Name:     vm.Name,
 		Status:   vm.PowerState,
 		Labels:   labels,
@@ -799,10 +799,6 @@ func closeClient(ctx context.Context, client lifecycleClient, stderr io.Writer) 
 	if err := client.Close(closeCtx); err != nil {
 		fmt.Fprintf(stderr, "warning: close xcp-ng session: %v\n", err)
 	}
-}
-
-func firstNonBlank(values ...string) string {
-	return shared.FirstNonBlank(values...)
 }
 
 func currentTime(rt core.Runtime) time.Time {

--- a/internal/providers/xcpng/client.go
+++ b/internal/providers/xcpng/client.go
@@ -171,7 +171,7 @@ func (c *xapiClient) ResolveTemplate(ctx context.Context, cfg xcpNgConfig) (xapi
 		return "", fmt.Errorf("validate xcp-ng template: %w", err)
 	}
 	if isTemplate != "true" {
-		return "", exit(4, "xcp-ng VM is not a template: %s", firstNonBlank(cfg.TemplateUUID, cfg.Template))
+		return "", exit(4, "xcp-ng VM is not a template: %s", shared.FirstNonBlank(cfg.TemplateUUID, cfg.Template))
 	}
 	return ref, nil
 }
@@ -472,10 +472,10 @@ func (c *xapiClient) CreateFreshVM(ctx context.Context, req xcpNgFreshVMRequest)
 	labeled = true
 	if req.Network != nil && req.Network.NetworkRef != "" {
 		vifRef, err := c.callString(ctx, "VIF.create", c.session, map[string]any{
-			"device":               firstNonBlank(req.Network.Device, "0"),
+			"device":               shared.FirstNonBlank(req.Network.Device, "0"),
 			"network":              req.Network.NetworkRef.value(),
 			"VM":                   ref,
-			"MAC":                  firstNonBlank(req.Network.MAC, ""),
+			"MAC":                  shared.FirstNonBlank(req.Network.MAC, ""),
 			"MTU":                  req.Network.MTU,
 			"other_config":         req.Network.Labels,
 			"currently_attached":   false,
@@ -545,8 +545,8 @@ func (c *xapiClient) ImportISO(ctx context.Context, req xcpNgImportISORequest) (
 		return xcpNgConfigDrive{}, exit(4, "xcp-ng ISO path must be a file: %s", path)
 	}
 	labels := isoMediaLabels(req.Labels)
-	name := firstNonBlank(strings.TrimSpace(req.Name), filepath.Base(path))
-	description := firstNonBlank(strings.TrimSpace(req.Description), "Crabbox imported installer media")
+	name := shared.FirstNonBlank(strings.TrimSpace(req.Name), filepath.Base(path))
+	description := shared.FirstNonBlank(strings.TrimSpace(req.Description), "Crabbox imported installer media")
 	vdiRef, err := c.callString(ctx, "VDI.create", c.session, map[string]any{
 		"name_label":       name,
 		"name_description": description,
@@ -589,8 +589,8 @@ func (c *xapiClient) AttachDisk(ctx context.Context, req xcpNgDiskAttachRequest)
 		sizeBytes = 20 * 1024 * 1024 * 1024
 	}
 	labels := vmDiskLabels(req.Labels)
-	name := firstNonBlank(strings.TrimSpace(req.Name), "crabbox-iso-install-disk")
-	description := firstNonBlank(strings.TrimSpace(req.Description), "Crabbox ISO install disk")
+	name := shared.FirstNonBlank(strings.TrimSpace(req.Name), "crabbox-iso-install-disk")
+	description := shared.FirstNonBlank(strings.TrimSpace(req.Description), "Crabbox ISO install disk")
 	vdiRef, err := c.callString(ctx, "VDI.create", c.session, map[string]any{
 		"name_label":       name,
 		"name_description": description,
@@ -611,7 +611,7 @@ func (c *xapiClient) AttachDisk(ctx context.Context, req xcpNgDiskAttachRequest)
 	vbdRef, err := c.callString(ctx, "VBD.create", c.session, map[string]any{
 		"VM":                       req.VMRef.value(),
 		"VDI":                      vdiRef,
-		"userdevice":               firstNonBlank(req.UserDevice, "0"),
+		"userdevice":               shared.FirstNonBlank(req.UserDevice, "0"),
 		"bootable":                 true,
 		"mode":                     "RW",
 		"type":                     "Disk",
@@ -691,7 +691,7 @@ func (c *xapiClient) AttachISO(ctx context.Context, req xcpNgISOAttachRequest) (
 	vbdRef, err := c.callString(ctx, "VBD.create", c.session, map[string]any{
 		"VM":                       req.VMRef.value(),
 		"VDI":                      vdiRef,
-		"userdevice":               firstNonBlank(req.UserDevice, "3"),
+		"userdevice":               shared.FirstNonBlank(req.UserDevice, "3"),
 		"bootable":                 req.Bootable,
 		"mode":                     "RO",
 		"type":                     "CD",
@@ -1536,7 +1536,7 @@ func (c *xapiClient) importFileVDI(ctx context.Context, vdiRef, path string, siz
 }
 
 func (c *xapiClient) importReaderVDI(ctx context.Context, vdiRef string, reader io.Reader, size int64, taskName, taskDescription string) error {
-	taskRef, err := c.callString(ctx, "task.create", c.session, firstNonBlank(taskName, "crabbox import config drive"), firstNonBlank(taskDescription, "Import Crabbox cloud-init config drive"))
+	taskRef, err := c.callString(ctx, "task.create", c.session, shared.FirstNonBlank(taskName, "crabbox import config drive"), shared.FirstNonBlank(taskDescription, "Import Crabbox cloud-init config drive"))
 	if err != nil {
 		return err
 	}

--- a/internal/providers/xcpng/cloudinit.go
+++ b/internal/providers/xcpng/cloudinit.go
@@ -444,15 +444,13 @@ func isoMediaLabels(base map[string]string) map[string]string {
 }
 
 func buildConfigDriveImage(payload xcpNgCloudInitPayload) ([]byte, error) {
-	files := []fatFile{
+	files := []shared.FATFile{
 		{Name: "user-data", Data: []byte(payload.UserData)},
 		{Name: "meta-data", Data: []byte(payload.MetaData)},
 	}
 	return buildFAT16Image("cidata", files)
 }
 
-type fatFile = shared.FATFile
-
-func buildFAT16Image(label string, files []fatFile) ([]byte, error) {
+func buildFAT16Image(label string, files []shared.FATFile) ([]byte, error) {
 	return shared.BuildFAT16Image(label, files, "CRAB%04dTXT", "config-drive")
 }

--- a/internal/providers/xcpng/cloudinit_test.go
+++ b/internal/providers/xcpng/cloudinit_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func TestCloudInitPayloadIncludesSSHUserKeyAndBootstrap(t *testing.T) {
@@ -179,7 +181,7 @@ func TestBuildConfigDriveImageRejectsOversizedPayload(t *testing.T) {
 }
 
 func TestBuildFAT16ImagePreservesXCPngEncoding(t *testing.T) {
-	image, err := buildFAT16Image("cidata", []fatFile{
+	image, err := buildFAT16Image("cidata", []shared.FATFile{
 		{Name: "user-data", Data: []byte("#cloud-config\nusers:\n- name: alice\n")},
 		{Name: "meta-data", Data: []byte("instance-id: crabbox-test\nlocal-hostname: my-app\n")},
 	})

--- a/internal/providers/xcpng/iso_e2e.go
+++ b/internal/providers/xcpng/iso_e2e.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type ISOE2EOptions struct {
@@ -252,7 +253,7 @@ func runISOE2EWindows(ctx context.Context, client lifecycleClient, placement xcp
 	labelCfg := opts.Config
 	labelCfg.TargetOS = core.TargetWindows
 	labelCfg.WindowsMode = core.WindowsModeNormal
-	workRoot := strings.TrimSpace(firstNonBlank(labelCfg.XCPNg.WorkRoot, labelCfg.WorkRoot))
+	workRoot := strings.TrimSpace(shared.FirstNonBlank(labelCfg.XCPNg.WorkRoot, labelCfg.WorkRoot))
 	if workRoot == "" || strings.HasPrefix(workRoot, "/") {
 		workRoot = `C:\crabbox`
 	}
@@ -357,9 +358,9 @@ func runISOE2EWindows(ctx context.Context, client lifecycleClient, placement xcp
 	runtime.sshTarget.TargetOS = "windows"
 	runtime.sshTarget.WindowsMode = "normal"
 	runtime.sshTarget.Key = runtime.keyPath
-	runtime.sshTarget.User = firstNonBlank(runtime.windowsUser, runtime.sshTarget.User, opts.Config.XCPNg.User, opts.Config.SSHUser)
+	runtime.sshTarget.User = shared.FirstNonBlank(runtime.windowsUser, runtime.sshTarget.User, opts.Config.XCPNg.User, opts.Config.SSHUser)
 	if runtime.sshTarget.Port == "" {
-		runtime.sshTarget.Port = firstNonBlank(opts.Config.SSHPort, "22")
+		runtime.sshTarget.Port = shared.FirstNonBlank(opts.Config.SSHPort, "22")
 	}
 	if err = isoE2EWaitForSSHReady(ctx, &runtime.sshTarget, "windows_first_boot", opts.Timeout); err != nil {
 		result.Classification = "environment_blocked"
@@ -389,7 +390,7 @@ func runISOE2ELinux(ctx context.Context, client lifecycleClient, placement xcpNg
 	guestCfg := opts.Config
 	guestCfg.TargetOS = core.TargetLinux
 	guestCfg.WindowsMode = ""
-	workRoot := strings.TrimSpace(firstNonBlank(guestCfg.XCPNg.WorkRoot, guestCfg.WorkRoot))
+	workRoot := strings.TrimSpace(shared.FirstNonBlank(guestCfg.XCPNg.WorkRoot, guestCfg.WorkRoot))
 	if workRoot == "" || !strings.HasPrefix(workRoot, "/") {
 		workRoot = "/work/crabbox"
 	}
@@ -486,10 +487,10 @@ func runISOE2ELinux(ctx context.Context, client lifecycleClient, placement xcpNg
 	runtime.sshTarget = core.SSHTargetFromConfig(opts.Config, firstBootIP)
 	runtime.sshTarget.Key = runtime.keyPath
 	if runtime.sshTarget.User == "" {
-		runtime.sshTarget.User = firstNonBlank(opts.Config.XCPNg.User, opts.Config.SSHUser)
+		runtime.sshTarget.User = shared.FirstNonBlank(opts.Config.XCPNg.User, opts.Config.SSHUser)
 	}
 	if runtime.sshTarget.Port == "" {
-		runtime.sshTarget.Port = firstNonBlank(opts.Config.SSHPort, "22")
+		runtime.sshTarget.Port = shared.FirstNonBlank(opts.Config.SSHPort, "22")
 	}
 	if err = isoE2EWaitForSSHReady(ctx, &runtime.sshTarget, "linux_first_boot", minDuration(isoE2EGuestMetricsTimeout, opts.Timeout/3)); err != nil {
 		result.Classification = "environment_blocked"


### PR DESCRIPTION
Consolidate common provider policies behind their existing core/shared owners: whitespace handling, loopback admission, cache and random naming, labels, retries, quoting, and cancellation waits. Remove exact forwarding layers and verified duplicate implementations across 47 adapters, reducing production source by 292 net lines.

Call sites identify the policy they use. Context-error waits retain ctx.Err through core.SleepContext; the separate cause-preserving helper retains its contract. Provider-specific arguments, error context, transport rules, and operation-lock policy keep their existing ownership. The GitHub Codespaces and NVIDIA Brev helper cleanup is included with their SSH parser in https://github.com/openclaw/crabbox/pull/2182.

Validation: full integrated Go 1.26.5 vet and race suite, affected provider race suites, cancellation regression, Windows x64 and ARM64 CLI builds, and scoped Codex review passed. Every final changed file matches the verified integration snapshot. No new dependencies or configuration.