### PR TITLE
refactor(providers): bind hooks directly to core functions

### DIFF
--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -813,7 +813,7 @@ var newAWSClient = func(ctx context.Context, cfg core.Config) (awsClient, error)
 	return core.NewAWSClient(ctx, cfg)
 }
 
-var ensureAWSSSHCIDRs = func(ctx context.Context, cfg *core.Config) { core.EnsureAWSSSHCIDRs(ctx, cfg) }
+var ensureAWSSSHCIDRs = core.EnsureAWSSSHCIDRs
 
 // bootstrapSSHHost returns the address used for the acquisition readiness probe.
 // Strict Tailscale mode cannot fall back to the public address, which can be

--- a/internal/providers/exedev/core.go
+++ b/internal/providers/exedev/core.go
@@ -1,10 +1,6 @@
 package exedev
 
 import (
-	"context"
-	"io"
-	"time"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
@@ -16,10 +12,6 @@ const (
 	networkPublic = core.NetworkPublic
 )
 
-var claimLeaseTargetForRepoConfigScopeIfUnchanged = func(leaseID, slug string, cfg core.Config, providerScope string, server core.Server, target core.SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected core.LeaseClaim, expectedExists bool) (core.LeaseClaim, error) {
-	return core.ClaimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug, cfg, providerScope, server, target, repoRoot, idleTimeout, reclaim, expected, expectedExists)
-}
+var claimLeaseTargetForRepoConfigScopeIfUnchanged = core.ClaimLeaseTargetForRepoConfigScopeIfUnchanged
 
-var waitForSSHReady = func(ctx context.Context, target *core.SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
-	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
-}
+var waitForSSHReady = core.WaitForSSHReady

--- a/internal/providers/multipass/core.go
+++ b/internal/providers/multipass/core.go
@@ -1,11 +1,6 @@
 package multipass
 
 import (
-	"context"
-
-	"io"
-	"time"
-
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
@@ -15,26 +10,14 @@ const (
 	sshPort      = "22"
 )
 
-var claimLeaseForRepoProviderScopePond = func(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProviderScopePond(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim)
-}
+var claimLeaseForRepoProviderScopePond = core.ClaimLeaseForRepoProviderScopePond
 
-var claimLeaseForRepoProviderScopePondEndpoint = func(leaseID, slug, provider, providerScope, pond, repoRoot string, idleTimeout time.Duration, reclaim bool, server core.Server, target core.SSHTarget) error {
-	return core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, provider, providerScope, pond, repoRoot, idleTimeout, reclaim, server, target)
-}
+var claimLeaseForRepoProviderScopePondEndpoint = core.ClaimLeaseForRepoProviderScopePondEndpoint
 
