### PR TITLE
refactor(providers): share resolved SSH lease construction

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -561,7 +561,7 @@ create, claim, bootstrap, and cleanup steps. Similar-looking acquisition bodies
 protect different ownership windows, credential dependencies, failure policies,
 and security boundaries. Share small primitives without centralizing their order.
 
-Acquisition already shares the mechanics that have provider-neutral contracts:
+Acquisition and resolution share mechanics with provider-neutral contracts:
 
 - `shared.AcquireAttemptsRetry` retries eligible fresh acquisitions outside the
   individual provider transaction and preserves bootstrap-failure/keep policy.
@@ -573,6 +573,10 @@ Acquisition already shares the mechanics that have provider-neutral contracts:
   identity checks, side effects, timeouts, and diagnostics.
 - `core.SSHTargetFromConfig` constructs conventional SSH endpoints, and
   `core.WaitForSSHReady` proves the common SSH bootstrap contract.
+- `shared.DirectSSHBackend.ResolvedLeaseTarget` packages an adapter-built endpoint
+  and reuses stored-key rebinding for ordinary resolution. Release-only resolution
+  skips stored-key lookup while preserving the configured endpoint. Adapters retain
+  ownership of region selection, host selection, and resource validation.
 - `shared.ClaimBinding`, `shared.ValidateClaimBinding`,
   `shared.ResolveProviderClaimStrict`, and `shared.ErrStrictClaimMismatch`
   validate structural identity and exact provider/scope-bound claim lookup;

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -465,12 +465,7 @@ func (b *awsLeaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) 
 			}
 			leaseID := core.Blank(server.Labels["lease"], req.ID)
 			target := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
-			if !req.ReleaseOnly {
-				if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
-					return core.LeaseTarget{}, err
-				}
-			}
-			return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+			return b.ResolvedLeaseTarget(server, target, leaseID, req.ReleaseOnly)
 		}
 		if lastErr != nil {
 			return core.LeaseTarget{}, lastErr
@@ -494,12 +489,7 @@ func (b *awsLeaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) 
 	} else if leaseID != "" {
 		cfg := awsConfigForServer(b.Cfg, server)
 		target := core.SSHTargetFromConfig(cfg, server.PublicNet.IPv4.IP)
-		if !req.ReleaseOnly {
-			if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
-				return core.LeaseTarget{}, err
-			}
-		}
-		return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+		return b.ResolvedLeaseTarget(server, target, leaseID, req.ReleaseOnly)
 	}
 	return core.LeaseTarget{}, core.Exit(4, "lease/server not found: %s", req.ID)
 }

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -1565,7 +1565,7 @@ func TestAWSResolveAndReleaseUseFallbackRegion(t *testing.T) {
 	}
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1"}
+	cfg := core.Config{Provider: "aws", AWSRegion: "us-east-1", SSHUser: "alice", SSHPort: "2222", SSHKey: "configured-key"}
 	cfg.Capacity.Regions = []string{"us-east-1", "us-west-2"}
 	backend := NewAWSLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "west"})
