### PR TITLE
refactor: require one provider machine type resolver

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -158,6 +158,11 @@ Testbox does this because its native run command has no supported sync bypass.
 
 ### Optional interfaces
 
+`ProviderServerTypeProvider` has one operation, `ServerTypeForConfig(Config)`.
+Resolve class defaults and explicit native size selectors from that request;
+providers do not need a separate class-only resolver. `ClassProfiles` remains
+the declarative catalog for supported target and architecture combinations.
+
 Add optional capabilities as small interfaces instead of widening every backend.
 
 Provider-owned idle activity during an SSH run is optional:

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -7215,40 +7215,7 @@ func serverTypeForConfig(cfg Config) string {
 }
 
 func serverTypeForProviderClass(provider, class string) string {
-	if resolved, err := ProviderFor(provider); err == nil {
-		provider = resolved.Name()
-		if typer, ok := resolved.(ProviderServerTypeProvider); ok {
-			return typer.ServerTypeForClass(class)
-		}
-	}
-	if isBlacksmithProvider(provider) || isStaticProvider(provider) || provider == "islo" || provider == "sprites" || provider == "local-container" || provider == "multipass" {
-		return ""
-	}
-	if provider == "e2b" {
-		return "base"
-	}
-	if provider == "exe-dev" {
-		return "default"
-	}
-	if provider == "modal" {
-		return "python:3.13-slim"
-	}
-	if provider == "daytona" {
-		return "snapshot"
-	}
-	if provider == "proxmox" {
-		return "template"
-	}
-	if provider == "firecracker" {
-		return "microvm"
-	}
-	if provider == "incus" {
-		return "container"
-	}
-	if provider == "parallels" {
-		return "template"
-	}
-	return ""
+	return serverTypeForConfig(Config{Provider: provider, TargetOS: targetLinux, Architecture: ArchitectureAMD64, Class: class})
 }
 
 func incusServerTypeForConfig(cfg Config) string {
@@ -7430,7 +7397,7 @@ func cloudflareContainerInstanceTypeForClass(class string) string {
 	provider, err := ProviderFor("cloudflare")
 	if err == nil {
 		if resolver, ok := provider.(ProviderServerTypeProvider); ok {
-			return resolver.ServerTypeForClass(class)
+			return resolver.ServerTypeForConfig(Config{Provider: "cloudflare", TargetOS: targetLinux, Architecture: ArchitectureAMD64, Class: class})
 		}
 	}
 	return strings.TrimSpace(class)

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -177,7 +177,6 @@ type DesktopCredentialResolver interface {
 
 type ProviderServerTypeProvider interface {
 	ServerTypeForConfig(cfg Config) string
-	ServerTypeForClass(class string) string
 }
 
 // ClassSpec reports the concrete machine one class resolves to on this

--- a/internal/cli/provider_classes_test.go
+++ b/internal/cli/provider_classes_test.go
@@ -16,7 +16,6 @@ type selectorOverrideProvider struct {
 }
 
 func (p selectorOverrideProvider) ServerTypeForConfig(cfg Config) string { return p.resolve(cfg) }
-func (selectorOverrideProvider) ServerTypeForClass(class string) string  { return class }
 func (p selectorOverrideProvider) ServerTypeOverrideForConfig(cfg Config) (string, bool) {
 	if p.override == nil {
 		return "", false

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -229,9 +229,6 @@ func (testAzureProvider) ServerTypeForConfig(cfg Config) string {
 	}
 	return candidates[0]
 }
-func (testAzureProvider) ServerTypeForClass(class string) string {
-	return azureVMSizeCandidatesForClass(class)[0]
-}
 func (p testAzureProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
 }
@@ -295,7 +292,6 @@ func (testAzureDynamicSessionsProvider) ApplyFlags(*Config, *flag.FlagSet, any) 
 	return nil
 }
 func (testAzureDynamicSessionsProvider) ServerTypeForConfig(Config) string { return "" }
-func (testAzureDynamicSessionsProvider) ServerTypeForClass(string) string  { return "" }
 func (p testAzureDynamicSessionsProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testDelegatedBackend{spec: p.Spec()}, nil
 }
@@ -416,9 +412,6 @@ func (testHetznerProvider) ServerTypeForConfig(cfg Config) string {
 	}
 	return candidates[0]
 }
-func (testHetznerProvider) ServerTypeForClass(class string) string {
-	return serverTypeCandidatesForClass(class)[0]
-}
 func (p testHetznerProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testHetznerBackend{testSSHBackend{spec: p.Spec()}}, nil
 }
@@ -459,7 +452,6 @@ func (testDigitalOceanProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 	return nil
 }
 func (testDigitalOceanProvider) ServerTypeForConfig(Config) string { return "s-1vcpu-1gb" }
-func (testDigitalOceanProvider) ServerTypeForClass(string) string  { return "s-1vcpu-1gb" }
 func (p testDigitalOceanProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
 }
@@ -483,7 +475,6 @@ func (testVultrProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 	return nil
 }
 func (testVultrProvider) ServerTypeForConfig(Config) string { return "vc2-1c-1gb" }
-func (testVultrProvider) ServerTypeForClass(string) string  { return "vc2-1c-1gb" }
 func (p testVultrProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
 }
@@ -515,7 +506,6 @@ func (testLinodeProvider) ServerTypeForConfig(cfg Config) string {
 	}
 	return "g6-standard-1"
 }
-func (testLinodeProvider) ServerTypeForClass(string) string { return "g6-standard-1" }
 func (p testLinodeProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
 }
@@ -547,7 +537,6 @@ func (testLambdaProvider) ServerTypeForConfig(cfg Config) string {
 	}
 	return "gpu_1x_a10"
 }
