### PR TITLE
refactor: share sandbox workspace preparation and path policy

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -165,6 +165,18 @@ some SDK/CLI transports support it without archive sync. An adapter that cannot
 skip transfer must reject it before acquisition or provider execution. Blacksmith
 Testbox does this because its native run command has no supported sync bypass.
 
+### Shared sandbox workspaces
+
+E2B-compatible adapters use `shared.EnvdWorkspace` for process-user resolution,
+home-relative workspace paths, directory preparation, and archive sync over the
+shared envd API. Adapters retain their user default, archive naming, transport
+credentials, endpoint routing, and command-stream completion policy.
+
+`shared.CleanPOSIXWorkspacePath` provides the common dedicated-directory check.
+Pass any additional protected mount roots explicitly; reserved roots are exact
+matches, so dedicated subdirectories remain valid. Providers with different
+path admission rules keep those checks in their own adapter.
+
 ### Optional interfaces
 
 `ProviderServerTypeProvider` has one operation, `ServerTypeForConfig(Config)`.

--- a/internal/providers/asciibox/backend.go
+++ b/internal/providers/asciibox/backend.go
@@ -668,19 +668,7 @@ func workdir(cfg core.Config) string {
 }
 
 func cleanWorkdir(workdir string) (string, error) {
-	trimmed := strings.TrimSpace(workdir)
-	if trimmed == "" {
-		return "", core.Exit(2, "ascii-box workdir is empty")
-	}
-	clean := path.Clean(trimmed)
-	if !strings.HasPrefix(clean, "/") {
-		return "", core.Exit(2, "ascii-box workdir %q must resolve to an absolute path", workdir)
-	}
-	switch clean {
-	case "/", "/bin", "/dev", "/etc", "/home", "/home/user", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspace", "/workspace/home":
-		return "", core.Exit(2, "ascii-box workdir %q is too broad; choose a dedicated subdirectory", clean)
-	}
-	return clean, nil
+	return shared.CleanPOSIXWorkspacePath("ascii-box workdir", workdir, "/home/user", "/workspace", "/workspace/home")
 }
 
 var waitForSSHReadyFunc = core.WaitForSSHReady