@@ -1574,6 +1574,9 @@ func TestAWSResolveAndReleaseUseFallbackRegion(t *testing.T) {
 	}
 	if lease.Server.CloudID != "i-west" || lease.Server.Labels["aws_region"] != "us-west-2" {
 		t.Fatalf("lease=%#v, want west-region server", lease.Server)
+	}
+	if lease.SSH.User != "alice" || lease.SSH.Port != "2222" || lease.SSH.Key != "configured-key" {
+		t.Fatalf("resolved SSH target: %#v", lease.SSH)
 	}
 	if err := core.ClaimLeaseTargetForConfig(lease.LeaseID, lease.Server.Labels["slug"], cfg, lease.Server, core.SSHTarget{}, time.Hour); err != nil {
 		t.Fatal(err)

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -148,12 +148,7 @@ func (b *azureLeaseBackend) Resolve(ctx context.Context, req core.ResolveRequest
 		}
 		leaseID := server.Labels["lease"]
 		target := core.SSHTargetFromConfig(b.Cfg, core.AzureServerHost(server, b.Cfg.AzureNetwork))
-		if !req.ReleaseOnly {
-			if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
-				return core.LeaseTarget{}, err
-			}
-		}
-		return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+		return b.ResolvedLeaseTarget(server, target, leaseID, req.ReleaseOnly)
 	}
 	servers, err := listOwnedAzureServers(ctx, client)
 	if err != nil {
@@ -163,12 +158,7 @@ func (b *azureLeaseBackend) Resolve(ctx context.Context, req core.ResolveRequest
 		return core.LeaseTarget{}, err
 	} else if leaseID != "" {
 		target := core.SSHTargetFromConfig(b.Cfg, core.AzureServerHost(server, b.Cfg.AzureNetwork))
-		if !req.ReleaseOnly {
-			if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
-				return core.LeaseTarget{}, err
-			}
-		}
-		return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+		return b.ResolvedLeaseTarget(server, target, leaseID, req.ReleaseOnly)
 	}
 	if req.ReleaseOnly {
 		return resolveMissingAzureReleaseClaim(req.ID, client.LeaseClaimScope())

--- a/internal/providers/azure/backend_test.go
+++ b/internal/providers/azure/backend_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 type fakeAzureClient struct {
@@ -1040,6 +1041,38 @@ func TestAzureConfigShowCompletePassiveSection(t *testing.T) {
 					t.Fatal("projection mutated supplied configuration")
 				}
 			})
+		}
+	}
+}
+
+func TestAzureResolvedEndpointDirectAndAlias(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	server := azureTestServer("crabbox-example", "cbx_123456abcdef", "example")
+	server.PublicNet.IPv4.IP = "192.0.2.10"
+	server.PrivateNet.IPv4.IP = "10.0.0.10"
+	fake := &fakeAzureClient{servers: []core.Server{server}, get: map[string]core.Server{server.CloudID: server}}
+	old := newAzureClient
+	newAzureClient = func(context.Context, core.Config) (azureClient, error) { return fake, nil }
+	t.Cleanup(func() { newAzureClient = old })
+	for _, network := range []string{"public", "private"} {
+		for _, id := range []string{server.CloudID, "example"} {
+			for _, releaseOnly := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/%s/release=%t", network, id, releaseOnly), func(t *testing.T) {
+					cfg := core.Config{SSHUser: "alice", SSHPort: "2222", SSHKey: "configured-key", TargetOS: "linux", AzureNetwork: network}
+					backend := NewAzureLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{}).(*azureLeaseBackend)
+					got, err := backend.Resolve(t.Context(), core.ResolveRequest{ID: id, ReleaseOnly: releaseOnly})
+					if err != nil {
+						t.Fatal(err)
+					}
+					wantHost := "192.0.2.10"
+					if network == "private" {
+						wantHost = "10.0.0.10"
+					}
+					if got.Server.CloudID != server.CloudID || got.LeaseID != "cbx_123456abcdef" || got.SSH.Host != wantHost || got.SSH.User != "alice" || got.SSH.Port != "2222" || got.SSH.Key != "configured-key" {
+						t.Fatalf("resolved target: %#v", got)
+					}
+				})
+			}
 		}
 	}
 }

--- a/internal/providers/gcp/backend.go
+++ b/internal/providers/gcp/backend.go
@@ -124,12 +124,7 @@ func (b *gcpLeaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) 
 			}
 			leaseID := core.Blank(server.Labels["lease"], req.ID)
 			target := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
-			if !req.ReleaseOnly {
-				if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
-					return core.LeaseTarget{}, err
-				}
-			}
-			return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+			return b.ResolvedLeaseTarget(server, target, leaseID, req.ReleaseOnly)
 		}
 	}
 	servers, err := client.ListCrabboxServers(ctx)
