### PR TITLE
feat(preflight): verify disposable Python environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add an opt-in `python3-venv` preflight that checks a disposable Python environment and pip with confirmed cleanup, without installing host tools or blocking workloads on missing capability. [Issue 1578](https://github.com/openclaw/crabbox/issues/1578). Thanks @coygeek.
+
 ## 0.58.0 - 2026-09-12
 
 ### Highlights

--- a/docs/commands/preflight-tools.md
+++ b/docs/commands/preflight-tools.md
@@ -56,6 +56,26 @@ Unknown names still fail with exit 2 before lease acquisition. Their diagnostic
 points to `crabbox preflight-tools`, and `crabbox run --help` includes the same
 discovery hint. Arbitrary executable names are not accepted.
 
+## Functional Python environment probe
+
+`python3-venv` is opt-in for `linux`, `macos` and `windows/wsl2`, not native
+Windows. It leaves the default list and literal `python`/`python3` version probes
+unchanged. `default,python3-venv,python3-venv` expands the ordered defaults followed
+by one functional probe. Listing it here does not execute it or establish readiness.
+
+The probe creates a disposable pip-enabled environment and invokes its own Python
+and pip. `ready` also requires confirmed worker quiescence, scratch cleanup and
+exact transport-stage retirement. It does not install host tools, activate or
+reuse project environments, or install project packages. Missing or broken
+capability, worker failure and probe timeout are diagnostic only when cleanup is
+confirmed. Unconfirmed cleanup is an operational failure that blocks the next
+workload; confirmed cleanup does not clear an operational transport, setup or
+envelope error (`unavailable cleanup=confirmed`). Caller cancellation is also
+propagated before the workload. See
+[run preflight](run.md#preflight) for every state, cleanup indication and timeout
+budget. This functional probe is not supported by profile-doctor version-only
+requirements.
+
 ## Command contract
 
 `--json` is the only data-output flag; `-h`/`--help` shows help, including when

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -568,8 +568,8 @@ stays on the remote workdir until you delete it or reset the lease. See
 ## Preflight
 
 `--preflight` prints a target-specific capability snapshot after sync and before
-the remote command. It is diagnostic only: Crabbox does not install tools,
-change the machine, or fail just because a tool is missing. Install logic
+the remote command. It is diagnostic only: Crabbox does not install or upgrade
+host tools, or fail just because a tool is missing. Install logic
 belongs in Actions hydration, a prebaked image, a devcontainer, Nix/mise/asdf,
 or the command/script you run.
 
@@ -586,6 +586,7 @@ crabbox run --preflight --preflight-tools node,bun,docker -- bun test
 crabbox run --preflight --preflight-tools default,uv -- node --test
 crabbox run --preflight --preflight-tools default,cmake -- cmake --build build
 crabbox run --preflight --preflight-tools python,python3 -- python3 -m pytest
+crabbox run --preflight --preflight-tools default,python3-venv -- python3 -m pytest
 crabbox run --preflight --preflight-tools raw_socket -- ./packet-tests
 crabbox run --preflight --preflight-tools none -- ./smoke.sh
 ```
@@ -602,6 +603,39 @@ probes likewise invoke the literal requested command with `--version`, including
 `python` and `python3` on native Windows; Crabbox does not map either name to
 `py`. An unavailable literal command prints `<name>=missing` and the run
 continues.
+
+`python3-venv` is a separate, opt-in functional probe for Linux, macOS and WSL2;
+native Windows skips it. It creates a fresh disposable virtual environment with
+pip, then invokes that environment's Python and pip. It never selects, activates
+or reuses a project environment, installs project packages, or upgrades host
+Python, `venv`, `ensurepip` or pip. Pip seeding stays inside the disposable
+environment. The literal `python` and `python3` version probes and default list
+remain unchanged; `default,python3-venv,python3-venv` keeps the default order and
+adds one functional result.
+
+The result line is `remote preflight python3-venv=<state> cleanup=<confirmed|unconfirmed>`.
+States are `ready`, `missing-python3`, `venv-unavailable`, `pip-unavailable`,
+`worker-failed`, `timed-out`, `canceled` and `unavailable`. `ready` requires both
+environment-local commands to succeed, owner-confirmed probe-process quiescence
+and scratch removal, and caller-confirmed retirement of the exact transport
+stage. `venv-unavailable` covers missing venv support, environment-creation failure
+or failure of the environment's Python; `pip-unavailable` covers missing or failing
+`ensurepip`, pip seeding or the environment's pip. `unavailable` means no reliable
+capability result. Cleanup is independent: a transport, setup or envelope error
+can remain after confirmed cleanup (`unavailable cleanup=confirmed`); unresolved
+quiescence, scratch removal or stage retirement reports `cleanup=unconfirmed`.
+
+Missing or broken capability is diagnostic only and does not skip the workload.
+Worker failure or probe timeout is also diagnostic only when cleanup is confirmed.
+In contrast, an operational transport, setup, envelope, ownership or cleanup
+failure prevents the next workload, even if cleanup is confirmed. In particular,
+`unavailable cleanup=unconfirmed` never permits continuation with an unresolved
+owned stage.
+Caller cancellation remains cancellation (`canceled`), and no later workload
+starts. The probe has a 90-second allowance and an independent 30-second cleanup
+reserve, plus separately bounded transport setup; this is not a promise that the
+whole command finishes within 120 seconds. This functional probe cannot be used
+as a profile-doctor version-only tool requirement.
 
 `raw_socket` uses `python3`, then `python`, to open and immediately close
 `socket(AF_INET, SOCK_RAW, IPPROTO_RAW)` without binding, connecting, sending,

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -1025,6 +1025,26 @@ list and prints only the workspace summary, without restoring default probes.
 Preflight probes are diagnostic only: a missing tool does not block the
 workload, and Crabbox does not install or upgrade toolchains.
 
+Add `python3-venv` to this list in repository or user configuration to opt into a
+functional disposable-venv check on Linux, macOS or WSL2. For example,
+`preflightTools: [default, python3-venv, python3-venv]` retains the ordered defaults
+and runs the added probe once; unsupported native Windows targets filter it out.
+The CLI equivalent is `--preflight-tools default,python3-venv`. It does not change
+literal `python`/`python3` probes or make the functional probe default-on.
+
+The probe creates a fresh environment, seeds pip only there, and checks its own
+Python and pip without installing host or project packages or reusing a project
+environment. Its diagnostic `ready` result requires confirmed cleanup, not just
+successful creation. Caller cancellation prevents the later workload; unavailable
+capability alone does not. A worker failure or probe timeout with confirmed
+cleanup is also diagnostic only. An unresolved owned stage, reported as
+`unavailable cleanup=unconfirmed`, fails the run before the workload. Cleanup status
+is independent: a transport, setup or envelope error can still fail the run after
+cleanup succeeds (`unavailable cleanup=confirmed`).
+See [run preflight](../commands/run.md#preflight) for
+the complete state/cleanup output and separate probe, cleanup and transport
+budgets. `python3-venv` is not a profile-doctor version-only tool requirement.
+
 ### Actions
 
 ```yaml

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -353,7 +353,7 @@ selected provider/target supports hydration.
 
 Preflight is a probe layer, not an installer. Missing tools print
 `tool=missing`; Crabbox does not run `apt install`, `corepack prepare`,
-`bun install`, or any other setup. Install toolchains through Actions hydration,
+`bun install`, or host toolchain setup. Install toolchains through Actions hydration,
 a prebaked image, a devcontainer/Nix/mise/asdf setup, or the uploaded
 script/command itself.
 
@@ -366,6 +366,7 @@ the probe list per run:
 ```sh
 crabbox run --preflight --preflight-tools python,python3 -- python3 -m pytest
 crabbox run --preflight --preflight-tools default,cmake -- cmake --build build
+crabbox run --preflight --preflight-tools default,python3-venv -- python3 -m pytest
 crabbox run --preflight --preflight-tools raw_socket -- ./packet-tests
 ```
 
@@ -373,6 +374,31 @@ The opt-in CMake probe invokes the literal `cmake --version` command on POSIX,
 WSL2, and native Windows targets. It reports only the first output line or
 `cmake=missing`; the result is diagnostic only, so missing CMake does not block
 the workload or trigger installation or upgrades.
+
+The opt-in `python3-venv` probe checks a real disposable environment on Linux,
+macOS and WSL2, not merely the interpreter version or whether `venv` imports.
+It reports `remote preflight python3-venv=<state> cleanup=<confirmed|unconfirmed>`.
+`ready` means the fresh environment's Python and pip succeeded, the probe owner
+confirmed process quiescence and scratch removal, and the caller confirmed exact
+transport-stage retirement. Capability results distinguish `missing-python3`,
+`venv-unavailable` and `pip-unavailable`; other states are `worker-failed`,
+`timed-out`, `canceled` and `unavailable`. `unavailable` means no reliable capability
+result. Cleanup is independent: an operational transport, setup or envelope error
+may remain after confirmed cleanup, yielding `unavailable cleanup=confirmed`.
+Unknown quiescence, scratch removal or stage retirement instead reports
+`cleanup=unconfirmed`; uncertainty is never successful cleanup.
+
+Capability absence, broken capability, worker failure or probe timeout does not
+block the workload when cleanup is confirmed. Operational transport, setup,
+envelope, ownership or cleanup errors prevent the later workload regardless of
+the cleanup flag. `unavailable cleanup=unconfirmed` also fails the run rather than
+continuing with unresolved ownership. Caller cancellation prevents continuation.
+The 90-second probe allowance and
+independent 30-second cleanup reserve exclude separately bounded transport setup,
+so they are not a total-command deadline. No host packages are installed or
+upgraded, and no project environment is activated or reused; pip is seeded only
+inside the disposable environment. See [run preflight](commands/run.md#preflight)
+for selection and target support.
 
 `raw_socket` reports `direct` when the execution user can open and immediately
 close `socket(AF_INET, SOCK_RAW, IPPROTO_RAW)`, `sudo` when only the same

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -1765,6 +1765,13 @@ func TestProfileValidationRejectsWindowsOnlyDoctorTool(t *testing.T) {
 	}
 }
 
+func TestProfileDoctorRejectsFunctionalPreflight(t *testing.T) {
+	err := validateProfileDoctorTools([]string{pythonVenvPreflightTool})
+	if ExitCodeForError(err, 0) != 2 || !strings.Contains(err.Error(), "not supported for POSIX profile doctor") {
+		t.Fatalf("functional run preflight was admitted as a version check: %v", err)
+	}
+}
+
 func TestRemoteProfileDoctorCommandChecksSudoAndDecode(t *testing.T) {
 	got := remoteProfileDoctorCommand("qa", DoctorProfileConfig{Enabled: true, Tools: []string{"sudo"}}, "/work/repo")
 	for _, want := range []string{"base64 -d >", "|| exit 1"} {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1651,9 +1651,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		printRunContextSummary(a.Stderr, coord, cfg, server, currentTarget, leaseID, executionRunID, recorder.runID, workdir, hydratedByActions, actionsURL)
 		contextPrinted = true
 	}
-	printPreflight := func(currentTarget SSHTarget) {
+	printPreflight := func(currentTarget SSHTarget) error {
 		if !*preflight || preflightPrinted {
-			return
+			return nil
 		}
 		hydrateTarget := currentTarget
 		if hydrateTarget.TargetOS == "" {
@@ -1663,8 +1663,12 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			hydrateTarget.WindowsMode = cfg.WindowsMode
 		}
 		hydrateSupported := supportsLocalActionsHydrateTarget(hydrateTarget) || supportsGitHubActionsRunnerTarget(hydrateTarget)
-		printRemoteCapabilityPreflight(ctx, a.Stderr, cfg, server, currentTarget, leaseID, workdir, remoteRunEnvFiles(actionsEnvFile, profileEnvFile), hydratedByActions, actionsURL, hydrateSupported, envSelection.Inline)
+		preflightErr := printRemoteCapabilityPreflight(ctx, a.Stderr, cfg, server, currentTarget, leaseID, workdir, remoteRunEnvFiles(actionsEnvFile, profileEnvFile), hydratedByActions, actionsURL, hydrateSupported, envSelection.Inline)
 		preflightPrinted = true
+		if preflightErr != nil {
+			return preflightErr
+		}
+		return context.Cause(ctx)
 	}
 	preflightRawJSRuntime := func(currentTarget SSHTarget) error {
 		if rawJSRuntimePreflightDone {
@@ -2354,7 +2358,9 @@ afterSync:
 		}
 	}
 	if *syncOnly {
-		printPreflight(target)
+		if err := printPreflight(target); err != nil {
+			return recordFailure(err)
+		}
 		fmt.Fprintf(a.Stdout, "synced %s\n", workdir)
 		fmt.Fprintln(a.Stderr, formatRunSummary(timings, time.Since(timings.started), 0))
 		if *timingJSON || timingRecordEnabled || observation != nil {
@@ -2470,7 +2476,9 @@ afterSync:
 			fmt.Fprintf(a.Stderr, "env helper remote=%s usage=%s\n", envHelperPath, shellQuote("./"+envHelperPath+" <command>"))
 		}
 	}
-	printPreflight(target)
+	if err := printPreflight(target); err != nil {
+		return recordFailure(err)
+	}
 	if expansion.Profile.Doctor.Enabled {
 		fmt.Fprintf(a.Stderr, "profile doctor profile=%s\n", cfg.Profile)
 		out, err := runSSHCombinedOutput(ctx, target, remoteProfileDoctorCommand(cfg.Profile, expansion.Profile.Doctor, workdir))

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -152,9 +152,9 @@ func runLogsURL(coord *CoordinatorClient, runID string) string {
 	return strings.TrimRight(redactedConfigURL(coord.BaseURL), "/") + "/v1/runs/" + url.PathEscape(runID) + "/logs"
 }
 
-func printRemoteCapabilityPreflight(ctx context.Context, w io.Writer, cfg Config, server Server, target SSHTarget, leaseID, workdir string, envFiles []string, hydrated bool, actionsURL string, hydrateSupported bool, env map[string]string) {
+func printRemoteCapabilityPreflight(ctx context.Context, w io.Writer, cfg Config, server Server, target SSHTarget, leaseID, workdir string, envFiles []string, hydrated bool, actionsURL string, hydrateSupported bool, env map[string]string) error {
 	if w == nil {
-		return
+		return nil
 	}
 	for _, line := range remotePreflightWorkspaceLines(cfg, target, leaseID, workdir, hydrated, actionsURL, hydrateSupported) {
 		fmt.Fprintln(w, line)
@@ -166,11 +166,16 @@ func printRemoteCapabilityPreflight(ctx context.Context, w io.Writer, cfg Config
 	}
 	tools := preflightToolsForTarget(target, cfg.Run.PreflightTools)
 	if len(tools) == 0 {
-		return
+		return nil
 	}
 	baseTools := make([]string, 0, len(tools))
 	rawSocketRequested := false
+	venvRequested := false
 	for _, tool := range tools {
+		if tool == pythonVenvPreflightTool {
+			venvRequested = true
+			continue
+		}
 		if tool == rawSocketPreflightTool {
 			rawSocketRequested = true
 			continue
@@ -200,10 +205,24 @@ func printRemoteCapabilityPreflight(ctx context.Context, w io.Writer, cfg Config
 			}
 		}
 	}
+	if venvRequested {
+		completion, err := runOwnedFunctionalPreflight(ctx, target, workdir, env, envFiles)
+		fmt.Fprintf(w, "remote preflight %s\n", functionalPreflightDiagnostic(ctx, completion, err))
+		if err != nil {
+			return err
+		}
+		if ctx.Err() != nil {
+			return context.Cause(ctx)
+		}
+		if !completion.WorkerQuiesced || !completion.ScratchRemoved || !completion.StageRetired {
+			return errors.New("functional preflight cleanup unconfirmed")
+		}
+	}
 	if rawSocketRequested {
 		state := runRawSocketCapabilityPreflight(ctx, target, workdir, env, envFiles)
 		fmt.Fprintf(w, "remote preflight %s=%s\n", rawSocketPreflightTool, state)
 	}
+	return nil
 }
 
 func printDelegatedPreflightUnsupported(w io.Writer, provider string) {
@@ -544,32 +563,33 @@ except BaseException:
     sys.exit(78)`
 
 var preflightToolRegistry = map[string]preflightToolSpec{
-	"apt":                  {Posix: []string{"apt-get", "--version"}, OS: map[string]bool{"linux": true}},
-	"bubblewrap":           {Posix: []string{"bwrap", "--version"}, OS: map[string]bool{"linux": true}},
-	"bun":                  {Posix: []string{"bun", "--version"}, Windows: []string{"bun", "--version"}},
-	"bwrap":                {Posix: []string{"bwrap", "--version"}, OS: map[string]bool{"linux": true}},
-	"cargo":                {Posix: []string{"cargo", "--version"}, Windows: []string{"cargo", "--version"}},
-	"cmake":                {Posix: []string{"cmake", "--version"}, Windows: []string{"cmake", "--version"}},
-	"corepack":             {Posix: []string{"corepack", "--version"}, Windows: []string{"corepack", "--version"}},
-	"docker":               {Posix: []string{"docker", "--version"}, Windows: []string{"docker", "--version"}},
-	"execution_policy":     {Windows: []string{"Get-ExecutionPolicy -Scope Process"}, OS: map[string]bool{"windows": true}},
-	"git":                  {Posix: []string{"git", "--version"}, Windows: []string{"git", "--version"}},
-	"go":                   {Posix: []string{"go", "version"}, Windows: []string{"go", "version"}},
-	"longpaths":            {Windows: []string{"git config --global --get core.longpaths"}, OS: map[string]bool{"windows": true}},
-	"make":                 {Posix: []string{"make", "--version"}},
-	"node":                 {Posix: []string{"node", "--version"}, Windows: []string{"node", "--version"}},
-	"npm":                  {Posix: []string{"npm", "--version"}, Windows: []string{"npm", "--version"}},
-	"pnpm":                 {Posix: []string{"pnpm", "--version"}, Windows: []string{"pnpm", "--version"}},
-	"powershell":           {Windows: []string{"$PSVersionTable.PSVersion.ToString()"}, OS: map[string]bool{"windows": true}},
-	"python":               {Posix: []string{"python", "--version"}, Windows: []string{"python", "--version"}},
-	"python3":              {Posix: []string{"python3", "--version"}, Windows: []string{"python3", "--version"}},
-	"pwsh":                 {Windows: []string{"pwsh", "--version"}, OS: map[string]bool{"windows": true}},
-	rawSocketPreflightTool: {OS: map[string]bool{"linux": true}},
-	"sudo":                 {OS: map[string]bool{"linux": true, "macos": true}},
-	"tar":                  {Posix: []string{"tar", "--version"}, Windows: []string{"tar", "--version"}},
-	"temp":                 {Windows: []string{"$env:TEMP"}, OS: map[string]bool{"windows": true}},
-	"uv":                   {Posix: []string{"uv", "--version"}, Windows: []string{"uv", "--version"}},
-	"yarn":                 {Posix: []string{"yarn", "--version"}, Windows: []string{"yarn", "--version"}},
+	"apt":                   {Posix: []string{"apt-get", "--version"}, OS: map[string]bool{"linux": true}},
+	"bubblewrap":            {Posix: []string{"bwrap", "--version"}, OS: map[string]bool{"linux": true}},
+	"bun":                   {Posix: []string{"bun", "--version"}, Windows: []string{"bun", "--version"}},
+	"bwrap":                 {Posix: []string{"bwrap", "--version"}, OS: map[string]bool{"linux": true}},
+	"cargo":                 {Posix: []string{"cargo", "--version"}, Windows: []string{"cargo", "--version"}},
+	"cmake":                 {Posix: []string{"cmake", "--version"}, Windows: []string{"cmake", "--version"}},
+	"corepack":              {Posix: []string{"corepack", "--version"}, Windows: []string{"corepack", "--version"}},
+	"docker":                {Posix: []string{"docker", "--version"}, Windows: []string{"docker", "--version"}},
+	"execution_policy":      {Windows: []string{"Get-ExecutionPolicy -Scope Process"}, OS: map[string]bool{"windows": true}},
+	"git":                   {Posix: []string{"git", "--version"}, Windows: []string{"git", "--version"}},
+	"go":                    {Posix: []string{"go", "version"}, Windows: []string{"go", "version"}},
+	"longpaths":             {Windows: []string{"git config --global --get core.longpaths"}, OS: map[string]bool{"windows": true}},
+	"make":                  {Posix: []string{"make", "--version"}},
+	"node":                  {Posix: []string{"node", "--version"}, Windows: []string{"node", "--version"}},
+	"npm":                   {Posix: []string{"npm", "--version"}, Windows: []string{"npm", "--version"}},
+	"pnpm":                  {Posix: []string{"pnpm", "--version"}, Windows: []string{"pnpm", "--version"}},
+	"powershell":            {Windows: []string{"$PSVersionTable.PSVersion.ToString()"}, OS: map[string]bool{"windows": true}},
+	"python":                {Posix: []string{"python", "--version"}, Windows: []string{"python", "--version"}},
+	"python3":               {Posix: []string{"python3", "--version"}, Windows: []string{"python3", "--version"}},
+	pythonVenvPreflightTool: {OS: map[string]bool{"linux": true, "macos": true}},
+	"pwsh":                  {Windows: []string{"pwsh", "--version"}, OS: map[string]bool{"windows": true}},
+	rawSocketPreflightTool:  {OS: map[string]bool{"linux": true}},
+	"sudo":                  {OS: map[string]bool{"linux": true, "macos": true}},
+	"tar":                   {Posix: []string{"tar", "--version"}, Windows: []string{"tar", "--version"}},
+	"temp":                  {Windows: []string{"$env:TEMP"}, OS: map[string]bool{"windows": true}},
+	"uv":                    {Posix: []string{"uv", "--version"}, Windows: []string{"uv", "--version"}},
+	"yarn":                  {Posix: []string{"yarn", "--version"}, Windows: []string{"yarn", "--version"}},
 }
 
 const rawSocketSudoPATH = "/usr/local/bin:/usr/bin:/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/run/current-system/profile/bin"

--- a/internal/cli/run_preflight_venv.go
+++ b/internal/cli/run_preflight_venv.go
@@ -1,0 +1,384 @@
+package cli
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+//go:embed scripts/functional-preflight-completion.sh
+var functionalPreflightCompletionScript string
+
+//go:embed scripts/functional-preflight-posix.sh
+var functionalPreflightPOSIXTemplate string
+
+var runFunctionalPreflightControl = functionalPreflightControl
+
+var runOwnedFunctionalPreflight = func(ctx context.Context, target SSHTarget, workdir string, env map[string]string, envFiles []string) (functionalPreflightCompletion, error) {
+	if isWindowsNativeTarget(target) {
+		return functionalPreflightCompletion{}, errors.New("functional preflight is unsupported on native Windows")
+	}
+	if isWindowsWSL2Target(target) {
+		return runWSLFunctionalPreflight(ctx, target, workdir, env, envFiles)
+	}
+	return runPOSIXFunctionalPreflight(ctx, target, workdir, env, envFiles)
+}
+
+func functionalPreflightDiagnostic(ctx context.Context, completion functionalPreflightCompletion, err error) string {
+	cleanup := "unconfirmed"
+	if completion.WorkerQuiesced && completion.ScratchRemoved && completion.StageRetired {
+		cleanup = "confirmed"
+	}
+	state := completion.State
+	if err != nil || cleanup != "confirmed" {
+		state = "unavailable"
+	}
+	if ctx.Err() != nil {
+		state = "canceled"
+	} else if state == "canceled" {
+		state = "unavailable"
+	}
+	switch state {
+	case "ready", "missing-python3", "venv-unavailable", "pip-unavailable", "worker-failed", "timed-out", "canceled":
+	default:
+		state = "unavailable"
+	}
+	return pythonVenvPreflightTool + "=" + state + " cleanup=" + cleanup
+}
+
+func functionalPreflightCleanupBudget(ctx context.Context) (context.Context, context.CancelFunc) {
+	// Staging has completed. The new command's transport preparation and native
+	// startup are separate from worker execution and the shared cleanup reserve.
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), functionalPreflightDispatchAllowance)
+	stop := context.AfterFunc(ctx, func() {
+		timer := time.NewTimer(pythonVenvPreflightCleanupTime)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			cancel()
+		case <-cleanupCtx.Done():
+		}
+	})
+	return cleanupCtx, func() { stop(); cancel() }
+}
+
+func functionalWSLPreflightHelper(budget time.Duration) string {
+	workload := strings.NewReplacer(
+		"@WORKLOAD_INIT@", fmt.Sprintf("deadline=$((SECONDS + %d))\n", max(1, int64((budget+time.Second-1)/time.Second))),
+		"@WORKLOAD_TICK@", "    if [ \"$SECONDS\" -ge \"$deadline\" ]; then : >\"$directory/.timed-out\"; break; fi\n",
+	).Replace(strings.TrimSuffix(guardedWorkload, "\n"))
+	completed := "    [ -f \"$directory/.completion\" ] && [ ! -e \"$directory/scratch\" ] && [ ! -L \"$directory/scratch\" ] && exit 0\n"
+	return strings.NewReplacer(
+		"@GUARDED_GROUP_FUNCTIONS@", strings.TrimSuffix(guardedGroupFunctions, "\n"),
+		"@GUARDED_MEMBERS@", strings.TrimSuffix(guardedMembers, "\n"),
+		"@GUARDED_WORKLOAD@", workload,
+		"@FUNCTIONAL_PRELUDE@", functionalPreflightCompletionScript+"\n",
+		"@FUNCTIONAL_CLEANUP@", completed,
+		"@FUNCTIONAL_CLEANUP_POLL@", completed,
+		"@FUNCTIONAL_SCRATCH@", "mkdir -m 700 -- \"$directory/scratch\" || exit 74\n",
+	).Replace(wslLinuxTemplate)
+}
+
+func functionalPOSIXPreflightHelper(budget time.Duration) string {
+	workload := strings.NewReplacer(
+		"@WORKLOAD_INIT@", fmt.Sprintf("deadline=$((SECONDS + %d))\n", max(1, int64((budget+time.Second-1)/time.Second))),
+		"@WORKLOAD_TICK@", "    if [ \"$interrupted\" = 1 ]; then : >\"$directory/.cancel\"; break; fi\n"+
+			"    if [ \"$SECONDS\" -ge \"$deadline\" ]; then : >\"$directory/.timed-out\"; break; fi\n",
+	).Replace(strings.TrimSuffix(guardedWorkload, "\n"))
+	return strings.NewReplacer(
+		"@GUARDED_GROUP_FUNCTIONS@", strings.TrimSuffix(guardedGroupFunctions, "\n"),
+		"@GUARDED_MEMBERS@", strings.TrimSuffix(guardedMembers, "\n"),
+		"@GUARDED_WORKLOAD@", workload,
+		"@FUNCTIONAL_PRELUDE@", strings.TrimSuffix(functionalPreflightCompletionScript, "\n"),
+	).Replace(functionalPreflightPOSIXTemplate)
+}
+
+func runPOSIXFunctionalPreflight(ctx context.Context, target SSHTarget, workdir string, env map[string]string, envFiles []string) (completion functionalPreflightCompletion, err error) {
+	nonce, err := randomHex(16)
+	if err != nil {
+		return completion, err
+	}
+	command := remoteShellCommandWithEnvFiles(workdir, env, envFiles,
+		pythonVenvPreflightWorker("/tmp/crabbox-command-"+nonce+"/scratch"))
+	if len(command) > wslStageMaxCommand {
+		return completion, errors.New("functional preflight command exceeds stage limit")
+	}
+	helper := functionalPOSIXPreflightHelper(pythonVenvPreflightExecutionTime)
+	remote := "export CBX_HELPER=" + shellQuote(helper) + "; exec bash -c \"$CBX_HELPER\" sh run " +
+		shellQuote("/tmp/crabbox-command-"+nonce) + " " + shellQuote(nonce) +
+		fmt.Sprintf(" %d 0 %d %d", len(command), wslStageIdleTimeout.Milliseconds(), wsl2SignalGrace.Milliseconds())
+	// Resolve a usable endpoint before starting the native operation's clock.
+	// The nonce-bound operation itself is dispatched only once on that route.
+	target.NoControlMaster = true
+	prepareCtx, cancelPrepare := context.WithTimeout(ctx, sshTransportPreparationTimeout)
+	defer cancelPrepare()
+	if err := resolveSSHPortNoInput(prepareCtx, &target, "2", "1", io.Discard); err != nil {
+		return completion, err
+	}
+	size := int64(len(command))
+	prepared, err := prepareWorkspaceOwnerRemote(prepareCtx, target, remote, &size)
+	if err != nil {
+		return completion, err
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, prepared.close(ctx, target))
+		}
+	}()
+	cleanupCtx, cancelCleanup := functionalPreflightCleanupBudget(ctx)
+	defer cancelCleanup()
+	// The helper owns the 90s worker deadline. Its transport wrapper must remain
+	// available for supervised cleanup; collection uses this same remaining clock.
+	deadline, _ := cleanupCtx.Deadline()
+	execCtx, cancelExec := context.WithDeadline(ctx, deadline)
+	defer cancelExec()
+	transport := sshTransportPreparation{command: prepared.command, direct: strings.NewReader(command), setupMarker: prepared.setupMarker}
+	_, runErr := transport.runOnce(execCtx, target, "2", "1", io.Discard, io.Discard, false)
+	if runErr == nil {
+		runErr = context.Cause(execCtx)
+	}
+	return finishFunctionalPreflight(ctx, cleanupCtx, target, nonce, runErr)
+}
+
+func runWSLFunctionalPreflight(ctx context.Context, target SSHTarget, workdir string, env map[string]string, envFiles []string) (completion functionalPreflightCompletion, err error) {
+	nonce, err := randomHex(16)
+	if err != nil {
+		return completion, err
+	}
+	command := remoteShellCommandWithEnvFiles(workdir, env, envFiles,
+		pythonVenvPreflightWorker("/tmp/crabbox-command-"+nonce+"/scratch"))
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, command, nil)
+	if err != nil {
+		return completion, err
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, prepared.close(ctx, target))
+		}
+	}()
+	limit := sshCommandLimit{execution: functionalPreflightSupervisorAllowance}
+	spool, err := newWSLStageSpoolWithHelper(prepared.command, nil, nil, 0, limit,
+		functionalWSLPreflightHelper(pythonVenvPreflightExecutionTime))
+	if err != nil {
+		return completion, err
+	}
+	defer func() {
+		if closeErr := spool.close(); closeErr != nil {
+			completion.State = ""
+			err = errors.Join(err, closeErr)
+		}
+	}()
+	spool.functionalNonce, spool.setupMarker = nonce, prepared.setupMarker
+	runErr := spool.run(ctx, &target, "2", "1", io.Discard, io.Discard)
+	if spool.functionalCleanup == nil {
+		// No native dispatch occurred; do not infer a worker completion or
+		// acquire Linux stage cleanup authority from a staging failure.
+		return completion, runErr
+	}
+	return finishFunctionalPreflight(ctx, spool.functionalCleanup, target, nonce, runErr)
+}
+
+func finishFunctionalPreflight(ctx, cleanupCtx context.Context, target SSHTarget, nonce string, runErr error) (functionalPreflightCompletion, error) {
+	action := "observe"
+	if runErr != nil || ctx.Err() != nil {
+		action = "cancel"
+	}
+	record, controlErr := runFunctionalPreflightControl(cleanupCtx, target, nonce, action)
+	completion, parseErr := parseFunctionalPreflightCompletion(record, nonce)
+	if controlErr != nil || parseErr != nil {
+		return functionalPreflightCompletion{}, errors.Join(runErr, context.Cause(ctx), controlErr, parseErr)
+	}
+	if _, err := runFunctionalPreflightControl(cleanupCtx, target, nonce, "retire"); err != nil {
+		completion.State = ""
+		return completion, errors.Join(runErr, context.Cause(ctx), err)
+	}
+	completion.StageRetired = true
+	if ctx.Err() != nil {
+		completion.State = ""
+		return completion, errors.Join(runErr, context.Cause(ctx))
+	}
+	if completion.State == "canceled" {
+		completion.State = ""
+		if runErr != nil {
+			return completion, runErr
+		}
+		return completion, errors.New("functional preflight owner canceled before completion")
+	}
+	if runErr != nil {
+		// An expected remote process exit may be diagnostic-only. A joined
+		// transport or envelope-cleanup failure must retain its own outcome.
+		processOutcome := runErr
+		for {
+			joined, ok := processOutcome.(interface{ Unwrap() []error })
+			if !ok || len(joined.Unwrap()) != 1 {
+				break
+			}
+			processOutcome = joined.Unwrap()[0]
+		}
+		if _, ok := processOutcome.(*exec.ExitError); !ok {
+			completion.State = ""
+			return completion, runErr
+		}
+		code := exitCode(processOutcome)
+		expected := completion.State == "missing-python3" && code == pythonVenvMissingInterpreter ||
+			completion.State == "venv-unavailable" && code == pythonVenvUnavailable ||
+			completion.State == "pip-unavailable" && code == pythonVenvPipUnavailable ||
+			completion.State == "timed-out" && code == 74 ||
+			completion.State == "worker-failed" && code > 0 && code != 255
+		if !expected {
+			completion.State = ""
+			return completion, runErr
+		}
+	}
+	return completion, nil
+}
+
+// These controls only address the caller's nonce-bound stage. They deliberately
+// use the transport's control boundary rather than register a second workload
+// with the workspace owner while the original supervisor is still cleaning up.
+func functionalPreflightControl(ctx context.Context, target SSHTarget, nonce, action string) ([]byte, error) {
+	command, err := functionalPreflightControlCommand(nonce, action)
+	if err != nil {
+		return nil, err
+	}
+	out := newSynchronizedBuffer(functionalPreflightCompletionLimit + 1)
+	err = executePreparedSSH(ctx, &target, "bash -c "+shellQuote(command), nil, 0,
+		sshCommandLimit{execution: 20 * time.Second}, "2", "1", &out, io.Discard)
+	if err != nil {
+		return nil, errors.Join(errors.New("functional preflight cleanup unconfirmed"), err)
+	}
+	return []byte(out.String()), nil
+}
+
+func functionalPreflightControlCommand(nonce, action string) (string, error) {
+	if len(nonce) != 32 || strings.Trim(nonce, "0123456789abcdef") != "" {
+		return "", errors.New("invalid functional preflight stage identity")
+	}
+	if action != "observe" && action != "cancel" && action != "retire" {
+		return "", errors.New("invalid functional preflight stage control")
+	}
+	return "nonce=" + shellQuote(nonce) + "\naction=" + shellQuote(action) + "\n" + `set -u
+umask 077
+directory=/tmp/crabbox-command-$nonce
+[ -d "$directory" ] && [ ! -L "$directory" ] && [ -O "$directory" ] || exit 74
+[ "$(cat "$directory/.nonce" 2>/dev/null)" = "$nonce" ] || exit 74
+if [ "$action" = cancel ] && [ ! -e "$directory/.completion" ]; then
+    : >"$directory/.cancel" || exit 74
+fi
+for ((i=0; i<150; i++)); do
+    [ -e "$directory/.completion" ] && break
+    sleep .1
+done
+[ -f "$directory/.completion" ] && [ ! -L "$directory/.completion" ] || exit 74
+[ "$(wc -c <"$directory/.completion")" -le 256 ] || exit 74
+if ! {
+    IFS= read -r protocol && IFS= read -r recorded_nonce && IFS= read -r state &&
+    IFS= read -r quiesced && IFS= read -r removed && IFS= read -r complete &&
+    ! IFS= read -r extra && [ -z "$extra" ]
+} <"$directory/.completion"; then exit 74; fi
+[ "$protocol" = CBX-PREFLIGHT-1 ] && [ "$recorded_nonce" = "$nonce" ] &&
+    [ "$quiesced" = worker-quiesced ] && [ "$removed" = scratch-removed ] &&
+    [ "$complete" = complete ] || exit 74
+case $state in
+    ready|missing-python3|venv-unavailable|pip-unavailable|worker-failed|timed-out|canceled) ;;
+    *) exit 74;;
+esac
+if [ "$action" = retire ]; then
+    [ ! -e "$directory/scratch" ] && [ ! -L "$directory/scratch" ] || exit 74
+    # Retirement follows the caller's successful completion validation. The
+    # owner has published atomically and performs no subsequent stage writes.
+    rm -rf -- "$directory" || exit 74
+    [ ! -e "$directory" ] && [ ! -L "$directory" ] || exit 74
+else
+    cat "$directory/.completion"
+fi
+`, nil
+}
+
+const (
+	pythonVenvPreflightTool                = "python3-venv"
+	pythonVenvPreflightExecutionTime       = 90 * time.Second
+	pythonVenvPreflightCleanupTime         = 30 * time.Second
+	functionalPreflightSupervisorAllowance = wslStageIdleTimeout + pythonVenvPreflightExecutionTime + 2*wsl2SignalGrace + wslStageCompletionMargin
+	functionalPreflightDispatchAllowance   = sshTransportPreparationTimeout + wslStageIdleTimeout + pythonVenvPreflightExecutionTime + pythonVenvPreflightCleanupTime
+	pythonVenvMissingInterpreter           = 20
+	pythonVenvUnavailable                  = 21
+	pythonVenvPipUnavailable               = 22
+	functionalPreflightCompletionLimit     = 256
+)
+
+type functionalPreflightCompletion struct {
+	State          string
+	WorkerQuiesced bool
+	ScratchRemoved bool
+	StageRetired   bool
+}
+
+// Only the stage owner may publish this record, after its children are reaped
+// and scratch is removed. Worker output is never accepted as an acknowledgement.
+func parseFunctionalPreflightCompletion(record []byte, nonce string) (functionalPreflightCompletion, error) {
+	var empty functionalPreflightCompletion
+	unconfirmed := errors.New("functional preflight cleanup unconfirmed")
+	if len(nonce) != 32 || strings.Trim(nonce, "0123456789abcdef") != "" || len(record) > functionalPreflightCompletionLimit {
+		return empty, unconfirmed
+	}
+	fields := strings.Split(string(record), "\n")
+	if len(fields) != 7 || fields[0] != "CBX-PREFLIGHT-1" || fields[1] != nonce ||
+		fields[3] != "worker-quiesced" || fields[4] != "scratch-removed" || fields[5] != "complete" || fields[6] != "" {
+		return empty, unconfirmed
+	}
+	switch fields[2] {
+	case "ready", "missing-python3", "venv-unavailable", "pip-unavailable", "worker-failed", "timed-out", "canceled":
+		return functionalPreflightCompletion{State: fields[2], WorkerQuiesced: true, ScratchRemoved: true}, nil
+	default:
+		return empty, unconfirmed
+	}
+}
+
+// The stage owns scratch and cleanup. The worker reports capability only;
+// its exit status never establishes quiescence or successful removal.
+func pythonVenvPreflightWorker(scratch string) string {
+	return "if ! command -v python3 >/dev/null 2>&1; then exit 20; fi\n" +
+		"TMPDIR=" + shellQuote(scratch) + " TMP=" + shellQuote(scratch) + " TEMP=" + shellQuote(scratch) +
+		" python3 -I -B -c " + shellQuote(pythonVenvPreflightScript) + " " + shellQuote(scratch) + " >/dev/null 2>&1"
+}
+
+const pythonVenvPreflightScript = `import os
+import subprocess
+import sys
+
+try:
+    import venv
+except ImportError:
+    sys.exit(21)
+
+environment = os.path.join(sys.argv[1], "venv")
+try:
+    venv.EnvBuilder(with_pip=False).create(environment)
+except Exception:
+    sys.exit(21)
+
+python = os.path.join(environment, "bin", "python")
+def invoke(arguments):
+    try:
+        return subprocess.run(
+            [python, "-I", "-B"] + arguments,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ).returncode == 0
+    except OSError:
+        return False
+
+if not invoke(["-c", "import sys; sys.exit(sys.prefix == sys.base_prefix)"]):
+    sys.exit(21)
+if not invoke(["-m", "ensurepip", "--default-pip"]):
+    sys.exit(22)
+if not invoke(["-m", "pip", "--version"]):
+    sys.exit(22)
+`

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -6667,6 +6667,246 @@ func TestCMakePreflightLiteralCommandGeneration(t *testing.T) {
 	}
 }
 
+func TestFunctionalPreflightProcessExit(t *testing.T) {
+	value := os.Getenv("CRABBOX_TEST_PREFLIGHT_EXIT")
+	if value == "" {
+		return
+	}
+	code, err := strconv.Atoi(value)
+	if err != nil || code < 1 || code > 255 {
+		t.Fatal("invalid synthetic exit")
+	}
+	os.Exit(code)
+}
+
+func TestFunctionalPreflightCompletionLifecycle(t *testing.T) {
+	const nonce = "0123456789abcdef0123456789abcdef"
+	for _, tc := range []struct {
+		name, state                                                                 string
+		code                                                                        int
+		canceled, partial, retireFailure, joinedFailure, ownerWrapped, ownerFailure bool
+	}{
+		{name: "ready", state: "ready"},
+		{name: "missing", state: "missing-python3", code: 20},
+		{name: "venv", state: "venv-unavailable", code: 21},
+		{name: "pip", state: "pip-unavailable", code: 22},
+		{name: "timeout", state: "timed-out", code: 74},
+		{name: "cleaned worker failure", state: "worker-failed", code: 23},
+		{name: "caller cancellation", state: "canceled", code: 74, canceled: true},
+		{name: "owner canceled with successful transport", state: "canceled"},
+		{name: "missing completion", code: 255, partial: true},
+		{name: "retirement failed", state: "ready", retireFailure: true},
+		{name: "transport failure is not readiness", state: "ready", code: 255},
+		{name: "capability exit with envelope cleanup failure", state: "missing-python3", code: 20, joinedFailure: true},
+		{name: "ordinary workspace owner wrapper", state: "venv-unavailable", code: 21, ownerWrapped: true},
+		{name: "workspace setup error is retained", state: "venv-unavailable", code: 21, ownerFailure: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			old := runFunctionalPreflightControl
+			t.Cleanup(func() { runFunctionalPreflightControl = old })
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			if tc.canceled {
+				cancel()
+			}
+			var runErr error
+			if tc.code != 0 {
+				childCtx, childCancel := context.WithTimeout(t.Context(), 10*time.Second)
+				defer childCancel()
+				child := exec.CommandContext(childCtx, os.Args[0], "-test.run=^TestFunctionalPreflightProcessExit$")
+				child.Env = append(os.Environ(), "CRABBOX_TEST_PREFLIGHT_EXIT="+strconv.Itoa(tc.code))
+				runErr = child.Run()
+				if exitCode(runErr) != tc.code {
+					t.Fatalf("synthetic process exit=%v", runErr)
+				}
+				if tc.joinedFailure {
+					runErr = errors.Join(runErr, errors.New("synthetic envelope cleanup failure"))
+				}
+				if tc.ownerWrapped {
+					_, _, finish := workspaceOwnerSetupStreams("synthetic-marker", io.Discard, io.Discard)
+					runErr = finish(runErr)
+				}
+				if tc.ownerFailure {
+					runErr = &workspaceOwnerSetupError{phase: "synthetic", cause: runErr}
+				}
+			}
+			calls := []string{}
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), pythonVenvPreflightCleanupTime)
+			defer cleanupCancel()
+			sharedCleanup := cleanupCtx
+			runFunctionalPreflightControl = func(cleanupCtx context.Context, _ SSHTarget, gotNonce, action string) ([]byte, error) {
+				deadline, ok := cleanupCtx.Deadline()
+				if cleanupCtx != sharedCleanup || gotNonce != nonce || cleanupCtx.Err() != nil || !ok || time.Until(deadline) > pythonVenvPreflightCleanupTime {
+					t.Fatal("cleanup lost its independent bounded operation identity")
+				}
+				calls = append(calls, action)
+				if action == "retire" {
+					if tc.retireFailure {
+						return nil, errors.New("synthetic retirement failure")
+					}
+					return nil, nil
+				}
+				if tc.partial {
+					return []byte("CBX-PREFLIGHT-1\n"), nil
+				}
+				return []byte("CBX-PREFLIGHT-1\n" + nonce + "\n" + tc.state + "\nworker-quiesced\nscratch-removed\ncomplete\n"), nil
+			}
+			got, err := finishFunctionalPreflight(ctx, cleanupCtx, SSHTarget{}, nonce, runErr)
+			wantAction := "observe"
+			if tc.code != 0 || tc.canceled {
+				wantAction = "cancel"
+			}
+			wantCalls := []string{wantAction, "retire"}
+			if tc.partial {
+				wantCalls = wantCalls[:1]
+			}
+			if !reflect.DeepEqual(calls, wantCalls) {
+				t.Fatalf("calls=%v want=%v", calls, wantCalls)
+			}
+			failure := tc.canceled || tc.state == "canceled" || tc.partial || tc.retireFailure || tc.code == 255 || tc.joinedFailure || tc.ownerFailure
+			if (err != nil) != failure {
+				t.Fatalf("completion=%+v error=%v", got, err)
+			}
+			if failure {
+				if got.State != "" {
+					t.Fatalf("failed completion claimed capability: %+v", got)
+				}
+			} else if got.State != tc.state || !got.WorkerQuiesced || !got.ScratchRemoved || !got.StageRetired {
+				t.Fatalf("completion=%+v", got)
+			}
+			if tc.canceled && !errors.Is(err, context.Canceled) {
+				t.Fatal("caller cancellation lost")
+			}
+			if tc.state == "canceled" && !tc.canceled && errors.Is(err, context.Canceled) {
+				t.Fatal("invented caller cancellation")
+			}
+			if (tc.code == 255 || tc.joinedFailure || tc.ownerFailure) && !errors.Is(err, runErr) {
+				t.Fatal("original transport outcome lost")
+			}
+			wantState, wantCleanup := tc.state, "confirmed"
+			if failure {
+				wantState = "unavailable"
+			}
+			if tc.canceled {
+				wantState = "canceled"
+			}
+			if tc.partial || tc.retireFailure {
+				wantCleanup = "unconfirmed"
+			}
+			wantDiagnostic := "python3-venv=" + wantState + " cleanup=" + wantCleanup
+			if got := functionalPreflightDiagnostic(ctx, got, err); got != wantDiagnostic {
+				t.Fatalf("diagnostic=%q want=%q", got, wantDiagnostic)
+			}
+		})
+	}
+}
+
+func TestFunctionalPreflightCompletion(t *testing.T) {
+	const nonce = "0123456789abcdef0123456789abcdef"
+	record := func(state string) string {
+		return "CBX-PREFLIGHT-1\n" + nonce + "\n" + state + "\nworker-quiesced\nscratch-removed\ncomplete\n"
+	}
+	for _, state := range []string{"ready", "missing-python3", "venv-unavailable", "pip-unavailable", "worker-failed", "timed-out", "canceled"} {
+		t.Run(state, func(t *testing.T) {
+			got, err := parseFunctionalPreflightCompletion([]byte(record(state)), nonce)
+			if err != nil || got.State != state || !got.WorkerQuiesced || !got.ScratchRemoved {
+				t.Fatalf("completion=%+v error=%v", got, err)
+			}
+		})
+	}
+	for _, tc := range []struct{ name, value, nonce string }{
+		{"missing", "", nonce},
+		{"partial", strings.TrimSuffix(record("ready"), "complete\n"), nonce},
+		{"other-operation", record("ready"), "abcdef0123456789abcdef0123456789"},
+		{"unknown-protocol", strings.Replace(record("ready"), "CBX-PREFLIGHT-1", "CBX-PREFLIGHT-2", 1), nonce},
+		{"unknown-state", record("finished"), nonce},
+		{"scratch-retained", strings.Replace(record("ready"), "scratch-removed", "scratch-retained", 1), nonce},
+		{"worker-only", "ready\n", nonce},
+		{"trailing-output", record("ready") + "extra\n", nonce},
+		{"oversized", strings.Repeat("x", functionalPreflightCompletionLimit+1), nonce},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseFunctionalPreflightCompletion([]byte(tc.value), tc.nonce)
+			if err == nil || err.Error() != "functional preflight cleanup unconfirmed" || got != (functionalPreflightCompletion{}) {
+				t.Fatalf("completion=%+v error=%v", got, err)
+			}
+		})
+	}
+}
+
+func TestPythonVenvWorkerTemporaryEnvironment(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX interpreter environment fixture")
+	}
+	root := t.TempDir()
+	tools := filepath.Join(root, "tools")
+	scratch := filepath.Join(root, "scratch")
+	ambient := filepath.Join(root, "ambient")
+	for _, dir := range []string{tools, scratch, ambient} {
+		if err := os.Mkdir(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	record, parent := filepath.Join(root, "child"), filepath.Join(root, "parent")
+	// Capture only the literal interpreter's environment/flags; real ensurepip
+	// containment is a separate runtime qualification, not simulated here.
+	writeExecutable(t, filepath.Join(tools, "python3"), "#!/bin/sh\nprintf '%s\\n' \"$TMPDIR\" \"$TMP\" \"$TEMP\" \"$1\" \"$2\" >"+shellQuote(record)+"\n")
+	script := pythonVenvPreflightWorker(scratch) + "\ncode=$?\nprintf '%s\\n' \"$TMPDIR\" \"$TMP\" \"$TEMP\" >" + shellQuote(parent) + "\nexit \"$code\"\n"
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "/bin/bash", "-c", script)
+	cmd.Env = []string{"PATH=" + tools, "HOME=" + root, "TMPDIR=" + ambient, "TMP=" + ambient, "TEMP=" + ambient}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("worker environment: %v %s", err, out)
+	}
+	child, err := os.ReadFile(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(child) != strings.Repeat(scratch+"\n", 3)+"-I\n-B\n" {
+		t.Fatalf("child environment/flags=%q", child)
+	}
+	after, err := os.ReadFile(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != strings.Repeat(ambient+"\n", 3) {
+		t.Fatalf("caller temporary environment changed: %q", after)
+	}
+}
+
+func TestPythonVenvPreflightSelection(t *testing.T) {
+	if err := validatePreflightTools([]string{"python3-venv"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name   string
+		target SSHTarget
+		want   string
+	}{
+		{"linux", SSHTarget{TargetOS: targetLinux}, "python3-venv"},
+		{"macos", SSHTarget{TargetOS: targetMacOS}, "python3-venv"},
+		{"wsl2", SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, "python3-venv"},
+		{"native windows", SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := strings.Join(preflightToolsForTarget(tc.target, []string{"python3-venv"}), ","); got != tc.want {
+				t.Fatalf("tools=%q want %q", got, tc.want)
+			}
+		})
+	}
+	for _, tool := range defaultPreflightToolNames {
+		if tool == "python3-venv" {
+			t.Fatal("functional probe became a default")
+		}
+	}
+	got := normalizePreflightToolNames([]string{"default,python3-venv,python3-venv"})
+	want := append(append([]string(nil), defaultPreflightToolNames...), "python3-venv")
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("deduplicated tools=%v want %v", got, want)
+	}
+}
+
 func TestCMakePreflightPOSIXPresentFirstLineAndMissing(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX shell behavior is covered on non-Windows CI")
@@ -6742,6 +6982,15 @@ func TestCMakePreflightNativeWindowsPresentAndMissing(t *testing.T) {
 }
 
 func TestCMakePreflightUserAndRepositoryConfig(t *testing.T) {
+	testPreflightToolUserAndRepositoryConfig(t, "cmake")
+}
+
+func TestPythonVenvPreflightUserAndRepositoryConfig(t *testing.T) {
+	testPreflightToolUserAndRepositoryConfig(t, "python3-venv")
+}
+
+func testPreflightToolUserAndRepositoryConfig(t *testing.T, tool string) {
+	t.Helper()
 	for _, source := range []string{"user", "repository"} {
 		t.Run(source, func(t *testing.T) {
 			clearConfigEnv(t)
@@ -6763,18 +7012,18 @@ func TestCMakePreflightUserAndRepositoryConfig(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			if err := os.WriteFile(path, []byte("run:\n  preflightTools: [cmake]\n"), 0o600); err != nil {
+			if err := os.WriteFile(path, []byte("run:\n  preflightTools: ["+tool+"]\n"), 0o600); err != nil {
 				t.Fatal(err)
 			}
 			cfg, err := loadConfig()
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got := strings.Join(cfg.Run.PreflightTools, ","); got != "cmake" {
+			if got := strings.Join(cfg.Run.PreflightTools, ","); got != tool {
 				t.Fatalf("%s run.preflightTools=%q", source, got)
 			}
 			if err := validatePreflightTools(cfg.Run.PreflightTools); err != nil {
-				t.Fatalf("%s cmake config should validate: %v", source, err)
+				t.Fatalf("%s %s config should validate: %v", source, tool, err)
 			}
 		})
 	}

--- a/internal/cli/scripts/functional-preflight-completion.sh
+++ b/internal/cli/scripts/functional-preflight-completion.sh
@@ -1,0 +1,22 @@
+remove_evidence() {
+    [ "$(cat "$directory/.nonce" 2>/dev/null)" = "$nonce" ] || return 1
+    # The supervisor calls this only after reaping its worker group, or before
+    # that group was started. Retire the private control stage after collection.
+    rm -rf -- "$directory/scratch" || return 1
+    [ ! -e "$directory/scratch" ] && [ ! -L "$directory/scratch" ] || return 1
+    local state=worker-failed
+    if [ -e "$directory/.timed-out" ]; then
+        state=timed-out
+    elif [ -e "$directory/.cancel" ] || [ -e "$directory/.lost" ]; then
+        state=canceled
+    else
+        case ${code:-74} in
+            0) state=ready;;
+            20) state=missing-python3;;
+            21) state=venv-unavailable;;
+            22) state=pip-unavailable;;
+        esac
+    fi
+    printf 'CBX-PREFLIGHT-1\n%s\n%s\nworker-quiesced\nscratch-removed\ncomplete\n' "$nonce" "$state" >"$directory/.completion.tmp" &&
+        mv -- "$directory/.completion.tmp" "$directory/.completion"
+}

--- a/internal/cli/scripts/functional-preflight-posix.sh
+++ b/internal/cli/scripts/functional-preflight-posix.sh
@@ -1,0 +1,114 @@
+set -u
+mode=$1 directory=$2 nonce=$3 command_size=$4 payload_size=$5 idle_ms=$6 grace_ms=$7
+caller_mask=${8:-$(umask)}
+umask "$caller_mask" 2>/dev/null || exit 74
+umask 077
+trap '' HUP
+
+identity() {
+    local raw pgid state weekday month day clock year extra
+    if [ -r "/proc/$1/stat" ]; then
+        IFS= read -r raw <"/proc/$1/stat" 2>/dev/null || return 1
+        raw=${raw##*) }
+        set -- $raw
+        [ "$1" != Z ] && [ "$1" != X ] || return 1
+        printf '%s %s\n' "$3" "${20}"
+        return
+    fi
+    read -r pgid state weekday month day clock year extra < <(LC_ALL=C ps -o pgid= -o state= -o lstart= -p "$1" 2>/dev/null) || return 1
+    case $state in Z*|X*) return 1;; esac
+    [ -z "${extra:-}" ] || return 1
+    case $month in
+        Jan) month=01;; Feb) month=02;; Mar) month=03;; Apr) month=04;;
+        May) month=05;; Jun) month=06;; Jul) month=07;; Aug) month=08;;
+        Sep) month=09;; Oct) month=10;; Nov) month=11;; Dec) month=12;;
+        *) return 1;;
+    esac
+    clock=${clock//:/}
+    case $pgid:$day:$clock:$year in *[!0-9:]*|:*|*::*|*:) return 1;; esac
+    # The living direct-child witness remains reserved through group cleanup.
+    # Preserve ps's full start-time representation, not a PID-only observation.
+    printf '%s %s%s%02d%s\n' "$pgid" "$year" "$month" "$((10#$day))" "$clock"
+}
+@GUARDED_GROUP_FUNCTIONS@
+@FUNCTIONAL_PRELUDE@
+case $mode in
+run)
+    # Bash monitor mode supplies the portable group boundary. The supervisor
+    # remains the direct parent/reaper of the separately guarded worker group.
+    set -m
+    bash -c "$CBX_HELPER" sh supervise "$directory" "$nonce" "$command_size" 0 "$idle_ms" "$grace_ms" "$caller_mask" <&0 &
+    supervisor=$!
+    supervisor_group=$(jobs -p %%)
+    set +m
+    armed=0
+    if [ "$supervisor" = "$supervisor_group" ]; then
+        for ((i=0; i<(idle_ms+99)/100; i++)); do
+            if [ -f "$directory/.supervisor" ]; then
+                observed=$(identity "$supervisor") || break
+                if [ "${observed%% *}" = "$supervisor" ] &&
+                    [ "$(cat "$directory/.nonce" 2>/dev/null)" = "$nonce" ] &&
+                    [ "$(cat "$directory/.supervisor" 2>/dev/null)" = "$supervisor $observed" ]; then
+                    : >"$directory/.native-armed" || break
+                    armed=1
+                    break
+                fi
+            fi
+            kill -0 "$supervisor" 2>/dev/null || break
+            sleep .1
+        done
+    fi
+    # An unarmed supervisor has its own bounded startup clock. Never acquire
+    # new signal authority from a stale pathname or a PID-only lookup.
+    code=0
+    wait "$supervisor" || code=$?
+    [ "$armed" = 1 ] || exit 74
+    exit "$code"
+    ;;
+@GUARDED_MEMBERS@
+watch)
+    while :; do IFS= read -r -t 1 -u 8 ignored || :; done
+    ;;
+supervise) ;;
+*) exit 74;;
+esac
+
+interrupted=0
+trap 'interrupted=1' TERM INT
+handoff_deadline=$((SECONDS + (idle_ms+999)/1000))
+mkdir -m 700 -- "$directory" || exit 74
+printf '%s' "$nonce" >"$directory/.nonce" || exit 74
+mkdir -m 700 -- "$directory/scratch" || exit 74
+printf '%s %s\n' "$$" "$(identity "$$")" >"$directory/.supervisor" || exit 74
+while [ ! -e "$directory/.native-armed" ]; do
+    if [ "$interrupted" = 1 ] || [ "$SECONDS" -ge "$handoff_deadline" ]; then
+        : >"$directory/.cancel"
+        remove_evidence || :
+        exit 74
+    fi
+    sleep .1
+done
+exec 3<&0
+exec 0</dev/null
+head -c "$command_size" <&3 >"$directory/command" 3<&- &
+receiver=$!
+failed=0
+while kill -0 "$receiver" 2>/dev/null; do
+    if [ "$interrupted" = 1 ] || [ -e "$directory/.cancel" ] || [ "$SECONDS" -ge "$handoff_deadline" ]; then
+        failed=1
+        kill "$receiver" 2>/dev/null || :
+        break
+    fi
+    sleep .1
+done
+wait "$receiver" || failed=1
+exec 3<&-
+[ "$(wc -c <"$directory/command")" -eq "$command_size" ] || failed=1
+if [ "$failed" = 1 ]; then remove_evidence || :; exit 74; fi
+: >"$directory/input"
+mkfifo -m 600 "$directory/scratch/control" || exit 74
+exec 8<>"$directory/scratch/control"
+bash -c "$CBX_HELPER" sh watch "$directory" "$nonce" 0 0 0 0 "$caller_mask" </dev/null &
+watcher=$!
+exec 8>&-
+@GUARDED_WORKLOAD@

--- a/internal/cli/scripts/guarded-group.sh
+++ b/internal/cli/scripts/guarded-group.sh
@@ -1,0 +1,33 @@
+read_guard() {
+    read -r guard started group extra 2>/dev/null <"$directory/.crabbox-owned" || return 1
+    case $guard:$started:$group in *[!0-9:]*|:*|*::*|*:) return 1;; esac
+    [ -z "${extra:-}" ]
+}
+valid_guard() {
+    local current
+    current=$(cat "$directory/.crabbox-owned" 2>/dev/null) || return 1
+    [ "$current" = "$guard $started $group" ] &&
+        [ "$(identity "$guard")" = "$group $started" ]
+}
+group_exists() {
+    local diagnostic
+    diagnostic=$(LC_ALL=C kill -0 -- "-$group" 2>&1) && return 0
+    # Only ESRCH proves absence. Permission failure must retain evidence too.
+    [[ "$diagnostic" != *": (-$group) - No such process" ]]
+}
+cleanup_group() {
+    # Keep the witness alive through TERM. Revalidate both its immutable
+    # process identity and the published record before the final KILL.
+    valid_guard || return 1
+    kill -TERM -- "-$group" 2>/dev/null || return 1
+    local ticks=$(((grace_ms + 99) / 100))
+    while [ "$ticks" -gt 0 ]; do sleep .1; ticks=$((ticks - 1)); done
+    valid_guard || return 1
+    kill -KILL -- "-$group" 2>/dev/null || return 1
+    wait "$leader" 2>/dev/null || :
+    wait "$guard" 2>/dev/null || :
+    ticks=$(((grace_ms + 99) / 100))
+    while group_exists && [ "$ticks" -gt 0 ]; do sleep .1; ticks=$((ticks - 1)); done
+    ! group_exists || return 1
+    [ "$(cat "$directory/.crabbox-owned" 2>/dev/null)" = "$guard $started $group" ]
+}

--- a/internal/cli/scripts/guarded-members.sh
+++ b/internal/cli/scripts/guarded-members.sh
@@ -1,0 +1,24 @@
+guard)
+    trap '' TERM
+    read -r group started < <(identity "$$") || exit 74
+    printf '%s %s %s\n' "$$" "$started" "$group" >"$directory/.crabbox-owned.tmp"
+    mv "$directory/.crabbox-owned.tmp" "$directory/.crabbox-owned" || exit 74
+    # A private FIFO supplies a blocking builtin, without a sleep child that
+    # could become an unreapable in-group zombie when the guard is killed.
+    while :; do IFS= read -r -t 1 -u 6 ignored || :; done
+    ;;
+workload)
+    trap ':' TERM
+    while [ ! -e "$directory/.armed" ]; do sleep .1; done
+    (umask "$caller_mask"; exec bash "$directory/command" <"$directory/input") &
+    child=$!
+    while :; do
+        code=0
+        wait "$child" || code=$?
+        kill -0 "$child" 2>/dev/null || break
+    done
+    # The supervisor must never observe a result before its status is complete.
+    printf '%s\n' "$code" >"$directory/.result.tmp" &&
+        mv -- "$directory/.result.tmp" "$directory/.result" || exit 74
+    exit "$code"
+    ;;

--- a/internal/cli/scripts/guarded-workload.sh
+++ b/internal/cli/scripts/guarded-workload.sh
@@ -1,0 +1,43 @@
+mkfifo -m 600 "$directory/guard-wait" || exit 74
+exec 6<>"$directory/guard-wait"
+set -m
+bash -c "$CBX_HELPER" sh guard "$directory" "$nonce" 0 0 0 0 "$caller_mask" </dev/null |
+    bash -c "$CBX_HELPER" sh workload "$directory" "$nonce" 0 0 0 0 "$caller_mask" <"$directory/input" 6>&- &
+leader=$!
+owned_guard=$(jobs -p %%)
+set +m
+exec 6>&-
+for ((i=0; i<50; i++)); do
+    [ -e "$directory/.crabbox-owned" ] && break
+    kill -0 "$owned_guard" 2>/dev/null || break
+    sleep .1
+done
+if ! read_guard || [ "$guard" != "$owned_guard" ] || ! valid_guard; then
+    # Publication failed before arming: only exact direct children can be
+    # stopped here, and the unarmed diagnostic state remains.
+    kill -KILL "$owned_guard" "$leader" "$watcher" 2>/dev/null || :
+    wait 2>/dev/null || :
+    exit 74
+fi
+@WORKLOAD_INIT@if [ ! -e "$directory/.lost" ] && [ ! -e "$directory/.cancel" ]; then : >"$directory/.armed"; fi
+code=74
+while valid_guard; do
+@WORKLOAD_TICK@    [ -e "$directory/.lost" ] || [ -e "$directory/.cancel" ] && break
+    if [ -e "$directory/.result" ]; then
+        if {
+            IFS= read -r result && ! IFS= read -r extra && [ -z "$extra" ]
+        } <"$directory/.result"; then
+            case $result in
+                ''|*[!0-9]*) ;;
+                *) [ "${#result}" -le 3 ] && [ "$result" -le 255 ] && code=$result;;
+            esac
+        fi
+        break
+    fi
+    kill -0 "$leader" 2>/dev/null || break
+    sleep .1
+done
+kill "$watcher" 2>/dev/null || :
+wait "$watcher" 2>/dev/null || :
+cleanup_group && remove_evidence || { echo 'WSL2 command cleanup failed: group absence unconfirmed' >&2; exit 74; }
+exit "$code"

--- a/internal/cli/scripts/wsl-supervisor.sh
+++ b/internal/cli/scripts/wsl-supervisor.sh
@@ -15,74 +15,19 @@ identity() {
     [ "$1" != Z ] && [ "$1" != X ] || return 1
     printf '%s %s\n' "$3" "${20}"
 }
-read_guard() {
-    read -r guard started group extra 2>/dev/null <"$directory/.crabbox-owned" || return 1
-    case $guard:$started:$group in *[!0-9:]*|:*|*::*|*:) return 1;; esac
-    [ -z "${extra:-}" ]
-}
-valid_guard() {
-    local current
-    current=$(cat "$directory/.crabbox-owned" 2>/dev/null) || return 1
-    [ "$current" = "$guard $started $group" ] &&
-        [ "$(identity "$guard")" = "$group $started" ]
-}
-group_exists() {
-    local diagnostic
-    diagnostic=$(LC_ALL=C kill -0 -- "-$group" 2>&1) && return 0
-    # Only ESRCH proves absence. Permission failure must retain evidence too.
-    [[ "$diagnostic" != *": (-$group) - No such process" ]]
-}
-cleanup_group() {
-    # Keep the witness alive through TERM. Revalidate both its immutable
-    # process identity and the published record before the final KILL.
-    valid_guard || return 1
-    kill -TERM -- "-$group" 2>/dev/null || return 1
-    local ticks=$(((grace_ms + 99) / 100))
-    while [ "$ticks" -gt 0 ]; do sleep .1; ticks=$((ticks - 1)); done
-    valid_guard || return 1
-    kill -KILL -- "-$group" 2>/dev/null || return 1
-    wait "$leader" 2>/dev/null || :
-    wait "$guard" 2>/dev/null || :
-    ticks=$(((grace_ms + 99) / 100))
-    while group_exists && [ "$ticks" -gt 0 ]; do sleep .1; ticks=$((ticks - 1)); done
-    ! group_exists || return 1
-    [ "$(cat "$directory/.crabbox-owned" 2>/dev/null)" = "$guard $started $group" ]
-}
+@GUARDED_GROUP_FUNCTIONS@
 remove_evidence() {
     [ "$(cat "$directory/.nonce" 2>/dev/null)" = "$nonce" ] || return 1
     rm -rf -- "$directory"
 }
 
-case $mode in
+@FUNCTIONAL_PRELUDE@case $mode in
 run)
     # setsid and ignored HUP preserve the supervisor after Windows loses its
     # launcher. It directly parents both members of the guarded pipeline.
     exec setsid --wait bash -c "$CBX_HELPER" sh supervise "$directory" "$nonce" "$command_size" "$payload_size" "$idle_ms" "$grace_ms" "$caller_mask"
     ;;
-guard)
-    trap '' TERM
-    read -r group started < <(identity "$$") || exit 74
-    printf '%s %s %s\n' "$$" "$started" "$group" >"$directory/.crabbox-owned.tmp"
-    mv "$directory/.crabbox-owned.tmp" "$directory/.crabbox-owned" || exit 74
-    # A private FIFO supplies a blocking builtin, without a sleep child that
-    # could become an unreapable in-group zombie when the guard is killed.
-    while :; do IFS= read -r -t 1 -u 6 ignored || :; done
-    ;;
-workload)
-    trap ':' TERM
-    while [ ! -e "$directory/.armed" ]; do sleep .1; done
-    (umask "$caller_mask"; exec bash "$directory/command" <"$directory/input") &
-    child=$!
-    while :; do
-        code=0
-        wait "$child" || code=$?
-        kill -0 "$child" 2>/dev/null || break
-    done
-    # The supervisor must never observe a result before its status is complete.
-    printf '%s\n' "$code" >"$directory/.result.tmp" &&
-        mv -- "$directory/.result.tmp" "$directory/.result" || exit 74
-    exit "$code"
-    ;;
+@GUARDED_MEMBERS@
 watch)
     IFS= read -r -N 1 -u 3 ignored || :
     : >"$directory/.lost"
@@ -92,11 +37,11 @@ cleanup)
     [ -e "$directory" ] || exit 0
     [ -d "$directory" ] && [ ! -L "$directory" ] &&
         [ "$(cat "$directory/.nonce" 2>/dev/null)" = "$nonce" ] || exit 74
-    read -r supervisor supervisor_identity <"$directory/.supervisor" || exit 74
+@FUNCTIONAL_CLEANUP@    read -r supervisor supervisor_identity <"$directory/.supervisor" || exit 74
     if [ "$(identity "$supervisor")" = "$supervisor_identity" ]; then
         : >"$directory/.cancel"
         for ((i=0; i<100; i++)); do
-            [ -e "$directory" ] || exit 0
+@FUNCTIONAL_CLEANUP_POLL@            [ -e "$directory" ] || exit 0
             sleep .1
         done
         exit 74
@@ -111,7 +56,7 @@ esac
 
 mkdir -m 700 -- "$directory" || exit 74
 printf '%s' "$nonce" >"$directory/.nonce"
-printf '%s %s\n' "$$" "$(identity "$$")" >"$directory/.supervisor"
+@FUNCTIONAL_SCRATCH@printf '%s %s\n' "$$" "$(identity "$$")" >"$directory/.supervisor"
 exec 3<&0
 exec 0</dev/null
 head -c "$((command_size + payload_size))" <&3 >"$directory/frame" 3<&- &
@@ -136,46 +81,4 @@ rm "$directory/frame"
 bash -c "$CBX_HELPER" sh watch "$directory" "$nonce" 0 0 0 0 "$caller_mask" </dev/null &
 watcher=$!
 exec 3<&-
-mkfifo -m 600 "$directory/guard-wait" || exit 74
-exec 6<>"$directory/guard-wait"
-set -m
-bash -c "$CBX_HELPER" sh guard "$directory" "$nonce" 0 0 0 0 "$caller_mask" </dev/null |
-    bash -c "$CBX_HELPER" sh workload "$directory" "$nonce" 0 0 0 0 "$caller_mask" <"$directory/input" 6>&- &
-leader=$!
-owned_guard=$(jobs -p %%)
-set +m
-exec 6>&-
-for ((i=0; i<50; i++)); do
-    [ -e "$directory/.crabbox-owned" ] && break
-    kill -0 "$owned_guard" 2>/dev/null || break
-    sleep .1
-done
-if ! read_guard || [ "$guard" != "$owned_guard" ] || ! valid_guard; then
-    # Publication failed before arming: only exact direct children can be
-    # stopped here, and the unarmed diagnostic state remains.
-    kill -KILL "$owned_guard" "$leader" "$watcher" 2>/dev/null || :
-    wait 2>/dev/null || :
-    exit 74
-fi
-if [ ! -e "$directory/.lost" ] && [ ! -e "$directory/.cancel" ]; then : >"$directory/.armed"; fi
-code=74
-while valid_guard; do
-    [ -e "$directory/.lost" ] || [ -e "$directory/.cancel" ] && break
-    if [ -e "$directory/.result" ]; then
-        if {
-            IFS= read -r result && ! IFS= read -r extra && [ -z "$extra" ]
-        } <"$directory/.result"; then
-            case $result in
-                ''|*[!0-9]*) ;;
-                *) [ "${#result}" -le 3 ] && [ "$result" -le 255 ] && code=$result;;
-            esac
-        fi
-        break
-    fi
-    kill -0 "$leader" 2>/dev/null || break
-    sleep .1
-done
-kill "$watcher" 2>/dev/null || :
-wait "$watcher" 2>/dev/null || :
-cleanup_group && remove_evidence || { echo 'WSL2 command cleanup failed: group absence unconfirmed' >&2; exit 74; }
-exit "$code"
+@GUARDED_WORKLOAD@

--- a/internal/cli/ssh_wsl_cleanup_linux_test.go
+++ b/internal/cli/ssh_wsl_cleanup_linux_test.go
@@ -28,6 +28,10 @@ type wslLinuxFixture struct {
 }
 
 func startWSLLinuxFixture(t *testing.T, command string, payload []byte, declared int, helper string, grace int) *wslLinuxFixture {
+	return startWSLLinuxFixtureWithNonce(t, command, payload, declared, helper, grace, "nonce")
+}
+
+func startWSLLinuxFixtureWithNonce(t *testing.T, command string, payload []byte, declared int, helper string, grace int, nonce string) *wslLinuxFixture {
 	t.Helper()
 	if _, err := exec.LookPath("setsid"); err != nil {
 		t.Fatal("native fixture requires the documented setsid prerequisite")
@@ -38,7 +42,7 @@ func startWSLLinuxFixture(t *testing.T, command string, payload []byte, declared
 		t.Fatal(err)
 	}
 	f.control = writer
-	f.command = exec.Command("sh", "-c", wslHelperBootstrap, "sh", strconv.Itoa(len(helper)), "0", "run", f.directory, "nonce", strconv.Itoa(declared), strconv.Itoa(len(payload)), "300", strconv.Itoa(grace))
+	f.command = exec.Command("sh", "-c", wslHelperBootstrap, "sh", strconv.Itoa(len(helper)), "0", "run", f.directory, nonce, strconv.Itoa(declared), strconv.Itoa(len(payload)), "300", strconv.Itoa(grace))
 	f.command.Stdin = reader
 	f.command.Stdout = &f.output
 	f.command.Stderr = &f.output
@@ -145,6 +149,64 @@ func assertWSLLinuxAbsent(t *testing.T, f *wslLinuxFixture) {
 	}
 	if _, err := os.Stat(f.directory); !os.IsNotExist(err) {
 		t.Fatalf("evidence remains after successful cleanup: %v", err)
+	}
+}
+
+func TestFunctionalWSLPreflightOwnerCompletion(t *testing.T) {
+	const nonce = "0123456789abcdef0123456789abcdef"
+	for _, tc := range []struct {
+		name, state     string
+		code            int
+		cancel, timeout bool
+	}{
+		{name: "ready", state: "ready"},
+		{name: "missing interpreter", state: "missing-python3", code: 20},
+		{name: "venv unavailable", state: "venv-unavailable", code: 21},
+		{name: "pip unavailable", state: "pip-unavailable", code: 22},
+		{name: "worker failed", state: "worker-failed", code: 23},
+		{name: "caller channel closed", state: "canceled", code: 74, cancel: true},
+		{name: "worker deadline", state: "timed-out", code: 74, timeout: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			command := `scratch=$(dirname "$0")/scratch
+test -d "$scratch" || exit 23
+printf marker >"$scratch/marker"
+`
+			budget := 10 * time.Second
+			if tc.cancel || tc.timeout {
+				command += `mkfifo "$scratch/wait"
+exec 7<>"$scratch/wait"
+trap 'exit 0' TERM
+while :; do read -r -t 1 -u 7 ignored || :; done
+`
+				if tc.timeout {
+					budget = time.Second
+				}
+			} else {
+				command += "sleep .2\nexit " + strconv.Itoa(tc.code) + "\n"
+			}
+			f := startWSLLinuxFixtureWithNonce(t, command, nil, len(command), functionalWSLPreflightHelper(budget), 100, nonce)
+			f.guard(t)
+			waitForTestFile(t, filepath.Join(f.directory, "scratch", "marker"), 5*time.Second)
+			if tc.cancel {
+				_ = f.control.Close()
+			}
+			f.wait(t, tc.code)
+			if err := syscall.Kill(-f.group, 0); err != syscall.ESRCH {
+				t.Fatalf("acknowledging live group: %v", err)
+			}
+			if _, err := os.Lstat(filepath.Join(f.directory, "scratch")); !os.IsNotExist(err) {
+				t.Fatalf("scratch was not removed: %v", err)
+			}
+			record, err := os.ReadFile(filepath.Join(f.directory, ".completion"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := parseFunctionalPreflightCompletion(record, nonce)
+			if err != nil || got.State != tc.state || !got.WorkerQuiesced || !got.ScratchRemoved {
+				t.Fatalf("completion=%+v error=%v", got, err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/ssh_wsl_stage.go
+++ b/internal/cli/ssh_wsl_stage.go
@@ -37,7 +37,23 @@ var wslStageVerifier string
 var wslWindowsOwner string
 
 //go:embed scripts/wsl-supervisor.sh
-var wslLinuxHelper string
+var wslLinuxTemplate string
+
+//go:embed scripts/guarded-group.sh
+var guardedGroupFunctions string
+
+//go:embed scripts/guarded-workload.sh
+var guardedWorkload string
+
+//go:embed scripts/guarded-members.sh
+var guardedMembers string
+
+var wslLinuxHelper = strings.NewReplacer(
+	"@GUARDED_GROUP_FUNCTIONS@", strings.TrimSuffix(guardedGroupFunctions, "\n"),
+	"@GUARDED_MEMBERS@", strings.TrimSuffix(guardedMembers, "\n"),
+	"@GUARDED_WORKLOAD@", strings.NewReplacer("@WORKLOAD_INIT@", "", "@WORKLOAD_TICK@", "").Replace(strings.TrimSuffix(guardedWorkload, "\n")),
+	"@FUNCTIONAL_PRELUDE@", "", "@FUNCTIONAL_CLEANUP@", "", "@FUNCTIONAL_CLEANUP_POLL@", "", "@FUNCTIONAL_SCRATCH@", "",
+).Replace(wslLinuxTemplate)
 
 // Framework's stdin StreamWriter may emit a UTF-8 preamble. Consume only the
 // declared preamble, then the exact helper; never read ahead into command/input.
@@ -181,13 +197,16 @@ func (p *wslStageCleanupPhase) start() context.Context {
 }
 
 type wslStageSpool struct {
-	setupMarker string
-	input       *replayableSSHInput
-	size        int64
-	expected    [sha256.Size]byte
-	timing      wslStageTiming
-	routeProof  string
-	shell       wslStageShell
+	setupMarker       string
+	input             *replayableSSHInput
+	size              int64
+	expected          [sha256.Size]byte
+	timing            wslStageTiming
+	routeProof        string
+	shell             wslStageShell
+	functionalNonce   string
+	functionalCleanup context.Context
+	functionalCancel  context.CancelFunc
 }
 type wslStageRouteProofKey struct{}
 type retryableWSLStageError struct{ error }
@@ -303,10 +322,14 @@ func wslStageBudget(floor, idle time.Duration, frameBytes int64) time.Duration {
 }
 
 func newWSLStageSpool(command string, payload []byte, source io.ReadSeeker, payloadSize int64, limit sshCommandLimit) (*wslStageSpool, error) {
+	return newWSLStageSpoolWithHelper(command, payload, source, payloadSize, limit, wslLinuxHelper)
+}
+
+func newWSLStageSpoolWithHelper(command string, payload []byte, source io.ReadSeeker, payloadSize int64, limit sshCommandLimit, linuxHelper string) (*wslStageSpool, error) {
 	owner := strings.NewReplacer("@BOOTSTRAP@", psQuote(wslHelperBootstrap),
 		"@STARTUP@", fmt.Sprint(wslStageIdleTimeout.Milliseconds())).Replace(wslWindowsOwner)
-	if len(owner) == 0 || len(wslLinuxHelper) == 0 || len(owner) > wslStageMaxHelper || len(wslLinuxHelper) > wslStageMaxHelper ||
-		!utf8.ValidString(wslLinuxHelper) || strings.ContainsRune(wslLinuxHelper, 0) ||
+	if len(owner) == 0 || len(linuxHelper) == 0 || len(owner) > wslStageMaxHelper || len(linuxHelper) > wslStageMaxHelper ||
+		!utf8.ValidString(linuxHelper) || strings.ContainsRune(linuxHelper, 0) ||
 		len(command) > wslStageMaxCommand || payloadSize < 0 || payloadSize > wslStageMaxSize || limit.execution < 0 {
 		return nil, errors.New("WSL2 envelope exceeds bounded descriptor limits")
 	}
@@ -324,7 +347,7 @@ func newWSLStageSpool(command string, payload []byte, source io.ReadSeeker, payl
 	var descriptor [wslStageHeaderSize]byte
 	copy(descriptor[:], "CBXFLAT2")
 	binary.LittleEndian.PutUint32(descriptor[8:], uint32(len(owner)))
-	binary.LittleEndian.PutUint32(descriptor[12:], uint32(len(wslLinuxHelper)))
+	binary.LittleEndian.PutUint32(descriptor[12:], uint32(len(linuxHelper)))
 	binary.LittleEndian.PutUint64(descriptor[16:], uint64(len(command)))
 	binary.LittleEndian.PutUint64(descriptor[24:], uint64(payloadSize))
 	binary.LittleEndian.PutUint64(descriptor[32:], uint64(timing.operation.Milliseconds()))
@@ -335,7 +358,7 @@ func newWSLStageSpool(command string, payload []byte, source io.ReadSeeker, payl
 	if _, err := io.ReadFull(wslStageEntropy, descriptor[wslStageBlindingOffset:]); err != nil {
 		return nil, errors.New("generate private WSL2 envelope blinding failed")
 	}
-	prefix := append(descriptor[:], []byte(owner+wslLinuxHelper+command)...)
+	prefix := append(descriptor[:], []byte(owner+linuxHelper+command)...)
 	total := int64(len(prefix)) + payloadSize
 	if total > wslStageMaxSize {
 		return nil, errors.New("WSL2 envelope is too large")
@@ -352,7 +375,12 @@ func newWSLStageSpool(command string, payload []byte, source io.ReadSeeker, payl
 	}
 	return spool, nil
 }
-func (s *wslStageSpool) close() error              { return s.input.close() }
+func (s *wslStageSpool) close() error {
+	if s.functionalCancel != nil {
+		s.functionalCancel()
+	}
+	return s.input.close()
+}
 func (s *wslStageSpool) digest() [sha256.Size]byte { return s.expected }
 func (s *wslStageSpool) prefixDigest(ctx context.Context, size int64) (digest [sha256.Size]byte, err error) {
 	if size < 0 || size > s.size {
@@ -396,7 +424,11 @@ func (s *wslStageSpool) run(ctx context.Context, target *SSHTarget, connectTimeo
 	}
 	defer func() {
 		if err != nil {
-			if cleanupErr := cleanupPublishedWSLStage(ctx, *target, nonce, s, wslStageCleanupBudget(ctx), wslStageCanceledCleanupTimeout, connectTimeout); cleanupErr != nil {
+			cleanupCtx := ctx
+			if s.functionalCleanup != nil {
+				cleanupCtx = s.functionalCleanup
+			}
+			if cleanupErr := cleanupPublishedWSLStage(cleanupCtx, *target, nonce, s, wslStageCleanupBudget(cleanupCtx), wslStageCanceledCleanupTimeout, connectTimeout); cleanupErr != nil {
 				err = errors.Join(err, fmt.Errorf("owned WSL2 ready stage cleanup failed: %w", cleanupErr))
 			}
 		}
@@ -414,6 +446,13 @@ func (s *wslStageSpool) run(ctx context.Context, target *SSHTarget, connectTimeo
 	}
 	defer cancel()
 	stdout, stderr, finish := workspaceOwnerSetupStreams(s.setupMarker, stdout, stderr)
+	if s.functionalNonce != "" {
+		s.functionalCleanup, s.functionalCancel = functionalPreflightCleanupBudget(ctx)
+		deadline, _ := s.functionalCleanup.Deadline()
+		boundedCtx, boundedCancel := context.WithDeadline(execCtx, deadline)
+		defer boundedCancel()
+		execCtx = boundedCtx
+	}
 	transport := sshTransportPreparation{command: command}
 	_, err = transport.runOnce(execCtx, *target, connectTimeout, attempts, stdout, stderr, false)
 	if err == nil {
@@ -440,6 +479,9 @@ func requireWSLStageExecutionReserve(ctx context.Context, reserve time.Duration)
 }
 
 func (s *wslStageSpool) stage(ctx context.Context, target *SSHTarget, timing wslStageTiming, connectTimeout, attempts string, stderr io.Writer) (string, error) {
+	if s.functionalNonce != "" && (len(s.functionalNonce) != 32 || strings.Trim(s.functionalNonce, "0123456789abcdef") != "") {
+		return "", errors.New("invalid functional preflight stage identity")
+	}
 	budgets := wslStageRouteBudgets(*target, timing, s.size)
 	budget := budgets.total
 	if timing.reserve > 0 {
@@ -463,6 +505,9 @@ func (s *wslStageSpool) stage(ctx context.Context, target *SSHTarget, timing wsl
 		nonce, nonceErr := randomHex(16)
 		if nonceErr != nil {
 			return "", nonceErr
+		}
+		if s.functionalNonce != "" {
+			nonce = s.functionalNonce
 		}
 		candidateCtx, cancelCandidate := context.WithTimeout(stageCtx, budgets.candidate)
 		timeoutErr := retryableWSLStageError{fmt.Errorf("WSL2 stage candidate timed out: %w", context.DeadlineExceeded)}

--- a/internal/cli/ssh_wsl_stage_test.go
+++ b/internal/cli/ssh_wsl_stage_test.go
@@ -2146,6 +2146,85 @@ public class HandoffFixture {
     public void GetResult() { }
 }'`
 
+func TestWSLFunctionalPreflightStagesPrivateCommand(t *testing.T) {
+	oldStage, oldControl := stageWSLSpool, runFunctionalPreflightControl
+	t.Cleanup(func() { stageWSLSpool, runFunctionalPreflightControl = oldStage, oldControl })
+	stagingFailure := errors.New("synthetic staging failure")
+	stages := 0
+	stageWSLSpool = func(spool *wslStageSpool, _ context.Context, _ *SSHTarget, timing wslStageTiming, _, _ string, _ io.Writer) (string, error) {
+		stages++
+		if len(spool.functionalNonce) != 32 || strings.Trim(spool.functionalNonce, "0123456789abcdef") != "" {
+			t.Fatal("scratch identity was not caller-bound before staging")
+		}
+		input, err := spool.input.reset()
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := io.ReadAll(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, helper, command, payload := decodeWSLStage(t, data)
+		if helper != functionalWSLPreflightHelper(90*time.Second) || helper == wslLinuxHelper || len(payload) != 0 {
+			t.Fatal("functional operation lost its supervised helper")
+		}
+		if !strings.Contains(command, "/tmp/crabbox-command-"+spool.functionalNonce+"/scratch") ||
+			!strings.Contains(command, "SYNTHETIC_SETTING=") || !strings.Contains(command, "fixture value") ||
+			!strings.Contains(command, "python3 -I -B -c") {
+			t.Fatal("private command lost its scratch, environment or literal interpreter")
+		}
+		if timing.operation != 116*time.Second || spool.functionalCleanup != nil {
+			t.Fatal("staging consumed the native cleanup clock")
+		}
+		return "", stagingFailure
+	}
+	runFunctionalPreflightControl = func(context.Context, SSHTarget, string, string) ([]byte, error) {
+		t.Fatal("staging failure must not invent Linux cleanup authority")
+		return nil, nil
+	}
+	completion, err := runWSLFunctionalPreflight(t.Context(), SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2},
+		"/work/probe", map[string]string{"SYNTHETIC_SETTING": "fixture value"}, nil)
+	if !errors.Is(err, stagingFailure) || completion != (functionalPreflightCompletion{}) || stages != 1 {
+		t.Fatalf("completion=%+v stages=%d error=%v", completion, stages, err)
+	}
+}
+
+func TestFunctionalPreflightCleanupBudget(t *testing.T) {
+	for _, canceled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("caller-canceled=%t", canceled), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				cleanupCtx, closeBudget := functionalPreflightCleanupBudget(ctx)
+				defer closeBudget()
+				deadline, ok := cleanupCtx.Deadline()
+				if !ok || time.Until(deadline) != 182*time.Second {
+					t.Fatal("native startup, worker and cleanup budgets were not kept separate")
+				}
+				if canceled {
+					time.Sleep(20 * time.Second)
+					cancel()
+					synctest.Wait()
+					time.Sleep(29 * time.Second)
+				} else {
+					time.Sleep(181 * time.Second)
+				}
+				if cleanupCtx.Err() != nil {
+					t.Fatal("cleanup reserve ended early")
+				}
+				time.Sleep(time.Second)
+				synctest.Wait()
+				if cleanupCtx.Err() == nil {
+					t.Fatal("cleanup reserve was extended")
+				}
+				if canceled && !errors.Is(context.Cause(ctx), context.Canceled) {
+					t.Fatal("caller cancellation changed")
+				}
+			})
+		})
+	}
+}
+
 func TestWSLStageInitialHandoffBudgets(t *testing.T) {
 	t.Run("embedded programs use LF", func(t *testing.T) {
 		for name, program := range map[string]string{

--- a/internal/cli/workspace_owner_bsd_test.go
+++ b/internal/cli/workspace_owner_bsd_test.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +14,322 @@ import (
 	"testing"
 	"time"
 )
+
+// The outer provider transport records dispatch, while the functional operation
+// runs the real local supervisor and completion controls with inert workers.
+// This covers CLI continuation, not SSH or Python installation readiness.
+func TestRunFunctionalPreflightContinuation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires the POSIX supervisor fixture")
+	}
+	for _, tc := range []struct {
+		name, state                                          string
+		code                                                 int
+		timeout, canceled, lostAck, lostRetire, cleanedError bool
+	}{
+		{name: "ready", state: "ready"},
+		{name: "missing", state: "missing-python3", code: 20},
+		{name: "venv", state: "venv-unavailable", code: 21},
+		{name: "pip", state: "pip-unavailable", code: 22},
+		{name: "worker", state: "worker-failed", code: 23},
+		{name: "timeout", state: "timed-out", code: 74, timeout: true},
+		{name: "canceled", state: "canceled", canceled: true},
+		{name: "unconfirmed acknowledgement", state: "unavailable", lostAck: true},
+		{name: "unconfirmed retirement", state: "unavailable", code: 21, lostRetire: true},
+		{name: "cleaned operational error", state: "unavailable", code: 21, cleanedError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			isolateRunTestUserDirs(t, dir)
+			t.Chdir(dir)
+			logPath := installRecordingSSH(t, dir)
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			oldRun, oldControl := runOwnedFunctionalPreflight, runFunctionalPreflightControl
+			t.Cleanup(func() { runOwnedFunctionalPreflight, runFunctionalPreflightControl = oldRun, oldControl })
+			controlFailure := errors.New("synthetic owned control transport unavailable")
+			calls := 0
+			var operationStage string
+			var operationDone <-chan struct{}
+			runOwnedFunctionalPreflight = func(probeCtx context.Context, target SSHTarget, _ string, _ map[string]string, _ []string) (functionalPreflightCompletion, error) {
+				calls++
+				nonce, err := randomHex(16)
+				if err != nil {
+					t.Fatal(err)
+				}
+				stage := "/tmp/crabbox-command-" + nonce
+				operationStage = stage
+				if _, err := os.Lstat(stage); !os.IsNotExist(err) {
+					t.Fatal("fixture stage already exists")
+				}
+				worker := "printf started >" + shellQuote(filepath.Join(stage, "scratch", "started")) + " || exit 75\n"
+				budget := 10 * time.Second
+				if tc.timeout || tc.canceled || tc.lostAck {
+					worker += "mkfifo " + shellQuote(filepath.Join(stage, "scratch", "wait")) + "\nexec 7<>" + shellQuote(filepath.Join(stage, "scratch", "wait")) + "\ntrap 'exit 0' TERM\nwhile :; do read -r -t 1 -u 7 ignored || :; done\n"
+					if tc.timeout {
+						budget = time.Second
+					}
+				} else {
+					worker += "exit " + strconv.Itoa(tc.code) + "\n"
+				}
+				helper := functionalPOSIXPreflightHelper(budget)
+				remoteCtx, remoteCancel := context.WithTimeout(t.Context(), 25*time.Second)
+				cmd := exec.CommandContext(remoteCtx, "/bin/bash", "-c", helper, "sh", "run", stage, nonce, strconv.Itoa(len(worker)), "0", "15000", "100")
+				cmd.Env = []string{"HOME=" + dir, "PATH=/usr/bin:/bin", "CBX_HELPER=" + helper}
+				cmd.Stdin = strings.NewReader(worker)
+				cmd.WaitDelay = 5 * time.Second
+				output := newSynchronizedBuffer(16 << 10)
+				cmd.Stdout, cmd.Stderr = &output, &output
+				if err := cmd.Start(); err != nil {
+					remoteCancel()
+					t.Fatal(err)
+				}
+				done := make(chan struct{})
+				operationDone = done
+				var runErr error
+				go func() { runErr = cmd.Wait(); close(done) }()
+				localControl := func(controlCtx context.Context, _ SSHTarget, gotNonce, action string) ([]byte, error) {
+					text, err := functionalPreflightControlCommand(gotNonce, action)
+					if err != nil {
+						return nil, err
+					}
+					control := exec.CommandContext(controlCtx, "/bin/bash", "-c", text)
+					control.Env = []string{"HOME=" + dir, "PATH=/usr/bin:/bin"}
+					return control.Output()
+				}
+				t.Cleanup(func() {
+					defer remoteCancel()
+					cleanupCtx, stop := context.WithTimeout(context.Background(), 30*time.Second)
+					defer stop()
+					if _, err := os.Lstat(stage); err == nil {
+						record, err := localControl(cleanupCtx, target, nonce, "cancel")
+						if err != nil {
+							t.Errorf("owned stage retained %s: %v %s", stage, err, output.String())
+							return
+						}
+						if _, err := parseFunctionalPreflightCompletion(record, nonce); err != nil {
+							t.Error(err)
+							return
+						}
+						if _, err := localControl(cleanupCtx, target, nonce, "retire"); err != nil {
+							t.Error(err)
+							return
+						}
+					}
+					select {
+					case <-done:
+					case <-cleanupCtx.Done():
+						t.Error("owned supervisor reaping unconfirmed")
+					}
+				})
+				runFunctionalPreflightControl = func(controlCtx context.Context, target SSHTarget, nonce, action string) ([]byte, error) {
+					if tc.lostAck || tc.lostRetire && action == "retire" {
+						return nil, controlFailure
+					}
+					return localControl(controlCtx, target, nonce, action)
+				}
+				cleanupCtx, stop := functionalPreflightCleanupBudget(probeCtx)
+				defer stop()
+				if tc.canceled || tc.lostAck {
+					limit := time.Now().Add(5 * time.Second)
+					for {
+						if _, err := os.Stat(filepath.Join(stage, "scratch", "started")); err == nil {
+							break
+						}
+						if time.Now().After(limit) {
+							t.Fatal("worker did not start")
+						}
+						time.Sleep(10 * time.Millisecond)
+					}
+					if tc.canceled {
+						cancel()
+					} else {
+						return finishFunctionalPreflight(probeCtx, cleanupCtx, target, nonce, controlFailure)
+					}
+					return finishFunctionalPreflight(probeCtx, cleanupCtx, target, nonce, context.Cause(probeCtx))
+				}
+				<-done
+				if tc.cleanedError {
+					runErr = errors.Join(runErr, controlFailure)
+				}
+				return finishFunctionalPreflight(probeCtx, cleanupCtx, target, nonce, runErr)
+			}
+			var stdout, stderr bytes.Buffer
+			err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(ctx, []string{"--provider", "ssh", "--static-host", "127.0.0.1", "--static-user", "runner", "--static-work-root", filepath.Join(dir, "remote"), "--no-sync", "--preflight", "--preflight-tools", "python3-venv,python3-venv", "--", "printf", "cbx-after-functional"})
+			blocked := tc.canceled || tc.lostAck || tc.lostRetire || tc.cleanedError
+			if (err != nil) != blocked || calls != 1 {
+				t.Fatalf("calls=%d err=%v stderr=%s", calls, err, stderr.String())
+			}
+			if tc.canceled && !errors.Is(err, context.Canceled) {
+				t.Fatalf("cancellation lost: %v", err)
+			}
+			if (tc.lostAck || tc.lostRetire || tc.cleanedError) && !errors.Is(err, controlFailure) {
+				t.Fatalf("control cause lost: %v", err)
+			}
+			if tc.lostAck {
+				select {
+				case <-operationDone:
+					t.Fatal("unconfirmed-ack fixture did not retain the active worker")
+				default:
+				}
+				if _, err := os.Stat(filepath.Join(operationStage, "scratch", "started")); err != nil {
+					t.Fatal(err)
+				}
+			} else if tc.lostRetire {
+				if _, err := os.Stat(filepath.Join(operationStage, ".completion")); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := os.Lstat(filepath.Join(operationStage, "scratch")); !os.IsNotExist(err) {
+					t.Fatal("completed worker scratch remains")
+				}
+			} else if _, err := os.Lstat(operationStage); !os.IsNotExist(err) {
+				t.Fatalf("production control did not retire stage before continuation: %v", err)
+			}
+			log, readErr := os.ReadFile(logPath)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if strings.Contains(string(log), "cbx-after-functional") == blocked {
+				t.Fatalf("workload dispatch blocked=%t: %s", blocked, log)
+			}
+			cleanup := "confirmed"
+			if tc.lostAck || tc.lostRetire {
+				cleanup = "unconfirmed"
+			}
+			want := "remote preflight python3-venv=" + tc.state + " cleanup=" + cleanup
+			if strings.Count(stderr.String(), "remote preflight python3-venv=") != 1 || !strings.Contains(stderr.String(), want) {
+				t.Fatalf("diagnostic wanted %q: %s", want, stderr.String())
+			}
+		})
+	}
+}
+
+func TestFunctionalPOSIXPreflightOwner(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX supervisor requires a POSIX host")
+	}
+	for _, tc := range []struct {
+		name, state     string
+		code            int
+		cancel, timeout bool
+	}{
+		{name: "ready", state: "ready"},
+		{name: "capability unavailable", state: "venv-unavailable", code: 21},
+		{name: "worker failed", state: "worker-failed", code: 23},
+		{name: "caller cancellation", state: "canceled", cancel: true},
+		{name: "worker deadline", state: "timed-out", code: 74, timeout: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			waitFile := func(path string, limit time.Duration) {
+				t.Helper()
+				deadline := time.Now().Add(limit)
+				for {
+					if _, err := os.Stat(path); err == nil {
+						return
+					} else if !os.IsNotExist(err) {
+						t.Fatal(err)
+					}
+					if time.Now().After(deadline) {
+						t.Fatalf("owned fixture did not publish %s", path)
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+			}
+			root, err := os.MkdirTemp("", "cbx-functional-owner-test-")
+			if err != nil {
+				t.Fatal(err)
+			}
+			directory := filepath.Join(root, "owned")
+			nonce := strings.Repeat("a", 32)
+			tools := filepath.Join(root, "tools")
+			if err := os.Mkdir(tools, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			for _, name := range []string{"bash", "ps", "mkdir", "head", "wc", "cat", "mkfifo", "mv", "rm", "sleep"} {
+				path := filepath.Join("/bin", name)
+				if _, err := os.Stat(path); err != nil {
+					path = filepath.Join("/usr/bin", name)
+				}
+				if err := os.Symlink(path, filepath.Join(tools, name)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			command := "test -d " + shellQuote(filepath.Join(directory, "scratch")) + " || exit 75\nprintf marker >" + shellQuote(filepath.Join(directory, "scratch", "marker")) + " || exit 75\n"
+			budget := 10 * time.Second
+			if tc.cancel || tc.timeout {
+				command += "mkfifo " + shellQuote(filepath.Join(directory, "scratch", "wait")) + "\nexec 7<>" + shellQuote(filepath.Join(directory, "scratch", "wait")) + "\ntrap 'exit 0' TERM\nwhile :; do read -r -t 1 -u 7 ignored || :; done\n"
+				if tc.timeout {
+					budget = time.Second
+				}
+			} else {
+				command += "sleep .2\nexit " + strconv.Itoa(tc.code) + "\n"
+			}
+			helper := functionalPOSIXPreflightHelper(budget)
+			ctx, cancel := context.WithTimeout(t.Context(), 25*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, "/bin/bash", "-c", helper, "sh", "run", directory, nonce, strconv.Itoa(len(command)), "0", "15000", "100")
+			cmd.Env = []string{"PATH=" + tools, "HOME=" + root, "CBX_HELPER=" + helper}
+			cmd.Stdin = strings.NewReader(command)
+			var out synchronizedBuffer = newSynchronizedBuffer(16 << 10)
+			cmd.Stdout, cmd.Stderr = &out, &out
+			cmd.WaitDelay = 5 * time.Second
+			if err := cmd.Start(); err != nil {
+				t.Fatal(err)
+			}
+			done := make(chan struct{})
+			var processErr error
+			go func() { processErr = cmd.Wait(); close(done) }()
+			t.Cleanup(func() {
+				if data, _ := os.ReadFile(filepath.Join(directory, ".nonce")); string(data) == nonce {
+					_ = os.WriteFile(filepath.Join(directory, ".cancel"), nil, 0o600)
+				}
+				select {
+				case <-done:
+				case <-time.After(20 * time.Second):
+					t.Errorf("owned supervisor unconfirmed; retained %s", root)
+					return
+				}
+				record, _ := os.ReadFile(filepath.Join(directory, ".completion"))
+				if _, err := parseFunctionalPreflightCompletion(record, nonce); err != nil {
+					t.Errorf("owned stage cleanup unconfirmed; retained %s: %s", root, out.String())
+					return
+				}
+				if err := os.RemoveAll(root); err != nil {
+					t.Error(err)
+				}
+			})
+			if tc.cancel {
+				waitFile(filepath.Join(directory, "scratch", "marker"), 20*time.Second)
+				// Match caller transport cancellation, then issue only the
+				// registered stage's ordinary cancellation control.
+				cancel()
+				if err := os.WriteFile(filepath.Join(directory, ".cancel"), nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			select {
+			case <-done:
+			case <-time.After(25 * time.Second):
+				t.Fatal("supervisor did not return")
+			}
+			if !tc.cancel && exitCode(processErr) != tc.code {
+				t.Fatalf("exit=%v: %s", processErr, out.String())
+			}
+			waitFile(filepath.Join(directory, ".completion"), 10*time.Second)
+			record, err := os.ReadFile(filepath.Join(directory, ".completion"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := parseFunctionalPreflightCompletion(record, nonce)
+			if err != nil || got.State != tc.state || !got.WorkerQuiesced || !got.ScratchRemoved {
+				t.Fatalf("completion=%+v error=%v: %s", got, err, out.String())
+			}
+			if _, err := os.Lstat(filepath.Join(directory, "scratch")); !os.IsNotExist(err) {
+				t.Fatalf("scratch remains: %v", err)
+			}
+		})
+	}
+}
 
 // Stock BSD tools only: no flock, lockf, GNU stat/date, or /proc helpers.
 func workspaceOwnerBSDPath(t *testing.T) string {


### PR DESCRIPTION
## Summary

Adds the opt-in `python3-venv` preflight requested in https://github.com/openclaw/crabbox/issues/1578. Unlike an interpreter version check, it creates a fresh disposable environment, invokes its own Python, seeds pip there, and invokes that pip. Thanks @coygeek for the detailed requirements.

The probe supports Linux, macOS and WSL2; native Windows filters it out. CLI and user/repository `run.preflightTools` selection preserve existing defaults, literal Python probes, deduplication and unknown-name rejection before acquisition. The probe itself does not install or upgrade host tools or project dependencies, and it does not select or activate a project environment.

## Lifecycle and reporting

`remote preflight python3-venv=<state> cleanup=<confirmed|unconfirmed>` separates the capability result from cleanup evidence. Readiness requires confirmed worker quiescence, scratch removal and exact stage retirement. Cleaned negative capability, worker failure and probe timeout remain diagnostic-only; caller cancellation and operational failures prevent the subsequent workload. An operational error can persist even when cleanup is confirmed.

POSIX and WSL2 share the guarded worker/cleanup components while preserving the ordinary WSL helper bytes. The worker retains its 90-second allowance and the independent cleanup reserve is 30 seconds. Separate bounded transport/startup time is accounted for; this is not a 120-second total-command promise. Bootstrap temporary directories are scoped to the probe-owned scratch, without changing the caller workload environment.

## Cancellation reporting correction

Live SIGINT validation found that the probe cleaned up and suppressed the workload correctly, but saved timing classified the precommand failure as a workload exit. The correction classifies that fallback using the preserved error. It also carries the existing stored workspace-owner failure through reporting without changing renewal, fencing, cancellation, or cleanup mechanics. Original numeric exit-code policy is retained.

## WSL cleanup correction

The native WSL cancellation trial exposed a second issue: cleanup control operations restaged the normal transport while consuming the original cleanup reserve. The correction sends validated control input through a bounded private stdin channel on the selected, pinned SSH route, without creating another stage. Native serialization checks cover quoting, multiline input, raw line endings, Unicode, and exit propagation. The strict completion parser, output limits, ordinary workload transport, and existing worker/cleanup budgets remain unchanged.

## Verification completed

- Corrective Go race regression suite: 40 top-level tests and 90 subtests passed without skips. It covers saved timing/local history, caller stops, stored ownership failures, primary exit preservation, and completed-workload behavior.
- The current-main integration selection passed 59 top-level tests and 129 subtests. One unrelated native-Windows CMake runtime case was explicitly skipped on macOS. Core vet, CLI build, Windows compile-only, offline catalog, docs links, and docs-site build all passed.
- The clean build of integration commit 56d122ef706f7b5e3e23a91dbfa8b841a0670ca6 is byte-identical to its tested composite. The functional worker/control components remain unchanged from native-qualified 07480286470f13e948912c8be0e58669ac5a4beb; the main integration preserves the desktop fix and provider cleanup.
- The earlier reporting-corrected build 7d756a8 passed actual macOS readiness and caller cancellation: real environment-local Python/pip execution, exact temporary-path cleanup, no workload after cancellation, and canceled classification in both saved timing and terminal local history.
- Linux readiness, caller cancellation and the unconfirmed-cleanup guard passed on reporting-corrected build 7d756a8. The guard blocked the workload when an ordinary owned permission obstruction prevented cleanup; later operator removal is not counted as product cleanup.
- On actual Windows Server 2022 with WSL2, the corrected cancellation run independently proved the worker, environment, scratch and exact transport stage absent within 15.24 seconds of caller SIGINT. No workload ran; saved timing and local history both recorded canceled. This was tested on 1f63a0f before the current-main integration.
- Native-qualified build 07480286 passed native Windows filtering through the normal SSH transport: duplicate selection produced no venv result or observed WSL/Python start, existing probes retained their order, and a real native Windows workload succeeded.
- Native-qualified build 07480286 passed the macOS transport-failure and healthy controls. Interrupting only the run's own SSH child after a real environment existed produced `unavailable cleanup=confirmed`, independently removed the stage/environment/worker within 10 seconds, suppressed the workload, and retained `failed/provider-error` in timing and local history. A subsequent fresh environment invoked its own Python/ensurepip/pip successfully and cleaned up.
- Earlier-candidate native Linux and macOS runs passed readiness, configuration/default/literal/project controls, missing or broken capability cases, worker failure, and functional timeout, with independently observed cleanup. Actual WSL2 readiness and genuine missing-ensurepip behavior also passed. Their original bindings remain separate from the current-head checks summarized below.
- A controlled local instance of the actual Worker admitted known-tool runs; a recording proxy then rejected lease acquisition before forwarding. Unknown CLI, trusted-user, repository, and native-Windows-target selections exited 2 without HTTP. No cloud resource was allocated by that witness.
- All five workflows at the preceding native-qualified head 07480286 passed on their first attempts: [CI](https://github.com/openclaw/crabbox/actions/runs/34751662048), [Connector Lifecycles](https://github.com/openclaw/crabbox/actions/runs/34751662067), [CodeQL](https://github.com/openclaw/crabbox/actions/runs/34751660081), [Release Check](https://github.com/openclaw/crabbox/actions/runs/34751662118), and [Docs Visual Proof](https://github.com/openclaw/crabbox/actions/runs/34751662078). Connector's unrelated desktop-resize job was skipped.
- Independent managed Codex review of the complete 21-path current-main change was scoped-clean at its selected P0 threshold.

## Completed native qualification

The remaining WSL2 matrix passed on 07480286470f13e948912c8be0e58669ac5a4beb: readiness, missing literal Python, unavailable venv/ensurepip, distinct pip-seeding failure, unusable environment Python/pip, managed worker failure, and natural functional timeout. Each applicable case checked actual fixture binding, workload continuation, and exact temporary-path/process absence before lease disposal. Separate default-only, expanded-default/dedup/literal, and existing-project-environment controls passed. Native Windows filtering and the current-head macOS operational-failure/healthy controls also passed.

Earlier Linux/macOS capability matrices retain their original c9dd bindings, corrected Linux/macOS cancellation retains its 7d756a8 binding, and corrected WSL cancellation retains its 1f63a0f binding. Source comparison and current integration tests verify the preserved paths; these are not mislabeled as fresh execution of every platform/case on the current commit. CLI/user/repository configuration and the live acquisition-boundary unknown-name witness are retained with the same explicit provenance.

The final WSL timeout observed full stage/environment/worker absence 16.31 seconds after the termination signal; corrected WSL caller cancellation observed full absence in 15.24 seconds. Internal managed-clock alignment was not directly observed, and total CLI duration is not substituted for it. All owned proof leases were canonically released and local handles reaped; independent EC2 terminal-state readback was unavailable without separate native credentials, so that stronger acknowledgment is not claimed.

One failed admission before probe execution left a coordinator record marked running. Its admission/recorder/publisher paths are unchanged from main; the precise transport failure remains uncertain and is recorded separately for follow-up. That failed attempt was not counted as capability proof.

The changelog and public run, observability, configuration and discovery docs are updated.

Closes https://github.com/openclaw/crabbox/issues/1578 after the complete feature is verified and landed.

## Final integration gate

The current head is 56d122ef706f7b5e3e23a91dbfa8b841a0670ca6, integrated with main 748c9572a3684f9e27b0277cafcf92945fea6fb0. Only the changelog needed manual union; the functional worker/control and ordinary WSL staging bytes are unchanged. Its seven local gate stages passed (59 tests/129 subtests, one unrelated native-Windows CMake skip), and full-scope managed review found no P0 findings. Native results retain the explicit original bindings above. All five final-head workflows passed on their first attempts: [CI](https://github.com/openclaw/crabbox/actions/runs/34757821719), [Connector Lifecycles](https://github.com/openclaw/crabbox/actions/runs/34757821694), [CodeQL](https://github.com/openclaw/crabbox/actions/runs/34757819892), [Release Check](https://github.com/openclaw/crabbox/actions/runs/34757821709), and [Docs Visual Proof](https://github.com/openclaw/crabbox/actions/runs/34757821678). The unrelated Connector desktop-resize job was skipped. The final branch review was scoped-clean at the requested P0 threshold.
