### PR TITLE
refactor(ssh): share generated connection config parsing

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -548,6 +548,12 @@ credential admission. Exact forwarding functions and type aliases only add a
 second name for an existing owner; use the core definition at the call site.
 Mutable injection hooks retain their explicit adapter boundary.
 
+Generated SSH configuration shares a connection-record parser in
+`shared.ParseGeneratedSSHConfig`. Adapters supply their generated format's
+comment and directive rules and keep host selection, proxy rewriting, and
+credential validation. The shared scanner reads connection fields; it is not a
+general OpenSSH configuration resolver.
+
 ## Acquisition stays adapter-owned
 
 SSH lease acquisition is a provider-owned transaction, not a shared sequence of

--- a/internal/providers/githubcodespaces/backend.go
+++ b/internal/providers/githubcodespaces/backend.go
@@ -443,7 +443,7 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 			}
 			server = b.mergeLiveServer(server, item)
 		}
-		repo := firstNonEmpty(server.Labels[labelRepository], item.Repository.FullName)
+		repo := shared.FirstNonBlankTrimmed(server.Labels[labelRepository], item.Repository.FullName)
 		cfg := b.repoConfig(repo)
 		if server.Labels == nil {
 			server.Labels = map[string]string{}
@@ -556,7 +556,7 @@ func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server
 	if codespaceStopped(state) || codespaceTerminal(state) || state == "paused" || state == "deleting" || state == "deleted" {
 		return core.Server{}, core.Exit(4, "github-codespaces lease %s is not active (state=%s)", leaseID, state)
 	}
-	requestedName := firstNonEmpty(req.Lease.Server.CloudID, req.Lease.Server.Name, req.Lease.Server.Labels[labelCodespaceName])
+	requestedName := shared.FirstNonBlankTrimmed(req.Lease.Server.CloudID, req.Lease.Server.Name, req.Lease.Server.Labels[labelCodespaceName])
 	if requestedName != "" && requestedName != claim.CloudID {
 		return core.Server{}, core.Exit(3, "github-codespaces touch resource mismatch: claim=%s request=%s", claim.CloudID, requestedName)
 	}
@@ -612,14 +612,14 @@ func (b *backend) releaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 			return err
 		}
 	}
