### PR TITLE
refactor(storage): share private file publication

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -1015,6 +1015,10 @@ Blacksmith does) when the config type is not ready to export cleanly.
 If a provider needs durable config, add typed config fields in `Config` and env
 overrides in `config.go`.
 
+`internal/atomicfile.WritePrivate` shares private-file staging, file syncing,
+and replacement. Callers retain path admission, directory creation, their
+platform-specific atomic replacement, and directory-sync/error policy.
+
 `cli.ResolveInheritedWorkRoot` shares the raw work-root decision used by exe.dev
 (core loading and backend defaults), Runpod, Multipass, Hyper-V, and Tart. A
 nonempty provider root wins; otherwise a generic root that is not an exact

--- a/internal/atomicfile/write.go
+++ b/internal/atomicfile/write.go
@@ -1,0 +1,43 @@
+package atomicfile
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// WritePrivate stages a complete 0600 file beside path, syncs and closes it,
+// then publishes it with replace. A successful replace must consume the staged
+// path. Callers retain path admission, parent creation, and directory-sync policy.
+func WritePrivate(path, pattern string, data []byte, replace func(string, string) error) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), pattern)
+	if err != nil {
+		return err
+	}
+	staged := tmp.Name()
+	published := false
+	defer func() {
+		if !published {
+			_ = os.Remove(staged)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := replace(staged, path); err != nil {
+		return err
+	}
+	published = true
+	return nil
+}

--- a/internal/atomicfile/write_test.go
+++ b/internal/atomicfile/write_test.go
@@ -1,0 +1,82 @@
+package atomicfile
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestWritePrivatePublishesCompletePrivateFileAndCleansFailures(t *testing.T) {
+	for _, mode := range []string{"success", "before-replace-failure", "after-replace-failure"} {
+		t.Run(mode, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "state")
+			if err := os.WriteFile(path, []byte("previous"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			failure := errors.New("replacement failed")
+			var staged string
+			err := WritePrivate(path, ".state-*.tmp", []byte("complete replacement"), func(from, to string) error {
+				staged = from
+				if to != path || filepath.Dir(from) != dir {
+					t.Fatalf("publication paths %q -> %q", from, to)
+				}
+				if matches, _ := filepath.Match(".state-*.tmp", filepath.Base(from)); !matches {
+					t.Fatalf("staged name=%s", from)
+				}
+				data, err := os.ReadFile(from)
+				if err != nil || string(data) != "complete replacement" {
+					t.Fatalf("staged contents=%q error=%v", data, err)
+				}
+				info, err := os.Stat(from)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+					t.Fatalf("staged permissions=%v", info.Mode())
+				}
+				prior, err := os.ReadFile(to)
+				if err != nil || string(prior) != "previous" {
+					t.Fatalf("destination changed before publication: %q %v", prior, err)
+				}
+				if mode == "before-replace-failure" {
+					return failure
+				}
+				if err := os.Rename(from, to); err != nil {
+					return err
+				}
+				if mode == "after-replace-failure" {
+					return failure
+				}
+				return nil
+			})
+			if mode == "success" && err != nil || mode != "success" && err != failure {
+				t.Fatalf("error=%v", err)
+			}
+			if _, err := os.Stat(staged); !os.IsNotExist(err) {
+				t.Fatalf("staged path remains: %v", err)
+			}
+			want := "complete replacement"
+			if mode == "before-replace-failure" {
+				want = "previous"
+			}
+			data, err := os.ReadFile(path)
+			if err != nil || string(data) != want {
+				t.Fatalf("destination=%q want=%q error=%v", data, want, err)
+			}
+		})
+	}
+}
+
+func TestWritePrivateDoesNotCreateParentDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing", "state")
+	err := WritePrivate(path, ".state-*", nil, func(string, string) error {
+		t.Fatal("replacement reached without an existing parent")
+		return nil
+	})
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("error=%v", err)
+	}
+}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openclaw/crabbox/internal/atomicfile"
 	"gopkg.in/yaml.v3"
 )
 
