### PR TITLE
refactor: reuse shared writable label copies

### DIFF
--- a/internal/providers/agentsandbox/backend.go
+++ b/internal/providers/agentsandbox/backend.go
@@ -434,13 +434,13 @@ func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.Stat
 		if expired, reason := sandboxClaimExpired(claim, liveClaim, core.ClockNow(b.rt.Clock).UTC()); expired {
 			view := baseView
 			view.State = "expired"
-			view.Labels = cloneStringMap(baseView.Labels)
+			view.Labels = shared.CloneLabels(baseView.Labels)
 			view.Labels["reason"] = reason
 			return view, nil
 		}
 		ready, readyErr := sandboxReadinessOnce(pollCtx, client, b.cfg.AgentSandbox.Namespace, claimName, identity)
 		view := baseView
-		view.Labels = cloneStringMap(baseView.Labels)
+		view.Labels = shared.CloneLabels(baseView.Labels)
 		if readyErr == nil {
 			view.State = statusViewReady
 			view.Ready = true
@@ -925,7 +925,7 @@ func (b *backend) claimIdentityForLiveClaim(claim core.LeaseClaim, live *kuberne
 	if !persist {
 		return claim, identity, nil
 	}
-	labels := cloneStringMap(claim.Labels)
+	labels := shared.CloneLabels(claim.Labels)
 	labels[claimLabelClaimUID] = uid
 	labels[claimLabelClaimUIDPending] = "false"
 	updated, err := core.UpdateLeaseClaimLabelsIfUnchanged(claim.LeaseID, claim, labels)

--- a/internal/providers/agentsandbox/backend_test.go
+++ b/internal/providers/agentsandbox/backend_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 	"io"
 	"os"
 	"os/exec"
@@ -966,7 +967,7 @@ func TestExistingRunReleasesClaimExpiringDuringReadiness(t *testing.T) {
 		t.Fatal(err)
 	}
 	expiresAt := now.Add(10 * time.Millisecond).Format(time.RFC3339)
-	labels := cloneStringMap(claim.Labels)
+	labels := shared.CloneLabels(claim.Labels)
 	labels[claimLabelExpiresAt] = expiresAt
 	claim, err = core.UpdateLeaseClaimLabelsIfUnchanged(claim.LeaseID, claim, labels)
 	if err != nil {
@@ -1389,7 +1390,7 @@ func TestRunReportsAndReleasesClaimThatExpiresDuringCommand(t *testing.T) {
 					t.Fatalf("claims=%#v err=%v", claims, err)
 				}
 				current := claims[0]
-				labels := cloneStringMap(current.Labels)
+				labels := shared.CloneLabels(current.Labels)
 				labels["test_activity_refresh"] = "true"
 				if _, updateErr := core.UpdateLeaseClaimLabelsIfUnchanged(current.LeaseID, current, labels); updateErr != nil {
 					t.Fatal(updateErr)

--- a/internal/providers/agentsandbox/claim.go
+++ b/internal/providers/agentsandbox/claim.go
@@ -209,7 +209,7 @@ func claimMetadataLabels(cfg core.Config, leaseID string, ready sandboxReadiness
 }
 
 func claimReadinessLabels(labels map[string]string, ready sandboxReadiness) map[string]string {
-	updated := cloneStringMap(labels)
+	updated := shared.CloneLabels(labels)
 	updated[claimLabelSandboxName] = ready.SandboxName
 	updated[claimLabelPodName] = ready.PodName
 	updated[claimLabelContainer] = ready.Container
@@ -342,14 +342,6 @@ func claimNameFromLocalClaim(claim core.LeaseClaim) string {
 		}
 	}
 	return strings.TrimPrefix(claim.LeaseID, leasePrefix)
-}
-
-func cloneStringMap(in map[string]string) map[string]string {
-	out := make(map[string]string, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
-	return out
 }
 
 func newClaimRecoveryNonce() (string, error) {

--- a/internal/providers/agentsandbox/kubernetes.go
+++ b/internal/providers/agentsandbox/kubernetes.go
@@ -602,8 +602,8 @@ func podStateFromObject(object kubernetesObject) podState {
 	state := podState{
 		Name:            object.Metadata.Name,
 		UID:             object.Metadata.UID,
-		Labels:          cloneStringMap(object.Metadata.Labels),
-		Annotations:     cloneStringMap(object.Metadata.Annotations),
+		Labels:          shared.CloneLabels(object.Metadata.Labels),
+		Annotations:     shared.CloneLabels(object.Metadata.Annotations),
 		OwnerReferences: append([]ownerReference(nil), object.Metadata.OwnerReferences...),
 		Phase:           object.Status.Phase,
 		PodIP:           object.Status.PodIP,

--- a/internal/providers/cloudrunsandbox/backend.go
+++ b/internal/providers/cloudrunsandbox/backend.go
@@ -621,7 +621,7 @@ func (b *backend) releaseClaimedSandboxIfUnchanged(ctx context.Context, transpor
 }
 
 func (b *backend) markClaimActivity(claim core.LeaseClaim, state string, timeout time.Duration) (core.LeaseClaim, error) {
-	labels := cloneLabels(claim.Labels)
+	labels := shared.CloneLabels(claim.Labels)
 	labels[claimStateLabel] = state
 	activeUntil := core.ClockNow(b.rt.Clock).UTC().Add(timeout)
 	if expires, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(labels[claimExpiresAtLabel])); err == nil && expires.Before(activeUntil) {
@@ -632,18 +632,10 @@ func (b *backend) markClaimActivity(claim core.LeaseClaim, state string, timeout
 }
 
 func (b *backend) clearClaimActivity(claim core.LeaseClaim) (core.LeaseClaim, error) {
-	labels := cloneLabels(claim.Labels)
+	labels := shared.CloneLabels(claim.Labels)
 	delete(labels, claimStateLabel)
 	delete(labels, claimActiveUntilLabel)
 	return core.UpdateLeaseClaimLabelsAndLastUsedIfUnchanged(claim.LeaseID, claim, labels, core.ClockNow(b.rt.Clock).UTC())
-}
-
-func cloneLabels(labels map[string]string) map[string]string {
-	cloned := make(map[string]string, len(labels)+3)
-	for key, value := range labels {
-		cloned[key] = value
-	}
-	return cloned
 }
 
 func claimOperationTimeout(claim core.LeaseClaim, maximum time.Duration, now time.Time) (time.Duration, error) {
@@ -772,13 +764,13 @@ func (b *backend) createSandbox(ctx context.Context, transport sandboxTransport,
 	}
 	createCtx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
-	recoveryLabels := cloneLabels(claim.Labels)
+	recoveryLabels := shared.CloneLabels(claim.Labels)
 	recoveryLabels[claimStateLabel] = "recovery"
 	delete(recoveryLabels, claimActiveUntilLabel)
-	conflictLabels := cloneLabels(claim.Labels)
+	conflictLabels := shared.CloneLabels(claim.Labels)
 	conflictLabels[claimStateLabel] = "conflict"
 	delete(conflictLabels, claimActiveUntilLabel)
-	readyLabels := cloneLabels(claim.Labels)
+	readyLabels := shared.CloneLabels(claim.Labels)
 	delete(readyLabels, claimStateLabel)
 	delete(readyLabels, claimActiveUntilLabel)
 	resolvedClaim, conflictClaimRemoved, actionSucceeded, createErr := core.ResolveLeaseClaimAfterActionIfUnchanged(leaseID, claim, func() error {
@@ -810,7 +802,7 @@ func (b *backend) createSandbox(ctx context.Context, transport sandboxTransport,
 		if rollbackErr == nil {
 			return "", "", "", core.LeaseClaim{}, fmt.Errorf("cloud-run-sandbox create succeeded but publishing ready ownership failed; sandbox rolled back lease=%s: %w", leaseID, createErr)
 		}
-		fallbackLabels := cloneLabels(rollbackClaim.Labels)
+		fallbackLabels := shared.CloneLabels(rollbackClaim.Labels)
 		fallbackLabels[claimStateLabel] = "recovery"
 		delete(fallbackLabels, claimActiveUntilLabel)
 		_, recoveryErr := core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, rollbackClaim, fallbackLabels)

--- a/internal/providers/cloudrunsandbox/backend_test.go
+++ b/internal/providers/cloudrunsandbox/backend_test.go
@@ -1113,7 +1113,7 @@ func TestCloudRunSandboxStatusReportsExpiredClaim(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	labels := cloneLabels(claim.Labels)
+	labels := shared.CloneLabels(claim.Labels)
 	labels[claimExpiresAtLabel] = now.Add(-time.Second).Format(time.RFC3339Nano)
 	if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, claim, labels); err != nil {
 		t.Fatal(err)

--- a/internal/providers/githubcodespaces/backend.go
+++ b/internal/providers/githubcodespaces/backend.go
@@ -215,7 +215,7 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 		}
 	}
 	if req.OnAcquired != nil {
-		acquired := core.LeaseTarget{Server: b.serverFromCodespace(created, cloneLabels(claim.Labels)), LeaseID: leaseID}
+		acquired := core.LeaseTarget{Server: b.serverFromCodespace(created, shared.CloneLabels(claim.Labels)), LeaseID: leaseID}
 		if err := req.OnAcquired(acquired); err != nil {
 			return core.LeaseTarget{}, errors.Join(err, rollbackUnboundCreatedCodespace(api, claim, created))
 		}
@@ -1087,7 +1087,7 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 
 func shouldDiscardMissingClaim(claim core.LeaseClaim, now time.Time) (bool, string) {
 	server := serverFromClaim(claim)
-	server.Labels = cloneLabels(server.Labels)
+	server.Labels = shared.CloneLabels(server.Labels)
 	server.Labels[labelState] = "provisioning"
 	return core.ShouldCleanupServer(server, now)
 }
@@ -1418,7 +1418,7 @@ func (b *backend) serverFromCodespace(item codespace, labels map[string]string) 
 		Provider: providerName,
 		Name:     item.Name,
 		Status:   item.State,
-		Labels:   cloneLabels(labels),
+		Labels:   shared.CloneLabels(labels),
 	}
 	server.ServerType.Name = shared.FirstNonBlankTrimmed(item.Machine.Name, b.effectiveMachine())
 	return server
@@ -1467,7 +1467,7 @@ func (b *backend) serversFromCodespaces(items []codespace) ([]core.LeaseView, er
 		if err := validateCodespaceClaimResource(claim, item); err != nil {
 			return nil, err
 		}
-		server := b.serverFromCodespace(item, cloneLabels(claim.Labels))
+		server := b.serverFromCodespace(item, shared.CloneLabels(claim.Labels))
 		server.Labels[labelCodespaceName] = item.Name
 		server.Labels[labelEnvironmentID] = shared.FirstNonBlankTrimmed(item.EnvironmentID, server.Labels[labelEnvironmentID])
 		server.Labels[labelRepository] = shared.FirstNonBlankTrimmed(item.Repository.FullName, server.Labels[labelRepository])
@@ -1497,7 +1497,7 @@ func (b *backend) resolveServer(items []codespace, id string) (core.Server, stri
 		name := shared.FirstNonBlankTrimmed(claim.CloudID, claim.Labels[labelCodespaceName])
 		for _, item := range items {
 			if item.Name == name {
-				return b.serverFromCodespace(item, cloneLabels(claim.Labels)), claim.LeaseID, nil
+				return b.serverFromCodespace(item, shared.CloneLabels(claim.Labels)), claim.LeaseID, nil
 			}
 		}
 		if name != "" {
@@ -1513,7 +1513,7 @@ func (b *backend) resolveServer(items []codespace, id string) (core.Server, stri
 			if !ok {
 				return core.Server{}, "", core.Exit(3, "refusing unmanaged github-codespaces codespace=%s without local claim", item.Name)
 			}
-			return b.serverFromCodespace(item, cloneLabels(claim.Labels)), claim.LeaseID, nil
+			return b.serverFromCodespace(item, shared.CloneLabels(claim.Labels)), claim.LeaseID, nil
 		}
 	}
 	return core.Server{}, "", nil
@@ -1671,7 +1671,7 @@ func serverFromClaim(claim core.LeaseClaim) core.Server {
 		Provider: providerName,
 		Name:     shared.FirstNonBlankTrimmed(claim.CloudID, claim.Labels[labelCodespaceName]),
 		Status:   claim.Labels[labelState],
-		Labels:   cloneLabels(claim.Labels),
+		Labels:   shared.CloneLabels(claim.Labels),
 	}
 	server.ServerType.Name = claim.Labels[labelMachine]
 	return server
@@ -1699,14 +1699,6 @@ func repoName(repo string) string {
 		return ""
 	}
 	return strings.TrimSuffix(name, ".git")
-}
-
-func cloneLabels(labels map[string]string) map[string]string {
-	out := map[string]string{}
-	for key, value := range labels {
-		out[key] = value
-	}
-	return out
 }
 
 func repoRootForClaim(repo core.Repo) (string, error) {

--- a/internal/providers/githubcodespaces/recovery.go
+++ b/internal/providers/githubcodespaces/recovery.go
@@ -233,7 +233,7 @@ func (b *backend) bindValidatedCreatedClaim(expected core.LeaseClaim, item codes
 	name := strings.TrimSpace(item.Name)
 	displayName := strings.TrimSpace(expected.Labels[labelDisplayName])
 	repo := shared.FirstNonBlankTrimmed(strings.TrimSpace(item.Repository.FullName), strings.TrimSpace(expected.Labels[labelRepository]))
-	labels := cloneLabels(expected.Labels)
+	labels := shared.CloneLabels(expected.Labels)
 	delete(labels, labelRecovery)
 	labels[labelCodespaceName] = name
 	labels[labelCodespaceID] = strconv.FormatInt(item.ID, 10)

--- a/internal/providers/githubcodespaces/safety_test.go
+++ b/internal/providers/githubcodespaces/safety_test.go
@@ -3,6 +3,7 @@ package githubcodespaces
 import (
 	"context"
 	"errors"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 	"reflect"
 	"strings"
 	"testing"
@@ -188,7 +189,7 @@ func TestSafetyClaimResourceRequiresPermanentIdentity(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			claim := baseClaim
-			claim.Labels = cloneLabels(baseClaim.Labels)
+			claim.Labels = shared.CloneLabels(baseClaim.Labels)
 			live := item
 			if test.mutateClaim != nil {
 				test.mutateClaim(&claim)
@@ -229,9 +230,9 @@ func TestSafetyTouchCannotRestoreStaleEndpointAfterRelease(t *testing.T) {
 	staleTarget := core.SSHTarget{Host: "cs.cs-stale-touch.main", Port: "22"}
 	server := mustCreateSafetyClaim(t, b, item, leaseID, "stale-touch", releaseStop, "ready", time.Now().Add(time.Hour), staleTarget)
 	staleServer := server
-	staleServer.Labels = cloneLabels(server.Labels)
+	staleServer.Labels = shared.CloneLabels(server.Labels)
 	releaseServer := server
-	releaseServer.Labels = cloneLabels(server.Labels)
+	releaseServer.Labels = shared.CloneLabels(server.Labels)
 
 	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{
 		Lease: core.LeaseTarget{LeaseID: leaseID, Server: releaseServer, SSH: staleTarget},

--- a/internal/providers/hetzner/checkpoint.go
+++ b/internal/providers/hetzner/checkpoint.go
@@ -277,7 +277,7 @@ func hetznerCheckpointResult(snapshot core.HetznerImage, location string, metada
 			Architecture: snapshot.Architecture,
 			Direct:       true,
 		},
-		Metadata: cloneMetadata(metadata),
+		Metadata: shared.CloneLabels(metadata),
 	}
 }
 
@@ -437,14 +437,6 @@ func validCheckpointID(value string) bool {
 		}
 	}
 	return true
-}
-
-func cloneMetadata(values map[string]string) map[string]string {
-	cloned := make(map[string]string, len(values))
-	for key, value := range values {
-		cloned[key] = value
-	}
-	return cloned
 }
 
 var (

--- a/internal/providers/hetzner/checkpoint_test.go
+++ b/internal/providers/hetzner/checkpoint_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 	"io"
 	"net/http"
 	"os"
@@ -136,7 +137,7 @@ func (f *fakeHetznerSnapshotClient) CreateServerSnapshot(_ context.Context, serv
 	f.events = append(f.events, "create-snapshot")
 	f.createServerID = serverID
 	f.createDescription = description
-	f.createLabels = cloneMetadata(labels)
+	f.createLabels = shared.CloneLabels(labels)
 	return f.created, f.createErr
 }
 
@@ -594,7 +595,7 @@ func TestHetznerCheckpointForkConfigPreservesImageLocationArchitectureAndOverrid
 		t.Fatalf("err=%v, want architecture refusal", err)
 	}
 	badSource := record
-	badSource.Metadata = cloneMetadata(record.Metadata)
+	badSource.Metadata = shared.CloneLabels(record.Metadata)
 	badSource.Metadata[checkpointMetadataSourceType] = "backup"
 	if err := (Provider{}).ApplyNativeCheckpointForkConfig(core.NativeCheckpointForkRequest{Config: &core.Config{}, Record: badSource}); err == nil {
 		t.Fatal("expected source type refusal")

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -226,12 +226,12 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 		if !hasCompleteCapturedRuntimeScope(completedScope) {
 			return core.LeaseTarget{}, core.Exit(2, "local-container runtime identity is incomplete; refusing to create an unscoped lease")
 		}
-		metadata := cloneLabels(cfg.LocalContainer.CheckpointMetadata)
+		metadata := shared.CloneLabels(cfg.LocalContainer.CheckpointMetadata)
 		for _, key := range checkpointScopeMetadataKeys {
 			metadata[key] = completedScope[key]
 		}
-		cfg.LocalContainer.CheckpointMetadata = cloneLabels(metadata)
-		b.cfg.LocalContainer.CheckpointMetadata = cloneLabels(metadata)
+		cfg.LocalContainer.CheckpointMetadata = shared.CloneLabels(metadata)
+		b.cfg.LocalContainer.CheckpointMetadata = shared.CloneLabels(metadata)
 	}
 	if strings.TrimSpace(req.RequestedLeaseID) != "" {
 		return b.acquireFixed(ctx, req, cfg)
@@ -369,7 +369,7 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 		return core.LeaseTarget{}, errors.Join(err, reconcileErr)
 	}
 	lease.Server.Status = "ready"
-	lease.Server.Labels = cloneLabels(lease.Server.Labels)
+	lease.Server.Labels = shared.CloneLabels(lease.Server.Labels)
 	lease.Server.Labels["state"] = "ready"
 	delete(lease.Server.Labels, "recovery")
 	readyClaim, err := core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, pendingClaim, lease.Server, lease.SSH)
@@ -583,7 +583,7 @@ func markPendingLease(server *core.Server) {
 	if server.Labels == nil {
 		server.Labels = map[string]string{}
 	} else {
-		server.Labels = cloneLabels(server.Labels)
+		server.Labels = shared.CloneLabels(server.Labels)
 	}
 	server.Status = pendingClaimState
 	server.Labels["state"] = pendingClaimState
@@ -684,7 +684,7 @@ func (b *backend) rollbackPendingLease(expected core.LeaseClaim, lease core.Leas
 		if err := b.removeContainer(rollbackCtx, lease.Server.CloudID); err != nil {
 			return err
 		}
-		labels := cloneLabels(lease.Server.Labels)
+		labels := shared.CloneLabels(lease.Server.Labels)
 		labels["bootstrap_dir"] = bootstrapDir
 		return b.cleanupContainerSidecars(lease.LeaseID, labels, true)
 	})
@@ -837,7 +837,7 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 				return core.LeaseTarget{}, errors.Join(err, reconcileErr)
 			}
 			lease.Server.Status = "ready"
-			lease.Server.Labels = cloneLabels(lease.Server.Labels)
+			lease.Server.Labels = shared.CloneLabels(lease.Server.Labels)
 			lease.Server.Labels["state"] = "ready"
 			delete(lease.Server.Labels, "recovery")
 			updatedClaim, updateErr = core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, exactClaim, lease.Server, lease.SSH)
@@ -916,7 +916,7 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 	lease.Server.Labels = publicLocalContainerClaimLabels(lease.Server.Labels)
 	if req.IncludeDiagnostics && req.IsReadOnlyStatus() && !req.ReadyProbe {
 		// All ownership/claim merges are complete. Enrich only the returned copy.
-		lease.Server.Labels = cloneLabels(lease.Server.Labels)
+		lease.Server.Labels = shared.CloneLabels(lease.Server.Labels)
 		for key := range lease.Server.Labels {
 			if strings.HasPrefix(key, memoryDiagnosticPrefix) {
 				delete(lease.Server.Labels, key)
@@ -2672,7 +2672,7 @@ func mergeLocalContainerClaim(server core.Server, claim core.LeaseClaim) core.Se
 }
 
 func publicLocalContainerClaimLabels(labels map[string]string) map[string]string {
-	out := cloneLabels(labels)
+	out := shared.CloneLabels(labels)
 	for key := range out {
 		if privateLocalContainerScopeLabel(key) {
 			delete(out, key)
@@ -2696,14 +2696,6 @@ func isPendingLocalContainerClaim(claim core.LeaseClaim) bool {
 		strings.TrimSpace(claim.Labels["recovery"]) == pendingRecoveryKind &&
 		strings.TrimSpace(claim.CloudID) != "" &&
 		strings.TrimSpace(claim.ProviderScope) != ""
-}
-
-func cloneLabels(labels map[string]string) map[string]string {
-	cloned := make(map[string]string, len(labels))
-	for key, value := range labels {
-		cloned[key] = value
-	}
-	return cloned
 }
 
 func containerSSHHostPort(container inspectContainer) (string, string, error) {

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -1662,7 +1662,7 @@ func TestRunFailureMemoryContext(t *testing.T) {
 
 func TestMemoryDiagnosticsResolveDoesNotPersist(t *testing.T) {
 	leaseID, _, initial, runner := createLocalContainerTouchClaim(t, time.Minute)
-	labels := cloneLabels(initial.Labels)
+	labels := shared.CloneLabels(initial.Labels)
 	labels["diagnostic.memory.stale"] = "old-observation"
 	var err error
 	initial, err = core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, initial, labels)
@@ -2768,7 +2768,7 @@ func TestCreateContainerDoesNotLabelPrivateRuntimeScope(t *testing.T) {
 	cfg.LocalContainer.CheckpointMetadata = checkpointScopeMetadata(checkpointScope{
 		Runtime: "docker", Context: "named", Config: "/private/docker-config", Host: "tcp://user:password@example.invalid:2376", Endpoint: "tcp://user:password@example.invalid:2376", DaemonID: "daemon-private",
 	})
-	b.cfg.LocalContainer.CheckpointMetadata = cloneLabels(cfg.LocalContainer.CheckpointMetadata)
+	b.cfg.LocalContainer.CheckpointMetadata = shared.CloneLabels(cfg.LocalContainer.CheckpointMetadata)
 	_, bootstrapDir, err := b.createContainer(context.Background(), cfg, "crabbox-private", "cbx_private", "private", "ssh-ed25519 AAAA test", true)
 	if err != nil {
 		t.Fatal(err)
@@ -3877,7 +3877,7 @@ func TestAcquireSSHReadinessSuccessCannotOverwriteNewerClaim(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		labels := cloneLabels(claim.Labels)
+		labels := shared.CloneLabels(claim.Labels)
 		labels["state"] = "superseded"
 		_, err = core.UpdateLeaseClaimLabelsIfUnchanged(*leaseID, claim, labels)
 		return err
@@ -3912,7 +3912,7 @@ func TestAcquireReadyCASRollsBackContainerClaimedByNewerIdentity(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		labels := cloneLabels(claim.Labels)
+		labels := shared.CloneLabels(claim.Labels)
 		labels["state"] = "ready"
 		replacement := claim
 		replacement.CloudID = "newer-container"
@@ -3951,7 +3951,7 @@ func TestAcquireReadinessFailureReconcilesDifferentClaim(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		labels := cloneLabels(claim.Labels)
+		labels := shared.CloneLabels(claim.Labels)
 		replacement := claim
 		replacement.CloudID = "newer-container"
 		replacement.Labels = labels
@@ -3995,7 +3995,7 @@ func TestKeepFalseReadinessRollbackFailurePrintsRecovery(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		labels := cloneLabels(claim.Labels)
+		labels := shared.CloneLabels(claim.Labels)
 		labels["concurrent_touch"] = "true"
 		if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(*leaseID, claim, labels); err != nil {
 			return err
@@ -5934,7 +5934,7 @@ func TestResolvePreviouslyReadyTerminalContainerWithoutSSHPort(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			labels := cloneLabels(claim.Labels)
+			labels := shared.CloneLabels(claim.Labels)
 			labels["state"] = "ready"
 			claim, err = core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, claim, labels)
 			if err != nil {
@@ -5990,7 +5990,7 @@ func TestLocalContainerTouchPersistsExactClaimLifecycle(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			leaseID, _, initial, runner := createLocalContainerTouchClaim(t, 37*time.Minute)
 			if test.ttlLabel != "" {
-				labels := cloneLabels(initial.Labels)
+				labels := shared.CloneLabels(initial.Labels)
 				labels["ttl_secs"] = test.ttlLabel
 				updated, err := core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, initial, labels)
 				if err != nil {
@@ -6069,7 +6069,7 @@ func TestLocalContainerTouchRejectsUnownedOrChangedClaimWithoutMutation(t *testi
 		mutate func(*testing.T, *backend, *core.LeaseTarget, core.LeaseClaim)
 	}{
 		{name: "missing carried snapshot", mutate: func(_ *testing.T, _ *backend, lease *core.LeaseTarget, _ core.LeaseClaim) {
-			lease.Server = core.Server{Provider: lease.Server.Provider, CloudID: lease.Server.CloudID, Labels: cloneLabels(lease.Server.Labels)}
+			lease.Server = core.Server{Provider: lease.Server.Provider, CloudID: lease.Server.CloudID, Labels: shared.CloneLabels(lease.Server.Labels)}
 		}},
 		{name: "wrong provider", mutate: func(t *testing.T, _ *backend, lease *core.LeaseTarget, claim core.LeaseClaim) {
 			claim.Provider = "aws"
@@ -6083,12 +6083,12 @@ func TestLocalContainerTouchRejectsUnownedOrChangedClaimWithoutMutation(t *testi
 			lease.Server.CloudID = strings.Repeat("b", 64)
 		}},
 		{name: "runtime metadata mismatch", mutate: func(t *testing.T, _ *backend, lease *core.LeaseTarget, claim core.LeaseClaim) {
-			claim.Labels = cloneLabels(claim.Labels)
+			claim.Labels = shared.CloneLabels(claim.Labels)
 			claim.Labels[checkpointMetadataContext] = "other"
 			core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
 		}},
 		{name: "stale carried snapshot after CAS replacement", mutate: func(t *testing.T, _ *backend, lease *core.LeaseTarget, claim core.LeaseClaim) {
-			labels := cloneLabels(claim.Labels)
+			labels := shared.CloneLabels(claim.Labels)
 			labels["concurrent_replacement"] = "true"
 			if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(lease.LeaseID, claim, labels); err != nil {
 				t.Fatal(err)
@@ -6438,7 +6438,7 @@ func TestReleaseLeaseRejectsClaimChangedAfterResolution(t *testing.T) {
 	}
 	server := core.Server{CloudID: "snapshot-container", Labels: map[string]string{"lease": leaseID}}
 	core.SetServerLeaseClaimSnapshot(&server, claim, true)
-	labels := cloneLabels(claim.Labels)
+	labels := shared.CloneLabels(claim.Labels)
 	labels["state"] = "newer"
 	if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, claim, labels); err != nil {
 		t.Fatal(err)
@@ -6687,7 +6687,7 @@ func TestMissingReleaseRejectsClaimChangedAfterResolution(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	labels := cloneLabels(claim.Labels)
+	labels := shared.CloneLabels(claim.Labels)
 	labels["state"] = "ready"
 	if _, err := core.UpdateLeaseClaimEndpointIfUnchanged(
 		leaseID,
@@ -7259,7 +7259,7 @@ func TestCleanupLiveClaimChangeFencesMutation(t *testing.T) {
 			fixture := newCleanupClaimFixture(t, "cbx_cleanup_reclaimed", "cleanup-old-container", "exited", false)
 			replacement := fixture.claim
 			replacement.CloudID = "cleanup-replacement-container"
-			replacement.Labels = cloneLabels(replacement.Labels)
+			replacement.Labels = shared.CloneLabels(replacement.Labels)
 			replaced := false
 			fixture.b.beforeCleanupMutation = func(leaseID string) {
 				if leaseID != fixture.leaseID || replaced {
@@ -7389,7 +7389,7 @@ func TestCleanupMissingPendingRechecksAbsenceInsideFence(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			fixture := newCleanupClaimFixture(t, "cbx_cleanup_missing_pending", "cleanup-missing-pending", "exited", false)
 			fixture.runner.responses[commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"})] = core.LocalCommandResult{}
-			labels := cloneLabels(fixture.claim.Labels)
+			labels := shared.CloneLabels(fixture.claim.Labels)
 			labels["state"] = pendingClaimState
 			labels["recovery"] = pendingRecoveryKind
 			updated, err := core.UpdateLeaseClaimLabelsIfUnchanged(fixture.leaseID, fixture.claim, labels)
@@ -8022,7 +8022,7 @@ func addDefaultLocalContainerScopeResponses(runner *recordingRunner) {
 }
 
 func testCapturedScopeLabels(labels map[string]string) map[string]string {
-	out := cloneLabels(labels)
+	out := shared.CloneLabels(labels)
 	for key, value := range checkpointScopeMetadata(checkpointScope{
 		Runtime: "docker", Context: "default", Endpoint: "unix:///tmp/docker-test.sock", DaemonID: "daemon-test",
 	}) {

--- a/internal/providers/localcontainer/checkpoint_test.go
+++ b/internal/providers/localcontainer/checkpoint_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 	"io"
 	"os"
 	"path/filepath"
@@ -475,7 +476,7 @@ func TestCheckpointScopeForServerUsesExactClaimSnapshot(t *testing.T) {
 		checkpointMetadataContext:  "remote-context",
 		checkpointMetadataDaemonID: "daemon-123",
 	}}
-	claimLabels := cloneLabels(server.Labels)
+	claimLabels := shared.CloneLabels(server.Labels)
 	claimLabels[checkpointMetadataConfig] = "/claim/docker-config"
 	claimLabels[checkpointMetadataEndpoint] = "unix:///claim/docker.sock"
 	core.SetServerLeaseClaimSnapshot(&server, core.LeaseClaim{Labels: claimLabels}, true)

--- a/internal/providers/localcontainer/cleanup_toctou_test.go
+++ b/internal/providers/localcontainer/cleanup_toctou_test.go
@@ -23,6 +23,7 @@ package localcontainer
 import (
 	"bytes"
 	"context"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 	"io"
 	"os"
 	"path/filepath"
@@ -407,7 +408,7 @@ func TestCleanupRetainsKeyPreparedByConcurrentAcquire(t *testing.T) {
 }
 
 func cleanupTOCTOUScopeLabels(labels map[string]string, contextName string) map[string]string {
-	out := cloneLabels(labels)
+	out := shared.CloneLabels(labels)
 	for key, value := range checkpointScopeMetadata(checkpointScope{
 		Runtime: "docker", Context: contextName, Endpoint: "unix:///tmp/docker-test.sock", DaemonID: "daemon-test",
 	}) {

--- a/internal/providers/localcontainer/fixed_lease.go
+++ b/internal/providers/localcontainer/fixed_lease.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 	"strconv"
 	"strings"
 
@@ -107,10 +108,10 @@ func (b *backend) acquireFixed(ctx context.Context, req core.AcquireRequest, cfg
 			return
 		}
 		pendingClaim = *claim
-		pendingClaim.Labels = cloneLabels(claim.Labels)
+		pendingClaim.Labels = shared.CloneLabels(claim.Labels)
 		if claim.FixedCreateIntent != nil {
 			intent := *claim.FixedCreateIntent
-			intent.Attempt = cloneLabels(claim.FixedCreateIntent.Attempt)
+			intent.Attempt = shared.CloneLabels(claim.FixedCreateIntent.Attempt)
 			intent.FailedAttempts = append([]string(nil), claim.FixedCreateIntent.FailedAttempts...)
 			pendingClaim.FixedCreateIntent = &intent
 		}
@@ -209,7 +210,7 @@ func (b *backend) acquireFixed(ctx context.Context, req core.AcquireRequest, cfg
 			pending := createdPendingLease(cfg, containerID, leaseID, intent.Slug, bootstrapDir, req.Keep)
 			pending.Server.Labels["fixed_intent_sha256"] = fingerprint
 			core.SetLeaseClaimResourceIdentity(claim, containerID, claim.CloudNumericID, claim.CloudImmutableID, nil)
-			claim.Labels = cloneLabels(pending.Server.Labels)
+			claim.Labels = shared.CloneLabels(pending.Server.Labels)
 			intent.Attempt["container_id"] = containerID
 			if err := persist(); err != nil {
 				return core.LeaseTarget{}, err
@@ -234,7 +235,7 @@ func (b *backend) acquireFixed(ctx context.Context, req core.AcquireRequest, cfg
 			pending := createdPendingLease(cfg, container.ID, leaseID, intent.Slug, container.Config.Labels["bootstrap_dir"], req.Keep)
 			pending.Server.Labels["fixed_intent_sha256"] = fingerprint
 			core.SetLeaseClaimResourceIdentity(claim, container.ID, claim.CloudNumericID, claim.CloudImmutableID, nil)
-			claim.Labels = cloneLabels(pending.Server.Labels)
+			claim.Labels = shared.CloneLabels(pending.Server.Labels)
 			intent.Attempt["container_id"] = container.ID
 			if err := persist(); err != nil {
 				return core.LeaseTarget{}, err
@@ -283,7 +284,7 @@ func (b *backend) acquireFixed(ctx context.Context, req core.AcquireRequest, cfg
 			return core.LeaseTarget{}, err
 		}
 		lease.Server.Status = "ready"
-		lease.Server.Labels = cloneLabels(lease.Server.Labels)
+		lease.Server.Labels = shared.CloneLabels(lease.Server.Labels)
 		lease.Server.Labels["state"] = "ready"
 		delete(lease.Server.Labels, "recovery")
 		for _, key := range checkpointScopeMetadataKeys {

--- a/internal/providers/localcontainer/provider.go
+++ b/internal/providers/localcontainer/provider.go
@@ -2,6 +2,7 @@ package localcontainer
 
 import (
 	"flag"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 	"path/filepath"
 	"strings"
 
@@ -67,7 +68,7 @@ func (Provider) PrepareLeaseClaimEndpoint(existing core.LeaseClaim, provider, sl
 	if existing.CloudID != "" && server.CloudID != "" && existing.CloudID != server.CloudID {
 		return core.Server{}, core.Exit(2, "local-container lease %s is bound to container %s; refusing endpoint rewrite to %s", existing.LeaseID, shortID(existing.CloudID), shortID(server.CloudID))
 	}
-	labels := cloneLabels(server.Labels)
+	labels := shared.CloneLabels(server.Labels)
 	for _, key := range append([]string{
 		"bootstrap_dir", "bootstrap_owned", "docker_socket", "host_work_root", "keep", "runtime", "runtime_context", "ssh_key_owned", "ssh_user", "work_root",
 	}, checkpointScopeMetadataKeys...) {

--- a/internal/providers/lume/backend.go
+++ b/internal/providers/lume/backend.go
@@ -414,7 +414,7 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 		return core.LeaseTarget{}, cleanupUnclaimedVM(err)
 	}
 	readyClaim := persistedClaim
-	readyClaim.Labels = cloneLabels(persistedClaim.Labels)
+	readyClaim.Labels = shared.CloneLabels(persistedClaim.Labels)
 	readyClaim.Labels["state"] = "ready"
 	lease, err := b.prepareLease(ctx, cfg, inst, readyClaim, true)
 	if err != nil {
@@ -1616,7 +1616,7 @@ func (b *backend) recoverPendingCloneClaim(ctx context.Context, claim core.Lease
 		}
 		bound := claim
 		bound.CloudImmutableID = immutableID
-		bound.Labels = cloneLabels(claim.Labels)
+		bound.Labels = shared.CloneLabels(claim.Labels)
 		bound.Labels["state"] = "error"
 		bound.Labels["recovery"] = "clone-ambiguous"
 		observed = inst
@@ -1817,14 +1817,6 @@ func removeLaunchHandoff(claim core.LeaseClaim) {
 	if handoff, err := launchHandoffForToken(strings.TrimSpace(claim.Labels["run_launch_token"])); err == nil {
 		_ = os.RemoveAll(handoff.Dir)
 	}
-}
-
-func cloneLabels(labels map[string]string) map[string]string {
-	cloned := make(map[string]string, len(labels))
-	for key, value := range labels {
-		cloned[key] = value
-	}
-	return cloned
 }
 
 func ownerProcessMatches(owner lumeRunOwner) bool {

--- a/internal/providers/nebius/backend.go
+++ b/internal/providers/nebius/backend.go
@@ -96,7 +96,7 @@ func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 		if err == nil || committed || strings.TrimSpace(created.ID) == "" {
 			return
 		}
-		recoveryLabels := cloneStringMap(labels)
+		recoveryLabels := shared.CloneLabels(labels)
 		if req.Keep {
 			recoveryLabels["recovery"] = "kept-after-failure"
 			retainKey = true
@@ -281,7 +281,7 @@ func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server
 	labels := liveServer.Labels
 	if req.IdleTimeout > 0 {
 		cfg.IdleTimeout = req.IdleTimeout
-		labels = cloneStringMap(labels)
+		labels = shared.CloneLabels(labels)
 		delete(labels, "idle_timeout")
 		delete(labels, "idle_timeout_secs")
 	}
@@ -475,14 +475,6 @@ func nebiusServerType(cfg core.Config) string {
 		return strings.TrimSpace(cfg.ServerType)
 	}
 	return strings.TrimSpace(cfg.Nebius.Preset)
-}
-
-func cloneStringMap(in map[string]string) map[string]string {
-	out := make(map[string]string, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
-	return out
 }
 
 var _ core.SSHLeaseBackend = (*backend)(nil)

--- a/internal/providers/unikraftcloud/backend.go
+++ b/internal/providers/unikraftcloud/backend.go
@@ -389,7 +389,7 @@ func (b *backend) Status(ctx context.Context, req core.StatusRequest) (core.Stat
 					State:      claim.Labels["state"],
 					ServerType: "unikraft-cloud-instance",
 					Network:    networkPublic,
-					Labels:     cloneLabels(claim.Labels),
+					Labels:     shared.CloneLabels(claim.Labels),
 				}, nil
 			}
 			if state := claim.Labels["state"]; state == ukcStateCreatePreflight || state == ukcStateCreateConflict {

--- a/internal/providers/unikraftcloud/durability_test.go
+++ b/internal/providers/unikraftcloud/durability_test.go
@@ -3,6 +3,7 @@ package unikraftcloud
 import (
 	"context"
 	"errors"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 	"net/http"
 	"reflect"
 	"strings"
@@ -74,7 +75,7 @@ func TestReconcileReadyClaimWriteRejectsChangedRecoveryIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 	changed := ready
-	changed.Labels = cloneLabels(ready.Labels)
+	changed.Labels = shared.CloneLabels(ready.Labels)
 	changed.Labels[ukcLabelRequestHash] = strings.Repeat("0", 64)
 	if err := core.ReplaceLeaseClaimIfUnchanged(ready.LeaseID, ready, changed); err != nil {
 		t.Fatal(err)
@@ -185,7 +186,7 @@ func TestCreateStateTransitionDoesNotReconcileGuardConflict(t *testing.T) {
 		t.Fatal(err)
 	}
 	concurrent := preflight
-	concurrent.Labels = cloneLabels(preflight.Labels)
+	concurrent.Labels = shared.CloneLabels(preflight.Labels)
 	concurrent.Labels["state"] = ukcStateCreateIntent
 	concurrent, err = replaceLeaseClaimIfUnchangedDurable(leaseID, preflight, concurrent)
 	if err != nil {

--- a/internal/providers/unikraftcloud/lifecycle.go
+++ b/internal/providers/unikraftcloud/lifecycle.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 	"net/http"
 	"reflect"
 	"strings"
@@ -46,14 +47,6 @@ func unikraftCloudCreateRequestHash(req createInstanceRequest) string {
 	return fmt.Sprintf("%x", sum[:])
 }
 
-func cloneLabels(labels map[string]string) map[string]string {
-	out := make(map[string]string, len(labels))
-	for key, value := range labels {
-		out[key] = value
-	}
-	return out
-}
-
 func (b *backend) createIntentClaim(leaseID, slug, scope, accountUUID string, req core.WarmupRequest, createReq createInstanceRequest) (core.LeaseClaim, error) {
 	labels := directLeaseLabels(b.cfg, leaseID, slug, req.Keep, core.ClockNow(b.rt.Clock))
 	labels["state"] = ukcStateCreatePreflight
@@ -83,7 +76,7 @@ func transitionUnikraftCloudCreateState(claim core.LeaseClaim, state string) (co
 		return core.LeaseClaim{}, core.Exit(5, "%s lease %s is already bound to instance %s", providerName, claim.LeaseID, claim.CloudID)
 	}
 	updated := claim
-	updated.Labels = cloneLabels(claim.Labels)
+	updated.Labels = shared.CloneLabels(claim.Labels)
 	updated.Labels["state"] = state
 	written, err := replaceLeaseClaimIfUnchangedDurable(claim.LeaseID, claim, updated)
 	if err != nil {
@@ -197,7 +190,7 @@ func (b *backend) publishReadyClaim(intent core.LeaseClaim, instance ukcInstance
 	if err := validateUnikraftCloudInstanceIdentity(instance, strings.TrimSpace(instance.UUID), resourceName); err != nil {
 		return core.LeaseClaim{}, err
 	}
-	labels := cloneLabels(intent.Labels)
+	labels := shared.CloneLabels(intent.Labels)
 	labels["state"] = ukcStateReady
 	labels[ukcLabelInstanceUUID] = instance.UUID
 	labels[ukcLabelProviderState] = normalizedInstanceState(instance.State)
@@ -247,7 +240,7 @@ func (b *backend) reconcileReadyClaimWrite(intent core.LeaseClaim, instance ukcI
 		unlockSlug()
 		return core.LeaseClaim{}, errors.Join(writeErr, fmt.Errorf("reserve restored %s lease slug: %w", providerName, slugErr))
 	}
-	labels := cloneLabels(intent.Labels)
+	labels := shared.CloneLabels(intent.Labels)
 	labels["slug"] = recoveredSlug
 	labels["state"] = ukcStateReady
 	labels[ukcLabelInstanceUUID] = instance.UUID
@@ -509,7 +502,7 @@ func (b *backend) deleteClaimedInstance(ctx context.Context, api unikraftCloudAP
 			return false, err
 		}
 		if state != ukcStateDeleteAttempt {
-			labels := cloneLabels(claim.Labels)
+			labels := shared.CloneLabels(claim.Labels)
 			labels["state"] = ukcStateDeleteAttempt
 			updated := claim
 			updated.Labels = labels
@@ -529,7 +522,7 @@ func (b *backend) deleteClaimedInstance(ctx context.Context, api unikraftCloudAP
 		if err := validateUnikraftCloudDeleteIdentity(deleted, instanceID, resourceName); err != nil {
 			return false, err
 		}
-		labels := cloneLabels(claim.Labels)
+		labels := shared.CloneLabels(claim.Labels)
 		labels["state"] = ukcStateDeleteAccepted
 		labels[ukcLabelProviderState] = normalizedInstanceState(deleted.State)
 		updated := claim
@@ -657,7 +650,7 @@ func unikraftCloudTerminalState(state string) bool {
 }
 
 func serverFromClaim(claim core.LeaseClaim) core.Server {
-	labels := cloneLabels(claim.Labels)
+	labels := shared.CloneLabels(claim.Labels)
 	return core.Server{
 		CloudID:  claim.CloudID,
 		Provider: providerName,

--- a/internal/providers/unikraftcloud/ownership_test.go
+++ b/internal/providers/unikraftcloud/ownership_test.go
@@ -2,6 +2,7 @@ package unikraftcloud
 
 import (
 	"context"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 	"strings"
 	"testing"
 
@@ -59,7 +60,7 @@ func TestStopRejectsDuplicateInstanceClaimsBeforeMutation(t *testing.T) {
 
 func TestCleanupRejectsDuplicateInstanceClaimsBeforeMutation(t *testing.T) {
 	b, api, first, _ := duplicateBoundUnikraftCloudClaims(t)
-	labels := cloneLabels(first.Labels)
+	labels := shared.CloneLabels(first.Labels)
 	labels["keep"] = "false"
 	labels["expires_at"] = "1"
 	if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(first.LeaseID, first, labels); err != nil {

--- a/internal/providers/unikraftcloud/resolution_inventory_test.go
+++ b/internal/providers/unikraftcloud/resolution_inventory_test.go
@@ -3,6 +3,7 @@ package unikraftcloud
 import (
 	"context"
 	"errors"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 	"strings"
 	"testing"
 
@@ -133,7 +134,7 @@ func TestStatusDoesNotRawFallbackForCorruptExactClaim(t *testing.T) {
 		t.Fatalf("Warmup: %v", err)
 	}
 	claim := onlyTestClaim(t)
-	labels := cloneLabels(claim.Labels)
+	labels := shared.CloneLabels(claim.Labels)
 	labels[ukcLabelAccountUUID] = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
 	if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(claim.LeaseID, claim, labels); err != nil {
 		t.Fatalf("corrupt claim: %v", err)

--- a/internal/providers/unikraftcloud/snapshot_test.go
+++ b/internal/providers/unikraftcloud/snapshot_test.go
@@ -1,6 +1,7 @@
 package unikraftcloud
 
 import (
+	"github.com/openclaw/crabbox/internal/providers/shared"
 	"strings"
 	"testing"
 
@@ -26,7 +27,7 @@ func TestVerifyUnikraftCloudClaimSnapshotRejectsRebind(t *testing.T) {
 		},
 	}
 	current := snapshot
-	current.Labels = cloneLabels(snapshot.Labels)
+	current.Labels = shared.CloneLabels(snapshot.Labels)
 	current.CloudID = "66666666-7777-8888-9999-000000000000"
 	current.Labels[ukcLabelInstanceUUID] = current.CloudID
 


### PR DESCRIPTION
Eight providers maintained private copies of the same writable label-map cloning operation. They now call `shared.CloneLabels` directly, and the duplicate functions are deleted.

Nil and empty inputs still produce independent writable maps, and mutations cannot affect the original ownership/recovery metadata. OpenSandbox retains its different empty-to-nil behavior. No provider lifecycle ordering, wire format, or configuration changes are involved.

Validation: existing shared clone tests and focused provider label/metadata tests pass. Linux vet, full race suites for all eight affected providers plus shared, and Windows amd64/arm64 builds passed on Go 1.26.5 in Crabbox run `run_9a94a44910e06d350698b82d2526debc` (exit 0). Required isolated review completed without actionable findings. Net production Go reduction: 61 lines, excluding tests.
