### PR TITLE
refactor(coordinator): share FIFO operation mutexes

### DIFF
--- a/docs/features/portable-coordinator.md
+++ b/docs/features/portable-coordinator.md
@@ -151,6 +151,9 @@ are idempotent, so repeated job delivery is expected and safe.
 
 Node does not inherit Durable Object event ordering, so lifecycle mutations use
 an explicit process mutex. Slow provider calls do not hold that mutex.
+The Node and Cloudflare runtimes share the same FIFO mutex implementation.
+Borrowing, bridge tickets, ingress, and maintenance keep separate mutexes;
+runtime deletion and snapshot bootstrap use independent queues per resource key.
 Provisioning follows three phases:
 
 1. reserve the lease and cost under the lifecycle lock;

--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -228,7 +228,11 @@ func TestWorkspaceOwnerSerializesIndependentClientsAndRevisions(t *testing.T) {
 		if active.Add(1) != 1 {
 			overlap.Store(true)
 		}
-		defer active.Add(-1)
+		var result error
+		defer func() {
+			active.Add(-1)
+			done <- result
+		}()
 		workspace.Lock()
 		workspace.revision = revision
 		workspace.Unlock()
@@ -242,10 +246,8 @@ func TestWorkspaceOwnerSerializesIndependentClientsAndRevisions(t *testing.T) {
 		executed := workspace.revision
 		workspace.Unlock()
 		if executed != revision {
-			done <- fmt.Errorf("executed revision %s, want %s", executed, revision)
-			return
+			result = fmt.Errorf("executed revision %s, want %s", executed, revision)
 		}
-		done <- nil
 	}
 	go run(ownerA, "revision-a", startedA, releaseA)
 	<-startedA

--- a/worker/node/server-support.ts
+++ b/worker/node/server-support.ts
@@ -3,6 +3,7 @@ import { BlockList, isIP } from "node:net";
 import type { Writable } from "node:stream";
 import { finished } from "node:stream/promises";
 
+import type { AsyncMutex } from "../src/async-mutex";
 import { coordinatorRequestQueue, type CoordinatorRequestQueue } from "../src/coordinator-runtime";
 import { runtimeAdapterRelayBodyLimit } from "../src/runtime-adapter-relay";
 
@@ -10,7 +11,6 @@ export const unauthenticatedRequestBodyBytes = 1024 * 1024;
 export const authenticatedRequestBodyBytes = 16 * 1024 * 1024;
 export const runFinishRequestBodyBytes = 64 * 1024 * 1024;
 
-const noop = () => {};
 const untrustedForwardingWarningIntervalMs = 60_000;
 
 export class RequestBodyTooLargeError extends Error {}
@@ -36,28 +36,6 @@ export function nodeRequestAbortSignal(
       response.off("close", abortResponse);
     },
   };