@@ -3260,38 +3261,10 @@ func writeUserFileConfigAtomic(path string, data []byte, replaceFile func(string
 	if err != nil {
 		return err
 	}
-	dir := filepath.Dir(writePath)
-	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
-	if err != nil {
+	if err := atomicfile.WritePrivate(writePath, "."+filepath.Base(path)+".tmp-*", data, replaceFile); err != nil {
 		return err
 	}
-	tmpPath := tmp.Name()
-	removeTemp := true
-	defer func() {
-		if removeTemp {
-			_ = os.Remove(tmpPath)
-		}
-	}()
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := replaceFile(tmpPath, writePath); err != nil {
-		return err
-	}
-	removeTemp = false
-	syncDirectory(dir)
+	syncDirectory(filepath.Dir(writePath))
 	return nil
 }
 

--- a/internal/cli/controller_subprocess.go
+++ b/internal/cli/controller_subprocess.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/openclaw/crabbox/internal/atomicfile"
 	"github.com/openclaw/crabbox/internal/prefixbuffer"
 )
 
@@ -1425,28 +1426,7 @@ func writeControllerChildIdentity(path string, identity controllerChildIdentity)
 	}
 	data = append(data, '\n')
 	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, ".controller-child-*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath)
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := replaceControllerFile(tmpPath, path); err != nil {
+	if err := atomicfile.WritePrivate(path, ".controller-child-*.tmp", data, replaceControllerFile); err != nil {
 		return err
 	}
 	if err := syncControllerDirectory(dir); err != nil {

--- a/internal/cli/state_file.go
+++ b/internal/cli/state_file.go
@@ -2,43 +2,17 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
+
+	"github.com/openclaw/crabbox/internal/atomicfile"
 )
 
 // Publish the complete record atomically and sync its namespace before remote effects.
 func writeStateFileAtomic(path string, data []byte, syncDirectory func(string) error) error {
 	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
-	if err != nil {
+	if err := atomicfile.WritePrivate(path, "."+filepath.Base(path)+".tmp-*", data, replaceClaimFile); err != nil {
 		return err
 	}
-	tmpPath := tmp.Name()
-	removeTemp := true
-	defer func() {
-		if removeTemp {
-			_ = os.Remove(tmpPath)
-		}
-	}()
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := replaceClaimFile(tmpPath, path); err != nil {
-		return err
-	}
-	removeTemp = false
 	if err := syncDirectory(dir); err != nil {
 		return fmt.Errorf("sync state directory %s: %w", dir, err)
 	}

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/openclaw/crabbox/internal/atomicfile"
 	"nhooyr.io/websocket"
 )
 
@@ -2470,28 +2471,7 @@ func writeWebVNCDaemonIdentity(pidPath string, identity webVNCDaemonIdentity) er
 		return err
 	}
 	data = append(data, '\n')
-	tmp, err := os.CreateTemp(filepath.Dir(pidPath), ".webvnc-identity-*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath)
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := replaceControllerFile(tmpPath, pidPath); err != nil {
+	if err := atomicfile.WritePrivate(pidPath, ".webvnc-identity-*.tmp", data, replaceControllerFile); err != nil {
 		return err
 	}
 	if err := syncControllerDirectory(filepath.Dir(pidPath)); err != nil {

--- a/internal/providers/asciibox/client.go
+++ b/internal/providers/asciibox/client.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openclaw/crabbox/internal/atomicfile"
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
@@ -582,38 +583,7 @@ func writePrivateFileAtomic(path string, data []byte) error {
 		return err
 	}
 
-	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	keep := false
-	defer func() {
-		if !keep {
-			_ = os.Remove(tmpPath)
-		}
-	}()
-
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		return err
-	}
-	keep = true
-	return nil
+	return atomicfile.WritePrivate(path, "."+filepath.Base(path)+".tmp-", data, os.Rename)
 }
 
 func (c *client) waitForBoxReady(ctx context.Context, box boxData) (boxData, error) {

--- a/internal/providers/incus/client.go
+++ b/internal/providers/incus/client.go
@@ -15,6 +15,7 @@ import (
 	incusclient "github.com/lxc/incus/v7/client"
 	"github.com/lxc/incus/v7/shared/api"
 	"github.com/lxc/incus/v7/shared/cliconfig"
+	"github.com/openclaw/crabbox/internal/atomicfile"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -511,28 +512,7 @@ func writeOIDCTokens(path string, tokens *oidc.Tokens[*oidc.IDTokenClaims]) erro
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
-	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath)
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	return os.Rename(tmpPath, path)
+	return atomicfile.WritePrivate(path, "."+filepath.Base(path)+".tmp-*", data, os.Rename)
 }
 
 func lockOIDCTokens(path string) (*flock.Flock, error) {


### PR DESCRIPTION
Private config and state writers repeated the same temporary-file publication sequence. A shared atomicfile.WritePrivate implementation now creates a 0600 file, writes and syncs the complete bytes, closes it, and invokes the caller's existing replacement operation.

Path admission, config symlink resolution, directory creation, temporary-name patterns, platform-specific replacement, directory syncing, and error messages remain in their existing callers. The change covers config, claim/state records, controller/WebVNC identities, AsciiBox config, and Incus token persistence.

Validation: targeted publication/config/identity/claim tests and complete affected provider suites passed; matching race tests and Windows x64/ARM64 builds passed on Crabbox. New tests cover complete private staging and failures before or after replacement. Scoped Codex review passed. No dependency, configuration, or credential changes.