### PR TITLE
chore: authorize v0.58.0 release source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## 0.58.0 - 2026-09-12
 
 ### Highlights

--- a/release/records/v0.58.0.json
+++ b/release/records/v0.58.0.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.58.0",
+  "tagObject": "35eb281c5521514901e411755f21abcf29b2769b",
+  "sourceCommit": "9de175962514381677cdace4935c90340115ee4c",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
Bind the verified signed v0.58.0 tag to source commit 9de175962514381677cdace4935c90340115ee4c and tag object 35eb281c5521514901e411755f21abcf29b2769b. The source passed full CI and connector E2E checks, plus a coordinator-backed Linux run with retained local/coordinator logs and confirmed lease cleanup.

Add the normal empty Unreleased section for later work while preserving the frozen 0.58.0 notes. Independent review passed. This source record enables candidate production; signing, frozen draft verification on both native macOS architectures, and the publication checks remain separate required gates.
