### PR TITLE
refactor(providers): share claim indexing and warmup reporting

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -580,6 +580,9 @@ Acquisition already shares the mechanics that have provider-neutral contracts:
 - `shared.LabelsWithDefaults` copies stored labels and fills missing or empty
   values during inventory projection. Adapters retain the default values and
   any authoritative state, identity, redaction, or live-port overrides.
+- `shared.IndexProviderClaims` builds lookup indexes from stored snapshots
+  using adapter-owned resource keys. Index entries remain candidates for later
+  ownership validation, rather than authority to mutate a resource.
 - `core.AcquireFixedLease`, `core.FixedAcquireOptions`,
   `core.FixedLeaseBinding`, and `core.FixedLeaseKind` already share durable
   fixed-ID intent locking, replay validation, acquired-state commit, and

--- a/internal/providers/asciibox/backend.go
+++ b/internal/providers/asciibox/backend.go
@@ -642,25 +642,13 @@ func boxIDFromScope(scope string) string {
 }
 
 func boxClaimsByID(cfg core.Config) (map[string]core.LeaseClaim, error) {
-	claims, err := core.ListLeaseClaims()
-	if err != nil {
-		return nil, err
-	}
-	out := map[string]core.LeaseClaim{}
-	for _, claim := range claims {
-		if claim.Provider != providerName {
-			continue
-		}
+	return shared.IndexProviderClaims(providerName, func(claim core.LeaseClaim) string {
 		boxID := boxIDFromScope(claim.ProviderScope)
 		if claim.ProviderScope == (Provider{}).ClaimScope(cfg) {
 			boxID = claim.CloudID
 		}
-		if boxID == "" {
-			continue
-		}
-		out[boxID] = claim
-	}
-	return out, nil
+		return boxID
+	})
 }
 
 func isNotFound(err error) bool {

--- a/internal/providers/blaxel/backend.go
+++ b/internal/providers/blaxel/backend.go
@@ -36,17 +36,12 @@ func (b *backend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 		fmt.Fprintf(b.rt.Stderr, "warning: blaxel warmup keeps the sandbox until explicit stop\n")
 	}
 	total := now(b.rt).Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return core.WriteTimingJSON(b.rt.Stderr, core.TimingReport{
-			Provider: providerName,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *backend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {

--- a/internal/providers/coder/backend.go
+++ b/internal/providers/coder/backend.go
@@ -467,27 +467,20 @@ func (b *coderLeaseBackend) Cleanup(ctx context.Context, req core.CleanupRequest
 }
 
 func listCoderClaimsByWorkspace(cfg core.Config) (map[string]core.LeaseClaim, error) {
-	claims, err := core.ListLeaseClaims()
-	if err != nil {
-		return nil, err
-	}
-	out := map[string]core.LeaseClaim{}
-	for _, claim := range claims {
-		if claim.Provider != coderProvider {
-			continue
-		}
+	return shared.IndexProviderClaims(coderProvider, func(claim core.LeaseClaim) string {
 		name := coderClaimWorkspaceRef(claim)
 		if name == "" {
+			var err error
 			name, err = coderClaimWorkspaceName(cfg, claim)
 			if err != nil {
-				continue
+				return ""
 			}
 		}
-		if name != "" {
-			out[coderClaimKey(name)] = claim
+		if name == "" {
+			return ""
 		}
-	}
-	return out, nil
+		return coderClaimKey(name)
+	})
 }
 
 func coderClaimForWorkspace(claims map[string]core.LeaseClaim, workspace coderWorkspace) (core.LeaseClaim, bool) {

--- a/internal/providers/freestyle/backend.go
+++ b/internal/providers/freestyle/backend.go
@@ -72,17 +72,12 @@ func (b *freestyleBackend) Warmup(ctx context.Context, req core.WarmupRequest) e
 		fmt.Fprintf(b.rt.Stderr, "warning: freestyle warmup keeps the sandbox until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return core.WriteTimingJSON(b.rt.Stderr, core.TimingReport{
-			Provider: freestyleProvider,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: freestyleProvider,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *freestyleBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -1270,22 +1270,7 @@ func (b *backend) powershellWithEnv(ctx context.Context, script string, env []st
 }
 
 func providerClaims() (map[string]core.LeaseClaim, error) {
-	claims, err := core.ListLeaseClaims()
-	if err != nil {
-		return nil, err
-	}
-	out := map[string]core.LeaseClaim{}
-	for _, claim := range claims {
-		if claim.Provider != providerName {
-			continue
-		}
-		name := instanceNameFromClaim(claim)
-		if name == "" {
-			continue
-		}
-		out[name] = claim
-	}
-	return out, nil
+	return shared.IndexProviderClaims(providerName, instanceNameFromClaim)
 }
 
 func instanceScope(name string) string {

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -130,17 +130,12 @@ func (b *isloBackend) Warmup(ctx context.Context, req core.WarmupRequest) error 
 		fmt.Fprintf(b.rt.Stderr, "warning: islo warmup keeps the sandbox until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return core.WriteTimingJSON(b.rt.Stderr, core.TimingReport{
-			Provider: isloProvider,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: isloProvider,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *isloBackend) Run(ctx context.Context, req core.RunRequest) (result core.RunResult, retErr error) {

--- a/internal/providers/lume/backend.go
+++ b/internal/providers/lume/backend.go
@@ -1731,20 +1731,7 @@ func (b *backend) serverFromInstance(inst lumeVM, claim core.LeaseClaim, cfg cor
 }
 
 func providerClaims() (map[string]core.LeaseClaim, error) {
-	claims, err := core.ListLeaseClaims()
-	if err != nil {
-		return nil, err
-	}
-	out := map[string]core.LeaseClaim{}
-	for _, claim := range claims {
-		if claim.Provider != providerName {
-			continue
-		}
-		if name := instanceNameFromClaim(claim); name != "" {
-			out[name] = claim
-		}
-	}
-	return out, nil
+	return shared.IndexProviderClaims(providerName, instanceNameFromClaim)
 }
 
 func instanceScope(name string) string { return "instance:" + strings.TrimSpace(name) }

--- a/internal/providers/multipass/backend.go
+++ b/internal/providers/multipass/backend.go
@@ -655,22 +655,7 @@ func (b *backend) serverFromInstance(inst multipassInstance, claim core.LeaseCla
 }
 
 func providerClaims() (map[string]core.LeaseClaim, error) {
-	claims, err := core.ListLeaseClaims()
-	if err != nil {
-		return nil, err
-	}
-	out := map[string]core.LeaseClaim{}
-	for _, claim := range claims {
-		if claim.Provider != providerName {
-			continue
-		}
-		name := instanceNameFromClaim(claim)
-		if name == "" {
-			continue
-		}
-		out[name] = claim
-	}
-	return out, nil
+	return shared.IndexProviderClaims(providerName, instanceNameFromClaim)
 }
 
 func instanceScope(name string) string {

--- a/internal/providers/shared/claim.go
+++ b/internal/providers/shared/claim.go
@@ -230,3 +230,23 @@ func LabelsWithDefaults(labels, defaults map[string]string) map[string]string {
 	}
 	return labels
 }
+
+// IndexProviderClaims indexes stored snapshots using adapter-owned resource
+// keys. Empty keys are skipped and later snapshots win duplicate keys. The
+// index is a lookup aid; it does not grant ownership or mutation authority.
+func IndexProviderClaims(provider string, key func(core.LeaseClaim) string) (map[string]core.LeaseClaim, error) {
+	claims, err := core.ListLeaseClaims()
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]core.LeaseClaim{}
+	for _, claim := range claims {
+		if claim.Provider != provider {
+			continue
+		}
+		if name := key(claim); name != "" {
+			out[name] = claim
+		}
+	}
+	return out, nil
+}

--- a/internal/providers/shared/claim_test.go
+++ b/internal/providers/shared/claim_test.go
@@ -31,6 +31,43 @@ func TestCloneLabels(t *testing.T) {
 	}
 }
 
+func TestIndexProviderClaimsPreservesFilteringAndLastKeyWinner(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	ids := []string{"cbx_000000000001", "cbx_000000000002", "cbx_000000000003", "cbx_000000000004"}
+	for index, id := range ids {
+		provider, native := "example", "same"
+		if index == 2 {
+			native = ""
+		}
+		if index == 3 {
+			provider = "other"
+		}
+		server := core.Server{Provider: provider, CloudID: id, Labels: map[string]string{"native": native}}
+		if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(id, "fixture", provider, "scope", "", t.TempDir(), time.Minute, false, server, core.SSHTarget{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var visited []string
+	indexed, err := IndexProviderClaims("example", func(claim core.LeaseClaim) string {
+		if claim.Provider != "example" {
+			t.Fatal("key projection ran for a foreign provider")
+		}
+		visited = append(visited, claim.LeaseID)
+		return claim.Labels["native"]
+	})
+	if err != nil || len(indexed) != 1 || indexed["same"].LeaseID != ids[1] || !reflect.DeepEqual(visited, ids[:3]) {
+		t.Fatalf("index=%v visited=%v error=%v", indexed, visited, err)
+	}
+	empty, err := IndexProviderClaims("absent", func(core.LeaseClaim) string {
+		t.Fatal("key projection ran for an absent provider")
+		return ""
+	})
+	if err != nil || empty == nil || len(empty) != 0 {
+		t.Fatalf("empty index=%v error=%v", empty, err)
+	}
+	empty["writable"] = core.LeaseClaim{}
+}
+
 func TestLabelsWithDefaultsPreservesStoredValuesAndCopies(t *testing.T) {
 	stored := map[string]string{"provider": "stored", "state": "", "space": " ", "extra": "kept"}
 	defaults := map[string]string{"provider": "fallback", "state": "running", "space": "fallback", "empty": ""}

--- a/internal/providers/smolvm/backend.go
+++ b/internal/providers/smolvm/backend.go
@@ -47,17 +47,12 @@ func (b *backend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 		fmt.Fprintf(b.rt.Stderr, "warning: smolvm warmup keeps the machine until explicit stop\n")
 	}
 	total := b.now().Sub(started)
-	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
-	if req.TimingJSON {
-		return core.WriteTimingJSON(b.rt.Stderr, core.TimingReport{
-			Provider: providerName,
-			LeaseID:  leaseID,
-			Slug:     slug,
-			TotalMs:  total.Milliseconds(),
-			ExitCode: 0,
-		})
-	}
-	return nil
+	return shared.CompleteWarmup(b.rt, req.TimingJSON, shared.WarmupCompletion{
+		Provider: providerName,
+		LeaseID:  leaseID,
+		Slug:     slug,
+		Total:    total,
+	})
 }
 
 func (b *backend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -816,22 +816,7 @@ func (b *backend) serverFromInstance(inst tartInstance, claim core.LeaseClaim, c
 }
 
 func providerClaims() (map[string]core.LeaseClaim, error) {
-	claims, err := core.ListLeaseClaims()
-	if err != nil {
-		return nil, err
-	}
-	out := map[string]core.LeaseClaim{}
-	for _, claim := range claims {
-		if claim.Provider != providerName {
-			continue
-		}
-		name := instanceNameFromClaim(claim)
-		if name == "" {
-			continue
-		}
-		out[name] = claim
-	}
-	return out, nil
+	return shared.IndexProviderClaims(providerName, instanceNameFromClaim)
 }
 
 func instanceScope(name string) string {


### PR DESCRIPTION
Provider bookkeeping repeated claim enumeration/indexing and warmup completion reporting. A shared claim index now filters the selected provider and indexes snapshots using adapter-owned keys, preserving empty-key omission and the last duplicate-key winner. Six adapters use it; their key parsing and later ownership checks remain local.

Four other adapters now use the existing warmup completion reporter with unchanged timing and output values. Apple VM's legacy provider-name routing and Daytona's separate elapsed-time observations remain unchanged.

Validation: complete affected provider suites passed; claim-index race suites and Windows x64/ARM64 builds passed. A regression checks provider filtering, skipped keys, deterministic duplicate handling, and writable empty results. Scoped Codex review passed. No dependency, configuration, or credential changes.