### PR TITLE
refactor(cli): reuse slug normalization

### DIFF
--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -3427,26 +3427,7 @@ func cleanGitHubRepo(owner, name string) (GitHubRepo, error) {
 }
 
 func sanitizeGitHubRunnerLabel(value string) string {
-	value = strings.ToLower(strings.TrimSpace(value))
-	var b strings.Builder
-	lastDash := false
-	for _, r := range value {
-		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
-		if ok {
-			b.WriteRune(r)
-			lastDash = false
-			continue
-		}
-		if !lastDash {
-			b.WriteByte('-')
-			lastDash = true
-		}
-	}
-	out := strings.Trim(b.String(), "-")
-	if out == "" {
-		return "unknown"
-	}
-	return out
+	return blank(normalizeLeaseSlug(value), "unknown")
 }
 
 func ghOutputWithChildEnvironment(ctx context.Context, dir string, childEnvDenylist []string, args ...string) (string, error) {

--- a/internal/cli/capsule.go
+++ b/internal/cli/capsule.go
@@ -1012,26 +1012,7 @@ func capsuleReplayFailureOutcome(failureSignature, replayOutput string, code int
 }
 
 func safePathComponent(value string) string {
-	value = strings.ToLower(strings.TrimSpace(value))
-	var b strings.Builder
-	lastDash := false
-	for _, r := range value {
-		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
-		if ok {
-			b.WriteRune(r)
-			lastDash = false
-			continue
-		}
-		if !lastDash {
-			b.WriteByte('-')
-			lastDash = true
-		}
-	}
-	out := strings.Trim(b.String(), "-")
-	if out == "" {
-		return "capsule"
-	}
-	return out
+	return blank(normalizeLeaseSlug(value), "capsule")
 }
 
 func sha256String(value string) string {


### PR DESCRIPTION
## What Problem This Solves

Runner labels and capsule path components each duplicate Crabbox's existing lowercase ASCII slug normalizer.

## User Impact

No user-visible change. The same input produces the same output, including `unknown` for empty runner labels and `capsule` for empty path components. No config or credential implications.

## Why This Change Was Made

Both callers now use `normalizeLeaseSlug` and retain their own fallback. This deletes two duplicate algorithms and removes 38 net production lines.

## Evidence

Existing slug, label, and capsule tests passed under the race detector. Required scoped Autoreview passed.