-var removeLeaseClaim = func(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
+var removeLeaseClaim = core.RemoveLeaseClaim
 
-var updateLeaseClaimEndpoint = func(leaseID string, server core.Server, target core.SSHTarget) error {
-	return core.UpdateLeaseClaimEndpoint(leaseID, server, target)
-}
+var updateLeaseClaimEndpoint = core.UpdateLeaseClaimEndpoint
 
-var updateLeaseClaimCacheVolumes = func(leaseID string, specs []string) error {
-	return core.UpdateLeaseClaimCacheVolumes(leaseID, specs)
-}
+var updateLeaseClaimCacheVolumes = core.UpdateLeaseClaimCacheVolumes
 
-var waitForSSHReady = func(ctx context.Context, target *core.SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
-	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
-}
+var waitForSSHReady = core.WaitForSSHReady

--- a/internal/providers/xcpng/backend.go
+++ b/internal/providers/xcpng/backend.go
@@ -812,25 +812,17 @@ var newLifecycleClient = func(ctx context.Context, cfg core.Config) (lifecycleCl
 	return newXAPIClient(ctx, cfg)
 }
 
-var newLeaseID = func() string { return core.NewLeaseID() }
-var allocateDirectLeaseSlug = func(id, requested string, servers []core.Server) (string, error) {
-	return core.AllocateDirectLeaseSlug(id, requested, servers)
-}
-var ensureTestboxKeyForConfig = func(cfg core.Config, leaseID string) (string, string, error) {
-	return core.EnsureTestboxKeyForConfig(cfg, leaseID)
-}
-var providerKeyForLease = func(leaseID string) string { return core.ProviderKeyForLease(leaseID) }
-var sshTargetFromConfig = func(cfg core.Config, host string) core.SSHTarget { return core.SSHTargetFromConfig(cfg, host) }
-var waitForSSHReady = func(ctx context.Context, target *core.SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
-	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
-}
-var bootstrapWaitTimeout = func(cfg core.Config) time.Duration { return core.BootstrapWaitTimeout(cfg) }
+var newLeaseID = core.NewLeaseID
+var allocateDirectLeaseSlug = core.AllocateDirectLeaseSlug
+var ensureTestboxKeyForConfig = core.EnsureTestboxKeyForConfig
+var providerKeyForLease = core.ProviderKeyForLease
+var sshTargetFromConfig = core.SSHTargetFromConfig
+var waitForSSHReady = core.WaitForSSHReady
+var bootstrapWaitTimeout = core.BootstrapWaitTimeout
 var guestIPPollInterval = 5 * time.Second
 var guestIPDiscoverInterval = 15 * time.Second
 var xcpNgRollbackCleanupTimeout = 11 * time.Minute
 var xcpNgPartialRollbackTimeout = 30 * time.Second
-var findServerByAlias = func(servers []core.Server, id string) (core.Server, string, error) {
-	return core.FindServerByAlias(servers, id)
-}
-var removeStoredTestboxKey = func(leaseID string) { core.RemoveStoredTestboxKey(leaseID) }
-var exit = func(code int, format string, args ...any) core.ExitError { return core.Exit(code, format, args...) }
+var findServerByAlias = core.FindServerByAlias
+var removeStoredTestboxKey = core.RemoveStoredTestboxKey
+var exit = core.Exit

--- a/internal/providers/xcpng/iso_e2e.go
+++ b/internal/providers/xcpng/iso_e2e.go
@@ -82,15 +82,11 @@ var (
 	isoE2EWaitForSSHReady = func(ctx context.Context, target *core.SSHTarget, phase string, timeout time.Duration) error {
 		return core.WaitForSSHReady(ctx, target, os.Stderr, phase, timeout)
 	}
-	isoE2ERunSSHQuiet = func(ctx context.Context, target core.SSHTarget, remote string) error {
-		return core.RunSSHQuiet(ctx, target, remote)
-	}
-	isoE2EEnsureTestboxKey = func(cfg core.Config, leaseID string) (string, string, error) {
-		return core.EnsureTestboxKeyForConfig(cfg, leaseID)
-	}
+	isoE2ERunSSHQuiet             = core.RunSSHQuiet
+	isoE2EEnsureTestboxKey        = core.EnsureTestboxKeyForConfig
 	isoE2EStoredTestboxKeyExists  = storedISOE2ETestboxKeyExists
 	isoE2ENewLeaseID              = core.NewLeaseID
-	isoE2EProviderKeyForLease     = func(leaseID string) string { return core.ProviderKeyForLease(leaseID) }
+	isoE2EProviderKeyForLease     = core.ProviderKeyForLease
 	isoE2ERemasterUbuntuISO       = remasterUbuntuAutoinstallISO
 	isoE2EWriteLinuxSeedISO       = writeLinuxSeedISO
 	isoE2EWriteWindowsAnswerISO   = writeWindowsAnswerISO


### PR DESCRIPTION
## What Problem This Solves

Several injectable provider hooks initialize themselves through anonymous functions that only forward their arguments to an existing core function.

## User Impact

No user-visible change. Hook variables remain replaceable, with identical signatures and call behavior. No configuration or credential changes.

## Why This Change Was Made

Bind 22 hooks directly to immutable core functions in AWS, Exe.dev, Multipass, and XCP-ng. Compiler type identity, argument order, and variadic behavior determine eligibility. Constructor adapters with different interface return types and callbacks that discard parameters retain their adapters.

This removes 37 net production lines.

## Evidence

All four provider suites passed locally under the race detector. Existing tests continue to replace and restore these hooks. Required scoped Autoreview passed. The same four suites passed under the race detector on Linux, followed by a Windows CLI build (Crabbox run run_645990c7aefb13ee3815da93699d870c).
