### PR TITLE
refactor(providers): centralize copied label defaults

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -577,6 +577,9 @@ Acquisition already shares the mechanics that have provider-neutral contracts:
   `shared.ResolveProviderClaimStrict`, and `shared.ErrStrictClaimMismatch`
   validate structural identity and exact provider/scope-bound claim lookup;
   `shared.CloneLabels` supplies writable label copies.
+- `shared.LabelsWithDefaults` copies stored labels and fills missing or empty
+  values during inventory projection. Adapters retain the default values and
+  any authoritative state, identity, redaction, or live-port overrides.
 - `core.AcquireFixedLease`, `core.FixedAcquireOptions`,
   `core.FixedLeaseBinding`, and `core.FixedLeaseKind` already share durable
   fixed-ID intent locking, replay validation, acquired-state commit, and

--- a/internal/providers/applecontainer/backend.go
+++ b/internal/providers/applecontainer/backend.go
@@ -811,20 +811,12 @@ func (b *backend) hostDNSServers(ctx context.Context) []string {
 }
 
 func (b *backend) serverFromContainer(c inspectContainer, cfg core.Config) core.Server {
-	labels := map[string]string{}
-	for key, value := range c.labels() {
-		labels[key] = value
-	}
+	labels := shared.LabelsWithDefaults(c.labels(), map[string]string{
+		"provider":    providerName,
+		"server_type": shared.FirstNonBlank(c.image(), cfg.AppleContainer.Image),
+		"state":       c.status(),
+	})
 	labels["container_id"] = c.id()
-	if labels["provider"] == "" {
-		labels["provider"] = providerName
-	}
-	if labels["server_type"] == "" {
-		labels["server_type"] = shared.FirstNonBlank(c.image(), cfg.AppleContainer.Image)
-	}
-	if labels["state"] == "" {
-		labels["state"] = c.status()
-	}
 	labels["ssh_port"] = sshPort
 	status := c.status()
 	if c.running() && labels["state"] == "ready" {

--- a/internal/providers/applevm/backend.go
+++ b/internal/providers/applevm/backend.go
@@ -732,44 +732,23 @@ func (e *missingInstanceError) Unwrap() error {
 }
 
 func (b *backend) serverFromInstance(inst applevmhelper.Instance, claim core.LeaseClaim, cfg core.Config) core.Server {
-	labels := map[string]string{}
-	for key, value := range claim.Labels {
-		labels[key] = value
-	}
-	if labels["crabbox"] == "" {
-		labels["crabbox"] = "true"
-	}
-	if labels["provider"] == "" {
-		labels["provider"] = providerName
-	}
-	if labels["instance"] == "" {
-		labels["instance"] = inst.Name
-	}
-	if labels["lease"] == "" {
-		labels["lease"] = shared.FirstNonBlankTrimmed(claim.LeaseID, inst.LeaseID)
-	}
-	if labels["slug"] == "" {
-		labels["slug"] = shared.FirstNonBlankTrimmed(claim.Slug, inst.Slug)
-	}
 	imageIdentity := applevmhelper.ImageIdentity(cfg.AppleVM.Image, cfg.AppleVM.ImageSHA256)
-	if labels["server_type"] == "" {
-		labels["server_type"] = shared.FirstNonBlankTrimmed(inst.Image, imageIdentity)
-	}
+	labels := shared.LabelsWithDefaults(claim.Labels, map[string]string{
+		"crabbox":     "true",
+		"provider":    providerName,
+		"instance":    inst.Name,
+		"lease":       shared.FirstNonBlankTrimmed(claim.LeaseID, inst.LeaseID),
+		"slug":        shared.FirstNonBlankTrimmed(claim.Slug, inst.Slug),
+		"server_type": shared.FirstNonBlankTrimmed(inst.Image, imageIdentity),
+		"image":       shared.FirstNonBlankTrimmed(inst.Image, imageIdentity),
+		"ssh_user":    shared.FirstNonBlankTrimmed(inst.SSHUser, cfg.AppleVM.User),
+		"ssh_port":    cfg.SSHPort,
+		"work_root":   shared.FirstNonBlankTrimmed(inst.WorkRoot, cfg.AppleVM.WorkRoot),
+	})
 	labels["server_type"] = applevmhelper.RedactImageRef(labels["server_type"])
-	if labels["image"] == "" {
-		labels["image"] = shared.FirstNonBlankTrimmed(inst.Image, imageIdentity)
-	}
 	labels["image"] = applevmhelper.RedactImageRef(labels["image"])
-	if labels["ssh_user"] == "" {
-		labels["ssh_user"] = shared.FirstNonBlankTrimmed(inst.SSHUser, cfg.AppleVM.User)
-	}
 	if inst.SSHPort > 0 {
 		labels["ssh_port"] = strconv.Itoa(inst.SSHPort)
-	} else if labels["ssh_port"] == "" {
-		labels["ssh_port"] = cfg.SSHPort
-	}
-	if labels["work_root"] == "" {
-		labels["work_root"] = shared.FirstNonBlankTrimmed(inst.WorkRoot, cfg.AppleVM.WorkRoot)
 	}
 	status := appleVMState(inst.Status)
 	if appleVMRunning(inst.Status) && labels["state"] == "ready" {

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -1214,40 +1214,20 @@ func (b *backend) queryVHDPaths(ctx context.Context, name string) []string {
 }
 
 func (b *backend) serverFromInstance(inst hypervVM, claim core.LeaseClaim, cfg core.Config) core.Server {
-	labels := map[string]string{}
-	for key, value := range claim.Labels {
-		labels[key] = value
-	}
-	if labels["crabbox"] == "" {
-		labels["crabbox"] = "true"
-	}
-	if labels["provider"] == "" {
-		labels["provider"] = providerName
-	}
-	if labels["instance"] == "" {
-		labels["instance"] = inst.Name
-	}
-	if labels["lease"] == "" {
-		labels["lease"] = claim.LeaseID
-	}
-	if labels["slug"] == "" {
-		labels["slug"] = claim.Slug
-	}
+	labels := shared.LabelsWithDefaults(claim.Labels, map[string]string{
+		"crabbox":   "true",
+		"provider":  providerName,
+		"instance":  inst.Name,
+		"lease":     claim.LeaseID,
+		"slug":      claim.Slug,
+		"image":     cfg.HyperV.Image,
+		"ssh_user":  cfg.HyperV.User,
+		"ssh_port":  sshPort,
+		"work_root": cfg.HyperV.WorkRoot,
+	})
 	liveState := hypervState(inst.State)
 	if inst.State != 2 || labels["state"] == "" {
 		labels["state"] = liveState
-	}
-	if labels["image"] == "" {
-		labels["image"] = cfg.HyperV.Image
-	}
-	if labels["ssh_user"] == "" {
-		labels["ssh_user"] = cfg.HyperV.User
-	}
-	if labels["ssh_port"] == "" {
-		labels["ssh_port"] = sshPort
-	}
-	if labels["work_root"] == "" {
-		labels["work_root"] = cfg.HyperV.WorkRoot
 	}
 	status := liveState
 	if inst.State == 2 && labels["state"] == "ready" {

--- a/internal/providers/lume/backend.go
+++ b/internal/providers/lume/backend.go
@@ -1696,28 +1696,21 @@ func requireAuthenticatedLumeHostKey(target core.SSHTarget, state, name string) 
 }
 
 func (b *backend) serverFromInstance(inst lumeVM, claim core.LeaseClaim, cfg core.Config) core.Server {
-	labels := map[string]string{}
-	for key, value := range claim.Labels {
-		labels[key] = value
-	}
+	labels := shared.LabelsWithDefaults(claim.Labels, map[string]string{
+		"lease":       claim.LeaseID,
+		"slug":        claim.Slug,
+		"server_type": cfg.Lume.Base,
+		"base":        cfg.Lume.Base,
+		"ssh_user":    cfg.Lume.User,
+		"ssh_port":    sshPort,
+		"work_root":   cfg.Lume.WorkRoot,
+	})
 	labels["crabbox"] = "true"
 	labels["provider"] = providerName
 	labels["instance"] = inst.Name
-	if labels["lease"] == "" {
-		labels["lease"] = claim.LeaseID
-	}
-	if labels["slug"] == "" {
-		labels["slug"] = claim.Slug
-	}
 	state := normalizedState(inst.Status)
 	if labels["state"] == "" || labels["state"] == "running" {
 		labels["state"] = state
-	}
-	if labels["server_type"] == "" {
-		labels["server_type"] = cfg.Lume.Base
-	}
-	if labels["base"] == "" {
-		labels["base"] = cfg.Lume.Base
 	}
 	if labels["storage"] == "" {
 		if storage := strings.TrimSpace(inst.LocationName); storage != "" {
@@ -1726,15 +1719,6 @@ func (b *backend) serverFromInstance(inst lumeVM, claim core.LeaseClaim, cfg cor
 		} else {
 			labels["storage"] = strings.TrimSpace(cfg.Lume.Storage)
 		}
-	}
-	if labels["ssh_user"] == "" {
-		labels["ssh_user"] = cfg.Lume.User
-	}
-	if labels["ssh_port"] == "" {
-		labels["ssh_port"] = sshPort
-	}
-	if labels["work_root"] == "" {
-		labels["work_root"] = cfg.Lume.WorkRoot
 	}
 	status := state
 	if instanceRunning(inst.Status) && labels["state"] == "ready" {

--- a/internal/providers/multipass/backend.go
+++ b/internal/providers/multipass/backend.go
@@ -625,43 +625,19 @@ func (b *backend) removeInstance(ctx context.Context, name string) error {
 }
 
 func (b *backend) serverFromInstance(inst multipassInstance, claim core.LeaseClaim, cfg core.Config) core.Server {
-	labels := map[string]string{}
-	for key, value := range claim.Labels {
-		labels[key] = value
-	}
-	if labels["crabbox"] == "" {
-		labels["crabbox"] = "true"
-	}
-	if labels["provider"] == "" {
-		labels["provider"] = providerName
-	}
-	if labels["instance"] == "" {
-		labels["instance"] = inst.Name
-	}
-	if labels["lease"] == "" {
-		labels["lease"] = claim.LeaseID
-	}
-	if labels["slug"] == "" {
-		labels["slug"] = claim.Slug
-	}
-	if labels["state"] == "" {
-		labels["state"] = multipassState(inst.State)
-	}
-	if labels["server_type"] == "" {
-		labels["server_type"] = shared.FirstNonBlank(inst.Release, cfg.Multipass.Image)
-	}
-	if labels["image"] == "" {
-		labels["image"] = cfg.Multipass.Image
-	}
-	if labels["ssh_user"] == "" {
-		labels["ssh_user"] = cfg.Multipass.User
-	}
-	if labels["ssh_port"] == "" {
-		labels["ssh_port"] = sshPort
-	}
-	if labels["work_root"] == "" {
-		labels["work_root"] = cfg.Multipass.WorkRoot
-	}
+	labels := shared.LabelsWithDefaults(claim.Labels, map[string]string{
+		"crabbox":     "true",
+		"provider":    providerName,
+		"instance":    inst.Name,
+		"lease":       claim.LeaseID,
+		"slug":        claim.Slug,
+		"state":       multipassState(inst.State),
+		"server_type": shared.FirstNonBlank(inst.Release, cfg.Multipass.Image),
+		"image":       cfg.Multipass.Image,
+		"ssh_user":    cfg.Multipass.User,
+		"ssh_port":    sshPort,
+		"work_root":   cfg.Multipass.WorkRoot,
+	})
 	status := multipassState(inst.State)
 	if instanceRunning(inst.State) && labels["state"] == "ready" {
 		status = "ready"

--- a/internal/providers/shared/claim.go
+++ b/internal/providers/shared/claim.go
@@ -218,3 +218,15 @@ func CloneLabels(labels map[string]string) map[string]string {
 	}
 	return clone
 }
+
+// LabelsWithDefaults copies labels and fills missing or empty values. Whitespace
+// is a stored value, and an empty default still creates the corresponding key.
+func LabelsWithDefaults(labels, defaults map[string]string) map[string]string {
+	labels = CloneLabels(labels)
+	for key, value := range defaults {
+		if labels[key] == "" {
+			labels[key] = value
+		}
+	}
+	return labels
+}

--- a/internal/providers/shared/claim_test.go
+++ b/internal/providers/shared/claim_test.go
@@ -31,6 +31,25 @@ func TestCloneLabels(t *testing.T) {
 	}
 }
 
+func TestLabelsWithDefaultsPreservesStoredValuesAndCopies(t *testing.T) {
+	stored := map[string]string{"provider": "stored", "state": "", "space": " ", "extra": "kept"}
+	defaults := map[string]string{"provider": "fallback", "state": "running", "space": "fallback", "empty": ""}
+	got := LabelsWithDefaults(stored, defaults)
+	want := map[string]string{"provider": "stored", "state": "running", "space": " ", "extra": "kept", "empty": ""}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("labels=%#v, want %#v", got, want)
+	}
+	got["provider"] = "changed"
+	if stored["provider"] != "stored" || stored["state"] != "" || defaults["provider"] != "fallback" {
+		t.Fatal("label projection mutated its inputs")
+	}
+	fromNil := LabelsWithDefaults(nil, map[string]string{"lease": ""})
+	if value, exists := fromNil["lease"]; !exists || value != "" {
+		t.Fatalf("empty default not materialized: %#v", fromNil)
+	}
+	LabelsWithDefaults(nil, nil)["new"] = "writable"
+}
+
 func TestValidateClaimBindingFields(t *testing.T) {
 	claim := core.LeaseClaim{
 		Provider:      "example",

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -785,42 +785,20 @@ func (b *backend) prepareLease(ctx context.Context, cfg core.Config, inst tartIn
 }
 
 func (b *backend) serverFromInstance(inst tartInstance, claim core.LeaseClaim, cfg core.Config) core.Server {
-	labels := map[string]string{}
-	for key, value := range claim.Labels {
-		labels[key] = value
-	}
-	if labels["crabbox"] == "" {
-		labels["crabbox"] = "true"
-	}
-	if labels["provider"] == "" {
-		labels["provider"] = providerName
-	}
-	if labels["instance"] == "" {
-		labels["instance"] = inst.Name
-	}
-	if labels["lease"] == "" {
-		labels["lease"] = claim.LeaseID
-	}
-	if labels["slug"] == "" {
-		labels["slug"] = claim.Slug
-	}
-	if labels["state"] == "" {
-		labels["state"] = tartState(inst.State)
-	}
-	if labels["server_type"] == "" {
-		labels["server_type"] = shared.FirstNonBlank(inst.Source, cfg.Tart.Image)
-	}
+	labels := shared.LabelsWithDefaults(claim.Labels, map[string]string{
+		"crabbox":     "true",
+		"provider":    providerName,
+		"instance":    inst.Name,
+		"lease":       claim.LeaseID,
+		"slug":        claim.Slug,
+		"state":       tartState(inst.State),
+		"server_type": shared.FirstNonBlank(inst.Source, cfg.Tart.Image),
+		"ssh_user":    cfg.Tart.User,
+		"ssh_port":    sshPort,
+		"work_root":   cfg.Tart.WorkRoot,
+	})
 	// Native inventory's Source is a storage kind, not an image identity.
 	// Only acquisition records image provenance in the claim.
-	if labels["ssh_user"] == "" {
-		labels["ssh_user"] = cfg.Tart.User
-	}
-	if labels["ssh_port"] == "" {
-		labels["ssh_port"] = sshPort
-	}
-	if labels["work_root"] == "" {
-		labels["work_root"] = cfg.Tart.WorkRoot
-	}
 	status := tartState(inst.State)
 	if instanceRunning(inst.State) && labels["state"] == "ready" {
 		status = "ready"


### PR DESCRIPTION
Six VM and container adapters duplicated the same claim-label projection: copy stored labels, then fill empty fields from inventory and configuration. A shared LabelsWithDefaults helper now owns that mechanism, while each adapter still supplies its own defaults and authoritative state, identity, redaction, and live-port overrides.

Stored nonempty values (including whitespace), explicit empty defaults, unknown labels, and input-map isolation are preserved. No CLI or configuration behavior changes.

Validation: complete shared, Apple Container, Apple VM, Hyper-V, Lume, Multipass, and Tart suites passed; the new regression checks empty values, whitespace, key presence, and copy isolation. Scoped Codex review passed. No dependency or credential changes.
