### PR TITLE
refactor(sandbox): share compatible control-plane contracts

### DIFF
--- a/docs/providers/cubesandbox.md
+++ b/docs/providers/cubesandbox.md
@@ -166,6 +166,10 @@ that a later stream trailer or sandbox deletion succeeded.
 The envd Connect wire codec is shared with E2B; this abnormal-end policy and
 CubeProxy routing remain CubeSandbox-owned.
 
+The compatible control plane also shares sandbox record types, returned-ID
+validation, and cursor pagination with E2B. Authentication, creation payloads,
+response-error decoding, and envd endpoint routing stay in each adapter.
+
 ## Gotchas
 
 - `--class` and `--type` are rejected; choose the template and CubeSandbox node

--- a/internal/providers/cubesandbox/backend.go
+++ b/internal/providers/cubesandbox/backend.go
@@ -126,9 +126,9 @@ func (b *cubesandboxBackend) Warmup(ctx context.Context, req core.WarmupRequest)
 }
 
 func (b *cubesandboxBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
-	var client cubesandboxAPI
+	var client shared.EnvdSandboxAPI
 	var processUser, leaseID, sandboxID, slug string
-	var session cubesandboxSession
+	var session shared.EnvdSandboxSession
 	workspace := cubesandboxWorkspacePath(b.cfg)
 	boundSandbox := func() shared.DelegatedSandbox {
 		return shared.DelegatedSandbox{LeaseID: leaseID, Slug: slug, CleanupCommand: cubesandboxCleanupCommand(leaseID)}
@@ -155,7 +155,7 @@ func (b *cubesandboxBackend) Run(ctx context.Context, req core.RunRequest) (core
 			})
 		},
 		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
