### PR TITLE
fix(sync): resolve macOS state paths without sibling scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Resolve macOS managed-state path spelling without scanning unrelated sibling files, so crowded temporary directories do not block sync preparation.
+- Resolve macOS managed-state path spelling without scanning unrelated sibling files, so crowded temporary directories do not block sync preparation. [PR 2187](https://github.com/openclaw/crabbox/pull/2187).
 - Avoid unnecessary sibling traversal for nested artifact globs with an exact, safe literal directory prefix, preserving matching, archive membership, and collection limits. [PR 2162](https://github.com/openclaw/crabbox/pull/2162). Thanks @vincentkoc.
 - Add opt-in private local run history with bounded logs and parsed results, offline readback after lease cleanup, explicit provenance, and bounded pruning. [PR 2141](https://github.com/openclaw/crabbox/pull/2141). Thanks @coygeek.
 - Honor an explicit `XDG_STATE_HOME` for generated lease SSH keys and host trust, preserving default paths and isolated-root reuse and cleanup. [PR 2164](https://github.com/openclaw/crabbox/pull/2164). Thanks @coygeek.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Resolve macOS managed-state path spelling without scanning unrelated sibling files, so crowded temporary directories do not block sync preparation.
 - Avoid unnecessary sibling traversal for nested artifact globs with an exact, safe literal directory prefix, preserving matching, archive membership, and collection limits. [PR 2162](https://github.com/openclaw/crabbox/pull/2162). Thanks @vincentkoc.
 - Add opt-in private local run history with bounded logs and parsed results, offline readback after lease cleanup, explicit provenance, and bounded pruning. [PR 2141](https://github.com/openclaw/crabbox/pull/2141). Thanks @coygeek.
 - Honor an explicit `XDG_STATE_HOME` for generated lease SSH keys and host trust, preserving default paths and isolated-root reuse and cleanup. [PR 2164](https://github.com/openclaw/crabbox/pull/2164). Thanks @coygeek.

--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -168,6 +168,10 @@ Git seeding is disabled so a seeded tree cannot materialize excluded paths.
 These protections do not remove state already committed upstream or previously
 shared with a runner.
 
+On macOS, managed-state path spelling uses descriptor metadata rather than
+enumerating sibling files, so crowded temporary directories do not block sync
+preparation.
+
 Native transports without subtree filtering require the selected managed
 namespace to be outside their shared source scope. This includes Blacksmith's
 native repository sync, Docker Sandbox's repository and extra workspaces, Apple

--- a/internal/cli/managed_state_spelling_darwin.go
+++ b/internal/cli/managed_state_spelling_darwin.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func managedStateEntrySpelling(resolvedParent, name string, info os.FileInfo) (string, error) {
+	path := filepath.Join(resolvedParent, name)
+	fd, err := unix.Open(path, unix.O_EVTONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return "", err
+	}
+	file := os.NewFile(uintptr(fd), path)
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil {
+		return "", err
+	}
+	if !os.SameFile(info, opened) {
+		return "", fmt.Errorf("managed-state transfer path changed during metadata inspection")
+	}
+	var buffer [unix.PathMax]byte
+	_, _, errno := unix.Syscall(unix.SYS_FCNTL, uintptr(fd), unix.F_GETPATH, uintptr(unsafe.Pointer(&buffer[0])))
+	if errno != 0 {
+		return "", errno
+	}
+	end := bytes.IndexByte(buffer[:], 0)
+	if end <= 0 || !filepath.IsAbs(string(buffer[:end])) {
+		return "", fmt.Errorf("invalid managed-state transfer descriptor path")
+	}
+	// Keep the resolved parent: a descriptor path must not redirect the scope
+	// through a different hard-link name or a backing firmlink namespace.
+	spelling := filepath.Base(string(buffer[:end]))
+	if !strings.EqualFold(spelling, name) {
+		return "", fmt.Errorf("ambiguous managed-state transfer path spelling")
+	}
+	candidate := filepath.Join(resolvedParent, spelling)
+	current, err := os.Lstat(candidate)
+	if err != nil {
+		return "", err
+	}
+	if !os.SameFile(opened, current) {
+		return "", fmt.Errorf("managed-state transfer path changed during metadata inspection")
+	}
+	return candidate, nil
+}

--- a/internal/cli/managed_state_spelling_darwin_test.go
+++ b/internal/cli/managed_state_spelling_darwin_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestManagedStateDarwinDescriptorSpelling(t *testing.T) {
+	root := t.TempDir()
+	directory := filepath.Join(root, "MixedDirectory")
+	if err := os.Mkdir(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(directory, "MixedFile.txt")
+	if err := os.WriteFile(file, []byte("benign marker\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(directory, "OtherLink.txt")
+	if err := os.Link(file, link); err != nil {
+		t.Fatal(err)
+	}
+	canonicalRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, rel := range []string{"MixedDirectory", "MixedDirectory/MixedFile.txt", "MixedDirectory/OtherLink.txt"} {
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		want := filepath.Join(canonicalRoot, filepath.FromSlash(rel))
+		t.Run(rel, func(t *testing.T) {
+			got, err := NormalizeManagedStateTransferRoot(path)
+			if err != nil || got != want {
+				t.Fatalf("normalization=%q want=%q error=%v", got, want, err)
+			}
+		})
+		t.Run("case-folded/"+rel, func(t *testing.T) {
+			input := filepath.Join(root, strings.ToLower(filepath.FromSlash(rel)))
+			aliasInfo, err := os.Lstat(input)
+			if os.IsNotExist(err) {
+				t.Skip("fixture filesystem does not expose this case-folded alias")
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			originalInfo, err := os.Lstat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !os.SameFile(originalInfo, aliasInfo) {
+				t.Skip("fixture case-folded path names a distinct object")
+			}
+			got, err := NormalizeManagedStateTransferRoot(input)
+			if err != nil || got != want {
+				t.Fatalf("normalization=%q want=%q error=%v", got, want, err)
+			}
+		})
+	}
+	t.Run("backing-firmlink-path", func(t *testing.T) {
+		backingRoot := filepath.Join("/System/Volumes/Data", canonicalRoot)
+		backingInfo, err := os.Stat(backingRoot)
+		if os.IsNotExist(err) {
+			t.Skip("fixture filesystem has no boot Data backing alias")
+		}
+		if err != nil {
+			t.Fatalf("owned backing-path fixture is unavailable: %v", err)
+		}
+		rootInfo, err := os.Stat(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !os.SameFile(rootInfo, backingInfo) {
+			t.Skip("backing path does not identify the owned fixture")
+		}
+		want := filepath.Join(backingRoot, "MixedDirectory", "OtherLink.txt")
+		got, err := NormalizeManagedStateTransferRoot(want)
+		if err != nil || got != want {
+			t.Fatalf("backing namespace changed: got=%q want=%q error=%v", got, want, err)
+		}
+	})
+	alias := filepath.Join(root, "parent-alias")
+	if err := os.Symlink(directory, alias); err != nil {
+		t.Fatal(err)
+	}
+	for _, rel := range []string{"MixedFile.txt", "absent/leaf"} {
+		got, err := NormalizeManagedStateTransferRoot(filepath.Join(alias, filepath.FromSlash(rel)))
+		want := filepath.Join(canonicalRoot, "MixedDirectory", filepath.FromSlash(rel))
+		if err != nil || got != want {
+			t.Fatalf("symlink-parent normalization=%q want=%q error=%v", got, want, err)
+		}
+	}
+	for _, path := range []string{file, link} {
+		data, err := os.ReadFile(path)
+		if err != nil || string(data) != "benign marker\n" {
+			t.Fatal("metadata normalization changed an owned marker")
+		}
+	}
+}

--- a/internal/cli/managed_state_spelling_other.go
+++ b/internal/cli/managed_state_spelling_other.go
@@ -1,0 +1,54 @@
+//go:build !darwin
+
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func managedStateEntrySpelling(resolvedParent, name string, info os.FileInfo) (string, error) {
+	// Stat alone does not reveal the real spelling on case-insensitive
+	// filesystems. Bound this directory-metadata lookup; never read data.
+	dir, err := os.Open(resolvedParent)
+	if err != nil {
+		return "", err
+	}
+	defer dir.Close()
+	found := ""
+	for count := 0; count < 65536; count += 256 {
+		entries, readErr := dir.ReadDir(256)
+		for _, entry := range entries {
+			if !strings.EqualFold(entry.Name(), name) {
+				continue
+			}
+			entryInfo, err := entry.Info()
+			if err != nil {
+				return "", err
+			}
+			if !os.SameFile(info, entryInfo) {
+				continue
+			}
+			if entry.Name() == name {
+				return filepath.Join(resolvedParent, name), nil
+			}
+			if found != "" {
+				return "", fmt.Errorf("ambiguous managed-state transfer path spelling")
+			}
+			found = entry.Name()
+		}
+		if readErr == io.EOF {
+			if found == "" {
+				return "", fmt.Errorf("managed-state transfer path changed during metadata inspection")
+			}
+			return filepath.Join(resolvedParent, found), nil
+		}
+		if readErr != nil {
+			return "", readErr
+		}
+	}
+	return "", fmt.Errorf("managed-state transfer directory exceeds metadata inspection limit")
+}

--- a/internal/cli/managed_state_sync.go
+++ b/internal/cli/managed_state_sync.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -79,46 +78,7 @@ func normalizeManagedTransferPath(path string, depth int) (string, error) {
 		name = filepath.Base(resolved)
 	}
 	if err == nil && (runtime.GOOS == "darwin" || runtime.GOOS == "windows") {
-		// Stat alone does not reveal the real spelling on case-insensitive
-		// filesystems. Bound this directory-metadata lookup; never read data.
-		dir, err := os.Open(resolvedParent)
-		if err != nil {
-			return "", err
-		}
-		defer dir.Close()
-		found := ""
-		for count := 0; count < 65536; count += 256 {
-			entries, readErr := dir.ReadDir(256)
-			for _, entry := range entries {
-				if !strings.EqualFold(entry.Name(), name) {
-					continue
-				}
-				entryInfo, err := entry.Info()
-				if err != nil {
-					return "", err
-				}
-				if !os.SameFile(info, entryInfo) {
-					continue
-				}
-				if entry.Name() == name {
-					return filepath.Join(resolvedParent, name), nil
-				}
-				if found != "" {
-					return "", fmt.Errorf("ambiguous managed-state transfer path spelling")
-				}
-				found = entry.Name()
-			}
-			if readErr == io.EOF {
-				if found == "" {
-					return "", fmt.Errorf("managed-state transfer path changed during metadata inspection")
-				}
-				return filepath.Join(resolvedParent, found), nil
-			}
-			if readErr != nil {
-				return "", readErr
-			}
-		}
-		return "", fmt.Errorf("managed-state transfer directory exceeds metadata inspection limit")
+		return managedStateEntrySpelling(resolvedParent, name, info)
 	}
 	return filepath.Join(resolvedParent, name), nil
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes: macOS sync preparation can reject an ordinary source path when its parent contains too many unrelated entries.

## User Impact

Managed-state path spelling no longer enumerates neighboring files on macOS. Existing path identity checks, literal exclusions, Windows behavior, and cleanup boundaries are preserved. No new configuration or dependency is required.

## Why This Change Was Made

The macOS implementation now obtains spelling through a metadata-only descriptor and uses only the resulting basename beneath the already-resolved parent. It verifies object identity before and after lookup. This removes the sibling-scan dependency without weakening the existing admission rules. The Windows bounded scan is unchanged.

## Evidence

Actual macOS tests passed exact and case-folded paths, both hard-link names, symlinked parents, missing suffixes, and preservation of the backing-volume namespace. The revised fixture detects filesystem capabilities independently; all case-folded and backing-volume clauses ran and passed on the validation host, with no skips. Tests use only small, owned benign fixtures.

The complete change passed scoped Codex review. Pinned Go 1.26.5 focused race tests and vet passed; Windows/Linux compilation passed. The pinned CI deadcode analyzer returned no findings for Linux/amd64 with CGO disabled; this is cross-target static analysis, not native Linux CI. Initial offline tool-setup failures were resolved by fetching the exact pinned tool dependencies without changing the product module files.

Validation uses small owned fixtures rather than a directory-size stress benchmark. Documentation and the Unreleased changelog are updated.

## Landing verification

Merged as [9e6385f8](https://github.com/openclaw/crabbox/commit/9e6385f828a73cad35e07184e5561a1c80bed056). Its complete source tree matches the reviewed and tested main integration. The only merge conflict was the changelog; both PR-linked entries were retained, with no change to this fix's implementation or tests.

Fresh tests on the actual merge passed 10 tests and 21 subtests across the CLI, Blaxel, and Linode packages, plus scoped vet and documentation-link checks. All case-folded and backing-volume clauses ran and passed without skips; source and Git state stayed unchanged. This is native metadata/fixture validation, not a large-directory stress benchmark or an all-provider live-test claim.

Post-merge [CI](https://github.com/openclaw/crabbox/actions/runs/34719913828) passed all 12 jobs, [Connector smokes](https://github.com/openclaw/crabbox/actions/runs/34719913830) passed all five, and [CodeQL](https://github.com/openclaw/crabbox/actions/runs/34719912986) passed all four. No CI retries were needed. Documentation and the changelog are updated on main.
