### PR TITLE
refactor(cua): remove unreachable provisioning helpers

### DIFF
--- a/internal/providers/cua/bridge.go
+++ b/internal/providers/cua/bridge.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	_ "embed"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -100,10 +99,6 @@ func newBridgeClient(cfg core.Config, rt core.Runtime) *bridgeClient {
 	return &bridgeClient{cfg: cfg, rt: rt}
 }
 
-func (c *bridgeClient) CreateSandbox(ctx context.Context, metadata map[string]string) (bridgeSandboxSummary, error) {
-	return bridgeSandboxSummary{}, provisioningUnsupported()
-}
-
 func (c *bridgeClient) ListSandboxes(ctx context.Context) ([]bridgeSandboxSummary, error) {
 	resp, err := c.RoundTrip(ctx, bridgeRequest{Action: "list"})
 	if err != nil {
@@ -160,16 +155,6 @@ func bridgeResponseError(action string, resp bridgeResponse) error {
 		class:  strings.TrimSpace(core.Blank(resp.Error.Class, resp.Class)),
 		msg:    strings.TrimSpace(resp.Error.Message),
 	}
-}
-
-func isCUANotFound(err error) bool {
-	var actionErr *bridgeActionError
-	if !errors.As(err, &actionErr) {
-		return false
-	}
-	class := strings.ToLower(strings.TrimSpace(actionErr.class))
-	code := strings.ToLower(strings.TrimSpace(actionErr.code))
-	return class == "not_found" || code == "not_found" || code == "notfound" || code == "notfounderror" || code == "sandboxnotfounderror"
 }
 
 func (c *bridgeClient) RoundTrip(ctx context.Context, req bridgeRequest) (bridgeResponse, error) {

--- a/internal/providers/cua/bridge_test.go
+++ b/internal/providers/cua/bridge_test.go
@@ -158,27 +158,6 @@ func TestBridgeSendsJSONOnStdinAndMapsSecretOnlyToSDKEnv(t *testing.T) {
 	}
 }
 
-func TestNotFoundClassificationRequiresStructuredSignal(t *testing.T) {
-	for _, err := range []error{
-		&bridgeActionError{class: "not_found", code: "HTTPStatusError", msg: "missing"},
-		&bridgeActionError{class: "cleanup_failed", code: "SandboxNotFoundError", msg: "missing"},
-	} {
-		if !isCUANotFound(err) {
-			t.Fatalf("isCUANotFound(%v)=false, want true", err)
-		}
-	}
-	for _, err := range []error{
-		&bridgeActionError{class: "cleanup_failed", code: "RuntimeError", msg: "request to sandbox-404 timed out"},
-		&bridgeActionError{class: "cleanup_failed", code: "RuntimeError", msg: "not found in response text"},
-		&bridgeActionError{class: "cleanup_failed", code: "FileNotFoundError", msg: "local file missing"},
-		&bridgeActionError{class: "cleanup_failed", code: "ModuleNotFoundError", msg: "SDK module missing"},
-	} {
-		if isCUANotFound(err) {
-			t.Fatalf("isCUANotFound(%v)=true for unstructured message", err)
-		}
-	}
-}
-
 func TestBridgeRedactsSecretFromCommandFailure(t *testing.T) {
 	secret := "placeholder"
 	t.Setenv("CRABBOX_CUA_API_KEY", secret)
@@ -218,10 +197,7 @@ func TestBridgeRedactsSecretBeforeTruncatingFailure(t *testing.T) {
 func TestBridgeMutationsFailClosedBeforeRunner(t *testing.T) {
 	runner := &recordingRunner{}
 	client := newBridgeClient(testConfig(), core.Runtime{Exec: runner})
-	if _, err := client.CreateSandbox(context.Background(), map[string]string{"lease": "test"}); err == nil || !strings.Contains(err.Error(), "idempotency key") || !strings.Contains(err.Error(), cuaTrackingIssue) {
-		t.Fatalf("CreateSandbox err=%v, want actionable provisioning guard", err)
-	}
-	if _, err := client.RoundTrip(context.Background(), bridgeRequest{Action: "create"}); err == nil || !strings.Contains(err.Error(), "idempotency key") {
+	if _, err := client.RoundTrip(context.Background(), bridgeRequest{Action: "create"}); err == nil || !strings.Contains(err.Error(), "idempotency key") || !strings.Contains(err.Error(), cuaTrackingIssue) {
 		t.Fatalf("RoundTrip(create) err=%v, want provisioning guard", err)
 	}
 	if _, err := client.RoundTrip(context.Background(), bridgeRequest{Action: "delete"}); err == nil || !strings.Contains(err.Error(), "atomically") {

--- a/internal/providers/cua/claims.go
+++ b/internal/providers/cua/claims.go
@@ -1,11 +1,8 @@
 package cua
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"os"
 	"strings"
-	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -15,21 +12,7 @@ const (
 	scopePrefix      = "cua-account-sha256:"
 	labelSandboxName = "cua.sandbox.name"
 	labelCreatedAt   = "cua.created-at"
-	labelImage       = "cua.image"
-	labelKind        = "cua.kind"
-	labelRegion      = "cua.region"
-	labelWorkdir     = "cua.workdir"
-	labelTTLSeconds  = "cua.ttl-seconds"
-	labelMissing     = "cua.missing"
 )
-
-func newCUALeaseID() string {
-	var b [6]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return leasePrefix + strings.ReplaceAll(time.Now().UTC().Format("20060102150405.000000"), ".", "")
-	}
-	return leasePrefix + hex.EncodeToString(b[:])
-}
 
 func cuaScope(cfg core.Config) (string, error) {
 	apiURL, err := cuaAPIURL(cfg)
@@ -127,8 +110,4 @@ func validateSandboxOwnership(claim core.LeaseClaim, sandbox bridgeSandboxSummar
 		return core.Exit(4, "CUA sandbox %q creation identity does not match its local claim", expectedName)
 	}
 	return nil
-}
-
-func claimIsMissing(claim core.LeaseClaim) bool {
-	return claim.Labels != nil && claim.Labels[labelMissing] == "true"
 }

--- a/internal/providers/cua/claims_test.go
+++ b/internal/providers/cua/claims_test.go
@@ -16,26 +16,19 @@ func claimLabels(cfg core.Config, sandboxName, createdAt string, missing bool) m
 	workdir, _ := cuaWorkdir(cfg)
 	labels := map[string]string{
 		labelSandboxName: sandboxName,
-		labelImage:       strings.TrimSpace(core.Blank(cfg.Cua.Image, core.CuaConfigDefaultImage)),
-		labelKind:        strings.ToLower(strings.TrimSpace(core.Blank(cfg.Cua.Kind, core.CuaConfigDefaultKind))),
-		labelRegion:      strings.TrimSpace(cfg.Cua.Region),
-		labelWorkdir:     workdir,
+		"cua.image":      strings.TrimSpace(core.Blank(cfg.Cua.Image, core.CuaConfigDefaultImage)),
+		"cua.kind":       strings.ToLower(strings.TrimSpace(core.Blank(cfg.Cua.Kind, core.CuaConfigDefaultKind))),
+		"cua.region":     strings.TrimSpace(cfg.Cua.Region),
+		"cua.workdir":    workdir,
 		labelCreatedAt:   strings.TrimSpace(createdAt),
 	}
 	if cfg.TTL > 0 {
-		labels[labelTTLSeconds] = fmt.Sprintf("%d", int64(cfg.TTL/time.Second))
+		labels["cua.ttl-seconds"] = fmt.Sprintf("%d", int64(cfg.TTL/time.Second))
 	}
 	if missing {
-		labels[labelMissing] = "true"
+		labels["cua.missing"] = "true"
 	}
 	return labels
-}
-
-func TestCUALeaseIDUsesProviderPrefix(t *testing.T) {
-	leaseID := newCUALeaseID()
-	if !strings.HasPrefix(leaseID, leasePrefix) {
-		t.Fatalf("leaseID=%q missing %q", leaseID, leasePrefix)
-	}
 }
 
 func TestCUAScopeNormalizesAPIURL(t *testing.T) {
@@ -87,7 +80,7 @@ func TestResolveClaimFiltersProviderAndScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve claim: %v", err)
 	}
-	if !ok || claim.LeaseID != "cuabx_111111111111" || !claimIsMissing(claim) {
+	if !ok || claim.LeaseID != "cuabx_111111111111" || claim.Labels["cua.missing"] != "true" {
 		t.Fatalf("claim=%#v ok=%v", claim, ok)
 	}
 	other := cfg


### PR DESCRIPTION
## What Problem This Solves

The read-only CUA adapter still contains unreachable provisioning and cleanup helpers.

## User Impact

No user-visible change. Diagnostics and inventory work as before; mutation requests still fail before invoking the Python bridge. Existing claim scope and resource identity checks remain intact. No config or credential changes.

## Why This Change Was Made

Remove the unused create method, lease-ID generator, not-found classifier, and missing-claim helper. Fixture-only label names now live directly in the fixture. Tests exercise the live RoundTrip mutation guard, including its tracking-issue guidance, instead of a redundant method that never reaches production.

This removes 36 net production lines and 67 lines overall.

## Evidence

The full CUA suite passed under the race detector locally and on Linux. The Windows CLI build passed. Linux proof: Crabbox run run_046ed20a4a3ec9fd3ed709fad4b4e090. Required scoped Autoreview passed.
