### PR TITLE
fix: support macOS socket paths in managed-state checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Resolve macOS managed-state paths for Unix sockets and FIFOs through bounded metadata queries without opening those entries or scanning sibling files.
+
 - Keep portable workspace ownership exclusive when a runner's mkdir reports success after losing a directory-creation race. [PR 2201](https://github.com/openclaw/crabbox/pull/2201).
 
 - Resolve macOS managed-state path spelling without scanning unrelated sibling files, so crowded temporary directories do not block sync preparation. [PR 2187](https://github.com/openclaw/crabbox/pull/2187).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Resolve macOS managed-state paths for Unix sockets and FIFOs through bounded metadata queries without opening those entries or scanning sibling files.
+- Resolve macOS managed-state paths for Unix sockets and FIFOs through bounded metadata queries without opening those entries or scanning sibling files. [PR 2207](https://github.com/openclaw/crabbox/pull/2207).
 
 - Keep portable workspace ownership exclusive when a runner's mkdir reports success after losing a directory-creation race. [PR 2201](https://github.com/openclaw/crabbox/pull/2201).
 

--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -168,9 +168,11 @@ Git seeding is disabled so a seeded tree cannot materialize excluded paths.
 These protections do not remove state already committed upstream or previously
 shared with a runner.
 
-On macOS, managed-state path spelling uses descriptor metadata rather than
-enumerating sibling files, so crowded temporary directories do not block sync
-preparation.
+On macOS, managed-state path spelling uses entry-name and identity attributes
+relative to a retained parent descriptor, rather than opening the leaf or
+enumerating sibling files. This also supports Unix socket and FIFO entries
+without opening them, while preserving object-identity and namespace checks.
+Crowded temporary directories do not block sync preparation.
 
 Native transports without subtree filtering require the selected managed
 namespace to be outside their shared source scope. This includes Blacksmith's

--- a/internal/cli/managed_state_spelling_darwin.go
+++ b/internal/cli/managed_state_spelling_darwin.go
@@ -2,43 +2,64 @@ package cli
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
 
 func managedStateEntrySpelling(resolvedParent, name string, info os.FileInfo) (string, error) {
-	path := filepath.Join(resolvedParent, name)
-	fd, err := unix.Open(path, unix.O_EVTONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	parentInfo, err := os.Lstat(resolvedParent)
 	if err != nil {
 		return "", err
 	}
-	file := os.NewFile(uintptr(fd), path)
+	fd, err := unix.Open(resolvedParent, unix.O_EVTONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return "", err
+	}
+	file := os.NewFile(uintptr(fd), resolvedParent)
 	defer file.Close()
 	opened, err := file.Stat()
 	if err != nil {
 		return "", err
 	}
-	if !os.SameFile(info, opened) {
+	if !os.SameFile(parentInfo, opened) {
 		return "", fmt.Errorf("managed-state transfer path changed during metadata inspection")
 	}
+	entry, err := unix.BytePtrFromString(name)
+	if err != nil {
+		return "", err
+	}
+	attrs := unix.Attrlist{Bitmapcount: unix.ATTR_BIT_MAP_COUNT, Commonattr: unix.ATTR_CMN_NAME | unix.ATTR_CMN_DEVID | unix.ATTR_CMN_FILEID}
 	var buffer [unix.PathMax]byte
-	_, _, errno := unix.Syscall(unix.SYS_FCNTL, uintptr(fd), unix.F_GETPATH, uintptr(unsafe.Pointer(&buffer[0])))
+	// Query the entry without opening it: sockets reject open and FIFOs can
+	// block even with O_EVTONLY. Darwin packs attributes on four-byte boundaries.
+	_, _, errno := unix.Syscall6(unix.SYS_GETATTRLISTAT, uintptr(fd), uintptr(unsafe.Pointer(entry)), uintptr(unsafe.Pointer(&attrs)), uintptr(unsafe.Pointer(&buffer[0])), uintptr(len(buffer)), unix.FSOPT_NOFOLLOW)
 	if errno != 0 {
 		return "", errno
 	}
-	end := bytes.IndexByte(buffer[:], 0)
-	if end <= 0 || !filepath.IsAbs(string(buffer[:end])) {
-		return "", fmt.Errorf("invalid managed-state transfer descriptor path")
+	total := int64(binary.NativeEndian.Uint32(buffer[0:4]))
+	start := 4 + int64(int32(binary.NativeEndian.Uint32(buffer[4:8])))
+	length := int64(binary.NativeEndian.Uint32(buffer[8:12]))
+	if total < 24 || total > int64(len(buffer)) || start < 24 || length < 2 || start+length > total {
+		return "", fmt.Errorf("invalid managed-state transfer entry attributes")
 	}
-	// Keep the resolved parent: a descriptor path must not redirect the scope
-	// through a different hard-link name or a backing firmlink namespace.
-	spelling := filepath.Base(string(buffer[:end]))
-	if !strings.EqualFold(spelling, name) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || binary.NativeEndian.Uint32(buffer[12:16]) != uint32(stat.Dev) || binary.NativeEndian.Uint64(buffer[16:24]) != stat.Ino {
+		return "", fmt.Errorf("managed-state transfer path changed during metadata inspection")
+	}
+	rawName := buffer[start : start+length]
+	if bytes.IndexByte(rawName, 0) != len(rawName)-1 {
+		return "", fmt.Errorf("invalid managed-state transfer entry name")
+	}
+	// Keep the resolved parent, including its chosen firmlink namespace.
+	spelling := string(rawName[:len(rawName)-1])
+	if filepath.Base(spelling) != spelling || !strings.EqualFold(spelling, name) {
 		return "", fmt.Errorf("ambiguous managed-state transfer path spelling")
 	}
 	candidate := filepath.Join(resolvedParent, spelling)
@@ -46,8 +67,15 @@ func managedStateEntrySpelling(resolvedParent, name string, info os.FileInfo) (s
 	if err != nil {
 		return "", err
 	}
-	if !os.SameFile(opened, current) {
+	if !os.SameFile(info, current) {
 		return "", fmt.Errorf("managed-state transfer path changed during metadata inspection")
+	}
+	currentParent, err := os.Lstat(resolvedParent)
+	if err != nil {
+		return "", err
+	}
+	if !os.SameFile(opened, currentParent) {
+		return "", fmt.Errorf("managed-state transfer parent changed during metadata inspection")
 	}
 	return candidate, nil
 }

--- a/internal/cli/managed_state_spelling_darwin_test.go
+++ b/internal/cli/managed_state_spelling_darwin_test.go
@@ -1,11 +1,85 @@
 package cli
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
+
+func TestManagedStateDarwinSpecialEntrySpelling(t *testing.T) {
+	root, err := os.MkdirTemp("/tmp", "cb-special-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	canonicalRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := filepath.Join(root, "State")
+	namespace := filepath.Join(state, "crabbox")
+	if err := os.MkdirAll(namespace, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_STATE_HOME", state)
+	for _, dir := range []string{root, namespace} {
+		for _, kind := range []string{"Socket", "FIFO"} {
+			path := filepath.Join(dir, kind)
+			if kind == "Socket" {
+				listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { _ = listener.Close() })
+			} else if err := unix.Mkfifo(path, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			info, err := os.Lstat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Run(rel, func(t *testing.T) {
+				got, err := NormalizeManagedStateTransferRoot(path)
+				if err != nil || got != filepath.Join(canonicalRoot, rel) {
+					t.Fatalf("normalization=%q err=%v", got, err)
+				}
+				current, err := os.Lstat(path)
+				if err != nil || !os.SameFile(info, current) || info.Mode() != current.Mode() {
+					t.Fatal("metadata lookup changed fixture")
+				}
+				err = ValidateManagedStateTransferScope("owned special entry", path)
+				if (err != nil) != (dir == namespace) {
+					t.Fatalf("overlap admission=%v", err)
+				}
+			})
+			t.Run(rel+"/case-folded", func(t *testing.T) {
+				input := filepath.Join(dir, strings.ToLower(kind))
+				alias, err := os.Lstat(input)
+				if os.IsNotExist(err) {
+					t.Skip("fixture filesystem does not expose this case-folded alias")
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !os.SameFile(info, alias) {
+					t.Skip("fixture case-folded path names a distinct object")
+				}
+				got, err := NormalizeManagedStateTransferRoot(input)
+				if err != nil || got != filepath.Join(canonicalRoot, rel) {
+					t.Fatalf("case-folded normalization=%q err=%v", got, err)
+				}
+			})
+		}
+	}
+}
 
 func TestManagedStateDarwinDescriptorSpelling(t *testing.T) {
 	root := t.TempDir()


### PR DESCRIPTION
## What Problem This Solves

Managed-state path checks on macOS rejected Unix socket mounts, and inspecting a FIFO could block.

## User Impact

Local-container Docker socket mounts work again without weakening managed-state overlap checks. Path normalization supports special entries without opening them or scanning sibling files.

## Why This Change Was Made

The descriptor-based spelling lookup introduced in https://github.com/openclaw/crabbox/pull/2187 opened the leaf with `O_EVTONLY`. That operation is unsuitable for sockets and FIFOs. The replacement requests bounded entry-name, device, and file-ID metadata relative to a retained no-follow parent descriptor, validates the packed result, and checks the original entry, resolved candidate, and parent identities. It preserves the selected parent namespace, including firmlinks.

## Evidence

An owned local baseline reproduced socket rejection and a blocked FIFO leaf open; that failed baseline was preserved. The replacement passed native macOS race tests: 6 tests and 32 subtests, with no skips. These include all four failing local-container socket/rollback cases, socket/FIFO namespace admission, case-folded names, and existing hardlink, symlink-parent, and firmlink behavior. Vet and documentation checks passed with Go 1.26.5.

Complete scoped Codex review found no actionable P0 findings. No real Docker daemon socket was mounted for the regression tests. Changelog and sync documentation are updated. No new dependency or configuration migration is required.

## Current-main verification

The exact change integrated cleanly with [current main](https://github.com/openclaw/crabbox/commit/f643fc0586de2ae10323c65dad7e2bc9d3ec513e), preserving the core export and checkpoint refactors. All four PR files are identical to the reviewed head. Native race tests passed all 6 tests and 32 subtests with no skips, plus vet and docs checks. An earlier integration attempt skipped a socket fixture because its temporary path was too long; the unchanged test ran successfully with a shorter owned temporary path.

Exact-head [CI](https://github.com/openclaw/crabbox/actions/runs/34729115953) passed all 12 jobs, [Connector smokes](https://github.com/openclaw/crabbox/actions/runs/34729115931) passed all five, and [CodeQL](https://github.com/openclaw/crabbox/actions/runs/34729113526) passed all four. Release Check and Docs UI also passed.

## Landing verification

Merged as [344f4336](https://github.com/openclaw/crabbox/commit/344f4336cb6532c1f59506c2c91c8927100ecd0b). Its raw parent and tree exactly match the tested current-main preview. On the actual merged source, native race tests again passed all 6 tests and 32 subtests with no skips, plus vet/docs. Source and Git state stayed unchanged; the isolated maintainer main checkout is clean after a fast-forward-only pull.

Postmerge [CI](https://github.com/openclaw/crabbox/actions/runs/34730520121) passed all 12 jobs, [Connector smokes](https://github.com/openclaw/crabbox/actions/runs/34730520221) passed all five, and [CodeQL](https://github.com/openclaw/crabbox/actions/runs/34730519804) passed all four. No workflow reruns were needed.
