### PR TITLE
fix(linode): record the resolved instance type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Keep Linode lease metadata consistent with the created instance type when an explicit type contains only whitespace.
 - Avoid unnecessary sibling traversal for nested artifact globs with an exact, safe literal directory prefix, preserving matching, archive membership, and collection limits. [PR 2162](https://github.com/openclaw/crabbox/pull/2162). Thanks @vincentkoc.
 - Add opt-in private local run history with bounded logs and parsed results, offline readback after lease cleanup, explicit provenance, and bounded pruning. [PR 2141](https://github.com/openclaw/crabbox/pull/2141). Thanks @coygeek.
 - Honor an explicit `XDG_STATE_HOME` for generated lease SSH keys and host trust, preserving default paths and isolated-root reuse and cleanup. [PR 2164](https://github.com/openclaw/crabbox/pull/2164). Thanks @coygeek.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Keep Linode lease metadata consistent with the created instance type when an explicit type contains only whitespace.
+- Keep Linode lease metadata consistent with the created instance type when an explicit type contains only whitespace. [PR 2186](https://github.com/openclaw/crabbox/pull/2186).
 - Avoid unnecessary sibling traversal for nested artifact globs with an exact, safe literal directory prefix, preserving matching, archive membership, and collection limits. [PR 2162](https://github.com/openclaw/crabbox/pull/2162). Thanks @vincentkoc.
 - Add opt-in private local run history with bounded logs and parsed results, offline readback after lease cleanup, explicit provenance, and bounded pruning. [PR 2141](https://github.com/openclaw/crabbox/pull/2141). Thanks @coygeek.
 - Honor an explicit `XDG_STATE_HOME` for generated lease SSH keys and host trust, preserving default paths and isolated-root reuse and cleanup. [PR 2164](https://github.com/openclaw/crabbox/pull/2164). Thanks @coygeek.

--- a/docs/providers/linode.md
+++ b/docs/providers/linode.md
@@ -60,6 +60,10 @@ Config keys under `linode:`:
 | `firewall` | `cfg.Linode.FirewallID` | empty | Optional numeric existing Linode firewall id to attach at create time. |
 | `sshCIDRs` | `cfg.Linode.SSHCIDRs` | empty | Reserved for firewall-aware follow-up work; Phase 1 does not create firewall rules. |
 
+Acquisition trims the selected native type. A blank explicit `--type` falls back
+to `linode.type`, then the class default. The create request, lease metadata, and
+recovery records use that same resolved type.
+
 The portable `--os ubuntu:24.04` selector maps to `linode/ubuntu24.04`. Linode
 does not currently offer the portable default Ubuntu 26.04 image in this
 provider, so provisioning with an explicit `--os ubuntu:26.04` is rejected

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -155,15 +155,13 @@ func (b *linodeLeaseBackend) acquireOnce(ctx context.Context, req core.AcquireRe
 	}()
 	cfg.SSHKey = keyPath
 	cfg.ProviderKey = providerKeyForLease(leaseID)
-	if !cfg.ServerTypeExplicit || cfg.ServerType == "" {
-		cfg.ServerType = linodeServerTypeForConfig(cfg)
-	}
+	cfg.ServerType = linodeServerTypeForConfig(cfg)
 	if cfg.Tailscale.Enabled && cfg.Tailscale.Hostname == "" {
 		cfg.Tailscale.Hostname = core.RenderTailscaleHostname(cfg.Tailscale.HostnameTemplate, leaseID, slug, cfg.Provider)
 	}
 	createReq := createLinodeRequest{
 		Region:         linodeRegionForConfig(cfg),
-		Type:           linodeServerTypeForConfig(cfg),
+		Type:           cfg.ServerType,
 		Image:          linodeImageForConfig(cfg),
 		Label:          core.LeaseProviderName(leaseID, slug),
 		Tags:           leaseTags(cfg, leaseID, slug, "provisioning", req.Keep, now),

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -287,26 +287,41 @@ func TestAcquireCreatesLinodeClaimsLeaseAndMarksReady(t *testing.T) {
 }
 
 func TestAcquireRecordsConfiguredLinodeTypeInMetadata(t *testing.T) {
-	api := &fakeLinodeAPI{}
-	backend := newTestBackend(t, api)
-	backend.Cfg.Linode.Type = "g6-standard-2"
-
-	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "custom-type"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(api.createRequests) != 1 || api.createRequests[0].Type != "g6-standard-2" {
-		t.Fatalf("createRequests=%#v", api.createRequests)
-	}
-	if lease.Server.ServerType.Name != "g6-standard-2" || lease.Server.Labels["server_type"] != "g6-standard-2" {
-		t.Fatalf("lease server type=%#v labels=%v", lease.Server.ServerType, lease.Server.Labels)
-	}
-	claim, ok, err := core.ResolveLeaseClaimForProvider("custom-type", providerName)
-	if err != nil || !ok {
-		t.Fatalf("claim ok=%v err=%v", ok, err)
-	}
-	if claim.Labels["server_type"] != "g6-standard-2" {
-		t.Fatalf("claim labels=%v", claim.Labels)
+	for _, tc := range []struct {
+		name, providerType, explicitType, want string
+	}{
+		{"provider type", "g6-standard-2", "", "g6-standard-2"},
+		{"explicit override", "g6-standard-2", "g6-nanode-1", "g6-nanode-1"},
+		{"padded explicit override", "g6-standard-2", " g6-nanode-1 ", "g6-nanode-1"},
+		{"blank explicit uses provider type", "g6-standard-2", " \t ", "g6-standard-2"},
+		{"blank explicit uses default", "", " ", defaultType},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			api := &fakeLinodeAPI{}
+			backend := newTestBackend(t, api)
+			backend.Cfg.Linode.Type = tc.providerType
+			if tc.explicitType != "" {
+				backend.Cfg.ServerType = tc.explicitType
+				backend.Cfg.ServerTypeExplicit = true
+			}
+			lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "custom-type"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(api.createRequests) != 1 || api.createRequests[0].Type != tc.want {
+				t.Fatalf("createRequests=%#v", api.createRequests)
+			}
+			if lease.Server.ServerType.Name != tc.want || lease.Server.Labels["server_type"] != tc.want {
+				t.Fatalf("lease server type=%#v labels=%v", lease.Server.ServerType, lease.Server.Labels)
+			}
+			claim, ok, err := core.ResolveLeaseClaimForProvider("custom-type", providerName)
+			if err != nil || !ok {
+				t.Fatalf("claim ok=%v err=%v", ok, err)
+			}
+			if claim.Labels["server_type"] != tc.want {
+				t.Fatalf("claim labels=%v", claim.Labels)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes: a whitespace-only explicit Linode type creates the fallback machine type but records `server_type=unknown` in lease metadata.

## User Impact

Created instances, returned lease metadata, and persisted recovery labels now agree on the selected Linode type. Existing native-type precedence and canonical versus legacy class behavior remain unchanged.

## Why This Change Was Made

Acquisition previously resolved the request type separately from the configuration used for labels. It now resolves the existing selector once and uses that value for both. This removes duplicate selection rather than adding a new fallback policy.

## Evidence

An ordinary fake-client regression reproduced the request/metadata mismatch before the fix. The existing metadata test now covers configured type, explicit override, padded override, and whitespace-only fallback to either provider configuration or the class default.

Pinned Go 1.26.5 validation passed the full Linode race suite (60 tests, 167 subtests), relevant core selector tests (six tests, 31 subtests), vet, Windows compilation, and documentation-link checks. Complete scoped Codex review found no actionable P0 findings. Windows runtime and live Linode lifecycle validation are not claimed; these checks use synthetic fixtures without provider allocation.

Documentation and the Unreleased changelog are updated.

## Landing verification

Merged as [d6a6a49e](https://github.com/openclaw/crabbox/commit/d6a6a49efc86be549a9ca60d7627cdbb3afc7f19). The raw merge tree exactly matches the four-file PR change applied to its recorded main parent, including the other maintainer refactors. Fresh tests on the actual merge passed the full Linode race suite (60 tests, 167 subtests), core selectors (six tests, 31 subtests), and vet, with no skips and no source changes.

Post-merge [CI](https://github.com/openclaw/crabbox/actions/runs/34718245784) passed all 12 jobs, [Connector smokes](https://github.com/openclaw/crabbox/actions/runs/34718245796) passed all five, and [CodeQL](https://github.com/openclaw/crabbox/actions/runs/34718245564) passed all four. No retries were needed. Documentation and the PR-linked changelog entry are on main.