-func (testLambdaProvider) ServerTypeForClass(string) string { return "gpu_1x_a10" }
 func (p testLambdaProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
 }
@@ -601,7 +590,6 @@ func (testScalewayProvider) ServerTypeForConfig(cfg Config) string {
 	}
 	return "DEV1-S"
 }
-func (testScalewayProvider) ServerTypeForClass(string) string { return "DEV1-S" }
 func (p testScalewayProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
 }
@@ -662,9 +650,6 @@ func (testGCPProvider) ServerTypeForConfig(cfg Config) string {
 		return ""
 	}
 	return candidates[0]
-}
-func (testGCPProvider) ServerTypeForClass(class string) string {
-	return gcpMachineTypeCandidatesForClass(class)[0]
 }
 func (p testGCPProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
@@ -744,9 +729,6 @@ func (testAWSProvider) ServerTypeForConfig(cfg Config) string {
 		return ""
 	}
 	return candidates[0]
-}
-func (testAWSProvider) ServerTypeForClass(class string) string {
-	return awsInstanceTypeCandidatesForClass(class)[0]
 }
 func (p testAWSProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	if testAWSBackendOverride != nil {
@@ -1085,7 +1067,6 @@ func (testXCPNgProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) e
 func (testXCPNgProvider) ServerTypeForConfig(cfg Config) string {
 	return xcpNgTestServerTypeForConfig(cfg)
 }
-func (testXCPNgProvider) ServerTypeForClass(string) string { return "template" }
 func (p testXCPNgProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
 }
@@ -1412,16 +1393,6 @@ func (testNamespaceProvider) ServerTypeForConfig(cfg Config) string {
 	}
 	return strings.ToUpper(strings.TrimSpace(cfg.Class))
 }
-func (testNamespaceProvider) ServerTypeForClass(class string) string {
-	cfg := Config{Provider: "namespace-devbox", TargetOS: targetLinux, Architecture: ArchitectureAMD64, Class: class}
-	if candidates, matched := providerClassCandidatesForConfig(cfg); matched {
-		return candidates[0]
-	}
-	if class == "" {
-		return "M"
-	}
-	return strings.ToUpper(strings.TrimSpace(class))
-}
 func (p testNamespaceProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
 }
@@ -1502,8 +1473,6 @@ func (testMorphProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) e
 func (testMorphProvider) ServerTypeForConfig(cfg Config) string {
 	return firstNonBlank(cfg.Morph.Snapshot, "snapshot")
 }
-
-func (testMorphProvider) ServerTypeForClass(string) string { return "snapshot" }
 
 func (p testMorphProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
@@ -1816,14 +1785,11 @@ func (testCloudflareProvider) ServerTypeForConfig(cfg Config) string {
 	if IsCanonicalProviderClass(cfg.Class) {
 		return ""
 	}
-	return cloudflareContainerInstanceTypeForClass(cfg.Class)
-}
-func (testCloudflareProvider) ServerTypeForClass(class string) string {
-	normalized := strings.ToLower(strings.TrimSpace(class))
-	if normalized == "" {
-		normalized = "standard"
+	class := cfg.Class
+	cfg.Class = strings.ToLower(strings.TrimSpace(class))
+	if cfg.Class == "" {
+		cfg.Class = "standard"
 	}
-	cfg := Config{Provider: "cloudflare", TargetOS: targetLinux, Architecture: ArchitectureAMD64, Class: normalized}
 	if candidates, matched := providerClassCandidatesForConfig(cfg); matched {
 		return candidates[0]
 	}

--- a/internal/providers/applevm/provider.go
+++ b/internal/providers/applevm/provider.go
@@ -48,8 +48,6 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	return applevmhelper.ImageIdentity(strings.TrimSpace(cfg.AppleVM.Image), cfg.AppleVM.ImageSHA256)
 }
 
-func (Provider) ServerTypeForClass(string) string { return "" }
-
 func (Provider) ValidateConfig(cfg core.Config) error {
 	if err := validateConfigBeforeDefaults(cfg); err != nil {
 		return err

--- a/internal/providers/aws/provider.go
+++ b/internal/providers/aws/provider.go
@@ -127,10 +127,6 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	return candidates[0]
 }
 
-func (Provider) ServerTypeForClass(class string) string {
-	return awsInstanceTypeCandidatesForClass(class)[0]
-}
-
 func (Provider) ClassProfiles() []core.ProviderClassProfile {
 	return classProfiles
 }

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -183,10 +183,6 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	return candidates[0]
 }
 
-func (Provider) ServerTypeForClass(class string) string {
-	return azureVMSizeCandidatesForClass(class)[0]
-}
-
 func (Provider) ClassProfiles() []core.ProviderClassProfile {
 	return classProfiles
 }

--- a/internal/providers/azuredynamicsessions/provider.go
+++ b/internal/providers/azuredynamicsessions/provider.go
@@ -45,8 +45,6 @@ func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error
 
 func (Provider) ServerTypeForConfig(core.Config) string { return "" }
 
-func (Provider) ServerTypeForClass(string) string { return "" }
-
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
 		return nil, core.Exit(2, "%s supports target=linux only", providerName)

--- a/internal/providers/blaxel/provider.go
+++ b/internal/providers/blaxel/provider.go
@@ -17,8 +17,6 @@ func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return nil }
 
 func (Provider) ServerTypeForConfig(core.Config) string { return "" }
-func (Provider) ServerTypeForClass(string) string       { return "" }
-
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
 		Authentication:             core.DirectProviderAuthentication(core.ProviderAuthenticationAPIKey),

--- a/internal/providers/boxd/provider.go
+++ b/internal/providers/boxd/provider.go
@@ -108,10 +108,6 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	return "machine"
 }
 
-func (Provider) ServerTypeForClass(string) string {
-	return "machine"
-}
-
 func applyDefaults(cfg *core.Config) {
 	cfg.Provider = providerName
 	if strings.TrimSpace(cfg.TargetOS) == "" {

--- a/internal/providers/cloudflare/core.go
+++ b/internal/providers/cloudflare/core.go
@@ -12,5 +12,5 @@ const (
 )
 
 func cloudflareContainerInstanceTypeForClass(class string) string {
-	return (Provider{}).ServerTypeForClass(class)
+	return (Provider{}).ServerTypeForConfig(core.Config{Provider: providerName, TargetOS: core.TargetLinux, Architecture: core.ArchitectureAMD64, Class: class})
 }

--- a/internal/providers/cloudflare/provider.go
+++ b/internal/providers/cloudflare/provider.go
@@ -55,14 +55,6 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	return cloudflareTypeForClass(cfg.Class)
 }
 
-func (Provider) ServerTypeForClass(class string) string {
-	cfg := core.Config{Provider: providerName, TargetOS: core.TargetLinux, Architecture: core.ArchitectureAMD64, Class: class}
-	if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
-		return candidates[0]
-	}
-	return cloudflareTypeForClass(class)
-}
-
 func cloudflareTypeForClass(class string) string {
 	normalizedClass := strings.ToLower(strings.TrimSpace(class))
 	if normalizedClass != class {

--- a/internal/providers/cloudflaresandbox/provider.go
+++ b/internal/providers/cloudflaresandbox/provider.go
@@ -17,8 +17,6 @@ func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return nil }
 
 func (Provider) ServerTypeForConfig(core.Config) string { return "" }
-func (Provider) ServerTypeForClass(string) string       { return "" }
-
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
 		Authentication:             core.DirectProviderAuthentication(core.ProviderAuthenticationAPIToken),

--- a/internal/providers/cloudrunsandbox/provider.go
+++ b/internal/providers/cloudrunsandbox/provider.go
@@ -33,8 +33,6 @@ func (Provider) DiagnosticSecrets(core.Config) []string {
 // ServerTypeForConfig / ServerTypeForClass: Cloud Run sandboxes share the
 // parent service resources; there is no Crabbox class/type surface.
 func (Provider) ServerTypeForConfig(core.Config) string { return "" }
-func (Provider) ServerTypeForClass(string) string       { return "" }
-
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
 		Authentication: core.ProviderAuthentication{

--- a/internal/providers/cloudrunsandbox/provider_test.go
+++ b/internal/providers/cloudrunsandbox/provider_test.go
@@ -34,7 +34,7 @@ func TestProviderAliasesAndDiagnosticSecrets(t *testing.T) {
 			t.Fatalf("missing alias %q in %v", want, aliases)
 		}
 	}
-	if p.ServerTypeForConfig(core.Config{}) != "" || p.ServerTypeForClass("any") != "" {
+	if p.ServerTypeForConfig(core.Config{}) != "" {
 		t.Fatal("expected empty server type surface")
 	}
 	t.Setenv("CLOUD_RUN_SANDBOX_SECRET", "s1")

--- a/internal/providers/cua/provider.go
+++ b/internal/providers/cua/provider.go
@@ -17,8 +17,6 @@ func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return nil }
 
 func (Provider) ServerTypeForConfig(core.Config) string { return "" }
-func (Provider) ServerTypeForClass(string) string       { return "" }
-
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
 		Authentication: core.DirectProviderAuthentication(core.ProviderAuthenticationAPIKey),

--- a/internal/providers/daytona/classes.go
+++ b/internal/providers/daytona/classes.go
@@ -40,7 +40,7 @@ func buildClassProfiles() []core.ProviderClassProfile {
 
 func (Provider) ClassProfiles() []core.ProviderClassProfile { return classProfiles }
 
-func (Provider) ServerTypeForClass(class string) string {
+func snapshotForClass(class string) string {
 	for _, profile := range classProfiles {
 		if profile.Class == class {
 			return profile.Primary.Type
@@ -63,7 +63,7 @@ func (p Provider) ServerTypeForConfig(cfg core.Config) string {
 	if snapshot := strings.TrimSpace(cfg.Daytona.Snapshot); snapshot != "" {
 		return snapshot
 	}
-	return p.ServerTypeForClass(cfg.Class)
+	return snapshotForClass(cfg.Class)
 }
 
 func (b *daytonaLeaseBackend) ValidateCoordinatorAcquire() error {

--- a/internal/providers/digitalocean/provider.go
+++ b/internal/providers/digitalocean/provider.go
@@ -92,10 +92,6 @@ func (p Provider) ServerTypeForConfig(cfg core.Config) string {
 	return digitalOceanServerTypeForClass(cfg.Class)
 }
 
-func (Provider) ServerTypeForClass(class string) string {
-	return digitalOceanServerTypeForClass(class)
-}
-
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	return NewDigitalOceanLeaseBackend(p.Spec(), cfg, rt), nil
 }

--- a/internal/providers/digitalocean/provider_test.go
+++ b/internal/providers/digitalocean/provider_test.go
@@ -25,8 +25,8 @@ func TestProviderSpec(t *testing.T) {
 }
 
 func TestProviderServerTypeDefaults(t *testing.T) {
-	if got := (Provider{}).ServerTypeForClass("standard"); got != "s-1vcpu-1gb" {
-		t.Fatalf("ServerTypeForClass standard=%q", got)
+	if got := (Provider{}).ServerTypeForConfig(core.Config{Class: "standard"}); got != "s-1vcpu-1gb" {
+		t.Fatalf("ServerTypeForConfig standard=%q", got)
 	}
 	if got := (Provider{}).ServerTypeForConfig(core.Config{ServerType: "s-2vcpu-2gb", ServerTypeExplicit: true}); got != "s-2vcpu-2gb" {
 		t.Fatalf("explicit ServerTypeForConfig=%q", got)

--- a/internal/providers/freestyle/provider.go
+++ b/internal/providers/freestyle/provider.go
@@ -18,11 +18,10 @@ func (Provider) Aliases() []string {
 	return nil
 }
 
-// ServerTypeForConfig / ServerTypeForClass implement ProviderServerTypeProvider
+// ServerTypeForConfig implements ProviderServerTypeProvider
 // so core needs no provider == "freestyle" special-case. Delegated-run Freestyle
 // VMs have no server-type concept, so both return "".
 func (Provider) ServerTypeForConfig(core.Config) string { return "" }
-func (Provider) ServerTypeForClass(string) string       { return "" }
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
 		Authentication:             core.DirectProviderAuthentication(core.ProviderAuthenticationAPIKey),

--- a/internal/providers/gcp/provider.go
+++ b/internal/providers/gcp/provider.go
@@ -165,10 +165,6 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	return gcpMachineTypeCandidatesForClass(cfg.Class)[0]
 }
 
-func (Provider) ServerTypeForClass(class string) string {
-	return gcpMachineTypeCandidatesForClass(class)[0]
-}
-
 func (Provider) ClassProfiles() []core.ProviderClassProfile {
 	return classProfiles
 }

--- a/internal/providers/githubcodespaces/provider.go
+++ b/internal/providers/githubcodespaces/provider.go
@@ -95,10 +95,6 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	return defaultCodespaceMachine
 }
 
-func (Provider) ServerTypeForClass(string) string {
-	return defaultCodespaceMachine
-}
-
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	cfg.Provider = providerName
 	if err := ValidateGitHubCodespacesConfig(cfg); err != nil {

--- a/internal/providers/githubcodespaces/provider_test.go
+++ b/internal/providers/githubcodespaces/provider_test.go
@@ -39,8 +39,8 @@ func TestServerTypeForConfigUsesMachineOrExplicitType(t *testing.T) {
 	if got := provider.ServerTypeForConfig(core.Config{ServerType: "premiumLinux", ServerTypeExplicit: true, GitHubCodespaces: core.GitHubCodespacesConfig{Machine: "standardLinux32gb"}}); got != "premiumLinux" {
 		t.Fatalf("explicit ServerTypeForConfig=%q", got)
 	}
-	if got := provider.ServerTypeForClass("beast"); got != defaultCodespaceMachine {
-		t.Fatalf("ServerTypeForClass=%q", got)
+	if got := provider.ServerTypeForConfig(core.Config{Class: "beast"}); got != defaultCodespaceMachine {
+		t.Fatalf("ServerTypeForConfig=%q", got)
 	}
 }
 

--- a/internal/providers/hetzner/provider.go
+++ b/internal/providers/hetzner/provider.go
@@ -126,14 +126,6 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	return cfg.Class
 }
 
-func (Provider) ServerTypeForClass(class string) string {
-	cfg := core.Config{Provider: "hetzner", TargetOS: core.TargetLinux, Architecture: core.ArchitectureAMD64, Class: class}
-	if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
-		return candidates[0]
-	}
-	return class
-}
-
 func (Provider) ClassProfiles() []core.ProviderClassProfile {
 	return classProfiles
 }

--- a/internal/providers/incus/provider.go
+++ b/internal/providers/incus/provider.go
@@ -44,11 +44,6 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	return core.IncusServerTypeForConfig(cfg)
 }
 
-func (Provider) ServerTypeForClass(class string) string {
-	_ = class
-	return "container"
-}
-
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	if cfg.TargetOS != "" && cfg.TargetOS != core.TargetLinux {
 		return nil, core.Exit(2, "provider=%s supports target=linux only", providerName)

--- a/internal/providers/lambda/provider.go
+++ b/internal/providers/lambda/provider.go
@@ -43,10 +43,6 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	return typeForConfig(cfg)
 }
 
-func (Provider) ServerTypeForClass(class string) string {
-	return serverTypeForClass(class)
-}
-
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	return &backend{spec: p.Spec(), cfg: cfg, rt: rt, clientFactory: newLambdaAPIClient}, nil
 }

--- a/internal/providers/linode/provider.go
+++ b/internal/providers/linode/provider.go
@@ -64,10 +64,6 @@ func (Provider) ServerTypeOverrideForConfig(cfg core.Config) (string, bool) {
 	return serverType, serverType != ""
 }
 
-func (Provider) ServerTypeForClass(class string) string {
-	return linodeServerTypeForClass(class)
-}
-
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	return NewLinodeLeaseBackend(p.Spec(), cfg, rt), nil
 }

--- a/internal/providers/linode/provider_test.go
+++ b/internal/providers/linode/provider_test.go
@@ -25,8 +25,8 @@ func TestProviderSpec(t *testing.T) {
 }
 
 func TestProviderServerTypeDefaults(t *testing.T) {
-	if got := (Provider{}).ServerTypeForClass("standard"); got != defaultType {
-		t.Fatalf("ServerTypeForClass standard=%q", got)
+	if got := (Provider{}).ServerTypeForConfig(core.Config{Class: "standard"}); got != defaultType {
+		t.Fatalf("ServerTypeForConfig standard=%q", got)
 	}
 	if got := (Provider{}).ServerTypeForConfig(core.Config{ServerType: "g6-standard-2", ServerTypeExplicit: true}); got != "g6-standard-2" {
 		t.Fatalf("explicit ServerTypeForConfig=%q", got)

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -1936,7 +1936,7 @@ func TestProviderClassCatalogAndSizeSelection(t *testing.T) {
 			cfg.Provider = providerName
 			cfg.Class = class
 			core.MarkClassExplicit(&cfg)
-			if got := provider.ServerTypeForClass(class); got != wantSizes[index] {
+			if got := provider.ServerTypeForConfig(cfg); got != wantSizes[index] {
 				t.Fatalf("class size=%q want=%q", got, wantSizes[index])
 			}
 			if err := provider.ApplyConfigDefaults(&cfg); err != nil || cfg.Machine0.Size != wantSizes[index] || cfg.ServerType != wantSizes[index] {

--- a/internal/providers/machine0/provider.go
+++ b/internal/providers/machine0/provider.go
@@ -129,15 +129,6 @@ func (Provider) ServerTypeOverrideForConfig(cfg core.Config) (string, bool) {
 	return size, cfg.Machine0.SizeExplicit && size != ""
 }
 
-func (Provider) ServerTypeForClass(class string) string {
-	for _, profile := range machine0ClassProfiles {
-		if profile.Class == class {
-			return profile.Primary.Type
-		}
-	}
-	return core.BaseConfig().Machine0.Size
-}
-
 func (Provider) ClassProfiles() []core.ProviderClassProfile { return machine0ClassProfiles }
 
 func buildClassProfiles() []core.ProviderClassProfile {

--- a/internal/providers/morph/provider.go
+++ b/internal/providers/morph/provider.go
@@ -68,7 +68,3 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	}
 	return "snapshot"
 }
-
-func (Provider) ServerTypeForClass(string) string {
-	return "snapshot"
-}

--- a/internal/providers/namespace/provider.go
+++ b/internal/providers/namespace/provider.go
@@ -73,14 +73,6 @@ func (Provider) ServerTypeOverrideForConfig(cfg core.Config) (string, bool) {
 	return strings.ToUpper(size), size != ""
 }
 
-func (Provider) ServerTypeForClass(class string) string {
-	cfg := core.Config{Provider: namespaceProvider, TargetOS: core.TargetLinux, Architecture: core.ArchitectureAMD64, Class: class}
-	if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
-		return candidates[0]
-	}
-	return namespaceSizeForClass(class)
-}
-
 func namespaceSizeForClass(class string) string {
 	normalized := strings.ToLower(strings.TrimSpace(class))
 	if normalized != class {

--- a/internal/providers/namespaceinstance/provider.go
+++ b/internal/providers/namespaceinstance/provider.go
@@ -149,10 +149,6 @@ func (Provider) ServerTypeOverrideForConfig(cfg core.Config) (string, bool) {
 	return machineType, machineType != ""
 }
 
-func (Provider) ServerTypeForClass(class string) string {
-	return machineTypeForClass(class)
-}
-
 func (Provider) ClassProfiles() []core.ProviderClassProfile {
 	return classProfiles
 }

--- a/internal/providers/nomad/provider.go
+++ b/internal/providers/nomad/provider.go
@@ -17,8 +17,6 @@ func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return nil }
 
 func (Provider) ServerTypeForConfig(core.Config) string { return "" }
-func (Provider) ServerTypeForClass(string) string       { return "" }
-
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
 		Authentication: core.ProviderAuthentication{

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -115,9 +115,6 @@ func TestProviderDoesNotReportServerTypeMetadata(t *testing.T) {
 	if got := p.ServerTypeForConfig(core.Config{Provider: providerName, Class: "beast"}); got != "" {
 		t.Fatalf("ServerTypeForConfig=%q want empty", got)
 	}
-	if got := p.ServerTypeForClass("beast"); got != "" {
-		t.Fatalf("ServerTypeForClass=%q want empty", got)
-	}
 }
 
 func TestOpenComputerWorkdirRejectsRelative(t *testing.T) {

--- a/internal/providers/opencomputer/provider.go
+++ b/internal/providers/opencomputer/provider.go
@@ -27,8 +27,6 @@ func (Provider) DiagnosticSecrets(core.Config) []string {
 }
 
 func (Provider) ServerTypeForConfig(core.Config) string { return "" }
-func (Provider) ServerTypeForClass(string) string       { return "" }
-
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
 		Authentication:             core.DirectProviderAuthentication(core.ProviderAuthenticationAPIKey),

--- a/internal/providers/opensandbox/provider.go
+++ b/internal/providers/opensandbox/provider.go
@@ -26,8 +26,6 @@ func (Provider) DiagnosticSecrets(core.Config) []string {
 }
 
 func (Provider) ServerTypeForConfig(core.Config) string { return "" }
-func (Provider) ServerTypeForClass(string) string       { return "" }
-
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
 		Authentication:             core.DirectProviderAuthentication(core.ProviderAuthenticationAPIKey),

--- a/internal/providers/ovh/provider.go
+++ b/internal/providers/ovh/provider.go
@@ -76,10 +76,6 @@ func (Provider) ServerTypeOverrideForConfig(cfg core.Config) (string, bool) {
 	return flavor, flavor != ""
 }
 
-func (Provider) ServerTypeForClass(class string) string {
-	return ovhServerTypeForClass(class)
-}
-
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	return NewBackend(p.Spec(), cfg, rt), nil
 }

--- a/internal/providers/ovh/provider_test.go
+++ b/internal/providers/ovh/provider_test.go
@@ -56,8 +56,8 @@ func TestProviderFlagsApplyNonSecretConfig(t *testing.T) {
 
 func TestProviderServerTypeForConfig(t *testing.T) {
 	provider := Provider{}
-	if got := provider.ServerTypeForClass("standard"); got != "b3-8" {
-		t.Fatalf("ServerTypeForClass standard=%q", got)
+	if got := provider.ServerTypeForConfig(core.Config{Class: "standard"}); got != "b3-8" {
+		t.Fatalf("ServerTypeForConfig standard=%q", got)
 	}
 	if got := provider.ServerTypeForConfig(core.Config{ServerType: "b3-16", ServerTypeExplicit: true, OVH: core.OVHConfig{Flavor: "b3-8"}}); got != "b3-16" {
 		t.Fatalf("explicit ServerTypeForConfig=%q", got)
@@ -140,7 +140,7 @@ func TestOVHBindingEndpointAndClassContract(t *testing.T) {
 		}
 	}
 	p := Provider{}
-	if p.ServerTypeForClass("standard") != "b3-8" || p.ServerTypeForClass("unknown-class") != "b3-8" {
+	if p.ServerTypeForConfig(core.Config{Class: "standard"}) != "b3-8" || p.ServerTypeForConfig(core.Config{Class: "unknown-class"}) != "b3-8" {
 		t.Fatal("fixed class policy changed")
 	}
 	for _, tc := range []struct {

--- a/internal/providers/phala/provider.go
+++ b/internal/providers/phala/provider.go
@@ -133,7 +133,3 @@ func (Provider) ServerTypeOverrideForConfig(cfg core.Config) (string, bool) {
 	selected := core.PhalaInstanceTypeWasExplicit(cfg) && core.PhalaInstanceTypeOverridesClass(cfg) && instanceType != ""
 	return instanceType, selected
 }
-
-func (Provider) ServerTypeForClass(class string) string {
-	return instanceTypeForClass(class)
-}

--- a/internal/providers/scaleway/client_test.go
+++ b/internal/providers/scaleway/client_test.go
@@ -548,7 +548,7 @@ func TestScalewayBindingProfilePrecedence(t *testing.T) {
 		}
 	}
 	p := Provider{}
-	if p.ServerTypeForClass("standard") != "DEV1-S" || p.ServerTypeForClass("unknown") != "DEV1-S" {
+	if p.ServerTypeForConfig(core.Config{Class: "standard"}) != "DEV1-S" || p.ServerTypeForConfig(core.Config{Class: "unknown"}) != "DEV1-S" {
 		t.Fatal("fixed class fallback changed")
 	}
 	for _, raw := range []string{"", "  "} {

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -90,10 +90,6 @@ func (Provider) ServerTypeOverrideForConfig(cfg core.Config) (string, bool) {
 	return serverType, serverType != ""
 }
 
-func (Provider) ServerTypeForClass(class string) string {
-	return scalewayServerTypeForClass(class)
-}
-
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	return &Backend{spec: p.Spec(), cfg: cfg, rt: rt, newClient: newClient}, nil
 }

--- a/internal/providers/superserve/provider.go
+++ b/internal/providers/superserve/provider.go
@@ -25,8 +25,6 @@ func (Provider) DiagnosticSecrets(core.Config) []string {
 }
 
 func (Provider) ServerTypeForConfig(core.Config) string { return "" }
-func (Provider) ServerTypeForClass(string) string       { return "" }
-
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
 		Authentication:             core.DirectProviderAuthentication(core.ProviderAuthenticationAPIKey),

--- a/internal/providers/tencentcloud/provider.go
+++ b/internal/providers/tencentcloud/provider.go
@@ -78,10 +78,6 @@ func (Provider) ServerTypeOverrideForConfig(cfg core.Config) (string, bool) {
 	return serverType, core.TencentCloudTypeWasExplicit(cfg) && serverType != ""
 }
 
-func (Provider) ServerTypeForClass(class string) string {
-	return serverTypeForClass(class)
-}
-
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	return NewBackend(p.Spec(), cfg, rt), nil
 }

--- a/internal/providers/tenki/provider.go
+++ b/internal/providers/tenki/provider.go
@@ -66,7 +66,3 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	}
 	return "sandbox"
 }
-
-func (Provider) ServerTypeForClass(string) string {
-	return "sandbox"
-}

--- a/internal/providers/vercelsandbox/provider.go
+++ b/internal/providers/vercelsandbox/provider.go
@@ -17,8 +17,6 @@ func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return nil }
 
 func (Provider) ServerTypeForConfig(core.Config) string { return "" }
-func (Provider) ServerTypeForClass(string) string       { return "" }
-
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
 		Authentication:             core.DirectProviderAuthentication(core.ProviderAuthenticationSDKCredentials),

--- a/internal/providers/vultr/provider.go
+++ b/internal/providers/vultr/provider.go
@@ -58,10 +58,6 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	return vultrServerTypeForClass(cfg.Class)
 }
 
-func (Provider) ServerTypeForClass(class string) string {
-	return vultrServerTypeForClass(class)
-}
-
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	return NewBackend(p.Spec(), cfg, rt), nil
 }

--- a/internal/providers/vultr/provider_test.go
+++ b/internal/providers/vultr/provider_test.go
@@ -60,8 +60,8 @@ func TestProviderServerTypeDefaults(t *testing.T) {
 		t.Fatalf("explicit ServerTypeForConfig=%q", got)
 	}
 	for _, class := range []string{"tiny", "small", "standard", "fast", "large", "beast", "unknown"} {
-		if got := provider.ServerTypeForClass(class); got != "vc2-1c-1gb" {
-			t.Fatalf("ServerTypeForClass(%q)=%q", class, got)
+		if got := provider.ServerTypeForConfig(core.Config{Class: class}); got != "vc2-1c-1gb" {
+			t.Fatalf("ServerTypeForConfig(%q)=%q", class, got)
 		}
 	}
 }

--- a/internal/providers/xcpng/provider.go
+++ b/internal/providers/xcpng/provider.go
@@ -168,8 +168,6 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	return xcpNgServerTypeForConfig(cfg)
 }
 
-func (Provider) ServerTypeForClass(string) string { return "template" }
-
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	return NewLeaseBackend(p.Spec(), cfg, rt), nil
 }

--- a/internal/providers/xcpng/provider_test.go
+++ b/internal/providers/xcpng/provider_test.go
@@ -63,9 +63,6 @@ func TestProviderServerTypeUsesTemplateIdentity(t *testing.T) {
 			}
 		})
 	}
-	if got := provider.ServerTypeForClass("linux-small"); got != "template" {
-		t.Fatalf("ServerTypeForClass=%q want template", got)
-	}
 }
 
 func TestFlagsApplyNonSecretConfigOnly(t *testing.T) {


### PR DESCRIPTION
`ProviderServerTypeProvider` required two machine-type resolvers, although normal provisioning already passed the full config and only a few generic class-only callers remained. Providers therefore carried duplicate mappings or empty methods solely to implement the interface.

The capability now requires only `ServerTypeForConfig`. Generic class lookups construct the standard Linux/amd64 config and use that resolver, and 34 provider class-only methods are deleted. Daytona's live snapshot mapping remains a private helper. Class profiles, explicit native-size precedence, target/architecture selection, discovery output, and CLI/config formats are preserved. The provider contract is documented and existing tests exercise the config-based operation.

Validation: focused core class/alias/default tests and production provider catalog/resolution tests pass, as do focused tests across the affected cloud adapters. The required isolated review completed without actionable findings. A stale Cloudflare core test double initially recursed through its former fallback path; it now owns its fallback directly, and the existing mapping tests pass. CI covers the full Go race suite, provider lifecycles, cross-platform builds, Worker, and documentation checks.
