### PR TITLE
refactor(proof): reuse preset placeholder validation

### DIFF
--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 )
@@ -541,29 +540,10 @@ func renderProofTemplateField(label, templateValue, fallback string, values map[
 	if strings.TrimSpace(templateValue) == "" {
 		return strings.TrimSpace(fallback), nil
 	}
-	if err := validateProofTemplatePlaceholders(label, templateValue, values); err != nil {
+	if err := validatePresetTemplatePlaceholders("proof template "+label, templateValue, values); err != nil {
 		return "", err
 	}
 	return expandPresetValue(templateValue, values), nil
-}
-
-func validateProofTemplatePlaceholders(label, value string, values map[string]string) error {
-	matches := presetPlaceholderPattern.FindAllString(value, -1)
-	if len(matches) == 0 {
-		return nil
-	}
-	var missing []string
-	for _, match := range appendUniqueStrings(nil, matches...) {
-		key := strings.TrimSuffix(strings.TrimPrefix(match, "{{"), "}}")
-		if _, ok := values[key]; !ok {
-			missing = append(missing, match)
-		}
-	}
-	if len(missing) == 0 {
-		return nil
-	}
-	sort.Strings(missing)
-	return exit(2, "proof template %s has unresolved preset variable(s): %s", label, strings.Join(missing, ", "))
 }
 
 func markdownFence(info, content string) (string, string) {


### PR DESCRIPTION
## What Problem This Solves

Proof templates use preset expansion but maintain a duplicate validator for unresolved preset placeholders.

## User Impact

No user-visible change. Unresolved placeholders retain the same sorted, unique error list and proof-template error prefix. No config or credential implications.

## Why This Change Was Made

Proof-template rendering now calls the existing preset validator with its label prefix. The duplicate validator and unused import are removed, deleting 20 net production lines.

## Evidence

Existing preset, proof rendering, and proof-template tests passed under the race detector. Required scoped Autoreview passed.
