### PR TITLE
refactor(tags): centralize schema field emission

### DIFF
--- a/internal/providers/digitalocean/tags.go
+++ b/internal/providers/digitalocean/tags.go
@@ -27,31 +27,15 @@ func leaseTags(cfg core.Config, leaseID, slug, state string, keep bool, now time
 	if cfg.Tailscale.Enabled && len(cfg.Tailscale.Tags) > 0 {
 		labels["tailscale_tags"] = strings.Join(cfg.Tailscale.Tags, ",")
 	}
-	tags := []string{
-		tagCrabbox,
-		"crabbox:provider:" + providerName,
-		"crabbox:target:" + core.TargetLinux,
-	}
-	for _, key := range tagSchema.Keys() {
-		if value := labels[key]; value != "" {
-			tags = append(tags, encodeTagKV(key, value))
-		}
-	}
-	return shared.NormalizeTags(tags)
+	return tagsFromLabels(labels)
 }
 
 func tagsFromLabels(labels map[string]string) []string {
-	tags := []string{
+	return tagSchema.EncodeTags(labels, []string{
 		tagCrabbox,
 		"crabbox:provider:" + providerName,
 		"crabbox:target:" + core.TargetLinux,
-	}
-	for _, key := range tagSchema.Keys() {
-		if value := labels[key]; value != "" {
-			tags = append(tags, encodeTagKV(key, value))
-		}
-	}
-	return shared.NormalizeTags(tags)
+	}, encodeTagKV)
 }
 
 func encodeTagKV(key, value string) string {

--- a/internal/providers/scaleway/tags.go
+++ b/internal/providers/scaleway/tags.go
@@ -39,17 +39,11 @@ func leaseTags(cfg core.Config, leaseID, slug, state string, keep bool, now time
 }
 
 func tagsFromLabels(labels map[string]string) []string {
-	tags := []string{
+	return tagSchema.EncodeTags(labels, []string{
 		tagCrabbox,
 		"crabbox:provider:" + providerName,
 		"crabbox:target:" + core.TargetLinux,
-	}
-	for _, key := range tagSchema.Keys() {
-		if value := labels[key]; value != "" {
-			tags = append(tags, encodeTagKV(key, value))
-		}
-	}
-	return shared.NormalizeTags(tags)
+	}, encodeTagKV)
 }
 
 func encodeTagKV(key, value string) string {

--- a/internal/providers/shared/tag_labels.go
+++ b/internal/providers/shared/tag_labels.go
@@ -87,6 +87,16 @@ func (s TagLabelSchema) Keys() []string { return slices.Clone(s.keys) }
 
 func (s TagLabelSchema) Exact(key string) bool { return s.fields[key].Exact }
 
+// EncodeTags emits nonempty schema fields using the adapter's wire encoder.
+func (s TagLabelSchema) EncodeTags(labels map[string]string, tags []string, encode func(string, string) string) []string {
+	for _, key := range s.keys {
+		if value := labels[key]; value != "" {
+			tags = append(tags, encode(key, value))
+		}
+	}
+	return NormalizeTags(tags)
+}
+
 type TagLabelReducer struct {
 	schema    TagLabelSchema
 	labels    map[string]string

--- a/internal/providers/vultr/tags.go
+++ b/internal/providers/vultr/tags.go
@@ -25,31 +25,15 @@ var tagSchema = shared.LeaseTagSchema(
 func leaseTags(cfg core.Config, leaseID, slug, state string, keep bool, now time.Time) []string {
 	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
 	labels["state"] = state
-	tags := []string{
-		tagCrabbox,
-		"crabbox:provider:" + providerName,
-		"crabbox:target:" + core.TargetLinux,
-	}
-	for _, key := range tagSchema.Keys() {
-		if value := labels[key]; value != "" {
-			tags = append(tags, encodeTagKV(key, value))
-		}
-	}
-	return shared.NormalizeTags(tags)
+	return tagsFromLabels(labels)
 }
 
 func tagsFromLabels(labels map[string]string) []string {
-	tags := []string{
+	return tagSchema.EncodeTags(labels, []string{
 		tagCrabbox,
 		"crabbox:provider:" + providerName,
 		"crabbox:target:" + core.TargetLinux,
-	}
-	for _, key := range tagSchema.Keys() {
-		if value := labels[key]; value != "" {
-			tags = append(tags, encodeTagKV(key, value))
-		}
-	}
-	return shared.NormalizeTags(tags)
+	}, encodeTagKV)
 }
 
 func encodeTagKV(key, value string) string {


### PR DESCRIPTION
DigitalOcean, Scaleway, and Vultr each walked the same lease label schema and normalized the resulting tags. Move that emission loop to TagLabelSchema.EncodeTags and reuse tagsFromLabels during lease creation. Adapter-specific base tags, encoding, length limits, and decoding remain unchanged.

Validation: complete shared, DigitalOcean, Scaleway, and Vultr Go suites pass; scoped Codex review passed. No configuration or secret changes.