### PR TITLE
refactor: share cloud provisioning candidate execution

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -47,6 +47,15 @@ Core owns the entire workflow after acquisition:
 - heartbeat/touch;
 - release.
 
+For capacity fallback, use `ProvisionServerCandidates` with an ordered list of
+`ProvisioningCandidate` values and a `ServerProvisioner`. The adapter selects
+the exact configurations and diagnostics; shared code sequences preparation and
+creation, aggregates create failures, and returns the successful configuration.
+`Prepare` errors stop immediately. Only the adapter's `CanRetry` decision allows
+another create, after its create path has handled partial-resource cleanup.
+GCP, Azure, and Hetzner use this owner. Region routing, resource identity,
+cleanup, and provider-specific market eligibility stay in the adapters.
+
 The backend owns only the provider lifecycle:
 
 ```go

--- a/internal/cli/azure.go
+++ b/internal/cli/azure.go
@@ -781,75 +781,55 @@ func (c *AzureClient) LeaseClaimScope() string {
 }
 
 func (c *AzureClient) createServerWithFallbackInLocation(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any)) (Server, Config, error) {
-	candidates := azureProvisioningCandidatesForConfig(cfg)
-	if len(candidates) == 0 {
-		provider, _ := ProviderFor(cfg.Provider)
-		if provider == nil {
-			return Server{}, cfg, Exit(2, "provider=%s has no class profile for class=%s", cfg.Provider, cfg.Class)
-		}
-		if err := validateProviderClassSelector(provider, cfg); err != nil {
-			return Server{}, cfg, err
-		}
-		return Server{}, cfg, Exit(2, "provider=%s has no usable provisioning candidates for class=%s", cfg.Provider, cfg.Class)
+	attempts, err := azureProvisioningPlan(cfg)
+	if err != nil {
+		return Server{}, cfg, err
 	}
-	var errs []error
 	sharedInfraReady := false
-	for i, vmSize := range candidates {
-		next := cfg
-		next.ServerType = vmSize
-		if i > 0 && logf != nil {
-			logf("fallback provisioning type=%s after quota/capacity rejection\n", vmSize)
-		}
-		if next.AzureSnapshot == "" {
-			if _, err := c.validatedAzureOSDiskMode(ctx, next); err != nil {
-				return Server{}, next, err
-			}
-		}
-		if !sharedInfraReady {
-			if err := c.EnsureSharedInfra(ctx); err != nil {
-				return Server{}, next, err
-			}
-			sharedInfraReady = true
-		}
-		server, err := c.createServer(ctx, next, publicKey, leaseID, slug, keep)
-		if err == nil {
-			return server, next, nil
-		}
-		errs = append(errs, fmt.Errorf("%s: %w", vmSize, err))
-		if !isAzureRetryableProvisioningError(err) {
-			return Server{}, next, joinErrors(errs)
-		}
-	}
-	if strings.EqualFold(cfg.Capacity.Market, "spot") && strings.HasPrefix(cfg.Capacity.Fallback, "on-demand") {
-		for _, vmSize := range candidates {
-			next := cfg
-			next.ServerType = vmSize
-			next.Capacity.Market = "on-demand"
-			if logf != nil {
-				logf("fallback provisioning type=%s market=on-demand after spot rejection\n", vmSize)
-			}
+	return ProvisionServerCandidates(ctx, cfg, attempts, ServerProvisioner{
+		Prepare: func(ctx context.Context, next Config) error {
 			if next.AzureSnapshot == "" {
 				if _, err := c.validatedAzureOSDiskMode(ctx, next); err != nil {
-					return Server{}, next, err
+					return err
 				}
 			}
 			if !sharedInfraReady {
 				if err := c.EnsureSharedInfra(ctx); err != nil {
-					return Server{}, next, err
+					return err
 				}
 				sharedInfraReady = true
 			}
-			server, err := c.createServer(ctx, next, publicKey, leaseID, slug, keep)
-			if err == nil {
-				return server, next, nil
+			return nil
+		},
+		Create: func(ctx context.Context, next Config) (Server, error) {
+			return c.createServer(ctx, next, publicKey, leaseID, slug, keep)
+		},
+		CanRetry: isAzureRetryableProvisioningError,
+	}, logf)
+}
+
+func azureProvisioningPlan(cfg Config) ([]ProvisioningCandidate, error) {
+	candidates := azureProvisioningCandidatesForConfig(cfg)
+	if err := validateProvisioningCandidates(cfg, candidates); err != nil {
+		return nil, err
+	}
+	var attempts []ProvisioningCandidate
+	for marketIndex, market := range provisioningMarkets(cfg) {
+		for i, vmSize := range candidates {
+			next := cfg
+			next.ServerType = vmSize
+			next.Capacity.Market = market
+			attempt := ProvisioningCandidate{Config: next, FailureLabel: vmSize}
+			if marketIndex > 0 {
+				attempt.FailureLabel = "on-demand " + vmSize
+				attempt.FallbackMessage = fmt.Sprintf("fallback provisioning type=%s market=on-demand after spot rejection\n", vmSize)
+			} else if i > 0 {
+				attempt.FallbackMessage = fmt.Sprintf("fallback provisioning type=%s after quota/capacity rejection\n", vmSize)
 			}
-			errs = append(errs, fmt.Errorf("on-demand %s: %w", vmSize, err))
-			if !isAzureRetryableProvisioningError(err) {
-				return Server{}, next, joinErrors(errs)
-			}
+			attempts = append(attempts, attempt)
 		}
 	}
-	return Server{}, cfg, joinErrors(errs)
+	return attempts, nil
 }
 
 func azureProvisioningCandidatesForConfig(cfg Config) []string {

--- a/internal/cli/gcp.go
+++ b/internal/cli/gcp.go
@@ -112,66 +112,51 @@ func GCPMachineTypeCandidatesForConfig(cfg Config) []string {
 }
 
 func (c *GCPClient) CreateServerWithFallback(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any)) (Server, Config, error) {
-	var candidates []string
-	if cfg.ServerTypeExplicit && cfg.ServerType != "" {
-		candidates = []string{cfg.ServerType}
-	} else {
+	attempts, err := gcpProvisioningPlan(cfg)
+	if err != nil {
+		return Server{}, cfg, err
+	}
+	return ProvisionServerCandidates(ctx, cfg, attempts, ServerProvisioner{
+		Create: func(ctx context.Context, next Config) (Server, error) {
+			server, err := c.withZone(next.GCPZone).createServer(ctx, next, publicKey, leaseID, slug, keep)
+			if err == nil {
+				c.Zone = next.GCPZone
+			}
+			return server, err
+		},
+		CanRetry: isGCPFallbackProvisioningError,
+	}, logf)
+}
+
+func gcpProvisioningPlan(cfg Config) ([]ProvisioningCandidate, error) {
+	candidates := []string{cfg.ServerType}
+	if !cfg.ServerTypeExplicit || cfg.ServerType == "" {
 		candidates = GCPMachineTypeCandidatesForConfig(cfg)
-		if len(candidates) == 0 {
-			provider, _ := ProviderFor(cfg.Provider)
-			if provider == nil {
-				return Server{}, cfg, Exit(2, "provider=%s has no class profile for class=%s", cfg.Provider, cfg.Class)
-			}
-			if err := validateProviderClassSelector(provider, cfg); err != nil {
-				return Server{}, cfg, err
-			}
-			return Server{}, cfg, Exit(2, "provider=%s has no usable provisioning candidates for class=%s", cfg.Provider, cfg.Class)
-		}
+	}
+	if err := validateProvisioningCandidates(cfg, candidates); err != nil {
+		return nil, err
 	}
 	zones := uniqueStrings(append([]string{cfg.GCPZone}, cfg.Capacity.AvailabilityZones...))
-	var errs []error
-	for _, zone := range zones {
-		for i, machineType := range candidates {
-			next := cfg
-			next.GCPZone = zone
-			next.ServerType = machineType
-			if (i > 0 || zone != cfg.GCPZone) && logf != nil {
-				logf("fallback provisioning zone=%s type=%s after fallback-eligible provisioning error\n", zone, machineType)
-			}
-			server, err := c.withZone(zone).createServer(ctx, next, publicKey, leaseID, slug, keep)
-			if err == nil {
-				c.Zone = zone
-				return server, next, nil
-			}
-			errs = append(errs, fmt.Errorf("%s/%s: %w", zone, machineType, err))
-			if !isGCPFallbackProvisioningError(err) {
-				return Server{}, next, joinErrors(errs)
-			}
-		}
-	}
-	if strings.EqualFold(cfg.Capacity.Market, "spot") && strings.HasPrefix(cfg.Capacity.Fallback, "on-demand") {
+	var attempts []ProvisioningCandidate
+	for marketIndex, market := range provisioningMarkets(cfg) {
 		for _, zone := range zones {
-			for _, machineType := range candidates {
+			for i, machineType := range candidates {
 				next := cfg
 				next.GCPZone = zone
 				next.ServerType = machineType
-				next.Capacity.Market = "on-demand"
-				if logf != nil {
-					logf("fallback provisioning zone=%s type=%s market=on-demand after spot rejection\n", zone, machineType)
+				next.Capacity.Market = market
+				attempt := ProvisioningCandidate{Config: next, FailureLabel: zone + "/" + machineType}
+				if marketIndex > 0 {
+					attempt.FailureLabel = "on-demand " + attempt.FailureLabel
+					attempt.FallbackMessage = fmt.Sprintf("fallback provisioning zone=%s type=%s market=on-demand after spot rejection\n", zone, machineType)
+				} else if i > 0 || zone != cfg.GCPZone {
+					attempt.FallbackMessage = fmt.Sprintf("fallback provisioning zone=%s type=%s after fallback-eligible provisioning error\n", zone, machineType)
 				}
-				server, err := c.withZone(zone).createServer(ctx, next, publicKey, leaseID, slug, keep)
-				if err == nil {
-					c.Zone = zone
-					return server, next, nil
-				}
-				errs = append(errs, fmt.Errorf("on-demand %s/%s: %w", zone, machineType, err))
-				if !isGCPFallbackProvisioningError(err) {
-					return Server{}, next, joinErrors(errs)
-				}
+				attempts = append(attempts, attempt)
 			}
 		}
 	}
-	return Server{}, cfg, joinErrors(errs)
+	return attempts, nil
 }
 
 func (c *GCPClient) withZone(zone string) *GCPClient {

--- a/internal/cli/hcloud.go
+++ b/internal/cli/hcloud.go
@@ -319,33 +319,25 @@ func (c *HetznerClient) CreateServerWithFallback(ctx context.Context, cfg Config
 	if len(candidates) == 0 && cfg.ServerTypeExplicit && cfg.ServerType != "" {
 		candidates = []string{cfg.ServerType}
 	}
-	if len(candidates) == 0 {
-		provider, _ := ProviderFor(cfg.Provider)
-		if provider == nil {
-			return Server{}, cfg, Exit(2, "provider=%s has no class profile for class=%s", cfg.Provider, cfg.Class)
-		}
-		if err := validateProviderClassSelector(provider, cfg); err != nil {
-			return Server{}, cfg, err
-		}
-		return Server{}, cfg, Exit(2, "provider=%s has no usable provisioning candidates for class=%s", cfg.Provider, cfg.Class)
+	if err := validateProvisioningCandidates(cfg, candidates); err != nil {
+		return Server{}, cfg, err
 	}
-	var errs []error
+	attempts := make([]ProvisioningCandidate, 0, len(candidates))
 	for i, serverType := range candidates {
 		next := cfg
 		next.ServerType = serverType
-		if i > 0 && logf != nil {
-			logf("fallback provisioning type=%s after quota/capacity rejection\n", serverType)
+		attempt := ProvisioningCandidate{Config: next, FailureLabel: serverType}
+		if i > 0 {
+			attempt.FallbackMessage = fmt.Sprintf("fallback provisioning type=%s after quota/capacity rejection\n", serverType)
 		}
-		server, err := c.CreateServer(ctx, next, publicKey, leaseID, slug, keep)
-		if err == nil {
-			return server, next, nil
-		}
-		errs = append(errs, fmt.Errorf("%s: %w", serverType, err))
-		if !isRetryableProvisioningError(err) {
-			return Server{}, next, joinErrors(errs)
-		}
+		attempts = append(attempts, attempt)
 	}
-	return Server{}, cfg, joinErrors(errs)
+	return ProvisionServerCandidates(ctx, cfg, attempts, ServerProvisioner{
+		Create: func(ctx context.Context, next Config) (Server, error) {
+			return c.CreateServer(ctx, next, publicKey, leaseID, slug, keep)
+		},
+		CanRetry: isRetryableProvisioningError,
+	}, logf)
 }
 
 func isRetryableProvisioningError(err error) bool {

--- a/internal/cli/provisioning.go
+++ b/internal/cli/provisioning.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// ProvisioningCandidate is one adapter-selected attempt. Order, location, market,
+// and diagnostics belong to the adapter; core never invents another candidate.
+type ProvisioningCandidate struct {
+	Config          Config
+	FailureLabel    string
+	FallbackMessage string
+}
+
+// ServerProvisioner separates admission from a remote create. Preparation errors
+// stop immediately, without capacity fallback or rewriting the original error.
+// Create must settle its own partial resources before CanRetry permits another
+// attempt. Core does not infer deletion authority from a failed create response.
+type ServerProvisioner struct {
+	Prepare  func(context.Context, Config) error
+	Create   func(context.Context, Config) (Server, error)
+	CanRetry func(error) bool
+}
+
+func ProvisionServerCandidates(ctx context.Context, original Config, candidates []ProvisioningCandidate, provisioner ServerProvisioner, logf func(string, ...any)) (Server, Config, error) {
+	var errs []error
+	for _, candidate := range candidates {
+		if candidate.FallbackMessage != "" && logf != nil {
+			logf("%s", candidate.FallbackMessage)
+		}
+		if provisioner.Prepare != nil {
+			if err := provisioner.Prepare(ctx, candidate.Config); err != nil {
+				return Server{}, candidate.Config, err
+			}
+		}
+		server, err := provisioner.Create(ctx, candidate.Config)
+		if err == nil {
+			return server, candidate.Config, nil
+		}
+		errs = append(errs, fmt.Errorf("%s: %w", candidate.FailureLabel, err))
+		if provisioner.CanRetry == nil || !provisioner.CanRetry(err) {
+			return Server{}, candidate.Config, joinErrors(errs)
+		}
+	}
+	return Server{}, original, joinErrors(errs)
+}
+
+func validateProvisioningCandidates(cfg Config, candidates []string) error {
+	if len(candidates) != 0 {
+		return nil
+	}
+	provider, _ := ProviderFor(cfg.Provider)
+	if provider == nil {
+		return Exit(2, "provider=%s has no class profile for class=%s", cfg.Provider, cfg.Class)
+	}
+	if err := validateProviderClassSelector(provider, cfg); err != nil {
+		return err
+	}
+	return Exit(2, "provider=%s has no usable provisioning candidates for class=%s", cfg.Provider, cfg.Class)
+}
+
+// provisioningMarkets preserves the requested market before its explicit
+// on-demand fallback. Providers with selective fallback build their own plan.
+func provisioningMarkets(cfg Config) []string {
+	markets := []string{cfg.Capacity.Market}
+	if strings.EqualFold(cfg.Capacity.Market, "spot") && strings.HasPrefix(cfg.Capacity.Fallback, "on-demand") {
+		markets = append(markets, "on-demand")
+	}
+	return markets
+}

--- a/internal/cli/provisioning_test.go
+++ b/internal/cli/provisioning_test.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestProvisionServerCandidatesFailureBoundaries(t *testing.T) {
+	rejection := errors.New("capacity rejected")
+	admission := errors.New("admission rejected")
+	for _, tc := range []struct {
+		name        string
+		prepareFail bool
+		retry       bool
+		succeed     bool
+		wantEvents  []string
+		wantConfig  string
+		wantError   string
+	}{
+		{"success after fallback", false, true, true, []string{"prepare:first", "create:first", "retry", "log:second", "prepare:second", "create:second"}, "second", ""},
+		{"exhaustion", false, true, false, []string{"prepare:first", "create:first", "retry", "log:second", "prepare:second", "create:second", "retry"}, "original", "first: capacity rejected; second: capacity rejected"},
+		{"terminal create", false, false, false, []string{"prepare:first", "create:first", "retry"}, "first", "first: capacity rejected"},
+		{"admission after fallback", true, true, false, []string{"prepare:first", "create:first", "retry", "log:second", "prepare:second"}, "second", "admission rejected"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var events []string
+			candidates := []ProvisioningCandidate{
+				{Config: Config{ServerType: "first"}, FailureLabel: "first"},
+				{Config: Config{ServerType: "second"}, FailureLabel: "second", FallbackMessage: "log:second"},
+			}
+			server, cfg, err := ProvisionServerCandidates(context.Background(), Config{ServerType: "original"}, candidates, ServerProvisioner{
+				Prepare: func(_ context.Context, cfg Config) error {
+					events = append(events, "prepare:"+cfg.ServerType)
+					if tc.prepareFail && cfg.ServerType == "second" {
+						return admission
+					}
+					return nil
+				},
+				Create: func(_ context.Context, cfg Config) (Server, error) {
+					events = append(events, "create:"+cfg.ServerType)
+					if tc.succeed && cfg.ServerType == "second" {
+						return Server{CloudID: "allocated"}, nil
+					}
+					return Server{CloudID: "partial-not-authority"}, rejection
+				},
+				CanRetry: func(err error) bool {
+					if err != rejection {
+						t.Fatalf("classifier received rewritten error: %v", err)
+					}
+					events = append(events, "retry")
+					return tc.retry
+				},
+			}, func(format string, args ...any) { events = append(events, fmt.Sprintf(format, args...)) })
+			if !reflect.DeepEqual(events, tc.wantEvents) || cfg.ServerType != tc.wantConfig {
+				t.Fatalf("events=%v config=%s", events, cfg.ServerType)
+			}
+			if tc.wantError == "" {
+				if err != nil || server.CloudID != "allocated" {
+					t.Fatalf("server=%+v err=%v", server, err)
+				}
+			} else if err == nil || err.Error() != tc.wantError || server.CloudID != "" {
+				t.Fatalf("server=%+v err=%v", server, err)
+			}
+			if tc.prepareFail && err != admission {
+				t.Fatalf("admission error identity lost: %v", err)
+			}
+			if !tc.retry && !errors.Is(err, rejection) {
+				t.Fatalf("single create error identity lost: %v", err)
+			}
+		})
+	}
+}
+
+func TestProvisionServerCandidatesRequiresRetryPermission(t *testing.T) {
+	calls := 0
+	rejection := errors.New("unsettled allocation")
+	_, cfg, err := ProvisionServerCandidates(context.Background(), Config{}, []ProvisioningCandidate{
+		{Config: Config{ServerType: "first"}, FailureLabel: "first"},
+		{Config: Config{ServerType: "second"}, FailureLabel: "second"},
+	}, ServerProvisioner{Create: func(context.Context, Config) (Server, error) {
+		calls++
+		return Server{}, rejection
+	}}, nil)
+	if calls != 1 || cfg.ServerType != "first" || !errors.Is(err, rejection) {
+		t.Fatalf("calls=%d cfg=%s err=%v", calls, cfg.ServerType, err)
+	}
+}
+
+func TestCloudProvisioningPlansKeepExactTypesAndMarketOrder(t *testing.T) {
+	for _, provider := range []string{"gcp", "azure"} {
+		t.Run(provider, func(t *testing.T) {
+			cfg := baseConfig()
+			cfg.Provider = provider
+			cfg.ServerType, cfg.ServerTypeExplicit = "exact-type", true
+			cfg.Capacity.Market, cfg.Capacity.Fallback = "spot", "on-demand"
+			cfg.GCPZone = "zone-a"
+			cfg.Capacity.AvailabilityZones = []string{"zone-b", "zone-a"}
+			plan := azureProvisioningPlan
+			want := []string{"spot/exact-type", "on-demand/exact-type"}
+			if provider == "gcp" {
+				plan = gcpProvisioningPlan
+				want = []string{"spot/zone-a/exact-type", "spot/zone-b/exact-type", "on-demand/zone-a/exact-type", "on-demand/zone-b/exact-type"}
+			}
+			attempts, err := plan(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got []string
+			for i, attempt := range attempts {
+				got = append(got, attempt.Config.Capacity.Market+"/"+strings.TrimPrefix(attempt.FailureLabel, "on-demand "))
+				if attempt.Config.ServerType != "exact-type" || (i == 0) != (attempt.FallbackMessage == "") {
+					t.Fatalf("unexpected attempt %d: type=%s message=%s", i, attempt.Config.ServerType, attempt.FallbackMessage)
+				}
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("got=%v want=%v", got, want)
+			}
+			cfg.Capacity.Fallback = "none"
+			attempts, err = plan(cfg)
+			if err != nil || len(attempts) != len(want)/2 {
+				t.Fatalf("disabled market fallback: attempts=%d err=%v", len(attempts), err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
GCP, Azure, and Hetzner implemented separate capacity-attempt loops, including duplicated spot-to-on-demand loops. They now supply ordered `ProvisioningCandidate` values to one `ProvisionServerCandidates` owner with explicit preparation, creation, and retry-classification operations.

Adapters retain exact type selection, zone/market order, diagnostic text, admission checks, native creation/rollback, and permission to retry. Preparation errors stop immediately and retain their original identity; failed creates use the existing error aggregation. Azure still prepares shared infrastructure once per location, and GCP updates the client's zone only after success. The provider-authoring contract documents the boundary. No CLI, configuration, credentials, or persistent-state format changes.

Validation: focused orchestration, ordering, exact-type, market-fallback, and existing provider candidate/admission tests pass. Required isolated review completed without actionable findings. All CI checks passed. A disposable Linux runner passed `go vet ./...`, `go test -race -timeout=20m ./...`, and Windows amd64/arm64 builds with Go 1.26.5 (run `run_cabae79e6ec4d5216a1c79c612512d00`; command exit 0). Coordinator receipt finalization timed out after the successful command; the local command log preserves the completed proof.

This is architecture groundwork: it removes 43 lines from provider implementations while adding a shared owner. It is not claimed as a net production-LOC reduction.