--- a/internal/providers/azuredynamicsessions/sync.go
+++ b/internal/providers/azuredynamicsessions/sync.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"strings"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func (b *azureDynamicSessionsBackend) syncWorkspace(ctx context.Context, client azureDynamicSessionsAPI, sessionID string, req core.RunRequest, workspace string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
@@ -74,19 +74,7 @@ func azureDynamicSessionsWorkspace(cfg core.Config) (string, error) {
 }
 
 func cleanAzureDynamicSessionsWorkspacePath(workspace string) (string, error) {
-	trimmed := strings.TrimSpace(workspace)
-	if trimmed == "" {
-		return "", core.Exit(2, "%s workspace path is empty", providerName)
-	}
-	clean := path.Clean(trimmed)
-	if !strings.HasPrefix(clean, "/") {
-		return "", core.Exit(2, "%s workspace path %q must resolve to an absolute path", providerName, workspace)
-	}
-	switch clean {
-	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/mnt", "/mnt/data", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspace":
-		return "", core.Exit(2, "%s workspace path %q is too broad; choose a dedicated subdirectory", providerName, clean)
-	}
-	return clean, nil
+	return shared.CleanPOSIXWorkspacePath("azure-dynamic-sessions workspace path", workspace, "/mnt", "/mnt/data", "/workspace")
 }
 
 func buildAzureDynamicSessionsCommand(command []string, shellMode bool) (string, error) {

--- a/internal/providers/cubesandbox/backend.go
+++ b/internal/providers/cubesandbox/backend.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"path"
 	"slices"
 	"strings"
 	"time"
@@ -102,7 +101,7 @@ type cubesandboxBackend struct {
 func (b *cubesandboxBackend) Spec() core.ProviderSpec { return b.spec }
 
 func (b *cubesandboxBackend) Warmup(ctx context.Context, req core.WarmupRequest) error {
-	if err := validateCubeSandboxUser(b.cfg.CubeSandbox.User); err != nil {
+	if _, err := workspaceForConfig(b.cfg, b.rt).ProcessUser(); err != nil {
 		return err
 	}
 	started := core.ClockNow(b.rt.Clock)
@@ -131,7 +130,7 @@ func (b *cubesandboxBackend) Run(ctx context.Context, req core.RunRequest) (core
 	var client shared.EnvdSandboxAPI
 	var processUser, leaseID, sandboxID, slug string
 	var session shared.EnvdSandboxSession
-	workspace := cubesandboxWorkspacePath(b.cfg)
+	workspace := workspaceForConfig(b.cfg, b.rt).Path()
 	boundSandbox := func() shared.DelegatedSandbox {
 		return shared.DelegatedSandbox{LeaseID: leaseID, Slug: slug, CleanupCommand: cubesandboxCleanupCommand(leaseID)}
 	}
@@ -143,7 +142,7 @@ func (b *cubesandboxBackend) Run(ctx context.Context, req core.RunRequest) (core
 				return err
 			}
 			var err error
-			processUser, err = cubesandboxProcessUser(b.cfg.CubeSandbox.User)
+			processUser, err = workspaceForConfig(b.cfg, b.rt).ProcessUser()
 			if err != nil {
 				return err
 			}
@@ -184,10 +183,10 @@ func (b *cubesandboxBackend) Run(ctx context.Context, req core.RunRequest) (core
 			return nil
 		},
 		Sync: func(ctx context.Context, prepared *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
-			return b.syncWorkspace(ctx, client, session, req, workspace, prepared)
+			return workspaceForConfig(b.cfg, b.rt).Sync(ctx, client, session, req, workspace, prepared)
 		},
 		NoSync: func(ctx context.Context) error {
-			return b.prepareWorkspace(ctx, client, session, workspace)
+			return workspaceForConfig(b.cfg, b.rt).Prepare(ctx, client, session, workspace)
 		},
 		Command: func(context.Context) (shared.DelegatedSandboxCommand, error) {
 			intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
@@ -396,7 +395,7 @@ func (b *cubesandboxBackend) createSandbox(ctx context.Context, client shared.En
 		return "", shared.EnvdSandbox{}, "", err
 	}
 	cfg := b.cfg
-	workspace, err := cleanCubeSandboxWorkspacePath(cubesandboxWorkspacePath(cfg))
+	workspace, err := shared.CleanPOSIXWorkspacePath("cubesandbox workspace path", workspaceForConfig(cfg, b.rt).Path())
 	if err != nil {
 		return "", shared.EnvdSandbox{}, "", err
 	}
@@ -657,52 +656,6 @@ func cubesandboxTimeoutDuration(ttl time.Duration) time.Duration {
 
 func cubesandboxTimeoutSeconds(ttl time.Duration) int {
 	return durationSecondsCeil(cubesandboxTimeoutDuration(ttl))
-}
-
-func cubesandboxWorkspacePath(cfg core.Config) string {
-	workdir := strings.TrimSpace(cfg.CubeSandbox.Workdir)
-	if workdir == "" {
-		workdir = "crabbox"
-	}
-	if strings.HasPrefix(workdir, "/") {
-		return path.Clean(workdir)
-	}
-	return path.Join(cubesandboxUserHome(cfg.CubeSandbox.User), workdir)
-}
-
-func cubesandboxUserHome(user string) string {
-	user = cubesandboxWorkspaceUser(user)
-	if user == "" {
-		user = "user"
-	}
-	if user == "root" {
-		return "/root"
-	}
-	return path.Join("/home", user)
-}
-
-func cubesandboxWorkspaceUser(user string) string {
-	clean, err := cubesandboxProcessUser(user)
-	if err != nil || clean == "" {
-		return "root"
-	}
-	return clean
-}
-
-func validateCubeSandboxUser(user string) error {
-	_, err := cubesandboxProcessUser(user)
-	return err
-}
-
-func cubesandboxProcessUser(user string) (string, error) {
-	clean := strings.TrimSpace(user)
-	if clean == "" {
-		return "root", nil
-	}
-	if clean == "." || clean == ".." || strings.ContainsAny(clean, `/\`) || strings.ContainsRune(clean, 0) {
-		return "", core.Exit(2, "invalid cubesandbox.user %q: use a login name, not a path", user)
-	}
-	return clean, nil
 }
 
 func rejectCubeSandboxSyncOptions(req core.RunRequest) error {

--- a/internal/providers/cubesandbox/backend_test.go
+++ b/internal/providers/cubesandbox/backend_test.go
@@ -257,19 +257,19 @@ func TestCubeSandboxDataPlaneStreamOutlivesControlTimeout(t *testing.T) {
 }
 
 func TestCubeSandboxWorkspacePath(t *testing.T) {
-	if got := cubesandboxWorkspacePath(core.Config{}); got != "/root/crabbox" {
+	if got := workspaceForConfig(core.Config{}, core.Runtime{}).Path(); got != "/root/crabbox" {
 		t.Fatalf("workspace=%q", got)
 	}
-	if got := cubesandboxWorkspacePath(core.Config{CubeSandbox: core.CubeSandboxConfig{Workdir: "repo"}}); got != "/root/repo" {
+	if got := workspaceForConfig(core.Config{CubeSandbox: core.CubeSandboxConfig{Workdir: "repo"}}, core.Runtime{}).Path(); got != "/root/repo" {
 		t.Fatalf("workspace=%q", got)
 	}
-	if got := cubesandboxWorkspacePath(core.Config{CubeSandbox: core.CubeSandboxConfig{User: "ubuntu", Workdir: "repo"}}); got != "/home/ubuntu/repo" {
+	if got := workspaceForConfig(core.Config{CubeSandbox: core.CubeSandboxConfig{User: "ubuntu", Workdir: "repo"}}, core.Runtime{}).Path(); got != "/home/ubuntu/repo" {
 		t.Fatalf("workspace=%q", got)
 	}
-	if got := cubesandboxWorkspacePath(core.Config{CubeSandbox: core.CubeSandboxConfig{User: "root", Workdir: "repo"}}); got != "/root/repo" {
+	if got := workspaceForConfig(core.Config{CubeSandbox: core.CubeSandboxConfig{User: "root", Workdir: "repo"}}, core.Runtime{}).Path(); got != "/root/repo" {
 		t.Fatalf("workspace=%q", got)
 	}
-	if got := cubesandboxWorkspacePath(core.Config{CubeSandbox: core.CubeSandboxConfig{Workdir: "/work/repo"}}); got != "/work/repo" {
+	if got := workspaceForConfig(core.Config{CubeSandbox: core.CubeSandboxConfig{Workdir: "/work/repo"}}, core.Runtime{}).Path(); got != "/work/repo" {
 		t.Fatalf("workspace=%q", got)
 	}
 }
@@ -290,7 +290,7 @@ func TestCubeSandboxProcessUser(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := cubesandboxProcessUser(tt.user)
+			got, err := workspaceForConfig(core.Config{CubeSandbox: core.CubeSandboxConfig{User: tt.user}}, core.Runtime{}).ProcessUser()
 			if tt.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 					t.Fatalf("err=%v, want %q", err, tt.wantErr)
@@ -343,7 +343,7 @@ func TestCleanCubeSandboxWorkspacePath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := cleanCubeSandboxWorkspacePath(tt.workspace)
+			got, err := shared.CleanPOSIXWorkspacePath("cubesandbox workspace path", tt.workspace)
 			if tt.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 					t.Fatalf("err=%v, want %q", err, tt.wantErr)
@@ -722,8 +722,8 @@ func TestCubeSandboxSyncWorkspaceUploadsRepoArchive(t *testing.T) {
 		cfg: cfg,
 		rt:  core.Runtime{Stderr: io.Discard},
 	}
-	workspace := cubesandboxWorkspacePath(backend.cfg)
-	_, _, err := backend.syncWorkspace(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
+	workspace := workspaceForConfig(backend.cfg, core.Runtime{}).Path()
+	_, _, err := workspaceForConfig(backend.cfg, backend.rt).Sync(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
 		Repo: core.Repo{Root: root, Name: "repo"},
 	}, workspace)
 	if err != nil {
@@ -781,8 +781,8 @@ func TestCubeSandboxSyncWorkspaceCleansRemoteArchiveWhenExtractFails(t *testing.
 		cfg: cfg,
 		rt:  core.Runtime{Stderr: io.Discard},
 	}
-	workspace := cubesandboxWorkspacePath(backend.cfg)
-	_, _, err := backend.syncWorkspace(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
+	workspace := workspaceForConfig(backend.cfg, core.Runtime{}).Path()
+	_, _, err := workspaceForConfig(backend.cfg, backend.rt).Sync(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
 		Repo: core.Repo{Root: root, Name: "repo"},
 	}, workspace)
 	if err == nil {
@@ -810,7 +810,7 @@ func TestCubeSandboxPrepareWorkspaceRejectsUnsafePath(t *testing.T) {
 		cfg: cfg,
 		rt:  core.Runtime{Stderr: io.Discard},
 	}
-	err := backend.prepareWorkspace(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, "/")
+	err := workspaceForConfig(backend.cfg, backend.rt).Prepare(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, "/")
 	if err == nil || !strings.Contains(err.Error(), "too broad") {
 		t.Fatalf("err=%v, want unsafe workspace error", err)
 	}
@@ -822,7 +822,7 @@ func TestCubeSandboxPrepareWorkspaceRejectsUnsafePath(t *testing.T) {
 func TestCubeSandboxPrepareWorkspacePreservesExistingWithoutSync(t *testing.T) {
 	client := &fakeCubeSandboxSyncClient{}
 	backend := &cubesandboxBackend{rt: core.Runtime{Stderr: io.Discard}}
-	if err := backend.prepareWorkspace(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, "/root/repo"); err != nil {
+	if err := workspaceForConfig(backend.cfg, backend.rt).Prepare(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, "/root/repo"); err != nil {
 		t.Fatal(err)
 	}
 	if len(client.commands) != 1 || client.commands[0] != "mkdir -p '/root/repo'" {

--- a/internal/providers/cubesandbox/client.go
+++ b/internal/providers/cubesandbox/client.go
@@ -55,7 +55,7 @@ var newCubeSandboxClient = func(cfg core.Config, rt core.Runtime) (shared.EnvdSa
 	if err != nil {
 		return nil, err
 	}
-	user, err := cubesandboxProcessUser(cfg.CubeSandbox.User)
+	user, err := workspaceForConfig(cfg, rt).ProcessUser()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/cubesandbox/sync.go
+++ b/internal/providers/cubesandbox/sync.go
@@ -1,87 +1,14 @@
 package cubesandbox
 
 import (
-	"context"
-	"fmt"
-	"io"
-	"path"
-	"strings"
-	"time"
-
 	core "github.com/openclaw/crabbox/internal/cli"
-	shared "github.com/openclaw/crabbox/internal/providers/shared"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func (b *cubesandboxBackend) syncWorkspace(ctx context.Context, client shared.EnvdSandboxAPI, session shared.EnvdSandboxSession, req core.RunRequest, workspace string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
-	workspace, err := cleanCubeSandboxWorkspacePath(workspace)
-	if err != nil {
-		return nil, 0, err
-	}
-	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
-		Config:              b.cfg,
-		Repo:                req.Repo,
-		ForceSyncLarge:      req.ForceSyncLarge,
-		Workdir:             workspace,
-		TempPattern:         "crabbox-cubesandbox-sync-*.tgz",
-		RemoteArchiveDir:    "/tmp",
+func workspaceForConfig(cfg core.Config, rt core.Runtime) shared.EnvdWorkspace {
+	return shared.EnvdWorkspace{
+		Provider: providerName, Config: cfg, Runtime: rt,
+		Workdir: cfg.CubeSandbox.Workdir, User: cfg.CubeSandbox.User, DefaultUser: "root",
 		RemoteArchivePrefix: "crabbox-cubesandbox-sync-",
-		PhaseName:           "cubesandbox_sync",
-		Provider:            providerName,
-		Stderr:              b.rt.Stderr,
-		Now:                 func() time.Time { return core.ClockNow(b.rt.Clock) },
-		Upload: func(uploadCtx context.Context, remoteArchive string, body io.Reader) error {
-			if err := client.UploadFile(uploadCtx, session, remoteArchive, body); err != nil {
-				return cubesandboxError("upload archive", err)
-			}
-			return nil
-		},
-		Exec: func(execCtx context.Context, command string) error {
-			return b.execShell(execCtx, client, session, command, io.Discard)
-		},
-	}, prepared...)
-}
-
-func (b *cubesandboxBackend) prepareWorkspace(ctx context.Context, client shared.EnvdSandboxAPI, session shared.EnvdSandboxSession, workspace string) error {
-	workspace, err := cleanCubeSandboxWorkspacePath(workspace)
-	if err != nil {
-		return err
 	}
-	return b.execShell(ctx, client, session, "mkdir -p "+core.ShellQuote(workspace), io.Discard)
-}
-
-func cleanCubeSandboxWorkspacePath(workspace string) (string, error) {
-	trimmed := strings.TrimSpace(workspace)
-	if trimmed == "" {
-		return "", core.Exit(2, "cubesandbox workspace path is empty")
-	}
-	clean := path.Clean(trimmed)
-	if !strings.HasPrefix(clean, "/") {
-		return "", core.Exit(2, "cubesandbox workspace path %q must resolve to an absolute path", workspace)
-	}
-	switch clean {
-	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var":
-		return "", core.Exit(2, "cubesandbox workspace path %q is too broad; choose a dedicated subdirectory", clean)
-	}
-	return clean, nil
-}
-
-func (b *cubesandboxBackend) execShell(ctx context.Context, client shared.EnvdSandboxAPI, session shared.EnvdSandboxSession, command string, stdout io.Writer) error {
-	user, err := cubesandboxProcessUser(b.cfg.CubeSandbox.User)
-	if err != nil {
-		return err
-	}
-	code, err := client.StartProcess(ctx, session, shared.EnvdSandboxProcessRequest{
-		Command: command,
-		User:    user,
-		Timeout: b.cfg.TTL,
-		Stdout:  stdout,
-		Stderr:  b.rt.Stderr,
-	})
-	if err != nil {
-		return fmt.Errorf("cubesandbox exec %q: %w", command, err)
-	}
-	if code != 0 {
-		return core.Exit(code, "cubesandbox exec %q exited %d", command, code)
-	}
-	return nil
 }

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"path"
 	"strings"
 	"time"
 
@@ -53,7 +52,7 @@ const e2bMaxSandboxTimeout = time.Hour
 func (b *e2bBackend) Spec() core.ProviderSpec { return b.spec }
 
 func (b *e2bBackend) Warmup(ctx context.Context, req core.WarmupRequest) error {
-	if err := validateE2BUser(b.cfg.E2B.User); err != nil {
+	if _, err := workspaceForConfig(b.cfg, b.rt).ProcessUser(); err != nil {
 		return err
 	}
 	started := core.ClockNow(b.rt.Clock)
@@ -80,7 +79,7 @@ func (b *e2bBackend) Warmup(ctx context.Context, req core.WarmupRequest) error {
 
 func (b *e2bBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResult, error) {
 	var processUser string
-	workspace := e2bWorkspacePath(b.cfg)
+	workspace := workspaceForConfig(b.cfg, b.rt).Path()
 	var client shared.EnvdSandboxAPI
 	var session shared.EnvdSandboxSession
 	var leaseID, sandboxID, slug string
@@ -95,7 +94,7 @@ func (b *e2bBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResu
 				return err
 			}
 			var err error
-			processUser, err = e2bProcessUser(b.cfg.E2B.User)
+			processUser, err = workspaceForConfig(b.cfg, b.rt).ProcessUser()
 			if err != nil {
 				return err
 			}
@@ -129,10 +128,10 @@ func (b *e2bBackend) Run(ctx context.Context, req core.RunRequest) (core.RunResu
 			return e2bError("connect sandbox", err)
 		},
 		Sync: func(ctx context.Context, prepared *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
-			return b.syncWorkspace(ctx, client, session, req, workspace, prepared)
+			return workspaceForConfig(b.cfg, b.rt).Sync(ctx, client, session, req, workspace, prepared)
 		},
 		NoSync: func(ctx context.Context) error {
-			return b.prepareWorkspace(ctx, client, session, workspace)
+			return workspaceForConfig(b.cfg, b.rt).Prepare(ctx, client, session, workspace)
 		},
 		Command: func(context.Context) (shared.DelegatedSandboxCommand, error) {
 			intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, req.CommandLiteralArgs)
@@ -325,7 +324,7 @@ func (b *e2bBackend) createSandbox(ctx context.Context, client shared.EnvdSandbo
 	}
 	template := core.Blank(b.cfg.E2B.Template, core.E2BConfigDefaultTemplate)
 	cfg := b.cfg
-	workspace, err := cleanE2BWorkspacePath(e2bWorkspacePath(cfg))
+	workspace, err := shared.CleanPOSIXWorkspacePath("e2b workspace path", workspaceForConfig(cfg, b.rt).Path())
 	if err != nil {
 		return "", shared.EnvdSandbox{}, "", err
 	}
@@ -609,52 +608,6 @@ func e2bTimeoutDuration(ttl time.Duration) time.Duration {
 
 func e2bTimeoutSeconds(ttl time.Duration) int {
 	return durationSecondsCeil(e2bTimeoutDuration(ttl))
-}
-
-func e2bWorkspacePath(cfg core.Config) string {
-	workdir := strings.TrimSpace(cfg.E2B.Workdir)
-	if workdir == "" {
-		workdir = core.E2BConfigDefaultWorkdir
-	}
-	if strings.HasPrefix(workdir, "/") {
-		return path.Clean(workdir)
-	}
-	return path.Join(e2bUserHome(cfg.E2B.User), workdir)
-}
-
-func e2bUserHome(user string) string {
-	user = e2bWorkspaceUser(user)
-	if user == "" {
-		user = "user"
-	}
-	if user == "root" {
-		return "/root"
-	}
-	return path.Join("/home", user)
-}
-
-func e2bWorkspaceUser(user string) string {
-	clean, err := e2bProcessUser(user)
-	if err != nil || clean == "" {
-		return "user"
-	}
-	return clean
-}
-
-func validateE2BUser(user string) error {
-	_, err := e2bProcessUser(user)
-	return err
-}
-
-func e2bProcessUser(user string) (string, error) {
-	clean := strings.TrimSpace(user)
-	if clean == "" {
-		return "", nil
-	}
-	if clean == "." || clean == ".." || strings.ContainsAny(clean, `/\`) || strings.ContainsRune(clean, 0) {
-		return "", core.Exit(2, "invalid e2b.user %q: use a login name, not a path", user)
-	}
-	return clean, nil
 }
 
 func rejectE2BSyncOptions(req core.RunRequest) error {

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -508,22 +508,22 @@ func TestE2BTemplateAcquisitionAndMetadataDefaultAreDistinct(t *testing.T) {
 }
 
 func TestE2BWorkspacePath(t *testing.T) {
-	if got := e2bWorkspacePath(core.Config{E2B: core.E2BConfig{User: " alice ", Workdir: "  "}}); got != "/home/alice/crabbox" {
+	if got := workspaceForConfig(core.Config{E2B: core.E2BConfig{User: " alice ", Workdir: "  "}}, core.Runtime{}).Path(); got != "/home/alice/crabbox" {
 		t.Fatalf("whitespace/default workspace=%q", got)
 	}
-	if got := e2bWorkspacePath(core.Config{}); got != "/home/user/crabbox" {
+	if got := workspaceForConfig(core.Config{}, core.Runtime{}).Path(); got != "/home/user/crabbox" {
 		t.Fatalf("workspace=%q", got)
 	}
-	if got := e2bWorkspacePath(core.Config{E2B: core.E2BConfig{Workdir: "repo"}}); got != "/home/user/repo" {
+	if got := workspaceForConfig(core.Config{E2B: core.E2BConfig{Workdir: "repo"}}, core.Runtime{}).Path(); got != "/home/user/repo" {
 		t.Fatalf("workspace=%q", got)
 	}
-	if got := e2bWorkspacePath(core.Config{E2B: core.E2BConfig{User: "ubuntu", Workdir: "repo"}}); got != "/home/ubuntu/repo" {
+	if got := workspaceForConfig(core.Config{E2B: core.E2BConfig{User: "ubuntu", Workdir: "repo"}}, core.Runtime{}).Path(); got != "/home/ubuntu/repo" {
 		t.Fatalf("workspace=%q", got)
 	}
-	if got := e2bWorkspacePath(core.Config{E2B: core.E2BConfig{User: "root", Workdir: "repo"}}); got != "/root/repo" {
+	if got := workspaceForConfig(core.Config{E2B: core.E2BConfig{User: "root", Workdir: "repo"}}, core.Runtime{}).Path(); got != "/root/repo" {
 		t.Fatalf("workspace=%q", got)
 	}
-	if got := e2bWorkspacePath(core.Config{E2B: core.E2BConfig{Workdir: "/work/repo"}}); got != "/work/repo" {
+	if got := workspaceForConfig(core.Config{E2B: core.E2BConfig{Workdir: "/work/repo"}}, core.Runtime{}).Path(); got != "/work/repo" {
 		t.Fatalf("workspace=%q", got)
 	}
 }
@@ -544,7 +544,7 @@ func TestE2BProcessUser(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := e2bProcessUser(tt.user)
+			got, err := workspaceForConfig(core.Config{E2B: core.E2BConfig{User: tt.user}}, core.Runtime{}).ProcessUser()
 			if tt.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 					t.Fatalf("err=%v, want %q", err, tt.wantErr)
@@ -597,7 +597,7 @@ func TestCleanE2BWorkspacePath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := cleanE2BWorkspacePath(tt.workspace)
+			got, err := shared.CleanPOSIXWorkspacePath("e2b workspace path", tt.workspace)
 			if tt.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 					t.Fatalf("err=%v, want %q", err, tt.wantErr)
@@ -910,8 +910,8 @@ func TestE2BSyncWorkspaceUploadsRepoArchive(t *testing.T) {
 		cfg: core.Config{E2B: core.E2BConfig{User: "ubuntu", Workdir: "repo"}},
 		rt:  core.Runtime{Stderr: io.Discard},
 	}
-	workspace := e2bWorkspacePath(backend.cfg)
-	_, _, err := backend.syncWorkspace(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
+	workspace := workspaceForConfig(backend.cfg, core.Runtime{}).Path()
+	_, _, err := workspaceForConfig(backend.cfg, backend.rt).Sync(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
 		Repo: core.Repo{Root: root, Name: "repo"},
 	}, workspace)
 	if err != nil {
@@ -952,8 +952,8 @@ func TestE2BSyncWorkspaceCleansRemoteArchiveWhenExtractFails(t *testing.T) {
 		cfg: core.Config{E2B: core.E2BConfig{User: "ubuntu", Workdir: "repo"}},
 		rt:  core.Runtime{Stderr: io.Discard},
 	}
-	workspace := e2bWorkspacePath(backend.cfg)
-	_, _, err := backend.syncWorkspace(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
+	workspace := workspaceForConfig(backend.cfg, core.Runtime{}).Path()
+	_, _, err := workspaceForConfig(backend.cfg, backend.rt).Sync(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
 		Repo: core.Repo{Root: root, Name: "repo"},
 	}, workspace)
 	if err == nil {
@@ -995,7 +995,7 @@ func TestE2BSyncDeletePreservesWorkspaceWhenReplacementFails(t *testing.T) {
 			backend := &e2bBackend{rt: core.Runtime{Stderr: io.Discard}}
 			backend.cfg.Sync.Delete = true
 
-			_, _, err := backend.syncWorkspace(t.Context(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
+			_, _, err := workspaceForConfig(backend.cfg, backend.rt).Sync(t.Context(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
 				Repo: core.Repo{Root: root, Name: "repo"},
 			}, workspace)
 			if err == nil {
@@ -1022,7 +1022,7 @@ func TestE2BSyncWorkspaceHonorsConfiguredTimeout(t *testing.T) {
 	backend.cfg.Sync.Timeout = 500 * time.Millisecond
 	started := time.Now()
 
-	_, _, err := backend.syncWorkspace(t.Context(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
+	_, _, err := workspaceForConfig(backend.cfg, backend.rt).Sync(t.Context(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, core.RunRequest{
 		Repo: core.Repo{Root: root, Name: "repo"},
 	}, "/home/user/repo")
 	if !errors.Is(err, context.DeadlineExceeded) {
@@ -1047,7 +1047,7 @@ func TestE2BPrepareWorkspaceRejectsUnsafePath(t *testing.T) {
 		cfg: cfg,
 		rt:  core.Runtime{Stderr: io.Discard},
 	}
-	err := backend.prepareWorkspace(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, "/")
+	err := workspaceForConfig(backend.cfg, backend.rt).Prepare(context.Background(), client, shared.EnvdSandboxSession{SandboxID: "sbx_1"}, "/")
 	if err == nil || !strings.Contains(err.Error(), "too broad") {
 		t.Fatalf("err=%v, want unsafe workspace error", err)
 	}

--- a/internal/providers/e2b/sync.go
+++ b/internal/providers/e2b/sync.go
@@ -1,83 +1,14 @@
 package e2b
 
 import (
-	"context"
-	"fmt"
-	"io"
-	"path"
-	"strings"
-	"time"
-
 	core "github.com/openclaw/crabbox/internal/cli"
-	shared "github.com/openclaw/crabbox/internal/providers/shared"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func (b *e2bBackend) syncWorkspace(ctx context.Context, client shared.EnvdSandboxAPI, session shared.EnvdSandboxSession, req core.RunRequest, workspace string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
-	workspace, err := cleanE2BWorkspacePath(workspace)
-	if err != nil {
-		return nil, 0, err
-	}
-	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
-		Config:              b.cfg,
-		Repo:                req.Repo,
-		ForceSyncLarge:      req.ForceSyncLarge,
-		Workdir:             workspace,
-		TempPattern:         "crabbox-e2b-sync-*.tgz",
+func workspaceForConfig(cfg core.Config, rt core.Runtime) shared.EnvdWorkspace {
+	return shared.EnvdWorkspace{
+		Provider: e2bProvider, Config: cfg, Runtime: rt,
+		Workdir: cfg.E2B.Workdir, User: cfg.E2B.User, DefaultUser: "",
 		RemoteArchivePrefix: "crabbox-",
-		PhaseName:           "e2b_sync",
-		Provider:            e2bProvider,
-		Stderr:              b.rt.Stderr,
-		Now:                 func() time.Time { return core.ClockNow(b.rt.Clock) },
-		Upload: func(uploadCtx context.Context, remoteArchive string, archive io.Reader) error {
-			return e2bError("upload archive", client.UploadFile(uploadCtx, session, remoteArchive, archive))
-		},
-		Exec: func(execCtx context.Context, command string) error {
-			return b.execShell(execCtx, client, session, command, io.Discard)
-		},
-	}, prepared...)
-}
-
-func (b *e2bBackend) prepareWorkspace(ctx context.Context, client shared.EnvdSandboxAPI, session shared.EnvdSandboxSession, workspace string) error {
-	workspace, err := cleanE2BWorkspacePath(workspace)
-	if err != nil {
-		return err
 	}
-	return b.execShell(ctx, client, session, "mkdir -p "+core.ShellQuote(workspace), io.Discard)
-}
-
-func cleanE2BWorkspacePath(workspace string) (string, error) {
-	trimmed := strings.TrimSpace(workspace)
-	if trimmed == "" {
-		return "", core.Exit(2, "e2b workspace path is empty")
-	}
-	clean := path.Clean(trimmed)
-	if !strings.HasPrefix(clean, "/") {
-		return "", core.Exit(2, "e2b workspace path %q must resolve to an absolute path", workspace)
-	}
-	switch clean {
-	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var":
-		return "", core.Exit(2, "e2b workspace path %q is too broad; choose a dedicated subdirectory", clean)
-	}
-	return clean, nil
-}
-
-func (b *e2bBackend) execShell(ctx context.Context, client shared.EnvdSandboxAPI, session shared.EnvdSandboxSession, command string, stdout io.Writer) error {
-	user, err := e2bProcessUser(b.cfg.E2B.User)
-	if err != nil {
-		return err
-	}
-	code, err := client.StartProcess(ctx, session, shared.EnvdSandboxProcessRequest{
-		Command: command,
-		User:    user,
-		Timeout: b.cfg.TTL,
-		Stdout:  stdout,
-		Stderr:  b.rt.Stderr,
-	})
-	if err != nil {
-		return fmt.Errorf("e2b exec %q: %w", command, err)
-	}
-	if code != 0 {
-		return core.Exit(code, "e2b exec %q exited %d", command, code)
-	}
-	return nil
 }

--- a/internal/providers/modal/backend.go
+++ b/internal/providers/modal/backend.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path"
 	"strings"
 	"time"
 
@@ -455,19 +454,7 @@ func modalWorkdir(cfg core.Config) string {
 }
 
 func cleanModalWorkdir(workdir string) (string, error) {
-	trimmed := strings.TrimSpace(workdir)
-	if trimmed == "" {
-		return "", core.Exit(2, "modal workdir is empty")
-	}
-	clean := path.Clean(trimmed)
-	if !strings.HasPrefix(clean, "/") {
-		return "", core.Exit(2, "modal workdir %q must resolve to an absolute path", workdir)
-	}
-	switch clean {
-	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspace":
-		return "", core.Exit(2, "modal workdir %q is too broad; choose a dedicated subdirectory", clean)
-	}
-	return clean, nil
+	return shared.CleanPOSIXWorkspacePath("modal workdir", workdir, "/workspace")
 }
 
 func modalTimeoutDuration(ttl time.Duration) time.Duration {

--- a/internal/providers/shared/envd_workspace.go
+++ b/internal/providers/shared/envd_workspace.go
@@ -1,0 +1,100 @@
+package shared
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// EnvdWorkspace owns workspace preparation over the compatible envd protocol.
+// Adapters supply their user default and archive naming; the client retains
+// authentication, endpoint routing, and process-completion interpretation.
+type EnvdWorkspace struct {
+	Provider            string
+	Config              core.Config
+	Runtime             core.Runtime
+	Workdir             string
+	User                string
+	DefaultUser         string
+	RemoteArchivePrefix string
+}
+
+func (w EnvdWorkspace) ProcessUser() (string, error) {
+	clean := strings.TrimSpace(w.User)
+	if clean == "" {
+		return w.DefaultUser, nil
+	}
+	if clean == "." || clean == ".." || strings.ContainsAny(clean, `/\`) || strings.ContainsRune(clean, 0) {
+		return "", core.Exit(2, "invalid %s.user %q: use a login name, not a path", w.Provider, w.User)
+	}
+	return clean, nil
+}
+
+func (w EnvdWorkspace) Path() string {
+	workdir := core.Blank(strings.TrimSpace(w.Workdir), "crabbox")
+	if strings.HasPrefix(workdir, "/") {
+		return path.Clean(workdir)
+	}
+	user, err := w.ProcessUser()
+	if err != nil || user == "" {
+		user = core.Blank(w.DefaultUser, "user")
+	}
+	home := path.Join("/home", user)
+	if user == "root" {
+		home = "/root"
+	}
+	return path.Join(home, workdir)
+}
+
+func (w EnvdWorkspace) Sync(ctx context.Context, client EnvdSandboxAPI, session EnvdSandboxSession, req core.RunRequest, workspace string, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
+	workspace, err := CleanPOSIXWorkspacePath(w.Provider+" workspace path", workspace)
+	if err != nil {
+		return nil, 0, err
+	}
+	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
+		Config: w.Config, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+		Workdir: workspace, TempPattern: "crabbox-" + w.Provider + "-sync-*.tgz",
+		RemoteArchivePrefix: w.RemoteArchivePrefix, PhaseName: w.Provider + "_sync", Provider: w.Provider,
+		Stderr: w.Runtime.Stderr, Now: func() time.Time { return core.ClockNow(w.Runtime.Clock) },
+		Upload: func(ctx context.Context, archivePath string, archive io.Reader) error {
+			if err := client.UploadFile(ctx, session, archivePath, archive); err != nil {
+				return fmt.Errorf("%s upload archive: %w", w.Provider, err)
+			}
+			return nil
+		},
+		Exec: func(ctx context.Context, command string) error {
+			return w.exec(ctx, client, session, command)
+		},
+	}, prepared...)
+}
+
+func (w EnvdWorkspace) Prepare(ctx context.Context, client EnvdSandboxAPI, session EnvdSandboxSession, workspace string) error {
+	workspace, err := CleanPOSIXWorkspacePath(w.Provider+" workspace path", workspace)
+	if err != nil {
+		return err
+	}
+	return w.exec(ctx, client, session, "mkdir -p "+core.ShellQuote(workspace))
+}
+
+func (w EnvdWorkspace) exec(ctx context.Context, client EnvdSandboxAPI, session EnvdSandboxSession, command string) error {
+	user, err := w.ProcessUser()
+	if err != nil {
+		return err
+	}
+	code, err := client.StartProcess(ctx, session, EnvdSandboxProcessRequest{
+		Command: command, User: user, Timeout: w.Config.TTL,
+		Stdout: io.Discard, Stderr: w.Runtime.Stderr,
+	})
+	if err != nil {
+		return fmt.Errorf("%s exec %q: %w", w.Provider, command, err)
+	}
+	if code != 0 {
+		return core.Exit(code, "%s exec %q exited %d", w.Provider, command, code)
+	}
+	return nil
+}

--- a/internal/providers/shared/workspace_path.go
+++ b/internal/providers/shared/workspace_path.go
@@ -1,0 +1,30 @@
+package shared
+
+import (
+	"path"
+	"slices"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// CleanPOSIXWorkspacePath rejects broad system roots, plus any adapter-owned
+// mount roots. It checks exact roots, not their dedicated subdirectories.
+func CleanPOSIXWorkspacePath(label, workspace string, reservedRoots ...string) (string, error) {
+	trimmed := strings.TrimSpace(workspace)
+	if trimmed == "" {
+		return "", core.Exit(2, "%s is empty", label)
+	}
+	clean := path.Clean(trimmed)
+	if !strings.HasPrefix(clean, "/") {
+		return "", core.Exit(2, "%s %q must resolve to an absolute path", label, workspace)
+	}
+	switch clean {
+	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var":
+		return "", core.Exit(2, "%s %q is too broad; choose a dedicated subdirectory", label, clean)
+	}
+	if slices.Contains(reservedRoots, clean) {
+		return "", core.Exit(2, "%s %q is too broad; choose a dedicated subdirectory", label, clean)
+	}
+	return clean, nil
+}

--- a/internal/providers/shared/workspace_path_test.go
+++ b/internal/providers/shared/workspace_path_test.go
@@ -1,0 +1,48 @@
+package shared
+
+import (
+	"errors"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestCleanPOSIXWorkspacePathPreservesDedicatedSubdirectories(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		roots []string
+		want  string
+	}{
+		{" /home/alice/repo/../work ", nil, "/home/alice/work"},
+		{"/workspace", nil, "/workspace"},
+		{"/workspace/repo", []string{"/workspace"}, "/workspace/repo"},
+		{"/mnt/data/repo", []string{"/mnt", "/mnt/data"}, "/mnt/data/repo"},
+		{"/tmp/repo", nil, "/tmp/repo"},
+		{"/tmpish", nil, "/tmpish"},
+	} {
+		got, err := CleanPOSIXWorkspacePath("example workspace", tc.input, tc.roots...)
+		if err != nil || got != tc.want {
+			t.Fatalf("input=%q roots=%v got=%q err=%v", tc.input, tc.roots, got, err)
+		}
+	}
+}
+
+func TestCleanPOSIXWorkspacePathRejectsRootsWithExistingDiagnostics(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		roots []string
+		want  string
+	}{
+		{"  ", nil, "example workspace is empty"},
+		{" relative ", nil, `example workspace " relative " must resolve to an absolute path`},
+		{"/tmp/..", nil, `example workspace "/" is too broad; choose a dedicated subdirectory`},
+		{"/workspace/../root", nil, `example workspace "/root" is too broad; choose a dedicated subdirectory`},
+		{"/workspace/home/", []string{"/workspace/home"}, `example workspace "/workspace/home" is too broad; choose a dedicated subdirectory`},
+	} {
+		got, err := CleanPOSIXWorkspacePath("example workspace", tc.input, tc.roots...)
+		var exitErr core.ExitError
+		if got != "" || !errors.As(err, &exitErr) || exitErr.Code != 2 || err.Error() != tc.want {
+			t.Fatalf("input=%q got=%q err=%v", tc.input, got, err)
+		}
+	}
+}

--- a/internal/providers/upstashbox/backend.go
+++ b/internal/providers/upstashbox/backend.go
@@ -447,19 +447,7 @@ func workdir(cfg core.Config) string {
 }
 
 func cleanWorkdir(workdir string) (string, error) {
-	trimmed := strings.TrimSpace(workdir)
-	if trimmed == "" {
-		return "", core.Exit(2, "upstash-box workdir is empty")
-	}
-	clean := path.Clean(trimmed)
-	if !strings.HasPrefix(clean, "/") {
-		return "", core.Exit(2, "upstash-box workdir %q must resolve to an absolute path", workdir)
-	}
-	switch clean {
-	case "/", "/bin", "/dev", "/etc", "/home", "/lib", "/lib64", "/opt", "/proc", "/root", "/sbin", "/sys", "/tmp", "/usr", "/var", "/workspace", "/workspace/home":
-		return "", core.Exit(2, "upstash-box workdir %q is too broad; choose a dedicated subdirectory", clean)
-	}
-	return clean, nil
+	return shared.CleanPOSIXWorkspacePath("upstash-box workdir", workdir, "/workspace", "/workspace/home")
 }
 
 const workspaceRoot = "/workspace/home"


### PR DESCRIPTION
E2B and CubeSandbox maintained separate implementations of the same envd workspace protocol. Both now declare their workspace configuration and use `shared.EnvdWorkspace` for user resolution, home-relative paths, directory preparation, archive upload, and setup-command execution.

Their existing process-user defaults, archive names, timeout handling, error messages, and client-owned authentication/routing/stream-completion policies are preserved. The common dedicated-directory validator also serves Modal, Upstash, AsciiBox, and Azure Dynamic Sessions; each adapter supplies its additional protected mount roots. Providers with different path rules remain independent.

Validation: all seven affected package suites pass locally, including existing archive and process-user behavior tests. New shared path tests cover normalization, exact protected roots, allowed subdirectories, and diagnostic/exit-code preservation. Required isolated review completed without actionable findings. Linux vet and the seven package race suites passed on a disposable Crabbox runner; Windows amd64/arm64 builds are included in that proof. CI covers the full Go, cross-platform, provider lifecycle, Worker, and documentation gates.


Crabbox run `run_3a42106d688a6e2bd00121718e25ed46` completed the Linux vet/race and both Windows builds with exit 0 (Go 1.26.5). Net production Go reduction: 155 lines, excluding tests and documentation.
