### PR TITLE
refactor(cleanup): share claim-backed sandbox scanning

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -629,6 +629,12 @@ semantic tests required by the mechanism. Keep acquisition adapter-owned unless
 a future proposal proves both behavior preservation and meaningful net value.
 ## Shared run sequencing and provider authority
 
+`shared.CleanupSandboxClaims` owns the claim-backed sandbox cleanup scan. It
+rechecks provider scope after acquiring each adapter's operation lock, preserves
+dry-run and missing-resource reporting, and removes claims only after provider
+deletion succeeds. Adapters supply resource lookup, identity checks, expiry,
+deletion, and special recovery handling; the lock spans the complete operation.
+
 `shared.RunDelegatedSandbox` owns the common sandbox run sequence: preflight,
 archive preparation, acquisition or resolution, setup, sync, command execution,
 and one final retention/cleanup decision before timing and session reporting.

--- a/internal/providers/crownest/backend.go
+++ b/internal/providers/crownest/backend.go
@@ -542,85 +542,20 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	}
 	scope := claimScope(api.BaseURL(), b.cfg)
 	now := core.ClockNow(b.rt.Clock).UTC()
-	checked := 0
-	removed := 0
-	claimsRemoved := 0
-	for _, listed := range claims {
-		if listed.Provider != providerName || listed.ProviderScope != scope {
-			continue
-		}
-		var checkedOne, removedOne, claimRemovedOne bool
-		err := func() error {
-			unlockOperation, err := lockCrownestLeaseOperation(ctx, listed.LeaseID)
-			if err != nil {
-				return err
-			}
-			defer unlockOperation()
-			claim, err := core.ReadLeaseClaim(listed.LeaseID)
-			if err != nil {
-				return err
-			}
-			if claim.LeaseID == "" || claim.Provider != providerName || claim.ProviderScope != scope {
-				return nil
-			}
-			checkedOne = true
-			sandboxID := sandboxIDFromLease(claim.LeaseID)
-			_, err = api.GetSandbox(ctx, sandboxID)
-			if err != nil {
-				if !isNotFound(err) {
-					return err
-				}
-				if !b.cfg.Crownest.ForgetMissing {
-					fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=missing-or-inaccessible; set crownest forget-missing to remove the claim\n", sandboxID, claim.LeaseID)
-					return nil
-				}
-				if req.DryRun {
-					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
-					return nil
-				}
-				if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
-					return err
-				}
-				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
-				claimRemovedOne = true
-				return nil
-			}
-			due, reason := crownestClaimCleanupDue(claim, now)
-			if !due {
-				fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
-				return nil
-			}
-			if req.DryRun {
-				fmt.Fprintf(b.rt.Stdout, "would delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
-				return nil
-			}
-			if err := api.DeleteSandbox(ctx, sandboxID); err != nil && !isNotFound(err) {
-				return err
-			}
-			if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
-				return err
-			}
-			fmt.Fprintf(b.rt.Stdout, "delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
-			removedOne = true
-			return nil
-		}()
-		if err != nil {
-			return err
-		}
-		if checkedOne {
-			checked++
-		}
-		if removedOne {
-			removed++
-		}
-		if claimRemovedOne {
-			claimsRemoved++
-		}
-	}
-	if !req.DryRun {
-		fmt.Fprintf(b.rt.Stdout, "%s cleanup removed=%d claims_removed=%d checked=%d\n", providerName, removed, claimsRemoved, checked)
-	}
-	return nil
+	return shared.CleanupSandboxClaims(ctx, req, claims, shared.SandboxClaimCleanup[sandbox]{
+		Provider:          providerName,
+		Runtime:           b.rt,
+		Now:               now,
+		MatchesScope:      func(claim core.LeaseClaim) bool { return claim.ProviderScope == scope },
+		Lock:              lockCrownestLeaseOperation,
+		SandboxID:         func(claim core.LeaseClaim) string { return sandboxIDFromLease(claim.LeaseID) },
+		Get:               api.GetSandbox,
+		Delete:            api.DeleteSandbox,
+		IsNotFound:        isNotFound,
+		ForgetMissing:     b.cfg.Crownest.ForgetMissing,
+		ForgetMissingHint: "crownest forget-missing",
+		Due:               crownestClaimCleanupDue,
+	})
 }
 
 func (b *backend) createSandbox(ctx context.Context, api client, repo core.Repo, reclaim bool, requestedSlug string) (string, string, string, error) {

--- a/internal/providers/opensandbox/backend.go
+++ b/internal/providers/opensandbox/backend.go
@@ -471,92 +471,28 @@ func (b *openSandboxBackend) Cleanup(ctx context.Context, req core.CleanupReques
 		return err
 	}
 	now := core.ClockNow(b.rt.Clock).UTC()
-	checked := 0
-	removed := 0
-	claimsRemoved := 0
-	for _, listedClaim := range claims {
-		if listedClaim.Provider != providerName || !openSandboxClaimMatchesEndpoint(listedClaim, api.BaseURL()) {
-			continue
-		}
-		var removedOne, claimRemovedOne, checkedOne bool
-		err := func() error {
-			unlock, err := lockOpenSandboxLeaseOperation(ctx, listedClaim.LeaseID)
-			if err != nil {
-				return err
+	return shared.CleanupSandboxClaims(ctx, req, claims, shared.SandboxClaimCleanup[sandboxInfo]{
+		Provider:          providerName,
+		Runtime:           b.rt,
+		Now:               now,
+		MatchesScope:      func(claim core.LeaseClaim) bool { return openSandboxClaimMatchesEndpoint(claim, api.BaseURL()) },
+		Lock:              lockOpenSandboxLeaseOperation,
+		SandboxID:         func(claim core.LeaseClaim) string { return strings.TrimPrefix(claim.LeaseID, leasePrefix) },
+		Get:               api.GetSandbox,
+		Delete:            api.DeleteSandbox,
+		IsNotFound:        isOpenSandboxNotFound,
+		ForgetMissing:     b.cfg.OpenSandbox.ForgetMissing,
+		ForgetMissingHint: "opensandbox forget-missing",
+		Due:               shared.ClaimIdleCleanupDue,
+		Validate:          validateOpenSandboxOwnership,
+		Special: func(ctx context.Context, claim core.LeaseClaim) (bool, bool, bool, error) {
+			if !strings.HasPrefix(claim.LeaseID, recoveryPrefix) {
+				return false, false, false, nil
 			}
-			defer unlock()
-			claim, err := core.ReadLeaseClaim(listedClaim.LeaseID)
-			if err != nil {
-				return err
-			}
-			if claim.LeaseID == "" || claim.Provider != providerName || !openSandboxClaimMatchesEndpoint(claim, api.BaseURL()) {
-				return nil
-			}
-			checkedOne = true
-			if strings.HasPrefix(claim.LeaseID, recoveryPrefix) {
-				removedOne, claimRemovedOne, err = b.cleanupOpenSandboxRecovery(ctx, api, claim, now, req.DryRun)
-				return err
-			}
-			sandboxID := strings.TrimPrefix(claim.LeaseID, leasePrefix)
-			sb, getErr := api.GetSandbox(ctx, sandboxID)
-			if getErr != nil {
-				if !isOpenSandboxNotFound(getErr) {
-					return getErr
-				}
-				if !b.cfg.OpenSandbox.ForgetMissing {
-					fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=missing-or-inaccessible; set opensandbox forget-missing to remove the claim\n", sandboxID, claim.LeaseID)
-					return nil
-				}
-				if req.DryRun {
-					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
-					return nil
-				}
-				if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
-					return err
-				}
-				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
-				claimRemovedOne = true
-				return nil
-			}
-			due, reason := shared.ClaimIdleCleanupDue(claim, now)
-			if !due {
-				fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
-				return nil
-			}
-			if err := validateOpenSandboxOwnership(claim, sb); err != nil {
-				return err
-			}
-			if req.DryRun {
-				fmt.Fprintf(b.rt.Stdout, "would delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
-				return nil
-			}
-			if err := api.DeleteSandbox(ctx, sandboxID); err != nil && !isOpenSandboxNotFound(err) {
-				return err
-			}
-			if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
-				return err
-			}
-			fmt.Fprintf(b.rt.Stdout, "delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
-			removedOne = true
-			return nil
-		}()
-		if err != nil {
-			return err
-		}
-		if checkedOne {
-			checked++
-		}
-		if removedOne {
-			removed++
-		}
-		if claimRemovedOne {
-			claimsRemoved++
-		}
-	}
-	if !req.DryRun {
-		fmt.Fprintf(b.rt.Stdout, "%s cleanup removed=%d claims_removed=%d checked=%d\n", providerName, removed, claimsRemoved, checked)
-	}
-	return nil
+			removed, claimRemoved, err := b.cleanupOpenSandboxRecovery(ctx, api, claim, now, req.DryRun)
+			return true, removed, claimRemoved, err
+		},
+	})
 }
 
 func (b *openSandboxBackend) cleanupOpenSandboxRecovery(ctx context.Context, api openSandboxClient, claim core.LeaseClaim, now time.Time, dryRun bool) (bool, bool, error) {

--- a/internal/providers/shared/sandbox_cleanup.go
+++ b/internal/providers/shared/sandbox_cleanup.go
@@ -1,0 +1,127 @@
+package shared
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// SandboxClaimCleanup describes the existing claim-backed sandbox cleanup
+// protocol. Adapters own scope admission, locking, resource identity, expiry,
+// and provider mutations. Special claims remain entirely adapter-owned.
+type SandboxClaimCleanup[T any] struct {
+	Provider          string
+	Runtime           core.Runtime
+	Now               time.Time
+	MatchesScope      func(core.LeaseClaim) bool
+	Lock              func(context.Context, string) (func(), error)
+	SandboxID         func(core.LeaseClaim) string
+	Get               func(context.Context, string) (T, error)
+	Delete            func(context.Context, string) error
+	IsNotFound        func(error) bool
+	ForgetMissing     bool
+	ForgetMissingHint string
+	Due               func(core.LeaseClaim, time.Time) (bool, string)
+	Validate          func(core.LeaseClaim, T) error
+	// Special runs after locked reread/admission, before normal resource lookup.
+	Special func(context.Context, core.LeaseClaim) (handled, removed, claimRemoved bool, err error)
+}
+
+type sandboxCleanupOutcome struct{ checked, removed, claimRemoved bool }
+
+// CleanupSandboxClaims keeps each operation lock through claim removal and
+// reporting. The first failure ends the scan without a success summary.
+func CleanupSandboxClaims[T any](ctx context.Context, req core.CleanupRequest, claims []core.LeaseClaim, cleanup SandboxClaimCleanup[T]) error {
+	checked, removed, claimsRemoved := 0, 0, 0
+	for _, listed := range claims {
+		if listed.Provider != cleanup.Provider || !cleanup.MatchesScope(listed) {
+			continue
+		}
+		outcome, err := cleanup.one(ctx, req.DryRun, listed)
+		if err != nil {
+			return err
+		}
+		if outcome.checked {
+			checked++
+		}
+		if outcome.removed {
+			removed++
+		}
+		if outcome.claimRemoved {
+			claimsRemoved++
+		}
+	}
+	if !req.DryRun {
+		fmt.Fprintf(cleanup.Runtime.Stdout, "%s cleanup removed=%d claims_removed=%d checked=%d\n", cleanup.Provider, removed, claimsRemoved, checked)
+	}
+	return nil
+}
+
+func (c SandboxClaimCleanup[T]) one(ctx context.Context, dryRun bool, listed core.LeaseClaim) (outcome sandboxCleanupOutcome, err error) {
+	unlock, err := c.Lock(ctx, listed.LeaseID)
+	if err != nil {
+		return outcome, err
+	}
+	defer unlock()
+	claim, err := core.ReadLeaseClaim(listed.LeaseID)
+	if err != nil {
+		return outcome, err
+	}
+	if claim.LeaseID == "" || claim.Provider != c.Provider || !c.MatchesScope(claim) {
+		return outcome, nil
+	}
+	outcome.checked = true
+	if c.Special != nil {
+		handled, removed, claimRemoved, err := c.Special(ctx, claim)
+		if handled || err != nil {
+			outcome.removed, outcome.claimRemoved = removed, claimRemoved
+			return outcome, err
+		}
+	}
+	sandboxID := c.SandboxID(claim)
+	sandbox, getErr := c.Get(ctx, sandboxID)
+	if getErr != nil {
+		if !c.IsNotFound(getErr) {
+			return outcome, getErr
+		}
+		if !c.ForgetMissing {
+			fmt.Fprintf(c.Runtime.Stderr, "skip sandbox=%s lease=%s reason=missing-or-inaccessible; set %s to remove the claim\n", sandboxID, claim.LeaseID, c.ForgetMissingHint)
+			return outcome, nil
+		}
+		if dryRun {
+			fmt.Fprintf(c.Runtime.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
+			return outcome, nil
+		}
+		if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+			return outcome, err
+		}
+		fmt.Fprintf(c.Runtime.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
+		outcome.claimRemoved = true
+		return outcome, nil
+	}
+	due, reason := c.Due(claim, c.Now)
+	if !due {
+		fmt.Fprintf(c.Runtime.Stderr, "skip sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
+		return outcome, nil
+	}
+	if c.Validate != nil {
+		if err := c.Validate(claim, sandbox); err != nil {
+			return outcome, err
+		}
+	}
+	if dryRun {
+		fmt.Fprintf(c.Runtime.Stdout, "would delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
+		return outcome, nil
+	}
+	if err := c.Delete(ctx, sandboxID); err != nil && !c.IsNotFound(err) {
+		return outcome, err
+	}
+	if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+		return outcome, err
+	}
+	fmt.Fprintf(c.Runtime.Stdout, "delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
+	outcome.removed = true
+	return outcome, nil
+}

--- a/internal/providers/shared/sandbox_cleanup_test.go
+++ b/internal/providers/shared/sandbox_cleanup_test.go
@@ -1,0 +1,98 @@
+package shared
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestSandboxCleanupRetainsLockedAdmissionAndMutationOrder(t *testing.T) {
+	for _, mode := range []string{"delete", "dry-run", "forget-missing", "retain-missing", "disappeared", "foreign-scope"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			const id = "cbx_aaaaaaaaaaaa"
+			scope := "scope"
+			if mode == "foreign-scope" {
+				scope = "foreign"
+			}
+			server := core.Server{Provider: "example", CloudID: "sandbox", Labels: map[string]string{"lease": id, "slug": "alpha"}}
+			if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(id, "alpha", "example", scope, "", t.TempDir(), time.Minute, false, server, core.SSHTarget{}); err != nil {
+				t.Fatal(err)
+			}
+			stored, err := core.ReadLeaseClaim(id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			listed := stored
+			listed.ProviderScope = "scope"
+			var stdout, stderr bytes.Buffer
+			var events []string
+			locked := false
+			observe := func(event string) {
+				if !locked {
+					t.Errorf("%s escaped the operation lock", event)
+				}
+				events = append(events, event)
+			}
+			missing := errors.New("missing")
+			cleanup := SandboxClaimCleanup[string]{
+				Provider: "example", Runtime: core.Runtime{Stdout: &stdout, Stderr: &stderr},
+				MatchesScope: func(claim core.LeaseClaim) bool { return claim.ProviderScope == "scope" },
+				Lock: func(context.Context, string) (func(), error) {
+					locked = true
+					events = append(events, "lock")
+					if mode == "disappeared" {
+						if err := core.RemoveLeaseClaimIfUnchanged(id, stored); err != nil {
+							return nil, err
+						}
+					}
+					return func() { events = append(events, "unlock"); locked = false }, nil
+				},
+				SandboxID: func(claim core.LeaseClaim) string { return claim.CloudID },
+				Get: func(context.Context, string) (string, error) {
+					observe("get")
+					if strings.HasSuffix(mode, "missing") {
+						return "", missing
+					}
+					return "sandbox", nil
+				},
+				IsNotFound:    func(err error) bool { return err == missing },
+				ForgetMissing: mode == "forget-missing", ForgetMissingHint: "example.forgetMissing",
+				Due:      func(core.LeaseClaim, time.Time) (bool, string) { observe("due"); return true, "expired" },
+				Validate: func(core.LeaseClaim, string) error { observe("validate"); return nil },
+				Delete:   func(context.Context, string) error { observe("delete"); return nil },
+			}
+			if err := CleanupSandboxClaims(t.Context(), core.CleanupRequest{DryRun: mode == "dry-run"}, []core.LeaseClaim{listed}, cleanup); err != nil {
+				t.Fatal(err)
+			}
+			want := []string{"lock", "get", "due", "validate", "delete", "unlock"}
+			if mode == "dry-run" {
+				want = []string{"lock", "get", "due", "validate", "unlock"}
+			} else if strings.HasSuffix(mode, "missing") {
+				want = []string{"lock", "get", "unlock"}
+			} else if mode == "disappeared" || mode == "foreign-scope" {
+				want = []string{"lock", "unlock"}
+			}
+			if !reflect.DeepEqual(events, want) || locked {
+				t.Fatalf("events=%v want=%v locked=%v", events, want, locked)
+			}
+			current, err := core.ReadLeaseClaim(id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantRemoved := mode == "delete" || mode == "forget-missing" || mode == "disappeared"
+			if (current.LeaseID == "") != wantRemoved {
+				t.Fatalf("claim removal=%v want=%v", current.LeaseID == "", wantRemoved)
+			}
+			if mode == "dry-run" && (!strings.Contains(stdout.String(), "would delete sandbox=sandbox") || strings.Contains(stdout.String(), "cleanup removed=")) {
+				t.Fatalf("dry-run output=%q", stdout.String())
+			}
+		})
+	}
+}

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -391,88 +391,21 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		return err
 	}
 	now := core.ClockNow(b.rt.Clock).UTC()
-	checked := 0
-	removed := 0
-	claimsRemoved := 0
-	for _, listed := range claims {
-		if listed.Provider != providerName || !superserveClaimMatchesEndpoint(listed, api.BaseURL()) {
-			continue
-		}
-		var removedOne, claimRemovedOne, checkedOne bool
-		err := func() error {
-			unlockOperation, err := lockSuperserveLeaseOperation(ctx, listed.LeaseID)
-			if err != nil {
-				return err
-			}
-			defer unlockOperation()
-			claim, err := core.ReadLeaseClaim(listed.LeaseID)
-			if err != nil {
-				return err
-			}
-			if claim.LeaseID == "" || claim.Provider != providerName || !superserveClaimMatchesEndpoint(claim, api.BaseURL()) {
-				return nil
-			}
-			checkedOne = true
-			sandboxID := strings.TrimPrefix(claim.LeaseID, leasePrefix)
-			sb, getErr := api.GetSandbox(ctx, sandboxID)
-			if getErr != nil {
-				if !isSuperserveNotFound(getErr) {
-					return getErr
-				}
-				if !b.cfg.Superserve.ForgetMissing {
-					fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=missing-or-inaccessible; set superserve forget-missing to remove the claim\n", sandboxID, claim.LeaseID)
-					return nil
-				}
-				if req.DryRun {
-					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
-					return nil
-				}
-				if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
-					return err
-				}
-				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
-				claimRemovedOne = true
-				return nil
-			}
-			due, reason := shared.ClaimIdleCleanupDue(claim, now)
-			if !due {
-				fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
-				return nil
-			}
-			if err := validateSuperserveSandboxOwnership(claim, sb); err != nil {
-				return err
-			}
-			if req.DryRun {
-				fmt.Fprintf(b.rt.Stdout, "would delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
-				return nil
-			}
-			if err := api.DeleteSandbox(ctx, sandboxID); err != nil && !isSuperserveNotFound(err) {
-				return err
-			}
-			if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
-				return err
-			}
-			fmt.Fprintf(b.rt.Stdout, "delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
-			removedOne = true
-			return nil
-		}()
-		if err != nil {
-			return err
-		}
-		if checkedOne {
-			checked++
-		}
-		if removedOne {
-			removed++
-		}
-		if claimRemovedOne {
-			claimsRemoved++
-		}
-	}
-	if !req.DryRun {
-		fmt.Fprintf(b.rt.Stdout, "%s cleanup removed=%d claims_removed=%d checked=%d\n", providerName, removed, claimsRemoved, checked)
-	}
-	return nil
+	return shared.CleanupSandboxClaims(ctx, req, claims, shared.SandboxClaimCleanup[superserveSandbox]{
+		Provider:          providerName,
+		Runtime:           b.rt,
+		Now:               now,
+		MatchesScope:      func(claim core.LeaseClaim) bool { return superserveClaimMatchesEndpoint(claim, api.BaseURL()) },
+		Lock:              lockSuperserveLeaseOperation,
+		SandboxID:         func(claim core.LeaseClaim) string { return strings.TrimPrefix(claim.LeaseID, leasePrefix) },
+		Get:               api.GetSandbox,
+		Delete:            api.DeleteSandbox,
+		IsNotFound:        isSuperserveNotFound,
+		ForgetMissing:     b.cfg.Superserve.ForgetMissing,
+		ForgetMissingHint: "superserve forget-missing",
+		Due:               shared.ClaimIdleCleanupDue,
+		Validate:          validateSuperserveSandboxOwnership,
+	})
 }
 
 func (b *backend) createSandbox(ctx context.Context, api superserveClient, repo core.Repo, reclaim bool, requestedSlug string) (string, string, string, func(), error) {

--- a/internal/providers/vercelsandbox/backend.go
+++ b/internal/providers/vercelsandbox/backend.go
@@ -375,88 +375,21 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		return err
 	}
 	now := core.ClockNow(b.rt.Clock).UTC()
-	checked := 0
-	removed := 0
-	claimsRemoved := 0
-	for _, listed := range claims {
-		if listed.Provider != providerName || !b.claimMatchesActiveScope(listed) {
-			continue
-		}
-		var removedOne, claimRemovedOne, checkedOne bool
-		err := func() error {
-			unlockOperation, err := lockVercelSandboxLeaseOperation(ctx, listed.LeaseID)
-			if err != nil {
-				return err
-			}
-			defer unlockOperation()
-			claim, err := core.ReadLeaseClaim(listed.LeaseID)
-			if err != nil {
-				return err
-			}
-			if claim.LeaseID == "" || claim.Provider != providerName || !b.claimMatchesActiveScope(claim) {
-				return nil
-			}
-			checkedOne = true
-			sandboxID := strings.TrimPrefix(claim.LeaseID, leasePrefix)
-			sb, getErr := api.GetSandbox(ctx, sandboxID)
-			if getErr != nil {
-				if !isVercelSandboxNotFound(getErr) {
-					return getErr
-				}
-				if !b.cfg.VercelSandbox.ForgetMissing {
-					fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=missing-or-inaccessible; set vercelSandbox.forgetMissing to remove the claim\n", sandboxID, claim.LeaseID)
-					return nil
-				}
-				if req.DryRun {
-					fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
-					return nil
-				}
-				if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
-					return err
-				}
-				fmt.Fprintf(b.rt.Stdout, "remove claim lease=%s slug=%s reason=missing sandbox\n", claim.LeaseID, core.Blank(claim.Slug, "-"))
-				claimRemovedOne = true
-				return nil
-			}
-			due, reason := shared.ClaimIdleCleanupDue(claim, now)
-			if !due {
-				fmt.Fprintf(b.rt.Stderr, "skip sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
-				return nil
-			}
-			if err := validateSandboxOwnership(claim, sb); err != nil {
-				return err
-			}
-			if req.DryRun {
-				fmt.Fprintf(b.rt.Stdout, "would delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
-				return nil
-			}
-			if err := api.DeleteSandbox(ctx, sandboxID); err != nil && !isVercelSandboxNotFound(err) {
-				return err
-			}
-			if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
-				return err
-			}
-			fmt.Fprintf(b.rt.Stdout, "delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
-			removedOne = true
-			return nil
-		}()
-		if err != nil {
-			return err
-		}
-		if checkedOne {
-			checked++
-		}
-		if removedOne {
-			removed++
-		}
-		if claimRemovedOne {
-			claimsRemoved++
-		}
-	}
-	if !req.DryRun {
-		fmt.Fprintf(b.rt.Stdout, "%s cleanup removed=%d claims_removed=%d checked=%d\n", providerName, removed, claimsRemoved, checked)
-	}
-	return nil
+	return shared.CleanupSandboxClaims(ctx, req, claims, shared.SandboxClaimCleanup[sandboxSummary]{
+		Provider:          providerName,
+		Runtime:           b.rt,
+		Now:               now,
+		MatchesScope:      b.claimMatchesActiveScope,
+		Lock:              lockVercelSandboxLeaseOperation,
+		SandboxID:         func(claim core.LeaseClaim) string { return strings.TrimPrefix(claim.LeaseID, leasePrefix) },
+		Get:               api.GetSandbox,
+		Delete:            api.DeleteSandbox,
+		IsNotFound:        isVercelSandboxNotFound,
+		ForgetMissing:     b.cfg.VercelSandbox.ForgetMissing,
+		ForgetMissingHint: "vercelSandbox.forgetMissing",
+		Due:               shared.ClaimIdleCleanupDue,
+		Validate:          validateSandboxOwnership,
+	})
 }
 
 func (b *backend) createSandbox(ctx context.Context, api vercelSandboxClient, repo core.Repo, reclaim bool, requestedSlug string, retained bool) (string, string, string, func(), error) {


### PR DESCRIPTION
Four sandbox adapters repeated the same claim-backed cleanup scan and reporting. Share that protocol: filter listed claims, acquire the adapter operation lock, reread and recheck scope, inspect the resource, apply expiry/ownership rules, and finish deletion or permitted claim removal before unlocking.

Adapters retain their scope, resource identity, expiration policy, missing-resource setting, and provider calls. OpenSandbox recovery claims stay in its existing recovery handler; Vercel still binds account scope before entering the scan. Dry-run behavior, output, counters, and stop-on-first-error ordering are preserved.

Validation: complete shared and four provider suites passed, along with their race suites and Windows x64/ARM64 CLI builds. Regression coverage checks locked rereads, changed/disappeared claims, dry runs, and missing resources. Scoped Codex review passed. No dependency, configuration, or credential changes.