### PR TITLE
fix: confirm portable workspace gate creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Keep portable workspace ownership exclusive when a runner's mkdir reports success after losing a directory-creation race.
+- Keep portable workspace ownership exclusive when a runner's mkdir reports success after losing a directory-creation race. [PR 2201](https://github.com/openclaw/crabbox/pull/2201).
 
 - Resolve macOS managed-state path spelling without scanning unrelated sibling files, so crowded temporary directories do not block sync preparation. [PR 2187](https://github.com/openclaw/crabbox/pull/2187).
 - Keep Linode lease metadata consistent with the created instance type when an explicit type contains only whitespace. [PR 2186](https://github.com/openclaw/crabbox/pull/2186).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Keep portable workspace ownership exclusive when a runner's mkdir reports success after losing a directory-creation race.
+
 - Resolve macOS managed-state path spelling without scanning unrelated sibling files, so crowded temporary directories do not block sync preparation. [PR 2187](https://github.com/openclaw/crabbox/pull/2187).
 - Keep Linode lease metadata consistent with the created instance type when an explicit type contains only whitespace. [PR 2186](https://github.com/openclaw/crabbox/pull/2186).
 - Avoid unnecessary sibling traversal for nested artifact globs with an exact, safe literal directory prefix, preserving matching, archive membership, and collection limits. [PR 2162](https://github.com/openclaw/crabbox/pull/2162). Thanks @vincentkoc.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -63,7 +63,10 @@ and SIGQUIT dispositions, including intentionally ignored signals.
 
 POSIX workspace ownership uses `flock`, BSD `lockf`, or an atomic directory gate
 when neither tool is available. Acquire, renewal, release, and foreground-child
-registration share the same gate. The directory fallback never steals a gate
+registration share the same gate. The directory fallback requires a
+BSD/GNU-compatible `mkdir -v` creation receipt, so a tool that
+incorrectly returns success for an existing directory cannot grant ownership.
+It never steals a gate
 based on elapsed time: an interrupted helper may still have a writer in flight.
 Stop and replace a managed lease if that gate remains ambiguous. Normal owner
 expiry recovery still requires proof that the recorded foreground child exited.

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -635,7 +635,9 @@ func workspaceOwnerPOSIXGate(timeout string) string {
     /bin/sh -c '
       gate_dir="$1.portable"
       remaining="$2"
-      while ! mkdir -m 700 "$gate_dir" 2>/dev/null; do
+      # Some mkdir implementations return success after an EEXIST race.
+      # Require the verbose creation receipt as well as a successful exit.
+      while ! { created=$(mkdir -m 700 -v "$gate_dir" 2>/dev/null) && [ -n "$created" ]; }; do
         # A successful contender may already have removed the gate.
         [ ! -f "$gate_dir" ] && [ ! -L "$gate_dir" ] || exit 74
         [ "$remaining" -gt 0 ] || exit 73

--- a/internal/cli/workspace_owner_bsd_test.go
+++ b/internal/cli/workspace_owner_bsd_test.go
@@ -187,6 +187,48 @@ func TestWorkspaceOwnerBSDConcurrentAcquireAndWitness(t *testing.T) {
 	}
 }
 
+func TestWorkspaceOwnerBSDGateRequiresConfirmedDirectoryCreation(t *testing.T) {
+	for _, tc := range []struct {
+		name, output string
+		code         int
+	}{
+		{name: "success without creation"},
+		{name: "output with failure", output: "created", code: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			nativeMkdir, err := exec.LookPath("mkdir")
+			if err != nil {
+				t.Fatal(err)
+			}
+			path, home := workspaceOwnerBSDPath(t), t.TempDir()
+			mkdir := filepath.Join(path, "mkdir")
+			if err := os.Remove(mkdir); err != nil {
+				t.Fatal(err)
+			}
+			// Model mkdir implementations that return success after losing an
+			// EEXIST race, and ensure failed commands cannot grant the gate.
+			stub := "#!/bin/sh\ncase \"$*\" in *'.gate.portable'*) printf %s " + shellQuote(tc.output) + "; exit " + strconv.Itoa(tc.code) + " ;; esac\nexec " + shellQuote(nativeMkdir) + " \"$@\"\n"
+			if err := os.WriteFile(mkdir, []byte(stub), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			key := workspaceOwnerKey("occupied-portable-gate")
+			gate := filepath.Join(home, ".crabbox", "workspace-owners", key+".gate.portable")
+			if err := os.MkdirAll(gate, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			req := workspaceOwnerRemoteRequest{Action: workspaceOwnerAcquire, Key: key, Token: strings.Repeat("a", 64), TTL: time.Minute}
+			cmd := exec.CommandContext(t.Context(), "/bin/sh", "-c", remoteWorkspaceOwnerPOSIX(req))
+			cmd.Env = []string{"HOME=" + home, "PATH=" + path}
+			if out, err := cmd.CombinedOutput(); err != nil || string(out) != "BUSY" {
+				t.Fatalf("occupied gate: out=%q err=%v", out, err)
+			}
+			if info, err := os.Stat(gate); err != nil || !info.IsDir() {
+				t.Fatalf("contender changed the existing gate: %v", err)
+			}
+		})
+	}
+}
+
 func TestWorkspaceOwnerBSDDetachedAndRenewingCommand(t *testing.T) {
 	testWorkspaceOwnerDetachedAndRenewingCommand(t, workspaceOwnerBSDPath(t))
 }


### PR DESCRIPTION
## What Problem This Solves

Portable workspace locking can admit two contenders when a runner's mkdir returns success after losing the directory-creation race.

## User Impact

Workspace operations stay exclusive on runners using the directory-lock fallback, including the affected uutils implementation. The fallback requires BSD/GNU-compatible `mkdir -v`; native flock and lockf routing remains unchanged. No credentials or configuration changes.

## Why This Change Was Made

The directory gate now requires a successful exit and a nonempty verbose creation receipt. Existing gate paths, retry deadlines, invalid-file checks, and the rule against stealing an occupied gate remain intact.

Linux syscall tracing confirmed mkdir returned EEXIST while uutils mkdir 0.8.0 exited zero. Its [source](https://github.com/uutils/coreutils/blob/0.8.0/src/uu/mkdir/src/mkdir.rs) treats a raced existing directory as success, but prints its verbose receipt only after actual creation.

## Evidence

A deterministic regression fails on the old implementation for success without creation and for output from a failing command. Both cases now preserve the existing gate and return BUSY. The BSD protocol, concurrent acquisition, and new regressions passed 20 repetitions under the race detector on macOS. Required scoped Autoreview passed. On Linux with uutils mkdir 0.8.0, the concurrency and creation-receipt regressions passed 200 race-enabled repetitions, followed by the entire workspace-owner suite under the race detector (Crabbox run `run_4b8452a24b8abc119a428fe0cb431876`).