-	if requestedName := firstNonEmpty(requestedServer.CloudID, requestedServer.Name, requestedServer.Labels[labelCodespaceName]); requestedName != "" && requestedName != claim.CloudID {
+	if requestedName := shared.FirstNonBlankTrimmed(requestedServer.CloudID, requestedServer.Name, requestedServer.Labels[labelCodespaceName]); requestedName != "" && requestedName != claim.CloudID {
 		return core.Exit(3, "github-codespaces release resource mismatch: claim=%s request=%s", claim.CloudID, requestedName)
 	}
 	server := serverFromClaim(claim)
 	if err := b.validateClaimForServer(claim, server, user); err != nil {
 		return err
 	}
-	name := firstNonEmpty(server.CloudID, server.Name, server.Labels[labelCodespaceName])
+	name := shared.FirstNonBlankTrimmed(server.CloudID, server.Name, server.Labels[labelCodespaceName])
 	if name == "" {
 		return core.Exit(2, "github-codespaces release requires a claim-backed codespace name")
 	}
@@ -776,12 +776,12 @@ func (b *backend) deleteClaimedCodespaceWithOutcome(ctx context.Context, api cod
 
 func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
 	if githubCodespacesClaimRelease(lease.LeaseID) == releaseStop {
-		return fmt.Sprintf("stopped github-codespaces lease=%s codespace=%s retained=true", lease.LeaseID, firstNonEmpty(lease.Server.CloudID, lease.Server.Name))
+		return fmt.Sprintf("stopped github-codespaces lease=%s codespace=%s retained=true", lease.LeaseID, shared.FirstNonBlankTrimmed(lease.Server.CloudID, lease.Server.Name))
 	}
 	if githubCodespacesDeleteOnRelease(lease, b.cfg) {
-		return fmt.Sprintf("deleted github-codespaces lease=%s codespace=%s", lease.LeaseID, firstNonEmpty(lease.Server.CloudID, lease.Server.Name))
+		return fmt.Sprintf("deleted github-codespaces lease=%s codespace=%s", lease.LeaseID, shared.FirstNonBlankTrimmed(lease.Server.CloudID, lease.Server.Name))
 	}
-	return fmt.Sprintf("stopped github-codespaces lease=%s codespace=%s retained=true", lease.LeaseID, firstNonEmpty(lease.Server.CloudID, lease.Server.Name))
+	return fmt.Sprintf("stopped github-codespaces lease=%s codespace=%s retained=true", lease.LeaseID, shared.FirstNonBlankTrimmed(lease.Server.CloudID, lease.Server.Name))
 }
 
 func (b *backend) RetainLeaseClaimAfterRelease(lease core.LeaseTarget) bool {
@@ -1317,7 +1317,7 @@ func (b *backend) effectiveMachine() string {
 	if b.cfg.ServerTypeExplicit && strings.TrimSpace(b.cfg.ServerType) != "" {
 		return strings.TrimSpace(b.cfg.ServerType)
 	}
-	return firstNonEmpty(strings.TrimSpace(b.cfg.GitHubCodespaces.Machine), defaultCodespaceMachine)
+	return shared.FirstNonBlankTrimmed(strings.TrimSpace(b.cfg.GitHubCodespaces.Machine), defaultCodespaceMachine)
 }
 
 func (b *backend) effectiveWorkRoot(repo string) string {
@@ -1398,12 +1398,12 @@ func (b *backend) labelsFor(leaseID, slug, repo, login string, keep bool, releas
 	if item.Owner.ID > 0 {
 		labels[labelOwnerID] = strconv.FormatInt(item.Owner.ID, 10)
 	}
-	labels[labelRepository] = firstNonEmpty(item.Repository.FullName, repo)
+	labels[labelRepository] = shared.FirstNonBlankTrimmed(item.Repository.FullName, repo)
 	if item.Repository.ID > 0 {
 		labels[labelRepositoryID] = strconv.FormatInt(item.Repository.ID, 10)
 	}
 	labels[labelRef] = strings.TrimSpace(b.cfg.GitHubCodespaces.Ref)
-	labels[labelMachine] = firstNonEmpty(item.Machine.Name, b.effectiveMachine())
+	labels[labelMachine] = shared.FirstNonBlankTrimmed(item.Machine.Name, b.effectiveMachine())
 	labels[labelLogin] = strings.TrimSpace(user.Login)
 	if user.ID > 0 {
 		labels[labelUserID] = strconv.FormatInt(user.ID, 10)
@@ -1420,7 +1420,7 @@ func (b *backend) serverFromCodespace(item codespace, labels map[string]string) 
 		Status:   item.State,
 		Labels:   cloneLabels(labels),
 	}
-	server.ServerType.Name = firstNonEmpty(item.Machine.Name, b.effectiveMachine())
+	server.ServerType.Name = shared.FirstNonBlankTrimmed(item.Machine.Name, b.effectiveMachine())
 	return server
 }
 
@@ -1469,9 +1469,9 @@ func (b *backend) serversFromCodespaces(items []codespace) ([]core.LeaseView, er
 		}
 		server := b.serverFromCodespace(item, cloneLabels(claim.Labels))
 		server.Labels[labelCodespaceName] = item.Name
-		server.Labels[labelEnvironmentID] = firstNonEmpty(item.EnvironmentID, server.Labels[labelEnvironmentID])
-		server.Labels[labelRepository] = firstNonEmpty(item.Repository.FullName, server.Labels[labelRepository])
-		server.Labels[labelMachine] = firstNonEmpty(item.Machine.Name, server.Labels[labelMachine])
+		server.Labels[labelEnvironmentID] = shared.FirstNonBlankTrimmed(item.EnvironmentID, server.Labels[labelEnvironmentID])
+		server.Labels[labelRepository] = shared.FirstNonBlankTrimmed(item.Repository.FullName, server.Labels[labelRepository])
+		server.Labels[labelMachine] = shared.FirstNonBlankTrimmed(item.Machine.Name, server.Labels[labelMachine])
 		servers = append(servers, server)
 	}
 	return servers, nil
@@ -1494,7 +1494,7 @@ func (b *backend) resolveServer(items []codespace, id string) (core.Server, stri
 		return core.Server{}, "", err
 	}
 	if ok {
-		name := firstNonEmpty(claim.CloudID, claim.Labels[labelCodespaceName])
+		name := shared.FirstNonBlankTrimmed(claim.CloudID, claim.Labels[labelCodespaceName])
 		for _, item := range items {
 			if item.Name == name {
 				return b.serverFromCodespace(item, cloneLabels(claim.Labels)), claim.LeaseID, nil
@@ -1531,16 +1531,16 @@ func (b *backend) mergeLiveServer(server core.Server, item codespace) core.Serve
 	if item.ID > 0 {
 		server.Labels[labelCodespaceID] = strconv.FormatInt(item.ID, 10)
 	}
-	server.Labels[labelEnvironmentID] = firstNonEmpty(item.EnvironmentID, server.Labels[labelEnvironmentID])
+	server.Labels[labelEnvironmentID] = shared.FirstNonBlankTrimmed(item.EnvironmentID, server.Labels[labelEnvironmentID])
 	if item.Owner.ID > 0 {
 		server.Labels[labelOwnerID] = strconv.FormatInt(item.Owner.ID, 10)
 	}
-	server.Labels[labelRepository] = firstNonEmpty(item.Repository.FullName, server.Labels[labelRepository])
+	server.Labels[labelRepository] = shared.FirstNonBlankTrimmed(item.Repository.FullName, server.Labels[labelRepository])
 	if item.Repository.ID > 0 {
 		server.Labels[labelRepositoryID] = strconv.FormatInt(item.Repository.ID, 10)
 	}
-	server.Labels[labelMachine] = firstNonEmpty(item.Machine.Name, server.Labels[labelMachine])
-	server.ServerType.Name = firstNonEmpty(item.Machine.Name, server.ServerType.Name)
+	server.Labels[labelMachine] = shared.FirstNonBlankTrimmed(item.Machine.Name, server.Labels[labelMachine])
+	server.ServerType.Name = shared.FirstNonBlankTrimmed(item.Machine.Name, server.ServerType.Name)
 	return server
 }
 
@@ -1667,9 +1667,9 @@ func validateCodespaceClaimResource(claim core.LeaseClaim, item codespace) error
 
 func serverFromClaim(claim core.LeaseClaim) core.Server {
 	server := core.Server{
-		CloudID:  firstNonEmpty(claim.CloudID, claim.Labels[labelCodespaceName]),
+		CloudID:  shared.FirstNonBlankTrimmed(claim.CloudID, claim.Labels[labelCodespaceName]),
 		Provider: providerName,
-		Name:     firstNonEmpty(claim.CloudID, claim.Labels[labelCodespaceName]),
+		Name:     shared.FirstNonBlankTrimmed(claim.CloudID, claim.Labels[labelCodespaceName]),
 		Status:   claim.Labels[labelState],
 		Labels:   cloneLabels(claim.Labels),
 	}

--- a/internal/providers/githubcodespaces/recovery.go
+++ b/internal/providers/githubcodespaces/recovery.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func githubCodespacesClaimScope(cfg core.Config) string {
@@ -231,7 +232,7 @@ func validateCreatedCodespaceIdentity(expected core.LeaseClaim, item codespace) 
 func (b *backend) bindValidatedCreatedClaim(expected core.LeaseClaim, item codespace) (core.LeaseClaim, error) {
 	name := strings.TrimSpace(item.Name)
 	displayName := strings.TrimSpace(expected.Labels[labelDisplayName])
-	repo := firstNonEmpty(strings.TrimSpace(item.Repository.FullName), strings.TrimSpace(expected.Labels[labelRepository]))
+	repo := shared.FirstNonBlankTrimmed(strings.TrimSpace(item.Repository.FullName), strings.TrimSpace(expected.Labels[labelRepository]))
 	labels := cloneLabels(expected.Labels)
 	delete(labels, labelRecovery)
 	labels[labelCodespaceName] = name
@@ -242,7 +243,7 @@ func (b *backend) bindValidatedCreatedClaim(expected core.LeaseClaim, item codes
 	labels[labelLogin] = item.Owner.Login
 	labels[labelRepository] = repo
 	labels[labelRepositoryID] = strconv.FormatInt(item.Repository.ID, 10)
-	labels[labelMachine] = firstNonEmpty(item.Machine.Name, labels[labelMachine])
+	labels[labelMachine] = shared.FirstNonBlankTrimmed(item.Machine.Name, labels[labelMachine])
 	labels[labelState] = "provisioning"
 	server := b.serverFromCodespace(item, labels)
 	claim, err := b.bindClaim(expected.LeaseID, expected, server)

--- a/internal/providers/githubcodespaces/ssh_config.go
+++ b/internal/providers/githubcodespaces/ssh_config.go
@@ -1,7 +1,6 @@
 package githubcodespaces
 
 import (
-	"bufio"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -9,63 +8,13 @@ import (
 	"unicode"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-type sshConfigEntry struct {
-	Aliases        []string
-	HostName       string
-	Port           string
-	User           string
-	IdentityFile   string
-	KnownHostsFile string
-	ProxyCommand   string
-}
-
-func parseSSHConfig(data string) ([]sshConfigEntry, error) {
-	var entries []sshConfigEntry
-	var current *sshConfigEntry
-	scanner := bufio.NewScanner(strings.NewReader(data))
-	for scanner.Scan() {
-		line := stripSSHConfigComment(scanner.Text())
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-		key, value := splitSSHConfigDirective(line)
-		if key == "" {
-			continue
-		}
-		if strings.EqualFold(key, "Host") {
-			aliases := splitSSHConfigFields(value)
-			if len(aliases) == 0 {
-				current = nil
-				continue
-			}
-			entries = append(entries, sshConfigEntry{Aliases: aliases})
-			current = &entries[len(entries)-1]
-			continue
-		}
-		if current == nil {
-			continue
-		}
-		switch strings.ToLower(key) {
-		case "hostname":
-			current.HostName = unquoteSSHConfigValue(value)
-		case "port":
-			current.Port = unquoteSSHConfigValue(value)
-		case "user":
-			current.User = unquoteSSHConfigValue(value)
-		case "identityfile":
-			current.IdentityFile = unquoteSSHConfigValue(value)
-		case "userknownhostsfile":
-			current.KnownHostsFile = unquoteSSHConfigValue(value)
-		case "proxycommand":
-			current.ProxyCommand = strings.TrimSpace(value)
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-	return entries, nil
+func parseSSHConfig(data string) ([]shared.GeneratedSSHConfigEntry, error) {
+	return shared.ParseGeneratedSSHConfig(data, func(line string) (string, string) {
+		return splitSSHConfigDirective(stripSSHConfigComment(line))
+	})
 }
 
 func selectSSHTarget(cfg core.Config, data, alias string) (core.SSHTarget, error) {
@@ -73,11 +22,11 @@ func selectSSHTarget(cfg core.Config, data, alias string) (core.SSHTarget, error
 	if err != nil {
 		return core.SSHTarget{}, err
 	}
-	user := firstNonEmpty(entry.User, cfg.SSHUser)
+	user := shared.FirstNonBlankTrimmed(entry.User, cfg.SSHUser)
 	if user == "" {
 		return core.SSHTarget{}, core.Exit(2, "github-codespaces SSH config entry %q is missing User", selectedAlias)
 	}
-	if !validSSHUser(user) {
+	if !shared.ValidSSHConfigUser(user) {
 		return core.SSHTarget{}, core.Exit(2, "github-codespaces SSH config entry %q has invalid User %q", selectedAlias, user)
 	}
 	if strings.TrimSpace(entry.IdentityFile) == "" {
@@ -124,16 +73,16 @@ func selectSSHTarget(cfg core.Config, data, alias string) (core.SSHTarget, error
 	return target, nil
 }
 
-func selectSSHConfigEntry(data, alias string) (sshConfigEntry, string, error) {
+func selectSSHConfigEntry(data, alias string) (shared.GeneratedSSHConfigEntry, string, error) {
 	alias = strings.TrimSpace(alias)
 	if alias == "" {
-		return sshConfigEntry{}, "", core.Exit(2, "github-codespaces SSH config host alias is required")
+		return shared.GeneratedSSHConfigEntry{}, "", core.Exit(2, "github-codespaces SSH config host alias is required")
 	}
 	entries, err := parseSSHConfig(data)
 	if err != nil {
-		return sshConfigEntry{}, "", err
+		return shared.GeneratedSSHConfigEntry{}, "", err
 	}
-	matches := make([]sshConfigEntry, 0, 1)
+	matches := make([]shared.GeneratedSSHConfigEntry, 0, 1)
 	matchAliases := make([]string, 0, 1)
 	for _, entry := range entries {
 		for _, candidate := range entry.Aliases {
@@ -150,19 +99,19 @@ func selectSSHConfigEntry(data, alias string) (sshConfigEntry, string, error) {
 				continue
 			}
 			matches = append(matches, entry)
-			matchAliases = append(matchAliases, firstNonEmpty(firstSSHConfigAlias(entry), alias))
+			matchAliases = append(matchAliases, shared.FirstNonBlankTrimmed(firstSSHConfigAlias(entry), alias))
 		}
 	}
 	if len(matches) == 0 {
-		return sshConfigEntry{}, "", core.Exit(4, "github-codespaces SSH config entry not found for host %q", alias)
+		return shared.GeneratedSSHConfigEntry{}, "", core.Exit(4, "github-codespaces SSH config entry not found for host %q", alias)
 	}
 	if len(matches) > 1 {
-		return sshConfigEntry{}, "", core.Exit(2, "github-codespaces SSH config entry for host %q is ambiguous", alias)
+		return shared.GeneratedSSHConfigEntry{}, "", core.Exit(2, "github-codespaces SSH config entry for host %q is ambiguous", alias)
 	}
 	return matches[0], matchAliases[0], nil
 }
 
-func firstSSHConfigAlias(entry sshConfigEntry) string {
+func firstSSHConfigAlias(entry shared.GeneratedSSHConfigEntry) string {
 	for _, alias := range entry.Aliases {
 		if strings.TrimSpace(alias) != "" {
 			return strings.TrimSpace(alias)
@@ -176,7 +125,7 @@ func proxyCommandReferencesCodespace(command, name string) bool {
 	if name == "" {
 		return false
 	}
-	fields := splitSSHConfigFields(command)
+	fields := shared.SplitSSHConfigFields(command)
 	for i, field := range fields {
 		switch {
 		case field == "-c" || field == "--codespace":
@@ -201,7 +150,7 @@ func rewriteProxyCommandGHPath(command, ghPath string) string {
 	if executableEnd < 0 {
 		return command
 	}
-	executable := unquoteSSHConfigValue(strings.TrimSpace(body[:executableEnd]))
+	executable := shared.UnquoteSSHConfigValue(strings.TrimSpace(body[:executableEnd]))
 	if executable == defaultGHPath {
 		if ghPath == "" || ghPath == defaultGHPath {
 			return command
@@ -253,7 +202,7 @@ func rewriteProxyCommandIdentityFile(command, identityFile string) string {
 		return command
 	}
 	valueStart := index + len(marker)
-	if unquoteSSHConfigValue(command[valueStart:]) != identityFile {
+	if shared.UnquoteSSHConfigValue(command[valueStart:]) != identityFile {
 		return command
 	}
 	return command[:valueStart] + quoteSSHProxyExecutable(identityFile)
@@ -360,7 +309,7 @@ func githubCodespacesReadyCheck(cfg core.Config) string {
 	if workRoot == "" {
 		workRoot = defaultWorkRoot
 	}
-	return "command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null && test -d " + shellQuote(workRoot)
+	return "command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null && test -d " + core.ShellQuote(workRoot)
 }
 
 func stripSSHConfigComment(line string) string {
@@ -404,47 +353,4 @@ func splitSSHConfigDirective(line string) (string, string) {
 		}
 	}
 	return line, ""
-}
-
-func splitSSHConfigFields(value string) []string {
-	var out []string
-	for _, field := range strings.Fields(value) {
-		field = unquoteSSHConfigValue(field)
-		if field != "" {
-			out = append(out, field)
-		}
-	}
-	return out
-}
-
-func unquoteSSHConfigValue(value string) string {
-	value = strings.TrimSpace(value)
-	if len(value) >= 2 {
-		if (value[0] == '"' && value[len(value)-1] == '"') || (value[0] == '\'' && value[len(value)-1] == '\'') {
-			return value[1 : len(value)-1]
-		}
-	}
-	return value
-}
-
-func validSSHUser(user string) bool {
-	if user == "" || strings.HasPrefix(user, "-") || strings.Contains(user, "@") {
-		return false
-	}
-	return strings.IndexFunc(user, func(r rune) bool {
-		return unicode.IsSpace(r) || unicode.IsControl(r)
-	}) == -1
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
-}
-
-func shellQuote(value string) string {
-	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }

--- a/internal/providers/githubcodespaces/ssh_config_permissions_unix.go
+++ b/internal/providers/githubcodespaces/ssh_config_permissions_unix.go
@@ -34,5 +34,5 @@ func syncSSHConfigDirectory(path string) error {
 }
 
 func quoteSSHProxyExecutable(path string) string {
-	return shellQuote(path)
+	return core.ShellQuote(path)
 }

--- a/internal/providers/githubcodespaces/ssh_config_permissions_unix_test.go
+++ b/internal/providers/githubcodespaces/ssh_config_permissions_unix_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestValidatePrivateSSHConfigFileRequires0600(t *testing.T) {
@@ -42,7 +44,7 @@ func TestRewriteProxyCommandPreservesSpaceContainingArgument(t *testing.T) {
 		rewriteProxyCommandGHPath(command, defaultGHPath),
 		identityFile,
 	)
-	if !strings.HasPrefix(rewritten, shellQuote(ghPath)+" ") || !strings.HasSuffix(rewritten, shellQuote(identityFile)) {
+	if !strings.HasPrefix(rewritten, core.ShellQuote(ghPath)+" ") || !strings.HasSuffix(rewritten, core.ShellQuote(identityFile)) {
 		t.Fatalf("proxy=%q", rewritten)
 	}
 	out, err := exec.Command("sh", "-c", rewritten).CombinedOutput()

--- a/internal/providers/nvidiabrev/backend.go
+++ b/internal/providers/nvidiabrev/backend.go
@@ -86,7 +86,7 @@ func (b *nvidiaBrevBackend) Acquire(ctx context.Context, req core.AcquireRequest
 			if workspaceIdentifier(workspace) == "" {
 				workspace.Name = name
 			}
-			err = b.retainFailedCreatedWorkspace(workspace, firstNonEmpty(workspaceOrgID, createOrg.ID), leaseID, slug, cfg, req, "kept_acquire_failed", err)
+			err = b.retainFailedCreatedWorkspace(workspace, shared.FirstNonBlankTrimmed(workspaceOrgID, createOrg.ID), leaseID, slug, cfg, req, "kept_acquire_failed", err)
 		} else {
 			if workspaceIdentifier(workspace) == "" {
 				workspace.Name = name
@@ -143,7 +143,7 @@ func (b *nvidiaBrevBackend) Resolve(ctx context.Context, req core.ResolveRequest
 		if err != nil {
 			return core.LeaseTarget{}, err
 		}
-		_, found, err := findBrevWorkspace(workspaces, firstNonEmpty(claim.CloudID, claim.Labels["brev_workspace_name"]))
+		_, found, err := findBrevWorkspace(workspaces, shared.FirstNonBlankTrimmed(claim.CloudID, claim.Labels["brev_workspace_name"]))
 		if err != nil {
 			return core.LeaseTarget{}, err
 		}
@@ -174,7 +174,7 @@ func (b *nvidiaBrevBackend) Resolve(ctx context.Context, req core.ResolveRequest
 	}
 	if req.ReleaseOnly || req.StatusOnly {
 		if req.ReadyProbe && brevWorkspaceReady(workspace) {
-			target, targetErr := b.resolveSSHTarget(ctx, client, cfg, workspace, firstNonEmpty(activeOrgID, claim.Labels["brev_org_id"]))
+			target, targetErr := b.resolveSSHTarget(ctx, client, cfg, workspace, shared.FirstNonBlankTrimmed(activeOrgID, claim.Labels["brev_org_id"]))
 			if targetErr != nil {
 				return core.LeaseTarget{}, targetErr
 			}
@@ -258,7 +258,7 @@ func (b *nvidiaBrevBackend) releaseLease(ctx context.Context, req core.ReleaseLe
 	if err := client.rejectOrgScopedMutation("release"); err != nil {
 		return err
 	}
-	identifier := firstNonEmpty(req.Lease.LeaseID, req.Lease.Server.CloudID, req.Lease.Server.Name)
+	identifier := shared.FirstNonBlankTrimmed(req.Lease.LeaseID, req.Lease.Server.CloudID, req.Lease.Server.Name)
 	if claim, claimed, claimErr := resolveNvidiaBrevClaim(identifier); claimErr != nil {
 		return claimErr
 	} else if claimed && strings.EqualFold(strings.TrimSpace(claim.Labels["state"]), "deleting") {
@@ -303,7 +303,7 @@ func (b *nvidiaBrevBackend) RetainLeaseClaimAfterRelease(lease core.LeaseTarget)
 }
 
 func (b *nvidiaBrevBackend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
-	workspace := firstNonEmpty(lease.Server.CloudID, lease.Server.Name, "-")
+	workspace := shared.FirstNonBlankTrimmed(lease.Server.CloudID, lease.Server.Name, "-")
 	if b.releaseResultAction(lease.Server.Labels) == "stop" {
 		if createRecoveryLabels(lease.Server.Labels) && lease.LeaseID != "" {
 			if _, retained, err := resolveLeaseClaimForProvider(lease.LeaseID); err == nil && !retained {
@@ -692,7 +692,7 @@ func deletingLeaseTarget(claim core.LeaseClaim) core.LeaseTarget {
 }
 
 func claimStateLeaseTarget(claim core.LeaseClaim) core.LeaseTarget {
-	return claimLeaseTargetWithStatus(claim, firstNonEmpty(claim.Labels["state"], "failed"))
+	return claimLeaseTargetWithStatus(claim, shared.FirstNonBlankTrimmed(claim.Labels["state"], "failed"))
 }
 
 func claimLeaseTargetWithStatus(claim core.LeaseClaim, status string) core.LeaseTarget {
@@ -1137,7 +1137,7 @@ func (b *nvidiaBrevBackend) resolveWorkspace(ctx context.Context, client *brevCl
 		return brevWorkspace{}, "", "", core.LeaseClaim{}, err
 	}
 	if claimed {
-		workspaceRef := firstNonEmpty(claim.CloudID, claim.Labels["brev_workspace_name"])
+		workspaceRef := shared.FirstNonBlankTrimmed(claim.CloudID, claim.Labels["brev_workspace_name"])
 		if workspace, found, err := findBrevWorkspace(workspaces, workspaceRef); err != nil {
 			return brevWorkspace{}, "", "", core.LeaseClaim{}, err
 		} else if found {
@@ -1333,7 +1333,7 @@ func workspaceToServer(cfg core.Config, workspace brevWorkspace, leaseID, slug s
 		Status:   labels["state"],
 		Labels:   labels,
 	}
-	server.ServerType.Name = firstNonEmpty(workspace.InstanceType, workspace.WorkspaceClass, cfg.NvidiaBrev.Type, cfg.NvidiaBrev.GPUName)
+	server.ServerType.Name = shared.FirstNonBlankTrimmed(workspace.InstanceType, workspace.WorkspaceClass, cfg.NvidiaBrev.Type, cfg.NvidiaBrev.GPUName)
 	server.Labels["server_type"] = server.ServerType.Name
 	return server
 }
@@ -1439,7 +1439,7 @@ func oneOf(value string, allowed ...string) bool {
 }
 
 func workspaceIdentifier(workspace brevWorkspace) string {
-	return firstNonEmpty(workspace.ID, workspace.Name)
+	return shared.FirstNonBlankTrimmed(workspace.ID, workspace.Name)
 }
 
 func safeWorkspaceRef(workspace brevWorkspace) string {

--- a/internal/providers/nvidiabrev/ssh_config.go
+++ b/internal/providers/nvidiabrev/ssh_config.go
@@ -1,25 +1,14 @@
 package nvidiabrev
 
 import (
-	"bufio"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"unicode"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
-
-type brevSSHConfigEntry struct {
-	Aliases        []string
-	HostName       string
-	Port           string
-	User           string
-	IdentityFile   string
-	KnownHostsFile string
-	ProxyCommand   string
-}
 
 func defaultBrevSSHConfigPath() string {
 	home, err := os.UserHomeDir()
@@ -30,52 +19,10 @@ func defaultBrevSSHConfigPath() string {
 	return filepath.Join(home, ".brev", "ssh_config")
 }
 
-func parseBrevSSHConfig(data string) ([]brevSSHConfigEntry, error) {
-	var entries []brevSSHConfigEntry
-	var current *brevSSHConfigEntry
-	scanner := bufio.NewScanner(strings.NewReader(data))
-	for scanner.Scan() {
-		line := stripSSHConfigComment(scanner.Text())
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-		key, value := splitSSHConfigDirective(line)
-		if key == "" {
-			continue
-		}
-		if strings.EqualFold(key, "Host") {
-			aliases := splitSSHConfigFields(value)
-			if len(aliases) == 0 {
-				current = nil
-				continue
-			}
-			entry := brevSSHConfigEntry{Aliases: aliases}
-			entries = append(entries, entry)
-			current = &entries[len(entries)-1]
-			continue
-		}
-		if current == nil {
-			continue
-		}
-		switch strings.ToLower(key) {
-		case "hostname":
-			current.HostName = unquoteSSHConfigValue(value)
-		case "port":
-			current.Port = unquoteSSHConfigValue(value)
-		case "user":
-			current.User = unquoteSSHConfigValue(value)
-		case "identityfile":
-			current.IdentityFile = unquoteSSHConfigValue(value)
-		case "userknownhostsfile":
-			current.KnownHostsFile = unquoteSSHConfigValue(value)
-		case "proxycommand":
-			current.ProxyCommand = strings.TrimSpace(value)
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-	return entries, nil
+func parseBrevSSHConfig(data string) ([]shared.GeneratedSSHConfigEntry, error) {
+	return shared.ParseGeneratedSSHConfig(data, func(line string) (string, string) {
+		return splitSSHConfigDirective(stripSSHConfigComment(line))
+	})
 }
 
 func stripSSHConfigComment(line string) string {
@@ -112,33 +59,12 @@ func splitSSHConfigDirective(line string) (string, string) {
 	return line, ""
 }
 
-func splitSSHConfigFields(value string) []string {
-	var out []string
-	for _, field := range strings.Fields(value) {
-		field = unquoteSSHConfigValue(field)
-		if field != "" {
-			out = append(out, field)
-		}
-	}
-	return out
-}
-
-func unquoteSSHConfigValue(value string) string {
-	value = strings.TrimSpace(value)
-	if len(value) >= 2 {
-		if (value[0] == '"' && value[len(value)-1] == '"') || (value[0] == '\'' && value[len(value)-1] == '\'') {
-			return value[1 : len(value)-1]
-		}
-	}
-	return value
-}
-
 func selectBrevSSHTarget(cfg core.Config, data, alias string) (core.SSHTarget, error) {
 	entries, err := parseBrevSSHConfig(data)
 	if err != nil {
 		return core.SSHTarget{}, err
 	}
-	var matches []brevSSHConfigEntry
+	var matches []shared.GeneratedSSHConfigEntry
 	for _, entry := range entries {
 		for _, candidate := range entry.Aliases {
 			if candidate == alias {
@@ -154,11 +80,11 @@ func selectBrevSSHTarget(cfg core.Config, data, alias string) (core.SSHTarget, e
 		return core.SSHTarget{}, core.Exit(2, "nvidia-brev SSH config entry for host %q is ambiguous", alias)
 	}
 	entry := matches[0]
-	user := firstNonEmpty(cfg.NvidiaBrev.User, entry.User, cfg.SSHUser)
+	user := shared.FirstNonBlankTrimmed(cfg.NvidiaBrev.User, entry.User, cfg.SSHUser)
 	if strings.TrimSpace(user) == "" {
 		return core.SSHTarget{}, core.Exit(2, "nvidia-brev SSH config entry %q is missing User", alias)
 	}
-	if !validBrevSSHUser(user) {
+	if !shared.ValidSSHConfigUser(user) {
 		return core.SSHTarget{}, core.Exit(2, "nvidia-brev SSH config entry %q has invalid User %q", alias, user)
 	}
 	if strings.TrimSpace(entry.IdentityFile) == "" {
@@ -196,28 +122,10 @@ func selectBrevSSHTarget(cfg core.Config, data, alias string) (core.SSHTarget, e
 	return target, nil
 }
 
-func validBrevSSHUser(user string) bool {
-	if user == "" || strings.HasPrefix(user, "-") || strings.Contains(user, "@") {
-		return false
-	}
-	return strings.IndexFunc(user, func(r rune) bool {
-		return unicode.IsSpace(r) || unicode.IsControl(r)
-	}) == -1
-}
-
 func brevSSHConfigAlias(workspaceName, target string) string {
 	name := strings.TrimSpace(workspaceName)
 	if strings.EqualFold(strings.TrimSpace(target), "host") {
 		return name + "-host"
 	}
 	return name
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
 }

--- a/internal/providers/shared/ssh_config.go
+++ b/internal/providers/shared/ssh_config.go
@@ -1,0 +1,93 @@
+package shared
+
+import (
+	"bufio"
+	"strings"
+	"unicode"
+)
+
+// GeneratedSSHConfigEntry is the connection subset emitted by provider CLIs.
+// Includes, Match blocks, wildcard resolution, and host selection stay outside
+// this parser; adapters retain their generated format's lexical rules.
+type GeneratedSSHConfigEntry struct {
+	Aliases        []string
+	HostName       string
+	Port           string
+	User           string
+	IdentityFile   string
+	KnownHostsFile string
+	ProxyCommand   string
+}
+
+func ParseGeneratedSSHConfig(data string, directive func(string) (string, string)) ([]GeneratedSSHConfigEntry, error) {
+	var entries []GeneratedSSHConfigEntry
+	var current *GeneratedSSHConfigEntry
+	scanner := bufio.NewScanner(strings.NewReader(data))
+	for scanner.Scan() {
+		key, value := directive(scanner.Text())
+		if key == "" {
+			continue
+		}
+		if strings.EqualFold(key, "Host") {
+			aliases := SplitSSHConfigFields(value)
+			if len(aliases) == 0 {
+				current = nil
+				continue
+			}
+			entries = append(entries, GeneratedSSHConfigEntry{Aliases: aliases})
+			current = &entries[len(entries)-1]
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		switch strings.ToLower(key) {
+		case "hostname":
+			current.HostName = UnquoteSSHConfigValue(value)
+		case "port":
+			current.Port = UnquoteSSHConfigValue(value)
+		case "user":
+			current.User = UnquoteSSHConfigValue(value)
+		case "identityfile":
+			current.IdentityFile = UnquoteSSHConfigValue(value)
+		case "userknownhostsfile":
+			current.KnownHostsFile = UnquoteSSHConfigValue(value)
+		case "proxycommand":
+			current.ProxyCommand = strings.TrimSpace(value)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func SplitSSHConfigFields(value string) []string {
+	var out []string
+	for _, field := range strings.Fields(value) {
+		field = UnquoteSSHConfigValue(field)
+		if field != "" {
+			out = append(out, field)
+		}
+	}
+	return out
+}
+
+func UnquoteSSHConfigValue(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) >= 2 {
+		if (value[0] == '"' && value[len(value)-1] == '"') || (value[0] == '\'' && value[len(value)-1] == '\'') {
+			return value[1 : len(value)-1]
+		}
+	}
+	return value
+}
+
+func ValidSSHConfigUser(user string) bool {
+	if user == "" || strings.HasPrefix(user, "-") || strings.Contains(user, "@") {
+		return false
+	}
+	return strings.IndexFunc(user, func(r rune) bool {
+		return unicode.IsSpace(r) || unicode.IsControl(r)
+	}) == -1
+}

--- a/internal/providers/shared/ssh_config_test.go
+++ b/internal/providers/shared/ssh_config_test.go
@@ -1,0 +1,65 @@
+package shared
+
+import (
+	"bufio"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func testSSHDirective(line string) (string, string) {
+	key, value, _ := strings.Cut(strings.TrimSpace(line), " ")
+	return key, strings.TrimSpace(value)
+}
+
+func TestGeneratedSSHConfigConnectionFieldsAndHostBoundaries(t *testing.T) {
+	entries, err := ParseGeneratedSSHConfig(`User ignored
+Host first 'second'
+ HostName old
+ hostname "new host"
+ Port 2222
+ User alice
+ IdentityFile '/tmp/key file'
+ UserKnownHostsFile "/tmp/hosts file"
+ ProxyCommand tool --arg='raw value'
+ Unknown ignored
+Host
+ User also-ignored
+HOST last
+ User bob
+`, testSSHDirective)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []GeneratedSSHConfigEntry{
+		{Aliases: []string{"first", "second"}, HostName: "new host", Port: "2222", User: "alice", IdentityFile: "/tmp/key file", KnownHostsFile: "/tmp/hosts file", ProxyCommand: "tool --arg='raw value'"},
+		{Aliases: []string{"last"}, User: "bob"},
+	}
+	if !reflect.DeepEqual(entries, want) {
+		t.Fatalf("entries = %#v, want %#v", entries, want)
+	}
+}
+
+func TestGeneratedSSHConfigPreservesEmptyAndScannerFailureResults(t *testing.T) {
+	entries, err := ParseGeneratedSSHConfig("User ignored\n", testSSHDirective)
+	if err != nil || entries != nil {
+		t.Fatalf("no hosts: %#v, %v", entries, err)
+	}
+	entries, err = ParseGeneratedSSHConfig("Host first\n"+strings.Repeat("x", bufio.MaxScanTokenSize+1), testSSHDirective)
+	if err == nil || entries != nil {
+		t.Fatalf("oversized line: %#v, %v", entries, err)
+	}
+}
+
+func TestGeneratedSSHConfigUserValidation(t *testing.T) {
+	for _, user := range []string{"alice", "_user", "a-b", "é"} {
+		if !ValidSSHConfigUser(user) {
+			t.Errorf("rejected user %q", user)
+		}
+	}
+	for _, user := range []string{"", "-option", "a@host", "a b", "a\n", "a\x00", "a\u2003b"} {
+		if ValidSSHConfigUser(user) {
+			t.Errorf("accepted invalid user %q", user)
+		}
+	}
+}


### PR DESCRIPTION
GitHub Codespaces and NVIDIA Brev duplicated scanning, connection-record fields, unquoting, and user validation for generated SSH configs. Give these operations one shared owner while preserving their distinct comment/directive lexers. Host selection, proxy rewriting, and credential admission remain in each adapter. The same adapters now call existing shared whitespace and quoting helpers directly.

Validation: complete shared and both provider test suites; full integrated Go 1.26.5 vet and race suite; Windows amd64 and arm64 CLI builds. Scoped Codex review passed. No configuration or secret changes.