-}
-
-export class AsyncMutex {
-  private tail: Promise<void> = Promise.resolve();
-
-  async run<T>(callback: () => Promise<T>): Promise<T> {
-    const previous = this.tail;
-    let release = noop;
-    this.tail = new Promise<void>((resolvePromise) => {
-      release = resolvePromise;
-    });
-    await previous;
-    try {
-      return await callback();
-    } finally {
-      release();
-    }
-  }
-
-  async drain(): Promise<void> {
-    await this.tail;
-  }
 }
 
 export class AsyncOperationTracker {

--- a/worker/node/server.ts
+++ b/worker/node/server.ts
@@ -4,6 +4,7 @@ import { extname, resolve, sep } from "node:path";
 import type { Duplex } from "node:stream";
 import { fileURLToPath, URL as NodeURL } from "node:url";
 
+import { AsyncMutex } from "../src/async-mutex";
 import { prepareCoordinatorRequest, routeCoordinatorRequest } from "../src/coordinator-entry";
 import { FleetCoordinator } from "../src/fleet";
 import {
@@ -13,7 +14,6 @@ import {
 } from "./aws-deployment";
 import { NodeCoordinatorRuntime, type NodeUpgradeContext } from "./node-runtime";
 import {
-  AsyncMutex,
   AsyncOperationTracker,
   RequestBodyTooLargeError,
   closeServer,

--- a/worker/src/async-mutex.ts
+++ b/worker/src/async-mutex.ts
@@ -1,0 +1,40 @@
+// FIFO in-process coordination; operation failures never poison the next turn.
+export class AsyncMutex {
+  private tail: Promise<void> = Promise.resolve();
+
+  async run<T>(callback: () => Promise<T>): Promise<T> {
+    const previous = this.tail;
+    let release!: () => void;
+    this.tail = new Promise<void>((resolvePromise) => {
+      release = resolvePromise;
+    });
+    await previous;
+    try {
+      return await callback();
+    } finally {
+      release();
+    }
+  }
+
+  async drain(): Promise<void> {
+    await this.tail;
+  }
+}
+
+export class KeyedAsyncMutex<K> {
+  private readonly entries = new Map<K, { mutex: AsyncMutex; users: number }>();
+
+  async run<T>(key: K, callback: () => Promise<T>): Promise<T> {
+    let entry = this.entries.get(key);
+    if (!entry) {
+      entry = { mutex: new AsyncMutex(), users: 0 };
+      this.entries.set(key, entry);
+    }
+    entry.users++;
+    try {
+      return await entry.mutex.run(callback);
+    } finally {
+      if (--entry.users === 0) this.entries.delete(key);
+    }
+  }
+}

--- a/worker/src/coordinator-runtime.ts
+++ b/worker/src/coordinator-runtime.ts
@@ -1,3 +1,4 @@
+import { AsyncMutex } from "./async-mutex";
 export interface CoordinatorStorageView {
   get<T>(key: string, options?: { noCache?: boolean }): Promise<T | undefined>;
   put<T>(key: string, value: T, options?: { noCache?: boolean }): Promise<void>;
@@ -275,24 +276,14 @@ export class CloudflareCoordinatorRuntime implements CoordinatorRuntime {
   readonly storage: CoordinatorStorage;
   readonly ephemeralWebSocketMaxPayloadBytes = 32 * 1024 * 1024;
   private readonly attachments = new WeakMap<WebSocket, unknown>();
-  private exclusiveTail = Promise.resolve();
+  private readonly exclusive = new AsyncMutex();
 
   constructor(private readonly state: DurableObjectState) {
     this.storage = state.storage;
   }
 
-  async runExclusive<T>(callback: () => Promise<T>): Promise<T> {
-    const predecessor = this.exclusiveTail;
-    let release!: () => void;
-    this.exclusiveTail = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    await predecessor;
-    try {
-      return await callback();
-    } finally {
-      release();
-    }
+  runExclusive<T>(callback: () => Promise<T>): Promise<T> {
+    return this.exclusive.run(callback);
   }
 
   createWebSocketUpgrade(

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1,5 +1,6 @@
 import ssh2, { type Client as SSHClient, type ClientChannel } from "ssh2";
 
+import { AsyncMutex, KeyedAsyncMutex } from "./async-mutex";
 import { AzureResumableProvisioning } from "./azure-provisioning";
 import {
   clearHostReservations,
@@ -1136,8 +1137,9 @@ export class FleetCoordinator {
   private readonly egressSessionStateHydrations = new Map<string, Promise<void>>();
   private readonly runtimeAdapterAgents = new Map<string, WebSocket>();
   private readonly runtimeAdapterPending = new Map<string, RuntimeAdapterPendingRequest>();
-  private readonly runtimeAdapterDeleteQueues = new Map<string, Promise<void>>();
-  private readonly daytonaSnapshotBootstrapQueues = new Map<string, Promise<void>>();
+  private readonly runtimeAdapterDeleteLocks = new KeyedAsyncMutex<string>();
+  // Same-name bootstraps must not observe another request's active snapshot.
+  private readonly daytonaSnapshotBootstrapLocks = new KeyedAsyncMutex<string>();
   private readonly controlSockets = new Map<string, WebSocket>();
   private readonly failedControlSockets = new WeakSet<WebSocket>();
   private readonly workspaceTerminals = new Map<string, Set<WebSocket>>();
@@ -1148,11 +1150,11 @@ export class FleetCoordinator {
   private readonly deviceMembershipCache = new Map<string, DeviceMembershipCacheEntry>();
   private currentAdminGrantVersion: string | undefined;
   private bridgeRestoreReady: Promise<boolean> | undefined;
-  private readyPoolBorrowQueue: Promise<void> = Promise.resolve();
-  private bridgeTicketQueue: Promise<void> = Promise.resolve();
+  private readonly readyPoolBorrowLock = new AsyncMutex();
+  private readonly bridgeTicketLock = new AsyncMutex();
   private readonly bridgeTickets: BridgeTickets;
-  private awsIngressBarrier: Promise<void> = Promise.resolve();
-  private providerMaintenanceQueue: Promise<void> = Promise.resolve();
+  private readonly awsIngressOperationLock = new AsyncMutex();
+  private readonly providerMaintenanceLock = new AsyncMutex();
   private readonly webVNCCredentialHandoffs: WebVNCCredentialHandoffs;
   private readonly leaseProvisioning: LeaseProvisioningController;
   private maintenanceRun: Promise<void> | undefined;
@@ -1204,7 +1206,7 @@ export class FleetCoordinator {
     );
     state.provisioning?.registerProvisioningTick(() => this.leaseProvisioning.tick());
     this.bridgeTickets = new BridgeTickets(state.storage, {
-      withLock: (operation) => this.withBridgeTicketLock(operation),
+      withLock: (operation) => this.bridgeTicketLock.run(operation),
       getLease: (id) => this.getLease(id),
       identifierMatchesLease,
       currentTicket: (ticket, lease) => this.currentLeaseBridgeTicket(ticket, lease),
@@ -3216,7 +3218,7 @@ export class FleetCoordinator {
     await this.webVNCCredentialHandoffs.cleanupExpired();
     await this.cleanupExpiredWebVNCPortalViewerAuth();
     await this.reconcileRuntimeAdapterDeletes(leaseIDs);
-    await this.withReadyPoolBorrowLock(() =>
+    await this.readyPoolBorrowLock.run(() =>
       this.state.runExclusive(() => this.maintainReadyPools(Date.now())),
     );
     await this.maintainWorkspacePrewarm();
@@ -4539,7 +4541,7 @@ export class FleetCoordinator {
       // Queued regional attempts must not restore access from their pre-provisioning snapshot.
       withLeaseAccess: (target, operation, observe) => {
         const ingressQueuedAt = Date.now();
-        return this.withAWSIngressOperationLock(async () => {
+        return this.awsIngressOperationLock.run(async () => {
           observe?.("ingress_wait", Date.now() - ingressQueuedAt);
           const lifecycleQueuedAt = Date.now();
           const access = await this.state.runExclusive(async () => {
@@ -7839,7 +7841,7 @@ export class FleetCoordinator {
     };
     const lease =
       managedProvider === "aws" && !committed.network?.awsPrivate
-        ? await this.withAWSIngressOperationLock(refresh)
+        ? await this.awsIngressOperationLock.run(refresh)
         : await refresh();
     return json({ lease: this.leaseForRequest(lease, request, isAdminRequest(request)) });
   }
@@ -8213,7 +8215,7 @@ export class FleetCoordinator {
         { status: 403 },
       );
     }
-    return await this.serializeRuntimeAdapterDelete(lease.id, async () => {
+    return await this.runtimeAdapterDeleteLocks.run(lease.id, async () => {
       const result = await this.finalizeRuntimeAdapterDeleteCompletion(
         lease,
         completion,
@@ -8274,7 +8276,7 @@ export class FleetCoordinator {
         { status: 403 },
       );
     }
-    return await this.serializeRuntimeAdapterDelete(lease.id, async () => {
+    return await this.runtimeAdapterDeleteLocks.run(lease.id, async () => {
       const result = await this.finalizeLegacyRuntimeAdapterDelete(
         lease,
         completion,
@@ -8349,7 +8351,7 @@ export class FleetCoordinator {
     lease: LeaseRecord,
     previousShare: NormalizedLeaseShare,
   ): Promise<void> {
-    await this.withBridgeTicketLock(async () => {
+    await this.bridgeTicketLock.run(async () => {
       await this.putLease(lease);
       if (leaseShareAccessShrank(previousShare, normalizedLeaseShare(lease.share))) {
         await this.revokeUnauthorizedLeaseBridges(lease);
@@ -9299,7 +9301,7 @@ export class FleetCoordinator {
         409,
       );
     }
-    return await this.serializeRuntimeAdapterDelete(lease.id, async () => {
+    return await this.runtimeAdapterDeleteLocks.run(lease.id, async () => {
       const current = await this.state.runExclusive(() => this.getLease(lease.id));
       if (!current || !leaseIsLive(current)) {
         return runtimeAdapterWorkspaceDeleteError(
@@ -9462,28 +9464,6 @@ export class FleetCoordinator {
         { status: 202 },
       );
     });
-  }
-
-  private async serializeRuntimeAdapterDelete<T>(
-    leaseID: string,
-    operation: () => Promise<T>,
-  ): Promise<T> {
-    const previous = this.runtimeAdapterDeleteQueues.get(leaseID) ?? Promise.resolve();
-    let release!: () => void;
-    const turn = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    const tail = previous.then(() => turn);
-    this.runtimeAdapterDeleteQueues.set(leaseID, tail);
-    await previous;
-    try {
-      return await operation();
-    } finally {
-      release();
-      if (this.runtimeAdapterDeleteQueues.get(leaseID) === tail) {
-        this.runtimeAdapterDeleteQueues.delete(leaseID);
-      }
-    }
   }
 
   private async markRuntimeAdapterDeletePending(
@@ -10089,7 +10069,7 @@ export class FleetCoordinator {
   }
 
   private async reconcileRuntimeAdapterDelete(lease: LeaseRecord): Promise<void> {
-    await this.serializeRuntimeAdapterDelete(lease.id, async () => {
+    await this.runtimeAdapterDeleteLocks.run(lease.id, async () => {
       const requestedAt = lease.runtimeAdapterDeleteRequestedAt;
       const adapterID = lease.runtimeAdapterID;
       const workspaceID = lease.runtimeAdapterWorkspaceID;
@@ -10934,7 +10914,7 @@ export class FleetCoordinator {
     if (!validWebVNCPortalViewerTicket(value)) {
       return undefined;
     }
-    return await this.withBridgeTicketLock(async () => {
+    return await this.bridgeTicketLock.run(async () => {
       const key = webVNCPortalViewerTicketKey(value);
       const ticket = await this.state.storage.get<WebVNCPortalViewerTicketRecord>(key);
       if (!ticket || ticket.ticket !== value) {
@@ -11059,7 +11039,7 @@ export class FleetCoordinator {
   private async consumeWebVNCPortalViewerCredentials(
     session: WebVNCPortalViewerSessionRecord,
   ): Promise<WebVNCCredentialHandoffResult> {
-    return await this.withBridgeTicketLock(async () => {
+    return await this.bridgeTicketLock.run(async () => {
       const key = webVNCPortalViewerSessionKey(session.session);
       const current = await this.state.storage.get<WebVNCPortalViewerSessionRecord>(key);
       const handoff = current?.credentialHandoffTicket;
@@ -11738,7 +11718,7 @@ export class FleetCoordinator {
     if (!validCodeViewerTicket(value)) {
       return undefined;
     }
-    return await this.withBridgeTicketLock(async () => {
+    return await this.bridgeTicketLock.run(async () => {
       const key = codeViewerTicketKey(value);
       const ticket = await this.state.storage.get<CodeViewerTicketRecord>(key);
       if (
@@ -11843,7 +11823,7 @@ export class FleetCoordinator {
         const expiresAt = Number.isFinite(tokenExpiresAt)
           ? Math.min(revocationExpiresAt, tokenExpiresAt)
           : revocationExpiresAt;
-        await this.withBridgeTicketLock(async () => {
+        await this.bridgeTicketLock.run(async () => {
           await this.state.storage.put<CodeViewerSessionRevocationRecord>(
             codeViewerSessionRevocationKey(portalSessionHash),
             {
@@ -11937,7 +11917,7 @@ export class FleetCoordinator {
     agent: WebSocket,
     bridgeGrant: CachedBridgeGrant,
   ): Promise<Response> {
-    return await this.withBridgeTicketLock(async () => {
+    return await this.bridgeTicketLock.run(async () => {
       const currentLease = await this.resolvePortalLease(lease.id, request);
       if (!currentLease) {
         return notFound();
@@ -12331,7 +12311,7 @@ export class FleetCoordinator {
         { status: 426 },
       );
     }
-    return await this.withBridgeTicketLock(async () => {
+    return await this.bridgeTicketLock.run(async () => {
       const lease = await this.resolvePortalLease(identifier, request);
       if (!lease) {
         return notFound();
@@ -12566,7 +12546,7 @@ export class FleetCoordinator {
     if (!validRuntimeAdapterTicket(value)) {
       return { status: "invalid" };
     }
-    return this.withBridgeTicketLock(async () => {
+    return this.bridgeTicketLock.run(async () => {
       const key = runtimeAdapterTicketKey(value);
       const ticket = await this.state.storage.get<RuntimeAdapterTicketRecord>(key);
       if (!ticket || ticket.ticket !== value || !isCurrentOrgKey(ticket.org)) {
@@ -12818,13 +12798,13 @@ export class FleetCoordinator {
     request: Request,
     typed = false,
   ): Promise<ReadyPoolEntry[]> {
-    return await this.withReadyPoolBorrowLock(() =>
+    return await this.readyPoolBorrowLock.run(() =>
       this.state.runExclusive(() => this.readyPoolStatusSnapshot(request, key, typed)),
     );
   }
 
   private async allReadyPoolStatus(request: Request): Promise<ReadyPoolEntry[]> {
-    return await this.withReadyPoolBorrowLock(() =>
+    return await this.readyPoolBorrowLock.run(() =>
       this.state.runExclusive(() => this.readyPoolStatusSnapshot(request)),
     );
   }
@@ -12972,7 +12952,7 @@ export class FleetCoordinator {
         { status: 409 },
       );
     }
-    return await this.withReadyPoolBorrowLock(() =>
+    return await this.readyPoolBorrowLock.run(() =>
       this.state.runExclusive(async () => {
         const lease = await this.getLease(leaseID);
         if (!lease) return notFound();
@@ -13131,7 +13111,7 @@ export class FleetCoordinator {
     } else {
       delete input.compatibilityKey;
     }
-    return await this.withReadyPoolBorrowLock(async () => {
+    return await this.readyPoolBorrowLock.run(async () => {
       return await this.state.runExclusive(async () => {
         await this.incrementReadyPoolCounters(request, key, { borrowRequests: 1 }, typed);
         const entries = (await this.readyPoolStatusSnapshot(request, key, typed)).filter((entry) =>
@@ -13234,7 +13214,7 @@ export class FleetCoordinator {
     if (!borrowToken) {
       return json({ error: "borrow_token_required" }, { status: 400 });
     }
-    return await this.withReadyPoolBorrowLock(() =>
+    return await this.readyPoolBorrowLock.run(() =>
       this.state.runExclusive(async () => {
         const current = await this.getReadyPoolEntry(key, leaseID, typed);
         const lease = await this.getLease(leaseID);
@@ -13349,7 +13329,7 @@ export class FleetCoordinator {
       ...(compatibilityKey ? { compatibilityKey } : {}),
     });
     const nowMs = Date.now();
-    return await this.withReadyPoolBorrowLock(() =>
+    return await this.readyPoolBorrowLock.run(() =>
       this.state.runExclusive(async () => {
         await this.maintainReadyPools(nowMs);
         const owner = requestOwner(request);
@@ -13502,7 +13482,7 @@ export class FleetCoordinator {
     if (!token) {
       return json({ error: "fill_claim_token_required" }, { status: 400 });
     }
-    return await this.withReadyPoolBorrowLock(() =>
+    return await this.readyPoolBorrowLock.run(() =>
       this.state.runExclusive(async () => {
         const claim = await this.state.storage.get<ReadyPoolFillClaim>(
           readyPoolFillClaimKey(token, typed),
@@ -13523,7 +13503,7 @@ export class FleetCoordinator {
   }
 
   private async readyPoolMetrics(request: Request, key: string): Promise<Response> {
-    return await this.withReadyPoolBorrowLock(() =>
+    return await this.readyPoolBorrowLock.run(() =>
       this.state.runExclusive(async () => {
         await this.maintainReadyPools(Date.now());
         const leases = new Map((await this.leaseRecords()).map((lease) => [lease.id, lease]));
@@ -13559,7 +13539,7 @@ export class FleetCoordinator {
     if (!validLeaseID(leaseID)) {
       return json({ error: "invalid_lease_id" }, { status: 400 });
     }
-    return await this.withReadyPoolBorrowLock(async () => {
+    return await this.readyPoolBorrowLock.run(async () => {
       const current = await this.getReadyPoolEntry(key, leaseID, typed);
       if (!current) {
         return notFound();
@@ -14105,7 +14085,7 @@ export class FleetCoordinator {
         { status: 400 },
       );
     }
-    return await this.withDaytonaSnapshotBootstrapLock(name, async () => {
+    return await this.daytonaSnapshotBootstrapLocks.run(name, async () => {
       const result = await new DaytonaClient(this.env).bootstrapSnapshot(
         name,
         cpu,
@@ -17235,7 +17215,7 @@ export class FleetCoordinator {
     }
     for (const target of work) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- one fence protects all shared AWS ingress mutations.
-      await this.withAWSIngressOperationLock(async () => {
+      await this.awsIngressOperationLock.run(async () => {
         const fresh = await this.state.runExclusive(async () => {
           const stored = await this.state.storage.get<StoredAWSIngressReconcileRecord>(
             awsIngressReconcileRecordKey,
@@ -17429,7 +17409,7 @@ export class FleetCoordinator {
     trigger: "alarm" | "admin",
     requestedConfig?: AWSOrphanSweepConfig,
   ): Promise<AWSOrphanSweepRecord | undefined> {
-    return this.withProviderMaintenanceLock(async () => {
+    return this.providerMaintenanceLock.run(async () => {
       const config = requestedConfig ?? this.awsOrphanSweepConfig();
       if (!config.enabled) {
         return undefined;
@@ -17730,7 +17710,7 @@ export class FleetCoordinator {
     trigger: "alarm" | "admin",
     requestedConfig?: AzureOrphanSweepConfig,
   ): Promise<AzureOrphanSweepRecord | undefined> {
-    return this.withProviderMaintenanceLock(async () => {
+    return this.providerMaintenanceLock.run(async () => {
       const config = requestedConfig ?? this.azureOrphanSweepConfig();
       if (!config.enabled) {
         return undefined;
@@ -18329,91 +18309,6 @@ export class FleetCoordinator {
 
   private async deleteReadyPoolEntry(entry: ReadyPoolEntry, typed = false): Promise<void> {
     await this.state.storage.delete(readyPoolKey(entry.key, entry.leaseID, typed));
-  }
-
-  private async withReadyPoolBorrowLock<T>(operation: () => Promise<T>): Promise<T> {
-    let release!: () => void;
-    const previous = this.readyPoolBorrowQueue.catch(() => {});
-    const next = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    this.readyPoolBorrowQueue = previous.then(() => next);
-    await previous;
-    try {
-      return await operation();
-    } finally {
-      release();
-    }
-  }
-
-  private async withBridgeTicketLock<T>(operation: () => Promise<T>): Promise<T> {
-    let release!: () => void;
-    const previous = this.bridgeTicketQueue.catch(() => {});
-    const next = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    this.bridgeTicketQueue = previous.then(() => next);
-    await previous;
-    try {
-      return await operation();
-    } finally {
-      release();
-    }
-  }
-
-  private async withAWSIngressOperationLock<T>(operation: () => Promise<T>): Promise<T> {
-    let release!: () => void;
-    const previous = this.awsIngressBarrier.catch(() => {});
-    const gate = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    this.awsIngressBarrier = previous.then(() => gate);
-    await previous;
-    try {
-      return await operation();
-    } finally {
-      release();
-    }
-  }
-
-  private async withProviderMaintenanceLock<T>(operation: () => Promise<T>): Promise<T> {
-    let release!: () => void;
-    const previous = this.providerMaintenanceQueue.catch(() => {});
-    const next = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    this.providerMaintenanceQueue = previous.then(() => next);
-    await previous;
-    try {
-      return await operation();
-    } finally {
-      release();
-    }
-  }
-
-  private async withDaytonaSnapshotBootstrapLock<T>(
-    name: string,
-    operation: () => Promise<T>,
-  ): Promise<T> {
-    let release!: () => void;
-    const previous =
-      this.daytonaSnapshotBootstrapQueues.get(name)?.catch(() => {}) ?? Promise.resolve();
-    const next = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    const tail = previous.then(() => next);
-    this.daytonaSnapshotBootstrapQueues.set(name, tail);
-    await previous;
-    try {
-      // Daytona exposes async snapshot completion by name, so same-name
-      // bootstraps must not overlap and observe another request's active row.
-      return await operation();
-    } finally {
-      release();
-      if (this.daytonaSnapshotBootstrapQueues.get(name) === tail) {
-        this.daytonaSnapshotBootstrapQueues.delete(name);
-      }
-    }
   }
 
   private async recentRuns(
@@ -19562,7 +19457,7 @@ export class FleetCoordinator {
   private withLeaseCleanupState<T>(lease: LeaseRecord, operation: () => Promise<T>): Promise<T> {
     const commit = () => this.state.runExclusive(operation);
     return managedLeaseProvider(lease) === "aws" && !lease.network?.awsPrivate
-      ? this.withAWSIngressOperationLock(commit)
+      ? this.awsIngressOperationLock.run(commit)
       : commit();
   }
 

--- a/worker/test/async-mutex.test.ts
+++ b/worker/test/async-mutex.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { AsyncMutex, KeyedAsyncMutex } from "../src/async-mutex";
+
+describe("operation mutexes", () => {
+  it("preserves FIFO ordering and releases after a rejected operation", async () => {
+    const mutex = new AsyncMutex();
+    const events: number[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const failure = new Error("operation failed");
+    const first = mutex.run(async () => {
+      events.push(1);
+      await gate;
+      throw failure;
+    });
+    const firstOutcome = first.catch((error: unknown) => error);
+    const second = mutex.run(async () => {
+      events.push(2);
+      return "second";
+    });
+    const third = mutex.run(async () => {
+      events.push(3);
+    });
+    await Promise.resolve();
+    expect(events).toEqual([1]);
+    release();
+    expect(await firstOutcome).toBe(failure);
+    expect(await second).toBe("second");
+    await third;
+    await mutex.drain();
+    expect(events).toEqual([1, 2, 3]);
+  });
+
+  it("keeps different keys concurrent and all same-key waiters serialized", async () => {
+    const mutex = new KeyedAsyncMutex<string>();
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    const first = mutex.run("same", async () => {
+      events.push("first");
+      await firstGate;
+    });
+    const second = mutex.run("same", async () => {
+      events.push("second");
+      await secondGate;
+    });
+    await mutex.run("other", async () => {
+      events.push("other");
+    });
+    expect(events).toEqual(["first", "other"]);
+    releaseFirst();
+    await first;
+    const third = mutex.run("same", async () => {
+      events.push("third");
+    });
+    await Promise.resolve();
+    expect(events).toEqual(["first", "other", "second"]);
+    releaseSecond();
+    await Promise.all([second, third]);
+    expect(events).toEqual(["first", "other", "second", "third"]);
+    await expect(mutex.run("same", async () => "reused")).resolves.toBe("reused");
+  });
+
+  it("releases a keyed turn after a synchronous throw", async () => {
+    const mutex = new KeyedAsyncMutex<string>();
+    const failure = new Error("synchronous failure");
+    await expect(
+      mutex.run("key", () => {
+        throw failure;
+      }),
+    ).rejects.toBe(failure);
+    await expect(mutex.run("key", async () => 7)).resolves.toBe(7);
+  });
+});

--- a/worker/test/aws-cleanup-recovery.postgres.test.ts
+++ b/worker/test/aws-cleanup-recovery.postgres.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, expect, it, vi } from "vitest";
 
 import { NodeCoordinatorRuntime } from "../node/node-runtime";
-import { AsyncMutex } from "../node/server-support";
+import { AsyncMutex } from "../src/async-mutex";
 import type { AWSLegacyCleanupAudit } from "../src/aws-cleanup-recovery";
 import type { CoordinatorStorageView } from "../src/coordinator-runtime";
 import { AWSProvider, FleetCoordinator } from "../src/fleet";

--- a/worker/test/capacity.test.ts
+++ b/worker/test/capacity.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { AsyncMutex, fleetRequestQueue } from "../node/server-support";
+import { fleetRequestQueue } from "../node/server-support";
+import { AsyncMutex } from "../src/async-mutex";
 import { issueUserToken } from "../src/auth";
 import { routeCoordinatorRequest } from "../src/coordinator-entry";
 import {

--- a/worker/test/node-runtime.test.ts
+++ b/worker/test/node-runtime.test.ts
@@ -5,6 +5,7 @@ import { createServer } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocket as NodeWebSocket } from "ws";
 
+import { AsyncMutex } from "../src/async-mutex";
 import { routeCoordinatorRequest } from "../src/coordinator-entry";
 import type { CoordinatorStorageView } from "../src/coordinator-runtime";
 import { FleetCoordinator } from "../src/fleet";
@@ -61,7 +62,7 @@ vi.mock("../node/postgres-storage", () => ({
 }));
 
 import { NodeCoordinatorRuntime } from "../node/node-runtime";
-import { AsyncMutex, fleetRequestQueue } from "../node/server-support";
+import { fleetRequestQueue } from "../node/server-support";
 
 describe("NodeCoordinatorRuntime", () => {
   beforeEach(() => {

--- a/worker/test/server-support.test.ts
+++ b/worker/test/server-support.test.ts
@@ -5,7 +5,6 @@ import { Writable } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 
 import {
-  AsyncMutex,
   AsyncOperationTracker,
   RequestBodyTooLargeError,
   closeServer,
@@ -27,6 +26,7 @@ import {
   validateTrustedProxyCIDRs,
   writeNodeResponseBody,
 } from "../node/server-support";
+import { AsyncMutex } from "../src/async-mutex";
 import { runtimeAdapterRelayBodyLimit } from "../src/runtime-adapter-relay";
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {


### PR DESCRIPTION
Coordinator borrowing, bridge tickets, ingress, maintenance, and keyed resource operations maintained separate copies of the same promise-queue algorithm. Use one FIFO mutex implementation shared with Node lifecycle handling, plus a keyed variant that retains an entry until its last active or waiting operation finishes.

Each operation domain still owns its own lock. Runtime deletions remain keyed by lease ID and Daytona snapshot bootstraps by name. Rejected or synchronously throwing operations release their turn; unrelated keys stay concurrent.

Validation: all 3,175 configured Worker tests passed (three existing environment-dependent skips), both TypeScript targets, lint/format, Worker build, and Node build passed on Crabbox. Added FIFO, failure-release, and keyed-concurrency tests; existing shutdown-drain tests also passed. Scoped Codex review passed. No dependency, configuration, or credential changes.

The first Go CI run exposed an existing test-instrumentation race: completion was reported before its active-operation counter was retired. The follow-up fixes that ordering without changing ownership implementation; the test passed 200 local race-enabled repetitions.