### PR TITLE
refactor(providers): share compatible sandbox views

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -1169,6 +1169,10 @@ own the remote workflow.
 `List` and `Status` should return normalized views. If the provider only offers a
 table or lossy native status shape, keep that parsing inside the backend.
 
+E2B-compatible adapters use `shared.EnvdSandboxViews` to project their common
+wire metadata. Provider identity and legacy ID prefixes stay explicit; resource
+ownership validation remains in each adapter.
+
 `Stop` should stop the provider resource, remove local claims, and remove local
 per-resource keys if the backend created them.
 

--- a/internal/providers/cubesandbox/backend.go
+++ b/internal/providers/cubesandbox/backend.go
@@ -28,6 +28,8 @@ type cubesandboxFlagValues struct {
 
 const cubesandboxCleanupTimeout = 30 * time.Second
 
+var sandboxViews = shared.EnvdSandboxViews{Provider: providerName, LeasePrefix: "cubesandbox_"}
+
 func RegisterCubeSandboxProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return cubesandboxFlagValues{
 		APIURL:        fs.String("cubesandbox-api-url", defaults.CubeSandbox.APIURL, "CubeSandbox API URL"),
@@ -244,7 +246,7 @@ func (b *cubesandboxBackend) List(ctx context.Context, req core.ListRequest) ([]
 	}
 	servers := make([]core.Server, 0, len(sandboxes))
 	for _, sandbox := range sandboxes {
-		servers = append(servers, cubesandboxSandboxToServer(sandbox))
+		servers = append(servers, sandboxViews.Server(sandbox))
 	}
 	return servers, nil
 }
@@ -275,7 +277,7 @@ func (b *cubesandboxBackend) Status(ctx context.Context, req core.StatusRequest)
 		if err != nil {
 			return core.StatusView{}, cubesandboxError("get sandbox", err)
 		}
-		view := cubesandboxStatusView(leaseID, sandbox)
+		view := sandboxViews.Status(leaseID, sandbox)
 		if !req.Wait || view.Ready {
 			return view, nil
 		}
@@ -356,9 +358,9 @@ func (b *cubesandboxBackend) ReclaimAndStop(ctx context.Context, req core.StopRe
 	if previousExists && previous.RepoRoot != "" {
 		claim, err = claimLeaseTargetForRepoConfigIfUnchanged(
 			leaseID,
-			cubesandboxSlug(leaseID, sandbox),
+			shared.EnvdSandboxSlug(leaseID, sandbox),
 			cfg,
-			cubesandboxSandboxToServer(sandbox), core.SSHTarget{}, previous.RepoRoot,
+			sandboxViews.Server(sandbox), core.SSHTarget{}, previous.RepoRoot,
 			cfg.IdleTimeout,
 			true,
 			previous,
@@ -367,9 +369,9 @@ func (b *cubesandboxBackend) ReclaimAndStop(ctx context.Context, req core.StopRe
 	} else {
 		claim, err = claimLeaseTargetForConfigIfUnchanged(
 			leaseID,
-			cubesandboxSlug(leaseID, sandbox),
+			shared.EnvdSandboxSlug(leaseID, sandbox),
 			cfg,
-			cubesandboxSandboxToServer(sandbox), core.SSHTarget{}, cfg.IdleTimeout,
+			sandboxViews.Server(sandbox), core.SSHTarget{}, cfg.IdleTimeout,
 			previous,
 			previousExists,
 		)
@@ -426,7 +428,7 @@ func (b *cubesandboxBackend) createSandbox(ctx context.Context, client shared.En
 		return "", shared.EnvdSandbox{}, "", core.Exit(5, "cubesandbox create sandbox returned no sandbox id")
 	}
 	cfg = cubesandboxClaimConfig(cfg)
-	server := cubesandboxSandboxToServer(sandbox)
+	server := sandboxViews.Server(sandbox)
 	if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, core.SSHTarget{}, repo.Root, cfg.IdleTimeout, reclaim); err != nil {
 		if cleanupErr := b.deleteSandboxForCleanup(client, sandbox.SandboxID); cleanupErr != nil {
 			leakErr := fmt.Errorf("cleanup cubesandbox sandbox %s after claim failure: %w; run `crabbox stop --provider cubesandbox --id %s --reclaim` to retry cleanup", sandbox.SandboxID, cleanupErr, sandbox.SandboxID)
@@ -510,9 +512,9 @@ func (b *cubesandboxBackend) resolveSandboxID(ctx context.Context, client shared
 	}
 	claim, err = claimLeaseTargetForRepoConfigIfUnchanged(
 		leaseID,
-		cubesandboxSlug(leaseID, sandbox),
+		shared.EnvdSandboxSlug(leaseID, sandbox),
 		cfg,
-		cubesandboxSandboxToServer(sandbox), core.SSHTarget{}, repoRoot,
+		sandboxViews.Server(sandbox), core.SSHTarget{}, repoRoot,
 		cfg.IdleTimeout,
 		true,
 		previous,
@@ -563,7 +565,7 @@ func (b *cubesandboxBackend) resolveClaimedSandbox(ctx context.Context, client s
 			claim.LeaseID,
 			claim.Slug,
 			cfg,
-			cubesandboxSandboxToServer(sandbox), core.SSHTarget{}, repoRoot,
+			sandboxViews.Server(sandbox), core.SSHTarget{}, repoRoot,
 			time.Duration(claim.IdleTimeoutSeconds)*time.Second,
 			reclaim,
 			claim,
@@ -636,73 +638,6 @@ func cubesandboxClaimConfig(cfg core.Config) core.Config {
 		cfg.CubeSandbox.APIURL = "http://127.0.0.1:3000"
 	}
 	return cfg
-}
-
-func cubesandboxSandboxToServer(sandbox shared.EnvdSandbox) core.Server {
-	labels := map[string]string{}
-	for k, v := range sandbox.Metadata {
-		labels[k] = v
-	}
-	labels["provider"] = providerName
-	labels["lease"] = cubesandboxLeaseID(sandbox)
-	if labels["slug"] == "" {
-		labels["slug"] = core.NewLeaseSlug(labels["lease"])
-	}
-	labels["target"] = targetLinux
-	if labels["state"] == "" {
-		labels["state"] = sandbox.State
-	}
-	server := core.Server{
-		Provider: providerName,
-		CloudID:  sandbox.SandboxID,
-		Name:     sandbox.SandboxID,
-		Status:   sandbox.State,
-		Labels:   labels,
-	}
-	server.ServerType.Name = core.Blank(sandbox.Alias, sandbox.TemplateID)
-	if server.ServerType.Name == "" {
-		server.ServerType.Name = "base"
-	}
-	return server
-}
-
-func cubesandboxStatusView(leaseID string, sandbox shared.EnvdSandbox) core.StatusView {
-	server := cubesandboxSandboxToServer(sandbox)
-	return core.StatusView{
-		ID:         leaseID,
-		Slug:       cubesandboxSlug(leaseID, sandbox),
-		Provider:   providerName,
-		TargetOS:   targetLinux,
-		State:      sandbox.State,
-		ServerID:   sandbox.SandboxID,
-		ServerType: server.ServerType.Name,
-		Network:    NetworkPublic,
-		Ready:      cubesandboxStatusReady(sandbox.State),
-		Labels:     server.Labels,
-	}
-}
-
-func cubesandboxStatusReady(status string) bool {
-	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "", "running":
-		return true
-	default:
-		return false
-	}
-}
-
-func cubesandboxLeaseID(sandbox shared.EnvdSandbox) string {
-	if lease := strings.TrimSpace(sandbox.Metadata["lease"]); lease != "" {
-		return lease
-	}
-	return "cubesandbox_" + sandbox.SandboxID
-}
-
-func cubesandboxSlug(leaseID string, sandbox shared.EnvdSandbox) string {
-	if slug := strings.TrimSpace(sandbox.Metadata["slug"]); slug != "" {
-		return slug
-	}
-	return core.NewLeaseSlug(leaseID)
 }
 
 func isCubeSandboxSyntheticID(id string) bool {

--- a/internal/providers/cubesandbox/backend_test.go
+++ b/internal/providers/cubesandbox/backend_test.go
@@ -847,11 +847,11 @@ func TestCubeSandboxCreateSandboxRejectsUnsafeWorkdirBeforeAPI(t *testing.T) {
 
 func TestCubeSandboxStatusReady(t *testing.T) {
 	for _, status := range []string{"", "running"} {
-		if !cubesandboxStatusReady(status) {
+		if !shared.EnvdSandboxStatusReady(status) {
 			t.Fatalf("expected %q ready", status)
 		}
 	}
-	if cubesandboxStatusReady("paused") {
+	if shared.EnvdSandboxStatusReady("paused") {
 		t.Fatal("paused should not be ready")
 	}
 }
@@ -1179,7 +1179,7 @@ func TestCubeSandboxRunPreservesAbnormalProcessExitCode(t *testing.T) {
 }
 
 func TestCubeSandboxSandboxToServerUsesMetadata(t *testing.T) {
-	server := cubesandboxSandboxToServer(shared.EnvdSandbox{
+	server := sandboxViews.Server(shared.EnvdSandbox{
 		SandboxID:  "sbx_1",
 		TemplateID: "base",
 		State:      "running",
@@ -1465,7 +1465,7 @@ func TestCubeSandboxReclaimAndStopPreservesRepoBoundClaim(t *testing.T) {
 			"slug":     "reclaim-me",
 		},
 	}
-	if err := claimLeaseTargetForRepoConfig(leaseID, "reclaim-me", firstCfg, cubesandboxSandboxToServer(sandbox), core.SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+	if err := claimLeaseTargetForRepoConfig(leaseID, "reclaim-me", firstCfg, sandboxViews.Server(sandbox), core.SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
 	client := &fakeCubeSandboxSyncClient{sandbox: sandbox}

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -16,6 +16,8 @@ import (
 
 const e2bCleanupTimeout = 30 * time.Second
 
+var sandboxViews = shared.EnvdSandboxViews{Provider: e2bProvider, LeasePrefix: "e2b_"}
+
 func RegisterE2BProviderFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return core.RegisterE2BConfigFlags(fs, defaults.E2B)
 }
@@ -164,7 +166,7 @@ func (b *e2bBackend) List(ctx context.Context, req core.ListRequest) ([]core.Lea
 	}
 	servers := make([]core.Server, 0, len(sandboxes))
 	for _, sandbox := range sandboxes {
-		servers = append(servers, e2bSandboxToServer(sandbox))
+		servers = append(servers, sandboxViews.Server(sandbox))
 	}
 	return servers, nil
 }
@@ -214,7 +216,7 @@ func (b *e2bBackend) Status(ctx context.Context, req core.StatusRequest) (core.S
 			}
 			return core.StatusView{}, e2bError("get sandbox", err)
 		}
-		view := e2bStatusView(leaseID, sandbox)
+		view := sandboxViews.Status(leaseID, sandbox)
 		if !req.Wait || view.Ready {
 			return view, nil
 		}
@@ -307,7 +309,7 @@ func (b *e2bBackend) ReclaimAndStop(ctx context.Context, req core.StopRequest) e
 			leaseID,
 			slug,
 			cfg,
-			e2bSandboxToServer(sandbox), core.SSHTarget{}, previous.RepoRoot,
+			sandboxViews.Server(sandbox), core.SSHTarget{}, previous.RepoRoot,
 			cfg.IdleTimeout,
 			true,
 			previous,
@@ -318,7 +320,7 @@ func (b *e2bBackend) ReclaimAndStop(ctx context.Context, req core.StopRequest) e
 			leaseID,
 			slug,
 			cfg,
-			e2bSandboxToServer(sandbox), core.SSHTarget{}, cfg.IdleTimeout,
+			sandboxViews.Server(sandbox), core.SSHTarget{}, cfg.IdleTimeout,
 			previous,
 			previousExists,
 		)
@@ -372,7 +374,7 @@ func (b *e2bBackend) createSandbox(ctx context.Context, client shared.EnvdSandbo
 		return "", shared.EnvdSandbox{}, "", core.Exit(5, "e2b create sandbox returned no sandbox id")
 	}
 	cfg = e2bClaimConfig(cfg)
-	if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, e2bSandboxToServer(sandbox), core.SSHTarget{}, repo.Root, cfg.IdleTimeout, reclaim); err != nil {
+	if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, sandboxViews.Server(sandbox), core.SSHTarget{}, repo.Root, cfg.IdleTimeout, reclaim); err != nil {
 		if cleanupErr := b.deleteSandboxForCleanup(client, sandbox.SandboxID); cleanupErr != nil {
 			leakErr := fmt.Errorf("cleanup e2b sandbox %s after claim failure: %w; run `crabbox stop --provider e2b --id %s --reclaim` to retry cleanup", sandbox.SandboxID, cleanupErr, sandbox.SandboxID)
 			fmt.Fprintf(b.rt.Stderr, "warning: %v\n", leakErr)
@@ -542,7 +544,7 @@ func (b *e2bBackend) resolveSandboxID(ctx context.Context, client shared.EnvdSan
 					claim.LeaseID,
 					claim.Slug,
 					cfg,
-					e2bSandboxToServer(sandbox), core.SSHTarget{}, repoRoot,
+					sandboxViews.Server(sandbox), core.SSHTarget{}, repoRoot,
 					time.Duration(claim.IdleTimeoutSeconds)*time.Second,
 					reclaim,
 					claim,
@@ -574,20 +576,20 @@ func (b *e2bBackend) resolveSandboxID(ctx context.Context, client shared.EnvdSan
 		if !isCrabboxE2BSandbox(sandbox) {
 			return "", "", "", core.Exit(4, "e2b sandbox %q is not claimed by Crabbox", id)
 		}
-		leaseID := e2bLeaseID(sandbox)
-		return leaseID, sandbox.SandboxID, e2bSlug(leaseID, sandbox), nil
+		leaseID := sandboxViews.LeaseID(sandbox)
+		return leaseID, sandbox.SandboxID, shared.EnvdSandboxSlug(leaseID, sandbox), nil
 	}
 	if strings.HasPrefix(id, "cbx_") {
 		sandbox, err := resolveE2BSandboxByLease(ctx, client, id)
 		if err != nil {
 			return "", "", "", err
 		}
-		return id, sandbox.SandboxID, e2bSlug(id, sandbox), nil
+		return id, sandbox.SandboxID, shared.EnvdSandboxSlug(id, sandbox), nil
 	}
 	sandbox, err := client.GetSandbox(ctx, id)
 	if err == nil && isCrabboxE2BSandbox(sandbox) {
-		leaseID := e2bLeaseID(sandbox)
-		return leaseID, sandbox.SandboxID, e2bSlug(leaseID, sandbox), nil
+		leaseID := sandboxViews.LeaseID(sandbox)
+		return leaseID, sandbox.SandboxID, shared.EnvdSandboxSlug(leaseID, sandbox), nil
 	}
 	if err != nil && !isNotFoundError(err) {
 		return "", "", "", e2bError("get sandbox", err)
@@ -606,73 +608,6 @@ func resolveE2BSandboxByLease(ctx context.Context, client shared.EnvdSandboxAPI,
 		}
 	}
 	return shared.EnvdSandbox{}, core.Exit(4, "e2b lease %q was not found", leaseID)
-}
-
-func e2bSandboxToServer(sandbox shared.EnvdSandbox) core.Server {
-	labels := map[string]string{}
-	for k, v := range sandbox.Metadata {
-		labels[k] = v
-	}
-	labels["provider"] = e2bProvider
-	labels["lease"] = e2bLeaseID(sandbox)
-	if labels["slug"] == "" {
-		labels["slug"] = core.NewLeaseSlug(labels["lease"])
-	}
-	labels["target"] = targetLinux
-	if labels["state"] == "" {
-		labels["state"] = sandbox.State
-	}
-	server := core.Server{
-		Provider: e2bProvider,
-		CloudID:  sandbox.SandboxID,
-		Name:     sandbox.SandboxID,
-		Status:   sandbox.State,
-		Labels:   labels,
-	}
-	server.ServerType.Name = core.Blank(sandbox.Alias, sandbox.TemplateID)
-	if server.ServerType.Name == "" {
-		server.ServerType.Name = "base"
-	}
-	return server
-}
-
-func e2bStatusView(leaseID string, sandbox shared.EnvdSandbox) core.StatusView {
-	server := e2bSandboxToServer(sandbox)
-	return core.StatusView{
-		ID:         leaseID,
-		Slug:       e2bSlug(leaseID, sandbox),
-		Provider:   e2bProvider,
-		TargetOS:   targetLinux,
-		State:      sandbox.State,
-		ServerID:   sandbox.SandboxID,
-		ServerType: server.ServerType.Name,
-		Network:    NetworkPublic,
-		Ready:      e2bStatusReady(sandbox.State),
-		Labels:     server.Labels,
-	}
-}
-
-func e2bStatusReady(status string) bool {
-	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "", "running":
-		return true
-	default:
-		return false
-	}
-}
-
-func e2bLeaseID(sandbox shared.EnvdSandbox) string {
-	if lease := strings.TrimSpace(sandbox.Metadata["lease"]); lease != "" {
-		return lease
-	}
-	return "e2b_" + sandbox.SandboxID
-}
-
-func e2bSlug(leaseID string, sandbox shared.EnvdSandbox) string {
-	if slug := strings.TrimSpace(sandbox.Metadata["slug"]); slug != "" {
-		return slug
-	}
-	return core.NewLeaseSlug(leaseID)
 }
 
 func isE2BSyntheticID(id string) bool {

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -500,7 +500,7 @@ func TestE2BTemplateAcquisitionAndMetadataDefaultAreDistinct(t *testing.T) {
 			if fake.createReq.TemplateID != want {
 				t.Fatalf("template=%q want=%q", fake.createReq.TemplateID, want)
 			}
-			if e2bSandboxToServer(sandbox).ServerType.Name != "base" {
+			if sandboxViews.Server(sandbox).ServerType.Name != "base" {
 				t.Fatal("missing remote metadata inferred configured template")
 			}
 		})
@@ -1073,11 +1073,11 @@ func TestE2BCreateSandboxRejectsUnsafeWorkdirBeforeAPI(t *testing.T) {
 
 func TestE2BStatusReady(t *testing.T) {
 	for _, status := range []string{"", "running"} {
-		if !e2bStatusReady(status) {
+		if !shared.EnvdSandboxStatusReady(status) {
 			t.Fatalf("expected %q ready", status)
 		}
 	}
-	if e2bStatusReady("paused") {
+	if shared.EnvdSandboxStatusReady("paused") {
 		t.Fatal("paused should not be ready")
 	}
 }
@@ -1370,7 +1370,7 @@ func TestE2BRunCleanupUsesExactClaim(t *testing.T) {
 }
 
 func TestE2BSandboxToServerUsesMetadata(t *testing.T) {
-	server := e2bSandboxToServer(shared.EnvdSandbox{
+	server := sandboxViews.Server(shared.EnvdSandbox{
 		SandboxID:  "sbx_1",
 		TemplateID: "base",
 		State:      "running",

--- a/internal/providers/shared/envd_views.go
+++ b/internal/providers/shared/envd_views.go
@@ -1,0 +1,76 @@
+package shared
+
+import (
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// EnvdSandboxViews projects compatible sandbox metadata into Crabbox views.
+// The adapter supplies its provider identity and legacy synthetic-ID prefix.
+type EnvdSandboxViews struct {
+	Provider    string
+	LeasePrefix string
+}
+
+func (v EnvdSandboxViews) Server(sandbox EnvdSandbox) core.Server {
+	leaseID := v.LeaseID(sandbox)
+	labels := LabelsWithDefaults(sandbox.Metadata, map[string]string{
+		"slug":  core.NewLeaseSlug(leaseID),
+		"state": sandbox.State,
+	})
+	labels["provider"] = v.Provider
+	labels["lease"] = leaseID
+	labels["target"] = core.TargetLinux
+	server := core.Server{
+		Provider: v.Provider,
+		CloudID:  sandbox.SandboxID,
+		Name:     sandbox.SandboxID,
+		Status:   sandbox.State,
+		Labels:   labels,
+	}
+	server.ServerType.Name = core.Blank(sandbox.Alias, sandbox.TemplateID)
+	if server.ServerType.Name == "" {
+		server.ServerType.Name = "base"
+	}
+	return server
+}
+
+func (v EnvdSandboxViews) Status(leaseID string, sandbox EnvdSandbox) core.StatusView {
+	server := v.Server(sandbox)
+	return core.StatusView{
+		ID:         leaseID,
+		Slug:       EnvdSandboxSlug(leaseID, sandbox),
+		Provider:   v.Provider,
+		TargetOS:   core.TargetLinux,
+		State:      sandbox.State,
+		ServerID:   sandbox.SandboxID,
+		ServerType: server.ServerType.Name,
+		Network:    core.NetworkPublic,
+		Ready:      EnvdSandboxStatusReady(sandbox.State),
+		Labels:     server.Labels,
+	}
+}
+
+func (v EnvdSandboxViews) LeaseID(sandbox EnvdSandbox) string {
+	if lease := strings.TrimSpace(sandbox.Metadata["lease"]); lease != "" {
+		return lease
+	}
+	return v.LeasePrefix + sandbox.SandboxID
+}
+
+func EnvdSandboxSlug(leaseID string, sandbox EnvdSandbox) string {
+	if slug := strings.TrimSpace(sandbox.Metadata["slug"]); slug != "" {
+		return slug
+	}
+	return core.NewLeaseSlug(leaseID)
+}
+
+func EnvdSandboxStatusReady(state string) bool {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "", "running":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/providers/shared/envd_views_test.go
+++ b/internal/providers/shared/envd_views_test.go
@@ -1,0 +1,55 @@
+package shared
+
+import (
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestEnvdSandboxViewsPreserveMetadataAndStatusIdentity(t *testing.T) {
+	views := EnvdSandboxViews{Provider: "compatible", LeasePrefix: "legacy_"}
+	sandbox := EnvdSandbox{
+		SandboxID:  "remote-id",
+		State:      " RUNNING ",
+		TemplateID: "template",
+		Metadata: map[string]string{
+			"provider": "untrusted", "target": "other", "lease": "  metadata-lease  ",
+			"slug": "  display-slug  ", "state": "label-state", "custom": "kept",
+		},
+	}
+	view := views.Status("requested-lease", sandbox)
+	if view.ID != "requested-lease" || view.Labels["lease"] != "metadata-lease" {
+		t.Fatalf("request and metadata identities conflated: %#v", view)
+	}
+	if view.Slug != "display-slug" || view.Labels["slug"] != "  display-slug  " {
+		t.Fatalf("display and raw metadata slug conflated: %#v", view)
+	}
+	if view.State != " RUNNING " || view.Labels["state"] != "label-state" || !view.Ready {
+		t.Fatalf("live and metadata states conflated: %#v", view)
+	}
+	if view.Provider != "compatible" || view.Labels["provider"] != "compatible" || view.Labels["target"] != core.TargetLinux || view.Labels["custom"] != "kept" {
+		t.Fatalf("metadata projection = %#v", view)
+	}
+	view.Labels["custom"] = "changed"
+	if sandbox.Metadata["custom"] != "kept" || sandbox.Metadata["provider"] != "untrusted" {
+		t.Fatal("view mutated source metadata")
+	}
+}
+
+func TestEnvdSandboxViewsUseAdapterFallbackIdentity(t *testing.T) {
+	for _, prefix := range []string{"e2b_", "cubesandbox_"} {
+		views := EnvdSandboxViews{Provider: "compatible", LeasePrefix: prefix}
+		sandbox := EnvdSandbox{SandboxID: "remote-id"}
+		server := views.Server(sandbox)
+		leaseID := prefix + "remote-id"
+		if server.Labels["lease"] != leaseID || server.Labels["slug"] != core.NewLeaseSlug(leaseID) || server.ServerType.Name != "base" {
+			t.Fatalf("fallback projection = %#v", server)
+		}
+		if _, exists := server.Labels["state"]; !exists {
+			t.Fatal("empty state label was omitted")
+		}
+		if !views.Status(leaseID, sandbox).Ready {
+			t.Fatal("compatible empty state stopped being ready")
+		}
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

E2B and CubeSandbox maintain duplicate projections of their compatible sandbox metadata into Crabbox server and status views.

## User Impact

No user-visible change. Provider names, legacy synthetic IDs, status readiness, template fallbacks, and label values stay the same. No config or credential implications.

## Why This Change Was Made

The compatible adapters now share `EnvdSandboxViews`, with provider identity and the legacy ID prefix supplied explicitly. Metadata remains copied before labeling, and requested lease identity, metadata identity, raw labels, and display values remain distinct. The old projection functions are removed. Ownership validation remains in each adapter.

This removes 54 net production lines; tests and documentation are excluded.

## Evidence

The shared, E2B, and CubeSandbox suites passed. New regressions cover metadata immutability, raw versus display labels, requested versus metadata identity, synthetic prefixes, and empty-state behavior. Required scoped Autoreview passed, including integration with the bounded status-wait refactor. The combined source passed full Go vet and race tests, Windows amd64/arm64 builds, both Worker/Node typechecks and builds, lint/format, and 3,175 Worker tests (three existing environment-dependent skips), in Crabbox run `run_43d074ff7ccee1dbc6232f44f250b754`.