@@ -140,12 +135,7 @@ func (b *gcpLeaseBackend) Resolve(ctx context.Context, req core.ResolveRequest) 
 		return core.LeaseTarget{}, err
 	} else if leaseID != "" {
 		target := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
-		if !req.ReleaseOnly {
-			if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
-				return core.LeaseTarget{}, err
-			}
-		}
-		return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+		return b.ResolvedLeaseTarget(server, target, leaseID, req.ReleaseOnly)
 	}
 	return core.LeaseTarget{}, core.Exit(4, "lease/server not found: %s", req.ID)
 }

--- a/internal/providers/gcp/backend_doctor_test.go
+++ b/internal/providers/gcp/backend_doctor_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 	"google.golang.org/api/googleapi"
 )
 
@@ -704,5 +705,31 @@ func TestGCPAcquireRetainsCleanupClientFailureDespiteFallbackSuccess(t *testing.
 	_, err := b.Acquire(context.Background(), core.AcquireRequest{})
 	if fake.createCalls != 1 || len(fake.deleted) != 1 || !errors.Is(err, primary) || !errors.Is(err, debt) {
 		t.Fatalf("creates=%d deletes=%v error=%v", fake.createCalls, fake.deleted, err)
+	}
+}
+
+func TestGCPResolvedEndpointDirectAndAlias(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	server := canonicalGCPTestServer("cbx_123456abcdef", "example")
+	server.PublicNet.IPv4.IP = "192.0.2.10"
+	fake := &fakeGCPDoctorClient{servers: []core.Server{server}, get: map[string]core.Server{server.CloudID: server}}
+	old := newGCPClient
+	newGCPClient = func(context.Context, core.Config) (gcpClient, error) { return fake, nil }
+	t.Cleanup(func() { newGCPClient = old })
+	for _, id := range []string{server.CloudID, "example"} {
+		for _, releaseOnly := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/release=%t", id, releaseOnly), func(t *testing.T) {
+				cfg := core.Config{SSHUser: "alice", SSHPort: "2222", SSHKey: "configured-key", TargetOS: "linux"}
+				backend := NewGCPLeaseBackend(core.ProviderSpec{}, cfg, core.Runtime{}).(*gcpLeaseBackend)
+				got, err := backend.Resolve(t.Context(), core.ResolveRequest{ID: id, ReleaseOnly: releaseOnly})
+				if err != nil {
+					t.Fatal(err)
+				}
+				wantHost := "192.0.2.10"
+				if got.Server.CloudID != server.CloudID || got.LeaseID != "cbx_123456abcdef" || got.SSH.Host != wantHost || got.SSH.User != "alice" || got.SSH.Port != "2222" || got.SSH.Key != "configured-key" {
+					t.Fatalf("resolved target: %#v", got)
+				}
+			})
+		}
 	}
 }

--- a/internal/providers/hetzner/backend.go
+++ b/internal/providers/hetzner/backend.go
@@ -169,12 +169,7 @@ func (b *hetznerLeaseBackend) Resolve(ctx context.Context, req core.ResolveReque
 		}
 		leaseID := core.Blank(server.Labels["lease"], req.ID)
 		target := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
-		if !req.ReleaseOnly {
-			if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
-				return core.LeaseTarget{}, err
-			}
-		}
-		return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+		return b.ResolvedLeaseTarget(server, target, leaseID, req.ReleaseOnly)
 	}
 	servers, err := client.ListCrabboxServers(ctx)
 	if err != nil {
@@ -188,12 +183,7 @@ func (b *hetznerLeaseBackend) Resolve(ctx context.Context, req core.ResolveReque
 			return core.LeaseTarget{}, err
 		}
 		target := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
-		if !req.ReleaseOnly {
-			if err := core.UseStoredTestboxKey(&target, leaseID); err != nil {
-				return core.LeaseTarget{}, err
-			}
-		}
-		return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+		return b.ResolvedLeaseTarget(server, target, leaseID, req.ReleaseOnly)
 	}
 	return core.LeaseTarget{}, core.Exit(4, "lease/server not found: %s", req.ID)
 }

