### PR TITLE
refactor(providers): share bounded status waiting

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -1162,6 +1162,11 @@ own the remote workflow.
 `List` and `Status` should return normalized views. If the provider only offers a
 table or lossy native status shape, keep that parsing inside the backend.
 
+Providers that bound in-flight status requests use `shared.StatusWait` for the
+wait context, deadline, and cancellation precedence. Construct it at the
+adapter's existing resolution boundary; keep ownership validation, readiness,
+terminal states, retry policy, and status-view fields in the adapter.
+
 `Stop` should stop the provider resource, remove local claims, and remove local
 per-resource keys if the backend created them.
 

--- a/internal/providers/azuredynamicsessions/backend.go
+++ b/internal/providers/azuredynamicsessions/backend.go
@@ -191,60 +191,34 @@ func (b *azureDynamicSessionsBackend) Status(ctx context.Context, req core.Statu
 	if err != nil {
 		return core.StatusView{}, err
 	}
-	waitTimeout := req.WaitTimeout
-	if waitTimeout <= 0 {
-		waitTimeout = 5 * time.Minute
-	}
-	deadline := core.ClockNow(b.rt.Clock).Add(waitTimeout)
-	pollCtx := ctx
-	cancel := func() {}
-	if req.Wait {
-		pollCtx, cancel = context.WithTimeout(ctx, waitTimeout)
-	}
-	defer cancel()
-	leaseID, slug, err := b.resolveSessionID(pollCtx, client, req.ID, "", false)
+	wait := shared.NewStatusWait(ctx, req, b.rt.Clock, func(id string) error {
+		return core.Exit(5, "timed out waiting for session %s to become ready", id)
+	})
+	defer wait.Close()
+	leaseID, slug, err := b.resolveSessionID(wait.Context(), client, req.ID, "", false)
 	if err != nil {
 		return core.StatusView{}, err
 	}
 	for {
-		session, err := client.GetSession(pollCtx, leaseID)
+		session, err := client.GetSession(wait.Context(), leaseID)
 		if err == nil {
 			view := b.statusView(leaseID, slug, session)
 			if !req.Wait || view.Ready {
 				return view, nil
 			}
-			if core.ClockNow(b.rt.Clock).After(deadline) {
-				return core.StatusView{}, core.Exit(5, "timed out waiting for session %s to become ready", leaseID)
-			}
-			select {
-			case <-pollCtx.Done():
-				if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-					return core.StatusView{}, core.Exit(5, "timed out waiting for session %s to become ready", leaseID)
-				}
-				return core.StatusView{}, pollCtx.Err()
-			case <-time.After(2 * time.Second):
+			if err := wait.Next(leaseID, 2*time.Second); err != nil {
+				return core.StatusView{}, err
 			}
 			continue
 		}
-		if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-			return core.StatusView{}, core.Exit(5, "timed out waiting for session %s to become ready", leaseID)
-		}
-		if ctx.Err() != nil {
-			return core.StatusView{}, ctx.Err()
+		if ctxErr := wait.ContextError(leaseID); ctxErr != nil {
+			return core.StatusView{}, ctxErr
 		}
 		if !isNotFoundError(err) || !req.Wait {
 			return core.StatusView{}, providerError("get session", err)
 		}
-		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return core.StatusView{}, core.Exit(5, "timed out waiting for session %s to become ready", leaseID)
-		}
-		select {
-		case <-pollCtx.Done():
-			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return core.StatusView{}, core.Exit(5, "timed out waiting for session %s to become ready", leaseID)
-			}
-			return core.StatusView{}, pollCtx.Err()
-		case <-time.After(2 * time.Second):
+		if err := wait.Next(leaseID, 2*time.Second); err != nil {
+			return core.StatusView{}, err
 		}
 	}
 }