-			var sandbox cubesandboxSandbox
+			var sandbox shared.EnvdSandbox
 			var err error
 			leaseID, sandbox, slug, err = b.createSandbox(ctx, client, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
 			if err != nil {
@@ -201,7 +201,7 @@ func (b *cubesandboxBackend) Run(ctx context.Context, req core.RunRequest) (core
 			return shared.DelegatedSandboxCommand{
 				Text: strings.Join(req.Command, " "),
 				Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
-					return client.StartProcess(ctx, session, cubesandboxProcessRequest{
+					return client.StartProcess(ctx, session, shared.EnvdSandboxProcessRequest{
 						Command: command, CWD: workspace, Env: commandEnv, User: processUser,
 						Timeout: cubesandboxTimeoutDuration(b.cfg.TTL), Stdout: stdout, Stderr: stderr,
 					})
@@ -387,20 +387,20 @@ func (b *cubesandboxBackend) ReclaimAndStop(ctx context.Context, req core.StopRe
 	return nil
 }
 
-func (b *cubesandboxBackend) createSandbox(ctx context.Context, client cubesandboxAPI, repo core.Repo, keep, reclaim bool, requestedSlug string) (string, cubesandboxSandbox, string, error) {
+func (b *cubesandboxBackend) createSandbox(ctx context.Context, client shared.EnvdSandboxAPI, repo core.Repo, keep, reclaim bool, requestedSlug string) (string, shared.EnvdSandbox, string, error) {
 	leaseID := core.NewLeaseID()
 	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
-		return "", cubesandboxSandbox{}, "", err
+		return "", shared.EnvdSandbox{}, "", err
 	}
 	cfg := b.cfg
 	workspace, err := cleanCubeSandboxWorkspacePath(cubesandboxWorkspacePath(cfg))
 	if err != nil {
-		return "", cubesandboxSandbox{}, "", err
+		return "", shared.EnvdSandbox{}, "", err
 	}
 	template := strings.TrimSpace(b.cfg.CubeSandbox.Template)
 	if template == "" {
-		return "", cubesandboxSandbox{}, "", core.Exit(2, "provider=cubesandbox requires a template; set --cubesandbox-template, CUBE_TEMPLATE_ID, or cubeSandbox.template")
+		return "", shared.EnvdSandbox{}, "", core.Exit(2, "provider=cubesandbox requires a template; set --cubesandbox-template, CUBE_TEMPLATE_ID, or cubeSandbox.template")
 	}
 	cfg.TTL = cubesandboxTimeoutDuration(cfg.TTL)
 	cfg.ServerType = template
@@ -413,17 +413,17 @@ func (b *cubesandboxBackend) createSandbox(ctx context.Context, client cubesandb
 	}
 	timeoutSeconds := cubesandboxTimeoutSeconds(cfg.TTL)
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=cubesandbox lease=%s slug=%s template=%s timeout=%ds\n", leaseID, slug, template, timeoutSeconds)
-	sandbox, err := client.CreateSandbox(ctx, cubesandboxCreateSandboxRequest{
+	sandbox, err := client.CreateSandbox(ctx, shared.EnvdSandboxCreateRequest{
 		TemplateID:          template,
 		TimeoutSeconds:      timeoutSeconds,
 		Metadata:            labels,
 		AllowInternetAccess: true,
 	})
 	if err != nil {
-		return "", cubesandboxSandbox{}, "", cubesandboxError("create sandbox", err)
+		return "", shared.EnvdSandbox{}, "", cubesandboxError("create sandbox", err)
 	}
 	if sandbox.SandboxID == "" {
-		return "", cubesandboxSandbox{}, "", core.Exit(5, "cubesandbox create sandbox returned no sandbox id")
+		return "", shared.EnvdSandbox{}, "", core.Exit(5, "cubesandbox create sandbox returned no sandbox id")
 	}
 	cfg = cubesandboxClaimConfig(cfg)
 	server := cubesandboxSandboxToServer(sandbox)
@@ -431,14 +431,14 @@ func (b *cubesandboxBackend) createSandbox(ctx context.Context, client cubesandb
 		if cleanupErr := b.deleteSandboxForCleanup(client, sandbox.SandboxID); cleanupErr != nil {
 			leakErr := fmt.Errorf("cleanup cubesandbox sandbox %s after claim failure: %w; run `crabbox stop --provider cubesandbox --id %s --reclaim` to retry cleanup", sandbox.SandboxID, cleanupErr, sandbox.SandboxID)
 			fmt.Fprintf(b.rt.Stderr, "warning: %v\n", leakErr)
-			return "", cubesandboxSandbox{}, "", errors.Join(err, leakErr)
+			return "", shared.EnvdSandbox{}, "", errors.Join(err, leakErr)
 		}
-		return "", cubesandboxSandbox{}, "", err
+		return "", shared.EnvdSandbox{}, "", err
 	}
 	return leaseID, sandbox, slug, nil
 }
 
-func (b *cubesandboxBackend) deleteSandboxForCleanup(client cubesandboxAPI, sandboxID string) error {
+func (b *cubesandboxBackend) deleteSandboxForCleanup(client shared.EnvdSandboxAPI, sandboxID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), cubesandboxCleanupTimeout)
 	defer cancel()
 	return client.DeleteSandbox(ctx, sandboxID)
@@ -448,7 +448,7 @@ func cubesandboxCleanupCommand(leaseID string) string {
 	return fmt.Sprintf("crabbox stop --provider %s --id %s", providerName, core.ShellQuote(leaseID))
 }
 
-func (b *cubesandboxBackend) resolveSandboxID(ctx context.Context, client cubesandboxAPI, id, repoRoot string, reclaim bool) (string, string, string, error) {
+func (b *cubesandboxBackend) resolveSandboxID(ctx context.Context, client shared.EnvdSandboxAPI, id, repoRoot string, reclaim bool) (string, string, string, error) {
 	if id == "" {
 		return "", "", "", core.Exit(2, "provider=cubesandbox requires a Crabbox lease id, slug, or CubeSandbox sandbox id")
 	}
@@ -540,7 +540,7 @@ func validateCubeSandboxReclaimCollision(leaseID, sandboxID string, previous cor
 	return nil
 }
 
-func (b *cubesandboxBackend) resolveClaimedSandbox(ctx context.Context, client cubesandboxAPI, claim core.LeaseClaim, repoRoot string, reclaim bool) (string, string, string, error) {
+func (b *cubesandboxBackend) resolveClaimedSandbox(ctx context.Context, client shared.EnvdSandboxAPI, claim core.LeaseClaim, repoRoot string, reclaim bool) (string, string, string, error) {
 	cfg := cubesandboxClaimConfig(b.cfg)
 	if claim.ProviderScope != providerClaimScope(cfg) {
 		return "", "", "", core.Exit(4, "cubesandbox lease %q belongs to a different API endpoint; use --reclaim with the exact sandbox id to adopt it", claim.LeaseID)
@@ -576,7 +576,7 @@ func (b *cubesandboxBackend) resolveClaimedSandbox(ctx context.Context, client c
 	return claim.LeaseID, sandbox.SandboxID, claim.Slug, nil
 }
 
-func (b *cubesandboxBackend) deleteClaimedSandbox(ctx context.Context, client cubesandboxAPI, leaseID, sandboxID string) error {
+func (b *cubesandboxBackend) deleteClaimedSandbox(ctx context.Context, client shared.EnvdSandboxAPI, leaseID, sandboxID string) error {
 	cfg := cubesandboxClaimConfig(b.cfg)
 	claim, ok, exact, err := resolveLeaseClaimForProviderScopeWithExact(leaseID, providerClaimScope(cfg))
 	if err != nil {
@@ -617,7 +617,7 @@ func (e *cubesandboxClaimedSandboxMissingError) Error() string {
 	return fmt.Sprintf("cubesandbox sandbox %q for lease %q no longer exists", e.claim.CloudID, e.claim.LeaseID)
 }
 
-func validateCubeSandboxClaim(cfg core.Config, claim core.LeaseClaim, sandbox cubesandboxSandbox) error {
+func validateCubeSandboxClaim(cfg core.Config, claim core.LeaseClaim, sandbox shared.EnvdSandbox) error {
 	if claim.Provider != providerName || claim.ProviderScope != providerClaimScope(cubesandboxClaimConfig(cfg)) {
 		return core.Exit(4, "cubesandbox lease %q belongs to a different provider or API endpoint", claim.LeaseID)
 	}
@@ -638,7 +638,7 @@ func cubesandboxClaimConfig(cfg core.Config) core.Config {
 	return cfg
 }
 
-func cubesandboxSandboxToServer(sandbox cubesandboxSandbox) core.Server {
+func cubesandboxSandboxToServer(sandbox shared.EnvdSandbox) core.Server {
 	labels := map[string]string{}
 	for k, v := range sandbox.Metadata {
 		labels[k] = v
@@ -666,7 +666,7 @@ func cubesandboxSandboxToServer(sandbox cubesandboxSandbox) core.Server {
 	return server
 }
 
-func cubesandboxStatusView(leaseID string, sandbox cubesandboxSandbox) core.StatusView {
+func cubesandboxStatusView(leaseID string, sandbox shared.EnvdSandbox) core.StatusView {
 	server := cubesandboxSandboxToServer(sandbox)
 	return core.StatusView{
 		ID:         leaseID,
@@ -691,14 +691,14 @@ func cubesandboxStatusReady(status string) bool {
 	}
 }
 
-func cubesandboxLeaseID(sandbox cubesandboxSandbox) string {
+func cubesandboxLeaseID(sandbox shared.EnvdSandbox) string {
 	if lease := strings.TrimSpace(sandbox.Metadata["lease"]); lease != "" {
 		return lease
 	}
 	return "cubesandbox_" + sandbox.SandboxID
 }
 
-func cubesandboxSlug(leaseID string, sandbox cubesandboxSandbox) string {
+func cubesandboxSlug(leaseID string, sandbox shared.EnvdSandbox) string {
 	if slug := strings.TrimSpace(sandbox.Metadata["slug"]); slug != "" {
 		return slug
 	}
@@ -709,7 +709,7 @@ func isCubeSandboxSyntheticID(id string) bool {
 	return strings.HasPrefix(id, "cubesandbox_") && len(id) > len("cubesandbox_")
 }
 
-func isCrabboxCubeSandboxSandbox(sandbox cubesandboxSandbox) bool {
+func isCrabboxCubeSandboxSandbox(sandbox shared.EnvdSandbox) bool {
 	return sandbox.Metadata["provider"] == providerName && sandbox.Metadata["crabbox"] == "true"
 }
 

--- a/internal/providers/cubesandbox/backend_test.go
+++ b/internal/providers/cubesandbox/backend_test.go
@@ -90,7 +90,7 @@ func TestCubeSandboxClientRedactsReflectedCredentials(t *testing.T) {
 			}, nil
 		})}
 		client := &cubesandboxClient{envdClient: httpClient}
-		_, err := client.StartProcess(context.Background(), cubesandboxSession{SandboxID: "sbx_1", Domain: "example.test", EnvdAccessToken: secret}, cubesandboxProcessRequest{Command: "true"})
+		_, err := client.StartProcess(context.Background(), shared.EnvdSandboxSession{SandboxID: "sbx_1", Domain: "example.test", EnvdAccessToken: secret}, shared.EnvdSandboxProcessRequest{Command: "true"})
 		testutil.RequireRedactedProviderError(t, err, secret)
 	})
 }
@@ -247,7 +247,7 @@ func TestCubeSandboxDataPlaneStreamOutlivesControlTimeout(t *testing.T) {
 		envdClient:  routedDataPlaneClient,
 	}
 	started := time.Now()
-	code, err := client.StartProcess(t.Context(), cubesandboxSession{SandboxID: "sbx_1", Domain: "cube.test"}, cubesandboxProcessRequest{Command: "true"})
+	code, err := client.StartProcess(t.Context(), shared.EnvdSandboxSession{SandboxID: "sbx_1", Domain: "cube.test"}, shared.EnvdSandboxProcessRequest{Command: "true"})
 	if err != nil || code != 0 {
 		t.Fatalf("StartProcess code=%d err=%v", code, err)
 	}
@@ -383,11 +383,11 @@ func TestCubeSandboxClientBindsObservedSandboxID(t *testing.T) {
 				}
 				var id, token string
 				if operation == "connect" {
-					var session cubesandboxSession
+					var session shared.EnvdSandboxSession
 					session, err = client.ConnectSandbox(t.Context(), "sbx_a", 120)
 					id, token = session.SandboxID, session.EnvdAccessToken
 				} else {
-					var sandbox cubesandboxSandbox
+					var sandbox shared.EnvdSandbox
 					sandbox, err = client.GetSandbox(t.Context(), "sbx_a")
 					id, token = sandbox.SandboxID, sandbox.EnvdAccessToken
 				}
@@ -472,7 +472,7 @@ func TestCubeSandboxClientCreateConnectListAndDeleteUseOfficialRESTShape(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	sandbox, err := api.CreateSandbox(t.Context(), cubesandboxCreateSandboxRequest{
+	sandbox, err := api.CreateSandbox(t.Context(), shared.EnvdSandboxCreateRequest{
 		TemplateID:          "base",
 		TimeoutSeconds:      60,
 		AllowInternetAccess: true,
@@ -575,7 +575,7 @@ func TestCubeSandboxClientRoutesEnvdToPort49983(t *testing.T) {
 		domain:      "cube.test",
 		proxyScheme: "http",
 	}
-	session := cubesandboxSession{SandboxID: "sbx_1", Domain: "cube.test"}
+	session := shared.EnvdSandboxSession{SandboxID: "sbx_1", Domain: "cube.test"}
 	endpoint := client.envdURL(session, "/process.Process/Start")
 	if got, want := endpoint, "http://49983-sbx_1.cube.test/process.Process/Start"; got != want {
 		t.Fatalf("endpoint=%q, want %q", got, want)
@@ -624,7 +624,7 @@ func TestCubeSandboxHTTPSProxyPreservesVirtualHostForSNI(t *testing.T) {
 		httpClient:  source,
 		envdClient:  envdClient,
 	}
-	session := cubesandboxSession{SandboxID: "sbx_1", Domain: "cube.test", EnvdAccessToken: "test-token"}
+	session := shared.EnvdSandboxSession{SandboxID: "sbx_1", Domain: "cube.test", EnvdAccessToken: "test-token"}
 	if err := client.UploadFile(t.Context(), session, "/tmp/proof", strings.NewReader("proof")); err != nil {
 		t.Fatal(err)
 	}
@@ -642,7 +642,7 @@ func TestCubeSandboxClientFollowsSameOriginRedirect(t *testing.T) {
 			http.Redirect(w, r, "/redirected", http.StatusTemporaryRedirect)
 		case "/redirected":
 			redirectedAuth = r.Header.Get("Authorization")
-			_ = json.NewEncoder(w).Encode([]cubesandboxSandbox{})
+			_ = json.NewEncoder(w).Encode([]shared.EnvdSandbox{})
 		default:
 			http.NotFound(w, r)
 		}
@@ -686,7 +686,7 @@ func TestCubeSandboxClientPreservesCallerRedirectPolicy(t *testing.T) {
 
 func TestCubeSandboxUploadFileRejectsMalformedDomainBeforeProducer(t *testing.T) {
 	client := &cubesandboxClient{apiKey: "cubesandbox_test", domain: "%zz", httpClient: http.DefaultClient}
-	err := client.UploadFile(context.Background(), cubesandboxSession{SandboxID: "sbx_1"}, "/tmp/archive.tgz", strings.NewReader("archive"))
+	err := client.UploadFile(context.Background(), shared.EnvdSandboxSession{SandboxID: "sbx_1"}, "/tmp/archive.tgz", strings.NewReader("archive"))
 	if err == nil {
 		t.Fatal("UploadFile err=nil, want malformed URL error")
 	}
@@ -723,7 +723,7 @@ func TestCubeSandboxSyncWorkspaceUploadsRepoArchive(t *testing.T) {
 		rt:  core.Runtime{Stderr: io.Discard},
 	}
 	workspace := cubesandboxWorkspacePath(backend.cfg)
-	_, _, err := backend.syncWorkspace(context.Background(), client, cubesandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
+	_, _, err := backend.syncWorkspace(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
 		Repo: core.Repo{Root: root, Name: "repo"},
 	}, workspace)
 	if err != nil {
@@ -782,7 +782,7 @@ func TestCubeSandboxSyncWorkspaceCleansRemoteArchiveWhenExtractFails(t *testing.
 		rt:  core.Runtime{Stderr: io.Discard},
 	}
 	workspace := cubesandboxWorkspacePath(backend.cfg)
-	_, _, err := backend.syncWorkspace(context.Background(), client, cubesandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
+	_, _, err := backend.syncWorkspace(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
 		Repo: core.Repo{Root: root, Name: "repo"},
 	}, workspace)
 	if err == nil {
@@ -810,7 +810,7 @@ func TestCubeSandboxPrepareWorkspaceRejectsUnsafePath(t *testing.T) {
 		cfg: cfg,
 		rt:  core.Runtime{Stderr: io.Discard},
 	}
-	err := backend.prepareWorkspace(context.Background(), client, cubesandboxSession{SandboxID: "sbx_1"}, "/")
+	err := backend.prepareWorkspace(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, "/")
 	if err == nil || !strings.Contains(err.Error(), "too broad") {
 		t.Fatalf("err=%v, want unsafe workspace error", err)
 	}
@@ -822,7 +822,7 @@ func TestCubeSandboxPrepareWorkspaceRejectsUnsafePath(t *testing.T) {
 func TestCubeSandboxPrepareWorkspacePreservesExistingWithoutSync(t *testing.T) {
 	client := &fakeCubeSandboxSyncClient{}
 	backend := &cubesandboxBackend{rt: core.Runtime{Stderr: io.Discard}}
-	if err := backend.prepareWorkspace(context.Background(), client, cubesandboxSession{SandboxID: "sbx_1"}, "/root/repo"); err != nil {
+	if err := backend.prepareWorkspace(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, "/root/repo"); err != nil {
 		t.Fatal(err)
 	}
 	if len(client.commands) != 1 || client.commands[0] != "mkdir -p '/root/repo'" {
@@ -1179,7 +1179,7 @@ func TestCubeSandboxRunPreservesAbnormalProcessExitCode(t *testing.T) {
 }
 
 func TestCubeSandboxSandboxToServerUsesMetadata(t *testing.T) {
-	server := cubesandboxSandboxToServer(cubesandboxSandbox{
+	server := cubesandboxSandboxToServer(shared.EnvdSandbox{
 		SandboxID:  "sbx_1",
 		TemplateID: "base",
 		State:      "running",
@@ -1202,7 +1202,7 @@ func TestCubeSandboxResolveSyntheticIDRequiresCrabboxMetadata(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	backend := &cubesandboxBackend{}
 	client := &fakeCubeSandboxSyncClient{
-		sandbox: cubesandboxSandbox{
+		sandbox: shared.EnvdSandbox{
 			SandboxID: "sbx_1",
 			Metadata:  map[string]string{"provider": "other"},
 		},
@@ -1268,7 +1268,7 @@ func TestCubeSandboxCreateBindsExactSandboxAndEndpoint(t *testing.T) {
 
 func TestCubeSandboxStopRejectsLabelledButUnclaimedSandbox(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	client := &fakeCubeSandboxSyncClient{sandbox: cubesandboxSandbox{
+	client := &fakeCubeSandboxSyncClient{sandbox: shared.EnvdSandbox{
 		SandboxID: "sbx_unclaimed",
 		Metadata: map[string]string{
 			"provider": providerName,
@@ -1429,7 +1429,7 @@ func TestCubeSandboxStopRejectsDifferentAPIEndpointBeforeRemoteRead(t *testing.T
 
 func TestCubeSandboxReclaimAndStopAdoptsExactSandbox(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	client := &fakeCubeSandboxSyncClient{sandbox: cubesandboxSandbox{
+	client := &fakeCubeSandboxSyncClient{sandbox: shared.EnvdSandbox{
 		SandboxID: "sbx_reclaim",
 		Metadata: map[string]string{
 			"provider": providerName,
@@ -1456,7 +1456,7 @@ func TestCubeSandboxReclaimAndStopPreservesRepoBoundClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	const leaseID = "cbx_123456789abc"
 	firstCfg := core.Config{Provider: providerName, CubeSandbox: core.CubeSandboxConfig{APIURL: "https://cube-a.example.test"}}
-	sandbox := cubesandboxSandbox{
+	sandbox := shared.EnvdSandbox{
 		SandboxID: "sbx_reclaim",
 		Metadata: map[string]string{
 			"provider": providerName,
@@ -1497,7 +1497,7 @@ func TestCubeSandboxReclaimRejectsCrossProviderLeaseCollision(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			client := &fakeCubeSandboxSyncClient{sandbox: cubesandboxSandbox{
+			client := &fakeCubeSandboxSyncClient{sandbox: shared.EnvdSandbox{
 				SandboxID: "sbx_reclaim",
 				Metadata: map[string]string{
 					"provider": providerName,
@@ -1536,7 +1536,7 @@ func TestCubeSandboxReclaimScopesCloudIDCollisionToEndpoint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client := &fakeCubeSandboxSyncClient{sandbox: cubesandboxSandbox{
+	client := &fakeCubeSandboxSyncClient{sandbox: shared.EnvdSandbox{
 		SandboxID: "same-sandbox-id",
 		Metadata: map[string]string{
 			"provider": providerName,
@@ -1571,8 +1571,8 @@ func TestCubeSandboxReclaimScopesCloudIDCollisionToEndpoint(t *testing.T) {
 type fakeCubeSandboxSyncClient struct {
 	commands          []string
 	users             []string
-	sandbox           cubesandboxSandbox
-	createReq         cubesandboxCreateSandboxRequest
+	sandbox           shared.EnvdSandbox
+	createReq         shared.EnvdSandboxCreateRequest
 	createCalls       int
 	getIDs            []string
 	getErr            error
@@ -1587,35 +1587,35 @@ type fakeCubeSandboxSyncClient struct {
 	processEnvs       []map[string]string
 }
 
-func swapNewCubeSandboxClient(fake cubesandboxAPI) func() {
+func swapNewCubeSandboxClient(fake shared.EnvdSandboxAPI) func() {
 	prev := newCubeSandboxClient
-	newCubeSandboxClient = func(core.Config, core.Runtime) (cubesandboxAPI, error) { return fake, nil }
+	newCubeSandboxClient = func(core.Config, core.Runtime) (shared.EnvdSandboxAPI, error) { return fake, nil }
 	return func() { newCubeSandboxClient = prev }
 }
 
-func (f *fakeCubeSandboxSyncClient) CreateSandbox(_ context.Context, req cubesandboxCreateSandboxRequest) (cubesandboxSandbox, error) {
+func (f *fakeCubeSandboxSyncClient) CreateSandbox(_ context.Context, req shared.EnvdSandboxCreateRequest) (shared.EnvdSandbox, error) {
 	f.createReq = req
 	f.createCalls++
 	if f.sandbox.SandboxID != "" {
 		return f.sandbox, nil
 	}
-	f.sandbox = cubesandboxSandbox{SandboxID: "sbx_1", Metadata: req.Metadata, State: "running"}
+	f.sandbox = shared.EnvdSandbox{SandboxID: "sbx_1", Metadata: req.Metadata, State: "running"}
 	return f.sandbox, nil
 }
 
-func (f *fakeCubeSandboxSyncClient) ConnectSandbox(context.Context, string, int) (cubesandboxSession, error) {
-	return cubesandboxSession{}, f.connectErr
+func (f *fakeCubeSandboxSyncClient) ConnectSandbox(context.Context, string, int) (shared.EnvdSandboxSession, error) {
+	return shared.EnvdSandboxSession{}, f.connectErr
 }
 
-func (f *fakeCubeSandboxSyncClient) GetSandbox(_ context.Context, sandboxID string) (cubesandboxSandbox, error) {
+func (f *fakeCubeSandboxSyncClient) GetSandbox(_ context.Context, sandboxID string) (shared.EnvdSandbox, error) {
 	f.getIDs = append(f.getIDs, sandboxID)
 	if f.getErr != nil {
-		return cubesandboxSandbox{}, f.getErr
+		return shared.EnvdSandbox{}, f.getErr
 	}
 	return f.sandbox, nil
 }
 
-func (f *fakeCubeSandboxSyncClient) ListSandboxes(context.Context, map[string]string) ([]cubesandboxSandbox, error) {
+func (f *fakeCubeSandboxSyncClient) ListSandboxes(context.Context, map[string]string) ([]shared.EnvdSandbox, error) {
 	return nil, nil
 }
 
@@ -1628,13 +1628,13 @@ func (f *fakeCubeSandboxSyncClient) DeleteSandbox(ctx context.Context, sandboxID
 	return f.deleteErr
 }
 
-func (f *fakeCubeSandboxSyncClient) UploadFile(_ context.Context, _ cubesandboxSession, targetPath string, r io.Reader) error {
+func (f *fakeCubeSandboxSyncClient) UploadFile(_ context.Context, _ shared.EnvdSandboxSession, targetPath string, r io.Reader) error {
 	f.uploadPath = targetPath
 	_, err := io.Copy(&f.uploaded, r)
 	return err
 }
 
-func (f *fakeCubeSandboxSyncClient) StartProcess(_ context.Context, _ cubesandboxSession, req cubesandboxProcessRequest) (int, error) {
+func (f *fakeCubeSandboxSyncClient) StartProcess(_ context.Context, _ shared.EnvdSandboxSession, req shared.EnvdSandboxProcessRequest) (int, error) {
 	f.commands = append(f.commands, req.Command)
 	f.users = append(f.users, req.User)
 	f.processEnvs = append(f.processEnvs, req.Env)

--- a/internal/providers/cubesandbox/client.go
+++ b/internal/providers/cubesandbox/client.go
@@ -2,7 +2,6 @@ package cubesandbox
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -15,16 +14,6 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
-
-type cubesandboxAPI interface {
-	CreateSandbox(context.Context, cubesandboxCreateSandboxRequest) (cubesandboxSandbox, error)
-	ConnectSandbox(context.Context, string, int) (cubesandboxSession, error)
-	GetSandbox(context.Context, string) (cubesandboxSandbox, error)
-	ListSandboxes(context.Context, map[string]string) ([]cubesandboxSandbox, error)
-	DeleteSandbox(context.Context, string) error
-	UploadFile(context.Context, cubesandboxSession, string, io.Reader) error
-	StartProcess(context.Context, cubesandboxSession, cubesandboxProcessRequest) (int, error)
-}
 
 type cubesandboxClient struct {
 	apiKey      string
@@ -41,48 +30,6 @@ const (
 	cubesandboxControlTimeout = 60 * time.Second
 )
 
-type cubesandboxCreateSandboxRequest struct {
-	TemplateID          string
-	TimeoutSeconds      int
-	Metadata            map[string]string
-	AllowInternetAccess bool
-}
-
-type cubesandboxSandbox struct {
-	TemplateID      string            `json:"templateID"`
-	SandboxID       string            `json:"sandboxID"`
-	ClientID        string            `json:"clientID"`
-	StartedAt       string            `json:"startedAt"`
-	EndAt           string            `json:"endAt"`
-	EnvdVersion     string            `json:"envdVersion"`
-	EnvdAccessToken string            `json:"envdAccessToken"`
-	TrafficToken    string            `json:"trafficAccessToken"`
-	Alias           string            `json:"alias"`
-	Domain          string            `json:"domain"`
-	State           string            `json:"state"`
-	CPUCount        int               `json:"cpuCount"`
-	MemoryMB        int               `json:"memoryMB"`
-	DiskSizeMB      int               `json:"diskSizeMB"`
-	Metadata        map[string]string `json:"metadata"`
-}
-
-type cubesandboxSession struct {
-	SandboxID       string
-	EnvdVersion     string
-	EnvdAccessToken string
-	Domain          string
-}
-
-type cubesandboxProcessRequest struct {
-	Command string
-	CWD     string
-	Env     map[string]string
-	User    string
-	Timeout time.Duration
-	Stdout  io.Writer
-	Stderr  io.Writer
-}
-
 type cubesandboxAPIError struct {
 	StatusCode int
 	Status     string
@@ -96,7 +43,7 @@ func (e *cubesandboxAPIError) Error() string {
 	return e.Status + ": " + e.Body
 }
 
-var newCubeSandboxClient = func(cfg core.Config, rt core.Runtime) (cubesandboxAPI, error) {
+var newCubeSandboxClient = func(cfg core.Config, rt core.Runtime) (shared.EnvdSandboxAPI, error) {
 	apiKey := strings.TrimSpace(cfg.CubeSandbox.APIKey)
 	httpClient, dataPlaneClient := shared.ControlAndDataHTTPClients(rt.HTTP, cubesandboxControlTimeout)
 	apiURL, err := validateCubeSandboxAPIURL(core.Blank(cfg.CubeSandbox.APIURL, "http://127.0.0.1:3000"))
@@ -210,7 +157,7 @@ func cubeSandboxRedirectError(destination *url.URL) error {
 	return fmt.Errorf("cubesandbox refused cross-origin redirect to %s", destination.Redacted())
 }
 
-func (c *cubesandboxClient) CreateSandbox(ctx context.Context, req cubesandboxCreateSandboxRequest) (cubesandboxSandbox, error) {
+func (c *cubesandboxClient) CreateSandbox(ctx context.Context, req shared.EnvdSandboxCreateRequest) (shared.EnvdSandbox, error) {
 	body := map[string]any{
 		"templateID": req.TemplateID,
 		"timeout":    req.TimeoutSeconds,
@@ -219,88 +166,30 @@ func (c *cubesandboxClient) CreateSandbox(ctx context.Context, req cubesandboxCr
 	if !req.AllowInternetAccess {
 		body["allowInternetAccess"] = false
 	}
-	var sandbox cubesandboxSandbox
-	if err := c.doJSON(ctx, http.MethodPost, "/sandboxes", nil, body, &sandbox); err != nil {
-		return cubesandboxSandbox{}, err
-	}
-	if sandbox.Metadata == nil {
-		sandbox.Metadata = req.Metadata
-	}
-	if sandbox.State == "" {
-		sandbox.State = "running"
-	}
-	return sandbox, nil
+	return c.control().CreateSandbox(ctx, body, req.Metadata)
 }
 
-func (c *cubesandboxClient) ConnectSandbox(ctx context.Context, sandboxID string, timeoutSeconds int) (cubesandboxSession, error) {
-	if timeoutSeconds <= 0 {
-		timeoutSeconds = 300
-	}
-	body := map[string]any{"timeout": timeoutSeconds}
-	var sandbox cubesandboxSandbox
-	if err := c.doJSON(ctx, http.MethodPost, "/sandboxes/"+url.PathEscape(sandboxID)+"/connect", nil, body, &sandbox); err != nil {
-		return cubesandboxSession{}, err
-	}
-	if shared.ValidateResourceID(sandboxID, sandbox.SandboxID) != nil {
-		return cubesandboxSession{}, errors.New("connect sandbox returned a different or missing sandbox ID")
+func (c *cubesandboxClient) ConnectSandbox(ctx context.Context, sandboxID string, timeoutSeconds int) (shared.EnvdSandboxSession, error) {
+	sandbox, err := c.control().ConnectSandbox(ctx, sandboxID, timeoutSeconds)
+	if err != nil {
+		return shared.EnvdSandboxSession{}, err
 	}
 	return c.sessionFromSandbox(sandbox), nil
 }
 
-func (c *cubesandboxClient) GetSandbox(ctx context.Context, sandboxID string) (cubesandboxSandbox, error) {
-	var sandbox cubesandboxSandbox
-	if err := c.doJSON(ctx, http.MethodGet, "/sandboxes/"+url.PathEscape(sandboxID), nil, nil, &sandbox); err != nil {
-		return cubesandboxSandbox{}, err
-	}
-	if shared.ValidateResourceID(sandboxID, sandbox.SandboxID) != nil {
-		return cubesandboxSandbox{}, errors.New("get sandbox returned a different or missing sandbox ID")
-	}
-	if sandbox.Metadata == nil {
-		sandbox.Metadata = map[string]string{}
-	}
-	return sandbox, nil
+func (c *cubesandboxClient) GetSandbox(ctx context.Context, sandboxID string) (shared.EnvdSandbox, error) {
+	return c.control().GetSandbox(ctx, sandboxID)
 }
 
-func (c *cubesandboxClient) ListSandboxes(ctx context.Context, metadata map[string]string) ([]cubesandboxSandbox, error) {
-	var all []cubesandboxSandbox
-	nextToken := ""
-	for {
-		query := url.Values{}
-		query.Set("limit", "100")
-		query.Set("state", "running,paused")
-		if nextToken != "" {
-			query.Set("nextToken", nextToken)
-		}
-		if len(metadata) > 0 {
-			values := url.Values{}
-			for key, value := range metadata {
-				values.Set(key, value)
-			}
-			query.Set("metadata", values.Encode())
-		}
-		var page []cubesandboxSandbox
-		headers, err := c.doJSONWithHeaders(ctx, http.MethodGet, "/v2/sandboxes", query, nil, &page)
-		if err != nil {
-			return nil, err
-		}
-		for i := range page {
-			if page[i].Metadata == nil {
-				page[i].Metadata = map[string]string{}
-			}
-		}
-		all = append(all, page...)
-		nextToken = headers.Get("x-next-token")
-		if nextToken == "" {
-			return all, nil
-		}
-	}
+func (c *cubesandboxClient) ListSandboxes(ctx context.Context, metadata map[string]string) ([]shared.EnvdSandbox, error) {
+	return c.control().ListSandboxes(ctx, metadata)
 }
 
 func (c *cubesandboxClient) DeleteSandbox(ctx context.Context, sandboxID string) error {
-	return c.doJSON(ctx, http.MethodDelete, "/sandboxes/"+url.PathEscape(sandboxID), nil, nil, nil)
+	return c.control().DeleteSandbox(ctx, sandboxID)
 }
 
-func (c *cubesandboxClient) UploadFile(ctx context.Context, session cubesandboxSession, targetPath string, r io.Reader) error {
+func (c *cubesandboxClient) UploadFile(ctx context.Context, session shared.EnvdSandboxSession, targetPath string, r io.Reader) error {
 	return shared.UploadEnvdFile(ctx, shared.EnvdUploadFileRequest{
 		Endpoint:       c.envdURL(session, "/files"),
 		TargetPath:     targetPath,
@@ -317,32 +206,21 @@ func (c *cubesandboxClient) UploadFile(ctx context.Context, session cubesandboxS
 	})
 }
 
-func (c *cubesandboxClient) StartProcess(ctx context.Context, session cubesandboxSession, req cubesandboxProcessRequest) (int, error) {
+func (c *cubesandboxClient) StartProcess(ctx context.Context, session shared.EnvdSandboxSession, req shared.EnvdSandboxProcessRequest) (int, error) {
 	return shared.StartEnvdProcess(ctx, shared.EnvdProcessRequest{
-		Endpoint:       c.envdURL(session, "/process.Process/Start"),
-		Command:        req.Command,
-		CWD:            req.CWD,
-		Env:            req.Env,
-		User:           req.User,
-		Timeout:        req.Timeout,
-		Stdout:         req.Stdout,
-		Stderr:         req.Stderr,
-		AccessToken:    session.EnvdAccessToken,
-		HTTPClient:     c.dataPlaneHTTPClient(),
-		SetHeaders:     func(httpReq *http.Request) { c.setEnvdHeaders(httpReq, session) },
-		RedirectError:  cubeSandboxRedirectError,
-		Provider:       "cubesandbox",
-		InterpretEnd:   interpretCubeSandboxProcessEnd,
-		SummarizeError: core.SummarizeJSON,
+		EnvdSandboxProcessRequest: req,
+		Endpoint:                  c.envdURL(session, "/process.Process/Start"),
+		AccessToken:               session.EnvdAccessToken,
+		HTTPClient:                c.dataPlaneHTTPClient(),
+		SetHeaders:                func(httpReq *http.Request) { c.setEnvdHeaders(httpReq, session) },
+		RedirectError:             cubeSandboxRedirectError,
+		Provider:                  "cubesandbox",
+		InterpretEnd:              interpretCubeSandboxProcessEnd,
+		SummarizeError:            core.SummarizeJSON,
 		APIError: func(statusCode int, status, body string) error {
 			return &cubesandboxAPIError{StatusCode: statusCode, Status: status, Body: body}
 		},
 	})
-}
-
-func (c *cubesandboxClient) doJSON(ctx context.Context, method, path string, query url.Values, body any, out any) error {
-	_, err := c.doJSONWithHeaders(ctx, method, path, query, body, out)
-	return err
 }
 
 func (c *cubesandboxClient) doJSONWithHeaders(ctx context.Context, method, path string, query url.Values, body any, out any) (http.Header, error) {
@@ -374,12 +252,12 @@ func (c *cubesandboxClient) doJSONWithHeaders(ctx context.Context, method, path 
 	return resp.Header.Clone(), nil
 }
 
-func (c *cubesandboxClient) sessionFromSandbox(sandbox cubesandboxSandbox) cubesandboxSession {
+func (c *cubesandboxClient) sessionFromSandbox(sandbox shared.EnvdSandbox) shared.EnvdSandboxSession {
 	domain := strings.TrimSpace(sandbox.Domain)
 	if domain == "" {
 		domain = c.domain
 	}
-	return cubesandboxSession{
+	return shared.EnvdSandboxSession{
 		SandboxID:       sandbox.SandboxID,
 		EnvdVersion:     sandbox.EnvdVersion,
 		EnvdAccessToken: sandbox.EnvdAccessToken,
@@ -387,7 +265,7 @@ func (c *cubesandboxClient) sessionFromSandbox(sandbox cubesandboxSandbox) cubes
 	}
 }
 
-func (c *cubesandboxClient) envdURL(session cubesandboxSession, path string) string {
+func (c *cubesandboxClient) envdURL(session shared.EnvdSandboxSession, path string) string {
 	domain := strings.TrimSpace(session.Domain)
 	if domain == "" {
 		domain = c.domain
@@ -400,7 +278,7 @@ func (c *cubesandboxClient) envdURL(session cubesandboxSession, path string) str
 	return scheme + "://" + virtualHost + path
 }
 
-func (c *cubesandboxClient) setEnvdHeaders(req *http.Request, session cubesandboxSession) {
+func (c *cubesandboxClient) setEnvdHeaders(req *http.Request, session shared.EnvdSandboxSession) {
 	req.Header.Set("X-Access-Token", session.EnvdAccessToken)
 	req.Header.Set("E2b-Sandbox-Id", session.SandboxID)
 	req.Header.Set("E2b-Sandbox-Port", strconv.Itoa(cubesandboxEnvdPort))
@@ -431,4 +309,8 @@ func interpretCubeSandboxProcessEnd(end shared.EnvdProcessEnd, stderr io.Writer,
 		code = 1
 	}
 	return code, shared.ObservedProcessEndError(fmt.Sprintf("cubesandbox process did not exit normally: %s", detail))
+}
+
+func (c *cubesandboxClient) control() shared.EnvdSandboxControl {
+	return shared.EnvdSandboxControl{Request: c.doJSONWithHeaders}
 }

--- a/internal/providers/cubesandbox/sync.go
+++ b/internal/providers/cubesandbox/sync.go
@@ -9,9 +9,10 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func (b *cubesandboxBackend) syncWorkspace(ctx context.Context, client cubesandboxAPI, session cubesandboxSession, req core.RunRequest, workspace string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
+func (b *cubesandboxBackend) syncWorkspace(ctx context.Context, client shared.EnvdSandboxAPI, session shared.EnvdSandboxSession, req core.RunRequest, workspace string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	workspace, err := cleanCubeSandboxWorkspacePath(workspace)
 	if err != nil {
 		return nil, 0, err
@@ -40,7 +41,7 @@ func (b *cubesandboxBackend) syncWorkspace(ctx context.Context, client cubesandb
 	}, prepared...)
 }
 
-func (b *cubesandboxBackend) prepareWorkspace(ctx context.Context, client cubesandboxAPI, session cubesandboxSession, workspace string) error {
+func (b *cubesandboxBackend) prepareWorkspace(ctx context.Context, client shared.EnvdSandboxAPI, session shared.EnvdSandboxSession, workspace string) error {
 	workspace, err := cleanCubeSandboxWorkspacePath(workspace)
 	if err != nil {
 		return err
@@ -64,12 +65,12 @@ func cleanCubeSandboxWorkspacePath(workspace string) (string, error) {
 	return clean, nil
 }
 
-func (b *cubesandboxBackend) execShell(ctx context.Context, client cubesandboxAPI, session cubesandboxSession, command string, stdout io.Writer) error {
+func (b *cubesandboxBackend) execShell(ctx context.Context, client shared.EnvdSandboxAPI, session shared.EnvdSandboxSession, command string, stdout io.Writer) error {
 	user, err := cubesandboxProcessUser(b.cfg.CubeSandbox.User)
 	if err != nil {
 		return err
 	}
-	code, err := client.StartProcess(ctx, session, cubesandboxProcessRequest{
+	code, err := client.StartProcess(ctx, session, shared.EnvdSandboxProcessRequest{
 		Command: command,
 		User:    user,
 		Timeout: b.cfg.TTL,

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -79,8 +79,8 @@ func (b *e2bBackend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 func (b *e2bBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	var processUser string
 	workspace := e2bWorkspacePath(b.cfg)
-	var client e2bAPI
-	var session e2bSession
+	var client shared.EnvdSandboxAPI
+	var session shared.EnvdSandboxSession
 	var leaseID, sandboxID, slug string
 	handle := func() shared.DelegatedSandbox {
 		return shared.DelegatedSandbox{LeaseID: leaseID, Slug: slug, CleanupCommand: e2bCleanupCommand(leaseID)}
@@ -107,7 +107,7 @@ func (b *e2bBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResu
 			})
 		},
 		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
-			var sandbox e2bSandbox
+			var sandbox shared.EnvdSandbox
 			var err error
 			leaseID, sandbox, slug, err = b.createSandbox(ctx, client, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
 			sandboxID = sandbox.SandboxID
@@ -140,7 +140,7 @@ func (b *e2bBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResu
 			command := intent.ShellSource()
 			return shared.DelegatedSandboxCommand{Run: func(ctx context.Context, stdout, stderr io.Writer) (int, error) {
 				fmt.Fprintf(b.rt.Stderr, "running on e2b %s\n", strings.Join(req.Command, " "))
-				return client.StartProcess(ctx, session, e2bProcessRequest{
+				return client.StartProcess(ctx, session, shared.EnvdSandboxProcessRequest{
 					Command: command, CWD: workspace, Env: req.Env, User: processUser,
 					Timeout: e2bTimeoutDuration(b.cfg.TTL), Stdout: stdout, Stderr: stderr,
 				})
@@ -336,17 +336,17 @@ func (b *e2bBackend) ReclaimAndStop(ctx context.Context, req core.StopRequest) e
 	return nil
 }
 
-func (b *e2bBackend) createSandbox(ctx context.Context, client e2bAPI, repo core.Repo, keep, reclaim bool, requestedSlug string) (string, e2bSandbox, string, error) {
+func (b *e2bBackend) createSandbox(ctx context.Context, client shared.EnvdSandboxAPI, repo core.Repo, keep, reclaim bool, requestedSlug string) (string, shared.EnvdSandbox, string, error) {
 	leaseID := core.NewLeaseID()
 	slug, err := core.AllocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
-		return "", e2bSandbox{}, "", err
+		return "", shared.EnvdSandbox{}, "", err
 	}
 	template := core.Blank(b.cfg.E2B.Template, core.E2BConfigDefaultTemplate)
 	cfg := b.cfg
 	workspace, err := cleanE2BWorkspacePath(e2bWorkspacePath(cfg))
 	if err != nil {
-		return "", e2bSandbox{}, "", err
+		return "", shared.EnvdSandbox{}, "", err
 	}
 	cfg.TTL = e2bTimeoutDuration(cfg.TTL)
 	cfg.ServerType = template
@@ -359,31 +359,31 @@ func (b *e2bBackend) createSandbox(ctx context.Context, client e2bAPI, repo core
 	}
 	timeoutSeconds := e2bTimeoutSeconds(cfg.TTL)
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=e2b lease=%s slug=%s template=%s timeout=%ds\n", leaseID, slug, template, timeoutSeconds)
-	sandbox, err := client.CreateSandbox(ctx, e2bCreateSandboxRequest{
+	sandbox, err := client.CreateSandbox(ctx, shared.EnvdSandboxCreateRequest{
 		TemplateID:          template,
 		TimeoutSeconds:      timeoutSeconds,
 		Metadata:            labels,
 		AllowInternetAccess: true,
 	})
 	if err != nil {
-		return "", e2bSandbox{}, "", e2bError("create sandbox", err)
+		return "", shared.EnvdSandbox{}, "", e2bError("create sandbox", err)
 	}
 	if sandbox.SandboxID == "" {
-		return "", e2bSandbox{}, "", core.Exit(5, "e2b create sandbox returned no sandbox id")
+		return "", shared.EnvdSandbox{}, "", core.Exit(5, "e2b create sandbox returned no sandbox id")
 	}
 	cfg = e2bClaimConfig(cfg)
 	if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, e2bSandboxToServer(sandbox), core.SSHTarget{}, repo.Root, cfg.IdleTimeout, reclaim); err != nil {
 		if cleanupErr := b.deleteSandboxForCleanup(client, sandbox.SandboxID); cleanupErr != nil {
 			leakErr := fmt.Errorf("cleanup e2b sandbox %s after claim failure: %w; run `crabbox stop --provider e2b --id %s --reclaim` to retry cleanup", sandbox.SandboxID, cleanupErr, sandbox.SandboxID)
 			fmt.Fprintf(b.rt.Stderr, "warning: %v\n", leakErr)
-			return "", e2bSandbox{}, "", errors.Join(err, leakErr)
+			return "", shared.EnvdSandbox{}, "", errors.Join(err, leakErr)
 		}
-		return "", e2bSandbox{}, "", err
+		return "", shared.EnvdSandbox{}, "", err
 	}
 	return leaseID, sandbox, slug, nil
 }
 
-func (b *e2bBackend) deleteSandboxForCleanup(client e2bAPI, sandboxID string) error {
+func (b *e2bBackend) deleteSandboxForCleanup(client shared.EnvdSandboxAPI, sandboxID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), e2bCleanupTimeout)
 	defer cancel()
 	return client.DeleteSandbox(ctx, sandboxID)
@@ -393,24 +393,24 @@ func e2bCleanupCommand(leaseID string) string {
 	return fmt.Sprintf("crabbox stop --provider %s --id %s", e2bProvider, core.ShellQuote(leaseID))
 }
 
-func (b *e2bBackend) resolveStopTarget(ctx context.Context, client e2bAPI, id string) (core.LeaseClaim, e2bSandbox, error) {
+func (b *e2bBackend) resolveStopTarget(ctx context.Context, client shared.EnvdSandboxAPI, id string) (core.LeaseClaim, shared.EnvdSandbox, error) {
 	if id == "" {
-		return core.LeaseClaim{}, e2bSandbox{}, core.Exit(2, "provider=e2b requires a Crabbox lease id, slug, or E2B sandbox id")
+		return core.LeaseClaim{}, shared.EnvdSandbox{}, core.Exit(2, "provider=e2b requires a Crabbox lease id, slug, or E2B sandbox id")
 	}
 	cfg := e2bClaimConfig(b.cfg)
 	claim, ok, exact, err := resolveLeaseClaimForProviderScopeWithExact(id, providerClaimScope(cfg))
 	if err != nil {
-		return core.LeaseClaim{}, e2bSandbox{}, err
+		return core.LeaseClaim{}, shared.EnvdSandbox{}, err
 	}
 	if exact && !ok {
 		if claim.Provider != e2bProvider {
-			return core.LeaseClaim{}, e2bSandbox{}, core.Exit(4, "e2b identifier %q is claimed by a different provider", id)
+			return core.LeaseClaim{}, shared.EnvdSandbox{}, core.Exit(4, "e2b identifier %q is claimed by a different provider", id)
 		}
-		return core.LeaseClaim{}, e2bSandbox{}, core.Exit(4, "e2b identifier %q is claimed for a different API endpoint", id)
+		return core.LeaseClaim{}, shared.EnvdSandbox{}, core.Exit(4, "e2b identifier %q is claimed for a different API endpoint", id)
 	}
 	if !ok {
 		if strings.HasPrefix(id, "cbx_") {
-			return core.LeaseClaim{}, e2bSandbox{}, core.Exit(4, "e2b lease %q has no exact local claim", id)
+			return core.LeaseClaim{}, shared.EnvdSandbox{}, core.Exit(4, "e2b lease %q has no exact local claim", id)
 		}
 		sandboxID := id
 		if isE2BSyntheticID(id) {
@@ -418,32 +418,32 @@ func (b *e2bBackend) resolveStopTarget(ctx context.Context, client e2bAPI, id st
 		}
 		claim, ok, err = resolveLeaseClaimForProviderCloudIDScope(sandboxID, providerClaimScope(cfg))
 		if err != nil {
-			return core.LeaseClaim{}, e2bSandbox{}, err
+			return core.LeaseClaim{}, shared.EnvdSandbox{}, err
 		}
 		if !ok {
-			return core.LeaseClaim{}, e2bSandbox{}, core.Exit(4, "e2b sandbox %q has no exact local claim; use --reclaim to adopt it explicitly", id)
+			return core.LeaseClaim{}, shared.EnvdSandbox{}, core.Exit(4, "e2b sandbox %q has no exact local claim; use --reclaim to adopt it explicitly", id)
 		}
 	}
 	if claim.ProviderScope != providerClaimScope(cfg) {
-		return core.LeaseClaim{}, e2bSandbox{}, core.Exit(4, "e2b lease %q belongs to a different API endpoint; use --reclaim with the exact sandbox id to adopt it", claim.LeaseID)
+		return core.LeaseClaim{}, shared.EnvdSandbox{}, core.Exit(4, "e2b lease %q belongs to a different API endpoint; use --reclaim with the exact sandbox id to adopt it", claim.LeaseID)
 	}
 	if strings.TrimSpace(claim.CloudID) == "" {
-		return core.LeaseClaim{}, e2bSandbox{}, core.Exit(4, "e2b lease %q has a legacy claim not bound to an exact sandbox; use --reclaim with the exact sandbox id to adopt it", claim.LeaseID)
+		return core.LeaseClaim{}, shared.EnvdSandbox{}, core.Exit(4, "e2b lease %q has a legacy claim not bound to an exact sandbox; use --reclaim with the exact sandbox id to adopt it", claim.LeaseID)
 	}
 	sandbox, err := client.GetSandbox(ctx, claim.CloudID)
 	if err != nil {
 		if isNotFoundError(err) {
-			return core.LeaseClaim{}, e2bSandbox{}, &e2bClaimedSandboxMissingError{claim: claim}
+			return core.LeaseClaim{}, shared.EnvdSandbox{}, &e2bClaimedSandboxMissingError{claim: claim}
 		}
-		return core.LeaseClaim{}, e2bSandbox{}, e2bError("get sandbox", err)
+		return core.LeaseClaim{}, shared.EnvdSandbox{}, e2bError("get sandbox", err)
 	}
 	if err := validateE2BClaim(cfg, claim, sandbox); err != nil {
-		return core.LeaseClaim{}, e2bSandbox{}, err
+		return core.LeaseClaim{}, shared.EnvdSandbox{}, err
 	}
 	return claim, sandbox, nil
 }
 
-func (b *e2bBackend) deleteClaimedSandbox(ctx context.Context, client e2bAPI, leaseID, sandboxID string) error {
+func (b *e2bBackend) deleteClaimedSandbox(ctx context.Context, client shared.EnvdSandboxAPI, leaseID, sandboxID string) error {
 	cfg := e2bClaimConfig(b.cfg)
 	claim, ok, exact, err := resolveLeaseClaimForProviderScopeWithExact(leaseID, providerClaimScope(cfg))
 	if err != nil {
@@ -497,7 +497,7 @@ func (e *e2bClaimedSandboxMissingError) Error() string {
 	return fmt.Sprintf("e2b sandbox %q for lease %q no longer exists", e.claim.CloudID, e.claim.LeaseID)
 }
 
-func validateE2BClaim(cfg core.Config, claim core.LeaseClaim, sandbox e2bSandbox) error {
+func validateE2BClaim(cfg core.Config, claim core.LeaseClaim, sandbox shared.EnvdSandbox) error {
 	if claim.Provider != e2bProvider || claim.ProviderScope != providerClaimScope(e2bClaimConfig(cfg)) {
 		return core.Exit(4, "e2b lease %q belongs to a different provider or API endpoint", claim.LeaseID)
 	}
@@ -518,7 +518,7 @@ func e2bClaimConfig(cfg core.Config) core.Config {
 	return cfg
 }
 
-func (b *e2bBackend) resolveSandboxID(ctx context.Context, client e2bAPI, id, repoRoot string, reclaim bool) (string, string, string, error) {
+func (b *e2bBackend) resolveSandboxID(ctx context.Context, client shared.EnvdSandboxAPI, id, repoRoot string, reclaim bool) (string, string, string, error) {
 	if id == "" {
 		return "", "", "", core.Exit(2, "provider=e2b requires a Crabbox lease id, slug, or E2B sandbox id")
 	}
@@ -595,20 +595,20 @@ func (b *e2bBackend) resolveSandboxID(ctx context.Context, client e2bAPI, id, re
 	return "", "", "", core.Exit(4, "e2b sandbox or claim %q was not found", id)
 }
 
-func resolveE2BSandboxByLease(ctx context.Context, client e2bAPI, leaseID string) (e2bSandbox, error) {
+func resolveE2BSandboxByLease(ctx context.Context, client shared.EnvdSandboxAPI, leaseID string) (shared.EnvdSandbox, error) {
 	sandboxes, err := client.ListSandboxes(ctx, map[string]string{"lease": leaseID, "provider": e2bProvider})
 	if err != nil {
-		return e2bSandbox{}, e2bError("list sandboxes", err)
+		return shared.EnvdSandbox{}, e2bError("list sandboxes", err)
 	}
 	for _, sandbox := range sandboxes {
 		if isCrabboxE2BSandbox(sandbox) {
 			return sandbox, nil
 		}
 	}
-	return e2bSandbox{}, core.Exit(4, "e2b lease %q was not found", leaseID)
+	return shared.EnvdSandbox{}, core.Exit(4, "e2b lease %q was not found", leaseID)
 }
 
-func e2bSandboxToServer(sandbox e2bSandbox) core.Server {
+func e2bSandboxToServer(sandbox shared.EnvdSandbox) core.Server {
 	labels := map[string]string{}
 	for k, v := range sandbox.Metadata {
 		labels[k] = v
@@ -636,7 +636,7 @@ func e2bSandboxToServer(sandbox e2bSandbox) core.Server {
 	return server
 }
 
-func e2bStatusView(leaseID string, sandbox e2bSandbox) core.StatusView {
+func e2bStatusView(leaseID string, sandbox shared.EnvdSandbox) core.StatusView {
 	server := e2bSandboxToServer(sandbox)
 	return core.StatusView{
 		ID:         leaseID,
@@ -661,14 +661,14 @@ func e2bStatusReady(status string) bool {
 	}
 }
 
-func e2bLeaseID(sandbox e2bSandbox) string {
+func e2bLeaseID(sandbox shared.EnvdSandbox) string {
 	if lease := strings.TrimSpace(sandbox.Metadata["lease"]); lease != "" {
 		return lease
 	}
 	return "e2b_" + sandbox.SandboxID
 }
 
-func e2bSlug(leaseID string, sandbox e2bSandbox) string {
+func e2bSlug(leaseID string, sandbox shared.EnvdSandbox) string {
 	if slug := strings.TrimSpace(sandbox.Metadata["slug"]); slug != "" {
 		return slug
 	}
@@ -679,7 +679,7 @@ func isE2BSyntheticID(id string) bool {
 	return strings.HasPrefix(id, "e2b_") && len(id) > len("e2b_")
 }
 
-func isCrabboxE2BSandbox(sandbox e2bSandbox) bool {
+func isCrabboxE2BSandbox(sandbox shared.EnvdSandbox) bool {
 	return sandbox.Metadata["provider"] == e2bProvider && sandbox.Metadata["crabbox"] == "true"
 }
 

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -110,7 +110,7 @@ func TestE2BClientRedactsReflectedCredentials(t *testing.T) {
 			}, nil
 		})}
 		client := &e2bClient{envdClient: httpClient}
-		_, err := client.StartProcess(context.Background(), e2bSession{SandboxID: "sbx_1", Domain: "example.test", EnvdAccessToken: secret}, e2bProcessRequest{Command: "true"})
+		_, err := client.StartProcess(context.Background(), shared.EnvdSandboxSession{SandboxID: "sbx_1", Domain: "example.test", EnvdAccessToken: secret}, shared.EnvdSandboxProcessRequest{Command: "true"})
 		testutil.RequireRedactedProviderError(t, err, secret)
 	})
 }
@@ -237,7 +237,7 @@ func TestE2BDataPlaneStreamOutlivesControlTimeout(t *testing.T) {
 		envdClient: e2bLoopbackClient(t, server, 0),
 	}
 	started := time.Now()
-	code, err := client.StartProcess(context.Background(), e2bSession{SandboxID: "sbx_1", Domain: "e2b.test"}, e2bProcessRequest{Command: "true"})
+	code, err := client.StartProcess(context.Background(), shared.EnvdSandboxSession{SandboxID: "sbx_1", Domain: "e2b.test"}, shared.EnvdSandboxProcessRequest{Command: "true"})
 	elapsed := time.Since(started)
 	if err != nil || code != 0 {
 		t.Fatalf("StartProcess code=%d err=%v", code, err)
@@ -287,7 +287,7 @@ func TestE2BDataPlaneUploadOutlivesControlTimeout(t *testing.T) {
 	}
 	reader := &e2bDelayedReader{data: payload, split: len("before-"), delay: 3 * controlTimeout}
 	started := time.Now()
-	err := client.UploadFile(context.Background(), e2bSession{SandboxID: "sbx_1", Domain: "e2b.test"}, "/tmp/archive.tgz", reader)
+	err := client.UploadFile(context.Background(), shared.EnvdSandboxSession{SandboxID: "sbx_1", Domain: "e2b.test"}, "/tmp/archive.tgz", reader)
 	elapsed := time.Since(started)
 	if err != nil {
 		t.Fatal(err)
@@ -637,11 +637,11 @@ func TestE2BClientBindsObservedSandboxID(t *testing.T) {
 				}
 				var id, token string
 				if operation == "connect" {
-					var session e2bSession
+					var session shared.EnvdSandboxSession
 					session, err = client.ConnectSandbox(t.Context(), "sbx_a", 120)
 					id, token = session.SandboxID, session.EnvdAccessToken
 				} else {
-					var sandbox e2bSandbox
+					var sandbox shared.EnvdSandbox
 					sandbox, err = client.GetSandbox(t.Context(), "sbx_a")
 					id, token = sandbox.SandboxID, sandbox.EnvdAccessToken
 				}
@@ -726,7 +726,7 @@ func TestE2BClientCreateConnectListAndDeleteUseOfficialRESTShape(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sandbox, err := api.CreateSandbox(t.Context(), e2bCreateSandboxRequest{
+	sandbox, err := api.CreateSandbox(t.Context(), shared.EnvdSandboxCreateRequest{
 		TemplateID:          "base",
 		TimeoutSeconds:      60,
 		AllowInternetAccess: true,
@@ -832,7 +832,7 @@ func TestE2BClientFollowsSameOriginRedirect(t *testing.T) {
 			http.Redirect(w, r, "/redirected", http.StatusTemporaryRedirect)
 		case "/redirected":
 			redirectedKey = r.Header.Get("X-API-Key")
-			_ = json.NewEncoder(w).Encode([]e2bSandbox{})
+			_ = json.NewEncoder(w).Encode([]shared.EnvdSandbox{})
 		default:
 			http.NotFound(w, r)
 		}
@@ -876,7 +876,7 @@ func TestE2BClientPreservesCallerRedirectPolicy(t *testing.T) {
 
 func TestE2BUploadFileRejectsMalformedDomainBeforeProducer(t *testing.T) {
 	client := &e2bClient{apiKey: "e2b_test", domain: "%zz", httpClient: http.DefaultClient}
-	err := client.UploadFile(context.Background(), e2bSession{SandboxID: "sbx_1"}, "/tmp/archive.tgz", strings.NewReader("archive"))
+	err := client.UploadFile(context.Background(), shared.EnvdSandboxSession{SandboxID: "sbx_1"}, "/tmp/archive.tgz", strings.NewReader("archive"))
 	if err == nil {
 		t.Fatal("UploadFile err=nil, want malformed URL error")
 	}
@@ -911,7 +911,7 @@ func TestE2BSyncWorkspaceUploadsRepoArchive(t *testing.T) {
 		rt:  core.Runtime{Stderr: io.Discard},
 	}
 	workspace := e2bWorkspacePath(backend.cfg)
-	_, _, err := backend.syncWorkspace(context.Background(), client, e2bSession{SandboxID: "sbx_1"}, core.RunRequest{
+	_, _, err := backend.syncWorkspace(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
 		Repo: core.Repo{Root: root, Name: "repo"},
 	}, workspace)
 	if err != nil {
@@ -953,7 +953,7 @@ func TestE2BSyncWorkspaceCleansRemoteArchiveWhenExtractFails(t *testing.T) {
 		rt:  core.Runtime{Stderr: io.Discard},
 	}
 	workspace := e2bWorkspacePath(backend.cfg)
-	_, _, err := backend.syncWorkspace(context.Background(), client, e2bSession{SandboxID: "sbx_1"}, core.RunRequest{
+	_, _, err := backend.syncWorkspace(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
 		Repo: core.Repo{Root: root, Name: "repo"},
 	}, workspace)
 	if err == nil {
@@ -995,7 +995,7 @@ func TestE2BSyncDeletePreservesWorkspaceWhenReplacementFails(t *testing.T) {
 			backend := &e2bBackend{rt: core.Runtime{Stderr: io.Discard}}
 			backend.cfg.Sync.Delete = true
 
-			_, _, err := backend.syncWorkspace(t.Context(), client, e2bSession{SandboxID: "sbx_1"}, core.RunRequest{
+			_, _, err := backend.syncWorkspace(t.Context(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
 				Repo: core.Repo{Root: root, Name: "repo"},
 			}, workspace)
 			if err == nil {
@@ -1022,7 +1022,7 @@ func TestE2BSyncWorkspaceHonorsConfiguredTimeout(t *testing.T) {
 	backend.cfg.Sync.Timeout = 500 * time.Millisecond
 	started := time.Now()
 
-	_, _, err := backend.syncWorkspace(t.Context(), client, e2bSession{SandboxID: "sbx_1"}, core.RunRequest{
+	_, _, err := backend.syncWorkspace(t.Context(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
 		Repo: core.Repo{Root: root, Name: "repo"},
 	}, "/home/user/repo")
 	if !errors.Is(err, context.DeadlineExceeded) {
@@ -1047,7 +1047,7 @@ func TestE2BPrepareWorkspaceRejectsUnsafePath(t *testing.T) {
 		cfg: cfg,
 		rt:  core.Runtime{Stderr: io.Discard},
 	}
-	err := backend.prepareWorkspace(context.Background(), client, e2bSession{SandboxID: "sbx_1"}, "/")
+	err := backend.prepareWorkspace(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, "/")
 	if err == nil || !strings.Contains(err.Error(), "too broad") {
 		t.Fatalf("err=%v, want unsafe workspace error", err)
 	}
@@ -1370,7 +1370,7 @@ func TestE2BRunCleanupUsesExactClaim(t *testing.T) {
 }
 
 func TestE2BSandboxToServerUsesMetadata(t *testing.T) {
-	server := e2bSandboxToServer(e2bSandbox{
+	server := e2bSandboxToServer(shared.EnvdSandbox{
 		SandboxID:  "sbx_1",
 		TemplateID: "base",
 		State:      "running",
@@ -1392,7 +1392,7 @@ func TestE2BSandboxToServerUsesMetadata(t *testing.T) {
 func TestE2BResolveSyntheticIDRequiresCrabboxMetadata(t *testing.T) {
 	backend := &e2bBackend{}
 	client := &fakeE2BSyncClient{
-		sandbox: e2bSandbox{
+		sandbox: shared.EnvdSandbox{
 			SandboxID: "sbx_1",
 			Metadata:  map[string]string{"provider": "other"},
 		},
@@ -1445,7 +1445,7 @@ func TestE2BCreateBindsExactSandboxAndEndpoint(t *testing.T) {
 
 func TestE2BStopRejectsLabelledButUnclaimedSandbox(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	client := &fakeE2BSyncClient{sandbox: e2bSandbox{
+	client := &fakeE2BSyncClient{sandbox: shared.EnvdSandbox{
 		SandboxID: "sbx_unclaimed",
 		Metadata: map[string]string{
 			"provider": e2bProvider,
@@ -1557,7 +1557,7 @@ func TestE2BStopRejectsDifferentAPIEndpointBeforeRemoteRead(t *testing.T) {
 
 func TestE2BReclaimAndStopAdoptsExactSandbox(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	client := &fakeE2BSyncClient{sandbox: e2bSandbox{
+	client := &fakeE2BSyncClient{sandbox: shared.EnvdSandbox{
 		SandboxID: "sbx_reclaim",
 		Metadata: map[string]string{
 			"provider": e2bProvider,
@@ -1583,12 +1583,12 @@ func TestE2BReclaimAndStopAdoptsExactSandbox(t *testing.T) {
 type fakeE2BSyncClient struct {
 	commands            []string
 	users               []string
-	sandbox             e2bSandbox
-	createReq           e2bCreateSandboxRequest
+	sandbox             shared.EnvdSandbox
+	createReq           shared.EnvdSandboxCreateRequest
 	createCalls         int
 	getIDs              []string
 	listFilters         []map[string]string
-	listedSandboxes     []e2bSandbox
+	listedSandboxes     []shared.EnvdSandbox
 	connectIDs          []string
 	getErr              error
 	getWaitForCancel    bool
@@ -1608,40 +1608,40 @@ type fakeE2BSyncClient struct {
 	processCodes        []int
 }
 
-func swapNewE2BClient(fake e2bAPI) func() {
+func swapNewE2BClient(fake shared.EnvdSandboxAPI) func() {
 	prev := newE2BClient
-	newE2BClient = func(core.Config, core.Runtime) (e2bAPI, error) { return fake, nil }
+	newE2BClient = func(core.Config, core.Runtime) (shared.EnvdSandboxAPI, error) { return fake, nil }
 	return func() { newE2BClient = prev }
 }
 
-func (f *fakeE2BSyncClient) CreateSandbox(_ context.Context, req e2bCreateSandboxRequest) (e2bSandbox, error) {
+func (f *fakeE2BSyncClient) CreateSandbox(_ context.Context, req shared.EnvdSandboxCreateRequest) (shared.EnvdSandbox, error) {
 	f.createReq = req
 	f.createCalls++
 	if f.sandbox.SandboxID != "" {
 		return f.sandbox, nil
 	}
-	f.sandbox = e2bSandbox{SandboxID: "sbx_1", Metadata: req.Metadata, State: "running"}
+	f.sandbox = shared.EnvdSandbox{SandboxID: "sbx_1", Metadata: req.Metadata, State: "running"}
 	return f.sandbox, nil
 }
 
-func (f *fakeE2BSyncClient) ConnectSandbox(_ context.Context, sandboxID string, _ int) (e2bSession, error) {
+func (f *fakeE2BSyncClient) ConnectSandbox(_ context.Context, sandboxID string, _ int) (shared.EnvdSandboxSession, error) {
 	f.connectIDs = append(f.connectIDs, sandboxID)
-	return e2bSession{}, f.connectErr
+	return shared.EnvdSandboxSession{}, f.connectErr
 }
 
-func (f *fakeE2BSyncClient) GetSandbox(ctx context.Context, sandboxID string) (e2bSandbox, error) {
+func (f *fakeE2BSyncClient) GetSandbox(ctx context.Context, sandboxID string) (shared.EnvdSandbox, error) {
 	f.getIDs = append(f.getIDs, sandboxID)
 	if f.getWaitForCancel && len(f.getIDs) > f.getWaitAfterCalls {
 		<-ctx.Done()
-		return e2bSandbox{}, ctx.Err()
+		return shared.EnvdSandbox{}, ctx.Err()
 	}
 	if f.getErr != nil {
-		return e2bSandbox{}, f.getErr
+		return shared.EnvdSandbox{}, f.getErr
 	}
 	return f.sandbox, nil
 }
 
-func (f *fakeE2BSyncClient) ListSandboxes(_ context.Context, filter map[string]string) ([]e2bSandbox, error) {
+func (f *fakeE2BSyncClient) ListSandboxes(_ context.Context, filter map[string]string) ([]shared.EnvdSandbox, error) {
 	f.listFilters = append(f.listFilters, filter)
 	return f.listedSandboxes, nil
 }
@@ -1655,7 +1655,7 @@ func (f *fakeE2BSyncClient) DeleteSandbox(ctx context.Context, sandboxID string)
 	return f.deleteErr
 }
 
-func (f *fakeE2BSyncClient) UploadFile(ctx context.Context, _ e2bSession, targetPath string, r io.Reader) error {
+func (f *fakeE2BSyncClient) UploadFile(ctx context.Context, _ shared.EnvdSandboxSession, targetPath string, r io.Reader) error {
 	f.uploadPath = targetPath
 	_, f.uploadDeadlineSet = ctx.Deadline()
 	if f.uploadWaitForCancel {
@@ -1674,7 +1674,7 @@ func (f *fakeE2BSyncClient) UploadFile(ctx context.Context, _ e2bSession, target
 	return nil
 }
 
-func (f *fakeE2BSyncClient) StartProcess(ctx context.Context, _ e2bSession, req e2bProcessRequest) (int, error) {
+func (f *fakeE2BSyncClient) StartProcess(ctx context.Context, _ shared.EnvdSandboxSession, req shared.EnvdSandboxProcessRequest) (int, error) {
 	f.commands = append(f.commands, req.Command)
 	f.users = append(f.users, req.User)
 	if strings.HasPrefix(req.Command, "rm -f ") {
@@ -1826,7 +1826,7 @@ func TestE2BRunCanonicalIDPreservesInventoryRecovery(t *testing.T) {
 				t.Fatal(err)
 			}
 			if state != "missing" {
-				client.listedSandboxes = []e2bSandbox{{SandboxID: "sbx_requested", Metadata: map[string]string{"lease": requestedID, "slug": "requested", "provider": e2bProvider, "crabbox": "true"}}}
+				client.listedSandboxes = []shared.EnvdSandbox{{SandboxID: "sbx_requested", Metadata: map[string]string{"lease": requestedID, "slug": "requested", "provider": e2bProvider, "crabbox": "true"}}}
 			}
 			if state == "legacy exact claim" {
 				if err := claimLeaseForRepoProvider(requestedID, "legacy", e2bProvider, repo.Root, time.Minute, false); err != nil {

--- a/internal/providers/e2b/bridge.go
+++ b/internal/providers/e2b/bridge.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 // E2B's bridge plane is built around the native per-sandbox preview URL
@@ -68,7 +69,7 @@ func (b *e2bBackend) bridgeSandboxCoords(ctx context.Context, leaseID string) (s
 	if err != nil {
 		return "", "", err
 	}
-	var sandbox e2bSandbox
+	var sandbox shared.EnvdSandbox
 	if isE2BSyntheticID(leaseID) {
 		sandboxID := strings.TrimPrefix(leaseID, "e2b_")
 		sandbox, err = client.GetSandbox(ctx, sandboxID)

--- a/internal/providers/e2b/bridge_test.go
+++ b/internal/providers/e2b/bridge_test.go
@@ -8,15 +8,16 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type fakeBridgeAPI struct {
 	fakeE2BSyncClient
-	listed  []e2bSandbox
+	listed  []shared.EnvdSandbox
 	listErr error
 }
 
-func (f *fakeBridgeAPI) ListSandboxes(_ context.Context, _ map[string]string) ([]e2bSandbox, error) {
+func (f *fakeBridgeAPI) ListSandboxes(_ context.Context, _ map[string]string) ([]shared.EnvdSandbox, error) {
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
@@ -26,7 +27,7 @@ func (f *fakeBridgeAPI) ListSandboxes(_ context.Context, _ map[string]string) ([
 func newBridgeBackend(t *testing.T, fake *fakeBridgeAPI) *e2bBackend {
 	t.Helper()
 	prev := newE2BClient
-	newE2BClient = func(core.Config, core.Runtime) (e2bAPI, error) { return fake, nil }
+	newE2BClient = func(core.Config, core.Runtime) (shared.EnvdSandboxAPI, error) { return fake, nil }
 	t.Cleanup(func() { newE2BClient = prev })
 	return &e2bBackend{
 		cfg: core.Config{Provider: e2bProvider, E2B: core.E2BConfig{APIKey: "key", Domain: "e2b.app"}},
@@ -36,7 +37,7 @@ func newBridgeBackend(t *testing.T, fake *fakeBridgeAPI) *e2bBackend {
 
 func TestE2BBridgeDomainAndPreviewDefaultPredicates(t *testing.T) {
 	for _, raw := range []string{"", "  ", " sandbox.example.invalid "} {
-		fake := &fakeBridgeAPI{fakeE2BSyncClient: fakeE2BSyncClient{sandbox: e2bSandbox{SandboxID: "example", Metadata: map[string]string{"provider": "e2b", "crabbox": "true"}}}}
+		fake := &fakeBridgeAPI{fakeE2BSyncClient: fakeE2BSyncClient{sandbox: shared.EnvdSandbox{SandboxID: "example", Metadata: map[string]string{"provider": "e2b", "crabbox": "true"}}}}
 		b := newBridgeBackend(t, fake)
 		b.cfg.E2B.Domain = raw
 		id, domain, err := b.bridgeSandboxCoords(context.Background(), "e2b_example")
@@ -67,7 +68,7 @@ func TestE2BBridgeDomainAndPreviewDefaultPredicates(t *testing.T) {
 
 func TestE2BPublishPeerReturnsCanonicalURL(t *testing.T) {
 	fake := &fakeBridgeAPI{
-		listed: []e2bSandbox{{
+		listed: []shared.EnvdSandbox{{
 			SandboxID: "sbx-abc123",
 			Domain:    "e2b.app",
 			Metadata: map[string]string{
@@ -95,7 +96,7 @@ func TestE2BPublishPeerReturnsCanonicalURL(t *testing.T) {
 func TestE2BPublishPeerAcceptsSyntheticLeaseID(t *testing.T) {
 	fake := &fakeBridgeAPI{
 		fakeE2BSyncClient: fakeE2BSyncClient{
-			sandbox: e2bSandbox{
+			sandbox: shared.EnvdSandbox{
 				SandboxID: "sbx_1",
 				Domain:    "e2b.app",
 				Metadata: map[string]string{
@@ -117,7 +118,7 @@ func TestE2BPublishPeerAcceptsSyntheticLeaseID(t *testing.T) {
 
 func TestE2BPublishPeerFallsBackToConfigDomain(t *testing.T) {
 	fake := &fakeBridgeAPI{
-		listed: []e2bSandbox{{
+		listed: []shared.EnvdSandbox{{
 			SandboxID: "sbx-z",
 			Domain:    "",
 			Metadata: map[string]string{
@@ -164,7 +165,7 @@ func TestE2BPublishPeerSurfacesAPIError(t *testing.T) {
 
 func TestE2BListPeerTargetsIsEmpty(t *testing.T) {
 	fake := &fakeBridgeAPI{
-		listed: []e2bSandbox{{
+		listed: []shared.EnvdSandbox{{
 			SandboxID: "sbx-y",
 			Domain:    "e2b.app",
 			Metadata: map[string]string{

--- a/internal/providers/e2b/client.go
+++ b/internal/providers/e2b/client.go
@@ -2,7 +2,6 @@ package e2b
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,16 +13,6 @@ import (
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-type e2bAPI interface {
-	CreateSandbox(context.Context, e2bCreateSandboxRequest) (e2bSandbox, error)
-	ConnectSandbox(context.Context, string, int) (e2bSession, error)
-	GetSandbox(context.Context, string) (e2bSandbox, error)
-	ListSandboxes(context.Context, map[string]string) ([]e2bSandbox, error)
-	DeleteSandbox(context.Context, string) error
-	UploadFile(context.Context, e2bSession, string, io.Reader) error
-	StartProcess(context.Context, e2bSession, e2bProcessRequest) (int, error)
-}
-
 type e2bClient struct {
 	apiKey     string
 	apiURL     string
@@ -34,48 +23,6 @@ type e2bClient struct {
 }
 
 const e2bControlTimeout = 60 * time.Second
-
-type e2bCreateSandboxRequest struct {
-	TemplateID          string
-	TimeoutSeconds      int
-	Metadata            map[string]string
-	AllowInternetAccess bool
-}
-
-type e2bSandbox struct {
-	TemplateID      string            `json:"templateID"`
-	SandboxID       string            `json:"sandboxID"`
-	ClientID        string            `json:"clientID"`
-	StartedAt       string            `json:"startedAt"`
-	EndAt           string            `json:"endAt"`
-	EnvdVersion     string            `json:"envdVersion"`
-	EnvdAccessToken string            `json:"envdAccessToken"`
-	TrafficToken    string            `json:"trafficAccessToken"`
-	Alias           string            `json:"alias"`
-	Domain          string            `json:"domain"`
-	State           string            `json:"state"`
-	CPUCount        int               `json:"cpuCount"`
-	MemoryMB        int               `json:"memoryMB"`
-	DiskSizeMB      int               `json:"diskSizeMB"`
-	Metadata        map[string]string `json:"metadata"`
-}
-
-type e2bSession struct {
-	SandboxID       string
-	EnvdVersion     string
-	EnvdAccessToken string
-	Domain          string
-}
-
-type e2bProcessRequest struct {
-	Command string
-	CWD     string
-	Env     map[string]string
-	User    string
-	Timeout time.Duration
-	Stdout  io.Writer
-	Stderr  io.Writer
-}
 
 type e2bAPIError struct {
 	StatusCode int
@@ -90,7 +37,7 @@ func (e *e2bAPIError) Error() string {
 	return e.Status + ": " + e.Body
 }
 
-var newE2BClient = func(cfg core.Config, rt core.Runtime) (e2bAPI, error) {
+var newE2BClient = func(cfg core.Config, rt core.Runtime) (shared.EnvdSandboxAPI, error) {
 	apiKey := strings.TrimSpace(cfg.E2B.APIKey)
 	if apiKey == "" {
 		return nil, core.Exit(2, "provider=e2b requires E2B_API_KEY")
@@ -123,7 +70,7 @@ func e2bRedirectError(destination *url.URL) error {
 	return fmt.Errorf("e2b refused cross-origin redirect to %s", destination.Redacted())
 }
 
-func (c *e2bClient) CreateSandbox(ctx context.Context, req e2bCreateSandboxRequest) (e2bSandbox, error) {
+func (c *e2bClient) CreateSandbox(ctx context.Context, req shared.EnvdSandboxCreateRequest) (shared.EnvdSandbox, error) {
 	body := map[string]any{
 		"templateID":            req.TemplateID,
 		"timeout":               req.TimeoutSeconds,
@@ -131,88 +78,30 @@ func (c *e2bClient) CreateSandbox(ctx context.Context, req e2bCreateSandboxReque
 		"allow_internet_access": req.AllowInternetAccess,
 		"metadata":              req.Metadata,
 	}
-	var sandbox e2bSandbox
-	if err := c.doJSON(ctx, http.MethodPost, "/sandboxes", nil, body, &sandbox); err != nil {
-		return e2bSandbox{}, err
-	}
-	if sandbox.Metadata == nil {
-		sandbox.Metadata = req.Metadata
-	}
-	if sandbox.State == "" {
-		sandbox.State = "running"
-	}
-	return sandbox, nil
+	return c.control().CreateSandbox(ctx, body, req.Metadata)
 }
 
-func (c *e2bClient) ConnectSandbox(ctx context.Context, sandboxID string, timeoutSeconds int) (e2bSession, error) {
-	if timeoutSeconds <= 0 {
-		timeoutSeconds = 300
-	}
-	body := map[string]any{"timeout": timeoutSeconds}
-	var sandbox e2bSandbox
-	if err := c.doJSON(ctx, http.MethodPost, "/sandboxes/"+url.PathEscape(sandboxID)+"/connect", nil, body, &sandbox); err != nil {
-		return e2bSession{}, err
-	}
-	if shared.ValidateResourceID(sandboxID, sandbox.SandboxID) != nil {
-		return e2bSession{}, errors.New("connect sandbox returned a different or missing sandbox ID")
+func (c *e2bClient) ConnectSandbox(ctx context.Context, sandboxID string, timeoutSeconds int) (shared.EnvdSandboxSession, error) {
+	sandbox, err := c.control().ConnectSandbox(ctx, sandboxID, timeoutSeconds)
+	if err != nil {
+		return shared.EnvdSandboxSession{}, err
 	}
 	return c.sessionFromSandbox(sandbox), nil
 }
 
-func (c *e2bClient) GetSandbox(ctx context.Context, sandboxID string) (e2bSandbox, error) {
-	var sandbox e2bSandbox
-	if err := c.doJSON(ctx, http.MethodGet, "/sandboxes/"+url.PathEscape(sandboxID), nil, nil, &sandbox); err != nil {
-		return e2bSandbox{}, err
-	}
-	if shared.ValidateResourceID(sandboxID, sandbox.SandboxID) != nil {
-		return e2bSandbox{}, errors.New("get sandbox returned a different or missing sandbox ID")
-	}
-	if sandbox.Metadata == nil {
-		sandbox.Metadata = map[string]string{}
-	}
-	return sandbox, nil
+func (c *e2bClient) GetSandbox(ctx context.Context, sandboxID string) (shared.EnvdSandbox, error) {
+	return c.control().GetSandbox(ctx, sandboxID)
 }
 
-func (c *e2bClient) ListSandboxes(ctx context.Context, metadata map[string]string) ([]e2bSandbox, error) {
-	var all []e2bSandbox
-	nextToken := ""
-	for {
-		query := url.Values{}
-		query.Set("limit", "100")
-		query.Set("state", "running,paused")
-		if nextToken != "" {
-			query.Set("nextToken", nextToken)
-		}
-		if len(metadata) > 0 {
-			values := url.Values{}
-			for key, value := range metadata {
-				values.Set(key, value)
-			}
-			query.Set("metadata", values.Encode())
-		}
-		var page []e2bSandbox
-		headers, err := c.doJSONWithHeaders(ctx, http.MethodGet, "/v2/sandboxes", query, nil, &page)
-		if err != nil {
-			return nil, err
-		}
-		for i := range page {
-			if page[i].Metadata == nil {
-				page[i].Metadata = map[string]string{}
-			}
-		}
-		all = append(all, page...)
-		nextToken = headers.Get("x-next-token")
-		if nextToken == "" {
-			return all, nil
-		}
-	}
+func (c *e2bClient) ListSandboxes(ctx context.Context, metadata map[string]string) ([]shared.EnvdSandbox, error) {
+	return c.control().ListSandboxes(ctx, metadata)
 }
 
 func (c *e2bClient) DeleteSandbox(ctx context.Context, sandboxID string) error {
-	return c.doJSON(ctx, http.MethodDelete, "/sandboxes/"+url.PathEscape(sandboxID), nil, nil, nil)
+	return c.control().DeleteSandbox(ctx, sandboxID)
 }
 
-func (c *e2bClient) UploadFile(ctx context.Context, session e2bSession, targetPath string, r io.Reader) error {
+func (c *e2bClient) UploadFile(ctx context.Context, session shared.EnvdSandboxSession, targetPath string, r io.Reader) error {
 	return shared.UploadEnvdFile(ctx, shared.EnvdUploadFileRequest{
 		Endpoint:       c.envdURL(session, "/files"),
 		TargetPath:     targetPath,
@@ -229,32 +118,21 @@ func (c *e2bClient) UploadFile(ctx context.Context, session e2bSession, targetPa
 	})
 }
 
-func (c *e2bClient) StartProcess(ctx context.Context, session e2bSession, req e2bProcessRequest) (int, error) {
+func (c *e2bClient) StartProcess(ctx context.Context, session shared.EnvdSandboxSession, req shared.EnvdSandboxProcessRequest) (int, error) {
 	return shared.StartEnvdProcess(ctx, shared.EnvdProcessRequest{
-		Endpoint:       c.envdURL(session, "/process.Process/Start"),
-		Command:        req.Command,
-		CWD:            req.CWD,
-		Env:            req.Env,
-		User:           req.User,
-		Timeout:        req.Timeout,
-		Stdout:         req.Stdout,
-		Stderr:         req.Stderr,
-		AccessToken:    session.EnvdAccessToken,
-		HTTPClient:     c.dataPlaneHTTPClient(),
-		SetHeaders:     func(httpReq *http.Request) { c.setEnvdHeaders(httpReq, session) },
-		RedirectError:  e2bRedirectError,
-		Provider:       "e2b",
-		InterpretEnd:   interpretE2BProcessEnd,
-		SummarizeError: core.SummarizeJSON,
+		EnvdSandboxProcessRequest: req,
+		Endpoint:                  c.envdURL(session, "/process.Process/Start"),
+		AccessToken:               session.EnvdAccessToken,
+		HTTPClient:                c.dataPlaneHTTPClient(),
+		SetHeaders:                func(httpReq *http.Request) { c.setEnvdHeaders(httpReq, session) },
+		RedirectError:             e2bRedirectError,
+		Provider:                  "e2b",
+		InterpretEnd:              interpretE2BProcessEnd,
+		SummarizeError:            core.SummarizeJSON,
 		APIError: func(statusCode int, status, body string) error {
 			return &e2bAPIError{StatusCode: statusCode, Status: status, Body: body}
 		},
 	})
-}
-
-func (c *e2bClient) doJSON(ctx context.Context, method, path string, query url.Values, body any, out any) error {
-	_, err := c.doJSONWithHeaders(ctx, method, path, query, body, out)
-	return err
 }
 
 func (c *e2bClient) doJSONWithHeaders(ctx context.Context, method, path string, query url.Values, body any, out any) (http.Header, error) {
@@ -284,12 +162,12 @@ func (c *e2bClient) doJSONWithHeaders(ctx context.Context, method, path string, 
 	return resp.Header.Clone(), nil
 }
 
-func (c *e2bClient) sessionFromSandbox(sandbox e2bSandbox) e2bSession {
+func (c *e2bClient) sessionFromSandbox(sandbox shared.EnvdSandbox) shared.EnvdSandboxSession {
 	domain := strings.TrimSpace(sandbox.Domain)
 	if domain == "" {
 		domain = c.domain
 	}
-	return e2bSession{
+	return shared.EnvdSandboxSession{
 		SandboxID:       sandbox.SandboxID,
 		EnvdVersion:     sandbox.EnvdVersion,
 		EnvdAccessToken: sandbox.EnvdAccessToken,
@@ -297,7 +175,7 @@ func (c *e2bClient) sessionFromSandbox(sandbox e2bSandbox) e2bSession {
 	}
 }
 
-func (c *e2bClient) envdURL(session e2bSession, path string) string {
+func (c *e2bClient) envdURL(session shared.EnvdSandboxSession, path string) string {
 	domain := strings.TrimSpace(session.Domain)
 	if domain == "" {
 		domain = c.domain
@@ -305,7 +183,7 @@ func (c *e2bClient) envdURL(session e2bSession, path string) string {
 	return "https://49983-" + session.SandboxID + "." + domain + path
 }
 
-func (c *e2bClient) setEnvdHeaders(req *http.Request, session e2bSession) {
+func (c *e2bClient) setEnvdHeaders(req *http.Request, session shared.EnvdSandboxSession) {
 	req.Header.Set("X-Access-Token", session.EnvdAccessToken)
 	req.Header.Set("E2b-Sandbox-Id", session.SandboxID)
 	req.Header.Set("E2b-Sandbox-Port", "49983")
@@ -323,4 +201,8 @@ func interpretE2BProcessEnd(end shared.EnvdProcessEnd, stderr io.Writer, secrets
 		fmt.Fprintln(stderr, shared.RedactErrorSecrets(end.Error, secrets...))
 	}
 	return end.ExitCode, nil
+}
+
+func (c *e2bClient) control() shared.EnvdSandboxControl {
+	return shared.EnvdSandboxControl{Request: c.doJSONWithHeaders}
 }

--- a/internal/providers/e2b/sync.go
+++ b/internal/providers/e2b/sync.go
@@ -9,9 +9,10 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	shared "github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func (b *e2bBackend) syncWorkspace(ctx context.Context, client e2bAPI, session e2bSession, req core.RunRequest, workspace string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
+func (b *e2bBackend) syncWorkspace(ctx context.Context, client shared.EnvdSandboxAPI, session shared.EnvdSandboxSession, req core.RunRequest, workspace string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	workspace, err := cleanE2BWorkspacePath(workspace)
 	if err != nil {
 		return nil, 0, err
@@ -36,7 +37,7 @@ func (b *e2bBackend) syncWorkspace(ctx context.Context, client e2bAPI, session e
 	}, prepared...)
 }
 
-func (b *e2bBackend) prepareWorkspace(ctx context.Context, client e2bAPI, session e2bSession, workspace string) error {
+func (b *e2bBackend) prepareWorkspace(ctx context.Context, client shared.EnvdSandboxAPI, session shared.EnvdSandboxSession, workspace string) error {
 	workspace, err := cleanE2BWorkspacePath(workspace)
 	if err != nil {
 		return err
@@ -60,12 +61,12 @@ func cleanE2BWorkspacePath(workspace string) (string, error) {
 	return clean, nil
 }
 
-func (b *e2bBackend) execShell(ctx context.Context, client e2bAPI, session e2bSession, command string, stdout io.Writer) error {
+func (b *e2bBackend) execShell(ctx context.Context, client shared.EnvdSandboxAPI, session shared.EnvdSandboxSession, command string, stdout io.Writer) error {
 	user, err := e2bProcessUser(b.cfg.E2B.User)
 	if err != nil {
 		return err
 	}
-	code, err := client.StartProcess(ctx, session, e2bProcessRequest{
+	code, err := client.StartProcess(ctx, session, shared.EnvdSandboxProcessRequest{
 		Command: command,
 		User:    user,
 		Timeout: b.cfg.TTL,

--- a/internal/providers/shared/envd.go
+++ b/internal/providers/shared/envd.go
@@ -80,15 +80,9 @@ func UploadEnvdFile(ctx context.Context, upload EnvdUploadFileRequest) error {
 }
 
 type EnvdProcessRequest struct {
+	EnvdSandboxProcessRequest
 	Provider      string
 	Endpoint      string
-	Command       string
-	CWD           string
-	Env           map[string]string
-	User          string
-	Timeout       time.Duration
-	Stdout        io.Writer
-	Stderr        io.Writer
 	AccessToken   string
 	HTTPClient    *http.Client
 	SetHeaders    func(*http.Request)

--- a/internal/providers/shared/envd_sandbox.go
+++ b/internal/providers/shared/envd_sandbox.go
@@ -1,0 +1,153 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// E2B-compatible control and envd data contracts. Adapters retain creation
+// payloads, credentials, endpoint routing, and process-completion policy.
+type EnvdSandboxAPI interface {
+	CreateSandbox(context.Context, EnvdSandboxCreateRequest) (EnvdSandbox, error)
+	ConnectSandbox(context.Context, string, int) (EnvdSandboxSession, error)
+	GetSandbox(context.Context, string) (EnvdSandbox, error)
+	ListSandboxes(context.Context, map[string]string) ([]EnvdSandbox, error)
+	DeleteSandbox(context.Context, string) error
+	UploadFile(context.Context, EnvdSandboxSession, string, io.Reader) error
+	StartProcess(context.Context, EnvdSandboxSession, EnvdSandboxProcessRequest) (int, error)
+}
+
+type EnvdSandboxCreateRequest struct {
+	TemplateID          string
+	TimeoutSeconds      int
+	Metadata            map[string]string
+	AllowInternetAccess bool
+}
+
+type EnvdSandbox struct {
+	TemplateID      string            `json:"templateID"`
+	SandboxID       string            `json:"sandboxID"`
+	ClientID        string            `json:"clientID"`
+	StartedAt       string            `json:"startedAt"`
+	EndAt           string            `json:"endAt"`
+	EnvdVersion     string            `json:"envdVersion"`
+	EnvdAccessToken string            `json:"envdAccessToken"`
+	TrafficToken    string            `json:"trafficAccessToken"`
+	Alias           string            `json:"alias"`
+	Domain          string            `json:"domain"`
+	State           string            `json:"state"`
+	CPUCount        int               `json:"cpuCount"`
+	MemoryMB        int               `json:"memoryMB"`
+	DiskSizeMB      int               `json:"diskSizeMB"`
+	Metadata        map[string]string `json:"metadata"`
+}
+
+type EnvdSandboxSession struct {
+	SandboxID       string
+	EnvdVersion     string
+	EnvdAccessToken string
+	Domain          string
+}
+
+type EnvdSandboxProcessRequest struct {
+	Command string
+	CWD     string
+	Env     map[string]string
+	User    string
+	Timeout time.Duration
+	Stdout  io.Writer
+	Stderr  io.Writer
+}
+
+// EnvdSandboxControl implements the compatible control-plane operations.
+// Request retains adapter-owned authentication, transport, and error decoding.
+// Creation payloads and envd session routing remain in each provider.
+type EnvdSandboxControl struct {
+	Request func(context.Context, string, string, url.Values, any, any) (http.Header, error)
+}
+
+func (c EnvdSandboxControl) CreateSandbox(ctx context.Context, body any, metadata map[string]string) (EnvdSandbox, error) {
+	var sandbox EnvdSandbox
+	if _, err := c.Request(ctx, http.MethodPost, "/sandboxes", nil, body, &sandbox); err != nil {
+		return EnvdSandbox{}, err
+	}
+	if sandbox.Metadata == nil {
+		sandbox.Metadata = metadata
+	}
+	if sandbox.State == "" {
+		sandbox.State = "running"
+	}
+	return sandbox, nil
+}
+
+func (c EnvdSandboxControl) ConnectSandbox(ctx context.Context, id string, timeoutSeconds int) (EnvdSandbox, error) {
+	if timeoutSeconds <= 0 {
+		timeoutSeconds = 300
+	}
+	var sandbox EnvdSandbox
+	if _, err := c.Request(ctx, http.MethodPost, "/sandboxes/"+url.PathEscape(id)+"/connect", nil, map[string]any{"timeout": timeoutSeconds}, &sandbox); err != nil {
+		return EnvdSandbox{}, err
+	}
+	if ValidateResourceID(id, sandbox.SandboxID) != nil {
+		return EnvdSandbox{}, errors.New("connect sandbox returned a different or missing sandbox ID")
+	}
+	return sandbox, nil
+}
+
+func (c EnvdSandboxControl) GetSandbox(ctx context.Context, id string) (EnvdSandbox, error) {
+	var sandbox EnvdSandbox
+	if _, err := c.Request(ctx, http.MethodGet, "/sandboxes/"+url.PathEscape(id), nil, nil, &sandbox); err != nil {
+		return EnvdSandbox{}, err
+	}
+	if ValidateResourceID(id, sandbox.SandboxID) != nil {
+		return EnvdSandbox{}, errors.New("get sandbox returned a different or missing sandbox ID")
+	}
+	if sandbox.Metadata == nil {
+		sandbox.Metadata = map[string]string{}
+	}
+	return sandbox, nil
+}
+
+func (c EnvdSandboxControl) ListSandboxes(ctx context.Context, metadata map[string]string) ([]EnvdSandbox, error) {
+	var all []EnvdSandbox
+	nextToken := ""
+	for {
+		query := url.Values{}
+		query.Set("limit", "100")
+		query.Set("state", "running,paused")
+		if nextToken != "" {
+			query.Set("nextToken", nextToken)
+		}
+		if len(metadata) > 0 {
+			values := url.Values{}
+			for key, value := range metadata {
+				values.Set(key, value)
+			}
+			query.Set("metadata", values.Encode())
+		}
+		var page []EnvdSandbox
+		headers, err := c.Request(ctx, http.MethodGet, "/v2/sandboxes", query, nil, &page)
+		if err != nil {
+			return nil, err
+		}
+		for i := range page {
+			if page[i].Metadata == nil {
+				page[i].Metadata = map[string]string{}
+			}
+		}
+		all = append(all, page...)
+		nextToken = headers.Get("x-next-token")
+		if nextToken == "" {
+			return all, nil
+		}
+	}
+}
+
+func (c EnvdSandboxControl) DeleteSandbox(ctx context.Context, id string) error {
+	_, err := c.Request(ctx, http.MethodDelete, "/sandboxes/"+url.PathEscape(id), nil, nil, nil)
+	return err
+}

--- a/internal/providers/shared/envd_sandbox_test.go
+++ b/internal/providers/shared/envd_sandbox_test.go
@@ -1,0 +1,75 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func TestEnvdSandboxControlPaginationRetainsWireQueryAndDiscardsPartialFailure(t *testing.T) {
+	metadata := map[string]string{"phase": "first"}
+	failure := errors.New("later page failed")
+	requests := 0
+	control := EnvdSandboxControl{Request: func(ctx context.Context, method, path string, query url.Values, body, out any) (http.Header, error) {
+		requests++
+		if method != http.MethodGet || path != "/v2/sandboxes" || query.Get("limit") != "100" || query.Get("state") != "running,paused" || body != nil {
+			t.Fatalf("unexpected request: %s %s %v", method, path, query)
+		}
+		if requests == 1 {
+			if query.Get("metadata") != "phase=first" || query.Has("nextToken") {
+				t.Fatalf("first query: %v", query)
+			}
+			*out.(*[]EnvdSandbox) = []EnvdSandbox{{SandboxID: "first"}}
+			metadata["phase"] = "second"
+			return http.Header{"X-Next-Token": {" next "}}, nil
+		}
+		if requests != 2 || query.Get("nextToken") != " next " || query.Get("metadata") != "phase=second" {
+			t.Fatalf("second query: %v", query)
+		}
+		return nil, failure
+	}}
+	got, err := control.ListSandboxes(t.Context(), metadata)
+	if got != nil || err != failure || requests != 2 {
+		t.Fatalf("result=%v error=%v requests=%d", got, err, requests)
+	}
+}
+
+func TestEnvdSandboxControlValidatesRequestedIdentityAndConnectDefault(t *testing.T) {
+	for _, operation := range []string{"get", "connect"} {
+		for _, returnedID := range []string{"", "other", "id/one"} {
+			t.Run(operation+"/"+returnedID, func(t *testing.T) {
+				control := EnvdSandboxControl{Request: func(ctx context.Context, method, path string, query url.Values, body, out any) (http.Header, error) {
+					wantMethod, wantPath := http.MethodGet, "/sandboxes/id%2Fone"
+					if operation == "connect" {
+						wantMethod, wantPath = http.MethodPost, wantPath+"/connect"
+						if !reflect.DeepEqual(body, map[string]any{"timeout": 300}) {
+							t.Fatalf("connect body=%#v", body)
+						}
+					}
+					if method != wantMethod || path != wantPath || query != nil {
+						t.Fatalf("request=%s %s %v", method, path, query)
+					}
+					*out.(*EnvdSandbox) = EnvdSandbox{SandboxID: returnedID}
+					return nil, nil
+				}}
+				var result EnvdSandbox
+				var err error
+				if operation == "get" {
+					result, err = control.GetSandbox(t.Context(), "id/one")
+				} else {
+					result, err = control.ConnectSandbox(t.Context(), "id/one", -1)
+				}
+				if returnedID != "id/one" {
+					if err == nil || result.SandboxID != "" {
+						t.Fatalf("unbound response accepted: %+v %v", result, err)
+					}
+				} else if err != nil || (operation == "get" && result.Metadata == nil) {
+					t.Fatalf("bound result=%+v error=%v", result, err)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
E2B and CubeSandbox repeated the same compatible sandbox record and command types, connection/get identity checks, and paginated inventory protocol. Give those contracts one shared owner, including the command fields passed into envd execution.

Each adapter still builds its own creation payload, authenticates requests, selects control/data transports and proxy endpoints, decodes API errors, and interprets abnormal process completion. Pagination keeps per-page metadata encoding, exact cursor values, empty metadata maps, and discard-on-error behavior.

Validation: both provider suites and shared tests passed, including returned-ID and pagination regressions; the same suites passed with the race detector and both Windows CLI builds passed on Crabbox. Scoped Codex review passed. No dependency, configuration, or credential changes.