--- a/internal/providers/shared/direct.go
+++ b/internal/providers/shared/direct.go
@@ -24,6 +24,17 @@ const CleanupSkipNoExactLocalClaim CleanupSkipReason = "no-exact-local-claim"
 
 func (b *DirectSSHBackend) Spec() core.ProviderSpec { return b.SpecValue }
 
+// ResolvedLeaseTarget preserves the adapter's endpoint and skips stored-key lookup for release-only resolution.
+func (b *DirectSSHBackend) ResolvedLeaseTarget(server core.Server, target core.SSHTarget, leaseID string, releaseOnly bool) (core.LeaseTarget, error) {
+	lease := core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
+	if !releaseOnly {
+		if err := b.RebindResolvedLeaseTarget(&lease, leaseID); err != nil {
+			return core.LeaseTarget{}, err
+		}
+	}
+	return lease, nil
+}
+
 func (b *DirectSSHBackend) RebindResolvedLeaseTarget(target *core.LeaseTarget, leaseID string) error {
 	if b.StoredLeaseKeys {
 		if err := core.UseStoredTestboxKey(&target.SSH, leaseID); err != nil {

--- a/internal/providers/shared/direct_test.go
+++ b/internal/providers/shared/direct_test.go
@@ -6,11 +6,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestCleanupServersUsesSingleBatchCutoff(t *testing.T) {
@@ -433,5 +436,74 @@ func TestAcquireCleanupFailureVetoesRetryThroughWrapping(t *testing.T) {
 	primary := bootstrapWaitErr()
 	if got := JoinAcquireCleanupError(primary, nil); got != primary {
 		t.Fatalf("successful cleanup changed primary: %v", got)
+	}
+}
+
+func TestResolvedLeaseTargetPreservesEndpoint(t *testing.T) {
+	for _, stored := range []bool{false, true} {
+		for _, enabled := range []bool{false, true} {
+			for _, releaseOnly := range []bool{false, true} {
+				t.Run(fmt.Sprintf("stored=%t/enabled=%t/release=%t", stored, enabled, releaseOnly), func(t *testing.T) {
+					testutil.IsolateUserDirs(t)
+					const leaseID = "cbx_123456abcdef"
+					path, err := core.TestboxKeyPath(leaseID)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if stored {
+						path, err = core.PrepareStoredTestboxKeyPath(leaseID)
+						if err != nil {
+							t.Fatal(err)
+						}
+						file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+						if err != nil {
+							t.Fatal(err)
+						}
+						secureErr := core.SecureCreatedLeaseSSHFile(file)
+						closeErr := file.Close()
+						if secureErr != nil {
+							t.Fatal(secureErr)
+						}
+						if closeErr != nil {
+							t.Fatal(closeErr)
+						}
+					}
+					target := core.SSHTarget{User: "alice", Host: "192.0.2.10", Key: "configured-key", Port: "2222", FallbackPorts: []string{"22"}, TargetOS: "linux", WindowsMode: "normal", ReadyCheck: "true", CertificateFile: "certificate", KnownHostsFile: "known-hosts", HostKeyAlias: "alias", SSHHostKey: "host-key", NoControlMaster: true, SSHConfigProxy: true, ProxyCommand: "proxy", ChildEnvDenylist: []string{"EXAMPLE"}, ChildEnv: map[string]string{"EXAMPLE_MODE": "test"}}
+					server := core.Server{CloudID: "instance", Labels: map[string]string{"lease": leaseID}}
+					want := core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
+					if stored && enabled && !releaseOnly {
+						want.SSH.Key = path
+					}
+					backend := DirectSSHBackend{StoredLeaseKeys: enabled}
+					got, err := backend.ResolvedLeaseTarget(server, target, leaseID, releaseOnly)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !reflect.DeepEqual(got, want) {
+						t.Fatalf("target mismatch: got %#v want %#v", got, want)
+					}
+					if target.Key != "configured-key" {
+						t.Fatal("input target changed")
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestResolvedLeaseTargetLookupErrorAndReleaseOnly(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	t.Setenv("XDG_STATE_HOME", "relative-state")
+	backend := DirectSSHBackend{StoredLeaseKeys: true}
+	server := core.Server{CloudID: "instance"}
+	target := core.SSHTarget{Host: "192.0.2.10", Key: "configured-key"}
+	got, err := backend.ResolvedLeaseTarget(server, target, "cbx_123456abcdef", false)
+	if err == nil || !reflect.DeepEqual(got, core.LeaseTarget{}) {
+		t.Fatalf("lookup error=%v target=%#v", err, got)
+	}
+	got, err = backend.ResolvedLeaseTarget(server, target, "cbx_123456abcdef", true)
+	want := core.LeaseTarget{Server: server, SSH: target, LeaseID: "cbx_123456abcdef"}
+	if err != nil || !reflect.DeepEqual(got, want) {
+		t.Fatalf("release-only error=%v target=%#v", err, got)
 	}
 }


### PR DESCRIPTION
## What Problem This Solves

Eight successful resolution paths duplicate lease construction and the stored-key lookup decision across AWS, GCP, Azure, and Hetzner.

## User Impact

No user-visible behavior change. Provider-specific endpoint selection, ownership checks, and metadata-only release behavior remain intact.

## Why This Change Was Made

The existing shared SSH backend now constructs a resolved lease from the adapter-built endpoint and reuses its existing stored-key rebinding policy. Each adapter still chooses its own region and host before delegation. Acquisition, terminal/missing-resource reconstruction, and later canonical-claim rebinding are unchanged.

## Evidence

A byte-for-byte reversal check confirms the only changes within the four provider backends are the eight delegated resolution tails. All four constructors already opt into stored lease keys.

Selected existing tests, focused race tests, and vet passed with pinned Go 1.26.5. Coverage includes endpoint field preservation, stored-key opt-in, ordinary lookup errors, release-only bypass, GCP direct/alias resolution, Azure public/private endpoints, AWS fallback-region resolution, and both existing Hetzner numeric/alias resolution cases. Those focused checks use local synthetic fixtures. An additional integration on main at [d6a6a49e](https://github.com/openclaw/crabbox/commit/d6a6a49efc86be549a9ca60d7627cdbb3afc7f19) passed all five affected package race suites (307 tests and 753 subtests), plus vet, with no skips or external-resource gaps. The source and Git state stayed unchanged. Live cloud lifecycle validation is not claimed; no provider resources or credentials were used.

Complete scoped Codex review found no actionable P0 findings. Architecture documentation is updated; no changelog entry is needed for this behavior-preserving internal refactor.

## Landing verification

Merged as [c21e9e86](https://github.com/openclaw/crabbox/commit/c21e9e867ccc4d0ebc13eac1fcd8e6bdcd79bc5d). The raw parent and tree match the ten-file change applied to current main, retaining the later label-default and sandbox refactors. The nine implementation/test files match the reviewed head; the documentation combines both maintainer changes.

On the actual merge, all five affected package race suites passed: 310 tests and 759 subtests, with zero skips or failures, plus scoped vet. Source and Git state remained unchanged. This remains local synthetic/loopback validation, not live cloud provisioning.

Post-merge [CI](https://github.com/openclaw/crabbox/actions/runs/34721372721) passed all 12 jobs, [Connector smokes](https://github.com/openclaw/crabbox/actions/runs/34721372668) passed all five, and [CodeQL](https://github.com/openclaw/crabbox/actions/runs/34721372270) passed all four. No retries were needed.