--- a/internal/providers/cloudflaresandbox/backend.go
+++ b/internal/providers/cloudflaresandbox/backend.go
@@ -269,25 +269,15 @@ func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.Stat
 	if !ok {
 		return core.StatusView{}, core.Exit(4, "cloudflare-sandbox sandbox %q is not claimed by Crabbox", req.ID)
 	}
-	waitTimeout := req.WaitTimeout
-	if waitTimeout <= 0 {
-		waitTimeout = 5 * time.Minute
-	}
-	deadline := core.ClockNow(b.rt.Clock).Add(waitTimeout)
-	pollCtx := ctx
-	cancel := func() {}
-	if req.Wait {
-		pollCtx, cancel = context.WithTimeout(ctx, waitTimeout)
-	}
-	defer cancel()
+	wait := shared.NewStatusWait(ctx, req, b.rt.Clock, func(id string) error {
+		return core.Exit(5, "timed out waiting for cloudflare-sandbox sandbox %s to become ready", id)
+	})
+	defer wait.Close()
 	for {
-		sb, getErr := api.GetSandbox(pollCtx, sandboxID)
+		sb, getErr := api.GetSandbox(wait.Context(), sandboxID)
 		if getErr != nil {
-			if req.Wait && ctx.Err() == nil && pollCtx.Err() != nil {
-				return core.StatusView{}, core.Exit(5, "timed out waiting for cloudflare-sandbox sandbox %s to become ready", sandboxID)
-			}
-			if ctx.Err() != nil {
-				return core.StatusView{}, ctx.Err()
+			if ctxErr := wait.ContextError(sandboxID); ctxErr != nil {
+				return core.StatusView{}, ctxErr
 			}
 			return core.StatusView{}, getErr
 		}
@@ -319,16 +309,8 @@ func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.Stat
 		if isTerminalState(state) {
 			return core.StatusView{}, core.Exit(5, "cloudflare-sandbox sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
-		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return core.StatusView{}, core.Exit(5, "timed out waiting for cloudflare-sandbox sandbox %s to become ready", sandboxID)
-		}
-		select {
-		case <-pollCtx.Done():
-			if ctx.Err() == nil {
-				return core.StatusView{}, core.Exit(5, "timed out waiting for cloudflare-sandbox sandbox %s to become ready", sandboxID)
-			}
-			return core.StatusView{}, pollCtx.Err()
-		case <-time.After(2 * time.Second):
+		if err := wait.Next(sandboxID, 2*time.Second); err != nil {
+			return core.StatusView{}, err
 		}
 	}
 }

--- a/internal/providers/codesandbox/backend.go
+++ b/internal/providers/codesandbox/backend.go
@@ -185,25 +185,15 @@ func (b *codeSandboxBackend) Status(ctx context.Context, req core.StatusRequest)
 	if err != nil {
 		return core.StatusView{}, err
 	}
-	waitTimeout := req.WaitTimeout
-	if waitTimeout <= 0 {
-		waitTimeout = 5 * time.Minute
-	}
-	deadline := core.ClockNow(b.rt.Clock).Add(waitTimeout)
-	pollCtx := ctx
-	cancel := func() {}
-	if req.Wait {
-		pollCtx, cancel = context.WithTimeout(ctx, waitTimeout)
-	}
-	defer cancel()
+	wait := shared.NewStatusWait(ctx, req, b.rt.Clock, func(id string) error {
+		return core.Exit(5, "timed out waiting for codesandbox sandbox %s to become ready", id)
+	})
+	defer wait.Close()
 	for {
-		sb, getErr := api.GetSandbox(pollCtx, sandboxID)
+		sb, getErr := api.GetSandbox(wait.Context(), sandboxID)
 		if getErr != nil {
-			if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return core.StatusView{}, core.Exit(5, "timed out waiting for codesandbox sandbox %s to become ready", sandboxID)
-			}
-			if ctx.Err() != nil {
-				return core.StatusView{}, ctx.Err()
+			if ctxErr := wait.ContextError(sandboxID); ctxErr != nil {
+				return core.StatusView{}, ctxErr
 			}
 			return core.StatusView{}, getErr
 		}
@@ -235,16 +225,8 @@ func (b *codeSandboxBackend) Status(ctx context.Context, req core.StatusRequest)
 		if isTerminalState(state) {
 			return core.StatusView{}, core.Exit(5, "codesandbox sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
-		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return core.StatusView{}, core.Exit(5, "timed out waiting for codesandbox sandbox %s to become ready", sandboxID)
-		}
-		select {
-		case <-pollCtx.Done():
-			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return core.StatusView{}, core.Exit(5, "timed out waiting for codesandbox sandbox %s to become ready", sandboxID)
-			}
-			return core.StatusView{}, pollCtx.Err()
-		case <-time.After(2 * time.Second):
+		if err := wait.Next(sandboxID, 2*time.Second); err != nil {
+			return core.StatusView{}, err
 		}
 	}
 }

--- a/internal/providers/codesandbox/claims.go
+++ b/internal/providers/codesandbox/claims.go
@@ -81,30 +81,7 @@ func resolveLeaseID(id string) (string, string, string, core.LeaseClaim, error) 
 }
 
 func resolveCodeSandboxLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
-	claims, err := listCodeSandboxLeaseClaims()
-	if err != nil {
-		return core.LeaseClaim{}, false, err
-	}
-	for _, claim := range claims {
-		if claim.Provider == providerName && claim.LeaseID == identifier {
-			if err := validateCodeSandboxClaimScope(claim); err != nil {
-				return core.LeaseClaim{}, false, err
-			}
-			return claim, true, nil
-		}
-	}
-	slug := core.NormalizeLeaseSlug(identifier)
-	if slug != "" {
-		for _, claim := range claims {
-			if claim.Provider == providerName && core.NormalizeLeaseSlug(claim.Slug) == slug {
-				if err := validateCodeSandboxClaimScope(claim); err != nil {
-					return core.LeaseClaim{}, false, err
-				}
-				return claim, true, nil
-			}
-		}
-	}
-	return core.LeaseClaim{}, false, nil
+	return shared.ResolveScopedLeaseClaim(identifier, providerName, listCodeSandboxLeaseClaims, validateCodeSandboxClaimScope)
 }
 
 func finishResolvedLease(claim core.LeaseClaim) (string, string, string, core.LeaseClaim, error) {

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -182,35 +182,22 @@ func (b *e2bBackend) Status(ctx context.Context, req core.StatusRequest) (core.S
 	if err != nil {
 		return core.StatusView{}, err
 	}
-	waitTimeout := req.WaitTimeout
-	if waitTimeout <= 0 {
-		waitTimeout = 5 * time.Minute
-	}
-	deadline := core.ClockNow(b.rt.Clock).Add(waitTimeout)
-	pollCtx := ctx
-	cancel := func() {}
-	if req.Wait {
-		pollCtx, cancel = context.WithTimeout(ctx, waitTimeout)
-	}
-	defer cancel()
-	leaseID, sandboxID, _, err := b.resolveSandboxID(pollCtx, client, req.ID, "", false)
+	wait := shared.NewStatusWait(ctx, req, b.rt.Clock, func(id string) error {
+		return core.Exit(5, "timed out waiting for sandbox %s to become ready", id)
+	})
+	defer wait.Close()
+	leaseID, sandboxID, _, err := b.resolveSandboxID(wait.Context(), client, req.ID, "", false)
 	if err != nil {
-		if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-			return core.StatusView{}, core.Exit(5, "timed out waiting for sandbox %s to become ready", req.ID)
-		}
-		if ctx.Err() != nil {
-			return core.StatusView{}, ctx.Err()
+		if ctxErr := wait.ContextError(req.ID); ctxErr != nil {
+			return core.StatusView{}, ctxErr
 		}
 		return core.StatusView{}, err
 	}
 	for {
-		sandbox, err := client.GetSandbox(pollCtx, sandboxID)
+		sandbox, err := client.GetSandbox(wait.Context(), sandboxID)
 		if err != nil {
-			if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return core.StatusView{}, core.Exit(5, "timed out waiting for sandbox %s to become ready", sandboxID)
-			}
-			if ctx.Err() != nil {
-				return core.StatusView{}, ctx.Err()
+			if ctxErr := wait.ContextError(sandboxID); ctxErr != nil {
+				return core.StatusView{}, ctxErr
 			}
 			return core.StatusView{}, e2bError("get sandbox", err)
 		}
@@ -218,16 +205,8 @@ func (b *e2bBackend) Status(ctx context.Context, req core.StatusRequest) (core.S
 		if !req.Wait || view.Ready {
 			return view, nil
 		}
-		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return core.StatusView{}, core.Exit(5, "timed out waiting for sandbox %s to become ready", sandboxID)
-		}
-		select {
-		case <-pollCtx.Done():
-			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return core.StatusView{}, core.Exit(5, "timed out waiting for sandbox %s to become ready", sandboxID)
-			}
-			return core.StatusView{}, pollCtx.Err()
-		case <-time.After(2 * time.Second):
+		if err := wait.Next(sandboxID, 2*time.Second); err != nil {
+			return core.StatusView{}, err
 		}
 	}
 }

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -236,25 +236,15 @@ func (b *openComputerBackend) Status(ctx context.Context, req core.StatusRequest
 	if !ok {
 		return core.StatusView{}, core.Exit(4, "opencomputer sandbox %q is not claimed by Crabbox", req.ID)
 	}
-	waitTimeout := req.WaitTimeout
-	if waitTimeout <= 0 {
-		waitTimeout = 5 * time.Minute
-	}
-	deadline := core.ClockNow(b.rt.Clock).Add(waitTimeout)
-	pollCtx := ctx
-	cancel := func() {}
-	if req.Wait {
-		pollCtx, cancel = context.WithTimeout(ctx, waitTimeout)
-	}
-	defer cancel()
+	wait := shared.NewStatusWait(ctx, req, b.rt.Clock, func(id string) error {
+		return core.Exit(5, "timed out waiting for opencomputer sandbox %s to become ready", id)
+	})
+	defer wait.Close()
 	for {
-		sb, getErr := api.getSandboxWithTags(pollCtx, sandboxID)
+		sb, getErr := api.getSandboxWithTags(wait.Context(), sandboxID)
 		if getErr != nil {
-			if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return core.StatusView{}, core.Exit(5, "timed out waiting for opencomputer sandbox %s to become ready", sandboxID)
-			}
-			if ctx.Err() != nil {
-				return core.StatusView{}, ctx.Err()
+			if ctxErr := wait.ContextError(sandboxID); ctxErr != nil {
+				return core.StatusView{}, ctxErr
 			}
 			// Surface real API failures (auth, 5xx, sandbox gone) instead of
 			// masking them as a not-ready status.
@@ -287,16 +277,8 @@ func (b *openComputerBackend) Status(ctx context.Context, req core.StatusRequest
 		if isTerminalState(state) {
 			return core.StatusView{}, core.Exit(5, "opencomputer sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
-		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return core.StatusView{}, core.Exit(5, "timed out waiting for opencomputer sandbox %s to become ready", sandboxID)
-		}
-		select {
-		case <-pollCtx.Done():
-			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return core.StatusView{}, core.Exit(5, "timed out waiting for opencomputer sandbox %s to become ready", sandboxID)
-			}
-			return core.StatusView{}, pollCtx.Err()
-		case <-time.After(2 * time.Second):
+		if err := wait.Next(sandboxID, 2*time.Second); err != nil {
+			return core.StatusView{}, err
 		}
 	}
 }

--- a/internal/providers/opensandbox/backend.go
+++ b/internal/providers/opensandbox/backend.go
@@ -345,25 +345,15 @@ func (b *openSandboxBackend) Status(ctx context.Context, req core.StatusRequest)
 	if !ok {
 		return core.StatusView{}, core.Exit(4, "opensandbox sandbox %q is not claimed by Crabbox", req.ID)
 	}
-	waitTimeout := req.WaitTimeout
-	if waitTimeout <= 0 {
-		waitTimeout = 5 * time.Minute
-	}
-	deadline := core.ClockNow(b.rt.Clock).Add(waitTimeout)
-	pollCtx := ctx
-	cancel := func() {}
-	if req.Wait {
-		pollCtx, cancel = context.WithTimeout(ctx, waitTimeout)
-	}
-	defer cancel()
+	wait := shared.NewStatusWait(ctx, req, b.rt.Clock, func(id string) error {
+		return core.Exit(5, "timed out waiting for opensandbox sandbox %s to become ready", id)
+	})
+	defer wait.Close()
 	for {
-		sb, getErr := api.GetSandbox(pollCtx, sandboxID)
+		sb, getErr := api.GetSandbox(wait.Context(), sandboxID)
 		if getErr != nil {
-			if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return core.StatusView{}, core.Exit(5, "timed out waiting for opensandbox sandbox %s to become ready", sandboxID)
-			}
-			if ctx.Err() != nil {
-				return core.StatusView{}, ctx.Err()
+			if ctxErr := wait.ContextError(sandboxID); ctxErr != nil {
+				return core.StatusView{}, ctxErr
 			}
 			return core.StatusView{}, getErr
 		}
@@ -373,15 +363,14 @@ func (b *openSandboxBackend) Status(ctx context.Context, req core.StatusRequest)
 		state := strings.ToLower(strings.TrimSpace(sb.State))
 		ready := false
 		if isReadyState(state) {
-			probeCtx, probeCancel := context.WithTimeout(pollCtx, b.statusProbeTimeout())
+			probeCtx, probeCancel := context.WithTimeout(wait.Context(), b.statusProbeTimeout())
 			pingErr := api.PingSandbox(probeCtx, sandboxID)
 			probeCancel()
 			ready = pingErr == nil
-			if pingErr != nil && pollCtx.Err() != nil {
-				if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-					return core.StatusView{}, core.Exit(5, "timed out waiting for opensandbox sandbox %s to become ready", sandboxID)
+			if pingErr != nil {
+				if ctxErr := wait.ContextError(sandboxID); ctxErr != nil {
+					return core.StatusView{}, ctxErr
 				}
-				return core.StatusView{}, pollCtx.Err()
 			}
 			if pingErr != nil && !isOpenSandboxReadinessPending(pingErr) {
 				return core.StatusView{}, fmt.Errorf("opensandbox status execd health: %w", pingErr)
@@ -410,16 +399,8 @@ func (b *openSandboxBackend) Status(ctx context.Context, req core.StatusRequest)
 		if isTerminalState(state) {
 			return core.StatusView{}, core.Exit(5, "opensandbox sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
-		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return core.StatusView{}, core.Exit(5, "timed out waiting for opensandbox sandbox %s to become ready", sandboxID)
-		}
-		select {
-		case <-pollCtx.Done():
-			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return core.StatusView{}, core.Exit(5, "timed out waiting for opensandbox sandbox %s to become ready", sandboxID)
-			}
-			return core.StatusView{}, pollCtx.Err()
-		case <-time.After(b.statusPollInterval()):
+		if err := wait.Next(sandboxID, b.statusPollInterval()); err != nil {
+			return core.StatusView{}, err
 		}
 	}
 }

--- a/internal/providers/shared/status_wait.go
+++ b/internal/providers/shared/status_wait.go
@@ -1,0 +1,66 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// StatusWait bounds provider requests as well as the delay between polls.
+// Adapters retain resolution, readiness, terminal-state, and API-error policy.
+type StatusWait struct {
+	parent   context.Context
+	ctx      context.Context
+	cancel   context.CancelFunc
+	clock    core.Clock
+	deadline time.Time
+	timeout  func(string) error
+}
+
+func NewStatusWait(ctx context.Context, req core.StatusRequest, clock core.Clock, timeout func(string) error) *StatusWait {
+	duration := req.WaitTimeout
+	if duration <= 0 {
+		duration = 5 * time.Minute
+	}
+	wait := &StatusWait{
+		parent:   ctx,
+		ctx:      ctx,
+		cancel:   func() {},
+		clock:    clock,
+		deadline: core.ClockNow(clock).Add(duration),
+		timeout:  timeout,
+	}
+	if req.Wait {
+		wait.ctx, wait.cancel = context.WithTimeout(ctx, duration)
+	}
+	return wait
+}
+
+func (w *StatusWait) Context() context.Context { return w.ctx }
+
+func (w *StatusWait) Close() { w.cancel() }
+
+// ContextError distinguishes our deadline from cancellation by the caller.
+// Call it only at transport/probe boundaries, never over ownership errors.
+func (w *StatusWait) ContextError(id string) error {
+	if errors.Is(w.ctx.Err(), context.DeadlineExceeded) && w.parent.Err() == nil {
+		return w.timeout(id)
+	}
+	return w.parent.Err()
+}
+
+// Next is called only after a waiting adapter has ruled out readiness and
+// terminal states. The adapter clock deadline takes precedence at this point.
+func (w *StatusWait) Next(id string, interval time.Duration) error {
+	if core.ClockNow(w.clock).After(w.deadline) {
+		return w.timeout(id)
+	}
+	select {
+	case <-w.ctx.Done():
+		return w.ContextError(id)
+	case <-time.After(interval):
+		return nil
+	}
+}

--- a/internal/providers/shared/status_wait_test.go
+++ b/internal/providers/shared/status_wait_test.go
@@ -1,0 +1,92 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestStatusWaitContextBoundaries(t *testing.T) {
+	timeout := func(id string) error { return fmt.Errorf("waiting for %s", id) }
+	t.Run("own deadline uses current identifier", func(t *testing.T) {
+		wait := NewStatusWait(context.Background(), core.StatusRequest{Wait: true, WaitTimeout: time.Millisecond}, nil, timeout)
+		defer wait.Close()
+		<-wait.Context().Done()
+		for _, id := range []string{"requested-slug", "resolved-id"} {
+			if err := wait.ContextError(id); err == nil || err.Error() != "waiting for "+id {
+				t.Fatalf("ContextError(%q) = %v", id, err)
+			}
+		}
+	})
+	t.Run("parent cancellation wins over expired child", func(t *testing.T) {
+		parent, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		wait := NewStatusWait(parent, core.StatusRequest{Wait: true, WaitTimeout: time.Millisecond}, nil, timeout)
+		defer wait.Close()
+		<-wait.Context().Done()
+		cancel()
+		if err := wait.ContextError("id"); err != context.Canceled {
+			t.Fatalf("ContextError = %v", err)
+		}
+	})
+	t.Run("parent deadline stays a context error", func(t *testing.T) {
+		parent, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+		wait := NewStatusWait(parent, core.StatusRequest{Wait: true}, nil, timeout)
+		defer wait.Close()
+		if err := wait.ContextError("id"); err != context.DeadlineExceeded {
+			t.Fatalf("ContextError = %v", err)
+		}
+	})
+	t.Run("nonwaiting requests keep the parent context", func(t *testing.T) {
+		parent, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		wait := NewStatusWait(parent, core.StatusRequest{WaitTimeout: time.Nanosecond}, nil, timeout)
+		if wait.Context() != parent || wait.ContextError("id") != nil {
+			t.Fatal("nonwaiting request received a child context or an error")
+		}
+		wait.Close()
+		if parent.Err() != nil {
+			t.Fatal("closing the wait canceled its parent")
+		}
+		cancel()
+		if err := wait.ContextError("id"); err != context.Canceled {
+			t.Fatalf("ContextError = %v", err)
+		}
+	})
+}
+
+func TestStatusWaitNextUsesClockAndCancellation(t *testing.T) {
+	expired := errors.New("adapter timeout")
+	for _, duration := range []time.Duration{0, -time.Second, time.Minute} {
+		t.Run(duration.String(), func(t *testing.T) {
+			clock := &sandboxTestClock{current: time.Now()}
+			parent, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			wait := NewStatusWait(parent, core.StatusRequest{Wait: true, WaitTimeout: duration}, clock, func(string) error { return expired })
+			defer wait.Close()
+			if err := wait.ContextError("id"); err != nil {
+				t.Fatalf("healthy context = %v", err)
+			}
+			if duration <= 0 {
+				duration = 5 * time.Minute
+			}
+			clock.current = clock.current.Add(duration)
+			if err := wait.Next("id", 0); err != nil {
+				t.Fatalf("exact deadline should still poll: %v", err)
+			}
+			cancel()
+			if err := wait.Next("id", time.Hour); err != context.Canceled {
+				t.Fatalf("canceled timer wait = %v", err)
+			}
+			clock.current = clock.current.Add(time.Nanosecond)
+			if err := wait.Next("id", time.Hour); err != expired {
+				t.Fatalf("elapsed adapter deadline should take precedence: %v", err)
+			}
+		})
+	}
+}

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -280,25 +280,15 @@ func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.Stat
 	if !ok {
 		return core.StatusView{}, core.Exit(4, "superserve sandbox %q is not claimed by Crabbox", req.ID)
 	}
-	waitTimeout := req.WaitTimeout
-	if waitTimeout <= 0 {
-		waitTimeout = 5 * time.Minute
-	}
-	deadline := core.ClockNow(b.rt.Clock).Add(waitTimeout)
-	pollCtx := ctx
-	cancel := func() {}
-	if req.Wait {
-		pollCtx, cancel = context.WithTimeout(ctx, waitTimeout)
-	}
-	defer cancel()
+	wait := shared.NewStatusWait(ctx, req, b.rt.Clock, func(id string) error {
+		return core.Exit(5, "timed out waiting for superserve sandbox %s to become ready", id)
+	})
+	defer wait.Close()
 	for {
-		sb, getErr := api.GetSandbox(pollCtx, sandboxID)
+		sb, getErr := api.GetSandbox(wait.Context(), sandboxID)
 		if getErr != nil {
-			if req.Wait && ctx.Err() == nil && pollCtx.Err() != nil {
-				return core.StatusView{}, core.Exit(5, "timed out waiting for superserve sandbox %s to become ready", sandboxID)
-			}
-			if ctx.Err() != nil {
-				return core.StatusView{}, ctx.Err()
+			if ctxErr := wait.ContextError(sandboxID); ctxErr != nil {
+				return core.StatusView{}, ctxErr
 			}
 			return core.StatusView{}, getErr
 		}
@@ -330,16 +320,8 @@ func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.Stat
 		if isTerminalState(state) {
 			return core.StatusView{}, core.Exit(5, "superserve sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
-		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return core.StatusView{}, core.Exit(5, "timed out waiting for superserve sandbox %s to become ready", sandboxID)
-		}
-		select {
-		case <-pollCtx.Done():
-			if ctx.Err() == nil {
-				return core.StatusView{}, core.Exit(5, "timed out waiting for superserve sandbox %s to become ready", sandboxID)
-			}
-			return core.StatusView{}, pollCtx.Err()
-		case <-time.After(2 * time.Second):
+		if err := wait.Next(sandboxID, 2*time.Second); err != nil {
+			return core.StatusView{}, err
 		}
 	}
 }

--- a/internal/providers/vercelsandbox/backend.go
+++ b/internal/providers/vercelsandbox/backend.go
@@ -249,25 +249,15 @@ func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.Stat
 	if !ok {
 		return core.StatusView{}, core.Exit(4, "vercel-sandbox sandbox %q is not claimed by Crabbox", req.ID)
 	}
-	waitTimeout := req.WaitTimeout
-	if waitTimeout <= 0 {
-		waitTimeout = 5 * time.Minute
-	}
-	deadline := core.ClockNow(b.rt.Clock).Add(waitTimeout)
-	pollCtx := ctx
-	cancel := func() {}
-	if req.Wait {
-		pollCtx, cancel = context.WithTimeout(ctx, waitTimeout)
-	}
-	defer cancel()
+	wait := shared.NewStatusWait(ctx, req, b.rt.Clock, func(id string) error {
+		return core.Exit(5, "timed out waiting for vercel-sandbox sandbox %s to become ready", id)
+	})
+	defer wait.Close()
 	for {
-		sb, getErr := api.GetSandbox(pollCtx, sandboxID)
+		sb, getErr := api.GetSandbox(wait.Context(), sandboxID)
 		if getErr != nil {
-			if req.Wait && ctx.Err() == nil && pollCtx.Err() != nil {
-				return core.StatusView{}, core.Exit(5, "timed out waiting for vercel-sandbox sandbox %s to become ready", sandboxID)
-			}
-			if ctx.Err() != nil {
-				return core.StatusView{}, ctx.Err()
+			if ctxErr := wait.ContextError(sandboxID); ctxErr != nil {
+				return core.StatusView{}, ctxErr
 			}
 			return core.StatusView{}, getErr
 		}
@@ -299,16 +289,8 @@ func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.Stat
 		if isTerminalState(state) {
 			return core.StatusView{}, core.Exit(5, "vercel-sandbox sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
 		}
-		if core.ClockNow(b.rt.Clock).After(deadline) {
-			return core.StatusView{}, core.Exit(5, "timed out waiting for vercel-sandbox sandbox %s to become ready", sandboxID)
-		}
-		select {
-		case <-pollCtx.Done():
-			if ctx.Err() == nil {
-				return core.StatusView{}, core.Exit(5, "timed out waiting for vercel-sandbox sandbox %s to become ready", sandboxID)
-			}
-			return core.StatusView{}, pollCtx.Err()
-		case <-time.After(2 * time.Second):
+		if err := wait.Next(sandboxID, 2*time.Second); err != nil {
+			return core.StatusView{}, err
 		}
 	}
 }


### PR DESCRIPTION
## What Problem This Solves

Eight provider status commands duplicate the same bounded wait and cancellation mechanism.

## User Impact

No user-visible change: status output, provider errors, timeout messages, ownership checks, and readiness decisions remain the same. No config, credential, or migration changes.

## Why This Change Was Made

`shared.StatusWait` owns the five-minute default, bounded request context, clock deadline, and delay between polls. Each adapter retains its resolution boundary, view fields, terminal-state policy, and API error handling. Azure still retries missing sessions, E2B keeps the original identifier for resolution errors, and OpenSandbox retains its shorter health-probe timeout. CodeSandbox also uses the existing scoped claim resolver instead of maintaining an identical copy.

This removes 113 net handwritten production lines; tests and documentation are excluded.

## Evidence

All eight provider suites and the shared suite passed locally. Deadline/cancellation regressions passed 20 repetitions under the race detector, including parent cancellation versus the child's deadline, nonwaiting requests, fake-clock boundaries, and requested versus resolved identifiers. CodeSandbox and shared suites passed again after the resolver adoption. Required scoped Autoreview passed. All nine packages also passed under the race detector on Linux, followed by Windows amd64/arm64 CLI builds (Crabbox run `run_73af72a85b5e219f21d4af3881a8c5db`). CI supplies full-suite validation.
